### PR TITLE
Remove JSHint directives from Mocha test blueprints

### DIFF
--- a/blueprints/acceptance-test/mocha-files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/mocha-files/tests/acceptance/__name__-test.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import { describe, it, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
 import startApp from '../helpers/start-app';

--- a/blueprints/component-test/mocha-files/tests/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/mocha-files/tests/__testType__/__path__/__test__.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import { expect } from 'chai';
 import { describeComponent, it } from 'ember-mocha';<% if (testType === 'integration') { %>
 import hbs from 'htmlbars-inline-precompile';<% } %>

--- a/blueprints/controller-test/mocha-files/tests/unit/__path__/__test__.js
+++ b/blueprints/controller-test/mocha-files/tests/unit/__path__/__test__.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
 

--- a/blueprints/helper-test/mocha-files/tests/__testType__/helpers/__name__-test.js
+++ b/blueprints/helper-test/mocha-files/tests/__testType__/helpers/__name__-test.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import { expect } from 'chai';
 <% if (testType == 'integration') { %>
 import { describeComponent, it } from 'ember-mocha';

--- a/blueprints/initializer-test/mocha-files/tests/unit/initializers/__name__-test.js
+++ b/blueprints/initializer-test/mocha-files/tests/unit/initializers/__name__-test.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
 import Ember from 'ember';

--- a/blueprints/instance-initializer-test/mocha-files/tests/unit/instance-initializers/__name__-test.js
+++ b/blueprints/instance-initializer-test/mocha-files/tests/unit/instance-initializers/__name__-test.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
 import Ember from 'ember';

--- a/blueprints/mixin-test/mocha-files/tests/unit/mixins/__name__-test.js
+++ b/blueprints/mixin-test/mocha-files/tests/unit/mixins/__name__-test.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import Ember from 'ember';

--- a/blueprints/route-test/mocha-files/tests/unit/__path__/__test__.js
+++ b/blueprints/route-test/mocha-files/tests/unit/__path__/__test__.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
 

--- a/blueprints/service-test/mocha-files/tests/unit/__path__/__name__-test.js
+++ b/blueprints/service-test/mocha-files/tests/unit/__path__/__name__-test.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
 

--- a/blueprints/util-test/mocha-files/tests/unit/utils/__name__-test.js
+++ b/blueprints/util-test/mocha-files/tests/unit/utils/__name__-test.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import <%= camelizedModuleName %> from '<%= dasherizedPackageName %>/utils/<%= dasherizedModuleName %>';


### PR DESCRIPTION
The `expr` rule should instead be deactivated in `tests/.jshintrc`.

see also https://github.com/ember-cli/ember-cli-legacy-blueprints/pull/33
