### PR TITLE
Remove `ember-registry-container-reform` feature flag.

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -72,18 +72,6 @@ for a detailed explanation.
   Implements RFC https://github.com/emberjs/rfcs/pull/65, adding support for
   custom deprecation and warning handlers.
 
-* `ember-registry-container-reform`
-
-  Implements RFC https://github.com/emberjs/rfcs/pull/46, fully encapsulating
-  and privatizing the `Container` and `Registry` classes by exposing a select
-  subset of public methods on `Application` and `ApplicationInstance`.
-
-  `Application` initializers now receive a single argument to `initialize`:
-  `application`.
-
-  Likewise, `ApplicationInstance` initializers still receive a single argument
-  to initialize: `applicationInstance`.
-
 * `ember-routing-routable-components`
 
   Implements RFC https://github.com/emberjs/rfcs/pull/38, adding support for

--- a/features.json
+++ b/features.json
@@ -7,7 +7,6 @@
     "ember-routing-route-configured-query-params": null,
     "ember-libraries-isregistered": null,
     "ember-debug-handlers": true,
-    "ember-registry-container-reform": true,
     "ember-routing-routable-components": null,
     "ember-metal-ember-assign": null,
     "ember-contextual-components": null

--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -1,7 +1,6 @@
 import Ember from 'ember-metal/core';
 import { assert } from 'ember-metal/debug';
 import dictionary from 'ember-metal/dictionary';
