### PR TITLE
[WIP] [BUGFIX release] Ensure CP's are `_super` wrapped.

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -141,9 +141,10 @@ function giveMethodSuper(obj, key, method, values, descs) {
   // the original object
   superMethod = superMethod || obj[key];
 
-  // Only wrap the new method if the original method was a function
+  // wrap the new method even if the original method undefined/not a function
+  // to ensure `_super` is present
   if (superMethod === undefined || 'function' !== typeof superMethod) {
-    return method;
+    superMethod = function() {};
   }
 
   return wrap(method, superMethod);

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -85,7 +85,7 @@ function concatenatedMixinProperties(concatProp, props, values, base) {
 }
 
 function giveDescriptorSuper(meta, key, property, values, descs, base) {
-  var superProperty;
+  let superProperty;
 
   // Computed properties override methods, and do not call super to them
   if (values[key] === undefined) {
@@ -102,8 +102,14 @@ function giveDescriptorSuper(meta, key, property, values, descs, base) {
     superProperty = superDesc;
   }
 
+  // add a default `_super` to ensure proper wrapping if `_super` is used in `property`
   if (superProperty === undefined || !(superProperty instanceof ComputedProperty)) {
-    return property;
+    superProperty = { _getter() {} };
+
+    // only provide a super setter if the property has one already
+    if (property._setter) {
+      superProperty._setter = function() {};
+    }
   }
 
   // Since multiple mixins may inherit from the same parent, we need

--- a/packages/ember-metal/tests/mixin/computed_test.js
+++ b/packages/ember-metal/tests/mixin/computed_test.js
@@ -139,3 +139,59 @@ QUnit.test('setter behavior works properly when overriding computed properties',
   equal(get(obj, 'cpWithoutSetter'), 'test', 'The default setter was called, the value is correct');
   ok(!cpWasCalled, 'The default setter was called, not the CP itself');
 });
+
+QUnit.test('calling _super from a getter when no inherited descriptor exists is bound properly [#13230]', function() {
+  let obj;
+
+  let MixinA = Mixin.create({
+    foo() {
+      return 'foo';
+    }
+  });
+
+  let MixinB = Mixin.create(MixinA, {
+    aProp: computed(function() {
+      return this._super(...arguments) + 'B';
+    }),
+
+    foo() {
+      return this._super(...arguments) + get(this, 'aProp');
+    }
+  });
+
+  obj = {};
+  MixinB.apply(obj);
+  equal(obj.foo(), 'fooundefinedB');
+});
+
+QUnit.test('calling _super from a setter when no inherited descriptor exists is bound properly [#13230]', function() {
+  let obj;
+
+  let MixinA = Mixin.create({
+    foo() {
+      return 'foo';
+    }
+  });
+
+  let MixinB = Mixin.create(MixinA, {
+    aProp: computed({
+      get() {
+        return this._super(...arguments) + 'B';
+      },
+
+      set() {
+        return this._super(...arguments) + 'C';
+      }
+    }),
+
+    foo() {
+      set(this, 'aProp', 'foo');
+
+      return this._super(...arguments) + get(this, 'aProp');
+    }
+  });
+
+  obj = {};
+  MixinB.apply(obj);
+  equal(obj.foo(), 'fooundefinedC');
+});

--- a/packages/ember-metal/tests/mixin/method_test.js
+++ b/packages/ember-metal/tests/mixin/method_test.js
@@ -130,6 +130,30 @@ QUnit.test('_super from a single mixin with no superclass does not error', funct
   ok(true);
 });
 
+QUnit.test('_super is not shared when invoking additional method with no superclass method [#13230]', function() {
+  let MixinA = Mixin.create({
+    foo() {
+      return this._super(...arguments) + '|MixinA-foo|';
+    }
+  });
+
+  let MixinB = Mixin.create(MixinA, {
+    bar() {
+      return this._super(...arguments) + '|MixinB-bar|';
+    },
+
+    foo() {
+      let superValue = this._super(...arguments);
+      return superValue + 'MixinB-foo|' + this.bar();
+    }
+  });
+
+  var obj = {};
+  MixinB.apply(obj);
+
+  equal(obj.foo(), 'undefined|MixinA-foo|MixinB-foo|undefined|MixinB-bar|');
+});
+
 QUnit.test('_super from a first-of-two mixins with no superclass function does not error', function() {
   // _super was previously calling itself in the second assertion.
   // Use remaining count of calls to ensure it doesn't loop indefinitely.


### PR DESCRIPTION
Prior to this change, a CP that was not included in the superclass would not get re-wrapped. This means that when calling it from another function that is required to be super wrapped would set that other function as the `_super`.

This changes to ensure that all descriptors are wrapped if they include `_super` (`hasSuper` check on platforms that support `Function.prototype.toString`).

Fixes #13230.

/cc @stefanpenner
