### PR TITLE
[BUGFIX beta] Partially revert #12229 and add a test for #13432

### DIFF
--- a/packages/ember-routing-htmlbars/tests/helpers/link-to_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/link-to_test.js
@@ -161,4 +161,16 @@ QUnit.test('able to safely extend the built-in component and use the normal path
   equal(view.$().text(), 'my custom link-to component', 'rendered a custom-link-to component');
 });
 
+QUnit.test('[GH#13432] able to safely extend the built-in component and invoke it inline', function() {
+  view = EmberView.create({
+    [OWNER]: owner,
+    title: 'my custom link-to component',
+    template: compile('{{custom-link-to view.title \'index\'}}')
+  });
+
+  runAppend(view);
+
+  equal(view.$().text(), 'my custom link-to component', 'rendered a custom-link-to component');
+});
+
 }

--- a/packages/ember-routing-views/lib/components/link-to.js
+++ b/packages/ember-routing-views/lib/components/link-to.js
@@ -323,6 +323,7 @@ import EmberComponent from 'ember-views/components/component';
 import inject from 'ember-runtime/inject';
 import 'ember-runtime/system/service'; // creates inject.service
 import ControllerMixin from 'ember-runtime/mixins/controller';
+import { HAS_BLOCK } from 'ember-htmlbars/node-managers/component-node-manager';
 import htmlbarsTemplate from 'ember-htmlbars/templates/link-to';
 import require from 'require';
 
@@ -666,7 +667,7 @@ let LinkComponent = EmberComponent.extend({
     if (lastParam && lastParam.isQueryParams) {
       params.pop();
     }
-    let onlyQueryParamsSupplied = (params.length === 0);
+    let onlyQueryParamsSupplied = (this[HAS_BLOCK] ? params.length === 0 : params.length === 1);
     if (onlyQueryParamsSupplied) {
       return get(this, '_routing.currentRouteName');
     }
@@ -777,7 +778,10 @@ let LinkComponent = EmberComponent.extend({
     }
 
     // Process the positional arguments, in order.
-    // 1. Inline link title was shifted off by AST.
+    // 1. Inline link title comes first, if present.
+    if (!this[HAS_BLOCK]) {
+      this.set('linkTitle', params.shift());
+    }
 
     // 2. `targetRouteName` is now always at index 0.
     this.set('targetRouteName', params[0]);


### PR DESCRIPTION
This PR partially reverts #12229 given that it made the inline form of
components extending from `LinkTo` impossible.

Beware that matching the exact behaviour is not there yet (as it wasn't
before #12229) given that `{{{link-to title route}}}` would unescape `title`
while `{{{my-link-to title route}}}` would not. This behaviour was not working
before and therefore is not working after this revert.

This PR does not address whether the inline form for `link-to` should be
deprecated or not.
