### PR TITLE
[DOC UPDATE] target is optional for service.addObserver

### DIFF
--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -344,6 +344,11 @@ export default Mixin.create({
     Note that if you add the same target/method pair on a key multiple times
     with different context parameters, your observer will only be called once
     with the last context you passed.
+    
+    The `target` object is optional, you can intuitively pass in an observer method like so:
+    ```javascript
+    SERVICE.addObserver('data', YourObserverMethod)
+    ```
 
     ### Observer Methods
 


### PR DESCRIPTION
This is based on my observation of this code: https://github.com/emberjs/ember.js/blob/v2.2.0/packages/ember-metal/lib/events.js#L87

Sorry I don't have time to make a better pull request right now. The documentation could probably use a full update and this PR could be discarded once that is started
