### PR TITLE
Document Ember.PromiseProxyMixin#content as public property

### DIFF
--- a/packages/ember-runtime/lib/mixins/promise_proxy.js
+++ b/packages/ember-runtime/lib/mixins/promise_proxy.js
@@ -100,6 +100,16 @@ export default Mixin.create({
   reason:  null,
 
   /**
+    If the proxied promise is resolved, this will contain the resolved
+    result.
+
+    @property content
+    @default null
+    @public
+  */
+  content:  null,
+
+  /**
     Once the proxied promise has settled this will become `false`.
 
     @property isPending


### PR DESCRIPTION
`Ember.PromiseProxyMixin#reason` is a public property. I think it make sense to make `Ember.PromiseProxyMixin#content` public as well.
