### PR TITLE
Fix typo in helpers_test.js

### DIFF
--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -615,14 +615,14 @@ QUnit.test('`fillIn` fires `input` and `change` events in the proper order', fun
       oninputHandler(e) {
         events.push(e.type);
       },
-      onchangeHanlders(e) {
+      onchangeHandler(e) {
         events.push(e.type);
       }
     }
   });
 
   App.IndexView = EmberView.extend({
-    template: compile('<input type="text" id="first" oninput={{action "oninputHandler"}} onchange={{action "onchangeHanlders"}}>')
+    template: compile('<input type="text" id="first" oninput={{action "oninputHandler"}} onchange={{action "onchangeHandler"}}>')
   });
 
   run(App, App.advanceReadiness);


### PR DESCRIPTION
Related: I noticed there's not a [consistent](https://github.com/emberjs/ember.js/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+typo) way of labeling typo fix commits. Has the ember team considered something like `[TYPO]` label for stuff like this?
