### PR TITLE
[BUG] Test identifying Ember 2.1 error-hook bubbling issues

### DIFF
--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -440,7 +440,6 @@ QUnit.test('Error events that aren\'t bubbled don\t throw application assertions
     },
     actions: {
       error(err) {
-        debugger
         equal(err.msg, 'did it broke?');
         return false;
       }

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -415,6 +415,41 @@ QUnit.test('Default error event moves into nested route', function() {
   equal(appController.get('currentPath'), 'grandma.error', 'Initial route fully loaded');
 });
 
+QUnit.test('Error events that aren\'t bubbled don\t throw application assertions', function() {
+  expect(2);
+
+  templates['grandma'] = 'GRANDMA {{outlet}}';
+
+  Router.map(function() {
+    this.route('grandma', function() {
+      this.route('mom', { resetNamespace: true }, function() {
+        this.route('sally');
+      });
+    });
+  });
+
+  App.ApplicationController = Ember.Controller.extend();
+
+  App.MomSallyRoute = Ember.Route.extend({
+    model() {
+      step(1, 'MomSallyRoute#model');
+
+      return Ember.RSVP.reject({
+        msg: 'did it broke?'
+      });
+    },
+    actions: {
+      error(err) {
+        debugger
+        equal(err.msg, 'did it broke?');
+        return false;
+      }
+    }
+  });
+
+  bootApplication('/grandma/mom/sally');
+});
+
 QUnit.test('Setting a query param during a slow transition should work', function() {
   var deferred = RSVP.defer();
 


### PR DESCRIPTION
This test addresses the difference in error bubbling between Ember 2.0 and 2.1

This test passes on Ember 2.0. It fails on Ember 2.1 because even though
the error is not bubbled, the application throws the handled error.

This is contrary to what the documentation indicates.

Full details about this issue are here: https://github.com/emberjs/ember.js/issues/12547

Obviously, more changes are necessary to either update the documentation, or make this test pass.
