### PR TITLE
Ember.assign: Prevent collision of index variable (i)

### DIFF
--- a/packages/ember-metal/lib/assign.js
+++ b/packages/ember-metal/lib/assign.js
@@ -22,8 +22,8 @@ export default function assign(original, ...args) {
 
     let updates = Object.keys(arg);
 
-    for (let i = 0; i < updates.length; i++) {
-      let prop = updates[i];
+    for (let k = 0; k < updates.length; k++) {
+      let prop = updates[k];
       original[prop] = arg[prop];
     }
   }


### PR DESCRIPTION
Current code in Ember.assign uses the variable `i` twice. This is error prone.
