### PR TITLE
[DOC] Update NativeArray documentation

### DIFF
--- a/packages/ember-runtime/lib/system/native_array.js
+++ b/packages/ember-runtime/lib/system/native_array.js
@@ -23,7 +23,7 @@ import copy from 'ember-runtime/copy';
   Array support Ember.MutableArray and all of its dependent APIs. Unless you
   have `Ember.EXTEND_PROTOTYPES` or `Ember.EXTEND_PROTOTYPES.Array` set to
   false, this will be applied automatically. Otherwise you can apply the mixin
-  at anytime by calling `Ember.NativeArray.activate`.
+  at anytime by calling `Ember.NativeArray.apply(Array.prototype)`.
 
   @class NativeArray
   @namespace Ember


### PR DESCRIPTION
`NativeArray.activate` was removed several months ago, but the documentation for the mixin still recommends that method for activating it. This change updates the docs to suggest the same code that is used internally by the `NativeArray` mixin to apply itself to `Array.prototype`.

/cc @rwjblue 
