### PR TITLE
[CLEANUP beta] Use Ember.A from module.

### DIFF
--- a/packages/ember-extension-support/tests/data_adapter_test.js
+++ b/packages/ember-extension-support/tests/data_adapter_test.js
@@ -1,4 +1,3 @@
-import Ember from 'ember-metal/core';
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
 import run from 'ember-metal/run_loop';
@@ -7,6 +6,7 @@ import {
   removeObserver
 } from 'ember-metal/observer';
 import EmberObject from 'ember-runtime/system/object';
+import { A as emberA } from 'ember-runtime/system/native_array';
 import EmberDataAdapter from 'ember-extension-support/data_adapter';
 import EmberApplication from 'ember-application/system/application';
 import DefaultResolver from 'ember-application/system/resolver';
@@ -43,7 +43,7 @@ QUnit.test('Model types added with DefaultResolver', function() {
   adapter = App.__container__.lookup('data-adapter:main');
   adapter.reopen({
     getRecords() {
-      return Ember.A([1, 2, 3]);
+      return emberA([1, 2, 3]);
     },
     columnsForType() {
       return [{ name: 'title', desc: 'Title' }];
@@ -71,7 +71,7 @@ QUnit.test('getRecords gets a model name as second argument', function() {
   adapter.reopen({
     getRecords(klass, name) {
       equal(name, 'post');
-      return Ember.A([]);
+      return emberA();
     }
   });
 
@@ -93,7 +93,7 @@ QUnit.test('Model types added with custom container-debug-adapter', function() {
   adapter = App.__container__.lookup('data-adapter:main');
   adapter.reopen({
     getRecords() {
-      return Ember.A([1, 2, 3]);
+      return emberA([1, 2, 3]);
     },
     columnsForType() {
       return [{ name: 'title', desc: 'Title' }];
@@ -119,7 +119,7 @@ QUnit.test('Model Types Updated', function() {
   App.Post = Model.extend();
 
   adapter = App.__container__.lookup('data-adapter:main');
-  var records = Ember.A([1, 2, 3]);
+  var records = emberA([1, 2, 3]);
   adapter.reopen({
     getRecords() {
       return records;
@@ -149,7 +149,7 @@ QUnit.test('Records Added', function() {
   App.Post = Model.extend();
 
   var post = App.Post.create();
-  var recordList = Ember.A([post]);
+  var recordList = emberA([post]);
 
   adapter = App.__container__.lookup('data-adapter:main');
   adapter.reopen({
@@ -186,7 +186,7 @@ QUnit.test('Observes and releases a record correctly', function() {
   App.Post = Model.extend();
 
   var post = App.Post.create({ title: 'Post' });
-  var recordList = Ember.A([post]);
+  var recordList = emberA([post]);
 
   adapter = App.__container__.lookup('data-adapter:main');
   adapter.reopen({

--- a/packages/ember-htmlbars/tests/helpers/collection_test.js
+++ b/packages/ember-htmlbars/tests/helpers/collection_test.js
@@ -1,4 +1,3 @@
-/*jshint newcap:false*/
 import Ember from 'ember-metal/core';
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
@@ -8,7 +7,7 @@ import EmberObject from 'ember-runtime/system/object';
 import ArrayProxy from 'ember-runtime/system/array_proxy';
 import Namespace from 'ember-runtime/system/namespace';
 import { Registry } from 'ember-runtime/system/container';
-import { A } from 'ember-runtime/system/native_array';
+import { A as emberA } from 'ember-runtime/system/native_array';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
 import CollectionView from 'ember-views/views/collection_view';
 import EmberView from 'ember-views/views/view';
@@ -67,7 +66,7 @@ QUnit.test('Collection views that specify an example view class have their child
       isCustom: true
     }),
 
-    content: A(['foo'])
+    content: emberA(['foo'])
   });
 
   view = EmberView.create({
@@ -91,7 +90,7 @@ QUnit.test('itemViewClass works in the #collection helper with a property', func
     possibleItemView: ExampleItemView,
     exampleCollectionView: ExampleCollectionView,
     exampleController: ArrayProxy.create({
-      content: A(['alpha'])
+      content: emberA(['alpha'])
     }),
     template: compile('{{#collection view.exampleCollectionView content=view.exampleController itemViewClass=view.possibleItemView}}beta{{/collection}}')
   });
@@ -110,7 +109,7 @@ QUnit.test('itemViewClass works in the #collection via container', function() {
     container: container,
     exampleCollectionView: CollectionView.extend(),
     exampleController: ArrayProxy.create({
-      content: A(['alpha'])
+      content: emberA(['alpha'])
     }),
     template: compile('{{#collection view.exampleCollectionView content=view.exampleController itemViewClass="example-item"}}beta{{/collection}}')
   });
@@ -124,7 +123,7 @@ QUnit.test('itemViewClass works in the #collection via container', function() {
 QUnit.test('passing a block to the collection helper sets it as the template for example views', function() {
   var CollectionTestView = CollectionView.extend({
     tagName: 'ul',
-    content: A(['foo', 'bar', 'baz'])
+    content: emberA(['foo', 'bar', 'baz'])
   });
 
   view = EmberView.create({
@@ -143,7 +142,7 @@ QUnit.test('collection helper should try to use container to resolve view', func
 
   var ACollectionView = CollectionView.extend({
     tagName: 'ul',
-    content: A(['foo', 'bar', 'baz'])
+    content: emberA(['foo', 'bar', 'baz'])
   });
 
   registry.register('view:collectionTest', ACollectionView);
@@ -163,7 +162,7 @@ QUnit.test('collection helper should accept relative paths', function() {
     template: compile('{{#collection view.collection}} <label></label> {{/collection}}'),
     collection: CollectionView.extend({
       tagName: 'ul',
-      content: A(['foo', 'bar', 'baz'])
+      content: emberA(['foo', 'bar', 'baz'])
     })
   });
 
@@ -182,7 +181,7 @@ QUnit.test('empty views should be removed when content is added to the collectio
   });
 
   var listController = ArrayProxy.create({
-    content : A()
+    content : emberA()
   });
 
   view = EmberView.create({
@@ -233,7 +232,7 @@ QUnit.test('should be able to specify which class should be used for the empty v
 QUnit.test('if no content is passed, and no \'else\' is specified, nothing is rendered', function() {
   var CollectionTestView = CollectionView.extend({
     tagName: 'ul',
-    content: A()
+    content: emberA()
   });
 
   view = EmberView.create({
@@ -249,7 +248,7 @@ QUnit.test('if no content is passed, and no \'else\' is specified, nothing is re
 QUnit.test('if no content is passed, and \'else\' is specified, the else block is rendered', function() {
   var CollectionTestView = CollectionView.extend({
     tagName: 'ul',
-    content: A()
+    content: emberA()
   });
 
   view = EmberView.create({
@@ -265,7 +264,7 @@ QUnit.test('if no content is passed, and \'else\' is specified, the else block i
 QUnit.test('a block passed to a collection helper defaults to the content property of the context', function() {
   var CollectionTestView = CollectionView.extend({
     tagName: 'ul',
-    content: A(['foo', 'bar', 'baz'])
+    content: emberA(['foo', 'bar', 'baz'])
   });
 
   view = EmberView.create({
@@ -286,7 +285,7 @@ QUnit.test('a block passed to a collection helper defaults to the content proper
 QUnit.test('a block passed to a collection helper defaults to the view', function() {
   var CollectionTestView = CollectionView.extend({
     tagName: 'ul',
-    content: A(['foo', 'bar', 'baz'])
+    content: emberA(['foo', 'bar', 'baz'])
   });
 
   view = EmberView.create({
@@ -305,7 +304,7 @@ QUnit.test('a block passed to a collection helper defaults to the view', functio
   equal(view.$('li:nth-child(3) label').text(), 'baz');
 
   run(function() {
-    set(firstChild(view), 'content', A());
+    set(firstChild(view), 'content', emberA());
   });
   equal(view.$('label').length, 0, 'all list item views should be removed from DOM');
 });
@@ -313,7 +312,7 @@ QUnit.test('a block passed to a collection helper defaults to the view', functio
 QUnit.test('should include an id attribute if id is set in the options hash', function() {
   var CollectionTestView = CollectionView.extend({
     tagName: 'ul',
-    content: A(['foo', 'bar', 'baz'])
+    content: emberA(['foo', 'bar', 'baz'])
   });
 
   view = EmberView.create({
@@ -329,7 +328,7 @@ QUnit.test('should include an id attribute if id is set in the options hash', fu
 QUnit.test('should give its item views the class specified by itemClass', function() {
   var ItemClassTestCollectionView = CollectionView.extend({
     tagName: 'ul',
-    content: A(['foo', 'bar', 'baz'])
+    content: emberA(['foo', 'bar', 'baz'])
   });
   view = EmberView.create({
     itemClassTestCollectionView: ItemClassTestCollectionView,
@@ -344,7 +343,7 @@ QUnit.test('should give its item views the class specified by itemClass', functi
 QUnit.test('should give its item views the class specified by itemClass binding', function() {
   var ItemClassBindingTestCollectionView = CollectionView.extend({
     tagName: 'ul',
-    content: A([EmberObject.create({ isBaz: false }), EmberObject.create({ isBaz: true }), EmberObject.create({ isBaz: true })])
+    content: emberA([EmberObject.create({ isBaz: false }), EmberObject.create({ isBaz: true }), EmberObject.create({ isBaz: true })])
   });
 
   view = EmberView.create({
@@ -374,7 +373,7 @@ QUnit.test('should give its item views the property specified by itemProperty', 
   // Set itemView bindings using item*
   view = EmberView.create({
     baz: 'baz',
-    content: A([EmberObject.create(), EmberObject.create(), EmberObject.create()]),
+    content: emberA([EmberObject.create(), EmberObject.create(), EmberObject.create()]),
     container: registry.container(),
     template: compile('{{#collection content=view.content tagName="ul" itemViewClass="item-property-binding-test-item-view" itemProperty=view.baz preserveContext=false}}{{view.property}}{{/collection}}')
   });
@@ -395,7 +394,7 @@ QUnit.test('should give its item views the property specified by itemProperty', 
 });
 
 QUnit.test('should work inside a bound {{#if}}', function() {
-  var testData = A([EmberObject.create({ isBaz: false }), EmberObject.create({ isBaz: true }), EmberObject.create({ isBaz: true })]);
+  var testData = emberA([EmberObject.create({ isBaz: false }), EmberObject.create({ isBaz: true }), EmberObject.create({ isBaz: true })]);
   var IfTestCollectionView = CollectionView.extend({
     tagName: 'ul',
     content: testData
@@ -422,7 +421,7 @@ QUnit.test('should pass content as context when using {{#each}} helper [DEPRECAT
   view = EmberView.create({
     template: compile('{{#each view.releases as |release|}}Mac OS X {{release.version}}: {{release.name}} {{/each}}'),
 
-    releases: A([
+    releases: emberA([
                 { version: '10.7',
                   name: 'Lion' },
                 { version: '10.6',
@@ -440,7 +439,7 @@ QUnit.test('should pass content as context when using {{#each}} helper [DEPRECAT
 QUnit.test('should re-render when the content object changes', function() {
   var RerenderTest = CollectionView.extend({
     tagName: 'ul',
-    content: A()
+    content: emberA()
   });
 
   view = EmberView.create({
@@ -451,11 +450,11 @@ QUnit.test('should re-render when the content object changes', function() {
   runAppend(view);
 
   run(function() {
-    set(firstChild(view), 'content', A(['bing', 'bat', 'bang']));
+    set(firstChild(view), 'content', emberA(['bing', 'bat', 'bang']));
   });
 
   run(function() {
-    set(firstChild(view), 'content', A(['ramalamadingdong']));
+    set(firstChild(view), 'content', emberA(['ramalamadingdong']));
   });
 
   equal(view.$('li').length, 1, 'rerenders with correct number of items');
@@ -464,7 +463,7 @@ QUnit.test('should re-render when the content object changes', function() {
 
 QUnit.test('select tagName on collection helper automatically sets child tagName to option', function() {
   var RerenderTest = CollectionView.extend({
-    content: A(['foo'])
+    content: emberA(['foo'])
   });
 
   view = EmberView.create({
@@ -479,7 +478,7 @@ QUnit.test('select tagName on collection helper automatically sets child tagName
 
 QUnit.test('tagName works in the #collection helper', function() {
   var RerenderTest = CollectionView.extend({
-    content: A(['foo', 'bar'])
+    content: emberA(['foo', 'bar'])
   });
 
   view = EmberView.create({
@@ -493,7 +492,7 @@ QUnit.test('tagName works in the #collection helper', function() {
   equal(view.$('li').length, 2, 'rerenders with correct number of items');
 
   run(function() {
-    set(firstChild(view), 'content', A(['bing', 'bat', 'bang']));
+    set(firstChild(view), 'content', emberA(['bing', 'bat', 'bang']));
   });
 
   equal(view.$('li').length, 3, 'rerenders with correct number of items');
@@ -502,7 +501,7 @@ QUnit.test('tagName works in the #collection helper', function() {
 
 QUnit.test('itemClassNames adds classes to items', function() {
   view = EmberView.create({
-    context: { list: A(['one', 'two']) },
+    context: { list: emberA(['one', 'two']) },
     template: compile('{{#collection content=list itemClassNames="some-class"}}{{/collection}}')
   });
 
@@ -516,12 +515,12 @@ QUnit.test('should render nested collections', function() {
   var container = registry.container();
   registry.register('view:inner-list', CollectionView.extend({
     tagName: 'ul',
-    content: A(['one', 'two', 'three'])
+    content: emberA(['one', 'two', 'three'])
   }));
 
   registry.register('view:outer-list', CollectionView.extend({
     tagName: 'ul',
-    content: A(['foo'])
+    content: emberA(['foo'])
   }));
 
   view = EmberView.create({
@@ -541,7 +540,7 @@ QUnit.test('should render multiple, bound nested collections (#68)', function() 
 
   run(function() {
     TemplateTests.contentController = ArrayProxy.create({
-      content: A(['foo', 'bar'])
+      content: emberA(['foo', 'bar'])
     });
 
     var InnerList = CollectionView.extend({
@@ -553,7 +552,7 @@ QUnit.test('should render multiple, bound nested collections (#68)', function() 
       innerListView: InnerList,
       template: compile('{{#collection view.innerListView class="inner"}}{{content}}{{/collection}}{{content}}'),
       innerListContent: computed(function() {
-        return A([1, 2, 3]);
+        return emberA([1, 2, 3]);
       })
     });
 
@@ -609,7 +608,7 @@ QUnit.test('should allow view objects to be swapped out without throwing an erro
   run(function() {
     dataset = EmberObject.create({
       ready: true,
-      items: A([1, 2, 3])
+      items: emberA([1, 2, 3])
     });
     TemplateTests.datasetController.set('dataset', dataset);
   });
@@ -632,7 +631,7 @@ QUnit.test('context should be content', function() {
   registry = new Registry();
   container = registry.container();
 
-  var items = A([
+  var items = emberA([
     EmberObject.create({ name: 'Dave' }),
     EmberObject.create({ name: 'Mary' }),
     EmberObject.create({ name: 'Sara' })

--- a/packages/ember-htmlbars/tests/helpers/each_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_test.js
@@ -1,10 +1,9 @@
-/*jshint newcap:false*/
 import Ember from 'ember-metal/core'; // Ember.lookup;
 import EmberObject from 'ember-runtime/system/object';
 import run from 'ember-metal/run_loop';
 import EmberView from 'ember-views/views/view';
 import LegacyEachView from 'ember-views/views/legacy_each_view';
-import { A } from 'ember-runtime/system/native_array';
+import { A as emberA } from 'ember-runtime/system/native_array';
 import EmberController from 'ember-runtime/controllers/controller';
 import { Registry } from 'ember-runtime/system/container';
 
@@ -35,7 +34,7 @@ QUnit.module('the #each helper', {
     registerAstPlugin(TransformEachIntoCollection);
 
     template = compile('{{#each view.people as |person|}}{{person.name}}{{/each}}');
-    people = A([{ name: 'Steve Holt' }, { name: 'Annabelle' }]);
+    people = emberA([{ name: 'Steve Holt' }, { name: 'Annabelle' }]);
 
     registry = new Registry();
     container = registry.container();
@@ -193,8 +192,8 @@ QUnit.test('View should not use keyword incorrectly - Issue #1315', function() {
     container: container,
     template: compile('{{#each view.content as |value|}}{{value}}-{{#each view.options as |option|}}{{option.value}}:{{option.label}} {{/each}}{{/each}}'),
 
-    content: A(['X', 'Y']),
-    options: A([
+    content: emberA(['X', 'Y']),
+    options: emberA([
       { label: 'One', value: 1 },
       { label: 'Two', value: 2 }
     ])
@@ -352,7 +351,7 @@ QUnit.test('it supports {{itemViewClass=}} with {{else}} block (DEPRECATED)', fu
         {{~else~}}
           No records!
         {{~/each}}`),
-      people: A(),
+      people: emberA(),
       container: container
     });
   }, /Using 'itemViewClass' with '{{each}}'/);
@@ -371,7 +370,7 @@ QUnit.test('it supports {{emptyView=}}', function() {
   expectDeprecation(() => {
     view = EmberView.create({
       template: compile('{{each view.people emptyView="anEmptyView"}}'),
-      people: A(),
+      people: emberA(),
       container: container
     });
   }, /Using 'emptyView' with '{{each}}'/);
@@ -392,7 +391,7 @@ QUnit.test('it defers all normalization of emptyView names to the resolver', fun
   expectDeprecation(() => {
     view = EmberView.create({
       template: compile('{{each view.people emptyView="an-empty-view"}}'),
-      people: A(),
+      people: emberA(),
       container: container
     });
   }, /Using 'emptyView' with '{{each}}'/);
@@ -410,7 +409,7 @@ QUnit.test('it supports {{emptyViewClass=}} via container', function() {
     view = EmberView.create({
       container: container,
       template: compile('{{each view.people emptyViewClass="my-empty-view"}}'),
-      people: A()
+      people: emberA()
     });
   }, /Using 'emptyViewClass' with '{{each}}'/);
 
@@ -424,7 +423,7 @@ QUnit.test('it supports {{emptyViewClass=}} with tagName (DEPRECATED)', function
   expectDeprecation(() => {
     view = EmberView.create({
       template: compile('{{each view.people emptyViewClass="my-empty-view" tagName="b"}}'),
-      people: A(),
+      people: emberA(),
       container: container
     });
   }, /Using 'emptyViewClass' with '{{each}}'/);
@@ -441,7 +440,7 @@ QUnit.test('it supports {{emptyViewClass=}} with in format', function() {
     view = EmberView.create({
       container: container,
       template: compile('{{each person in view.people emptyViewClass="my-empty-view"}}'),
-      people: A()
+      people: emberA()
     });
   }, /Using 'emptyViewClass' with '{{each}}'/);
 
@@ -454,7 +453,7 @@ QUnit.test('it uses {{else}} when replacing model with an empty array', function
   runDestroy(view);
   view = EmberView.create({
     template: compile('{{#each view.items as |item|}}{{item}}{{else}}Nothing{{/each}}'),
-    items: A(['one', 'two'])
+    items: emberA(['one', 'two'])
   });
 
   runAppend(view);
@@ -462,7 +461,7 @@ QUnit.test('it uses {{else}} when replacing model with an empty array', function
   assertHTML(view, 'onetwo');
 
   run(function() {
-    view.set('items', A());
+    view.set('items', emberA());
   });
 
   assertHTML(view, 'Nothing');
@@ -470,7 +469,7 @@ QUnit.test('it uses {{else}} when replacing model with an empty array', function
 
 QUnit.test('it uses {{else}} when removing all items in an array', function() {
   runDestroy(view);
-  var items = A(['one', 'two']);
+  var items = emberA(['one', 'two']);
   view = EmberView.create({
     template: compile('{{#each view.items as |item|}}{{item}}{{else}}Nothing{{/each}}'),
     items
@@ -490,7 +489,7 @@ QUnit.test('it uses {{else}} when removing all items in an array', function() {
 
 QUnit.test('it can move to and from {{else}} properly when the backing array gains and looses items (#11140)', function() {
   runDestroy(view);
-  var items = A(['one', 'two']);
+  var items = emberA(['one', 'two']);
   view = EmberView.create({
     template: compile('{{#each view.items as |item|}}{{item}}{{else}}Nothing{{/each}}'),
     items
@@ -541,7 +540,7 @@ QUnit.test('#each accepts a name binding', function() {
   view = EmberView.create({
     template: compile('{{#each view.items as |item|}}{{view.title}} {{item}}{{/each}}'),
     title: 'My Cool Each Test',
-    items: A([1, 2])
+    items: emberA([1, 2])
   });
 
   runAppend(view);
@@ -560,7 +559,7 @@ QUnit.test('#each accepts a name binding and does not change the context', funct
   view = EmberView.create({
     template: compile('{{#each view.items as |item|}}{{name}}{{/each}}'),
     title: 'My Cool Each Test',
-    items: A([obj]),
+    items: emberA([obj]),
     controller: controller
   });
 
@@ -573,7 +572,7 @@ QUnit.test('#each accepts a name binding and can display child properties', func
   view = EmberView.create({
     template: compile('{{#each view.items as |item|}}{{view.title}} {{item.name}}{{/each}}'),
     title: 'My Cool Each Test',
-    items: A([{ name: 1 }, { name: 2 }])
+    items: emberA([{ name: 1 }, { name: 2 }])
   });
 
   runAppend(view);
@@ -585,7 +584,7 @@ QUnit.test('#each accepts \'this\' as the right hand side', function() {
   view = EmberView.create({
     template: compile('{{#each this as |item|}}{{view.title}} {{item.name}}{{/each}}'),
     title: 'My Cool Each Test',
-    controller: A([{ name: 1 }, { name: 2 }])
+    controller: emberA([{ name: 1 }, { name: 2 }])
   });
 
   runAppend(view);
@@ -595,7 +594,7 @@ QUnit.test('#each accepts \'this\' as the right hand side', function() {
 
 QUnit.test('it doesn\'t assert when the morph tags have the same parent', function() {
   view = EmberView.create({
-    controller: A(['Cyril', 'David']),
+    controller: emberA(['Cyril', 'David']),
     template: compile('<table><tbody>{{#each this as |name|}}<tr><td>{{name}}</td></tr>{{/each}}</tbody></table>')
   });
 
@@ -636,7 +635,7 @@ QUnit.test('the index is passed as the second parameter to #each blocks', functi
 
   var adam = { name: 'Adam' };
   view = EmberView.create({
-    controller: A([adam, { name: 'Steve' }]),
+    controller: emberA([adam, { name: 'Steve' }]),
     template: compile('{{#each this as |person index|}}{{index}}. {{person.name}}{{/each}}')
   });
   runAppend(view);
@@ -752,7 +751,7 @@ QUnit.test('duplicate keys work properly with primitive items', function() {
 QUnit.test('pushing a new duplicate key will render properly with primitive items', function() {
   runDestroy(view);
   view = EmberView.create({
-    items: A(['a', 'b', 'c']),
+    items: emberA(['a', 'b', 'c']),
     template: compile('{{#each view.items as |item|}}{{item}}{{/each}}')
   });
 
@@ -768,7 +767,7 @@ QUnit.test('pushing a new duplicate key will render properly with primitive item
 QUnit.test('pushing primitive item twice will render properly', function() {
   runDestroy(view);
   view = EmberView.create({
-    items: A(),
+    items: emberA(),
     template: compile('{{#each view.items as |item|}}{{item}}{{/each}}')
   });
 
@@ -811,7 +810,7 @@ QUnit.test('pushing a new duplicate key will render properly with objects', func
 
   let duplicateItem = { display: 'foo' };
   view = EmberView.create({
-    items: A([
+    items: emberA([
       duplicateItem,
       { display: 'bar' },
       { display: 'qux' }

--- a/packages/ember-htmlbars/tests/helpers/if_unless_test.js
+++ b/packages/ember-htmlbars/tests/helpers/if_unless_test.js
@@ -147,16 +147,16 @@ function testIfArray(array) {
 }
 
 QUnit.test('The `if` helper updates if an array is empty or not', function() {
-  testIfArray(Ember.A());
+  testIfArray(emberA());
 });
 
 QUnit.test('The `if` helper updates if an array-like object is empty or not', function() {
-  testIfArray(ArrayProxy.create({ content: Ember.A([]) }));
+  testIfArray(ArrayProxy.create({ content: emberA() }));
 });
 
 QUnit.test('The `unless` helper updates if an array-like object is empty or not', function() {
   view = EmberView.create({
-    array: ArrayProxy.create({ content: Ember.A([]) }),
+    array: ArrayProxy.create({ content: emberA() }),
 
     template: compile('{{#unless view.array}}Yep{{/unless}}')
   });
@@ -835,7 +835,7 @@ QUnit.test('`if` helper with inline form: respects isTruthy when property change
 });
 
 QUnit.test('`if` helper with inline form: respects length test when list content changes', function() {
-  var list = Ember.A();
+  var list = emberA();
 
   view = EmberView.create({
     conditional: list,

--- a/packages/ember-htmlbars/tests/helpers/unbound_test.js
+++ b/packages/ember-htmlbars/tests/helpers/unbound_test.js
@@ -1,9 +1,8 @@
-/*jshint newcap:false*/
 import EmberView from 'ember-views/views/view';
 import EmberComponent from 'ember-views/components/component';
 import EmberObject from 'ember-runtime/system/object';
 
-import { A } from 'ember-runtime/system/native_array';
+import { A as emberA } from 'ember-runtime/system/native_array';
 import Ember from 'ember-metal/core';
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
@@ -83,7 +82,7 @@ QUnit.test('should property escape unsafe hrefs', function() {
 
   view = EmberView.create({
     template: compile('<ul>{{#each view.people as |person|}}<a href="{{unbound person.url}}">{{person.name}}</a>{{/each}}</ul>'),
-    people: A([{
+    people: emberA([{
       name: 'Bob',
       url: 'javascript:bob-is-cool'
     }, {
@@ -413,7 +412,7 @@ QUnit.test('should be able to render an unbound helper invocation in #each helpe
        '{{-capitalize person.firstName}} {{unbound (-capitalize person.firstName)}}',
        '{{/each}}'].join('')),
     context: {
-      people: Ember.A([
+      people: emberA([
         {
           firstName: 'shooby',
           lastName:  'taylor'
@@ -542,7 +541,7 @@ QUnit.test('should be able to output a property without binding', function() {
 
 QUnit.test('should be able to use unbound helper in #each helper', function() {
   view = EmberView.create({
-    items: A(['a', 'b', 'c', 1, 2, 3]),
+    items: emberA(['a', 'b', 'c', 1, 2, 3]),
     template: compile('<ul>{{#each view.items as |item|}}<li>{{unbound item}}</li>{{/each}}</ul>')
   });
 
@@ -554,7 +553,7 @@ QUnit.test('should be able to use unbound helper in #each helper', function() {
 
 QUnit.test('should be able to use unbound helper in #each helper (with objects)', function() {
   view = EmberView.create({
-    items: A([{ wham: 'bam' }, { wham: 1 }]),
+    items: emberA([{ wham: 'bam' }, { wham: 1 }]),
     template: compile('<ul>{{#each view.items as |item|}}<li>{{unbound item.wham}}</li>{{/each}}</ul>')
   });
 
@@ -569,7 +568,7 @@ QUnit.test('should work properly with attributes', function() {
 
   view = EmberView.create({
     template: compile('<ul>{{#each view.people as |person|}}<li class="{{unbound person.cool}}">{{person.name}}</li>{{/each}}</ul>'),
-    people: A([{
+    people: emberA([{
       name: 'Bob',
       cool: 'not-cool'
     }, {

--- a/packages/ember-htmlbars/tests/helpers/with_test.js
+++ b/packages/ember-htmlbars/tests/helpers/with_test.js
@@ -1,4 +1,3 @@
-/*jshint newcap:false*/
 import Ember from 'ember-metal/core';
 import EmberView from 'ember-views/views/view';
 import run from 'ember-metal/run_loop';

--- a/packages/ember-htmlbars/tests/helpers/yield_test.js
+++ b/packages/ember-htmlbars/tests/helpers/yield_test.js
@@ -1,11 +1,9 @@
-/*jshint newcap:false*/
 import Ember from 'ember-metal/core';
 import run from 'ember-metal/run_loop';
 import EmberView from 'ember-views/views/view';
 import { computed } from 'ember-metal/computed';
 import { Registry } from 'ember-runtime/system/container';
-//import { set } from "ember-metal/property_set";
-import { A } from 'ember-runtime/system/native_array';
+import { A as emberA } from 'ember-runtime/system/native_array';
 import Component from 'ember-views/components/component';
 import helpers from 'ember-htmlbars/helpers';
 import ComponentLookup from 'ember-views/component_lookup';
@@ -85,7 +83,7 @@ QUnit.test('templates should yield to block, when the yield is embedded in a hie
     n: null,
     index: computed(function() {
       var n = this.attrs.n;
-      var indexArray = A();
+      var indexArray = emberA();
       for (var i = 0; i < n; i++) {
         indexArray[i] = i;
       }

--- a/packages/ember-htmlbars/tests/integration/component_invocation_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_invocation_test.js
@@ -12,6 +12,7 @@ import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
 import alias from 'ember-metal/alias';
 import run from 'ember-metal/run_loop';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 var registry, container, view;
 
@@ -812,7 +813,7 @@ QUnit.test('non-block with each rendering child components', function() {
   registry.register('template:components/non-block', compile('In layout. {{#each attrs.items as |item|}}[{{child-non-block item=item}}]{{/each}}'));
   registry.register('template:components/child-non-block', compile('Child: {{attrs.item}}.'));
 
-  var items = Ember.A(['Tom', 'Dick', 'Harry']);
+  var items = emberA(['Tom', 'Dick', 'Harry']);
 
   view = EmberView.extend({
     template: compile('{{non-block items=view.items}}'),

--- a/packages/ember-htmlbars/tests/integration/select_in_template_test.js
+++ b/packages/ember-htmlbars/tests/integration/select_in_template_test.js
@@ -1,4 +1,3 @@
-import Ember from 'ember-metal/core';
 import EmberObject from 'ember-runtime/system/object';
 import run from 'ember-metal/run_loop';
 import EmberView from 'ember-views/views/view';
@@ -7,6 +6,7 @@ import EventDispatcher from 'ember-views/system/event_dispatcher';
 import { computed } from 'ember-metal/computed';
 import Namespace from 'ember-runtime/system/namespace';
 import ArrayProxy from 'ember-runtime/system/array_proxy';
+import { A as emberA } from 'ember-runtime/system/native_array';
 import SelectView from 'ember-views/views/select';
 import compile from 'ember-template-compiler/system/compile';
 import Controller from 'ember-runtime/controllers/controller';
@@ -48,7 +48,7 @@ QUnit.test('works from a template with bindings [DEPRECATED]', function() {
   var application = Namespace.create();
 
   application.peopleController = Controller.create({
-    content: Ember.A([
+    content: emberA([
       Person.create({ id: 1, firstName: 'Yehuda', lastName: 'Katz' }),
       Person.create({ id: 2, firstName: 'Tom', lastName: 'Dale' }),
       Person.create({ id: 3, firstName: 'Peter', lastName: 'Wagenet' }),
@@ -110,7 +110,7 @@ QUnit.test('works from a template', function() {
   var application = Namespace.create();
 
   application.peopleController = Controller.create({
-    content: Ember.A([
+    content: emberA([
       Person.create({ id: 1, firstName: 'Yehuda', lastName: 'Katz' }),
       Person.create({ id: 2, firstName: 'Tom', lastName: 'Dale' }),
       Person.create({ id: 3, firstName: 'Peter', lastName: 'Wagenet' }),
@@ -160,8 +160,8 @@ if (!environment.isFirefox) {
   // firefox has bugs...
   // TODO: figure out a solution
   QUnit.test('upon content change, the DOM should reflect the selection (#481)', function() {
-    var userOne = { name: 'Mike', options: Ember.A(['a', 'b']), selectedOption: 'a' };
-    var userTwo = { name: 'John', options: Ember.A(['c', 'd']), selectedOption: 'd' };
+    var userOne = { name: 'Mike', options: emberA(['a', 'b']), selectedOption: 'a' };
+    var userTwo = { name: 'John', options: emberA(['c', 'd']), selectedOption: 'd' };
 
     view = EmberView.create({
       user: userOne,
@@ -195,7 +195,7 @@ QUnit.test('upon content change with Array-like content, the DOM should reflect 
   var sylvain = { id: 5, name: 'Sylvain' };
 
   var proxy = ArrayProxy.create({
-    content: Ember.A(),
+    content: emberA(),
     selectedOption: sylvain
   });
 
@@ -217,7 +217,7 @@ QUnit.test('upon content change with Array-like content, the DOM should reflect 
   equal(selectEl.selectedIndex, -1, 'Precond: The DOM reflects the lack of selection');
 
   run(function() {
-    proxy.set('content', Ember.A([tom, sylvain]));
+    proxy.set('content', emberA([tom, sylvain]));
   });
 
   equal(select.get('selection'), sylvain, 'Selection was properly set after content change');
@@ -226,7 +226,7 @@ QUnit.test('upon content change with Array-like content, the DOM should reflect 
 
 function testValueBinding(templateString) {
   view = EmberView.create({
-    collection: Ember.A([{ name: 'Wes', value: 'w' }, { name: 'Gordon', value: 'g' }]),
+    collection: emberA([{ name: 'Wes', value: 'w' }, { name: 'Gordon', value: 'g' }]),
     val: 'g',
     selectView: SelectView,
     template: compile(templateString)
@@ -276,7 +276,7 @@ QUnit.test('select element should correctly initialize and update selectedIndex 
 
 function testSelectionBinding(templateString) {
   view = EmberView.create({
-    collection: Ember.A([{ name: 'Wes', value: 'w' }, { name: 'Gordon', value: 'g' }]),
+    collection: emberA([{ name: 'Wes', value: 'w' }, { name: 'Gordon', value: 'g' }]),
     selection: { name: 'Gordon', value: 'g' },
     selectView: SelectView,
     template: compile(templateString)
@@ -335,7 +335,7 @@ QUnit.test('select element should correctly initialize and update selectedIndex 
     '    selection=view.selection}}';
 
   view = EmberView.create({
-    collection: Ember.A([{ name: 'Wes', val: 'w' }, { name: 'Gordon', val: 'g' }]),
+    collection: emberA([{ name: 'Wes', val: 'w' }, { name: 'Gordon', val: 'g' }]),
     selection: { name: 'Gordon', val: 'g' },
     selectView: SelectView,
     template: compile(templateString)

--- a/packages/ember-htmlbars/tests/integration/tagless_views_rerender_test.js
+++ b/packages/ember-htmlbars/tests/integration/tagless_views_rerender_test.js
@@ -1,8 +1,8 @@
-import Ember from 'ember-metal/core';
 import run from 'ember-metal/run_loop';
 import EmberView from 'ember-views/views/view';
 import { compile } from 'ember-template-compiler';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 var view;
 
@@ -15,7 +15,7 @@ QUnit.module('ember-htmlbars: tagless views should be able to add/remove child v
 QUnit.test('can insert new child views after initial tagless view rendering', function() {
   view = EmberView.create({
     shouldShow: false,
-    array: Ember.A([1]),
+    array: emberA([1]),
 
     template: compile('{{#if view.shouldShow}}{{#each view.array as |item|}}{{item}}{{/each}}{{/if}}')
   });
@@ -41,7 +41,7 @@ QUnit.test('can insert new child views after initial tagless view rendering', fu
 QUnit.test('can remove child views after initial tagless view rendering', function() {
   view = EmberView.create({
     shouldShow: false,
-    array: Ember.A([]),
+    array: emberA(),
 
     template: compile('{{#if view.shouldShow}}{{#each view.array as |item|}}{{item}}{{/each}}{{/if}}')
   });

--- a/packages/ember-routing-htmlbars/tests/helpers/element_action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/element_action_test.js
@@ -1,4 +1,3 @@
-import Ember from 'ember-metal/core'; // A, FEATURES, assert
 import { set } from 'ember-metal/property_set';
 import run from 'ember-metal/run_loop';
 import EventDispatcher from 'ember-views/system/event_dispatcher';
@@ -6,6 +5,7 @@ import ActionManager from 'ember-views/system/action_manager';
 
 import EmberObject from 'ember-runtime/system/object';
 import EmberController from 'ember-runtime/controllers/controller';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 import compile from 'ember-template-compiler/system/compile';
 import EmberView from 'ember-views/views/view';
@@ -351,7 +351,7 @@ QUnit.test('should work properly in an #each block', function() {
 
   view = EmberView.create({
     controller: controller,
-    items: Ember.A([1, 2, 3, 4]),
+    items: emberA([1, 2, 3, 4]),
     template: compile('{{#each view.items as |item|}}<a href="#" {{action "edit"}}>click me</a>{{/each}}')
   });
 
@@ -411,7 +411,7 @@ QUnit.test('should unregister event handlers on rerender', function() {
 });
 
 QUnit.test('should unregister event handlers on inside virtual views', function() {
-  var things = Ember.A([
+  var things = emberA([
     {
       name: 'Thingy'
     }
@@ -788,7 +788,7 @@ QUnit.test('a quoteless parameter should lookup actionName in context [DEPRECATE
   });
 
   var controller = EmberController.extend({
-    allactions: Ember.A([{ title: 'Biggity Boom', name: 'biggityBoom' },
+    allactions: emberA([{ title: 'Biggity Boom', name: 'biggityBoom' },
                          { title: 'Whomp Whomp', name: 'whompWhomp' },
                          { title: 'Sloopy Dookie', name: 'sloopyDookie' }]),
     actions: {
@@ -837,7 +837,7 @@ QUnit.test('a quoteless string parameter should resolve actionName, including pa
   });
 
   var controller = EmberController.extend({
-    allactions: Ember.A([{ title: 'Biggity Boom', name: 'biggityBoom' },
+    allactions: emberA([{ title: 'Biggity Boom', name: 'biggityBoom' },
                          { title: 'Whomp Whomp', name: 'whompWhomp' },
                          { title: 'Sloopy Dookie', name: 'sloopyDookie' }]),
     actions: {

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -17,6 +17,7 @@ import {
   classify
 } from 'ember-runtime/system/string';
 import EmberObject from 'ember-runtime/system/object';
+import { A as emberA } from 'ember-runtime/system/native_array';
 import Evented from 'ember-runtime/mixins/evented';
 import ActionHandler, { deprecateUnderscoreActions } from 'ember-runtime/mixins/action_handler';
 import generateController from 'ember-routing/system/generate_controller';
@@ -184,7 +185,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
       var defaultValue = get(controllerProto, propName);
 
       if (Array.isArray(defaultValue)) {
-        defaultValue = Ember.A(defaultValue.slice());
+        defaultValue = emberA(defaultValue.slice());
       }
 
       var type = desc.type || typeOf(defaultValue);
@@ -387,7 +388,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     } else if (defaultValueType === 'number') {
       return (Number(value)).valueOf();
     } else if (defaultValueType === 'array') {
-      return Ember.A(JSON.parse(value));
+      return emberA(JSON.parse(value));
     }
     return value;
   },
@@ -2207,7 +2208,7 @@ function getQueryParamsFor(route, state) {
 
 function copyDefaultValue(value) {
   if (Array.isArray(value)) {
-    return Ember.A(value.slice());
+    return emberA(value.slice());
   }
   return value;
 }

--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -3,7 +3,6 @@
 @submodule ember-runtime
 */
 
-import Ember from 'ember-metal/core';
 import { assert } from 'ember-metal/debug';
 import { get } from 'ember-metal/property_get';
 import EmberError from 'ember-metal/error';
@@ -11,6 +10,7 @@ import { ComputedProperty, computed } from 'ember-metal/computed';
 import { addObserver, removeObserver } from 'ember-metal/observer';
 import compare from 'ember-runtime/compare';
 import { isArray } from 'ember-runtime/utils';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 function reduceMacro(dependentKey, callback, initialValue) {
   return computed(`${dependentKey}.[]`, function() {
@@ -37,9 +37,9 @@ function arrayMacro(dependentKey, callback) {
   return computed(dependentKey, function() {
     var value = get(this, propertyName);
     if (isArray(value)) {
-      return Ember.A(callback.call(this, value));
+      return emberA(callback.call(this, value));
     } else {
-      return Ember.A();
+      return emberA();
     }
   }).readOnly();
 }
@@ -48,7 +48,7 @@ function multiArrayMacro(dependentKeys, callback) {
   var args = dependentKeys.map(key => `${key}.[]`);
 
   args.push(function() {
-    return Ember.A(callback.call(this, dependentKeys));
+    return emberA(callback.call(this, dependentKeys));
   });
 
   return computed.apply(this, args).readOnly();
@@ -343,7 +343,7 @@ export function filterBy(dependentKey, propertyKey, value) {
 */
 export function uniq(...args) {
   return multiArrayMacro(args, function(dependentKeys) {
-    var uniq = Ember.A();
+    var uniq = emberA();
 
     dependentKeys.forEach(dependentKey => {
       var value = get(this, dependentKey);
@@ -422,7 +422,7 @@ export function intersect(...args) {
     });
 
 
-    return Ember.A(results);
+    return emberA(results);
   });
 }
 
@@ -468,8 +468,8 @@ export function setDiff(setAProperty, setBProperty) {
     var setA = this.get(setAProperty);
     var setB = this.get(setBProperty);
 
-    if (!isArray(setA)) { return Ember.A(); }
-    if (!isArray(setB)) { return Ember.A(setA); }
+    if (!isArray(setA)) { return emberA(); }
+    if (!isArray(setB)) { return emberA(setA); }
 
     return setA.filter(x => setB.indexOf(x) === -1);
   }).readOnly();
@@ -571,7 +571,7 @@ function propertySort(itemsKey, sortPropertiesKey) {
     var items = itemsKey === '@this' ? this : get(this, itemsKey);
     var sortProperties = get(this, sortPropertiesKey);
 
-    if (items === null || typeof items !== 'object') { return Ember.A(); }
+    if (items === null || typeof items !== 'object') { return emberA(); }
 
     // TODO: Ideally we'd only do this if things have changed
     if (cp._sortPropObservers) {
@@ -598,7 +598,7 @@ function propertySort(itemsKey, sortPropertiesKey) {
       addObserver.apply(null, args);
     });
 
-    return Ember.A(items.slice().sort((itemA, itemB) => {
+    return emberA(items.slice().sort((itemA, itemB) => {
       for (var i = 0; i < normalizedSort.length; ++i) {
         var [prop, direction] = normalizedSort[i];
         var result = compare(get(itemA, prop), get(itemB, prop));

--- a/packages/ember-runtime/lib/system/lazy_load.js
+++ b/packages/ember-runtime/lib/system/lazy_load.js
@@ -1,7 +1,7 @@
 /*globals CustomEvent */
 
 import Ember from 'ember-metal/core'; // Ember.ENV.EMBER_LOAD_HOOKS
-import 'ember-runtime/system/native_array'; // make sure Ember.A is setup.
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 /**
   @module ember
@@ -34,7 +34,7 @@ export var _loaded = loaded;
 export function onLoad(name, callback) {
   var object = loaded[name];
 
-  loadHooks[name] = loadHooks[name] || Ember.A();
+  loadHooks[name] = loadHooks[name] || emberA();
   loadHooks[name].pushObject(callback);
 
   if (object) {

--- a/packages/ember-runtime/tests/computed/computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/computed_macros_test.js
@@ -1,4 +1,3 @@
-import Ember from 'ember-metal/core';
 import { computed } from 'ember-metal/computed';
 import {
   empty,
@@ -22,6 +21,7 @@ import alias from 'ember-metal/alias';
 import { defineProperty } from 'ember-metal/properties';
 import EmberObject from 'ember-runtime/system/object';
 import { testBoth } from 'ember-metal/tests/props_helper';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 QUnit.module('CP macros');
 
@@ -33,7 +33,7 @@ testBoth('Ember.computed.empty', function (get, set) {
     bestLannisterUnspecified: empty('bestLannister'),
     noLannistersKnown: empty('lannisters')
   }).create({
-    lannisters: Ember.A([])
+    lannisters: emberA()
   });
 
   equal(get(obj, 'bestLannisterUnspecified'), true, 'bestLannister initially empty');
@@ -54,7 +54,7 @@ testBoth('Ember.computed.notEmpty', function(get, set) {
     bestLannisterSpecified: notEmpty('bestLannister'),
     LannistersKnown: notEmpty('lannisters')
   }).create({
-    lannisters: Ember.A([])
+    lannisters: emberA()
   });
 
   equal(get(obj, 'bestLannisterSpecified'), false, 'bestLannister initially empty');

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -1,4 +1,3 @@
-import Ember from 'ember-metal/core';
 import run from 'ember-metal/run_loop';
 import EmberObject from 'ember-runtime/system/object';
 import setProperties from 'ember-metal/set_properties';
@@ -22,6 +21,7 @@ import {
   intersect
 } from 'ember-runtime/computed/reduce_computed_macros';
 import { isArray } from 'ember-runtime/utils';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 var obj;
 QUnit.module('map', {
@@ -30,12 +30,12 @@ QUnit.module('map', {
       mapped: map('array.@each.v', (item) => item.v),
       mappedObjects: map('arrayObjects.@each.v',  (item) => ({ name: item.v.name }))
     }).create({
-      arrayObjects: Ember.A([
+      arrayObjects: emberA([
         { v: { name: 'Robert' } },
         { v: { name: 'Leanna' } }
       ]),
 
-      array: Ember.A([
+      array: emberA([
         { v: 1 },
         { v: 3 },
         { v: 2 },
@@ -68,7 +68,7 @@ QUnit.test('it maps simple properties', function() {
 });
 
 QUnit.test('it maps simple unshifted properties', function() {
-  var array = Ember.A();
+  var array = emberA();
 
   obj = EmberObject.extend({
     mapped: map('array', (item) => item.toUpperCase())
@@ -145,7 +145,7 @@ QUnit.test('it maps objects', function() {
 });
 
 QUnit.test('it maps unshifted objects with property observers', function() {
-  var array = Ember.A();
+  var array = emberA();
   var cObj = { v: 'c' };
 
   obj = EmberObject.extend({
@@ -169,7 +169,7 @@ QUnit.module('mapBy', {
     obj = EmberObject.extend({
       mapped: mapBy('array', 'v')
     }).create({
-      array: Ember.A([
+      array: emberA([
         { v: 1 },
         { v: 3 },
         { v: 2 },
@@ -217,7 +217,7 @@ QUnit.module('filter', {
     obj = EmberObject.extend({
       filtered: filter('array', (item) => item % 2 === 0)
     }).create({
-      array: Ember.A([1, 2, 3, 4, 5, 6, 7, 8])
+      array: emberA([1, 2, 3, 4, 5, 6, 7, 8])
     });
   },
   teardown() {
@@ -265,7 +265,7 @@ QUnit.test('it passes the array to the callback', function() {
   obj = EmberObject.extend({
     filtered: filter('array',  (item, index, array) => index === get(array, 'length') - 2)
   }).create({
-    array: Ember.A(['a', 'b', 'c'])
+    array: emberA(['a', 'b', 'c'])
   });
 
   deepEqual(obj.get('filtered'), ['b'], 'array is passed to callback correctly');
@@ -343,7 +343,7 @@ QUnit.module('filterBy', {
       as: filterBy('array', 'a'),
       bs: filterBy('array', 'b')
     }).create({
-      array: Ember.A([
+      array: emberA([
         { name: 'one', a: 1, b: false },
         { name: 'two', a: 2, b: false },
         { name: 'three', a: 1, b: true },
@@ -438,9 +438,9 @@ QUnit.test('properties values can be replaced', function() {
       obj = EmberObject.extend({
         union: macro('array', 'array2', 'array3')
       }).create({
-        array: Ember.A([1, 2, 3, 4, 5, 6]),
-        array2: Ember.A([4, 5, 6, 7, 8, 9, 4, 5, 6, 7, 8, 9]),
-        array3: Ember.A([1, 8, 10])
+        array: emberA([1, 2, 3, 4, 5, 6]),
+        array2: emberA([4, 5, 6, 7, 8, 9, 4, 5, 6, 7, 8, 9]),
+        array3: emberA([1, 8, 10])
       });
     },
     teardown() {
@@ -497,9 +497,9 @@ QUnit.module('computed.intersect', {
     obj = EmberObject.extend({
       intersection: intersect('array', 'array2', 'array3')
     }).create({
-      array: Ember.A([1, 2, 3, 4, 5, 6]),
-      array2: Ember.A([3, 3, 3, 4, 5]),
-      array3: Ember.A([3, 5, 6, 7, 8])
+      array: emberA([1, 2, 3, 4, 5, 6]),
+      array2: emberA([3, 3, 3, 4, 5]),
+      array3: emberA([3, 5, 6, 7, 8])
     });
   },
   teardown() {
@@ -545,8 +545,8 @@ QUnit.module('setDiff', {
     obj = EmberObject.extend({
       diff: setDiff('array', 'array2')
     }).create({
-      array: Ember.A([1, 2, 3, 4, 5, 6, 7]),
-      array2: Ember.A([3, 4, 5, 10])
+      array: emberA([1, 2, 3, 4, 5, 6, 7]),
+      array2: emberA([3, 4, 5, 10])
     });
   },
   teardown() {
@@ -565,8 +565,8 @@ QUnit.test('it throws an error if given fewer or more than two dependent propert
     EmberObject.extend({
       diff: setDiff('array')
     }).create({
-      array: Ember.A([1, 2, 3, 4, 5, 6, 7]),
-      array2: Ember.A([3, 4, 5])
+      array: emberA([1, 2, 3, 4, 5, 6, 7]),
+      array2: emberA([3, 4, 5])
     });
   }, /requires exactly two dependent arrays/, 'setDiff requires two dependent arrays');
 
@@ -574,9 +574,9 @@ QUnit.test('it throws an error if given fewer or more than two dependent propert
     EmberObject.extend({
       diff: setDiff('array', 'array2', 'array3')
     }).create({
-      array: Ember.A([1, 2, 3, 4, 5, 6, 7]),
-      array2: Ember.A([3, 4, 5]),
-      array3: Ember.A([7])
+      array: emberA([1, 2, 3, 4, 5, 6, 7]),
+      array2: emberA([3, 4, 5]),
+      array3: emberA([7])
     });
   }, /requires exactly two dependent arrays/, 'setDiff requires two dependent arrays');
 });
@@ -781,8 +781,8 @@ QUnit.module('sort - sortProperties', {
     obj = EmberObject.extend({
       sortedItems: sort('items', 'itemSorting')
     }).create({
-      itemSorting: Ember.A(['lname', 'fname']),
-      items: Ember.A([
+      itemSorting: emberA(['lname', 'fname']),
+      items: emberA([
         { fname: 'Jaime', lname: 'Lannister', age: 34 },
         { fname: 'Cersei', lname: 'Lannister', age: 34 },
         { fname: 'Robb', lname: 'Stark', age: 16 },
@@ -813,7 +813,7 @@ QUnit.test('updating sort properties detaches observers for old sort properties'
     'Robb'
   ], 'precond - array is initially sorted');
 
-  obj.set('itemSorting', Ember.A(['fname:desc']));
+  obj.set('itemSorting', emberA(['fname:desc']));
 
   deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Robb',
@@ -847,7 +847,7 @@ QUnit.test('updating sort properties updates the sorted array', function() {
     'Robb'
   ], 'precond - array is initially sorted');
 
-  obj.set('itemSorting', Ember.A(['fname:desc']));
+  obj.set('itemSorting', emberA(['fname:desc']));
 
   deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Robb',
@@ -886,7 +886,7 @@ QUnit.test('updating new sort properties invalidates the sorted array', function
     'Robb'
   ], 'precond - array is initially sorted');
 
-  obj.set('itemSorting', Ember.A(['age:desc', 'fname:asc']));
+  obj.set('itemSorting', emberA(['age:desc', 'fname:asc']));
 
   deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Cersei',
@@ -922,7 +922,7 @@ QUnit.test('sort direction defaults to ascending (with sort property change)', f
     'Robb'
   ], 'precond - array is initially sorted');
 
-  obj.set('itemSorting', Ember.A(['fname']));
+  obj.set('itemSorting', emberA(['fname']));
 
   deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Bran',
@@ -1019,7 +1019,7 @@ QUnit.test('array observers do not leak', function() {
 
   var sisters = [jane, daria];
 
-  var sortProps = Ember.A(['name']);
+  var sortProps = emberA(['name']);
   var jaime = EmberObject.extend({
     sortedPeople: sort('sisters', 'sortProps'),
     sortProps
@@ -1128,7 +1128,7 @@ QUnit.module('sort - sort function', {
     obj = EmberObject.extend({
       sortedItems: sort('items.@each.fname', sortByLnameFname)
     }).create({
-      items: Ember.A([
+      items: emberA([
         { fname: 'Jaime', lname: 'Lannister', age: 34 },
         { fname: 'Cersei', lname: 'Lannister', age: 34 },
         { fname: 'Robb', lname: 'Stark', age: 16 },
@@ -1151,7 +1151,7 @@ QUnit.test('sort has correct `this`', function() {
       return sortByFnameAsc(a, b);
     }
   }).create({
-    items: Ember.A([
+    items: emberA([
       { fname: 'Jaime', lname: 'Lannister', age: 34 },
       { fname: 'Cersei', lname: 'Lannister', age: 34 },
       { fname: 'Robb', lname: 'Stark', age: 16 },
@@ -1231,7 +1231,7 @@ QUnit.module('sort - concurrency', {
       sortedItems: sort('items', 'sortProps'),
       customSortedItems: sort('items.@each.count', (a, b) => a.count - b.count)
     }).create({
-      items: Ember.A([
+      items: emberA([
         { name: 'A', count: 1 },
         { name: 'B', count: 2 },
         { name: 'C', count: 3 },
@@ -1271,7 +1271,7 @@ QUnit.module('max', {
     obj = EmberObject.extend({
       max: max('items')
     }).create({
-      items: Ember.A([1, 2, 3])
+      items: emberA([1, 2, 3])
     });
   },
   teardown() {
@@ -1316,7 +1316,7 @@ QUnit.module('min', {
     obj = EmberObject.extend({
       min: min('items')
     }).create({
-      items: Ember.A([1, 2, 3])
+      items: emberA([1, 2, 3])
     });
   },
   teardown() {
@@ -1360,14 +1360,14 @@ QUnit.module('Ember.arrayComputed - mixed sugar', {
   setup() {
     obj = EmberObject.extend({
       lannisters: filterBy('items', 'lname', 'Lannister'),
-      lannisterSorting: Ember.A(['fname']),
+      lannisterSorting: emberA(['fname']),
       sortedLannisters: sort('lannisters', 'lannisterSorting'),
 
       starks: filterBy('items', 'lname', 'Stark'),
       starkAges: mapBy('starks', 'age'),
       oldestStarkAge: max('starkAges')
     }).create({
-      items: Ember.A([
+      items: emberA([
         { fname: 'Jaime', lname: 'Lannister', age: 34 },
         { fname: 'Cersei', lname: 'Lannister', age: 34 },
         { fname: 'Robb', lname: 'Stark', age: 16 },
@@ -1429,7 +1429,7 @@ QUnit.module('Ember.arrayComputed - chains', {
       sorted: sort('todos.@each.priority', priorityComparator),
       filtered: filter('sorted.@each.priority', evenPriorities)
     }).create({
-      todos: Ember.A([
+      todos: emberA([
         todo('E', 4),
         todo('D', 3),
         todo('C', 2),
@@ -1464,7 +1464,7 @@ QUnit.module('Chaining array and reduced CPs', {
       max: max('mapped'),
       maxDidChange: observer('max', () => userFnCalls++)
     }).create({
-      array: Ember.A([
+      array: emberA([
         { v: 1 },
         { v: 3 },
         { v: 2 },
@@ -1496,7 +1496,7 @@ QUnit.module('sum', {
     obj = EmberObject.extend({
       total: sum('array')
     }).create({
-      array: Ember.A([1, 2, 3])
+      array: emberA([1, 2, 3])
     });
   },
 

--- a/packages/ember-runtime/tests/core/is_array_test.js
+++ b/packages/ember-runtime/tests/core/is_array_test.js
@@ -1,5 +1,5 @@
-import Ember from 'ember-metal/core';
 import { isArray } from 'ember-runtime/utils';
+import { A as emberA } from 'ember-runtime/system/native_array';
 import ArrayProxy from 'ember-runtime/system/array_proxy';
 
 QUnit.module('Ember Type Checking');
@@ -14,7 +14,7 @@ QUnit.test('Ember.isArray', function() {
   var object        = {};
   var length        = { length: 12 };
   var fn            = function() {};
-  var arrayProxy = ArrayProxy.create({ content: Ember.A() });
+  var arrayProxy = ArrayProxy.create({ content: emberA() });
 
   equal(isArray(numarray), true, '[1,2,3]');
   equal(isArray(number), false, '23');

--- a/packages/ember-runtime/tests/core/is_empty_test.js
+++ b/packages/ember-runtime/tests/core/is_empty_test.js
@@ -1,11 +1,11 @@
-import Ember from 'ember-metal/core';
 import isEmpty from 'ember-metal/is_empty';
 import ArrayProxy from 'ember-runtime/system/array_proxy';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 QUnit.module('Ember.isEmpty');
 
 QUnit.test('Ember.isEmpty', function() {
-  var arrayProxy = ArrayProxy.create({ content: Ember.A() });
+  var arrayProxy = ArrayProxy.create({ content: emberA() });
 
   equal(true, isEmpty(arrayProxy), 'for an ArrayProxy that has empty content');
 });

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/chained_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/chained_test.js
@@ -1,9 +1,9 @@
-import Ember from 'ember-metal/core';
-import {get} from 'ember-metal/property_get';
-import {set} from 'ember-metal/property_set';
+import { get } from 'ember-metal/property_get';
+import { set } from 'ember-metal/property_set';
 import run from 'ember-metal/run_loop';
 import EmberObject from 'ember-runtime/system/object';
-import {addObserver}  from 'ember-metal/observer';
+import { addObserver }  from 'ember-metal/observer';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 /*
   NOTE: This test is adapted from the 1.x series of unit tests.  The tests
@@ -28,7 +28,7 @@ QUnit.test('chained observers on enumerable properties are triggered when the ob
   var child4 = EmberObject.create({ name: 'Nancy' });
 
   set(family, 'momma', momma);
-  set(momma, 'children', Ember.A([child1, child2, child3]));
+  set(momma, 'children', emberA([child1, child2, child3]));
 
   var observerFiredCount = 0;
   addObserver(family, 'momma.children.@each.name', this, function() {

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -6,6 +6,7 @@ import { observer } from 'ember-metal/mixin';
 import { w } from 'ember-runtime/system/string';
 import EmberObject from 'ember-runtime/system/object';
 import Observable from 'ember-runtime/mixins/observable';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 /*
   NOTE: This test is adapted from the 1.x series of unit tests.  The tests
@@ -639,7 +640,7 @@ QUnit.module('Observable objects & object properties ', {
       toggleVal: true,
       observedProperty: 'beingWatched',
       testRemove: 'observerToBeRemoved',
-      normalArray: Ember.A([1, 2, 3, 4, 5])
+      normalArray: emberA([1, 2, 3, 4, 5])
     });
   }
 });

--- a/packages/ember-runtime/tests/mixins/array_test.js
+++ b/packages/ember-runtime/tests/mixins/array_test.js
@@ -1,4 +1,3 @@
-import Ember from 'ember-metal/core'; // Ember.A
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
 import { addObserver } from 'ember-metal/observer';
@@ -8,6 +7,7 @@ import { testBoth } from 'ember-metal/tests/props_helper';
 import { ArrayTests } from 'ember-runtime/tests/suites/array';
 import EmberObject from 'ember-runtime/system/object';
 import EmberArray from 'ember-runtime/mixins/array';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 /*
   Implement a basic fake mutable array.  This validates that any non-native
@@ -395,7 +395,7 @@ testBoth('should be clear caches for computed properties that have dependent key
   var obj = EmberObject.extend({
     init() {
       this._super(...arguments);
-      set(this, 'resources', Ember.A());
+      set(this, 'resources', emberA());
     },
 
     common: computed('resources.@each.common', function() {
@@ -417,7 +417,7 @@ testBoth('observers that contain @each in the path should fire only once the fir
     init() {
       this._super(...arguments);
       // Observer does not fire on init
-      set(this, 'resources', Ember.A());
+      set(this, 'resources', emberA());
     },
 
     commonDidChange: emberObserver('resources.@each.common', function() {

--- a/packages/ember-runtime/tests/mixins/enumerable_test.js
+++ b/packages/ember-runtime/tests/mixins/enumerable_test.js
@@ -1,12 +1,11 @@
-import Ember from 'ember-metal/core'; // for Ember.A
 import EnumerableTests from 'ember-runtime/tests/suites/enumerable';
 import EmberObject from 'ember-runtime/system/object';
 import Enumerable from 'ember-runtime/mixins/enumerable';
 import EmberArray from 'ember-runtime/mixins/array';
+import { A as emberA } from 'ember-runtime/system/native_array';
 import { get } from 'ember-metal/property_get';
 import { computed } from 'ember-metal/computed';
 import { observer as emberObserver } from 'ember-metal/mixin';
-
 
 function K() { return this; }
 
@@ -110,7 +109,7 @@ QUnit.test('should apply Ember.Array to return value of uniq', function() {
 });
 
 QUnit.test('any', function() {
-  var kittens = Ember.A([{
+  var kittens = emberA([{
     color: 'white'
   }, {
     color: 'black'
@@ -125,7 +124,7 @@ QUnit.test('any', function() {
 });
 
 QUnit.test('any with NaN', function() {
-  var numbers = Ember.A([1, 2, NaN, 4]);
+  var numbers = emberA([1, 2, NaN, 4]);
 
   var hasNaN = numbers.any(function(n) {
     return isNaN(n);
@@ -135,14 +134,14 @@ QUnit.test('any with NaN', function() {
 });
 
 QUnit.test('every', function() {
-  var allColorsKittens = Ember.A([{
+  var allColorsKittens = emberA([{
     color: 'white'
   }, {
     color: 'black'
   }, {
     color: 'white'
   }]);
-  var allWhiteKittens = Ember.A([{
+  var allWhiteKittens = emberA([{
     color: 'white'
   }, {
     color: 'white'

--- a/packages/ember-runtime/tests/mixins/mutable_array_test.js
+++ b/packages/ember-runtime/tests/mixins/mutable_array_test.js
@@ -1,8 +1,8 @@
-import Ember from 'ember-metal/core';
 import { computed } from 'ember-metal/computed';
 import MutableArrayTests from 'ember-runtime/tests/suites/mutable_array';
 import MutableArray from 'ember-runtime/mixins/mutable_array';
 import EmberObject from 'ember-runtime/system/object';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 /*
   Implement a basic fake mutable array.  This validates that any non-native
@@ -13,7 +13,7 @@ var TestMutableArray = EmberObject.extend(MutableArray, {
   _content: null,
 
   init(ary) {
-    this._content = Ember.A(ary || []);
+    this._content = emberA(ary || []);
   },
 
   replace(idx, amt, objects) {

--- a/packages/ember-runtime/tests/suites/enumerable/any.js
+++ b/packages/ember-runtime/tests/suites/enumerable/any.js
@@ -1,5 +1,5 @@
-import Ember from 'ember-metal/core';
-import {SuiteModuleBuilder} from 'ember-runtime/tests/suites/suite';
+import { SuiteModuleBuilder } from 'ember-runtime/tests/suites/suite';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 var suite = SuiteModuleBuilder.create();
 
@@ -42,7 +42,7 @@ suite.test('any should stop invoking when you return true', function() {
 
 
 suite.test('any should return true if any object matches the callback', function() {
-  var obj = Ember.A([0, 1, 2]);
+  var obj = emberA([0, 1, 2]);
   var result;
 
   result = obj.any(function(i) { return !!i; });
@@ -51,7 +51,7 @@ suite.test('any should return true if any object matches the callback', function
 
 
 suite.test('any should return false if no object matches the callback', function() {
-  var obj = Ember.A([0, null, false]);
+  var obj = emberA([0, null, false]);
   var result;
 
   result = obj.any(function(i) { return !!i; });
@@ -60,7 +60,7 @@ suite.test('any should return false if no object matches the callback', function
 
 
 suite.test('any should produce correct results even if the matching element is undefined', function() {
-  var obj = Ember.A([undefined]);
+  var obj = emberA([undefined]);
   var result;
 
   result = obj.any(function(i) { return true; });

--- a/packages/ember-runtime/tests/suites/mutable_enumerable/removeObject.js
+++ b/packages/ember-runtime/tests/suites/mutable_enumerable/removeObject.js
@@ -1,6 +1,6 @@
-import Ember from 'ember-metal/core';
 import { get } from 'ember-metal/property_get';
 import { SuiteModuleBuilder } from 'ember-runtime/tests/suites/suite';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 var suite = SuiteModuleBuilder.create();
 
@@ -16,7 +16,7 @@ suite.test('should return receiver', function() {
 suite.test('[A,B,C].removeObject(B) => [A,C] + notify', function() {
   var obj, before, after, observer;
 
-  before = Ember.A(this.newFixture(3));
+  before = emberA(this.newFixture(3));
   after  = [before[0], before[2]];
   obj = before;
   observer = this.newObserver(obj, '[]', 'length', 'firstObject', 'lastObject');
@@ -39,7 +39,7 @@ suite.test('[A,B,C].removeObject(B) => [A,C] + notify', function() {
 suite.test('[A,B,C].removeObject(D) => [A,B,C]', function() {
   var obj, before, after, observer, item;
 
-  before = Ember.A(this.newFixture(3));
+  before = emberA(this.newFixture(3));
   after  = before;
   item   = this.newFixture(1)[0];
   obj = before;

--- a/packages/ember-runtime/tests/suites/mutable_enumerable/removeObjects.js
+++ b/packages/ember-runtime/tests/suites/mutable_enumerable/removeObjects.js
@@ -1,6 +1,6 @@
-import {SuiteModuleBuilder} from 'ember-runtime/tests/suites/suite';
-import {get} from 'ember-metal/property_get';
-import Ember from 'ember-metal/core';
+import { SuiteModuleBuilder } from 'ember-runtime/tests/suites/suite';
+import { get } from 'ember-metal/property_get';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 var suite = SuiteModuleBuilder.create();
 
@@ -8,7 +8,7 @@ suite.module('removeObjects');
 
 suite.test('should return receiver', function() {
   var before, obj;
-  before = Ember.A(this.newFixture(3));
+  before = emberA(this.newFixture(3));
   obj = before;
   equal(obj.removeObjects(before[1]), obj, 'should return receiver');
 });
@@ -16,7 +16,7 @@ suite.test('should return receiver', function() {
 suite.test('[A,B,C].removeObjects([B]) => [A,C] + notify', function() {
   var obj, before, after, observer;
 
-  before = Ember.A(this.newFixture(3));
+  before = emberA(this.newFixture(3));
   after = [before[0], before[2]];
   obj = before;
   observer = this.newObserver(obj, '[]', 'length', 'firstObject', 'lastObject');
@@ -39,7 +39,7 @@ suite.test('[A,B,C].removeObjects([B]) => [A,C] + notify', function() {
 suite.test('[{A},{B},{C}].removeObjects([{B}]) => [{A},{C}] + notify', function() {
   var obj, before, after, observer;
 
-  before = Ember.A(this.newObjectsFixture(3));
+  before = emberA(this.newObjectsFixture(3));
   after = [before[0], before[2]];
   obj = before;
   observer = this.newObserver(obj, '[]', 'length', 'firstObject', 'lastObject');
@@ -62,7 +62,7 @@ suite.test('[{A},{B},{C}].removeObjects([{B}]) => [{A},{C}] + notify', function(
 suite.test('[A,B,C].removeObjects([A,B]) => [C] + notify', function() {
   var obj, before, after, observer;
 
-  before = Ember.A(this.newFixture(3));
+  before = emberA(this.newFixture(3));
   after  = [before[2]];
   obj = before;
   observer = this.newObserver(obj, '[]', 'length', 'firstObject', 'lastObject');
@@ -85,7 +85,7 @@ suite.test('[A,B,C].removeObjects([A,B]) => [C] + notify', function() {
 suite.test('[{A},{B},{C}].removeObjects([{A},{B}]) => [{C}] + notify', function() {
   var obj, before, after, observer;
 
-  before = Ember.A(this.newObjectsFixture(3));
+  before = emberA(this.newObjectsFixture(3));
   after = [before[2]];
   obj = before;
   observer = this.newObserver(obj, '[]', 'length', 'firstObject', 'lastObject');
@@ -108,7 +108,7 @@ suite.test('[{A},{B},{C}].removeObjects([{A},{B}]) => [{C}] + notify', function(
 suite.test('[A,B,C].removeObjects([A,B,C]) => [] + notify', function() {
   var obj, before, after, observer;
 
-  before = Ember.A(this.newFixture(3));
+  before = emberA(this.newFixture(3));
   after = [];
   obj = before;
   observer = this.newObserver(obj, '[]', 'length', 'firstObject', 'lastObject');
@@ -131,7 +131,7 @@ suite.test('[A,B,C].removeObjects([A,B,C]) => [] + notify', function() {
 suite.test('[{A},{B},{C}].removeObjects([{A},{B},{C}]) => [] + notify', function() {
   var obj, before, after, observer;
 
-  before = Ember.A(this.newObjectsFixture(3));
+  before = emberA(this.newObjectsFixture(3));
   after = [];
   obj = before;
   observer = this.newObserver(obj, '[]', 'length', 'firstObject', 'lastObject');
@@ -154,7 +154,7 @@ suite.test('[{A},{B},{C}].removeObjects([{A},{B},{C}]) => [] + notify', function
 suite.test('[A,B,C].removeObjects([D]) => [A,B,C]', function() {
   var obj, before, after, observer, item;
 
-  before = Ember.A(this.newFixture(3));
+  before = emberA(this.newFixture(3));
   after = before;
   item = this.newFixture(1)[0];
   obj = before;

--- a/packages/ember-runtime/tests/system/array_proxy/arranged_content_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/arranged_content_test.js
@@ -1,7 +1,7 @@
-import Ember from 'ember-metal/core';
 import run from 'ember-metal/run_loop';
-import {computed} from 'ember-metal/computed';
+import { computed } from 'ember-metal/computed';
 import ArrayProxy from 'ember-runtime/system/array_proxy';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 var array;
 
@@ -11,14 +11,14 @@ QUnit.module('ArrayProxy - arrangedContent', {
       array = ArrayProxy.extend({
         arrangedContent: computed('content.[]', function() {
           var content = this.get('content');
-          return content && Ember.A(content.slice().sort(function(a, b) {
+          return content && emberA(content.slice().sort(function(a, b) {
             if (a == null) { a = -1; }
             if (b == null) { b = -1; }
             return b - a;
           }));
         })
       }).create({
-        content: Ember.A([1, 2, 4, 5])
+        content: emberA([1, 2, 4, 5])
       });
     });
   },
@@ -45,7 +45,7 @@ QUnit.test('addObjects - adds to end of \'content\' if not present', function() 
 });
 
 QUnit.test('compact - returns arrangedContent without nulls and undefined', function() {
-  run(function() { array.set('content', Ember.A([1, 3, null, 2, undefined])); });
+  run(function() { array.set('content', emberA([1, 3, null, 2, undefined])); });
   deepEqual(array.compact(), [3, 2, 1]);
 });
 
@@ -177,7 +177,7 @@ QUnit.module('ArrayProxy - arrangedContent matching content', {
   setup() {
     run(function() {
       array = ArrayProxy.create({
-        content: Ember.A([1, 2, 4, 5])
+        content: emberA([1, 2, 4, 5])
       });
     });
   },
@@ -209,7 +209,7 @@ QUnit.module('ArrayProxy - arrangedContent with transforms', {
       array = ArrayProxy.extend({
         arrangedContent: computed(function() {
           var content = this.get('content');
-          return content && Ember.A(content.slice().sort(function(a, b) {
+          return content && emberA(content.slice().sort(function(a, b) {
             if (a == null) { a = -1; }
             if (b == null) { b = -1; }
             return b - a;
@@ -221,7 +221,7 @@ QUnit.module('ArrayProxy - arrangedContent with transforms', {
           return obj && obj.toString();
         }
       }).create({
-        content: Ember.A([1, 2, 4, 5])
+        content: emberA([1, 2, 4, 5])
       });
     });
   },

--- a/packages/ember-runtime/tests/system/array_proxy/content_change_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/content_change_test.js
@@ -1,14 +1,14 @@
-import Ember from 'ember-metal/core';
 import { set } from 'ember-metal/property_set';
 import { not } from 'ember-metal/computed_macros';
 import run from 'ember-metal/run_loop';
 import ArrayProxy from 'ember-runtime/system/array_proxy';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 QUnit.module('ArrayProxy - content change');
 
 QUnit.test('should update length for null content', function() {
   var proxy = ArrayProxy.create({
-        content: Ember.A([1, 2, 3])
+        content: emberA([1, 2, 3])
       });
 
   equal(proxy.get('length'), 3, 'precond - length is 3');
@@ -22,7 +22,7 @@ QUnit.test('should update length for null content when there is a computed prope
   var proxy = ArrayProxy.extend({
     isEmpty: not('length')
   }).create({
-    content: Ember.A([1, 2, 3])
+    content: emberA([1, 2, 3])
   });
 
   equal(proxy.get('length'), 3, 'precond - length is 3');
@@ -45,7 +45,7 @@ QUnit.test('The `arrangedContentWillChange` method is invoked before `content` i
       equal(this.get('arrangedContent.length'), expectedLength, 'hook should be invoked before array has changed');
       callCount++;
     }
-  }).create({ content: Ember.A([1, 2, 3]) });
+  }).create({ content: emberA([1, 2, 3]) });
 
   proxy.pushObject(4);
   equal(callCount, 0, 'pushing content onto the array doesn\'t trigger it');
@@ -54,7 +54,7 @@ QUnit.test('The `arrangedContentWillChange` method is invoked before `content` i
   equal(callCount, 0, 'pushing content onto the content array doesn\'t trigger it');
 
   expectedLength = 5;
-  proxy.set('content', Ember.A(['a', 'b']));
+  proxy.set('content', emberA(['a', 'b']));
   equal(callCount, 1, 'replacing the content array triggers the hook');
 });
 
@@ -68,7 +68,7 @@ QUnit.test('The `arrangedContentDidChange` method is invoked after `content` is 
       callCount++;
     }
   }).create({
-    content: Ember.A([1, 2, 3])
+    content: emberA([1, 2, 3])
   });
 
   equal(callCount, 0, 'hook is not called after creating the object');
@@ -80,7 +80,7 @@ QUnit.test('The `arrangedContentDidChange` method is invoked after `content` is 
   equal(callCount, 0, 'pushing content onto the content array doesn\'t trigger it');
 
   expectedLength = 2;
-  proxy.set('content', Ember.A(['a', 'b']));
+  proxy.set('content', emberA(['a', 'b']));
   equal(callCount, 1, 'replacing the content array triggers the hook');
 });
 

--- a/packages/ember-runtime/tests/system/array_proxy/content_update_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/content_update_test.js
@@ -1,6 +1,6 @@
-import Ember from 'ember-metal/core';
-import {computed} from 'ember-metal/computed';
+import { computed } from 'ember-metal/computed';
 import ArrayProxy from 'ember-runtime/system/array_proxy';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 QUnit.module('Ember.ArrayProxy - content update');
 
@@ -10,7 +10,7 @@ QUnit.test('The `contentArrayDidChange` method is invoked after `content` is upd
 
   proxy = ArrayProxy.extend({
     arrangedContent: computed('content', function(key) {
-      return Ember.A(this.get('content').slice());
+      return emberA(this.get('content').slice());
     }),
 
     contentArrayDidChange(array, idx, removedCount, addedCount) {
@@ -18,7 +18,7 @@ QUnit.test('The `contentArrayDidChange` method is invoked after `content` is upd
       return this._super(array, idx, removedCount, addedCount);
     }
   }).create({
-    content: Ember.A()
+    content: emberA()
   });
 
   proxy.pushObject(1);

--- a/packages/ember-runtime/tests/system/array_proxy/suite_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/suite_test.js
@@ -1,7 +1,7 @@
-import Ember from 'ember-metal/core';
 import MutableArrayTests from 'ember-runtime/tests/suites/mutable_array';
 import ArrayProxy from 'ember-runtime/system/array_proxy';
-import {get} from 'ember-metal/property_get';
+import { get } from 'ember-metal/property_get';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 MutableArrayTests.extend({
 
@@ -9,7 +9,7 @@ MutableArrayTests.extend({
 
   newObject(ary) {
     var ret = ary ? ary.slice() : this.newFixture(3);
-    return ArrayProxy.create({ content: Ember.A(ret) });
+    return ArrayProxy.create({ content: emberA(ret) });
   },
 
   mutate(obj) {

--- a/packages/ember-runtime/tests/system/native_array/copyable_suite_test.js
+++ b/packages/ember-runtime/tests/system/native_array/copyable_suite_test.js
@@ -1,12 +1,12 @@
-import Ember from 'ember-metal/core';
 import { generateGuid } from 'ember-metal/utils';
+import { A as emberA } from 'ember-runtime/system/native_array';
 import CopyableTests from 'ember-runtime/tests/suites/copyable';
 
 CopyableTests.extend({
   name: 'NativeArray Copyable',
 
   newObject() {
-    return Ember.A([generateGuid()]);
+    return emberA([generateGuid()]);
   },
 
   isEqual(a, b) {
@@ -31,7 +31,7 @@ CopyableTests.extend({
 QUnit.module('NativeArray Copyable');
 
 QUnit.test('deep copy is respected', function() {
-  var array = Ember.A([{ id: 1 }, { id: 2 }, { id: 3 }]);
+  var array = emberA([{ id: 1 }, { id: 2 }, { id: 3 }]);
 
   var copiedArray = array.copy(true);
 

--- a/packages/ember-runtime/tests/system/native_array/suite_test.js
+++ b/packages/ember-runtime/tests/system/native_array/suite_test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember-metal/core';
+import { A as emberA } from 'ember-runtime/system/native_array';
 import MutableArrayTests from 'ember-runtime/tests/suites/mutable_array';
 
 MutableArrayTests.extend({
@@ -6,7 +6,7 @@ MutableArrayTests.extend({
   name: 'Native Array',
 
   newObject(ary) {
-    return Ember.A(ary ? ary.slice() : this.newFixture(3));
+    return emberA(ary ? ary.slice() : this.newFixture(3));
   },
 
   mutate(obj) {

--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -1,8 +1,8 @@
-import Ember from 'ember-metal/core';
 import emberRun from 'ember-metal/run_loop';
 import RSVP from 'ember-runtime/ext/rsvp';
 import setupForTesting from 'ember-testing/setup_for_testing';
 import EmberApplication from 'ember-application/system/application';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 /**
   @module ember
@@ -250,7 +250,7 @@ var Test = {
       context = null;
     }
     if (!this.waiters) {
-      this.waiters = Ember.A();
+      this.waiters = emberA();
     }
     this.waiters.push([context, callback]);
   },
@@ -270,7 +270,7 @@ var Test = {
       callback = context;
       context = null;
     }
-    this.waiters = Ember.A(this.waiters.filter(function(elt) {
+    this.waiters = emberA(this.waiters.filter(function(elt) {
       return !(elt[0] === context && elt[1] === callback);
     }));
   }

--- a/packages/ember-testing/tests/integration_test.js
+++ b/packages/ember-testing/tests/integration_test.js
@@ -1,4 +1,3 @@
-import Ember from 'ember-metal/core';
 import run from 'ember-metal/run_loop';
 import EmberObject from 'ember-runtime/system/object';
 import jQuery from 'ember-views/system/jquery';
@@ -8,6 +7,7 @@ import EmberRoute from 'ember-routing/system/route';
 import EmberApplication from 'ember-application/system/application';
 import compile from 'ember-template-compiler/system/compile';
 import Controller from 'ember-runtime/controllers/controller';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 import 'ember-application';
 
@@ -44,7 +44,7 @@ QUnit.module('ember-testing Integration', {
 
       App.Person.reopenClass({
         find() {
-          return Ember.A();
+          return emberA();
         }
       });
 
@@ -76,7 +76,7 @@ QUnit.module('ember-testing Integration', {
 
 QUnit.test('template is bound to empty array of people', function() {
   App.Person.find = function() {
-    return Ember.A();
+    return emberA();
   };
   run(App, 'advanceReadiness');
   visit('/').then(function() {
@@ -87,7 +87,7 @@ QUnit.test('template is bound to empty array of people', function() {
 
 QUnit.test('template is bound to array of 2 people', function() {
   App.Person.find = function() {
-    var people = Ember.A();
+    var people = emberA();
     var first = App.Person.create({ firstName: 'x' });
     var last = App.Person.create({ firstName: 'y' });
     run(people, people.pushObject, first);
@@ -103,7 +103,7 @@ QUnit.test('template is bound to array of 2 people', function() {
 
 QUnit.test('template is again bound to empty array of people', function() {
   App.Person.find = function() {
-    return Ember.A();
+    return emberA();
   };
   run(App, 'advanceReadiness');
   visit('/').then(function() {
@@ -114,7 +114,7 @@ QUnit.test('template is again bound to empty array of people', function() {
 
 QUnit.test('`visit` can be called without advancedReadiness.', function() {
   App.Person.find = function() {
-    return Ember.A();
+    return emberA();
   };
 
   visit('/').then(function() {

--- a/packages/ember-views/lib/compat/metamorph_view.js
+++ b/packages/ember-views/lib/compat/metamorph_view.js
@@ -1,4 +1,3 @@
-/*jshint newcap:false*/
 import { deprecate } from 'ember-metal/debug';
 import View from 'ember-views/views/view';
 import { Mixin } from 'ember-metal/mixin';

--- a/packages/ember-views/lib/mixins/view_child_views_support.js
+++ b/packages/ember-views/lib/mixins/view_child_views_support.js
@@ -2,12 +2,12 @@
 @module ember
 @submodule ember-views
 */
-import Ember from 'ember-metal/core';
 import { assert } from 'ember-metal/debug';
 import { Mixin } from 'ember-metal/mixin';
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
 import setProperties from 'ember-metal/set_properties';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 var EMPTY_ARRAY = [];
 
@@ -28,7 +28,7 @@ export default Mixin.create({
 
     // setup child views. be sure to clone the child views array first
     // 2.0TODO: Remove Ember.A() here
-    this.childViews = Ember.A(this.childViews.slice());
+    this.childViews = emberA(this.childViews.slice());
     this.ownerView = this.ownerView || this;
   },
 

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -1,6 +1,7 @@
 import Ember from 'ember-metal/core';
 import { assert, deprecate } from 'ember-metal/debug';
 import MutableArray from 'ember-runtime/mixins/mutable_array';
+import { A as emberA } from 'ember-runtime/system/native_array';
 import View from 'ember-views/views/view';
 
 import { get } from 'ember-metal/property_get';
@@ -190,7 +191,7 @@ var ContainerView = View.extend(MutableArray, {
     // redefine view's childViews property that was obliterated
     // 2.0TODO: Don't Ember.A() this so users disabling prototype extensions
     // don't pay a penalty.
-    var childViews = this.childViews = Ember.A([]);
+    var childViews = this.childViews = emberA();
 
     userChildViews.forEach((viewName, idx) => {
       var view;
@@ -208,7 +209,7 @@ var ContainerView = View.extend(MutableArray, {
 
     var currentView = get(this, 'currentView');
     if (currentView) {
-      if (!childViews.length) { childViews = this.childViews = Ember.A(this.childViews.slice()); }
+      if (!childViews.length) { childViews = this.childViews = emberA(this.childViews.slice()); }
       childViews.push(this.createChildView(currentView));
     }
 

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -8,6 +8,7 @@ import View from 'ember-views/views/view';
 import Registry from 'container/registry';
 import compile from 'ember-template-compiler/system/compile';
 import getElementStyle from 'ember-views/tests/test-helpers/get-element-style';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 import { registerKeyword, resetKeyword } from 'ember-htmlbars/tests/utils';
 import viewKeyword from 'ember-htmlbars/keywords/view';
@@ -38,7 +39,7 @@ QUnit.module('CollectionView', {
 
 QUnit.test('should render a view for each item in its content array', function() {
   view = CollectionView.create({
-    content: Ember.A([1, 2, 3, 4])
+    content: emberA([1, 2, 3, 4])
   });
 
   run(function() {
@@ -49,7 +50,7 @@ QUnit.test('should render a view for each item in its content array', function()
 
 QUnit.test('should render the emptyView if content array is empty (view class)', function() {
   view = CollectionView.create({
-    content: Ember.A(),
+    content: emberA(),
 
     emptyView: View.extend({
       template: compile('OY SORRY GUVNAH NO NEWS TODAY EH')
@@ -66,7 +67,7 @@ QUnit.test('should render the emptyView if content array is empty (view class)',
 QUnit.test('should render the emptyView if content array is empty (view class with custom tagName)', function() {
   view = CollectionView.create({
     tagName: 'del',
-    content: Ember.A(),
+    content: emberA(),
 
     emptyView: View.extend({
       tagName: 'kbd',
@@ -84,7 +85,7 @@ QUnit.test('should render the emptyView if content array is empty (view class wi
 QUnit.test('should render the emptyView if content array is empty (view instance)', function() {
   view = CollectionView.create({
     tagName: 'del',
-    content: Ember.A(),
+    content: emberA(),
 
     emptyView: View.create({
       tagName: 'kbd',
@@ -102,7 +103,7 @@ QUnit.test('should render the emptyView if content array is empty (view instance
 QUnit.test('should be able to override the tag name of itemViewClass even if tag is in default mapping', function() {
   view = CollectionView.create({
     tagName: 'del',
-    content: Ember.A(['NEWS GUVNAH']),
+    content: emberA(['NEWS GUVNAH']),
 
     itemViewClass: View.extend({
       tagName: 'kbd',
@@ -118,7 +119,7 @@ QUnit.test('should be able to override the tag name of itemViewClass even if tag
 });
 
 QUnit.test('should allow custom item views by setting itemViewClass', function() {
-  var content = Ember.A(['foo', 'bar', 'baz']);
+  var content = emberA(['foo', 'bar', 'baz']);
   view = CollectionView.create({
     content: content,
 
@@ -135,7 +136,7 @@ QUnit.test('should allow custom item views by setting itemViewClass', function()
 });
 
 QUnit.test('should insert a new item in DOM when an item is added to the content array', function() {
-  var content = Ember.A(['foo', 'bar', 'baz']);
+  var content = emberA(['foo', 'bar', 'baz']);
 
   view = CollectionView.create({
     content: content,
@@ -161,7 +162,7 @@ QUnit.test('should insert a new item in DOM when an item is added to the content
 });
 
 QUnit.test('should remove an item from DOM when an item is removed from the content array', function() {
-  var content = Ember.A(['foo', 'bar', 'baz']);
+  var content = emberA(['foo', 'bar', 'baz']);
 
   view = CollectionView.create({
     content: content,
@@ -185,7 +186,7 @@ QUnit.test('should remove an item from DOM when an item is removed from the cont
 });
 
 QUnit.test('it updates the view if an item is replaced', function() {
-  var content = Ember.A(['foo', 'bar', 'baz']);
+  var content = emberA(['foo', 'bar', 'baz']);
   view = CollectionView.create({
     content: content,
 
@@ -213,7 +214,7 @@ QUnit.test('it updates the view if an item is replaced', function() {
 });
 
 QUnit.test('can add and replace in the same runloop', function() {
-  var content = Ember.A(['foo', 'bar', 'baz']);
+  var content = emberA(['foo', 'bar', 'baz']);
   view = CollectionView.create({
     content: content,
 
@@ -240,7 +241,7 @@ QUnit.test('can add and replace in the same runloop', function() {
 });
 
 QUnit.test('can add and replace the object before the add in the same runloop', function() {
-  var content = Ember.A(['foo', 'bar', 'baz']);
+  var content = emberA(['foo', 'bar', 'baz']);
   view = CollectionView.create({
     content: content,
 
@@ -267,7 +268,7 @@ QUnit.test('can add and replace the object before the add in the same runloop', 
 });
 
 QUnit.test('can add and replace complicatedly', function() {
-  var content = Ember.A(['foo', 'bar', 'baz']);
+  var content = emberA(['foo', 'bar', 'baz']);
   view = CollectionView.create({
     content: content,
 
@@ -296,7 +297,7 @@ QUnit.test('can add and replace complicatedly', function() {
 });
 
 QUnit.test('can add and replace complicatedly harder', function() {
-  var content = Ember.A(['foo', 'bar', 'baz']);
+  var content = emberA(['foo', 'bar', 'baz']);
   view = CollectionView.create({
     content: content,
 
@@ -334,9 +335,9 @@ QUnit.test('should allow changes to content object before layer is created', fun
 
 
   run(function() {
-    set(view, 'content', Ember.A());
-    set(view, 'content', Ember.A([1, 2, 3]));
-    set(view, 'content', Ember.A([1, 2]));
+    set(view, 'content', emberA());
+    set(view, 'content', emberA([1, 2, 3]));
+    set(view, 'content', emberA([1, 2]));
     view.append();
   });
 
@@ -349,7 +350,7 @@ QUnit.test('should fire life cycle events when elements are added and removed', 
   var willDestroyElement = 0;
   var willDestroy = 0;
   var destroy = 0;
-  var content = Ember.A([1, 2, 3]);
+  var content = emberA([1, 2, 3]);
   run(function () {
     view = CollectionView.create({
       content: content,
@@ -406,7 +407,7 @@ QUnit.test('should fire life cycle events when elements are added and removed', 
   equal(trim(view.$().text()), '123');
 
   run(function () {
-    view.set('content', Ember.A([7, 8, 9]));
+    view.set('content', emberA([7, 8, 9]));
   });
 
   equal(didInsertElement, 8);
@@ -428,7 +429,7 @@ QUnit.test('should fire life cycle events when elements are added and removed', 
 
 QUnit.test('should allow changing content property to be null', function() {
   view = CollectionView.create({
-    content: Ember.A([1, 2, 3]),
+    content: emberA([1, 2, 3]),
 
     emptyView: View.extend({
       template: compile('(empty)')
@@ -450,7 +451,7 @@ QUnit.test('should allow changing content property to be null', function() {
 
 QUnit.test('should allow items to access to the CollectionView\'s current index in the content array', function() {
   view = CollectionView.create({
-    content: Ember.A(['zero', 'one', 'two']),
+    content: emberA(['zero', 'one', 'two']),
     itemViewClass: View.extend({
       template: compile('{{view.contentIndex}}')
     })
@@ -470,7 +471,7 @@ QUnit.test('should allow declaration of itemViewClass as a string', function() {
 
   view = CollectionView.create({
     container: registry.container(),
-    content: Ember.A([1, 2, 3]),
+    content: emberA([1, 2, 3]),
     itemViewClass: 'simple-view'
   });
 
@@ -484,7 +485,7 @@ QUnit.test('should allow declaration of itemViewClass as a string', function() {
 QUnit.test('should not render the emptyView if content is emptied and refilled in the same run loop', function() {
   view = CollectionView.create({
     tagName: 'div',
-    content: Ember.A(['NEWS GUVNAH']),
+    content: emberA(['NEWS GUVNAH']),
 
     emptyView: View.extend({
       tagName: 'kbd',
@@ -525,7 +526,7 @@ QUnit.test('when a collection view is emptied, deeply nested views elements are 
   });
 
   var view = CollectionView.create({
-    content: Ember.A([1]),
+    content: emberA([1]),
     itemViewClass: ChildView
   });
 
@@ -555,7 +556,7 @@ QUnit.test('should render the emptyView if content array is empty and emptyView 
 
   view = CollectionView.create({
     tagName: 'del',
-    content: Ember.A(),
+    content: emberA(),
     container: registry.container(),
 
     emptyView: 'custom-empty'
@@ -577,7 +578,7 @@ QUnit.test('should lookup against the container if itemViewClass is given as a s
 
   view = CollectionView.create({
     container: registry.container(),
-    content: Ember.A([1, 2, 3, 4]),
+    content: emberA([1, 2, 3, 4]),
     itemViewClass: 'item'
   });
 
@@ -597,7 +598,7 @@ QUnit.test('should lookup only global path against the container if itemViewClas
 
   view = CollectionView.create({
     container: registry.container(),
-    content: Ember.A(['hi']),
+    content: emberA(['hi']),
     itemViewClass: 'top'
   });
 
@@ -619,7 +620,7 @@ QUnit.test('should lookup against the container and render the emptyView if empt
   view = CollectionView.create({
     container: registry.container(),
     tagName: 'del',
-    content: Ember.A(),
+    content: emberA(),
     emptyView: 'empty'
   });
 
@@ -639,7 +640,7 @@ QUnit.test('should lookup from only global path against the container if emptyVi
 
   view = CollectionView.create({
     container: registry.container(),
-    content: Ember.A(),
+    content: emberA(),
     emptyView: 'top'
   });
 
@@ -654,7 +655,7 @@ QUnit.test('Collection with style attribute supports changing content', function
   view = CollectionView.create({
     attributeBindings: ['style'],
     style: 'width: 100px;',
-    content: Ember.A(['foo', 'bar'])
+    content: emberA(['foo', 'bar'])
   });
 
   run(function() {

--- a/packages/ember-views/tests/views/select_test.js
+++ b/packages/ember-views/tests/views/select_test.js
@@ -1,4 +1,3 @@
-import Ember from 'ember-metal/core';
 import run from 'ember-metal/run_loop';
 import EmberObject from 'ember-runtime/system/object';
 import EmberSelect from 'ember-views/views/select';
@@ -6,6 +5,7 @@ import jQuery from 'ember-views/system/jquery';
 import EventDispatcher from 'ember-views/system/event_dispatcher';
 import SafeString from 'htmlbars-util/safe-string';
 import RSVP from 'ember-runtime/ext/rsvp';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 import { registerKeyword, resetKeyword } from 'ember-htmlbars/tests/utils';
 import viewKeyword from 'ember-htmlbars/keywords/view';
@@ -92,7 +92,7 @@ QUnit.test('should become disabled if the disabled attribute is changed', functi
 });
 
 QUnit.test('can have options', function() {
-  select.set('content', Ember.A([1, 2, 3]));
+  select.set('content', emberA([1, 2, 3]));
 
   append();
 
@@ -125,7 +125,7 @@ QUnit.test('select name is updated when setting name property of view', function
 });
 
 QUnit.test('can specify the property path for an option\'s label and value', function() {
-  select.set('content', Ember.A([
+  select.set('content', emberA([
     { id: 1, firstName: 'Yehuda' },
     { id: 2, firstName: 'Tom' }
   ]));
@@ -142,7 +142,7 @@ QUnit.test('can specify the property path for an option\'s label and value', fun
 });
 
 QUnit.test('XSS: does not escape label value when it is a SafeString', function() {
-  select.set('content', Ember.A([
+  select.set('content', emberA([
     { id: 1, firstName: new SafeString('<p>Yehuda</p>') },
     { id: 2, firstName: new SafeString('<p>Tom</p>') }
   ]));
@@ -161,7 +161,7 @@ QUnit.test('XSS: does not escape label value when it is a SafeString', function(
 });
 
 QUnit.test('XSS: escapes label value content', function() {
-  select.set('content', Ember.A([
+  select.set('content', emberA([
     { id: 1, firstName: '<p>Yehuda</p>' },
     { id: 2, firstName: '<p>Tom</p>' }
   ]));
@@ -183,7 +183,7 @@ QUnit.test('can retrieve the current selected option when multiple=false', funct
   var yehuda = { id: 1, firstName: 'Yehuda' };
   var tom = { id: 2, firstName: 'Tom' };
 
-  select.set('content', Ember.A([yehuda, tom]));
+  select.set('content', emberA([yehuda, tom]));
 
   append();
 
@@ -201,7 +201,7 @@ QUnit.test('can retrieve the current selected options when multiple=true', funct
   var david = { id: 3, firstName: 'David' };
   var brennain = { id: 4, firstName: 'Brennain' };
 
-  select.set('content', Ember.A([yehuda, tom, david, brennain]));
+  select.set('content', emberA([yehuda, tom, david, brennain]));
   select.set('multiple', true);
   select.set('optionLabelPath', 'content.firstName');
   select.set('optionValuePath', 'content.firstName');
@@ -226,7 +226,7 @@ QUnit.test('selection can be set when multiple=false', function() {
   var tom = { id: 2, firstName: 'Tom' };
 
   run(function() {
-    select.set('content', Ember.A([yehuda, tom]));
+    select.set('content', emberA([yehuda, tom]));
     select.set('multiple', false);
     select.set('selection', tom);
   });
@@ -247,7 +247,7 @@ QUnit.test('selection can be set from a Promise when multiple=false', function()
   var tom = { id: 2, firstName: 'Tom' };
 
   run(function() {
-    select.set('content', Ember.A([yehuda, tom]));
+    select.set('content', emberA([yehuda, tom]));
     select.set('multiple', false);
     select.set('selection', RSVP.Promise.resolve(tom));
   });
@@ -267,7 +267,7 @@ QUnit.test('selection from a Promise don\'t overwrite newer selection once resol
   QUnit.stop();
 
   run(function() {
-    select.set('content', Ember.A([yehuda, tom, seb]));
+    select.set('content', emberA([yehuda, tom, seb]));
     select.set('multiple', false);
     select.set('selection', new RSVP.Promise(function(resolve, reject) {
       run.later(function() {
@@ -297,7 +297,7 @@ QUnit.test('selection from a Promise resolving to null should not select when mu
   var tom = { id: 2, firstName: 'Tom' };
 
   run(function() {
-    select.set('content', Ember.A([yehuda, tom]));
+    select.set('content', emberA([yehuda, tom]));
     select.set('multiple', false);
     select.set('selection', RSVP.Promise.resolve(null));
   });
@@ -314,7 +314,7 @@ QUnit.test('selection can be set when multiple=true', function() {
   var brennain = { id: 4, firstName: 'Brennain' };
 
   run(() => {
-    select.set('content', Ember.A([
+    select.set('content', emberA([
       yehuda,
       tom,
       david,
@@ -340,7 +340,7 @@ QUnit.test('selection can be set when multiple=true and prompt', function() {
   var brennain = { id: 4, firstName: 'Brennain' };
 
   run(() => {
-    select.set('content', Ember.A([
+    select.set('content', emberA([
       yehuda,
       tom,
       david,
@@ -369,7 +369,7 @@ QUnit.test('multiple selections can be set when multiple=true', function() {
   var brennain = { id: 4, firstName: 'Brennain' };
 
   run(() => {
-    select.set('content', Ember.A([
+    select.set('content', emberA([
       yehuda,
       tom,
       david,
@@ -378,14 +378,14 @@ QUnit.test('multiple selections can be set when multiple=true', function() {
     select.set('optionLabelPath', 'content.firstName');
     select.set('multiple', true);
 
-    select.set('selection', Ember.A([yehuda, david]));
+    select.set('selection', emberA([yehuda, david]));
   });
 
   append();
 
   deepEqual(select.get('selection'), [yehuda, david], 'Initial selection should be correct');
 
-  run(() => select.set('selection', Ember.A([
+  run(() => select.set('selection', emberA([
     tom,
     brennain
   ])));
@@ -401,10 +401,10 @@ QUnit.test('multiple selections can be set by changing in place the selection ar
   var tom = { id: 2, firstName: 'Tom' };
   var david = { id: 3, firstName: 'David' };
   var brennain = { id: 4, firstName: 'Brennain' };
-  var selection = Ember.A([yehuda, tom]);
+  var selection = emberA([yehuda, tom]);
 
   run(function() {
-    select.set('content', Ember.A([yehuda, tom, david, brennain]));
+    select.set('content', emberA([yehuda, tom, david, brennain]));
     select.set('optionLabelPath', 'content.firstName');
     select.set('multiple', true);
     select.set('selection', selection);
@@ -415,7 +415,7 @@ QUnit.test('multiple selections can be set by changing in place the selection ar
   deepEqual(select.get('selection'), [yehuda, tom], 'Initial selection should be correct');
 
   run(function() {
-    selection.replace(0, selection.get('length'), Ember.A([david, brennain]));
+    selection.replace(0, selection.get('length'), emberA([david, brennain]));
   });
 
   deepEqual(
@@ -446,8 +446,8 @@ QUnit.test('multiple selections can be set indirectly via bindings and in-place 
       }).create();
 
       indirectContent.set('controller', EmberObject.create({
-        content: Ember.A([tom, david, brennain]),
-        selection: Ember.A([david])
+        content: emberA([tom, david, brennain]),
+        selection: emberA([david])
       }));
     });
 
@@ -458,8 +458,8 @@ QUnit.test('multiple selections can be set indirectly via bindings and in-place 
   deepEqual(select.get('selection'), [david], 'Initial selection should be correct');
 
   run(function() {
-    indirectContent.set('controller.content', Ember.A([david, cyril]));
-    indirectContent.set('controller.selection', Ember.A([cyril]));
+    indirectContent.set('controller.content', emberA([david, cyril]));
+    indirectContent.set('controller.selection', emberA([cyril]));
   });
 
   deepEqual(select.get('content'), [david, cyril], 'After updating bound content, content should be correct');
@@ -467,7 +467,7 @@ QUnit.test('multiple selections can be set indirectly via bindings and in-place 
 });
 
 QUnit.test('select with group can group options', function() {
-  var content = Ember.A([
+  var content = emberA([
     { firstName: 'Yehuda', organization: 'Tilde' },
     { firstName: 'Tom', organization: 'Tilde' },
     { firstName: 'Keith', organization: 'Envato' }
@@ -494,7 +494,7 @@ QUnit.test('select with group can group options', function() {
 });
 
 QUnit.test('select with group doesn\'t break options', function() {
-  var content = Ember.A([
+  var content = emberA([
     { id: 1, firstName: 'Yehuda', organization: 'Tilde' },
     { id: 2, firstName: 'Tom', organization: 'Tilde' },
     { id: 3, firstName: 'Keith', organization: 'Envato' }
@@ -523,7 +523,7 @@ QUnit.test('select with group doesn\'t break options', function() {
 });
 
 QUnit.test('select with group works for initial value', function() {
-  var content = Ember.A([
+  var content = emberA([
     { id: 1, firstName: 'Yehuda', organization: 'Tilde' },
     { id: 2, firstName: 'Tom', organization: 'Tilde' },
     { id: 3, firstName: 'Keith', organization: 'Envato' }
@@ -543,7 +543,7 @@ QUnit.test('select with group works for initial value', function() {
 
 QUnit.test('select with group observes its content', function() {
   var wycats = { firstName: 'Yehuda', organization: 'Tilde' };
-  var content = Ember.A([
+  var content = emberA([
     wycats
   ]);
 
@@ -590,10 +590,10 @@ QUnit.test('selection uses the same array when multiple=true', function() {
   var tom = { id: 2, firstName: 'Tom' };
   var david = { id: 3, firstName: 'David' };
   var brennain = { id: 4, firstName: 'Brennain' };
-  var selection = Ember.A([yehuda, david]);
+  var selection = emberA([yehuda, david]);
 
   run(function() {
-    select.set('content', Ember.A([yehuda, tom, david, brennain]));
+    select.set('content', emberA([yehuda, tom, david, brennain]));
     select.set('multiple', true);
     select.set('optionLabelPath', 'content.firstName');
     select.set('selection', selection);
@@ -619,7 +619,7 @@ QUnit.test('Ember.SelectedOption knows when it is selected when multiple=false',
   var brennain = { id: 4, firstName: 'Brennain' };
 
   run(function() {
-    select.set('content', Ember.A([yehuda, tom, david, brennain]));
+    select.set('content', emberA([yehuda, tom, david, brennain]));
     select.set('multiple', false);
 
     select.set('selection', david);
@@ -641,7 +641,7 @@ QUnit.test('Ember.SelectedOption knows when it is selected when multiple=true', 
   var brennain = { id: 4, firstName: 'Brennain' };
 
   run(function() {
-    select.set('content', Ember.A([yehuda, tom, david, brennain]));
+    select.set('content', emberA([yehuda, tom, david, brennain]));
     select.set('multiple', true);
 
     select.set('selection', [yehuda, david]);
@@ -660,7 +660,7 @@ QUnit.test('Ember.SelectedOption knows when it is selected when multiple=true', 
 
 QUnit.test('Ember.SelectedOption knows when it is selected when multiple=true and options are primitives', function() {
   run(function() {
-    select.set('content', Ember.A([1, 2, 3, 4]));
+    select.set('content', emberA([1, 2, 3, 4]));
     select.set('multiple', true);
     select.set('selection', [1, 3]);
   });
@@ -679,7 +679,7 @@ QUnit.test('a prompt can be specified', function() {
   var tom = { id: 2, firstName: 'Tom' };
 
   run(function() {
-    select.set('content', Ember.A([yehuda, tom]));
+    select.set('content', emberA([yehuda, tom]));
     select.set('prompt', 'Pick a person');
     select.set('optionLabelPath', 'content.firstName');
     select.set('optionValuePath', 'content.id');
@@ -736,7 +736,7 @@ QUnit.test('valueBinding handles 0 as initiated value (issue #2763)', function()
     select.destroy(); // Destroy the existing select
 
     select = EmberSelect.extend({
-      content: Ember.A([1, 0]),
+      content: emberA([1, 0]),
       indirectData: indirectData,
       valueBinding: 'indirectData.value'
     }).create();
@@ -752,7 +752,7 @@ QUnit.test('valueBinding handles 0 as initiated value (issue #2763)', function()
 
 QUnit.test('should be able to select an option and then reselect the prompt', function() {
   run(function() {
-    select.set('content', Ember.A(['one', 'two', 'three']));
+    select.set('content', emberA(['one', 'two', 'three']));
     select.set('prompt', 'Select something');
   });
 
@@ -770,7 +770,7 @@ QUnit.test('should be able to select an option and then reselect the prompt', fu
 
 QUnit.test('should be able to get the current selection\'s value', function() {
   run(function() {
-    select.set('content', Ember.A([
+    select.set('content', emberA([
       { label: 'Yehuda Katz', value: 'wycats' },
       { label: 'Tom Dale', value: 'tomdale' },
       { label: 'Peter Wagenet', value: 'wagenet' },
@@ -789,7 +789,7 @@ QUnit.test('should be able to set the current selection by value', function() {
   var ebryn = { label: 'Erik Bryn', value: 'ebryn' };
 
   run(function() {
-    select.set('content', Ember.A([
+    select.set('content', emberA([
       { label: 'Yehuda Katz', value: 'wycats' },
       { label: 'Tom Dale', value: 'tomdale' },
       { label: 'Peter Wagenet', value: 'wagenet' },

--- a/packages/ember-views/tests/views/view/child_views_test.js
+++ b/packages/ember-views/tests/views/view/child_views_test.js
@@ -1,8 +1,8 @@
 import run from 'ember-metal/run_loop';
-import Ember from 'ember-metal/core';
 import EmberView from 'ember-views/views/view';
 import Component from 'ember-views/components/component';
 import { compile } from 'ember-template-compiler';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 import { registerKeyword, resetKeyword } from 'ember-htmlbars/tests/utils';
 import viewKeyword from 'ember-htmlbars/keywords/view';
@@ -147,7 +147,7 @@ QUnit.test('should remove childViews inside {{each}} on destroy', function() {
 
   equal(outerView.get('childViews.length'), 0);
 
-  run(outerView, 'set', 'data', Ember.A([
+  run(outerView, 'set', 'data', emberA([
     { id: 1, value: new Date() },
     { id: 2, value: new Date() }
   ]));

--- a/packages/ember/tests/component_registration_test.js
+++ b/packages/ember/tests/component_registration_test.js
@@ -7,6 +7,7 @@ import compile from 'ember-template-compiler/system/compile';
 import helpers from 'ember-htmlbars/helpers';
 import { OutletView } from 'ember-routing-views/views/outlet';
 import jQuery from 'ember-views/system/jquery';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 var App, registry, container;
 var originalHelpers;
@@ -15,7 +16,7 @@ function prepare() {
   Ember.TEMPLATES['components/expand-it'] = compile('<p>hello {{yield}}</p>');
   Ember.TEMPLATES.application = compile('Hello world {{#expand-it}}world{{/expand-it}}');
 
-  originalHelpers = Ember.A(keys(helpers));
+  originalHelpers = emberA(keys(helpers));
 }
 
 function cleanup() {
@@ -31,7 +32,7 @@ function cleanup() {
 }
 
 function cleanupHelpers() {
-  var currentHelpers = Ember.A(keys(helpers));
+  var currentHelpers = emberA(keys(helpers));
 
   currentHelpers.forEach(function(name) {
     if (!originalHelpers.contains(name)) {

--- a/packages/ember/tests/controller_test.js
+++ b/packages/ember/tests/controller_test.js
@@ -4,6 +4,7 @@ import { compile } from 'ember-template-compiler';
 import EmberView from 'ember-views/views/view';
 import Application from 'ember-application/system/application';
 import jQuery from 'ember-views/system/jquery';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 import plugins, { registerPlugin } from 'ember-template-compiler/plugins';
 import TransformEachIntoCollection from 'ember-template-compiler/plugins/transform-each-into-collection';
@@ -116,7 +117,7 @@ QUnit.test('{{#each}} inside outlet can have an itemController', function(assert
   }, `Using 'itemController' with '{{each}}' (L2:C20) is deprecated.  Please refactor to a component.`);
 
   App.IndexController = Ember.Controller.extend({
-    model: Ember.A([1, 2, 3])
+    model: emberA([1, 2, 3])
   });
 
   App.ThingController = Ember.Controller.extend();

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -9,6 +9,7 @@ import alias from 'ember-metal/alias';
 import Application from 'ember-application/system/application';
 import jQuery from 'ember-views/system/jquery';
 import inject from 'ember-runtime/inject';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 import { compile } from 'ember-template-compiler';
 import EmberView from 'ember-views/views/view';
@@ -610,7 +611,7 @@ QUnit.test('The {{link-to}} helper moves into the named route with context', fun
 
   App.AboutRoute = Ember.Route.extend({
     model() {
-      return Ember.A([
+      return emberA([
         { id: 'yehuda', name: 'Yehuda Katz' },
         { id: 'tom', name: 'Tom Dale' },
         { id: 'erik', name: 'Erik Brynroflsson' }
@@ -1027,7 +1028,7 @@ QUnit.test('The {{link-to}} helper works in an #each\'d array of string route na
   });
 
   App.IndexController = Ember.Controller.extend({
-    routeNames: Ember.A(['foo', 'bar', 'rar']),
+    routeNames: emberA(['foo', 'bar', 'rar']),
     route1: 'bar',
     route2: 'foo'
   });
@@ -1137,7 +1138,7 @@ QUnit.test('The non-block form {{link-to}} helper moves into the named route wit
 
   App.IndexRoute = Ember.Route.extend({
     model() {
-      return Ember.A([
+      return emberA([
         { id: 'yehuda', name: 'Yehuda Katz' },
         { id: 'tom', name: 'Tom Dale' },
         { id: 'erik', name: 'Erik Brynroflsson' }

--- a/packages/ember/tests/homepage_example_test.js
+++ b/packages/ember/tests/homepage_example_test.js
@@ -5,6 +5,7 @@ import EmberObject from 'ember-runtime/system/object';
 import { computed } from 'ember-metal/computed';
 import { compile } from 'ember-template-compiler';
 import jQuery from 'ember-views/system/jquery';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 var App, $fixture;
 
@@ -25,7 +26,7 @@ function setupExample() {
 
   App.IndexRoute = Ember.Route.extend({
     model() {
-      var people = Ember.A([
+      var people = emberA([
         App.Person.create({
           firstName: 'Tom',
           lastName: 'Dale'

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -12,6 +12,7 @@ import EmberView from 'ember-views/views/view';
 import { compile } from 'ember-template-compiler';
 import Application from 'ember-application/system/application';
 import jQuery from 'ember-views/system/jquery';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 var trim = jQuery.trim;
 
@@ -603,7 +604,7 @@ QUnit.test('The Homepage with a `setupController` hook', function() {
 
   App.HomeRoute = Ember.Route.extend({
     setupController(controller) {
-      set(controller, 'hours', Ember.A([
+      set(controller, 'hours', emberA([
         'Monday through Friday: 9am to 5pm',
         'Saturday: Noon to Midnight',
         'Sunday: Noon to 6pm'
@@ -722,7 +723,7 @@ QUnit.test('The Homepage with a `setupController` hook modifying other controlle
 
   App.HomeRoute = Ember.Route.extend({
     setupController(controller) {
-      set(this.controllerFor('home'), 'hours', Ember.A([
+      set(this.controllerFor('home'), 'hours', emberA([
         'Monday through Friday: 9am to 5pm',
         'Saturday: Noon to Midnight',
         'Sunday: Noon to 6pm'
@@ -746,7 +747,7 @@ QUnit.test('The Homepage with a computed context that does not get overridden', 
 
   App.HomeController = Ember.Controller.extend({
     model: computed(function() {
-      return Ember.A([
+      return emberA([
         'Monday through Friday: 9am to 5pm',
         'Saturday: Noon to Midnight',
         'Sunday: Noon to 6pm'
@@ -770,7 +771,7 @@ QUnit.test('The Homepage getting its controller context via model', function() {
 
   App.HomeRoute = Ember.Route.extend({
     model() {
-      return Ember.A([
+      return emberA([
         'Monday through Friday: 9am to 5pm',
         'Saturday: Noon to Midnight',
         'Sunday: Noon to 6pm'
@@ -2053,7 +2054,7 @@ QUnit.test('Rendering into specified template with slash notation', function() {
 
 QUnit.test('Parent route context change', function() {
   var editCount = 0;
-  var editedPostIds = Ember.A();
+  var editedPostIds = emberA();
 
   Ember.TEMPLATES.application = compile('{{outlet}}');
   Ember.TEMPLATES.posts = compile('{{outlet}}');
@@ -2320,7 +2321,7 @@ QUnit.test('Application template does not duplicate when re-rendered', function(
 
   App.ApplicationRoute = Ember.Route.extend({
     model() {
-      return Ember.A();
+      return emberA();
     }
   });
 

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -6,6 +6,7 @@ import { computed } from 'ember-metal/computed';
 import { compile } from 'ember-template-compiler';
 import Application from 'ember-application/system/application';
 import jQuery from 'ember-views/system/jquery';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 var Router, App, router, container;
 var get = Ember.get;
@@ -735,7 +736,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     });
 
     App.HomeController = Ember.Controller.extend({
-      foo: Ember.A([])
+      foo: emberA()
     });
 
     App.HomeRoute = Ember.Route.extend({
@@ -794,14 +795,14 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     });
 
     App.HomeController = Ember.Controller.extend({
-      foo: Ember.A([1])
+      foo: emberA([1])
     });
 
     bootApplication();
 
     equal(modelCount, 1);
     var controller = container.lookup('controller:home');
-    setAndFlush(controller, 'model', Ember.A([1]));
+    setAndFlush(controller, 'model', emberA([1]));
     equal(modelCount, 1);
     equal(router.get('location.path'), '');
   });
@@ -1724,7 +1725,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     App.HomeRoute = Ember.Route.extend({
       queryParams: {
         foo: {
-          defaultValue: Ember.A([])
+          defaultValue: emberA()
         }
       }
     });
@@ -1772,7 +1773,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     App.HomeRoute = Ember.Route.extend({
       queryParams: {
         foo: {
-          defaultValue: Ember.A([1])
+          defaultValue: emberA([1])
         }
       },
       model() {
@@ -1784,7 +1785,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
 
     equal(modelCount, 1);
     var controller = container.lookup('controller:home');
-    setAndFlush(controller, 'model', Ember.A([1]));
+    setAndFlush(controller, 'model', emberA([1]));
     equal(modelCount, 1);
     equal(router.get('location.path'), '');
   });
@@ -2878,7 +2879,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
 
     App.HomeController = Ember.Controller.extend({
       queryParams: ['foo'],
-      foo: Ember.A([])
+      foo: emberA()
     });
 
     bootApplication();
@@ -2929,14 +2930,14 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
 
     App.HomeController = Ember.Controller.extend({
       queryParams: ['foo'],
-      foo: Ember.A([1])
+      foo: emberA([1])
     });
 
     bootApplication();
 
     equal(modelCount, 1);
     var controller = container.lookup('controller:home');
-    setAndFlush(controller, 'model', Ember.A([1]));
+    setAndFlush(controller, 'model', emberA([1]));
     equal(modelCount, 1);
     equal(router.get('location.path'), '');
   });

--- a/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
@@ -5,6 +5,7 @@ import { computed } from 'ember-metal/computed';
 import { compile } from 'ember-template-compiler';
 import Application from 'ember-application/system/application';
 import jQuery from 'ember-views/system/jquery';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 var Router, App, router, registry, container;
 
@@ -339,7 +340,7 @@ QUnit.module('Model Dep Query Params', {
       this.route('about');
     });
 
-    var articles = this.articles = Ember.A([{ id: 'a-1' }, { id: 'a-2' }, { id: 'a-3' }]);
+    var articles = this.articles = emberA([{ id: 'a-1' }, { id: 'a-2' }, { id: 'a-3' }]);
 
     App.ApplicationController = Ember.Controller.extend({
       articles: this.articles
@@ -430,7 +431,7 @@ QUnit.module('Model Dep Query Params (nested)', {
       this.route('about');
     });
 
-    var site_articles = this.site_articles = Ember.A([{ id: 'a-1' }, { id: 'a-2' }, { id: 'a-3' }]);
+    var site_articles = this.site_articles = emberA([{ id: 'a-1' }, { id: 'a-2' }, { id: 'a-3' }]);
 
     App.ApplicationController = Ember.Controller.extend({
       articles: this.site_articles
@@ -519,8 +520,8 @@ QUnit.module('Model Dep Query Params (nested & more than 1 dynamic segment)', {
       });
     });
 
-    var sites = this.sites = Ember.A([{ id: 's-1' }, { id: 's-2' }, { id: 's-3' }]);
-    var site_articles = this.site_articles = Ember.A([{ id: 'a-1' }, { id: 'a-2' }, { id: 'a-3' }]);
+    var sites = this.sites = emberA([{ id: 's-1' }, { id: 's-2' }, { id: 's-3' }]);
+    var site_articles = this.site_articles = emberA([{ id: 'a-1' }, { id: 'a-2' }, { id: 'a-3' }]);
 
     App.ApplicationController = Ember.Controller.extend({
       siteArticles: this.site_articles,


### PR DESCRIPTION
Some files were using `jshint newcap:false` and `import { A }` but I thought it would be better to be consistent with the jshint rules.

Happy to switch to `A` and disable the `newcap` rule if that's preferable.
