### PR TITLE
[BUGFIX beta] Allow call, apply to trigger `_super` wrapping.

### DIFF
--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -252,6 +252,7 @@ export function guidFor(obj) {
   }
 }
 
+const HAS_SUPER_PATTERN = /\.(_super|call\(this|apply\(this)/;
 
 const checkHasSuper = (function () {
   let sourceAvailable = (function() {
@@ -260,7 +261,7 @@ const checkHasSuper = (function () {
 
   if (sourceAvailable) {
     return function checkHasSuper(func) {
-      return func.toString().indexOf('_super') > -1;
+      return HAS_SUPER_PATTERN.test(func.toString());
     };
   }
 

--- a/packages/ember-runtime/tests/system/object/computed_test.js
+++ b/packages/ember-runtime/tests/system/object/computed_test.js
@@ -220,3 +220,47 @@ QUnit.test('list of properties updates when an additional property is added (suc
 
   deepEqual(list.sort(), ['bar', 'foo', 'baz'].sort(), 'expected three computed properties');
 });
+
+QUnit.test('Calling _super in call outside the immediate function of a CP getter works', function() {
+  function macro(callback) {
+    return computed(function() {
+      return callback.call(this);
+    });
+  }
+
+  var MyClass = EmberObject.extend({
+    foo: computed(function() {
+      return 'FOO';
+    })
+  });
+
+  var SubClass = MyClass.extend({
+    foo: macro(function() {
+      return this._super();
+    })
+  });
+
+  ok(emberGet(SubClass.create(), 'foo'), 'FOO', 'super value is fetched');
+});
+
+QUnit.test('Calling _super in apply outside the immediate function of a CP getter works', function() {
+  function macro(callback) {
+    return computed(function() {
+      return callback.apply(this);
+    });
+  }
+
+  var MyClass = EmberObject.extend({
+    foo: computed(function() {
+      return 'FOO';
+    })
+  });
+
+  var SubClass = MyClass.extend({
+    foo: macro(function() {
+      return this._super();
+    })
+  });
+
+  ok(emberGet(SubClass.create(), 'foo'), 'FOO', 'super value is fetched');
+});


### PR DESCRIPTION
So, the new `_super` logic coming in 2.1 appears to have a slightly different behavior than that of 2.0 regarding making `_super` available to CPs. Because the getter function of this `macro` does not contain the string `this._super`, the super is not provided (and `ROOT` is incorrectly used instead).

This change wraps methods using `call` and `apply` in addition to those using `_super` in case super is called.
