### PR TITLE
provide ember-core from NPM

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,42 @@
 /* jshint node: true */
 'use strict';
+var stew = require('broccoli-stew');
+
+var paths = {};
+var absolutePaths = {};
+
+function add(paths, name, path) {
+  Object.defineProperty(paths, name, {
+    configurable: false,
+    get: function() { return path; }
+  });
+}
+
+add(paths, 'prod',  'vendor/ember/ember.prod.js');
+add(paths, 'debug', 'vendor/ember/ember.debug.js');
+
+add(absolutePaths, 'templateCompiler', __dirname + '/dist/ember-template-compiler.js');
 
 module.exports = {
-  name: 'ember'
+  name: 'ember-source',
+  paths: paths,
+  absolutePaths: absolutePaths,
+  treeForVendor: function() {
+    return stew.find(__dirname + '/dist', {
+      destDir: 'ember',
+      files: [
+        'ember-runtime.js',
+        'ember-runtime.map',
+        'ember-template-compiler.js',
+        'ember-template-compiler.map',
+        'ember-testing.js',
+        'ember.debug.cjs.js',
+        'ember.debug.cjs.map',
+        'ember.debug.js',
+        'ember.min.js',
+        'ember.prod.js',
+        // 'shims/shims.js'
+      ]
+    });
+  }
 };

