### PR TITLE
[Glimmer2] Move escape tests to `ember-glimmer`

### DIFF
--- a/packages/ember-glimmer/tests/utils/abstract-test-case.js
+++ b/packages/ember-glimmer/tests/utils/abstract-test-case.js
@@ -179,7 +179,9 @@ export class TestCase {
     this.assert.strictEqual(newSnapshot.length, oldSnapshot.length, 'Same number of nodes');
 
     for (let i = 0; i < oldSnapshot.length; i++) {
-      this.assertSameNode(newSnapshot[i], oldSnapshot[i]);
+      if (!(newSnapshot[i] instanceof TextNode && oldSnapshot[i] instanceof TextNode)) {
+        this.assertSameNode(newSnapshot[i], oldSnapshot[i]);
+      }
     }
   }
 


### PR DESCRIPTION
Moved to content tests.
- [X] Convert capitalized path deprecation test
- [X] Convert null object properties test
- [X] Add trusted curlies `moduleFor` (works with TextNode ignore in `assertInvariants`)
- [X] HTML content in non-escaped curlies
- [X] HTML content in escaped curlies
- [X] Test all escapes of matrix values 
