### PR TITLE
[Bugfix Beta] Fix for auto-mut wrapping of closure actions.

### DIFF
--- a/packages/ember-glimmer/lib/helpers/action.js
+++ b/packages/ember-glimmer/lib/helpers/action.js
@@ -13,6 +13,7 @@ import {
 } from 'ember-metal';
 
 export const INVOKE = symbol('INVOKE');
+export const ACTION = symbol('ACTION');
 
 /**
   The `{{action}}` helper provides a way to pass triggers for behavior (usually
@@ -373,5 +374,6 @@ export function createClosureAction(target, action, valuePath, actionArgs) {
     };
   }
 
+  closureAction[ACTION] = true;
   return closureAction;
 }

--- a/packages/ember-glimmer/lib/utils/process-args.js
+++ b/packages/ember-glimmer/lib/utils/process-args.js
@@ -3,6 +3,7 @@ import { CONSTANT_TAG } from 'glimmer-reference';
 import { ARGS } from '../component';
 import { UPDATE } from './references';
 import { MUTABLE_CELL } from 'ember-views';
+import { ACTION } from '../helpers/action';
 
 export default function processArgs(args, positionalParamsDefinition) {
   if (!positionalParamsDefinition || positionalParamsDefinition.length === 0 || args.positional.length === 0) {
@@ -50,7 +51,9 @@ class SimpleArgs {
       let ref = namedArgs.get(name);
       let value = attrs[name];
 
-      if (ref[UPDATE]) {
+      if (typeof value === 'function' && value[ACTION]) {
+        attrs[name] = value;
+      } else if (ref[UPDATE]) {
         attrs[name] = new MutableCell(ref, value);
       }
 

--- a/packages/ember-glimmer/tests/integration/helpers/closure-action-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/closure-action-test.js
@@ -970,7 +970,7 @@ moduleFor('Helpers test: closure {{action}}', class extends RenderingTest {
     this.render('{{outer-component}}');
 
     this.runTask(() => {
-      innerComponent.fireAction();
+      actualReturnedValue = innerComponent.fireAction();
     });
 
     this.assert.equal(actualFirst, first, 'first argument is correct');

--- a/packages/ember-glimmer/tests/integration/helpers/closure-action-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/closure-action-test.js
@@ -912,7 +912,7 @@ moduleFor('Helpers test: closure {{action}}', class extends RenderingTest {
     this.assert.equal(actualValue, newValue, 'property is read');
   }
 
-  ['@test action closure does not get auto-mut wrapped']() {
+  ['@test action closure does not get auto-mut wrapped'](assert) {
     let first = 'raging robert';
     let second = 'mild machty';
     let returnValue = 'butch brian';
@@ -928,7 +928,14 @@ moduleFor('Helpers test: closure {{action}}', class extends RenderingTest {
         innerComponent = this;
       },
       fireAction() {
-        actualReturnedValue = this.attrs.submit(second);
+        this.get('submit')(second);
+        this.get('attrs-submit')(second);
+        let attrsSubmitReturnValue = this.attrs['attrs-submit'](second);
+        let submitReturnValue = this.attrs.submit(second);
+
+        assert.equal(attrsSubmitReturnValue, submitReturnValue, 'both attrs.foo and foo should behave the same');
+
+        return submitReturnValue;
       }
     });
 
@@ -952,7 +959,7 @@ moduleFor('Helpers test: closure {{action}}', class extends RenderingTest {
 
     this.registerComponent('middle-component', {
       ComponentClass: MiddleComponent,
-      template: `{{inner-component submit=attrs.submit}}`
+      template: `{{inner-component attrs-submit=attrs.submit submit=submit}}`
     });
 
     this.registerComponent('outer-component', {


### PR DESCRIPTION
Given the following:

``` hbs
{{x-foo derp=(action 'herk')}}
```

``` hbs
{{! app/templates/components/x-foo.hbs }}

{{x-bar derp=derp}}
```

``` js
export default Component.extend({
  didInsertElement() {
    this.get('derp')();
  }
});
```

An error is triggered with the following output:

```
TypeError: this.attrs.derp is not a function
    at Class.fireAction (http://localhost:7200/ember-tests.js:21306:46)
    at http://localhost:7200/ember-tests.js:21344:24
    at Object.run (http://localhost:7200/ember.debug.js:294:25)
    at Object.run [as default] (http://localhost:7200/ember.debug.js:19515:27)
    at _class2.runTask (http://localhost:7200/ember-tests.js:32041:34)
    at _class2.testActionClosureDoesNotGetAutoMutWrapped [as @test action closure does not get auto-mut wrapped] (http://localhost:7200/ember-tests.js:21343:12)
    at Object.<anonymous> (http://localhost:7200/ember-tests.js:31691:31)
    at runTest (http://localhost:7200/qunit/qunit.js:843:28)
    at Object.run (http://localhost:7200/qunit/qunit.js:828:4)
    at http://localhost:7200/qunit/qunit.js:970:11
```
