### PR TITLE
Make acceptance helpers fire native events instead of jQuery ones.

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -59,3 +59,8 @@ for a detailed explanation.
 
   When the proper API's are implemented by the resolver in use this feature allows `{{x-foo}}` in a
   given routes template (say the `post` route) to lookup a component nested under `post`.
+
+* `ember-test-helpers-fire-native-events`
+
+  Makes ember test helpers (`fillIn`, `click`, `triggerEvent` ...) fire native javascript events instead
+  of `jQuery.Event`s, maching more closely app's real usage.

--- a/features.json
+++ b/features.json
@@ -3,6 +3,7 @@
     "features-stripped-test": null,
     "ember-htmlbars-component-generation": false,
     "ember-application-visit": true,
+    "ember-test-helpers-fire-native-events": true,
     "ember-routing-route-configured-query-params": null,
     "ember-libraries-isregistered": null,
     "ember-debug-handlers": true,


### PR DESCRIPTION
Following issue #12569

Goal: To fire events in relatively accurate and cross-browser way.

Simulate real events in pure javascript accurately is nearly impossible, but
this is a best effort. This fires 3 different kind of events:
- MouseEvents: click, dbclick, mousedown, mouseup, mouseenter, mouseleave, ...
- KeyEvents: keydown, keypress and keyup
- Events: Anything other than mouse or keyboard events falls in this generic kind of event.

This should probably cover 99% of use cases.

Caveats found:

I've only encountered 2 failing tests after this refactor, both related to the same problem:

```
triggerEvent('.input', 'keydown', { keyCode: 13 });
// ...
equal(event.keyCode, 13, 'options were passed');
```

It turns that `keyCode` is a reserved property that only works with keyboardEvents, so although the event has this property mixed, the wrapped jquery event does not copy that property if the original event is not a keyboard event. 
Seems very reasonable and probably that test was a bad example.
