### PR TITLE
[CLEANUP canary] Remove unused `isLegacyViewHelper` flag.

### DIFF
--- a/packages/ember-htmlbars/lib/hooks/invoke-helper.js
+++ b/packages/ember-htmlbars/lib/hooks/invoke-helper.js
@@ -1,20 +1,7 @@
-import { assert } from 'ember-metal/debug';
 import { buildHelperStream } from 'ember-htmlbars/system/invoke-helper';
 import subscribe from 'ember-htmlbars/utils/subscribe';
 
 export default function invokeHelper(morph, env, scope, visitor, params, hash, helper, templates, context) {
-  if (helper.isLegacyViewHelper) {
-    assert(
-      'You can only pass attributes (such as name=value) not bare ' +
-      'values to a helper for a View found in \'' + helper.viewClass + '\'',
-      params.length === 0
-    );
-
-    env.hooks.keyword('view', morph, env, scope, [helper.viewClass], hash, templates.template.raw, null, visitor);
-    // Opts into a special mode for view helpers
-    return { handled: true };
-  }
-
   var helperStream = buildHelperStream(helper, params, hash, templates, env, scope);
 
   // Ember.Helper helpers are pure values, thus linkable


### PR DESCRIPTION
This was added to support `Ember.Handlebars.makeViewHelper` which was
removed leading up to Ember 2.0.0 so it is no longer needed.
