### PR TITLE
[BUGFIX beta] Fix ember-metal/cache

### DIFF
--- a/packages/ember-glimmer/tests/unit/layout-cache-test.js
+++ b/packages/ember-glimmer/tests/unit/layout-cache-test.js
@@ -1,0 +1,126 @@
+import { RenderingTest, moduleFor } from '../utils/test-case';
+import EmptyObject from 'ember-metal/empty_object';
+import { CompiledBlock } from 'glimmer-runtime';
+
+class Counter {
+  constructor() {
+    this.reset();
+  }
+
+  increment(key) {
+    this.total++;
+    return this.counts[key] = (this.counts[key] || 0) + 1;
+  }
+
+  get(key) {
+    return this.counts[key] || 0;
+  }
+
+  reset() {
+    this.total  = 0;
+    this.counts = new EmptyObject();
+  }
+}
+
+const COUNTER = new Counter();
+
+class BasicCompiler {
+  constructor(template) {
+    this.template = template;
+  }
+
+  compile(builder) {
+    let { template } = this;
+    COUNTER.increment(`${this.constructor.id}+${template.id}`);
+    builder.wrapLayout(template.asLayout());
+  }
+}
+
+class TypeOneCompiler extends BasicCompiler {}
+class TypeTwoCompiler extends BasicCompiler {}
+
+TypeOneCompiler.id = 'type-one';
+TypeTwoCompiler.id = 'type-two';
+
+moduleFor('Layout cache test', class extends RenderingTest {
+
+  constructor() {
+    super();
+    COUNTER.reset();
+  }
+
+  templateFor(content) {
+    let Factory = this.compile(content);
+    return new Factory(this);
+  }
+
+  ['@test each template is only compiled once'](assert) {
+    let { env } = this;
+
+    let template1 = this.templateFor('Hello world!');
+    let template2 = this.templateFor('{{foo}} {{bar}}');
+
+    assert.ok(env.getCompiledBlock(TypeOneCompiler, template1) instanceof CompiledBlock, 'should return a CompiledBlock');
+    assert.strictEqual(COUNTER.get(`type-one+${template1.id}`), 1);
+    assert.strictEqual(COUNTER.get(`type-one+${template2.id}`), 0);
+    assert.strictEqual(COUNTER.total, 1);
+
+    assert.ok(env.getCompiledBlock(TypeOneCompiler, template1) instanceof CompiledBlock, 'should return a CompiledBlock');
+    assert.strictEqual(COUNTER.get(`type-one+${template1.id}`), 1);
+    assert.strictEqual(COUNTER.get(`type-one+${template2.id}`), 0);
+    assert.strictEqual(COUNTER.total, 1);
+
+    assert.ok(env.getCompiledBlock(TypeOneCompiler, template2) instanceof CompiledBlock, 'should return a CompiledBlock');
+    assert.strictEqual(COUNTER.get(`type-one+${template1.id}`), 1);
+    assert.strictEqual(COUNTER.get(`type-one+${template2.id}`), 1);
+    assert.strictEqual(COUNTER.total, 2);
+
+    assert.ok(env.getCompiledBlock(TypeOneCompiler, template1) instanceof CompiledBlock, 'should return a CompiledBlock');
+    assert.ok(env.getCompiledBlock(TypeOneCompiler, template1) instanceof CompiledBlock, 'should return a CompiledBlock');
+    assert.ok(env.getCompiledBlock(TypeOneCompiler, template2) instanceof CompiledBlock, 'should return a CompiledBlock');
+    assert.ok(env.getCompiledBlock(TypeOneCompiler, template1) instanceof CompiledBlock, 'should return a CompiledBlock');
+    assert.ok(env.getCompiledBlock(TypeOneCompiler, template1) instanceof CompiledBlock, 'should return a CompiledBlock');
+    assert.ok(env.getCompiledBlock(TypeOneCompiler, template1) instanceof CompiledBlock, 'should return a CompiledBlock');
+    assert.ok(env.getCompiledBlock(TypeOneCompiler, template2) instanceof CompiledBlock, 'should return a CompiledBlock');
+    assert.ok(env.getCompiledBlock(TypeOneCompiler, template2) instanceof CompiledBlock, 'should return a CompiledBlock');
+
+    assert.strictEqual(COUNTER.get(`type-one+${template1.id}`), 1);
+    assert.strictEqual(COUNTER.get(`type-one+${template2.id}`), 1);
+    assert.strictEqual(COUNTER.total, 2);
+  }
+
+  ['@test each template/compiler pair is treated as unique'](assert) {
+    let { env } = this;
+
+    let template = this.templateFor('Hello world!');
+
+    assert.ok(env.getCompiledBlock(TypeOneCompiler, template) instanceof CompiledBlock, 'should return a CompiledBlock');
+    assert.strictEqual(COUNTER.get(`type-one+${template.id}`), 1);
+    assert.strictEqual(COUNTER.get(`type-two+${template.id}`), 0);
+    assert.strictEqual(COUNTER.total, 1);
+
+    assert.ok(env.getCompiledBlock(TypeOneCompiler, template) instanceof CompiledBlock, 'should return a CompiledBlock');
+    assert.strictEqual(COUNTER.get(`type-one+${template.id}`), 1);
+    assert.strictEqual(COUNTER.get(`type-two+${template.id}`), 0);
+    assert.strictEqual(COUNTER.total, 1);
+
+    assert.ok(env.getCompiledBlock(TypeTwoCompiler, template) instanceof CompiledBlock, 'should return a CompiledBlock');
+    assert.strictEqual(COUNTER.get(`type-one+${template.id}`), 1);
+    assert.strictEqual(COUNTER.get(`type-two+${template.id}`), 1);
+    assert.strictEqual(COUNTER.total, 2);
+
+    assert.ok(env.getCompiledBlock(TypeOneCompiler, template) instanceof CompiledBlock, 'should return a CompiledBlock');
+    assert.ok(env.getCompiledBlock(TypeOneCompiler, template) instanceof CompiledBlock, 'should return a CompiledBlock');
+    assert.ok(env.getCompiledBlock(TypeTwoCompiler, template) instanceof CompiledBlock, 'should return a CompiledBlock');
+    assert.ok(env.getCompiledBlock(TypeOneCompiler, template) instanceof CompiledBlock, 'should return a CompiledBlock');
+    assert.ok(env.getCompiledBlock(TypeOneCompiler, template) instanceof CompiledBlock, 'should return a CompiledBlock');
+    assert.ok(env.getCompiledBlock(TypeOneCompiler, template) instanceof CompiledBlock, 'should return a CompiledBlock');
+    assert.ok(env.getCompiledBlock(TypeTwoCompiler, template) instanceof CompiledBlock, 'should return a CompiledBlock');
+    assert.ok(env.getCompiledBlock(TypeTwoCompiler, template) instanceof CompiledBlock, 'should return a CompiledBlock');
+
+    assert.strictEqual(COUNTER.get(`type-one+${template.id}`), 1);
+    assert.strictEqual(COUNTER.get(`type-two+${template.id}`), 1);
+    assert.strictEqual(COUNTER.total, 2);
+  }
+
+});

