### PR TITLE
remove extra call to metaFor

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -378,7 +378,7 @@ function applyMixin(obj, mixins, partial) {
   // * Set up _super wrapping if necessary
   // * Set up computed property descriptors
   // * Copying `toString` in broken browsers
-  mergeMixins(mixins, metaFor(obj), descs, values, obj, keys);
+  mergeMixins(mixins, m, descs, values, obj, keys);
 
   for (var i = 0, l = keys.length; i < l; i++) {
     key = keys[i];


### PR DESCRIPTION
as this already occurs several lines above: https://github.com/emberjs/ember.js/pull/12421/files#diff-6ace70f858a849113c336029e6e55f16R368
