### PR TITLE
[BUGFIX release] Fix mergedProperties at create time modifying proto

### DIFF
--- a/packages/ember-metal/tests/mixin/merged_properties_test.js
+++ b/packages/ember-metal/tests/mixin/merged_properties_test.js
@@ -105,6 +105,29 @@ QUnit.test('mergedProperties should exist even if not explicitly set on create',
   equal(get(obj, 'options').b.c, 'ccc');
 });
 
+QUnit.test('defining mergedProperties at create time should not modify the prototype', function() {
+  var AnObj = EmberObject.extend({
+    mergedProperties: ['options'],
+    options: {
+      a: 1
+    }
+  });
+
+  var objA = AnObj.create({
+    options: {
+      a: 2
+    }
+  });
+  var objB = AnObj.create({
+    options: {
+      a: 3
+    }
+  });
+
+  equal(get(objA, 'options').a, 2);
+  equal(get(objB, 'options').a, 3);
+});
+
 QUnit.test('mergedProperties\' overwriting methods can call _super', function() {
   expect(4);
 

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -147,7 +147,7 @@ function makeCtor() {
               mergedProperties.indexOf(keyName) >= 0) {
             var originalValue = this[keyName];
 
-            value = assign(originalValue, value);
+            value = assign({}, originalValue, value);
           }
 
           if (desc) {


### PR DESCRIPTION
When `mergedProperties` are passed into an object at `.create()` time, the objects prototype is inadvertently modified, which is then reflected on all instances of the object. Simply passing in a new
object during `assign()` resolves this problem (per krisselden). Also added a test for this use case, where `objA` results in 3 when the proto is modified. Fixes #11714
