### PR TITLE
Access property only once during `Ember.get`

### DIFF
--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -61,8 +61,8 @@ export function get(obj, keyName) {
   }
 
   var meta = peekMeta(obj);
-  var possibleDesc = obj[keyName];
-  var desc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
+  var value = obj[keyName];
+  var desc = (value !== null && typeof value === 'object' && value.isDescriptor) ? value : undefined;
   var ret;
 
   if (desc === undefined && isPath(keyName)) {
@@ -76,10 +76,10 @@ export function get(obj, keyName) {
       if (meta && meta.peekWatching(keyName) > 0) {
         ret = meta.peekValues(keyName);
       } else {
-        ret = obj[keyName];
+        ret = value;
       }
     } else {
-      ret = obj[keyName];
+      ret = value;
     }
 
     if (ret === undefined &&

--- a/packages/ember-metal/tests/accessors/get_test.js
+++ b/packages/ember-metal/tests/accessors/get_test.js
@@ -28,6 +28,17 @@ QUnit.test('should get arbitrary properties on an object', function() {
   }
 });
 
+QUnit.test('should not access a property more than once', function() {
+  var count = 0;
+  var obj = {
+    get id() { return ++count; }
+  };
+
+  get(obj, 'id');
+
+  equal(count, 1);
+});
+
 testBoth('should call unknownProperty on watched values if the value is undefined', function(get, set) {
   var obj = {
     count: 0,


### PR DESCRIPTION
Inside of `Ember.get`, there are cases where the property on an object will get accessed more than once for a single call. In most cases this isn't a problem, but if the object has a getter defined on it then we wind up doing extra work and incurring a performance hit.
