### PR TITLE
[BUGFIX release-1-13] Ensure concatenatedProperties are not stomped.

### DIFF
--- a/packages/ember-htmlbars/tests/integration/component_invocation_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_invocation_test.js
@@ -799,6 +799,29 @@ QUnit.test('specifying classNames results in correct class', function(assert) {
   ok(button.is('.foo.bar.baz.ember-view'), 'the element has the correct classes: ' + button.attr('class'));
 });
 
+QUnit.test('specifying custom concatenatedProperties avoids clobbering', function(assert) {
+  expect(1);
+
+  let clickyThing;
+  registry.register('component:some-clicky-thing', Component.extend({
+    concatenatedProperties: ['blahzz'],
+    blahzz: ['blark', 'pory'],
+    init() {
+      this._super(...arguments);
+      clickyThing = this;
+    }
+  }));
+
+  view = EmberView.extend({
+    template: compile('{{#some-clicky-thing blahzz="baz"}}Click Me{{/some-clicky-thing}}'),
+    container: container
+  }).create();
+
+  runAppend(view);
+
+  assert.deepEqual(clickyThing.get('blahzz'),  ['blark', 'pory', 'baz'], 'property is properly combined');
+});
+
 // jscs:disable validateIndentation
 if (isEnabled('ember-htmlbars-component-generation')) {
   QUnit.module('component - invocation (angle brackets)', {


### PR DESCRIPTION
When `_propagateAttrsToThis` is invoked it iterates all properties that are present in `this.attrs` and calls `this.set(attrName, attrValue)`.  This is normally exactly what you expect. However, in the case of `concatenatedProperties` and `mergedProperties` this `set`ing causes the concatenated / merged property to be completely clobbered.

The fix introduced in #12073 adds a very simple work around for the internally known items (just hard coding things like `classNames`, `classNameBindings`, `attributeBindings`, and `actions`). This was obviously a very naive check, and leaves any external usages of `concatenatedProperties` in components/views completely hosed.

---

The changes here introduces a __avoidPropagating property that we can use to prevent `concatenatedProperties` and `mergedProperties` from being set inside `_propagateAttrsToThis`. To avoid introducing this cost for every component created (when only classes can define new concatenated / merged properties) we are storing the `__avoidPropagating` on the constructor itself.

One notable addon that has broken functionality is [yapplabs/ember-modal-dialog#71](https://github.com/yapplabs/ember-modal-dialog/issues/71).

---

Fixes #12099.

Implemented by @rondale-sc and @rwjblue.
