### PR TITLE
Fix testem.json to quote url substitution.

### DIFF
--- a/testem.dist.json
+++ b/testem.dist.json
@@ -6,35 +6,35 @@
   "disable_watching": true,
   "launchers": {
     "SL_Chrome_Current": {
-      "command": "npm run sauce:launch -- -b chrome -v latest --no-ct -u <url>",
+      "command": "npm run sauce:launch -- -b chrome -v latest --no-ct -u '<url>'",
       "protocol": "tap"
     },
     "SL_Firefox_Current": {
-      "command": "npm run sauce:launch -- -b firefox -v latest --no-ct -u <url>",
+      "command": "npm run sauce:launch -- -b firefox -v latest --no-ct -u '<url>'",
       "protocol": "tap"
     },
     "SL_Safari_Current": {
-      "command": "npm run sauce:launch -- -b safari -v 8 --no-ct -u <url>",
+      "command": "npm run sauce:launch -- -b safari -v 8 --no-ct -u '<url>'",
       "protocol": "tap"
     },
     "SL_Safari_Last": {
-      "command": "npm run sauce:launch -- -b safari -v 7 --no-ct -u <url>",
+      "command": "npm run sauce:launch -- -b safari -v 7 --no-ct -u '<url>'",
       "protocol": "tap"
     },
     "SL_MS_Edge": {
-      "command": "npm run sauce:launch -- -b 'microsoftedge' --no-ct -u <url>",
+      "command": "npm run sauce:launch -- -b 'microsoftedge' --no-ct -u '<url>'",
       "protocol": "tap"
     },
     "SL_IE_11": {
-      "command": "npm run sauce:launch -- -b 'internet explorer' -v 11 --no-ct -u <url>",
+      "command": "npm run sauce:launch -- -b 'internet explorer' -v 11 --no-ct -u '<url>'",
       "protocol": "tap"
     },
     "SL_IE_10": {
-      "command": "npm run sauce:launch -- -b 'internet explorer' -v 10 --no-ct -u <url>",
+      "command": "npm run sauce:launch -- -b 'internet explorer' -v 10 --no-ct -u '<url>'",
       "protocol": "tap"
     },
     "SL_IE_9": {
-      "command": "npm run sauce:launch  -- -b 'internet explorer' -v 9 --no-ct -u <url>",
+      "command": "npm run sauce:launch  -- -b 'internet explorer' -v 9 --no-ct -u '<url>'",
       "protocol": "tap"
     }
   },


### PR DESCRIPTION
Testem just does a `replace('<url>', testUrl)` on the command, so `&` was being interpreted by the command shell, clipping test_page to "tests/index.html?hidepassed"
