### PR TITLE
Support jQuery 3.0

### DIFF
--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -126,6 +126,9 @@ function generateOldJQueryTests() {
   testFunctions.push(function() {
     return run('jquery=1.10.2&nojshint=true');
   });
+  testFunctions.push(function() {
+    return run('jquery=2.2.4&nojshint=true');
+  });
 }
 
 function generateExtendPrototypeTests() {

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/emberjs/ember.js.git"
   },
   "dependencies": {
-    "jquery": ">=1.11.1 <3.0.0",
+    "jquery": ">=1.11.1 <4.0.0",
     "qunit": "^1.20.0",
     "qunit-phantom-runner": "jonkemp/qunit-phantomjs-runner#1.2.0"
   },

--- a/config/package_manager_files/bower.json
+++ b/config/package_manager_files/bower.json
@@ -12,6 +12,6 @@
     "url": "https://github.com/emberjs/ember.js.git"
   },
   "dependencies": {
-    "jquery": ">= 1.7.0 < 3.0.0"
+    "jquery": ">= 1.7.0 < 4.0.0"
   }
 }

--- a/config/package_manager_files/component.json
+++ b/config/package_manager_files/component.json
@@ -9,6 +9,6 @@
     "ember.debug.js"
   ],
   "dependencies": {
-    "components/jquery": ">= 1.7.0 < 3.0.0"
+    "components/jquery": ">= 1.7.0 < 4.0.0"
   }
 }

--- a/config/package_manager_files/composer.json
+++ b/config/package_manager_files/composer.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "homepage": "https://github.com/emberjs/ember.js",
   "require": {
-    "components/jquery": ">=1.7.0, < 3.0.0"
+    "components/jquery": ">=1.7.0, < 4.0.0"
   },
   "extra": {
     "component": {

--- a/config/package_manager_files/package.json
+++ b/config/package_manager_files/package.json
@@ -9,7 +9,7 @@
   ],
   "main": "./ember.debug.js",
   "dependencies": {
-    "jquery": ">=1.7.0 <3.0.0"
+    "jquery": ">=1.7.0 <4.0.0"
   },
   "jspm": {
     "main": "ember.debug",

--- a/packages/ember-views/lib/system/jquery.js
+++ b/packages/ember-views/lib/system/jquery.js
@@ -10,20 +10,24 @@ if (environment.hasDOM) {
   }
 
   if (jQuery) {
-    // http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#dndevents
-    [
-      'dragstart',
-      'drag',
-      'dragenter',
-      'dragleave',
-      'dragover',
-      'drop',
-      'dragend'
-    ].forEach(eventName => {
-      jQuery.event.fixHooks[eventName] = {
-        props: ['dataTransfer']
-      };
-    });
+    if (jQuery.event.addProp) {
+      jQuery.event.addProp('dataTransfer');
+    } else {
+      // http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#dndevents
+      [
+        'dragstart',
+        'drag',
+        'dragenter',
+        'dragleave',
+        'dragover',
+        'drop',
+        'dragend'
+      ].forEach(eventName => {
+        jQuery.event.fixHooks[eventName] = {
+          props: ['dataTransfer']
+        };
+      });
+    }
   }
 }
 

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -2106,7 +2106,7 @@ QUnit.test('Application template does not duplicate when re-rendered', function(
   // should cause application template to re-render
   handleURL('/posts');
 
-  equal(jQuery('h3:contains(I Render Once)').size(), 1);
+  equal(jQuery('h3:contains(I Render Once)').length, 1);
 });
 
 QUnit.test('Child routes should render inside the application template if the application template causes a redirect', function() {


### PR DESCRIPTION
I use `jQuery.event.addProp` instead of `jQuery.event. fixHooks` to work with jQuery 3.
It seems that `addProp` is introduced by https://github.com/jquery/jquery/commit/e61fccb9d736235b4b011f89cba6866bc0b8997d instead of `fixHooks`.

It has no ability to extend individual event.
However, what extending `jQuery.Event` in globally has no bad effect as far as I know.

Close https://github.com/emberjs/ember.js/issues/13661
