### PR TITLE
Refactor the shared conditionals test cases

### DIFF
--- a/packages/ember-glimmer/tests/integration/helpers/if-unless-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/if-unless-test.js
@@ -1,13 +1,9 @@
 import { moduleFor } from '../../utils/test-case';
 import { set } from 'ember-metal/property_set';
 
-import {
-  BASIC_TRUTHY_TESTS,
-  BASIC_FALSY_TESTS,
-  SharedHelperConditionalsTest
-} from '../../utils/shared-conditional-tests';
+import { TogglingHelperConditionalsTest } from '../../utils/shared-conditional-tests';
 
-moduleFor('Helpers test: inline {{if}}', class extends SharedHelperConditionalsTest {
+moduleFor('Helpers test: inline {{if}}', class extends TogglingHelperConditionalsTest {
 
   templateFor({ cond, truthy, falsy }) {
     return `{{if ${cond} ${truthy} ${falsy}}}`;
@@ -53,25 +49,25 @@ moduleFor('Helpers test: inline {{if}}', class extends SharedHelperConditionalsT
     }, /The inline form of the `if` and `unless` helpers expect two or three arguments/);
   }
 
-}, BASIC_TRUTHY_TESTS, BASIC_FALSY_TESTS);
+});
 
-moduleFor('@glimmer Helpers test: nested {{if}} helpers (returning truthy values)', class extends SharedHelperConditionalsTest {
+moduleFor('@glimmer Helpers test: nested {{if}} helpers (returning truthy values)', class extends TogglingHelperConditionalsTest {
 
   templateFor({ cond, truthy, falsy }) {
     return `{{if (if ${cond} ${cond} false) ${truthy} ${falsy}}}`;
   }
 
-}, BASIC_TRUTHY_TESTS, BASIC_FALSY_TESTS);
+});
 
-moduleFor('@glimmer Helpers test: nested {{if}} helpers (returning falsy values)', class extends SharedHelperConditionalsTest {
+moduleFor('@glimmer Helpers test: nested {{if}} helpers (returning falsy values)', class extends TogglingHelperConditionalsTest {
 
   templateFor({ cond, truthy, falsy }) {
     return `{{if (if ${cond} true ${cond}) ${truthy} ${falsy}}}`;
   }
 
-}, BASIC_TRUTHY_TESTS, BASIC_FALSY_TESTS);
+});
 
