### PR TITLE
[DOC release] Update ember-metal/is_present.js example return value to true for cases where input value is false.

### DIFF
--- a/packages/ember-metal/lib/is_present.js
+++ b/packages/ember-metal/lib/is_present.js
@@ -11,7 +11,7 @@ import isBlank from 'ember-metal/is_blank';
   Ember.isPresent([]);              // false
   Ember.isPresent('\n\t');          // false
   Ember.isPresent('  ');            // false
-  Ember.isPresent(false);           // true 
+  Ember.isPresent(false);           // true
   Ember.isPresent({});              // true
   Ember.isPresent('\n\t Hello');    // true
   Ember.isPresent('Hello world');   // true

--- a/packages/ember-metal/lib/is_present.js
+++ b/packages/ember-metal/lib/is_present.js
@@ -8,13 +8,17 @@ import isBlank from 'ember-metal/is_blank';
   Ember.isPresent(null);            // false
   Ember.isPresent(undefined);       // false
   Ember.isPresent('');              // false
-  Ember.isPresent([]);              // false
-  Ember.isPresent('\n\t');          // false
   Ember.isPresent('  ');            // false
+  Ember.isPresent('\n\t');          // false
+  Ember.isPresent([]);              // false
+  Ember.isPresent({ length: 0 })    // false
   Ember.isPresent(false);           // true
+  Ember.isPresent(true);            // true
+  Ember.isPresent('string');        // true
+  Ember.isPresent(0);               // true
+  Ember.isPresent(function() {})    // true
   Ember.isPresent({});              // true
   Ember.isPresent('\n\t Hello');    // true
-  Ember.isPresent('Hello world');   // true
   Ember.isPresent([1,2,3]);         // true
   ```
 

--- a/packages/ember-metal/lib/is_present.js
+++ b/packages/ember-metal/lib/is_present.js
@@ -7,11 +7,11 @@ import isBlank from 'ember-metal/is_blank';
   Ember.isPresent();                // false
   Ember.isPresent(null);            // false
   Ember.isPresent(undefined);       // false
-  Ember.isPresent(false);           // false
   Ember.isPresent('');              // false
   Ember.isPresent([]);              // false
   Ember.isPresent('\n\t');          // false
   Ember.isPresent('  ');            // false
+  Ember.isPresent(false);           // true 
   Ember.isPresent({});              // true
   Ember.isPresent('\n\t Hello');    // true
   Ember.isPresent('Hello world');   // true


### PR DESCRIPTION
The current return value when calling `Ember.isPresent` with `false` as a parameter is `true`. The goal here is to update the docs such that the examples given are brought back in line with the actual behaviour.
