### PR TITLE
[DOC] address typos in packages directory

### DIFF
--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -246,7 +246,7 @@ const ApplicationInstance = EngineInstance.extend({
     Navigate the instance to a particular URL. This is useful in tests, for
     example, or to tell the app to start at a particular URL. This method
     returns a promise that resolves with the app instance when the transition
-    is complete, or rejects if the transion was aborted due to an error.
+    is complete, or rejects if the transition was aborted due to an error.
 
     @public
     @param url {String} the destination URL
@@ -261,7 +261,7 @@ const ApplicationInstance = EngineInstance.extend({
       // Resolve only after rendering is complete
       return new RSVP.Promise((resolve) => {
         // TODO: why is this necessary? Shouldn't 'actions' queue be enough?
-        // Also, aren't proimses supposed to be async anyway?
+        // Also, aren't promises supposed to be async anyway?
         run.next(null, resolve, this);
       });
     };

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -406,7 +406,7 @@ const Application = Engine.extend({
     be created at Application construction (not boot) time to expose
     App.__container__ and the global Ember.View.views registry. If
     autoboot sees that this instance exists, it will continue booting
-    it to avoid doing unncessary work (as opposed to building a new
+    it to avoid doing unnecessary work (as opposed to building a new
     instance at boot time), but they are otherwise unrelated.
 
     @private
@@ -801,7 +801,7 @@ const Application = Engine.extend({
     Boot a new instance of `Ember.ApplicationInstance` for the current
     application and navigate it to the given `url`. Returns a `Promise` that
     resolves with the instance when the initial routing and rendering is
-    complete, or rejects with any error that occured during the boot process.
+    complete, or rejects with any error that occurred during the boot process.
 
     When `autoboot` is disabled, calling `visit` would first cause the
     application to boot, which runs the application initializers.
@@ -826,7 +826,7 @@ const Application = Engine.extend({
     result in unexpected behavior.
 
     For example, booting the instance in the full browser environment
-    while specifying a foriegn `document` object (e.g. `{ isBrowser: true,
+    while specifying a foreign `document` object (e.g. `{ isBrowser: true,
     document: iframe.contentDocument }`) does not work correctly today,
     largely due to Ember's jQuery dependency.
 
@@ -841,7 +841,7 @@ const Application = Engine.extend({
     Ember will boot a default instance for your Application on "DOM ready".
     However, you can customize this behavior by disabling `autoboot`.
 
-    For example, this allows you to render a miniture demo of your application
+    For example, this allows you to render a miniature demo of your application
     into a specific area on your marketing website:
 
     ```javascript
@@ -929,7 +929,7 @@ const Application = Engine.extend({
 
     This setup allows you to run the routing layer of your Ember app in a server
     environment using Node.js and completely disable rendering. This allows you
-    to simulate and discover the resources (i.e. AJAX requests) needed to fufill
+    to simulate and discover the resources (i.e. AJAX requests) needed to fulfill
     a given request and eagerly "push" these resources to the client.
 
     ```app/initializers/network-service.js
@@ -937,7 +937,7 @@ const Application = Engine.extend({
     import NodeNetworkService from 'app/services/network/node';
 
     // Inject a (hypothetical) service for abstracting all AJAX calls and use
-    // the appropiate implementaion on the client/server. This also allows the
+    // the appropriate implementation on the client/server. This also allows the
     // server to log all the AJAX calls made during a particular request and use
     // that for resource-discovery purpose.
 

--- a/packages/ember-htmlbars/lib/components/link-to.js
+++ b/packages/ember-htmlbars/lib/components/link-to.js
@@ -271,7 +271,7 @@
   ```
 
   See [Ember.LinkComponent](/api/classes/Ember.LinkComponent.html) for a
-  complete list of overrideable properties. Be sure to also
+  complete list of overridable properties. Be sure to also
   check out inherited properties of `LinkComponent`.
 
   ### Overriding Application-wide Defaults

--- a/packages/ember-htmlbars/lib/keywords/action.js
+++ b/packages/ember-htmlbars/lib/keywords/action.js
@@ -71,7 +71,7 @@ import closureAction from 'ember-htmlbars/keywords/closure-action';
   Two options can be passed to the `action` helper when it is used in this way.
 
   * `target=someProperty` will look to `someProperty` instead of the current
-    context for the `actions` hash. This can be useful when targetting a
+    context for the `actions` hash. This can be useful when targeting a
     service for actions.
   * `value="target.value"` will read the path `target.value` off the first
     argument to the action when it is called and rewrite the first argument

--- a/packages/ember-htmlbars/lib/renderer.js
+++ b/packages/ember-htmlbars/lib/renderer.js
@@ -252,7 +252,7 @@ Renderer.prototype.remove = function (view, shouldDestroy) {
 
 Renderer.prototype.renderElementRemoval =
   function Renderer_renderElementRemoval(view) {
-    // Use the _willRemoveElement flag to avoid mulitple removal attempts in
+    // Use the _willRemoveElement flag to avoid multiple removal attempts in
     // case many have been scheduled. This should be more performant than using
     // `scheduleOnce`.
     if (view._willRemoveElement) {

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -137,7 +137,7 @@ function ComputedProperty(config, opts) {
     this._getter = config;
   } else {
     assert('Ember.computed expects a function or an object as last argument.', typeof config === 'object' && !Array.isArray(config));
-    assert('Config object pased to a Ember.computed can only contain `get` or `set` keys.', (function() {
+    assert('Config object passed to an Ember.computed can only contain `get` or `set` keys.', (function() {
       let keys = Object.keys(config);
       for (let i = 0; i < keys.length; i++) {
         if (keys[i] !== 'get' && keys[i] !== 'set') {
@@ -170,7 +170,7 @@ var ComputedPropertyPrototype = ComputedProperty.prototype;
   any changes if you want to observe this property.
 
   Dependency keys have no effect on volatile properties as they are for cache
-  invalidation and notification when cached value is invalidated.
+  invalidation and notification when the cached value is invalidated.
 
   ```javascript
   let outsideService = Ember.Object.extend({

--- a/packages/ember-metal/lib/dictionary.js
+++ b/packages/ember-metal/lib/dictionary.js
@@ -2,7 +2,7 @@ import EmptyObject from './empty_object';
 
 // the delete is meant to hint at runtimes that this object should remain in
 // dictionary mode. This is clearly a runtime specific hack, but currently it
-// appears worthwhile in some usecases. Please note, these deletes do increase
+// appears worthwhile in some use cases. Please note, these deletes do increase
 // the cost of creation dramatically over a plain Object.create. And as this
 // only makes sense for long-lived dictionaries that aren't instantiated often.
 export default function makeDictionary(parent) {

--- a/packages/ember-metal/lib/watch_key.js
+++ b/packages/ember-metal/lib/watch_key.js
@@ -48,7 +48,7 @@ if (isEnabled('mandatory-setter')) {
   };
 
   // Future traveler, although this code looks scary. It merely exists in
-  // development to aid in development asertions. Production builds of
+  // development to aid in development assertions. Production builds of
   // ember strip this entire block out
   handleMandatorySetter = function handleMandatorySetter(m, obj, keyName) {
     let descriptor = lookupDescriptor(obj, keyName);

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -45,7 +45,7 @@ QUnit.test('computed properties defined with an object only allow `get` and `set
       set() {},
       other() {}
     });
-  }, 'Config object pased to a Ember.computed can only contain `get` or `set` keys.');
+  }, 'Config object passed to an Ember.computed can only contain `get` or `set` keys.');
 });
 
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -58,7 +58,7 @@ var EmberRouter = EmberObject.extend(Evented, {
     * `history` - use the browser's history API to make the URLs look just like any standard URL
     * `hash` - use `#` to separate the server part of the URL from the Ember part: `/blog/#/posts/new`
     * `none` - do not store the Ember URL in the actual browser URL (mainly used for testing)
-    * `auto` - use the best option based on browser capabilites: `history` if possible, then `hash` if possible, otherwise `none`
+    * `auto` - use the best option based on browser capabilities: `history` if possible, then `hash` if possible, otherwise `none`
 
     Note: If using ember-cli, this value is defaulted to `auto` by the `locationType` setting of `/config/environment.js`
 
@@ -129,7 +129,7 @@ var EmberRouter = EmberObject.extend(Evented, {
   },
 
   /*
-    Resets all pending query paramter changes.
+    Resets all pending query parameter changes.
     Called after transitioning to a new route
     based on query parameter changes.
   */
@@ -1193,7 +1193,7 @@ function appendLiveRoute(liveRoutes, defaultParentState, renderOptions) {
       // right here that the user tried to target a nonexistent
       // thing. But for now we still need to support the `render`
       // helper, and people are allowed to target templates rendered
-      // by the render helper. So instead we defer doing anyting with
+      // by the render helper. So instead we defer doing anything with
       // these orphan renders until afterRender.
       appendOrphan(liveRoutes, renderOptions.into, myState);
     } else {

--- a/packages/ember-routing/lib/utils.js
+++ b/packages/ember-routing/lib/utils.js
@@ -47,7 +47,7 @@ export function stashParamNames(router, handlerInfos) {
 }
 
 function _calculateCacheValuePrefix(prefix, part) {
-  // calculates the dot seperated sections from prefix that are also
+  // calculates the dot separated sections from prefix that are also
   // at the start of part - which gives us the route name
 
   // given : prefix = site.article.comments, part = site.article.id

--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -237,7 +237,7 @@ export function mapBy(dependentKey, propertyKey) {
   The callback method you provide should have the following signature.
   `item` is the current item in the iteration.
   `index` is the integer index of the current item in the iteration.
-  `array` is the dependant array itself.
+  `array` is the dependent array itself.
 
   ```javascript
   function(item, index, array);

--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -105,7 +105,7 @@ export default Mixin.create({
     handler.
 
     Because `get` unifies the syntax for accessing all these kinds
-    of properties, it can make many refactorings easier, such as replacing a
+    of properties, it can make many refactors easier, such as replacing a
     simple property with a computed property, or vice versa.
 
     ### Computed Properties

--- a/packages/ember-template-compiler/lib/system/compile_options.js
+++ b/packages/ember-template-compiler/lib/system/compile_options.js
@@ -19,7 +19,7 @@ compileOptions = function(_options) {
 
   let options;
   // When calling `Ember.Handlebars.compile()` a second argument of `true`
-  // had a special meaning (long since lost), this just gaurds against
+  // had a special meaning (long since lost), this just guards against
   // `options` being true, and causing an error during compilation.
   if (_options === true) {
     options = {};

--- a/packages/ember-views/lib/mixins/text_support.js
+++ b/packages/ember-views/lib/mixins/text_support.js
@@ -17,7 +17,7 @@ const KEY_EVENTS = {
   `TextSupport` is a shared mixin used by both `Ember.TextField` and
   `Ember.TextArea`. `TextSupport` adds a number of methods that allow you to
   specify a controller action to invoke when a certain event is fired on your
-  text field or textarea. The specifed controller action would get the current
+  text field or textarea. The specified controller action would get the current
   value of the field passed in as the only argument unless the value of
   the field is empty. In that case, the instance of the field itself is passed
   in as the only argument.

--- a/packages/ember-views/lib/system/utils.js
+++ b/packages/ember-views/lib/system/utils.js
@@ -42,7 +42,7 @@ export function getViewClientRects(view) {
   `getViewBoundingClientRect` provides information about the position of the
   bounding border box edges of a view relative to the viewport.
 
-  It is only intended to be used by development tools like the Ember Inpsector
+  It is only intended to be used by development tools like the Ember Inspector
   and may not work on older browsers.
 
   @private

--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -21,7 +21,7 @@ var renderer;
 /**
   `Ember.CoreView` is an abstract class that exists to give view-like behavior
   to both Ember's main view class `Ember.View` and other classes that don't need
-  the fully functionaltiy of `Ember.View`.
+  the fully functionality of `Ember.View`.
 
   Unless you have specific needs for `CoreView`, you will use `Ember.View`
   in your applications.


### PR DESCRIPTION
Was looking over some easy contributions for new contributors and spotted a few typos and figured that would be a good starting point.  Mostly just a few mis-spellings.
