### PR TITLE
[BUGFIX beta] Fixes `computed.sort works incorrectly with empty sort properties array`

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -668,6 +668,9 @@ function normalizeSortProperties(sortProperties) {
 }
 
 function sortByNormalizedSortProperties(items, normalizedSortProperties) {
+  if (normalizedSortProperties.length === 0) {
+    return emberA(items.slice());
+  }
   return emberA(items.slice().sort((itemA, itemB) => {
     for (let i = 0; i < normalizedSortProperties.length; i++) {
       let [prop, direction] = normalizedSortProperties[i];

--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -12,6 +12,7 @@ import compare from 'ember-runtime/compare';
 import { isArray } from 'ember-runtime/utils';
 import { A as emberA } from 'ember-runtime/system/native_array';
 import isNone from 'ember-metal/is_none';
+import isEmpty from 'ember-metal/is_empty';
 import getProperties from 'ember-metal/get_properties';
 import WeakMap from 'ember-metal/weak_map';
 
@@ -667,11 +668,12 @@ function normalizeSortProperties(sortProperties) {
   });
 }
 
-function sortByNormalizedSortProperties(items, normalizedSortProperties) {
-  if (normalizedSortProperties.length === 0) {
-    return emberA(items.slice());
+function sortByNormalizedSortProperties(_items, normalizedSortProperties) {
+  let items = _items.slice();
+  if (isEmpty(normalizedSortProperties)) {
+    return emberA(items);
   }
-  return emberA(items.slice().sort((itemA, itemB) => {
+  return emberA(items.sort((itemA, itemB) => {
     for (let i = 0; i < normalizedSortProperties.length; i++) {
       let [prop, direction] = normalizedSortProperties[i];
       let result = compare(get(itemA, prop), get(itemB, prop));

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -879,6 +879,20 @@ QUnit.test('updating sort properties invalidates the sorted array', function() {
   ], 'after updating sort properties array is updated');
 });
 
+QUnit.test('sorted array should not be changed if sort properties array is empty', function () {
+  // issue doesn't appear with small arrays (about 10 items), so 20 items are used
+  var o = EmberObject.extend({
+    sortedItems: sort('items', 'itemSorting')
+  }).create({
+    itemSorting: emberA([]),
+    items: emberA([
+      { p: 1 }, { p: 2 }, { p: 3 }, { p: 4 }, { p: 5 }, { p: 6 }, { p: 7 }, { p: 8 }, { p: 9 }, { p: 10 },
+      { p: 11 }, { p: 12 }, { p: 13 }, { p: 14 }, { p: 15 }, { p: 16 }, { p: 17 }, { p: 18 }, { p: 19 }, { p: 20 }
+    ])
+  });
+  deepEqual(o.get('sortedItems').mapBy('p'), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20], 'array is not changed');
+});
+
 QUnit.test('updating new sort properties invalidates the sorted array', function() {
   deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Cersei',


### PR DESCRIPTION
Fix for #13037 
