### PR TITLE
[FEATURE ember-htmlbars-local-lookup]

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -52,3 +52,10 @@ for a detailed explanation.
   ```
 
   Implements RFC [#64](https://github.com/emberjs/rfcs/blob/master/text/0064-contextual-component-lookup.md)
+
+* `ember-htmlbars-local-lookup`
+
+  Provides the ability for component lookup to be relative to the source template.
+
+  When the proper API's are implemented by the resolver in use this feature allows `{{x-foo}}` in a
+  given routes template (say the `post` route) to lookup a component nested under `post`.

--- a/features.json
+++ b/features.json
@@ -9,6 +9,7 @@
     "ember-routing-routable-components": null,
     "ember-metal-ember-assign": null,
     "ember-contextual-components": true,
-    "ember-container-inject-owner": true
+    "ember-container-inject-owner": true,
+    "ember-htmlbars-local-lookup": null
   }
 }

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -610,3 +610,45 @@ if (isEnabled('ember-container-inject-owner')) {
     strictEqual(postController.container, container, '');
   });
 }
+
+if (isEnabled('ember-htmlbars-local-lookup')) {
+  QUnit.test('lookupFactory passes options through to expandlocallookup', function(assert) {
+    let registry = new Registry();
+    let container = registry.container();
+    let PostController = factory();
+
+    registry.register('controller:post', PostController);
+
+    registry.expandLocalLookup = function(fullName, options) {
+      assert.ok(true, 'expandLocalLookup was called');
+      assert.equal(fullName, 'foo:bar');
+      assert.deepEqual(options, { source: 'baz:qux' });
+
+      return 'controller:post';
+    };
+
+    let PostControllerFactory = container.lookupFactory('foo:bar', { source: 'baz:qux' });
+
+    assert.ok(PostControllerFactory.create() instanceof  PostController, 'The return of factory.create is an instance of PostController');
+  });
+
+  QUnit.test('lookup passes options through to expandlocallookup', function(assert) {
+    let registry = new Registry();
+    let container = registry.container();
+    let PostController = factory();
+
+    registry.register('controller:post', PostController);
+
+    registry.expandLocalLookup = function(fullName, options) {
+      assert.ok(true, 'expandLocalLookup was called');
+      assert.equal(fullName, 'foo:bar');
+      assert.deepEqual(options, { source: 'baz:qux' });
+
+      return 'controller:post';
+    };
+
+    let PostControllerLookupResult = container.lookup('foo:bar', { source: 'baz:qux' });
+
+    assert.ok(PostControllerLookupResult instanceof PostController);
+  });
+}

--- a/packages/container/tests/test-helpers/build-owner.js
+++ b/packages/container/tests/test-helpers/build-owner.js
@@ -7,7 +7,8 @@ export default function buildOwner(props) {
   let Owner = EmberObject.extend(RegistryProxy, ContainerProxy, {
     init() {
       this._super(...arguments);
-      let registry = this.__registry__ = new Registry();
+      let registry = new Registry(this._registryOptions);
+      this.__registry__ = registry;
       this.__container__ = registry.container({ owner: this });
     }
   });

--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -221,8 +221,10 @@ export default EmberObject.extend({
     var name = fullNameWithoutType;
     var namespace = get(this, 'namespace');
     var root = namespace;
+    let lastSlashIndex = name.lastIndexOf('/');
+    let dirname = lastSlashIndex !== -1 ? name.slice(0, lastSlashIndex) : null;
 
-    if (type !== 'template' && name.indexOf('/') !== -1) {
+    if (type !== 'template' && lastSlashIndex !== -1) {
       var parts = name.split('/');
       name = parts[parts.length - 1];
       var namespaceName = capitalize(parts.slice(0, -1).join('.'));
@@ -245,6 +247,7 @@ export default EmberObject.extend({
       fullName: fullName,
       type: type,
       fullNameWithoutType: fullNameWithoutType,
+      dirname,
       name: name,
       root: root,
       resolveMethodName: 'resolve' + resolveMethodName

--- a/packages/ember-htmlbars/lib/hooks/component.js
+++ b/packages/ember-htmlbars/lib/hooks/component.js
@@ -1,3 +1,4 @@
+import isEnabled from 'ember-metal/features';
 import { assert } from 'ember-metal/debug';
 import ComponentNodeManager from 'ember-htmlbars/node-managers/component-node-manager';
 import buildComponentTemplate, { buildHTMLTemplate } from 'ember-views/system/build-component-template';
@@ -98,7 +99,17 @@ export default function componentHook(renderNode, env, scope, _tagName, params, 
 
   let component, layout;
   if (isDasherized || !isAngleBracket) {
-    let result = lookupComponent(env.owner, tagName);
+    let options = { };
+    if (isEnabled('ember-htmlbars-local-lookup')) {
+      let moduleName = env.meta && env.meta.moduleName;
+
+      if (moduleName) {
+        options.source = `template:${moduleName}`;
+      }
+    }
+
+    let result = lookupComponent(env.owner, tagName, options);
+
     component = result.component;
     layout = result.layout;
 

--- a/packages/ember-htmlbars/lib/hooks/has-helper.js
+++ b/packages/ember-htmlbars/lib/hooks/has-helper.js
@@ -11,6 +11,16 @@ export default function hasHelperHook(env, scope, helperName) {
     if (owner.hasRegistration(registrationName)) {
       return true;
     }
+
+    let options = {};
+    let moduleName = env.meta && env.meta.moduleName;
+    if (moduleName) {
+      options.source = `template:${moduleName}`;
+    }
+
+    if (owner.hasRegistration(registrationName, options)) {
+      return true;
+    }
   }
 
   return false;

--- a/packages/ember-htmlbars/lib/keywords/outlet.js
+++ b/packages/ember-htmlbars/lib/keywords/outlet.js
@@ -91,7 +91,11 @@ export default {
   },
 
   childEnv(state, env) {
-    return env.childWithOutletState(state.outletState && state.outletState.outlets, true);
+    let outletState = state.outletState;
+    let toRender = outletState && outletState.render;
+    let meta = toRender && toRender.template && toRender.template.meta;
+
+    return env.childWithOutletState(outletState && outletState.outlets, true, meta);
   },
 
   isStable(lastState, nextState) {

--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -134,7 +134,8 @@ ComponentNodeManager.prototype.render = function ComponentNodeManager_render(_en
   var { component } = this;
 
   return instrument(component, function ComponentNodeManager_render_instrument() {
-    let env = _env.childWithView(component);
+    let meta = this.block && this.block.template.meta;
+    let env = _env.childWithView(component, meta);
 
     env.renderer.componentWillRender(component);
     env.renderedViews.push(component.elementId);

--- a/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
@@ -88,6 +88,10 @@ ViewNodeManager.prototype.render = function ViewNodeManager_render(env, attrs, v
     var newEnv = env;
     if (component) {
       newEnv = env.childWithView(component);
+    } else {
+      let meta = this.block && this.block.template.meta;
+
+      newEnv = env.childWithMeta(meta);
     }
 
     if (component) {
@@ -138,7 +142,12 @@ ViewNodeManager.prototype.rerender = function ViewNodeManager_rerender(env, attr
       env.renderer.willRender(component);
 
       env.renderedViews.push(component.elementId);
+    } else {
+      let meta = this.block && this.block.template.meta;
+
+      newEnv = env.childWithMeta(meta);
     }
+
     if (this.block) {
       this.block.invoke(newEnv, [], undefined, this.renderNode, this.scope, visitor);
     }

--- a/packages/ember-htmlbars/lib/system/render-env.js
+++ b/packages/ember-htmlbars/lib/system/render-env.js
@@ -13,6 +13,7 @@ export default function RenderEnv(options) {
   this.owner = options.owner;
   this.renderer = options.renderer;
   this.dom = options.dom;
+  this.meta = options.meta;
 
   this.hooks = defaultEnv.hooks;
   this.helpers = defaultEnv.helpers;
@@ -20,17 +21,33 @@ export default function RenderEnv(options) {
   this.destinedForDOM = this.renderer._destinedForDOM;
 }
 
-RenderEnv.build = function(view) {
+RenderEnv.build = function(view, meta) {
   return new RenderEnv({
     view: view,
     outletState: view.outletState,
     owner: getOwner(view),
     renderer: view.renderer,
-    dom: view.renderer._dom
+    dom: view.renderer._dom,
+    meta
   });
 };
 
-RenderEnv.prototype.childWithView = function(view) {
+RenderEnv.prototype.childWithMeta = function(meta) {
+  return new RenderEnv({
+    view: this.view,
+    outletState: this.outletState,
+    owner: this.owner,
+    renderer: this.renderer,
+    dom: this.dom,
+    lifecycleHooks: this.lifecycleHooks,
+    renderedViews: this.renderedViews,
+    renderedNodes: this.renderedNodes,
+    hasParentOutlet: this.hasParentOutlet,
+    meta
+  });
+};
+
+RenderEnv.prototype.childWithView = function(view, meta=this.meta) {
   return new RenderEnv({
     view: view,
     outletState: this.outletState,
@@ -40,11 +57,12 @@ RenderEnv.prototype.childWithView = function(view) {
     lifecycleHooks: this.lifecycleHooks,
     renderedViews: this.renderedViews,
     renderedNodes: this.renderedNodes,
-    hasParentOutlet: this.hasParentOutlet
+    hasParentOutlet: this.hasParentOutlet,
+    meta
   });
 };
 
-RenderEnv.prototype.childWithOutletState = function(outletState, hasParentOutlet=this.hasParentOutlet) {
+RenderEnv.prototype.childWithOutletState = function(outletState, hasParentOutlet=this.hasParentOutlet, meta=this.meta) {
   return new RenderEnv({
     view: this.view,
     outletState: outletState,
@@ -54,6 +72,7 @@ RenderEnv.prototype.childWithOutletState = function(outletState, hasParentOutlet
     lifecycleHooks: this.lifecycleHooks,
     renderedViews: this.renderedViews,
     renderedNodes: this.renderedNodes,
-    hasParentOutlet: hasParentOutlet
+    hasParentOutlet: hasParentOutlet,
+    meta
   });
 };

--- a/packages/ember-htmlbars/lib/system/render-view.js
+++ b/packages/ember-htmlbars/lib/system/render-view.js
@@ -4,7 +4,8 @@ import RenderEnv from 'ember-htmlbars/system/render-env';
 // This function only gets called once per render of a "root view" (`appendTo`). Otherwise,
 // HTMLBars propagates the existing env and renders templates for a given render node.
 export function renderHTMLBarsBlock(view, block, renderNode) {
-  var env = RenderEnv.build(view);
+  let meta = block && block.template && block.template.meta;
+  var env = RenderEnv.build(view, meta);
 
   view.env = env;
   createOrUpdateComponent(view, {}, null, renderNode, env);

--- a/packages/ember-htmlbars/lib/utils/is-component.js
+++ b/packages/ember-htmlbars/lib/utils/is-component.js
@@ -3,12 +3,18 @@
 @submodule ember-htmlbars
 */
 
+import isEnabled from 'ember-metal/features';
 import {
   CONTAINS_DASH_CACHE,
   CONTAINS_DOT_CACHE
 } from 'ember-htmlbars/system/lookup-helper';
 import { isComponentCell } from 'ember-htmlbars/keywords/closure-component';
 import { isStream } from 'ember-metal/streams/utils';
+
+function hasComponentOrTemplate(owner, path, options) {
+  return owner.hasRegistration('component:' + path, options) ||
+    owner.hasRegistration('template:components/' + path, options);
+}
 
 /*
  Given a path name, returns whether or not a component with that
@@ -28,7 +34,24 @@ export default function isComponent(env, scope, path) {
       }
     }
     if (!CONTAINS_DASH_CACHE.get(path)) { return false; }
-    return owner.hasRegistration('component:' + path) ||
-           owner.hasRegistration('template:components/' + path);
+
+    if (hasComponentOrTemplate(owner, path)) {
+      return true; // global component found
+    } else {
+      if (isEnabled('ember-htmlbars-local-lookup')) {
+        let moduleName = env.meta && env.meta.moduleName;
+
+        if (!moduleName) {
+          // without a source moduleName we can not perform local lookups
+          return false;
+        }
+
+        let options = { source: `template:${moduleName}` };
+
+        return hasComponentOrTemplate(owner, path, options);
+      } else {
+        return false;
+      }
+    }
   }
 }

--- a/packages/ember-htmlbars/lib/utils/lookup-component.js
+++ b/packages/ember-htmlbars/lib/utils/lookup-component.js
@@ -1,8 +1,26 @@
-export default function lookupComponent(container, tagName) {
-  var componentLookup = container.lookup('component-lookup:main');
+import isEnabled from 'ember-metal/features';
 
+function lookupComponentPair(componentLookup, owner, tagName, options) {
   return {
-    component: componentLookup.componentFor(tagName, container),
-    layout: componentLookup.layoutFor(tagName, container)
+    component: componentLookup.componentFor(tagName, owner, options),
+    layout: componentLookup.layoutFor(tagName, owner, options)
   };
+}
+
+export default function lookupComponent(owner, tagName, options) {
+  let componentLookup = owner.lookup('component-lookup:main');
+
+  if (isEnabled('ember-htmlbars-local-lookup')) {
+    let source = options && options.source;
+
+    if (source) {
+      let localResult = lookupComponentPair(componentLookup, owner, tagName, options);
+
+      if (localResult.component || localResult.layout) {
+        return localResult;
+      }
+    }
+  }
+
+  return lookupComponentPair(componentLookup, owner, tagName);
 }

--- a/packages/ember-htmlbars/tests/integration/local-lookup-test.js
+++ b/packages/ember-htmlbars/tests/integration/local-lookup-test.js
@@ -1,0 +1,174 @@
+import isEnabled from 'ember-metal/features';
+import EmberView from 'ember-views/views/view';
+import compile from 'ember-template-compiler/system/compile';
+import ComponentLookup from 'ember-views/component_lookup';
+import Component from 'ember-views/components/component';
+import { helper } from 'ember-htmlbars/helper';
+import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
+import buildOwner from 'container/tests/test-helpers/build-owner';
+import { OWNER } from 'container/owner';
+
+var owner, view;
+
+function buildResolver() {
+  let resolver = {
+    resolve() { },
+    expandLocalLookup(fullName, sourceFullName) {
+      let [sourceType, sourceName ] = sourceFullName.split(':');
+      let [type, name ] = fullName.split(':');
+
+      if (type !== 'template' && sourceType === 'template' && sourceName.slice(0, 11) === 'components/') {
+        sourceName = sourceName.slice(11);
+      }
+
+      if (type === 'template' && sourceType === 'template' && name.slice(0, 11) === 'components/') {
+        name = name.slice(11);
+      }
+
+
+      let result = `${type}:${sourceName}/${name}`;
+
+      return result;
+    }
+  };
+
+  return resolver;
+}
+
+function commonSetup() {
+  owner = buildOwner({
+    _registryOptions: {
+      resolver: buildResolver()
+    }
+  });
+  owner.registerOptionsForType('component', { singleton: false });
+  owner.registerOptionsForType('view', { singleton: false });
+  owner.registerOptionsForType('template', { instantiate: false });
+  owner.register('component-lookup:main', ComponentLookup);
+}
+
+function commonTeardown() {
+  runDestroy(view);
+  runDestroy(owner);
+  owner = view = null;
+}
+
+function appendViewFor(template, moduleName='', hash={}) {
+  let view = EmberView.extend({
+    template: compile(template, { moduleName }),
+    [OWNER]: owner
+  }).create(hash);
+
+  runAppend(view);
+
+  return view;
+}
+
+function registerTemplate(moduleName, snippet) {
+  owner.register(`template:${moduleName}`, compile(snippet, { moduleName }));
+}
+
+function registerComponent(name, factory) {
+  owner.register(`component:${name}`, factory);
+}
+
+function registerHelper(name, helper) {
+  owner.register(`helper:${name}`, helper);
+}
+
+QUnit.module('component - local lookup', {
+  setup() {
+    commonSetup();
+  },
+
+  teardown() {
+    commonTeardown();
+  }
+});
+
+if (isEnabled('ember-htmlbars-local-lookup')) {
+  // jscs:disable validateIndentation
+
+QUnit.test('local component lookup with matching template', function() {
+  expect(1);
+
+  registerTemplate('components/x-outer', '{{#x-inner}}Hi!{{/x-inner}}');
+  registerTemplate('components/x-outer/x-inner', 'Nested template says: {{yield}}');
+
+  view = appendViewFor(`{{x-outer}}`, 'route-template');
+
+  equal(view.$().text(), 'Nested template says: Hi!');
+});
+
+QUnit.test('local component lookup with matching component', function() {
+  expect(1);
+
+  registerTemplate('components/x-outer', '{{#x-inner}}Hi!{{/x-inner}}');
+  registerComponent('x-outer/x-inner', Component.extend({
+    tagName: 'span'
+  }));
+
+  view = appendViewFor(`{{x-outer}}`, 'route-template');
+
+  equal(view.$('span').text(), 'Hi!');
+});
+
+QUnit.test('local helper lookup', function() {
+  expect(1);
+
+  registerTemplate('components/x-outer', 'Who dat? {{x-helper}}');
+  registerHelper('x-outer/x-helper', helper(() => {
+    return 'Who dis?';
+  }));
+
+  view = appendViewFor(`{{x-outer}}`, 'route-template');
+
+  equal(view.$().text(), 'Who dat? Who dis?');
+});
+
+QUnit.test('local helper lookup overrides global lookup', function() {
+  expect(1);
+
+  registerTemplate('components/x-outer', 'Who dat? {{x-helper}}');
+  registerHelper('x-outer/x-helper', helper(() => 'Who dis?'));
+  registerHelper('x-helper', helper(() => 'I dunno'));
+
+  view = appendViewFor(`{{x-outer}} {{x-helper}}`, 'route-template');
+
+  equal(view.$().text(), 'Who dat? Who dis? I dunno');
+});
+
+QUnit.test('lookup without match issues standard assertion (with local helper name)', function() {
+  expect(1);
+
+  registerTemplate('components/x-outer', '{{#x-inner}}Hi!{{/x-inner}}');
+
+  expectAssertion(function() {
+    appendViewFor(`{{x-outer}}`, 'route-template');
+  }, /A helper named 'x-inner' could not be found/);
+});
+
+QUnit.test('local lookup overrides global lookup', function() {
+  expect(1);
+
+  registerTemplate('components/x-outer', '{{#x-inner}}Hi!{{/x-inner}}');
+  registerTemplate('components/x-outer/x-inner', 'Nested template says (from local): {{yield}}');
+  registerTemplate('components/x-inner', 'Nested template says (from global): {{yield}}');
+
+  view = appendViewFor(`{{#x-inner}}Hi!{{/x-inner}} {{x-outer}} {{#x-outer/x-inner}}Hi!{{/x-outer/x-inner}}`, 'route-template');
+
+  equal(view.$().text(), 'Nested template says (from global): Hi! Nested template says (from local): Hi! Nested template says (from local): Hi!');
+});
+} else {
+  QUnit.test('lookup with both global and local match uses specifically invoked component', function() {
+    expect(1);
+
+    registerTemplate('components/x-outer', '{{#x-inner}}Hi!{{/x-inner}}');
+    registerTemplate('components/x-outer/x-inner', 'Nested template says (from local): {{yield}}');
+    registerTemplate('components/x-inner', 'Nested template says (from global): {{yield}}');
+
+    view = appendViewFor(`{{#x-inner}}Hi!{{/x-inner}} {{x-outer}} {{#x-outer/x-inner}}Hi!{{/x-outer/x-inner}}`, 'route-template');
+
+    equal(view.$().text(), 'Nested template says (from global): Hi! Nested template says (from global): Hi! Nested template says (from local): Hi!');
+  });
+}

