### PR TITLE
[BUGFIX release] Fixes `{{#with proxy as |foo|}}`

### DIFF
--- a/packages/ember-glimmer/tests/integration/syntax/with-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/with-test.js
@@ -129,6 +129,34 @@ moduleFor('Syntax test: {{#with as}}', class extends TogglingSyntaxConditionalsT
     this.assertText('No Thing bar');
   }
 
+  ['@test can access alias of a proxy']() {
+    this.render(`{{#with proxyThing as |person|}}{{person.name}}{{/with}}`, {
+      proxyThing: { isTruthy: true, name: 'Tom Dale' }
+    });
+
+    this.assertText('Tom Dale');
+
+    this.runTask(() => this.rerender());
+
+    this.assertText('Tom Dale');
+
+    this.runTask(() => set(this.context, 'proxyThing.name', 'Yehuda Katz'));
+
+    this.assertText('Yehuda Katz');
+
+    this.runTask(() => set(this.context, 'proxyThing.isTruthy', false));
+
+    this.assertText('');
+
+    this.runTask(() => set(this.context, 'proxyThing.name', 'Godfrey Chan'));
+
+    this.assertText('');
+
+    this.runTask(() => set(this.context, 'proxyThing', { isTruthy: true, name: 'Tom Dale' }));
+
+    this.assertText('Tom Dale');
+  }
+
   ['@test can access alias of an array']() {
     this.render(`{{#with arrayThing as |words|}}{{#each words as |word|}}{{word}}{{/each}}{{/with}}`, {
       arrayThing: emberA(['Hello', ' ', 'world'])

--- a/packages/ember-htmlbars/lib/hooks/link-render-node.js
+++ b/packages/ember-htmlbars/lib/hooks/link-render-node.js
@@ -87,7 +87,7 @@ function shouldDisplay(predicate, coercer) {
     let isTruthyVal = read(isTruthy);
 
     if (isArray(predicateVal)) {
-      return lengthVal > 0 ? predicateVal : false;
+      return lengthVal > 0 ? coercer(predicateVal) : false;
     }
 
     if (typeof isTruthyVal === 'boolean') {

--- a/packages/ember-htmlbars/lib/hooks/link-render-node.js
+++ b/packages/ember-htmlbars/lib/hooks/link-render-node.js
@@ -91,7 +91,7 @@ function shouldDisplay(predicate, coercer) {
     }
 
     if (typeof isTruthyVal === 'boolean') {
-      return isTruthyVal;
+      return isTruthyVal ? coercer(predicateVal) : false;
     }
 
     return coercer(predicateVal);


### PR DESCRIPTION
This fixes an issue in HTMLBars where passing a truthy proxy (i.e. `{ isTruthy: true, ... }`) to `{{#with}}` would end up yielding the literal `true` rather than the proxy itself.

The Glimmer implementation is unaffected by this bug.

Fixes #13045
