### PR TITLE
[Glimmer2] Backtracking Rerender

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 
 node_js:
   - "5"
-  
+
 cache:
   directories:
     - node_modules
@@ -55,3 +55,4 @@ env:
     - TEST_SUITE=node DISABLE_JSCS=true DISABLE_JSHINT=true
     - TEST_SUITE=blueprints
     - TEST_SUITE=sauce
+    - TEST_SUITE=allow-backtracking-rerender ALLOW_BACKTRACKING=true

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -25,6 +25,13 @@ function babelConfigFor(environment) {
 
   var features = JSON.parse(featuresJson).features;
   features['mandatory-setter'] = isDevelopment;
+  features['ember-glimmer-detect-backtracking-rerender'] = isDevelopment;
+  features['ember-glimmer-allow-backtracking-rerender'] = false;
+
+  if (process.env.ALLOW_BACKTRACKING) {
+    features['ember-glimmer-allow-backtracking-rerender'] = true;
+    features['ember-glimmer-detect-backtracking-rerender'] = false;
+  }
 
   var plugins = [];
 

--- a/features.json
+++ b/features.json
@@ -10,6 +10,7 @@
     "ember-runtime-enumerable-includes": true,
     "ember-string-ishtmlsafe": true,
     "ember-testing-check-waiters": true,
-    "ember-metal-weakmap": null
+    "ember-metal-weakmap": null,
+    "ember-glimmer-allow-backtracking-rerender": null
   }
 }

--- a/packages/ember-glimmer-template-compiler/lib/plugins/transform-attrs-into-args.js
+++ b/packages/ember-glimmer-template-compiler/lib/plugins/transform-attrs-into-args.js
@@ -13,7 +13,7 @@
   to
 
   ```handlebars
- {{foo.bar}}
+ {{@foo.bar}}
   ```
 
   as well as `{{#if attrs.foo}}`, `{{deeply (nested attrs.foobar.baz)}}` etc
@@ -38,7 +38,10 @@ TransformAttrsToProps.prototype.transform = function TransformAttrsToProps_trans
   traverse(ast, {
     PathExpression(node) {
       if (node.parts[0] === 'attrs') {
-        return b.path(node.original.substr(6));
+        let path = b.path(node.original.substr(6));
+        path.original = `@${path.original}`;
+        path.data = true;
+        return path;
       }
     }
   });

--- a/packages/ember-glimmer-template-compiler/lib/system/compile-options.js
+++ b/packages/ember-glimmer-template-compiler/lib/system/compile-options.js
@@ -1,7 +1,7 @@
 import defaultPlugins from 'ember-template-compiler/plugins';
 import TransformActionSyntax from '../plugins/transform-action-syntax';
 import TransformInputTypeSyntax from '../plugins/transform-input-type-syntax';
-import TransformAttrsIntoProps from '../plugins/transform-attrs-into-props';
+import TransformAttrsIntoArgs from '../plugins/transform-attrs-into-args';
 import TransformEachInIntoEach from '../plugins/transform-each-in-into-each';
 import TransformHasBlockSyntax from '../plugins/transform-has-block-syntax';
 import assign from 'ember-metal/assign';
@@ -11,7 +11,7 @@ export const PLUGINS = [
   // the following are ember-glimmer specific
   TransformActionSyntax,
   TransformInputTypeSyntax,
-  TransformAttrsIntoProps,
+  TransformAttrsIntoArgs,
   TransformEachInIntoEach,
   TransformHasBlockSyntax
 ];

--- a/packages/ember-glimmer/lib/helpers/readonly.js
+++ b/packages/ember-glimmer/lib/helpers/readonly.js
@@ -1,12 +1,5 @@
-import symbol from 'ember-metal/symbol';
 import { UPDATE } from '../utils/references';
 import { unMut } from './mut';
