### PR TITLE
[BUGFIX] Disable DOM-related component hooks in FastBoot

### DIFF
--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -153,10 +153,14 @@ ComponentNodeManager.prototype.render = function(_env, visitor) {
 
     var element = this.expectElement && this.renderNode.firstNode;
 
-    env.renderer.didCreateElement(component, element);
-    env.renderer.willInsertElement(component, element); // 2.0TODO remove legacy hook
+    // In environments like FastBoot, disable any hooks that would cause the component
+    // to access the DOM directly.
+    if (env.destinedForDOM) {
+      env.renderer.didCreateElement(component, element);
+      env.renderer.willInsertElement(component, element); // 2.0TODO remove legacy hook
 
-    env.lifecycleHooks.push({ type: 'didInsertElement', view: component });
+      env.lifecycleHooks.push({ type: 'didInsertElement', view: component });
+    }
   }, this);
 };
 

--- a/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
@@ -97,9 +97,13 @@ ViewNodeManager.prototype.render = function(env, attrs, visitor) {
     if (component) {
       var element = this.expectElement && this.renderNode.firstNode;
 
-      env.renderer.didCreateElement(component, element); // 2.0TODO: Remove legacy hooks.
-      env.renderer.willInsertElement(component, element);
-      env.lifecycleHooks.push({ type: 'didInsertElement', view: component });
+      // In environments like FastBoot, disable any hooks that would cause the component
+      // to access the DOM directly.
+      if (env.destinedForDOM) {
+        env.renderer.didCreateElement(component, element); // 2.0TODO: Remove legacy hooks.
+        env.renderer.willInsertElement(component, element);
+        env.lifecycleHooks.push({ type: 'didInsertElement', view: component });
+      }
     }
   }, this);
 };

--- a/packages/ember-htmlbars/lib/system/render-env.js
+++ b/packages/ember-htmlbars/lib/system/render-env.js
@@ -17,6 +17,7 @@ export default function RenderEnv(options) {
   this.hooks = defaultEnv.hooks;
   this.helpers = defaultEnv.helpers;
   this.useFragmentCache = defaultEnv.useFragmentCache;
+  this.destinedForDOM = this.renderer._destinedForDOM;
 }
 
 RenderEnv.build = function(view) {

--- a/packages/ember-metal-views/lib/renderer.js
+++ b/packages/ember-metal-views/lib/renderer.js
@@ -4,9 +4,20 @@ import { set } from 'ember-metal/property_set';
 import assign from 'ember-metal/assign';
 import setProperties from 'ember-metal/set_properties';
 import buildComponentTemplate from 'ember-views/system/build-component-template';
+import environment from 'ember-metal/environment';
 
-function Renderer(_helper) {
-  this._dom = _helper;
+function Renderer(domHelper, destinedForDOM) {
+  this._dom = domHelper;
+
+  // This flag indicates whether the resulting rendered element will be
+  // inserted into the DOM. This should be set to `false` if the rendered
+  // element is going to be serialized to HTML without being inserted into
+  // the DOM (e.g., in FastBoot mode). By default, this flag is the same
+  // as whether we are running in an environment with DOM, but may be
+  // overridden.
+  this._destinedForDOM = destinedForDOM === undefined ?
+    environment.hasDOM :
+    destinedForDOM;
 }
 
 Renderer.prototype.prerenderTopLevelView =

--- a/tests/node/app-boot-test.js
+++ b/tests/node/app-boot-test.js
@@ -80,3 +80,44 @@ QUnit.test("outlets", function(assert) {
 
   return this.all(promises);
 });
+
+QUnit.test("lifecycle hooks disabled", function(assert) {
+  expect(2);
+
+  this.template('application', "{{my-component}}{{outlet}}");
+
+  this.component('my-component', {
+    willRender: function() {
+      ok(true, "should trigger component willRender hook");
+    },
+    didRender: function() {
+      ok(false, "should not trigger didRender hook");
+    },
+    willInsertElement: function() {
+      ok(false, "should not trigger willInsertElement hook");
+    },
+    didInsertElement: function() {
+      ok(false, "should not trigger didInsertElement hook");
+    }
+  });
+
+  this.view('index', {
+    _willRender: function() {
+      ok(true, "should trigger view _willRender hook");
+    },
+    didRender: function() {
+      ok(false, "should not trigger didRender hook");
+    },
+    willInsertElement: function() {
+      ok(false, "should not trigger willInsertElement hook");
+    },
+    didCreateElement: function() {
+      ok(false, "should not trigger didCreateElement hook");
+    },
+    didInsertElement: function() {
+      ok(false, "should not trigger didInsertElement hook");
+    }
+  });
+
+  return this.renderToHTML('/');
+});

--- a/tests/node/component-rendering-test.js
+++ b/tests/node/component-rendering-test.js
@@ -55,8 +55,12 @@ function buildComponent(template, props) {
 }
 
 function renderComponent(component) {
-  run(component, component.createElement);
+  var element;
+
+  run(function() {
+    element = component.renderToElement();
+  });
 
   var serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
-  return serializer.serialize(component.element);
+  return serializer.serialize(element);
 }

--- a/tests/node/helpers/app-module.js
+++ b/tests/node/helpers/app-module.js
@@ -68,7 +68,13 @@ features['ember-application-visit'] = true;
 
 /*jshint -W079 */
 global.EmberENV = {
-  FEATURES: features
+  FEATURES: features,
+  // Views are disabled but can be re-enabled via an addon.
+  // This flag simulates the addon so we can verify those
+  // views remain compatible with FastBoot. This can
+  // be removed in Ember 2.4 when view support is dropped
+  // entirely.
+  _ENABLE_LEGACY_VIEW_SUPPORT: true
 };
 
 module.exports = function(moduleName) {
@@ -89,6 +95,7 @@ module.exports = function(moduleName) {
       this.template = registerTemplate;
       this.component = registerComponent;
       this.controller = registerController;
+      this.view = registerView;
       this.routes = registerRoutes;
       this.registry = {};
       this.renderToElement = renderToElement;
@@ -199,6 +206,11 @@ function registerComponent(name, componentProps) {
 function registerController(name, controllerProps) {
   var controller = this.Ember.Controller.extend(controllerProps);
   this.register('controller:'+name, controller);
+}
+
+function registerView(name, viewProps) {
+  var view = this.Ember.View.extend(viewProps);
+  this.register('view:'+name, view);
 }
 
 function registerRoutes(cb) {


### PR DESCRIPTION
This commit fixes #11325, which reported a regression where components and views lifecycle hooks were inappropriately invoked in FastBoot.

FastBoot needs a mechanism to signal to the rendering layer that it is operating in an environment without a full DOM, and thus userland hooks that may expect a fully-functioning DOM (didInsertElement, didRender, etc) should not be invoked.

Previously, the Renderer’s constructor accepted a second argument that disabled this, but support for that appears to have been lost somewhere along the way.

This commit introduces a test that verifies these hooks are disabled. It also causes the RenderEnv to copy the Renderer’s `destinedForDOM` flag, making it available inside HTMLBars helpers and keywords.

Now, the ViewNodeManager and ComponentNodeManager check the env for the `destinedForDOM` flag, and if it’s false, do not invoke these lifecycle hooks.
