### PR TITLE
Rename "Object" imports to "EmberObject"

### DIFF
--- a/packages/ember-glimmer/lib/helper.js
+++ b/packages/ember-glimmer/lib/helper.js
@@ -4,7 +4,7 @@
 */
 
 import symbol from 'ember-metal/symbol';
-import Object from 'ember-runtime/system/object';
+import EmberObject from 'ember-runtime/system/object';
 import { POST_INIT } from 'ember-runtime/system/core_object';
 import { DirtyableTag } from 'glimmer-reference';
 
@@ -50,7 +50,7 @@ export const RECOMPUTE_TAG = symbol('RECOMPUTE_TAG');
   @public
   @since 1.13.0
 */
-var Helper = Object.extend({
+var Helper = EmberObject.extend({
   isHelperInstance: true,
 
   [POST_INIT]() {

--- a/packages/ember-htmlbars/lib/helper.js
+++ b/packages/ember-htmlbars/lib/helper.js
@@ -3,7 +3,7 @@
 @submodule ember-templates
 */
 
-import Object from 'ember-runtime/system/object';
+import EmberObject from 'ember-runtime/system/object';
 
 /**
   Ember Helpers are functions that can compute values, and are used in templates.
@@ -60,7 +60,7 @@ import Object from 'ember-runtime/system/object';
   @public
   @since 1.13.0
 */
-const Helper = Object.extend({
+const Helper = EmberObject.extend({
   isHelperInstance: true,
 
   /**

--- a/packages/ember-runtime/lib/system/service.js
+++ b/packages/ember-runtime/lib/system/service.js
@@ -1,4 +1,4 @@
-import Object from 'ember-runtime/system/object';
+import EmberObject from 'ember-runtime/system/object';
 import { createInjectionHelper } from 'ember-runtime/inject';
 
 
@@ -39,7 +39,7 @@ createInjectionHelper('service');
   @since 1.10.0
   @public
 */
-const Service = Object.extend();
+const Service = EmberObject.extend();
 
 Service.reopenClass({
   isServiceFactory: true

--- a/packages/ember-runtime/tests/controllers/controller_test.js
+++ b/packages/ember-runtime/tests/controllers/controller_test.js
@@ -3,7 +3,7 @@
 import Controller from 'ember-runtime/controllers/controller';
 import Service from 'ember-runtime/system/service';
 import Mixin from 'ember-metal/mixin';
-import Object from 'ember-runtime/system/object';
+import EmberObject from 'ember-runtime/system/object';
 import inject from 'ember-runtime/inject';
 import { get } from 'ember-metal/property_get';
 import buildOwner from 'container/tests/test-helpers/build-owner';
@@ -157,7 +157,7 @@ if (!EmberDev.runningProdBuild) {
     expectAssertion(function() {
       let owner = buildOwner();
 
-      let AnObject = Object.extend({
+      let AnObject = EmberObject.extend({
         foo: inject.controller('bar')
       });
 

--- a/packages/ember-runtime/tests/inject_test.js
+++ b/packages/ember-runtime/tests/inject_test.js
@@ -5,7 +5,7 @@ import inject from 'ember-runtime/inject';
 import {
   createInjectionHelper
 } from 'ember-runtime/inject';
-import Object from 'ember-runtime/system/object';
+import EmberObject from 'ember-runtime/system/object';
 import buildOwner from 'container/tests/test-helpers/build-owner';
 
 QUnit.module('inject');
@@ -28,7 +28,7 @@ if (!EmberDev.runningProdBuild) {
 
     let owner = buildOwner();
 
-    let AnObject = Object.extend({
+    let AnObject = EmberObject.extend({
       bar: inject.foo(),
       baz: inject.foo()
     });
@@ -39,7 +39,7 @@ if (!EmberDev.runningProdBuild) {
 
   QUnit.test('attempting to inject a nonexistent container key should error', function() {
     let owner = buildOwner();
-    let AnObject = Object.extend({
+    let AnObject = EmberObject.extend({
       foo: new InjectedProperty('bar', 'baz')
     });
 
@@ -52,7 +52,7 @@ if (!EmberDev.runningProdBuild) {
 }
 
 QUnit.test('factories should return a list of lazy injection full names', function() {
-  let AnObject = Object.extend({
+  let AnObject = EmberObject.extend({
     foo: new InjectedProperty('foo', 'bar'),
     bar: new InjectedProperty('quux')
   });

--- a/packages/ember-runtime/tests/system/array_proxy/length_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/length_test.js
@@ -1,5 +1,5 @@
 import ArrayProxy from 'ember-runtime/system/array_proxy';
-import Object from 'ember-runtime/system/object';
+import EmberObject from 'ember-runtime/system/object';
 import { observer } from 'ember-metal/mixin';
 import { computed } from 'ember-metal/computed';
 import { A as a } from 'ember-runtime/system/native_array';
@@ -11,7 +11,7 @@ QUnit.test('array proxy + aliasedProperty complex test', function() {
 
   aCalled = bCalled = cCalled = dCalled = eCalled = 0;
 
-  let obj = Object.extend({
+  let obj = EmberObject.extend({
     colors: computed.reads('model'),
     length: computed.reads('colors.length'),
 


### PR DESCRIPTION
Importing this as "Object" hides the native "Object" API which can lead to unexpected results.

This is also necessary to enable https://github.com/emberjs/emberjs-build/pull/165
