### PR TITLE
[BUGFIX canary] Support tagless components in fastboot

### DIFF
--- a/packages/ember-views/lib/components/component.js
+++ b/packages/ember-views/lib/components/component.js
@@ -1,4 +1,5 @@
 import { assert, deprecate } from 'ember-metal/debug';
+import environment from 'ember-metal/environment';
 
 import TargetActionSupport from 'ember-runtime/mixins/target_action_support';
 import View from 'ember-views/views/view';
@@ -163,7 +164,7 @@ var Component = View.extend(TargetActionSupport, {
     // If in a tagless component, assert that no event handlers are defined
     assert(
       `You can not define a function that handles DOM events in the \`${this}\` tagless component since it doesn't have any DOM element.`,
-      this.tagName !== '' || !(() => {
+      this.tagName !== '' || !environment.hasDOM || !(() => {
         let eventDispatcher = getOwner(this).lookup('event_dispatcher:main');
         let events = (eventDispatcher && eventDispatcher._finalEvents) || {};
 

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -14,6 +14,7 @@ import ActionManager from 'ember-views/system/action_manager';
 import View from 'ember-views/views/view';
 import assign from 'ember-metal/assign';
 import { getOwner } from 'container/owner';
+import environment from 'ember-metal/environment';
 
 let ROOT_ELEMENT_CLASS = 'ember-application';
 let ROOT_ELEMENT_SELECTOR = '.' + ROOT_ELEMENT_CLASS;
@@ -135,6 +136,11 @@ export default EmberObject.extend({
     @private
   */
   canDispatchToEventManager: true,
+
+  init() {
+    this._super();
+    assert('EventDispatcher should never be instantiated in fastboot mode. Please report this as an Ember bug.', environment.hasDOM);
+  },
 
   /**
     Sets up event listeners for standard browser events.

--- a/tests/node/visit-test.js
+++ b/tests/node/visit-test.js
@@ -301,4 +301,21 @@ if (appModule.canRunTests) {
       assert.strictEqual(xFooInstances, 0, 'it should not create any x-foo components');
     });
   });
+
+  QUnit.test('FastBoot: tagless components can render', function(assert) {
+    this.template('application', "<div class='my-context'>{{my-component}}</div>");
+    this.component('my-component', { tagName: '' });
+    this.template('components/my-component', '<h1>hello world</h1>');
+
+    var App = this.createApplication();
+
+    return RSVP.all([
+      fastbootVisit(App, '/').then(
+        assertFastbootResult(assert, { url: '/', body: /<div class="my-context"><h1>hello world<\/h1><\/div>/ }),
+        handleError(assert)
+      )
+    ]);
+  });
+
+
 }


### PR DESCRIPTION
Attempting to render a component with `tagName: ''` in fastboot kills the fastboot server with a stack trace that looks like:

```
undefined:55214
      _emberViewsSystemJquery.default(rootElement).off('.ember', '**').removeC
                                     ^
TypeError: undefined is not a function
    at exports.default._emberRuntimeSystemObject.default.extend.destroy (<anonymous>:55214:38)
    at superWrapper [as destroy] (<anonymous>:33934:22)
    at <anonymous>:11887:16
    at eachDestroyable (<anonymous>:12166:9)
    at Object.Container.destroy (<anonymous>:11885:7)
    at Object.Backburner.run (<anonymous>:11256:25)
    at Object.run [as default] (<anonymous>:31959:27)
    at exports.default._emberMetalMixin.Mixin.create.willDestroy (<anonymous>:44068:36)
    at superWrapper (<anonymous>:33934:22)
    at _emberRuntimeSystemObject.default.extend.willDestroy (<anonymous>:15925:19)

```

The root cause is that initializing a tagless component causes a lookup of `event_dispatcher:main`. This actually succeeds, and the `EventDispatcher` doesn't try to do anything, but then during container teardown the EventDispatcher's `destroy` method throws the above exception.

To make any future bugs in this class more obvious, I added an assertion in `EventDispatcher` so that it will fail faster if you try to instantiate it in fastboot mode.
