### PR TITLE
[DOC release] Mark didTransition and willTransition as public

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -179,7 +179,7 @@ var EmberRouter = EmberObject.extend(Evented, {
     Triggers the router level `didTransition` hook.
 
     @method didTransition
-    @private
+    @public
     @since 1.2.0
   */
   didTransition(infos) {
@@ -241,7 +241,7 @@ var EmberRouter = EmberObject.extend(Evented, {
     Triggers the router level `willTransition` hook.
 
     @method willTransition
-    @private
+    @public
     @since 1.11.0
   */
   willTransition(oldInfos, newInfos, transition) {


### PR DESCRIPTION
`didTransition` is extremely useful for page tracking and many analytics addons already use it.
