### PR TITLE
[GLIMMER] Fix `Component#readDOMAttr`.

### DIFF
--- a/packages/ember-glimmer/lib/component.js
+++ b/packages/ember-glimmer/lib/component.js
@@ -20,6 +20,7 @@ import {
   PropertyReference
 } from './utils/references';
 import { DirtyableTag } from 'glimmer-reference';
+import { readDOMAttr } from 'glimmer-runtime';
 import { assert, deprecate } from 'ember-metal/debug';
 import { NAME_KEY } from 'ember-metal/mixin';
 import { getOwner } from 'container/owner';
@@ -116,8 +117,7 @@ const Component = CoreView.extend(
     },
 
     readDOMAttr(name) {
-      // TODO this is probably not correct
-      return this.element.getAttribute(name);
+      return readDOMAttr(this.element, name);
     },
 
     [TO_ROOT_REFERENCE]() {


### PR DESCRIPTION
There are a number of specific attributes that must be converted to properties after initial values. Using `this.readDOMAttr` was designed to assist with the `<input value="adf">` case (to prevent cursor position loss).  This migrates from the temporary `this.element.getAttribute` to the more fully featured `readDOMAttr` that is exported by `glimmer-runtime`.
