### PR TITLE
[WIP] [Glimmer 2] link-to classNameBindings assertion

### DIFF
--- a/packages/ember-template-compiler/tests/plugins/assert-reserved-named-arguments-test.js
+++ b/packages/ember-template-compiler/tests/plugins/assert-reserved-named-arguments-test.js
@@ -23,4 +23,3 @@ QUnit.test('Paths beginning with @ are not valid', function() {
     });
   }, `'@foo' is not a valid path. ('baz/foo-bar' @ L1:C17) `);
 });
-

--- a/packages/ember-template-compiler/tests/plugins/transform-old-class-bindings-syntax-test.js
+++ b/packages/ember-template-compiler/tests/plugins/transform-old-class-bindings-syntax-test.js
@@ -1,0 +1,19 @@
+import { compile } from '../utils/helpers';
+
+QUnit.module('transform-old-class-bindings-syntax-test');
+
+QUnit.test('valid `classNameBindings`', function() {
+  compile('{{#link-to "index" classNameBindings=":valid isBig:big isOpen:open:closed"}}go{{/link-to}}', {
+    moduleName: 'baz/foo-bar'
+  });
+
+  ok(true, 'should not produce an assert');
+});
+
+QUnit.test('invalid `classNameBindings`', function() {
+  expectAssertion(() => {
+    compile('{{#link-to "index" classNameBindings=":valid isBig:big isOpen:open:closed invalid"}}go{{/link-to}}', {
+      moduleName: 'baz/foo-bar'
+    });
+  }, `'invalid' is not a valid classNameBinding. ('baz/foo-bar' @ L1:C19) `);
+});


### PR DESCRIPTION
fixes https://github.com/emberjs/ember.js/issues/13955

TODO:
- [ ] add similar assertion to class definition? **update:** maybe not - see https://github.com/emberjs/ember.js/pull/13975#issuecomment-236424314

---

``` hbs
{{#link-to "index" classNameBindings=":valid isBig:big isOpen:open:closed invalid"}}
  click me
{{/link-to}}
```

will now produce:

`'invalid' is not a valid classNameBinding. ('baz/foo-bar' @ L1:C19)`
