### PR TITLE
[Glimmer2] Fix a few dynamic component tests for Glimmer

### DIFF
--- a/packages/ember-glimmer/lib/components/dynamic-component.js
+++ b/packages/ember-glimmer/lib/components/dynamic-component.js
@@ -1,5 +1,6 @@
 import { ArgsSyntax, StatementSyntax } from 'glimmer-runtime';
 import { ConstReference, isConst } from 'glimmer-reference';
+import { assert } from 'ember-metal/debug';
 
 class DynamicComponentLookup {
   constructor(args) {
@@ -47,7 +48,10 @@ class DynamicComponentReference {
 
 function lookup(env, name) {
   if (typeof name === 'string') {
-    return env.getComponentDefinition([name]);
+    let componentDefinition = env.getComponentDefinition([name]);
+    assert(`Glimmer error: Could not find component named "${name}" (no component or template with that name was found)`, componentDefinition);
+
+    return componentDefinition;
   } else {
     throw new Error(`Cannot render ${name} as a component`);
   }

--- a/packages/ember-glimmer/tests/integration/components/dynamic-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/dynamic-components-test.js
@@ -506,7 +506,7 @@ moduleFor('Components test: dynamic components', class extends RenderingTest {
     this.assertText('hello Alex');
   }
 
-  ['@htmlbars component helper properly invalidates hash params inside an {{each}} invocation #11044'](assert) {
+  ['@test component helper properly invalidates hash params inside an {{each}} invocation #11044'](assert) {
     this.registerComponent('foo-bar', {
       template: '[{{internalName}} - {{attrs.name}}]',
       ComponentClass: Component.extend({

--- a/packages/ember-glimmer/tests/integration/components/dynamic-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/dynamic-components-test.js
@@ -474,13 +474,13 @@ moduleFor('Components test: dynamic components', class extends RenderingTest {
     this.assertText('yippie! Caracas yummy Caracas arepas!');
   }
 
-  ['@htmlbars component with dynamic name argument resolving to non-existent component'](assert) {
+  ['@test component with dynamic name argument resolving to non-existent component'](assert) {
     expectAssertion(() => {
       this.render('{{component componentName}}', { componentName: 'does-not-exist' });
     }, /Could not find component named "does-not-exist"/);
   }
 
-  ['@htmlbars component with static name argument for non-existent component'](assert) {
+  ['@test component with static name argument for non-existent component'](assert) {
     expectAssertion(() => {
       this.render('{{component "does-not-exist"}}');
     }, /Could not find component named "does-not-exist"/);


### PR DESCRIPTION
I was perusing some of the skipped tests and saw some low hanging fruit:
1. "component helper properly invalidates hash params inside an {{each}} invocation" This seems to be fixed now that Glimmer component lifecycle hooks are working. 
2. "component with dynamic/static name argument resolving to non-existent component". It appears that these were only missing an assertion.
