### PR TITLE
[FEATURE ember-route-serializers] Introduce serialize method to Router DSL options and deprecate Route#serialize

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -31,6 +31,10 @@ for a detailed explanation.
   Makes ember test helpers (`fillIn`, `click`, `triggerEvent` ...) fire native javascript events instead
   of `jQuery.Event`s, maching more closely app's real usage.
 
+* `ember-route-serializers`
+
+  Deprecates `Route#serialize` and introduces a `serialize` option to the router DSL as a replacement (as per the [Route Serializers RFC](https://github.com/emberjs/rfcs/blob/master/text/0120-route-serializers.md)).
+
  * `ember-runtime-computed-uniq-by`
 
    Introduces a computed and enumerable method "uniqBy" that allows creation of a new enumerable with unique values as  determined by the given property key.

--- a/features.json
+++ b/features.json
@@ -8,6 +8,7 @@
     "ember-metal-ember-assign": true,
     "ember-htmlbars-local-lookup": true,
     "ember-application-engines": null,
+    "ember-route-serializers": null,
     "ember-glimmer": null,
     "ember-runtime-computed-uniq-by": null,
     "ember-improved-instrumentation": null

--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -1,4 +1,5 @@
 import { assert, deprecate } from 'ember-metal/debug';
+import isEnabled from 'ember-metal/features';
 
 /**
 @module ember
@@ -11,6 +12,10 @@ function DSL(name, options) {
   this.matches = [];
   this.explicitIndex = undefined;
   this.options = options;
+
+  if (isEnabled('ember-route-serializers')) {
+    this.router = options && options.router;
+  }
 }
 
 export default DSL;
@@ -39,6 +44,10 @@ DSL.prototype = {
     if (this.enableLoadingSubstates) {
       createRoute(this, `${name}_loading`, { resetNamespace: options.resetNamespace });
       createRoute(this, `${name}_error`, { path: dummyErrorRoute });
+    }
+
+    if (isEnabled('ember-route-serializers') && options.serialize && this.router) {
+      this.router._serializeMethods[name] = options.serialize;
     }
 
     if (callback) {

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -742,12 +742,6 @@ QUnit.test('The {{link-to}} helper moves into the named route with context', fun
     }
   });
 
-  App.ItemRoute = Route.extend({
-    serialize(object) {
-      return { id: object.id };
-    }
-  });
-
   bootApplication();
 
   run(function() {
@@ -925,22 +919,36 @@ QUnit.test('Issue 4201 - Shorthand for route.index shouldn\'t throw errors about
 QUnit.test('The {{link-to}} helper unwraps controllers', function() {
   expect(5);
 
-  Router.map(function() {
-    this.route('filter', { path: '/filters/:filter' });
-  });
-
   var indexObject = { filter: 'popular' };
 
-  App.FilterRoute = Route.extend({
-    model(params) {
-      return indexObject;
-    },
+  function serializeFilterRoute(passedObject) {
+    equal(passedObject, indexObject, 'The unwrapped object is passed');
+    return { filter: 'popular' };
+  }
 
-    serialize(passedObject) {
-      equal(passedObject, indexObject, 'The unwrapped object is passed');
-      return { filter: 'popular' };
-    }
-  });
+  if (isEnabled('ember-route-serializers')) {
+    Router.map(function() {
+      this.route('filter', { path: '/filters/:filter', serialize: serializeFilterRoute });
+    });
+
+    App.FilterRoute = Route.extend({
+      model(params) {
+        return indexObject;
+      }
+    });
+  } else {
+    Router.map(function() {
+      this.route('filter', { path: '/filters/:filter' });
+    });
+
+    App.FilterRoute = Route.extend({
+      model(params) {
+        return indexObject;
+      },
+
+      serialize: serializeFilterRoute
+    });
+  }
 
   App.IndexRoute = Route.extend({
     model() {
@@ -1272,6 +1280,7 @@ QUnit.test('The non-block form {{link-to}} helper updates the link text when it 
 
 QUnit.test('The non-block form {{link-to}} helper moves into the named route with context', function() {
   expect(5);
+
   Router.map(function(match) {
     this.route('item', { path: '/item/:id' });
   });
@@ -1283,12 +1292,6 @@ QUnit.test('The non-block form {{link-to}} helper moves into the named route wit
         { id: 'tom', name: 'Tom Dale' },
         { id: 'erik', name: 'Erik Brynroflsson' }
       ]);
-    }
-  });
-
-  App.ItemRoute = Route.extend({
-    serialize(object) {
-      return { id: object.id };
     }
   });
 


### PR DESCRIPTION
Implementation of emberjs/rfcs#120.

TODO:
- [x] Add entry to `FEATURES.md`
- [x] Add entry to emberjs/website deprecation guide for `ember-routing.serialize-function` (and update `deprecate` calls here to include the `url`) [emberjs/website#2557]
- [x] Review documentation, and determine update needs for guides and API docs (making an issue/PR in emberjs/guides for changes needed there, and an issue in emberjs/ember.js with a list of updates needed here when the feature is enabled). [emberjs/guides#1380, emberjs/ember.js#13360]
