### PR TITLE
Update to jQuery 1.12.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/emberjs/ember.js.git"
   },
   "dependencies": {
-    "jquery": "~1.11.1",
+    "jquery": "~1.12.0",
     "qunit": "~1.20.0",
     "qunit-phantom-runner": "jonkemp/qunit-phantomjs-runner#1.2.0"
   },


### PR DESCRIPTION
To run ember tests against the new version. Tests passed locally, but would be good to go along with @rwjblue 's #12793
