### PR TITLE
Fix multiplicative observation of controllers in views

### DIFF
--- a/packages/ember-views/lib/mixins/legacy_view_support.js
+++ b/packages/ember-views/lib/mixins/legacy_view_support.js
@@ -16,16 +16,6 @@ var LegacyViewSupport = Mixin.create({
 
   afterRender(buffer) {},
 
-  walkChildViews(callback) {
-    var childViews = this.childViews.slice();
-
-    while (childViews.length) {
-      var view = childViews.pop();
-      callback(view);
-      childViews.push(...view.childViews);
-    }
-  },
-
   mutateChildViews(callback) {
     var childViews = get(this, 'childViews');
     var idx = childViews.length;

--- a/packages/ember-views/lib/mixins/view_context_support.js
+++ b/packages/ember-views/lib/mixins/view_context_support.js
@@ -96,7 +96,7 @@ var ViewContextSupport = Mixin.create(LegacyViewSupport, {
   }),
 
   _legacyControllerDidChange: observer('controller', function() {
-    this.walkChildViews(view => view.notifyPropertyChange('controller'));
+    this.childViews.forEach(view => view.notifyPropertyChange('controller'));
   }),
 
   _notifyControllerChange: on('parentViewDidChange', function() {

--- a/packages/ember-views/tests/views/view/controller_test.js
+++ b/packages/ember-views/tests/views/view/controller_test.js
@@ -48,3 +48,45 @@ QUnit.test('controller property should be inherited from nearest ancestor with c
     grandchild.destroy();
   });
 });
+
+QUnit.test('controller changes are passed to descendants', function() {
+  var grandparent = ContainerView.create();
+  var parent = ContainerView.create();
+  var child = ContainerView.create();
+  var grandchild = ContainerView.create();
+
+  run(function() {
+    grandparent.set('controller', {});
+
+    grandparent.pushObject(parent);
+    parent.pushObject(child);
+    child.pushObject(grandchild);
+  });
+
+  var parentCount = 0;
+  var childCount = 0;
+  var grandchildCount = 0;
+
+  parent.addObserver('controller', parent, function() { parentCount++; });
+  child.addObserver('controller', child, function() { childCount++; });
+  grandchild.addObserver('controller', grandchild, function() { grandchildCount++; });
+
+  run(function() { grandparent.set('controller', {}); });
+
+  equal(parentCount, 1);
+  equal(childCount, 1);
+  equal(grandchildCount, 1);
+
+  run(function() { grandparent.set('controller', {}); });
+
+  equal(parentCount, 2);
+  equal(childCount, 2);
+  equal(grandchildCount, 2);
+
+  run(function() {
+    grandparent.destroy();
+    parent.destroy();
+    child.destroy();
+    grandchild.destroy();
+  });
+});


### PR DESCRIPTION
Addresses issue #12016.

**Root cause**: when the controller changed for a view, it would notify all of it's descendant views which would in turn notify all of their descendant views resulting in a multiplication of work, especially when many descendants are involved.

**Solution**: when the controller changes for a view, only notify it's immediate children.
