### PR TITLE
[BUGFIX release] Fix `Ember.computed.sum`

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -13,7 +13,11 @@ import { isArray } from 'ember-runtime/utils';
 
 function reduceMacro(dependentKey, callback, initialValue) {
   return computed(`${dependentKey}.[]`, function() {
-    return get(this, dependentKey).reduce((previousValue, currentValue, index, array) => {
+    const arr = get(this, dependentKey);
+
+    if (arr === null || typeof arr !== 'object') { return initialValue; }
+
+    return arr.reduce((previousValue, currentValue, index, array) => {
       return callback.call(this, previousValue, currentValue, index, array);
     }, initialValue);
   }).readOnly();

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -1501,6 +1501,17 @@ QUnit.test('sums the values in the dependentKey', function() {
   equal(obj.get('total'), 6, 'sums the values');
 });
 
+QUnit.test('if the dependentKey is neither an array nor object, it will return `0`', () => {
+  set(obj, 'array', null);
+  equal(get(obj, 'total'), 0, 'returns 0');
+
+  set(obj, 'array', undefined);
+  equal(get(obj, 'total'), 0, 'returns 0');
+
+  set(obj, 'array', 'not an array');
+  equal(get(obj, 'total'), 0, 'returns 0');
+});
+
 QUnit.test('updates when array is modified', function() {
   obj.get('array').pushObject(1);
 


### PR DESCRIPTION
Check to see if the `dependentKey` is an array, if not, then return
the `initialValue`.

Closes #12096
