### PR TITLE
[BUGFIX Release-1-13] Added deprecation for Ember.SortableMixin.

### DIFF
--- a/packages/ember-htmlbars/tests/integration/select_in_template_test.js
+++ b/packages/ember-htmlbars/tests/integration/select_in_template_test.js
@@ -27,6 +27,7 @@ QUnit.module("ember-htmlbars: Ember.Select - usage inside templates", {
 
 QUnit.test("works from a template with bindings [DEPRECATED]", function() {
   expectDeprecation(arrayControllerDeprecation);
+  expectDeprecation(/Ember.SortableMixin/);
   var Person = EmberObject.extend({
     id: null,
     firstName: null,

--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -122,6 +122,11 @@ export default Mixin.create(MutableEnumerable, {
   */
   sortFunction: compare,
 
+  init() {
+    this._super(...arguments);
+    Ember.deprecate(`Ember.SortableMixin is deprecated and was used in ${this}. Please use Ember.computed.sort instead.`, this.isGenerated);
+  },
+
   orderBy(item1, item2) {
     var result = 0;
     var sortProperties = get(this, 'sortProperties');

--- a/packages/ember-runtime/tests/mixins/sortable_test.js
+++ b/packages/ember-runtime/tests/mixins/sortable_test.js
@@ -15,6 +15,8 @@ QUnit.module("Ember.Sortable");
 QUnit.module("Ember.Sortable with content", {
   setup() {
     run(function() {
+      expectDeprecation(/Ember.SortableMixin/);
+
       var array = [{ id: 1, name: "Scumbag Dale" }, { id: 2, name: "Scumbag Katz" }, { id: 3, name: "Scumbag Bryn" }];
 
       unsortedArray = Ember.A(Ember.A(array).copy());

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -6,6 +6,7 @@ import ActionManager from "ember-views/system/action_manager";
 import EmberView from "ember-views/views/view";
 import { arrayControllerDeprecation } from "ember-runtime/controllers/array_controller";
 
+
 import EmberHandlebars from "ember-htmlbars/compat";
 
 var compile = EmberHandlebars.compile;
@@ -628,6 +629,7 @@ QUnit.test("The Homepage with a `setupController` hook modifying other controlle
 
 QUnit.test("The Homepage with a computed context that does not get overridden", function() {
   expectDeprecation(arrayControllerDeprecation);
+  expectDeprecation(/Ember.SortableMixin/);
 
   Router.map(function() {
     this.route("home", { path: "/" });


### PR DESCRIPTION
Addresses #12470. If this is good, I'll add a docs PR to the website. 
