### PR TITLE
{{else}} block for {{component}} helper

### DIFF
--- a/features.json
+++ b/features.json
@@ -8,6 +8,7 @@
     "ember-libraries-isregistered": null,
     "ember-debug-handlers": true,
     "ember-registry-container-reform": true,
-    "ember-routing-routable-components": null
+    "ember-routing-routable-components": null,
+    "ember-htmlbars-component-else": null
   }
 }

--- a/packages/ember-htmlbars/lib/keywords/component.js
+++ b/packages/ember-htmlbars/lib/keywords/component.js
@@ -4,6 +4,10 @@
   @public
 */
 import assign from 'ember-metal/assign';
+import lookupComponent from 'ember-htmlbars/utils/lookup-component';
+import { assert } from 'ember-metal/debug';
+import { internal } from 'htmlbars-runtime';
+import isEnabled from 'ember-metal/features';
 
 /**
   The `{{component}}` helper lets you add instances of `Ember.Component` to a
@@ -12,7 +16,16 @@ import assign from 'ember-metal/assign';
   `{{component}}`'s primary use is for cases where you want to dynamically
   change which type of component is rendered as the state of your application
   changes. The provided block will be applied as the template for the component.
-  Given an empty `<body>` the following template:
+
+  You should not use this helper when you are consistently rendering the same
+  component. In that case, use standard component syntax, for example:
+
+  ```handlebars
+  {{! application.hbs }}
+  {{live-updating-chart}}
+  ```
+
+  Given an empty `<body>` with the following template:
 
   ```handlebars
   {{! application.hbs }}
@@ -39,13 +52,32 @@ import assign from 'ember-metal/assign';
   `true`, and the `market-close-summary` component will be appended when
   `isMarketOpen` is `false`. If the value changes while the app is running,
   the component will be automatically swapped out accordingly.
-  Note: You should not use this helper when you are consistently rendering the same
-  component. In that case, use standard component syntax, for example:
+
+  You can also use the `{{component}}` with an `{{else}}` block if you want
+  to provide a fallback in case the dynamic component can not be found.
 
   ```handlebars
   {{! application.hbs }}
-  {{live-updating-chart}}
+  {{#component myChart}}
+    {{! this block yields in the component if it is found}}
+  {{else}}
+    Component {{myChart}} not found.
+  {{/component}}
   ```
+
+  ```javascript
+  export default Ember.Controller.extend({
+    myChart: computed('chart.type', {
+      get() {
+        return `chart-${chart.type}`;
+      }
+    })
+  });
+  ```
+
+  When the name of the component is `null` or `undefined`, nothing is rendered.
+  Otherwise, if the component can not be resolved and no `{{else}}` block
+  has been provided, an error wil be thrown.
 
   @method component
   @since 1.11.0
@@ -54,7 +86,7 @@ import assign from 'ember-metal/assign';
 */
 export default {
   setupState(lastState, env, scope, params, hash) {
-    let componentPath = env.hooks.getValue(params[0]);
+    const componentPath = env.hooks.getValue(params[0]);
     return assign({}, lastState, { componentPath, isComponentHelper: true });
   },
 
@@ -75,13 +107,25 @@ export default {
 };
 
 function render(morph, env, scope, params, hash, template, inverse, visitor) {
-  let componentPath = morph.state.componentPath;
+  const componentPath = morph.state.componentPath;
 
   // If the value passed to the {{component}} helper is undefined or null,
   // don't create a new ComponentNode.
   if (componentPath === undefined || componentPath === null) {
     return;
   }
-
-  env.hooks.component(morph, env, scope, componentPath, params, hash, { default: template, inverse }, visitor);
+  const { component, layout } = lookupComponent(env.container, componentPath);
+  const found = !!(component || layout);
+  if (!isEnabled('ember-htmlbars-component-else')) {
+    env.hooks.component(morph, env, scope, componentPath, params, hash, { default: template, inverse }, visitor);
+    return;
+  }
+  assert(`HTMLBars error: Could not find component named "${componentPath}" (no component or template with that name was found) and no {{else}} block was provided`, found || inverse);
+  if (!found && inverse) {
+    internal.hostBlock(morph, env, scope, inverse, null, null, visitor, function(options) {
+      options.templates.template.yield();
+    });
+  } else {
+    env.hooks.component(morph, env, scope, componentPath, params, hash, { default: template, inverse }, visitor);
+  }
 }


### PR DESCRIPTION
Answering my own needs (see http://discuss.emberjs.com/t/failsafe-component-helper/8705),
I added the `{{else}}` block for the `{{component}}` helper; this block is rendered when Ember is not able to lookup the component.

This solves a different use case that when `null` or `undefined` is given to the helper as a component name. It allows much simpler CPs to generate component names (without component lookups) yet with a failsafe display.
The updated docs will certainly explain it all much better :)

I will also take the opportunity to discuss about the values `null` or `undefined`.
I didn't change the existing behaviour but I'm inclined to think it would fit better in the `{{else}}` block (giving responsibility to the developers) than in the internals of the helper. What do you think?
