### PR TITLE
Do not re-raise on errors handled in route error action.

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -21,6 +21,7 @@ import {
 import { guidFor } from 'ember-metal/utils';
 import RouterState from './router_state';
 import { getOwner } from 'container/owner';
+import dictionary from 'ember-metal/dictionary';
 
 /**
 @module ember
@@ -113,6 +114,7 @@ var EmberRouter = EmberObject.extend(Evented, {
     this._activeViews = {};
     this._qpCache = new EmptyObject();
     this._resetQueuedQueryParameterChanges();
+    this._handledErrors = dictionary(null);
   },
 
   /*
@@ -727,22 +729,18 @@ var EmberRouter = EmberObject.extend(Evented, {
     this._slowTransitionTimer = null;
   },
 
-  _handledErrors: computed(function() {
-    return {};
-  }),
-
   // These three helper functions are used to ensure errors aren't
   // re-raised if they're handled in a route's error action.
-  _markErrorAsHandled(error) {
-    this.get('_handledErrors')[error] = true;
+  _markErrorAsHandled(errorGuid) {
+    this._handledErrors[errorGuid] = true;
   },
 
-  _isErrorHandled(error) {
-    return this.get('_handledErrors')[error];
+  _isErrorHandled(errorGuid) {
+    return this._handledErrors[errorGuid];
   },
 
-  _clearHandledError(error) {
-    delete this.get('_handledErrors')[error];
+  _clearHandledError(errorGuid) {
+    delete this._handledErrors[errorGuid];
   }
 });
 

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1022,6 +1022,7 @@ QUnit.test('The Special page returning an error invokes SpecialRoute\'s error ha
     actions: {
       error(reason) {
         equal(reason, 'Setup error', 'SpecialRoute#error received the error thrown from setup');
+        return true;
       }
     }
   });
@@ -1059,6 +1060,7 @@ function testOverridableErrorHandler(handlersName) {
   attrs[handlersName] = {
     error(reason) {
       equal(reason, 'Setup error', 'error was correctly passed to custom ApplicationRoute handler');
+      return true;
     }
   };
 

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -415,6 +415,40 @@ QUnit.test('Default error event moves into nested route', function() {
   equal(appController.get('currentPath'), 'grandma.error', 'Initial route fully loaded');
 });
 
+QUnit.test('Error events that aren\'t bubbled don\t throw application assertions', function() {
+  expect(2);
+
+  templates['grandma'] = 'GRANDMA {{outlet}}';
+
+  Router.map(function() {
+    this.route('grandma', function() {
+      this.route('mom', { resetNamespace: true }, function() {
+        this.route('sally');
+      });
+    });
+  });
+
+  App.ApplicationController = Ember.Controller.extend();
+
+  App.MomSallyRoute = Ember.Route.extend({
+    model() {
+      step(1, 'MomSallyRoute#model');
+
+      return Ember.RSVP.reject({
+        msg: 'did it broke?'
+      });
+    },
+    actions: {
+      error(err) {
+        equal(err.msg, 'did it broke?');
+        return false;
+      }
+    }
+  });
+
+  bootApplication('/grandma/mom/sally');
+});
+
 QUnit.test('Setting a query param during a slow transition should work', function() {
   var deferred = RSVP.defer();
 

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -449,6 +449,148 @@ QUnit.test('Error events that aren\'t bubbled don\t throw application assertions
   bootApplication('/grandma/mom/sally');
 });
 
+QUnit.test('Non-bubbled errors that re-throw aren\'t swallowed', function() {
+  expect(2);
+
+  templates['grandma'] = 'GRANDMA {{outlet}}';
+
+  Router.map(function() {
+    this.route('grandma', function() {
+      this.route('mom', { resetNamespace: true }, function() {
+        this.route('sally');
+      });
+    });
+  });
+
+  App.ApplicationController = Ember.Controller.extend();
+
+  App.MomSallyRoute = Ember.Route.extend({
+    model() {
+      step(1, 'MomSallyRoute#model');
+
+      return Ember.RSVP.reject({
+        msg: 'did it broke?'
+      });
+    },
+    actions: {
+      error(err) {
+        // returns undefined which is falsey
+        throw err;
+      }
+    }
+  });
+
+  throws(function() {
+    bootApplication('/grandma/mom/sally');
+  }, function(err) { return err.msg === 'did it broke?';});
+});
+
+QUnit.test('Handled errors that re-throw aren\'t swallowed', function() {
+  expect(4);
+
+  var handledError;
+
+  templates['grandma'] = 'GRANDMA {{outlet}}';
+
+  Router.map(function() {
+    this.route('grandma', function() {
+      this.route('mom', { resetNamespace: true }, function() {
+        this.route('sally');
+        this.route('this-route-throws');
+      });
+    });
+  });
+
+  App.ApplicationController = Ember.Controller.extend();
+
+  App.MomSallyRoute = Ember.Route.extend({
+    model() {
+      step(1, 'MomSallyRoute#model');
+
+      return Ember.RSVP.reject({
+        msg: 'did it broke?'
+      });
+    },
+    actions: {
+      error(err) {
+        step(2, 'MomSallyRoute#error');
+
+        handledError = err;
+
+        this.transitionTo('mom.this-route-throws');
+
+        // Marks error as handled
+        return false;
+      }
+    }
+  });
+
+  App.MomThisRouteThrowsRoute = Ember.Route.extend({
+    model() {
+      step(3, 'MomThisRouteThrows#model');
+
+      throw handledError;
+    }
+  });
+
+  throws(function() {
+    bootApplication('/grandma/mom/sally');
+  }, function(err) { return err.msg === 'did it broke?'; });
+});
+
+QUnit.test('Handled errors that are thrown through rejection aren\'t swallowed', function() {
+  expect(4);
+
+  var handledError;
+
+  templates['grandma'] = 'GRANDMA {{outlet}}';
+
+  Router.map(function() {
+    this.route('grandma', function() {
+      this.route('mom', { resetNamespace: true }, function() {
+        this.route('sally');
+        this.route('this-route-throws');
+      });
+    });
+  });
+
+  App.ApplicationController = Ember.Controller.extend();
+
+  App.MomSallyRoute = Ember.Route.extend({
+    model() {
+      step(1, 'MomSallyRoute#model');
+
+      return Ember.RSVP.reject({
+        msg: 'did it broke?'
+      });
+    },
+    actions: {
+      error(err) {
+        step(2, 'MomSallyRoute#error');
+
+        handledError = err;
+
+        this.transitionTo('mom.this-route-throws');
+
+        // Marks error as handled
+        return false;
+      }
+    }
+  });
+
+  App.MomThisRouteThrowsRoute = Ember.Route.extend({
+    model() {
+      step(3, 'MomThisRouteThrows#model');
+
+      return Ember.RSVP.reject(handledError);
+    }
+  });
+
+  throws(function() {
+    bootApplication('/grandma/mom/sally');
+  }, function(err) { return err.msg === 'did it broke?'; });
+});
+
 QUnit.test('Setting a query param during a slow transition should work', function() {
   var deferred = RSVP.defer();
 


### PR DESCRIPTION
- https://github.com/emberjs/ember.js/pull/12549 fixes an issue (since 2.1) where errors handled in a routes `error` action are always rethrown (even if not bubbled).
- Rebase https://github.com/emberjs/ember.js/pull/12549
- Add MOAR tests.
- Tweak logic for adding `_handledErrors` (no need for computed + `this.get`).

All of the hard work here was done by @minasmart over in #12549.

Fixes #12547.
Fixes #12472.
Fixes #12166.
