### PR TITLE
[FEATURE ember-application-engines] Introduce mount keyword.

### DIFF
--- a/packages/ember-htmlbars/lib/env.js
+++ b/packages/ember-htmlbars/lib/env.js
@@ -2,6 +2,7 @@ import { environment } from 'ember-environment';
 
 import { hooks } from 'htmlbars-runtime';
 import assign from 'ember-metal/assign';
+import isEnabled from 'ember-metal/features';
 
 import subexpr from 'ember-htmlbars/hooks/subexpr';
 import concat from 'ember-htmlbars/hooks/concat';
@@ -74,6 +75,7 @@ import outlet from 'ember-htmlbars/keywords/outlet';
 import unbound from 'ember-htmlbars/keywords/unbound';
 import componentKeyword from 'ember-htmlbars/keywords/component';
 import elementComponent from 'ember-htmlbars/keywords/element-component';
+import mount from 'ember-htmlbars/keywords/mount';
 import partial from 'ember-htmlbars/keywords/partial';
 import input from 'ember-htmlbars/keywords/input';
 import textarea from 'ember-htmlbars/keywords/textarea';
@@ -91,6 +93,9 @@ registerKeyword('outlet', outlet);
 registerKeyword('unbound', unbound);
 registerKeyword('component', componentKeyword);
 registerKeyword('@element_component', elementComponent);
+if (isEnabled('ember-application-engines')) {
+  registerKeyword('mount', mount);
+}
 registerKeyword('partial', partial);
 registerKeyword('input', input);
 registerKeyword('textarea', textarea);

