### PR TITLE
Add action and dom event instrumentation

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -45,3 +45,10 @@ for a detailed explanation.
    ],
    dedupedComments: Ember.computed.uniqBy('comments', 'id')
    ```
+
+* `ember-improved-instrumentation`
+
+  Adds additional instrumentation to Ember:
+
+  - `interaction.<event-name>` for events handled by a component.
+  - `interaction.ember-action` for closure actions.

--- a/features.json
+++ b/features.json
@@ -9,6 +9,7 @@
     "ember-htmlbars-local-lookup": true,
     "ember-application-engines": null,
     "ember-glimmer": null,
-    "ember-runtime-computed-uniq-by": null
+    "ember-runtime-computed-uniq-by": null,
+    "ember-improved-instrumentation": null
   }
 }

--- a/packages/ember-views/lib/views/states/has_element.js
+++ b/packages/ember-views/lib/views/states/has_element.js
@@ -2,6 +2,7 @@ import _default from 'ember-views/views/states/default';
 import assign from 'ember-metal/assign';
 import jQuery from 'ember-views/system/jquery';
 import run from 'ember-metal/run_loop';
+import { flaggedInstrument } from 'ember-metal/instrumentation';
 
 /**
 @module ember
@@ -46,11 +47,13 @@ assign(hasElement, {
   },
 
   // Handle events from `Ember.EventDispatcher`
-  handleEvent(view, eventName, evt) {
+  handleEvent(view, eventName, event) {
     if (view.has(eventName)) {
       // Handler should be able to re-dispatch events, so we don't
       // preventDefault or stopPropagation.
-      return run.join(view, view.trigger, eventName, evt);
+      return flaggedInstrument(`interaction.${eventName}`, { event, view }, () => {
+        return run.join(view, view.trigger, eventName, event);
+      });
     } else {
       return true; // continue event propagation
     }

--- a/packages/ember/tests/view_instrumentation_test.js
+++ b/packages/ember/tests/view_instrumentation_test.js
@@ -27,6 +27,7 @@ import isEnabled from 'ember-metal/features';
 if (!isEnabled('ember-glimmer')) {
   // jscs:disable
 
+let subscriber;
 QUnit.module('View Instrumentation', {
   setup() {
     run(function() {
@@ -45,6 +46,9 @@ QUnit.module('View Instrumentation', {
   },
 
   teardown() {
+    if (subscriber) {
+      unsubscribe(subscriber);
+    }
     run(App, 'destroy');
     App = null;
     Ember.TEMPLATES = {};
@@ -53,7 +57,7 @@ QUnit.module('View Instrumentation', {
 
 QUnit.test('Nodes without view instances are instrumented', function(assert) {
   var called = false;
-  var subscriber = subscribe('render', {
+  subscriber = subscribe('render', {
     before() {
       called = true;
     },
@@ -64,7 +68,6 @@ QUnit.test('Nodes without view instances are instrumented', function(assert) {
   called = false;
   handleURL('/posts');
   assert.ok(called, 'instrumentation called on transition to non-view backed route');
-  unsubscribe(subscriber);
 });
 
 }


### PR DESCRIPTION
This is just the action and dom instrumentation part copied and merged over from @chadhietala's PR here: https://github.com/emberjs/ember.js/pull/13017

This is the highest priority part for getting us off of private APIs for tracking.

I noticed that some of the tests seem to be disabled for glimmer2, so I'm wondering what I need to do to get this working and tested with glimmer2.

cc @krisselden 
