### PR TITLE
[GLIMMER2] Fix spooky {{render}}/route functionality

### DIFF
--- a/packages/ember-glimmer/lib/renderer.js
+++ b/packages/ember-glimmer/lib/renderer.js
@@ -6,10 +6,11 @@ import { CURRENT_TAG, UNDEFINED_REFERENCE } from 'glimmer-reference';
 const { backburner } = run;
 
 class DynamicScope {
-  constructor({ view, controller, outletState, isTopLevel, targetObject }) {
+  constructor({ view, controller, outletState, rootOutletState, isTopLevel, targetObject }) {
     this.view = view;
     this.controller = controller;
     this.outletState = outletState;
+    this.rootOutletState = rootOutletState;
     this.isTopLevel = isTopLevel;
     this.targetObject = targetObject;
   }
@@ -132,11 +133,13 @@ class Renderer {
     let env = this._env;
     let self = new RootReference(view);
     let controller = view.outletState.render.controller;
+    let ref = view.toReference();
     let dynamicScope = new DynamicScope({
       view,
       controller,
       targetObject: controller,
-      outletState: view.toReference(),
+      outletState: ref,
+      rootOutletState: ref,
       isTopLevel: true
     });
 
@@ -161,6 +164,7 @@ class Renderer {
       // instance
       targetObject: view,
       outletState: UNDEFINED_REFERENCE,
+      rootOutletState: UNDEFINED_REFERENCE,
       isTopLevel: true
     });
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -1274,7 +1274,8 @@ function appendLiveRoute(liveRoutes, defaultParentState, renderOptions) {
   let target;
   let myState = {
     render: renderOptions,
-    outlets: new EmptyObject()
+    outlets: new EmptyObject(),
+    wasUsed: false
   };
   if (renderOptions.into) {
     target = findLiveRoute(liveRoutes, renderOptions.into);
@@ -1285,7 +1286,7 @@ function appendLiveRoute(liveRoutes, defaultParentState, renderOptions) {
     set(target.outlets, renderOptions.outlet, myState);
   } else {
     if (renderOptions.into) {
-      // Megahax time. Post-2.0-breaking-changes, we will just assert
+      // Megahax time. Post-3.0-breaking-changes, we will just assert
       // right here that the user tried to target a nonexistent
       // thing. But for now we still need to support the `render`
       // helper, and people are allowed to target templates rendered
@@ -1313,8 +1314,7 @@ function appendOrphan(liveRoutes, into, myState) {
   }
   liveRoutes.outlets.__ember_orphans__.outlets[into] = myState;
   run.schedule('afterRender', function() {
-    // `wasUsed` gets set by the render helper. See the function
-    // `impersonateAnOutlet`.
+    // `wasUsed` gets set by the render helper.
     assert('You attempted to render into \'' + into + '\' but it was not found',
                  liveRoutes.outlets.__ember_orphans__.outlets[into].wasUsed);
   });

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -22,7 +22,6 @@ import { Transition } from 'router/transition';
 import copy from 'ember-runtime/copy';
 import { addObserver } from 'ember-metal/observer';
 import { setTemplates, set as setTemplate } from 'ember-templates/template_registry';
-import { test } from 'internal-test-helpers/tests/skip-if-glimmer';
 
 let trim = jQuery.trim;
 
@@ -3409,46 +3408,46 @@ QUnit.test('Allows any route to disconnectOutlet another route\'s templates', fu
   equal(trim(jQuery('#qunit-fixture').text()), 'hi');
 });
 
-test('Can this.render({into:...}) the render helper', function() {
-  setTemplate('application', compile('{{render "foo"}}'));
-  setTemplate('foo', compile('<div class="foo">{{outlet}}</div>'));
+QUnit.test('Can this.render({into:...}) the render helper', function() {
+  setTemplate('application', compile('{{render "sidebar"}}'));
+  setTemplate('sidebar', compile('<div class="sidebar">{{outlet}}</div>'));
   setTemplate('index', compile('other'));
   setTemplate('bar', compile('bar'));
 
   App.IndexRoute = Route.extend({
     renderTemplate() {
-      this.render({ into: 'foo' });
+      this.render({ into: 'sidebar' });
     },
     actions: {
       changeToBar() {
         this.disconnectOutlet({
-          parentView: 'foo',
+          parentView: 'sidebar',
           outlet: 'main'
         });
-        this.render('bar', { into: 'foo' });
+        this.render('bar', { into: 'sidebar' });
       }
     }
   });
 
   bootApplication();
-  equal(jQuery('#qunit-fixture .foo').text(), 'other');
+  equal(jQuery('#qunit-fixture .sidebar').text(), 'other');
   run(router, 'send', 'changeToBar');
-  equal(jQuery('#qunit-fixture .foo').text(), 'bar');
+  equal(jQuery('#qunit-fixture .sidebar').text(), 'bar');
 });
 
-test('Can disconnect from the render helper', function() {
-  setTemplate('application', compile('{{render "foo"}}'));
-  setTemplate('foo', compile('<div class="foo">{{outlet}}</div>'));
+QUnit.test('Can disconnect from the render helper', function() {
+  setTemplate('application', compile('{{render "sidebar"}}'));
+  setTemplate('sidebar', compile('<div class="sidebar">{{outlet}}</div>'));
   setTemplate('index', compile('other'));
 
   App.IndexRoute = Route.extend({
     renderTemplate() {
-      this.render({ into: 'foo' });
+      this.render({ into: 'sidebar' });
     },
     actions: {
       disconnect: function() {
         this.disconnectOutlet({
-          parentView: 'foo',
+          parentView: 'sidebar',
           outlet: 'main'
         });
       }
@@ -3456,21 +3455,21 @@ test('Can disconnect from the render helper', function() {
   });
 
   bootApplication();
-  equal(jQuery('#qunit-fixture .foo').text(), 'other');
+  equal(jQuery('#qunit-fixture .sidebar').text(), 'other');
   run(router, 'send', 'disconnect');
-  equal(jQuery('#qunit-fixture .foo').text(), '');
+  equal(jQuery('#qunit-fixture .sidebar').text(), '');
 });
 
-test('Can this.render({into:...}) the render helper\'s children', function() {
-  setTemplate('application', compile('{{render "foo"}}'));
-  setTemplate('foo', compile('<div class="foo">{{outlet}}</div>'));
+QUnit.test('Can this.render({into:...}) the render helper\'s children', function() {
+  setTemplate('application', compile('{{render "sidebar"}}'));
+  setTemplate('sidebar', compile('<div class="sidebar">{{outlet}}</div>'));
   setTemplate('index', compile('<div class="index">{{outlet}}</div>'));
   setTemplate('other', compile('other'));
   setTemplate('bar', compile('bar'));
 
   App.IndexRoute = Route.extend({
     renderTemplate() {
-      this.render({ into: 'foo' });
+      this.render({ into: 'sidebar' });
       this.render('other', { into: 'index' });
     },
     actions: {
@@ -3485,20 +3484,20 @@ test('Can this.render({into:...}) the render helper\'s children', function() {
   });
 
   bootApplication();
-  equal(jQuery('#qunit-fixture .foo .index').text(), 'other');
+  equal(jQuery('#qunit-fixture .sidebar .index').text(), 'other');
   run(router, 'send', 'changeToBar');
-  equal(jQuery('#qunit-fixture .foo .index').text(), 'bar');
+  equal(jQuery('#qunit-fixture .sidebar .index').text(), 'bar');
 });
 
-test('Can disconnect from the render helper\'s children', function() {
-  setTemplate('application', compile('{{render "foo"}}'));
-  setTemplate('foo', compile('<div class="foo">{{outlet}}</div>'));
+QUnit.test('Can disconnect from the render helper\'s children', function() {
+  setTemplate('application', compile('{{render "sidebar"}}'));
+  setTemplate('sidebar', compile('<div class="sidebar">{{outlet}}</div>'));
   setTemplate('index', compile('<div class="index">{{outlet}}</div>'));
   setTemplate('other', compile('other'));
 
   App.IndexRoute = Route.extend({
     renderTemplate() {
-      this.render({ into: 'foo' });
+      this.render({ into: 'sidebar' });
       this.render('other', { into: 'index' });
     },
     actions: {
@@ -3512,53 +3511,53 @@ test('Can disconnect from the render helper\'s children', function() {
   });
 
   bootApplication();
-  equal(jQuery('#qunit-fixture .foo .index').text(), 'other');
+  equal(jQuery('#qunit-fixture .sidebar .index').text(), 'other');
   run(router, 'send', 'disconnect');
-  equal(jQuery('#qunit-fixture .foo .index').text(), '');
+  equal(jQuery('#qunit-fixture .sidebar .index').text(), '');
 });
 
-test('Can this.render({into:...}) nested render helpers', function() {
-  setTemplate('application', compile('{{render "foo"}}'));
-  setTemplate('foo', compile('<div class="foo">{{render "bar"}}</div>'));
-  setTemplate('bar', compile('<div class="bar">{{outlet}}</div>'));
+QUnit.test('Can this.render({into:...}) nested render helpers', function() {
+  setTemplate('application', compile('{{render "sidebar"}}'));
+  setTemplate('sidebar', compile('<div class="sidebar">{{render "cart"}}</div>'));
+  setTemplate('cart', compile('<div class="cart">{{outlet}}</div>'));
   setTemplate('index', compile('other'));
   setTemplate('baz', compile('baz'));
 
   App.IndexRoute = Route.extend({
     renderTemplate() {
-      this.render({ into: 'bar' });
+      this.render({ into: 'cart' });
     },
     actions: {
       changeToBaz() {
         this.disconnectOutlet({
-          parentView: 'bar',
+          parentView: 'cart',
           outlet: 'main'
         });
-        this.render('baz', { into: 'bar' });
+        this.render('baz', { into: 'cart' });
       }
     }
   });
 
   bootApplication();
-  equal(jQuery('#qunit-fixture .bar').text(), 'other');
+  equal(jQuery('#qunit-fixture .cart').text(), 'other');
   run(router, 'send', 'changeToBaz');
-  equal(jQuery('#qunit-fixture .bar').text(), 'baz');
+  equal(jQuery('#qunit-fixture .cart').text(), 'baz');
 });
 
-test('Can disconnect from nested render helpers', function() {
-  setTemplate('application', compile('{{render "foo"}}'));
-  setTemplate('foo', compile('<div class="foo">{{render "bar"}}</div>'));
-  setTemplate('bar', compile('<div class="bar">{{outlet}}</div>'));
+QUnit.test('Can disconnect from nested render helpers', function() {
+  setTemplate('application', compile('{{render "sidebar"}}'));
+  setTemplate('sidebar', compile('<div class="sidebar">{{render "cart"}}</div>'));
+  setTemplate('cart', compile('<div class="cart">{{outlet}}</div>'));
   setTemplate('index', compile('other'));
 
   App.IndexRoute = Route.extend({
     renderTemplate() {
-      this.render({ into: 'bar' });
+      this.render({ into: 'cart' });
     },
     actions: {
       disconnect() {
         this.disconnectOutlet({
-          parentView: 'bar',
+          parentView: 'cart',
           outlet: 'main'
         });
       }
@@ -3566,9 +3565,9 @@ test('Can disconnect from nested render helpers', function() {
   });
 
   bootApplication();
-  equal(jQuery('#qunit-fixture .bar').text(), 'other');
+  equal(jQuery('#qunit-fixture .cart').text(), 'other');
   run(router, 'send', 'disconnect');
-  equal(jQuery('#qunit-fixture .bar').text(), '');
+  equal(jQuery('#qunit-fixture .cart').text(), '');
 });
 
 QUnit.test('Components inside an outlet have their didInsertElement hook invoked when the route is displayed', function(assert) {


### PR DESCRIPTION
This is carry over from things that were not removed in 2.0. We really should make it a point to deprecate this spooky functionality post-glimmer release. This will to make sure we do not carry this functionality for another JavaScript half-life.
