### PR TITLE
[bugfix beta] Revert backburner update

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "qunit-phantom-runner": "jonkemp/qunit-phantomjs-runner#1.2.0"
   },
   "devDependencies": {
-    "backburner": "https://github.com/ebryn/backburner.js.git#22a4df33f23c40257bc49972e5833038452ded2e",
+    "backburner": "https://github.com/ebryn/backburner.js.git#2d96beedec2cd81ab66f40b9d5516cf5c356681c",
     "rsvp": "https://github.com/tildeio/rsvp.js.git#3.0.20",
     "router.js": "https://github.com/tildeio/router.js.git#ed45bc5c5e055af0ab875ef2c52feda792ee23e4",
     "dag-map": "https://github.com/krisselden/dag-map.git#1.0.2",


### PR DESCRIPTION
This reverts commit e7f2656962853fad5a066c338368a9077fad782f, but only on the beta branch.

Tests don't pass on IE9 for some reason on beta (but do on canary), I will investigate.
