### PR TITLE
[BUGFIX release-1-13] Prevent `classNames` from being duplicated.

### DIFF
--- a/packages/ember-htmlbars/tests/integration/component_invocation_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_invocation_test.js
@@ -999,13 +999,15 @@ QUnit.test('non-block with each rendering child components', function() {
 });
 
 QUnit.test('specifying classNames results in correct class', function(assert) {
-  expect(1);
+  expect(3);
 
+  let clickyThing;
   registry.register('component:some-clicky-thing', Component.extend({
     tagName: 'button',
     classNames: ['foo', 'bar'],
-    click() {
-      assert.ok(true, 'click was fired!');
+    init() {
+      this._super(...arguments);
+      clickyThing = this;
     }
   }));
 
@@ -1018,6 +1020,12 @@ QUnit.test('specifying classNames results in correct class', function(assert) {
 
   let button = view.$('button');
   ok(button.is('.foo.bar.baz.ember-view'), 'the element has the correct classes: ' + button.attr('class'));
+
+  let expectedClassNames = ['ember-view', 'foo', 'bar', 'baz'];
+  assert.deepEqual(clickyThing.get('classNames'),  expectedClassNames, 'classNames are properly combined');
+
+  let buttonClassNames = button.attr('class');
+  assert.deepEqual(buttonClassNames.split(' '), expectedClassNames, 'all classes are set 1:1 in DOM');
 });
 
 QUnit.test('specifying custom concatenatedProperties avoids clobbering', function(assert) {

--- a/packages/ember-views/lib/system/build-component-template.js
+++ b/packages/ember-views/lib/system/build-component-template.js
@@ -247,10 +247,6 @@ function normalizeClass(component, attrs) {
     normalizeClasses(attrs.classBinding.split(' '), normalizedClass);
   }
 
-  if (attrs.classNames) {
-    normalizedClass.push(['value', attrs.classNames]);
-  }
-
   if (classNames) {
     for (i=0, l=classNames.length; i<l; i++) {
       normalizedClass.push(classNames[i]);


### PR DESCRIPTION
This PR cherry picks the fix from #12184 into the 1.13 branch.  Not sure if anything can/should be done about the names of the commits that were cherry picked since they don't really fit the naming convention for this branch...
