### PR TITLE
Remove broken `require('jquery')`.

### DIFF
--- a/packages/ember-views/lib/system/jquery.js
+++ b/packages/ember-views/lib/system/jquery.js
@@ -1,13 +1,9 @@
 import { context, environment } from 'ember-environment';
-import require from 'require';
 
 let jQuery;
 
 if (environment.hasDOM) {
   jQuery = context.imports.jQuery;
-  if (!jQuery && typeof require === 'function') {
-    jQuery = require('jquery');
-  }
 
   if (jQuery) {
     if (jQuery.event.addProp) {


### PR DESCRIPTION
Originally [this line](https://github.com/emberjs/ember.js/blob/3ab8ba2af6551a174f3b91ac9b202bc9f27c09a4/packages/ember-views/lib/system/jquery.js#L8) was checking for a global `require`, but as of https://github.com/emberjs/ember.js/pull/13440 we changed to import or own internal `require`. At the moment, that `require('jquery')` (using our internal loader's version of `require`) will never find a module named `jquery` and will error.

I believe we should just remove this guard/check completely. We can always reevaluate if folks still need this for something...

/cc @krisselden 
