### PR TITLE
[BUGFIX beta] Avoid _lazyInjections in production builds.

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -1,5 +1,5 @@
 import { ENV } from 'ember-environment';
-import { assert, deprecate } from 'ember-metal/debug';
+import { assert, deprecate, runInDebug } from 'ember-metal/debug';
 import dictionary from 'ember-metal/dictionary';
 import isEnabled from 'ember-metal/features';
 import { setOwner, OWNER } from './owner';
@@ -341,13 +341,15 @@ function instantiate(container, fullName) {
 
     validationCache = container.validationCache;
 
-    // Ensure that all lazy injections are valid at instantiation time
-    if (!validationCache[fullName] && typeof factory._lazyInjections === 'function') {
-      lazyInjections = factory._lazyInjections();
-      lazyInjections = container.registry.normalizeInjectionsHash(lazyInjections);
+    runInDebug(function() {
+      // Ensure that all lazy injections are valid at instantiation time
+      if (!validationCache[fullName] && typeof factory._lazyInjections === 'function') {
+        lazyInjections = factory._lazyInjections();
+        lazyInjections = container.registry.normalizeInjectionsHash(lazyInjections);
 
-      container.registry.validateInjections(lazyInjections);
-    }
+        container.registry.validateInjections(lazyInjections);
+      }
+    });
 
     validationCache[fullName] = true;
 

--- a/packages/ember-runtime/tests/inject_test.js
+++ b/packages/ember-runtime/tests/inject_test.js
@@ -36,20 +36,20 @@ if (!EmberDev.runningProdBuild) {
     owner.register('foo:main', AnObject);
     owner._lookupFactory('foo:main');
   });
-}
 
-QUnit.test('attempting to inject a nonexistent container key should error', function() {
-  let owner = buildOwner();
-  var AnObject = Object.extend({
-    foo: new InjectedProperty('bar', 'baz')
+  QUnit.test('attempting to inject a nonexistent container key should error', function() {
+    let owner = buildOwner();
+    var AnObject = Object.extend({
+      foo: new InjectedProperty('bar', 'baz')
+    });
+
+    owner.register('foo:main', AnObject);
+
+    throws(function() {
+      owner.lookup('foo:main');
+    }, /Attempting to inject an unknown injection: `bar:baz`/);
   });
-
-  owner.register('foo:main', AnObject);
-
-  throws(function() {
-    owner.lookup('foo:main');
-  }, /Attempting to inject an unknown injection: `bar:baz`/);
-});
+}
 
 QUnit.test('factories should return a list of lazy injection full names', function() {
   var AnObject = Object.extend({


### PR DESCRIPTION
This is only used to trigger an assertion, and is quite slow (it iterates 200+ properties on every factory looked up). There is no need to do this in production builds...
