### PR TITLE
[CLEANUP beta]

### DIFF
--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -164,7 +164,7 @@ setDebugFunction('deprecate', _deprecate);
 setDebugFunction('warn', _warn);
 
 /**
-  Will call `Ember.warn()` if ENABLE_ALL_FEATURES, ENABLE_OPTIONAL_FEATURES, or
+  Will call `Ember.warn()` if ENABLE_OPTIONAL_FEATURES or
   any specific FEATURES flag is truthy.
 
   This method is called automatically in debug canary builds.
@@ -175,7 +175,6 @@ setDebugFunction('warn', _warn);
 */
 export function _warnIfUsingStrippedFeatureFlags(FEATURES, featuresWereStripped) {
   if (featuresWereStripped) {
-    warn('Ember.ENV.ENABLE_ALL_FEATURES is only available in canary builds.', !Ember.ENV.ENABLE_ALL_FEATURES, { id: 'ember-debug.feature-flag-with-features-stripped' });
     warn('Ember.ENV.ENABLE_OPTIONAL_FEATURES is only available in canary builds.', !Ember.ENV.ENABLE_OPTIONAL_FEATURES, { id: 'ember-debug.feature-flag-with-features-stripped' });
 
     for (var key in FEATURES) {

--- a/packages/ember-debug/tests/warn_if_using_stripped_feature_flags_test.js
+++ b/packages/ember-debug/tests/warn_if_using_stripped_feature_flags_test.js
@@ -2,7 +2,7 @@ import Ember from 'ember-metal/core';
 import { getDebugFunction, setDebugFunction } from 'ember-metal/debug';
 import { _warnIfUsingStrippedFeatureFlags } from 'ember-debug';
 
-var oldWarn, oldRunInDebug, origEnvFeatures, origEnableAll, origEnableOptional;
+var oldWarn, oldRunInDebug, origEnvFeatures, origEnableOptional;
 
 function confirmWarns(expectedMsg) {
   var featuresWereStripped = true;
@@ -31,7 +31,6 @@ QUnit.module('ember-debug - _warnIfUsingStrippedFeatureFlags', {
     oldWarn            = getDebugFunction('warn');
     oldRunInDebug      = getDebugFunction('runInDebug');
     origEnvFeatures    = Ember.ENV.FEATURES;
-    origEnableAll      = Ember.ENV.ENABLE_ALL_FEATURES;
     origEnableOptional = Ember.ENV.ENABLE_OPTIONAL_FEATURES;
   },
 
@@ -39,25 +38,13 @@ QUnit.module('ember-debug - _warnIfUsingStrippedFeatureFlags', {
     setDebugFunction('warn', oldWarn);
     setDebugFunction('runInDebug', oldRunInDebug);
     Ember.ENV.FEATURES                 = origEnvFeatures;
-    Ember.ENV.ENABLE_ALL_FEATURES      = origEnableAll;
     Ember.ENV.ENABLE_OPTIONAL_FEATURES = origEnableOptional;
   }
-});
-
-QUnit.test('Setting Ember.ENV.ENABLE_ALL_FEATURES truthy in non-canary, debug build causes a warning', function() {
-  expect(1);
-
-  Ember.ENV.ENABLE_ALL_FEATURES = true;
-  Ember.ENV.ENABLE_OPTIONAL_FEATURES = false;
-  Ember.ENV.FEATURES = {};
-
-  confirmWarns('Ember.ENV.ENABLE_ALL_FEATURES is only available in canary builds.');
 });
 
 QUnit.test('Setting Ember.ENV.ENABLE_OPTIONAL_FEATURES truthy in non-canary, debug build causes a warning', function() {
   expect(1);
 
-  Ember.ENV.ENABLE_ALL_FEATURES = false;
   Ember.ENV.ENABLE_OPTIONAL_FEATURES = true;
   Ember.ENV.FEATURES = {};
 
@@ -67,7 +54,6 @@ QUnit.test('Setting Ember.ENV.ENABLE_OPTIONAL_FEATURES truthy in non-canary, deb
 QUnit.test('Enabling a FEATURES flag in non-canary, debug build causes a warning', function() {
   expect(1);
 
-  Ember.ENV.ENABLE_ALL_FEATURES = false;
   Ember.ENV.ENABLE_OPTIONAL_FEATURES = false;
   Ember.ENV.FEATURES = {
     'fred': true,

--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -89,12 +89,12 @@ if (Ember.ENV) {
   Ember.ENV = {};
 }
 
-Ember.config = Ember.config || {};
-
-// We disable the RANGE API by default for performance reasons
-if ('undefined' === typeof Ember.ENV.DISABLE_RANGE_API) {
-  Ember.ENV.DISABLE_RANGE_API = true;
+// ENABLE_ALL_FEATURES was documented, but you can't actually enable non optional features.
+if (Ember.ENV.ENABLE_ALL_FEATURES) {
+  Ember.ENV.ENABLE_OPTIONAL_FEATURES = Ember.ENV.ENABLE_ALL_FEATURES;
 }
+
+Ember.config = Ember.config || {};
 
 // ..........................................................
 // BOOTSTRAP
@@ -135,17 +135,6 @@ if (typeof Ember.EXTEND_PROTOTYPES === 'undefined') {
   @public
 */
 Ember.LOG_STACKTRACE_ON_DEPRECATION = (Ember.ENV.LOG_STACKTRACE_ON_DEPRECATION !== false);
-
-/**
-  The `SHIM_ES5` property, when true, tells Ember to add ECMAScript 5 Array
-  shims to older browsers.
-
-  @property SHIM_ES5
-  @type Boolean
-  @default Ember.EXTEND_PROTOTYPES
-  @public
-*/
-Ember.SHIM_ES5 = (Ember.ENV.SHIM_ES5 === false) ? false : Ember.EXTEND_PROTOTYPES;
 
 /**
   The `LOG_VERSION` property, when true, tells Ember to log versions of all

--- a/packages/ember-metal/lib/features.js
+++ b/packages/ember-metal/lib/features.js
@@ -22,7 +22,6 @@ export var FEATURES = assign(DEFAULT_FEATURES, Ember.ENV.FEATURES); // jshint ig
 
   You can define the following configuration options:
 
-  * `EmberENV.ENABLE_ALL_FEATURES` - force all features to be enabled.
   * `EmberENV.ENABLE_OPTIONAL_FEATURES` - enable any features that have not been explicitly
     enabled/disabled.
 
@@ -36,9 +35,7 @@ export var FEATURES = assign(DEFAULT_FEATURES, Ember.ENV.FEATURES); // jshint ig
 export default function isEnabled(feature) {
   var featureValue = FEATURES[feature];
 
-  if (Ember.ENV.ENABLE_ALL_FEATURES) {
-    return true;
-  } else if (featureValue === true || featureValue === false || featureValue === undefined) {
+  if (featureValue === true || featureValue === false || featureValue === undefined) {
     return featureValue;
   } else if (Ember.ENV.ENABLE_OPTIONAL_FEATURES) {
     return true;

--- a/packages/ember-metal/tests/features_test.js
+++ b/packages/ember-metal/tests/features_test.js
@@ -2,12 +2,11 @@ import Ember from 'ember-metal/core';
 import isEnabled, { FEATURES } from 'ember-metal/features';
 import assign from 'ember-metal/assign';
 
-var origFeatures, origEnableAll, origEnableOptional;
+var origFeatures, origEnableOptional;
 
 QUnit.module('isEnabled', {
   setup() {
     origFeatures = assign({}, FEATURES);
-    origEnableAll = Ember.ENV.ENABLE_ALL_FEATURES;
     origEnableOptional = Ember.ENV.ENABLE_OPTIONAL_FEATURES;
   },
 
@@ -17,19 +16,8 @@ QUnit.module('isEnabled', {
     }
     assign(FEATURES, origFeatures);
 
-    Ember.ENV.ENABLE_ALL_FEATURES = origEnableAll;
     Ember.ENV.ENABLE_OPTIONAL_FEATURES = origEnableOptional;
   }
-});
-
-QUnit.test('ENV.ENABLE_ALL_FEATURES', function() {
-  Ember.ENV.ENABLE_ALL_FEATURES = true;
-  FEATURES['fred'] = false;
-  FEATURES['wilma'] = null;
-
-  equal(isEnabled('fred'), true, 'overrides features set to false');
-  equal(isEnabled('wilma'), true, 'enables optional features');
-  equal(isEnabled('betty'), true, 'enables non-specified features');
 });
 
 QUnit.test('ENV.ENABLE_OPTIONAL_FEATURES', function() {
@@ -45,7 +33,6 @@ QUnit.test('ENV.ENABLE_OPTIONAL_FEATURES', function() {
 });
 
 QUnit.test('isEnabled without ENV options', function() {
-  Ember.ENV.ENABLE_ALL_FEATURES = false;
   Ember.ENV.ENABLE_OPTIONAL_FEATURES = false;
 
   FEATURES['fred'] = false;

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -2,7 +2,7 @@
 // Ember.ContainerView circular dependency
 // Ember.ENV
 import Ember from 'ember-metal/core';
-import { deprecate, warn } from 'ember-metal/debug';
+import { deprecate } from 'ember-metal/debug';
 
 import 'ember-views/system/ext';  // for the side effect of extending Ember.run.queues
 
@@ -28,13 +28,6 @@ import { deprecateProperty } from 'ember-metal/deprecate_property';
 @submodule ember-views
 */
 
-warn(
-  'The VIEW_PRESERVES_CONTEXT flag has been removed and the functionality can no longer be disabled.',
-  Ember.ENV.VIEW_PRESERVES_CONTEXT !== false,
-  {
-    id: 'ember-views.view-preserves-context-flag',
-    until: '2.0.0'
-  });
 /**
   `Ember.View` is the class in Ember responsible for encapsulating templates of
   HTML content, combining templates with data to render as sections of a page's


### PR DESCRIPTION
Remove unused ENV flags, this is just to keep PRs small, this is part of a fix for Mixin that went into beta.

ENABLE_ALL_FEATURES can't actually do anything more than ENABLE_OPTIONAL_FEATURES, other features are always build time.

SHIM_ES5 is just unused as is DISABLE_RANGE_API
