### PR TITLE
[BUGFIX release] Fix legacy addon deprecations

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -3,7 +3,7 @@
 @submodule ember-application
 */
 import Ember from 'ember-metal'; // Ember.libraries, LOG_VERSION, Namespace, BOOTED
-import { assert, debug } from 'ember-metal/debug';
+import { assert, debug, deprecate } from 'ember-metal/debug';
 import isEnabled from 'ember-metal/features';
 import { get } from 'ember-metal/property_get';
 import { runLoadHooks } from 'ember-runtime/system/lazy_load';
@@ -38,6 +38,15 @@ import RSVP from 'ember-runtime/ext/rsvp';
 import Engine from './engine';
 
 var librariesRegistered = false;
+
+let warnedAboutLegacyViewAddon = false;
+let warnedAboutLegacyControllerAddon = false;
+
+// For testing
+export function _resetLegacyAddonWarnings() {
+  warnedAboutLegacyViewAddon = false;
+  warnedAboutLegacyControllerAddon = false;
+}
 
 /**
   An instance of `Ember.Application` is the starting point for every Ember
@@ -593,6 +602,26 @@ const Application = Engine.extend({
   */
   _bootSync() {
     if (this._booted) { return; }
+
+    if (Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT && !warnedAboutLegacyViewAddon) {
+      deprecate(
+        'Support for the `ember-legacy-views` addon will end soon, please remove it from your application.',
+        false,
+        { id: 'ember-legacy-views', until: '2.6.0', url: 'http://emberjs.com/deprecations/v1.x/#toc_ember-view' }
+      );
+
+      warnedAboutLegacyViewAddon = true;
+    }
+
+    if (Ember.ENV._ENABLE_LEGACY_CONTROLLER_SUPPORT && !warnedAboutLegacyControllerAddon) {
+      deprecate(
+        'Support for the `ember-legacy-controllers` addon will end soon, please remove it from your application.',
+        false,
+        { id: 'ember-legacy-controllers', until: '2.6.0', url: 'http://emberjs.com/deprecations/v1.x/#toc_objectcontroller' }
+      );
+
+      warnedAboutLegacyControllerAddon = true;
+    }
 
     // Even though this returns synchronously, we still need to make sure the
     // boot promise exists for book-keeping purposes: if anything went wrong in

--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -6,7 +6,7 @@
 // BEGIN IMPORTS
 import require, { has } from 'require';
 import Ember from 'ember-metal/core';
-import { deprecate, deprecateFunc } from 'ember-metal/debug';
+import { deprecateFunc } from 'ember-metal/debug';
 import isEnabled, { FEATURES } from 'ember-metal/features';
 import assign from 'ember-metal/assign';
 import merge from 'ember-metal/merge';
@@ -366,16 +366,6 @@ if (has('ember-debug')) {
     Ember.Debug.registerWarnHandler = function() { };
   }
 }
-
-deprecate(
-  'Support for the `ember-legacy-views` addon will end soon, please remove it from your application.',
-  !!Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT,
-  { id: 'ember-legacy-views', until: '2.6.0', url: 'http://emberjs.com/deprecations/v1.x/#toc_ember-view' });
-
-deprecate(
-  'Support for the `ember-legacy-controllers` addon will end soon, please remove it from your application.',
-  !!Ember.ENV._ENABLE_LEGACY_CONTROLLER_SUPPORT,
-  { id: 'ember-legacy-controllers', until: '2.6.0', url: 'http://emberjs.com/deprecations/v1.x/#toc_objectcontroller' });
 
 Ember.create = deprecateFunc('Ember.create is deprecated in favor of Object.create', { id: 'ember-metal.ember-create', until: '3.0.0' }, Object.create);
 Ember.keys = deprecateFunc('Ember.keys is deprecated in favor of Object.keys', { id: 'ember-metal.ember.keys', until: '3.0.0' }, Object.keys);

--- a/tests/index.html
+++ b/tests/index.html
@@ -116,6 +116,16 @@
           }
         }
 
+        Ember.Debug.registerDeprecationHandler(function (message, options, next) {
+          var id = options && options.id;
+
+          if (id === 'ember-legacy-views' || id === 'ember-legacy-controllers') {
+            // Our test suite relies on the legacy semantics... to test the legacy semantics
+          } else {
+            next(message, options);
+          }
+        });
+
         window.EmberDev = window.EmberDev || {};
         EmberDev.runningProdBuild = !!QUnit.urlParams.prod;
 


### PR DESCRIPTION
The signature of `Ember.deprecate` is `message`, `test`, `options`,
where `test` is `If falsy, the deprecation will be displayed.` Here,
we did the opposite, causing the deprecation message to be shown only
when the addons are NOT installed.
