### PR TITLE
[BUGFIX beta] Align Em.isArray behavior with Array.isArray for FileList type

### DIFF
--- a/packages/ember-runtime/lib/utils.js
+++ b/packages/ember-runtime/lib/utils.js
@@ -12,7 +12,8 @@ const TYPE_MAP = {
   '[object Array]':    'array',
   '[object Date]':     'date',
   '[object RegExp]':   'regexp',
-  '[object Object]':   'object'
+  '[object Object]':   'object',
+  '[object FileList]': 'filelist'
 };
 
 const { toString } = Object.prototype;
@@ -70,6 +71,7 @@ export function isArray(obj) {
       | 'array'       | An instance of Array                                 |
       | 'regexp'      | An instance of RegExp                                |
       | 'date'        | An instance of Date                                  |
+      | 'filelist'    | An instance of FileList                              |
       | 'class'       | An Ember class (created using Ember.Object.extend()) |
       | 'instance'    | An Ember object instance                             |
       | 'error'       | An instance of the Error object                      |
@@ -91,6 +93,7 @@ export function isArray(obj) {
   Ember.typeOf([1, 2, 90]);             // 'array'
   Ember.typeOf(/abc/);                  // 'regexp'
   Ember.typeOf(new Date());             // 'date'
+  Ember.typeOf(event.target.files);     // 'filelist'
   Ember.typeOf(Ember.Object.extend());  // 'class'
   Ember.typeOf(Ember.Object.create());  // 'instance'
   Ember.typeOf(new Error('teamocil'));  // 'error'

--- a/packages/ember-runtime/tests/core/is_array_test.js
+++ b/packages/ember-runtime/tests/core/is_array_test.js
@@ -1,6 +1,7 @@
 import { isArray } from '../../utils';
 import { A as emberA } from '../../system/native_array';
 import ArrayProxy from '../../system/array_proxy';
+import { environment } from 'ember-environment';
 
 QUnit.module('Ember Type Checking');
 
@@ -26,3 +27,12 @@ QUnit.test('Ember.isArray', function() {
   equal(isArray(fn), false, 'function() {}');
   equal(isArray(arrayProxy), true, '[]');
 });
+
+if (environment.window && typeof environment.window.FileList === 'function') {
+  QUnit.test('Ember.isArray(fileList)', function() {
+    let fileListElement = document.createElement('input');
+    fileListElement.type = 'file';
+    let fileList = fileListElement.files;
+    equal(isArray(fileList), false, 'fileList');
+  });
+}

--- a/packages/ember-runtime/tests/core/type_of_test.js
+++ b/packages/ember-runtime/tests/core/type_of_test.js
@@ -1,5 +1,6 @@
 import { typeOf } from '../../utils';
 import EmberObject from '../../system/object';
+import { environment } from 'ember-environment';
 
 QUnit.module('Ember Type Checking');
 
@@ -36,3 +37,12 @@ QUnit.test('Ember.typeOf', function() {
   equal(typeOf(EmberObject.extend()), 'class', 'item of type class');
   equal(typeOf(new Error()), 'error', 'item of type error');
 });
+
+if (environment.window && typeof environment.window.FileList === 'function') {
+  QUnit.test('Ember.typeOf(fileList)', function() {
+    let fileListElement = document.createElement('input');
+    fileListElement.type = 'file';
+    let fileList = fileListElement.files;
+    equal(typeOf(fileList), 'filelist', 'item of type filelist');
+  });
+}


### PR DESCRIPTION
`FileList` type is currently detected as `array`, however it doesn't provide it's methods like `forEach` or `map`.
Also `Array.isArray` doesn't consider `FileType` as an `array`.

This PR unifies this behavior and fixes #12688.
