### PR TITLE
IE8 Fix for host object array filter

### DIFF
--- a/packages/ember-metal/lib/array.js
+++ b/packages/ember-metal/lib/array.js
@@ -101,7 +101,7 @@ var filter = defineNativeShim(ArrayPrototype.filter, function(fn, context) {
   var length = this.length;
 
   for (i = 0; i < length; i++) {
-    if (this.hasOwnProperty(i)) {
+    if (Object.prototype.hasOwnProperty.call(this, i)) {
       value = this[i];
       if (fn.call(context, value, i, this)) {
         result.push(value);


### PR DESCRIPTION
[BUGFIX release-1-13] IE8 doesn't define hasOwnProperty for host objects, So execution of  `Array.prototype.filter.call(document.getElementsByTagName('li'),function(){return true});` causes `Object doesn't support property or method 'hasOwnProperty'` error.
