### PR TITLE
Registry setup fixes

### DIFF
--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -131,21 +131,7 @@ const ApplicationInstance = EngineInstance.extend({
   },
 
   setupRegistry(options) {
-    let registry = this.__registry__;
-
-    registry.register('-environment:main', options.toEnvironment(), { instantiate: false });
-    registry.injection('view', '_environment', '-environment:main');
-    registry.injection('route', '_environment', '-environment:main');
-
-    registry.register('service:-document', options.document, { instantiate: false });
-
-    if (options.isInteractive) {
-      registry.injection('view', 'renderer', 'renderer:-dom');
-      registry.injection('component', 'renderer', 'renderer:-dom');
-    } else {
-      registry.injection('view', 'renderer', 'renderer:-inert');
-      registry.injection('component', 'renderer', 'renderer:-inert');
-    }
+    this.constructor.setupRegistry(this.__registry__, options);
   },
 
   router: computed(function() {
@@ -285,6 +271,30 @@ const ApplicationInstance = EngineInstance.extend({
 
     // getURL returns the set url with the rootURL stripped off
     return router.handleURL(location.getURL()).then(handleResolve, handleReject);
+  }
+});
+
+ApplicationInstance.reopenClass({
+  /**
+   @private
+   @method setupRegistry
+   @param {Registry} registry
+   @param {BootOptions} options
+  */
+  setupRegistry(registry, options = new BootOptions()) {
+    registry.register('-environment:main', options.toEnvironment(), { instantiate: false });
+    registry.injection('view', '_environment', '-environment:main');
+    registry.injection('route', '_environment', '-environment:main');
+
+    registry.register('service:-document', options.document, { instantiate: false });
+
+    if (options.isInteractive) {
+      registry.injection('view', 'renderer', 'renderer:-dom');
+      registry.injection('component', 'renderer', 'renderer:-dom');
+    } else {
+      registry.injection('view', 'renderer', 'renderer:-inert');
+      registry.injection('component', 'renderer', 'renderer:-inert');
+    }
   }
 });
 

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -29,6 +29,7 @@ import { environment } from 'ember-environment';
 import RSVP from 'ember-runtime/ext/rsvp';
 import Engine, { GLIMMER } from './engine';
 import require from 'require';
+import isEnabled from 'ember-metal/features';
 
 let librariesRegistered = false;
 
@@ -1018,12 +1019,17 @@ Application.reopenClass({
 
     commonSetupRegistry(registry);
 
-    if (options[GLIMMER]) {
+    if (isEnabled('ember-glimmer')) {
       let glimmerSetupRegistry = require('ember-glimmer/setup-registry').setupApplicationRegistry;
       glimmerSetupRegistry(registry);
     } else {
-      let htmlbarsSetupRegistry = require('ember-htmlbars/setup-registry').setupApplicationRegistry;
-      htmlbarsSetupRegistry(registry);
+      if (options[GLIMMER]) {
+        let glimmerSetupRegistry = require('ember-glimmer/setup-registry').setupApplicationRegistry;
+        glimmerSetupRegistry(registry);
+      } else {
+        let htmlbarsSetupRegistry = require('ember-htmlbars/setup-registry').setupApplicationRegistry;
+        htmlbarsSetupRegistry(registry);
+      }
     }
 
     return registry;

--- a/packages/ember-application/lib/system/engine.js
+++ b/packages/ember-application/lib/system/engine.js
@@ -403,12 +403,17 @@ Engine.reopenClass({
 
     commonSetupRegistry(registry);
 
-    if (options[GLIMMER]) {
+    if (isEnabled('ember-glimmer')) {
       let glimmerSetupRegistry = require('ember-glimmer/setup-registry').setupEngineRegistry;
       glimmerSetupRegistry(registry);
     } else {
-      let htmlbarsSetupRegistry = require('ember-htmlbars/setup-registry').setupEngineRegistry;
-      htmlbarsSetupRegistry(registry);
+      if (options[GLIMMER]) {
+        let glimmerSetupRegistry = require('ember-glimmer/setup-registry').setupEngineRegistry;
+        glimmerSetupRegistry(registry);
+      } else {
+        let htmlbarsSetupRegistry = require('ember-htmlbars/setup-registry').setupEngineRegistry;
+        htmlbarsSetupRegistry(registry);
+      }
     }
 
     return registry;

--- a/packages/ember-application/tests/system/application_instance_test.js
+++ b/packages/ember-application/tests/system/application_instance_test.js
@@ -6,6 +6,7 @@ import jQuery from 'ember-views/system/jquery';
 import factory from 'container/tests/test-helpers/factory';
 import isEnabled from 'ember-metal/features';
 import { privatize as P } from 'container/registry';
+import EmberObject from 'ember-runtime/system/object';
 
 let application, appInstance;
 
@@ -178,5 +179,17 @@ if (isEnabled('ember-application-engines')) {
             `Engine and parent app share singleton '${key}'`);
         });
       });
+  });
+
+  QUnit.test('can build a registry via Ember.ApplicationInstance.setupRegistry() -- simulates ember-test-helpers', function(assert) {
+    let namespace = EmberObject.create({
+      Resolver: { create: function() { } }
+    });
+
+    let registry = Application.buildRegistry(namespace);
+
+    ApplicationInstance.setupRegistry(registry);
+
+    assert.equal(registry.resolve('service:-document'), document);
   });
 }

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -401,3 +401,13 @@ QUnit.test('does not leak itself in onLoad._loaded', function() {
   run(app, 'destroy');
   equal(_loaded.application, undefined);
 });
+
+QUnit.test('can build a registry via Ember.Application.buildRegistry() --- simulates ember-test-helpers', function(assert) {
+  let namespace = EmberObject.create({
+    Resolver: { create: function() { } }
+  });
+
+  let registry = Application.buildRegistry(namespace);
+
+  assert.equal(registry.resolve('application:main'), namespace);
+});


### PR DESCRIPTION
- Ensure `Ember.Application.buildRegistry` uses Glimmer registry in alpha. ember-test-helpers calls `Ember.Application.buildRegistry` to create a registry for its testing harness. Prior to these changes, `options[GLIMMER]` would be `undefined` and therefore throw an error when building a registry in the alpha series.
- Expose `Ember.ApplicationInstance.setupRegistry` for tooling. Glimmer requires that a number of factories and injections added by `ApplicationInstance#setupRegistry` are present, but the testing harness only has access to calling `Ember.Application.buildRegistry` which leaves the registry in a partially populated state. This exposes `Ember.ApplicationInstance.setupRegistry` so that `ember-test-helpers` can ensure that its registry is properly populated.

Addresses part of the issues identified in #13963.
