### PR TITLE
[BUGFIX beta] Remove double loop over attrs to create a component.

### DIFF
--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -1,5 +1,4 @@
 import { assert, warn, runInDebug } from 'ember-metal/debug';
-import assign from 'ember-metal/assign';
 import buildComponentTemplate from 'ember-views/system/build-component-template';
 import getCellOrValue from 'ember-htmlbars/hooks/get-cell-or-value';
 import { get } from 'ember-metal/property_get';
@@ -255,17 +254,14 @@ ComponentNodeManager.prototype.destroy = function ComponentNodeManager_destroy()
   component.destroy();
 };
 
-export function createComponent(_component, isAngleBracket, _props, renderNode, env, attrs = {}) {
-  let props = assign({}, _props);
-
-  let snapshot = takeSnapshot(attrs);
-  props.attrs = snapshot;
-
+export function createComponent(_component, isAngleBracket, props, renderNode, env, attrs = {}) {
   if (!isAngleBracket) {
     assert('controller= is no longer supported', !('controller' in attrs));
 
-    mergeBindings(props, snapshot);
+    snapshotAndUpdateTarget(attrs, props);
   } else {
+    props.attrs = takeSnapshot(attrs);
+
     props._isAngleBracket = true;
   }
 
@@ -311,9 +307,13 @@ export function takeLegacySnapshot(attrs) {
   return hash;
 }
 
-function mergeBindings(target, attrs) {
-  for (var prop in attrs) {
-    if (!attrs.hasOwnProperty(prop)) { continue; }
+function snapshotAndUpdateTarget(rawAttrs, target) {
+  let attrs = {};
+
+  for (var prop in rawAttrs) {
+    let value = getCellOrValue(rawAttrs[prop]);
+    attrs[prop] = value;
+
     // when `attrs` is an actual value being set in the
     // attrs hash (`{{foo-bar attrs="blah"}}`) we cannot
     // set `"blah"` to the root of the target because
@@ -322,16 +322,15 @@ function mergeBindings(target, attrs) {
       warn(`Invoking a component with a hash attribute named \`attrs\` is not supported. Please refactor usage of ${target} to avoid passing \`attrs\` as a hash parameter.`, false, { id: 'ember-htmlbars.component-unsupported-attrs' });
       continue;
     }
-    let value = attrs[prop];
 
     if (value && value[MUTABLE_CELL]) {
-      target[prop] = value.value;
-    } else {
-      target[prop] = value;
+      value = value.value;
     }
+
+    target[prop] = value;
   }
 
-  return target;
+  return target.attrs = attrs;
 }
 
 function buildChildEnv(state, env) {


### PR DESCRIPTION
Previously, we would loop over `attrs` and create additional objects for each entry then subsequently merge that "snapshot" back into a target object TWICE for initial render.

This updates to loop once over the attrs and do all the work needed in that one pass. It also avoids allocating two temporary objects and the extra `Object.assign` to merge them back into the target.

This doesn't have a giant impact on ef4/initial-render-perf (around 6%), but less work is less work and we will take any improvements we can get!
