### PR TITLE
[BUGFIX beta] Allow deprecated access to registry.

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -39,7 +39,7 @@ import LinkToComponent from 'ember-routing-views/views/link';
 import RoutingService from 'ember-routing/services/routing';
 import ContainerDebugAdapter from 'ember-extension-support/container_debug_adapter';
 import { _loaded } from 'ember-runtime/system/lazy_load';
-import RegistryProxy from 'ember-runtime/mixins/registry_proxy';
+import RegistryProxy, { buildFakeRegistryWithDeprecations } from 'ember-runtime/mixins/registry_proxy';
 import environment from 'ember-metal/environment';
 
 function props(obj) {
@@ -710,6 +710,16 @@ var Application = Namespace.extend(RegistryProxy, {
     this.constructor.initializer(options);
   }
 });
+
+if (isEnabled('ember-registry-container-reform')) {
+  Object.defineProperty(Application.prototype, 'registry', {
+    configurable: true,
+    enumerable: false,
+    get() {
+      return buildFakeRegistryWithDeprecations(this, 'Application');
+    }
+  });
+}
 
 Application.reopenClass({
   /**

--- a/packages/ember-application/tests/system/application_instance_test.js
+++ b/packages/ember-application/tests/system/application_instance_test.js
@@ -46,11 +46,11 @@ QUnit.test('properties (and aliases) are correctly assigned for accessing the co
   ok(appInstance.__registry__, '#__registry__ is accessible');
 
   if (isEnabled('ember-registry-container-reform')) {
-    expect(6);
+    expect(9);
 
     ok(typeof appInstance.container.lookup === 'function', '#container.lookup is available as a function');
 
-    // stub `lookup` with a no-op to keep deprecation test simple
+    // stub with a no-op to keep deprecation test simple
     appInstance.__container__.lookup = function() {
       ok(true, '#loookup alias is called correctly');
     };
@@ -58,6 +58,16 @@ QUnit.test('properties (and aliases) are correctly assigned for accessing the co
     expectDeprecation(function() {
       appInstance.container.lookup();
     }, /Using `ApplicationInstance.container.lookup` is deprecated. Please use `ApplicationInstance.lookup` instead./);
+
+
+    ok(typeof appInstance.registry.register === 'function', '#registry.register is available as a function');
+    appInstance.__registry__.register = function() {
+      ok(true, '#register alias is called correctly');
+    };
+
+    expectDeprecation(function() {
+      appInstance.registry.register();
+    }, /Using `ApplicationInstance.registry.register` is deprecated. Please use `ApplicationInstance.register` instead./);
   } else {
     expect(5);
 

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -13,6 +13,7 @@ import EmberRoute from 'ember-routing/system/route';
 import jQuery from 'ember-views/system/jquery';
 import compile from 'ember-template-compiler/system/compile';
 import { _loaded } from 'ember-runtime/system/lazy_load';
+import isEnabled from 'ember-metal/features';
 
 var trim = jQuery.trim;
 
@@ -97,6 +98,22 @@ QUnit.test('acts like a namespace', function() {
   app.Foo = EmberObject.extend();
   equal(app.Foo.toString(), 'TestApp.Foo', 'Classes pick up their parent namespace');
 });
+
+if (isEnabled('ember-registry-container-reform')) {
+  QUnit.test('includes deprecated access to `application.registry`', function() {
+    expect(3);
+
+    ok(typeof application.registry.register === 'function', '#registry.register is available as a function');
+
+    application.__registry__.register = function() {
+      ok(true, '#register alias is called correctly');
+    };
+
+    expectDeprecation(function() {
+      application.registry.register();
+    }, /Using `Application.registry.register` is deprecated. Please use `Application.register` instead./);
+  });
+}
 
 QUnit.module('Ember.Application initialization', {
   teardown() {

--- a/packages/ember-runtime/lib/mixins/registry_proxy.js
+++ b/packages/ember-runtime/lib/mixins/registry_proxy.js
@@ -1,3 +1,4 @@
+import Ember from 'ember-metal/core';
 import { Mixin } from 'ember-metal/mixin';
 
 export default Mixin.create({
@@ -244,5 +245,36 @@ export default Mixin.create({
 function registryAlias(name) {
   return function () {
     return this.__registry__[name](...arguments);
+  };
+}
+
+export function buildFakeRegistryWithDeprecations(instance, typeForMessage) {
+  var fakeRegistry = {};
+  var registryProps = {
+    resolve: 'resolveRegistration',
+    register: 'register',
+    unregister: 'unregister',
+    has: 'hasRegistration',
+    option: 'registerOption',
+    options: 'registerOptions',
+    getOptions: 'registeredOptions',
+    optionsForType: 'registerOptionsForType',
+    getOptionsForType: 'registeredOptionsForType',
+    injection: 'inject'
+  };
+
+  for (var deprecatedProperty in registryProps) {
+    fakeRegistry[deprecatedProperty] = buildFakeRegistryFunction(instance, typeForMessage, deprecatedProperty, registryProps[deprecatedProperty]);
+  }
+
+  return fakeRegistry;
+}
+
+function buildFakeRegistryFunction(instance, typeForMessage, deprecatedProperty, nonDeprecatedProperty) {
+  return function() {
+    Ember.deprecate(`Using \`${typeForMessage}.registry.${deprecatedProperty}\` is deprecated. Please use \`${typeForMessage}.${nonDeprecatedProperty}\` instead.`,
+                    false,
+                    { id: 'ember-application.app-instance-registry', until: '3.0.0' });
+    return instance[nonDeprecatedProperty](...arguments);
   };
 }


### PR DESCRIPTION
As part of the `ember-registry-container-reform` the registry was moved from `Application#registry` / `ApplicationInstance#registry` to `__registry__`, and a new public API was created allowing access to the majority of functions that folks used directly on `Application` or `ApplicationInstance` instances.

We created an alias `container` property for `ApplicationInstances`, but missed creating the same thing for `registry` which was exposed non-underscored on both `Application` and `ApplicationInstance` instances.

This adds an alias for all public `registry` methods at their original location and provides a helpful deprecation warning instructing you what to use instead.

Also, changes the `ApplicationInstance` `Object.defineProperty` calls to be done once on the `ApplicationInstance` prototype (instead of on each instance).

---

This fixes a regression that was reported in a number of prominent projects:
- https://github.com/emberjs/data/pull/3665
- https://github.com/jamesarosen/ember-i18n/issues/292
- https://github.com/jamesarosen/ember-i18n/issues/294