--- a/packages/ember-metal/lib/cache.js
+++ b/packages/ember-metal/lib/cache.js
@@ -11,31 +11,36 @@ export default class Cache {
     this.store  = store || new DefaultStore();
   }
 
-  set(obj, value) {
-    if (this.limit > this.size) {
-      let key = this.key === undefined ? obj : this.key(obj);
-      this.size ++;
-      if (value === undefined) {
-        this.store.set(key, UNDEFINED);
-      } else {
-        this.store.set(key, value);
-      }
-    }
-    return value;
-  }
-
   get(obj) {
     let key = this.key === undefined ? obj : this.key(obj);
     let value = this.store.get(key);
     if (value === undefined) {
       this.misses ++;
-      value = this.set(key, this.func(obj));
+      value = this._set(key, this.func(obj));
     } else if (value === UNDEFINED) {
       this.hits ++;
       value = undefined;
     } else {
       this.hits ++;
       // nothing to translate
+    }
+
+    return value;
+  }
+
+  set(obj, value) {
+    let key = this.key === undefined ? obj : this.key(obj);
+    return this._set(key, value);
+  }
+
+  _set(key, value) {
+    if (this.limit > this.size) {
+      this.size ++;
+      if (value === undefined) {
+        this.store.set(key, UNDEFINED);
+      } else {
+        this.store.set(key, value);
+      }
     }
 
     return value;

--- a/packages/ember-metal/tests/cache_test.js
+++ b/packages/ember-metal/tests/cache_test.js
@@ -10,6 +10,20 @@ QUnit.test('basic', function() {
   equal(cache.get('foo'), 'FOO');
 });
 
+QUnit.test('explicit sets', function() {
+  let cache = new Cache(100, key => key.toUpperCase());
+
+  equal(cache.get('foo'), 'FOO');
+
+  equal(cache.set('foo', 'FOO!!!'), 'FOO!!!');
+
+  equal(cache.get('foo'), 'FOO!!!');
+
+  strictEqual(cache.set('foo', undefined), undefined);
+
+  strictEqual(cache.get('foo'), undefined);
+});
+
 QUnit.test('caches computation correctly', function() {
   let count = 0;
   let cache = new Cache(100, key => {
@@ -28,10 +42,41 @@ QUnit.test('caches computation correctly', function() {
   equal(count, 2);
 });
 
-QUnit.test('handles undefined value correctly', function() {
-  let cache = new Cache(100, (key) => { });
+QUnit.test('caches computation correctly with custom cache keys', function() {
+  let count = 0;
+  let cache = new Cache(
+    100,
+    obj => {
+      count++;
+      return obj.value.toUpperCase();
+    },
+    obj => obj.key
+  );
 
-  equal(cache.get('foo'), undefined);
+  equal(count, 0);
+  cache.get({ key: 'foo', value: 'foo' });
+  equal(count, 1);
+  cache.get({ key: 'bar', value: 'bar' });
+  equal(count, 2);
+  cache.get({ key: 'bar', value: 'bar' });
+  equal(count, 2);
+  cache.get({ key: 'foo', value: 'foo' });
+  equal(count, 2);
+});
+
+QUnit.test('handles undefined value correctly', function() {
+  let count = 0;
+  let cache = new Cache(100, key => { count++; });
+
+  equal(count, 0);
+  strictEqual(cache.get('foo'), undefined);
+  equal(count, 1);
+  strictEqual(cache.get('bar'), undefined);
+  equal(count, 2);
+  strictEqual(cache.get('bar'), undefined);
+  equal(count, 2);
+  strictEqual(cache.get('foo'), undefined);
+  equal(count, 2);
 });
 
 QUnit.test('continues working after reaching cache limit', function() {


### PR DESCRIPTION
In #13829, we introduced the ability to pass a custom key function for the cache. However, we are incorrectly passing `(key, value)` to `set` when the function expects `(obj, value)`.

This is causing problems for caches that uses a custom cache keying function (such as Glimmer's compilation cache), because the get side would handle the keying correctly, but the set side would compute the key based on the already-computed key (i.e. `this.key(this.key(obj))`).

In Glimmer's compilation cache, this is causing the cache to always miss because the `set` side would cache everything under the `"undefined"` key.

cc @krisselden 
