### PR TITLE
[BUGFIX beta] Remove unreferenced function from `ember-metal/replace`

### DIFF
--- a/packages/ember-metal/lib/replace.js
+++ b/packages/ember-metal/lib/replace.js
@@ -1,6 +1,6 @@
 let { splice } = Array.prototype;
 
-export function _replace(array, idx, amt, objects) {
+export default function replace(array, idx, amt, objects) {
   let args = [].concat(objects);
   let ret = [];
   // https://code.google.com/p/chromium/issues/detail?id=56588
@@ -22,39 +22,4 @@ export function _replace(array, idx, amt, objects) {
     ret = ret.concat(splice.apply(array, chunk));
   }
   return ret;
-}
-
-/**
-  Replaces objects in an array with the passed objects.
-
-  ```javascript
-    let array = [1,2,3];
-    Ember.EnumerableUtils.replace(array, 1, 2, [4, 5]); // [1, 4, 5]
-
-    let array = [1,2,3];
-    Ember.EnumerableUtils.replace(array, 1, 1, [4, 5]); // [1, 4, 5, 3]
-
-    let array = [1,2,3];
-    Ember.EnumerableUtils.replace(array, 10, 1, [4, 5]); // [1, 2, 3, 4, 5]
-  ```
-
-  @method replace
-  @deprecated
-  @param {Array} array The array the objects should be inserted into.
-  @param {Number} idx Starting index in the array to replace. If *idx* >=
-  length, then append to the end of the array.
-  @param {Number} amt Number of elements that should be removed from the array,
-  starting at *idx*
-  @param {Array} objects An array of zero or more objects that should be
-  inserted into the array at *idx*
-
-  @return {Array} The modified array.
-  @public
-*/
-export default function replace(array, idx, amt, objects) {
-  if (array.replace) {
-    return array.replace(idx, amt, objects);
-  } else {
-    return _replace(array, idx, amt, objects);
-  }
 }

--- a/packages/ember-runtime/lib/system/native_array.js
+++ b/packages/ember-runtime/lib/system/native_array.js
@@ -4,7 +4,7 @@
 */
 import Ember from 'ember-metal/core'; // Ember.A circular
 import { ENV } from 'ember-environment';
-import { _replace as replace } from 'ember-metal/replace';
+import replace from 'ember-metal/replace';
 import { get } from 'ember-metal/property_get';
 import { Mixin } from 'ember-metal/mixin';
 import EmberArray, {


### PR DESCRIPTION
This function became unnecessary with the followings:
- Ember.ArrayController: 9899dffe
- Ember.Select: 4b5b9729

I think we can remove this function due to un-exported.
If are there some fears, should it be shown deprecation warning?
