### PR TITLE
[DOC release] Remove whitespace from function declaration

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -411,7 +411,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     App.ArticlesRoute = Ember.Route.extend({
       // ...
 
-      resetController: function (controller, isExiting, transition) {
+      resetController: function(controller, isExiting, transition) {
         if (isExiting) {
           controller.set('page', 1);
         }
@@ -1626,7 +1626,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
         return this.store.findAll('photo');
       },
 
-      setupController: function (controller, model) {
+      setupController: function(controller, model) {
         // Call _super for default behavior
         this._super(controller, model);
         // Implement your custom setup after

--- a/packages/ember-runtime/lib/system/object_proxy.js
+++ b/packages/ember-runtime/lib/system/object_proxy.js
@@ -44,7 +44,7 @@ import _ProxyMixin from 'ember-runtime/mixins/-proxy';
 
   ```javascript
   ProxyWithComputedProperty = Ember.ObjectProxy.extend({
-    fullName: function () {
+    fullName: function() {
       var firstName = this.get('firstName'),
           lastName = this.get('lastName');
       if (firstName && lastName) {


### PR DESCRIPTION
Remove extra whitespace from a few function declarations in the docs to conform to the following guideline in the [Ember.js JavaScript Style Guide](https://github.com/emberjs/ember.js/blob/master/STYLEGUIDE.md#whitespace):
- Keep parenthesis adjacent to the function name when declared or called.

``` javascript
function foo() {
}

foo();
```
