### PR TITLE
Ensure currentRouteName and currentPath are always set.

### DIFF
--- a/packages/ember-routing/lib/services/routing.js
+++ b/packages/ember-routing/lib/services/routing.js
@@ -27,6 +27,7 @@ export default Service.extend({
   targetState: readOnly('router.targetState'),
   currentState: readOnly('router.currentState'),
   currentRouteName: readOnly('router.currentRouteName'),
+  currentPath: readOnly('router.currentPath'),
 
   availableRoutes() {
     return Object.keys(get(this, 'router').router.recognizer.names);

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -881,7 +881,14 @@ function calculatePostTransitionState(emberRouter, leafRouteName, contexts) {
 }
 
 function updatePaths(router) {
-  var appController = router.container.lookup('controller:application');
+  let infos = router.router.currentHandlerInfos;
+  let path = EmberRouter._routePath(infos);
+  let currentRouteName = infos[infos.length - 1].name;
+
+  set(router, 'currentPath', path);
+  set(router, 'currentRouteName', currentRouteName);
+
+  let appController = router.container.lookup('controller:application');
 
   if (!appController) {
     // appController might not exist when top-level loading/error
@@ -890,22 +897,17 @@ function updatePaths(router) {
     return;
   }
 
-  var infos = router.router.currentHandlerInfos;
-  var path = EmberRouter._routePath(infos);
-
   if (!('currentPath' in appController)) {
     defineProperty(appController, 'currentPath');
   }
 
   set(appController, 'currentPath', path);
-  set(router, 'currentPath', path);
 
   if (!('currentRouteName' in appController)) {
     defineProperty(appController, 'currentRouteName');
   }
 
-  set(appController, 'currentRouteName', infos[infos.length - 1].name);
-  set(router, 'currentRouteName', infos[infos.length - 1].name);
+  set(appController, 'currentRouteName', currentRouteName);
 }
 
 EmberRouter.reopenClass({


### PR DESCRIPTION
Previously, the `currentRouteName` and `currentPath` were only set if `controller:application` existed. This ensures that the props on the router itself are set (just not the ones on `controller:application` when it isn't setup yet).

Also, add `currentPath` to `service:-routing`.
