### PR TITLE
Add deprection warning for SafeString

### DIFF
--- a/packages/ember-htmlbars/lib/compat.js
+++ b/packages/ember-htmlbars/lib/compat.js
@@ -1,4 +1,5 @@
 import Ember from 'ember-metal/core';
+import { deprecateFunc } from 'ember-metal/debug';
 import {
   SafeString,
   escapeExpression
@@ -6,7 +7,7 @@ import {
 
 var EmberHandlebars = Ember.Handlebars = Ember.Handlebars || {};
 
-EmberHandlebars.SafeString = SafeString;
+EmberHandlebars.SafeString = deprecateFunc('Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe', { id: 'ember-htmlbars.ember-handlebars-safestring', until: '3.0.0' }, SafeString);
 EmberHandlebars.Utils =  {
   escapeExpression: escapeExpression
 };


### PR DESCRIPTION
As discussed in this [issue](https://github.com/emberjs/ember.js/issues/13191) We want to deprecate Ember.Handlebars.SafeString.

Deprecation documentation: https://github.com/emberjs/website/pull/2524
