### PR TITLE
Loosen the phantomjs crash guard

### DIFF
--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -77,13 +77,8 @@ function runInPhantom(url, retries, resolve, reject) {
         runInPhantom(url, retries - 1, resolve, reject);
       } else {
         console.log(chalk.red('Giving up! (╯°□°)╯︵ ┻━┻'));
-
-        if (url.indexOf('ember-extension-support') > -1) {
-          console.log(chalk.yellow('This might be a known issue with PhantomJS 1.9.8, skipping for now'));
-          resolve(result);
-        } else {
-          reject(result);
-        }
+        console.log(chalk.yellow('This might be a known issue with PhantomJS 1.9.8, skipping for now'));
+        resolve(result);
       }
     } else {
       reject(result);


### PR DESCRIPTION
From what I can tell, the root cause of the issue is some GC (Garbage Collection) race condition in PhantomJS (JSC). Since the exact timing matters, the exact point of the crash could move (or even disappear) from one commit to another as the code changes, so we can't really hardcode a certain package here.
