### PR TITLE
[Glimmer 2] Step 1 of reducing `CURRENT_TAG`s

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "git-repo-info": "^1.1.4",
     "git-repo-version": "^0.3.1",
     "github": "^0.2.3",
-    "glimmer-engine": "tildeio/glimmer#b7f441fd",
+    "glimmer-engine": "tildeio/glimmer#2b342e2",
     "glob": "^5.0.13",
     "htmlbars": "0.14.24",
     "mocha": "^2.4.5",

--- a/packages/ember-glimmer/lib/helpers/get.js
+++ b/packages/ember-glimmer/lib/helpers/get.js
@@ -1,5 +1,5 @@
 import { CachedReference } from '../utils/references';
-import { CURRENT_TAG, CONSTANT_TAG, UpdatableTag, combine, isConst, referenceFromParts } from 'glimmer-reference';
+import { CONSTANT_TAG, UpdatableTag, combine, isConst, referenceFromParts } from 'glimmer-reference';
 
 /**
 @module ember
@@ -58,7 +58,6 @@ export default {
   }
 };
 
-
 class GetHelperReference extends CachedReference {
   static create(sourceReference, pathReference) {
     if (isConst(pathReference)) {
@@ -77,7 +76,7 @@ class GetHelperReference extends CachedReference {
     this.lastPath = null;
     this.innerReference = null;
 
-    let innerTag = this.innerTag = new UpdatableTag(CURRENT_TAG);
+    let innerTag = this.innerTag = new UpdatableTag(CONSTANT_TAG);
 
     this.tag = combine([sourceReference.tag, pathReference.tag, innerTag]);
   }

--- a/packages/ember-glimmer/lib/helpers/if-unless.js
+++ b/packages/ember-glimmer/lib/helpers/if-unless.js
@@ -5,7 +5,7 @@
 
 import { assert } from 'ember-metal/debug';
 import { UNDEFINED_REFERENCE, CachedReference, ConditionalReference } from '../utils/references';
-import { CURRENT_TAG, UpdatableTag, combine, isConst } from 'glimmer-reference';
+import { CONSTANT_TAG, UpdatableTag, combine, isConst } from 'glimmer-reference';
 
 class ConditionalHelperReference extends CachedReference {
   static create(_condRef, _truthyRef, _falsyRef) {
@@ -23,7 +23,7 @@ class ConditionalHelperReference extends CachedReference {
   constructor(cond, truthy, falsy) {
     super();
 
-    this.branchTag = new UpdatableTag(CURRENT_TAG);
+    this.branchTag = new UpdatableTag(CONSTANT_TAG);
     this.tag = combine([cond.tag, this.branchTag]);
 
     this.cond = cond;

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -271,9 +271,9 @@ class CurlyComponentManager {
     let { component, args, argsRevision } = bucket;
 
     if (!args.tag.validate(argsRevision)) {
-      bucket.argsRevision = args.tag.value();
-
       let { attrs, props } = args.value();
+
+      bucket.argsRevision = args.tag.value();
 
       let oldAttrs = component.attrs;
       let newAttrs = attrs;

--- a/packages/ember-glimmer/lib/utils/iterable.js
+++ b/packages/ember-glimmer/lib/utils/iterable.js
@@ -6,7 +6,7 @@ import { objectAt, isEmberArray } from 'ember-runtime/mixins/array';
 import { isProxy } from 'ember-runtime/mixins/-proxy';
 import { UpdatableReference, UpdatablePrimitiveReference } from './references';
 import { isEachIn } from '../helpers/each-in';
-import { CURRENT_TAG, UpdatableTag, combine } from 'glimmer-reference';
+import { CONSTANT_TAG, CURRENT_TAG, UpdatableTag, combine } from 'glimmer-reference';
 
 const ITERATOR_KEY_GUID = 'be277757-bbbe-4620-9fcb-213ef433cca2';
 
@@ -151,7 +151,7 @@ const EMPTY_ITERATOR = new EmptyIterator();
 
 class Iterable {
   constructor(ref, keyFor) {
-    let valueTag = this.valueTag = new UpdatableTag(CURRENT_TAG);
+    let valueTag = this.valueTag = new UpdatableTag(CONSTANT_TAG);
 
     this.tag = combine([ref.tag, valueTag]);
     this.ref = ref;

--- a/packages/ember-glimmer/lib/utils/references.js
+++ b/packages/ember-glimmer/lib/utils/references.js
@@ -48,8 +48,8 @@ export class CachedReference extends EmberPathReference {
     let { tag, _lastRevision, _lastValue } = this;
 
     if (!_lastRevision || !tag.validate(_lastRevision)) {
-      this._lastRevision = tag.value();
       _lastValue = this._lastValue = this.compute();
+      this._lastRevision = tag.value();
     }
 
     return _lastValue;
@@ -126,7 +126,7 @@ export class PropertyReference extends CachedReference { // jshint ignore:line
     super();
 
     let parentReferenceTag = parentReference.tag;
-    let parentObjectTag = new UpdatableTag(CURRENT_TAG);
+    let parentObjectTag = new UpdatableTag(CONSTANT_TAG);
 
     this._parentReference = parentReference;
     this._parentObjectTag = parentObjectTag;
@@ -219,7 +219,7 @@ export class ConditionalReference extends GlimmerConditionalReference {
   constructor(reference) {
     super(reference);
 
-    this.objectTag = new UpdatableTag(CURRENT_TAG);
+    this.objectTag = new UpdatableTag(CONSTANT_TAG);
     this.tag = combine([reference.tag, this.objectTag]);
   }
 


### PR DESCRIPTION
Pulling the value of a reference could be a side-effectful operation from the perspective of the revision timeline (e.g. updating an `UpdatableTag` is a change on the timeline). Therefore we should always compute the value first, then pull from the validation tag.

If we always follow that protocol, there is no actual reason to initialize an `UpdatableTag` with a `CURRENT_TAG`. While this is always "correct", it causes values that doesn't otherwise matter to "poison" an tag combinator all the way up. (And also causes caches to miss – because the tag value might have changed after computing the value, as it is usually the case when an `UpdatableTag` is involved.)
