### PR TITLE
Fixes leading slash being added to component-test module name

### DIFF
--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -43,7 +43,7 @@ module.exports = useTestFrameworkDetector({
     var testType = options.testType || 'integration';
     var friendlyTestDescription = testInfo.description(options.entity.name, 'Integration', 'Component');
 
-    if (options.pod && options.path !== 'components' && options.path !== '') {
+    if (options.pod && options.path && options.path !== 'components') {
       componentPathName = [options.path, dasherizedModuleName].join('/');
     }
 

--- a/node-tests/blueprints/component-test.js
+++ b/node-tests/blueprints/component-test.js
@@ -956,6 +956,25 @@ describe('Acceptance: ember generate component', function() {
     });
   });
 
+  it('component-test x-foo --pod', function() {
+    return generateAndDestroy(['component-test', 'x-foo', '--pod'], {
+      podModulePrefix: true,
+      files: [
+        {
+          file: 'tests/integration/pods/components/x-foo/component-test.js',
+          contains: [
+            "import { moduleForComponent, test } from 'ember-qunit';",
+            "import hbs from 'htmlbars-inline-precompile';",
+            "moduleForComponent('x-foo'",
+            "integration: true",
+            "{{x-foo}}",
+            "{{#x-foo}}"
+          ]
+        }
+      ]
+    });
+  });
+
   it('component-test x-foo --unit', function() {
     return generateAndDestroy(['component-test', 'x-foo', '--unit'], {
       files: [


### PR DESCRIPTION
Fixes leading slash being added to component-test module name when not generated alongside a component.

https://github.com/ember-cli/ember-cli/issues/5518
https://github.com/ember-cli/ember-cli/pull/5673
