### PR TITLE
Use new blueprint testing API

### DIFF
--- a/node-tests/blueprints/acceptance-test-test.js
+++ b/node-tests/blueprints/acceptance-test-test.js
@@ -1,98 +1,85 @@
 'use strict';
 
-var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
-var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
-var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+var modifyPackages = blueprintHelpers.modifyPackages;
+
+var chai = require('ember-cli-blueprint-test-helpers/chai');
+var expect = chai.expect;
 
 describe('Acceptance: ember generate and destroy acceptance-test', function() {
   setupTestHooks(this);
 
   it('acceptance-test foo', function() {
-    // pass any additional command line options in the arguments array
-    return generateAndDestroy(['acceptance-test', 'foo'], {
-      files: [
-        {
-          file: 'tests/acceptance/foo-test.js',
-          contains: [
-            "import { test } from 'qunit';",
-            "moduleForAcceptance('Acceptance | foo');",
-            "test('visiting /foo', function(assert) {",
-            "visit('/foo');",
-            "andThen(function() {",
-            "assert.equal(currentURL(), '/foo');"
-          ]
-        }
-      ]
-    });
+    var args = ['acceptance-test', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/acceptance/foo-test.js'))
+          .to.contain("import { test } from 'qunit';")
+          .to.contain("moduleForAcceptance('Acceptance | foo');")
+          .to.contain("test('visiting /foo', function(assert) {")
+          .to.contain("visit('/foo');")
+          .to.contain("andThen(function() {")
+          .to.contain("assert.equal(currentURL(), '/foo');");
+      }));
   });
 
   it('in-addon acceptance-test foo', function() {
-    return generateAndDestroy(['acceptance-test', 'foo'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'tests/acceptance/foo-test.js',
-          contains: [
-            "import { test } from 'qunit';",
-            "moduleForAcceptance('Acceptance | foo');",
-            "test('visiting /foo', function(assert) {",
-            "visit('/foo');",
-            "andThen(function() {",
-            "assert.equal(currentURL(), '/foo');"
-          ]
-        },
-        {
-          file: 'app/acceptance-tests/foo.js',
-          exists: false
-        }
-      ]
-    });
+    var args = ['acceptance-test', 'foo'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/acceptance/foo-test.js'))
+          .to.contain("import { test } from 'qunit';")
+          .to.contain("moduleForAcceptance('Acceptance | foo');")
+          .to.contain("test('visiting /foo', function(assert) {")
+          .to.contain("visit('/foo');")
+          .to.contain("andThen(function() {")
+          .to.contain("assert.equal(currentURL(), '/foo');");
+
+        expect(_file('app/acceptance-tests/foo.js'))
+          .to.not.exist;
+      }));
   });
 
   it('in-addon acceptance-test foo/bar', function() {
-    return generateAndDestroy(['acceptance-test', 'foo/bar'], {
-        target: 'addon',
-        files: [
-          {
-            file: 'tests/acceptance/foo/bar-test.js',
-            contains: [
-              "import { test } from 'qunit';",
-              "moduleForAcceptance('Acceptance | foo/bar');",
-              "test('visiting /foo/bar', function(assert) {",
-              "visit('/foo/bar');",
-              "andThen(function() {",
-              "assert.equal(currentURL(), '/foo/bar');"
-            ]
-          },
-          {
-            file: 'app/acceptance-tests/foo/bar.js',
-            exists: false
-          }
-        ]
-    });
+    var args = ['acceptance-test', 'foo/bar'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/acceptance/foo/bar-test.js'))
+          .to.contain("import { test } from 'qunit';")
+          .to.contain("moduleForAcceptance('Acceptance | foo/bar');")
+          .to.contain("test('visiting /foo/bar', function(assert) {")
+          .to.contain("visit('/foo/bar');")
+          .to.contain("andThen(function() {")
+          .to.contain("assert.equal(currentURL(), '/foo/bar');");
+
+        expect(_file('app/acceptance-tests/foo/bar.js'))
+          .to.not.exist;
+      }));
   });
 
   it('acceptance-test foo for mocha', function() {
-    // pass any additional command line options in the arguments array
-    return generateAndDestroy(['acceptance-test', 'foo'], {
-      packages: [
-        { name: 'ember-cli-qunit', delete: true },
-        { name: 'ember-cli-mocha', dev: true }
-      ],
-      files: [
-        {
-          file: 'tests/acceptance/foo-test.js',
-          contains: [
-            "import { describe, it, beforeEach, afterEach } from 'mocha';",
-            "import { expect } from 'chai';",
-            "describe('Acceptance | foo', function() {",
-            "it('can visit /foo', function() {",
-            "visit('/foo');",
-            "andThen(function() {",
-            "expect(currentURL()).to.equal('/foo');"
-          ]
-        }
-      ]
-    });
+    var args = ['acceptance-test', 'foo'];
+
+    return emberNew()
+      .then(() => modifyPackages([
+        {name: 'ember-cli-qunit', delete: true},
+        {name: 'ember-cli-mocha', dev: true}
+      ]))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/acceptance/foo-test.js'))
+          .to.contain("import { describe, it, beforeEach, afterEach } from 'mocha';")
+          .to.contain("import { expect } from 'chai';")
+          .to.contain("describe('Acceptance | foo', function() {")
+          .to.contain("it('can visit /foo', function() {")
+          .to.contain("visit('/foo');")
+          .to.contain("andThen(function() {")
+          .to.contain("expect(currentURL()).to.equal('/foo');");
+      }));
   });
 });

--- a/node-tests/blueprints/component-addon-test.js
+++ b/node-tests/blueprints/component-addon-test.js
@@ -1,23 +1,23 @@
 'use strict';
 
-var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
-var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
-var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+
+var chai = require('ember-cli-blueprint-test-helpers/chai');
+var expect = chai.expect;
 
 describe('Acceptance: ember generate and destroy component-addon', function() {
   setupTestHooks(this);
 
   it('component-addon foo-bar', function() {
-    // pass any additional command line options in the arguments array
-    return generateAndDestroy(['component-addon', 'foo-bar'], {
-      target: 'addon',
-      // define files to assert, and their contents
-      files: [
-        {
-          file: 'app/components/foo-bar.js',
-          contents: "export { default } from 'my-addon/components/foo-bar';"
-        }
-      ]
-    });
+    var args = ['component-addon', 'foo-bar'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/components/foo-bar.js'))
+          .to.contain("export { default } from 'my-addon/components/foo-bar';");
+      }));
   });
 });

--- a/node-tests/blueprints/component-test.js
+++ b/node-tests/blueprints/component-test.js
@@ -1,1077 +1,823 @@
 'use strict';
 
