### PR TITLE
Collapse two Travis builds into one.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ env:
   matrix:
     - TEST_SUITE=each-package-tests
     - TEST_SUITE=built-tests EMBER_ENV=production DISABLE_JSCS=true DISABLE_JSHINT=true
-    - TEST_SUITE=old-jquery
-    - TEST_SUITE=extend-prototypes
+    - TEST_SUITE=old-jquery-and-extend-prototypes
     - TEST_SUITE=node DISABLE_JSCS=true DISABLE_JSHINT=true
     - TEST_SUITE=sauce

--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -141,12 +141,9 @@ switch (process.env.TEST_SUITE) {
     console.log('suite: built-tests');
     generateBuiltTests();
     break;
-  case 'old-jquery':
-    console.log('suite: old-jquery');
+  case 'old-jquery-and-extend-prototypes':
+    console.log('suite: old-jquery-and-extend-prototypes');
     generateOldJQueryTests();
-    break;
-  case 'extend-prototypes':
-    console.log('suite: extend-prototypes');
     generateExtendPrototypeTests();
     break;
   case 'all':


### PR DESCRIPTION
The build setup takes longer than actually running these. This updates Travis config to run one less build, but the same actual tests.
