### PR TITLE
[Glimmer2] Migrate fragment tests

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/fragment-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/fragment-components-test.js
@@ -3,8 +3,13 @@ import { strip } from '../../utils/abstract-test-case';
 import { set } from 'ember-metal/property_set';
 import Component from 'ember-views/components/component';
 
-
 moduleFor('Components test: fragment components', class extends RenderingTest {
+  getCustomDispatcherEvents() {
+    return {
+      hitDem: 'folks'
+    };
+  }
+
   ['@htmlbars fragments do not render an outer tag']() {
     let instance;
     let FooBarComponent = Component.extend({
@@ -39,5 +44,113 @@ moduleFor('Components test: fragment components', class extends RenderingTest {
       set(instance, 'bar', 'bar');
       set(instance, 'foo', true);
     });
+  }
+
+  ['@htmlbars throws an error if an event function is defined in a tagless component']() {
+    let instance;
+    let template = `hit dem folks`;
+    let FooBarComponent = Component.extend({
+      tagName: '',
+      init() {
+        this._super();
+        instance = this;
+      },
+      click() { }
+    });
+
+    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template });
+
+    expectAssertion(() => {
+      this.render(`{{#foo-bar}}{{/foo-bar}}`);
+    }, /You can not define a function that handles DOM events in the .* tagless component since it doesn't have any DOM element./);
+  }
+
+  ['@htmlbars throws an error if a custom defined event function is defined in a tagless component']() {
+    let instance;
+    let template = `hit dem folks`;
+    let FooBarComponent = Component.extend({
+      tagName: '',
+      init() {
+        this._super();
+        instance = this;
+      },
+      folks() { }
+    });
+
+    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template });
+
+    expectAssertion(() => {
+      this.render(`{{#foo-bar}}{{/foo-bar}}`);
+    }, /You can not define a function that handles DOM events in the .* tagless component since it doesn't have any DOM element./);
+  }
+
+  ['@htmlbars throws an error if `tagName` is an empty string and `classNameBindings` are specified']() {
+    let instance;
+    let template = `hit dem folks`;
+    let FooBarComponent = Component.extend({
+      tagName: '',
+      init() {
+        this._super();
+        instance = this;
+      },
+      foo: true,
+      classNameBindings: ['foo:is-foo:is-bar']
+    });
+
+    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template });
+
+    expectAssertion(() => {
+      this.render(`{{#foo-bar}}{{/foo-bar}}`);
+    }, /You cannot use `classNameBindings` on a tag-less component/);
+  }
+
+  ['@htmlbars throws an error if when $() is accessed on component where `tagName` is an empty string']() {
+    let template = `hit dem folks`;
+    let FooBarComponent = Component.extend({
+      tagName: '',
+      init() {
+        this._super();
+        this.$();
+      }
+    });
+
+    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template });
+
+    expectAssertion(() => {
+      this.render(`{{#foo-bar}}{{/foo-bar}}`);
+    }, /You cannot access this.\$\(\) on a component with `tagName: \'\'` specified/);
+  }
+
+  ['@htmlbars renders a contained view with omitted start tag and tagless parent view context']() {
+    this.registerComponent('root-component', {
+      ComponentClass: Component.extend({
+        tagName: 'section'
+      }),
+      template: '{{frag-ment}}'
+    });
+
+    this.registerComponent('frag-ment', {
+      ComponentClass: Component.extend({
+        tagName: ''
+      }),
+      template: '{{my-span}}'
+    });
+
+    this.registerComponent('my-span', {
+      ComponentClass: Component.extend({
+        tagName: 'span'
+      }),
+      template: 'dab'
+    });
+
+    this.render(`{{root-component}}`);
+
+    this.assertElement(this.firstChild, { tagName: 'section' });
+    this.assertElement(this.firstChild.firstElementChild, { tagName: 'span' });
+
+    this.runTask(() => this.rerender());
+
+    this.assertElement(this.firstChild, { tagName: 'section' });
+    this.assertElement(this.firstChild.firstElementChild, { tagName: 'span' });
   }
 });

