### PR TITLE
[BUGFIX release] use bracket notation to access unknown attr #12035

### DIFF
--- a/packages/ember-htmlbars/tests/integration/attrs_lookup_test.js
+++ b/packages/ember-htmlbars/tests/integration/attrs_lookup_test.js
@@ -82,3 +82,29 @@ QUnit.test('should be able to modify a provided attr into local state #11571 / #
   equal(view.$().text(), 'FIRST ATTR', 'template lookup uses local state');
   equal(component.get('first'), 'FIRST ATTR', 'component lookup uses local state');
 });
+
+QUnit.test('should be able to access unspecified attr #12035', function() {
+  var component;
+
+  registry.register('component:foo-bar', Component.extend({
+    init() {
+      this._super(...arguments);
+      component = this;
+    },
+
+    didReceiveAttrs() {
+      equal(this.get('woot'), 'yes', 'found attr in didReceiveAttrs');
+    }
+  }));
+  // registry.register('template:components/foo-bar', compile('{{first}}'));
+
+  view = EmberView.extend({
+    template: compile('{{foo-bar woot="yes"}}'),
+    container: container
+  }).create();
+
+  runAppend(view);
+
+  // equal(view.$().text(), 'FIRST ATTR', 'template lookup uses local state');
+  equal(component.get('woot'), 'yes', 'component found attr');
+});

--- a/packages/ember-views/lib/compat/attrs-proxy.js
+++ b/packages/ember-views/lib/compat/attrs-proxy.js
@@ -70,7 +70,7 @@ let AttrsProxyMixin = {
       // do not deprecate accessing `this[key]` at this time.
       // add this back when we have a proper migration path
       // Ember.deprecate(deprecation(key), { id: 'ember-views.', until: '3.0.0' });
-      let possibleCell = attrs.key;
+      let possibleCell = attrs[key];
 
       if (possibleCell && possibleCell[MUTABLE_CELL]) {
         return possibleCell.value;


### PR DESCRIPTION
Since 1.13.7, the `unknownProperty` function of `AttrProxyMixin` wasn't finding properties passed to the `Component`.

Switched to use bracket notation instead.
