### PR TITLE
[BUGFIX beta] Various Chrome deopt fixes.

### DIFF
--- a/packages/ember-glimmer/lib/utils/references.js
+++ b/packages/ember-glimmer/lib/utils/references.js
@@ -110,7 +110,7 @@ export class PropertyReference extends CachedReference { // jshint ignore:line
       _parentObjectTag.update(tagFor(parentValue));
     }
 
-    if (parentValue && typeof parentValue === 'object') {
+    if (typeof parentValue === 'object' && parentValue) {
       if (isEnabled('mandatory-setter')) {
         let meta = metaFor(parentValue);
         watchKey(parentValue, _propertyKey, meta);

--- a/packages/ember-htmlbars/lib/keywords/get.js
+++ b/packages/ember-htmlbars/lib/keywords/get.js
@@ -66,7 +66,7 @@ const DynamicKeyStream = BasicStream.extend({
     if (object !== this.observedObject || key !== this.observedKey) {
       this._clearObservedObject();
 
-      if (object && typeof object === 'object' && key) {
+      if (typeof object === 'object' && object && key) {
         addObserver(object, key, this, this.notify);
         this.observedObject = object;
         this.observedKey = key;

--- a/packages/ember-htmlbars/lib/streams/key-stream.js
+++ b/packages/ember-htmlbars/lib/streams/key-stream.js
@@ -63,7 +63,7 @@ export default BasicStream.extend({
     if (object !== this.observedObject) {
       this._clearObservedObject();
 
-      if (object && typeof object === 'object') {
+      if (typeof object === 'object' && object) {
         addObserver(object, this.key, this, this.notify);
         this.observedObject = object;
       }

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -585,7 +585,7 @@ function _detect(curMixin, targetMixin, seen) {
   @private
 */
 MixinPrototype.detect = function(obj) {
-  if (!obj) { return false; }
+  if (typeof obj !== 'object' || obj === null) { return false; }
   if (obj instanceof Mixin) { return _detect(obj, this, {}); }
   let m = peekMeta(obj);
   if (!m) { return false; }

--- a/packages/ember-metal/lib/tags.js
+++ b/packages/ember-metal/lib/tags.js
@@ -16,7 +16,7 @@ export function tagFor(object, _meta) {
     throw new Error('Cannot call tagFor without Glimmer');
   }
 
-  if (object && typeof object === 'object') {
+  if (typeof object === 'object' && object) {
     let meta = _meta || metaFor(object);
     return meta.writableTag(makeTag);
   } else {

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -179,7 +179,11 @@ export function generateGuid(obj, prefix) {
   @return {String} the unique guid for this instance.
 */
 export function guidFor(obj) {
-  if (obj && obj[GUID_KEY]) {
+  let type = typeof obj;
+  let isObject = type === 'object' && obj !== null;
+  let isFunction = type === 'function';
+
+  if ((isObject || isFunction) && obj[GUID_KEY]) {
     return obj[GUID_KEY];
   }
 
@@ -193,7 +197,6 @@ export function guidFor(obj) {
   }
 
   let ret;
-  let type = typeof obj;
 
   // Don't allow prototype changes to String etc. to change the guidFor
   switch (type) {


### PR DESCRIPTION
- Prevent indexing into primitive types in `guidFor`. Doing `obj[GUID_KEY]` on primitive objects (strings, booleans, numbers, etc) will not work, and triggers a deopt.
- Prevent deopting `Mixin.detect` for each type found. With the truthiness check that existed before, this method is deopted everytime it sees a new type of value. (See screenshots from irhydra in commit message).
- Check `typeof` before testing for truthiness. Using the `typeof` check before the truthiness check, prevents deopts in Chrome for each new object type that is seen (after it initially optimizes).
