### PR TITLE
[BUGFIX] Child outlet did-create-element crash

### DIFF
--- a/packages/ember-glimmer/lib/syntax/outlet.js
+++ b/packages/ember-glimmer/lib/syntax/outlet.js
@@ -179,7 +179,7 @@ class OutletComponentDefinition extends AbstractOutletComponentDefinition {
   }
 
   compile(builder) {
-    builder.fromLayout(this.template.asLayout());
+    builder.wrapLayout(this.template.asLayout());
   }
 }
 

--- a/packages/ember-glimmer/lib/views/outlet.js
+++ b/packages/ember-glimmer/lib/views/outlet.js
@@ -97,7 +97,6 @@ export default class OutletView {
   setOutletState(state) {
     this.outletState = state;
     this._tag.dirty();
-    this.rerender(); // FIXME
   }
 
   toReference() {

--- a/packages/ember-glimmer/tests/integration/application/rendering-test.js
+++ b/packages/ember-glimmer/tests/integration/application/rendering-test.js
@@ -318,4 +318,15 @@ moduleFor('Application test: rendering', class extends ApplicationTest {
     });
   }
 
+  // Regression test, glimmer child outlets tried to assume the first element.
+  // but the if put-args clobbered the args used by did-create-element.
+  // I wish there was a way to assert that the OutletComponentManager did not
+  // receive a didCreateElement.
+  ['@test a child outlet is always a fragment']() {
+    this.registerTemplate('application', '{{outlet}}');
+    this.registerTemplate('index', '{{#if true}}1{{/if}}<div>2</div>');
+    return this.visit('/').then(() => {
+      this.assertComponentElement(this.firstChild, { content: '1<div>2</div>' });
+    });
+  }
 });


### PR DESCRIPTION
Workaround to prevent outlets from trying to assume the element of their layout.  Currently fragments are only supported for dynamic tags.
