### PR TITLE
A more friendly assert for incorrect mut value

### DIFF
--- a/packages/ember-htmlbars/lib/keywords/mut.js
+++ b/packages/ember-htmlbars/lib/keywords/mut.js
@@ -140,7 +140,7 @@ function mutParam(read, stream, internal) {
       stream = new LiteralStream(literal);
     }
   } else {
-    assert('You can only pass a path to mut', isStream(stream));
+    assert('You can only pass a binding to mut (e.g. `mut foo`)', isStream(stream));
   }
 
   if (stream[MUTABLE_REFERENCE]) {


### PR DESCRIPTION
I believe the term "binding" makes more sense to most users as opposed to "path", because there are helpers which _do_ accept "paths as strings"

This comes from a user I talked to, whom encountered the assert after doing `{{mut 'isActive'}}` by mistake and had trouble deciphering the meaning of the current assert error.

@wycats as the original author, do you have any thoughts/review for this?
