### PR TITLE
Fix deprecation for Ember.Handlebars.SafeString.

### DIFF
--- a/packages/ember-htmlbars/lib/compat.js
+++ b/packages/ember-htmlbars/lib/compat.js
@@ -1,20 +1,25 @@
 import Ember from 'ember-metal/core';
-import { deprecateFunc } from 'ember-metal/debug';
+import { htmlSafe } from 'ember-htmlbars/utils/string';
+import { deprecate } from 'ember-metal/debug';
 import {
-  SafeString,
   escapeExpression
 } from 'ember-htmlbars/utils/string';
 
 var EmberHandlebars = Ember.Handlebars = Ember.Handlebars || {};
 
-EmberHandlebars.SafeString = deprecateFunc(
-  'Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe',
-  {
-    id: 'ember-htmlbars.ember-handlebars-safestring',
-    until: '3.0.0',
-    url: 'http://emberjs.com/deprecations/v2.x#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring'
-  },
-  SafeString);
+EmberHandlebars.SafeString = function(value) {
+  deprecate(
+    'Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe',
+    false,
+    {
+      id: 'ember-htmlbars.ember-handlebars-safestring',
+      until: '3.0.0',
+      url: 'http://emberjs.com/deprecations/v2.x#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring'
+    }
+  );
+
+  return htmlSafe(value);
+};
 
 EmberHandlebars.Utils =  {
   escapeExpression: escapeExpression

--- a/packages/ember-htmlbars/tests/compat/safe_string_test.js
+++ b/packages/ember-htmlbars/tests/compat/safe_string_test.js
@@ -3,7 +3,11 @@ import EmberHandlebars from 'ember-htmlbars/compat';
 QUnit.module('ember-htmlbars: compat - SafeString');
 
 QUnit.test('using new results in a deprecation', function(assert) {
+  let result;
+
   expectDeprecation(function() {
-    new EmberHandlebars.SafeString('test');
+    result = new EmberHandlebars.SafeString('<b>test</b>');
   }, 'Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe');
+
+  assert.equal(result.toHTML(), '<b>test</b>');
 });


### PR DESCRIPTION
We have been trolled by exactly the same issue that has caused us to deprecate `Ember.Handlebars.SafeString` to begin with. Invoking the function doesn't actually work, we must instantiate a class (which is not done by `deprecateFunc`).

:trollface: 

Fixes #13225.
