### PR TITLE
Support jQuery versions 1.12 and 2.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/emberjs/ember.js.git"
   },
   "dependencies": {
-    "jquery": "~1.11.1",
+    "jquery": "~1.12.0",
     "qunit": "~1.20.0",
     "qunit-phantom-runner": "jonkemp/qunit-phantomjs-runner#1.2.0"
   },

--- a/packages/ember-views/lib/system/jquery.js
+++ b/packages/ember-views/lib/system/jquery.js
@@ -15,7 +15,7 @@ if (environment.hasDOM) {
 
   assert(
     'Ember Views require jQuery between 1.7 and 2.1',
-    jQuery && (jQuery().jquery.match(/^((1\.(7|8|9|10|11|12))|(2\.(0|1)))(\.\d+)?(pre|rc\d?)?/) || Ember.ENV.FORCE_JQUERY)
+    jQuery && (jQuery().jquery.match(/^((1\.(7|8|9|10|11|12))|(2\.(0|1|2)))(\.\d+)?(pre|rc\d?)?/) || Ember.ENV.FORCE_JQUERY)
   );
 
   if (jQuery) {

--- a/packages/ember-views/lib/system/jquery.js
+++ b/packages/ember-views/lib/system/jquery.js
@@ -15,7 +15,7 @@ if (environment.hasDOM) {
 
   assert(
     'Ember Views require jQuery between 1.7 and 2.1',
-    jQuery && (jQuery().jquery.match(/^((1\.(7|8|9|10|11))|(2\.(0|1)))(\.\d+)?(pre|rc\d?)?/) || Ember.ENV.FORCE_JQUERY)
+    jQuery && (jQuery().jquery.match(/^((1\.(7|8|9|10|11|12))|(2\.(0|1)))(\.\d+)?(pre|rc\d?)?/) || Ember.ENV.FORCE_JQUERY)
   );
 
   if (jQuery) {


### PR DESCRIPTION
The [1.12.0](https://github.com/jquery/jquery/tree/1.12.0) and [2.2.0](https://github.com/jquery/jquery/tree/2.2.0) release of jQuery have been tagged  a couple of hours ago.
The regex for checking jQuery versions for Ember Views didn't pass for 1.12.x or 2.2.x
