### PR TITLE
[glimmer2] fix #each with key option test

### DIFF
--- a/packages/ember-glimmer/tests/integration/syntax/each-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/each-test.js
@@ -303,7 +303,7 @@ moduleFor('Syntax test: {{#each as}}', class extends EachTest {
     this.assertInvariants();
   }
 
-  [`@htmlbars it maintains DOM stability for stable keys when list is updated`]() {
+  [`@test it maintains DOM stability for stable keys when list is updated`]() {
     this.render(`{{#each list key="text" as |item|}}{{item.text}}{{/each}}`, {
       list: emberA([{ text: 'Hello' }, { text: ' ' }, { text: 'world' }])
     });
@@ -318,11 +318,11 @@ moduleFor('Syntax test: {{#each as}}', class extends EachTest {
       let list = get(this.context, 'list');
       list.unshiftObject({ text: ', ' });
       list.unshiftObject({ text: 'Hi' });
-      list.pushObject({ text: ' ' });
+      list.pushObject({ text: '!' });
       list.pushObject({ text: 'earth' });
     });
 
-    this.assertText('Hi, Hello world earth');
+    this.assertText('Hi, Hello world!earth');
 
     this.assertPartialInvariants(2, 5);
 


### PR DESCRIPTION
In Ember, you can remove duplicates in an array by providing the `key`
option to the `{{#each}}` helper.

For example, if given the following `model` property:

``` javascript
[
  {
    "id": "1",
    "name": "Robert Jackson"
  },
  {
    "id": "1",
    "name": "Robert Jackson with diff name but same ID"
  },
  {
    "id": "2",
    "name": "Katie Gengler"
  }
]
```

And the following template:

``` handlebars
{{#each model key="id" as |person|
  {{person.name}}
{{/each}}
```

It would render the following:

``` html
Robert Jackson
Katie Gengler
```

Even though we have two objects with "Robert Jackson" as the name, they
share the same "id", so Ember will only render the first object it
encounters with that "id" while iterating. That's why "Robert Jackson"
shows up but not "Robert Jackson with diff name but same ID".

This test was adding in a new object (in our case `{text: ' '}`), but an
object with `{text: ' '}` already existed in the setup line. Because it
was cached by the same `'text'` value, it did not show up in the
subsequent rerender.

We change it to a different text value so we can assert it was added
correctly in the list.

refs #13644
