### PR TITLE
Update jQuery to 2.2.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/emberjs/ember.js.git"
   },
   "dependencies": {
-    "jquery": "~1.11.1",
+    "jquery": "~2.2.0",
     "qunit": "~1.20.0",
     "qunit-phantom-runner": "jonkemp/qunit-phantomjs-runner#1.2.0"
   },


### PR DESCRIPTION
Related: ember-cli/ember-cli#4670

As noted in that PR, the only difference between jQuery 2.x and 1.x is dropped support for IE 6, 7, and 8, which Ember 2.x does not support either.
