### PR TITLE
[BUGFIX beta] Fix revalidation hook messages.

### DIFF
--- a/packages/ember-htmlbars/lib/renderer.js
+++ b/packages/ember-htmlbars/lib/renderer.js
@@ -85,6 +85,7 @@ Renderer.prototype.dispatchLifecycleHooks =
         case 'didUpdate': this.didUpdate(hook.view); break;
       }
 
+      ownerView._dispatching = 'didRender';
       this.didRender(hook.view);
     }
 

--- a/packages/ember-htmlbars/lib/utils/subscribe.js
+++ b/packages/ember-htmlbars/lib/utils/subscribe.js
@@ -21,6 +21,6 @@ export default function subscribe(node, env, scope, stream) {
       node.shouldReceiveAttrs = true;
     }
 
-    node.ownerNode.emberView.scheduleRevalidate(node, labelFor(stream));
+    node.ownerNode.emberView.scheduleRevalidate(node, labelFor(stream), undefined, component);
   }));
 }

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -508,7 +508,7 @@ export default Mixin.create({
     this.scheduledRevalidation = false;
   },
 
-  scheduleRevalidate(node, label, manualRerender) {
+  scheduleRevalidate(node, label, manualRerender, revalidationSource) {
     if (node && !this._dispatching && this.env.renderedNodes.has(node)) {
       if (manualRerender) {
         deprecate(
@@ -528,7 +528,7 @@ export default Mixin.create({
     }
 
     deprecate(
-      `A property of ${this} was modified inside the ${this._dispatching} hook. You should never change properties on components, services or models during ${this._dispatching} because it causes significant performance degradation.`,
+      `A property of ${revalidationSource || this} was modified inside the ${this._dispatching} hook. You should never change properties on components, services or models during ${this._dispatching} because it causes significant performance degradation.`,
       !this._dispatching,
       { id: 'ember-views.dispatching-modify-property', until: '3.0.0' }
     );


### PR DESCRIPTION
The source of the revalidation was being lost, and the message indicated the root `ownerView` (which was not the thing that triggered a rerender). Also, the `_dispatching` flag was not being changed after calling `didInsertElement` / `didUpdateElement` and before calling `didRender`.

Fixes #11505.
Fixes #11493.
