### PR TITLE
Recognizes jquery v1.12 for ember views

### DIFF
--- a/packages/ember-views/lib/system/jquery.js
+++ b/packages/ember-views/lib/system/jquery.js
@@ -15,7 +15,7 @@ if (environment.hasDOM) {
 
   assert(
     'Ember Views require jQuery between 1.7 and 2.1',
-    jQuery && (jQuery().jquery.match(/^((1\.(7|8|9|10|11))|(2\.(0|1)))(\.\d+)?(pre|rc\d?)?/) || Ember.ENV.FORCE_JQUERY)
+    jQuery && (jQuery().jquery.match(/^((1\.(7|8|9|10|11|12))|(2\.(0|1)))(\.\d+)?(pre|rc\d?)?/) || Ember.ENV.FORCE_JQUERY)
   );
 
   if (jQuery) {


### PR DESCRIPTION
ember-cli uses semver ^1.11.3 for jquery, which resolves to 1.12.0.  Unfortunately, the regexp in ember.debug only matches 1.7 through 1.11 for 1.x releases, resulting in "Assertion Failed: Ember Views require jQuery between 1.7 and 2.1".  (Note that as a result of this error, the tutorial as presented in the guide will not run, which must give newcomers fits.)  This PR simply amends the regexp to include 1.12.
