### PR TITLE
[BUGFIX release] Fix mouseenter typo in ember-testing helpers

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -19,7 +19,7 @@ var keyboardEventTypes, mouseEventTypes, buildKeyboardEvent, buildMouseEvent, bu
 if (isEnabled('ember-test-helpers-fire-native-events')) {
   let defaultEventOptions = { canBubble: true, cancelable: true };
   keyboardEventTypes = ['keydown', 'keypress', 'keyup'];
-  mouseEventTypes = ['click', 'mousedown', 'mouseup', 'dblclick', 'mousenter', 'mouseleave', 'mousemove', 'mouseout', 'mouseover'];
+  mouseEventTypes = ['click', 'mousedown', 'mouseup', 'dblclick', 'mouseenter', 'mouseleave', 'mousemove', 'mouseout', 'mouseover'];
 
 
   buildKeyboardEvent = function buildKeyboardEvent(type, options = {}) {

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -447,6 +447,38 @@ QUnit.test('`click` triggers native events with simulated X/Y coordinates', func
   });
 });
 
+QUnit.test('`triggerEvent` with mouseenter triggers native events with simulated X/Y coordinates', function() {
+  expect(5);
+
+  var triggerEvent, wait, evt;
+
+  App.IndexView = EmberView.extend({
+    classNames: 'index-view',
+
+    didInsertElement() {
+      this.element.addEventListener('mouseenter', e => evt = e);
+    }
+  });
+
+
+  Ember.TEMPLATES.index = compile('some text');
+
+  run(App, App.advanceReadiness);
+
+  triggerEvent = App.testHelpers.triggerEvent;
+  wait  = App.testHelpers.wait;
+
+  return wait().then(function() {
+    return triggerEvent('.index-view', 'mouseenter');
+  }).then(function() {
+    ok(evt instanceof window.Event, 'The event is an instance of MouseEvent');
+    ok(typeof evt.screenX === 'number' && evt.screenX > 0, 'screenX is correct');
+    ok(typeof evt.screenY === 'number' && evt.screenY > 0, 'screenY is correct');
+    ok(typeof evt.clientX === 'number' && evt.clientX > 0, 'clientX is correct');
+    ok(typeof evt.clientY === 'number' && evt.clientY > 0, 'clientY is correct');
+  });
+});
+
 }
 
 QUnit.test('`wait` waits for outstanding timers', function() {


### PR DESCRIPTION
It looks like there was a typo in https://github.com/emberjs/ember.js/pull/12575 `mousenter` should be `mouseenter`
