### PR TITLE
[Glimmer] Ensure run loop when dirtying

### DIFF
--- a/packages/ember-extension-support/tests/data_adapter_test.js
+++ b/packages/ember-extension-support/tests/data_adapter_test.js
@@ -61,7 +61,7 @@ QUnit.test('Model types added with DefaultResolver', function() {
     deepEqual(postType.columns, [{ name: 'title', desc: 'Title' }], 'Correctly sets the columns');
   };
 
-  adapter.watchModelTypes(modelTypesAdded);
+  run(adapter, 'watchModelTypes', modelTypesAdded);
 });
 
 QUnit.test('getRecords gets a model name as second argument', function() {
@@ -112,7 +112,7 @@ QUnit.test('Model types added with custom container-debug-adapter', function() {
     deepEqual(postType.columns, [{ name: 'title', desc: 'Title' }], 'Correctly sets the columns');
   };
 
-  adapter.watchModelTypes(modelTypesAdded);
+  run(adapter, 'watchModelTypes', modelTypesAdded);
 });
 
 QUnit.test('Model Types Updated', function() {
@@ -139,7 +139,7 @@ QUnit.test('Model Types Updated', function() {
     equal(postType.count, 4, 'Correctly updates the count');
   };
 
-  adapter.watchModelTypes(modelTypesAdded, modelTypesUpdated);
+  run(adapter, 'watchModelTypes', modelTypesAdded, modelTypesUpdated);
 });
 
 QUnit.test('Records Added', function() {

--- a/packages/ember-glimmer/lib/renderer.js
+++ b/packages/ember-glimmer/lib/renderer.js
@@ -1,5 +1,6 @@
 import { RootReference } from './utils/references';
 import run from 'ember-metal/run_loop';
+import { setHasViews } from 'ember-metal/tags';
 import { CURRENT_TAG } from 'glimmer-reference';
 
 const { backburner } = run;
@@ -68,9 +69,9 @@ class SchedulerRegistrar {
 }
 const schedulerRegistrar = new SchedulerRegistrar();
 
-export function rendererHasViews() {
+setHasViews(function rendererHasViews() {
   return schedulerRegistrar.hasRegistrations();
-}
+});
 
 class Scheduler {
   constructor() {

--- a/packages/ember-glimmer/lib/renderer.js
+++ b/packages/ember-glimmer/lib/renderer.js
@@ -45,7 +45,11 @@ class SchedulerRegistrar {
     return !!this._eventCallbacks.length;
   }
 }
-export const schedulerRegistrar = new SchedulerRegistrar();
+const schedulerRegistrar = new SchedulerRegistrar();
+
+export function rendererHasViews() {
+  return schedulerRegistrar.hasRegistrations();
+}
 
 class Scheduler {
   constructor() {

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -9,6 +9,7 @@ import { moduleFor, RenderingTest } from '../../utils/test-case';
 import { classes, equalTokens, equalsElement } from '../../utils/test-helpers';
 import { htmlSafe } from 'ember-htmlbars/utils/string';
 import { computed } from 'ember-metal/computed';
+import run from 'ember-metal/run_loop';
 
 moduleFor('Components test: curly components', class extends RenderingTest {
 
@@ -63,7 +64,7 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { id: 'blahzorz' }, content: 'blahzorz' });
 
     if (EmberDev && !EmberDev.runningProdBuild) {
-      let willThrow = () => set(component, 'elementId', 'herpyderpy');
+      let willThrow = () => run(null, set, component, 'elementId', 'herpyderpy');
 
       assert.throws(willThrow, /Changing a view's elementId after creation is not allowed/);
 

--- a/packages/ember-metal/lib/tags.js
+++ b/packages/ember-metal/lib/tags.js
@@ -1,5 +1,7 @@
 import { meta as metaFor } from './meta';
 import require, { has } from 'require';
+import run from './run_loop';
+import { schedulerRegistrar } from 'ember-glimmer/renderer';
 
 let hasGlimmer = has('glimmer-reference');
 let CONSTANT_TAG, CURRENT_TAG, DirtyableTag, makeTag;
@@ -19,11 +21,19 @@ export function tagFor(object, _meta) {
   }
 }
 
+function K() {}
+function ensureRunloop() {
+  if (schedulerRegistrar.hasRegistrations() && !run.backburner.currentInstance) {
+    run.schedule('actions', K);
+  }
+}
+
 if (hasGlimmer) {
   ({ DirtyableTag, CONSTANT_TAG, CURRENT_TAG } = require('glimmer-reference'));
   makeTag = function() { return new DirtyableTag(); };
 
   markObjectAsDirty = function(meta) {
+    ensureRunloop();
     let tag = (meta && meta.readableTag()) || CURRENT_TAG;
     tag.dirty();
   };

--- a/packages/ember-metal/lib/tags.js
+++ b/packages/ember-metal/lib/tags.js
@@ -2,7 +2,12 @@ import { meta as metaFor } from './meta';
 import require, { has } from 'require';
 
 let hasGlimmer = has('glimmer-reference');
-let CONSTANT_TAG, CURRENT_TAG, DirtyableTag, makeTag, rendererHasViews, run;
+let CONSTANT_TAG, CURRENT_TAG, DirtyableTag, makeTag, run;
+
+let hasViews = () => false;
+export function setHasViews(fn) {
+  hasViews = fn;
+}
 
 export let markObjectAsDirty;
 
@@ -25,11 +30,7 @@ function ensureRunloop() {
     run = require('ember-metal/run_loop').default;
   }
 
-  if (!rendererHasViews) {
-    rendererHasViews = require('ember-glimmer/renderer').rendererHasViews;
-  }
-
-  if (rendererHasViews() && !run.backburner.currentInstance) {
+  if (hasViews() && !run.backburner.currentInstance) {
     run.schedule('actions', K);
   }
 }

--- a/packages/ember-metal/lib/tags.js
+++ b/packages/ember-metal/lib/tags.js
@@ -2,7 +2,7 @@ import { meta as metaFor } from './meta';
 import require, { has } from 'require';
 
 let hasGlimmer = has('glimmer-reference');
-let CONSTANT_TAG, CURRENT_TAG, DirtyableTag, makeTag, schedulerRegistrar, run;
+let CONSTANT_TAG, CURRENT_TAG, DirtyableTag, makeTag, rendererHasViews, run;
 
 export let markObjectAsDirty;
 
@@ -25,11 +25,11 @@ function ensureRunloop() {
     run = require('ember-metal/run_loop').default;
   }
 
-  if (!schedulerRegistrar) {
-    schedulerRegistrar = require('ember-glimmer/renderer').schedulerRegistrar;
+  if (!rendererHasViews) {
+    rendererHasViews = require('ember-glimmer/renderer').rendererHasViews;
   }
 
-  if (schedulerRegistrar.hasRegistrations() && !run.backburner.currentInstance) {
+  if (rendererHasViews() && !run.backburner.currentInstance) {
     run.schedule('actions', K);
   }
 }

--- a/packages/ember-metal/lib/tags.js
+++ b/packages/ember-metal/lib/tags.js
@@ -1,10 +1,8 @@
 import { meta as metaFor } from './meta';
 import require, { has } from 'require';
-import run from './run_loop';
-import { schedulerRegistrar } from 'ember-glimmer/renderer';
 
 let hasGlimmer = has('glimmer-reference');
-let CONSTANT_TAG, CURRENT_TAG, DirtyableTag, makeTag;
+let CONSTANT_TAG, CURRENT_TAG, DirtyableTag, makeTag, schedulerRegistrar, run;
 
 export let markObjectAsDirty;
 
@@ -23,6 +21,14 @@ export function tagFor(object, _meta) {
 
 function K() {}
 function ensureRunloop() {
+  if (!run) {
+    run = require('ember-metal/run_loop').default;
+  }
+
+  if (!schedulerRegistrar) {
+    schedulerRegistrar = require('ember-glimmer/renderer').schedulerRegistrar;
+  }
+
   if (schedulerRegistrar.hasRegistrations() && !run.backburner.currentInstance) {
     run.schedule('actions', K);
   }


### PR DESCRIPTION
Ensure there is a run loop running when an object is dirtied. This complements #13430, so that re-rendering happens automatically when properties are changed.

What still needs to be done?
- [x] Don't use an array for re-render scheduling unless necessary.
- [x] If possible, move `schedulerRegistrar` out of `ember-metal/tags`.
- [x] Resolve test failures
