### PR TITLE
Engine registrations

### DIFF
--- a/packages/ember-application/tests/system/engine_instance_test.js
+++ b/packages/ember-application/tests/system/engine_instance_test.js
@@ -39,18 +39,18 @@ QUnit.test('unregistering a factory clears all cached instances of that factory'
     engineInstance = EngineInstance.create({ base: engine });
   });
 
-  let PostController = factory();
+  let PostComponent = factory();
 
-  engineInstance.register('controller:post', PostController);
+  engineInstance.register('component:post', PostComponent);
 
-  let postController1 = engineInstance.lookup('controller:post');
-  assert.ok(postController1, 'lookup creates instance');
+  let postComponent1 = engineInstance.lookup('component:post');
+  assert.ok(postComponent1, 'lookup creates instance');
 
-  engineInstance.unregister('controller:post');
-  engineInstance.register('controller:post', PostController);
+  engineInstance.unregister('component:post');
+  engineInstance.register('component:post', PostComponent);
 
-  let postController2 = engineInstance.lookup('controller:post');
-  assert.ok(postController2, 'lookup creates instance');
+  let postComponent2 = engineInstance.lookup('component:post');
+  assert.ok(postComponent2, 'lookup creates instance');
 
-  assert.notStrictEqual(postController1, postController2, 'lookup creates a brand new instance because previous one was reset');
+  assert.notStrictEqual(postComponent1, postComponent2, 'lookup creates a brand new instance because previous one was reset');
 });

--- a/packages/ember-application/tests/system/engine_test.js
+++ b/packages/ember-application/tests/system/engine_test.js
@@ -1,7 +1,10 @@
 import { context } from 'ember-environment';
+import isEnabled from 'ember-metal/features';
 import run from 'ember-metal/run_loop';
 import Engine from 'ember-application/system/engine';
 import EmberObject from 'ember-runtime/system/object';
+import { privatize as P } from 'container/registry';
+import { verifyInjection, verifyRegistration } from '../test-helpers/registry-check';
 
 let engine;
 let originalLookup = context.lookup;
@@ -30,4 +33,53 @@ QUnit.test('acts like a namespace', function() {
 
   engine.Foo = EmberObject.extend();
   equal(engine.Foo.toString(), 'TestEngine.Foo', 'Classes pick up their parent namespace');
+});
+
+QUnit.test('builds a registry', function() {
+  strictEqual(engine.resolveRegistration('application:main'), engine, `application:main is registered`);
+  deepEqual(engine.registeredOptionsForType('component'), { singleton: false }, `optionsForType 'component'`);
+  deepEqual(engine.registeredOptionsForType('view'), { singleton: false }, `optionsForType 'view'`);
+  verifyInjection(engine, 'renderer', 'dom', 'service:-dom-helper');
+  verifyRegistration(engine, 'controller:basic');
+  verifyInjection(engine, 'service:-dom-helper', 'document', 'service:-document');
+  verifyInjection(engine, 'view', '_viewRegistry', '-view-registry:main');
+  verifyInjection(engine, 'route', '_topLevelViewTemplate', 'template:-outlet');
+  verifyInjection(engine, 'view:-outlet', 'namespace', 'application:main');
+
+  verifyInjection(engine, 'controller', 'target', 'router:main');
+  verifyInjection(engine, 'controller', 'namespace', 'application:main');
+
+  verifyInjection(engine, 'router', '_bucketCache', P`-bucket-cache:main`);
+  verifyInjection(engine, 'route', '_bucketCache', P`-bucket-cache:main`);
+  verifyInjection(engine, 'controller', '_bucketCache', P`-bucket-cache:main`);
+
+  verifyInjection(engine, 'route', 'router', 'router:main');
+
+  verifyRegistration(engine, 'component:-text-field');
+  verifyRegistration(engine, 'component:-text-area');
+  verifyRegistration(engine, 'component:-checkbox');
+  verifyRegistration(engine, 'component:link-to');
+
+  verifyRegistration(engine, 'service:-routing');
+  verifyInjection(engine, 'service:-routing', 'router', 'router:main');
+
+  // DEBUGGING
+  verifyRegistration(engine, 'resolver-for-debugging:main');
+  verifyInjection(engine, 'container-debug-adapter:main', 'resolver', 'resolver-for-debugging:main');
+  verifyInjection(engine, 'data-adapter:main', 'containerDebugAdapter', 'container-debug-adapter:main');
+  verifyRegistration(engine, 'container-debug-adapter:main');
+
+  if (isEnabled('ember-glimmer')) {
+    verifyRegistration(engine, 'view:-outlet');
+    verifyRegistration(engine, P`template:components/-default`);
+    verifyRegistration(engine, 'template:-outlet');
+    verifyInjection(engine, 'view:-outlet', 'template', 'template:-outlet');
+    verifyInjection(engine, 'template', 'env', 'service:-glimmer-environment');
+    deepEqual(engine.registeredOptionsForType('helper'), { instantiate: false }, `optionsForType 'helper'`);
+  } else {
+    deepEqual(engine.registeredOptionsForType('template'), { instantiate: false }, `optionsForType 'template'`);
+    verifyRegistration(engine, 'view:-outlet');
+    verifyRegistration(engine, 'template:-outlet');
+    verifyRegistration(engine, 'view:toplevel');
+  }
 });

--- a/packages/ember-application/tests/test-helpers/registry-check.js
+++ b/packages/ember-application/tests/test-helpers/registry-check.js
@@ -1,0 +1,28 @@
+export function verifyRegistration(owner, fullName) {
+  ok(owner.resolveRegistration(fullName), `has registration: ${fullName}`);
+}
+
+export function verifyInjection(owner, fullName, property, injectionName) {
+  let registry = owner.__registry__;
+  let injections;
+
+  if (fullName.indexOf(':') === -1) {
+    injections = registry.getTypeInjections(fullName);
+  } else {
+    injections = registry.getInjections(registry.normalize(fullName));
+  }
+
+  let normalizedName = registry.normalize(injectionName);
+  let hasInjection = false;
+  let injection;
+
+  for (let i = 0, l = injections.length; i < l; i++) {
+    injection = injections[i];
+    if (injection.property === property && injection.fullName === normalizedName) {
+      hasInjection = true;
+      break;
+    }
+  }
+
+  ok(hasInjection, `has injection: ${fullName}.${property} = ${injectionName}`);
+}


### PR DESCRIPTION
Splits registrations between Application and Engine classes. Registrations that have proven to be necessary for all engines, based on work in the [ember-engines](https://github.com/dgeb/ember-engines) addon, are moved from the Application class to the Engine class.

This eliminates the need for overrides in ember-engines, while tests still ensure that applications are initialized with the same entries in their registries as always. This does make the registry verification tests rather verbose, but I wanted to make sure nothing was dropped during this transition.

There is still work TBD re: synchronization between engine instances and their parents which could be handled either in this same PR or separately.

/cc @rwjblue
