### PR TITLE
update deprecation messages in scheduleRevalidate to mention accurate version

### DIFF
--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -676,13 +676,13 @@ export default Mixin.create({
     if (node && !this._dispatching && this.env.renderedNodes.has(node)) {
       if (manualRerender) {
         deprecate(
-          `You manually rerendered ${label} (a parent component) from a child component during the rendering process. This rarely worked in Ember 1.x and will be removed in Ember 2.0`,
+          `You manually rerendered ${label} (a parent component) from a child component during the rendering process. This rarely worked in Ember 1.x and will be removed in Ember 3.0`,
           false,
           { id: 'ember-views.manual-parent-rerender', until: '3.0.0' }
         );
       } else {
         deprecate(
-          `You modified ${label} twice in a single render. This was unreliable in Ember 1.x and will be removed in Ember 2.0`,
+          `You modified ${label} twice in a single render. This was unreliable in Ember 1.x and will be removed in Ember 3.0`,
           false,
           { id: 'ember-views.render-double-modify', until: '3.0.0' }
         );


### PR DESCRIPTION
currently the message says this will be removed in Ember 2.0 but the until key has 3.0.0 underneath it
