### PR TITLE
Allow engine instances to spawn other engine instances.

### DIFF
--- a/packages/ember-application/lib/system/engine-instance.js
+++ b/packages/ember-application/lib/system/engine-instance.js
@@ -7,6 +7,8 @@ import EmberObject from 'ember-runtime/system/object';
 import Registry from 'container/registry';
 import ContainerProxy from 'ember-runtime/mixins/container_proxy';
 import RegistryProxy from 'ember-runtime/mixins/registry_proxy';
+import { getEngineParent } from 'ember-application/system/engine-parent';
+import { assert } from 'ember-metal/debug';
 import run from 'ember-metal/run_loop';
 import RSVP from 'ember-runtime/ext/rsvp';
 
@@ -90,6 +92,8 @@ const EngineInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
   */
   _bootSync(options) {
     if (this._booted) { return this; }
+
+    assert('An engine instance\'s parent must be set via `setEngineParent(engine, parent)` prior to calling `engine.boot()`.', getEngineParent(this));
 
     this.base.runInstanceInitializers(this);
 

--- a/packages/ember-application/lib/system/engine-instance.js
+++ b/packages/ember-application/lib/system/engine-instance.js
@@ -4,13 +4,15 @@
 */
 
 import EmberObject from 'ember-runtime/system/object';
+import EmberError from 'ember-metal/error';
 import Registry from 'container/registry';
 import ContainerProxy from 'ember-runtime/mixins/container_proxy';
 import RegistryProxy from 'ember-runtime/mixins/registry_proxy';
-import { getEngineParent } from 'ember-application/system/engine-parent';
+import { getEngineParent, setEngineParent } from 'ember-application/system/engine-parent';
 import { assert } from 'ember-metal/debug';
 import run from 'ember-metal/run_loop';
 import RSVP from 'ember-runtime/ext/rsvp';
+import isEnabled from 'ember-metal/features';
 
 /**
   The `EngineInstance` encapsulates all of the stateful aspects of a
@@ -125,5 +127,35 @@ const EngineInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
     run(this.__container__, 'destroy');
   }
 });
+
+if (isEnabled('ember-application-engines')) {
+  EngineInstance.reopen({
+    /**
+      Build a new `Ember.EngineInstance` that's a child of this instance.
+
+      Engines must be registered by name with their parent engine
+      (or application).
+
+      @private
+      @method buildChildEngineInstance
+      @param name {String} the registered name of the engine.
+      @param options {Object} options provided to the engine instance.
+      @return {Ember.EngineInstance,Error}
+    */
+    buildChildEngineInstance(name, options = {}) {
+      let Engine = this.lookup(`engine:${name}`);
+
+      if (!Engine) {
+        throw new EmberError(`You attempted to mount the engine '${name}', but it is not registered with its parent.`);
+      }
+
+      let engineInstance = Engine.buildInstance(options);
+
+      setEngineParent(engineInstance, this);
+
+      return engineInstance;
+    }
+  });
+}
 
 export default EngineInstance;

--- a/packages/ember-application/lib/system/engine-parent.js
+++ b/packages/ember-application/lib/system/engine-parent.js
@@ -1,0 +1,33 @@
+/**
+@module ember
+@submodule ember-application
+*/
+
+import symbol from 'ember-metal/symbol';
+
+export const ENGINE_PARENT = symbol('ENGINE_PARENT');
+
+/**
+  `getEngineParent` retrieves an engine instance's parent instance.
+
+  @method getEngineParent
+  @param {EngineInstance} engine An engine instance.
+  @return {EngineInstance} The parent engine instance.
+  @for Ember
+  @public
+*/
+export function getEngineParent(engine) {
+  return engine[ENGINE_PARENT];
+}
+
+/**
+  `setEngineParent` sets an engine instance's parent instance.
+
+  @method setEngineParent
+  @param {EngineInstance} engine An engine instance.
+  @param {EngineInstance} parent The parent engine instance.
+  @private
+*/
+export function setEngineParent(engine, parent) {
+  engine[ENGINE_PARENT] = parent;
+}

