### PR TITLE
[BUGFIX release-1-13] use `read` in action helper

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,6 @@
 {
     "predef": [
+        "-Promise",
         "QUnit",
         "define",
         "console",

--- a/packages/ember-htmlbars/tests/attr_nodes/sanitized_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/sanitized_test.js
@@ -58,6 +58,7 @@ var badTags = [
     multipartTemplate: compile("<iframe src='{{protocol}}{{path}}'></iframe>") }
 ];
 
+/*jshint loopfunc: true */
 for (var i=0, l=badTags.length; i<l; i++) {
   (function() {
     var subject = badTags[i];

--- a/packages/ember-routing-htmlbars/lib/keywords/element-action.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/element-action.js
@@ -2,6 +2,7 @@ import Ember from "ember-metal/core"; // assert
 import { uuid } from "ember-metal/utils";
 import run from "ember-metal/run_loop";
 import { readUnwrappedModel } from "ember-views/streams/utils";
+import { read } from 'ember-metal/streams/utils';
 import { isSimpleClick } from "ember-views/system/utils";
 import ActionManager from "ember-views/system/action_manager";
 
@@ -14,7 +15,6 @@ function assert(message, test) {
 export default {
   setupState: function(state, env, scope, params, hash) {
     var getStream = env.hooks.get;
-    var read = env.hooks.getValue;
 
     var actionName = read(params[0]);
 
@@ -62,7 +62,6 @@ export default {
       eventName: hash.on || "click",
       bubbles: hash.bubbles,
       preventDefault: hash.preventDefault,
-      withKeyCode: hash.withKeyCode,
       allowedKeys: hash.allowedKeys
     });
 
@@ -88,17 +87,17 @@ ActionHelper.registerAction = function({ actionId, node, eventName, preventDefau
   }
 
   actions.push({
-    eventName,
+    eventName: read(eventName),
     handler(event) {
-      if (!isAllowedEvent(event, allowedKeys)) {
+      if (!isAllowedEvent(event, read(allowedKeys))) {
         return true;
       }
 
-      if (preventDefault !== false) {
+      if (read(preventDefault) !== false) {
         event.preventDefault();
       }
 
-      if (bubbles === false) {
+      if (read(bubbles) === false) {
         event.stopPropagation();
       }
 

--- a/packages/ember-routing-htmlbars/tests/helpers/render_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/render_test.js
@@ -24,12 +24,12 @@ function runSet(object, key, value) {
   });
 }
 
-var view, container;
+var view, container, registry;
 
 QUnit.module("ember-routing-htmlbars: {{render}} helper", {
   setup() {
     var namespace = Namespace.create();
-    var registry = buildRegistry(namespace);
+    registry = buildRegistry(namespace);
     container = registry.container();
   },
 
@@ -222,6 +222,7 @@ QUnit.test("{{render}} helper should render with given controller", function() {
   var template = '{{render "home" controller="posts"}}';
   var controller = EmberController.extend({ container: container });
   var id = 0;
+  let model = Ember.A([]);
   container._registry.register('controller:posts', EmberArrayController.extend({
     init() {
       this._super.apply(this, arguments);

--- a/packages/ember-runtime/lib/ext/rsvp.js
+++ b/packages/ember-runtime/lib/ext/rsvp.js
@@ -1,5 +1,3 @@
-/* globals RSVP:true */
-
 import Ember from 'ember-metal/core';
 import Logger from 'ember-metal/logger';
 import run from "ember-metal/run_loop";

--- a/packages/ember-runtime/tests/ext/rsvp_test.js
+++ b/packages/ember-runtime/tests/ext/rsvp_test.js
@@ -1,5 +1,3 @@
-/* global Promise:true */
-
 import run from "ember-metal/run_loop";
 import RSVP from "ember-runtime/ext/rsvp";
 


### PR DESCRIPTION
Before, the values passed to the `action` helper were not using `read`.
This means if you did not pass a literal, but passed a binding or
computed property, it would pass the `KeyStream` along instead of
reading the value from the stream.

fixes #13062

I also fixed the jshint errors and other tests that were failing.
