### PR TITLE
[BUGFIX beta] Update Backburner.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "qunit-phantom-runner": "jonkemp/qunit-phantomjs-runner#1.2.0"
   },
   "devDependencies": {
-    "backburner": "https://github.com/ebryn/backburner.js.git#22a4df33f23c40257bc49972e5833038452ded2e",
+    "backburner": "https://github.com/ebryn/backburner.js.git#325a969dbc7eae42dc1edfbf0ae9fb83923df5a6",
     "rsvp": "https://github.com/tildeio/rsvp.js.git#3.0.20",
     "router.js": "https://github.com/tildeio/router.js.git#ed45bc5c5e055af0ab875ef2c52feda792ee23e4",
     "dag-map": "https://github.com/krisselden/dag-map.git#1.0.2",


### PR DESCRIPTION
Compare view:

https://github.com/ebryn/backburner.js/compare/22a4df33f23c40257bc49972e5833038452ded2e...325a969dbc7eae42dc1edfbf0ae9fb83923df5a6

Notable changes are here:
- [FEATURE] configurable setTimeout: https://github.com/ebryn/backburner.js/pull/163
- [breaking] Use native `Date.now()`: https://github.com/ebryn/backburner.js/pull/166

Replaces #12930.
