### PR TITLE
[FEATURE wai-aria-attribute-support] Modifies the aria_role_support Mixin to support any WAI-ARIA property that starts with 'aria-'

### DIFF
--- a/packages/ember-glimmer/lib/ember-views/component.js
+++ b/packages/ember-glimmer/lib/ember-views/component.js
@@ -3,7 +3,7 @@ import ChildViewsSupport from './child-views-support';
 import ClassNamesSupport from './class-names-support';
 import ViewStateSupport from 'ember-views/mixins/view_state_support';
 import InstrumentationSupport from 'ember-views/mixins/instrumentation_support';
-import AriaRoleSupport from 'ember-views/mixins/aria_role_support';
+import AriaSupport from 'ember-views/mixins/aria_support';
 import ViewMixin from 'ember-views/mixins/view_support';
 import EmberView from 'ember-views/views/view';
 
@@ -12,7 +12,7 @@ export default CoreView.extend(
   ViewStateSupport,
   ClassNamesSupport,
   InstrumentationSupport,
-  AriaRoleSupport,
+  AriaSupport,
   ViewMixin, {
     isComponent: true,
     template: null,

--- a/packages/ember-htmlbars/lib/glimmer-component.js
+++ b/packages/ember-htmlbars/lib/glimmer-component.js
@@ -4,7 +4,7 @@ import ViewStateSupport from 'ember-views/mixins/view_state_support';
 import TemplateRenderingSupport from 'ember-views/mixins/template_rendering_support';
 import ClassNamesSupport from 'ember-views/mixins/class_names_support';
 import InstrumentationSupport from 'ember-views/mixins/instrumentation_support';
-import AriaRoleSupport from 'ember-views/mixins/aria_role_support';
+import AriaSupport from 'ember-views/mixins/aria_support';
 import ViewMixin from 'ember-views/mixins/view_support';
 import EmberView from 'ember-views/views/view';
 
@@ -14,7 +14,7 @@ export default CoreView.extend(
   TemplateRenderingSupport,
   ClassNamesSupport,
   InstrumentationSupport,
-  AriaRoleSupport,
+  AriaSupport,
   ViewMixin, {
     isComponent: true,
     isGlimmerComponent: true,

--- a/packages/ember-views/lib/mixins/aria_support.js
+++ b/packages/ember-views/lib/mixins/aria_support.js
@@ -6,12 +6,26 @@
 import { Mixin } from 'ember-metal/mixin';
 
 /**
- @class AriaRoleSupport
+ @class AriaSupport
  @namespace Ember
  @private
 */
 export default Mixin.create({
   attributeBindings: ['ariaRole:role'],
+
+  init() {
+    this._super(...arguments);
+
+    if (!this.attributeBindings) {
+      this.attributeBindings = [];
+    }
+
+    Object.keys(this).forEach(attr => {
+      if (attr.startsWith('aria-')) {
+        this.attributeBindings.push(attr);
+      }
+    });
+  },
 
   /**
    The WAI-ARIA role of the control represented by this view. For example, a

--- a/packages/ember-views/lib/mixins/aria_support.js
+++ b/packages/ember-views/lib/mixins/aria_support.js
@@ -21,7 +21,7 @@ export default Mixin.create({
     }
 
     Object.keys(this).forEach(attr => {
-      if (attr.startsWith('aria-')) {
+      if (/^aria-/i.test(attr)) {
         this.attributeBindings.push(attr);
       }
     });

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -14,7 +14,7 @@ import TemplateRenderingSupport from 'ember-views/mixins/template_rendering_supp
 import ClassNamesSupport from 'ember-views/mixins/class_names_support';
 import LegacyViewSupport from 'ember-views/mixins/legacy_view_support';
 import InstrumentationSupport from 'ember-views/mixins/instrumentation_support';
-import AriaRoleSupport from 'ember-views/mixins/aria_role_support';
+import AriaSupport from 'ember-views/mixins/aria_support';
 import VisibilitySupport from 'ember-views/mixins/visibility_support';
 import CompatAttrsProxy from 'ember-views/compat/attrs-proxy';
 import ViewMixin from 'ember-views/mixins/view_support';
@@ -645,7 +645,7 @@ import { deprecateProperty } from 'ember-metal/deprecate_property';
   @uses Ember.LegacyViewSupport
   @uses Ember.InstrumentationSupport
   @uses Ember.VisibilitySupport
-  @uses Ember.AriaRoleSupport
+  @uses Ember.AriaSupport
   @public
 */
 // jscs:disable validateIndentation
@@ -660,7 +660,7 @@ var View = CoreView.extend(
   InstrumentationSupport,
   VisibilitySupport,
   CompatAttrsProxy,
-  AriaRoleSupport,
+  AriaSupport,
   ViewMixin, {
     init() {
       this._super(...arguments);

--- a/packages/ember-views/tests/views/view/attribute_bindings_test.js
+++ b/packages/ember-views/tests/views/view/attribute_bindings_test.js
@@ -467,6 +467,24 @@ QUnit.test('role attribute is not included if not provided', function() {
   ok(!view.element.hasAttribute('role'), 'role attribute is not present');
 });
 
+QUnit.test('aria-label attribute is included if provided', function() {
+  view = EmberView.create({
+    'aria-label': 'Aria label'
+  });
+
+  appendView();
+
+  equal(view.$().attr('aria-label'), 'Aria label');
+});
+
+QUnit.test('aria-label attribute is not included if not provided', function() {
+  view = EmberView.create();
+
+  appendView();
+
+  ok(!view.element.hasAttribute('aria-label'), 'aria-label attribute is not present');
+});
+
 QUnit.test('can set id initially via attributeBindings', function() {
   view = EmberView.create({
     attributeBindings: ['specialSauce:id'],


### PR DESCRIPTION
Implements the feature https://github.com/emberjs/ember.js/issues/13224

With this modification, any property defined in Views or Components that starts with 'aria-' will be rendered into the View/Component's DOM, improving accessibility in Ember.js apps.
