### PR TITLE
[BUGFIX beta] Fix documentation

### DIFF
--- a/packages/ember-htmlbars/lib/keywords/component.js
+++ b/packages/ember-htmlbars/lib/keywords/component.js
@@ -60,7 +60,7 @@ import assign from 'ember-metal/assign';
 
   ```handlebars
   {{yield (hash
-      nameInput=(component "input" value=model.name placeholder="First Name"))}}
+      nameInput=(component "my-input-component" value=model.name placeholder="First Name"))}}
   ```
 
   The following snippet:


### PR DESCRIPTION
Currently, the `input` keyword cannot be used as a contextual component. This fixes the misleading documentation.
