### PR TITLE
Show a better error message for invalid deep nested @each computed properties

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -250,7 +250,8 @@ ComputedPropertyPrototype.property = function() {
     warn(
       `Dependent keys containing @each only work one level deep. ` +
         `You used the key "${property}" which is invalid. ` +
-          `Please create an intermediary computed property.`,
+          `You used: ${property} . ` +
+            `Please create an intermediary computed property.`,
       DEEP_EACH_REGEX.test(property) === false,
       { id: 'ember-metal.computed-deep-each' }
     );

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -89,6 +89,11 @@ QUnit.test('defining a computed property with a dependent key ending with @each 
 });
 
 QUnit.test('defining a computed property with a dependent key more than one level deep beyond @each is not supported', function() {
+  let warning = `Dependent keys containing @each only work one level deep. ` +
+                `You cannot use nested forms like todos.@each.owner.name or todos.@each.owner.@each.name. ` +
+                `You used: $computed . ` +
+                `Please create an intermediary computed property.`;
+
   expectNoWarning(() => {
     computed('todos', () => {});
   });
@@ -99,11 +104,11 @@ QUnit.test('defining a computed property with a dependent key more than one leve
 
   expectWarning(() => {
     computed('todos.@each.owner.name', () => {});
-  }, /You used the key "todos\.@each\.owner\.name" which is invalid\. /);
+  }, warning.replace('$computed', 'todos.@each.owner.name'));
 
   expectWarning(() => {
     computed('todos.@each.owner.@each.name', () => {});
-  }, /You used the key "todos\.@each\.owner\.@each\.name" which is invalid\. /);
+  }, warning.replace('$computed', 'todos.@each.owner.@each.name'));
 });
 
 let objA, objB;


### PR DESCRIPTION
Currently when using deep nested properties the error presented to the developer is generic and doesn't give any clue on what computed property is causing it like:

`WARNING: Dependent keys containing @each only work one level deep. You cannot use nested forms like todos.@each.owner.name or todos.@each.owner.@each.name. Please create an intermediary computed property.`

This PR adds the property to the message so it appears like:

`WARNING: Dependent keys containing @each only work one level deep. You cannot use nested forms like todos.@each.owner.name or todos.@each.owner.@each.name. You used: some.@each.nested.property . Please create an intermediary computed property.`
