### PR TITLE
Misc Glimmer 2 fixes

### DIFF
--- a/lib/packages.js
+++ b/lib/packages.js
@@ -44,9 +44,11 @@ if (glimmerStatus === null || glimmerStatus === true) {
   };
 
   var templateCompiler = packages['ember-template-compiler'];
+  templateCompiler.templateCompilerVendor.push('glimmer-wire-format');
   templateCompiler.templateCompilerVendor.push('glimmer-syntax');
   templateCompiler.templateCompilerVendor.push('glimmer-util');
   templateCompiler.templateCompilerVendor.push('glimmer-compiler');
+  templateCompiler.templateCompilerVendor.push('glimmer-reference');
   templateCompiler.templateCompilerVendor.push('glimmer-runtime');
   templateCompiler.templateCompilerVendor.push('handlebars');
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "express": "^4.5.0",
     "finalhandler": "^0.4.0",
     "github": "^0.2.3",
-    "glimmer-engine": "tildeio/glimmer#5918a481",
+    "glimmer-engine": "tildeio/glimmer#8182ab3",
     "glob": "^5.0.13",
     "htmlbars": "0.14.16",
     "mocha": "^2.4.5",

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -141,14 +141,7 @@ export default class Environment extends GlimmerEnvironment {
   }
 
   toConditionalReference(reference) {
-    // if (isConst(reference)) {
-    //   return new ConstConditionalReference(reference);
-    // } else {
-    //   return new ConditionalReference(reference);
-    // }
-
-    // FIXME: fix failing proxy tests
-    return new ConditionalReference(reference);
+    return ConditionalReference.create(reference);
   }
 
   iterableFor(ref, args) {

--- a/packages/ember-glimmer/lib/helpers/get.js
+++ b/packages/ember-glimmer/lib/helpers/get.js
@@ -1,5 +1,5 @@
 import { GetHelperReference } from '../utils/references';
-import { isConst } from 'glimmer-reference';
+import { isConst, referenceFromParts } from 'glimmer-reference';
 
 /**
 @module ember
@@ -58,7 +58,8 @@ export default {
     let propertyPathReference = args.positional.at(1); // bar in (get foo bar)
 
     if (isConst(propertyPathReference)) {
-      return sourceReference.get(propertyPathReference.value());
+      let parts = propertyPathReference.value().split('.');
+      return referenceFromParts(sourceReference, parts);
     } else {
       return new GetHelperReference(sourceReference, propertyPathReference);
     }

--- a/packages/ember-glimmer/tests/integration/helpers/get-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/get-test.js
@@ -1,8 +1,8 @@
 import { RenderingTest, moduleFor } from '../../utils/test-case';
+import { Component } from '../../utils/helpers';
 import { set } from 'ember-metal/property_set';
 import { get } from 'ember-metal/property_get';
 import TextField from 'ember-views/views/text_field';
-import Component from 'ember-views/components/component';
 
 moduleFor('Helpers test: {{get}}', class extends RenderingTest {
 

--- a/packages/ember-glimmer/tests/integration/helpers/hash-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/hash-test.js
@@ -1,6 +1,6 @@
 import { RenderingTest, moduleFor } from '../../utils/test-case';
+import { Component } from '../../utils/helpers';
 import { set } from 'ember-metal/property_set';
-import Component from 'ember-views/components/component';
 
 moduleFor('Helpers test: {{hash}}', class extends RenderingTest {
 

--- a/packages/ember-glimmer/tests/integration/helpers/if-unless-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/if-unless-test.js
@@ -10,13 +10,13 @@ moduleFor('Helpers test: inline {{if}}', class extends TogglingHelperConditional
   ['@test it raises when there are more than three arguments']() {
     expectAssertion(() => {
       this.render(`{{if condition 'a' 'b' 'c'}}`, { condition: true });
-    }, /The inline form of the `if` and `unless` helpers expect two or three arguments/);
+    }, /The inline form of the `if` helper expects two or three arguments/);
   }
 
   ['@test it raises when there are less than two arguments']() {
     expectAssertion(() => {
       this.render(`{{if condition}}`, { condition: true });
-    }, /The inline form of the `if` and `unless` helpers expect two or three arguments/);
+    }, /The inline form of the `if` helper expects two or three arguments/);
   }
 
 });
@@ -82,13 +82,13 @@ moduleFor('Helpers test: inline {{unless}}', class extends TogglingHelperConditi
   ['@test it raises when there are more than three arguments']() {
     expectAssertion(() => {
       this.render(`{{unless condition 'a' 'b' 'c'}}`, { condition: true });
-    }, /The inline form of the `if` and `unless` helpers expect two or three arguments/);
+    }, /The inline form of the `unless` helper expects two or three arguments/);
   }
 
   ['@test it raises when there are less than two arguments']() {
     expectAssertion(() => {
       this.render(`{{unless condition}}`, { condition: true });
-    }, /The inline form of the `if` and `unless` helpers expect two or three arguments/);
+    }, /The inline form of the `unless` helper expects two or three arguments/);
   }
 
 });

--- a/packages/ember-htmlbars/lib/helpers/if_unless.js
+++ b/packages/ember-htmlbars/lib/helpers/if_unless.js
@@ -63,6 +63,18 @@ import shouldDisplay from 'ember-views/streams/should_display';
   @public
 */
 function ifHelper(params, hash, options) {
+  assert(
+    'The block form of the `if` helper expects exactly one argument, e.g. ' +
+    '`{{#if newMessages}} You have new messages. {{/if}}.`',
+    !options.template.yield || params.length === 1
+  );
+
+  assert(
+    'The inline form of the `if` helper expects two or three arguments, e.g. ' +
+    '`{{if trialExpired "Expired" expiryDate}}`.',
+    !!options.template.yield || params.length === 2 || params.length === 3
+  );
+
   return ifUnless(params, hash, options, shouldDisplay(params[0]));
 }
 
@@ -76,23 +88,22 @@ function ifHelper(params, hash, options) {
   @public
 */
 function unlessHelper(params, hash, options) {
-  return ifUnless(params, hash, options, !shouldDisplay(params[0]));
-}
-
-function ifUnless(params, hash, options, truthy) {
   assert(
-    'The block form of the `if` and `unless` helpers expect exactly one ' +
-    'argument, e.g. `{{#if newMessages}} You have new messages. {{/if}}.`',
+    'The block form of the `unless` helper expects exactly one argument, e.g. ' +
+    '`{{#unless isFirstLogin}} Welcome back! {{/unless}}.`',
     !options.template.yield || params.length === 1
   );
 
   assert(
-    'The inline form of the `if` and `unless` helpers expect two or ' +
-    'three arguments, e.g. `{{if trialExpired \'Expired\' expiryDate}}` ' +
-    'or `{{unless isFirstLogin \'Welcome back!\'}}`.',
+    'The inline form of the `unless` helper expects two or three arguments, e.g. ' +
+    '`{{if trialExpired "Expired" expiryDate}}`.',
     !!options.template.yield || params.length === 2 || params.length === 3
   );
 
+  return ifUnless(params, hash, options, !shouldDisplay(params[0]));
+}
+
+function ifUnless(params, hash, options, truthy) {
   if (truthy) {
     if (options.template.yield) {
       options.template.yield();

--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -54,7 +54,6 @@ export function set(obj, keyName, value, tolerant) {
     meta = peekMeta(obj);
     possibleDesc = obj[keyName];
     desc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
-    markObjectAsDirty(meta);
   }
 
   var isUnknown, currentValue;
@@ -64,6 +63,8 @@ export function set(obj, keyName, value, tolerant) {
 
   assert(`calling set on destroyed object: ${toString(obj)}.${keyName} = ${toString(value)}`,
          !obj.isDestroyed);
+
+  markObjectAsDirty(meta);
 
   if (desc) {
     desc.set(obj, keyName, value);

--- a/packages/ember-template-compiler/lib/index.js
+++ b/packages/ember-template-compiler/lib/index.js
@@ -1,4 +1,5 @@
 export { default as _Ember } from 'ember-metal'; // Is this still needed
+import isEnabled from 'ember-metal/features';
 import { ENV } from 'ember-environment';
 import precompile from 'ember-template-compiler/system/precompile';
 import compile from 'ember-template-compiler/system/compile';
@@ -27,9 +28,11 @@ import 'ember-template-compiler/compat';
 registerPlugin('ast', TransformOldBindingSyntax);
 registerPlugin('ast', TransformOldClassBindingSyntax);
 registerPlugin('ast', TransformItemClass);
-registerPlugin('ast', TransformClosureComponentAttrsIntoMut);
-registerPlugin('ast', TransformComponentAttrsIntoMut);
-registerPlugin('ast', TransformComponentCurlyToReadonly);
+if (!isEnabled('ember-glimmer')) {
+  registerPlugin('ast', TransformClosureComponentAttrsIntoMut);
+  registerPlugin('ast', TransformComponentAttrsIntoMut);
+  registerPlugin('ast', TransformComponentCurlyToReadonly);
+}
 registerPlugin('ast', TransformAngleBracketComponents);
 registerPlugin('ast', TransformInputOnToOnEvent);
 registerPlugin('ast', TransformTopLevelComponents);


### PR DESCRIPTION
- Glimmer compiler needs wire-format and references
- [Const reference optimization](https://github.com/emberjs/ember.js/pull/13332) for dynamic component
  
  This optimizes `{{component "foo-bar"}}` into the same thing as `{{foo-bar}}` in the updating program. It also works for passed-in attrs like `{{component @stuff}}` where `@stuff` is static on the invocation side `{{x-outside stuff="foo-bar"}}`.
- Correctly dirty `Ember.set(foo, 'bar.baz.bat', ...)`
  
  Previously, doing a `Ember.set(foo, 'bar.baz.bat', ...)` incorrectly marks both the "foo", "bar" and "baz" objects as dirty. This fixes the problem and only mark "bat" as dirty, i.e. making this the same as doing `Ember.set(Ember.get(foo, 'bar.baz'), 'bat', ...)`.
- Disable AST transforms on Glimmer for now
  
  This is causing issues because we have not implemented the `mut` helper in `ember-glimmer` (among other things). We can selectively re-enable stuff we still need (and works) as we go.
- Make conditional helpers/references not volatile
  
  We previously marked them as `volatile` with a FIXME because we need to support proxies. This reduces the scope and only mark conditionals with proxies as volatile (we can still do better than that by making proxy objects have a special tag that combines its own `DirtyableTag` with the tag from its `content`, but it's pretty low priority at the moment).
  
  The refactor also added a new optimizations: by reusing the same code across the syntax (`{{#if}}`) and the helper (`{{if}}`) versions, the inline conditional helpers now also participate in the same const optimization, i.e. `{{if true foo bar}}` will be optimized into `{{foo}}` in the updating program, so as `{{if @stuff foo bar}}` if `@stuff` is static.
  
  TODO: fix tests that uses fake proxies, see comment in `references.js` (cc @chadhietala)

cc @krisselden 