-var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
-var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
-var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+var modifyPackages = blueprintHelpers.modifyPackages;
+var setupPodConfig = blueprintHelpers.setupPodConfig;
+
+var chai = require('ember-cli-blueprint-test-helpers/chai');
+var expect = chai.expect;
 
 describe('Acceptance: ember generate component', function() {
   setupTestHooks(this);
 
   it('component x-foo', function() {
-    return generateAndDestroy(['component', 'x-foo'], {
-      files:[
-        {
-          file: 'app/components/x-foo.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Component.extend({",
-            "});"
-          ]
-        },
-        {
-          file: 'app/templates/components/x-foo.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'tests/integration/components/x-foo-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('x-foo'",
-            "integration: true",
-            "{{x-foo}}",
-            "{{#x-foo}}"
-          ]
-        }
-      ]
-    });
+    var args = ['component', 'x-foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/components/x-foo.js')).to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("});");
+
+        expect(_file('app/templates/components/x-foo.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('tests/integration/components/x-foo-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{x-foo}}")
+          .to.contain("{{#x-foo}}");
+      }));
   });
 
   it('component foo/x-foo', function() {
-    return generateAndDestroy(['component', 'foo/x-foo'], {
-      files: [
-        {
-          file: 'app/components/foo/x-foo.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Component.extend({",
-            "});"
-          ]
-        },
-        {
-          file: 'app/templates/components/foo/x-foo.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'tests/integration/components/foo/x-foo-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('foo/x-foo'",
-            "integration: true",
-            "{{foo/x-foo}}",
-            "{{#foo/x-foo}}"
-          ]
-        }
-      ]
-    });
+    var args = ['component', 'foo/x-foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/components/foo/x-foo.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("});");
+
+        expect(_file('app/templates/components/foo/x-foo.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('tests/integration/components/foo/x-foo-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('foo/x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{foo/x-foo}}")
+          .to.contain("{{#foo/x-foo}}");
+      }));
   });
 
   it('component x-foo ignores --path option', function() {
-    return generateAndDestroy(['component', 'x-foo', '--path', 'foo'], {
-      files: [
-        {
-          file: 'app/components/x-foo.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Component.extend({",
-            "});"
-          ]
-        },
-        {
-          file: 'app/templates/components/x-foo.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'tests/integration/components/x-foo-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('x-foo'",
-            "integration: true",
-            "{{x-foo}}",
-            "{{#x-foo}}"
-          ]
-        }
-      ]
-    });
+    var args = ['component', 'x-foo', '--path', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/components/x-foo.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("});");
+
+        expect(_file('app/templates/components/x-foo.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('tests/integration/components/x-foo-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{x-foo}}")
+          .to.contain("{{#x-foo}}");
+      }));
   });
 
   it('in-addon component x-foo', function() {
-    return generateAndDestroy(['component', 'x-foo'], {
-      target: 'addon',
-      files: [
-        {
-          file:'addon/components/x-foo.js',
-          contains: [
-            "import Ember from 'ember';",
-            "import layout from '../templates/components/x-foo';",
-            "export default Ember.Component.extend({",
-            "layout",
-            "});"
-          ]
-        },
-        {
-          file:'addon/templates/components/x-foo.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file:'app/components/x-foo.js',
-          contains: [
-            "export { default } from 'my-addon/components/x-foo';"
-          ]
-        },
-        {
-          file:'tests/integration/components/x-foo-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('x-foo'",
-            "integration: true",
-            "{{x-foo}}",
-            "{{#x-foo}}"
-          ]
-        }
-      ]
-    });
+    var args = ['component', 'x-foo'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('addon/components/x-foo.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("import layout from '../templates/components/x-foo';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("layout")
+          .to.contain("});");
+
+        expect(_file('addon/templates/components/x-foo.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('app/components/x-foo.js'))
+          .to.contain("export { default } from 'my-addon/components/x-foo';");
+
+        expect(_file('tests/integration/components/x-foo-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{x-foo}}")
+          .to.contain("{{#x-foo}}");
+      }));
   });
 
   it('in-addon component nested/x-foo', function() {
-    return generateAndDestroy(['component', 'nested/x-foo'], {
-      target: 'addon',
-      files: [
-        {
-          file:'addon/components/nested/x-foo.js',
-          contains: [
-            "import Ember from 'ember';",
-            "import layout from '../../templates/components/nested/x-foo';",
-            "export default Ember.Component.extend({",
-            "layout",
-            "});"
-          ]
-        },
-        {
-          file:'addon/templates/components/nested/x-foo.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file:'app/components/nested/x-foo.js',
-          contains: [
-            "export { default } from 'my-addon/components/nested/x-foo';"
-          ]
-        },
-        {
-          file:'tests/integration/components/nested/x-foo-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('nested/x-foo'",
-            "integration: true",
-            "{{nested/x-foo}}",
-            "{{#nested/x-foo}}"
-          ]
-        }
-      ]
-    });
+    var args = ['component', 'nested/x-foo'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('addon/components/nested/x-foo.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("import layout from '../../templates/components/nested/x-foo';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("layout")
+          .to.contain("});");
+
+        expect(_file('addon/templates/components/nested/x-foo.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('app/components/nested/x-foo.js'))
+          .to.contain("export { default } from 'my-addon/components/nested/x-foo';");
+
+        expect(_file('tests/integration/components/nested/x-foo-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('nested/x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{nested/x-foo}}")
+          .to.contain("{{#nested/x-foo}}");
+      }));
   });
 
   it('dummy component x-foo', function() {
-    return generateAndDestroy(['component', 'x-foo', '--dummy'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'tests/dummy/app/components/x-foo.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Component.extend({",
-            "});"
-          ]
-        },
-        {
-          file: 'tests/dummy/app/templates/components/x-foo.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'app/components/x-foo.js',
-          exists: false
-        },
-        {
-          file: 'tests/unit/components/x-foo-test.js',
-          exists: false
-        }
-      ]
-    });
+    var args = ['component', 'x-foo', '--dummy'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/dummy/app/components/x-foo.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("});");
+
+        expect(_file('tests/dummy/app/templates/components/x-foo.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('app/components/x-foo.js'))
+          .to.not.exist;
+
+        expect(_file('tests/unit/components/x-foo-test.js'))
+          .to.not.exist;
+      }));
   });
 
   it('dummy component nested/x-foo', function() {
-    return generateAndDestroy(['component', 'nested/x-foo', '--dummy'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'tests/dummy/app/components/nested/x-foo.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Component.extend({",
-            "});"
-          ]
-        },
-        {
-          file: 'tests/dummy/app/templates/components/nested/x-foo.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'app/components/nested/x-foo.js',
-          exists: false
-        },
-        {
-          file: 'tests/unit/components/nested/x-foo-test.js',
-          exists: false
-        }
-      ]
-    });
+    var args = ['component', 'nested/x-foo', '--dummy'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/dummy/app/components/nested/x-foo.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("});");
+
+        expect(_file('tests/dummy/app/templates/components/nested/x-foo.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('app/components/nested/x-foo.js'))
+          .to.not.exist;
+
+        expect(_file('tests/unit/components/nested/x-foo-test.js'))
+          .to.not.exist;
+      }));
   });
 
   it('in-repo-addon component x-foo', function() {
-    return generateAndDestroy(['component', 'x-foo', '--in-repo-addon=my-addon'], {
-      target: 'inRepoAddon',
-      files: [
-        {
-          file: 'lib/my-addon/addon/components/x-foo.js',
-          contains: [
-            "import Ember from 'ember';",
-            "import layout from '../templates/components/x-foo';",
-            "export default Ember.Component.extend({",
-            "layout",
-            "});"
-          ]
-        },
-        {
-          file: 'lib/my-addon/addon/templates/components/x-foo.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'lib/my-addon/app/components/x-foo.js',
-          contains: [
-            "export { default } from 'my-addon/components/x-foo';"
-          ]
-        },
-        {
-          file: 'tests/integration/components/x-foo-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('x-foo'",
-            "integration: true",
-            "{{x-foo}}",
-            "{{#x-foo}}"
-          ]
-        }
-      ]
-    });
+    var args = ['component', 'x-foo', '--in-repo-addon=my-addon'];
+
+    return emberNew({ target: 'in-repo-addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('lib/my-addon/addon/components/x-foo.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("import layout from '../templates/components/x-foo';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("layout")
+          .to.contain("});");
+
+        expect(_file('lib/my-addon/addon/templates/components/x-foo.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('lib/my-addon/app/components/x-foo.js'))
+          .to.contain("export { default } from 'my-addon/components/x-foo';");
+
+        expect(_file('tests/integration/components/x-foo-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{x-foo}}")
+          .to.contain("{{#x-foo}}");
+      }));
   });
 
   it('in-repo-addon component-test x-foo', function() {
-    return generateAndDestroy(['component-test', 'x-foo', '--in-repo-addon=my-addon'], {
-      target: 'inRepoAddon',
-      files: [
-        {
-          file: 'tests/integration/components/x-foo-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('x-foo'",
-            "integration: true",
-            "{{x-foo}}",
-            "{{#x-foo}}"
-          ]
-        }
-      ]
-    });
+    var args = ['component-test', 'x-foo', '--in-repo-addon=my-addon'];
+
+    return emberNew({ target: 'in-repo-addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/integration/components/x-foo-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{x-foo}}")
+          .to.contain("{{#x-foo}}");
+      }));
   });
 
   it('in-repo-addon component-test x-foo --unit', function() {
-    return generateAndDestroy(['component-test', 'x-foo', '--in-repo-addon=my-addon', '--unit'], {
-      target: 'inRepoAddon',
-      files: [
-        {
-          file: 'tests/unit/components/x-foo-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "moduleForComponent('x-foo'",
-            "unit: true"
-          ]
-        }
-      ]
-    });
+    var args = ['component-test', 'x-foo', '--in-repo-addon=my-addon', '--unit'];
+
+    return emberNew({ target: 'in-repo-addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/components/x-foo-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("moduleForComponent('x-foo'")
+          .to.contain("unit: true");
+      }));
   });
 
   it('in-repo-addon component nested/x-foo', function() {
-    return generateAndDestroy(['component', 'nested/x-foo', '--in-repo-addon=my-addon'], {
-      target: 'inRepoAddon',
-      files: [
-        {
-          file: 'lib/my-addon/addon/components/nested/x-foo.js',
-          contains: [
-            "import Ember from 'ember';",
-            "import layout from '../../templates/components/nested/x-foo';",
-            "export default Ember.Component.extend({",
-            "layout",
-            "});"
-          ]
-        },
-        {
-          file: 'lib/my-addon/addon/templates/components/nested/x-foo.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'lib/my-addon/app/components/nested/x-foo.js',
-          contains: [
-            "export { default } from 'my-addon/components/nested/x-foo';"
-          ]
-        },
-        {
-          file: 'tests/integration/components/nested/x-foo-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('nested/x-foo'",
-            "integration: true"
-          ]
-        }
-      ]
-    });
+    var args = ['component', 'nested/x-foo', '--in-repo-addon=my-addon'];
+
+    return emberNew({ target: 'in-repo-addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('lib/my-addon/addon/components/nested/x-foo.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("import layout from '../../templates/components/nested/x-foo';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("layout")
+          .to.contain("});");
+
+        expect(_file('lib/my-addon/addon/templates/components/nested/x-foo.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('lib/my-addon/app/components/nested/x-foo.js'))
+          .to.contain("export { default } from 'my-addon/components/nested/x-foo';");
+
+        expect(_file('tests/integration/components/nested/x-foo-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('nested/x-foo'")
+          .to.contain("integration: true");
+      }));
   });
-/**
-* Pod tests
-*
-*/
+  /**
+   * Pod tests
+   *
+   */
   it('component x-foo --pod', function() {
-    return generateAndDestroy(['component', 'x-foo', '--pod'], {
-      files: [
-        {
-          file: 'app/components/x-foo/component.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Component.extend({",
-            "});"
-          ]
-        },
-        {
-          file: 'app/components/x-foo/template.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'tests/integration/components/x-foo/component-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('x-foo'",
-            "integration: true"
-          ]
-        },
-      ]
-    });
+    var args = ['component', 'x-foo', '--pod'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/components/x-foo/component.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("});");
+
+        expect(_file('app/components/x-foo/template.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('tests/integration/components/x-foo/component-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('x-foo'")
+          .to.contain("integration: true");
+      }));
   });
 
   it('component x-foo --pod podModulePrefix', function() {
-    return generateAndDestroy(['component', 'x-foo', '--pod'], {
-      podModulePrefix: true,
-      files: [
-        {
-          file: 'app/pods/components/x-foo/component.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Component.extend({",
-            "});"
-          ]
-        },
-        {
-          file: 'app/pods/components/x-foo/template.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'tests/integration/pods/components/x-foo/component-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('x-foo'",
-            "integration: true",
-            "{{x-foo}}",
-            "{{#x-foo}}"
-          ]
-        },
-      ]
-    });
+    var args = ['component', 'x-foo', '--pod'];
+
+    return emberNew()
+      .then(() => setupPodConfig({ podModulePrefix: true }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/pods/components/x-foo/component.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("});");
+
+        expect(_file('app/pods/components/x-foo/template.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('tests/integration/pods/components/x-foo/component-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{x-foo}}")
+          .to.contain("{{#x-foo}}");
+      }));
   });
 
   it('component foo/x-foo --pod', function() {
-    return generateAndDestroy(['component', 'foo/x-foo', '--pod'], {
-      files: [
-        {
-          file: 'app/components/foo/x-foo/component.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Component.extend({",
-            "});"
-          ]
-        },
-        {
-          file: 'app/components/foo/x-foo/template.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'tests/integration/components/foo/x-foo/component-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('foo/x-foo'",
-            "integration: true",
-            "{{foo/x-foo}}",
-            "{{#foo/x-foo}}"
-          ]
-        },
-    ]
-    });
+    var args = ['component', 'foo/x-foo', '--pod'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/components/foo/x-foo/component.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("});");
+
+        expect(_file('app/components/foo/x-foo/template.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('tests/integration/components/foo/x-foo/component-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('foo/x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{foo/x-foo}}")
+          .to.contain("{{#foo/x-foo}}");
+      }));
   });
 
   it('component foo/x-foo --pod podModulePrefix', function() {
-    return generateAndDestroy(['component', 'foo/x-foo', '--pod'], {
-      podModulePrefix: true,
-      files: [
-        {
-          file: 'app/pods/components/foo/x-foo/component.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Component.extend({",
-            "});"
-          ]
-        },
-        {
-          file: 'app/pods/components/foo/x-foo/template.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'tests/integration/pods/components/foo/x-foo/component-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('foo/x-foo'",
-            "integration: true",
-            "{{foo/x-foo}}",
-            "{{#foo/x-foo}}"
-          ]
-        },
-      ]
-    });
+    var args = ['component', 'foo/x-foo', '--pod'];
+
+    return emberNew()
+      .then(() => setupPodConfig({ podModulePrefix: true }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/pods/components/foo/x-foo/component.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("});");
+
+        expect(_file('app/pods/components/foo/x-foo/template.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('tests/integration/pods/components/foo/x-foo/component-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('foo/x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{foo/x-foo}}")
+          .to.contain("{{#foo/x-foo}}");
+      }));
   });
 
   it('component x-foo --pod --path', function() {
-    return generateAndDestroy(['component', 'x-foo', '--pod', '--path', 'bar'], {
-      files: [
-        {
-          file: 'app/bar/x-foo/component.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Component.extend({",
-            "});"
-          ]
-        },
-        {
-          file: 'app/bar/x-foo/template.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'tests/integration/bar/x-foo/component-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('bar/x-foo'",
-            "integration: true",
-            "{{bar/x-foo}}",
-            "{{#bar/x-foo}}"
-          ]
-        },
-      ]
-    });
+    var args = ['component', 'x-foo', '--pod', '--path', 'bar'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/bar/x-foo/component.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("});");
+
+        expect(_file('app/bar/x-foo/template.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('tests/integration/bar/x-foo/component-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('bar/x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{bar/x-foo}}")
+          .to.contain("{{#bar/x-foo}}");
+      }));
   });
 
   it('component x-foo --pod --path podModulePrefix', function() {
-    return generateAndDestroy(['component', 'x-foo', '--pod', '--path', 'bar'], {
-      podModulePrefix: true,
-      files: [
-        {
-        file: 'app/pods/bar/x-foo/component.js',
-        contains: [
-          "import Ember from 'ember';",
-          "export default Ember.Component.extend({",
-          "});"
-        ]
-      },
-      {
-        file: 'app/pods/bar/x-foo/template.hbs',
-        contains: "{{yield}}"
-      },
-      {
-        file: 'tests/integration/pods/bar/x-foo/component-test.js',
-        contains: [
-          "import { moduleForComponent, test } from 'ember-qunit';",
-          "import hbs from 'htmlbars-inline-precompile';",
-          "moduleForComponent('bar/x-foo'",
-          "integration: true",
-          "{{bar/x-foo}}",
-          "{{#bar/x-foo}}"
-        ]
-      },
-    ]
-    });
+    var args = ['component', 'x-foo', '--pod', '--path', 'bar'];
+
+    return emberNew()
+      .then(() => setupPodConfig({ podModulePrefix: true }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/pods/bar/x-foo/component.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("});");
+
+        expect(_file('app/pods/bar/x-foo/template.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('tests/integration/pods/bar/x-foo/component-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('bar/x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{bar/x-foo}}")
+          .to.contain("{{#bar/x-foo}}");
+      }));
   });
 
   it('component foo/x-foo --pod --path', function() {
-    return generateAndDestroy(['component', 'foo/x-foo', '--pod', '--path', 'bar'], {
-      files: [
-        {
-          file: 'app/bar/foo/x-foo/component.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Component.extend({",
-            "});"
-          ]
-        },
-        {
-          file: 'app/bar/foo/x-foo/template.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'tests/integration/bar/foo/x-foo/component-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('bar/foo/x-foo'",
-            "integration: true",
-            "{{bar/foo/x-foo}}",
-            "{{#bar/foo/x-foo}}"
-          ]
-        },
-      ]
-    });
+    var args = ['component', 'foo/x-foo', '--pod', '--path', 'bar'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/bar/foo/x-foo/component.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("});");
+
+        expect(_file('app/bar/foo/x-foo/template.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('tests/integration/bar/foo/x-foo/component-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('bar/foo/x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{bar/foo/x-foo}}")
+          .to.contain("{{#bar/foo/x-foo}}");
+      }));
   });
 
   it('component foo/x-foo --pod --path podModulePrefix', function() {
-    return generateAndDestroy(['component', 'foo/x-foo', '--pod', '--path', 'bar'], {
-      podModulePrefix: true,
-      files: [
-        {
-          file: 'app/pods/bar/foo/x-foo/component.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Component.extend({",
-            "});"
-          ]
-        },
-        {
-          file: 'app/pods/bar/foo/x-foo/template.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'tests/integration/pods/bar/foo/x-foo/component-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "moduleForComponent('bar/foo/x-foo'",
-            "integration: true",
-            "{{bar/foo/x-foo}}",
-            "{{#bar/foo/x-foo}}"
-          ]
-        },
-      ]
-    });
+    var args = ['component', 'foo/x-foo', '--pod', '--path', 'bar'];
+
+    return emberNew()
+      .then(() => setupPodConfig({ podModulePrefix: true }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/pods/bar/foo/x-foo/component.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("});");
+
+        expect(_file('app/pods/bar/foo/x-foo/template.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('tests/integration/pods/bar/foo/x-foo/component-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("moduleForComponent('bar/foo/x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{bar/foo/x-foo}}")
+          .to.contain("{{#bar/foo/x-foo}}");
+      }));
   });
 
   it('component x-foo --pod --path nested', function() {
-    return generateAndDestroy(['component', 'x-foo', '--pod', '--path', 'bar/baz'], {
-      files: [
-        {
-          file: 'app/bar/baz/x-foo/component.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Component.extend({",
-            "});"
-          ]
-        },
-        {
-          file: 'app/bar/baz/x-foo/template.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'tests/integration/bar/baz/x-foo/component-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('bar/baz/x-foo'",
-            "integration: true",
-            "{{bar/baz/x-foo}}",
-            "{{#bar/baz/x-foo}}"
-          ]
-        },
-      ]
-    });
+    var args = ['component', 'x-foo', '--pod', '--path', 'bar/baz'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/bar/baz/x-foo/component.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("});");
+
+        expect(_file('app/bar/baz/x-foo/template.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('tests/integration/bar/baz/x-foo/component-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('bar/baz/x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{bar/baz/x-foo}}")
+          .to.contain("{{#bar/baz/x-foo}}");
+      }));
   });
 
   it('component x-foo --pod --path nested podModulePrefix', function() {
-    return generateAndDestroy(['component', 'x-foo', '--pod', '--path', 'bar/baz'], {
-      podModulePrefix: true,
-      files: [
-        {
-          file: 'app/pods/bar/baz/x-foo/component.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Component.extend({",
-            "});"
-          ]
-        },
-        {
-          file: 'app/pods/bar/baz/x-foo/template.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'tests/integration/pods/bar/baz/x-foo/component-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('bar/baz/x-foo'",
-            "integration: true",
-            "{{bar/baz/x-foo}}",
-            "{{#bar/baz/x-foo}}"
-          ]
-        },
-      ]
-    });
+    var args = ['component', 'x-foo', '--pod', '--path', 'bar/baz'];
+
+    return emberNew()
+      .then(() => setupPodConfig({ podModulePrefix: true }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/pods/bar/baz/x-foo/component.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("});");
+
+        expect(_file('app/pods/bar/baz/x-foo/template.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('tests/integration/pods/bar/baz/x-foo/component-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('bar/baz/x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{bar/baz/x-foo}}")
+          .to.contain("{{#bar/baz/x-foo}}");
+      }));
   });
 
   it('component foo/x-foo --pod --path nested', function() {
-    return generateAndDestroy(['component', 'foo/x-foo', '--pod', '--path', 'bar/baz'], {
-      files: [
-        {
-          file: 'app/bar/baz/foo/x-foo/component.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Component.extend({",
-            "});"
-          ]
-        },
-        {
-          file: 'app/bar/baz/foo/x-foo/template.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'tests/integration/bar/baz/foo/x-foo/component-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('bar/baz/foo/x-foo'",
-            "integration: true",
-            "{{bar/baz/foo/x-foo}}",
-            "{{#bar/baz/foo/x-foo}}"
-          ]
-        },
-      ]
-    });
+    var args = ['component', 'foo/x-foo', '--pod', '--path', 'bar/baz'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/bar/baz/foo/x-foo/component.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("});");
+
+        expect(_file('app/bar/baz/foo/x-foo/template.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('tests/integration/bar/baz/foo/x-foo/component-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('bar/baz/foo/x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{bar/baz/foo/x-foo}}")
+          .to.contain("{{#bar/baz/foo/x-foo}}");
+      }));
   });
 
   it('component foo/x-foo --pod --path nested podModulePrefix', function() {
-    return generateAndDestroy(['component', 'foo/x-foo', '--pod', '--path', 'bar/baz'], {
-      podModulePrefix: true,
-      files: [
-        {
-          file: 'app/pods/bar/baz/foo/x-foo/component.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Component.extend({",
-            "});"
-          ]
-        },
-        {
-          file: 'app/pods/bar/baz/foo/x-foo/template.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'tests/integration/pods/bar/baz/foo/x-foo/component-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('bar/baz/foo/x-foo'",
-            "integration: true",
-            "{{bar/baz/foo/x-foo}}",
-            "{{#bar/baz/foo/x-foo}}"
-          ]
-        },
-      ]
-    });
+    var args = ['component', 'foo/x-foo', '--pod', '--path', 'bar/baz'];
+
+    return emberNew()
+      .then(() => setupPodConfig({ podModulePrefix: true }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/pods/bar/baz/foo/x-foo/component.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("});");
+
+        expect(_file('app/pods/bar/baz/foo/x-foo/template.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('tests/integration/pods/bar/baz/foo/x-foo/component-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('bar/baz/foo/x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{bar/baz/foo/x-foo}}")
+          .to.contain("{{#bar/baz/foo/x-foo}}");
+      }));
   });
 
   it('component x-foo --pod -no-path', function() {
-    return generateAndDestroy(['component', 'x-foo', '--pod', '-no-path'], {
-      files: [
-        {
-          file: 'app/x-foo/component.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Component.extend({",
-            "});"
-          ]
-        },
-        {
-          file: 'app/x-foo/template.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'tests/integration/x-foo/component-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('x-foo'",
-            "integration: true",
-            "{{x-foo}}",
-            "{{#x-foo}}"
-          ]
-        },
-      ]
-    });
+    var args = ['component', 'x-foo', '--pod', '-no-path'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/x-foo/component.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("});");
+
+        expect(_file('app/x-foo/template.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('tests/integration/x-foo/component-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{x-foo}}")
+          .to.contain("{{#x-foo}}");
+      }));
   });
 
   it('component x-foo --pod -no-path podModulePrefix', function() {
-    return generateAndDestroy(['component', 'x-foo', '--pod', '-no-path'], {
-      podModulePrefix: true,
-      files: [
-        {
-          file: 'app/pods/x-foo/component.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Component.extend({",
-            "});"
-          ]
-        },
-        {
-          file: 'app/pods/x-foo/template.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'tests/integration/pods/x-foo/component-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('x-foo'",
-            "integration: true",
-            "{{x-foo}}",
-            "{{#x-foo}}"
-          ]
-        },
-      ]
-    });
+    var args = ['component', 'x-foo', '--pod', '-no-path'];
+
+    return emberNew()
+      .then(() => setupPodConfig({ podModulePrefix: true }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/pods/x-foo/component.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("});");
+
+        expect(_file('app/pods/x-foo/template.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('tests/integration/pods/x-foo/component-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{x-foo}}")
+          .to.contain("{{#x-foo}}");
+      }));
   });
 
   it('component foo/x-foo --pod -no-path', function() {
-    return generateAndDestroy(['component', 'foo/x-foo', '--pod', '-no-path'], {
-      files: [
-        {
-          file: 'app/foo/x-foo/component.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Component.extend({",
-            "});"
-          ]
-        },
-        {
-          file: 'app/foo/x-foo/template.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'tests/integration/foo/x-foo/component-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('foo/x-foo'",
-            "integration: true",
-            "{{foo/x-foo}}",
-            "{{#foo/x-foo}}"
-          ]
-        },
-      ]
-    });
+    var args = ['component', 'foo/x-foo', '--pod', '-no-path'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/foo/x-foo/component.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("});");
+
+        expect(_file('app/foo/x-foo/template.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('tests/integration/foo/x-foo/component-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('foo/x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{foo/x-foo}}")
+          .to.contain("{{#foo/x-foo}}");
+      }));
   });
 
   it('component foo/x-foo --pod -no-path podModulePrefix', function() {
-    return generateAndDestroy(['component', 'foo/x-foo', '--pod', '-no-path'], {
-      podModulePrefix: true,
-      files: [
-        {
-          file: 'app/pods/foo/x-foo/component.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Component.extend({",
-            "});"
-          ]
-        },
-        {
-          file: 'app/pods/foo/x-foo/template.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'tests/integration/pods/foo/x-foo/component-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('foo/x-foo'",
-            "integration: true",
-            "{{foo/x-foo}}",
-            "{{#foo/x-foo}}"
-          ]
-        },
-      ]
-    });
+    var args = ['component', 'foo/x-foo', '--pod', '-no-path'];
+
+    return emberNew()
+      .then(() => setupPodConfig({ podModulePrefix: true }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/pods/foo/x-foo/component.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("});");
+
+        expect(_file('app/pods/foo/x-foo/template.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('tests/integration/pods/foo/x-foo/component-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('foo/x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{foo/x-foo}}")
+          .to.contain("{{#foo/x-foo}}");
+      }));
   });
 
   it('in-addon component x-foo --pod', function() {
-    return generateAndDestroy(['component', 'x-foo', '--pod'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'addon/components/x-foo/component.js',
-          contains: [
-            "import Ember from 'ember';",
-            "import layout from './template';",
-            "export default Ember.Component.extend({",
-            "layout",
-            "});"
-          ]
-        },
-        {
-          file: 'addon/components/x-foo/template.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'app/components/x-foo/component.js',
-          contains: [
-            "export { default } from 'my-addon/components/x-foo/component';"
-          ]
-        },
-        {
-          file: 'tests/integration/components/x-foo/component-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "moduleForComponent('x-foo'",
-            "integration: true"
-          ]
-        }
-      ]
-    });
+    var args = ['component', 'x-foo', '--pod'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('addon/components/x-foo/component.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("import layout from './template';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("layout")
+          .to.contain("});");
+
+        expect(_file('addon/components/x-foo/template.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('app/components/x-foo/component.js'))
+          .to.contain("export { default } from 'my-addon/components/x-foo/component';");
+
+        expect(_file('tests/integration/components/x-foo/component-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("moduleForComponent('x-foo'")
+          .to.contain("integration: true");
+      }));
   });
 
   it('in-repo-addon component x-foo --pod', function() {
-    return generateAndDestroy(['component', 'x-foo', '--in-repo-addon=my-addon', '--pod'], {
-      target: 'inRepoAddon',
-      files: [
-        {
-          file: 'lib/my-addon/addon/components/x-foo/component.js',
-          contains: [
-            "import Ember from 'ember';",
-            "import layout from './template';",
-            "export default Ember.Component.extend({",
-            "layout",
-            "});"
-          ]
-        },
-        {
-          file: 'lib/my-addon/addon/components/x-foo/template.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'lib/my-addon/app/components/x-foo/component.js',
-          contains: [
-            "export { default } from 'my-addon/components/x-foo/component';"
-          ]
-        },
-        {
-          file: 'tests/integration/components/x-foo/component-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "moduleForComponent('x-foo'",
-            "integration: true"
-          ]
-        }
-      ]
-    });
+    var args = ['component', 'x-foo', '--in-repo-addon=my-addon', '--pod'];
+
+    return emberNew({ target: 'in-repo-addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('lib/my-addon/addon/components/x-foo/component.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("import layout from './template';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("layout")
+          .to.contain("});");
+
+        expect(_file('lib/my-addon/addon/components/x-foo/template.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('lib/my-addon/app/components/x-foo/component.js'))
+          .to.contain("export { default } from 'my-addon/components/x-foo/component';");
+
+        expect(_file('tests/integration/components/x-foo/component-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("moduleForComponent('x-foo'")
+          .to.contain("integration: true");
+      }));
   });
 
   it('in-repo-addon component nested/x-foo', function() {
-    return generateAndDestroy(['component', 'nested/x-foo', '--in-repo-addon=my-addon', '--pod'], {
-      target: 'inRepoAddon',
-      files: [
-        {
-          file: 'lib/my-addon/addon/components/nested/x-foo/component.js',
-          contains: [
-            "import Ember from 'ember';",
-            "import layout from './template';",
-            "export default Ember.Component.extend({",
-            "layout",
-            "});"
-          ]
-        },
-        {
-          file: 'lib/my-addon/addon/components/nested/x-foo/template.hbs',
-          contains: "{{yield}}"
-        },
-        {
-          file: 'lib/my-addon/app/components/nested/x-foo/component.js',
-          contains: [
-            "export { default } from 'my-addon/components/nested/x-foo/component';"
-          ]
-        },
-        {
-          file: 'tests/integration/components/nested/x-foo/component-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "moduleForComponent('nested/x-foo'",
-            "integration: true"
-          ]
-        }
-      ]
-    });
+    var args = ['component', 'nested/x-foo', '--in-repo-addon=my-addon', '--pod'];
+
+    return emberNew({ target: 'in-repo-addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('lib/my-addon/addon/components/nested/x-foo/component.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("import layout from './template';")
+          .to.contain("export default Ember.Component.extend({")
+          .to.contain("layout")
+          .to.contain("});");
+
+        expect(_file('lib/my-addon/addon/components/nested/x-foo/template.hbs'))
+          .to.contain("{{yield}}");
+
+        expect(_file('lib/my-addon/app/components/nested/x-foo/component.js'))
+          .to.contain("export { default } from 'my-addon/components/nested/x-foo/component';");
+
+        expect(_file('tests/integration/components/nested/x-foo/component-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("moduleForComponent('nested/x-foo'")
+          .to.contain("integration: true");
+      }));
   });
 
   it('component-test x-foo', function() {
-    return generateAndDestroy(['component-test', 'x-foo'], {
-      files: [
-        {
-          file: 'tests/integration/components/x-foo-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('x-foo'",
-            "integration: true",
-            "{{x-foo}}",
-            "{{#x-foo}}"
-          ]
-        }
-      ]
-    });
+    var args = ['component-test', 'x-foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/integration/components/x-foo-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{x-foo}}")
+          .to.contain("{{#x-foo}}");
+      }));
   });
 
   it('component-test x-foo --unit', function() {
-    return generateAndDestroy(['component-test', 'x-foo', '--unit'], {
-      files: [
-        {
-          file: 'tests/unit/components/x-foo-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "moduleForComponent('x-foo'",
-            "unit: true"
-          ]
-        }
-      ]
-    });
+    var args = ['component-test', 'x-foo', '--unit'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/components/x-foo-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("moduleForComponent('x-foo'")
+          .to.contain("unit: true");
+      }));
   });
 
   it('in-addon component-test x-foo', function() {
-    return generateAndDestroy(['component-test', 'x-foo'], {
-      target: 'addon',
-      files: [
-        {
-          file:'tests/integration/components/x-foo-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('x-foo'",
-            "integration: true",
-            "{{x-foo}}",
-            "{{#x-foo}}"
-          ]
-        },
-        {
-          file: 'app/component-test/x-foo.js',
-          exists: false
-        }
-      ]
-    });
+    var args = ['component-test', 'x-foo'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/integration/components/x-foo-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('x-foo'")
+          .to.contain("integration: true")
+          .to.contain("{{x-foo}}")
+          .to.contain("{{#x-foo}}");
+
+        expect(_file('app/component-test/x-foo.js'))
+          .to.not.exist;
+      }));
   });
 
   it('in-addon component-test x-foo --unit', function() {
-    return generateAndDestroy(['component-test', 'x-foo', '--unit'], {
-      target: 'addon',
-      files: [
-        {
-          file:'tests/unit/components/x-foo-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "moduleForComponent('x-foo'",
-            "unit: true"
-          ]
-        },
-        {
-          file: 'app/component-test/x-foo.js',
-          exists: false
-        }
-      ]
-    });
+    var args = ['component-test', 'x-foo', '--unit'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/components/x-foo-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("moduleForComponent('x-foo'")
+          .to.contain("unit: true");
+
+        expect(_file('app/component-test/x-foo.js'))
+          .to.not.exist;
+      }));
   });
 
   it('dummy component-test x-foo', function() {
-    return generateAndDestroy(['component-test', 'x-foo', '--dummy'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'tests/integration/components/x-foo-test.js',
-          contains: [
-            "import { moduleForComponent, test } from 'ember-qunit';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "moduleForComponent('x-foo'"
-          ]
-        },
-        {
-          file: 'app/component-test/x-foo.js',
-          exists: false
-        }
-      ]
-    });
+    var args = ['component-test', 'x-foo', '--dummy'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/integration/components/x-foo-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('x-foo'");
+
+        expect(_file('app/component-test/x-foo.js'))
+          .to.not.exist;
+      }));
   });
 
   it('component-test x-foo for mocha', function() {
-    return generateAndDestroy(['component-test', 'x-foo'], {
-      packages: [
-        { name: 'ember-cli-qunit', delete: true },
-        { name: 'ember-cli-mocha', dev: true }
-      ],
-      files: [
-        {
-          file: 'tests/integration/components/x-foo-test.js',
-          contains: [
-            "import { describeComponent, it } from 'ember-mocha';",
-            "import hbs from 'htmlbars-inline-precompile';",
-            "describeComponent('x-foo', 'Integration | Component | x foo'",
-            "integration: true",
-            "{{x-foo}}",
-            "{{#x-foo}}"
-          ]
-        }
-      ]
-    });
+    var args = ['component-test', 'x-foo'];
+
+    return emberNew()
+      .then(() => modifyPackages([
+        {name: 'ember-cli-qunit', delete: true},
+        {name: 'ember-cli-mocha', dev: true}
+      ]))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/integration/components/x-foo-test.js'))
+          .to.contain("import { describeComponent, it } from 'ember-mocha';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("describeComponent('x-foo', 'Integration | Component | x foo'")
+          .to.contain("integration: true")
+          .to.contain("{{x-foo}}")
+          .to.contain("{{#x-foo}}");
+      }));
   });
 
   it('component-test x-foo --unit for mocha', function() {
-    return generateAndDestroy(['component-test', 'x-foo', '--unit'], {
-      packages: [
-        { name: 'ember-cli-qunit', delete: true },
-        { name: 'ember-cli-mocha', dev: true }
-      ],
-      files: [
-        {
-          file: 'tests/unit/components/x-foo-test.js',
-          contains: [
-            "import { describeComponent, it } from 'ember-mocha';",
-            "describeComponent('x-foo', 'Unit | Component | x foo",
-            "unit: true"
-          ]
-        }
-      ]
-    });
+    var args = ['component-test', 'x-foo', '--unit'];
+
+    return emberNew()
+      .then(() => modifyPackages([
+        {name: 'ember-cli-qunit', delete: true},
+        {name: 'ember-cli-mocha', dev: true}
+      ]))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/components/x-foo-test.js'))
+          .to.contain("import { describeComponent, it } from 'ember-mocha';")
+          .to.contain("describeComponent('x-foo', 'Unit | Component | x foo")
+          .to.contain("unit: true");
+      }));
   });
 });

