### PR TITLE
[BUGFIX release] Fix to throw error for `Ember.Map()` without `new`

### DIFF
--- a/packages/ember-metal/lib/map.js
+++ b/packages/ember-metal/lib/map.js
@@ -240,13 +240,13 @@ OrderedSet.prototype = {
   @constructor
 */
 function Map() {
-  if (this instanceof this.constructor) {
+  if (this instanceof Map) {
     this._keys = OrderedSet.create();
     this._keys._silenceRemoveDeprecation = true;
     this._values = new EmptyObject();
     this.size = 0;
   } else {
-    missingNew('OrderedSet');
+    missingNew('Map');
   }
 }
 

--- a/packages/ember-metal/tests/map_test.js
+++ b/packages/ember-metal/tests/map_test.js
@@ -468,6 +468,13 @@ QUnit.test('Map.prototype.constructor', function() {
   equal(map.constructor, Map);
 });
 
+QUnit.test('Map() without `new`', function() {
+  QUnit.throws(() => {
+    // jshint newcap:false
+    Map();
+  }, /Constructor Map requires 'new'/);
+});
+
 QUnit.test('MapWithDefault.prototype.constructor', function() {
   let map = new MapWithDefault({
     defaultValue(key) { return key; }
@@ -510,6 +517,13 @@ QUnit.module('OrderedSet', {
 
     map = OrderedSet.create();
   }
+});
+
+QUnit.test('OrderedSet() without `new`', function() {
+  QUnit.throws(() => {
+    // jshint newcap:false
+    OrderedSet();
+  }, /Constructor OrderedSet requires 'new'/);
 });
 
 QUnit.test('add returns the set', function() {


### PR DESCRIPTION
The `this` keyword refers global context (such as `window`) inside function call.

``` js
this instanceof this.constructor // === window instanceof window.constructor
//=> true
```

This means that `Ember.Map()`(without `new`) contaminates global variables unexpectedly.
