### PR TITLE
Add deprecation for legacy addons

### DIFF
--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -6,7 +6,7 @@
 // BEGIN IMPORTS
 import require, { has } from 'require';
 import Ember from 'ember-metal/core';
-import { deprecateFunc } from 'ember-metal/debug';
+import { deprecate, deprecateFunc } from 'ember-metal/debug';
 import isEnabled, { FEATURES } from 'ember-metal/features';
 import assign from 'ember-metal/assign';
 import merge from 'ember-metal/merge';
@@ -366,6 +366,18 @@ if (has('ember-debug')) {
     Ember.Debug.registerWarnHandler = function() { };
   }
 }
+
+deprecate(
+  'Support for the `ember-legacy-views` addon will end soon, please remove it from your application.',
+  !!Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT,
+  { id: 'ember-legacy-views', until: '2.6.0', url: 'http://emberjs.com/deprecations/v1.x/#toc_ember-view' }
+);
+
+deprecate(
+  'Support for the `ember-legacy-controllers` addon will end soon, please remove it from your application.',
+  !!Ember.ENV._ENABLE_LEGACY_CONTROLLER_SUPPORT,
+  { id: 'ember-legacy-controllers', until: '2.6.0', url: 'http://emberjs.com/deprecations/v1.x/#toc_objectcontroller' }
+);
 
 Ember.create = deprecateFunc('Ember.create is deprecated in favor of Object.create', { id: 'ember-metal.ember-create', until: '3.0.0' }, Object.create);
 Ember.keys = deprecateFunc('Ember.keys is deprecated in favor of Object.keys', { id: 'ember-metal.ember.keys', until: '3.0.0' }, Object.keys);


### PR DESCRIPTION
This adds a deprecation warning when we detect that the legacy view/controller
addons are enabled. Since these addons enable "hidden" features, users should
remove the addons from their applications even if they are not hitting the
existing deprecation paths (e.g. `Ember.View#init`), so that they can be sure
that their applications will continue to work after we drop support for the
addons.
