### PR TITLE
[BUGFIX release] fix two bugs in closure actions

### DIFF
--- a/packages/ember-htmlbars/lib/hooks/subexpr.js
+++ b/packages/ember-htmlbars/lib/hooks/subexpr.js
@@ -34,7 +34,7 @@ export default function subexpr(env, scope, helperName, params, hash) {
   return helperStream;
 }
 
-function labelForSubexpr(params, hash, helperName) {
+export function labelForSubexpr(params, hash, helperName) {
   var paramsLabels = labelsForParams(params);
   var hashLabels = labelsForHash(hash);
   var label = `(${helperName}`;


### PR DESCRIPTION
Closure actions accidentally invoked `addDependency` for all params and
hash every time the value was recomputed.

Effectively, this means that when the params and hash value change, the
stream representing the closure action gets totally superfluous repeated
dependencies. This probably doesn’t cause incorrect behavior, because
the subscriptions are simply responsible for dirtying nodes, but it does
cause a memory leak.

Additionally, this commit adds a label to the closure action stream,
which was previously missing.

/cc @mmun @mixonic @rwjblue 

This should probably be backported to 1.13.
