### PR TITLE
[Glimmer] Unskip some Ember tests

### DIFF
--- a/packages/ember-glimmer/lib/component.js
+++ b/packages/ember-glimmer/lib/component.js
@@ -90,6 +90,10 @@ or {{${name} ${key}=(if theTruth "truth" "false")}}.
 
 Component[NAME_KEY] = 'Ember.Component';
 
+Component.reopenClass({
+  isComponentFactory: true
+});
+
 function strip([...strings], ...values) {
   let str = strings.map((string, index) => {
     let interpolated = values[index];

--- a/packages/ember/tests/application_lifecycle_test.js
+++ b/packages/ember/tests/application_lifecycle_test.js
@@ -125,9 +125,7 @@ QUnit.test('Destroying the application resets the router before the appInstance 
   equal(controllerFor(appInstance, 'application').get('selectedMenuItem'), null);
 });
 
-import { test } from 'ember-glimmer/tests/utils/skip-if-glimmer';
-
-test('initializers can augment an applications customEvents hash', function(assert) {
+QUnit.test('initializers can augment an applications customEvents hash', function(assert) {
   assert.expect(1);
 
   run(App, 'destroy');
@@ -161,7 +159,7 @@ test('initializers can augment an applications customEvents hash', function(asse
   });
 });
 
-test('instanceInitializers can augment an the customEvents hash', function(assert) {
+QUnit.test('instanceInitializers can augment an the customEvents hash', function(assert) {
   assert.expect(1);
 
   run(App, 'destroy');


### PR DESCRIPTION
Un-skips some tests. Tests pass with and without Opt Features enabled:

![Tests passing with and without optional features.](https://cloud.githubusercontent.com/assets/1056681/15488809/015332a2-210f-11e6-9d04-8dc49504333e.png)
