### PR TITLE
Expose Ember.lookup for compatibility with add-ons using it.

### DIFF
--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -379,6 +379,17 @@ Object.defineProperty(Ember, 'ENV', {
 });
 
 /**
+  The context that Ember searches for namespace instances on.
+
+  @private
+ */
+Object.defineProperty(Ember, 'lookup', {
+  get: () => context.lookup,
+  set: value => context.lookup = value,
+  enumerable: false
+});
+
+/**
   A function may be assigned to `Ember.onerror` to be called when Ember
   internals encounter an error. This is useful for specialized error handling
   and reporting code.


### PR DESCRIPTION
We will add deprecation in a followup PR, this is just to stop breaking add-ons using it.

Fixes #13352.
