### PR TITLE
Use native DOM methods instead of jQuery.

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -1050,7 +1050,7 @@ function registerLibraries() {
   if (!librariesRegistered) {
     librariesRegistered = true;
 
-    if (environment.hasDOM) {
+    if (environment.hasDOM && typeof jQuery === 'function') {
       libraries.registerCoreLibrary('jQuery', jQuery().jquery);
     }
   }

--- a/packages/ember-application/tests/system/reset_test.js
+++ b/packages/ember-application/tests/system/reset_test.js
@@ -5,7 +5,6 @@ import EmberApplication from 'ember-application/system/application';
 import EmberObject from 'ember-runtime/system/object';
 import Router from 'ember-routing/system/router';
 import Controller from 'ember-runtime/controllers/controller';
-import jQuery from 'ember-views/system/jquery';
 import Registry from 'container/registry';
 
 let application, Application;
@@ -239,20 +238,4 @@ QUnit.test('With ember-data like initializer and constant', function() {
 
   ok(DS.defaultStore, 'still has defaultStore');
   ok(application.__container__.lookup('store:main'), 'store is still present');
-});
-
-QUnit.test('Ensure that the hashchange event listener is removed', function() {
-  let listeners;
-
-  jQuery(window).off('hashchange'); // ensure that any previous listeners are cleared
-
-  application = run(() => Application.create());
-
-  listeners = jQuery._data(jQuery(window)[0], 'events');
-  equal(listeners['hashchange'].length, 1, 'hashchange event listener was set up');
-
-  application.reset();
-
-  listeners = jQuery._data(jQuery(window)[0], 'events');
-  equal(listeners['hashchange'].length, 1, 'hashchange event only exists once');
 });

--- a/packages/ember-glimmer/tests/utils/helpers.js
+++ b/packages/ember-glimmer/tests/utils/helpers.js
@@ -26,6 +26,7 @@ export function buildOwner(options) {
   owner.register('service:-document', document, { instantiate: false });
   owner.register('-environment:main', {
     isInteractive: true,
+    hasDOM: true,
     options: { jQuery }
   }, { instantiate: false });
   owner.inject('view', '_environment', '-environment:main');

--- a/packages/ember-routing/lib/location/hash_location.js
+++ b/packages/ember-routing/lib/location/hash_location.js
@@ -1,11 +1,9 @@
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
 import run from 'ember-metal/run_loop';
-import { guidFor } from 'ember-metal/utils';
 
 import EmberObject from 'ember-runtime/system/object';
 import EmberLocation from 'ember-routing/location/api';
-import jQuery from 'ember-views/system/jquery';
 
 /**
 @module ember
@@ -27,6 +25,8 @@ export default EmberObject.extend({
 
   init() {
     set(this, 'location', get(this, '_location') || window.location);
+
+    this._hashchangeHandler = undefined;
   },
 
   /**
@@ -106,9 +106,9 @@ export default EmberObject.extend({
     @param callback {Function}
   */
   onUpdateURL(callback) {
-    let guid = guidFor(this);
+    this._removeEventListener();
 
-    jQuery(window).on(`hashchange.ember-location-${guid}`, () => {
+    this._hashchangeHandler = () => {
       run(() => {
         let path = this.getURL();
         if (get(this, 'lastSetURL') === path) { return; }
@@ -117,7 +117,9 @@ export default EmberObject.extend({
 
         callback(path);
       });
-    });
+    };
+
+    window.addEventListener('hashchange', this._hashchangeHandler);
   },
 
   /**
@@ -142,8 +144,12 @@ export default EmberObject.extend({
     @method willDestroy
   */
   willDestroy() {
-    let guid = guidFor(this);
+    this._removeEventListener();
+  },
 
-    jQuery(window).off(`hashchange.ember-location-${guid}`);
+  _removeEventListener() {
+    if (this._hashchangeHandler) {
+      window.removeEventListener('hashchange', this._hashchangeHandler);
+    }
   }
 });

--- a/packages/ember-testing/lib/support.js
+++ b/packages/ember-testing/lib/support.js
@@ -27,7 +27,7 @@ function testCheckboxClick(handler) {
     .remove();
 }
 
-if (environment.hasDOM) {
+if (environment.hasDOM && typeof $ === 'function') {
   $(function() {
     /*
       Determine whether a checkbox checked using jQuery's "click" method will have

--- a/packages/ember-views/lib/system/utils.js
+++ b/packages/ember-views/lib/system/utils.js
@@ -1,3 +1,5 @@
+/* globals Element */
+
 /**
 @module ember
 @submodule ember-views
@@ -58,4 +60,24 @@ export function getViewClientRects(view) {
 export function getViewBoundingClientRect(view) {
   let range = getViewRange(view);
   return range.getBoundingClientRect();
+}
+
+/**
+  Determines if the element matches the specified selector.
+
+  @private
+  @method matches
+  @param {DOMElement} el
+  @param {String} selector
+*/
+export const elMatches = typeof Element !== 'undefined' &&
+  (Element.prototype.matches ||
+   Element.prototype.matchesSelector ||
+   Element.prototype.mozMatchesSelector ||
+   Element.prototype.msMatchesSelector ||
+   Element.prototype.oMatchesSelector ||
+   Element.prototype.webkitMatchesSelector);
+
+export function matches(el, selector) {
+  return elMatches.call(el, selector);
 }


### PR DESCRIPTION
This allows Ember itself to be evaluated without jQuery and mostly boot
an application without jQuery present.  The only caveat is with
`EventDispatcher`.

There are still future changes needed to make the event dispatcher use
native DOM API's, but that is a bit more tricky because we still need to
support `$('#foo').trigger('click')` which will not work if you only use
`document.addEventListener`.  There is a path forward here, but I'd like
to work on it separately.
