### PR TITLE
[Glimmer 2] Implement mut and readonly helpers

### DIFF
--- a/packages/ember-glimmer-template-compiler/lib/plugins/transform-attrs-into-props.js
+++ b/packages/ember-glimmer-template-compiler/lib/plugins/transform-attrs-into-props.js
@@ -1,0 +1,47 @@
+/**
+ @module ember
+ @submodule ember-glimmer
+*/
+
+/**
+  A Glimmer2 AST transformation that replaces all instances of
+
+  ```handlebars
+ {{attrs.foo.bar}}
+  ```
+
+  to
+
+  ```handlebars
+ {{foo.bar}}
+  ```
+
+  as well as `{{#if attrs.foo}}`, `{{deeply (nested attrs.foobar.baz)}}` etc
+
+  @private
+  @class TransformAttrsToProps
+*/
+
+export default function TransformAttrsToProps() {
+  // set later within Glimmer2 to the syntax package
+  this.syntax = null;
+}
+
+/**
+  @private
+  @method transform
+  @param {AST} ast The AST to be transformed.
+*/
+TransformAttrsToProps.prototype.transform = function TransformAttrsToProps_transform(ast) {
+  let { traverse, builders: b } = this.syntax;
+
+  traverse(ast, {
+    PathExpression(node) {
+      if (node.parts[0] === 'attrs') {
+        return b.path(node.original.substr(6));
+      }
+    }
+  });
+
+  return ast;
+};

--- a/packages/ember-glimmer-template-compiler/lib/system/compile-options.js
+++ b/packages/ember-glimmer-template-compiler/lib/system/compile-options.js
@@ -1,15 +1,17 @@
 import defaultPlugins from 'ember-template-compiler/plugins';
-import TransformHasBlockSyntax from '../plugins/transform-has-block-syntax';
 import TransformActionSyntax from '../plugins/transform-action-syntax';
+import TransformAttrsIntoProps from '../plugins/transform-attrs-into-props';
 import TransformEachInIntoEach from '../plugins/transform-each-in-into-each';
+import TransformHasBlockSyntax from '../plugins/transform-has-block-syntax';
 import assign from 'ember-metal/assign';
 
 export const PLUGINS = [
   ...defaultPlugins,
   // the following are ember-glimmer specific
-  TransformHasBlockSyntax,
   TransformActionSyntax,
-  TransformEachInIntoEach
+  TransformAttrsIntoProps,
+  TransformEachInIntoEach,
+  TransformHasBlockSyntax
 ];
 
 let USER_PLUGINS = [];

--- a/packages/ember-glimmer/lib/component.js
+++ b/packages/ember-glimmer/lib/component.js
@@ -7,9 +7,17 @@ import AriaRoleSupport from 'ember-views/mixins/aria_role_support';
 import ViewMixin from 'ember-views/mixins/view_support';
 import EmberView from 'ember-views/views/view';
 import symbol from 'ember-metal/symbol';
+import EmptyObject from 'ember-metal/empty_object';
 import { get } from 'ember-metal/property_get';
 import { PROPERTY_DID_CHANGE } from 'ember-metal/property_events';
-import { UPDATE } from './utils/references';
+import {
+  UPDATE,
+  TO_ROOT_REFERENCE,
+  REFERENCE_FOR_KEY,
+  RootReference,
+  PropertyReference
+} from './utils/references';
+import { isReadonly } from './helpers/readonly';
 import { DirtyableTag } from 'glimmer-reference';
 import { assert, deprecate } from 'ember-metal/debug';
 import { NAME_KEY } from 'ember-metal/mixin';
@@ -17,6 +25,8 @@ import { getOwner } from 'container/owner';
 
 export const DIRTY_TAG = symbol('DIRTY_TAG');
 export const ARGS = symbol('ARGS');
+export const ROOT_REF = symbol('ROOT_REF');
+export const REFS = symbol('REFS');
 export const IS_DISPATCHING_ATTRS = symbol('IS_DISPATCHING_ATTRS');
 export const HAS_BLOCK = symbol('HAS_BLOCK');
 
@@ -35,6 +45,8 @@ const Component = CoreView.extend(
       this._super(...arguments);
       this._viewRegistry = this._viewRegistry || EmberView.views;
       this[DIRTY_TAG] = new DirtyableTag();
+      this[ROOT_REF] = null;
+      this[REFS] = new EmptyObject();
 
       // If a `defaultLayout` was specified move it to the `layout` prop.
       // `layout` is no longer a CP, so this just ensures that the `defaultLayout`
@@ -88,19 +100,65 @@ const Component = CoreView.extend(
       let args, reference;
 
       if ((args = this[ARGS]) && (reference = args[key])) {
+        let value = get(this, key);
+
         if (reference[UPDATE]) {
-          reference[UPDATE](get(this, key));
-        } else {
+          reference[UPDATE](value);
+        } else if (!isReadonly(reference)) {
           let name = this._debugContainerKey.split(':')[1];
-          let value = get(this, key);
+
           throw new Error(strip`
-Cannot set the \`${key}\` property (on component ${name}) to
-\`${value}\`. The \`${key}\` property came from an immutable
-binding in the template, such as {{${name} ${key}="string"}}
-or {{${name} ${key}=(if theTruth "truth" "false")}}.
+            Cannot set the \`${key}\` property (on component ${name}) to
+            \`${value}\`. The \`${key}\` property came from an immutable
+            binding in the template, such as {{${name} ${key}="string"}}
+            or {{${name} ${key}=(if theTruth "truth" "false")}}.
           `);
         }
       }
+    },
+
+    [TO_ROOT_REFERENCE]() {
+      let ref = this[ROOT_REF];
+
+      if (!ref) {
+        ref = this[ROOT_REF] = new RootReference(this);
+      }
+
+      return ref;
+    },
+
+    [REFERENCE_FOR_KEY](key) {
+      let refs = this[REFS];
+      let ref = refs[key];
+
+      if (ref) {
+        return ref;
+      }
+
+      let args = this[ARGS];
+      ref = args && args[key];
+
+      if (!ref || isReadonly(ref)) {
+        return refs[key] = new PropertyReference(this[TO_ROOT_REFERENCE](), key);
+      }
+
+      let { concatenatedProperties } = this;
+
+      if (concatenatedProperties &&
+          concatenatedProperties.length > 0 &&
+          concatenatedProperties.indexOf(key) >= 0) {
+        return refs[key] = new PropertyReference(this[TO_ROOT_REFERENCE](), key);
+      }
+
+      let { mergedProperties } = this;
+
+      if (mergedProperties &&
+          mergedProperties.length > 0 &&
+          mergedProperties.indexOf(key) >= 0) {
+        return refs[key] = new PropertyReference(this[TO_ROOT_REFERENCE](), key);
+      }
+
+      return refs[key] = ref;
     }
   }
 );

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -11,23 +11,23 @@ import { OutletSyntax } from './syntax/outlet';
 import lookupComponent from 'ember-views/utils/lookup-component';
 import createIterable from './utils/iterable';
 import {
-  RootReference,
   ConditionalReference,
   SimpleHelperReference,
   ClassBasedHelperReference
 } from './utils/references';
 
