### PR TITLE
Remove `latest` from `chrome` sauce labs tests.

### DIFF
--- a/testem.dist.json
+++ b/testem.dist.json
@@ -6,7 +6,7 @@
   "disable_watching": true,
   "launchers": {
     "SL_Chrome_Current": {
-      "command": "npm run sauce:launch -- -b chrome -v latest --no-ct -u '<url>'",
+      "command": "npm run sauce:launch -- -b chrome --no-ct -u '<url>'",
       "protocol": "tap"
     },
     "SL_Firefox_Current": {


### PR DESCRIPTION
This is erroring for all PR's saying that `latest` is not a valid
version. We need to dig in and/or report an issue to the Sauce Labs
folks, but this should gets us back to a passing build.
