### PR TITLE
Show deprecation warning when using didInitAttrs

### DIFF
--- a/packages/ember-htmlbars/tests/integration/component_lifecycle_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_lifecycle_test.js
@@ -133,7 +133,9 @@ styles.forEach(style => {
       twitter: '@tomdale'
     }).create();
 
-    runAppend(view);
+    expectDeprecation(() => {
+      runAppend(view);
+    }, /\[DEPRECATED\] didInitAttrs called in <\(subclass of Ember.Component\)\:ember[\d+]+>\./);
 
     ok(component, 'The component was inserted');
     equal(jQuery('#qunit-fixture').text(), 'Twitter: @tomdale Name: Tom Dale Website: tomdale.net');
@@ -285,7 +287,9 @@ styles.forEach(style => {
       twitter: '@tomdale'
     }).create();
 
-    runAppend(view);
+    expectDeprecation(() => {
+      runAppend(view);
+    }, /\[DEPRECATED\] didInitAttrs called in <\(subclass of Ember.Component\)\:ember[\d+]+>\./);
 
     ok(component, 'The component was inserted');
     equal(jQuery('#qunit-fixture').text(), 'Top: Middle: Bottom: @tomdale');
@@ -361,7 +365,9 @@ styles.forEach(style => {
   });
 
   QUnit.test('changing a component\'s displayed properties inside didInsertElement() is deprecated', function(assert) {
-    let component = style.class.extend({
+    let component;
+
+    component = style.class.extend({
       [OWNER]: owner,
       layout: compile('<div>{{handle}}</div>'),
       handle: '@wycats',
@@ -376,6 +382,28 @@ styles.forEach(style => {
     }, /modified inside the didInsertElement hook/);
 
     assert.strictEqual(component.$().text(), '@tomdale');
+
+    run(() => {
+      component.destroy();
+    });
+  });
+
+  QUnit.test('DEPRECATED: didInitAttrs is deprecated', function(assert) {
+    let component;
+
+    let componentClass = style.class.extend({
+      [OWNER]: owner,
+      layout: compile('<div>{{handle}}</div>'),
+      handle: '@wycats',
+
+      didInitAttrs() {
+        this._super(...arguments);
+      }
+    });
+
+    expectDeprecation(() => {
+      component = componentClass.create();
+    }, /\[DEPRECATED\] didInitAttrs called in <\(subclass of Ember.Component\)\:ember[\d+]+>\./);
 
     run(() => {
       component.destroy();

--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -12,6 +12,7 @@ import {
   applyStr
 } from 'ember-metal/utils';
 import { meta as metaFor, peekMeta } from 'ember-metal/meta';
+import { deprecate } from 'ember-metal/debug';
 
 import { ONCE, SUSPENDED } from 'ember-metal/meta_listeners';
 
@@ -83,6 +84,18 @@ export function accumulateListeners(obj, eventName, otherActions) {
 */
 export function addListener(obj, eventName, target, method, once) {
   assert('You must pass at least an object and event name to Ember.addListener', !!obj && !!eventName);
+
+  if (eventName === 'didInitAttrs' && obj.isComponent) {
+    deprecate(
+      `[DEPRECATED] didInitAttrs called in ${obj.toString()}.`,
+      false,
+      {
+        id: 'ember-views.did-init-attrs',
+        until: '3.0.0',
+        url: 'http://emberjs.com/deprecations/v2.x#toc_ember-component-didinitattrs'
+      }
+    );
+  }
 
   if (!method && 'function' === typeof target) {
     method = target;

--- a/packages/ember-metal/tests/events_test.js
+++ b/packages/ember-metal/tests/events_test.js
@@ -1,5 +1,6 @@
 import { Mixin } from 'ember-metal/mixin';
 import { meta } from 'ember-metal/meta';
+import Component from 'ember-views/components/component';
 
 import {
   on,
@@ -257,4 +258,12 @@ QUnit.test('a listener added as part of a mixin may be overridden', function() {
 
   sendEvent(obj, 'baz');
   equal(triggered, 1, 'should invoke from subclass property');
+});
+
+QUnit.test('DEPRECATED: adding didInitAttrs as a listener is deprecated', function() {
+  var obj = Component.create();
+
+  expectDeprecation(() => {
+    addListener(obj, 'didInitAttrs');
+  }, /\[DEPRECATED\] didInitAttrs called in <\Ember.Component\:ember[\d+]+>\./);
 });

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -630,6 +630,18 @@ export default Mixin.create({
 
     this[INIT_WAS_CALLED] = true;
 
+    if (typeof(this.didInitAttrs) === 'function') {
+      deprecate(
+        `[DEPRECATED] didInitAttrs called in ${this.toString()}.`,
+        false,
+        {
+          id: 'ember-views.did-init-attrs',
+          until: '3.0.0',
+          url: 'http://emberjs.com/deprecations/v2.x#toc_ember-component-didinitattrs'
+        }
+      );
+    }
+
     assert(
       'Using a custom `.render` function is no longer supported.',
       !this.render


### PR DESCRIPTION
[Deprecation Guide](https://github.com/emberjs/website/pull/2525)
[Related Issue](https://github.com/emberjs/ember.js/issues/13033)

This adds deprecation warning when using `didInitAttrs`. The preferred way is to now use `init`. Refer to related issue for more details.
