### PR TITLE
[BUGFIX] Remove code for IE <9

### DIFF
--- a/packages/ember-views/tests/system/jquery_ext_test.js
+++ b/packages/ember-views/tests/system/jquery_ext_test.js
@@ -6,23 +6,14 @@ import View from 'ember-views/views/view';
 var view, dispatcher;
 
 // Adapted from https://github.com/jquery/jquery/blob/f30f7732e7775b6e417c4c22ced7adb2bf76bf89/test/data/testinit.js
-var canDataTransfer, fireNativeWithDataTransfer;
 
-if (document.createEvent) {
-  canDataTransfer = !!document.createEvent('HTMLEvents').dataTransfer;
-  fireNativeWithDataTransfer = function(node, type, dataTransfer) {
-    var event = document.createEvent('HTMLEvents');
-    event.initEvent(type, true, true);
-    event.dataTransfer = dataTransfer;
-    node.dispatchEvent(event);
-  };
-} else {
-  canDataTransfer = !!document.createEventObject().dataTransfer;
-  fireNativeWithDataTransfer = function(node, type, dataTransfer) {
-    var event = document.createEventObject();
-    event.dataTransfer = dataTransfer;
-    node.fireEvent('on' + type, event);
-  };
+var canDataTransfer = !!document.createEvent('HTMLEvents').dataTransfer;
+
+function fireNativeWithDataTransfer(node, type, dataTransfer) {
+  var event = document.createEvent('HTMLEvents');
+  event.initEvent(type, true, true);
+  event.dataTransfer = dataTransfer;
+  node.dispatchEvent(event);
 }
 
 QUnit.module('EventDispatcher - jQuery integration', {


### PR DESCRIPTION
`document.createEventObject()` is an API for legacy IE.
It is deprecated since IE 9 and `document.createEvent()` (that is a DOM Level 3 standard API) is supported.

ref: https://msdn.microsoft.com/en-us//library/ff986080(v=vs.85).aspx
