### PR TITLE
[DOC] Fix indent

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -212,9 +212,9 @@ var EmberRouter = EmberObject.extend(Evented, {
         this._super(...arguments);
 
         return ga('send', 'pageview', {
-            'page': this.get('url'),
-            'title': this.get('url')
-          });
+          'page': this.get('url'),
+          'title': this.get('url')
+        });
       }
     });
     ```


### PR DESCRIPTION
Removed extra indent in the `didTransition` docs.
