### PR TITLE
[BUGFIX canary] Ensure `Ember.ENV` is present.

### DIFF
--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -373,6 +373,11 @@ Object.defineProperty(Ember, 'LOG_BINDINGS', {
   enumerable: false
 });
 
+Object.defineProperty(Ember, 'ENV', {
+  get: () => ENV,
+  enumerable: false
+});
+
 /**
   A function may be assigned to `Ember.onerror` to be called when Ember
   internals encounter an error. This is useful for specialized error handling


### PR DESCRIPTION
This adds a non-enumerable property to `Ember` for `ENV`.  Accessing/updating `ENV` after initial boot is not a supported operation, however ember-cli-htmlbars was using this private API to setup the various flags (i.e. `EXTEND_PROTOTYPES` and friends).

An update will come shortly for `ember-cli-htmlbars`, but this PR prevents updating to canary Ember from being a breaking change for users of current versions of ember-cli-htmlbars.

Fixes #13347.
