### PR TITLE
Update dag-map.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "backburner": "https://github.com/ebryn/backburner.js.git#ea82b6d703a7b65b4c4c65671843edb8d67f2a6c",
     "rsvp": "https://github.com/tildeio/rsvp.js.git#3.0.20",
     "router.js": "https://github.com/tildeio/router.js.git#ed45bc5c5e055af0ab875ef2c52feda792ee23e4",
-    "dag-map": "https://github.com/krisselden/dag-map.git#e307363256fe918f426e5a646cb5f5062d3245be",
+    "dag-map": "https://github.com/krisselden/dag-map.git#1.0.2",
     "ember-dev": "https://github.com/emberjs/ember-dev.git#eace5340485bdb5e4223ab67fecf4aff31c1940c"
   }
 }


### PR DESCRIPTION
We're using an old version of `dag-map`. There are no real feature changes in this time period, just tooling. This simply bumps the dependency to `HEAD`.
