### PR TITLE
Merge #13915 and cleanup each-in tests

### DIFF
--- a/packages/ember-glimmer/lib/helpers/each-in.js
+++ b/packages/ember-glimmer/lib/helpers/each-in.js
@@ -6,9 +6,7 @@
 import symbol from 'ember-metal/symbol';
 
 /**
-  The `{{each-in}}` helper loops over properties on an object. It is unbound,
-  in that new (or removed) properties added to the target object will not be
-  rendered.
+  The `{{each-in}}` helper loops over properties on an object.
 
   For example, given a `user` object that looks like:
 

--- a/packages/ember-glimmer/lib/utils/iterable.js
+++ b/packages/ember-glimmer/lib/utils/iterable.js
@@ -171,6 +171,10 @@ class Iterable {
 
     if (iterable === undefined || iterable === null) {
       return EMPTY_ITERATOR;
+    } else if (isEachIn(ref)) {
+      let keys = Object.keys(iterable);
+      let values = keys.map(key => iterable[key]);
+      return keys.length > 0 ? new ObjectKeysIterator(keys, values, keyFor) : EMPTY_ITERATOR;
     } else if (isEmberArray(iterable)) {
       return new EmberArrayIterator(iterable, keyFor);
     } else if (Array.isArray(iterable)) {
@@ -181,10 +185,6 @@ class Iterable {
         array.push(item);
       });
       return array.length > 0 ? new ArrayIterator(array, keyFor) : EMPTY_ITERATOR;
-    } else if (isEachIn(ref)) {
-      let keys = Object.keys(iterable);
-      let values = keys.map(key => iterable[key]);
-      return keys.length > 0 ? new ObjectKeysIterator(keys, values, keyFor) : EMPTY_ITERATOR;
     } else {
       throw new Error(`Don't know how to {{#each ${iterable}}}`);
     }

--- a/packages/ember-glimmer/tests/integration/syntax/each-in-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/each-in-test.js
@@ -15,8 +15,13 @@ import {
 
 class EachInTest extends BasicConditionalsTest {
 
-  get truthyValue() { return { 'Not Empty': 1 }; }
-  get falsyValue() { return {}; }
+  get truthyValue() {
+    return { 'Not Empty': 1 };
+  }
+
+  get falsyValue() {
+    return {};
+  }
 
 }
 
@@ -303,5 +308,40 @@ moduleFor('Syntax test: {{#each-in}} undefined path', class extends RenderingTes
     this.runTask(() => set(this.context, 'foo', {}));
 
     this.assertText('');
+  }
+});
+
+moduleFor('Syntax test: {{#each-in}}  for array', class extends RenderingTest {
+  ['@test it iterate over array with `in` instead of walking over elements'](assert) {
+    let arr = [1, 2, 3];
+
+    this.render(strip`
+      {{#each-in arr as |key value|}}
+        [{{key}}:{{value}}]
+      {{/each-in}}`, { arr });
+
+    this.assertText('[0:1][1:2][2:3]');
+
+    this.runTask(() => this.rerender());
+
+    this.assertText('[0:1][1:2][2:3]');
+
+    this.runTask(() => {
+      set(arr, 'someKey', 'someKeyValue');
+      this.rerender();
+    });
+
+    this.assertText('[0:1][1:2][2:3][someKey:someKeyValue]');
+
+    this.runTask(() => {
+      delete arr.someKey;
+      this.rerender();
+    });
+
+    this.assertText('[0:1][1:2][2:3]');
+
+    this.runTask(() => set(this.context, 'arr', [1, 2, 3]));
+
+    this.assertText('[0:1][1:2][2:3]');
   }
 });


### PR DESCRIPTION
Also fixed Glimmer's `each-in` docs: Glimmer's `each-in` is not unbound. (The tag system is essentially a "star observer".)
