### PR TITLE
[FEATURE ember-metal-ember-assign] Introduce Ember.assign()

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -88,3 +88,7 @@ for a detailed explanation.
 
   Implements RFC https://github.com/emberjs/rfcs/pull/38, adding support for
   routable components.
+
+* `ember-metal-ember-assign`
+
+  Add `Ember.assign` that is polyfill for `Object.assign`.

--- a/features.json
+++ b/features.json
@@ -8,6 +8,7 @@
     "ember-libraries-isregistered": null,
     "ember-debug-handlers": true,
     "ember-registry-container-reform": true,
-    "ember-routing-routable-components": null
+    "ember-routing-routable-components": null,
+    "ember-metal-ember-assign": null
   }
 }

--- a/packages/ember-htmlbars/lib/env.js
+++ b/packages/ember-htmlbars/lib/env.js
@@ -2,7 +2,7 @@ import _Ember from 'ember-metal';
 import environment from 'ember-metal/environment';
 
 import { hooks } from 'htmlbars-runtime';
-import merge from 'ember-metal/merge';
+import assign from 'ember-metal/assign';
 
 import subexpr from 'ember-htmlbars/hooks/subexpr';
 import concat from 'ember-htmlbars/hooks/concat';
@@ -36,10 +36,10 @@ import keywords, { registerKeyword } from 'ember-htmlbars/keywords';
 
 import DOMHelper from 'ember-htmlbars/system/dom-helper';
 
-var emberHooks = merge({}, hooks);
+var emberHooks = assign({}, hooks);
 emberHooks.keywords = keywords;
 
