### PR TITLE
Bump RSVP dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "qunit-extras": "^1.4.0",
     "qunitjs": "^1.19.0",
     "route-recognizer": "0.1.5",
-    "rsvp": "~3.0.6",
+    "rsvp": "~3.1.0",
     "serve-static": "^1.10.0",
     "simple-dom": "^0.2.7",
     "testem": "^0.9.5"


### PR DESCRIPTION
Hey,

would be nice to have latest rsvp which adds the `label` as second argument to the `on('error', ...)` hook.

https://github.com/tildeio/rsvp.js/pull/404

BR,
Domme
