### PR TITLE
[FEATURE ember-application-engines] Initial extraction of engines from applications

### DIFF
--- a/features.json
+++ b/features.json
@@ -10,6 +10,7 @@
     "ember-metal-ember-assign": null,
     "ember-contextual-components": true,
     "ember-container-inject-owner": true,
-    "ember-htmlbars-local-lookup": null
+    "ember-htmlbars-local-lookup": null,
+    "ember-application-engines": null
   }
 }

--- a/packages/ember-application/lib/index.js
+++ b/packages/ember-application/lib/index.js
@@ -1,4 +1,5 @@
 import Ember from 'ember-metal/core';
+import isEnabled from 'ember-metal/features';
 import { runLoadHooks } from 'ember-runtime/system/lazy_load';
 
 /**
@@ -11,10 +12,14 @@ import {
   Resolver
 } from 'ember-application/system/resolver';
 import Application from 'ember-application/system/application';
+import Engine from 'ember-application/system/engine';
 
 Ember.Application = Application;
 Ember.Resolver = Resolver;
 Ember.DefaultResolver = DefaultResolver;
 
+if (isEnabled('ember-application-engines')) {
+  Ember.Engine = Engine;
+}
 
 runLoadHooks('Ember.Application', Application);

--- a/packages/ember-application/lib/index.js
+++ b/packages/ember-application/lib/index.js
@@ -12,7 +12,9 @@ import {
   Resolver
 } from 'ember-application/system/resolver';
 import Application from 'ember-application/system/application';
+import ApplicationInstance from 'ember-application/system/application-instance';
 import Engine from 'ember-application/system/engine';
+import EngineInstance from 'ember-application/system/engine-instance';
 
 Ember.Application = Application;
 Ember.Resolver = Resolver;
@@ -20,6 +22,11 @@ Ember.DefaultResolver = DefaultResolver;
 
 if (isEnabled('ember-application-engines')) {
   Ember.Engine = Engine;
+
+  // Expose `EngineInstance` and `ApplicationInstance` for easy overriding.
+  // Reanalyze whether to continue exposing these after feature flag is removed.
+  Ember.EngineInstance = EngineInstance;
+  Ember.ApplicationInstance = ApplicationInstance;
 }
 
 runLoadHooks('Ember.Application', Application);

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -7,18 +7,17 @@ import { deprecate } from 'ember-metal/debug';
 import isEnabled from 'ember-metal/features';
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
-import EmberObject from 'ember-runtime/system/object';
 import run from 'ember-metal/run_loop';
 import { computed } from 'ember-metal/computed';
-import ContainerProxy from 'ember-runtime/mixins/container_proxy';
 import DOMHelper from 'ember-htmlbars/system/dom-helper';
 import Registry from 'container/registry';
-import RegistryProxy, { buildFakeRegistryWithDeprecations } from 'ember-runtime/mixins/registry_proxy';
+import { buildFakeRegistryWithDeprecations } from 'ember-runtime/mixins/registry_proxy';
 import Renderer from 'ember-metal-views/renderer';
 import assign from 'ember-metal/assign';
 import environment from 'ember-metal/environment';
 import RSVP from 'ember-runtime/ext/rsvp';
 import jQuery from 'ember-views/system/jquery';
+import EngineInstance from './engine-instance';
 
 
 let BootOptions;
@@ -45,12 +44,10 @@ let BootOptions;
 
   @public
   @class Ember.ApplicationInstance
-  @extends Ember.Object
-  @uses RegistryProxyMixin
-  @uses ContainerProxyMixin
+  @extends Ember.EngineInstance
 */
 
-let ApplicationInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
+let ApplicationInstance = EngineInstance.extend({
   /**
     The `Application` for which this is an instance.
 

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -10,7 +10,6 @@ import { set } from 'ember-metal/property_set';
 import run from 'ember-metal/run_loop';
 import { computed } from 'ember-metal/computed';
 import DOMHelper from 'ember-htmlbars/system/dom-helper';
-import Registry from 'container/registry';
 import { buildFakeRegistryWithDeprecations } from 'ember-runtime/mixins/registry_proxy';
 import Renderer from 'ember-metal-views/renderer';
 import assign from 'ember-metal/assign';
@@ -82,21 +81,11 @@ let ApplicationInstance = EngineInstance.extend({
   init() {
     this._super(...arguments);
 
-    var application = get(this, 'application');
+    let application = get(this, 'application');
 
     if (!isEnabled('ember-application-visit')) {
       set(this, 'rootElement', get(application, 'rootElement'));
     }
-
-    // Create a per-instance registry that will use the application's registry
-    // as a fallback for resolving registrations.
-    var applicationRegistry = get(application, '__registry__');
-    var registry = this.__registry__ = new Registry({
-      fallback: applicationRegistry
-    });
-
-    // Create a per-instance container from the instance's registry
-    this.__container__ = registry.container({ owner: this });
 
     // Register this instance in the per-instance registry.
     //
@@ -267,29 +256,6 @@ let ApplicationInstance = EngineInstance.extend({
     dispatcher.setup(customEvents, this.rootElement);
 
     return dispatcher;
-  },
-
-  /**
-    @private
-  */
-  willDestroy() {
-    this._super(...arguments);
-    run(this.__container__, 'destroy');
-  },
-
-  /**
-   Unregister a factory.
-
-   Overrides `RegistryProxy#unregister` in order to clear any cached instances
-   of the unregistered factory.
-
-   @public
-   @method unregister
-   @param {String} fullName
-   */
-  unregister(fullName) {
-    this.__container__.reset(fullName);
-    this._super(...arguments);
   }
 });
 

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -46,7 +46,7 @@ let BootOptions;
   @extends Ember.EngineInstance
 */
 
