### PR TITLE
Integrate with Glimmer reference interface

### DIFF
--- a/packages/ember-glimmer/lib/ember-metal-views/index.js
+++ b/packages/ember-glimmer/lib/ember-metal-views/index.js
@@ -1,3 +1,5 @@
+import { RootReference } from '../environment';
+
 export class Renderer {
   constructor(domHelper, { destinedForDOM, env } = {}) {
     this._dom = domHelper;
@@ -6,9 +8,10 @@ export class Renderer {
 
   appendTo(view, target) {
     let env = this._env;
+    let self = new RootReference(view);
 
     env.begin();
-    let result = view.template.render(view, env, { appendTo: target });
+    let result = view.template.render(self, env, { appendTo: target });
     env.commit();
 
     // FIXME: Store this somewhere else

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -1,0 +1,61 @@
+import { Environment } from 'glimmer-runtime';
+import { get } from 'ember-metal/property_get';
+
+// @implements PathReference
+export class RootReference {
+  constructor(value) {
+    this._value = value;
+  }
+
+  value() {
+    return this._value;
+  }
+
+  isDirty() {
+    return true;
+  }
+
+  get(propertyKey) {
+    return new PropertyReference(this, propertyKey);
+  }
+
+  destroy() {
+  }
+}
+
+// @implements PathReference
+class PropertyReference {
+  constructor(parentReference, propertyKey) {
+    this._parentReference = parentReference;
+    this._propertyKey = propertyKey;
+  }
+
+  value() {
+    return get(this._parentReference.value(), this._propertyKey);
+  }
+
+  isDirty() {
+    return true;
+  }
+
+  get(propertyKey) {
+    return new PropertyReference(this, propertyKey);
+  }
+
+  destroy() {
+  }
+}
+
+export default class extends Environment {
+  hasComponentDefinition() {
+    return false;
+  }
+
+  hasHelper() {
+    return false;
+  }
+
+  rootReferenceFor(value) {
+    return new RootReference(value);
+  }
+}

--- a/packages/ember-glimmer/lib/main.js
+++ b/packages/ember-glimmer/lib/main.js
@@ -1,0 +1,1 @@
+export { default as Environment } from 'ember-glimmer/environment';

--- a/packages/ember-glimmer/tests/integration/content-test.js
+++ b/packages/ember-glimmer/tests/integration/content-test.js
@@ -1,5 +1,7 @@
 import { RenderingTest, moduleFor } from '../utils/test-case';
 import { set } from 'ember-metal/property_set';
+import { computed } from 'ember-metal/computed';
+import EmberObject from 'ember-runtime/system/object';
 
 moduleFor('Static content tests', class extends RenderingTest {
 
@@ -77,6 +79,65 @@ moduleFor('Dynamic content tests', class extends RenderingTest {
 
     this.rerender();
     let text4 = this.assertTextNode(this.firstChild, 'hello');
+
+    this.assertSameNode(text1, text4);
+  }
+
+  ['@test it can render a dynamic text node with deeply nested paths']() {
+    this.render('{{a.b.c.d.e.f}}', {
+      a: { b: { c: { d: { e: { f: 'hello' } } } } }
+    });
+    let text1 = this.assertTextNode(this.firstChild, 'hello');
+
+    this.rerender();
+    let text2 = this.assertTextNode(this.firstChild, 'hello');
+
+    this.assertSameNode(text1, text2);
+
+    set(this.context, 'a.b.c.d.e.f', 'goodbye');
+
+    this.rerender();
+    let text3 = this.assertTextNode(this.firstChild, 'goodbye');
+
+    this.assertSameNode(text1, text3);
+
+    set(this.context, 'a.b.c.d.e.f', 'hello');
+
+    this.rerender();
+    let text4 = this.assertTextNode(this.firstChild, 'hello');
+
+    this.assertSameNode(text1, text4);
+  }
+
+  ['@test it can render a dynamic text node where the value is a computed property']() {
+    let Formatter = EmberObject.extend({
+      formattedMessage: computed('message', function() {
+        return this.get('message').toUpperCase();
+      })
+    });
+
+    let m = Formatter.create({ message: 'hello' });
+
+    this.render('{{m.formattedMessage}}', { m });
+
+    let text1 = this.assertTextNode(this.firstChild, 'HELLO');
+
+    this.rerender();
+    let text2 = this.assertTextNode(this.firstChild, 'HELLO');
+
+    this.assertSameNode(text1, text2);
+
+    set(m, 'message', 'goodbye');
+
+    this.rerender();
+    let text3 = this.assertTextNode(this.firstChild, 'GOODBYE');
+
+    this.assertSameNode(text1, text3);
+
+    set(m, 'message', 'hello');
+
+    this.rerender();
+    let text4 = this.assertTextNode(this.firstChild, 'HELLO');
 
     this.assertSameNode(text1, text4);
   }

--- a/packages/ember-glimmer/tests/utils/environment.js
+++ b/packages/ember-glimmer/tests/utils/environment.js
@@ -1,1 +1,1 @@
-export { TestEnvironment as default } from 'glimmer-test-helpers';
+export { Environment as default } from 'ember-glimmer';


### PR DESCRIPTION
As part of this, we have stopped “borrowing” the
glimmer `TestEnvironment` and started implementing
the Ember-specific environment.
