### PR TITLE
Deprecate altering outlets outside of route transitions

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1216,10 +1216,19 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
 
     if (isEnabled('ember-application-visit')) {
       if (!this._environment || this._environment.options.shouldRender) {
-        this.renderTemplate(controller, context);
+        this._invokeRenderTemplate(controller, context);
       }
     } else {
+      this._invokeRenderTemplate(controller, context);
+    }
+  },
+
+  _invokeRenderTemplate(controller, context) {
+    try {
+      this._insideRenderTemplate = true;
       this.renderTemplate(controller, context);
+    } finally {
+      this._insideRenderTemplate = false;
     }
   },
 
@@ -1942,6 +1951,8 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
   render(_name, options) {
     assert('The name in the given arguments is undefined', arguments.length > 0 ? !isNone(arguments[0]) : true);
 
+    deprecate(`Calling "render" in a route is only allowed inside the renderTemplate hook. Rendering at any other time violates the purpose of Route, which is to bind URLs to the application state. Consider replacing the outlet you were targeting with a Component that injects a Service, and use the Service to communicate what should be rendered.`, this._insideRenderTemplate, { id: 'ember-routing.deprecate-render-outside-renderTemplate', until: '3.0.0' });
+
     var namePassed = typeof _name === 'string' && !!_name;
     var isDefaultRender = arguments.length === 0 || Ember.isEmpty(arguments[0]);
     var name;
@@ -2003,6 +2014,8 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @private
   */
   disconnectOutlet(options) {
+    deprecate(`Calling "disconnectOutlet" is only allowed inside the renderTemplate hook. Altering outlets at any other time violates the purpose of Route, which is to bind URLs to the application state. Consider replacing the outlet you were targeting with a Component that injects a Service, and use the Service to communicate what should be rendered.`, this._insideRenderTemplate, { id: 'ember-routing.deprecate-disconnectOutlet-outside-renderTemplate', until: '3.0.0' });
+
     var outletName;
     var parentView;
     if (!options || typeof options === 'string') {

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -20,6 +20,8 @@ import NoneLocation from 'ember-routing/location/none_location';
 import HistoryLocation from 'ember-routing/location/history_location';
 
 var trim = jQuery.trim;
+var renderDeprecationMessage = /Calling "render" in a route is only allowed inside the renderTemplate hook/;
+var disconnectOutletDeprecationMessage = /Calling "disconnectOutlet" is only allowed inside the renderTemplate hook/;
 
 var Router, App, router, registry, container, originalLoggerError;
 
@@ -544,10 +546,12 @@ QUnit.test('defining templateName allows other templates to be rendered', functi
     templateName: 'the_real_home_template',
     actions: {
       showAlert() {
-        this.render('alert', {
-          into: 'home',
-          outlet: 'alert'
-        });
+        expectDeprecation(() => {
+          this.render('alert', {
+            into: 'home',
+            outlet: 'alert'
+          });
+        }, renderDeprecationMessage);
       }
     }
   });
@@ -2625,13 +2629,17 @@ QUnit.test('Route supports clearing outlet explicitly', function() {
   App.PostsRoute = Route.extend({
     actions: {
       showModal() {
-        this.render('postsModal', {
-          into: 'application',
-          outlet: 'modal'
-        });
+        expectDeprecation(() => {
+          this.render('postsModal', {
+            into: 'application',
+            outlet: 'modal'
+          });
+        }, renderDeprecationMessage);
       },
       hideModal() {
-        this.disconnectOutlet({ outlet: 'modal', parentView: 'application' });
+        expectDeprecation(() => {
+          this.disconnectOutlet({ outlet: 'modal', parentView: 'application' });
+        }, disconnectOutletDeprecationMessage);
       }
     }
   });
@@ -2639,12 +2647,16 @@ QUnit.test('Route supports clearing outlet explicitly', function() {
   App.PostsIndexRoute = Route.extend({
     actions: {
       showExtra() {
-        this.render('postsExtra', {
-          into: 'posts/index'
-        });
+        expectDeprecation(() => {
+          this.render('postsExtra', {
+            into: 'posts/index'
+          });
+        }, renderDeprecationMessage);
       },
       hideExtra() {
-        this.disconnectOutlet({ parentView: 'posts/index' });
+        expectDeprecation(() => {
+          this.disconnectOutlet({ parentView: 'posts/index' });
+        }, disconnectOutletDeprecationMessage);
       }
     }
   });
@@ -2702,13 +2714,17 @@ QUnit.test('Route supports clearing outlet using string parameter', function() {
   App.PostsRoute = Route.extend({
     actions: {
       showModal() {
-        this.render('postsModal', {
-          into: 'application',
-          outlet: 'modal'
-        });
+        expectDeprecation(() => {
+          this.render('postsModal', {
+            into: 'application',
+            outlet: 'modal'
+          });
+        }, renderDeprecationMessage);
       },
       hideModal() {
-        this.disconnectOutlet('modal');
+        expectDeprecation(() => {
+          this.disconnectOutlet('modal');
+        }, disconnectOutletDeprecationMessage);
       }
     }
   });
@@ -2734,7 +2750,7 @@ QUnit.test('Route supports clearing outlet using string parameter', function() {
 });
 
 QUnit.test('Route silently fails when cleaning an outlet from an inactive view', function() {
-  expect(1); // handleURL
+  expect(4); // handleURL
 
   Ember.TEMPLATES.application = compile('{{outlet}}');
   Ember.TEMPLATES.posts = compile('{{outlet \'modal\'}}');
@@ -2747,13 +2763,19 @@ QUnit.test('Route silently fails when cleaning an outlet from an inactive view',
   App.PostsRoute = Route.extend({
     actions: {
       hideSelf() {
-        this.disconnectOutlet({ outlet: 'main', parentView: 'application' });
+        expectDeprecation(() => {
+          this.disconnectOutlet({ outlet: 'main', parentView: 'application' });
+        }, disconnectOutletDeprecationMessage);
       },
       showModal() {
-        this.render('modal', { into: 'posts', outlet: 'modal' });
+        expectDeprecation(() => {
+          this.render('modal', { into: 'posts', outlet: 'modal' });
+        }, renderDeprecationMessage);
       },
       hideModal() {
-        this.disconnectOutlet({ outlet: 'modal', parentView: 'posts' });
+        expectDeprecation(() => {
+          this.disconnectOutlet({ outlet: 'modal', parentView: 'posts' });
+        }, disconnectOutletDeprecationMessage);
       }
     }
   });
@@ -3563,10 +3585,12 @@ QUnit.test('Can disconnect a named outlet at the top level', function() {
     },
     actions: {
       banish() {
-        this.disconnectOutlet({
-          parentView: 'application',
-          outlet: 'other'
-        });
+        expectDeprecation(() => {
+          this.disconnectOutlet({
+            parentView: 'application',
+            outlet: 'other'
+          });
+        }, disconnectOutletDeprecationMessage);
       }
     }
   }));
@@ -3612,10 +3636,12 @@ QUnit.test('Can render into a named outlet at the top level, later', function() 
   registry.register('route:application', Route.extend({
     actions: {
       launch() {
-        this.render('modal', {
-          into: 'application',
-          outlet: 'other'
-        });
+        expectDeprecation(() => {
+          this.render('modal', {
+            into: 'application',
+            outlet: 'other'
+          });
+        }, renderDeprecationMessage);
       }
     }
   }));
@@ -3678,16 +3704,20 @@ QUnit.test('Tolerates stacked renders', function() {
   App.ApplicationRoute = Route.extend({
     actions: {
       openLayer: function() {
-        this.render('layer', {
-          into: 'application',
-          outlet: 'modal'
-        });
+        expectDeprecation(() => {
+          this.render('layer', {
+            into: 'application',
+            outlet: 'modal'
+          });
+        }, renderDeprecationMessage);
       },
       close: function() {
-        this.disconnectOutlet({
-          outlet: 'modal',
-          parentView: 'application'
-        });
+        expectDeprecation(() => {
+          this.disconnectOutlet({
+            outlet: 'modal',
+            parentView: 'application'
+          });
+        }, disconnectOutletDeprecationMessage);
       }
     }
   });
@@ -3735,20 +3765,24 @@ QUnit.test('Allows any route to disconnectOutlet another route\'s templates', fu
   App.ApplicationRoute = Route.extend({
     actions: {
       openLayer: function() {
-        this.render('layer', {
-          into: 'application',
-          outlet: 'modal'
-        });
+        expectDeprecation(() => {
+          this.render('layer', {
+            into: 'application',
+            outlet: 'modal'
+          });
+        }, renderDeprecationMessage);
       }
     }
   });
   App.IndexRoute = Route.extend({
     actions: {
       close: function() {
-        this.disconnectOutlet({
-          parentView: 'application',
-          outlet: 'modal'
-        });
+        expectDeprecation(() => {
+          this.disconnectOutlet({
+            parentView: 'application',
+            outlet: 'modal'
+          });
+        }, disconnectOutletDeprecationMessage);
       }
     }
   });
@@ -3772,11 +3806,15 @@ QUnit.test('Can this.render({into:...}) the render helper', function() {
     },
     actions: {
       changeToBar: function() {
-        this.disconnectOutlet({
-          parentView: 'foo',
-          outlet: 'main'
-        });
-        this.render('bar', { into: 'foo' });
+        expectDeprecation(() => {
+          this.disconnectOutlet({
+            parentView: 'foo',
+            outlet: 'main'
+          });
+        }, disconnectOutletDeprecationMessage);
+        expectDeprecation(() => {
+          this.render('bar', { into: 'foo' });
+        }, renderDeprecationMessage);
       }
     }
   });
@@ -3798,10 +3836,12 @@ QUnit.test('Can disconnect from the render helper', function() {
     },
     actions: {
       disconnect: function() {
-        this.disconnectOutlet({
-          parentView: 'foo',
-          outlet: 'main'
-        });
+        expectDeprecation(() => {
+          this.disconnectOutlet({
+            parentView: 'foo',
+            outlet: 'main'
+          });
+        }, disconnectOutletDeprecationMessage);
       }
     }
   });
@@ -3827,11 +3867,15 @@ QUnit.test('Can this.render({into:...}) the render helper\'s children', function
     },
     actions: {
       changeToBar: function() {
-        this.disconnectOutlet({
-          parentView: 'index',
-          outlet: 'main'
-        });
-        this.render('bar', { into: 'index' });
+        expectDeprecation(() => {
+          this.disconnectOutlet({
+            parentView: 'index',
+            outlet: 'main'
+          });
+        }, disconnectOutletDeprecationMessage);
+        expectDeprecation(() => {
+          this.render('bar', { into: 'index' });
+        }, renderDeprecationMessage);
       }
     }
   });
@@ -3855,10 +3899,12 @@ QUnit.test('Can disconnect from the render helper\'s children', function() {
     },
     actions: {
       disconnect: function() {
-        this.disconnectOutlet({
-          parentView: 'index',
-          outlet: 'main'
-        });
+        expectDeprecation(() => {
+          this.disconnectOutlet({
+            parentView: 'index',
+            outlet: 'main'
+          });
+        }, disconnectOutletDeprecationMessage);
       }
     }
   });
@@ -3882,11 +3928,15 @@ QUnit.test('Can this.render({into:...}) nested render helpers', function() {
     },
     actions: {
       changeToBaz: function() {
-        this.disconnectOutlet({
-          parentView: 'bar',
-          outlet: 'main'
-        });
-        this.render('baz', { into: 'bar' });
+        expectDeprecation(() => {
+          this.disconnectOutlet({
+            parentView: 'bar',
+            outlet: 'main'
+          });
+        }, disconnectOutletDeprecationMessage);
+        expectDeprecation(() => {
+          this.render('baz', { into: 'bar' });
+        }, renderDeprecationMessage);
       }
     }
   });
@@ -3909,10 +3959,12 @@ QUnit.test('Can disconnect from nested render helpers', function() {
     },
     actions: {
       disconnect: function() {
-        this.disconnectOutlet({
-          parentView: 'bar',
-          outlet: 'main'
-        });
+        expectDeprecation(() => {
+          this.disconnectOutlet({
+            parentView: 'bar',
+            outlet: 'main'
+          });
+        }, disconnectOutletDeprecationMessage);
       }
     }
   });
@@ -4010,16 +4062,20 @@ QUnit.test('Exception if outlet name is undefined in render and disconnectOutlet
   App.ApplicationRoute = Route.extend({
     actions: {
       showModal: function() {
-        this.render({
-          outlet: undefined,
-          parentView: 'application'
-        });
+        expectDeprecation(() => {
+          this.render({
+            outlet: undefined,
+            parentView: 'application'
+          });
+        }, renderDeprecationMessage);
       },
       hideModal: function() {
-        this.disconnectOutlet({
-          outlet: undefined,
-          parentView: 'application'
-        });
+        expectDeprecation(() => {
+          this.disconnectOutlet({
+            outlet: undefined,
+            parentView: 'application'
+          });
+        }, disconnectOutletDeprecationMessage);
       }
     }
   });


### PR DESCRIPTION
This deprecates the use of `render` and `disconnectOutlet` outside of
the `renderTemplate` hook. The only appropriate time for a Route
to change application state is during a transition.

While we have historically supported calling these methods from a route's action
handlers, that is a clear violation of the purpose of `Route`, which is to
bind application state to the URL.

If you want to change something on screen without changing the URL, a
Route is the wrong place to do it. You should use a `Component` and
communicate as needed with the `Component` via a `Service`.
