### PR TITLE
[CLEANUP] Remove view options in routes

### DIFF
--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -297,17 +297,13 @@ QUnit.test('initialize application with stateManager via initialize call from Ro
   equal(jQuery('#qunit-fixture h1').text(), 'Hello!');
 });
 
-import { test } from 'internal-test-helpers/tests/skip-if-glimmer';
-
-test('ApplicationView is inserted into the page', function() {
+QUnit.test('ApplicationView is inserted into the page', function() {
   run(function() {
     app = Application.create({
       rootElement: '#qunit-fixture'
     });
 
-    app.ApplicationView = View.extend({
-      template: compile('<h1>Hello!</h1>')
-    });
+    setTemplate('application', compile('<h1>Hello!</h1>'));
 
     app.ApplicationController = Controller.extend();
 

--- a/packages/ember-application/tests/system/logging_test.js
+++ b/packages/ember-application/tests/system/logging_test.js
@@ -205,26 +205,6 @@ QUnit.test('do not log when template and view are missing when flag is not true'
   });
 });
 
-import { test } from 'internal-test-helpers/tests/skip-if-glimmer';
-
-test('log which view is used with a template', function() {
-  if (EmberDev && EmberDev.runningProdBuild) {
-    ok(true, 'Logging does not occur in production builds');
-    return;
-  }
-
-  App.register('template:application', compile('{{outlet}}'));
-  App.register('template:foo', compile('Template with custom view'));
-  App.register('view:posts', View.extend({ templateName: 'foo' }));
-  run(App, 'advanceReadiness');
-
-  visit('/posts').then(function() {
-    equal(logs['view:application'], 1, 'toplevel view always get an element');
-    equal(logs['view:index'], undefined, 'expected: Should not log when index is not present.');
-    equal(logs['view:posts'], 1, 'expected: Rendering posts with PostsView.');
-  });
-});
-
 QUnit.test('do not log which views are used with templates when flag is not true', function() {
   App.reopen({
     LOG_VIEW_LOOKUPS: false

--- a/packages/ember-application/tests/system/logging_test.js
+++ b/packages/ember-application/tests/system/logging_test.js
@@ -3,7 +3,6 @@
 import Logger from 'ember-console';
 import run from 'ember-metal/run_loop';
 import Application from 'ember-application/system/application';
-import View from 'ember-views/views/view';
 import Controller from 'ember-runtime/controllers/controller';
 import Route from 'ember-routing/system/route';
 import RSVP from 'ember-runtime/ext/rsvp';

--- a/packages/ember-application/tests/system/reset_test.js
+++ b/packages/ember-application/tests/system/reset_test.js
@@ -4,7 +4,6 @@ import { set } from 'ember-metal/property_set';
 import EmberApplication from 'ember-application/system/application';
 import EmberObject from 'ember-runtime/system/object';
 import Router from 'ember-routing/system/router';
-import View from 'ember-views/views/view';
 import Controller from 'ember-runtime/controllers/controller';
 import jQuery from 'ember-views/system/jquery';
 import Registry from 'container/registry';

--- a/packages/ember-application/tests/system/reset_test.js
+++ b/packages/ember-application/tests/system/reset_test.js
@@ -129,29 +129,6 @@ QUnit.test('When an application is reset, the eventDispatcher is destroyed and r
   Registry.prototype.register = originalRegister;
 });
 
-import { test } from 'internal-test-helpers/tests/skip-if-glimmer';
-
-test('When an application is reset, the ApplicationView is torn down', function() {
-  run(function() {
-    application = Application.create();
-    application.ApplicationView = View.extend({
-      elementId: 'application-view'
-    });
-  });
-
-  equal(jQuery('#qunit-fixture #application-view').length, 1, 'precond - the application view is rendered');
-
-  var originalView = View.views['application-view'];
-
-  application.reset();
-
-  var resettedView = View.views['application-view'];
-
-  equal(jQuery('#qunit-fixture #application-view').length, 1, 'the application view is rendered');
-
-  notStrictEqual(originalView, resettedView, 'The view object has changed');
-});
-
 QUnit.test('When an application is reset, the router URL is reset to `/`', function() {
   var location, router;
 

--- a/packages/ember-application/tests/system/visit_test.js
+++ b/packages/ember-application/tests/system/visit_test.js
@@ -6,7 +6,6 @@ import Application from 'ember-application/system/application';
 import ApplicationInstance from 'ember-application/system/application-instance';
 import Route from 'ember-routing/system/route';
 import Router from 'ember-routing/system/router';
-import View from 'ember-views/views/view';
 import Component from 'ember-htmlbars/component';
 import { compile } from 'ember-template-compiler/tests/utils/helpers';
 import jQuery from 'ember-views/system/jquery';

--- a/packages/ember-application/tests/system/visit_test.js
+++ b/packages/ember-application/tests/system/visit_test.js
@@ -342,38 +342,6 @@ QUnit.test('visit() returns a promise that resolves when the view has rendered',
 
 import { test, testModule } from 'internal-test-helpers/tests/skip-if-glimmer';
 
-test('Views created via visit() are not added to the global views hash', function(assert) {
-  run(function() {
-    createApplication();
-
-    App.register('template:application', compile('<h1>Hello world</h1> {{component "x-child"}}'));
-
-    App.register('view:application', View.extend({
-      elementId: 'my-cool-app'
-    }));
-
-    App.register('component:x-child', View.extend({
-      elementId: 'child-view'
-    }));
-  });
-
-  assert.strictEqual(jQuery('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
-
-  return run(App, 'visit', '/').then(instance => {
-    assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
-    assert.equal(jQuery('#qunit-fixture > #my-cool-app h1').text(), 'Hello world', 'the application was rendered once the promise resolves');
-    assert.strictEqual(View.views['my-cool-app'], undefined, 'view was not registered globally');
-
-    function lookup(fullName) {
-      return instance.lookup(fullName);
-    }
-
-    assert.ok(lookup('-view-registry:main')['my-cool-app'] instanceof View, 'view was registered on the instance\'s view registry');
-    assert.ok(lookup('-view-registry:main')['child-view'] instanceof View, 'child view was registered on the instance\'s view registry');
-  });
-});
-
-
 testModule('Ember.Application - visit() Integration Tests', {
   teardown() {
     if (instances) {

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -2117,8 +2117,6 @@ function buildRenderOptions(route, namePassed, isDefaultRender, _name, options) 
     controller.set('model', options.model);
   }
 
-  let viewName = namePassed && name || name;
-  let ViewClass = owner._lookupFactory(`view:${viewName}`);
   let template = owner.lookup(`template:${templateName}`);
 
   let parent;
@@ -2132,14 +2130,13 @@ function buildRenderOptions(route, namePassed, isDefaultRender, _name, options) 
     outlet,
     name,
     controller,
-    ViewClass,
     template: template || route._topLevelViewTemplate
   };
 
-  assert(`Could not find "${name}" template, view, or component.`, isDefaultRender || ViewClass || template);
+  assert(`Could not find "${name}" template, view, or component.`, isDefaultRender || template);
 
   let LOG_VIEW_LOOKUPS = get(route.router, 'namespace.LOG_VIEW_LOOKUPS');
-  if (LOG_VIEW_LOOKUPS && !ViewClass && !template) {
+  if (LOG_VIEW_LOOKUPS && !template) {
     info(`Could not find "${name}" template. Nothing will be rendered`, { fullName: `template:${name}` });
   }
 

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -494,39 +494,8 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
   },
 
   /**
-    The name of the view to use by default when rendering this routes template.
-
-    When rendering a template, the route will, by default, determine the
-    template and view to use from the name of the route itself. If you need to
-    define a specific view, set this property.
-
-    This is useful when multiple routes would benefit from using the same view
-    because it doesn't require a custom `renderTemplate` method. For example,
-    the following routes will all render using the `App.PostsListView` view:
-
-    ```javascript
-    var PostsList = Ember.Route.extend({
-      viewName: 'postsList'
-    });
-
-    App.PostsIndexRoute = PostsList.extend();
-    App.PostsArchivedRoute = PostsList.extend();
-    ```
-
-    @property viewName
-    @type String
-    @default null
-    @since 1.4.0
-    @public
-  */
-  viewName: null,
-
-  /**
     The name of the template to use by default when rendering this routes
     template.
-
-    This is similar with `viewName`, but is useful when you just want a custom
-    template without a view.
 
     ```javascript
     var PostsList = Ember.Route.extend({
@@ -556,7 +525,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     This is useful in many ways, as the controller specified will be:
 
     * passed to the `setupController` method.
-    * used as the controller for the view being rendered by the route.
+    * used as the controller for the template being rendered by the route.
     * returned from a call to `controllerFor` for the route.
 
     @property controllerName
@@ -1881,7 +1850,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     });
     ```
 
-    `render` additionally allows you to supply which `view`, `controller`, and
+    `render` additionally allows you to supply which `controller` and
     `model` objects should be loaded and associated with the rendered template.
 
 
@@ -1892,7 +1861,6 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
         this.render('posts', {    // the template to render, referenced by name
           into: 'application',    // the template to render into, referenced by name
           outlet: 'anOutletName', // the outlet inside `options.template` to render into.
-          view: 'aViewName',      // the view to use for this template, referenced by name
           controller: 'someControllerName', // the controller to use for this template, referenced by name
           model: model            // the model to set on `options.controller`.
         })
@@ -1900,14 +1868,14 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     });
     ```
 
-    The string values provided for the template name, view, and controller
+    The string values provided for the template name, and controller
     will eventually pass through to the resolver for lookup. See
     Ember.Resolver for how these are mapped to JavaScript objects in your
     application.
 
     Not all options need to be passed to `render`. Default values will be used
     based on the name of the route specified in the router or the Route's
-    `controllerName`, `viewName` and `templateName` properties.
+    `controllerName` and `templateName` properties.
 
     For example:
 
@@ -1938,7 +1906,6 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     this.render('post', {  // the template name associated with 'post' Route
       into: 'application', // the parent route to 'post' Route
       outlet: 'main',      // {{outlet}} and {{outlet 'main'}} are synonymous,
-      view: 'post',        // the view associated with the 'post' Route
       controller: 'post',  // the controller associated with the 'post' Route
     })
     ```
@@ -2150,7 +2117,7 @@ function buildRenderOptions(route, namePassed, isDefaultRender, _name, options) 
     controller.set('model', options.model);
   }
 
-  let viewName = options && options.view || namePassed && name || route.viewName || name;
+  let viewName = namePassed && name || name;
   let ViewClass = owner._lookupFactory(`view:${viewName}`);
   let template = owner.lookup(`template:${templateName}`);
 
@@ -2173,7 +2140,7 @@ function buildRenderOptions(route, namePassed, isDefaultRender, _name, options) 
 
   let LOG_VIEW_LOOKUPS = get(route.router, 'namespace.LOG_VIEW_LOOKUPS');
   if (LOG_VIEW_LOOKUPS && !ViewClass && !template) {
-    info(`Could not find "${name}" template or view. Nothing will be rendered`, { fullName: `template:${name}` });
+    info(`Could not find "${name}" template. Nothing will be rendered`, { fullName: `template:${name}` });
   }
 
   return renderOptions;

--- a/packages/ember/tests/controller_test.js
+++ b/packages/ember/tests/controller_test.js
@@ -3,7 +3,6 @@ import Route from 'ember-routing/system/route';
 import run from 'ember-metal/run_loop';
 import { compile } from 'ember-template-compiler/tests/utils/helpers';
 import Application from 'ember-application/system/application';
-import EmberView from 'ember-views/views/view';
 import Component from 'ember-templates/component';
 import jQuery from 'ember-views/system/jquery';
 import { setTemplates, set as setTemplate } from 'ember-templates/template_registry';
@@ -73,28 +72,6 @@ test('Actions inside an outlet go to the associated controller', function() {
   bootApp();
 
   $fixture.find('.component-with-action').click();
-});
-
-test('the controller property is provided to route driven views', function() {
-  var applicationController, applicationViewController;
-
-  App.ApplicationController = Controller.extend({
-    init: function() {
-      this._super(...arguments);
-      applicationController = this;
-    }
-  });
-
-  App.ApplicationView = EmberView.extend({
-    init: function() {
-      this._super(...arguments);
-      applicationViewController = this.get('controller');
-    }
-  });
-
-  bootApp();
-
-  equal(applicationViewController, applicationController, 'application view should get its controller set properly');
 });
 
 function bootApp() {

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -991,26 +991,17 @@ QUnit.test("Issue 4201 - Shorthand for route.index shouldn't throw errors about 
   shouldBeActive('#lobby-link');
 });
 
-test("The {{link-to}} helper doesn't change view context", function() {
-  App.IndexView = EmberView.extend({
-    elementId: 'index',
-    name: 'test',
-    isTrue: true
+QUnit.test('Quoteless route param performs property lookup', function() {
+  let component;
+
+  App.FooBarComponent = Component.extend({
+    foo: 'index',
+    init() {
+      this._super(...arguments);
+      component = this;
+    },
+    layout: compile("{{#link-to 'index' id='string-link'}}string{{/link-to}}{{#link-to foo id='path-link'}}path{{/link-to}}{{#link-to foo id='view-link'}}{{foo}}{{/link-to}}")
   });
-
-  setTemplate('index', compile("{{view.name}}-{{#link-to 'index' id='self-link'}}Link: {{view.name}}-{{#if view.isTrue}}{{view.name}}{{/if}}{{/link-to}}"));
-
-  bootApplication();
-
-  run(function() {
-    router.handleURL('/');
-  });
-
-  equal(jQuery('#index', '#qunit-fixture').text(), 'test-Link: test-test', 'accesses correct view');
-});
-
-test('Quoteless route param performs property lookup', function() {
-  setTemplate('index', compile("{{#link-to 'index' id='string-link'}}string{{/link-to}}{{#link-to foo id='path-link'}}path{{/link-to}}{{#link-to view.foo id='view-link'}}{{view.foo}}{{/link-to}}"));
 
   function assertEquality(href) {
     equal(normalizeUrl(jQuery('#string-link', '#qunit-fixture').attr('href')), '/');
@@ -1018,14 +1009,7 @@ test('Quoteless route param performs property lookup', function() {
     equal(normalizeUrl(jQuery('#view-link', '#qunit-fixture').attr('href')), href);
   }
 
-  App.IndexView = EmberView.extend({
-    foo: 'index',
-    elementId: 'index-view'
-  });
-
-  App.IndexController = Controller.extend({
-    foo: 'index'
-  });
+  setTemplate('index', compile('{{foo-bar}}'));
 
   App.Router.map(function() {
     this.route('about');
@@ -1037,11 +1021,8 @@ test('Quoteless route param performs property lookup', function() {
 
   assertEquality('/');
 
-  var controller = appInstance.lookup('controller:index');
-  var view = EmberView.views['index-view'];
   run(function() {
-    controller.set('foo', 'about');
-    view.set('foo', 'about');
+    component.set('foo', 'about');
   });
 
   assertEquality('/about');
@@ -1335,23 +1316,25 @@ QUnit.test('The non-block form {{link-to}} helper moves into the named route wit
   equal(normalizeUrl(jQuery('li a:contains(Erik)').attr('href')), '/item/erik');
 });
 
-test('The non-block form {{link-to}} performs property lookup', function() {
-  setTemplate('index', compile("{{link-to 'string' 'index' id='string-link'}}{{link-to path foo id='path-link'}}{{link-to view.foo view.foo id='view-link'}}"));
+QUnit.test('The non-block form {{link-to}} performs property lookup', function() {
+  let component;
+  App.FooBarComponent = Component.extend({
+    foo: 'index',
+    elementId: 'index-view',
+    init() {
+      this._super(...arguments);
+      component = this;
+    },
+    layout: compile("{{link-to 'string' 'index' id='string-link'}}{{link-to path foo id='path-link'}}{{link-to foo foo id='view-link'}}")
+  });
+
+  setTemplate('index', compile('{{foo-bar}}'));
 
   function assertEquality(href) {
     equal(normalizeUrl(jQuery('#string-link', '#qunit-fixture').attr('href')), '/');
     equal(normalizeUrl(jQuery('#path-link', '#qunit-fixture').attr('href')), href);
     equal(normalizeUrl(jQuery('#view-link', '#qunit-fixture').attr('href')), href);
   }
-
-  App.IndexView = EmberView.extend({
-    foo: 'index',
-    elementId: 'index-view'
-  });
-
-  App.IndexController = Controller.extend({
-    foo: 'index'
-  });
 
   App.Router.map(function() {
     this.route('about');
@@ -1363,11 +1346,8 @@ test('The non-block form {{link-to}} performs property lookup', function() {
 
   assertEquality('/');
 
-  var controller = appInstance.lookup('controller:index');
-  var view = EmberView.views['index-view'];
   run(function() {
-    controller.set('foo', 'about');
-    view.set('foo', 'about');
+    component.set('foo', 'about');
   });
 
   assertEquality('/about');

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -11,7 +11,6 @@ import { computed } from 'ember-metal/computed';
 import Mixin, { observer } from 'ember-metal/mixin';
 import Component from 'ember-templates/component';
 import ActionManager from 'ember-views/system/action_manager';
-import EmberView from 'ember-views/views/view';
 import jQuery from 'ember-views/system/jquery';
 import { compile } from 'ember-template-compiler/tests/utils/helpers';
 import Application from 'ember-application/system/application';
@@ -373,45 +372,6 @@ QUnit.test('defining templateName allows other templates to be rendered', functi
   });
 
   equal(jQuery('.alert-box', '#qunit-fixture').text(), 'Invader!', 'Template for alert was render into outlet');
-});
-
-test('Specifying a name to render should have precedence over everything else', function() {
-  Router.map(function() {
-    this.route('home', { path: '/' });
-  });
-
-  App.HomeController = Controller.extend();
-  App.HomeRoute = Route.extend({
-    templateName: 'home',
-    controllerName: 'home',
-    viewName: 'home',
-
-    renderTemplate() {
-      this.render('homepage');
-    }
-  });
-
-  App.HomeView = EmberView.extend({
-    template: compile('<h3>This should not be rendered</h3><p>{{model.home}}</p>')
-  });
-
-  App.HomepageController = Controller.extend({
-    model: {
-      home: 'Tinytroll'
-    }
-  });
-  App.HomepageView = EmberView.extend({
-    layout: compile(
-      '<span>Outer</span>{{yield}}<span>troll</span>'
-    ),
-    templateName: 'homepage'
-  });
-
-  bootApplication();
-
-  equal(jQuery('h3', '#qunit-fixture').text(), 'Megatroll', 'The homepage template was rendered');
-  equal(jQuery('p', '#qunit-fixture').text(), 'Tinytroll', 'The homepage controller was used');
-  equal(jQuery('span', '#qunit-fixture').text(), 'Outertroll', 'The homepage view was used');
 });
 
 QUnit.test('The Homepage with a `setupController` hook', function() {
@@ -2216,14 +2176,14 @@ test('The template is not re-rendered when the route\'s context changes', functi
   });
 
   var insertionCount = 0;
-  App.PageView = EmberView.extend({
+  App.FooBarComponent = Component.extend({
     didInsertElement() {
       insertionCount += 1;
     }
   });
 
   setTemplate('page', compile(
-    '<p>{{model.name}}</p>'
+    '<p>{{model.name}}{{foo-bar}}</p>'
   ));
 
   bootApplication();
@@ -3348,31 +3308,6 @@ QUnit.test('{{outlet}} works when created after initial render', function() {
   handleURL('/2');
 
   equal(jQuery('#qunit-fixture').text(), 'HiBooBye', 'third render');
-});
-
-test('Can rerender application view multiple times when it contains an outlet', function() {
-  setTemplate('application', compile('App{{outlet}}'));
-  setTemplate('index', compile('Hello world'));
-
-  registry.register('view:application', EmberView.extend({
-    elementId: 'im-special'
-  }));
-
-  bootApplication();
-
-  equal(jQuery('#qunit-fixture').text(), 'AppHello world', 'initial render');
-
-  run(function() {
-    EmberView.views['im-special'].rerender();
-  });
-
-  equal(jQuery('#qunit-fixture').text(), 'AppHello world', 'second render');
-
-  run(function() {
-    EmberView.views['im-special'].rerender();
-  });
-
-  equal(jQuery('#qunit-fixture').text(), 'AppHello world', 'third render');
 });
 
 QUnit.test('Can render into a named outlet at the top level', function() {

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -767,7 +767,8 @@ test('Slow promises returned from ApplicationRoute#model enter ApplicationLoadin
   equal(jQuery('#app', '#qunit-fixture').text(), 'INDEX');
 });
 
-test('Slow promises returned from ApplicationRoute#model enter application_loading if template present', function() {
+// SKIP FOR NOW
+QUnit.skip('Slow promises returned from ApplicationRoute#model enter application_loading if template present', function() {
   expect(3);
 
   templates['application_loading'] = 'TOPLEVEL LOADING';
@@ -777,17 +778,6 @@ test('Slow promises returned from ApplicationRoute#model enter application_loadi
     model() {
       return appDeferred.promise;
     }
-  });
-
-  var loadingRouteEntered = false;
-  App.ApplicationLoadingRoute = Route.extend({
-    setupController() {
-      loadingRouteEntered = true;
-    }
-  });
-
-  App.ApplicationLoadingView = EmberView.extend({
-    elementId: 'toplevel-loading'
   });
 
   bootApplication();

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -3,7 +3,6 @@ import Controller from 'ember-runtime/controllers/controller';
 import Route from 'ember-routing/system/route';
 import run from 'ember-metal/run_loop';
 import { compile } from 'ember-template-compiler/tests/utils/helpers';
-import EmberView from 'ember-views/views/view';
 import Application from 'ember-application/system/application';
 import jQuery from 'ember-views/system/jquery';
 import NoneLocation from 'ember-routing/location/none_location';
@@ -767,11 +766,10 @@ test('Slow promises returned from ApplicationRoute#model enter ApplicationLoadin
   equal(jQuery('#app', '#qunit-fixture').text(), 'INDEX');
 });
 
-// SKIP FOR NOW
-QUnit.skip('Slow promises returned from ApplicationRoute#model enter application_loading if template present', function() {
+test('Slow promises returned from ApplicationRoute#model enter application_loading if template present', function() {
   expect(3);
 
-  templates['application_loading'] = 'TOPLEVEL LOADING';
+  templates['application_loading'] = '<div id="toplevel-loading">TOPLEVEL LOADING</div>';
 
   var appDeferred = RSVP.defer();
   App.ApplicationRoute = Route.extend({
@@ -782,7 +780,7 @@ QUnit.skip('Slow promises returned from ApplicationRoute#model enter application
 
   bootApplication();
 
-  equal(jQuery('#qunit-fixture > #toplevel-loading').text(), 'TOPLEVEL LOADING');
+  equal(jQuery('#qunit-fixture #toplevel-loading').text(), 'TOPLEVEL LOADING');
 
   run(appDeferred, 'resolve', {});
 

--- a/packages/ember/tests/routing/toplevel_dom_test.js
+++ b/packages/ember/tests/routing/toplevel_dom_test.js
@@ -55,13 +55,3 @@ QUnit.test('Topmost template always get an element', function() {
   bootApplication();
   equal(jQuery('#qunit-fixture > .ember-view').text(), 'hello world');
 });
-
-import { test } from 'internal-test-helpers/tests/skip-if-glimmer';
-
-test('If topmost view has its own element, it doesn\'t get wrapped in a higher element', function() {
-  App.register('view:application', EmberView.extend({
-    classNames: ['im-special']
-  }));
-  bootApplication();
-  equal(jQuery('#qunit-fixture > .im-special').text(), 'hello world');
-});

--- a/packages/ember/tests/routing/toplevel_dom_test.js
+++ b/packages/ember/tests/routing/toplevel_dom_test.js
@@ -1,6 +1,5 @@
 import run from 'ember-metal/run_loop';
 import { compile } from 'ember-template-compiler/tests/utils/helpers';
-import EmberView from 'ember-views/views/view';
 import Application from 'ember-application/system/application';
 import jQuery from 'ember-views/system/jquery';
 import NoneLocation from 'ember-routing/location/none_location';


### PR DESCRIPTION
This removes the `viewName` and `view` option in `Route`. This is dependent on #13580  or I can make them part of this PR.
