### PR TITLE
[BUGFIX beta] Fix subexpr `{{if}}` / `{{unless}}` to use protocol.

### DIFF
--- a/packages/ember-glimmer/tests/integration/helpers/if-unless-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/if-unless-test.js
@@ -21,7 +21,7 @@ moduleFor('Helpers test: inline {{if}}', class extends TogglingHelperConditional
 
 });
 
-moduleFor('@glimmer Helpers test: nested {{if}} helpers (returning truthy values)', class extends TogglingHelperConditionalsTest {
+moduleFor('Helpers test: nested {{if}} helpers (returning truthy values)', class extends TogglingHelperConditionalsTest {
 
   templateFor({ cond, truthy, falsy }) {
     return `{{if (if ${cond} ${cond} false) ${truthy} ${falsy}}}`;
@@ -29,7 +29,7 @@ moduleFor('@glimmer Helpers test: nested {{if}} helpers (returning truthy values
 
 });
 
-moduleFor('@glimmer Helpers test: nested {{if}} helpers (returning falsy values)', class extends TogglingHelperConditionalsTest {
+moduleFor('Helpers test: nested {{if}} helpers (returning falsy values)', class extends TogglingHelperConditionalsTest {
 
   templateFor({ cond, truthy, falsy }) {
     return `{{if (if ${cond} true ${cond}) ${truthy} ${falsy}}}`;
@@ -37,7 +37,7 @@ moduleFor('@glimmer Helpers test: nested {{if}} helpers (returning falsy values)
 
 });
 
-moduleFor('@glimmer Helpers test: {{if}} used with another helper', class extends TogglingHelperConditionalsTest {
+moduleFor('Helpers test: {{if}} used with another helper', class extends TogglingHelperConditionalsTest {
 
   wrapperFor(templates) {
     return `{{concat ${templates.join(' ')}}}`;

--- a/packages/ember-htmlbars/lib/hooks/link-render-node.js
+++ b/packages/ember-htmlbars/lib/hooks/link-render-node.js
@@ -21,14 +21,10 @@ export default function linkRenderNode(renderNode, env, scope, path, params, has
   let keyword = env.hooks.keywords[path];
   if (keyword && keyword.link) {
     keyword.link(renderNode.getState(), params, hash);
+  } else if (path === 'unbound') {
+    return true;
   } else {
-    switch (path) {
-      case 'unbound': return true;
-      case 'unless':
-      case 'if': params[0] = shouldDisplay(params[0], toBool); break;
-      case 'each': params[0] = eachParam(params[0]); break;
-      case 'with': params[0] = shouldDisplay(params[0], identity); break;
-    }
+    linkParamsFor(path, params);
   }
 
   // If there is a dot in the path, we need to subscribe to the arguments in the
@@ -63,6 +59,15 @@ export default function linkRenderNode(renderNode, env, scope, path, params, has
   // recomputed on subsequent re-renders because they are
   // streams.
   return true;
+}
+
+export function linkParamsFor(path, params) {
+  switch (path) {
+  case 'unless':
+  case 'if': params[0] = shouldDisplay(params[0], toBool); break;
+  case 'each': params[0] = eachParam(params[0]); break;
+  case 'with': params[0] = shouldDisplay(params[0], identity); break;
+  }
 }
 
 function eachParam(list) {

--- a/packages/ember-htmlbars/lib/hooks/subexpr.js
+++ b/packages/ember-htmlbars/lib/hooks/subexpr.js
@@ -9,6 +9,7 @@ import {
   labelsFor,
   labelFor
 } from 'ember-metal/streams/utils';
+import { linkParamsFor } from 'ember-htmlbars/hooks/link-render-node';
 
 export default function subexpr(env, scope, helperName, params, hash) {
   // TODO: Keywords and helper invocation should be integrated into
@@ -17,6 +18,8 @@ export default function subexpr(env, scope, helperName, params, hash) {
   if (keyword) {
     return keyword(null, env, scope, params, hash, null, null);
   }
+
+  linkParamsFor(helperName, params);
 
   var label = labelForSubexpr(params, hash, helperName);
   var helper = lookupHelper(helperName, scope.getSelf(), env);


### PR DESCRIPTION
Prior to this change, the inline `{{if` / `{{unless` helpers would not recalulate at the same time as the non-inline versions (because they were not respecting the `isTruthy` and `.length` checks properly).

This fixes that by properly wrapping the generated stream with those dependencies (sharing the same code as the block versions of `{{if` / `{{unless`).

The tests for this were already written, but disabled when running under HTMLBars. This enables them for running properly in both HTMLBars and Glimmer engines.

Fixes #11701.
