### PR TITLE
Controller#replaceRoute should be public

### DIFF
--- a/packages/ember-routing/lib/ext/controller.js
+++ b/packages/ember-routing/lib/ext/controller.js
@@ -171,7 +171,7 @@ ControllerMixin.reopen({
     while transitioning to the route.
     @for Ember.ControllerMixin
     @method replaceRoute
-    @private
+    @public
   */
   replaceRoute() {
     // target may be either another controller or a router


### PR DESCRIPTION
This method should be public, incorrectly marked as private in the big update last year
