### PR TITLE
[BUGFIX Release] Clear cached instances when factories are unregistered.

### DIFF
--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -278,6 +278,21 @@ let ApplicationInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
   willDestroy() {
     this._super(...arguments);
     run(this.__container__, 'destroy');
+  },
+
+  /**
+   Unregister a factory.
+
+   Overrides `RegistryProxy#unregister` in order to clear any cached instances
+   of the unregistered factory.
+
+   @public
+   @method unregister
+   @param {String} fullName
+   */
+  unregister(fullName) {
+    this.__container__.reset(fullName);
+    this._super(...arguments);
   }
 });
 

--- a/packages/ember-application/tests/system/application_instance_test.js
+++ b/packages/ember-application/tests/system/application_instance_test.js
@@ -2,6 +2,7 @@ import Application from 'ember-application/system/application';
 import ApplicationInstance from 'ember-application/system/application-instance';
 import run from 'ember-metal/run_loop';
 import jQuery from 'ember-views/system/jquery';
+import factory from 'container/tests/test-helpers/factory';
 
 let app, appInstance;
 
@@ -123,4 +124,27 @@ QUnit.test('customEvents added to the application instance before setupEventDisp
   };
 
   appInstance.setupEventDispatcher();
+});
+
+QUnit.test('unregistering a factory clears all cached instances of that factory', function(assert) {
+  assert.expect(3);
+
+  run(function() {
+    appInstance = ApplicationInstance.create({ application: app });
+  });
+
+  let PostController = factory();
+
+  appInstance.register('controller:post', PostController);
+
+  let postController1 = appInstance.lookup('controller:post');
+  assert.ok(postController1, 'lookup creates instance');
+
+  appInstance.unregister('controller:post');
+  appInstance.register('controller:post', PostController);
+
+  let postController2 = appInstance.lookup('controller:post');
+  assert.ok(postController2, 'lookup creates instance');
+
+  assert.notStrictEqual(postController1, postController2, 'lookup creates a brand new instance, because previous one was reset');
 });


### PR DESCRIPTION
`ApplicationInstance#unregister` now overrides 
`RegistryProxy#unregister` in order to clear any cached instances of the
unregistered factory (via `__container__.reset()`).

[Closes #11173]
