### PR TITLE
[BUGFIX beta] Avoid leaking variables between component instances

### DIFF
--- a/packages/ember-htmlbars/lib/keywords/component.js
+++ b/packages/ember-htmlbars/lib/keywords/component.js
@@ -6,6 +6,8 @@
 import { keyword } from 'htmlbars-runtime/hooks';
 import closureComponent from 'ember-htmlbars/keywords/closure-component';
 import isEnabled from 'ember-metal/features';
+import EmptyObject from 'ember-metal/empty_object';
+import assign from 'ember-metal/assign';
 
 /**
   The `{{component}}` helper lets you add instances of `Ember.Component` to a
@@ -79,13 +81,13 @@ import isEnabled from 'ember-metal/features';
 */
 export default function(morph, env, scope, params, hash, template, inverse, visitor) {
   if (isEnabled('ember-contextual-components')) {
-    if (morph) {
-      keyword('@element_component', morph, env, scope, params, hash, template, inverse, visitor);
-      return true;
+    if (!morph) {
+      return closureComponent(env, params, hash);
     }
-    return closureComponent(env, params, hash);
-  } else {
-    keyword('@element_component', morph, env, scope, params, hash, template, inverse, visitor);
-    return true;
   }
+
+  let newHash = assign(new EmptyObject(), hash);
+
+  keyword('@element_component', morph, env, scope, params, newHash, template, inverse, visitor);
+  return true;
 }

--- a/packages/ember-htmlbars/lib/keywords/element-component.js
+++ b/packages/ember-htmlbars/lib/keywords/element-component.js
@@ -6,6 +6,8 @@ import {
   mergeInNewHash,
   processPositionalParamsFromCell,
 } from  './closure-component';
+import lookupComponent from 'ember-htmlbars/utils/lookup-component';
+import extractPositionalParams from 'ember-htmlbars/utils/extract-positional-params';
 
 export default {
   setupState(lastState, env, scope, params, hash) {
@@ -42,7 +44,7 @@ function getComponentPath(param, env) {
   return path;
 }
 
-function render(morph, env, scope, [path, ...params], hash, template, inverse, visitor) {
+function render(morph, env, scope, [path, ...params], hash, template, inverse, visitor, isRerender=false) {
   let {
     componentPath
   } = morph.getState();
@@ -54,6 +56,13 @@ function render(morph, env, scope, [path, ...params], hash, template, inverse, v
   }
 
   path = env.hooks.getValue(path);
+
+  if (isRerender) {
+    let result = lookupComponent(env.owner, componentPath);
+    let component = result.component;
+
+    extractPositionalParams(null, component, params, hash);
+  }
 
   if (isComponentCell(path)) {
     let closureComponent = env.hooks.getValue(path);


### PR DESCRIPTION
Given that attributes are modified in place, the `{{component}}` helper needs
to duplicate the `hash`. Furthermore, rerendering a `@element_component` needs
to process positional parameters.
