### PR TITLE
Adds test for Ember.copy on an array

### DIFF
--- a/packages/ember-runtime/tests/core/copy_test.js
+++ b/packages/ember-runtime/tests/core/copy_test.js
@@ -22,3 +22,10 @@ QUnit.test('Ember.copy null prototype object', function() {
 
   equal(copy(obj).foo, 'bar', 'bar should still be bar');
 });
+
+QUnit.test('Ember.copy Array', function() {
+  var array = [1, null, new Date(2015, 9, 9), 'four'];
+  var arrayCopy = copy(array);
+
+  deepEqual(array, arrayCopy, 'array content cloned successfully in new array');
+});


### PR DESCRIPTION
This PR adds test coverage for `Ember.copy` when copying an Array. The current `copy_test.js` was passing when I commented out line 26 of `packages/ember-runtime/lib/copy.js`:

``` javascript
ret = obj.slice();
```

I thought it should have failed, but then realized that there wasn't enough coverage, so this PR attempts to fix that.
