### PR TITLE
[DOC] Add documentation to second parameter in Ember.computed.deprecatingAlias

### DIFF
--- a/packages/ember-runtime/lib/computed/computed_macros.js
+++ b/packages/ember-runtime/lib/computed/computed_macros.js
@@ -625,6 +625,7 @@ export function readOnly(dependentKey) {
   @method deprecatingAlias
   @for Ember.computed
   @param {String} dependentKey
+  @param {Object} options Options for `Ember.deprecate`.
   @return {Ember.ComputedProperty} computed property which creates an
   alias with a deprecation to the original value for property.
   @since 1.7.0


### PR DESCRIPTION
Given that this second parameter is passed as is to `Ember.deprecate`, the
documentation just references this other public method.

Fixes #13630 
