### PR TITLE
[DOC beta] Make ContainerProxyMixin and RegistryProxyMixin private.

### DIFF
--- a/packages/ember-runtime/lib/mixins/container_proxy.js
+++ b/packages/ember-runtime/lib/mixins/container_proxy.js
@@ -1,3 +1,7 @@
+/**
+@module ember
+@submodule ember-runtime
+*/
 import run from 'ember-metal/run_loop';
 import { Mixin } from 'ember-metal/mixin';
 
@@ -7,7 +11,7 @@ import { Mixin } from 'ember-metal/mixin';
   container functionality.
 
   @class ContainerProxyMixin
-  @public
+  @private
 */
 export default Mixin.create({
   /**

--- a/packages/ember-runtime/lib/mixins/registry_proxy.js
+++ b/packages/ember-runtime/lib/mixins/registry_proxy.js
@@ -11,7 +11,7 @@ import { Mixin } from 'ember-metal/mixin';
   registry functionality.
 
   @class RegistryProxyMixin
-  @public
+  @private
 */
 export default Mixin.create({
   __registry__: null,


### PR DESCRIPTION
Leaves the methods on them as public, but not the classes themselves.
