### PR TITLE
[Glimmer2] Rerender on run loop if data has changed

### DIFF
--- a/packages/ember-glimmer/lib/ember-metal-views/index.js
+++ b/packages/ember-glimmer/lib/ember-metal-views/index.js
@@ -1,6 +1,6 @@
 import { RootReference } from '../utils/references';
 import run from 'ember-metal/run_loop';
-// import { CURRENT_TAG } from 'glimmer-reference';
+import { CURRENT_TAG } from 'glimmer-reference';
 
 class DynamicScope {
   constructor({ view, controller, outletState, isTopLevel }) {
@@ -16,15 +16,15 @@ class DynamicScope {
 }
 
 const RENDERED_ROOTS = [];
-// let LAST_TAG_VALUE;
+let LAST_TAG_VALUE;
 
 function maybeUpdate() {
-  // if (CURRENT_TAG.validate(LAST_TAG_VALUE)) { return; }
+  if (CURRENT_TAG.validate(LAST_TAG_VALUE)) { return; }
   for (let i = 0; i < RENDERED_ROOTS.length; ++i) {
     let view = RENDERED_ROOTS[i];
     view.renderer.rerender(view);
   }
-  // LAST_TAG_VALUE = CURRENT_TAG.value();
+  LAST_TAG_VALUE = CURRENT_TAG.value();
 }
 
 function scheduleMaybeUpdate() {
@@ -32,7 +32,7 @@ function scheduleMaybeUpdate() {
 }
 
 function registerView(view) {
-  // LAST_TAG_VALUE = LAST_TAG_VALUE || CURRENT_TAG.value();
+  LAST_TAG_VALUE = LAST_TAG_VALUE || CURRENT_TAG.value();
   if (!RENDERED_ROOTS.length) {
     run.backburner.on('begin', scheduleMaybeUpdate);
   }

--- a/packages/ember-glimmer/lib/ember-metal-views/index.js
+++ b/packages/ember-glimmer/lib/ember-metal-views/index.js
@@ -28,11 +28,11 @@ function maybeUpdate() {
 }
 
 function scheduleMaybeUpdate() {
+  LAST_TAG_VALUE = CURRENT_TAG.value();
   run.backburner.schedule('render', maybeUpdate);
 }
 
 function registerView(view) {
-  LAST_TAG_VALUE = LAST_TAG_VALUE || CURRENT_TAG.value();
   if (!RENDERED_ROOTS.length) {
     run.backburner.on('begin', scheduleMaybeUpdate);
   }

--- a/packages/ember-glimmer/lib/ember-metal-views/index.js
+++ b/packages/ember-glimmer/lib/ember-metal-views/index.js
@@ -23,6 +23,13 @@ class Scheduler {
     };
   }
 
+  destroy() {
+    if (this._roots.length) {
+      this._roots.splice(0, this._roots.length);
+      run.backburner.off('begin', this._scheduleMaybeUpdate);
+    }
+  }
+
   registerView(view) {
     if (!this._roots.length) {
       run.backburner.on('begin', this._scheduleMaybeUpdate);
@@ -56,6 +63,10 @@ class Renderer {
     this._env = env;
     this._destinedForDOM = destinedForDOM;
     this._scheduler = new Scheduler();
+  }
+
+  destroy() {
+    this._scheduler.destroy();
   }
 
   appendOutletView(view, target) {

--- a/packages/ember-glimmer/tests/utils/test-case.js
+++ b/packages/ember-glimmer/tests/utils/test-case.js
@@ -30,11 +30,4 @@ export class RenderingTest extends AbstractRenderingTest {
     super.render(...args);
     this.renderer._root = this.component;
   }
-
-  runTask(callback) {
-    super.runTask(() => {
-      callback();
-      this.component.rerender();
-    });
-  }
 }


### PR DESCRIPTION
Marking an object as dirty kicks off a run loop if one has not already been started. At the start of every run loop, a task is scheduled on the render queue to rerender the main view if any changes have occurred.

Tested by disabling the automatic invocation of manual rerendering in the glimmer tests.

Will require ember-dev to be updated since this invalidates the assumption that a run loop should never be automatically started inside a test.