-import isEnabled from 'ember-metal/features';
 
 /**
  A container used to instantiate and cache objects.
@@ -349,18 +348,6 @@ function resetMember(container, fullName) {
       member.destroy();
     }
   }
-}
-
-// Once registry / container reform is enabled, we no longer need to expose
-// Container#_registry, since Container itself will be fully private.
-if (!isEnabled('ember-registry-container-reform')) {
-  Object.defineProperty(Container.prototype, '_registry', {
-    configurable: true,
-    enumerable: false,
-    get() {
-      return this.registry;
-    }
-  });
 }
 
 export default Container;

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -1,7 +1,6 @@
 import Ember from 'ember-metal/core';
 import Registry from 'container/registry';
 import { factory } from 'container/tests/container_helper';
-import isEnabled from 'ember-metal/features';
 
 var originalModelInjections;
 
@@ -536,13 +535,3 @@ QUnit.test('Lazy injection validations are cached', function() {
   container.lookup('apple:main');
   container.lookup('apple:main');
 });
-
-if (!isEnabled('ember-registry-container-reform')) {
-  QUnit.test('Container#_registry provides an alias to Container#registry while Container is pseudo-public', function() {
-    var registry = new Registry();
-    var container = registry.container();
-
-    strictEqual(container.registry, registry, '#registry points to the parent registry');
-    strictEqual(container._registry, registry, '#_registry is an alias to #registry');
-  });
-}

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -112,11 +112,6 @@ let ApplicationInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
     // in tests, or rendered to a string in the case of FastBoot.
     this.register('-application-instance:main', this, { instantiate: false });
 
-    if (!isEnabled('ember-registry-container-reform')) {
-      this.container = this.__container__;
-      this.registry = this.__registry__;
-    }
-
     this._booted = false;
   },
 
@@ -543,35 +538,33 @@ function isResolverModuleBased(applicationInstance) {
   return !!applicationInstance.application.__registry__.resolver.moduleBasedResolver;
 }
 
-if (isEnabled('ember-registry-container-reform')) {
-  Object.defineProperty(ApplicationInstance.prototype, 'container', {
-    configurable: true,
-    enumerable: false,
-    get() {
-      var instance = this;
-      return {
-        lookup() {
-          deprecate(
-            'Using `ApplicationInstance.container.lookup` is deprecated. Please use `ApplicationInstance.lookup` instead.',
-            false, {
-              id: 'ember-application.app-instance-container',
-              until: '3.0.0',
-              url: 'http://emberjs.com/deprecations/v2.x/#toc_ember-applicationinstance-container'
-            }
-          );
-          return instance.lookup(...arguments);
-        }
-      };
-    }
-  });
+Object.defineProperty(ApplicationInstance.prototype, 'container', {
+  configurable: true,
+  enumerable: false,
+  get() {
+    var instance = this;
+    return {
+      lookup() {
+        deprecate(
+          'Using `ApplicationInstance.container.lookup` is deprecated. Please use `ApplicationInstance.lookup` instead.',
+          false, {
+            id: 'ember-application.app-instance-container',
+            until: '3.0.0',
+            url: 'http://emberjs.com/deprecations/v2.x/#toc_ember-applicationinstance-container'
+          }
+        );
+        return instance.lookup(...arguments);
+      }
+    };
+  }
+});
 
-  Object.defineProperty(ApplicationInstance.prototype, 'registry', {
-    configurable: true,
-    enumerable: false,
-    get() {
-      return buildFakeRegistryWithDeprecations(this, 'ApplicationInstance');
-    }
-  });
-}
+Object.defineProperty(ApplicationInstance.prototype, 'registry', {
+  configurable: true,
+  enumerable: false,
+  get() {
+    return buildFakeRegistryWithDeprecations(this, 'ApplicationInstance');
+  }
+});
 
 export default ApplicationInstance;

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -754,15 +754,14 @@ var Application = Namespace.extend(RegistryProxy, {
     this._runInitializer('initializers', function(name, initializer) {
       assert('No application initializer named \'' + name + '\'', !!initializer);
       if (initializer.initialize.length === 2) {
-        if (isEnabled('ember-registry-container-reform')) {
-          deprecate('The `initialize` method for Application initializer \'' + name + '\' should take only one argument - `App`, an instance of an `Application`.',
-                    false,
-                    {
-                      id: 'ember-application.app-initializer-initialize-arguments',
-                      until: '3.0.0',
-                      url: 'http://emberjs.com/deprecations/v2.x/#toc_initializer-arity'
-                    });
-        }
+        deprecate('The `initialize` method for Application initializer \'' + name + '\' should take only one argument - `App`, an instance of an `Application`.',
+                  false,
+                  {
+                    id: 'ember-application.app-initializer-initialize-arguments',
+                    until: '3.0.0',
+                    url: 'http://emberjs.com/deprecations/v2.x/#toc_initializer-arity'
+                  });
+
         initializer.initialize(App.__registry__, App);
       } else {
         initializer.initialize(App);
@@ -901,15 +900,13 @@ var Application = Namespace.extend(RegistryProxy, {
   }
 });
 
-if (isEnabled('ember-registry-container-reform')) {
-  Object.defineProperty(Application.prototype, 'registry', {
-    configurable: true,
-    enumerable: false,
-    get() {
-      return buildFakeRegistryWithDeprecations(this, 'Application');
-    }
-  });
-}
+Object.defineProperty(Application.prototype, 'registry', {
+  configurable: true,
+  enumerable: false,
+  get() {
+    return buildFakeRegistryWithDeprecations(this, 'Application');
+  }
+});
 
 Application.reopenClass({
   /**

--- a/packages/ember-application/tests/system/application_instance_test.js
+++ b/packages/ember-application/tests/system/application_instance_test.js
@@ -2,7 +2,6 @@ import Application from 'ember-application/system/application';
 import ApplicationInstance from 'ember-application/system/application-instance';
 import run from 'ember-metal/run_loop';
 import jQuery from 'ember-views/system/jquery';
-import isEnabled from 'ember-metal/features';
 
 let app, appInstance;
 
@@ -37,6 +36,8 @@ QUnit.test('an application instance can be created based upon an application', f
 });
 
 QUnit.test('properties (and aliases) are correctly assigned for accessing the container and registry', function() {
+  expect(9);
+
   run(function() {
     appInstance = ApplicationInstance.create({ application: app });
   });
@@ -45,35 +46,26 @@ QUnit.test('properties (and aliases) are correctly assigned for accessing the co
   ok(appInstance.__container__, '#__container__ is accessible');
   ok(appInstance.__registry__, '#__registry__ is accessible');
 
-  if (isEnabled('ember-registry-container-reform')) {
-    expect(9);
+  ok(typeof appInstance.container.lookup === 'function', '#container.lookup is available as a function');
 
-    ok(typeof appInstance.container.lookup === 'function', '#container.lookup is available as a function');
+  // stub with a no-op to keep deprecation test simple
+  appInstance.__container__.lookup = function() {
+    ok(true, '#loookup alias is called correctly');
+  };
 
-    // stub with a no-op to keep deprecation test simple
-    appInstance.__container__.lookup = function() {
-      ok(true, '#loookup alias is called correctly');
-    };
-
-    expectDeprecation(function() {
-      appInstance.container.lookup();
-    }, /Using `ApplicationInstance.container.lookup` is deprecated. Please use `ApplicationInstance.lookup` instead./);
+  expectDeprecation(function() {
+    appInstance.container.lookup();
+  }, /Using `ApplicationInstance.container.lookup` is deprecated. Please use `ApplicationInstance.lookup` instead./);
 
 
-    ok(typeof appInstance.registry.register === 'function', '#registry.register is available as a function');
-    appInstance.__registry__.register = function() {
-      ok(true, '#register alias is called correctly');
-    };
+  ok(typeof appInstance.registry.register === 'function', '#registry.register is available as a function');
+  appInstance.__registry__.register = function() {
+    ok(true, '#register alias is called correctly');
+  };
 
-    expectDeprecation(function() {
-      appInstance.registry.register();
-    }, /Using `ApplicationInstance.registry.register` is deprecated. Please use `ApplicationInstance.register` instead./);
-  } else {
-    expect(5);
-
-    strictEqual(appInstance.container, appInstance.__container__, '#container alias should be assigned');
-    strictEqual(appInstance.registry, appInstance.__registry__, '#registry alias should be assigned');
-  }
+  expectDeprecation(function() {
+    appInstance.registry.register();
+  }, /Using `ApplicationInstance.registry.register` is deprecated. Please use `ApplicationInstance.register` instead./);
 });
 
 QUnit.test('customEvents added to the application before setupEventDispatcher', function(assert) {

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -13,7 +13,6 @@ import EmberRoute from 'ember-routing/system/route';
 import jQuery from 'ember-views/system/jquery';
 import compile from 'ember-template-compiler/system/compile';
 import { _loaded } from 'ember-runtime/system/lazy_load';
-import isEnabled from 'ember-metal/features';
 import { getDebugFunction, setDebugFunction } from 'ember-metal/debug';
 
 var trim = jQuery.trim;
@@ -100,21 +99,19 @@ QUnit.test('acts like a namespace', function() {
   equal(app.Foo.toString(), 'TestApp.Foo', 'Classes pick up their parent namespace');
 });
 
-if (isEnabled('ember-registry-container-reform')) {
-  QUnit.test('includes deprecated access to `application.registry`', function() {
-    expect(3);
+QUnit.test('includes deprecated access to `application.registry`', function() {
+  expect(3);
 
-    ok(typeof application.registry.register === 'function', '#registry.register is available as a function');
+  ok(typeof application.registry.register === 'function', '#registry.register is available as a function');
 
-    application.__registry__.register = function() {
-      ok(true, '#register alias is called correctly');
-    };
+  application.__registry__.register = function() {
+    ok(true, '#register alias is called correctly');
+  };
 
-    expectDeprecation(function() {
-      application.registry.register();
-    }, /Using `Application.registry.register` is deprecated. Please use `Application.register` instead./);
-  });
-}
+  expectDeprecation(function() {
+    application.registry.register();
+  }, /Using `Application.registry.register` is deprecated. Please use `Application.register` instead./);
+});
 
 QUnit.module('Ember.Application initialization', {
   teardown() {

--- a/packages/ember-application/tests/system/initializers_test.js
+++ b/packages/ember-application/tests/system/initializers_test.js
@@ -2,7 +2,6 @@ import Ember from 'ember-metal/core';
 import run from 'ember-metal/run_loop';
 import Application from 'ember-application/system/application';
 import jQuery from 'ember-views/system/jquery';
-import Registry from 'container/registry';
 import isEnabled from 'ember-metal/features';
 
 var app;
@@ -70,44 +69,23 @@ if (isEnabled('ember-application-visit')) {
   });
 }
 
-if (isEnabled('ember-registry-container-reform')) {
-  QUnit.test('initializers are passed an App', function() {
-    var MyApplication = Application.extend();
+QUnit.test('initializers are passed an App', function() {
+  var MyApplication = Application.extend();
 
-    MyApplication.initializer({
-      name: 'initializer',
-      initialize(App) {
-        ok(App instanceof Application, 'initialize is passed an Application');
-      }
-    });
+  MyApplication.initializer({
+    name: 'initializer',
+    initialize(App) {
+      ok(App instanceof Application, 'initialize is passed an Application');
+    }
+  });
 
-    run(function() {
-      app = MyApplication.create({
-        router: false,
-        rootElement: '#qunit-fixture'
-      });
+  run(function() {
+    app = MyApplication.create({
+      router: false,
+      rootElement: '#qunit-fixture'
     });
   });
-} else {
-  QUnit.test('initializers are passed a registry and App', function() {
-    var MyApplication = Application.extend();
-
-    MyApplication.initializer({
-      name: 'initializer',
-      initialize(registry, App) {
-        ok(registry instanceof Registry, 'initialize is passed a registry');
-        ok(App instanceof Application, 'initialize is passed an Application');
-      }
-    });
-
-    run(function() {
-      app = MyApplication.create({
-        router: false,
-        rootElement: '#qunit-fixture'
-      });
-    });
-  });
-}
+});
 
 QUnit.test('initializers can be registered in a specified order', function() {
   var order = [];
@@ -409,25 +387,23 @@ QUnit.test('initializers should be executed in their own context', function() {
   });
 });
 
-if (isEnabled('ember-registry-container-reform')) {
-  QUnit.test('initializers should throw a deprecation warning when receiving a second argument', function() {
-    expect(1);
+QUnit.test('initializers should throw a deprecation warning when receiving a second argument', function() {
+  expect(1);
 
-    var MyApplication = Application.extend();
+  var MyApplication = Application.extend();
 
-    MyApplication.initializer({
-      name: 'deprecated',
-      initialize(registry, application) {
-      }
-    });
-
-    expectDeprecation(function() {
-      run(function() {
-        app = MyApplication.create({
-          router: false,
-          rootElement: '#qunit-fixture'
-        });
-      });
-    }, /The `initialize` method for Application initializer 'deprecated' should take only one argument - `App`, an instance of an `Application`./);
+  MyApplication.initializer({
+    name: 'deprecated',
+    initialize(registry, application) {
+    }
   });
-}
+
+  expectDeprecation(function() {
+    run(function() {
+      app = MyApplication.create({
+        router: false,
+        rootElement: '#qunit-fixture'
+      });
+    });
+  }, /The `initialize` method for Application initializer 'deprecated' should take only one argument - `App`, an instance of an `Application`./);
+});

--- a/packages/ember-application/tests/system/reset_test.js
+++ b/packages/ember-application/tests/system/reset_test.js
@@ -8,7 +8,6 @@ import View from 'ember-views/views/view';
 import Controller from 'ember-runtime/controllers/controller';
 import jQuery from 'ember-views/system/jquery';
 import Registry from 'container/registry';
-import isEnabled from 'ember-metal/features';
 
 var application, Application;
 
@@ -241,27 +240,15 @@ QUnit.test('With ember-data like initializer and constant', function() {
     })
   };
 
-  if (isEnabled('ember-registry-container-reform')) {
-    Application.initializer({
-      name: 'store',
-      initialize(application) {
-        application.unregister('store:main');
-        application.register('store:main', application.Store);
+  Application.initializer({
+    name: 'store',
+    initialize(application) {
+      application.unregister('store:main');
+      application.register('store:main', application.Store);
 
-        application.__container__.lookup('store:main');
-      }
-    });
-  } else {
-    Application.initializer({
-      name: 'store',
-      initialize(registry, application) {
-        registry.unregister('store:main');
-        registry.register('store:main', application.Store);
-
-        application.__container__.lookup('store:main');
-      }
-    });
-  }
+      application.__container__.lookup('store:main');
+    }
+  });
 
   run(function() {
     application = Application.create();

--- a/packages/ember-application/tests/system/visit_test.js
+++ b/packages/ember-application/tests/system/visit_test.js
@@ -366,11 +366,7 @@ if (isEnabled('ember-application-visit')) {
       assert.strictEqual(View.views['my-cool-app'], undefined, 'view was not registered globally');
 
       function lookup(fullName) {
-        if (isEnabled('ember-registry-container-reform')) {
-          return instance.lookup(fullName);
-        } else {
-          return instance.container.lookup(fullName);
-        }
+        return instance.lookup(fullName);
       }
 
       assert.ok(lookup('-view-registry:main')['my-cool-app'] instanceof View, 'view was registered on the instance\'s view registry');
@@ -680,11 +676,7 @@ if (isEnabled('ember-application-visit')) {
     assert.strictEqual(jQuery('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
 
     function lookup(instance, fullName) {
-      if (isEnabled('ember-registry-container-reform')) {
-        return instance.lookup(fullName);
-      } else {
-        return instance.container.lookup(fullName);
-      }
+      return instance.lookup(fullName);
     }
 
     let a = run(App, 'visit', '/a', { isBrowser: false, shouldRender: false }).then(instance => {

--- a/packages/ember/tests/application_lifecycle_test.js
+++ b/packages/ember/tests/application_lifecycle_test.js
@@ -1,7 +1,6 @@
 import Ember from 'ember-metal/core';
 import Application from 'ember-application/system/application';
 import Route from 'ember-routing/system/route';
-import isEnabled from 'ember-metal/features';
 import run from 'ember-metal/run_loop';
 import Component from 'ember-views/components/component';
 import jQuery from 'ember-views/system/jquery';
@@ -133,25 +132,14 @@ QUnit.test('initializers can augment an applications customEvents hash', functio
 
   var ApplicationSubclass = Application.extend();
 
-  if (isEnabled('ember-registry-container-reform')) {
-    ApplicationSubclass.initializer({
-      name: 'customize-things',
-      initialize(application) {
-        application.customEvents = {
-          wowza: 'wowza'
-        };
-      }
-    });
-  } else {
-    ApplicationSubclass.initializer({
-      name: 'customize-things',
-      initialize(registry, application) {
-        application.customEvents = {
-          wowza: 'wowza'
-        };
-      }
-    });
-  }
+  ApplicationSubclass.initializer({
+    name: 'customize-things',
+    initialize(application) {
+      application.customEvents = {
+        wowza: 'wowza'
+      };
+    }
+  });
 
   setupApp(ApplicationSubclass);
 


### PR DESCRIPTION
This flag is no longer needed now that this feature is out of beta.
