### PR TITLE
[closes #12304] marginally faster dictionary creation.

### DIFF
--- a/packages/ember-metal/lib/dictionary.js
+++ b/packages/ember-metal/lib/dictionary.js
@@ -1,3 +1,4 @@
+import EmptyObject from './empty_object';
 
 // the delete is meant to hint at runtimes that this object should remain in
 // dictionary mode. This is clearly a runtime specific hack, but currently it
@@ -5,7 +6,14 @@
 // the cost of creation dramatically over a plain Object.create. And as this
 // only makes sense for long-lived dictionaries that aren't instantiated often.
 export default function makeDictionary(parent) {
-  var dict = Object.create(parent);
+  var dict;
+
+  if (arguments.length === 0 || parent === null) {
+    dict = new EmptyObject();
+  } else {
+    dict = Object.create(parent);
+  }
+
   dict['_dict'] = null;
   delete dict['_dict'];
   return dict;


### PR DESCRIPTION
on chrome 47:

```
makeDictionary(null) ..................... 2,390,190.74 op/s
makeDictionaryWithEmptyObject ............ 3,377,259.20 op/s
```

---

Safari: Version 8.0.7 (10600.7.12)

```
makeDictionary(null) ..................... 1,606,191.49 op/s
makeDictionaryWithEmptyObject ............ 1,595,042.30 op/s
```

---

Saf Version 8.0.7 (10600.7.12, r189464)

```
makeDictionary(null) ..................... 2,460,767.99 op/s
makeDictionaryWithEmptyObject ............ 3,182,898.12 op/s
```

---

FF 43.0a1 (2015-08-18)

```
makeDictionary(null) ..................... 8,872,924.67 op/s
makeDictionaryWithEmptyObject ............ 8,665,248.18 op/s
```
