### PR TITLE
[FEATURE ember-application-engines] Enable loading and error substates for mounts

### DIFF
--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -190,6 +190,12 @@ if (isEnabled('ember-application-engines')) {
       }
     }
 
+    if (this.enableLoadingSubstates) {
+      let dummyErrorRoute = `/_unused_dummy_error_path_route_${name}/:error`;
+      createRoute(this, `${name}_loading`, { resetNamespace: options.resetNamespace });
+      createRoute(this, `${name}_error`, { path: dummyErrorRoute });
+    }
+
     let localFullName = 'application';
     let routeInfo = assign({ localFullName }, engineInfo);
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -1004,7 +1004,17 @@ function logError(_error, initialMessage) {
 function findChildRouteName(parentRoute, originatingChildRoute, name) {
   let router = parentRoute.router;
   let childName;
-  let targetChildRouteName = originatingChildRoute.routeName.split('.').pop();
+  let originatingChildRouteName = originatingChildRoute.routeName;
+
+  if (isEnabled('ember-application-engines')) {
+    // The only time the originatingChildRoute's name should be 'application'
+    // is if we're entering an engine
+    if (originatingChildRouteName === 'application') {
+      originatingChildRouteName = getOwner(originatingChildRoute).mountPoint;
+    }
+  }
+
+  let targetChildRouteName = originatingChildRouteName.split('.').pop();
   let namespace = parentRoute.routeName === 'application' ? '' : parentRoute.routeName + '.';
 
   // First, try a named loading state, e.g. 'foo_loading'

--- a/packages/ember-routing/tests/system/dsl_test.js
+++ b/packages/ember-routing/tests/system/dsl_test.js
@@ -209,4 +209,62 @@ if (isEnabled('ember-application-engines')) {
       ['bleep', 'bloop', 'blork'],
       'segments are properly associated with mounted engine with aliased name');
   });
+
+  QUnit.test('should add loading and error routes to a mount if _isRouterMapResult is true', function() {
+    Router.map(function() {
+      this.mount('chat');
+    });
+
+    let engineInstance = buildOwner({
+      routable: true
+    });
+
+    let router = Router.create({
+      _hasModuleBasedResolver() { return true; }
+    });
+    setOwner(router, engineInstance);
+    router._initRouterJs();
+
+    ok(router.router.recognizer.names['chat'], 'main route was created');
+    ok(router.router.recognizer.names['chat_loading'], 'loading route was added');
+    ok(router.router.recognizer.names['chat_error'], 'error route was added');
+  });
+
+  QUnit.test('should add loading and error routes to a mount alias if _isRouterMapResult is true', function() {
+    Router.map(function() {
+      this.mount('chat', { as: 'shoutbox' });
+    });
+
+    let engineInstance = buildOwner({
+      routable: true
+    });
+
+    let router = Router.create({
+      _hasModuleBasedResolver() { return true; }
+    });
+    setOwner(router, engineInstance);
+    router._initRouterJs();
+
+    ok(router.router.recognizer.names['shoutbox'], 'main route was created');
+    ok(router.router.recognizer.names['shoutbox_loading'], 'loading route was added');
+    ok(router.router.recognizer.names['shoutbox_error'], 'error route was added');
+  });
+
+  QUnit.test('should not add loading and error routes to a mount if _isRouterMapResult is false', function() {
+    Router.map(function() {
+      this.mount('chat');
+    });
+
+    let engineInstance = buildOwner({
+      routable: true
+    });
+
+    let router = Router.create();
+    setOwner(router, engineInstance);
+    router._initRouterJs(false);
+
+    ok(router.router.recognizer.names['chat'], 'main route was created');
+    ok(!router.router.recognizer.names['chat_loading'], 'loading route was not added');
+    ok(!router.router.recognizer.names['chat_error'], 'error route was not added');
+  });
 }


### PR DESCRIPTION
Reference: https://github.com/dgeb/ember-engines/issues/103

One open question, how shold substates work when used in conjunction with `resetNamespace` (with either `mount` or `route`)? In other words if I have:

``` js
Router.map(function() {
  this.route('news', function() {
    this.{mount|route}('blog', { resetNamespace: true });
  });
});
```

Should the path to the substate then be: `blog_loading` or `news.blog_loading`? I feel like it should be `blog_loading` but in the current checks the namespace is always applied ([see here](https://github.com/emberjs/ember.js/blob/master/packages/ember-routing/lib/system/router.js#L1021)), so it will look for `news.blog_loading` even if `resetNamespace` is applied. Seems like maybe this a bug? If so, I can fix that while I'm in here.

cc @rwjblue @dgeb @nathanhammond 
