### PR TITLE
PERF: Guard QP generation

### DIFF
--- a/packages/ember-routing/lib/services/routing.js
+++ b/packages/ember-routing/lib/services/routing.js
@@ -61,7 +61,9 @@ export default Service.extend({
     var visibleQueryParams = {};
     assign(visibleQueryParams, queryParams);
 
-    this.normalizeQueryParams(routeName, models, visibleQueryParams);
+    if (queryParams) {
+      this.normalizeQueryParams(routeName, models, visibleQueryParams);
+    }
 
     var args = routeArgs(routeName, models, visibleQueryParams);
     return router.generate.apply(router, args);


### PR DESCRIPTION
`generateURL` in general needs a lot of love and currently accounts for a decent amount of slowness for each different type of URL. This is more of a common sense fix that makes sure we do not normalize query params when we do not have any.
