### PR TITLE
[CLEANUP beta] Unify glimmer behavior with htmlbars and remove unsed code

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/fragment-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/fragment-components-test.js
@@ -104,7 +104,7 @@ moduleFor('Components test: fragment components', class extends RenderingTest {
     }, /You cannot use `classNameBindings` on a tag-less component/);
   }
 
-  ['@glimmer throws an error if `tagName` is an empty string and `attributeBindings` are specified']() {
+  ['@test throws an error if `tagName` is an empty string and `attributeBindings` are specified']() {
     let template = `hit dem folks`;
     let FooBarComponent = Component.extend({
       tagName: '',
@@ -117,7 +117,7 @@ moduleFor('Components test: fragment components', class extends RenderingTest {
     }, /You cannot use `attributeBindings` on a tag-less component/);
   }
 
-  ['@glimmer throws an error if `tagName` is an empty string and `elementId` is specified via JS']() {
+  ['@test throws an error if `tagName` is an empty string and `elementId` is specified via JS']() {
     let template = `hit dem folks`;
     let FooBarComponent = Component.extend({
       tagName: '',

--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -4,7 +4,7 @@ import getCellOrValue from 'ember-htmlbars/hooks/get-cell-or-value';
 import { get } from 'ember-metal/property_get';
 import { MUTABLE_CELL } from 'ember-views/compat/attrs-proxy';
 import { instrument } from 'ember-htmlbars/system/instrumentation-support';
-import LegacyEmberComponent, { HAS_BLOCK } from 'ember-htmlbars/component';
+import EmberComponent, { HAS_BLOCK } from 'ember-htmlbars/component';
 import extractPositionalParams from 'ember-htmlbars/utils/extract-positional-params';
 import { setOwner, getOwner } from 'container/owner';
 
@@ -33,7 +33,7 @@ ComponentNodeManager.create = function ComponentNodeManager_create(renderNode, e
         layout,
         templates } = options;
 
-  component = component || LegacyEmberComponent;
+  component = component || EmberComponent;
 
   let createOptions = {
     parentView,
@@ -74,7 +74,6 @@ ComponentNodeManager.create = function ComponentNodeManager_create(renderNode, e
   return new ComponentNodeManager(component, parentScope, renderNode, attrs, results.block, results.createdElement);
 };
 
-
 function configureTagName(attrs, tagName, component, createOptions) {
   if (attrs.tagName) {
     createOptions.tagName = getValue(attrs.tagName);
@@ -86,7 +85,6 @@ function configureCreateOptions(attrs, createOptions) {
   // instance. Make sure we use getValue() to get them from `attrs` since
   // they are still streams.
   if (attrs.id) { createOptions.elementId = getValue(attrs.id); }
-  if (attrs._defaultTagName) { createOptions._defaultTagName = getValue(attrs._defaultTagName); }
 }
 
 ComponentNodeManager.prototype.render = function ComponentNodeManager_render(_env, visitor) {

--- a/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
@@ -40,7 +40,6 @@ ViewNodeManager.create = function ViewNodeManager_create(renderNode, env, attrs,
 
     if (attrs && attrs.id) { options.elementId = getValue(attrs.id); }
     if (attrs && attrs.tagName) { options.tagName = getValue(attrs.tagName); }
-    if (attrs && attrs._defaultTagName) { options._defaultTagName = getValue(attrs._defaultTagName); }
 
     component = componentInfo.component = createOrUpdateComponent(found.component, options, found.createOptions, renderNode, env, attrs);
 

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -428,14 +428,6 @@ export default Mixin.create({
   // the default case and a user-specified tag.
   tagName: null,
 
-  /*
-    Used to specify a default tagName that can be overridden when extending
-    or invoking from a template.
-
-    @property _defaultTagName
-    @private
-  */
-
   // .......................................................
   // CORE DISPLAY METHODS
   //

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -512,24 +512,7 @@ var View = CoreView.extend(
   VisibilitySupport,
   CompatAttrsProxy,
   AriaRoleSupport,
-  ViewMixin, {
-    attributeBindings: ['ariaRole:role'],
-
-    /**
-      Given a property name, returns a dasherized version of that
-      property name if the property evaluates to a non-falsy value.
-
-      For example, if the view has property `isUrgent` that evaluates to true,
-      passing `isUrgent` to this method will return `"is-urgent"`.
-
-      @method _classStringForProperty
-      @param property
-      @private
-    */
-    _classStringForProperty(parsedPath) {
-      return View._classStringForValue(parsedPath.path, parsedPath.stream.value(), parsedPath.className, parsedPath.falsyClassName);
-    }
-  });
+  ViewMixin);
 
 // jscs:enable validateIndentation
 


### PR DESCRIPTION
Normalize attribute assertions and behavior across htmlbars and glimmer

Remove _defaultTagName which was for support of legacy each AST plugin
which was removed

Some general cleanup
