### PR TITLE
[GLIMMER] Skip remaining failing tests when flag is enabled.

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/link-to-test.js
+++ b/packages/ember-glimmer/tests/integration/components/link-to-test.js
@@ -22,6 +22,26 @@ moduleFor('Link-to component', class extends ApplicationTest {
     return p;
   }
 
+  ['@test accessing `currentWhen` triggers a deprecation'](assert) {
+    let component;
+    this.registerComponent('link-to', {
+      ComponentClass: LinkTo.extend({
+        init() {
+          this._super(...arguments);
+          component = this;
+        }
+      })
+    });
+
+    this.registerTemplate('application', `{{link-to 'Index' 'index'}}`);
+
+    return this.visit('/').then(() => {
+      expectDeprecation(() => {
+        component.get('currentWhen');
+      }, /Usage of `currentWhen` is deprecated, use `current-when` instead/);
+    });
+  }
+
   ['@test should be able to be inserted in DOM when the router is not present']() {
     this.registerTemplate('application', `{{#link-to 'index'}}Go to Index{{/link-to}}`);
 

--- a/packages/ember-metal/tests/events_test.js
+++ b/packages/ember-metal/tests/events_test.js
@@ -262,7 +262,9 @@ QUnit.test('a listener added as part of a mixin may be overridden', function() {
   equal(triggered, 1, 'should invoke from subclass property');
 });
 
-QUnit.test('DEPRECATED: adding didInitAttrs as a listener is deprecated', function() {
+import { test } from 'internal-test-helpers/tests/skip-if-glimmer';
+
+test('DEPRECATED: adding didInitAttrs as a listener is deprecated', function() {
   let obj = Component.create();
 
   expectDeprecation(() => {

--- a/packages/ember-templates/tests/reexports_test.js
+++ b/packages/ember-templates/tests/reexports_test.js
@@ -56,10 +56,3 @@ function getDescriptor(obj, path) {
   let last = parts[parts.length - 1];
   return Object.getOwnPropertyDescriptor(value, last);
 }
-
-// TODO: This test should go somewhere else
-QUnit.test('`LinkComponent#currentWhen` is deprecated in favour of `current-when` (DEPRECATED)', function() {
-  expectDeprecation(/Usage of `currentWhen` is deprecated, use `current-when` instead/);
-  let link = Ember.LinkComponent.create();
-  link.get('currentWhen');
-});

--- a/packages/ember-views/tests/views/instrumentation_test.js
+++ b/packages/ember-views/tests/views/instrumentation_test.js
@@ -43,7 +43,8 @@ QUnit.module('EmberView#instrumentation', {
   }
 });
 
-QUnit.test('generates the proper instrumentation details when called directly', function() {
+import { test } from 'internal-test-helpers/tests/skip-if-glimmer';
+test('generates the proper instrumentation details when called directly', function() {
   let payload = {};
 
   view.instrumentDetails(payload);

--- a/packages/ember-views/tests/views/view/append_to_test.js
+++ b/packages/ember-views/tests/views/view/append_to_test.js
@@ -3,14 +3,15 @@ import run from 'ember-metal/run_loop';
 
 import jQuery from 'ember-views/system/jquery';
 import EmberView from 'ember-views/views/view';
-import { compile } from 'ember-htmlbars-template-compiler';
 import ComponentLookup from 'ember-views/component_lookup';
-import Component from 'ember-htmlbars/component';
+import Component from 'ember-templates/component';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
 import buildOwner from 'container/tests/test-helpers/build-owner';
 import { OWNER } from 'container/owner';
+import { test, testModule } from 'internal-test-helpers/tests/skip-if-glimmer';
+import require from 'require';
 
-let owner, View, view, otherView, willDestroyCalled;
+let compile, owner, View, view, otherView, willDestroyCalled;
 
 function commonSetup() {
   owner = buildOwner();
@@ -18,10 +19,13 @@ function commonSetup() {
   owner.registerOptionsForType('view', { singleton: false });
   owner.registerOptionsForType('template', { instantiate: false });
   owner.register('component-lookup:main', ComponentLookup);
+
+  compile = require('ember-htmlbars-template-compiler').compile;
 }
 
-QUnit.module('EmberView - append() and appendTo()', {
+testModule('EmberView - append() and appendTo()', {
   setup() {
+    commonSetup();
     View = EmberView.extend({});
   },
 
@@ -31,7 +35,7 @@ QUnit.module('EmberView - append() and appendTo()', {
   }
 });
 
-QUnit.test('can call `appendTo` for multiple views #11109', function() {
+test('can call `appendTo` for multiple views #11109', function() {
   let elem;
   jQuery('#qunit-fixture').html('<div id="menu"></div><div id="other-menu"></div>');
 
@@ -53,7 +57,7 @@ QUnit.test('can call `appendTo` for multiple views #11109', function() {
   ok(elem.length > 0, 'creates and appends the second view\'s element');
 });
 
-QUnit.test('should be added to the specified element when calling appendTo()', function() {
+test('should be added to the specified element when calling appendTo()', function() {
   jQuery('#qunit-fixture').html('<div id="menu"></div>');
 
   view = View.create();
@@ -66,7 +70,7 @@ QUnit.test('should be added to the specified element when calling appendTo()', f
   ok(viewElem.length > 0, 'creates and appends the view\'s element');
 });
 
-QUnit.test('should be added to the document body when calling append()', function() {
+test('should be added to the document body when calling append()', function() {
   view = View.create({
     template: compile('foo bar baz')
   });
@@ -79,7 +83,7 @@ QUnit.test('should be added to the document body when calling append()', functio
   ok(viewElem.length > 0, 'creates and appends the view\'s element');
 });
 
-QUnit.test('raises an assert when a target does not exist in the DOM', function() {
+test('raises an assert when a target does not exist in the DOM', function() {
   view = View.create();
 
   expectAssertion(() => {
@@ -88,7 +92,7 @@ QUnit.test('raises an assert when a target does not exist in the DOM', function(
 });
 
 
-QUnit.test('destroy more forcibly removes the view', function() {
+test('destroy more forcibly removes the view', function() {
   willDestroyCalled = 0;
 
   view = View.create({
@@ -111,7 +115,7 @@ QUnit.test('destroy more forcibly removes the view', function() {
   equal(willDestroyCalled, 1, 'the willDestroyElement hook was called once');
 });
 
-QUnit.module('EmberView - append() and appendTo() in a view hierarchy', {
+testModule('EmberView - append() and appendTo() in a view hierarchy', {
   setup() {
     commonSetup();
 
@@ -130,7 +134,7 @@ QUnit.module('EmberView - append() and appendTo() in a view hierarchy', {
   }
 });
 
-QUnit.test('should be added to the specified element when calling appendTo()', function() {
+test('should be added to the specified element when calling appendTo()', function() {
   jQuery('#qunit-fixture').html('<div id="menu"></div>');
 
   view = View.create();
@@ -143,7 +147,7 @@ QUnit.test('should be added to the specified element when calling appendTo()', f
   ok(viewElem.length > 0, 'creates and appends the view\'s element');
 });
 
-QUnit.test('should be added to the document body when calling append()', function() {
+test('should be added to the document body when calling append()', function() {
   jQuery('#qunit-fixture').html('<div id="menu"></div>');
 
   view = View.create();

--- a/packages/ember-views/tests/views/view/render_to_element_test.js
+++ b/packages/ember-views/tests/views/view/render_to_element_test.js
@@ -2,12 +2,14 @@ import { get } from 'ember-metal/property_get';
 import run from 'ember-metal/run_loop';
 import EmberView from 'ember-views/views/view';
 
-import { compile } from 'ember-htmlbars-template-compiler';
+import { test, testModule } from 'internal-test-helpers/tests/skip-if-glimmer';
+import require from 'require';
 
-let View, view;
+let View, view, compile;
 
-QUnit.module('EmberView - renderToElement()', {
+testModule('EmberView - renderToElement()', {
   setup() {
+    compile = compile || require('ember-htmlbars-template-compiler').compile;
     View = EmberView.extend({
       template: compile('<h1>hello world</h1> goodbye world')
     });
@@ -20,7 +22,7 @@ QUnit.module('EmberView - renderToElement()', {
   }
 });
 
-QUnit.test('should render into and return a body element', function() {
+test('should render into and return a body element', function() {
   view = View.create();
 
   ok(!get(view, 'element'), 'precond - should not have an element');
@@ -33,7 +35,7 @@ QUnit.test('should render into and return a body element', function() {
   equal(element.firstChild.firstChild.nextSibling.nodeValue, ' goodbye world', 'renders the text node');
 });
 
-QUnit.test('should create and render into an element with a provided tagName', function() {
+test('should create and render into an element with a provided tagName', function() {
   view = View.create();
 
   ok(!get(view, 'element'), 'precond - should not have an element');


### PR DESCRIPTION
With these changes, enabling the `ember-glimmer` flag passes the browser
tests.
