### PR TITLE
[DOC release] Removes extraneous backslash in code snipper

### DIFF
--- a/packages/ember-routing-htmlbars/lib/keywords/action.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/action.js
@@ -58,7 +58,7 @@ import closureAction from 'ember-routing-htmlbars/keywords/closure-action';
   ```js
   export default Ember.Component.extend({
     actions: {
-      save(/* event *\/) {
+      save() {
         this.get('model').save();
       }
     }


### PR DESCRIPTION
The backslash is "escaping" the code comment closing `*/`.
