### PR TITLE
Don't spin up extra run-loops when bubbling events.  Fixes #11540

### DIFF
--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -256,7 +256,7 @@ export default EmberObject.extend({
   },
 
   _bubbleEvent(view, evt, eventName) {
-    return run.join(view, view.handleEvent, eventName, evt);
+    return view.handleEvent(eventName, evt);
   },
 
   destroy() {

--- a/packages/ember-views/lib/views/states/has_element.js
+++ b/packages/ember-views/lib/views/states/has_element.js
@@ -1,6 +1,7 @@
 import _default from 'ember-views/views/states/default';
 import merge from 'ember-metal/merge';
 import jQuery from 'ember-views/system/jquery';
+import run from 'ember-metal/run_loop';
 
 /**
 @module ember
@@ -61,7 +62,7 @@ merge(hasElement, {
     if (view.has(eventName)) {
       // Handler should be able to re-dispatch events, so we don't
       // preventDefault or stopPropagation.
-      return view.trigger(eventName, evt);
+      return run.join(view, view.trigger, eventName, evt);
     } else {
       return true; // continue event propagation
     }


### PR DESCRIPTION
Fixes #11540
