### PR TITLE
Allow instanceInitializers to set `customEvents`.

### DIFF
--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -14,6 +14,7 @@ import { computed } from 'ember-metal/computed';
 import Registry from 'container/registry';
 import RegistryProxy from 'ember-runtime/mixins/registry_proxy';
 import ContainerProxy from 'ember-runtime/mixins/container_proxy';
+import assign from 'ember-metal/assign';
 
 /**
   The `ApplicationInstance` encapsulates all of the stateful aspects of a
@@ -188,8 +189,10 @@ let ApplicationInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
   setupEventDispatcher() {
     var dispatcher = this.lookup('event_dispatcher:main');
     var applicationCustomEvents = get(this.application, 'customEvents');
+    var instanceCustomEvents = get(this, 'customEvents');
 
-    dispatcher.setup(applicationCustomEvents, this.rootElement);
+    var customEvents = assign({}, applicationCustomEvents, instanceCustomEvents);
+    dispatcher.setup(customEvents, this.rootElement);
 
     return dispatcher;
   },

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -615,11 +615,12 @@ var Application = Namespace.extend(RegistryProxy, {
   */
   didBecomeReady() {
     if (this.autoboot) {
+      this.runInstanceInitializers(this.__deprecatedInstance__);
+
       if (environment.hasDOM) {
         this.__deprecatedInstance__.setupEventDispatcher();
       }
 
-      this.runInstanceInitializers(this.__deprecatedInstance__);
       this.ready(); // user hook
       this.__deprecatedInstance__.startRouting();
 

--- a/packages/ember-application/tests/system/application_instance_test.js
+++ b/packages/ember-application/tests/system/application_instance_test.js
@@ -84,3 +84,41 @@ QUnit.test('customEvents added to the application before setupEventDispatcher', 
 
   appInstance.setupEventDispatcher();
 });
+
+QUnit.test('customEvents added to the application before setupEventDispatcher', function(assert) {
+  assert.expect(1);
+
+  run(function() {
+    appInstance = ApplicationInstance.create({ application: app });
+  });
+
+  app.customEvents = {
+    awesome: 'sauce'
+  };
+
+  var eventDispatcher = appInstance.lookup('event_dispatcher:main');
+  eventDispatcher.setup = function(events) {
+    assert.equal(events.awesome, 'sauce');
+  };
+
+  appInstance.setupEventDispatcher();
+});
+
+QUnit.test('customEvents added to the application instance before setupEventDispatcher', function(assert) {
+  assert.expect(1);
+
+  run(function() {
+    appInstance = ApplicationInstance.create({ application: app });
+  });
+
+  appInstance.customEvents = {
+    awesome: 'sauce'
+  };
+
+  var eventDispatcher = appInstance.lookup('event_dispatcher:main');
+  eventDispatcher.setup = function(events) {
+    assert.equal(events.awesome, 'sauce');
+  };
+
+  appInstance.setupEventDispatcher();
+});


### PR DESCRIPTION
Instance initializers were previously not able to affect the `customEvents` that will be provided to the `EventDispatcher`. This is most helpful when you are receiving configuration that is registered as in an initiailzer.

The fix here is to run instance initializers before the event dispatcher is setup, so that they can augment the `customEvents` hash.

Related to https://github.com/emberjs/ember.js/pull/12056.

---

Please note this has not worked previously (though from the look of the code, it was intended to), so it is not a `[BUGFIX release]` candidate.
