### PR TITLE
[DOC release] Fix typo

### DIFF
--- a/packages/ember-views/lib/system/ext.js
+++ b/packages/ember-views/lib/system/ext.js
@@ -7,6 +7,6 @@ import run from 'ember-metal/run_loop';
 
 // Add a new named queue for rendering views that happens
 // after bindings have synced, and a queue for scheduling actions
-// that that should occur after view rendering.
+// that should occur after view rendering.
 run._addQueue('render', 'actions');
 run._addQueue('afterRender', 'render');


### PR DESCRIPTION
This fixes a double word typo, 'that'.
