### PR TITLE
[Glimmer 2] Allow for null lookups on `get` to fail gracefully

### DIFF
--- a/packages/ember-glimmer/lib/utils/references.js
+++ b/packages/ember-glimmer/lib/utils/references.js
@@ -119,7 +119,7 @@ export class GetHelperReference extends CachedReference {
 
   isDirty() { return true; }
 
-  value() {
+  compute() {
     let key = this.pathReference.value();
     let keyType = typeof key;
 

--- a/packages/ember-glimmer/lib/utils/references.js
+++ b/packages/ember-glimmer/lib/utils/references.js
@@ -120,7 +120,14 @@ export class GetHelperReference extends CachedReference {
   isDirty() { return true; }
 
   value() {
-    return this.sourceReference.get(this.pathReference.value()).value();
+    let key = this.pathReference.value();
+    let keyType = typeof key;
+
+    if (key && (keyType === 'string' || keyType === 'number')) {
+      return this.sourceReference.get(key).value();
+    }
+
+    return null;
   }
 
   get(propertyKey) {

--- a/packages/ember-glimmer/tests/integration/helpers/get-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/get-test.js
@@ -309,7 +309,7 @@ moduleFor('Helpers test: {{get}}', class extends RenderingTest {
     this.assertText('banana');
   }
 
-  ['@htmlbars should handle object values as nulls']() {
+  ['@test should handle object values as nulls']() {
     this.render(`[{{get colors 'apple'}}] [{{if true (get colors 'apple')}}]`, {
       colors: null
     });
@@ -329,7 +329,7 @@ moduleFor('Helpers test: {{get}}', class extends RenderingTest {
     this.assertText('[] []');
   }
 
-  ['@htmlbars should handle object keys as nulls']() {
+  ['@test should handle object keys as nulls']() {
     this.render(`[{{get colors key}}] [{{if true (get colors key)}}]`, {
       colors: {
         apple: 'red',
@@ -353,7 +353,7 @@ moduleFor('Helpers test: {{get}}', class extends RenderingTest {
     this.assertText('[] []');
   }
 
-  ['@htmlbars should handle object values and keys as nulls']() {
+  ['@test should handle object values and keys as nulls']() {
     this.render(`[{{get colors 'apple'}}] [{{if true (get colors key)}}]`, {
       colors: null,
       key: null


### PR DESCRIPTION
Fixes 3 failing tests under `get` helper in #13316 
