### PR TITLE
[FEATURE ember-contextual-components] Remove global feature flag syntax.

### DIFF
--- a/packages/ember-htmlbars/lib/keywords/component.js
+++ b/packages/ember-htmlbars/lib/keywords/component.js
@@ -3,9 +3,9 @@
   @submodule ember-templates
   @public
 */
-import Ember from 'ember-metal/core';
 import { keyword } from 'htmlbars-runtime/hooks';
 import closureComponent from 'ember-htmlbars/keywords/closure-component';
+import isEnabled from 'ember-metal/features';
 
 /**
   The `{{component}}` helper lets you add instances of `Ember.Component` to a
@@ -55,7 +55,7 @@ import closureComponent from 'ember-htmlbars/keywords/closure-component';
   @public
 */
 export default function(morph, env, scope, params, hash, template, inverse, visitor) {
-  if (Ember.FEATURES.isEnabled('ember-contextual-components')) {
+  if (isEnabled('ember-contextual-components')) {
     if (morph) {
       keyword('@element_component', morph, env, scope, params, hash, template, inverse, visitor);
       return true;
@@ -66,4 +66,3 @@ export default function(morph, env, scope, params, hash, template, inverse, visi
     return true;
   }
 }
-

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -149,7 +149,7 @@ registerHelper('concat', concatHelper);
 registerHelper('-join-classes', joinClassesHelper);
 registerHelper('-html-safe', htmlSafeHelper);
 
-if (Ember.FEATURES.isEnabled('ember-contextual-components')) {
+if (isEnabled('ember-contextual-components')) {
   registerHelper('hash', hashHelper);
 }
 

--- a/packages/ember-htmlbars/tests/helpers/closure_component_test.js
+++ b/packages/ember-htmlbars/tests/helpers/closure_component_test.js
@@ -1,14 +1,14 @@
-import Ember from 'ember-metal/core';
 import Registry from 'container/registry';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
 import ComponentLookup from 'ember-views/component_lookup';
 import Component from 'ember-views/components/component';
 import compile from 'ember-template-compiler/system/compile';
 import run from 'ember-metal/run_loop';
+import isEnabled from 'ember-metal/features';
 
 let component, registry, container;
 
-if (Ember.FEATURES.isEnabled('ember-contextual-components')) {
+if (isEnabled('ember-contextual-components')) {
   QUnit.module('ember-htmlbars: closure component helper', {
     setup() {
       registry = new Registry();


### PR DESCRIPTION
Introduced in #12285, but I didn't realize until after merging.
