### PR TITLE
Fix bootstrapping of script tag templates.

### DIFF
--- a/packages/ember-application/lib/initializers/dom-templates.js
+++ b/packages/ember-application/lib/initializers/dom-templates.js
@@ -4,13 +4,14 @@ import Application from '../system/application';
 
 let bootstrap = function() { };
 
-let bootstrapModuleId = 'ember-template-compiler/system/bootstrap';
-if (environment.hasDOM && has(bootstrapModuleId)) {
-  bootstrap = require(bootstrapModuleId);
-}
-
-
 Application.initializer({
   name: 'domTemplates',
-  initialize: bootstrap
+  initialize() {
+    let bootstrapModuleId = 'ember-template-compiler/system/bootstrap';
+    if (environment.hasDOM && has(bootstrapModuleId)) {
+      bootstrap = require(bootstrapModuleId).default;
+    }
+
+    bootstrap();
+  }
 });

--- a/packages/ember-application/tests/system/bootstrap-test.js
+++ b/packages/ember-application/tests/system/bootstrap-test.js
@@ -1,0 +1,35 @@
+import run from 'ember-metal/run_loop';
+import Application from 'ember-application/system/application';
+import Router from 'ember-routing/system/router';
+import jQuery from 'ember-views/system/jquery';
+import { setTemplates } from 'ember-templates/template_registry';
+
+let app;
+
+QUnit.module('Ember.Application', {
+  teardown() {
+    if (app) {
+      run(app, 'destroy');
+    }
+
+    setTemplates({});
+  }
+});
+
+QUnit.test('templates in script tags are extracted at application creation', function(assert) {
+  jQuery('#qunit-fixture').html(`
+    <div id="app"></div>
+
+    <script type="text/x-handlebars">Hello {{outlet}}</script>
+    <script type="text/x-handlebars" id="index">World!</script>
+  `);
+
+  let application = Application.extend();
+  application.Router = Router.extend({
+    location: 'none'
+  });
+
+  app = run(() => application.create({ rootElement: '#app' }));
+
+  assert.equal(jQuery('#app').text(), 'Hello World!');
+});


### PR DESCRIPTION
There were two main issues with this:
- When the `ember-template-compiler/system/bootstrap` module was present, the initializers `initialize` function was being set to an object (not a function). The fix is "simple", grab the `.default` export from the module.
- Depending on timing, the `ember-application/initializers/dom-templates` module is evaluated before the second script tag including `ember-template-compiler.js`, which means that the `bootstrap` function was never updated (since it was only checking for the boostrap module at eval time). The fix for this is to lazily check for the module during the initializer itself.
