### PR TITLE
[Glimmer2] Support partials

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "express": "^4.5.0",
     "finalhandler": "^0.4.0",
     "github": "^0.2.3",
-    "glimmer-engine": "tildeio/glimmer#0b086ae",
+    "glimmer-engine": "tildeio/glimmer#0beb69d",
     "glob": "^5.0.13",
     "htmlbars": "0.14.23",
     "mocha": "^2.4.5",

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -1,3 +1,4 @@
+import lookupPartial, { hasPartial } from 'ember-views/system/lookup_partial';
 import {
   Environment as GlimmerEnvironment,
   HelperSyntax
@@ -128,7 +129,7 @@ export default class Environment extends GlimmerEnvironment {
       templates
     } = statement;
 
-    if (isSimple && (isInline || isBlock)) {
+    if (key !== 'partial' && isSimple && (isInline || isBlock)) {
       if (key === 'component') {
         return new DynamicComponentSyntax({ args, templates, isBlock });
       } else if (key === 'outlet') {
@@ -178,6 +179,22 @@ export default class Environment extends GlimmerEnvironment {
     }
 
     return definition;
+  }
+
+  hasPartial(name) {
+    return hasPartial(this, name[0]);
+  }
+
+  lookupPartial(name) {
+    let partial = {
+      template: lookupPartial(this, name[0]).spec
+    };
+
+    if (partial) {
+      return partial;
+    } else {
+      throw new Error(`${name} is not a partial`);
+    }
   }
 
   hasHelper(name) {

--- a/packages/ember-glimmer/tests/integration/helpers/partial-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/partial-test.js
@@ -5,7 +5,7 @@ import { strip } from '../../utils/abstract-test-case';
 
 moduleFor('Helpers test: {{partial}}', class extends RenderingTest {
 
-  ['@htmlbars should render other templates registered with the container']() {
+  ['@test should render other templates registered with the container']() {
     this.registerPartial('_subTemplateFromContainer', 'sub-template');
 
     this.render(`This {{partial "subTemplateFromContainer"}} is pretty great.`);
@@ -15,7 +15,7 @@ moduleFor('Helpers test: {{partial}}', class extends RenderingTest {
     this.assertText('This sub-template is pretty great.');
   }
 
-  ['@htmlbars should render other slash-separated templates registered with the container']() {
+  ['@test should render other slash-separated templates registered with the container']() {
     this.registerPartial('child/_subTemplateFromContainer', 'sub-template');
 
     this.render(`This {{partial "child/subTemplateFromContainer"}} is pretty great.`);
@@ -25,7 +25,7 @@ moduleFor('Helpers test: {{partial}}', class extends RenderingTest {
     this.assertText('This sub-template is pretty great.');
   }
 
-  ['@htmlbars should use the current context']() {
+  ['@test should use the current context']() {
     this.registerPartial('_person_name', '{{model.firstName}} {{model.lastName}}');
 
     this.render('Who is {{partial "person_name"}}?', {
@@ -48,7 +48,7 @@ moduleFor('Helpers test: {{partial}}', class extends RenderingTest {
     this.assertText('Who is Kris Selden?');
   }
 
-  ['@htmlbars Quoteless parameters passed to {{partial}} perform a bound property lookup of the partial name']() {
+  ['@test Quoteless parameters passed to {{partial}} perform a bound property lookup of the partial name']() {
     this.registerPartial('_subTemplate', 'sub-template');
     this.registerPartial('_otherTemplate', 'other-template');
 
@@ -73,7 +73,7 @@ moduleFor('Helpers test: {{partial}}', class extends RenderingTest {
     this.assertText('This sub-template is pretty great.');
   }
 
-  ['@htmlbars dynamic partials in {{#each}}']() {
+  ['@test dynamic partials in {{#each}}']() {
     this.registerPartial('_odd', 'ODD{{i}}');
     this.registerPartial('_even', 'EVEN{{i}}');
 
@@ -103,7 +103,7 @@ moduleFor('Helpers test: {{partial}}', class extends RenderingTest {
     this.assertText('number: EVEN0number: ODD1number: EVEN2number: ODD3');
   }
 
-  ['@htmlbars dynamic partials in {{#with}}']() {
+  ['@test dynamic partials in {{#with}}']() {
     this.registerPartial('_thing', '{{t}}');
 
     this.render(strip`

--- a/packages/ember-glimmer/tests/utils/abstract-test-case.js
+++ b/packages/ember-glimmer/tests/utils/abstract-test-case.js
@@ -15,6 +15,7 @@ import { privatize as P } from 'container/registry';
 import DefaultComponentTemplate from 'ember-glimmer/templates/component';
 import EventDispatcher from 'ember-views/system/event_dispatcher';
 import { defaultCompileOptions } from 'ember-template-compiler';
+import { PartialDefinition } from 'glimmer-runtime';
 
 const packageTag = `@${packageName} `;
 
@@ -374,11 +375,15 @@ export class RenderingTest extends TestCase {
   }
 
   registerPartial(name, template) {
-    let { owner } = this;
-
+    let owner = this.env.owner || this.owner;
     if (typeof template === 'string') {
       let moduleName = `template:${name}`;
-      owner.register(moduleName, this.compile(template, { moduleName }));
+      if (isEnabled('ember-glimmer')) {
+        let partial = new PartialDefinition(moduleName, this.compile(template, { moduleName, env: this.env }));
+        owner.register(moduleName, partial.template);
+      } else {
+        owner.register(moduleName, this.compile(template, { moduleName }));
+      }
     }
   }
 

--- a/packages/ember-views/lib/system/lookup_partial.js
+++ b/packages/ember-views/lib/system/lookup_partial.js
@@ -1,16 +1,19 @@
 import { assert } from 'ember-metal/debug';
 import EmberError from 'ember-metal/error';
 
-export default function lookupPartial(env, templateName) {
-  if (templateName == null) { return; }
-
-  var nameParts = templateName.split('/');
-  var lastPart = nameParts[nameParts.length - 1];
+function parseUnderscoredName(templateName) {
+  let nameParts = templateName.split('/');
+  let lastPart = nameParts[nameParts.length - 1];
 
   nameParts[nameParts.length - 1] = '_' + lastPart;
 
-  var underscoredName = nameParts.join('/');
-  var template = templateFor(env, underscoredName, templateName);
+  return nameParts.join('/');
+}
+
+export default function lookupPartial(env, templateName) {
+  if (templateName == null) { return; }
+
+  let template = templateFor(env, parseUnderscoredName(templateName), templateName);
 
   assert(
     'Unable to find partial with name "' + templateName + '"',
@@ -18,6 +21,16 @@ export default function lookupPartial(env, templateName) {
   );
 
   return template;
+}
+
+export function hasPartial(env, name) {
+  if (!env.owner) {
+    throw new EmberError('Container was not found when looking up a views template. ' +
+               'This is most likely due to manually instantiating an Ember.View. ' +
+               'See: http://git.io/EKPpnA');
+  }
+
+  return env.owner.hasRegistration('template:' + parseUnderscoredName(name)) || env.owner.hasRegistration('template:' + name);
 }
 
 function templateFor(env, underscored, name) {


### PR DESCRIPTION
~~Need some guidance @krisselden @mmun. Why are the test partials [registered with a `_` in the name](https://github.com/emberjs/ember.js/compare/master...asakusuma:partials?expand=1#diff-6200fd37f2358aea2699a69836cc0f2bR9)?~~

Right now, I have ember's `refineStatement` passthrough to glimmer's `refineStatement` to do [the PartialSyntax creation](https://github.com/tildeio/glimmer/blob/master/packages/glimmer-runtime/lib/environment.ts#L147-L151).
