### PR TITLE
[DOC beta] Mark `LinkComponent#activeClass` as public.

### DIFF
--- a/packages/ember-glimmer/lib/components/link-to.js
+++ b/packages/ember-glimmer/lib/components/link-to.js
@@ -405,7 +405,7 @@ const LinkComponent = EmberComponent.extend({
     @property activeClass
     @type String
     @default active
-    @private
+    @public
   **/
   activeClass: 'active',
 


### PR DESCRIPTION
`activeClass` is mark as private in `Ember.LinkComponent` though in the
documentation suggests to use it for modifying the class added when link is
active.