-merge(emberHooks, {
+assign(emberHooks, {
   linkRenderNode,
   createFreshScope,
   createChildScope,

--- a/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
@@ -1,4 +1,4 @@
-import merge from 'ember-metal/merge';
+import assign from 'ember-metal/assign';
 import { assert, warn } from 'ember-metal/debug';
 import buildComponentTemplate from 'ember-views/system/build-component-template';
 import { get } from 'ember-metal/property_get';
@@ -163,7 +163,7 @@ function getTemplate(componentOrView) {
 
 export function createOrUpdateComponent(component, options, createOptions, renderNode, env, attrs = {}) {
   let snapshot = takeSnapshot(attrs);
-  let props = merge({}, options);
+  let props = assign({}, options);
   let defaultController = View.proto().controller;
   let hasSuppliedController = 'controller' in attrs || 'controller' in props;
 
@@ -176,7 +176,7 @@ export function createOrUpdateComponent(component, options, createOptions, rende
     let proto = component.proto();
 
     if (createOptions) {
-      merge(props, createOptions);
+      assign(props, createOptions);
     }
 
     mergeBindings(props, snapshot);

--- a/packages/ember-htmlbars/tests/htmlbars_test.js
+++ b/packages/ember-htmlbars/tests/htmlbars_test.js
@@ -2,14 +2,14 @@ import compile from 'ember-template-compiler/system/compile';
 import defaultEnv from 'ember-htmlbars/env';
 import { domHelper } from 'ember-htmlbars/env';
 import { equalHTML } from 'htmlbars-test-helpers';
-import merge from 'ember-metal/merge';
+import assign from 'ember-metal/assign';
 
 QUnit.module('ember-htmlbars: main');
 
 QUnit.test('HTMLBars is present and can be executed', function() {
   var template = compile('ohai');
 
-  var env = merge({ dom: domHelper }, defaultEnv);
+  var env = assign({ dom: domHelper }, defaultEnv);
 
   var output = template.render({}, env, { contextualElement: document.body }).fragment;
   equalHTML(output, 'ohai');

--- a/packages/ember-metal/lib/assign.js
+++ b/packages/ember-metal/lib/assign.js
@@ -1,3 +1,20 @@
+/**
+  Copy properties from a source object to a target object.
+
+  ```javascript
+  var a = {first: 'Yehuda'};
+  var b = {last: 'Katz'};
+  var c = {company: 'Tilde Inc.'};
+  Ember.assign(a, b, c); // a === {first: 'Yehuda', last: 'Katz', company: 'Tilde Inc.'}, b === {last: 'Katz'}, c === {company: 'Tilde Inc.'}
+  ```
+
+  @method assign
+  @for Ember
+  @param {Object} original The object to assign into
+  @param {Object} ...args The objects to copy properties from
+  @return {Object}
+  @public
+*/
 export default function assign(original, ...args) {
   for (let i = 0, l = args.length; i < l; i++) {
     let arg = args[i];

--- a/packages/ember-metal/lib/main.js
+++ b/packages/ember-metal/lib/main.js
@@ -7,6 +7,7 @@
 import Ember from 'ember-metal/core';
 import { deprecateFunc } from 'ember-metal/debug';
 import isEnabled, { FEATURES } from 'ember-metal/features';
+import assign from 'ember-metal/assign';
 import merge from 'ember-metal/merge';
 import {
   instrument,
@@ -321,7 +322,12 @@ Ember.isEmpty = isEmpty;
 Ember.isBlank = isBlank;
 Ember.isPresent = isPresent;
 
-Ember.merge = merge;
+if (isEnabled('ember-metal-ember-assign')) {
+  Ember.assign = Object.assign || assign;
+  Ember.merge = merge;
+} else {
+  Ember.merge = merge;
+}
 
 Ember.FEATURES = FEATURES;
 Ember.FEATURES.isEnabled = isEnabled;

--- a/packages/ember-metal/lib/merge.js
+++ b/packages/ember-metal/lib/merge.js
@@ -1,3 +1,6 @@
+import { deprecate } from 'ember-metal/debug';
+import isEnabled from 'ember-metal/features';
+
 /**
   Merge the contents of two objects together into the first object.
 
@@ -16,6 +19,10 @@
   @public
 */
 export default function merge(original, updates) {
+  if (isEnabled('ember-metal-ember-assign')) {
+    deprecate('Usage of `Ember.merge` is deprecated, use `Ember.assign` instead.', false, { id: 'ember-metal.merge', until: '3.0.0' });
+  }
+
   if (!updates || typeof updates !== 'object') {
     return original;
   }

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -9,7 +9,7 @@
 
 import Ember from 'ember-metal/core'; // warn, assert, wrap, et;
 import { assert, deprecate, runInDebug } from 'ember-metal/debug';
-import merge from 'ember-metal/merge';
+import assign from 'ember-metal/assign';
 import EmptyObject from 'ember-metal/empty_object';
 import { get } from 'ember-metal/property_get';
 import { set, trySet } from 'ember-metal/property_set';
@@ -169,7 +169,7 @@ function applyMergedProperties(obj, key, value, values) {
 
   if (!baseValue) { return value; }
 
-  var newBase = merge({}, baseValue);
+  var newBase = assign({}, baseValue);
   var hasFunction = false;
 
   for (var prop in value) {

--- a/packages/ember-metal/lib/streams/dependency.js
+++ b/packages/ember-metal/lib/streams/dependency.js
@@ -1,5 +1,5 @@
 import { assert } from 'ember-metal/debug';
-import merge from 'ember-metal/merge';
+import assign from 'ember-metal/assign';
 import {
   read,
   setValue,
@@ -27,7 +27,7 @@ function Dependency(depender, dependee) {
   this.unsubscription = null;
 }
 
-merge(Dependency.prototype, {
+assign(Dependency.prototype, {
   subscribe() {
     assert('Dependency error: Dependency tried to subscribe while already subscribed', !this.unsubscription);
 

--- a/packages/ember-metal/lib/streams/stream.js
+++ b/packages/ember-metal/lib/streams/stream.js
@@ -1,5 +1,5 @@
 import Ember from 'ember-metal/core';
-import merge from 'ember-metal/merge';
+import assign from 'ember-metal/assign';
 import { debugSeal, assert } from 'ember-metal/debug';
 import { getFirstKey, getTailPath } from 'ember-metal/path_cache';
 import { addObserver, removeObserver } from 'ember-metal/observer';
@@ -313,7 +313,7 @@ BasicStream.extend = function(object) {
 
   Child.prototype = Object.create(this.prototype);
 
-  merge(Child.prototype, object);
+  assign(Child.prototype, object);
   Child.extend = BasicStream.extend;
   return Child;
 };

--- a/packages/ember-metal/lib/streams/subscriber.js
+++ b/packages/ember-metal/lib/streams/subscriber.js
@@ -1,4 +1,4 @@
-import merge from 'ember-metal/merge';
+import assign from 'ember-metal/assign';
 
 /**
   @module ember-metal
@@ -17,7 +17,7 @@ function Subscriber(callback, context) {
   this.context = context;
 }
 
-merge(Subscriber.prototype, {
+assign(Subscriber.prototype, {
   removeFrom(stream) {
     var next = this.next;
     var prev = this.prev;

--- a/packages/ember-metal/tests/assign_test.js
+++ b/packages/ember-metal/tests/assign_test.js
@@ -1,0 +1,20 @@
+import assign from 'ember-metal/assign';
+import isEnabled from 'ember-metal/features';
+
+QUnit.module('Ember.assign');
+
+if (isEnabled('ember-metal-ember-assign')) {
+  QUnit.test('Ember.assign', function() {
+    var a = { a: 1 };
+    var b = { b: 2 };
+    var c = { c: 3 };
+    var a2 = { a: 4 };
+
+    assign(a, b, c, a2);
+
+    deepEqual(a, { a: 4, b: 2, c: 3 });
+    deepEqual(b, { b: 2 });
+    deepEqual(c, { c: 3 });
+    deepEqual(a2, { a: 4 });
+  });
+}

--- a/packages/ember-metal/tests/features_test.js
+++ b/packages/ember-metal/tests/features_test.js
@@ -1,12 +1,12 @@
 import Ember from 'ember-metal/core';
 import isEnabled, { FEATURES } from 'ember-metal/features';
-import merge from 'ember-metal/merge';
+import assign from 'ember-metal/assign';
 
 var origFeatures, origEnableAll, origEnableOptional;
 
 QUnit.module('isEnabled', {
   setup() {
-    origFeatures = merge({}, FEATURES);
+    origFeatures = assign({}, FEATURES);
     origEnableAll = Ember.ENV.ENABLE_ALL_FEATURES;
     origEnableOptional = Ember.ENV.ENABLE_OPTIONAL_FEATURES;
   },
@@ -15,7 +15,7 @@ QUnit.module('isEnabled', {
     for (var feature in FEATURES) {
       delete FEATURES[feature];
     }
-    merge(FEATURES, origFeatures);
+    assign(FEATURES, origFeatures);
 
     Ember.ENV.ENABLE_ALL_FEATURES = origEnableAll;
     Ember.ENV.ENABLE_OPTIONAL_FEATURES = origEnableOptional;

--- a/packages/ember-metal/tests/merge_test.js
+++ b/packages/ember-metal/tests/merge_test.js
@@ -1,0 +1,12 @@
+import merge from 'ember-metal/merge';
+import isEnabled from 'ember-metal/features';
+
+QUnit.module('Ember.merge');
+
+if (isEnabled('ember-metal-ember-assign')) {
+  QUnit.test('Ember.merge should be deprecated', function() {
+    expectDeprecation(function() {
+      merge({ a: 1 }, { b: 2 });
+    }, 'Usage of `Ember.merge` is deprecated, use `Ember.assign` instead.');
+  });
+}

--- a/packages/ember-routing/lib/services/routing.js
+++ b/packages/ember-routing/lib/services/routing.js
@@ -8,7 +8,7 @@ import Service from 'ember-runtime/system/service';
 import { get } from 'ember-metal/property_get';
 import { readOnly } from 'ember-metal/computed_macros';
 import { routeArgs } from 'ember-routing/utils';
-import merge from 'ember-metal/merge';
+import assign from 'ember-metal/assign';
 
 /**
   The Routing service is used by LinkComponent, and provides facilities for
@@ -57,7 +57,7 @@ export default Service.extend({
     if (!router.router) { return; }
 
     var visibleQueryParams = {};
-    merge(visibleQueryParams, queryParams);
+    assign(visibleQueryParams, queryParams);
 
     this.normalizeQueryParams(routeName, models, visibleQueryParams);
 

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -7,7 +7,7 @@ import { set } from 'ember-metal/property_set';
 import getProperties from 'ember-metal/get_properties';
 import isNone from 'ember-metal/is_none';
 import { computed } from 'ember-metal/computed';
-import merge from 'ember-metal/merge';
+import assign from 'ember-metal/assign';
 import {
   typeOf
 } from 'ember-runtime/utils';
@@ -330,8 +330,8 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     var state = transition ? transition.state : this.router.router.state;
 
     var params = {};
-    merge(params, state.params[name]);
-    merge(params, getQueryParamsFor(route, state));
+    assign(params, state.params[name]);
+    assign(params, getQueryParamsFor(route, state));
 
     return params;
   },
@@ -2172,7 +2172,7 @@ function getFullQueryParams(router, state) {
   if (state.fullQueryParams) { return state.fullQueryParams; }
 
   state.fullQueryParams = {};
-  merge(state.fullQueryParams, state.queryParams);
+  assign(state.fullQueryParams, state.queryParams);
 
   var targetRouteName = state.handlerInfos[state.handlerInfos.length - 1].name;
   router._deserializeQueryParams(targetRouteName, state.fullQueryParams);
@@ -2238,8 +2238,8 @@ function mergeEachQueryParams(controllerQP, routeQP) {
     if (!controllerQP.hasOwnProperty(cqpName)) { continue; }
 
     var newControllerParameterConfiguration = {};
-    merge(newControllerParameterConfiguration, controllerQP[cqpName]);
-    merge(newControllerParameterConfiguration, routeQP[cqpName]);
+    assign(newControllerParameterConfiguration, controllerQP[cqpName]);
+    assign(newControllerParameterConfiguration, routeQP[cqpName]);
 
     qps[cqpName] = newControllerParameterConfiguration;
 
@@ -2253,7 +2253,7 @@ function mergeEachQueryParams(controllerQP, routeQP) {
     if (!routeQP.hasOwnProperty(rqpName) || keysAlreadyMergedOrSkippable[rqpName]) { continue; }
 
     var newRouteParameterConfiguration = {};
-    merge(newRouteParameterConfiguration, routeQP[rqpName], controllerQP[rqpName]);
+    assign(newRouteParameterConfiguration, routeQP[rqpName], controllerQP[rqpName]);
     qps[rqpName] = newRouteParameterConfiguration;
   }
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -6,7 +6,7 @@ import { set } from 'ember-metal/property_set';
 import { defineProperty } from 'ember-metal/properties';
 import EmptyObject from 'ember-metal/empty_object';
 import { computed } from 'ember-metal/computed';
-import merge from 'ember-metal/merge';
+import assign from 'ember-metal/assign';
 import run from 'ember-metal/run_loop';
 import EmberObject from 'ember-runtime/system/object';
 import Evented from 'ember-runtime/mixins/evented';
@@ -592,7 +592,7 @@ var EmberRouter = EmberObject.extend(Evented, {
     assert(`The route ${targetRouteName} was not found`, targetRouteName && this.router.hasRoute(targetRouteName));
 
     var queryParams = {};
-    merge(queryParams, _queryParams);
+    assign(queryParams, _queryParams);
     this._prepareQueryParams(targetRouteName, models, queryParams);
 
     var transitionArgs = routeArgs(targetRouteName, models, queryParams);
@@ -637,7 +637,7 @@ var EmberRouter = EmberObject.extend(Evented, {
 
       if (!qpMeta) { continue; }
 
-      merge(map, qpMeta.map);
+      assign(map, qpMeta.map);
       qps.push.apply(qps, qpMeta.qps);
     }
 

--- a/packages/ember-routing/lib/system/router_state.js
+++ b/packages/ember-routing/lib/system/router_state.js
@@ -1,7 +1,7 @@
 import isEmpty from 'ember-metal/is_empty';
 import keys from 'ember-metal/keys';
 import EmberObject from 'ember-runtime/system/object';
-import merge from 'ember-metal/merge';
+import assign from 'ember-metal/assign';
 
 var RouterState = EmberObject.extend({
   emberRouter: null,
@@ -16,7 +16,7 @@ var RouterState = EmberObject.extend({
 
     if (queryParamsMustMatch && !emptyQueryParams) {
       var visibleQueryParams = {};
-      merge(visibleQueryParams, queryParams);
+      assign(visibleQueryParams, queryParams);
 
       this.emberRouter._prepareQueryParams(routeName, models, visibleQueryParams);
       return shallowEqual(visibleQueryParams, state.queryParams);

--- a/packages/ember-routing/lib/utils.js
+++ b/packages/ember-routing/lib/utils.js
@@ -1,4 +1,4 @@
-import merge from 'ember-metal/merge';
+import assign from 'ember-metal/assign';
 import { get } from 'ember-metal/property_get';
 
 export function routeArgs(targetRouteName, models, queryParams) {
@@ -159,7 +159,7 @@ function accumulateQueryParamDescriptors(_desc, accum) {
     }
 
     tmp = accum[key] || { as: null, scope: 'model' };
-    merge(tmp, singleDesc);
+    assign(tmp, singleDesc);
 
     accum[key] = tmp;
   }

--- a/packages/ember-routing/tests/location/auto_location_test.js
+++ b/packages/ember-routing/tests/location/auto_location_test.js
@@ -1,6 +1,6 @@
 import { get } from 'ember-metal/property_get';
 import run from 'ember-metal/run_loop';
-import merge from 'ember-metal/merge';
+import assign from 'ember-metal/assign';
 import AutoLocation from 'ember-routing/location/auto_location';
 import {
   getHistoryPath,
@@ -13,7 +13,7 @@ import Registry from 'container/registry';
 
 
 function mockBrowserLocation(overrides) {
-  return merge({
+  return assign({
     href: 'http://test.com/',
     pathname: '/',
     hash: '',
@@ -25,7 +25,7 @@ function mockBrowserLocation(overrides) {
 }
 
 function mockBrowserHistory(overrides) {
-  return merge({
+  return assign({
     pushState() {
       ok(false, 'history.pushState should not be called during testing');
     },

--- a/packages/ember-routing/tests/location/util_test.js
+++ b/packages/ember-routing/tests/location/util_test.js
@@ -1,4 +1,4 @@
-import merge from 'ember-metal/merge';
+import assign from 'ember-metal/assign';
 import {
   replacePath,
   getPath,
@@ -11,7 +11,7 @@ import {
 } from 'ember-routing/location/util';
 
 function mockBrowserLocation(overrides) {
-  return merge({
+  return assign({
     href: 'http://test.com/',
     pathname: '/',
     hash: '',

--- a/packages/ember-routing/tests/system/router_test.js
+++ b/packages/ember-routing/tests/system/router_test.js
@@ -1,4 +1,4 @@
-import merge from 'ember-metal/merge';
+import assign from 'ember-metal/assign';
 import Registry from 'container/registry';
 import HashLocation from 'ember-routing/location/hash_location';
 import HistoryLocation from 'ember-routing/location/history_location';
@@ -10,7 +10,7 @@ import { runDestroy } from 'ember-runtime/tests/utils';
 var registry, container;
 
 function createRouter(overrides, disableSetup) {
-  var opts = merge({ container: container }, overrides);
+  var opts = assign({ container: container }, overrides);
   var routerWithContainer = Router.extend();
   var router = routerWithContainer.create(opts);
 

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -12,7 +12,7 @@
 import Ember from 'ember-metal';
 import { assert, runInDebug } from 'ember-metal/debug';
 import isEnabled from 'ember-metal/features';
-import merge from 'ember-metal/merge';
+import assign from 'ember-metal/assign';
 
 // NOTE: this object should never be included directly. Instead use `Ember.Object`.
 // We only define this separately so that `Ember.Set` can depend on it.
@@ -155,7 +155,7 @@ function makeCtor() {
               mergedProperties.indexOf(keyName) >= 0) {
             var originalValue = this[keyName];
 
-            value = merge(originalValue, value);
+            value = assign(originalValue, value);
           }
 
           if (desc) {

--- a/packages/ember-views/lib/views/states.js
+++ b/packages/ember-views/lib/views/states.js
@@ -1,4 +1,4 @@
-import merge from 'ember-metal/merge';
+import assign from 'ember-metal/assign';
 import _default from 'ember-views/views/states/default';
 import preRender from 'ember-views/views/states/pre_render';
 import hasElement from 'ember-views/views/states/has_element';
@@ -16,7 +16,7 @@ export function cloneStates(from) {
 
   for (var stateName in from) {
     if (!from.hasOwnProperty(stateName)) { continue; }
-    merge(into[stateName], from[stateName]);
+    assign(into[stateName], from[stateName]);
   }
 
   return into;

--- a/packages/ember-views/lib/views/states/destroying.js
+++ b/packages/ember-views/lib/views/states/destroying.js
@@ -1,4 +1,4 @@
-import merge from 'ember-metal/merge';
+import assign from 'ember-metal/assign';
 import _default from 'ember-views/views/states/default';
 import EmberError from 'ember-metal/error';
 /**
@@ -8,7 +8,7 @@ import EmberError from 'ember-metal/error';
 
 var destroying = Object.create(_default);
 
-merge(destroying, {
+assign(destroying, {
   appendChild() {
     throw new EmberError('You can\'t call appendChild on a view being destroyed');
   },

--- a/packages/ember-views/lib/views/states/has_element.js
+++ b/packages/ember-views/lib/views/states/has_element.js
@@ -1,5 +1,5 @@
 import _default from 'ember-views/views/states/default';
-import merge from 'ember-metal/merge';
+import assign from 'ember-metal/assign';
 import jQuery from 'ember-views/system/jquery';
 import run from 'ember-metal/run_loop';
 
@@ -13,7 +13,7 @@ import { internal } from 'htmlbars-runtime';
 
 var hasElement = Object.create(_default);
 
-merge(hasElement, {
+assign(hasElement, {
   $(view, sel) {
     var elem = view.element;
     return sel ? jQuery(sel, elem) : jQuery(elem);

--- a/packages/ember-views/lib/views/states/in_dom.js
+++ b/packages/ember-views/lib/views/states/in_dom.js
@@ -1,5 +1,5 @@
 import { runInDebug } from 'ember-metal/debug';
-import merge from 'ember-metal/merge';
+import assign from 'ember-metal/assign';
 import EmberError from 'ember-metal/error';
 import { _addBeforeObserver } from 'ember-metal/observer';
 
@@ -11,7 +11,7 @@ import hasElement from 'ember-views/views/states/has_element';
 
 var inDOM = Object.create(hasElement);
 
-merge(inDOM, {
+assign(inDOM, {
   enter(view) {
     // Register the view for event handling. This hash is used by
     // Ember.EventDispatcher to dispatch incoming events.

--- a/packages/ember-views/lib/views/states/pre_render.js
+++ b/packages/ember-views/lib/views/states/pre_render.js
@@ -1,5 +1,5 @@
 import _default from 'ember-views/views/states/default';
-import merge from 'ember-metal/merge';
+import assign from 'ember-metal/assign';
 
 /**
 @module ember
@@ -8,7 +8,7 @@ import merge from 'ember-metal/merge';
 
 let preRender = Object.create(_default);
 
-merge(preRender, {
+assign(preRender, {
   legacyPropertyDidChange(view, key) {}
 });
 


### PR DESCRIPTION
`Ember.assign()` is discussed in https://github.com/emberjs/ember.js/pull/11978 .
- [x] Add feature flagging for the API addition
- [x] Add a test for the deprecation of `Ember.merge` when the flag is enabled
- [x] Add some cursory tests for `ember-metal/assign` (doesn't need to be complicated, but I noticed no tests were tweaked/changed for `merge` or `assign` and figured we probably want some to exist).
- [x] We should use `Object.assign` if it exists (making our `Ember.assign` a straight up polyfill).
