### PR TITLE
[BUGFIX canary] Fix default args for calculateLocationDisplay.

### DIFF
--- a/packages/ember-template-compiler/lib/system/calculate-location-display.js
+++ b/packages/ember-template-compiler/lib/system/calculate-location-display.js
@@ -1,4 +1,5 @@
-export default function calculateLocationDisplay(moduleName, loc = {}) {
+export default function calculateLocationDisplay(moduleName, _loc) {
+  let loc = _loc || {};
   let { column, line } = loc.start || {};
   let moduleInfo = '';
   if (moduleName) {

--- a/packages/ember-template-compiler/tests/plugins/transform-inline-link-to-test.js
+++ b/packages/ember-template-compiler/tests/plugins/transform-inline-link-to-test.js
@@ -1,0 +1,42 @@
+import Ember from 'ember-metal/core';
+import { compile } from 'ember-template-compiler';
+import AssertNoViewAndControllerPaths from 'ember-template-compiler/plugins/assert-no-view-and-controller-paths';
+import plugins, { registerPlugin } from 'ember-template-compiler/plugins';
+
+function registerAstPlugin(plugin) {
+  registerPlugin('ast', plugin);
+}
+
+function removeAstPlugin(plugin) {
+  let index = plugins['ast'].indexOf(plugin);
+  plugins['ast'].splice(index, 1);
+}
+
+let legacyViewSupportOriginalValue;
+
+import isEnabled from 'ember-metal/features';
+if (!isEnabled('ember-glimmer')) {
+  // jscs:disable
+
+QUnit.module('ember-template-compiler: assert-no-view-and-controller-paths without legacy view support', {
+  setup() {
+    legacyViewSupportOriginalValue = Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT;
+    Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT = false;
+    registerAstPlugin(AssertNoViewAndControllerPaths);
+  },
+
+  teardown() {
+    Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT = legacyViewSupportOriginalValue;
+    removeAstPlugin(AssertNoViewAndControllerPaths);
+  }
+});
+
+QUnit.test('Can transform an inline {{link-to}} without error', function() {
+  expect(0);
+
+  compile(`{{link-to 'foo' 'index'}}`, {
+    moduleName: 'foo/bar/baz'
+  });
+});
+
+}


### PR DESCRIPTION
Ensure that undefined or null args are allowed for 
`calculateLocationDisplay`.

Fixes an error transforming an inline `{{link-to}}` without legacy
view support.
