### PR TITLE
Mention async cache in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ Ember.js also provides access to the most advanced features of Javascript, HTML 
 6. Run `bower install` to ensure required web dependencies are installed.
 7. Run `npm run build` to build Ember.js. The builds will be placed in the `dist/` directory.
 
+If you edit the `feature.json` file, you may also need to clear the async disk
+cache to get a proper build:
+
+```js
+rm -rf tmp $TMPDIR/async-disk-cache/
+```
+
 ## npm install troubleshooting
 
 If you encounter a problem with downloading dependencies like:


### PR DESCRIPTION
Without flushing the async cache, you may end up building Ember with a cached set of feature flags.
