### PR TITLE
Cleanup Ember.Error

### DIFF
--- a/packages/ember-metal/lib/error.js
+++ b/packages/ember-metal/lib/error.js
@@ -1,12 +1,4 @@
-const errorProps = [
-  'description',
-  'fileName',
-  'lineNumber',
-  'message',
-  'name',
-  'number',
-  'stack'
-];
+
 
 /**
   A subclass of the JavaScript Error object for use in Ember.
@@ -17,23 +9,26 @@ const errorProps = [
   @constructor
   @public
 */
-export default function EmberError() {
-  let tmp = Error.apply(this, arguments);
+export default function EmberError(message) {
+  if (!(this instanceof EmberError)) {
+    return new EmberError(message);
+  }
 
-  // Adds a `stack` property to the given error object that will yield the
-  // stack trace at the time captureStackTrace was called.
-  // When collecting the stack trace all frames above the topmost call
-  // to this function, including that call, will be left out of the
-  // stack trace.
-  // This is useful because we can hide Ember implementation details
-  // that are not very helpful for the user.
+  let error = Error.call(this, message);
+
   if (Error.captureStackTrace) {
     Error.captureStackTrace(this, EmberError);
+  } else {
+    this.stack = error.stack;
   }
-  // Unfortunately errors are not enumerable in Chrome (at least), so `for prop in tmp` doesn't work.
-  for (let idx = 0; idx < errorProps.length; idx++) {
-    this[errorProps[idx]] = tmp[errorProps[idx]];
-  }
+
+  this.description = error.description;
+  this.fileName = error.fileName;
+  this.lineNumber = error.lineNumber;
+  this.message = error.message;
+  this.name = error.name;
+  this.number = error.number;
+  this.code = error.code;
 }
 
 EmberError.prototype = Object.create(Error.prototype);


### PR DESCRIPTION
- if constructor was called and not new'd, new it
- capture stack to the subclass
- ensure the Error constructor `this` is preserved
- unroll the loop
