### PR TITLE
[BUGFIX RELEASE] Fix toString to not add the property on the class

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -15,6 +15,7 @@
         "throws",
         "deepEqual",
         "ok",
+        "notOk",
         "strictEqual",
         "expect",
         "minispade",

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -523,16 +523,11 @@ CoreObject.PrototypeMixin = Mixin.create({
     var extension = hasToStringExtension ? ':' + this.toStringExtension() : '';
     var ret = '<' + this.constructor.toString() + ':' + guidFor(this) + extension + '>';
 
-    this.toString = makeToString(ret);
     return ret;
   }
 });
 
 CoreObject.PrototypeMixin.ownerConstructor = CoreObject;
-
-function makeToString(ret) {
-  return function() { return ret; };
-}
 
 CoreObject.__super__ = null;
 

--- a/packages/ember-runtime/tests/system/core_object_test.js
+++ b/packages/ember-runtime/tests/system/core_object_test.js
@@ -26,3 +26,14 @@ QUnit.test('works with new (> 1 arg)', function() {
 
   equal(obj.other, undefined); // doesn't support multiple pojo' to the constructor
 });
+
+QUnit.test('toString should be not be added as a property when calling toString()', function() {
+  var obj = new CoreObject({
+    firstName: 'Foo',
+    lastName: 'Bar'
+  });
+
+  obj.toString();
+
+  notOk(obj.hasOwnProperty('toString'), 'Calling toString() should not create a toString class property');
+});


### PR DESCRIPTION
When calling `toString()` method on an Ember Object, it attaches the `toString` as a class property for the first time. This does not seem right since this should be on the prototype of the class. We could memoize the value on the class meta data.

In v2.5.0 and above, when calling `.set()` on an Ember Object, you end up also attaching the `toString()` property on the class. This [PR](https://github.com/emberjs/ember.js/commit/3a2486eb911ad77d2ab1a4324c1aacef08c156da) calls `toString()` on the object during setting any property. Therefore, when you walk through the object properties you end up getting an additional property on the object.

Thanks to Kris & Chad for guiding on this!

cc: @krisselden @chadhietala 
