### PR TITLE
[Glimmer2] Implement positional parameter

### DIFF
--- a/packages/ember-glimmer/lib/components/curly-component.js
+++ b/packages/ember-glimmer/lib/components/curly-component.js
@@ -1,8 +1,8 @@
 import { StatementSyntax, ValueReference } from 'glimmer-runtime';
 import { AttributeBindingReference, RootReference, applyClassNameBinding } from '../utils/references';
 import { DIRTY_TAG } from '../ember-views/component';
-import EmptyObject from 'ember-metal/empty_object';
 import { assert } from 'ember-metal/debug';
+import processArgs from '../utils/process-args';
 
 export class CurlyComponentSyntax extends StatementSyntax {
   constructor({ args, definition, templates }) {
@@ -18,21 +18,6 @@ export class CurlyComponentSyntax extends StatementSyntax {
   }
 }
 
-function attrsToProps(keys, attrs) {
-  let merged = new EmptyObject();
-
-  merged.attrs = attrs;
-
-  for (let i = 0, l = keys.length; i < l; i++) {
-    let name = keys[i];
-    let value = attrs[name];
-
-    merged[name] = value;
-  }
-
-  return merged;
-}
-
 class ComponentStateBucket {
   constructor(component, args) {
     this.component = component;
@@ -46,8 +31,7 @@ class CurlyComponentManager {
     let parentView = dynamicScope.view;
 
     let klass = definition.ComponentClass;
-    let attrs = args.named.value();
-    let props = attrsToProps(args.named.keys, attrs);
+    let { attrs, props } = processArgs(args, klass.positionalParams);
 
     props.renderer = parentView.renderer;
 
@@ -135,8 +119,7 @@ class CurlyComponentManager {
     if (!args.tag.validate(argsRevision)) {
       bucket.argsRevision = args.tag.value();
 
-      let attrs = args.named.value();
-      let props = attrsToProps(args.named.keys, attrs);
+      let { attrs, props } = processArgs(args, component.constructor.positionalParams);
 
       let oldAttrs = component.attrs;
       let newAttrs = attrs;

--- a/packages/ember-glimmer/lib/utils/process-args.js
+++ b/packages/ember-glimmer/lib/utils/process-args.js
@@ -1,0 +1,95 @@
+import { assert } from 'ember-metal/debug';
+import assign from 'ember-metal/assign';
+import EmptyObject from 'ember-metal/empty_object';
+
+export default function processArgs(args, positionalParamsDefinition) {
+  let attrs = assign(new EmptyObject(), args.named.value());
+  processPositionalParams(positionalParamsDefinition || [], args.positional, attrs);
+
+  let props = attrsToProps(keysForAttrs(args, positionalParamsDefinition), attrs);
+
+  return { attrs, props };
+}
+
+// Transforms an object of external attributes to internal properties.
+// This means that each key-value pair needs to be accessible both as key and
+// attrs.key
+function attrsToProps(keys, attrs) {
+  let merged = new EmptyObject();
+
+  merged.attrs = attrs;
+
+  for (let i = 0, l = keys.length; i < l; i++) {
+    let name = keys[i];
+    let value = attrs[name];
+
+    merged[name] = value;
+  }
+
+  return merged;
+}
+
+function processPositionalParams(positionalParams, params, attrs) {
+  let isRest = typeof positionalParams === 'string';
+
+  if (isRest) {
+    processRestPositionalParameters(positionalParams, params, attrs);
+  } else {
+    processNamedPositionalParameters(positionalParams, params, attrs);
+  }
+}
+
+function processNamedPositionalParameters(positionalParams, params, attrs) {
+  let limit = Math.min(params.length, positionalParams.length);
+
+  for (let i = 0; i < limit; i++) {
+    let param = params.at(i).value();
+
+    assert(`You cannot specify both a positional param (at position ${i}) and the hash argument \`${positionalParams[i]}\`.`,
+           !(positionalParams[i] in attrs));
+
+    attrs[positionalParams[i]] = param;
+  }
+}
+
+function processRestPositionalParameters(positionalParamsName, params, attrs) {
+  let nameInAttrs = positionalParamsName in attrs;
+
+  // when no params are used, do not override the specified `attrs.stringParamName` value
+  if (params.length === 0 && nameInAttrs) {
+    return;
+  }
+
+  // If there is already an attribute for that variable, do nothing
+  assert(`You cannot specify positional parameters and the hash argument \`${positionalParamsName}\`.`,
+         !nameInAttrs);
+
+  attrs[positionalParamsName] = params.value();
+}
+
+// Keys to copy from named arguments
+function keysForAttrs(args, posParamsDefinition) {
+  let namedKeys = args.named.keys;
+  let posKeys = keysForPositionalParameters(args, posParamsDefinition);
+
+  return namedKeys.concat(posKeys);
+}
+
+// Keys to copy for positional arguments
+function keysForPositionalParameters(args, posParamsDefinition) {
+  let numberOfPosParams = args.positional.length;
+  if (numberOfPosParams === 0) {
+    // If there are no positional parameters passed, returned an empty array
+    return [];
+  } else if (typeof posParamsDefinition === 'string') {
+    // If there are any positional parameter and we are receiving a rest type
+    // positional parameter, then return an array with the only key.
+    return [posParamsDefinition];
+  } else {
+    // If we have received any positional parameter, return the keys for those
+    // parameters we have received.
+    let posEndIndex = Math.min(posParamsDefinition.length, args.positional.length);
+    return posParamsDefinition.slice(0, posEndIndex);
+  }
+}
+

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -1384,7 +1384,7 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     this.assertText('In layout - someProp: something here - In template');
   }
 
-  ['@htmlbars static arbitrary number of positional parameters'](assert) {
+  ['@test static arbitrary number of positional parameters'](assert) {
     this.registerComponent('sample-component', {
       ComponentClass: Component.extend().reopenClass({
         positionalParams: 'names'
@@ -1396,23 +1396,20 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     });
 
     this.render(strip`
-      {{sample-component "Foo" 4 "Bar" id="args-3"}}
-      {{sample-component "Foo" 4 "Bar" 5 "Baz" id="args-5"}}
-      {{component "sample-component" "Foo" 4 "Bar" 5 "Baz" id="helper"}}`
+      {{sample-component "Foo" 4 "Bar" elementId="args-3"}}
+      {{sample-component "Foo" 4 "Bar" 5 "Baz" elementId="args-5"}}`
     );
 
     assert.equal(this.$('#args-3').text(), 'Foo4Bar');
     assert.equal(this.$('#args-5').text(), 'Foo4Bar5Baz');
-    assert.equal(this.$('#helper').text(), 'Foo4Bar5Baz');
 
     this.runTask(() => this.rerender());
 
     assert.equal(this.$('#args-3').text(), 'Foo4Bar');
     assert.equal(this.$('#args-5').text(), 'Foo4Bar5Baz');
-    assert.equal(this.$('#helper').text(), 'Foo4Bar5Baz');
   }
 
-  ['@htmlbars arbitrary positional parameter conflict with hash parameter is reported']() {
+  ['@test arbitrary positional parameter conflict with hash parameter is reported']() {
     this.registerComponent('sample-component', {
       ComponentClass: Component.extend().reopenClass({
         positionalParams: 'names'
@@ -1468,7 +1465,7 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     this.assertText('Foo4Bar');
   }
 
-  ['@htmlbars can use hash parameter instead of positional param'](assert) {
+  ['@test can use hash parameter instead of positional param'](assert) {
     this.registerComponent('sample-component', {
       ComponentClass: Component.extend().reopenClass({
         positionalParams: ['first', 'second']
@@ -1476,10 +1473,11 @@ moduleFor('Components test: curly components', class extends RenderingTest {
       template: '{{first}} - {{second}}'
     });
 
+    // TODO: Fix when id is implemented
     this.render(strip`
-      {{sample-component "one" "two" id="two-positional"}}
-      {{sample-component "one" second="two" id="one-positional"}}
-      {{sample-component first="one" second="two" id="no-positional"}}`);
+      {{sample-component "one" "two" elementId="two-positional"}}
+      {{sample-component "one" second="two" elementId="one-positional"}}
+      {{sample-component first="one" second="two" elementId="no-positional"}}`);
 
     assert.equal(this.$('#two-positional').text(), 'one - two');
     assert.equal(this.$('#one-positional').text(), 'one - two');
@@ -1492,7 +1490,7 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     assert.equal(this.$('#no-positional').text(), 'one - two');
   }
 
-  ['@htmlbars dynamic arbitrary number of positional parameters'](assert) {
+  ['@test dynamic arbitrary number of positional parameters'](assert) {
     this.registerComponent('sample-component', {
       ComponentClass: Component.extend().reopenClass({
         positionalParams: 'n'
@@ -1503,40 +1501,33 @@ moduleFor('Components test: curly components', class extends RenderingTest {
         {{/each}}`
     });
 
-    this.render(strip`
-      {{sample-component user1 user2 id="direct"}}
-      {{component "sample-component" user1 user2 id="helper"}}`,
+    this.render(`{{sample-component user1 user2}}`,
       {
         user1: 'Foo',
         user2: 4
       }
     );
 
-    assert.equal(this.$('#direct').text(), 'Foo4', 'direct');
-    assert.equal(this.$('#helper').text(), 'Foo4', 'helper');
+    this.assertText('Foo4');
 
     this.runTask(() => this.rerender());
 
-    assert.equal(this.$('#direct').text(), 'Foo4', 'direct');
-    assert.equal(this.$('#helper').text(), 'Foo4', 'helper');
+    this.assertText('Foo4');
 
     this.runTask(() => this.context.set('user1', 'Bar'));
 
-    assert.equal(this.$('#direct').text(), 'Bar4', 'direct');
-    assert.equal(this.$('#helper').text(), 'Bar4', 'helper');
+    this.assertText('Bar4');
 
     this.runTask(() => this.context.set('user2', '5'));
 
-    assert.equal(this.$('#direct').text(), 'Bar5', 'direct');
-    assert.equal(this.$('#helper').text(), 'Bar5', 'helper');
+    this.assertText('Bar5');
 
     this.runTask(() => {
       this.context.set('user1', 'Foo');
       this.context.set('user2', 4);
     });
 
-    assert.equal(this.$('#direct').text(), 'Foo4', 'direct');
-    assert.equal(this.$('#helper').text(), 'Foo4', 'helper');
+    this.assertText('Foo4');
   }
 
   ['@test with ariaRole specified']() {
@@ -1683,7 +1674,7 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     this.assertText('In block No Block Param!');
   }
 
-  ['@htmlbars static named positional parameters']() {
+  ['@test static named positional parameters']() {
     this.registerComponent('sample-component', {
       ComponentClass: Component.extend().reopenClass({
         positionalParams: ['name', 'age']
@@ -1700,7 +1691,7 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     this.assertText('Quint4');
   }
 
-  ['@htmlbars dynamic named positional parameters']() {
+  ['@test dynamic named positional parameters']() {
     this.registerComponent('sample-component', {
       ComponentClass: Component.extend().reopenClass({
         positionalParams: ['name', 'age']
@@ -1735,7 +1726,7 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     this.assertText('Quint4');
   }
 
-  ['@htmlbars if a value is passed as a non-positional parameter, it raises an assertion']() {
+  ['@test if a value is passed as a non-positional parameter, it raises an assertion']() {
     this.registerComponent('sample-component', {
       ComponentClass: Component.extend().reopenClass({
         positionalParams: ['name']


### PR DESCRIPTION
This PR implements positional parameters in Glimmer 2.
- [x] Basic processing of positional parameters
- [x] Query parameters in dynamic components (`{{component "x-component" "a" "b"`}}`)
- [x] Improve processing based on Glimmer 2 positional args API.
- [x] Pass all tests that currently pass in `@htmlbars`.
- [x] If `id` arg is implemented before closing this PR, change tests back to `id="x"`.
