### PR TITLE
[DOC release] Fix typo in computed.sum function description

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -57,7 +57,7 @@ function multiArrayMacro(dependentKeys, callback) {
 }
 
 /**
-  A computed property that returns the sum of the value
+  A computed property that returns the sum of the values
   in the dependent array.
 
   @method sum


### PR DESCRIPTION
Adds an "s" to "value" in the docs for `Ember.computed.sum` so that

```
A computed property that returns the sum of the value in the dependent array
```

becomes

```
A computed property that returns the sum of the values in the dependent array
```
