### PR TITLE
[BUGFIX release] Ensure initializers can augment customEvents.

### DIFF
--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -75,7 +75,6 @@ let ApplicationInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
 
     var application = get(this, 'application');
 
-    set(this, 'customEvents', get(application, 'customEvents'));
     set(this, 'rootElement', get(application, 'rootElement'));
 
     // Create a per-instance registry that will use the application's registry
@@ -188,7 +187,9 @@ let ApplicationInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
   */
   setupEventDispatcher() {
     var dispatcher = this.lookup('event_dispatcher:main');
-    dispatcher.setup(this.customEvents, this.rootElement);
+    var applicationCustomEvents = get(this.application, 'customEvents');
+
+    dispatcher.setup(applicationCustomEvents, this.rootElement);
 
     return dispatcher;
   },

--- a/packages/ember-application/tests/system/application_instance_test.js
+++ b/packages/ember-application/tests/system/application_instance_test.js
@@ -65,3 +65,22 @@ QUnit.test('properties (and aliases) are correctly assigned for accessing the co
     strictEqual(appInstance.registry, appInstance.__registry__, '#registry alias should be assigned');
   }
 });
+
+QUnit.test('customEvents added to the application before setupEventDispatcher', function(assert) {
+  assert.expect(1);
+
+  run(function() {
+    appInstance = ApplicationInstance.create({ application: app });
+  });
+
+  app.customEvents = {
+    awesome: 'sauce'
+  };
+
+  var eventDispatcher = appInstance.lookup('event_dispatcher:main');
+  eventDispatcher.setup = function(events) {
+    assert.equal(events.awesome, 'sauce');
+  };
+
+  appInstance.setupEventDispatcher();
+});


### PR DESCRIPTION
The initial refactor for Ember 1.11 to use `ApplicationInstance` broke the ability for an initializer to specify `customEvents`.  This meant for example that addons could not add their own events to the listing before the `EventDispatcher` was setup.

The reason for the failure, was that we were copying `customEvents` from the application upon `init` of the `ApplicationInstance` (which is done before initializers are called), and never looking at `application.customEvents` again.

The fix is to avoid eagerly copying from `application.customEvents` when the application instance is created, and to do it just before setting up the event dispatcher.

Also, apparently `packages/tests/application_lifecycle.js` test file was never running because it didn't have the proper test file suffix.

Fixes #10534.