--- a/node-tests/blueprints/controller-test.js
+++ b/node-tests/blueprints/controller-test.js
@@ -1,346 +1,250 @@
 'use strict';
 
-var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
-var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
-var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+var modifyPackages = blueprintHelpers.modifyPackages;
+var setupPodConfig = blueprintHelpers.setupPodConfig;
+
+var chai = require('ember-cli-blueprint-test-helpers/chai');
+var expect = chai.expect;
 
 describe('Acceptance: ember generate and destroy controller', function() {
   setupTestHooks(this);
 
   it('controller foo', function() {
-    return generateAndDestroy(['controller', 'foo'], {
-      files: [
-        {
-          file: 'app/controllers/foo.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Controller.extend({\n});"
-          ]
-        },
-        {
-          file: 'tests/unit/controllers/foo-test.js',
-          contains: [
-            "import { moduleFor, test } from 'ember-qunit';",
-            "moduleFor('controller:foo'"
-          ]
-        },
-      ]
-    });
+    var args = ['controller', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/controllers/foo.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Controller.extend({\n});");
+
+        expect(_file('tests/unit/controllers/foo-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('controller:foo'");
+      }));
   });
 
   it('controller foo/bar', function() {
-    return generateAndDestroy(['controller', 'foo/bar'], {
-      files: [
-        {
-          file: 'app/controllers/foo/bar.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Controller.extend({\n});"
-          ]
-        },
-        {
-          file: 'tests/unit/controllers/foo/bar-test.js',
-          contains: [
-            "import { moduleFor, test } from 'ember-qunit';",
-            "moduleFor('controller:foo/bar'"
-          ]
-        }
-      ]
-    });
+    var args = ['controller', 'foo/bar'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/controllers/foo/bar.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Controller.extend({\n});");
+
+        expect(_file('tests/unit/controllers/foo/bar-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('controller:foo/bar'");
+      }));
   });
 
   it('in-addon controller foo', function() {
-    return generateAndDestroy(['controller', 'foo'], {
-        target: 'addon',
-        files: [
-          {
-            file: 'addon/controllers/foo.js',
-            contains: [
-              "import Ember from 'ember';",
-              "export default Ember.Controller.extend({\n});"
-            ]
-          },
-          {
-            file: 'app/controllers/foo.js',
-            contains: [
-              "export { default } from 'my-addon/controllers/foo';"
-            ]
-          },
-          {
-            file: 'tests/unit/controllers/foo-test.js',
-            contains: [
-              "import { moduleFor, test } from 'ember-qunit';",
-              "moduleFor('controller:foo'"
-            ]
-          }
-        ]
-    });
+    var args = ['controller', 'foo'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('addon/controllers/foo.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Controller.extend({\n});");
+
+        expect(_file('app/controllers/foo.js'))
+          .to.contain("export { default } from 'my-addon/controllers/foo';");
+
+        expect(_file('tests/unit/controllers/foo-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('controller:foo'");
+      }));
   });
 
   it('in-addon controller foo/bar', function() {
-    return generateAndDestroy(['controller', 'foo/bar'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'addon/controllers/foo/bar.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Controller.extend({\n});"
-          ]
-        },
-        {
-          file: 'app/controllers/foo/bar.js',
-          contains: [
-            "export { default } from 'my-addon/controllers/foo/bar';"
-          ]
-        },
-        {
-          file: 'tests/unit/controllers/foo/bar-test.js',
-          contains: [
-            "import { moduleFor, test } from 'ember-qunit';",
-            "moduleFor('controller:foo/bar'"
-          ]
-        }
-      ]
-    });
+    var args = ['controller', 'foo/bar'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('addon/controllers/foo/bar.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Controller.extend({\n});");
+
+        expect(_file('app/controllers/foo/bar.js'))
+          .to.contain("export { default } from 'my-addon/controllers/foo/bar';");
+
+        expect(_file('tests/unit/controllers/foo/bar-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('controller:foo/bar'");
+      }));
   });
 
   it('dummy controller foo', function() {
-    return generateAndDestroy(['controller', 'foo', '--dummy'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'tests/dummy/app/controllers/foo.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Controller.extend({\n});"
-          ]
-        },
-        {
-          file: 'app/controllers/foo-test.js',
-          exists: false
-        },
-        {
-          file: 'tests/unit/controllers/foo-test.js',
-          exists: false
-        }
-      ]
-    });
+    var args = ['controller', 'foo', '--dummy'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/dummy/app/controllers/foo.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Controller.extend({\n});");
+
+        expect(_file('app/controllers/foo-test.js'))
+          .to.not.exist;
+
+        expect(_file('tests/unit/controllers/foo-test.js'))
+          .to.not.exist;
+      }));
   });
 
   it('dummy controller foo/bar', function() {
-    return generateAndDestroy(['controller', 'foo/bar', '--dummy'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'tests/dummy/app/controllers/foo/bar.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Controller.extend({\n});"
-          ]
-        },
-        {
-          file: 'app/controllers/foo/bar.js',
-          exists: false
-        },
-        {
-          file: 'tests/unit/controllers/foo/bar-test.js',
-          exists: false
-        }
-      ]
-    });
+    var args = ['controller', 'foo/bar', '--dummy'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/dummy/app/controllers/foo/bar.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Controller.extend({\n});");
+
+        expect(_file('app/controllers/foo/bar.js'))
+          .to.not.exist;
+
+        expect(_file('tests/unit/controllers/foo/bar-test.js'))
+          .to.not.exist;
+      }));
   });
 
   it('in-repo-addon controller foo', function() {
-    return generateAndDestroy(['controller', 'foo', '--in-repo-addon=my-addon'], {
-      target: 'inRepoAddon',
-      files: [
-        {
-          file: 'lib/my-addon/addon/controllers/foo.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Controller.extend({\n});"
-          ]
-        },
-        {
-          file: 'lib/my-addon/app/controllers/foo.js',
-          contains: [
-            "export { default } from 'my-addon/controllers/foo';"
-          ]
-        },
-        {
-          file: 'tests/unit/controllers/foo-test.js',
-          contains: [
-            "import { moduleFor, test } from 'ember-qunit';",
-            "moduleFor('controller:foo'"
-          ]
-        }
-      ]
-    });
+    var args = ['controller', 'foo', '--in-repo-addon=my-addon'];
+
+    return emberNew({ target: 'in-repo-addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('lib/my-addon/addon/controllers/foo.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Controller.extend({\n});");
+
+        expect(_file('lib/my-addon/app/controllers/foo.js'))
+          .to.contain("export { default } from 'my-addon/controllers/foo';");
+
+        expect(_file('tests/unit/controllers/foo-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('controller:foo'");
+      }));
   });
 
   it('in-repo-addon controller foo/bar', function() {
-    return generateAndDestroy(['controller', 'foo/bar', '--in-repo-addon=my-addon'], {
-      target: 'inRepoAddon',
-      files: [
-        {
-          file: 'lib/my-addon/addon/controllers/foo/bar.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Controller.extend({\n});"
-          ]
-        },
-        {
-          file: 'lib/my-addon/app/controllers/foo/bar.js',
-          contains: [
-            "export { default } from 'my-addon/controllers/foo/bar';"
-          ]
-        },
-        {
-          file: 'tests/unit/controllers/foo/bar-test.js',
-          contains: [
-            "import { moduleFor, test } from 'ember-qunit';",
-            "moduleFor('controller:foo/bar'"
-          ]
-        }
-      ]
-    });
+    var args = ['controller', 'foo/bar', '--in-repo-addon=my-addon'];
+
+    return emberNew({ target: 'in-repo-addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('lib/my-addon/addon/controllers/foo/bar.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Controller.extend({\n});");
+
+        expect(_file('lib/my-addon/app/controllers/foo/bar.js'))
+          .to.contain("export { default } from 'my-addon/controllers/foo/bar';");
+
+        expect(_file('tests/unit/controllers/foo/bar-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('controller:foo/bar'");
+      }));
   });
 
-/**
-* Pod tests
-*
-*/
   it('controller foo --pod', function() {
-    return generateAndDestroy(['controller', 'foo', '--pod'], {
-      files: [
-        {
-          file: 'app/foo/controller.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Controller.extend({\n});"
-          ]
-        },
-        {
-          file: 'tests/unit/foo/controller-test.js',
-          contains: [
-            "import { moduleFor, test } from 'ember-qunit';",
-            "moduleFor('controller:foo'"
-          ]
-        }
-      ]
-    });
+    var args = ['controller', 'foo', '--pod'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/foo/controller.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Controller.extend({\n});");
+
+        expect(_file('tests/unit/foo/controller-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('controller:foo'");
+      }));
   });
 
   it('controller foo --pod podModulePrefix', function() {
-    return generateAndDestroy(['controller', 'foo', '--pod'], {
-      podModulePrefix: true,
-      files: [
-        {
-          file: 'app/pods/foo/controller.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Controller.extend({\n});"
-          ]
-        },
-        {
-          file: 'tests/unit/pods/foo/controller-test.js',
-          contains: [
-            "import { moduleFor, test } from 'ember-qunit';",
-            "moduleFor('controller:foo'"
-          ]
-        }
-      ]
-    });
+    var args = ['controller', 'foo', '--pod'];
+
+    return emberNew()
+      .then(() => setupPodConfig({ podModulePrefix: true }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/pods/foo/controller.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Controller.extend({\n});");
+
+        expect(_file('tests/unit/pods/foo/controller-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('controller:foo'");
+      }));
   });
 
   it('controller foo/bar --pod', function() {
-    return generateAndDestroy(['controller', 'foo/bar', '--pod'], {
-      files: [
-        {
-          file: 'app/foo/bar/controller.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Controller.extend({\n});"
-          ]
-        },
-        {
-          file: 'tests/unit/foo/bar/controller-test.js',
-          contains: [
-            "import { moduleFor, test } from 'ember-qunit';",
-            "moduleFor('controller:foo/bar'"
-          ]
-        }
-      ]
-    });
+    var args = ['controller', 'foo/bar', '--pod'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/foo/bar/controller.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Controller.extend({\n});");
+
+        expect(_file('tests/unit/foo/bar/controller-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('controller:foo/bar'");
+      }));
   });
 
   it('controller foo/bar --pod podModulePrefix', function() {
-    return generateAndDestroy(['controller', 'foo/bar', '--pod'], {
-      podModulePrefix: true,
-      files: [
-        {
-          file: 'app/pods/foo/bar/controller.js',
-          contains: [
-            "import Ember from 'ember';",
-            "export default Ember.Controller.extend({\n});"
-          ]
-        },
-        {
-          file: 'tests/unit/pods/foo/bar/controller-test.js',
-          contains: [
-            "import { moduleFor, test } from 'ember-qunit';",
-            "moduleFor('controller:foo/bar'"
-          ]
-        }
-      ]
-    });
+    var args = ['controller', 'foo/bar', '--pod'];
+
+    return emberNew()
+      .then(() => setupPodConfig({ podModulePrefix: true }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/pods/foo/bar/controller.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export default Ember.Controller.extend({\n});");
+
+        expect(_file('tests/unit/pods/foo/bar/controller-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('controller:foo/bar'");
+      }));
   });
 
   it('controller-test foo', function() {
-    return generateAndDestroy(['controller-test', 'foo'], {
-      files: [
-        {
-          file: 'tests/unit/controllers/foo-test.js',
-          contains: [
-            "import { moduleFor, test } from 'ember-qunit';",
-            "moduleFor('controller:foo'"
-          ]
-        },
-      ]
-    });
+    var args = ['controller-test', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/controllers/foo-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('controller:foo'");
+      }));
   });
 
   it('in-addon controller-test foo', function() {
-    return generateAndDestroy(['controller-test', 'foo'], {
-        target: 'addon',
-        files: [
-          {
-            file: 'tests/unit/controllers/foo-test.js',
-            contains: [
-              "import { moduleFor, test } from 'ember-qunit';",
-              "moduleFor('controller:foo'"
-            ]
-          }
-        ]
-    });
+    var args = ['controller-test', 'foo'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/controllers/foo-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('controller:foo'");
+      }));
   });
 
   it('controller-test foo for mocha', function() {
-    return generateAndDestroy(['controller-test', 'foo'], {
-      packages: [
-        { name: 'ember-cli-qunit', delete: true },
-        { name: 'ember-cli-mocha', dev: true }
-      ],
-      files: [
-        {
-          file: 'tests/unit/controllers/foo-test.js',
-          contains: [
-            "import { describeModule, it } from 'ember-mocha';",
-            "describeModule('controller:foo', 'Unit | Controller | foo'"
-          ]
-        }
-      ]
-    });
+    var args = ['controller-test', 'foo'];
+
+    return emberNew()
+      .then(() => modifyPackages([
+        {name: 'ember-cli-qunit', delete: true},
+        {name: 'ember-cli-mocha', dev: true}
+      ]))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/controllers/foo-test.js'))
+          .to.contain("import { describeModule, it } from 'ember-mocha';")
+          .to.contain("describeModule('controller:foo', 'Unit | Controller | foo'");
+      }));
   });
 });

