### PR TITLE
Bind the watchModelTypes's release function to `this` so it correctly…

### DIFF
--- a/packages/ember-extension-support/lib/data_adapter.js
+++ b/packages/ember-extension-support/lib/data_adapter.js
@@ -302,9 +302,7 @@ export default EmberObject.extend({
 
     addArrayObserver(records, this, observer);
 
-    function release() {
-      removeArrayObserver(records, this, observer);
-    }
+    let release = () => removeArrayObserver(records, this, observer);
 
     return release;
   },


### PR DESCRIPTION
… removes the array observers

Not sure what the best way to test this is since it's tied to the cleanup of the app.
