### PR TITLE
[CLEANUP] Unlock simple-dom version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "route-recognizer": "0.1.5",
     "rsvp": "~3.0.6",
     "serve-static": "^1.10.0",
-    "simple-dom": "0.2.4",
+    "simple-dom": "^0.2.7",
     "testem": "^0.8.0-1"
   }
 }


### PR DESCRIPTION
Fixes #11943, which reported a test failure after updating to newer
versions of simple-dom. I believe the regression  was fixed with the
recent Node test refactorings.
