### PR TITLE
Remove unreachable code in transformation

### DIFF
--- a/packages/ember-template-compiler/lib/plugins/transform-top-level-components.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-top-level-components.js
@@ -9,31 +9,15 @@ function TransformTopLevelComponents() {
   @param {AST} The AST to be transformed.
 */
 TransformTopLevelComponents.prototype.transform = function TransformTopLevelComponents_transform(ast) {
-  let b = this.syntax.builders;
-
   hasSingleComponentNode(ast, component => {
-    if (component.type === 'ComponentNode') {
-      component.tag = `@${component.tag}`;
-      component.isStatic = true;
-    }
-  }, element => {
-    let hasTripleCurlies = element.attributes.some(attr => attr.value.escaped === false);
-
-    if (element.modifiers.length || hasTripleCurlies) {
-      return element;
-    } else {
-      // TODO: Properly copy loc from children
-      let program = b.program(element.children);
-      let component = b.component(`@<${element.tag}>`, element.attributes, program, element.loc);
-      component.isStatic = true;
-      return component;
-    }
+    component.tag = `@${component.tag}`;
+    component.isStatic = true;
   });
 
   return ast;
 };
 
-function hasSingleComponentNode(program, componentCallback, elementCallback) {
+function hasSingleComponentNode(program, componentCallback) {
   let { loc, body } = program;
   if (!loc || loc.start.line !== 1 || loc.start.column !== 0) { return; }
 


### PR DESCRIPTION
In `transform-top-level-components` there was an unused callback and the node's
type was checked twice. This PR fixes them.
