### PR TITLE
[BUGFIX release] Setting a property during `init` flows upstream.

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -2101,4 +2101,40 @@ moduleFor('Components test: curly components', class extends RenderingTest {
 
     this.assertText('initial value');
   }
+
+  ['@htmlbars ensure attributes which have been passed in can be mutated, when they are mutated the external source is updated (#11192)']() {
+    let component;
+    let FooBarComponent = Component.extend({
+      init() {
+        this._super(...arguments);
+        component = this;
+        this.set('bar', 'hellllloooooo');
+      }
+    });
+
+    this.registerComponent('foo-bar', {
+      ComponentClass: FooBarComponent,
+      template: ''
+    });
+
+    expectDeprecation(() => {
+      this.render('{{localBar}}{{foo-bar bar=localBar}}', {
+        localBar: undefined
+      });
+    }, /You modified localBar twice in a single render/);
+
+    this.assertText('hellllloooooo');
+
+    this.runTask(() => this.rerender());
+
+    this.assertText('hellllloooooo');
+
+    this.runTask(() => { component.set('bar', 'updated value'); });
+
+    this.assertText('updated value');
+
+    this.runTask(() => { component.set('bar', 'hellllloooooo'); });
+
+    this.assertText('hellllloooooo');
+  }
 });

--- a/packages/ember-views/lib/views/states/pre_render.js
+++ b/packages/ember-views/lib/views/states/pre_render.js
@@ -1,5 +1,4 @@
 import _default from 'ember-views/views/states/default';
-import assign from 'ember-metal/assign';
 
 /**
 @module ember
@@ -7,9 +6,5 @@ import assign from 'ember-metal/assign';
 */
 
 let preRender = Object.create(_default);
-
-assign(preRender, {
-  legacyPropertyDidChange(view, key) {}
-});
 
 export default preRender;


### PR DESCRIPTION
This `legacyPropertyDidChange` method is used by the `AttrsProxy` to properly set the upstream values, it is included in the `default` state [here](https://github.com/emberjs/ember.js/blob/master/packages/ember-views/lib/views/states/default.js#L23-L34) (so it is available in all other states), but `preRender` state (which is where `init` is executed in) was being overridden with a noop.  This overrride was introduced in https://github.com/emberjs/ember.js/pull/11081, however the implementation of the `AttrsProxy` completely changed from what was causing the original reported regression (https://github.com/emberjs/ember.js/issues/11023) and the test added for that regression still passes when removing this change.

Fixes #11192.
