### PR TITLE
[DOC beta] mark Application.visit as Public API

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -997,7 +997,6 @@ if (isEnabled('ember-application-visit')) {
       @param url {String} The initial URL to navigate to
       @param options {Ember.ApplicationInstance.BootOptions}
       @return {Promise<Ember.ApplicationInstance, Error>}
-      @private
     */
     visit(url, options) {
       return this.boot().then(() => {


### PR DESCRIPTION
As it is mentioned in the 2.3 blog post here:

http://emberjs.com/blog/2016/01/15/ember-2-3-released.html

It's used in Ember CLI Fastboot, Ember Fastboot Server, and its
usage examples seem to indicate its usage to be a public API.
