### PR TITLE
[BUGFIX beta] revert #13169 and add test to cover {{link-to}} active class regression

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -731,11 +731,6 @@ var EmberRouter = EmberObject.extend(Evented, {
   currentState: null,
   targetState: null,
 
-  _resetTargetState() {
-    let currentState = this.get('currentState');
-    this.set('targetState', currentState);
-  },
-
   _handleSlowTransition(transition, originRoute) {
     if (!this.router.activeTransition) {
       // Don't fire an event if we've since moved on from
@@ -1106,7 +1101,6 @@ function didBeginTransition(transition, router) {
     if (router._isErrorHandled(errorId)) {
       router._clearHandledError(errorId);
     } else {
-      router._resetTargetState();
       throw error;
     }
   });

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1730,4 +1730,30 @@ QUnit.test('The {{link-to}} helper can use dynamic params', function() {
   equal(link.attr('href'), '/bar/one/two/three');
 });
 
+QUnit.test('GJ: {{link-to}} to a parent root model hook which performs a `transitionTo` has correct active class #13256', function() {
+  expect(1);
+
+  Router.map(function() {
+    this.route('parent', function() {
+      this.route('child');
+    });
+  });
+
+  App.ParentRoute = Route.extend({
+    afterModel(transition) {
+      this.transitionTo('parent.child');
+    }
+  });
+
+  Ember.TEMPLATES.application = compile(`
+    {{link-to 'Parent' 'parent' id='parent-link'}}
+  `);
+
+  bootApplication();
+
+  run(jQuery('#parent-link'), 'click');
+
+  shouldBeActive('#parent-link');
+});
+
 }

--- a/packages/ember/tests/helpers/link_to_test/link_to_transitioning_classes_test.js
+++ b/packages/ember/tests/helpers/link_to_test/link_to_transitioning_classes_test.js
@@ -204,41 +204,4 @@ QUnit.test('while a transition is underway with nested link-to\'s', function() {
   assertHasClass('ember-transitioning-out', $index, false, $about, false, $other, false);
 });
 
-QUnit.test('with an aborted transition', function() {
-  expect(6);
-
-  Router.map(function() {
-    this.route('about');
-  });
-
-  App.AboutRoute = Route.extend({
-    beforeModel(transition) {
-      aboutDefer = RSVP.defer();
-      return aboutDefer.promise.then(function() {
-        transition.abort();
-      });
-    }
-  });
-
-  Ember.TEMPLATES.application = compile(`
-    {{link-to 'About' 'about' id='about-link'}}
-  `);
-
-  bootApplication();
-
-  var $about = jQuery('#about-link');
-
-  run($about, 'click');
-
-  assertHasClass('active', $about, false);
-  assertHasClass('ember-transitioning-in', $about, true);
-  assertHasClass('ember-transitioning-out', $about, false);
-
-  run(aboutDefer, 'resolve');
-
-  assertHasClass('active', $about, false);
-  assertHasClass('ember-transitioning-in', $about, false);
-  assertHasClass('ember-transitioning-out', $about, false);
-});
-
 }


### PR DESCRIPTION
fixes https://github.com/emberjs/ember.js/issues/13256
reopens https://github.com/emberjs/ember.js/issues/13164

TIL doing a `transitionTo` in a route model hook results in a `TransitionAborted` error. I was [using](https://github.com/emberjs/ember.js/pull/13169) that to reset the router target state to address https://github.com/emberjs/ember.js/issues/13164. This won't work so I'm reverting https://github.com/emberjs/ember.js/pull/13169 and adding a test to cover the regression.
