### PR TITLE
[GLIMMER] Ensure objects with `.forEach` can be iterated.

### DIFF
--- a/packages/ember-glimmer/lib/utils/iterable.js
+++ b/packages/ember-glimmer/lib/utils/iterable.js
@@ -175,6 +175,12 @@ class Iterable {
       return new EmberArrayIterator(iterable, keyFor);
     } else if (Array.isArray(iterable)) {
       return iterable.length > 0 ? new ArrayIterator(iterable, keyFor) : EMPTY_ITERATOR;
+    } else if (typeof iterable.forEach === 'function') {
+      let array = [];
+      iterable.forEach(function(item) {
+        array.push(item);
+      });
+      return array.length > 0 ? new ArrayIterator(array, keyFor) : EMPTY_ITERATOR;
     } else if (isEachIn(ref)) {
       let keys = Object.keys(iterable);
       let values = keys.map(key => iterable[key]);


### PR DESCRIPTION
This was supported (though untested) in HTMLBars.  Added some tests and implemented in Glimmer.
