### PR TITLE
Update API docs for `computed`

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -526,7 +526,7 @@ ComputedPropertyPrototype.teardown = function(obj, keyName) {
     firstName: 'Betty',
     lastName: 'Jones',
 
-    fullName: Ember.computed('firstName', 'lastName', function(key, value) {
+    fullName: Ember.computed('firstName', 'lastName', function() {
       return this.get('firstName') + ' ' + this.get('lastName');
     })
   });


### PR DESCRIPTION
This example was showing the old-style computed property arguments, which were deprecated before 2.0.
