### PR TITLE
[WIP] Make model hooks run in parallel

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -29,6 +29,7 @@ import {
   normalizeControllerQueryParams,
   calculateCacheKey
 } from 'ember-routing/utils';
+import RSVP from 'rsvp';
 
 var slice = Array.prototype.slice;
 
@@ -1472,9 +1473,9 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     if (!name && sawParams) {
       return copy(params);
     } else if (!name) {
-      if (transition.resolveIndex < 1) { return; }
+      if (transition.requestIndex < 2) { return; }
 
-      var parentModel = transition.state.handlerInfos[transition.resolveIndex - 1].context;
+      var parentModel = transition.state.handlerInfos[transition.requestIndex - 2].modelPromise;
 
       return parentModel;
     }
@@ -1776,7 +1777,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
       }
     }
 
-    return route && route.currentModel;
+    return route && RSVP.Promise.resolve(route.currentModel);
   },
 
   /**


### PR DESCRIPTION
Opening for discussion on how to support running model hooks in parallel. From an IRL discussion with @wycats and @nathanhammond, this should be built as an addon, so that apps must explicitly opt into the functionality and related consequences. I am laying out the required changes directly in the source so we can plan how to hook into the necessary parts of Ember from that addon.

The big consequence of making model hooks run in parallel is that `modelFor` must return a promise. Here are the changes that make that happen.

Parallel model hooks require changes to router.js as well: tildeio/router.js#171
