### PR TITLE
[GLIMMER2] Make proxies not VOLATILE

### DIFF
--- a/packages/ember-glimmer/lib/utils/iterable.js
+++ b/packages/ember-glimmer/lib/utils/iterable.js
@@ -6,7 +6,7 @@ import { objectAt, isEmberArray } from 'ember-runtime/mixins/array';
 import { isProxy } from 'ember-runtime/mixins/-proxy';
 import { UpdatableReference, UpdatablePrimitiveReference } from './references';
 import { isEachIn } from '../helpers/each-in';
-import { CURRENT_TAG, VOLATILE_TAG, UpdatableTag, combine } from 'glimmer-reference';
+import { CURRENT_TAG, UpdatableTag, combine } from 'glimmer-reference';
 
 const ITERATOR_KEY_GUID = 'be277757-bbbe-4620-9fcb-213ef433cca2';
 
@@ -164,7 +164,7 @@ class Iterable {
     let iterable = ref.value();
 
     if (isProxy(iterable)) {
-      valueTag.update(VOLATILE_TAG);
+      valueTag.update(CURRENT_TAG);
     } else {
       valueTag.update(tagFor(iterable));
     }

--- a/packages/ember-glimmer/lib/utils/references.js
+++ b/packages/ember-glimmer/lib/utils/references.js
@@ -3,7 +3,7 @@ import { set } from 'ember-metal/property_set';
 import { tagFor } from 'ember-metal/tags';
 import { didRender } from 'ember-metal/transaction';
 import symbol from 'ember-metal/symbol';
-import { CURRENT_TAG, CONSTANT_TAG, VOLATILE_TAG, ConstReference, DirtyableTag, UpdatableTag, combine, isConst } from 'glimmer-reference';
+import { CURRENT_TAG, CONSTANT_TAG, ConstReference, DirtyableTag, UpdatableTag, combine, isConst } from 'glimmer-reference';
 import { ConditionalReference as GlimmerConditionalReference, NULL_REFERENCE, UNDEFINED_REFERENCE } from 'glimmer-runtime';
 import emberToBool from './to-bool';
 import { RECOMPUTE_TAG } from '../helper';
@@ -147,7 +147,7 @@ export class PropertyReference extends CachedReference { // jshint ignore:line
     let parentValue = _parentReference.value();
 
     if (isProxy(parentValue)) {
-      _parentObjectTag.update(VOLATILE_TAG);
+      _parentObjectTag.update(CURRENT_TAG);
     } else {
       _parentObjectTag.update(tagFor(parentValue));
     }
@@ -225,7 +225,7 @@ export class ConditionalReference extends GlimmerConditionalReference {
 
   toBool(predicate) {
     if (isProxy(predicate)) {
-      this.objectTag.update(VOLATILE_TAG);
+      this.objectTag.update(CURRENT_TAG);
       return get(predicate, 'isTruthy');
     } else {
       this.objectTag.update(tagFor(predicate));


### PR DESCRIPTION
This was done previously to be more conservative, but I suspect it is not actually needed. As long as things you are proxying are dirtied with a `set`, this should be fine.

`CURRENT_TAG` means if anything within the boundaries of the object model has changed, then this object _might_ have changed. `VOLATILE_TAG` means the object you are talking about falls outside of the boundaries of the object model, therefore you literally cannot tell.

I don’t _think_ that’s needed for proxy. If this is causing problems in real apps during alpha, we can revert it.
