### PR TITLE
Remove registering unncessary component

### DIFF
--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -159,6 +159,8 @@ let ApplicationInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
       let environment = options.toEnvironment();
 
       registry.register('-environment:main', environment, { instantiate: false });
+      registry.injection('view', '_environment', '-environment:main');
+      registry.injection('route', '_environment', '-environment:main');
 
       registry.register('renderer:-dom', {
         create() {

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -1352,12 +1352,6 @@ Application.reopenClass({
     registry.optionsForType('view', { singleton: false });
     registry.optionsForType('template', { instantiate: false });
 
-    if (isEnabled('ember-application-visit')) {
-      registry.register('-environment:main', environment, { instantiate: false });
-      registry.injection('view', '_environment', '-environment:main');
-      registry.injection('route', '_environment', '-environment:main');
-    }
-
     registry.register('application:main', namespace, { instantiate: false });
 
     registry.register('controller:basic', Controller, { instantiate: false });


### PR DESCRIPTION
When application-visit is enabled, both `renderer:-dom` and
`-environment:main` are always instance-specific, because they are
dependent on the boot options that are specified when creating the
instance. Therefore it is unncessary (and confusing) to register them on
the `Application` just to have them always overriden by something else on
the `ApplicationInstance`.

cc @krisselden 
