### PR TITLE
Do less work when creating Components in glimmer

### DIFF
--- a/packages/ember-glimmer/lib/components/curly-component.js
+++ b/packages/ember-glimmer/lib/components/curly-component.js
@@ -75,7 +75,7 @@ class CurlyComponentManager {
 const MANAGER = new CurlyComponentManager();
 
 import { ComponentDefinition, ValueReference } from 'glimmer-runtime';
-import Component from 'ember-views/components/component';
+import Component from '../ember-views/component';
 
 function elementId(vm) {
   let component = vm.dynamicScope().view;

--- a/packages/ember-glimmer/lib/ember-views/child-views-support.js
+++ b/packages/ember-glimmer/lib/ember-views/child-views-support.js
@@ -1,0 +1,73 @@
+/**
+@module ember
+@submodule ember-views
+*/
+import { Mixin } from 'ember-metal/mixin';
+import { getOwner, setOwner, OWNER } from 'container/owner';
+
+export default Mixin.create({
+  init() {
+    this._super(...arguments);
+
+    /**
+      Array of child views. You should never edit this array directly.
+      Instead, use `appendChild` and `removeFromParent`.
+
+      @property childViews
+      @type Array
+      @default []
+      @private
+    */
+    this.childViews = [];
+    this.parentView = null;
+    this.ownerView = this.ownerView || this;
+  },
+
+  appendChild(view) {
+    this.linkChild(view);
+    this.childViews.push(view);
+  },
+
+  destroyChild(view) {
+    view.destroy();
+  },
+
+  /**
+    Removes the child view from the parent view.
+
+    @method removeChild
+    @param {Ember.View} view
+    @return {Ember.View} receiver
+    @private
+  */
+  removeChild(view) {
+    // If we're destroying, the entire subtree will be
+    // freed, and the DOM will be handled separately,
+    // so no need to mess with childViews.
+    if (this.isDestroying) { return; }
+
+    // update parent node
+    this.unlinkChild(view);
+
+    // remove view from childViews array.
+    let { childViews } = this;
+
+    let index = childViews.indexOf(view);
+    if (index !== -1) { childViews.splice(index, 1); }
+
+    return this;
+  },
+
+  linkChild(instance) {
+    if (!instance[OWNER]) {
+      setOwner(instance, getOwner(this));
+    }
+
+    instance.parentView = this;
+    instance.ownerView = this.ownerView;
+  },
+
+  unlinkChild(instance) {
+    instance.parentView = null;
+  }
+});

--- a/packages/ember-glimmer/lib/ember-views/component.js
+++ b/packages/ember-glimmer/lib/ember-views/component.js
@@ -1,0 +1,26 @@
+import CoreView from 'ember-views/views/core_view';
+import ChildViewsSupport from './child-views-support';
+import ViewStateSupport from 'ember-views/mixins/view_state_support';
+import ClassNamesSupport from 'ember-views/mixins/class_names_support';
+import InstrumentationSupport from 'ember-views/mixins/instrumentation_support';
+import AriaRoleSupport from 'ember-views/mixins/aria_role_support';
+import ViewMixin from 'ember-views/mixins/view_support';
+import EmberView from 'ember-views/views/view';
+
+export default CoreView.extend(
+  ChildViewsSupport,
+  ViewStateSupport,
+  ClassNamesSupport,
+  InstrumentationSupport,
+  AriaRoleSupport,
+  ViewMixin, {
+    isComponent: true,
+    template: null,
+    layoutName: null,
+    layout: null,
+
+    init() {
+      this._super(...arguments);
+      this._viewRegistry = this._viewRegistry || EmberView.views;
+    }
+  });

--- a/packages/ember-glimmer/tests/utils/abstract-test-case.js
+++ b/packages/ember-glimmer/tests/utils/abstract-test-case.js
@@ -1,10 +1,9 @@
 import packageName from './package-name';
 import Environment from './environment';
-import { compile, helper, Helper, DOMHelper, Renderer } from './helpers';
+import { compile, helper, Helper, Component, DOMHelper, Renderer } from './helpers';
 import { equalsElement, equalTokens, regex, classes } from './test-helpers';
 import run from 'ember-metal/run_loop';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
-import Component from 'ember-views/components/component';
 import jQuery from 'ember-views/system/jquery';
 import assign from 'ember-metal/assign';
 import Application from 'ember-application/system/application';

--- a/packages/ember-glimmer/tests/utils/helpers.js
+++ b/packages/ember-glimmer/tests/utils/helpers.js
@@ -1,4 +1,5 @@
 export { default as Helper, helper } from 'ember-glimmer/helper';
+export { default as Component } from 'ember-glimmer/ember-views/component';
 export { DOMHelper } from 'glimmer-runtime';
 export { Renderer } from 'ember-glimmer/ember-metal-views';
 export { default as compile } from 'ember-glimmer/ember-template-compiler/system/compile';

--- a/packages/ember-htmlbars/tests/utils/helpers.js
+++ b/packages/ember-htmlbars/tests/utils/helpers.js
@@ -1,4 +1,5 @@
 export { default as Helper, helper } from 'ember-htmlbars/helper';
 export { default as DOMHelper } from 'ember-htmlbars/system/dom-helper';
+export { default as Component } from 'ember-views/components/component';
 export { Renderer } from 'ember-metal-views';
 export { default as compile } from 'ember-template-compiler/system/compile';


### PR DESCRIPTION
We starting noticing that there are quite a bit of work we do in Components init that are not needed in Glimmer, so we tried to make a slimmer version. When we eventually get to feature-flagging, we can conditionally export the right class. We will probably need to add more stuff as we go (or perhaps we can remove more work), but this is a good start.
