### PR TITLE
Enable passing skipped tests.

### DIFF
--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -417,7 +417,7 @@ test('`click` triggers appropriate events in order', function() {
   });
 });
 
-test('`click` triggers native events with simulated X/Y coordinates', function() {
+QUnit.test('`click` triggers native events with simulated X/Y coordinates', function() {
   expect(15);
 
   var click, wait, events;

--- a/packages/ember/tests/component_registration_test.js
+++ b/packages/ember/tests/component_registration_test.js
@@ -5,13 +5,20 @@ import Application from 'ember-application/system/application';
 import Router from 'ember-routing/system/router';
 import { compile } from 'ember-template-compiler/tests/utils/helpers';
 import helpers from 'ember-htmlbars/helpers';
-import { OutletView } from 'ember-htmlbars/views/outlet';
 import Component from 'ember-templates/component';
 import jQuery from 'ember-views/system/jquery';
 import { A as emberA } from 'ember-runtime/system/native_array';
 import { setTemplates, set as setTemplate } from 'ember-templates/template_registry';
 import { test } from 'internal-test-helpers/tests/skip-if-glimmer';
 import isEnabled from 'ember-metal/features';
+import require from 'require';
+
+let OutletView;
+if (isEnabled('ember-glimmer')) {
+  OutletView = require('ember-glimmer/views/outlet').default;
+} else {
+  OutletView = require('ember-htmlbars/views/outlet').OutletView;
+}
 
 var App, appInstance;
 var originalHelpers;
@@ -401,7 +408,7 @@ QUnit.test('Components trigger actions in the components context when called fro
   jQuery('#fizzbuzz', '#wrapper').click();
 });
 
-test('Components receive the top-level view as their ownerView', function(assert) {
+QUnit.test('Components receive the top-level view as their ownerView', function(assert) {
   setTemplate('application', compile('{{outlet}}'));
   setTemplate('index', compile('{{my-component}}'));
   setTemplate('components/my-component', compile('<div></div>'));
@@ -424,6 +431,4 @@ test('Components receive the top-level view as their ownerView', function(assert
   assert.ok(ownerView, 'owner view was set');
   assert.ok(ownerView instanceof OutletView, 'owner view has no parent view');
   assert.notStrictEqual(component, ownerView, 'owner view is not itself');
-
-  assert.ok(ownerView._outlets, 'owner view has an internal array of outlets');
 });

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -984,7 +984,7 @@ QUnit.test("Issue 4201 - Shorthand for route.index shouldn't throw errors about 
   shouldBeActive('#lobby-link');
 });
 
-test('Quoteless route param performs property lookup', function() {
+QUnit.test('Quoteless route param performs property lookup', function() {
   setTemplate('index', compile("{{#link-to 'index' id='string-link'}}string{{/link-to}}{{#link-to foo id='path-link'}}path{{/link-to}}"));
 
   function assertEquality(href) {
@@ -1302,7 +1302,7 @@ QUnit.test('The non-block form {{link-to}} helper moves into the named route wit
   equal(normalizeUrl(jQuery('li a:contains(Erik)').attr('href')), '/item/erik');
 });
 
-test('The non-block form {{link-to}} performs property lookup', function() {
+QUnit.test('The non-block form {{link-to}} performs property lookup', function() {
   setTemplate('index', compile("{{link-to 'string' 'index' id='string-link'}}{{link-to path foo id='path-link'}}"));
 
   function assertEquality(href) {

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -2003,7 +2003,7 @@ QUnit.test('The rootURL is passed properly to the location implementation', func
 });
 
 
-test('Only use route rendered into main outlet for default into property on child', function() {
+QUnit.test('Only use route rendered into main outlet for default into property on child', function() {
   setTemplate('application', compile('{{outlet \'menu\'}}{{outlet}}'));
   setTemplate('posts', compile('{{outlet}}'));
   setTemplate('posts/index', compile('<p class="posts-index">postsIndex</p>'));
@@ -2096,7 +2096,7 @@ QUnit.test('Nested index route is not overriden by parent\'s implicit index rout
 });
 
 if (isEnabled('ember-route-serializers')) {
-  test('Custom Route#serialize method still works [DEPRECATED]', function() {
+  QUnit.test('Custom Route#serialize method still works [DEPRECATED]', function() {
     Router.map(function() {
       this.route('posts', function() {
         this.route('index', {
@@ -2949,7 +2949,7 @@ test('Specifying non-existent controller name in route#render throws', function(
   bootApplication();
 });
 
-test('Redirecting with null model doesn\'t error out', function() {
+QUnit.test('Redirecting with null model doesn\'t error out', function() {
   function serializeAboutRoute(model) {
     if (model === null) {
       return { hurhurhur: 'TreeklesMcGeekles' };

--- a/packages/internal-test-helpers/tests/skip-if-glimmer.js
+++ b/packages/internal-test-helpers/tests/skip-if-glimmer.js
@@ -2,9 +2,9 @@ import isEnabled from 'ember-metal/features';
 
 export function test(name, fn) {
   if (isEnabled('ember-glimmer')) {
-    QUnit.skip('[GLIMMER] ' + name, fn);
+    QUnit.skip('[SKIPPED IN GLIMMER] ' + name, fn);
   } else {
-    QUnit.test(name, fn);
+    QUnit.test('[SKIPPED IN GLIMMER] ' + name, fn);
   }
 }
 


### PR DESCRIPTION
Also update `skip-if-glimmer` to add a prefix to make the skipped tests easier to find now passing tests (as more underlying things are fixed).
