### PR TITLE
Deprecates Ember.ArrayProxy

### DIFF
--- a/packages/ember-htmlbars/tests/helpers/collection_test.js
+++ b/packages/ember-htmlbars/tests/helpers/collection_test.js
@@ -86,13 +86,19 @@ QUnit.test('itemViewClass works in the #collection helper with a property', func
   });
 
   var ExampleCollectionView = CollectionView;
+  var arrayProxy;
+
+  expectDeprecation(function() {
+    arrayProxy = ArrayProxy.create({
+      content: emberA(['alpha'])
+    });
+  }, '`Ember.ArrayProxy` is deprecated and will be removed in a future release.');
+
 
   view = EmberView.create({
     possibleItemView: ExampleItemView,
     exampleCollectionView: ExampleCollectionView,
-    exampleController: ArrayProxy.create({
-      content: emberA(['alpha'])
-    }),
+    exampleController: arrayProxy,
     template: compile('{{#collection view.exampleCollectionView content=view.exampleController itemViewClass=view.possibleItemView}}beta{{/collection}}')
   });
 
@@ -106,12 +112,19 @@ QUnit.test('itemViewClass works in the #collection via container', function() {
     isAlsoCustom: true
   }));
 
+  var arrayProxy;
+
+  expectDeprecation(function() {
+    arrayProxy = ArrayProxy.create({
+      content: emberA(['alpha'])
+    });
+  }, '`Ember.ArrayProxy` is deprecated and will be removed in a future release.');
+
+
   view = EmberView.create({
     [OWNER]: owner,
     exampleCollectionView: CollectionView.extend(),
-    exampleController: ArrayProxy.create({
-      content: emberA(['alpha'])
-    }),
+    exampleController: arrayProxy,
     template: compile('{{#collection view.exampleCollectionView content=view.exampleController itemViewClass="example-item"}}beta{{/collection}}')
   });
 
@@ -178,9 +191,13 @@ QUnit.test('empty views should be removed when content is added to the collectio
     emptyView: EmptyView
   });
 
