### PR TITLE
Bump glimmer; allow dynamic components to be optional

### DIFF
--- a/packages/ember-glimmer/lib/syntax/dynamic-component.js
+++ b/packages/ember-glimmer/lib/syntax/dynamic-component.js
@@ -41,8 +41,13 @@ class DynamicComponentReference {
   value() {
     let { env, nameRef } = this;
     let name = nameRef.value();
-    let definition = env.getComponentDefinition([name]);
-    return definition;
+
+    if (typeof name === 'string') {
+      let definition = env.getComponentDefinition([name]);
+      return definition;
+    } else {
+      return null;
+    }
   }
 
   get() {

--- a/packages/ember-glimmer/tests/integration/components/dynamic-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/dynamic-components-test.js
@@ -486,7 +486,7 @@ moduleFor('Components test: dynamic components', class extends RenderingTest {
     }, /Could not find component named "does-not-exist"/);
   }
 
-  ['@htmlbars component with dynamic component name resolving to a component, then non-existent component'](assert) {
+  ['@test component with dynamic component name resolving to a component, then non-existent component'](assert) {
     this.registerComponent('foo-bar', { template: 'hello {{name}}' });
 
     this.render('{{component componentName name=name}}', { componentName: 'foo-bar', name: 'Alex' });


### PR DESCRIPTION
This un-gates a test for Glimmer to allow dynamic components to "go missing" when their path is falsy. This means that a component will not be rendered instead of throwing an exception (which is what it does now). This PR is complimentary to https://github.com/tildeio/glimmer/pull/177.
