### PR TITLE
[WIP] Ensure correct shaping for `isDestroy[ing|ed]` on CoreObject.

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -50,6 +50,13 @@ var finishPartial = Mixin.finishPartial;
 var reopen = Mixin.prototype.reopen;
 var hasCachedComputedProperties = false;
 
+const FALSE_DESCRIPTOR = {
+  configurable: true,
+  writable: true,
+  enumerable: false,
+  value: false
+};
+
 function makeCtor() {
   // Note: avoid accessing any properties on the object since it makes the
   // method a lot faster. This is glue code so we want it to be as fast as
@@ -67,7 +74,18 @@ function makeCtor() {
       initProperties = [arguments[0]];
     }
 
+    this.__defineNonEnumerable({
+      name: 'isDestroying',
+      descriptor: FALSE_DESCRIPTOR
+    });
+
+    this.__defineNonEnumerable({
+      name: 'isDestroyed',
+      descriptor: FALSE_DESCRIPTOR
+    });
+
     this.__defineNonEnumerable(GUID_KEY_PROPERTY);
+
     var m = meta(this);
     var proto = m.proto;
     m.proto = this;

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -3,7 +3,6 @@ import RSVP from 'ember-runtime/ext/rsvp';
 import Route from 'ember-routing/system/route';
 import run from 'ember-metal/run_loop';
 import get from 'ember-metal/property_get';
-import EmberObject from 'ember-runtime/system/object';
 import isEnabled from 'ember-metal/features';
 import { computed } from 'ember-metal/computed';
 import { compile } from 'ember-template-compiler/tests/utils/helpers';
@@ -2551,11 +2550,11 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
 
     let indexModelCount = 0;
     App.IndexRoute = Route.extend({
-      queryParams: EmberObject.create({
+      queryParams: {
         unknownProperty(keyName) {
           return { refreshModel: true };
         }
-      }),
+      },
       model(params) {
         indexModelCount++;
 
@@ -2745,12 +2744,12 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     });
 
     App.ApplicationRoute = Route.extend({
-      queryParams: EmberObject.create({
+      queryParams: {
         unknownProperty(keyName) {
           // We are simulating all qps requiring refresh
           return { replace: true };
         }
-      })
+      }
     });
 
     bootApplication();


### PR DESCRIPTION
Shaping the prototype is not enough, we should ensure the instance properties are set in the constructor.
