### PR TITLE
Prevent ungettable objects from getting gotten during path lookup

### DIFF
--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -5,6 +5,12 @@
 import { assert } from 'ember-metal/debug';
 import { isPath, hasThis } from 'ember-metal/path_cache';
 
+const ALLOWABLE_TYPES = {
+  object: true,
+  function: true,
+  string: true
+};
+
 // ..........................................................
 // GET AND SET
 //
@@ -75,7 +81,7 @@ export function _getPath(root, path) {
   let parts = path.split('.');
 
   for (let i = 0; i < parts.length; i++) {
-    if (obj == null) {
+    if (!isGettable(obj)) {
       return undefined;
     }
 
@@ -87,6 +93,14 @@ export function _getPath(root, path) {
   }
 
   return obj;
+}
+
+function isGettable(obj) {
+  if (obj == null) {
+    return false;
+  }
+
+  return ALLOWABLE_TYPES[typeof obj];
 }
 
 /**

--- a/packages/ember-metal/tests/accessors/get_path_test.js
+++ b/packages/ember-metal/tests/accessors/get_path_test.js
@@ -51,7 +51,7 @@ QUnit.test('[obj, falseValue.notDefined] -> (undefined)', function() {
 });
 
 QUnit.test('[obj, emptyString.length] -> 0', function() {
-  equal(get(obj, 'emptyString.length'), 0);
+  strictEqual(get(obj, 'emptyString.length'), 0);
 });
 
 QUnit.test('[obj, nullValue.notDefined] -> (undefined)', function() {


### PR DESCRIPTION
This is a follow-up to #13449.

It was observed by @krisselden that doing something like the following…

``` js
Ember.get({ foo: 42 }, 'foo.bar');
```

… would eventually call `get` internally like…

``` js
get(42, 'bar');
```

… which is no bueno.

To generalize, we should only call `get` from `_getPath` with objects (except `null`), functions, and strings. I'm also wondering if we should add a deprecation to warn people when they do something like…

``` js
Ember.get(42, 'bar');
```

… so we can eventually add an assertion. Right now that will just return `undefined`.