--- a/packages/ember-glimmer/tests/integration/components/fragment-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/fragment-components-test.js
@@ -1,0 +1,43 @@
+import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { strip } from '../../utils/abstract-test-case';
+import { set } from 'ember-metal/property_set';
+import Component from 'ember-views/components/component';
+
+
+moduleFor('Components test: fragment components', class extends RenderingTest {
+  ['@htmlbars fragments do not render an outer tag']() {
+    let instance;
+    let FooBarComponent = Component.extend({
+      tagName: '',
+      init() {
+        this._super();
+        instance = this;
+        this.foo = true;
+        this.bar = 'bar';
+      }
+    });
+
+    let template = `{{#if foo}}<div>Hey</div>{{/if}}{{yield bar}}`;
+
+    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template });
+
+    this.render(`{{#foo-bar as |bar|}}{{bar}}{{/foo-bar}}`);
+
+    this.assertHTML(strip`<div>Hey</div>bar`);
+
+    this.assertStableRerender();
+
+    this.runTask(() => set(instance, 'foo', false));
+
+    this.assertHTML(strip`<!---->bar`);
+
+    this.runTask(() => set(instance, 'bar', 'bizz'));
+
+    this.assertHTML(strip`<!---->bizz`);
+
+    this.runTask(() => {
+      set(instance, 'bar', 'bar');
+      set(instance, 'foo', true);
+    });
+  }
+});

