### PR TITLE
[BUGFIX release] mark handled errors and dont reraise

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -18,6 +18,7 @@ import {
   stashParamNames,
   calculateCacheKey
 } from 'ember-routing/utils';
+import { guidFor } from 'ember-metal/utils';
 import RouterState from './router_state';
 import { getOwner } from 'container/owner';
 
@@ -32,6 +33,7 @@ import 'router/transition';
 function K() { return this; }
 
 var slice = [].slice;
+
 
 /**
   The `Ember.Router` class manages the application state and URLs. Refer to
@@ -283,8 +285,7 @@ var EmberRouter = EmberObject.extend(Evented, {
 
   _doURLTransition(routerJsMethod, url) {
     var transition = this.router[routerJsMethod](url || '/');
-    didBeginTransition(transition, this);
-    return transition;
+    return didBeginTransition(transition, this);
   },
 
   transitionTo(...args) {
@@ -708,6 +709,24 @@ var EmberRouter = EmberObject.extend(Evented, {
       run.cancel(this._slowTransitionTimer);
     }
     this._slowTransitionTimer = null;
+  },
+
+  _handledErrors: computed(function() {
+    return {};
+  }),
+
+  // These three helper functions are used to ensure errors aren't
+  // re-raised if they're handled in a route's error action.
+  _markErrorAsHandled(error) {
+    this.get('_handledErrors')[error] = true;
+  },
+
+  _isErrorHandled(error) {
+    return this.get('_handledErrors')[error];
+  },
+
+  _clearHandledError(error) {
+    delete this.get('_handledErrors')[error];
   }
 });
 
@@ -849,6 +868,7 @@ function routeHasBeenDefined(router, name) {
          (owner.hasRegistration(`template:${name}`) || owner.hasRegistration(`route:${name}`));
 }
 
+
 function triggerEvent(handlerInfos, ignoreFailure, args) {
   var name = args.shift();
 
@@ -868,6 +888,11 @@ function triggerEvent(handlerInfos, ignoreFailure, args) {
       if (handler.actions[name].apply(handler, args) === true) {
         eventWasHandled = true;
       } else {
+        // Should only hit here if a non-bubbling error action is triggered on a route.
+        if (name === 'error') {
+          var errorId = guidFor(args[0]);
+          handler.router._markErrorAsHandled(errorId);
+        }
         return;
       }
     }
@@ -1031,6 +1056,16 @@ function didBeginTransition(transition, router) {
     router.set('currentState', routerState);
   }
   router.set('targetState', routerState);
+
+  return transition.catch(function(error) {
+    var errorId = guidFor(error);
+
+    if (router._isErrorHandled(errorId)) {
+      router._clearHandledError(errorId);
+    } else {
+      throw error;
+    }
+  });
 }
 
 function resemblesURL(str) {

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1022,6 +1022,7 @@ QUnit.test('The Special page returning an error invokes SpecialRoute\'s error ha
     actions: {
       error(reason) {
         equal(reason, 'Setup error', 'SpecialRoute#error received the error thrown from setup');
+        return true;
       }
     }
   });
@@ -1059,6 +1060,7 @@ function testOverridableErrorHandler(handlersName) {
   attrs[handlersName] = {
     error(reason) {
       equal(reason, 'Setup error', 'error was correctly passed to custom ApplicationRoute handler');
+      return true;
     }
   };
 

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -415,6 +415,40 @@ QUnit.test('Default error event moves into nested route', function() {
   equal(appController.get('currentPath'), 'grandma.error', 'Initial route fully loaded');
 });
 
+QUnit.test('Error events that aren\'t bubbled don\t throw application assertions', function() {
+  expect(2);
+
+  templates['grandma'] = 'GRANDMA {{outlet}}';
+
+  Router.map(function() {
+    this.route('grandma', function() {
+      this.route('mom', { resetNamespace: true }, function() {
+        this.route('sally');
+      });
+    });
+  });
+
+  App.ApplicationController = Ember.Controller.extend();
+
+  App.MomSallyRoute = Ember.Route.extend({
+    model() {
+      step(1, 'MomSallyRoute#model');
+
+      return Ember.RSVP.reject({
+        msg: 'did it broke?'
+      });
+    },
+    actions: {
+      error(err) {
+        equal(err.msg, 'did it broke?');
+        return false;
+      }
+    }
+  });
+
+  bootApplication('/grandma/mom/sally');
+});
+
 QUnit.test('Setting a query param during a slow transition should work', function() {
   var deferred = RSVP.defer();
 

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -449,6 +449,148 @@ QUnit.test('Error events that aren\'t bubbled don\t throw application assertions
   bootApplication('/grandma/mom/sally');
 });
 
+QUnit.test('Non-bubbled errors that re-throw aren\'t swallowed', function() {
+  expect(2);
+
+  templates['grandma'] = 'GRANDMA {{outlet}}';
+
+  Router.map(function() {
+    this.route('grandma', function() {
+      this.route('mom', { resetNamespace: true }, function() {
+        this.route('sally');
+      });
+    });
+  });
+
+  App.ApplicationController = Ember.Controller.extend();
+
+  App.MomSallyRoute = Ember.Route.extend({
+    model() {
+      step(1, 'MomSallyRoute#model');
+
+      return Ember.RSVP.reject({
+        msg: 'did it broke?'
+      });
+    },
+    actions: {
+      error(err) {
+        // returns undefined which is falsey
+        throw err;
+      }
+    }
+  });
+
+  throws(function() {
+    bootApplication('/grandma/mom/sally');
+  }, function(err) { return err.msg === 'did it broke?';});
+});
+
+QUnit.test('Handled errors that re-throw aren\'t swallowed', function() {
+  expect(4);
+
+  var handledError;
+
+  templates['grandma'] = 'GRANDMA {{outlet}}';
+
+  Router.map(function() {
+    this.route('grandma', function() {
+      this.route('mom', { resetNamespace: true }, function() {
+        this.route('sally');
+        this.route('this-route-throws');
+      });
+    });
+  });
+
+  App.ApplicationController = Ember.Controller.extend();
+
+  App.MomSallyRoute = Ember.Route.extend({
+    model() {
+      step(1, 'MomSallyRoute#model');
+
+      return Ember.RSVP.reject({
+        msg: 'did it broke?'
+      });
+    },
+    actions: {
+      error(err) {
+        step(2, 'MomSallyRoute#error');
+
+        handledError = err;
+
+        this.transitionTo('mom.this-route-throws');
+
+        // Marks error as handled
+        return false;
+      }
+    }
+  });
+
+  App.MomThisRouteThrowsRoute = Ember.Route.extend({
+    model() {
+      step(3, 'MomThisRouteThrows#model');
+
+      throw handledError;
+    }
+  });
+
+  throws(function() {
+    bootApplication('/grandma/mom/sally');
+  }, function(err) { return err.msg === 'did it broke?'; });
+});
+
+QUnit.test('Handled errors that are thrown through rejection aren\'t swallowed', function() {
+  expect(4);
+
+  var handledError;
+
+  templates['grandma'] = 'GRANDMA {{outlet}}';
+
+  Router.map(function() {
+    this.route('grandma', function() {
+      this.route('mom', { resetNamespace: true }, function() {
+        this.route('sally');
+        this.route('this-route-throws');
+      });
+    });
+  });
+
+  App.ApplicationController = Ember.Controller.extend();
+
+  App.MomSallyRoute = Ember.Route.extend({
+    model() {
+      step(1, 'MomSallyRoute#model');
+
+      return Ember.RSVP.reject({
+        msg: 'did it broke?'
+      });
+    },
+    actions: {
+      error(err) {
+        step(2, 'MomSallyRoute#error');
+
+        handledError = err;
+
+        this.transitionTo('mom.this-route-throws');
+
+        // Marks error as handled
+        return false;
+      }
+    }
+  });
+
+  App.MomThisRouteThrowsRoute = Ember.Route.extend({
+    model() {
+      step(3, 'MomThisRouteThrows#model');
+
+      return Ember.RSVP.reject(handledError);
+    }
+  });
+
+  throws(function() {
+    bootApplication('/grandma/mom/sally');
+  }, function(err) { return err.msg === 'did it broke?'; });
+});
+
 QUnit.test('Setting a query param during a slow transition should work', function() {
   var deferred = RSVP.defer();
 


### PR DESCRIPTION
Ember 2.1 introduced a regression where all errors during a transition
were thrown, even when those errors had been handled in a route's error
action. This PR adds a test to identify the regression, and adds some
logic and state to identify errors that have been handled, and not
reraise them, while maintaining the desired behaviour of throwing errors
that aren't handled.

This is especially valuable in any application that tests error
handling. Since all errors were being thrown regardless of handling,
failed assertions were being registered by qunit, and it became
impossible to test application flow that entered the error hook.

Further details about this issue are here: #12547
