### PR TITLE
[DOC release] Marks `nearestOfType` as public instead of private.

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -810,7 +810,7 @@ var View = CoreView.extend(
     @param {Class,Mixin} klass Subclass of Ember.View (or Ember.View itself),
            or an instance of Ember.Mixin.
     @return Ember.View
-    @private
+    @public
   */
   nearestOfType(klass) {
     var view = get(this, 'parentView');


### PR DESCRIPTION
related to #12110
