### PR TITLE
[DOC helper] fix `mut` helper docs in connection with `action` helper

### DIFF
--- a/packages/ember-htmlbars/lib/keywords/mut.js
+++ b/packages/ember-htmlbars/lib/keywords/mut.js
@@ -72,7 +72,7 @@ let MutStream = ProxyStream.extend({
   mutate a value. For example:
 
   ```handlebars
-  {{my-child childClickCount=totalClicks click-count-change=(action (mut "totalClicks"))}}
+  {{my-child childClickCount=totalClicks click-count-change=(action (mut totalClicks))}}
   ```
 
   The child `Component` would invoke the action with the new click value:


### PR DESCRIPTION
You not get the `mut` helper to work until I removed the parenthesis around the variable.
