### PR TITLE
Don’t require curly braces for if statements

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -23,7 +23,6 @@
   "disallowEmptyBlocks": true,
   "requireSpacesInsideObjectBrackets": "all",
   "requireCurlyBraces": [
-    "if",
     "else",
     "for",
     "while",


### PR DESCRIPTION
This allows the common pattern of:

``` javascript
function doThings(a, b, c) {
  if (!a) return;

  ...
}
```
