### PR TITLE
[GLIMMER2] Migrate query-params

### DIFF
--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -30,6 +30,7 @@ import { default as log } from './helpers/log';
 import { default as readonly } from './helpers/readonly';
 import { default as unbound } from './helpers/unbound';
 import { default as classHelper } from './helpers/-class';
+import { default as queryParams } from './helpers/query-param';
 import { OWNER } from 'container/owner';
 
 const builtInHelpers = {
@@ -43,6 +44,7 @@ const builtInHelpers = {
   log,
   readonly,
   unbound,
+  'query-params': queryParams,
   '-class': classHelper
 };
 

--- a/packages/ember-glimmer/lib/helpers/query-param.js
+++ b/packages/ember-glimmer/lib/helpers/query-param.js
@@ -1,0 +1,19 @@
+import { InternalHelperReference } from '../utils/references';
+import { assert } from 'ember-metal/debug';
+import QueryParams from 'ember-routing/system/query_params';
+import assign from 'ember-metal/assign';
+
+function queryParams({ positional, named }) {
+  assert('The `query-params` helper only accepts hash parameters, e.g. (query-params queryParamPropertyName=\'foo\') as opposed to just (query-params \'foo\')', positional.value().length === 0);
+
+  return QueryParams.create({
+    values: assign({}, named.value())
+  });
+}
+
+export default {
+  isInternalHelper: true,
+  toReference(args) {
+    return new InternalHelperReference(queryParams, args);
+  }
+};

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -78,9 +78,9 @@ function sharedTeardown() {
   setTemplates({});
 }
 
-import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
+import { test } from 'ember-glimmer/tests/utils/skip-if-glimmer';
 
-testModule('The {{link-to}} helper', {
+QUnit.module('The {{link-to}} helper', {
   setup() {
     run(function() {
       sharedSetup();
@@ -1502,7 +1502,7 @@ test('{{link-to}} populates href with default query param values even without qu
   equal(jQuery('#the-link').attr('href'), '/', 'link has right href');
 });
 
-test('{{link-to}} populates href with default query param values with empty query-params object', function() {
+QUnit.test('{{link-to}} populates href with default query param values with empty query-params object', function() {
   if (isEnabled('ember-routing-route-configured-query-params')) {
     App.IndexRoute = Route.extend({
       queryParams: {
@@ -1523,7 +1523,7 @@ test('{{link-to}} populates href with default query param values with empty quer
   equal(jQuery('#the-link').attr('href'), '/', 'link has right href');
 });
 
-test('{{link-to}} populates href with supplied query param values', function() {
+QUnit.test('{{link-to}} populates href with supplied query param values', function() {
   if (isEnabled('ember-routing-route-configured-query-params')) {
     App.IndexRoute = Route.extend({
       queryParams: {
@@ -1544,7 +1544,7 @@ test('{{link-to}} populates href with supplied query param values', function() {
   equal(jQuery('#the-link').attr('href'), '/?foo=456', 'link has right href');
 });
 
-test('{{link-to}} populates href with partially supplied query param values', function() {
+QUnit.test('{{link-to}} populates href with partially supplied query param values', function() {
   if (isEnabled('ember-routing-route-configured-query-params')) {
     App.IndexRoute = Route.extend({
       queryParams: {
@@ -1569,7 +1569,7 @@ test('{{link-to}} populates href with partially supplied query param values', fu
   equal(jQuery('#the-link').attr('href'), '/?foo=456', 'link has right href');
 });
 
-test('{{link-to}} populates href with partially supplied query param values, but omits if value is default value', function() {
+QUnit.test('{{link-to}} populates href with partially supplied query param values, but omits if value is default value', function() {
   if (isEnabled('ember-routing-route-configured-query-params')) {
     App.IndexRoute = Route.extend({
       queryParams: {
@@ -1590,7 +1590,7 @@ test('{{link-to}} populates href with partially supplied query param values, but
   equal(jQuery('#the-link').attr('href'), '/', 'link has right href');
 });
 
-test('{{link-to}} populates href with fully supplied query param values', function() {
+QUnit.test('{{link-to}} populates href with fully supplied query param values', function() {
   if (isEnabled('ember-routing-route-configured-query-params')) {
     App.IndexRoute = Route.extend({
       queryParams: {
@@ -1615,7 +1615,7 @@ test('{{link-to}} populates href with fully supplied query param values', functi
   equal(jQuery('#the-link').attr('href'), '/?bar=NAW&foo=456', 'link has right href');
 });
 
-test('{{link-to}} with only query-params and a block updates when route changes', function() {
+QUnit.test('{{link-to}} with only query-params and a block updates when route changes', function() {
   Router.map(function() {
     this.route('about');
   });
@@ -1649,7 +1649,7 @@ test('{{link-to}} with only query-params and a block updates when route changes'
   equal(jQuery('#the-link').attr('href'), '/about?bar=NAW&foo=456', 'link has right href');
 });
 
-test('Block-less {{link-to}} with only query-params updates when route changes', function() {
+QUnit.test('Block-less {{link-to}} with only query-params updates when route changes', function() {
   Router.map(function() {
     this.route('about');
   });

--- a/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
+++ b/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
@@ -65,10 +65,10 @@ function sharedTeardown() {
   setTemplates({});
 }
 
-import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
+import { test } from 'ember-glimmer/tests/utils/skip-if-glimmer';
 
 if (isEnabled('ember-routing-route-configured-query-params')) {
-  testModule('The {{link-to}} helper: invoking with query params when defined on a route', {
+  QUnit.module('The {{link-to}} helper: invoking with query params when defined on a route', {
     setup() {
       run(function() {
         sharedSetup();
@@ -111,7 +111,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
 
   // jscs:disable
 
-  test("doesn't update controller QP properties on current route when invoked", function() {
+  QUnit.test("doesn't update controller QP properties on current route when invoked", function() {
     setTemplate('index', compile("{{#link-to 'index' id='the-link'}}Index{{/link-to}}"));
     bootApplication();
 
@@ -120,7 +120,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     deepEqual(indexController.getProperties('foo', 'bar'), { foo: '123', bar: 'abc' }, 'controller QP properties not');
   });
 
-  test("doesn't update controller QP properties on current route when invoked (empty query-params obj)", function() {
+  QUnit.test("doesn't update controller QP properties on current route when invoked (empty query-params obj)", function() {
     setTemplate('index', compile("{{#link-to 'index' (query-params) id='the-link'}}Index{{/link-to}}"));
     bootApplication();
 
@@ -136,7 +136,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     }, /one or more/);
   });
 
-  test("doesn't update controller QP properties on current route when invoked (empty query-params obj, inferred route)", function() {
+  QUnit.test("doesn't update controller QP properties on current route when invoked (empty query-params obj, inferred route)", function() {
     setTemplate('index', compile("{{#link-to (query-params) id='the-link'}}Index{{/link-to}}"));
     bootApplication();
 
@@ -145,7 +145,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     deepEqual(indexController.getProperties('foo', 'bar'), { foo: '123', bar: 'abc' }, 'controller QP properties not');
   });
 
-  test('updates controller QP properties on current route when invoked', function() {
+  QUnit.test('updates controller QP properties on current route when invoked', function() {
     setTemplate('index', compile("{{#link-to 'index' (query-params foo='456') id='the-link'}}Index{{/link-to}}"));
     bootApplication();
 
@@ -154,7 +154,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     deepEqual(indexController.getProperties('foo', 'bar'), { foo: '456', bar: 'abc' }, 'controller QP properties updated');
   });
 
-  test('updates controller QP properties on current route when invoked (inferred route)', function() {
+  QUnit.test('updates controller QP properties on current route when invoked (inferred route)', function() {
     setTemplate('index', compile("{{#link-to (query-params foo='456') id='the-link'}}Index{{/link-to}}"));
     bootApplication();
 
@@ -163,7 +163,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     deepEqual(indexController.getProperties('foo', 'bar'), { foo: '456', bar: 'abc' }, 'controller QP properties updated');
   });
 
-  test('updates controller QP properties on other route after transitioning to that route', function() {
+  QUnit.test('updates controller QP properties on other route after transitioning to that route', function() {
     Router.map(function() {
       this.route('about');
     });
@@ -179,7 +179,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     equal(container.lookup('controller:application').get('currentPath'), 'about');
   });
 
-  test('supplied QP properties can be bound', function() {
+  QUnit.test('supplied QP properties can be bound', function() {
     setTemplate('index', compile("{{#link-to (query-params foo=boundThing) id='the-link'}}Index{{/link-to}}"));
     bootApplication();
 
@@ -191,7 +191,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     equal(jQuery('#the-link').attr('href'), '/?foo=ASL');
   });
 
-  test('supplied QP properties can be bound (booleans)', function() {
+  QUnit.test('supplied QP properties can be bound (booleans)', function() {
     var indexController = container.lookup('controller:index');
     setTemplate('index', compile("{{#link-to (query-params abool=boundThing) id='the-link'}}Index{{/link-to}}"));
 
@@ -206,7 +206,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     deepEqual(indexController.getProperties('foo', 'bar', 'abool'), { foo: '123', bar: 'abc', abool: false });
   });
 
-  test('href updates when unsupplied controller QP props change', function() {
+  QUnit.test('href updates when unsupplied controller QP props change', function() {
     setTemplate('index', compile("{{#link-to (query-params foo='lol') id='the-link'}}Index{{/link-to}}"));
 
     bootApplication();
@@ -220,7 +220,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     equal(jQuery('#the-link').attr('href'), '/?bar=BORF&foo=lol');
   });
 
-  test('The {{link-to}} with only query params always transitions to the current route with the query params applied', function() {
+  QUnit.test('The {{link-to}} with only query params always transitions to the current route with the query params applied', function() {
     // Test harness for bug #12033
 
     setTemplate('cars', compile(
@@ -270,7 +270,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     });
   });
 
-  test('The {{link-to}} applies activeClass when query params are not changed', function() {
+  QUnit.test('The {{link-to}} applies activeClass when query params are not changed', function() {
     setTemplate('index', compile(
       "{{#link-to (query-params foo='cat') id='cat-link'}}Index{{/link-to}} " +
       "{{#link-to (query-params foo='dog') id='dog-link'}}Index{{/link-to}} " +
@@ -370,7 +370,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     shouldNotBeActive('#change-search-same-sort-child-and-parent');
   });
 
-  test('The {{link-to}} applies active class when query-param is number', function() {
+  QUnit.test('The {{link-to}} applies active class when query-param is number', function() {
     setTemplate('index', compile(
       "{{#link-to (query-params page=pageNumber) id='page-link'}}Index{{/link-to}} "));
 
@@ -393,7 +393,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     shouldBeActive('#page-link');
   });
 
-  test('The {{link-to}} applies active class when query-param is array', function() {
+  QUnit.test('The {{link-to}} applies active class when query-param is array', function() {
     setTemplate('index', compile(
       "{{#link-to (query-params pages=pagesArray) id='array-link'}}Index{{/link-to}} " +
       "{{#link-to (query-params pages=biggerArray) id='bigger-link'}}Index{{/link-to}} " +
@@ -432,7 +432,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     shouldNotBeActive('#empty-link');
   });
 
-  test('The {{link-to}} helper applies active class to parent route', function() {
+  QUnit.test('The {{link-to}} helper applies active class to parent route', function() {
     App.Router.map(function() {
       this.route('parent', function() {
         this.route('child');
@@ -463,7 +463,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     shouldNotBeActive('#parent-link-qp');
   });
 
-  test('The {{link-to}} helper disregards query-params in activeness computation when current-when specified', function() {
+  QUnit.test('The {{link-to}} helper disregards query-params in activeness computation when current-when specified', function() {
     App.Router.map(function() {
       this.route('parent');
     });
@@ -502,7 +502,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     equal(router.get('location.path'), '/parent');
   });
 } else {
-  testModule('The {{link-to}} helper: invoking with query params', {
+  QUnit.module('The {{link-to}} helper: invoking with query params', {
     setup() {
       run(function() {
         sharedSetup();
@@ -530,7 +530,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     teardown: sharedTeardown
   });
 
-  test("doesn't update controller QP properties on current route when invoked", function() {
+  QUnit.test("doesn't update controller QP properties on current route when invoked", function() {
     setTemplate('index', compile("{{#link-to 'index' id='the-link'}}Index{{/link-to}}"));
     bootApplication();
 
@@ -539,7 +539,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     deepEqual(indexController.getProperties('foo', 'bar'), { foo: '123', bar: 'abc' }, 'controller QP properties not');
   });
 
-  test("doesn't update controller QP properties on current route when invoked (empty query-params obj)", function() {
+  QUnit.test("doesn't update controller QP properties on current route when invoked (empty query-params obj)", function() {
     setTemplate('index', compile("{{#link-to 'index' (query-params) id='the-link'}}Index{{/link-to}}"));
     bootApplication();
 
@@ -548,14 +548,14 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     deepEqual(indexController.getProperties('foo', 'bar'), { foo: '123', bar: 'abc' }, 'controller QP properties not');
   });
 
-  test('link-to with no params throws', function() {
+  QUnit.test('link-to with no params throws', function() {
     setTemplate('index', compile("{{#link-to id='the-link'}}Index{{/link-to}}"));
     expectAssertion(function() {
       bootApplication();
     }, /one or more/);
   });
 
-  test("doesn't update controller QP properties on current route when invoked (empty query-params obj, inferred route)", function() {
+  QUnit.test("doesn't update controller QP properties on current route when invoked (empty query-params obj, inferred route)", function() {
     setTemplate('index', compile("{{#link-to (query-params) id='the-link'}}Index{{/link-to}}"));
     bootApplication();
 
@@ -564,7 +564,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     deepEqual(indexController.getProperties('foo', 'bar'), { foo: '123', bar: 'abc' }, 'controller QP properties not');
   });
 
-  test('updates controller QP properties on current route when invoked', function() {
+  QUnit.test('updates controller QP properties on current route when invoked', function() {
     setTemplate('index', compile("{{#link-to 'index' (query-params foo='456') id='the-link'}}Index{{/link-to}}"));
     bootApplication();
 
@@ -573,7 +573,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     deepEqual(indexController.getProperties('foo', 'bar'), { foo: '456', bar: 'abc' }, 'controller QP properties updated');
   });
 
-  test('updates controller QP properties on current route when invoked (inferred route)', function() {
+  QUnit.test('updates controller QP properties on current route when invoked (inferred route)', function() {
     setTemplate('index', compile("{{#link-to (query-params foo='456') id='the-link'}}Index{{/link-to}}"));
     bootApplication();
 
@@ -582,7 +582,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     deepEqual(indexController.getProperties('foo', 'bar'), { foo: '456', bar: 'abc' }, 'controller QP properties updated');
   });
 
-  test('updates controller QP properties on other route after transitioning to that route', function() {
+  QUnit.test('updates controller QP properties on other route after transitioning to that route', function() {
     Router.map(function() {
       this.route('about');
     });
@@ -598,7 +598,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     equal(container.lookup('controller:application').get('currentPath'), 'about');
   });
 
-  test('supplied QP properties can be bound', function() {
+  QUnit.test('supplied QP properties can be bound', function() {
     var indexController = container.lookup('controller:index');
     setTemplate('index', compile("{{#link-to (query-params foo=boundThing) id='the-link'}}Index{{/link-to}}"));
 
@@ -609,7 +609,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     equal(jQuery('#the-link').attr('href'), '/?foo=ASL');
   });
 
-  test('supplied QP properties can be bound (booleans)', function() {
+  QUnit.test('supplied QP properties can be bound (booleans)', function() {
     var indexController = container.lookup('controller:index');
     setTemplate('index', compile("{{#link-to (query-params abool=boundThing) id='the-link'}}Index{{/link-to}}"));
 
@@ -624,7 +624,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     deepEqual(indexController.getProperties('foo', 'bar', 'abool'), { foo: '123', bar: 'abc', abool: false });
   });
 
-  test('href updates when unsupplied controller QP props change', function() {
+  QUnit.test('href updates when unsupplied controller QP props change', function() {
     setTemplate('index', compile("{{#link-to (query-params foo='lol') id='the-link'}}Index{{/link-to}}"));
 
     bootApplication();
@@ -637,7 +637,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     equal(jQuery('#the-link').attr('href'), '/?bar=BORF&foo=lol');
   });
 
-  test('The {{link-to}} with only query params always transitions to the current route with the query params applied', function() {
+  QUnit.test('The {{link-to}} with only query params always transitions to the current route with the query params applied', function() {
     // Test harness for bug #12033
 
     setTemplate('cars', compile(
@@ -688,7 +688,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     });
   });
 
-  test('The {{link-to}} applies activeClass when query params are not changed', function() {
+  QUnit.test('The {{link-to}} applies activeClass when query params are not changed', function() {
     setTemplate('index', compile(
       "{{#link-to (query-params foo='cat') id='cat-link'}}Index{{/link-to}} " +
       "{{#link-to (query-params foo='dog') id='dog-link'}}Index{{/link-to}} " +
@@ -778,7 +778,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     shouldNotBeActive('#change-search-same-sort-child-and-parent');
   });
 
-  test('The {{link-to}} applies active class when query-param is number', function() {
+  QUnit.test('The {{link-to}} applies active class when query-param is number', function() {
     setTemplate('index', compile(
       "{{#link-to (query-params page=pageNumber) id='page-link'}}Index{{/link-to}} "));
 
@@ -795,7 +795,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     shouldBeActive('#page-link');
   });
 
-  test('The {{link-to}} applies active class when query-param is array', function() {
+  QUnit.test('The {{link-to}} applies active class when query-param is array', function() {
     setTemplate('index', compile(
       "{{#link-to (query-params pages=pagesArray) id='array-link'}}Index{{/link-to}} " +
       "{{#link-to (query-params pages=biggerArray) id='bigger-link'}}Index{{/link-to}} " +
@@ -827,7 +827,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     shouldNotBeActive('#empty-link');
   });
 
-  test('The {{link-to}} helper applies active class to parent route', function() {
+  QUnit.test('The {{link-to}} helper applies active class to parent route', function() {
     App.Router.map(function() {
       this.route('parent', function() {
         this.route('child');
@@ -855,7 +855,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     shouldNotBeActive('#parent-link-qp');
   });
 
-  test('The {{link-to}} helper disregards query-params in activeness computation when current-when specified', function() {
+  QUnit.test('The {{link-to}} helper disregards query-params in activeness computation when current-when specified', function() {
     App.Router.map(function() {
       this.route('parent');
     });

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -107,10 +107,10 @@ function sharedTeardown() {
   }
 }
 
-import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
+import { test } from 'ember-glimmer/tests/utils/skip-if-glimmer';
 // jscs:disable
 
-testModule('Routing with Query Params', {
+QUnit.module('Routing with Query Params', {
   setup() {
     sharedSetup();
   },
@@ -545,7 +545,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     equal(parentModelCount, 2);
   });
 
-  test('URL transitions that remove QPs still register as QP changes when configuration lives on the route', function() {
+  QUnit.test('URL transitions that remove QPs still register as QP changes when configuration lives on the route', function() {
     expect(2);
 
     App.IndexRoute = Route.extend({
@@ -565,7 +565,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     equal(indexController.get('omg'), 'lol');
   });
 
-  test('Subresource naming style is supported when configuration is all on the route', function() {
+  QUnit.test('Subresource naming style is supported when configuration is all on the route', function() {
     App.Router.map(function() {
       this.route('abc.def', { path: '/abcdef' }, function() {
         this.route('zoo');
@@ -867,7 +867,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     bootApplication();
   });
 
-  test('opting into replace does not affect transitions between routes when configuration occurs on the route', function() {
+  QUnit.test('opting into replace does not affect transitions between routes when configuration occurs on the route', function() {
     expect(5);
     App.register('template:application', compile(
       "{{link-to 'Foo' 'foo' id='foo-link'}}" +
@@ -1028,7 +1028,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     bootApplication();
   });
 
-  test("controllers won't be eagerly instantiated by internal query params logic when configured on the route", function() {
+  QUnit.test("controllers won't be eagerly instantiated by internal query params logic when configured on the route", function() {
     expect(10);
     App.Router.map(function() {
       this.route('cats', function() {
@@ -1417,7 +1417,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     run(appController, 'setProperties', { alex: 'sriracha' });
   });
 
-  test('can opt into full transition by setting refreshModel in route queryParams when transitioning from child to parent when configured on the route', function() {
+  QUnit.test('can opt into full transition by setting refreshModel in route queryParams when transitioning from child to parent when configured on the route', function() {
     App.register('template:parent', compile('{{outlet}}'));
     App.register('template:parent.child', compile("{{link-to 'Parent' 'parent' (query-params foo='change') id='parent-link'}}"));
 
@@ -1534,7 +1534,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     equal(indexController.get('omg'), 'lol');
   });
 
-  test('Subresource naming style is supported when configured on the route', function() {
+  QUnit.test('Subresource naming style is supported when configured on the route', function() {
     App.Router.map(function() {
       this.route('abc.def', { path: '/abcdef' }, function() {
         this.route('zoo');
@@ -1880,7 +1880,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     bootApplication();
   });
 
-  test('opting into replace does not affect transitions between routes when configured on route', function() {
+  QUnit.test('opting into replace does not affect transitions between routes when configured on route', function() {
     expect(5);
     App.register('template:application', compile(
       "{{link-to 'Foo' 'foo' id='foo-link'}}" +
@@ -1949,7 +1949,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     equal(get(controller, 'foo'), undefined);
   });
 
-  test('Changing a query param property on a controller after navigating using a {{link-to}} should preserve the unchanged query params', function() {
+  QUnit.test('Changing a query param property on a controller after navigating using a {{link-to}} should preserve the unchanged query params', function() {
     expect(11);
     App.Router.map(function() {
       this.route('example');
@@ -2187,7 +2187,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     equal(router.get('location.path'), '');
   });
 
-  test('controllers won\'t be eagerly instantiated by internal query params logic', function() {
+  QUnit.test('controllers won\'t be eagerly instantiated by internal query params logic', function() {
     expect(10);
     App.Router.map(function() {
       this.route('cats', function() {
@@ -2659,7 +2659,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     run(appController, 'setProperties', { alex: 'sriracha' });
   });
 
-  test('can opt into full transition by setting refreshModel in route queryParams when transitioning from child to parent', function() {
+  QUnit.test('can opt into full transition by setting refreshModel in route queryParams when transitioning from child to parent', function() {
     App.register('template:parent', compile('{{outlet}}'));
     App.register('template:parent.child', compile('{{link-to \'Parent\' \'parent\' (query-params foo=\'change\') id=\'parent-link\'}}'));
 
@@ -2785,7 +2785,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     equal(router.get('location.path'), '/?omg=' + encodeURIComponent(JSON.stringify(['OVERRIDE'])));
   });
 
-  test('URL transitions that remove QPs still register as QP changes', function() {
+  QUnit.test('URL transitions that remove QPs still register as QP changes', function() {
     expect(2);
 
     App.IndexController = Controller.extend({
@@ -2802,7 +2802,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     equal(indexController.get('omg'), 'lol');
   });
 
-  test('Subresource naming style is supported', function() {
+  QUnit.test('Subresource naming style is supported', function() {
     App.Router.map(function() {
       this.route('abc.def', { path: '/abcdef' }, function() {
         this.route('zoo');
@@ -3112,7 +3112,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     bootApplication();
   });
 
-  test('opting into replace does not affect transitions between routes', function() {
+  QUnit.test('opting into replace does not affect transitions between routes', function() {
     expect(5);
     App.register('template:application', compile(
       '{{link-to \'Foo\' \'foo\' id=\'foo-link\'}}' +


### PR DESCRIPTION
While I think we need to migrate to the new test infra, query params and link-to are currently not tested in their respected engine package. This simply makes majority of the `(query-param)` tests pass but on the old infra.
