### PR TITLE
Pave the way for shipping only glimmer engine.

### DIFF
--- a/lib/packages.js
+++ b/lib/packages.js
@@ -15,23 +15,9 @@ var packages = {
   'ember-template-compiler': {
     trees: null,
     templateCompilerOnly: true,
-    requirements: ['ember-metal', 'ember-environment', 'ember-console', 'ember-htmlbars-template-compiler', 'ember-templates'],
+    requirements: ['ember-metal', 'ember-environment', 'ember-console', 'ember-templates'],
     templateCompilerVendor: ['simple-html-tokenizer']
   },
-  'ember-htmlbars-template-compiler': {
-    trees: null,
-    templateCompilerOnly: true,
-    requirements: [],
-    vendorRequirements: ['htmlbars-runtime'],
-    templateCompilerVendor: ['htmlbars-runtime', 'htmlbars-util', 'htmlbars-compiler', 'htmlbars-syntax', 'htmlbars-test-helpers', 'morph-range', 'backburner']
-  },
-  'ember-htmlbars':             {
-                                  trees: null,
-                                  vendorRequirements: ['dom-helper', 'morph-range', 'morph-attr', 'htmlbars-util', 'htmlbars-runtime'],
-                                  requirements: ['ember-routing', 'ember-metal'],
-                                  testingVendorRequirements: ['htmlbars-test-helpers'],
-                                  hasTemplates: true
-                                },
   'ember-templates':            { trees: null,  requirements: ['ember-metal', 'ember-environment'] },
   'ember-routing':              { trees: null,  vendorRequirements: ['router', 'route-recognizer'],
                                                requirements: ['ember-runtime', 'ember-views'] },
@@ -40,8 +26,23 @@ var packages = {
   'internal-test-helpers':      { trees: null }
 };
 
+var includeGlimmer = false;
+var includeHTMLBars = false;
+
 var glimmerStatus = features['ember-glimmer'];
-if (glimmerStatus === null || glimmerStatus === true) {
+
+if (glimmerStatus === null) {
+  includeGlimmer = true;
+  includeHTMLBars = true;
+} else if (glimmerStatus === true) {
+  includeGlimmer = true;
+  includeHTMLBars = false;
+} else if (glimmerStatus === false) {
+  includeGlimmer = false;
+  includeHTMLBars = true;
+}
+
+if (includeGlimmer) {
   packages['ember-glimmer'] = {
     trees: null,
     requirements: ['container', 'ember-metal', 'ember-routing', 'ember-templates'],
@@ -74,4 +75,23 @@ if (glimmerStatus === null || glimmerStatus === true) {
   packages['ember-template-compiler'].requirements.push('ember-glimmer-template-compiler');
 }
 
+if (includeHTMLBars) {
+  packages['ember-htmlbars-template-compiler'] = {
+    trees: null,
+    templateCompilerOnly: true,
+    requirements: [],
+    vendorRequirements: ['htmlbars-runtime'],
+    templateCompilerVendor: ['htmlbars-runtime', 'htmlbars-util', 'htmlbars-compiler', 'htmlbars-syntax', 'htmlbars-test-helpers', 'morph-range', 'backburner']
+  };
+
+  packages['ember-htmlbars'] = {
+    trees: null,
+    vendorRequirements: ['dom-helper', 'morph-range', 'morph-attr', 'htmlbars-util', 'htmlbars-runtime'],
+    requirements: ['ember-routing', 'ember-metal'],
+    testingVendorRequirements: ['htmlbars-test-helpers'],
+    hasTemplates: true
+  };
+
+  packages['ember-template-compiler'].requirements.push('ember-htmlbars-template-compiler');
+}
 module.exports = packages;


### PR DESCRIPTION
Update build system to allow excluding `ember-htmlbars` and its dependencies if `ember-glimmer` feature flag is `true`.
