### PR TITLE
Use `Cache` for tagname operations.

### DIFF
--- a/packages/ember-htmlbars/lib/hooks/component.js
+++ b/packages/ember-htmlbars/lib/hooks/component.js
@@ -2,6 +2,15 @@ import { assert } from 'ember-metal/debug';
 import ComponentNodeManager from 'ember-htmlbars/node-managers/component-node-manager';
 import buildComponentTemplate, { buildHTMLTemplate } from 'ember-views/system/build-component-template';
 import lookupComponent from 'ember-htmlbars/utils/lookup-component';
+import Cache from 'ember-metal/cache';
+
+var IS_ANGLE_CACHE = new Cache(1000, function(key) {
+  return key.match(/^(@?)<(.*)>$/);
+});
+
+var CONTAINS_DASH = new Cache(1000, function(key) {
+  return key.indexOf('-') !== -1;
+});
 
 export default function componentHook(renderNode, env, scope, _tagName, params, attrs, templates, visitor) {
   var state = renderNode.getState();
@@ -17,7 +26,7 @@ export default function componentHook(renderNode, env, scope, _tagName, params, 
   let isTopLevel = false;
   let isDasherized = false;
 
-  let angles = tagName.match(/^(@?)<(.*)>$/);
+  let angles = IS_ANGLE_CACHE.get(tagName);
 
   if (angles) {
     tagName = angles[2];
@@ -25,7 +34,7 @@ export default function componentHook(renderNode, env, scope, _tagName, params, 
     isTopLevel = !!angles[1];
   }
 
-  if (tagName.indexOf('-') !== -1) {
+  if (CONTAINS_DASH.get(tagName)) {
     isDasherized = true;
   }
 

--- a/packages/ember-metal/lib/cache.js
+++ b/packages/ember-metal/lib/cache.js
@@ -1,8 +1,8 @@
-import dictionary from 'ember-metal/dictionary';
+import EmptyObject from 'ember-metal/empty_object';
 export default Cache;
 
 function Cache(limit, func) {
-  this.store  = dictionary(null);
+  this.store  = new EmptyObject();
   this.size   = 0;
   this.misses = 0;
   this.hits   = 0;
@@ -44,7 +44,7 @@ Cache.prototype = {
   },
 
   purge() {
-    this.store  = dictionary(null);
+    this.store  = new EmptyObject();
     this.size   = 0;
     this.hits   = 0;
     this.misses = 0;


### PR DESCRIPTION
- Avoid running a regexp match against the same string many times.
- Avoid searching the same string for a dash many times.
- Change `Cache` to use `new EmptyObject()` since we do not need `delete` support, we don't need to force into "slow mode"

---

Timing shows a small improvement (tested against ef4/initial-render-perf):

Before: 164ms average (for 10 runs)
After: 159ms average (for 10 runs)
