### PR TITLE
[DOC release] Fix `action` helper event type example

### DIFF
--- a/packages/ember-routing-htmlbars/lib/keywords/action.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/action.js
@@ -182,7 +182,7 @@ import closureAction from 'ember-routing-htmlbars/keywords/closure-action';
   supply an `on` option to the helper to specify a different DOM event name:
 
   ```handlebars
-  <div {{action "anActionName" on="double-click"}}>
+  <div {{action "anActionName" on="doubleClick"}}>
     click me
   </div>
   ```


### PR DESCRIPTION
The event types only work if they are camel cased.
