### PR TITLE
[BUGFIX beta] allow watching of ES5+ Getter

### DIFF
--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -26,9 +26,12 @@ export function Descriptor() {
 //
 
 export function MANDATORY_SETTER_FUNCTION(name) {
-  return function SETTER_FUNCTION(value) {
+  function SETTER_FUNCTION(value) {
     assert(`You must use Ember.set() to set the \`${name}\` property (of ${this}) to \`${value}\`.`, false);
-  };
+  }
+
+  SETTER_FUNCTION.isMandatorySetter = true;
+  return SETTER_FUNCTION;
 }
 
 export function DEFAULT_GETTER_FUNCTION(name) {

--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -4,16 +4,12 @@
 
 import Ember from 'ember-metal/core';
 import { assert } from 'ember-metal/debug';
-import isEnabled from 'ember-metal/features';
 import EmberError from 'ember-metal/error';
 import {
   isGlobal as detectIsGlobal,
   isPath,
   hasThis as pathHasThis
 } from 'ember-metal/path_cache';
-import {
-  peekMeta
-} from 'ember-metal/meta';
 
 var FIRST_KEY = /^([^\.]+)/;
 
@@ -60,7 +56,6 @@ export function get(obj, keyName) {
     return obj;
   }
 
-  var meta = peekMeta(obj);
   var value = obj[keyName];
   var desc = (value !== null && typeof value === 'object' && value.isDescriptor) ? value : undefined;
   var ret;
@@ -72,15 +67,7 @@ export function get(obj, keyName) {
   if (desc) {
     return desc.get(obj, keyName);
   } else {
-    if (isEnabled('mandatory-setter')) {
-      if (meta && meta.peekWatching(keyName) > 0) {
-        ret = meta.peekValues(keyName);
-      } else {
-        ret = value;
-      }
-    } else {
-      ret = value;
-    }
+    ret = value;
 
     if (ret === undefined &&
         'object' === typeof obj && !(keyName in obj) && 'function' === typeof obj.unknownProperty) {

--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -73,11 +73,7 @@ export function set(obj, keyName, value, tolerant) {
       obj.setUnknownProperty(keyName, value);
     } else if (meta && meta.peekWatching(keyName) > 0) {
       if (meta.proto !== obj) {
-        if (isEnabled('mandatory-setter')) {
-          currentValue = meta.peekValues(keyName);
-        } else {
-          currentValue = obj[keyName];
-        }
+        currentValue = obj[keyName];
       }
       // only trigger a change if the value has changed
       if (value !== currentValue) {

--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -16,6 +16,10 @@ import {
   peekMeta
 } from 'ember-metal/meta';
 
+import {
+  lookupDescriptor
+} from 'ember-metal/utils';
+
 /**
   Sets the value of a property on an object, respecting computed properties
   and notifying observers and other listeners of the change. If the
@@ -78,14 +82,20 @@ export function set(obj, keyName, value, tolerant) {
       // only trigger a change if the value has changed
       if (value !== currentValue) {
         propertyWillChange(obj, keyName);
+
         if (isEnabled('mandatory-setter')) {
-          if (
-            (currentValue === undefined && !(keyName in obj)) ||
+          if ((currentValue === undefined && !(keyName in obj)) ||
             !Object.prototype.propertyIsEnumerable.call(obj, keyName)
           ) {
             defineProperty(obj, keyName, null, value); // setup mandatory setter
           } else {
-            meta.writeValues(keyName, value);
+            let descriptor = lookupDescriptor(obj, keyName);
+            let isMandatorySetter = descriptor && descriptor.set && descriptor.set.isMandatorySetter;
+            if (isMandatorySetter) {
+              meta.writeValues(keyName, value);
+            } else {
+              obj[keyName] = value;
+            }
           }
         } else {
           obj[keyName] = value;

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -504,8 +504,25 @@ export function applyStr(t, m, a) {
   }
 }
 
+export function lookupDescriptor(obj, keyName) {
+  let current = obj;
+  while (current) {
+    let descriptor = Object.getOwnPropertyDescriptor(current, keyName);
+
+    if (descriptor) {
+      return descriptor;
+    }
+
+    current = Object.getPrototypeOf(current);
+  }
+
+  return null;
+}
+
 export {
   GUID_KEY,
   makeArray,
   canInvoke
 };
+
+

--- a/packages/ember-metal/lib/watch_key.js
+++ b/packages/ember-metal/lib/watch_key.js
@@ -107,21 +107,24 @@ export function unwatchKey(obj, keyName, meta) {
       // that occurs, and attempt to provide more helpful feedback. The alternative
       // is tricky to debug partially observable properties.
       if (!desc && keyName in obj) {
-        Object.defineProperty(obj, keyName, {
-          configurable: true,
-          enumerable: Object.prototype.propertyIsEnumerable.call(obj, keyName),
-          set(val) {
-            // redefine to set as enumerable
-            Object.defineProperty(obj, keyName, {
-              configurable: true,
-              writable: true,
-              enumerable: true,
-              value: val
-            });
-            m.deleteFromValues(keyName);
-          },
-          get: DEFAULT_GETTER_FUNCTION(keyName)
-        });
+        var maybeMandatoryDescriptor = lookupDescriptor(obj, keyName);
+        if (maybeMandatoryDescriptor.set && maybeMandatoryDescriptor.set.isMandatorySetter) {
+          Object.defineProperty(obj, keyName, {
+            configurable: true,
+            enumerable: Object.prototype.propertyIsEnumerable.call(obj, keyName),
+            set(val) {
+              // redefine to set as enumerable
+              Object.defineProperty(obj, keyName, {
+                configurable: true,
+                writable: true,
+                enumerable: true,
+                value: val
+              });
+              m.deleteFromValues(keyName);
+            },
+            get: DEFAULT_GETTER_FUNCTION(keyName)
+          });
+        }
       }
     }
   } else if (count > 1) {

--- a/packages/ember-metal/lib/watch_key.js
+++ b/packages/ember-metal/lib/watch_key.js
@@ -6,8 +6,9 @@ import {
   MANDATORY_SETTER_FUNCTION,
   DEFAULT_GETTER_FUNCTION
 } from 'ember-metal/properties';
+import { lookupDescriptor } from 'ember-metal/utils';
 
-let handleMandatorySetter, lookupDescriptor;
+let handleMandatorySetter;
 
 export function watchKey(obj, keyName, meta) {
   // can't watch length on Array - it is special...
@@ -37,29 +38,6 @@ export function watchKey(obj, keyName, meta) {
 
 
 if (isEnabled('mandatory-setter')) {
-  // It is true, the following code looks quite WAT. But have no fear, It
-  // exists purely to improve development ergonomics and is removed from
-  // ember.min.js and ember.prod.js builds.
-  //
-  // Some further context: Once a property is watched by ember, bypassing `set`
-  // for mutation, will bypass observation. This code exists to assert when
-  // that occurs, and attempt to provide more helpful feedback. The alternative
-  // is tricky to debug partially observable properties.
-  lookupDescriptor = function lookupDescriptor(obj, keyName) {
-    let current = obj;
-    while (current) {
-      let descriptor = Object.getOwnPropertyDescriptor(current, keyName);
-
-      if (descriptor) {
-        return descriptor;
-      }
-
-      current = Object.getPrototypeOf(current);
-    }
-
-    return null;
-  };
-
   handleMandatorySetter = function handleMandatorySetter(m, obj, keyName) {
     let descriptor = lookupDescriptor(obj, keyName);
     var configurable = descriptor ? descriptor.configurable : true;

--- a/packages/ember-metal/tests/accessors/mandatory_setters_test.js
+++ b/packages/ember-metal/tests/accessors/mandatory_setters_test.js
@@ -1,7 +1,7 @@
 import isEnabled from 'ember-metal/features';
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
-import { watch } from 'ember-metal/watching';
+import { watch, unwatch } from 'ember-metal/watching';
 import { meta as metaFor } from 'ember-metal/meta';
 
 QUnit.module('mandatory-setters');
@@ -48,6 +48,27 @@ if (isEnabled('mandatory-setter')) {
     ok(!hasMandatorySetter(obj, 'd'), 'mandatory-setter should not be installed');
     ok(!hasMandatorySetter(obj, 'e'), 'mandatory-setter should not be installed');
     ok(!hasMandatorySetter(obj, 'f'), 'mandatory-setter should not be installed');
+  });
+
+  QUnit.test('should not teardown non mandatory-setter descriptor', function() {
+    expect(1);
+
+    var obj = { get a() { return 'hi'; } };
+
+    watch(obj, 'a');
+    unwatch(obj, 'a');
+
+    equal(obj.a, 'hi');
+  });
+
+  QUnit.test('should not confuse non descriptor watched gets', function() {
+    expect(2);
+
+    var obj = { get a() { return 'hi'; } };
+
+    watch(obj, 'a');
+    equal(get(obj, 'a'), 'hi');
+    equal(obj.a, 'hi');
   });
 
   QUnit.test('should not setup mandatory-setter if setter is already setup on property', function() {

--- a/packages/ember-metal/tests/accessors/mandatory_setters_test.js
+++ b/packages/ember-metal/tests/accessors/mandatory_setters_test.js
@@ -92,6 +92,21 @@ if (isEnabled('mandatory-setter')) {
     obj.someProp = 'foo-bar';
   });
 
+  QUnit.test('watched ES5 setter should not be smashed by mandatory setter', function() {
+    let value;
+    let obj = {
+      get foo() { },
+      set foo(_value) {
+        value = _value;
+      }
+    };
+
+    watch(obj, 'foo');
+
+    set(obj, 'foo', 2);
+    equal(value, 2);
+  });
+
   QUnit.test('should not setup mandatory-setter if setter is already setup on property in parent prototype', function() {
     expect(2);
 

--- a/packages/ember-metal/tests/keys_test.js
+++ b/packages/ember-metal/tests/keys_test.js
@@ -162,6 +162,7 @@ QUnit.test('observer switched on and off and then setter', function () {
   addObserver(beer, 'type', K);
   removeObserver(beer, 'type', K);
 
+  deepEqual(Object.keys(beer), [], 'addObserver -> removeObserver');
   set(beer, 'type', 'ale');
 
   deepEqual(Object.keys(beer), ['type'], 'addObserver -> removeObserver -> set');

--- a/packages/ember-metal/tests/keys_test.js
+++ b/packages/ember-metal/tests/keys_test.js
@@ -1,0 +1,168 @@
+import { set } from 'ember-metal/property_set';
+import {
+  addObserver,
+  removeObserver
+} from 'ember-metal/observer';
+
+function K() { return this; }
+
+QUnit.module('Fetch Keys ');
+
+QUnit.test('should get a key array for a specified object', function() {
+  var object1 = {};
+
+  object1.names = 'Rahul';
+  object1.age = '23';
+  object1.place = 'Mangalore';
+
+  var object2 = Object.keys(object1);
+
+  deepEqual(object2, ['names', 'age', 'place']);
+});
+
+// This test is for IE8.
+QUnit.test('should get a key array for property that is named the same as prototype property', function() {
+  var object1 = {
+    toString() {}
+  };
+
+  var object2 = Object.keys(object1);
+
+  deepEqual(object2, ['toString']);
+});
+
+QUnit.test('should not contain properties declared in the prototype', function () {
+  function Beer() { }
+  Beer.prototype.type = 'ipa';
+
+  var beer = new Beer();
+
+  deepEqual(Object.keys(beer), []);
+});
+
+QUnit.test('should return properties that were set after object creation', function () {
+  function Beer() { }
+  Beer.prototype.type = 'ipa';
+
+  var beer = new Beer();
+
+  set(beer, 'brand', 'big daddy');
+
+  deepEqual(Object.keys(beer), ['brand']);
+});
+
+QUnit.module('Keys behavior with observers');
+
+QUnit.test('should not leak properties on the prototype', function () {
+  function Beer() { }
+  Beer.prototype.type = 'ipa';
+
+  var beer = new Beer();
+
+  addObserver(beer, 'type', K);
+  deepEqual(Object.keys(beer), []);
+  removeObserver(beer, 'type', K);
+});
+
+QUnit.test('observing a non existent property', function () {
+  function Beer() { }
+  Beer.prototype.type = 'ipa';
+
+  var beer = new Beer();
+
+  addObserver(beer, 'brand', K);
+
+  deepEqual(Object.keys(beer), []);
+
+  set(beer, 'brand', 'Corona');
+  deepEqual(Object.keys(beer), ['brand']);
+
+  removeObserver(beer, 'brand', K);
+});
+
+QUnit.test('with observers switched on and off', function () {
+  function Beer() { }
+  Beer.prototype.type = 'ipa';
+
+  var beer = new Beer();
+
+  addObserver(beer, 'type', K);
+  removeObserver(beer, 'type', K);
+
+  deepEqual(Object.keys(beer), []);
+});
+
+QUnit.test('observers switched on and off with setter in between (observed property is not shadowing)', function () {
+  function Beer() { }
+
+  var beer = new Beer();
+  set(beer, 'type', 'ale');
+  deepEqual(Object.keys(beer), ['type'], 'only set');
+
+  var otherBeer = new Beer();
+  addObserver(otherBeer, 'type', K);
+  set(otherBeer, 'type', 'ale');
+  deepEqual(Object.keys(otherBeer), ['type'], 'addObserver -> set');
+
+  var yetAnotherBeer = new Beer();
+  addObserver(yetAnotherBeer, 'type', K);
+  set(yetAnotherBeer, 'type', 'ale');
+  removeObserver(beer, 'type', K);
+  deepEqual(Object.keys(yetAnotherBeer), ['type'], 'addObserver -> set -> removeOjbserver');
+
+  var itsMyLastBeer = new Beer();
+  set(itsMyLastBeer, 'type', 'ale');
+  removeObserver(beer, 'type', K);
+  deepEqual(Object.keys(itsMyLastBeer), ['type'], 'set -> removeObserver');
+});
+
+QUnit.test('observers switched on and off with setter in between (observed property is shadowing one on the prototype)', function () {
+  function Beer() { }
+  Beer.prototype.type = 'ipa';
+
+  var beer = new Beer();
+  set(beer, 'type', 'ale');
+  deepEqual(Object.keys(beer), ['type'], 'after set');
+
+  var otherBeer = new Beer();
+  addObserver(otherBeer, 'type', K);
+  set(otherBeer, 'type', 'ale');
+  deepEqual(Object.keys(otherBeer), ['type'], 'addObserver -> set');
+
+  var yetAnotherBeer = new Beer();
+  addObserver(yetAnotherBeer, 'type', K);
+  set(yetAnotherBeer, 'type', 'ale');
+  removeObserver(beer, 'type', K);
+  deepEqual(Object.keys(yetAnotherBeer), ['type'], 'addObserver -> set -> removeObserver');
+
+  var itsMyLastBeer = new Beer();
+  set(itsMyLastBeer, 'type', 'ale');
+  removeObserver(beer, 'type', K);
+  deepEqual(Object.keys(itsMyLastBeer), ['type'], 'set -> removeObserver');
+});
+
+QUnit.test('observers switched on and off with setter in between', function () {
+  function Beer() { }
+  Beer.prototype.type = 'ipa';
+
+  var beer = new Beer();
+
+  addObserver(beer, 'type', K);
+  set(beer, 'type', 'ale');
+
+  deepEqual(Object.keys(beer), ['type']);
+});
+
+QUnit.test('observer switched on and off and then setter', function () {
+  function Beer() { }
+  Beer.prototype.type = 'ipa';
+
+  var beer = new Beer();
+
+  addObserver(beer, 'type', K);
+  removeObserver(beer, 'type', K);
+
+  set(beer, 'type', 'ale');
+
+  deepEqual(Object.keys(beer), ['type'], 'addObserver -> removeObserver -> set');
+});

--- a/packages/ember-metal/tests/watching/unwatch_test.js
+++ b/packages/ember-metal/tests/watching/unwatch_test.js
@@ -107,3 +107,14 @@ testBoth('unwatching "length" property on an object', function(get, set) {
   equal(willCount, 0, 'should NOT have invoked willCount');
   equal(didCount, 0, 'should NOT have invoked didCount');
 });
+
+testBoth('unwatching should not destroy non MANDATORY_SETTER descriptor', function(get, set) {
+  var obj = { get foo() { return 'RUN'; } };
+
+  equal(obj.foo, 'RUN', 'obj.foo');
+  watch(obj, 'foo');
+  equal(obj.foo, 'RUN', 'obj.foo after watch');
+  unwatch(obj, 'foo');
+  equal(obj.foo, 'RUN', 'obj.foo after unwatch');
+});
+

--- a/packages/ember-metal/tests/watching/watch_test.js
+++ b/packages/ember-metal/tests/watching/watch_test.js
@@ -271,3 +271,36 @@ testBoth('watching "length" property on an array', function(get, set) {
   equal(get(arr, 'length'), 10, 'should get new value');
   equal(arr.length, 10, 'property should be accessible on arr');
 });
+
+testBoth('watch + ES5 getter', function(get) {
+  var parent = { b: 1 };
+  var child = {
+    get b() {
+      return parent.b;
+    }
+  };
+
+  equal(parent.b,  1, 'parent.b should be 1');
+  equal(child.b, 1, 'child.b should be 1');
+  equal(get(child, 'b'), 1, 'Ember.get(child, "b") should be 1');
+
+  watch(child, 'b');
+
+  equal(parent.b,  1, 'parent.b should be 1 (after watch)');
+  equal(child.b, 1, 'child.b should be 1  (after watch)');
+
+  equal(get(child, 'b'), 1, 'Ember.get(child, "b") should be 1 (after watch)');
+});
+
+testBoth('watch + Ember.set + no-descriptor', function(get, set) {
+  var child = { };
+
+  equal(child.b, undefined, 'child.b ');
+  equal(get(child, 'b'), undefined, 'Ember.get(child, "b")');
+
+  watch(child, 'b');
+  set(child, 'b', 1);
+
+  equal(child.b, 1, 'child.b (after watch)');
+  equal(get(child, 'b'), 1, 'Ember.get(child, "b") (after watch)');
+});


### PR DESCRIPTION
Before this commit MandatorySetter enabled + current property being watched
resulted in `get` always fetching via meta.values. Although this typically works,
the default getter for a MandatorySetter already does this, so it is actually redundant.

Going further, when a user defines their own getter this code-path is incorrectly taken,
instead the original value (which originated from the getter) should be the consulted value.

This is blocking an ember-data fix, and likely causing grief for users who use ES5 getter/setters mixed in with our templates.

cc @krisselden 
