### PR TITLE
Remove internal uses of beforeObservers

### DIFF
--- a/packages/ember-runtime/tests/system/array_proxy/content_change_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/content_change_test.js
@@ -22,13 +22,11 @@ QUnit.test('The `arrangedContentWillChange` method is invoked before `content` i
   var expectedLength;
 
   var proxy = ArrayProxy.extend({
-    content: Ember.A([1, 2, 3]),
-
     arrangedContentWillChange() {
       equal(this.get('arrangedContent.length'), expectedLength, 'hook should be invoked before array has changed');
       callCount++;
     }
-  }).create();
+  }).create({ content: Ember.A([1, 2, 3]) });
 
   proxy.pushObject(4);
   equal(callCount, 0, 'pushing content onto the array doesn\'t trigger it');
@@ -46,13 +44,13 @@ QUnit.test('The `arrangedContentDidChange` method is invoked after `content` is 
   var expectedLength;
 
   var proxy = ArrayProxy.extend({
-    content: Ember.A([1, 2, 3]),
-
     arrangedContentDidChange() {
       equal(this.get('arrangedContent.length'), expectedLength, 'hook should be invoked after array has changed');
       callCount++;
     }
-  }).create();
+  }).create({
+    content: Ember.A([1, 2, 3])
+  });
 
   equal(callCount, 0, 'hook is not called after creating the object');
 

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -4,10 +4,7 @@ import View from 'ember-views/views/view';
 
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
-import {
-  observer,
-  _beforeObserver
-} from 'ember-metal/mixin';
+import { observer } from 'ember-metal/mixin';
 import { on } from 'ember-metal/events';
 
 import containerViewTemplate from 'ember-htmlbars/templates/container-view';
@@ -181,7 +178,7 @@ var ContainerView = View.extend(MutableArray, {
 
   init() {
     this._super(...arguments);
-
+    this._prevCurrentView = undefined;
     var userChildViews = get(this, 'childViews');
     Ember.deprecate('Setting `childViews` on a Container is deprecated.',
                     Ember.isEmpty(userChildViews),
@@ -228,15 +225,13 @@ var ContainerView = View.extend(MutableArray, {
     }
   },
 
-  _currentViewWillChange: _beforeObserver('currentView', function() {
-    var currentView = get(this, 'currentView');
-    if (currentView) {
-      currentView.destroy();
-    }
-  }),
-
   _currentViewDidChange: observer('currentView', function() {
+    var prevView = this._prevCurrentView;
+    if (prevView) {
+      prevView.destroy();
+    }
     var currentView = get(this, 'currentView');
+    this._prevCurrentView = currentView;
     if (currentView) {
       Ember.assert('You tried to set a current view that already has a parent. Make sure you don\'t have multiple outlets in the same view.', !currentView.parentView);
       this.pushObject(currentView);


### PR DESCRIPTION
This refactors array_proxy, collection_view, and container_view to not depend on beforeObservers. The motivation here is to get us closer to the point where an app that doesn't use any beforeObservers doesn't need to pay the performance cost of supporting them.
