### PR TITLE
[FEATURE ember-improved-instrumentation] Pass link-to component

### DIFF
--- a/packages/ember-htmlbars/lib/components/link-to.js
+++ b/packages/ember-htmlbars/lib/components/link-to.js
@@ -648,6 +648,7 @@ const LinkComponent = EmberComponent.extend({
     let shouldReplace = get(this, 'replace');
 
     let payload = {
+      target: this,
       queryParams,
       routeName: qualifiedRouteName
     };

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -137,6 +137,28 @@ if (isEnabled('ember-improved-instrumentation')) {
     jQuery('#about-link', '#qunit-fixture').click();
   });
 
+  QUnit.test('The {{link-to}} helper interaction event includes the target link-to component', function(assert) {
+    assert.expect(2);
+    Router.map(function(match) {
+      this.route('about');
+    });
+
+    bootApplication();
+
+    run(() => router.handleURL('/'));
+
+    subscribe('interaction.link-to', {
+      before(name, timestamp, { target }) {
+        assert.equal(target.id, 'about-link', 'instrumentation subscriber was passed target link-to component');
+      },
+      after(name, timestamp, { target }) {
+        assert.equal(target.id, 'about-link', 'instrumentation subscriber was passed target link-to component');
+      }
+    });
+
+    jQuery('#about-link', '#qunit-fixture').click();
+  });
+
   QUnit.test('The {{link-to}} helper interaction event includes the route name', function(assert) {
     assert.expect(2);
     Router.map(function(match) {


### PR DESCRIPTION
Include the link-to component in the `interaction.link-to` event payload. Useful including metadata in tracking/analytics associated with clicking a link.
