### PR TITLE
[BUGFIX beta] Ensure Mixin.prototype.toString is defined.

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -585,6 +585,10 @@ MixinPrototype.applyPartial = function(obj) {
   return applyMixin(obj, [this], true);
 };
 
+MixinPrototype.toString = function Mixin_toString() {
+  return '(unknown mixin)';
+};
+
 function _detect(curMixin, targetMixin, seen) {
   var guid = guidFor(curMixin);
 


### PR DESCRIPTION
`Mixin.prototype` is sealed after its initial definition, but `Mixin.prototype.toString` is assigned later in `ember-runtime/namespace`.  This causes issues when `ember-template-compiler.js` is loaded before the rest of Ember (because the `Mixin.prototype` is sealed).  Unfortunately, the debug functions (for `Object.seal`) does not work in the `ember-metal` package at this time.

This fix is a temporary fix ensures that the slot for `toString` exists on `Mixin.prototype` to allow the loading of `ember-template-compiler.js` to be before or after `ember.debug.js`. The more permanent fix is to ensure that `debugSeal` works in ember-metal properly.

Fixes #12623.
