### PR TITLE
Add documentation for container (getOwner, etc.)

### DIFF
--- a/packages/container/lib/owner.js
+++ b/packages/container/lib/owner.js
@@ -41,9 +41,10 @@ export const OWNER = symbol('OWNER');
   ```
 
   @method getOwner
+  @for Ember
   @param {Object} object An object with an owner.
   @return {Object} An owner object.
-  @for Ember
+  @since 2.3.0
   @public
 */
 export function getOwner(object) {
@@ -55,9 +56,10 @@ export function getOwner(object) {
   useful in some testing cases.
 
   @method setOwner
+  @for Ember
   @param {Object} object An object with an owner.
   @return {Object} An owner object.
-  @for Ember
+  @since 2.3.0
   @public
 */
 export function setOwner(object, owner) {

--- a/yuidoc.json
+++ b/yuidoc.json
@@ -15,6 +15,7 @@
       "packages/ember-application/lib",
       "packages/ember-testing/lib",
       "packages/ember-extension-support/lib",
+      "packages/container/lib",
       "bower_components/rsvp/lib",
       "bower_components/router.js/lib/router"
     ],


### PR DESCRIPTION
Per the discussion on #13734 I added the since parameter and reordered to match other files. I searched the history to find the version number when this was introduced:

``` console
$ git log --stat -- packages/container/lib/owner.js
$ git tag --contains 7d7450c99bbcec8e51b4adb184a147633603683e
```

Fixes #13734
