### PR TITLE
[FEATURE ember-route-serializers] Use getSerializer method on router.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "backburner": "https://github.com/ebryn/backburner.js.git#b893c979cb38f9819f65561725907add1aed7b21",
     "rsvp": "https://github.com/tildeio/rsvp.js.git#3.0.20",
-    "router.js": "https://github.com/tildeio/router.js.git#04b27c911995902b022966f4d29d8686ba7d847c",
+    "router.js": "https://github.com/tildeio/router.js.git#8368cf339ca978d52f40b2c77211f813c24737b0",
     "dag-map": "https://github.com/krisselden/dag-map.git#1.0.2",
     "ember-dev": "https://github.com/emberjs/ember-dev.git#eace5340485bdb5e4223ab67fecf4aff31c1940c"
   }

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -559,20 +559,28 @@ var EmberRouter = EmberObject.extend(Evented, {
         }
       }
 
-      if (isEnabled('ember-route-serializers')) {
+      handler.routeName = name;
+      return handler;
+    };
+  },
+
+  _getSerializerFunction() {
+    return (name) => {
+      var serializer = this._serializeMethods[name];
+
+      if (!serializer) {
+        var handler = this.router.getHandler(name);
+
         deprecate(
           `Defining a serialize function on route '${name}' is deprecated. Instead, define it in the router's map as an option.`,
           hasDefaultSerialize(handler),
           { id: 'ember-routing.serialize-function', until: '3.0.0', url: 'http://emberjs.com/deprecations/v2.x#toc_route-serialize' }
         );
 
-        if (this._serializeMethods[name]) {
-          handler.serialize = this._serializeMethods[name];
-        }
+        this._serializeMethods[name] = handler.serialize;
       }
 
-      handler.routeName = name;
-      return handler;
+      return serializer;
     };
   },
 
@@ -581,6 +589,10 @@ var EmberRouter = EmberObject.extend(Evented, {
     var emberRouter = this;
 
     router.getHandler = this._getHandlerFunction();
+
+    if (isEnabled('ember-route-serializers')) {
+      router.getSerializer = this._getSerializerFunction();
+    }
 
     var doUpdateURL = function() {
       location.setURL(lastURL);


### PR DESCRIPTION
Next step in the [Route Serializer RFC](https://github.com/emberjs/rfcs/blob/master/text/0120-route-serializers.md). Here's the [relevant commit from router.js](https://github.com/tildeio/router.js/pull/182).

Unsure if I should go ahead and remove the default `serialize` method from `Route`, or if that should occur after the deprecation period ends.

I think the existing tests should cover the changes here, as it is primarily an internal refactor.