-moduleFor('@glimmer Helpers test: {{if}} used with another helper', class extends SharedHelperConditionalsTest {
+moduleFor('@glimmer Helpers test: {{if}} used with another helper', class extends TogglingHelperConditionalsTest {
 
   wrapperFor(templates) {
     return `{{concat ${templates.join(' ')}}}`;
@@ -81,9 +77,9 @@ moduleFor('@glimmer Helpers test: {{if}} used with another helper', class extend
     return `(if ${cond} ${truthy} ${falsy})`;
   }
 
-}, BASIC_TRUTHY_TESTS, BASIC_FALSY_TESTS);
+});
 
-moduleFor('@glimmer Helpers test: {{if}} used in attribute position', class extends SharedHelperConditionalsTest {
+moduleFor('@glimmer Helpers test: {{if}} used in attribute position', class extends TogglingHelperConditionalsTest {
 
   wrapperFor(templates) {
     return `<div data-foo="${templates.join('')}" />`;
@@ -97,4 +93,4 @@ moduleFor('@glimmer Helpers test: {{if}} used in attribute position', class exte
     return this.$('div').attr('data-foo');
   }
 
-}, BASIC_TRUTHY_TESTS, BASIC_FALSY_TESTS);
+});

--- a/packages/ember-glimmer/tests/integration/syntax/if-unless-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/if-unless-test.js
@@ -1,82 +1,26 @@
 import { moduleFor } from '../../utils/test-case';
-import { set } from 'ember-metal/property_set';
-import {
-  BASIC_TRUTHY_TESTS,
-  BASIC_FALSY_TESTS,
-  SharedSyntaxConditionalsTest
-} from '../../utils/shared-conditional-tests';
+import { TogglingSyntaxConditionalsTest } from '../../utils/shared-conditional-tests';
 
-moduleFor('Syntax test: {{#if}}', class extends SharedSyntaxConditionalsTest {
+moduleFor('Syntax test: {{#if}} with inverse', class extends TogglingSyntaxConditionalsTest {
 
   templateFor({ cond, truthy, falsy }) {
     return `{{#if ${cond}}}${truthy}{{else}}${falsy}{{/if}}`;
   }
 
-  ['@test it renders and hides the given block based on the conditional']() {
-    this.render(`{{#if cond1}}T1{{/if}}{{#if cond2}}T2{{/if}}`, { cond1: true, cond2: false });
+});
 
-    this.assertText('T1');
-
-    this.runTask(() => this.rerender());
-
-    this.assertText('T1');
-
-    this.runTask(() => set(this.context, 'cond1', false));
-
-    this.assertText('');
-
-    this.runTask(() => {
-      set(this.context, 'cond1', true);
-      set(this.context, 'cond2', true);
-    });
-
-    this.assertText('T1T2');
-
-    this.runTask(() => {
-      set(this.context, 'cond1', true);
-      set(this.context, 'cond2', false);
-    });
-
-    this.assertText('T1');
-  }
-
-}, BASIC_TRUTHY_TESTS, BASIC_FALSY_TESTS);
-
-moduleFor('Syntax test: {{#unless}}', class extends SharedSyntaxConditionalsTest {
+moduleFor('Syntax test: {{#unless}} with inverse', class extends TogglingSyntaxConditionalsTest {
 
   templateFor({ cond, truthy, falsy }) {
     return `{{#unless ${cond}}}${falsy}{{else}}${truthy}{{/unless}}`;
   }
 
-  ['@test it renders and hides the given block based on the conditional']() {
-    this.render(`{{#unless cond1}}F1{{/unless}}{{#unless cond2}}F2{{/unless}}`, {
-      cond1: true,
-      cond2: false
-    });
+});
 
-    this.assertText('F2');
+moduleFor('Syntax test: {{#if}} and {{#unless}} without inverse', class extends TogglingSyntaxConditionalsTest {
 
-    this.runTask(() => this.rerender());
-
-    this.assertText('F2');
-
-    this.runTask(() => set(this.context, 'cond2', true));
-
-    this.assertText('');
-
-    this.runTask(() => {
-      set(this.context, 'cond1', false);
-      set(this.context, 'cond2', false);
-    });
-
-    this.assertText('F1F2');
-
-    this.runTask(() => {
-      set(this.context, 'cond1', true);
-      set(this.context, 'cond2', false);
-    });
-
-    this.assertText('F2');
+  templateFor({ cond, truthy, falsy }) {
+    return `{{#if ${cond}}}${truthy}{{/if}}{{#unless ${cond}}}${falsy}{{/unless}}`;
   }
 
-}, BASIC_TRUTHY_TESTS, BASIC_FALSY_TESTS);
+});

--- a/packages/ember-glimmer/tests/integration/syntax/with-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/with-test.js
@@ -1,20 +1,18 @@
 import { moduleFor } from '../../utils/test-case';
 import { set } from 'ember-metal/property_set';
-import {
-  BASIC_TRUTHY_TESTS,
-  BASIC_FALSY_TESTS,
-  SharedSyntaxConditionalsTest
-} from '../../utils/shared-conditional-tests';
+import { TogglingSyntaxConditionalsTest } from '../../utils/shared-conditional-tests';
 import { RenderingTest } from '../../utils/test-case';
 
-moduleFor('Syntax test: {{#with}}', class extends SharedSyntaxConditionalsTest {
+moduleFor('Syntax test: {{#with}}', class extends TogglingSyntaxConditionalsTest {
+
   templateFor({ cond, truthy, falsy }) {
     return `{{#with ${cond}}}${truthy}{{else}}${falsy}{{/with}}`;
   }
 
-}, BASIC_TRUTHY_TESTS, BASIC_FALSY_TESTS);
+});
 
-moduleFor('Syntax test: {{#with as}}', class extends SharedSyntaxConditionalsTest {
+moduleFor('Syntax test: {{#with as}}', class extends TogglingSyntaxConditionalsTest {
+
   templateFor({ cond, truthy, falsy }) {
     return `{{#with ${cond} as |test|}}${truthy}{{else}}${falsy}{{/with}}`;
   }
@@ -30,13 +28,17 @@ moduleFor('Syntax test: {{#with as}}', class extends SharedSyntaxConditionalsTes
 
     this.assertText('Hello');
 
+    this.runTask(() => set(this.context, 'cond1.greeting', 'Hello world'));
+
+    this.assertText('Hello world');
+
     this.runTask(() => set(this.context, 'cond1', false));
 
     this.assertText('False');
 
-    this.runTask(() => this.rerender());
+    this.runTask(() => set(this.context, 'cond1', { greeting: 'Hello' }));
 
-    this.assertText('False');
+    this.assertText('Hello');
   }
 
   ['@test can access alias and original scope']() {
@@ -145,9 +147,11 @@ moduleFor('Syntax test: {{#with as}}', class extends SharedSyntaxConditionalsTes
 
     this.assertText('Empty Array');
   }
-}, BASIC_TRUTHY_TESTS, BASIC_FALSY_TESTS);
+
+});
 
 moduleFor('Syntax test: Multiple {{#with as}} helpers', class extends RenderingTest {
+
   ['@test re-using the same variable with different #with blocks does not override each other']() {
     this.render(`Admin: {{#with admin as |person|}}{{person.name}}{{/with}} User: {{#with user as |person|}}{{person.name}}{{/with}}`, {
       admin: { name: 'Tom Dale' },
@@ -300,4 +304,5 @@ moduleFor('Syntax test: Multiple {{#with as}} helpers', class extends RenderingT
 
     this.assertText('Los Pivots');
   }
+
 });

--- a/packages/ember-glimmer/tests/utils/shared-conditional-tests.js
+++ b/packages/ember-glimmer/tests/utils/shared-conditional-tests.js
@@ -1,3 +1,4 @@
+import { applyMixins } from './abstract-test-case';
 import { RenderingTest } from './test-case';
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
@@ -8,6 +9,10 @@ import { A as emberA } from 'ember-runtime/system/native_array';
 import ArrayProxy from 'ember-runtime/system/array_proxy';
 
 class AbstractConditionalsTest extends RenderingTest {
+
+  get truthyValue() { return true; }
+
+  get falsyValue() { return false; }
 
   wrapperFor(templates) {
     return templates.join('');
@@ -30,6 +35,19 @@ class AbstractConditionalsTest extends RenderingTest {
 
 }
 
+class AbstractGenerator {
+
+  constructor(cases) {
+    this.cases = cases;
+  }
+
+  /* abstract */
+  generate(value) {
+    throw new Error('Not implemented: `generate`');
+  }
+
+}
+
 /*
   The test cases in this file generally follow the following pattern:
 
@@ -40,35 +58,10 @@ class AbstractConditionalsTest extends RenderingTest {
   5. Reset them to their original values (through replacement)
 */
 
-export const BASIC_TRUTHY_TESTS = {
-
-  cases: [
-    true,
-    ' ',
-    'hello',
-    'false',
-    'null',
-    'undefined',
-    1,
-    ['hello'],
-    emberA(['hello']),
-    {},
-    { foo: 'bar' },
-    EmberObject.create(),
-    EmberObject.create({ foo: 'bar' }),
-    EmberObject.create({ isTruthy: true }),
-    /*jshint -W053 */
-    new String('hello'),
-    new String(''),
-    new Boolean(true),
-    new Boolean(false),
-    new Date()
-    /*jshint +W053 */
-  ],
+export class TruthyGenerator extends AbstractGenerator {
 
   generate(value) {
     return {
-
       [`@test it should consider ${JSON.stringify(value)} truthy`]() {
         this.renderValues(value);
 
@@ -78,7 +71,7 @@ export const BASIC_TRUTHY_TESTS = {
 
         this.assertText('T1');
 
-        this.runTask(() => set(this.context, 'cond1', false));
+        this.runTask(() => set(this.context, 'cond1', this.falsyValue));
 
         this.assertText('F1');
 
@@ -86,28 +79,15 @@ export const BASIC_TRUTHY_TESTS = {
 
         this.assertText('T1');
       }
-
     };
   }
 
-};
+}
 
-export const BASIC_FALSY_TESTS = {
-
-  cases: [
-    false,
-    null,
-    undefined,
-    '',
-    0,
-    [],
-    emberA(),
-    EmberObject.create({ isTruthy: false })
-  ],
+export class FalsyGenerator extends AbstractGenerator {
 
   generate(value) {
-    let tests = {
-
+    return {
       [`@test it should consider ${JSON.stringify(value)} falsy`]() {
         this.renderValues(value);
 
@@ -117,7 +97,7 @@ export const BASIC_FALSY_TESTS = {
 
         this.assertText('F1');
 
-        this.runTask(() => set(this.context, 'cond1', true));
+        this.runTask(() => set(this.context, 'cond1', this.truthyValue));
 
         this.assertText('T1');
 
@@ -125,40 +105,124 @@ export const BASIC_FALSY_TESTS = {
 
         this.assertText('F1');
       }
-
     };
+  }
 
-    if (value !== false) {
-      // Only `{ isTruthy: false }` is falsy, `{ isTruthy: null }` etc are not
+}
 
-      tests[`@test it should consider { isTruthy: ${JSON.stringify(value)} } truthy`] = function() {
-        this.renderValues({ isTruthy: value });
+export class StableTruthyGenerator extends TruthyGenerator {
+
+  generate(value) {
+    return assign(super.generate(value), {
+      [`@test it maintains DOM stability when condition changes from ${value} to another truthy value and back`]() {
+        this.renderValues(value);
 
         this.assertText('T1');
 
-        this.runTask(() => this.rerender());
+        this.takeSnapshot();
+
+        this.runTask(() => set(this.context, 'cond1', this.truthyValue));
 
         this.assertText('T1');
 
-        this.runTask(() => set(this.context, 'cond1.isTruthy', false));
+        this.assertInvariants();
+
+        this.runTask(() => set(this.context, 'cond1', value));
+
+        this.assertText('T1');
+
+        this.assertInvariants();
+      }
+    });
+  }
+
+}
+
+export class StableFalsyGenerator extends FalsyGenerator {
+
+  generate(value) {
+    return assign(super.generate(value), {
+      [`@test it maintains DOM stability when condition changes from ${value} to another falsy value and back`]() {
+        this.renderValues(value);
 
         this.assertText('F1');
 
-        this.runTask(() => set(this.context, 'cond1', { isTruthy: value }));
+        this.takeSnapshot();
 
-        this.assertText('T1');
+        this.runTask(() => set(this.context, 'cond1', this.falsyValue));
+
+        this.assertText('F1');
+
+        this.assertInvariants();
+
+        this.runTask(() => set(this.context, 'cond1', value));
+
+        this.assertText('F1');
+
+        this.assertInvariants();
+      }
+    });
+  }
+
+}
+
+class IsTruthyGenerator extends AbstractGenerator {
+
+  generate(value) {
+    // Only `{ isTruthy: false }` is falsy, anything else is considered truthy,
+    // including `{ isTruthy: undefined }`, `{ isTruthy: null }`, etc
+
+    if (value === false) {
+      return {
+        [`@test it should consider { isTruthy: false } falsy`]() {
+          this.renderValues({ isTruthy: false });
+
+          this.assertText('F1');
+
+          this.runTask(() => this.rerender());
+
+          this.assertText('F1');
+
+          this.runTask(() => set(this.context, 'cond1.isTruthy', this.truthyValue));
+
+          this.assertText('T1');
+
+          this.runTask(() => set(this.context, 'cond1', { isTruthy: false }));
+
+          this.assertText('F1');
+        }
+      };
+    } else {
+      return {
+        [`@test it should consider { isTruthy: ${JSON.stringify(value)} } truthy`]() {
+          this.renderValues({ isTruthy: value });
+
+          this.assertText('T1');
+
+          this.runTask(() => this.rerender());
+
+          this.assertText('T1');
+
+          this.runTask(() => set(this.context, 'cond1.isTruthy', this.falsyValue));
+
+          this.assertText('F1');
+
+          this.runTask(() => set(this.context, 'cond1', { isTruthy: value }));
+
+          this.assertText('T1');
+        }
       };
     }
-
-    return tests;
   }
 
-};
+}
 
-export class SharedConditionalsTest extends AbstractConditionalsTest {
+// Testing behaviors shared across all conditionals, i.e. {{#if}}, {{#unless}},
+// {{#with}}, {{#each}}, {{#each-in}}, (if) and (unless)
+export class BasicConditionalsTest extends AbstractConditionalsTest {
 
   ['@test it renders the corresponding block based on the conditional']() {
-    this.renderValues(true, false);
+    this.renderValues(this.truthyValue, this.falsyValue);
 
     this.assertText('T1F2');
 
@@ -166,27 +230,32 @@ export class SharedConditionalsTest extends AbstractConditionalsTest {
 
     this.assertText('T1F2');
 
-    this.runTask(() => set(this.context, 'cond1', false));
+    this.runTask(() => set(this.context, 'cond1', this.falsyValue));
 
     this.assertText('F1F2');
 
     this.runTask(() => {
-      set(this.context, 'cond1', true);
-      set(this.context, 'cond2', true);
+      set(this.context, 'cond1', this.truthyValue);
+      set(this.context, 'cond2', this.truthyValue);
     });
 
     this.assertText('T1T2');
 
     this.runTask(() => {
-      set(this.context, 'cond1', true);
-      set(this.context, 'cond2', false);
+      set(this.context, 'cond1', this.truthyValue);
+      set(this.context, 'cond2', this.falsyValue);
     });
 
     this.assertText('T1F2');
   }
+
+}
+
+// Testing behaviors related to objects, object proxies, `{ isTruthy: (true|false) }`, etc
+export const ObjectTestCases = {
 
   ['@test it tests for `isTruthy` if available']() {
-    this.renderValues({ isTruthy: true }, { isTruthy: false });
+    this.renderValues({ isTruthy: this.truthyValue }, { isTruthy: this.falsyValue });
 
     this.assertText('T1F2');
 
@@ -194,29 +263,29 @@ export class SharedConditionalsTest extends AbstractConditionalsTest {
 
     this.assertText('T1F2');
 
-    this.runTask(() => set(this.context, 'cond1.isTruthy', false));
+    this.runTask(() => set(this.context, 'cond1.isTruthy', this.falsyValue));
 
     this.assertText('F1F2');
 
     this.runTask(() => {
-      set(this.context, 'cond1.isTruthy', true);
-      set(this.context, 'cond2.isTruthy', true);
+      set(this.context, 'cond1.isTruthy', this.truthyValue);
+      set(this.context, 'cond2.isTruthy', this.truthyValue);
     });
 
     this.assertText('T1T2');
 
     this.runTask(() => {
-      set(this.context, 'cond1', { isTruthy: true });
-      set(this.context, 'cond2', { isTruthy: false });
+      set(this.context, 'cond1', { isTruthy: this.truthyValue });
+      set(this.context, 'cond2', { isTruthy: this.falsyValue });
     });
 
     this.assertText('T1F2');
-  }
+  },
 
   ['@test it tests for `isTruthy` on Ember objects if available']() {
     this.renderValues(
-      EmberObject.create({ isTruthy: true }),
-      EmberObject.create({ isTruthy: false })
+      EmberObject.create({ isTruthy: this.truthyValue }),
+      EmberObject.create({ isTruthy: this.falsyValue })
     );
 
     this.assertText('T1F2');
@@ -225,55 +294,24 @@ export class SharedConditionalsTest extends AbstractConditionalsTest {
 
     this.assertText('T1F2');
 
-    this.runTask(() => set(this.context, 'cond1.isTruthy', false));
+    this.runTask(() => set(this.context, 'cond1.isTruthy', this.falsyValue));
 
     this.assertText('F1F2');
 
     this.runTask(() => {
-      set(this.context, 'cond1.isTruthy', true);
-      set(this.context, 'cond2.isTruthy', true);
+      set(this.context, 'cond1.isTruthy', this.truthyValue);
+      set(this.context, 'cond2.isTruthy', this.truthyValue);
     });
 
     this.assertText('T1T2');
 
     this.runTask(() => {
-      set(this.context, 'cond1', EmberObject.create({ isTruthy: true }));
-      set(this.context, 'cond2', EmberObject.create({ isTruthy: false }));
+      set(this.context, 'cond1', EmberObject.create({ isTruthy: this.truthyValue }));
+      set(this.context, 'cond2', EmberObject.create({ isTruthy: this.falsyValue }));
     });
 
     this.assertText('T1F2');
-  }
-
-  ['@test it considers empty arrays falsy']() {
-    this.renderValues(
-      emberA(['hello']),
-      emberA()
-    );
-
-    this.assertText('T1F2');
-
-    this.runTask(() => this.rerender());
-
-    this.assertText('T1F2');
-
-    this.runTask(() => get(this.context, 'cond1').removeAt(0));
-
-    this.assertText('F1F2');
-
-    this.runTask(() => {
-      get(this.context, 'cond1').pushObject('hello');
-      get(this.context, 'cond2').pushObjects([1, 2, 3]);
-    });
-
-    this.assertText('T1T2');
-
-    this.runTask(() => {
-      set(this.context, 'cond1', emberA(['hello']));
-      set(this.context, 'cond2', emberA());
-    });
-
-    this.assertText('T1F2');
-  }
+  },
 
   ['@test it considers object proxies without content falsy']() {
     this.renderValues(
@@ -312,6 +350,42 @@ export class SharedConditionalsTest extends AbstractConditionalsTest {
     this.assertText('T1T2F3');
   }
 
+};
+
+// Testing behaviors related to arrays and array proxies
+export const ArrayTestCases = {
+
+  ['@test it considers empty arrays falsy']() {
+    this.renderValues(
+      emberA(['hello']),
+      emberA()
+    );
+
+    this.assertText('T1F2');
+
+    this.runTask(() => this.rerender());
+
+    this.assertText('T1F2');
+
+    this.runTask(() => get(this.context, 'cond1').removeAt(0));
+
+    this.assertText('F1F2');
+
+    this.runTask(() => {
+      get(this.context, 'cond1').pushObject('hello');
+      get(this.context, 'cond2').pushObjects([1]);
+    });
+
+    this.assertText('T1T2');
+
+    this.runTask(() => {
+      set(this.context, 'cond1', emberA(['hello']));
+      set(this.context, 'cond2', emberA());
+    });
+
+    this.assertText('T1F2');
+  },
+
   ['@test it considers array proxies without content falsy']() {
     this.renderValues(
       ArrayProxy.create({ content: emberA(['hello']) }),
@@ -333,7 +407,7 @@ export class SharedConditionalsTest extends AbstractConditionalsTest {
 
     this.runTask(() => {
       set(this.context, 'cond1.content', emberA(['hello']));
-      set(this.context, 'cond2.content', emberA([1, 2, 3]));
+      set(this.context, 'cond2.content', emberA([1]));
     });
 
     this.assertText('T1T2');
@@ -344,7 +418,7 @@ export class SharedConditionalsTest extends AbstractConditionalsTest {
     });
 
     this.assertText('T1F2');
-  }
+  },
 
   ['@test it considers array proxies with empty arrays falsy']() {
     this.renderValues(
@@ -364,7 +438,7 @@ export class SharedConditionalsTest extends AbstractConditionalsTest {
 
     this.runTask(() => {
       get(this.context, 'cond1.content').pushObject('hello');
-      get(this.context, 'cond2.content').pushObjects([1, 2, 3]);
+      get(this.context, 'cond2.content').pushObjects([1]);
     });
 
     this.assertText('T1T2');
@@ -377,37 +451,89 @@ export class SharedConditionalsTest extends AbstractConditionalsTest {
     this.assertText('T1F2');
   }
 
-  ['@test it maintains DOM stability when condition changes from a truthy to a different truthy value']() {
-    this.renderValues(true);
+};
 
-    this.assertText('T1');
+// Testing behaviors shared across the "toggling" conditionals, i.e. {{#if}},
+// {{#unless}}, {{#with}}, (if) and (unless)
+export class TogglingConditionalsTest extends BasicConditionalsTest {}
 
-    this.takeSnapshot();
+applyMixins(TogglingConditionalsTest,
 
-    this.runTask(() => set(this.context, 'cond1', 'hello'));
+  new StableTruthyGenerator([
+    true,
+    ' ',
+    'hello',
+    'false',
+    'null',
+    'undefined',
+    1,
+    ['hello'],
+    emberA(['hello']),
+    {},
+    { foo: 'bar' },
+    EmberObject.create(),
+    EmberObject.create({ foo: 'bar' }),
+    EmberObject.create({ isTruthy: true }),
+    /*jshint -W053 */
+    new String('hello'),
+    new String(''),
+    new Boolean(true),
+    new Boolean(false),
+    /*jshint +W053 */
+    new Date()
+  ]),
 
-    this.assertText('T1');
+  new StableFalsyGenerator([
+    false,
+    null,
+    undefined,
+    '',
+    0,
+    [],
+    emberA(),
+    EmberObject.create({ isTruthy: false })
+  ]),
 
-    this.assertInvariants();
-  }
+  new IsTruthyGenerator([
+    true,
+    ' ',
+    'hello',
+    'false',
+    'null',
+    'undefined',
+    1,
+    ['hello'],
+    emberA(['hello']),
+    {},
+    { foo: 'bar' },
+    EmberObject.create(),
+    EmberObject.create({ foo: 'bar' }),
+    EmberObject.create({ isTruthy: true }),
+    /*jshint -W053 */
+    new String('hello'),
+    new String(''),
+    new Boolean(true),
+    new Boolean(false),
+    /*jshint +W053 */
+    new Date(),
+    false,
+    null,
+    undefined,
+    '',
+    0,
+    [],
+    emberA(),
+    EmberObject.create({ isTruthy: false })
+  ]),
 
-  ['@test it maintains DOM stability when condition changes from a falsy to a different falsy value']() {
-    this.renderValues(false);
+  ObjectTestCases,
 
-    this.assertText('F1');
+  ArrayTestCases
 
-    this.takeSnapshot();
+);
 
-    this.runTask(() => set(this.context, 'cond1', ''));
-
-    this.assertText('F1');
-
-    this.assertInvariants();
-  }
-
-}
-
-export class SharedHelperConditionalsTest extends SharedConditionalsTest {
+// Testing behaviors shared across the (if) and (unless) helpers
+export class TogglingHelperConditionalsTest extends TogglingConditionalsTest {
 
   renderValues(...values) {
     let templates = [];
@@ -431,7 +557,7 @@ export class SharedHelperConditionalsTest extends SharedConditionalsTest {
       this.wrappedTemplateFor({ cond: '(unbound cond2)', truthy: '"T2"', falsy: '"F2"' })
     }`;
 
-    this.render(template, { cond1: true, cond2: false });
+    this.render(template, { cond1: this.truthyValue, cond2: this.falsyValue });
 
     this.assertText('T1F2');
 
@@ -439,20 +565,20 @@ export class SharedHelperConditionalsTest extends SharedConditionalsTest {
 
     this.assertText('T1F2');
 
-    this.runTask(() => set(this.context, 'cond1', false));
+    this.runTask(() => set(this.context, 'cond1', this.falsyValue));
 
     this.assertText('T1F2');
 
     this.runTask(() => {
-      set(this.context, 'cond1', true);
-      set(this.context, 'cond2', true);
+      set(this.context, 'cond1', this.truthyValue);
+      set(this.context, 'cond2', this.truthyValue);
     });
 
     this.assertText('T1F2');
 
     this.runTask(() => {
-      set(this.context, 'cond1', true);
-      set(this.context, 'cond2', false);
+      set(this.context, 'cond1', this.truthyValue);
+      set(this.context, 'cond2', this.falsyValue);
     });
 
     this.assertText('T1F2');
@@ -461,7 +587,7 @@ export class SharedHelperConditionalsTest extends SharedConditionalsTest {
   ['@test it tests for `isTruthy` on the context if available']() {
     let template = this.wrappedTemplateFor({ cond: 'this', truthy: '"T1"', falsy: '"F1"' });
 
-    this.render(template, { isTruthy: true });
+    this.render(template, { isTruthy: this.truthyValue });
 
     this.assertText('T1');
 
@@ -469,18 +595,18 @@ export class SharedHelperConditionalsTest extends SharedConditionalsTest {
 
     this.assertText('T1');
 
-    this.runTask(() => set(this.context, 'isTruthy', false));
+    this.runTask(() => set(this.context, 'isTruthy', this.falsyValue));
 
     this.assertText('F1');
 
-    this.runTask(() => set(this.context, 'isTruthy', true));
+    this.runTask(() => set(this.context, 'isTruthy', this.truthyValue));
 
     this.assertText('T1');
   }
 
 }
 
-export class SharedSyntaxConditionalsTest extends SharedConditionalsTest {
+export const SyntaxCondtionalTestHelpers = {
 
   renderValues(...values) {
     let templates = [];
@@ -495,6 +621,12 @@ export class SharedSyntaxConditionalsTest extends SharedConditionalsTest {
     this.render(wrappedTemplate, assign({ t: 'T', f: 'F' }, context));
   }
 
+};
+
+// Testing behaviors shared across the "toggling" syntatical constructs,
+// i.e. {{#if}}, {{#unless}} and {{#with}}
+export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
+
   ['@htmlbars it does not update when the unbound helper is used']() {
     let template = `${
       this.templateFor({ cond: '(unbound cond1)', truthy: 'T1', falsy: 'F1' })
@@ -502,7 +634,7 @@ export class SharedSyntaxConditionalsTest extends SharedConditionalsTest {
       this.templateFor({ cond: '(unbound cond2)', truthy: 'T2', falsy: 'F2' })
     }`;
 
-    this.render(template, { cond1: true, cond2: false });
+    this.render(template, { cond1: true, cond2: this.falsyValue });
 
     this.assertText('T1F2');
 
@@ -510,20 +642,20 @@ export class SharedSyntaxConditionalsTest extends SharedConditionalsTest {
 
     this.assertText('T1F2');
 
-    this.runTask(() => set(this.context, 'cond1', false));
+    this.runTask(() => set(this.context, 'cond1', this.falsyValue));
 
     this.assertText('T1F2');
 
     this.runTask(() => {
-      set(this.context, 'cond1', true);
-      set(this.context, 'cond2', true);
+      set(this.context, 'cond1', this.truthyValue);
+      set(this.context, 'cond2', this.truthyValue);
     });
 
     this.assertText('T1F2');
 
     this.runTask(() => {
-      set(this.context, 'cond1', true);
-      set(this.context, 'cond2', false);
+      set(this.context, 'cond1', this.truthyValue);
+      set(this.context, 'cond2', this.falsyValue);
     });
 
     this.assertText('T1F2');
@@ -532,7 +664,7 @@ export class SharedSyntaxConditionalsTest extends SharedConditionalsTest {
   ['@test it tests for `isTruthy` on the context if available']() {
     let template = this.wrappedTemplateFor({ cond: 'this', truthy: 'T1', falsy: 'F1' });
 
-    this.render(template, { isTruthy: true });
+    this.render(template, { isTruthy: this.truthyValue });
 
     this.assertText('T1');
 
@@ -540,11 +672,11 @@ export class SharedSyntaxConditionalsTest extends SharedConditionalsTest {
 
     this.assertText('T1');
 
-    this.runTask(() => set(this.context, 'isTruthy', false));
+    this.runTask(() => set(this.context, 'isTruthy', this.falsyValue));
 
     this.assertText('F1');
 
-    this.runTask(() => set(this.context, 'isTruthy', true));
+    this.runTask(() => set(this.context, 'isTruthy', this.truthyValue));
 
     this.assertText('T1');
   }
@@ -553,7 +685,7 @@ export class SharedSyntaxConditionalsTest extends SharedConditionalsTest {
     // This tests whether the outer conditional tracks its bounds correctly as its inner bounds changes
     let template = this.wrappedTemplateFor({ cond: 'outer', truthy: '{{#if inner}}T-inner{{else}}F-inner{{/if}}', falsy: 'F-outer' });
 
-    this.render(template, { outer: true, inner: true });
+    this.render(template, { outer: this.truthyValue, inner: this.truthyValue });
 
     this.assertText('T-inner');
 
@@ -562,12 +694,12 @@ export class SharedSyntaxConditionalsTest extends SharedConditionalsTest {
     this.assertText('T-inner');
 
     // Changes the inner bounds
-    this.runTask(() => set(this.context, 'inner', false));
+    this.runTask(() => set(this.context, 'inner', this.falsyValue));
 
     this.assertText('F-inner');
 
     // Now rerender the outer conditional, which require first clearing its bounds
-    this.runTask(() => set(this.context, 'outer', false));
+    this.runTask(() => set(this.context, 'outer', this.falsyValue));
 
     this.assertText('F-outer');
   }
@@ -576,7 +708,7 @@ export class SharedSyntaxConditionalsTest extends SharedConditionalsTest {
     // This tests whether the outer conditional tracks its bounds correctly as its inner bounds changes
     let template = this.wrappedTemplateFor({ cond: 'outer', truthy: '{{#each inner as |text|}}{{text}}{{/each}}', falsy: 'F-outer' });
 
-    this.render(template, { outer: true, inner: ['inner', '-', 'before'] });
+    this.render(template, { outer: this.truthyValue, inner: ['inner', '-', 'before'] });
 
     this.assertText('inner-before');
 
@@ -590,14 +722,14 @@ export class SharedSyntaxConditionalsTest extends SharedConditionalsTest {
     this.assertText('inner-after');
 
     // Now rerender the outer conditional, which require first clearing its bounds
-    this.runTask(() => set(this.context, 'outer', false));
+    this.runTask(() => set(this.context, 'outer', this.falsyValue));
 
     this.assertText('F-outer');
 
     // Reset
     this.runTask(() => {
       set(this.context, 'inner', ['inner-again']);
-      set(this.context, 'outer', true);
+      set(this.context, 'outer', this.truthyValue);
     });
 
     this.assertText('inner-again');
@@ -608,7 +740,7 @@ export class SharedSyntaxConditionalsTest extends SharedConditionalsTest {
     this.assertText('');
 
     // Now rerender the outer conditional, which require first clearing its bounds
-    this.runTask(() => set(this.context, 'outer', false));
+    this.runTask(() => set(this.context, 'outer', this.falsyValue));
 
     this.assertText('F-outer');
   }
@@ -617,7 +749,7 @@ export class SharedSyntaxConditionalsTest extends SharedConditionalsTest {
     // This tests whether the outer conditional tracks its bounds correctly as its inner bounds changes
     let template = this.wrappedTemplateFor({ cond: 'outer', truthy: '{{{inner}}}', falsy: 'F-outer' });
 
-    this.render(template, { outer: true, inner: '<b>inner</b>-<b>before</b>' });
+    this.render(template, { outer: this.truthyValue, inner: '<b>inner</b>-<b>before</b>' });
 
     this.assertText('inner-before');
 
@@ -631,9 +763,11 @@ export class SharedSyntaxConditionalsTest extends SharedConditionalsTest {
     this.assertText('inner-after');
 
     // Now rerender the outer conditional, which require first clearing its bounds
-    this.runTask(() => set(this.context, 'outer', false));
+    this.runTask(() => set(this.context, 'outer', this.falsyValue));
 
     this.assertText('F-outer');
   }
 
 }
+
+applyMixins(TogglingSyntaxConditionalsTest, SyntaxCondtionalTestHelpers);


### PR DESCRIPTION
- Extract the apply “generators” logic into a more generic function which allows us to pre-mix the `BASIC_*_TESTS` into a super class, instead of having to repeat that every time you call `moduleFor`.
- Extend the “generators” concept to a more generic (very basic) mixin system, which allows us to separate the test cases into groups.
- Instead of hard coding `true` and `false` inside the test cases, go through a getter that can be overridden by the subclasses.
- Restructure the conditionals test classes to achieve better layering.
- Test `{{#if}}/{{#unless}}` without inverse as a “matrix item” instead of a single test case which should give us better coverage. (The trick is to generate them as a pair in `templateFor`.)

Most of these work is to make it possible to reuse the basic test cases for `{{#each}}` tests, which will come in a different PR. This is needed because `{{#each}}` has different rules about truthiness than the “toggling” conditional constructs.

/cc @GavinJoyce @chadhietala @rwjblue 
