### PR TITLE
Fix "super() use outside of constructor" issues

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/closure-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/closure-components-test.js
@@ -635,7 +635,7 @@ moduleFor('@htmlbars Components test: closure components', class extends Renderi
 
 class ClosureComponentMutableParamsTest extends RenderingTest {
   render(templateStr, context = {}) {
-    super(`${templateStr}<span class="value">{{model.val2}}</span>`, assign(context, { model: { val2: 8 } }));
+    super.render(`${templateStr}<span class="value">{{model.val2}}</span>`, assign(context, { model: { val2: 8 } }));
   }
 }
 

--- a/packages/ember-glimmer/tests/integration/content-test.js
+++ b/packages/ember-glimmer/tests/integration/content-test.js
@@ -952,7 +952,7 @@ if (!EmberDev.runningProdBuild) {
     }
 
     teardown() {
-      super(...arguments);
+      super.teardown(...arguments);
       setDebugFunction('warn', originalWarn);
     }
 

--- a/packages/ember-glimmer/tests/integration/helpers/loc-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/loc-test.js
@@ -14,7 +14,7 @@ moduleFor('Helpers test: {{loc}}', class extends RenderingTest {
   }
 
   teardown() {
-    super();
+    super.teardown();
     Ember.STRINGS = this.oldString;
   }
 

--- a/packages/ember-glimmer/tests/integration/helpers/log-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/log-test.js
@@ -15,7 +15,7 @@ moduleFor('Helpers test: {{log}}', class extends RenderingTest {
   }
 
   teardown() {
-    super();
+    super.teardown();
     Logger.log = this.originalLog;
   }
 

--- a/packages/ember-testing/lib/test/promise.js
+++ b/packages/ember-testing/lib/test/promise.js
@@ -14,7 +14,7 @@ export default class TestPromise extends RSVP.Promise {
   }
 
   then(onFulfillment, ...args) {
-    return super(result => isolate(onFulfillment, result), ...args);
+    return super.then(result => isolate(onFulfillment, result), ...args);
   }
 }
 


### PR DESCRIPTION
Babel 6 flags these as SyntaxError

/cc @rwjblue @stefanpenner 
