### PR TITLE
[Glimmer2] sendAction

### DIFF
--- a/packages/ember-glimmer/lib/component.js
+++ b/packages/ember-glimmer/lib/component.js
@@ -5,6 +5,8 @@ import ViewStateSupport from 'ember-views/mixins/view_state_support';
 import InstrumentationSupport from 'ember-views/mixins/instrumentation_support';
 import AriaRoleSupport from 'ember-views/mixins/aria_role_support';
 import ViewMixin from 'ember-views/mixins/view_support';
+import ActionSupport from 'ember-views/mixins/action_support';
+import TargetActionSupport from 'ember-runtime/mixins/target_action_support';
 import EmberView from 'ember-views/views/view';
 import symbol from 'ember-metal/symbol';
 import EmptyObject from 'ember-metal/empty_object';
@@ -36,10 +38,14 @@ const Component = CoreView.extend(
   ClassNamesSupport,
   InstrumentationSupport,
   AriaRoleSupport,
+  TargetActionSupport,
+  ActionSupport,
   ViewMixin, {
     isComponent: true,
     layoutName: null,
     layout: null,
+    controller: null,
+    _controller: null,
 
     init() {
       this._super(...arguments);
@@ -47,6 +53,7 @@ const Component = CoreView.extend(
       this[DIRTY_TAG] = new DirtyableTag();
       this[ROOT_REF] = null;
       this[REFS] = new EmptyObject();
+      this.controller = this;
 
       // If a `defaultLayout` was specified move it to the `layout` prop.
       // `layout` is no longer a CP, so this just ensures that the `defaultLayout`

--- a/packages/ember-glimmer/lib/renderer.js
+++ b/packages/ember-glimmer/lib/renderer.js
@@ -149,7 +149,7 @@ class Renderer {
   appendTo(view, target) {
     let env = this._env;
     let self = new RootReference(view);
-    let dynamicScope = new DynamicScope({ view });
+    let dynamicScope = new DynamicScope({ view, controller: view.controller });
 
     env.begin();
     let result = view.template.asEntryPoint().render(self, env, { appendTo: target, dynamicScope });

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -6,6 +6,8 @@ import processArgs from '../utils/process-args';
 import { getOwner } from 'container/owner';
 import { privatize as P } from 'container/registry';
 import get from 'ember-metal/property_get';
+import { ComponentDefinition } from 'glimmer-runtime';
+import Component from '../component';
 
 const DEFAULT_LAYOUT = P`template:components/-default`;
 
@@ -77,6 +79,13 @@ class CurlyComponentManager {
 
     dynamicScope.view = component;
     parentView.appendChild(component);
+
+    if (parentView.controller) {
+      dynamicScope.controller = parentView.controller;
+    }
+
+    component._controller = dynamicScope.controller;
+
 
     component.trigger('didInitAttrs', { attrs });
     component.trigger('didReceiveAttrs', { newAttrs: attrs });
@@ -225,9 +234,6 @@ class CurlyComponentManager {
 }
 
 const MANAGER = new CurlyComponentManager();
-
-import { ComponentDefinition } from 'glimmer-runtime';
-import Component from '../component';
 
 function tagName(vm) {
   let { tagName } = vm.dynamicScope().view;

--- a/packages/ember-glimmer/lib/syntax/outlet.js
+++ b/packages/ember-glimmer/lib/syntax/outlet.js
@@ -128,8 +128,10 @@ const TOP_LEVEL_MANAGER = new TopLevelOutletComponentManager();
 
 class OutletComponentManager extends AbstractOutletComponentManager {
   create(definition, args, dynamicScope) {
-    let outletState = dynamicScope.outletState = dynamicScope.outletState.get(definition.outletName);
-    return outletState.value();
+    let outletStateReference = dynamicScope.outletState = dynamicScope.outletState.get(definition.outletName);
+    let outletState = outletStateReference.value();
+    dynamicScope.controller = outletState.render.controller;
+    return outletState;
   }
 }
 

--- a/packages/ember-glimmer/lib/utils/process-args.js
+++ b/packages/ember-glimmer/lib/utils/process-args.js
@@ -4,6 +4,7 @@ import { assert } from 'ember-metal/debug';
 import EmptyObject from 'ember-metal/empty_object';
 import { ARGS } from '../component';
 import { UPDATE } from './references';
+import { MUTABLE_CELL } from 'ember-views/compat/attrs-proxy';
 
 export default function processArgs(args, positionalParamsDefinition) {
   if (!positionalParamsDefinition || positionalParamsDefinition.length === 0 || args.positional.length === 0) {
@@ -64,8 +65,6 @@ class SimpleArgs {
     return { attrs, props };
   }
 }
-
-const MUTABLE_CELL = symbol('MUTABLE_CELL');
 
 export function isCell(val) {
   return val && val[MUTABLE_CELL];

--- a/packages/ember-glimmer/tests/integration/application/rendering-test.js
+++ b/packages/ember-glimmer/tests/integration/application/rendering-test.js
@@ -241,6 +241,29 @@ moduleFor('Application test: rendering', class extends ApplicationTest {
     });
   }
 
+  ['@test it should have the right controller in scope for the route template']() {
+    this.router.map(function() {
+      this.route('a');
+      this.route('b');
+    });
+
+    this.registerController('a', Controller.extend({
+      value: 'a'
+    }));
+
+    this.registerController('b', Controller.extend({
+      value: 'b'
+    }));
+
+    this.registerTemplate('a', '{{value}}');
+    this.registerTemplate('b', '{{value}}');
+
+    return this.visit('/a').then(() => {
+      this.assertText('a');
+      return this.visit('/b');
+    }).then(() => this.assertText('b'));
+  }
+
   ['@test it should update correctly when the controller changes'](assert) {
     this.router.map(function() {
       this.route('color', { path: '/colors/:color' });

--- a/packages/ember-glimmer/tests/integration/components/dynamic-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/dynamic-components-test.js
@@ -399,7 +399,7 @@ moduleFor('Components test: dynamic components', class extends RenderingTest {
     this.assertText('foo-bar Caracas Caracas arepas!');
   }
 
-  ['@htmlbars component helper with actions'](assert) {
+  ['@test component helper with actions'](assert) {
     this.registerComponent('inner-component', {
       template: 'inner-component {{yield}}',
       ComponentClass: Component.extend({

--- a/packages/ember-glimmer/tests/integration/components/target-action-test.js
+++ b/packages/ember-glimmer/tests/integration/components/target-action-test.js
@@ -1,0 +1,556 @@
+import { moduleFor, RenderingTest, ApplicationTest } from '../../utils/test-case';
+import { set } from 'ember-metal/property_set';
+import { Component } from '../../utils/helpers';
+import assign from 'ember-metal/assign';
+import Controller from 'ember-runtime/controllers/controller';
+import { Mixin } from 'ember-metal/mixin';
+import Route from 'ember-routing/system/route';
+import EmberObject from 'ember-runtime/system/object';
+
+moduleFor('Components test: sendAction', class extends RenderingTest {
+
+  constructor() {
+    super();
+    this.actionCounts = {};
+    this.sendCount = 0;
+    this.actionArguments = null;
+
+    var self = this;
+
+    this.registerComponent('action-delegate', {
+      ComponentClass: Component.extend({
+        init() {
+          this._super();
+          self.delegate = this;
+        }
+      })
+    });
+  }
+
+  renderDelegate(template = '{{action-delegate}}', context = {}) {
+    let root = this;
+    context = assign(context, {
+      send(actionName, ...args) {
+        root.sendCount++;
+        root.actionCounts[actionName] = root.actionCounts[actionName] || 0;
+        root.actionCounts[actionName]++;
+        root.actionArguments = args;
+      }
+    });
+    this.render(template, context);
+  }
+
+  assertSendCount(count) {
+    this.assert.equal(this.sendCount, count, `Send was called ${count} time(s)`);
+  }
+
+  assertNamedSendCount(actionName, count) {
+    this.assert.equal(this.actionCounts[actionName], count, `An action named '${actionName}' was sent ${count} times`);
+  }
+
+  assertSentWithArgs(expected, message = 'arguments were sent with the action') {
+    this.assert.deepEqual(this.actionArguments, expected, message);
+  }
+
+  ['@test Calling sendAction on a component without an action defined does nothing']() {
+    this.renderDelegate();
+
+    this.runTask(() => this.delegate.sendAction());
+
+    this.assertSendCount(0);
+  }
+
+  ['@test Calling sendAction on a component with an action defined calls send on the controller']() {
+    this.renderDelegate();
+
+    this.runTask(() => {
+      set(this.delegate, 'action', 'addItem');
+      this.delegate.sendAction();
+    });
+
+    this.assertSendCount(1);
+    this.assertNamedSendCount('addItem', 1);
+  }
+
+  ['@test Calling sendAction on a component with a function calls the function']() {
+    this.assert.expect(1);
+
+    this.renderDelegate();
+
+    this.runTask(() => {
+      set(this.delegate, 'action', () => this.assert.ok(true, 'function is called'));
+      this.delegate.sendAction();
+    });
+  }
+
+  ['@test Calling sendAction on a component with a function calls the function with arguments']() {
+    this.assert.expect(1);
+    let argument = {};
+
+    this.renderDelegate();
+
+    this.runTask(() => {
+      set(this.delegate, 'action', (actualArgument) => {
+        this.assert.deepEqual(argument, actualArgument, 'argument is passed');
+      });
+      this.delegate.sendAction('action', argument);
+    });
+  }
+
+  // TODO consolidate these next 2 tests
+  ['@glimmer Calling sendAction on a component with a reference attr calls the function with arguments']() {
+    this.renderDelegate('{{action-delegate playing=playing}}', {
+      playing: null
+    });
+
+    this.runTask(() => this.delegate.sendAction());
+
+    this.assertSendCount(0);
+
+
+    this.runTask(() => {
+      set(this.context, 'playing', 'didStartPlaying');
+    });
+
+    this.runTask(() => {
+      this.delegate.sendAction('playing');
+    });
+
+    this.assertSendCount(1);
+    this.assertNamedSendCount('didStartPlaying', 1);
+  }
+
+  ['@htmlbars Calling sendAction on a component with a {{mut}} attr calls the function with arguments']() {
+    this.renderDelegate('{{action-delegate playing=(mut playing)}}', {
+      playing: null
+    });
+
+    this.runTask(() => this.delegate.sendAction('playing'));
+
+    this.assertSendCount(0);
+
+    this.runTask(() => this.delegate.attrs.playing.update('didStartPlaying'));
+    this.runTask(() => this.delegate.sendAction('playing'));
+
+    this.assertSendCount(1);
+    this.assertNamedSendCount('didStartPlaying', 1);
+  }
+
+  ['@test Calling sendAction with a named action uses the component\'s property as the action name']() {
+    this.renderDelegate();
+
+    let component = this.delegate;
+
+    this.runTask(() => {
+      set(this.delegate, 'playing', 'didStartPlaying');
+      component.sendAction('playing');
+    });
+
+    this.assertSendCount(1);
+    this.assertNamedSendCount('didStartPlaying', 1);
+
+    this.runTask(() => component.sendAction('playing'));
+
+    this.assertSendCount(2);
+    this.assertNamedSendCount('didStartPlaying', 2);
+
+    this.runTask(() => {
+      set(component, 'action', 'didDoSomeBusiness');
+      component.sendAction();
+    });
+
+    this.assertSendCount(3);
+    this.assertNamedSendCount('didDoSomeBusiness', 1);
+  }
+
+  ['@test Calling sendAction when the action name is not a string raises an exception']() {
+    this.renderDelegate();
+
+    this.runTask(() => {
+      set(this.delegate, 'action', {});
+      set(this.delegate, 'playing', {});
+    });
+
+    expectAssertion(() => this.delegate.sendAction());
+    expectAssertion(() => this.delegate.sendAction('playing'));
+  }
+
+  ['@test Calling sendAction on a component with contexts']() {
+    this.renderDelegate();
+
+    let testContext = { song: 'She Broke My Ember' };
+    let firstContext  = { song: 'She Broke My Ember' };
+    let secondContext = { song: 'My Achey Breaky Ember' };
+
+    this.runTask(() => {
+      set(this.delegate, 'playing', 'didStartPlaying');
+      this.delegate.sendAction('playing', testContext);
+    });
+
+    this.assertSendCount(1);
+    this.assertNamedSendCount('didStartPlaying', 1);
+    this.assertSentWithArgs([testContext], 'context was sent with the action');
+
+    this.runTask(() => {
+      this.delegate.sendAction('playing', firstContext, secondContext);
+    });
+
+    this.assertSendCount(2);
+    this.assertNamedSendCount('didStartPlaying', 2);
+    this.assertSentWithArgs([firstContext, secondContext], 'multiple contexts were sent to the action');
+  }
+
+});
+
+moduleFor('Components test: sendAction to a controller', class extends ApplicationTest {
+
+  ['@test sendAction should trigger an action on the parent component\'s controller if it exists'](assert) {
+    assert.expect(15);
+
+    let component;
+
+    this.router.map(function () {
+      this.route('a');
+      this.route('b');
+      this.route('c', function () {
+        this.route('d');
+        this.route('e');
+      });
+    });
+
+    this.registerComponent('foo-bar', {
+      ComponentClass: Component.extend({
+        init() {
+          this._super(...arguments);
+          component = this;
+        }
+      }),
+      template: `{{val}}`
+    });
+
+    this.registerController('a', Controller.extend({
+      send(actionName, actionContext) {
+        assert.equal(actionName, 'poke', 'send() method was invoked from a top level controller');
+        assert.equal(actionContext, 'top', 'action arguments were passed into the top level controller');
+      }
+    }));
+    this.registerTemplate('a', '{{foo-bar val="a" poke="poke"}}');
+
+    this.registerRoute('b', Route.extend({
+      actions: {
+        poke(actionContext) {
+          assert.ok(true, 'Unhandled action sent to route');
+          assert.equal(actionContext, 'top no controller');
+        }
+      }
+    }));
+    this.registerTemplate('b', '{{foo-bar val="b" poke="poke"}}');
+
+    this.registerRoute('c', Route.extend({
+      actions: {
+        poke(actionContext) {
+          assert.ok(true, 'Unhandled action sent to route');
+          assert.equal(actionContext, 'top with nested no controller');
+        }
+      }
+    }));
+    this.registerTemplate('c', '{{foo-bar val="c" poke="poke"}}{{outlet}}');
+
+    this.registerRoute('c.d', Route.extend({}));
+
+    this.registerController('c.d', Controller.extend({
+      send(actionName, actionContext) {
+        assert.equal(actionName, 'poke', 'send() method was invoked from a nested controller');
+        assert.equal(actionContext, 'nested', 'action arguments were passed into the nested controller');
+      }
+    }));
+    this.registerTemplate('c.d', '{{foo-bar val=".d" poke="poke"}}');
+
+    this.registerRoute('c.e', Route.extend({
+      actions: {
+        poke(actionContext) {
+          assert.ok(true, 'Unhandled action sent to route');
+          assert.equal(actionContext, 'nested no controller');
+        }
+      }
+    }));
+    this.registerTemplate('c.e', '{{foo-bar val=".e" poke="poke"}}');
+
+    return this.visit('/a')
+      .then(() => component.sendAction('poke', 'top'))
+      .then(() => {
+        this.assertText('a');
+        return this.visit('/b');
+      })
+      .then(() => component.sendAction('poke', 'top no controller'))
+      .then(() => {
+        this.assertText('b');
+        return this.visit('/c');
+      })
+      .then(() => component.sendAction('poke', 'top with nested no controller'))
+      .then(() => {
+        this.assertText('c');
+        return this.visit('/c/d');
+      })
+      .then(() => component.sendAction('poke', 'nested'))
+      .then(() => {
+        this.assertText('c.d');
+        return this.visit('/c/e');
+      })
+      .then(() => component.sendAction('poke', 'nested no controller'))
+      .then(() => this.assertText('c.e'));
+  }
+
+  ['@test sendAction should not trigger an action in an outlet\'s controller if a parent component handles it'](assert) {
+    assert.expect(1);
+
+    let component;
+
+    this.registerComponent('x-parent', {
+      ComponentClass: Component.extend({
+        actions: {
+          poke() {
+            assert.ok(true, 'parent component handled the aciton');
+          }
+        }
+      }),
+      template: '{{x-child poke="poke"}}'
+    });
+
+    this.registerComponent('x-child', {
+      ComponentClass: Component.extend({
+        init() {
+          this._super(...arguments);
+          component = this;
+        }
+      })
+    });
+
+    this.registerTemplate('application', '{{x-parent}}');
+    this.registerController('application', Controller.extend({
+      send(actionName) {
+        throw new Error('controller action should not be called');
+      }
+    }));
+
+    return this.visit('/').then(() => component.sendAction('poke'));
+  }
+
+});
+
+moduleFor('Components test: sendAction of a closure action', class extends RenderingTest {
+
+  ['@test action should be called'](assert) {
+    assert.expect(1);
+    let component;
+
+    this.registerComponent('inner-component', {
+      ComponentClass: Component.extend({
+        init() {
+          this._super(...arguments);
+          component = this;
+        }
+      }),
+      template: 'inner'
+    });
+
+    this.registerComponent('outer-component', {
+      ComponentClass: Component.extend({
+        outerSubmit() {
+          assert.ok(true, 'outerSubmit called');
+        }
+      }),
+      template: '{{inner-component submitAction=(action outerSubmit)}}'
+    });
+
+    this.render('{{outer-component}}');
+
+    this.runTask(() => component.sendAction('submitAction'));
+  }
+
+  ['@test contexts passed to sendAction are appended to the bound arguments on a closure action']() {
+    let first = 'mitch';
+    let second = 'martin';
+    let third = 'matt';
+    let fourth = 'wacky wycats';
+
+    let innerComponent;
+    let actualArgs;
+
+    this.registerComponent('inner-component', {
+      ComponentClass: Component.extend({
+        init() {
+          this._super(...arguments);
+          innerComponent = this;
+        }
+      }),
+      template: 'inner'
+    });
+
+    this.registerComponent('outer-component', {
+      ComponentClass: Component.extend({
+        third,
+        actions: {
+          outerSubmit() {
+            actualArgs = [...arguments];
+          }
+        }
+      }),
+      template: `{{inner-component innerSubmit=(action (action "outerSubmit" "${first}") "${second}" third)}}`
+    });
+
+    this.render('{{outer-component}}');
+
+    this.runTask(() => innerComponent.sendAction('innerSubmit', fourth));
+
+    this.assert.deepEqual(actualArgs, [first, second, third, fourth], 'action has the correct args');
+  }
+});
+
+moduleFor('Components test: send', class extends RenderingTest {
+  ['@test sending to undefined actions triggers an error'](assert) {
+    assert.expect(2);
+
+    let component;
+
+    this.registerComponent('foo-bar', {
+      ComponentClass: Component.extend({
+        init() {
+          this._super();
+          component = this;
+        },
+        actions: {
+          foo(message) {
+            assert.equal('bar', message);
+          }
+        }
+      })
+    });
+
+    this.render('{{foo-bar}}');
+
+    this.runTask(() => component.send('foo', 'bar'));
+
+    expectAssertion(() => {
+      return component.send('baz', 'bar');
+    }, /had no action handler for: baz/);
+  }
+
+  ['@test `send` will call send from a target if it is defined']() {
+    let component;
+    let target = {
+      send: (message, payload) => {
+        this.assert.equal('foo', message);
+        this.assert.equal('baz', payload);
+      }
+    };
+
+    this.registerComponent('foo-bar', {
+      ComponentClass: Component.extend({
+        init() {
+          this._super();
+          component = this;
+        },
+        target
+      })
+    });
+
+    this.render('{{foo-bar}}');
+
+    this.runTask(() => component.send('foo', 'baz'));
+  }
+
+  ['@test a handled action can be bubbled to the target for continued processing']() {
+    this.assert.expect(2);
+
+    let component;
+
+    this.registerComponent('foo-bar', {
+      ComponentClass: Component.extend({
+        init() {
+          this._super(...arguments);
+          component = this;
+        },
+        actions: {
+          poke: () => {
+            this.assert.ok(true, 'component action called');
+            return true;
+          }
+        },
+        target: Controller.extend({
+          actions: {
+            poke: () => {
+              this.assert.ok(true, 'action bubbled to controller');
+            }
+          }
+        }).create()
+      })
+    });
+
+    this.render('{{foo-bar poke="poke"}}');
+
+    this.runTask(() => component.send('poke'));
+  }
+
+   ['@test action can be handled by a superclass\' actions object'](assert) {
+    this.assert.expect(4);
+
+    let component;
+
+    let SuperComponent = Component.extend({
+      actions: {
+        foo() {
+          assert.ok(true, 'foo');
+        },
+        bar(msg) {
+          assert.equal(msg, 'HELLO');
+        }
+      }
+    });
+
+    let BarViewMixin = Mixin.create({
+      actions: {
+        bar(msg) {
+          assert.equal(msg, 'HELLO');
+          this._super(msg);
+        }
+      }
+    });
+
+    this.registerComponent('x-index', {
+      ComponentClass: SuperComponent.extend(BarViewMixin, {
+        init() {
+          this._super(...arguments);
+          component = this;
+        },
+        actions: {
+          baz() {
+            assert.ok(true, 'baz');
+          }
+        }
+      })
+    });
+
+    this.render('{{x-index}}');
+
+    this.runTask(() => {
+      component.send('foo');
+      component.send('bar', 'HELLO');
+      component.send('baz');
+    });
+  }
+
+  ['@test actions cannot be provided at create time'](assert) {
+    expectAssertion(() => Component.create({
+      actions: {
+        foo() {
+          assert.ok(true, 'foo');
+        }
+      }
+    }));
+    // but should be OK on an object that doesn't mix in Ember.ActionHandler
+    EmberObject.create({
+      actions: ['foo']
+    });
+  }
+});

--- a/packages/ember-htmlbars/lib/component.js
+++ b/packages/ember-htmlbars/lib/component.js
@@ -3,32 +3,16 @@ import { NAME_KEY } from 'ember-metal/mixin';
 import { environment } from 'ember-environment';
 
 import TargetActionSupport from 'ember-runtime/mixins/target_action_support';
+import ActionSupport from 'ember-views/mixins/action_support';
 import View from 'ember-views/views/view';
 
-import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
-import isNone from 'ember-metal/is_none';
-import { inspect } from 'ember-metal/utils';
 import { computed } from 'ember-metal/computed';
-
-import { MUTABLE_CELL } from 'ember-views/compat/attrs-proxy';
 
 import { getOwner } from 'container/owner';
 import symbol from 'ember-metal/symbol';
 
 export let HAS_BLOCK = symbol('HAS_BLOCK');
-
-function validateAction(component, actionName) {
-  if (actionName && actionName[MUTABLE_CELL]) {
-    actionName = actionName.value;
-  }
-  assert(
-    'The default action was triggered on the component ' + component.toString() +
-    ', but the action name (' + actionName + ') was not a string.',
-    isNone(actionName) || typeof actionName === 'string' || typeof actionName === 'function'
-  );
-  return actionName;
-}
 
 /**
 @module ember
@@ -122,7 +106,7 @@ function validateAction(component, actionName) {
   @uses Ember.ViewTargetActionSupport
   @public
 */
-const Component = View.extend(TargetActionSupport, {
+const Component = View.extend(TargetActionSupport, ActionSupport, {
   isComponent: true,
   /*
     This is set so that the proto inspection in appendTemplatedView does not
@@ -183,22 +167,6 @@ const Component = View.extend(TargetActionSupport, {
   layout: null,
 
   /**
-    If the component is currently inserted into the DOM of a parent view, this
-    property will point to the controller of the parent view.
-
-    @property targetObject
-    @type Ember.Controller
-    @default null
-    @private
-  */
-  targetObject: computed('controller', function(key) {
-    if (this._targetObject) { return this._targetObject; }
-    if (this._controller) { return this._controller; }
-    let parentView = get(this, 'parentView');
-    return parentView ? get(parentView, 'controller') : null;
-  }),
-
-  /**
     Normally, Ember's component model is "write-only". The component takes a
     bunch of attributes that it got passed in, and uses them to render its
     template.
@@ -234,132 +202,6 @@ const Component = View.extend(TargetActionSupport, {
     let attr = this._renderNode.childNodes.filter(node => node.attrName === name)[0];
     if (!attr) { return null; }
     return attr.getContent();
-  },
-
-  /**
-    Calls an action passed to a component.
-
-    For example a component for playing or pausing music may translate click events
-    into action notifications of "play" or "stop" depending on some internal state
-    of the component:
-
-    ```javascript
-    // app/components/play-button.js
-    export default Ember.Component.extend({
-      click() {
-        if (this.get('isPlaying')) {
-          this.sendAction('play');
-        } else {
-          this.sendAction('stop');
-        }
-      }
-    });
-    ```
-
-    The actions "play" and "stop" must be passed to this `play-button` component:
-
-    ```handlebars
-    {{! app/templates/application.hbs }}
-    {{play-button play=(action "musicStarted") stop=(action "musicStopped")}}
-    ```
-
-    When the component receives a browser `click` event it translate this
-    interaction into application-specific semantics ("play" or "stop") and
-    calls the specified action.
-
-    ```javascript
-    // app/controller/application.js
-    export default Ember.Controller.extend({
-      actions: {
-        musicStarted() {
-          // called when the play button is clicked
-          // and the music started playing
-        },
-        musicStopped() {
-          // called when the play button is clicked
-          // and the music stopped playing
-        }
-      }
-    });
-    ```
-
-    If no action is passed to `sendAction` a default name of "action"
-    is assumed.
-
-    ```javascript
-    // app/components/next-button.js
-    export default Ember.Component.extend({
-      click() {
-        this.sendAction();
-      }
-    });
-    ```
-
-    ```handlebars
-    {{! app/templates/application.hbs }}
-    {{next-button action=(action "playNextSongInAlbum")}}
-    ```
-
-    ```javascript
-    // app/controllers/application.js
-    App.ApplicationController = Ember.Controller.extend({
-      actions: {
-        playNextSongInAlbum() {
-          ...
-        }
-      }
-    });
-    ```
-
-    @method sendAction
-    @param [action] {String} the action to call
-    @param [params] {*} arguments for the action
-    @public
-  */
-  sendAction(action, ...contexts) {
-    let actionName;
-
-    // Send the default action
-    if (action === undefined) {
-      action = 'action';
-    }
-    actionName = get(this, `attrs.${action}`) || get(this, action);
-    actionName = validateAction(this, actionName);
-
-    // If no action name for that action could be found, just abort.
-    if (actionName === undefined) { return; }
-
-    if (typeof actionName === 'function') {
-      actionName(...contexts);
-    } else {
-      this.triggerAction({
-        action: actionName,
-        actionContext: contexts
-      });
-    }
-  },
-
-  send(actionName, ...args) {
-    let target;
-    let action = this.actions && this.actions[actionName];
-
-    if (action) {
-      let shouldBubble = action.apply(this, args) === true;
-      if (!shouldBubble) { return; }
-    }
-
-    if (target = get(this, 'target')) {
-      assert(
-        'The `target` for ' + this + ' (' + target +
-        ') does not have a `send` method',
-        typeof target.send === 'function'
-      );
-      target.send(...arguments);
-    } else {
-      if (!action) {
-        throw new Error(inspect(this) + ' had no action handler for: ' + actionName);
-      }
-    }
   }
 
   /**

--- a/packages/ember-views/lib/mixins/action_support.js
+++ b/packages/ember-views/lib/mixins/action_support.js
@@ -1,0 +1,163 @@
+import { Mixin } from 'ember-metal/mixin';
+import { computed } from 'ember-metal/computed';
+import { get } from 'ember-metal/property_get';
+import isNone from 'ember-metal/is_none';
+import { assert } from 'ember-metal/debug';
+import { MUTABLE_CELL } from 'ember-views/compat/attrs-proxy';
+import { inspect } from 'ember-metal/utils';
+
+function validateAction(component, actionName) {
+  if (actionName && actionName[MUTABLE_CELL]) {
+    actionName = actionName.value;
+  }
+
+  assert(
+    'The default action was triggered on the component ' + component.toString() +
+    ', but the action name (' + actionName + ') was not a string.',
+    isNone(actionName) || typeof actionName === 'string' || typeof actionName === 'function'
+  );
+  return actionName;
+}
+
+
+export default Mixin.create({
+  /**
+    Calls an action passed to a component.
+
+    For example a component for playing or pausing music may translate click events
+    into action notifications of "play" or "stop" depending on some internal state
+    of the component:
+
+    ```javascript
+    // app/components/play-button.js
+    export default Ember.Component.extend({
+      click() {
+        if (this.get('isPlaying')) {
+          this.sendAction('play');
+        } else {
+          this.sendAction('stop');
+        }
+      }
+    });
+    ```
+
+    The actions "play" and "stop" must be passed to this `play-button` component:
+
+    ```handlebars
+    {{! app/templates/application.hbs }}
+    {{play-button play=(action "musicStarted") stop=(action "musicStopped")}}
+    ```
+
+    When the component receives a browser `click` event it translate this
+    interaction into application-specific semantics ("play" or "stop") and
+    calls the specified action.
+
+    ```javascript
+    // app/controller/application.js
+    export default Ember.Controller.extend({
+      actions: {
+        musicStarted() {
+          // called when the play button is clicked
+          // and the music started playing
+        },
+        musicStopped() {
+          // called when the play button is clicked
+          // and the music stopped playing
+        }
+      }
+    });
+    ```
+
+    If no action is passed to `sendAction` a default name of "action"
+    is assumed.
+
+    ```javascript
+    // app/components/next-button.js
+    export default Ember.Component.extend({
+      click() {
+        this.sendAction();
+      }
+    });
+    ```
+
+    ```handlebars
+    {{! app/templates/application.hbs }}
+    {{next-button action=(action "playNextSongInAlbum")}}
+    ```
+
+    ```javascript
+    // app/controllers/application.js
+    App.ApplicationController = Ember.Controller.extend({
+      actions: {
+        playNextSongInAlbum() {
+          ...
+        }
+      }
+    });
+    ```
+
+    @method sendAction
+    @param [action] {String} the action to call
+    @param [params] {*} arguments for the action
+    @public
+  */
+  sendAction(action, ...contexts) {
+    let actionName;
+
+    // Send the default action
+    if (action === undefined) {
+      action = 'action';
+    }
+    actionName = get(this, `attrs.${action}`) || get(this, action);
+    actionName = validateAction(this, actionName);
+
+    // If no action name for that action could be found, just abort.
+    if (actionName === undefined) { return; }
+
+    if (typeof actionName === 'function') {
+      actionName(...contexts);
+    } else {
+      this.triggerAction({
+        action: actionName,
+        actionContext: contexts
+      });
+    }
+  },
+
+  /**
+    If the component is currently inserted into the DOM of a parent view, this
+    property will point to the controller of the parent view.
+
+    @property targetObject
+    @type Ember.Controller
+    @default null
+    @private
+  */
+  targetObject: computed('controller', function(key) {
+    if (this._targetObject) { return this._targetObject; }
+    if (this._controller) { return this._controller; }
+    let parentView = get(this, 'parentView');
+    return parentView ? get(parentView, 'controller') : null;
+  }),
+
+  send(actionName, ...args) {
+    let target;
+    let action = this.actions && this.actions[actionName];
+
+    if (action) {
+      let shouldBubble = action.apply(this, args) === true;
+      if (!shouldBubble) { return; }
+    }
+
+    if (target = get(this, 'target')) {
+      assert(
+        'The `target` for ' + this + ' (' + target +
+        ') does not have a `send` method',
+        typeof target.send === 'function'
+      );
+      target.send(...arguments);
+    } else {
+      assert(`${inspect(this)} had no action handler for: ${actionName}`, action);
+    }
+  }
+});

--- a/packages/ember-views/tests/views/component_test.js
+++ b/packages/ember-views/tests/views/component_test.js
@@ -237,22 +237,6 @@ QUnit.test('services can be injected into components', function() {
 
 QUnit.module('Ember.Component - subscribed and sent actions trigger errors');
 
-QUnit.test('something', function() {
-  expect(2);
-
-  let appComponent = Component.extend({
-    actions: {
-      foo(message) {
-        equal('bar', message);
-      }
-    }
-  }).create();
-
-  appComponent.send('foo', 'bar');
-
-  throws(() => appComponent.send('baz', 'bar'), /had no action handler for: baz/, 'asdf');
-});
-
 QUnit.test('component with target', function() {
   expect(2);
 


### PR DESCRIPTION
This supersedes #13532 and sets up the action "scoping" setting similar to how HTMLBars does it. There are couple tasks that will quickly follow once this has landed:
- Unskip all of the glimmer tests that depend on this functionality
- Delete some of the old action tests
- Potentially consolidate some the tests in this PR as the implementation is roughly the same
- More cleanup around target action (currently there are like 3 things that handle actions)

Part of #13644 
