### PR TITLE
[BUGFIX beta] Guard against `null` `attrs` in getRoot hook.

### DIFF
--- a/packages/ember-htmlbars/lib/hooks/get-root.js
+++ b/packages/ember-htmlbars/lib/hooks/get-root.js
@@ -31,7 +31,7 @@ function getKey(scope, key) {
   }
 
   let attrs = scope.getAttrs();
-  if (key in attrs) {
+  if (attrs && key in attrs) {
     // TODO: attrs
     // deprecate("You accessed the `" + key + "` attribute directly. Please use `attrs." + key + "` instead.");
     return attrs[key];


### PR DESCRIPTION
In certain circumstances, `attrs` can be null (that is the default value). This guards against a `key in null` error.
