### PR TITLE
[BUGFIX beta] Ensure that `this._super` is called by Components.

### DIFF
--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -606,13 +606,14 @@ export default Mixin.create({
     @private
   */
   init() {
+    this._super(...arguments);
+
     if (!this.elementId) {
       this.elementId = guidFor(this);
     }
 
     this.scheduledRevalidation = false;
 
-    this._super(...arguments);
     this[INIT_WAS_CALLED] = true;
 
     assert(

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -7,6 +7,9 @@ import { guidFor } from 'ember-metal/utils';
 import { computed } from 'ember-metal/computed';
 import { Mixin } from 'ember-metal/mixin';
 import { POST_INIT } from 'ember-runtime/system/core_object';
+import { symbol } from 'ember-metal/utils';
+
+const INIT_WAS_CALLED = symbol('INIT_WAS_CALLED');
 
 import jQuery from 'ember-views/system/jquery';
 
@@ -610,6 +613,7 @@ export default Mixin.create({
     this.scheduledRevalidation = false;
 
     this._super(...arguments);
+    this[INIT_WAS_CALLED] = true;
 
     assert(
       'Using a custom `.render` function is no longer supported.',
@@ -628,6 +632,12 @@ export default Mixin.create({
    */
   [POST_INIT]: function() {
     this._super(...arguments);
+
+    assert(
+      `You must call \`this._super(...arguments);\` when implementing \`init\` in a component. Please update ${this} to call \`this._super\` from \`init\`.`,
+      this[INIT_WAS_CALLED]
+    );
+
     this.renderer.componentInitAttrs(this, this.attrs || {});
   },
 

--- a/packages/ember-views/tests/views/component_test.js
+++ b/packages/ember-views/tests/views/component_test.js
@@ -27,6 +27,16 @@ QUnit.module('Ember.Component', {
   }
 });
 
+QUnit.test('throws an error if `this._super` is not called from `init`', function() {
+  let TestComponent = Component.extend({
+    init() { }
+  });
+
+  expectAssertion(function() {
+    TestComponent.create();
+  }, /You must call `this._super\(...arguments\);` when implementing `init` in a component. Please update .* to call `this._super` from `init`/);
+});
+
 QUnit.test('can access `actions` hash via `_actions` [DEPRECATED]', function() {
   expect(2);
 


### PR DESCRIPTION
When implementing `init` in a component subclass you must call `this._super(...arguments)`.  If you do not you will get an error.  Unfortunately, that error is **very** hard to understand and is completely unrelated to code that you have written.

This change adds a small flag (via symbol to avoid exposing this publicly) that we can use to ensure that `_super` was called properly.

---

After these changes, given the following:

``` javascript
import Ember from 'ember';

export default Ember.Component.extend({
  init() {
    this.doThings();
  }
});
```

Will throw an error that explains that you must call `_super`:

```
You must call `this._super(...arguments);` when implementing `init`
in a component. Please update ${this} to call `this._super` from `init`.
```

/cc @ef4
