### PR TITLE
add assertions for tagless component event handlers

### DIFF
--- a/packages/ember-views/lib/components/component.js
+++ b/packages/ember-views/lib/components/component.js
@@ -158,6 +158,23 @@ var Component = View.extend(TargetActionSupport, {
 
       this.layout = this.defaultLayout;
     }
+
+    // If in a tagless component, assert that no event handlers are defined
+    assert(
+      `You can not define a function that handles DOM events in the \`${this}\` tagless component since it doesn't have any DOM element.`,
+      this.tagName !== '' || !(() => {
+        let eventDispatcher = this.container.lookup('event_dispatcher:main');
+        let events = (eventDispatcher && eventDispatcher._finalEvents) || {};
+
+        for (let key in events) {
+          let methodName = events[key];
+
+          if (typeof this[methodName]  === 'function') {
+            return true; // indicate that the assertion should be triggered
+          }
+        }
+      }
+    )());
   },
 
   template: null,

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -149,7 +149,7 @@ export default EmberObject.extend({
   */
   setup(addedEvents, rootElement) {
     var event;
-    var events = assign({}, get(this, 'events'), addedEvents);
+    var events = this._finalEvents = assign({}, get(this, 'events'), addedEvents);
 
     if (!isNone(rootElement)) {
       set(this, 'rootElement', rootElement);


### PR DESCRIPTION
Should application instance custom events be considered as well?

Should I access it using `this.container.lookup('-application-instance:main')`?

Feel free to tag this PR if needed.

/cc @rwjblue @mixonic 
