### PR TITLE
[BUGFIX release-1-13] Ensure concat streams unsubscribe properly.

### DIFF
--- a/packages/ember-metal/lib/streams/utils.js
+++ b/packages/ember-metal/lib/streams/utils.js
@@ -183,7 +183,7 @@ export function concat(array, separator) {
     });
 
     for (i = 0, l = array.length; i < l; i++) {
-      subscribe(array[i], stream.notify, stream);
+      stream.addDependency(array[i]);
     }
 
     // used by angle bracket components to detect an attribute was provided

--- a/packages/ember-metal/tests/streams/concat_test.js
+++ b/packages/ember-metal/tests/streams/concat_test.js
@@ -1,0 +1,63 @@
+import Stream from 'ember-metal/streams/stream';
+import {
+  concat,
+  read
+} from 'ember-metal/streams/utils';
+
+
+function hasSubscribers(stream) {
+  // this uses the private internal property `subscriberHead`
+  // for the purposes of ensuring that subscription is cleared
+  // after deactivation.  Adding a util helper to the `Stream` code
+  // just for the test seems dubious, as does accessing the private
+  // property directly in the test.
+  return stream && !!stream.subscriberHead;
+}
+
+QUnit.module('Stream - concat');
+
+QUnit.test('returns string if no streams were in the array', function(assert) {
+  let result = concat(['foo', 'bar', 'baz'], ' ');
+
+  assert.equal(result, 'foo bar baz');
+});
+
+QUnit.test('returns a stream if a stream is in the array', function(assert) {
+  let stream = new Stream(function() {
+    return 'bar';
+  });
+  let result = concat(['foo', stream, 'baz'], ' ');
+
+  assert.ok(result.isStream, 'a stream is returned');
+  assert.equal(read(result), 'foo bar baz');
+});
+
+QUnit.test('returns updated value upon input dirtied', function(assert) {
+  let value = 'bar';
+  let stream = new Stream(function() {
+    return value;
+  });
+  let result = concat(['foo', stream, 'baz'], ' ');
+  result.activate();
+
+  assert.equal(read(result), 'foo bar baz');
+
+  value = 'qux';
+  stream.notify();
+
+  assert.equal(read(result), 'foo qux baz');
+});
+
+QUnit.test('removes dependencies when unsubscribeDependencies is called', function(assert) {
+  let stream = new Stream(function() {
+    return 'bar';
+  });
+  let result = concat(['foo', stream, 'baz'], ' ');
+  result.activate();
+
+  assert.equal(hasSubscribers(stream), true, 'subscribers are present from the concat stream');
+
+  result.maybeDeactivate();
+
+  assert.equal(hasSubscribers(stream), false, 'subscribers are removed after concat stream is deactivated');
+});


### PR DESCRIPTION
The stream returned by `concat` should subscribe to any input streams so that the "concat stream" is marked as dirty if any of the input streams are dirtied. This is/was working properly.

Unfortunately, when `subscribe`ing directly as done in 1.13.0, the subscriptions are never cleared if the "concat stream" is deactivated.  This means, that listeners build up over time and leak the "concat streams" and the `KeyStream`'s / `ProxyStream`'s that are in use.

Using `stream.addDependency` instead of manually `subscribe`ing allows the returned "concat stream" to properly remove subscribers when it is deactivated.

Authored by @raytiley / @rwjblue / @mmun.

Fixes #11802.
