### PR TITLE
[DOC release] Update `willDestroy` document

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -455,7 +455,11 @@ CoreObject.PrototypeMixin = Mixin.create({
   },
 
   /**
-    Override to implement teardown.
+    Override to implement teardown. Will be called asynchronously.
+    This is scheduled for execution by the `destroy` method.
+
+    If you want to cancel a scheduled item with `Ember.run.cancel`, you should
+    do it in `destroy` to avoid race condition.
 
     @method willDestroy
     @public


### PR DESCRIPTION
guide user to do `Ember.run.cancel` in `destroy` instead of `willDestroy`
