### PR TITLE
Objects that define INVOKE can be cast to actions

### DIFF
--- a/packages/ember-routing-htmlbars/lib/keywords/closure-action.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/closure-action.js
@@ -45,6 +45,9 @@ export default function closureAction(morph, env, scope, params, hash, template,
         if (!action) {
           throw new EmberError(`An action named '${actionName}' was not found in ${target}.`);
         }
+      } else if (action && typeof action[INVOKE] === 'function') {
+        target = action;
+        action = action[INVOKE];
       } else if (actionType !== 'function') {
         throw new EmberError(`An action could not be made for \`${rawAction.label}\` in ${target}. Please confirm that you are using either a quoted action name (i.e. \`(action '${rawAction.label}')\`) or a function available in ${target}.`);
       }

--- a/packages/ember-routing-htmlbars/tests/helpers/closure_action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/closure_action_test.js
@@ -2,6 +2,7 @@ import run from 'ember-metal/run_loop';
 import compile from 'ember-template-compiler/system/compile';
 import EmberComponent from 'ember-views/components/component';
 import { computed } from 'ember-metal/computed';
+import { INVOKE } from 'ember-routing-htmlbars/keywords/closure-action';
 
 import {
   runAppend,
@@ -546,6 +547,34 @@ QUnit.test('action should be called within a run loop', function(assert) {
         assert.ok(run.currentRunLoop, 'action is called within a run loop');
       }
     }
+  }).create();
+
+  runAppend(outerComponent);
+
+  innerComponent.fireAction();
+});
+
+QUnit.test('objects that define INVOKE can be casted to actions', function(assert) {
+  assert.expect(2);
+
+  innerComponent = EmberComponent.extend({
+    fireAction() {
+      assert.equal(this.attrs.submit(4,5,6), 123);
+    }
+  }).create();
+
+  outerComponent = EmberComponent.extend({
+    layout: compile(`{{view innerComponent submit=(action submitTask 1 2 3)}}`),
+    innerComponent,
+    foo: 123,
+    submitTask: computed(function() {
+      return {
+        [INVOKE]: (...args) => {
+          assert.deepEqual(args, [1,2,3,4,5,6]);
+          return this.foo;
+        }
+      };
+    })
   }).create();
 
   runAppend(outerComponent);


### PR DESCRIPTION
This is useful for ember-concurrency (and other similar
ideas I've tried in the past) where you want to be
able to pass an object directly to the action helper
(rather than having to define another kind of helper
that does the casting for you).

cc @rwjblue @mixonic
