### PR TITLE
[BUGFIX release] Prevent helper:@content-helper lookups.

### DIFF
--- a/packages/ember-htmlbars/lib/hooks/link-render-node.js
+++ b/packages/ember-htmlbars/lib/hooks/link-render-node.js
@@ -23,6 +23,7 @@ export default function linkRenderNode(renderNode, env, scope, path, params, has
       case 'unless':
       case 'if': params[0] = shouldDisplay(params[0]); break;
       case 'each': params[0] = eachParam(params[0]); break;
+      case '@content-helper': break;
       default:
         helper = findHelper(path, env.view, env);
 


### PR DESCRIPTION
This special value is used in HTMLBars in some circumstances, and causes an error in the ember-cli resolver (until latest version).

The default path here is only present to support legacy `makeViewHelper` style helpers, and is removed on 2.0.0.

Fixes #11987.
