### PR TITLE
[FEATURE ember-runtime-enumerable-includes] Implements Array.includes and deprecates Array.contains

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -57,3 +57,8 @@ for a detailed explanation.
   - `interaction.<event-name>` for events handled by a component.
   - `interaction.ember-action` for closure actions.
   - `interaction.link-to` for link-to execution.
+
+* `ember-runtime-enumerable-includes`
+
+Deprecates `Enumerable#contains` and `Array#contains` in favor of `Enumerable#includes` and `Array#includes` 
+to stay in line with ES standards (see [RFC](https://github.com/emberjs/rfcs/blob/master/text/0136-contains-to-includes.md)).

--- a/features.json
+++ b/features.json
@@ -10,6 +10,7 @@
     "ember-route-serializers": null,
     "ember-glimmer": null,
     "ember-runtime-computed-uniq-by": null,
-    "ember-improved-instrumentation": null
+    "ember-improved-instrumentation": null,
+    "ember-runtime-enumerable-includes": null
   }
 }

--- a/packages/ember-runtime/lib/mixins/mutable_array.js
+++ b/packages/ember-runtime/lib/mixins/mutable_array.js
@@ -24,6 +24,7 @@ import { Mixin } from 'ember-metal/mixin';
 import EmberArray, { objectAt } from 'ember-runtime/mixins/array';
 import MutableEnumerable from 'ember-runtime/mixins/mutable_enumerable';
 import Enumerable from 'ember-runtime/mixins/enumerable';
