### PR TITLE
Fix ported outlet test

### DIFF
--- a/packages/ember-glimmer/tests/integration/outlet-test.js
+++ b/packages/ember-glimmer/tests/integration/outlet-test.js
@@ -1,46 +1,50 @@
 import { RenderingTest, moduleFor } from '../utils/test-case';
-import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
+import { runAppend } from 'ember-runtime/tests/utils';
 
 moduleFor('outlet view', class extends RenderingTest {
   constructor() {
     super(...arguments);
 
     let CoreOutlet = this.owner._lookupFactory('view:-outlet');
-    this.top = CoreOutlet.create();
-  }
-
-  teardown() {
-    runDestroy(this.top);
-
-    super.teardown(...arguments);
-  }
-
-  withTemplate(string) {
-    return {
-      render: {
-        template: this.compile(string)
-      },
-      outlets: {}
-    };
-  }
-
-  appendTop() {
-    runAppend(this.top);
+    this.component = CoreOutlet.create();
   }
 
   ['@htmlbars should render the outlet when set after DOM insertion']() {
-    let routerState = this.withTemplate('<h1>HI</h1>{{outlet}}');
-    this.top.setOutletState(routerState);
+    let outletState = {
+      render: {
+        owner: this.owner,
+        into: undefined,
+        outlet: 'main',
+        name: 'application',
+        controller: {},
+        ViewClass: undefined,
+        template: this.compile('HI{{outlet}}')
+      },
+      outlets: Object.create(null)
+    };
 
-    this.appendTop();
+    this.runTask(() => this.component.setOutletState(outletState));
+
+    runAppend(this.component);
 
     this.assertText('HI');
 
     this.assertStableRerender();
 
-    routerState.outlets.main = this.withTemplate('<p>BYE</p>');
+    outletState.outlets.main = {
+      render: {
+        owner: this.owner,
+        into: undefined,
+        outlet: 'main',
+        name: 'application',
+        controller: {},
+        ViewClass: undefined,
+        template: this.compile('<p>BYE</p>')
+      },
+      outlets: Object.create(null)
+    };
 
-    this.runTask(() => this.top.setOutletState(routerState));
+    this.runTask(() => this.component.setOutletState(outletState));
 
     this.assertText('HIBYE');
   }

--- a/packages/ember-htmlbars/lib/keywords/outlet.js
+++ b/packages/ember-htmlbars/lib/keywords/outlet.js
@@ -3,8 +3,6 @@
 @submodule ember-templates
 */
 
-import { info } from 'ember-metal/debug';
-import { get } from 'ember-metal/property_get';
 import ViewNodeManager from 'ember-htmlbars/node-managers/view-node-manager';
 import topLevelViewTemplate from 'ember-htmlbars/templates/top-level-view';
 import isEnabled from 'ember-metal/features';
@@ -119,8 +117,7 @@ export default {
     let parentView = env.view;
     let outletState = state.outletState;
     let toRender = outletState.render;
-    let namespace = owner.lookup('application:main');
-    let LOG_VIEW_LOOKUPS = get(namespace, 'LOG_VIEW_LOOKUPS');
+
 
     let ViewClass = outletState.render.ViewClass;
 
@@ -142,10 +139,6 @@ export default {
     };
 
     let template = _template || toRender.template && toRender.template.raw;
-
-    if (LOG_VIEW_LOOKUPS && ViewClass) {
-      info('Rendering ' + toRender.name + ' with ' + ViewClass, { fullName: 'view:' + toRender.name });
-    }
 
     if (state.manager) {
       state.manager.destroy();

--- a/packages/ember-htmlbars/tests/integration/event-dispatcher-test.js
+++ b/packages/ember-htmlbars/tests/integration/event-dispatcher-test.js
@@ -1,0 +1,1 @@
+../../../ember-glimmer/tests/integration/event-dispatcher-test.js

--- a/packages/ember-htmlbars/tests/integration/outlet-test.js
+++ b/packages/ember-htmlbars/tests/integration/outlet-test.js
@@ -1,0 +1,1 @@
+../../../ember-glimmer/tests/integration/outlet-test.js


### PR DESCRIPTION
Symlink integration tests to htmlbars.

LOG_VIEW_LOOKUPS is done in the router

Ensure outlet state matches router.

TODO: extract building outlet states, also, I think ViewClass is no longer used by anything.
