### PR TITLE
Failing tests for ArrayProxy#length cacheing issue

### DIFF
--- a/packages/ember-runtime/tests/system/array_proxy/content_change_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/content_change_test.js
@@ -17,6 +17,24 @@ QUnit.test('should update length for null content', function() {
   equal(proxy.get('length'), 0, 'length updates');
 });
 
+QUnit.test('should update length for null content when there is a computed property watching length', function() {
+  var proxy = ArrayProxy.extend({
+    isEmpty: Ember.computed.not('length')
+  }).create({
+    content: Ember.A([1, 2, 3])
+  });
+
+  equal(proxy.get('length'), 3, 'precond - length is 3');
+
+  // Consume computed property that depends on length
+  proxy.get('isEmpty');
+
+  // update content
+  proxy.set('content', null);
+
+  equal(proxy.get('length'), 0, 'length updates');
+});
+
 QUnit.test('The `arrangedContentWillChange` method is invoked before `content` is changed.', function() {
   var callCount = 0;
   var expectedLength;


### PR DESCRIPTION
The Ember Data tests are currently failing (issue started on August 24th) with the canary build of ember. 

I've tracked in down to an issue with the `length` property of an ArrayProxy. In Ember beta (2.1) and release (2.0) channels `length` updates when setting a new `content` array on the ArrayProxy. However, in the canary channel the `length` property is not updated until there is some other mutation performed on the ArrayProxy. 

When debugging this issue I also noticed it only seems to happen when there is an computed property that depends on the `length` property. If there is no depended computed property `length` will return the correct value.
