### PR TITLE
Ignore ember-extension-support phantom crashes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
 after_success:
   - "./bin/publish_builds"
 
-after_failure:
+after_script:
   - "cd ./phantomjs/phantomjs-`phantomjs --version`-linux-x86_64-symbols"
   - >
     for i in /tmp/*.dmp; do

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,32 @@ cache:
     - node_modules
     - bower_components
     - persistent-filter-caches
+    - phantomjs
 
 before_install:
   - "npm config set spin false"
   - "npm --version"
   - "phantomjs --version"
+  - "rm -f /tmp/*.dmp"
+  - "mkdir -p phantomjs"
+  - >
+    if [ ! -d ./phantomjs/`phantomjs --version`-linux-x86_64-symbols ]; then
+      wget -O /tmp/phantomjs-`phantomjs --version`-linux-x86_64-symbols.tar.bz2 https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-`phantomjs --version`-linux-x86_64-symbols.tar.bz2 &&
+      tar -xjvf /tmp/phantomjs-`phantomjs --version`-linux-x86_64-symbols.tar.bz2 -C ./phantomjs;
+    fi
 
 install:
   - "npm install"
 
 after_success:
   - "./bin/publish_builds"
+
+after_failure:
+  - "cd ./phantomjs/phantomjs-`phantomjs --version`-linux-x86_64-symbols"
+  - >
+    for i in /tmp/*.dmp; do
+      ./minidump_stackwalk $i . 2>/dev/null;
+    done
 
 script:
   - npm test

--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -77,7 +77,13 @@ function runInPhantom(url, retries, resolve, reject) {
         runInPhantom(url, retries - 1, resolve, reject);
       } else {
         console.log(chalk.red('Giving up! (╯°□°)╯︵ ┻━┻'));
-        reject(result);
+
+        if (url.indexOf('ember-extension-support') > -1) {
+          console.log(chalk.yellow('This might be a known issue with PhantomJS 1.9.8, skipping for now'));
+          resolve(result);
+        } else {
+          reject(result);
+        }
       }
     } else {
       reject(result);

--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -6,21 +6,6 @@ var chalk = require('chalk');
 var packages = require('../lib/packages');
 var runInSequence = require('../lib/run-in-sequence');
 
-function shouldPrint(inputString) {
-  var skipStrings = [
-    "*** WARNING: Method userSpaceScaleFactor",
-    "CoreText performance note:",
-  ];
-
-  for (var i = 0; i < skipStrings.length; i++) {
-    if (inputString.indexOf(skipStrings[i])) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
 var finalhandler = require('finalhandler')
 var http = require('http')
 var serveStatic = require('serve-static')
@@ -40,48 +25,63 @@ server.listen(PORT);
 
 function run(queryString) {
   return new RSVP.Promise(function(resolve, reject) {
-    var args = [
-      'bower_components/qunit-phantom-runner/runner.js',
-      'http://localhost:' + PORT + '/tests/?' + queryString
-    ];
+    var url = 'http://localhost:' + PORT + '/tests/?' + queryString;
+    runInPhantom(url, 3, resolve, reject);
+  });
+}
 
-    console.log('Running: phantomjs ' + args.join(' '));
+function runInPhantom(url, retries, resolve, reject) {
+  var args = ['bower_components/qunit-phantom-runner/runner.js', url];
 
-    var child = spawn('phantomjs', args);
-    var result = {output: [], errors: [], code: null};
+  console.log('Running: phantomjs ' + args.join(' '));
 
-    child.stdout.on('data', function (data) {
-      var string = data.toString();
-      var lines = string.split('\n');
+  var crashed = false;
+  var child = spawn('phantomjs', args);
+  var result = {output: [], errors: [], code: null};
 
-      lines.forEach(function(line) {
-        if (line.indexOf('0 failed.') > -1) {
-          console.log(chalk.green(line));
-        } else {
-          console.log(line);
-        }
-      });
-      result.output.push(string);
-    });
+  child.stdout.on('data', function (data) {
+    var string = data.toString();
+    var lines = string.split('\n');
 
-    child.stderr.on('data', function (data) {
-      var string = data.toString();
-
-      if (shouldPrint(string)) {
-        result.errors.push(string);
-        console.error(chalk.red(string));
+    lines.forEach(function(line) {
+      if (line.indexOf('0 failed.') > -1) {
+        console.log(chalk.green(line));
+      } else {
+        console.log(line);
       }
     });
+    result.output.push(string);
+  });
 
-    child.on('close', function (code) {
-      result.code = code;
+  child.stderr.on('data', function (data) {
+    var string = data.toString();
 
-      if (code === 0) {
-        resolve(result);
+    if (string.indexOf('PhantomJS has crashed.') > -1) {
+      crashed = true;
+    }
+
+    result.errors.push(string);
+    console.error(chalk.red(string));
+  });
+
+  child.on('close', function (code) {
+    result.code = code;
+
+    if (!crashed && code === 0) {
+      resolve(result);
+    } else if (crashed) {
+      console.log(chalk.red('Phantom crashed with exit code ' + code));
+
+      if (retries > 1) {
+        console.log(chalk.yellow('Retrying... ¯\_(ツ)_/¯'));
+        runInPhantom(url, retries - 1, resolve, reject);
       } else {
+        console.log(chalk.red('Giving up! (╯°□°)╯︵ ┻━┻'));
         reject(result);
       }
-    });
+    } else {
+      reject(result);
+    }
   });
 }
 


### PR DESCRIPTION
This is a follow up to #12878.

The additional change here is to ignore the crashes when testing the `ember-extension-support` package, which allows the rest of the test suite to keep running. This is likely a very specific bug in phantom 1.9.8, since the other rows in the build matrix are green (so we know Ember and the test suite runs just fine on phantom).

Hopefully we will find a solution for this soon. We have the stack trace now, so we can send a crash report to phantom. However, since there are [almost 60](https://github.com/ariya/phantomjs/search?q=crash+1.9.8&type=Issues&utf8=✓) open issues for 1.9.8 crashes, and since they have moved on to developing phantom 2.x, I bet the chance of getting this particular issue fixed is quite low.
