### PR TITLE
Expose router.transitionTo as a public method

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -321,7 +321,7 @@ var EmberRouter = EmberObject.extend(Evented, {
       containing a mapping of query parameters
     @return {Transition} the transition object associated with this
       attempted transition
-    @private
+    @public
   */
   transitionTo(...args) {
     var queryParams;


### PR DESCRIPTION
`route.transitionTo` is public, and it's pretty much just a proxy to `router.transitionTo`: https://github.com/emberjs/ember.js/blob/master/packages/ember-routing/lib/system/route.js#L1027

This would be useful if a service wants to execute a transition.
