### PR TITLE
[Glimmer 2] Fix undefined path lookups

### DIFF
--- a/packages/ember-glimmer/lib/utils/references.js
+++ b/packages/ember-glimmer/lib/utils/references.js
@@ -75,9 +75,12 @@ class PropertyReference extends CachedReference { // jshint ignore:line
     let { _parentReference, _parentObjectTag, _propertyKey } = this;
 
     let parent = _parentReference.value();
-    _parentObjectTag.update(tagFor(parent));
 
-    return get(parent, _propertyKey);
+    if (parent) {
+      _parentObjectTag.update(tagFor(parent));
+
+      return get(parent, _propertyKey);
+    }
   }
 
   get(propertyKey) {

--- a/packages/ember-glimmer/lib/utils/references.js
+++ b/packages/ember-glimmer/lib/utils/references.js
@@ -74,12 +74,14 @@ class PropertyReference extends CachedReference { // jshint ignore:line
   compute() {
     let { _parentReference, _parentObjectTag, _propertyKey } = this;
 
-    let parent = _parentReference.value();
+    let parentValue = _parentReference.value();
 
-    if (parent) {
-      _parentObjectTag.update(tagFor(parent));
+    _parentObjectTag.update(tagFor(parentValue));
 
-      return get(parent, _propertyKey);
+    if (parentValue && typeof parentValue === 'object') {
+      return get(parentValue, _propertyKey);
+    } else {
+      return null;
     }
   }
 

--- a/packages/ember-glimmer/tests/integration/content-test.js
+++ b/packages/ember-glimmer/tests/integration/content-test.js
@@ -483,4 +483,89 @@ moduleFor('Dynamic content tests (integration)', class extends RenderingTest {
     this.assertHTML(ember);
   }
 
+  ['@test it should evaluate to nothing if part of the path is `undefined`']() {
+    this.render('{{foo.bar.baz.bizz}}', {
+      foo: {}
+    });
+
+    this.assertText('');
+
+    this.runTask(() => this.rerender());
+
+    this.assertText('');
+
+    this.runTask(() => set(this.context, 'foo', {
+      bar: { baz: { bizz: 'Hey!' } }
+    }));
+
+    this.assertText('Hey!');
+
+    this.runTask(() => set(this.context, 'foo', {}));
+
+    this.assertText('');
+
+    this.runTask(() => set(this.context, 'foo', {
+      bar: { baz: { bizz: 'Hello!' } }
+    }));
+
+    this.assertText('Hello!');
+
+    this.runTask(() => set(this.context, 'foo', {}));
+
+    this.assertText('');
+  }
+
+  ['@test it should evaluate to nothing if part of the path is a primative']() {
+    this.render('{{foo.bar.baz.bizz}}', {
+      foo: { bar: true }
+    });
+
+    this.assertText('');
+
+    this.runTask(() => this.rerender());
+
+    this.assertText('');
+
+    this.runTask(() => set(this.context, 'foo', {
+      bar: false
+    }));
+
+    this.assertText('');
+
+    this.runTask(() => set(this.context, 'foo', {
+      bar: 'Haha'
+    }));
+
+    this.assertText('');
+
+    this.runTask(() => set(this.context, 'foo', {
+      bar: null
+    }));
+
+    this.assertText('');
+
+    this.runTask(() => set(this.context, 'foo', {
+      bar: undefined
+    }));
+
+    this.assertText('');
+
+    this.runTask(() => set(this.context, 'foo', {
+      bar: 1
+    }));
+
+    this.assertText('');
+
+    this.runTask(() => set(this.context, 'foo', {
+      bar: { baz: { bizz: 'Hello!' } }
+    }));
+
+    this.assertText('Hello!');
+
+    this.runTask(() => set(this.context, 'foo', {
+      bar: true
+    }));
+
+    this.assertText('');
+  }
 });

--- a/packages/ember-glimmer/tests/integration/syntax/each-in-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/each-in-test.js
@@ -1,7 +1,7 @@
 import { set } from 'ember-metal/property_set';
 import { strip } from '../../utils/abstract-test-case';
 import { applyMixins } from '../../utils/abstract-test-case';
-import { moduleFor } from '../../utils/test-case';
+import { moduleFor, RenderingTest } from '../../utils/test-case';
 import {
   BasicConditionalsTest,
   SyntaxCondtionalTestHelpers,
@@ -155,4 +155,27 @@ moduleFor('@htmlbars Syntax test: {{#each-in}}', class extends EachInTest {
     `);
   }
 
+});
+
+moduleFor('@htmlbars Syntax test: {{#each-in}} undefined path', class extends RenderingTest {
+  ['@test keying off of `undefined` does not render'](assert) {
+    this.render(strip`
+      {{#each-in foo.bar.baz as |thing|}}
+        {{thing}}
+      {{/each-in}}`, { foo: {} });
+
+    this.assertText('');
+
+    this.runTask(() => this.rerender());
+
+    this.assertText('');
+
+    this.runTask(() => set(this.context, 'foo', { bar: { baz: { 'Here!': 1 } } }));
+
+    this.assertText('Here!');
+
+    this.runTask(() => set(this.context, 'foo', {}));
+
+    this.assertText('');
+  }
 });

--- a/packages/ember-glimmer/tests/integration/syntax/each-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/each-test.js
@@ -3,6 +3,7 @@ import { set } from 'ember-metal/property_set';
 import { applyMixins } from '../../utils/abstract-test-case';
 import { moduleFor, RenderingTest } from '../../utils/test-case';
 import { A as emberA } from 'ember-runtime/system/native_array';
+import { strip } from '../../utils/abstract-test-case';
 import {
   BasicConditionalsTest,
   SyntaxCondtionalTestHelpers,
@@ -295,4 +296,27 @@ moduleFor('Syntax test: Multiple {{#each as}} helpers', class extends RenderingT
     this.assertText('caterpillar');
   }
 
+});
+
+moduleFor('Syntax test: {{#each as}} undefined path', class extends RenderingTest {
+  ['@test keying off of `undefined` does not render'](assert) {
+    this.render(strip`
+      {{#each foo.bar.baz as |thing|}}
+        {{thing}}
+      {{/each}}`, { foo: {} });
+
+    this.assertText('');
+
+    this.runTask(() => this.rerender());
+
+    this.assertText('');
+
+    this.runTask(() => set(this.context, 'foo', { bar: { baz: ['Here!'] } }));
+
+    this.assertText('Here!');
+
+    this.runTask(() => set(this.context, 'foo', {}));
+
+    this.assertText('');
+  }
 });

--- a/packages/ember-glimmer/tests/integration/syntax/if-unless-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/if-unless-test.js
@@ -70,4 +70,27 @@ moduleFor('Syntax test: {{#if}}', class extends RenderingTest {
     this.assertText('123');
   }
 
+  ['@test looking up `undefined` property defaults to false'](assert) {
+    this.render(strip`
+      {{#if foo.bar.baz}}
+        Here!
+      {{else}}
+        Nothing Here!
+      {{/if}}`, { foo: {} });
+
+    this.assertText('Nothing Here!');
+
+    this.runTask(() => this.rerender());
+
+    this.assertText('Nothing Here!');
+
+    this.runTask(() => set(this.context, 'foo', { bar: { baz: true } }));
+
+    this.assertText('Here!');
+
+    this.runTask(() => set(this.context, 'foo', {}));
+
+    this.assertText('Nothing Here!');
+  }
+
 });

--- a/packages/ember-glimmer/tests/integration/syntax/with-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/with-test.js
@@ -19,6 +19,27 @@ moduleFor('Syntax test: {{#with as}}', class extends TogglingSyntaxConditionalsT
     return `{{#with ${cond} as |test|}}${truthy}{{else}}${falsy}{{/with}}`;
   }
 
+  ['@test keying off of `undefined` does not render'](assert) {
+    this.render(strip`
+      {{#with foo.bar.baz as |thing|}}
+        {{thing}}
+      {{/with}}`, { foo: {} });
+
+    this.assertText('');
+
+    this.runTask(() => this.rerender());
+
+    this.assertText('');
+
+    this.runTask(() => set(this.context, 'foo', { bar: { baz: 'Here!' } }));
+
+    this.assertText('Here!');
+
+    this.runTask(() => set(this.context, 'foo', {}));
+
+    this.assertText('');
+  }
+
   ['@test it renders and hides the given block based on the conditional']() {
     this.render(`{{#with cond1 as |cond|}}{{cond.greeting}}{{else}}False{{/with}}`, {
       cond1: { greeting: 'Hello' }


### PR DESCRIPTION
This fixes issues where `get` would error if the context side was
undefined.
