### PR TITLE
Use meta to build `eachComputedProperty`.

### DIFF
--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -37,7 +37,8 @@ let counters = {
  peekWatching, clearWatching, writeMixins,
  peekMixins, clearMixins, writeBindings,
  peekBindings, clearBindings, writeValues,
- peekValues, clearValues, writeDeps, forEachInDeps
+ peekValues, clearValues, writeDescriptor,
+ forEachDescriptor, writeDeps, forEachInDeps
  writableChainWatchers, readableChainWatchers, writableChains,
  readableChains, writableTag, readableTag
 
@@ -49,6 +50,7 @@ let members = {
   mixins: inheritedMap,
   bindings: inheritedMap,
   values: inheritedMap,
+  descriptor: inheritedMap,
   deps: inheritedMapOfMaps,
   chainWatchers: ownCustomObject,
   chains: inheritedCustomObject,
@@ -73,6 +75,7 @@ export function Meta(obj, parentMeta) {
   this._mixins = undefined;
   this._bindings = undefined;
   this._values = undefined;
+  this._descriptor = undefined;
   this._deps = undefined;
   this._chainWatchers = undefined;
   this._chains = undefined;
@@ -139,6 +142,11 @@ function inheritedMap(name, Meta) {
     map[subkey] = value;
   };
 
+  Meta.prototype['reset' + capitalized] = function(subkey) {
+    let map = this._getOrCreateOwnMap(key);
+    map[subkey] = UNDEFINED;
+  };
+
   Meta.prototype['peek' + capitalized] = function(subkey) {
     return this._findInherited(key, subkey);
   };
@@ -152,7 +160,10 @@ function inheritedMap(name, Meta) {
         for (let key in map) {
           if (!seen[key]) {
             seen[key] = true;
-            fn(key, map[key]);
+
+            if (map[key] !== UNDEFINED) {
+              fn(key, map[key]);
+            }
           }
         }
       }

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -345,6 +345,9 @@ function applyMixin(obj, mixins, partial) {
 
   obj._super = ROOT;
 
+  let knownDescriptors = [];
+  m.forEachDescriptor(name => knownDescriptors.push(name));
+
   // Go through all mixins and hashes passed in, and:
   //
   // * Handle concatenated properties
@@ -367,6 +370,12 @@ function applyMixin(obj, mixins, partial) {
       let followed = followAlias(obj, desc, m, descs, values);
       desc = followed.desc;
       value = followed.value;
+    }
+
+    if (desc && desc.isDescriptor) {
+      m.writeDescriptor(key, desc);
+    } else if (knownDescriptors.indexOf(key) > -1) {
+      m.resetDescriptor(key);
     }
 
     if (desc === undefined && value === undefined) { continue; }

--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -142,7 +142,7 @@ export function defineProperty(obj, keyName, desc, data, meta) {
     existingDesc.teardown(obj, keyName);
   }
 
-  if (desc instanceof Descriptor) {
+  if (desc !== null && typeof desc === 'object' && desc.isDescriptor) {
     value = desc;
     if (isEnabled('mandatory-setter')) {
       if (watching) {
@@ -159,6 +159,8 @@ export function defineProperty(obj, keyName, desc, data, meta) {
       obj[keyName] = value;
     }
     if (desc.setup) { desc.setup(obj, keyName); }
+
+    meta.writeDescriptor(keyName, desc);
   } else {
     if (desc == null) {
       value = data;

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -7,8 +7,6 @@
   @submodule ember-runtime
 */
 
-// using ember-metal/lib/main here to ensure that ember-debug is setup
-// if present
 import {
   assign,
   guidFor,
@@ -21,7 +19,6 @@ import {
   assert,
   runInDebug,
   isFeatureEnabled,
-  get,
   meta,
   finishChains,
   sendEvent,
@@ -32,7 +29,6 @@ import {
   defineProperty,
   Binding,
   ComputedProperty,
-  computed,
   InjectedProperty,
   run,
   destroy
@@ -45,7 +41,6 @@ var schedule = run.schedule;
 var applyMixin = Mixin._apply;
 var finishPartial = Mixin.finishPartial;
 var reopen = Mixin.prototype.reopen;
-var hasCachedComputedProperties = false;
 
 function makeCtor() {
   // Note: avoid accessing any properties on the object since it makes the
@@ -825,36 +820,18 @@ var ClassMixinProps = {
     @private
   */
   metaForProperty(key) {
-    var proto = this.proto();
-    var possibleDesc = proto[key];
-    var desc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
+    this.proto(); // ensure prototype is initialized
+    let m = meta(this.prototype);
+    let desc = m.peekDescriptor(key);
 
     assert(
       'metaForProperty() could not find a computed property ' +
       'with key \'' + key + '\'.',
       !!desc && desc instanceof ComputedProperty
     );
+
     return desc._meta || {};
   },
-
-  _computedProperties: computed(function() {
-    hasCachedComputedProperties = true;
-    var proto = this.proto();
-    var property;
-    var properties = [];
-
-    for (var name in proto) {
-      property = proto[name];
-
-      if (property && property.isDescriptor) {
-        properties.push({
-          name: name,
-          meta: property._meta
-        });
-      }
-    }
-    return properties;
-  }).readOnly(),
 
   /**
     Iterate over each computed property for the class, passing its name
@@ -866,16 +843,17 @@ var ClassMixinProps = {
     @param {Object} binding
     @private
   */
-  eachComputedProperty(callback, binding) {
-    var property;
-    var empty = {};
+  eachComputedProperty(callback, _binding) {
+    this.proto(); // ensure prototype is initialized
+    let empty = {};
+    let binding = _binding || this;
 
-    var properties = get(this, '_computedProperties');
+    let m = meta(this.prototype);
+    m.forEachDescriptor(function(name, descriptor) {
+      let meta = descriptor._meta || empty;
 
-    for (var i = 0; i < properties.length; i++) {
-      property = properties[i];
-      callback.call(binding || this, property.name, property.meta || empty);
-    }
+      callback.call(binding, name, meta);
+    });
   }
 };
 
@@ -925,16 +903,7 @@ CoreObject.ClassMixin = ClassMixin;
 ClassMixin.apply(CoreObject);
 
 CoreObject.reopen({
-  didDefineProperty(proto, key, value) {
-    if (hasCachedComputedProperties === false) { return; }
-    if (value instanceof ComputedProperty) {
-      var cache = meta(this.constructor).readableCache();
-
-      if (cache && cache._computedProperties !== undefined) {
-        cache._computedProperties = undefined;
-      }
-    }
-  }
+  didDefineProperty() { }
 });
 
 export default CoreObject;


### PR DESCRIPTION
This avoids iterating all properties on a given class when `.eachComputedProperty` is used by storing each descriptor in the prototypes meta.

This also fixes an issue where, `.eachComputedProperty` would _not_ update properly when `Ember.defineProperty` is used to add a CP (instead of `.extend` or `.reopen`).

/cc @krisselden
