### PR TITLE
[BUGFIX beta] Add warning for “deep @each” usage in dependent keys

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -21,6 +21,8 @@
         "expectAssertion",
         "expectDeprecation",
         "expectNoDeprecation",
+        "expectWarning",
+        "expectNoWarning",
         "ignoreAssertion",
         "ignoreDeprecation",
 

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -1,4 +1,4 @@
-import { assert } from 'ember-metal/debug';
+import { assert, warn } from 'ember-metal/debug';
 import { set } from 'ember-metal/property_set';
 import { inspect } from 'ember-metal/utils';
 import { meta as metaFor, peekMeta } from 'ember-metal/meta';
@@ -24,6 +24,8 @@ import {
 
 
 function UNDEFINED() { }
+
+const DEEP_EACH_REGEX = /\.@each\.[^.]+\./;
 
 // ..........................................................
 // COMPUTED PROPERTY
@@ -252,6 +254,13 @@ ComputedPropertyPrototype.property = function() {
   var args;
 
   var addArg = function(property) {
+    warn(
+      `Dependent keys containing @each only work one level deep. ` +
+        `You cannot use nested forms like todos.@each.owner.name or todos.@each.owner.@each.name. ` +
+          `Please create an intermediary computed property.`,
+      DEEP_EACH_REGEX.test(property) === false,
+      { id: 'ember-metal.computed-deep-each' }
+    );
     args.push(property);
   };
 

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -88,6 +88,28 @@ QUnit.test('defining a computed property with a dependent key ending with @each 
   deepEqual(cp._dependentKeys, ['qux', 'zoopa.[]']);
 });
 
+QUnit.test('defining a computed property with a dependent key more than one level deep beyond @each is not supported', function() {
+  let warning = `Dependent keys containing @each only work one level deep. ` +
+                `You cannot use nested forms like todos.@each.owner.name or todos.@each.owner.@each.name. ` +
+                `Please create an intermediary computed property.`;
+
+  expectNoWarning(() => {
+    computed('todos', () => {});
+  });
+
+  expectNoWarning(() => {
+    computed('todos.@each.owner', () => {});
+  });
+
+  expectWarning(() => {
+    computed('todos.@each.owner.name', () => {});
+  }, warning);
+
+  expectWarning(() => {
+    computed('todos.@each.owner.@each.name', () => {});
+  }, warning);
+});
+
 var objA, objB;
 QUnit.module('computed should inherit through prototype', {
   setup() {


### PR DESCRIPTION
Adds a warning when defining dependent keys of the form `todos.@each.owner.name` or `todos.@each.owner.@each.name` as described [in the guides](https://guides.emberjs.com/v2.2.0/object-model/computed-properties-and-aggregate-data/).

Fixes https://github.com/emberjs/ember.js/issues/12840.
