### PR TITLE
[BUGFIX release] Fix NoneLocation#getURL

### DIFF
--- a/packages/ember-routing/lib/location/history_location.js
+++ b/packages/ember-routing/lib/location/history_location.js
@@ -76,8 +76,8 @@ export default EmberObject.extend({
 
     // remove baseURL and rootURL from start of path
     var url = path
-      .replace(new RegExp('^' + baseURL), '')
-      .replace(new RegExp('^' + rootURL), '');
+      .replace(new RegExp('^' + baseURL + '(?=/|$)'), '')
+      .replace(new RegExp('^' + rootURL + '(?=/|$)'), '');
 
     var search = location.search || '';
     url += search;

--- a/packages/ember-routing/lib/location/none_location.js
+++ b/packages/ember-routing/lib/location/none_location.js
@@ -54,7 +54,7 @@ export default EmberObject.extend({
     rootURL = rootURL.replace(/\/$/, '');
 
     // remove rootURL from url
-    return path.replace(new RegExp('^' + rootURL), '');
+    return path.replace(new RegExp('^' + rootURL + '(?=/|$)'), '');
   },
 
   /**

--- a/packages/ember-routing/tests/location/history_location_test.js
+++ b/packages/ember-routing/tests/location/history_location_test.js
@@ -189,6 +189,22 @@ QUnit.test('HistoryLocation.getURL() returns the current url, does not remove ro
   equal(location.getURL(), '/foo/bar/baz');
 });
 
+QUnit.test('HistoryLocation.getURL() will not remove the rootURL when only a partial match', function() {
+  expect(1);
+
+  HistoryTestLocation.reopen({
+    init() {
+      this._super(...arguments);
+      set(this, 'location', mockBrowserLocation('/bars/baz'));
+      set(this, 'rootURL', '/bar/');
+    }
+  });
+
+  createLocation();
+
+  equal(location.getURL(), '/bars/baz');
+});
+
 QUnit.test('HistoryLocation.getURL() returns the current url, does not remove baseURL if its not at start of url', function() {
   expect(1);
 
@@ -204,6 +220,22 @@ QUnit.test('HistoryLocation.getURL() returns the current url, does not remove ba
   createLocation();
 
   equal(location.getURL(), '/foo/bar/baz');
+});
+
+QUnit.test('HistoryLocation.getURL() will not remove the baseURL when only a partial match', function() {
+  expect(1);
+
+  HistoryTestLocation.reopen({
+    init() {
+      this._super(...arguments);
+      set(this, 'location', mockBrowserLocation('/bars/baz'));
+      set(this, 'baseURL', '/bar/');
+    }
+  });
+
+  createLocation();
+
+  equal(location.getURL(), '/bars/baz');
 });
 
 QUnit.test('HistoryLocation.getURL() includes location.search', function() {

--- a/packages/ember-routing/tests/location/none_location_test.js
+++ b/packages/ember-routing/tests/location/none_location_test.js
@@ -52,7 +52,7 @@ QUnit.test('NoneLocation.getURL() returns the current path minus rootURL', funct
   equal(location.getURL(), '/bar');
 });
 
-QUnit.test('NonoLocation.getURL() will remove the rootURL only from the beginning of a url', function() {
+QUnit.test('NoneLocation.getURL() will remove the rootURL only from the beginning of a url', function() {
   expect(1);
 
   NoneTestLocation.reopen({
@@ -66,4 +66,20 @@ QUnit.test('NonoLocation.getURL() will remove the rootURL only from the beginnin
   createLocation();
 
   equal(location.getURL(), '/foo/bar/baz');
+});
+
+QUnit.test('NoneLocation.getURL() will not remove the rootURL when only a partial match', function() {
+  expect(1);
+
+  NoneTestLocation.reopen({
+    init() {
+      this._super(...arguments);
+      set(this, 'rootURL', '/bar/');
+      set(this, 'path', '/bars/baz');
+    }
+  });
+
+  createLocation();
+
+  equal(location.getURL(), '/bars/baz');
 });


### PR DESCRIPTION
Prior fixes to NoneLocation#getURL broke the case where the rootURL
matched the start of the main URL. Resolve that case by checking for
a subsequent forward slash or end of string.
