### PR TITLE
[BUGFIX release-1-13] Do not require _super in didRecieveAttrs.

### DIFF
--- a/packages/ember-metal-views/lib/renderer.js
+++ b/packages/ember-metal-views/lib/renderer.js
@@ -147,6 +147,8 @@ Renderer.prototype.setAttrs = function (view, attrs) {
 }; // set attrs the first time
 
 Renderer.prototype.componentInitAttrs = function (component, attrs) {
+  // for attrs-proxy support
+  component.trigger('_internalDidReceiveAttrs');
   component.trigger('didInitAttrs', { attrs });
   component.trigger('didReceiveAttrs', { newAttrs: attrs });
 }; // set attrs the first time
@@ -181,6 +183,8 @@ Renderer.prototype.componentUpdateAttrs = function (component, newAttrs) {
     set(component, 'attrs', newAttrs);
   }
 
+  // for attrs-proxy support
+  component.trigger('_internalDidReceiveAttrs');
   component.trigger('didUpdateAttrs', { oldAttrs, newAttrs });
   component.trigger('didReceiveAttrs', { oldAttrs, newAttrs });
 };

--- a/packages/ember-views/lib/compat/attrs-proxy.js
+++ b/packages/ember-views/lib/compat/attrs-proxy.js
@@ -81,7 +81,7 @@ let AttrsProxyMixin = {
     this._isDispatchingAttrs = false;
   }),
 
-  didReceiveAttrs() {
+  _internalDidReceiveAttrs() {
     this._super();
     this._isDispatchingAttrs = true;
     this._propagateAttrsToThis();


### PR DESCRIPTION
Default framework hooks should not _require_ that users call `this._super` (however, it is still a best practice).

This adds a new `_internalDidReceiveAttrs` hook for use internally to avoid using a `didRecieveAttrs` in `AttrsProxy`.

Fixes #11992.