--- a/packages/ember-glimmer/tests/utils/abstract-test-case.js
+++ b/packages/ember-glimmer/tests/utils/abstract-test-case.js
@@ -301,7 +301,11 @@ export class RenderingTest extends TestCase {
 
     owner.register(P`template:components/-default`, DefaultComponentTemplate);
     owner.register('event_dispatcher:main', EventDispatcher);
-    owner.lookup('event_dispatcher:main').setup({}, owner.element);
+    owner.lookup('event_dispatcher:main').setup(this.getCustomDispatcherEvents(), owner.element);
+  }
+
+  getCustomDispatcherEvents() {
+    return {};
   }
 
   getOwnerOptions() {

--- a/packages/ember-glimmer/tests/utils/test-helpers.js
+++ b/packages/ember-glimmer/tests/utils/test-helpers.js
@@ -83,7 +83,7 @@ export function equalsElement(element, tagName, attributes, content) {
     QUnit.push(element instanceof HTMLElement, null, null, 'Element must be an HTML Element, not an SVG Element');
   } else {
     QUnit.push(
-      element.attributes.length === expectedCount,
+      element.attributes.length === expectedCount || !attributes,
       element.attributes.length,
       expectedCount,
       `Expected ${expectedCount} attributes; got ${element.outerHTML}`

--- a/packages/ember-views/tests/views/component_test.js
+++ b/packages/ember-views/tests/views/component_test.js
@@ -4,15 +4,12 @@ import EmberObject from 'ember-runtime/system/object';
 import Service from 'ember-runtime/system/service';
 import inject from 'ember-runtime/inject';
 import { get } from 'ember-metal/property_get';
-import Application from 'ember-application/system/application';
-import ApplicationInstance from 'ember-application/system/application-instance';
 
 import EmberView from 'ember-views/views/view';
 import Component from 'ember-views/components/component';
 
 import { MUTABLE_CELL } from 'ember-views/compat/attrs-proxy';
 import buildOwner from 'container/tests/test-helpers/build-owner';
-import { OWNER } from 'container/owner';
 
 var a_slice = Array.prototype.slice;
 
@@ -280,87 +277,4 @@ QUnit.test('component with target', function() {
   });
 
   appComponent.send('foo', 'baz');
-});
-
-let app, appInstance;
-
-QUnit.module('Ember.Component - tagless components assertions', {
-  teardown() {
-    if (appInstance) {
-      run(appInstance, 'destroy');
-    }
-
-    if (app) {
-      run(app, 'destroy');
-    }
-  }
-});
-
-
-QUnit.test('throws an error if an event function is defined in a tagless component', function() {
-  app = run(Application, 'create', { rootElement: '#qunit-fixture', autoboot: false });
-
-  run(function() {
-    appInstance = ApplicationInstance.create({ application: app });
-    appInstance.setupEventDispatcher();
-  });
-
-  let TestComponent = Component.extend({
-    tagName: '',
-    [OWNER]: appInstance,
-    click() { }
-  });
-
-  expectAssertion(function() {
-    TestComponent.create();
-  }, /You can not define a function that handles DOM events in the .* tagless component since it doesn't have any DOM element./);
-});
-
-QUnit.test('throws an error if an Application custom event handler is defined in a tagless component', function() {
-  app = run(Application, 'create', {
-    rootElement: '#qunit-fixture',
-    autoboot: false,
-    customEvents: {
-      awesome: 'sauce'
-    }
-  });
-
-  run(function() {
-    appInstance = ApplicationInstance.create({ application: app });
-    appInstance.setupEventDispatcher();
-  });
-
-  let TestComponent = Component.extend({
-    tagName: '',
-    [OWNER]: appInstance,
-    sauce() { }
-  });
-
-  expectAssertion(function() {
-    TestComponent.create();
-  }, /You can not define a function that handles DOM events in the .* tagless component since it doesn't have any DOM element./);
-});
-
-QUnit.test('throws an error if an ApplicationInstance custom event handler is defined in a tagless component', function() {
-  app = run(Application, 'create', { rootElement: '#qunit-fixture', autoboot: false });
-
-  run(function() {
-    appInstance = ApplicationInstance.create({
-      application: app,
-      customEvents: {
-        love: 'hurts'
-      }
-    });
-    appInstance.setupEventDispatcher();
-  });
-
-  let TestComponent = Component.extend({
-    tagName: '',
-    [OWNER]: appInstance,
-    hurts() { }
-  });
-
-  expectAssertion(function() {
-    TestComponent.create();
-  }, /You can not define a function that handles DOM events in the .* tagless component since it doesn't have any DOM element./);
 });

--- a/packages/ember-views/tests/views/view/create_element_test.js
+++ b/packages/ember-views/tests/views/view/create_element_test.js
@@ -32,26 +32,6 @@ QUnit.test('returns the receiver', function() {
   equal(ret, view, 'returns receiver');
 });
 
-QUnit.test('should assert if `tagName` is an empty string and `classNameBindings` are specified', function() {
-  expect(1);
-
-  view = EmberView.create({
-    tagName: '',
-    foo: true,
-    classNameBindings: ['foo:is-foo:is-bar']
-  });
-
-  expectAssertion(function() {
-    run(function() {
-      view.createElement();
-    });
-  }, /You cannot use `classNameBindings` on a tag-less component/);
-
-  // Prevent further assertions
-  view._renderNode = null;
-});
-
-
 import { test } from 'ember-glimmer/tests/utils/skip-if-glimmer';
 
 test('calls render and turns resultant string into element', function() {

--- a/packages/ember-views/tests/views/view/jquery_test.js
+++ b/packages/ember-views/tests/views/view/jquery_test.js
@@ -51,17 +51,3 @@ QUnit.test('returns empty jQuery object if filter passed that does not match ite
   var jquery = view.$('body'); // would normally work if not scoped to view
   equal(jquery.length, 0, 'view.$(body) should have no elements');
 });
-
-QUnit.test('asserts for tagless views', function() {
-  var view = EmberView.create({
-    tagName: ''
-  });
-
-  runAppend(view);
-
-  expectAssertion(function() {
-    view.$();
-  }, /You cannot access this.\$\(\) on a component with `tagName: \'\'` specified/);
-
-  runDestroy(view);
-});

--- a/packages/ember-views/tests/views/view_test.js
+++ b/packages/ember-views/tests/views/view_test.js
@@ -87,30 +87,6 @@ test('should re-render if the context is changed', function() {
   equal(jQuery('#qunit-fixture #template-context-test').text(), 'bang baz', 're-renders the view with the updated context');
 });
 
-test('renders a contained view with omitted start tag and tagless parent view context', function() {
-  view = EmberView.create({
-    tagName: 'table',
-    template: compile('{{view view.pivot}}'),
-    pivot: EmberView.extend({
-      tagName: '',
-      template: compile('{{view view.row}}'),
-      row: EmberView.extend({
-        tagName: 'tr'
-      })
-    })
-  });
-
-  run(view, view.append);
-
-  equal(view.element.tagName, 'TABLE', 'container view is table');
-  ok(view.$('tr').length, 'inner view is tr');
-
-  run(view, view.rerender);
-
-  equal(view.element.tagName, 'TABLE', 'container view is table');
-  ok(view.$('tr').length, 'inner view is tr');
-});
-
 test('propagates dependent-key invalidated sets upstream', function() {
   view = EmberView.create({
     parentProp: 'parent-value',


### PR DESCRIPTION
Picking up what @chadhietala started here: https://github.com/emberjs/ember.js/pull/13152

I omitted the "virtual view" (not quite sure what that is) tests and the [Fastboot](https://github.com/emberjs/ember.js/blob/fd03495063ea7862bdb67a6c96dd57159d074a52/tests/node/visit-test.js#L307) test that @chadhietala originally listed. Not sure the fastboot test belongs here since it seems that the focus is fastboot and not templating features.

@krisselden @rwjblue can either of you guys speak to whether the "virtual view" tests belong here?
