### PR TITLE
[Glimmer 2] Two-way binding support

### DIFF
--- a/packages/ember-glimmer/lib/utils/process-args.js
+++ b/packages/ember-glimmer/lib/utils/process-args.js
@@ -1,6 +1,7 @@
 import { CONSTANT_TAG } from 'glimmer-reference';
 import { assert } from 'ember-metal/debug';
 import EmptyObject from 'ember-metal/empty_object';
+import { ARGS } from '../component';
 
 export default function processArgs(args, positionalParamsDefinition) {
   if (!positionalParamsDefinition || positionalParamsDefinition.length === 0 || args.positional.length === 0) {
@@ -16,7 +17,7 @@ const EMPTY_ARGS = {
   tag: CONSTANT_TAG,
 
   value() {
-    return { attrs: {}, props: { attrs: {} } };
+    return { attrs: {}, props: { attrs: {}, [ARGS]: {} } };
   }
 };
 
@@ -39,13 +40,16 @@ class SimpleArgs {
     let keys = namedArgs.keys;
     let attrs = namedArgs.value();
     let props = new EmptyObject();
+    let args = new EmptyObject();
 
     props.attrs = attrs;
+    props[ARGS] = args;
 
     for (let i = 0, l = keys.length; i < l; i++) {
       let name = keys[i];
       let value = attrs[name];
 
+      args[name] = namedArgs.get(name);
       props[name] = value;
     }
 
@@ -72,6 +76,7 @@ class RestArgs {
 
     let result = simpleArgs.value();
 
+    result.props[ARGS] = positionalArgs;
     result.attrs[restArgName] = result.props[restArgName] = positionalArgs.value();
 
     return result;
@@ -111,7 +116,8 @@ class PositionalArgs {
 
     for (let i = 0; i < positionalParamNames.length; i++) {
       let name = positionalParamNames[i];
-      result.attrs[name] = result.props[name] = positionalArgs.at(i).value();
+      let reference = result.props[ARGS][name] = positionalArgs.at(i);
+      result.attrs[name] = result.props[name] = reference.value();
     }
 
     return result;

--- a/packages/ember-glimmer/lib/utils/references.js
+++ b/packages/ember-glimmer/lib/utils/references.js
@@ -1,10 +1,14 @@
 import { get } from 'ember-metal/property_get';
+import { set } from 'ember-metal/property_set';
 import { tagFor } from 'ember-metal/tags';
+import symbol from 'ember-metal/symbol';
 import { CURRENT_TAG, CONSTANT_TAG, VOLATILE_TAG, ConstReference, DirtyableTag, UpdatableTag, combine, isConst } from 'glimmer-reference';
 import { ConditionalReference as GlimmerConditionalReference, NULL_REFERENCE, UNDEFINED_REFERENCE } from 'glimmer-runtime';
 import emberToBool from './to-bool';
 import { RECOMPUTE_TAG } from '../helper';
 import { dasherize } from 'ember-runtime/system/string';
+
+export const UPDATE = symbol('UPDATE');
 
 // FIXME: fix tests that uses a "fake" proxy (i.e. a POJOs that "happen" to
 // have an `isTruthy` property on them). This is not actually supported –
@@ -95,6 +99,11 @@ class PropertyReference extends CachedReference { // jshint ignore:line
     } else {
       return null;
     }
+  }
+
+  [UPDATE](value) {
+    let parent = this._parentReference.value();
+    set(parent, this._propertyKey, value);
   }
 
   get(propertyKey) {

--- a/packages/ember-glimmer/tests/integration/content-test.js
+++ b/packages/ember-glimmer/tests/integration/content-test.js
@@ -190,6 +190,32 @@ class DynamicContentTest extends RenderingTest {
     this.assertInvariants();
   }
 
+  ['@test it can render a computed property with nested dependency']() {
+    let Formatter = EmberObject.extend({
+      formattedMessage: computed('messenger.message', function() {
+        return this.get('messenger.message').toUpperCase();
+      })
+    });
+
+    let m = Formatter.create({ messenger: { message: 'hello' } });
+
+    this.renderPath('m.formattedMessage', { m });
+
+    this.assertContent('HELLO');
+
+    this.assertStableRerender();
+
+    this.runTask(() => set(m, 'messenger.message', 'goodbye'));
+
+    this.assertContent('GOODBYE');
+    this.assertInvariants();
+
+    this.runTask(() => set(this.context, 'm', Formatter.create({ messenger: { message: 'hello' } })));
+
+    this.assertContent('HELLO');
+    this.assertInvariants();
+  }
+
   ['@test it can read from a null object']() {
     let nullObject = Object.create(null);
     nullObject['message'] = 'hello';

--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -334,6 +334,8 @@ ChainNode.prototype = {
   }
 };
 
+import { makeChainNode } from './watch_path';
+
 export function finishChains(obj) {
   // We only create meta if we really have to
   let m = peekMeta(obj);
@@ -348,7 +350,7 @@ export function finishChains(obj) {
     // ensure that if we have inherited any chains they have been
     // copied onto our own meta.
     if (m.readableChains()) {
-      m.writableChains();
+      m.writableChains(makeChainNode);
     }
   }
 }

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -416,10 +416,7 @@ ComputedPropertyPrototype._set = function computedPropertySet(obj, keyName, valu
     return ret;
   }
 
-  let watched = meta.peekWatching(keyName);
-  if (watched) {
-    propertyWillChange(obj, keyName);
-  }
+  propertyWillChange(obj, keyName);
 
   if (hadCachedValue) {
     cache[keyName] = undefined;
@@ -435,9 +432,7 @@ ComputedPropertyPrototype._set = function computedPropertySet(obj, keyName, valu
     cache[keyName] = ret;
   }
 
-  if (watched) {
-    propertyDidChange(obj, keyName);
-  }
+  propertyDidChange(obj, keyName);
 
   return ret;
 };

--- a/packages/ember-metal/lib/watch_path.js
+++ b/packages/ember-metal/lib/watch_path.js
@@ -10,14 +10,11 @@ function chainsFor(obj, meta) {
   return (meta || metaFor(obj)).writableChains(makeChainNode);
 }
 
-function makeChainNode(obj) {
+export function makeChainNode(obj) {
   return new ChainNode(null, null, obj);
 }
 
 export function watchPath(obj, keyPath, meta) {
-  // can't watch length on Array - it is special...
-  if (keyPath === 'length' && Array.isArray(obj)) { return; }
-
   var m = meta || metaFor(obj);
   let counter = m.peekWatching(keyPath) || 0;
   if (!counter) { // activate watching first time

--- a/packages/ember-metal/lib/watching.js
+++ b/packages/ember-metal/lib/watching.js
@@ -35,9 +35,6 @@ import {
   @param {String} _keyPath
 */
 function watch(obj, _keyPath, m) {
-  // can't watch length on Array - it is special...
-  if (_keyPath === 'length' && Array.isArray(obj)) { return; }
-
   if (!isPath(_keyPath)) {
     watchKey(obj, _keyPath, m);
   } else {
@@ -58,9 +55,6 @@ export function watcherCount(obj, key) {
 }
 
 export function unwatch(obj, _keyPath, m) {
-  // can't watch length on Array - it is special...
-  if (_keyPath === 'length' && Array.isArray(obj)) { return; }
-
   if (!isPath(_keyPath)) {
     unwatchKey(obj, _keyPath, m);
   } else {

--- a/packages/ember-metal/tests/watching/watch_test.js
+++ b/packages/ember-metal/tests/watching/watch_test.js
@@ -216,8 +216,8 @@ testBoth('watching "length" property on an array', function(get, set) {
   equal(get(arr, 'length'), 0, 'should have original prop');
 
   set(arr, 'length', '10');
-  equal(willCount, 0, 'should NOT have invoked willCount');
-  equal(didCount, 0, 'should NOT have invoked didCount');
+  equal(willCount, 1, 'should NOT have invoked willCount');
+  equal(didCount, 1, 'should NOT have invoked didCount');
 
   equal(get(arr, 'length'), 10, 'should get new value');
   equal(arr.length, 10, 'property should be accessible on arr');

--- a/packages/ember-runtime/lib/system/native_array.js
+++ b/packages/ember-runtime/lib/system/native_array.js
@@ -37,9 +37,7 @@ var NativeArray = Mixin.create(MutableArray, Observable, Copyable, {
   // because length is a built-in property we need to know to just get the
   // original property.
   get(key) {
-    if (key === 'length') {
-      return this.length;
-    } else if ('number' === typeof key) {
+    if ('number' === typeof key) {
       return this[key];
     } else {
       return this._super(key);

--- a/packages/ember-runtime/tests/system/object/observer_test.js
+++ b/packages/ember-runtime/tests/system/object/observer_test.js
@@ -208,4 +208,8 @@ testBoth('chain observer on class that has a reference to an uninitialized objec
   parent.set('one.two', 'new');
 
   equal(changed, true, 'child should have been notified of change to path');
+
+  parent.set('one', { two: 'newer' });
+
+  equal(changed, true, 'child should have been notified of change to path');
 });


### PR DESCRIPTION
This commit restructures some of the more arcane parts of ember-metal's observer system.

It eliminates some special casing around `length`, which isn't necessary anymore but complicates the overall abstraction of observable properties.

Relatedly, it also finishes implementing PROPERTY_DID_CHANGE, which now executes reliably any time an observer would have fired. You can think of it as an always-on observer if it's present on an object. Glimmer 2 curly components use this hook to propagate `set`s on components back to their original bindings (if the bindings are present).

This commit also implements two way bindings in Glimmer 2, by making PropertyReferences implement an `UPDATE` method. If that method is present, it is used to propagate changes upwards (otherwise, an exception is thrown).
