### PR TITLE
Revert "[BUGFIX beta] Don't use prototype extensions (arrayContent{Did,Will}Change, removeAt)"

### DIFF
--- a/packages/ember-glimmer/tests/integration/helpers/element-action-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/element-action-test.js
@@ -5,7 +5,6 @@ import { set } from 'ember-metal/property_set';
 
 import EmberObject from 'ember-runtime/system/object';
 import { A as emberA } from 'ember-runtime/system/native_array';
-import { removeAt } from 'ember-runtime/mixins/mutable_array';
 
 import ActionManager from 'ember-views/system/action_manager';
 import jQuery from 'ember-views/system/jquery';
@@ -762,7 +761,7 @@ moduleFor('Helpers test: element action', class extends RenderingTest {
     var actionId = this.$('a[data-ember-action]').attr('data-ember-action');
 
     this.runTask(() => {
-      removeAt(things, 0);
+      things.removeAt(0);
     });
 
     ok(!ActionManager.registeredActions[actionId], 'After the virtual view was destroyed, the action was unregistered');

--- a/packages/ember-glimmer/tests/integration/syntax/each-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/each-test.js
@@ -3,7 +3,6 @@ import { set } from 'ember-metal/property_set';
 import { applyMixins, strip } from '../../utils/abstract-test-case';
 import { moduleFor, RenderingTest } from '../../utils/test-case';
 import { A as emberA } from 'ember-runtime/system/native_array';
-import { removeAt } from 'ember-runtime/mixins/mutable_array';
 
 import {
   BasicConditionalsTest,
@@ -79,7 +78,7 @@ moduleFor('Syntax test: {{#each as}}', class extends EachTest {
     this.runTask(() => {
       let list = get(this.context, 'list');
       list.pushObject({ text: 'Earth' });
-      removeAt(list, 1);
+      list.removeAt(1);
       list.insertAt(1, { text: 'Globe' });
     });
 
@@ -88,11 +87,11 @@ moduleFor('Syntax test: {{#each as}}', class extends EachTest {
     this.runTask(() => {
       let list = get(this.context, 'list');
       list.pushObject({ text: 'Planet' });
-      removeAt(list, 1);
+      list.removeAt(1);
       list.insertAt(1, { text: ' ' });
       list.pushObject({ text: ' ' });
       list.pushObject({ text: 'Earth' });
-      removeAt(list, 3);
+      list.removeAt(3);
     });
 
     this.assertText('Hello WorldPlanet Earth');
@@ -100,11 +99,11 @@ moduleFor('Syntax test: {{#each as}}', class extends EachTest {
     this.runTask(() => {
       let list = get(this.context, 'list');
       list.pushObject({ text: 'Globe' });
-      removeAt(list, 1);
+      list.removeAt(1);
       list.insertAt(1, { text: ' ' });
       list.pushObject({ text: ' ' });
       list.pushObject({ text: 'World' });
-      removeAt(list, 2);
+      list.removeAt(2);
     });
 
     this.assertText('Hello Planet EarthGlobe World');
@@ -373,7 +372,7 @@ moduleFor('Syntax test: {{#each as}}', class extends EachTest {
     this.runTask(() => {
       let people = get(this.context, 'people');
       set(people.objectAt(1), 'name', 'Stefan Penner');
-      removeAt(people, 0);
+      people.removeAt(0);
       people.pushObject({ name: 'Tom Dale' });
       people.insertAt(1, { name: 'Chad Hietala' });
       set(this.context, 'title', 'Principal Engineer');

--- a/packages/ember-glimmer/tests/integration/syntax/with-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/with-test.js
@@ -5,7 +5,6 @@ import { moduleFor, RenderingTest } from '../../utils/test-case';
 import { TogglingSyntaxConditionalsTest } from '../../utils/shared-conditional-tests';
 import { strip } from '../../utils/abstract-test-case';
 import ObjectProxy from 'ember-runtime/system/object_proxy';
-import { removeAt } from 'ember-runtime/mixins/mutable_array';
 
 moduleFor('Syntax test: {{#with}}', class extends TogglingSyntaxConditionalsTest {
 
@@ -199,7 +198,7 @@ moduleFor('Syntax test: {{#with as}}', class extends TogglingSyntaxConditionalsT
     this.runTask(() => {
       let array = get(this.context, 'arrayThing');
       array.replace(0, 1, 'Goodbye');
-      removeAt(array, 1);
+      array.removeAt(1);
       array.insertAt(1, ', ');
       array.pushObject('!');
     });

--- a/packages/ember-glimmer/tests/utils/shared-conditional-tests.js
+++ b/packages/ember-glimmer/tests/utils/shared-conditional-tests.js
@@ -7,7 +7,6 @@ import EmberObject from 'ember-runtime/system/object';
 import ObjectProxy from 'ember-runtime/system/object_proxy';
 import { A as emberA } from 'ember-runtime/system/native_array';
 import ArrayProxy from 'ember-runtime/system/array_proxy';
-import { removeAt } from 'ember-runtime/mixins/mutable_array';
 import { Component } from './helpers';
 
 class AbstractConditionalsTest extends RenderingTest {
@@ -309,7 +308,7 @@ export const ArrayTestCases = {
 
     this.assertText('T1F2');
 
-    this.runTask(() => removeAt(get(this.context, 'cond1'), 0));
+    this.runTask(() => get(this.context, 'cond1').removeAt(0));
 
     this.assertText('F1F2');
 
@@ -374,7 +373,7 @@ export const ArrayTestCases = {
 
     this.assertText('T1F2');
 
-    this.runTask(() => removeAt(get(this.context, 'cond1.content'), 0));
+    this.runTask(() => get(this.context, 'cond1.content').removeAt(0));
 
     this.assertText('F1F2');
 

--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -68,99 +68,6 @@ export function objectAt(content, idx) {
   return content[idx];
 }
 
-export function arrayContentWillChange(array, startIdx, removeAmt, addAmt) {
-  let removing, lim;
-
-  // if no args are passed assume everything changes
-  if (startIdx === undefined) {
-    startIdx = 0;
-    removeAmt = addAmt = -1;
-  } else {
-    if (removeAmt === undefined) {
-      removeAmt = -1;
-    }
-
-    if (addAmt === undefined) {
-      addAmt = -1;
-    }
-  }
-
-  if (array.__each) {
-    array.__each.arrayWillChange(array, startIdx, removeAmt, addAmt);
-  }
-
-  sendEvent(array, '@array:before', [array, startIdx, removeAmt, addAmt]);
-
-  if (startIdx >= 0 && removeAmt >= 0 && get(array, 'hasEnumerableObservers')) {
-    removing = [];
-    lim = startIdx + removeAmt;
-
-    for (let idx = startIdx; idx < lim; idx++) {
-      removing.push(objectAt(array, idx));
-    }
-  } else {
-    removing = removeAmt;
-  }
-
-  array.enumerableContentWillChange(removing, addAmt);
-
-  return array;
-}
-
-export function arrayContentDidChange(array, startIdx, removeAmt, addAmt) {
-  markObjectAsDirty(metaFor(array));
-
-  // if no args are passed assume everything changes
-  if (startIdx === undefined) {
-    startIdx = 0;
-    removeAmt = addAmt = -1;
-  } else {
-    if (removeAmt === undefined) {
-      removeAmt = -1;
-    }
-
-    if (addAmt === undefined) {
-      addAmt = -1;
-    }
-  }
-
-  let adding;
-  if (startIdx >= 0 && addAmt >= 0 && get(array, 'hasEnumerableObservers')) {
-    adding = [];
-    let lim = startIdx + addAmt;
-
-    for (let idx = startIdx; idx < lim; idx++) {
-      adding.push(objectAt(array, idx));
-    }
-  } else {
-    adding = addAmt;
-  }
-
-  array.enumerableContentDidChange(removeAmt, adding);
-
-  if (array.__each) {
-    array.__each.arrayDidChange(array, startIdx, removeAmt, addAmt);
-  }
-
-  sendEvent(array, '@array:change', [array, startIdx, removeAmt, addAmt]);
-
-  let length = get(array, 'length');
-  let cachedFirst = cacheFor(array, 'firstObject');
-  let cachedLast = cacheFor(array, 'lastObject');
-
-  if (objectAt(array, 0) !== cachedFirst) {
-    propertyWillChange(array, 'firstObject');
-    propertyDidChange(array, 'firstObject');
-  }
-
-  if (objectAt(array, length - 1) !== cachedLast) {
-    propertyWillChange(array, 'lastObject');
-    propertyDidChange(array, 'lastObject');
-  }
-
-  return array;
-}
-
 const EMBER_ARRAY = symbol('EMBER_ARRAY');
 
 export function isEmberArray(obj) {
@@ -530,7 +437,43 @@ const ArrayMixin = Mixin.create(Enumerable, {
     @public
   */
   arrayContentWillChange(startIdx, removeAmt, addAmt) {
-    return arrayContentWillChange(this, startIdx, removeAmt, addAmt);
+    let removing, lim;
+
+    // if no args are passed assume everything changes
+    if (startIdx === undefined) {
+      startIdx = 0;
+      removeAmt = addAmt = -1;
+    } else {
+      if (removeAmt === undefined) {
+        removeAmt = -1;
+      }
+
+      if (addAmt === undefined) {
+        addAmt = -1;
+      }
+    }
+
+    if (this.__each) {
+      this.__each.arrayWillChange(this, startIdx, removeAmt, addAmt);
+    }
+
+    sendEvent(this, '@array:before', [this, startIdx, removeAmt, addAmt]);
+
+
+    if (startIdx >= 0 && removeAmt >= 0 && get(this, 'hasEnumerableObservers')) {
+      removing = [];
+      lim = startIdx + removeAmt;
+
+      for (let idx = startIdx; idx < lim; idx++) {
+        removing.push(objectAt(this, idx));
+      }
+    } else {
+      removing = removeAmt;
+    }
+
+    this.enumerableContentWillChange(removing, addAmt);
+
+    return this;
   },
 
   /**
@@ -549,7 +492,57 @@ const ArrayMixin = Mixin.create(Enumerable, {
     @public
   */
   arrayContentDidChange(startIdx, removeAmt, addAmt) {
-    return arrayContentDidChange(this, startIdx, removeAmt, addAmt);
+    markObjectAsDirty(metaFor(this));
+
+    // if no args are passed assume everything changes
+    if (startIdx === undefined) {
+      startIdx = 0;
+      removeAmt = addAmt = -1;
+    } else {
+      if (removeAmt === undefined) {
+        removeAmt = -1;
+      }
+
+      if (addAmt === undefined) {
+        addAmt = -1;
+      }
+    }
+
+    let adding;
+    if (startIdx >= 0 && addAmt >= 0 && get(this, 'hasEnumerableObservers')) {
+      adding = [];
+      let lim = startIdx + addAmt;
+
+      for (let idx = startIdx; idx < lim; idx++) {
+        adding.push(objectAt(this, idx));
+      }
+    } else {
+      adding = addAmt;
+    }
+
+    this.enumerableContentDidChange(removeAmt, adding);
+
+    if (this.__each) {
+      this.__each.arrayDidChange(this, startIdx, removeAmt, addAmt);
+    }
+
+    sendEvent(this, '@array:change', [this, startIdx, removeAmt, addAmt]);
+
+    let length = get(this, 'length');
+    let cachedFirst = cacheFor(this, 'firstObject');
+    let cachedLast = cacheFor(this, 'lastObject');
+
+    if (objectAt(this, 0) !== cachedFirst) {
+      propertyWillChange(this, 'firstObject');
+      propertyDidChange(this, 'firstObject');
+    }
+
+    if (objectAt(this, length - 1) !== cachedLast) {
+      propertyWillChange(this, 'lastObject');
+      propertyDidChange(this, 'lastObject');
+    }
+
+    return this;
   },
 
   /**

--- a/packages/ember-runtime/lib/mixins/mutable_array.js
+++ b/packages/ember-runtime/lib/mixins/mutable_array.js
@@ -26,23 +26,6 @@ import MutableEnumerable from 'ember-runtime/mixins/mutable_enumerable';
 import Enumerable from 'ember-runtime/mixins/enumerable';
 import isEnabled from 'ember-metal/features';
 
-export function removeAt(array, start, len) {
-  if ('number' === typeof start) {
-    if ((start < 0) || (start >= get(array, 'length'))) {
-      throw new EmberError(OUT_OF_RANGE_EXCEPTION);
-    }
-
-    // fast case
-    if (len === undefined) {
-      len = 1;
-    }
-
-    array.replace(start, len, EMPTY);
-  }
-
-  return array;
-}
-
 /**
   This mixin defines the API for modifying array-like objects. These methods
   can be applied only to a collection that keeps its items in an ordered set.
@@ -158,7 +141,20 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
     @public
   */
   removeAt(start, len) {
-    return removeAt(this, start, len);
+    if ('number' === typeof start) {
+      if ((start < 0) || (start >= get(this, 'length'))) {
+        throw new EmberError(OUT_OF_RANGE_EXCEPTION);
+      }
+
+      // fast case
+      if (len === undefined) {
+        len = 1;
+      }
+
+      this.replace(start, len, EMPTY);
+    }
+
+    return this;
   },
 
   /**

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -20,8 +20,6 @@ import alias from 'ember-metal/alias';
 import {
   addArrayObserver,
   removeArrayObserver,
-  arrayContentDidChange,
-  arrayContentWillChange,
   objectAt
 } from 'ember-runtime/mixins/array';
 
@@ -34,7 +32,6 @@ const OUT_OF_RANGE_EXCEPTION = 'Index out of range';
 const EMPTY = [];
 
 function K() { return this; }
-
 
 /**
   An ArrayProxy wraps any other object that implements `Ember.Array` and/or
@@ -374,11 +371,11 @@ export default EmberObject.extend(MutableArray, {
   },
 
   arrangedContentArrayWillChange(item, idx, removedCnt, addedCnt) {
-    arrayContentWillChange(this, idx, removedCnt, addedCnt);
+    this.arrayContentWillChange(idx, removedCnt, addedCnt);
   },
 
   arrangedContentArrayDidChange(item, idx, removedCnt, addedCnt) {
-    arrayContentDidChange(this, idx, removedCnt, addedCnt);
+    this.arrayContentDidChange(idx, removedCnt, addedCnt);
   },
 
   init() {

--- a/packages/ember-runtime/lib/system/native_array.js
+++ b/packages/ember-runtime/lib/system/native_array.js
@@ -7,10 +7,7 @@ import { ENV } from 'ember-environment';
 import { _replace as replace } from 'ember-metal/replace';
 import { get } from 'ember-metal/property_get';
 import { Mixin } from 'ember-metal/mixin';
-import EmberArray, {
-  arrayContentDidChange,
-  arrayContentWillChange
-} from 'ember-runtime/mixins/array';
+import EmberArray from 'ember-runtime/mixins/array';
 import MutableArray from 'ember-runtime/mixins/mutable_array';
 import Observable from 'ember-runtime/mixins/observable';
 import Copyable from 'ember-runtime/mixins/copyable';
@@ -61,7 +58,7 @@ let NativeArray = Mixin.create(MutableArray, Observable, Copyable, {
     // replaced range. Otherwise, pass the full remaining array length
     // since everything has shifted
     let len = objects ? get(objects, 'length') : 0;
-    arrayContentWillChange(this, idx, amt, len);
+    this.arrayContentWillChange(idx, amt, len);
 
     if (len === 0) {
       this.splice(idx, amt);
@@ -69,7 +66,7 @@ let NativeArray = Mixin.create(MutableArray, Observable, Copyable, {
       replace(this, idx, amt, objects);
     }
 
-    arrayContentDidChange(this, idx, amt, len);
+    this.arrayContentDidChange(idx, amt, len);
     return this;
   },
 

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -28,7 +28,6 @@ import {
 import { isArray } from 'ember-runtime/utils';
 import { testBoth } from 'ember-metal/tests/props_helper';
 import { A as emberA } from 'ember-runtime/system/native_array';
-import { removeAt } from 'ember-runtime/mixins/mutable_array';
 
 let obj;
 QUnit.module('map', {
@@ -69,7 +68,7 @@ QUnit.test('it maps simple properties', function() {
 
   deepEqual(obj.get('mapped'), [1, 3, 2, 1, 5]);
 
-  removeAt(obj.get('array'), 3);
+  obj.get('array').removeAt(3);
 
   deepEqual(obj.get('mapped'), [1, 3, 2, 5]);
 });
@@ -136,7 +135,7 @@ QUnit.test('it maps objects', function() {
     { name: 'Eddard' }
   ]);
 
-  removeAt(obj.get('arrayObjects'), 1);
+  obj.get('arrayObjects').removeAt(1);
 
   deepEqual(obj.get('mappedObjects'), [
     { name: 'Robert' },
@@ -202,7 +201,7 @@ QUnit.test('it maps properties', function() {
 
   deepEqual(obj.get('mapped'), [1, 3, 2, 1, 5]);
 
-  removeAt(obj.get('array'), 3);
+  obj.get('array').removeAt(3);
 
   deepEqual(obj.get('mapped'), [1, 3, 2, 5]);
 });
@@ -475,7 +474,7 @@ QUnit.test('properties values can be replaced', function() {
 
     deepEqual(obj.get('union').sort((x, y) => x - y), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], name + ' adds new items');
 
-    removeAt(array2, 6); // remove 7
+    array2.removeAt(6); // remove 7
 
     deepEqual(obj.get('union').sort((x, y) => x - y), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], name + ' does not remove items that are still in the dependent array');
 

--- a/packages/ember-runtime/tests/mixins/array_test.js
+++ b/packages/ember-runtime/tests/mixins/array_test.js
@@ -9,8 +9,6 @@ import EmberObject from 'ember-runtime/system/object';
 import EmberArray, {
   addArrayObserver,
   removeArrayObserver,
-  arrayContentDidChange,
-  arrayContentWillChange,
   objectAt
 } from 'ember-runtime/mixins/array';
 import { A as emberA } from 'ember-runtime/system/native_array';
@@ -31,15 +29,15 @@ const TestArray = EmberObject.extend(EmberArray, {
   // MutableArray is just a standard API for mutation but not required.
   addObject(obj) {
     let idx = this._content.length;
-    arrayContentWillChange(this, idx, 0, 1);
+    this.arrayContentWillChange(idx, 0, 1);
     this._content.push(obj);
-    arrayContentDidChange(this, idx, 0, 1);
+    this.arrayContentDidChange(idx, 0, 1);
   },
 
   removeFirst(idx) {
-    arrayContentWillChange(this, 0, 1, 0);
+    this.arrayContentWillChange(0, 1, 0);
     this._content.shift();
-    arrayContentDidChange(this, 0, 1, 0);
+    this.arrayContentDidChange(0, 1, 0);
   },
 
   objectAt(idx) {
@@ -126,8 +124,8 @@ QUnit.test('should notify observers of []', function() {
 
   equal(obj._count, 0, 'should not have invoked yet');
 
-  arrayContentWillChange(obj, 0, 1, 1);
-  arrayContentDidChange(obj, 0, 1, 1);
+  obj.arrayContentWillChange(0, 1, 1);
+  obj.arrayContentDidChange(0, 1, 1);
 
   equal(obj._count, 1, 'should have invoked');
 });
@@ -155,27 +153,27 @@ QUnit.module('notify observers of length', {
 });
 
 QUnit.test('should notify observers when call with no params', function() {
-  arrayContentWillChange(obj);
+  obj.arrayContentWillChange();
   equal(obj._after, 0);
 
-  arrayContentDidChange(obj);
+  obj.arrayContentDidChange();
   equal(obj._after, 1);
 });
 
 // API variation that included items only
 QUnit.test('should not notify when passed lengths are same', function() {
-  arrayContentWillChange(obj, 0, 1, 1);
+  obj.arrayContentWillChange(0, 1, 1);
   equal(obj._after, 0);
 
-  arrayContentDidChange(obj, 0, 1, 1);
+  obj.arrayContentDidChange(0, 1, 1);
   equal(obj._after, 0);
 });
 
 QUnit.test('should notify when passed lengths are different', function() {
-  arrayContentWillChange(obj, 0, 1, 2);
+  obj.arrayContentWillChange(0, 1, 2);
   equal(obj._after, 0);
 
-  arrayContentDidChange(obj, 0, 1, 2);
+  obj.arrayContentDidChange(0, 1, 2);
   equal(obj._after, 1);
 });
 
@@ -212,36 +210,36 @@ QUnit.module('notify array observers', {
 });
 
 QUnit.test('should notify enumerable observers when called with no params', function() {
-  arrayContentWillChange(obj);
+  obj.arrayContentWillChange();
   deepEqual(observer._before, [obj, 0, -1, -1]);
 
-  arrayContentDidChange(obj);
+  obj.arrayContentDidChange();
   deepEqual(observer._after, [obj, 0, -1, -1]);
 });
 
 // API variation that included items only
 QUnit.test('should notify when called with same length items', function() {
-  arrayContentWillChange(obj, 0, 1, 1);
+  obj.arrayContentWillChange(0, 1, 1);
   deepEqual(observer._before, [obj, 0, 1, 1]);
 
-  arrayContentDidChange(obj, 0, 1, 1);
+  obj.arrayContentDidChange(0, 1, 1);
   deepEqual(observer._after, [obj, 0, 1, 1]);
 });
 
 QUnit.test('should notify when called with diff length items', function() {
-  arrayContentWillChange(obj, 0, 2, 1);
+  obj.arrayContentWillChange(0, 2, 1);
   deepEqual(observer._before, [obj, 0, 2, 1]);
 
-  arrayContentDidChange(obj, 0, 2, 1);
+  obj.arrayContentDidChange(0, 2, 1);
   deepEqual(observer._after, [obj, 0, 2, 1]);
 });
 
 QUnit.test('removing enumerable observer should disable', function() {
   removeArrayObserver(obj, observer);
-  arrayContentWillChange(obj);
+  obj.arrayContentWillChange();
   deepEqual(observer._before, null);
 
-  arrayContentDidChange(obj);
+  obj.arrayContentDidChange();
   deepEqual(observer._after, null);
 });
 
@@ -277,36 +275,36 @@ QUnit.module('notify enumerable observers as well', {
 });
 
 QUnit.test('should notify enumerable observers when called with no params', function() {
-  arrayContentWillChange(obj);
+  obj.arrayContentWillChange();
   deepEqual(observer._before, [obj, null, null], 'before');
 
-  arrayContentDidChange(obj);
+  obj.arrayContentDidChange();
   deepEqual(observer._after, [obj, null, null], 'after');
 });
 
 // API variation that included items only
 QUnit.test('should notify when called with same length items', function() {
-  arrayContentWillChange(obj, 0, 1, 1);
+  obj.arrayContentWillChange(0, 1, 1);
   deepEqual(observer._before, [obj, ['ITEM-0'], 1], 'before');
 
-  arrayContentDidChange(obj, 0, 1, 1);
+  obj.arrayContentDidChange(0, 1, 1);
   deepEqual(observer._after, [obj, 1, ['ITEM-0']], 'after');
 });
 
 QUnit.test('should notify when called with diff length items', function() {
-  arrayContentWillChange(obj, 0, 2, 1);
+  obj.arrayContentWillChange(0, 2, 1);
   deepEqual(observer._before, [obj, ['ITEM-0', 'ITEM-1'], 1], 'before');
 
-  arrayContentDidChange(obj, 0, 2, 1);
+  obj.arrayContentDidChange(0, 2, 1);
   deepEqual(observer._after, [obj, 2, ['ITEM-0']], 'after');
 });
 
 QUnit.test('removing enumerable observer should disable', function() {
   obj.removeEnumerableObserver(observer);
-  arrayContentWillChange(obj);
+  obj.arrayContentWillChange();
   deepEqual(observer._before, null, 'before');
 
-  arrayContentDidChange(obj);
+  obj.arrayContentDidChange();
   deepEqual(observer._after, null, 'after');
 });
 

--- a/packages/ember-runtime/tests/mixins/mutable_array_test.js
+++ b/packages/ember-runtime/tests/mixins/mutable_array_test.js
@@ -3,10 +3,6 @@ import MutableArrayTests from 'ember-runtime/tests/suites/mutable_array';
 import MutableArray from 'ember-runtime/mixins/mutable_array';
 import EmberObject from 'ember-runtime/system/object';
 import { A as emberA } from 'ember-runtime/system/native_array';
-import {
-  arrayContentDidChange,
-  arrayContentWillChange
-} from 'ember-runtime/mixins/array';
 
 /*
   Implement a basic fake mutable array.  This validates that any non-native
@@ -25,12 +21,12 @@ const TestMutableArray = EmberObject.extend(MutableArray, {
     let removeAmt = amt;
     let addAmt    = args.length;
 
-    arrayContentWillChange(this, idx, removeAmt, addAmt);
+    this.arrayContentWillChange(idx, removeAmt, addAmt);
 
     args.unshift(amt);
     args.unshift(idx);
     this._content.splice.apply(this._content, args);
-    arrayContentDidChange(this, idx, removeAmt, addAmt);
+    this.arrayContentDidChange(idx, removeAmt, addAmt);
     return this;
   },
 

--- a/packages/ember-runtime/tests/suites/mutable_array/removeAt.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/removeAt.js
@@ -1,12 +1,11 @@
 import {SuiteModuleBuilder} from 'ember-runtime/tests/suites/suite';
 import {get} from 'ember-metal/property_get';
-import { removeAt } from 'ember-runtime/mixins/mutable_array';
 
 const suite = SuiteModuleBuilder.create();
 
 suite.module('removeAt');
 
-suite.test('removeAt([X], 0) => [] + notify', function() {
+suite.test('[X].removeAt(0) => [] + notify', function() {
   let before = this.newFixture(1);
   let after  = [];
   let obj = this.newObject(before);
@@ -14,7 +13,7 @@ suite.test('removeAt([X], 0) => [] + notify', function() {
 
   obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
 
-  equal(removeAt(obj, 0), obj, 'return self');
+  equal(obj.removeAt(0), obj, 'return self');
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(get(obj, 'length'), after.length, 'length');
@@ -26,12 +25,12 @@ suite.test('removeAt([X], 0) => [] + notify', function() {
   equal(observer.timesCalled('lastObject'), 1, 'should have notified lastObject once');
 });
 
-suite.test('removeAt([], 200) => OUT_OF_RANGE_EXCEPTION exception', function() {
+suite.test('[].removeAt(200) => OUT_OF_RANGE_EXCEPTION exception', function() {
   let obj = this.newObject([]);
-  throws(() => removeAt(obj, 200), Error);
+  throws(() => obj.removeAt(200), Error);
 });
 
-suite.test('removeAt([A,B], 0) => [B] + notify', function() {
+suite.test('[A,B].removeAt(0) => [B] + notify', function() {
   let before = this.newFixture(2);
   let after  = [before[1]];
   let obj = this.newObject(before);
@@ -39,7 +38,7 @@ suite.test('removeAt([A,B], 0) => [B] + notify', function() {
 
   obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
 
-  equal(removeAt(obj, 0), obj, 'return self');
+  equal(obj.removeAt(0), obj, 'return self');
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(get(obj, 'length'), after.length, 'length');
@@ -52,7 +51,7 @@ suite.test('removeAt([A,B], 0) => [B] + notify', function() {
   equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject');
 });
 
-suite.test('removeAt([A,B], 1) => [A] + notify', function() {
+suite.test('[A,B].removeAt(1) => [A] + notify', function() {
   let before = this.newFixture(2);
   let after  = [before[0]];
   let obj = this.newObject(before);
@@ -60,7 +59,7 @@ suite.test('removeAt([A,B], 1) => [A] + notify', function() {
 
   obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
 
-  equal(removeAt(obj, 1), obj, 'return self');
+  equal(obj.removeAt(1), obj, 'return self');
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(get(obj, 'length'), after.length, 'length');
@@ -73,7 +72,7 @@ suite.test('removeAt([A,B], 1) => [A] + notify', function() {
   equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject once');
 });
 
-suite.test('removeAt([A,B,C], 1) => [A,C] + notify', function() {
+suite.test('[A,B,C].removeAt(1) => [A,C] + notify', function() {
   let before = this.newFixture(3);
   let after  = [before[0], before[2]];
   let obj = this.newObject(before);
@@ -81,28 +80,7 @@ suite.test('removeAt([A,B,C], 1) => [A,C] + notify', function() {
 
   obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
 
-  equal(removeAt(obj, 1), obj, 'return self');
-
-  deepEqual(this.toArray(obj), after, 'post item results');
-  equal(get(obj, 'length'), after.length, 'length');
-
-  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-  equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-  equal(observer.timesCalled('length'), 1, 'should have notified length once');
-
-  equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject once');
-  equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject once');
-});
-
-suite.test('removeAt([A,B,C,D], 1,2) => [A,D] + notify', function() {
-  let before = this.newFixture(4);
-  let after  = [before[0], before[3]];
-  let obj = this.newObject(before);
-  let observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
-
-  obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
-
-  equal(removeAt(obj, 1, 2), obj, 'return self');
+  equal(obj.removeAt(1), obj, 'return self');
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(get(obj, 'length'), after.length, 'length');
@@ -116,12 +94,11 @@ suite.test('removeAt([A,B,C,D], 1,2) => [A,D] + notify', function() {
 });
 
 suite.test('[A,B,C,D].removeAt(1,2) => [A,D] + notify', function() {
-  var obj, before, after, observer;
+  let before = this.newFixture(4);
+  let after  = [before[0], before[3]];
+  let obj = this.newObject(before);
+  let observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
-  before = this.newFixture(4);
-  after  = [before[0], before[3]];
-  obj = this.newObject(before);
-  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
   obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
 
   equal(obj.removeAt(1, 2), obj, 'return self');


### PR DESCRIPTION
Reverts emberjs/ember.js#13534.

After discussing @krisselden I realized that I merged #13534 prematurely (I am sorry about that).  There are still a few things that need to be addressed there to allow us to drop `Ember.A` usage and those need to be addressed before landing again.  

/cc @btecu 
