### PR TITLE
[DOC beta] Update documentation for container-registry-reform feature.

### DIFF
--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -1,7 +1,6 @@
 /**
 @module ember
 @submodule ember-application
-@private
 */
 
 import { deprecate } from 'ember-metal/debug';
@@ -37,6 +36,10 @@ import assign from 'ember-metal/assign';
   it once the particular test run or FastBoot request has finished.
 
   @public
+  @class Ember.ApplicationInstance
+  @extends Ember.Object
+  @uses RegistryProxyMixin
+  @uses ContainerProxyMixin
 */
 
 let ApplicationInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -175,7 +175,7 @@ var librariesRegistered = false;
   });
   ```
 
-  Initializers provide an opportunity to access the container, which
+  Initializers provide an opportunity to access the internal registry, which
   organizes the different components of an Ember application. Additionally
   they provide a chance to access the instantiated application. Beyond
   being used for libraries, initializers are also a great way to organize
@@ -208,6 +208,7 @@ var librariesRegistered = false;
   @class Application
   @namespace Ember
   @extends Ember.Namespace
+  @uses RegistryProxyMixin
   @public
 */
 

--- a/packages/ember-extension-support/lib/container_debug_adapter.js
+++ b/packages/ember-extension-support/lib/container_debug_adapter.js
@@ -36,7 +36,7 @@ import EmberObject from 'ember-runtime/system/object';
   Application.initializer({
     name: "containerDebugAdapter",
 
-    initialize: function(container, application) {
+    initialize: function(application) {
       application.register('container-debug-adapter:main', require('app/container-debug-adapter'));
     }
   });

--- a/packages/ember-extension-support/lib/data_adapter.js
+++ b/packages/ember-extension-support/lib/data_adapter.js
@@ -42,7 +42,7 @@ import Application from 'ember-application/system/application';
   Application.initializer({
     name: "data-adapter",
 
-    initialize: function(container, application) {
+    initialize: function(application) {
       application.register('data-adapter:main', DS.DataAdapter);
     }
   });

--- a/packages/ember-runtime/lib/mixins/container_proxy.js
+++ b/packages/ember-runtime/lib/mixins/container_proxy.js
@@ -1,6 +1,14 @@
 import run from 'ember-metal/run_loop';
 import { Mixin } from 'ember-metal/mixin';
 
+
+/**
+  ContainerProxyMixin is used to provide public access to specific
+  container functionality.
+
+  @class ContainerProxyMixin
+  @public
+*/
 export default Mixin.create({
   /**
    The container stores state.

--- a/packages/ember-runtime/lib/mixins/registry_proxy.js
+++ b/packages/ember-runtime/lib/mixins/registry_proxy.js
@@ -1,6 +1,18 @@
+/**
+@module ember
+@submodule ember-runtime
+*/
+
 import { deprecate } from 'ember-metal/debug';
 import { Mixin } from 'ember-metal/mixin';
 
+/**
+  RegistryProxyMixin is used to provide public access to specific
+  registry functionality.
+
+  @class RegistryProxyMixin
+  @public
+*/
 export default Mixin.create({
   __registry__: null,
 
@@ -67,7 +79,6 @@ export default Mixin.create({
     App.register('session', App.session, { instantiate: false });
     ```
 
-    @public
     @method register
     @param  fullName {String} type:name (e.g., 'model:user')
     @param  factory {Function} (e.g., App.Person)


### PR DESCRIPTION
Addresses parts of #12336.

/cc @mixonic

---
### Ember.Application Docs

`Ember.Application` header:

![screenshot](https://monosnap.com/file/YQsewaqY9J32RlcEsnGacPIA2lPWWp.png)

`Ember.Application` methods list, including `RegistryProxyMixin` methods:

![screenshot](https://monosnap.com/file/yZZJJ8Oo6vTvCN8WdQVZjHpnlLGLTD.png)

`Ember.Application#inject` documentation:

![screenshot](https://monosnap.com/file/DoyzK3hzgWaBiD6EpeMgKXMGEHsFeg.png)
### Ember.ApplicationInstance Docs

`Ember.ApplicationInstance` header:

![screenshot](https://monosnap.com/file/eXOw1TgDSZ0jYkiIm7L2LC0yORvNPg.png)

`Ember.ApplicationInstance` methods list, including `RegistryProxyMixin` and `ContainerProxyMixin` methods:

![screenshot](https://monosnap.com/file/q9cvcU0vfGKu71la3SEVzKMnIQl7mU.png)

`Ember.ApplicationInstance#lookup` documentation:

![screenshot](https://monosnap.com/file/9gswoTZ7hNC43kc5W5ZLmBqVgdGXu1.png)
