### PR TITLE
[BUGFIX beta] Update route-recognizer to v0.2.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "mocha": "^2.4.5",
     "qunit-extras": "^1.5.0",
     "qunitjs": "^1.22.0",
-    "route-recognizer": "0.1.10",
+    "route-recognizer": "0.2.0",
     "rsvp": "~3.2.1",
     "serve-static": "^1.10.0",
     "simple-dom": "^0.3.0",


### PR DESCRIPTION
This update includes a number of fixes regarding encoding/decoding from https://github.com/tildeio/route-recognizer/pull/91.

I have included a snippet from the upstream fixing PR below, but the full PR description itself contains a wonderful explanation of the problem and solution.

This addresses the following:
- Adds many tests for non-standard routes and paths (with percent-encodings and/or unicode characters)
- Adds normalization for added routes and recognized paths to improve the matching of non-standard routes and paths
- Fixes a bug where dynamic segments are not percent-encoded during generation
- Fixes a bug where dynamic segments are not percent-decoded during recognition
- Adds tests (and some code) to ensure that star segments in routes do _not_ get decoded during recognition
- Adds a flag that can be turned off by consumers to opt-out of the changes introduced here

It may only affect users who have routes with:
- percent-encoded or unicode characters
- dynamic segments that may match paths with percent-encoded characters
- dynamic segments that are generated using values that have characters that should be encoded (e.g. forward slash: `/`)

It **may cause breaking changes** for users who have workarounds in place to encode/decode before generation/recognition. The breakage can be fixed by removing the workaround.

It will likely **not cause breaking changes** for users who have static routes with percent-encoded or unicode characters. All static route/path combinations that currently match will _also_ match after this PR. Static routes that used to be considered distinct (e.g. `/f%20o` and `/f o`) are now normalized to the same thing. Users with affected static route/path combos likely need to do nothing; they may simply end up with superfluous routes that can be removed.

Full diff from v0.1.10 to v0.2.0: https://github.com/tildeio/route-recognizer/compare/v0.1.10...v0.2.0

/cc @bantic
