### PR TITLE
Fix Glimmer builds

### DIFF
--- a/lib/packages.js
+++ b/lib/packages.js
@@ -15,7 +15,7 @@ module.exports = function(features) {
       trees: null,
       templateCompilerOnly: true,
       requirements: ['ember-metal', 'ember-environment', 'ember-console', 'ember-templates'],
-      templateCompilerVendor: ['simple-html-tokenizer']
+      templateCompilerVendor: ['simple-html-tokenizer', 'backburner']
     },
     'ember-templates':            { trees: null,  requirements: ['ember-metal', 'ember-environment'] },
     'ember-routing':              { trees: null,  vendorRequirements: ['router', 'route-recognizer'],
@@ -80,7 +80,7 @@ module.exports = function(features) {
       templateCompilerOnly: true,
       requirements: [],
       vendorRequirements: ['htmlbars-runtime'],
-      templateCompilerVendor: ['htmlbars-runtime', 'htmlbars-util', 'htmlbars-compiler', 'htmlbars-syntax', 'htmlbars-test-helpers', 'morph-range', 'backburner']
+      templateCompilerVendor: ['htmlbars-runtime', 'htmlbars-util', 'htmlbars-compiler', 'htmlbars-syntax', 'htmlbars-test-helpers', 'morph-range']
     };
 
     packages['ember-htmlbars'] = {


### PR DESCRIPTION
Both template compilers seem to need backburner, hoisting it up.
