### PR TITLE
Fix Windows builds

### DIFF
--- a/lib/jscs-rules/require-comments-to-include-access.js
+++ b/lib/jscs-rules/require-comments-to-include-access.js
@@ -5,11 +5,11 @@ function isDocComment(comment) {
 }
 
 function isModuleOnlyComment(comment) {
-  return comment.value.match(/^\*\n\s*@module.+\n(?:\s*@submodule.+\n)?$/);
+  return comment.value.match(/^\*\r?\n\s*@module.+\r?\n(?:\s*@submodule.+\r?\n)?$/);
 }
 
 function accessDeclarationCount(comment) {
-  var matched = comment.value.match(/\n\s*(?:@private|@public|@protected)\s/g);
+  var matched = comment.value.match(/\r?\n\s*(?:@private|@public|@protected)\s/g);
   return matched ? matched.length : 0;
 }
 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "build": "ember build --environment production",
     "pretest": "ember build",
-    "test": "bin/run-tests.js",
-    "test:sauce": "bin/run-sauce-tests.js",
+    "test": "node bin/run-tests.js",
+    "test:sauce": "node bin/run-sauce-tests.js",
     "test:testem": "testem -f testem.dist.json",
     "test:blueprints": "node node-tests/nodetest-runner.js",
     "start": "ember serve",


### PR DESCRIPTION
This PR is related to bug #13227 and should fix it.

Moreover, I updated `package.json` to change `test` and `test:sauce` script to add explicit `node` command behind. Without that, these command were not working on Windows.

I successfully tested both JSCS update and scripts on Windows and Ubuntu. I guess it should be also OK on OSX.

Let me know if I missed something.
