### PR TITLE
Remove this.__nextSuper

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -25,7 +25,6 @@ import {
 import {
   generateGuid,
   GUID_KEY_PROPERTY,
-  NEXT_SUPER_PROPERTY,
   makeArray
 } from 'ember-metal/utils';
 import { meta } from 'ember-metal/meta';
@@ -73,7 +72,6 @@ function makeCtor() {
     }
 
     this.__defineNonEnumerable(GUID_KEY_PROPERTY);
-    this.__defineNonEnumerable(NEXT_SUPER_PROPERTY);
     var m = meta(this);
     var proto = m.proto;
     m.proto = this;


### PR DESCRIPTION
This just ensures that the superFunction is wrapped with a terminal _super instead of relying on this.__nextSuper = null while invoked to prevent recursion. Allows wrapped functions not to have to go through 2 argument applies, makes debugging a lot easier and performs better.
