### PR TITLE
[BUGFIX canary] Ensure components actions function without controller.

### DIFF
--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -62,6 +62,8 @@ ComponentNodeManager.create = function ComponentNodeManager_create(renderNode, e
   // `sendAction` correctly.
   if (parentScope.hasLocal('controller')) {
     createOptions._controller = getValue(parentScope.getLocal('controller'));
+  } else {
+    createOptions._targetObject = getValue(parentScope.getSelf());
   }
 
   extractPositionalParams(renderNode, component, params, attrs);


### PR DESCRIPTION
On canary we no longer create `controller` and `view` template locals.  Unfortunately, our test suite still pretends that they are there (since they are added back in by the legacy addons) so all tests pass that were using `scope.getLocal('controller')` and friends).

This commit adds a test for sending actions that runs without the flags enabled (the test failed prior to this change), and updates component-node-manager to provide either `_controller` _OR_ `_targetObject` to the component that is being created.

Fixes #12409.

/cc @tomdale @wycats for review
