### PR TITLE
[BUGFIX release] Fix childViews property for nested virtual views

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -821,7 +821,7 @@ var View = CoreView.extend(
   // childViews will change.
   _childViewsWillChange: beforeObserver('childViews', function() {
     if (this.isVirtual) {
-      var parentView = get(this, 'parentView');
+      var parentView = this._parentView;
       if (parentView) { propertyWillChange(parentView, 'childViews'); }
     }
   }),
@@ -830,7 +830,7 @@ var View = CoreView.extend(
   // childViews did change.
   _childViewsDidChange: observer('childViews', function() {
     if (this.isVirtual) {
-      var parentView = get(this, 'parentView');
+      var parentView = this._parentView;
       if (parentView) { propertyDidChange(parentView, 'childViews'); }
     }
   }),

--- a/packages/ember-views/tests/views/view/virtual_views_test.js
+++ b/packages/ember-views/tests/views/view/virtual_views_test.js
@@ -60,6 +60,16 @@ QUnit.test("when a virtual view's child views change, the parent's childViews sh
 
     render(buffer) {
       buffer.push("<h1>Hi</h1>");
+      this.appendChild(virtualVirtualView);
+    }
+  });
+
+  var virtualVirtualView = EmberView.create({
+    isVirtual: true,
+    tagName: '',
+
+    render(buffer) {
+      buffer.push("<h2>Virtual</h2>");
       this.appendChild(virtualView);
     }
   });
@@ -69,7 +79,7 @@ QUnit.test("when a virtual view's child views change, the parent's childViews sh
     tagName: '',
 
     render(buffer) {
-      buffer.push("<h2>Virtual</h2>");
+      buffer.push("<h3>Virtual</h3>");
       this.appendChild(childView);
     }
   });
@@ -85,13 +95,13 @@ QUnit.test("when a virtual view's child views change, the parent's childViews sh
     rootView.appendTo("#qunit-fixture");
   });
 
-  equal(virtualView.get('childViews.length'), 1, "has childView - precond");
+  equal(virtualVirtualView.get('childViews.length'), 1, "has childView - precond");
   equal(rootView.get('childViews.length'), 1, "has childView - precond");
 
   run(function() {
     childView.removeFromParent();
   });
 
-  equal(virtualView.get('childViews.length'), 0, "has no childView");
+  equal(virtualVirtualView.get('childViews.length'), 0, "has no childView");
   equal(rootView.get('childViews.length'), 0, "has no childView");
 });


### PR DESCRIPTION
This fixed an issue in 1.12 release branch which can get the `childViews` property out of sync with the actual view hierarchy.

Specifically, a nested virtual view will signal `childViews` changes to the non-virtual parent view, rather than the virtual one. This causes the intermediate virtual views `childViews` to _not_ be invalidated, and effectively such `childViews` changes will be disregarded, as seen from the master view.
