### PR TITLE
Bump glimmer-engine to include htmlSafe changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "express": "^4.5.0",
     "finalhandler": "^0.4.0",
     "github": "^0.2.3",
-    "glimmer-engine": "tildeio/glimmer#b421a52",
+    "glimmer-engine": "tildeio/glimmer#58f1f91",
     "glob": "^5.0.13",
     "htmlbars": "0.14.16",
     "mocha": "^2.4.5",


### PR DESCRIPTION
Bumps the version of glimmer-engine to include the changes made related to `htmlSafe` and `SafeString`.
