### PR TITLE
[DOC release] Amend `Ember.run.cancel` docs

### DIFF
--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -467,7 +467,7 @@ run.next = function(...args) {
 
 /**
   Cancels a scheduled item. Must be a value returned by `run.later()`,
-  `run.once()`, `run.next()`, `run.debounce()`, or
+  `run.once()`, `run.scheduleOnce()`, `run.next()`, `run.debounce()`, or
   `run.throttle()`.
 
   ```javascript
@@ -482,6 +482,12 @@ run.next = function(...args) {
   }, 500);
 
   run.cancel(runLater);
+
+  var runScheduleOnce = run.scheduleOnce('afterRender', myContext, function() {
+    // will not be executed
+  });
+
+  run.cancel(runScheduleOnce);
 
   var runOnce = run.once(myContext, function() {
     // will not be executed


### PR DESCRIPTION
The documentation listed the functions that return a cancelable timer, and `Ember.run.scheduleOnce` was not among them.

I tested and it returns a cancelable timer.