--- a/node-tests/blueprints/helper-addon-test.js
+++ b/node-tests/blueprints/helper-addon-test.js
@@ -1,24 +1,23 @@
 'use strict';
 
-var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
-var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
-var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+
+var chai = require('ember-cli-blueprint-test-helpers/chai');
+var expect = chai.expect;
 
 describe('Acceptance: ember generate and destroy helper-addon', function() {
   setupTestHooks(this);
 
   it('in-addon helper-addon foo-bar', function() {
-    return generateAndDestroy(['helper-addon', 'foo-bar'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'app/helpers/foo-bar.js',
-          contains: [
-            "export { default, fooBar } from 'my-addon/helpers/foo-bar';"
-          ]
-        },
-      ]
-    });
-  });
+    var args = ['helper-addon', 'foo-bar'];
 
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/helpers/foo-bar.js'))
+          .to.contain("export { default, fooBar } from 'my-addon/helpers/foo-bar';");
+      }));
+  });
 });

--- a/node-tests/blueprints/helper-test.js
+++ b/node-tests/blueprints/helper-test.js
@@ -1,304 +1,252 @@
 'use strict';
 
-var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
-var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
-var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+var modifyPackages = blueprintHelpers.modifyPackages;
+var setupPodConfig = blueprintHelpers.setupPodConfig;
+
+var chai = require('ember-cli-blueprint-test-helpers/chai');
+var expect = chai.expect;
 
 describe('Acceptance: ember generate and destroy helper', function() {
   setupTestHooks(this);
 
   it('helper foo/bar-baz', function() {
-    return generateAndDestroy(['helper', 'foo/bar-baz'], {
-      files: [
-        {
-          file: 'app/helpers/foo/bar-baz.js',
-          contains: "import Ember from 'ember';\n\n" +
-                    "export function fooBarBaz(params/*, hash*/) {\n" +
-                    "  return params;\n" +
-                    "}\n\n" +
-                    "export default Ember.Helper.helper(fooBarBaz);"
-        },
-        {
-          file: 'tests/unit/helpers/foo/bar-baz-test.js',
-          contains: "import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';"
-        }
-      ]
-    });
+    var args = ['helper', 'foo/bar-baz'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/helpers/foo/bar-baz.js'))
+          .to.contain("import Ember from 'ember';\n\n" +
+                      "export function fooBarBaz(params/*, hash*/) {\n" +
+                      "  return params;\n" +
+                      "}\n\n" +
+                      "export default Ember.Helper.helper(fooBarBaz);");
+
+        expect(_file('tests/unit/helpers/foo/bar-baz-test.js'))
+          .to.contain("import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';");
+      }));
   });
 
   it('in-addon helper foo-bar', function() {
-    return generateAndDestroy(['helper', 'foo-bar'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'addon/helpers/foo-bar.js',
-          contains: "import Ember from 'ember';\n\n" +
-                    "export function fooBar(params/*, hash*/) {\n" +
-                    "  return params;\n" +
-                    "}\n\n" +
-                    "export default Ember.Helper.helper(fooBar);"
-        },
-        {
-          file: 'app/helpers/foo-bar.js',
-          contains: [
-            "export { default, fooBar } from 'my-addon/helpers/foo-bar';"
-          ]
-        },
-        {
-          file: 'tests/unit/helpers/foo-bar-test.js',
-          contains: "import { fooBar } from 'dummy/helpers/foo-bar';"
-        }
-      ]
-    });
+    var args = ['helper', 'foo-bar'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('addon/helpers/foo-bar.js'))
+          .to.contain("import Ember from 'ember';\n\n" +
+                      "export function fooBar(params/*, hash*/) {\n" +
+                      "  return params;\n" +
+                      "}\n\n" +
+                      "export default Ember.Helper.helper(fooBar);");
+
+        expect(_file('app/helpers/foo-bar.js'))
+          .to.contain("export { default, fooBar } from 'my-addon/helpers/foo-bar';");
+        expect(_file('tests/unit/helpers/foo-bar-test.js'))
+          .to.contain("import { fooBar } from 'dummy/helpers/foo-bar';");
+      }));
   });
 
   it('in-addon helper foo/bar-baz', function() {
-    return generateAndDestroy(['helper', 'foo/bar-baz'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'addon/helpers/foo/bar-baz.js',
-          contains: "import Ember from 'ember';\n\n" +
-                    "export function fooBarBaz(params/*, hash*/) {\n" +
-                    "  return params;\n" +
-                    "}\n\n" +
-                    "export default Ember.Helper.helper(fooBarBaz);"
-        },
-        {
-          file: 'app/helpers/foo/bar-baz.js',
-          contains: [
-            "export { default, fooBarBaz } from 'my-addon/helpers/foo/bar-baz';"
-          ]
-        },
-        {
-          file: 'tests/unit/helpers/foo/bar-baz-test.js',
-          contains: "import { fooBarBaz } from 'dummy/helpers/foo/bar-baz';"
-        }
-      ]
-    });
+    var args = ['helper', 'foo/bar-baz'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('addon/helpers/foo/bar-baz.js'))
+          .to.contain("import Ember from 'ember';\n\n" +
+                      "export function fooBarBaz(params/*, hash*/) {\n" +
+                      "  return params;\n" +
+                      "}\n\n" +
+                      "export default Ember.Helper.helper(fooBarBaz);");
+
+        expect(_file('app/helpers/foo/bar-baz.js'))
+          .to.contain("export { default, fooBarBaz } from 'my-addon/helpers/foo/bar-baz';");
+        expect(_file('tests/unit/helpers/foo/bar-baz-test.js'))
+          .to.contain("import { fooBarBaz } from 'dummy/helpers/foo/bar-baz';");
+      }));
   });
 
   it('dummy helper foo-bar', function() {
-    return generateAndDestroy(['helper', 'foo-bar', '--dummy'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'tests/dummy/app/helpers/foo-bar.js',
-          contains: "import Ember from 'ember';\n\n" +
-                    "export function fooBar(params/*, hash*/) {\n" +
-                    "  return params;\n" +
-                    "}\n\n" +
-                    "export default Ember.Helper.helper(fooBar);"
-        },
-        {
-          file: 'app/helpers/foo-bar.js',
-          exists: false
-        },
-        {
-          file: 'tests/unit/helpers/foo-bar-test.js',
-          exists: false
-        }
-      ]
-    });
+    var args = ['helper', 'foo-bar', '--dummy'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/dummy/app/helpers/foo-bar.js'))
+          .to.contain("import Ember from 'ember';\n\n" +
+                      "export function fooBar(params/*, hash*/) {\n" +
+                      "  return params;\n" +
+                      "}\n\n" +
+                      "export default Ember.Helper.helper(fooBar);");
+
+        expect(_file('app/helpers/foo-bar.js'))
+          .to.not.exist;
+        expect(_file('tests/unit/helpers/foo-bar-test.js'))
+          .to.not.exist;
+      }));
   });
 
   it('dummy helper foo/bar-baz', function() {
-    return generateAndDestroy(['helper', 'foo/bar-baz', '--dummy'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'tests/dummy/app/helpers/foo/bar-baz.js',
-          contains: "import Ember from 'ember';\n\n" +
-                    "export function fooBarBaz(params/*, hash*/) {\n" +
-                    "  return params;\n" +
-                    "}\n\n" +
-                    "export default Ember.Helper.helper(fooBarBaz);"
-        },
-        {
-          file: 'app/helpers/foo/bar-baz.js',
-          exists: false
-        },
-        {
-          file: 'tests/unit/helpers/foo/bar-baz-test.js',
-          exists: false
-        }
-      ]
-    });
+    var args = ['helper', 'foo/bar-baz', '--dummy'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/dummy/app/helpers/foo/bar-baz.js'))
+          .to.contain("import Ember from 'ember';\n\n" +
+                      "export function fooBarBaz(params/*, hash*/) {\n" +
+                      "  return params;\n" +
+                      "}\n\n" +
+                      "export default Ember.Helper.helper(fooBarBaz);");
+
+        expect(_file('app/helpers/foo/bar-baz.js'))
+          .to.not.exist;
+        expect(_file('tests/unit/helpers/foo/bar-baz-test.js'))
+          .to.not.exist;
+      }));
   });
 
   it('in-repo-addon helper foo-bar', function() {
-    return generateAndDestroy(['helper', 'foo-bar', '--in-repo-addon=my-addon'], {
-      target: 'inRepoAddon',
-      files: [
-        {
-          file: 'lib/my-addon/addon/helpers/foo-bar.js',
-          contains: "import Ember from 'ember';\n\n" +
-                    "export function fooBar(params/*, hash*/) {\n" +
-                    "  return params;\n" +
-                    "}\n\n" +
-                    "export default Ember.Helper.helper(fooBar);"
-        },
-        {
-          file: 'lib/my-addon/app/helpers/foo-bar.js',
-          contains: [
-            "export { default, fooBar } from 'my-addon/helpers/foo-bar';"
-          ]
-        },
-        {
-          file: 'tests/unit/helpers/foo-bar-test.js',
-          contains: "import { fooBar } from 'my-app/helpers/foo-bar';"
-        }
-      ]
-    });
+    var args = ['helper', 'foo-bar', '--in-repo-addon=my-addon'];
+
+    return emberNew({ target: 'in-repo-addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('lib/my-addon/addon/helpers/foo-bar.js'))
+          .to.contain("import Ember from 'ember';\n\n" +
+                      "export function fooBar(params/*, hash*/) {\n" +
+                      "  return params;\n" +
+                      "}\n\n" +
+                      "export default Ember.Helper.helper(fooBar);");
+
+        expect(_file('lib/my-addon/app/helpers/foo-bar.js'))
+          .to.contain("export { default, fooBar } from 'my-addon/helpers/foo-bar';");
+        expect(_file('tests/unit/helpers/foo-bar-test.js'))
+          .to.contain("import { fooBar } from 'my-app/helpers/foo-bar';");
+      }));
   });
 
   it('in-repo-addon helper foo/bar-baz', function() {
-    return generateAndDestroy(['helper', 'foo/bar-baz', '--in-repo-addon=my-addon'], {
-      target: 'inRepoAddon',
-      files: [
-        {
-          file: 'lib/my-addon/addon/helpers/foo/bar-baz.js',
-          contains: "import Ember from 'ember';\n\n" +
-                    "export function fooBarBaz(params/*, hash*/) {\n" +
-                    "  return params;\n" +
-                    "}\n\n" +
-                    "export default Ember.Helper.helper(fooBarBaz);"
-        },
-        {
-          file: 'lib/my-addon/app/helpers/foo/bar-baz.js',
-          contains: [
-            "export { default, fooBarBaz } from 'my-addon/helpers/foo/bar-baz';"
-          ]
-        },
-        {
-          file: 'tests/unit/helpers/foo/bar-baz-test.js',
-          contains: "import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';"
-        }
-      ]
-    });
+    var args = ['helper', 'foo/bar-baz', '--in-repo-addon=my-addon'];
+
+    return emberNew({ target: 'in-repo-addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('lib/my-addon/addon/helpers/foo/bar-baz.js'))
+          .to.contain("import Ember from 'ember';\n\n" +
+                      "export function fooBarBaz(params/*, hash*/) {\n" +
+                      "  return params;\n" +
+                      "}\n\n" +
+                      "export default Ember.Helper.helper(fooBarBaz);");
+
+        expect(_file('lib/my-addon/app/helpers/foo/bar-baz.js'))
+          .to.contain("export { default, fooBarBaz } from 'my-addon/helpers/foo/bar-baz';");
+        expect(_file('tests/unit/helpers/foo/bar-baz-test.js'))
+          .to.contain("import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';");
+      }));
   });
 
-/**
-* Pod tests
-*
-*/
   it('helper foo-bar --pod', function() {
-    return generateAndDestroy(['helper', 'foo-bar', '--pod'], {
-      files: [
-        {
-          file: 'app/helpers/foo-bar.js',
-          contains: "import Ember from 'ember';\n\n" +
-                    "export function fooBar(params/*, hash*/) {\n" +
-                    "  return params;\n" +
-                    "}\n\n" +
-                    "export default Ember.Helper.helper(fooBar);"
-        },
-        {
-          file: 'tests/unit/helpers/foo-bar-test.js',
-          contains: "import { fooBar } from 'my-app/helpers/foo-bar';"
-        }
-      ]
-    });
+    var args = ['helper', 'foo-bar', '--pod'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/helpers/foo-bar.js'))
+          .to.contain("import Ember from 'ember';\n\n" +
+                      "export function fooBar(params/*, hash*/) {\n" +
+                      "  return params;\n" +
+                      "}\n\n" +
+                      "export default Ember.Helper.helper(fooBar);");
+
+        expect(_file('tests/unit/helpers/foo-bar-test.js'))
+          .to.contain("import { fooBar } from 'my-app/helpers/foo-bar';");
+      }));
   });
 
   it('helper foo-bar --pod podModulePrefix', function() {
-    return generateAndDestroy(['helper', 'foo-bar', '--pod'], {
-      podModulePrefix: true,
-      files: [
-        {
-          file: 'app/helpers/foo-bar.js',
-          contains: "import Ember from 'ember';\n\n" +
-                    "export function fooBar(params/*, hash*/) {\n" +
-                    "  return params;\n" +
-                    "}\n\n" +
-                    "export default Ember.Helper.helper(fooBar);"
-        },
-        {
-          file: 'tests/unit/helpers/foo-bar-test.js',
-          contains: "import { fooBar } from 'my-app/helpers/foo-bar';"
-        }
-      ]
-    });
+    var args = ['helper', 'foo-bar', '--pod'];
+
+    return emberNew()
+      .then(() => setupPodConfig({ podModulePrefix: true }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/helpers/foo-bar.js'))
+          .to.contain("import Ember from 'ember';\n\n" +
+                      "export function fooBar(params/*, hash*/) {\n" +
+                      "  return params;\n" +
+                      "}\n\n" +
+                      "export default Ember.Helper.helper(fooBar);");
+
+        expect(_file('tests/unit/helpers/foo-bar-test.js'))
+          .to.contain("import { fooBar } from 'my-app/helpers/foo-bar';");
+      }));
   });
 
   it('helper foo/bar-baz --pod', function() {
-    return generateAndDestroy(['helper', 'foo/bar-baz', '--pod'], {
-      files: [
-        {
-          file: 'app/helpers/foo/bar-baz.js',
-          contains: "import Ember from 'ember';\n\n" +
-                    "export function fooBarBaz(params/*, hash*/) {\n" +
-                    "  return params;\n" +
-                    "}\n\n" +
-                    "export default Ember.Helper.helper(fooBarBaz);"
-        },
-        {
-          file: 'tests/unit/helpers/foo/bar-baz-test.js',
-          contains: "import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';"
-        }
-      ]
-    });
+    var args = ['helper', 'foo/bar-baz', '--pod'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/helpers/foo/bar-baz.js'))
+          .to.contain("import Ember from 'ember';\n\n" +
+                      "export function fooBarBaz(params/*, hash*/) {\n" +
+                      "  return params;\n" +
+                      "}\n\n" +
+                      "export default Ember.Helper.helper(fooBarBaz);");
+
+        expect(_file('tests/unit/helpers/foo/bar-baz-test.js'))
+          .to.contain("import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';");
+      }));
   });
 
   it('helper foo/bar-baz --pod podModulePrefix', function() {
-    return generateAndDestroy(['helper', 'foo/bar-baz', '--pod'], {
-      podModulePrefix: true,
-      files: [
-        {
-          file: 'app/helpers/foo/bar-baz.js',
-          contains: "import Ember from 'ember';\n\n" +
-                    "export function fooBarBaz(params/*, hash*/) {\n" +
-                    "  return params;\n" +
-                    "}\n\n" +
-                    "export default Ember.Helper.helper(fooBarBaz);"
-        },
-        {
-          file: 'tests/unit/helpers/foo/bar-baz-test.js',
-          contains: "import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';"
-        }
-      ]
-    });
+    var args = ['helper', 'foo/bar-baz', '--pod'];
+
+    return emberNew()
+      .then(() => setupPodConfig({ podModulePrefix: true }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/helpers/foo/bar-baz.js'))
+          .to.contain("import Ember from 'ember';\n\n" +
+                      "export function fooBarBaz(params/*, hash*/) {\n" +
+                      "  return params;\n" +
+                      "}\n\n" +
+                      "export default Ember.Helper.helper(fooBarBaz);");
+
+        expect(_file('tests/unit/helpers/foo/bar-baz-test.js'))
+          .to.contain("import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';");
+      }));
   });
 
   it('helper-test foo/bar-baz', function() {
-    return generateAndDestroy(['helper-test', 'foo/bar-baz'], {
-      files: [
-        {
-          file: 'tests/unit/helpers/foo/bar-baz-test.js',
-          contains: "import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';"
-        }
-      ]
-    });
+    var args = ['helper-test', 'foo/bar-baz'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/helpers/foo/bar-baz-test.js'))
+          .to.contain("import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';");
+      }));
   });
 
   it('in-addon helper-test foo-bar', function() {
-    return generateAndDestroy(['helper-test', 'foo-bar'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'tests/unit/helpers/foo-bar-test.js',
-          contains: "import { fooBar } from 'dummy/helpers/foo-bar';"
-        }
-      ]
-    });
+    var args = ['helper-test', 'foo-bar'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/helpers/foo-bar-test.js'))
+          .to.contain("import { fooBar } from 'dummy/helpers/foo-bar';");
+      }));
   });
 
   it('helper-test foo/bar-baz for mocha', function() {
-    return generateAndDestroy(['helper-test', 'foo/bar-baz'], {
-      packages: [
-        { name: 'ember-cli-qunit', delete: true },
-        { name: 'ember-cli-mocha', dev: true }
-      ],
-      files: [
-        {
-          file: 'tests/unit/helpers/foo/bar-baz-test.js',
-          contains: [
-            "import { describe, it } from 'mocha';",
-            "import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';",
-            "describe('Unit | Helper | foo/bar baz', function() {"
-          ]
-        }
-      ]
-    });
+    var args = ['helper-test', 'foo/bar-baz'];
+
+    return emberNew()
+      .then(() => modifyPackages([
+        {name: 'ember-cli-qunit', delete: true},
+        {name: 'ember-cli-mocha', dev: true}
+      ]))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/helpers/foo/bar-baz-test.js'))
+          .to.contain("import { describe, it } from 'mocha';")
+          .to.contain("import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';")
+          .to.contain("describe('Unit | Helper | foo/bar baz', function() {");
+      }));
   });
 });

