### PR TITLE
[BUGFIX beta] Cleanup CP set, volatile and various related things.

### DIFF
--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -15,12 +15,8 @@ function isObject(obj) {
 }
 
 function isVolatile(obj) {
-  return !(isObject(obj) && obj.isDescriptor && obj._cacheable);
+  return !(isObject(obj) && obj.isDescriptor && !obj._volatile);
 }
-
-function Chains() { }
-
-Chains.prototype = new EmptyObject();
 
 function ChainWatchers(obj) {
   // this obj would be the referencing chain node's parent node's value
@@ -28,7 +24,7 @@ function ChainWatchers(obj) {
   // chain nodes that reference a key in this obj by key
   // we only create ChainWatchers when we are going to add them
   // so create this upfront
-  this.chains = new Chains();
+  this.chains = new EmptyObject();
 }
 
 ChainWatchers.prototype = {
@@ -327,7 +323,7 @@ ChainNode.prototype = {
     var chains = this._chains;
     var node;
     if (chains === undefined) {
-      chains = this._chains = new Chains();
+      chains = this._chains = new EmptyObject();
     } else {
       node = chains[key];
     }

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -275,7 +275,7 @@ ComputedPropertyPrototype.didChange = function(obj, keyName) {
 
   // don't create objects just to invalidate
   let meta = obj.__ember_meta__;
-  if (meta.source !== obj) {
+  if (!meta || meta.source !== obj) {
     return;
   }
 
@@ -395,7 +395,7 @@ ComputedPropertyPrototype.get = function(obj, keyName) {
 */
 ComputedPropertyPrototype.set = function computedPropertySetEntry(obj, keyName, value) {
   if (this._readOnly) {
-    throw new EmberError(`Cannot set read-only property "${keyName}" on object: ${inspect(obj)}`);
+    this._throwReadOnlyError(obj, keyName);
   }
 
   if (!this._setter) {
@@ -407,6 +407,10 @@ ComputedPropertyPrototype.set = function computedPropertySetEntry(obj, keyName, 
   }
 
   return this.setWithSuspend(obj, keyName, value);
+};
+
+ComputedPropertyPrototype._throwReadOnlyError = function computedPropertyThrowReadOnlyError(obj, keyName) {
+  throw new EmberError(`Cannot set read-only property "${keyName}" on object: ${inspect(obj)}`);
 };
 
 ComputedPropertyPrototype.clobberSet = function computedPropertyClobberSet(obj, keyName, value) {

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -122,7 +122,7 @@ function ComputedProperty(config, opts) {
   this._dependentKeys = undefined;
   this._suspended = undefined;
   this._meta = undefined;
-  this._cacheable = true;
+  this._volatile = false;
   this._dependentKeys = opts && opts.dependentKeys;
   this._readOnly =  false;
 }
@@ -134,6 +134,12 @@ var ComputedPropertyPrototype = ComputedProperty.prototype;
 /**
   Call on a computed property to set it into non-cached mode. When in this
   mode the computed property will not automatically cache the return value.
+
+  It also does not automatically fire any change events. You must manually notify
+  any changes if you want to observe this property.
+
+  Dependency keys have no effect on volatile properties as they are for cache
+  invalidation and notification when cached value is invalidated.
 
   ```javascript
   var outsideService = Ember.Object.extend({
@@ -149,7 +155,7 @@ var ComputedPropertyPrototype = ComputedProperty.prototype;
   @public
 */
 ComputedPropertyPrototype.volatile = function() {
-  this._cacheable = false;
+  this._volatile = true;
   return this;
 };
 
@@ -259,17 +265,24 @@ ComputedPropertyPrototype.meta = function(meta) {
   }
 };
 
-/* impl descriptor API */
+// invalidate cache when CP key changes
 ComputedPropertyPrototype.didChange = function(obj, keyName) {
   // _suspended is set via a CP.set to ensure we don't clear
   // the cached value set by the setter
-  if (this._cacheable && this._suspended !== obj) {
-    let meta = metaFor(obj);
-    let cache = meta.readableCache();
-    if (cache && cache[keyName] !== undefined) {
-      cache[keyName] = undefined;
-      removeDependentKeys(this, obj, keyName, meta);
-    }
+  if (this._volatile || this._suspended === obj) {
+    return;
+  }
+
+  // don't create objects just to invalidate
+  let meta = obj.__ember_meta__;
+  if (meta.source !== obj) {
+    return;
+  }
+
+  let cache = meta.readableCache();
+  if (cache && cache[keyName] !== undefined) {
+    cache[keyName] = undefined;
+    removeDependentKeys(this, obj, keyName, meta);
   }
 };
 
@@ -301,35 +314,33 @@ ComputedPropertyPrototype.didChange = function(obj, keyName) {
   @public
 */
 ComputedPropertyPrototype.get = function(obj, keyName) {
-  var ret, cache, meta;
-  if (this._cacheable) {
-    meta = metaFor(obj);
-    cache = meta.writableCache();
-
-    var result = cache[keyName];
-
-    if (result === UNDEFINED) {
-      return undefined;
-    } else if (result !== undefined) {
-      return result;
-    }
-
-    ret = this._getter.call(obj, keyName);
-
-    if (ret === undefined) {
-      cache[keyName] = UNDEFINED;
-    } else {
-      cache[keyName] = ret;
-    }
-
-    let chainWatchers = meta.readableChainWatchers();
-    if (chainWatchers) {
-      chainWatchers.revalidate(keyName);
-    }
-    addDependentKeys(this, obj, keyName, meta);
-  } else {
-    ret = this._getter.call(obj, keyName);
+  if (this._volatile) {
+    return this._getter.call(obj, keyName);
   }
+
+  let meta = metaFor(obj);
+  let cache = meta.writableCache();
+
+  let result = cache[keyName];
+  if (result === UNDEFINED) {
+    return undefined;
+  } else if (result !== undefined) {
+    return result;
+  }
+
+  let ret = this._getter.call(obj, keyName);
+  if (ret === undefined) {
+    cache[keyName] = UNDEFINED;
+  } else {
+    cache[keyName] = ret;
+  }
+
+  let chainWatchers = meta.readableChainWatchers();
+  if (chainWatchers) {
+    chainWatchers.revalidate(keyName);
+  }
+  addDependentKeys(this, obj, keyName, meta);
+
   return ret;
 };
 
@@ -382,49 +393,65 @@ ComputedPropertyPrototype.get = function(obj, keyName) {
   @return {Object} The return value of the function backing the CP.
   @public
 */
-ComputedPropertyPrototype.set = function computedPropertySetWithSuspend(obj, keyName, value) {
-  var oldSuspended = this._suspended;
+ComputedPropertyPrototype.set = function computedPropertySetEntry(obj, keyName, value) {
+  if (this._readOnly) {
+    throw new EmberError(`Cannot set read-only property "${keyName}" on object: ${inspect(obj)}`);
+  }
 
+  if (!this._setter) {
+    return this.clobberSet(obj, keyName, value);
+  }
+
+  if (this._volatile) {
+    return this.volatileSet(obj, keyName, value);
+  }
+
+  return this.setWithSuspend(obj, keyName, value);
+};
+
+ComputedPropertyPrototype.clobberSet = function computedPropertyClobberSet(obj, keyName, value) {
+  let cachedValue = cacheFor(obj, keyName);
+  defineProperty(obj, keyName, null, cachedValue);
+  set(obj, keyName, value);
+  return value;
+};
+
+ComputedPropertyPrototype.volatileSet = function computedPropertyVolatileSet(obj, keyName, value) {
+  return this._setter.call(obj, keyName, value);
+};
+
+ComputedPropertyPrototype.setWithSuspend = function computedPropertySetWithSuspend(obj, keyName, value) {
+  let oldSuspended = this._suspended;
   this._suspended = obj;
-
   try {
-    this._set(obj, keyName, value);
+    return this._set(obj, keyName, value);
   } finally {
     this._suspended = oldSuspended;
   }
 };
 
 ComputedPropertyPrototype._set = function computedPropertySet(obj, keyName, value) {
-  var cacheable      = this._cacheable;
-  var setter         = this._setter;
-  var meta           = metaFor(obj, cacheable);
-  var cache          = meta.readableCache();
-  var hadCachedValue = false;
-
-  var cachedValue, ret;
-
-  if (this._readOnly) {
-    throw new EmberError(`Cannot set read-only property "${keyName}" on object: ${inspect(obj)}`);
-  }
-
-  if (cacheable && cache && cache[keyName] !== undefined) {
+  // cache requires own meta
+  let meta           = metaFor(obj);
+  // either there is a writable cache or we need one to update
+  let cache          = meta.writableCache();
+  let hadCachedValue = false;
+  let cachedValue;
+  if (cache[keyName] !== undefined) {
     if (cache[keyName] !== UNDEFINED) {
       cachedValue = cache[keyName];
     }
-
     hadCachedValue = true;
   }
 
-  if (!setter) {
-    defineProperty(obj, keyName, null, cachedValue);
-    return set(obj, keyName, value);
-  } else {
-    ret = setter.call(obj, keyName, value, cachedValue);
+  let ret = this._setter.call(obj, keyName, value, cachedValue);
+
+  // allows setter to return the same value that is cached already
+  if (hadCachedValue && cachedValue === ret) {
+    return ret;
   }
 
-  if (hadCachedValue && cachedValue === ret) { return; }
-
-  var watched = meta.peekWatching(keyName);
+  let watched = meta.peekWatching(keyName);
   if (watched) {
     propertyWillChange(obj, keyName);
   }
@@ -433,18 +460,14 @@ ComputedPropertyPrototype._set = function computedPropertySet(obj, keyName, valu
     cache[keyName] = undefined;
   }
 
-  if (cacheable) {
-    if (!hadCachedValue) {
-      addDependentKeys(this, obj, keyName, meta);
-    }
-    if (!cache) {
-      cache = meta.writableCache();
-    }
-    if (ret === undefined) {
-      cache[keyName] = UNDEFINED;
-    } else {
-      cache[keyName] = ret;
-    }
+  if (!hadCachedValue) {
+    addDependentKeys(this, obj, keyName, meta);
+  }
+
+  if (ret === undefined) {
+    cache[keyName] = UNDEFINED;
+  } else {
+    cache[keyName] = ret;
   }
 
   if (watched) {
@@ -456,19 +479,16 @@ ComputedPropertyPrototype._set = function computedPropertySet(obj, keyName, valu
 
 /* called before property is overridden */
 ComputedPropertyPrototype.teardown = function(obj, keyName) {
-  var meta = metaFor(obj);
-  let cache = meta.readableCache();
-  if (cache) {
-    if (keyName in cache) {
-      removeDependentKeys(this, obj, keyName, meta);
-    }
-
-    if (this._cacheable) { delete cache[keyName]; }
+  if (this._volatile) {
+    return;
   }
-
-  return null; // no value to restore
+  let meta = metaFor(obj);
+  let cache = meta.readableCache();
+  if (cache && cache[keyName] !== undefined) {
+    removeDependentKeys(this, obj, keyName, meta);
+    cache[keyName] = undefined;
+  }
 };
-
 
 /**
   This helper returns a new property descriptor that wraps the passed
@@ -556,8 +576,8 @@ export default function computed(func) {
   @public
 */
 function cacheFor(obj, key) {
-  var meta = obj['__ember_meta__'];
-  var cache = meta && meta.readableCache();
+  var meta = obj.__ember_meta__;
+  var cache = meta && meta.source === obj && meta.readableCache();
   var ret = cache && cache[key];
 
   if (ret === UNDEFINED) {

--- a/packages/ember-metal/tests/binding/sync_test.js
+++ b/packages/ember-metal/tests/binding/sync_test.js
@@ -6,6 +6,7 @@ import {
 import { bind } from 'ember-metal/binding';
 import { computed } from 'ember-metal/computed';
 import { defineProperty } from 'ember-metal/properties';
+import { propertyWillChange, propertyDidChange } from 'ember-metal/property_events';
 
 QUnit.module('system/binding/sync_test.js');
 
@@ -24,7 +25,9 @@ testBoth('bindings should not sync twice in a single run loop', function(get, se
       },
       set: function(key, value) {
         setCalled++;
+        propertyWillChange(this, key);
         setValue = value;
+        propertyDidChange(this, key);
         return value;
       }
     }).volatile());

--- a/packages/ember-metal/tests/observer_test.js
+++ b/packages/ember-metal/tests/observer_test.js
@@ -831,7 +831,7 @@ testBoth('depending on a chain with a computed property', function (get, set) {
     changed++;
   });
 
-  equal(undefined, cacheFor(obj, 'computed'), 'addObserver should not compute CP');
+  equal(cacheFor(obj, 'computed'), undefined, 'addObserver should not compute CP');
 
   set(obj, 'computed.foo', 'baz');
 

--- a/packages/ember-views/lib/mixins/view_context_support.js
+++ b/packages/ember-views/lib/mixins/view_context_support.js
@@ -32,7 +32,7 @@ var ViewContextSupport = Mixin.create(LegacyViewSupport, {
       set(this, '_context', value);
       return value;
     }
-  }).volatile(),
+  }),
 
   /**
     Private copy of the view's template context. This can be set directly

--- a/packages/ember-views/tests/views/view/init_test.js
+++ b/packages/ember-views/tests/views/view/init_test.js
@@ -37,7 +37,7 @@ QUnit.test('should warn if a computed property is used for classNames', function
       elementId: 'test',
       classNames: computed(function() {
         return ['className'];
-      }).volatile()
+      })
     }).create();
   }, /Only arrays of static class strings.*For dynamic classes/i);
 });
@@ -48,7 +48,7 @@ QUnit.test('should warn if a non-array is used for classNameBindings', function(
       elementId: 'test',
       classNameBindings: computed(function() {
         return ['className'];
-      }).volatile()
+      })
     }).create();
   }, /Only arrays are allowed/i);
 });


### PR DESCRIPTION
Breakup set method into a top level branching method that has 4 paths, readonly check/throw, clobber set, volatile set or normal set.

`volatile()` does not simply mean don’t cache, it means this value is inherently not observable and/or you need to manually notify/cache the value.

ArrayProxy is a good example, length is observable but has to be manually notified for NativeArray mixin, so ArrayProxy just delegates to the underlying array but doesn’t setup DKs or any notification since it is notified already by the mutation methods.

It is not an escape value for you not getting the correct DKs or it seems to solve some bug I can’t figure out.  It is not the equivalent of the old sprout core behavior and hasn’t been for a while.  If you have a dependency that does not fit into a DK, you can notifyPropertyChange() manually.

If you don’t understand the above you should not be using `volatile` it has an extremely narrow use case.
