### PR TITLE
[BUGFIX canary] Add meta and GUID keys to stream shape.

### DIFF
--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -333,10 +333,14 @@ export function meta(obj, writable) {
     ret = new Meta(obj, ret);
   }
 
-  if (obj.__defineNonEnumerable) {
-    obj.__defineNonEnumerable(EMBER_META_PROPERTY);
-  } else {
-    Object.defineProperty(obj, '__ember_meta__', META_DESC);
+  // if `null` already, just set it to the new value
+  // otherwise define property first
+  if (obj.__ember_meta__ !== null) {
+    if (obj.__defineNonEnumerable) {
+      obj.__defineNonEnumerable(EMBER_META_PROPERTY);
+    } else {
+      Object.defineProperty(obj, '__ember_meta__', META_DESC);
+    }
   }
   obj.__ember_meta__ = ret;
 

--- a/packages/ember-metal/lib/streams/stream.js
+++ b/packages/ember-metal/lib/streams/stream.js
@@ -7,6 +7,7 @@ import { isStream } from 'ember-metal/streams/utils';
 import EmptyObject from 'ember-metal/empty_object';
 import Subscriber from 'ember-metal/streams/subscriber';
 import Dependency from 'ember-metal/streams/dependency';
+import { GUID_KEY } from 'ember-metal/utils';
 
 /**
   @module ember-metal
@@ -40,6 +41,8 @@ BasicStream.prototype = {
     this.dependencyHead = null;
     this.dependencyTail = null;
     this.observedProxy = null;
+    this.__ember_meta__ = null;
+    this[GUID_KEY] = null;
   },
 
   _makeChildStream(key) {


### PR DESCRIPTION
After `init` is ran for stream objects we seal the object to ensure that we maintain a consistent object shape.

In some scenarios the Ember Inspector needs to call `Ember.guidFor` on a stream to keep track of which streams have already been seen/walked.  Unfortunately, we forgot to add `GUID_KEY` and `__ember_meta__` to the base stream object before sealing, which causes an error:

``` javascript
Uncaught TypeError: Cannot define property:__ember1442443003034, object is not extensible.
```

This adds the proper placeholders to the base stream class to prevent this error.

---

Fixes emberjs/ember-inspector#468.