+import isEnabled from 'ember-metal/features';
 
 /**
   This mixin defines the API for modifying array-like objects. These methods
@@ -388,7 +389,15 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
     @public
   */
   addObject(obj) {
-    if (!this.contains(obj)) {
+    var included;
+
+    if (isEnabled('ember-runtime-enumerable-includes')) {
+      included = this.includes(obj);
+    } else {
+      included = this.contains(obj);
+    }
+
+    if (!included) {
       this.pushObject(obj);
     }
 

--- a/packages/ember-runtime/tests/mixins/enumerable_test.js
+++ b/packages/ember-runtime/tests/mixins/enumerable_test.js
@@ -6,6 +6,7 @@ import { A as emberA } from 'ember-runtime/system/native_array';
 import { get } from 'ember-metal/property_get';
 import { computed } from 'ember-metal/computed';
 import { observer as emberObserver } from 'ember-metal/mixin';
+import isEnabled from 'ember-metal/features';
 
 function K() { return this; }
 
@@ -93,11 +94,21 @@ QUnit.test('should apply Ember.Array to return value of toArray', function() {
 });
 
 QUnit.test('should apply Ember.Array to return value of without', function() {
-  var x = EmberObject.extend(Enumerable, {
+  var X = EmberObject.extend(Enumerable, {
     contains() {
       return true;
     }
-  }).create();
+  });
+
+  if (isEnabled('ember-runtime-enumerable-includes')) {
+    X.reopen({
+      includes() {
+        return true;
+      }
+    });
+  }
+
+  var x = X.create();
   var y = x.without(K);
   equal(EmberArray.detect(y), true, 'should have mixin applied');
 });
@@ -163,6 +174,17 @@ QUnit.test('every', function() {
   allWhite = allWhiteKittens.isEvery('color', 'white');
   equal(allWhite, true);
 });
+
+if (isEnabled('ember-runtime-enumerable-includes')) {
+  QUnit.test('should throw an error passing a second argument to includes', function() {
+    var x = EmberObject.extend(Enumerable).create();
+
+    equal(x.includes('any'), false);
+    expectAssertion(() => {
+      x.includes('any', 1);
+    }, /Enumerable#includes cannot accept a second argument "startAt" as enumerable items are unordered./);
+  });
+}
 
 // ..........................................................
 // CONTENT DID CHANGE

--- a/packages/ember-runtime/tests/suites/array.js
+++ b/packages/ember-runtime/tests/suites/array.js
@@ -5,10 +5,12 @@ import {
 import indexOfTests from 'ember-runtime/tests/suites/array/indexOf';
 import lastIndexOfTests from 'ember-runtime/tests/suites/array/lastIndexOf';
 import objectAtTests from 'ember-runtime/tests/suites/array/objectAt';
+import includesTests from 'ember-runtime/tests/suites/array/includes';
 import {
   addArrayObserver,
   removeArrayObserver
 } from 'ember-runtime/mixins/array';
+import isEnabled from 'ember-metal/features';
 
 var ObserverClass = EnumerableTestsObserverClass.extend({
 
@@ -45,5 +47,9 @@ ArrayTests.ObserverClass = ObserverClass;
 ArrayTests.importModuleTests(indexOfTests);
 ArrayTests.importModuleTests(lastIndexOfTests);
 ArrayTests.importModuleTests(objectAtTests);
+
+if (isEnabled('ember-runtime-enumerable-includes')) {
+  ArrayTests.importModuleTests(includesTests);
+}
 
 export {ArrayTests, ObserverClass};

--- a/packages/ember-runtime/tests/suites/array/includes.js
+++ b/packages/ember-runtime/tests/suites/array/includes.js
@@ -1,0 +1,39 @@
+import {SuiteModuleBuilder} from 'ember-runtime/tests/suites/suite';
+
+var suite = SuiteModuleBuilder.create();
+
+suite.module('includes');
+
+suite.test('includes returns correct value if startAt is positive', function() {
+  var data = this.newFixture(3);
+  var obj  = this.newObject(data);
+
+  equal(obj.includes(data[1], 1), true, 'should return true if included');
+  equal(obj.includes(data[0], 1), false, 'should return false if not included');
+});
+
+suite.test('includes returns correct value if startAt is negative', function() {
+  var data = this.newFixture(3);
+  var obj  = this.newObject(data);
+
+  equal(obj.includes(data[1], -2), true, 'should return true if included');
+  equal(obj.includes(data[0], -2), false, 'should return false if not included');
+});
+
+suite.test('includes returns true if startAt + length is still negative', function() {
+  var data = this.newFixture(1);
+  var obj  = this.newObject(data);
+
+  equal(obj.includes(data[0], -2), true, 'should return true if included');
+  equal(obj.includes(this.newFixture(1), -2), false, 'should return false if not included');
+});
+
+suite.test('includes returns false if startAt out of bounds', function() {
+  var data = this.newFixture(1);
+  var obj  = this.newObject(data);
+
+  equal(obj.includes(data[0], 2), false, 'should return false if startAt >= length');
+  equal(obj.includes(this.newFixture(1), 2), false, 'should return false if startAt >= length');
+});
+
+export default suite;

--- a/packages/ember-runtime/tests/suites/enumerable.js
+++ b/packages/ember-runtime/tests/suites/enumerable.js
@@ -285,6 +285,7 @@ import anyTests         from 'ember-runtime/tests/suites/enumerable/any';
 import isAnyTests       from 'ember-runtime/tests/suites/enumerable/is_any';
 import compactTests     from 'ember-runtime/tests/suites/enumerable/compact';
 import containsTests    from 'ember-runtime/tests/suites/enumerable/contains';
+import includesTests    from 'ember-runtime/tests/suites/enumerable/includes';
 import everyTests       from 'ember-runtime/tests/suites/enumerable/every';
 import filterTests      from 'ember-runtime/tests/suites/enumerable/filter';
 import findTests        from 'ember-runtime/tests/suites/enumerable/find';
@@ -323,6 +324,10 @@ EnumerableTests.importModuleTests(uniqTests);
 
 if (isEnabled('ember-runtime-computed-uniq-by')) {
   EnumerableTests.importModuleTests(uniqByTests);
+}
+
+if (isEnabled('ember-runtime-enumerable-includes')) {
+  EnumerableTests.importModuleTests(includesTests);
 }
 
 EnumerableTests.importModuleTests(withoutTests);

--- a/packages/ember-runtime/tests/suites/enumerable/contains.js
+++ b/packages/ember-runtime/tests/suites/enumerable/contains.js
@@ -1,18 +1,27 @@
 import {SuiteModuleBuilder} from 'ember-runtime/tests/suites/suite';
+import isEnabled from 'ember-metal/features';
 
 var suite = SuiteModuleBuilder.create();
 
 suite.module('contains');
 
-suite.test('contains returns true if items is in enumerable', function() {
+suite.test('contains returns true if item is in enumerable', function() {
   var data = this.newFixture(3);
   var obj  = this.newObject(data);
+
+  if (isEnabled('ember-runtime-enumerable-includes')) {
+    expectDeprecation('`Enumerable#contains` is deprecated, use `Enumerable#includes` instead.');
+  }
   equal(obj.contains(data[1]), true, 'should return true if contained');
 });
 
 suite.test('contains returns false if item is not in enumerable', function() {
   var data = this.newFixture(1);
   var obj  = this.newObject(this.newFixture(3));
+
+  if (isEnabled('ember-runtime-enumerable-includes')) {
+    expectDeprecation('`Enumerable#contains` is deprecated, use `Enumerable#includes` instead.');
+  }
   equal(obj.contains(data[0]), false, 'should return false if not contained');
 });
 

--- a/packages/ember-runtime/tests/suites/enumerable/includes.js
+++ b/packages/ember-runtime/tests/suites/enumerable/includes.js
@@ -1,0 +1,25 @@
+import {SuiteModuleBuilder} from 'ember-runtime/tests/suites/suite';
+
+var suite = SuiteModuleBuilder.create();
+
+suite.module('includes');
+
+suite.test('includes returns true if item is in enumerable', function() {
+  var data = this.newFixture(1);
+  var obj  = this.newObject([...data, NaN, undefined, null]);
+
+  equal(obj.includes(data[0]), true, 'should return true if included');
+  equal(obj.includes(NaN), true, 'should return true if NaN included');
+  equal(obj.includes(undefined), true, 'should return true if undefined included');
+  equal(obj.includes(null), true, 'should return true if null included');
+});
+
+suite.test('includes returns false if item is not in enumerable', function() {
+  var data = this.newFixture(1);
+  var obj  = this.newObject([...this.newFixture(3), null]);
+
+  equal(obj.includes(data[0]), false, 'should return false if not included');
+  equal(obj.includes(undefined), false, 'should return false if undefined not included but null is included');
+});
+
+export default suite;

--- a/packages/ember-runtime/tests/suites/enumerable/without.js
+++ b/packages/ember-runtime/tests/suites/enumerable/without.js
@@ -1,4 +1,5 @@
 import {SuiteModuleBuilder} from 'ember-runtime/tests/suites/suite';
+import isEnabled from 'ember-metal/features';
 
 var suite = SuiteModuleBuilder.create();
 
@@ -15,6 +16,19 @@ suite.test('should return new instance with item removed', function() {
   deepEqual(this.toArray(ret), after, 'should have removed item');
   deepEqual(this.toArray(obj), before, 'should not have changed original');
 });
+
+if (isEnabled('ember-runtime-enumerable-includes')) {
+  suite.test('should remove NaN value', function() {
+    var before, after, obj, ret;
+
+    before = [...this.newFixture(2), NaN];
+    after  = [before[0], before[1]];
+    obj    = this.newObject(before);
+
+    ret = obj.without(NaN);
+    deepEqual(this.toArray(ret), after, 'should have removed item');
+  });
+}
 
 suite.test('should return same instance if object not found', function() {
   var item, obj, ret;

--- a/packages/ember/tests/component_registration_test.js
+++ b/packages/ember/tests/component_registration_test.js
@@ -11,6 +11,7 @@ import jQuery from 'ember-views/system/jquery';
 import { A as emberA } from 'ember-runtime/system/native_array';
 import { setTemplates, set as setTemplate } from 'ember-templates/template_registry';
 import { test } from 'ember-glimmer/tests/utils/skip-if-glimmer';
+import isEnabled from 'ember-metal/features';
 
 var App, appInstance;
 var originalHelpers;
@@ -39,9 +40,17 @@ function cleanup() {
 }
 
 function cleanupHelpers() {
+  var included;
+
   keys(helpers).
     forEach((name) => {
-      if (!originalHelpers.contains(name)) {
+      if (isEnabled('ember-runtime-enumerable-includes')) {
+        included = originalHelpers.includes(name);
+      } else {
+        included = originalHelpers.contains(name);
+      }
+
+      if (!included) {
         delete helpers[name];
       }
     });


### PR DESCRIPTION
Implementation of emberjs/rfcs#136

TODO : 
- [x]  Implement `Enumerable.includes` 
- [x]  Implement `Array.includes`
- [x]  Deprecate `contains` under feature flag
- [x]  Replace usages of `contains` by `includes`
- [x]  Update docs, guides (emberjs/guides#1439) & API. To be merged once feature enabled.
- [x] Write deprecation guide (emberjs/website#2600) & add url in deprecate call
- [x] Rebase / squash
