### PR TITLE
[Glimmer 2] Remove invalid tests for {{link-to}} without router.

### DIFF
--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -8,14 +8,11 @@ import { subscribe, reset } from 'ember-metal/instrumentation';
 import isEnabled from 'ember-metal/features';
 import alias from 'ember-metal/alias';
 import Application from 'ember-application/system/application';
-import Component from 'ember-templates/component';
-import ComponentLookup from 'ember-views/component_lookup';
 import jQuery from 'ember-views/system/jquery';
 import EmberObject from 'ember-runtime/system/object';
 import inject from 'ember-runtime/inject';
 import { A as emberA } from 'ember-runtime/system/native_array';
 import NoneLocation from 'ember-routing/location/none_location';
-import { OWNER } from 'container/owner';
 import { compile } from 'ember-template-compiler/tests/utils/helpers';
 import { setTemplates, set as setTemplate } from 'ember-templates/template_registry';
 
@@ -97,41 +94,6 @@ QUnit.module('The {{link-to}} helper', {
   },
 
   teardown: sharedTeardown
-});
-
-// These two tests are designed to simulate the context of an ember-qunit/ember-test-helpers component integration test,
-// so the container is available but it does not boot the entire app
-test('Using {{link-to}} does not cause an exception if it is rendered before the router has started routing', function(assert) {
-  Router.map(function() {
-    this.route('about');
-  });
-
-  appInstance.register('component-lookup:main', ComponentLookup);
-
-  let component = Component.extend({
-    [OWNER]: appInstance,
-    layout: compile('{{#link-to "about"}}Go to About{{/link-to}}')
-  }).create();
-
-  let router = appInstance.lookup('router:main');
-  router.setupRouter();
-
-  run(() => component.appendTo('#qunit-fixture'));
-
-  assert.strictEqual(component.$('a').length, 1, 'the link is rendered');
-});
-
-test('Using {{link-to}} does not cause an exception if it is rendered without a router.js instance', function(assert) {
-  appInstance.register('component-lookup:main', ComponentLookup);
-
-  let component = Component.extend({
-    [OWNER]: appInstance,
-    layout: compile('{{#link-to "nonexistent"}}Does not work.{{/link-to}}')
-  }).create();
-
-  run(() => component.appendTo('#qunit-fixture'));
-
-  assert.strictEqual(component.$('a').length, 1, 'the link is rendered');
 });
 
 QUnit.test('The {{link-to}} helper moves into the named route', function() {


### PR DESCRIPTION
These tests are not properly emulating the behaviors of ember-test-helpers. In these tests, the application registry has not been properly setup/created since it is done in `_bootSync` but the test harness defers readiness and never truly boots the application (causing the registry to not be setup).

The specific scenario of `{{link-to}}` working without a router available is properly tested [here](https://github.com/emberjs/ember.js/blob/81102a1f49b2b607ddf290ad17b2d1c067c85b6c/packages/ember-glimmer/tests/integration/components/link-to-test.js#L22-L28).

Closes #13671.
