### PR TITLE
[FEATURE ember-application-engines] Merge route serializers into engines work

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,10 +15,6 @@ for a detailed explanation.
   Implements RFC https://github.com/emberjs/rfcs/pull/38, adding support for
   routable components.
 
-* `ember-route-serializers`
-
-  Deprecates `Route#serialize` and introduces a `serialize` option to the router DSL as a replacement (as per the [Route Serializers RFC](https://github.com/emberjs/rfcs/blob/master/text/0120-route-serializers.md)).
-
 * `ember-runtime-computed-uniq-by`
 
   Introduces a computed and enumerable method "uniqBy" that allows creation of a new enumerable with unique values as  determined by the given property key.

--- a/features.json
+++ b/features.json
@@ -4,7 +4,6 @@
     "ember-routing-route-configured-query-params": null,
     "ember-libraries-isregistered": null,
     "ember-application-engines": null,
-    "ember-route-serializers": null,
     "ember-glimmer": null,
     "ember-runtime-computed-uniq-by": true,
     "ember-improved-instrumentation": null,

--- a/packages/ember-glimmer/lib/setup-registry.js
+++ b/packages/ember-glimmer/lib/setup-registry.js
@@ -6,8 +6,6 @@ import Checkbox from 'ember-glimmer/components/checkbox';
 import LinkToComponent from 'ember-glimmer/components/link-to';
 
 export function setupApplicationRegistry(registry) {
-  let Environment = require('ember-glimmer/environment').default;
-  registry.register('service:-glimmer-environment', Environment);
   registry.injection('service:-glimmer-environment', 'dom', 'service:-dom-helper');
   registry.injection('renderer', 'env', 'service:-glimmer-environment');
 
@@ -31,6 +29,9 @@ export function setupEngineRegistry(registry) {
   registry.register(P`template:components/-default`, glimmerComponentTemplate);
   registry.register('template:-outlet', glimmerOutletTemplate);
   registry.injection('view:-outlet', 'template', 'template:-outlet');
+
+  let Environment = require('ember-glimmer/environment').default;
+  registry.register('service:-glimmer-environment', Environment);
   registry.injection('template', 'env', 'service:-glimmer-environment');
 
   registry.optionsForType('helper', { instantiate: false });

--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -14,7 +14,7 @@ function DSL(name, options) {
   this.explicitIndex = undefined;
   this.options = options;
 
-  if (isEnabled('ember-route-serializers')) {
+  if (isEnabled('ember-application-engines')) {
     this.router = options && options.router;
   }
 }
@@ -47,7 +47,7 @@ DSL.prototype = {
       createRoute(this, `${name}_error`, { path: dummyErrorRoute });
     }
 
-    if (isEnabled('ember-route-serializers') && options.serialize && this.router) {
+    if (isEnabled('ember-application-engines') && options.serialize && this.router) {
       this.router._serializeMethods[name] = options.serialize;
     }
 

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -58,7 +58,7 @@ function defaultSerialize(model, params) {
 
 const DEFAULT_SERIALIZE = symbol('DEFAULT_SERIALIZE');
 
-if (isEnabled('ember-route-serializers')) {
+if (isEnabled('ember-application-engines')) {
   defaultSerialize[DEFAULT_SERIALIZE] = true;
 }
 

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -36,7 +36,7 @@ const { slice } = Array.prototype;
 
 function K() { return this; }
 
-function defaultSerialize(model, params) {
+export function defaultSerialize(model, params) {
   if (params.length < 1) { return; }
   if (!model) { return; }
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -1,5 +1,5 @@
 import Logger from 'ember-console';
-import { assert, info, deprecate } from 'ember-metal/debug';
+import { assert, info } from 'ember-metal/debug';
 import EmberError from 'ember-metal/error';
 import isEnabled from 'ember-metal/features';
 import { get } from 'ember-metal/property_get';
@@ -11,7 +11,7 @@ import assign from 'ember-metal/assign';
 import run from 'ember-metal/run_loop';
 import EmberObject from 'ember-runtime/system/object';
 import Evented from 'ember-runtime/mixins/evented';
-import { hasDefaultSerialize } from 'ember-routing/system/route';
+import { defaultSerialize, hasDefaultSerialize } from 'ember-routing/system/route';
 import EmberRouterDSL from 'ember-routing/system/dsl';
 import EmberLocation from 'ember-routing/location/api';
 import {
@@ -112,7 +112,6 @@ const EmberRouter = EmberObject.extend(Evented, {
       let owner = getOwner(this);
       let router = this;
 
-      options.router = router;
       options.enableLoadingSubstates = !!moduleBasedResolver;
 
       options.resolveRouteMap = function(name) {
@@ -140,7 +139,6 @@ const EmberRouter = EmberObject.extend(Evented, {
     if (isEnabled('ember-application-engines')) {
       this._engineInstances = new EmptyObject();
       this._engineInfoByRoute = new EmptyObject();
-      this._serializeMethods = new EmptyObject();
     }
   },
 
@@ -568,9 +566,10 @@ const EmberRouter = EmberObject.extend(Evented, {
     return (name) => {
       let routeName = name;
       let routeOwner = owner;
+      let engineInfo;
 
       if (isEnabled('ember-application-engines')) {
-        let engineInfo = this._engineInfoByRoute[routeName];
+        engineInfo = this._engineInfoByRoute[routeName];
 
         if (engineInfo) {
           let engineInstance = this._getEngineInstance(engineInfo);
@@ -603,27 +602,24 @@ const EmberRouter = EmberObject.extend(Evented, {
 
       handler.routeName = routeName;
 
+      if (engineInfo && !hasDefaultSerialize(handler)) {
+        throw new Error('Defining a custom serialize method on an Engine route is not supported.');
+      }
+
       return handler;
     };
   },
 
   _getSerializerFunction() {
     return (name) => {
-      let serializer = this._serializeMethods[name];
+      let engineInfo = this._engineInfoByRoute[name];
 
-      if (!serializer) {
-        let handler = this.router.getHandler(name);
-
-        deprecate(
-          `Defining a serialize function on route '${name}' is deprecated. Instead, define it in the router's map as an option.`,
-          hasDefaultSerialize(handler),
-          { id: 'ember-routing.serialize-function', until: '3.0.0', url: 'http://emberjs.com/deprecations/v2.x#toc_route-serialize' }
-        );
-
-        this._serializeMethods[name] = handler.serialize;
+      // If this is not an Engine route, we fall back to the handler for serialization
+      if (!engineInfo) {
+        return;
       }
 
-      return serializer;
+      return engineInfo.serializeMethod || defaultSerialize;
     };
   },
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -108,14 +108,11 @@ const EmberRouter = EmberObject.extend(Evented, {
       enableLoadingSubstates: !!moduleBasedResolver
     };
 
-    if (isEnabled('ember-route-serializers')) {
-      options.router = this;
-    }
-
     if (isEnabled('ember-application-engines')) {
       let owner = getOwner(this);
       let router = this;
 
+      options.router = router;
       options.enableLoadingSubstates = !!moduleBasedResolver;
 
       options.resolveRouteMap = function(name) {
@@ -140,13 +137,10 @@ const EmberRouter = EmberObject.extend(Evented, {
     this._resetQueuedQueryParameterChanges();
     this._handledErrors = dictionary(null);
 
-    if (isEnabled('ember-route-serializers')) {
-      this._serializeMethods = new EmptyObject();
-    }
-
     if (isEnabled('ember-application-engines')) {
       this._engineInstances = new EmptyObject();
       this._engineInfoByRoute = new EmptyObject();
+      this._serializeMethods = new EmptyObject();
     }
   },
 
@@ -639,7 +633,7 @@ const EmberRouter = EmberObject.extend(Evented, {
 
     router.getHandler = this._getHandlerFunction();
 
-    if (isEnabled('ember-route-serializers')) {
+    if (isEnabled('ember-application-engines')) {
       router.getSerializer = this._getSerializerFunction();
     }
 

--- a/packages/ember-routing/tests/system/dsl_test.js
+++ b/packages/ember-routing/tests/system/dsl_test.js
@@ -115,6 +115,16 @@ QUnit.test('should not add loading and error routes if _isRouterMapResult is fal
 });
 
 if (isEnabled('ember-application-engines')) {
+  QUnit.test('should throw an error when defining a route serializer outside an engine', function() {
+    Router.map(function() {
+      throws(() => {
+        this.route('posts', { serialize: function() {} });
+      }, /Defining a route serializer on route 'posts' outside an Engine is not allowed/);
+    });
+
+    Router.create()._initRouterJs();
+  });
+
   QUnit.module('Ember Router DSL with engines', {
     setup,
     teardown

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -894,7 +894,7 @@ QUnit.asyncTest('Nested callbacks are not exited when moving to siblings', funct
     return this._super(...arguments);
   }
 
-  if (isEnabled('ember-route-serializers')) {
+  if (isEnabled('ember-application-engines')) {
     Router.map(function() {
       this.route('root', { path: '/', serialize: serializeRootRoute }, function() {
         this.route('special', { path: '/specials/:menu_item_id', resetNamespace: true });
@@ -2045,7 +2045,7 @@ QUnit.test('Nested index route is not overriden by parent\'s implicit index rout
   deepEqual(router.location.path, '/posts/emberjs');
 });
 
-if (isEnabled('ember-route-serializers')) {
+if (isEnabled('ember-application-engines')) {
   QUnit.test('Custom Route#serialize method still works [DEPRECATED]', function() {
     Router.map(function() {
       this.route('posts', function() {
@@ -2901,7 +2901,7 @@ QUnit.test('Redirecting with null model doesn\'t error out', function() {
     }
   }
 
-  if (isEnabled('ember-route-serializers')) {
+  if (isEnabled('ember-application-engines')) {
     Router.map(function() {
       this.route('home', { path: '/' });
       this.route('about', { path: '/about/:hurhurhur', serialize: serializeAboutRoute });

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -13,6 +13,7 @@ import Component from 'ember-templates/component';
 import jQuery from 'ember-views/system/jquery';
 import { compile } from 'ember-template-compiler/tests/utils/helpers';
 import Application from 'ember-application/system/application';
+import Engine from 'ember-application/system/engine';
 import { A as emberA } from 'ember-runtime/system/native_array';
 import NoneLocation from 'ember-routing/location/none_location';
 import HistoryLocation from 'ember-routing/location/history_location';
@@ -889,56 +890,31 @@ QUnit.asyncTest('Moving from one page to another triggers the correct callbacks'
 });
 
 QUnit.asyncTest('Nested callbacks are not exited when moving to siblings', function() {
-  function serializeRootRoute() {
-    rootSerialize++;
-    return this._super(...arguments);
-  }
-
-  if (isEnabled('ember-application-engines')) {
-    Router.map(function() {
-      this.route('root', { path: '/', serialize: serializeRootRoute }, function() {
-        this.route('special', { path: '/specials/:menu_item_id', resetNamespace: true });
-      });
+  Router.map(function() {
+    this.route('root', { path: '/' }, function() {
+      this.route('special', { path: '/specials/:menu_item_id', resetNamespace: true });
     });
+  });
 
-    App.RootRoute = Route.extend({
-      model() {
-        rootModel++;
-        return this._super(...arguments);
-      },
+  App.RootRoute = Route.extend({
+    model() {
+      rootModel++;
+      return this._super(...arguments);
+    },
 
-      setupController() {
-        rootSetup++;
-      },
+    setupController() {
+      rootSetup++;
+    },
 
-      renderTemplate() {
-        rootRender++;
-      }
-    });
-  } else {
-    Router.map(function() {
-      this.route('root', { path: '/' }, function() {
-        this.route('special', { path: '/specials/:menu_item_id', resetNamespace: true });
-      });
-    });
+    renderTemplate() {
+      rootRender++;
+    },
 
-    App.RootRoute = Route.extend({
-      model() {
-        rootModel++;
-        return this._super(...arguments);
-      },
-
-      setupController() {
-        rootSetup++;
-      },
-
-      renderTemplate() {
-        rootRender++;
-      },
-
-      serialize: serializeRootRoute
-    });
-  }
+    serialize: function() {
+      rootSerialize++;
+      return this._super(...arguments);
+    }
+  });
 
   let currentPath;
 
@@ -2045,33 +2021,6 @@ QUnit.test('Nested index route is not overriden by parent\'s implicit index rout
   deepEqual(router.location.path, '/posts/emberjs');
 });
 
-if (isEnabled('ember-application-engines')) {
-  QUnit.test('Custom Route#serialize method still works [DEPRECATED]', function() {
-    Router.map(function() {
-      this.route('posts', function() {
-        this.route('index', {
-          path: ':category'
-        });
-      });
-    });
-
-    App.PostsIndexRoute = Route.extend({
-      serialize(model) {
-        return { category: model.category };
-      }
-    });
-
-    bootApplication();
-
-    run(() => {
-      expectDeprecation(() => router.transitionTo('posts', { category: 'emberjs' }),
-                        'Defining a serialize function on route \'posts.index\' is deprecated. Instead, define it in the router\'s map as an option.');
-    });
-
-    deepEqual(router.location.path, '/posts/emberjs');
-  });
-}
-
 QUnit.test('Application template does not duplicate when re-rendered', function() {
   setTemplate('application', compile('<h3>I Render Once</h3>{{outlet}}'));
 
@@ -2895,27 +2844,18 @@ QUnit.test('Specifying non-existent controller name in route#render throws', fun
 });
 
 QUnit.test('Redirecting with null model doesn\'t error out', function() {
-  function serializeAboutRoute(model) {
-    if (model === null) {
-      return { hurhurhur: 'TreeklesMcGeekles' };
+  Router.map(function() {
+    this.route('home', { path: '/' });
+    this.route('about', { path: '/about/:hurhurhur' });
+  });
+
+  App.AboutRoute = Route.extend({
+    serialize: function(model) {
+      if (model === null) {
+        return { hurhurhur: 'TreeklesMcGeekles' };
+      }
     }
-  }
-
-  if (isEnabled('ember-application-engines')) {
-    Router.map(function() {
-      this.route('home', { path: '/' });
-      this.route('about', { path: '/about/:hurhurhur', serialize: serializeAboutRoute });
-    });
-  } else {
-    Router.map(function() {
-      this.route('home', { path: '/' });
-      this.route('about', { path: '/about/:hurhurhur' });
-    });
-
-    App.AboutRoute = Route.extend({
-      serialize: serializeAboutRoute
-    });
-  }
+  });
 
   App.HomeRoute = Route.extend({
     beforeModel() {
@@ -3725,3 +3665,58 @@ QUnit.test('Exception if outlet name is undefined in render and disconnectOutlet
     run(() => router.send('hideModal'));
   }, /You passed undefined as the outlet name/);
 });
+
+if (isEnabled('ember-application-engines')) {
+  QUnit.test('Route serializers work for Engines', function() {
+    expect(2);
+
+    // Register engine
+    let BlogEngine = Engine.extend();
+    registry.register('engine:blog', BlogEngine);
+
+    // Register engine route map
+    let postSerialize = function(params) {
+      ok(true, 'serialize hook runs');
+      return {
+        post_id: params.id
+      };
+    };
+    let BlogMap = function() {
+      this.route('post', { path: '/post/:post_id', serialize: postSerialize });
+    };
+    registry.register('route-map:blog', BlogMap);
+
+    Router.map(function() {
+      this.mount('blog');
+    });
+
+    bootApplication();
+
+    equal(router.router.generate('blog.post', { id: '13' }), '/blog/post/13', 'url is generated properly');
+  });
+
+  QUnit.test('Defining a Route#serialize method in an Engine throws an error', function() {
+    expect(1);
+
+    // Register engine
+    let BlogEngine = Engine.extend();
+    registry.register('engine:blog', BlogEngine);
+
+    // Register engine route map
+    let BlogMap = function() {
+      this.route('post');
+    };
+    registry.register('route-map:blog', BlogMap);
+
+    Router.map(function() {
+      this.mount('blog');
+    });
+
+    bootApplication();
+
+    let PostRoute = Route.extend({ serialize() {} });
+    container.lookup('engine:blog').register('route:post', PostRoute);
+
+    throws(() => router.transitionTo('blog.post'), /Defining a custom serialize method on an Engine route is not supported/);
+  });
+}


### PR DESCRIPTION
Reference: https://github.com/dgeb/ember-engines/issues/156.

This PR scopes the route-serializer work to Engines only and merges them into the same feature flag. Also has a small fix to get tests working with Glimmer.

cc @dgeb @rwjblue @nathanhammond 
