### PR TITLE
[BUGFIX release] Fix inlining of superWrapper.

### DIFF
--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -7,10 +7,7 @@
 @submodule ember-metal
 */
 import { assert } from 'ember-metal/debug';
-import {
-  apply,
-  applyStr
-} from 'ember-metal/utils';
+import { applyStr } from 'ember-metal/utils';
 import { meta as metaFor, peekMeta } from 'ember-metal/meta';
 import { deprecate } from 'ember-metal/debug';
 
@@ -237,7 +234,7 @@ export function sendEvent(obj, eventName, params, actions) {
       }
     } else {
       if (params) {
-        apply(target, method, params);
+        method.apply(target, params);
       } else {
         method.call(target);
       }


### PR DESCRIPTION
This fixes the inlining of superWrapper.  The bug that copying the arguments was addressing has been fixed for long enough that more users are affected by fix than the fix benefits.  This also fixes a deopt in the megamorphic load of toString, since we store metadata on functions we have many shapes of functions.

I also retested call vs apply branching in modern browsers and did not see any difference between the two.
