### PR TITLE
[WIP] Chore: add commitplease to check commit messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "bower": "~1.7.7",
     "broccoli-stew": "^1.2.0",
     "chalk": "^1.1.1",
+    "commitplease": "^2.6.1",
     "ember-cli": "^2.6.1",
     "ember-cli-blueprint-test-helpers": "^0.12.0",
     "ember-cli-dependency-checker": "^1.2.0",


### PR DESCRIPTION
Hello, ember.js! I have noticed that you consistently use a [commit message style](https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md#commit-tagging). However, once in a while there is a stray commit message that does not follow the style, like e176cff7ee9dc3cf5200d1ffe3cadfdf892208d9 or 751e7c2a032070a1903cd240f8a47c4d6adb7d96

Would you like to automatically check the style of your commit messages? Here is a quick example how you could set it up with [`commitplease`](https://github.com/jzaefferer/commitplease/issues/62), a module that I contribute to:

![record_ember](https://cloud.githubusercontent.com/assets/962850/17145358/ddf91c8e-536a-11e6-8087-03e36cb05811.gif)

So, whenever you type `git commit`, an automatic style check of the commit message is run. Under the hood it is just another `devDependency` for your project that installs with `npm install` and just works.

commitplease is used by Query Core, jQuery UI, jQuery Mobile, Globalize and QUnit. If you feel like using it too, let me know. We would add an ember commit message style to the list of supported styles then. Or maybe you even would like to switch to [jquery style](http://contribute.jquery.org/commits-and-pull-requests/#commit-guidelines) or [angular style](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit)? 
