### PR TITLE
[Glimmer 2] Remove support for "fake proxies" (isTruthy)

### DIFF
--- a/packages/ember-glimmer/lib/utils/references.js
+++ b/packages/ember-glimmer/lib/utils/references.js
@@ -85,7 +85,11 @@ class PropertyReference extends CachedReference { // jshint ignore:line
 
     let parentValue = _parentReference.value();
 
-    _parentObjectTag.update(tagFor(parentValue));
+    if (isProxy(parentValue)) {
+      _parentObjectTag.update(VOLATILE_TAG);
+    } else {
+      _parentObjectTag.update(tagFor(parentValue));
+    }
 
     if (parentValue && typeof parentValue === 'object') {
       if (isEnabled('mandatory-setter')) {

--- a/packages/ember-glimmer/lib/utils/references.js
+++ b/packages/ember-glimmer/lib/utils/references.js
@@ -10,18 +10,9 @@ import { dasherize } from 'ember-runtime/system/string';
 import { meta as metaFor } from 'ember-metal/meta';
 import { watchKey } from 'ember-metal/watch_key';
 import isEnabled from 'ember-metal/features';
-export const UPDATE = symbol('UPDATE');
+import { isProxy } from 'ember-runtime/mixins/-proxy';
 
-// FIXME: fix tests that uses a "fake" proxy (i.e. a POJOs that "happen" to
-// have an `isTruthy` property on them). This is not actually supported –
-// we should fix the tests to use an actual proxy. When that's done, we should
-// remove this and use the real `isProxy` from `ember-metal`.
-//
-// import { isProxy } from 'ember-metal/-proxy';
-//
-function isProxy(obj) {
-  return (obj && typeof obj === 'object' && 'isTruthy' in obj);
-}
+export const UPDATE = symbol('UPDATE');
 
 // @implements PathReference
 export class PrimitiveReference extends ConstReference {
@@ -164,11 +155,11 @@ export class ConditionalReference extends GlimmerConditionalReference {
   toBool(predicate) {
     if (isProxy(predicate)) {
       this.objectTag.update(VOLATILE_TAG);
+      return get(predicate, 'isTruthy');
     } else {
       this.objectTag.update(tagFor(predicate));
+      return emberToBool(predicate);
     }
-
-    return emberToBool(predicate);
   }
 }
 

--- a/packages/ember-glimmer/lib/utils/to-bool.js
+++ b/packages/ember-glimmer/lib/utils/to-bool.js
@@ -10,14 +10,6 @@ export default function toBool(predicate) {
     return true;
   }
 
-  if (typeof predicate === 'object') {
-    let isTruthy = get(predicate, 'isTruthy');
-
-    if (typeof isTruthy === 'boolean') {
-      return isTruthy;
-    }
-  }
-
   if (isArray(predicate)) {
     return get(predicate, 'length') !== 0;
   }

--- a/packages/ember-glimmer/tests/integration/syntax/with-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/with-test.js
@@ -4,6 +4,7 @@ import { A as emberA } from 'ember-runtime/system/native_array';
 import { moduleFor, RenderingTest } from '../../utils/test-case';
 import { TogglingSyntaxConditionalsTest } from '../../utils/shared-conditional-tests';
 import { strip } from '../../utils/abstract-test-case';
+import ObjectProxy from 'ember-runtime/system/object_proxy';
 
 moduleFor('Syntax test: {{#with}}', class extends TogglingSyntaxConditionalsTest {
 
@@ -152,8 +153,8 @@ moduleFor('Syntax test: {{#with as}}', class extends TogglingSyntaxConditionalsT
   }
 
   ['@test can access alias of a proxy']() {
-    this.render(`{{#with proxyThing as |person|}}{{person.name}}{{/with}}`, {
-      proxyThing: { isTruthy: true, name: 'Tom Dale' }
+    this.render(`{{#with proxy as |person|}}{{person.name}}{{/with}}`, {
+      proxy: ObjectProxy.create({ content: { name: 'Tom Dale' } })
     });
 
     this.assertText('Tom Dale');
@@ -162,19 +163,23 @@ moduleFor('Syntax test: {{#with as}}', class extends TogglingSyntaxConditionalsT
 
     this.assertText('Tom Dale');
 
-    this.runTask(() => set(this.context, 'proxyThing.name', 'Yehuda Katz'));
+    this.runTask(() => set(this.context, 'proxy.name', 'Yehuda Katz'));
 
     this.assertText('Yehuda Katz');
 
-    this.runTask(() => set(this.context, 'proxyThing.isTruthy', false));
+    this.runTask(() => set(this.context, 'proxy.content', { name: 'Godfrey Chan' }));
+
+    this.assertText('Godfrey Chan');
+
+    this.runTask(() => set(this.context, 'proxy.content.name', 'Stefan Penner'));
+
+    this.assertText('Stefan Penner');
+
+    this.runTask(() => set(this.context, 'proxy.content', null));
 
     this.assertText('');
 
-    this.runTask(() => set(this.context, 'proxyThing.name', 'Godfrey Chan'));
-
-    this.assertText('');
-
-    this.runTask(() => set(this.context, 'proxyThing', { isTruthy: true, name: 'Tom Dale' }));
+    this.runTask(() => set(this.context, 'proxy', ObjectProxy.create({ content: { name: 'Tom Dale' } })));
 
     this.assertText('Tom Dale');
   }


### PR DESCRIPTION
Cleaned up #13441

Previously, the code checks for an `isTruthy` property on _any_ kind of objects, even though this features was only added originally to support proxy objects. This commit remove that generic check in favor of a proxy brand check.
