### PR TITLE
[DOC] Issue #13397, update documentation for click helper

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -268,18 +268,19 @@ asyncHelper('visit', visit);
 
 /**
   Clicks an element and triggers any actions triggered by the element's `click`
-  event.
+  event. Accepts `context` as an optional second argument.
 
   Example:
 
   ```javascript
-  click('.some-jQuery-selector').then(function() {
+  click('.some-jQuery-selector', 'body').then(function() {
     // assert something
   });
   ```
 
   @method click
   @param {String} selector jQuery selector for finding element on the DOM
+  @param {String} context for finding element on the DOM
   @return {RSVP.Promise}
   @public
 */

--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -268,19 +268,27 @@ asyncHelper('visit', visit);
 
 /**
   Clicks an element and triggers any actions triggered by the element's `click`
-  event. Accepts `context` as an optional second argument.
+  event.
 
   Example:
 
   ```javascript
-  click('.some-jQuery-selector', 'body').then(function() {
+  click('.some-jQuery-selector').then(function() {
+    // assert something
+  });
+  ```
+
+  Accepts `context` as an optional second argument. Useful for scoping the element lookup.
+
+  ```javascript
+  click('.some-jQuery-selector', '.modal-dialog').then(function() {
     // assert something
   });
   ```
 
   @method click
   @param {String} selector jQuery selector for finding element on the DOM
-  @param {String} context for finding element on the DOM
+  @param {String} [context] jQuery selector for scoping element lookup on the DOM
   @return {RSVP.Promise}
   @public
 */


### PR DESCRIPTION
Update documentation to mention the `click` test helper takes a `context` argument.

Fixes https://github.com/emberjs/ember.js/issues/13397