--- a/packages/ember-htmlbars/lib/keywords/mount.js
+++ b/packages/ember-htmlbars/lib/keywords/mount.js
@@ -1,0 +1,152 @@
+/**
+@module ember
+@submodule ember-templates
+*/
+
+import ViewNodeManager from 'ember-htmlbars/node-managers/view-node-manager';
+import RenderEnv from 'ember-htmlbars/system/render-env';
+import { assert } from 'ember-metal/debug';
+import { getOwner, setOwner } from 'container/owner';
+import { isOutletStable } from './outlet';
+import { childOutletState } from './render';
+
+/**
+  The `{{mount}}` helper lets you embed a routeless engine in a template.
+
+  Mounting an engine will cause an instance to be booted and its `application`
+  template to be rendered.
+
+  For example, the following template mounts the `ember-chat` engine:
+
+  ```handlebars
+  {{! application.hbs }}
+  {{mount "ember-chat"}}
+  ```
+
+  Currently, the engine name is the only argument that can be passed to
+  `{{mount}}`.
+
+  @method mount
+  @for Ember.Templates.helpers
+  @category ember-application-engines
+  @public
+*/
+export default {
+  setupState(prevState, env, scope, params /*, hash */) {
+    let name = params[0];
+
+    assert(
+      'The first argument of {{mount}} must be an engine name, e.g. {{mount "chat-engine"}}.',
+      params.length === 1
+    );
+
+    assert(
+      'The first argument of {{mount}} must be quoted, e.g. {{mount "chat-engine"}}.',
+      typeof name === 'string'
+    );
+
+    assert(
+      'You used `{{mount \'' + name + '\'}}`, but the engine \'' + name + '\' can not be found.',
+      env.owner.hasRegistration(`engine:${name}`)
+    );
+
+    let engineInstance = env.owner.buildChildEngineInstance(name);
+
+    engineInstance.boot();
+
+    let state = {
+      parentView: env.view,
+      manager: prevState.manager,
+      controller: lookupEngineController(engineInstance),
+      childOutletState: childOutletState(name, env)
+    };
+
+    setOwner(state, engineInstance);
+
+    return state;
+  },
+
+  childEnv(state, env) {
+    return buildEnvForEngine(getOwner(state), env);
+  },
+
+  isStable(lastState, nextState) {
+    return isStable(lastState.childOutletState, nextState.childOutletState);
+  },
+
+  isEmpty(/* state */) {
+    return false;
+  },
+
+  render(node, env, scope, params, hash, template, inverse, visitor) {
+    let state = node.getState();
+
+    let engineInstance = getOwner(state);
+
+    let engineController = lookupEngineController(engineInstance);
+
+    let engineTemplate = lookupEngineTemplate(engineInstance);
+
+    let options = {
+      layout: null,
+      self: engineController
+    };
+
+    let engineEnv = buildEnvForEngine(engineInstance, env);
+
+    let nodeManager = ViewNodeManager.create(node, engineEnv, hash, options, state.parentView, null, null, engineTemplate);
+
+    state.manager = nodeManager;
+
+    nodeManager.render(engineEnv, hash, visitor);
+  }
+};
+
+function isStable(a, b) {
+  if (!a && !b) {
+    return true;
+  }
+  if (!a || !b) {
+    return false;
+  }
+  for (var outletName in a) {
+    if (!isOutletStable(a[outletName], b[outletName])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function lookupEngineController(engineInstance) {
+  return engineInstance.lookup('controller:application');
+}
+
+function lookupEngineView(engineInstance, ownerView) {
+  let engineView = engineInstance.lookup('view:toplevel');
+
+  if (engineView.ownerView !== ownerView) {
+    engineView.ownerView = ownerView;
+  }
+
+  return engineView;
+}
+
+function lookupEngineTemplate(engineInstance) {
+  let engineTemplate = engineInstance.lookup('template:application');
+
+  if (engineTemplate && engineTemplate.raw) {
+    engineTemplate = engineTemplate.raw;
+  }
+
+  return engineTemplate;
+}
+
+function buildEnvForEngine(engineInstance, parentEnv) {
+  let engineView = lookupEngineView(engineInstance, parentEnv.view.ownerView);
+
+  let engineTemplate = lookupEngineTemplate(engineInstance);
+
+  let engineEnv = RenderEnv.build(engineView, engineTemplate.meta);
+
+  return engineEnv;
+}

--- a/packages/ember-htmlbars/lib/keywords/outlet.js
+++ b/packages/ember-htmlbars/lib/keywords/outlet.js
@@ -106,11 +106,11 @@ export default {
   },
 
   isStable(lastState, nextState) {
-    return isStable(lastState.outletState, nextState.outletState);
+    return isOutletStable(lastState.outletState, nextState.outletState);
   },
 
   isEmpty(state) {
-    return isEmpty(state.outletState);
+    return isOutletEmpty(state.outletState);
   },
 
   render(renderNode, env, scope, params, hash, _template, inverse, visitor) {
@@ -169,11 +169,11 @@ export default {
   }
 };
 
-function isEmpty(outletState) {
+function isOutletEmpty(outletState) {
   return !outletState || (!outletState.render.ViewClass && !outletState.render.template);
 }
 
-function isStable(a, b) {
+export function isOutletStable(a, b) {
   if (!a && !b) {
     return true;
   }

--- a/packages/ember-htmlbars/lib/keywords/render.js
+++ b/packages/ember-htmlbars/lib/keywords/render.js
@@ -221,7 +221,7 @@ export default {
   }
 };
 
-function childOutletState(name, env) {
+export function childOutletState(name, env) {
   let topLevel = env.view.ownerView;
   if (!topLevel || !topLevel.outletState) { return; }
 

--- a/packages/ember-htmlbars/tests/integration/mount_test.js
+++ b/packages/ember-htmlbars/tests/integration/mount_test.js
@@ -1,0 +1,130 @@
+import Application from 'ember-application/system/application';
+import Engine from 'ember-application/system/engine';
+import EmberObject from 'ember-runtime/system/object';
+import { compile } from 'ember-htmlbars-template-compiler';
+import ComponentLookup from 'ember-views/component_lookup';
+import Component from 'ember-htmlbars/component';
+import Controller from 'ember-runtime/controllers/controller';
+import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
+import run from 'ember-metal/run_loop';
+import { OWNER, getOwner } from 'container/owner';
+import isEnabled from 'ember-metal/features';
+import { getEngineParent } from 'ember-application/system/engine-parent';
+import { test, testModule } from 'internal-test-helpers/tests/skip-if-glimmer';
+
+let App,
+    app,
+    appInstance,
+    ChatEngine,
+    chatEngineResolutions;
+
+function commonSetup() {
+  App = Application.extend({ router: null });
+
+  let ChatEngineResolver = EmberObject.extend({
+    resolve(fullName) {
+      return chatEngineResolutions[fullName];
+    }
+  });
+
+  ChatEngine = Engine.extend({
+    router: null,
+    Resolver: ChatEngineResolver
+  });
+
+  run(function() {
+    app = App.create();
+    app.register('engine:chat', ChatEngine);
+    app.registerOptionsForType('template', { instantiate: false });
+    app.registerOptionsForType('component', { singleton: false });
+    app.register('component-lookup:main', ComponentLookup);
+
+    appInstance = app.buildInstance();
+  });
+}
+
+function commonTeardown() {
+  runDestroy(appInstance);
+  runDestroy(app);
+  app = appInstance = null;
+}
+
+if (isEnabled('ember-application-engines')) {
+  testModule('mount keyword', {
+    setup() {
+      commonSetup();
+    },
+
+    teardown() {
+      commonTeardown();
+    }
+  });
+
+  test('asserts that only a single param is passed', function(assert) {
+    assert.expect(1);
+
+    let component = Component.extend({
+      [OWNER]: appInstance,
+      layout: compile('{{mount "chat" "extra"}}')
+    }).create();
+
+    expectAssertion(() => {
+      runAppend(component);
+    }, /The first argument of {{mount}} must be an engine name, e.g. {{mount "chat-engine"}}./i);
+  });
+
+  test('asserts that the engine name argument is quoted', function(assert) {
+    assert.expect(1);
+
+    let component = Component.extend({
+      [OWNER]: appInstance,
+      layout: compile('{{mount chat}}')
+    }).create();
+
+    expectAssertion(() => {
+      runAppend(component);
+    }, /The first argument of {{mount}} must be quoted, e.g. {{mount "chat-engine"}}./i);
+  });
+
+  test('asserts that the specified engine is registered', function(assert) {
+    assert.expect(1);
+
+    let component = Component.extend({
+      [OWNER]: appInstance,
+      layout: compile('{{mount "does-not-exist"}}')
+    }).create();
+
+    expectAssertion(() => {
+      runAppend(component);
+    }, /You used `{{mount 'does-not-exist'}}`, but the engine 'does-not-exist' can not be found./i);
+  });
+
+  test('boots an engine, instantiates its application controller, and renders its application template', function(assert) {
+    assert.expect(3);
+
+    chatEngineResolutions = {
+      'template:application': compile('<h2>Chat here</h2>')
+    };
+
+    chatEngineResolutions['controller:application'] = Controller.extend({
+      init: function() {
+        this._super();
+
+        assert.ok(true, 'engine\'s application controller has been instantiated');
+
+        let engineInstance = getOwner(this);
+        assert.strictEqual(getEngineParent(engineInstance), appInstance, 'engine instance has appInstance as its parent');
+      }
+    });
+
+    let component = Component.extend({
+      [OWNER]: appInstance,
+      layout: compile('{{mount "chat"}}'),
+      didInsertElement() {
+        assert.equal(this.$().text(), 'Chat here', 'engine\'s application template has rendered properly');
+      }
+    }).create();
+
+    runAppend(component);
+  });
+}


### PR DESCRIPTION
The `{{mount}}` keyword lets you embed a routeless engine in a template.

Mounting an engine will cause an instance to be booted and its 
`application` template to be rendered.
