### PR TITLE
[BUGFIX release-1-13] Allow current-when to be specified via a variable

### DIFF
--- a/packages/ember-routing-views/lib/views/link.js
+++ b/packages/ember-routing-views/lib/views/link.js
@@ -6,12 +6,12 @@
 import Ember from "ember-metal/core"; // FEATURES, Logger, assert
 
 import { get } from "ember-metal/property_get";
-import { set } from "ember-metal/property_set";
 import { computed } from "ember-metal/computed";
 import { isSimpleClick } from "ember-views/system/utils";
 import EmberComponent from "ember-views/views/component";
 import inject from "ember-runtime/inject";
 import ControllerMixin from "ember-runtime/mixins/controller";
+import getValue from 'ember-htmlbars/hooks/get-value';
 
 import linkToTemplate from "ember-htmlbars/templates/link-to";
 linkToTemplate.meta.revision = 'Ember@VERSION_STRING_PLACEHOLDER';
@@ -408,19 +408,11 @@ var LinkComponent = EmberComponent.extend({
       queryParams = {};
     }
 
-    if (attrs.disabledClass) {
-      this.set('disabledClass', attrs.disabledClass);
-    }
-
-    if (attrs.activeClass) {
-      this.set('activeClass', attrs.activeClass);
-    }
-
     if (attrs.disabledWhen) {
-      this.set('disabled', attrs.disabledWhen);
+      this.set('disabled', getValue(attrs.disabledWhen));
     }
 
-    var currentWhen = attrs['current-when'];
+    var currentWhen = getValue(attrs['current-when']);
 
     if (attrs.currentWhen) {
       Ember.deprecate('Using currentWhen with {{link-to}} is deprecated in favor of `current-when`.', !attrs.currentWhen);
@@ -434,10 +426,6 @@ var LinkComponent = EmberComponent.extend({
     // TODO: Change to built-in hasBlock once it's available
     if (!attrs.hasBlock) {
       this.set('linkTitle', params.shift());
-    }
-
-    if (attrs.loadingClass) {
-      set(this, 'loadingClass', attrs.loadingClass);
     }
 
     for (let i = 0; i < params.length; i++) {

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -250,6 +250,27 @@ QUnit.test("the {{link-to}} helper supports a custom disabledClass", function ()
 
 });
 
+QUnit.test("the {{link-to}} helper supports a custom disabledClass set via bound param", function () {
+  Ember.TEMPLATES.index = compile('{{#link-to "about" id="about-link" disabledWhen=true disabledClass=disabledClass}}About{{/link-to}}');
+
+  Router.map(function() {
+    this.route("about");
+  });
+
+  App.IndexController = Ember.Controller.extend({
+    disabledClass: 'do-not-want'
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/");
+  });
+
+  equal(Ember.$('#about-link.do-not-want', '#qunit-fixture').length, 1, "The link can apply a custom disabled class");
+
+});
+
 QUnit.test("the {{link-to}} helper does not respond to clicks when disabled", function () {
   Ember.TEMPLATES.index = compile('{{#link-to "about" id="about-link" disabledWhen=true}}About{{/link-to}}');
 
@@ -270,11 +291,57 @@ QUnit.test("the {{link-to}} helper does not respond to clicks when disabled", fu
   equal(Ember.$('h3:contains(About)', '#qunit-fixture').length, 0, "Transitioning did not occur");
 });
 
+QUnit.test("the {{link-to}} helper does not respond to clicks when disabled via a bound param", function () {
+  Ember.TEMPLATES.index = compile('{{#link-to "about" id="about-link" disabledWhen=disabledWhen}}About{{/link-to}}');
+
+  Router.map(function() {
+    this.route("about");
+  });
+
+  App.IndexController = Ember.Controller.extend({
+    disabledWhen: true
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/");
+  });
+
+  Ember.run(function() {
+    Ember.$('#about-link', '#qunit-fixture').click();
+  });
+
+  equal(Ember.$('h3:contains(About)', '#qunit-fixture').length, 0, "Transitioning did not occur");
+});
+
 QUnit.test("The {{link-to}} helper supports a custom activeClass", function() {
   Ember.TEMPLATES.index = compile("<h3>Home</h3>{{#link-to 'about' id='about-link'}}About{{/link-to}}{{#link-to 'index' id='self-link' activeClass='zomg-active'}}Self{{/link-to}}");
 
   Router.map(function() {
     this.route("about");
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/");
+  });
+
+  equal(Ember.$('h3:contains(Home)', '#qunit-fixture').length, 1, "The home template was rendered");
+  equal(Ember.$('#self-link.zomg-active', '#qunit-fixture').length, 1, "The self-link was rendered with active class");
+  equal(Ember.$('#about-link:not(.active)', '#qunit-fixture').length, 1, "The other link was rendered without active class");
+});
+
+QUnit.test("The {{link-to}} helper supports a custom activeClass from a bound param", function() {
+  Ember.TEMPLATES.index = compile("<h3>Home</h3>{{#link-to 'about' id='about-link'}}About{{/link-to}}{{#link-to 'index' id='self-link' activeClass=activeClass}}Self{{/link-to}}");
+
+  Router.map(function() {
+    this.route("about");
+  });
+
+  App.IndexController = Ember.Controller.extend({
+    activeClass: 'zomg-active'
   });
 
   bootApplication();
@@ -398,6 +465,33 @@ QUnit.test("The {{link-to}} helper does not disregard current-when when it is gi
   });
 
   equal(Ember.$('#other-link.active', '#qunit-fixture').length, 1, "The link is active when current-when is given for explicitly for a resource");
+});
+
+QUnit.test("The {{link-to}} helper does not disregard current-when when it is set via a bound param", function() {
+  Router.map(function(match) {
+    this.resource("index", { path: "/" }, function() {
+      this.route("about");
+    });
+
+    this.resource("items", function() {
+      this.route('item');
+    });
+  });
+
+  App.IndexAboutController = Ember.Controller.extend({
+    currentWhen: 'index'
+  });
+
+  Ember.TEMPLATES.index = compile("<h3>Home</h3>{{outlet}}");
+  Ember.TEMPLATES['index/about'] = compile("{{#link-to 'items' id='other-link' current-when=currentWhen}}ITEM{{/link-to}}");
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/about");
+  });
+
+  equal(Ember.$('#other-link.active', '#qunit-fixture').length, 1, "The link is active when current-when is set via a bound param");
 });
 
 QUnit.test("The {{link-to}} helper supports multiple current-when routes", function() {
@@ -793,13 +887,14 @@ QUnit.test("link-to with null/undefined dynamic parameters are put in a loading 
   var oldWarn = Ember.Logger.warn;
   var warnCalled = false;
   Ember.Logger.warn = function() { warnCalled = true; };
-  Ember.TEMPLATES.index = compile("{{#link-to destinationRoute routeContext loadingClass='i-am-loading' id='context-link'}}string{{/link-to}}{{#link-to secondRoute loadingClass='i-am-loading' id='static-link'}}string{{/link-to}}");
+  Ember.TEMPLATES.index = compile("{{#link-to destinationRoute routeContext loadingClass='i-am-loading' id='context-link'}}string{{/link-to}}{{#link-to secondRoute loadingClass=loadingClass id='static-link'}}string{{/link-to}}");
 
   var thing = Ember.Object.create({ id: 123 });
 
   App.IndexController = Ember.Controller.extend({
     destinationRoute: null,
-    routeContext: null
+    routeContext: null,
+    loadingClass: 'i-am-loading'
   });
 
   App.AboutRoute = Ember.Route.extend({


### PR DESCRIPTION
Per guidance from @stefanpenner this fixes the issue where we are not able to set `current-when` to a variable property in 1.13.

Fixes #12296
