### PR TITLE
[BUGFIX beta] Create a new hash parameter when creating a component cell 

### DIFF
--- a/packages/ember-htmlbars/lib/hooks/component.js
+++ b/packages/ember-htmlbars/lib/hooks/component.js
@@ -3,6 +3,8 @@ import { assert } from 'ember-metal/debug';
 import ComponentNodeManager from 'ember-htmlbars/node-managers/component-node-manager';
 import buildComponentTemplate, { buildHTMLTemplate } from 'ember-views/system/build-component-template';
 import lookupComponent from 'ember-htmlbars/utils/lookup-component';
+import assign from 'ember-metal/assign';
+import EmptyObject from 'ember-metal/empty_object';
 import Cache from 'ember-metal/cache';
 import {
   CONTAINS_DASH_CACHE,
@@ -42,9 +44,10 @@ export default function componentHook(renderNode, env, scope, _tagName, params, 
        * on top of the closure component attributes.
        *
        */
-      processPositionalParamsFromCell(componentCell, params, attrs);
+      let newAttrs = assign(new EmptyObject(), attrs);
+      processPositionalParamsFromCell(componentCell, params, newAttrs);
       params = [];
-      attrs = mergeInNewHash(componentCell[COMPONENT_HASH], attrs);
+      attrs = mergeInNewHash(componentCell[COMPONENT_HASH], newAttrs);
     }
   }
 

--- a/packages/ember-htmlbars/lib/keywords/closure-component.js
+++ b/packages/ember-htmlbars/lib/keywords/closure-component.js
@@ -7,6 +7,7 @@ import { assert } from 'ember-metal/debug';
 import isNone from 'ember-metal/is_none';
 import symbol from 'ember-metal/symbol';
 import BasicStream from 'ember-metal/streams/stream';
+import EmptyObject from 'ember-metal/empty_object';
 import { read } from 'ember-metal/streams/utils';
 import { labelForSubexpr } from 'ember-htmlbars/hooks/subexpr';
 import assign from 'ember-metal/assign';
@@ -54,12 +55,14 @@ function createClosureComponentCell(env, originalComponentPath, params, hash, la
   assert(`Component path cannot be null in ${label}`,
          !isNone(componentPath));
 
+  let newHash = assign(new EmptyObject(), hash);
+
   if (isComponentCell(componentPath)) {
-    return createNestedClosureComponentCell(componentPath, params, hash);
+    return createNestedClosureComponentCell(componentPath, params, newHash);
   } else {
     assert(`The component helper cannot be used without a valid component name. You used "${componentPath}" via ${label}`,
           isValidComponentPath(env, componentPath));
-    return createNewClosureComponentCell(env, componentPath, params, hash);
+    return createNewClosureComponentCell(env, componentPath, params, newHash);
   }
 }
 

--- a/packages/ember-htmlbars/lib/utils/extract-positional-params.js
+++ b/packages/ember-htmlbars/lib/utils/extract-positional-params.js
@@ -1,6 +1,6 @@
 import { assert } from 'ember-metal/debug';
 import { Stream } from 'ember-metal/streams/stream';
-import { readArray } from 'ember-metal/streams/utils';
+import { isStream, readArray } from 'ember-metal/streams/utils';
 
 export default function extractPositionalParams(renderNode, component, params, attrs) {
   let positionalParams = component.positionalParams;
@@ -25,9 +25,10 @@ function processNamedPositionalParameters(renderNode, positionalParams, params, 
 
   for (let i = 0; i < limit; i++) {
     let param = params[i];
+    let isActiveStreamParam = isStream(param) && param.isActive;
 
     assert(`You cannot specify both a positional param (at position ${i}) and the hash argument \`${positionalParams[i]}\`.`,
-           !(positionalParams[i] in attrs));
+           isActiveStreamParam || !(positionalParams[i] in attrs));
 
     attrs[positionalParams[i]] = param;
   }

--- a/packages/ember-htmlbars/lib/utils/extract-positional-params.js
+++ b/packages/ember-htmlbars/lib/utils/extract-positional-params.js
@@ -1,6 +1,6 @@
 import { assert } from 'ember-metal/debug';
 import { Stream } from 'ember-metal/streams/stream';
-import { isStream, readArray } from 'ember-metal/streams/utils';
+import { readArray } from 'ember-metal/streams/utils';
 
 export default function extractPositionalParams(renderNode, component, params, attrs) {
   let positionalParams = component.positionalParams;
@@ -25,10 +25,9 @@ function processNamedPositionalParameters(renderNode, positionalParams, params, 
 
   for (let i = 0; i < limit; i++) {
     let param = params[i];
-    let isActiveStreamParam = isStream(param) && param.isActive;
 
     assert(`You cannot specify both a positional param (at position ${i}) and the hash argument \`${positionalParams[i]}\`.`,
-           isActiveStreamParam || !(positionalParams[i] in attrs));
+           !(positionalParams[i] in attrs));
 
     attrs[positionalParams[i]] = param;
   }

--- a/packages/ember-htmlbars/tests/helpers/closure_component_test.js
+++ b/packages/ember-htmlbars/tests/helpers/closure_component_test.js
@@ -339,6 +339,38 @@ if (isEnabled('ember-contextual-components')) {
     }, `You cannot specify both a positional param (at position 0) and the hash argument \`name\`.`);
   });
 
+  QUnit.test('conflicting positional and hash parameters does not raise and assertion if rerendered', function() {
+    let LookedUp = Component.extend();
+    LookedUp.reopenClass({
+      positionalParams: ['name']
+    });
+    owner.register(
+      'component:-looked-up',
+      LookedUp
+    );
+    owner.register(
+      'template:components/-looked-up',
+      compile(`{{greeting}} {{name}}`)
+    );
+
+    let template = compile(
+      `{{component (component "-looked-up" name greeting="Hodi")}}`
+    );
+
+    component = Component.extend({
+      [OWNER]: owner,
+      template,
+      name: 'Hodari'
+    }).create();
+
+    runAppend(component);
+    equal(component.$().text(), 'Hodi Hodari', 'component is rendered');
+
+    run(() => component.set('name', 'Sergio'));
+
+    equal(component.$().text(), 'Hodi Sergio', 'component is rendered');
+  });
+
   QUnit.test('conflicting positional and hash parameters does not raise and assertion if in the different closure', function() {
     let LookedUp = Component.extend();
     LookedUp.reopenClass({


### PR DESCRIPTION
If we merge positional and hash parameters without duplicating the hash before,
then we get an error when rerendering.

Fixes test in #12711
