### PR TITLE
[GLIMMER] Enable passing tests.

### DIFF
--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -13,8 +13,6 @@ import { setTemplates, set as setTemplate } from 'ember-templates/template_regis
 
 var App, find, click, fillIn, currentRoute, currentURL, visit, originalAdapter, andThen, indexHitCount;
 
-import { test } from 'internal-test-helpers/tests/skip-if-glimmer';
-
 QUnit.module('ember-testing Acceptance', {
   setup() {
     jQuery('<style>#ember-testing-container { position: absolute; background: white; bottom: 0; right: 0; width: 640px; height: 384px; overflow: auto; z-index: 9999; border: 1px solid #ccc; } #ember-testing { zoom: 50%; }</style>').appendTo('head');
@@ -103,7 +101,7 @@ QUnit.module('ember-testing Acceptance', {
   }
 });
 
-test('helpers can be chained with then', function() {
+QUnit.test('helpers can be chained with then', function() {
   expect(6);
 
   currentRoute = 'index';
@@ -130,7 +128,7 @@ test('helpers can be chained with then', function() {
 
 // Keep this for backwards compatibility
 
-test('helpers can be chained to each other', function() {
+QUnit.test('helpers can be chained to each other', function() {
   expect(7);
 
   currentRoute = 'index';
@@ -155,7 +153,7 @@ test('helpers can be chained to each other', function() {
   });
 });
 
-test('helpers don\'t need to be chained', function() {
+QUnit.test('helpers don\'t need to be chained', function() {
   expect(5);
 
   currentRoute = 'index';
@@ -180,7 +178,7 @@ test('helpers don\'t need to be chained', function() {
   });
 });
 
-test('Nested async helpers', function() {
+QUnit.test('Nested async helpers', function() {
   expect(5);
 
   currentRoute = 'index';
@@ -207,7 +205,7 @@ test('Nested async helpers', function() {
   });
 });
 
-test('Multiple nested async helpers', function() {
+QUnit.test('Multiple nested async helpers', function() {
   expect(3);
 
   visit('/posts');
@@ -226,7 +224,7 @@ test('Multiple nested async helpers', function() {
   });
 });
 
-test('Helpers nested in thens', function() {
+QUnit.test('Helpers nested in thens', function() {
   expect(5);
 
   currentRoute = 'index';

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -347,7 +347,7 @@ QUnit.test('`wait` helper can be passed a resolution value', function() {
 
 import { test } from 'internal-test-helpers/tests/skip-if-glimmer';
 
-test('`click` triggers appropriate events in order', function() {
+QUnit.test('`click` triggers appropriate events in order', function() {
   expect(5);
 
   var click, wait, events;
@@ -547,7 +547,7 @@ QUnit.test('`wait` does not error if routing has not begun', function() {
   });
 });
 
-test('`triggerEvent accepts an optional options hash without context', function() {
+QUnit.test('`triggerEvent accepts an optional options hash without context', function() {
   expect(3);
 
   var triggerEvent, wait, event;
@@ -577,7 +577,7 @@ test('`triggerEvent accepts an optional options hash without context', function(
   });
 });
 
-test('`triggerEvent can limit searching for a selector to a scope', function() {
+QUnit.test('`triggerEvent can limit searching for a selector to a scope', function() {
   expect(2);
 
   var triggerEvent, wait, event;
@@ -607,7 +607,7 @@ test('`triggerEvent can limit searching for a selector to a scope', function() {
   });
 });
 
-test('`triggerEvent` can be used to trigger arbitrary events', function() {
+QUnit.test('`triggerEvent` can be used to trigger arbitrary events', function() {
   expect(2);
 
   var triggerEvent, wait, event;
@@ -636,7 +636,7 @@ test('`triggerEvent` can be used to trigger arbitrary events', function() {
   });
 });
 
-test('`fillIn` takes context into consideration', function() {
+QUnit.test('`fillIn` takes context into consideration', function() {
   expect(2);
   var fillIn, find, visit, andThen, wait;
 

--- a/packages/ember/tests/controller_test.js
+++ b/packages/ember/tests/controller_test.js
@@ -45,9 +45,7 @@ QUnit.module('Template scoping examples', {
   }
 });
 
-import { test } from 'internal-test-helpers/tests/skip-if-glimmer';
-
-test('Actions inside an outlet go to the associated controller', function() {
+QUnit.test('Actions inside an outlet go to the associated controller', function() {
   expect(1);
 
   setTemplate('index', compile('{{component-with-action action=\'componentAction\'}}'));


### PR DESCRIPTION
These tests were unlocked by fixing `{{input}}` and `sendAction`, re-enable them.
