### PR TITLE
Use a map to back meta's cache.

### DIFF
--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -182,8 +182,8 @@ function lazyGet(obj, key) {
   // Otherwise attempt to get the cached value of the computed property
   } else {
     let cache = meta.readableCache();
-    if (cache && key in cache) {
-      return cache[key];
+    if (cache && cache.has(key)) {
+      return cache.get(key);
     }
   }
 }

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -316,8 +316,8 @@ ComputedPropertyPrototype.didChange = function(obj, keyName) {
   }
 
   let cache = meta.readableCache();
-  if (cache && cache[keyName] !== undefined) {
-    cache[keyName] = undefined;
+  if (cache && cache.get(keyName) !== undefined) {
+    cache.set(keyName, undefined);
     removeDependentKeys(this, obj, keyName, meta);
   }
 };
@@ -329,8 +329,8 @@ ComputedPropertyPrototype.get = function(obj, keyName) {
 
   let meta = metaFor(obj);
   let cache = meta.writableCache();
+  let result = cache.get(keyName);
 
-  let result = cache[keyName];
   if (result === UNDEFINED) {
     return undefined;
   } else if (result !== undefined) {
@@ -339,9 +339,9 @@ ComputedPropertyPrototype.get = function(obj, keyName) {
 
   let ret = this._getter.call(obj, keyName);
   if (ret === undefined) {
-    cache[keyName] = UNDEFINED;
+    cache.set(keyName, UNDEFINED);
   } else {
-    cache[keyName] = ret;
+    cache.set(keyName, ret);
   }
 
   let chainWatchers = meta.readableChainWatchers();
@@ -400,10 +400,12 @@ ComputedPropertyPrototype._set = function computedPropertySet(obj, keyName, valu
   // either there is a writable cache or we need one to update
   let cache          = meta.writableCache();
   let hadCachedValue = false;
+  let rawCachedValue = cache.get(keyName);
   let cachedValue;
-  if (cache[keyName] !== undefined) {
-    if (cache[keyName] !== UNDEFINED) {
-      cachedValue = cache[keyName];
+
+  if (rawCachedValue !== undefined) {
+    if (rawCachedValue !== UNDEFINED) {
+      cachedValue = rawCachedValue;
     }
     hadCachedValue = true;
   }
@@ -418,7 +420,7 @@ ComputedPropertyPrototype._set = function computedPropertySet(obj, keyName, valu
   propertyWillChange(obj, keyName);
 
   if (hadCachedValue) {
-    cache[keyName] = undefined;
+    cache.set(keyName, undefined);
   }
 
   if (!hadCachedValue) {
@@ -426,9 +428,9 @@ ComputedPropertyPrototype._set = function computedPropertySet(obj, keyName, valu
   }
 
   if (ret === undefined) {
-    cache[keyName] = UNDEFINED;
+    cache.set(keyName, UNDEFINED);
   } else {
-    cache[keyName] = ret;
+    cache.set(keyName, ret);
   }
 
   propertyDidChange(obj, keyName);
@@ -443,9 +445,9 @@ ComputedPropertyPrototype.teardown = function(obj, keyName) {
   }
   let meta = metaFor(obj);
   let cache = meta.readableCache();
-  if (cache && cache[keyName] !== undefined) {
+  if (cache && cache.get(keyName) !== undefined) {
     removeDependentKeys(this, obj, keyName, meta);
-    cache[keyName] = undefined;
+    cache.set(keyName, undefined);
   }
 };
 
@@ -568,7 +570,7 @@ export default function computed(func) {
 function cacheFor(obj, key) {
   let meta = peekMeta(obj);
   let cache = meta && meta.source === obj && meta.readableCache();
-  let ret = cache && cache[key];
+  let ret = cache && cache.get(key);
 
   if (ret === UNDEFINED) {
     return undefined;
@@ -578,14 +580,14 @@ function cacheFor(obj, key) {
 
 cacheFor.set = function(cache, key, value) {
   if (value === undefined) {
-    cache[key] = UNDEFINED;
+    cache.set(key, UNDEFINED);
   } else {
-    cache[key] = value;
+    cache.set(key, value);
   }
 };
 
 cacheFor.get = function(cache, key) {
-  let ret = cache[key];
+  let ret = cache.get(key);
   if (ret === UNDEFINED) {
     return undefined;
   }
@@ -593,7 +595,7 @@ cacheFor.get = function(cache, key) {
 };
 
 cacheFor.remove = function(cache, key) {
-  cache[key] = undefined;
+  cache.set(key, undefined);
 };
 
 export {

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -47,7 +47,7 @@ let members = {
   tag: ownCustomObject
 };
 
-let memberNames = Object.keys(members);
+const memberNames = Object.keys(members);
 const META_FIELD = '__ember_meta__';
 
 function Meta(obj, parentMeta) {
@@ -92,10 +92,10 @@ memberNames.forEach(name => members[name](name, Meta));
 function ownMap(name, Meta) {
   let key = memberProperty(name);
   let capitalized = capitalize(name);
-  Meta.prototype['writable' + capitalized] = function() {
+  Meta.prototype[`writable${capitalized}`] = function() {
     return this._getOrCreateOwnMap(key);
   };
-  Meta.prototype['readable' + capitalized] = function() { return this[key]; };
+  Meta.prototype[`readable${capitalized}`] = function() { return this[key]; };
 }
 
 Meta.prototype._getOrCreateOwnMap = function(key) {
@@ -112,16 +112,16 @@ function inheritedMap(name, Meta) {
   let key = memberProperty(name);
   let capitalized = capitalize(name);
 
-  Meta.prototype['write' + capitalized] = function(subkey, value) {
+  Meta.prototype[`write${capitalized}`] = function(subkey, value) {
     let map = this._getOrCreateOwnMap(key);
     map.set(subkey, value);
   };
 
-  Meta.prototype['peek' + capitalized] = function(subkey) {
+  Meta.prototype[`peek${capitalized}`] = function(subkey) {
     return this._findInherited(key, subkey);
   };
 
-  Meta.prototype['forEach' + capitalized] = function(fn) {
+  Meta.prototype[`forEach${capitalized}`] = function(fn) {
     let pointer = this;
     let seen = new LodashishStack();
 
@@ -141,15 +141,15 @@ function inheritedMap(name, Meta) {
     }
   };
 
-  Meta.prototype['clear' + capitalized] = function() {
+  Meta.prototype[`clear${capitalized}`] = function() {
     this[key] = undefined;
   };
 
-  Meta.prototype['deleteFrom' + capitalized] = function(subkey) {
+  Meta.prototype[`deleteFrom${capitalized}`] = function(subkey) {
     this._getOrCreateOwnMap(key).delete(subkey);
   };
 
-  Meta.prototype['hasIn' + capitalized] = function(subkey) {
+  Meta.prototype[`hasIn${capitalized}`] = function(subkey) {
     return this._findInherited(key, subkey) !== undefined;
   };
 }
@@ -186,7 +186,7 @@ function inheritedMapOfMaps(name, Meta) {
   let key = memberProperty(name);
   let capitalized = capitalize(name);
 
-  Meta.prototype['write' + capitalized] = function(subkey, itemkey, value) {
+  Meta.prototype[`write${capitalized}`] = function(subkey, itemkey, value) {
     let keyMap = this._getOrCreateOwnMap(key);
     let subkeyMap = keyMap.get(subkey);
     if (!subkeyMap) {
@@ -196,7 +196,7 @@ function inheritedMapOfMaps(name, Meta) {
     subkeyMap.set(itemkey, value);
   };
 
-  Meta.prototype['peek' + capitalized] = function(subkey, itemkey) {
+  Meta.prototype[`peek${capitalized}`] = function(subkey, itemkey) {
     let pointer = this;
     while (pointer !== undefined) {
       let keyMap = pointer[key];
@@ -213,7 +213,7 @@ function inheritedMapOfMaps(name, Meta) {
     }
   };
 
-  Meta.prototype['has' + capitalized] = function(subkey) {
+  Meta.prototype[`has${capitalized}`] = function(subkey) {
     let pointer = this;
     while (pointer !== undefined) {
       if (pointer[key] && pointer[key].has(subkey)) {
@@ -224,7 +224,7 @@ function inheritedMapOfMaps(name, Meta) {
     return false;
   };
 
-  Meta.prototype['forEachIn' + capitalized] = function(subkey, fn) {
+  Meta.prototype[`forEachIn${capitalized}`] = function(subkey, fn) {
     return this._forEachIn(key, subkey, fn);
   };
 }
@@ -264,14 +264,14 @@ Meta.prototype._forEachIn = function(key, subkey, fn) {
 function ownCustomObject(name, Meta) {
   let key = memberProperty(name);
   let capitalized = capitalize(name);
-  Meta.prototype['writable' + capitalized] = function(create) {
+  Meta.prototype[`writable${capitalized}`] = function(create) {
     let ret = this[key];
     if (!ret) {
       ret = this[key] = create(this.source);
     }
     return ret;
   };
-  Meta.prototype['readable' + capitalized] = function() {
+  Meta.prototype[`readable${capitalized}`] = function() {
     return this[key];
   };
 }
@@ -282,18 +282,18 @@ function ownCustomObject(name, Meta) {
 function inheritedCustomObject(name, Meta) {
   let key = memberProperty(name);
   let capitalized = capitalize(name);
-  Meta.prototype['writable' + capitalized] = function(create) {
+  Meta.prototype[`writable${capitalized}`] = function(create) {
     let ret = this[key];
     if (!ret) {
       if (this.parent) {
-        ret = this[key] = this.parent['writable' + capitalized](create).copy(this.source);
+        ret = this[key] = this.parent[`writable${capitalized}`](create).copy(this.source);
       } else {
         ret = this[key] = create(this.source);
       }
     }
     return ret;
   };
-  Meta.prototype['readable' + capitalized] = function() {
+  Meta.prototype[`readable${capitalized}`] = function() {
     return this._getInherited(key);
   };
 }
@@ -309,7 +309,7 @@ function capitalize(name) {
   return name.replace(/^\w/, m => m.toUpperCase());
 }
 
-export var META_DESC = {
+export const META_DESC = {
   writable: true,
   configurable: true,
   enumerable: false,

--- a/packages/ember-metal/lib/utils/lodash-stack.js
+++ b/packages/ember-metal/lib/utils/lodash-stack.js
@@ -1,5 +1,10 @@
+// jshint eqeqeq:false
+// jshint laxbreak:true
+
+import EmptyObject from '../empty_object';
+
 /*
- From Lodash's private ListCache here:
+ From Lodash's private Stack/Hash/MapCache/ListCache here:
 
  https://github.com/lodash/lodash/blob/4.13.1/dist/lodash.js#L1790-L1900
 
@@ -16,6 +21,24 @@
  ***********************************************************************
 
 */
+
+const LARGE_ARRAY_SIZE = 200;
+const HASH_UNDEFINED = '__lodash_hash_undefined__';
+
+function isKeyable(value) {
+  var type = typeof value;
+  return (type == 'string' || type == 'number' || type == 'symbol' || type == 'boolean')
+    ? (value !== '__proto__')
+    : (value === null);
+}
+
+function getMapData(map, key) {
+  var data = map.__data__;
+  return isKeyable(key)
+    ? data[typeof key == 'string' ? 'string' : 'hash']
+  : data.map;
+}
+
 function assocIndexOf(array, key) {
   var length = array.length;
   while (length--) {
@@ -27,9 +50,108 @@ function assocIndexOf(array, key) {
   return -1;
 }
 
-export default class ListCache {
-  constructor() {
-    this.__data__ = [];
+export class Hash {
+  constructor(entries) {
+    let index = -1;
+    let length = entries ? entries.length : 0;
+
+    this.clear();
+
+    while (++index < length) {
+      let entry = entries[index];
+      this.set(entry[0], entry[1]);
+    }
+  }
+
+  clear() {
+    this.__data__ = new EmptyObject();
+  }
+
+  delete(key) {
+    return this.has(key) && delete this.__data__[key];
+  }
+
+  get(key) {
+    let data = this.__data__;
+    let result = data[key];
+
+    return result === HASH_UNDEFINED ? undefined : result;
+  }
+
+  has(key) {
+    let data = this.__data__;
+    return data[key] !== undefined;
+  }
+
+  set(key, value) {
+    var data = this.__data__;
+    data[key] = value === undefined ? HASH_UNDEFINED : value;
+  }
+
+  forEach(callback) {
+    let data = this.__data__;
+    for (let key in data) {
+      callback(key, data[key]);
+    }
+  }
+}
+
+export class MapCache {
+  constructor(entries) {
+    let index = -1;
+    let length = entries ? entries.length : 0;
+
+    this.clear();
+
+    while (++index < length) {
+      let entry = entries[index];
+      this.set(entry[0], entry[1]);
+    }
+  }
+
+  clear() {
+    this.__data__ = {
+      'hash': new Hash(),
+      // TODO: use native Map if present
+      'map': new ListCache(),
+      'string': new Hash()
+    };
+  }
+
+  delete(key) {
+    return getMapData(this, key)['delete'](key);
+  }
+
+  get(key) {
+    return getMapData(this, key).get(key);
+  }
+
+  has(key) {
+    return getMapData(this, key).has(key);
+  }
+
+  set(key, value) {
+    getMapData(this, key).set(key, value);
+  }
+
+  forEach(callback) {
+    this.__data__.hash.forEach(callback);
+    this.__data__.map.forEach(callback);
+    this.__data__.string.forEach(callback);
+  }
+}
+
+export class ListCache {
+  constructor(entries) {
+    let index = -1;
+    let length = entries ? entries.length : 0;
+
+    this.clear();
+
+    while (++index < length) {
+      let entry = entries[index];
+      this.set(entry[0], entry[1]);
+    }
   }
 
   clear() {
@@ -44,7 +166,7 @@ export default class ListCache {
       return false;
     }
     var lastIndex = data.length - 1;
-    if (index == lastIndex) {     // jshint ignore:line
+    if (index == lastIndex) {
       data.pop();
     } else {
       data.splice(index, 1);
@@ -73,19 +195,51 @@ export default class ListCache {
     } else {
       data[index][1] = value;
     }
-
-    return this;
   }
 
-  /*
-   This is not included in the lodash ListCache/Stack interface
-   but is required to support all the operations of Meta.
-   */
   forEach(callback) {
     let index = -1;
 
     while (++index < this.__data__.length) {
       callback.apply(null, this.__data__[index]);
     }
+  }
+}
+
+export default class Stack {
+  constructor() {
+    this.__data__ = new ListCache();
+  }
+
+  clear() {
+    this.__data__ = new ListCache();
+  }
+
+  delete(key) {
+    return this.__data__.delete(key);
+  }
+
+  get(key) {
+    return this.__data__.get(key);
+  }
+
+  has(key) {
+    return this.__data__.has(key);
+  }
+
+  set(key, value) {
+    let cache = this.__data__;
+    if (cache instanceof ListCache && cache.__data__.length == LARGE_ARRAY_SIZE) {
+      cache = this.__data__ = new MapCache(cache.__data__);
+    }
+    cache.set(key, value);
+  }
+
+  /*
+   This is not included in the lodash Stack interface
+   but is required to support all the operations of Meta.
+   */
+  forEach(callback) {
+    this.__data__.forEach(callback);
   }
 }

--- a/packages/ember-metal/lib/utils/lodash-stack.js
+++ b/packages/ember-metal/lib/utils/lodash-stack.js
@@ -1,0 +1,91 @@
+/*
+ From Lodash's private ListCache here:
+
+ https://github.com/lodash/lodash/blob/4.13.1/dist/lodash.js#L1790-L1900
+
+ The long term plan is to replace this and simply utilize lodash itself (via
+ rollup or other) in the build itself.
+
+ ***********************************************************************
+ * @license
+ * lodash <https://lodash.com/>
+ * Copyright jQuery Foundation and other contributors <https://jquery.org/>
+ * Released under MIT license <https://lodash.com/license>
+ * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
+ * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+ ***********************************************************************
+
+*/
+function assocIndexOf(array, key) {
+  var length = array.length;
+  while (length--) {
+    if (array[length][0] === key) {
+      return length;
+    }
+  }
+
+  return -1;
+}
+
+export default class ListCache {
+  constructor() {
+    this.__data__ = [];
+  }
+
+  clear() {
+    this.__data__ = [];
+  }
+
+  delete(key) {
+    let data = this.__data__;
+    let index = assocIndexOf(data, key);
+
+    if (index < 0) {
+      return false;
+    }
+    var lastIndex = data.length - 1;
+    if (index == lastIndex) {     // jshint ignore:line
+      data.pop();
+    } else {
+      data.splice(index, 1);
+    }
+
+    return true;
+  }
+
+  get(key) {
+    let data = this.__data__;
+    let index = assocIndexOf(data, key);
+
+    return index < 0 ? undefined : data[index][1];
+  }
+
+  has(key) {
+    return assocIndexOf(this.__data__, key) > -1;
+  }
+
+  set(key, value) {
+    let data = this.__data__;
+    let index = assocIndexOf(data, key);
+
+    if (index < 0) {
+      data.push([key, value]);
+    } else {
+      data[index][1] = value;
+    }
+
+    return this;
+  }
+
+  /*
+   This is not included in the lodash ListCache/Stack interface
+   but is required to support all the operations of Meta.
+   */
+  forEach(callback) {
+    let index = -1;
+
+    while (++index < this.__data__.length) {
+      callback.apply(null, this.__data__[index]);
+    }
+  }
+}

--- a/packages/ember-metal/lib/weak_map.js
+++ b/packages/ember-metal/lib/weak_map.js
@@ -58,11 +58,12 @@ WeakMap.prototype.get = function(obj) {
   if (meta) {
     let map = meta.readableWeak();
     if (map) {
-      if (map[this._id] === UNDEFINED) {
+      let value = map.get(this._id);
+      if (value === UNDEFINED) {
         return undefined;
       }
 
-      return map[this._id];
+      return value;
     }
   }
 };
@@ -82,7 +83,7 @@ WeakMap.prototype.set = function(obj, value) {
     value = UNDEFINED;
   }
 
-  metaFor(obj).writableWeak()[this._id] = value;
+  metaFor(obj).writableWeak().set(this._id, value);
 
   return this;
 };
@@ -101,7 +102,7 @@ WeakMap.prototype.has = function(obj) {
   if (meta) {
     let map = meta.readableWeak();
     if (map) {
-      return map[this._id] !== undefined;
+      return map.get(this._id) !== undefined;
     }
   }
 
@@ -115,7 +116,7 @@ WeakMap.prototype.has = function(obj) {
  */
 WeakMap.prototype.delete = function(obj) {
   if (this.has(obj)) {
-    delete metaFor(obj).writableWeak()[this._id];
+    metaFor(obj).writableWeak().delete(this._id);
     return true;
   } else {
     return false;

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -936,8 +936,8 @@ CoreObject.reopen({
     if (value instanceof ComputedProperty) {
       var cache = meta(this.constructor).readableCache();
 
-      if (cache && cache._computedProperties !== undefined) {
-        cache._computedProperties = undefined;
+      if (cache && cache.get('_computedProperties') !== undefined) {
+        cache.set('_computedProperties', undefined);
       }
     }
   }


### PR DESCRIPTION
This is a first step to making the baking store of `Meta`'s underlying data structures swappable. The first implementation is using a simple array of key value pairs, but since we are using the `set`, `get`, `has`, `delete` interface we can change the backing data store at will (or even "upgrade" at runtime).

The underlying implementation of the "lodash-stack" is mostly copied from lodash itself (with inline attribution), but in the longer term we should simply use this from lodash itself (and embed these modules from lodash-es in our build process).

/cc @krisselden @ef4 
