### PR TITLE
Failing test for 12475

### DIFF
--- a/packages/ember-runtime/tests/computed/chains_test.js
+++ b/packages/ember-runtime/tests/computed/chains_test.js
@@ -24,13 +24,15 @@ QUnit.module('chain watching', {
     a4 = { foo: false, id: 4 };
 
     obj = { };
-    defineProperty(obj, 'a', computed('array.@each.foo', function() {}));
+    defineProperty(obj, 'a', computed('array.@each.foo', function() {
+      return this.array.map(item => get(item, 'foo'));
+    }));
   }
 });
 
 QUnit.test('replace array (no overlap)', function() {
   set(obj, 'array', emberA([a1, a2]));
-  get(obj, 'a'); // kick CP;
+  get(obj, 'a'); // kick CP
 
   ok(isWatching(a1, 'foo'), 'BEFORE: a1.foo is watched');
   ok(isWatching(a2, 'foo'), 'BEFORE: a2.foo is watched');
@@ -38,6 +40,7 @@ QUnit.test('replace array (no overlap)', function() {
   ok(!isWatching(a4, 'foo'), 'BEFORE: a4.foo is NOT watched');
 
   set(obj, 'array', [a3, a4]);
+  get(obj, 'a'); // kick CP
 
   ok(!isWatching(a1, 'foo'), 'AFTER: a1.foo is NOT watched');
   ok(!isWatching(a2, 'foo'), 'AFTER: a2.foo is NOT watched');
@@ -47,7 +50,7 @@ QUnit.test('replace array (no overlap)', function() {
 
 QUnit.test('replace array (overlap)', function() {
   set(obj, 'array', emberA([a1, a2, a3]));
-  get(obj, 'a'); // kick CP;
+  get(obj, 'a'); // kick CP
 
   ok(isWatching(a1, 'foo'), 'BEFORE: a1.foo is watched');
   ok(isWatching(a2, 'foo'), 'BEFORE: a2.foo is watched');
@@ -55,6 +58,7 @@ QUnit.test('replace array (overlap)', function() {
   ok(!isWatching(a4, 'foo'), 'BEFORE: a4.foo is NOT watched');
 
   set(obj, 'array', [a2, a3, a4]);
+  get(obj, 'a'); // kick CP
 
   ok(!isWatching(a1, 'foo'), 'AFTER: a1.foo is NOT watched');
   ok(isWatching(a2, 'foo'), 'AFTER: a2.foo is watched');
@@ -66,7 +70,7 @@ QUnit.test('splice array (no overlap)', function() {
   let array = emberA([a1, a2]);
 
   set(obj, 'array', array);
-  get(obj, 'a'); // kick CP;
+  get(obj, 'a'); // kick CP
 
   ok(isWatching(a1, 'foo'), 'BEFORE: a1.foo is watched');
   ok(isWatching(a2, 'foo'), 'BEFORE: a2.foo is watched');
@@ -74,6 +78,7 @@ QUnit.test('splice array (no overlap)', function() {
   ok(!isWatching(a4, 'foo'), 'BEFORE: a4.foo is NOT watched');
 
   array.replace(0, 2, [a3, a4]);
+  get(obj, 'a'); // kick CP
 
   ok(!isWatching(a1, 'foo'), 'AFTER: a1.foo is NOT watched');
   ok(!isWatching(a2, 'foo'), 'AFTER: a2.foo is NOT watched');
@@ -85,7 +90,7 @@ QUnit.test('splice array (overlap)', function() {
   let array = emberA([a1, a2, a3]);
 
   set(obj, 'array', array);
-  get(obj, 'a'); // kick CP;
+  get(obj, 'a'); // kick CP
 
   ok(isWatching(a1, 'foo'), 'BEFORE: a1.foo is watched');
   ok(isWatching(a2, 'foo'), 'BEFORE: a2.foo is watched');
@@ -93,6 +98,7 @@ QUnit.test('splice array (overlap)', function() {
   ok(!isWatching(a4, 'foo'), 'BEFORE: a4.foo is NOT watched');
 
   array.replace(0, 3, [a2, a3, a4]);
+  get(obj, 'a'); // kick CP
 
   ok(!isWatching(a1, 'foo'), 'AFTER: a1.foo is NOT watched');
   ok(isWatching(a2, 'foo'), 'AFTER: a2.foo is watched');

--- a/packages/ember-runtime/tests/computed/chains_test.js
+++ b/packages/ember-runtime/tests/computed/chains_test.js
@@ -66,7 +66,7 @@ QUnit.test('responds to change of property value on element after replacing arra
   deepEqual(get(obj, 'a'), 3, 'value is correct initially');
   set(a1, 'foo', false);
   deepEqual(get(obj, 'a'), 2, 'responds to change of property on element');
-  set(obj, 'array', [a1, a2, a3]);
+  set(obj, 'array', emberA([a1, a2, a3]));
   deepEqual(get(obj, 'a'), 6, 'responds to content array change');
   set(a1, 'foo', true);
   deepEqual(get(obj, 'a'), 7, 'still responds to change of property on element');

--- a/packages/ember-runtime/tests/computed/chains_test.js
+++ b/packages/ember-runtime/tests/computed/chains_test.js
@@ -207,8 +207,8 @@ QUnit.test('responds to change of property value on element after replacing arra
 QUnit.test('responds to change of property value on element after replacing array (object promise proxy-un-settled)', function() {
   run(_ => {
     set(obj, 'array', emberA([
-          ObjectPromiseProxy.create({ promise: RSVP.Promise.resolve(a1) }),
-          ObjectPromiseProxy.create({ promise: RSVP.Promise.resolve(a2) }),
+      ObjectPromiseProxy.create({ promise: RSVP.Promise.resolve(a1) }),
+      ObjectPromiseProxy.create({ promise: RSVP.Promise.resolve(a2) })
     ]));
 
     equal(get(obj, 'a'), 0, 'value is correct initially');
@@ -220,8 +220,8 @@ QUnit.test('responds to change of property value on element after replacing arra
 
   run(_ => {
     set(obj, 'array', emberA([
-          ObjectPromiseProxy.create({ promise: RSVP.Promise.resolve(a2) }),
-          ObjectPromiseProxy.create({ promise: RSVP.Promise.resolve(a3) })
+      ObjectPromiseProxy.create({ promise: RSVP.Promise.resolve(a2) }),
+      ObjectPromiseProxy.create({ promise: RSVP.Promise.resolve(a3) })
     ]));
 
     equal(get(obj, 'a'), 0, 'expected no change');

--- a/packages/ember-runtime/tests/computed/chains_test.js
+++ b/packages/ember-runtime/tests/computed/chains_test.js
@@ -4,6 +4,8 @@ import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
 import { isWatching } from 'ember-metal/watching';
 import { A as emberA } from 'ember-runtime/system/native_array';
+import ObjectProxy from 'ember-runtime/system/object_proxy';
+import ArrayProxy from 'ember-runtime/system/array_proxy';
 
 let a1, a2, a3, a4, obj;
 
@@ -46,7 +48,7 @@ QUnit.test('replace array (overlap)', function() {
   ok(isWatching(a3, 'foo'), 'BEFORE: a3.foo is watched');
   ok(!isWatching(a4, 'foo'), 'BEFORE: a4.foo is NOT watched');
 
-  obj.set('array', [a2, a3, a4]);
+  set(obj, 'array', [a2, a3, a4]);
 
   ok(!isWatching(a1, 'foo'), 'AFTER: a1.foo is NOT watched');
   ok(isWatching(a2, 'foo'), 'AFTER: a2.foo is watched');
@@ -64,11 +66,91 @@ QUnit.test('responds to change of property value on element after replacing arra
   set(obj, 'array', emberA([a1, a2]));
 
   deepEqual(get(obj, 'a'), 3, 'value is correct initially');
+
   set(a1, 'foo', false);
+
   deepEqual(get(obj, 'a'), 2, 'responds to change of property on element');
+
   set(obj, 'array', emberA([a1, a2, a3]));
-  deepEqual(get(obj, 'a'), 6, 'responds to content array change');
+
+  deepEqual(get(obj, 'a'), 2, 'responds to content array change');
+
   set(a1, 'foo', true);
-  deepEqual(get(obj, 'a'), 7, 'still responds to change of property on element');
+
+  deepEqual(get(obj, 'a'), 3, 'still responds to change of property on element');
+  set(a3, 'foo', true);
+
+  deepEqual(get(obj, 'a'), 6, 'still responds to change of property on element');
 });
 
+
+QUnit.test('responds to change of property value on element after replacing array (object proxy)', function() {
+  let obj = { };
+
+  defineProperty(obj, 'a', computed('array.@each.foo', function() {
+    return get(this, 'array').filter(elt => get(elt, 'foo')).reduce((a, b) => a + get(b, 'id'), 0);
+  }));
+
+  set(obj, 'array', emberA([
+    ObjectProxy.create({ content: a1 }),
+    ObjectProxy.create({ content: a2 })
+  ]));
+
+  deepEqual(get(obj, 'a'), 3, 'value is correct initially');
+
+  set(a1, 'foo', false);
+
+  deepEqual(get(obj, 'a'), 2, 'responds to change of property on element');
+  set(obj, 'array', emberA([
+    ObjectProxy.create({ content: a1 }),
+    ObjectProxy.create({ content: a2 }),
+    ObjectProxy.create({ content: a3 })
+  ]));
+
+  deepEqual(get(obj, 'a'), 2, 'responds to content array change');
+
+  set(a1, 'foo', true);
+
+  deepEqual(get(obj, 'a'), 3, 'still responds to change of property on element');
+  set(a3, 'foo', true);
+
+  deepEqual(get(obj, 'a'), 6, 'still responds to change of property on element');
+});
+
+
+QUnit.test('responds to change of property value on element after replacing array (array proxy)', function() {
+  let obj = { };
+
+  defineProperty(obj, 'a', computed('array.@each.foo', function() {
+    return get(this, 'array').filter(elt => get(elt, 'foo')).reduce((a, b) => a + get(b, 'id'), 0);
+  }));
+
+  set(obj, 'array', ArrayProxy.create({
+    content: emberA([
+      ObjectProxy.create({ content: a1 }),
+      ObjectProxy.create({ content: a2 })
+    ])
+  }));
+
+  deepEqual(get(obj, 'a'), 3, 'value is correct initially');
+
+  set(a1, 'foo', false);
+
+  deepEqual(get(obj, 'a'), 2, 'responds to change of property on element');
+  set(obj, 'array', ArrayProxy.create({
+    content: emberA([
+      ObjectProxy.create({ content: a1 }),
+      ObjectProxy.create({ content: a2 }),
+      ObjectProxy.create({ content: a3 })
+    ])
+  }));
+
+  deepEqual(get(obj, 'a'), 2, 'responds to content array change');
+
+  set(a1, 'foo', true);
+
+  deepEqual(get(obj, 'a'), 3, 'still responds to change of property on element');
+  set(a3, 'foo', true);
+
+  deepEqual(get(obj, 'a'), 6, 'still responds to change of property on element');
+});

--- a/packages/ember-runtime/tests/computed/chains_test.js
+++ b/packages/ember-runtime/tests/computed/chains_test.js
@@ -1,0 +1,74 @@
+import { computed } from 'ember-metal/computed';
+import { defineProperty } from 'ember-metal/properties';
+import { get } from 'ember-metal/property_get';
+import { set } from 'ember-metal/property_set';
+import { isWatching } from 'ember-metal/watching';
+import { A as emberA } from 'ember-runtime/system/native_array';
+
+let a1, a2, a3, a4, obj;
+
+QUnit.module('chain watching', {
+  setup() {
+    a1 = { foo: true,  id: 1 };
+    a2 = { foo: true,  id: 2 };
+
+    a3 = { foo: false, id: 3 };
+    a4 = { foo: false, id: 4 };
+
+    obj = { };
+    defineProperty(obj, 'a', computed('array.@each.foo', function() {}));
+  }
+});
+
+QUnit.test('replace array (no overlap)', function() {
+  set(obj, 'array', Ember.A([a1, a2]));
+  get(obj, 'a'); // kick CP;
+
+  ok( isWatching(a1, 'foo'), 'BEFORE: a1.foo is watched');
+  ok( isWatching(a2, 'foo'), 'BEFORE: a2.foo is watched');
+  ok(!isWatching(a3, 'foo'), 'BEFORE: a3.foo is NOT watched');
+  ok(!isWatching(a4, 'foo'), 'BEFORE: a4.foo is NOT watched');
+
+  set(obj, 'array', [a3, a4]);
+
+  ok(!isWatching(a1, 'foo'), 'AFTER: a1.foo is NOT watched');
+  ok(!isWatching(a2, 'foo'), 'AFTER: a2.foo is NOT watched');
+  ok( isWatching(a3, 'foo'), 'AFTER: a3.foo is watched');
+  ok( isWatching(a4, 'foo'), 'AFTER: a4.foo is watched');
+});
+
+QUnit.test('replace array (overlap)', function() {
+  set(obj, 'array', Ember.A([a1, a2, a3]));
+  get(obj, 'a'); // kick CP;
+
+  ok( isWatching(a1, 'foo'), 'BEFORE: a1.foo is watched');
+  ok( isWatching(a2, 'foo'), 'BEFORE: a2.foo is watched');
+  ok( isWatching(a3, 'foo'), 'BEFORE: a3.foo is watched');
+  ok(!isWatching(a4, 'foo'), 'BEFORE: a4.foo is NOT watched');
+
+  obj.set('array', [a2, a3, a4]);
+
+  ok(!isWatching(a1, 'foo'), 'AFTER: a1.foo is NOT watched');
+  ok( isWatching(a2, 'foo'), 'AFTER: a2.foo is watched');
+  ok( isWatching(a3, 'foo'), 'AFTER: a3.foo is watched');
+  ok( isWatching(a4, 'foo'), 'AFTER: a4.foo is watched');
+});
+
+QUnit.test('responds to change of property value on element after replacing array', function() {
+  let obj = { };
+
+  defineProperty(obj, 'a', computed('array.@each.foo', function() {
+    return this.array.filter(elt => elt.foo).reduce(((a,b) => a + b.id), 0);
+  }));
+
+  set(obj, 'array', emberA([a1,a2]));
+
+  deepEqual(get(obj, 'a'), 3, 'value is correct initially');
+  set(a1, 'foo', false);
+  deepEqual(get(obj, 'a'), 2, 'responds to change of property on element');
+  set(obj, 'array', [a1, a2, a3]);
+  deepEqual(get(obj, 'a'), 6, 'responds to content array change');
+  set(a1, 'foo', true);
+  deepEqual(get(obj, 'a'), 7, 'still responds to change of property on element');
+});
+

--- a/packages/ember-runtime/tests/computed/chains_test.js
+++ b/packages/ember-runtime/tests/computed/chains_test.js
@@ -62,6 +62,44 @@ QUnit.test('replace array (overlap)', function() {
   ok(isWatching(a4, 'foo'), 'AFTER: a4.foo is watched');
 });
 
+QUnit.test('splice array (no overlap)', function() {
+  let array = emberA([a1, a2]);
+
+  set(obj, 'array', array);
+  get(obj, 'a'); // kick CP;
+
+  ok(isWatching(a1, 'foo'), 'BEFORE: a1.foo is watched');
+  ok(isWatching(a2, 'foo'), 'BEFORE: a2.foo is watched');
+  ok(!isWatching(a3, 'foo'), 'BEFORE: a3.foo is NOT watched');
+  ok(!isWatching(a4, 'foo'), 'BEFORE: a4.foo is NOT watched');
+
+  array.replace(0, 2, [a3, a4]);
+
+  ok(!isWatching(a1, 'foo'), 'AFTER: a1.foo is NOT watched');
+  ok(!isWatching(a2, 'foo'), 'AFTER: a2.foo is NOT watched');
+  ok(isWatching(a3, 'foo'), 'AFTER: a3.foo is watched');
+  ok(isWatching(a4, 'foo'), 'AFTER: a4.foo is watched');
+});
+
+QUnit.test('splice array (overlap)', function() {
+  let array = emberA([a1, a2, a3]);
+
+  set(obj, 'array', array);
+  get(obj, 'a'); // kick CP;
+
+  ok(isWatching(a1, 'foo'), 'BEFORE: a1.foo is watched');
+  ok(isWatching(a2, 'foo'), 'BEFORE: a2.foo is watched');
+  ok(isWatching(a3, 'foo'), 'BEFORE: a3.foo is watched');
+  ok(!isWatching(a4, 'foo'), 'BEFORE: a4.foo is NOT watched');
+
+  array.replace(0, 3, [a2, a3, a4]);
+
+  ok(!isWatching(a1, 'foo'), 'AFTER: a1.foo is NOT watched');
+  ok(isWatching(a2, 'foo'), 'AFTER: a2.foo is watched');
+  ok(isWatching(a3, 'foo'), 'AFTER: a3.foo is watched');
+  ok(isWatching(a4, 'foo'), 'AFTER: a4.foo is watched');
+});
+
 let a1Remote, a2Remote, a3Remote;
 
 QUnit.module('chain watching (filter)', {

--- a/packages/ember-runtime/tests/computed/chains_test.js
+++ b/packages/ember-runtime/tests/computed/chains_test.js
@@ -21,11 +21,11 @@ QUnit.module('chain watching', {
 });
 
 QUnit.test('replace array (no overlap)', function() {
-  set(obj, 'array', Ember.A([a1, a2]));
+  set(obj, 'array', emberA([a1, a2]));
   get(obj, 'a'); // kick CP;
 
-  ok( isWatching(a1, 'foo'), 'BEFORE: a1.foo is watched');
-  ok( isWatching(a2, 'foo'), 'BEFORE: a2.foo is watched');
+  ok(isWatching(a1, 'foo'), 'BEFORE: a1.foo is watched');
+  ok(isWatching(a2, 'foo'), 'BEFORE: a2.foo is watched');
   ok(!isWatching(a3, 'foo'), 'BEFORE: a3.foo is NOT watched');
   ok(!isWatching(a4, 'foo'), 'BEFORE: a4.foo is NOT watched');
 
@@ -33,35 +33,35 @@ QUnit.test('replace array (no overlap)', function() {
 
   ok(!isWatching(a1, 'foo'), 'AFTER: a1.foo is NOT watched');
   ok(!isWatching(a2, 'foo'), 'AFTER: a2.foo is NOT watched');
-  ok( isWatching(a3, 'foo'), 'AFTER: a3.foo is watched');
-  ok( isWatching(a4, 'foo'), 'AFTER: a4.foo is watched');
+  ok(isWatching(a3, 'foo'), 'AFTER: a3.foo is watched');
+  ok(isWatching(a4, 'foo'), 'AFTER: a4.foo is watched');
 });
 
 QUnit.test('replace array (overlap)', function() {
-  set(obj, 'array', Ember.A([a1, a2, a3]));
+  set(obj, 'array', emberA([a1, a2, a3]));
   get(obj, 'a'); // kick CP;
 
-  ok( isWatching(a1, 'foo'), 'BEFORE: a1.foo is watched');
-  ok( isWatching(a2, 'foo'), 'BEFORE: a2.foo is watched');
-  ok( isWatching(a3, 'foo'), 'BEFORE: a3.foo is watched');
+  ok(isWatching(a1, 'foo'), 'BEFORE: a1.foo is watched');
+  ok(isWatching(a2, 'foo'), 'BEFORE: a2.foo is watched');
+  ok(isWatching(a3, 'foo'), 'BEFORE: a3.foo is watched');
   ok(!isWatching(a4, 'foo'), 'BEFORE: a4.foo is NOT watched');
 
   obj.set('array', [a2, a3, a4]);
 
   ok(!isWatching(a1, 'foo'), 'AFTER: a1.foo is NOT watched');
-  ok( isWatching(a2, 'foo'), 'AFTER: a2.foo is watched');
-  ok( isWatching(a3, 'foo'), 'AFTER: a3.foo is watched');
-  ok( isWatching(a4, 'foo'), 'AFTER: a4.foo is watched');
+  ok(isWatching(a2, 'foo'), 'AFTER: a2.foo is watched');
+  ok(isWatching(a3, 'foo'), 'AFTER: a3.foo is watched');
+  ok(isWatching(a4, 'foo'), 'AFTER: a4.foo is watched');
 });
 
 QUnit.test('responds to change of property value on element after replacing array', function() {
   let obj = { };
 
   defineProperty(obj, 'a', computed('array.@each.foo', function() {
-    return this.array.filter(elt => elt.foo).reduce(((a,b) => a + b.id), 0);
+    return this.array.filter(elt => elt.foo).reduce((a, b) => a + b.id, 0);
   }));
 
-  set(obj, 'array', emberA([a1,a2]));
+  set(obj, 'array', emberA([a1, a2]));
 
   deepEqual(get(obj, 'a'), 3, 'value is correct initially');
   set(a1, 'foo', false);

--- a/packages/ember-runtime/tests/computed/chains_test.js
+++ b/packages/ember-runtime/tests/computed/chains_test.js
@@ -207,9 +207,8 @@ QUnit.test('responds to change of property value on element after replacing arra
 QUnit.test('responds to change of property value on element after replacing array (object promise proxy-un-settled)', function() {
   run(_ => {
     set(obj, 'array', emberA([
-          ObjectProxy.create({ promise: RSVP.Promise.resolve(a1) }),
-          ObjectProxy.create({ promise: RSVP.Promise.resolve(a2) }),
-          ObjectProxy.create({ promise: RSVP.Promise.resolve(a3) })
+          ObjectPromiseProxy.create({ promise: RSVP.Promise.resolve(a1) }),
+          ObjectPromiseProxy.create({ promise: RSVP.Promise.resolve(a2) }),
     ]));
 
     equal(get(obj, 'a'), 0, 'value is correct initially');
@@ -221,23 +220,24 @@ QUnit.test('responds to change of property value on element after replacing arra
 
   run(_ => {
     set(obj, 'array', emberA([
-          ObjectProxy.create({ promise: RSVP.Promise.resolve(a1) }),
-          ObjectProxy.create({ promise: RSVP.Promise.resolve(a2) }),
-          ObjectProxy.create({ promise: RSVP.Promise.resolve(a3) })
+          ObjectPromiseProxy.create({ promise: RSVP.Promise.resolve(a2) }),
+          ObjectPromiseProxy.create({ promise: RSVP.Promise.resolve(a3) })
     ]));
 
-    equal(get(obj, 'a'), 2, 'expected no change');
+    equal(get(obj, 'a'), 0, 'expected no change');
     set(a1, 'foo', true);
-    equal(get(obj, 'a'), 2, 'expected no change');
-    set(a3, 'foo', true);
-    equal(get(obj, 'a'), 2, 'expected no change');
+    equal(get(obj, 'a'), 0, 'expected no change');
   });
 
-  equal(get(obj, 'a'), 3, 'still responds to change of property on element');
+  equal(get(obj, 'a'), 2, 'still responds to change of property on element');
 
   set(a3, 'foo', true);
 
-  equal(get(obj, 'a'), 6, 'still responds to change of property on element');
+  equal(get(obj, 'a'), 5, 'still responds to change of property on element');
+
+  set(a3, 'foo', false);
+
+  equal(get(obj, 'a'), 2, 'still responds to change of property on element');
 });
 
 QUnit.test('responds to change of property value on element after replacing array (array promise proxy)', function() {

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -428,28 +428,6 @@ QUnit.test('properties values can be replaced', function() {
   deepEqual(obj.get('a1bs').mapBy('name'), ['item1'], 'properties can be filtered by matching value');
 });
 
-QUnit.test('responds to change of property value on element after replacing array', function() {
-  let a1 = { foo: true, id: 1 };
-  let a2 = { foo: true, id: 2 };
-  let a3 = { foo: true, id: 4 };
-
-  obj = EmberObject.extend({
-    a: computed('array.@each.foo', function() {
-      return this.get('array').filter(elt => elt.foo).reduce(((a,b) => a + b.id), 0);
-    })
-  }).create({
-    array: emberA([a1, a2])
-  });
-
-  deepEqual(obj.get('a'), 3, 'value is correct initially');
-  set(a1, 'foo', false);
-  deepEqual(obj.get('a'), 2, 'responds to change of property on element');
-  obj.set('array', [a1, a2, a3]);
-  deepEqual(obj.get('a'), 6, 'responds to content array change');
-  set(a1, 'foo', true);
-  deepEqual(obj.get('a'), 7, 'still responds to change of property on element');
-});
-
 [
   ['uniq', uniq],
   ['union', union]

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -6,7 +6,6 @@ import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
 import { addObserver } from 'ember-metal/observer';
 import { observer } from 'ember-metal/mixin';
-import { computed } from 'ember-metal/computed';
 import {
   sum,
   min,

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -6,6 +6,7 @@ import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
 import { addObserver } from 'ember-metal/observer';
 import { observer } from 'ember-metal/mixin';
+import { computed } from 'ember-metal/computed';
 import {
   sum,
   min,
@@ -425,6 +426,28 @@ QUnit.test('properties values can be replaced', function() {
   ]);
 
   deepEqual(obj.get('a1bs').mapBy('name'), ['item1'], 'properties can be filtered by matching value');
+});
+
+QUnit.test('responds to change of property value on element after replacing array', function() {
+  let a1 = { foo: true, id: 1 };
+  let a2 = { foo: true, id: 2 };
+  let a3 = { foo: true, id: 4 };
+
+  obj = EmberObject.extend({
+    a: computed('array.@each.foo', function() {
+      return this.get('array').filter(elt => elt.foo).reduce(((a,b) => a + b.id), 0);
+    })
+  }).create({
+    array: emberA([a1, a2])
+  });
+
+  deepEqual(obj.get('a'), 3, 'value is correct initially');
+  set(a1, 'foo', false);
+  deepEqual(obj.get('a'), 2, 'responds to change of property on element');
+  obj.set('array', [a1, a2, a3]);
+  deepEqual(obj.get('a'), 6, 'responds to content array change');
+  set(a1, 'foo', true);
+  deepEqual(obj.get('a'), 7, 'still responds to change of property on element');
 });
 
 [


### PR DESCRIPTION
This adds a failing test for #12475. It appears that `obj.set('array', [a1, a2, a3])` fails to install contentKey observers on the new array value so that the subsequent changes to `foo` are ignored.