--- a/packages/ember-views/lib/component_lookup.js
+++ b/packages/ember-views/lib/component_lookup.js
@@ -36,21 +36,21 @@ export default EmberObject.extend({
     }
   },
 
-  componentFor(name, owner) {
+  componentFor(name, owner, options) {
     if (this.invalidName(name)) {
       return;
     }
 
     var fullName = 'component:' + name;
-    return owner._lookupFactory(fullName);
+    return owner._lookupFactory(fullName, options);
   },
 
-  layoutFor(name, owner) {
+  layoutFor(name, owner, options) {
     if (this.invalidName(name)) {
       return;
     }
 
     var templateFullName = 'template:components/' + name;
-    return owner.lookup(templateFullName);
+    return owner.lookup(templateFullName, options);
   }
 });


### PR DESCRIPTION
Implements local lookup concepts. This new concept is primarily used from the template layer in this initial implementation, but the `source` option is usable generally.

There are a couple main concepts being added here:
- Expanding a `type:name` relative to a given source `type:name` into a fully qualified `type:name` (that includes the source info).
- Expose the currently rendering `template`'s `meta` information on the `RenderEnv`.
- Adding a second layer of lookups in all places that components or helpers are resolved.
#### `expandLocalLookup`

We use the `expandLocalLookup` function on the resolver (when present) to take both the source and target full names and return a new fully qualified full name. By default the resolver will not have an `expandLocalLookup` function, but an example implementation exists in the `ember-htmlbars/tests/integration/local-lookup-test` module here.
#### `meta`

As of Ember 1.12, metadata has been appended to every template to allow better customization of things like deprecation messages and template compilation errors.

With the changes in this commit that metadata is exposed on the `RenderEnv` which is present through the various internal glimmer engine hooks (and provides us the `source` information needed for the local lookups added here).
#### local + global lookups

The various places that are responsible for looking helpers and components up have been updated to do two layers of lookups.  Once for the current global style lookups, and a second for lookups relative to the invocation template.

---

I have created a small demo twiddle: [here](https://ember-twiddle.com/6a0c17f23fd8ce8ca95c?numColumns=0&route=%2Flocal-only)

The builds from this PR can also be located [here](https://github.com/rwjblue/ember/tree/local-lookup) and available from bower at:

``` json
"ember": "rwjblue/ember#local-lookup",
```
