### PR TITLE
Update QUnit to 1.18.0.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "jquery": "~1.11.1",
-    "qunit": "~1.17.1",
+    "qunit": "~1.18.0",
     "qunit-phantom-runner": "jonkemp/qunit-phantomjs-runner#1.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ember-cli-sauce": "^1.3.0",
     "ember-cli-yuidoc": "0.7.0",
     "ember-publisher": "0.0.7",
-    "emberjs-build": "0.2.5",
+    "emberjs-build": "0.2.6",
     "express": "^4.5.0",
     "finalhandler": "^0.4.0",
     "github": "^0.2.3",


### PR DESCRIPTION
Also includes an update to emberjs-build to ensure the static test page that is generated contains the correct QUnit version.
