### PR TITLE
Remove usage of `targetObject` computed property.

### DIFF
--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -74,18 +74,14 @@ class CurlyComponentManager {
 
     props.renderer = parentView.renderer;
     props[HAS_BLOCK] = hasBlock;
+    // parentView.controller represents any parent components
+    // dynamicScope.controller represents the outlet controller
+    props._targetObject = parentView.controller || dynamicScope.controller;
 
     let component = klass.create(props);
 
     dynamicScope.view = component;
     parentView.appendChild(component);
-
-    if (parentView.controller) {
-      dynamicScope.controller = parentView.controller;
-    }
-
-    component._controller = dynamicScope.controller;
-
 
     component.trigger('didInitAttrs', { attrs });
     component.trigger('didReceiveAttrs', { newAttrs: attrs });

--- a/packages/ember-views/lib/mixins/action_support.js
+++ b/packages/ember-views/lib/mixins/action_support.js
@@ -1,5 +1,4 @@
 import { Mixin } from 'ember-metal/mixin';
-import { computed } from 'ember-metal/computed';
 import { get } from 'ember-metal/property_get';
 import isNone from 'ember-metal/is_none';
 import { assert } from 'ember-metal/debug';
@@ -123,22 +122,6 @@ export default Mixin.create({
       });
     }
   },
-
-  /**
-    If the component is currently inserted into the DOM of a parent view, this
-    property will point to the controller of the parent view.
-
-    @property targetObject
-    @type Ember.Controller
-    @default null
-    @private
-  */
-  targetObject: computed('controller', function(key) {
-    if (this._targetObject) { return this._targetObject; }
-    if (this._controller) { return this._controller; }
-    let parentView = get(this, 'parentView');
-    return parentView ? get(parentView, 'controller') : null;
-  }),
 
   send(actionName, ...args) {
     let target;


### PR DESCRIPTION
This PR removes the `targetObject` CP in favor of simply looking up the correct `targetObject` when needed. This simplifies the code path for `sendAction` and removes some overloading of the term "controller" (before this change it could mean an actual outlet's controller or the parentView.controller which may be a component and not a "real" controller).

Fixes comments from @krisselden on the the `sendAction` PR (#13745 / #13532).

/cc @krisselden @chadhietala
