### PR TITLE
[BUGFIX canary] Create new hash when merging parameters hashes in components

### DIFF
--- a/packages/ember-htmlbars/lib/hooks/component.js
+++ b/packages/ember-htmlbars/lib/hooks/component.js
@@ -11,7 +11,7 @@ import {
   COMPONENT_PATH,
   COMPONENT_HASH,
   isComponentCell,
-  mergeHash,
+  mergeInNewHash,
 } from 'ember-htmlbars/keywords/closure-component';
 
 var IS_ANGLE_CACHE = new Cache(1000, function(key) {
@@ -33,7 +33,7 @@ export default function componentHook(renderNode, env, scope, _tagName, params, 
     let componentCell = stream.value();
     if (isComponentCell(componentCell)) {
       tagName = componentCell[COMPONENT_PATH];
-      attrs = mergeHash(componentCell[COMPONENT_HASH], attrs);
+      attrs = mergeInNewHash(componentCell[COMPONENT_HASH], attrs);
     }
   }
 

--- a/packages/ember-htmlbars/lib/keywords/closure-component.js
+++ b/packages/ember-htmlbars/lib/keywords/closure-component.js
@@ -81,7 +81,7 @@ function createNestedClosureComponentCell(componentCell, params, hash) {
 
   return {
     [COMPONENT_PATH]: componentCell[COMPONENT_PATH],
-    [COMPONENT_HASH]: mergeHash(componentCell[COMPONENT_HASH], hash),
+    [COMPONENT_HASH]: mergeInNewHash(componentCell[COMPONENT_HASH], hash),
     [COMPONENT_POSITIONAL_PARAMS]: positionalParams,
     [COMPONENT_CELL]: true
   };
@@ -117,6 +117,6 @@ function getPositionalParams(container, componentPath) {
   }
 }
 
-export function mergeHash(original, updates) {
-  return assign(original, updates);
+export function mergeInNewHash(original, updates) {
+  return assign({}, original, updates);
 }

--- a/packages/ember-htmlbars/lib/keywords/element-component.js
+++ b/packages/ember-htmlbars/lib/keywords/element-component.js
@@ -4,7 +4,7 @@ import {
   COMPONENT_POSITIONAL_PARAMS,
   COMPONENT_HASH,
   isComponentCell,
-  mergeHash,
+  mergeInNewHash,
 } from  './closure-component';
 import { processPositionalParams } from 'ember-htmlbars/utils/extract-positional-params';
 
@@ -63,7 +63,7 @@ function render(morph, env, scope, [path, ...params], hash, template, inverse, v
     // This needs to be done in each nesting level to avoid raising assertions
     processPositionalParams(null, positionalParams, params, hash);
     params = [];
-    hash = mergeHash(closureComponent[COMPONENT_HASH], hash);
+    hash = mergeInNewHash(closureComponent[COMPONENT_HASH], hash);
   }
 
   let templates = { default: template, inverse };

--- a/packages/ember-htmlbars/tests/helpers/closure_component_test.js
+++ b/packages/ember-htmlbars/tests/helpers/closure_component_test.js
@@ -385,4 +385,25 @@ if (isEnabled('ember-contextual-components')) {
     runAppend(component);
     equal(component.$().text(), expectedText, '-looked-up component rendered');
   });
+
+  QUnit.test('adding parameters to a closure component\'s instance does not add it to other instances', function(assert) {
+    registry.register(
+      'template:components/select-box',
+      compile('{{yield (hash option=(component "select-box-option"))}}')
+    );
+
+    registry.register(
+      'template:components/select-box-option',
+      compile('{{label}}')
+    );
+
+    let template = compile(
+      '{{#select-box as |sb|}}{{sb.option label="Foo"}}{{sb.option}}{{/select-box}}'
+    );
+
+    component = Component.extend({ container, template }).create();
+
+    runAppend(component);
+    equal(component.$().text(), 'Foo', 'there is only one Foo');
+  });
 }


### PR DESCRIPTION
When merging two parameters hashes coming from components/closure components we
want them to be merged into a new hash. This refactors does not only make this
happen but it changes `mergeHash` into `mergeInNewHah` to be explicit about
this.

Fix #12537
