### PR TITLE
Make computed.or and computed.and support property expansion

### DIFF
--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -14,11 +14,15 @@ import expandProperties from 'ember-metal/expand_properties';
 
 function getProperties(self, propertyNames) {
   var ret = {};
-  for (var i = 0; i < propertyNames.length; i++) {
-    expandProperties(propertyNames[i], function (name) {
-      ret[name] = get(self, name);
-    });
+
+  function extractProperty(name) {
+    ret[name] = get(self, name);
   }
+
+  for (var i = 0; i < propertyNames.length; i++) {
+    expandProperties(propertyNames[i], extractProperty);
+  }
+
   return ret;
 }
 

--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -413,22 +413,30 @@ export function lte(dependentKey, value) {
   A computed property that performs a logical `and` on the
   original values for the provided dependent properties.
 
+  You may pass in more than two properties and even use
+  property brace expansion.  The computed property will
+  returns the first falsy value or last truthy value
+  just like JavaScript's `||` operator.
+
   Example
 
   ```javascript
   var Hamster = Ember.Object.extend({
-    readyForCamp: Ember.computed.and('hasTent', 'hasBackpack')
+    readyForCamp: Ember.computed.and('hasTent', 'hasBackpack'),
+    readyForHike: Ember.computed.and('hasWalkingStick', 'hasBackpack')
   });
 
-  var hamster = Hamster.create();
+  var tomster = Hamster.create();
 
-  hamster.get('readyForCamp'); // false
-  hamster.set('hasTent', true);
-  hamster.get('readyForCamp'); // false
-  hamster.set('hasBackpack', true);
-  hamster.get('readyForCamp'); // true
-  hamster.set('hasBackpack', 'Yes');
-  hamster.get('readyForCamp'); // 'Yes'
+  tomster.get('readyForCamp'); // false
+  tomster.set('hasTent', true);
+  tomster.get('readyForCamp'); // false
+  tomster.set('hasBackpack', true);
+  tomster.get('readyForCamp'); // true
+  tomster.set('hasBackpack', 'Yes');
+  tomster.get('readyForCamp'); // 'Yes'
+  tomster.set('hasWalkingStick', null);
+  tomster.get('readyForHike'); // null
   ```
 
   @method and
@@ -453,20 +461,28 @@ export var and = generateComputedWithProperties(function(properties) {
   A computed property which performs a logical `or` on the
   original values for the provided dependent properties.
 
+  You may pass in more than two properties and even use
+  property brace expansion.  The computed property will
+  returns the first truthy value or last falsy value just
+  like JavaScript's `||` operator.
+
   Example
 
   ```javascript
   var Hamster = Ember.Object.extend({
-    readyForRain: Ember.computed.or('hasJacket', 'hasUmbrella')
+    readyForRain: Ember.computed.or('hasJacket', 'hasUmbrella'),
+    readyForBeach: Ember.computed.or('{hasSunscreen,hasUmbrella}')
   });
 
-  var hamster = Hamster.create();
+  var tomster = Hamster.create();
 
-  hamster.get('readyForRain'); // false
-  hamster.set('hasUmbrella', true);
-  hamster.get('readyForRain'); // true
-  hamster.set('hasJacket', 'Yes');
-  hamster.get('readyForRain'); // 'Yes'
+  tomster.get('readyForRain'); // undefined
+  tomster.set('hasUmbrella', true);
+  tomster.get('readyForRain'); // true
+  tomster.set('hasJacket', 'Yes');
+  tomster.get('readyForRain'); // 'Yes'
+  tomster.set('hasSunscreen', 'Check');
+  tomster.get('readyForBeach'); // 'Check'
   ```
 
   @method or

--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -14,25 +14,28 @@ import expandProperties from 'ember-metal/expand_properties';
 
 function getProperties(self, propertyNames) {
   var ret = {};
-
-  function extractProperty(name) {
-    ret[name] = get(self, name);
-  }
-
   for (var i = 0; i < propertyNames.length; i++) {
-    expandProperties(propertyNames[i], extractProperty);
+    ret[propertyNames[i]] = get(self, propertyNames[i]);
   }
-
   return ret;
 }
 
 function generateComputedWithProperties(macro) {
   return function(...properties) {
+    var expandedProperties = [];
     var computedFunc = computed(function() {
-      return macro.apply(this, [getProperties(this, properties)]);
+      return macro.apply(this, [getProperties(this, expandedProperties)]);
     });
 
-    return computedFunc.property.apply(computedFunc, properties);
+    function extractProperty(entry) {
+      expandedProperties.push(entry);
+    }
+
+    for (var i = 0; i < properties.length; i++) {
+      expandProperties(properties[i], extractProperty);
+    }
+
+    return computedFunc.property.apply(computedFunc, expandedProperties);
   };
 }
 

--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -5,6 +5,7 @@ import { computed } from 'ember-metal/computed';
 import isEmpty from 'ember-metal/is_empty';
 import isNone from 'ember-metal/is_none';
 import alias from 'ember-metal/alias';
+import expandProperties from 'ember-metal/expand_properties';
 
 /**
 @module ember
@@ -14,7 +15,9 @@ import alias from 'ember-metal/alias';
 function getProperties(self, propertyNames) {
   var ret = {};
   for (var i = 0; i < propertyNames.length; i++) {
-    ret[propertyNames[i]] = get(self, propertyNames[i]);
+    expandProperties(propertyNames[i], function (name) {
+      ret[name] = get(self, name);
+    });
   }
   return ret;
 }

--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -443,7 +443,7 @@ export var and = generateComputedWithProperties(function(properties) {
   for (var key in properties) {
     value = properties[key];
     if (properties.hasOwnProperty(key) && !value) {
-      return false;
+      return value;
     }
   }
   return value;

--- a/packages/ember-runtime/tests/computed/computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/computed_macros_test.js
@@ -251,7 +251,7 @@ testBoth('computed.lte', function(get, set) {
   equal(get(obj, 'isLesserOrEqualThenOne'), false, 'is not lte');
 });
 
-testBoth('computed.and', function(get, set) {
+testBoth('computed.and two properties', function(get, set) {
   var obj = { one: true, two: true };
   defineProperty(obj, 'oneAndTwo', and('one', 'two'));
 
@@ -267,7 +267,41 @@ testBoth('computed.and', function(get, set) {
   equal(get(obj, 'oneAndTwo'), 2, 'returns truthy value as in &&');
 });
 
-testBoth('computed.or', function(get, set) {
+testBoth('computed.and three properties', function(get, set) {
+  var obj = { one: true, two: true, three: true };
+  defineProperty(obj, 'oneTwoThree', and('one', 'two', 'three'));
+
+  equal(get(obj, 'oneTwoThree'), true, 'one and two and three');
+
+  set(obj, 'one', false);
+
+  equal(get(obj, 'oneTwoThree'), false, 'one and not two and not three');
+
+  set(obj, 'one', true);
+  set(obj, 'two', 2);
+  set(obj, 'three', 3);
+
+  equal(get(obj, 'oneTwoThree'), 3, 'returns truthy value as in &&');
+});
+
+testBoth('computed.and expand properties', function(get, set) {
+  var obj = { one: true, two: true, three: true };
+  defineProperty(obj, 'oneTwoThree', and('{one,two,three}'));
+
+  equal(get(obj, 'oneTwoThree'), true, 'one and two and three');
+
+  set(obj, 'one', false);
+
+  equal(get(obj, 'oneTwoThree'), false, 'one and not two and not three');
+
+  set(obj, 'one', true);
+  set(obj, 'two', 2);
+  set(obj, 'three', 3);
+
+  equal(get(obj, 'oneTwoThree'), 3, 'returns truthy value as in &&');
+});
+
+testBoth('computed.or two properties', function(get, set) {
   var obj = { one: true, two: true };
   defineProperty(obj, 'oneOrTwo', or('one', 'two'));
 
@@ -279,7 +313,7 @@ testBoth('computed.or', function(get, set) {
 
   set(obj, 'two', false);
 
-  equal(get(obj, 'oneOrTwo'), false, 'nore one nore two');
+  equal(get(obj, 'oneOrTwo'), false, 'nor one nor two');
 
   set(obj, 'two', null);
 
@@ -292,6 +326,68 @@ testBoth('computed.or', function(get, set) {
   set(obj, 'one', 1);
 
   equal(get(obj, 'oneOrTwo'), 1, 'returns truthy value as in ||');
+});
+
+testBoth('computed.or three properties', function(get, set) {
+  var obj = { one: true, two: true, three: true };
+  defineProperty(obj, 'oneTwoThree', or('one', 'two', 'three'));
+
+  equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+
+  set(obj, 'one', false);
+
+  equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+
+  set(obj, 'two', false);
+
+  equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+
+  set(obj, 'three', false);
+
+  equal(get(obj, 'oneTwoThree'), false, 'one or two or three');
+
+  set(obj, 'three', null);
+
+  equal(get(obj, 'oneTwoThree'), null, 'returns last falsy value as in ||');
+
+  set(obj, 'two', true);
+
+  equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+
+  set(obj, 'one', 1);
+
+  equal(get(obj, 'oneTwoThree'), 1, 'returns truthy value as in ||');
+});
+
+testBoth('computed.or expand properties', function(get, set) {
+  var obj = { one: true, two: true, three: true };
+  defineProperty(obj, 'oneTwoThree', or('{one,two,three}'));
+
+  equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+
+  set(obj, 'one', false);
+
+  equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+
+  set(obj, 'two', false);
+
+  equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+
+  set(obj, 'three', false);
+
+  equal(get(obj, 'oneTwoThree'), false, 'one or two or three');
+
+  set(obj, 'three', null);
+
+  equal(get(obj, 'oneTwoThree'), null, 'returns last falsy value as in ||');
+
+  set(obj, 'two', true);
+
+  equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+
+  set(obj, 'one', 1);
+
+  equal(get(obj, 'oneTwoThree'), 1, 'returns truthy value as in ||');
 });
 
 testBoth('computed.collect', function(get, set) {

--- a/packages/ember-runtime/tests/computed/computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/computed_macros_test.js
@@ -261,6 +261,11 @@ testBoth('computed.and two properties', function(get, set) {
 
   equal(get(obj, 'oneAndTwo'), false, 'one and not two');
 
+  set(obj, 'one', null);
+  set(obj, 'two', 'Yes');
+
+  equal(get(obj, 'oneAndTwo'), null, 'returns falsy value as in &&');
+
   set(obj, 'one', true);
   set(obj, 'two', 2);
 


### PR DESCRIPTION
`computed.or` and `computed.and` already supports more than two properties. I added some test cases for this use case.

Added code to pass `getProperties` through `Ember.expandProperties` to further enhance the above case.
