### PR TITLE
[DOC release] Fix up ember-templates namespace docs

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/-concat.js
+++ b/packages/ember-htmlbars/lib/helpers/-concat.js
@@ -1,4 +1,9 @@
 /**
+@module ember
+@submodule ember-templates
+*/
+
+/**
   Concatenates input params together.
 
   Example:
@@ -11,7 +16,7 @@
 
   @public
   @method concat
-  @for Ember.HTMLBars
+  @for Ember.Templates.helpers
 */
 export default function concat(params) {
   return params.join('');

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -1,6 +1,78 @@
 /**
+  Ember templates are executed by [HTMLBars](https://github.com/tildeio/htmlbars),
+  an HTML-friendly version of [Handlebars](http://handlebarsjs.com/). Any valid Handlebars syntax is valid in an Ember template.
 
-  &nbsp;
+  ### Showing a property
+
+  Templates manage the flow of an application's UI, and display state (through
+  the DOM) to a user. For example, given a component with the property "name",
+  that component's template can use the name in several ways:
+
+  ```javascript
+  // app/components/person.js
+  export default Ember.Component.extend({
+    name: 'Jill'
+  });
+  ```
+
+  ```handlebars
+  {{! app/components/person.hbs }}
+  {{name}}
+  <div>{{name}}</div>
+  <span data-name={{name}}></span>
+  ```
+
+  Any time the "name" property on the component changes, the DOM will be
+  updated.
+
+  Properties can be chained as well:
+
+  ```handlebars
+  {{aUserModel.name}}
+  <div>{{listOfUsers.firstObject.name}}</div>
+  ```
+
+  ### Using Ember helpers
+
+  When content is passed in mustaches `{{}}`, Ember will first try to find a helper
+  or component with that name. For example, the `if` helper:
+
+  ```handlebars
+  {{if name "I have a name" "I have no name"}}
+  <span data-has-name={{if name true}}></span>
+  ```
+
+  The returned value is placed where the `{{}}` is called. The above style is
+  called "inline". A second style of helper usage is called "block". For example:
+
+  ```handlebars
+  {{#if name}}
+    I have a name
+  {{else}}
+    I have no name
+  {{/if}}
+  ```
+
+  The block form of helpers allows you to control how the UI is created based
+  on the values of properties.
+
+  A third form of helper is called "nested". For example here the concat
+  helper will add " Doe" to a displayed name if the person has no last name:
+
+  ```handlebars
+  <span data-name={{concat firstName (
+   if lastName (concat " " lastName) "Doe"
+  )}}></span>
+  ```
+
+  Ember's built-in helpers are described under the [Ember.Templates.helpers](/api/classes/Ember.Templates.helpers.html)
+  namespace. Documentation on creating custom helpers can be found under
+  [Ember.Helper](/api/classes/Ember.Helper.html).
+
+  ### Invoking a Component
+
+  Ember components represent state to the UI of an application. Further
+  reading on components can be found under [Ember.Component](/api/classes/Ember.Component.html).
 
   @module ember
   @submodule ember-templates


### PR DESCRIPTION
Since `Ember.Templates` doesn't even show up there as a class there should be something helpful. Plus this give us a place to explain inline, block and nested helpers.
