### PR TITLE
[BUGFIX beta] Change error message when Ember.computed.or contains a space

### DIFF
--- a/packages/ember-metal/lib/expand_properties.js
+++ b/packages/ember-metal/lib/expand_properties.js
@@ -38,7 +38,8 @@ var END_WITH_EACH_REGEX = /\.@each$/;
 export default function expandProperties(pattern, callback) {
   assert('A computed property key must be a string', typeof pattern === 'string');
   assert(
-    'Brace expanded properties cannot contain spaces, e.g. "user.{firstName, lastName}" should be "user.{firstName,lastName}"',
+    'Dependent keys passed to Ember.computed.or() cannot contain spaces,' +
+      ' e.g. Ember.computed.or("foo bar", "baz") should be Ember.computed.or("foobar", "baz")',
     pattern.indexOf(' ') === -1
   );
 

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -487,7 +487,7 @@ testBoth('throws assertion if brace expansion notation has spaces', function (ge
       count++;
       return 'roo ' + count;
     }).property('fee.{bar, baz,bop , }'));
-  }, /cannot contain spaces/);
+  }, /Dependent keys passed to Ember\.computed\.or\(\) cannot contain spaces/);
 });
 
 // ..........................................................

--- a/packages/ember-metal/tests/expand_properties_test.js
+++ b/packages/ember-metal/tests/expand_properties_test.js
@@ -88,5 +88,5 @@ QUnit.test('A pattern must not contain a space', function() {
 
   expectAssertion(function() {
     expandProperties('a, b', addProperty);
-  }, /Brace expanded properties cannot contain spaces, e.g. "user.{firstName, lastName}" should be "user.{firstName,lastName}"/);
+  }, /Dependent keys passed to Ember\.computed\.or\(\) cannot contain spaces/);
 });


### PR DESCRIPTION
Fixes #13176 by returning a less confusing error message and example.
