### PR TITLE
add 1.12 to jquery regexp matches

### DIFF
--- a/packages/ember-views/lib/system/jquery.js
+++ b/packages/ember-views/lib/system/jquery.js
@@ -15,7 +15,7 @@ if (environment.hasDOM) {
 
   assert(
     'Ember Views require jQuery between 1.7 and 2.1',
-    jQuery && (jQuery().jquery.match(/^((1\.(7|8|9|10|11))|(2\.(0|1)))(\.\d+)?(pre|rc\d?)?/) || Ember.ENV.FORCE_JQUERY)
+    jQuery && (jQuery().jquery.match(/^((1\.(7|8|9|10|11|12))|(2\.(0|1)))(\.\d+)?(pre|rc\d?)?/) || Ember.ENV.FORCE_JQUERY)
   );
 
   if (jQuery) {


### PR DESCRIPTION
due to http://blog.jquery.com/2016/01/08/jquery-2-2-and-1-12-released/
