### PR TITLE
[FEATURE ember-views-tagless-jquery] add support for this.$() in tagless components

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -52,3 +52,7 @@ for a detailed explanation.
   ```
 
   Implements RFC [#64](https://github.com/emberjs/rfcs/blob/master/text/0064-contextual-component-lookup.md)
+
+* `ember-views-tagless-jquery`
+
+  Add the possibility to call `this.$()` in tagless components.

--- a/features.json
+++ b/features.json
@@ -9,6 +9,7 @@
     "ember-routing-routable-components": null,
     "ember-metal-ember-assign": null,
     "ember-contextual-components": true,
-    "ember-container-inject-owner": true
+    "ember-container-inject-owner": true,
+    "ember-views-tagless-jquery": null
   }
 }

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -207,6 +207,10 @@ export default Mixin.create({
     string, this method will return a jQuery object, using the current element
     as its buffer.
 
+    If it is called within a tagless view, this method will return a jQuery
+    object containing all the elements it encloses. You can also
+    pass in a selector string, just like you would do in a normal view.
+
     For example, calling `view.$('li')` will return a jQuery object containing
     all of the `li` elements inside the DOM element of this view.
 
@@ -216,7 +220,9 @@ export default Mixin.create({
     @public
   */
   $(sel) {
-    assert('You cannot access this.$() on a component with `tagName: \'\'` specified.', this.tagName !== '');
+    if (!isEnabled('ember-views-tagless-jquery')) {
+      assert('You cannot access this.$() on a component with `tagName: \'\'` specified.', this.tagName !== '');
+    }
     return this._currentState.$(this, sel);
   },
 

--- a/packages/ember-views/tests/views/view/jquery_test.js
+++ b/packages/ember-views/tests/views/view/jquery_test.js
@@ -2,6 +2,12 @@ import { get } from 'ember-metal/property_get';
 import EmberView from 'ember-views/views/view';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
 import compile from 'ember-template-compiler/system/compile';
+import isEnabled from 'ember-metal/features';
+
+import ComponentLookup from 'ember-views/component_lookup';
+import buildOwner from 'container/tests/test-helpers/build-owner';
+import { OWNER } from 'container/owner';
+import Component from 'ember-views/components/component';
 
 var view;
 QUnit.module('EmberView#$', {
@@ -50,16 +56,130 @@ QUnit.test('returns empty jQuery object if filter passed that does not match ite
   equal(jquery.length, 0, 'view.$(body) should have no elements');
 });
 
-QUnit.test('asserts for tagless views', function() {
-  var view = EmberView.create({
-    tagName: ''
+if (!isEnabled('ember-views-tagless-jquery')) {
+  QUnit.test('asserts for tagless views', function() {
+    var view = EmberView.create({
+      tagName: ''
+    });
+
+    runAppend(view);
+
+    expectAssertion(function() {
+      view.$();
+    }, /You cannot access this.\$\(\) on a component with `tagName: \'\'` specified/);
+
+    runDestroy(view);
+  });
+}
+
+if (isEnabled('ember-views-tagless-jquery')) {
+  QUnit.test('returns empty jQuery object on tagless components without template', function() {
+    var view = EmberView.extend({
+      tagName: ''
+    }).create();
+
+    runAppend(view);
+
+    var jquery = view.$();
+    equal(jquery.length, 0, 'view.$() should have no elements');
+
+    runDestroy(view);
   });
 
-  runAppend(view);
+  QUnit.test('returns empty jQuery object on tagless components with template with empty bound properties', function() {
+    var view = EmberView.extend({
+      tagName: '',
+      template: compile('{{text1}}{{text2}}{{text3}}{{text4}}')
+    }).create();
 
-  expectAssertion(function() {
-    view.$();
-  }, /You cannot access this.\$\(\) on a component with `tagName: \'\'` specified/);
+    runAppend(view);
 
-  runDestroy(view);
-});
+    var jquery = view.$();
+    equal(jquery.length, 0, 'view.$() should have no elements');
+
+    runDestroy(view);
+  });
+
+  QUnit.test('returns jQuery object with child elements on tagless components', function() {
+    var view = EmberView.extend({
+      tagName: '',
+      template: compile('<span></span><p></p><h1></h1>')
+    }).create();
+
+    runAppend(view);
+
+    var jquery = view.$();
+    equal(jquery.length, 3, 'view.$() should have three elements');
+    equal(jquery[0].tagName, 'SPAN', 'first element should be span');
+    equal(jquery[1].tagName, 'P', 'second element should be p');
+    equal(jquery[2].tagName, 'H1', 'third element should be h1');
+
+    runDestroy(view);
+  });
+
+  QUnit.test('returns jQuery object with child elements on tagless components', function() {
+    var view = EmberView.extend({
+      tagName: '',
+      template: compile('<span></span><p><span id="theelement"></span></p><h1></h1>')
+    }).create();
+
+    runAppend(view);
+
+    var jquery = view.$('span');
+    equal(jquery.length, 2, 'view.$() should have 2 spans');
+
+    jquery = view.$('#theelement');
+    equal(jquery.length, 1, 'view.$() can select inner elements');
+
+    runDestroy(view);
+  });
+
+  QUnit.test('returned jQuery object ignores first and last empty text nodes', function() {
+    var owner = buildOwner();
+    owner.registerOptionsForType('template', { instantiate: false });
+    owner.register('component-lookup:main', ComponentLookup);
+
+    owner.register('template:components/foo-bar', compile('<div id="child-div"></div>'));
+    owner.register('component:foo-bar', Component.extend({
+      classNames: 'foo-bar'
+    }));
+
+    var view = EmberView.extend({
+      tagName: '',
+      [OWNER]: owner,
+      template: compile('{{component "foo-bar"}}')
+    }).create();
+
+    runAppend(view);
+
+    var jquery = view.$();
+
+    equal(jquery.length, 1, 'view.$() should have one element');
+    ok(jquery.eq(0).hasClass('foo-bar'), 'element has class foo-bar');
+    equal(jquery.eq(0).children()[0].id, 'child-div', 'component template rendered properly');
+
+    runDestroy(view);
+  });
+
+  QUnit.test('returned jQuery object includes bound properties', function() {
+    var view = EmberView.extend({
+      tagName: '',
+      context: {
+        rawHTML: '<span></span><p></p><h1></h1>',
+        text: 'çup?'
+      },
+      template: compile('{{text}}{{{rawHTML}}}')
+    }).create();
+
+    runAppend(view);
+
+    var jquery = view.$();
+    equal(jquery.length, 4, 'view.$() should have four elements');
+    equal(jquery[0].nodeValue, 'çup?', 'first node should be a text node');
+    equal(jquery[1].tagName, 'SPAN', 'second element should be span');
+    equal(jquery[2].tagName, 'P', 'third element should be p');
+    equal(jquery[3].tagName, 'H1', 'fourth element should be h1');
+
+    runDestroy(view);
+  });
+}


### PR DESCRIPTION
Tests are green with and without features flags enabled.
This seems to be the most concise way of returning a range of objects in jquery.

Please let me know if something's missing.