-
-const READONLY_REFERENCE = symbol('READONLY');
-
-export function isReadonly(ref) {
-  return ref && ref[READONLY_REFERENCE];
-}
 
 export default {
   isInternalHelper: true,
@@ -16,7 +9,6 @@ export default {
 
     let wrapped = Object.create(ref);
 
-    wrapped[READONLY_REFERENCE] = true;
     wrapped[UPDATE] = undefined;
 
     return wrapped;

--- a/packages/ember-glimmer/tests/integration/components/attrs-lookup-test.js
+++ b/packages/ember-glimmer/tests/integration/components/attrs-lookup-test.js
@@ -67,14 +67,12 @@ moduleFor('Components test: attrs lookup', class extends RenderingTest {
       },
 
       didReceiveAttrs() {
-        this.set('first', this.getAttr('first').toUpperCase());
+        this.set('first', this.get('first').toUpperCase());
       }
     });
     this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: '{{first}}' });
 
-    this.render(`{{foo-bar first=firstAttr}}`, {
-      firstAttr: 'first attr'
-    });
+    this.render(`{{foo-bar first="first attr"}}`);
 
     assert.equal(instance.get('first'), 'FIRST ATTR', 'component lookup uses local state');
     this.assertText('FIRST ATTR');
@@ -84,16 +82,8 @@ moduleFor('Components test: attrs lookup', class extends RenderingTest {
     assert.equal(instance.get('first'), 'FIRST ATTR', 'component lookup uses local state during rerender');
     this.assertText('FIRST ATTR');
 
-    // TODO: For some reason didReceiveAttrs is not called after this mutation occurs,
-    // See https://github.com/emberjs/ember.js/pull/13203
-    // this.runTask(() => set(this.context, 'firstAttr', 'second attr'));
-    // assert.equal(instance.get('first'), 'SECOND ATTR', 'component lookup uses modified local state');
-    // this.assertText('SECOND ATTR');
-
-    this.runTask(() => set(this.context, 'firstAttr', 'first attr'));
-
-    assert.equal(instance.get('first'), 'FIRST ATTR', 'component lookup uses reset local state');
-    this.assertText('FIRST ATTR');
+    // This is testing that passing string literals for use as initial values,
+    // so there is no update step
   }
 
   ['@test should be able to access unspecified attr #12035'](assert) {

--- a/packages/ember-glimmer/tests/integration/helpers/mut-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/mut-test.js
@@ -118,26 +118,6 @@ moduleFor('Helpers test: {{mut}}', class extends RenderingTest {
     }, 'You can only pass a path to mut');
   }
 
-  ['@glimmer passing a literal indirectly results in an assertion']() {
-    this.registerComponent('bottom-mut', { template: '{{setMe}}' });
-
-    this.registerComponent('middle-mut', { template: '{{bottom-mut setMe=(mut value)}}' });
-
-    expectAssertion(() => {
-      this.render('{{middle-mut value="foo bar"}}');
-    }, 'You can only pass a path to mut');
-  }
-
-  ['@glimmer passing the result of a helper invocation indirectly results in an assertion']() {
-    this.registerComponent('bottom-mut', { template: '{{setMe}}' });
-
-    this.registerComponent('middle-mut', { template: '{{bottom-mut setMe=(mut value)}}' });
-
-    expectAssertion(() => {
-      this.render('{{middle-mut value=(concat "foo" " " "bar")}}');
-    }, 'You can only pass a path to mut');
-  }
-
   // See https://github.com/emberjs/ember.js/commit/807a0cd for an explanation of this test
   ['@test using a string value through middle tier does not trigger assertion (due to the auto-mut transform)']() {
     let bottom;

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -46,6 +46,12 @@ let members = {
   tag: ownCustomObject
 };
 
+if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
+    isEnabled('ember-glimmer-allow-backtracking-rerender')) {
+  members.lastRendered = ownMap;
+  members.lastRenderedFrom = ownMap; // FIXME: not used in production, remove me from prod builds
+}
+
 let memberNames = Object.keys(members);
 const META_FIELD = '__ember_meta__';
 
@@ -73,6 +79,12 @@ function Meta(obj, parentMeta) {
   // have detailed knowledge of how each property should really be
   // inherited, and we can optimize it much better than JS runtimes.
   this.parent = parentMeta;
+
+  if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
+      isEnabled('ember-glimmer-allow-backtracking-rerender')) {
+    this._lastRendered = undefined;
+    this._lastRenderedFrom = undefined; // FIXME: not used in production, remove me from prod builds
+  }
 
   this._initializeListeners();
 }

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -13,6 +13,8 @@ import {
 } from './tags';
 import ObserverSet from 'ember-metal/observer_set';
 import symbol from 'ember-metal/symbol';
