### PR TITLE
[BUGFIX release] Remove wasted DK's for `template` and `layout`.

### DIFF
--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -155,7 +155,7 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
   @property template
   @public
   */
-  template: computed('_template', {
+  template: computed({
     get() {
       Ember.deprecate(`Accessing 'template' in ${this} is deprecated. To determine if a block was specified to ${this} please use '{{#if hasBlock}}' in the components layout.`,
                       false,
@@ -169,7 +169,7 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
     }
   }),
 
-  _template: computed('templateName', {
+  _template: computed({
     get() {
       if (this._deprecatedFlagForBlockProvided) {
         return true;

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -734,7 +734,7 @@ var View = CoreView.extend(
     @type Function
     @private
   */
-  template: computed('templateName', {
+  template: computed({
     get() {
       var templateName = get(this, 'templateName');
       var template = this.templateForName(templateName, 'template');
@@ -762,7 +762,7 @@ var View = CoreView.extend(
     @type Function
     @public
   */
-  layout: computed('layoutName', {
+  layout: computed({
     get(key) {
       var layoutName = get(this, 'layoutName');
       var layout = this.templateForName(layoutName, 'layout');


### PR DESCRIPTION
We used to observe and rerender properly when `template` or `layout` changed. As of 1.13 we do not rerender any longer, and the additional dependent keys cause extra unusable observers (which add up perf wise).

It is unclear if the change to make `layout` not rerender is a regression, but we certainly shouldn't be paying for observation when we can't take advantage of it.
