### PR TITLE
Deprecate Ember.Handlebars.SafeString in favor of Ember.String.htmlSafe

### DIFF
--- a/packages/ember-htmlbars/lib/compat.js
+++ b/packages/ember-htmlbars/lib/compat.js
@@ -1,4 +1,5 @@
 import Ember from 'ember-metal/core';
+import { deprecateFunc } from 'ember-metal/debug';
 import {
   SafeString,
   escapeExpression
@@ -6,7 +7,15 @@ import {
 
 var EmberHandlebars = Ember.Handlebars = Ember.Handlebars || {};
 
-EmberHandlebars.SafeString = SafeString;
+EmberHandlebars.SafeString = deprecateFunc(
+  'Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe',
+  {
+    id: 'ember-htmlbars.ember-handlebars-safestring',
+    until: '3.0.0',
+    url: 'http://emberjs.com/deprecations/v2.x#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring'
+  },
+  SafeString);
+
 EmberHandlebars.Utils =  {
   escapeExpression: escapeExpression
 };

--- a/packages/ember-htmlbars/tests/compat/safe_string_test.js
+++ b/packages/ember-htmlbars/tests/compat/safe_string_test.js
@@ -1,0 +1,9 @@
+import EmberHandlebars from 'ember-htmlbars/compat';
+
+QUnit.module('ember-htmlbars: compat - SafeString');
+
+QUnit.test('using new results in a deprecation', function(assert) {
+  expectDeprecation(function() {
+    new EmberHandlebars.SafeString('test');
+  }, 'Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe');
+});


### PR DESCRIPTION
Addresses #13191 
