### PR TITLE
[GLIMMER2] Implement closure components

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "express": "^4.5.0",
     "finalhandler": "^0.4.0",
     "github": "^0.2.3",
-    "glimmer-engine": "tildeio/glimmer#e90bdea",
+    "glimmer-engine": "tildeio/glimmer#be998e6",
     "glob": "^5.0.13",
     "htmlbars": "0.14.24",
     "mocha": "^2.4.5",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "express": "^4.5.0",
     "finalhandler": "^0.4.0",
     "github": "^0.2.3",
-    "glimmer-engine": "tildeio/glimmer#0a13e7b",
+    "glimmer-engine": "tildeio/glimmer#e90bdea",
     "glob": "^5.0.13",
     "htmlbars": "0.14.24",
     "mocha": "^2.4.5",

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -211,6 +211,7 @@ export default class Environment extends GlimmerEnvironment {
     }
 
     let {
+      appendType,
       isSimple,
       isInline,
       isBlock,
@@ -256,6 +257,10 @@ export default class Environment extends GlimmerEnvironment {
       }
 
       assert(`A helper named "${key}" could not be found`, !isBlock || this.hasHelper(key, parentMeta));
+    }
+
+    if ((!isSimple && appendType === 'unknown') || appendType === 'self-get') {
+      return statement.original.deopt();
     }
 
     assert(`Helpers may not be used in the block form, for example {{#${key}}}{{/${key}}}. Please use a component, or alternatively use the helper in combination with a built-in Ember helper, for example {{#if (${key})}}{{/if}}.`, !isBlock || !this.hasHelper(key, parentMeta));

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -324,7 +324,7 @@ export default class Environment extends GlimmerEnvironment {
       this.owner.lookup(`helper:${name}`);
     // TODO: try to unify this into a consistent protocol to avoid wasteful closure allocations
     if (helper.isInternalHelper) {
-      return (vm, args) => helper.toReference(args);
+      return (vm, args) => helper.toReference(args, this);
     } else if (helper.isHelperInstance) {
       return (vm, args) => SimpleHelperReference.create(helper.compute, args);
     } else if (helper.isHelperFactory) {

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -27,6 +27,7 @@ import {
 } from './helpers/if-unless';
 
 import { default as action } from './helpers/action';
+import { default as componentHelper } from './helpers/component';
 import { default as concat } from './helpers/concat';
 import { default as get } from './helpers/get';
 import { default as hash } from './helpers/hash';
@@ -102,6 +103,7 @@ const builtInDynamicComponents = {
 const builtInHelpers = {
   if: inlineIf,
   action,
+  component: componentHelper,
   concat,
   get,
   hash,

--- a/packages/ember-glimmer/lib/helpers/component.js
+++ b/packages/ember-glimmer/lib/helpers/component.js
@@ -1,7 +1,143 @@
+import { CachedReference } from '../utils/references';
+import { CurlyComponentDefinition } from '../syntax/curly-component';
+import { EvaluatedArgs, EvaluatedNamedArgs, EvaluatedPositionalArgs } from 'glimmer-runtime';
+import { assert } from 'ember-metal/debug';
+import assign from 'ember-metal/assign';
+
+const CLOSURE_COMPONENT = 'ba564e81-ceda-4475-84a7-1c44f1c42c0e';
+
+export function isClosureComponent(object) {
+  return object && !!object[CLOSURE_COMPONENT];
+}
+
+class ClosureComponentDefinition extends CurlyComponentDefinition {
+  constructor(name, ComponentClass, template, args) {
+    super(...arguments);
+    this[CLOSURE_COMPONENT] = true;
+  }
+}
+
+export class ClosureComponentReference extends CachedReference {
+  static create(args, parentMeta, env) {
+    return new ClosureComponentReference(args, parentMeta, env);
+  }
+
+  constructor(args, parentMeta, env) {
+    super();
+    this.defRef = args.positional.at(0);
+    this.env = env;
+    this.tag = args.tag;
+    this.parentMeta = parentMeta;
+    this.args = args;
+  }
+
+  compute() {
+    // TODO: Figure out how to extract this because it's nearly identical to
+    // DynamicComponentReference::compute(). The only differences besides
+    // currying are in the assertion messages.
+    let { args, defRef, env, parentMeta } = this;
+    let nameOrDef = defRef.value();
+    let definition = null;
+
+    if (typeof nameOrDef === 'string') {
+      definition = env.getComponentDefinition([nameOrDef], parentMeta);
+      assert(`The component helper cannot be used without a valid component name. You used "${nameOrDef}" via (component "${nameOrDef}")`, definition);
+    } else if (isClosureComponent(nameOrDef)) {
+      definition = nameOrDef;
+    } else {
+      assert(
+        `You cannot create a component from ${nameOrDef} using the {{component}} helper`,
+        nameOrDef
+      );
+      return null;
+    }
+
+    let newDef = createCurriedDefinition(definition, args);
+
+    return newDef;
+  }
+}
+
+function createCurriedDefinition(definition, args) {
+  let curriedArgs = curryArgs(definition, args);
+
+  return new ClosureComponentDefinition(
+    definition.name,
+    definition.ComponentClass,
+    definition.template,
+    curriedArgs
+  );
+}
+
+function curryArgs(definition, newArgs) {
+  let { args, ComponentClass } = definition;
+  let { positionalParams } = ComponentClass;
+  
+  // The args being passed in are from the (component ...) invocation,
+  // so the first positional argument is actually the name or component
+  // definition. It needs to be dropped in order for any actual positional
+  // args to coincide with the ComponentClass's positionParams.
+
+  // For "normal" curly components this slicing is done at the syntax layer,
+  // but we don't have that luxury here.
+
+  let [, ...slicedPositionalArgs] = newArgs.positional.values;
+
+  if (positionalParams && slicedPositionalArgs.length) {
+    validatePositionalParameters(newArgs.named, slicedPositionalArgs, positionalParams);
+  }
+
+  // args (aka 'oldArgs') may be undefined or simply be empty args, so
+  // we need to fall back to an empty array or object.
+  let oldNamed = args && args.named && args.named.map || {};
+  let oldPositional = args && args.positional && args.positional.values || [];  
+
+  // Merge positional arrays
+  let mergedPositional = new Array(Math.max(oldPositional.length, slicedPositionalArgs.length));
+  mergedPositional.splice(0, oldPositional.length, ...oldPositional);
+  mergedPositional.splice(0, slicedPositionalArgs.length, ...slicedPositionalArgs);
+
+  // Merge named maps
+  let mergedNamed = assign({}, oldNamed, newArgs.named.map);
+
+  let mergedArgs = EvaluatedArgs.create({
+    named: EvaluatedNamedArgs.create({
+      map: mergedNamed
+    }),
+    positional: EvaluatedPositionalArgs.create({
+      values: mergedPositional
+    })
+  });
+
+  return mergedArgs;
+}
+
+function validatePositionalParameters(named, positional, positionalParamsDefinition) {
+  let paramType = typeof positionalParamsDefinition;
+
+  if (paramType === 'string') {
+    assert(`You cannot specify positional parameters and the hash argument \`${positionalParamsDefinition}\`.`, !named.has(positionalParamsDefinition));
+  } else {
+    if (positional.length < positionalParamsDefinition.length) {
+      positionalParamsDefinition = positionalParamsDefinition.slice(0, positional.length);
+    }
+
+    for (let i = 0; i < positionalParamsDefinition.length; i++) {
+      let name = positionalParamsDefinition[i];
+
+      assert(
+        `You cannot specify both a positional param (at position ${i}) and the hash argument \`${name}\`.`,
+        !named.has(name)
+      );
+    }
+  }
+}
+
 export default {
   isInternalHelper: true,
 
-  toReference(args) {
-    return args.positional.at(0);
+  toReference(args, env) {
+    // TODO: Need to figure out what to do about parentMeta here.
+    return ClosureComponentReference.create(args, null, env);
   }
 };

--- a/packages/ember-glimmer/lib/helpers/component.js
+++ b/packages/ember-glimmer/lib/helpers/component.js
@@ -7,7 +7,7 @@ import assign from 'ember-metal/assign';
 const CLOSURE_COMPONENT = 'ba564e81-ceda-4475-84a7-1c44f1c42c0e';
 
 export function isClosureComponent(object) {
-  return object && !!object[CLOSURE_COMPONENT];
+  return typeof object === 'object' && object && object[CLOSURE_COMPONENT];
 }
 
 class ClosureComponentDefinition extends CurlyComponentDefinition {

--- a/packages/ember-glimmer/lib/helpers/component.js
+++ b/packages/ember-glimmer/lib/helpers/component.js
@@ -1,0 +1,7 @@
+export default {
+  isInternalHelper: true,
+
+  toReference(args) {
+    return args.positional.at(0);
+  }
+};

--- a/packages/ember-glimmer/lib/helpers/component.js
+++ b/packages/ember-glimmer/lib/helpers/component.js
@@ -1,5 +1,5 @@
 import { CachedReference } from '../utils/references';
-import { CurlyComponentDefinition } from '../syntax/curly-component';
+import { CurlyComponentDefinition, validatePositionalParameters } from '../syntax/curly-component';
 import { EvaluatedArgs, EvaluatedNamedArgs, EvaluatedPositionalArgs } from 'glimmer-runtime';
 import { assert } from 'ember-metal/debug';
 import assign from 'ember-metal/assign';
@@ -72,7 +72,7 @@ function createCurriedDefinition(definition, args) {
 function curryArgs(definition, newArgs) {
   let { args, ComponentClass } = definition;
   let { positionalParams } = ComponentClass;
-  
+
   // The args being passed in are from the (component ...) invocation,
   // so the first positional argument is actually the name or component
   // definition. It needs to be dropped in order for any actual positional
@@ -90,7 +90,7 @@ function curryArgs(definition, newArgs) {
   // args (aka 'oldArgs') may be undefined or simply be empty args, so
   // we need to fall back to an empty array or object.
   let oldNamed = args && args.named && args.named.map || {};
-  let oldPositional = args && args.positional && args.positional.values || [];  
+  let oldPositional = args && args.positional && args.positional.values || [];
 
   // Merge positional arrays
   let mergedPositional = new Array(Math.max(oldPositional.length, slicedPositionalArgs.length));
@@ -110,27 +110,6 @@ function curryArgs(definition, newArgs) {
   });
 
   return mergedArgs;
-}
-
-function validatePositionalParameters(named, positional, positionalParamsDefinition) {
-  let paramType = typeof positionalParamsDefinition;
-
-  if (paramType === 'string') {
-    assert(`You cannot specify positional parameters and the hash argument \`${positionalParamsDefinition}\`.`, !named.has(positionalParamsDefinition));
-  } else {
-    if (positional.length < positionalParamsDefinition.length) {
-      positionalParamsDefinition = positionalParamsDefinition.slice(0, positional.length);
-    }
-
-    for (let i = 0; i < positionalParamsDefinition.length; i++) {
-      let name = positionalParamsDefinition[i];
-
-      assert(
-        `You cannot specify both a positional param (at position ${i}) and the hash argument \`${name}\`.`,
-        !named.has(name)
-      );
-    }
-  }
 }
 
 export default {

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -62,6 +62,10 @@ class ComponentStateBucket {
 }
 
 class CurlyComponentManager {
+  prepareArgs(definition, args) {
+    return args;
+  }
+
   create(definition, args, dynamicScope, hasBlock) {
     let parentView = dynamicScope.view;
 

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -1,9 +1,10 @@
-import { StatementSyntax, ValueReference } from 'glimmer-runtime';
+import { StatementSyntax, ValueReference, EvaluatedArgs, EvaluatedNamedArgs, EvaluatedPositionalArgs } from 'glimmer-runtime';
 import { TO_ROOT_REFERENCE, AttributeBindingReference, applyClassNameBinding } from '../utils/references';
 import { DIRTY_TAG, IS_DISPATCHING_ATTRS, HAS_BLOCK } from '../component';
 import { assert } from 'ember-metal/debug';
 import processArgs from '../utils/process-args';
 import { privatize as P } from 'container/registry';
+import assign from 'ember-metal/assign';
 import get from 'ember-metal/property_get';
 import { ComponentDefinition } from 'glimmer-runtime';
 import Component from '../component';
@@ -63,6 +64,43 @@ class ComponentStateBucket {
 
 class CurlyComponentManager {
   prepareArgs(definition, args) {
+    if (definition.args) {
+      // args (aka 'oldArgs') may be undefined or simply be empty args, so
+      // we need to fall back to an empty array or object.
+      let newNamed = args && args.named && args.named.map || {};
+      let newPositional = args && args.positional && args.positional.values || [];
+
+      let oldNamed = definition.args.named.map;
+      let oldPositional = definition.args.positional.values;
+
+      // Merge positional arrays
+      let mergedPositional = new Array(Math.max(oldPositional.length, newPositional.length));
+      mergedPositional.splice(0, oldPositional.length, ...oldPositional);
+      mergedPositional.splice(0, newPositional.length, ...newPositional);
+
+      // Merge named maps
+      let mergedNamed = assign({}, oldNamed, newNamed);
+
+      // THOUGHT: It might be nice to have a static method on EvaluatedArgs that
+      // can merge two sets of args for us.
+      let mergedArgs = EvaluatedArgs.create({
+        named: EvaluatedNamedArgs.create({
+          map: mergedNamed
+        }),
+        positional: EvaluatedPositionalArgs.create({
+          values: mergedPositional
+        })
+      }).withInternal();
+
+      // Preserve the invocation args' `internal` storage.
+      mergedArgs.internal = args.internal;
+
+      return mergedArgs;
+    } 
+    // else {
+      // No merge necessary!
+    // }
+
     return args;
   }
 
@@ -248,9 +286,10 @@ function ariaRole(vm) {
 }
 
 export class CurlyComponentDefinition extends ComponentDefinition {
-  constructor(name, ComponentClass, template) {
+  constructor(name, ComponentClass, template, args) {
     super(name, MANAGER, ComponentClass || Component);
     this.template = template;
+    this.args = args;
   }
 }
 

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -119,7 +119,7 @@ class CurlyComponentManager {
         positional: EvaluatedPositionalArgs.create({
           values: mergedPositional
         })
-      }).withInternal();
+      });
 
       // Preserve the invocation args' `internal` storage.
       mergedArgs.internal = args.internal;

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -1,7 +1,7 @@
 import { StatementSyntax, ValueReference, EvaluatedArgs, EvaluatedNamedArgs, EvaluatedPositionalArgs } from 'glimmer-runtime';
 import { TO_ROOT_REFERENCE, AttributeBindingReference, applyClassNameBinding } from '../utils/references';
 import { DIRTY_TAG, IS_DISPATCHING_ATTRS, HAS_BLOCK } from '../component';
-import { assert } from 'ember-metal/debug';
+import { assert, runInDebug } from 'ember-metal/debug';
 import processArgs from '../utils/process-args';
 import { privatize as P } from 'container/registry';
 import assign from 'ember-metal/assign';
@@ -12,28 +12,30 @@ import Component from '../component';
 const DEFAULT_LAYOUT = P`template:components/-default`;
 
 export function validatePositionalParameters(named, positional, positionalParamsDefinition) {
-  if (!named || !positional || !positional.length) {
-    return;
-  }
-
-  let paramType = typeof positionalParamsDefinition;
-
-  if (paramType === 'string') {
-    assert(`You cannot specify positional parameters and the hash argument \`${positionalParamsDefinition}\`.`, !named.has(positionalParamsDefinition));
-  } else {
-    if (positional.length < positionalParamsDefinition.length) {
-      positionalParamsDefinition = positionalParamsDefinition.slice(0, positional.length);
+  runInDebug(() => {
+    if (!named || !positional || !positional.length) {
+      return;
     }
 
-    for (let i = 0; i < positionalParamsDefinition.length; i++) {
-      let name = positionalParamsDefinition[i];
+    let paramType = typeof positionalParamsDefinition;
 
-      assert(
-        `You cannot specify both a positional param (at position ${i}) and the hash argument \`${name}\`.`,
-        !named.has(name)
-      );
+    if (paramType === 'string') {
+      assert(`You cannot specify positional parameters and the hash argument \`${positionalParamsDefinition}\`.`, !named.has(positionalParamsDefinition));
+    } else {
+      if (positional.length < positionalParamsDefinition.length) {
+        positionalParamsDefinition = positionalParamsDefinition.slice(0, positional.length);
+      }
+
+      for (let i = 0; i < positionalParamsDefinition.length; i++) {
+        let name = positionalParamsDefinition[i];
+
+        assert(
+          `You cannot specify both a positional param (at position ${i}) and the hash argument \`${name}\`.`,
+          !named.has(name)
+        );
+      }
     }
-  }
+  });
 }
 
 function aliasIdToElementId(args, props) {

--- a/packages/ember-glimmer/lib/syntax/dynamic-component.js
+++ b/packages/ember-glimmer/lib/syntax/dynamic-component.js
@@ -1,5 +1,6 @@
 import { ArgsSyntax, StatementSyntax } from 'glimmer-runtime';
 import { ConstReference, isConst, UNDEFINED_REFERENCE } from 'glimmer-reference';
+import { isClosureComponent } from '../helpers/component';
 import { assert } from 'ember-metal/debug';
 
 function dynamicComponentFor(vm) {
@@ -37,23 +38,26 @@ export class DynamicComponentSyntax extends StatementSyntax {
 }
 
 class DynamicComponentReference {
-  constructor({ nameRef, env, parentMeta }) {
+  constructor({ nameRef, env, parentMeta, args }) {
     this.nameRef = nameRef;
     this.env = env;
     this.tag = nameRef.tag;
     this.parentMeta = parentMeta;
+    this.args = args;
   }
 
   value() {
     let { env, nameRef, parentMeta } = this;
-    let name = nameRef.value();
+    let nameOrDef = nameRef.value();
 
-    if (typeof name === 'string') {
-      let definition = env.getComponentDefinition([name], parentMeta);
+    if (typeof nameOrDef === 'string') {
+      let definition = env.getComponentDefinition([nameOrDef], parentMeta);
 
-      assert(`Could not find component named "${name}" (no component or template with that name was found)`, definition);
+      assert(`Could not find component named "${nameOrDef}" (no component or template with that name was found)`, definition);
 
       return definition;
+    } else if (isClosureComponent(nameOrDef)) {
+      return nameOrDef;
     } else {
       return null;
     }

--- a/packages/ember-glimmer/lib/syntax/outlet.js
+++ b/packages/ember-glimmer/lib/syntax/outlet.js
@@ -95,6 +95,10 @@ function revalidate(definition, lastState, newState) {
 }
 
 class AbstractOutletComponentManager {
+  prepareArgs(definition, args) {
+    return args;
+  }
+
   create(definition, args, dynamicScope) {
     throw new Error('Not implemented: create');
   }

--- a/packages/ember-glimmer/lib/syntax/render.js
+++ b/packages/ember-glimmer/lib/syntax/render.js
@@ -56,6 +56,10 @@ export class RenderSyntax extends StatementSyntax {
 }
 
 class AbstractRenderManager {
+  prepareArgs(definition, args) {
+    return args;
+  }
+
   /* abstract create(definition, args, dynamicScope); */
 
   layoutFor(definition, bucket, env) {

--- a/packages/ember-glimmer/lib/utils/process-args.js
+++ b/packages/ember-glimmer/lib/utils/process-args.js
@@ -1,6 +1,5 @@
 import { CONSTANT_TAG } from 'glimmer-reference';
 import symbol from 'ember-metal/symbol';
-// import { assert } from 'ember-metal/debug';
 import EmptyObject from 'ember-metal/empty_object';
 import { ARGS } from '../component';
 import { UPDATE } from './references';
@@ -86,8 +85,6 @@ class MutableCell {
 
 class RestArgs {
   static create(args, restArgName) {
-    // assert(`You cannot specify positional parameters and the hash argument \`${restArgName}\`.`, !args.named.has(restArgName));
-
     return new RestArgs(args, restArgName);
   }
 
@@ -116,15 +113,6 @@ class PositionalArgs {
     if (args.positional.length < positionalParamNames.length) {
       positionalParamNames = positionalParamNames.slice(0, args.positional.length);
     }
-
-    // for (let i = 0; i < positionalParamNames.length; i++) {
-    //   let name = positionalParamNames[i];
-
-    //   // assert(
-    //   //   `You cannot specify both a positional param (at position ${i}) and the hash argument \`${name}\`.`,
-    //   //   !args.named.has(name)
-    //   // );
-    // }
 
     return new PositionalArgs(args, positionalParamNames);
   }

--- a/packages/ember-glimmer/lib/utils/process-args.js
+++ b/packages/ember-glimmer/lib/utils/process-args.js
@@ -1,6 +1,6 @@
 import { CONSTANT_TAG } from 'glimmer-reference';
 import symbol from 'ember-metal/symbol';
-import { assert } from 'ember-metal/debug';
+// import { assert } from 'ember-metal/debug';
 import EmptyObject from 'ember-metal/empty_object';
 import { ARGS } from '../component';
 import { UPDATE } from './references';
@@ -117,14 +117,14 @@ class PositionalArgs {
       positionalParamNames = positionalParamNames.slice(0, args.positional.length);
     }
 
-    for (let i = 0; i < positionalParamNames.length; i++) {
-      let name = positionalParamNames[i];
+    // for (let i = 0; i < positionalParamNames.length; i++) {
+    //   let name = positionalParamNames[i];
 
-      // assert(
-      //   `You cannot specify both a positional param (at position ${i}) and the hash argument \`${name}\`.`,
-      //   !args.named.has(name)
-      // );
-    }
+    //   // assert(
+    //   //   `You cannot specify both a positional param (at position ${i}) and the hash argument \`${name}\`.`,
+    //   //   !args.named.has(name)
+    //   // );
+    // }
 
     return new PositionalArgs(args, positionalParamNames);
   }

--- a/packages/ember-glimmer/lib/utils/process-args.js
+++ b/packages/ember-glimmer/lib/utils/process-args.js
@@ -86,7 +86,7 @@ class MutableCell {
 
 class RestArgs {
   static create(args, restArgName) {
-    assert(`You cannot specify positional parameters and the hash argument \`${restArgName}\`.`, !args.named.has(restArgName));
+    // assert(`You cannot specify positional parameters and the hash argument \`${restArgName}\`.`, !args.named.has(restArgName));
 
     return new RestArgs(args, restArgName);
   }
@@ -120,10 +120,10 @@ class PositionalArgs {
     for (let i = 0; i < positionalParamNames.length; i++) {
       let name = positionalParamNames[i];
 
-      assert(
-        `You cannot specify both a positional param (at position ${i}) and the hash argument \`${name}\`.`,
-        !args.named.has(name)
-      );
+      // assert(
+      //   `You cannot specify both a positional param (at position ${i}) and the hash argument \`${name}\`.`,
+      //   !args.named.has(name)
+      // );
     }
 
     return new PositionalArgs(args, positionalParamNames);

--- a/packages/ember-glimmer/tests/integration/components/closure-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/closure-components-test.js
@@ -4,7 +4,7 @@ import { moduleFor, RenderingTest } from '../../utils/test-case';
 import assign from 'ember-metal/assign';
 import isEmpty from 'ember-metal/is_empty';
 
-moduleFor('@htmlbars Components test: closure components', class extends RenderingTest {
+moduleFor('Components test: closure components', class extends RenderingTest {
   ['@test renders with component helper']() {
     let expectedText = 'Hodi';
 
@@ -74,6 +74,7 @@ moduleFor('@htmlbars Components test: closure components', class extends Renderi
     this.assertText('Gabon Zack');
   }
 
+  // Take a look at this one. Seems to pass even when currying isn't implemented.
   ['@test overwrites nested rest positional parameters if rendered with positional parameters']() {
     this.registerComponent('-looked-up', {
       ComponentClass: Component.extend().reopenClass({
@@ -252,7 +253,7 @@ moduleFor('@htmlbars Components test: closure components', class extends Renderi
     this.assertText('Hodi');
   }
 
-  ['@test updates when curried hash arguments is bound in block form']() {
+  ['@htmlbars updates when curried hash arguments is bound in block form']() {
     this.registerComponent('-looked-up', {
       template: '{{greeting}}'
     });
@@ -497,10 +498,10 @@ moduleFor('@htmlbars Components test: closure components', class extends Renderi
       this.render('{{component (component compName)}}', {
         compName: 'not-a-component'
       });
-    }, 'The component helper cannot be used without a valid component name. You used "not-a-component" via (component compName)');
+    }, /The component helper cannot be used without a valid component name. You used "not-a-component" via \(component .*\)/);
   }
 
-  ['@test renders with dot path']() {
+  ['@htmlbars renders with dot path']() {
     let expectedText = 'Hodi';
     this.registerComponent('-looked-up', {
       template: expectedText
@@ -518,7 +519,7 @@ moduleFor('@htmlbars Components test: closure components', class extends Renderi
     this.assertText(expectedText);
   }
 
-  ['@test renders with dot path and attr']() {
+  ['@htmlbars renders with dot path and attr']() {
     let expectedText = 'Hodi';
     this.registerComponent('-looked-up', {
       template: '{{expectedText}}'
@@ -549,7 +550,7 @@ moduleFor('@htmlbars Components test: closure components', class extends Renderi
     this.assertText(expectedText);
   }
 
-  ['@test renders with dot path and curried over attr']() {
+  ['@htmlbars renders with dot path and curried over attr']() {
     let expectedText = 'Hodi';
     this.registerComponent('-looked-up', {
       template: '{{expectedText}}'
@@ -580,7 +581,7 @@ moduleFor('@htmlbars Components test: closure components', class extends Renderi
     this.assertText(expectedText);
   }
 
-  ['@test renders with dot path and with rest positional parameters']() {
+  ['@htmlbars renders with dot path and with rest positional parameters']() {
     this.registerComponent('-looked-up', {
       ComponentClass: Component.extend().reopenClass({
         positionalParams: 'params'
@@ -615,7 +616,7 @@ moduleFor('@htmlbars Components test: closure components', class extends Renderi
     this.assertText(`${expectedText},Hola`);
   }
 
-  ['@test renders with dot path and rest parameter does not leak'](assert) {
+  ['@htmlbars renders with dot path and rest parameter does not leak'](assert) {
     // In the original implementation, positional parameters were not handled
     // correctly causing the first positional parameter to be the closure
     // component itself.
@@ -640,7 +641,7 @@ moduleFor('@htmlbars Components test: closure components', class extends Renderi
     assert.ok(isEmpty(value), 'value is an empty parameter');
   }
 
-  ['@test renders with dot path and updates attributes'](assert) {
+  ['@htmlbars renders with dot path and updates attributes'](assert) {
     this.registerComponent('my-nested-component', {
       ComponentClass: Component.extend({
         didReceiveAttrs() {
@@ -693,7 +694,7 @@ moduleFor('@htmlbars Components test: closure components', class extends Renderi
     assert.equal(this.$('#nested-prop').text(), '1');
   }
 
-  ['@test adding parameters to a closure component\'s instance does not add it to other instances']() {
+  ['@htmlbars adding parameters to a closure component\'s instance does not add it to other instances']() {
     // If parameters and attributes are not handled correctly, setting a value
     // in an invokation can leak to others invocation.
     this.registerComponent('select-box', {
@@ -860,4 +861,4 @@ applyMixins(ClosureComponentMutableParamsTest,
   ])
 );
 
-moduleFor('@htmlbars Components test: closure components -- mutable params', ClosureComponentMutableParamsTest);
+moduleFor('Components test: closure components -- mutable params', ClosureComponentMutableParamsTest);


### PR DESCRIPTION
This PR implements the `{{component}}` helper (when used as a subexpression) in Glimmer 2. This enables "closure components".

The basic idea is that the `{{component}}` helper produces a `ComponentDefinition` that composes a component and a set of args to use when constructing it. If the incoming component is itself a closure component, then the args are merged according to closure component rules. The resulting definition will have a populated `args` property, which can be used in a component manager's `prepareArgs` hook.

Since parameters are being merged according to closure component rules, some of the rest/position parameter validation logic had to be moved around.

Some of the code here can be cleaned up to reduce duplication, but I wanted to get eyes on this before anything fancy happens.
