### PR TITLE
[DOC Release] Mark multiple methods in Ember.Router as public

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -157,7 +157,7 @@ var EmberRouter = EmberObject.extend(Evented, {
     If no value is found `/` will be used.
 
     @method startRouting
-    @private
+    @public
   */
   startRouting() {
     var initialURL = get(this, 'initialURL');

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -392,7 +392,7 @@ var EmberRouter = EmberObject.extend(Evented, {
     Resets the state of the router by clearing the current route
     handlers and deactivating them.
 
-    @private
+    @public
     @method reset
    */
   reset() {

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -349,7 +349,7 @@ var EmberRouter = EmberObject.extend(Evented, {
     @method isActive
     @param routeName
     @return {Boolean}
-    @private
+    @public
   */
   isActive(routeName) {
     var router = this.router;

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -382,7 +382,7 @@ var EmberRouter = EmberObject.extend(Evented, {
 
     @method hasRoute
     @return {Boolean}
-    @private
+    @public
   */
   hasRoute(route) {
     return this.router.hasRoute(route);

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -131,7 +131,7 @@ var EmberRouter = EmberObject.extend(Evented, {
 
     @method url
     @return {String} The current URL.
-    @private
+    @public
   */
   url: computed(function() {
     return get(this, 'location').getURL();

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -366,7 +366,7 @@ var EmberRouter = EmberObject.extend(Evented, {
     @param models
     @param queryParams
     @return {Boolean}
-    @private
+    @public
     @since 1.7.0
   */
   isActiveIntent(routeName, models, queryParams) {


### PR DESCRIPTION
Mark Ember.Router.url as public
Mark Ember.Router.startRouting as public
Mark Ember.Router.isActive as public
Mark Ember.Router.isActiveIntent as public
Mark Ember.Router.hasRoute as public
Mark Ember.Router.reset as public
