### PR TITLE
[glimmer2] fix each key collision detection

### DIFF
--- a/packages/ember-glimmer/tests/integration/syntax/each-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/each-test.js
@@ -4,6 +4,7 @@ import { applyMixins, strip } from '../../utils/abstract-test-case';
 import { moduleFor, RenderingTest } from '../../utils/test-case';
 import { A as emberA } from 'ember-runtime/system/native_array';
 import { removeAt } from 'ember-runtime/mixins/mutable_array';
+import ArrayProxy from 'ember-runtime/system/array_proxy';
 
 import {
   BasicConditionalsTest,
@@ -332,7 +333,7 @@ moduleFor('Syntax test: {{#each as}}', class extends EachTest {
     this.assertInvariants(oldSnapshot, this.takeSnapshot());
   }
 
-  [`@htmlbars it renders all items with duplicate key values`]() {
+  [`@test it renders all items with duplicate key values`]() {
     this.render(`{{#each list key="text" as |item|}}{{item.text}}{{/each}}`, {
       list: emberA([{ text: 'Hello' }, { text: 'Hello' }, { text: 'Hello' }])
     });
@@ -340,6 +341,34 @@ moduleFor('Syntax test: {{#each as}}', class extends EachTest {
     this.assertText('HelloHelloHello');
 
     let list = get(this.context, 'list');
+
+    this.runTask(() => {
+      list.forEach(hash => set(hash, 'text', 'Goodbye'));
+    });
+
+    this.assertText('GoodbyeGoodbyeGoodbye');
+  }
+
+  [`@test it renders all items with duplicate key values - Ember array`]() {
+    let list = ArrayProxy.create({
+      content: [
+        {
+          text: 'Hello'
+        },
+        {
+          text: 'Hello'
+        },
+        {
+          text: 'Hello'
+        }
+      ]
+    });
+
+    this.render(`{{#each list key="text" as |item|}}{{item.text}}{{/each}}`, {
+      list
+    });
+
+    this.assertText('HelloHelloHello');
 
     this.runTask(() => {
       list.forEach(hash => set(hash, 'text', 'Goodbye'));


### PR DESCRIPTION
When using `{{#each things key="key" as |thing|}}`, glimmer2 integration
did not update the DOM correctly when `things` was an array with objects
that shared the same `key` value. For example:

``` javascript
this.set('data', [
  {
    name: 'Yehuda' }
  },
  {
    name: 'Jenn'
  },
  {
    name: 'Yehuda'
  }
]);
```

and the following template:

``` handlebars
{{#each data key="name" as |person|}}
  {{person.name}}
{{/each}}
```

In the above example, we want each item in the list to render, even though two objects have the same
value for the key (Notice there are two "Yehuda"'s above.

As the iterator goes through the array, it will cache value of the `key` `name`.
In order to make sure the cache updates correctly, we assign it a unique key.
