### PR TITLE
Ensure babel-plugin-feature-flags is at least 0.2.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "aws-sdk": "~2.2.43",
-    "babel-plugin-feature-flags": "~0.2.0",
+    "babel-plugin-feature-flags": "~0.2.1",
     "babel-plugin-filter-imports": "~0.2.0",
     "bower": "~1.7.7",
     "broccoli-stew": "^1.2.0",


### PR DESCRIPTION
We are using the newer capabilities included in 0.2.1, so we should ensure that we list that as our min version.