--- a/node-tests/blueprints/initializer-addon-test.js
+++ b/node-tests/blueprints/initializer-addon-test.js
@@ -1,24 +1,23 @@
 'use strict';
 
-var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
-var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
-var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+
+var chai = require('ember-cli-blueprint-test-helpers/chai');
+var expect = chai.expect;
 
 describe('Acceptance: ember generate and destroy initializer-addon', function() {
   setupTestHooks(this);
 
   it('initializer-addon foo', function() {
-    // pass any additional command line options in the arguments array
-    return generateAndDestroy(['initializer-addon', 'foo'], {
-      // define files to assert, and their contents
-      target: 'addon',
-      files: [
-        {
-          file: 'app/initializers/foo.js',
-          contains: "export { default, initialize } from 'my-addon/initializers/foo';"
-        }
-      ]
-    });
-  });
+    var args = ['initializer-addon', 'foo'];
 
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/initializers/foo.js'))
+          .to.contain("export { default, initialize } from 'my-addon/initializers/foo';");
+      }));
+  });
 });

--- a/node-tests/blueprints/initializer-test.js
+++ b/node-tests/blueprints/initializer-test.js
@@ -1,350 +1,310 @@
 'use strict';
 
-var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
-var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
-var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+var modifyPackages = blueprintHelpers.modifyPackages;
+var setupPodConfig = blueprintHelpers.setupPodConfig;
+
+var chai = require('ember-cli-blueprint-test-helpers/chai');
+var expect = chai.expect;
 
 describe('Acceptance: ember generate and destroy initializer', function() {
   setupTestHooks(this);
 
   it('initializer foo', function() {
-    return generateAndDestroy(['initializer', 'foo'], {
-      files: [
-        {
-          file:'app/initializers/foo.js',
-          contains: "export function initialize(/* application */) {\n" +
-                    "  // application.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo',\n" +
-                    "  initialize\n" +
-                    "};"
-        },
-        {
-          file:'tests/unit/initializers/foo-test.js',
-          contains: "import FooInitializer from 'my-app/initializers/foo';"
-        }
-      ]
-    });
+    var args = ['initializer', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/initializers/foo.js'))
+          .to.contain("export function initialize(/* application */) {\n" +
+                      "  // application.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo',\n" +
+                      "  initialize\n" +
+                      "};");
+
+        expect(_file('tests/unit/initializers/foo-test.js'))
+          .to.contain("import FooInitializer from 'my-app/initializers/foo';");
+      }));
   });
 
   it('initializer foo/bar', function() {
-    return generateAndDestroy(['initializer', 'foo/bar'], {
-      files: [
-        {
-          file:'app/initializers/foo/bar.js',
-          contains: "export function initialize(/* application */) {\n" +
-                    "  // application.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo/bar',\n" +
-                    "  initialize\n" +
-                    "};"
-        },
-        {
-          file:'tests/unit/initializers/foo/bar-test.js',
-          contains: "import FooBarInitializer from 'my-app/initializers/foo/bar';"
-        }
-      ]
-    });
+    var args = ['initializer', 'foo/bar'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/initializers/foo/bar.js'))
+          .to.contain("export function initialize(/* application */) {\n" +
+                      "  // application.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo/bar',\n" +
+                      "  initialize\n" +
+                      "};");
+
+        expect(_file('tests/unit/initializers/foo/bar-test.js'))
+          .to.contain("import FooBarInitializer from 'my-app/initializers/foo/bar';");
+      }));
   });
 
   it('in-addon initializer foo', function() {
-    return generateAndDestroy(['initializer', 'foo'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'addon/initializers/foo.js',
-          contains: "export function initialize(/* application */) {\n" +
-                    "  // application.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo',\n" +
-                    "  initialize\n" +
-                    "};"
-        },
-        {
-          file: 'app/initializers/foo.js',
-          contains: [
-            "export { default, initialize } from 'my-addon/initializers/foo';"
-          ]
-        },
-        {
-          file: 'tests/unit/initializers/foo-test.js'
-        }
-      ]
-    });
+    var args = ['initializer', 'foo'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('addon/initializers/foo.js'))
+          .to.contain("export function initialize(/* application */) {\n" +
+                      "  // application.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo',\n" +
+                      "  initialize\n" +
+                      "};");
+
+        expect(_file('app/initializers/foo.js'))
+          .to.contain("export { default, initialize } from 'my-addon/initializers/foo';");
+
+        expect(_file('tests/unit/initializers/foo-test.js'))
+          .to.exist;
+      }));
   });
 
   it('in-addon initializer foo/bar', function() {
-    return generateAndDestroy(['initializer', 'foo/bar'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'addon/initializers/foo/bar.js',
-          contains: "export function initialize(/* application */) {\n" +
-                    "  // application.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo/bar',\n" +
-                    "  initialize\n" +
-                    "};"
-        },
-        {
-          file: 'app/initializers/foo/bar.js',
-          contains: [
-            "export { default, initialize } from 'my-addon/initializers/foo/bar';"
-          ]
-        },
-        {
-          file: 'tests/unit/initializers/foo/bar-test.js'
-        }
-      ]
-    });
+    var args = ['initializer', 'foo/bar'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('addon/initializers/foo/bar.js'))
+          .to.contain("export function initialize(/* application */) {\n" +
+                      "  // application.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo/bar',\n" +
+                      "  initialize\n" +
+                      "};");
+
+        expect(_file('app/initializers/foo/bar.js'))
+          .to.contain("export { default, initialize } from 'my-addon/initializers/foo/bar';");
+
+        expect(_file('tests/unit/initializers/foo/bar-test.js'))
+          .to.exist;
+      }));
   });
 
   it('dummy initializer foo', function() {
-    return generateAndDestroy(['initializer', 'foo', '--dummy'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'tests/dummy/app/initializers/foo.js',
-          contains: "export function initialize(/* application */) {\n" +
-                    "  // application.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo',\n" +
-                    "  initialize\n" +
-                    "};"
-        },
-        {
-          file: 'app/initializers/foo.js',
-          exists: false
-        },
-        {
-          file: 'tests/unit/initializers/foo-test.js',
-          exists: false
-        }
-      ]
-    });
+    var args = ['initializer', 'foo', '--dummy'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/dummy/app/initializers/foo.js'))
+          .to.contain("export function initialize(/* application */) {\n" +
+                      "  // application.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo',\n" +
+                      "  initialize\n" +
+                      "};");
+
+        expect(_file('app/initializers/foo.js'))
+          .to.not.exist;
+
+        expect(_file('tests/unit/initializers/foo-test.js'))
+          .to.not.exist;
+      }));
   });
 
   it('dummy initializer foo/bar', function() {
-    return generateAndDestroy(['initializer', 'foo/bar', '--dummy'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'tests/dummy/app/initializers/foo/bar.js',
-          contains: "export function initialize(/* application */) {\n" +
-                    "  // application.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo/bar',\n" +
-                    "  initialize\n" +
-                    "};"
-        },
-        {
-          file: 'app/initializers/foo/bar.js',
-          exists: false
-        },
-        {
-          file: 'tests/unit/initializers/foo/bar-test.js',
-          exists: false
-        }
-      ]
-    });
+    var args = ['initializer', 'foo/bar', '--dummy'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/dummy/app/initializers/foo/bar.js'))
+          .to.contain("export function initialize(/* application */) {\n" +
+                      "  // application.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo/bar',\n" +
+                      "  initialize\n" +
+                      "};");
+
+        expect(_file('app/initializers/foo/bar.js'))
+          .to.not.exist;
+
+        expect(_file('tests/unit/initializers/foo/bar-test.js'))
+          .to.not.exist;
+      }));
   });
 
   it('in-repo-addon initializer foo', function() {
-    return generateAndDestroy(['initializer', 'foo', '--in-repo-addon=my-addon'], {
-      target: 'inRepoAddon',
-      files: [
-        {
-          file: 'lib/my-addon/addon/initializers/foo.js',
-          contains: "export function initialize(/* application */) {\n" +
-                    "  // application.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo',\n" +
-                    "  initialize\n" +
-                    "};"
-        },
-        {
-          file: 'lib/my-addon/app/initializers/foo.js',
-          contains: [
-            "export { default, initialize } from 'my-addon/initializers/foo';"
-          ]
-        },
-        {
-          file: 'tests/unit/initializers/foo-test.js'
-        }
-      ]
-    });
+    var args = ['initializer', 'foo', '--in-repo-addon=my-addon'];
+
+    return emberNew({ target: 'in-repo-addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('lib/my-addon/addon/initializers/foo.js'))
+          .to.contain("export function initialize(/* application */) {\n" +
+                      "  // application.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo',\n" +
+                      "  initialize\n" +
+                      "};");
+
+        expect(_file('lib/my-addon/app/initializers/foo.js'))
+          .to.contain("export { default, initialize } from 'my-addon/initializers/foo';");
+
+        expect(_file('tests/unit/initializers/foo-test.js'))
+          .to.exist;
+      }));
   });
 
   it('in-repo-addon initializer foo/bar', function() {
-    return generateAndDestroy(['initializer', 'foo/bar', '--in-repo-addon=my-addon'], {
-      target: 'inRepoAddon',
-      files: [
-        {
-          file: 'lib/my-addon/addon/initializers/foo/bar.js',
-          contains: "export function initialize(/* application */) {\n" +
-                    "  // application.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo/bar',\n" +
-                    "  initialize\n" +
-                    "};"
-        },
-        {
-          file: 'lib/my-addon/app/initializers/foo/bar.js',
-          contains: [
-            "export { default, initialize } from 'my-addon/initializers/foo/bar';"
-          ]
-        },
-        {
-          file: 'tests/unit/initializers/foo/bar-test.js'
-        }
-      ]
-    });
+    var args = ['initializer', 'foo/bar', '--in-repo-addon=my-addon'];
+
+    return emberNew({ target: 'in-repo-addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('lib/my-addon/addon/initializers/foo/bar.js'))
+          .to.contain("export function initialize(/* application */) {\n" +
+                      "  // application.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo/bar',\n" +
+                      "  initialize\n" +
+                      "};");
+
+        expect(_file('lib/my-addon/app/initializers/foo/bar.js'))
+          .to.contain("export { default, initialize } from 'my-addon/initializers/foo/bar';");
+
+        expect(_file('tests/unit/initializers/foo/bar-test.js'))
+          .to.exist;
+      }));
   });
 
   /* Pod tests */
 
   it('initializer foo --pod', function() {
-    return generateAndDestroy(['initializer', 'foo', '--pod'], {
-      files: [
-        {
-          file: 'app/initializers/foo.js',
-          contains: "export function initialize(/* application */) {\n" +
-                    "  // application.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo',\n" +
-                    "  initialize\n" +
-                    "};"
-        }
-      ]
-    });
+    var args = ['initializer', 'foo', '--pod'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/initializers/foo.js'))
+          .to.contain("export function initialize(/* application */) {\n" +
+                      "  // application.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo',\n" +
+                      "  initialize\n" +
+                      "};");
+      }));
   });
 
   it('initializer foo --pod podModulePrefix', function() {
-    return generateAndDestroy(['initializer', 'foo', '--pod'], {
-      podModulePrefix: true,
-      files: [
-        {
-          file: 'app/initializers/foo.js',
-          contains: "export function initialize(/* application */) {\n" +
-                    "  // application.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo',\n" +
-                    "  initialize\n" +
-                    "};"
-        }
-      ]
-    });
+    var args = ['initializer', 'foo', '--pod'];
+
+    return emberNew()
+      .then(() => setupPodConfig({ podModulePrefix: true }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/initializers/foo.js'))
+          .to.contain("export function initialize(/* application */) {\n" +
+                      "  // application.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo',\n" +
+                      "  initialize\n" +
+                      "};");
+      }));
   });
 
   it('initializer foo/bar --pod', function() {
-    return generateAndDestroy(['initializer', 'foo/bar', '--pod'], {
-      files: [
-        {
-          file: 'app/initializers/foo/bar.js',
-          contains: "export function initialize(/* application */) {\n" +
-                    "  // application.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo/bar',\n" +
-                    "  initialize\n" +
-                    "};"
-        }
-      ]
-    });
+    var args = ['initializer', 'foo/bar', '--pod'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/initializers/foo/bar.js'))
+          .to.contain("export function initialize(/* application */) {\n" +
+                      "  // application.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo/bar',\n" +
+                      "  initialize\n" +
+                      "};");
+      }));
   });
 
 
   it('initializer foo/bar --pod podModulePrefix', function() {
-    return generateAndDestroy(['initializer', 'foo/bar', '--pod'], {
-      podModulePrefix: true,
-      files: [
-        {
-          file: 'app/initializers/foo/bar.js',
-          contains: "export function initialize(/* application */) {\n" +
-                    "  // application.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo/bar',\n" +
-                    "  initialize\n" +
-                    "};"
-        }
-      ]
-    });
+    var args = ['initializer', 'foo/bar', '--pod'];
+
+    return emberNew()
+      .then(() => setupPodConfig({ podModulePrefix: true }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/initializers/foo/bar.js'))
+          .to.contain("export function initialize(/* application */) {\n" +
+                      "  // application.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo/bar',\n" +
+                      "  initialize\n" +
+                      "};");
+      }));
   });
 
 
   it('initializer-test foo', function() {
-    return generateAndDestroy(['initializer-test', 'foo'], {
-      files: [
-        {
-          file: 'tests/unit/initializers/foo-test.js',
-          contains: [
-            "import FooInitializer from 'my-app/initializers/foo';",
-            "module('Unit | Initializer | foo'",
-            "application = Ember.Application.create();",
-            "FooInitializer.initialize(application);"
-          ]
-        }
-      ]
-    });
+    var args = ['initializer-test', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/initializers/foo-test.js'))
+          .to.contain("import FooInitializer from 'my-app/initializers/foo';")
+          .to.contain("module('Unit | Initializer | foo'")
+          .to.contain("application = Ember.Application.create();")
+          .to.contain("FooInitializer.initialize(application);");
+      }));
   });
 
   it('in-addon initializer-test foo', function() {
-    return generateAndDestroy(['initializer-test', 'foo'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'tests/unit/initializers/foo-test.js',
-          contains: [
-            "import FooInitializer from 'dummy/initializers/foo';",
-            "module('Unit | Initializer | foo'",
-            "application = Ember.Application.create();",
-            "FooInitializer.initialize(application);"
-          ]
-        }
-      ]
-    });
+    var args = ['initializer-test', 'foo'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/initializers/foo-test.js'))
+          .to.contain("import FooInitializer from 'dummy/initializers/foo';")
+          .to.contain("module('Unit | Initializer | foo'")
+          .to.contain("application = Ember.Application.create();")
+          .to.contain("FooInitializer.initialize(application);");
+      }));
   });
 
   it('initializer-test foo for mocha', function() {
-    return generateAndDestroy(['initializer-test', 'foo'], {
-      packages: [
-        { name: 'ember-cli-qunit', delete: true },
-        { name: 'ember-cli-mocha', dev: true }
-      ],
-      files: [
-        {
-          file: 'tests/unit/initializers/foo-test.js',
-          contains: [
-            "import FooInitializer from 'my-app/initializers/foo';",
-            "describe('Unit | Initializer | foo', function() {",
-            "application = Ember.Application.create();",
-            "FooInitializer.initialize(application);"
-          ]
-        }
-      ]
-    });
+    var args = ['initializer-test', 'foo'];
+
+    return emberNew()
+      .then(() => modifyPackages([
+        {name: 'ember-cli-qunit', delete: true},
+        {name: 'ember-cli-mocha', dev: true}
+      ]))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/initializers/foo-test.js'))
+          .to.contain("import FooInitializer from 'my-app/initializers/foo';")
+          .to.contain("describe('Unit | Initializer | foo', function() {")
+          .to.contain("application = Ember.Application.create();")
+          .to.contain("FooInitializer.initialize(application);");
+      }));
   });
 });

--- a/node-tests/blueprints/instance-initializer-addon-test.js
+++ b/node-tests/blueprints/instance-initializer-addon-test.js
@@ -1,25 +1,23 @@
 'use strict';
 
-var tmpenv             = require('ember-cli-blueprint-test-helpers/lib/helpers/tmp-env');
-var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
-var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
-var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+
+var chai = require('ember-cli-blueprint-test-helpers/chai');
+var expect = chai.expect;
 
 describe('Acceptance: ember generate and destroy instance-initializer-addon', function() {
-  setupTestHooks(this, tmpenv);
+  setupTestHooks(this);
 
   it('instance-initializer-addon foo', function() {
-    // pass any additional command line options in the arguments array
-    return generateAndDestroy(['instance-initializer-addon', 'foo'], {
-      // define files to assert, and their contents
-      target: 'addon',
-      files: [
-        {
-          file: 'app/instance-initializers/foo.js',
-          contains: "export { default, initialize } from 'my-addon/instance-initializers/foo';"
-        }
-      ]
-    });
-  });
+    var args = ['instance-initializer-addon', 'foo'];
 
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/instance-initializers/foo.js'))
+          .to.contain("export { default, initialize } from 'my-addon/instance-initializers/foo';");
+      }));
+  });
 });

--- a/node-tests/blueprints/instance-initializer-test.js
+++ b/node-tests/blueprints/instance-initializer-test.js
@@ -1,353 +1,311 @@
 'use strict';
 
