### PR TITLE
[BUGFIX beta] Enable component support in outlet

### DIFF
--- a/packages/ember-htmlbars/lib/keywords/outlet.js
+++ b/packages/ember-htmlbars/lib/keywords/outlet.js
@@ -7,7 +7,6 @@ import { info } from 'ember-metal/debug';
 import { get } from 'ember-metal/property_get';
 import ViewNodeManager from 'ember-htmlbars/node-managers/view-node-manager';
 import topLevelViewTemplate from 'ember-htmlbars/templates/top-level-view';
-import isEnabled from 'ember-metal/features';
 
 topLevelViewTemplate.meta.revision = 'Ember@VERSION_STRING_PLACEHOLDER';
 
@@ -120,11 +119,7 @@ export default {
       ViewClass = env.owner._lookupFactory('view:toplevel');
     }
 
-    var Component;
-
-    if (isEnabled('ember-routing-routable-components')) {
-      Component = outletState.render.Component;
-    }
+    var Component = outletState.render.Component;
 
     var options;
     var attrs = {};


### PR DESCRIPTION
My application makes heavy use of routable components. We are hoping to move into production soon, and I'd like to switch from canary to a release or beta build. Obviously moving from canary means I lose any features behind feature flags, such as the initial routable components implementation.

I can implement routable components myself by reopening the `Ember.Route` class and overriding the `render` and `buildRenderOptions` functions with what is currently sitting behind the feature flag. However, currently the `outlet` helper's `render` function ignores any `Component` passed to it, because this is also sitting behind the feature flag. The `outlet` helper is much harder to override, because it is not an `Ember.Object` subclass.

This PR simply enables support for components passed to `outlet` from the route's render options by removing the feature conditional. Note that this will have no effect in normal operation, because the `Component` property is normally `undefined`, and is only set within a conditional that is also behind the feature flag (see https://github.com/emberjs/ember.js/blob/fbab176eb41727dc6a4718ee3dfdc6490706b3b2/packages/ember-routing/lib/system/route.js#L2163).
