### PR TITLE
Test white space in `Ember.isEmpty`

### DIFF
--- a/packages/ember-metal/lib/is_empty.js
+++ b/packages/ember-metal/lib/is_empty.js
@@ -17,6 +17,8 @@ import isNone from 'ember-metal/is_none';
   Ember.isEmpty({});              // false
   Ember.isEmpty('Adam Hawkins');  // false
   Ember.isEmpty([0,1,2]);         // false
+  Ember.isEmpty('\n\t');          // false
+  Ember.isEmpty('  ');            // false
   ```
 
   @method isEmpty

--- a/packages/ember-metal/tests/is_empty_test.js
+++ b/packages/ember-metal/tests/is_empty_test.js
@@ -14,6 +14,8 @@ QUnit.test('Ember.isEmpty', function() {
   equal(true, isEmpty(null), 'for null');
   equal(true, isEmpty(undefined), 'for undefined');
   equal(true, isEmpty(''), 'for an empty String');
+  equal(false, isEmpty('  '), 'for a whitespace String');
+  equal(false, isEmpty('\n\t'), 'for another whitespace String');
   equal(false, isEmpty(true), 'for true');
   equal(false, isEmpty(false), 'for false');
   equal(false, isEmpty(string), 'for a String');


### PR DESCRIPTION
Most of the examples for `Ember.isEmpty` are similar to that from `Ember.isBlank` (https://github.com/emberjs/ember.js/blob/v2.1.0/packages/ember-metal/lib/is_blank.js#L3). Examples for white space are missing.
