### PR TITLE
Update QUnit test adapter to be 2.0 compatible

### DIFF
--- a/packages/ember-testing/lib/adapters/qunit.js
+++ b/packages/ember-testing/lib/adapters/qunit.js
@@ -11,11 +11,19 @@ import { inspect } from 'ember-metal/utils';
   @public
 */
 export default Adapter.extend({
+  done: [],
   asyncStart() {
-    QUnit.stop();
+    this.done.push(QUnit.config.current.assert.async());
   },
   asyncEnd() {
-    QUnit.start();
+    let current = QUnit.config.current;
+    this.done.pop()();
+
+    // If we're done with async and the user hasn't invoked async manually,
+    // then set usedAsync to false so that assertions can still happen
+    if (this.done.length === 0 && current.semaphore === 0) {
+      current.usedAsync = false;
+    }
   },
   exception(error) {
     ok(false, inspect(error));

--- a/packages/ember-testing/tests/adapters/qunit_test.js
+++ b/packages/ember-testing/tests/adapters/qunit_test.js
@@ -12,28 +12,18 @@ QUnit.module('ember-testing QUnitAdapter', {
   }
 });
 
-QUnit.test('asyncStart calls stop', function() {
-  var originalStop = QUnit.stop;
-  try {
-    QUnit.stop = function() {
-      ok(true, 'stop called');
-    };
-    adapter.asyncStart();
-  } finally {
-    QUnit.stop = originalStop;
-  }
+QUnit.test('can still do assertions after asyncEnd', function() {
+  adapter.asyncStart();
+  adapter.asyncEnd();
+  ok(true);
 });
 
-QUnit.test('asyncEnd calls start', function() {
-  var originalStart = QUnit.start;
-  try {
-    QUnit.start = function() {
-      ok(true, 'start called');
-    };
+QUnit.test('asyncStart waits for asyncEnd to finish a test', function() {
+  adapter.asyncStart();
+  setTimeout(function() {
+    ok(true);
     adapter.asyncEnd();
-  } finally {
-    QUnit.start = originalStart;
-  }
+  }, 50);
 });
 
 QUnit.test('exception causes a failing assertion', function() {


### PR DESCRIPTION
An attempt to fix #13696.

The good: it works! There are some other things to be cleaned up in the ecosystem (such as the use of `setup`/`teardown`), but this makes all the code in Ember itself QUnit 2.0 compatible.

The bad: it relies on some private QUnit knowledge. Without some revamping of how tests are run though I don't see much way around that.
