### PR TITLE
Improve assertion error traceability

### DIFF
--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -48,7 +48,7 @@ export function set(obj, keyName, value, tolerant) {
     return setPath(obj, keyName, value, tolerant);
   }
 
-  assert('calling set on destroyed object', !obj.isDestroyed);
+  assert('calling set on destroyed object: %@.%@ = %@'.fmt(obj, keyName, value), !obj.isDestroyed);
 
   if (desc) {
     desc.set(obj, keyName, value);


### PR DESCRIPTION
When this assertion fails the stack trace is often too long to find the original place where it occurred. Getting to know the class name, object ID and property name can help identify and track issues. I hope it's safe to use the prototype extension of String.
