### PR TITLE
[FEATURE beta] Refactor auto mut in closure components to use traverse

### DIFF
--- a/packages/ember-template-compiler/lib/plugins/transform-closure-component-attrs-into-mut.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-closure-component-attrs-into-mut.js
@@ -10,40 +10,17 @@ function TransformClosureComponentAttrsIntoMut() {
 */
 TransformClosureComponentAttrsIntoMut.prototype.transform = function TransformClosureComponentAttrsIntoMut_transform(ast) {
   let b = this.syntax.builders;
-  let walker = new this.syntax.Walker();
 
-  walker.visit(ast, function(node) {
-    if (validate(node)) {
-      processExpression(b, node);
+  this.syntax.traverse(ast, {
+    SubExpression: function(node) {
+      if (isComponentClosure(node)) {
+        mutParameters(b, node);
+      }
     }
   });
 
   return ast;
 };
-
-function processExpression(builder, node) {
-  processSubExpressionsInNode(builder, node);
-
-  if (isComponentClosure(node)) {
-    mutParameters(builder, node);
-  }
-}
-
-function processSubExpressionsInNode(builder, node) {
-  for (let i = 0; i < node.params.length; i++) {
-    if (node.params[i].type === 'SubExpression') {
-      processExpression(builder, node.params[i]);
-    }
-  }
-
-  each(node.hash.pairs, function(pair) {
-    let { value } = pair;
-
-    if (value.type === 'SubExpression') {
-      processExpression(builder, value);
-    }
-  });
-}
 
 function isComponentClosure(node) {
   return node.type === 'SubExpression' && node.path.original === 'component';
@@ -63,10 +40,6 @@ function mutParameters(builder, node) {
       pair.value = builder.sexpr(builder.path('@mut'), [pair.value]);
     }
   });
-}
-
-function validate(node) {
-  return node.type === 'BlockStatement' || node.type === 'MustacheStatement';
 }
 
 function each(list, callback) {


### PR DESCRIPTION
When adding the plugin for adding mut to contextual components I did not know
about `this.syntax.traverse` so I had to rely on a hack on `walker.visit`
creating a fairly complicated code.

This PR simplifies that code while keeping the tests green.
