### PR TITLE
[Glimmer2] Mark glimmer2 tests on context.isTruthy to be @htmlbars only

### DIFF
--- a/packages/ember-glimmer/lib/utils/references.js
+++ b/packages/ember-glimmer/lib/utils/references.js
@@ -7,14 +7,11 @@ import { ConditionalReference as GlimmerConditionalReference, NULL_REFERENCE, UN
 import emberToBool from './to-bool';
 import { RECOMPUTE_TAG } from '../helper';
 import { dasherize } from 'ember-runtime/system/string';
-<<<<<<< dc4b60be5849a6dad2cc464822294a435e08e31c
 import { meta as metaFor } from 'ember-metal/meta';
 import { watchKey } from 'ember-metal/watch_key';
 import isEnabled from 'ember-metal/features';
-=======
 import { isProxy } from 'ember-runtime/mixins/-proxy';
 
->>>>>>> [Glimmer2] Mark glimmer2 tests on context.isTruthy to be @htmlbars only
 export const UPDATE = symbol('UPDATE');
 
 // @implements PathReference

--- a/packages/ember-glimmer/lib/utils/references.js
+++ b/packages/ember-glimmer/lib/utils/references.js
@@ -7,21 +7,15 @@ import { ConditionalReference as GlimmerConditionalReference, NULL_REFERENCE, UN
 import emberToBool from './to-bool';
 import { RECOMPUTE_TAG } from '../helper';
 import { dasherize } from 'ember-runtime/system/string';
+<<<<<<< dc4b60be5849a6dad2cc464822294a435e08e31c
 import { meta as metaFor } from 'ember-metal/meta';
 import { watchKey } from 'ember-metal/watch_key';
 import isEnabled from 'ember-metal/features';
-export const UPDATE = symbol('UPDATE');
+=======
+import { isProxy } from 'ember-runtime/mixins/-proxy';
 
-// FIXME: fix tests that uses a "fake" proxy (i.e. a POJOs that "happen" to
-// have an `isTruthy` property on them). This is not actually supported –
-// we should fix the tests to use an actual proxy. When that's done, we should
-// remove this and use the real `isProxy` from `ember-metal`.
-//
-// import { isProxy } from 'ember-metal/-proxy';
-//
-function isProxy(obj) {
-  return (obj && typeof obj === 'object' && 'isTruthy' in obj);
-}
+>>>>>>> [Glimmer2] Mark glimmer2 tests on context.isTruthy to be @htmlbars only
+export const UPDATE = symbol('UPDATE');
 
 // @implements PathReference
 export class PrimitiveReference extends ConstReference {

--- a/packages/ember-glimmer/tests/integration/syntax/with-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/with-test.js
@@ -167,13 +167,9 @@ moduleFor('Syntax test: {{#with as}}', class extends TogglingSyntaxConditionalsT
 
     this.assertText('Yehuda Katz');
 
-    this.runTask(() => set(this.context, 'proxyThing.isTruthy', false));
+    this.runTask(() => set(this.context, 'proxyThing.content', { name: 'Godfrey Chan' }));
 
-    this.assertText('');
-
-    this.runTask(() => set(this.context, 'proxyThing.name', 'Godfrey Chan'));
-
-    this.assertText('');
+    this.assertText('Godfrey Chan');
 
     this.runTask(() => set(this.context, 'proxyThing', ObjectProxy.create({ content: { name: 'Tom Dale' } })));
 

--- a/packages/ember-glimmer/tests/integration/syntax/with-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/with-test.js
@@ -4,6 +4,7 @@ import { A as emberA } from 'ember-runtime/system/native_array';
 import { moduleFor, RenderingTest } from '../../utils/test-case';
 import { TogglingSyntaxConditionalsTest } from '../../utils/shared-conditional-tests';
 import { strip } from '../../utils/abstract-test-case';
+import ObjectProxy from 'ember-runtime/system/object_proxy';
 
 moduleFor('Syntax test: {{#with}}', class extends TogglingSyntaxConditionalsTest {
 
@@ -153,7 +154,7 @@ moduleFor('Syntax test: {{#with as}}', class extends TogglingSyntaxConditionalsT
 
   ['@test can access alias of a proxy']() {
     this.render(`{{#with proxyThing as |person|}}{{person.name}}{{/with}}`, {
-      proxyThing: { isTruthy: true, name: 'Tom Dale' }
+      proxyThing: ObjectProxy.create({ content: { name: 'Tom Dale' } })
     });
 
     this.assertText('Tom Dale');
@@ -174,7 +175,7 @@ moduleFor('Syntax test: {{#with as}}', class extends TogglingSyntaxConditionalsT
 
     this.assertText('');
 
-    this.runTask(() => set(this.context, 'proxyThing', { isTruthy: true, name: 'Tom Dale' }));
+    this.runTask(() => set(this.context, 'proxyThing', ObjectProxy.create({ content: { name: 'Tom Dale' } })));
 
     this.assertText('Tom Dale');
   }

--- a/packages/ember-glimmer/tests/utils/shared-conditional-tests.js
+++ b/packages/ember-glimmer/tests/utils/shared-conditional-tests.js
@@ -351,13 +351,13 @@ export const ObjectTestCases = {
     });
 
     this.assertText('T1T2F3');
-  }
+  },
 
   ['@test setting the isTruthy property of an object proxy overrides its truthiness regardless of its content']() {
     this.renderValues(
       ObjectProxy.create({ content: {} }),
       EmberObject.create({ content: false, isTruthy: true }),
-      ObjectProxy.create()
+      ObjectProxy.create({ content: null })
     );
 
     this.assertText('T1T2F3');
@@ -390,9 +390,9 @@ export const ObjectTestCases = {
     this.assertText('T1T2T3');
 
     this.runTask(() => {
-      set(this.context, 'cond1.content', undefined);
-      set(this.context, 'cond2.content', undefined);
-      set(this.context, 'cond3.content', undefined);
+      set(this.context, 'cond1.content', null);
+      set(this.context, 'cond2.content', null);
+      set(this.context, 'cond3.content', null);
     });
 
     this.assertText('T1T2F3');
@@ -400,7 +400,7 @@ export const ObjectTestCases = {
     this.runTask(() => {
       set(this.context, 'cond1', ObjectProxy.create({ content: {} }));
       set(this.context, 'cond2', EmberObject.create({ content: true, isTruthy: true }));
-      set(this.context, 'cond3', ObjectProxy.create({ content: [] }));
+      set(this.context, 'cond3', ObjectProxy.create({ content: null }));
     });
 
     this.assertText('T1T2F3');

--- a/packages/ember-glimmer/tests/utils/shared-conditional-tests.js
+++ b/packages/ember-glimmer/tests/utils/shared-conditional-tests.js
@@ -255,7 +255,8 @@ export class BasicConditionalsTest extends AbstractConditionalsTest {
 // Testing behaviors related to objects, object proxies, `{ isTruthy: (true|false) }`, etc
 export const ObjectTestCases = {
 
-  ['@test it tests for `isTruthy` if available']() {
+  // No longer supported for Glimmer2, since contexts are always components
+  ['@htmlbars it tests for `isTruthy` if available']() {
     this.renderValues({ isTruthy: this.truthyValue }, { isTruthy: this.falsyValue });
 
     this.assertText('T1F2');
@@ -492,7 +493,7 @@ applyMixins(TogglingConditionalsTest,
     0,
     [],
     emberA(),
-    EmberObject.create({ isTruthy: false })
+    ObjectProxy.create({ isTruthy: false })
   ]),
 
   new IsTruthyGenerator([
@@ -509,7 +510,7 @@ applyMixins(TogglingConditionalsTest,
     { foo: 'bar' },
     EmberObject.create(),
     EmberObject.create({ foo: 'bar' }),
-    EmberObject.create({ isTruthy: true }),
+    ObjectProxy.create({ content: true }),
     /*jshint -W053 */
     new String('hello'),
     new String(''),
@@ -524,7 +525,7 @@ applyMixins(TogglingConditionalsTest,
     0,
     [],
     emberA(),
-    EmberObject.create({ isTruthy: false })
+    ObjectProxy.create({ isTruthy: false })
   ]),
 
   ObjectTestCases,
@@ -585,7 +586,8 @@ export class TogglingHelperConditionalsTest extends TogglingConditionalsTest {
     this.assertText('T1F2');
   }
 
-  ['@test it tests for `isTruthy` on the context if available']() {
+  // This no longer makes sense for glimmer since `this` refers to the component, which cannot be a proxy
+  ['@htmlbars it tests for `isTruthy` on the context if available']() {
     let template = this.wrappedTemplateFor({ cond: 'this', truthy: '"T1"', falsy: '"F1"' });
 
     this.render(template, { isTruthy: this.truthyValue });
@@ -715,7 +717,8 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
     this.assertText('T1F2');
   }
 
-  ['@test it tests for `isTruthy` on the context if available']() {
+  // This no longer makes sense for glimmer since `this` refers to the component, which cannot be a proxy
+  ['@htmlbars it tests for `isTruthy` on the context if available']() {
     let template = this.wrappedTemplateFor({ cond: 'this', truthy: 'T1', falsy: 'F1' });
 
     this.render(template, { isTruthy: this.truthyValue });

--- a/packages/ember-glimmer/tests/utils/shared-conditional-tests.js
+++ b/packages/ember-glimmer/tests/utils/shared-conditional-tests.js
@@ -255,7 +255,7 @@ export class BasicConditionalsTest extends AbstractConditionalsTest {
 // Testing behaviors related to objects, object proxies, `{ isTruthy: (true|false) }`, etc
 export const ObjectTestCases = {
 
-  // POJOs can no longer mimic Proxies in glimmer2. See proxy tests below.
+  // Marking as @htmlbars since POJOs can no longer masquerade as Proxies in glimmer2. See proxy tests below.
   ['@htmlbars it tests for `isTruthy` if available']() {
     this.renderValues({ isTruthy: this.truthyValue }, { isTruthy: this.falsyValue });
 
@@ -284,7 +284,7 @@ export const ObjectTestCases = {
     this.assertText('T1F2');
   },
 
-  // POJOs can no longer mimic Proxies in glimmer2. See proxy tests below.
+  // Marking as @htmlbars since POJOs can no longer masquerade as Proxies in glimmer2. See proxy tests below.
   ['@htmlbars it tests for `isTruthy` on Ember objects if available']() {
     this.renderValues(
       EmberObject.create({ isTruthy: this.truthyValue }),
@@ -773,7 +773,7 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
     this.assertText('T1F2');
   }
 
-  // This no longer makes sense for glimmer since `this` refers to the component, which is not a proxy
+  // Marking as @htmlbars since this no longer relevant for glimmer as `this` refers to the component, which is never a proxy
   ['@htmlbars it tests for `isTruthy` on the context if available']() {
     let template = this.wrappedTemplateFor({ cond: 'this', truthy: 'T1', falsy: 'F1' });
 


### PR DESCRIPTION
Fixes the FIXME introduced in https://github.com/emberjs/ember.js/pull/13332 

cc @chancancode 
