### PR TITLE
Downgrade route-recognizer to 0.1.5.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "qunit-extras": "^1.5.0",
     "qunitjs": "^1.22.0",
     "rimraf": "^2.5.2",
-    "route-recognizer": "0.1.9",
+    "route-recognizer": "0.1.5",
     "rsvp": "~3.2.1",
     "serve-static": "^1.10.0",
     "simple-dom": "^0.3.0",


### PR DESCRIPTION
Due to https://github.com/emberjs/ember.js/issues/13211 and https://github.com/tildeio/route-recognizer/issues/82.
