### PR TITLE
updates getWithDefault to return default on `null` and `undefined`

### DIFF
--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -92,7 +92,7 @@ export function _getPath(root, path) {
 
 /**
   Retrieves the value of a property from an Object, or a default value in the
-  case that the property returns `undefined`.
+  case that the property returns `undefined` or `null`.
 
   ```javascript
   Ember.getWithDefault(person, 'lastName', 'Doe');
@@ -102,14 +102,14 @@ export function _getPath(root, path) {
   @for Ember
   @param {Object} obj The object to retrieve from.
   @param {String} keyName The name of the property to retrieve
-  @param {Object} defaultValue The value to return if the property value is undefined
+  @param {Object} defaultValue The value to return if the property value is undefined or null
   @return {Object} The property value or the defaultValue.
   @public
 */
 export function getWithDefault(root, key, defaultValue) {
   var value = get(root, key);
 
-  if (value === undefined) { return defaultValue; }
+  if (value == null) { return defaultValue; }
   return value;
 }
 

--- a/packages/ember-metal/tests/accessors/get_test.js
+++ b/packages/ember-metal/tests/accessors/get_test.js
@@ -155,11 +155,13 @@ QUnit.test('should get arbitrary properties on an object', function() {
   }
 
   obj = {
-    undef: undefined
+    undef: undefined,
+    nullValue: null
   };
 
   equal(getWithDefault(obj, 'undef', 'default'), 'default', 'explicit undefined retrieves the default');
   equal(getWithDefault(obj, 'not-present', 'default'), 'default', 'non-present key retrieves the default');
+  equal(getWithDefault(obj, 'nullValue', 'default'), 'default', 'explicit null retrieves the default');
 });
 
 QUnit.test('should call unknownProperty if defined and value is undefined', function() {


### PR DESCRIPTION
I noticed that `getWithDefault` only returns the default on missing keys or explicit `undefined` values. Is there a reason why we wouldn't want this method to work with `null` values too?
