### PR TITLE
[BUGFIX beta] Cleanup view teardown.

### DIFF
--- a/packages/ember-glimmer/lib/renderer.js
+++ b/packages/ember-glimmer/lib/renderer.js
@@ -192,7 +192,9 @@ class Renderer {
       _renderResult.destroy();
     }
 
-    view.destroy();
+    if (!view.isDestroying) {
+      view.destroy();
+    }
   }
 
   componentInitAttrs() {

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -72,6 +72,7 @@ class CurlyComponentManager {
 
     aliasIdToElementId(args, props);
 
+    props.parentView = parentView;
     props.renderer = parentView.renderer;
     props[HAS_BLOCK] = hasBlock;
 

--- a/packages/ember-glimmer/tests/integration/components/dynamic-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/dynamic-components-test.js
@@ -310,10 +310,15 @@ moduleFor('Components test: dynamic components', class extends RenderingTest {
 
   ['@test component helper destroys underlying component when it is swapped out'](assert) {
     let destroyed = { 'foo-bar': 0, 'foo-bar-baz': 0 };
+    let testContext = this;
 
     this.registerComponent('foo-bar', {
       template: 'hello from foo-bar',
       ComponentClass: Component.extend({
+        willDestroyElement() {
+          assert.equal(testContext.$(`#${this.elementId}`).length, 1, 'element is still attached to the document');
+        },
+
         willDestroy() {
           this._super();
           destroyed['foo-bar']++;

--- a/packages/ember-htmlbars/lib/component.js
+++ b/packages/ember-htmlbars/lib/component.js
@@ -193,7 +193,7 @@ const Component = View.extend(TargetActionSupport, ActionSupport, {
     let attr = this._renderNode.childNodes.filter(node => node.attrName === name)[0];
     if (!attr) { return null; }
     return attr.getContent();
-  }
+  },
 
   /**
     Returns true when the component was invoked with a block template.
@@ -359,6 +359,7 @@ const Component = View.extend(TargetActionSupport, ActionSupport, {
     @public
     @since 1.13.0
   */
+  didReceiveAttrs() {},
 
   /**
     Called when the attributes passed into the component have been updated.
@@ -379,6 +380,7 @@ const Component = View.extend(TargetActionSupport, ActionSupport, {
     @public
     @since 1.13.0
   */
+  didRender() {},
 
   /**
     Called after a component has been rendered, both on initial render and
@@ -397,6 +399,7 @@ const Component = View.extend(TargetActionSupport, ActionSupport, {
     @public
     @since 1.13.0
   */
+  willRender() {},
 
   /**
     Called before a component has been rendered, both on initial render and
@@ -415,6 +418,7 @@ const Component = View.extend(TargetActionSupport, ActionSupport, {
     @public
     @since 1.13.0
   */
+  didUpdateAttrs() {},
 
   /**
     Called when the attributes passed into the component have been changed.
@@ -433,6 +437,7 @@ const Component = View.extend(TargetActionSupport, ActionSupport, {
     @public
     @since 1.13.0
   */
+  willUpdate() {},
 
   /**
     Called when the component is about to update and rerender itself.
@@ -447,10 +452,11 @@ const Component = View.extend(TargetActionSupport, ActionSupport, {
     Called when the component has updated and rerendered itself.
     Called only during a rerender, not during an initial render.
 
-    @event didUpdate
+    @method didUpdate
     @public
     @since 1.13.0
   */
+  didUpdate() {}
 
   /**
     Called when the component has updated and rerendered itself.
@@ -465,7 +471,8 @@ const Component = View.extend(TargetActionSupport, ActionSupport, {
 Component[NAME_KEY] = 'Ember.Component';
 
 Component.reopenClass({
-  isComponentFactory: true
+  isComponentFactory: true,
+  positionalParams: []
 });
 
 export default Component;

--- a/packages/ember-htmlbars/lib/hooks/destroy-render-node.js
+++ b/packages/ember-htmlbars/lib/hooks/destroy-render-node.js
@@ -2,10 +2,10 @@
 @module ember
 @submodule ember-htmlbars
 */
-
 export default function destroyRenderNode(renderNode) {
-  if (renderNode.emberView) {
-    renderNode.emberView.destroy();
+  let view = renderNode.emberView;
+  if (view) {
+    view.renderer.remove(view, true);
   }
 
   let streamUnsubscribers = renderNode.streamUnsubscribers;

--- a/packages/ember-htmlbars/lib/morphs/morph.js
+++ b/packages/ember-htmlbars/lib/morphs/morph.js
@@ -29,6 +29,7 @@ proto.HTMLBarsMorph$constructor = HTMLBarsMorph;
 proto.HTMLBarsMorph$clear = HTMLBarsMorph.prototype.clear;
 
 proto.addDestruction = function(toDestroy) {
+  // called from Router.prototype._connectActiveComponentNode for {{render}}
   this.emberToDestroy = this.emberToDestroy || [];
   this.emberToDestroy.push(toDestroy);
 };
@@ -38,7 +39,6 @@ proto.cleanup = function() {
 
   if (view) {
     let parentView = view.parentView;
-
     if (parentView && view.ownerView._destroyingSubtreeForView === parentView) {
       parentView.removeChild(view);
     }

--- a/packages/ember-htmlbars/lib/morphs/morph.js
+++ b/packages/ember-htmlbars/lib/morphs/morph.js
@@ -35,15 +35,6 @@ proto.addDestruction = function(toDestroy) {
 };
 
 proto.cleanup = function() {
-  let view = this.emberView;
-
-  if (view) {
-    let parentView = view.parentView;
-    if (parentView && view.ownerView._destroyingSubtreeForView === parentView) {
-      parentView.removeChild(view);
-    }
-  }
-
   let toDestroy = this.emberToDestroy;
 
   if (toDestroy) {

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -368,7 +368,22 @@ export default Mixin.create({
     @private
   */
   destroyElement() {
-    return this._currentState.destroyElement(this);
+    this._currentState.destroyElement(this);
+    return this;
+  },
+
+  /**
+    You must call `destroy` on a view to destroy the view (and all of its
+    child views). This will remove the view from any parent node, then make
+    sure that the DOM element managed by the view can be released by the
+    memory manager.
+
+    @method destroy
+    @private
+  */
+  destroy() {
+    this._super(...arguments);
+    this._currentState.destroy(this);
   },
 
   /**
@@ -522,26 +537,6 @@ export default Mixin.create({
       this.scheduledRevalidation = true;
       run.scheduleOnce('render', this, this.revalidate);
     }
-  },
-
-  /**
-    You must call `destroy` on a view to destroy the view (and all of its
-    child views). This will remove the view from any parent node, then make
-    sure that the DOM element managed by the view can be released by the
-    memory manager.
-
-    @method destroy
-    @private
-  */
-  destroy() {
-    if (!this._super(...arguments)) { return; }
-
-    // Destroy HTMLbars template
-    if (this.lastResult) {
-      this.lastResult.destroy();
-    }
-
-    return this;
   },
 
   // .......................................................

--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -41,6 +41,15 @@ const CoreView = EmberObject.extend(Evented, ActionHandler, {
     this._super(...arguments);
     this._state = 'preRender';
     this._currentState = this._states.preRender;
+    this._willInsert = false;
+    this._renderNode = null;
+    this.lastResult = null;
+    this._dispatching = null;
+    this._destroyingSubtreeForView = null;
+    this._isDispatchingAttrs = false;
+    this._isVisible = false;
+    this.element = null;
+    this.env = null;
     this._isVisible = get(this, 'isVisible');
 
     // Fallback for legacy cases where the view was created directly
@@ -50,9 +59,6 @@ const CoreView = EmberObject.extend(Evented, ActionHandler, {
       renderer = renderer || InteractiveRenderer.create({ dom: new DOMHelper() });
       this.renderer = renderer;
     }
-
-    this._destroyingSubtreeForView = null;
-    this._dispatching = null;
   },
 
   /**
@@ -97,14 +103,6 @@ const CoreView = EmberObject.extend(Evented, ActionHandler, {
 
   has(name) {
     return typeOf(this[name]) === 'function' || this._super(name);
-  },
-
-  destroy() {
-    if (!this._super(...arguments)) { return; }
-
-    this._currentState.cleanup(this);
-
-    return this;
   }
 });
 

--- a/packages/ember-views/lib/views/states/default.js
+++ b/packages/ember-views/lib/views/states/default.js
@@ -38,8 +38,9 @@ export default {
     return true; // continue event propagation
   },
 
-  cleanup() { } ,
   destroyElement() { },
+
+  destroy() { },
 
   rerender(view) {
     view.renderer.ensureViewNotRendering(view);

--- a/packages/ember-views/lib/views/states/destroying.js
+++ b/packages/ember-views/lib/views/states/destroying.js
@@ -21,4 +21,3 @@ assign(destroying, {
 });
 
 export default destroying;
-

--- a/packages/ember-views/lib/views/states/has_element.js
+++ b/packages/ember-views/lib/views/states/has_element.js
@@ -33,17 +33,12 @@ assign(hasElement, {
     view.renderer.rerender(view);
   },
 
-  cleanup(view) {
-    view._currentState.destroyElement(view);
-  },
-
-  // once the view is already in the DOM, destroying it removes it
-  // from the DOM, nukes its element, and puts it back into the
-  // preRender state if inDOM.
-
   destroyElement(view) {
     view.renderer.remove(view, false);
-    return view;
+  },
+
+  destroy(view) {
+    view.renderer.remove(view, true);
   },
 
   // Handle events from `Ember.EventDispatcher`

--- a/packages/ember-views/lib/views/states/in_dom.js
+++ b/packages/ember-views/lib/views/states/in_dom.js
@@ -27,7 +27,9 @@ assign(inDOM, {
   },
 
   exit(view) {
-    view._unregister();
+    if (view.tagName !== '') {
+      view._unregister();
+    }
   }
 });
 

--- a/packages/ember-views/tests/system/event_dispatcher_test.js
+++ b/packages/ember-views/tests/system/event_dispatcher_test.js
@@ -108,9 +108,7 @@ QUnit.test('should not dispatch events to views not inDOM', function() {
   let $element = view.$();
 
   run(() => {
-    // TODO change this test not to use private API
-    // Force into preRender
-    view.renderer.remove(view, false, true);
+    view.destroyElement();
   });
 
   $element.trigger('mousedown');


### PR DESCRIPTION
- [x] Add tests to ensure `.parentView` is available in all hooks.
- [x] Add tests to ensure `.element` is available in appropriate hooks.
- [x] add tests that assure counts of hooks in all dynamic scenarios
- [x] add regression tests
  - [x] `willDestroyElement` is called for components invoked from the `{{else}}` hook of an `{{#each` https://github.com/emberjs/ember.js/issues/12716.
  - [x] `this.parentView` is available in `willDestroyElement` https://github.com/emberjs/ember.js/issues/12080.
  - [x] `willDestroyElement` is called before actual destruction for components rendered with `{{component` helper.

This should fix #12080 #12716 and #13028
