### PR TITLE
[Glimmer 2] Assert if class base helper is used in block form

### DIFF
--- a/packages/ember-glimmer/tests/integration/helpers/custom-helper-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/custom-helper-test.js
@@ -290,7 +290,7 @@ moduleFor('Helpers test: custom helpers', class extends RenderingTest {
     }, /Helpers may not be used in the block form/);
   }
 
-  ['@htmlbars class-based helper not usable with a block']() {
+  ['@test class-based helper not usable with a block']() {
     this.registerHelper('some-helper', {
       compute() {
       }


### PR DESCRIPTION
Was fixed in #13376