-import { default as concat } from './helpers/concat';
 import {
   inlineIf,
   inlineUnless
 } from './helpers/if-unless';
 
 import { default as action } from './helpers/action';
+import { default as concat } from './helpers/concat';
 import { default as get } from './helpers/get';
 import { default as hash } from './helpers/hash';
 import { default as loc } from './helpers/loc';
 import { default as log } from './helpers/log';
+import { default as mut } from './helpers/mut';
 import { default as readonly } from './helpers/readonly';
 import { default as unbound } from './helpers/unbound';
 import { default as classHelper } from './helpers/-class';
@@ -40,17 +40,18 @@ const builtInComponents = {
 };
 
 const builtInHelpers = {
-  concat,
   if: inlineIf,
-  unless: inlineUnless,
   action,
+  concat,
   get,
   hash,
   loc,
   log,
+  mut,
+  'query-params': queryParams,
   readonly,
   unbound,
-  'query-params': queryParams,
+  unless: inlineUnless,
   '-class': classHelper,
   '-each-in': eachIn
 };
@@ -232,10 +233,6 @@ export default class Environment extends GlimmerEnvironment {
     } else {
       throw new Error(`${name} is not a modifier`);
     }
-  }
-
-  rootReferenceFor(value) {
-    return new RootReference(value);
   }
 
   toConditionalReference(reference) {

--- a/packages/ember-glimmer/lib/helpers/action.js
+++ b/packages/ember-glimmer/lib/helpers/action.js
@@ -1,9 +1,12 @@
 import { CachedReference } from '../utils/references';
-import { NULL_REFERENCE, UNDEFINED_REFERENCE } from 'glimmer-runtime';
 import EmberError from 'ember-metal/error';
+import symbol from 'ember-metal/symbol';
 import run from 'ember-metal/run_loop';
 import { get } from 'ember-metal/property_get';
 import { flaggedInstrument } from 'ember-metal/instrumentation';
+import isNone from 'ember-metal/is_none';
+
+export const INVOKE = symbol('INVOKE');
 
 export class ClosureActionReference extends CachedReference {
   static create(args) {
@@ -23,6 +26,7 @@ export class ClosureActionReference extends CachedReference {
     let positionalValues = positional.value();
 
     let target = positionalValues[0];
+    let rawActionRef = positional.at(1);
     let rawAction = positionalValues[1];
 
     // The first two argument slots are reserved.
@@ -31,15 +35,18 @@ export class ClosureActionReference extends CachedReference {
     // Anything else is an action argument.
     let actionArgs = positionalValues.slice(2);
 
-    // TODO: Check if rawAction is INVOKE-able or (mut)
-
     // on-change={{action setName}}
     // element-space actions look to "controller" then target. Here we only
     // look to "target".
     let actionType = typeof rawAction;
     let action = rawAction;
 
-    if (actionType === 'string') {
+    if (isNone(rawAction)) {
+      throw new EmberError(`Action passed is null or undefined in (action) from ${target}.`);
+    } else if (rawActionRef[INVOKE]) {
+      target = rawActionRef;
+      action = rawActionRef[INVOKE];
+    } else if (actionType === 'string') {
       // on-change={{action 'setName'}}
       let actionName = rawAction;
 
@@ -57,14 +64,15 @@ export class ClosureActionReference extends CachedReference {
       if (!action) {
         throw new EmberError(`An action named '${actionName}' was not found in ${target}`);
       }
+    } else if (action && typeof action[INVOKE] === 'function') {
+      target = action;
+      action = action[INVOKE];
     } else if (actionType !== 'function') {
-      throw new EmberError(`An action could not be made for \`${rawAction}\` in ${target}. Please confirm that you are using either a quoted action name (i.e. \`(action '${rawAction}')\`) or a function available in ${target}.`);
+      // TODO: Is there a better way of doing this?
+      let rawActionLabel = rawActionRef._propertyKey || rawAction;
+      throw new EmberError(`An action could not be made for \`${rawActionLabel}\` in ${target}. Please confirm that you are using either a quoted action name (i.e. \`(action '${rawActionLabel}')\`) or a function available in ${target}.`);
     }
 
-    // TODO: Handle INVOKE explicitly here.
-
-    // <button on-keypress={{action (mut name) value="which"}}
-    // on-keypress is not even an Ember feature yet
     let valuePath = named.get('value').value();
 
     return createClosureAction(target, action, valuePath, actionArgs);
@@ -75,12 +83,6 @@ export default {
   isInternalHelper: true,
 
   toReference(args) {
-    let rawActionRef = args.positional.at(1);
-
-    if (rawActionRef === UNDEFINED_REFERENCE || rawActionRef === NULL_REFERENCE) {
-      throw new Error(`Action passed is null or undefined in (action) from ${args.positional.at(0).value()}.`);
-    }
-
     return ClosureActionReference.create(args);
   }
 };

--- a/packages/ember-glimmer/lib/helpers/mut.js
+++ b/packages/ember-glimmer/lib/helpers/mut.js
@@ -1,0 +1,101 @@
+import symbol from 'ember-metal/symbol';
+import { assert } from 'ember-metal/debug';
+import { UPDATE } from '../utils/references';
+import { INVOKE } from './action';
+
+/**
+  The `mut` helper lets you __clearly specify__ that a child `Component` can update the
+  (mutable) value passed to it, which will __change the value of the parent component__.
+
+  This is very helpful for passing mutable values to a `Component` of any size, but
+  critical to understanding the logic of a large/complex `Component`.
+
+  To specify that a parameter is mutable, when invoking the child `Component`:
+
+  ```handlebars
+  {{my-child childClickCount=(mut totalClicks)}}
+  ```
+
+  The child `Component` can then modify the parent's value as needed:
+
+  ```javascript
+  // my-child.js
+  export default Component.extend({
+    click() {
+      this.get('childClickCount').update(this.get('childClickCount').value + 1);
+    }
+  });
+  ```
+
+  Additionally, the `mut` helper can be combined with the `action` helper to
+  mutate a value. For example:
+
+  ```handlebars
+  {{my-child childClickCount=totalClicks click-count-change=(action (mut totalClicks))}}
+  ```
+
+  The child `Component` would invoke the action with the new click value:
+
+  ```javascript
+  // my-child.js
+  export default Component.extend({
+    click() {
+      this.get('clickCountChange')(this.get('childClickCount') + 1);
+    }
+  });
+  ```
+
+  The `mut` helper changes the `totalClicks` value to what was provided as the action argument.
+
+  See a [2.0 blog post](http://emberjs.com/blog/2015/05/10/run-up-to-two-oh.html#toc_the-code-mut-code-helper) for
+  additional information on using `{{mut}}`.
+
+  @method mut
+  @param {Object} [attr] the "two-way" attribute that can be modified.
+  @for Ember.Templates.helpers
+  @public
+*/
+const MUT_REFERENCE = symbol('MUT');
+const SOURCE = symbol('SOURCE');
+
+export function isMut(ref) {
+  return ref && ref[MUT_REFERENCE];
+}
+
+export function unMut(ref) {
+  return ref[SOURCE] || ref;
+}
+
+export default {
+  isInternalHelper: true,
+
+  toReference(args) {
+    let rawRef = args.positional.at(0);
+
+    if (isMut(rawRef)) {
+      return rawRef;
+    }
+
+    // TODO: Improve this error message. This covers at least two distinct
+    // cases:
+    //
+    // 1. (mut "not a path") – passing a literal, result from a helper
+    //    invocation, etc
+    //
+    // 2. (mut receivedValue) – passing a value received from the caller
+    //    that was originally derived from a literal, result from a helper
+    //    invocation, etc
+    //
+    // This message is alright for the first case, but could be quite
+    // confusing for the second case.
+    assert('You can only pass a path to mut', rawRef[UPDATE]);
+
+    let wrappedRef = Object.create(rawRef);
+
+    wrappedRef[SOURCE] = rawRef;
+    wrappedRef[INVOKE] = rawRef[UPDATE];
+    wrappedRef[MUT_REFERENCE] = true;
+
+    return wrappedRef;
+  }
+};

--- a/packages/ember-glimmer/lib/helpers/readonly.js
+++ b/packages/ember-glimmer/lib/helpers/readonly.js
@@ -1,7 +1,24 @@
-import { helper } from '../helper';
+import symbol from 'ember-metal/symbol';
+import { UPDATE } from '../utils/references';
+import { unMut } from './mut';
 
-function readonly(args) {
-  return args[0];
+const READONLY_REFERENCE = symbol('READONLY');
+
+export function isReadonly(ref) {
+  return ref && ref[READONLY_REFERENCE];
 }
 
-export default helper(readonly);
+export default {
+  isInternalHelper: true,
+
+  toReference(args) {
+    let ref = unMut(args.positional.at(0));
+
+    let wrapped = Object.create(ref);
+
+    wrapped[READONLY_REFERENCE] = true;
+    wrapped[UPDATE] = undefined;
+
+    return wrapped;
+  }
+};

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -1,5 +1,5 @@
 import { StatementSyntax, ValueReference } from 'glimmer-runtime';
-import { AttributeBindingReference, RootReference, applyClassNameBinding } from '../utils/references';
+import { TO_ROOT_REFERENCE, AttributeBindingReference, applyClassNameBinding } from '../utils/references';
 import { DIRTY_TAG, IS_DISPATCHING_ATTRS, HAS_BLOCK } from '../component';
 import { assert } from 'ember-metal/debug';
 import processArgs from '../utils/process-args';
@@ -89,7 +89,7 @@ class CurlyComponentManager {
       bucket.classRef = args.named.get('class');
     }
 
-    assert('classNameBindings must not have spaces in them', (() => {
+    assert(`classNameBindings must not have spaces in them: ${component.toString()}`, (() => {
       let { classNameBindings } = component;
       for (let i = 0; i < classNameBindings.length; i++) {
         let binding = classNameBindings[i];
@@ -150,7 +150,7 @@ class CurlyComponentManager {
   }
 
   getSelf({ component }) {
-    return new RootReference(component);
+    return component[TO_ROOT_REFERENCE]();
   }
 
   didCreateElement({ component, classRef }, element, operations) {

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -89,7 +89,7 @@ class CurlyComponentManager {
       bucket.classRef = args.named.get('class');
     }
 
-    assert('classNameBindings must not have spaces in them', () => {
+    assert('classNameBindings must not have spaces in them', (() => {
       let { classNameBindings } = component;
       for (let i = 0; i < classNameBindings.length; i++) {
         let binding = classNameBindings[i];
@@ -98,22 +98,22 @@ class CurlyComponentManager {
         }
       }
       return true;
-    });
+    })());
 
-    assert('You cannot use `classNameBindings` on a tag-less component: ' + component.toString(), () => {
+    assert('You cannot use `classNameBindings` on a tag-less component: ' + component.toString(), (() => {
       let { classNameBindings, tagName } = component;
-      return tagName || !classNameBindings || classNameBindings.length === 0;
-    });
+      return tagName !== '' || !classNameBindings || classNameBindings.length === 0;
+    })());
 
-    assert('You cannot use `elementId` on a tag-less component: ' + component.toString(), () => {
+    assert('You cannot use `elementId` on a tag-less component: ' + component.toString(), (() => {
       let { elementId, tagName } = component;
-      return tagName || (!elementId && elementId !== '');
-    });
+      return tagName !== '' || (!elementId && elementId !== '');
+    })());
 
-    assert('You cannot use `attributeBindings` on a tag-less component: ' + component.toString(), () => {
+    assert('You cannot use `attributeBindings` on a tag-less component: ' + component.toString(), (() => {
       let { attributeBindings, tagName } = component;
-      return tagName || !attributeBindings || attributeBindings.length === 0;
-    });
+      return tagName !== '' || !attributeBindings || attributeBindings.length === 0;
+    })());
 
     return bucket;
   }
@@ -158,7 +158,7 @@ class CurlyComponentManager {
 
     let { attributeBindings, classNames, classNameBindings } = component;
 
-    if (attributeBindings) {
+    if (attributeBindings && attributeBindings.length) {
       applyAttributeBindings(attributeBindings, component, operations);
     }
 
@@ -166,13 +166,13 @@ class CurlyComponentManager {
       operations.addAttribute('class', classRef);
     }
 
-    if (classNames) {
+    if (classNames && classNames.length) {
       classNames.forEach(name => {
         operations.addAttribute('class', new ValueReference(name));
       });
     }
 
-    if (classNameBindings) {
+    if (classNameBindings && classNameBindings.length) {
       classNameBindings.forEach(binding => {
         applyClassNameBinding(component, binding, operations);
       });
@@ -240,6 +240,10 @@ function elementId(vm) {
   return new ValueReference(component.elementId);
 }
 
+function ariaRole(vm) {
+  return vm.getSelf().get('ariaRole');
+}
+
 export class CurlyComponentDefinition extends ComponentDefinition {
   constructor(name, ComponentClass, template) {
     super(name, MANAGER, ComponentClass || Component);
@@ -251,6 +255,7 @@ export class CurlyComponentDefinition extends ComponentDefinition {
     builder.wrapLayout(this.template.asLayout());
     builder.tag.dynamic(tagName);
     builder.attrs.dynamic('id', elementId);
+    builder.attrs.dynamic('role', ariaRole);
     builder.attrs.static('class', 'ember-view');
   }
 

--- a/packages/ember-glimmer/lib/utils/process-args.js
+++ b/packages/ember-glimmer/lib/utils/process-args.js
@@ -3,7 +3,6 @@ import symbol from 'ember-metal/symbol';
 import { assert } from 'ember-metal/debug';
 import EmptyObject from 'ember-metal/empty_object';
 import { ARGS } from '../component';
-import { isMut } from '../helpers/mut';
 import { UPDATE } from './references';
 
 export default function processArgs(args, positionalParamsDefinition) {
@@ -53,7 +52,7 @@ class SimpleArgs {
       let ref = namedArgs.get(name);
       let value = attrs[name];
 
-      if (isMut(ref)) {
+      if (ref[UPDATE]) {
         attrs[name] = new MutableCell(ref, value);
       }
 

--- a/packages/ember-glimmer/lib/utils/references.js
+++ b/packages/ember-glimmer/lib/utils/references.js
@@ -407,6 +407,4 @@ export class UnboundReference {
   get(key) {
     return new UnboundReference(this, key);
   }
-
-  destroy() {}
 }

--- a/packages/ember-glimmer/tests/integration/components/attribute-bindings-test.js
+++ b/packages/ember-glimmer/tests/integration/components/attribute-bindings-test.js
@@ -442,7 +442,6 @@ moduleFor('Attribute bindings integration', class extends RenderingTest {
 
   ['@test asserts if an attributeBinding is setup on class']() {
     let FooBarComponent = Component.extend({
-      tagName: 'div',
       attributeBindings: ['class']
     });
 

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -2127,11 +2127,11 @@ moduleFor('Components test: curly components', class extends RenderingTest {
 
     this.assertText('blarkporybaz- Click Me');
 
-    // Errors here cause `blahzz` has become just `baz` and `Don't know how to
-    // {{#each baz}}`
-    // this.runTask(() => this.rerender());
+    if (this.isGlimmer) {
+      this.runTask(() => this.rerender());
 
-    // this.assertText('blarkporybaz- Click Me');
+      this.assertText('blarkporybaz- Click Me');
+    }
   }
 
   ['@glimmer cannot set an immutable argument']() {

--- a/packages/ember-glimmer/tests/integration/components/dynamic-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/dynamic-components-test.js
@@ -508,12 +508,12 @@ moduleFor('Components test: dynamic components', class extends RenderingTest {
 
   ['@test component helper properly invalidates hash params inside an {{each}} invocation #11044'](assert) {
     this.registerComponent('foo-bar', {
-      template: '[{{internalName}} - {{attrs.name}}]',
+      template: '[{{internalName}} - {{name}}]',
       ComponentClass: Component.extend({
         willRender() {
           // store internally available name to ensure that the name available in `this.attrs.name`
           // matches the template lookup name
-          set(this, 'internalName', this.attrs.name);
+          set(this, 'internalName', this.get('name'));
         }
       })
     });

--- a/packages/ember-glimmer/tests/integration/components/fragment-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/fragment-components-test.js
@@ -1,7 +1,7 @@
 import { moduleFor, RenderingTest } from '../../utils/test-case';
 import { strip } from '../../utils/abstract-test-case';
+import { Component } from '../../utils/helpers';
 import { set } from 'ember-metal/property_set';
-import Component from 'ember-htmlbars/component';
 
 moduleFor('Components test: fragment components', class extends RenderingTest {
   getCustomDispatcherEvents() {

--- a/packages/ember-glimmer/tests/integration/helpers/element-action-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/element-action-test.js
@@ -1219,7 +1219,6 @@ moduleFor('Helpers test: element action', class extends RenderingTest {
 
   ['@test a quoteless parameter that does not resolve to a value asserts']() {
     let ExampleComponent = Component.extend({
-      tagName: 'div',
       actions: {
         ohNoeNotValid() {}
       }

--- a/packages/ember-glimmer/tests/integration/helpers/mut-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/mut-test.js
@@ -340,7 +340,40 @@ moduleFor('Helpers test: {{mut}}', class extends RenderingTest {
     this.assertText('12');
   }
 
-  ['@htmlbars automatic mutable bindings tolerate undefined non-stream inputs and attempts to set them']() {
+  ['@test automatic mutable bindings exposes a mut cell in attrs']() {
+    let inner;
+
+    this.registerComponent('x-inner', {
+      ComponentClass: Component.extend({
+        didInsertElement() {
+          inner = this;
+        }
+      }),
+      template: '{{foo}}'
+    });
+
+    this.registerComponent('x-outer', {
+      template: '{{x-inner foo=bar}}'
+    });
+
+    this.render('{{x-outer bar=baz}}', { baz: 'foo' });
+
+    this.assertText('foo');
+
+    this.assertStableRerender();
+
+    this.runTask(() => inner.attrs.foo.update('bar'));
+
+    this.assert.equal(inner.attrs.foo.value, 'bar');
+    this.assert.equal(get(inner, 'foo'), 'bar');
+    this.assertText('bar');
+
+    this.runTask(() => inner.attrs.foo.update('foo'));
+
+    this.assertText('foo');
+  }
+
+  ['@test automatic mutable bindings tolerate undefined non-stream inputs and attempts to set them']() {
     let inner;
 
     this.registerComponent('x-inner', {
@@ -373,6 +406,8 @@ moduleFor('Helpers test: {{mut}}', class extends RenderingTest {
     this.assertText('');
   }
 
+  // TODO: This is not really consistent with how the rest of the system works. Investigate if we need to
+  // support this, if not then this test can be deleted.
   ['@htmlbars automatic mutable bindings tolerate constant non-stream inputs and attempts to set them']() {
     let inner;
 

--- a/packages/ember-glimmer/tests/integration/helpers/mut-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/mut-test.js
@@ -1,13 +1,13 @@
-import { RenderingTest, moduleFor } from '../utils/test-case';
-import { Component } from '../utils/helpers';
+import { RenderingTest, moduleFor } from '../../utils/test-case';
+import { Component } from '../../utils/helpers';
 import { set } from 'ember-metal/property_set';
 import { get } from 'ember-metal/property_get';
 import { computed } from 'ember-metal/computed';
-import { styles } from '../utils/test-helpers';
+import { styles } from '../../utils/test-helpers';
 
-moduleFor('@htmlbars Mutable bindings integration tests', class extends RenderingTest {
+moduleFor('Helpers test: {{mut}}', class extends RenderingTest {
 
-  ['@test a simple mutable binding using `mut` propagates properly'](assert) {
+  ['@test a simple mutable binding using `mut` propagates properly']() {
     let bottom;
 
     this.registerComponent('bottom-mut', {
@@ -33,16 +33,25 @@ moduleFor('@htmlbars Mutable bindings integration tests', class extends Renderin
 
     this.runTask(() => bottom.attrs.setMe.update(13));
 
-    this.assertText('13', 'The set took effect');
-    assert.strictEqual(get(this.context, 'val'), 13, 'the set propagated back up');
+    this.assertText('13', 'the set took effect');
+    this.assert.strictEqual(get(bottom, 'setMe'), 13, 'the set took effect on bottom\'s prop');
+    this.assert.strictEqual(bottom.attrs.setMe.value, 13, 'the set took effect on bottom\'s attr');
+    this.assert.strictEqual(get(this.context, 'val'), 13, 'the set propagated back up');
+
+    this.runTask(() => set(bottom, 'setMe', 14));
+
+    this.assertText('14', 'the set took effect');
+    this.assert.strictEqual(get(bottom, 'setMe'), 14, 'the set took effect on bottom\'s prop');
+    this.assert.strictEqual(bottom.attrs.setMe.value, 14, 'the set took effect on bottom\'s attr');
+    this.assert.strictEqual(get(this.context, 'val'), 14, 'the set propagated back up');
 
     this.runTask(() => set(this.context, 'val', 12));
 
     this.assertText('12');
   }
 
-  ['@test a simple mutable binding using `mut` inserts into the DOM'](assert) {
-    let bottom;
+  ['@test a simple mutable binding using `mut` inserts into the DOM']() {
+    let bottom, middle;
 
     this.registerComponent('bottom-mut', {
       ComponentClass: Component.extend({
@@ -54,6 +63,11 @@ moduleFor('@htmlbars Mutable bindings integration tests', class extends Renderin
     });
 
     this.registerComponent('middle-mut', {
+      ComponentClass: Component.extend({
+        didInsertElement() {
+          middle = this;
+        }
+      }),
       template: '{{bottom-mut setMe=(mut value)}}'
     });
 
@@ -68,15 +82,64 @@ moduleFor('@htmlbars Mutable bindings integration tests', class extends Renderin
     this.runTask(() => bottom.attrs.setMe.update(13));
 
     this.assertText('13', 'the set took effect');
-    assert.strictEqual(get(this.context, 'val'), 13, 'the set propagated back up');
+    this.assert.strictEqual(get(bottom, 'setMe'), 13, 'the set took effect on bottom\'s prop');
+    this.assert.strictEqual(bottom.attrs.setMe.value, 13, 'the set took effect on bottom\'s attr');
+    this.assert.strictEqual(get(middle, 'value'), 13, 'the set propagated to middle\'s prop');
+    this.assert.strictEqual(middle.attrs.value.value, 13, 'the set propagated to middle\'s attr');
+    this.assert.strictEqual(get(this.context, 'val'), 13, 'the set propagated back up');
+
+    this.runTask(() => set(bottom, 'setMe', 14));
+
+    this.assertText('14', 'the set took effect');
+    this.assert.strictEqual(get(bottom, 'setMe'), 14, 'the set took effect on bottom\'s prop');
+    this.assert.strictEqual(bottom.attrs.setMe.value, 14, 'the set took effect on bottom\'s attr');
+    this.assert.strictEqual(get(middle, 'value'), 14, 'the set propagated to middle\'s prop');
+    this.assert.strictEqual(middle.attrs.value.value, 14, 'the set propagated to middle\'s attr');
+    this.assert.strictEqual(get(this.context, 'val'), 14, 'the set propagated back up');
 
     this.runTask(() => set(this.context, 'val', 12));
 
     this.assertText('12');
   }
 
+  ['@test passing a literal results in a assertion']() {
+    this.registerComponent('bottom-mut', { template: '{{setMe}}' });
+
+    expectAssertion(() => {
+      this.render('{{bottom-mut setMe=(mut "foo bar")}}');
+    }, 'You can only pass a path to mut');
+  }
+
+  ['@glimmer passing the result of a helper invocation results in an assertion']() {
+    this.registerComponent('bottom-mut', { template: '{{setMe}}' });
+
+    expectAssertion(() => {
+      this.render('{{bottom-mut setMe=(mut (concat "foo" " " "bar"))}}');
+    }, 'You can only pass a path to mut');
+  }
+
+  ['@glimmer passing a literal indirectly results in an assertion']() {
+    this.registerComponent('bottom-mut', { template: '{{setMe}}' });
+
+    this.registerComponent('middle-mut', { template: '{{bottom-mut setMe=(mut value)}}' });
+
+    expectAssertion(() => {
+      this.render('{{middle-mut value="foo bar"}}');
+    }, 'You can only pass a path to mut');
+  }
+
+  ['@glimmer passing the result of a helper invocation indirectly results in an assertion']() {
+    this.registerComponent('bottom-mut', { template: '{{setMe}}' });
+
+    this.registerComponent('middle-mut', { template: '{{bottom-mut setMe=(mut value)}}' });
+
+    expectAssertion(() => {
+      this.render('{{middle-mut value=(concat "foo" " " "bar")}}');
+    }, 'You can only pass a path to mut');
+  }
+
   // See https://github.com/emberjs/ember.js/commit/807a0cd for an explanation of this test
-  ['@test using a string value through middle tier does not trigger assertion'](assert) {
+  ['@test using a string value through middle tier does not trigger assertion (due to the auto-mut transform)']() {
     let bottom;
 
     this.registerComponent('bottom-mut', {
@@ -94,7 +157,7 @@ moduleFor('@htmlbars Mutable bindings integration tests', class extends Renderin
 
     this.render('{{middle-mut value="foo"}}');
 
-    assert.equal(bottom.attrs.stuff.value, 'foo', 'the data propagated');
+    this.assert.equal(get(bottom, 'stuff'), 'foo', 'the data propagated');
     this.assertText('foo');
 
     this.assertStableRerender();
@@ -102,7 +165,7 @@ moduleFor('@htmlbars Mutable bindings integration tests', class extends Renderin
     // No U-R for this test
   }
 
-  ['@test a simple mutable binding using `mut` can be converted into an immutable binding'](assert) {
+  ['@test {{readonly}} of a {{mut}} is converted into an immutable binding']() {
     let middle, bottom;
 
     this.registerComponent('bottom-mut', {
@@ -133,10 +196,16 @@ moduleFor('@htmlbars Mutable bindings integration tests', class extends Renderin
 
     this.runTask(() => middle.attrs.value.update(13));
 
-    assert.strictEqual(middle.attrs.value.value, 13, 'the set took effect');
-    assert.strictEqual(bottom.attrs.setMe, 13, 'the mutable binding has been converted to an immutable cell');
-    this.assertText('13');
-    assert.strictEqual(get(this.context, 'val'), 13, 'the set propagated back up');
+    this.assert.strictEqual(get(middle, 'value'), 13, 'the set took effect on middle\'s prop');
+    this.assert.strictEqual(middle.attrs.value.value, 13, 'the set took effect on middle\'s attr');
+
+    this.runTask(() => set(middle, 'value', 14));
+
+    this.assert.strictEqual(get(middle, 'value'), 14, 'the set took effect on middle\'s prop');
+    this.assert.strictEqual(middle.attrs.value.value, 14, 'the set took effect on middle\'s attr');
+    this.assert.strictEqual(bottom.attrs.setMe, 14, 'the mutable binding has been converted to an immutable cell');
+    this.assertText('14');
+    this.assert.strictEqual(get(this.context, 'val'), 14, 'the set propagated back up');
 
     this.runTask(() => set(this.context, 'val', 12));
 
@@ -169,7 +238,7 @@ moduleFor('@htmlbars Mutable bindings integration tests', class extends Renderin
     this.assertText('Matthew Beale');
   }
 
-  ['@test a simple mutable binding using `mut` is available in hooks'](assert) {
+  ['@test a simple mutable binding using {{mut}} is available in hooks']() {
     let bottom;
     let willRender = [];
     let didInsert = [];
@@ -177,10 +246,10 @@ moduleFor('@htmlbars Mutable bindings integration tests', class extends Renderin
     this.registerComponent('bottom-mut', {
       ComponentClass: Component.extend({
         willRender() {
-          willRender.push(this.attrs.setMe.value);
+          willRender.push(get(this, 'setMe'));
         },
         didInsertElement() {
-          didInsert.push(this.attrs.setMe.value);
+          didInsert.push(get(this, 'setMe'));
           bottom = this;
         }
       }),
@@ -195,27 +264,38 @@ moduleFor('@htmlbars Mutable bindings integration tests', class extends Renderin
       val: 12
     });
 
-    assert.deepEqual(willRender, [12], 'willReceive is [12]');
-    assert.deepEqual(didInsert, [12], 'didInsert is [12]');
+    this.assert.deepEqual(willRender, [12], 'willReceive is [12]');
+    this.assert.deepEqual(didInsert, [12], 'didInsert is [12]');
     this.assertText('12');
 
     this.assertStableRerender();
 
-    assert.deepEqual(willRender, [12, 12], 'willReceive is [12, 12]');
-    assert.deepEqual(didInsert, [12], 'didInsert is [12]');
-    assert.strictEqual(bottom.attrs.setMe.value, 12, 'the data propagated');
+    if (this.isHTMLBars) {
+      this.assert.deepEqual(willRender, [12, 12], 'willReceive is [12, 12]');
+    } else {
+      this.assert.deepEqual(willRender, [12], 'willReceive is [12]');
+    }
+    this.assert.deepEqual(didInsert, [12], 'didInsert is [12]');
+    this.assert.strictEqual(get(bottom, 'setMe'), 12, 'the data propagated');
 
     this.runTask(() => bottom.attrs.setMe.update(13));
 
-    assert.strictEqual(bottom.attrs.setMe.value, 13, 'the set took effect');
-    assert.strictEqual(get(this.context, 'val'), 13, 'the set propagated back up');
+    this.assert.strictEqual(get(bottom, 'setMe'), 13, 'the set took effect on bottom\'s prop');
+    this.assert.strictEqual(bottom.attrs.setMe.value, 13, 'the set took effect on bottom\'s attr');
+    this.assert.strictEqual(get(this.context, 'val'), 13, 'the set propagated back up');
+
+    this.runTask(() => set(bottom, 'setMe', 14));
+
+    this.assert.strictEqual(get(bottom, 'setMe'), 14, 'the set took effect on bottom\'s prop');
+    this.assert.strictEqual(bottom.attrs.setMe.value, 14, 'the set took effect on bottom\'s attr');
+    this.assert.strictEqual(get(this.context, 'val'), 14, 'the set propagated back up');
 
     this.runTask(() => set(this.context, 'val', 12));
 
     this.assertText('12');
   }
 
-  ['@test a mutable binding with a backing computed property and attribute present in the root of the component is updated when the upstream property invalidates #11023'](assert) {
+  ['@test a mutable binding with a backing computed property and attribute present in the root of the component is updated when the upstream property invalidates #11023']() {
     let bottom, middle;
 
     this.registerComponent('bottom-mut', {
@@ -243,14 +323,16 @@ moduleFor('@htmlbars Mutable bindings integration tests', class extends Renderin
 
     this.render('{{middle-mut}}');
 
-    assert.strictEqual(bottom.attrs.thingy.value, 12, 'data propagated');
+    this.assert.strictEqual(get(bottom, 'thingy'), 12, 'data propagated');
     this.assertText('12');
 
     this.assertStableRerender();
 
     this.runTask(() => set(middle, 'baseValue', 13));
 
-    assert.strictEqual(bottom.attrs.thingy.value, 13, 'the set took effect');
+    this.assert.strictEqual(get(middle, 'val'), 13, 'the set took effect');
+    this.assert.strictEqual(bottom.attrs.thingy.value, 13, 'the set propagated down to bottom\'s attrs');
+    this.assert.strictEqual(get(bottom, 'thingy'), 13, 'the set propagated down to bottom\'s prop');
     this.assertText('13');
 
     this.runTask(() => set(middle, 'baseValue', 12));
@@ -258,7 +340,7 @@ moduleFor('@htmlbars Mutable bindings integration tests', class extends Renderin
     this.assertText('12');
   }
 
-  ['@test automatic mutable bindings tolerate undefined non-stream inputs and attempts to set them'](assert) {
+  ['@htmlbars automatic mutable bindings tolerate undefined non-stream inputs and attempts to set them']() {
     let inner;
 
     this.registerComponent('x-inner', {
@@ -282,7 +364,8 @@ moduleFor('@htmlbars Mutable bindings integration tests', class extends Renderin
 
     this.runTask(() => inner.attrs.model.update(42));
 
-    assert.equal(inner.attrs.model.value, 42);
+    this.assert.equal(inner.attrs.model.value, 42);
+    this.assert.equal(get(inner, 'model'), 42);
     this.assertText('42');
 
     this.runTask(() => inner.attrs.model.update(undefined));
@@ -290,7 +373,7 @@ moduleFor('@htmlbars Mutable bindings integration tests', class extends Renderin
     this.assertText('');
   }
 
-  ['@test automatic mutable bindings tolerate constant non-stream inputs and attempts to set them'](assert) {
+  ['@htmlbars automatic mutable bindings tolerate constant non-stream inputs and attempts to set them']() {
     let inner;
 
     this.registerComponent('x-inner', {
@@ -314,9 +397,9 @@ moduleFor('@htmlbars Mutable bindings integration tests', class extends Renderin
 
     this.runTask(() => inner.attrs.model.update(42));
 
-    assert.equal(inner.attrs.model.value, 42);
+    this.assert.equal(inner.attrs.model.value, 42);
+    this.assert.equal(get(inner, 'model'), 42);
     this.assertText('hello42');
-
 
     this.runTask(() => inner.attrs.model.update('foo'));
 
@@ -325,9 +408,9 @@ moduleFor('@htmlbars Mutable bindings integration tests', class extends Renderin
 
 });
 
-moduleFor('@htmlbars Mutable Bindings used in Computed Properties that are bound as attributeBindings', class extends RenderingTest {
+moduleFor('Mutable Bindings used in Computed Properties that are bound as attributeBindings', class extends RenderingTest {
 
-  ['@test an attribute binding of a computed property of a 2-way bound attr recomputes when the attr changes'](assert) {
+  ['@test an attribute binding of a computed property of a 2-way bound attr recomputes when the attr changes']() {
     let input, output;
 
     this.registerComponent('x-input', {
@@ -363,17 +446,23 @@ moduleFor('@htmlbars Mutable Bindings used in Computed Properties that are bound
 
     this.runTask(() => input.attrs.height.update(35));
 
-    assert.strictEqual(get(output, 'height'), 35, 'the set took effect');
-    assert.strictEqual(get(this.context, 'height'), 35, 'the set propagated back up');
+    this.assert.strictEqual(get(output, 'height'), 35, 'the set took effect');
+    this.assert.strictEqual(get(this.context, 'height'), 35, 'the set propagated back up');
     this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { style: styles('height: 35px;') }, content: '35' });
+
+    this.runTask(() => set(input, 'height', 36));
+
+    this.assert.strictEqual(get(output, 'height'), 36, 'the set took effect');
+    this.assert.strictEqual(get(this.context, 'height'), 36, 'the set propagated back up');
+    this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { style: styles('height: 36px;') }, content: '36' });
 
     this.runTask(() => set(this.context, 'height', 60));
 
     this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { style: styles('height: 60px;') }, content: '60' });
-    assert.strictEqual(get(input, 'height'), 60);
+    this.assert.strictEqual(get(input, 'height'), 60);
   }
 
-  ['@test an attribute binding of a computed property with a setter of a 2-way bound attr recomputes when the attr changes'](assert) {
+  ['@test an attribute binding of a computed property with a setter of a 2-way bound attr recomputes when the attr changes']() {
     let input, output;
 
     this.registerComponent('x-input', {
@@ -417,15 +506,21 @@ moduleFor('@htmlbars Mutable Bindings used in Computed Properties that are bound
 
     this.assertStableRerender();
 
-    this.runTask(() => input.attrs.width.update(80));
+    this.runTask(() => set(input, 'width', 80));
 
-    assert.strictEqual(get(output, 'width'), 80, 'the set took effect');
-    assert.strictEqual(get(this.context, 'width'), 80, 'the set propagated back up');
+    this.assert.strictEqual(get(output, 'width'), 80, 'the set took effect');
+    this.assert.strictEqual(get(this.context, 'width'), 80, 'the set propagated back up');
     this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { style: styles('height: 40px; width: 80px;') }, content: '80x40' });
+
+    this.runTask(() => input.attrs.width.update(90));
+
+    this.assert.strictEqual(get(output, 'width'), 90, 'the set took effect');
+    this.assert.strictEqual(get(this.context, 'width'), 90, 'the set propagated back up');
+    this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { style: styles('height: 45px; width: 90px;') }, content: '90x45' });
 
     this.runTask(() => set(this.context, 'width', 70));
 
     this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { style: styles('height: 35px; width: 70px;') }, content: '70x35' });
-    assert.strictEqual(get(input, 'width'), 70);
+    this.assert.strictEqual(get(input, 'width'), 70);
   }
 });

--- a/packages/ember-glimmer/tests/integration/helpers/readonly-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/readonly-test.js
@@ -1,0 +1,138 @@
+import { RenderingTest, moduleFor } from '../../utils/test-case';
+import { Component } from '../../utils/helpers';
+import { set } from 'ember-metal/property_set';
+import { get } from 'ember-metal/property_get';
+
+moduleFor('Helpers test: {{readonly}}', class extends RenderingTest {
+
+  ['@test {{readonly}} of a path should work']() {
+    let component;
+
+    this.registerComponent('foo-bar', {
+      ComponentClass: Component.extend({
+        didInsertElement() {
+          component = this;
+        }
+      }),
+      template: '{{value}}'
+    });
+
+    this.render('{{foo-bar value=(readonly val)}}', {
+      val: 12
+    });
+
+    this.assertText('12');
+
+    this.assertStableRerender();
+
+    this.runTask(() => set(component, 'value', 13));
+    this.assert.notOk(component.attrs.value.update);
+
+    this.assertText('13', 'local property is updated');
+    this.assert.equal(get(this.context, 'val'), 12, 'upstream attribute is not updated');
+
+    // No U-R
+  }
+
+  ['@test {{readonly}} of a string renders correctly']() {
+    let component;
+
+    this.registerComponent('foo-bar', {
+      ComponentClass: Component.extend({
+        didInsertElement() {
+          component = this;
+        }
+      }),
+      template: '{{value}}'
+    });
+
+    this.render('{{foo-bar value=(readonly "12")}}');
+
+    this.assertText('12');
+
+    this.assertStableRerender();
+
+    this.assert.notOk(component.attrs.value.update);
+    this.assert.strictEqual(get(component, 'value'), '12');
+
+    this.runTask(() => set(component, 'value', '13'));
+
+    this.assertText('13', 'local property is updated');
+    this.assert.strictEqual(get(component, 'value'), '13');
+
+    this.runTask(() => set(component, 'value', '12'));
+
+    this.assertText('12');
+  }
+
+  ['@test {{mut}} of a {{readonly}} mutates only the middle and bottom tiers']() {
+    let middle, bottom;
+
+    this.registerComponent('x-bottom', {
+      ComponentClass: Component.extend({
+        didInsertElement() {
+          bottom = this;
+        }
+      }),
+      template: '{{bar}}'
+    });
+
+    this.registerComponent('x-middle', {
+      ComponentClass: Component.extend({
+        didInsertElement() {
+          middle = this;
+        }
+      }),
+      template: '{{foo}} {{x-bottom bar=(mut foo)}}'
+    });
+
+    this.render('{{x-middle foo=(readonly val)}}', {
+      val: 12
+    });
+
+    this.assertText('12 12');
+
+    this.assertStableRerender();
+
+    this.assert.equal(get(bottom, 'bar'), 12, 'bottom\'s local bar received the value');
+    this.assert.equal(get(middle, 'foo'), 12, 'middle\'s local foo received the value');
+
+    this.runTask(() => bottom.attrs.bar.update(13));
+
+    this.assert.equal(get(bottom, 'bar'), 13, 'bottom\'s local bar was updated after set of bottom\'s bar');
+    this.assert.equal(get(middle, 'foo'), 13, 'middle\'s local foo was updated after set of bottom\'s bar');
+    this.assertText('13 13');
+    this.assert.equal(get(this.context, 'val'), 12, 'But context val is not updated');
+
+    this.runTask(() => set(bottom, 'bar', 14));
+
+    this.assert.equal(get(bottom, 'bar'), 14, 'bottom\'s local bar was updated after set of bottom\'s bar');
+    this.assert.equal(get(middle, 'foo'), 14, 'middle\'s local foo was updated after set of bottom\'s bar');
+    this.assertText('14 14');
+    this.assert.equal(get(this.context, 'val'), 12, 'But context val is not updated');
+
+    this.assert.notOk(middle.attrs.foo.update, 'middle\'s foo attr is not a mutable cell');
+    this.runTask(() => set(middle, 'foo', 15));
+
+    this.assertText('15 15');
+    this.assert.equal(get(middle, 'foo'), 15, 'set of middle\'s foo took effect');
+    this.assert.equal(get(bottom, 'bar'), 15, 'bottom\'s local bar was updated after set of middle\'s foo');
+    this.assert.equal(get(this.context, 'val'), 12, 'Context val remains unchanged');
+
+    this.runTask(() => set(this.context, 'val', 10));
+
+    this.assertText('10 10');
+    this.assert.equal(get(bottom, 'bar'), 10, 'bottom\'s local bar was updated after set of context\'s val');
+    this.assert.equal(get(middle, 'foo'), 10, 'middle\'s local foo was updated after set of context\'s val');
+
+    this.runTask(() => set(bottom, 'bar', undefined));
+
+    this.assertText(' ');
+    this.assert.equal(get(bottom, 'bar'), undefined, 'bottom\'s local bar was updated to a falsy value');
+    this.assert.equal(get(middle, 'foo'), undefined, 'middle\'s local foo was updated to a falsy value');
+
+    this.runTask(() => set(this.context, 'val', 12));
+    this.assertText('12 12', 'bottom and middle were both reset');
+  }
+
+ });

--- a/packages/ember-glimmer/tests/utils/helpers.js
+++ b/packages/ember-glimmer/tests/utils/helpers.js
@@ -6,8 +6,8 @@ import {
   template
 } from 'ember-glimmer-template-compiler';
 
-
 export { default as Helper, helper } from 'ember-glimmer/helper';
+export { INVOKE } from 'ember-glimmer/helpers/action';
 export { default as Component } from 'ember-glimmer/component';
 export { default as Checkbox } from 'ember-glimmer/components/checkbox';
 export { default as TextArea } from 'ember-glimmer/components/text_area';

--- a/packages/ember-htmlbars/lib/components/link-to.js
+++ b/packages/ember-htmlbars/lib/components/link-to.js
@@ -778,13 +778,13 @@ const LinkComponent = EmberComponent.extend({
       params = params.slice();
     }
 
-    assert('You must provide one or more parameters to the link-to component.', () => {
+    assert('You must provide one or more parameters to the link-to component.', (() => {
       if (!params) {
         return false;
       }
 
       return params.length;
-    });
+    })());
 
     let disabledWhen = get(this, 'disabledWhen');
     if (disabledWhen !== undefined) {

--- a/packages/ember-htmlbars/lib/keywords/mut.js
+++ b/packages/ember-htmlbars/lib/keywords/mut.js
@@ -91,7 +91,6 @@ const MutStream = ProxyStream.extend({
   See a [2.0 blog post](http://emberjs.com/blog/2015/05/10/run-up-to-two-oh.html#toc_the-code-mut-code-helper) for
   additional information on using `{{mut}}`.
 
-  @public
   @method mut
   @param {Object} [attr] the "two-way" attribute that can be modified.
   @for Ember.Templates.helpers

--- a/packages/ember-htmlbars/lib/system/build-component-template.js
+++ b/packages/ember-htmlbars/lib/system/build-component-template.js
@@ -254,8 +254,8 @@ function normalizeClasses(classes, output, streamBasePath) {
 }
 
 function validateTaglessComponent(component) {
-  assert('You cannot use `classNameBindings` on a tag-less component: ' + component.toString(), () => {
+  assert('You cannot use `classNameBindings` on a tag-less component: ' + component.toString(), (() => {
     let classNameBindings = component.classNameBindings;
     return !classNameBindings || classNameBindings.length === 0;
-  }());
+  })());
 }

--- a/packages/ember-htmlbars/tests/integration/mutable-binding-test.js
+++ b/packages/ember-htmlbars/tests/integration/mutable-binding-test.js
@@ -1,1 +1,0 @@
-../../../ember-glimmer/tests/integration/mutable-binding-test.js

--- a/packages/ember-htmlbars/tests/utils/helpers.js
+++ b/packages/ember-htmlbars/tests/utils/helpers.js
@@ -7,6 +7,7 @@ import { defaultCompileOptions } from 'ember-htmlbars-template-compiler';
 
 export { template } from 'ember-htmlbars-template-compiler';
 export { default as Helper, helper } from 'ember-htmlbars/helper';
+export { INVOKE } from 'ember-htmlbars/keywords/closure-action';
 export { default as DOMHelper } from 'ember-htmlbars/system/dom-helper';
 export { default as Component } from 'ember-htmlbars/component';
 export { default as Checkbox } from 'ember-htmlbars/components/checkbox';

--- a/packages/ember-views/lib/mixins/aria_role_support.js
+++ b/packages/ember-views/lib/mixins/aria_role_support.js
@@ -11,8 +11,6 @@ import { Mixin } from 'ember-metal/mixin';
  @private
 */
 export default Mixin.create({
-  attributeBindings: ['ariaRole:role'],
-
   /**
    The WAI-ARIA role of the control represented by this view. For example, a
    button may have a role of type 'button', or a pane may have a role of

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -521,6 +521,8 @@ var View = CoreView.extend(
   CompatAttrsProxy,
   AriaRoleSupport,
   ViewMixin, {
+    attributeBindings: ['ariaRole:role'],
+
     init() {
       this._super(...arguments);
 


### PR DESCRIPTION
Also, implement support for the [INVOKE] symbol in closure actions.

This also enables (partial) "reference pooling" on components – when doing rending a `{{foo}}` in the `{{foo-bar}}` layout, it first checks if `{{foo}}` is an arg passed from the outside (`{{foo-bar foo=...}}`), and if so, it tries to reuse the same reference instead of making a newone. This should reduce the total number of references created and also reduce the number of `value()` computation as the same reference can be reused across multiple curlies.

This also allows Glimmer to better optimize things – for example, if the component is invoked with literals (`{{foo-bar foo=true}}`) and `foo` is then used in a conditional in its layout (`{{#if foo}}...`), Glimmer will be now able to see that `foo` is a const reference and optimize out the updating step. This works recursively as well – if `foo-bar` then passes the same property down (`{{bar-baz bar=foo}}`), we now propagate the same reference all the way down.

Thanks @Joelkang for doing most of the work on this one in #13541!

Closes #13541
