### PR TITLE
[DOC release] Make controller property on Route public

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -740,7 +740,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @property controller
     @type Ember.Controller
     @since 1.6.0
-    @private
+    @public
   */
 
   _actions: {


### PR DESCRIPTION
It sounds like a lot of people rely on accessing this private property; the only public alternative for Route methods that don't get the controller passed in is `this.controllerFor(this.routeName)`.

This is also the only private Route property without a leading underscore.

Routable components might make this PR a moot point, but I'm submitting anyways per @rwjblue's suggestion.

Thanks!
