### PR TITLE
[FEATURE] Add support for positional parameters in the component blueprint

### DIFF
--- a/blueprints/component/files/__root__/__path__/__name__.js
+++ b/blueprints/component/files/__root__/__path__/__name__.js
@@ -1,4 +1,12 @@
 import Ember from 'ember';
 <%= importTemplate %>
-export default Ember.Component.extend({<%= contents %>
+<% if (posParams) { %>const Component = <% } else { %> export default <% } %>Ember.Component.extend({<%= contents %>
 });
+
+<% if (posParams) { %>
+Component.reopenClass({
+  positionalParams: []
+});
+
+export default Component;
+<% } %>

--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -19,6 +19,14 @@ module.exports = {
       aliases:[
         {'no-path': ''}
       ]
+    },
+    {
+      name: 'positional-parameters',
+      type: Boolean,
+      default: false,
+      aliases: [
+        { 'p': true }
+      ]
     }
   ],
 
@@ -70,7 +78,8 @@ module.exports = {
     return {
       importTemplate: importTemplate,
       contents: contents,
-      path: getPathOption(options)
+      path: getPathOption(options),
+      posParams: options.positionalParameters
     };
   }
 };


### PR DESCRIPTION
Hello,
This is a feature I've been feeling is lacking. I often make components that take positional parameters, and I think a flag on the generator would be a good addition. This PR adds a `--positional-parameters` (aliased to `-p`) flag that makes a component like so:

``` javascript
import ...;

const Component = Ember.Component.extend({...});

Component.reopenClass(({
  positionalParams: []
});

export default Component;
```

I'm not sure where the tests are for the generators, I will write one if someone points me in the right direction. I've made this PR to kick off the CI as my local tests seem to have a lot of (hopefully) unrelated failures and to get feedback - this is my first PR so I'm sure there are problems!

Also I'd like to enable people to specify a list of positional parameters through the command line, like `-p arg1,arg2,arg3` but I'm not sure how to add this.
