### PR TITLE
Revisiting the visit API (aka FastBoot™)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+	"files.exclude": {
+		"**/.git": true,
+		"**/.DS_Store": true,
+		"tmp": true,
+		"dist": true
+	}
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+	"compilerOptions": {
+		"target": "ES6"
+	}
+}

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -532,7 +532,8 @@ if (isEnabled('ember-application-visit')) {
 
   BootOptions.prototype.toEnvironment = function() {
     let env = assign({}, environment);
-    env.hasDOM = this.browser;
+    // For compatibility with existing code
+    env.hasDOM = this.isBrowser;
     env.options = this;
     return env;
   };

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -372,9 +372,7 @@ if (isEnabled('ember-application-visit')) {
     @namespace @Ember.ApplicationInstance
     @public
   */
-  BootOptions = function BootOptions(options) {
-    options = options || {};
-
+  BootOptions = function BootOptions(options = {}) {
     /**
       Provide a specific instance of jQuery. This is useful in conjunction with
       the `document` option, as it allows you to use a copy of `jQuery` that is

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -116,11 +116,9 @@ let ApplicationInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
       this.container = this.__container__;
       this.registry = this.__registry__;
     }
-  },
 
-  _bootOptions: null,
-  _bootPromise: null,
-  _booted: false,
+    this._booted = false;
+  },
 
   /**
     Initialize the `Ember.ApplicationInstance` and return a promise that resolves
@@ -135,19 +133,12 @@ let ApplicationInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
     @param options
     @return {Promise<Ember.ApplicationInstance,Error>}
   */
-  boot(options) {
+  boot(options = {}) {
     if (this._bootPromise) { return this._bootPromise; }
 
-    let defer = new Ember.RSVP.defer();
-    let promise = this._bootPromise = defer.promise;
+    this._bootPromise = new Ember.RSVP.Promise(resolve => resolve(this._bootSync(options)));
 
-    try {
-      defer.resolve(this._bootSync(options));
-    } catch(e) {
-      defer.reject(e);
-    }
-
-    return promise;
+    return this._bootPromise;
   },
 
   /**

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -167,7 +167,7 @@ let ApplicationInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
 
       registry.register('renderer:-dom', {
         create() {
-          return new Renderer(new DOMHelper(options.document), options.interactive);
+          return new Renderer(new DOMHelper(options.document), options.isInteractive);
         }
       });
 
@@ -184,7 +184,7 @@ let ApplicationInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
 
       this.application.runInstanceInitializers(this);
 
-      if (options.interactive) {
+      if (options.isInteractive) {
         this.setupEventDispatcher();
       }
     } else {
@@ -383,18 +383,18 @@ if (isEnabled('ember-application-visit')) {
       @default auto-detected
       @private
     */
-    this.jQuery = jQuery;
+    this.jQuery = jQuery; // This default is overridable below
 
     /**
       Interactive mode: whether we need to set up event delegation and invoke
       lifecycle callbacks on Components.
 
-      @property interactive
+      @property isInteractive
       @type boolean
       @default auto-detected
       @private
     */
-    this.interactive = environment.hasDOM;
+    this.isInteractive = environment.hasDOM; // This default is overridable below
 
     /**
       Run in a full browser environment.
@@ -415,20 +415,20 @@ if (isEnabled('ember-application-visit')) {
         the location adapter specified in the app's router instead, you can also
         specify `{ location: null }` to specifically opt-out.)
 
-      @property browser
+      @property isBrowser
       @type boolean
       @default auto-detected
       @public
     */
-    if (options.browser !== undefined) {
-      this.browser = !!options.browser;
+    if (options.isBrowser !== undefined) {
+      this.isBrowser = !!options.isBrowser;
     } else {
-      this.browser = environment.hasDOM;
+      this.isBrowser = environment.hasDOM;
     }
 
-    if (!this.browser) {
+    if (!this.isBrowser) {
       this.jQuery = null;
-      this.interactive = false;
+      this.isInteractive = false;
       this.location = 'none';
     }
 
@@ -439,20 +439,20 @@ if (isEnabled('ember-application-visit')) {
       pipeline. Essentially, this puts the app into "routing-only" mode. No
       templates will be rendered, and no Components will be created.
 
-      @property render
+      @property shouldRender
       @type boolean
       @default true
       @public
     */
-    if (options.render !== undefined) {
-      this.render = !!options.render;
+    if (options.shouldRender !== undefined) {
+      this.shouldRender = !!options.shouldRender;
     } else {
-      this.render = true;
+      this.shouldRender = true;
     }
 
-    if (!this.render) {
+    if (!this.shouldRender) {
       this.jQuery = null;
-      this.interactive = false;
+      this.isInteractive = false;
     }
 
     /**
@@ -503,6 +503,10 @@ if (isEnabled('ember-application-visit')) {
       this.rootElement = options.rootElement;
     }
 
+    // Set these options last to give the user a chance to override the
+    // defaults from the "combo" options like `isBrowser` (although in
+    // practice, the resulting combination is probably invalid)
+
     /**
       If present, overrides the router's `location` property with this
       value. This is useful for environments where trying to modify the
@@ -521,8 +525,8 @@ if (isEnabled('ember-application-visit')) {
       this.jQuery = options.jQuery;
     }
 
-    if (options.interactive !== undefined) {
-      this.interactive = !!options.interactive;
+    if (options.isInteractive !== undefined) {
+      this.isInteractive = !!options.isInteractive;
     }
   };
 

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -163,8 +163,6 @@ let ApplicationInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
       let registry = this.__registry__;
       let environment = options.toEnvironment();
 
-      set(this, '_environment', environment);
-
       registry.register('-environment:main', environment, { instantiate: false });
 
       registry.register('renderer:-dom', {
@@ -174,9 +172,9 @@ let ApplicationInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
       });
 
       if (options.rootElement) {
-        set(this, 'rootElement', options.rootElement);
+        this.rootElement = options.rootElement;
       } else {
-        set(this, 'rootElement', get(this.application, 'rootElement'));
+        this.rootElement = this.application.rootElement;
       }
 
       if (options.location) {

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -150,7 +150,7 @@ let ApplicationInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
     We would like new code (like the `visit` API) to stop making this assumption,
     so we created the asynchronous version above that returns a promise. But until
     we have migrated all the code, we would have to expose this method for use
-    *internall* in places where we need to boot an instance synchronously.
+    *internally* in places where we need to boot an instance synchronously.
 
     @private
   */
@@ -374,7 +374,7 @@ if (isEnabled('ember-application-visit')) {
     /**
       Provide a specific instance of jQuery. This is useful in conjunction with
       the `document` option, as it allows you to use a copy of `jQuery` that is
-      appropiately bound to the foriegn `document` (e.g. a jsdom).
+      appropriately bound to the foreign `document` (e.g. a jsdom).
 
       This is highly experimental and support very incomplete at the moment.
 
@@ -403,7 +403,7 @@ if (isEnabled('ember-application-visit')) {
       and interactive features. Specifically:
 
       * It does not use `jQuery` to append the root view; the `rootElement`
-        (either specified as a subsequent option or on the applicatio itself)
+        (either specified as a subsequent option or on the application itself)
         must already be an `Element` in the given `document` (as opposed to a
         string selector).
 

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -721,9 +721,16 @@ var Application = Namespace.extend(RegistryProxy, {
   */
   didBecomeReady() {
     try {
-      let instance;
+      // TODO: Is this needed for globalsMode = false?
+      if (!Ember.testing) {
+        // Eagerly name all classes that are already loaded
+        Ember.Namespace.processAll();
+        Ember.BOOTED = true;
+      }
 
       if (this.autoboot) {
+        let instance;
+
         if (this.globalsMode) {
           // If we already have the __deprecatedInstance__ lying around, boot it to
           // avoid unnecessary work
@@ -740,16 +747,7 @@ var Application = Namespace.extend(RegistryProxy, {
 
         // TODO: App.ready() is not called when autoboot is disabled, is this correct?
         this.ready();
-      }
 
-      // TODO: Is this needed for globalsMode = false?
-      if (!Ember.testing) {
-        // Eagerly name all classes that are already loaded
-        Ember.Namespace.processAll();
-        Ember.BOOTED = true;
-      }
-
-      if (this.autoboot) {
         instance.startRouting();
       }
     } catch(e) {

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -308,7 +308,7 @@ var Application = Namespace.extend(RegistryProxy, {
 
   /**
     Whether the application should be configured for the legacy "globals mode".
-    Under this mode, the Application object serves as a gobal namespace for all
+    Under this mode, the Application object serves as a global namespace for all
     classes.
 
     ```javascript
@@ -329,15 +329,15 @@ var Application = Namespace.extend(RegistryProxy, {
     });
     ```
 
-    This flag also exposes other internal APIs that assumes the existance of
+    This flag also exposes other internal APIs that assumes the existence of
     a special "default instance", like `App.__container__.lookup(...)`.
 
     This option is currently not configurable, its value is derived from
     the `autoboot` flag – disabling `autoboot` also implies opting-out of
-    globals mode support, although they are ultimately orthgonal concerns.
+    globals mode support, although they are ultimately orthogonal concerns.
 
     Most of the global modes features are already deprecated in 1.x. The
-    existance of this flag is to untangle the globals mode code paths from
+    existence of this flag is to untangle the globals mode code paths from
     the autoboot code paths, so that these legacy features can be reviewed
     for removal separately.
 
@@ -435,7 +435,7 @@ var Application = Namespace.extend(RegistryProxy, {
     Build the deprecated instance for legacy globals mode support.
     Called when creating and resetting the application.
 
-    This is orthgonal to autoboot: the deprecated instance needs to
+    This is orthogonal to autoboot: the deprecated instance needs to
     be created at Application construction (not boot) time to expose
     App.__container__ and the global Ember.View.views registry. If
     autoboot sees that this instance exists, it will continue booting
@@ -504,10 +504,11 @@ var Application = Namespace.extend(RegistryProxy, {
     }
     ```
 
-    Unfortunately, because we need to participate in the "synchronous" boot
-    process. While the code above would work fine on the initial boot (i.e.
-    DOM ready), when `App.reset()` is called, we need to boot a new instance
-    synchronously (see the documentation on `_bootSync()` for details).
+    Unfortunately, we cannot actually write this because we need to participate
+    in the "synchronous" boot process. While the code above would work fine on
+    the initial boot (i.e. DOM ready), when `App.reset()` is called, we need to
+    boot a new instance synchronously (see the documentation on `_bootSync()`
+    for details).
 
     Because of this restriction, the actual logic of this method is located
     inside `didBecomeReady()`.
@@ -981,8 +982,9 @@ if (isEnabled('ember-application-visit')) {
       resolves with the instance when the initial routing and rendering is
       complete, or rejects with any error that occured during the boot process.
 
-      When `autoboot` is disabled, calling `visit` would first cause boot the
-      application. See the documentation on the `boot` method for details.
+      When `autoboot` is disabled, calling `visit` would first cause the
+      application to boot. See the documentation on the `boot` method for
+      details.
 
       This method also takes a hash of boot-time configuration options for
       customizing the instance's behavior. See the documentation on
@@ -1011,7 +1013,7 @@ if (isEnabled('ember-application-visit')) {
       correctly today, largely due to Ember's jQuery dependency.
 
       Currently, there are three officially supported scenarios/configurations.
-      Usages outside of these scenarios are not guarenteed to work, but please
+      Usages outside of these scenarios are not guaranteed to work, but please
       feel free to file bug reports documenting your experience and any issues
       you encountered to help expand support.
 

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -992,21 +992,35 @@ if (isEnabled('ember-application-visit')) {
       @method visit
       @private
     */
-    visit(url) {
+    visit(url, options) {
       return this.boot().then(() => {
-        let defer = new Ember.RSVP.defer();
+        options = options || {};
 
-        return this.buildInstance().boot({
-          location: 'none',
-          hasDOM: false,
-          didCreateRootView(view) {
-            this.view = view;
-            defer.resolve(this);
-          }
-        }).then((instance) => {
+        let instance = this.buildInstance();
+
+        var bootOptions = {};
+
+        if (options.location !== null) {
+          bootOptions.location = options.location || 'none';
+        }
+
+        if (options.server) {
+          bootOptions.hasDOM = false;
+          bootOptions.didCreateRootView = function(view) {
+            view.renderer.appendTo(view, options.rootElement);
+          };
+        }
+
+        if (options.document) {
+          bootOptions.document = options.document;
+        }
+
+        if (options.rootElement) {
+          bootOptions.rootElement = options.rootElement;
+        }
+
+        return instance.boot(bootOptions).then(() => {
           return instance.visit(url);
-        }).then(() => {
-          return defer.promise;
         });
       });
     }

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -617,7 +617,7 @@ var Application = Namespace.extend(RegistryProxy, {
     We would like new code (like the `visit` API) to stop making this assumption,
     so we created the asynchronous version above that returns a promise. But until
     we have migrated all the code, we would have to expose this method for use
-    *internall* in places where we need to boot an app "synchronously".
+    *internally* in places where we need to boot an app "synchronously".
 
     @private
   */

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -336,10 +336,10 @@ var Application = Namespace.extend(RegistryProxy, {
     the `autoboot` flag – disabling `autoboot` also implies opting-out of
     globals mode support, although they are ultimately orthogonal concerns.
 
-    Most of the global modes features are already deprecated in 1.x. The
+    Some of the global modes features are already deprecated in 1.x. The
     existence of this flag is to untangle the globals mode code paths from
     the autoboot code paths, so that these legacy features can be reviewed
-    for removal separately.
+    for deprecation/removal separately.
 
     Forcing the (autoboot=true, _globalsMode=false) here and running the tests
     would reveal all the places where we are still relying on these legacy

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -406,10 +406,8 @@ var Application = Namespace.extend(RegistryProxy, {
     @method buildInstance
     @return {Ember.ApplicationInstance} the application instance
   */
-  buildInstance(options) {
-    options = options || {};
+  buildInstance(options = {}) {
     options.application = this;
-
     return ApplicationInstance.create(options);
   },
 

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -994,17 +994,19 @@ if (isEnabled('ember-application-visit')) {
     */
     visit(url) {
       return this.boot().then(() => {
-        return new Ember.RSVP.Promise((resolve, reject) => {
-          this.buildInstance().boot({
-            location: 'none',
-            hasDOM: false,
-            didCreateRootView(view) {
-              this.view = view;
-              resolve(this);
-            }
-          }).then((instance) => {
-            instance.handleURL(url);
-          }).catch(reject);
+        let defer = new Ember.RSVP.defer();
+
+        return this.buildInstance().boot({
+          location: 'none',
+          hasDOM: false,
+          didCreateRootView(view) {
+            this.view = view;
+            defer.resolve(this);
+          }
+        }).then((instance) => {
+          return instance.visit(url);
+        }).then(() => {
+          return defer.promise;
         });
       });
     }

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -914,20 +914,22 @@ if (isEnabled('ember-application-visit')) {
       @private
     */
     visit(url) {
-      var instance = this.buildInstance();
-      this.bootInstance(instance);
+      return this.boot().then(() => {
+        var instance = this.buildInstance();
+        this.bootInstance(instance);
 
-      var renderPromise = new Ember.RSVP.Promise(function(res, rej) {
-        instance.didCreateRootView = function(view) {
-          instance.view = view;
-          res(instance);
-        };
-      });
+        var renderPromise = new Ember.RSVP.Promise(function(res, rej) {
+          instance.didCreateRootView = function(view) {
+            instance.view = view;
+            res(instance);
+          };
+        });
 
-      instance.overrideRouterLocation({ location: 'none' });
+        instance.overrideRouterLocation({ location: 'none' });
 
-      return instance.handleURL(url).then(function() {
-        return renderPromise;
+        return instance.handleURL(url).then(function() {
+          return renderPromise;
+        });
       });
     }
   });

--- a/packages/ember-application/tests/system/initializers_test.js
+++ b/packages/ember-application/tests/system/initializers_test.js
@@ -34,6 +34,42 @@ QUnit.test('initializers require proper \'name\' and \'initialize\' properties',
   });
 });
 
+if (isEnabled('ember-application-visit')) {
+  QUnit.test('initializers that thorws causes the boot promise to reject with the error', function() {
+    QUnit.expect(2);
+    QUnit.stop();
+
+    var MyApplication = Application.extend();
+
+    MyApplication.initializer({
+      name: 'initializer',
+      initialize() { throw new Error('boot failure'); }
+    });
+
+    var app = MyApplication.create({
+      autoboot: false
+    });
+
+    try {
+      app.boot().then(
+        (app) => {
+          QUnit.start();
+          ok(false, 'The boot promise should not resolve when there is a boot error');
+        },
+        (err) => {
+          QUnit.start();
+          ok(err instanceof Error, 'The boot promise should reject with an error');
+          equal(err.message, 'boot failure');
+        }
+      );
+    } catch(e) {
+      QUnit.start();
+      ok(false, 'The boot method should not throw');
+      throw e;
+    }
+  });
+}
+
 if (isEnabled('ember-registry-container-reform')) {
   QUnit.test('initializers are passed an App', function() {
     var MyApplication = Application.extend();

--- a/packages/ember-application/tests/system/visit_test.js
+++ b/packages/ember-application/tests/system/visit_test.js
@@ -3,6 +3,7 @@ import EmberObject from 'ember-runtime/system/object';
 import isEnabled from 'ember-metal/features';
 import inject from 'ember-runtime/inject';
 import run from 'ember-metal/run_loop';
+import { onerrorDefault } from 'ember-runtime/ext/rsvp';
 import Application from 'ember-application/system/application';
 import ApplicationInstance from 'ember-application/system/application-instance';
 import Route from 'ember-routing/system/route';
@@ -51,9 +52,15 @@ function createApplication(integration) {
   return App;
 }
 
+function expectAsyncError() {
+  Ember.RSVP.off('error');
+}
+
 if (isEnabled('ember-application-visit')) {
   QUnit.module('Ember.Application - visit()', {
     teardown() {
+      Ember.RSVP.on('error', onerrorDefault);
+
       if (instance) {
         run(instance, 'destroy');
         instance = null;
@@ -73,8 +80,9 @@ if (isEnabled('ember-application-visit')) {
   // instance initializer that would normally get called on DOM ready
   // does not fire.
   QUnit.test('Applications with autoboot set to false do not autoboot', function(assert) {
-    QUnit.expect(4);
-    QUnit.stop();
+    function delay(time) {
+      return new Ember.RSVP.Promise(resolve => Ember.run.later(resolve, time));
+    }
 
     let appBooted = 0;
     let instanceBooted = 0;
@@ -98,33 +106,18 @@ if (isEnabled('ember-application-visit')) {
     });
 
     // Continue after 500ms
-    setTimeout(function() {
-      QUnit.start();
-      ok(appBooted === 0, '500ms elapsed without app being booted');
-      ok(instanceBooted === 0, '500ms elapsed without instances being booted');
+    return delay(500).then(() => {
+      assert.ok(appBooted === 0, '500ms elapsed without app being booted');
+      assert.ok(instanceBooted === 0, '500ms elapsed without instances being booted');
 
-      QUnit.stop();
-
-      run(function() {
-        App.boot().then(
-          () => {
-            QUnit.start();
-            assert.ok(appBooted === 1, 'app should boot when manually calling `app.boot()`');
-            assert.ok(instanceBooted === 0, 'no instances should be booted automatically when manually calling `app.boot()');
-          },
-          (error) => {
-            QUnit.start();
-            assert.ok(false, 'the boot process failed with ' + error);
-          }
-        );
-      });
-    }, 500);
+      return run(App, 'boot');
+    }).then(() => {
+      assert.ok(appBooted === 1, 'app should boot when manually calling `app.boot()`');
+      assert.ok(instanceBooted === 0, 'no instances should be booted automatically when manually calling `app.boot()');
+    });
   });
 
   QUnit.test('calling visit() on app without first calling boot() should boot the app', function(assert) {
-    QUnit.expect(2);
-    QUnit.stop();
-
     let appBooted = 0;
     let instanceBooted = 0;
 
@@ -144,25 +137,15 @@ if (isEnabled('ember-application-visit')) {
           instanceBooted++;
         }
       });
+    });
 
-      App.visit('/').then(
-        () => {
-          QUnit.start();
-          assert.ok(appBooted === 1, 'the app should be booted`');
-          assert.ok(instanceBooted === 1, 'an instances should be booted');
-        },
-        (error) => {
-          QUnit.start();
-          assert.ok(false, 'the boot process failed with ' + error);
-        }
-      );
+    return run(App, 'visit', '/').then(() => {
+      assert.ok(appBooted === 1, 'the app should be booted`');
+      assert.ok(instanceBooted === 1, 'an instances should be booted');
     });
   });
 
   QUnit.test('calling visit() on an already booted app should not boot it again', function(assert) {
-    QUnit.expect(6);
-    QUnit.stop();
-
     let appBooted = 0;
     let instanceBooted = 0;
 
@@ -182,36 +165,25 @@ if (isEnabled('ember-application-visit')) {
           instanceBooted++;
         }
       });
+    });
 
-      App.boot().then(() => {
-        QUnit.start();
-        assert.ok(appBooted === 1, 'the app should be booted');
-        assert.ok(instanceBooted === 0, 'no instances should be booted');
-        QUnit.stop();
+    return run(App, 'boot').then(() => {
+      assert.ok(appBooted === 1, 'the app should be booted');
+      assert.ok(instanceBooted === 0, 'no instances should be booted');
 
-        return App.visit('/');
-      }).then(() => {
-        QUnit.start();
-        assert.ok(appBooted === 1, 'the app should not be booted again');
-        assert.ok(instanceBooted === 1, 'an instance should be booted');
-        QUnit.stop();
+      return run(App, 'visit', '/');
+    }).then(() => {
+      assert.ok(appBooted === 1, 'the app should not be booted again');
+      assert.ok(instanceBooted === 1, 'an instance should be booted');
 
-        return App.visit('/');
-      }).then(() => {
-        QUnit.start();
-        assert.ok(appBooted === 1, 'the app should not be booted again');
-        assert.ok(instanceBooted === 2, 'another instance should be booted');
-      }).catch((error) => {
-        QUnit.start();
-        assert.ok(false, 'the boot process failed with ' + error);
-      });
+      return run(App, 'visit', '/');
+    }).then(() => {
+      assert.ok(appBooted === 1, 'the app should not be booted again');
+      assert.ok(instanceBooted === 2, 'another instance should be booted');
     });
   });
 
   QUnit.test('visit() rejects on application boot failure', function(assert) {
-    QUnit.expect(2);
-    QUnit.stop();
-
     run(function() {
       createApplication();
 
@@ -221,25 +193,19 @@ if (isEnabled('ember-application-visit')) {
           throw new Error('boot failure');
         }
       });
+    });
 
-      App.visit('/').then(
-        () => {
-          QUnit.start();
-          assert.ok(false, 'It should not resolve the promise');
-        },
-        (error) => {
-          QUnit.start();
-          assert.ok(error instanceof Error, 'It should reject the promise with the boot error');
-          assert.equal(error.message, 'boot failure');
-        }
-      );
+    expectAsyncError();
+
+    return run(App, 'visit', '/').then(() => {
+      assert.ok(false, 'It should not resolve the promise');
+    }, error => {
+      assert.ok(error instanceof Error, 'It should reject the promise with the boot error');
+      assert.equal(error.message, 'boot failure');
     });
   });
 
   QUnit.test('visit() rejects on instance boot failure', function(assert) {
-    QUnit.expect(2);
-    QUnit.stop();
-
     run(function() {
       createApplication();
 
@@ -249,25 +215,19 @@ if (isEnabled('ember-application-visit')) {
           throw new Error('boot failure');
         }
       });
+    });
 
-      App.visit('/').then(
-        () => {
-          QUnit.start();
-          assert.ok(false, 'It should not resolve the promise');
-        },
-        (error) => {
-          QUnit.start();
-          assert.ok(error instanceof Error, 'It should reject the promise with the boot error');
-          assert.equal(error.message, 'boot failure');
-        }
-      );
+    expectAsyncError();
+
+    return run(App, 'visit', '/').then(() => {
+      assert.ok(false, 'It should not resolve the promise');
+    }, error => {
+      assert.ok(error instanceof Error, 'It should reject the promise with the boot error');
+      assert.equal(error.message, 'boot failure');
     });
   });
 
   QUnit.test('visit() follows redirects', function(assert) {
-    QUnit.expect(2);
-    QUnit.stop();
-
     run(function() {
       createApplication();
 
@@ -288,25 +248,15 @@ if (isEnabled('ember-application-visit')) {
           this.transitionTo('c', params.b);
         }
       }));
+    });
 
-      App.visit('/a').then(
-        (instance) => {
-          QUnit.start();
-          assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
-          assert.equal(instance.getURL(), '/c/zomg', 'It should follow all redirects');
-        },
-        (error) => {
-          QUnit.start();
-          assert.ok(false, 'The visit() promise was rejected: ' + error);
-        }
-      );
+    return run(App, 'visit', '/a').then(instance => {
+      assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+      assert.equal(instance.getURL(), '/c/zomg', 'It should follow all redirects');
     });
   });
 
   QUnit.test('visit() rejects if an error occured during a transition', function(assert) {
-    QUnit.expect(2);
-    QUnit.stop();
-
     run(function() {
       createApplication();
 
@@ -333,25 +283,19 @@ if (isEnabled('ember-application-visit')) {
           throw new Error('transition failure');
         }
       }));
+    });
 
-      App.visit('/a').then(
-        () => {
-          QUnit.start();
-          assert.ok(false, 'It should not resolve the promise');
-        },
-        (error) => {
-          QUnit.start();
-          assert.ok(error instanceof Error, 'It should reject the promise with the boot error');
-          assert.equal(error.message, 'transition failure');
-        }
-      );
+    expectAsyncError();
+
+    return run(App, 'visit', '/a').then(() => {
+      assert.ok(false, 'It should not resolve the promise');
+    }, error => {
+      assert.ok(error instanceof Error, 'It should reject the promise with the boot error');
+      assert.equal(error.message, 'transition failure');
     });
   });
 
   QUnit.test('visit() chain', function(assert) {
-    QUnit.expect(8);
-    QUnit.stop();
-
     run(function() {
       createApplication();
 
@@ -360,43 +304,30 @@ if (isEnabled('ember-application-visit')) {
         this.route('b');
         this.route('c');
       });
+    });
 
-      App.visit('/').then((instance) => {
-        QUnit.start();
-        assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
-        assert.equal(instance.getURL(), '/');
+    return run(App, 'visit', '/').then(instance => {
+      assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+      assert.equal(instance.getURL(), '/');
 
-        QUnit.stop();
-        return instance.visit('/a');
-      }).then((instance) => {
-        QUnit.start();
-        assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
-        assert.equal(instance.getURL(), '/a');
+      return instance.visit('/a');
+    }).then(instance => {
+      assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+      assert.equal(instance.getURL(), '/a');
 
-        QUnit.stop();
-        return instance.visit('/b');
-      }).then((instance) => {
-        QUnit.start();
-        assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
-        assert.equal(instance.getURL(), '/b');
+      return instance.visit('/b');
+    }).then(instance => {
+      assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+      assert.equal(instance.getURL(), '/b');
 
-        QUnit.stop();
-        return instance.visit('/c');
-      }).then((instance) => {
-        QUnit.start();
-        assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
-        assert.equal(instance.getURL(), '/c');
-      }).catch((error) => {
-        QUnit.start();
-        assert.ok(false, 'The visit() promise was rejected: ' + error);
-      });
+      return instance.visit('/c');
+    }).then(instance => {
+      assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+      assert.equal(instance.getURL(), '/c');
     });
   });
 
   QUnit.test('visit() returns a promise that resolves when the view has rendered', function(assert) {
-    QUnit.expect(3);
-    QUnit.stop();
-
     run(function() {
       createApplication();
 
@@ -405,22 +336,13 @@ if (isEnabled('ember-application-visit')) {
 
     assert.strictEqual(Ember.$('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
 
-    run(function() {
-      App.visit('/').then(function(instance) {
-        QUnit.start();
-        assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
-        assert.equal(Ember.$('#qunit-fixture > .ember-view h1').text(), 'Hello world', 'the application was rendered once the promise resolves');
-      }, function(error) {
-        QUnit.start();
-        assert.ok(false, 'The visit() promise was rejected: ' + error);
-      });
+    return run(App, 'visit', '/').then(instance => {
+      assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+      assert.equal(Ember.$('#qunit-fixture > .ember-view h1').text(), 'Hello world', 'the application was rendered once the promise resolves');
     });
   });
 
   QUnit.test('Views created via visit() are not added to the global views hash', function(assert) {
-    QUnit.expect(6);
-    QUnit.stop();
-
     run(function() {
       createApplication();
 
@@ -437,27 +359,21 @@ if (isEnabled('ember-application-visit')) {
 
     assert.strictEqual(Ember.$('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
 
-    run(function() {
-      App.visit('/').then(function(instance) {
-        QUnit.start();
-        assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
-        assert.equal(Ember.$('#qunit-fixture > #my-cool-app h1').text(), 'Hello world', 'the application was rendered once the promise resolves');
-        assert.strictEqual(View.views['my-cool-app'], undefined, 'view was not registered globally');
+    return run(App, 'visit', '/').then(instance => {
+      assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+      assert.equal(Ember.$('#qunit-fixture > #my-cool-app h1').text(), 'Hello world', 'the application was rendered once the promise resolves');
+      assert.strictEqual(View.views['my-cool-app'], undefined, 'view was not registered globally');
 
-        function lookup(fullName) {
-          if (isEnabled('ember-registry-container-reform')) {
-            return instance.lookup(fullName);
-          } else {
-            return instance.container.lookup(fullName);
-          }
+      function lookup(fullName) {
+        if (isEnabled('ember-registry-container-reform')) {
+          return instance.lookup(fullName);
+        } else {
+          return instance.container.lookup(fullName);
         }
+      }
 
-        assert.ok(lookup('-view-registry:main')['my-cool-app'] instanceof View, 'view was registered on the instance\'s view registry');
-        assert.ok(lookup('-view-registry:main')['child-view'] instanceof View, 'child view was registered on the instance\'s view registry');
-      }, function(error) {
-        QUnit.start();
-        assert.ok(false, 'The visit() promise was rejected: ' + error);
-      });
+      assert.ok(lookup('-view-registry:main')['my-cool-app'] instanceof View, 'view was registered on the instance\'s view registry');
+      assert.ok(lookup('-view-registry:main')['child-view'] instanceof View, 'child view was registered on the instance\'s view registry');
     });
   });
 
@@ -475,99 +391,95 @@ if (isEnabled('ember-application-visit')) {
     }
   });
 
-  QUnit.test('FastBoot-style setup', function(assert) {
-    QUnit.expect(15);
-    QUnit.stop();
+  if (document.implementation && typeof document.implementation.createHTMLDocument === 'function') {
+    QUnit.test('FastBoot-style setup', function(assert) {
+      let initCalled = false;
+      let didInsertElementCalled = false;
 
-    let initCalled = false;
-    let didInsertElementCalled = false;
+      run(function() {
+        createApplication(true);
 
-    run(function() {
-      createApplication(true);
+        App.Router.map(function() {
+          this.route('a');
+          this.route('b');
+        });
 
-      App.Router.map(function() {
-        this.route('a');
-        this.route('b');
+        App.register('template:application', compile('<h1>Hello world</h1>\n{{outlet}}'));
+
+        App.register('template:a', compile('<h2>Welcome to {{x-foo page="A"}}</h2>'));
+
+        App.register('template:b', compile('<h2>{{x-foo page="B"}}</h2>'));
+
+        App.register('template:components/x-foo', compile('Page {{page}}'));
+
+        App.register('component:x-foo', Component.extend({
+          tagName: 'span',
+          init() {
+            this._super();
+            initCalled = true;
+          },
+          didInsertElement() {
+            didInsertElementCalled = true;
+          }
+        }));
       });
 
-      App.register('template:application', compile('<h1>Hello world</h1>\n{{outlet}}'));
+      assert.strictEqual(Ember.$('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
 
-      App.register('template:a', compile('<h2>Welcome to {{x-foo page="A"}}</h2>'));
+      function makeForiegnDocument() {
+        // TODO: use simple-dom
+        return document.implementation.createHTMLDocument();
+      }
 
-      App.register('template:b', compile('<h2>{{x-foo page="B"}}</h2>'));
+      let a = run(function() {
+        let dom = makeForiegnDocument();
 
-      App.register('template:components/x-foo', compile('Page {{page}}'));
+        return App.visit('/a', { isBrowser: false, document: dom, rootElement: dom.body }).then(instance => {
+          QUnit.start();
+          assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+          assert.equal(instance.getURL(), '/a');
 
-      App.register('component:x-foo', Component.extend({
-        tagName: 'span',
-        init() {
-          this._super();
-          initCalled = true;
-        },
-        didInsertElement() {
-          didInsertElementCalled = true;
-        }
-      }));
-    });
+          let serialized = dom.body.innerHTML;
+          let $parsed = Ember.$(serialized);
 
-    assert.strictEqual(Ember.$('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
+          assert.equal($parsed.find('h1').text(), 'Hello world');
+          assert.equal($parsed.find('h2').text(), 'Welcome to Page A');
 
-    function makeFakeDom() {
-      // TODO: use simple-dom
-      return document.implementation.createHTMLDocument();
-    }
+          assert.ok(initCalled, 'Component#init should be called');
+          assert.ok(!didInsertElementCalled, 'Component#didInsertElement should not be called');
 
-    let a = run(function() {
-      let dom = makeFakeDom();
-
-      return App.visit('/a', { isBrowser: false, document: dom, rootElement: dom.body }).then(instance => {
-        QUnit.start();
-        assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
-        assert.equal(instance.getURL(), '/a');
-
-        let serialized = dom.body.innerHTML;
-        let $parsed = Ember.$(serialized);
-
-        assert.equal($parsed.find('h1').text(), 'Hello world');
-        assert.equal($parsed.find('h2').text(), 'Welcome to Page A');
-
-        assert.ok(initCalled, 'Component#init should be called');
-        assert.ok(!didInsertElementCalled, 'Component#didInsertElement should not be called');
-
-        assert.strictEqual(Ember.$('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
-        QUnit.stop();
+          assert.strictEqual(Ember.$('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
+          QUnit.stop();
+        });
       });
-    });
 
-    let b = run(function() {
-      let dom = makeFakeDom();
+      let b = run(function() {
+        let dom = makeForiegnDocument();
 
-      return App.visit('/b', { isBrowser: false, document: dom, rootElement: dom.body }).then(instance => {
-        QUnit.start();
-        assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
-        assert.equal(instance.getURL(), '/b');
+        return App.visit('/b', { isBrowser: false, document: dom, rootElement: dom.body }).then(instance => {
+          QUnit.start();
+          assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+          assert.equal(instance.getURL(), '/b');
 
-        let serialized = dom.body.innerHTML;
-        let $parsed = Ember.$(serialized);
+          let serialized = dom.body.innerHTML;
+          let $parsed = Ember.$(serialized);
 
-        assert.equal($parsed.find('h1').text(), 'Hello world');
-        assert.equal($parsed.find('h2').text(), 'Page B');
+          assert.equal($parsed.find('h1').text(), 'Hello world');
+          assert.equal($parsed.find('h2').text(), 'Page B');
 
-        assert.ok(initCalled, 'Component#init should be called');
-        assert.ok(!didInsertElementCalled, 'Component#didInsertElement should not be called');
+          assert.ok(initCalled, 'Component#init should be called');
+          assert.ok(!didInsertElementCalled, 'Component#didInsertElement should not be called');
 
-        assert.strictEqual(Ember.$('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
-        QUnit.stop();
+          assert.strictEqual(Ember.$('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
+          QUnit.stop();
+        });
       });
-    });
 
-    Ember.RSVP.all([a, b]).finally(() => QUnit.start());
-  });
+      return Ember.RSVP.all([a, b]);
+    });
+  }
 
   QUnit.test('Ember Islands-style setup', function(assert) {
-    QUnit.expect(14);
-    QUnit.stop();
-
     let xFooInitCalled = false;
     let xFooDidInsertElementCalled = false;
 
@@ -662,49 +574,43 @@ if (isEnabled('ember-application-visit')) {
     let $bar = Ember.$('<div />').appendTo('#qunit-fixture');
 
     let data = encodeURIComponent(JSON.stringify({ name: 'Godfrey' }));
-    run(function() {
-      Ember.RSVP.all([
-        App.visit(`/x-foo?data=${data}`, { rootElement: $foo[0] }),
-        App.visit('/x-bar', { rootElement: $bar[0] })
-      ]).then(() => {
-        QUnit.start();
 
-        assert.ok(xFooInitCalled);
-        assert.ok(xFooDidInsertElementCalled);
+    return Ember.RSVP.all([
+      run(App, 'visit', `/x-foo?data=${data}`, { rootElement: $foo[0] }),
+      run(App, 'visit', '/x-bar', { rootElement: $bar[0] })
+    ]).then(() => {
+      assert.ok(xFooInitCalled);
+      assert.ok(xFooDidInsertElementCalled);
 
-        assert.ok(xBarInitCalled);
-        assert.ok(xBarDidInsertElementCalled);
+      assert.ok(xBarInitCalled);
+      assert.ok(xBarDidInsertElementCalled);
 
-        assert.equal($foo.find('h1').text(), 'X-Foo');
-        assert.equal($foo.find('p').text(), 'Hello Godfrey, I have been clicked 0 times (0 times combined)!');
-        assert.ok($foo.text().indexOf('X-Bar') === -1);
+      assert.equal($foo.find('h1').text(), 'X-Foo');
+      assert.equal($foo.find('p').text(), 'Hello Godfrey, I have been clicked 0 times (0 times combined)!');
+      assert.ok($foo.text().indexOf('X-Bar') === -1);
 
-        assert.equal($bar.find('h1').text(), 'X-Bar');
-        assert.equal($bar.find('button').text(), 'Join 0 others in clicking me!');
-        assert.ok($bar.text().indexOf('X-Foo') === -1);
+      assert.equal($bar.find('h1').text(), 'X-Bar');
+      assert.equal($bar.find('button').text(), 'Join 0 others in clicking me!');
+      assert.ok($bar.text().indexOf('X-Foo') === -1);
 
-        run(function() {
-          $foo.find('x-foo').click();
-        });
-
-        assert.equal($foo.find('p').text(), 'Hello Godfrey, I have been clicked 1 times (1 times combined)!');
-        assert.equal($bar.find('button').text(), 'Join 1 others in clicking me!');
-
-        run(function() {
-          $bar.find('button').click();
-          $bar.find('button').click();
-        });
-
-        assert.equal($foo.find('p').text(), 'Hello Godfrey, I have been clicked 1 times (3 times combined)!');
-        assert.equal($bar.find('button').text(), 'Join 3 others in clicking me!');
+      run(function() {
+        $foo.find('x-foo').click();
       });
+
+      assert.equal($foo.find('p').text(), 'Hello Godfrey, I have been clicked 1 times (1 times combined)!');
+      assert.equal($bar.find('button').text(), 'Join 1 others in clicking me!');
+
+      run(function() {
+        $bar.find('button').click();
+        $bar.find('button').click();
+      });
+
+      assert.equal($foo.find('p').text(), 'Hello Godfrey, I have been clicked 1 times (3 times combined)!');
+      assert.equal($bar.find('button').text(), 'Join 3 others in clicking me!');
     });
   });
 
   QUnit.test('Resource-discovery setup', function(assert) {
-    QUnit.expect(26);
-    QUnit.stop();
-
     let xFooInstances = 0;
 
     run(function() {
@@ -780,92 +686,72 @@ if (isEnabled('ember-application-visit')) {
       }
     }
 
-    let a = run(function() {
-      return App.visit('/a', { isBrowser: false, shouldRender: false }).then((instance) => {
-        QUnit.start();
-        assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+    let a = run(App, 'visit', '/a', { isBrowser: false, shouldRender: false }).then(instance => {
+      assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
 
-        assert.strictEqual(Ember.$('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
-        assert.strictEqual(xFooInstances, 0, 'did not create any x-foo components');
+      assert.strictEqual(Ember.$('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
+      assert.strictEqual(xFooInstances, 0, 'did not create any x-foo components');
 
-        let viewRegistry = lookup(instance, '-view-registry:main');
-        assert.strictEqual(Object.keys(viewRegistry).length, 0, 'did not create any views');
+      let viewRegistry = lookup(instance, '-view-registry:main');
+      assert.strictEqual(Object.keys(viewRegistry).length, 0, 'did not create any views');
 
-        let networkService = lookup(instance, 'service:network');
-        assert.deepEqual(networkService.get('requests'), ['/a', '/b', '/c']);
-        QUnit.stop();
-      });
+      let networkService = lookup(instance, 'service:network');
+      assert.deepEqual(networkService.get('requests'), ['/a', '/b', '/c']);
     });
 
-    let b = run(function() {
-      return App.visit('/b', { isBrowser: false, shouldRender: false }).then((instance) => {
-        QUnit.start();
-        assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+    let b = run(App, 'visit', '/b', { isBrowser: false, shouldRender: false }).then(instance => {
+      assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
 
-        assert.strictEqual(Ember.$('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
-        assert.strictEqual(xFooInstances, 0, 'did not create any x-foo components');
+      assert.strictEqual(Ember.$('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
+      assert.strictEqual(xFooInstances, 0, 'did not create any x-foo components');
 
-        let viewRegistry = lookup(instance, '-view-registry:main');
-        assert.strictEqual(Object.keys(viewRegistry).length, 0, 'did not create any views');
+      let viewRegistry = lookup(instance, '-view-registry:main');
+      assert.strictEqual(Object.keys(viewRegistry).length, 0, 'did not create any views');
 
-        let networkService = lookup(instance, 'service:network');
-        assert.deepEqual(networkService.get('requests'), ['/b', '/c']);
-        QUnit.stop();
-      });
+      let networkService = lookup(instance, 'service:network');
+      assert.deepEqual(networkService.get('requests'), ['/b', '/c']);
     });
 
-    let c = run(function() {
-      return App.visit('/c', { isBrowser: false, shouldRender: false }).then((instance) => {
-        QUnit.start();
-        assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+    let c = run(App, 'visit', '/c', { isBrowser: false, shouldRender: false }).then(instance => {
+      assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
 
-        assert.strictEqual(Ember.$('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
-        assert.strictEqual(xFooInstances, 0, 'did not create any x-foo components');
+      assert.strictEqual(Ember.$('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
+      assert.strictEqual(xFooInstances, 0, 'did not create any x-foo components');
 
-        let viewRegistry = lookup(instance, '-view-registry:main');
-        assert.strictEqual(Object.keys(viewRegistry).length, 0, 'did not create any views');
+      let viewRegistry = lookup(instance, '-view-registry:main');
+      assert.strictEqual(Object.keys(viewRegistry).length, 0, 'did not create any views');
 
-        let networkService = lookup(instance, 'service:network');
-        assert.deepEqual(networkService.get('requests'), ['/c']);
-        QUnit.stop();
-      });
+      let networkService = lookup(instance, 'service:network');
+      assert.deepEqual(networkService.get('requests'), ['/c']);
     });
 
-    let d = run(function() {
-      return App.visit('/d', { isBrowser: false, shouldRender: false }).then((instance) => {
-        QUnit.start();
-        assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+    let d = run(App, 'visit', '/d', { isBrowser: false, shouldRender: false }).then(instance => {
+      assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
 
-        assert.strictEqual(Ember.$('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
-        assert.strictEqual(xFooInstances, 0, 'did not create any x-foo components');
+      assert.strictEqual(Ember.$('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
+      assert.strictEqual(xFooInstances, 0, 'did not create any x-foo components');
 
-        let viewRegistry = lookup(instance, '-view-registry:main');
-        assert.strictEqual(Object.keys(viewRegistry).length, 0, 'did not create any views');
+      let viewRegistry = lookup(instance, '-view-registry:main');
+      assert.strictEqual(Object.keys(viewRegistry).length, 0, 'did not create any views');
 
-        let networkService = lookup(instance, 'service:network');
-        assert.deepEqual(networkService.get('requests'), ['/d', '/e']);
-        QUnit.stop();
-      });
+      let networkService = lookup(instance, 'service:network');
+      assert.deepEqual(networkService.get('requests'), ['/d', '/e']);
     });
 
-    let e = run(function() {
-      return App.visit('/e', { isBrowser: false, shouldRender: false }).then((instance) => {
-        QUnit.start();
-        assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+    let e = run(App, 'visit', '/e', { isBrowser: false, shouldRender: false }).then(instance => {
+      assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
 
-        assert.strictEqual(Ember.$('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
-        assert.strictEqual(xFooInstances, 0, 'did not create any x-foo components');
+      assert.strictEqual(Ember.$('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
+      assert.strictEqual(xFooInstances, 0, 'did not create any x-foo components');
 
-        let viewRegistry = lookup(instance, '-view-registry:main');
-        assert.strictEqual(Object.keys(viewRegistry).length, 0, 'did not create any views');
+      let viewRegistry = lookup(instance, '-view-registry:main');
+      assert.strictEqual(Object.keys(viewRegistry).length, 0, 'did not create any views');
 
-        let networkService = lookup(instance, 'service:network');
-        assert.deepEqual(networkService.get('requests'), ['/e']);
-        QUnit.stop();
-      });
+      let networkService = lookup(instance, 'service:network');
+      assert.deepEqual(networkService.get('requests'), ['/e']);
     });
 
-    Ember.RSVP.all([a, b, c, d, e]).finally(() => QUnit.start());
+    return Ember.RSVP.all([a, b, c, d, e]);
   });
 
   QUnit.skip('Test setup', function(assert) {

--- a/packages/ember-application/tests/system/visit_test.js
+++ b/packages/ember-application/tests/system/visit_test.js
@@ -3,6 +3,7 @@ import isEnabled from 'ember-metal/features';
 import run from 'ember-metal/run_loop';
 import Application from 'ember-application/system/application';
 import ApplicationInstance from 'ember-application/system/application-instance';
+import Route from 'ember-routing/system/route';
 import Router from 'ember-routing/system/router';
 import View from 'ember-views/views/view';
 import compile from 'ember-template-compiler/system/compile';
@@ -65,7 +66,6 @@ if (isEnabled('ember-application-visit')) {
     run(function() {
       createApplication();
 
-      // Create an application initializer that should *not* get run.
       App.initializer({
         name: 'assert-no-autoboot',
         initialize() {
@@ -73,7 +73,6 @@ if (isEnabled('ember-application-visit')) {
         }
       });
 
-      // Create an instance initializer that should *not* get run.
       App.instanceInitializer({
         name: 'assert-no-autoboot',
         initialize() {
@@ -94,12 +93,12 @@ if (isEnabled('ember-application-visit')) {
         App.boot().then(
           () => {
             QUnit.start();
-            ok(appBooted === 1, 'app should boot when manually calling `app.boot()`');
-            ok(instanceBooted === 0, 'no instances should be booted automatically when manually calling `app.boot()');
+            assert.ok(appBooted === 1, 'app should boot when manually calling `app.boot()`');
+            assert.ok(instanceBooted === 0, 'no instances should be booted automatically when manually calling `app.boot()');
           },
           (error) => {
             QUnit.start();
-            ok(false, 'the boot process failed with ' + error);
+            assert.ok(false, 'the boot process failed with ' + error);
           }
         );
       });
@@ -116,7 +115,6 @@ if (isEnabled('ember-application-visit')) {
     run(function() {
       createApplication();
 
-      // Create an application initializer that should *not* get run.
       App.initializer({
         name: 'assert-no-autoboot',
         initialize() {
@@ -124,7 +122,6 @@ if (isEnabled('ember-application-visit')) {
         }
       });
 
-      // Create an instance initializer that should *not* get run.
       App.instanceInitializer({
         name: 'assert-no-autoboot',
         initialize() {
@@ -135,12 +132,12 @@ if (isEnabled('ember-application-visit')) {
       App.visit('/').then(
         () => {
           QUnit.start();
-          ok(appBooted === 1, 'the app should be booted`');
-          ok(instanceBooted === 1, 'an instances should be booted');
+          assert.ok(appBooted === 1, 'the app should be booted`');
+          assert.ok(instanceBooted === 1, 'an instances should be booted');
         },
         (error) => {
           QUnit.start();
-          ok(false, 'the boot process failed with ' + error);
+          assert.ok(false, 'the boot process failed with ' + error);
         }
       );
     });
@@ -156,7 +153,6 @@ if (isEnabled('ember-application-visit')) {
     run(function() {
       createApplication();
 
-      // Create an application initializer that should *not* get run.
       App.initializer({
         name: 'assert-no-autoboot',
         initialize() {
@@ -164,7 +160,6 @@ if (isEnabled('ember-application-visit')) {
         }
       });
 
-      // Create an instance initializer that should *not* get run.
       App.instanceInitializer({
         name: 'assert-no-autoboot',
         initialize() {
@@ -174,25 +169,210 @@ if (isEnabled('ember-application-visit')) {
 
       App.boot().then(() => {
         QUnit.start();
-        ok(appBooted === 1, 'the app should be booted');
-        ok(instanceBooted === 0, 'no instances should be booted');
+        assert.ok(appBooted === 1, 'the app should be booted');
+        assert.ok(instanceBooted === 0, 'no instances should be booted');
         QUnit.stop();
 
         return App.visit('/');
       }).then(() => {
         QUnit.start();
-        ok(appBooted === 1, 'the app should not be booted again');
-        ok(instanceBooted === 1, 'an instance should be booted');
+        assert.ok(appBooted === 1, 'the app should not be booted again');
+        assert.ok(instanceBooted === 1, 'an instance should be booted');
         QUnit.stop();
 
         return App.visit('/');
       }).then(() => {
         QUnit.start();
-        ok(appBooted === 1, 'the app should not be booted again');
-        ok(instanceBooted === 2, 'another instance should be booted');
+        assert.ok(appBooted === 1, 'the app should not be booted again');
+        assert.ok(instanceBooted === 2, 'another instance should be booted');
       }).catch((error) => {
         QUnit.start();
-        ok(false, 'the boot process failed with ' + error);
+        assert.ok(false, 'the boot process failed with ' + error);
+      });
+    });
+  });
+
+  QUnit.test('visit() rejects on application boot failure', function(assert) {
+    QUnit.expect(2);
+    QUnit.stop();
+
+    run(function() {
+      createApplication();
+
+      App.initializer({
+        name: 'error',
+        initialize() {
+          throw new Error('boot failure');
+        }
+      });
+
+      App.visit('/').then(
+        () => {
+          QUnit.start();
+          assert.ok(false, 'It should not resolve the promise');
+        },
+        (error) => {
+          QUnit.start();
+          assert.ok(error instanceof Error, 'It should reject the promise with the boot error');
+          assert.equal(error.message, 'boot failure');
+        }
+      );
+    });
+  });
+
+  QUnit.test('visit() rejects on instance boot failure', function(assert) {
+    QUnit.expect(2);
+    QUnit.stop();
+
+    run(function() {
+      createApplication();
+
+      App.instanceInitializer({
+        name: 'error',
+        initialize() {
+          throw new Error('boot failure');
+        }
+      });
+
+      App.visit('/').then(
+        () => {
+          QUnit.start();
+          assert.ok(false, 'It should not resolve the promise');
+        },
+        (error) => {
+          QUnit.start();
+          assert.ok(error instanceof Error, 'It should reject the promise with the boot error');
+          assert.equal(error.message, 'boot failure');
+        }
+      );
+    });
+  });
+
+  QUnit.test('visit() follows redirects', function(assert) {
+    QUnit.expect(2);
+    QUnit.stop();
+
+    run(function() {
+      createApplication();
+
+      App.Router.map(function() {
+        this.route('a');
+        this.route('b', { path: '/b/:b' });
+        this.route('c', { path: '/c/:c' });
+      });
+
+      App.register('route:a', Route.extend({
+        afterModel() {
+          this.replaceWith('b', 'zomg');
+        }
+      }));
+
+      App.register('route:b', Route.extend({
+        afterModel(params) {
+          this.transitionTo('c', params.b);
+        }
+      }));
+
+      App.visit('/a').then(
+        (instance) => {
+          QUnit.start();
+          assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+          assert.equal(instance.getURL(), '/c/zomg', 'It should follow all redirects');
+        },
+        (error) => {
+          QUnit.start();
+          assert.ok(false, 'The visit() promise was rejected: ' + error);
+        }
+      );
+    });
+  });
+
+  QUnit.test('visit() rejects if an error occured during a transition', function(assert) {
+    QUnit.expect(2);
+    QUnit.stop();
+
+    run(function() {
+      createApplication();
+
+      App.Router.map(function() {
+        this.route('a');
+        this.route('b', { path: '/b/:b' });
+        this.route('c', { path: '/c/:c' });
+      });
+
+      App.register('route:a', Route.extend({
+        afterModel() {
+          this.replaceWith('b', 'zomg');
+        }
+      }));
+
+      App.register('route:b', Route.extend({
+        afterModel(params) {
+          this.transitionTo('c', params.b);
+        }
+      }));
+
+      App.register('route:c', Route.extend({
+        afterModel(params) {
+          throw new Error('transition failure');
+        }
+      }));
+
+      App.visit('/a').then(
+        () => {
+          QUnit.start();
+          assert.ok(false, 'It should not resolve the promise');
+        },
+        (error) => {
+          QUnit.start();
+          assert.ok(error instanceof Error, 'It should reject the promise with the boot error');
+          assert.equal(error.message, 'transition failure');
+        }
+      );
+    });
+  });
+
+  QUnit.test('visit() chain', function(assert) {
+    QUnit.expect(8);
+    QUnit.stop();
+
+    run(function() {
+      createApplication();
+
+      App.Router.map(function() {
+        this.route('a');
+        this.route('b');
+        this.route('c');
+      });
+
+      App.visit('/').then((instance) => {
+        QUnit.start();
+        assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+        assert.equal(instance.getURL(), '/');
+
+        QUnit.stop();
+        return instance.visit('/a');
+      }).then((instance) => {
+        QUnit.start();
+        assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+        assert.equal(instance.getURL(), '/a');
+
+        QUnit.stop();
+        return instance.visit('/b');
+      }).then((instance) => {
+        QUnit.start();
+        assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+        assert.equal(instance.getURL(), '/b');
+
+        QUnit.stop();
+        return instance.visit('/c');
+      }).then((instance) => {
+        QUnit.start();
+        assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+        assert.equal(instance.getURL(), '/c');
+      }).catch((error) => {
+        QUnit.start();
+        assert.ok(false, 'The visit() promise was rejected: ' + error);
       });
     });
   });
@@ -204,15 +384,12 @@ if (isEnabled('ember-application-visit')) {
     run(function() {
       createApplication();
 
-      App.instanceInitializer({
-        name: 'register-application-template',
-        initialize(instance) {
-          instance.register('template:application', compile('<h1>Hello world</h1>'));
-        }
-      });
+      App.register('template:application', compile('<h1>Hello world</h1>'));
+    });
 
-      assert.equal(Ember.$('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
+    assert.strictEqual(Ember.$('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
 
+    run(function() {
       App.visit('/').then(function(instance) {
         QUnit.start();
         assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
@@ -233,18 +410,15 @@ if (isEnabled('ember-application-visit')) {
     run(function() {
       createApplication();
 
-      App.instanceInitializer({
-        name: 'register-application-template',
-        initialize(instance) {
-          instance.register('template:application', compile('<h1>Hello world</h1> {{component "x-child"}}'));
-          instance.register('view:application', View.extend({
-            elementId: 'my-cool-app'
-          }));
-          instance.register('component:x-child', View.extend({
-            elementId: 'child-view'
-          }));
-        }
-      });
+      App.register('template:application', compile('<h1>Hello world</h1> {{component "x-child"}}'));
+
+      App.register('view:application', View.extend({
+        elementId: 'my-cool-app'
+      }));
+
+      App.register('component:x-child', View.extend({
+        elementId: 'child-view'
+      }));
     });
 
     assert.equal(Ember.$('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
@@ -266,8 +440,8 @@ if (isEnabled('ember-application-visit')) {
           }
         }
 
-        ok(lookup('-view-registry:main')['my-cool-app'] instanceof View, 'view was registered on the instance\'s view registry');
-        ok(lookup('-view-registry:main')['child-view'] instanceof View, 'child view was registered on the instance\'s view registry');
+        assert.ok(lookup('-view-registry:main')['my-cool-app'] instanceof View, 'view was registered on the instance\'s view registry');
+        assert.ok(lookup('-view-registry:main')['child-view'] instanceof View, 'child view was registered on the instance\'s view registry');
       }, function(error) {
         QUnit.start();
         assert.ok(false, 'The visit() promise was rejected: ' + error);

--- a/packages/ember-application/tests/system/visit_test.js
+++ b/packages/ember-application/tests/system/visit_test.js
@@ -520,7 +520,7 @@ if (isEnabled('ember-application-visit')) {
     let a = run(function() {
       let dom = makeFakeDom();
 
-      return App.visit('/a', { browser: false, document: dom, rootElement: dom.body }).then(instance => {
+      return App.visit('/a', { isBrowser: false, document: dom, rootElement: dom.body }).then(instance => {
         QUnit.start();
         assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
         assert.equal(instance.getURL(), '/a');
@@ -542,7 +542,7 @@ if (isEnabled('ember-application-visit')) {
     let b = run(function() {
       let dom = makeFakeDom();
 
-      return App.visit('/b', { browser: false, document: dom, rootElement: dom.body }).then(instance => {
+      return App.visit('/b', { isBrowser: false, document: dom, rootElement: dom.body }).then(instance => {
         QUnit.start();
         assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
         assert.equal(instance.getURL(), '/b');
@@ -781,7 +781,7 @@ if (isEnabled('ember-application-visit')) {
     }
 
     let a = run(function() {
-      return App.visit('/a', { browser: false, render: false }).then((instance) => {
+      return App.visit('/a', { isBrowser: false, shouldRender: false }).then((instance) => {
         QUnit.start();
         assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
 
@@ -798,7 +798,7 @@ if (isEnabled('ember-application-visit')) {
     });
 
     let b = run(function() {
-      return App.visit('/b', { browser: false, render: false }).then((instance) => {
+      return App.visit('/b', { isBrowser: false, shouldRender: false }).then((instance) => {
         QUnit.start();
         assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
 
@@ -815,7 +815,7 @@ if (isEnabled('ember-application-visit')) {
     });
 
     let c = run(function() {
-      return App.visit('/c', { browser: false, render: false }).then((instance) => {
+      return App.visit('/c', { isBrowser: false, shouldRender: false }).then((instance) => {
         QUnit.start();
         assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
 
@@ -832,7 +832,7 @@ if (isEnabled('ember-application-visit')) {
     });
 
     let d = run(function() {
-      return App.visit('/d', { browser: false, render: false }).then((instance) => {
+      return App.visit('/d', { isBrowser: false, shouldRender: false }).then((instance) => {
         QUnit.start();
         assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
 
@@ -849,7 +849,7 @@ if (isEnabled('ember-application-visit')) {
     });
 
     let e = run(function() {
-      return App.visit('/e', { browser: false, render: false }).then((instance) => {
+      return App.visit('/e', { isBrowser: false, shouldRender: false }).then((instance) => {
         QUnit.start();
         assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
 

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1213,7 +1213,13 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
 
     this.setupController(controller, context, transition);
 
-    this.renderTemplate(controller, context);
+    if (isEnabled('ember-application-visit')) {
+      if (!this._environment || this._environment.options.render) {
+        this.renderTemplate(controller, context);
+      }
+    } else {
+      this.renderTemplate(controller, context);
+    }
   },
 
   /*

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1214,7 +1214,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     this.setupController(controller, context, transition);
 
     if (isEnabled('ember-application-visit')) {
-      if (!this._environment || this._environment.options.render) {
+      if (!this._environment || this._environment.options.shouldRender) {
         this.renderTemplate(controller, context);
       }
     } else {

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -363,6 +363,16 @@ QUnit.test('test must not finish while asyncHelpers are pending', function () {
   }
 });
 
+QUnit.test('visiting a URL that causes another transition should yield the correct URL', function () {
+  expect(1);
+
+  visit('/redirect');
+
+  andThen(function () {
+    equal(currentURL(), '/comments', 'Redirected to Comments URL');
+  });
+});
+
 QUnit.test('visiting a URL and then visiting a second URL with a transition should yield the correct URL', function () {
   expect(2);
 

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -7,6 +7,7 @@ import { guidFor } from 'ember-metal/utils';
 import { computed } from 'ember-metal/computed';
 import { Mixin } from 'ember-metal/mixin';
 import { POST_INIT } from 'ember-runtime/system/core_object';
+import isEnabled from 'ember-metal/features';
 
 import jQuery from 'ember-views/system/jquery';
 
@@ -251,12 +252,32 @@ export default Mixin.create({
     @private
   */
   appendTo(selector) {
-    var target = jQuery(selector);
+    if (isEnabled('ember-application-visit')) {
+      let $ = this._environment ? this._environment.options.jQuery : jQuery;
 
-    assert('You tried to append to (' + selector + ') but that isn\'t in the DOM', target.length > 0);
-    assert('You cannot append to an existing Ember.View. Consider using Ember.ContainerView instead.', !target.is('.ember-view') && !target.parents().is('.ember-view'));
+      if ($) {
+        let target = $(selector);
 
-    this.renderer.appendTo(this, target[0]);
+        assert('You tried to append to (' + selector + ') but that isn\'t in the DOM', target.length > 0);
+        assert('You cannot append to an existing Ember.View. Consider using Ember.ContainerView instead.', !target.is('.ember-view') && !target.parents().is('.ember-view'));
+
+        this.renderer.appendTo(this, target[0]);
+      } else {
+        let target = selector;
+
+        assert('You tried to append to a selector string (' + selector + ') in an environment without jQuery', typeof target !== 'string');
+        assert('You tried to append to a non-Element (' + selector + ') in an environment without jQuery', typeof selector.appendChild === 'function');
+
+        this.renderer.appendTo(this, target);
+      }
+    } else {
+      let target = jQuery(selector);
+
+      assert('You tried to append to (' + selector + ') but that isn\'t in the DOM', target.length > 0);
+      assert('You cannot append to an existing Ember.View. Consider using Ember.ContainerView instead.', !target.is('.ember-view') && !target.parents().is('.ember-view'));
+
+      this.renderer.appendTo(this, target[0]);
+    }
 
     return this;
   },

--- a/tests/node/helpers/app-module.js
+++ b/tests/node/helpers/app-module.js
@@ -87,11 +87,10 @@ module.exports = function(moduleName) {
   QUnit.module(moduleName, {
     beforeEach: function() {
       var Ember = this.Ember = require(emberPath);
-      var DOMHelper = Ember.HTMLBars.DOMHelper;
+
       Ember.testing = true;
 
       this.compile = require(templateCompilerPath).compile;
-      this.domHelper = createDOMHelper(DOMHelper);
       this.run = Ember.run;
       this.all = Ember.RSVP.all;
 
@@ -104,8 +103,22 @@ module.exports = function(moduleName) {
       this.view = registerView;
       this.routes = registerRoutes;
       this.registry = {};
-      this.renderToElement = renderToElement;
       this.renderToHTML = renderToHTML;
+
+      // TODO: REMOVE ME
+
+      // Patch DOMHelper
+      Ember.HTMLBars.DOMHelper.prototype.zomg = "ZOMG";
+
+      Ember.HTMLBars.DOMHelper.prototype.protocolForURL = function(url) {
+        var protocol = URL.parse(url).protocol;
+        return (protocol == null) ? ':' : protocol;
+      };
+
+      Ember.HTMLBars.DOMHelper.prototype.setMorphHTML = function(morph, html) {
+        var section = this.document.createRawHTMLSection(html);
+        morph.setNode(section);
+      };
     },
 
     afterEach: function() {
@@ -123,6 +136,8 @@ module.exports = function(moduleName) {
 module.exports.canRunTests = canRunTests;
 
 function createApplication() {
+  if (this.app) return this.app;
+
   var app = this.Ember.Application.extend().create({
     autoboot: false
   });
@@ -135,12 +150,11 @@ function createApplication() {
     app.Router.map(this.routesCallback);
   }
 
-  registerDOMHelper(this.Ember, app, this.domHelper);
   registerApplicationClasses(app, this.registry);
 
-  this.run(function() {
-    app.boot();
-  });
+  // Run application initializers
+  this.run(app, 'boot');
+
   this.app = app;
 
   return app;
@@ -151,44 +165,32 @@ function register(containerKey, klass) {
 }
 
 function visit(url) {
-  if (!this.app) { this.createApplication(); }
+  var app = this.createApplication();
+  var dom = new SimpleDOM.Document();
 
-  var promise;
-  this.run(this, function() {
-    promise = this.app.visit(url);
-  });
-
-  return promise;
-}
-
-function registerDOMHelper(Ember, app, domHelper) {
-  app.initializer({
-    name: 'register-dom-helper',
-    initialize: function(app) {
-      app.register('renderer:-dom', {
-        create: function() {
-          return new Ember._Renderer(domHelper, false);
-        }
-      });
-    }
+  return this.run(app, 'visit', url, {
+    isBrowser: false,
+    document: dom,
+    rootElement: dom.body
   });
 }
 
-function createDOMHelper(DOMHelper) {
-  var document = new SimpleDOM.Document();
-  var domHelper = new DOMHelper(document);
+function renderToHTML(url) {
+  var app = this.createApplication();
+  var dom = new SimpleDOM.Document();
+  var root = dom.body;
 
-  domHelper.protocolForURL = function(url) {
-    var protocol = URL.parse(url).protocol;
-    return (protocol == null) ? ':' : protocol;
-  };
+  return this.run(app, 'visit', url, {
+    isBrowser: false,
+    document: dom,
+    rootElement: root
+  }).then(function() {
+    var element = root;
+    var serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
+    var serialized = serializer.serialize(root);
 
-  domHelper.setMorphHTML = function(morph, html) {
-    var section = this.document.createRawHTMLSection(html);
-    morph.setNode(section);
-  };
-
-  return domHelper;
+    return serialized;
+  });
 }
 
 function registerApplicationClasses(app, registry) {
@@ -223,24 +225,4 @@ function registerView(name, viewProps) {
 
 function registerRoutes(cb) {
   this.routesCallback = cb;
-}
-
-function renderToElement(instance) {
-  var element;
-  this.run(function() {
-    element = instance.view.renderToElement();
-  });
-
-  return element;
-}
-
-function renderToHTML(route) {
-  var self = this;
-  return this.visit(route).then(function(instance) {
-    var element = self.renderToElement(instance);
-    var serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
-    var serialized = serializer.serialize(element);
-
-    return serialized;
-  });
 }


### PR DESCRIPTION
:arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook: :arrow_right_hook:

It's time to put on some finishing touches for the `visit` API! Since this is a somewhat big patch, here is a detailed description.
# Summary

The `visit` API exposes `ApplicationInstance` as a useful primitive for many scenarios, including FastBoot™, widgets, resource discover, testing, and more.
## Background

Ember 1.12 introduced the concept of `ApplicationInstance`s. While they are very well designed and could be very useful in many cases, there are no official APIs to create them. The `visit` API helps fill this void by exposing a supported way to boot and customize instances.
## What's in the box :package:
- [x] Refactoring
- [x] New APIs
- [x] Tests
- [x] Documentation
- [x] Bonus DLC Pack
- [x] Emojis
### Refactoring
1. **A Clear Boot Phase**
   
   Previously, we don't have a very clear concept of a boot phase, especially for `ApplictionInstance`. This creates a lot of implicit timing dependencies around when certain options can be set/changed. For example, the `ember-cli-fastboot` changes the `autoboot` flag in an application initializer (i.e. in the middle of the boot phase), which created a strange fork in the boot flow.
   
   As part of this patch I did some work to solidify the boot phase. Options like `autoboot` should be set
   ~~before `boot()` is called~~ at instantiation time. What I can do on `Application` is rather limited, but I tried to make that clear in the new `ApplicationInstance` boot phase, which takes a hash of boot-time options in favor of ad-hoc methods like `overrideRouterLocation`.
2. **Asynchronous APIs**
   
   Booting an `Application` (and to a lesser extent, an `ApplicationInstance`) is an inertially asynchronous task. Naturally, we would like to express the asynchrony here with promises/async functions. However, the architecture we have predated Ember's adoption of promises, and a lot of code assumes that it is a "synchronous". Specifically, a lot of tests assumes the last call to `app.advanceReadiness()` or `app.reset()` will complete the boot process when the same runloop ends, which makes it impossible to async-ify the process.
   
   This wasn't clear to me when I started working on the code – I actually spent some time making them fully async, only to find a lot of tests failing. However, we should start embracing the asynchrony here going forward. I converted the primary (internal) APIs async, which we can start using for new code like the `visit` API. Internally, they wrap their synchronous counterparts which we will use for legacy paths.
   
   This makes things a bit annoying in the short term, but it should help us iterate towards the right direction.
3. **Globals Mode**
   
   Previously, setting the `autoboot` flag also skipped some seemingly unrelated code paths in the boot process. It turns out that most of these code paths are there for the legacy "globals mode" (where the application object acts as a "namespace" for attaching classes, i.e. `App.MyComponent = ...`).
   
   While it's fair to overload the `autoboot` flag as an opt-out for these features, they are ultimately unrelated concerns. To make the distinction clear, I added an internal `_globalsMode` flag to track these code paths. Its value is currently tied to the `autoboot` flag, but you can manually hardcode the `autoboot = true, _globalsMode = false` combo and run the tests, which should reveal that spots where we are relying on these behaviors. Since most of these features have already been deprecated, separating it from `autoboot` as a concept should help to review and remove them independently.
4. **Expansion of the `environment` concept**
   
   With HTMLBars, most of the initial render path has already been jQuery-free (which is why FastBoot works in node). The last bit I had to plumb was the `view.appendTo(rootElement)` call, which uses jQuery to resolve the `rootElement` selector into an Element.
   
   The current `visit` implement works around this by exposing the "root view" without attaching its element. This isn't ideal since we already deprecated/removed views and it requires the use of other private APIs like `appendTo` and `renderToElement`.
   
   In practice, if we were given an actual `Element` object as the `rootElement`, our renderer already knows how to append it into the DOM without jQuery. All I need to do is to tell plumb that through to the view layer so that it can skip the jQuery lookup if the user has opt-ed to not user jQuery. To do this, I expanded on the `environment` abstraction and made it instance specific through the `-environment:main` container key. I only did what I needed to do to make my scenarios work, but that should lay the ground work for the eventual "optional jQuery" world.

See also https://github.com/emberjs/ember.js/issues/11291 and https://github.com/emberjs/ember.js/pull/11289#issuecomment-105960488
### New (Public) APIs
- `Application.autoboot` flag
- `Application#boot()`
- `Application#visit()`
- `ApplicationInstance#getURL()`
- `ApplicationInstance#visit()`
### Tests

I expanded the unit tests coverage, and added some end-to-end integration tests for the a few target scenarios we intend to support.
### Documentation

You can find them in the diff.
### Bonus DLC Pack

To redeem, enter the following code into the Ember Data store: `F83J-7BD2-D16Z-3QA4`
### Emojis

:+1: :star: :point_right: :heart: :headphones: :key: :rocket: :japanese_goblin: 
## Differences from current implementation
- `Application.autoboot` should only be set before boot time (e.g. at `create` time)
- `Application#visit()` no longer rejects if a redirect occurred during the initial transition
- `Application#visit()` no longer attach a `view` property to the instance it returns
- `Application#visit()` no longer prevents the router from inserting the top-level view into the DOM (use `rootElement` to customize the insertion point as usual)
- `Application#visit()` resolves only after rendering is complete and the root view is attached to the DOM
- `Application#visit()` now takes an option hash for customizing the instance
- Uncaught errors in application/instance initializers now causes `Application#visit()` to reject instead of synchronously throws
- Removed `ApplicationView#overrideRouterLocation` (use the `location` boot option instead)
- New flags that enables a much wider range of scenarios
- Better documentation
## TODOs
- [ ] Add some node tests
- [ ] Update the `ember-cli-fastboot` implementation
- [ ] Move [`ember-cli-fastboot`-specific hacks](https://github.com/tildeio/ember-cli-fastboot/blob/master/app/initializers/fastboot.js#L12-L20) into the appropriate package; since the DOMHelper API is not public, we cannot ship until things works out of the box (see also https://github.com/krisselden/morph-range/pull/7)
- [ ] Better error reporting: differentiate between a `BootError` and a `TransitionError`: for transition errors, it is useful to still return the instance, as there we might have rendered an error page into the DOM
## Open questions
- [ ] Various TODOs in the code comments that I have no answers to
- [ ] Are we comfortable committing the the three scenarios I listed in the documentation? Do we need to add more?
- [ ] Is the `ApplicationInstance#visit` implementation correct?
- [ ] Can we consolidate `autoboot` with Ember CLI's `autorun` flag? (they do related but not identical things)
## Future extensions
- Formalize the API requirements for the fake DOM, DOMHelper, etc
- Use these API for tests: boot a new instance in each test case by calling `visit()` and `destroy()` it in teardown, instead of calling `App.reset()`. Use `ApplicationInstance#visit` to implement the `visit` test helper, etc
- Work with @mitchlloyd on Ember Islands type scenarios (see the [test](https://github.com/emberjs/ember.js/commit/b037894a2d278effb07f469d64cb68c7ec0739b8))
- Flesh out the options to enable other scenarios
- Plumb the `environment` through the rest of the view layer to make `jQuery` optional
- Remove reliance on globals mode in tests
- Add a mechanism to differentiate between the various types of redirects and common errors, so that a FastBoot server can return the right status code

cc @wycats @tomdale @stefanpenner @krisselden @mitchlloyd @chadhietala @joshvfleming :pray: 
