### PR TITLE
Revert "Refactoring meta, part 2" from #12177

### DIFF
--- a/packages/ember-metal/lib/dependent_keys.js
+++ b/packages/ember-metal/lib/dependent_keys.js
@@ -19,7 +19,7 @@ import {
 export function addDependentKeys(desc, obj, keyName, meta) {
   // the descriptor has a list of dependent keys, so
   // add all of its dependent keys.
-  var idx, len, depKey;
+  var idx, len, depKey, keys;
   var depKeys = desc._dependentKeys;
   if (!depKeys) {
     return;
@@ -27,8 +27,10 @@ export function addDependentKeys(desc, obj, keyName, meta) {
 
   for (idx = 0, len = depKeys.length; idx < len; idx++) {
     depKey = depKeys[idx];
+    // Lookup keys meta for depKey
+    keys = meta.writableDeps(depKey);
     // Increment the number of times depKey depends on keyName.
-    meta.writeDeps(depKey, keyName, (meta.peekDeps(depKey, keyName)|| 0) + 1);
+    keys[keyName] = (keys[keyName] || 0) + 1;
     // Watch the depKey
     watch(obj, depKey, meta);
   }
@@ -38,15 +40,17 @@ export function removeDependentKeys(desc, obj, keyName, meta) {
   // the descriptor has a list of dependent keys, so
   // remove all of its dependent keys.
   var depKeys = desc._dependentKeys;
-  var idx, len, depKey;
+  var idx, len, depKey, keys;
   if (!depKeys) {
     return;
   }
 
   for (idx = 0, len = depKeys.length; idx < len; idx++) {
     depKey = depKeys[idx];
+    // Lookup keys meta for depKey
+    keys = meta.writableDeps(depKey);
     // Decrement the number of times depKey depends on keyName.
-    meta.writeDeps(depKey, keyName, (meta.peekDeps(depKey, keyName) || 0) - 1);
+    keys[keyName] = (keys[keyName] || 0) - 1;
     // Unwatch the depKey
     unwatch(obj, depKey, meta);
   }

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -113,12 +113,12 @@ function inheritedMap(name, Meta) {
     while (pointer !== undefined) {
       let map = pointer[key];
       if (map) {
-        for (let key in map) {
+        Object.keys(map).forEach(key => {
           if (!seen[key]) {
             seen[key] = true;
             fn(key, map[key]);
           }
-        }
+        });
       }
       pointer = pointer.parent;
     }
@@ -211,12 +211,12 @@ Meta.prototype._forEachIn = function(key, subkey, fn) {
     if (map) {
       let innerMap = map[subkey];
       if (innerMap) {
-        for (let innerKey in innerMap) {
-          if (!seen[innerKey]) {
-            seen[innerKey] = true;
-            fn(innerKey, innerMap[innerKey]);
+        Object.keys(innerMap).forEach(key => {
+          if (!seen[key]) {
+            seen[key] = true;
+            fn(key, innerMap[key]);
           }
-        }
+        });
       }
     }
     pointer = pointer.parent;

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -2,6 +2,7 @@
 // Remove "use strict"; from transpiled module until
 // https://bugs.webkit.org/show_bug.cgi?id=138038 is fixed
 
+import isEnabled from 'ember-metal/features';
 import { protoMethods as listenerMethods } from 'ember-metal/meta_listeners';
 import EmptyObject from 'ember-metal/empty_object';
 
@@ -21,11 +22,11 @@ import EmptyObject from 'ember-metal/empty_object';
  The following methods will get generated metaprogrammatically, and
  I'm including them here for greppability:
 
- writableCache, readableCache, writeWatching,
- peekWatching, clearWatching, writeMixins,
- peekMixins, clearMixins, writeBindings,
- peekBindings, clearBindings, writeValues,
- peekValues, clearValues, writeDeps, forEachInDeps
+ writableCache, readableCache, writableWatching, readableWatching,
+ peekWatching, clearWatching, writableMixins, readableMixins,
+ peekMixins, clearMixins, writableBindings, readableBindings,
+ peekBindings, clearBindings, writableValues, readableValues,
+ peekValues, clearValues, writableDeps, readableDeps, getAllDeps
  writableChainWatchers, readableChainWatchers, writableChains,
  readableChains
 
@@ -98,44 +99,37 @@ function inheritedMap(name, Meta) {
   let key = memberProperty(name);
   let capitalized = capitalize(name);
 
-  Meta.prototype['write' + capitalized] = function(subkey, value) {
-    let map = this._getOrCreateOwnMap(key);
-    map[subkey] = value;
+  Meta.prototype['writable' + capitalized] = function() {
+    return this._getOrCreateInheritedMap(key);
+  };
+
+  Meta.prototype['readable' + capitalized] = function() {
+    return this._getInherited(key);
   };
 
   Meta.prototype['peek' + capitalized] = function(subkey) {
-    return this._findInherited(key, subkey);
-  };
-
-  Meta.prototype['forEach' + capitalized] = function(fn) {
-    let pointer = this;
-    let seen = new EmptyObject();
-    while (pointer !== undefined) {
-      let map = pointer[key];
-      if (map) {
-        Object.keys(map).forEach(key => {
-          if (!seen[key]) {
-            seen[key] = true;
-            fn(key, map[key]);
-          }
-        });
-      }
-      pointer = pointer.parent;
+    let map = this._getInherited(key);
+    if (map) {
+      return map[subkey];
     }
   };
 
   Meta.prototype['clear' + capitalized] = function() {
     this[key] = new EmptyObject();
   };
-
-  Meta.prototype['deleteFrom' + capitalized] = function(subkey) {
-    delete this._getOrCreateOwnMap(key)[subkey];
-  };
-
-  Meta.prototype['hasIn' + capitalized] = function(subkey) {
-    return this._findInherited(key, subkey) !== undefined;
-  };
 }
+
+Meta.prototype._getOrCreateInheritedMap = function(key) {
+  let ret = this[key];
+  if (!ret) {
+    if (this.parent) {
+      ret = this[key] = Object.create(this.parent._getOrCreateInheritedMap(key));
+    } else {
+      ret = this[key] = new EmptyObject();
+    }
+  }
+  return ret;
+};
 
 Meta.prototype._getInherited = function(key) {
   let pointer = this;
@@ -147,81 +141,34 @@ Meta.prototype._getInherited = function(key) {
   }
 };
 
-Meta.prototype._findInherited = function(key, subkey) {
-  let pointer = this;
-  while (pointer !== undefined) {
-    let map = pointer[key];
-    if (map) {
-      let value = map[subkey];
-      if (value !== undefined) {
-        return value;
-      }
-    }
-    pointer = pointer.parent;
-  }
-};
-
-
 // Implements a member that provides a lazily created map of maps,
 // with inheritance at both levels.
 function inheritedMapOfMaps(name, Meta) {
   let key = memberProperty(name);
   let capitalized = capitalize(name);
 
-  Meta.prototype['write' + capitalized] = function(subkey, itemkey, value) {
-    let outerMap = this._getOrCreateOwnMap(key);
+  Meta.prototype['writable' + capitalized] = function(subkey) {
+    let outerMap = this._getOrCreateInheritedMap(key);
     let innerMap = outerMap[subkey];
     if (!innerMap) {
       innerMap = outerMap[subkey] = new EmptyObject();
+    } else if (!Object.hasOwnProperty.call(outerMap, subkey)) {
+      innerMap = outerMap[subkey] = Object.create(innerMap);
     }
-    innerMap[itemkey] = value;
+    return innerMap;
   };
 
-  Meta.prototype['peek' + capitalized] = function(subkey, itemkey) {
-    let pointer = this;
-    while (pointer !== undefined) {
-      let map = pointer[key];
-      if (map) {
-        let value = map[subkey];
-        if (value) {
-          if (value[itemkey] !== undefined) {
-            return value[itemkey];
-          }
-        }
-      }
-      pointer = pointer.parent;
-    }
-  };
-
-  Meta.prototype['has' + capitalized] = function(subkey) {
+  Meta.prototype['readable' + capitalized] = function(subkey) {
     let map = this._getInherited(key);
-    return map && !!map[subkey];
+    if (map) {
+      return map[subkey];
+    }
   };
 
-  Meta.prototype['forEachIn' + capitalized] = function(subkey, fn) {
-    return this._forEachIn(key, subkey, fn);
+  Meta.prototype['getAll' + capitalized] = function() {
+    return this._getInherited(key);
   };
 }
-
-Meta.prototype._forEachIn = function(key, subkey, fn) {
-  let pointer = this;
-  let seen = new EmptyObject();
-  while (pointer !== undefined) {
-    let map = pointer[key];
-    if (map) {
-      let innerMap = map[subkey];
-      if (innerMap) {
-        Object.keys(innerMap).forEach(key => {
-          if (!seen[key]) {
-            seen[key] = true;
-            fn(key, innerMap[key]);
-          }
-        });
-      }
-    }
-    pointer = pointer.parent;
-  }
-};
 
 // Implements a member that provides a non-heritable, lazily-created
 // object using the method you provide.
@@ -288,6 +235,10 @@ var EMBER_META_PROPERTY = {
 // Placeholder for non-writable metas.
 export var EMPTY_META = new Meta(null);
 
+if (isEnabled('mandatory-setter')) {
+  EMPTY_META.writableValues();
+}
+
 /**
   Retrieves the meta hash for an object. If `writable` is true ensures the
   hash is writable for this object as well.
@@ -318,6 +269,9 @@ export function meta(obj, writable) {
 
   if (!ret) {
     ret = new Meta(obj);
+    if (isEnabled('mandatory-setter')) {
+      ret.writableValues();
+    }
   } else {
     ret = new Meta(obj, ret);
   }

--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -122,7 +122,7 @@ export function defineProperty(obj, keyName, desc, data, meta) {
 
       if (isEnabled('mandatory-setter')) {
         if (watching) {
-          meta.writeValues(keyName, data);
+          meta.writableValues()[keyName] = data;
           Object.defineProperty(obj, keyName, {
             configurable: true,
             enumerable: true,

--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -82,7 +82,7 @@ export function set(obj, keyName, value, tolerant) {
           ) {
             defineProperty(obj, keyName, null, value); // setup mandatory setter
           } else {
-            meta.writeValues(keyName, value);
+            meta.writableValues()[keyName] = value;
           }
         } else {
           obj[keyName] = value;

--- a/packages/ember-metal/lib/watch_key.js
+++ b/packages/ember-metal/lib/watch_key.js
@@ -12,10 +12,11 @@ export function watchKey(obj, keyName, meta) {
   if (keyName === 'length' && Array.isArray(obj)) { return; }
 
   var m = meta || metaFor(obj);
+  var watching = m.writableWatching();
 
   // activate watching first time
-  if (!m.peekWatching(keyName)) {
-    m.writeWatching(keyName, 1);
+  if (!watching[keyName]) {
+    watching[keyName] = 1;
 
     var possibleDesc = obj[keyName];
     var desc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
@@ -29,7 +30,7 @@ export function watchKey(obj, keyName, meta) {
       handleMandatorySetter(m, obj, keyName);
     }
   } else {
-    m.writeWatching(keyName, (m.peekWatching(keyName) || 0) + 1);
+    watching[keyName] = (watching[keyName] || 0) + 1;
   }
 }
 
@@ -47,7 +48,7 @@ if (isEnabled('mandatory-setter')) {
 
     // this x in Y deopts, so keeping it in this function is better;
     if (configurable && isWritable && hasValue && keyName in obj) {
-      m.writeValues(keyName, obj[keyName]);
+      m.writableValues()[keyName] = obj[keyName];
       Object.defineProperty(obj, keyName, {
         configurable: true,
         enumerable: Object.prototype.propertyIsEnumerable.call(obj, keyName),
@@ -64,9 +65,10 @@ if (isEnabled('mandatory-setter')) {
 
 export function unwatchKey(obj, keyName, meta) {
   var m = meta || metaFor(obj);
-  let count = m.peekWatching(keyName);
-  if (count === 1) {
-    m.writeWatching(keyName, 0);
+  var watching = m.writableWatching();
+
+  if (watching[keyName] === 1) {
+    watching[keyName] = 0;
 
     var possibleDesc = obj[keyName];
     var desc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
@@ -89,13 +91,13 @@ export function unwatchKey(obj, keyName, meta) {
               enumerable: true,
               value: val
             });
-            m.deleteFromValues(keyName);
+            delete m.writableValues()[keyName];
           },
           get: DEFAULT_GETTER_FUNCTION(keyName)
         });
       }
     }
-  } else if (count > 1) {
-    m.writeWatching(keyName, count - 1);
+  } else if (watching[keyName] > 1) {
+    watching[keyName]--;
   }
 }

--- a/packages/ember-metal/lib/watch_path.js
+++ b/packages/ember-metal/lib/watch_path.js
@@ -19,23 +19,24 @@ export function watchPath(obj, keyPath, meta) {
   if (keyPath === 'length' && Array.isArray(obj)) { return; }
 
   var m = meta || metaFor(obj);
-  let counter = m.peekWatching(keyPath) || 0;
-  if (!counter) { // activate watching first time
-    m.writeWatching(keyPath, 1);
+  var watching = m.writableWatching();
+
+  if (!watching[keyPath]) { // activate watching first time
+    watching[keyPath] = 1;
     chainsFor(obj, m).add(keyPath);
   } else {
-    m.writeWatching(keyPath, counter + 1);
+    watching[keyPath] = (watching[keyPath] || 0) + 1;
   }
 }
 
 export function unwatchPath(obj, keyPath, meta) {
   var m = meta || metaFor(obj);
-  let counter = m.peekWatching(keyPath) || 0;
+  var watching = m.writableWatching();
 
-  if (counter === 1) {
-    m.writeWatching(keyPath, 0);
+  if (watching[keyPath] === 1) {
+    watching[keyPath] = 0;
     chainsFor(obj, m).remove(keyPath);
-  } else if (counter > 1) {
-    m.writeWatching(keyPath, counter - 1);
+  } else if (watching[keyPath] > 1) {
+    watching[keyPath]--;
   }
 }

--- a/packages/ember-metal/tests/accessors/mandatory_setters_test.js
+++ b/packages/ember-metal/tests/accessors/mandatory_setters_test.js
@@ -7,7 +7,9 @@ import { meta as metaFor } from 'ember-metal/meta';
 QUnit.module('mandatory-setters');
 
 function hasMandatorySetter(object, property) {
-  return metaFor(object).hasInValues(property);
+  var meta = metaFor(object);
+  let values = meta.readableValues();
+  return values && property in values;
 }
 
 if (isEnabled('mandatory-setter')) {
@@ -103,6 +105,7 @@ if (isEnabled('mandatory-setter')) {
         return 'custom-object';
       }
     };
+    var meta = metaFor(obj);
 
     Object.defineProperty(obj, 'someProp', {
       configurable: false,
@@ -111,7 +114,7 @@ if (isEnabled('mandatory-setter')) {
     });
 
     watch(obj, 'someProp');
-    ok(!(hasMandatorySetter(obj, 'someProp')), 'blastix');
+    ok(!('someProp' in meta.readableValues()), 'blastix');
   });
 
   QUnit.test('sets up mandatory-setter if property comes from prototype', function() {
@@ -126,8 +129,9 @@ if (isEnabled('mandatory-setter')) {
     var obj2 = Object.create(obj);
 
     watch(obj2, 'someProp');
+    var meta = metaFor(obj2);
 
-    ok(hasMandatorySetter(obj2, 'someProp'), 'mandatory setter has been setup');
+    ok(('someProp' in meta.readableValues()), 'mandatory setter has been setup');
 
     expectAssertion(function() {
       obj2.someProp = 'foo-bar';

--- a/packages/ember-metal/tests/alias_test.js
+++ b/packages/ember-metal/tests/alias_test.js
@@ -37,9 +37,9 @@ QUnit.test('basic lifecycle', function() {
   defineProperty(obj, 'bar', alias('foo.faz'));
   var m = meta(obj);
   addObserver(obj, 'bar', incrementCount);
-  equal(m.peekDeps('foo.faz', 'bar'), 1);
+  equal(m.readableDeps('foo.faz').bar, 1);
   removeObserver(obj, 'bar', incrementCount);
-  equal(m.peekDeps('foo.faz', 'bar'), 0);
+  equal(m.readableDeps('foo.faz').bar, 0);
 });
 
 QUnit.test('old dependent keys should not trigger property changes', function() {

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -110,7 +110,7 @@ function makeCtor() {
           var value = properties[keyName];
 
           if (IS_BINDING.test(keyName)) {
-            m.writeBindings(keyName, value);
+            m.writableBindings()[keyName] = value;
           }
 
           var possibleDesc = this[keyName];

--- a/packages/ember-runtime/tests/system/array_proxy/content_change_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/content_change_test.js
@@ -17,6 +17,24 @@ QUnit.test('should update length for null content', function() {
   equal(proxy.get('length'), 0, 'length updates');
 });
 
+QUnit.test('should update length for null content when there is a computed property watching length', function() {
+  var proxy = ArrayProxy.extend({
+    isEmpty: Ember.computed.not('length')
+  }).create({
+    content: Ember.A([1, 2, 3])
+  });
+
+  equal(proxy.get('length'), 3, 'precond - length is 3');
+
+  // Consume computed property that depends on length
+  proxy.get('isEmpty');
+
+  // update content
+  proxy.set('content', null);
+
+  equal(proxy.get('length'), 0, 'length updates');
+});
+
 QUnit.test('The `arrangedContentWillChange` method is invoked before `content` is changed.', function() {
   var callCount = 0;
   var expectedLength;


### PR DESCRIPTION
Revert "Refactoring meta, part 2" from #12177 as those changes to meta resulted in a number of reported errors. This reverts the changes in that PR and lands a previously failing test from #12218 that can be used to confirm things are fixed when brought back.

/cc @ef4

Closes #12234.
Closes #12218.
