### PR TITLE
Ensure compile options are functioning properly.

### DIFF
--- a/packages/ember-glimmer-template-compiler/lib/index.js
+++ b/packages/ember-glimmer-template-compiler/lib/index.js
@@ -1,4 +1,5 @@
 export { default as compile } from './system/compile';
 export { default as precompile } from './system/precompile';
 export { default as template } from './system/template';
+export { default as defaultCompileOptions } from './system/compile-options';
 export { registerPlugin } from './system/compile-options';

--- a/packages/ember-glimmer-template-compiler/lib/system/compile-options.js
+++ b/packages/ember-glimmer-template-compiler/lib/system/compile-options.js
@@ -13,7 +13,7 @@ export default function compileOptions(options) {
   options = options || {};
   options = assign({}, options);
   if (!options.plugins) {
-    options.plugins = PLUGINS;
+    options.plugins = { ast: [...USER_PLUGINS, ...PLUGINS] };
   } else {
     let potententialPugins = [...USER_PLUGINS, ...PLUGINS];
     let pluginsToAdd = potententialPugins.filter((plugin) => {

--- a/packages/ember-glimmer-template-compiler/lib/system/compile-options.js
+++ b/packages/ember-glimmer-template-compiler/lib/system/compile-options.js
@@ -1,8 +1,11 @@
+import defaultPlugins from 'ember-template-compiler/plugins';
 import TransformHasBlockSyntax from '../plugins/transform-has-block-syntax';
 import TransformActionSyntax from '../plugins/transform-action-syntax';
 import assign from 'ember-metal/assign';
 
 export const PLUGINS = [
+  ...defaultPlugins,
+  // the following are ember-glimmer specific
   TransformHasBlockSyntax,
   TransformActionSyntax
 ];

--- a/packages/ember-glimmer/tests/utils/abstract-test-case.js
+++ b/packages/ember-glimmer/tests/utils/abstract-test-case.js
@@ -14,7 +14,6 @@ import isEnabled from 'ember-metal/features';
 import { privatize as P } from 'container/registry';
 import DefaultComponentTemplate from 'ember-glimmer/templates/component';
 import EventDispatcher from 'ember-views/system/event_dispatcher';
-import { defaultCompileOptions } from 'ember-template-compiler';
 import { PartialDefinition } from 'glimmer-runtime';
 
 const packageTag = `@${packageName} `;
@@ -277,7 +276,7 @@ export class ApplicationTest extends TestCase {
   }
 
   compile(string, options) {
-    return compile(string, assign({}, defaultCompileOptions(), options));
+    return compile(...arguments);
   }
 
   registerRoute(name, route) {
@@ -310,8 +309,8 @@ export class RenderingTest extends TestCase {
     owner.lookup('event_dispatcher:main').setup(this.getCustomDispatcherEvents(), owner.element);
   }
 
-  compile(string, options) {
-    return compile(string, assign({}, defaultCompileOptions(), options));
+  compile() {
+    return compile(...arguments);
   }
 
   getCustomDispatcherEvents() {

--- a/packages/ember-glimmer/tests/utils/helpers.js
+++ b/packages/ember-glimmer/tests/utils/helpers.js
@@ -1,6 +1,5 @@
 import assign from 'ember-metal/assign';
-import { defaultCompileOptions } from 'ember-template-compiler';
-import { compile as compiler } from 'ember-glimmer-template-compiler';
+import { compile as compiler, defaultCompileOptions } from 'ember-glimmer-template-compiler';
 
 export { default as Helper, helper } from 'ember-glimmer/helper';
 export { default as Component } from 'ember-glimmer/component';

--- a/packages/ember-htmlbars-template-compiler/lib/index.js
+++ b/packages/ember-htmlbars-template-compiler/lib/index.js
@@ -1,4 +1,5 @@
 export { default as compile } from './system/compile';
 export { default as precompile } from './system/precompile';
 export { default as template } from './system/template';
+export { default as defaultCompileOptions } from './system/compile-options';
 export { registerPlugin } from './system/compile-options';

--- a/packages/ember-htmlbars-template-compiler/lib/system/compile-options.js
+++ b/packages/ember-htmlbars-template-compiler/lib/system/compile-options.js
@@ -5,6 +5,7 @@
 
 import VERSION from 'ember/version';
 import assign from 'ember-metal/assign';
+import defaultPlugins from 'ember-template-compiler/plugins';
 import TransformClosureComponentAttrsIntoMut from '../plugins/transform-closure-component-attrs-into-mut';
 import TransformComponentAttrsIntoMut from '../plugins/transform-component-attrs-into-mut';
 import TransformComponentCurlyToReadonly from '../plugins/transform-component-curly-to-readonly';
@@ -13,6 +14,9 @@ import TransformOldClassBindingSyntax from '../plugins/transform-old-class-bindi
 let compileOptions;
 
 export let PLUGINS = [
+  ...defaultPlugins,
+
+  // the following are ember-htmlbars specific
   TransformClosureComponentAttrsIntoMut,
   TransformComponentAttrsIntoMut,
   TransformComponentCurlyToReadonly,

--- a/packages/ember-htmlbars-template-compiler/lib/system/compile-options.js
+++ b/packages/ember-htmlbars-template-compiler/lib/system/compile-options.js
@@ -25,7 +25,7 @@ function mergePlugins(options) {
   options = options || {};
   options = assign({}, options);
   if (!options.plugins) {
-    options.plugins = PLUGINS;
+    options.plugins = { ast: [...USER_PLUGINS, ...PLUGINS] };
   } else {
     let potententialPugins = [...USER_PLUGINS, ...PLUGINS];
     let pluginsToAdd = potententialPugins.filter((plugin) => {

--- a/packages/ember-htmlbars-template-compiler/tests/utils/helpers.js
+++ b/packages/ember-htmlbars-template-compiler/tests/utils/helpers.js
@@ -1,6 +1,5 @@
-import { compile as compiler } from 'ember-htmlbars-template-compiler';
+import { compile as compiler, defaultCompileOptions } from 'ember-htmlbars-template-compiler';
 import assign from 'ember-metal/assign';
-import { defaultCompileOptions } from 'ember-template-compiler';
 
 export * from 'ember-htmlbars-template-compiler';
 export { removePlugin } from 'ember-htmlbars-template-compiler/system/compile-options';

--- a/packages/ember-htmlbars/tests/utils/helpers.js
+++ b/packages/ember-htmlbars/tests/utils/helpers.js
@@ -3,7 +3,7 @@ import {
   compile as compiler,
   precompile as precompiler
 } from 'ember-htmlbars-template-compiler';
-import { defaultCompileOptions } from 'ember-template-compiler';
+import { defaultCompileOptions } from 'ember-htmlbars-template-compiler';
 
 export { template } from 'ember-htmlbars-template-compiler';
 export { default as Helper, helper } from 'ember-htmlbars/helper';

--- a/packages/ember-template-compiler/lib/system/compile-options.js
+++ b/packages/ember-template-compiler/lib/system/compile-options.js
@@ -1,10 +1,5 @@
-import DEFAULT_PLUGINS from '../plugins';
-import assign from 'ember-metal/assign';
+import compiler from '../compiler';
 
-export default function compileOptions() {
-  return assign({}, {
-    plugins: {
-      ast: [...DEFAULT_PLUGINS]
-    }
-  });
-}
+let { defaultCompileOptions } = compiler();
+
+export default defaultCompileOptions;

--- a/packages/ember-template-compiler/tests/system/compile_options_test.js
+++ b/packages/ember-template-compiler/tests/system/compile_options_test.js
@@ -1,11 +1,5 @@
 import { defaultCompileOptions } from 'ember-template-compiler';
-import TransformOldBindingSyntax from 'ember-template-compiler/plugins/transform-old-binding-syntax';
-import TransformItemClass from 'ember-template-compiler/plugins/transform-item-class';
-import TransformAngleBracketComponents from 'ember-template-compiler/plugins/transform-angle-bracket-components';
-import TransformInputOnToOnEvent from 'ember-template-compiler/plugins/transform-input-on-to-onEvent';
-import TransformTopLevelComponents from 'ember-template-compiler/plugins/transform-top-level-components';
-import DeprecateRenderModel from 'ember-template-compiler/plugins/deprecate-render-model';
-import TransformInlineLinkTo from 'ember-template-compiler/plugins/transform-inline-link-to';
+import defaultPlugins from 'ember-template-compiler/plugins';
 
 QUnit.module('ember-template-compiler: default compile options');
 
@@ -13,16 +7,13 @@ QUnit.test('default options are a new copy', function() {
   notEqual(defaultCompileOptions(), defaultCompileOptions());
 });
 
-QUnit.test('has default AST plugins', function() {
+QUnit.test('has default AST plugins', function(assert) {
+  assert.expect(defaultPlugins.length);
+
   let plugins = defaultCompileOptions().plugins.ast;
 
-  deepEqual(plugins, [
-    TransformOldBindingSyntax,
-    TransformItemClass,
-    TransformAngleBracketComponents,
-    TransformInputOnToOnEvent,
-    TransformTopLevelComponents,
-    DeprecateRenderModel,
-    TransformInlineLinkTo
-  ]);
+  for (let i = 0; i < defaultPlugins.length; i++) {
+    let plugin = defaultPlugins[i];
+    assert.ok(plugins.indexOf(plugin) > -1, `includes ${plugin}`);
+  }
 });


### PR DESCRIPTION
Fixes more issues with `Ember.Handlebars.compile` / `Ember.HTMLBars.compile`.
- The AST plugins were not being run (due to incorrect defaulting of the `plugins` property to an array instead of an object with an `ast` prop).
- Updated ember-glimmer test infrastructure to use `ember-glimmer-template-compiler` to compile.
- Ensure `ember-template-compiler/system/compile-options` uses the engine specific compile options.
- Fix assertions in compile options tests to ensure they stay in sync as more plugins are added.

Fixes #13594.
