### PR TITLE
enhance custom location API documentation 

### DIFF
--- a/packages/ember-routing/lib/location/api.js
+++ b/packages/ember-routing/lib/location/api.js
@@ -119,15 +119,23 @@ import { getHash } from 'ember-routing/location/util';
 
   Calling setURL or replaceURL will not trigger onUpdateURL callbacks.
   
-  Custom location implementation should be registered like so:
+  ## Custom implementation
+  
+  Ember scans `app/locations/*` for extending the Location API.
+  
+  Example:
   
   ```javascript
-  Em.Application.initializer({
-    name: 'my-implementation',
-    initialize: function(container) {
-      container.register('location:my-implementation', MyLocation);
+  import Ember from 'ember';
+
+  export default Ember.HistoryLocation.extend({
+    implementation: 'history-url-logging',
+
+    pushState: function (path) {
+      console.log(path);
+      this._super.apply(this, arguments);
     }
-  };
+  });
   ```
 
   @class Location

--- a/packages/ember-routing/lib/location/api.js
+++ b/packages/ember-routing/lib/location/api.js
@@ -118,13 +118,13 @@ import { getHash } from 'ember-routing/location/util';
       to `false`.
 
   Calling setURL or replaceURL will not trigger onUpdateURL callbacks.
-  
+
   ## Custom implementation
-  
+
   Ember scans `app/locations/*` for extending the Location API.
-  
+
   Example:
-  
+
   ```javascript
   import Ember from 'ember';
 

--- a/packages/ember-routing/lib/location/api.js
+++ b/packages/ember-routing/lib/location/api.js
@@ -118,6 +118,17 @@ import { getHash } from 'ember-routing/location/util';
       to `false`.
 
   Calling setURL or replaceURL will not trigger onUpdateURL callbacks.
+  
+  Custom location implementation should be registered like so:
+  
+  ```javascript
+  Em.Application.initializer({
+    name: 'my-implementation',
+    initialize: function(container) {
+      container.register('location:my-implementation', MyLocation);
+    }
+  };
+  ```
 
   @class Location
   @namespace Ember


### PR DESCRIPTION
didn't  find anything on how to register cutom location implementation for router.

Not sure should i use `ember-cli` code examples with `export default {` instead of `Em.Application.initializer({`
