### PR TITLE
Update documentation to indicate that Ember.computed.and does not per…

### DIFF
--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -439,6 +439,9 @@ export function lte(dependentKey, value) {
   tomster.get('readyForHike'); // null
   ```
 
+  Note that it does not perform short-circuit evaluation, i.e. if a first property is `false`,
+  it will still compute the following properties.
+
   @method and
   @for Ember.computed
   @param {String} dependentKey*

--- a/packages/ember-runtime/tests/computed/computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/computed_macros_test.js
@@ -29,7 +29,7 @@ import { A as emberA } from 'ember-runtime/system/native_array';
 
 QUnit.module('CP macros');
 
-testBoth('Ember.computed.empty', function (get, set) {
+testBoth('computed.empty', function (get, set) {
   var obj = EmberObject.extend({
     bestLannister: null,
     lannisters: null,
@@ -50,7 +50,7 @@ testBoth('Ember.computed.empty', function (get, set) {
   equal(get(obj, 'noLannistersKnown'), false, 'empty respects array mutations');
 });
 
-testBoth('Ember.computed.notEmpty', function(get, set) {
+testBoth('computed.notEmpty', function(get, set) {
   var obj = EmberObject.extend({
     bestLannister: null,
     lannisters: null,
@@ -278,11 +278,11 @@ testBoth('computed.and does not perform short-circuit evaluation', function(get,
     let numberCallsToOne = 0;
     let numberCallsToTwo = 0;
     const obj = {};
-    defineProperty(obj, 'one', Ember.computed(function() {
+    defineProperty(obj, 'one', computed(function() {
       numberCallsToOne++;
       return false;
     }));
-    defineProperty(obj, 'two', Ember.computed(function() {
+    defineProperty(obj, 'two', computed(function() {
       numberCallsToTwo++;
       return true;
     }));
@@ -298,15 +298,15 @@ testBoth('computed.and does not perform short-circuit evaluation', function(get,
     let numberCallsToOne = 0;
     let numberCallsToTwo = 0;
     const obj = {};
-    defineProperty(obj, 'one', Ember.computed(function() {
+    defineProperty(obj, 'one', computed(function() {
       numberCallsToOne++;
       return false;
     }));
-    defineProperty(obj, 'two', Ember.computed(function() {
+    defineProperty(obj, 'two', computed(function() {
       numberCallsToTwo++;
       return true;
     }));
-    defineProperty(obj, 'manualOneAndTwo', Ember.computed('one', 'two', function() {
+    defineProperty(obj, 'manualOneAndTwo', computed('one', 'two', function() {
       return get(this, 'one') && get(this, 'two');
     }));
     equal(get(obj, 'manualOneAndTwo'), false, 'manual one and two');

--- a/packages/ember-runtime/tests/computed/computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/computed_macros_test.js
@@ -277,7 +277,7 @@ testBoth('computed.and does not perform short-circuit evaluation', function(get,
   {
     let numberCallsToOne = 0;
     let numberCallsToTwo = 0;
-    const obj = {};
+    let obj = {};
     defineProperty(obj, 'one', computed(function() {
       numberCallsToOne++;
       return false;
@@ -297,7 +297,7 @@ testBoth('computed.and does not perform short-circuit evaluation', function(get,
   {
     let numberCallsToOne = 0;
     let numberCallsToTwo = 0;
-    const obj = {};
+    let obj = {};
     defineProperty(obj, 'one', computed(function() {
       numberCallsToOne++;
       return false;

--- a/packages/ember-runtime/tests/computed/computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/computed_macros_test.js
@@ -272,6 +272,49 @@ testBoth('computed.and two properties', function(get, set) {
   equal(get(obj, 'oneAndTwo'), 2, 'returns truthy value as in &&');
 });
 
+testBoth('computed.and does not perform short-circuit evaluation', function(get, set) {
+  // Ember.computed.and
+  {
+    let numberCallsToOne = 0;
+    let numberCallsToTwo = 0;
+    const obj = {};
+    defineProperty(obj, 'one', Ember.computed(function() {
+      numberCallsToOne++;
+      return false;
+    }));
+    defineProperty(obj, 'two', Ember.computed(function() {
+      numberCallsToTwo++;
+      return true;
+    }));
+    defineProperty(obj, 'oneAndTwo', and('one', 'two'));
+
+    equal(get(obj, 'oneAndTwo'), false, 'one and two');
+    equal(numberCallsToOne, 1, 'computes one');
+    equal(numberCallsToTwo, 1, 'computes two');
+  }
+
+  // a && b
+  {
+    let numberCallsToOne = 0;
+    let numberCallsToTwo = 0;
+    const obj = {};
+    defineProperty(obj, 'one', Ember.computed(function() {
+      numberCallsToOne++;
+      return false;
+    }));
+    defineProperty(obj, 'two', Ember.computed(function() {
+      numberCallsToTwo++;
+      return true;
+    }));
+    defineProperty(obj, 'manualOneAndTwo', Ember.computed('one', 'two', function() {
+      return get(this, 'one') && get(this, 'two');
+    }));
+    equal(get(obj, 'manualOneAndTwo'), false, 'manual one and two');
+    equal(numberCallsToOne, 1, 'computes one');
+    equal(numberCallsToTwo, 0, 'does not compute two');
+  }
+});
+
 testBoth('computed.and three properties', function(get, set) {
   var obj = { one: true, two: true, three: true };
   defineProperty(obj, 'oneTwoThree', and('one', 'two', 'three'));


### PR DESCRIPTION
…form short-circuit evaluation

Also added a test case that demonstrates this behavior, i.e. the behavior of `Ember.computed.and('a', 'b')` vs `a && b`.
