### PR TITLE
[WIP] [FEATURE canary] Pass owner to internal helpers in Glimmer 2

### DIFF
--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -169,7 +169,7 @@ export default class Environment extends GlimmerEnvironment {
 
     // TODO: try to unify this into a consistent protocol to avoid wasteful closure allocations
     if (helper.isInternalHelper) {
-      return (args) => helper.toReference(args);
+      return (args) => helper.toReference(args, this.owner);
     } else if (helper.isHelperInstance) {
       return (args) => SimpleHelperReference.create(helper.compute, args);
     } else if (helper.isHelperFactory) {


### PR DESCRIPTION
Closure components need access to the owner to get the `positionalParams`
property in the component's class. This is needed to both ease processing the
args and to error if a positional parameter clashes with a named argument.
