### PR TITLE
[DOC release] Initial pass at filtering out api docs behind FFs

### DIFF
--- a/bin/feature-flag-yuidoc-filter.js
+++ b/bin/feature-flag-yuidoc-filter.js
@@ -1,0 +1,57 @@
+var fs = require('fs');
+
+function isClassToBeIncluded(item, featuresToFilter) {
+  if (item.category) {
+    for (var j = 0; j < featuresToFilter.length; j++) {
+      for (var k = 0; k < item.category.length; k++) {
+        if (featuresToFilter[j] === item.category[k]) {
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+};
+
+function gatherFeatures() {
+    var featuresJson = JSON.parse(fs.readFileSync('features.json'));
+    var featuresObj = featuresJson.features;
+    var featuresToFilter = [];
+    for (var feature in featuresObj) {
+        if (featuresObj[feature] === null || featuresObj[feature] === false) {
+            featuresToFilter.push(feature);
+        }
+    }
+    return featuresToFilter;
+};
+
+function gatherClassesToDocument(data, featuresToFilter) {
+  var classesToDocument = {};
+
+  for (var c in data.classes) {
+    if (isClassToBeIncluded(data.classes[c], featuresToFilter)) {
+      classesToDocument[c] = data.classes[c];
+    }
+  }
+  return classesToDocument;
+};
+
+function updateClassReferencesInNamespaces(data) {
+  for (var namespace in data.modules) {
+    var namespaceClasses = {};
+    var originalClasses = data.modules[namespace].classes;
+    for(var className in originalClasses) {
+      if (data.classes.hasOwnProperty(className)) {
+        namespaceClasses[className] = originalClasses[className]
+      }
+    }
+    data.modules[namespace].classes = namespaceClasses;
+  }
+
+};
+
+module.exports = function (data, options) {
+    var featuresToFilter = gatherFeatures();
+    data.classes = gatherClassesToDocument(data, featuresToFilter);
+    updateClassReferencesInNamespaces(data);
+};

--- a/packages/ember-application/lib/system/engine-instance.js
+++ b/packages/ember-application/lib/system/engine-instance.js
@@ -18,6 +18,7 @@ import run from 'ember-metal/run_loop';
   @extends Ember.Object
   @uses RegistryProxyMixin
   @uses ContainerProxyMixin
+  @category ember-application-engines
 */
 
 const EngineInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {

--- a/packages/ember-application/lib/system/engine.js
+++ b/packages/ember-application/lib/system/engine.js
@@ -43,6 +43,7 @@ function props(obj) {
   @namespace Ember
   @extends Ember.Namespace
   @uses RegistryProxy
+  @category ember-application-engines
   @public
 */
 const Engine = Namespace.extend(RegistryProxy, {

--- a/yuidoc.json
+++ b/yuidoc.json
@@ -20,6 +20,7 @@
       "bower_components/router.js/lib/router"
     ],
     "exclude": "vendor,bower_components/router.js/lib/router/handler-info,bower_components/router.js/lib/router/transition-intent,bower_components/router.js/lib/router/router.js,bower_components/router.js/lib/router/transition-intent.js,bower_components/router.js/lib/router/transition-state.js,bower_components/router.js/lib/router/unrecognized-url-error.js,bower_components/router.js/lib/router/utils.js",
-    "outdir":   "docs"
+    "outdir":   "docs",
+    "preprocessor": "bin/feature-flag-yuidoc-filter"
   }
 }


### PR DESCRIPTION
This PR is to address issue #13101 

It uses a yuidoc preprocessor to parse features.json and determine features that are not yet turned on by default.  If not turned on, any class with an `@category` tag matching that feature will be filtered out of the api docs class list.
