### PR TITLE
[BUGFIX beta] Update HTMLBars to 0.14.7.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2692,9 +2692,8 @@
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz"
     },
     "htmlbars": {
-      "version": "0.14.6",
-      "from": "htmlbars@0.14.6",
-      "resolved": "https://registry.npmjs.org/htmlbars/-/htmlbars-0.14.6.tgz"
+      "version": "0.14.7",
+      "from": "htmlbars@0.14.7"
     },
     "htmlparser2": {
       "version": "3.8.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "finalhandler": "^0.4.0",
     "github": "^0.2.3",
     "glob": "~4.3.2",
-    "htmlbars": "0.14.6",
+    "htmlbars": "0.14.7",
     "qunit-extras": "^1.4.0",
     "qunitjs": "^1.19.0",
     "route-recognizer": "0.1.5",


### PR DESCRIPTION
Compare view: https://github.com/tildeio/htmlbars/compare/v0.14.6...v0.14.7

Main issue fixed is for Android 4.0/4.1 builtin browser throwing errors in non-minified builds (due to unquoted usage of `yield`).

/cc @fivetanley
