### PR TITLE
[BUGFIX beta] Ensure pauseTest runs after other async helpers

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -242,7 +242,7 @@ helper('currentURL', currentURL);
  @return {Object} A promise that will never resolve
  @public
 */
-helper('pauseTest', pauseTest);
+asyncHelper('pauseTest', pauseTest);
 
 /**
   Triggers the given DOM event on the element identified by the provided selector.

--- a/packages/ember-testing/lib/helpers/pause_test.js
+++ b/packages/ember-testing/lib/helpers/pause_test.js
@@ -1,7 +1,5 @@
 import RSVP from 'ember-runtime/ext/rsvp';
-import Test from '../test';
 
 export default function pauseTest() {
-  Test.adapter.asyncStart();
   return new RSVP.Promise(function() { }, 'TestAdapter paused promise');
 }

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -772,11 +772,14 @@ QUnit.module('ember-testing debugging helpers', {
 
 QUnit.test('pauseTest pauses', function() {
   expect(1);
+
   function fakeAdapterAsyncStart() {
-    ok(true, 'Async start should be called');
+    ok(true, 'Async start should be called after waiting for other helpers');
   }
 
-  Test.adapter.asyncStart = fakeAdapterAsyncStart;
+  App.testHelpers.andThen(() => {
+    Test.adapter.asyncStart = fakeAdapterAsyncStart;
+  });
 
   App.testHelpers.pauseTest();
 });


### PR DESCRIPTION
While looking into implementing `resumeTest`, I noticed that `pauseTest` didn't seem to be behaving properly (in that it wasn't properly waiting for prior async helpers). I'm unsure why this wasn't registered as an `asyncHelper` to begin with, but after looking at the repo in the state of the original commit, it looks like some internals of the helpers have changed which probably caused the regression.
