### PR TITLE
Split glimmer packages up to reduce duplication.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -44,7 +44,12 @@ function babelConfigFor(environment) {
 
 var glimmerEngine = require('glimmer-engine/ember-cli-build')();
 var find = require('broccoli-stew').find;
+var mv = require('broccoli-stew').mv;
 var log = require('broccoli-stew').log;
+
+function addGlimmerPackage(vendoredPackages, name) {
+  vendoredPackages[name] = find(glimmerEngine, 'named-amd/' + name + '/**/*.js');
+}
 
 module.exports = function() {
   var features = JSON.parse(featuresJson).features;
@@ -69,16 +74,16 @@ module.exports = function() {
 
   var glimmerStatus = features['ember-glimmer'];
   if (glimmerStatus === null || glimmerStatus === true) {
-    vendorPackages['glimmer-engine'] = find(glimmerEngine, {
-      include: [
-        'amd/glimmer-common.amd.js',
-        'amd/glimmer-common.amd.map',
-        'amd/glimmer-compiler.amd.js',
-        'amd/glimmer-compiler.amd.map',
-        'amd/glimmer-runtime.amd.js',
-        'amd/glimmer-runtime.amd.map',
-      ]
-    });
+    addGlimmerPackage(vendorPackages, 'glimmer');
+    addGlimmerPackage(vendorPackages, 'glimmer-compiler');
+    addGlimmerPackage(vendorPackages, 'glimmer-object');
+    addGlimmerPackage(vendorPackages, 'glimmer-reference');
+    addGlimmerPackage(vendorPackages, 'glimmer-runtime');
+    addGlimmerPackage(vendorPackages, 'glimmer-syntax');
+    addGlimmerPackage(vendorPackages, 'glimmer-test-helpers');
+    addGlimmerPackage(vendorPackages, 'glimmer-util');
+    addGlimmerPackage(vendorPackages, 'glimmer-wire-format');
+    addGlimmerPackage(vendorPackages, 'handlebars'); // inlined parser and whatnot
 
     vendorPackages['glimmer-engine-tests'] = find(glimmerEngine, {
       include: [

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -27,12 +27,23 @@ if (glimmerStatus === null || glimmerStatus === true) {
     trees: null,
     requirements: ['ember-metal'],
     vendorRequirements: [
-      'glimmer-engine'
+      'glimmer',
+      'glimmer-runtime',
+      'glimmer-reference',
+      'glimmer-util',
+      'glimmer-wire-format'
     ],
     testingVendorRequirements: [
+      'glimmer-object',
       'glimmer-engine-tests'
     ]
   };
+
+  var templateCompiler = packages['ember-template-compiler'];
+  templateCompiler.templateCompilerVendor.push('glimmer-syntax');
+  templateCompiler.templateCompilerVendor.push('glimmer-util');
+  templateCompiler.templateCompilerVendor.push('glimmer-compiler');
+  templateCompiler.templateCompilerVendor.push('handlebars');
 }
 
 module.exports = packages;


### PR DESCRIPTION
- Removes glimmer template compiler packages from
  ember.debug.js/ember.prod.js.
- Removes glimmer-object from ember.debug.js/ember.prod.js (it is not
  used outside of glimmer's tests)
- Prevent double inclusion of simple-html-tokenizer
