### PR TITLE
[CLEANUP/BUGFIX lts] Remove remnants of angle bracket components.

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/web-component-fallback-test.js
+++ b/packages/ember-glimmer/tests/integration/components/web-component-fallback-test.js
@@ -1,0 +1,32 @@
+import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { set } from 'ember-metal/property_set';
+
+moduleFor('Components test: web component fallback', class extends RenderingTest {
+  ['@test custom elements are rendered']() {
+    let template = `<foo-bar some-attr="123">hello</foo-bar>`;
+
+    this.render(template);
+
+    this.assertHTML(template);
+
+    this.assertStableRerender();
+  }
+
+  ['@test custom elements can have bound attributes']() {
+    let template = `<foo-bar some-attr="{{name}}">hello</foo-bar>`;
+
+    this.render(template, { name: 'Robert' });
+
+    this.assertHTML(`<foo-bar some-attr="Robert">hello</foo-bar>`);
+
+    this.assertStableRerender();
+
+    this.runTask(() => set(this.context, 'name', 'Kris'));
+
+    this.assertHTML(`<foo-bar some-attr="Kris">hello</foo-bar>`);
+
+    this.runTask(() => set(this.context, 'name', 'Robert'));
+
+    this.assertHTML(`<foo-bar some-attr="Robert">hello</foo-bar>`);
+  }
+});

--- a/packages/ember-htmlbars/lib/hooks/component.js
+++ b/packages/ember-htmlbars/lib/hooks/component.js
@@ -14,19 +14,12 @@ import {
   mergeInNewHash,
   processPositionalParamsFromCell,
 } from 'ember-htmlbars/keywords/closure-component';
-import { buildHTMLTemplate } from 'ember-htmlbars/system/build-component-template';
 
 export default function componentHook(renderNode, env, scope, _tagName, params, _attrs, templates, visitor) {
   let state = renderNode.getState();
 
   let tagName = _tagName;
   let attrs = _attrs;
-  if (isAngle(tagName)) {
-    tagName = tagName.slice(1, -1);
-    let block = buildHTMLTemplate(tagName, attrs, { templates, scope });
-    block.invoke(env, [], undefined, renderNode, scope, visitor);
-    return;
-  }
 
   if (CONTAINS_DOT_CACHE.get(tagName)) {
     let stream = env.hooks.get(env, scope, tagName);
@@ -91,8 +84,4 @@ export default function componentHook(renderNode, env, scope, _tagName, params, 
 
   state.manager = manager;
   manager.render(env, visitor);
-}
-
-function isAngle(tagName) {
-  return tagName.charCodeAt(0) === 60;
 }


### PR DESCRIPTION
The original techniques/hooks were removed when the feature was removed, but this code remained. Unfortunately, when tagName is '' we were still attempting to `''.charCodeAt(0)` which deopts the native `charCodeAt`.
