### PR TITLE
[BUGFIX release] Do not set model on {{render}} rerender

### DIFF
--- a/packages/ember-routing-htmlbars/lib/keywords/render.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/render.js
@@ -241,8 +241,10 @@ export default {
   },
 
   rerender(node, env, scope, params, hash, template, inverse, visitor) {
-    var model = read(params[1]);
-    node.getState().controller.set('model', model);
+    if (params.length > 1) {
+      var model = read(params[1]);
+      node.getState().controller.set('model', model);
+    }
   }
 };
 


### PR DESCRIPTION
Upon rerender of the {{render}} helper, the model was set to the value of the second argument regardless of if there was a second argument. This means upon rerender a singleton controller would lose its model.

Should be backported to 1.13
