### PR TITLE
[BUGFIX beta] Avoid allocating a binding map in meta when possible

### DIFF
--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -126,7 +126,7 @@ function inheritedMap(name, Meta) {
   };
 
   Meta.prototype['clear' + capitalized] = function() {
-    this[key] = new EmptyObject();
+    this[key] = undefined;
   };
 
   Meta.prototype['deleteFrom' + capitalized] = function(subkey) {

--- a/packages/ember-runtime/tests/system/object/create_test.js
+++ b/packages/ember-runtime/tests/system/object/create_test.js
@@ -1,7 +1,8 @@
 import Ember from 'ember-metal/core';
 import isEnabled from 'ember-metal/features';
-import {computed} from 'ember-metal/computed';
-import {Mixin, observer} from 'ember-metal/mixin';
+import { meta } from 'ember-metal/meta';
+import { computed } from 'ember-metal/computed';
+import { Mixin, observer } from 'ember-metal/mixin';
 import EmberObject from 'ember-runtime/system/object';
 
 var moduleOptions, originalLookup;
@@ -143,4 +144,10 @@ QUnit.test('EmberObject.create can take undefined as a parameter', function() {
 QUnit.test('EmberObject.create can take null as a parameter', function() {
   var o = EmberObject.create(null);
   deepEqual(EmberObject.create(), o);
+});
+
+QUnit.test('EmberObject.create avoids allocating a binding map when not necessary', function() {
+  let o = EmberObject.create();
+  let m = meta(o);
+  ok(!m.peekBindings(), 'A binding map is not allocated');
 });


### PR DESCRIPTION
Before this PR, the `connectBindings` phase of Ember.Object creation would call `meta.clearBindings()` on _every single object_. This causes an extra `EmptyObject` to be allocated for every `Ember.Object`. The worst part is that it is never used on instances.

This change works around the issue making `clearBindings` simply setting `_bindings` to `undefined` in meta. We could likely remove this field completely if we had separate `Meta` classes for instances and classes.
