### PR TITLE
[GLIMMER2] Don’t make `Iterable`s volatile

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "express": "^4.5.0",
     "finalhandler": "^0.4.0",
     "github": "^0.2.3",
-    "glimmer-engine": "tildeio/glimmer#1df4b45",
+    "glimmer-engine": "tildeio/glimmer#0a13e7b",
     "glob": "^5.0.13",
     "htmlbars": "0.14.24",
     "mocha": "^2.4.5",

--- a/packages/ember-glimmer/lib/renderer.js
+++ b/packages/ember-glimmer/lib/renderer.js
@@ -185,7 +185,11 @@ class Renderer {
   }
 
   rerender(view) {
+    let env = this._env;
+
+    env.begin();
     (view['_renderResult'] || this._root['_renderResult']).rerender();
+    env.commit();
   }
 
   remove(view) {


### PR DESCRIPTION
`Iterable`s now proxy the validation tag from the source reference, so we won’t have to loop through the array again if it has not been mutated (via `pushObject`, etc)
