### PR TITLE
[CLEANUP] Unskipping more tests

### DIFF
--- a/packages/ember-htmlbars/tests/attr_nodes/boolean_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/boolean_test.js
@@ -9,9 +9,7 @@ function appendView(view) {
   run(function() { view.appendTo('#qunit-fixture'); });
 }
 
-import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
-
-testModule('ember-htmlbars: boolean attribute', {
+QUnit.module('ember-htmlbars: boolean attribute', {
   teardown() {
     if (view) {
       run(view, view.destroy);
@@ -19,7 +17,7 @@ testModule('ember-htmlbars: boolean attribute', {
   }
 });
 
-test('disabled property can be set true', function() {
+QUnit.test('disabled property can be set true', function() {
   view = EmberView.create({
     context: { isDisabled: true },
     template: compile('<input disabled={{isDisabled}}>')
@@ -31,7 +29,7 @@ test('disabled property can be set true', function() {
         'boolean property is set true');
 });
 
-test('disabled property can be set false with a blank string', function() {
+QUnit.test('disabled property can be set false with a blank string', function() {
   view = EmberView.create({
     context: { isDisabled: '' },
     template: compile('<input disabled={{isDisabled}}>')
@@ -43,7 +41,7 @@ test('disabled property can be set false with a blank string', function() {
         'boolean property is set false');
 });
 
-test('disabled property can be set false', function() {
+QUnit.test('disabled property can be set false', function() {
   view = EmberView.create({
     context: { isDisabled: false },
     template: compile('<input disabled={{isDisabled}}>')
@@ -56,7 +54,7 @@ test('disabled property can be set false', function() {
         'boolean property is set false');
 });
 
-test('disabled property can be set true with a string', function() {
+QUnit.test('disabled property can be set true with a string', function() {
   view = EmberView.create({
     context: { isDisabled: 'oh, no a string' },
     template: compile('<input disabled={{isDisabled}}>')
@@ -68,7 +66,7 @@ test('disabled property can be set true with a string', function() {
         'boolean property is set true');
 });
 
-test('disabled attribute turns a value to a string', function() {
+QUnit.test('disabled attribute turns a value to a string', function() {
   view = EmberView.create({
     context: { isDisabled: false },
     template: compile('<input disabled=\'{{isDisabled}}\'>')
@@ -80,7 +78,7 @@ test('disabled attribute turns a value to a string', function() {
         'boolean property is set true');
 });
 
-test('disabled attribute preserves a blank string value', function() {
+QUnit.test('disabled attribute preserves a blank string value', function() {
   view = EmberView.create({
     context: { isDisabled: '' },
     template: compile('<input disabled=\'{{isDisabled}}\'>')

--- a/packages/ember-htmlbars/tests/attr_nodes/data_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/data_test.js
@@ -6,17 +6,16 @@ import { InteractiveRenderer } from 'ember-htmlbars/renderer';
 import { equalInnerHTML } from 'htmlbars-test-helpers';
 import { domHelper as dom } from 'ember-htmlbars/env';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
-import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
 
 var view, originalSetAttribute, setAttributeCalls, renderer;
 
-testModule('ember-htmlbars: data attribute', {
+QUnit.module('ember-htmlbars: data attribute', {
   teardown() {
     runDestroy(view);
   }
 });
 
-test('property is output', function() {
+QUnit.test('property is output', function() {
   view = EmberView.create({
     context: { name: 'erik' },
     template: compile('<div data-name={{name}}>Hi!</div>')
@@ -26,7 +25,7 @@ test('property is output', function() {
   equalInnerHTML(view.element, '<div data-name="erik">Hi!</div>', 'attribute is output');
 });
 
-test('property set before didInsertElement', function() {
+QUnit.test('property set before didInsertElement', function() {
   var matchingElement;
   view = EmberView.create({
     didInsertElement() {
@@ -41,7 +40,7 @@ test('property set before didInsertElement', function() {
   equal(matchingElement.length, 1, 'element is in the DOM when didInsertElement');
 });
 
-test('quoted attributes are concatenated', function() {
+QUnit.test('quoted attributes are concatenated', function() {
   view = EmberView.create({
     context: { firstName: 'max', lastName: 'jackson' },
     template: compile('<div data-name=\'{{firstName}} {{lastName}}\'>Hi!</div>')
@@ -51,7 +50,7 @@ test('quoted attributes are concatenated', function() {
   equalInnerHTML(view.element, '<div data-name="max jackson">Hi!</div>', 'attribute is output');
 });
 
-test('quoted attributes are updated when changed', function() {
+QUnit.test('quoted attributes are updated when changed', function() {
   view = EmberView.create({
     context: { firstName: 'max', lastName: 'jackson' },
     template: compile('<div data-name=\'{{firstName}} {{lastName}}\'>Hi!</div>')
@@ -65,7 +64,7 @@ test('quoted attributes are updated when changed', function() {
   equalInnerHTML(view.element, '<div data-name="james jackson">Hi!</div>', 'attribute is output');
 });
 
-test('quoted attributes are not removed when value is null', function() {
+QUnit.test('quoted attributes are not removed when value is null', function() {
   view = EmberView.create({
     context: { firstName: 'max', lastName: 'jackson' },
     template: compile('<div data-name=\'{{firstName}}\'>Hi!</div>')
@@ -79,7 +78,7 @@ test('quoted attributes are not removed when value is null', function() {
   equal(view.element.firstChild.getAttribute('data-name'), '', 'attribute is output');
 });
 
-test('unquoted attributes are removed when value is null', function() {
+QUnit.test('unquoted attributes are removed when value is null', function() {
   view = EmberView.create({
     context: { firstName: 'max' },
     template: compile('<div data-name={{firstName}}>Hi!</div>')
@@ -93,7 +92,7 @@ test('unquoted attributes are removed when value is null', function() {
   ok(!view.element.firstChild.hasAttribute('data-name'), 'attribute is removed output');
 });
 
-test('unquoted attributes that are null are not added', function() {
+QUnit.test('unquoted attributes that are null are not added', function() {
   view = EmberView.create({
     context: { firstName: null },
     template: compile('<div data-name={{firstName}}>Hi!</div>')
@@ -103,7 +102,7 @@ test('unquoted attributes that are null are not added', function() {
   equalInnerHTML(view.element, '<div>Hi!</div>', 'attribute is not present');
 });
 
-test('unquoted attributes are added when changing from null', function() {
+QUnit.test('unquoted attributes are added when changing from null', function() {
   view = EmberView.create({
     context: { firstName: null },
     template: compile('<div data-name={{firstName}}>Hi!</div>')
@@ -117,7 +116,7 @@ test('unquoted attributes are added when changing from null', function() {
   equalInnerHTML(view.element, '<div data-name="max">Hi!</div>', 'attribute is added output');
 });
 
-test('property value is directly added to attribute', function() {
+QUnit.test('property value is directly added to attribute', function() {
   view = EmberView.create({
     context: { name: '"" data-foo="blah"' },
     template: compile('<div data-name={{name}}>Hi!</div>')
@@ -127,7 +126,7 @@ test('property value is directly added to attribute', function() {
   equal(view.element.firstChild.getAttribute('data-name'), '"" data-foo="blah"', 'attribute is output');
 });
 
-test('path is output', function() {
+QUnit.test('path is output', function() {
   view = EmberView.create({
     context: { name: { firstName: 'erik' } },
     template: compile('<div data-name={{name.firstName}}>Hi!</div>')
@@ -137,7 +136,7 @@ test('path is output', function() {
   equalInnerHTML(view.element, '<div data-name="erik">Hi!</div>', 'attribute is output');
 });
 
-test('changed property updates', function() {
+QUnit.test('changed property updates', function() {
   var context = EmberObject.create({ name: 'erik' });
   view = EmberView.create({
     context: context,
@@ -152,7 +151,7 @@ test('changed property updates', function() {
   equalInnerHTML(view.element, '<div data-name="mmun">Hi!</div>', 'attribute is updated output');
 });
 
-test('updates are scheduled in the render queue', function() {
+QUnit.test('updates are scheduled in the render queue', function() {
   expect(4);
 
   var context = EmberObject.create({ name: 'erik' });
@@ -179,7 +178,7 @@ test('updates are scheduled in the render queue', function() {
   equalInnerHTML(view.element, '<div data-name="mmun">Hi!</div>', 'attribute is updated output');
 });
 
-test('updates fail silently after an element is destroyed', function() {
+QUnit.test('updates fail silently after an element is destroyed', function() {
   var context = EmberObject.create({ name: 'erik' });
   view = EmberView.create({
     context: context,
@@ -195,7 +194,7 @@ test('updates fail silently after an element is destroyed', function() {
   });
 });
 
-testModule('ember-htmlbars: {{attribute}} helper -- setAttribute', {
+QUnit.module('ember-htmlbars: {{attribute}} helper -- setAttribute', {
   setup() {
     renderer = InteractiveRenderer.create({ dom });
 
@@ -218,7 +217,7 @@ testModule('ember-htmlbars: {{attribute}} helper -- setAttribute', {
   }
 });
 
-test('calls setAttribute for new values', function() {
+QUnit.test('calls setAttribute for new values', function() {
   var context = EmberObject.create({ name: 'erik' });
   view = EmberView.create({
     renderer: renderer,
@@ -237,7 +236,7 @@ test('calls setAttribute for new values', function() {
   deepEqual(setAttributeCalls, expected);
 });
 
-test('does not call setAttribute if the same value is set', function() {
+QUnit.test('does not call setAttribute if the same value is set', function() {
   var context = EmberObject.create({ name: 'erik' });
   view = EmberView.create({
     renderer: renderer,

--- a/packages/ember-htmlbars/tests/attr_nodes/href_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/href_test.js
@@ -2,7 +2,6 @@ import EmberView from 'ember-views/views/view';
 import run from 'ember-metal/run_loop';
 import { compile } from '../utils/helpers';
 import { equalInnerHTML } from 'htmlbars-test-helpers';
-import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
 
 var view;
 
@@ -10,7 +9,7 @@ function appendView(view) {
   run(function() { view.appendTo('#qunit-fixture'); });
 }
 
-testModule('ember-htmlbars: href attribute', {
+QUnit.module('ember-htmlbars: href attribute', {
   teardown() {
     if (view) {
       run(view, view.destroy);
@@ -18,7 +17,7 @@ testModule('ember-htmlbars: href attribute', {
   }
 });
 
-test('href is set', function() {
+QUnit.test('href is set', function() {
   view = EmberView.create({
     context: { url: 'http://example.com' },
     template: compile('<a href={{url}}></a>')

--- a/packages/ember-htmlbars/tests/attr_nodes/property_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/property_test.js
@@ -1,7 +1,6 @@
 import EmberView from 'ember-views/views/view';
 import run from 'ember-metal/run_loop';
 import { compile } from '../utils/helpers';
-import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
 
 var view;
 
@@ -16,7 +15,7 @@ function canSetFalsyMaxLength() {
   return input.maxLength === 0;
 }
 
-testModule('ember-htmlbars: property', {
+QUnit.module('ember-htmlbars: property', {
   teardown() {
     if (view) {
       run(view, view.destroy);
@@ -24,7 +23,7 @@ testModule('ember-htmlbars: property', {
   }
 });
 
-test('maxlength sets the property and attribute', function() {
+QUnit.test('maxlength sets the property and attribute', function() {
   view = EmberView.create({
     context: { length: 5 },
     template: compile('<input maxlength={{length}}>')
@@ -37,7 +36,7 @@ test('maxlength sets the property and attribute', function() {
   equal(view.element.firstChild.maxLength, 1);
 });
 
-test('quoted maxlength sets the attribute and is reflected as a property', function() {
+QUnit.test('quoted maxlength sets the attribute and is reflected as a property', function() {
   view = EmberView.create({
     context: { length: 5 },
     template: compile('<input maxlength=\'{{length}}\'>')
@@ -55,7 +54,7 @@ test('quoted maxlength sets the attribute and is reflected as a property', funct
   }
 });
 
-test('array value can be set as property', function() {
+QUnit.test('array value can be set as property', function() {
   view = EmberView.create({
     context: {},
     template: compile('<input value={{items}}>')

--- a/packages/ember-htmlbars/tests/attr_nodes/sanitized_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/sanitized_test.js
@@ -5,11 +5,10 @@ import { compile } from '../utils/helpers';
 import { SafeString } from 'ember-htmlbars/utils/string';
 import { runDestroy } from 'ember-runtime/tests/utils';
 import { environment } from 'ember-environment';
-import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
 
 var view;
 
-testModule('ember-htmlbars: sanitized attribute', {
+QUnit.module('ember-htmlbars: sanitized attribute', {
   teardown() {
     runDestroy(view);
   }
@@ -65,7 +64,7 @@ for (var i = 0; i < badTags.length; i++) {
       return;
     }
 
-    test(`${subject.tag} ${subject.attr} is sanitized when using blacklisted protocol`, function() {
+    QUnit.test(`${subject.tag} ${subject.attr} is sanitized when using blacklisted protocol`, function() {
       view = EmberView.create({
         context: { url: 'javascript://example.com' },
         template: subject.unquotedTemplate
@@ -78,7 +77,7 @@ for (var i = 0; i < badTags.length; i++) {
             'attribute is output');
     });
 
-    test(`${subject.tag} ${subject.attr} is sanitized when using quoted non-whitelisted protocol`, function() {
+    QUnit.test(`${subject.tag} ${subject.attr} is sanitized when using quoted non-whitelisted protocol`, function() {
       view = EmberView.create({
         context: { url: 'javascript://example.com' },
         template: subject.quotedTemplate
@@ -91,7 +90,7 @@ for (var i = 0; i < badTags.length; i++) {
             'attribute is output');
     });
 
-    test(`${subject.tag} ${subject.attr} is not sanitized when using non-whitelisted protocol with a SafeString`, function() {
+    QUnit.test(`${subject.tag} ${subject.attr} is not sanitized when using non-whitelisted protocol with a SafeString`, function() {
       view = EmberView.create({
         context: { url: new SafeString('javascript://example.com') },
         template: subject.unquotedTemplate
@@ -109,7 +108,7 @@ for (var i = 0; i < badTags.length; i++) {
       }
     });
 
-    test(`${subject.tag} ${subject.attr} is sanitized when using quoted+concat non-whitelisted protocol`, function() {
+    QUnit.test(`${subject.tag} ${subject.attr} is sanitized when using quoted+concat non-whitelisted protocol`, function() {
       view = EmberView.create({
         context: { protocol: 'javascript:', path: '//example.com' },
         template: subject.multipartTemplate

--- a/packages/ember-htmlbars/tests/attr_nodes/svg_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/svg_test.js
@@ -2,7 +2,6 @@ import EmberView from 'ember-views/views/view';
 import run from 'ember-metal/run_loop';
 import { compile } from '../utils/helpers';
 import { equalInnerHTML } from 'htmlbars-test-helpers';
-import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
 
 var view;
 
@@ -10,7 +9,7 @@ function appendView(view) {
   run(function() { view.appendTo('#qunit-fixture'); });
 }
 
-testModule('ember-htmlbars: svg attribute', {
+QUnit.module('ember-htmlbars: svg attribute', {
   teardown() {
     if (view) {
       run(view, view.destroy);
@@ -18,7 +17,7 @@ testModule('ember-htmlbars: svg attribute', {
   }
 });
 
-test('unquoted viewBox property is output', function() {
+QUnit.test('unquoted viewBox property is output', function() {
   var viewBoxString = '0 0 100 100';
   view = EmberView.create({
     context: { viewBoxString: viewBoxString },
@@ -32,7 +31,7 @@ test('unquoted viewBox property is output', function() {
   equal(view.element.getAttribute('svg'), null, 'attribute is removed');
 });
 
-test('quoted viewBox property is output', function() {
+QUnit.test('quoted viewBox property is output', function() {
   var viewBoxString = '0 0 100 100';
   view = EmberView.create({
     context: { viewBoxString: viewBoxString },
@@ -43,7 +42,7 @@ test('quoted viewBox property is output', function() {
   equalInnerHTML(view.element, `<svg viewBox="${viewBoxString}"></svg>`, 'attribute is output');
 });
 
-test('quoted viewBox property is concat', function() {
+QUnit.test('quoted viewBox property is concat', function() {
   var viewBoxString = '100 100';
   view = EmberView.create({
     context: { viewBoxString: viewBoxString },
@@ -59,7 +58,7 @@ test('quoted viewBox property is concat', function() {
   equalInnerHTML(view.element, `<svg viewBox="0 0 ${newViewBoxString}"></svg>`, 'attribute is output');
 });
 
-test('class is output', function() {
+QUnit.test('class is output', function() {
   view = EmberView.create({
     context: { color: 'blue' },
     template: compile('<svg class=\'{{color}} tall\'></svg>')

--- a/packages/ember-htmlbars/tests/attr_nodes/value_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/value_test.js
@@ -1,7 +1,6 @@
 import EmberView from 'ember-views/views/view';
 import run from 'ember-metal/run_loop';
 import { compile } from '../utils/helpers';
-import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
 
 var view;
 
@@ -9,7 +8,7 @@ function appendView(view) {
   run(function() { view.appendTo('#qunit-fixture'); });
 }
 
-testModule('ember-htmlbars: value attribute', {
+QUnit.module('ember-htmlbars: value attribute', {
   teardown() {
     if (view) {
       run(view, view.destroy);
@@ -17,7 +16,7 @@ testModule('ember-htmlbars: value attribute', {
   }
 });
 
-test('property is output', function() {
+QUnit.test('property is output', function() {
   view = EmberView.create({
     context: { name: 'rick' },
     template: compile('<input value={{name}}>')
@@ -29,7 +28,7 @@ test('property is output', function() {
         'property is set true');
 });
 
-test('string property is output', function() {
+QUnit.test('string property is output', function() {
   view = EmberView.create({
     context: { name: 'rick' },
     template: compile('<input value=\'{{name}}\'>')
@@ -41,7 +40,7 @@ test('string property is output', function() {
         'property is set true');
 });
 
-test('blank property is output', function() {
+QUnit.test('blank property is output', function() {
   view = EmberView.create({
     context: { name: '' },
     template: compile('<input value={{name}}>')

--- a/packages/ember-htmlbars/tests/helpers/-html-safe-test.js
+++ b/packages/ember-htmlbars/tests/helpers/-html-safe-test.js
@@ -6,11 +6,10 @@ import Component from 'ember-htmlbars/component';
 import { compile } from '../utils/helpers';
 
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
-import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
 
 var component, registry, container, warnings, originalWarn;
 
-testModule('ember-htmlbars: {{-html-safe}} helper', {
+QUnit.module('ember-htmlbars: {{-html-safe}} helper', {
   setup() {
     registry = new Registry();
     container = registry.container();
@@ -32,7 +31,7 @@ testModule('ember-htmlbars: {{-html-safe}} helper', {
   }
 });
 
-test('adds the attribute to the element', function() {
+QUnit.test('adds the attribute to the element', function() {
   component = Component.create({
     container,
 
@@ -45,7 +44,7 @@ test('adds the attribute to the element', function() {
 });
 
 if (!EmberDev.runningProdBuild) {
-  test('no warnings are triggered from setting style attribute', function() {
+  QUnit.test('no warnings are triggered from setting style attribute', function() {
     component = Component.create({
       container,
 

--- a/packages/ember-htmlbars/tests/helpers/input_test.js
+++ b/packages/ember-htmlbars/tests/helpers/input_test.js
@@ -9,7 +9,6 @@ import Checkbox from 'ember-htmlbars/components/checkbox';
 import EventDispatcher from 'ember-views/system/event_dispatcher';
 import buildOwner from 'container/tests/test-helpers/build-owner';
 import { OWNER } from 'container/owner';
-import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
 
 var view;
 var controller, owner;
@@ -25,7 +24,7 @@ function commonSetup() {
   dispatcher.setup({}, '#qunit-fixture');
 }
 
-testModule('{{input type=\'text\'}}', {
+QUnit.module('{{input type=\'text\'}}', {
   setup() {
     commonSetup();
 
@@ -53,11 +52,11 @@ testModule('{{input type=\'text\'}}', {
   }
 });
 
-test('should insert a text field into DOM', function() {
+QUnit.test('should insert a text field into DOM', function() {
   equal(view.$('input').length, 1, 'A single text field was inserted');
 });
 
-test('should become disabled if the disabled attribute is true', function() {
+QUnit.test('should become disabled if the disabled attribute is true', function() {
   ok(view.$('input').is(':not(:disabled)'), 'There are no disabled text fields');
 
   run(null, set, controller, 'disabled', true);
@@ -67,7 +66,7 @@ test('should become disabled if the disabled attribute is true', function() {
   ok(view.$('input').is(':not(:disabled)'), 'There are no disabled text fields');
 });
 
-test('input value is updated when setting value property of view', function() {
+QUnit.test('input value is updated when setting value property of view', function() {
   equal(view.$('input').val(), 'hello', 'renders text field with value');
 
   let id = view.$('input').prop('id');
@@ -78,37 +77,37 @@ test('input value is updated when setting value property of view', function() {
   equal(view.$('input').prop('id'), id, 'the component hasn\'t changed');
 });
 
-test('input placeholder is updated when setting placeholder property of view', function() {
+QUnit.test('input placeholder is updated when setting placeholder property of view', function() {
   equal(view.$('input').attr('placeholder'), 'Enter some text', 'renders text field with placeholder');
   run(null, set, controller, 'place', 'Text, please enter it');
   equal(view.$('input').attr('placeholder'), 'Text, please enter it', 'updates text field after placeholder changes');
 });
 
-test('input name is updated when setting name property of view', function() {
+QUnit.test('input name is updated when setting name property of view', function() {
   equal(view.$('input').attr('name'), 'some-name', 'renders text field with name');
   run(null, set, controller, 'name', 'other-name');
   equal(view.$('input').attr('name'), 'other-name', 'updates text field after name changes');
 });
 
-test('input maxlength is updated when setting maxlength property of view', function() {
+QUnit.test('input maxlength is updated when setting maxlength property of view', function() {
   equal(view.$('input').attr('maxlength'), '30', 'renders text field with maxlength');
   run(null, set, controller, 'max', 40);
   equal(view.$('input').attr('maxlength'), '40', 'updates text field after maxlength changes');
 });
 
-test('input size is updated when setting size property of view', function() {
+QUnit.test('input size is updated when setting size property of view', function() {
   equal(view.$('input').attr('size'), '30', 'renders text field with size');
   run(null, set, controller, 'size', 40);
   equal(view.$('input').attr('size'), '40', 'updates text field after size changes');
 });
 
-test('input tabindex is updated when setting tabindex property of view', function() {
+QUnit.test('input tabindex is updated when setting tabindex property of view', function() {
   equal(view.$('input').attr('tabindex'), '5', 'renders text field with the tabindex');
   run(null, set, controller, 'tab', 3);
   equal(view.$('input').attr('tabindex'), '3', 'updates text field after tabindex changes');
 });
 
-test('cursor position is not lost when updating content', function() {
+QUnit.test('cursor position is not lost when updating content', function() {
   equal(view.$('input').val(), 'hello', 'precondition - renders text field with value');
 
   var $input = view.$('input');
@@ -129,7 +128,7 @@ test('cursor position is not lost when updating content', function() {
   equal(input.selectionEnd, 3, 'cursor position was not lost');
 });
 
-test('input can be updated multiple times', function() {
+QUnit.test('input can be updated multiple times', function() {
   equal(view.$('input').val(), 'hello', 'precondition - renders text field with value');
 
   var $input = view.$('input');
@@ -150,7 +149,7 @@ test('input can be updated multiple times', function() {
 });
 
 
-testModule('{{input type=\'text\'}} - static values', {
+QUnit.module('{{input type=\'text\'}} - static values', {
   setup() {
     commonSetup();
 
@@ -171,39 +170,39 @@ testModule('{{input type=\'text\'}} - static values', {
   }
 });
 
-test('should insert a text field into DOM', function() {
+QUnit.test('should insert a text field into DOM', function() {
   equal(view.$('input').length, 1, 'A single text field was inserted');
 });
 
-test('should become disabled if the disabled attribute is true', function() {
+QUnit.test('should become disabled if the disabled attribute is true', function() {
   ok(view.$('input').is(':disabled'), 'The text field is disabled');
 });
 
-test('input value is updated when setting value property of view', function() {
+QUnit.test('input value is updated when setting value property of view', function() {
   equal(view.$('input').val(), 'hello', 'renders text field with value');
 });
 
-test('input placeholder is updated when setting placeholder property of view', function() {
+QUnit.test('input placeholder is updated when setting placeholder property of view', function() {
   equal(view.$('input').attr('placeholder'), 'Enter some text', 'renders text field with placeholder');
 });
 
-test('input name is updated when setting name property of view', function() {
+QUnit.test('input name is updated when setting name property of view', function() {
   equal(view.$('input').attr('name'), 'some-name', 'renders text field with name');
 });
 
-test('input maxlength is updated when setting maxlength property of view', function() {
+QUnit.test('input maxlength is updated when setting maxlength property of view', function() {
   equal(view.$('input').attr('maxlength'), '30', 'renders text field with maxlength');
 });
 
-test('input size is updated when setting size property of view', function() {
+QUnit.test('input size is updated when setting size property of view', function() {
   equal(view.$('input').attr('size'), '30', 'renders text field with size');
 });
 
-test('input tabindex is updated when setting tabindex property of view', function() {
+QUnit.test('input tabindex is updated when setting tabindex property of view', function() {
   equal(view.$('input').attr('tabindex'), '5', 'renders text field with the tabindex');
 });
 
-test('specifying `on="someevent" action="foo"` triggers the action', function() {
+QUnit.test('specifying `on="someevent" action="foo"` triggers the action', function() {
   expect(2);
   runDestroy(view);
   expectDeprecation(`Using '{{input on="focus-in" action="doFoo"}}' ('foo.hbs' @ L1:C0) is deprecated. Please use '{{input focus-in="doFoo"}}' instead.`);
@@ -228,7 +227,7 @@ test('specifying `on="someevent" action="foo"` triggers the action', function() 
   });
 });
 
-testModule('{{input type=\'text\'}} - dynamic type', {
+QUnit.module('{{input type=\'text\'}} - dynamic type', {
   setup() {
     commonSetup();
 
@@ -251,11 +250,11 @@ testModule('{{input type=\'text\'}} - dynamic type', {
   }
 });
 
-test('should insert a text field into DOM', function() {
+QUnit.test('should insert a text field into DOM', function() {
   equal(view.$('input').attr('type'), 'password', 'a bound property can be used to determine type.');
 });
 
-test('should change if the type changes', function() {
+QUnit.test('should change if the type changes', function() {
   equal(view.$('input').attr('type'), 'password', 'a bound property can be used to determine type.');
 
   run(function() {
@@ -265,7 +264,7 @@ test('should change if the type changes', function() {
   equal(view.$('input').attr('type'), 'text', 'it changes after the type changes');
 });
 
-testModule('{{input}} - default type', {
+QUnit.module('{{input}} - default type', {
   setup() {
     commonSetup();
 
@@ -286,11 +285,11 @@ testModule('{{input}} - default type', {
   }
 });
 
-test('should have the default type', function() {
+QUnit.test('should have the default type', function() {
   equal(view.$('input').attr('type'), 'text', 'Has a default text type');
 });
 
-testModule('{{input type=\'checkbox\'}}', {
+QUnit.module('{{input type=\'checkbox\'}}', {
   setup() {
     commonSetup();
 
@@ -315,35 +314,35 @@ testModule('{{input type=\'checkbox\'}}', {
   }
 });
 
-test('should append a checkbox', function() {
+QUnit.test('should append a checkbox', function() {
   equal(view.$('input[type=checkbox]').length, 1, 'A single checkbox is added');
 });
 
-test('should begin disabled if the disabled attribute is true', function() {
+QUnit.test('should begin disabled if the disabled attribute is true', function() {
   ok(view.$('input').is(':not(:disabled)'), 'The checkbox isn\'t disabled');
   run(null, set, controller, 'disabled', true);
   ok(view.$('input').is(':disabled'), 'The checkbox is now disabled');
 });
 
-test('should support the tabindex property', function() {
+QUnit.test('should support the tabindex property', function() {
   equal(view.$('input').prop('tabindex'), '6', 'the initial checkbox tabindex is set in the DOM');
   run(null, set, controller, 'tab', 3);
   equal(view.$('input').prop('tabindex'), '3', 'the checkbox tabindex changes when it is changed in the view');
 });
 
-test('checkbox name is updated', function() {
+QUnit.test('checkbox name is updated', function() {
   equal(view.$('input').attr('name'), 'hello', 'renders checkbox with the name');
   run(null, set, controller, 'name', 'bye');
   equal(view.$('input').attr('name'), 'bye', 'updates checkbox after name changes');
 });
 
-test('checkbox checked property is updated', function() {
+QUnit.test('checkbox checked property is updated', function() {
   equal(view.$('input').prop('checked'), false, 'the checkbox isn\'t checked yet');
   run(null, set, controller, 'val', true);
   equal(view.$('input').prop('checked'), true, 'the checkbox is checked now');
 });
 
-testModule('{{input type=\'checkbox\'}} - prevent value= usage', {
+QUnit.module('{{input type=\'checkbox\'}} - prevent value= usage', {
   setup() {
     commonSetup();
 
@@ -360,13 +359,13 @@ testModule('{{input type=\'checkbox\'}} - prevent value= usage', {
   }
 });
 
-test('It asserts the presence of checked=', function() {
+QUnit.test('It asserts the presence of checked=', function() {
   expectAssertion(function() {
     runAppend(view);
   }, /you must use `checked=/);
 });
 
-testModule('{{input type=boundType}}', {
+QUnit.module('{{input type=boundType}}', {
   setup() {
     commonSetup();
 
@@ -390,17 +389,17 @@ testModule('{{input type=boundType}}', {
   }
 });
 
-test('should append a checkbox', function() {
+QUnit.test('should append a checkbox', function() {
   equal(view.$('input[type=checkbox]').length, 1, 'A single checkbox is added');
 });
 
 // Checking for the checked property is a good way to verify that the correct
 // view was used.
-test('checkbox checked property is updated', function() {
+QUnit.test('checkbox checked property is updated', function() {
   equal(view.$('input').prop('checked'), true, 'the checkbox is checked');
 });
 
-testModule('{{input type=\'checkbox\'}} - static values', {
+QUnit.module('{{input type=\'checkbox\'}} - static values', {
   setup() {
     commonSetup();
 
@@ -425,23 +424,23 @@ testModule('{{input type=\'checkbox\'}} - static values', {
   }
 });
 
-test('should begin disabled if the disabled attribute is true', function() {
+QUnit.test('should begin disabled if the disabled attribute is true', function() {
   ok(view.$().is(':not(:disabled)'), 'The checkbox isn\'t disabled');
 });
 
-test('should support the tabindex property', function() {
+QUnit.test('should support the tabindex property', function() {
   equal(view.$('input').prop('tabindex'), '6', 'the initial checkbox tabindex is set in the DOM');
 });
 
-test('checkbox name is updated', function() {
+QUnit.test('checkbox name is updated', function() {
   equal(view.$('input').attr('name'), 'hello', 'renders checkbox with the name');
 });
 
-test('checkbox checked property is updated', function() {
+QUnit.test('checkbox checked property is updated', function() {
   equal(view.$('input').prop('checked'), false, 'the checkbox isn\'t checked yet');
 });
 
-testModule('{{input type=\'text\'}} - null/undefined values', {
+QUnit.module('{{input type=\'text\'}} - null/undefined values', {
   setup() {
     commonSetup();
   },
@@ -452,7 +451,7 @@ testModule('{{input type=\'text\'}} - null/undefined values', {
   }
 });
 
-test('placeholder attribute bound to undefined is not present', function() {
+QUnit.test('placeholder attribute bound to undefined is not present', function() {
   view = View.extend({
     [OWNER]: owner,
     controller: {},
@@ -468,7 +467,7 @@ test('placeholder attribute bound to undefined is not present', function() {
   equal(view.element.childNodes[1].getAttribute('placeholder'), 'foo', 'attribute is present');
 });
 
-test('placeholder attribute bound to null is not present', function() {
+QUnit.test('placeholder attribute bound to null is not present', function() {
   view = View.extend({
     [OWNER]: owner,
     controller: {

--- a/packages/ember-htmlbars/tests/helpers/link-to_test.js
+++ b/packages/ember-htmlbars/tests/helpers/link-to_test.js
@@ -40,9 +40,7 @@ QUnit.module('ember-htmlbars: link-to helper', {
   }
 });
 
-import { test } from 'ember-glimmer/tests/utils/skip-if-glimmer';
-
-test('should be able to be inserted in DOM when the router is not present', function() {
+QUnit.test('should be able to be inserted in DOM when the router is not present', function() {
   var template = '{{#link-to \'index\'}}Go to Index{{/link-to}}';
   view = EmberView.create({
     [OWNER]: owner,
@@ -54,7 +52,7 @@ test('should be able to be inserted in DOM when the router is not present', func
   equal(view.$().text(), 'Go to Index');
 });
 
-test('re-renders when title changes', function() {
+QUnit.test('re-renders when title changes', function() {
   var template = '{{link-to title routeName}}';
   view = EmberView.create({
     [OWNER]: owner,
@@ -76,7 +74,7 @@ test('re-renders when title changes', function() {
   equal(view.$().text(), 'bar');
 });
 
-test('can read bound title', function() {
+QUnit.test('can read bound title', function() {
   var template = '{{link-to title routeName}}';
   view = EmberView.create({
     [OWNER]: owner,
@@ -92,7 +90,7 @@ test('can read bound title', function() {
   equal(view.$().text(), 'foo');
 });
 
-test('escaped inline form (double curlies) escapes link title', function() {
+QUnit.test('escaped inline form (double curlies) escapes link title', function() {
   view = EmberView.create({
     [OWNER]: owner,
     title: '<b>blah</b>',
@@ -104,7 +102,7 @@ test('escaped inline form (double curlies) escapes link title', function() {
   equal(view.$('b').length, 0, 'no <b> were found');
 });
 
-test('escaped inline form with (-html-safe) does not escape link title', function() {
+QUnit.test('escaped inline form with (-html-safe) does not escape link title', function() {
   view = EmberView.create({
     [OWNER]: owner,
     title: '<b>blah</b>',
@@ -116,7 +114,7 @@ test('escaped inline form with (-html-safe) does not escape link title', functio
   equal(view.$('b').length, 1, '<b> was found');
 });
 
-test('unescaped inline form (triple curlies) does not escape link title', function() {
+QUnit.test('unescaped inline form (triple curlies) does not escape link title', function() {
   view = EmberView.create({
     [OWNER]: owner,
     title: '<b>blah</b>',
@@ -128,7 +126,7 @@ test('unescaped inline form (triple curlies) does not escape link title', functi
   equal(view.$('b').length, 1, '<b> was found');
 });
 
-test('unwraps controllers', function() {
+QUnit.test('unwraps controllers', function() {
   var template = '{{#link-to \'index\' view.otherController}}Text{{/link-to}}';
 
   view = EmberView.create({
@@ -146,7 +144,7 @@ test('unwraps controllers', function() {
   equal(view.$().text(), 'Text');
 });
 
-test('able to safely extend the built-in component and use the normal path', function() {
+QUnit.test('able to safely extend the built-in component and use the normal path', function() {
   view = EmberView.create({
     [OWNER]: owner,
     title: 'my custom link-to component',
@@ -158,7 +156,7 @@ test('able to safely extend the built-in component and use the normal path', fun
   equal(view.$().text(), 'my custom link-to component', 'rendered a custom-link-to component');
 });
 
-test('[GH#13432] able to safely extend the built-in component and invoke it inline', function() {
+QUnit.test('[GH#13432] able to safely extend the built-in component and invoke it inline', function() {
   view = EmberView.create({
     [OWNER]: owner,
     title: 'my custom link-to component',

--- a/packages/ember-htmlbars/tests/helpers/outlet_test.js
+++ b/packages/ember-htmlbars/tests/helpers/outlet_test.js
@@ -5,13 +5,12 @@ import jQuery from 'ember-views/system/jquery';
 import { compile } from '../utils/helpers';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
 import { buildAppInstance } from 'ember-htmlbars/tests/utils';
-import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
 
 var trim = jQuery.trim;
 
 var appInstance, top;
 
-testModule('ember-htmlbars: {{outlet}} helper', {
+QUnit.module('ember-htmlbars: {{outlet}} helper', {
   setup() {
     appInstance = buildAppInstance();
     var CoreOutlet = appInstance._lookupFactory('view:core-outlet');
@@ -25,7 +24,7 @@ testModule('ember-htmlbars: {{outlet}} helper', {
   }
 });
 
-test('view should render the outlet when set after dom insertion', function() {
+QUnit.test('view should render the outlet when set after dom insertion', function() {
   var routerState = withTemplate('<h1>HI</h1>{{outlet}}');
   top.setOutletState(routerState);
   runAppend(top);
@@ -42,7 +41,7 @@ test('view should render the outlet when set after dom insertion', function() {
   equal(trim(top.$().text()), 'HIBYE');
 });
 
-test('a top-level outlet should always be a view', function() {
+QUnit.test('a top-level outlet should always be a view', function() {
   appInstance.register('view:toplevel', EmberView.extend({
     elementId: 'top-level'
   }));
@@ -55,7 +54,7 @@ test('a top-level outlet should always be a view', function() {
   equal(trim(top.$('#top-level').text()), 'HIBYE');
 });
 
-test('view should render the outlet when set before dom insertion', function() {
+QUnit.test('view should render the outlet when set before dom insertion', function() {
   var routerState = withTemplate('<h1>HI</h1>{{outlet}}');
   routerState.outlets.main = withTemplate('<p>BYE</p>');
   top.setOutletState(routerState);
@@ -66,7 +65,7 @@ test('view should render the outlet when set before dom insertion', function() {
 });
 
 
-test('outlet should support an optional name', function() {
+QUnit.test('outlet should support an optional name', function() {
   var routerState = withTemplate('<h1>HI</h1>{{outlet \'mainView\'}}');
   top.setOutletState(routerState);
   runAppend(top);
@@ -83,7 +82,7 @@ test('outlet should support an optional name', function() {
   equal(trim(top.$().text()), 'HIBYE');
 });
 
-test('Outlets bind to the current view, not the current concrete view', function() {
+QUnit.test('Outlets bind to the current view, not the current concrete view', function() {
   var routerState = withTemplate('<h1>HI</h1>{{outlet}}');
   top.setOutletState(routerState);
   runAppend(top);
@@ -100,7 +99,7 @@ test('Outlets bind to the current view, not the current concrete view', function
   equal(output, 'BOTTOM', 'all templates were rendered');
 });
 
-test('Outlets bind to the current template\'s view, not inner contexts [DEPRECATED]', function() {
+QUnit.test('Outlets bind to the current template\'s view, not inner contexts [DEPRECATED]', function() {
   var parentTemplate = '<h1>HI</h1>{{#if view.alwaysTrue}}{{outlet}}{{/if}}';
   var bottomTemplate = '<h3>BOTTOM</h3>';
 
@@ -128,19 +127,19 @@ test('Outlets bind to the current template\'s view, not inner contexts [DEPRECAT
   equal(output, 'BOTTOM', 'all templates were rendered');
 });
 
-test('should not throw deprecations if {{outlet}} is used without a name', function() {
+QUnit.test('should not throw deprecations if {{outlet}} is used without a name', function() {
   expectNoDeprecation();
   top.setOutletState(withTemplate('{{outlet}}'));
   runAppend(top);
 });
 
-test('should not throw deprecations if {{outlet}} is used with a quoted name', function() {
+QUnit.test('should not throw deprecations if {{outlet}} is used with a quoted name', function() {
   expectNoDeprecation();
   top.setOutletState(withTemplate('{{outlet "foo"}}'));
   runAppend(top);
 });
 
-test('{{outlet}} should work with an unquoted name', function() {
+QUnit.test('{{outlet}} should work with an unquoted name', function() {
   var routerState = {
     render: {
       controller: Controller.create({
@@ -159,7 +158,7 @@ test('{{outlet}} should work with an unquoted name', function() {
   equal(top.$().text().trim(), 'It\'s magic');
 });
 
-test('{{outlet}} should rerender when bound name changes', function() {
+QUnit.test('{{outlet}} should rerender when bound name changes', function() {
   var routerState = {
     render: {
       controller: Controller.create({
@@ -182,7 +181,7 @@ test('{{outlet}} should rerender when bound name changes', function() {
   equal(top.$().text().trim(), 'second');
 });
 
-test('views created by {{outlet}} should get destroyed', function() {
+QUnit.test('views created by {{outlet}} should get destroyed', function() {
   let inserted = 0;
   let destroyed = 0;
   var routerState = {

--- a/packages/ember-htmlbars/tests/helpers/render_test.js
+++ b/packages/ember-htmlbars/tests/helpers/render_test.js
@@ -9,8 +9,6 @@ import { buildAppInstance } from 'ember-htmlbars/tests/utils';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
 import { OWNER } from 'container/owner';
 import { setTemplates, set as setTemplate } from 'ember-templates/template_registry';
-import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
-
 
 function runSet(object, key, value) {
   run(function() {
@@ -21,7 +19,7 @@ function runSet(object, key, value) {
 const ORIGINAL_LEGACY_CONTROLLER_FLAG = ENV._ENABLE_LEGACY_CONTROLLER_SUPPORT;
 var view, appInstance;
 
-testModule('ember-htmlbars: {{render}} helper', {
+QUnit.module('ember-htmlbars: {{render}} helper', {
   setup() {
     appInstance = buildAppInstance();
   },
@@ -34,7 +32,7 @@ testModule('ember-htmlbars: {{render}} helper', {
   }
 });
 
-test('{{render}} helper should render given template', function() {
+QUnit.test('{{render}} helper should render given template', function() {
   var template = '<h1>HI</h1>{{render \'home\'}}';
   var controller = EmberController.extend();
 
@@ -54,7 +52,7 @@ test('{{render}} helper should render given template', function() {
   ok(appInstance.lookup('router:main')._lookupActiveComponentNode('home'), 'should register home as active view');
 });
 
-test('{{render}} helper should render nested helpers', function() {
+QUnit.test('{{render}} helper should render nested helpers', function() {
   var template = '<h1>HI</h1>{{render \'foo\'}}';
   var controller = EmberController.extend();
 
@@ -73,7 +71,7 @@ test('{{render}} helper should render nested helpers', function() {
   equal(view.$().text(), 'HIFOOBARBAZ');
 });
 
-test('{{render}} helper should have assertion if neither template nor view exists', function() {
+QUnit.test('{{render}} helper should have assertion if neither template nor view exists', function() {
   var template = '<h1>HI</h1>{{render \'oops\'}}';
   var controller = EmberController.extend();
 
@@ -88,7 +86,7 @@ test('{{render}} helper should have assertion if neither template nor view exist
   }, 'You used `{{render \'oops\'}}`, but \'oops\' can not be found as either a template or a view.');
 });
 
-test('{{render}} helper should not have assertion if view exists without a template', function() {
+QUnit.test('{{render}} helper should not have assertion if view exists without a template', function() {
   var template = '<h1>HI</h1>{{render \'oops\'}}';
   var controller = EmberController.extend();
 
@@ -105,7 +103,7 @@ test('{{render}} helper should not have assertion if view exists without a templ
   equal(view.$().text(), 'HI');
 });
 
-test('{{render}} helper should render given template with a supplied model', function() {
+QUnit.test('{{render}} helper should render given template with a supplied model', function() {
   var template = '<h1>HI</h1>{{render \'post\' post}}';
   var post = {
     title: 'Rails is omakase'
@@ -149,7 +147,7 @@ test('{{render}} helper should render given template with a supplied model', fun
   deepEqual(postController.get('model'), { title: 'Rails is unagi' });
 });
 
-test('{{render}} helper with a supplied model should not fire observers on the controller', function () {
+QUnit.test('{{render}} helper with a supplied model should not fire observers on the controller', function () {
   var template = '<h1>HI</h1>{{render \'post\' post}}';
   var post = {
     title: 'Rails is omakase'
@@ -182,7 +180,7 @@ test('{{render}} helper with a supplied model should not fire observers on the c
   equal(modelDidChange, 0, 'model observer did not fire');
 });
 
-test('{{render}} helper should raise an error when a given controller name does not resolve to a controller', function() {
+QUnit.test('{{render}} helper should raise an error when a given controller name does not resolve to a controller', function() {
   let template = '<h1>HI</h1>{{render "home" controller="postss"}}';
   let Controller = EmberController.extend();
   let controller = Controller.create({
@@ -204,7 +202,7 @@ test('{{render}} helper should raise an error when a given controller name does 
   }, 'The controller name you supplied \'postss\' did not resolve to a controller.');
 });
 
-test('{{render}} helper should render with given controller', function() {
+QUnit.test('{{render}} helper should render with given controller', function() {
   var template = '{{render "home" controller="posts"}}';
   var Controller = EmberController.extend();
   let model = {};
@@ -239,7 +237,7 @@ test('{{render}} helper should render with given controller', function() {
   equal(renderedModel, model, 'rendered with model on controller');
 });
 
-test('{{render}} helper should rerender with given controller', function() {
+QUnit.test('{{render}} helper should rerender with given controller', function() {
   let template = '{{render "home" controller="posts"}}';
   let Controller = EmberController.extend();
   let model = {};
@@ -278,7 +276,7 @@ test('{{render}} helper should rerender with given controller', function() {
   equal(renderedModel, model, 'rendered with model on controller');
 });
 
-test('{{render}} helper should render a template without a model only once', function() {
+QUnit.test('{{render}} helper should render a template without a model only once', function() {
   var template = '<h1>HI</h1>{{render \'home\'}}<hr/>{{render \'home\'}}';
   var Controller = EmberController.extend();
   let controller = Controller.create({
@@ -298,7 +296,7 @@ test('{{render}} helper should render a template without a model only once', fun
   }, /\{\{render\}\} helper once/i);
 });
 
-test('{{render}} helper should render templates with models multiple times', function() {
+QUnit.test('{{render}} helper should render templates with models multiple times', function() {
   var template = '<h1>HI</h1> {{render \'post\' post1}} {{render \'post\' post2}}';
   var post1 = {
     title: 'Me first'
@@ -351,7 +349,7 @@ test('{{render}} helper should render templates with models multiple times', fun
   deepEqual(postController1.get('model'), { title: 'I am new' });
 });
 
-test('{{render}} helper should not leak controllers', function() {
+QUnit.test('{{render}} helper should not leak controllers', function() {
   var template = '<h1>HI</h1> {{render \'post\' post1}}';
   var post1 = {
     title: 'Me first'
@@ -391,7 +389,7 @@ test('{{render}} helper should not leak controllers', function() {
   ok(postController.isDestroyed, 'expected postController to be destroyed');
 });
 
-test('{{render}} helper should not treat invocations with falsy contexts as context-less', function() {
+QUnit.test('{{render}} helper should not treat invocations with falsy contexts as context-less', function() {
   var template = '<h1>HI</h1> {{render \'post\' zero}} {{render \'post\' nonexistent}}';
 
   let controller = EmberController.create({
@@ -429,7 +427,7 @@ test('{{render}} helper should not treat invocations with falsy contexts as cont
   equal(postController2.get('model'), undefined);
 });
 
-test('{{render}} helper should render templates both with and without models', function() {
+QUnit.test('{{render}} helper should render templates both with and without models', function() {
   var template = '<h1>HI</h1> {{render \'post\'}} {{render \'post\' post}}';
   var post = {
     title: 'Rails is omakase'
@@ -478,7 +476,7 @@ test('{{render}} helper should render templates both with and without models', f
   deepEqual(postController2.get('model'), { title: 'Rails is unagi' });
 });
 
-test('{{render}} helper should be able to render a template again when it was removed', function() {
+QUnit.test('{{render}} helper should be able to render a template again when it was removed', function() {
   let CoreOutlet = appInstance._lookupFactory('view:core-outlet');
   let Controller = EmberController.extend();
   let controller = Controller.create({
@@ -524,7 +522,7 @@ test('{{render}} helper should be able to render a template again when it was re
   equal(view.$().text(), 'HI2BYE');
 });
 
-test('{{render}} works with dot notation', function() {
+QUnit.test('{{render}} works with dot notation', function() {
   var template = '{{render "blog.post"}}';
 
   var ContextController = EmberController.extend();
@@ -557,7 +555,7 @@ test('{{render}} works with dot notation', function() {
   equal(singletonController.uniqueId, view.$().html(), 'rendered with correct singleton controller');
 });
 
-test('throws an assertion if {{render}} is called with an unquoted template name', function() {
+QUnit.test('throws an assertion if {{render}} is called with an unquoted template name', function() {
   var template = '<h1>HI</h1>{{render home}}';
   var Controller = EmberController.extend();
   var controller = Controller.create({
@@ -576,7 +574,7 @@ test('throws an assertion if {{render}} is called with an unquoted template name
   }, 'The first argument of {{render}} must be quoted, e.g. {{render "sidebar"}}.');
 });
 
-test('throws an assertion if {{render}} is called with a literal for a model', function() {
+QUnit.test('throws an assertion if {{render}} is called with a literal for a model', function() {
   var template = '<h1>HI</h1>{{render "home" "model"}}';
   var Controller = EmberController.extend();
   var controller = Controller.create({
@@ -596,7 +594,7 @@ test('throws an assertion if {{render}} is called with a literal for a model', f
   }, 'The second argument of {{render}} must be a path, e.g. {{render "post" post}}.');
 });
 
-test('{{render}} helper should let view provide its own template', function() {
+QUnit.test('{{render}} helper should let view provide its own template', function() {
   var template = '{{render \'fish\'}}';
   var Controller = EmberController.extend();
   var controller = Controller.create({
@@ -621,7 +619,7 @@ test('{{render}} helper should let view provide its own template', function() {
   equal(view.$().text(), 'Hello other!');
 });
 
-test('{{render}} helper should not require view to provide its own template', function() {
+QUnit.test('{{render}} helper should not require view to provide its own template', function() {
   var template = '{{render \'fish\'}}';
   var Controller = EmberController.extend();
   var controller = Controller.create({
@@ -643,7 +641,7 @@ test('{{render}} helper should not require view to provide its own template', fu
   equal(view.$().text(), 'Hello fish!');
 });
 
-test('{{render}} helper should set router as target when parentController is not found', function() {
+QUnit.test('{{render}} helper should set router as target when parentController is not found', function() {
   expect(3);
 
   ENV._ENABLE_LEGACY_CONTROLLER_SUPPORT = false;

--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -45,9 +45,7 @@ function viewClass(options) {
 
 var firstChild = nthChild;
 
-import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
-
-testModule('ember-htmlbars: {{#view}} helper', {
+QUnit.module('ember-htmlbars: {{#view}} helper', {
   setup() {
     originalViewKeyword = registerKeyword('view',  viewKeyword);
 
@@ -72,7 +70,7 @@ testModule('ember-htmlbars: {{#view}} helper', {
 });
 
 // https://github.com/emberjs/ember.js/issues/120
-test('should not enter an infinite loop when binding an attribute in Handlebars', function() {
+QUnit.test('should not enter an infinite loop when binding an attribute in Handlebars', function() {
   var LinkView = EmberView.extend({
     classNames: ['app-link'],
     tagName: 'a',
@@ -101,7 +99,7 @@ test('should not enter an infinite loop when binding an attribute in Handlebars'
   runDestroy(parentView);
 });
 
-test('By default view:toplevel is used', function() {
+QUnit.test('By default view:toplevel is used', function() {
   var DefaultView = viewClass({
     elementId: 'toplevel-view',
     template: compile('hello world')
@@ -119,7 +117,7 @@ test('By default view:toplevel is used', function() {
   equal(jQuery('#toplevel-view').text(), 'hello world');
 });
 
-test('By default, without an owner, EmberView is used', function() {
+QUnit.test('By default, without an owner, EmberView is used', function() {
   view = EmberView.extend({
     template: compile('{{view tagName="span"}}')
   }).create();
@@ -129,7 +127,7 @@ test('By default, without an owner, EmberView is used', function() {
   ok(jQuery('#qunit-fixture').html().toUpperCase().match(/<SPAN/), 'contains view with span');
 });
 
-test('View lookup - \'fu\'', function() {
+QUnit.test('View lookup - \'fu\'', function() {
   var FuView = viewClass({
     elementId: 'fu',
     template: compile('bro')
@@ -147,7 +145,7 @@ test('View lookup - \'fu\'', function() {
   equal(jQuery('#fu').text(), 'bro');
 });
 
-test('View lookup - \'fu\' when fu is a property and a view name', function() {
+QUnit.test('View lookup - \'fu\' when fu is a property and a view name', function() {
   var FuView = viewClass({
     elementId: 'fu',
     template: compile('bro')
@@ -166,7 +164,7 @@ test('View lookup - \'fu\' when fu is a property and a view name', function() {
   equal(jQuery('#fu').text(), 'bro');
 });
 
-test('View lookup - view.computed', function() {
+QUnit.test('View lookup - view.computed', function() {
   var FuView = viewClass({
     elementId: 'fu',
     template: compile('bro')
@@ -185,7 +183,7 @@ test('View lookup - view.computed', function() {
   equal(jQuery('#fu').text(), 'bro');
 });
 
-test('id bindings downgrade to one-time property lookup', function() {
+QUnit.test('id bindings downgrade to one-time property lookup', function() {
   view = EmberView.extend({
     template: compile('{{#view id=view.meshuggah}}{{view.parentView.meshuggah}}{{/view}}'),
     meshuggah: 'stengah'
@@ -198,7 +196,7 @@ test('id bindings downgrade to one-time property lookup', function() {
   equal(jQuery('#stengah').text(), 'omg', 'id didn\'t change');
 });
 
-test('specifying `id` as a static value works properly', function() {
+QUnit.test('specifying `id` as a static value works properly', function() {
   view = EmberView.extend({
     template: compile('{{#view id=\'blah\'}}{{view.parentView.meshuggah}}{{/view}}'),
     meshuggah: 'stengah'
@@ -209,7 +207,7 @@ test('specifying `id` as a static value works properly', function() {
   equal(view.$('#blah').text(), 'stengah', 'id binding performed property lookup');
 });
 
-test('mixing old and new styles of property binding fires a warning, treats value as if it were quoted', function() {
+QUnit.test('mixing old and new styles of property binding fires a warning, treats value as if it were quoted', function() {
   if (EmberDev && EmberDev.runningProdBuild) {
     ok(true, 'Logging does not occur in production builds');
     return;
@@ -241,7 +239,7 @@ test('mixing old and new styles of property binding fires a warning, treats valu
   setDebugFunction('warn', oldWarn);
 });
 
-test('"Binding"-suffixed bindings are runloop-synchronized [DEPRECATED]', function() {
+QUnit.test('"Binding"-suffixed bindings are runloop-synchronized [DEPRECATED]', function() {
   var subview;
 
   var Subview = EmberView.extend({
@@ -290,7 +288,7 @@ test('"Binding"-suffixed bindings are runloop-synchronized [DEPRECATED]', functi
   equal(get(subview, 'color'), 'persian rose', 'bound property is updated after runloop flush');
 });
 
-test('Non-"Binding"-suffixed bindings are runloop-synchronized', function() {
+QUnit.test('Non-"Binding"-suffixed bindings are runloop-synchronized', function() {
   var subview;
 
   var Subview = EmberView.extend({
@@ -333,7 +331,7 @@ test('Non-"Binding"-suffixed bindings are runloop-synchronized', function() {
   equal(get(subview, 'color'), 'persian rose', 'bound property is updated after runloop flush');
 });
 
-test('allows you to pass attributes that will be assigned to the class instance, like class="foo"', function() {
+QUnit.test('allows you to pass attributes that will be assigned to the class instance, like class="foo"', function() {
   expect(4);
 
   owner.register('view:toplevel', EmberView.extend());
@@ -351,7 +349,7 @@ test('allows you to pass attributes that will be assigned to the class instance,
   equal(jQuery('#bar').text(), 'Bar');
 });
 
-test('Should apply class without condition always', function() {
+QUnit.test('Should apply class without condition always', function() {
   view = EmberView.create({
     controller: EmberObject.create(),
     template: compile('{{#view id="foo" classBinding=":foo"}} Foo{{/view}}')
@@ -362,7 +360,7 @@ test('Should apply class without condition always', function() {
   ok(jQuery('#foo').hasClass('foo'), 'Always applies classbinding without condition');
 });
 
-test('Should apply classes when bound property specified', function() {
+QUnit.test('Should apply classes when bound property specified', function() {
   view = EmberView.create({
     controller: {
       someProp: 'foo'
@@ -375,7 +373,7 @@ test('Should apply classes when bound property specified', function() {
   ok(jQuery('#foo').hasClass('foo'), 'Always applies classbinding without condition');
 });
 
-test('Should apply a class from a sub expression', function() {
+QUnit.test('Should apply a class from a sub expression', function() {
   owner.register('helper:string-concat', makeHelper(function(params) {
     return params.join('');
   }));
@@ -399,7 +397,7 @@ test('Should apply a class from a sub expression', function() {
   ok(jQuery('#foo').hasClass('btn-medium'), 'adds classname from subexpression update');
 });
 
-test('Should not apply classes when bound property specified is false', function() {
+QUnit.test('Should not apply classes when bound property specified is false', function() {
   view = EmberView.create({
     controller: {
       someProp: false
@@ -412,7 +410,7 @@ test('Should not apply classes when bound property specified is false', function
   ok(!jQuery('#foo').hasClass('some-prop'), 'does not add class when value is falsey');
 });
 
-test('Should apply classes of the dasherized property name when bound property specified is true', function() {
+QUnit.test('Should apply classes of the dasherized property name when bound property specified is true', function() {
   view = EmberView.create({
     controller: {
       someProp: true
@@ -425,7 +423,7 @@ test('Should apply classes of the dasherized property name when bound property s
   ok(jQuery('#foo').hasClass('some-prop'), 'adds dasherized class when value is true');
 });
 
-test('Should update classes from a bound property', function() {
+QUnit.test('Should update classes from a bound property', function() {
   var controller = {
     someProp: true
   };
@@ -452,7 +450,7 @@ test('Should update classes from a bound property', function() {
   ok(jQuery('#foo').hasClass('fooBar'), 'changes property to string value (but does not dasherize)');
 });
 
-test('bound properties should be available in the view', function() {
+QUnit.test('bound properties should be available in the view', function() {
   var FuView = viewClass({
     elementId: 'fu',
     template: compile('{{view.attrs.foo}}')
@@ -477,7 +475,7 @@ test('bound properties should be available in the view', function() {
   equal(view.$('#fu').text(), 'second value');
 });
 
-test('should escape HTML in normal mustaches', function() {
+QUnit.test('should escape HTML in normal mustaches', function() {
   view = EmberView.create({
     template: compile('{{view.output}}'),
     output: 'you need to be more <b>bold</b>'
@@ -495,7 +493,7 @@ test('should escape HTML in normal mustaches', function() {
   equal(view.$('i').length, 0, 'does not create an element when value is updated');
 });
 
-test('should not escape HTML in triple mustaches', function() {
+QUnit.test('should not escape HTML in triple mustaches', function() {
   view = EmberView.create({
     template: compile('{{{view.output}}}'),
     output: 'you need to be more <b>bold</b>'
@@ -512,7 +510,7 @@ test('should not escape HTML in triple mustaches', function() {
   equal(view.$('i').length, 1, 'creates an element when value is updated');
 });
 
-test('should not escape HTML if string is a Handlebars.SafeString', function() {
+QUnit.test('should not escape HTML if string is a Handlebars.SafeString', function() {
   view = EmberView.create({
     template: compile('{{view.output}}'),
     output: new SafeString('you need to be more <b>bold</b>')
@@ -529,7 +527,7 @@ test('should not escape HTML if string is a Handlebars.SafeString', function() {
   equal(view.$('i').length, 1, 'creates an element when value is updated');
 });
 
-test('should teardown observers from bound properties on rerender', function() {
+QUnit.test('should teardown observers from bound properties on rerender', function() {
   view = EmberView.create({
     template: compile('{{view.foo}}'),
     foo: 'bar'
@@ -546,7 +544,7 @@ test('should teardown observers from bound properties on rerender', function() {
   equal(observersFor(view, 'foo').length, 1);
 });
 
-test('should update bound values after the view is removed and then re-appended', function() {
+QUnit.test('should update bound values after the view is removed and then re-appended', function() {
   view = EmberView.create({
     template: compile('{{#if view.showStuff}}{{view.boundValue}}{{else}}Not true.{{/if}}'),
     showStuff: true,
@@ -581,7 +579,7 @@ test('should update bound values after the view is removed and then re-appended'
   equal(trim(view.$().text()), 'bar');
 });
 
-test('views set the template of their children to a passed block', function() {
+QUnit.test('views set the template of their children to a passed block', function() {
   owner.register('template:parent', compile('<h1>{{#view}}<span>It worked!</span>{{/view}}</h1>'));
 
   view = EmberView.create({
@@ -593,7 +591,7 @@ test('views set the template of their children to a passed block', function() {
   ok(view.$('h1:has(span)').length === 1, 'renders the passed template inside the parent template');
 });
 
-test('{{view}} should not override class bindings defined on a child view', function() {
+QUnit.test('{{view}} should not override class bindings defined on a child view', function() {
   var LabelView = EmberView.extend({
     classNameBindings: ['something'],
     something:         'visible'
@@ -614,7 +612,7 @@ test('{{view}} should not override class bindings defined on a child view', func
   ok(view.$('.visible').length > 0, 'class bindings are not overriden');
 });
 
-test('child views can be inserted using the {{view}} helper', function() {
+QUnit.test('child views can be inserted using the {{view}} helper', function() {
   owner.register('template:nester', compile('<h1 id="hello-world">Hello {{world}}</h1>{{view view.labelView}}'));
   owner.register('template:nested', compile('<div id="child-view">Goodbye {{cruel}} {{world}}</div>'));
 
@@ -643,7 +641,7 @@ test('child views can be inserted using the {{view}} helper', function() {
   ok(view.$().text().match(/Hello world!.*Goodbye cruel world\!/), 'parent view should appear before the child view');
 });
 
-test('should be able to explicitly set a view\'s context', function() {
+QUnit.test('should be able to explicitly set a view\'s context', function() {
   var context = EmberObject.create({
     test: 'test'
   });
@@ -663,7 +661,7 @@ test('should be able to explicitly set a view\'s context', function() {
   equal(view.$().text(), 'test');
 });
 
-test('Template views add an elementId to child views created using the view helper', function() {
+QUnit.test('Template views add an elementId to child views created using the view helper', function() {
   owner.register('template:parent', compile('<div>{{view view.childView}}</div>'));
   owner.register('template:child', compile('I can\'t believe it\'s not butter.'));
 
@@ -683,7 +681,7 @@ test('Template views add an elementId to child views created using the view help
   equal(view.$().children().first().children().first().attr('id'), get(childView, 'elementId'));
 });
 
-test('Child views created using the view helper should have their parent view set properly', function() {
+QUnit.test('Child views created using the view helper should have their parent view set properly', function() {
   var template = '{{#view}}{{#view}}{{view}}{{/view}}{{/view}}';
 
   view = EmberView.create({
@@ -696,7 +694,7 @@ test('Child views created using the view helper should have their parent view se
   equal(childView, get(firstChild(childView), 'parentView'), 'parent view is correct');
 });
 
-test('Child views created using the view helper should have their IDs registered for events', function() {
+QUnit.test('Child views created using the view helper should have their IDs registered for events', function() {
   var template = '{{view}}{{view id="templateViewTest"}}';
 
   view = EmberView.create({
@@ -715,7 +713,7 @@ test('Child views created using the view helper should have their IDs registered
   equal(EmberView.views[id], childView, 'childView with passed ID is registered with View.views so that it can properly receive events from EventDispatcher');
 });
 
-test('Child views created using the view helper and that have a viewName should be registered as properties on their parentView', function() {
+QUnit.test('Child views created using the view helper and that have a viewName should be registered as properties on their parentView', function() {
   var template = '{{#view}}{{view viewName="ohai"}}{{/view}}';
 
   view = EmberView.create({
@@ -730,7 +728,7 @@ test('Child views created using the view helper and that have a viewName should 
   equal(get(parentView, 'ohai'), childView);
 });
 
-test('{{view}} id attribute should set id on layer', function() {
+QUnit.test('{{view}} id attribute should set id on layer', function() {
   owner.register('template:foo', compile('{{#view view.idView id="bar"}}baz{{/view}}'));
 
   var IdView = EmberView;
@@ -747,7 +745,7 @@ test('{{view}} id attribute should set id on layer', function() {
   equal(view.$('#bar').text(), 'baz', 'emits content');
 });
 
-test('{{view}} tag attribute should set tagName of the view', function() {
+QUnit.test('{{view}} tag attribute should set tagName of the view', function() {
   owner.register('template:foo', compile('{{#view view.tagView tag="span"}}baz{{/view}}'));
 
   var TagView = EmberView;
@@ -764,7 +762,7 @@ test('{{view}} tag attribute should set tagName of the view', function() {
   equal(view.$('span').text(), 'baz', 'emits content');
 });
 
-test('{{view}} class attribute should set class on layer', function() {
+QUnit.test('{{view}} class attribute should set class on layer', function() {
   owner.register('template:foo', compile('{{#view view.idView class="bar"}}baz{{/view}}'));
 
   var IdView = EmberView;
@@ -781,7 +779,7 @@ test('{{view}} class attribute should set class on layer', function() {
   equal(view.$('.bar').text(), 'baz', 'emits content');
 });
 
-test('{{view}} should not allow attributeBindings to be set', function() {
+QUnit.test('{{view}} should not allow attributeBindings to be set', function() {
   expectAssertion(function() {
     view = EmberView.create({
       template: compile('{{view attributeBindings="one two"}}')
@@ -790,7 +788,7 @@ test('{{view}} should not allow attributeBindings to be set', function() {
   }, /Setting 'attributeBindings' via template helpers is not allowed/);
 });
 
-test('{{view}} should be able to point to a local view', function() {
+QUnit.test('{{view}} should be able to point to a local view', function() {
   view = EmberView.create({
     template: compile('{{view view.common}}'),
 
@@ -804,7 +802,7 @@ test('{{view}} should be able to point to a local view', function() {
   equal(view.$().text(), 'common', 'tries to look up view name locally');
 });
 
-test('{{view}} should evaluate class bindings set in the current context', function() {
+QUnit.test('{{view}} should evaluate class bindings set in the current context', function() {
   view = EmberView.create({
     isView:      true,
     isEditable:  true,
@@ -833,7 +831,7 @@ test('{{view}} should evaluate class bindings set in the current context', funct
   ok(view.$('input').hasClass('disabled'), 'evaluates ternary operator in classBindings');
 });
 
-test('{{view}} should evaluate other attributes bindings set in the current context', function() {
+QUnit.test('{{view}} should evaluate other attributes bindings set in the current context', function() {
   view = EmberView.create({
     name: 'myView',
     textField: TextField,
@@ -845,7 +843,7 @@ test('{{view}} should evaluate other attributes bindings set in the current cont
   equal(view.$('input').val(), 'myView', 'evaluates attributes bound in the current context');
 });
 
-test('{{view}} should be able to bind class names to truthy properties', function() {
+QUnit.test('{{view}} should be able to bind class names to truthy properties', function() {
   owner.register('template:template', compile('{{#view view.classBindingView classBinding="view.number:is-truthy"}}foo{{/view}}'));
 
   var ClassBindingView = EmberView.extend();
@@ -868,7 +866,7 @@ test('{{view}} should be able to bind class names to truthy properties', functio
   equal(view.$('.is-truthy').length, 0, 'removes class name if bound property is set to falsey');
 });
 
-test('{{view}} should be able to bind class names to truthy or falsy properties', function() {
+QUnit.test('{{view}} should be able to bind class names to truthy or falsy properties', function() {
   owner.register('template:template', compile('{{#view view.classBindingView classBinding="view.number:is-truthy:is-falsy"}}foo{{/view}}'));
 
   var ClassBindingView = EmberView.extend();
@@ -893,7 +891,7 @@ test('{{view}} should be able to bind class names to truthy or falsy properties'
   equal(view.$('.is-falsy').length, 1, 'sets class name to falsy value');
 });
 
-test('a view helper\'s bindings are to the parent context', function() {
+QUnit.test('a view helper\'s bindings are to the parent context', function() {
   var Subview = EmberView.extend({
     classNameBindings: ['attrs.color'],
     controller: EmberObject.create({
@@ -919,7 +917,7 @@ test('a view helper\'s bindings are to the parent context', function() {
   equal(view.$('h1 .mauve').text(), 'foo bar', 'renders property bound in template from subview context');
 });
 
-test('should expose a controller that can be used in the view instance', function() {
+QUnit.test('should expose a controller that can be used in the view instance', function() {
   var templateString = '{{#view view.childThing tagName="div"}}Stuff{{/view}}';
   var controller = {
     foo: 'bar'
@@ -943,7 +941,7 @@ test('should expose a controller that can be used in the view instance', functio
   equal(controller, childThingController, 'childThing should get the same controller as the outer scope');
 });
 
-test('should work with precompiled templates', function() {
+QUnit.test('should work with precompiled templates', function() {
   var templateString = precompile('{{view.value}}');
   var compiledTemplate = template(eval(templateString));
 
@@ -963,7 +961,7 @@ test('should work with precompiled templates', function() {
   equal(view.$().text(), 'updated', 'the precompiled template was updated');
 });
 
-test('bindings should be relative to the current context [DEPRECATED]', function() {
+QUnit.test('bindings should be relative to the current context [DEPRECATED]', function() {
   view = EmberView.create({
     museumOpen: true,
 
@@ -984,7 +982,7 @@ test('bindings should be relative to the current context [DEPRECATED]', function
   equal(trim(view.$().text()), 'Name: SFMoMA Price: $20', 'should print baz twice');
 });
 
-test('bindings should respect keywords [DEPRECATED]', function() {
+QUnit.test('bindings should respect keywords [DEPRECATED]', function() {
   view = EmberView.create({
     museumOpen: true,
 
@@ -1008,7 +1006,7 @@ test('bindings should respect keywords [DEPRECATED]', function() {
   equal(trim(view.$().text()), 'Name: SFMoMA Price: $20', 'should print baz twice');
 });
 
-test('should respect keywords', function() {
+QUnit.test('should respect keywords', function() {
   view = EmberView.create({
     museumOpen: true,
 
@@ -1032,7 +1030,7 @@ test('should respect keywords', function() {
   equal(trim(view.$().text()), 'Name: SFMoMA Price: $20', 'should print baz twice');
 });
 
-test('should bind to the property if no registered helper found for a mustache without parameters', function() {
+QUnit.test('should bind to the property if no registered helper found for a mustache without parameters', function() {
   view = EmberView.extend({
     foobarProperty: computed(function() {
       return 'foobarProperty';
@@ -1046,7 +1044,7 @@ test('should bind to the property if no registered helper found for a mustache w
   ok(view.$().text() === 'foobarProperty', 'Property was bound to correctly');
 });
 
-test('{{view}} should be able to point to a local instance of view', function() {
+QUnit.test('{{view}} should be able to point to a local instance of view', function() {
   view = EmberView.create({
     template: compile('{{view view.common}}'),
 
@@ -1059,7 +1057,7 @@ test('{{view}} should be able to point to a local instance of view', function() 
   equal(view.$().text(), 'common', 'tries to look up view name locally');
 });
 
-test('{{view}} should be able to point to a local instance of subclass of view', function() {
+QUnit.test('{{view}} should be able to point to a local instance of subclass of view', function() {
   var MyView = EmberView.extend();
   view = EmberView.create({
     template: compile('{{view view.subclassed}}'),
@@ -1072,7 +1070,7 @@ test('{{view}} should be able to point to a local instance of subclass of view',
   equal(view.$().text(), 'subclassed', 'tries to look up view name locally');
 });
 
-test('{{view}} asserts that a view class is present', function() {
+QUnit.test('{{view}} asserts that a view class is present', function() {
   var MyView = EmberObject.extend();
   view = EmberView.create({
     template: compile('{{view view.notView}}'),
@@ -1086,7 +1084,7 @@ test('{{view}} asserts that a view class is present', function() {
   }, /must be a subclass or an instance of Ember.View/);
 });
 
-test('{{view}} asserts that a view class is present off controller', function() {
+QUnit.test('{{view}} asserts that a view class is present off controller', function() {
   var MyView = EmberObject.extend();
   view = EmberView.create({
     template: compile('{{view notView}}'),
@@ -1102,7 +1100,7 @@ test('{{view}} asserts that a view class is present off controller', function() 
   }, /must be a subclass or an instance of Ember.View/);
 });
 
-test('{{view}} asserts that a view instance is present', function() {
+QUnit.test('{{view}} asserts that a view instance is present', function() {
   var MyView = EmberObject.extend();
   view = EmberView.create({
     template: compile('{{view view.notView}}'),
@@ -1116,7 +1114,7 @@ test('{{view}} asserts that a view instance is present', function() {
   }, /must be a subclass or an instance of Ember.View/);
 });
 
-test('{{view}} asserts that a view subclass instance is present off controller', function() {
+QUnit.test('{{view}} asserts that a view subclass instance is present off controller', function() {
   var MyView = EmberObject.extend();
   view = EmberView.create({
     template: compile('{{view notView}}'),
@@ -1132,7 +1130,7 @@ test('{{view}} asserts that a view subclass instance is present off controller',
   }, /must be a subclass or an instance of Ember.View/);
 });
 
-test('Specifying `id` to {{view}} is set on the view.', function() {
+QUnit.test('Specifying `id` to {{view}} is set on the view.', function() {
   owner.register('view:derp', EmberView.extend({
     template: compile('<div id="view-id">{{view.id}}</div><div id="view-elementId">{{view.elementId}}</div>')
   }));
@@ -1150,7 +1148,7 @@ test('Specifying `id` to {{view}} is set on the view.', function() {
   equal(view.$('#view-elementId').text(), 'bar', 'the views elementId property is set');
 });
 
-test('Specifying `id` to {{view}} does not allow bound id changes.', function() {
+QUnit.test('Specifying `id` to {{view}} does not allow bound id changes.', function() {
   owner.register('view:derp', EmberView.extend({
     template: compile('<div id="view-id">{{view.id}}</div><div id="view-elementId">{{view.elementId}}</div>')
   }));
@@ -1170,7 +1168,7 @@ test('Specifying `id` to {{view}} does not allow bound id changes.', function() 
   equal(view.$('#bar #view-id').text(), 'baz', 'the views id property is not changed');
 });
 
-test('using a bound view name does not change on view name property changes', function() {
+QUnit.test('using a bound view name does not change on view name property changes', function() {
   owner.register('view:foo', viewClass({
     elementId: 'foo'
   }));
@@ -1198,7 +1196,7 @@ test('using a bound view name does not change on view name property changes', fu
   equal(view.$('#foo').length, 1, 'the originally rendered view is still present');
 });
 
-test('should have the correct action target', function() {
+QUnit.test('should have the correct action target', function() {
   owner.register('component:x-outer', EmberComponent.extend({
     layout: compile('{{#x-middle}}{{view innerView dismiss="dismiss"}}{{/x-middle}}'),
     actions: {
@@ -1231,7 +1229,7 @@ test('should have the correct action target', function() {
   });
 });
 
-test('Throw an `Unsupported Content` error when attempting to bind to a function', () => {
+QUnit.test('Throw an `Unsupported Content` error when attempting to bind to a function', () => {
   view = EmberView.extend({
     someFunction() {},
     template: compile('{{view.someFunction}}')

--- a/packages/ember-htmlbars/tests/htmlbars_test.js
+++ b/packages/ember-htmlbars/tests/htmlbars_test.js
@@ -4,11 +4,9 @@ import { domHelper } from 'ember-htmlbars/env';
 import { equalHTML } from 'htmlbars-test-helpers';
 import assign from 'ember-metal/assign';
 
-import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
+QUnit.module('ember-htmlbars: main');
 
-testModule('ember-htmlbars: main');
-
-test('HTMLBars is present and can be executed', function() {
+QUnit.test('HTMLBars is present and can be executed', function() {
   var template = compile('ohai');
 
   var env = assign({ dom: domHelper }, defaultEnv);

--- a/packages/ember-htmlbars/tests/integration/attribute_bindings_test.js
+++ b/packages/ember-htmlbars/tests/integration/attribute_bindings_test.js
@@ -7,15 +7,13 @@ import { set } from 'ember-metal/property_set';
 
 var view;
 
-import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
-
-testModule('ember-htmlbars: custom morph integration tests', {
+QUnit.module('ember-htmlbars: custom morph integration tests', {
   teardown() {
     runDestroy(view);
   }
 });
 
-test('can properly re-render an if/else with attribute morphs', function() {
+QUnit.test('can properly re-render an if/else with attribute morphs', function() {
   view = EmberView.create({
     trueClass: 'truthy',
     falseClass: 'falsey',
@@ -35,7 +33,7 @@ test('can properly re-render an if/else with attribute morphs', function() {
   equal(view.$('.falsey').length, 1, 'inverse block rendered properly');
 });
 
-test('can properly re-render an if/else with element morphs', function() {
+QUnit.test('can properly re-render an if/else with element morphs', function() {
   view = EmberView.create({
     trueClass: 'truthy',
     falseClass: 'falsey',

--- a/packages/ember-htmlbars/tests/integration/component_invocation_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_invocation_test.js
@@ -20,9 +20,7 @@ function commonTeardown() {
   owner = component = null;
 }
 
-import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
-
-testModule('component - invocation', {
+QUnit.module('component - invocation', {
   setup() {
     commonSetup();
   },
@@ -32,7 +30,7 @@ testModule('component - invocation', {
   }
 });
 
-test('moduleName is available on _renderNode when a layout is present', function() {
+QUnit.test('moduleName is available on _renderNode when a layout is present', function() {
   expect(1);
 
   var layoutModuleName = 'my-app-name/templates/components/sample-component';
@@ -54,7 +52,7 @@ test('moduleName is available on _renderNode when a layout is present', function
   runAppend(component);
 });
 
-test('moduleName is available on _renderNode when no layout is present', function() {
+QUnit.test('moduleName is available on _renderNode when no layout is present', function() {
   expect(1);
 
   var templateModuleName = 'my-app-name/templates/application';

--- a/packages/ember-htmlbars/tests/integration/component_lifecycle_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_lifecycle_test.js
@@ -16,8 +16,6 @@ let styles = [{
   class: Component
 }];
 
-import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
-
 styles.forEach(style => {
   function invoke(name, hash = {}) {
     if (style.name === 'curly') {
@@ -45,7 +43,7 @@ styles.forEach(style => {
     return { isString: true, value: val };
   }
 
-  testModule(`component - lifecycle hooks (${style.name})`, {
+  QUnit.module(`component - lifecycle hooks (${style.name})`, {
     setup() {
       owner = buildOwner();
       owner.registerOptionsForType('component', { singleton: false });
@@ -71,7 +69,7 @@ styles.forEach(style => {
     return { type: type, view: view, arg: arg };
   }
 
-  test('lifecycle hooks are invoked in a predictable order', function() {
+  QUnit.test('lifecycle hooks are invoked in a predictable order', function() {
     var components = {};
 
     function component(label) {
@@ -225,7 +223,7 @@ styles.forEach(style => {
     ]);
   });
 
-  test('passing values through attrs causes lifecycle hooks to fire if the attribute values have changed', function() {
+  QUnit.test('passing values through attrs causes lifecycle hooks to fire if the attribute values have changed', function() {
     var components = {};
 
     function component(label) {
@@ -361,7 +359,7 @@ styles.forEach(style => {
     ]);
   });
 
-  test('changing a component\'s displayed properties inside didInsertElement() is deprecated', function(assert) {
+  QUnit.test('changing a component\'s displayed properties inside didInsertElement() is deprecated', function(assert) {
     let component;
 
     component = style.class.extend({
@@ -385,7 +383,7 @@ styles.forEach(style => {
     });
   });
 
-  test('DEPRECATED: didInitAttrs is deprecated', function(assert) {
+  QUnit.test('DEPRECATED: didInitAttrs is deprecated', function(assert) {
     let component;
 
     let componentClass = style.class.extend({
@@ -407,7 +405,7 @@ styles.forEach(style => {
     });
   });
 
-  test('properties set during `init` are availabe in `didReceiveAttrs`', function(assert) {
+  QUnit.test('properties set during `init` are availabe in `didReceiveAttrs`', function(assert) {
     assert.expect(1);
 
     owner.register('component:the-thing', style.class.extend({

--- a/packages/ember-htmlbars/tests/node-managers/view-node-manager-test.js
+++ b/packages/ember-htmlbars/tests/node-managers/view-node-manager-test.js
@@ -1,9 +1,8 @@
 import ViewNodeManager from 'ember-htmlbars/node-managers/view-node-manager';
-import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
 
-testModule('ember-htmlbars: node-managers - ViewNodeManager');
+QUnit.module('ember-htmlbars: node-managers - ViewNodeManager');
 
-test('create method should assert if component hasn\'t been found', assert => {
+QUnit.test('create method should assert if component hasn\'t been found', assert => {
   assert.expect(1);
 
   let found = {
@@ -18,7 +17,7 @@ test('create method should assert if component hasn\'t been found', assert => {
   }, 'HTMLBars error: Could not find component named "' + path + '" (no component or template with that name was found)');
 });
 
-test('create method shouldn\'t assert if `found.component` is truthy', assert => {
+QUnit.test('create method shouldn\'t assert if `found.component` is truthy', assert => {
   assert.expect(1);
 
   let found = {
@@ -39,7 +38,7 @@ test('create method shouldn\'t assert if `found.component` is truthy', assert =>
   ViewNodeManager.create(renderNode, env, attrs, found);
 });
 
-test('create method shouldn\'t assert if `found.layout` is truthy', assert => {
+QUnit.test('create method shouldn\'t assert if `found.layout` is truthy', assert => {
   assert.expect(0);
 
   let found = {
@@ -50,7 +49,7 @@ test('create method shouldn\'t assert if `found.layout` is truthy', assert => {
   ViewNodeManager.create(null, null, null, found);
 });
 
-test('create method shouldn\'t assert if `path` is falsy and `contentTemplate` is truthy', assert => {
+QUnit.test('create method shouldn\'t assert if `path` is falsy and `contentTemplate` is truthy', assert => {
   assert.expect(0);
 
   let found = {

--- a/packages/ember-htmlbars/tests/system/lookup-helper_test.js
+++ b/packages/ember-htmlbars/tests/system/lookup-helper_test.js
@@ -21,11 +21,9 @@ function generateOwner() {
   return owner;
 }
 
-import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
+QUnit.module('ember-htmlbars: lookupHelper hook');
 
-testModule('ember-htmlbars: lookupHelper hook');
-
-test('looks for helpers in the provided `env.helpers`', function() {
+QUnit.test('looks for helpers in the provided `env.helpers`', function() {
   var env = generateEnv({
     'flubarb'() { }
   });
@@ -35,7 +33,7 @@ test('looks for helpers in the provided `env.helpers`', function() {
   equal(actual, env.helpers.flubarb, 'helpers are looked up on env');
 });
 
-test('returns undefined if no container exists (and helper is not found in env)', function() {
+QUnit.test('returns undefined if no container exists (and helper is not found in env)', function() {
   var env = generateEnv();
   var view = {};
 
@@ -44,7 +42,7 @@ test('returns undefined if no container exists (and helper is not found in env)'
   equal(actual, undefined, 'does not blow up if view does not have a container');
 });
 
-test('does not lookup in the container if the name does not contain a dash (and helper is not found in env)', function() {
+QUnit.test('does not lookup in the container if the name does not contain a dash (and helper is not found in env)', function() {
   var env = generateEnv();
   var view = {
     container: {
@@ -59,7 +57,7 @@ test('does not lookup in the container if the name does not contain a dash (and 
   equal(actual, undefined, 'does not blow up if view does not have a container');
 });
 
-test('does a lookup in the container if the name contains a dash (and helper is not found in env)', function() {
+QUnit.test('does a lookup in the container if the name contains a dash (and helper is not found in env)', function() {
   let owner = generateOwner();
   var env = generateEnv(null, owner);
   var view = {
@@ -74,7 +72,7 @@ test('does a lookup in the container if the name contains a dash (and helper is 
   ok(someName.detect(actual), 'helper is an instance of the helper class');
 });
 
-test('does a lookup in the container if the name is found in knownHelpers', function() {
+QUnit.test('does a lookup in the container if the name is found in knownHelpers', function() {
   let owner = generateOwner();
   var env = generateEnv(null, owner);
   var view = {
@@ -90,7 +88,7 @@ test('does a lookup in the container if the name is found in knownHelpers', func
   ok(t.detect(actual), 'helper is an instance of the helper class');
 });
 
-test('looks up a shorthand helper in the container', function() {
+QUnit.test('looks up a shorthand helper in the container', function() {
   expect(2);
   let owner = generateOwner();
   var env = generateEnv(null, owner);
@@ -113,7 +111,7 @@ test('looks up a shorthand helper in the container', function() {
   ok(called, 'HTMLBars compatible wrapper is wraping the provided function');
 });
 
-test('fails with a useful error when resolving a function', function() {
+QUnit.test('fails with a useful error when resolving a function', function() {
   expect(1);
   let owner = generateOwner();
   var env = generateEnv(null, owner);

--- a/packages/ember-htmlbars/tests/utils/string_test.js
+++ b/packages/ember-htmlbars/tests/utils/string_test.js
@@ -1,24 +1,22 @@
 import SafeString from 'htmlbars-util/safe-string';
 import { htmlSafe } from 'ember-htmlbars/utils/string';
 
-import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
+QUnit.module('ember-htmlbars: SafeString');
 
-testModule('ember-htmlbars: SafeString');
-
-test('htmlSafe should return an instance of SafeString', function() {
+QUnit.test('htmlSafe should return an instance of SafeString', function() {
   var safeString = htmlSafe('you need to be more <b>bold</b>');
 
   ok(safeString instanceof SafeString, 'should be a SafeString');
 });
 
-test('htmlSafe should return an empty string for null', function() {
+QUnit.test('htmlSafe should return an empty string for null', function() {
   var safeString = htmlSafe(null);
 
   equal(safeString instanceof SafeString, true, 'should be a SafeString');
   equal(safeString.toString(), '', 'should return an empty string');
 });
 
-test('htmlSafe should return an empty string for undefined', function() {
+QUnit.test('htmlSafe should return an empty string for undefined', function() {
   var safeString = htmlSafe();
 
   equal(safeString instanceof SafeString, true, 'should be a SafeString');

--- a/packages/ember/tests/helpers/link_to_test/link_to_transitioning_classes_test.js
+++ b/packages/ember/tests/helpers/link_to_test/link_to_transitioning_classes_test.js
@@ -62,9 +62,8 @@ function sharedTeardown() {
   setTemplates({});
 }
 
-import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
 
-testModule('The {{link-to}} helper: .transitioning-in .transitioning-out CSS classes', {
+QUnit.module('The {{link-to}} helper: .transitioning-in .transitioning-out CSS classes', {
   setup() {
     run(function() {
       sharedSetup();
@@ -101,7 +100,7 @@ testModule('The {{link-to}} helper: .transitioning-in .transitioning-out CSS cla
   }
 });
 
-test('while a transition is underway', function() {
+QUnit.test('while a transition is underway', function() {
   expect(18);
   bootApplication();
 
@@ -122,7 +121,7 @@ test('while a transition is underway', function() {
   assertHasClass('ember-transitioning-out', $index, false, $about, false, $other, false);
 });
 
-test('while a transition is underway with nested link-to\'s', function() {
+QUnit.test('while a transition is underway with nested link-to\'s', function() {
   expect(54);
 
   Router.map(function() {

--- a/packages/ember/tests/integration/multiple-app-test.js
+++ b/packages/ember/tests/integration/multiple-app-test.js
@@ -56,9 +56,7 @@ QUnit.module('View Integration', {
   }
 });
 
-import { test } from 'ember-glimmer/tests/utils/skip-if-glimmer';
-
-test('booting multiple applications can properly handle events', function(assert) {
+QUnit.test('booting multiple applications can properly handle events', function(assert) {
   run(App1, 'advanceReadiness');
   run(App2, 'advanceReadiness');
 


### PR DESCRIPTION
This unskips HTMLBars tests when the `ember-glimmer` flag is turned on. Prior to this commit the template compilers were not split thus we had to skip these.
