### PR TITLE
[BUGFIX beta] Remove SafeString deprecation.

### DIFF
--- a/packages/ember-htmlbars/lib/compat.js
+++ b/packages/ember-htmlbars/lib/compat.js
@@ -1,25 +1,20 @@
 import Ember from 'ember-metal/core'; // for Handlebars export
-import { htmlSafe } from 'ember-htmlbars/utils/string';
-import { deprecate } from 'ember-metal/debug';
+import { deprecateFunc } from 'ember-metal/debug';
 import {
+  SafeString,
   escapeExpression
 } from 'ember-htmlbars/utils/string';
 
 var EmberHandlebars = Ember.Handlebars = Ember.Handlebars || {};
 
-EmberHandlebars.SafeString = function(value) {
-  deprecate(
-    'Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe',
-    false,
-    {
-      id: 'ember-htmlbars.ember-handlebars-safestring',
-      until: '3.0.0',
-      url: 'http://emberjs.com/deprecations/v2.x#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring'
-    }
-  );
-
-  return htmlSafe(value);
-};
+EmberHandlebars.SafeString = deprecateFunc(
+  'Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe',
+  {
+    id: 'ember-htmlbars.ember-handlebars-safestring',
+    until: '3.0.0',
+    url: 'http://emberjs.com/deprecations/v2.x#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring'
+  },
+  SafeString);
 
 EmberHandlebars.Utils =  {
   escapeExpression: escapeExpression

--- a/packages/ember-htmlbars/lib/compat.js
+++ b/packages/ember-htmlbars/lib/compat.js
@@ -1,5 +1,4 @@
 import Ember from 'ember-metal/core'; // for Handlebars export
-import { deprecateFunc } from 'ember-metal/debug';
 import {
   SafeString,
   escapeExpression
@@ -7,15 +6,7 @@ import {
 
 var EmberHandlebars = Ember.Handlebars = Ember.Handlebars || {};
 
-EmberHandlebars.SafeString = deprecateFunc(
-  'Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe',
-  {
-    id: 'ember-htmlbars.ember-handlebars-safestring',
-    until: '3.0.0',
-    url: 'http://emberjs.com/deprecations/v2.x#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring'
-  },
-  SafeString);
-
+EmberHandlebars.SafeString = SafeString;
 EmberHandlebars.Utils =  {
   escapeExpression: escapeExpression
 };

--- a/packages/ember-htmlbars/tests/compat/safe_string_test.js
+++ b/packages/ember-htmlbars/tests/compat/safe_string_test.js
@@ -1,9 +1,0 @@
-import EmberHandlebars from 'ember-htmlbars/compat';
-
-QUnit.module('ember-htmlbars: compat - SafeString');
-
-QUnit.test('using new results in a deprecation', function(assert) {
-  expectDeprecation(function() {
-    new EmberHandlebars.SafeString('test');
-  }, 'Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe');
-});

--- a/packages/ember-htmlbars/tests/compat/safe_string_test.js
+++ b/packages/ember-htmlbars/tests/compat/safe_string_test.js
@@ -3,11 +3,7 @@ import EmberHandlebars from 'ember-htmlbars/compat';
 QUnit.module('ember-htmlbars: compat - SafeString');
 
 QUnit.test('using new results in a deprecation', function(assert) {
-  let result;
-
   expectDeprecation(function() {
-    result = new EmberHandlebars.SafeString('<b>test</b>');
+    new EmberHandlebars.SafeString('test');
   }, 'Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe');
-
-  assert.equal(result.toHTML(), '<b>test</b>');
 });


### PR DESCRIPTION
See #13318 for details.

To bring this back, we need to have implemented https://github.com/emberjs/rfcs/issues/139.
