### PR TITLE
Use EmptyObject for `dictionary(null)`.

### DIFF
--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -282,10 +282,14 @@ QUnit.test('knownForType returns each item for a given type found', function() {
 
   let found = registry.resolver.knownForType('helper');
 
-  deepEqual(found, {
-    'helper:foo-bar': true,
-    'helper:baz-qux': true
-  });
+  // using `Object.keys` and manually confirming values over using `deepEqual`
+  // due to an issue in QUnit (through at least 1.20.0) that are unable to properly compare
+  // objects with an `undefined` constructor (like ember-metal/empty_object)
+  let foundKeys = Object.keys(found);
+
+  deepEqual(foundKeys, ['helper:foo-bar', 'helper:baz-qux']);
+  ok(found['helper:foo-bar']);
+  ok(found['helper:baz-qux']);
 });
 
 QUnit.test('knownForType is not required to be present on the resolver', function() {

--- a/packages/ember-metal/lib/dictionary.js
+++ b/packages/ember-metal/lib/dictionary.js
@@ -1,3 +1,4 @@
+import EmptyObject from './empty_object';
 
 // the delete is meant to hint at runtimes that this object should remain in
 // dictionary mode. This is clearly a runtime specific hack, but currently it
@@ -5,7 +6,12 @@
 // the cost of creation dramatically over a plain Object.create. And as this
 // only makes sense for long-lived dictionaries that aren't instantiated often.
 export default function makeDictionary(parent) {
-  var dict = Object.create(parent);
+  var dict;
+  if (parent === null) {
+    dict = new EmptyObject();
+  } else {
+    dict = Object.create(parent);
+  }
   dict['_dict'] = null;
   delete dict['_dict'];
   return dict;


### PR DESCRIPTION
A huge number of usages of `ember-metal/dictionary` are using `null` as the parent. Creating a `new EmptyObject()` is quite a bit faster than `Object.create(null)` (see comments in `ember-metal/empty_object` for details).
