### PR TITLE
[BUGFIX beta] Update HTMLBars

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2693,9 +2693,9 @@
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz"
     },
     "htmlbars": {
-      "version": "0.14.9",
-      "from": "htmlbars@0.14.9",
-      "resolved": "https://registry.npmjs.org/htmlbars/-/htmlbars-0.14.9.tgz"
+      "version": "0.14.10",
+      "from": "htmlbars@0.14.10",
+      "resolved": "https://registry.npmjs.org/htmlbars/-/htmlbars-0.14.10.tgz"
     },
     "htmlparser2": {
       "version": "3.8.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "finalhandler": "^0.4.0",
     "github": "^0.2.3",
     "glob": "~4.3.2",
-    "htmlbars": "0.14.9",
+    "htmlbars": "0.14.10",
     "qunit-extras": "^1.4.0",
     "qunitjs": "^1.19.0",
     "route-recognizer": "0.1.5",


### PR DESCRIPTION
Add support for Glimmer components whose name has a dot.

Please, can someone check this? I cannot install dependencies using the `npm-shrinkwrap` file but I can install them without it.

Furthermore, I don't know which prefix to use for this PR. `[BUGFIX canary]`? `[BUGFIX beta]`?
