### PR TITLE
[FEATURE ember-application-engines] Enable routable engines.

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -112,6 +112,23 @@ const EmberRouter = EmberObject.extend(Evented, {
       options.router = this;
     }
 
+    if (isEnabled('ember-application-engines')) {
+      let owner = getOwner(this);
+      let router = this;
+
+      options.enableLoadingSubstates = !!moduleBasedResolver;
+
+      options.resolveRouteMap = function(name) {
+        return owner._lookupFactory('route-map:' + name);
+      };
+
+      options.addRouteForEngine = function(name, engineInfo) {
+        if (!router._engineInfoByRoute[name]) {
+          router._engineInfoByRoute[name] = engineInfo;
+        }
+      };
+    }
+
     return new EmberRouterDSL(null, options);
   },
 

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -5,6 +5,7 @@ import EmberRoute from 'ember-routing/system/route';
 import inject from 'ember-runtime/inject';
 import buildOwner from 'container/tests/test-helpers/build-owner';
 import { setOwner } from 'container/owner';
+import isEnabled from 'ember-metal/features';
 
 let route, routeOne, routeTwo, lookupHash;
 
@@ -321,3 +322,94 @@ QUnit.test('services can be injected into routes', function() {
 
   equal(authService, appRoute.get('authService'), 'service.auth is injected');
 });
+
+if (isEnabled('ember-application-engines')) {
+  QUnit.module('Ember.Route with engines');
+
+  QUnit.test('paramsFor considers an engine\'s mountPoint', function(assert) {
+    expect(2);
+
+    let router = {
+      _deserializeQueryParams() {},
+      router: {
+        state: {
+          handlerInfos: [
+            { name: 'posts' }
+          ],
+          params: {
+            'foo.bar': { a: 'b' },
+            'foo.bar.posts': { c: 'd' }
+          }
+        }
+      }
+    };
+
+    let engineInstance = buildOwner({
+      routable: true,
+
+      mountPoint: 'foo.bar',
+
+      lookup(name) {
+        if (name === 'route:posts') {
+          return postsRoute;
+        } else if (name === 'route:application') {
+          return applicationRoute;
+        }
+      }
+    });
+
+    let applicationRoute = EmberRoute.create({ router, routeName: 'application' });
+    let postsRoute = EmberRoute.create({ router, routeName: 'posts' });
+    let route = EmberRoute.create({ router });
+
+    setOwner(applicationRoute, engineInstance);
+    setOwner(postsRoute, engineInstance);
+    setOwner(route, engineInstance);
+
+    assert.deepEqual(route.paramsFor('application'), { a: 'b' }, 'params match for root `application` route in engine');
+    assert.deepEqual(route.paramsFor('posts'), { c: 'd' }, 'params match for `posts` route in engine');
+  });
+
+  QUnit.test('modelFor considers an engine\'s mountPoint', function() {
+    expect(2);
+
+    let applicationModel = { id: '1' };
+    let postsModel = { id: '2' };
+
+    let router = {
+      router: {
+        activeTransition: {
+          resolvedModels: {
+            'foo.bar': applicationModel,
+            'foo.bar.posts': postsModel
+          }
+        }
+      }
+    };
+
+    let engineInstance = buildOwner({
+      routable: true,
+
+      mountPoint: 'foo.bar',
+
+      lookup(name) {
+        if (name === 'route:posts') {
+          return postsRoute;
+        } else if (name === 'route:application') {
+          return applicationRoute;
+        }
+      }
+    });
+
+    let applicationRoute = EmberRoute.create({ router, routeName: 'application' });
+    let postsRoute = EmberRoute.create({ router, routeName: 'posts' });
+    let route = EmberRoute.create({ router });
+
+    setOwner(applicationRoute, engineInstance);
+    setOwner(postsRoute, engineInstance);
+    setOwner(route, engineInstance);
+
+    strictEqual(route.modelFor('application'), applicationModel);
+    strictEqual(route.modelFor('posts'), postsModel);
+  });
+}


### PR DESCRIPTION
Moves routing-related code upstream from [ember-engines](https://github.com/dgeb/ember-engines).

Extends `Route`, `Router`, `Outlet`, and `DSL` classes to support routable engines.

Changes are all behind the `ember-application-engines` feature flag.
