### PR TITLE
[BUGFIX] Ensure Glimmer tests are not shipped in builds.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -77,6 +77,11 @@ module.exports = function() {
         'amd/glimmer-compiler.amd.map',
         'amd/glimmer-runtime.amd.js',
         'amd/glimmer-runtime.amd.map',
+      ]
+    });
+
+    vendorPackages['glimmer-engine-tests'] = find(glimmerEngine, {
+      include: [
         'amd/glimmer-tests.amd.js',
         'amd/glimmer-tests.amd.map'
       ]

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -23,9 +23,16 @@ var packages = {
 
 var glimmerStatus = features['ember-glimmer'];
 if (glimmerStatus === null || glimmerStatus === true) {
-  packages['ember-glimmer'] = { trees: null,  requirements: ['ember-metal'], vendorRequirements: [
-    'glimmer-engine'
-  ] };
+  packages['ember-glimmer'] = {
+    trees: null,
+    requirements: ['ember-metal'],
+    vendorRequirements: [
+      'glimmer-engine'
+    ],
+    testingVendorRequirements: [
+      'glimmer-engine-tests'
+    ]
+  };
 }
 
 module.exports = packages;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ember-cli-sauce": "^1.4.2",
     "ember-cli-yuidoc": "0.7.0",
     "ember-publisher": "0.0.7",
-    "emberjs-build": "0.6.0",
+    "emberjs-build": "0.6.1",
     "express": "^4.5.0",
     "finalhandler": "^0.4.0",
     "github": "^0.2.3",


### PR DESCRIPTION
This still ensures that the tests themselves run in the normal test run, but the tests are included in the ember-tests.js file instead of ember.debug.js/ember.prod.js.

Fixes #12952.
