### PR TITLE
Remove `ember-testing-checkbox-helpers` feature

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -18,34 +18,6 @@ for a detailed explanation.
   serially and call `reset()` each time), as well as being critical to
   for FastBoot.
 
-* `ember-testing-checkbox-helpers`
-
-  Add `check` and `uncheck` test helpers.
-
-  `check`:
-
-  Checks a checkbox. Ensures the presence of the `checked` attribute
-
-  Example:
-
-  ```javascript
-  check('#remember-me').then(function() {
-    // assert something
-  });
-  ```
-
-  `uncheck`:
-
-  Unchecks a checkbox. Ensures the absence of the `checked` attribute
-
-  Example:
-
-  ```javascript
-  uncheck('#remember-me').then(function() {
-    // assert something
-  });
-  ```
-
 * `ember-htmlbars-component-generation`
 
   Enables HTMLBars compiler to interpret `<x-foo></x-foo>` as a component

--- a/features.json
+++ b/features.json
@@ -2,7 +2,6 @@
   "features": {
     "features-stripped-test": null,
     "ember-htmlbars-component-generation": null,
-    "ember-testing-checkbox-helpers": null,
     "ember-application-visit": null,
     "ember-routing-route-configured-query-params": null,
     "ember-libraries-isregistered": null,

--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -1,5 +1,3 @@
-import { assert } from 'ember-metal/debug';
-import isEnabled from 'ember-metal/features';
 import { get } from 'ember-metal/property_get';
 import EmberError from 'ember-metal/error';
 import run from 'ember-metal/run_loop';
@@ -87,38 +85,6 @@ function click(app, selector, context) {
 
   run($el, 'mouseup');
   run($el, 'click');
-
-  return app.testHelpers.wait();
-}
-
-function check(app, selector, context) {
-  var $el = app.testHelpers.findWithAssert(selector, context);
-  var type = $el.prop('type');
-
-  assert(
-    `To check '${selector}', the input must be a checkbox`,
-    type === 'checkbox'
-  );
-
-  if (!$el.prop('checked')) {
-    app.testHelpers.click(selector, context);
-  }
-
-  return app.testHelpers.wait();
-}
-
-function uncheck(app, selector, context) {
-  var $el = app.testHelpers.findWithAssert(selector, context);
-  var type = $el.prop('type');
-
-  assert(
-    `To uncheck '${selector}', the input must be a checkbox`,
-    type === 'checkbox'
-  );
-
-  if ($el.prop('checked')) {
-    app.testHelpers.click(selector, context);
-  }
 
   return app.testHelpers.wait();
 }
@@ -284,45 +250,6 @@ asyncHelper('visit', visit);
 */
 asyncHelper('click', click);
 
-if (isEnabled('ember-testing-checkbox-helpers')) {
-  /**
-    Checks a checkbox. Ensures the presence of the `checked` attribute
-
-    Example:
-
-    ```javascript
-    check('#remember-me').then(function() {
-      // assert something
-    });
-    ```
-
-    @method check
-    @param {String} selector jQuery selector finding an `input[type="checkbox"]`
-    element on the DOM to check
-    @return {RSVP.Promise}
-    @private
-  */
-  asyncHelper('check', check);
-
-  /**
-    Unchecks a checkbox. Ensures the absence of the `checked` attribute
-
-    Example:
-
-    ```javascript
-    uncheck('#remember-me').then(function() {
-     // assert something
-    });
-    ```
-
-    @method check
-    @param {String} selector jQuery selector finding an `input[type="checkbox"]`
-    element on the DOM to uncheck
-    @return {RSVP.Promise}
-    @private
-  */
-  asyncHelper('uncheck', uncheck);
-}
 /**
   Simulates a key event, e.g. `keypress`, `keydown`, `keyup` with the desired keyCode
 

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -1,7 +1,6 @@
 import Ember from 'ember-metal/core';
 import Route from 'ember-routing/system/route';
 import Controller from 'ember-runtime/controllers/controller';
-import isEnabled from 'ember-metal/features';
 import run from 'ember-metal/run_loop';
 import EmberObject from 'ember-runtime/system/object';
 import RSVP from 'ember-runtime/ext/rsvp';
@@ -64,11 +63,6 @@ function assertHelpers(application, helperContainer, expected) {
   checkHelperPresent('fillIn', expected);
   checkHelperPresent('wait', expected);
   checkHelperPresent('triggerEvent', expected);
-
-  if (isEnabled('ember-testing-checkbox-helpers')) {
-    checkHelperPresent('check', expected);
-    checkHelperPresent('uncheck', expected);
-  }
 }
 
 function assertNoHelpers(application, helperContainer) {
@@ -646,100 +640,6 @@ QUnit.test('`fillIn` fires `input` and `change` events in the proper order', fun
 
   return wait();
 });
-
-if (isEnabled('ember-testing-checkbox-helpers')) {
-  QUnit.test('`check` ensures checkboxes are `checked` state for checkboxes', function() {
-    expect(2);
-    var check, find, visit, andThen, wait;
-
-    App.IndexView = EmberView.extend({
-      template: compile('<input type="checkbox" id="unchecked"><input type="checkbox" id="checked" checked>')
-    });
-
-    run(App, App.advanceReadiness);
-
-    check = App.testHelpers.check;
-    find = App.testHelpers.find;
-    visit = App.testHelpers.visit;
-    andThen = App.testHelpers.andThen;
-    wait = App.testHelpers.wait;
-
-    visit('/');
-    check('#unchecked');
-    check('#checked');
-    andThen(function() {
-      equal(find('#unchecked').is(':checked'), true, 'can check an unchecked checkbox');
-      equal(find('#checked').is(':checked'), true, 'can check a checked checkbox');
-    });
-
-    return wait();
-  });
-
-  QUnit.test('`uncheck` ensures checkboxes are not `checked`', function() {
-    expect(2);
-    var uncheck, find, visit, andThen, wait;
-
-    App.IndexView = EmberView.extend({
-      template: compile('<input type="checkbox" id="unchecked"><input type="checkbox" id="checked" checked>')
-    });
-
-    run(App, App.advanceReadiness);
-
-    uncheck = App.testHelpers.uncheck;
-    find = App.testHelpers.find;
-    visit = App.testHelpers.visit;
-    andThen = App.testHelpers.andThen;
-    wait = App.testHelpers.wait;
-
-    visit('/');
-    uncheck('#unchecked');
-    uncheck('#checked');
-    andThen(function() {
-      equal(find('#unchecked').is(':checked'), false, 'can uncheck an unchecked checkbox');
-      equal(find('#checked').is(':checked'), false, 'can uncheck a checked checkbox');
-    });
-
-    return wait();
-  });
-
-  QUnit.test('`check` asserts the selected inputs are checkboxes', function() {
-    var check, visit;
-
-    App.IndexView = EmberView.extend({
-      template: compile('<input type="text" id="text">')
-    });
-
-    run(App, App.advanceReadiness);
-
-    check = App.testHelpers.check;
-    visit = App.testHelpers.visit;
-
-    return visit('/').then(function() {
-      return check('#text').catch(function(error) {
-        ok(/must be a checkbox/.test(error.message));
-      });
-    });
-  });
-
-  QUnit.test('`uncheck` asserts the selected inputs are checkboxes', function() {
-    var visit, uncheck;
-
-    App.IndexView = EmberView.extend({
-      template: compile('<input type="text" id="text">')
-    });
-
-    run(App, App.advanceReadiness);
-
-    visit = App.testHelpers.visit;
-    uncheck = App.testHelpers.uncheck;
-
-    return visit('/').then(function() {
-      return uncheck('#text').catch(function(error) {
-        ok(/must be a checkbox/.test(error.message));
-      });
-    });
-  });
-}
 
 QUnit.test('`triggerEvent accepts an optional options hash and context', function() {
   expect(3);


### PR DESCRIPTION
The `ember-testing-checkbox-helpers` feature hasn't gained traction and
should be considered a failure as an Ember.js feature.

The helpers have been extracted into [thoughtbot/ralphs-little-helpers](https://github.com/thoughtbot/ralphs-little-helpers/pull/9).
