### PR TITLE
[BUGFIX release] Fix Ember.isArray export

### DIFF
--- a/packages/ember-runtime/lib/main.js
+++ b/packages/ember-runtime/lib/main.js
@@ -66,7 +66,7 @@ import RSVP from 'ember-runtime/ext/rsvp';     // just for side effect of extend
 import 'ember-runtime/ext/string';   // just for side effect of extending String.prototype
 import 'ember-runtime/ext/function'; // just for side effect of extending Function.prototype
 
-import { typeOf } from 'ember-runtime/utils';
+import { isArray, typeOf } from 'ember-runtime/utils';
 // END IMPORTS
 
 // BEGIN EXPORTS
@@ -95,7 +95,7 @@ Ember.PromiseProxyMixin = PromiseProxyMixin;
 Ember.Observable = Observable;
 
 Ember.typeOf = typeOf;
-Ember.isArray = Array.isArray;
+Ember.isArray = isArray;
 
 // ES6TODO: this seems a less than ideal way/place to add properties to Ember.computed
 var EmComputed = Ember.computed;

--- a/packages/ember/tests/global-api-test.js
+++ b/packages/ember/tests/global-api-test.js
@@ -1,11 +1,16 @@
 /*globals Ember */
 import 'ember';
+import { isArray } from 'ember-runtime/utils';
 
 QUnit.module('Global API Tests');
 
-function confirmExport(property) {
+function confirmExport(property, internal) {
   QUnit.test('confirm ' + property + ' is exported', function() {
-    ok(Ember.get(window, property) + ' is exported propertly');
+    var theExport = Ember.get(window, property);
+    ok(theExport + ' is exported');
+    if (internal !== undefined) {
+      equal(theExport, internal, theExport + ' is exported properly');
+    }
   });
 }
 
@@ -13,3 +18,4 @@ confirmExport('Ember.DefaultResolver');
 confirmExport('Ember.generateController');
 confirmExport('Ember.Helper');
 confirmExport('Ember.Helper.helper');
+confirmExport('Ember.isArray', isArray);


### PR DESCRIPTION
As of Ember 2.0, `Ember.isArray` is an alias to `Array.isArray`. However, the [documentation of `Ember#isArray`](http://emberjs.com/api/classes/Ember.html#method_isArray) continues to state "Returns true if the passed object is an array or Array-like" and gives the example of `Ember.isArray(Ember.ArrayProxy.create({ content: [] }));  // true`, which now returns false.

No tests caught this because they test `isArray` directly from `ember-runtime/utils`, which has not changed, rather than what is exported to the `Ember` namespace, which has changed.
