### PR TITLE
Update emberjs-build to v0.3.5.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ember-cli-sauce": "^1.3.0",
     "ember-cli-yuidoc": "0.7.0",
     "ember-publisher": "0.0.7",
-    "emberjs-build": "0.3.3",
+    "emberjs-build": "0.3.5",
     "express": "^4.5.0",
     "finalhandler": "^0.4.0",
     "github": "^0.2.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ember-cli-sauce": "^1.3.0",
     "ember-cli-yuidoc": "0.7.0",
     "ember-publisher": "0.0.7",
-    "emberjs-build": "0.3.2",
+    "emberjs-build": "0.3.3",
     "express": "^4.5.0",
     "finalhandler": "^0.4.0",
     "github": "^0.2.3",

--- a/packages/ember-metal/lib/dependent_keys.js
+++ b/packages/ember-metal/lib/dependent_keys.js
@@ -1,7 +1,6 @@
+'no use strict';
 // Remove "use strict"; from transpiled module until
 // https://bugs.webkit.org/show_bug.cgi?id=138038 is fixed
-//
-'REMOVE_USE_STRICT: true';
 
 import {
   watch,

--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -1,7 +1,6 @@
+'no use strict';
 // Remove "use strict"; from transpiled module until
 // https://bugs.webkit.org/show_bug.cgi?id=138038 is fixed
-//
-'REMOVE_USE_STRICT: true';
 
 /**
 @module ember

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -1,7 +1,6 @@
+'no use strict';
 // Remove "use strict"; from transpiled module until
 // https://bugs.webkit.org/show_bug.cgi?id=138038 is fixed
-//
-'REMOVE_USE_STRICT: true';
 
 import { protoMethods as listenerMethods } from 'ember-metal/meta_listeners';
 import EmptyObject from 'ember-metal/empty_object';

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -1,7 +1,6 @@
+'no use strict';
 // Remove "use strict"; from transpiled module until
 // https://bugs.webkit.org/show_bug.cgi?id=138038 is fixed
-//
-'REMOVE_USE_STRICT: true';
 
 /**
 @module ember

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -1,7 +1,6 @@
+'no use strict';
 // Remove "use strict"; from transpiled module until
 // https://bugs.webkit.org/show_bug.cgi?id=138038 is fixed
-//
-'REMOVE_USE_STRICT: true';
 
 /**
 @module ember-metal

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -1,7 +1,6 @@
+'no use strict';
 // Remove "use strict"; from transpiled module until
 // https://bugs.webkit.org/show_bug.cgi?id=138038 is fixed
-//
-'REMOVE_USE_STRICT: true';
 
 /**
   @module ember

--- a/packages/loader/lib/main.js
+++ b/packages/loader/lib/main.js
@@ -60,7 +60,7 @@ var mainContext = this;
         if (deps[i] === 'exports') {
           reified.push(exports);
         } else {
-          reified.push(internalRequire(resolve(deps[i], name), name));
+          reified.push(internalRequire(deps[i], name));
         }
       }
 
@@ -68,28 +68,6 @@ var mainContext = this;
 
       return exports;
     };
-
-    function resolve(child, name) {
-      if (child.charAt(0) !== '.') {
-        return child;
-      }
-      var parts = child.split('/');
-      var parentBase = name.split('/').slice(0, -1);
-
-      for (var i = 0, l = parts.length; i < l; i++) {
-        var part = parts[i];
-
-        if (part === '..') {
-          parentBase.pop();
-        } else if (part === '.') {
-          continue;
-        } else {
-          parentBase.push(part);
-        }
-      }
-
-      return parentBase.join('/');
-    }
 
     requirejs._eak_seen = registry;
 


### PR DESCRIPTION
- Remove recursion in loader (should help initial boot a tiny bit, but is less bytes either way :smiley:)
- Remove need for broccoli-use-strict-remover (by replacing with a babel plugin)
