### PR TITLE
[FEATURE ember-contextual-components] Enable by default.

### DIFF
--- a/features.json
+++ b/features.json
@@ -9,6 +9,6 @@
     "ember-debug-handlers": true,
     "ember-routing-routable-components": null,
     "ember-metal-ember-assign": null,
-    "ember-contextual-components": null
+    "ember-contextual-components": true
   }
 }


### PR DESCRIPTION
As discussed in Ember core team meeting on 2015-10-23.

Prior to 2.3 branching into beta we need to evaluate the local lookup feature to ensure that contextual components land within one version of local lookup. If it looks like local lookup will not land by 2.4 (before branching 2.3.0-beta.1) this feature will be delayed. This timing should not be an issue.
