### PR TITLE
[Glimmer 2] added failing test for #13955 "inline`classNameBindings` in`link-to` yields an exception"

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/class-bindings-test.js
+++ b/packages/ember-glimmer/tests/integration/components/class-bindings-test.js
@@ -7,7 +7,7 @@ import computed from 'ember-metal/computed';
 
 moduleFor('ClassNameBindings integration', class extends RenderingTest {
 
-  ['@test it can have class name bindings']() {
+  ['@test it can have class name bindings on the class definition']() {
     let FooBarComponent = Component.extend({
       classNameBindings: ['foo', 'isEnabled:enabled', 'isHappy:happy:sad']
     });
@@ -43,6 +43,58 @@ moduleFor('ClassNameBindings integration', class extends RenderingTest {
     });
 
     this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { 'class': classes('ember-view foo enabled sad') }, content: 'hello' });
+  }
+
+  ['@test it can have class name bindings in the template']() {
+    this.registerComponent('foo-bar', { template: 'hello' });
+
+    this.render('{{foo-bar classNameBindings="someInitiallyTrueProperty someInitiallyFalseProperty someInitiallyUndefinedProperty :static isBig:big isOpen:open:closed isUp::down"}}', {
+      someInitiallyTrueProperty: true,
+      someInitiallyFalseProperty: false,
+      isBig: true,
+      isOpen: false,
+      isUp: true
+    });
+
+    this.assertComponentElement(this.firstChild, {
+      attrs: { 'class': classes('ember-view some-initially-true-property static big closed') },
+      content: 'hello'
+    });
+
+    this.runTask(() => this.rerender());
+
+    this.assertComponentElement(this.firstChild, {
+      attrs: { 'class': classes('ember-view some-initially-true-property static big closed') },
+      content: 'hello'
+    });
+
+    this.runTask(() => {
+      set(this.context, 'someInitiallyTrueProperty', false);
+      set(this.context, 'someInitiallyFalseProperty', true);
+      set(this.context, 'someInitiallyUndefinedProperty', true);
+      set(this.context, 'isBig', false);
+      set(this.context, 'isOpen', true);
+      set(this.context, 'isUp', false);
+    });
+
+    this.assertComponentElement(this.firstChild, {
+      attrs: { 'class': classes('ember-view some-initially-false-property some-initially-undefined-property static open down') },
+      content: 'hello'
+    });
+
+    this.runTask(() => {
+      set(this.context, 'someInitiallyTrueProperty', true);
+      set(this.context, 'someInitiallyFalseProperty', false);
+      set(this.context, 'someInitiallyUndefinedProperty', undefined);
+      set(this.context, 'isBig', true);
+      set(this.context, 'isOpen', false);
+      set(this.context, 'isUp', true);
+    });
+
+    this.assertComponentElement(this.firstChild, {
+      attrs: { 'class': classes('ember-view some-initially-true-property static big closed') },
+      content: 'hello'
+    });
   }
 
   ['@test it can have class name bindings with nested paths']() {


### PR DESCRIPTION
Failing tests for https://github.com/emberjs/ember.js/issues/13955

<img width="1254" alt="screen shot 2016-08-04 at 12 34 59" src="https://cloud.githubusercontent.com/assets/2526/17400457/e5fb5d62-5a3f-11e6-8093-26bb95e7a26c.png">

I've added some details on why this might be happening here: https://github.com/emberjs/ember.js/issues/13955#issuecomment-237513127
