### PR TITLE
[BUGFIX beta] Run SSR tests only if feature flag enabled

### DIFF
--- a/tests/node/app-boot-test.js
+++ b/tests/node/app-boot-test.js
@@ -7,117 +7,123 @@ function assertHTMLMatches(assert, actualHTML, expectedHTML) {
 
 appModule("App Boot");
 
-QUnit.test("App boots and routes to a URL", function(assert) {
-  this.visit('/');
-  assert.ok(this.app);
-});
-
-QUnit.test("nested {{component}}", function(assert) {
-  this.template('index', "{{root-component}}");
-
-  this.template('components/root-component', "\
-    <h1>Hello {{#if hasExistence}}{{location}}{{/if}}</h1>\
-    <div>{{component 'foo-bar'}}</div>\
-  ");
-
-  this.component('root-component', {
-    location: "World",
-    hasExistence: true
+// Because running these tests relies on certain feature flags being
+// enabled, we check to see if those flags are on before registering
+// the tests. Once all feature flags are on by default we can remove
+// this conditional.
+if (appModule.canRunTests) {
+  QUnit.test("App boots and routes to a URL", function(assert) {
+    this.visit('/');
+    assert.ok(this.app);
   });
 
-  this.template('components/foo-bar', "\
-    <p>The files are *inside* the computer?!</p>\
-  ");
+  QUnit.test("nested {{component}}", function(assert) {
+    this.template('index', "{{root-component}}");
 
-  return this.renderToHTML('/').then(function(html) {
-    assertHTMLMatches(assert, html, /<h1>Hello World<\/h1>\s+<div><div id="(.*)" class="ember-view">\s+<p>The files are \*inside\* the computer\?\!<\/p>\s+<\/div><\/div>/);
-  });
-});
+    this.template('components/root-component', "\
+      <h1>Hello {{#if hasExistence}}{{location}}{{/if}}</h1>\
+      <div>{{component 'foo-bar'}}</div>\
+    ");
 
-QUnit.test("{{link-to}}", function(assert) {
-  this.template('application', "<h1>{{#link-to 'photos'}}Go to photos{{/link-to}}</h1>");
-  this.routes(function() {
-    this.route('photos');
-  });
+    this.component('root-component', {
+      location: "World",
+      hasExistence: true
+    });
 
-  return this.renderToHTML('/').then(function(html) {
-    assertHTMLMatches(assert, html, /<div id="ember\d+" class="ember-view"><h1><a id="ember\d+" href="\/photos" class="ember-view">Go to photos<\/a><\/h1><\/div>/);
-  });
-});
+    this.template('components/foo-bar', "\
+      <p>The files are *inside* the computer?!</p>\
+    ");
 
-QUnit.test("non-escaped content", function(assert) {
-  this.routes(function() {
-    this.route('photos');
+    return this.renderToHTML('/').then(function(html) {
+      assertHTMLMatches(assert, html, /<h1>Hello World<\/h1>\s+<div><div id="(.*)" class="ember-view">\s+<p>The files are \*inside\* the computer\?\!<\/p>\s+<\/div><\/div>/);
+    });
   });
 
-  this.template('application', "<h1>{{{title}}}</h1>");
-  this.controller('application', {
-    title: "<b>Hello world</b>"
+  QUnit.test("{{link-to}}", function(assert) {
+    this.template('application', "<h1>{{#link-to 'photos'}}Go to photos{{/link-to}}</h1>");
+    this.routes(function() {
+      this.route('photos');
+    });
+
+    return this.renderToHTML('/').then(function(html) {
+      assertHTMLMatches(assert, html, /<div id="ember\d+" class="ember-view"><h1><a id="ember\d+" href="\/photos" class="ember-view">Go to photos<\/a><\/h1><\/div>/);
+    });
   });
 
-  return this.renderToHTML('/').then(function(html) {
-    assertHTMLMatches(assert, html, /<div id="ember\d+" class="ember-view"><h1><b>Hello world<\/b><\/h1><\/div>/);
-  });
-});
+  QUnit.test("non-escaped content", function(assert) {
+    this.routes(function() {
+      this.route('photos');
+    });
 
-QUnit.test("outlets", function(assert) {
-  this.routes(function() {
-    this.route('photos');
-  });
+    this.template('application', "<h1>{{{title}}}</h1>");
+    this.controller('application', {
+      title: "<b>Hello world</b>"
+    });
 
-  this.template('application', "<p>{{outlet}}</p>");
-  this.template('index', "<span>index</span>");
-  this.template('photos', "<em>photos</em>");
-
-  var promises = [];
-  promises.push(this.renderToHTML('/').then(function(html) {
-    assertHTMLMatches(assert, html, /<div id="ember(.*)" class="ember-view"><p><span>index<\/span><\/p><\/div>/);
-  }));
-
-  promises.push(this.renderToHTML('/photos').then(function(html) {
-    assertHTMLMatches(assert, html, /<div id="ember(.*)" class="ember-view"><p><em>photos<\/em><\/p><\/div>/);
-  }));
-
-  return this.all(promises);
-});
-
-QUnit.test("lifecycle hooks disabled", function(assert) {
-  expect(2);
-
-  this.template('application', "{{my-component}}{{outlet}}");
-
-  this.component('my-component', {
-    willRender: function() {
-      ok(true, "should trigger component willRender hook");
-    },
-    didRender: function() {
-      ok(false, "should not trigger didRender hook");
-    },
-    willInsertElement: function() {
-      ok(false, "should not trigger willInsertElement hook");
-    },
-    didInsertElement: function() {
-      ok(false, "should not trigger didInsertElement hook");
-    }
+    return this.renderToHTML('/').then(function(html) {
+      assertHTMLMatches(assert, html, /<div id="ember\d+" class="ember-view"><h1><b>Hello world<\/b><\/h1><\/div>/);
+    });
   });
 
-  this.view('index', {
-    _willRender: function() {
-      ok(true, "should trigger view _willRender hook");
-    },
-    didRender: function() {
-      ok(false, "should not trigger didRender hook");
-    },
-    willInsertElement: function() {
-      ok(false, "should not trigger willInsertElement hook");
-    },
-    didCreateElement: function() {
-      ok(false, "should not trigger didCreateElement hook");
-    },
-    didInsertElement: function() {
-      ok(false, "should not trigger didInsertElement hook");
-    }
+  QUnit.test("outlets", function(assert) {
+    this.routes(function() {
+      this.route('photos');
+    });
+
+    this.template('application', "<p>{{outlet}}</p>");
+    this.template('index', "<span>index</span>");
+    this.template('photos', "<em>photos</em>");
+
+    var promises = [];
+    promises.push(this.renderToHTML('/').then(function(html) {
+      assertHTMLMatches(assert, html, /<div id="ember(.*)" class="ember-view"><p><span>index<\/span><\/p><\/div>/);
+    }));
+
+    promises.push(this.renderToHTML('/photos').then(function(html) {
+      assertHTMLMatches(assert, html, /<div id="ember(.*)" class="ember-view"><p><em>photos<\/em><\/p><\/div>/);
+    }));
+
+    return this.all(promises);
   });
 
-  return this.renderToHTML('/');
-});
+  QUnit.test("lifecycle hooks disabled", function(assert) {
+    expect(2);
+
+    this.template('application', "{{my-component}}{{outlet}}");
+
+    this.component('my-component', {
+      willRender: function() {
+        ok(true, "should trigger component willRender hook");
+      },
+      didRender: function() {
+        ok(false, "should not trigger didRender hook");
+      },
+      willInsertElement: function() {
+        ok(false, "should not trigger willInsertElement hook");
+      },
+      didInsertElement: function() {
+        ok(false, "should not trigger didInsertElement hook");
+      }
+    });
+
+    this.view('index', {
+      _willRender: function() {
+        ok(true, "should trigger view _willRender hook");
+      },
+      didRender: function() {
+        ok(false, "should not trigger didRender hook");
+      },
+      willInsertElement: function() {
+        ok(false, "should not trigger willInsertElement hook");
+      },
+      didCreateElement: function() {
+        ok(false, "should not trigger didCreateElement hook");
+      },
+      didInsertElement: function() {
+        ok(false, "should not trigger didInsertElement hook");
+      }
+    });
+
+    return this.renderToHTML('/');
+  });
+}

--- a/tests/node/helpers/app-module.js
+++ b/tests/node/helpers/app-module.js
@@ -61,21 +61,27 @@ var URL = require('url');
  *     });
 */
 
-// Server-side rendering relies on the `ember-application-visit` feature flag,
-// which we enable explicitly for these tests. Once that flag is enabled by
-// default, you may remove this guard.
-features['ember-application-visit'] = true;
+// Server-side rendering relies on the `ember-application-visit` feature flag.
+// If the flag is enabled, or if the flag is disabled but not stripped, we can
+// run the tests. Otherwise, for builds that have the feature stripped, we just
+// skip the tests.
+var canRunTests = features['ember-application-visit'] != false;
 
-/*jshint -W079 */
-global.EmberENV = {
-  FEATURES: features,
-  // Views are disabled but can be re-enabled via an addon.
-  // This flag simulates the addon so we can verify those
-  // views remain compatible with FastBoot. This can
-  // be removed in Ember 2.4 when view support is dropped
-  // entirely.
-  _ENABLE_LEGACY_VIEW_SUPPORT: true
-};
+if (canRunTests) {
+  // Enable the flag if it was disabled but not stripped.
+  features['ember-application-visit'] = true;
+
+  /*jshint -W079 */
+  global.EmberENV = {
+    FEATURES: features,
+    // Views are disabled but can be re-enabled via an addon.
+    // This flag simulates the addon so we can verify those
+    // views remain compatible with FastBoot. This can
+    // be removed in Ember 2.4 when view support is dropped
+    // entirely.
+    _ENABLE_LEGACY_VIEW_SUPPORT: true
+  };
+}
 
 module.exports = function(moduleName) {
   QUnit.module(moduleName, {
@@ -113,6 +119,8 @@ module.exports = function(moduleName) {
     }
   });
 };
+
+module.exports.canRunTests = canRunTests;
 
 function createApplication() {
   var app = this.Ember.Application.extend().create({


### PR DESCRIPTION
This fixes a regression where the server-side rendering tests were failing because the application-visit feature flag was stripped.

Now, rather than forcing it to be enabled, we only run the tests when the feature is available.
