### PR TITLE
[DOC release] Make Ember.Controller.target public.

### DIFF
--- a/packages/ember-runtime/lib/mixins/controller.js
+++ b/packages/ember-runtime/lib/mixins/controller.js
@@ -30,7 +30,7 @@ export default Mixin.create(ActionHandler, ControllerContentModelAliasDeprecatio
 
     @property target
     @default null
-    @private
+    @public
   */
   target: null,
 


### PR DESCRIPTION
In order to bridge the gap between closure actions & the route, you might want to call `this.target.send('anAction')` from a controller action. Making `target` public helps legitimize this tactic until controllers go away in 2.x.

Resolves #12152.
