### PR TITLE
[GLIMMER2] Cache component def until name changes

### DIFF
--- a/packages/ember-glimmer/lib/helpers/component.js
+++ b/packages/ember-glimmer/lib/helpers/component.js
@@ -29,15 +29,23 @@ export class ClosureComponentReference extends CachedReference {
     this.tag = args.positional.at(0).tag;
     this.parentMeta = parentMeta;
     this.args = args;
+    this.lastDefinition = undefined;
+    this.lastName = undefined;
   }
 
   compute() {
     // TODO: Figure out how to extract this because it's nearly identical to
     // DynamicComponentReference::compute(). The only differences besides
     // currying are in the assertion messages.
-    let { args, defRef, env, parentMeta } = this;
+    let { args, defRef, env, parentMeta, lastDefinition, lastName } = this;
     let nameOrDef = defRef.value();
     let definition = null;
+
+    if (nameOrDef && nameOrDef === lastName) {
+      return lastDefinition;
+    }
+
+    this.lastName = nameOrDef;
 
     if (typeof nameOrDef === 'string') {
       definition = env.getComponentDefinition([nameOrDef], parentMeta);
@@ -53,6 +61,8 @@ export class ClosureComponentReference extends CachedReference {
     }
 
     let newDef = createCurriedDefinition(definition, args);
+
+    this.lastDefinition = newDef;
 
     return newDef;
   }


### PR DESCRIPTION
Addresses an issue discovered in #13982. The `component` helper will now keep track of the value of its `nameRef` and when it changes it will construct a new definition, otherwise it returns the last definition it created. This is needed to avoid recomputing the definition when there is a false positive in the tag/reference system in Glimmer.

/cc @rwjblue @chancancode 
