### PR TITLE
[BUGFIX release-1-13] Make type attr on inputs immutable for IE8

### DIFF
--- a/packages/ember-htmlbars/tests/helpers/input_test.js
+++ b/packages/ember-htmlbars/tests/helpers/input_test.js
@@ -265,6 +265,44 @@ QUnit.test("should change if the type changes", function() {
   equal(view.$('input').attr('type'), 'text', "it changes after the type changes");
 });
 
+QUnit.module("{{input type='text'}} - dynamic type in IE8 safe environment", {
+  setup() {
+    commonSetup();
+
+    controller = {
+      someProperty: 'password',
+      ie8Safe: true
+    };
+
+    view = View.extend({
+      container: container,
+      controller: controller,
+      template: compile('{{input type=someProperty ie8SafeInput=true}}')
+    }).create();
+
+    runAppend(view);
+  },
+
+  teardown() {
+    runDestroy(view);
+    runDestroy(container);
+  }
+});
+
+QUnit.test("should insert a text field into DOM", function() {
+  equal(view.$('input').attr('type'), 'password', "a bound property can be used to determine type in IE8.");
+});
+
+QUnit.test("should NOT change if the type changes", function() {
+  equal(view.$('input').attr('type'), 'password', "a bound property can be used to determine type in IE8.");
+
+  run(function() {
+    set(controller, 'someProperty', 'text');
+  });
+
+  equal(view.$('input').attr('type'), 'password', "it does NOT change after the type changes in IE8");
+});
+
 QUnit.module("{{input}} - default type", {
   setup() {
     commonSetup();

--- a/packages/ember-views/lib/system/build-component-template.js
+++ b/packages/ember-views/lib/system/build-component-template.js
@@ -44,28 +44,29 @@ export default function buildComponentTemplate({ component, layout, isAngleBrack
   return { createdElement: !!tagName, block: blockToRender };
 }
 
+// Static flag used to see if we can mutate the type attribute on elements. IE8
+// does not support changing the type attribute after an element is inserted in
+// a tree.
+var isTypeAttributeMutable = (function() {
+  var docFragment = document.createDocumentFragment();
+  var mutableInputTypeTextElement = document.createElement('input');
+  mutableInputTypeTextElement.type = 'text';
+  try {
+    docFragment.appendChild(mutableInputTypeTextElement);
+    mutableInputTypeTextElement.setAttribute('type', 'password');
+  } catch (e) {
+    return false;
+  }
+  return true;
+})();
+
 function canChangeTypeAfterRender(attrs) {
   // This permits testing of the unbound type attr behavior outside of IE8.
   if (attrs.ie8SafeInput) {
     return false;
   }
-  var mutableInputTypeTextElement, docFragment;
-  if (!docFragment) {
-    docFragment = document.createDocumentFragment();
-  }
 
-  if (!mutableInputTypeTextElement) {
-    mutableInputTypeTextElement = document.createElement('input');
-    mutableInputTypeTextElement.type = 'text';
-  }
-
-  try {
-    docFragment.appendChild(mutableInputTypeTextElement);
-    mutableInputTypeTextElement.setAttribute('type', 'password');
-  } catch(e) {
-    return false;
-  }
-  return true;
+  return isTypeAttributeMutable;
 }
 
 function blockFor(template, options) {

--- a/packages/ember-views/lib/views/text_field.js
+++ b/packages/ember-views/lib/views/text_field.js
@@ -98,7 +98,9 @@ export default Component.extend(TextSupport, {
   value: "",
 
   /**
-    The `type` attribute of the input element.
+    The `type` attribute of the input element. To remain compatible with IE8, this
+    cannot change after the element has been rendered. It is suggested to avoid using
+    a dynamic type attribute if you are supporting IE8 since it will be set once and never change.
 
     @property type
     @type String


### PR DESCRIPTION
This fixes #11553 and #12295 as well as https://github.com/tildeio/htmlbars/issues/380. This works by detecting if the browser can change the type attr on an input after it has been appended to a node, and then if it cannot, unbinding the type attr so that it is set on the input immediately before being appended to a node.
