### PR TITLE
Ember.isArray will not detect plain object with length property

### DIFF
--- a/packages/ember-runtime/lib/utils.js
+++ b/packages/ember-runtime/lib/utils.js
@@ -48,7 +48,6 @@ export function isArray(obj) {
 
   let type = typeOf(obj);
   if ('array' === type) { return true; }
-  if ((obj.length !== undefined) && 'object' === type) { return true; }
   return false;
 }
 

--- a/packages/ember-runtime/tests/core/is_array_test.js
+++ b/packages/ember-runtime/tests/core/is_array_test.js
@@ -21,7 +21,7 @@ QUnit.test('Ember.isArray', function() {
   equal(isArray(strarray), true, '["Hello", "Hi"]');
   equal(isArray(string), false, '"Hello"');
   equal(isArray(object), false, '{}');
-  equal(isArray(length), true, '{ length: 12 }');
+  equal(isArray(length), false, '{ length: 12 }');
   equal(isArray(global), false, 'global');
   equal(isArray(fn), false, 'function() {}');
   equal(isArray(arrayProxy), true, '[]');


### PR DESCRIPTION
To fix https://github.com/emberjs/ember.js/issues/12738 and https://github.com/emberjs/ember.js/issues/12688

This is a backwards incompatible change (if someone was relying on this test returning true for an object that happened to have a length property), but the old behaviour is surprising and out of line with native Array.isArray implementations, lodash.isArray and so on.
