### PR TITLE
Implement Glimmer teardown

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "express": "^4.5.0",
     "finalhandler": "^0.4.0",
     "github": "^0.2.3",
-    "glimmer-engine": "tildeio/glimmer#71a683d",
+    "glimmer-engine": "tildeio/glimmer#4c2b632",
     "glob": "~4.3.2",
     "htmlbars": "0.14.14",
     "qunit-extras": "^1.4.0",

--- a/packages/ember-glimmer/lib/components/curly-component.js
+++ b/packages/ember-glimmer/lib/components/curly-component.js
@@ -37,14 +37,14 @@ class CurlyComponentManager {
 
   didCreateElement(component, element) {
     component.element = element;
-    // component._transitionTo('hasElement');
+    component._transitionTo('hasElement');
   }
 
 
   didCreate(component) {
     // component.didInsertElement();
     // component.didRender();
-    // component._transitionTo('inDOM');
+    component._transitionTo('inDOM');
   }
 
   update(component, args, keywords) {
@@ -62,6 +62,10 @@ class CurlyComponentManager {
   didUpdate(component) {
     // component.didUpdate();
     // component.didRender();
+  }
+
+  getDestructor(component) {
+    return component;
   }
 }
 

--- a/packages/ember-glimmer/lib/ember-metal-views/index.js
+++ b/packages/ember-glimmer/lib/ember-metal-views/index.js
@@ -28,6 +28,7 @@ export class Renderer {
 
   remove(view) {
     view._transitionTo('destroying');
+    view['_renderResult'].destroy();
     view.destroy();
   }
 

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -44,7 +44,7 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     this.assertSameNode(element2, element1);
   }
 
-  ['@htmlbars it has a jQuery proxy to the element'](assert) {
+  ['@test it has a jQuery proxy to the element'](assert) {
     let instance;
 
     let FooBarComponent = Component.extend({
@@ -71,7 +71,7 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     this.assertSameNode(element2, element1);
   }
 
-  ['@htmlbars it scopes the jQuery proxy to the component element'](assert) {
+  ['@test it scopes the jQuery proxy to the component element'](assert) {
     let instance;
 
     let FooBarComponent = Component.extend({

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -1,5 +1,6 @@
 import { set } from 'ember-metal/property_set';
 import Component from 'ember-views/components/component';
+import { strip } from '../../utils/abstract-test-case';
 import { moduleFor, RenderingTest } from '../../utils/test-case';
 
 moduleFor('Components test: curly components', class extends RenderingTest {
@@ -196,6 +197,78 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     this.runTask(() => set(this.context, 'message', 'hello'));
 
     this.assertComponentElement(this.firstChild, { content: 'hello' });
+  }
+
+  ['@test the component and its child components are destroyed'](assert) {
+    let destroyed = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 0 };
+
+    this.registerComponent('foo-bar', {
+      template: '{{id}} {{yield}}',
+      ComponentClass: Component.extend({
+        willDestroy() {
+          this._super();
+          destroyed[this.get('id')]++;
+        }
+      })
+    });
+
+    this.render(strip(`
+      {{#if cond1}}
+        {{#foo-bar id=1}}
+          {{#if cond2}}
+            {{#foo-bar id=2}}{{/foo-bar}}
+            {{#if cond3}}
+              {{#foo-bar id=3}}
+                {{#if cond4}}
+                  {{#foo-bar id=4}}
+                    {{#if cond5}}
+                      {{#foo-bar id=5}}{{/foo-bar}}
+                      {{#foo-bar id=6}}{{/foo-bar}}
+                      {{#foo-bar id=7}}{{/foo-bar}}
+                    {{/if}}
+                    {{#foo-bar id=8}}{{/foo-bar}}
+                  {{/foo-bar}}
+                {{/if}}
+              {{/foo-bar}}
+            {{/if}}
+          {{/if}}
+        {{/foo-bar}}
+      {{/if}}`),
+      {
+        cond1: true,
+        cond2: true,
+        cond3: true,
+        cond4: true,
+        cond5: true
+      }
+    );
+
+    this.assertText('1 2 3 4 5 6 7 8 ');
+
+    this.runTask(() => this.rerender());
+
+    assert.deepEqual(destroyed, { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 0 });
+
+    this.runTask(() => set(this.context, 'cond5', false));
+
+    this.assertText('1 2 3 4 8 ');
+
+    assert.deepEqual(destroyed, { 1: 0, 2: 0, 3: 0, 4: 0, 5: 1, 6: 1, 7: 1, 8: 0 });
+
+    this.runTask(() => {
+      set(this.context, 'cond3', false);
+      set(this.context, 'cond5', true);
+      set(this.context, 'cond4', false);
+    });
+
+    assert.deepEqual(destroyed, { 1: 0, 2: 0, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1 });
+
+    this.runTask(() => {
+      set(this.context, 'cond2', false);
+      set(this.context, 'cond1', false);
+    });
+
+    assert.deepEqual(destroyed, { 1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1 });
   }
 
 });

--- a/packages/ember-glimmer/tests/utils/abstract-test-case.js
+++ b/packages/ember-glimmer/tests/utils/abstract-test-case.js
@@ -229,3 +229,7 @@ export class RenderingTest extends TestCase {
     }
   }
 }
+
+export function strip(str) {
+  return str.split('\n').map(s => s.trim()).join('');
+}


### PR DESCRIPTION
Also re-enabled the `this.$()` tests (they were previously failing because of view registry not being cleared, but that is now handled correctly at teardown).
