### PR TITLE
Update route-recognizer to 0.1.10.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "qunit-extras": "^1.5.0",
     "qunitjs": "^1.22.0",
     "rimraf": "^2.5.2",
-    "route-recognizer": "0.1.5",
+    "route-recognizer": "0.1.10",
     "rsvp": "~3.2.1",
     "serve-static": "^1.10.0",
     "simple-dom": "^0.3.0",


### PR DESCRIPTION
Fixes a number of bugs:
- [tildeio/route-recognizer#46](https://github.com/tildeio/route-recognizer/pull/46) Implement a smarter route match algorithm.
  Fixes a number of route priority issues, specifically one around glob
  route priority matching.
- [tildeio/route-recognizer#62](https://github.com/tildeio/route-recognizer/pull/62)
  Handle malformed URI error. Prevents errors from being thrown (and
  halting the boot of an app) when a malformed queryParam is present.
- General performance tweaks in:
  - https://github.com/tildeio/route-recognizer/pull/76 Add benchmark
    suite.
  - https://github.com/tildeio/route-recognizer/pull/75 Pre-allocate
    array lengths.
  - https://github.com/tildeio/route-recognizer/pull/77 Cache results of
    `State.get`.
  - https://github.com/tildeio/route-recognizer/pull/78 Route result
    should be of a fixed size.
  - https://github.com/tildeio/route-recognizer/pull/79 Removes closures
    around `eachChar`.
  - https://github.com/tildeio/route-recognizer/pull/80 Fix State and
    `charSpec` shaping.

Compare view:

https://github.com/tildeio/route-recognizer/compare/v0.1.5...v0.1.10
