### PR TITLE
[FEATURE ember-views-event-capture] Uses `useCapture` and custom delegation.

### DIFF
--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -365,14 +365,22 @@ export default EmberObject.extend({
 
 function filterCaptureFunction(idHandler, actionHandler, walker) {
   return function(e) {
-    var node = walker.closest(e.target);
-    if (node) {
-      if (node[0] === 'id') {
-        return idHandler.call(node[1], e);
-      } else {
-        return actionHandler.call(node[1], e);
+    let node;
+    let result;
+    do {
+      node = walker.closest(e.target);
+      if (node) {
+        if (node[0] === 'id') {
+          result = idHandler.call(node[1], e);
+        } else {
+          result = actionHandler.call(node[1], e);
+        }
+        if (result) {
+          node = node.parentNode;
+        }
       }
-    }
+    } while (result && node);
+    return result;
   };
 }
 

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -339,7 +339,7 @@ export default EmberObject.extend({
   },
 
   _bubbleEvent(view, evt, eventName) {
-    return run.join(view, view.handleEvent, eventName, evt);
+    return view.handleEvent(eventName, evt);
   },
 
   destroy() {

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -386,19 +386,21 @@ function filterCaptureFunction(idHandler, actionHandler, walker) {
 
 
 function EventWalker(registry) {
-  function inRegistry(id) {
-    return !!registry[id];
-  }
-
-  this.closest = function(closest) {
-    do {
-      if (closest.id && inRegistry(closest.id)) {
-        return ['id', closest];
-      }
-      if (closest.hasAttribute('data-ember-action')) {
-        return ['action', closest];
-      }
-    } while (closest = closest.parentNode);
-    return null;
-  };
+  this.registry = registry;
 }
+
+EventWalker.prototype.inRegistry = function EventWalker_inRegistry(id) {
+  return !!this.registry[id];
+};
+
+EventWalker.prototype.closest = function EventWalker_closest(closest) {
+  do {
+    if (closest.id && this.inRegistry(closest.id)) {
+      return ['id', closest];
+    }
+    if (closest.hasAttribute('data-ember-action')) {
+      return ['action', closest];
+    }
+  } while (closest = closest.parentNode);
+  return null;
+};

--- a/packages/ember-views/lib/views/states/has_element.js
+++ b/packages/ember-views/lib/views/states/has_element.js
@@ -1,6 +1,7 @@
 import _default from 'ember-views/views/states/default';
 import merge from 'ember-metal/merge';
 import jQuery from 'ember-views/system/jquery';
+import run from 'ember-metal/run_loop';
 
 /**
 @module ember
@@ -61,7 +62,7 @@ merge(hasElement, {
     if (view.has(eventName)) {
       // Handler should be able to re-dispatch events, so we don't
       // preventDefault or stopPropagation.
-      return view.trigger(eventName, evt);
+      return run.join(view, view.trigger, eventName, evt);
     } else {
       return true; // continue event propagation
     }


### PR DESCRIPTION
This is a test implementation that would enable Ember to keep existing event behavior while converting to an event-capture based eventing model.

Instead of bubbling, events are captured immediately at the application root, then a walker is used to find the collect the views or actions which trigger for the event.  Any handler which returns `true` causes the walker to continue walking the tree.

Notes:
- A could-be-improved perf test showing that this form of delegation can be faster than native bubbling even without cacheing event handler resolutions: http://jsperf.com/event-delegation-with-capture-vs-bubble
