### PR TITLE
Remove ember-metal-stream feature.

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -62,12 +62,6 @@ for a detailed explanation.
   Enables HTMLBars compiler to interpret `<x-foo></x-foo>` as a component
   invocation (instead of a standard HTML5 style element).
 
-* `ember-metal-stream`
-
-  Exposes the basic internal stream implementation as `Ember.Stream`.
-
-  Added in [#9693](https://github.com/emberjs/ember.js/pull/9693)
-
 * `ember-htmlbars-each-with-index`
 
   Adds an optional second parameter to `{{each}}` block parameters that is the index of the item.

--- a/features.json
+++ b/features.json
@@ -3,7 +3,6 @@
     "features-stripped-test": null,
     "ember-htmlbars-component-generation": null,
     "ember-testing-checkbox-helpers": null,
-    "ember-metal-stream": null,
     "ember-application-visit": null,
     "ember-routing-core-outlet": null,
     "ember-routing-route-configured-query-params": null,

--- a/packages/ember-metal/lib/main.js
+++ b/packages/ember-metal/lib/main.js
@@ -336,23 +336,6 @@ Ember.isPresent = isPresent;
 
 Ember.merge = merge;
 
-if (isEnabled('ember-metal-stream')) {
-  Ember.stream = {
-    Stream: Stream,
-
-    isStream: isStream,
-    subscribe: subscribe,
-    unsubscribe: unsubscribe,
-    read: read,
-    readHash: readHash,
-    readArray: readArray,
-    scanArray: scanArray,
-    scanHash: scanHash,
-    concat: concat,
-    chain: chain
-  };
-}
-
 Ember.FEATURES = FEATURES;
 Ember.FEATURES.isEnabled = isEnabled;
 

--- a/packages/ember-metal/lib/streams/utils.js
+++ b/packages/ember-metal/lib/streams/utils.js
@@ -4,7 +4,7 @@ import Stream from './stream';
 /*
  Check whether an object is a stream or not
 
- @public
+ @private
  @for Ember.stream
  @function isStream
  @param {Object|Stream} object object to check whether it is a stream
@@ -36,7 +36,7 @@ export function subscribe(object, callback, context) {
  A method of unsubscribing from a stream which is safe for use with a non-stream
  object. If a non-stream object is passed, the function does nothing.
 
- @public
+ @private
  @for Ember.stream
  @function unsubscribe
  @param {Object|Stream} object object or stream to potentially unsubscribe from
@@ -53,7 +53,7 @@ export function unsubscribe(object, callback, context) {
  Retrieve the value of a stream, or in the case a non-stream object is passed,
  return the object itself.
 
- @public
+ @private
  @for Ember.stream
  @function read
  @param {Object|Stream} object object to return the value of
@@ -70,7 +70,7 @@ export function read(object) {
 /*
  Map an array, replacing any streams with their values.
 
- @public
+ @private
  @for Ember.stream
  @function readArray
  @param {Array} array The array to read values from
@@ -92,7 +92,7 @@ export function readArray(array) {
  Map a hash, replacing any stream property values with the current value of that
  stream.
 
- @public
+ @private
  @for Ember.stream
  @function readHash
  @param {Object} object The hash to read keys and values from
@@ -112,7 +112,7 @@ export function readHash(object) {
 /*
  Check whether an array contains any stream values
 
- @public
+ @private
  @for Ember.stream
  @function scanArray
  @param {Array} array array given to a handlebars helper
@@ -136,7 +136,7 @@ export function scanArray(array) {
 /*
  Check whether a hash has any stream property values
 
- @public
+ @private
  @for Ember.stream
  @function scanHash
  @param {Object} hash "hash" argument given to a handlebars helper
@@ -159,7 +159,7 @@ export function scanHash(hash) {
 /*
  Join an array, with any streams replaced by their current values
 
- @public
+ @private
  @for Ember.stream
  @function concat
  @param {Array} array An array containing zero or more stream objects and
@@ -308,7 +308,7 @@ export function zipHash(object, callback, label) {
  In the example, result is a stream if source is a stream, or a number of
  source was numeric.
 
- @public
+ @private
  @for Ember.stream
  @function chain
  @param {Object|Stream} value A stream or non-stream object


### PR DESCRIPTION
We have generally decided that if streams require being exposed as
public API that we have somewhat failed in regards to the other API's.

The Glimmer refactors make that much closer to reality (streams should
not be leaking into public API's in 2.0.0).

Removing this extra feature flag...
