### PR TITLE
[BUGFIX beta] Fix issue with `Ember.trySet` on destroyed objects.

### DIFF
--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -47,7 +47,11 @@ export function set(obj, keyName, value, tolerant) {
   assert(`Cannot call set with '${keyName}' on an undefined object.`, obj && typeof obj === 'object' || typeof obj === 'function');
   assert(`The key provided to set must be a string or number, you passed ${keyName}`, typeof keyName === 'string' || (typeof keyName === 'number' && !isNaN(keyName)));
   assert(`'this' in paths is not supported`, typeof keyName !== 'string' || keyName.lastIndexOf('this.', 0) !== 0);
-  assert(`calling set on destroyed object: ${toString(obj)}.${keyName} = ${toString(value)}`, !obj.isDestroyed);
+
+  if (obj.isDestroyed) {
+    assert(`calling set on destroyed object: ${toString(obj)}.${keyName} = ${toString(value)}`, tolerant);
+    return;
+  }
 
   if (isPath(keyName)) {
     return setPath(obj, keyName, value, tolerant);

--- a/packages/ember-metal/tests/accessors/set_test.js
+++ b/packages/ember-metal/tests/accessors/set_test.js
@@ -1,6 +1,7 @@
 import {
   get,
   set,
+  trySet,
   setHasViews
 } from '../..';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
@@ -97,6 +98,13 @@ moduleFor('set', class extends AbstractTestCase {
     set(obj, 'foo', 'bar');
 
     assert.equal(obj.foo, 'bar');
+  }
+
+  ['@test does not warn on attempts of calling set on a destroyed object with `trySet`'](assert) {
+    let obj = { isDestroyed: true };
+
+    trySet(obj, 'favoriteFood', 'hot dogs');
+    assert.equal(obj.favoriteFood, undefined, 'does not set and does not error');
   }
 });
 


### PR DESCRIPTION
`Ember.trySet` is designed to be an error-tolerant form of `Ember.set` (per its public API documentation). However, in some circumstances an error is still thrown when setting on a destroyed object.

Prior to this change, the following would properly prevent an error:

``` js
let obj = { some: { deep : 'path', isDestroyed: true }};

Ember.trySet(obj, 'some.deep', 'stuff');
```

But the following would throw an error incorrectly:

``` js
let obj = { some: 'path', isDestroyed: true };

Ember.trySet(obj, 'some', 'stuff');
```

This fixes the latter case...

Fixes #12356.
