### PR TITLE
Refactoring meta, part 2

### DIFF
--- a/packages/ember-metal/lib/dependent_keys.js
+++ b/packages/ember-metal/lib/dependent_keys.js
@@ -20,7 +20,7 @@ import {
 export function addDependentKeys(desc, obj, keyName, meta) {
   // the descriptor has a list of dependent keys, so
   // add all of its dependent keys.
-  var idx, len, depKey, keys;
+  var idx, len, depKey;
   var depKeys = desc._dependentKeys;
   if (!depKeys) {
     return;
@@ -28,10 +28,8 @@ export function addDependentKeys(desc, obj, keyName, meta) {
 
   for (idx = 0, len = depKeys.length; idx < len; idx++) {
     depKey = depKeys[idx];
-    // Lookup keys meta for depKey
-    keys = meta.writableDeps(depKey);
     // Increment the number of times depKey depends on keyName.
-    keys[keyName] = (keys[keyName] || 0) + 1;
+    meta.writeDeps(depKey, keyName, (meta.peekDeps(depKey, keyName)|| 0) + 1);
     // Watch the depKey
     watch(obj, depKey, meta);
   }
@@ -41,17 +39,15 @@ export function removeDependentKeys(desc, obj, keyName, meta) {
   // the descriptor has a list of dependent keys, so
   // remove all of its dependent keys.
   var depKeys = desc._dependentKeys;
-  var idx, len, depKey, keys;
+  var idx, len, depKey;
   if (!depKeys) {
     return;
   }
 
   for (idx = 0, len = depKeys.length; idx < len; idx++) {
     depKey = depKeys[idx];
-    // Lookup keys meta for depKey
-    keys = meta.writableDeps(depKey);
     // Decrement the number of times depKey depends on keyName.
-    keys[keyName] = (keys[keyName] || 0) - 1;
+    meta.writeDeps(depKey, keyName, (meta.peekDeps(depKey, keyName) || 0) - 1);
     // Unwatch the depKey
     unwatch(obj, depKey, meta);
   }

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -114,12 +114,12 @@ function inheritedMap(name, Meta) {
     while (pointer !== undefined) {
       let map = pointer[key];
       if (map) {
-        Object.keys(map).forEach(key => {
+        for (let key in map) {
           if (!seen[key]) {
             seen[key] = true;
             fn(key, map[key]);
           }
-        });
+        }
       }
       pointer = pointer.parent;
     }
@@ -212,12 +212,12 @@ Meta.prototype._forEachIn = function(key, subkey, fn) {
     if (map) {
       let innerMap = map[subkey];
       if (innerMap) {
-        Object.keys(innerMap).forEach(key => {
-          if (!seen[key]) {
-            seen[key] = true;
-            fn(key, innerMap[key]);
+        for (let innerKey in innerMap) {
+          if (!seen[innerKey]) {
+            seen[innerKey] = true;
+            fn(innerKey, innerMap[innerKey]);
           }
-        });
+        }
       }
     }
     pointer = pointer.parent;

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -45,10 +45,6 @@ ROOT.__hasSuper = false;
 var REQUIRED;
 var a_slice = [].slice;
 
-function mixinsMeta(obj) {
-  return metaFor(obj, true).writableMixins();
-}
-
 function isMethod(obj) {
   return 'function' === typeof obj &&
          obj.isMethod !== false &&
@@ -67,8 +63,8 @@ function mixinProperties(mixinsMeta, mixin) {
 
   if (mixin instanceof Mixin) {
     guid = guidFor(mixin);
-    if (mixinsMeta[guid]) { return CONTINUE; }
-    mixinsMeta[guid] = mixin;
+    if (mixinsMeta.peekMixins(guid)) { return CONTINUE; }
+    mixinsMeta.writeMixins(guid, mixin);
     return mixin.properties;
   } else {
     return mixin; // apply anonymous mixin properties
@@ -269,7 +265,7 @@ var IS_BINDING = /^.+Binding$/;
 
 function detectBinding(obj, key, value, m) {
   if (IS_BINDING.test(key)) {
-    m.writableBindings()[key] = value;
+    m.writeBindings(key, value);
   }
 }
 
@@ -300,29 +296,24 @@ function connectStreamBinding(obj, key, stream) {
 
 function connectBindings(obj, m) {
   // TODO Mixin.apply(instance) should disconnect binding if exists
-  var bindings = m.readableBindings();
-  var key, binding, to;
-  if (bindings) {
-    for (key in bindings) {
-      binding = bindings[key];
-      if (binding) {
-        to = key.slice(0, -7); // strip Binding off end
-        if (isStream(binding)) {
-          connectStreamBinding(obj, to, binding);
-          continue;
-        } else if (binding instanceof Binding) {
-          binding = binding.copy(); // copy prototypes' instance
-          binding.to(to);
-        } else { // binding is string path
-          binding = new Binding(to, binding);
-        }
-        binding.connect(obj);
-        obj[key] = binding;
+  m.forEachBindings((key, binding) => {
+    if (binding) {
+      let to = key.slice(0, -7); // strip Binding off end
+      if (isStream(binding)) {
+        connectStreamBinding(obj, to, binding);
+        return;
+      } else if (binding instanceof Binding) {
+        binding = binding.copy(); // copy prototypes' instance
+        binding.to(to);
+      } else { // binding is string path
+        binding = new Binding(to, binding);
       }
+      binding.connect(obj);
+      obj[key] = binding;
     }
-    // mark as applied
-    m.clearBindings();
-  }
+  });
+  // mark as applied
+  m.clearBindings();
 }
 
 function finishPartial(obj, m) {
@@ -390,7 +381,7 @@ function applyMixin(obj, mixins, partial) {
   // * Set up _super wrapping if necessary
   // * Set up computed property descriptors
   // * Copying `toString` in broken browsers
-  mergeMixins(mixins, mixinsMeta(obj), descs, values, obj, keys);
+  mergeMixins(mixins, metaFor(obj), descs, values, obj, keys);
 
   for (var i = 0, l = keys.length; i < l; i++) {
     key = keys[i];
@@ -656,17 +647,13 @@ MixinPrototype.keys = function() {
 // TODO: Make Ember.mixin
 Mixin.mixins = function(obj) {
   var m = obj['__ember_meta__'];
-  var mixins = m && m.readableMixins();
   var ret = [];
+  if (!m) { return ret; }
 
-  if (!mixins) { return ret; }
-
-  for (var key in mixins) {
-    var currentMixin = mixins[key];
-
+  m.forEachMixins((key, currentMixin) => {
     // skip primitive mixins since these are always anonymous
     if (!currentMixin.properties) { ret.push(currentMixin); }
-  }
+  });
 
   return ret;
 };

--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -122,7 +122,7 @@ export function defineProperty(obj, keyName, desc, data, meta) {
 
       if (isEnabled('mandatory-setter')) {
         if (watching) {
-          meta.writableValues()[keyName] = data;
+          meta.writeValues(keyName, data);
           Object.defineProperty(obj, keyName, {
             configurable: true,
             enumerable: true,

--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -81,7 +81,7 @@ export function set(obj, keyName, value, tolerant) {
           ) {
             defineProperty(obj, keyName, null, value); // setup mandatory setter
           } else {
-            meta.writableValues()[keyName] = value;
+            meta.writeValues(keyName, value);
           }
         } else {
           obj[keyName] = value;

--- a/packages/ember-metal/lib/watch_path.js
+++ b/packages/ember-metal/lib/watch_path.js
@@ -19,24 +19,23 @@ export function watchPath(obj, keyPath, meta) {
   if (keyPath === 'length' && Array.isArray(obj)) { return; }
 
   var m = meta || metaFor(obj);
-  var watching = m.writableWatching();
-
-  if (!watching[keyPath]) { // activate watching first time
-    watching[keyPath] = 1;
+  let counter = m.peekWatching(keyPath) || 0;
+  if (!counter) { // activate watching first time
+    m.writeWatching(keyPath, 1);
     chainsFor(obj, m).add(keyPath);
   } else {
-    watching[keyPath] = (watching[keyPath] || 0) + 1;
+    m.writeWatching(keyPath, counter + 1);
   }
 }
 
 export function unwatchPath(obj, keyPath, meta) {
   var m = meta || metaFor(obj);
-  var watching = m.writableWatching();
+  let counter = m.peekWatching(keyPath) || 0;
 
-  if (watching[keyPath] === 1) {
-    watching[keyPath] = 0;
+  if (counter === 1) {
+    m.writeWatching(keyPath, 0);
     chainsFor(obj, m).remove(keyPath);
-  } else if (watching[keyPath] > 1) {
-    watching[keyPath]--;
+  } else if (counter > 1) {
+    m.writeWatching(keyPath, counter - 1);
   }
 }

--- a/packages/ember-metal/tests/accessors/mandatory_setters_test.js
+++ b/packages/ember-metal/tests/accessors/mandatory_setters_test.js
@@ -7,9 +7,7 @@ import { meta as metaFor } from 'ember-metal/meta';
 QUnit.module('mandatory-setters');
 
 function hasMandatorySetter(object, property) {
-  var meta = metaFor(object);
-  let values = meta.readableValues();
-  return values && property in values;
+  return metaFor(object).hasInValues(property);
 }
 
 if (isEnabled('mandatory-setter')) {
@@ -105,7 +103,6 @@ if (isEnabled('mandatory-setter')) {
         return 'custom-object';
       }
     };
-    var meta = metaFor(obj);
 
     Object.defineProperty(obj, 'someProp', {
       configurable: false,
@@ -114,7 +111,7 @@ if (isEnabled('mandatory-setter')) {
     });
 
     watch(obj, 'someProp');
-    ok(!('someProp' in meta.readableValues()), 'blastix');
+    ok(!(hasMandatorySetter(obj, 'someProp')), 'blastix');
   });
 
   QUnit.test('sets up mandatory-setter if property comes from prototype', function() {
@@ -129,9 +126,8 @@ if (isEnabled('mandatory-setter')) {
     var obj2 = Object.create(obj);
 
     watch(obj2, 'someProp');
-    var meta = metaFor(obj2);
 
-    ok(('someProp' in meta.readableValues()), 'mandatory setter has been setup');
+    ok(hasMandatorySetter(obj2, 'someProp'), 'mandatory setter has been setup');
 
     expectAssertion(function() {
       obj2.someProp = 'foo-bar';

--- a/packages/ember-metal/tests/alias_test.js
+++ b/packages/ember-metal/tests/alias_test.js
@@ -37,9 +37,9 @@ QUnit.test('basic lifecycle', function() {
   defineProperty(obj, 'bar', alias('foo.faz'));
   var m = meta(obj);
   addObserver(obj, 'bar', incrementCount);
-  equal(m.readableDeps('foo.faz').bar, 1);
+  equal(m.peekDeps('foo.faz', 'bar'), 1);
   removeObserver(obj, 'bar', incrementCount);
-  equal(m.readableDeps('foo.faz').bar, 0);
+  equal(m.peekDeps('foo.faz', 'bar'), 0);
 });
 
 QUnit.test('old dependent keys should not trigger property changes', function() {

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -108,7 +108,7 @@ function makeCtor() {
           var value = properties[keyName];
 
           if (IS_BINDING.test(keyName)) {
-            m.writableBindings()[keyName] = value;
+            m.writeBindings(keyName, value);
           }
 
           var possibleDesc = this[keyName];


### PR DESCRIPTION
This improves encapsulation of all the `inheritedMap` and `inheritedMapOfMaps` meta properties, and changes their internal implementations to avoid `Object.create` and some potential shape de-opts. I'm seeing single digit percentage improvements in initial render speed.

The improved encapsulation should make it easier for anyone to experiment with further optimizations.
