### PR TITLE
Pin glimmer-engine version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ before_install:
       wget -O /tmp/phantomjs-`phantomjs --version`-linux-x86_64-symbols.tar.bz2 https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-`phantomjs --version`-linux-x86_64-symbols.tar.bz2 &&
       tar -xjvf /tmp/phantomjs-`phantomjs --version`-linux-x86_64-symbols.tar.bz2 -C ./phantomjs;
     fi
-  - "rm -rf node_modules/glimmer-engine"
 
 install:
   - "npm install"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "express": "^4.5.0",
     "finalhandler": "^0.4.0",
     "github": "^0.2.3",
-    "glimmer-engine": "tildeio/glimmer#master",
+    "glimmer-engine": "tildeio/glimmer#2f64496",
     "glob": "~4.3.2",
     "htmlbars": "0.14.14",
     "qunit-extras": "^1.4.0",


### PR DESCRIPTION
This will shield us from build failures due to upstream changes and help us manage the PR flow across the projects while churn is still high.
