### PR TITLE
[BUGFIX release] Only add `view:select` for ember-legacy-views.

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -985,7 +985,9 @@ Application.reopenClass({
     registry.register('renderer:-dom', { create() { return new Renderer(new DOMHelper()); } });
 
     registry.injection('view', 'renderer', 'renderer:-dom');
-    registry.register('view:select', SelectView);
+    if (Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT) {
+      registry.register('view:select', SelectView);
+    }
     registry.register('view:-outlet', OutletView);
 
     registry.register('-view-registry:main', { create() { return {}; } });


### PR DESCRIPTION
This causes some issues if you want to add a route named `select` (because we clober `view:select`).

Fixes #11893.
