### PR TITLE
Clone shared dependencies between an engine instance and its parent.

### DIFF
--- a/packages/ember-application/tests/system/engine_instance_initializers_test.js
+++ b/packages/ember-application/tests/system/engine_instance_initializers_test.js
@@ -9,7 +9,10 @@ let MyEngine,
 
 function buildEngineInstance(EngineClass) {
   let engineInstance = EngineClass.buildInstance();
-  setEngineParent(engineInstance, {});
+  setEngineParent(engineInstance, {
+    lookup() { return {}; },
+    resolveRegistration() { return {}; }
+  });
   return engineInstance;
 }
 

--- a/packages/ember-application/tests/system/engine_instance_test.js
+++ b/packages/ember-application/tests/system/engine_instance_test.js
@@ -57,23 +57,31 @@ QUnit.test('unregistering a factory clears all cached instances of that factory'
   assert.notStrictEqual(postComponent1, postComponent2, 'lookup creates a brand new instance because previous one was reset');
 });
 
-QUnit.test('can be booted when its parent has been set', function(assert) {
-  run(function() {
-    engineInstance = EngineInstance.create({ base: engine });
-  });
-
-  expectAssertion(function() {
-    engineInstance._bootSync();
-  }, 'An engine instance\'s parent must be set via `setEngineParent(engine, parent)` prior to calling `engine.boot()`.');
-
-  setEngineParent(engineInstance, {});
-
-  return engineInstance.boot().then(() => {
-    assert.ok(true, 'boot successful');
-  });
-});
-
 if (isEnabled('ember-application-engines')) {
+  QUnit.test('can be booted when its parent has been set', function(assert) {
+    assert.expect(3);
+
+    run(function() {
+      engineInstance = EngineInstance.create({ base: engine });
+    });
+
+    expectAssertion(function() {
+      engineInstance._bootSync();
+    }, 'An engine instance\'s parent must be set via `setEngineParent(engine, parent)` prior to calling `engine.boot()`.');
+
+    setEngineParent(engineInstance, {});
+
+    // Stub `cloneParentDependencies`, the internals of which are tested along
+    // with application instances.
+    engineInstance.cloneParentDependencies = function() {
+      assert.ok(true, 'parent dependencies are cloned');
+    };
+
+    return engineInstance.boot().then(() => {
+      assert.ok(true, 'boot successful');
+    });
+  });
+
   QUnit.test('can build a child instance of a registered engine', function(assert) {
     let ChatEngine = Engine.extend();
     let chatEngineInstance;


### PR DESCRIPTION
Continues the move upstream of functionality from [ember-engines](https://github.com/dgeb/ember-engines) into ember core:
- Certain registrations must be global to an application and all its engines. These are cloned from the parent registry to the engine’s registry when the engine instance is booted.

Notes: 
- These changes are only enabled via the `ember-application-engines` feature flag.
- The concept of [custom dependencies](https://github.com/dgeb/ember-engines/blob/master/addon/-private/engine-instance-ext.js#L253-L278) will remain wholly in the addon for now.
