### PR TITLE
[BUGFIX release] Ember.computed.sort was crashing when it hit a null value. Fixes #12207.

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -571,6 +571,8 @@ function propertySort(itemsKey, sortPropertiesKey) {
     var items = itemsKey === '@this' ? this : get(this, itemsKey);
     var sortProperties = get(this, sortPropertiesKey);
 
+    if (items === null || typeof items !== 'object') { return Ember.A(); }
+
     // TODO: Ideally we'd only do this if things have changed
     if (cp._sortPropObservers) {
       cp._sortPropObservers.forEach(args => removeObserver.apply(null, args));

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -20,6 +20,7 @@ import {
   union,
   intersect
 } from 'ember-runtime/computed/reduce_computed_macros';
+import { isArray } from 'ember-runtime/utils';
 
 var obj;
 QUnit.module('map', {
@@ -1087,6 +1088,17 @@ QUnit.test('property paths in sort properties update the sorted array', function
   obj.set('sortProps', ['relatedObj.firstName']);
 
   deepEqual(obj.get('sortedPeople'), [cersei, jaime, sansa], 'array is sorted correctly');
+});
+
+QUnit.test('if the dependentKey is neither an array nor object, it will return an empty array', () => {
+  set(obj, 'items', null);
+  ok(isArray(obj.get('sortedItems')), 'returns an empty arrays');
+
+  set(obj, 'array', undefined);
+  ok(isArray(obj.get('sortedItems')), 'returns an empty arrays');
+
+  set(obj, 'array', 'not an array');
+  ok(isArray(obj.get('sortedItems')), 'returns an empty arrays');
 });
 
 function sortByLnameFname(a, b) {


### PR DESCRIPTION
Returning an empty array when the source array for an `Ember.computed.sort` is null. This provides durability and is consistent with Ember 1.13 behavior.
