### PR TITLE
Failing test for computed property alias in angle-bracket component

### DIFF
--- a/packages/ember-htmlbars/tests/integration/component_invocation_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_invocation_test.js
@@ -1264,6 +1264,18 @@ if (isEnabled('ember-htmlbars-component-generation')) {
     runAppend(view);
   });
 
+  QUnit.test('computed property alias on attrs', function() {
+    registry.register('template:components/computed-alias', compile('{{otherProp}}'));
+
+    registry.register('component:computed-alias', Component.extend({
+      otherProp: Ember.computed.alias('attrs.someProp')
+    }));
+
+    view = appendViewFor('<computed-alias someProp="value"></computed-alias>');
+
+    equal(view.$().text(), 'value');
+  });
+
   QUnit.test('parameterized hasBlock default', function() {
     registry.register('template:components/check-block', compile('<check-block>{{#if (hasBlock)}}Yes{{else}}No{{/if}}</check-block>'));
 


### PR DESCRIPTION
Failing spec for: https://github.com/emberjs/ember.js/issues/11948

This works:

``` javascript
// Template
{{my-component someProp='value'}}

// component.js
otherProp: Ember.computed.alias('someProp')
```

While this doesn't:

``` javascript
// Template
<my-component someProp='value'></my-component>

// component.js
otherProp: Ember.computed.alias('attrs.someProp')
```

The test passes if `{{otherProp}}` is replaced with `{{attrs.someProp}}` in the component template
