### PR TITLE
Implement Ember semantics for Glimmer {{#each}}

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "express": "^4.5.0",
     "finalhandler": "^0.4.0",
     "github": "^0.2.3",
-    "glimmer-engine": "tildeio/glimmer#4c2b632",
+    "glimmer-engine": "tildeio/glimmer#2910a5b",
     "glob": "~4.3.2",
     "htmlbars": "0.14.14",
     "qunit-extras": "^1.4.0",

--- a/packages/ember-glimmer/lib/ember-metal-views/index.js
+++ b/packages/ember-glimmer/lib/ember-metal-views/index.js
@@ -1,4 +1,4 @@
-import { RootReference } from '../environment';
+import { RootReference } from '../utils/references';
 
 export class Renderer {
   constructor(domHelper, { destinedForDOM, env } = {}) {

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -1,54 +1,9 @@
-import { Environment, ConditionalReference } from 'glimmer-runtime';
-import { get } from 'ember-metal/property_get';
+import { Environment } from 'glimmer-runtime';
 import Dict from 'ember-metal/empty_object';
-import { toBool as emberToBool } from './helpers/if-unless';
 import { CurlyComponentSyntax, CurlyComponentDefinition } from './components/curly-component';
 import lookupComponent from './utils/lookup-component';
-
-// @implements PathReference
-export class RootReference {
-  constructor(value) {
-    this._value = value;
-  }
-
-  value() {
-    return this._value;
-  }
-
-  isDirty() {
-    return true;
-  }
-
-  get(propertyKey) {
-    return new PropertyReference(this, propertyKey);
-  }
-
-  destroy() {
-  }
-}
-
-// @implements PathReference
-class PropertyReference {
-  constructor(parentReference, propertyKey) {
-    this._parentReference = parentReference;
-    this._propertyKey = propertyKey;
-  }
-
-  value() {
-    return get(this._parentReference.value(), this._propertyKey);
-  }
-
-  isDirty() {
-    return true;
-  }
-
-  get(propertyKey) {
-    return new PropertyReference(this, propertyKey);
-  }
-
-  destroy() {
-  }
-}
+import createIterable from './utils/iterable';
+import { RootReference, ConditionalReference } from './utils/references';
 
 import { default as concat } from './helpers/concat';
 import { default as inlineIf } from './helpers/inline-if';
@@ -57,12 +12,6 @@ const helpers = {
   concat,
   if: inlineIf
 };
-
-class EmberConditionalReference extends ConditionalReference {
-  toBool(predicate) {
-    return emberToBool(predicate);
-  }
-}
 
 const VIEW_KEYWORD = 'view'; // legacy ? 'view' : symbol('view');
 const KEYWORDS = [VIEW_KEYWORD];
@@ -147,6 +96,11 @@ export default class extends Environment {
   }
 
   toConditionalReference(reference) {
-    return new EmberConditionalReference(reference);
+    return new ConditionalReference(reference);
+  }
+
+  iterableFor(ref, args) {
+    let keyPath = args.named.get('key').value();
+    return createIterable(ref, keyPath);
   }
 }

--- a/packages/ember-glimmer/lib/utils/iterable.js
+++ b/packages/ember-glimmer/lib/utils/iterable.js
@@ -1,0 +1,130 @@
+import { get } from 'ember-metal/property_get';
+import { guidFor } from 'ember-metal/utils';
+import { objectAt, isEmberArray } from 'ember-runtime/mixins/array';
+import { UpdatableReference } from './references';
+
+export default function iterableFor(ref, keyPath) {
+  return new Iterable(ref, keyFor(keyPath));
+}
+
+function keyFor(keyPath) {
+  switch (keyPath) {
+    case '@index':
+      return index;
+    case '@identity':
+    case undefined:
+    case null:
+      return identity;
+    default:
+      return (item) => get(item, keyPath);
+  }
+}
+
+function index(item, index) {
+  return String(index);
+}
+
+function identity(item) {
+  switch (typeof item) {
+    case 'string':
+    case 'number':
+      return String(item);
+    default:
+      return guidFor(item);
+  }
+}
+
+class ArrayIterator {
+  constructor(array, keyFor) {
+    this.array = array;
+    this.length = array.length;
+    this.keyFor = keyFor;
+    this.position = 0;
+  }
+
+  isEmpty() {
+    return false;
+  }
+
+  next() {
+    let { array, length, keyFor, position } = this;
+
+    if (position >= length) { return null; }
+
+    let value = array[position];
+    let key = keyFor(value, position);
+
+    this.position++;
+
+    return { key, value };
+  }
+}
+
+class EmberArrayIterator {
+  constructor(array, keyFor) {
+    this.array = array;
+    this.length = get(array, 'length');
+    this.keyFor = keyFor;
+    this.position = 0;
+  }
+
+  isEmpty() {
+    return this.length === 0;
+  }
+
+  next() {
+    let { array, length, keyFor, position } = this;
+
+    if (position >= length) { return null; }
+
+    let value = objectAt(array, position);
+    let key = keyFor(value, position);
+
+    this.position++;
+
+    return { key, value };
+  }
+}
+
+class EmptyIterator {
+  isEmpty() {
+    return true;
+  }
+
+  next() {
+    throw new Error('Cannot call next() on an empty iterator');
+  }
+}
+
+const EMPTY_ITERATOR = new EmptyIterator();
+
+class Iterable {
+  constructor(ref, keyFor) {
+    this.ref = ref;
+    this.keyFor = keyFor;
+  }
+
+  iterate() {
+    let { ref, keyFor } = this;
+
+    let iterable = ref.value();
+
+    if (iterable === undefined || iterable === null) {
+      return EMPTY_ITERATOR;
+    } else if (Array.isArray(iterable)) {
+      return iterable.length > 0 ? new ArrayIterator(iterable, keyFor) : EMPTY_ITERATOR;
+    } else if (isEmberArray(iterable)) {
+      return new EmberArrayIterator(iterable, keyFor);
+    } else {
+      throw new Error(`Don't know how to {{#each ${iterable}}}`);
+    }
+  }
+
+  referenceFor(item) {
+    return new UpdatableReference(item.value);
+  }
+
+  updateReference(reference, item) {
+    reference.update(item.value);
+  }
+}

--- a/packages/ember-glimmer/lib/utils/references.js
+++ b/packages/ember-glimmer/lib/utils/references.js
@@ -1,0 +1,61 @@
+import { get } from 'ember-metal/property_get';
+import { ConditionalReference as GlimmerConditionalReference } from 'glimmer-runtime';
+import { toBool as emberToBool } from '../helpers/if-unless';
+
+// @implements PathReference
+export class RootReference {
+  constructor(value) {
+    this._value = value;
+  }
+
+  value() {
+    return this._value;
+  }
+
+  isDirty() {
+    return true;
+  }
+
+  get(propertyKey) {
+    return new PropertyReference(this, propertyKey);
+  }
+
+  destroy() {
+  }
+}
+
+// @implements PathReference
+class PropertyReference {
+  constructor(parentReference, propertyKey) {
+    this._parentReference = parentReference;
+    this._propertyKey = propertyKey;
+  }
+
+  value() {
+    return get(this._parentReference.value(), this._propertyKey);
+  }
+
+  isDirty() {
+    return true;
+  }
+
+  get(propertyKey) {
+    return new PropertyReference(this, propertyKey);
+  }
+
+  destroy() {
+  }
+}
+
+// @implements PathReference
+export class UpdatableReference extends RootReference {
+  update(value) {
+    this._value = value;
+  }
+}
+
+export class ConditionalReference extends GlimmerConditionalReference {
+  toBool(predicate) {
+    return emberToBool(predicate);
+  }
+}

--- a/packages/ember-glimmer/tests/integration/syntax/each-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/each-test.js
@@ -1,0 +1,378 @@
+import { applyMixins } from '../../utils/abstract-test-case';
+import { moduleFor } from '../../utils/test-case';
+import { set } from 'ember-metal/property_set';
+import { A as emberA } from 'ember-runtime/system/native_array';
+import {
+  BasicConditionalsTest,
+  SyntaxCondtionalTestHelpers,
+  TruthyGenerator,
+  FalsyGenerator,
+  ArrayTestCases
+} from '../../utils/shared-conditional-tests';
+// import { RenderingTest } from '../../utils/test-case';
+
+class EachTest extends BasicConditionalsTest {
+
+  get truthyValue() { return ['non-empty']; }
+  get falsyValue() { return []; }
+
+}
+
+applyMixins(EachTest,
+
+  SyntaxCondtionalTestHelpers,
+
+  new TruthyGenerator([
+    // TODO: figure out what the rest of the cases are
+    ['hello']
+  ]),
+
+  new FalsyGenerator([
+    // TODO: figure out what the rest of the cases are
+    [],
+    undefined
+  ]),
+
+  ArrayTestCases
+
+);
+
+moduleFor('@glimmer Syntax test: {{#each}}', class extends EachTest {
+
+  templateFor({ cond, truthy, falsy }) {
+    return `{{#each ${cond}}}${truthy}{{else}}${falsy}{{/each}}`;
+  }
+
+});
+
+moduleFor('@glimmer Syntax test: {{#each as}}', class extends EachTest {
+
+  templateFor({ cond, truthy, falsy }) {
+    return `{{#each ${cond} as |test|}}${truthy}{{else}}${falsy}{{/each}}`;
+  }
+
+  ['@test it repeats the given block for each item in the array']() {
+    this.render(`{{#each list as |item|}}{{item.text}}{{else}}Empty{{/each}}`, {
+      list: emberA([{ text: 'hello' }])
+    });
+
+    this.assertText('hello');
+
+    this.runTask(() => this.rerender());
+
+    this.assertText('hello');
+
+    this.runTask(() => set(this.context.get('list').objectAt(0), 'text', 'Hello'));
+
+    this.assertText('Hello');
+
+    this.runTask(() => {
+      let list = this.context.get('list');
+      list.pushObject({ text: ' ' });
+      list.pushObject({ text: 'world' });
+    });
+
+    this.assertText('Hello world');
+
+    this.runTask(() => this.context.get('list').clear());
+
+    this.assertText('Empty');
+
+    this.runTask(() => set(this.context, 'list', [{ text: 'hello' }]));
+
+    this.assertText('hello');
+  }
+
+  [`@test it maintains DOM stability when condition changes between objects with the same keys`]() {
+    this.render(`{{#each list key="text" as |item|}}{{item.text}}{{/each}}`, {
+      list: emberA([{ text: 'Hello' }, { text: ' ' }, { text: 'world' }])
+    });
+
+    this.assertText('Hello world');
+
+    this.takeSnapshot();
+
+    this.runTask(() => {
+      let list = this.context.get('list');
+      list.popObject();
+      list.popObject();
+      list.pushObject({ text: ' ' });
+      list.pushObject({ text: 'world' });
+    });
+
+    this.assertText('Hello world');
+
+    this.assertInvariants();
+
+    this.runTask(() => set(this.context, 'list', [{ text: 'Hello' }, { text: ' ' }, { text: 'world' }]));
+
+    this.assertText('Hello world');
+
+    this.assertInvariants();
+  }
+
+  // TODO: these tests are copied from with-test.js, probably good to port them here
+
+  // ['@test can access alias and original scope']() {
+  //   this.render(`{{#with person as |tom|}}{{title}}: {{tom.name}}{{/with}}`, {
+  //     title: 'Señor Engineer',
+  //     person: { name: 'Tom Dale' }
+  //   });
+
+  //   this.assertText('Señor Engineer: Tom Dale');
+
+  //   this.runTask(() => this.rerender());
+
+  //   this.assertText('Señor Engineer: Tom Dale');
+
+  //   this.runTask(() => {
+  //     set(this.context, 'person.name', 'Yehuda Katz');
+  //     set(this.context, 'title', 'Principal Engineer');
+  //   });
+
+  //   this.assertText('Principal Engineer: Yehuda Katz');
+
+  //   this.runTask(() => {
+  //     set(this.context, 'person', { name: 'Tom Dale' });
+  //     set(this.context, 'title', 'Señor Engineer');
+  //   });
+
+  //   this.assertText('Señor Engineer: Tom Dale');
+  // }
+
+  // ['@test the scoped variable is not available outside the {{with}} block.']() {
+  //   this.render(`{{name}}-{{#with other as |name|}}{{name}}{{/with}}-{{name}}`, {
+  //     name: 'Stef',
+  //     other: 'Yehuda'
+  //   });
+
+  //   this.assertText('Stef-Yehuda-Stef');
+
+  //   this.runTask(() => this.rerender());
+
+  //   this.assertText('Stef-Yehuda-Stef');
+
+  //   this.runTask(() => set(this.context, 'other', 'Chad'));
+
+  //   this.assertText('Stef-Chad-Stef');
+
+  //   this.runTask(() => set(this.context, 'name', 'Tom'));
+
+  //   this.assertText('Tom-Chad-Tom');
+
+  //   this.runTask(() => {
+  //     set(this.context, 'name', 'Stef');
+  //     set(this.context, 'other', 'Yehuda');
+  //   });
+
+  //   this.assertText('Stef-Yehuda-Stef');
+  // }
+
+  // ['@test inverse template is displayed with context']() {
+  //   this.render(`{{#with falsyThing as |thing|}}Has Thing{{else}}No Thing {{otherThing}}{{/with}}`, {
+  //     falsyThing: null,
+  //     otherThing: 'bar'
+  //   });
+
+  //   this.assertText('No Thing bar');
+
+  //   this.runTask(() => this.rerender());
+
+  //   this.assertText('No Thing bar');
+
+  //   this.runTask(() => set(this.context, 'falsyThing', true));
+
+  //   this.assertText('Has Thing');
+
+  //   this.runTask(() => set(this.context, 'otherThing', 'biz'));
+
+  //   this.assertText('Has Thing');
+
+  //   this.runTask(() => {
+  //     set(this.context, 'otherThing', 'bar');
+  //     set(this.context, 'falsyThing', null);
+  //   });
+
+  //   this.assertText('No Thing bar');
+  // }
+
+  // ['@test can access alias of an array']() {
+  //   this.render(`{{#with arrayThing as |thing|}}{{#each thing as |value|}}{{value}}{{/each}}{{/with}}`, {
+  //     arrayThing: ['a', 'b', 'c', 'd']
+  //   });
+
+  //   this.assertText('abcd');
+
+  //   this.runTask(() => this.rerender());
+
+  //   this.assertText('abcd');
+  // }
+
+  // ['@test empty arrays yield inverse']() {
+  //   this.render(`{{#with arrayThing as |thing|}}{{thing}}{{else}}Empty Array{{/with}}`, {
+  //     arrayThing: []
+  //   });
+
+  //   this.assertText('Empty Array');
+
+  //   this.runTask(() => this.rerender());
+
+  //   this.assertText('Empty Array');
+  // }
+
+});
+
+// moduleFor('Syntax test: Multiple {{#with as}} helpers', class extends EachTest {
+//   ['@test re-using the same variable with different #with blocks does not override each other']() {
+//     this.render(`Admin: {{#with admin as |person|}}{{person.name}}{{/with}} User: {{#with user as |person|}}{{person.name}}{{/with}}`, {
+//       admin: { name: 'Tom Dale' },
+//       user: { name: 'Yehuda Katz' }
+//     });
+
+//     this.assertText('Admin: Tom Dale User: Yehuda Katz');
+
+//     this.runTask(() => this.rerender());
+
+//     this.assertText('Admin: Tom Dale User: Yehuda Katz');
+
+//     this.runTask(() => {
+//       set(this.context, 'admin.name', 'Godfrey Chan');
+//       set(this.context, 'user.name', 'Stefan Penner');
+//     });
+
+//     this.assertText('Admin: Godfrey Chan User: Stefan Penner');
+
+//     this.runTask(() => {
+//       set(this.context, 'admin', { name: 'Tom Dale' });
+//       set(this.context, 'user', { name: 'Yehuda Katz' });
+//     });
+
+//     this.assertText('Admin: Tom Dale User: Yehuda Katz');
+//   }
+
+//   ['@test re-using the same variable with different #with blocks does not override each other']() {
+//     this.render(`Admin: {{#with admin as |person|}}{{person.name}}{{/with}} User: {{#with user as |person|}}{{person.name}}{{/with}}`, {
+//       admin: { name: 'Tom Dale' },
+//       user: { name: 'Yehuda Katz' }
+//     });
+
+//     this.assertText('Admin: Tom Dale User: Yehuda Katz');
+
+//     this.runTask(() => this.rerender());
+
+//     this.assertText('Admin: Tom Dale User: Yehuda Katz');
+
+//     this.runTask(() => {
+//       set(this.context, 'admin.name', 'Erik Bryn');
+//       set(this.context, 'user.name', 'Chad Hietala');
+//     });
+
+//     this.assertText('Admin: Erik Bryn User: Chad Hietala');
+
+//     this.runTask(() => {
+//       set(this.context, 'admin', { name: 'Tom Dale' });
+//       set(this.context, 'user', { name: 'Yehuda Katz' });
+//     });
+
+//     this.assertText('Admin: Tom Dale User: Yehuda Katz');
+//   }
+
+//   ['@test the scoped variable is not available outside the {{with}} block.']() {
+//     this.render(`{{#with first as |ring|}}{{ring}}-{{#with fifth as |ring|}}{{ring}}-{{#with ninth as |ring|}}{{ring}}-{{/with}}{{ring}}-{{/with}}{{ring}}{{/with}}`, {
+//       first: 'Limbo',
+//       fifth: 'Wrath',
+//       ninth: 'Treachery'
+//     });
+
+//     this.assertText('Limbo-Wrath-Treachery-Wrath-Limbo');
+
+//     this.runTask(() => this.rerender());
+
+//     this.assertText('Limbo-Wrath-Treachery-Wrath-Limbo');
+
+//     this.runTask(() => {
+//       set(this.context, 'first', 'I');
+//       set(this.context, 'fifth', 'D');
+//       set(this.context, 'ninth', 'K');
+//     });
+
+//     this.assertText('I-D-K-D-I');
+
+//     this.runTask(() => {
+//       set(this.context, 'first', 'Limbo');
+//       set(this.context, 'fifth', 'Wrath');
+//       set(this.context, 'ninth', 'Treachery');
+//     });
+
+//     this.assertText('Limbo-Wrath-Treachery-Wrath-Limbo');
+//   }
+
+//   ['@test it should support #with name as |foo|, then #with foo as |bar|']() {
+//     this.render(`{{#with name as |foo|}}{{#with foo as |bar|}}{{bar}}{{/with}}{{/with}}`, {
+//       name: 'caterpillar'
+//     });
+
+//     this.assertText('caterpillar');
+
+//     this.runTask(() => this.rerender());
+
+//     this.assertText('caterpillar');
+
+//     this.runTask(() => set(this.context, 'name', 'butterfly'));
+
+//     this.assertText('butterfly');
+
+//     this.runTask(() => set(this.context, 'name', 'caterpillar'));
+
+//     this.assertText('caterpillar');
+//   }
+
+//   ['@test nested {{with}} blocks shadow the outer scoped variable properly.']() {
+//     this.render(`{{#with first as |ring|}}{{ring}}-{{#with fifth as |ring|}}{{ring}}-{{#with ninth as |ring|}}{{ring}}-{{/with}}{{ring}}-{{/with}}{{ring}}{{/with}}`, {
+//       first: 'Limbo',
+//       fifth: 'Wrath',
+//       ninth: 'Treachery'
+//     });
+
+//     this.assertText('Limbo-Wrath-Treachery-Wrath-Limbo');
+
+//     this.runTask(() => this.rerender());
+
+//     this.assertText('Limbo-Wrath-Treachery-Wrath-Limbo');
+
+//     this.runTask(() => {
+//       set(this.context, 'first', 'I');
+//       set(this.context, 'ninth', 'K');
+//     });
+
+//     this.assertText('I-Wrath-K-Wrath-I');
+
+//     this.runTask(() => {
+//       set(this.context, 'first', 'Limbo');
+//       set(this.context, 'fifth', 'Wrath');
+//       set(this.context, 'ninth', 'Treachery');
+//     });
+
+//     this.assertText('Limbo-Wrath-Treachery-Wrath-Limbo');
+//   }
+
+//   ['@test updating the context should update the alias']() {
+//     this.render(`{{#with this as |person|}}{{person.name}}{{/with}}`, {
+//       name: 'Los Pivots'
+//     });
+
+//     this.assertText('Los Pivots');
+
+//     this.runTask(() => this.rerender());
+
+//     this.assertText('Los Pivots');
+
+//     this.runTask(() => set(this.context, 'name', 'l\'Pivots'));
+
+//     this.assertText('l\'Pivots');
+
+//     this.runTask(() => set(this.context, 'name', 'Los Pivots'));
+
+//     this.assertText('Los Pivots');
+//   }
+// });

--- a/packages/ember-glimmer/tests/utils/shared-conditional-tests.js
+++ b/packages/ember-glimmer/tests/utils/shared-conditional-tests.js
@@ -681,7 +681,7 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
     this.assertText('T1');
   }
 
-  ['@htmlbars it updates correctly when enclosing another conditional']() {
+  ['@test it updates correctly when enclosing another conditional']() {
     // This tests whether the outer conditional tracks its bounds correctly as its inner bounds changes
     let template = this.wrappedTemplateFor({ cond: 'outer', truthy: '{{#if inner}}T-inner{{else}}F-inner{{/if}}', falsy: 'F-outer' });
 
@@ -704,7 +704,7 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
     this.assertText('F-outer');
   }
 
-  ['@htmlbars it updates correctly when enclosing #each']() {
+  ['@test it updates correctly when enclosing #each']() {
     // This tests whether the outer conditional tracks its bounds correctly as its inner bounds changes
     let template = this.wrappedTemplateFor({ cond: 'outer', truthy: '{{#each inner as |text|}}{{text}}{{/each}}', falsy: 'F-outer' });
 
@@ -745,7 +745,7 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
     this.assertText('F-outer');
   }
 
-  ['@htmlbars it updates correctly when enclosing triple-curlies']() {
+  ['@test it updates correctly when enclosing triple-curlies']() {
     // This tests whether the outer conditional tracks its bounds correctly as its inner bounds changes
     let template = this.wrappedTemplateFor({ cond: 'outer', truthy: '{{{inner}}}', falsy: 'F-outer' });
 

--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -8,6 +8,7 @@
 //
 import Ember from 'ember-metal/core'; // ES6TODO: Ember.A
 
+import symbol from 'ember-metal/symbol';
 import { get } from 'ember-metal/property_get';
 import {
   computed,
@@ -63,6 +64,12 @@ export function objectAt(content, idx) {
   return content[idx];
 }
 
+const EMBER_ARRAY = symbol('EMBER_ARRAY');
+
+export function isEmberArray(obj) {
+  return obj && !!obj[EMBER_ARRAY];
+}
+
 // ..........................................................
 // ARRAY
 //
@@ -104,6 +111,8 @@ export function objectAt(content, idx) {
   @public
 */
 export default Mixin.create(Enumerable, {
+
+  [EMBER_ARRAY]: true,
 
   /**
     __Required.__ You must implement this method to apply this mixin.


### PR DESCRIPTION
As usual, we only ported enough tests to test the system is working, and we need to finish porting the rest of the tests (we actually haven’t looked into the existing each tests yet – we just borrowed the `{{#with}}` tests as a starting point). However, since we are now sharing the same basic test cases from the conditionals test, we already covered a lot of ground from-the-get-go.
