### PR TITLE
[Glimmer2] Various skipped tests

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/closure-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/closure-components-test.js
@@ -330,7 +330,7 @@ moduleFor('@htmlbars Components test: closure components', class extends Renderi
     this.assertText('Hodi Sigmundur 33');
   }
 
-  ['@skip bound outer named parameters get updated in the right scope']() {
+  ['@glimmer bound outer named parameters get updated in the right scope']() {
     this.registerComponent('-inner-component', {
       ComponentClass: Component.extend().reopenClass({
         positionalParams: ['comp']
@@ -376,7 +376,7 @@ moduleFor('@htmlbars Components test: closure components', class extends Renderi
     this.assertText('Inner 28');
   }
 
-  ['@skip bound outer hash parameters get updated in the right scope']() {
+  ['@test bound outer hash parameters get updated in the right scope']() {
     this.registerComponent('-inner-component', {
       ComponentClass: Component.extend().reopenClass({
         positionalParams: ['comp']

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -978,7 +978,7 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     this.assertText('In layout - someProp: something here');
   }
 
-  ['@skip non-block with properties overridden in init']() {
+  ['@glimmer non-block with properties overridden in init']() {
     let instance;
     this.registerComponent('non-block', {
       ComponentClass: Component.extend({

--- a/packages/ember-glimmer/tests/integration/input-test.js
+++ b/packages/ember-glimmer/tests/integration/input-test.js
@@ -94,7 +94,7 @@ moduleFor('Input element tests', class extends RenderingTest {
     this.assertValue('', 'Value is updated the second time');
   }
 
-  ['@skip DOM is SSOT if value is set']() {
+  ['@test DOM is SSOT if value is set']() {
     let template = `<input value={{value}}>`;
     this.render(template, { value: 'hola' });
 
@@ -108,9 +108,19 @@ moduleFor('Input element tests', class extends RenderingTest {
 
     this.assertValue('hola', 'DOM is used');
 
-    this.setComponentValue('hello');
+    this.setComponentValue('bye');
 
-    this.assertValue('hello', 'DOM is used');
+    this.assertValue('bye', 'Value is used');
+
+    // Simulates setting the input to the same value as it already is which won't cause a rerender
+
+    this.setDOMValue('hola');
+
+    this.assertValue('hola', 'DOM is used');
+
+    this.setComponentValue('hola');
+
+    this.assertValue('hola', 'Value is used');
   }
 
   // private helpers and assertions


### PR DESCRIPTION
@krisselden can you verify that the input SSOT test is correct. The TL;DR of the test is that we do not know of an out of band DOM property set thus setting the value on the backing component was idempotent operation and never caused a render.
