### PR TITLE
[FEATURE ember-metal-weakmap] Add a WeakMap polyfill

### DIFF
--- a/features.json
+++ b/features.json
@@ -10,6 +10,7 @@
     "ember-improved-instrumentation": null,
     "ember-runtime-enumerable-includes": null,
     "ember-string-ishtmlsafe": null,
-    "ember-testing-check-waiters": null
+    "ember-testing-check-waiters": null,
+    "ember-metal-weakmap": null
   }
 }

--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -78,11 +78,13 @@ import {
   trySet
 } from 'ember-metal/property_set';
 
+import WeakMap from 'ember-metal/weak_map';
 import {
   Map,
   MapWithDefault,
   OrderedSet
 } from 'ember-metal/map';
+
 import getProperties from 'ember-metal/get_properties';
 import setProperties from 'ember-metal/set_properties';
 import {
@@ -226,6 +228,9 @@ Ember.defineProperty = defineProperty;
 Ember.set    = set;
 Ember.trySet = trySet;
 
+if (isEnabled('ember-metal-weakmap')) {
+  Ember.WeakMap = WeakMap;
+}
 Ember.OrderedSet = OrderedSet;
 Ember.Map = Map;
 Ember.MapWithDefault = MapWithDefault;

--- a/packages/ember-metal/lib/weak_map.js
+++ b/packages/ember-metal/lib/weak_map.js
@@ -1,4 +1,3 @@
-import { assert } from 'ember-metal/debug';
 import { GUID_KEY } from 'ember-metal/utils';
 import {
   peekMeta,
@@ -8,9 +7,15 @@ import {
 let id = 0;
 function UNDEFINED() {}
 
+// Returns whether Type(value) is Object according to the terminology in the spec
+function isObject(value) {
+  return (typeof value === 'object' && value !== null) || typeof value === 'function';
+}
+
 /*
- * @private
  * @class Ember.WeakMap
+ * @public
+ * @category ember-metal-weakmap
  *
  * A partial polyfill for [WeakMap](http://www.ecma-international.org/ecma-262/6.0/#sec-weakmap-objects).
  *
@@ -20,13 +25,23 @@ function UNDEFINED() {}
  * practice, most use cases satisfy this limitation which is why it is included
  * in ember-metal.
  */
-export default function WeakMap() {
-  assert(
-    'Invoking the WeakMap constructor with arguments is not supported at this time',
-    arguments.length === 0
-  );
+export default function WeakMap(iterable) {
+  if (!(this instanceof WeakMap)) {
+    throw new TypeError(`Constructor WeakMap requires 'new'`);
+  }
 
   this._id = GUID_KEY + (id++);
+
+  if (iterable === null || iterable === undefined) {
+    return;
+  } else if (Array.isArray(iterable)) {
+    for (let i = 0; i < iterable.length; i++) {
+      let [key, value] = iterable[i];
+      this.set(key, value);
+    }
+  } else {
+    throw new TypeError('The weak map constructor polyfill only supports an array argument');
+  }
 }
 
 /*
@@ -35,6 +50,10 @@ export default function WeakMap() {
  * @return {Any} stored value
  */
 WeakMap.prototype.get = function(obj) {
+  if (!isObject(obj)) {
+    return undefined;
+  }
+
   let meta = peekMeta(obj);
   if (meta) {
     let map = meta.readableWeak();
@@ -55,10 +74,9 @@ WeakMap.prototype.get = function(obj) {
  * @return {WeakMap} the weak map
  */
 WeakMap.prototype.set = function(obj, value) {
-  assert(
-    'Uncaught TypeError: Invalid value used as weak map key',
-    obj && (typeof obj === 'object' || typeof obj === 'function')
-  );
+  if (!isObject(obj)) {
+    throw new TypeError('Invalid value used as weak map key');
+  }
 
   if (value === undefined) {
     value = UNDEFINED;
@@ -75,6 +93,10 @@ WeakMap.prototype.set = function(obj, value) {
  * @return {boolean} if the key exists
  */
 WeakMap.prototype.has = function(obj) {
+  if (!isObject(obj)) {
+    return false;
+  }
+
   let meta = peekMeta(obj);
   if (meta) {
     let map = meta.readableWeak();
@@ -98,4 +120,12 @@ WeakMap.prototype.delete = function(obj) {
   } else {
     return false;
   }
+};
+
+/*
+ * @method toString
+ * @return {String}
+ */
+WeakMap.prototype.toString = function() {
+  return '[object WeakMap]';
 };

--- a/packages/ember-metal/tests/weak_map_test.js
+++ b/packages/ember-metal/tests/weak_map_test.js
@@ -47,20 +47,42 @@ QUnit.test('has weakMap like qualities', function(assert) {
   assert.strictEqual(map.get(b), undefined);
 });
 
-QUnit.test('invoking the WeakMap constructor with arguments is not supported at this time', function(assert) {
-  expectAssertion(function() {
-    new WeakMap([[{}, 1]]);
-  }, /Invoking the WeakMap constructor with arguments is not supported at this time/);
+QUnit.test('WeakMap constructor requres new', function(assert) {
+  let expectedError = new TypeError(`Constructor WeakMap requires 'new'`);
+
+  assert.throws(() => {
+    // jshint newcap: false
+    WeakMap();
+  }, expectedError);
+});
+
+QUnit.test('constructing a WeakMap with an invalid iterator throws an error', function(assert) {
+  let expectedError = new TypeError('The weak map constructor polyfill only supports an array argument');
+
+  assert.throws(() => { new WeakMap({ a: 1 }); }, expectedError);
+});
+
+QUnit.test('constructing a WeakMap with a valid iterator inserts the entries', function(assert) {
+  let a = {};
+  let b = {};
+  let c = {};
+
+  let map = new WeakMap([[a, 1], [b, 2], [c, 3]]);
+
+  assert.strictEqual(map.get(a), 1);
+  assert.strictEqual(map.get(b), 2);
+  assert.strictEqual(map.get(c), 3);
 });
 
 QUnit.test('that error is thrown when using a primitive key', function(assert) {
+  let expectedError = new TypeError('Invalid value used as weak map key');
   let map = new WeakMap();
 
-  expectAssertion(() => map.set('a', 1),       /Uncaught TypeError: Invalid value used as weak map key/);
-  expectAssertion(() => map.set(1, 1),         /Uncaught TypeError: Invalid value used as weak map key/);
-  expectAssertion(() => map.set(true, 1),      /Uncaught TypeError: Invalid value used as weak map key/);
-  expectAssertion(() => map.set(null, 1),      /Uncaught TypeError: Invalid value used as weak map key/);
-  expectAssertion(() => map.set(undefined, 1), /Uncaught TypeError: Invalid value used as weak map key/);
+  assert.throws(() => map.set('a', 1), expectedError);
+  assert.throws(() => map.set(1, 1), expectedError);
+  assert.throws(() => map.set(true, 1), expectedError);
+  assert.throws(() => map.set(null, 1), expectedError);
+  assert.throws(() => map.set(undefined, 1), expectedError);
 });
 
 QUnit.test('that .has and .delete work as expected', function(assert) {
@@ -81,4 +103,10 @@ QUnit.test('that .has and .delete work as expected', function(assert) {
   assert.strictEqual(map.delete(a), true);
   assert.strictEqual(map.delete(a), false);
   assert.strictEqual(map.has(a), false);
+});
+
+QUnit.test('that .toString works as expected', function(assert) {
+  let map = new WeakMap();
+
+  assert.strictEqual(map.toString(), '[object WeakMap]');
 });


### PR DESCRIPTION
This patch exposes the Ember's private WeakMap polyfill under a feature flag. This implementation has a small but important caveat. It assumes that the weak map will live longer (in the sense of garbage collection) than all of its keys, otherwise it is possible to leak the values stored in the weak map.

This patch also includes a few improvements:
- implement WeakMap constructor
- implement WeakMap toString
- guard against non-Object keys
