### PR TITLE
[BUGFIX canary] Delete unused templates

### DIFF
--- a/packages/ember-htmlbars/lib/templates/link-to-escaped.hbs
+++ b/packages/ember-htmlbars/lib/templates/link-to-escaped.hbs
@@ -1,1 +1,0 @@
-{{linkTitle}}

--- a/packages/ember-htmlbars/lib/templates/link-to-unescaped.hbs
+++ b/packages/ember-htmlbars/lib/templates/link-to-unescaped.hbs
@@ -1,1 +1,0 @@
-{{{linkTitle}}}


### PR DESCRIPTION
These don't appear to do anything anymore.
