### PR TITLE
Add debugSeal to Morphs to ensure consistent shaping.

### DIFF
--- a/packages/ember-htmlbars/lib/morphs/attr-morph.js
+++ b/packages/ember-htmlbars/lib/morphs/attr-morph.js
@@ -1,4 +1,4 @@
-import { warn } from 'ember-metal/debug';
+import { warn, debugSeal } from 'ember-metal/debug';
 import DOMHelper from 'dom-helper';
 
 var HTMLBarsAttrMorph = DOMHelper.prototype.AttrMorphClass;
@@ -13,6 +13,8 @@ let proto = HTMLBarsAttrMorph.prototype;
 
 proto.didInit = function() {
   this.streamUnsubscribers = null;
+
+  debugSeal(this);
 };
 
 function deprecateEscapedStyle(morph, value) {

--- a/packages/ember-htmlbars/lib/morphs/morph.js
+++ b/packages/ember-htmlbars/lib/morphs/morph.js
@@ -1,4 +1,5 @@
 import DOMHelper from 'dom-helper';
+import { debugSeal } from 'ember-metal/debug';
 
 var HTMLBarsMorph = DOMHelper.prototype.MorphClass;
 let guid = 1;
@@ -19,6 +20,8 @@ function EmberMorph(DOMHelper, contextualElement) {
   // one of its attributes changed, which also triggers the attribute
   // update flag (didUpdateAttrs).
   this.shouldReceiveAttrs = false;
+
+  debugSeal(this);
 }
 
 var proto = EmberMorph.prototype = Object.create(HTMLBarsMorph.prototype);


### PR DESCRIPTION
The `debugSeal` debug function is stripped in production builds so it does not affect their performance, but using it in debug builds allows us to ensure that the Morph's and AttrMorph's created by Ember are not changing shape over time.
