### PR TITLE
Deprecated slash-as-namespace

### DIFF
--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -4,7 +4,7 @@
 */
 
 import { dictionary } from 'ember-utils';
-import { assert, info, get } from 'ember-metal';
+import { assert, info, deprecate, get  } from 'ember-metal/debug';
 import {
   String as StringUtils,
   Object as EmberObject,
@@ -217,6 +217,10 @@ export default EmberObject.extend({
     let dirname = lastSlashIndex !== -1 ? name.slice(0, lastSlashIndex) : null;
 
     if (type !== 'template' && lastSlashIndex !== -1) {
+      deprecate(`Using / as a namespace, used by: "${name}"`, true, {
+        id: 'slash-as-namespace',
+        until: 'next LTS' // TODO
+      });
       let parts = name.split('/');
       name = parts[parts.length - 1];
       let namespaceName = StringUtils.capitalize(parts.slice(0, -1).join('.'));


### PR DESCRIPTION
This is a really old thing, that didn't really work (it is possible for some to use but, it comes at a cost), basically it allows resolving other global namespaces via the default resolver. But does so in a potentially ambiguous way `/` as namespace separate. In non-globals world, this isn't at all possible (well not without breaking non-globals features), as `/` is just part of the module name.

We have also remove support for it in other places, such as the `render` helper. Frankly I believe we just forgot about this code-path for 2.0.

The reason I would like to deprecate this, is a larger refactoring/reduction of [Ember.Namespace](https://github.com/emberjs/ember.js/blob/master/packages/ember-runtime/lib/system/namespace.js#) becomes possible. A surprising amount of code in ember is dedicated to globals mode toString creation. This include enumerating the global object, and naming globals based on how they are assigned to said global. 

My long term goal, would be to remove (or make optional when needed) code dedicates to globals mode.
- https://github.com/emberjs/ember.js/blob/master/packages/ember-runtime/lib/system/namespace.js#L88
- https://github.com/emberjs/ember.js/blob/master/packages/ember-runtime/lib/system/namespace.js#L97
- https://github.com/emberjs/ember.js/blob/master/packages/ember-runtime/lib/system/namespace.js#L101-L133
- https://github.com/emberjs/ember.js/blob/master/packages/ember-runtime/lib/system/namespace.js#L152-L231
- https://github.com/emberjs/ember.js/blob/master/packages/ember-runtime/lib/system/core_object.js#L517-L521

This by no means removes the ability to use globals with ember, but rather disables a feature that can no longer be taught, cannot be used in idiomatic apps. I suspect with a deprecate in-place we can gauge usage, and we can decide if a compat story is required.

If we know upfront a compat story is required, I can extra /w tests. 
- [ ] deprecation docs
- [ ] pick correct deprecation "until"
- [ ] get +1, or some path forward.
