### PR TITLE
[FEATURE ember-htmlbars-component-generation] Make GlimmerComponent i…

### DIFF
--- a/packages/ember-htmlbars/lib/glimmer-component.js
+++ b/packages/ember-htmlbars/lib/glimmer-component.js
@@ -8,7 +8,7 @@ import AriaRoleSupport from 'ember-views/mixins/aria_role_support';
 import ViewMixin from 'ember-views/mixins/view_support';
 import EmberView from 'ember-views/views/view';
 
-export default CoreView.extend(
+const GlimmerComponent = CoreView.extend(
   ViewChildViewsSupport,
   ViewStateSupport,
   TemplateRenderingSupport,
@@ -24,3 +24,9 @@ export default CoreView.extend(
       this._viewRegistry = this._viewRegistry || EmberView.views;
     }
   });
+
+GlimmerComponent.reopenClass({
+  isComponentFactory: true
+});
+
+export default GlimmerComponent;


### PR DESCRIPTION
Solves 

> Make GlimmerComponent `isComponentFactory`

 from #12129
## 

An app I work on has been using an `instance-initializer` to get around the following `DEPRECATION` with the `ember-htmlbars-component-generation` flag enabled for about week now with extensive testing in staging and all seems to be going well (tests passing, no errors, etc). 

`You registered (subclass of Ember.GlimmerComponent) as a component factory. Either add the `isComponentFactory` property to this factory or extend from Ember.Component.`
## 
###### P.S

This is my first time submitting a PR on the project so if any additional requirements are necessary let me know. 