-let ApplicationInstance = EngineInstance.extend({
+const ApplicationInstance = EngineInstance.extend({
   /**
     The `Application` for which this is an instance.
 

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -81,7 +81,7 @@ const ApplicationInstance = EngineInstance.extend({
   init() {
     this._super(...arguments);
 
-    let application = get(this, 'application');
+    let application = this.application;
 
     if (!isEnabled('ember-application-visit')) {
       set(this, 'rootElement', get(application, 'rootElement'));

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -2,19 +2,16 @@
 @module ember
 @submodule ember-application
 */
-import DAG from 'dag-map';
 import Registry from 'container/registry';
 
 import Ember from 'ember-metal'; // Ember.libraries, LOG_VERSION, Namespace, BOOTED
-import { assert, deprecate, debug } from 'ember-metal/debug';
+import { assert, debug } from 'ember-metal/debug';
 import isEnabled from 'ember-metal/features';
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
-import EmptyObject from 'ember-metal/empty_object';
 import { runLoadHooks } from 'ember-runtime/system/lazy_load';
 import DefaultResolver from 'ember-application/system/resolver';
 import run from 'ember-metal/run_loop';
-import { canInvoke } from 'ember-metal/utils';
 import Controller from 'ember-runtime/controllers/controller';
 import Renderer from 'ember-metal-views/renderer';
 import DOMHelper from 'ember-htmlbars/system/dom-helper';
@@ -43,16 +40,6 @@ import { buildFakeRegistryWithDeprecations } from 'ember-runtime/mixins/registry
 import environment from 'ember-metal/environment';
 import RSVP from 'ember-runtime/ext/rsvp';
 import Engine from './engine';
-
-function props(obj) {
-  var properties = [];
-
-  for (var key in obj) {
-    properties.push(key);
-  }
-
-  return properties;
-}
 
 var librariesRegistered = false;
 
@@ -398,7 +385,7 @@ var Application = Engine.extend({
     @return {Ember.Registry} the configured registry
   */
   buildRegistry() {
-    var registry = this.__registry__ = Application.buildRegistry(this);
+    var registry = this.__registry__ = this.constructor.buildRegistry(this);
 
     return registry;
   },
@@ -739,66 +726,6 @@ var Application = Engine.extend({
 
   /**
     @private
-    @method instanceInitializer
-  */
-  instanceInitializer(options) {
-    this.constructor.instanceInitializer(options);
-  },
-
-  /**
-    @private
-    @method runInitializers
-  */
-  runInitializers() {
-    var App = this;
-    this._runInitializer('initializers', function(name, initializer) {
-      assert('No application initializer named \'' + name + '\'', !!initializer);
-      if (initializer.initialize.length === 2) {
-        deprecate('The `initialize` method for Application initializer \'' + name + '\' should take only one argument - `App`, an instance of an `Application`.',
-                  false,
-                  {
-                    id: 'ember-application.app-initializer-initialize-arguments',
-                    until: '3.0.0',
-                    url: 'http://emberjs.com/deprecations/v2.x/#toc_initializer-arity'
-                  });
-
-        initializer.initialize(App.__registry__, App);
-      } else {
-        initializer.initialize(App);
-      }
-    });
-  },
-
-  /**
-    @private
-    @since 1.12.0
-    @method runInstanceInitializers
-  */
-  runInstanceInitializers(instance) {
-    this._runInitializer('instanceInitializers', function(name, initializer) {
-      assert('No instance initializer named \'' + name + '\'', !!initializer);
-      initializer.initialize(instance);
-    });
-  },
-
-  _runInitializer(bucketName, cb) {
-    var initializersByName = get(this.constructor, bucketName);
-    var initializers = props(initializersByName);
-    var graph = new DAG();
-    var initializer;
-
-    for (var i = 0; i < initializers.length; i++) {
-      initializer = initializersByName[initializers[i]];
-      graph.addEdges(initializer.name, initializer, initializer.before, initializer.after);
-    }
-
-    graph.topsort(function (vertex) {
-      cb(vertex.name, vertex.value);
-    });
-  },
-
-  /**
-    @private
     @method didBecomeReady
   */
   didBecomeReady() {
@@ -898,10 +825,6 @@ var Application = Engine.extend({
     if (this._globalsMode && this.__deprecatedInstance__) {
       this.__deprecatedInstance__.destroy();
     }
-  },
-
-  initializer(options) {
-    this.constructor.initializer(options);
   }
 });
 
@@ -911,73 +834,6 @@ Object.defineProperty(Application.prototype, 'registry', {
   get() {
     return buildFakeRegistryWithDeprecations(this, 'Application');
   }
-});
-
-Application.reopenClass({
-  /**
-    Instance initializers run after all initializers have run. Because
-    instance initializers run after the app is fully set up. We have access
-    to the store, container, and other items. However, these initializers run
-    after code has loaded and are not allowed to defer readiness.
-
-    Instance initializer receives an object which has the following attributes:
-    `name`, `before`, `after`, `initialize`. The only required attribute is
-    `initialize`, all others are optional.
-
-    * `name` allows you to specify under which name the instanceInitializer is
-    registered. This must be a unique name, as trying to register two
-    instanceInitializer with the same name will result in an error.
-
-    ```javascript
-    Ember.Application.instanceInitializer({
-      name: 'namedinstanceInitializer',
-
-      initialize: function(application) {
-        Ember.debug('Running namedInitializer!');
-      }
-    });
-    ```
-
-    * `before` and `after` are used to ensure that this initializer is ran prior
-    or after the one identified by the value. This value can be a single string
-    or an array of strings, referencing the `name` of other initializers.
-
-    * See Ember.Application.initializer for discussion on the usage of before
-    and after.
-
-    Example instanceInitializer to preload data into the store.
-
-    ```javascript
-    Ember.Application.initializer({
-      name: 'preload-data',
-
-      initialize: function(application) {
-        var userConfig, userConfigEncoded, store;
-        // We have a HTML escaped JSON representation of the user's basic
-        // configuration generated server side and stored in the DOM of the main
-        // index.html file. This allows the app to have access to a set of data
-        // without making any additional remote calls. Good for basic data that is
-        // needed for immediate rendering of the page. Keep in mind, this data,
-        // like all local models and data can be manipulated by the user, so it
-        // should not be relied upon for security or authorization.
-        //
-        // Grab the encoded data from the meta tag
-        userConfigEncoded = Ember.$('head meta[name=app-user-config]').attr('content');
-        // Unescape the text, then parse the resulting JSON into a real object
-        userConfig = JSON.parse(unescape(userConfigEncoded));
-        // Lookup the store
-        store = application.lookup('service:store');
-        // Push the encoded JSON into the store
-        store.pushPayload(userConfig);
-      }
-    });
-    ```
-
-    @method instanceInitializer
-    @param instanceInitializer
-    @public
-  */
-  instanceInitializer: buildInitializerMethod('instanceInitializers', 'instance initializer')
 });
 
 if (isEnabled('ember-application-visit')) {
@@ -1190,129 +1046,6 @@ if (isEnabled('ember-application-visit')) {
 }
 
 Application.reopenClass({
-  initializers: new EmptyObject(),
-  instanceInitializers: new EmptyObject(),
-
-  /**
-    The goal of initializers should be to register dependencies and injections.
-    This phase runs once. Because these initializers may load code, they are
-    allowed to defer application readiness and advance it. If you need to access
-    the container or store you should use an InstanceInitializer that will be run
-    after all initializers and therefore after all code is loaded and the app is
-    ready.
-
-    Initializer receives an object which has the following attributes:
-    `name`, `before`, `after`, `initialize`. The only required attribute is
-    `initialize`, all others are optional.
-
-    * `name` allows you to specify under which name the initializer is registered.
-    This must be a unique name, as trying to register two initializers with the
-    same name will result in an error.
-
-    ```javascript
-    Ember.Application.initializer({
-      name: 'namedInitializer',
-
-      initialize: function(application) {
-        Ember.debug('Running namedInitializer!');
-      }
-    });
-    ```
-
-    * `before` and `after` are used to ensure that this initializer is ran prior
-    or after the one identified by the value. This value can be a single string
-    or an array of strings, referencing the `name` of other initializers.
-
-    An example of ordering initializers, we create an initializer named `first`:
-
-    ```javascript
-    Ember.Application.initializer({
-      name: 'first',
-
-      initialize: function(application) {
-        Ember.debug('First initializer!');
-      }
-    });
-
-    // DEBUG: First initializer!
-    ```
-
-    We add another initializer named `second`, specifying that it should run
-    after the initializer named `first`:
-
-    ```javascript
-    Ember.Application.initializer({
-      name: 'second',
-      after: 'first',
-
-      initialize: function(application) {
-        Ember.debug('Second initializer!');
-      }
-    });
-
-    // DEBUG: First initializer!
-    // DEBUG: Second initializer!
-    ```
-
-    Afterwards we add a further initializer named `pre`, this time specifying
-    that it should run before the initializer named `first`:
-
-    ```javascript
-    Ember.Application.initializer({
-      name: 'pre',
-      before: 'first',
-
-      initialize: function(application) {
-        Ember.debug('Pre initializer!');
-      }
-    });
-
-    // DEBUG: Pre initializer!
-    // DEBUG: First initializer!
-    // DEBUG: Second initializer!
-    ```
-
-    Finally we add an initializer named `post`, specifying it should run after
-    both the `first` and the `second` initializers:
-
-    ```javascript
-    Ember.Application.initializer({
-      name: 'post',
-      after: ['first', 'second'],
-
-      initialize: function(application) {
-        Ember.debug('Post initializer!');
-      }
-    });
-
-    // DEBUG: Pre initializer!
-    // DEBUG: First initializer!
-    // DEBUG: Second initializer!
-    // DEBUG: Post initializer!
-    ```
-
-    * `initialize` is a callback function that receives one argument,
-      `application`, on which you can operate.
-
-    Example of using `application` to register an adapter:
-
-    ```javascript
-    Ember.Application.initializer({
-      name: 'api-adapter',
-
-      initialize: function(application) {
-        application.register('api-adapter:main', ApiAdapter);
-      }
-    });
-    ```
-
-    @method initializer
-    @param initializer {Object}
-    @public
-  */
-
-  initializer: buildInitializerMethod('initializers', 'initializer'),
-
   /**
     This creates a registry with the default Ember naming conventions.
 
@@ -1466,26 +1199,6 @@ function logLibraryVersions() {
     }
     debug('-------------------------------');
   }
-}
-
-function buildInitializerMethod(bucketName, humanName) {
-  return function(initializer) {
-    // If this is the first initializer being added to a subclass, we are going to reopen the class
-    // to make sure we have a new `initializers` object, which extends from the parent class' using
-    // prototypal inheritance. Without this, attempting to add initializers to the subclass would
-    // pollute the parent class as well as other subclasses.
-    if (this.superclass[bucketName] !== undefined && this.superclass[bucketName] === this[bucketName]) {
-      var attrs = {};
-      attrs[bucketName] = Object.create(this[bucketName]);
-      this.reopenClass(attrs);
-    }
-
-    assert('The ' + humanName + ' \'' + initializer.name + '\' has already been registered', !this[bucketName][initializer.name]);
-    assert('An ' + humanName + ' cannot be registered without an initialize function', canInvoke(initializer, 'initialize'));
-    assert('An ' + humanName + ' cannot be registered without a name property', initializer.name !== undefined);
-
-    this[bucketName][initializer.name] = initializer;
-  };
 }
 
 export default Application;

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -196,7 +196,7 @@ var librariesRegistered = false;
   @public
 */
 
-var Application = Engine.extend({
+const Application = Engine.extend({
   _suppressDeferredDeprecation: true,
 
   /**

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -12,7 +12,6 @@ import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
 import EmptyObject from 'ember-metal/empty_object';
 import { runLoadHooks } from 'ember-runtime/system/lazy_load';
-import Namespace from 'ember-runtime/system/namespace';
 import DefaultResolver from 'ember-application/system/resolver';
 import run from 'ember-metal/run_loop';
 import { canInvoke } from 'ember-metal/utils';
@@ -40,9 +39,10 @@ import LinkToComponent from 'ember-routing-views/components/link-to';
 import RoutingService from 'ember-routing/services/routing';
 import ContainerDebugAdapter from 'ember-extension-support/container_debug_adapter';
 import { _loaded } from 'ember-runtime/system/lazy_load';
-import RegistryProxy, { buildFakeRegistryWithDeprecations } from 'ember-runtime/mixins/registry_proxy';
+import { buildFakeRegistryWithDeprecations } from 'ember-runtime/mixins/registry_proxy';
 import environment from 'ember-metal/environment';
 import RSVP from 'ember-runtime/ext/rsvp';
+import Engine from './engine';
 
 function props(obj) {
   var properties = [];
@@ -208,12 +208,12 @@ var librariesRegistered = false;
 
   @class Application
   @namespace Ember
-  @extends Ember.Namespace
+  @extends Ember.Engine
   @uses RegistryProxyMixin
   @public
 */
 
-var Application = Namespace.extend(RegistryProxy, {
+var Application = Engine.extend({
   _suppressDeferredDeprecation: true,
 
   /**

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -379,6 +379,7 @@ var Application = Engine.extend({
     @return {Ember.ApplicationInstance} the application instance
   */
   buildInstance(options = {}) {
+    options.base = this;
     options.application = this;
     return ApplicationInstance.create(options);
   },

--- a/packages/ember-application/lib/system/engine-instance.js
+++ b/packages/ember-application/lib/system/engine-instance.js
@@ -22,7 +22,7 @@ import run from 'ember-metal/run_loop';
   @uses ContainerProxyMixin
 */
 
-let EngineInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
+const EngineInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
   /**
     The base `Engine` for which this is an instance.
 

--- a/packages/ember-application/lib/system/engine-instance.js
+++ b/packages/ember-application/lib/system/engine-instance.js
@@ -4,8 +4,12 @@
 */
 
 import EmberObject from 'ember-runtime/system/object';
+import Registry from 'container/registry';
 import ContainerProxy from 'ember-runtime/mixins/container_proxy';
 import RegistryProxy from 'ember-runtime/mixins/registry_proxy';
+import { get } from 'ember-metal/property_get';
+import { set } from 'ember-metal/property_set';
+import run from 'ember-metal/run_loop';
 
 /**
   The `EngineInstance` encapsulates all of the stateful aspects of a
@@ -20,12 +24,56 @@ import RegistryProxy from 'ember-runtime/mixins/registry_proxy';
 
 let EngineInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
   /**
-    The `Engine` for which this is an instance.
+    The base `Engine` for which this is an instance.
 
     @property {Ember.Engine} engine
     @private
   */
-  engine: null
+  base: null,
+
+  init() {
+    this._super(...arguments);
+
+    let base = get(this, 'base');
+
+    if (!base) {
+      base = get(this, 'application');
+      set(this, 'base', base);
+    }
+
+    // Create a per-instance registry that will use the application's registry
+    // as a fallback for resolving registrations.
+    let baseRegistry = get(base, '__registry__');
+    let registry = this.__registry__ = new Registry({
+      fallback: baseRegistry
+    });
+
+    // Create a per-instance container from the instance's registry
+    this.__container__ = registry.container({ owner: this });
+  },
+
+  /**
+   Unregister a factory.
+
+   Overrides `RegistryProxy#unregister` in order to clear any cached instances
+   of the unregistered factory.
+
+   @public
+   @method unregister
+   @param {String} fullName
+   */
+  unregister(fullName) {
+    this.__container__.reset(fullName);
+    this._super(...arguments);
+  },
+
+  /**
+    @private
+  */
+  willDestroy() {
+    this._super(...arguments);
+    run(this.__container__, 'destroy');
+  }
 });
 
 export default EngineInstance;

--- a/packages/ember-application/lib/system/engine-instance.js
+++ b/packages/ember-application/lib/system/engine-instance.js
@@ -7,8 +7,6 @@ import EmberObject from 'ember-runtime/system/object';
 import Registry from 'container/registry';
 import ContainerProxy from 'ember-runtime/mixins/container_proxy';
 import RegistryProxy from 'ember-runtime/mixins/registry_proxy';
-import { get } from 'ember-metal/property_get';
-import { set } from 'ember-metal/property_set';
 import run from 'ember-metal/run_loop';
 
 /**
@@ -34,18 +32,17 @@ const EngineInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
   init() {
     this._super(...arguments);
 
-    let base = get(this, 'base');
+    let base = this.base;
 
     if (!base) {
-      base = get(this, 'application');
-      set(this, 'base', base);
+      base = this.application;
+      this.base = base;
     }
 
     // Create a per-instance registry that will use the application's registry
     // as a fallback for resolving registrations.
-    let baseRegistry = get(base, '__registry__');
     let registry = this.__registry__ = new Registry({
-      fallback: baseRegistry
+      fallback: base.__registry__
     });
 
     // Create a per-instance container from the instance's registry

--- a/packages/ember-application/lib/system/engine-instance.js
+++ b/packages/ember-application/lib/system/engine-instance.js
@@ -1,0 +1,31 @@
+/**
+@module ember
+@submodule ember-application
+*/
+
+import EmberObject from 'ember-runtime/system/object';
+import ContainerProxy from 'ember-runtime/mixins/container_proxy';
+import RegistryProxy from 'ember-runtime/mixins/registry_proxy';
+
+/**
+  The `EngineInstance` encapsulates all of the stateful aspects of a
+  running `Engine`.
+
+  @public
+  @class Ember.EngineInstance
+  @extends Ember.Object
+  @uses RegistryProxyMixin
+  @uses ContainerProxyMixin
+*/
+
+let EngineInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
+  /**
+    The `Engine` for which this is an instance.
+
+    @property {Ember.Engine} engine
+    @private
+  */
+  engine: null
+});
+
+export default EngineInstance;

--- a/packages/ember-application/lib/system/engine.js
+++ b/packages/ember-application/lib/system/engine.js
@@ -1,0 +1,30 @@
+/**
+@module ember
+@submodule ember-application
+*/
+import Namespace from 'ember-runtime/system/namespace';
+import RegistryProxy from 'ember-runtime/mixins/registry_proxy';
+
+/**
+  The `Engine` class contains core functionality for both applications and
+  engines.
+
+  Each engine manages a registry that's used for dependency injection and
+  exposed through `RegistryProxy`.
+
+  Engines also manage initializers and instance initializers.
+
+  Engines can spawn `EngineInstance` instances via `buildInstance()`.
+
+  @class Engine
+  @namespace Ember
+  @extends Ember.Namespace
+  @uses RegistryProxyMixin
+  @public
+*/
+
+let Engine = Namespace.extend(RegistryProxy, {
+
+});
+
+export default Engine;

--- a/packages/ember-application/lib/system/engine.js
+++ b/packages/ember-application/lib/system/engine.js
@@ -4,6 +4,21 @@
 */
 import Namespace from 'ember-runtime/system/namespace';
 import RegistryProxy from 'ember-runtime/mixins/registry_proxy';
+import DAG from 'dag-map';
+import { get } from 'ember-metal/property_get';
+import { assert, deprecate } from 'ember-metal/debug';
+import { canInvoke } from 'ember-metal/utils';
+import EmptyObject from 'ember-metal/empty_object';
+
+function props(obj) {
+  var properties = [];
+
+  for (var key in obj) {
+    properties.push(key);
+  }
+
+  return properties;
+}
 
 /**
   The `Engine` class contains core functionality for both applications and
@@ -19,12 +34,286 @@ import RegistryProxy from 'ember-runtime/mixins/registry_proxy';
   @class Engine
   @namespace Ember
   @extends Ember.Namespace
-  @uses RegistryProxyMixin
+  @uses RegistryProxy
   @public
 */
-
 let Engine = Namespace.extend(RegistryProxy, {
+  /**
+    @private
+    @method initializer
+  */
+  initializer(options) {
+    this.constructor.initializer(options);
+  },
 
+  /**
+    @private
+    @method instanceInitializer
+  */
+  instanceInitializer(options) {
+    this.constructor.instanceInitializer(options);
+  },
+
+  /**
+    @private
+    @method runInitializers
+  */
+  runInitializers() {
+    this._runInitializer('initializers', (name, initializer) => {
+      assert('No application initializer named \'' + name + '\'', !!initializer);
+      if (initializer.initialize.length === 2) {
+        deprecate('The `initialize` method for Application initializer \'' + name + '\' should take only one argument - `App`, an instance of an `Application`.',
+                  false,
+                  {
+                    id: 'ember-application.app-initializer-initialize-arguments',
+                    until: '3.0.0',
+                    url: 'http://emberjs.com/deprecations/v2.x/#toc_initializer-arity'
+                  });
+
+        initializer.initialize(this.__registry__, this);
+      } else {
+        initializer.initialize(this);
+      }
+    });
+  },
+
+  /**
+    @private
+    @since 1.12.0
+    @method runInstanceInitializers
+  */
+  runInstanceInitializers(instance) {
+    this._runInitializer('instanceInitializers', (name, initializer) => {
+      assert('No instance initializer named \'' + name + '\'', !!initializer);
+      initializer.initialize(instance);
+    });
+  },
+
+  _runInitializer(bucketName, cb) {
+    var initializersByName = get(this.constructor, bucketName);
+    var initializers = props(initializersByName);
+    var graph = new DAG();
+    var initializer;
+
+    for (var i = 0; i < initializers.length; i++) {
+      initializer = initializersByName[initializers[i]];
+      graph.addEdges(initializer.name, initializer, initializer.before, initializer.after);
+    }
+
+    graph.topsort(function (vertex) {
+      cb(vertex.name, vertex.value);
+    });
+  }
 });
+
+Engine.reopenClass({
+  initializers: new EmptyObject(),
+  instanceInitializers: new EmptyObject(),
+
+  /**
+    The goal of initializers should be to register dependencies and injections.
+    This phase runs once. Because these initializers may load code, they are
+    allowed to defer application readiness and advance it. If you need to access
+    the container or store you should use an InstanceInitializer that will be run
+    after all initializers and therefore after all code is loaded and the app is
+    ready.
+
+    Initializer receives an object which has the following attributes:
+    `name`, `before`, `after`, `initialize`. The only required attribute is
+    `initialize`, all others are optional.
+
+    * `name` allows you to specify under which name the initializer is registered.
+    This must be a unique name, as trying to register two initializers with the
+    same name will result in an error.
+
+    ```javascript
+    Ember.Application.initializer({
+      name: 'namedInitializer',
+
+      initialize: function(application) {
+        Ember.debug('Running namedInitializer!');
+      }
+    });
+    ```
+
+    * `before` and `after` are used to ensure that this initializer is ran prior
+    or after the one identified by the value. This value can be a single string
+    or an array of strings, referencing the `name` of other initializers.
+
+    An example of ordering initializers, we create an initializer named `first`:
+
+    ```javascript
+    Ember.Application.initializer({
+      name: 'first',
+
+      initialize: function(application) {
+        Ember.debug('First initializer!');
+      }
+    });
+
+    // DEBUG: First initializer!
+    ```
+
+    We add another initializer named `second`, specifying that it should run
+    after the initializer named `first`:
+
+    ```javascript
+    Ember.Application.initializer({
+      name: 'second',
+      after: 'first',
+
+      initialize: function(application) {
+        Ember.debug('Second initializer!');
+      }
+    });
+
+    // DEBUG: First initializer!
+    // DEBUG: Second initializer!
+    ```
+
+    Afterwards we add a further initializer named `pre`, this time specifying
+    that it should run before the initializer named `first`:
+
+    ```javascript
+    Ember.Application.initializer({
+      name: 'pre',
+      before: 'first',
+
+      initialize: function(application) {
+        Ember.debug('Pre initializer!');
+      }
+    });
+
+    // DEBUG: Pre initializer!
+    // DEBUG: First initializer!
+    // DEBUG: Second initializer!
+    ```
+
+    Finally we add an initializer named `post`, specifying it should run after
+    both the `first` and the `second` initializers:
+
+    ```javascript
+    Ember.Application.initializer({
+      name: 'post',
+      after: ['first', 'second'],
+
+      initialize: function(application) {
+        Ember.debug('Post initializer!');
+      }
+    });
+
+    // DEBUG: Pre initializer!
+    // DEBUG: First initializer!
+    // DEBUG: Second initializer!
+    // DEBUG: Post initializer!
+    ```
+
+    * `initialize` is a callback function that receives one argument,
+      `application`, on which you can operate.
+
+    Example of using `application` to register an adapter:
+
+    ```javascript
+    Ember.Application.initializer({
+      name: 'api-adapter',
+
+      initialize: function(application) {
+        application.register('api-adapter:main', ApiAdapter);
+      }
+    });
+    ```
+
+    @method initializer
+    @param initializer {Object}
+    @public
+  */
+
+  initializer: buildInitializerMethod('initializers', 'initializer'),
+
+  /**
+    Instance initializers run after all initializers have run. Because
+    instance initializers run after the app is fully set up. We have access
+    to the store, container, and other items. However, these initializers run
+    after code has loaded and are not allowed to defer readiness.
+
+    Instance initializer receives an object which has the following attributes:
+    `name`, `before`, `after`, `initialize`. The only required attribute is
+    `initialize`, all others are optional.
+
+    * `name` allows you to specify under which name the instanceInitializer is
+    registered. This must be a unique name, as trying to register two
+    instanceInitializer with the same name will result in an error.
+
+    ```javascript
+    Ember.Application.instanceInitializer({
+      name: 'namedinstanceInitializer',
+
+      initialize: function(application) {
+        Ember.debug('Running namedInitializer!');
+      }
+    });
+    ```
+
+    * `before` and `after` are used to ensure that this initializer is ran prior
+    or after the one identified by the value. This value can be a single string
+    or an array of strings, referencing the `name` of other initializers.
+
+    * See Ember.Application.initializer for discussion on the usage of before
+    and after.
+
+    Example instanceInitializer to preload data into the store.
+
+    ```javascript
+    Ember.Application.initializer({
+      name: 'preload-data',
+
+      initialize: function(application) {
+        var userConfig, userConfigEncoded, store;
+        // We have a HTML escaped JSON representation of the user's basic
+        // configuration generated server side and stored in the DOM of the main
+        // index.html file. This allows the app to have access to a set of data
+        // without making any additional remote calls. Good for basic data that is
+        // needed for immediate rendering of the page. Keep in mind, this data,
+        // like all local models and data can be manipulated by the user, so it
+        // should not be relied upon for security or authorization.
+        //
+        // Grab the encoded data from the meta tag
+        userConfigEncoded = Ember.$('head meta[name=app-user-config]').attr('content');
+        // Unescape the text, then parse the resulting JSON into a real object
+        userConfig = JSON.parse(unescape(userConfigEncoded));
+        // Lookup the store
+        store = application.lookup('service:store');
+        // Push the encoded JSON into the store
+        store.pushPayload(userConfig);
+      }
+    });
+    ```
+
+    @method instanceInitializer
+    @param instanceInitializer
+    @public
+  */
+  instanceInitializer: buildInitializerMethod('instanceInitializers', 'instance initializer')
+});
+
+function buildInitializerMethod(bucketName, humanName) {
+  return function(initializer) {
+    // If this is the first initializer being added to a subclass, we are going to reopen the class
+    // to make sure we have a new `initializers` object, which extends from the parent class' using
+    // prototypal inheritance. Without this, attempting to add initializers to the subclass would
+    // pollute the parent class as well as other subclasses.
+    if (this.superclass[bucketName] !== undefined && this.superclass[bucketName] === this[bucketName]) {
+      var attrs = {};
+      attrs[bucketName] = Object.create(this[bucketName]);
+      this.reopenClass(attrs);
+    }
+
+    assert('The ' + humanName + ' \'' + initializer.name + '\' has already been registered', !this[bucketName][initializer.name]);
+    assert('An ' + humanName + ' cannot be registered without an initialize function', canInvoke(initializer, 'initialize'));
+    assert('An ' + humanName + ' cannot be registered without a name property', initializer.name !== undefined);
+
+    this[bucketName][initializer.name] = initializer;
+  };
+}
 
 export default Engine;

--- a/packages/ember-application/lib/system/engine.js
+++ b/packages/ember-application/lib/system/engine.js
@@ -12,6 +12,7 @@ import { assert, deprecate } from 'ember-metal/debug';
 import { canInvoke } from 'ember-metal/utils';
 import EmptyObject from 'ember-metal/empty_object';
 import DefaultResolver from 'ember-application/system/resolver';
+import EngineInstance from './engine-instance';
 
 function props(obj) {
   var properties = [];
@@ -45,6 +46,18 @@ let Engine = Namespace.extend(RegistryProxy, {
     this._super(...arguments);
 
     this.buildRegistry();
+  },
+
+  /**
+    Create an EngineInstance for this application.
+
+    @private
+    @method buildInstance
+    @return {Ember.EngineInstance} the application instance
+  */
+  buildInstance(options = {}) {
+    options.base = this;
+    return EngineInstance.create(options);
   },
 
   /**

--- a/packages/ember-application/lib/system/engine.js
+++ b/packages/ember-application/lib/system/engine.js
@@ -41,7 +41,7 @@ function props(obj) {
   @uses RegistryProxy
   @public
 */
-let Engine = Namespace.extend(RegistryProxy, {
+const Engine = Namespace.extend(RegistryProxy, {
   init() {
     this._super(...arguments);
 

--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -20,7 +20,7 @@ import {
   get as getTemplate
 } from 'ember-htmlbars/template_registry';
 
-export var Resolver = EmberObject.extend({
+export const Resolver = EmberObject.extend({
   /*
     This will be set to the Application instance when it is
     created.

--- a/packages/ember-application/tests/system/engine_instance_test.js
+++ b/packages/ember-application/tests/system/engine_instance_test.js
@@ -1,5 +1,7 @@
 import Engine from 'ember-application/system/engine';
+import EngineInstance from 'ember-application/system/engine-instance';
 import run from 'ember-metal/run_loop';
+import factory from 'container/tests/test-helpers/factory';
 
 let engine, engineInstance;
 
@@ -19,4 +21,36 @@ QUnit.module('Ember.EngineInstance', {
       run(engine, 'destroy');
     }
   }
+});
+
+QUnit.test('an engine instance can be created based upon a base engine', function() {
+  run(function() {
+    engineInstance = EngineInstance.create({ base: engine });
+  });
+
+  ok(engineInstance, 'instance should be created');
+  equal(engineInstance.base, engine, 'base should be set to engine');
+});
+
+QUnit.test('unregistering a factory clears all cached instances of that factory', function(assert) {
+  assert.expect(3);
+
+  run(function() {
+    engineInstance = EngineInstance.create({ base: engine });
+  });
+
+  let PostController = factory();
+
+  engineInstance.register('controller:post', PostController);
+
+  let postController1 = engineInstance.lookup('controller:post');
+  assert.ok(postController1, 'lookup creates instance');
+
+  engineInstance.unregister('controller:post');
+  engineInstance.register('controller:post', PostController);
+
+  let postController2 = engineInstance.lookup('controller:post');
+  assert.ok(postController2, 'lookup creates instance');
+
+  assert.notStrictEqual(postController1, postController2, 'lookup creates a brand new instance, because previous one was reset');
 });

--- a/packages/ember-application/tests/system/engine_instance_test.js
+++ b/packages/ember-application/tests/system/engine_instance_test.js
@@ -1,0 +1,22 @@
+import Engine from 'ember-application/system/engine';
+import run from 'ember-metal/run_loop';
+
+let engine, engineInstance;
+
+QUnit.module('Ember.EngineInstance', {
+  setup() {
+    run(function() {
+      engine = Engine.create({ router: null });
+    });
+  },
+
+  teardown() {
+    if (engineInstance) {
+      run(engineInstance, 'destroy');
+    }
+
+    if (engine) {
+      run(engine, 'destroy');
+    }
+  }
+});

--- a/packages/ember-application/tests/system/engine_test.js
+++ b/packages/ember-application/tests/system/engine_test.js
@@ -1,0 +1,18 @@
+import run from 'ember-metal/run_loop';
+import Engine from 'ember-application/system/engine';
+
+var engine;
+
+QUnit.module('Ember.Engine', {
+  setup() {
+    run(function() {
+      engine = Engine.create({ router: null });
+    });
+  },
+
+  teardown() {
+    if (engine) {
+      run(engine, 'destroy');
+    }
+  }
+});

--- a/packages/ember-application/tests/system/engine_test.js
+++ b/packages/ember-application/tests/system/engine_test.js
@@ -1,12 +1,14 @@
+import Ember from 'ember-metal/core';
 import run from 'ember-metal/run_loop';
 import Engine from 'ember-application/system/engine';
+import EmberObject from 'ember-runtime/system/object';
 
-var engine;
+let engine;
 
 QUnit.module('Ember.Engine', {
   setup() {
     run(function() {
-      engine = Engine.create({ router: null });
+      engine = Engine.create();
     });
   },
 
@@ -15,4 +17,15 @@ QUnit.module('Ember.Engine', {
       run(engine, 'destroy');
     }
   }
+});
+
+QUnit.test('acts like a namespace', function() {
+  let lookup = Ember.lookup = {};
+
+  run(function() {
+    engine = lookup.TestEngine = Engine.create();
+  });
+
+  engine.Foo = EmberObject.extend();
+  equal(engine.Foo.toString(), 'TestEngine.Foo', 'Classes pick up their parent namespace');
 });


### PR DESCRIPTION
This initial PR for engines follows the strategy proposed in the [Engines RFC](https://github.com/emberjs/rfcs/pull/10).

It introduces a base class, `Engine`, which is wholly extracted from (and then extended by) `Application`. Similarly, `EngineInstance` has been wholly extracted from (and then extended by) `ApplicationInstance`.

The `Engine` base class is now responsible for maintaining a registry and initializers.

The `EngineInstance` base class is now responsible for maintaining an instance-level registry and container.

`Ember.Engine` is only exposed when the new `ember-application-engines` feature flag is enabled.

The APIs and behavior of `Application` and `ApplicationInstance` remain identical, as do tests and documentation.

Some tests of extracted behavior were duplicated for engines, but the original tests for applications were kept in place. Any test duplication should be revisited before the feature flag is enabled.

The primary purpose of this PR is to allow for further experimentation with engines in an addon. It will also allow behavior to be folded into ember core gradually as experimentation proceeds.
