### PR TITLE
Add basic ember-cli addon structure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_install:
 
 install:
   - "npm install"
+  - bower install
 
 after_success:
   - "./bin/publish_builds"

--- a/index.js
+++ b/index.js
@@ -1,0 +1,6 @@
+/* jshint node: true */
+'use strict';
+
+module.exports = {
+  name: 'ember'
+};

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "ember",
   "license": "MIT",
   "version": "2.5.0-canary",
+  "keywords": [
+    "ember-addon"
+  ],
   "scripts": {
     "build": "ember build --environment production",
     "pretest": "ember build",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "2.5.0-canary",
   "scripts": {
     "build": "ember build --environment production",
-    "postinstall": "bower install",
     "pretest": "ember build",
     "test": "bin/run-tests.js",
     "test:sauce": "bin/run-sauce-tests.js",


### PR DESCRIPTION
This PR adds the base structure for `ember-cli` to recognize this project as an addon and continues the work started in https://github.com/emberjs/ember.js/pull/12412.

This PR _only_ adds the base structure, more advanced things should IMHO be done in unrelated PRs and can be done in parallel once this one is merged:
- import blueprints from `ember-cli` (see #13029)
- import shims from `ember-cli-shims` (see #13022)
- add necessary Ember.js files to the broccoli trees (see #13022)

/cc @mmun @stefanpenner 
