### PR TITLE
More glimmer tests

### DIFF
--- a/packages/ember-glimmer/lib/ember-metal-views/index.js
+++ b/packages/ember-glimmer/lib/ember-metal-views/index.js
@@ -8,11 +8,31 @@ export class Renderer {
     let env = this._env;
 
     env.begin();
-    view.template.render({ view }, env, { appendTo: target });
+    let result = view.template.render(view, env, { appendTo: target });
     env.commit();
+
+    // FIXME: Store this somewhere else
+    view['_renderResult'] = result;
+
+    // FIXME: This should happen inside `env.commit()`
+    view._transitionTo('inDOM');
+  }
+
+  rerender(view) {
+    view['_renderResult'].rerender();
+  }
+
+  remove(view) {
+    view._transitionTo('destroying');
+    view.destroy();
   }
 
   componentInitAttrs() {
     // TODO: Remove me
+  }
+
+  ensureViewNotRendering() {
+    // TODO: Implement this
+    // throw new Error('Something you did caused a view to re-render after it rendered but before it was inserted into the DOM.');
   }
 }

--- a/packages/ember-glimmer/tests/integration/content-test.js
+++ b/packages/ember-glimmer/tests/integration/content-test.js
@@ -3,7 +3,7 @@ import { set } from 'ember-metal/property_set';
 
 moduleFor('Static content tests', class extends RenderingTest {
 
-  ['TEST: it can render a static text node']() {
+  ['@test it can render a static text node']() {
     this.render('hello');
     let text1 = this.assertTextNode(this.firstChild, 'hello');
 
@@ -13,7 +13,7 @@ moduleFor('Static content tests', class extends RenderingTest {
     this.assertSameNode(text1, text2);
   }
 
-  ['TEST: it can render a static element']() {
+  ['@test it can render a static element']() {
     this.render('<p>hello</p>');
     let p1 = this.assertElement(this.firstChild, { tagName: 'p' });
     let text1 = this.assertTextNode(this.firstChild.firstChild, 'hello');
@@ -26,7 +26,7 @@ moduleFor('Static content tests', class extends RenderingTest {
     this.assertSameNode(text1, text2);
   }
 
-  ['TEST: it can render a static template']() {
+  ['@test it can render a static template']() {
     let template = `
       <div class="header">
         <h1>Welcome to Ember.js</h1>
@@ -55,7 +55,7 @@ moduleFor('Static content tests', class extends RenderingTest {
 
 moduleFor('Dynamic content tests', class extends RenderingTest {
 
-  ['TEST: it can render a dynamic text node']() {
+  ['@test it can render a dynamic text node']() {
     this.render('{{message}}', {
       message: 'hello'
     });
@@ -81,7 +81,7 @@ moduleFor('Dynamic content tests', class extends RenderingTest {
     this.assertSameNode(text1, text4);
   }
 
-  ['TEST: it can render a dynamic element']() {
+  ['@test it can render a dynamic element']() {
     this.render('<p>{{message}}</p>', {
       message: 'hello'
     });
@@ -114,7 +114,7 @@ moduleFor('Dynamic content tests', class extends RenderingTest {
     this.assertSameNode(text1, text4);
   }
 
-  ['TEST: it can render a dynamic template']() {
+  ['@test it can render a dynamic template']() {
     let template = `
       <div class="header">
         <h1>Welcome to {{framework}}</h1>

--- a/packages/ember-glimmer/tests/integration/content-test.js
+++ b/packages/ember-glimmer/tests/integration/content-test.js
@@ -1,10 +1,188 @@
 import { RenderingTest, moduleFor } from '../utils/test-case';
+import { set } from 'ember-metal/property_set';
 
-moduleFor('Content tests', class extends RenderingTest {
+moduleFor('Static content tests', class extends RenderingTest {
 
-  ['TEST: it can render static content']() {
+  ['TEST: it can render a static text node']() {
     this.render('hello');
-    this.assertText('hello');
+    let text1 = this.assertTextNode(this.firstChild, 'hello');
+
+    this.rerender();
+    let text2 = this.assertTextNode(this.firstChild, 'hello');
+
+    this.assertSameNode(text1, text2);
+  }
+
+  ['TEST: it can render a static element']() {
+    this.render('<p>hello</p>');
+    let p1 = this.assertElement(this.firstChild, { tagName: 'p' });
+    let text1 = this.assertTextNode(this.firstChild.firstChild, 'hello');
+
+    this.rerender();
+    let p2 = this.assertElement(this.firstChild, { tagName: 'p' });
+    let text2 = this.assertTextNode(this.firstChild.firstChild, 'hello');
+
+    this.assertSameNode(p1, p2);
+    this.assertSameNode(text1, text2);
+  }
+
+  ['TEST: it can render a static template']() {
+    let template = `
+      <div class="header">
+        <h1>Welcome to Ember.js</h1>
+      </div>
+      <div class="body">
+        <h2>Why you should use Ember.js?</h2>
+        <ol>
+          <li>It's great</li>
+          <li>It's awesome</li>
+          <li>It's Ember.js</li>
+        </ol>
+      </div>
+      <div class="footer">
+        Ember.js is free, open source and always will be.
+      </div>
+    `;
+
+    this.render(template);
+    this.assertHTML(template);
+
+    this.rerender();
+    this.assertHTML(template);
+  }
+
+});
+
+moduleFor('Dynamic content tests', class extends RenderingTest {
+
+  ['TEST: it can render a dynamic text node']() {
+    this.render('{{message}}', {
+      message: 'hello'
+    });
+    let text1 = this.assertTextNode(this.firstChild, 'hello');
+
+    this.rerender();
+    let text2 = this.assertTextNode(this.firstChild, 'hello');
+
+    this.assertSameNode(text1, text2);
+
+    set(this.context, 'message', 'goodbye');
+
+    this.rerender();
+    let text3 = this.assertTextNode(this.firstChild, 'goodbye');
+
+    this.assertSameNode(text1, text3);
+
+    set(this.context, 'message', 'hello');
+
+    this.rerender();
+    let text4 = this.assertTextNode(this.firstChild, 'hello');
+
+    this.assertSameNode(text1, text4);
+  }
+
+  ['TEST: it can render a dynamic element']() {
+    this.render('<p>{{message}}</p>', {
+      message: 'hello'
+    });
+    let p1 = this.assertElement(this.firstChild, { tagName: 'p' });
+    let text1 = this.assertTextNode(this.firstChild.firstChild, 'hello');
+
+    this.rerender();
+    let p2 = this.assertElement(this.firstChild, { tagName: 'p' });
+    let text2 = this.assertTextNode(this.firstChild.firstChild, 'hello');
+
+    this.assertSameNode(p1, p2);
+    this.assertSameNode(text1, text2);
+
+    set(this.context, 'message', 'goodbye');
+
+    this.rerender();
+    let p3 = this.assertElement(this.firstChild, { tagName: 'p' });
+    let text3 = this.assertTextNode(this.firstChild.firstChild, 'goodbye');
+
+    this.assertSameNode(p1, p3);
+    this.assertSameNode(text1, text3);
+
+    set(this.context, 'message', 'hello');
+
+    this.rerender();
+    let p4 = this.assertElement(this.firstChild, { tagName: 'p' });
+    let text4 = this.assertTextNode(this.firstChild.firstChild, 'hello');
+
+    this.assertSameNode(p1, p4);
+    this.assertSameNode(text1, text4);
+  }
+
+  ['TEST: it can render a dynamic template']() {
+    let template = `
+      <div class="header">
+        <h1>Welcome to {{framework}}</h1>
+      </div>
+      <div class="body">
+        <h2>Why you should use {{framework}}?</h2>
+        <ol>
+          <li>It's great</li>
+          <li>It's awesome</li>
+          <li>It's {{framework}}</li>
+        </ol>
+      </div>
+      <div class="footer">
+        {{framework}} is free, open source and always will be.
+      </div>
+    `;
+
+    let ember = `
+      <div class="header">
+        <h1>Welcome to Ember.js</h1>
+      </div>
+      <div class="body">
+        <h2>Why you should use Ember.js?</h2>
+        <ol>
+          <li>It's great</li>
+          <li>It's awesome</li>
+          <li>It's Ember.js</li>
+        </ol>
+      </div>
+      <div class="footer">
+        Ember.js is free, open source and always will be.
+      </div>
+    `;
+
+    let react = `
+      <div class="header">
+        <h1>Welcome to React</h1>
+      </div>
+      <div class="body">
+        <h2>Why you should use React?</h2>
+        <ol>
+          <li>It's great</li>
+          <li>It's awesome</li>
+          <li>It's React</li>
+        </ol>
+      </div>
+      <div class="footer">
+        React is free, open source and always will be.
+      </div>
+    `;
+
+    this.render(template, {
+      framework: 'Ember.js'
+    });
+    this.assertHTML(ember);
+
+    this.rerender();
+    this.assertHTML(ember);
+
+    set(this.context, 'framework', 'React');
+
+    this.rerender();
+    this.assertHTML(react);
+
+    set(this.context, 'framework', 'Ember.js');
+
+    this.rerender();
+    this.assertHTML(ember);
   }
 
 });

--- a/packages/ember-glimmer/tests/utils/test-case.js
+++ b/packages/ember-glimmer/tests/utils/test-case.js
@@ -1,6 +1,7 @@
 import packageName from './package-name';
 import Environment from './environment';
 import { compile, DOMHelper, Renderer } from './helpers';
+import { equalTokens } from 'glimmer-test-helpers';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
 import Component from 'ember-views/components/component';
 import jQuery from 'ember-views/system/jquery';
@@ -34,6 +35,9 @@ export function moduleFor(description, TestClass) {
 
 let assert = QUnit.assert;
 
+const TextNode = window.Text;
+const HTMLElement = window.HTMLElement;
+
 export class TestCase {
   teardown() {}
 }
@@ -45,12 +49,21 @@ export class RenderingTest extends TestCase {
     let env = this.env = new Environment(dom);
     this.renderer = new Renderer(dom, { destinedForDOM: true, env });
     this.component = null;
+    this.element = jQuery('#qunit-fixture')[0];
   }
 
   teardown() {
     if (this.component) {
       runDestroy(this.component);
     }
+  }
+
+  get context() {
+    return this.component;
+  }
+
+  get firstChild() {
+    return this.element.firstChild;
   }
 
   render(templateStr, context = {}) {
@@ -71,6 +84,30 @@ export class RenderingTest extends TestCase {
   }
 
   assertText(text) {
-    assert.strictEqual(jQuery('#qunit-fixture').text(), text, `#qunit-fixture contents`);
+    assert.strictEqual(jQuery(this.element).text(), text, '#qunit-fixture content');
+  }
+
+  assertHTML(html) {
+    equalTokens(this.element, html, '#qunit-fixture content');
+  }
+
+  assertTextNode(node, text) {
+    if (!(node instanceof TextNode)) {
+      throw new Error(`Expecting a text node, but got ${node}`);
+    }
+
+    assert.strictEqual(text, node.textContent, 'node.textContent');
+  }
+
+  assertElement(node, { ElementType = HTMLElement, tagName }) {
+    if (!(node instanceof ElementType)) {
+      throw new Error(`Expecting a ${ElementType.name}, but got ${node}`);
+    }
+
+    assert.strictEqual(tagName.toUpperCase(), node.tagName, 'node.tagName');
+  }
+
+  assertSameNode(node1, node2) {
+    assert.strictEqual(node1, node2, 'DOM node stability');
   }
 }

--- a/packages/ember-glimmer/tests/utils/test-case.js
+++ b/packages/ember-glimmer/tests/utils/test-case.js
@@ -7,7 +7,7 @@ import Component from 'ember-views/components/component';
 import jQuery from 'ember-views/system/jquery';
 import assign from 'ember-metal/assign';
 
-const packageTag = `${packageName.toUpperCase()}: `;
+const packageTag = `@${packageName} `;
 
 export function moduleFor(description, TestClass) {
   let context;
@@ -23,9 +23,9 @@ export function moduleFor(description, TestClass) {
   });
 
   Object.keys(TestClass.prototype).forEach(name => {
-    if (name.indexOf('TEST: ') === 0) {
+    if (name.indexOf('@test ') === 0) {
       QUnit.test(name.slice(5), assert => context[name](assert));
-    } else if (name.indexOf('SKIP: ') === 0) {
+    } else if (name.indexOf('@skip ') === 0) {
       QUnit.skip(name.slice(5), assert => context[name](assert));
     } else if (name.indexOf(packageTag) === 0) {
       QUnit.test(name.slice(packageTag.length), assert => context[name](assert));

--- a/packages/ember-metal-views/lib/htmlbars-renderer.js
+++ b/packages/ember-metal-views/lib/htmlbars-renderer.js
@@ -5,6 +5,7 @@ import assign from 'ember-metal/assign';
 import setProperties from 'ember-metal/set_properties';
 import buildComponentTemplate from 'ember-views/system/build-component-template';
 import environment from 'ember-metal/environment';
+import { internal } from 'htmlbars-runtime';
 
 export function Renderer(domHelper, { destinedForDOM } = {}) {
   this._dom = domHelper;
@@ -225,6 +226,20 @@ Renderer.prototype.willRender = function (view) {
 
 Renderer.prototype.componentWillRender = function (component) {
   component.trigger('willRender');
+};
+
+Renderer.prototype.rerender = function (view) {
+  var renderNode = view._renderNode;
+
+  renderNode.isDirty = true;
+  internal.visitChildren(renderNode.childNodes, function(node) {
+    if (node.getState().manager) {
+      node.shouldReceiveAttrs = true;
+    }
+    node.isDirty = true;
+  });
+
+  renderNode.ownerNode.emberView.scheduleRevalidate(renderNode, view.toString(), 'rerendering');
 };
 
 Renderer.prototype.remove = function (view, shouldDestroy) {

--- a/packages/ember-views/lib/views/states/has_element.js
+++ b/packages/ember-views/lib/views/states/has_element.js
@@ -9,7 +9,6 @@ import run from 'ember-metal/run_loop';
 */
 
 import { get } from 'ember-metal/property_get';
-import { internal } from 'htmlbars-runtime';
 
 var hasElement = Object.create(_default);
 
@@ -30,18 +29,7 @@ assign(hasElement, {
   // deferred to allow bindings to synchronize.
   rerender(view) {
     view.renderer.ensureViewNotRendering(view);
-
-    var renderNode = view._renderNode;
-
-    renderNode.isDirty = true;
-    internal.visitChildren(renderNode.childNodes, function(node) {
-      if (node.getState().manager) {
-        node.shouldReceiveAttrs = true;
-      }
-      node.isDirty = true;
-    });
-
-    renderNode.ownerNode.emberView.scheduleRevalidate(renderNode, view.toString(), 'rerendering');
+    view.renderer.rerender(view);
   },
 
   cleanup(view) {


### PR DESCRIPTION
This is the initial work to implement the shared testing infrastructure between `ember-htmlbars` and `ember-glimmer`.

Quoting @wycats :kissing:

> It is worth noting that the `ember-glimmer` tests are using Ember.View and Ember.Component. In order to make these tests pass, we hit a failing test that confirms that the view registry is empty, which means that (1) the view registry was getting populated, and (2) we had to empty it. There's still quite a bit left to do, of course, but this integration is the real deal.

Next steps:
- Symlink this test file and the shared utils to `ember-htmlbars`, implement the htmlbars version of the helpers, and make it pass in both packages.
- Start porting existing tests into the new format and repeat the symlink step.
