### PR TITLE
[BUGFIX beta] Don't use prototype extensions ({add,remove}ArrayObserver)

### DIFF
--- a/packages/ember-extension-support/lib/data_adapter.js
+++ b/packages/ember-extension-support/lib/data_adapter.js
@@ -6,7 +6,11 @@ import EmberObject from 'ember-runtime/system/object';
 import { A as emberA } from 'ember-runtime/system/native_array';
 import Application from 'ember-application/system/application';
 import { getOwner } from 'container/owner';
-import { objectAt } from 'ember-runtime/mixins/array';
+import {
+  addArrayObserver,
+  removeArrayObserver,
+  objectAt
+} from 'ember-runtime/mixins/array';
 
 /**
 @module ember
@@ -219,11 +223,11 @@ export default EmberObject.extend({
     };
 
     var observer = { didChange: contentDidChange, willChange() { return this; } };
-    records.addArrayObserver(this, observer);
+    addArrayObserver(records, this, observer);
 
     release = () => {
       releaseMethods.forEach(function(fn) { fn(); });
-      records.removeArrayObserver(this, observer);
+      removeArrayObserver(records, this, observer);
       this.releaseMethods.removeObject(release);
     };
 
@@ -298,10 +302,10 @@ export default EmberObject.extend({
       willChange() { return this; }
     };
 
-    records.addArrayObserver(this, observer);
+    addArrayObserver(records, this, observer);
 
     var release = () => {
-      records.removeArrayObserver(this, observer);
+      removeArrayObserver(records, this, observer);
     };
 
     return release;

--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -47,6 +47,14 @@ function arrayObserversHelper(obj, target, opts, operation, notify) {
   return obj;
 }
 
+export function addArrayObserver(array, target, opts) {
+  return arrayObserversHelper(array, target, opts, addListener, false);
+}
+
+export function removeArrayObserver(array, target, opts) {
+  return arrayObserversHelper(array, target, opts, removeListener, true);
+}
+
 export function objectAt(content, idx) {
   if (content.objectAt) {
     return content.objectAt(idx);
@@ -364,7 +372,7 @@ export default Mixin.create(Enumerable, {
   */
 
   addArrayObserver(target, opts) {
-    return arrayObserversHelper(this, target, opts, addListener, false);
+    return addArrayObserver(this, target, opts);
   },
 
   /**
@@ -380,7 +388,7 @@ export default Mixin.create(Enumerable, {
     @public
   */
   removeArrayObserver(target, opts) {
-    return arrayObserversHelper(this, target, opts, removeListener, true);
+    return removeArrayObserver(this, target, opts);
   },
 
   /**

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -17,7 +17,11 @@ import EmberObject from 'ember-runtime/system/object';
 import MutableArray from 'ember-runtime/mixins/mutable_array';
 import Enumerable from 'ember-runtime/mixins/enumerable';
 import alias from 'ember-metal/alias';
-import { objectAt } from 'ember-runtime/mixins/array';
+import {
+  addArrayObserver,
+  removeArrayObserver,
+  objectAt
+} from 'ember-runtime/mixins/array';
 
 /**
 @module ember
@@ -140,7 +144,7 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
     var content = get(this, 'content');
 
     if (content) {
-      content.removeArrayObserver(this, {
+      removeArrayObserver(content, this, {
         willChange: 'contentArrayWillChange',
         didChange: 'contentArrayDidChange'
       });
@@ -193,7 +197,7 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
     if (content) {
       assert(`ArrayProxy expects an Array or Ember.ArrayProxy, but you passed ${typeof content}`, isArray(content) || content.isDestroyed);
 
-      content.addArrayObserver(this, {
+      addArrayObserver(content, this, {
         willChange: 'contentArrayWillChange',
         didChange: 'contentArrayDidChange'
       });
@@ -229,7 +233,7 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
       assert(`ArrayProxy expects an Array or Ember.ArrayProxy, but you passed ${typeof arrangedContent}`,
         isArray(arrangedContent) || arrangedContent.isDestroyed);
 
-      arrangedContent.addArrayObserver(this, {
+      addArrayObserver(arrangedContent, this, {
         willChange: 'arrangedContentArrayWillChange',
         didChange: 'arrangedContentArrayDidChange'
       });
@@ -240,7 +244,7 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
     var arrangedContent = get(this, 'arrangedContent');
 
     if (arrangedContent) {
-      arrangedContent.removeArrayObserver(this, {
+      removeArrayObserver(arrangedContent, this, {
         willChange: 'arrangedContentArrayWillChange',
         didChange: 'arrangedContentArrayDidChange'
       });

--- a/packages/ember-runtime/tests/mixins/array_test.js
+++ b/packages/ember-runtime/tests/mixins/array_test.js
@@ -6,7 +6,11 @@ import { computed } from 'ember-metal/computed';
 import { testBoth } from 'ember-metal/tests/props_helper';
 import { ArrayTests } from 'ember-runtime/tests/suites/array';
 import EmberObject from 'ember-runtime/system/object';
-import EmberArray, { objectAt } from 'ember-runtime/mixins/array';
+import EmberArray, {
+  addArrayObserver,
+  removeArrayObserver,
+  objectAt
+} from 'ember-runtime/mixins/array';
 import { A as emberA } from 'ember-runtime/system/native_array';
 
 /*
@@ -199,7 +203,7 @@ QUnit.module('notify array observers', {
       _after: null
     });
 
-    obj.addArrayObserver(observer);
+    addArrayObserver(obj, observer);
   },
 
   teardown() {
@@ -233,7 +237,7 @@ QUnit.test('should notify when called with diff length items', function() {
 });
 
 QUnit.test('removing enumerable observer should disable', function() {
-  obj.removeArrayObserver(observer);
+  removeArrayObserver(obj, observer);
   obj.arrayContentWillChange();
   deepEqual(observer._before, null);
 

--- a/packages/ember-runtime/tests/suites/array.js
+++ b/packages/ember-runtime/tests/suites/array.js
@@ -5,16 +5,20 @@ import {
 import indexOfTests from 'ember-runtime/tests/suites/array/indexOf';
 import lastIndexOfTests from 'ember-runtime/tests/suites/array/lastIndexOf';
 import objectAtTests from 'ember-runtime/tests/suites/array/objectAt';
+import {
+  addArrayObserver,
+  removeArrayObserver
+} from 'ember-runtime/mixins/array';
 
 var ObserverClass = EnumerableTestsObserverClass.extend({
 
   observeArray(obj) {
-    obj.addArrayObserver(this);
+    addArrayObserver(obj, this);
     return this;
   },
 
   stopObserveArray(obj) {
-    obj.removeArrayObserver(this);
+    removeArrayObserver(obj, this);
     return this;
   },
 

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -7,7 +7,11 @@ import Ember from 'ember-metal/core';
 import { assert, deprecate } from 'ember-metal/debug';
 import ContainerView from 'ember-views/views/container_view';
 import View from 'ember-views/views/view';
-import EmberArray, { objectAt } from 'ember-runtime/mixins/array';
+import EmberArray, {
+  addArrayObserver,
+  removeArrayObserver,
+  objectAt
+} from 'ember-runtime/mixins/array';
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
 import { computed } from 'ember-metal/computed';
@@ -224,7 +228,7 @@ var CollectionView = ContainerView.extend(EmptyViewSupport, {
   */
   _contentDidChange: observer('content', function() {
     var prevContent = this._prevContent;
-    if (prevContent) { prevContent.removeArrayObserver(this); }
+    if (prevContent) { removeArrayObserver(prevContent, this); }
     var len = prevContent ? get(prevContent, 'length') : 0;
     this.arrayWillChange(prevContent, 0, len);
 
@@ -233,7 +237,7 @@ var CollectionView = ContainerView.extend(EmptyViewSupport, {
     if (content) {
       this._prevContent = content;
       this._assertArrayLike(content);
-      content.addArrayObserver(this);
+      addArrayObserver(content, this);
     }
 
     len = content ? get(content, 'length') : 0;
@@ -260,7 +264,7 @@ var CollectionView = ContainerView.extend(EmptyViewSupport, {
     if (!this._super(...arguments)) { return; }
 
     var content = get(this, 'content');
-    if (content) { content.removeArrayObserver(this); }
+    if (content) { removeArrayObserver(content, this); }
 
     if (this._createdEmptyView) {
       this._createdEmptyView.destroy();


### PR DESCRIPTION
Do not use prototype extensions for `addArrayObserver` and `removeArrayObserver`.

Related to #9269 and #10899.
