### PR TITLE
[GLIMMER] Refactor attributebinding application

### DIFF
--- a/packages/ember-glimmer/lib/utils/references.js
+++ b/packages/ember-glimmer/lib/utils/references.js
@@ -237,24 +237,34 @@ export class InternalHelperReference extends CachedReference {
 import { assert } from 'ember-metal/debug';
 
 export class AttributeBindingReference extends CachedReference {
-  static apply(component, microsyntax, operations) {
-    let reference = this.parse(component, microsyntax);
+  static apply(component, parsedMicroSyntax, operations) {
+    let reference;
+    let prop = parsedMicroSyntax[0];
+    let attr;
+
+    if (parsedMicroSyntax.length === 1) {
+      reference = new this(component, prop);
+    } else {
+      attr = parsedMicroSyntax[1];
+      reference = new this(component, prop, attr);
+    }
+
     operations.addAttribute(reference.attributeName, reference);
   }
 
-  static parse(component, microsyntax) {
+  static parseMicroSyntax(microsyntax) {
     let colonIndex = microsyntax.indexOf(':');
 
     if (colonIndex === -1) {
       assert('You cannot use class as an attributeBinding, use classNameBindings instead.', microsyntax !== 'class');
-      return new this(component, microsyntax);
+      return [microsyntax];
     } else {
       let prop = microsyntax.substring(0, colonIndex);
       let attr = microsyntax.substring(colonIndex + 1);
 
       assert('You cannot use class as an attributeBinding, use classNameBindings instead.', attr !== 'class');
 
-      return new this(component, prop, attr);
+      return [prop, attr];
     }
   }
 

--- a/packages/ember-glimmer/tests/integration/components/attribute-bindings-test.js
+++ b/packages/ember-glimmer/tests/integration/components/attribute-bindings-test.js
@@ -315,7 +315,7 @@ moduleFor('Attribute bindings integration', class extends RenderingTest {
     this.assertComponentElement(this.nthChild(0), { tagName: 'div', attrs: { 'id': 'special-sauce' } });
   }
 
-  ['@htmlbars attributeBindings are overwritten']() {
+  ['@test attributeBindings are overwritten']() {
     let FooBarComponent = Component.extend({
       attributeBindings: ['href'],
       href: 'a href'


### PR DESCRIPTION
We need to apply attribute bindings in reverse to account for concated
properties.
