### PR TITLE
[BUGFIX canary] Trust Ember.set

### DIFF
--- a/packages/ember-metal/lib/streams/dependency.js
+++ b/packages/ember-metal/lib/streams/dependency.js
@@ -49,7 +49,9 @@ merge(Dependency.prototype, {
         this.unsubscribe();
         this.subscribe();
       }
+      return true;
     }
+    return false;
   },
 
   getValue() {

--- a/packages/ember-metal/lib/streams/proxy-stream.js
+++ b/packages/ember-metal/lib/streams/proxy-stream.js
@@ -1,5 +1,6 @@
 import merge from 'ember-metal/merge';
 import Stream from 'ember-metal/streams/stream';
+import EmberObject from 'ember-runtime/system/object';
 
 function ProxyStream(source, label) {
   this.init(label);
@@ -18,8 +19,13 @@ merge(ProxyStream.prototype, {
   },
 
   setSource(source) {
-    this.sourceDep.replace(source);
-    this.notify();
+    let didChange = this.sourceDep.replace(source);
+    if (didChange || !(source instanceof EmberObject)) {
+      // If the source changed, we must notify. If the source is not
+      // an Ember.Object, we must also notify, because it could have
+      // interior mutability that is otherwise not being observed.
+      this.notify();
+    }
   }
 });
 


### PR DESCRIPTION
This change eliminates unnecessary dirtying of proxy streams when the
source object is an Ember.Object. It results in significant re-render
performance improvement in certain scenarios, especially when people are
iterating over lists of Ember.Objects to render components with
expensive lifecycle hooks.

We already have a longstanding convention that people need to use `set`
to mutate Ember.Objects if they expect any observability, and as long as
people are using `set`, interior mutability will be captured by other
observers further downstream.

The same is not necessarily true for POJOs. We would like to allow
something conceptually like:

```
myComponent.set('thing', aPojo);
aPojo.deep.inside.here = 'newValue';
myComponent.notifyPropertyChange('thing');
```

to work correctly, such that the deep mutation gets noticed. Which is
why this change treats POJOs and Ember.Object's differently.

Credit to @wycats for formulating this approach.
