### PR TITLE
Revert "[BUGFIX canary] Update Ember.compare to use operators"

### DIFF
--- a/packages/ember-runtime/lib/compare.js
+++ b/packages/ember-runtime/lib/compare.js
@@ -109,18 +109,7 @@ export default function compare(v, w) {
       return spaceship(v, w);
 
     case 'string':
-      // We are comparing Strings using operators instead of `String#localeCompare`
-      // because of unexpected behavior for certain edge cases.
-      // For example `'Z'.localeCompare('a')` returns `1`.
-      //
-      // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#Description
-      if (v < w) {
-        return -1;
-      } else if (v === w) {
-        return 0;
-      }
-
-      return 1;
+      return spaceship(v.localeCompare(w), 0);
 
     case 'array':
       var vLen = v.length;

--- a/packages/ember-runtime/tests/core/compare_test.js
+++ b/packages/ember-runtime/tests/core/compare_test.js
@@ -74,8 +74,4 @@ QUnit.test('comparables should return values in the range of -1, 0, 1', function
   equal(compare('a', negOne), 1, 'Second item comparable - returns -1 (negated)');
   equal(compare('b', zero), 0, 'Second item comparable - returns  0 (negated)');
   equal(compare('c', one), -1, 'Second item comparable - returns  1 (negated)');
-
-  equal(compare('A', 'Z'), -1, `'A' < 'Z' returns -1`);
-  equal(compare('Z', 'a'), -1, `'Z' < 'a' returns -1`);
-  equal(compare('a', 'z'), -1, `'a' < 'z' returns -1`);
 });


### PR DESCRIPTION
It is a breaking change to make compare be locale invariant from using the default locale and many locales do not default to being case sensitive for sorting.  Non localizable data like sorting ids needs an invariant compare and yes that is a valid use case but I don't see how we could switch this now, collation affects not just case sensitivity but accent sensitivity and more.  This change makes it compare character code values, which is fine for locale invariant data like base64 encoded ids but not necessarily ok for names.
