### PR TITLE
[DOC release] Fix typos

### DIFF
--- a/packages/ember-htmlbars/lib/system/bootstrap.js
+++ b/packages/ember-htmlbars/lib/system/bootstrap.js
@@ -21,7 +21,7 @@ import environment from 'ember-metal/environment';
 /**
   Find templates stored in the head tag as script tags and make them available
   to `Ember.CoreView` in the global `Ember.TEMPLATES` object. This will be run
-  as as jQuery DOM-ready callback.
+  as a jQuery DOM-ready callback.
 
   Script tags with `text/x-handlebars` will be compiled
   with Ember's template compiler and are suitable for use as a view's template.

--- a/packages/ember-routing-views/lib/components/link-to.js
+++ b/packages/ember-routing-views/lib/components/link-to.js
@@ -140,8 +140,7 @@
   ### Keeping a link active for other routes
 
   If you need a link to be 'active' even when it doesn't match
-  the current route, you can use the the `current-when`
-  argument.
+  the current route, you can use the `current-when` argument.
 
   ```handlebars
   {{#link-to 'photoGallery' current-when='photos'}}

--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -343,7 +343,7 @@ export default Mixin.create(Enumerable, {
       called just after the array is modified.
 
     Both callbacks will be passed the observed object, starting index of the
-    change as well a a count of the items to be removed and added. You can use
+    change as well as a count of the items to be removed and added. You can use
     these callbacks to optionally inspect the array during the change, clear
     caches, or do any other bookkeeping necessary.
 

--- a/packages/ember-runtime/lib/mixins/promise_proxy.js
+++ b/packages/ember-runtime/lib/mixins/promise_proxy.js
@@ -60,7 +60,7 @@ function tap(proxy, promise) {
   proxy.get('isFulfilled') //=> false
   ```
 
-  When the the $.getJSON completes, and the promise is fulfilled
+  When the $.getJSON completes, and the promise is fulfilled
   with json, the life cycle attributes will update accordingly.
 
   ```javascript

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -226,7 +226,7 @@ Ember.TEMPLATES = {};
   <div id="ember1" class="ember-view disabled"></div>
   ```
 
-  Updates to the the value of a class name binding will result in automatic
+  Updates to the value of a class name binding will result in automatic
   update of the  HTML `class` attribute in the view's rendered HTML
   representation. If the value becomes `false` or `undefined` the class name
   will be removed.
@@ -323,7 +323,7 @@ Ember.TEMPLATES = {};
   });
   ```
 
-  Updates to the the property of an attribute binding will result in automatic
+  Updates to the property of an attribute binding will result in automatic
   update of the  HTML attribute in the view's rendered HTML representation.
 
   `attributeBindings` is a concatenated property. See [Ember.Object](/api/classes/Ember.Object.html)
@@ -507,7 +507,7 @@ Ember.TEMPLATES = {};
   ```javascript
   AView = Ember.View.extend({
     click: function(event) {
-      // will be called when when an instance's
+      // will be called when an instance's
       // rendered element is clicked
     }
   });
@@ -528,7 +528,7 @@ Ember.TEMPLATES = {};
   AView = Ember.View.extend({
     eventManager: Ember.Object.create({
       doubleClick: function(event, view) {
-        // will be called when when an instance's
+        // will be called when an instance's
         // rendered element or any rendering
         // of this view's descendant
         // elements is clicked


### PR DESCRIPTION
This fixes a series of double-word typos, and relates to https://github.com/emberjs/website/pull/2429.
