### PR TITLE
[FEATURE ember-string-ishtmlsafe] Prevent deprecation when not enabled.

### DIFF
--- a/packages/ember-glimmer/tests/compat/safe-string-test.js
+++ b/packages/ember-glimmer/tests/compat/safe-string-test.js
@@ -2,30 +2,43 @@ import EmberHandlebars from 'ember-htmlbars/compat';
 import { isHtmlSafe } from 'ember-htmlbars/utils/string';
 import { TestCase } from '../utils/abstract-test-case';
 import { moduleFor } from '../utils/test-case';
+import isEnabled from 'ember-metal/features';
 
 
 moduleFor('compat - SafeString', class extends TestCase {
   ['@test using new results in a deprecation']() {
     let result;
 
-    expectDeprecation(() => {
+    if (isEnabled('ember-string-ishtmlsafe')) {
+      expectDeprecation(() => {
+        result = new EmberHandlebars.SafeString('<b>test</b>');
+      }, 'Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe');
+    } else {
       result = new EmberHandlebars.SafeString('<b>test</b>');
-    }, 'Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe');
+    }
 
     this.assert.equal(result.toHTML(), '<b>test</b>');
 
-    // Ensure this functionality is maintained for backwards compat, but also deprecated.
-    expectDeprecation(() => {
+    if (isEnabled('ember-string-ishtmlsafe')) {
+      // Ensure this functionality is maintained for backwards compat, but also deprecated.
+      expectDeprecation(() => {
+        this.assert.ok(result instanceof EmberHandlebars.SafeString);
+      }, 'Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe');
+    } else {
       this.assert.ok(result instanceof EmberHandlebars.SafeString);
-    }, 'Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe');
+    }
   }
 
   ['@test isHtmlSafe should detect SafeString']() {
     let safeString;
 
-    expectDeprecation(() => {
+    if (isEnabled('ember-string-ishtmlsafe')) {
+      expectDeprecation(() => {
+        safeString = new EmberHandlebars.SafeString('<b>test</b>');
+      }, 'Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe');
+    } else {
       safeString = new EmberHandlebars.SafeString('<b>test</b>');
-    }, 'Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe');
+    }
 
     this.assert.ok(isHtmlSafe(safeString));
   }

--- a/packages/ember-htmlbars/lib/compat.js
+++ b/packages/ember-htmlbars/lib/compat.js
@@ -4,23 +4,29 @@ import {
   SafeString,
   escapeExpression
 } from 'ember-htmlbars/utils/string';
+import isEnabled from 'ember-metal/features';
 
 let EmberHandlebars = Ember.Handlebars = Ember.Handlebars || {};
-Object.defineProperty(EmberHandlebars, 'SafeString', {
-  get() {
-    deprecate(
-      'Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe',
-      false,
-      {
-        id: 'ember-htmlbars.ember-handlebars-safestring',
-        until: '3.0.0',
-        url: 'http://emberjs.com/deprecations/v2.x#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring'
-      }
-    );
 
-    return SafeString;
-  }
-});
+if (isEnabled('ember-string-ishtmlsafe')) {
+  Object.defineProperty(EmberHandlebars, 'SafeString', {
+    get() {
+      deprecate(
+        'Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe',
+        false,
+        {
+          id: 'ember-htmlbars.ember-handlebars-safestring',
+          until: '3.0.0',
+          url: 'http://emberjs.com/deprecations/v2.x#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring'
+        }
+      );
+
+      return SafeString;
+    }
+  });
+} else {
+  EmberHandlebars.SafeString = SafeString;
+}
 
 EmberHandlebars.Utils =  {
   escapeExpression: escapeExpression


### PR DESCRIPTION
I missed this in review, but it seems that accessing `Ember.Handlebars.SafeString` was issuing a deprecation even with the `ember-string-ishtmlsafe` flag was not enabled.

/cc @workmanw for review
