### PR TITLE
Update emberjs-build to prevent errors when ember-glimmer is enabled.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ember-cli-sauce": "^1.4.2",
     "ember-cli-yuidoc": "0.8.4",
     "ember-publisher": "0.0.7",
-    "emberjs-build": "0.11.0",
+    "emberjs-build": "0.11.1",
     "express": "^4.5.0",
     "finalhandler": "^0.4.0",
     "github": "^0.2.3",


### PR DESCRIPTION
Includes only the changes from https://github.com/emberjs/emberjs-build/pull/170.
