### PR TITLE
[DOC release] add yuidoc preprocessor to filter out private, deprecat…

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "rsvp": "~3.1.0",
     "serve-static": "^1.10.0",
     "simple-dom": "^0.2.7",
-    "testem": "^1.0.0-rc.3"
+    "testem": "^1.0.0-rc.3",
+    "yuidoc-filters": "^0.0.2"
   }
 }

--- a/yuidoc.json
+++ b/yuidoc.json
@@ -19,6 +19,8 @@
       "bower_components/rsvp/lib"
     ],
     "exclude": "vendor",
-    "outdir":   "docs"
+    "outdir":   "docs",
+    "preprocessor": "yuidoc-filters",
+    "yuidoc-filters-exclude": ["private", "deprecated"]
   }
 }


### PR DESCRIPTION
…ed classes

This addresses issue https://github.com/emberjs/website/issues/2452 where private classes and deprecated classes show up on the website.  It not only fixes it for the website, but also for other 3rd party clients that render ember's documentation.

I created a yuidoc preprocessor npm package to comb the yuidoc generated json and pull out classes with a private accessor or a deprecated flag.  See https://github.com/toddjordan/yuidoc-filters
