### PR TITLE
[BUGFIX release] Deprecate using `controller` for {{with}}

### DIFF
--- a/packages/ember-htmlbars/tests/helpers/with_test.js
+++ b/packages/ember-htmlbars/tests/helpers/with_test.js
@@ -208,10 +208,15 @@ QUnit.test('destroys the controller generated with {{with foo as |bar| controlle
     name: 'Bob Loblaw'
   });
 
+  var template;
+  expectDeprecation(function() {
+    template = compile('{{#with person controller="person" as |steve|}}{{controllerName}}{{/with}}');
+  }, `Using the {{with}} helper with a \`controller\` specified (L1:C0) is deprecated and will be removed in 2.0.0.`);
+
   view = EmberView.create({
-    container: container,
-    template: compile('{{#with person controller="person" as |steve|}}{{controllerName}}{{/with}}'),
-    controller: parentController
+    controller: parentController,
+    template,
+    container
   });
 
   registry.register('controller:person', Controller);

--- a/packages/ember-template-compiler/lib/main.js
+++ b/packages/ember-template-compiler/lib/main.js
@@ -15,6 +15,7 @@ import TransformTopLevelComponents from 'ember-template-compiler/plugins/transfo
 import TransformEachIntoCollection from 'ember-template-compiler/plugins/transform-each-into-collection';
 import DeprecateViewAndControllerPaths from 'ember-template-compiler/plugins/deprecate-view-and-controller-paths';
 import DeprecateViewHelper from 'ember-template-compiler/plugins/deprecate-view-helper';
+import DeprecateWithController from 'ember-template-compiler/plugins/deprecate-with-controller';
 
 // used for adding Ember.Handlebars.compile for backwards compat
 import 'ember-template-compiler/compat';
@@ -27,6 +28,7 @@ registerPlugin('ast', TransformComponentCurlyToReadonly);
 registerPlugin('ast', TransformAngleBracketComponents);
 registerPlugin('ast', TransformInputOnToOnEvent);
 registerPlugin('ast', TransformTopLevelComponents);
+registerPlugin('ast', DeprecateWithController);
 
 if (_Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT) {
   registerPlugin('ast', TransformEachIntoCollection);

--- a/packages/ember-template-compiler/lib/plugins/deprecate-with-controller.js
+++ b/packages/ember-template-compiler/lib/plugins/deprecate-with-controller.js
@@ -1,0 +1,64 @@
+import Ember from 'ember-metal/core';
+import calculateLocationDisplay from 'ember-template-compiler/system/calculate-location-display';
+
+/**
+ @module ember
+ @submodule ember-template-compiler
+*/
+
+/**
+  An HTMLBars AST transformation that deprecates usage of `controller` with the `{{with}}`
+  helper.
+
+  @private
+  @class DeprecateWithController
+*/
+function DeprecateWithController(options) {
+  // set later within HTMLBars to the syntax package
+  this.syntax = null;
+  this.options = options || {};
+}
+
+/**
+  @private
+  @method transform
+  @param {AST} ast The AST to be transformed.
+*/
+DeprecateWithController.prototype.transform = function DeprecateWithController_transform(ast) {
+  const pluginContext = this;
+  const walker = new pluginContext.syntax.Walker();
+  const moduleName = pluginContext.options.moduleName;
+
+  walker.visit(ast, function(node) {
+    if (pluginContext.validate(node)) {
+      let moduleInfo = calculateLocationDisplay(moduleName, node.loc);
+
+      Ember.deprecate(
+        `Using the {{with}} helper with a \`controller\` specified ${moduleInfo}is deprecated and will be removed in 2.0.0.`,
+        false,
+        { id: 'ember-template-compiler.with-controller', until: '2.0.0' }
+      );
+    }
+  });
+
+  return ast;
+};
+
+DeprecateWithController.prototype.validate = function TransformWithAsToHash_validate(node) {
+  return (node.type === 'BlockStatement' || node.type === 'MustacheStatement') &&
+    node.path.original === 'with' &&
+    hashPairForKey(node.hash, 'controller');
+};
+
+function hashPairForKey(hash, key) {
+  for (let i = 0, l = hash.pairs.length; i < l; i++) {
+    let pair = hash.pairs[i];
+    if (pair.key === key) {
+      return pair;
+    }
+  }
+
+  return false;
+}
+
+export default DeprecateWithController;

--- a/packages/ember-template-compiler/tests/plugins/deprecate-with-controller-test.js
+++ b/packages/ember-template-compiler/tests/plugins/deprecate-with-controller-test.js
@@ -1,0 +1,13 @@
+import { compile } from 'ember-template-compiler';
+
+QUnit.module('ember-template-compiler: deprecate-with-controller');
+
+QUnit.test('Using `{{with}}` with `controller` hash argument provides a deprecation', function() {
+  expect(1);
+
+  expectDeprecation(function() {
+    compile('{{#with controller="foo"}}{{/with}}', {
+      moduleName: 'foo/bar/baz'
+    });
+  }, `Using the {{with}} helper with a \`controller\` specified ('foo/bar/baz' @ L1:C0) is deprecated and will be removed in 2.0.0.`);
+});


### PR DESCRIPTION
Need to deprecate in stable, then remove in beta.
