### PR TITLE
[BUGFIX beta] Fix positional parameters when used with component helper

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -1408,12 +1408,12 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     this.runTask(() => this.context.set('user1', 'Bar'));
 
     assert.equal(this.$('#direct').text(), 'Bar4', 'direct');
-    //assert.equal(this.$('#helper').text(), 'Bar4', 'helper');
+    assert.equal(this.$('#helper').text(), 'Bar4', 'helper');
 
     this.runTask(() => this.context.set('user2', '5'));
 
     assert.equal(this.$('#direct').text(), 'Bar5', 'direct');
-    //assert.equal(this.$('#helper').text(), 'Bar5', 'helper');
+    assert.equal(this.$('#helper').text(), 'Bar5', 'helper');
 
     this.runTask(() => {
       this.context.set('user1', 'Foo');

--- a/packages/ember-glimmer/tests/integration/components/dynamic-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/dynamic-components-test.js
@@ -556,42 +556,50 @@ moduleFor('Components test: dynamic components', class extends RenderingTest {
 
   ['@htmlbars positional parameters does not clash when rendering different components'](assert) {
     this.registerComponent('foo-bar', {
-      template: 'hello {{name}} from foo-bar',
+      template: 'hello {{name}} ({{age}}) from foo-bar',
       ComponentClass: Component.extend().reopenClass({
-        positionalParams: ['name']
+        positionalParams: ['name', 'age']
       })
     });
 
     this.registerComponent('foo-bar-baz', {
-      template: 'hello {{name}} from foo-bar-baz',
+      template: 'hello {{name}} ({{age}}) from foo-bar-baz',
       ComponentClass: Component.extend().reopenClass({
-        positionalParams: ['name']
+        positionalParams: ['name', 'age']
       })
     });
 
-    this.render('{{component componentName name}}', { componentName: 'foo-bar', name: 'Alex' });
+    this.render('{{component componentName name age}}', {
+      componentName: 'foo-bar',
+      name: 'Alex',
+      age: 29
+    });
 
-    this.assertComponentElement(this.firstChild, { content: 'hello Alex from foo-bar' });
+    this.assertComponentElement(this.firstChild, { content: 'hello Alex (29) from foo-bar' });
 
     this.runTask(() => this.rerender());
 
-    this.assertComponentElement(this.firstChild, { content: 'hello Alex from foo-bar' });
+    this.assertComponentElement(this.firstChild, { content: 'hello Alex (29) from foo-bar' });
 
     this.runTask(() => set(this.context, 'name', 'Ben'));
 
-    // TODO: this fails in htmlbars - https://github.com/emberjs/ember.js/issues/13158
-    // this.assertComponentElement(this.firstChild, { content: 'hello Ben from foo-bar' });
+    this.assertComponentElement(this.firstChild, { content: 'hello Ben (29) from foo-bar' });
+
+    this.runTask(() => set(this.context, 'age', 22));
+
+    this.assertComponentElement(this.firstChild, { content: 'hello Ben (22) from foo-bar' });
 
     this.runTask(() => set(this.context, 'componentName', 'foo-bar-baz'));
 
-    this.assertComponentElement(this.firstChild, { content: 'hello Ben from foo-bar-baz' });
+    this.assertComponentElement(this.firstChild, { content: 'hello Ben (22) from foo-bar-baz' });
 
     this.runTask(() => {
       set(this.context, 'componentName', 'foo-bar');
       set(this.context, 'name', 'Alex');
+      set(this.context, 'age', 29);
     });
 
-    this.assertComponentElement(this.firstChild, { content: 'hello Alex from foo-bar' });
+    this.assertComponentElement(this.firstChild, { content: 'hello Alex (29) from foo-bar' });
   }
 
   ['@htmlbars positional parameters does not pollute the attributes when changing components'](assert) {

--- a/packages/ember-htmlbars/lib/hooks/component.js
+++ b/packages/ember-htmlbars/lib/hooks/component.js
@@ -10,6 +10,7 @@ import {
   CONTAINS_DASH_CACHE,
   CONTAINS_DOT_CACHE
 } from 'ember-htmlbars/system/lookup-helper';
+import extractPositionalParams from 'ember-htmlbars/utils/extract-positional-params';
 import {
   COMPONENT_PATH,
   COMPONENT_HASH,
@@ -55,6 +56,7 @@ export default function componentHook(renderNode, env, scope, _tagName, params, 
   if (state.manager) {
     let templateMeta = state.manager.block.template.meta;
     env.meta.moduleName = (templateMeta && templateMeta.moduleName) || (env.meta && env.meta.moduleName);
+    extractPositionalParams(renderNode, state.manager.component.constructor, params, attrs, false);
     state.manager.rerender(env, attrs, visitor);
     return;
   }

--- a/packages/ember-htmlbars/lib/utils/extract-positional-params.js
+++ b/packages/ember-htmlbars/lib/utils/extract-positional-params.js
@@ -2,38 +2,38 @@ import { assert } from 'ember-metal/debug';
 import { Stream } from 'ember-metal/streams/stream';
 import { readArray } from 'ember-metal/streams/utils';
 
-export default function extractPositionalParams(renderNode, component, params, attrs) {
+export default function extractPositionalParams(renderNode, component, params, attrs, raiseAssertions = true) {
   let positionalParams = component.positionalParams;
 
   if (positionalParams) {
-    processPositionalParams(renderNode, positionalParams, params, attrs);
+    processPositionalParams(renderNode, positionalParams, params, attrs, raiseAssertions);
   }
 }
 
-export function processPositionalParams(renderNode, positionalParams, params, attrs) {
+export function processPositionalParams(renderNode, positionalParams, params, attrs, raiseAssertions = true) {
   let isRest = typeof positionalParams === 'string';
 
   if (isRest) {
-    processRestPositionalParameters(renderNode, positionalParams, params, attrs);
+    processRestPositionalParameters(renderNode, positionalParams, params, attrs, raiseAssertions);
   } else {
-    processNamedPositionalParameters(renderNode, positionalParams, params, attrs);
+    processNamedPositionalParameters(renderNode, positionalParams, params, attrs, raiseAssertions);
   }
 }
 
-function processNamedPositionalParameters(renderNode, positionalParams, params, attrs) {
+function processNamedPositionalParameters(renderNode, positionalParams, params, attrs, raiseAssertions) {
   let limit = Math.min(params.length, positionalParams.length);
 
   for (let i = 0; i < limit; i++) {
     let param = params[i];
 
     assert(`You cannot specify both a positional param (at position ${i}) and the hash argument \`${positionalParams[i]}\`.`,
-           !(positionalParams[i] in attrs));
+           !(positionalParams[i] in attrs && raiseAssertions));
 
     attrs[positionalParams[i]] = param;
   }
 }
 
-function processRestPositionalParameters(renderNode, positionalParamsName, params, attrs) {
+function processRestPositionalParameters(renderNode, positionalParamsName, params, attrs, raiseAssertions) {
   let nameInAttrs = positionalParamsName in attrs;
 
   // when no params are used, do not override the specified `attrs.stringParamName` value
@@ -43,7 +43,7 @@ function processRestPositionalParameters(renderNode, positionalParamsName, param
 
   // If there is already an attribute for that variable, do nothing
   assert(`You cannot specify positional parameters and the hash argument \`${positionalParamsName}\`.`,
-         !nameInAttrs);
+         !(nameInAttrs && raiseAssertions));
 
   let paramsStream = new Stream(() => {
     return readArray(params.slice(0));


### PR DESCRIPTION
Updates positional parameters when component is invoked with the component
helper.

Uncomments the test, as asked in #13158.

Fixes #13158 in `htmlbars`
