### PR TITLE
router.js: Fixed YUIDoc tag

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -792,15 +792,13 @@ var EmberRouter = EmberObject.extend(Evented, {
   }
 });
 
-/*
-  Helper function for iterating root-ward, starting
-  from (but not including) the provided `originRoute`.
 
-  Returns true if the last callback fired requested
-  to bubble upward.
+// Helper function for iterating root-ward, starting
+// from (but not including) the provided `originRoute`.
 
-  @private
- */
+// Returns true if the last callback fired requested
+// to bubble upward.
+  
 function forEachRouteAbove(originRoute, transition, callback) {
   var handlerInfos = transition.state.handlerInfos;
   var originRouteFound = false;


### PR DESCRIPTION
The `forEachRouteAbove` function is a closure. No need to define it as `@private`: it's not part of the class, cannot be overridden and cannot even be invoked outside the file.

Having a `@private` tag without a `@method`/`@property`/`@event` results in an unnamed, unclassified item appearing in YUIDoc's resulting JSON.
