### PR TITLE
Revert "[FEATURE ember-application-visit] Enable by default."

### DIFF
--- a/features.json
+++ b/features.json
@@ -2,7 +2,7 @@
   "features": {
     "features-stripped-test": null,
     "ember-htmlbars-component-generation": null,
-    "ember-application-visit": true,
+    "ember-application-visit": null,
     "ember-routing-route-configured-query-params": null,
     "ember-libraries-isregistered": null,
     "ember-debug-handlers": true,


### PR DESCRIPTION
This reverts commit afb6f274d34774be43a456754da490afcda0a63c.

Fixes #12572.

---

@chancancode - Do you think you can look into the failure so we can get it reenabled?
