### PR TITLE
Add generator function code style rules

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -87,5 +87,9 @@
     "beforeOpeningRoundBrace": false,
     "beforeOpeningCurlyBrace": true
   },
+  "requireSpacesInGenerator": {
+    "beforeStar": true,
+    "afterStar": true
+  },
   "requireCommentsToIncludeAccess": true
 }


### PR DESCRIPTION
Since [ember-concurrency](https://github.com/machty/ember-concurrency) has begun using generator functions, it is safe to assume they'll become commonplace across Ember.js projects. This PR is an attempt to declare an officially preferred style rule before the syntax spreads.

The rules currently follow @machty's [choice of style](https://github.com/machty/ember-concurrency/blob/master/tests/unit/task-test.js#L14), but it can be whatever the Core thinks is best.
