### PR TITLE
[CLEANUP beta] Don't import entire `ember` module

### DIFF
--- a/packages/ember/tests/application_lifecycle_test.js
+++ b/packages/ember/tests/application_lifecycle_test.js
@@ -1,4 +1,3 @@
-import 'ember';
 import Ember from 'ember-metal/core';
 import isEnabled from 'ember-metal/features';
 

--- a/packages/ember/tests/component_registration_test.js
+++ b/packages/ember/tests/component_registration_test.js
@@ -1,4 +1,3 @@
-import 'ember';
 import Ember from 'ember-metal/core';
 import keys from 'ember-metal/keys';
 

--- a/packages/ember/tests/controller_test.js
+++ b/packages/ember/tests/controller_test.js
@@ -1,4 +1,3 @@
-import 'ember';
 import Ember from 'ember-metal/core';
 import { compile } from 'ember-template-compiler';
 import EmberView from 'ember-views/views/view';

--- a/packages/ember/tests/global-api-test.js
+++ b/packages/ember/tests/global-api-test.js
@@ -1,5 +1,4 @@
 /*globals Ember */
-import 'ember';
 import { isArray } from 'ember-runtime/utils';
 
 QUnit.module('Global API Tests');

--- a/packages/ember/tests/helpers/helper_registration_test.js
+++ b/packages/ember/tests/helpers/helper_registration_test.js
@@ -1,4 +1,3 @@
-import 'ember';
 import Ember from 'ember-metal/core';
 import helpers from 'ember-htmlbars/helpers';
 import { compile } from 'ember-template-compiler';

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1,4 +1,3 @@
-import 'ember';
 import Ember from 'ember-metal/core';
 import ComponentLookup from 'ember-views/component_lookup';
 import isEnabled from 'ember-metal/features';

--- a/packages/ember/tests/helpers/link_to_test/link_to_transitioning_classes_test.js
+++ b/packages/ember/tests/helpers/link_to_test/link_to_transitioning_classes_test.js
@@ -1,4 +1,3 @@
-import 'ember';
 import Ember from 'ember-metal/core';
 import { compile } from 'ember-template-compiler';
 

--- a/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
+++ b/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
@@ -1,4 +1,3 @@
-import 'ember';
 import Ember from 'ember-metal/core';
 import isEnabled from 'ember-metal/features';
 import { compile } from 'ember-template-compiler';

--- a/packages/ember/tests/homepage_example_test.js
+++ b/packages/ember/tests/homepage_example_test.js
@@ -1,4 +1,3 @@
-import 'ember';
 import Ember from 'ember-metal/core';
 import { compile } from 'ember-template-compiler';
 

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1,4 +1,3 @@
-import 'ember';
 import Ember from 'ember-metal/core';
 import isEnabled from 'ember-metal/features';
 import { get } from 'ember-metal/property_get';

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -1,4 +1,3 @@
-import 'ember';
 import Ember from 'ember-metal/core';
 import isEnabled from 'ember-metal/features';
 import { computed } from 'ember-metal/computed';

--- a/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
@@ -1,4 +1,3 @@
-import 'ember';
 import Ember from 'ember-metal/core';
 import isEnabled from 'ember-metal/features';
 import { compile } from 'ember-template-compiler';

--- a/packages/ember/tests/routing/query_params_test/overlapping_query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test/overlapping_query_params_test.js
@@ -1,4 +1,3 @@
-import 'ember';
 import Ember from 'ember-metal/core';
 import isEnabled from 'ember-metal/features';
 import { compile } from 'ember-template-compiler';

--- a/packages/ember/tests/routing/query_params_test/query_params_paramless_link_to_test.js
+++ b/packages/ember/tests/routing/query_params_test/query_params_paramless_link_to_test.js
@@ -1,4 +1,3 @@
-import 'ember';
 import Ember from 'ember-metal/core';
 import isEnabled from 'ember-metal/features';
 import { capitalize } from 'ember-runtime/system/string';

--- a/packages/ember/tests/routing/router_map_test.js
+++ b/packages/ember/tests/routing/router_map_test.js
@@ -1,4 +1,3 @@
-import 'ember';
 import Ember from 'ember-metal/core';
 import compile from 'ember-template-compiler/system/compile';
 

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -1,4 +1,3 @@
-import 'ember';
 import Ember from 'ember-metal/core';
 import { compile } from 'ember-template-compiler';
 import EmberView from 'ember-views/views/view';

--- a/packages/ember/tests/routing/toplevel_dom_test.js
+++ b/packages/ember/tests/routing/toplevel_dom_test.js
@@ -1,4 +1,3 @@
-import 'ember';
 import Ember from 'ember-metal/core';
 import { compile } from 'ember-template-compiler';
 import EmberView from 'ember-views/views/view';


### PR DESCRIPTION
- Removes `import 'ember'` from tests. :ice_cream:
