### PR TITLE
[BUGFIX beta] Add private WeakMap

### DIFF
--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -47,6 +47,7 @@ const META_FIELD = '__ember_meta__';
 
 function Meta(obj, parentMeta) {
   this._cache = undefined;
+  this._weak = undefined;
   this._watching = undefined;
   this._mixins = undefined;
   this._bindings = undefined;
@@ -54,7 +55,6 @@ function Meta(obj, parentMeta) {
   this._deps = undefined;
   this._chainWatchers = undefined;
   this._chains = undefined;
-  this._weak = undefined;
   // used only internally
   this.source = obj;
 
@@ -148,18 +148,6 @@ Meta.prototype._getInherited = function(key) {
     }
     pointer = pointer.parent;
   }
-};
-
-Meta.prototype.getWeak = function(symbol) {
-  var weak = this.readableWeak();
-  if (weak) {
-    return weak[symbol];
-  }
-};
-
-Meta.prototype.setWeak = function(symbol, value) {
-  var weak = this.writableWeak();
-  return weak[symbol] = value;
 };
 
 Meta.prototype._findInherited = function(key, subkey) {

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -32,6 +32,7 @@ import EmptyObject from 'ember-metal/empty_object';
 */
 let members = {
   cache: ownMap,
+  weak: ownMap,
   watching: inheritedMap,
   mixins: inheritedMap,
   bindings: inheritedMap,
@@ -53,6 +54,7 @@ function Meta(obj, parentMeta) {
   this._deps = undefined;
   this._chainWatchers = undefined;
   this._chains = undefined;
+  this._weak = undefined;
   // used only internally
   this.source = obj;
 
@@ -146,6 +148,18 @@ Meta.prototype._getInherited = function(key) {
     }
     pointer = pointer.parent;
   }
+};
+
+Meta.prototype.getWeak = function(symbol) {
+  var weak = this.readableWeak();
+  if (weak) {
+    return weak[symbol];
+  }
+};
+
+Meta.prototype.setWeak = function(symbol, value) {
+  var weak = this.writableWeak();
+  return weak[symbol] = value;
 };
 
 Meta.prototype._findInherited = function(key, subkey) {

--- a/packages/ember-metal/lib/weak_map.js
+++ b/packages/ember-metal/lib/weak_map.js
@@ -1,0 +1,39 @@
+import { GUID_KEY } from 'ember-metal/utils';
+import { meta } from 'ember-metal/meta';
+
+var id = 0;
+
+/*
+ * @private
+ * @class Ember.WeakMap
+ *
+ * Weak relationship from Map -> Key, but not Key to Map.
+ *
+ * Key must be a non null object
+ */
+export default function WeakMap() {
+  this._id = GUID_KEY + (id++);
+}
+
+/*
+ * @method get
+ * @param key {Object}
+ * @return {*} stored value
+ */
+WeakMap.prototype.get = function(obj) {
+  var map = meta(obj).readableWeak();
+  if (map) {
+    return map[this._id];
+  }
+};
+
+/*
+ * @method set
+ * @param key {Object}
+ * @param value {Any}
+ * @return {Any} stored value
+ */
+WeakMap.prototype.set = function(obj, value) {
+  meta(obj).writableWeak()[this._id] = value;
+  return this;
+};

--- a/packages/ember-metal/lib/weak_map.js
+++ b/packages/ember-metal/lib/weak_map.js
@@ -1,10 +1,12 @@
+import { assert } from 'ember-metal/debug';
 import { GUID_KEY } from 'ember-metal/utils';
 import { meta } from 'ember-metal/meta';
 
 var id = 0;
+function UNDEFINED() {}
 
 /*
- * @private
+ * @public
  * @class Ember.WeakMap
  *
  * Weak relationship from Map -> Key, but not Key to Map.
@@ -23,6 +25,10 @@ export default function WeakMap() {
 WeakMap.prototype.get = function(obj) {
   var map = meta(obj).readableWeak();
   if (map) {
+    if (map[this._id] === UNDEFINED) {
+      return undefined;
+    }
+
     return map[this._id];
   }
 };
@@ -34,6 +40,35 @@ WeakMap.prototype.get = function(obj) {
  * @return {Any} stored value
  */
 WeakMap.prototype.set = function(obj, value) {
+  assert('Uncaught TypeError: Invalid value used as weak map key', obj && (typeof obj === 'object' || typeof obj === 'function'));
+
+  if (value === undefined) {
+    value = UNDEFINED;
+  }
+
   meta(obj).writableWeak()[this._id] = value;
+  return this;
+};
+
+/*
+ * @method has
+ * @param key {Object}
+ * @return {Boolean} if the key exists
+ */
+WeakMap.prototype.has = function(obj) {
+  var map = meta(obj).readableWeak();
+
+  return (map && map[this._id] !== undefined);
+};
+
+/*
+ * @method delete
+ * @param key {Object}
+ */
+WeakMap.prototype.delete = function(obj) {
+  if (this.has(obj)) {
+    delete meta(obj).writableWeak()[this._id];
+  }
+
   return this;
 };

--- a/packages/ember-metal/lib/weak_map.js
+++ b/packages/ember-metal/lib/weak_map.js
@@ -1,74 +1,101 @@
 import { assert } from 'ember-metal/debug';
 import { GUID_KEY } from 'ember-metal/utils';
-import { meta } from 'ember-metal/meta';
+import {
+  peekMeta,
+  meta as metaFor
+} from 'ember-metal/meta';
 
-var id = 0;
+let id = 0;
 function UNDEFINED() {}
 
 /*
- * @public
+ * @private
  * @class Ember.WeakMap
  *
- * Weak relationship from Map -> Key, but not Key to Map.
+ * A partial polyfill for [WeakMap](http://www.ecma-international.org/ecma-262/6.0/#sec-weakmap-objects).
  *
- * Key must be a non null object
+ * There is a small but important caveat. This implementation assumes that the
+ * weak map will live longer (in the sense of garbage collection) than all of its
+ * keys, otherwise it is possible to leak the values stored in the weak map. In
+ * practice, most use cases satisfy this limitation which is why it is included
+ * in ember-metal.
  */
 export default function WeakMap() {
+  assert(
+    'Invoking the WeakMap constructor with arguments is not supported at this time',
+    arguments.length === 0
+  );
+
   this._id = GUID_KEY + (id++);
 }
 
 /*
  * @method get
- * @param key {Object}
- * @return {*} stored value
+ * @param key {Object | Function}
+ * @return {Any} stored value
  */
 WeakMap.prototype.get = function(obj) {
-  var map = meta(obj).readableWeak();
-  if (map) {
-    if (map[this._id] === UNDEFINED) {
-      return undefined;
-    }
+  let meta = peekMeta(obj);
+  if (meta) {
+    let map = meta.readableWeak();
+    if (map) {
+      if (map[this._id] === UNDEFINED) {
+        return undefined;
+      }
 
-    return map[this._id];
+      return map[this._id];
+    }
   }
 };
 
 /*
  * @method set
- * @param key {Object}
+ * @param key {Object | Function}
  * @param value {Any}
- * @return {Any} stored value
+ * @return {WeakMap} the weak map
  */
 WeakMap.prototype.set = function(obj, value) {
-  assert('Uncaught TypeError: Invalid value used as weak map key', obj && (typeof obj === 'object' || typeof obj === 'function'));
+  assert(
+    'Uncaught TypeError: Invalid value used as weak map key',
+    obj && (typeof obj === 'object' || typeof obj === 'function')
+  );
 
   if (value === undefined) {
     value = UNDEFINED;
   }
 
-  meta(obj).writableWeak()[this._id] = value;
+  metaFor(obj).writableWeak()[this._id] = value;
+
   return this;
 };
 
 /*
  * @method has
- * @param key {Object}
- * @return {Boolean} if the key exists
+ * @param key {Object | Function}
+ * @return {boolean} if the key exists
  */
 WeakMap.prototype.has = function(obj) {
-  var map = meta(obj).readableWeak();
+  let meta = peekMeta(obj);
+  if (meta) {
+    let map = meta.readableWeak();
+    if (map) {
+      return map[this._id] !== undefined;
+    }
+  }
 
-  return (map && map[this._id] !== undefined);
+  return false;
 };
 
 /*
  * @method delete
- * @param key {Object}
+ * @param key {Object | Function}
+ * @return {boolean} if the key was deleted
  */
 WeakMap.prototype.delete = function(obj) {
   if (this.has(obj)) {
-    delete meta(obj).writableWeak()[this._id];
+    delete metaFor(obj).writableWeak()[this._id];
+    return true;
+  } else {
+    return false;
   }
-
-  return this;
 };

--- a/packages/ember-metal/tests/weak_map_test.js
+++ b/packages/ember-metal/tests/weak_map_test.js
@@ -1,0 +1,48 @@
+import WeakMap from 'ember-metal/weak_map';
+
+QUnit.module('Ember.WeakMap');
+
+QUnit.test('has weakMap like qualities', function(assert) {
+  var map = new WeakMap();
+  var map2 = new WeakMap();
+
+  var a = {};
+  var b = {};
+  var c = {};
+
+  equal(map.get(a), undefined);
+  equal(map.get(b), undefined);
+  equal(map.get(c), undefined);
+
+  equal(map2.get(a), undefined);
+  equal(map2.get(b), undefined);
+  equal(map2.get(c), undefined);
+
+  equal(map.set(a,  1), map, 'map.set should return itself');
+  equal(map.get(a), 1);
+  equal(map.set(b,  undefined), map);
+  equal(map.set(a, 2), map);
+  equal(map.get(a), 2);
+  equal(map.set(b,  undefined), map);
+
+  equal(map2.get(a), undefined);
+  equal(map2.get(b), undefined);
+  equal(map2.get(c), undefined);
+
+  equal(map.set(c, 1), map);
+  equal(map.get(c), 1);
+  equal(map.get(a), 2);
+  equal(map.get(b), undefined);
+
+  equal(map2.set(a, 3), map2);
+  equal(map2.set(b, 4), map2);
+  equal(map2.set(c, 5), map2);
+
+  equal(map2.get(a), 3);
+  equal(map2.get(b), 4);
+  equal(map2.get(c), 5);
+
+  equal(map.get(c), 1);
+  equal(map.get(a), 2);
+  equal(map.get(b), undefined);
+});

--- a/packages/ember-metal/tests/weak_map_test.js
+++ b/packages/ember-metal/tests/weak_map_test.js
@@ -46,3 +46,45 @@ QUnit.test('has weakMap like qualities', function(assert) {
   equal(map.get(a), 2);
   equal(map.get(b), undefined);
 });
+
+QUnit.test('that error is thrown when using a primitive key', function(assert) {
+  var map = new WeakMap();
+
+  expectAssertion(function() {
+    map.set('a', 1);
+  }, /Uncaught TypeError: Invalid value used as weak map key/);
+
+  expectAssertion(function() {
+    map.set(1, 1);
+  }, /Uncaught TypeError: Invalid value used as weak map key/);
+
+  expectAssertion(function() {
+    map.set(true, 1);
+  }, /Uncaught TypeError: Invalid value used as weak map key/);
+
+  expectAssertion(function() {
+    map.set(null, 1);
+  }, /Uncaught TypeError: Invalid value used as weak map key/);
+
+  expectAssertion(function() {
+    map.set(undefined, 1);
+  }, /Uncaught TypeError: Invalid value used as weak map key/);
+});
+
+QUnit.test('that .has and .delete work as expected', function(assert) {
+  var map = new WeakMap();
+  var a = {};
+  var b = {};
+  var foo = { id: 1, name: 'My file', progress: 0 };
+
+  deepEqual(map.set(a, foo), map);
+  deepEqual(map.get(a), foo);
+  ok(map.has(a));
+  ok(!map.has(b));
+
+  deepEqual(map.delete(a), map);
+  ok(!map.has(a));
+
+  map.set(a, undefined);
+  ok(map.has(a));
+});

--- a/packages/ember-metal/tests/weak_map_test.js
+++ b/packages/ember-metal/tests/weak_map_test.js
@@ -3,52 +3,58 @@ import WeakMap from 'ember-metal/weak_map';
 QUnit.module('Ember.WeakMap');
 
 QUnit.test('has weakMap like qualities', function(assert) {
-  var map = new WeakMap();
-  var map2 = new WeakMap();
+  let map = new WeakMap();
+  let map2 = new WeakMap();
 
-  var a = {};
-  var b = {};
-  var c = {};
+  let a = {};
+  let b = {};
+  let c = {};
 
-  equal(map.get(a), undefined);
-  equal(map.get(b), undefined);
-  equal(map.get(c), undefined);
+  assert.strictEqual(map.get(a), undefined);
+  assert.strictEqual(map.get(b), undefined);
+  assert.strictEqual(map.get(c), undefined);
 
-  equal(map2.get(a), undefined);
-  equal(map2.get(b), undefined);
-  equal(map2.get(c), undefined);
+  assert.strictEqual(map2.get(a), undefined);
+  assert.strictEqual(map2.get(b), undefined);
+  assert.strictEqual(map2.get(c), undefined);
 
-  equal(map.set(a,  1), map, 'map.set should return itself');
-  equal(map.get(a), 1);
-  equal(map.set(b,  undefined), map);
-  equal(map.set(a, 2), map);
-  equal(map.get(a), 2);
-  equal(map.set(b,  undefined), map);
+  assert.strictEqual(map.set(a,  1), map, 'map.set should return itself');
+  assert.strictEqual(map.get(a), 1);
+  assert.strictEqual(map.set(b,  undefined), map);
+  assert.strictEqual(map.set(a, 2), map);
+  assert.strictEqual(map.get(a), 2);
+  assert.strictEqual(map.set(b,  undefined), map);
 
-  equal(map2.get(a), undefined);
-  equal(map2.get(b), undefined);
-  equal(map2.get(c), undefined);
+  assert.strictEqual(map2.get(a), undefined);
+  assert.strictEqual(map2.get(b), undefined);
+  assert.strictEqual(map2.get(c), undefined);
 
-  equal(map.set(c, 1), map);
-  equal(map.get(c), 1);
-  equal(map.get(a), 2);
-  equal(map.get(b), undefined);
+  assert.strictEqual(map.set(c, 1), map);
+  assert.strictEqual(map.get(c), 1);
+  assert.strictEqual(map.get(a), 2);
+  assert.strictEqual(map.get(b), undefined);
 
-  equal(map2.set(a, 3), map2);
-  equal(map2.set(b, 4), map2);
-  equal(map2.set(c, 5), map2);
+  assert.strictEqual(map2.set(a, 3), map2);
+  assert.strictEqual(map2.set(b, 4), map2);
+  assert.strictEqual(map2.set(c, 5), map2);
 
-  equal(map2.get(a), 3);
-  equal(map2.get(b), 4);
-  equal(map2.get(c), 5);
+  assert.strictEqual(map2.get(a), 3);
+  assert.strictEqual(map2.get(b), 4);
+  assert.strictEqual(map2.get(c), 5);
 
-  equal(map.get(c), 1);
-  equal(map.get(a), 2);
-  equal(map.get(b), undefined);
+  assert.strictEqual(map.get(c), 1);
+  assert.strictEqual(map.get(a), 2);
+  assert.strictEqual(map.get(b), undefined);
+});
+
+QUnit.test('invoking the WeakMap constructor with arguments is not supported at this time', function(assert) {
+  expectAssertion(function() {
+    new WeakMap([[{}, 1]]);
+  }, /Invoking the WeakMap constructor with arguments is not supported at this time/);
 });
 
 QUnit.test('that error is thrown when using a primitive key', function(assert) {
-  var map = new WeakMap();
+  let map = new WeakMap();
 
   expectAssertion(function() {
     map.set('a', 1);
@@ -72,19 +78,21 @@ QUnit.test('that error is thrown when using a primitive key', function(assert) {
 });
 
 QUnit.test('that .has and .delete work as expected', function(assert) {
-  var map = new WeakMap();
-  var a = {};
-  var b = {};
-  var foo = { id: 1, name: 'My file', progress: 0 };
+  let map = new WeakMap();
+  let a = {};
+  let b = {};
+  let foo = { id: 1, name: 'My file', progress: 0 };
 
-  deepEqual(map.set(a, foo), map);
-  deepEqual(map.get(a), foo);
-  ok(map.has(a));
-  ok(!map.has(b));
-
-  deepEqual(map.delete(a), map);
-  ok(!map.has(a));
-
-  map.set(a, undefined);
-  ok(map.has(a));
+  assert.strictEqual(map.set(a, foo), map);
+  assert.strictEqual(map.get(a), foo);
+  assert.strictEqual(map.has(a), true);
+  assert.strictEqual(map.has(b), false);
+  assert.strictEqual(map.delete(a), true);
+  assert.strictEqual(map.has(a), false);
+  assert.strictEqual(map.delete(a), false);
+  assert.strictEqual(map.set(a, undefined), map);
+  assert.strictEqual(map.has(a), true);
+  assert.strictEqual(map.delete(a), true);
+  assert.strictEqual(map.delete(a), false);
+  assert.strictEqual(map.has(a), false);
 });


### PR DESCRIPTION
This is a step towards fixing #12212. Finishes #12417 and #12224.

Implements a partial polyfill for [WeakMap](http://www.ecma-international.org/ecma-262/6.0/#sec-weakmap-objects).

There is a small but important caveat. This implementation assumes that the weak map will live longer (in the sense of garbage collection) than all of its keys otherwise it is possible to leak the values stored in the weak map. In practice, most use cases satisfy this limitation which is why it is included in ember-metal.
