### PR TITLE
Remove reference to `.controller` on components.

### DIFF
--- a/packages/ember-glimmer/lib/renderer.js
+++ b/packages/ember-glimmer/lib/renderer.js
@@ -1,16 +1,17 @@
 import { RootReference } from './utils/references';
 import run from 'ember-metal/run_loop';
 import { setHasViews } from 'ember-metal/tags';
-import { CURRENT_TAG } from 'glimmer-reference';
+import { CURRENT_TAG, UNDEFINED_REFERENCE } from 'glimmer-reference';
 
 const { backburner } = run;
 
 class DynamicScope {
-  constructor({ view, controller, outletState, isTopLevel }) {
+  constructor({ view, controller, outletState, isTopLevel, targetObject }) {
     this.view = view;
     this.controller = controller;
     this.outletState = outletState;
     this.isTopLevel = isTopLevel;
+    this.targetObject = targetObject;
   }
 
   child() {
@@ -130,9 +131,11 @@ class Renderer {
 
     let env = this._env;
     let self = new RootReference(view);
+    let controller = view.outletState.render.controller;
     let dynamicScope = new DynamicScope({
       view,
-      controller: view.outletState.render.controller,
+      controller,
+      targetObject: controller,
       outletState: view.toReference(),
       isTopLevel: true
     });
@@ -149,7 +152,13 @@ class Renderer {
   appendTo(view, target) {
     let env = this._env;
     let self = new RootReference(view);
-    let dynamicScope = new DynamicScope({ view, controller: view.controller });
+    let dynamicScope = new DynamicScope({
+      view,
+      controller: undefined,
+      targetObject: undefined,
+      outletState: UNDEFINED_REFERENCE,
+      isTopLevel: true
+    });
 
     env.begin();
     let result = view.template.asEntryPoint().render(self, env, { appendTo: target, dynamicScope });

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -74,13 +74,16 @@ class CurlyComponentManager {
 
     props.renderer = parentView.renderer;
     props[HAS_BLOCK] = hasBlock;
-    // parentView.controller represents any parent components
-    // dynamicScope.controller represents the outlet controller
-    props._targetObject = parentView.controller || dynamicScope.controller;
+
+    // dynamicScope here is inherited from the parent dynamicScope,
+    // but is set shortly below to the new target
+    props._targetObject = dynamicScope.targetObject;
 
     let component = klass.create(props);
 
     dynamicScope.view = component;
+    dynamicScope.targetObject = component;
+
     parentView.appendChild(component);
 
     component.trigger('didInitAttrs', { attrs });

--- a/packages/ember-glimmer/lib/syntax/outlet.js
+++ b/packages/ember-glimmer/lib/syntax/outlet.js
@@ -130,7 +130,7 @@ class OutletComponentManager extends AbstractOutletComponentManager {
   create(definition, args, dynamicScope) {
     let outletStateReference = dynamicScope.outletState = dynamicScope.outletState.get(definition.outletName);
     let outletState = outletStateReference.value();
-    dynamicScope.controller = outletState.render.controller;
+    dynamicScope.targetObject = dynamicScope.controller = outletState.render.controller;
     return outletState;
   }
 }


### PR DESCRIPTION
Start "taking back" the meaning/intent of `controller` in the code.  It should **only** mean "route controller", all other usages (target object for send/sendAction here) should use a more descriptive thing.
