### PR TITLE
[BUGFIX release] Ensure injected property assertion checks `container`.

### DIFF
--- a/packages/ember-metal/lib/injected_property.js
+++ b/packages/ember-metal/lib/injected_property.js
@@ -25,7 +25,7 @@ function InjectedProperty(type, name) {
 
 function injectedPropertyGet(keyName) {
   var desc = this[keyName];
-  let owner = getOwner(this);
+  let owner = getOwner(this) || this.container; // fallback to `container` for backwards compat
 
   assert(`InjectedProperties should be defined with the Ember.inject computed property macros.`, desc && desc.isDescriptor && desc.type);
   assert(`Attempting to lookup an injected property on an object without a container, ensure that the object was instantiated via a container.`, owner);

--- a/packages/ember-metal/tests/injected_property_test.js
+++ b/packages/ember-metal/tests/injected_property_test.js
@@ -22,13 +22,28 @@ QUnit.test('injected properties should be overridable', function() {
   equal(get(obj, 'foo'), 'bar', 'should return the overriden value');
 });
 
-QUnit.test('getting on an object without a container should fail assertion', function() {
+QUnit.test('getting on an object without an owner or container should fail assertion', function() {
   var obj = {};
   defineProperty(obj, 'foo', new InjectedProperty('type', 'name'));
 
   expectAssertion(function() {
     get(obj, 'foo');
   }, /Attempting to lookup an injected property on an object without a container, ensure that the object was instantiated via a container./);
+});
+
+QUnit.test('getting on an object without an owner but with a container should not fail', function() {
+  var obj = {
+    container: {
+      lookup(key) {
+        ok(true, 'should call container.lookup');
+        return key;
+      }
+    }
+  };
+
+  defineProperty(obj, 'foo', new InjectedProperty('type', 'name'));
+
+  equal(get(obj, 'foo'), 'type:name', 'should return the value of container.lookup');
 });
 
 QUnit.test('getting should return a lookup on the container', function() {


### PR DESCRIPTION
During the Ember 2.3.0 cycle, we introduced the `getOwner` / `setOwner` concepts and deprecated using the injected `.container` property on objects. Unfortunately, if you are using an older library to create objects that hasn't been updated to use `setOwner` you would only have the `container` specified which causes this injection assertion to be thrown (since `getOwner(this)` returns undefined).

Specifically, using Ember Data 1.13.<latest> with Ember 2.4.5 and having a model with an injected property will trigger an assertion.
