### PR TITLE
[Bugfix] Using simple comparison for Ember.computed.max, min #13387

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -110,7 +110,7 @@ export function sum(dependentKey) {
   @public
 */
 export function max(dependentKey) {
-  return reduceMacro(dependentKey, (max, item) => Math.max(max, item), -Infinity);
+  return reduceMacro(dependentKey, (max, item) => item > max ? item : max, -Infinity);
 }
 
 /**
@@ -148,7 +148,7 @@ export function max(dependentKey) {
   @public
 */
 export function min(dependentKey) {
-  return reduceMacro(dependentKey, (min, item) => Math.min(min, item), Infinity);
+  return reduceMacro(dependentKey, (min, item) => item < min ? item : min, Infinity);
 }
 
 /**

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -1466,6 +1466,34 @@ QUnit.test('max recomputes when the current max is removed', function() {
   equal(obj.get('max'), 1, 'max is recomputed when the current max is removed');
 });
 
+QUnit.test('max returns a Date type when all inputs are dates', function() {
+  var items = obj.get('items');
+  items.removeObject(1);
+  items.removeObject(2);
+  items.removeObject(3);
+
+  var date1 = new Date('09 Jul 2017');
+  var date2 = new Date('10 Sep 2016');
+  var date3 = new Date('11 Aug 2016');
+  var date4 = new Date('10 Aug 2016');
+
+  items.pushObject(date1);
+  items.pushObject(date2);
+  items.pushObject(date3);
+  items.pushObject(date4);
+
+  ok(obj.get('max') instanceof Date, 'max of dates returns a Date instance');
+  equal(obj.get('max').getTime(), date1.getTime(), 'max of dates has a correct value');
+
+  items.removeObject(date1);
+
+  equal(obj.get('max').getTime(), date2.getTime(), 'max of dates updates its value when the maximum changes');
+
+  items.removeObject(date4);
+
+  equal(obj.get('max').getTime(), date2.getTime(), 'max of dates does not update what the non maximal date is removed');
+});
+
 QUnit.module('min', {
   setup() {
     obj = EmberObject.extend({
@@ -1509,6 +1537,34 @@ QUnit.test('min recomputes when the current min is removed', function() {
   items.removeObject(1);
 
   equal(obj.get('min'), 3, 'min is recomputed when the current min is removed');
+});
+
+QUnit.test('min returns a Date type when all inputs are dates', function() {
+  var items = obj.get('items');
+  items.removeObject(1);
+  items.removeObject(2);
+  items.removeObject(3);
+
+  var date1 = new Date('10 Aug 2016');
+  var date2 = new Date('11 Aug 2016');
+  var date3 = new Date('10 Sep 2016');
+  var date4 = new Date('09 Jul 2017');
+
+  items.pushObject(date1);
+  items.pushObject(date2);
+  items.pushObject(date3);
+  items.pushObject(date4);
+
+  ok(obj.get('min') instanceof Date, 'min of dates returns a Date instance');
+  equal(obj.get('min').getTime(), date1.getTime(), 'min of dates has a correct value');
+
+  items.removeObject(date1);
+
+  equal(obj.get('min').getTime(), date2.getTime(), 'min of dates updates its value when the minimum changes');
+
+  items.removeObject(date4);
+
+  equal(obj.get('min').getTime(), date2.getTime(), 'min of dates does not update what the non minmal date is removed');
 });
 
 QUnit.module('Ember.arrayComputed - mixed sugar', {


### PR DESCRIPTION
Using simple comparison instead of Math.max, Math.min for the implementation of Ember.computed.max, Ember.computed.min. issue #13387
This approach is the one used for _.min, _.max.
When computing the min / max of dates, the result will be a Date instance instead of a Number.
