### PR TITLE
Clean up server-side rendering tests

### DIFF
--- a/tests/node/app-boot-test.js
+++ b/tests/node/app-boot-test.js
@@ -1,288 +1,82 @@
-/*globals global,__dirname*/
+/*jshint multistr:true*/
+var appModule = require('./helpers/app-module');
 
-var path = require('path');
-var distPath = path.join(__dirname, '../../dist');
-var emberPath = path.join(distPath, 'ember.debug.cjs');
-var templateCompilerPath = path.join(distPath, 'ember-template-compiler');
-
-var defeatureifyConfig = require(path.join(__dirname, '../../features.json'));
-
-var canUseInstanceInitializers = true;
-var canUseApplicationVisit;
-
-if (defeatureifyConfig.features['ember-application-visit'] !== false) {
-  canUseApplicationVisit = true;
+function assertHTMLMatches(assert, actualHTML, expectedHTML) {
+  assert.ok(actualHTML.match(expectedHTML), actualHTML + " matches " + expectedHTML);
 }
 
-var features = {};
-for (var feature in defeatureifyConfig.features) {
-  features[feature] = defeatureifyConfig.features[feature];
-}
-features['ember-application-visit'] =true;
+appModule("App Boot");
 
-/*jshint -W079 */
-global.EmberENV = {
-  FEATURES: features
-};
-
-var Ember, compile, domHelper, run, DOMHelper, app;
-
-var SimpleDOM = require('simple-dom');
-var URL = require('url');
-
-function createApplication() {
-  var App = Ember.Application.extend().create({
-    autoboot: false
-  });
-
-  App.Router = Ember.Router.extend({
-    location: 'none'
-  });
-
-  return App;
-}
-
-function createDOMHelper() {
-  var document = new SimpleDOM.Document();
-  var domHelper = new DOMHelper(document);
-
-  domHelper.protocolForURL = function(url) {
-    var protocol = URL.parse(url).protocol;
-    return (protocol == null) ? ':' : protocol;
-  };
-
-  domHelper.setMorphHTML = function(morph, html) {
-    var section = this.document.createRawHTMLSection(html);
-    morph.setNode(section);
-  };
-
-  return domHelper;
-}
-
-function registerDOMHelper(app) {
-  app.instanceInitializer({
-    name: 'register-dom-helper',
-    initialize: function(app) {
-      app.register('renderer:-dom', {
-        create: function() {
-          return new Ember._Renderer(domHelper, false);
-        }
-      });
-    }
-  });
-}
-
-function registerTemplates(app, templates) {
-  app.instanceInitializer({
-    name: 'register-application-template',
-
-    initialize: function(app) {
-      for (var key in templates) {
-        app.register('template:' + key, compile(templates[key]));
-      }
-    }
-  });
-}
-
-function registerControllers(app, controllers) {
-  app.instanceInitializer({
-    name: 'register-application-controllers',
-
-    initialize: function(app) {
-      for (var key in controllers) {
-        app.register('controller:' + key, controllers[key]);
-      }
-    }
-  });
-}
-
-function renderToElement(instance) {
-  var element;
-  run(function() {
-    element = instance.view.renderToElement();
-  });
-
-  return element;
-}
-
-function assertHTMLMatches(assert, actualElement, expectedHTML) {
-  var serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
-  var serialized = serializer.serialize(actualElement);
-
-  assert.ok(serialized.match(expectedHTML), serialized + " matches " + expectedHTML);
-}
-
-
-QUnit.module("App boot", {
-  setup: function() {
-    Ember = require(emberPath);
-    compile = require(templateCompilerPath).compile;
-    Ember.testing = true;
-    DOMHelper = Ember.HTMLBars.DOMHelper;
-    domHelper = createDOMHelper();
-    run = Ember.run;
-  },
-
-  teardown: function() {
-    Ember.run(app, 'destroy');
-
-    delete global.Ember;
-
-    // clear the previously cached version of this module
-    delete require.cache[emberPath + '.js'];
-    delete require.cache[templateCompilerPath + '.js'];
-  }
+QUnit.test("App boots and routes to a URL", function(assert) {
+  this.visit('/');
+  assert.ok(this.app);
 });
 
-if (canUseInstanceInitializers && canUseApplicationVisit) {
-  QUnit.test("App is created without throwing an exception", function(assert) {
-    run(function() {
-      app = createApplication();
-      registerDOMHelper(app);
+QUnit.test("nested {{component}}", function(assert) {
+  this.template('index', "{{root-component}}");
 
-      app.visit('/');
-    });
+  this.template('components/root-component', "\
+    <h1>Hello {{#if hasExistence}}{{location}}{{/if}}</h1>\
+    <div>{{component 'foo-bar'}}</div>\
+  ");
 
-    assert.ok(app);
+  this.component('root-component', {
+    location: "World",
+    hasExistence: true
   });
 
-  QUnit.test("It is possible to render a view in Node", function(assert) {
-    var View = Ember.Component.extend({
-      renderer: new Ember._Renderer(new DOMHelper(new SimpleDOM.Document())),
-      layout: compile("<h1>Hello</h1>")
-    });
+  this.template('components/foo-bar', "\
+    <p>The files are *inside* the computer?!</p>\
+  ");
 
-    var view = View.create({
-      _domHelper: new DOMHelper(new SimpleDOM.Document()),
-    });
+  return this.renderToHTML('/').then(function(html) {
+    assertHTMLMatches(assert, html, /<h1>Hello World<\/h1>\s+<div><div id="(.*)" class="ember-view">\s+<p>The files are \*inside\* the computer\?\!<\/p>\s+<\/div><\/div>/);
+  });
+});
 
-    run(view, view.createElement);
-
-    var serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
-    assert.ok(serializer.serialize(view.element).match(/<h1>Hello<\/h1>/));
+QUnit.test("{{link-to}}", function(assert) {
+  this.template('application', "<h1>{{#link-to 'photos'}}Go to photos{{/link-to}}</h1>");
+  this.routes(function() {
+    this.route('photos');
   });
 
-  QUnit.test("It is possible to render a view with curlies in Node", function(assert) {
-    var View = Ember.Component.extend({
-      renderer: new Ember._Renderer(new DOMHelper(new SimpleDOM.Document())),
-      layout: compile("<h1>Hello {{location}}</h1>"),
-      location: "World"
-    });
+  return this.renderToHTML('/').then(function(html) {
+    assertHTMLMatches(assert, html, /<div id="ember\d+" class="ember-view"><h1><a id="ember\d+" href="\/photos" class="ember-view">Go to photos<\/a><\/h1><\/div>/);
+  });
+});
 
-    var view = View.create({
-      _domHelper: new DOMHelper(new SimpleDOM.Document())
-    });
-
-    run(view, view.createElement);
-
-    var serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
-
-    assert.ok(serializer.serialize(view.element).match(/<h1>Hello World<\/h1>/));
+QUnit.test("non-escaped content", function(assert) {
+  this.routes(function() {
+    this.route('photos');
   });
 
-  QUnit.test("It is possible to render a view with a nested {{component}} helper in Node", function(assert) {
-    var registry = new Ember.Application.buildRegistry({ get: function(path) { return Ember.get(this, path); } });
-    registry.register('component-lookup:main', Ember.ComponentLookup);
-    var container = registry.container();
-
-    var View = Ember.Component.extend({
-      container: container,
-      renderer: new Ember._Renderer(new DOMHelper(new SimpleDOM.Document())),
-      layout: compile("<h1>Hello {{#if hasExistence}}{{location}}{{/if}}</h1> <div>{{component 'foo-bar'}}</div>"),
-      location: "World",
-      hasExistence: true
-    });
-
-    registry.register('component:foo-bar', Ember.Component.extend({
-      layout: compile("<p>The files are *inside* the computer?!</p>")
-    }));
-
-    var view = View.create();
-
-    run(view, function() { view.createElement(); });
-
-    var serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
-    assert.ok(serializer.serialize(view.element).match(/<h1>Hello World<\/h1> <div><div id="(.*)" class="ember-view"><p>The files are \*inside\* the computer\?\!<\/p><\/div><\/div>/));
+  this.template('application', "<h1>{{{title}}}</h1>");
+  this.controller('application', {
+    title: "<b>Hello world</b>"
   });
 
-  QUnit.test("It is possible to render a view with {{link-to}} in Node", function(assert) {
-    run(function() {
-      app = createApplication();
+  return this.renderToHTML('/').then(function(html) {
+    assertHTMLMatches(assert, html, /<div id="ember\d+" class="ember-view"><h1><b>Hello world<\/b><\/h1><\/div>/);
+  });
+});
 
-      app.Router.map(function() {
-        this.route('photos');
-      });
-
-      registerDOMHelper(app);
-      registerTemplates(app, {
-        application: "<h1>{{#link-to 'photos'}}Go to photos{{/link-to}}</h1>"
-      });
-    });
-
-    return app.visit('/').then(function(instance) {
-      var element = renderToElement(instance);
-
-      assertHTMLMatches(assert, element.firstChild, /^<div id="ember\d+" class="ember-view"><h1><a id="ember\d+" href="\/photos" class="ember-view">Go to photos<\/a><\/h1><\/div>$/);
-    });
+QUnit.test("outlets", function(assert) {
+  this.routes(function() {
+    this.route('photos');
   });
 
-  QUnit.test("It is possible to render non-escaped content", function(assert) {
-    debugger;
-    run(function() {
-      app = createApplication();
+  this.template('application', "<p>{{outlet}}</p>");
+  this.template('index', "<span>index</span>");
+  this.template('photos', "<em>photos</em>");
 
-      app.Router.map(function() {
-        this.route('photos');
-      });
+  var promises = [];
+  promises.push(this.renderToHTML('/').then(function(html) {
+    assertHTMLMatches(assert, html, /<div id="ember(.*)" class="ember-view"><p><span>index<\/span><\/p><\/div>/);
+  }));
 
-      registerDOMHelper(app);
-      registerTemplates(app, {
-        application: "<h1>{{{title}}}</h1>"
-      });
+  promises.push(this.renderToHTML('/photos').then(function(html) {
+    assertHTMLMatches(assert, html, /<div id="ember(.*)" class="ember-view"><p><em>photos<\/em><\/p><\/div>/);
+  }));
 
-      registerControllers(app, {
-        application: Ember.Controller.extend({
-          title: "<b>Hello world</b>"
-        })
-      });
-    });
-
-    return app.visit('/').then(function(instance) {
-      var element = renderToElement(instance);
-
-      assertHTMLMatches(assert, element.firstChild, /^<div id="ember\d+" class="ember-view"><h1><b>Hello world<\/b><\/h1><\/div>$/);
-    });
-  });
-
-  QUnit.test("It is possible to render outlets in Node", function(assert) {
-    run(function() {
-      app = createApplication();
-
-      app.Router.map(function() {
-        this.route('photos');
-      });
-
-      registerDOMHelper(app);
-      registerTemplates(app, {
-        application: "<p>{{outlet}}</p>",
-        index: "<span>index</span>",
-        photos: "<em>photos</em>"
-      });
-    });
-
-    var visits = [];
-    visits.push(app.visit('/').then(function(instance) {
-      var element = renderToElement(instance);
-
-      assertHTMLMatches(assert, element.firstChild, /<div id="ember(.*)" class="ember-view"><p><span>index<\/span><\/p><\/div>/);
-    }));
-
-    visits.push(app.visit('/photos').then(function(instance) {
-      var element = renderToElement(instance);
-
-      assertHTMLMatches(assert, element.firstChild, /<div id="ember(.*)" class="ember-view"><p><em>photos<\/em><\/p><\/div>/);
-    }));
-
-    return Ember.RSVP.Promise.all(visits);
-  });
-}
+  return this.all(promises);
+});

--- a/tests/node/component-rendering-test.js
+++ b/tests/node/component-rendering-test.js
@@ -1,0 +1,62 @@
+/*globals global,__dirname*/
+
+var SimpleDOM = require('simple-dom');
+var path = require('path');
+
+var distPath = path.join(__dirname, '../../dist');
+var emberPath = path.join(distPath, 'ember.debug.cjs');
+var templateCompilerPath = path.join(distPath, 'ember-template-compiler');
+
+var compile = require(templateCompilerPath).compile;
+var Ember, DOMHelper, run;
+
+QUnit.module("Components can be rendered without a DOM dependency", {
+  beforeEach: function() {
+    Ember = require(emberPath);
+    DOMHelper = Ember.HTMLBars.DOMHelper;
+    run = Ember.run;
+  },
+
+  afterEach: function() {
+    delete global.Ember;
+
+    // clear the previously cached version of this module
+    delete require.cache[emberPath + '.js'];
+    delete require.cache[templateCompilerPath + '.js'];
+  }
+});
+
+QUnit.test("Simple component", function(assert) {
+  var component = buildComponent("<h1>Hello</h1>");
+  var html = renderComponent(component);
+
+  assert.ok(html.match(/<h1>Hello<\/h1>/));
+});
+
+QUnit.test("Component with dynamic value", function(assert) {
+  var component = buildComponent('<h1>Hello {{location}}</h1>', {
+    location: "World"
+  });
+
+  var html = renderComponent(component);
+
+  assert.ok(html.match(/<h1>Hello World<\/h1>/));
+});
+
+function buildComponent(template, props) {
+  var Component = Ember.Component.extend({
+    renderer: new Ember._Renderer(new DOMHelper(new SimpleDOM.Document())),
+    layout: compile(template)
+  }, props || {});
+
+  return Component.create({
+    _domHelper: new DOMHelper(new SimpleDOM.Document()),
+  });
+}
+
+function renderComponent(component) {
+  run(component, component.createElement);
+
+  var serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
+  return serializer.serialize(component.element);
+}

--- a/tests/node/helpers/app-module.js
+++ b/tests/node/helpers/app-module.js
@@ -1,0 +1,226 @@
+/*jshint node:true*/
+/*globals global,__dirname*/
+
+var path = require('path');
+var distPath = path.join(__dirname, '../../../dist');
+var emberPath = path.join(distPath, 'ember.debug.cjs');
+var templateCompilerPath = path.join(distPath, 'ember-template-compiler');
+var features = require(path.join(__dirname, '../../../features.json')).features;
+var SimpleDOM = require('simple-dom');
+var URL = require('url');
+
+/*
+ * This helper sets up a QUnit test module with all of the environment and
+ * helper methods necessary to test an Ember.js application running in the
+ * server-side environment.
+ *
+ * On each test, it loads a fresh version of the compiled Ember.js library
+ * from `dist`, just like how FastBoot works. It uses the new `visit()` API
+ * to simulate a FastBoot environment (enabling that feature flag if it is
+ * not already turned on).
+ *
+ * To test an app, register the objects that make up the app. For example,
+ * to register a component:
+ *
+ *     this.component('component-name', {
+ *       componetProperty: true
+ *     });
+ *
+ * Or a template:
+ *
+ *    this.template('application', '{{outlet}}');
+ *    this.template('components/foo-bar', '<h1>Hello world</h1>');
+ *
+ * Or a controller:
+ *
+ *    this.controller('controller-name', {
+ *      actions: {
+ *        sendEmail: function() { }
+ *      }
+ *    });
+ *
+ * You can also provide the routes for the application by calling `this.routes()`,
+ * which is equivalent to `App.Router.map()`:
+ *
+ *     this.routes(function() {
+ *       this.route('photos');
+ *       this.route('admin', function() {
+ *         this.route('logout');
+ *       });
+ *     });
+ *
+ * Once all of the constituent parts of the app are registered, you can kick off
+ * app boot by calling either `this.visit(url)` or `this.renderToHTML(url)`.
+ *
+ * `visit` returns a promise that resolves to the application instance, and
+ * `renderToHTML` returns a promise that resolves to the rendered HTML of the
+ * application.
+ *
+ *     return this.renderToHTML('/'photos).then(function(html) {
+ *       assert.ok(html.matches('<h1>Hello world</h1>'));
+ *     });
+*/
+
+// Server-side rendering relies on the `ember-application-visit` feature flag,
+// which we enable explicitly for these tests. Once that flag is enabled by
+// default, you may remove this guard.
+features['ember-application-visit'] = true;
+
+/*jshint -W079 */
+global.EmberENV = {
+  FEATURES: features
+};
+
+module.exports = function(moduleName) {
+  QUnit.module(moduleName, {
+    beforeEach: function() {
+      var Ember = this.Ember = require(emberPath);
+      var DOMHelper = Ember.HTMLBars.DOMHelper;
+      Ember.testing = true;
+
+      this.compile = require(templateCompilerPath).compile;
+      this.domHelper = createDOMHelper(DOMHelper);
+      this.run = Ember.run;
+      this.all = Ember.RSVP.all;
+
+      this.visit = visit;
+      this.createApplication = createApplication;
+      this.register = register;
+      this.template = registerTemplate;
+      this.component = registerComponent;
+      this.controller = registerController;
+      this.routes = registerRoutes;
+      this.registry = {};
+      this.renderToElement = renderToElement;
+      this.renderToHTML = renderToHTML;
+    },
+
+    afterEach: function() {
+      this.Ember.run(this.app, 'destroy');
+
+      delete global.Ember;
+
+      // clear the previously cached version of this module
+      delete require.cache[emberPath + '.js'];
+      delete require.cache[templateCompilerPath + '.js'];
+    }
+  });
+};
+
+function createApplication() {
+  var app = this.Ember.Application.extend().create({
+    autoboot: false
+  });
+
+  app.Router = this.Ember.Router.extend({
+    location: 'none'
+  });
+
+  if (this.routesCallback) {
+    app.Router.map(this.routesCallback);
+  }
+
+  registerDOMHelper(this.Ember, app, this.domHelper);
+  registerApplicationClasses(app, this.registry);
+
+  this.run(function() {
+    app.boot();
+  });
+  this.app = app;
+
+  return app;
+}
+
+function register(containerKey, klass) {
+  this.registry[containerKey] = klass;
+}
+
+function visit(url) {
+  if (!this.app) { this.createApplication(); }
+
+  var promise;
+  this.run(this, function() {
+    promise = this.app.visit(url);
+  });
+
+  return promise;
+}
+
+function registerDOMHelper(Ember, app, domHelper) {
+  app.initializer({
+    name: 'register-dom-helper',
+    initialize: function(app) {
+      app.register('renderer:-dom', {
+        create: function() {
+          return new Ember._Renderer(domHelper, false);
+        }
+      });
+    }
+  });
+}
+
+function createDOMHelper(DOMHelper) {
+  var document = new SimpleDOM.Document();
+  var domHelper = new DOMHelper(document);
+
+  domHelper.protocolForURL = function(url) {
+    var protocol = URL.parse(url).protocol;
+    return (protocol == null) ? ':' : protocol;
+  };
+
+  domHelper.setMorphHTML = function(morph, html) {
+    var section = this.document.createRawHTMLSection(html);
+    morph.setNode(section);
+  };
+
+  return domHelper;
+}
+
+function registerApplicationClasses(app, registry) {
+  app.initializer({
+    name: 'register-application-classes',
+    initialize: function(app) {
+      for (var key in registry) {
+        app.register(key, registry[key]);
+      }
+    }
+  });
+}
+
+function registerTemplate(name, template) {
+  this.register('template:'+name, this.compile(template));
+}
+
+function registerComponent(name, componentProps) {
+  var component = this.Ember.Component.extend(componentProps);
+  this.register('component:'+name, component);
+}
+
+function registerController(name, controllerProps) {
+  var controller = this.Ember.Controller.extend(controllerProps);
+  this.register('controller:'+name, controller);
+}
+
+function registerRoutes(cb) {
+  this.routesCallback = cb;
+}
+
+function renderToElement(instance) {
+  var element;
+  this.run(function() {
+    element = instance.view.renderToElement();
+  });
+
+  return element;
+}
+
+function renderToHTML(route) {
+  var self = this;
+  return this.visit(route).then(function(instance) {
+    var element = self.renderToElement(instance);
+    var serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
+    var serialized = serializer.serialize(element);
+
+    return serialized;
+  });
+}


### PR DESCRIPTION
The tests for running Ember applications inside a Node.js environment evolved organically and were in need of a cleanup. In particular, there was so much boilerplate code that was repeated for each test that it was hard for the layperson to follow along, and even experienced users had trouble understanding what the intent of the test was without careful parsing.

This commit splits the test into two files:
1. Simple component rendering tests that just verify that a single component can be rendered to a string of HTML
2. Integration tests that boot and test an entire application.

The integration tests have been cleaned up significantly. I implemented a small DSL for building up an application in the tests, as well as some helper methods that abstract the steps necessary to put Ember into server-side rendering mode, as well as the asynchrony that comes with it.

That abstraction happens in a helper that wraps QUnit.module, giving any tests in that module a pre-built environment for registering classes in the application, then routing to a URL and testing the resulting HTML.
