### PR TITLE
Ensure Ember.HTMLBars is reexported based on rendering engine.

### DIFF
--- a/packages/ember-htmlbars/lib/index.js
+++ b/packages/ember-htmlbars/lib/index.js
@@ -96,13 +96,6 @@
 */
 import Ember from 'ember-metal/core'; // reexports
 
-import {
-  precompile,
-  compile,
-  template,
-  registerPlugin
-} from 'ember-htmlbars-template-compiler';
-
 import makeBoundHelper from 'ember-htmlbars/system/make_bound_helper';
 
 import {
@@ -144,10 +137,6 @@ registerHelper('hash', hashHelper);
 registerHelper('query-params', queryParamsHelper);
 
 Ember.HTMLBars = {
-  template: template,
-  compile: compile,
-  precompile: precompile,
   makeBoundHelper: makeBoundHelper,
-  registerPlugin: registerPlugin,
   DOMHelper
 };

--- a/packages/ember-template-compiler/lib/compat.js
+++ b/packages/ember-template-compiler/lib/compat.js
@@ -1,10 +1,12 @@
 import Ember from 'ember-metal/core'; // reexports
 import compiler from './compiler';
 
-var EmberHandlebars = Ember.Handlebars = Ember.Handlebars || {};
+let EmberHandlebars = Ember.Handlebars = Ember.Handlebars || {};
+let EmberHTMLBars = Ember.HTMLBars = Ember.HTMLBars || {};
 
-let { precompile, compile, template } = compiler();
+let { precompile, compile, template, registerPlugin } = compiler();
 
-EmberHandlebars.precompile = precompile;
-EmberHandlebars.compile = compile;
-EmberHandlebars.template = template;
+EmberHTMLBars.precompile = EmberHandlebars.precompile = precompile;
+EmberHTMLBars.compile = EmberHandlebars.compile = compile;
+EmberHTMLBars.template = EmberHandlebars.template = template;
+EmberHTMLBars.registerPlugin = registerPlugin;


### PR DESCRIPTION
Fixes usage with ember-twiddle.com and emberjs.jsbin.com.

/cc @chadhietala @krisselden
