### PR TITLE
[FEATURE Ember.computed.same macro]

### DIFF
--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -265,6 +265,42 @@ export function equal(dependentKey, value) {
 }
 
 /**
+  A computed property that returns true if the provided two dependent properties
+  have the same value.
+
+  Example
+
+  ```javascript
+  var Hamster = Ember.Object.extend({
+    isSpy: Ember.computed.same('name', 'alias')
+  });
+
+  var hamster = Hamster.create({
+    name: 'Tomster'
+  });
+
+  hamster.get('isSpy'); // false
+  hamster.set('alias', 'Tomster');
+  hamster.get('isSpy'); // true
+  hamster.set('alias', 'J.J. Abrams');
+  hamster.get('isSpy'); // false
+  ```
+
+  @method same
+  @for Ember.computed
+  @param {String} dependentKey
+  @param {String} comparisonKey
+  @return {Ember.ComputedProperty} computed property that returns true if the
+  provided two dependent properties have the same value.
+  @public
+*/
+export function same(dependentKey, comparisonKey) {
+  return computed(dependentKey, comparisonKey, function() {
+    return get(this, dependentKey) === get(this, comparisonKey);
+  });
+}
+
+/**
   A computed property that returns true if the provided dependent property
   is greater than the provided value.
 

--- a/packages/ember-runtime/tests/computed/computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/computed_macros_test.js
@@ -6,6 +6,7 @@ import {
   bool,
   match,
   equal as computedEqual,
+  same,
   gt,
   gte,
   lt,
@@ -185,6 +186,17 @@ testBoth('computed.equal', function(get, set) {
   set(obj, 'name', 'Pierre');
 
   equal(get(obj, 'isPaul'), false, 'is not Paul anymore');
+});
+
+testBoth('computed.same', function(get, set) {
+  var obj = { name: 'Paul', alias: 'Paul' };
+  defineProperty(obj, 'realName', same('name', 'alias'));
+
+  equal(get(obj, 'realName'), true, 'is Paul');
+
+  set(obj, 'alias', 'Pierre');
+
+  equal(get(obj, 'realName'), false, 'has an alias');
 });
 
 testBoth('computed.gt', function(get, set) {


### PR DESCRIPTION
When working with applications, there are times when you want to check if two properties of an object hold the same value.

This pull request adds this as a new `same` macro with the following syntax:

``` js
var Hamster = Ember.Object.extend({
  isSpy: Ember.computed.same('name', 'alias')
});

var hamster = Hamster.create({
  name: 'Tomster'
});
```
