### PR TITLE
Bump glimmer-engine version and re-export UNDEFINED and NULL references

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "express": "^4.5.0",
     "finalhandler": "^0.4.0",
     "github": "^0.2.3",
-    "glimmer-engine": "tildeio/glimmer#2c22999",
+    "glimmer-engine": "tildeio/glimmer#741c98f",
     "glob": "^5.0.13",
     "htmlbars": "0.14.16",
     "mocha": "^2.4.5",

--- a/packages/ember-glimmer/lib/utils/references.js
+++ b/packages/ember-glimmer/lib/utils/references.js
@@ -1,7 +1,7 @@
 import { get } from 'ember-metal/property_get';
 import { tagFor } from 'ember-metal/tags';
 import { CURRENT_TAG, CONSTANT_TAG, VOLATILE_TAG, ConstReference, DirtyableTag, UpdatableTag, combine, isConst, referenceFromParts } from 'glimmer-reference';
-import { ConditionalReference as GlimmerConditionalReference } from 'glimmer-runtime';
+import { ConditionalReference as GlimmerConditionalReference, UNDEFINED_REFERENCE } from 'glimmer-runtime';
 import emberToBool from './to-bool';
 import { RECOMPUTE_TAG } from '../helper';
 import { dasherize } from 'ember-runtime/system/string';
@@ -24,8 +24,7 @@ export class PrimitiveReference extends ConstReference {
   }
 }
 
-export const NULL_REFERENCE = new ConstReference(null);
-export const UNDEFINED_REFERENCE = new ConstReference(undefined);
+export { NULL_REFERENCE, UNDEFINED_REFERENCE } from 'glimmer-runtime';
 
 // @abstract
 // @implements PathReference


### PR DESCRIPTION
This bumps up the version of glimmer-engine so that the exported `UNDEFINED_REFERENCE` and `NULL_REFERENCE` can be used.
