### PR TITLE
[BUGFIX beta] Ability to set a query param to a string of "null" when default value is null

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -411,6 +411,8 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     // to a certain query param.
     if (defaultValueType === 'array') {
       return JSON.stringify(value);
+    } else if (defaultValueType === 'null' && value === null) {
+      return null;
     }
     return `${value}`;
   },

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -439,6 +439,21 @@ QUnit.test('Route#paramsFor fetches query params', function() {
   bootApplication();
 });
 
+QUnit.test('query paramater with a default value of null should be able to get set to a string of null', function() {
+  expect(1);
+
+  App.IndexController = Controller.extend({
+    queryParams: ['foo'],
+    foo: null
+  });
+
+  startingURL = '/';
+  bootApplication();
+  run(router, 'transitionTo', { queryParams: { foo: 'null' } });
+  equal(router.get('location.path'), '/?foo=null', 'foo can be set to a string of null');
+});
+
+
 QUnit.test('model hook can query prefix-less application params (overridden by incoming url value)', function() {
   App.ApplicationController = Controller.extend({
     queryParams: ['appomg'],


### PR DESCRIPTION
If a default query parameter is null, we should leave it as `null` and not switch it to a string value of `"null"`.

This came up when in a controller we had set a default value for a query parameter of `search` to be `null`. Then if we tried to do a search for `"null"` it would not perform the search since it was casting the `null` value to a string of `"null"` for the default, and failed the difference check between the new query param and the default.

Didn't see any pertinent tests in the local package tests, so I added a test to the general ember routing query param test.
