### PR TITLE
Ensure top level destroys DOM

### DIFF
--- a/packages/ember-htmlbars/lib/hooks/destroy-render-node.js
+++ b/packages/ember-htmlbars/lib/hooks/destroy-render-node.js
@@ -14,4 +14,6 @@ export default function destroyRenderNode(renderNode) {
       streamUnsubscribers[i]();
     }
   }
+
+  renderNode.destroy();
 }


### PR DESCRIPTION
Prior to this change, the render nodes are cleared (replaced with `<!---->`) but not removed from the DOM

/cc @krisselden
