### PR TITLE
[FEATURE ember-registry-container-reform] Enable by default.

### DIFF
--- a/features.json
+++ b/features.json
@@ -8,7 +8,7 @@
     "ember-routing-route-configured-query-params": null,
     "ember-libraries-isregistered": null,
     "ember-debug-handlers": true,
-    "ember-registry-container-reform": null,
+    "ember-registry-container-reform": true,
     "ember-routing-routable-components": null
   },
   "debugStatements": [

--- a/packages/ember-runtime/lib/mixins/container_proxy.js
+++ b/packages/ember-runtime/lib/mixins/container_proxy.js
@@ -60,11 +60,11 @@ export default Mixin.create({
    Given a fullName return the corresponding factory.
 
    @private
-   @method lookupFactory
+   @method _lookupFactory
    @param {String} fullName
    @return {any}
    */
-  lookupFactory: containerAlias('lookupFactory'),
+  _lookupFactory: containerAlias('lookupFactory'),
 
   /**
    @private


### PR DESCRIPTION
Also, underscores `_lookupFactory` to make it very clear that it is still considered private.
