### PR TITLE
Enforce const usage in module scope only.

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -2,6 +2,7 @@
   "esnext": true,
   "excludeFiles": ["ember-runtime/ext/rsvp.js"],
   "additionalRules": [ "lib/jscs-rules/*.js" ],
+  "disallowConstOutsideModuleScope": true,
   "disallowSpacesInsideArrayBrackets": "all",
   "disallowMultipleVarDeclWithAssignment": true,
   "disallowPaddingNewlinesInBlocks": true,

--- a/lib/jscs-rules/disallow-const-outside-module-scope.js
+++ b/lib/jscs-rules/disallow-const-outside-module-scope.js
@@ -1,0 +1,38 @@
+var assert = require('assert');
+
+module.exports = function() { };
+
+module.exports.prototype = {
+  configure: function(option) {
+    assert(option === true, this.getOptionName() + ' requires a true value');
+  },
+
+  getOptionName: function() {
+    return 'disallowConstOutsideModuleScope';
+  },
+
+  check: function(file, errors) {
+    file.iterateNodesByType('VariableDeclaration', function(node) {
+      if (node.parentNode.type === 'Program') {
+        // declaration is in root of module
+        return;
+      }
+
+      if (node.parentNode.type === 'ExportNamedDeclaration' && node.parentNode.parentNode.type === 'Program') {
+        // declaration is a `export const foo = 'asdf'` in root of the module
+        return;
+      }
+
+      for (var i = 0; i < node.declarations.length; i++) {
+        var thisDeclaration = node.declarations[i];
+
+        if (thisDeclaration.parentNode.kind === 'const') {
+          errors.add(
+            '`const` should only be used in module scope (not inside functions/blocks).',
+            node.loc.start
+          );
+        }
+      }
+    });
+  }
+};

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -537,11 +537,11 @@ if (isEnabled('ember-container-inject-owner')) {
   });
 } else {
   QUnit.test('A `container` property is appended to every instantiated object', function() {
-    const registry = new Registry();
-    const container = registry.container();
-    const PostController = factory();
+    let registry = new Registry();
+    let container = registry.container();
+    let PostController = factory();
     registry.register('controller:post', PostController);
-    const postController = container.lookup('controller:post');
+    let postController = container.lookup('controller:post');
 
     strictEqual(postController.container, container, '');
   });

--- a/packages/container/tests/test-helpers/build-owner.js
+++ b/packages/container/tests/test-helpers/build-owner.js
@@ -7,9 +7,10 @@ export default function buildOwner(props) {
   let Owner = EmberObject.extend(RegistryProxy, ContainerProxy, {
     init() {
       this._super(...arguments);
-      const registry = this.__registry__ = new Registry();
+      let registry = this.__registry__ = new Registry();
       this.__container__ = registry.container({ owner: this });
     }
   });
+
   return Owner.create(props);
 }

--- a/packages/ember-htmlbars/lib/hooks/has-helper.js
+++ b/packages/ember-htmlbars/lib/hooks/has-helper.js
@@ -5,7 +5,7 @@ export default function hasHelperHook(env, scope, helperName) {
     return true;
   }
 
-  const owner = env.owner;
+  let owner = env.owner;
   if (validateLazyHelperName(helperName, owner, env.hooks.keywords)) {
     var registrationName = 'helper:' + helperName;
     if (owner.hasRegistration(registrationName)) {

--- a/packages/ember-htmlbars/lib/keywords/closure-component.js
+++ b/packages/ember-htmlbars/lib/keywords/closure-component.js
@@ -64,7 +64,7 @@ function createClosureComponentCell(env, originalComponentPath, params, hash, la
 }
 
 function isValidComponentPath(env, path) {
-  const result = lookupComponent(env.owner, path);
+  let result = lookupComponent(env.owner, path);
 
   return !!(result.component || result.layout);
 }

--- a/packages/ember-htmlbars/lib/keywords/get.js
+++ b/packages/ember-htmlbars/lib/keywords/get.js
@@ -15,8 +15,8 @@ import {
 } from 'ember-metal/observer';
 
 function labelFor(source, key) {
-  const sourceLabel = source.label ? source.label : '';
-  const keyLabel = key.label ? key.label : '';
+  let sourceLabel = source.label ? source.label : '';
+  let keyLabel = key.label ? key.label : '';
   return `(get ${sourceLabel} ${keyLabel})`;
 }
 
@@ -34,7 +34,7 @@ let DynamicKeyStream = BasicStream.extend({
   },
 
   key() {
-    const key = this.keyDep.getValue();
+    let key = this.keyDep.getValue();
     if (typeof key === 'string') {
       return key;
     }
@@ -84,12 +84,12 @@ let DynamicKeyStream = BasicStream.extend({
 });
 
 const buildStream = function buildStream(params) {
-  const [objRef, pathRef] = params;
+  let [objRef, pathRef] = params;
 
   assert('The first argument to {{get}} must be a stream', isStream(objRef));
   assert('{{get}} requires at least two arguments', params.length > 1);
 
-  const stream = buildDynamicKeyStream(objRef, pathRef);
+  let stream = buildDynamicKeyStream(objRef, pathRef);
 
   return stream;
 };

--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -236,7 +236,7 @@ export function createComponent(_component, isAngleBracket, props, renderNode, e
   props.renderer = props.parentView ? props.parentView.renderer : env.owner.lookup('renderer:-dom');
   props._viewRegistry = props.parentView ? props.parentView._viewRegistry : env.owner.lookup('-view-registry:main');
 
-  const component = _component.create(props);
+  let component = _component.create(props);
 
   // for the fallback case
   if (!getOwner(component)) {

--- a/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
@@ -182,7 +182,7 @@ export function createOrUpdateComponent(component, options, createOptions, rende
 
     mergeBindings(props, snapshot);
 
-    const owner = options.parentView ? getOwner(options.parentView) : env.owner;
+    let owner = options.parentView ? getOwner(options.parentView) : env.owner;
 
     setOwner(props, owner);
     props.renderer = options.parentView ? options.parentView.renderer : owner && owner.lookup('renderer:-dom');

--- a/packages/ember-htmlbars/lib/system/lookup-helper.js
+++ b/packages/ember-htmlbars/lib/system/lookup-helper.js
@@ -36,7 +36,7 @@ export function findHelper(name, view, env) {
   var helper = env.helpers[name];
 
   if (!helper) {
-    const owner = env.owner;
+    let owner = env.owner;
     if (validateLazyHelperName(name, owner, env.hooks.keywords)) {
       var helperName = 'helper:' + name;
       if (owner.hasRegistration(helperName)) {

--- a/packages/ember-htmlbars/lib/utils/extract-positional-params.js
+++ b/packages/ember-htmlbars/lib/utils/extract-positional-params.js
@@ -11,7 +11,7 @@ export default function extractPositionalParams(renderNode, component, params, a
 }
 
 export function processPositionalParams(renderNode, positionalParams, params, attrs) {
-  const isNamed = typeof positionalParams === 'string';
+  let isNamed = typeof positionalParams === 'string';
 
   if (isNamed) {
     processRestPositionalParameters(renderNode, positionalParams, params, attrs);

--- a/packages/ember-htmlbars/lib/utils/is-component.js
+++ b/packages/ember-htmlbars/lib/utils/is-component.js
@@ -15,7 +15,7 @@ import { isStream } from 'ember-metal/streams/utils';
  name was found in the container.
 */
 export default function isComponent(env, scope, path) {
-  const owner = env.owner;
+  let owner = env.owner;
   if (!owner) { return false; }
   if (typeof path === 'string') {
     if (CONTAINS_DOT_CACHE.get(path)) {

--- a/packages/ember-htmlbars/tests/compat/view_helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/view_helper_test.js
@@ -36,7 +36,7 @@ QUnit.module('ember-htmlbars: compat - view helper', {
 });
 
 QUnit.test('using the view helper fails assertion', function(assert) {
-  const ViewClass = EmberView.extend({
+  let ViewClass = EmberView.extend({
     template: compile('fooView')
   });
   owner.register('view:foo', ViewClass);
@@ -67,7 +67,7 @@ QUnit.module('ember-htmlbars: compat - view helper [LEGACY]', {
 });
 
 QUnit.test('using the view helper with a string (inline form) fails assertion [LEGACY]', function(assert) {
-  const ViewClass = EmberView.extend({
+  let ViewClass = EmberView.extend({
     template: compile('fooView')
   });
   owner.register('view:foo', ViewClass);
@@ -85,7 +85,7 @@ QUnit.test('using the view helper with a string (inline form) fails assertion [L
 });
 
 QUnit.test('using the view helper with a string (block form) fails assertion [LEGACY]', function(assert) {
-  const ViewClass = EmberView.extend({
+  let ViewClass = EmberView.extend({
     template: compile('Foo says: {{yield}}')
   });
   owner.register('view:foo', ViewClass);

--- a/packages/ember-htmlbars/tests/glimmer-component/render-test.js
+++ b/packages/ember-htmlbars/tests/glimmer-component/render-test.js
@@ -48,7 +48,7 @@ function renderComponent(tag, component) {
     .map(key => `${key}=${hash[key]}`)
     .join(' ');
 
-  const owner = buildOwner();
+  let owner = buildOwner();
   owner.register('component-lookup:main', ComponentLookup);
   owner.register(`component:${tag}`, implementation);
 

--- a/packages/ember-htmlbars/tests/integration/component_invocation_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_invocation_test.js
@@ -32,7 +32,7 @@ function commonTeardown() {
 }
 
 function appendViewFor(template, hash={}) {
-  const view = EmberView.extend({
+  let view = EmberView.extend({
     [OWNER]: owner,
     template: compile(template)
   }).create(hash);

--- a/packages/ember-htmlbars/tests/system/lookup-helper_test.js
+++ b/packages/ember-htmlbars/tests/system/lookup-helper_test.js
@@ -14,7 +14,7 @@ function generateEnv(helpers, owner) {
 }
 
 function generateOwner() {
-  const owner = buildOwner();
+  let owner = buildOwner();
 
   owner.register('component-lookup:main', ComponentLookup);
 
@@ -58,7 +58,7 @@ QUnit.test('does not lookup in the container if the name does not contain a dash
 });
 
 QUnit.test('does a lookup in the container if the name contains a dash (and helper is not found in env)', function() {
-  const owner = generateOwner();
+  let owner = generateOwner();
   var env = generateEnv(null, owner);
   var view = {
     [OWNER]: owner
@@ -73,7 +73,7 @@ QUnit.test('does a lookup in the container if the name contains a dash (and help
 });
 
 QUnit.test('does a lookup in the container if the name is found in knownHelpers', function() {
-  const owner = generateOwner();
+  let owner = generateOwner();
   var env = generateEnv(null, owner);
   var view = {
     [OWNER]: owner
@@ -90,7 +90,7 @@ QUnit.test('does a lookup in the container if the name is found in knownHelpers'
 
 QUnit.test('looks up a shorthand helper in the container', function() {
   expect(2);
-  const owner = generateOwner();
+  let owner = generateOwner();
   var env = generateEnv(null, owner);
   var view = {
     [OWNER]: owner
@@ -113,7 +113,7 @@ QUnit.test('looks up a shorthand helper in the container', function() {
 
 QUnit.test('fails with a useful error when resolving a function', function() {
   expect(1);
-  const owner = generateOwner();
+  let owner = generateOwner();
   var env = generateEnv(null, owner);
   var view = {
     [OWNER]: owner

--- a/packages/ember-htmlbars/tests/utils.js
+++ b/packages/ember-htmlbars/tests/utils.js
@@ -6,7 +6,7 @@ function registerAstPlugin(plugin) {
 }
 
 function removeAstPlugin(plugin) {
-  const index = plugins['ast'].indexOf(plugin);
+  let index = plugins['ast'].indexOf(plugin);
   plugins['ast'].splice(index, 1);
 }
 

--- a/packages/ember-metal/lib/injected_property.js
+++ b/packages/ember-metal/lib/injected_property.js
@@ -25,7 +25,7 @@ function InjectedProperty(type, name) {
 
 function injectedPropertyGet(keyName) {
   var desc = this[keyName];
-  const owner = getOwner(this);
+  let owner = getOwner(this);
 
   assert(`InjectedProperties should be defined with the Ember.inject computed property macros.`, desc && desc.isDescriptor && desc.type);
   assert(`Attempting to lookup an injected property on an object without a container, ensure that the object was instantiated via a container.`, owner);

--- a/packages/ember-routing-htmlbars/tests/helpers/closure_action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/closure_action_test.js
@@ -120,10 +120,10 @@ QUnit.test('action should be called on the correct scope', function(assert) {
 QUnit.test('arguments to action are passed, curry', function(assert) {
   assert.expect(4);
 
-  const first = 'mitch';
-  const second =  'martin';
-  const third = 'matt';
-  const fourth = 'wacky wycats';
+  let first = 'mitch';
+  let second =  'martin';
+  let third = 'matt';
+  let fourth = 'wacky wycats';
 
   innerComponent = EmberComponent.extend({
     fireAction() {
@@ -155,7 +155,7 @@ QUnit.test('arguments to action are passed, curry', function(assert) {
 QUnit.test('arguments to action are bound', function(assert) {
   assert.expect(1);
 
-  const value = 'lazy leah';
+  let value = 'lazy leah';
 
   innerComponent = EmberComponent.extend({
     fireAction() {
@@ -186,9 +186,9 @@ QUnit.test('arguments to action are bound', function(assert) {
 QUnit.test('array arguments are passed correctly to action', function(assert) {
   assert.expect(3);
 
-  const first = 'foo';
-  const second = [3, 5];
-  const third = [4, 9];
+  let first = 'foo';
+  let second = [3, 5];
+  let third = [4, 9];
 
   innerComponent = EmberComponent.extend({
     fireAction() {
@@ -384,7 +384,7 @@ QUnit.test('action can create closures over actions with target', function(asser
 QUnit.test('value can be used with action over actions', function(assert) {
   assert.expect(1);
 
-  const newValue = 'yelping yehuda';
+  let newValue = 'yelping yehuda';
 
   innerComponent = EmberComponent.extend({
     fireAction() {
@@ -419,7 +419,7 @@ QUnit.test('value can be used with action over actions', function(assert) {
 QUnit.test('action will read the value of a first property', function(assert) {
   assert.expect(1);
 
-  const newValue = 'irate igor';
+  let newValue = 'irate igor';
 
   innerComponent = EmberComponent.extend({
     fireAction() {
@@ -449,7 +449,7 @@ QUnit.test('action will read the value of a first property', function(assert) {
 QUnit.test('action will read the value of a curried first argument property', function(assert) {
   assert.expect(1);
 
-  const newValue = 'kissing kris';
+  let newValue = 'kissing kris';
 
   innerComponent = EmberComponent.extend({
     fireAction() {

--- a/packages/ember-routing-htmlbars/tests/helpers/render_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/render_test.js
@@ -170,7 +170,7 @@ QUnit.test('{{render}} helper with a supplied model should not fire observers on
   var post = {
     title: 'Rails is omakase'
   };
-  const controller = EmberController.create({
+  let controller = EmberController.create({
     [OWNER]: appInstance,
     post: post
   });
@@ -197,9 +197,9 @@ QUnit.test('{{render}} helper with a supplied model should not fire observers on
 });
 
 QUnit.test('{{render}} helper should raise an error when a given controller name does not resolve to a controller', function() {
-  const template = '<h1>HI</h1>{{render "home" controller="postss"}}';
-  const Controller = EmberController.extend();
-  const controller = Controller.create({
+  let template = '<h1>HI</h1>{{render "home" controller="postss"}}';
+  let Controller = EmberController.extend();
+  let controller = Controller.create({
     [OWNER]: appInstance
   });
 
@@ -221,7 +221,7 @@ QUnit.test('{{render}} helper should raise an error when a given controller name
 QUnit.test('{{render}} helper should render with given controller', function() {
   var template = '{{render "home" controller="posts"}}';
   var Controller = EmberController.extend();
-  const controller = Controller.create({
+  let controller = Controller.create({
     [OWNER]: appInstance
   });
   var id = 0;
@@ -251,7 +251,7 @@ QUnit.test('{{render}} helper should render with given controller', function() {
 QUnit.test('{{render}} helper should render a template without a model only once', function() {
   var template = '<h1>HI</h1>{{render \'home\'}}<hr/>{{render \'home\'}}';
   var Controller = EmberController.extend();
-  const controller = Controller.create({
+  let controller = Controller.create({
     [OWNER]: appInstance
   });
 
@@ -360,7 +360,7 @@ QUnit.test('{{render}} helper should not leak controllers', function() {
 QUnit.test('{{render}} helper should not treat invocations with falsy contexts as context-less', function() {
   var template = '<h1>HI</h1> {{render \'post\' zero}} {{render \'post\' nonexistent}}';
 
-  const controller = EmberController.create({
+  let controller = EmberController.create({
     [OWNER]: appInstance,
     zero: false
   });
@@ -442,8 +442,8 @@ QUnit.test('{{render}} helper should render templates both with and without mode
 
 QUnit.test('{{render}} helper should link child controllers to the parent controller', function() {
   let parentTriggered = 0;
-  const template = '<h1>HI</h1>{{render "posts"}}';
-  const Controller = EmberController.extend({
+  let template = '<h1>HI</h1>{{render "posts"}}';
+  let Controller = EmberController.extend({
     actions: {
       parentPlease() {
         parentTriggered++;
@@ -451,7 +451,7 @@ QUnit.test('{{render}} helper should link child controllers to the parent contro
     },
     role: 'Mom'
   });
-  const controller = Controller.create({
+  let controller = Controller.create({
     [OWNER]: appInstance
   });
 
@@ -480,9 +480,9 @@ QUnit.test('{{render}} helper should link child controllers to the parent contro
 });
 
 QUnit.test('{{render}} helper should be able to render a template again when it was removed', function() {
-  const CoreOutlet = appInstance._lookupFactory('view:core-outlet');
-  const Controller = EmberController.extend();
-  const controller = Controller.create({
+  let CoreOutlet = appInstance._lookupFactory('view:core-outlet');
+  let Controller = EmberController.extend();
+  let controller = Controller.create({
     [OWNER]: appInstance
   });
 

--- a/packages/ember-routing-htmlbars/tests/utils.js
+++ b/packages/ember-routing-htmlbars/tests/utils.js
@@ -42,14 +42,14 @@ function resolverFor(namespace) {
 
 function buildAppInstance() {
   let registry;
-  const App = EmberObject.extend(RegistryProxy, ContainerProxy, {
+  let App = EmberObject.extend(RegistryProxy, ContainerProxy, {
     init() {
       this._super(...arguments);
       registry = this.__registry__ = new Registry();
       this.__container__ = registry.container({ owner: this });
     }
   });
-  const appInstance = App.create();
+  let appInstance = App.create();
 
   registry.resolver = resolverFor(App);
 

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -2134,7 +2134,7 @@ function buildRenderOptions(route, namePassed, isDefaultRender, name, options) {
     controller.set('model', options.model);
   }
 
-  const owner = getOwner(route);
+  let owner = getOwner(route);
   viewName = options && options.view || namePassed && name || route.viewName || name;
   ViewClass = owner._lookupFactory(`view:${viewName}`);
   template = owner.lookup(`template:${templateName}`);

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -247,7 +247,7 @@ var EmberRouter = EmberObject.extend(Evented, {
       defaultParentState = ownState;
     }
     if (!this._toplevelView) {
-      const owner = getOwner(this);
+      let owner = getOwner(this);
       var OutletView = owner._lookupFactory('view:-outlet');
       this._toplevelView = OutletView.create();
       var instance = owner.lookup('-application-instance:main');
@@ -449,7 +449,7 @@ var EmberRouter = EmberObject.extend(Evented, {
   _setupLocation() {
     var location = get(this, 'location');
     var rootURL = get(this, 'rootURL');
-    const owner = getOwner(this);
+    let owner = getOwner(this);
 
     if ('string' === typeof location && owner) {
       var resolvedLocation = owner.lookup(`location:${location}`);
@@ -488,7 +488,7 @@ var EmberRouter = EmberObject.extend(Evented, {
 
   _getHandlerFunction() {
     var seen = new EmptyObject();
-    const owner = getOwner(this);
+    let owner = getOwner(this);
     var DefaultRoute = owner._lookupFactory('route:basic');
 
     return (name) => {
@@ -844,7 +844,7 @@ function findChildRouteName(parentRoute, originatingChildRoute, name) {
 }
 
 function routeHasBeenDefined(router, name) {
-  const owner = getOwner(router);
+  let owner = getOwner(router);
   return router.hasRoute(name) &&
          (owner.hasRegistration(`template:${name}`) || owner.hasRegistration(`route:${name}`));
 }

--- a/packages/ember-routing/tests/location/auto_location_test.js
+++ b/packages/ember-routing/tests/location/auto_location_test.js
@@ -36,13 +36,13 @@ function mockBrowserHistory(overrides) {
 }
 
 function createLocation(location, history) {
-  const owner = buildOwner();
+  let owner = buildOwner();
 
   owner.register('location:history', HistoryLocation);
   owner.register('location:hash', HashLocation);
   owner.register('location:none', NoneLocation);
 
-  const autolocation = AutoLocation.create({
+  let autolocation = AutoLocation.create({
     [OWNER]: owner,
     location: location,
     history: history,

--- a/packages/ember-routing/tests/system/controller_for_test.js
+++ b/packages/ember-routing/tests/system/controller_for_test.js
@@ -12,7 +12,7 @@ import {
 import buildOwner from 'container/tests/test-helpers/build-owner';
 
 var buildInstance = function(namespace) {
-  const owner = buildOwner();
+  let owner = buildOwner();
 
   owner.__registry__.resolver = resolverFor(namespace);
   owner.registerOptionsForType('view', { singleton: false });

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -55,7 +55,7 @@ QUnit.test('\'store\' can be injected by data persistence frameworks', function(
   expect(8);
   runDestroy(route);
 
-  const owner = buildOwner();
+  let owner = buildOwner();
 
   var post = {
     id: 1
@@ -85,7 +85,7 @@ QUnit.test('assert if \'store.find\' method is not found', function() {
   expect(1);
   runDestroy(route);
 
-  const owner = buildOwner();
+  let owner = buildOwner();
   var Post = EmberObject.extend();
 
   owner.register('route:index', EmberRoute);
@@ -102,7 +102,7 @@ QUnit.test('asserts if model class is not found', function() {
   expect(1);
   runDestroy(route);
 
-  const owner = buildOwner();
+  let owner = buildOwner();
   owner.register('route:index', EmberRoute);
 
   route = owner.lookup('route:index');
@@ -117,7 +117,7 @@ QUnit.test('\'store\' does not need to be injected', function() {
 
   runDestroy(route);
 
-  const owner = buildOwner();
+  let owner = buildOwner();
 
   owner.register('route:index', EmberRoute);
 
@@ -133,12 +133,12 @@ QUnit.test('\'store\' does not need to be injected', function() {
 QUnit.test('modelFor doesn\'t require the router', function() {
   expect(1);
 
-  const owner = buildOwner();
+  let owner = buildOwner();
   setOwner(route, owner);
 
-  const foo = { name: 'foo' };
+  let foo = { name: 'foo' };
 
-  const FooRoute = EmberRoute.extend({
+  let FooRoute = EmberRoute.extend({
     currentModel: foo
   });
 
@@ -308,7 +308,7 @@ QUnit.test('controllerFor uses route\'s controllerName if specified', function()
 QUnit.module('Route injected properties');
 
 QUnit.test('services can be injected into routes', function() {
-  const owner = buildOwner();
+  let owner = buildOwner();
 
   owner.register('route:application', EmberRoute.extend({
     authService: inject.service('auth')

--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -14,7 +14,7 @@ import { A as emberA } from 'ember-runtime/system/native_array';
 
 function reduceMacro(dependentKey, callback, initialValue) {
   return computed(`${dependentKey}.[]`, function() {
-    const arr = get(this, dependentKey);
+    let arr = get(this, dependentKey);
 
     if (arr === null || typeof arr !== 'object') { return initialValue; }
 

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -431,7 +431,7 @@ QUnit.test('properties values can be replaced', function() {
   ['uniq', uniq],
   ['union', union]
 ].forEach((tuple) => {
-  const [name, macro] = tuple;
+  let [name, macro] = tuple;
 
   QUnit.module(`computed.${name}`, {
     setup() {

--- a/packages/ember-runtime/tests/controllers/controller_test.js
+++ b/packages/ember-runtime/tests/controllers/controller_test.js
@@ -155,7 +155,7 @@ QUnit.module('Controller injected properties');
 if (!EmberDev.runningProdBuild) {
   QUnit.test('defining a controller on a non-controller should fail assertion', function() {
     expectAssertion(function() {
-      const owner = buildOwner();
+      let owner = buildOwner();
 
       var AnObject = Object.extend({
         foo: inject.controller('bar')
@@ -169,7 +169,7 @@ if (!EmberDev.runningProdBuild) {
 }
 
 QUnit.test('controllers can be injected into controllers', function() {
-  const owner = buildOwner();
+  let owner = buildOwner();
 
   owner.register('controller:post', Controller.extend({
     postsController: inject.controller('posts')
@@ -184,7 +184,7 @@ QUnit.test('controllers can be injected into controllers', function() {
 });
 
 QUnit.test('services can be injected into controllers', function() {
-  const owner = buildOwner();
+  let owner = buildOwner();
 
   owner.register('controller:application', Controller.extend({
     authService: inject.service('auth')

--- a/packages/ember-runtime/tests/inject_test.js
+++ b/packages/ember-runtime/tests/inject_test.js
@@ -26,7 +26,7 @@ if (!EmberDev.runningProdBuild) {
       ok(true, 'should call validation method');
     });
 
-    const owner = buildOwner();
+    let owner = buildOwner();
 
     var AnObject = Object.extend({
       bar: inject.foo(),
@@ -39,7 +39,7 @@ if (!EmberDev.runningProdBuild) {
 }
 
 QUnit.test('attempting to inject a nonexistent container key should error', function() {
-  const owner = buildOwner();
+  let owner = buildOwner();
   var AnObject = Object.extend({
     foo: new InjectedProperty('bar', 'baz')
   });

--- a/packages/ember-template-compiler/lib/plugins/assert-no-view-and-controller-paths.js
+++ b/packages/ember-template-compiler/lib/plugins/assert-no-view-and-controller-paths.js
@@ -56,7 +56,7 @@ function assertPath(moduleName, node, path) {
     `Using \`{{${path && path.type === 'PathExpression' && path.parts[0]}}}\` or any path based on it ${calculateLocationDisplay(moduleName, node.loc)}has been removed in Ember 2.0`, () => {
       let noAssertion = true;
 
-      const viewKeyword = path && path.type === 'PathExpression' && path.parts && path.parts[0];
+      let viewKeyword = path && path.type === 'PathExpression' && path.parts && path.parts[0];
       if (viewKeyword === 'view') {
         noAssertion = Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT;
       } else if (viewKeyword === 'controller') {

--- a/packages/ember-template-compiler/lib/plugins/assert-no-view-helper.js
+++ b/packages/ember-template-compiler/lib/plugins/assert-no-view-helper.js
@@ -30,7 +30,7 @@ AssertNoViewHelper.prototype.transform = function AssertNoViewHelper_transform(a
 };
 
 function assertHelper(moduleName, node) {
-  const paramValue = node.params.length && node.params[0].value;
+  let paramValue = node.params.length && node.params[0].value;
 
   if (!paramValue) {
     return;

--- a/packages/ember-template-compiler/lib/plugins/transform-input-on-to-onEvent.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-input-on-to-onEvent.js
@@ -36,10 +36,10 @@ function TransformInputOnToOnEvent(options) {
   @param {AST} ast The AST to be transformed.
 */
 TransformInputOnToOnEvent.prototype.transform = function TransformInputOnToOnEvent_transform(ast) {
-  const pluginContext = this;
-  const b = pluginContext.syntax.builders;
-  const walker = new pluginContext.syntax.Walker();
-  const moduleName = pluginContext.options.moduleName;
+  let pluginContext = this;
+  let b = pluginContext.syntax.builders;
+  let walker = new pluginContext.syntax.Walker();
+  let moduleName = pluginContext.options.moduleName;
 
   walker.visit(ast, function(node) {
     if (pluginContext.validate(node)) {

--- a/packages/ember-views/lib/mixins/view_child_views_support.js
+++ b/packages/ember-views/lib/mixins/view_child_views_support.js
@@ -86,7 +86,7 @@ export default Mixin.create({
       throw new TypeError('createChildViews first argument must exist');
     }
 
-    const owner = getOwner(this);
+    let owner = getOwner(this);
 
     if (maybeViewClass.isView && maybeViewClass.parentView === this && getOwner(maybeViewClass) === owner) {
       return maybeViewClass;

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -118,7 +118,7 @@ export default Mixin.create({
     if (!name) { return; }
     assert('templateNames are not allowed to contain periods: ' + name, name.indexOf('.') === -1);
 
-    const owner = getOwner(this);
+    let owner = getOwner(this);
 
     if (!owner) {
       throw new EmberError('Container was not found when looking up a views template. ' +

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -190,8 +190,8 @@ export default EmberObject.extend({
   setupHandler(rootElement, event, eventName) {
     var self = this;
 
-    const owner = getOwner(this);
-    const viewRegistry = owner && owner.lookup('-view-registry:main') || View.views;
+    let owner = getOwner(this);
+    let viewRegistry = owner && owner.lookup('-view-registry:main') || View.views;
 
     if (eventName === null) {
       return;

--- a/packages/ember-views/tests/views/component_test.js
+++ b/packages/ember-views/tests/views/component_test.js
@@ -231,7 +231,7 @@ QUnit.test('Calling sendAction on a component with multiple parameters', functio
 QUnit.module('Ember.Component - injected properties');
 
 QUnit.test('services can be injected into components', function() {
-  const owner = buildOwner();
+  let owner = buildOwner();
 
   owner.register('component:application', Component.extend({
     profilerService: inject.service('profiler')

--- a/packages/ember-views/tests/views/container_view_test.js
+++ b/packages/ember-views/tests/views/container_view_test.js
@@ -32,7 +32,7 @@ QUnit.module('Ember.ContainerView', {
 });
 
 QUnit.test('should be able to insert views after the DOM representation is created', function() {
-  const owner = buildOwner();
+  let owner = buildOwner();
 
   container = ContainerView.create({
     [OWNER]: owner,
@@ -87,7 +87,7 @@ QUnit.test('should be able to observe properties that contain child views', func
 });
 
 QUnit.test('childViews inherit their parents owner, and retain the original container even when moved', function() {
-  const owner = buildOwner();
+  let owner = buildOwner();
 
   container = ContainerView.create({
     [OWNER]: owner

--- a/packages/ember-views/tests/views/view/inject_test.js
+++ b/packages/ember-views/tests/views/view/inject_test.js
@@ -6,7 +6,7 @@ import buildOwner from 'container/tests/test-helpers/build-owner';
 QUnit.module('EmberView - injected properties');
 
 QUnit.test('services can be injected into views', function() {
-  const owner = buildOwner();
+  let owner = buildOwner();
 
   owner.register('view:application', View.extend({
     profilerService: inject.service('profiler')


### PR DESCRIPTION
Good:

``` js
const FOO = 'FOO';
```

Bad:

``` js
function derp() {
  const FOO = 'FOO';
}

if (false) {
  const BLAH = 'BLAH';
}
```
