### PR TITLE
Rebase #13393 + #13478

### DIFF
--- a/packages/ember-glimmer/lib/components/curly-component.js
+++ b/packages/ember-glimmer/lib/components/curly-component.js
@@ -1,8 +1,8 @@
 import { StatementSyntax, ValueReference } from 'glimmer-runtime';
 import { AttributeBindingReference, RootReference, applyClassNameBinding } from '../utils/references';
 import { DIRTY_TAG } from '../ember-views/component';
-import EmptyObject from 'ember-metal/empty_object';
 import { assert } from 'ember-metal/debug';
+import processArgs from '../utils/process-args';
 
 export class CurlyComponentSyntax extends StatementSyntax {
   constructor({ args, definition, templates }) {
@@ -18,21 +18,6 @@ export class CurlyComponentSyntax extends StatementSyntax {
   }
 }
 
-function attrsToProps(keys, attrs) {
-  let merged = new EmptyObject();
-
-  merged.attrs = attrs;
-
-  for (let i = 0, l = keys.length; i < l; i++) {
-    let name = keys[i];
-    let value = attrs[name];
-
-    merged[name] = value;
-  }
-
-  return merged;
-}
-
 class ComponentStateBucket {
   constructor(component, args) {
     this.component = component;
@@ -46,8 +31,7 @@ class CurlyComponentManager {
     let parentView = dynamicScope.view;
 
     let klass = definition.ComponentClass;
-    let attrs = args.named.value();
-    let props = attrsToProps(args.named.keys, attrs);
+    let { attrs, props } = processArgs(args, klass.positionalParams);
 
     props.renderer = parentView.renderer;
 
@@ -146,8 +130,7 @@ class CurlyComponentManager {
     if (!args.tag.validate(argsRevision)) {
       bucket.argsRevision = args.tag.value();
 
-      let attrs = args.named.value();
-      let props = attrsToProps(args.named.keys, attrs);
+      let { attrs, props } = processArgs(args, component.constructor.positionalParams);
 
       let oldAttrs = component.attrs;
       let newAttrs = attrs;

--- a/packages/ember-glimmer/lib/components/curly-component.js
+++ b/packages/ember-glimmer/lib/components/curly-component.js
@@ -4,6 +4,13 @@ import { DIRTY_TAG } from '../ember-views/component';
 import { assert } from 'ember-metal/debug';
 import processArgs from '../utils/process-args';
 
+function aliasIdToElementId(args, props) {
+  if (args.named.has('id')) {
+    assert(`You cannot invoke a component with both 'id' and 'elementId' at the same time.`, !args.named.has('elementId'));
+    props.elementId = props.id;
+  }
+}
+
 export class CurlyComponentSyntax extends StatementSyntax {
   constructor({ args, definition, templates }) {
     super();
@@ -34,6 +41,8 @@ class CurlyComponentManager {
     let klass = definition.ComponentClass;
     let processedArgs = processArgs(args, klass.positionalParams);
     let { attrs, props } = processedArgs.value();
+
+    aliasIdToElementId(args, props);
 
     props.renderer = parentView.renderer;
 

--- a/packages/ember-glimmer/lib/components/curly-component.js
+++ b/packages/ember-glimmer/lib/components/curly-component.js
@@ -22,6 +22,7 @@ class ComponentStateBucket {
   constructor(component, args) {
     this.component = component;
     this.classRef = null;
+    this.args = args;
     this.argsRevision = args.tag.value();
   }
 }
@@ -31,7 +32,8 @@ class CurlyComponentManager {
     let parentView = dynamicScope.view;
 
     let klass = definition.ComponentClass;
-    let { attrs, props } = processArgs(args, klass.positionalParams);
+    let processedArgs = processArgs(args, klass.positionalParams);
+    let { attrs, props } = processedArgs.value();
 
     props.renderer = parentView.renderer;
 
@@ -45,7 +47,7 @@ class CurlyComponentManager {
     component.trigger('willInsertElement');
     component.trigger('willRender');
 
-    let bucket = new ComponentStateBucket(component, args);
+    let bucket = new ComponentStateBucket(component, processedArgs);
 
     if (args.named.has('class')) {
       bucket.classRef = args.named.get('class');
@@ -124,13 +126,13 @@ class CurlyComponentManager {
     component._transitionTo('inDOM');
   }
 
-  update(bucket, args, dynamicScope) {
-    let { component, argsRevision } = bucket;
+  update(bucket, _, dynamicScope) {
+    let { component, args, argsRevision } = bucket;
 
     if (!args.tag.validate(argsRevision)) {
       bucket.argsRevision = args.tag.value();
 
-      let { attrs, props } = processArgs(args, component.constructor.positionalParams);
+      let { attrs, props } = args.value();
 
       let oldAttrs = component.attrs;
       let newAttrs = attrs;

--- a/packages/ember-glimmer/lib/utils/process-args.js
+++ b/packages/ember-glimmer/lib/utils/process-args.js
@@ -1,95 +1,120 @@
+import { CONSTANT_TAG } from 'glimmer-reference';
 import { assert } from 'ember-metal/debug';
-import assign from 'ember-metal/assign';
 import EmptyObject from 'ember-metal/empty_object';
 
 export default function processArgs(args, positionalParamsDefinition) {
-  let attrs = assign(new EmptyObject(), args.named.value());
-  processPositionalParams(positionalParamsDefinition || [], args.positional, attrs);
-
-  let props = attrsToProps(keysForAttrs(args, positionalParamsDefinition), attrs);
-
-  return { attrs, props };
-}
-
-// Transforms an object of external attributes to internal properties.
-// This means that each key-value pair needs to be accessible both as key and
-// attrs.key
-function attrsToProps(keys, attrs) {
-  let merged = new EmptyObject();
-
-  merged.attrs = attrs;
-
-  for (let i = 0, l = keys.length; i < l; i++) {
-    let name = keys[i];
-    let value = attrs[name];
-
-    merged[name] = value;
-  }
-
-  return merged;
-}
-
-function processPositionalParams(positionalParams, params, attrs) {
-  let isRest = typeof positionalParams === 'string';
-
-  if (isRest) {
-    processRestPositionalParameters(positionalParams, params, attrs);
+  if (!positionalParamsDefinition || positionalParamsDefinition.length === 0 || args.positional.length === 0) {
+    return SimpleArgs.create(args);
+  } else if (typeof positionalParamsDefinition === 'string') {
+    return RestArgs.create(args, positionalParamsDefinition);
   } else {
-    processNamedPositionalParameters(positionalParams, params, attrs);
+    return PositionalArgs.create(args, positionalParamsDefinition);
   }
 }
 
-function processNamedPositionalParameters(positionalParams, params, attrs) {
-  let limit = Math.min(params.length, positionalParams.length);
+const EMPTY_ARGS = {
+  tag: CONSTANT_TAG,
 
-  for (let i = 0; i < limit; i++) {
-    let param = params.at(i).value();
+  value() {
+    return { attrs: {}, props: { attrs: {} } };
+  }
+};
 
-    assert(`You cannot specify both a positional param (at position ${i}) and the hash argument \`${positionalParams[i]}\`.`,
-           !(positionalParams[i] in attrs));
+class SimpleArgs {
+  static create({ named }) {
+    if (named.keys.length === 0) {
+      return EMPTY_ARGS;
+    } else {
+      return new SimpleArgs(named);
+    }
+  }
 
-    attrs[positionalParams[i]] = param;
+  constructor(namedArgs) {
+    this.tag = namedArgs.tag;
+    this.namedArgs = namedArgs;
+  }
+
+  value() {
+    let { namedArgs } = this;
+    let keys = namedArgs.keys;
+    let attrs = namedArgs.value();
+    let props = new EmptyObject();
+
+    props.attrs = attrs;
+
+    for (let i = 0, l = keys.length; i < l; i++) {
+      let name = keys[i];
+      let value = attrs[name];
+
+      props[name] = value;
+    }
+
+
+    return { attrs, props };
   }
 }
 
-function processRestPositionalParameters(positionalParamsName, params, attrs) {
-  let nameInAttrs = positionalParamsName in attrs;
+class RestArgs {
+  static create(args, restArgName) {
+    assert(`You cannot specify positional parameters and the hash argument \`${restArgName}\`.`, !args.named.has(restArgName));
 
-  // when no params are used, do not override the specified `attrs.stringParamName` value
-  if (params.length === 0 && nameInAttrs) {
-    return;
+    return new RestArgs(args, restArgName);
   }
 
-  // If there is already an attribute for that variable, do nothing
-  assert(`You cannot specify positional parameters and the hash argument \`${positionalParamsName}\`.`,
-         !nameInAttrs);
+  constructor(args, restArgName) {
+    this.tag = args.tag;
+    this.simpleArgs = SimpleArgs.create(args);
+    this.positionalArgs = args.positional;
+    this.restArgName = restArgName;
+  }
 
-  attrs[positionalParamsName] = params.value();
-}
+  value() {
+    let { simpleArgs, positionalArgs, restArgName } = this;
 
-// Keys to copy from named arguments
-function keysForAttrs(args, posParamsDefinition) {
-  let namedKeys = args.named.keys;
-  let posKeys = keysForPositionalParameters(args, posParamsDefinition);
+    let result = simpleArgs.value();
 
-  return namedKeys.concat(posKeys);
-}
+    result.attrs[restArgName] = result.props[restArgName] = positionalArgs.value();
 
-// Keys to copy for positional arguments
-function keysForPositionalParameters(args, posParamsDefinition) {
-  let numberOfPosParams = args.positional.length;
-  if (numberOfPosParams === 0) {
-    // If there are no positional parameters passed, returned an empty array
-    return [];
-  } else if (typeof posParamsDefinition === 'string') {
-    // If there are any positional parameter and we are receiving a rest type
-    // positional parameter, then return an array with the only key.
-    return [posParamsDefinition];
-  } else {
-    // If we have received any positional parameter, return the keys for those
-    // parameters we have received.
-    let posEndIndex = Math.min(posParamsDefinition.length, args.positional.length);
-    return posParamsDefinition.slice(0, posEndIndex);
+    return result;
   }
 }
 
+
+class PositionalArgs {
+  static create(args, positionalParamNames) {
+    if (args.positional.length < positionalParamNames.length) {
+      positionalParamNames = positionalParamNames.slice(0, args.positional.length);
+    }
+
+    for (let i = 0; i < positionalParamNames.length; i++) {
+      let name = positionalParamNames[i];
+
+      assert(
+        `You cannot specify both a positional param (at position ${i}) and the hash argument \`${name}\`.`,
+        !args.named.has(name)
+      );
+    }
+
+    return new PositionalArgs(args, positionalParamNames);
+  }
+
+  constructor(args, positionalParamNames) {
+    this.tag = args.tag;
+    this.simpleArgs = SimpleArgs.create(args);
+    this.positionalArgs = args.positional;
+    this.positionalParamNames = positionalParamNames;
+  }
+
+  value() {
+    let { simpleArgs, positionalArgs, positionalParamNames } = this;
+
+    let result = simpleArgs.value();
+
+    for (let i = 0; i < positionalParamNames.length; i++) {
+      let name = positionalParamNames[i];
+      result.attrs[name] = result.props[name] = positionalArgs.at(i).value();
+    }
+
+    return result;
+  }
+}

--- a/packages/ember-glimmer/lib/utils/process-args.js
+++ b/packages/ember-glimmer/lib/utils/process-args.js
@@ -49,7 +49,6 @@ class SimpleArgs {
       props[name] = value;
     }
 
-
     return { attrs, props };
   }
 }

--- a/packages/ember-glimmer/lib/utils/process-args.js
+++ b/packages/ember-glimmer/lib/utils/process-args.js
@@ -1,0 +1,95 @@
+import { assert } from 'ember-metal/debug';
+import assign from 'ember-metal/assign';
+import EmptyObject from 'ember-metal/empty_object';
+
+export default function processArgs(args, positionalParamsDefinition) {
+  let attrs = assign(new EmptyObject(), args.named.value());
+  processPositionalParams(positionalParamsDefinition || [], args.positional, attrs);
+
+  let props = attrsToProps(keysForAttrs(args, positionalParamsDefinition), attrs);
+
+  return { attrs, props };
+}
+
+// Transforms an object of external attributes to internal properties.
+// This means that each key-value pair needs to be accessible both as key and
+// attrs.key
+function attrsToProps(keys, attrs) {
+  let merged = new EmptyObject();
+
+  merged.attrs = attrs;
+
+  for (let i = 0, l = keys.length; i < l; i++) {
+    let name = keys[i];
+    let value = attrs[name];
+
+    merged[name] = value;
+  }
+
+  return merged;
+}
+
+function processPositionalParams(positionalParams, params, attrs) {
+  let isRest = typeof positionalParams === 'string';
+
+  if (isRest) {
+    processRestPositionalParameters(positionalParams, params, attrs);
+  } else {
+    processNamedPositionalParameters(positionalParams, params, attrs);
+  }
+}
+
+function processNamedPositionalParameters(positionalParams, params, attrs) {
+  let limit = Math.min(params.length, positionalParams.length);
+
+  for (let i = 0; i < limit; i++) {
+    let param = params.at(i).value();
+
+    assert(`You cannot specify both a positional param (at position ${i}) and the hash argument \`${positionalParams[i]}\`.`,
+           !(positionalParams[i] in attrs));
+
+    attrs[positionalParams[i]] = param;
+  }
+}
+
+function processRestPositionalParameters(positionalParamsName, params, attrs) {
+  let nameInAttrs = positionalParamsName in attrs;
+
+  // when no params are used, do not override the specified `attrs.stringParamName` value
+  if (params.length === 0 && nameInAttrs) {
+    return;
+  }
+
+  // If there is already an attribute for that variable, do nothing
+  assert(`You cannot specify positional parameters and the hash argument \`${positionalParamsName}\`.`,
+         !nameInAttrs);
+
+  attrs[positionalParamsName] = params.value();
+}
+
+// Keys to copy from named arguments
+function keysForAttrs(args, posParamsDefinition) {
+  let namedKeys = args.named.keys;
+  let posKeys = keysForPositionalParameters(args, posParamsDefinition);
+
+  return namedKeys.concat(posKeys);
+}
+
+// Keys to copy for positional arguments
+function keysForPositionalParameters(args, posParamsDefinition) {
+  let numberOfPosParams = args.positional.length;
+  if (numberOfPosParams === 0) {
+    // If there are no positional parameters passed, returned an empty array
+    return [];
+  } else if (typeof posParamsDefinition === 'string') {
+    // If there are any positional parameter and we are receiving a rest type
+    // positional parameter, then return an array with the only key.
+    return [posParamsDefinition];
+  } else {
+    // If we have received any positional parameter, return the keys for those
+    // parameters we have received.
+    let posEndIndex = Math.min(posParamsDefinition.length, args.positional.length);
+    return posParamsDefinition.slice(0, posEndIndex);
+  }
+}
+

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -1147,7 +1147,7 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     this.assertText('In layout - someProp: something here - In template');
   }
 
-  ['@htmlbars static arbitrary number of positional parameters'](assert) {
+  ['@test static arbitrary number of positional parameters'](assert) {
     this.registerComponent('sample-component', {
       ComponentClass: Component.extend().reopenClass({
         positionalParams: 'names'
@@ -1159,23 +1159,20 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     });
 
     this.render(strip`
-      {{sample-component "Foo" 4 "Bar" id="args-3"}}
-      {{sample-component "Foo" 4 "Bar" 5 "Baz" id="args-5"}}
-      {{component "sample-component" "Foo" 4 "Bar" 5 "Baz" id="helper"}}`
+      {{sample-component "Foo" 4 "Bar" elementId="args-3"}}
+      {{sample-component "Foo" 4 "Bar" 5 "Baz" elementId="args-5"}}`
     );
 
     assert.equal(this.$('#args-3').text(), 'Foo4Bar');
     assert.equal(this.$('#args-5').text(), 'Foo4Bar5Baz');
-    assert.equal(this.$('#helper').text(), 'Foo4Bar5Baz');
 
     this.runTask(() => this.rerender());
 
     assert.equal(this.$('#args-3').text(), 'Foo4Bar');
     assert.equal(this.$('#args-5').text(), 'Foo4Bar5Baz');
-    assert.equal(this.$('#helper').text(), 'Foo4Bar5Baz');
   }
 
-  ['@htmlbars arbitrary positional parameter conflict with hash parameter is reported']() {
+  ['@test arbitrary positional parameter conflict with hash parameter is reported']() {
     this.registerComponent('sample-component', {
       ComponentClass: Component.extend().reopenClass({
         positionalParams: 'names'
@@ -1231,7 +1228,7 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     this.assertText('Foo4Bar');
   }
 
-  ['@htmlbars can use hash parameter instead of positional param'](assert) {
+  ['@test can use hash parameter instead of positional param'](assert) {
     this.registerComponent('sample-component', {
       ComponentClass: Component.extend().reopenClass({
         positionalParams: ['first', 'second']
@@ -1239,10 +1236,11 @@ moduleFor('Components test: curly components', class extends RenderingTest {
       template: '{{first}} - {{second}}'
     });
 
+    // TODO: Fix when id is implemented
     this.render(strip`
-      {{sample-component "one" "two" id="two-positional"}}
-      {{sample-component "one" second="two" id="one-positional"}}
-      {{sample-component first="one" second="two" id="no-positional"}}`);
+      {{sample-component "one" "two" elementId="two-positional"}}
+      {{sample-component "one" second="two" elementId="one-positional"}}
+      {{sample-component first="one" second="two" elementId="no-positional"}}`);
 
     assert.equal(this.$('#two-positional').text(), 'one - two');
     assert.equal(this.$('#one-positional').text(), 'one - two');
@@ -1255,7 +1253,7 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     assert.equal(this.$('#no-positional').text(), 'one - two');
   }
 
-  ['@htmlbars dynamic arbitrary number of positional parameters'](assert) {
+  ['@test dynamic arbitrary number of positional parameters'](assert) {
     this.registerComponent('sample-component', {
       ComponentClass: Component.extend().reopenClass({
         positionalParams: 'n'
@@ -1266,40 +1264,33 @@ moduleFor('Components test: curly components', class extends RenderingTest {
         {{/each}}`
     });
 
-    this.render(strip`
-      {{sample-component user1 user2 id="direct"}}
-      {{component "sample-component" user1 user2 id="helper"}}`,
+    this.render(`{{sample-component user1 user2}}`,
       {
         user1: 'Foo',
         user2: 4
       }
     );
 
-    assert.equal(this.$('#direct').text(), 'Foo4', 'direct');
-    assert.equal(this.$('#helper').text(), 'Foo4', 'helper');
+    this.assertText('Foo4');
 
     this.runTask(() => this.rerender());
 
-    assert.equal(this.$('#direct').text(), 'Foo4', 'direct');
-    assert.equal(this.$('#helper').text(), 'Foo4', 'helper');
+    this.assertText('Foo4');
 
     this.runTask(() => this.context.set('user1', 'Bar'));
 
-    assert.equal(this.$('#direct').text(), 'Bar4', 'direct');
-    assert.equal(this.$('#helper').text(), 'Bar4', 'helper');
+    this.assertText('Bar4');
 
     this.runTask(() => this.context.set('user2', '5'));
 
-    assert.equal(this.$('#direct').text(), 'Bar5', 'direct');
-    assert.equal(this.$('#helper').text(), 'Bar5', 'helper');
+    this.assertText('Bar5');
 
     this.runTask(() => {
       this.context.set('user1', 'Foo');
       this.context.set('user2', 4);
     });
 
-    assert.equal(this.$('#direct').text(), 'Foo4', 'direct');
-    assert.equal(this.$('#helper').text(), 'Foo4', 'helper');
+    this.assertText('Foo4');
   }
 
   ['@test with ariaRole specified']() {
@@ -1446,7 +1437,7 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     this.assertText('In block No Block Param!');
   }
 
-  ['@htmlbars static named positional parameters']() {
+  ['@test static named positional parameters']() {
     this.registerComponent('sample-component', {
       ComponentClass: Component.extend().reopenClass({
         positionalParams: ['name', 'age']
@@ -1463,7 +1454,7 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     this.assertText('Quint4');
   }
 
-  ['@htmlbars dynamic named positional parameters']() {
+  ['@test dynamic named positional parameters']() {
     this.registerComponent('sample-component', {
       ComponentClass: Component.extend().reopenClass({
         positionalParams: ['name', 'age']
@@ -1498,7 +1489,7 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     this.assertText('Quint4');
   }
 
-  ['@htmlbars if a value is passed as a non-positional parameter, it raises an assertion']() {
+  ['@test if a value is passed as a non-positional parameter, it raises an assertion']() {
     this.registerComponent('sample-component', {
       ComponentClass: Component.extend().reopenClass({
         positionalParams: ['name']

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -23,7 +23,7 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     this.assertComponentElement(this.firstChild, { content: 'hello' });
   }
 
-  ['@htmlbars it can have a custom id and it is not bound']() {
+  ['@test it can have a custom id and it is not bound']() {
     this.registerComponent('foo-bar', { template: '{{id}} {{elementId}}' });
 
     this.render('{{foo-bar id=customId}}', {
@@ -90,7 +90,7 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     assert.equal(foundId, newFoundId);
   }
 
-  ['@htmlbars passing literal id is ignored and results in a default elementId'](assert) {
+  ['@test id is an alias for elementId'](assert) {
     let FooBarComponent = Component.extend({
       tagName: 'h1'
     });
@@ -108,6 +108,14 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     assert.equal(newFoundId, 'custom-id');
 
     assert.equal(foundId, newFoundId);
+  }
+
+  ['@glimmer cannot pass both id and elementId at the same time'](assert) {
+    this.registerComponent('foo-bar', { template: '' });
+
+    expectAssertion(() => {
+      this.render('{{foo-bar id="zomg" elementId="lol"}}');
+    }, /You cannot invoke a component with both 'id' and 'elementId' at the same time./);
   }
 
   ['@test it can have a custom tagName']() {


### PR DESCRIPTION
Rebased #13393  + #13478 refactored the implementations. This refactor turns the args processing into a reference. This pushes some of the triage and validation work upfront to allow for better runtime (especially update time) performance. It also tries to make the positional params feature Pay-As-You-Go by creating specialized objects for the three different cases.
