### PR TITLE
[BUGFIX release] improve performance of guidFor when reading an exist…

### DIFF
--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -201,6 +201,10 @@ export function generateGuid(obj, prefix) {
   @return {String} the unique guid for this instance.
 */
 export function guidFor(obj) {
+  if (obj && obj[GUID_KEY]) {
+    return obj[GUID_KEY];
+  }
+
   // special cases where we don't want to add a key to object
   if (obj === undefined) {
     return '(undefined)';
@@ -237,10 +241,6 @@ export function guidFor(obj) {
       return obj ? '(true)' : '(false)';
 
     default:
-      if (obj[GUID_KEY]) {
-        return obj[GUID_KEY];
-      }
-
       if (obj === Object) {
         return '(Object)';
       }


### PR DESCRIPTION
…ing guid
- This made OrderedSet#add 2x -> 3x faster (really helps our ember-data friends)
- This appears to have made OrderedSet#add faster then V8 native Set#add (for now – in one specific + common scenario)
- will help all scenarios where we use `guidFor` on an object that already has a guid
