### PR TITLE
Revert QP changes from LTS 2.4.

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -759,7 +759,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
       var totalChanged = Object.keys(changed).concat(Object.keys(removed));
       for (var i = 0, len = totalChanged.length; i < len; ++i) {
         var qp = qpMap[totalChanged[i]];
-        if (qp && get(this._optionsForQueryParam(qp), 'refreshModel') && this.router.currentState) {
+        if (qp && get(this._optionsForQueryParam(qp), 'refreshModel')) {
           this.refresh();
         }
       }

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -631,12 +631,6 @@ var EmberRouter = EmberObject.extend(Evented, {
     assert(`The route ${targetRouteName} was not found`, targetRouteName && this.router.hasRoute(targetRouteName));
 
     var queryParams = {};
-    // merge in any queryParams from the active transition which could include
-    // queryparams from the url on initial load.
-    if (this.router.activeTransition) {
-      assign(queryParams, this.router.activeTransition.queryParams);
-    }
-
     assign(queryParams, _queryParams);
     this._prepareQueryParams(targetRouteName, models, queryParams);
 

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -375,33 +375,6 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     equal(indexModelCount, 2);
   });
 
-  QUnit.test('refreshModel does not cause a second transition during app boot ', function() {
-    expect(0);
-
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        appomg: {
-          defaultValue: 'applol'
-        }
-      }
-    });
-
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        omg: {
-          defaultValue: 'lol',
-          refreshModel: true
-        }
-      },
-      refresh: function() {
-        ok(false);
-      }
-    });
-
-    startingURL = '/?appomg=hello&omg=world';
-    bootApplication();
-  });
-
   QUnit.test('can use refreshModel even w URL changes that remove QPs from address bar when QP configured on route', function() {
     expect(4);
 
@@ -2458,33 +2431,6 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
 
     equal(appModelCount, 1);
     equal(indexModelCount, 2);
-  });
-
-  QUnit.test('refreshModel does not cause a second transition during app boot ', function() {
-    expect(0);
-    App.ApplicationController = Controller.extend({
-      queryParams: ['appomg'],
-      appomg: 'applol'
-    });
-
-    App.IndexController = Controller.extend({
-      queryParams: ['omg'],
-      omg: 'lol'
-    });
-
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        omg: {
-          refreshModel: true
-        }
-      },
-      refresh: function() {
-        ok(false);
-      }
-    });
-
-    startingURL = '/?appomg=hello&omg=world';
-    bootApplication();
   });
 
   QUnit.test('Use Ember.get to retrieve query params \'refreshModel\' configuration', function() {

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -1960,64 +1960,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     equal(get(controller, 'bar'), 'rab');
     equal(get(controller, 'foo'), '456');
   });
-
-  QUnit.test('Calling transitionTo does not lose query params already on the activeTransition', function() {
-    expect(2);
-    App.Router.map(function() {
-      this.route('parent', function() {
-        this.route('child');
-        this.route('sibling');
-      });
-    });
-
-    App.ParentRoute = Route.extend({
-      queryParams: { foo: { defaultValue: 'bar' } }
-    });
-
-    App.ParentChildRoute = Route.extend({
-      afterModel: function() {
-        ok(true, 'The after model hook was called');
-        this.transitionTo('parent.sibling');
-      }
-    });
-
-    startingURL = '/parent/child?foo=lol';
-    bootApplication();
-
-    var parentController = container.lookup('controller:parent');
-
-    equal(parentController.get('foo'), 'lol');
-  });
 } else {
-  QUnit.test('Calling transitionTo does not lose query params already on the activeTransition', function() {
-    expect(2);
-    App.Router.map(function() {
-      this.route('parent', function() {
-        this.route('child');
-        this.route('sibling');
-      });
-    });
-
-    App.ParentChildRoute = Route.extend({
-      afterModel: function() {
-        ok(true, 'The after model hook was called');
-        this.transitionTo('parent.sibling');
-      }
-    });
-
-    App.ParentController = Controller.extend({
-      queryParams: ['foo'],
-      foo: 'bar'
-    });
-
-    startingURL = '/parent/child?foo=lol';
-    bootApplication();
-
-    var parentController = container.lookup('controller:parent');
-
-    equal(parentController.get('foo'), 'lol');
-  });
-
   QUnit.test('Single query params can be set on the controller [DEPRECATED]', function() {
     Router.map(function() {
       this.route('home', { path: '/' });


### PR DESCRIPTION
We discussed this in depth in a recent core team call, and decided that we should revert these changes from the LTS branch. They fix a number of issues that existed since 2.0.0, but they also introduced some new failures.  We will continue to iterate and address the new failures in 2.7+, but we should strive to ensure the latest LTS patch release is usable for folks.

Sadly, reverting these commits means that anyone using 2.4.5 and relying on the bugs that were originally being fixed will now have an issue on 2.4.6 (when released). I agree that this is annoying, but I think it is much better to keep the issues that are present on 2.4 branch consistent with the earlier point releases.
