### PR TITLE
Ensure attributeBindings work when legacy view addon is disabled.

### DIFF
--- a/packages/ember-views/lib/system/build-component-template.js
+++ b/packages/ember-views/lib/system/build-component-template.js
@@ -1,7 +1,6 @@
 import { assert, deprecate } from 'ember-metal/debug';
 import { get } from 'ember-metal/property_get';
 import assign from 'ember-metal/assign';
-import { isGlobal } from 'ember-metal/path_cache';
 import { internal, render } from 'htmlbars-runtime';
 import getValue from 'ember-htmlbars/hooks/get-value';
 import { isStream } from 'ember-metal/streams/utils';
@@ -280,8 +279,7 @@ function normalizeClasses(classes, output, streamBasePath) {
       continue;
     }
 
-    // 2.0TODO: Remove deprecated global path
-    var prop = isGlobal(propName) ? propName : `${streamBasePath}${propName}`;
+    var prop = `${streamBasePath}${propName}`;
 
     output.push(['subexpr', '-normalize-class', [
       // params

--- a/packages/ember-views/lib/system/build-component-template.js
+++ b/packages/ember-views/lib/system/build-component-template.js
@@ -158,6 +158,7 @@ function tagNameFor(view) {
 function normalizeComponentAttributes(component, isAngleBracket, attrs) {
   var normalized = {};
   var attributeBindings = component.attributeBindings;
+  var streamBasePath = component.isComponent ? '' : 'view.';
   var i, l;
 
   if (attrs.id && getValue(attrs.id)) {
@@ -177,7 +178,7 @@ function normalizeComponentAttributes(component, isAngleBracket, attrs) {
       if (colonIndex !== -1) {
         var attrProperty = attr.substring(0, colonIndex);
         attrName = attr.substring(colonIndex + 1);
-        expression = ['get', 'view.' + attrProperty];
+        expression = ['get', `${streamBasePath}${attrProperty}`];
       } else if (attrs[attr]) {
         // TODO: For compatibility with 1.x, we probably need to `set`
         // the component's attribute here if it is a CP, but we also
@@ -187,7 +188,7 @@ function normalizeComponentAttributes(component, isAngleBracket, attrs) {
         expression = ['value', attrs[attr]];
       } else {
         attrName = attr;
-        expression = ['get', 'view.' + attr];
+        expression = ['get', `${streamBasePath}${attr}`];
       }
 
       assert('You cannot use class as an attributeBinding, use classNameBindings instead.', attrName !== 'class');
@@ -211,7 +212,7 @@ function normalizeComponentAttributes(component, isAngleBracket, attrs) {
     component.tagName = attrs.tagName;
   }
 
-  var normalizedClass = normalizeClass(component, attrs);
+  var normalizedClass = normalizeClass(component, attrs, streamBasePath);
 
   if (normalizedClass) {
     normalized.class = normalizedClass;
@@ -231,7 +232,7 @@ function normalizeComponentAttributes(component, isAngleBracket, attrs) {
   return normalized;
 }
 
-function normalizeClass(component, attrs) {
+function normalizeClass(component, attrs, streamBasePath) {
   var i, l;
   var normalizedClass = [];
   var classNames = get(component, 'classNames');
@@ -246,7 +247,7 @@ function normalizeClass(component, attrs) {
   }
 
   if (attrs.classBinding) {
-    normalizeClasses(attrs.classBinding.split(' '), normalizedClass);
+    normalizeClasses(attrs.classBinding.split(' '), normalizedClass, streamBasePath);
   }
 
   if (classNames) {
@@ -256,7 +257,7 @@ function normalizeClass(component, attrs) {
   }
 
   if (classNameBindings) {
-    normalizeClasses(classNameBindings, normalizedClass);
+    normalizeClasses(classNameBindings, normalizedClass, streamBasePath);
   }
 
   if (normalizeClass.length) {
@@ -264,7 +265,7 @@ function normalizeClass(component, attrs) {
   }
 }
 
-function normalizeClasses(classes, output) {
+function normalizeClasses(classes, output, streamBasePath) {
   var i, l;
 
   for (i = 0, l = classes.length; i < l; i++) {
@@ -280,7 +281,7 @@ function normalizeClasses(classes, output) {
     }
 
     // 2.0TODO: Remove deprecated global path
-    var prop = isGlobal(propName) ? propName : 'view.' + propName;
+    var prop = isGlobal(propName) ? propName : `${streamBasePath}${propName}`;
 
     output.push(['subexpr', '-normalize-class', [
       // params


### PR DESCRIPTION
When the `_Ember.ENV._LEGACY_VIEW_SUPPORT` flag is falsey, the `view` stream is not setup as of 6963750. This resulted in anything added in `attributeBindings` being `undefined` (because the attribute binding system was essentially using `href=view.href` instead of `href=this.href` or just `href=href`).

You might thing (as I did initially): "HOW CAN WE NOT HAVE A SINGLE TEST THAT CHECKS FOR AN ATTRIBUTE VALUE?!?!?!?", and the answer is somewhat more disconcerting.  We currently run all tests with the legacy view and controller flags set to `true`. :(

Future test refactoring efforts will be needed to fix that mistake.

---

Fixes https://github.com/emberjs/ember.js/issues/12302.
