### PR TITLE
Create an issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,26 @@
+### Expected Behavior
+
+(Describe how things should work.)
+
+
+### Actual Behavior
+
+(Describe what went wrong.)
+
+
+### Steps to Reproduce the issue
+
+(Describe how someone can see a working example of the issue. Include what version of Ember.js/Ember CLI you are using, and any details regarding browser specific behaviors. Is there a feature flag that needs to be enabled to reproduce the issue?)
+
+
+### Attempts to Solve the issue
+
+(Describe what you have tried to solve this issue. Did you try an earlier release of Ember, or perhaps beta/canary release channels?)
+
+
+### Before submitting this issue, please review the following…
+
+- [ ] [Reporting a Bug](https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md#reporting-a-bug)
+- [ ] [Requesting a Feature](https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md#requesting-a-feature)
+- [ ] Is your issue a question? If so, have you tried Stack Overflow or joined the embercommunity.slack.com #needhelp channel?
+- [ ] Are reporting a bug? If so, have you created a reproducible example that demontrates the bug? (Perhaps try to create an example with ember-twiddle.com) If you are not able to create an example, once you've submitted this issue, please join the #needhelp channel to request help from the community to create working code example that demonstrates your issue.


### PR DESCRIPTION
Adds an issue template

See:
- https://help.github.com/articles/creating-an-issue-template-for-your-repository/
- https://github.com/blog/2111-issue-and-pull-request-templates

I think having an issue template will help with managing issues and triage, helping to reduce noise, and even more… help to point people in a direction where they will get the most traction. A lot of questions end up in the issue tracker and the feedback cycle is slow for a question issue type. Also, there is a delay in addressing issues that don't have a reproducible example of a bug.

The goal of an issue template will be to give an optional format with a short list of info that will help posters be successful in getting solutions/answers to their issues.

Here are some motivations for issue triage, https://gist.github.com/pixelhandler/b8354b084654947061ec#target-actionable-results 

I think having an issue template will help the signal to noise ratio and help to surface actionable results more efficiently.

I'm sure the language of the issue template can be improved - so that it has a friendly tone, perhaps like a valet -> let me help you park your ____ (bug/issue) 
