### PR TITLE
[CLEANUP] Removes duplicate logic in Ember.copy.

### DIFF
--- a/packages/ember-runtime/lib/copy.js
+++ b/packages/ember-runtime/lib/copy.js
@@ -5,11 +5,6 @@ import Copyable from 'ember-runtime/mixins/copyable';
 function _copy(obj, deep, seen, copies) {
   var ret, loc, key;
 
-  // primitive data types are immutable, just return them.
-  if (typeof obj !== 'object' || obj === null) {
-    return obj;
-  }
-
   // avoid cyclical loops
   if (deep && (loc = seen.indexOf(obj)) >= 0) {
     return copies[loc];


### PR DESCRIPTION
`Ember.copy` fast-paths "copying" immutable primitives, the private function it delegates to repeats this check.
