### PR TITLE
[DEPRECATE release] Deprecate usage of `{{render}}` with a block.

### DIFF
--- a/packages/ember-routing-htmlbars/tests/helpers/render_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/render_test.js
@@ -91,22 +91,6 @@ QUnit.test('{{render}} helper should have assertion if neither template nor view
   }, 'You used `{{render \'oops\'}}`, but \'oops\' can not be found as either a template or a view.');
 });
 
-QUnit.test('{{render}} helper should not have assertion if template is supplied in block-form', function() {
-  var template = '<h1>HI</h1>{{#render \'good\'}} {{name}}{{/render}}';
-  var controller = EmberController.extend();
-  appInstance.register('controller:good', EmberController.extend({ name: 'Rob' }));
-
-  view = EmberView.create({
-    [OWNER]: appInstance,
-    controller: controller.create(),
-    template: compile(template)
-  });
-
-  runAppend(view);
-
-  equal(view.$().text(), 'HI Rob');
-});
-
 QUnit.test('{{render}} helper should not have assertion if view exists without a template', function() {
   var template = '<h1>HI</h1>{{render \'oops\'}}';
   var controller = EmberController.extend();

--- a/packages/ember-template-compiler/lib/index.js
+++ b/packages/ember-template-compiler/lib/index.js
@@ -14,6 +14,7 @@ import TransformAngleBracketComponents from 'ember-template-compiler/plugins/tra
 import TransformInputOnToOnEvent from 'ember-template-compiler/plugins/transform-input-on-to-onEvent';
 import TransformTopLevelComponents from 'ember-template-compiler/plugins/transform-top-level-components';
 import DeprecateRenderModel from 'ember-template-compiler/plugins/deprecate-render-model';
+import DeprecateRenderBlock from 'ember-template-compiler/plugins/deprecate-render-block';
 import TransformInlineLinkTo from 'ember-template-compiler/plugins/transform-inline-link-to';
 import AssertNoViewAndControllerPaths from 'ember-template-compiler/plugins/assert-no-view-and-controller-paths';
 import AssertNoViewHelper from 'ember-template-compiler/plugins/assert-no-view-helper';
@@ -32,6 +33,7 @@ registerPlugin('ast', TransformAngleBracketComponents);
 registerPlugin('ast', TransformInputOnToOnEvent);
 registerPlugin('ast', TransformTopLevelComponents);
 registerPlugin('ast', DeprecateRenderModel);
+registerPlugin('ast', DeprecateRenderBlock);
 registerPlugin('ast', AssertNoEachIn);
 registerPlugin('ast', TransformInlineLinkTo);
 

--- a/packages/ember-template-compiler/lib/plugins/deprecate-render-block.js
+++ b/packages/ember-template-compiler/lib/plugins/deprecate-render-block.js
@@ -1,0 +1,41 @@
+import { deprecate } from 'ember-metal/debug';
+import calculateLocationDisplay from
+  'ember-template-compiler/system/calculate-location-display';
+
+export default function DeprecateRenderBlock(options) {
+  this.syntax = null;
+  this.options = options;
+}
+
+DeprecateRenderBlock.prototype.transform =
+  function DeprecateRenderBlock_transform(ast) {
+  let moduleName = this.options.moduleName;
+  let walker = new this.syntax.Walker();
+
+  walker.visit(ast, function(node) {
+    if (!validate(node)) { return; }
+
+    deprecate(
+      deprecationMessage(moduleName, node),
+      false,
+      {
+        id: 'ember-template-compiler.deprecate-render-block',
+        until: '2.4.0',
+        url: 'http://emberjs.com/deprecations/v2.x#toc_render-helper-with-block'
+      }
+    );
+  });
+
+  return ast;
+};
+
+function validate(node) {
+  return (node.type === 'BlockStatement') &&
+    (node.path.original === 'render');
+}
+
+function deprecationMessage(moduleName, node) {
+  let sourceInformation = calculateLocationDisplay(moduleName, node.loc);
+
+  return `Usage of \`render\` in block form is deprecated ${sourceInformation}.`;
+}

--- a/packages/ember-template-compiler/tests/plugins/deprecate-render-block-test.js
+++ b/packages/ember-template-compiler/tests/plugins/deprecate-render-block-test.js
@@ -1,0 +1,20 @@
+import { compile } from 'ember-template-compiler';
+import isEnabled from 'ember-metal/features';
+
+if (!isEnabled('ember-glimmer')) {
+  // jscs:disable
+
+  QUnit.module('ember-template-compiler: deprecate-render-block');
+
+  QUnit.test('Using `render` with a block issues a deprecation', function() {
+    expect(1);
+
+    let expectedMessage = `Usage of \`render\` in block form is deprecated ('baz/foo-bar' @ L1:C0) .`;
+
+    expectDeprecation(function() {
+      compile('{{#render "foo-bar"}}{{/render}}', {
+        moduleName: 'baz/foo-bar'
+      });
+    }, expectedMessage);
+  });
+}


### PR DESCRIPTION
This was not intended to be supported and is rarely used. Adding support for this in tildeio/glimmer will be pretty hard (due to very bizarre `controller` and target values for the block).

This deprecation is intended to help guide anyone actually using this functionality before upgrading to 2.5.0 or later.
