### PR TITLE
Sauce: Test against latest

### DIFF
--- a/testem.dist.json
+++ b/testem.dist.json
@@ -6,11 +6,11 @@
   "disable_watching": true,
   "launchers": {
     "SL_Chrome_Current": {
-      "command": "npm run sauce:launch -- -b chrome --no-ct -u <url>",
+      "command": "npm run sauce:launch -- -b chrome -v latest --no-ct -u <url>",
       "protocol": "tap"
     },
     "SL_Firefox_Current": {
-      "command": "npm run sauce:launch -- -b firefox -v 34 --no-ct -u <url>",
+      "command": "npm run sauce:launch -- -b firefox -v latest --no-ct -u <url>",
       "protocol": "tap"
     },
     "SL_Safari_Current": {


### PR DESCRIPTION
Uses the new saucelabs syntax to test against the latest version: http://sauceio.com/index.php/2016/03/new-browser-version-shortcuts/
