### PR TITLE
[DOC release] Updated Ember.observer example

### DIFF
--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -63,9 +63,9 @@ import isNone from 'ember-metal/is_none';
 
   ```javascript
   Ember.Object.extend({
-    valueObserver: function() {
+    valueObserver: Ember.observer('value', function() {
       // Executes whenever the "value" property changes
-    }.observes('value')
+    })
   });
   ```
 


### PR DESCRIPTION
Switched from prototype extension syntax to the new `Ember.observer`
syntax
