### PR TITLE
[DOC release] Fixes `defineProperty` computed property code sample

### DIFF
--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -96,9 +96,9 @@ export function INHERITING_GETTER_FUNCTION(name) {
   Ember.defineProperty(contact, 'lastName', undefined, 'Jolley');
 
   // define a computed property
-  Ember.defineProperty(contact, 'fullName', Ember.computed(function() {
+  Ember.defineProperty(contact, 'fullName', Ember.computed('firstName', 'lastName', function() {
     return this.firstName+' '+this.lastName;
-  }).property('firstName', 'lastName'));
+  }));
   ```
 
   @private


### PR DESCRIPTION
Was using function prototype extension instead of passing arguments to `Ember.computed`.
