### PR TITLE
Register `component-lookup:main` for all engines.

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -30,7 +30,6 @@ import { environment } from 'ember-environment';
 import RSVP from 'ember-runtime/ext/rsvp';
 import Engine, { GLIMMER } from './engine';
 import require from 'require';
-import ComponentLookup from 'ember-views/component_lookup';
 
 let librariesRegistered = false;
 
@@ -1050,8 +1049,6 @@ function commonSetupRegistry(registry) {
   registry.register('location:none', NoneLocation);
 
   registry.register(P`-bucket-cache:main`, BucketCache);
-
-  registry.register('component-lookup:main', ComponentLookup);
 }
 
 function registerLibraries() {

--- a/packages/ember-application/lib/system/engine.js
+++ b/packages/ember-application/lib/system/engine.js
@@ -19,6 +19,7 @@ import symbol from 'ember-metal/symbol';
 import Controller from 'ember-runtime/controllers/controller';
 import RoutingService from 'ember-routing/services/routing';
 import ContainerDebugAdapter from 'ember-extension-support/container_debug_adapter';
+import ComponentLookup from 'ember-views/component_lookup';
 import require from 'require';
 
 export const GLIMMER = symbol('GLIMMER');
@@ -512,6 +513,8 @@ function commonSetupRegistry(registry) {
   // Custom resolver authors may want to register their own ContainerDebugAdapter with this key
 
   registry.register('container-debug-adapter:main', ContainerDebugAdapter);
+
+  registry.register('component-lookup:main', ComponentLookup);
 }
 
 export default Engine;

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -152,6 +152,7 @@ QUnit.test('builds a registry', function() {
   verifyInjection(application, 'container-debug-adapter:main', 'resolver', 'resolver-for-debugging:main');
   verifyInjection(application, 'data-adapter:main', 'containerDebugAdapter', 'container-debug-adapter:main');
   verifyRegistration(application, 'container-debug-adapter:main');
+  verifyRegistration(application, 'component-lookup:main');
 
   if (isEnabled('ember-glimmer')) {
     verifyRegistration(application, 'service:-glimmer-environment');

--- a/packages/ember-application/tests/system/engine_test.js
+++ b/packages/ember-application/tests/system/engine_test.js
@@ -64,6 +64,7 @@ QUnit.test('builds a registry', function() {
   verifyInjection(engine, 'container-debug-adapter:main', 'resolver', 'resolver-for-debugging:main');
   verifyInjection(engine, 'data-adapter:main', 'containerDebugAdapter', 'container-debug-adapter:main');
   verifyRegistration(engine, 'container-debug-adapter:main');
+  verifyRegistration(engine, 'component-lookup:main');
 
   if (isEnabled('ember-glimmer')) {
     verifyRegistration(engine, 'view:-outlet');


### PR DESCRIPTION
This registration is required for applications _and_ engines.

Follow up to https://github.com/emberjs/ember.js/pull/13841
