### PR TITLE
[FEATURE ember-computed-includes] Creates includes macro for Ember.computed

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -59,3 +59,21 @@ to stay in line with ES standards (see [RFC](https://github.com/emberjs/rfcs/blo
 
 Expose a simple mechanism for test tooling to determine if all foreign async has been
 handled before continueing the test. Replaces the intimate API `Ember.Test.waiters` (with a deprecation).
+
+* `ember-computed-includes`
+
+  Introduces a new macro for Ember.computed to detect if an array includes a given element. Example:
+
+  ```javascript
+  let Hamster = Ember.Object.extend({
+    hasABanana: Ember.computed.includes('possessions', 'banana')
+  });
+
+  let hamster = Hamster.create();
+
+  hamster.get('hasABanana'); // false
+  hamster.set('possessions', ['orange']);
+  hamster.get('hasABanana'); // false
+  hamster.set('possessions', ['banana']);
+  hamster.get('hasABanana'); // true
+  ```

--- a/features.json
+++ b/features.json
@@ -11,5 +11,6 @@
     "ember-string-ishtmlsafe": true,
     "ember-testing-check-waiters": true,
     "ember-metal-weakmap": null
+    "ember-computed-includes": null
   }
 }

--- a/packages/ember-runtime/lib/computed/computed_macros.js
+++ b/packages/ember-runtime/lib/computed/computed_macros.js
@@ -6,6 +6,8 @@ import isEmpty from 'ember-metal/is_empty';
 import isNone from 'ember-metal/is_none';
 import alias from 'ember-metal/alias';
 import expandProperties from 'ember-metal/expand_properties';
+import isEnabled from 'ember-metal/features';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 /**
 @module ember
@@ -657,4 +659,45 @@ export function deprecatingAlias(dependentKey, options) {
       return value;
     }
   });
+}
+
+/**
+  A computed property that returns true if the provided dependent property
+  includes the provided value.
+
+  Example
+
+  ```javascript
+  let Hamster = Ember.Object.extend({
+    hasABanana: Ember.computed.includes('possessions', 'banana')
+  });
+
+  let hamster = Hamster.create();
+
+  hamster.get('hasABanana'); // false
+  hamster.set('possessions', ['orange']);
+  hamster.get('hasABanana'); // false
+  hamster.set('possessions', ['banana']);
+  hamster.get('hasABanana'); // true
+  ```
+
+  @method includes
+  @for Ember.computed
+  @param {String} dependentKey
+  @param {String|Number|Boolean} value
+  @return {Ember.ComputedProperty} computed property which returns true if the
+  the original value for property is an array and includes the given value
+  @public
+ */
+export function includes(dependentKey, value) {
+  if (isEnabled('ember-computed-includes')) {
+    return computed(dependentKey, function () {
+      let array = get(this, dependentKey);
+      if (Array.isArray(array)) {
+        array = emberA(array);
+        return array.includes(value);
+      }
+      return false;
+    });
+  }
 }

--- a/packages/ember-runtime/tests/computed/computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/computed_macros_test.js
@@ -15,6 +15,7 @@ import {
   deprecatingAlias,
   and,
   or,
+  includes
 } from 'ember-runtime/computed/computed_macros';
 
 import alias from 'ember-metal/alias';
@@ -22,6 +23,7 @@ import { defineProperty } from 'ember-metal/properties';
 import EmberObject from 'ember-runtime/system/object';
 import { testBoth } from 'ember-metal/tests/props_helper';
 import { A as emberA } from 'ember-runtime/system/native_array';
+import isEnabled from 'ember-metal/features';
 
 QUnit.module('CP macros');
 
@@ -499,4 +501,49 @@ testBoth('computed.deprecatingAlias', function(get, set) {
   equal(get(obj, 'bar'), 'newBar');
   equal(get(obj, 'baz'), 'newBaz');
   equal(get(obj, 'quz'), null);
+});
+
+testBoth('computed.includes', function (get, set) {
+  if (!isEnabled('ember-computed-includes')) {
+    expect(0);
+    return;
+  }
+
+  let obj = { array: ['one', '2', 3] };
+
+  defineProperty(obj, 'includesOne', includes('array', 'one'));
+
+  equal(get(obj, 'includesOne'), true, 'includes one');
+
+  defineProperty(obj, 'includesTwo', includes('array', '2'));
+
+  equal(get(obj, 'includesTwo'), true, 'includes two');
+
+  defineProperty(obj, 'includesThree', includes('array', 3));
+
+  equal(get(obj, 'includesThree'), true, 'includes three');
+
+  defineProperty(obj, 'includesNumericTwo', includes('array', 2));
+
+  equal(get(obj, 'includesNumericTwo'), false, 'does not contain numeric two');
+
+  defineProperty(obj, 'includesStringThree', includes('array', '3'));
+
+  equal(get(obj, 'includesStringThree'), false, 'does not contain string three');
+
+  set(obj, 'array', []);
+
+  equal(get(obj, 'includesOne'), false, 'false on empty array');
+
+  set(obj, 'array', 3);
+
+  equal(get(obj, 'includesOne'), false, 'false when not array');
+
+  set(obj, 'array', undefined);
+
+  equal(get(obj, 'includesOne'), false, 'false on undefined');
+
+  set(obj, 'array', emberA(['one']));
+
+  equal(get(obj, 'includesOne'), true, 'Supports ember arrays');
 });


### PR DESCRIPTION
Several times I've needed a computed property to find out if an array contains a string, or a number. 

``` javascript
  let Hamster = Ember.Object.extend({
    hasABanana: Ember.computed.contains('possessions', 'banana')
  });

  let hamster = Hamster.create();

  hamster.get('hasABanana'); // false
  hamster.set('possessions', ['orange']);
  hamster.get('hasABanana'); // false
  hamster.set('possessions', ['banana']);
  hamster.get('hasABanana'); // true
```
