### PR TITLE
[BUGFIX beta] Prevent sending undefined views

### DIFF
--- a/packages/ember-views/lib/mixins/legacy_view_support.js
+++ b/packages/ember-views/lib/mixins/legacy_view_support.js
@@ -21,8 +21,10 @@ var LegacyViewSupport = Mixin.create({
 
     while (childViews.length) {
       var view = childViews.pop();
-      callback(view);
-      childViews.push(...view.childViews);
+      if (view) {
+        callback(view);
+        childViews.push(...view.childViews);
+      }
     }
   },
 


### PR DESCRIPTION
Only allow a valid `view` to be passed in. 

Fixes `view is undefined` error when eventually calling `_legacyControllerDidChange` as mentioned in issue: https://github.com/emberjs/ember.js/issues/12016

This affects Ember 2.0.0 and up.
