### PR TITLE
Fix Ember.Handlebars.Utils.escapeExpression global export.

### DIFF
--- a/packages/ember-glimmer/lib/utils/string.js
+++ b/packages/ember-glimmer/lib/utils/string.js
@@ -3,6 +3,9 @@
 @submodule ember-glimmer
 */
 
+import isEnabled from 'ember-metal/features';
+import { deprecate } from 'ember-metal/debug';
+
 export class SafeString {
   constructor(string) {
     this.string = string;
@@ -15,6 +18,20 @@ export class SafeString {
   toHTML() {
     return this.toString();
   }
+}
+
+export function getSafeString() {
+  deprecate(
+    'Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe',
+    !isEnabled('ember-string-ishtmlsafe'),
+    {
+      id: 'ember-htmlbars.ember-handlebars-safestring',
+      until: '3.0.0',
+      url: 'http://emberjs.com/deprecations/v2.x#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring'
+    }
+  );
+
+  return SafeString;
 }
 
 const escape = {

--- a/packages/ember-templates/lib/compat.js
+++ b/packages/ember-templates/lib/compat.js
@@ -1,41 +1,22 @@
 import Ember from 'ember-metal/core'; // reexports
 import template from './template';
 import {
-  SafeString,
+  getSafeString,
   escapeExpression,
   htmlSafe,
   isHTMLSafe
 } from './string';
 import EmberStringUtil from 'ember-runtime/system/string';
 import isEnabled from 'ember-metal/features';
-import { deprecate } from 'ember-metal/debug';
-
 
 export let EmberHandlebars = Ember.Handlebars = Ember.Handlebars || {};
 export let EmberHTMLBars = Ember.HTMLBars = Ember.HTMLBars || {};
-let EmberHandleBarsUtils = EmberHandlebars.Utils || {};
+export let EmberHandleBarsUtils = EmberHandlebars.Utils = EmberHandlebars.Utils || {};
 
-if (isEnabled('ember-string-ishtmlsafe')) {
-  Object.defineProperty(EmberHandlebars, 'SafeString', {
-    get() {
-      deprecate(
-        'Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe',
-        false,
-        {
-          id: 'ember-htmlbars.ember-handlebars-safestring',
-          until: '3.0.0',
-          url: 'http://emberjs.com/deprecations/v2.x#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring'
-        }
-      );
+Object.defineProperty(EmberHandlebars, 'SafeString', {
+  get: getSafeString
+});
 
-      return SafeString;
-    }
-  });
-} else {
-  EmberHandlebars.SafeString = SafeString;
-}
-
-EmberHTMLBars.SafeString = SafeString;
 EmberHTMLBars.template = EmberHandlebars.template = template;
 EmberHandleBarsUtils.escapeExpression = escapeExpression;
 EmberStringUtil.htmlSafe = htmlSafe;

--- a/packages/ember-templates/lib/string.js
+++ b/packages/ember-templates/lib/string.js
@@ -13,3 +13,4 @@ export const SafeString = strings.SafeString;
 export const escapeExpression = strings.escapeExpression;
 export const htmlSafe = strings.htmlSafe;
 export const isHTMLSafe = strings.isHTMLSafe;
+export const getSafeString = strings.getSafeString;

--- a/packages/ember-templates/tests/reexports_test.js
+++ b/packages/ember-templates/tests/reexports_test.js
@@ -1,4 +1,5 @@
 import Ember from 'ember-templates';
+import isEnabled from 'ember-metal/features';
 import require from 'require';
 
 QUnit.module('ember-templates reexports');
@@ -12,20 +13,34 @@ QUnit.module('ember-templates reexports');
   ['LinkComponent', 'ember-templates/components/link-to',    'default'],
   ['TextArea',      'ember-templates/components/text_area',  'default'],
   ['TextField',     'ember-templates/components/text_field', 'default'],
-  ['TEMPLATES',     'ember-templates/template_registry',     { get: 'getTemplates', set: 'setTemplates' }]
+  ['TEMPLATES',     'ember-templates/template_registry',     { get: 'getTemplates', set: 'setTemplates' }],
+  ['Handlebars.template', 'ember-templates/template', 'default'],
+  ['Handlebars.SafeString', 'ember-templates/string', { get: 'getSafeString' }],
+  ['Handlebars.Utils.escapeExpression', 'ember-templates/string', 'escapeExpression'],
+  ['String.htmlSafe', 'ember-templates/string', 'htmlSafe']
 ].forEach(reexport => {
   let [path, moduleId, exportName] = reexport;
   QUnit.test(`Ember.${path} exports correctly`, assert => {
-    let desc = getDescriptor(Ember, path);
-    let mod = require(moduleId);
-    if (typeof exportName === 'string') {
-      assert.equal(desc.value, mod[exportName], `Ember.${path} is exported correctly`);
-    } else {
-      assert.equal(desc.get, mod[exportName.get], `Ember.${path} getter is exported correctly`);
-      assert.equal(desc.set, mod[exportName.set], `Ember.${path} setter is exported correctly`);
-    }
+    confirmExport(assert, path, moduleId, exportName);
   });
 });
+
+if (isEnabled('ember-string-ishtmlsafe')) {
+  QUnit.test('Ember.String.isHTMLSafe exports correctly', function(assert) {
+    confirmExport(assert, 'String.isHTMLSafe', 'ember-templates/string', 'isHTMLSafe');
+  });
+}
+
+function confirmExport(assert, path, moduleId, exportName) {
+  let desc = getDescriptor(Ember, path);
+  let mod = require(moduleId);
+  if (typeof exportName === 'string') {
+    assert.equal(desc.value, mod[exportName], `Ember.${path} is exported correctly`);
+  } else {
+    assert.equal(desc.get, mod[exportName.get], `Ember.${path} getter is exported correctly`);
+    assert.equal(desc.set, mod[exportName.set], `Ember.${path} setter is exported correctly`);
+  }
+}
 
 function getDescriptor(obj, path) {
   let parts = path.split('.');


### PR DESCRIPTION
- Fix export of `Ember.Handlebars.Utils.escapeExpression`.
- Create `getSafeString` getter function in the engine specific package.
- Add tests for compat exports from ember-templates.
