### PR TITLE
Add missing feature flag import statement.

### DIFF
--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -95,6 +95,7 @@
   @public
 */
 import Ember from 'ember-metal/core';
+import isEnabled from 'ember-metal/features';
 
 import {
   precompile,


### PR DESCRIPTION
This line was removed in a prior commit, but after the glimmer component PR had already been rebased.