--- a/packages/ember-application/lib/system/engine.js
+++ b/packages/ember-application/lib/system/engine.js
@@ -80,7 +80,7 @@ const Engine = Namespace.extend(RegistryProxy, {
   _initializersRan: false,
 
   /**
-    Ensure that initializers are run once, and only once, per Engine.
+    Ensure that initializers are run once, and only once, per engine.
 
     @private
     @method ensureInitializers
@@ -93,11 +93,11 @@ const Engine = Namespace.extend(RegistryProxy, {
   },
 
   /**
-    Create an EngineInstance for this application.
+    Create an EngineInstance for this engine.
 
     @private
     @method buildInstance
-    @return {Ember.EngineInstance} the application instance
+    @return {Ember.EngineInstance} the engine instance
   */
   buildInstance(options = {}) {
     this.ensureInitializers();
@@ -106,7 +106,7 @@ const Engine = Namespace.extend(RegistryProxy, {
   },
 
   /**
-    Build and configure the registry for the current application.
+    Build and configure the registry for the current engine.
 
     @private
     @method buildRegistry

--- a/packages/ember-application/tests/system/engine_instance_initializers_test.js
+++ b/packages/ember-application/tests/system/engine_instance_initializers_test.js
@@ -1,10 +1,17 @@
 import run from 'ember-metal/run_loop';
 import Engine from 'ember-application/system/engine';
 import EngineInstance from 'ember-application/system/engine-instance';
+import { setEngineParent } from 'ember-application/system/engine-parent';
 
 let MyEngine,
     myEngine,
     myEngineInstance;
+
+function buildEngineInstance(EngineClass) {
+  let engineInstance = EngineClass.buildInstance();
+  setEngineParent(engineInstance, {});
+  return engineInstance;
+}
 
 QUnit.module('Ember.Engine instance initializers', {
   setup() {
@@ -50,7 +57,7 @@ QUnit.test('initializers are passed an engine instance', function() {
   });
 
   myEngine = MyEngine.create();
-  myEngineInstance = myEngine.buildInstance();
+  myEngineInstance = buildEngineInstance(myEngine);
   return myEngineInstance.boot();
 });
 
@@ -108,7 +115,7 @@ QUnit.test('initializers can be registered in a specified order', function() {
   });
 
   myEngine = MyEngine.create();
-  myEngineInstance = myEngine.buildInstance();
+  myEngineInstance = buildEngineInstance(myEngine);
 
   return myEngineInstance.boot().then(() => {
     deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
@@ -168,7 +175,7 @@ QUnit.test('initializers can be registered in a specified order as an array', fu
   });
 
   myEngine = MyEngine.create();
-  myEngineInstance = myEngine.buildInstance();
+  myEngineInstance = buildEngineInstance(myEngine);
 
   return myEngineInstance.boot().then(() => {
     deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
@@ -222,7 +229,7 @@ QUnit.test('initializers can have multiple dependencies', function () {
   MyEngine.instanceInitializer(c);
 
   myEngine = MyEngine.create();
-  myEngineInstance = myEngine.buildInstance();
+  myEngineInstance = buildEngineInstance(myEngine);
 
   return myEngineInstance.boot().then(() => {
     ok(order.indexOf(a.name) < order.indexOf(b.name), 'a < b');
@@ -256,7 +263,7 @@ QUnit.test('initializers set on Engine subclasses should not be shared between e
   });
 
   firstEngine = FirstEngine.create();
-  firstEngineInstance = firstEngine.buildInstance();
+  firstEngineInstance = buildEngineInstance(firstEngine);
 
   return firstEngineInstance.boot()
     .then(() => {
@@ -264,7 +271,7 @@ QUnit.test('initializers set on Engine subclasses should not be shared between e
       equal(secondInitializerRunCount, 0, 'first initializer only was run');
 
       secondEngine = SecondEngine.create();
-      secondEngineInstance = secondEngine.buildInstance();
+      secondEngineInstance = buildEngineInstance(secondEngine);
       return secondEngineInstance.boot();
     })
     .then(() => {
@@ -303,7 +310,7 @@ QUnit.test('initializers are concatenated', function() {
   });
 
   let firstEngine = FirstEngine.create();
-  let firstEngineInstance = firstEngine.buildInstance();
+  let firstEngineInstance = buildEngineInstance(firstEngine);
 
   let secondEngine, secondEngineInstance;
 
@@ -314,7 +321,7 @@ QUnit.test('initializers are concatenated', function() {
       firstInitializerRunCount = 0;
 
       secondEngine = SecondEngine.create();
-      secondEngineInstance = secondEngine.buildInstance();
+      secondEngineInstance = buildEngineInstance(secondEngine);
       return secondEngineInstance.boot();
     })
     .then(() => {
@@ -371,7 +378,7 @@ QUnit.test('initializers are executed in their own context', function() {
   });
 
   myEngine = MyEngine.create();
-  myEngineInstance = myEngine.buildInstance();
+  myEngineInstance = buildEngineInstance(myEngine);
 
   return myEngineInstance.boot();
 });

--- a/packages/ember-application/tests/system/engine_instance_test.js
+++ b/packages/ember-application/tests/system/engine_instance_test.js
@@ -1,5 +1,6 @@
 import Engine from 'ember-application/system/engine';
 import EngineInstance from 'ember-application/system/engine-instance';
+import { setEngineParent } from 'ember-application/system/engine-parent';
 import run from 'ember-metal/run_loop';
 import factory from 'container/tests/test-helpers/factory';
 
@@ -53,4 +54,20 @@ QUnit.test('unregistering a factory clears all cached instances of that factory'
   assert.ok(postComponent2, 'lookup creates instance');
 
   assert.notStrictEqual(postComponent1, postComponent2, 'lookup creates a brand new instance because previous one was reset');
+});
+
+QUnit.test('can be booted when its parent has been set', function(assert) {
+  run(function() {
+    engineInstance = EngineInstance.create({ base: engine });
+  });
+
+  expectAssertion(function() {
+    engineInstance._bootSync();
+  }, 'An engine instance\'s parent must be set via `setEngineParent(engine, parent)` prior to calling `engine.boot()`.');
+
+  setEngineParent(engineInstance, {});
+
+  return engineInstance.boot().then(() => {
+    assert.ok(true, 'boot successful');
+  });
 });

--- a/packages/ember-application/tests/system/engine_parent_test.js
+++ b/packages/ember-application/tests/system/engine_parent_test.js
@@ -1,0 +1,16 @@
+import { getEngineParent, setEngineParent, ENGINE_PARENT } from 'ember-application/system/engine-parent';
+
+QUnit.module('EngineParent', {});
+
+QUnit.test('An engine\'s parent can be set with `setEngineParent` and retrieved with `getEngineParent`', function() {
+  let engine = {};
+  let parent = {};
+
+  strictEqual(getEngineParent(engine), undefined, 'parent has not been set');
+
+  setEngineParent(engine, parent);
+
+  strictEqual(getEngineParent(engine), parent, 'parent has been set');
+
+  strictEqual(engine[ENGINE_PARENT], parent, 'parent has been set to the ENGINE_PARENT symbol');
+});


### PR DESCRIPTION
Continues the move upstream of functionality from [ember-engines](https://github.com/dgeb/ember-engines) into ember core:
- Introduces a new `ENGINE_PARENT` symbol, as well as `getEngineParent` and `setEngineParent` methods, for tracking the parents of engine instances.
- Introduces a new `buildChildEngineInstance` method on `EngineInstance`.
