### PR TITLE
Breaks circular references in rejected jqXhr promises

### DIFF
--- a/packages/ember-runtime/lib/ext/rsvp.js
+++ b/packages/ember-runtime/lib/ext/rsvp.js
@@ -32,18 +32,21 @@ RSVP.configure('async', function(callback, promise) {
   });
 });
 
-export function onerrorDefault(e) {
+export function onerrorDefault(reason) {
   var error;
 
-  if (e && e.errorThrown) {
+  if (reason && reason.errorThrown) {
     // jqXHR provides this
-    error = e.errorThrown;
+    error = reason.errorThrown;
     if (typeof error === 'string') {
       error = new Error(error);
     }
-    error.__reason_with_error_thrown__ = e;
+    Object.defineProperty(error, '__reason_with_error_thrown__', {
+      value: reason,
+      enumerable: false
+    });
   } else {
-    error = e;
+    error = reason;
   }
 
   if (error && error.name === "UnrecognizedURLError") {

--- a/packages/ember-runtime/tests/ext/rsvp_test.js
+++ b/packages/ember-runtime/tests/ext/rsvp_test.js
@@ -167,6 +167,30 @@ QUnit.test('rejections where the errorThrown is a string should wrap the sting i
   }
 });
 
+QUnit.test('rejections can be serialized to JSON', function (assert) {
+  expect(2);
+
+  var wasEmberTesting = Ember.testing;
+  var wasOnError      = Ember.onerror;
+
+  try {
+    Ember.testing = false;
+    Ember.onerror = function(error) {
+      assert.equal(error.message, 'a fail');
+      assert.ok(JSON.stringify(error), 'Error can be serialized');
+    };
+
+    var jqXHR = {
+      errorThrown: new Error('a fail')
+    };
+
+    run(RSVP, 'reject', jqXHR);
+  } finally {
+    Ember.onerror = wasOnError;
+    Ember.testing = wasEmberTesting;
+  }
+});
+
 var wasTesting;
 var reason = 'i failed';
 QUnit.module('Ember.test: rejection assertions', {


### PR DESCRIPTION
`Ember.RSVP.onerrorDefault` creates a circular reference to jqXhr instances by ultimately doing:

``` js
e.errorThrown.__reason_with_error_thrown__ = e;
```

It prevents libraries like Sentry to properly handle errors as they usually `JSON.stringify` stuff and this fails (because circular reference).

Here's an example JSBin : https://emberjs.jsbin.com/kubefos/edit?html,js,output
