### PR TITLE
[BUGFIX beta] Only add deprecated container after create when present.

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -385,7 +385,9 @@ function instantiate(container, fullName) {
 
       // TODO - remove when Ember reaches v3.0.0
       if (isEnabled('ember-container-inject-owner')) {
-        injectDeprecatedContainer(obj, container);
+        if (!Object.isFrozen(obj) && 'container' in obj) {
+          injectDeprecatedContainer(obj, container);
+        }
       }
     }
 


### PR DESCRIPTION
When the object returned from calling `.create` on a non-extendable factory does not contain a `container` property, do not set it.

Previously, in Ember 2.2.0 it was possible to use non-extendable factories that were frozen after creation. After the changes to add a mock container to `.create` and swap that with the deprecated property after `.create` was finished, we trigger errors for anything that is frozen or sealed.

---

Addresses https://github.com/firebase/emberfire/issues/340
