### PR TITLE
[DOC beta] Add URL for deprecation guide on initializer arity.

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -756,8 +756,12 @@ var Application = Namespace.extend(RegistryProxy, {
       if (initializer.initialize.length === 2) {
         if (isEnabled('ember-registry-container-reform')) {
           deprecate('The `initialize` method for Application initializer \'' + name + '\' should take only one argument - `App`, an instance of an `Application`.',
-                          false,
-                          { id: 'ember-application.app-initializer-initialize-arguments', until: '3.0.0' });
+                    false,
+                    {
+                      id: 'ember-application.app-initializer-initialize-arguments',
+                      until: '3.0.0',
+                      url: 'http://emberjs.com/deprecations/v2.x/#toc_initializer-arity'
+                    });
         }
         initializer.initialize(App.__registry__, App);
       } else {


### PR DESCRIPTION
Links to deprecation guide entry added in https://github.com/emberjs/website/pull/2376.

Addresses the last item in #12336.
