### PR TITLE
[BUGFIX beta] Enumerable#any bug - not always returning a boolean

### DIFF
--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -667,7 +667,7 @@ var Enumerable = Mixin.create({
 
     next = last = null;
     context = pushCtx(context);
-    return found;
+    return !!found;
   },
 
   /**

--- a/packages/ember-runtime/tests/suites/enumerable/any.js
+++ b/packages/ember-runtime/tests/suites/enumerable/any.js
@@ -19,7 +19,7 @@ suite.test('any should should invoke callback on each item as long as you return
     found.push(i);
     return false;
   });
-  equal(result, false, 'return value of obj.any');
+  strictEqual(result, false, 'return value of obj.any');
   deepEqual(found, ary, 'items passed during any() should match');
 });
 
@@ -35,27 +35,27 @@ suite.test('any should stop invoking when you return true', function() {
     found.push(i);
     return --cnt <= 0;
   });
-  equal(result, true, 'return value of obj.any');
-  equal(found.length, exp, 'should invoke proper number of times');
+  strictEqual(result, true, 'return value of obj.any');
+  strictEqual(found.length, exp, 'should invoke proper number of times');
   deepEqual(found, ary.slice(0, -2), 'items passed during any() should match');
 });
 
 
-suite.test('any should return true if any object matches the callback', function() {
+suite.test('any should return true if any object returns a truthy value for the callback', function() {
   var obj = emberA([0, 1, 2]);
   var result;
 
-  result = obj.any(function(i) { return !!i; });
-  equal(result, true, 'return value of obj.any');
+  result = obj.any(function(i) { return i; });
+  strictEqual(result, true, 'return value of obj.any');
 });
 
 
-suite.test('any should return false if no object matches the callback', function() {
-  var obj = emberA([0, null, false]);
+suite.test('any should return false if no object returns a truthy value for the callback', function() {
+  var obj = emberA([0, null, false, undefined]);
   var result;
 
-  result = obj.any(function(i) { return !!i; });
-  equal(result, false, 'return value of obj.any');
+  result = obj.any(function(i) { return i; });
+  strictEqual(result, false, 'return value of obj.any');
 });
 
 
@@ -64,7 +64,7 @@ suite.test('any should produce correct results even if the matching element is u
   var result;
 
   result = obj.any(function(i) { return true; });
-  equal(result, true, 'return value of obj.any');
+  strictEqual(result, true, 'return value of obj.any');
 });
 
 


### PR DESCRIPTION
closes #12533 

`Enumerable#any` is supposed to return only a boolean, but is currently returning whatever truthy value is returned in the callback. This changed functionality is now aligned with `Array#some`. 

Potentially a breaking change if someone was relying on the buggy functionality. It was introduced here - https://github.com/emberjs/ember.js/pull/4144/ 
