### PR TITLE
[BUGFIX Beta] Move warn api doc to a place where it gets picked up by the build

### DIFF
--- a/packages/ember-debug/lib/deprecate.js
+++ b/packages/ember-debug/lib/deprecate.js
@@ -79,6 +79,11 @@ export let missingOptionsIdDeprecation = 'When calling `Ember.deprecate` you mus
 export let missingOptionsUntilDeprecation = 'When calling `Ember.deprecate` you must provide `until` in options.';
 
 /**
+@module ember
+@submodule ember-debug
+*/
+
+/**
   Display a deprecation warning with the provided message and a stack trace
   (Chrome and Firefox only). Ember build tools will remove any calls to
   `Ember.deprecate()` when doing a production build.
@@ -92,6 +97,7 @@ export let missingOptionsUntilDeprecation = 'When calling `Ember.deprecate` you 
     `id` for this deprecation. The `id` can be used by Ember debugging tools
     to change the behavior (raise, log or silence) for that specific deprecation.
     The `id` should be namespaced by dots, e.g. "view.helper.select".
+  @for Ember
   @public
 */
 export default function deprecate(message, test, options) {

--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -160,7 +160,9 @@ setDebugFunction('debugSeal', function debugSeal(obj) {
 });
 
 setDebugFunction('deprecate', _deprecate);
+
 setDebugFunction('warn', _warn);
+
 /**
   Will call `Ember.warn()` if ENABLE_ALL_FEATURES, ENABLE_OPTIONAL_FEATURES, or
   any specific FEATURES flag is truthy.

--- a/packages/ember-debug/lib/warn.js
+++ b/packages/ember-debug/lib/warn.js
@@ -19,6 +19,11 @@ export let missingOptionsDeprecation = 'When calling `Ember.warn` you ' +
 export let missingOptionsIdDeprecation = 'When calling `Ember.warn` you must provide `id` in options.';
 
 /**
+@module ember
+@submodule ember-debug
+*/
+
+/**
   Display a warning with the provided message. Ember build tools will
   remove any calls to `Ember.warn()` when doing a production build.
 
@@ -26,6 +31,11 @@ export let missingOptionsIdDeprecation = 'When calling `Ember.warn` you must pro
   @param {String} message A warning to display.
   @param {Boolean} test An optional boolean. If falsy, the warning
     will be displayed.
+  @param {Object} options An ojbect that can be used to pass a unique
+    `id` for this warning.  The `id` can be used by Ember debugging tools
+    to change the behavior (raise, log, or silence) for that specific warning.
+    The `id` should be namespaced by dots, e.g. "ember-debug.feature-flag-with-features-stripped"
+  @for Ember
   @public
 */
 export default function warn(message, test, options) {


### PR DESCRIPTION
Fix for Issue https://github.com/emberjs/ember.js/issues/12442

Moving the doc to main.js did the trick, though I'm open to other ways of getting this working.

I also added doc on the new options param, which was previously absent.
