### PR TITLE
[GLIMMER2] Update glimmer version, un-gate htmlSafe test

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "express": "^4.5.0",
     "finalhandler": "^0.4.0",
     "github": "^0.2.3",
-    "glimmer-engine": "tildeio/glimmer#2849de8",
+    "glimmer-engine": "tildeio/glimmer#b421a52",
     "glob": "^5.0.13",
     "htmlbars": "0.14.16",
     "mocha": "^2.4.5",

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -877,7 +877,7 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     equalTokens(this.firstChild, expectedHtmlBold);
   }
 
-  ['@htmlbars should not escape HTML if string is a htmlSafe'](assert) {
+  ['@test should not escape HTML if string is a htmlSafe'](assert) {
     let expectedHtmlBold = 'you need to be more <b>bold</b>';
     let expectedHtmlItalic = 'you are so <i>super</i>';
     let component;


### PR DESCRIPTION
Now that `htmlSafe` has been implemented in Glimmer, this un-gates the test for `htmlSafe`. It also bumps the version of `glimmer-engine` to the SHA where `htmlSafe` has been implemented.
