### PR TITLE
Prevent 'invalid marker' error

### DIFF
--- a/packages/ember-testing/lib/support.js
+++ b/packages/ember-testing/lib/support.js
@@ -19,7 +19,7 @@ var $ = jQuery;
   @method testCheckboxClick
 */
 function testCheckboxClick(handler) {
-  $('<input type="checkbox">')
+  $('<input type="checkbox" />')
     .css({ position: 'absolute', left: '-1000px', top: '-1000px' })
     .appendTo('body')
     .on('click', handler)


### PR DESCRIPTION
The input tag needs to be closed.

It produce an error with specific dtd.
