### PR TITLE
[DOC release] remove misleading statement

### DIFF
--- a/packages/ember-debug/lib/index.js
+++ b/packages/ember-debug/lib/index.js
@@ -32,7 +32,8 @@ import { generateTestAsFunctionDeprecation } from 'ember-debug/handlers';
 /**
   Define an assertion that will throw an exception if the condition is not
   met. Ember build tools will remove any calls to `Ember.assert()` when
-  doing a production build. Example:
+  doing an Ember.js framework production build and will make the assertion a
+  no-op for an application production build. Example:
 
   ```javascript
   // Test for truthiness


### PR DESCRIPTION
The `Ember build tools will remove any calls to Ember.assert() when doing a production build` statement is pretty misleading IMO. I expected that ember-cli would strip them from my app, which [isn't the case](https://github.com/ember-cli/ember-cli/issues/5680#issuecomment-201142739).
