### PR TITLE
Update QUnit test timeout to 15 seconds.

### DIFF
--- a/packages/ember-testing/tests/helper_registration_test.js
+++ b/packages/ember-testing/tests/helper_registration_test.js
@@ -53,15 +53,18 @@ QUnit.test('Helper gets registered', function() {
   ok(helperContainer.boot);
 });
 
-QUnit.test('Helper is ran when called', function() {
-  expect(1);
+QUnit.test('Helper is ran when called', function(assert) {
+  let done = assert.async();
+  assert.expect(1);
 
   registerHelper();
   setupApp();
 
-  App.testHelpers.boot().then(function() {
-    ok(appBooted);
-  });
+  App.testHelpers.boot()
+    .then(function() {
+      assert.ok(appBooted);
+    })
+    .finally(done);
 });
 
 QUnit.test('Helper can be unregistered', function() {
@@ -80,4 +83,3 @@ QUnit.test('Helper can be unregistered', function() {
   ok(!App.testHelpers.boot, 'once unregistered the helper is not added to App.testHelpers');
   ok(!helperContainer.boot, 'once unregistered the helper is not added to the helperContainer');
 });
-

--- a/tests/index.html
+++ b/tests/index.html
@@ -143,8 +143,8 @@
         });
         setupQUnit(testHelpers);
 
-        // Tests should time out after 5 seconds
-        QUnit.config.testTimeout = 7500;
+        // Tests should time out after 15 seconds
+        QUnit.config.testTimeout = 15000;
         // Handle testing feature flags
         QUnit.config.urlConfig.push({ id: 'enableoptionalfeatures', label: "Enable Opt Features"});
         // Handle extending prototypes


### PR DESCRIPTION
We have an annoying intermitent test failure that occurs when running tests on older browsers in Sauce Labs. The failure is generally occurring when the VM itself is slower than normal, and will pass after a restart.

This increases the timeout to allow more time (from 7 seconds to 15 seconds) in the hopes that this resolves the majority of our random failure scenarios.
