### PR TITLE
[DOC] Fix Ember.computed documentation to include dependent keys of `fullName`

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -578,7 +578,7 @@ ComputedPropertyPrototype.teardown = function(obj, keyName) {
       this.lastName = 'Jones';
     },
 
-    fullName: Ember.computed({
+    fullName: Ember.computed('firstName', 'lastName', {
       get(key) {
         return `${this.get('firstName')} ${this.get('lastName')}`;
       },


### PR DESCRIPTION
Reported by lavalike in Ember Slack
