### PR TITLE
[CLEANUP beta] - Populate `ember-metal/symbol`

### DIFF
--- a/packages/container/lib/owner.js
+++ b/packages/container/lib/owner.js
@@ -3,7 +3,7 @@
 @submodule ember-runtime
 */
 
-import { symbol } from 'ember-metal/utils';
+import symbol from 'ember-metal/symbol';
 
 export const OWNER = symbol('OWNER');
 

--- a/packages/ember-htmlbars/lib/keywords/closure-component.js
+++ b/packages/ember-htmlbars/lib/keywords/closure-component.js
@@ -5,7 +5,7 @@
 
 import { assert } from 'ember-metal/debug';
 import isNone from 'ember-metal/is_none';
-import { symbol } from 'ember-metal/utils';
+import symbol from 'ember-metal/symbol';
 import BasicStream from 'ember-metal/streams/stream';
 import { read } from 'ember-metal/streams/utils';
 import { labelForSubexpr } from 'ember-htmlbars/hooks/subexpr';

--- a/packages/ember-htmlbars/lib/keywords/mut.js
+++ b/packages/ember-htmlbars/lib/keywords/mut.js
@@ -4,7 +4,7 @@
 */
 
 import { assert } from 'ember-metal/debug';
-import { symbol } from 'ember-metal/utils';
+import  symbol from 'ember-metal/symbol';
 import ProxyStream from 'ember-metal/streams/proxy-stream';
 import BasicStream from 'ember-metal/streams/stream';
 import { isStream } from 'ember-metal/streams/utils';

--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -8,7 +8,7 @@ import { instrument } from 'ember-htmlbars/system/instrumentation-support';
 import LegacyEmberComponent from 'ember-views/components/component';
 import GlimmerComponent from 'ember-htmlbars/glimmer-component';
 import extractPositionalParams from 'ember-htmlbars/utils/extract-positional-params';
-import { symbol } from 'ember-metal/utils';
+import symbol from 'ember-metal/symbol';
 import { setOwner } from 'container/owner';
 
 // These symbols will be used to limit link-to's public API surface area.

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -9,7 +9,7 @@ import {
   accumulateListeners
 } from 'ember-metal/events';
 import ObserverSet from 'ember-metal/observer_set';
-import { symbol } from 'ember-metal/utils';
+import symbol from 'ember-metal/symbol';
 
 export let PROPERTY_DID_CHANGE = symbol('PROPERTY_DID_CHANGE');
 

--- a/packages/ember-metal/lib/symbol.js
+++ b/packages/ember-metal/lib/symbol.js
@@ -1,0 +1,9 @@
+import { GUID_KEY, intern } from 'ember-metal/utils';
+
+export default function symbol(debugName) {
+  // TODO: Investigate using platform symbols, but we do not
+  // want to require non-enumerability for this API, which
+  // would introduce a large cost.
+
+  return intern(debugName + ' [id=' + GUID_KEY + Math.floor(Math.random() * new Date()) + ']');
+}

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -80,7 +80,7 @@ var stringCache  = {};
   @private
   @return {String} interned version of the provided string
 */
-function intern(str) {
+export function intern(str) {
   var obj = {};
   obj[str] = 1;
   for (var key in obj) {
@@ -89,14 +89,6 @@ function intern(str) {
     }
   }
   return str;
-}
-
-export function symbol(debugName) {
-  // TODO: Investigate using platform symbols, but we do not
-  // want to require non-enumerability for this API, which
-  // would introduce a large cost.
-
-  return intern(debugName + ' [id=' + GUID_KEY + Math.floor(Math.random() * new Date()) + ']');
 }
 
 /**

--- a/packages/ember-routing-htmlbars/lib/keywords/closure-action.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/closure-action.js
@@ -3,7 +3,7 @@ import {
   read,
   readArray
 } from 'ember-metal/streams/utils';
-import { symbol } from 'ember-metal/utils';
+import symbol from 'ember-metal/symbol';
 import { get } from 'ember-metal/property_get';
 import { labelForSubexpr } from 'ember-htmlbars/hooks/subexpr';
 import EmberError from 'ember-metal/error';

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -45,7 +45,7 @@ import {
   K
 } from 'ember-metal/core';
 import { validatePropertyInjections } from 'ember-runtime/inject';
-import { symbol } from 'ember-metal/utils';
+import symbol from 'ember-metal/symbol';
 
 export let POST_INIT = symbol('POST_INIT');
 var schedule = run.schedule;

--- a/packages/ember-views/lib/compat/attrs-proxy.js
+++ b/packages/ember-views/lib/compat/attrs-proxy.js
@@ -1,5 +1,5 @@
 import { Mixin } from 'ember-metal/mixin';
-import { symbol } from 'ember-metal/utils';
+import symbol from 'ember-metal/symbol';
 import { PROPERTY_DID_CHANGE } from 'ember-metal/property_events';
 
 export function deprecation(key) {

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -8,7 +8,7 @@ import { computed } from 'ember-metal/computed';
 import { Mixin } from 'ember-metal/mixin';
 import { POST_INIT } from 'ember-runtime/system/core_object';
 import isEnabled from 'ember-metal/features';
-import { symbol } from 'ember-metal/utils';
+import symbol from 'ember-metal/symbol';
 import { getOwner } from 'container/owner';
 
 const INIT_WAS_CALLED = symbol('INIT_WAS_CALLED');


### PR DESCRIPTION
~~~\* Seems that `ember-metal/lib/symbol` was a forgotten artifact.~~~

Per discussion, this PR now moves `symbol` to `ember-metal/symbol`.
