### PR TITLE
[GLIMMER2] Fix ember-glimmer iterators when handling dupes in ({{#each}})

### DIFF
--- a/packages/ember-glimmer/tests/integration/syntax/each-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/each-test.js
@@ -230,7 +230,7 @@ moduleFor('Syntax test: {{#each as}}', class extends EachTest {
     this.assertText('123');
   }
 
-  ['@htmlbars it can render duplicate primitive items']() {
+  ['@test it can render duplicate primitive items']() {
     this.render(`{{#each list as |item|}}{{item}}{{/each}}`, {
       list: emberA(['a', 'a', 'a'])
     });
@@ -252,7 +252,7 @@ moduleFor('Syntax test: {{#each as}}', class extends EachTest {
     this.assertText('aaa');
   }
 
-  ['@htmlbars it can render duplicate objects']() {
+  ['@test it can render duplicate objects']() {
     let duplicateItem = { text: 'foo' };
     this.render(`{{#each list as |item|}}{{item.text}}{{/each}}`, {
       list: emberA([duplicateItem, duplicateItem, { text: 'bar' }, { text: 'baz' }])


### PR DESCRIPTION
The purpose of this PR is to fix array iteration via `{{#each}}` in Glimmer2 when the iteratee contains duplicate items. The following tests from `ember-glimmer/tests/integration/syntax/each-test.js` are now passing for Glimmer2:
- it can render duplicate primitive items
- it can render duplicate objects

Key changes:
- The order that we check objects for array-like-ness changed such that we look for Emberish arrays before plain JS arrays. Emberish arrays seemed to be falling into the plain JS array check -- which seems wrong.
- `ArrayIterator` and `EmberArrayIterator` now keep track of the keys they've seen, and when a duplicate key is seen it creates a composite key using a GUID of the array as a separator. 
