### PR TITLE
[Glimmer2] Fragment Tests WIP

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/fragment-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/fragment-components-test.js
@@ -1,0 +1,43 @@
+import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { strip } from '../../utils/abstract-test-case';
+import { set } from 'ember-metal/property_set';
+import Component from 'ember-views/components/component';
+
+
+moduleFor('Components test: fragment components', class extends RenderingTest {
+  ['@htmlbars fragments do not render an outer tag']() {
+    let instance;
+    let FooBarComponent = Component.extend({
+      tagName: '',
+      init() {
+        this._super();
+        instance = this;
+        this.foo = true;
+        this.bar = 'bar';
+      }
+    });
+
+    let template = `{{#if foo}}<div>Hey</div>{{/if}}{{yield bar}}`;
+
+    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template });
+
+    this.render(`{{#foo-bar as |bar|}}{{bar}}{{/foo-bar}}`);
+
+    this.assertHTML(strip`<div>Hey</div>bar`);
+
+    this.assertStableRerender();
+
+    this.runTask(() => set(instance, 'foo', false));
+
+    this.assertHTML(strip`<!---->bar`);
+
+    this.runTask(() => set(instance, 'bar', 'bizz'));
+
+    this.assertHTML(strip`<!---->bizz`);
+
+    this.runTask(() => {
+      set(instance, 'bar', 'bar');
+      set(instance, 'foo', true);
+    });
+  }
+});


### PR DESCRIPTION
This seems to not be implemented in Glimmer2.
- [x] Basic tests to ensure fragment templates work properly
- [ ] Coalesce other fragment tests

**Existing Fragment Tests**
- [ ] [if_unless_test.js](https://github.com/emberjs/ember.js/blob/fd03495063ea7862bdb67a6c96dd57159d074a52/packages/ember-htmlbars/tests/helpers/if_unless_test.js#L192)
- [ ]  [Fragment with event handler part 1](https://github.com/emberjs/ember.js/blob/fd03495063ea7862bdb67a6c96dd57159d074a52/packages/ember-views/tests/views/component_test.js#L309)
- [ ] [Fragment with event handler part 2](https://github.com/emberjs/ember.js/blob/fd03495063ea7862bdb67a6c96dd57159d074a52/packages/ember-views/tests/views/component_test.js#L334)
- [ ]  [Fragment with event handler part 3](https://github.com/emberjs/ember.js/blob/fd03495063ea7862bdb67a6c96dd57159d074a52/packages/ember-views/tests/views/component_test.js#L358)
- [ ]  [Fragment with classNameBindings ](https://github.com/emberjs/ember.js/blob/fd03495063ea7862bdb67a6c96dd57159d074a52/packages/ember-views/tests/views/view/create_element_test.js#L41)
- [ ]  [DEPRECATED  renders the child view templates in the right context](https://github.com/emberjs/ember.js/blob/fd03495063ea7862bdb67a6c96dd57159d074a52/packages/ember-views/tests/views/view/create_element_test.js#L81)
- [ ] [DEPRECATED does not wrap many tr children in tbody elements](https://github.com/emberjs/ember.js/blob/fd03495063ea7862bdb67a6c96dd57159d074a52/packages/ember-views/tests/views/view/create_element_test.js#L106)
- [ ] [jQuery lookups](https://github.com/emberjs/ember.js/blob/fd03495063ea7862bdb67a6c96dd57159d074a52/packages/ember-views/tests/views/view/jquery_test.js#L55)
- [ ]  [Fragment parent](https://github.com/emberjs/ember.js/blob/fd03495063ea7862bdb67a6c96dd57159d074a52/packages/ember-views/tests/views/view_test.js#L93)
- [ ] [Fastboot fragment](https://github.com/emberjs/ember.js/blob/fd03495063ea7862bdb67a6c96dd57159d074a52/tests/node/visit-test.js#L307)
- [ ] [Yield hierarchy of fragments part 1](https://github.com/emberjs/ember.js/blob/fd03495063ea7862bdb67a6c96dd57159d074a52/packages/ember-htmlbars/tests/helpers/yield_test.js#L84)
- [ ] [Yield hierarchy of fragments part 2](https://github.com/emberjs/ember.js/blob/fd03495063ea7862bdb67a6c96dd57159d074a52/packages/ember-htmlbars/tests/helpers/yield_test.js#L207)
- [ ] [Event handlers inside of fragments](https://github.com/emberjs/ember.js/blob/fd03495063ea7862bdb67a6c96dd57159d074a52/packages/ember-routing-htmlbars/tests/helpers/element_action_test.js#L575)

/cc @chancancode @rwjblue 
