### PR TITLE
[Glimmer2] Add compile-time assert for block usage of custom helper

### DIFF
--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -74,11 +74,7 @@ export default class Environment extends GlimmerEnvironment {
     }
 
     let nativeSyntax = super.refineStatement(statement);
-
-    if (!nativeSyntax && key && this.hasHelper(key)) {
-      assert(`Helpers may not be used in the block form, for example {{#${key}}}{{/${key}}}. Please use a component, or alternatively use the helper in combination with a built-in Ember helper, for example {{#if (${key})}}{{/if}}.`, !isBlock);
-    }
-
+    assert(`Helpers may not be used in the block form, for example {{#${key}}}{{/${key}}}. Please use a component, or alternatively use the helper in combination with a built-in Ember helper, for example {{#if (${key})}}{{/if}}.`, !nativeSyntax && key && this.hasHelper(key) ? !isBlock : true);
     return nativeSyntax;
   }
 

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -1,5 +1,6 @@
 import { Environment as GlimmerEnvironment } from 'glimmer-runtime';
 import Dict from 'ember-metal/empty_object';
+import { assert } from 'ember-metal/debug';
 import { CurlyComponentSyntax, CurlyComponentDefinition } from './components/curly-component';
 import { DynamicComponentSyntax } from './components/dynamic-component';
 import { OutletSyntax } from './components/outlet';
@@ -72,7 +73,13 @@ export default class Environment extends GlimmerEnvironment {
       }
     }
 
-    return super.refineStatement(statement);
+    let nativeSyntax = super.refineStatement(statement);
+
+    if (!nativeSyntax && key && this.hasHelper(key)) {
+      assert(`Helpers may not be used in the block form, for example {{#${key}}}{{/${key}}}. Please use a component, or alternatively use the helper in combination with a built-in Ember helper, for example {{#if (${key})}}{{/if}}.`, !isBlock);
+    }
+
+    return nativeSyntax;
   }
 
   hasComponentDefinition() {

--- a/packages/ember-glimmer/tests/integration/helpers/custom-helper-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/custom-helper-test.js
@@ -282,7 +282,7 @@ moduleFor('Helpers test: custom helpers', class extends RenderingTest {
     this.assertText('Who overcomes by force hath overcome but half his foe');
   }
 
-  ['@htmlbars simple helper not usable with a block']() {
+  ['@test simple helper not usable with a block']() {
     this.registerHelper('some-helper', () => {});
 
     expectAssertion(() => {


### PR DESCRIPTION
This throws an error during compile time when custom helpers are used in a block form
