### PR TITLE
[FEATURE ember-container-inject-owner] Inject fake container with deprecations.

### DIFF
--- a/packages/ember-runtime/lib/mixins/container_proxy.js
+++ b/packages/ember-runtime/lib/mixins/container_proxy.js
@@ -3,6 +3,7 @@
 @submodule ember-runtime
 */
 import run from 'ember-metal/run_loop';
+import { deprecate } from 'ember-metal/debug';
 import { Mixin } from 'ember-metal/mixin';
 
 
@@ -93,5 +94,34 @@ export default Mixin.create({
 function containerAlias(name) {
   return function () {
     return this.__container__[name](...arguments);
+  };
+}
+
+export function buildFakeContainerWithDeprecations(container) {
+  let fakeContainer = {};
+  let propertyMappings = {
+    lookup: 'lookup',
+    lookupFactory: '_lookupFactory'
+  };
+
+  for (let containerProperty in propertyMappings) {
+    fakeContainer[containerProperty] = buildFakeContainerFunction(container, containerProperty, propertyMappings[containerProperty]);
+  }
+
+  return fakeContainer;
+}
+
+function buildFakeContainerFunction(container, containerProperty, ownerProperty) {
+  return function() {
+    deprecate(
+      `Using the injected \`container\` is deprecated. Please use the \`getOwner\` helper to access the owner of this object and then call \`${ownerProperty}\` instead.`,
+      false,
+      {
+        id: 'ember-application.injected-container',
+        until: '3.0.0',
+        url: 'http://emberjs.com/deprecations/v2.x#toc_injected-container-access'
+      }
+    );
+    return container[containerProperty](...arguments);
   };
 }


### PR DESCRIPTION
The fake container provides access to the following methods:
- `lookup`
- `lookupFactory`

These methods are mapped through the equivalent `ContainerProxy` methods
(`lookup` and `_lookupFactory`) on the container's owner. 

Deprecation warnings are provided.

TBD: deprecation id and url
