### PR TITLE
[BUGFIX beta] Ensure all template statements are constant length.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "github": "^0.2.3",
     "glimmer-engine": "tildeio/glimmer#d4d1e3a",
     "glob": "^5.0.13",
-    "htmlbars": "0.14.23",
+    "htmlbars": "0.14.24",
     "mocha": "^2.4.5",
     "qunit-extras": "^1.5.0",
     "qunitjs": "^1.22.0",


### PR DESCRIPTION
Addresses https://github.com/tildeio/htmlbars/issues/468 and utilizes the `buildStatement` helper from https://github.com/tildeio/htmlbars/pull/469 to ensure all statement nodes are the same length.

/cc @krisselden
