### PR TITLE
[BUGFIX release] Fix link-to with only qps linking to outdated route

### DIFF
--- a/packages/ember-routing-views/lib/views/link.js
+++ b/packages/ember-routing-views/lib/views/link.js
@@ -320,7 +320,7 @@ var LinkComponent = EmberComponent.extend({
     }
 
     var routing = get(this, '_routing');
-    var targetRouteName = get(this, 'targetRouteName');
+    var targetRouteName = this._handleOnlyQueryParamsSupplied(get(this, 'targetRouteName'));
     var models = get(this, 'models');
     var queryParamValues = get(this, 'queryParams.values');
     var shouldReplace = get(this, 'attrs.replace');

--- a/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
+++ b/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
@@ -211,6 +211,56 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     equal(Ember.$('#the-link').attr('href'), '/?bar=BORF&foo=lol');
   });
 
+  QUnit.test('The {{link-to}} with only query params always transitions to the current route with the query params applied', function() {
+    // Test harness for bug #12033
+
+    Ember.TEMPLATES.cars = compile(
+      '{{#link-to \'cars.create\' id=\'create-link\'}}Create new car{{/link-to}} ' +
+      '{{#link-to (query-params page=\'2\') id=\'page2-link\'}}Page 2{{/link-to}}' +
+      '{{outlet}}'
+    );
+
+    Ember.TEMPLATES['cars/create'] = compile(
+      '{{#link-to \'cars\' id=\'close-link\'}}Close create form{{/link-to}}'
+    );
+
+    Router.map(function() {
+      this.route('cars', function() {
+        this.route('create');
+      });
+    });
+
+    App.CarsRoute = Ember.Route.extend({
+      queryParams: {
+        page: { defaultValue: 1 }
+      }
+    });
+
+    bootApplication();
+
+    Ember.run(function() {
+      router.handleURL('/cars/create');
+    });
+
+    Ember.run(function() {
+      equal(router.currentRouteName, 'cars.create');
+      Ember.$('#close-link').click();
+    });
+
+    Ember.run(function() {
+      equal(router.currentRouteName, 'cars.index');
+      equal(router.get('url'), '/cars');
+      equal(container.lookup('controller:cars').get('page'), 1, 'The page query-param is 1');
+      Ember.$('#page2-link').click();
+    });
+
+    Ember.run(function() {
+      equal(router.currentRouteName, 'cars.index', 'The active route is still cars');
+      equal(router.get('url'), '/cars?page=2', 'The url has been updated');
+      equal(container.lookup('controller:cars').get('page'), 2, 'The query params have been updated');
+    });
+  });
+
   QUnit.test('The {{link-to}} applies activeClass when query params are not changed', function() {
     Ember.TEMPLATES.index = compile(
       '{{#link-to (query-params foo=\'cat\') id=\'cat-link\'}}Index{{/link-to}} ' +
@@ -576,6 +626,57 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     equal(Ember.$('#the-link').attr('href'), '/?bar=BORF&foo=lol');
     Ember.run(indexController, 'set', 'foo', 'YEAH');
     equal(Ember.$('#the-link').attr('href'), '/?bar=BORF&foo=lol');
+  });
+
+  QUnit.test('The {{link-to}} with only query params always transitions to the current route with the query params applied', function() {
+    // Test harness for bug #12033
+
+    Ember.TEMPLATES.cars = compile(
+      '{{#link-to \'cars.create\' id=\'create-link\'}}Create new car{{/link-to}} ' +
+      '{{#link-to (query-params page=\'2\') id=\'page2-link\'}}Page 2{{/link-to}}' +
+      '{{outlet}}'
+    );
+
+    Ember.TEMPLATES['cars/create'] = compile(
+      '{{#link-to \'cars\' id=\'close-link\'}}Close create form{{/link-to}}'
+    );
+
+    Router.map(function() {
+      this.route('cars', function() {
+        this.route('create');
+      });
+    });
+
+    App.CarsController = Ember.Controller.extend({
+      queryParams: ['page'],
+      page: 1
+    });
+
+    bootApplication();
+
+    var carsController = container.lookup('controller:cars');
+
+    Ember.run(function() {
+      router.handleURL('/cars/create');
+    });
+
+    Ember.run(function() {
+      equal(router.currentRouteName, 'cars.create');
+      Ember.$('#close-link').click();
+    });
+
+    Ember.run(function() {
+      equal(router.currentRouteName, 'cars.index');
+      equal(router.get('url'), '/cars');
+      equal(carsController.get('page'), 1, 'The page query-param is 1');
+      Ember.$('#page2-link').click();
+    });
+
+    Ember.run(function() {
+      equal(router.currentRouteName, 'cars.index', 'The active route is still cars');
+      equal(router.get('url'), '/cars?page=2', 'The url has been updated');
+      equal(carsController.get('page'), 2, 'The query params have been updated');
+    });
   });
 
   QUnit.test('The {{link-to}} applies activeClass when query params are not changed', function() {


### PR DESCRIPTION
Fixes #12033

Once a link with only qps was created in a certain route, the `targetRouteName` was never updated again (the URL however was updated properly)
