### PR TITLE
[Glimmer2] Move hash helper to use reference infra

### DIFF
--- a/packages/ember-glimmer/lib/helpers/hash.js
+++ b/packages/ember-glimmer/lib/helpers/hash.js
@@ -1,4 +1,4 @@
-import { InternalHelperReference } from '../utils/references';
+import { HashHelperReference } from '../utils/references';
 /**
 @module ember
 @submodule ember-templates
@@ -31,13 +31,9 @@ import { InternalHelperReference } from '../utils/references';
    @public
  */
 
-function hash({ named }) {
-  return named.value();
-}
-
 export default {
   isInternalHelper: true,
   toReference(args) {
-    return new InternalHelperReference(hash, args);
+    return new HashHelperReference(args);
   }
 };

--- a/packages/ember-glimmer/lib/helpers/hash.js
+++ b/packages/ember-glimmer/lib/helpers/hash.js
@@ -1,4 +1,4 @@
-import { helper } from '../helper';
+import { InternalHelperReference } from '../utils/references';
 /**
 @module ember
 @submodule ember-templates
@@ -31,8 +31,13 @@ import { helper } from '../helper';
    @public
  */
 
-function hash(params, hash, options) {
-  return hash;
+function hash({ named }) {
+  return named.value();
 }
 
-export default helper(hash);
+export default {
+  isInternalHelper: true,
+  toReference(args) {
+    return new InternalHelperReference(hash, args);
+  }
+};

--- a/packages/ember-glimmer/lib/utils/references.js
+++ b/packages/ember-glimmer/lib/utils/references.js
@@ -52,6 +52,24 @@ export class UpdatableReference extends RootReference {
   }
 }
 
+export class HashHelperReference {
+  constructor(args) {
+    this.namedArgs = args.named;
+  }
+
+  isDirty() { return true; }
+
+  value() {
+    return this.namedArgs.value();
+  }
+
+  get(propertyKey) {
+    return this.namedArgs.get(propertyKey);
+  }
+
+  destroy() {}
+}
+
 export class ConditionalReference extends GlimmerConditionalReference {
   toBool(predicate) {
     return emberToBool(predicate);


### PR DESCRIPTION
This may or may not be correct. Was just looking at the `{{if}}`/`{{unless}}` helpers.
