### PR TITLE
add failing test for filterBy

### DIFF
--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -427,6 +427,23 @@ QUnit.test('properties values can be replaced', function() {
   deepEqual(obj.get('a1bs').mapBy('name'), ['item1'], 'properties can be filtered by matching value');
 });
 
+QUnit.test('responds to change of property value on element', function() {
+  let a1 = { foo: true };
+  let a2 = { foo: true };
+
+  obj = EmberObject.extend({
+    a: filterBy('array', 'foo')
+  }).create({
+    array: [a1, a2]
+  });
+
+  deepEqual(obj.get('a'), [a1, a2], 'value is correct initially');
+
+  set(a1, 'foo', false);
+
+  deepEqual(obj.get('a'), [a2], 'responds to change of property on element');
+});
+
 [
   ['uniq', uniq],
   ['union', union]


### PR DESCRIPTION
DO NOT MERGE

I believe this test demonstrates behavior that used to work. The first deepEqual assertion passes but the second one fails.

This is related to #12475.

This is a duplicate of #12538, which got messed up because it was targeting release.
