### PR TITLE
[BUGFIX RELEASE] Do not refresh routes on initial transition

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -759,7 +759,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
       var totalChanged = Object.keys(changed).concat(Object.keys(removed));
       for (var i = 0, len = totalChanged.length; i < len; ++i) {
         var qp = qpMap[totalChanged[i]];
-        if (qp && get(this._optionsForQueryParam(qp), 'refreshModel')) {
+        if (qp && get(this._optionsForQueryParam(qp), 'refreshModel') && this.router.currentState) {
           this.refresh();
         }
       }

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -378,6 +378,33 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     equal(indexModelCount, 2);
   });
 
+  QUnit.test('refreshModel does not cause a second transition during app boot ', function() {
+    expect(0);
+
+    App.ApplicationRoute = Route.extend({
+      queryParams: {
+        appomg: {
+          defaultValue: 'applol'
+        }
+      }
+    });
+
+    App.IndexRoute = Route.extend({
+      queryParams: {
+        omg: {
+          defaultValue: 'lol',
+          refreshModel: true
+        }
+      },
+      refresh: function() {
+        ok(false);
+      }
+    });
+
+    startingURL = '/?appomg=hello&omg=world';
+    bootApplication();
+  });
+
   QUnit.test('can use refreshModel even w URL changes that remove QPs from address bar when QP configured on route', function() {
     expect(4);
 
@@ -2436,6 +2463,33 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
 
     equal(appModelCount, 1);
     equal(indexModelCount, 2);
+  });
+
+  QUnit.test('refreshModel does not cause a second transition during app boot ', function() {
+    expect(0);
+    App.ApplicationController = Controller.extend({
+      queryParams: ['appomg'],
+      appomg: 'applol'
+    });
+
+    App.IndexController = Controller.extend({
+      queryParams: ['omg'],
+      omg: 'lol'
+    });
+
+    App.IndexRoute = Route.extend({
+      queryParams: {
+        omg: {
+          refreshModel: true
+        }
+      },
+      refresh: function() {
+        ok(false);
+      }
+    });
+
+    startingURL = '/?appomg=hello&omg=world';
+    bootApplication();
   });
 
   QUnit.test('Use Ember.get to retrieve query params \'refreshModel\' configuration', function() {


### PR DESCRIPTION
Refreshing the route heighercy do to query param change on the initial transition is pointless, so now we only call refresh if there is a `currentState`. This fixes #10945
