### PR TITLE
[DOC] Fix docs on idiomatic helper export pattern

### DIFF
--- a/packages/ember-htmlbars/lib/helper.js
+++ b/packages/ember-htmlbars/lib/helper.js
@@ -113,8 +113,7 @@ Helper.reopenClass({
 
   ```js
   // app/helpers/format-currency.js
-  export function Ember.Helper.helper(function(params, hash) {
-    let cents = params[0];
+  export function formatCurrency([cents], hash) {
     let currency = hash.currency;
     return `${currency}${cents * 0.01}`;
   });
@@ -122,7 +121,7 @@ Helper.reopenClass({
   export default Ember.Helper.helper(formatCurrency);
 
   // tests/myhelper.js
-  import {formatCurrency} from ..../helpers/myhelper
+  import { formatCurrency } from ..../helpers/myhelper
   // add some tests
   ```
 


### PR DESCRIPTION
Update docs to match the pattern that ember-cli uses when a helper is generated
via command line. In that pattern, the helper function is a pure function exported
as a named export, and the default export is `Ember.Helper.helper(fnName)`

@habdelra I found this on a recent commit you made. 
