### PR TITLE
Add node test for protected bound attrs with no value

### DIFF
--- a/tests/node/component-rendering-test.js
+++ b/tests/node/component-rendering-test.js
@@ -44,6 +44,17 @@ QUnit.test("Component with dynamic value", function(assert) {
   assert.ok(html.match(/<h1>Hello World<\/h1>/));
 });
 
+QUnit.test("Ensure undefined attributes requiring protocol sanitization do not error", function(assert) {
+  var component = buildComponent('', {
+    tagName: 'link',
+    attributeBindings: ['href', 'rel'],
+    rel: 'canonical'
+  });
+
+  var html = renderComponent(component);
+  assert.ok(html.match(/rel="canonical"/));
+});
+
 function buildComponent(template, props) {
   var Component = Ember.Component.extend({
     renderer: new Ember._Renderer(new DOMHelper(new SimpleDOM.Document())),


### PR DESCRIPTION
See https://github.com/tildeio/htmlbars/pull/455

This test demonstrates that with the current version of htmlbars bound
view attributes requiring sanitization will throw an error in node if
their value is undefined.
