### PR TITLE
Do not override `OWNER` if already present on child view.

### DIFF
--- a/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
@@ -9,7 +9,7 @@ import { MUTABLE_CELL } from 'ember-views/compat/attrs-proxy';
 import getCellOrValue from 'ember-htmlbars/hooks/get-cell-or-value';
 import { instrument } from 'ember-htmlbars/system/instrumentation-support';
 import { takeLegacySnapshot } from 'ember-htmlbars/node-managers/component-node-manager';
-import { getOwner, setOwner } from 'container/owner';
+import { setOwner } from 'container/owner';
 
 // In theory this should come through the env, but it should
 // be safe to import this until we make the hook system public
@@ -191,7 +191,7 @@ export function createOrUpdateComponent(component, options, createOptions, rende
 
     mergeBindings(props, snapshot);
 
-    let owner = options.parentView ? getOwner(options.parentView) : env.owner;
+    let owner = env.owner;
 
     setOwner(props, owner);
     props.renderer = options.parentView ? options.parentView.renderer : owner && owner.lookup('renderer:-dom');

--- a/packages/ember-views/lib/mixins/legacy_child_views_support.js
+++ b/packages/ember-views/lib/mixins/legacy_child_views_support.js
@@ -1,11 +1,14 @@
 import { Mixin } from 'ember-metal/mixin';
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
-import { getOwner, setOwner } from 'container/owner';
+import { getOwner, setOwner, OWNER } from 'container/owner';
 
 export default Mixin.create({
   linkChild(instance) {
-    setOwner(instance, getOwner(this));
+    if (!instance[OWNER]) {
+      setOwner(instance, getOwner(this));
+    }
+
     if (get(instance, 'parentView') !== this) {
       // linkChild should be idempotent
       set(instance, 'parentView', this);

--- a/packages/ember-views/lib/mixins/view_child_views_support.js
+++ b/packages/ember-views/lib/mixins/view_child_views_support.js
@@ -8,7 +8,7 @@ import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
 import setProperties from 'ember-metal/set_properties';
 import { A as emberA } from 'ember-runtime/system/native_array';
-import { getOwner, setOwner } from 'container/owner';
+import { getOwner, setOwner, OWNER } from 'container/owner';
 
 var EMPTY_ARRAY = [];
 
@@ -128,7 +128,10 @@ export default Mixin.create({
   },
 
   linkChild(instance) {
-    setOwner(instance, getOwner(this));
+    if (!instance[OWNER]) {
+      setOwner(instance, getOwner(this));
+    }
+
     instance.parentView = this;
     instance.ownerView = this.ownerView;
   },


### PR DESCRIPTION
Previously, `linkChild` would always set the new child view's `OWNER` to its own `OWNER`.  Unfortunately, when dealing with Engines mounted at a given outlet this means that any components and whatnot rendered in that engines template have their `OWNER` changed after init (just before render).

The intent of the original code was to ensure that all child views had an `OWNER` (actually it was `.container` at the time). The `ViewNodeManager` and `ComponentNodeManager`'s now handle properly creating the views/components with the right `OWNER` so this code is mostly no longer needed (except for edge case legacy support). The guard added here ensures that we are only setting `OWNER` if it wasn't previously set (which is that one legacy edge case).
