### PR TITLE
[BUGFIX beta] Fix a recent regression with `Ember.A`

### DIFF
--- a/packages/ember-runtime/lib/system/native_array.js
+++ b/packages/ember-runtime/lib/system/native_array.js
@@ -138,9 +138,10 @@ var A;
 
 if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Array) {
   NativeArray.apply(Array.prototype);
-  A = function (arr = []) { return arr; };
+  A = function (arr) { return arr || []; };
 } else {
-  A = function (arr = []) {
+  A = function (arr) {
+    if (!arr) { arr = []; }
     return EmberArray.detect(arr) ? arr : NativeArray.apply(arr);
   };
 }

--- a/packages/ember-runtime/tests/system/native_array/a_test.js
+++ b/packages/ember-runtime/tests/system/native_array/a_test.js
@@ -1,0 +1,12 @@
+import EmberArray from 'ember-runtime/mixins/array';
+import { A } from 'ember-runtime/system/native_array';
+
+QUnit.module('Ember.A');
+
+QUnit.test('Ember.A', function() {
+  deepEqual(A([1, 2]), [1, 2], 'array values were not be modified');
+  deepEqual(A(), [], 'returned an array with no arguments');
+  deepEqual(A(null), [], 'returned an array with a null argument');
+  ok(EmberArray.detect(A()), 'returned an ember array');
+  ok(EmberArray.detect(A([1, 2])), 'returned an ember array');
+});


### PR DESCRIPTION
Due to a recent regression, `Ember.A(null)` would return `null` instead of `[]`. See issue #13284.
