### PR TITLE
[BUGFIX release] Do not error when EmberENV.FEATURES is not defined.

### DIFF
--- a/packages/ember-debug/lib/index.js
+++ b/packages/ember-debug/lib/index.js
@@ -184,7 +184,7 @@ export function _warnIfUsingStrippedFeatureFlags(FEATURES, knownFeatures, featur
   if (featuresWereStripped) {
     warn('Ember.ENV.ENABLE_OPTIONAL_FEATURES is only available in canary builds.', !Ember.ENV.ENABLE_OPTIONAL_FEATURES, { id: 'ember-debug.feature-flag-with-features-stripped' });
 
-    let keys = Object.keys(FEATURES);
+    let keys = Object.keys(FEATURES || {});
     for (let i = 0; i < keys.length; i++) {
       let key = keys[i];
       if (key === 'isEnabled' || !(key in knownFeatures)) {

--- a/packages/ember-debug/tests/warn_if_using_stripped_feature_flags_test.js
+++ b/packages/ember-debug/tests/warn_if_using_stripped_feature_flags_test.js
@@ -79,3 +79,12 @@ QUnit.test('Enabling an unknown FEATURE flag in non-canary debug build does not 
 
   confirmWarns('FEATURE["fred"] is set as enabled, but FEATURE flags are only available in canary builds.');
 });
+
+QUnit.test('`ENV.FEATURES` being undefined does not cause an error', function() {
+  expect(0);
+
+  Ember.ENV.ENABLE_OPTIONAL_FEATURES = false;
+  features = undefined;
+
+  confirmWarns();
+});


### PR DESCRIPTION
Fixes #13297.
