### PR TITLE
[CLEANUP beta] Remove unreferenced module 'ember-runtime/core'

### DIFF
--- a/packages/ember-runtime/lib/core.js
+++ b/packages/ember-runtime/lib/core.js
@@ -1,4 +1,0 @@
-/**
-@module ember
-@submodule ember-runtime
-*/


### PR DESCRIPTION
It is unnecessary since 149c4f41.
