### PR TITLE
[DOC release] Fix computed property syntax with prototype extensions.

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -526,7 +526,7 @@ ComputedPropertyPrototype.teardown = function(obj, keyName) {
   The alternative syntax, with prototype extensions, might look like:
 
   ```js
-  fullName() {
+  fullName: function() {
     return this.get('firstName') + ' ' + this.get('lastName');
   }.property('firstName', 'lastName')
   ```


### PR DESCRIPTION
The previous code was a syntax error since you can't use a shorthand object method as part of a member expression.
