### PR TITLE
Fixes #13750 update documentation to cast `getJSON` to compliant promise

### DIFF
--- a/packages/ember-runtime/lib/mixins/promise_proxy.js
+++ b/packages/ember-runtime/lib/mixins/promise_proxy.js
@@ -38,7 +38,7 @@ function tap(proxy, promise) {
   let ObjectPromiseProxy = Ember.ObjectProxy.extend(Ember.PromiseProxyMixin);
 
   let proxy = ObjectPromiseProxy.create({
-    promise: $.getJSON('/some/remote/data.json')
+    promise: Ember.RSVP.cast($.getJSON('/some/remote/data.json'))
   });
 
   proxy.then(function(json){
@@ -60,6 +60,9 @@ function tap(proxy, promise) {
 
   When the $.getJSON completes, and the promise is fulfilled
   with json, the life cycle attributes will update accordingly.
+  Note that $.getJSON doesn't return an ECMA specified promise,
+  it is useful to wrap this with an `RSVP.cast` so that it behaves
+  as a spec compliant promise.
 
   ```javascript
   proxy.get('isPending')   //=> false


### PR DESCRIPTION
This is from Wicked Good Ember contributing workshop in row #2 https://docs.google.com/spreadsheets/d/12lAjN5ro2UO4j30FbVtfCQgMgJaywSow8mA2OEbIIV0/edit#gid=0
