### PR TITLE
Improve error message on encountering falsy rawAction value

### DIFF
--- a/packages/ember-routing-htmlbars/lib/keywords/closure-action.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/closure-action.js
@@ -14,7 +14,7 @@ export const ACTION = symbol('ACTION');
 
 export default function closureAction(morph, env, scope, params, hash, template, inverse, visitor) {
   let s = new Stream(function() {
-    var rawAction = params[0];
+    var rawAction = extractRawAction(params, scope);
     var actionArguments = readArray(params.slice(1, params.length));
 
     var target, action, valuePath;
@@ -65,6 +65,22 @@ export default function closureAction(morph, env, scope, params, hash, template,
   Object.keys(hash).forEach(item => s.addDependency(item));
 
   return s;
+}
+
+
+function extractRawAction(params, scope) {
+  var [value] = params;
+  if (value) {
+    return value;
+  }
+
+  /* Emit a more descriptive error when `(action attrs.foo)` and `foo` is falsy
+   *
+   * If accessing properties of `attrs` could yield a stream (?), this might not
+   * even be necessary
+   */
+  var target = read(scope.getSelf());
+  throw new EmberError(`${target} is using action closure helper with an action of value \`${value}\`. If passing an action via \`attrs.someAction\`, confirm that \`someAction\` is either a string or a function.`);
 }
 
 function createClosureAction(target, action, valuePath, actionArguments) {

--- a/packages/ember-routing-htmlbars/tests/helpers/closure_action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/closure_action_test.js
@@ -641,27 +641,3 @@ QUnit.test('action should be called within a run loop', function(assert) {
 
   innerComponent.fireAction();
 });
-
-QUnit.test('action should be called within a run loop', function(assert) {
-  assert.expect(1);
-
-  innerComponent = EmberComponent.extend({
-    fireAction() {
-      this.attrs.submit();
-    }
-  }).create();
-
-  outerComponent = EmberComponent.extend({
-    layout: compile(`{{view innerComponent submit=(action 'submit')}}`),
-    innerComponent,
-    actions: {
-      submit(newValue) {
-        assert.ok(run.currentRunLoop, 'action is called within a run loop');
-      }
-    }
-  }).create();
-
-  runAppend(outerComponent);
-
-  innerComponent.fireAction();
-});


### PR DESCRIPTION
This addresses the need for better error reporting as identified in https://github.com/emberjs/ember.js/issues/12718#issuecomment-165802268.
### Background

Presently, doing this:

``` handlebars
{{my-widget click=(action someFalsyValue)}}
```

...yields this:

```
Uncaught TypeError: Cannot read property 'INVOKE [id=__ember14526275715741349532282241]' of undefined
```

The new error emitted will be:

```
<App.SourceOfProblemComponent:ember1300> is using action closure helper with an
action of value `undefined`. If passing an action via `attrs.someAction`, confirm
that `someAction` is either a string or a function.
```
