### PR TITLE
[BUGFIX beta] Move `View#currentState` to `View#_currentState`.

### DIFF
--- a/packages/ember-views/lib/compat/attrs-proxy.js
+++ b/packages/ember-views/lib/compat/attrs-proxy.js
@@ -117,8 +117,8 @@ AttrsProxyMixin[PROPERTY_DID_CHANGE] = function(key) {
   if (this._isAngleBracket) { return; }
   if (this._isDispatchingAttrs) { return; }
 
-  if (this.currentState) {
-    this.currentState.legacyPropertyDidChange(this, key);
+  if (this._currentState) {
+    this._currentState.legacyPropertyDidChange(this, key);
   }
 };
 

--- a/packages/ember-views/lib/mixins/view_state_support.js
+++ b/packages/ember-views/lib/mixins/view_state_support.js
@@ -10,8 +10,8 @@ var ViewStateSupport = Mixin.create({
   },
 
   _transitionTo(state) {
-    var priorState = this.currentState;
-    var currentState = this.currentState = this._states[state];
+    var priorState = this._currentState;
+    var currentState = this._currentState = this._states[state];
     this._state = state;
 
     if (priorState && priorState.exit) { priorState.exit(this); }

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -178,7 +178,7 @@ export default Mixin.create({
     @public
   */
   rerender() {
-    return this.currentState.rerender(this);
+    return this._currentState.rerender(this);
   },
 
   // ..........................................................
@@ -209,7 +209,7 @@ export default Mixin.create({
   */
   $(sel) {
     Ember.assert('You cannot access this.$() on a component with `tagName: \'\'` specified.', this.tagName !== '');
-    return this.currentState.$(this, sel);
+    return this._currentState.$(this, sel);
   },
 
   forEachChildView(callback) {
@@ -496,7 +496,7 @@ export default Mixin.create({
     @private
   */
   destroyElement() {
-    return this.currentState.destroyElement(this);
+    return this._currentState.destroyElement(this);
   },
 
   /**
@@ -713,7 +713,7 @@ export default Mixin.create({
     @private
   */
   handleEvent(eventName, evt) {
-    return this.currentState.handleEvent(this, eventName, evt);
+    return this._currentState.handleEvent(this, eventName, evt);
   },
 
   /**
@@ -765,7 +765,7 @@ export default Mixin.create({
   _wrapAsScheduled(fn) {
     var view = this;
     var stateCheckedFn = function() {
-      view.currentState.invokeObserver(this, fn);
+      view._currentState.invokeObserver(this, fn);
     };
     var scheduledFn = function() {
       run.scheduleOnce('render', this, stateCheckedFn);

--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -43,7 +43,7 @@ var CoreView = EmberObject.extend(Evented, ActionHandler, {
   init() {
     this._super.apply(this, arguments);
     this._state = 'preRender';
-    this.currentState = this._states.preRender;
+    this._currentState = this._states.preRender;
     this._isVisible = get(this, 'isVisible');
 
     // Fallback for legacy cases where the view was created directly
@@ -108,7 +108,7 @@ var CoreView = EmberObject.extend(Evented, ActionHandler, {
   destroy() {
     if (!this._super(...arguments)) { return; }
 
-    this.currentState.cleanup(this);
+    this._currentState.cleanup(this);
 
     // If the destroyingSubtreeForView property is not set but we have an
     // associated render node, it means this view is being destroyed from user

--- a/packages/ember-views/lib/views/states/has_element.js
+++ b/packages/ember-views/lib/views/states/has_element.js
@@ -44,7 +44,7 @@ merge(hasElement, {
   },
 
   cleanup(view) {
-    view.currentState.destroyElement(view);
+    view._currentState.destroyElement(view);
   },
 
   // once the view is already in the DOM, destroying it removes it

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -22,6 +22,7 @@ import AriaRoleSupport from 'ember-views/mixins/aria_role_support';
 import VisibilitySupport from 'ember-views/mixins/visibility_support';
 import CompatAttrsProxy from 'ember-views/compat/attrs-proxy';
 import ViewMixin from 'ember-views/mixins/view_support';
+import { deprecateProperty } from 'ember-metal/deprecate_property';
 
 /**
 @module ember
@@ -694,6 +695,12 @@ var View = CoreView.extend(
       return View._classStringForValue(parsedPath.path, parsedPath.stream.value(), parsedPath.className, parsedPath.falsyClassName);
     }
   });
+
+deprecateProperty(View.prototype, 'currentState', '_currentState', {
+  id: 'ember-view.current-state',
+  until: '2.3.0'
+});
+
 // jscs:enable validateIndentation
 
 /*

--- a/packages/ember-views/tests/views/view/current_state_deprecation_test.js
+++ b/packages/ember-views/tests/views/view/current_state_deprecation_test.js
@@ -1,0 +1,30 @@
+import EmberView from 'ember-views/views/view';
+import run from 'ember-metal/run_loop';
+
+var view;
+
+QUnit.module('views/view/current_state_deprecation', {
+  setup() {
+    view = EmberView.create();
+  },
+  teardown() {
+    run(view, 'destroy');
+  }
+});
+
+QUnit.test('deprecates when calling currentState', function() {
+  expect(2);
+
+  view = EmberView.create();
+
+  expectDeprecation(function() {
+    equal(view.currentState, view._currentState);
+  }, 'Usage of `currentState` is deprecated, use `_currentState` instead.');
+});
+
+QUnit.test('doesn\'t deprecate when calling _currentState', function() {
+  expect(1);
+
+  view = EmberView.create();
+  ok(view._currentState, '_currentState can be used without deprecation');
+});

--- a/packages/ember-views/tests/views/view/replace_in_test.js
+++ b/packages/ember-views/tests/views/view/replace_in_test.js
@@ -81,7 +81,7 @@ QUnit.test('should move the view to the inDOM state after replacing', function()
     view.replaceIn('#menu');
   });
 
-  equal(view.currentState, view._states.inDOM, 'the view is in the inDOM state');
+  equal(view._currentState, view._states.inDOM, 'the view is in the inDOM state');
 });
 
 QUnit.module('EmberView - replaceIn() in a view hierarchy', {

--- a/packages/ember-views/tests/views/view/view_lifecycle_test.js
+++ b/packages/ember-views/tests/views/view/view_lifecycle_test.js
@@ -367,10 +367,9 @@ QUnit.test('trigger rerender on a view in the inDOM state keeps its state as inD
     view.rerender();
   });
 
-  equal(view.currentState, view._states.inDOM, 'the view is still in the inDOM state');
+  equal(view._currentState, view._states.inDOM, 'the view is still in the inDOM state');
 
   run(function() {
     view.destroy();
   });
 });
-


### PR DESCRIPTION
`View.prototype.currentState` is private and I am not aware of any usage in the wild, but this adds a deprecation that we can remove after the next LTS release (which I have listed as 2.3.0 based on discussions with a few others).

Closes #11374.
