### PR TITLE
Update api doc for Enumerable#contains to flag it as deprecated

### DIFF
--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -227,6 +227,7 @@ const Enumerable = Mixin.create({
     ```
 
     @method contains
+    @deprecated Use `Enumerable#includes` instead. See http://emberjs.com/deprecations/v2.x#toc_enumerable-contains
     @param {Object} obj The object to search for.
     @return {Boolean} `true` if object is found in enumerable.
     @public


### PR DESCRIPTION
Doc update related to #13553.

For merging only once `ember-runtime-enumerable-includes` has been enabled without feature flag.
