### PR TITLE
Adds warning for nested key passed to mapBy

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -3,7 +3,7 @@
 @submodule ember-runtime
 */
 
-import { assert } from 'ember-metal/debug';
+import { assert, warn } from 'ember-metal/debug';
 import { get } from 'ember-metal/property_get';
 import EmberError from 'ember-metal/error';
 import { ComputedProperty, computed } from 'ember-metal/computed';
@@ -240,6 +240,13 @@ export function mapBy(dependentKey, propertyKey) {
     'Ember.computed.mapBy expects a property string for its second argument, ' +
     'perhaps you meant to use "map"',
     typeof propertyKey === 'string'
+  );
+
+  warn(
+    'Ember.computed.mapBy does not work with nested dependent keys. You cannot use ' +
+    'nested forms like computed.mapBy("todos", "owner.name").',
+    (propertyKey.indexOf('.') === -1),
+    { id: 'ember-runtime.computed-map-by-nested-keys' }
   );
 
   return map(`${dependentKey}.@each.${propertyKey}`, item => get(item, propertyKey));

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -218,6 +218,23 @@ QUnit.test('it is observable', function() {
   equal(calls, 1, 'mapBy is observable');
 });
 
+QUnit.test('it does not support nested dependent keys', function() {
+  var warning = 'Ember.computed.mapBy does not work with nested dependent keys. You cannot use ' +
+                'nested forms like computed.mapBy("todos", "owner.name").';
+
+  expectNoWarning(() => {
+    mapBy('array', 'k');
+  });
+
+  expectWarning(() => {
+    mapBy('array', 'k.v');
+  }, warning);
+
+  expectWarning(() => {
+    mapBy('array', 'k.v.z');
+  }, warning);
+});
+
 QUnit.module('filter', {
   setup() {
     obj = EmberObject.extend({


### PR DESCRIPTION
When a nested dependent key is passed to a mapBy (e.g.
computed.mapBy('todos', 'owner.name')), it will now
warn the user that nested dependent keys aren't supported.
