### PR TITLE
[BUGFIX release] Ensure `_actions` specified to extend works.

### DIFF
--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -213,6 +213,39 @@ QUnit.test('can access `actions` hash via `_actions` [DEPRECATED]', function() {
   }, 'Usage of `_actions` is deprecated, use `actions` instead.');
 });
 
+QUnit.test('actions in both `_actions` and `actions` results in an assertion', function() {
+  expectAssertion(function() {
+    EmberRoute.extend({
+      _actions: { },
+      actions: { }
+    }).create();
+  }, 'Specifying `_actions` and `actions` in the same mixin is not supported.');
+});
+
+QUnit.test('actions added via `_actions` can be used [DEPRECATED]', function() {
+  expect(3);
+
+  let route;
+  expectDeprecation(function() {
+    route = EmberRoute.extend({
+      _actions: {
+        bar: function() {
+          ok(true, 'called bar action');
+        }
+      }
+    }, {
+      actions: {
+        foo: function() {
+          ok(true, 'called foo action');
+        }
+      }
+    }).create();
+  }, 'Specifying actions in `_actions` is deprecated, please use `actions` instead.');
+
+  route.send('foo');
+  route.send('bar');
+});
+
 QUnit.module('Ember.Route serialize', {
   setup: setup,
   teardown: teardown


### PR DESCRIPTION
The initial deprecation of `_actions` and moving it to `actions` was a bit too naive. The `deprecateProperty` helper was used, which meant that when `_actions` was set, it would call `set(this, 'actions', newValue)`.  This meant that passing `_actions` to `Ember.Route.extend` (or `.reopen`) resulted in the `_actions` completely clobbering `actions` (and loosing any previously defined actions there).

The fix was to:
- Replace the generic `deprecateProperty` usage with a custom `Object.defineProperty` call, that defines a setter with an assertion instead of clobbering.
- Implementing a `willMergeMixin` that mutates the `props` at extend time (to ensure that `_actions` is moved to `actions` with a deprecation).

Fixes #12081.

Thanks to @kimroen for helping track this down.
