### PR TITLE
[BUGFIX release] `Ember.String.htmlSafe()` should return a instance of SafeString for `null` / `undefined`

### DIFF
--- a/packages/ember-htmlbars/lib/utils/string.js
+++ b/packages/ember-htmlbars/lib/utils/string.js
@@ -24,10 +24,8 @@ import { SafeString, escapeExpression } from 'htmlbars-util';
 */
 function htmlSafe(str) {
   if (str === null || str === undefined) {
-    return '';
-  }
-
-  if (typeof str !== 'string') {
+    str = '';
+  } else if (typeof str !== 'string') {
     str = '' + str;
   }
   return new SafeString(str);

--- a/packages/ember-htmlbars/tests/utils/string_test.js
+++ b/packages/ember-htmlbars/tests/utils/string_test.js
@@ -6,13 +6,19 @@ QUnit.module('ember-htmlbars: SafeString');
 QUnit.test('htmlSafe should return an instance of SafeString', function() {
   var safeString = htmlSafe('you need to be more <b>bold</b>');
 
-  ok(safeString instanceof SafeString, 'should return SafeString');
+  ok(safeString instanceof SafeString, 'should be a SafeString');
 });
 
 QUnit.test('htmlSafe should return an empty string for null', function() {
-  equal(htmlSafe(null).toString(), '', 'should return an empty string');
+  var safeString = htmlSafe(null);
+
+  equal(safeString instanceof SafeString, true, 'should be a SafeString');
+  equal(safeString.toString(), '', 'should return an empty string');
 });
 
 QUnit.test('htmlSafe should return an empty string for undefined', function() {
-  equal(htmlSafe().toString(), '', 'should return an empty string');
+  var safeString = htmlSafe();
+
+  equal(safeString instanceof SafeString, true, 'should be a SafeString');
+  equal(safeString.toString(), '', 'should return an empty string');
 });


### PR DESCRIPTION
Currently, `Ember.String.htmlSafe()` returns a just String, not HTML Safe.
We expect it is a safe string.

I think this behavior has no problem in the most of case, but it shows warning when it is bound to `style` property.

---

For example:

``` js
App = Ember.Application.create();

App.Router.map(function() {
});

App.IndexController = Ember.Controller.extend({
  style: Ember.computed(function() {
    return Ember.String.htmlSafe(
      /* Some property will be given, but it may be `null` or `undefined`. */
    );
  })
});
```

``` hbs
{{! index.hbs}}
<span style={{style}}>Hi, Tomster!</span>
```

http://emberjs.jsbin.com/ficesumeju/2

The above code shows the following warning:

```
WARNING: Binding style attributes may introduce cross-site scripting vulnerabilities; please ensure that values being bound are properly escaped. For more information, including how to disable this warning, see http://emberjs.com/deprecations/v1.x/#toc_binding-style-attributes.
```