-var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
-var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
-var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+var modifyPackages = blueprintHelpers.modifyPackages;
+var setupPodConfig = blueprintHelpers.setupPodConfig;
+
+var chai = require('ember-cli-blueprint-test-helpers/chai');
+var expect = chai.expect;
 
 describe('Acceptance: ember generate and destroy instance-initializer', function() {
   setupTestHooks(this);
 
   it('instance-initializer foo', function() {
-    return generateAndDestroy(['instance-initializer', 'foo'], {
-      files: [
-        {
-          file:'app/instance-initializers/foo.js',
-          contains: "export function initialize(/* appInstance */) {\n" +
-                    "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo',\n" +
-                    "  initialize\n" +
-                    "};"
-        },
-        {
-          file:'tests/unit/instance-initializers/foo-test.js',
-          contains: "import { initialize } from 'my-app/instance-initializers/foo';"
-        }
-      ]
-    });
+    var args = ['instance-initializer', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/instance-initializers/foo.js'))
+          .to.contain("export function initialize(/* appInstance */) {\n" +
+                      "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo',\n" +
+                      "  initialize\n" +
+                      "};");
+
+        expect(_file('tests/unit/instance-initializers/foo-test.js'))
+          .to.contain("import { initialize } from 'my-app/instance-initializers/foo';");
+      }));
   });
 
   it('instance-initializer foo/bar', function() {
-    return generateAndDestroy(['instance-initializer', 'foo/bar'], {
-      files: [
-        {
-          file:'app/instance-initializers/foo/bar.js',
-          contains: "export function initialize(/* appInstance */) {\n" +
-                    "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo/bar',\n" +
-                    "  initialize\n" +
-                    "};"
-        },
-        {
-          file:'tests/unit/instance-initializers/foo/bar-test.js',
-          contains: "import { initialize } from 'my-app/instance-initializers/foo/bar';"
-        }
-      ]
-    });
+    var args = ['instance-initializer', 'foo/bar'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/instance-initializers/foo/bar.js'))
+          .to.contain("export function initialize(/* appInstance */) {\n" +
+                      "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo/bar',\n" +
+                      "  initialize\n" +
+                      "};");
+
+        expect(_file('tests/unit/instance-initializers/foo/bar-test.js'))
+          .to.contain("import { initialize } from 'my-app/instance-initializers/foo/bar';");
+      }));
   });
 
   it('in-addon instance-initializer foo', function() {
-    return generateAndDestroy(['instance-initializer', 'foo'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'addon/instance-initializers/foo.js',
-          contains: "export function initialize(/* appInstance */) {\n" +
-                    "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo',\n" +
-                    "  initialize\n" +
-                    "};"
-        },
-        {
-          file: 'app/instance-initializers/foo.js',
-          contains: [
-            "export { default, initialize } from 'my-addon/instance-initializers/foo';"
-          ]
-        },
-        {
-          file: 'tests/unit/instance-initializers/foo-test.js'
-        }
-      ]
-    });
+    var args = ['instance-initializer', 'foo'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('addon/instance-initializers/foo.js'))
+          .to.contain("export function initialize(/* appInstance */) {\n" +
+                      "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo',\n" +
+                      "  initialize\n" +
+                      "};");
+
+        expect(_file('app/instance-initializers/foo.js'))
+          .to.contain("export { default, initialize } from 'my-addon/instance-initializers/foo';");
+
+        expect(_file('tests/unit/instance-initializers/foo-test.js'));
+      }));
   });
 
   it('in-addon instance-initializer foo/bar', function() {
-    return generateAndDestroy(['instance-initializer', 'foo/bar'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'addon/instance-initializers/foo/bar.js',
-          contains: "export function initialize(/* appInstance */) {\n" +
-                    "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo/bar',\n" +
-                    "  initialize\n" +
-                    "};"
-        },
-        {
-          file: 'app/instance-initializers/foo/bar.js',
-          contains: [
-            "export { default, initialize } from 'my-addon/instance-initializers/foo/bar';"
-          ]
-        },
-        {
-          file: 'tests/unit/instance-initializers/foo/bar-test.js'
-        }
-      ]
-    });
+    var args = ['instance-initializer', 'foo/bar'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('addon/instance-initializers/foo/bar.js'))
+          .to.contain("export function initialize(/* appInstance */) {\n" +
+                      "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo/bar',\n" +
+                      "  initialize\n" +
+                      "};");
+
+        expect(_file('app/instance-initializers/foo/bar.js'))
+          .to.contain("export { default, initialize } from 'my-addon/instance-initializers/foo/bar';");
+
+        expect(_file('tests/unit/instance-initializers/foo/bar-test.js'));
+      }));
   });
 
   it('dummy instance-initializer foo', function() {
-    return generateAndDestroy(['instance-initializer', 'foo', '--dummy'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'tests/dummy/app/instance-initializers/foo.js',
-          contains: "export function initialize(/* appInstance */) {\n" +
-                    "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo',\n" +
-                    "  initialize\n" +
-                    "};"
-        },
-        {
-          file: 'app/instance-initializers/foo.js',
-          exists: false
-        },
-        {
-          file: 'tests/unit/instance-initializers/foo-test.js',
-          exists: false
-        }
-      ]
-    });
+    var args = ['instance-initializer', 'foo', '--dummy'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/dummy/app/instance-initializers/foo.js'))
+          .to.contain("export function initialize(/* appInstance */) {\n" +
+                      "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo',\n" +
+                      "  initialize\n" +
+                      "};");
+
+        expect(_file('app/instance-initializers/foo.js'))
+          .to.not.exist;
+
+        expect(_file('tests/unit/instance-initializers/foo-test.js'))
+          .to.not.exist;
+      }));
   });
 
   it('dummy instance-initializer foo/bar', function() {
-    return generateAndDestroy(['instance-initializer', 'foo/bar', '--dummy'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'tests/dummy/app/instance-initializers/foo/bar.js',
-          contains: "export function initialize(/* appInstance */) {\n" +
-                    "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo/bar',\n" +
-                    "  initialize\n" +
-                    "};"
-        },
-        {
-          file: 'app/instance-initializers/foo/bar.js',
-          exists: false
-        },
-        {
-          file: 'tests/unit/instance-initializers/foo/bar-test.js',
-          exists: false
-        }
-      ]
-    });
+    var args = ['instance-initializer', 'foo/bar', '--dummy'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/dummy/app/instance-initializers/foo/bar.js'))
+          .to.contain("export function initialize(/* appInstance */) {\n" +
+                      "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo/bar',\n" +
+                      "  initialize\n" +
+                      "};");
+
+        expect(_file('app/instance-initializers/foo/bar.js'))
+          .to.not.exist;
+
+        expect(_file('tests/unit/instance-initializers/foo/bar-test.js'))
+          .to.not.exist;
+      }));
   });
 
   it('in-repo-addon instance-initializer foo', function() {
-    return generateAndDestroy(['instance-initializer', 'foo', '--in-repo-addon=my-addon'], {
-      target: 'inRepoAddon',
-      files: [
-        {
-          file: 'lib/my-addon/addon/instance-initializers/foo.js',
-          contains: "export function initialize(/* appInstance */) {\n" +
-                    "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo',\n" +
-                    "  initialize\n" +
-                    "};"
-        },
-        {
-          file: 'lib/my-addon/app/instance-initializers/foo.js',
-          contains: [
-            "export { default, initialize } from 'my-addon/instance-initializers/foo';"
-          ]
-        },
-        {
-          file: 'tests/unit/instance-initializers/foo-test.js'
-        }
-      ]
-    });
+    var args = ['instance-initializer', 'foo', '--in-repo-addon=my-addon'];
+
+    return emberNew({ target: 'in-repo-addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('lib/my-addon/addon/instance-initializers/foo.js'))
+          .to.contain("export function initialize(/* appInstance */) {\n" +
+                      "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo',\n" +
+                      "  initialize\n" +
+                      "};");
+
+        expect(_file('lib/my-addon/app/instance-initializers/foo.js'))
+          .to.contain("export { default, initialize } from 'my-addon/instance-initializers/foo';");
+
+        expect(_file('tests/unit/instance-initializers/foo-test.js'))
+          .to.exist;
+      }));
   });
 
   it('in-repo-addon instance-initializer foo/bar', function() {
-    return generateAndDestroy(['instance-initializer', 'foo/bar', '--in-repo-addon=my-addon'], {
-      target: 'inRepoAddon',
-      files: [
-        {
-          file: 'lib/my-addon/addon/instance-initializers/foo/bar.js',
-          contains: "export function initialize(/* appInstance */) {\n" +
-                    "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo/bar',\n" +
-                    "  initialize\n" +
-                    "};"
-        },
-        {
-          file: 'lib/my-addon/app/instance-initializers/foo/bar.js',
-          contains: [
-            "export { default, initialize } from 'my-addon/instance-initializers/foo/bar';"
-          ]
-        },
-        {
-          file: 'tests/unit/instance-initializers/foo/bar-test.js'
-        }
-      ]
-    });
+    var args = ['instance-initializer', 'foo/bar', '--in-repo-addon=my-addon'];
+
+    return emberNew({ target: 'in-repo-addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('lib/my-addon/addon/instance-initializers/foo/bar.js'))
+          .to.contain("export function initialize(/* appInstance */) {\n" +
+                      "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo/bar',\n" +
+                      "  initialize\n" +
+                      "};");
+
+        expect(_file('lib/my-addon/app/instance-initializers/foo/bar.js'))
+          .to.contain("export { default, initialize } from 'my-addon/instance-initializers/foo/bar';");
+
+        expect(_file('tests/unit/instance-initializers/foo/bar-test.js'))
+          .to.exist;
+      }));
   });
 
   /* Pod tests */
 
   it('instance-initializer foo --pod', function() {
-    return generateAndDestroy(['instance-initializer', 'foo', '--pod'], {
-      files: [
-        {
-          file: 'app/instance-initializers/foo.js',
-          contains: "export function initialize(/* appInstance */) {\n" +
-                    "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo',\n" +
-                    "  initialize\n" +
-                    "};"
-        }
-      ]
-    });
+    var args = ['instance-initializer', 'foo', '--pod'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/instance-initializers/foo.js'))
+          .to.contain("export function initialize(/* appInstance */) {\n" +
+                      "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo',\n" +
+                      "  initialize\n" +
+                      "};");
+      }));
   });
 
   it('instance-initializer foo --pod podModulePrefix', function() {
-    return generateAndDestroy(['instance-initializer', 'foo', '--pod'], {
-      podModulePrefix: true,
-      files: [
-        {
-          file: 'app/instance-initializers/foo.js',
-          contains: "export function initialize(/* appInstance */) {\n" +
-                    "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo',\n" +
-                    "  initialize\n" +
-                    "};"
-        }
-      ]
-    });
+    var args = ['instance-initializer', 'foo', '--pod'];
+
+    return emberNew()
+      .then(() => setupPodConfig({ podModulePrefix: true }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/instance-initializers/foo.js'))
+          .to.contain("export function initialize(/* appInstance */) {\n" +
+                      "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo',\n" +
+                      "  initialize\n" +
+                      "};");
+      }));
   });
 
   it('instance-initializer foo/bar --pod', function() {
-    return generateAndDestroy(['instance-initializer', 'foo/bar', '--pod'], {
-      files: [
-        {
-          file: 'app/instance-initializers/foo/bar.js',
-          contains: "export function initialize(/* appInstance */) {\n" +
-                    "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo/bar',\n" +
-                    "  initialize\n" +
-                    "};"
-        }
-      ]
-    });
+    var args = ['instance-initializer', 'foo/bar', '--pod'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/instance-initializers/foo/bar.js'))
+          .to.contain("export function initialize(/* appInstance */) {\n" +
+                      "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo/bar',\n" +
+                      "  initialize\n" +
+                      "};");
+      }));
   });
 
 
   it('instance-initializer foo/bar --pod podModulePrefix', function() {
-    return generateAndDestroy(['instance-initializer', 'foo/bar', '--pod'], {
-      podModulePrefix: true,
-      files: [
-        {
-          file: 'app/instance-initializers/foo/bar.js',
-          contains: "export function initialize(/* appInstance */) {\n" +
-                    "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
-                    "}\n" +
-                    "\n"+
-                    "export default {\n" +
-                    "  name: 'foo/bar',\n" +
-                    "  initialize\n" +
-                    "};"
-        }
-      ]
-    });
+    var args = ['instance-initializer', 'foo/bar', '--pod'];
+
+    return emberNew()
+      .then(() => setupPodConfig({ podModulePrefix: true }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/instance-initializers/foo/bar.js'))
+          .to.contain("export function initialize(/* appInstance */) {\n" +
+                      "  // appInstance.inject('route', 'foo', 'service:foo');\n" +
+                      "}\n" +
+                      "\n" +
+                      "export default {\n" +
+                      "  name: 'foo/bar',\n" +
+                      "  initialize\n" +
+                      "};");
+      }));
   });
 
 
   it('instance-initializer-test foo', function() {
-    return generateAndDestroy(['instance-initializer-test', 'foo'], {
-      files: [
-        {
-          file: 'tests/unit/instance-initializers/foo-test.js',
-          contains: [
-            "import { initialize } from 'my-app/instance-initializers/foo';",
-            "module('Unit | Instance Initializer | foo'",
-            "application = Ember.Application.create();",
-            "this.appInstance = this.application.buildInstance();",
-            "initialize(this.appInstance);"
-          ]
-        }
-      ]
-    });
+    var args = ['instance-initializer-test', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/instance-initializers/foo-test.js'))
+          .to.contain("import { initialize } from 'my-app/instance-initializers/foo';")
+          .to.contain("module('Unit | Instance Initializer | foo'")
+          .to.contain("application = Ember.Application.create();")
+          .to.contain("this.appInstance = this.application.buildInstance();")
+          .to.contain("initialize(this.appInstance);");
+      }));
   });
 
   it('in-addon instance-initializer-test foo', function() {
-    return generateAndDestroy(['instance-initializer-test', 'foo'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'tests/unit/instance-initializers/foo-test.js',
-          contains: [
-            "import { initialize } from 'dummy/instance-initializers/foo';",
-            "module('Unit | Instance Initializer | foo'",
-            "application = Ember.Application.create();",
-            "this.appInstance = this.application.buildInstance();",
-            "initialize(this.appInstance);"
-          ]
-        }
-      ]
-    });
+    var args = ['instance-initializer-test', 'foo'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/instance-initializers/foo-test.js'))
+          .to.contain("import { initialize } from 'dummy/instance-initializers/foo';")
+          .to.contain("module('Unit | Instance Initializer | foo'")
+          .to.contain("application = Ember.Application.create();")
+          .to.contain("this.appInstance = this.application.buildInstance();")
+          .to.contain("initialize(this.appInstance);");
+      }));
   });
 
   it('instance-initializer-test foo for mocha', function() {
-    return generateAndDestroy(['instance-initializer-test', 'foo'], {
-      packages: [
-        { name: 'ember-cli-qunit', delete: true },
-        { name: 'ember-cli-mocha', dev: true }
-      ],
-      files: [
-        {
-          file: 'tests/unit/instance-initializers/foo-test.js',
-          contains: [
-            "import { initialize } from 'my-app/instance-initializers/foo';",
-            "describe('Unit | Instance Initializer | foo', function() {",
-            "application = Ember.Application.create();",
-            "appInstance = application.buildInstance();",
-            "initialize(appInstance);"
-          ]
-        }
-      ]
-    });
+    var args = ['instance-initializer-test', 'foo'];
+
+    return emberNew()
+      .then(() => modifyPackages([
+        {name: 'ember-cli-qunit', delete: true},
+        {name: 'ember-cli-mocha', dev: true}
+      ]))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/instance-initializers/foo-test.js'))
+          .to.contain("import { initialize } from 'my-app/instance-initializers/foo';")
+          .to.contain("describe('Unit | Instance Initializer | foo', function() {")
+          .to.contain("application = Ember.Application.create();")
+          .to.contain("appInstance = application.buildInstance();")
+          .to.contain("initialize(appInstance);");
+      }));
   });
 });

--- a/node-tests/blueprints/mixin-test.js
+++ b/node-tests/blueprints/mixin-test.js
@@ -1,336 +1,248 @@
 'use strict';
 
