### PR TITLE
Update sauce labs browser listing.

### DIFF
--- a/testem.dist.json
+++ b/testem.dist.json
@@ -10,15 +10,15 @@
       "protocol": "tap"
     },
     "SL_Firefox_Current": {
-      "command": "npm run sauce:launch -- -b firefox -v latest --no-ct -u '<url>'",
+      "command": "npm run sauce:launch -- -b firefox -v 45 --no-ct -u '<url>'",
       "protocol": "tap"
     },
     "SL_Safari_Current": {
-      "command": "npm run sauce:launch -- -b safari -v 8 --no-ct -u '<url>'",
+      "command": "npm run sauce:launch -- -b safari -v 9 --no-ct -u '<url>'",
       "protocol": "tap"
     },
     "SL_Safari_Last": {
-      "command": "npm run sauce:launch -- -b safari -v 7 --no-ct -u '<url>'",
+      "command": "npm run sauce:launch -- -b safari -v 8 --no-ct -u '<url>'",
       "protocol": "tap"
     },
     "SL_MS_Edge": {


### PR DESCRIPTION
- Update Safari_Current to 9 (and Safari_Last to 8).
- Lock Firefox to 45 (`latest` throws errors RE: `The environment you
  requested was unavailable`).
