### PR TITLE
[PERF] Bail on get if type does not have accessors

### DIFF
--- a/packages/ember-metal/lib/streams/key-stream.js
+++ b/packages/ember-metal/lib/streams/key-stream.js
@@ -24,10 +24,18 @@ let KeyStream = BasicStream.extend({
   },
 
   compute() {
-    var object = this.sourceDep.getValue();
-    if (object) {
+    let object = this.sourceDep.getValue();
+    let type = typeof object;
+
+    if (!object || type === 'boolean') {
+      return;
+    }
+
+    if (type === 'object') {
       return get(object, this.key);
     }
+
+    return object[this.key];
   },
 
   setValue(value) {


### PR DESCRIPTION
When compute is called it is expected that object is an actual Object,
sometimes the object is a Bool and yet we continue down the stack look
values up on it even though the result will be undefined. This change
bails out early if `object` is a Bool.

Before:
<img width="599" alt="screen shot 2015-10-06 at 11 38 32 am" src="https://cloud.githubusercontent.com/assets/183799/10318677/6e0f35bc-6c1f-11e5-9f4f-c6e55095ba3e.png">

After:
<img width="634" alt="screen shot 2015-10-06 at 11 59 07 am" src="https://cloud.githubusercontent.com/assets/183799/10319167/b354bc1c-6c21-11e5-86e0-7cec64e91b80.png">
