### PR TITLE
Update in readme.md in the Building Ember Section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ on building killer features and UI.
 # Building Ember.js
 
 1. Ensure that [Node.js](http://nodejs.org/) is installed.
-2. Run `npm install` to ensure the required dependencies are installed.
+2. Run `npm install -g ember-cli` to ensure the required dependencies are installed.
 3. Run `npm run build` to build Ember.js. The builds will be placed in the `dist/` directory.
 
 ## npm install troubleshooting


### PR DESCRIPTION
Updating Building Ember.js in the readme.md
Earlier: 
'npm install'
Now after change:
'npm install -g ember-cli'
As given in official site emberjs.com it should be the command as I changed because if we type 'npm install' then no file or package is found. This command written after change is already present in the official site but not in the readme for which I faced problem in installations.
@rwjblue Correct me if I am wrong as I am new to the Ember community.
