### PR TITLE
[Glimmer 2] Support classNameBindings from the call site

### DIFF
--- a/packages/ember-glimmer/lib/helpers/-normalize-class.js
+++ b/packages/ember-glimmer/lib/helpers/-normalize-class.js
@@ -1,0 +1,47 @@
+import { InternalHelperReference } from '../utils/references';
+import { dasherize } from 'ember-runtime/system/string';
+
+function normalizeClass({ positional, named }) {
+  let value = positional.at(1).value();
+  let activeClass = named.at('activeClass').value();
+  let inactiveClass = named.at('inactiveClass').value();
+
+  // When using the colon syntax, evaluate the truthiness or falsiness
+  // of the value to determine which className to return.
+  if (activeClass || inactiveClass) {
+    if (!!value) {
+      return activeClass;
+    } else {
+      return inactiveClass;
+    }
+
+  // If value is a Boolean and true, return the dasherized property
+  // name.
+  } else if (value === true) {
+    let propName = positional.at(0);
+    // Only apply to last segment in the path.
+    if (propName) {
+      let segments = propName.split('.');
+      propName = segments[segments.length - 1];
+    }
+
+    return dasherize(propName);
+
+  // If the value is not false, undefined, or null, return the current
+  // value of the property.
+  } else if (value !== false && value != null) {
+    return value;
+
+  // Nothing to display. Return null so that the old class is removed
+  // but no new class is added.
+  } else {
+    return null;
+  }
+}
+
+export default {
+  isInternalHelper: true,
+  toReference(args) {
+    return new InternalHelperReference(normalizeClass, args);
+  }
+};

--- a/packages/ember-glimmer/tests/integration/components/class-bindings-test.js
+++ b/packages/ember-glimmer/tests/integration/components/class-bindings-test.js
@@ -44,6 +44,27 @@ moduleFor('ClassNameBindings intigration', class extends RenderingTest {
     this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { 'class': classes('ember-view foo enabled sad') }, content: 'hello' });
   }
 
