### PR TITLE
[CLEANUP beta] Remove IE specific workaround from `Ember.create`'s test

### DIFF
--- a/packages/ember-runtime/tests/system/object/create_test.js
+++ b/packages/ember-runtime/tests/system/object/create_test.js
@@ -51,13 +51,6 @@ if (isEnabled('mandatory-setter')) {
     var o = MyClass.create({ foo: 'bar', bar: 'baz' });
     equal(o.get('foo'), 'bar');
 
-    // Catch IE8 where Object.getOwnPropertyDescriptor exists but only works on DOM elements
-    try {
-      Object.getOwnPropertyDescriptor({}, 'foo');
-    } catch(e) {
-      return;
-    }
-
     var descriptor = Object.getOwnPropertyDescriptor(o, 'foo');
     ok(descriptor.set, 'Mandatory setter was setup');
 


### PR DESCRIPTION
This workaround is introduced by 06a680159d51bc5fd2d730d6195d146ef326e625 ( https://github.com/emberjs/ember.js/pull/2521 ).
However IE8 is no longer supported.
