### PR TITLE
[FEATURE ember-testing-resume-test] Introduce resumeTest helper to complement pauseTest

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -54,3 +54,7 @@ for a detailed explanation.
 
   Expose a simple mechanism for test tooling to determine if all foreign async has been
   handled before continuing the test. Replaces the intimate API `Ember.Test.waiters` (with a deprecation).
+
+* `ember-testing-resume-test`
+
+  Introduces the `resumeTest` testing helper to complement the `pauseTest` helper.

--- a/features.json
+++ b/features.json
@@ -8,6 +8,7 @@
     "ember-string-ishtmlsafe": true,
     "ember-testing-check-waiters": true,
     "ember-metal-weakmap": null,
-    "ember-glimmer-allow-backtracking-rerender": null
+    "ember-glimmer-allow-backtracking-rerender": null,
+    "ember-testing-resume-test": null
   }
 }

--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -1,3 +1,4 @@
+import { isFeatureEnabled } from 'ember-metal';
 import {
   registerHelper as helper,
   registerAsyncHelper as asyncHelper
@@ -11,7 +12,7 @@ import fillIn from './helpers/fill_in';
 import find from './helpers/find';
 import findWithAssert from './helpers/find_with_assert';
 import keyEvent from './helpers/key_event';
-import pauseTest from './helpers/pause_test';
+import { pauseTest, resumeTest } from './helpers/pause_test';
 import triggerEvent from './helpers/trigger_event';
 import visit from './helpers/visit';
 import wait from './helpers/wait';
@@ -30,3 +31,7 @@ helper('findWithAssert', findWithAssert);
 helper('currentRouteName', currentRouteName);
 helper('currentPath', currentPath);
 helper('currentURL', currentURL);
+
+if (isFeatureEnabled('ember-testing-resume-test')) {
+  helper('resumeTest', resumeTest);
+}

--- a/packages/ember-testing/lib/helpers/pause_test.js
+++ b/packages/ember-testing/lib/helpers/pause_test.js
@@ -3,6 +3,26 @@
 @submodule ember-testing
 */
 import { RSVP } from 'ember-runtime';
+import Logger from 'ember-console';
+import {
+  assert,
+  isFeatureEnabled
+} from 'ember-metal';
+
+let resume;
+
+/**
+ Resumes a test paused by `pauseTest`.
+
+ @method resumeTest
+ @return {void}
+ @public
+*/
+export function resumeTest() {
+  assert('Testing has not been paused. There is nothing to resume.', resume);
+  resume();
+  resume = undefined;
+}
 
 /**
  Pauses the current test - this is useful for debugging while testing or for test-driving.
@@ -18,6 +38,14 @@ import { RSVP } from 'ember-runtime';
  @return {Object} A promise that will never resolve
  @public
 */
-export default function pauseTest() {
-  return new RSVP.Promise(function() { }, 'TestAdapter paused promise');
+export function pauseTest() {
+  if (isFeatureEnabled('ember-testing-resume-test')) {
+    Logger.info('Testing paused. Use `resumeTest()` to continue.');
+  }
+
+  return new RSVP.Promise((resolve) => {
+    if (isFeatureEnabled('ember-testing-resume-test')) {
+      resume = resolve;
+    }
+  }, 'TestAdapter paused promise');
 }

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -4,7 +4,10 @@ import {
   Object as EmberObject,
   RSVP
 } from 'ember-runtime';
-import { run } from 'ember-metal';
+import {
+  run,
+  isFeatureEnabled
+} from 'ember-metal';
 import { jQuery } from 'ember-views';
 import {
   Component,
@@ -811,6 +814,23 @@ QUnit.test('pauseTest pauses', function() {
 
   App.testHelpers.pauseTest();
 });
+
+if (isFeatureEnabled('ember-testing-resume-test')) {
+  QUnit.test('resumeTest resumes paused tests', function() {
+    expect(1);
+
+    let pausePromise = App.testHelpers.pauseTest();
+    setTimeout(() => App.testHelpers.resumeTest(), 0);
+
+    return pausePromise.then(() => ok(true, 'pauseTest promise was resolved'));
+  });
+
+  QUnit.test('resumeTest throws if nothing to resume', function() {
+    expect(1);
+
+    throws(() => App.testHelpers.resumeTest(), /Testing has not been paused. There is nothing to resume./);
+  });
+}
 
 QUnit.module('ember-testing routing helpers', {
   setup() {


### PR DESCRIPTION
This introduces a `resumeTest` helper to complement `pauseTest`. As discussed in https://github.com/emberjs/rfcs/issues/146.

Introduces the feature flag `ember-testing-resume-test` to gate the functionality.