+  ['@test const bindings can be set as attrs']() {
+    this.registerComponent('foo-bar', { template: 'hello' });
+    this.render('{{foo-bar classNameBindings="foo:enabled:disabled"}}', {
+      foo: true
+    });
+
+    this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { 'class': classes('ember-view enabled') }, content: 'hello' });
+
+    this.runTask(() => this.rerender());
+
+    this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { 'class': classes('ember-view enabled') }, content: 'hello' });
+
+    this.runTask(() => set(this.context, 'foo', false));
+
+    this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { 'class': classes('ember-view disabled') }, content: 'hello' });
+
+    this.runTask(() => set(this.context, 'foo', true));
+
+    this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { 'class': classes('ember-view enabled') }, content: 'hello' });
+  }
+
   ['@test :: class name syntax works with an empty true class']() {
     let FooBarComponent = Component.extend({
       classNameBindings: ['isEnabled::not-enabled']
@@ -170,11 +191,8 @@ moduleFor('ClassNameBindings intigration', class extends RenderingTest {
 
 });
 
-const bindingDeprecationMessage = '`Ember.Binding` is deprecated. Consider' +
-  ' using an `alias` computed property instead.';
-
 moduleFor('ClassBinding intigration', class extends RenderingTest {
-  ['@htmlbars it should apply classBinding without condition always']() {
+  ['@test it should apply classBinding without condition always']() {
     this.registerComponent('foo-bar', { template: 'hello' });
 
     this.render('{{foo-bar classBinding=":foo"}}');
@@ -186,9 +204,7 @@ moduleFor('ClassBinding intigration', class extends RenderingTest {
     this.assertComponentElement(this.firstChild, { tagName: 'div', content: 'hello', attrs: { 'class': classes('foo  ember-view') } });
   }
 
-  ['@glimmer it should merge classBinding with class']() {
-    expectDeprecation(bindingDeprecationMessage);
-
+  ['@test it should merge classBinding with class']() {
     this.registerComponent('foo-bar', { template: 'hello' });
 
     this.render('{{foo-bar classBinding="birdman:respeck" class="myName"}}', { birdman: true });
@@ -200,23 +216,7 @@ moduleFor('ClassBinding intigration', class extends RenderingTest {
     this.assertComponentElement(this.firstChild, { tagName: 'div', content: 'hello', attrs: { 'class': classes('respeck myName ember-view') } });
   }
 
-  ['@glimmer in glimmer it should apply classBinding without condition always']() {
-    expectDeprecation(bindingDeprecationMessage);
-
-    this.registerComponent('foo-bar', { template: 'hello' });
-
-    this.render('{{foo-bar classBinding=":foo"}}');
-
-    this.assertComponentElement(this.firstChild, { tagName: 'div', content: 'hello', attrs: { 'class': classes('foo  ember-view') } });
-
-    this.runTask(() => this.rerender());
-
-    this.assertComponentElement(this.firstChild, { tagName: 'div', content: 'hello', attrs: { 'class': classes('foo  ember-view') } });
-  }
-
-  ['@glimmer it should apply classBinding with only truthy condition']() {
-    expectDeprecation(bindingDeprecationMessage);
-
+  ['@test it should apply classBinding with only truthy condition']() {
     this.registerComponent('foo-bar', { template: 'hello' });
 
     this.render('{{foo-bar classBinding="myName:respeck"}}', { myName: true });
@@ -228,9 +228,7 @@ moduleFor('ClassBinding intigration', class extends RenderingTest {
     this.assertComponentElement(this.firstChild, { tagName: 'div', content: 'hello', attrs: { 'class': classes('respeck  ember-view') } });
   }
 
-  ['@glimmer it should apply classBinding with only falsy condition']() {
-    expectDeprecation(bindingDeprecationMessage);
-
+  ['@test it should apply classBinding with only falsy condition']() {
     this.registerComponent('foo-bar', { template: 'hello' });
 
     this.render('{{foo-bar classBinding="myName::shade"}}', { myName: false });
@@ -242,9 +240,7 @@ moduleFor('ClassBinding intigration', class extends RenderingTest {
     this.assertComponentElement(this.firstChild, { tagName: 'div', content: 'hello', attrs: { 'class': classes('shade  ember-view') } });
   }
 
-  ['@glimmer it should apply nothing when classBinding is falsy but only supplies truthy class']() {
-    expectDeprecation(bindingDeprecationMessage);
-
+  ['@test it should apply nothing when classBinding is falsy but only supplies truthy class']() {
     this.registerComponent('foo-bar', { template: 'hello' });
 
     this.render('{{foo-bar classBinding="myName:respeck"}}', { myName: false });
@@ -256,9 +252,7 @@ moduleFor('ClassBinding intigration', class extends RenderingTest {
     this.assertComponentElement(this.firstChild, { tagName: 'div', content: 'hello', attrs: { 'class': classes('ember-view') } });
   }
 
-  ['@glimmer it should apply nothing when classBinding is truthy but only supplies falsy class']() {
-    expectDeprecation(bindingDeprecationMessage);
-
+  ['@test it should apply nothing when classBinding is truthy but only supplies falsy class']() {
     this.registerComponent('foo-bar', { template: 'hello' });
 
     this.render('{{foo-bar classBinding="myName::shade"}}', { myName: true });
@@ -270,9 +264,7 @@ moduleFor('ClassBinding intigration', class extends RenderingTest {
     this.assertComponentElement(this.firstChild, { tagName: 'div', content: 'hello', attrs: { 'class': classes('ember-view') } });
   }
 
-  ['@glimmer it should apply classBinding with falsy condition']() {
-    expectDeprecation(bindingDeprecationMessage);
-
+  ['@test it should apply classBinding with falsy condition']() {
     this.registerComponent('foo-bar', { template: 'hello' });
 
     this.render('{{foo-bar classBinding="swag:fresh:scrub"}}', { swag: false });
@@ -284,9 +276,7 @@ moduleFor('ClassBinding intigration', class extends RenderingTest {
     this.assertComponentElement(this.firstChild, { tagName: 'div', content: 'hello', attrs: { 'class': classes('scrub  ember-view') } });
   }
 
-  ['@glimmer it should apply classBinding with truthy condition']() {
-    expectDeprecation(bindingDeprecationMessage);
-
+  ['@test it should apply classBinding with truthy condition']() {
     this.registerComponent('foo-bar', { template: 'hello' });
 
     this.render('{{foo-bar classBinding="swag:fresh:scrub"}}', { swag: true });

--- a/packages/ember-htmlbars-template-compiler/lib/system/compile-options.js
+++ b/packages/ember-htmlbars-template-compiler/lib/system/compile-options.js
@@ -9,7 +9,6 @@ import defaultPlugins from 'ember-template-compiler/plugins';
 import TransformClosureComponentAttrsIntoMut from '../plugins/transform-closure-component-attrs-into-mut';
 import TransformComponentAttrsIntoMut from '../plugins/transform-component-attrs-into-mut';
 import TransformComponentCurlyToReadonly from '../plugins/transform-component-curly-to-readonly';
-import TransformOldClassBindingSyntax from '../plugins/transform-old-class-binding-syntax';
 
 export let PLUGINS = [
   ...defaultPlugins,
@@ -17,8 +16,7 @@ export let PLUGINS = [
   // the following are ember-htmlbars specific
   TransformClosureComponentAttrsIntoMut,
   TransformComponentAttrsIntoMut,
-  TransformComponentCurlyToReadonly,
-  TransformOldClassBindingSyntax
+  TransformComponentCurlyToReadonly
 ];
 
 let USER_PLUGINS = [];

--- a/packages/ember-template-compiler/lib/plugins/index.js
+++ b/packages/ember-template-compiler/lib/plugins/index.js
@@ -5,6 +5,7 @@ import TransformInputOnToOnEvent from 'ember-template-compiler/plugins/transform
 import TransformTopLevelComponents from 'ember-template-compiler/plugins/transform-top-level-components';
 import DeprecateRenderModel from 'ember-template-compiler/plugins/deprecate-render-model';
 import TransformInlineLinkTo from 'ember-template-compiler/plugins/transform-inline-link-to';
+import TransformOldClassBindingSyntax from 'ember-template-compiler/plugins/transform-old-class-binding-syntax';
 
 export default Object.freeze([
   TransformOldBindingSyntax,
@@ -13,5 +14,6 @@ export default Object.freeze([
   TransformInputOnToOnEvent,
   TransformTopLevelComponents,
   DeprecateRenderModel,
-  TransformInlineLinkTo
+  TransformInlineLinkTo,
+  TransformOldClassBindingSyntax
 ]);

--- a/packages/ember-template-compiler/lib/plugins/transform-old-class-binding-syntax.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-old-class-binding-syntax.js
@@ -56,7 +56,7 @@ TransformOldClassBindingSyntax.prototype.transform = function TransformOldClassB
     });
 
     let hash = b.hash();
-    classPair.value = b.sexpr(b.string('concat'), classValue, hash);
+    classPair.value = b.sexpr(b.path('concat'), classValue, hash);
   });
 
   return ast;
@@ -73,7 +73,7 @@ function buildSexprs(microsyntax, sexprs, b) {
     } else {
       let params = [b.path(propName)];
 
-      if (activeClass) {
+      if (activeClass || activeClass === '') {
         params.push(b.string(activeClass));
       } else {
         let sexprParams = [b.string(propName), b.path(propName)];
@@ -90,11 +90,11 @@ function buildSexprs(microsyntax, sexprs, b) {
         params.push(b.sexpr(b.string('-normalize-class'), sexprParams, hash));
       }
 
-      if (inactiveClass) {
+      if (inactiveClass || inactiveClass === '') {
         params.push(b.string(inactiveClass));
       }
 
-      sexpr = b.sexpr(b.string('if'), params);
+      sexpr = b.sexpr(b.path('if'), params);
     }
 
     sexprs.push(sexpr);

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -76,8 +76,6 @@ function sharedTeardown() {
   reset();
 }
 
-import { test } from 'internal-test-helpers/tests/skip-if-glimmer';
-
 QUnit.module('The {{link-to}} helper', {
   setup() {
     run(() => {
@@ -417,7 +415,7 @@ QUnit.test('The {{link-to}} helper supports a custom activeClass from a bound pa
   equal(jQuery('#about-link:not(.active)', '#qunit-fixture').length, 1, 'The other link was rendered without active class');
 });
 
-test("The {{link-to}} helper supports 'classNameBindings' with custom values [GH #11699]", function() {
+QUnit.test("The {{link-to}} helper supports 'classNameBindings' with custom values [GH #11699]", function() {
   setTemplate('index', compile(`<h3>Home</h3>{{#link-to 'about' id='about-link' classNameBindings='foo:foo-is-true:foo-is-false'}}About{{/link-to}}`));
 
   Router.map(function() {


### PR DESCRIPTION
This brings back the build time transforms for `classNameBindings` and `classBindings`.
