### PR TITLE
[BUGFIX release] Ensure `{{render}}` sets up target properly.

### DIFF
--- a/packages/ember-routing-htmlbars/lib/keywords/render.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/render.js
@@ -186,6 +186,7 @@ export default {
     }
 
     var parentController = read(scope.getLocal('controller'));
+    let target = parentController || router;
     var controller;
 
     // choose name
@@ -195,8 +196,8 @@ export default {
 
       controller = factory.create({
         model: read(context),
-        parentController: parentController,
-        target: parentController
+        parentController,
+        target
       });
 
       node.addDestruction(controller);
@@ -205,8 +206,8 @@ export default {
                    generateController(owner, controllerName);
 
       controller.setProperties({
-        target: parentController,
-        parentController: parentController
+        target,
+        parentController
       });
     }
 


### PR DESCRIPTION
When the _ENABLE_LEGACY_CONTROLLER_SUPPORT flag is disabled, the `controller` local is `undefined`. This causes the controller created by `{{render}}` to have an undefined `target` (so it swallows any actions triggered).

This properly sets the `target` to `router:main` if there is no `parentController` present.

Fixes https://github.com/emberjs/ember.js/issues/13182.
