### PR TITLE
Deprecate usage of `{{render` helper with a model param

### DIFF
--- a/packages/ember-routing-htmlbars/tests/helpers/render_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/render_test.js
@@ -143,11 +143,13 @@ QUnit.test('{{render}} helper should render given template with a supplied model
     [OWNER]: appInstance
   });
 
-  view = EmberView.create({
-    [OWNER]: appInstance,
-    controller: controller,
-    template: compile(template)
-  });
+  expectDeprecation(() => {
+    view = EmberView.create({
+      [OWNER]: appInstance,
+      controller: controller,
+      template: compile(template)
+    });
+  }, /Please refactor [\w\{\}"` ]+ to a component/);
 
   var postController;
   var PostController = EmberController.extend({
@@ -181,11 +183,13 @@ QUnit.test('{{render}} helper with a supplied model should not fire observers on
     post: post
   });
 
-  view = EmberView.create({
-    [OWNER]: appInstance,
-    controller,
-    template: compile(template)
-  });
+  expectDeprecation(() => {
+    view = EmberView.create({
+      [OWNER]: appInstance,
+      controller,
+      template: compile(template)
+    });
+  }, /Please refactor [\w\{\}"` ]+ to a component/);
 
   var PostController = EmberController.extend({
     modelDidChange: observer('model', function() {
@@ -336,11 +340,13 @@ QUnit.test('{{render}} helper should render templates with models multiple times
     [OWNER]: appInstance
   });
 
-  view = EmberView.create({
-    [OWNER]: appInstance,
-    controller: controller,
-    template: compile(template)
-  });
+  expectDeprecation(() => {
+    view = EmberView.create({
+      [OWNER]: appInstance,
+      controller: controller,
+      template: compile(template)
+    });
+  }, /Please refactor [\w\{\}"` ]+ to a component/);
 
   var postController1, postController2;
   var PostController = EmberController.extend({
@@ -383,11 +389,13 @@ QUnit.test('{{render}} helper should not leak controllers', function() {
     [OWNER]: appInstance
   });
 
-  view = EmberView.create({
-    [OWNER]: appInstance,
-    controller: controller,
-    template: compile(template)
-  });
+  expectDeprecation(() => {
+    view = EmberView.create({
+      [OWNER]: appInstance,
+      controller: controller,
+      template: compile(template)
+    });
+  }, /Please refactor [\w\{\}"` ]+ to a component/);
 
   var postController;
   var PostController = EmberController.extend({
@@ -415,11 +423,13 @@ QUnit.test('{{render}} helper should not treat invocations with falsy contexts a
     zero: false
   });
 
-  view = EmberView.create({
-    [OWNER]: appInstance,
-    controller,
-    template: compile(template)
-  });
+  expectDeprecation(() => {
+    view = EmberView.create({
+      [OWNER]: appInstance,
+      controller,
+      template: compile(template)
+    });
+  }, /Please refactor [\w\{\}"` ]+ to a component/);
 
   var postController1, postController2;
   var PostController = EmberController.extend({
@@ -457,11 +467,13 @@ QUnit.test('{{render}} helper should render templates both with and without mode
     [OWNER]: appInstance
   });
 
-  view = EmberView.create({
-    [OWNER]: appInstance,
-    controller: controller,
-    template: compile(template)
-  });
+  expectDeprecation(() => {
+    view = EmberView.create({
+      [OWNER]: appInstance,
+      controller: controller,
+      template: compile(template)
+    });
+  }, /Please refactor [\w\{\}"` ]+ to a component/);
 
   var postController1, postController2;
   var PostController = EmberController.extend({
@@ -695,16 +707,18 @@ QUnit.test('{{render}} helper should not require view to provide its own templat
 });
 
 QUnit.test('{{render}} helper should set router as target when parentController is not found', function() {
-  expect(2);
+  expect(3);
 
   Ember.ENV._ENABLE_LEGACY_CONTROLLER_SUPPORT = false;
 
   let template = `{{render 'post' post1}}`;
 
-  view = EmberView.create({
-    [OWNER]: appInstance,
-    template: compile(template)
-  });
+  expectDeprecation(() => {
+    view = EmberView.create({
+      [OWNER]: appInstance,
+      template: compile(template)
+    });
+  }, /Please refactor [\w\{\}"` ]+ to a component/);
 
   let postController;
   let PostController = EmberController.extend({

--- a/packages/ember-template-compiler/lib/index.js
+++ b/packages/ember-template-compiler/lib/index.js
@@ -14,6 +14,7 @@ import TransformAngleBracketComponents from 'ember-template-compiler/plugins/tra
 import TransformInputOnToOnEvent from 'ember-template-compiler/plugins/transform-input-on-to-onEvent';
 import TransformTopLevelComponents from 'ember-template-compiler/plugins/transform-top-level-components';
 import TransformUnescapedInlineLinkTo from 'ember-template-compiler/plugins/transform-unescaped-inline-link-to';
+import DeprecateRenderModel from 'ember-template-compiler/plugins/deprecate-render-model';
 import AssertNoViewAndControllerPaths from 'ember-template-compiler/plugins/assert-no-view-and-controller-paths';
 import AssertNoViewHelper from 'ember-template-compiler/plugins/assert-no-view-helper';
 import AssertNoEachIn from 'ember-template-compiler/plugins/assert-no-each-in';
@@ -31,6 +32,7 @@ registerPlugin('ast', TransformAngleBracketComponents);
 registerPlugin('ast', TransformInputOnToOnEvent);
 registerPlugin('ast', TransformTopLevelComponents);
 registerPlugin('ast', TransformUnescapedInlineLinkTo);
+registerPlugin('ast', DeprecateRenderModel);
 registerPlugin('ast', AssertNoEachIn);
 
 if (!_Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT) {

--- a/packages/ember-template-compiler/lib/plugins/deprecate-render-model.js
+++ b/packages/ember-template-compiler/lib/plugins/deprecate-render-model.js
@@ -1,0 +1,52 @@
+import { deprecate } from 'ember-metal/debug';
+import calculateLocationDisplay from
+  'ember-template-compiler/system/calculate-location-display';
+
+export default function DeprecateRenderModel(options) {
+  this.syntax = null;
+  this.options = options;
+}
+
+DeprecateRenderModel.prototype.transform =
+  function DeprecateRenderModel_transform(ast) {
+  let moduleName = this.options.moduleName;
+  let walker = new this.syntax.Walker();
+
+  walker.visit(ast, function(node) {
+    if (!validate(node)) { return; }
+
+    each(node.params, (param) => {
+      if (param.type !== 'PathExpression') { return; }
+
+      deprecate(deprecationMessage(moduleName, node, param), false, {
+        id: 'ember-template-compiler.deprecate-render-model',
+        until: '3.0.0'
+      });
+    });
+  });
+
+  return ast;
+};
+
+function validate(node) {
+  return (node.type === 'MustacheStatement') &&
+    (node.path.original === 'render') &&
+    (node.params.length > 1);
+}
+
+function each(list, callback) {
+  for (let i = 0, l = list.length; i < l; i++) {
+    callback(list[i]);
+  }
+}
+
+function deprecationMessage(moduleName, node, param) {
+  let sourceInformation = calculateLocationDisplay(moduleName, node.loc);
+  let componentName = node.params[0].original;
+  let modelName = param.original;
+  let original = `{{render "${componentName}" ${modelName}}}`;
+  let preferred = `{{${componentName} model=${modelName}}}`;
+
+  return `Please refactor \`${original}\` to a component and invoke via` +
+    ` \`${preferred}\`. ${sourceInformation}`;
+}

--- a/packages/ember-template-compiler/tests/plugins/deprecate-render-model-test.js
+++ b/packages/ember-template-compiler/tests/plugins/deprecate-render-model-test.js
@@ -1,0 +1,22 @@
+import { compile } from 'ember-template-compiler';
+import isEnabled from 'ember-metal/features';
+
+if (!isEnabled('ember-glimmer')) {
+  // jscs:disable
+
+  QUnit.module('ember-template-compiler: deprecate-model-render');
+  
+  QUnit.test('Using `{{render` with model provides a deprecation', function() {
+    expect(1);
+
+    let expectedMessage =
+      `Please refactor \`{{render "foo-bar" coolModel}}\` to a component and` +
+      ` invoke via \`{{foo-bar model=coolModel}}\`. ('baz/foo-bar' @ L1:C0) `;
+  
+    expectDeprecation(function() {
+      compile('{{render "foo-bar" coolModel}}', {
+        moduleName: 'baz/foo-bar'
+      });
+    }, expectedMessage);
+  });
+}


### PR DESCRIPTION
Addresses first part of #13183.

This is my first time diving into Ember internals like this, so I'm pretty sure it won't be 100% off the bat. Also not sure about how to tag this.
