### PR TITLE
Add example for white space

### DIFF
--- a/packages/ember-metal/lib/is_empty.js
+++ b/packages/ember-metal/lib/is_empty.js
@@ -17,6 +17,8 @@ import isNone from 'ember-metal/is_none';
   Ember.isEmpty({});              // false
   Ember.isEmpty('Adam Hawkins');  // false
   Ember.isEmpty([0,1,2]);         // false
+  Ember.isEmpty('\n\t');          // false
+  Ember.isEmpty('  ');            // false
   ```
 
   @method isEmpty


### PR DESCRIPTION
Most of the examples for `Ember.isEmpty` are similar to that from `Ember.isBlank` (https://github.com/emberjs/ember.js/blob/v2.1.0/packages/ember-metal/lib/is_blank.js#L3). Examples for white space are missing.
