### PR TITLE
[DOC release] fix typo

### DIFF
--- a/packages/ember-htmlbars/lib/helper.js
+++ b/packages/ember-htmlbars/lib/helper.js
@@ -93,7 +93,7 @@ Helper.reopenClass({
 
 /**
   In many cases, the ceremony of a full `Ember.Helper` class is not required.
-  The `helper` method create pure-function helpers without instances. For
+  The `helper` method creates pure-function helpers without instances. For
   example:
 
   ```js


### PR DESCRIPTION
This fixes a small typo in `packages/ember-htmlbars/lib/helper.js`.