+import isEnabled from 'ember-metal/features';
+import { assertNotRendered } from 'ember-metal/transaction';
 
 export let PROPERTY_DID_CHANGE = symbol('PROPERTY_DID_CHANGE');
 
@@ -108,6 +110,11 @@ function propertyDidChange(obj, keyName) {
   }
 
   markObjectAsDirty(m);
+
+  if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
+      isEnabled('ember-glimmer-allow-backtracking-rerender')) {
+    assertNotRendered(obj, keyName, m);
+  }
 }
 
 

--- a/packages/ember-metal/lib/transaction.js
+++ b/packages/ember-metal/lib/transaction.js
@@ -1,0 +1,84 @@
+import { meta as metaFor } from './meta';
+import { assert, runInDebug, deprecate } from 'ember-metal/debug';
+import isEnabled from 'ember-metal/features';
+
+let runInTransaction, didRender, assertNotRendered;
+
+if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
+    isEnabled('ember-glimmer-allow-backtracking-rerender')) {
+  assert('It appears you are trying to use the backtracking rerender without the "ember-glimmer" flag turned on. Please make sure that "ember-glimmer" is turned on.');
+}
+
+
+let raise = assert;
+if (isEnabled('ember-glimmer-allow-backtracking-rerender')) {
+  raise = (message, test) => {
+    deprecate(message, test, { id: 'ember-views.render-double-modify', until: '3.0.0' });
+  };
+}
+
+if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
+    isEnabled('ember-glimmer-allow-backtracking-rerender')) {
+  let counter = 0;
+  let inTransaction = false;
+  let shouldReflush;
+
+  runInTransaction = function(callback) {
+    shouldReflush = false;
+    inTransaction = true;
+    callback();
+    inTransaction = false;
+    counter++;
+    return shouldReflush;
+  };
+
+  didRender = function(object, key, reference) {
+    if (!inTransaction) { return; }
+    let meta = metaFor(object);
+    let lastRendered = meta.writableLastRendered();
+    lastRendered[key] = counter;
+
+    runInDebug(() => {
+      let lastRenderedFrom = meta.writableLastRenderedFrom();
+      lastRenderedFrom[key] = reference;
+    });
+  };
+
+  assertNotRendered = function(object, key, _meta) {
+    let meta = _meta || metaFor(object);
+    let lastRendered = meta.readableLastRendered();
+
+    if (lastRendered && lastRendered[key] === counter) {
+      raise(
+        (function() {
+          let ref = meta.readableLastRenderedFrom();
+          let parts = [];
+          let lastRef = ref[key];
+
+          while (lastRef && lastRef._propertyKey && lastRef._parentReference) {
+            parts.unshift(lastRef._propertyKey);
+            lastRef = lastRef._parentReference;
+          }
+
+          return `You modified ${parts.join('.')} twice in a single render. This was unreliable and slow in Ember 1.x and will be removed in Ember 3.0.`;
+        }()),
+        false);
+
+      shouldReflush = true;
+    }
+  };
+} else {
+  runInTransaction = function() {
+    throw new Error('Cannot call runInTransaction without Glimmer');
+  };
+
+  didRender = function() {
+    throw new Error('Cannot call didRender without Glimmer');
+  };
+
+  assertNotRendered = function() {
+    throw new Error('Cannot call assertNotRendered without Glimmer');
+  };
+}
+
+export { runInTransaction as default, didRender, assertNotRendered };


### PR DESCRIPTION
Depends on https://github.com/tildeio/glimmer/pull/223.

Backtracking re-render refers to a scenario where, in the middle of the rendering process, you have modified something that has already been rendered. This behavior has always been unreliable, but was partially supported with a deprecation (since Ember 1.13). In Glimmer 2, while the extra re-render is relatively cheap, the extra book-keeping to detect a backtracking `set` is not. One of the wins of the Glimmer 2 system is that it does not need to eagerly setup observers to track changes. If you re-render a value in a single transaction we now throw an error.

The feature previously known as two-waying flushing. 🚽 