-var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
-var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
-var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+var modifyPackages = blueprintHelpers.modifyPackages;
+var setupPodConfig = blueprintHelpers.setupPodConfig;
+
+var chai = require('ember-cli-blueprint-test-helpers/chai');
+var expect = chai.expect;
 
 describe('Acceptance: ember generate and destroy mixin', function() {
   setupTestHooks(this);
 
   it('mixin foo', function() {
-    return generateAndDestroy(['mixin', 'foo'], {
-      files: [
-        {
-          file: 'app/mixins/foo.js',
-          contains: [
-            "import Ember from 'ember';",
-            'export default Ember.Mixin.create({\n});'
-          ]
-        },
-        {
-          file: 'tests/unit/mixins/foo-test.js',
-          contains: [
-            "import FooMixin from 'my-app/mixins/foo';"
-          ]
-        }
-      ]
-    });
+    var args = ['mixin', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/mixins/foo.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain('export default Ember.Mixin.create({\n});');
+
+        expect(_file('tests/unit/mixins/foo-test.js'))
+          .to.contain("import FooMixin from 'my-app/mixins/foo';");
+      }));
   });
 
   it('mixin foo/bar', function() {
-    return generateAndDestroy(['mixin', 'foo/bar'], {
-      files: [
-        {
-          file: 'app/mixins/foo/bar.js',
-          contains: [
-            "import Ember from 'ember';",
-            'export default Ember.Mixin.create({\n});'
-          ]
-        },
-        {
-          file: 'tests/unit/mixins/foo/bar-test.js',
-          contains: [
-            "import FooBarMixin from 'my-app/mixins/foo/bar';"
-          ]
-        }
-      ]
-    });
+    var args = ['mixin', 'foo/bar'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/mixins/foo/bar.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain('export default Ember.Mixin.create({\n});');
+
+        expect(_file('tests/unit/mixins/foo/bar-test.js'))
+          .to.contain("import FooBarMixin from 'my-app/mixins/foo/bar';");
+      }));
   });
 
   it('mixin foo/bar/baz', function() {
-    return generateAndDestroy(['mixin', 'foo/bar/baz'], {
-      files: [
-        {
-          file: 'tests/unit/mixins/foo/bar/baz-test.js',
-          contains: [
-            "import FooBarBazMixin from 'my-app/mixins/foo/bar/baz';"
-          ]
-        }
-      ]
-    });
+    var args = ['mixin', 'foo/bar/baz'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/mixins/foo/bar/baz-test.js'))
+          .to.contain("import FooBarBazMixin from 'my-app/mixins/foo/bar/baz';");
+      }));
   });
 
   it('in-addon mixin foo', function() {
-    return generateAndDestroy(['mixin', 'foo'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'addon/mixins/foo.js',
-          contains: [
-            "import Ember from 'ember';",
-            'export default Ember.Mixin.create({\n});'
-          ]
-        },
-        {
-          file: 'tests/unit/mixins/foo-test.js',
-          contains: [
-            "import FooMixin from 'my-addon/mixins/foo';"
-          ]
-        },
-        {
-          file: 'app/mixins/foo.js',
-          exists: false
-        }
-      ]
-    });
+    var args = ['mixin', 'foo'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('addon/mixins/foo.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain('export default Ember.Mixin.create({\n});');
+
+        expect(_file('tests/unit/mixins/foo-test.js'))
+          .to.contain("import FooMixin from 'my-addon/mixins/foo';");
+
+        expect(_file('app/mixins/foo.js'))
+          .to.not.exist;
+      }));
   });
 
   it('in-addon mixin foo/bar', function() {
-    return generateAndDestroy(['mixin', 'foo/bar'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'addon/mixins/foo/bar.js',
-          contains: [
-            "import Ember from 'ember';",
-            'export default Ember.Mixin.create({\n});'
-          ]
-        },
-        {
-          file: 'tests/unit/mixins/foo/bar-test.js',
-          contains: [
-            "import FooBarMixin from 'my-addon/mixins/foo/bar';"
-          ]
-        },
-        {
-          file: 'app/mixins/foo/bar.js',
-          exists: false
-        }
-      ]
-    });
+    var args = ['mixin', 'foo/bar'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('addon/mixins/foo/bar.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain('export default Ember.Mixin.create({\n});');
+
+        expect(_file('tests/unit/mixins/foo/bar-test.js'))
+          .to.contain("import FooBarMixin from 'my-addon/mixins/foo/bar';");
+
+        expect(_file('app/mixins/foo/bar.js'))
+          .to.not.exist;
+      }));
   });
 
   it('in-addon mixin foo/bar/baz', function() {
-    return generateAndDestroy(['mixin', 'foo/bar/baz'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'addon/mixins/foo/bar/baz.js',
-          contains: [
-            "import Ember from 'ember';",
-            'export default Ember.Mixin.create({\n});'
-          ]
-        },
-        {
-          file: 'tests/unit/mixins/foo/bar/baz-test.js',
-          contains: [
-            "import FooBarBazMixin from 'my-addon/mixins/foo/bar/baz';"
-          ]
-        },
-        {
-          file: 'app/mixins/foo/bar/baz.js',
-          exists: false
-        }
-      ]
-    });
-  })
+    var args = ['mixin', 'foo/bar/baz'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('addon/mixins/foo/bar/baz.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain('export default Ember.Mixin.create({\n});');
+
+        expect(_file('tests/unit/mixins/foo/bar/baz-test.js'))
+          .to.contain("import FooBarBazMixin from 'my-addon/mixins/foo/bar/baz';");
+
+        expect(_file('app/mixins/foo/bar/baz.js'))
+          .to.not.exist;
+      }));
+  });
 
   it('in-repo-addon mixin foo', function() {
-    return generateAndDestroy(['mixin', 'foo', '--in-repo-addon=my-addon'], {
-      target: 'inRepoAddon',
-      files: [
-        {
-          file: 'lib/my-addon/addon/mixins/foo.js',
-          contains: [
-            "import Ember from 'ember';",
-            'export default Ember.Mixin.create({\n});'
-          ]
-        },
-        {
-          file: 'tests/unit/mixins/foo-test.js',
-          contains: [
-            "import FooMixin from 'my-addon/mixins/foo';"
-          ]
-        }
-      ]
-    });
+    var args = ['mixin', 'foo', '--in-repo-addon=my-addon'];
+
+    return emberNew({ target: 'in-repo-addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('lib/my-addon/addon/mixins/foo.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain('export default Ember.Mixin.create({\n});');
+
+        expect(_file('tests/unit/mixins/foo-test.js'))
+          .to.contain("import FooMixin from 'my-addon/mixins/foo';");
+      }));
   });
 
   it('in-repo-addon mixin foo/bar', function() {
-    return generateAndDestroy(['mixin', 'foo/bar', '--in-repo-addon=my-addon'], {
-      target: 'inRepoAddon',
-      files: [
-        {
-          file: 'lib/my-addon/addon/mixins/foo/bar.js',
-          contains: [
-            "import Ember from 'ember';",
-            'export default Ember.Mixin.create({\n});'
-          ]
-        },
-        {
-          file: 'tests/unit/mixins/foo/bar-test.js',
-          contains: [
-            "import FooBarMixin from 'my-addon/mixins/foo/bar';"
-          ]
-        }
-      ]
-    });
+    var args = ['mixin', 'foo/bar', '--in-repo-addon=my-addon'];
+
+    return emberNew({ target: 'in-repo-addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('lib/my-addon/addon/mixins/foo/bar.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain('export default Ember.Mixin.create({\n});');
+
+        expect(_file('tests/unit/mixins/foo/bar-test.js'))
+          .to.contain("import FooBarMixin from 'my-addon/mixins/foo/bar';");
+      }));
   });
 
   it('in-repo-addon mixin foo/bar/baz', function() {
-    return generateAndDestroy(['mixin', 'foo/bar/baz', '--in-repo-addon=my-addon'], {
-      target: 'inRepoAddon',
-      files: [
-        {
-          file: 'tests/unit/mixins/foo/bar/baz-test.js',
-          contains: [
-            "import FooBarBazMixin from 'my-addon/mixins/foo/bar/baz';"
-          ]
-        }
-      ]
-    });
+    var args = ['mixin', 'foo/bar/baz', '--in-repo-addon=my-addon'];
+
+    return emberNew({ target: 'in-repo-addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/mixins/foo/bar/baz-test.js'))
+          .to.contain("import FooBarBazMixin from 'my-addon/mixins/foo/bar/baz';");
+      }));
   });
 
   /* Pod tests */
 
   it('mixin foo --pod', function() {
-    return generateAndDestroy(['mixin', 'foo', '--pod'], {
-      files: [
-        {
-          file: 'app/mixins/foo.js',
-          contains: [
-            "import Ember from 'ember';",
-            'export default Ember.Mixin.create({\n});'
-          ]
-        },
-        {
-          file: 'tests/unit/mixins/foo-test.js',
-          contains: [
-            "import FooMixin from 'my-app/mixins/foo';"
-          ]
-        }
-      ]
-    });
+    var args = ['mixin', 'foo', '--pod'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/mixins/foo.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain('export default Ember.Mixin.create({\n});');
+
+        expect(_file('tests/unit/mixins/foo-test.js'))
+          .to.contain("import FooMixin from 'my-app/mixins/foo';");
+      }));
   });
 
   it('mixin foo --pod podModulePrefix', function() {
-    return generateAndDestroy(['mixin', 'foo', '--pod'], {
-      podModulePrefix: true,
-      files: [
-        {
-          file: 'app/mixins/foo.js',
-          contains: [
-            "import Ember from 'ember';",
-            'export default Ember.Mixin.create({\n});'
-          ]
-        },
-        {
-          file: 'tests/unit/mixins/foo-test.js',
-          contains: [
-            "import FooMixin from 'my-app/mixins/foo';"
-          ]
-        }
-      ]
-    });
+    var args = ['mixin', 'foo', '--pod'];
+
+    return emberNew()
+      .then(() => setupPodConfig({ podModulePrefix: true }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/mixins/foo.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain('export default Ember.Mixin.create({\n});');
+
+        expect(_file('tests/unit/mixins/foo-test.js'))
+          .to.contain("import FooMixin from 'my-app/mixins/foo';");
+      }));
   });
 
   it('mixin foo/bar --pod', function() {
-    return generateAndDestroy(['mixin', 'foo/bar', '--pod'], {
-      files: [
-        {
-          file: 'app/mixins/foo/bar.js',
-          contains: [
-            "import Ember from 'ember';",
-            'export default Ember.Mixin.create({\n});'
-          ]
-        },
-        {
-          file: 'tests/unit/mixins/foo/bar-test.js',
-          contains: [
-            "import FooBarMixin from 'my-app/mixins/foo/bar';"
-          ]
-        }
-      ]
-    });
+    var args = ['mixin', 'foo/bar', '--pod'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/mixins/foo/bar.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain('export default Ember.Mixin.create({\n});');
+
+        expect(_file('tests/unit/mixins/foo/bar-test.js'))
+          .to.contain("import FooBarMixin from 'my-app/mixins/foo/bar';");
+      }));
   });
 
   it('mixin foo/bar --pod podModulePrefix', function() {
-    return generateAndDestroy(['mixin', 'foo/bar', '--pod'], {
-      podModulePrefix: true,
-      files: [
-        {
-          file: 'app/mixins/foo/bar.js',
-          contains: [
-            "import Ember from 'ember';",
-            'export default Ember.Mixin.create({\n});'
-          ]
-        },
-        {
-          file: 'tests/unit/mixins/foo/bar-test.js',
-          contains: [
-            "import FooBarMixin from 'my-app/mixins/foo/bar';"
-          ]
-        }
-      ]
-    });
+    var args = ['mixin', 'foo/bar', '--pod'];
+
+    return emberNew()
+      .then(() => setupPodConfig({ podModulePrefix: true }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/mixins/foo/bar.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain('export default Ember.Mixin.create({\n});');
+
+        expect(_file('tests/unit/mixins/foo/bar-test.js'))
+          .to.contain("import FooBarMixin from 'my-app/mixins/foo/bar';");
+      }));
   });
 
   it('mixin foo/bar/baz --pod', function() {
-    return generateAndDestroy(['mixin', 'foo/bar/baz', '--pod'], {
-      files: [
-        {
-          file: 'tests/unit/mixins/foo/bar/baz-test.js',
-          contains: [
-            "import FooBarBazMixin from 'my-app/mixins/foo/bar/baz';"
-          ]
-        }
-      ]
-    });
+    var args = ['mixin', 'foo/bar/baz', '--pod'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/mixins/foo/bar/baz-test.js'))
+          .to.contain("import FooBarBazMixin from 'my-app/mixins/foo/bar/baz';");
+      }));
   });
 
   it('mixin-test foo', function() {
-    return generateAndDestroy(['mixin-test', 'foo'], {
-      files: [
-        {
-          file: 'tests/unit/mixins/foo-test.js',
-          contains: [
-            "import FooMixin from 'my-app/mixins/foo';"
-          ]
-        }
-      ]
-    });
+    var args = ['mixin-test', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/mixins/foo-test.js'))
+          .to.contain("import FooMixin from 'my-app/mixins/foo';");
+      }));
   });
 
   it('in-addon mixin-test foo', function() {
-    return generateAndDestroy(['mixin-test', 'foo'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'tests/unit/mixins/foo-test.js',
-          contains: [
-            "import FooMixin from 'my-addon/mixins/foo';"
-          ]
-        }
-      ]
-    });
+    var args = ['mixin-test', 'foo'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/mixins/foo-test.js'))
+          .to.contain("import FooMixin from 'my-addon/mixins/foo';");
+      }));
   });
 
   it('mixin-test foo for mocha', function() {
-    return generateAndDestroy(['mixin-test', 'foo'], {
-      packages: [
-        { name: 'ember-cli-qunit', delete: true },
-        { name: 'ember-cli-mocha', dev: true }
-      ],
-      files: [
-        {
-          file: 'tests/unit/mixins/foo-test.js',
-          contains: [
-            "import { describe, it } from 'mocha';",
-            "import FooMixin from 'my-app/mixins/foo';",
-            "describe('Unit | Mixin | foo', function() {"
-          ]
-        }
-      ]
-    });
+    var args = ['mixin-test', 'foo'];
+
+    return emberNew()
+      .then(() => modifyPackages([
+        {name: 'ember-cli-qunit', delete: true},
+        {name: 'ember-cli-mocha', dev: true}
+      ]))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/mixins/foo-test.js'))
+          .to.contain("import { describe, it } from 'mocha';")
+          .to.contain("import FooMixin from 'my-app/mixins/foo';")
+          .to.contain("describe('Unit | Mixin | foo', function() {");
+      }));
   });
 });

--- a/node-tests/blueprints/route-addon-test.js
+++ b/node-tests/blueprints/route-addon-test.js
@@ -1,30 +1,25 @@
 'use strict';
 
-var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
-var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
-var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+
+var chai = require('ember-cli-blueprint-test-helpers/chai');
+var expect = chai.expect;
 
 describe('Acceptance: ember generate and destroy route-addon', function() {
   setupTestHooks(this);
 
   it('route-addon foo', function() {
-    return generateAndDestroy(['route-addon', 'foo'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'app/routes/foo.js',
-          contains: [
-            "export { default } from 'my-addon/routes/foo';"
-          ]
-        },
-        {
-          file: 'app/templates/foo.js',
-          contains: [
-            "export { default } from 'my-addon/templates/foo';"
-          ]
-        },
-      ]
-    });
-  });
+    var args = ['route-addon', 'foo'];
 
+    return emberNew({ target: 'addon' }).then(() => emberGenerateDestroy(args, _file => {
+      expect(_file('app/routes/foo.js'))
+        .to.contain("export { default } from 'my-addon/routes/foo';");
+
+      expect(_file('app/templates/foo.js'))
+        .to.contain("export { default } from 'my-addon/templates/foo';");
+    }));
+  });
 });

--- a/node-tests/blueprints/service-test.js
+++ b/node-tests/blueprints/service-test.js
@@ -1,247 +1,182 @@
 'use strict';
 
-var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
-var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
-var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+var modifyPackages = blueprintHelpers.modifyPackages;
+var setupPodConfig = blueprintHelpers.setupPodConfig;
+
+var chai = require('ember-cli-blueprint-test-helpers/chai');
+var expect = chai.expect;
 
 describe('Acceptance: ember generate and destroy service', function() {
   setupTestHooks(this);
 
   it('service foo', function() {
-    return generateAndDestroy(['service', 'foo'], {
-      files: [
-        {
-          file: 'app/services/foo.js',
-          contains: [
-            "import Ember from 'ember';",
-            'export default Ember.Service.extend({\n});'
-          ]
-        },
-        {
-          file: 'tests/unit/services/foo-test.js',
-          contains: [
-            "import { moduleFor, test } from 'ember-qunit';",
-            "moduleFor('service:foo'"
-          ]
-        }
-      ]
-    });
+    var args = ['service', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/services/foo.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain('export default Ember.Service.extend({\n});');
+
+        expect(_file('tests/unit/services/foo-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('service:foo'");
+      }));
   });
 
   it('service foo/bar', function() {
-    return generateAndDestroy(['service', 'foo/bar'], {
-      files: [
-        {
-          file: 'app/services/foo/bar.js',
-          contains: [
-            "import Ember from 'ember';",
-            'export default Ember.Service.extend({\n});'
-          ]
-        },
-        {
-          file: 'tests/unit/services/foo/bar-test.js',
-          contains: [
-            "import { moduleFor, test } from 'ember-qunit';",
-            "moduleFor('service:foo/bar'"
-          ]
-        }
-      ]
-    });
+    var args = ['service', 'foo/bar'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/services/foo/bar.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain('export default Ember.Service.extend({\n});');
+
+        expect(_file('tests/unit/services/foo/bar-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('service:foo/bar'");
+      }));
   });
   it('in-addon service foo', function() {
-    return generateAndDestroy(['service', 'foo'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'addon/services/foo.js',
-          contains: [
-            "import Ember from 'ember';",
-            'export default Ember.Service.extend({\n});'
-          ]
-        },
-        {
-          file: 'app/services/foo.js',
-          contains: [
-            "export { default } from 'my-addon/services/foo';"
-          ]
-        },
-        {
-          file: 'tests/unit/services/foo-test.js',
-          contains: [
-            "import { moduleFor, test } from 'ember-qunit';",
-            "moduleFor('service:foo'"
-          ]
-        }
-      ]
-    });
+    var args = ['service', 'foo'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('addon/services/foo.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain('export default Ember.Service.extend({\n});');
+
+        expect(_file('app/services/foo.js'))
+          .to.contain("export { default } from 'my-addon/services/foo';");
+
+        expect(_file('tests/unit/services/foo-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('service:foo'");
+      }));
   });
 
   it('in-addon service foo/bar', function() {
-    return generateAndDestroy(['service', 'foo/bar'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'addon/services/foo/bar.js',
-          contains: [
-            "import Ember from 'ember';",
-            'export default Ember.Service.extend({\n});'
-          ]
-        },
-        {
-          file: 'app/services/foo/bar.js',
-          contains: [
-            "export { default } from 'my-addon/services/foo/bar';"
-          ]
-        },
-        {
-          file: 'tests/unit/services/foo/bar-test.js',
-          contains: [
-            "import { moduleFor, test } from 'ember-qunit';",
-            "moduleFor('service:foo/bar'"
-          ]
-        }
-      ]
-    });
+    var args = ['service', 'foo/bar'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('addon/services/foo/bar.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain('export default Ember.Service.extend({\n});');
+
+        expect(_file('app/services/foo/bar.js'))
+          .to.contain("export { default } from 'my-addon/services/foo/bar';");
+
+        expect(_file('tests/unit/services/foo/bar-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('service:foo/bar'");
+      }));
   });
-/**
-* Pod tests
-*
-*/
 
   it('service foo --pod', function() {
-    return generateAndDestroy(['service', 'foo', '--pod'], {
-      files: [
-        {
-          file: 'app/foo/service.js',
-          contains: [
-            "import Ember from 'ember';",
-            'export default Ember.Service.extend({\n});'
-          ]
-        },
-        {
-          file: 'tests/unit/foo/service-test.js',
-          contains: [
-            "import { moduleFor, test } from 'ember-qunit';",
-            "moduleFor('service:foo'"
-          ]
-        }
-      ]
-    });
+    var args = ['service', 'foo', '--pod'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/foo/service.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain('export default Ember.Service.extend({\n});');
+
+        expect(_file('tests/unit/foo/service-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('service:foo'");
+      }));
   });
 
   it('service foo/bar --pod', function() {
-    return generateAndDestroy(['service', 'foo/bar', '--pod'], {
-      files: [
-        {
-          file: 'app/foo/bar/service.js',
-          contains: [
-            "import Ember from 'ember';",
-            'export default Ember.Service.extend({\n});'
-          ]
-        },
-        {
-          file: 'tests/unit/foo/bar/service-test.js',
-          contains: [
-            "import { moduleFor, test } from 'ember-qunit';",
-            "moduleFor('service:foo/bar'"
-          ]
-        }
-      ]
-    });
+    var args = ['service', 'foo/bar', '--pod'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/foo/bar/service.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain('export default Ember.Service.extend({\n});');
+
+        expect(_file('tests/unit/foo/bar/service-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('service:foo/bar'");
+      }));
   });
 
   it('service foo --pod podModulePrefix', function() {
-    return generateAndDestroy(['service', 'foo', '--pod'], {
-      podModulePrefix: true,
-      files: [
-        {
-          file: 'app/pods/foo/service.js',
-          contains: [
-            "import Ember from 'ember';",
-            'export default Ember.Service.extend({\n});'
-          ]
-        },
-        {
-          file: 'tests/unit/pods/foo/service-test.js',
-          contains: [
-            "import { moduleFor, test } from 'ember-qunit';",
-            "moduleFor('service:foo'"
-          ]
-        }
-      ]
-    });
+    var args = ['service', 'foo', '--pod'];
+
+    return emberNew()
+      .then(() => setupPodConfig({ podModulePrefix: true }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/pods/foo/service.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain('export default Ember.Service.extend({\n});');
+
+        expect(_file('tests/unit/pods/foo/service-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('service:foo'");
+      }));
   });
 
   it('service foo/bar --pod podModulePrefix', function() {
-    return generateAndDestroy(['service', 'foo/bar', '--pod'], {
-      podModulePrefix: true,
-      files: [
-        {
-          file: 'app/pods/foo/bar/service.js',
-          contains: [
-            "import Ember from 'ember';",
-            'export default Ember.Service.extend({\n});'
-          ]
-        },
-        {
-          file: 'tests/unit/pods/foo/bar/service-test.js',
-          contains: [
-            "import { moduleFor, test } from 'ember-qunit';",
-            "moduleFor('service:foo/bar'"
-          ]
-        }
-      ]
-    });
+    var args = ['service', 'foo/bar', '--pod'];
+
+    return emberNew()
+      .then(() => setupPodConfig({ podModulePrefix: true }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/pods/foo/bar/service.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain('export default Ember.Service.extend({\n});');
+
+        expect(_file('tests/unit/pods/foo/bar/service-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('service:foo/bar'");
+      }));
   });
 
   it('service-test foo', function() {
-    return generateAndDestroy(['service-test', 'foo'], {
-      files: [
-        {
-          file: 'tests/unit/services/foo-test.js',
-          contains: [
-            "import { moduleFor, test } from 'ember-qunit';",
-            "moduleFor('service:foo'"
-          ]
-        }
-      ]
-    });
+    var args = ['service-test', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/services/foo-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('service:foo'");
+      }));
   });
 
   it('in-addon service-test foo', function() {
-    return generateAndDestroy(['service-test', 'foo'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'tests/unit/services/foo-test.js',
-          contains: [
-            "import { moduleFor, test } from 'ember-qunit';",
-            "moduleFor('service:foo'"
-          ]
-        },
-        {
-          file: 'app/service-test/foo.js',
-          exists: false
-        }
-      ]
-    });
+    var args = ['service-test', 'foo'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/services/foo-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('service:foo'");
+
+        expect(_file('app/service-test/foo.js'))
+          .to.not.exist;
+      }));
   });
 
   it('service-test foo for mocha', function() {
-    return generateAndDestroy(['service-test', 'foo'], {
-      packages: [
-        { name: 'ember-cli-qunit', delete: true },
-        { name: 'ember-cli-mocha', dev: true }
-      ],
-      files: [
-        {
-          file: 'tests/unit/services/foo-test.js',
-          contains: [
-            "import { describeModule, it } from 'ember-mocha';",
-            "describeModule('service:foo', 'Unit | Service | foo'"
-          ]
-        }
-      ]
-    });
+    var args = ['service-test', 'foo'];
+
+    return emberNew()
+      .then(() => modifyPackages([
+        {name: 'ember-cli-qunit', delete: true},
+        {name: 'ember-cli-mocha', dev: true}
+      ]))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/services/foo-test.js'))
+          .to.contain("import { describeModule, it } from 'ember-mocha';")
+          .to.contain("describeModule('service:foo', 'Unit | Service | foo'");
+      }));
   });
 });

