### PR TITLE
Add Weakmap – Weak from Map -> Obj, not Obj -> Map

### DIFF
--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -33,6 +33,7 @@ import EmptyObject from 'ember-metal/empty_object';
 */
 let members = {
   cache: ownMap,
+  weak: ownMap,
   watching: inheritedMap,
   mixins: inheritedMap,
   bindings: inheritedMap,
@@ -53,6 +54,7 @@ function Meta(obj, parentMeta) {
   this._deps = undefined;
   this._chainWatchers = undefined;
   this._chains = undefined;
+  this._weak = undefined;
   // used only internally
   this.source = obj;
 
@@ -146,6 +148,18 @@ Meta.prototype._getInherited = function(key) {
     }
     pointer = pointer.parent;
   }
+};
+
+Meta.prototype.getWeak = function(symbol) {
+  var weak = this.readableWeak();
+  if (weak) {
+    return weak[symbol];
+  }
+};
+
+Meta.prototype.setWeak = function(symbol, value) {
+  var weak = this.writableWeak();
+  return weak[symbol] = value;
 };
 
 Meta.prototype._findInherited = function(key, subkey) {

--- a/packages/ember-metal/lib/weak_map.js
+++ b/packages/ember-metal/lib/weak_map.js
@@ -37,3 +37,24 @@ WeakMap.prototype.set = function(obj, value) {
   meta(obj).writableWeak()[this._id] = value;
   return this;
 };
+
+/*
+ * @method has
+ * @param key {Object}
+ * @return {Boolean} if the key exists
+ */
+WeakMap.prototype.has = function(obj) {
+  return !!this.get(obj);
+};
+
+/*
+ * @method delete
+ * @param key {Object}
+ */
+WeakMap.prototype.delete = function(obj) {
+  if (this.has(obj)) {
+    delete meta(obj).writableWeak()[this._id];
+  }
+
+  return this;
+};

--- a/packages/ember-metal/lib/weak_map.js
+++ b/packages/ember-metal/lib/weak_map.js
@@ -43,7 +43,7 @@ WeakMap.prototype.get = function(obj) {
 WeakMap.prototype.set = function(obj, value) {
   assert('Uncaught TypeError: Invalid value used as weak map key', typeOf(obj) === 'object');
 
-  if (typeOf(value) === 'undefined') {
+  if (value === undefined) {
     value = UNDEFINED;
   }
 
@@ -59,7 +59,7 @@ WeakMap.prototype.set = function(obj, value) {
 WeakMap.prototype.has = function(obj) {
   var map = meta(obj).readableWeak();
 
-  if (map && typeOf(map[this._id]) !== 'undefined') {
+  if (map && map[this._id] !== undefined) {
     return true;
   }
 

--- a/packages/ember-metal/lib/weak_map.js
+++ b/packages/ember-metal/lib/weak_map.js
@@ -1,0 +1,39 @@
+import { GUID_KEY } from 'ember-metal/utils';
+import { meta } from 'ember-metal/meta';
+
+var id = 0;
+
+/*
+ * @private
+ * @class Ember.WeakMap
+ *
+ * Weak relationship from Map -> Key, but not Key to Map.
+ *
+ * Key must be a non null object
+ */
+export default function WeakMap() {
+  this._id = GUID_KEY + (id++);
+}
+
+/*
+ * @method get
+ * @param key {Object}
+ * @return {*} stored value
+ */
+WeakMap.prototype.get = function(obj) {
+  var map = meta(obj).readableWeak();
+  if (map) {
+    return map[this._id];
+  }
+};
+
+/*
+ * @method set
+ * @param key {Object}
+ * @param value {Any}
+ * @return {Any} stored value
+ */
+WeakMap.prototype.set = function(obj, value) {
+  meta(obj).writableWeak()[this._id] = value;
+  return this;
+};

--- a/packages/ember-metal/lib/weak_map.js
+++ b/packages/ember-metal/lib/weak_map.js
@@ -1,4 +1,3 @@
-import { typeOf } from 'ember-runtime/utils';
 import { assert } from 'ember-metal/debug';
 import { GUID_KEY } from 'ember-metal/utils';
 import { meta } from 'ember-metal/meta';
@@ -6,8 +5,22 @@ import { meta } from 'ember-metal/meta';
 var id = 0;
 function UNDEFINED() {}
 
+function isPrimitiveType(thing) {
+  switch(typeof thing) {
+    case 'string':
+    case 'boolean':
+    case 'number':
+    case 'undefined':
+    case 'null':
+    case 'symbol':
+      return true;
+    default:
+      return false;
+  }
+}
+
 /*
- * @private
+ * @public
  * @class Ember.WeakMap
  *
  * Weak relationship from Map -> Key, but not Key to Map.
@@ -41,7 +54,7 @@ WeakMap.prototype.get = function(obj) {
  * @return {Any} stored value
  */
 WeakMap.prototype.set = function(obj, value) {
-  assert('Uncaught TypeError: Invalid value used as weak map key', typeOf(obj) === 'object');
+  assert('Uncaught TypeError: Invalid value used as weak map key', !isPrimitiveType(obj));
 
   if (value === undefined) {
     value = UNDEFINED;
@@ -59,11 +72,7 @@ WeakMap.prototype.set = function(obj, value) {
 WeakMap.prototype.has = function(obj) {
   var map = meta(obj).readableWeak();
 
-  if (map && map[this._id] !== undefined) {
-    return true;
-  }
-
-  return false;
+  return (map && map[this._id] !== undefined);
 };
 
 /*

--- a/packages/ember-metal/lib/weak_map.js
+++ b/packages/ember-metal/lib/weak_map.js
@@ -5,20 +5,6 @@ import { meta } from 'ember-metal/meta';
 var id = 0;
 function UNDEFINED() {}
 
-function isPrimitiveType(thing) {
-  switch(typeof thing) {
-    case 'string':
-    case 'boolean':
-    case 'number':
-    case 'undefined':
-    case 'null':
-    case 'symbol':
-      return true;
-    default:
-      return false;
-  }
-}
-
 /*
  * @public
  * @class Ember.WeakMap
@@ -54,7 +40,7 @@ WeakMap.prototype.get = function(obj) {
  * @return {Any} stored value
  */
 WeakMap.prototype.set = function(obj, value) {
-  assert('Uncaught TypeError: Invalid value used as weak map key', !isPrimitiveType(obj));
+  assert('Uncaught TypeError: Invalid value used as weak map key', typeof obj === 'object' || typeof obj === 'function');
 
   if (value === undefined) {
     value = UNDEFINED;

--- a/packages/ember-metal/lib/weak_map.js
+++ b/packages/ember-metal/lib/weak_map.js
@@ -1,7 +1,10 @@
+import { typeOf } from 'ember-runtime/utils';
+import { assert } from 'ember-metal/debug';
 import { GUID_KEY } from 'ember-metal/utils';
 import { meta } from 'ember-metal/meta';
 
 var id = 0;
+const UNDEFINED = function() {};
 
 /*
  * @private
@@ -23,6 +26,10 @@ export default function WeakMap() {
 WeakMap.prototype.get = function(obj) {
   var map = meta(obj).readableWeak();
   if (map) {
+    if (map[this._id] === UNDEFINED) {
+      return undefined;
+    }
+
     return map[this._id];
   }
 };
@@ -34,6 +41,12 @@ WeakMap.prototype.get = function(obj) {
  * @return {Any} stored value
  */
 WeakMap.prototype.set = function(obj, value) {
+  assert('Uncaught TypeError: Invalid value used as weak map key', typeOf(obj) === 'object');
+
+  if (typeOf(value) === 'undefined') {
+    value = UNDEFINED;
+  }
+
   meta(obj).writableWeak()[this._id] = value;
   return this;
 };
@@ -44,7 +57,13 @@ WeakMap.prototype.set = function(obj, value) {
  * @return {Boolean} if the key exists
  */
 WeakMap.prototype.has = function(obj) {
-  return !!this.get(obj);
+  var map = meta(obj).readableWeak();
+
+  if (map && typeOf(map[this._id]) !== 'undefined') {
+    return true;
+  }
+
+  return false;
 };
 
 /*

--- a/packages/ember-metal/lib/weak_map.js
+++ b/packages/ember-metal/lib/weak_map.js
@@ -4,7 +4,7 @@ import { GUID_KEY } from 'ember-metal/utils';
 import { meta } from 'ember-metal/meta';
 
 var id = 0;
-const UNDEFINED = function() {};
+function UNDEFINED() {}
 
 /*
  * @private

--- a/packages/ember-metal/lib/weak_map.js
+++ b/packages/ember-metal/lib/weak_map.js
@@ -40,7 +40,7 @@ WeakMap.prototype.get = function(obj) {
  * @return {Any} stored value
  */
 WeakMap.prototype.set = function(obj, value) {
-  assert('Uncaught TypeError: Invalid value used as weak map key', typeof obj === 'object' || typeof obj === 'function');
+  assert('Uncaught TypeError: Invalid value used as weak map key', obj && (typeof obj === 'object' || typeof obj === 'function'));
 
   if (value === undefined) {
     value = UNDEFINED;

--- a/packages/ember-metal/tests/weak_map_test.js
+++ b/packages/ember-metal/tests/weak_map_test.js
@@ -59,10 +59,6 @@ QUnit.test('that error is thrown when using a primitive key', function(assert) {
   }, /Uncaught TypeError: Invalid value used as weak map key/);
 
   expectAssertion(function() {
-    map.set(Symbol(), 1);
-  }, /Uncaught TypeError: Invalid value used as weak map key/);
-
-  expectAssertion(function() {
     map.set(true, 1);
   }, /Uncaught TypeError: Invalid value used as weak map key/);
 

--- a/packages/ember-metal/tests/weak_map_test.js
+++ b/packages/ember-metal/tests/weak_map_test.js
@@ -47,6 +47,14 @@ QUnit.test('has weakMap like qualities', function(assert) {
   equal(map.get(b), undefined);
 });
 
+QUnit.test('that error is thrown when using a non object key', function(assert) {
+  var map = new WeakMap();
+
+  throws(function() {
+    map.set('a', 1);
+  }, /Uncaught TypeError: Invalid value used as weak map key/);
+});
+
 QUnit.test('that .has and .delete work as expected', function(assert) {
   var map = new WeakMap();
   var a = {};
@@ -60,4 +68,8 @@ QUnit.test('that .has and .delete work as expected', function(assert) {
 
   deepEqual(map.delete(a), map);
   ok(!map.has(a));
+
+  map.set(a, undefined);
+  ok(map.has(a));
 });
+

--- a/packages/ember-metal/tests/weak_map_test.js
+++ b/packages/ember-metal/tests/weak_map_test.js
@@ -47,30 +47,30 @@ QUnit.test('has weakMap like qualities', function(assert) {
   equal(map.get(b), undefined);
 });
 
-QUnit.test('that error is thrown when using a non object key', function(assert) {
+QUnit.test('that error is thrown when using a primitive key', function(assert) {
   var map = new WeakMap();
 
-  throws(function() {
+  expectAssertion(function() {
     map.set('a', 1);
   }, /Uncaught TypeError: Invalid value used as weak map key/);
 
-  throws(function() {
+  expectAssertion(function() {
     map.set(1, 1);
   }, /Uncaught TypeError: Invalid value used as weak map key/);
 
-  throws(function() {
+  expectAssertion(function() {
     map.set(Symbol(), 1);
   }, /Uncaught TypeError: Invalid value used as weak map key/);
 
-  throws(function() {
+  expectAssertion(function() {
     map.set(true, 1);
   }, /Uncaught TypeError: Invalid value used as weak map key/);
 
-  throws(function() {
+  expectAssertion(function() {
     map.set(null, 1);
   }, /Uncaught TypeError: Invalid value used as weak map key/);
 
-  throws(function() {
+  expectAssertion(function() {
     map.set(undefined, 1);
   }, /Uncaught TypeError: Invalid value used as weak map key/);
 });

--- a/packages/ember-metal/tests/weak_map_test.js
+++ b/packages/ember-metal/tests/weak_map_test.js
@@ -46,3 +46,18 @@ QUnit.test('has weakMap like qualities', function(assert) {
   equal(map.get(a), 2);
   equal(map.get(b), undefined);
 });
+
+QUnit.test('that .has and .delete work as expected', function(assert) {
+  var map = new WeakMap();
+  var a = {};
+  var b = {};
+  var foo = { id: 1, name: 'My file', progress: 0 };
+
+  deepEqual(map.set(a, foo), map);
+  deepEqual(map.get(a), foo);
+  ok(map.has(a));
+  ok(!map.has(b));
+
+  deepEqual(map.delete(a), map);
+  ok(!map.has(a));
+});

--- a/packages/ember-metal/tests/weak_map_test.js
+++ b/packages/ember-metal/tests/weak_map_test.js
@@ -53,6 +53,26 @@ QUnit.test('that error is thrown when using a non object key', function(assert) 
   throws(function() {
     map.set('a', 1);
   }, /Uncaught TypeError: Invalid value used as weak map key/);
+
+  throws(function() {
+    map.set(1, 1);
+  }, /Uncaught TypeError: Invalid value used as weak map key/);
+
+  throws(function() {
+    map.set(Symbol(), 1);
+  }, /Uncaught TypeError: Invalid value used as weak map key/);
+
+  throws(function() {
+    map.set(true, 1);
+  }, /Uncaught TypeError: Invalid value used as weak map key/);
+
+  throws(function() {
+    map.set(null, 1);
+  }, /Uncaught TypeError: Invalid value used as weak map key/);
+
+  throws(function() {
+    map.set(undefined, 1);
+  }, /Uncaught TypeError: Invalid value used as weak map key/);
 });
 
 QUnit.test('that .has and .delete work as expected', function(assert) {
@@ -72,4 +92,3 @@ QUnit.test('that .has and .delete work as expected', function(assert) {
   map.set(a, undefined);
   ok(map.has(a));
 });
-

--- a/packages/ember-metal/tests/weak_map_test.js
+++ b/packages/ember-metal/tests/weak_map_test.js
@@ -1,0 +1,48 @@
+import WeakMap from 'ember-metal/weak_map';
+
+QUnit.module('Ember.WeakMap');
+
+QUnit.test('has weakMap like qualities', function(assert) {
+  var map = new WeakMap();
+  var map2 = new WeakMap();
+
+  var a = {};
+  var b = {};
+  var c = {};
+
+  equal(map.get(a), undefined);
+  equal(map.get(b), undefined);
+  equal(map.get(c), undefined);
+
+  equal(map2.get(a), undefined);
+  equal(map2.get(b), undefined);
+  equal(map2.get(c), undefined);
+
+  equal(map.set(a,  1), map, 'map.set should return itself');
+  equal(map.get(a), 1);
+  equal(map.set(b,  undefined), map);
+  equal(map.set(a, 2), map);
+  equal(map.get(a), 2);
+  equal(map.set(b,  undefined), map);
+
+  equal(map2.get(a), undefined);
+  equal(map2.get(b), undefined);
+  equal(map2.get(c), undefined);
+
+  equal(map.set(c, 1), map);
+  equal(map.get(c), 1);
+  equal(map.get(a), 2);
+  equal(map.get(b), undefined);
+
+  equal(map2.set(a, 3), map2);
+  equal(map2.set(b, 4), map2);
+  equal(map2.set(c, 5), map2);
+
+  equal(map2.get(a), 3);
+  equal(map2.get(b), 4);
+  equal(map2.get(c), 5);
+
+  equal(map.get(c), 1);
+  equal(map.get(a), 2);
+  equal(map.get(b), undefined);
+});


### PR DESCRIPTION
RFC is likely not needed, as this is a polyfil using embers internal machinery for a spec'd ES6 feature. We don't really have flex room on this feature, constraints are fixed.
- [ ] docs
  - [x] basic API
  - [ ] flesh out + examples
- [ ] feature flags
- [x] RFC https://github.com/emberjs/rfcs/pull/91