-  var listController = ArrayProxy.create({
-    content : emberA()
-  });
+  var listController;
+
+  expectDeprecation(function() {
+    listController = ArrayProxy.create({
+      content: emberA()
+    });
+  }, '`Ember.ArrayProxy` is deprecated and will be removed in a future release.');
 
   view = EmberView.create({
     _viewRegistry: {},
@@ -532,9 +549,11 @@ QUnit.test('should render multiple, bound nested collections (#68)', function() 
   var view;
 
   run(function() {
-    TemplateTests.contentController = ArrayProxy.create({
-      content: emberA(['foo', 'bar'])
-    });
+    expectDeprecation(function() {
+      TemplateTests.contentController = ArrayProxy.create({
+        content: emberA(['foo', 'bar'])
+      });
+    }, '`Ember.ArrayProxy` is deprecated and will be removed in a future release.');
 
     var InnerList = CollectionView.extend({
       tagName: 'ul',

--- a/packages/ember-htmlbars/tests/helpers/if_unless_test.js
+++ b/packages/ember-htmlbars/tests/helpers/if_unless_test.js
@@ -152,13 +152,27 @@ QUnit.test('The `if` helper updates if an array is empty or not', function() {
 });
 
 QUnit.test('The `if` helper updates if an array-like object is empty or not', function() {
-  testIfArray(ArrayProxy.create({ content: emberA() }));
+  var arrayProxy;
+
+  expectDeprecation(function() {
+    arrayProxy = ArrayProxy.create({
+      content: emberA()
+    });
+  }, '`Ember.ArrayProxy` is deprecated and will be removed in a future release.');
+  testIfArray(arrayProxy);
 });
 
 QUnit.test('The `unless` helper updates if an array-like object is empty or not', function() {
-  view = EmberView.create({
-    array: ArrayProxy.create({ content: emberA() }),
+  var arrayProxy;
 
+  expectDeprecation(function() {
+    arrayProxy = ArrayProxy.create({
+      content: emberA()
+    });
+  }, '`Ember.ArrayProxy` is deprecated and will be removed in a future release.');
+
+  view = EmberView.create({
+    array: arrayProxy,
     template: compile('{{#unless view.array}}Yep{{/unless}}')
   });
 

--- a/packages/ember-htmlbars/tests/integration/select_in_template_test.js
+++ b/packages/ember-htmlbars/tests/integration/select_in_template_test.js
@@ -194,10 +194,15 @@ QUnit.test('upon content change with Array-like content, the DOM should reflect 
   var tom = { id: 4, name: 'Tom' };
   var sylvain = { id: 5, name: 'Sylvain' };
 
-  var proxy = ArrayProxy.create({
-    content: emberA(),
-    selectedOption: sylvain
-  });
+  var proxy;
+
+  expectDeprecation(function() {
+    proxy = ArrayProxy.create({
+      content: emberA(),
+      selectedOption: sylvain
+    });
+  }, '`Ember.ArrayProxy` is deprecated and will be removed in a future release.');
+
 
   view = EmberView.create({
     proxy: proxy,

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -1,4 +1,4 @@
-import { assert } from 'ember-metal/debug';
+import { assert, deprecate } from 'ember-metal/debug';
 import { get } from 'ember-metal/property_get';
 import {
   isArray
@@ -63,9 +63,9 @@ function K() { return this; }
   @extends Ember.Object
   @uses Ember.MutableArray
   @public
+  @deprecated
 */
 var ArrayProxy = EmberObject.extend(MutableArray, {
-
   /**
     The content array. Must be an object that implements `Ember.Array` and/or
     `Ember.MutableArray.`
@@ -373,6 +373,17 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
     this._super(...arguments);
     this._setupContent();
     this._setupArrangedContent();
+
+    if (!this._LEGACY_EMBER_DATA_SUPPORT) {
+      deprecate(
+        '`Ember.ArrayProxy` is deprecated and will be removed in a future release.',
+        false, {
+          id: 'ember-runtime.array-proxy',
+          until: '3.0.0',
+          url: 'http://emberjs.com/deprecations/v2.x/#toc_ember-runtimearray-proxy'
+        }
+      );
+    }
   },
 
   willDestroy() {

--- a/packages/ember-runtime/tests/core/is_array_test.js
+++ b/packages/ember-runtime/tests/core/is_array_test.js
@@ -14,7 +14,13 @@ QUnit.test('Ember.isArray', function() {
   var object        = {};
   var length        = { length: 12 };
   var fn            = function() {};
-  var arrayProxy = ArrayProxy.create({ content: emberA() });
+  var arrayProxy;
+
+  expectDeprecation(function() {
+    arrayProxy = ArrayProxy.create({
+      content: emberA()
+    });
+  }, '`Ember.ArrayProxy` is deprecated and will be removed in a future release.');
 
   equal(isArray(numarray), true, '[1,2,3]');
   equal(isArray(number), false, '23');

--- a/packages/ember-runtime/tests/core/is_empty_test.js
+++ b/packages/ember-runtime/tests/core/is_empty_test.js
@@ -5,7 +5,12 @@ import { A as emberA } from 'ember-runtime/system/native_array';
 QUnit.module('Ember.isEmpty');
 
 QUnit.test('Ember.isEmpty', function() {
-  var arrayProxy = ArrayProxy.create({ content: emberA() });
+  var arrayProxy;
+  expectDeprecation(function() {
+    arrayProxy = ArrayProxy.create({
+      content: emberA([])
+    });
+  }, '`Ember.ArrayProxy` is deprecated and will be removed in a future release.');
 
   equal(true, isEmpty(arrayProxy), 'for an ArrayProxy that has empty content');
 });

--- a/packages/ember-runtime/tests/system/array_proxy/arranged_content_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/arranged_content_test.js
@@ -8,18 +8,20 @@ var array;
 QUnit.module('ArrayProxy - arrangedContent', {
   setup() {
     run(function() {
-      array = ArrayProxy.extend({
-        arrangedContent: computed('content.[]', function() {
-          var content = this.get('content');
-          return content && emberA(content.slice().sort(function(a, b) {
-            if (a == null) { a = -1; }
-            if (b == null) { b = -1; }
-            return b - a;
-          }));
-        })
-      }).create({
-        content: emberA([1, 2, 4, 5])
-      });
+      expectDeprecation(function() {
+        array = ArrayProxy.extend({
+          arrangedContent: computed('content.[]', function() {
+            var content = this.get('content');
+            return content && emberA(content.slice().sort(function(a, b) {
+              if (a == null) { a = -1; }
+              if (b == null) { b = -1; }
+              return b - a;
+            }));
+          })
+        }).create({
+          content: emberA([1, 2, 4, 5])
+        });
+      }, '`Ember.ArrayProxy` is deprecated and will be removed in a future release.');
     });
   },
   teardown() {
@@ -176,9 +178,11 @@ QUnit.test('firstObject - returns first arranged object', function() {
 QUnit.module('ArrayProxy - arrangedContent matching content', {
   setup() {
     run(function() {
-      array = ArrayProxy.create({
-        content: emberA([1, 2, 4, 5])
-      });
+      expectDeprecation(function() {
+        array = ArrayProxy.create({
+          content: emberA([1, 2, 4, 5])
+        });
+      }, '`Ember.ArrayProxy` is deprecated and will be removed in a future release.');
     });
   },
   teardown() {
@@ -206,23 +210,25 @@ QUnit.test('reverseObjects - reverses content', function() {
 QUnit.module('ArrayProxy - arrangedContent with transforms', {
   setup() {
     run(function() {
-      array = ArrayProxy.extend({
-        arrangedContent: computed(function() {
-          var content = this.get('content');
-          return content && emberA(content.slice().sort(function(a, b) {
-            if (a == null) { a = -1; }
-            if (b == null) { b = -1; }
-            return b - a;
-          }));
-        }).property('content.[]'),
+      expectDeprecation(function() {
+        array = ArrayProxy.extend({
+          arrangedContent: computed(function() {
+            var content = this.get('content');
+            return content && emberA(content.slice().sort(function(a, b) {
+              if (a == null) { a = -1; }
+              if (b == null) { b = -1; }
+              return b - a;
+            }));
+          }).property('content.[]'),
 
-        objectAtContent(idx) {
-          var obj = this.get('arrangedContent').objectAt(idx);
-          return obj && obj.toString();
-        }
-      }).create({
-        content: emberA([1, 2, 4, 5])
-      });
+          objectAtContent(idx) {
+            var obj = this.get('arrangedContent').objectAt(idx);
+            return obj && obj.toString();
+          }
+        }).create({
+          content: emberA([1, 2, 4, 5])
+        });
+      }, '`Ember.ArrayProxy` is deprecated and will be removed in a future release.');
     });
   },
   teardown() {

--- a/packages/ember-runtime/tests/system/array_proxy/content_change_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/content_change_test.js
@@ -7,9 +7,12 @@ import { A as emberA } from 'ember-runtime/system/native_array';
 QUnit.module('ArrayProxy - content change');
 
 QUnit.test('should update length for null content', function() {
-  var proxy = ArrayProxy.create({
-        content: emberA([1, 2, 3])
-      });
+  var proxy;
+  expectDeprecation(function() {
+    proxy = ArrayProxy.create({
+      content: emberA([1, 2, 3])
+    });
+  }, '`Ember.ArrayProxy` is deprecated and will be removed in a future release.');
 
   equal(proxy.get('length'), 3, 'precond - length is 3');
 
@@ -19,11 +22,15 @@ QUnit.test('should update length for null content', function() {
 });
 
 QUnit.test('should update length for null content when there is a computed property watching length', function() {
-  var proxy = ArrayProxy.extend({
-    isEmpty: not('length')
-  }).create({
-    content: emberA([1, 2, 3])
-  });
+  var proxy;
+  expectDeprecation(function() {
+    proxy = ArrayProxy.extend({
+      isEmpty: not('length')
+    }).create({
+      content: emberA([1, 2, 3])
+    });
+  }, '`Ember.ArrayProxy` is deprecated and will be removed in a future release.');
+
 
   equal(proxy.get('length'), 3, 'precond - length is 3');
 
@@ -39,13 +46,16 @@ QUnit.test('should update length for null content when there is a computed prope
 QUnit.test('The `arrangedContentWillChange` method is invoked before `content` is changed.', function() {
   var callCount = 0;
   var expectedLength;
+  var proxy;
+  expectDeprecation(function() {
+    proxy = ArrayProxy.extend({
+      arrangedContentWillChange() {
+        equal(this.get('arrangedContent.length'), expectedLength, 'hook should be invoked before array has changed');
+        callCount++;
+      }
+    }).create({ content: emberA([1, 2, 3]) });
+  }, '`Ember.ArrayProxy` is deprecated and will be removed in a future release.');
 
-  var proxy = ArrayProxy.extend({
-    arrangedContentWillChange() {
-      equal(this.get('arrangedContent.length'), expectedLength, 'hook should be invoked before array has changed');
-      callCount++;
-    }
-  }).create({ content: emberA([1, 2, 3]) });
 
   proxy.pushObject(4);
   equal(callCount, 0, 'pushing content onto the array doesn\'t trigger it');
@@ -62,14 +72,18 @@ QUnit.test('The `arrangedContentDidChange` method is invoked after `content` is 
   var callCount = 0;
   var expectedLength;
 
-  var proxy = ArrayProxy.extend({
-    arrangedContentDidChange() {
-      equal(this.get('arrangedContent.length'), expectedLength, 'hook should be invoked after array has changed');
-      callCount++;
-    }
-  }).create({
-    content: emberA([1, 2, 3])
-  });
+  var proxy;
+  expectDeprecation(function() {
+    proxy = ArrayProxy.extend({
+      arrangedContentDidChange() {
+        equal(this.get('arrangedContent.length'), expectedLength, 'hook should be invoked after array has changed');
+        callCount++;
+      }
+    }).create({
+      content: emberA([1, 2, 3])
+    });
+  }, '`Ember.ArrayProxy` is deprecated and will be removed in a future release.');
+
 
   equal(callCount, 0, 'hook is not called after creating the object');
 
@@ -85,8 +99,12 @@ QUnit.test('The `arrangedContentDidChange` method is invoked after `content` is 
 });
 
 QUnit.test('The ArrayProxy doesn\'t explode when assigned a destroyed object', function() {
-  var proxy1 = ArrayProxy.create();
-  var proxy2 = ArrayProxy.create();
+  var proxy1, proxy2;
+
+  expectDeprecation(function() {
+    proxy1 = ArrayProxy.create();
+    proxy2 = ArrayProxy.create();
+  }, '`Ember.ArrayProxy` is deprecated and will be removed in a future release.');
 
   run(function() {
     proxy1.destroy();

--- a/packages/ember-runtime/tests/system/array_proxy/content_update_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/content_update_test.js
@@ -8,18 +8,20 @@ QUnit.test('The `contentArrayDidChange` method is invoked after `content` is upd
   var proxy;
   var observerCalled = false;
 
-  proxy = ArrayProxy.extend({
-    arrangedContent: computed('content', function(key) {
-      return emberA(this.get('content').slice());
-    }),
+  expectDeprecation(function() {
+    proxy = ArrayProxy.extend({
+      arrangedContent: computed('content', function(key) {
+        return emberA(this.get('content').slice());
+      }),
 
-    contentArrayDidChange(array, idx, removedCount, addedCount) {
-      observerCalled = true;
-      return this._super(array, idx, removedCount, addedCount);
-    }
-  }).create({
-    content: emberA()
-  });
+      contentArrayDidChange(array, idx, removedCount, addedCount) {
+        observerCalled = true;
+        return this._super(array, idx, removedCount, addedCount);
+      }
+    }).create({
+      content: emberA()
+    });
+  }, '`Ember.ArrayProxy` is deprecated and will be removed in a future release.');
 
   proxy.pushObject(1);
 

--- a/packages/ember-runtime/tests/system/array_proxy/length_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/length_test.js
@@ -7,9 +7,19 @@ import { A as a } from 'ember-runtime/system/native_array';
 QUnit.module('Ember.ArrayProxy - content change (length)');
 
 QUnit.test('array proxy + aliasedProperty complex test', function() {
-  var aCalled, bCalled, cCalled, dCalled, eCalled;
+  var aCalled, bCalled, cCalled, dCalled, eCalled, arrayProxy;
 
   aCalled = bCalled = cCalled = dCalled = eCalled = 0;
+
+  expectDeprecation(function() {
+    arrayProxy = ArrayProxy.create({
+      content: a([
+        'red',
+        'yellow',
+        'blue'
+      ])
+    });
+  }, '`Ember.ArrayProxy` is deprecated and will be removed in a future release.');
 
   var obj = Object.extend({
     colors: computed.reads('model'),
@@ -36,14 +46,7 @@ QUnit.test('array proxy + aliasedProperty complex test', function() {
     })
   }).create();
 
-  obj.set('model', ArrayProxy.create({
-    content: a([
-      'red',
-      'yellow',
-      'blue'
-    ])
-  })
-  );
+  obj.set('model', arrayProxy);
 
   equal(obj.get('colors.content.length'), 3);
   equal(obj.get('colors.length'), 3);

--- a/packages/ember-runtime/tests/system/array_proxy/suite_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/suite_test.js
@@ -9,7 +9,15 @@ MutableArrayTests.extend({
 
   newObject(ary) {
     var ret = ary ? ary.slice() : this.newFixture(3);
-    return ArrayProxy.create({ content: emberA(ret) });
+    var arrayProxy;
+
+    expectDeprecation(function() {
+      arrayProxy = ArrayProxy.create({
+        content: emberA(ret)
+      });
+    }, '`Ember.ArrayProxy` is deprecated and will be removed in a future release.');
+
+    return arrayProxy;
   },
 
   mutate(obj) {


### PR DESCRIPTION
Includes a legacy flag for Ember Data to continue to use Ember.ArrayProxy internally.
- [x] Deprecate
- [ ] PR a shim to Ember Data that enables `_LEGACY_EMBER_DATA_SUPPORT` flag
- [ ] Add deprecation entry at http://emberjs.com/deprecations/v2.x/#toc_ember-runtimearray-proxy
