### PR TITLE
Helper references reorg

### DIFF
--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -171,9 +171,9 @@ export default class Environment extends GlimmerEnvironment {
     if (helper.isInternalHelper) {
       return (args) => helper.toReference(args);
     } else if (helper.isHelperInstance) {
-      return (args) => new SimpleHelperReference(helper.compute, args);
+      return (args) => SimpleHelperReference.create(helper.compute, args);
     } else if (helper.isHelperFactory) {
-      return (args) => new ClassBasedHelperReference(helper.create(), args);
+      return (args) => ClassBasedHelperReference.create(helper, args);
     } else {
       throw new Error(`${name} is not a helper`);
     }

--- a/packages/ember-glimmer/lib/helpers/hash.js
+++ b/packages/ember-glimmer/lib/helpers/hash.js
@@ -1,4 +1,6 @@
-import { HashHelperReference } from '../utils/references';
+import { isConst } from 'glimmer-reference';
+import { CachedReference, RootReference } from '../utils/references';
+
 /**
 @module ember
 @submodule ember-templates
@@ -34,6 +36,27 @@ import { HashHelperReference } from '../utils/references';
 export default {
   isInternalHelper: true,
   toReference(args) {
-    return new HashHelperReference(args);
+    return HashHelperReference.create(args.named);
   }
 };
+
+class HashHelperReference extends CachedReference {
+  static create(namedArgs) {
+    if (isConst(namedArgs)) {
+      return new RootReference(namedArgs.value());
+    } else {
+      return new HashHelperReference(namedArgs);
+    }
+  }
+
+  constructor(namedArgs) {
+    super();
+
+    this.tag = namedArgs.tag;
+    this.namedArgs = namedArgs;
+  }
+
+  compute() {
+    return this.namedArgs.value();
+  }
+}


### PR DESCRIPTION
- Formalize the reference creation pattern. `SomeReference.create` is responsible for determining "const-ness" and apply the right optimization if applicable.
- Move specialized reference out of the `/utils/references.js` file. This file should be reserved for common "util" references like `RootReference` and `CachedReference`. The specialized ones could just live in where they are used.
- New optimization: simple helpers with const args produces const references – that means things like `{{concat "foo" "bar"}}` (or more likely – `{{concat foo bar}}` where `foo` and `bar` are known to come from const sources) does not incur any updating cost.
  
  This implements the optimization discussed https://github.com/tildeio/glimmer/pull/133#discussion_r60147755

cc @zackthehuman @krisselden 
