### PR TITLE
LocationApi:: Added notes about how to extend

### DIFF
--- a/packages/ember-routing/lib/location/api.js
+++ b/packages/ember-routing/lib/location/api.js
@@ -108,7 +108,7 @@ import { getHash } from 'ember-routing/location/util';
 
   Example:
  
-  app/locations/hashbang.js 
+  ```app/locations/hashbang.js 
 	#Creates URLs prefixed with #!
 	import Ember from 'ember';
 
@@ -146,7 +146,7 @@ import { getHash } from 'ember-routing/location/util';
 	    }	
 	
 	});
-
+  ```
   
 
   ## Location API

--- a/packages/ember-routing/lib/location/api.js
+++ b/packages/ember-routing/lib/location/api.js
@@ -107,15 +107,15 @@ import { getHash } from 'ember-routing/location/util';
   Ember scans the path `app/locations/*` for extending the Location API.
 
   Example:
- 
-  ```app/locations/hashbang.js 
+
+  ```app/locations/hashbang.js
 	#Creates URLs prefixed with #!
 	import Ember from 'ember';
 
 	var get = Ember.get, set = Ember.set;
 
 	export default Ember.HashLocation.extend({
-	
+
 	    getURL: function() {
 	        return get(this, 'location').hash.substr(2);
 	    },
@@ -143,11 +143,11 @@ import { getHash } from 'ember-routing/location/util';
 
 	    formatURL: function(url) {
 	        return '#!'+url;
-	    }	
+	    }
 	
 	});
   ```
-  
+
 
   ## Location API
 

--- a/packages/ember-routing/lib/location/api.js
+++ b/packages/ember-routing/lib/location/api.js
@@ -144,7 +144,7 @@ import { getHash } from 'ember-routing/location/util';
 	    formatURL: function(url) {
 	        return '#!'+url;
 	    }
-	
+
 	});
   ```
 

--- a/packages/ember-routing/lib/location/api.js
+++ b/packages/ember-routing/lib/location/api.js
@@ -102,9 +102,9 @@ import { getHash } from 'ember-routing/location/util';
   in the actual URL. This is generally used for testing purposes, and is one
   of the changes made when calling `App.setupForTesting()`.
 
-  ### Extending Implementations
+  ## Extending Implementations
 
-  Ember scans the path app/locations/* for extending the Location API.
+  Ember scans the path `app/locations/*` for extending the Location API.
 
   Example:
  

--- a/packages/ember-routing/lib/location/api.js
+++ b/packages/ember-routing/lib/location/api.js
@@ -102,6 +102,53 @@ import { getHash } from 'ember-routing/location/util';
   in the actual URL. This is generally used for testing purposes, and is one
   of the changes made when calling `App.setupForTesting()`.
 
+  ### Extending Implementations
+
+  Ember scans the path app/locations/* for extending the Location API.
+
+  Example:
+ 
+  app/locations/hashbang.js 
+	#Creates URLs prefixed with #!
+	import Ember from 'ember';
+
+	var get = Ember.get, set = Ember.set;
+
+	export default Ember.HashLocation.extend({
+	
+	    getURL: function() {
+	        return get(this, 'location').hash.substr(2);
+	    },
+
+	    setURL: function(path) {
+	        get(this, 'location').hash = "!"+path;
+	        set(this, 'lastSetURL', "!"+path);
+	    },
+
+	    onUpdateURL: function(callback) {
+	        var self = this;
+	        var guid = Ember.guidFor(this);
+
+	            Ember.$(window).bind('hashchange.ember-location-'+guid, function() {
+	                Ember.run(function() {
+	                    var path = location.hash.substr(2);
+	                    if (get(self, 'lastSetURL') === path) { return; }
+
+	                    set(self, 'lastSetURL', null);
+
+	                    callback(location.hash.substr(2));
+	                });
+	            });
+	        },
+
+	    formatURL: function(url) {
+	        return '#!'+url;
+	    }	
+	
+	});
+
+  
+
   ## Location API
 
   Each location implementation must provide the following methods:


### PR DESCRIPTION
Put some notes about how ember scans /app/locations/\* and an example of how to extend to make a custom location.