--- a/index.js
+++ b/index.js
@@ -21,11 +21,11 @@ add(absolutePaths, 'templateCompiler', __dirname + '/dist/ember-template-compile
 module.exports = {
   init: function() {
     if ('ember' in this.project.bowerDependencies()) {
-      throw new TypeError('Ember.js is now provided by node_module `ember-source`, please remove it from bower');
+      throw new TypeError('Ember.js is now provided by node_module `ember-core`, please remove it from bower');
     }
   },
 
-  name: 'ember-source',
+  name: 'ember-core',
   paths: paths,
   absolutePaths: absolutePaths,
   treeForVendor: function() {

--- a/index.js
+++ b/index.js
@@ -19,6 +19,12 @@ add(paths, 'shims', 'vendor/ember/shims.js');
 add(absolutePaths, 'templateCompiler', __dirname + '/dist/ember-template-compiler.js');
 
 module.exports = {
+  init: function() {
+    if ('ember' in this.project.bowerDependencies()) {
+      throw new TypeError('Ember.js is now provided by node_module `ember-source`, please remove it from bower');
+    }
+  },
+
   name: 'ember-source',
   paths: paths,
   absolutePaths: absolutePaths,

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ function add(paths, name, path) {
 
 add(paths, 'prod',  'vendor/ember/ember.prod.js');
 add(paths, 'debug', 'vendor/ember/ember.debug.js');
+add(paths, 'shims', 'vendor/ember/shims.js');
 
 add(absolutePaths, 'templateCompiler', __dirname + '/dist/ember-template-compiler.js');
 
@@ -22,7 +23,7 @@ module.exports = {
   paths: paths,
   absolutePaths: absolutePaths,
   treeForVendor: function() {
-    return stew.find(__dirname + '/dist', {
+    var ember = stew.find(__dirname + '/dist', {
       destDir: 'ember',
       files: [
         'ember-runtime.js',
@@ -34,9 +35,18 @@ module.exports = {
         'ember.debug.cjs.map',
         'ember.debug.js',
         'ember.min.js',
-        'ember.prod.js',
-        // 'shims/shims.js'
+        'ember.prod.js'
       ]
     });
+
+    var shims = stew.find(__dirname + '/vendor/ember', {
+      destDir: 'ember',
+      files: [ 'shims.js' ]
+    });
+
+    return stew.find([
+      ember,
+      shims
+    ]);
   }
 };

--- a/index.js
+++ b/index.js
@@ -24,11 +24,11 @@ module.exports = {
 		this._super.init && this._super.init.apply(this, arguments);
     if ('ember' in this.project.bowerDependencies()) {
       // TODO: move this to a throw soon.
-      this.ui.writeWarnLine('Ember.js is now provided by node_module `ember-core`, please remove it from bower');
+      this.ui.writeWarnLine('Ember.js is now provided by node_module `ember-source`, please remove it from bower');
     }
   },
 
-  name: 'ember-core',
+  name: 'ember-source',
   paths: paths,
   absolutePaths: absolutePaths,
   treeForVendor: function() {

--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@ module.exports = {
   init: function() {
 		this._super.init && this._super.init.apply(this, arguments);
     if ('ember' in this.project.bowerDependencies()) {
-      throw new TypeError('Ember.js is now provided by node_module `ember-core`, please remove it from bower');
+      // TODO: move this to a throw soon.
+      this.ui.writeWarnLine('Ember.js is now provided by node_module `ember-core`, please remove it from bower');
     }
   },
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function add(paths, name, path) {
 add(paths, 'prod',  'vendor/ember/ember.prod.js');
 add(paths, 'debug', 'vendor/ember/ember.debug.js');
 add(paths, 'shims', 'vendor/ember/shims.js');
+add(paths, 'jquery', 'vendor/ember/jquery/jquery.js');
 
 add(absolutePaths, 'templateCompiler', __dirname + '/dist/ember-template-compiler.js');
 
@@ -33,15 +34,12 @@ module.exports = {
       destDir: 'ember',
       files: [
         'ember-runtime.js',
-        'ember-runtime.map',
         'ember-template-compiler.js',
-        'ember-template-compiler.map',
         'ember-testing.js',
-        'ember.debug.cjs.js',
-        'ember.debug.cjs.map',
         'ember.debug.js',
         'ember.min.js',
-        'ember.prod.js'
+        'ember.prod.js',
+        'jquery/jquery.js'
       ]
     });
 

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ add(absolutePaths, 'templateCompiler', __dirname + '/dist/ember-template-compile
 
 module.exports = {
   init: function() {
+		this._super.init && this._super.init.apply(this, arguments);
     if ('ember' in this.project.bowerDependencies()) {
       throw new TypeError('Ember.js is now provided by node_module `ember-core`, please remove it from bower');
     }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ember",
+  "name": "ember-source",
   "license": "MIT",
   "version": "2.10.0",
   "keywords": [
@@ -61,6 +61,8 @@
     "ember-cli-path-utils": "^1.0.0",
     "ember-cli-string-utils": "^1.0.0",
     "ember-cli-test-info": "^1.0.0",
-    "ember-cli-valid-component-name": "^1.0.0"
+    "ember-cli-valid-component-name": "^1.0.0",
+    "simple-dom": "^0.3.0",
+    "broccoli-stew": "^1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -64,5 +64,8 @@
     "ember-cli-valid-component-name": "^1.0.0",
     "simple-dom": "^0.3.0",
     "broccoli-stew": "^1.2.0"
+  },
+  "ember-addon": {
+    "after": "ember-cli-legacy-blueprints"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ember-core",
+  "name": "ember-source",
   "license": "MIT",
   "version": "2.10.0",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ember-source",
+  "name": "ember-core",
   "license": "MIT",
   "version": "2.10.0",
   "keywords": [

--- a/vendor/ember/shims.js
+++ b/vendor/ember/shims.js
@@ -1,0 +1,247 @@
+(function() {
+/* globals define, Ember, jQuery */
+
+  function processEmberShims() {
+    var shims = {
+      'ember': {
+        'default': Ember
+      },
+      'ember-application': {
+        'default': Ember.Application
+      },
+      'ember-array': {
+        'default': Ember.Array
+      },
+      'ember-array/mutable': {
+        'default': Ember.MutableArray
+      },
+      'ember-array/utils': {
+        'A':            Ember.A,
+        'isEmberArray': Ember.isArray,
+        'wrap':         Ember.makeArray
+      },
+      'ember-component': {
+        'default': Ember.Component
+      },
+      'ember-components/checkbox': {
+        'default': Ember.Checkbox
+      },
+      'ember-components/text-area': {
+        'default': Ember.TextArea
+      },
+      'ember-components/text-field': {
+        'default': Ember.TextField
+      },
+      'ember-controller': {
+        'default': Ember.Controller
+      },
+      'ember-controller/inject': {
+        'default': Ember.inject.controller
+      },
+      'ember-controller/proxy': {
+        'default': Ember.ArrayProxy
+      },
+      'ember-controllers/sortable': {
+        'default': Ember.SortableMixin
+      },
+      'ember-debug': {
+        'log':      Ember.debug,
+        'inspect':  Ember.inspect,
+        'run':      Ember.runInDebug,
+        'warn':     Ember.warn
+      },
+      'ember-debug/container-debug-adapter': {
+        'default': Ember.ContainerDebugAdapter
+      },
+      'ember-debug/data-adapter': {
+        'default': Ember.DataAdapter
+      },
+      'ember-deprecations': {
+        'deprecate':      Ember.deprecate,
+        'deprecateFunc':  Ember.deprecateFunc
+      },
+      'ember-enumerable': {
+        'default': Ember.Enumerable
+      },
+      'ember-evented': {
+        'default': Ember.Evented
+      },
+      'ember-evented/on': {
+        'default': Ember.on
+      },
+      'ember-globals-resolver': {
+        'default': Ember.DefaultResolver
+      },
+      'ember-helper': {
+        'default':  Ember.Helper,
+        'helper':   Ember.Helper && Ember.Helper.helper
+      },
+      'ember-instrumentation': {
+        'instrument':   Ember.Instrumentation.instrument,
+        'reset':        Ember.Instrumentation.reset,
+        'subscribe':    Ember.Instrumentation.subscribe,
+        'unsubscribe':  Ember.Instrumentation.unsubscribe
+      },
+      'ember-locations/hash': {
+        'default': Ember.HashLocation
+      },
+      'ember-locations/history': {
+        'default': Ember.HistoryLocation
+      },
+      'ember-locations/none': {
+        'default': Ember.NoneLocation
+      },
+      'ember-map': {
+        'default':      Ember.Map,
+        'withDefault':  Ember.MapWithDefault
+      },
+      'ember-metal/destroy': {
+        'default': Ember.destroy
+      },
+      'ember-metal/events': {
+        'addListener':    Ember.addListener,
+        'removeListener': Ember.removeListener,
+        'send':           Ember.sendEvent
+      },
+      'ember-metal/get': {
+        'default': Ember.get
+      },
+      'ember-metal/mixin': {
+        'default': Ember.Mixin
+      },
+      'ember-metal/observer': {
+        'default':        Ember.observer,
+        'addObserver':    Ember.addObserver,
+        'removeObserver': Ember.removeObserver
+      },
+      'ember-metal/on-load': {
+        'default':  Ember.onLoad,
+        'run':      Ember.runLoadHooks
+      },
+      'ember-metal/set': {
+        'default':        Ember.set,
+        'setProperties':  Ember.setProperties,
+        'trySet':         Ember.trySet
+      },
+      'ember-metal/utils': {
+        'aliasMethod':  Ember.aliasMethod,
+        'assert':       Ember.assert,
+        'cacheFor':     Ember.cacheFor,
+        'copy':         Ember.copy
+      },
+      'ember-object': {
+        'default': Ember.Object
+      },
+      'ember-platform': {
+        'assign':         Ember.merge,
+        'create':         Ember.create,
+        'defineProperty': Ember.platform.defineProperty,
+        'hasAccessors':   Ember.platform.hasPropertyAccessors,
+        'keys':           Ember.keys
+      },
+      'ember-route': {
+        'default': Ember.Route
+      },
+      'ember-router': {
+        'default': Ember.Router
+      },
+      'ember-runloop': {
+        'default':      Ember.run,
+        'begin':        Ember.run.begin,
+        'bind':         Ember.run.bind,
+        'cancel':       Ember.run.cancel,
+        'debounce':     Ember.run.debounce,
+        'end':          Ember.run.end,
+        'join':         Ember.run.join,
+        'later':        Ember.run.later,
+        'next':         Ember.run.next,
+        'once':         Ember.run.once,
+        'schedule':     Ember.run.schedule,
+        'scheduleOnce': Ember.run.scheduleOnce,
+        'throttle':     Ember.run.throttle
+      },
+      'ember-service': {
+        'default': Ember.Service
+      },
+      'ember-service/inject': {
+        'default': Ember.inject.service
+      },
+      'ember-set/ordered': {
+        'default': Ember.OrderedSet
+      },
+      'ember-string': {
+        'camelize':     Ember.String.camelize,
+        'capitalize':   Ember.String.capitalize,
+        'classify':     Ember.String.classify,
+        'dasherize':    Ember.String.dasherize,
+        'decamelize':   Ember.String.decamelize,
+        'fmt':          Ember.String.fmt,
+        'htmlSafe':     Ember.String.htmlSafe,
+        'loc':          Ember.String.loc,
+        'underscore':   Ember.String.underscore,
+        'w':            Ember.String.w
+      },
+      'ember-utils': {
+        'isBlank':    Ember.isBlank,
+        'isEmpty':    Ember.isEmpty,
+        'isNone':     Ember.isNone,
+        'isPresent':  Ember.isPresent,
+        'tryInvoke':  Ember.tryInvoke,
+        'typeOf':     Ember.typeOf
+      }
+    };
+
+    // populate `ember/computed` named exports
+    shims['ember-computed'] = {
+      'default': Ember.computed
+    };
+    var computedMacros = [
+      "empty","notEmpty", "none", "not", "bool", "match", "equal", "gt", "gte",
+      "lt", "lte", "alias", "oneWay", "reads", "readOnly", "deprecatingAlias",
+      "and", "or", "collect", "sum", "min", "max", "map", "sort", "setDiff",
+      "mapBy", "filter", "filterBy", "uniq", "union", "intersect"
+    ];
+
+    for (var i = 0, l = computedMacros.length; i < l; i++) {
+      var key = computedMacros[i];
+      shims['ember-computed'][key] = Ember.computed[key];
+    }
+
+    for (var moduleName in shims) {
+      generateModule(moduleName, shims[moduleName]);
+    }
+  }
+
+  function processTestShims() {
+    if (Ember.Test) {
+      var testShims = {
+        'ember-test': {
+          'default': Ember.Test
+        },
+        'ember-test/adapter': {
+          'default': Ember.Test.Adapter
+        },
+        'ember-test/qunit-adapter': {
+          'default': Ember.Test.QUnitAdapter
+        }
+      };
+
+      for (var moduleName in testShims) {
+        generateModule(moduleName, testShims[moduleName]);
+      }
+    }
+  }
+
+  function generateModule(name, values) {
+    define(name, [], function() {
+      'use strict';
+
+      return values;
+    });
+  }
+
+  processEmberShims();
+  processTestShims();
+  generateModule('jquery', { 'default': self.jQuery });
+  generateModule('rsvp', { 'default': Ember.RSVP });
+})();

--- a/vendor/ember/shims.js
+++ b/vendor/ember/shims.js
@@ -132,6 +132,12 @@
       'ember-object': {
         'default': Ember.Object
       },
+      'ember-owner/get': {
+        'default': Ember.getOwner
+      },
+      'ember-owner/set': {
+        'default': Ember.setOwner
+      },
       'ember-platform': {
         'assign':         Ember.merge,
         'create':         Ember.create,


### PR DESCRIPTION
- obviate the need to `bower install ember.js`
- provide an api for addons to retrieve paths to
  ember.debug.js, ember.prod.js and
  ember-template-compiler.js
- [x] actually decide on name
- [x] shims
- [x] throw if ember-cli version does not support this
- [x] ember-data fix ->  https://github.com/emberjs/data/issues/4192
- [ ] ~~on-demand build for master, and maybe beta?~~ can happen after
- [ ] release
- [ ] rename to ember-source - [ember](https://github.com/emberjs/ember.js/pull/14396) [ember-cli](https://github.com/ember-cli/ember-cli/pull/6324/files) [ember-cli-legacy-blueprints](https://github.com/ember-cli/ember-cli-legacy-blueprints/pull/62)
- [ ] ~~backport to release~~ (decided to let it ride the beta cycle so folks can test)

related:
-  https://github.com/ember-cli/ember-cli/pull/5921
- https://github.com/ember-cli/ember-cli/pull/5531
- https://github.com/ember-cli/ember-cli-htmlbars/pull/68
- https://github.com/emberjs/data/issues/4192
