### PR TITLE
Update emberjs-build to remove need for derequire.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ember-cli-sauce": "^1.3.0",
     "ember-cli-yuidoc": "0.7.0",
     "ember-publisher": "0.0.7",
-    "emberjs-build": "0.3.5",
+    "emberjs-build": "0.4.0",
     "express": "^4.5.0",
     "finalhandler": "^0.4.0",
     "github": "^0.2.3",

--- a/packages/loader/lib/main.js
+++ b/packages/loader/lib/main.js
@@ -1,4 +1,4 @@
-var define, requireModule, require, requirejs, Ember;
+var enifed, requireModule, require, requirejs, Ember;
 var mainContext = this;
 
 (function() {
@@ -15,7 +15,7 @@ var mainContext = this;
     var registry = {};
     var seen = {};
 
-    define = function(name, deps, callback) {
+    enifed = function(name, deps, callback) {
       var value = { };
 
       if (!callback) {
@@ -72,12 +72,12 @@ var mainContext = this;
     requirejs._eak_seen = registry;
 
     Ember.__loader = {
-      define: define,
+      define: enifed,
       require: require,
       registry: registry
     };
   } else {
-    define = Ember.__loader.define;
+    enifed = Ember.__loader.define;
     requirejs = require = requireModule = Ember.__loader.require;
   }
 })();


### PR DESCRIPTION
emberjs-build now uses a babel plugin to transform top level `define` calls into `enifed` calls. This allows us to:
- keep dev builds closer to prod builds (by removing this specific
  difference)
- shave another 3-5 seconds off of production builds.

```
% ember s -prod

Before:

initial build, cold boot: Build successful - 86282ms.
initial build, warm boot: Build successful - 19390ms.

After:

initial build, cold boot: Build successful - 61330ms.
initial build, warm boot: Build successful - 13912ms.
```
