### PR TITLE
[DOC] Update copyright year

### DIFF
--- a/generators/license.js
+++ b/generators/license.js
@@ -1,6 +1,6 @@
 /*!
  * @overview  Ember - JavaScript Application Framework
- * @copyright Copyright 2011-2015 Tilde Inc. and contributors
+ * @copyright Copyright 2011-2016 Tilde Inc. and contributors
  *            Portions Copyright 2006-2011 Strobe Inc.
  *            Portions Copyright 2008-2011 Apple Inc. All rights reserved.
  * @license   Licensed under MIT license


### PR DESCRIPTION
Bumps the copyright year to 2016

Should this actually match what's in https://github.com/emberjs/ember.js/blob/068ffdab28aa77a14995750f15a7412308f16dcc/LICENSE#L1?
