### PR TITLE
Allows the target for action functions

### DIFF
--- a/packages/ember-routing-htmlbars/lib/keywords/closure-action.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/closure-action.js
@@ -45,6 +45,12 @@ export default function closureAction(morph, env, scope, params, hash, template,
         if (!action) {
           throw new EmberError(`An action named '${actionName}' was not found in ${target}.`);
         }
+      } else if (actionType === 'function') {
+        // on-change={{action setName}}
+        if (hash.target) {
+          // on-change={{action alternativeComponent.setName target=alternativeComponent}}
+          target = read(hash.target);
+        }
       } else if (actionType !== 'function') {
         throw new EmberError(`An action could not be made for \`${rawAction.label}\` in ${target}. Please confirm that you are using either a quoted action name (i.e. \`(action '${rawAction.label}')\`) or a function available in ${target}.`);
       }

--- a/packages/ember-routing-htmlbars/tests/helpers/closure_action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/closure_action_test.js
@@ -381,6 +381,37 @@ QUnit.test('action can create closures over actions with target', function(asser
   });
 });
 
+QUnit.test('action can create closures over functions with target', function(assert) {
+  assert.expect(1);
+
+  innerComponent = EmberComponent.extend({
+    fireAction() {
+      this.attrs.submit();
+    }
+  }).create();
+
+  outerComponent = EmberComponent.extend({
+    layout: compile(`
+        {{view innerComponent submit=(action otherComponent.outerAction target=otherComponent)}}
+      `),
+    innerComponent,
+    otherComponent: computed(function() {
+      var obj = {
+        outerAction() {
+          assert.ok(this === obj, 'action called on otherComponent with correct context');
+        }
+      };
+      return obj;
+    })
+  }).create();
+
+  runAppend(outerComponent);
+
+  run(function() {
+    innerComponent.fireAction();
+  });
+});
+
 QUnit.test('value can be used with action over actions', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
Currently invocations `(action "actionName")`, `(action "actionName" target=serviceName)` and `(action funcName)` are possible. `(action serviceName.funcName)` is possible too but the function will run in the current scope.

This PR enables the target attribute for invocations when the action is a function.  With this PR, `(action serviceName.funcName target=serviceName)` runs in the serviceName context. `(action serviceName.funcName)` still runs in the current context.
