### PR TITLE
[wip] failing test for `{{link-to}}` active class

### DIFF
--- a/packages/ember/tests/helpers/link_to_test/link_to_transitioning_classes_test.js
+++ b/packages/ember/tests/helpers/link_to_test/link_to_transitioning_classes_test.js
@@ -241,4 +241,34 @@ QUnit.test('with an aborted transition', function() {
   assertHasClass('ember-transitioning-out', $about, false);
 });
 
+QUnit.test('with a parent root model hook which performs a `transitionTo`', function() {
+  expect(1);
+
+  Router.map(function() {
+    this.route('about');
+    this.route('parent', function() {
+      this.route('child');
+    });
+  });
+
+  App.ParentRoute = Route.extend({
+    afterModel(transition) {
+      this.transitionTo('parent.child');
+    }
+  });
+
+  Ember.TEMPLATES.application = compile(`
+    {{link-to 'About' 'about' id='about-link'}}
+    {{link-to 'Parent' 'parent' id='parent-link'}}
+  `);
+
+  bootApplication();
+
+  var $parent = jQuery('#parent-link');
+
+  run($parent, 'click');
+
+  assertHasClass('active', $parent, true);
+});
+
 }


### PR DESCRIPTION
for https://github.com/emberjs/ember.js/issues/13256
