### PR TITLE
[BUGFIX beta] Ensure didInitAttrs deprecation is stripped in prod.

### DIFF
--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -82,17 +82,15 @@ export function accumulateListeners(obj, eventName, otherActions) {
 export function addListener(obj, eventName, target, method, once) {
   assert('You must pass at least an object and event name to Ember.addListener', !!obj && !!eventName);
 
-  if (eventName === 'didInitAttrs' && obj.isComponent) {
-    deprecate(
-      `[DEPRECATED] didInitAttrs called in ${obj.toString()}.`,
-      false,
-      {
-        id: 'ember-views.did-init-attrs',
-        until: '3.0.0',
-        url: 'http://emberjs.com/deprecations/v2.x#toc_ember-component-didinitattrs'
-      }
-    );
-  }
+  deprecate(
+    `didInitAttrs called in ${obj && obj.toString && obj.toString()}.`,
+    eventName !== 'didInitAttrs',
+    {
+      id: 'ember-views.did-init-attrs',
+      until: '3.0.0',
+      url: 'http://emberjs.com/deprecations/v2.x#toc_ember-component-didinitattrs'
+    }
+  );
 
   if (!method && 'function' === typeof target) {
     method = target;

--- a/packages/ember-metal/tests/events_test.js
+++ b/packages/ember-metal/tests/events_test.js
@@ -267,5 +267,5 @@ QUnit.test('DEPRECATED: adding didInitAttrs as a listener is deprecated', functi
 
   expectDeprecation(() => {
     addListener(obj, 'didInitAttrs');
-  }, /\[DEPRECATED\] didInitAttrs called in <\Ember.Component\:ember[\d+]+>\./);
+  }, /didInitAttrs called in <\Ember.Component\:ember[\d+]+>\./);
 });


### PR DESCRIPTION
In production builds, the `didInitAttrs` deprecation was not being fully stripped. This refactors to remove the guarding `if` (in favor `Ember.deprecate` test parameter).
