### PR TITLE
Stop testing `ember-htmlbars-component-generation`

### DIFF
--- a/features.json
+++ b/features.json
@@ -1,7 +1,7 @@
 {
   "features": {
     "features-stripped-test": null,
-    "ember-htmlbars-component-generation": null,
+    "ember-htmlbars-component-generation": false,
     "ember-application-visit": true,
     "ember-routing-route-configured-query-params": null,
     "ember-libraries-isregistered": null,


### PR DESCRIPTION
This temporarily sets the ember-htmlbars-component-generation feature flag to false, which stops it from being tested in the `enableoptionalfeatures` config and remove it from the  canary build.

The current implementation of the "Glimmer Components" feature is pretty incomplete and buggy, and the implementation strategry we employed is considered a dead-end due to its complexity. We have found some additional bugs lately that are interfering with other on going work. Since this implementation is not going anywhere (and no one has the cycles to fix a dead-end implementation), setting the flag to false is the quickest stop-gap solution to unblock other ongoing work.

I would like to remove this feature flag and the assoicated code completely, but I would bring it up on Friday's core team meeting before proceeding.

The "Glimmer Component" feature will return with a better implementation once the glimmer engine integration work is complete.
