### PR TITLE
[BUGFIX canary] Remove Glimmer dependency in `ember-htmlbars`

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/concat.js
+++ b/packages/ember-htmlbars/lib/helpers/concat.js
@@ -1,1 +1,20 @@
-../../../ember-glimmer/lib/helpers/concat.js
+/**
+@module ember
+@submodule ember-templates
+*/
+
+/**
+  Concatenates input params together.
+  Example:
+  ```handlebars
+  {{some-component name=(concat firstName " " lastName)}}
+  {{! would pass name="<first name value> <last name value>" to the component}}
+  ```
+  @public
+  @method concat
+  @for Ember.Templates.helpers
+  @since 1.13.0
+*/
+export default function concat(params) {
+  return params.join('');
+}


### PR DESCRIPTION
Since 5efb731, we have removed the `{{concat}}` implementation in `ember-htmlbars` and moved it into `ember-glimmer` with a symlink.

In c655638, we introduced a dependency on Glimmer (`normalizeTextValue`) in the new implementation, preventing the helper from working when the feature flag is off.

This essentially reverts both of those changes and brings back the old implementation for `ember-htmlbars`.
