### PR TITLE
[GLIMMER] Ensure the view registry is propagated.

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -12,7 +12,6 @@ import Namespace, {
 } from 'ember-runtime/system/namespace';
 import { runLoadHooks } from 'ember-runtime/system/lazy_load';
 import run from 'ember-metal/run_loop';
-import EmberView from 'ember-views/views/view';
 import EventDispatcher from 'ember-views/system/event_dispatcher';
 import jQuery from 'ember-views/system/jquery';
 import Route from 'ember-routing/system/route';
@@ -403,10 +402,10 @@ const Application = Engine.extend({
 
     This is orthogonal to autoboot: the deprecated instance needs to
     be created at Application construction (not boot) time to expose
-    App.__container__ and the global Ember.View.views registry. If
-    autoboot sees that this instance exists, it will continue booting
-    it to avoid doing unncessary work (as opposed to building a new
-    instance at boot time), but they are otherwise unrelated.
+    App.__container__. If autoboot sees that this instance exists,
+    it will continue booting it to avoid doing unncessary work (as
+    opposed to building a new instance at boot time), but they are
+    otherwise unrelated.
 
     @private
     @method _buildDeprecatedInstance
@@ -419,10 +418,6 @@ const Application = Engine.extend({
     // on App that rely on a single, default instance.
     this.__deprecatedInstance__ = instance;
     this.__container__ = instance.__container__;
-
-    // For the default instance only, set the view registry to the global
-    // Ember.View.views hash for backwards-compatibility.
-    EmberView.views = instance.lookup('-view-registry:main');
   },
 
   /**

--- a/packages/ember-application/lib/system/engine.js
+++ b/packages/ember-application/lib/system/engine.js
@@ -487,6 +487,8 @@ function commonSetupRegistry(registry) {
   registry.injection('service:-dom-helper', 'document', 'service:-document');
 
   registry.injection('view', '_viewRegistry', '-view-registry:main');
+  registry.injection('renderer', '_viewRegistry', '-view-registry:main');
+  registry.injection('event_dispatcher:main', '_viewRegistry', '-view-registry:main');
 
   registry.injection('route', '_topLevelViewTemplate', 'template:-outlet');
 

--- a/packages/ember-glimmer/lib/component.js
+++ b/packages/ember-glimmer/lib/component.js
@@ -7,7 +7,6 @@ import AriaRoleSupport from 'ember-views/mixins/aria_role_support';
 import ViewMixin from 'ember-views/mixins/view_support';
 import ActionSupport from 'ember-views/mixins/action_support';
 import TargetActionSupport from 'ember-runtime/mixins/target_action_support';
-import EmberView from 'ember-views/views/view';
 import symbol from 'ember-metal/symbol';
 import EmptyObject from 'ember-metal/empty_object';
 import { get } from 'ember-metal/property_get';
@@ -48,7 +47,6 @@ const Component = CoreView.extend(
 
     init() {
       this._super(...arguments);
-      this._viewRegistry = this._viewRegistry || EmberView.views;
       this[DIRTY_TAG] = new DirtyableTag();
       this[ROOT_REF] = null;
       this[REFS] = new EmptyObject();

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -1968,54 +1968,6 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     assert.equal(outer.parentView, this.context, 'x-outer receives the ambient scope as its parentView');
   }
 
-  ['@htmlbars component should receive the viewRegistry from the parentView'](assert) {
-    let outer, innerTemplate, innerLayout;
-
-    let viewRegistry = {};
-
-    this.registerComponent('x-outer', {
-      ComponentClass: Component.extend({
-        init() {
-          this._super(...arguments);
-          outer = this;
-        }
-      }),
-      template: '{{x-inner-in-layout}}{{yield}}'
-    });
-
-    this.registerComponent('x-inner-in-template', {
-      ComponentClass: Component.extend({
-        init() {
-          this._super(...arguments);
-          innerTemplate = this;
-        }
-      })
-    });
-
-    this.registerComponent('x-inner-in-layout', {
-      ComponentClass: Component.extend({
-        init() {
-          this._super(...arguments);
-          innerLayout = this;
-        }
-      })
-    });
-
-    this.render('{{#x-outer}}{{x-inner-in-template}}{{/x-outer}}', {
-      _viewRegistry: viewRegistry
-    });
-
-    assert.equal(innerTemplate._viewRegistry, viewRegistry);
-    assert.equal(innerLayout._viewRegistry, viewRegistry);
-    assert.equal(outer._viewRegistry, viewRegistry);
-
-    this.runTask(() => this.rerender());
-
-    assert.equal(innerTemplate._viewRegistry, viewRegistry);
-    assert.equal(innerLayout._viewRegistry, viewRegistry);
-    assert.equal(outer._viewRegistry, viewRegistry);
-  }
-
   ['@htmlbars component should rerender when a property is changed during children\'s rendering'](assert) {
     expectDeprecation(/modified value twice in a single render/);
 

--- a/packages/ember-glimmer/tests/utils/abstract-test-case.js
+++ b/packages/ember-glimmer/tests/utils/abstract-test-case.js
@@ -319,6 +319,7 @@ export class AbstractRenderingTest extends TestCase {
     this.component = null;
 
     owner.register('event_dispatcher:main', EventDispatcher);
+    owner.inject('event_dispatcher:main', '_viewRegistry', '-view-registry:main');
     owner.lookup('event_dispatcher:main').setup(this.getCustomDispatcherEvents(), owner.element);
   }
 

--- a/packages/ember-glimmer/tests/utils/helpers.js
+++ b/packages/ember-glimmer/tests/utils/helpers.js
@@ -23,6 +23,9 @@ export function buildOwner(options) {
   owner.inject('service:-dom-helper', 'document', 'service:-document');
   owner.inject('component', 'renderer', 'renderer:-dom');
   owner.inject('template', 'env', 'service:-glimmer-environment');
+
+  owner.register('-view-registry:main', { create() { return {}; } });
+  owner.inject('renderer', '_viewRegistry', '-view-registry:main');
+
   return owner;
 }
-

--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -169,7 +169,6 @@ export function createComponent(_component, props, renderNode, env, attrs = {}) 
 
   setOwner(props, env.owner);
   props.renderer = props.parentView ? props.parentView.renderer : env.owner.lookup('renderer:-dom');
-  props._viewRegistry = props.parentView ? props.parentView._viewRegistry : env.owner.lookup('-view-registry:main');
 
   let component = _component.create(props);
 

--- a/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
@@ -191,7 +191,6 @@ export function createOrUpdateComponent(component, options, createOptions, rende
 
     setOwner(props, owner);
     props.renderer = options.parentView ? options.parentView.renderer : owner && owner.lookup('renderer:-dom');
-    props._viewRegistry = options.parentView ? options.parentView._viewRegistry : owner && owner.lookup('-view-registry:main');
 
     if (proto.controller !== defaultController || hasSuppliedController) {
       delete props._context;

--- a/packages/ember-htmlbars/tests/utils/helpers.js
+++ b/packages/ember-htmlbars/tests/utils/helpers.js
@@ -23,5 +23,11 @@ export function buildOwner(options) {
   setupApplicationRegistry(owner.__registry__);
   owner.register('service:-htmlbars-environment', new Environment(), { instantiate: false });
   owner.inject('service:-htmlbars-environment', 'dom', 'service:-dom-helper');
+
+  owner.register('-view-registry:main', { create() { return {}; } });
+  owner.inject('renderer', '_viewRegistry', '-view-registry:main');
+  owner.inject('renderer', 'dom', 'service:-dom-helper');
+  owner.inject('component', 'renderer', 'renderer:-dom');
+
   return owner;
 }

--- a/packages/ember-views/lib/compat/fallback-view-registry.js
+++ b/packages/ember-views/lib/compat/fallback-view-registry.js
@@ -1,0 +1,3 @@
+import dict from 'ember-metal/dictionary';
+
+export default dict(null);

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -553,32 +553,5 @@ export default Mixin.create({
   */
   handleEvent(eventName, evt) {
     return this._currentState.handleEvent(this, eventName, evt);
-  },
-
-  /**
-    Registers the view in the view registry, keyed on the view's `elementId`.
-    This is used by the EventDispatcher to locate the view in response to
-    events.
-
-    This method should only be called once the view has been inserted into the
-    DOM.
-
-    @method _register
-    @private
-  */
-  _register() {
-    assert('Attempted to register a view with an id already in use: ' + this.elementId, !this._viewRegistry[this.elementId]);
-    this._viewRegistry[this.elementId] = this;
-  },
-
-  /**
-    Removes the view from the view registry. This should be called when the
-    view is removed from DOM.
-
-    @method _unregister
-    @private
-  */
-  _unregister() {
-    delete this._viewRegistry[this.elementId];
   }
 });

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -11,10 +11,10 @@ import run from 'ember-metal/run_loop';
 import EmberObject from 'ember-runtime/system/object';
 import jQuery from 'ember-views/system/jquery';
 import ActionManager from 'ember-views/system/action_manager';
-import View from 'ember-views/views/view';
 import assign from 'ember-metal/assign';
 import { getOwner } from 'container/owner';
 import { environment } from 'ember-environment';
+import fallbackViewRegistry from 'ember-views/compat/fallback-view-registry';
 
 const ROOT_ELEMENT_CLASS = 'ember-application';
 const ROOT_ELEMENT_SELECTOR = '.' + ROOT_ELEMENT_CLASS;
@@ -199,7 +199,7 @@ export default EmberObject.extend({
     let self = this;
 
     let owner = getOwner(this);
-    let viewRegistry = owner && owner.lookup('-view-registry:main') || View.views;
+    let viewRegistry = owner && owner.lookup('-view-registry:main') || fallbackViewRegistry;
 
     if (eventName === null) {
       return;

--- a/packages/ember-views/lib/views/states/in_dom.js
+++ b/packages/ember-views/lib/views/states/in_dom.js
@@ -16,7 +16,7 @@ assign(inDOM, {
     // Register the view for event handling. This hash is used by
     // Ember.EventDispatcher to dispatch incoming events.
     if (view.tagName !== '') {
-      view._register();
+      view.renderer._register(view);
     }
 
     runInDebug(() => {
@@ -28,7 +28,7 @@ assign(inDOM, {
 
   exit(view) {
     if (view.tagName !== '') {
-      view._unregister();
+      view.renderer._unregister(view);
     }
   }
 });

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -515,14 +515,6 @@ var View = CoreView.extend(
   ViewMixin, {
     attributeBindings: ['ariaRole:role'],
 
-    init() {
-      this._super(...arguments);
-
-      if (!this._viewRegistry) {
-        this._viewRegistry = View.views;
-      }
-    },
-
     /**
       Given a property name, returns a dasherized version of that
       property name if the property evaluates to a non-falsy value.
@@ -567,18 +559,6 @@ var View = CoreView.extend(
 
 // once the view has been inserted into the DOM, legal manipulations
 // are done on the DOM element.
-
-View.reopenClass({
-  /**
-    Global views hash
-
-    @property views
-    @static
-    @type Object
-    @private
-  */
-  views: {}
-});
 
 export default View;
 

--- a/packages/ember-views/tests/views/view/append_to_test.js
+++ b/packages/ember-views/tests/views/view/append_to_test.js
@@ -106,7 +106,6 @@ QUnit.test('remove removes an element from the DOM', function() {
   run(() => view.destroyElement());
 
   ok(jQuery('#' + get(view, 'elementId')).length === 0, 'remove removes an element from the DOM');
-  ok(EmberView.views[get(view, 'elementId')] === undefined, 'remove does not remove the view from the view hash');
   ok(!get(view, 'element'), 'remove nulls out the element');
   equal(willDestroyCalled, 1, 'the willDestroyElement hook was called once');
 });
@@ -129,7 +128,6 @@ QUnit.test('destroy more forcibly removes the view', function() {
   run(() => view.destroy());
 
   ok(jQuery('#' + get(view, 'elementId')).length === 0, 'destroy removes an element from the DOM');
-  ok(EmberView.views[get(view, 'elementId')] === undefined, 'destroy removes a view from the global views hash');
   equal(get(view, 'isDestroyed'), true, 'the view is marked as destroyed');
   ok(!get(view, 'element'), 'the view no longer has an element');
   equal(willDestroyCalled, 1, 'the willDestroyElement hook was called once');


### PR DESCRIPTION
- Add an injection to ensure that `component`'s all get the `-view-registry:main` injected.
- Replace usage of `Ember.View.views` as the fallback registry, with a custom fallback registry that is only used when views/components are instantiated outside of the DI system.
