### PR TITLE
Update ember-dev to support the module-based assert API

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,6 @@
     "rsvp": "https://github.com/tildeio/rsvp.js.git#3.0.20",
     "router.js": "https://github.com/tildeio/router.js.git#ed45bc5c5e055af0ab875ef2c52feda792ee23e4",
     "dag-map": "https://github.com/krisselden/dag-map.git#e307363256fe918f426e5a646cb5f5062d3245be",
-    "ember-dev": "https://github.com/emberjs/ember-dev.git#a064f0cd2f4c225ffd023b63d4cb31a79db04aaf"
+    "ember-dev": "https://github.com/emberjs/ember-dev.git#2af9f2b85321e28b771e1d784f3bc40b094b3a75"
   }
 }

--- a/features.json
+++ b/features.json
@@ -32,6 +32,11 @@
     "_emberMetal.default.warn",
     "_emberMetal.default.assert",
     "_emberMetal.default.debug",
-    "_emberMetal.default.runInDebug"
+    "_emberMetal.default.runInDebug",
+    "_emberMetalAssert.deprecate",
+    "_emberMetalAssert.warn",
+    "_emberMetalAssert.assert",
+    "_emberMetalAssert.debug",
+    "_emberMetalAssert.runInDebug"
   ]
 }

--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -1,5 +1,5 @@
 import Ember from 'ember-metal/core';
-import { registerDebugFunction } from 'ember-metal/assert';
+import { setDebugFunction } from 'ember-metal/assert';
 import isEnabled, { FEATURES } from 'ember-metal/features';
 import EmberError from 'ember-metal/error';
 import Logger from 'ember-metal/logger';
@@ -11,8 +11,6 @@ import warn, {
   registerHandler as registerWarnHandler
 } from 'ember-debug/warn';
 import isPlainFunction from 'ember-debug/is-plain-function';
-
-Ember.deprecate = deprecate;
 
 /**
 @module ember
@@ -136,12 +134,12 @@ function runInDebug(func) {
   func();
 }
 
-registerDebugFunction('assert', assert);
-registerDebugFunction('warn', warn);
-registerDebugFunction('debug', debug);
-registerDebugFunction('deprecate', deprecate);
-registerDebugFunction('deprecateFunc', deprecateFunc);
-registerDebugFunction('runInDebug', runInDebug);
+setDebugFunction('assert', assert);
+setDebugFunction('warn', warn);
+setDebugFunction('debug', debug);
+setDebugFunction('deprecate', deprecate);
+setDebugFunction('deprecateFunc', deprecateFunc);
+setDebugFunction('runInDebug', runInDebug);
 
 /**
   Will call `Ember.warn()` if ENABLE_ALL_FEATURES, ENABLE_OPTIONAL_FEATURES, or

--- a/packages/ember-metal/lib/assert.js
+++ b/packages/ember-metal/lib/assert.js
@@ -7,7 +7,11 @@ export let debugFunctions = {
   runInDebug() {}
 };
 
-export function registerDebugFunction(name, fn) {
+export function getDebugFunction(name) {
+  return debugFunctions[name];
+}
+
+export function setDebugFunction(name, fn) {
   debugFunctions[name] = fn;
 }
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -133,7 +133,13 @@
 
         var EmberDevTestHelperAssert = window.Ember.__loader.require('ember-dev/test-helper/index')['default'];
         var setupQUnit = window.Ember.__loader.require('ember-dev/test-helper/setup-qunit')['default'];
-        var testHelpers = new EmberDevTestHelperAssert(window.Ember, EmberDev.runningProdBuild);
+        var assertModule = window.Ember.__loader.require('ember-metal/assert');
+        var testHelpers = new EmberDevTestHelperAssert({
+          Ember: window.Ember,
+          runningProdBuild: EmberDev.runningProdBuild,
+          getDebugFunction: assertModule.getDebugFunction,
+          setDebugFunction: assertModule.setDebugFunction
+        });
         setupQUnit(testHelpers);
 
         // Tests should time out after 5 seconds


### PR DESCRIPTION
This uses the latest version of ember-dev which accommodates the modulified debug functions.
