### PR TITLE
[DOC Release] Show args in Ember.observer example

### DIFF
--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -63,8 +63,9 @@ import isNone from 'ember-metal/is_none';
 
   ```javascript
   Ember.Object.extend({
-    valueObserver: Ember.observer('value', function() {
+    valueObserver: Ember.observer('value', function(sender, key, value, rev) {
       // Executes whenever the "value" property changes
+      // See the addObserver method for more information about the callback arguments
     })
   });
   ```


### PR DESCRIPTION
I couldn't find any documentation showing the arguments passed into callback method for `object.addObserver()` are also passed into the callback method for `Ember.observer()`. At the moment, someone reading about the `Ember.Observable` class would need to click into the `addObserver` method docs before seeing what kind of args might also be passed into `Ember.observer`. I believe this addition to the `Ember.observer` code sample shows what is passed into that callback method, as well as directs the reader to where they can find more information about those args. 
