### PR TITLE
[Glimmer2] Clean up a couple failing glimmer tests

### DIFF
--- a/packages/ember-htmlbars-template-compiler/tests/system/compile_test.js
+++ b/packages/ember-htmlbars-template-compiler/tests/system/compile_test.js
@@ -1,0 +1,13 @@
+import { compile } from '../utils/helpers';
+
+QUnit.module('ember-htmlbars: compile');
+
+QUnit.test('calls template on the compiled function', function() {
+  var templateString = '{{foo}} -- {{some-bar blah=\'foo\'}}';
+
+  var actual = compile(templateString);
+
+  ok(actual.isTop, 'sets isTop via template function');
+  ok(actual.isMethod === false, 'sets isMethod via template function');
+});
+

--- a/packages/ember-template-compiler/tests/system/compile_test.js
+++ b/packages/ember-template-compiler/tests/system/compile_test.js
@@ -8,15 +8,6 @@ import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
 
 testModule('ember-template-compiler: compile');
 
-test('compiles the provided template with htmlbars', function() {
-  var templateString = '{{foo}} -- {{some-bar blah=\'foo\'}}';
-
-  var actual = compile(templateString);
-  var expected = htmlbarsCompile(templateString);
-
-  equal(actual.toString(), expected.toString(), 'compile function matches content with htmlbars compile');
-});
-
 test('includes the current revision in the compiled template', function() {
   var templateString = '{{foo}} -- {{some-bar blah=\'foo\'}}';
 

--- a/packages/ember-template-compiler/tests/system/compile_test.js
+++ b/packages/ember-template-compiler/tests/system/compile_test.js
@@ -6,7 +6,7 @@ import VERSION from 'ember/version';
 
 import { test, testModule } from 'ember-glimmer/tests/utils/skip-if-glimmer';
 
-testModule('ember-htmlbars: compile');
+testModule('ember-template-compiler: compile');
 
 test('compiles the provided template with htmlbars', function() {
   var templateString = '{{foo}} -- {{some-bar blah=\'foo\'}}';
@@ -15,15 +15,6 @@ test('compiles the provided template with htmlbars', function() {
   var expected = htmlbarsCompile(templateString);
 
   equal(actual.toString(), expected.toString(), 'compile function matches content with htmlbars compile');
-});
-
-test('calls template on the compiled function', function() {
-  var templateString = '{{foo}} -- {{some-bar blah=\'foo\'}}';
-
-  var actual = compile(templateString);
-
-  ok(actual.isTop, 'sets isTop via template function');
-  ok(actual.isMethod === false, 'sets isMethod via template function');
 });
 
 test('includes the current revision in the compiled template', function() {


### PR DESCRIPTION
- move a HTMLBars specific test from `ember-template-compiler` to `ember-htmlbars-template-compiler`
- remove a test that doesn't do so much

cc @chadhietala 
