### PR TITLE
Use an AST transform to handle unescaped inline link-to

### DIFF
--- a/packages/ember-htmlbars/lib/templates/link-to.hbs
+++ b/packages/ember-htmlbars/lib/templates/link-to.hbs
@@ -1,1 +1,1 @@
-{{#if linkTitle}}{{#if attrs.escaped}}{{linkTitle}}{{else}}{{{linkTitle}}}{{/if}}{{else}}{{yield}}{{/if}}
+{{#if linkTitle}}{{linkTitle}}{{else}}{{yield}}{{/if}}

--- a/packages/ember-routing-htmlbars/lib/keywords/link-to.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/link-to.js
@@ -327,8 +327,6 @@ export default {
     // TODO: Remove once `hasBlock` is working again
     attrs.hasBlock = !!template;
 
-    attrs.escaped = !morph.parseTextAsHTML;
-
     env.hooks.component(morph, env, scope, '-link-to', params, attrs, { default: template }, visitor);
   },
 

--- a/packages/ember-routing-htmlbars/tests/helpers/link-to_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/link-to_test.js
@@ -103,6 +103,18 @@ QUnit.test('escaped inline form (double curlies) escapes link title', function()
   equal(view.$('b').length, 0, 'no <b> were found');
 });
 
+QUnit.test('escaped inline form with (-html-safe) does not escape link title', function() {
+  view = EmberView.create({
+    title: '<b>blah</b>',
+    template: compile('{{link-to (-html-safe view.title)}}'),
+    container: container
+  });
+
+  runAppend(view);
+
+  equal(view.$('b').length, 1, '<b> was found');
+});
+
 QUnit.test('unescaped inline form (triple curlies) does not escape link title', function() {
   view = EmberView.create({
     title: '<b>blah</b>',

--- a/packages/ember-template-compiler/lib/main.js
+++ b/packages/ember-template-compiler/lib/main.js
@@ -13,6 +13,7 @@ import TransformAngleBracketComponents from 'ember-template-compiler/plugins/tra
 import TransformInputOnToOnEvent from 'ember-template-compiler/plugins/transform-input-on-to-onEvent';
 import TransformTopLevelComponents from 'ember-template-compiler/plugins/transform-top-level-components';
 import TransformEachIntoCollection from 'ember-template-compiler/plugins/transform-each-into-collection';
+import TransformUnescapedInlineLinkTo from 'ember-template-compiler/plugins/transform-unescaped-inline-link-to';
 import AssertNoViewAndControllerPaths from 'ember-template-compiler/plugins/assert-no-view-and-controller-paths';
 import AssertNoViewHelper from 'ember-template-compiler/plugins/assert-no-view-helper';
 
@@ -27,6 +28,7 @@ registerPlugin('ast', TransformComponentCurlyToReadonly);
 registerPlugin('ast', TransformAngleBracketComponents);
 registerPlugin('ast', TransformInputOnToOnEvent);
 registerPlugin('ast', TransformTopLevelComponents);
+registerPlugin('ast', TransformUnescapedInlineLinkTo);
 
 if (_Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT) {
   registerPlugin('ast', TransformEachIntoCollection);

--- a/packages/ember-template-compiler/lib/plugins/transform-unescaped-inline-link-to.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-unescaped-inline-link-to.js
@@ -1,0 +1,29 @@
+export default function TransformUnescapedInlineLinkTo(options) {
+  this.options = options;
+  this.syntax = null;
+}
+
+TransformUnescapedInlineLinkTo.prototype.transform = function TransformUnescapedInlineLinkTo_transform(ast) {
+  var b = this.syntax.builders;
+  var walker = new this.syntax.Walker();
+
+  walker.visit(ast, function(node) {
+    if (!validate(node)) { return; }
+
+    node.escaped = true;
+    node.params[0] = b.sexpr(
+      b.string('-html-safe'),
+      [node.params[0]]
+    );
+  });
+
+  return ast;
+};
+
+function validate(node) {
+  return (
+    node.type === 'MustacheStatement' &&
+    node.path.original === 'link-to' &&
+    !node.escaped
+  );
+}


### PR DESCRIPTION
This means we don't have to expose `escaped` and can simplify the link-to template.
