### PR TITLE
[BUGFIX beta] Fix block behaviour for `Helper.extend` helpers

### DIFF
--- a/packages/ember-htmlbars/lib/system/invoke-helper.js
+++ b/packages/ember-htmlbars/lib/system/invoke-helper.js
@@ -4,13 +4,14 @@ import HelperFactoryStream from 'ember-htmlbars/streams/helper-factory';
 import BuiltInHelperStream from 'ember-htmlbars/streams/built-in-helper';
 
 export function buildHelperStream(helper, params, hash, templates, env, scope, label) {
+  let isAnyKindOfHelper = helper.isHelperInstance || helper.isHelperFactory;
   assert(
     'Helpers may not be used in the block form, for example {{#my-helper}}{{/my-helper}}. Please use a component, or alternatively use the helper in combination with a built-in Ember helper, for example {{#if (my-helper)}}{{/if}}.',
-    !(helper.isHelperInstance && !helper.isHelperFactory) || (!templates || !templates.template || !templates.template.meta)
+    !(isAnyKindOfHelper && templates && templates.template && templates.template.meta)
   );
   assert(
     'Helpers may not be used in the element form, for example <div {{my-helper}}>.',
-    !(helper.isHelperInstance && !helper.isHelperFactory) || (!templates || !templates.element)
+    !(isAnyKindOfHelper && templates && templates.element)
   );
   if (helper.isHelperFactory) {
     return new HelperFactoryStream(helper, params, hash, label);

--- a/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
+++ b/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
@@ -232,7 +232,7 @@ QUnit.test('dashed helper usable in subexpressions', function() {
     'Who overcomes by force hath overcome but half his foe');
 });
 
-QUnit.test('dashed helper not usable with a block', function() {
+QUnit.test('dashed shorthand helper not usable with a block', function() {
   var SomeHelper = makeHelper(function() {});
   owner.register('helper:some-helper', SomeHelper);
   component = Component.extend({
@@ -245,8 +245,34 @@ QUnit.test('dashed helper not usable with a block', function() {
   }, /Helpers may not be used in the block form/);
 });
 
-QUnit.test('dashed helper not usable within element', function() {
+QUnit.test('dashed helper not usable with a block', function() {
+  var SomeHelper = Helper.extend({ compute() { } });
+  owner.register('helper:some-helper', SomeHelper);
+  component = Component.extend({
+    [OWNER]: owner,
+    layout: compile(`{{#some-helper}}{{/some-helper}}`)
+  }).create();
+
+  expectAssertion(function() {
+    runAppend(component);
+  }, /Helpers may not be used in the block form/);
+});
+
+QUnit.test('dashed shorthand helper not usable within element', function() {
   var SomeHelper = makeHelper(function() {});
+  owner.register('helper:some-helper', SomeHelper);
+  component = Component.extend({
+    [OWNER]: owner,
+    layout: compile(`<div {{some-helper}}></div>`)
+  }).create();
+
+  expectAssertion(function() {
+    runAppend(component);
+  }, /Helpers may not be used in the element form/);
+});
+
+QUnit.test('dashed helper not usable within element', function() {
+  var SomeHelper = Helper.extend({ compute() { } });
   owner.register('helper:some-helper', SomeHelper);
   component = Component.extend({
     [OWNER]: owner,


### PR DESCRIPTION
Change the condition in invoke helper assertions to throw on helpers extending
`Ember.Helper`.

Fixes #12804
