### PR TITLE
[BUGFIX beta] Avoid setting shadowed properties twice.

### DIFF
--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -4,7 +4,6 @@ import buildComponentTemplate from 'ember-views/system/build-component-template'
 import getCellOrValue from 'ember-htmlbars/hooks/get-cell-or-value';
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
-import setProperties from 'ember-metal/set_properties';
 import { MUTABLE_CELL } from 'ember-views/compat/attrs-proxy';
 import { instrument } from 'ember-htmlbars/system/instrumentation-support';
 import LegacyEmberComponent from 'ember-views/components/component';
@@ -226,11 +225,6 @@ ComponentNodeManager.prototype.rerender = function(_env, attrs, visitor) {
 
     if (component._renderNode.shouldReceiveAttrs) {
       env.renderer.componentUpdateAttrs(component, snapshot);
-
-      if (!component._isAngleBracket) {
-        setProperties(component, mergeBindings({}, shadowedAttrs(component, snapshot)));
-      }
-
       component._renderNode.shouldReceiveAttrs = false;
     }
 

--- a/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
@@ -123,7 +123,6 @@ ViewNodeManager.prototype.rerender = function(env, attrs, visitor) {
 
       if (component._renderNode.shouldReceiveAttrs) {
         env.renderer.componentUpdateAttrs(component, snapshot);
-        setProperties(component, mergeBindings({}, shadowedAttrs(component, snapshot)));
         component._renderNode.shouldReceiveAttrs = false;
       }
 
@@ -184,7 +183,6 @@ export function createOrUpdateComponent(component, options, createOptions, rende
     component = component.create(props);
   } else {
     env.renderer.componentUpdateAttrs(component, snapshot);
-    mergeBindings(props, shadowedAttrs(component, snapshot));
     setProperties(component, props);
   }
 


### PR DESCRIPTION
The recent work done on the AttrsProxy means that everything in `this.attrs` is propagated back to the root of the component for every time `willReceiveAttrs` is called. Unfortunately, this was also being done in the various node-managers causing the same properties to be set twice for each rerender.
