### PR TITLE
[DOC?] Demo of a Brutal Error Message

### DIFF
--- a/packages/ember-htmlbars/tests/helpers/get_test.js
+++ b/packages/ember-htmlbars/tests/helpers/get_test.js
@@ -493,3 +493,19 @@ QUnit.test('get helper value should be updatable using {{input}} and (mut) - sta
   equal(view.$('#get-input').val(), 'some value');
   equal(view.get('context.source.banana'), 'some value');
 });
+
+QUnit.test('get helper provides a meaningful error message when the key path is shitty', function() {
+  var context = {
+    responses: {
+      'Favourite colour?': 'red',
+      'Tell me more.': 'yellow is also cool'
+    }
+  };
+
+  view = EmberView.create({
+    context: context,
+    template: compile('[{{get colors \'Tell me more.\'}}]')
+  });
+
+  runAppend(view);
+});


### PR DESCRIPTION
When using the `{{get` helper, it isn't entirely clear that the second argument is an object path in the docs. When one provides, for example, a sentence like "Yo, dawg.", the following error message _might_ be raised:

"Assertion Failed: KeyStream error: key must be a non-empty string"

I've also seen the following:

"Object in path  could not be found or was destroyed"

I don't believe that the `{{get` helper should necessarily accommodate this usage, but I do believe it should provide both a more helpful error message, and clearer docs.

Perhaps a more helpful error message would be "Assertion Failed: KeyStream error: key must be a non-empty string. Double check the object path you've provided."? The docs could simply be updated to note that the second argument to `{{get` is treated as an object path.