--- a/node-tests/blueprints/template-test.js
+++ b/node-tests/blueprints/template-test.js
@@ -1,118 +1,137 @@
 'use strict';
 
-var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
-var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
-var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+var setupPodConfig = blueprintHelpers.setupPodConfig;
+
+var chai = require('ember-cli-blueprint-test-helpers/chai');
+var expect = chai.expect;
 
 describe('Acceptance: ember generate and destroy template', function() {
   setupTestHooks(this);
 
   it('template foo', function() {
-    return generateAndDestroy(['template', 'foo'], {
-      files: [
-        { file: 'app/templates/foo.hbs', isEmpty: true }
-      ]
-    });
+    var args = ['template', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/templates/foo.hbs')).to.equal('');
+      }));
   });
 
   it('template foo/bar', function() {
-    return generateAndDestroy(['template', 'foo/bar'], {
-      files: [
-        { file: 'app/templates/foo/bar.hbs', isEmpty: true }
-      ]
-    });
+    var args = ['template', 'foo/bar'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/templates/foo/bar.hbs')).to.equal('');
+      }));
   });
 
   it('template foo --pod', function() {
-    return generateAndDestroy(['template', 'foo'], {
-      usePods: true,
-      files: [
-        { file: 'app/foo/template.hbs', isEmpty: true }
-      ]
-    });
+    var args = ['template', 'foo'];
+
+    return emberNew()
+      .then(() => setupPodConfig({
+        usePods: true
+      }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/foo/template.hbs')).to.equal('');
+      }));
   });
 
   it('template foo/bar --pod', function() {
-    return generateAndDestroy(['template', 'foo/bar'], {
-      usePods: true,
-      files: [
-        { file: 'app/foo/bar/template.hbs', isEmpty: true }
-      ]
-    });
+    var args = ['template', 'foo/bar'];
+
+    return emberNew()
+      .then(() => setupPodConfig({
+        usePods: true
+      }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/foo/bar/template.hbs')).to.equal('');
+      }));
   });
 
   it('template foo --pod podModulePrefix', function() {
-    return generateAndDestroy(['template', 'foo'], {
-      usePods: true,
-      podModulePrefix: true,
-      files: [
-        { file: 'app/pods/foo/template.hbs', isEmpty: true }
-      ]
-    });
+    var args = ['template', 'foo'];
+
+    return emberNew()
+      .then(() => setupPodConfig({
+        usePods: true,
+        podModulePrefix: true
+      }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/pods/foo/template.hbs')).to.equal('');
+      }));
   });
 
   it('template foo/bar --pod podModulePrefix', function() {
-    return generateAndDestroy(['template', 'foo/bar'], {
-      usePods: true,
-      podModulePrefix: true,
-      files: [
-        { file: 'app/pods/foo/bar/template.hbs', isEmpty: true }
-      ]
-    });
+    var args = ['template', 'foo/bar'];
+
+    return emberNew()
+      .then(() => setupPodConfig({
+        usePods: true,
+        podModulePrefix: true
+      }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/pods/foo/bar/template.hbs')).to.equal('');
+      }));
   });
 
   it('in-addon template foo', function() {
-    return generateAndDestroy(['template', 'foo'], {
-      target: 'addon',
-      files: [
-        { file: 'addon/templates/foo.hbs', isEmpty: true }
-      ]
-    });
+    var args = ['template', 'foo'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('addon/templates/foo.hbs')).to.equal('');
+      }));
   });
 
   it('in-addon template foo/bar', function() {
-    return generateAndDestroy(['template', 'foo/bar'], {
-      target: 'addon',
-      files: [
-        { file: 'addon/templates/foo/bar.hbs', isEmpty: true }
-      ]
-    });
+    var args = ['template', 'foo/bar'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('addon/templates/foo/bar.hbs')).to.equal('');
+      }));
   });
 
   it('dummy template foo', function() {
-    return generateAndDestroy(['template', 'foo', '--dummy'], {
-      target: 'addon',
-      files: [
-        { file: 'tests/dummy/app/templates/foo.hbs', isEmpty: true }
-      ]
-    });
+    var args = ['template', 'foo', '--dummy'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/dummy/app/templates/foo.hbs')).to.equal('');
+      }));
   });
 
   it('dummy template foo/bar', function() {
-    return generateAndDestroy(['template', 'foo/bar', '--dummy'], {
-      target: 'addon',
-      files: [
-        { file: 'tests/dummy/app/templates/foo/bar.hbs', isEmpty: true }
-      ]
-    });
+    var args = ['template', 'foo/bar', '--dummy'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/dummy/app/templates/foo/bar.hbs')).to.equal('');
+      }));
   });
 
   it('in-repo-addon template foo', function() {
-    return generateAndDestroy(['template', 'foo', '--in-repo-addon=my-addon'], {
-      target: 'inRepoAddon',
-      files: [
-        { file: 'lib/my-addon/addon/templates/foo.hbs', isEmpty: true }
-      ]
-    });
+    var args = ['template', 'foo', '--in-repo-addon=my-addon'];
+
+    return emberNew({ target: 'in-repo-addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('lib/my-addon/addon/templates/foo.hbs')).to.equal('');
+      }));
   });
 
   it('in-repo-addon template foo/bar', function() {
-    return generateAndDestroy(['template', 'foo/bar', '--in-repo-addon=my-addon'], {
-      target: 'inRepoAddon',
-      files: [
-        { file: 'lib/my-addon/addon/templates/foo/bar.hbs', isEmpty: true }
-      ]
-    });
+    var args = ['template', 'foo/bar', '--in-repo-addon=my-addon'];
+
+    return emberNew({ target: 'in-repo-addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('lib/my-addon/addon/templates/foo/bar.hbs')).to.equal('');
+      }));
   });
 
 });

--- a/node-tests/blueprints/test-helper-test.js
+++ b/node-tests/blueprints/test-helper-test.js
@@ -1,23 +1,24 @@
 'use strict';
 
-var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
-var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
-var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+
+var chai = require('ember-cli-blueprint-test-helpers/chai');
+var expect = chai.expect;
 
 describe('Acceptance: ember generate and destroy test-helper', function() {
   setupTestHooks(this);
 
   it('test-helper foo', function() {
-    return generateAndDestroy(['test-helper', 'foo'], {
-      files: [
-        {
-          file: 'tests/helpers/foo.js',
-          contains: [
-            "import Ember from 'ember';",
-            'export default Ember.Test.registerAsyncHelper(\'foo\', function(app) {\n\n}'
-          ]
-        }
-      ]
-    });
+    var args = ['test-helper', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/helpers/foo.js'))
+          .to.contain("import Ember from 'ember';")
+          .to.contain('export default Ember.Test.registerAsyncHelper(\'foo\', function(app) {\n\n}');
+      }));
   });
 });

--- a/node-tests/blueprints/util-test.js
+++ b/node-tests/blueprints/util-test.js
@@ -1,207 +1,163 @@
 'use strict';
 
-var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
-var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
-var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+var modifyPackages = blueprintHelpers.modifyPackages;
+var setupPodConfig = blueprintHelpers.setupPodConfig;
+
+var chai = require('ember-cli-blueprint-test-helpers/chai');
+var expect = chai.expect;
 
 describe('Acceptance: ember generate and destroy util', function() {
   setupTestHooks(this);
 
   it('util foo-bar', function() {
-    return generateAndDestroy(['util', 'foo-bar'], {
-      files: [
-        {
-          file: 'app/utils/foo-bar.js',
-          contains: 'export default function fooBar() {\n' +
-                    '  return true;\n' +
-                    '}'
-        },
-        {
-          file: 'tests/unit/utils/foo-bar-test.js',
-          contains: [
-            "import fooBar from 'my-app/utils/foo-bar';"
-          ]
-        }
-      ]
-    });
+    var args = ['util', 'foo-bar'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/utils/foo-bar.js'))
+          .to.contain('export default function fooBar() {\n' +
+                      '  return true;\n' +
+                      '}');
+
+        expect(_file('tests/unit/utils/foo-bar-test.js'))
+          .to.contain("import fooBar from 'my-app/utils/foo-bar';");
+      }));
   });
 
   it('util foo-bar/baz', function() {
-    return generateAndDestroy(['util', 'foo/bar-baz'], {
-      files: [
-        {
-          file: 'app/utils/foo/bar-baz.js',
-          contains: 'export default function fooBarBaz() {\n' +
-                    '  return true;\n' +
-                    '}'
-        },
-        {
-          file: 'tests/unit/utils/foo/bar-baz-test.js',
-          contains: [
-            "import fooBarBaz from 'my-app/utils/foo/bar-baz';"
-          ]
-        }
-      ]
-    });
+    var args = ['util', 'foo/bar-baz'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/utils/foo/bar-baz.js'))
+          .to.contain('export default function fooBarBaz() {\n' +
+                      '  return true;\n' +
+                      '}');
+
+        expect(_file('tests/unit/utils/foo/bar-baz-test.js'))
+          .to.contain("import fooBarBaz from 'my-app/utils/foo/bar-baz';");
+      }));
   });
 
   it('in-addon util foo-bar', function() {
-    return generateAndDestroy(['util', 'foo-bar'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'addon/utils/foo-bar.js',
-          contains: 'export default function fooBar() {\n' +
-                    '  return true;\n' +
-                    '}'
-        },
-        {
-          file: 'app/utils/foo-bar.js',
-          contains: [
-            "export { default } from 'my-addon/utils/foo-bar';"
-          ]
-        },
-        {
-          file: 'tests/unit/utils/foo-bar-test.js',
-          contains: [
-            "import fooBar from 'dummy/utils/foo-bar';"
-          ]
-        }
-      ]
-    });
+    var args = ['util', 'foo-bar'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('addon/utils/foo-bar.js'))
+          .to.contain('export default function fooBar() {\n' +
+                      '  return true;\n' +
+                      '}');
+
+        expect(_file('app/utils/foo-bar.js'))
+          .to.contain("export { default } from 'my-addon/utils/foo-bar';");
+
+        expect(_file('tests/unit/utils/foo-bar-test.js'))
+          .to.contain("import fooBar from 'dummy/utils/foo-bar';");
+      }));
   });
 
   it('in-addon util foo-bar/baz', function() {
-    return generateAndDestroy(['util', 'foo/bar-baz'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'addon/utils/foo/bar-baz.js',
-          contains: 'export default function fooBarBaz() {\n' +
-                    '  return true;\n' +
-                    '}'
-        },
-        {
-          file: 'app/utils/foo/bar-baz.js',
-          contains: [
-            "export { default } from 'my-addon/utils/foo/bar-baz';"
-          ]
-        },
-        {
-          file: 'tests/unit/utils/foo/bar-baz-test.js',
-          contains: [
-            "import fooBarBaz from 'dummy/utils/foo/bar-baz';"
-          ]
-        }
-      ]
-    });
+    var args = ['util', 'foo/bar-baz'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('addon/utils/foo/bar-baz.js'))
+          .to.contain('export default function fooBarBaz() {\n' +
+                      '  return true;\n' +
+                      '}');
+
+        expect(_file('app/utils/foo/bar-baz.js'))
+          .to.contain("export { default } from 'my-addon/utils/foo/bar-baz';");
+
+        expect(_file('tests/unit/utils/foo/bar-baz-test.js'))
+          .to.contain("import fooBarBaz from 'dummy/utils/foo/bar-baz';");
+      }));
   });
-/**
-* Pod tests
-*
-*/
 
   it('util foo-bar --pod', function() {
-    return generateAndDestroy(['util', 'foo-bar', '--pod'], {
-      files: [
-        {
-          file: 'app/utils/foo-bar.js',
-          contains: 'export default function fooBar() {\n' +
-                    '  return true;\n' +
-                    '}'
-        },
-        {
-          file: 'tests/unit/utils/foo-bar-test.js',
-          contains: [
-            "import fooBar from 'my-app/utils/foo-bar';"
-          ]
-        }
-      ]
-    });
+    var args = ['util', 'foo-bar', '--pod'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/utils/foo-bar.js'))
+          .to.contain('export default function fooBar() {\n' +
+                      '  return true;\n' +
+                      '}');
+
+        expect(_file('tests/unit/utils/foo-bar-test.js'))
+          .to.contain("import fooBar from 'my-app/utils/foo-bar';");
+      }));
   });
 
   it('util foo-bar --pod podModulePrefix', function() {
-    return generateAndDestroy(['util', 'foo-bar', '--pod'], {
-      podModulePrefix: true,
-      files: [
-        {
-          file: 'app/utils/foo-bar.js',
-          contains: 'export default function fooBar() {\n' +
-                    '  return true;\n' +
-                    '}'
-        },
-        {
-          file: 'tests/unit/utils/foo-bar-test.js',
-          contains: [
-            "import fooBar from 'my-app/utils/foo-bar';"
-          ]
-        }
-      ]
-    });
+    var args = ['util', 'foo-bar', '--pod'];
+
+    return emberNew()
+      .then(() => setupPodConfig({ podModulePrefix: true }))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/utils/foo-bar.js'))
+          .to.contain('export default function fooBar() {\n' +
+                      '  return true;\n' +
+                      '}');
+
+        expect(_file('tests/unit/utils/foo-bar-test.js'))
+          .to.contain("import fooBar from 'my-app/utils/foo-bar';");
+      }));
   });
 
   it('util foo-bar/baz --pod', function() {
-    return generateAndDestroy(['util', 'foo/bar-baz', '--pod'], {
-      files: [
-        {
-          file: 'app/utils/foo/bar-baz.js',
-          contains: 'export default function fooBarBaz() {\n' +
-                    '  return true;\n' +
-                    '}'
-        },
-        {
-          file: 'tests/unit/utils/foo/bar-baz-test.js',
-          contains: [
-            "import fooBarBaz from 'my-app/utils/foo/bar-baz';"
-          ]
-        }
-      ]
-    });
+    var args = ['util', 'foo/bar-baz', '--pod'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/utils/foo/bar-baz.js'))
+          .to.contain('export default function fooBarBaz() {\n' +
+                      '  return true;\n' +
+                      '}');
+
+        expect(_file('tests/unit/utils/foo/bar-baz-test.js'))
+          .to.contain("import fooBarBaz from 'my-app/utils/foo/bar-baz';");
+      }));
   });
 
   it('util-test foo-bar', function() {
-    return generateAndDestroy(['util-test', 'foo-bar'], {
-      files: [
-        {
-          file: 'tests/unit/utils/foo-bar-test.js',
-          contains: [
-            "import fooBar from 'my-app/utils/foo-bar';"
-          ]
-        }
-      ]
-    });
+    var args = ['util-test', 'foo-bar'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/utils/foo-bar-test.js'))
+          .to.contain("import fooBar from 'my-app/utils/foo-bar';");
+      }));
   });
 
   it('in-addon util-test foo-bar', function() {
-    return generateAndDestroy(['util-test', 'foo-bar'], {
-      target: 'addon',
-      files: [
-        {
-          file: 'tests/unit/utils/foo-bar-test.js',
-          contains: [
-            "import fooBar from 'dummy/utils/foo-bar';"
-          ]
-        }
-      ]
-    });
+    var args = ['util-test', 'foo-bar'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/utils/foo-bar-test.js'))
+          .to.contain("import fooBar from 'dummy/utils/foo-bar';");
+      }));
   });
 
   it('util-test foo-bar for mocha', function() {
-    return generateAndDestroy(['util-test', 'foo-bar'], {
-      packages: [
-        { name: 'ember-cli-qunit', delete: true },
-        { name: 'ember-cli-mocha', dev: true }
-      ],
-      files: [
-        {
-          file: 'tests/unit/utils/foo-bar-test.js',
-          contains: [
-            "import { describe, it } from 'mocha';",
-            "import fooBar from 'my-app/utils/foo-bar';",
-            "describe('Unit | Utility | foo bar', function() {"
-          ]
-        }
-      ]
-    });
+    var args = ['util-test', 'foo-bar'];
+
+    return emberNew()
+      .then(() => modifyPackages([
+        {name: 'ember-cli-qunit', delete: true},
+        {name: 'ember-cli-mocha', dev: true}
+      ]))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/utils/foo-bar-test.js'))
+          .to.contain("import { describe, it } from 'mocha';")
+          .to.contain("import fooBar from 'my-app/utils/foo-bar';")
+          .to.contain("describe('Unit | Utility | foo bar', function() {");
+      }));
   });
 });

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "broccoli-stew": "^1.2.0",
     "chalk": "^1.1.1",
     "ember-cli": "^2.4.2",
-    "ember-cli-blueprint-test-helpers": "^0.9.0",
+    "ember-cli-blueprint-test-helpers": "^0.11.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-internal-test-helpers": "^0.7.0",
     "ember-cli-sauce": "^1.4.2",


### PR DESCRIPTION
This PR modifies the blueprint tests to use the new blueprint testing API introduced in https://github.com/ember-cli/ember-cli-blueprint-test-helpers/pull/45.

/cc @trabus @rwjblue @stefanpenner 
