### PR TITLE
[BUGFIX beta] CPs check presence of getter function

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -115,9 +115,20 @@ function ComputedProperty(config, opts) {
   if (typeof config === 'function') {
     this._getter = config;
   } else {
+    Ember.assert('Ember.computed expects a function or an object as last argument.', typeof config === 'object' && !Array.isArray(config));
+    Ember.assert('Config object pased to a Ember.computed can only contain `get` or `set` keys.', (function() {
+      let keys = Object.keys(config);
+      for (let i = 0; i < keys.length; i++) {
+        if (keys[i] !== 'get' && keys[i] !== 'set') {
+          return false;
+        }
+      }
+      return true;
+    })());
     this._getter = config.get;
     this._setter = config.set;
   }
+  Ember.assert('Computed properties must receive a getter or a setter, you passed none.', !!this._getter || !!this._setter);
   this._dependentKeys = undefined;
   this._suspended = undefined;
   this._meta = undefined;

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -26,6 +26,29 @@ QUnit.test('computed property should be an instance of descriptor', function() {
   ok(computed(function() {}) instanceof Descriptor);
 });
 
+QUnit.test('computed properties assert the presence of a getter or setter function', function() {
+  expectAssertion(function() {
+    computed('nogetternorsetter', {});
+  }, 'Computed properties must receive a getter or a setter, you passed none.');
+});
+
+QUnit.test('computed properties check for the presence of a function or configuration object', function() {
+  expectAssertion(function() {
+    computed('nolastargument');
+  }, 'Ember.computed expects a function or an object as last argument.');
+});
+
+QUnit.test('computed properties defined with an object only allow `get` and `set` keys', function() {
+  expectAssertion(function() {
+    computed({
+      get() {},
+      set() {},
+      other() {}
+    });
+  }, 'Config object pased to a Ember.computed can only contain `get` or `set` keys.');
+});
+
+
 QUnit.test('defining computed property should invoke property on get', function() {
   var obj = {};
   var count = 0;


### PR DESCRIPTION
Today I spent some time tracking a cryptic stack trace.

It turns out that I typed `years: computed('age')` instead of `years: computed.alias('age')`

This will check the presence of the getter function in creation time, instead of failing when you try to access the property, usually 10 minutes after writing it when you have no idea where to look.
