### PR TITLE
Refactor `{{#each}}` tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "git-repo-info": "^1.1.4",
     "git-repo-version": "^0.3.1",
     "github": "^0.2.3",
-    "glimmer-engine": "tildeio/glimmer#c48c75b",
+    "glimmer-engine": "tildeio/glimmer#5a11172",
     "glob": "^5.0.13",
     "htmlbars": "0.14.24",
     "mocha": "^2.4.5",

--- a/packages/ember-glimmer/lib/utils/iterable.js
+++ b/packages/ember-glimmer/lib/utils/iterable.js
@@ -165,20 +165,31 @@ class Iterable {
 
     if (isProxy(iterable)) {
       valueTag.update(CURRENT_TAG);
+      iterable = get(iterable, 'content');
     } else {
       valueTag.update(tagFor(iterable));
     }
 
     if (iterable === undefined || iterable === null) {
       return EMPTY_ITERATOR;
-    } else if (isEachIn(ref)) {
+    }
+
+    let typeofIterable = typeof iterable;
+
+    if (typeofIterable !== 'object' && typeofIterable !== 'function') {
+      return EMPTY_ITERATOR;
+    }
+
+    if (isEachIn(ref)) {
       let keys = Object.keys(iterable);
       let values = keys.map(key => iterable[key]);
       return keys.length > 0 ? new ObjectKeysIterator(keys, values, keyFor) : EMPTY_ITERATOR;
-    } else if (isEmberArray(iterable)) {
-      return new EmberArrayIterator(iterable, keyFor);
-    } else if (Array.isArray(iterable)) {
+    }
+
+    if (Array.isArray(iterable)) {
       return iterable.length > 0 ? new ArrayIterator(iterable, keyFor) : EMPTY_ITERATOR;
+    } else if (isEmberArray(iterable)) {
+      return get(iterable, 'length') > 0 ? new EmberArrayIterator(iterable, keyFor) : EMPTY_ITERATOR;
     } else if (typeof iterable.forEach === 'function') {
       let array = [];
       iterable.forEach(function(item) {
@@ -186,7 +197,7 @@ class Iterable {
       });
       return array.length > 0 ? new ArrayIterator(array, keyFor) : EMPTY_ITERATOR;
     } else {
-      throw new Error(`Don't know how to {{#each ${iterable}}}`);
+      return EMPTY_ITERATOR;
     }
   }
 

--- a/packages/ember-glimmer/tests/integration/helpers/if-unless-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/if-unless-test.js
@@ -1,7 +1,7 @@
 import { moduleFor } from '../../utils/test-case';
-import { TogglingHelperConditionalsTest } from '../../utils/shared-conditional-tests';
+import { IfUnlessHelperTest } from '../../utils/shared-conditional-tests';
 
-moduleFor('Helpers test: inline {{if}}', class extends TogglingHelperConditionalsTest {
+moduleFor('Helpers test: inline {{if}}', class extends IfUnlessHelperTest {
 
   templateFor({ cond, truthy, falsy }) {
     return `{{if ${cond} ${truthy} ${falsy}}}`;
@@ -21,7 +21,7 @@ moduleFor('Helpers test: inline {{if}}', class extends TogglingHelperConditional
 
 });
 
-moduleFor('Helpers test: nested {{if}} helpers (returning truthy values)', class extends TogglingHelperConditionalsTest {
+moduleFor('Helpers test: nested {{if}} helpers (returning truthy values)', class extends IfUnlessHelperTest {
 
   templateFor({ cond, truthy, falsy }) {
     return `{{if (if ${cond} ${cond} false) ${truthy} ${falsy}}}`;
@@ -29,7 +29,7 @@ moduleFor('Helpers test: nested {{if}} helpers (returning truthy values)', class
 
 });
 
-moduleFor('Helpers test: nested {{if}} helpers (returning falsy values)', class extends TogglingHelperConditionalsTest {
+moduleFor('Helpers test: nested {{if}} helpers (returning falsy values)', class extends IfUnlessHelperTest {
 
   templateFor({ cond, truthy, falsy }) {
     return `{{if (if ${cond} true ${cond}) ${truthy} ${falsy}}}`;
@@ -37,7 +37,7 @@ moduleFor('Helpers test: nested {{if}} helpers (returning falsy values)', class 
 
 });
 
-moduleFor('Helpers test: {{if}} used with another helper', class extends TogglingHelperConditionalsTest {
+moduleFor('Helpers test: {{if}} used with another helper', class extends IfUnlessHelperTest {
 
   wrapperFor(templates) {
     return `{{concat ${templates.join(' ')}}}`;
@@ -49,7 +49,7 @@ moduleFor('Helpers test: {{if}} used with another helper', class extends Togglin
 
 });
 
-moduleFor('@glimmer Helpers test: {{if}} used in attribute position', class extends TogglingHelperConditionalsTest {
+moduleFor('@glimmer Helpers test: {{if}} used in attribute position', class extends IfUnlessHelperTest {
 
   wrapperFor(templates) {
     return `<div data-foo="${templates.join('')}" />`;
@@ -65,7 +65,7 @@ moduleFor('@glimmer Helpers test: {{if}} used in attribute position', class exte
 
 });
 
-moduleFor('Helpers test: inline {{if}} and {{unless}} without the inverse argument', class extends TogglingHelperConditionalsTest {
+moduleFor('Helpers test: inline {{if}} and {{unless}} without the inverse argument', class extends IfUnlessHelperTest {
 
   templateFor({ cond, truthy, falsy }) {
     return `{{if ${cond} ${truthy}}}{{unless ${cond} ${falsy}}}`;
@@ -73,7 +73,7 @@ moduleFor('Helpers test: inline {{if}} and {{unless}} without the inverse argume
 
 });
 
-moduleFor('Helpers test: inline {{unless}}', class extends TogglingHelperConditionalsTest {
+moduleFor('Helpers test: inline {{unless}}', class extends IfUnlessHelperTest {
 
   templateFor({ cond, truthy, falsy }) {
     return `{{unless ${cond} ${falsy} ${truthy}}}`;
@@ -93,7 +93,7 @@ moduleFor('Helpers test: inline {{unless}}', class extends TogglingHelperConditi
 
 });
 
-moduleFor('@glimmer Helpers test: nested {{unless}} helpers (returning truthy values)', class extends TogglingHelperConditionalsTest {
+moduleFor('@glimmer Helpers test: nested {{unless}} helpers (returning truthy values)', class extends IfUnlessHelperTest {
 
   templateFor({ cond, truthy, falsy }) {
     return `{{unless (unless ${cond} false ${cond}) ${falsy} ${truthy}}}`;
@@ -101,7 +101,7 @@ moduleFor('@glimmer Helpers test: nested {{unless}} helpers (returning truthy va
 
 });
 
-moduleFor('@glimmer Helpers test: nested {{unless}} helpers (returning falsy values)', class extends TogglingHelperConditionalsTest {
+moduleFor('@glimmer Helpers test: nested {{unless}} helpers (returning falsy values)', class extends IfUnlessHelperTest {
 
   templateFor({ cond, truthy, falsy }) {
     return `{{unless (unless ${cond} ${cond} true) ${falsy} ${truthy}}}`;
@@ -109,7 +109,7 @@ moduleFor('@glimmer Helpers test: nested {{unless}} helpers (returning falsy val
 
 });
 
-moduleFor('@glimmer Helpers test: {{unless}} used with another helper', class extends TogglingHelperConditionalsTest {
+moduleFor('@glimmer Helpers test: {{unless}} used with another helper', class extends IfUnlessHelperTest {
 
   wrapperFor(templates) {
     return `{{concat ${templates.join(' ')}}}`;
@@ -121,7 +121,7 @@ moduleFor('@glimmer Helpers test: {{unless}} used with another helper', class ex
 
 });
 
-moduleFor('@glimmer Helpers test: {{unless}} used in attribute position', class extends TogglingHelperConditionalsTest {
+moduleFor('@glimmer Helpers test: {{unless}} used in attribute position', class extends IfUnlessHelperTest {
 
   wrapperFor(templates) {
     return `<div data-foo="${templates.join('')}" />`;

--- a/packages/ember-glimmer/tests/integration/syntax/each-in-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/each-in-test.js
@@ -14,12 +14,8 @@ import {
 
 class EachInTest extends TogglingSyntaxConditionalsTest {
 
-  get truthyValue() {
-    return { 'Not Empty': 1 };
-  }
-
-  get falsyValue() {
-    return {};
+  templateFor({ cond, truthy, falsy }) {
+    return `{{#each-in ${cond} as |key|}}${truthy}{{else}}${falsy}{{/each-in}}`;
   }
 
 }
@@ -34,12 +30,13 @@ class EmptyConstructor {}
 class NonEmptyConstructor {}
 NonEmptyConstructor.foo = 'bar';
 
-applyMixins(EachInTest,
+class BasicEachInTest extends EachInTest {}
+
+applyMixins(BasicEachInTest,
 
   new TruthyGenerator([
     { foo: 1 },
     EmberObject.create({ 'Not Empty': 1 }),
-    ObjectProxy.create({ content: { 'Not empty': 1 } }),
     [1],
     NonEmptyFunction,
     NonEmptyConstructor
@@ -48,12 +45,9 @@ applyMixins(EachInTest,
   new FalsyGenerator([
     null,
     undefined,
-    true,
     false,
     '',
-    'hello',
     0,
-    1,
     [],
     EmptyFunction,
     EmptyConstructor,
@@ -61,21 +55,18 @@ applyMixins(EachInTest,
     Object.create(null),
     Object.create({}),
     Object.create({ 'Not Empty': 1 }),
-    EmberObject.create(),
-    ObjectProxy.create(),
-    ObjectProxy.create({ content: null }),
-    ObjectProxy.create({ content: {} }),
-    ObjectProxy.create({ content: Object.create(null) }),
-    ObjectProxy.create({ content: Object.create({}) }),
-    ObjectProxy.create({ content: Object.create({ 'Not Empty': 1 }) }),
-    ObjectProxy.create({ content: EmberObject.create() })
+    EmberObject.create()
   ])
 );
 
-moduleFor('Syntax test: {{#each-in}}', class extends EachInTest {
+moduleFor('Syntax test: {{#each-in}}', class extends BasicEachInTest {
 
-  templateFor({ cond, truthy, falsy }) {
-    return `{{#each-in ${cond} as |key|}}${truthy}{{else}}${falsy}{{/each-in}}`;
+  get truthyValue() {
+    return { 'Not Empty': 1 };
+  }
+
+  get falsyValue() {
+    return {};
   }
 
   [`@test it repeats the given block for each item in the hash`]() {
@@ -362,6 +353,131 @@ moduleFor('Syntax test: {{#each-in}}', class extends EachInTest {
     this.runTask(() => set(this.context, 'arr', arr));
 
     this.assertText('[0:1][1:2][2:3][foo:bar]');
+  }
+
+});
+
+class EachInEdgeCasesTest extends EachInTest {}
+
+applyMixins(EachInEdgeCasesTest,
+
+  new FalsyGenerator([
+    true,
+    1,
+    'hello'
+  ])
+
+);
+
+moduleFor('@glimmer Syntax test: {{#each-in}} edge cases', class extends EachInEdgeCasesTest {
+
+  get truthyValue() {
+    return { 'Not Empty': 1 };
+  }
+
+  get falsyValue() {
+    return {};
+  }
+
+});
+
+class EachInProxyTest extends EachInTest {}
+
+applyMixins(EachInProxyTest,
+
+  new TruthyGenerator([
+    ObjectProxy.create({ content: { 'Not empty': 1 } })
+  ]),
+
+  new FalsyGenerator([
+    ObjectProxy.create(),
+    ObjectProxy.create({ content: null }),
+    ObjectProxy.create({ content: {} }),
+    ObjectProxy.create({ content: Object.create(null) }),
+    ObjectProxy.create({ content: Object.create({}) }),
+    ObjectProxy.create({ content: Object.create({ 'Not Empty': 1 }) }),
+    ObjectProxy.create({ content: EmberObject.create() })
+  ])
+);
+
+moduleFor('@glimmer Syntax test: {{#each-in}} with `ObjectProxy`', class extends EachInProxyTest {
+
+  get truthyValue() {
+    return ObjectProxy.create({ content: { 'Not Empty': 1 } });
+  }
+
+  get falsyValue() {
+    return ObjectProxy.create({ content: null });
+  }
+
+  ['@test it iterates over the content, not the proxy']() {
+    let content = {
+      'Smartphones': 8203,
+      'JavaScript Frameworks': Infinity
+    };
+
+    let proxy = ObjectProxy.create({
+      content,
+      foo: 'bar'
+    });
+
+    this.render(strip`
+      <ul>
+        {{#each-in categories as |category count|}}
+          <li>{{category}}: {{count}}</li>
+        {{/each-in}}
+      </ul>
+    `, { categories: proxy });
+
+    this.assertHTML(strip`
+      <ul>
+        <li>Smartphones: 8203</li>
+        <li>JavaScript Frameworks: Infinity</li>
+      </ul>
+    `);
+
+    this.assertStableRerender();
+
+    this.runTask(() => {
+      set(proxy, 'content.Smartphones', 100);
+      set(proxy, 'content.Tweets', 443115);
+    });
+
+    this.assertHTML(strip`
+      <ul>
+        <li>Smartphones: 100</li>
+        <li>JavaScript Frameworks: Infinity</li>
+        <li>Tweets: 443115</li>
+      </ul>
+    `);
+
+    this.runTask(() => {
+      set(proxy, 'content', {
+        'Smartphones': 100,
+        'Tablets': 20
+      });
+    });
+
+    this.assertHTML(strip`
+      <ul>
+        <li>Smartphones: 100</li>
+        <li>Tablets: 20</li>
+      </ul>
+    `);
+
+    this.runTask(() => set(this.context, 'categories', ObjectProxy.create({
+      content: {
+        'Smartphones': 8203,
+        'JavaScript Frameworks': Infinity
+      }
+    })));
+
+    this.assertHTML(strip`
+      <ul>
+        <li>Smartphones: 8203</li>
+        <li>JavaScript Frameworks: Infinity</li>
+      </ul>
+    `);
   }
 
 });

--- a/packages/ember-glimmer/tests/integration/syntax/each-in-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/each-in-test.js
@@ -19,34 +19,56 @@ class EachInTest extends TogglingSyntaxConditionalsTest {
   }
 
   get falsyValue() {
-    return false;
+    return {};
   }
 
 }
 
+function EmptyFunction() {}
+
+function NonEmptyFunction() {}
+NonEmptyFunction.foo = 'bar';
+
+class EmptyConstructor {}
+
+class NonEmptyConstructor {}
+NonEmptyConstructor.foo = 'bar';
+
 applyMixins(EachInTest,
 
   new TruthyGenerator([
-    // TODO: figure out what the rest of the cases are
     { foo: 1 },
     EmberObject.create({ 'Not Empty': 1 }),
     ObjectProxy.create({ content: { 'Not empty': 1 } }),
-    ObjectProxy.create({ content: Object.create({}) }),
-    ObjectProxy.create({ content: EmberObject.create() })
+    [1],
+    NonEmptyFunction,
+    NonEmptyConstructor
   ]),
 
   new FalsyGenerator([
-    // TODO: figure out what the rest of the cases are
-    {},
-    Object.create({ 'Not Empty': 1 }),
-    Object.create({}),
-    EmberObject.create(),
-    ObjectProxy.create({}),
-    // TODO: These 2 should be falsy but are returning true
-    //ObjectProxy.create({ content: null }),
-    //ObjectProxy.create({ content: {} }),
+    null,
     undefined,
-    null
+    true,
+    false,
+    '',
+    'hello',
+    0,
+    1,
+    [],
+    EmptyFunction,
+    EmptyConstructor,
+    {},
+    Object.create(null),
+    Object.create({}),
+    Object.create({ 'Not Empty': 1 }),
+    EmberObject.create(),
+    ObjectProxy.create(),
+    ObjectProxy.create({ content: null }),
+    ObjectProxy.create({ content: {} }),
+    ObjectProxy.create({ content: Object.create(null) }),
+    ObjectProxy.create({ content: Object.create({}) }),
+    ObjectProxy.create({ content: Object.create({ 'Not Empty': 1 }) }),
+    ObjectProxy.create({ content: EmberObject.create() })
   ])
 );
 

--- a/packages/ember-glimmer/tests/integration/syntax/each-in-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/each-in-test.js
@@ -7,27 +7,24 @@ import ObjectProxy from 'ember-runtime/system/object_proxy';
 import EmberObject from 'ember-runtime/system/object';
 
 import {
-  BasicConditionalsTest,
-  SyntaxCondtionalTestHelpers,
+  TogglingSyntaxConditionalsTest,
   TruthyGenerator,
   FalsyGenerator
 } from '../../utils/shared-conditional-tests';
 
-class EachInTest extends BasicConditionalsTest {
+class EachInTest extends TogglingSyntaxConditionalsTest {
 
   get truthyValue() {
     return { 'Not Empty': 1 };
   }
 
   get falsyValue() {
-    return {};
+    return false;
   }
 
 }
 
 applyMixins(EachInTest,
-
-  SyntaxCondtionalTestHelpers,
 
   new TruthyGenerator([
     // TODO: figure out what the rest of the cases are

--- a/packages/ember-glimmer/tests/integration/syntax/each-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/each-test.js
@@ -13,46 +13,6 @@ import {
   ArrayTestCases
 } from '../../utils/shared-conditional-tests';
 
-class TogglingEachTest extends TogglingSyntaxConditionalsTest {
-
-  get truthyValue() { return ['non-empty']; }
-  get falsyValue() { return []; }
-
-}
-
-applyMixins(TogglingEachTest,
-
-  new TruthyGenerator([
-    // TODO: figure out what the rest of the cases are
-    ['hello']
-  ]),
-
-  new FalsyGenerator([
-    // TODO: figure out what the rest of the cases are
-    [],
-    undefined
-  ]),
-
-  ArrayTestCases
-
-);
-
-moduleFor('Syntax test: toggling {{#each}}', class extends TogglingEachTest {
-
-  templateFor({ cond, truthy, falsy }) {
-    return `{{#each ${cond}}}${truthy}{{else}}${falsy}{{/each}}`;
-  }
-
-});
-
-moduleFor('Syntax test: toggling {{#each as}}', class extends TogglingEachTest {
-
-  templateFor({ cond, truthy, falsy }) {
-    return `{{#each ${cond} as |test|}}${truthy}{{else}}${falsy}{{/each}}`;
-  }
-
-});
-
 class ArrayLike {
   constructor(content) {
     this._array = content;
@@ -130,6 +90,61 @@ class ArrayLike {
   }
 
 }
+
+class TogglingEachTest extends TogglingSyntaxConditionalsTest {
+
+  get truthyValue() { return ['non-empty']; }
+  get falsyValue() { return []; }
+
+}
+
+applyMixins(TogglingEachTest,
+
+  new TruthyGenerator([
+    ['hello'],
+    emberA(['hello']),
+    new ArrayLike(['hello']),
+    ArrayProxy.create({ content: ['hello'] }),
+    ArrayProxy.create({ content: emberA(['hello']) })
+  ]),
+
+  new FalsyGenerator([
+    true,
+    false,
+    null,
+    undefined,
+    '',
+    0,
+    1,
+    Object,
+    function() {},
+    [],
+    {},
+    { foo: 'bar' },
+    Object.create(null),
+    Object.create({}),
+    Object.create({ foo: 'bar' })
+  ]),
+
+  ArrayTestCases
+
+);
+
+moduleFor('Syntax test: toggling {{#each}}', class extends TogglingEachTest {
+
+  templateFor({ cond, truthy, falsy }) {
+    return `{{#each ${cond}}}${truthy}{{else}}${falsy}{{/each}}`;
+  }
+
+});
+
+moduleFor('Syntax test: toggling {{#each as}}', class extends TogglingEachTest {
+
+  templateFor({ cond, truthy, falsy }) {
+    return `{{#each ${cond} as |test|}}${truthy}{{else}}${falsy}{{/each}}`;
+  }
+
+});
 
 class AbstractEachTest extends RenderingTest {
 

--- a/packages/ember-glimmer/tests/integration/syntax/each-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/each-test.js
@@ -98,7 +98,9 @@ class TogglingEachTest extends TogglingSyntaxConditionalsTest {
 
 }
 
-applyMixins(TogglingEachTest,
+class BasicEachTest extends TogglingEachTest {}
+
+applyMixins(BasicEachTest,
 
   new TruthyGenerator([
     ['hello'],
@@ -109,28 +111,19 @@ applyMixins(TogglingEachTest,
   ]),
 
   new FalsyGenerator([
-    true,
-    false,
     null,
     undefined,
+    false,
     '',
     0,
-    1,
-    Object,
-    function() {},
-    [],
-    {},
-    { foo: 'bar' },
-    Object.create(null),
-    Object.create({}),
-    Object.create({ foo: 'bar' })
+    []
   ]),
 
   ArrayTestCases
 
 );
 
-moduleFor('Syntax test: toggling {{#each}}', class extends TogglingEachTest {
+moduleFor('Syntax test: toggling {{#each}}', class extends BasicEachTest {
 
   templateFor({ cond, truthy, falsy }) {
     return `{{#each ${cond}}}${truthy}{{else}}${falsy}{{/each}}`;
@@ -138,7 +131,42 @@ moduleFor('Syntax test: toggling {{#each}}', class extends TogglingEachTest {
 
 });
 
-moduleFor('Syntax test: toggling {{#each as}}', class extends TogglingEachTest {
+moduleFor('Syntax test: toggling {{#each as}}', class extends BasicEachTest {
+
+  templateFor({ cond, truthy, falsy }) {
+    return `{{#each ${cond} as |test|}}${truthy}{{else}}${falsy}{{/each}}`;
+  }
+
+});
+
+class EachEdgeCasesTest extends TogglingEachTest {}
+
+applyMixins(EachEdgeCasesTest,
+
+  new FalsyGenerator([
+    true,
+    'hello',
+    1,
+    Object,
+    function() {},
+    {},
+    { foo: 'bar' },
+    Object.create(null),
+    Object.create({}),
+    Object.create({ foo: 'bar' })
+  ])
+
+);
+
+moduleFor('@glimmer Syntax test: toggling {{#each}}', class extends EachEdgeCasesTest {
+
+  templateFor({ cond, truthy, falsy }) {
+    return `{{#each ${cond}}}${truthy}{{else}}${falsy}{{/each}}`;
+  }
+
+});
+
+moduleFor('@glimmer Syntax test: toggling {{#each as}}', class extends EachEdgeCasesTest {
 
   templateFor({ cond, truthy, falsy }) {
     return `{{#each ${cond} as |test|}}${truthy}{{else}}${falsy}{{/each}}`;

--- a/packages/ember-glimmer/tests/integration/syntax/each-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/each-test.js
@@ -68,59 +68,64 @@ class ArrayLike {
 
   // The following methods are APIs used by the tests
 
-  clear() {
-    this._array.length = 0;
-    propertyDidChange(this, 'length');
-  }
-
   objectAt(idx) {
     return this._array[idx];
   }
 
+  clear() {
+    this._array.length = 0;
+    this.arrayContentDidChange();
+  }
+
   replace(idx, del, ins) {
     this._array.splice(idx, del, ...ins);
-    propertyDidChange(this, 'length');
+    this.arrayContentDidChange();
   }
 
   unshiftObject(obj) {
     this._array.unshift(obj);
-    propertyDidChange(this, 'length');
+    this.arrayContentDidChange();
   }
 
   unshiftObjects(arr) {
     this._array.unshift(...arr);
-    propertyDidChange(this, 'length');
+    this.arrayContentDidChange();
   }
 
   pushObject(obj) {
     this._array.push(obj);
-    propertyDidChange(this, 'length');
+    this.arrayContentDidChange();
   }
 
   pushObjects(arr) {
     this._array.push(...arr);
-    propertyDidChange(this, 'length');
+    this.arrayContentDidChange();
   }
 
   shiftObject() {
     let obj = this._array.shift();
-    propertyDidChange(this, 'length');
+    this.arrayContentDidChange();
     return obj;
   }
 
   popObject() {
     let obj = this._array.pop();
-    propertyDidChange(this, 'length');
+    this.arrayContentDidChange();
     return obj;
   }
 
   insertAt(idx, obj) {
     this._array.splice(idx, 0, obj);
-    propertyDidChange(this, 'length');
+    this.arrayContentDidChange();
   }
 
   removeAt(idx, len = 1) {
     this._array.splice(idx, len);
+    this.arrayContentDidChange();
+  }
+
+  arrayContentDidChange() {
+    propertyDidChange(this, '[]');
     propertyDidChange(this, 'length');
   }
 
@@ -571,18 +576,6 @@ moduleFor('Syntax test: {{#each}} with array-like objects', class extends Single
 
   makeList(list) {
     return this.list = new ArrayLike(list);
-  }
-
-  runTask(taskFunc) {
-    // This feature requires manual re-render in HTMLBars
-    if (this.isGlimmer) {
-      return super.runTask(taskFunc);
-    } else {
-      return super.runTask(() => {
-        taskFunc();
-        this.rerender();
-      });
-    }
   }
 
 });

--- a/packages/ember-glimmer/tests/integration/syntax/each-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/each-test.js
@@ -135,12 +135,60 @@ class AbstractEachTest extends RenderingTest {
 
   /* abstract */
   makeList() {
-    // this.list = ...;
+    // this.list = this.delegate = ...;
     throw new Error('Not implemented: `makeList`');
   }
 
   replaceList(list) {
     this.runTask(() => set(this.context, 'list', this.makeList(list)));
+  }
+
+  forEach(callback) {
+    return this.delegate.forEach(callback);
+  }
+
+  objectAt(idx) {
+    return this.delegate.objectAt(idx);
+  }
+
+  clear() {
+    return this.delegate.clear();
+  }
+
+  replace(idx, del, ins) {
+    return this.delegate.replace(idx, del, ins);
+  }
+
+  unshiftObject(obj) {
+    return this.delegate.unshiftObject(obj);
+  }
+
+  unshiftObjects(arr) {
+    return this.delegate.unshiftObjects(arr);
+  }
+
+  pushObject(obj) {
+    return this.delegate.pushObject(obj);
+  }
+
+  pushObjects(arr) {
+    return this.delegate.pushObjects(arr);
+  }
+
+  shiftObject() {
+    return this.delegate.shiftObject();
+  }
+
+  popObject() {
+    return this.delegate.popObject();
+  }
+
+  insertAt(idx, obj) {
+    return this.delegate.insertAt(idx, obj);
+  }
+
+  removeAt(idx, len) {
+    return this.delegate.removeAt(idx, len);
   }
 
   render(template, context = {}) {
@@ -158,7 +206,7 @@ class AbstractEachTest extends RenderingTest {
 class SingleEachTest extends AbstractEachTest {
 
   ['@test it repeats the given block for each item in the array']() {
-    let list = this.makeList([{ text: 'hello' }]);
+    this.makeList([{ text: 'hello' }]);
 
     this.render(`{{#each list as |item|}}{{item.text}}{{else}}Empty{{/each}}`);
 
@@ -168,52 +216,52 @@ class SingleEachTest extends AbstractEachTest {
 
     this.assertText('hello');
 
-    this.runTask(() => set(list.objectAt(0), 'text', 'Hello'));
+    this.runTask(() => set(this.objectAt(0), 'text', 'Hello'));
 
     this.assertText('Hello');
 
     this.runTask(() => {
-      list.pushObject({ text: ' ' });
-      list.pushObject({ text: 'World' });
+      this.pushObject({ text: ' ' });
+      this.pushObject({ text: 'World' });
     });
 
     this.assertText('Hello World');
 
     this.runTask(() => {
-      list.pushObject({ text: 'Earth' });
-      list.removeAt(1);
-      list.insertAt(1, { text: 'Globe' });
+      this.pushObject({ text: 'Earth' });
+      this.removeAt(1);
+      this.insertAt(1, { text: 'Globe' });
     });
 
     this.assertText('HelloGlobeWorldEarth');
 
     this.runTask(() => {
-      list.pushObject({ text: 'Planet' });
-      list.removeAt(1);
-      list.insertAt(1, { text: ' ' });
-      list.pushObject({ text: ' ' });
-      list.pushObject({ text: 'Earth' });
-      list.removeAt(3);
+      this.pushObject({ text: 'Planet' });
+      this.removeAt(1);
+      this.insertAt(1, { text: ' ' });
+      this.pushObject({ text: ' ' });
+      this.pushObject({ text: 'Earth' });
+      this.removeAt(3);
     });
 
     this.assertText('Hello WorldPlanet Earth');
 
     this.runTask(() => {
-      list.pushObject({ text: 'Globe' });
-      list.removeAt(1);
-      list.insertAt(1, { text: ' ' });
-      list.pushObject({ text: ' ' });
-      list.pushObject({ text: 'World' });
-      list.removeAt(2);
+      this.pushObject({ text: 'Globe' });
+      this.removeAt(1);
+      this.insertAt(1, { text: ' ' });
+      this.pushObject({ text: ' ' });
+      this.pushObject({ text: 'World' });
+      this.removeAt(2);
     });
 
     this.assertText('Hello Planet EarthGlobe World');
 
-    this.runTask(() => list.replace(2, 4, { text: 'my' }));
+    this.runTask(() => this.replace(2, 4, { text: 'my' }));
 
     this.assertText('Hello my World');
 
-    this.runTask(() => list.clear());
+    this.runTask(() => this.clear());
 
     this.assertText('Empty');
 
@@ -223,7 +271,7 @@ class SingleEachTest extends AbstractEachTest {
   }
 
   ['@test it receives the index as the second parameter']() {
-    let list = this.makeList([{ text: 'hello' }, { text: 'world' }]);
+    this.makeList([{ text: 'hello' }, { text: 'world' }]);
 
     this.render(`{{#each list as |item index|}}[{{index}}. {{item.text}}]{{/each}}`);
 
@@ -231,7 +279,7 @@ class SingleEachTest extends AbstractEachTest {
 
     this.assertStableRerender();
 
-    this.runTask(() => list.insertAt(1, { text: 'my' }));
+    this.runTask(() => this.insertAt(1, { text: 'my' }));
 
     this.assertText('[0. hello][1. my][2. world]');
 
@@ -241,7 +289,7 @@ class SingleEachTest extends AbstractEachTest {
   }
 
   ['@test it accepts a string key']() {
-    let list = this.makeList([{ text: 'hello' }, { text: 'world' }]);
+    this.makeList([{ text: 'hello' }, { text: 'world' }]);
 
     this.render(`{{#each list key='text' as |item|}}{{item.text}}{{/each}}`);
 
@@ -249,7 +297,7 @@ class SingleEachTest extends AbstractEachTest {
 
     this.assertStableRerender();
 
-    this.runTask(() => list.pushObject({ text: 'again' }));
+    this.runTask(() => this.pushObject({ text: 'again' }));
 
     this.assertText('helloworldagain');
 
@@ -259,7 +307,7 @@ class SingleEachTest extends AbstractEachTest {
   }
 
   ['@test it accepts a numeric key']() {
-    let list = this.makeList([{ id: 1 }, { id: 2 }]);
+    this.makeList([{ id: 1 }, { id: 2 }]);
 
     this.render(`{{#each list key='id' as |item|}}{{item.id}}{{/each}}`);
 
@@ -267,7 +315,7 @@ class SingleEachTest extends AbstractEachTest {
 
     this.assertStableRerender();
 
-    this.runTask(() => list.pushObject({ id: 3 }));
+    this.runTask(() => this.pushObject({ id: 3 }));
 
     this.assertText('123');
 
@@ -277,7 +325,7 @@ class SingleEachTest extends AbstractEachTest {
   }
 
   ['@test it can specify @index as the key']() {
-    let list = this.makeList([{ id: 1 }, { id: 2 }]);
+    this.makeList([{ id: 1 }, { id: 2 }]);
 
     this.render(`{{#each list key='@index' as |item|}}{{item.id}}{{/each}}`);
 
@@ -285,7 +333,7 @@ class SingleEachTest extends AbstractEachTest {
 
     this.assertStableRerender();
 
-    this.runTask(() => list.pushObject({ id: 3 }));
+    this.runTask(() => this.pushObject({ id: 3 }));
 
     this.assertText('123');
 
@@ -295,7 +343,7 @@ class SingleEachTest extends AbstractEachTest {
   }
 
   ['@test it can specify @identity as the key for arrays of primitives']() {
-    let list = this.makeList([1, 2]);
+    this.makeList([1, 2]);
 
     this.render(`{{#each list key='@identity' as |item|}}{{item}}{{/each}}`);
 
@@ -303,7 +351,7 @@ class SingleEachTest extends AbstractEachTest {
 
     this.assertStableRerender();
 
-    this.runTask(() => list.pushObject(3));
+    this.runTask(() => this.pushObject(3));
 
     this.assertText('123');
 
@@ -313,7 +361,7 @@ class SingleEachTest extends AbstractEachTest {
   }
 
   ['@test it can specify @identity as the key for mixed arrays of objects and primitives']() {
-    let list = this.makeList([1, { id: 2 }, 3]);
+    this.makeList([1, { id: 2 }, 3]);
 
     this.render(`{{#each list key='@identity' as |item|}}{{if item.id item.id item}}{{/each}}`);
 
@@ -321,7 +369,7 @@ class SingleEachTest extends AbstractEachTest {
 
     this.assertStableRerender();
 
-    this.runTask(() => list.insertAt(2, { id: 4 }));
+    this.runTask(() => this.insertAt(2, { id: 4 }));
 
     this.assertText('1243');
 
@@ -331,7 +379,7 @@ class SingleEachTest extends AbstractEachTest {
   }
 
   ['@test it can render duplicate primitive items']() {
-    let list = this.makeList(['a', 'a', 'a']);
+    this.makeList(['a', 'a', 'a']);
 
     this.render(`{{#each list as |item|}}{{item}}{{/each}}`);
 
@@ -339,11 +387,11 @@ class SingleEachTest extends AbstractEachTest {
 
     this.assertStableRerender();
 
-    this.runTask(() => list.pushObject('a'));
+    this.runTask(() => this.pushObject('a'));
 
     this.assertText('aaaa');
 
-    this.runTask(() => list.pushObject('a'));
+    this.runTask(() => this.pushObject('a'));
 
     this.assertText('aaaaa');
 
@@ -355,7 +403,7 @@ class SingleEachTest extends AbstractEachTest {
   ['@test it can render duplicate objects']() {
     let duplicateItem = { text: 'foo' };
 
-    let list = this.makeList([duplicateItem, duplicateItem, { text: 'bar' }, { text: 'baz' }]);
+    this.makeList([duplicateItem, duplicateItem, { text: 'bar' }, { text: 'baz' }]);
 
     this.render(`{{#each list as |item|}}{{item.text}}{{/each}}`);
 
@@ -363,11 +411,11 @@ class SingleEachTest extends AbstractEachTest {
 
     this.assertStableRerender();
 
-    this.runTask(() => list.pushObject(duplicateItem));
+    this.runTask(() => this.pushObject(duplicateItem));
 
     this.assertText('foofoobarbazfoo');
 
-    this.runTask(() => list.pushObject(duplicateItem));
+    this.runTask(() => this.pushObject(duplicateItem));
 
     this.assertText('foofoobarbazfoofoo');
 
@@ -377,7 +425,7 @@ class SingleEachTest extends AbstractEachTest {
   }
 
   [`@test it maintains DOM stability when condition changes between objects with the same keys`]() {
-    let list = this.makeList([{ text: 'Hello' }, { text: ' ' }, { text: 'world' }]);
+    this.makeList([{ text: 'Hello' }, { text: ' ' }, { text: 'world' }]);
 
     this.render(`{{#each list key="text" as |item|}}{{item.text}}{{/each}}`);
 
@@ -386,10 +434,10 @@ class SingleEachTest extends AbstractEachTest {
     this.takeSnapshot();
 
     this.runTask(() => {
-      list.popObject();
-      list.popObject();
-      list.pushObject({ text: ' ' });
-      list.pushObject({ text: 'world' });
+      this.popObject();
+      this.popObject();
+      this.pushObject({ text: ' ' });
+      this.pushObject({ text: 'world' });
     });
 
     this.assertText('Hello world');
@@ -404,7 +452,7 @@ class SingleEachTest extends AbstractEachTest {
   }
 
   [`@test it maintains DOM stability for stable keys when list is updated`]() {
-    let list = this.makeList([{ text: 'Hello' }, { text: ' ' }, { text: 'world' }]);
+    this.makeList([{ text: 'Hello' }, { text: ' ' }, { text: 'world' }]);
 
     this.render(`{{#each list key="text" as |item|}}{{item.text}}{{/each}}`);
 
@@ -412,13 +460,13 @@ class SingleEachTest extends AbstractEachTest {
 
     this.assertStableRerender();
 
-    let oldSnapshot = this.snapshot;
+    let oldSnapshot = this.takeSnapshot();
 
     this.runTask(() => {
-      list.unshiftObject({ text: ', ' });
-      list.unshiftObject({ text: 'Hi' });
-      list.pushObject({ text: '!' });
-      list.pushObject({ text: 'earth' });
+      this.unshiftObject({ text: ', ' });
+      this.unshiftObject({ text: 'Hi' });
+      this.pushObject({ text: '!' });
+      this.pushObject({ text: 'earth' });
     });
 
     this.assertText('Hi, Hello world!earth');
@@ -433,14 +481,14 @@ class SingleEachTest extends AbstractEachTest {
   }
 
   [`@test it renders all items with duplicate key values`]() {
-    let list = this.makeList([{ text: 'Hello' }, { text: 'Hello' }, { text: 'Hello' }]);
+    this.makeList([{ text: 'Hello' }, { text: 'Hello' }, { text: 'Hello' }]);
 
     this.render(`{{#each list key="text" as |item|}}{{item.text}}{{/each}}`);
 
     this.assertText('HelloHelloHello');
 
     this.runTask(() => {
-      list.forEach(hash => set(hash, 'text', 'Goodbye'));
+      this.forEach(hash => set(hash, 'text', 'Goodbye'));
     });
 
     this.assertText('GoodbyeGoodbyeGoodbye');
@@ -451,7 +499,7 @@ class SingleEachTest extends AbstractEachTest {
   }
 
   ['@test context is not changed to the inner scope inside an {{#each as}} block']() {
-    let list = this.makeList([{ name: 'Chad' }, { name: 'Zack' }, { name: 'Asa' }]);
+    this.makeList([{ name: 'Chad' }, { name: 'Zack' }, { name: 'Asa' }]);
 
     this.render(`{{name}}-{{#each list as |person|}}{{name}}{{/each}}-{{name}}`, {
       name: 'Joel'
@@ -461,7 +509,7 @@ class SingleEachTest extends AbstractEachTest {
 
     this.assertStableRerender();
 
-    this.runTask(() => list.shiftObject());
+    this.runTask(() => this.shiftObject());
 
     this.assertText('Joel-JoelJoel-Joel');
 
@@ -476,7 +524,7 @@ class SingleEachTest extends AbstractEachTest {
   }
 
   ['@test can access the item and the original scope']() {
-    let list = this.makeList([{ name: 'Tom Dale' }, { name: 'Yehuda Katz' }, { name: 'Godfrey Chan' }]);
+    this.makeList([{ name: 'Tom Dale' }, { name: 'Yehuda Katz' }, { name: 'Godfrey Chan' }]);
 
     this.render(`{{#each list key="name" as |person|}}[{{title}}: {{person.name}}]{{/each}}`, {
       title: 'Señor Engineer'
@@ -489,10 +537,10 @@ class SingleEachTest extends AbstractEachTest {
     this.assertText('[Señor Engineer: Tom Dale][Señor Engineer: Yehuda Katz][Señor Engineer: Godfrey Chan]');
 
     this.runTask(() => {
-      set(list.objectAt(1), 'name', 'Stefan Penner');
-      list.removeAt(0);
-      list.pushObject({ name: 'Tom Dale' });
-      list.insertAt(1, { name: 'Chad Hietala' });
+      set(this.objectAt(1), 'name', 'Stefan Penner');
+      this.removeAt(0);
+      this.pushObject({ name: 'Tom Dale' });
+      this.insertAt(1, { name: 'Chad Hietala' });
       set(this.context, 'title', 'Principal Engineer');
     });
 
@@ -505,7 +553,7 @@ class SingleEachTest extends AbstractEachTest {
   }
 
   ['@test the scoped variable is not available outside the {{#each}} block.']() {
-    let list = this.makeList(['Yehuda']);
+    this.makeList(['Yehuda']);
 
     this.render(`{{name}}-{{#each list as |name|}}{{name}}{{/each}}-{{name}}`, {
       name: 'Stef'
@@ -517,7 +565,7 @@ class SingleEachTest extends AbstractEachTest {
 
     this.assertText('Stef-Yehuda-Stef');
 
-    this.runTask(() => list.pushObjects([' ', 'Katz']));
+    this.runTask(() => this.pushObjects([' ', 'Katz']));
 
     this.assertText('Stef-Yehuda Katz-Stef');
 
@@ -532,7 +580,7 @@ class SingleEachTest extends AbstractEachTest {
   }
 
   ['@test inverse template is displayed with context']() {
-    let list = this.makeList([]);
+    this.makeList([]);
 
     this.render(`{{#each list as |thing|}}Has Thing{{else}}No Thing {{otherThing}}{{/each}}`, {
       otherThing: 'bar'
@@ -548,7 +596,7 @@ class SingleEachTest extends AbstractEachTest {
 
     this.assertText('No Thing biz');
 
-    this.runTask(() => list.pushObject('non-empty'));
+    this.runTask(() => this.pushObject('non-empty'));
 
     this.assertText('Has Thing');
 
@@ -567,7 +615,7 @@ class SingleEachTest extends AbstractEachTest {
 moduleFor('Syntax test: {{#each}} with arrays', class extends SingleEachTest {
 
   makeList(list) {
-    return this.list = emberA(list);
+    return this.list = this.delegate = emberA(list);
   }
 
 });
@@ -575,15 +623,15 @@ moduleFor('Syntax test: {{#each}} with arrays', class extends SingleEachTest {
 moduleFor('Syntax test: {{#each}} with array-like objects', class extends SingleEachTest {
 
   makeList(list) {
-    return this.list = new ArrayLike(list);
+    return this.list = this.delegate = new ArrayLike(list);
   }
 
 });
 
-moduleFor('Syntax test: {{#each}} with array proxies, replacing itself', class extends SingleEachTest {
+moduleFor('Syntax test: {{#each}} with array proxies, modifying itself', class extends SingleEachTest {
 
   makeList(list) {
-    return this.list = ArrayProxy.create({ content: emberA(list) });
+    return this.list = this.delegate = ArrayProxy.create({ content: emberA(list) });
   }
 
 });
@@ -591,7 +639,8 @@ moduleFor('Syntax test: {{#each}} with array proxies, replacing itself', class e
 moduleFor('Syntax test: {{#each}} with array proxies, replacing its content', class extends SingleEachTest {
 
   makeList(list) {
-    return this.list = ArrayProxy.create({ content: emberA(list) });
+    let content = this.delegate = emberA(list);
+    return this.list = ArrayProxy.create({ content });
   }
 
   replaceList(list) {

--- a/packages/ember-glimmer/tests/integration/syntax/if-unless-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/if-unless-test.js
@@ -4,9 +4,9 @@ import { set } from 'ember-metal/property_set';
 import { strip } from '../../utils/abstract-test-case';
 
 import { RenderingTest, moduleFor } from '../../utils/test-case';
-import { TogglingSyntaxConditionalsTest } from '../../utils/shared-conditional-tests';
+import { IfUnlessWithSyntaxTest } from '../../utils/shared-conditional-tests';
 
-moduleFor('Syntax test: {{#if}} with inverse', class extends TogglingSyntaxConditionalsTest {
+moduleFor('Syntax test: {{#if}} with inverse', class extends IfUnlessWithSyntaxTest {
 
   templateFor({ cond, truthy, falsy }) {
     return `{{#if ${cond}}}${truthy}{{else}}${falsy}{{/if}}`;
@@ -14,7 +14,7 @@ moduleFor('Syntax test: {{#if}} with inverse', class extends TogglingSyntaxCondi
 
 });
 
-moduleFor('Syntax test: {{#unless}} with inverse', class extends TogglingSyntaxConditionalsTest {
+moduleFor('Syntax test: {{#unless}} with inverse', class extends IfUnlessWithSyntaxTest {
 
   templateFor({ cond, truthy, falsy }) {
     return `{{#unless ${cond}}}${falsy}{{else}}${truthy}{{/unless}}`;
@@ -22,7 +22,7 @@ moduleFor('Syntax test: {{#unless}} with inverse', class extends TogglingSyntaxC
 
 });
 
-moduleFor('Syntax test: {{#if}} and {{#unless}} without inverse', class extends TogglingSyntaxConditionalsTest {
+moduleFor('Syntax test: {{#if}} and {{#unless}} without inverse', class extends IfUnlessWithSyntaxTest {
 
   templateFor({ cond, truthy, falsy }) {
     return `{{#if ${cond}}}${truthy}{{/if}}{{#unless ${cond}}}${falsy}{{/unless}}`;

--- a/packages/ember-glimmer/tests/integration/syntax/with-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/with-test.js
@@ -2,12 +2,12 @@ import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
 import { A as emberA } from 'ember-runtime/system/native_array';
 import { moduleFor, RenderingTest } from '../../utils/test-case';
-import { TogglingSyntaxConditionalsTest } from '../../utils/shared-conditional-tests';
+import { IfUnlessWithSyntaxTest } from '../../utils/shared-conditional-tests';
 import { strip } from '../../utils/abstract-test-case';
 import ObjectProxy from 'ember-runtime/system/object_proxy';
 import { removeAt } from 'ember-runtime/mixins/mutable_array';
 
-moduleFor('Syntax test: {{#with}}', class extends TogglingSyntaxConditionalsTest {
+moduleFor('Syntax test: {{#with}}', class extends IfUnlessWithSyntaxTest {
 
   templateFor({ cond, truthy, falsy }) {
     return `{{#with ${cond}}}${truthy}{{else}}${falsy}{{/with}}`;
@@ -15,7 +15,7 @@ moduleFor('Syntax test: {{#with}}', class extends TogglingSyntaxConditionalsTest
 
 });
 
-moduleFor('Syntax test: {{#with as}}', class extends TogglingSyntaxConditionalsTest {
+moduleFor('Syntax test: {{#with as}}', class extends IfUnlessWithSyntaxTest {
 
   templateFor({ cond, truthy, falsy }) {
     return `{{#with ${cond} as |test|}}${truthy}{{else}}${falsy}{{/with}}`;

--- a/packages/ember-glimmer/tests/utils/abstract-test-case.js
+++ b/packages/ember-glimmer/tests/utils/abstract-test-case.js
@@ -31,8 +31,8 @@ export function applyMixins(TestClass, ...mixins) {
       let generator = mixinOrGenerator;
       mixin = {};
 
-      generator.cases.forEach(value => {
-        assign(mixin, generator.generate(value));
+      generator.cases.forEach((value, idx) => {
+        assign(mixin, generator.generate(value, idx));
       });
     } else {
       mixin = mixinOrGenerator;

--- a/packages/ember-glimmer/tests/utils/shared-conditional-tests.js
+++ b/packages/ember-glimmer/tests/utils/shared-conditional-tests.js
@@ -44,7 +44,7 @@ class AbstractGenerator {
   }
 
   /* abstract */
-  generate(value) {
+  generate(value, idx) {
     throw new Error('Not implemented: `generate`');
   }
 
@@ -62,9 +62,9 @@ class AbstractGenerator {
 
 export class TruthyGenerator extends AbstractGenerator {
 
-  generate(value) {
+  generate(value, idx) {
     return {
-      [`@test it should consider ${JSON.stringify(value)} truthy`]() {
+      [`@test it should consider ${JSON.stringify(value)} truthy [${idx}]`]() {
         this.renderValues(value);
 
         this.assertText('T1');
@@ -88,9 +88,9 @@ export class TruthyGenerator extends AbstractGenerator {
 
 export class FalsyGenerator extends AbstractGenerator {
 
-  generate(value) {
+  generate(value, idx) {
     return {
-      [`@test it should consider ${JSON.stringify(value)} falsy`]() {
+      [`@test it should consider ${JSON.stringify(value)} falsy [${idx}]`]() {
         this.renderValues(value);
 
         this.assertText('F1');
@@ -114,9 +114,9 @@ export class FalsyGenerator extends AbstractGenerator {
 
 export class StableTruthyGenerator extends TruthyGenerator {
 
-  generate(value) {
-    return assign(super.generate(value), {
-      [`@test it maintains DOM stability when condition changes from ${value} to another truthy value and back`]() {
+  generate(value, idx) {
+    return assign(super.generate(value, idx), {
+      [`@test it maintains DOM stability when condition changes from ${value} to another truthy value and back [${idx}]`]() {
         this.renderValues(value);
 
         this.assertText('T1');
@@ -142,9 +142,9 @@ export class StableTruthyGenerator extends TruthyGenerator {
 
 export class StableFalsyGenerator extends FalsyGenerator {
 
-  generate(value) {
+  generate(value, idx) {
     return assign(super.generate(value), {
-      [`@test it maintains DOM stability when condition changes from ${value} to another falsy value and back`]() {
+      [`@test it maintains DOM stability when condition changes from ${value} to another falsy value and back [${idx}]`]() {
         this.renderValues(value);
 
         this.assertText('F1');
@@ -170,12 +170,12 @@ export class StableFalsyGenerator extends FalsyGenerator {
 
 class ObjectProxyGenerator extends AbstractGenerator {
 
-  generate(value) {
+  generate(value, idx) {
     // This is inconsistent with our usual to-bool policy, but the current proxy implementation
     // simply uses !!content to determine truthiness
     if (value) {
       return {
-        [`@test it should consider an object proxy with \`${JSON.stringify(value)}\` truthy`]() {
+        [`@test it should consider an object proxy with \`${JSON.stringify(value)}\` truthy [${idx}]`]() {
           this.renderValues(ObjectProxy.create({ content: value }));
 
           this.assertText('T1');
@@ -195,7 +195,7 @@ class ObjectProxyGenerator extends AbstractGenerator {
       };
     } else {
       return {
-        [`@test it should consider an object proxy with \`${JSON.stringify(value)}\` falsy`]() {
+        [`@test it should consider an object proxy with \`${JSON.stringify(value)}\` falsy [${idx}]`]() {
           this.renderValues(ObjectProxy.create({ content: value }));
 
           this.assertText('F1');

--- a/packages/ember-glimmer/tests/utils/shared-conditional-tests.js
+++ b/packages/ember-glimmer/tests/utils/shared-conditional-tests.js
@@ -395,11 +395,7 @@ export const ArrayTestCases = {
 
 };
 
-// Testing behaviors shared across the "toggling" conditionals, i.e. {{#if}},
-// {{#unless}}, {{#with}}, (if) and (unless)
-export class TogglingConditionalsTest extends BasicConditionalsTest {}
-
-applyMixins(TogglingConditionalsTest,
+const IfUnlessWithTestCases = [
 
   new StableTruthyGenerator([
     true,
@@ -474,7 +470,11 @@ applyMixins(TogglingConditionalsTest,
 
   ArrayTestCases
 
-);
+];
+
+// Testing behaviors shared across the "toggling" conditionals, i.e. {{#if}},
+// {{#unless}}, {{#with}}, {{#each}}, {{#each-in}}, (if) and (unless)
+export class TogglingConditionalsTest extends BasicConditionalsTest {}
 
 // Testing behaviors shared across the (if) and (unless) helpers
 export class TogglingHelperConditionalsTest extends TogglingConditionalsTest {
@@ -492,6 +492,44 @@ export class TogglingHelperConditionalsTest extends TogglingConditionalsTest {
 
     let wrappedTemplate = this.wrapperFor(templates);
     this.render(wrappedTemplate, context);
+  }
+
+  ['@test it has access to the outer scope from both templates']() {
+    let template = this.wrapperFor([
+      this.templateFor({ cond: 'cond1', truthy: 'truthy', falsy: 'falsy' }),
+      this.templateFor({ cond: 'cond2', truthy: 'truthy', falsy: 'falsy' })
+    ]);
+
+    this.render(template, { cond1: this.truthyValue, cond2: this.falsyValue, truthy: 'YES', falsy: 'NO' });
+
+    this.assertText('YESNO');
+
+    this.runTask(() => this.rerender());
+
+    this.assertText('YESNO');
+
+    this.runTask(() => {
+      set(this.context, 'truthy', 'YASS');
+      set(this.context, 'falsy', 'NOPE');
+    });
+
+    this.assertText('YASSNOPE');
+
+    this.runTask(() => {
+      set(this.context, 'cond1', this.falsyValue);
+      set(this.context, 'cond2', this.truthyValue);
+    });
+
+    this.assertText('NOPEYASS');
+
+    this.runTask(() => {
+      set(this.context, 'truthy', 'YES');
+      set(this.context, 'falsy', 'NO');
+      set(this.context, 'cond1', this.truthyValue);
+      set(this.context, 'cond2', this.falsyValue);
+    });
+
+    this.assertText('YESNO');
   }
 
   ['@test it does not update when the unbound helper is used']() {
@@ -582,7 +620,13 @@ export class TogglingHelperConditionalsTest extends TogglingConditionalsTest {
 
 }
 
-export const SyntaxCondtionalTestHelpers = {
+export class IfUnlessHelperTest extends TogglingHelperConditionalsTest {}
+
+applyMixins(IfUnlessHelperTest, ...IfUnlessWithTestCases);
+
+// Testing behaviors shared across the "toggling" syntatical constructs,
+// i.e. {{#if}}, {{#unless}}, {{#with}}, {{#each}} and {{#each-in}}
+export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
 
   renderValues(...values) {
     let templates = [];
@@ -597,12 +641,6 @@ export const SyntaxCondtionalTestHelpers = {
     this.render(wrappedTemplate, assign({ t: 'T', f: 'F' }, context));
   }
 
-};
-
-// Testing behaviors shared across the "toggling" syntatical constructs,
-// i.e. {{#if}}, {{#unless}} and {{#with}}
-export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
-
   ['@test it does not update when the unbound helper is used']() {
     let template = `${
       this.templateFor({ cond: '(unbound cond1)', truthy: 'T1', falsy: 'F1' })
@@ -610,7 +648,7 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
       this.templateFor({ cond: '(unbound cond2)', truthy: 'T2', falsy: 'F2' })
     }`;
 
-    this.render(template, { cond1: true, cond2: this.falsyValue });
+    this.render(template, { cond1: this.truthyValue, cond2: this.falsyValue });
 
     this.assertText('T1F2');
 
@@ -635,6 +673,44 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
     });
 
     this.assertText('T1F2');
+  }
+
+  ['@test it has access to the outer scope from both templates']() {
+    let template = this.wrapperFor([
+      this.templateFor({ cond: 'cond1', truthy: '{{truthy}}', falsy: '{{falsy}}' }),
+      this.templateFor({ cond: 'cond2', truthy: '{{truthy}}', falsy: '{{falsy}}' })
+    ]);
+
+    this.render(template, { cond1: this.truthyValue, cond2: this.falsyValue, truthy: 'YES', falsy: 'NO' });
+
+    this.assertText('YESNO');
+
+    this.runTask(() => this.rerender());
+
+    this.assertText('YESNO');
+
+    this.runTask(() => {
+      set(this.context, 'truthy', 'YASS');
+      set(this.context, 'falsy', 'NOPE');
+    });
+
+    this.assertText('YASSNOPE');
+
+    this.runTask(() => {
+      set(this.context, 'cond1', this.falsyValue);
+      set(this.context, 'cond2', this.truthyValue);
+    });
+
+    this.assertText('NOPEYASS');
+
+    this.runTask(() => {
+      set(this.context, 'truthy', 'YES');
+      set(this.context, 'falsy', 'NO');
+      set(this.context, 'cond1', this.truthyValue);
+      set(this.context, 'cond2', this.falsyValue);
+    });
+
+    this.assertText('YESNO');
   }
 
   ['@test it updates correctly when enclosing another conditional']() {
@@ -822,4 +898,6 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
 
 }
 
-applyMixins(TogglingSyntaxConditionalsTest, SyntaxCondtionalTestHelpers);
+export class IfUnlessWithSyntaxTest extends TogglingSyntaxConditionalsTest {}
+
+applyMixins(IfUnlessWithSyntaxTest, ...IfUnlessWithTestCases);

--- a/packages/ember-glimmer/tests/utils/shared-conditional-tests.js
+++ b/packages/ember-glimmer/tests/utils/shared-conditional-tests.js
@@ -412,6 +412,8 @@ const IfUnlessWithTestCases = [
     EmberObject.create(),
     EmberObject.create({ foo: 'bar' }),
     ObjectProxy.create({ content: true }),
+    Object,
+    function() {},
     /*jshint -W053 */
     new String('hello'),
     new String(''),
@@ -715,7 +717,8 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
 
   ['@test it updates correctly when enclosing another conditional']() {
     // This tests whether the outer conditional tracks its bounds correctly as its inner bounds changes
-    let template = this.wrappedTemplateFor({ cond: 'outer', truthy: '{{#if inner}}T-inner{{else}}F-inner{{/if}}', falsy: 'F-outer' });
+    let inner = this.templateFor({ cond: 'inner', truthy: 'T-inner', falsy: 'F-inner' });
+    let template = this.wrappedTemplateFor({ cond: 'outer', truthy: inner, falsy: 'F-outer' });
 
     this.render(template, { outer: this.truthyValue, inner: this.truthyValue });
 


### PR DESCRIPTION
- Refactor `TogglingConditionalsSyntaxTest`, so that `{{#each}}` and `{{#each-in}}` can share the same test cases with `{{#if}}`, `{{#unless}}` and `{{#with}}`
- Refactor most of the `{{#each}}` tests so that we can run them against `emberA`, array-like objects (objects with a `forEach` method) and array proxies
