### PR TITLE
[BUGFIX beta] Provide a helpful error for undefined closure actions.

### DIFF
--- a/packages/ember-routing-htmlbars/lib/keywords/closure-action.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/closure-action.js
@@ -27,7 +27,9 @@ export default function closureAction(morph, env, scope, params, hash, template,
       // look to "target".
       target = read(scope.self);
       action = read(rawAction);
-      if (typeof action === 'string') {
+      let actionType = typeof action;
+
+      if (actionType === 'string') {
         let actionName = action;
         action = null;
         // on-change={{action 'setName'}}
@@ -42,6 +44,8 @@ export default function closureAction(morph, env, scope, params, hash, template,
         if (!action) {
           throw new EmberError(`An action named '${actionName}' was not found in ${target}.`);
         }
+      } else if (actionType !== 'function') {
+        throw new EmberError(`An action could not be made for \`${rawAction.label}\` in ${target}. Please confirm that you are using either a quoted action name (i.e. \`(action '${rawAction.label}')\`) or a function available in ${target}.`);
       }
     }
 

--- a/packages/ember-routing-htmlbars/tests/helpers/closure_action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/closure_action_test.js
@@ -49,6 +49,22 @@ QUnit.test('action should be called', function(assert) {
   });
 });
 
+QUnit.test('an error is triggered when bound action function is undefined', function(assert) {
+  assert.expect(1);
+
+  innerComponent = EmberComponent.extend({
+  }).create();
+
+  outerComponent = EmberComponent.extend({
+    layout: compile('{{view innerComponent submit=(action somethingThatIsUndefined)}}'),
+    innerComponent
+  }).create();
+
+  throws(function() {
+    runAppend(outerComponent);
+  }, /An action could not be made for `somethingThatIsUndefined` in .*\. Please confirm that you are using either a quoted action name \(i\.e\. `\(action 'somethingThatIsUndefined'\)`\) or a function available in .*\./);
+});
+
 QUnit.test('action value is returned', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
In the following scenario:

``` handlebars
{{#foo-bar blah=(action somethingThatIsUndefined)}}
  Click Me!
{{/foo-bar}}
```

Previously, an error was only thrown when attempting to invoke `this.attrs.blah()`.  After this change a helpful error like the following will be thrown:

```
An action could not be made for `somethingThatIsUndefined` in
< component object id>.  Please confirm that you are using either
a quoted action name (i.e. `(action 'somethingThatIsUndefined')`)
or a function available in < component object id>.
```

Fixes https://github.com/emberjs/ember.js/issues/12240.
