### PR TITLE
[Glimmer2] Add fragment assertions

### DIFF
--- a/packages/ember-glimmer/lib/components/curly-component.js
+++ b/packages/ember-glimmer/lib/components/curly-component.js
@@ -72,6 +72,16 @@ class CurlyComponentManager {
       return tagName || !classNameBindings || classNameBindings.length === 0;
     });
 
+    assert('You cannot use `elementId` on a tag-less component: ' + component.toString(), () => {
+      let { elementId, tagName } = component;
+      return tagName || (!elementId && elementId !== '');
+    });
+
+    assert('You cannot use `attributeBindings` on a tag-less component: ' + component.toString(), () => {
+      let { attributeBindings, tagName } = component;
+      return tagName || !attributeBindings || attributeBindings.length === 0;
+    });
+
     return bucket;
   }
 

--- a/packages/ember-glimmer/tests/integration/components/fragment-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/fragment-components-test.js
@@ -104,6 +104,32 @@ moduleFor('Components test: fragment components', class extends RenderingTest {
     }, /You cannot use `classNameBindings` on a tag-less component/);
   }
 
+  ['@glimmer throws an error if `tagName` is an empty string and `attributeBindings` are specified']() {
+    let template = `hit dem folks`;
+    let FooBarComponent = Component.extend({
+      tagName: '',
+      attributeBindings: ['href']
+    });
+
+    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template });
+    expectAssertion(() => {
+      this.render(`{{#foo-bar}}{{/foo-bar}}`);
+    }, /You cannot use `attributeBindings` on a tag-less component/);
+  }
+
+  ['@glimmer throws an error if `tagName` is an empty string and `elementId` is specified via JS']() {
+    let template = `hit dem folks`;
+    let FooBarComponent = Component.extend({
+      tagName: '',
+      elementId: 'turntUp'
+    });
+
+    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template });
+    expectAssertion(() => {
+      this.render(`{{#foo-bar}}{{/foo-bar}}`);
+    }, /You cannot use `elementId` on a tag-less component/);
+  }
+
   ['@test throws an error if when $() is accessed on component where `tagName` is an empty string']() {
     let template = `hit dem folks`;
     let FooBarComponent = Component.extend({

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -619,7 +619,7 @@ export default Mixin.create({
   init() {
     this._super(...arguments);
 
-    if (!this.elementId) {
+    if (!this.elementId && this.tagName !== '') {
       this.elementId = guidFor(this);
     }
 


### PR DESCRIPTION
As requested by @chancancode in https://github.com/emberjs/ember.js/pull/13475.

Doesn't seem like this stuff was being tested in htmlbars
