### PR TITLE
Fix build for 2.6.0 release branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "aws-sdk": "~2.2.43",
-    "babel-plugin-feature-flags": "~0.2.0",
+    "babel-plugin-feature-flags": "0.2.0",
     "babel-plugin-filter-imports": "~0.2.0",
     "bower": "~1.7.7",
     "broccoli-stew": "^1.2.0",


### PR DESCRIPTION
The release versions of `babel-plugin-feature-flags` seem to be in a messed up state. 0.2.1 release contains a [fix](https://github.com/ember-cli/babel-plugin-feature-flags/commit/b120f9f905c42372cf661f8a2e5932b103b7a9d5) which ports to Babel 6 and should have gone in 0.3.0 release. This causes the build for v2.6.x to fail.

Per the readme of `babel-plugin-feature-flags`: "This plugin is for Babel 6. If you need to support Babel 5 use the 0.2.x releases.".

This PR locks the version of the plugin to 0.2.0.

PS: I did not find a `release-2-6` branch and figured 2.6 was released from this branch. So I did a diff against this branch. Build on master seems to work with Babel 6 so probably this needs to be ported to previous release branches too.

cc: @krisselden @chadhietala @rwjblue 
