### PR TITLE
[BUGFIX release] Avoid `this.attrs.params` in LinkComponent.

### DIFF
--- a/packages/ember-routing-views/lib/components/link-to.js
+++ b/packages/ember-routing-views/lib/components/link-to.js
@@ -656,7 +656,7 @@ let LinkComponent = EmberComponent.extend({
   queryParams: null,
 
   qualifiedRouteName: computed('targetRouteName', '_routing.currentState', function computeLinkToComponentQualifiedRouteName() {
-    let params = this.attrs.params.slice();
+    let params = get(this, 'params').slice();
     let lastParam = params[params.length - 1];
     if (lastParam && lastParam.isQueryParams) {
       params.pop();
@@ -741,7 +741,7 @@ let LinkComponent = EmberComponent.extend({
     let attrs = this.attrs;
 
     // Do not mutate params in place
-    let params = attrs.params.slice();
+    let params = get(this, 'params').slice();
 
     assert('You must provide one or more parameters to the link-to component.', params.length);
 

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1523,3 +1523,52 @@ QUnit.test('Block-less {{link-to}} with only query-params updates when route cha
   });
   equal(jQuery('#the-link').attr('href'), '/about?bar=NAW&foo=456', 'link has right href');
 });
+
+QUnit.test('The {{link-to}} helper can use dynamic params', function() {
+  Router.map(function(match) {
+    this.route('foo', { path: 'foo/:some/:thing' });
+    this.route('bar', { path: 'bar/:some/:thing/:else' });
+  });
+
+  let controller;
+  App.IndexController = Controller.extend({
+    init() {
+      this._super(...arguments);
+
+      controller = this;
+
+      this.dynamicLinkParams = [
+        'foo',
+        'one',
+        'two'
+      ];
+    }
+  });
+
+  Ember.TEMPLATES.index = compile(`
+    <h3>Home</h3>
+
+    {{#link-to params=dynamicLinkParams id="dynamic-link"}}Dynamic{{/link-to}}
+  `);
+
+  bootApplication();
+
+  run(function() {
+    router.handleURL('/');
+  });
+
+  let link = jQuery('#dynamic-link', '#qunit-fixture');
+
+  equal(link.attr('href'), '/foo/one/two');
+
+  run(function() {
+    controller.set('dynamicLinkParams', [
+      'bar',
+      'one',
+      'two',
+      'three'
+    ]);
+  });
+
+  equal(link.attr('href'), '/bar/one/two/three');
+});


### PR DESCRIPTION
Due to the nature of `positionalParams`, it is trivial to supply `params` as a hash argument to `{{link-to}}` instead of ordered args (this allows truly dynamic link's). However, if `{{link-to params=foo}}` is used `params` will be a `MutableCell` and the current code throws an error in that circumstance.

_tldr;_ `this.attrs` should be avoided. It is quite a :trollface: in non-`GlimmerComponent`'s.
