### PR TITLE
Application / Engine boot refactor

### DIFF
--- a/packages/ember-application/lib/system/engine.js
+++ b/packages/ember-application/lib/system/engine.js
@@ -70,6 +70,27 @@ const Engine = Namespace.extend(RegistryProxy, {
   },
 
   /**
+    A private flag indicating whether an engine's initializers have run yet.
+
+    @private
+    @property _initializersRan
+  */
+  _initializersRan: false,
+
+  /**
+    Ensure that initializers are run once, and only once, per Engine.
+
+    @private
+    @method ensureInitializers
+  */
+  ensureInitializers() {
+    if (!this._initializersRan) {
+      this.runInitializers();
+      this._initializersRan = true;
+    }
+  },
+
+  /**
     Create an EngineInstance for this application.
 
     @private
@@ -77,6 +98,7 @@ const Engine = Namespace.extend(RegistryProxy, {
     @return {Ember.EngineInstance} the application instance
   */
   buildInstance(options = {}) {
+    this.ensureInitializers();
     options.base = this;
     return EngineInstance.create(options);
   },

--- a/packages/ember-application/tests/system/engine_initializers_test.js
+++ b/packages/ember-application/tests/system/engine_initializers_test.js
@@ -1,0 +1,342 @@
+import run from 'ember-metal/run_loop';
+import Engine from 'ember-application/system/engine';
+
+let MyEngine,
+    myEngine,
+    myEngineInstance;
+
+QUnit.module('Ember.Engine initializers', {
+  setup() {
+  },
+
+  teardown() {
+    run(function() {
+      if (myEngineInstance) {
+        myEngineInstance.destroy();
+      }
+
+      if (myEngine) {
+        myEngine.destroy();
+      }
+    });
+  }
+});
+
+QUnit.test('initializers require proper \'name\' and \'initialize\' properties', function() {
+  MyEngine = Engine.extend();
+
+  expectAssertion(function() {
+    run(function() {
+      MyEngine.initializer({ name: 'initializer' });
+    });
+  });
+
+  expectAssertion(function() {
+    run(function() {
+      MyEngine.initializer({ initialize() {} });
+    });
+  });
+});
+
+QUnit.test('initializers are passed an Engine', function() {
+  MyEngine = Engine.extend();
+
+  MyEngine.initializer({
+    name: 'initializer',
+    initialize(engine) {
+      ok(engine instanceof Engine, 'initialize is passed an Engine');
+    }
+  });
+
+  myEngine = MyEngine.create();
+  myEngineInstance = myEngine.buildInstance();
+});
+
+QUnit.test('initializers can be registered in a specified order', function() {
+  let order = [];
+
+  MyEngine = Engine.extend();
+  MyEngine.initializer({
+    name: 'fourth',
+    after: 'third',
+    initialize(engine) {
+      order.push('fourth');
+    }
+  });
+
+  MyEngine.initializer({
+    name: 'second',
+    after: 'first',
+    before: 'third',
+    initialize(engine) {
+      order.push('second');
+    }
+  });
+
+  MyEngine.initializer({
+    name: 'fifth',
+    after: 'fourth',
+    before: 'sixth',
+    initialize(engine) {
+      order.push('fifth');
+    }
+  });
+
+  MyEngine.initializer({
+    name: 'first',
+    before: 'second',
+    initialize(engine) {
+      order.push('first');
+    }
+  });
+
+  MyEngine.initializer({
+    name: 'third',
+    initialize(engine) {
+      order.push('third');
+    }
+  });
+
+  MyEngine.initializer({
+    name: 'sixth',
+    initialize(engine) {
+      order.push('sixth');
+    }
+  });
+
+  myEngine = MyEngine.create();
+  myEngineInstance = myEngine.buildInstance();
+
+  deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
+});
+
+QUnit.test('initializers can be registered in a specified order as an array', function() {
+  let order = [];
+
+  MyEngine = Engine.extend();
+
+  MyEngine.initializer({
+    name: 'third',
+    initialize(engine) {
+      order.push('third');
+    }
+  });
+
+  MyEngine.initializer({
+    name: 'second',
+    after: 'first',
+    before: ['third', 'fourth'],
+    initialize(engine) {
+      order.push('second');
+    }
+  });
+
+  MyEngine.initializer({
+    name: 'fourth',
+    after: ['second', 'third'],
+    initialize(engine) {
+      order.push('fourth');
+    }
+  });
+
+  MyEngine.initializer({
+    name: 'fifth',
+    after: 'fourth',
+    before: 'sixth',
+    initialize(engine) {
+      order.push('fifth');
+    }
+  });
+
+  MyEngine.initializer({
+    name: 'first',
+    before: ['second'],
+    initialize(engine) {
+      order.push('first');
+    }
+  });
+
+  MyEngine.initializer({
+    name: 'sixth',
+    initialize(engine) {
+      order.push('sixth');
+    }
+  });
+
+  myEngine = MyEngine.create();
+  myEngineInstance = myEngine.buildInstance();
+
+  deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
+});
+
+QUnit.test('initializers can have multiple dependencies', function () {
+  let order = [];
+
+  MyEngine = Engine.extend();
+
+  let a = {
+    name: 'a',
+    before: 'b',
+    initialize(engine) {
+      order.push('a');
+    }
+  };
+  let b = {
+    name: 'b',
+    initialize(engine) {
+      order.push('b');
+    }
+  };
+  let c = {
+    name: 'c',
+    after: 'b',
+    initialize(engine) {
+      order.push('c');
+    }
+  };
+  let afterB = {
+    name: 'after b',
+    after: 'b',
+    initialize(engine) {
+      order.push('after b');
+    }
+  };
+  let afterC = {
+    name: 'after c',
+    after: 'c',
+    initialize(engine) {
+      order.push('after c');
+    }
+  };
+
+  MyEngine.initializer(b);
+  MyEngine.initializer(a);
+  MyEngine.initializer(afterC);
+  MyEngine.initializer(afterB);
+  MyEngine.initializer(c);
+
+  myEngine = MyEngine.create();
+  myEngineInstance = myEngine.buildInstance();
+
+  ok(order.indexOf(a.name) < order.indexOf(b.name), 'a < b');
+  ok(order.indexOf(b.name) < order.indexOf(c.name), 'b < c');
+  ok(order.indexOf(b.name) < order.indexOf(afterB.name), 'b < afterB');
+  ok(order.indexOf(c.name) < order.indexOf(afterC.name), 'c < afterC');
+});
+
+QUnit.test('initializers set on Engine subclasses are not shared between engines', function() {
+  let firstInitializerRunCount = 0;
+  let secondInitializerRunCount = 0;
+  let FirstEngine = Engine.extend();
+
+  FirstEngine.initializer({
+    name: 'first',
+    initialize(engine) {
+      firstInitializerRunCount++;
+    }
+  });
+
+  let SecondEngine = Engine.extend();
+
+  SecondEngine.initializer({
+    name: 'second',
+    initialize(engine) {
+      secondInitializerRunCount++;
+    }
+  });
+
+  let firstEngine = FirstEngine.create();
+  let firstEngineInstance = firstEngine.buildInstance();
+
+  equal(firstInitializerRunCount, 1, 'first initializer only was run');
+  equal(secondInitializerRunCount, 0, 'first initializer only was run');
+
+  let secondEngine = SecondEngine.create();
+  let secondEngineInstance = secondEngine.buildInstance();
+
+  equal(firstInitializerRunCount, 1, 'second initializer only was run');
+  equal(secondInitializerRunCount, 1, 'second initializer only was run');
+
+  run(function() {
+    firstEngineInstance.destroy();
+    secondEngineInstance.destroy();
+
+    firstEngine.destroy();
+    secondEngine.destroy();
+  });
+});
+
+QUnit.test('initializers are concatenated', function() {
+  let firstInitializerRunCount = 0;
+  let secondInitializerRunCount = 0;
+  let FirstEngine = Engine.extend();
+
+  FirstEngine.initializer({
+    name: 'first',
+    initialize(engine) {
+      firstInitializerRunCount++;
+    }
+  });
+
+  let SecondEngine = FirstEngine.extend();
+
+  SecondEngine.initializer({
+    name: 'second',
+    initialize(engine) {
+      secondInitializerRunCount++;
+    }
+  });
+
+  let firstEngine = FirstEngine.create();
+  let firstEngineInstance = firstEngine.buildInstance();
+
+  equal(firstInitializerRunCount, 1, 'first initializer only was run when base class created');
+  equal(secondInitializerRunCount, 0, 'second initializer was not run when first base class created');
+  firstInitializerRunCount = 0;
+
+  let secondEngine = SecondEngine.create();
+  let secondEngineInstance = secondEngine.buildInstance();
+
+  equal(firstInitializerRunCount, 1, 'first initializer was run when subclass created');
+  equal(secondInitializerRunCount, 1, 'second initializers was run when subclass created');
+
+  run(function() {
+    firstEngineInstance.destroy();
+    secondEngineInstance.destroy();
+
+    firstEngine.destroy();
+    secondEngine.destroy();
+  });
+});
+
+QUnit.test('initializers are per-engine', function() {
+  expect(0);
+  let FirstEngine = Engine.extend();
+  FirstEngine.initializer({
+    name: 'shouldNotCollide',
+    initialize(engine) {}
+  });
+
+  let SecondEngine = Engine.extend();
+  SecondEngine.initializer({
+    name: 'shouldNotCollide',
+    initialize(engine) {}
+  });
+});
+
+QUnit.test('initializers are executed in their own context', function() {
+  expect(1);
+
+  MyEngine = Engine.extend();
+
+  MyEngine.initializer({
+    name: 'coolInitializer',
+    myProperty: 'cool',
+    initialize(engine) {
+      equal(this.myProperty, 'cool', 'should have access to its own context');
+    }
+  });
+
+  myEngine = MyEngine.create();
+  myEngineInstance = myEngine.buildInstance();
+});

--- a/packages/ember-application/tests/system/engine_initializers_test.js
+++ b/packages/ember-application/tests/system/engine_initializers_test.js
@@ -310,18 +310,29 @@ QUnit.test('initializers are concatenated', function() {
 });
 
 QUnit.test('initializers are per-engine', function() {
-  expect(0);
+  expect(2);
+
   let FirstEngine = Engine.extend();
+
   FirstEngine.initializer({
-    name: 'shouldNotCollide',
+    name: 'abc',
     initialize(engine) {}
   });
 
+  throws(function() {
+    FirstEngine.initializer({
+      name: 'abc',
+      initialize(engine) {}
+    });
+  }, Error, /Assertion Failed: The initializer 'abc' has already been registered'/);
+
   let SecondEngine = Engine.extend();
-  SecondEngine.initializer({
-    name: 'shouldNotCollide',
+  SecondEngine.instanceInitializer({
+    name: 'abc',
     initialize(engine) {}
   });
+
+  ok(true, 'Two engines can have initializers named the same.');
 });
 
 QUnit.test('initializers are executed in their own context', function() {

--- a/packages/ember-application/tests/system/engine_instance_initializers_test.js
+++ b/packages/ember-application/tests/system/engine_instance_initializers_test.js
@@ -1,0 +1,366 @@
+import run from 'ember-metal/run_loop';
+import Engine from 'ember-application/system/engine';
+import EngineInstance from 'ember-application/system/engine-instance';
+
+let MyEngine,
+    myEngine,
+    myEngineInstance;
+
+QUnit.module('Ember.Engine instance initializers', {
+  setup() {
+  },
+
+  teardown() {
+    run(function() {
+      if (myEngineInstance) {
+        myEngineInstance.destroy();
+      }
+
+      if (myEngine) {
+        myEngine.destroy();
+      }
+    });
+  }
+});
+
+QUnit.test('initializers require proper \'name\' and \'initialize\' properties', function() {
+  MyEngine = Engine.extend();
+
+  expectAssertion(function() {
+    run(function() {
+      MyEngine.instanceInitializer({ name: 'initializer' });
+    });
+  });
+
+  expectAssertion(function() {
+    run(function() {
+      MyEngine.instanceInitializer({ initialize() {} });
+    });
+  });
+});
+
+QUnit.test('initializers are passed an engine instance', function() {
+  MyEngine = Engine.extend();
+
+  MyEngine.instanceInitializer({
+    name: 'initializer',
+    initialize(instance) {
+      ok(instance instanceof EngineInstance, 'initialize is passed an engine instance');
+    }
+  });
+
+  myEngine = MyEngine.create();
+  myEngineInstance = myEngine.buildInstance();
+  return myEngineInstance.boot();
+});
+
+QUnit.test('initializers can be registered in a specified order', function() {
+  let order = [];
+
+  MyEngine = Engine.extend();
+
+  MyEngine.instanceInitializer({
+    name: 'fourth',
+    after: 'third',
+    initialize(engine) {
+      order.push('fourth');
+    }
+  });
+
+  MyEngine.instanceInitializer({
+    name: 'second',
+    after: 'first',
+    before: 'third',
+    initialize(engine) {
+      order.push('second');
+    }
+  });
+
+  MyEngine.instanceInitializer({
+    name: 'fifth',
+    after: 'fourth',
+    before: 'sixth',
+    initialize(engine) {
+      order.push('fifth');
+    }
+  });
+
+  MyEngine.instanceInitializer({
+    name: 'first',
+    before: 'second',
+    initialize(engine) {
+      order.push('first');
+    }
+  });
+
+  MyEngine.instanceInitializer({
+    name: 'third',
+    initialize(engine) {
+      order.push('third');
+    }
+  });
+
+  MyEngine.instanceInitializer({
+    name: 'sixth',
+    initialize(engine) {
+      order.push('sixth');
+    }
+  });
+
+  myEngine = MyEngine.create();
+  myEngineInstance = myEngine.buildInstance();
+
+  return myEngineInstance.boot().then(() => {
+    deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
+  });
+});
+
+QUnit.test('initializers can be registered in a specified order as an array', function() {
+  let order = [];
+  MyEngine = Engine.extend();
+
+  MyEngine.instanceInitializer({
+    name: 'third',
+    initialize(engine) {
+      order.push('third');
+    }
+  });
+
+  MyEngine.instanceInitializer({
+    name: 'second',
+    after: 'first',
+    before: ['third', 'fourth'],
+    initialize(engine) {
+      order.push('second');
+    }
+  });
+
+  MyEngine.instanceInitializer({
+    name: 'fourth',
+    after: ['second', 'third'],
+    initialize(engine) {
+      order.push('fourth');
+    }
+  });
+
+  MyEngine.instanceInitializer({
+    name: 'fifth',
+    after: 'fourth',
+    before: 'sixth',
+    initialize(engine) {
+      order.push('fifth');
+    }
+  });
+
+  MyEngine.instanceInitializer({
+    name: 'first',
+    before: ['second'],
+    initialize(engine) {
+      order.push('first');
+    }
+  });
+
+  MyEngine.instanceInitializer({
+    name: 'sixth',
+    initialize(engine) {
+      order.push('sixth');
+    }
+  });
+
+  myEngine = MyEngine.create();
+  myEngineInstance = myEngine.buildInstance();
+
+  return myEngineInstance.boot().then(() => {
+    deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
+  });
+});
+
+QUnit.test('initializers can have multiple dependencies', function () {
+  let order = [];
+
+  MyEngine = Engine.extend();
+
+  let a = {
+    name: 'a',
+    before: 'b',
+    initialize(engine) {
+      order.push('a');
+    }
+  };
+  let b = {
+    name: 'b',
+    initialize(engine) {
+      order.push('b');
+    }
+  };
+  let c = {
+    name: 'c',
+    after: 'b',
+    initialize(engine) {
+      order.push('c');
+    }
+  };
+  let afterB = {
+    name: 'after b',
+    after: 'b',
+    initialize(engine) {
+      order.push('after b');
+    }
+  };
+  let afterC = {
+    name: 'after c',
+    after: 'c',
+    initialize(engine) {
+      order.push('after c');
+    }
+  };
+
+  MyEngine.instanceInitializer(b);
+  MyEngine.instanceInitializer(a);
+  MyEngine.instanceInitializer(afterC);
+  MyEngine.instanceInitializer(afterB);
+  MyEngine.instanceInitializer(c);
+
+  myEngine = MyEngine.create();
+  myEngineInstance = myEngine.buildInstance();
+
+  return myEngineInstance.boot().then(() => {
+    ok(order.indexOf(a.name) < order.indexOf(b.name), 'a < b');
+    ok(order.indexOf(b.name) < order.indexOf(c.name), 'b < c');
+    ok(order.indexOf(b.name) < order.indexOf(afterB.name), 'b < afterB');
+    ok(order.indexOf(c.name) < order.indexOf(afterC.name), 'c < afterC');
+  });
+});
+
+QUnit.test('initializers set on Engine subclasses should not be shared between engines', function() {
+  let firstInitializerRunCount = 0;
+  let secondInitializerRunCount = 0;
+  let FirstEngine = Engine.extend();
+  let firstEngine, firstEngineInstance;
+
+  FirstEngine.instanceInitializer({
+    name: 'first',
+    initialize(engine) {
+      firstInitializerRunCount++;
+    }
+  });
+
+  let SecondEngine = Engine.extend();
+  let secondEngine, secondEngineInstance;
+
+  SecondEngine.instanceInitializer({
+    name: 'second',
+    initialize(engine) {
+      secondInitializerRunCount++;
+    }
+  });
+
+  firstEngine = FirstEngine.create();
+  firstEngineInstance = firstEngine.buildInstance();
+
+  return firstEngineInstance.boot()
+    .then(() => {
+      equal(firstInitializerRunCount, 1, 'first initializer only was run');
+      equal(secondInitializerRunCount, 0, 'first initializer only was run');
+
+      secondEngine = SecondEngine.create();
+      secondEngineInstance = secondEngine.buildInstance();
+      return secondEngineInstance.boot();
+    })
+    .then(() => {
+      equal(firstInitializerRunCount, 1, 'second initializer only was run');
+      equal(secondInitializerRunCount, 1, 'second initializer only was run');
+
+      run(function() {
+        firstEngineInstance.destroy();
+        secondEngineInstance.destroy();
+
+        firstEngine.destroy();
+        secondEngine.destroy();
+      });
+    });
+});
+
+QUnit.test('initializers are concatenated', function() {
+  let firstInitializerRunCount = 0;
+  let secondInitializerRunCount = 0;
+  let FirstEngine = Engine.extend();
+
+  FirstEngine.instanceInitializer({
+    name: 'first',
+    initialize(engine) {
+      firstInitializerRunCount++;
+    }
+  });
+
+  let SecondEngine = FirstEngine.extend();
+
+  SecondEngine.instanceInitializer({
+    name: 'second',
+    initialize(engine) {
+      secondInitializerRunCount++;
+    }
+  });
+
+  let firstEngine = FirstEngine.create();
+  let firstEngineInstance = firstEngine.buildInstance();
+
+  let secondEngine, secondEngineInstance;
+
+  return firstEngineInstance.boot()
+    .then(() => {
+      equal(firstInitializerRunCount, 1, 'first initializer only was run when base class created');
+      equal(secondInitializerRunCount, 0, 'second initializer was not run when first base class created');
+      firstInitializerRunCount = 0;
+
+      secondEngine = SecondEngine.create();
+      secondEngineInstance = secondEngine.buildInstance();
+      return secondEngineInstance.boot();
+    })
+    .then(() => {
+      equal(firstInitializerRunCount, 1, 'first initializer was run when subclass created');
+      equal(secondInitializerRunCount, 1, 'second initializers was run when subclass created');
+
+      run(function() {
+        firstEngineInstance.destroy();
+        secondEngineInstance.destroy();
+
+        firstEngine.destroy();
+        secondEngine.destroy();
+      });
+    });
+});
+
+QUnit.test('initializers are per-engine', function() {
+  expect(0);
+  let FirstEngine = Engine.extend();
+  FirstEngine.instanceInitializer({
+    name: 'shouldNotCollide',
+    initialize(engine) {}
+  });
+
+  let SecondEngine = Engine.extend();
+  SecondEngine.instanceInitializer({
+    name: 'shouldNotCollide',
+    initialize(engine) {}
+  });
+});
+
+QUnit.test('initializers are executed in their own context', function() {
+  expect(1);
+
+  let MyEngine = Engine.extend();
+
+  MyEngine.instanceInitializer({
+    name: 'coolInitializer',
+    myProperty: 'cool',
+    initialize(engine) {
+      equal(this.myProperty, 'cool', 'should have access to its own context');
+    }
+  });
+
+  myEngine = MyEngine.create();
+  myEngineInstance = myEngine.buildInstance();
+
+  return myEngineInstance.boot();
+});

--- a/packages/ember-application/tests/system/engine_instance_initializers_test.js
+++ b/packages/ember-application/tests/system/engine_instance_initializers_test.js
@@ -332,18 +332,29 @@ QUnit.test('initializers are concatenated', function() {
 });
 
 QUnit.test('initializers are per-engine', function() {
-  expect(0);
+  expect(2);
+
   let FirstEngine = Engine.extend();
+
   FirstEngine.instanceInitializer({
-    name: 'shouldNotCollide',
+    name: 'abc',
     initialize(engine) {}
   });
 
+  throws(function() {
+    FirstEngine.instanceInitializer({
+      name: 'abc',
+      initialize(engine) {}
+    });
+  }, Error, /Assertion Failed: The instance initializer 'abc' has already been registered'/);
+
   let SecondEngine = Engine.extend();
   SecondEngine.instanceInitializer({
-    name: 'shouldNotCollide',
+    name: 'abc',
     initialize(engine) {}
   });
+
+  ok(true, 'Two engines can have initializers named the same.');
 });
 
 QUnit.test('initializers are executed in their own context', function() {

--- a/packages/ember-application/tests/system/initializers_test.js
+++ b/packages/ember-application/tests/system/initializers_test.js
@@ -349,18 +349,29 @@ QUnit.test('initializers are concatenated', function() {
 });
 
 QUnit.test('initializers are per-app', function() {
-  expect(0);
-  var FirstApp = Application.extend();
+  expect(2);
+
+  let FirstApp = Application.extend();
+
   FirstApp.initializer({
-    name: 'shouldNotCollide',
-    initialize(application) {}
+    name: 'abc',
+    initialize(app) {}
   });
 
-  var SecondApp = Application.extend();
-  SecondApp.initializer({
-    name: 'shouldNotCollide',
-    initialize(application) {}
+  throws(function() {
+    FirstApp.initializer({
+      name: 'abc',
+      initialize(app) {}
+    });
+  }, Error, /Assertion Failed: The initializer 'abc' has already been registered'/);
+
+  let SecondApp = Application.extend();
+  SecondApp.instanceInitializer({
+    name: 'abc',
+    initialize(app) {}
   });
+
+  ok(true, 'Two apps can have initializers named the same.');
 });
 
 QUnit.test('initializers are executed in their own context', function() {

--- a/packages/ember-application/tests/system/instance_initializers_test.js
+++ b/packages/ember-application/tests/system/instance_initializers_test.js
@@ -318,18 +318,29 @@ QUnit.test('initializers are concatenated', function() {
 });
 
 QUnit.test('initializers are per-app', function() {
-  expect(0);
-  var FirstApp = Application.extend();
+  expect(2);
+
+  let FirstApp = Application.extend();
+
   FirstApp.instanceInitializer({
-    name: 'shouldNotCollide',
-    initialize(registry) {}
+    name: 'abc',
+    initialize(app) {}
   });
 
-  var SecondApp = Application.extend();
+  throws(function() {
+    FirstApp.instanceInitializer({
+      name: 'abc',
+      initialize(app) {}
+    });
+  }, Error, /Assertion Failed: The instance initializer 'abc' has already been registered'/);
+
+  let SecondApp = Application.extend();
   SecondApp.instanceInitializer({
-    name: 'shouldNotCollide',
-    initialize(registry) {}
+    name: 'abc',
+    initialize(app) {}
   });
+
+  ok(true, 'Two apps can have initializers named the same.');
 });
 
 QUnit.test('initializers are run before ready hook', function() {


### PR DESCRIPTION
Common boot concerns for engine instances and application instances have been moved to the `EngineInstance` class. These concerns include running engine initializers and engine instance initializers. 

Engine initializers are run once before the first engine instance is built, following the [approach taken in ember-engines](https://github.com/dgeb/ember-engines/commit/a7f3a891a4f243e97cc5c1b2d94b2d36b45505bb).

Setup of an engine instance's registry based upon its parent will be handled in a separate PR.
