### PR TITLE
Cleanup router & DSL processing.

### DIFF
--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -209,7 +209,7 @@ const ApplicationInstance = EngineInstance.extend({
   */
   startRouting() {
     var router = get(this, 'router');
-    router.startRouting(isResolverModuleBased(this));
+    router.startRouting();
     this._didSetupRouter = true;
   },
 
@@ -227,7 +227,7 @@ const ApplicationInstance = EngineInstance.extend({
     this._didSetupRouter = true;
 
     var router = get(this, 'router');
-    router.setupRouter(isResolverModuleBased(this));
+    router.setupRouter();
   },
 
   /**
@@ -509,10 +509,6 @@ if (isEnabled('ember-application-visit')) {
     env.options = this;
     return env;
   };
-}
-
-function isResolverModuleBased(applicationInstance) {
-  return !!applicationInstance.application.__registry__.resolver.moduleBasedResolver;
 }
 
 Object.defineProperty(ApplicationInstance.prototype, 'container', {

--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -10,7 +10,9 @@ function DSL(name, options) {
   this.enableLoadingSubstates = options && options.enableLoadingSubstates;
   this.matches = [];
   this.explicitIndex = undefined;
+  this.options = options;
 }
+
 export default DSL;
 
 DSL.prototype = {
@@ -47,9 +49,7 @@ DSL.prototype = {
 
     if (callback) {
       var fullName = getFullName(this, name, options.resetNamespace);
-      var dsl = new DSL(fullName, {
-        enableLoadingSubstates: this.enableLoadingSubstates
-      });
+      var dsl = new DSL(fullName, this.options);
 
       createRoute(dsl, 'loading');
       createRoute(dsl, 'error', { path: dummyErrorRoute });

--- a/packages/ember-routing/tests/system/dsl_test.js
+++ b/packages/ember-routing/tests/system/dsl_test.js
@@ -117,8 +117,11 @@ QUnit.test('should add loading and error routes if _isRouterMapResult is true', 
     this.route('blork');
   });
 
-  var router = Router.create();
-  router._initRouterJs(true);
+  var router = Router.create({
+    _hasModuleBasedResolver() { return true; }
+  });
+
+  router._initRouterJs();
 
   ok(router.router.recognizer.names['blork'], 'main route was created');
   ok(router.router.recognizer.names['blork_loading'], 'loading route was added');


### PR DESCRIPTION
- Remove manual threading of `moduleBasedResolver`. As of the most
  recent resolver changes we can directly ask the "real" resolver when
  we need to. This avoids poluting a bunch of places with
  `moduleBasedResolver` that do not care about that flag.
- Prevent creating additional closure just to create application route.
- Avoid manually recreating input options for each layer of DSL (just
  pass options down).
- Make DSL creation a separate function.

No public API changes, only small refactoring to clean up some things that I saw while making a plan for Engine work...
