### PR TITLE
[BUGFIX beta] `Ember.get` with first part of path chain resolving to `null` returns `null` rather than `undefined`

### DIFF
--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -76,7 +76,7 @@ export function _getPath(root, path) {
 
   for (let i = 0; i < parts.length; i++) {
     if (obj == null) {
-      return obj;
+      return undefined;
     }
 
     obj = get(obj, parts[i]);

--- a/packages/ember-metal/tests/accessors/get_path_test.js
+++ b/packages/ember-metal/tests/accessors/get_path_test.js
@@ -18,7 +18,8 @@ var moduleOpts = {
       emptyString: '',
       Wuz: {
         nar: 'foo'
-      }
+      },
+      nullValue: null
     };
   },
 
@@ -46,11 +47,15 @@ QUnit.test('[obj, foothis.bar] -> obj.foothis.bar', function() {
 });
 
 QUnit.test('[obj, falseValue.notDefined] -> (undefined)', function() {
-  equal(get(obj, 'falseValue.notDefined'), undefined);
+  strictEqual(get(obj, 'falseValue.notDefined'), undefined);
 });
 
 QUnit.test('[obj, emptyString.length] -> 0', function() {
   equal(get(obj, 'emptyString.length'), 0);
+});
+
+QUnit.test('[obj, nullValue.notDefined] -> (undefined)', function() {
+  strictEqual(get(obj, 'nullValue.notDefined'), undefined);
 });
 
 // ..........................................................
@@ -66,9 +71,9 @@ QUnit.test('[obj, Wuz.nar] -> obj.Wuz.nar', function() {
 });
 
 QUnit.test('[obj, Foo] -> (undefined)', function() {
-  equal(get(obj, 'Foo'), undefined);
+  strictEqual(get(obj, 'Foo'), undefined);
 });
 
 QUnit.test('[obj, Foo.bar] -> (undefined)', function() {
-  equal(get(obj, 'Foo.bar'), undefined);
+  strictEqual(get(obj, 'Foo.bar'), undefined);
 });

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -129,8 +129,8 @@ QUnit.test('should return null when property value is null on Ember.Observable',
 });
 
 QUnit.test('should call unknownProperty when value is undefined on Ember.Observable', function() {
-  equal(get(object, 'unknown'), 'unknown');
-  equal(object.lastUnknownProperty, 'unknown');
+  equal(get(objectA, 'unknown'), 'unknown');
+  equal(objectA.lastUnknownProperty, 'unknown');
 });
 
 QUnit.test('should get normal properties on standard objects', function() {


### PR DESCRIPTION
Addresses issue #13444.

As is:

``` js
Ember.get({ foo: null }, 'foo.bar') === null
```

Expected:

``` js
Ember.get({ foo: null }, 'foo.bar') === undefined
```

This bug results in:

``` js
let o = Ember.Object.extend({ foo: null }).create();
o.get('foo.bar') || 'x' === 'x' 
o.getWithDefault('foo.bar', 'x') === null // wat
```
