### PR TITLE
Prevent MS Edge failure when function name is preserved.

### DIFF
--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -1340,6 +1340,6 @@ QUnit.test('Throw an `Unsupported Content` error when attempting to bind to a fu
   try {
     runAppend(view);
   } catch(error) {
-    equal(error.message, 'Unsupported Content: Cannot bind to function');
+    ok(error.message.indexOf('Unsupported Content: Cannot bind to function') > -1);
   }
 });


### PR DESCRIPTION
The error that is thrown may also include the functions name, if the browser supports that. Recently, MS Edge added support for this, so this test fails in that environment.

See:
- https://github.com/krisselden/morph-range/pull/6
