### PR TITLE
[BUGFIX beta] Allow usage of bound properties in {{link-to}}.

### DIFF
--- a/packages/ember-routing-views/lib/components/link-to.js
+++ b/packages/ember-routing-views/lib/components/link-to.js
@@ -623,14 +623,16 @@ let LinkComponent = EmberComponent.extend({
   _invoke(event) {
     if (!isSimpleClick(event)) { return true; }
 
-    if (this.attrs.preventDefault !== false) {
-      let targetAttribute = this.attrs.target;
+    let preventDefault = get(this, 'preventDefault');
+    let targetAttribute = get(this, 'target');
+
+    if (preventDefault !== false) {
       if (!targetAttribute || targetAttribute === '_self') {
         event.preventDefault();
       }
     }
 
-    if (this.attrs.bubbles === false) { event.stopPropagation(); }
+    if (get(this, 'bubbles') === false) { event.stopPropagation(); }
 
     if (get(this, '_isDisabled')) { return false; }
 
@@ -639,8 +641,7 @@ let LinkComponent = EmberComponent.extend({
       return false;
     }
 
-    let targetAttribute2 = this.attrs.target;
-    if (targetAttribute2 && targetAttribute2 !== '_self') {
+    if (targetAttribute && targetAttribute !== '_self') {
       return false;
     }
 
@@ -648,7 +649,7 @@ let LinkComponent = EmberComponent.extend({
     let qualifiedRouteName = get(this, 'qualifiedRouteName');
     let models = get(this, 'models');
     let queryParamValues = get(this, 'queryParams.values');
-    let shouldReplace = get(this, 'attrs.replace');
+    let shouldReplace = get(this, 'replace');
 
     routing.transitionTo(qualifiedRouteName, models, queryParamValues, shouldReplace);
   },
@@ -738,15 +739,14 @@ let LinkComponent = EmberComponent.extend({
   willRender() {
     let queryParams;
 
-    let attrs = this.attrs;
-
     // Do not mutate params in place
     let params = get(this, 'params').slice();
 
     assert('You must provide one or more parameters to the link-to component.', params.length);
 
-    if (attrs.disabledWhen) {
-      this.set('disabled', attrs.disabledWhen);
+    let disabledWhen = get(this, 'disabledWhen');
+    if (disabledWhen) {
+      this.set('disabled', disabledWhen);
     }
 
     // Process the positional arguments, in order.

--- a/packages/ember-routing-views/lib/components/link-to.js
+++ b/packages/ember-routing-views/lib/components/link-to.js
@@ -656,7 +656,7 @@ let LinkComponent = EmberComponent.extend({
   queryParams: null,
 
   qualifiedRouteName: computed('targetRouteName', '_routing.currentState', function computeLinkToComponentQualifiedRouteName() {
-    let params = this.attrs.params.slice();
+    let params = get(this, 'params').slice();
     let lastParam = params[params.length - 1];
     if (lastParam && lastParam.isQueryParams) {
       params.pop();
@@ -741,7 +741,7 @@ let LinkComponent = EmberComponent.extend({
     let attrs = this.attrs;
 
     // Do not mutate params in place
-    let params = attrs.params.slice();
+    let params = get(this, 'params').slice();
 
     assert('You must provide one or more parameters to the link-to component.', params.length);
 

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1523,3 +1523,52 @@ QUnit.test('Block-less {{link-to}} with only query-params updates when route cha
   });
   equal(jQuery('#the-link').attr('href'), '/about?bar=NAW&foo=456', 'link has right href');
 });
+
+QUnit.test('The {{link-to}} helper can use dynamic params', function() {
+  Router.map(function(match) {
+    this.route('foo', { path: 'foo/:some/:thing' });
+    this.route('bar', { path: 'bar/:some/:thing/:else' });
+  });
+
+  let controller;
+  App.IndexController = Controller.extend({
+    init() {
+      this._super(...arguments);
+
+      controller = this;
+
+      this.dynamicLinkParams = [
+        'foo',
+        'one',
+        'two'
+      ];
+    }
+  });
+
+  Ember.TEMPLATES.index = compile(`
+    <h3>Home</h3>
+
+    {{#link-to params=dynamicLinkParams id="dynamic-link"}}Dynamic{{/link-to}}
+  `);
+
+  bootApplication();
+
+  run(function() {
+    router.handleURL('/');
+  });
+
+  let link = jQuery('#dynamic-link', '#qunit-fixture');
+
+  equal(link.attr('href'), '/foo/one/two');
+
+  run(function() {
+    controller.set('dynamicLinkParams', [
+      'bar',
+      'one',
+      'two',
+      'three'
+    ]);
+  });
+
+  equal(link.attr('href'), '/bar/one/two/three');
+});


### PR DESCRIPTION
Due to values in `this.attrs` being either a `MutableCell` or the actual value, many flags in `link-to` would not function properly when provided a
bound property. This PR fixes that by using the standard public API for accessing a components provided attributes (`this.get('attributeName')`).

_tldr;_ `this.attrs` should be avoided. It is quite a :trollface: in non-`GlimmerComponent`'s.

Note: This builds on top of #12454, but due to this being a larger set of changes I preferred to make this a separate PR that is targetted to 2.2 beta.
