### PR TITLE
[typo] `componet` > `component`

### DIFF
--- a/tests/node/helpers/app-module.js
+++ b/tests/node/helpers/app-module.js
@@ -24,7 +24,7 @@ var SimpleDOM = require('simple-dom');
  * to register a component:
  *
  *     this.component('component-name', {
- *       componetProperty: true
+ *       componentProperty: true
  *     });
  *
  * Or a template:


### PR DESCRIPTION
I made a typo in a repository search and found this typo in a comment!
