### PR TITLE
[BUGFIX beta] Fix issue 12967. Using render without a name losing templateName property.

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1941,7 +1941,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     let name;
 
     if (typeof _name === 'object' && !options) {
-      name = this.routeName;
+      name = this.templateName || this.routeName;
       options = _name;
     } else {
       name = _name;

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -367,6 +367,30 @@ QUnit.test('defining templateName allows other templates to be rendered', functi
   equal(jQuery('.alert-box', '#qunit-fixture').text(), 'Invader!', 'Template for alert was render into outlet');
 });
 
+QUnit.test('templateName is still used when calling render with no name and options', function() {
+  Router.map(function() {
+    this.route('home', { path: '/' });
+  });
+
+  setTemplate('alert', compile(
+    '<div class=\'alert-box\'>Invader!</div>'
+  ));
+  setTemplate('home', compile(
+    '<p>THIS IS THE REAL HOME</p>{{outlet \'alert\'}}'
+  ));
+
+  App.HomeRoute = Route.extend({
+    templateName: 'alert',
+    renderTemplate: function() {
+      this.render({});
+    }
+  });
+
+  bootApplication();
+
+  equal(jQuery('.alert-box', '#qunit-fixture').text(), 'Invader!', 'default templateName was rendered into outlet');
+});
+
 QUnit.test('The Homepage with a `setupController` hook', function() {
   Router.map(function() {
     this.route('home', { path: '/' });


### PR DESCRIPTION
Using render without a name misses using templateName property on route.
