### PR TITLE
[GLIMMER2] Update glimmer version and un-gate helper element form tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "express": "^4.5.0",
     "finalhandler": "^0.4.0",
     "github": "^0.2.3",
-    "glimmer-engine": "tildeio/glimmer#8182ab3",
+    "glimmer-engine": "tildeio/glimmer#591a188",
     "glob": "^5.0.13",
     "htmlbars": "0.14.16",
     "mocha": "^2.4.5",

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -42,6 +42,9 @@ const builtInHelpers = {
   '-class': classHelper
 };
 
+const builtInModifiers = {
+};
+
 function wrapClassAttribute(args) {
   let hasClass = args.named.has('class');
 
@@ -73,6 +76,7 @@ export default class Environment extends GlimmerEnvironment {
       isSimple,
       isInline,
       isBlock,
+      isModifier,
       key,
       path,
       args,
@@ -96,6 +100,7 @@ export default class Environment extends GlimmerEnvironment {
 
     let nativeSyntax = super.refineStatement(statement);
     assert(`Helpers may not be used in the block form, for example {{#${key}}}{{/${key}}}. Please use a component, or alternatively use the helper in combination with a built-in Ember helper, for example {{#if (${key})}}{{/if}}.`, !nativeSyntax && key && this.hasHelper(key) ? !isBlock : true);
+    assert(`Helpers may not be used in the element form.`, !nativeSyntax && key && this.hasHelper(key) ? !isModifier : true);
     return nativeSyntax;
   }
 
@@ -134,6 +139,15 @@ export default class Environment extends GlimmerEnvironment {
     } else {
       throw new Error(`${name} is not a helper`);
     }
+  }
+
+  hasModifier(name) {
+    return !!builtInModifiers[name[0]];
+  }
+
+  lookupModifier(name) {
+    let modifier = builtInModifiers[name[0]];
+    return modifier;
   }
 
   rootReferenceFor(value) {

--- a/packages/ember-glimmer/tests/integration/helpers/custom-helper-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/custom-helper-test.js
@@ -301,7 +301,7 @@ moduleFor('Helpers test: custom helpers', class extends RenderingTest {
     }, /Helpers may not be used in the block form/);
   }
 
-  ['@htmlbars simple helper not usable within element']() {
+  ['@test simple helper not usable within element']() {
     this.registerHelper('some-helper', () => {});
 
     expectAssertion(() => {
@@ -309,7 +309,7 @@ moduleFor('Helpers test: custom helpers', class extends RenderingTest {
     }, /Helpers may not be used in the element form/);
   }
 
-  ['@htmlbars class-based helper not usable within element']() {
+  ['@test class-based helper not usable within element']() {
     this.registerHelper('some-helper', {
       compute() {
       }


### PR DESCRIPTION
This bumps `glimmer-engine` to the version containing basic support for element modifiers. As a result, we can now detect if helpers are used in element form and throw an error. This also enables the associated test for Glimmer.
