### PR TITLE
[DOC release] Fix documentation of Route queryParamsDidChange

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -760,7 +760,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
 
       @method queryParamsDidChange
       @param changed {Object} Keys are names of query params that have changed.
-      @param totalPresent {Number}
+      @param totalPresent {Object} Keys are names of query params that are currently set.
       @param removed {Object} Keys are names of query params that have been removed.
       @returns {boolean}
       @private


### PR DESCRIPTION
The second parameter is an object of the query parameters currently set on the URL, not an integer.

It's the router.js library that calls this `queryParamsDidChange` function, and while this method signature isn't clearly documented on router.js's end, you can see that it's an object through a couple of hops:
- `queryParamsDidChange` is called with the second argument being `queryParamChangelist.all`: https://github.com/tildeio/router.js/blob/04b27c911995902b022966f4d29d8686ba7d847c/lib/router/router.js#L385
- `queryParamChangelist` in turn originates from `getChangelist` where you can see that `.all` is an object (similar to the `changed` and `removed` options that were already documented as objects): https://github.com/tildeio/router.js/blob/04b27c911995902b022966f4d29d8686ba7d847c/lib/router/utils.js#L126-L130
