### PR TITLE
[DOC release] Fix spacing typo in objects

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/each.js
+++ b/packages/ember-htmlbars/lib/helpers/each.js
@@ -14,7 +14,7 @@ import decodeEachKey from 'ember-htmlbars/utils/decode-each-key';
   item in an array passing the item as the first block parameter.
 
   ```javascript
-  var developers = [{name: 'Yehuda'},{name: 'Tom'}, {name: 'Paul'}];
+  var developers = [{ name: 'Yehuda' },{ name: 'Tom' }, { name: 'Paul' }];
   ```
 
   ```handlebars

--- a/packages/ember-metal/lib/assign.js
+++ b/packages/ember-metal/lib/assign.js
@@ -2,10 +2,10 @@
   Copy properties from a source object to a target object.
 
   ```javascript
-  var a = {first: 'Yehuda'};
-  var b = {last: 'Katz'};
-  var c = {company: 'Tilde Inc.'};
-  Ember.assign(a, b, c); // a === {first: 'Yehuda', last: 'Katz', company: 'Tilde Inc.'}, b === {last: 'Katz'}, c === {company: 'Tilde Inc.'}
+  var a = { first: 'Yehuda' };
+  var b = { last: 'Katz' };
+  var c = { company: 'Tilde Inc.' };
+  Ember.assign(a, b, c); // a === { first: 'Yehuda', last: 'Katz', company: 'Tilde Inc.' }, b === { last: 'Katz' }, c === { company: 'Tilde Inc.' }
   ```
 
   @method assign

--- a/packages/ember-metal/lib/merge.js
+++ b/packages/ember-metal/lib/merge.js
@@ -2,10 +2,10 @@
   Merge the contents of two objects together into the first object.
 
   ```javascript
-  Ember.merge({first: 'Tom'}, {last: 'Dale'}); // {first: 'Tom', last: 'Dale'}
-  let a = {first: 'Yehuda'};
-  let b = {last: 'Katz'};
-  Ember.merge(a, b); // a == {first: 'Yehuda', last: 'Katz'}, b == {last: 'Katz'}
+  Ember.merge({ first: 'Tom' }, { last: 'Dale' }); // { first: 'Tom', last: 'Dale' }
+  var a = { first: 'Yehuda' };
+  var b = { last: 'Katz' };
+  Ember.merge(a, b); // a == { first: 'Yehuda', last: 'Katz' }, b == { last: 'Katz' }
   ```
 
   @method merge

--- a/packages/ember-routing/lib/ext/controller.js
+++ b/packages/ember-routing/lib/ext/controller.js
@@ -92,11 +92,11 @@ ControllerMixin.reopen({
 
     ```javascript
     aController.transitionToRoute('blogPost', 1, {
-      queryParams: {showComments: 'true'}
+      queryParams: { showComments: 'true' }
     });
 
     // if you just want to transition the query parameters without changing the route
-    aController.transitionToRoute({queryParams: {sort: 'date'}});
+    aController.transitionToRoute({ queryParams: { sort: 'date' } });
     ```
 
     See also [replaceRoute](/api/classes/Ember.ControllerMixin.html#method_replaceRoute).

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -936,11 +936,11 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
 
     ```javascript
     this.transitionTo('blogPost', 1, {
-      queryParams: {showComments: 'true'}
+      queryParams: { showComments: 'true' }
     });
 
     // if you just want to transition the query parameters without changing the route
-    this.transitionTo({queryParams: {sort: 'date'}});
+    this.transitionTo({ queryParams: { sort: 'date' } });
     ```
 
     See also [replaceWith](#method_replaceWith).
@@ -1020,7 +1020,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     App.IndexRoute = Ember.Route.extend({
       actions: {
         transitionToApples: function() {
-          this.transitionTo('fruits.apples', {queryParams: {color: 'red'}});
+          this.transitionTo('fruits.apples', { queryParams: { color: 'red' } });
         }
       }
     });

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -493,9 +493,9 @@ const EmberRouter = EmberObject.extend(Evented, {
 
     if these methods are called in succession:
     this._activeQPChanged('foo', '10');
-      // results in _queuedQPChanges = {foo: '10'}
+      // results in _queuedQPChanges = { foo: '10' }
     this._activeQPChanged('bar', false);
-      // results in _queuedQPChanges = {foo: '10', bar: false}
+      // results in _queuedQPChanges = { foo: '10', bar: false }
 
 
     _queuedQPChanges will represent both of these changes


### PR DESCRIPTION
This PR just fixes up some spacing typos.

What read before as . . . 

``` javascript
queryParams: {showComments: 'true'}
```

and

``` javascript
aController.transitionToRoute({queryParams: {sort: 'date'}});
```

now reads as . . .

``` javascript
queryParams: { showComments: 'true' }
```

``` javascript
aController.transitionToRoute({ queryParams: { sort: 'date' } });
```
