### PR TITLE
[BUGFIX] Pass environment options forward to Engines

### DIFF
--- a/packages/ember-application/lib/system/engine-instance.js
+++ b/packages/ember-application/lib/system/engine-instance.js
@@ -179,8 +179,12 @@ if (isEnabled('ember-application-engines')) {
       [
         'router:main',
         P`-bucket-cache:main`,
-        '-view-registry:main'
+        '-view-registry:main',
+        '-environment:main'
       ].forEach(key => this.register(key, parent.lookup(key), { instantiate: false }));
+
+      this.inject('view', '_environment', '-environment:main');
+      this.inject('route', '_environment', '-environment:main');
     }
   });
 }

--- a/packages/ember-application/tests/system/application_instance_test.js
+++ b/packages/ember-application/tests/system/application_instance_test.js
@@ -141,7 +141,7 @@ QUnit.test('unregistering a factory clears all cached instances of that factory'
 
 if (isEnabled('ember-application-engines')) {
   QUnit.test('can build and boot a registered engine', function(assert) {
-    assert.expect(7);
+    assert.expect(8);
 
     let ChatEngine = Engine.extend();
     let chatEngineInstance;
@@ -150,6 +150,7 @@ if (isEnabled('ember-application-engines')) {
 
     run(() => {
       appInstance = ApplicationInstance.create({ application });
+      appInstance.setupRegistry();
       chatEngineInstance = appInstance.buildChildEngineInstance('chat');
     });
 
@@ -171,7 +172,8 @@ if (isEnabled('ember-application-engines')) {
         [
           'router:main',
           P`-bucket-cache:main`,
-          '-view-registry:main'
+          '-view-registry:main',
+          '-environment:main'
         ].forEach(key => {
           assert.strictEqual(
             chatEngineInstance.lookup(key),

--- a/packages/ember-application/tests/system/visit_test.js
+++ b/packages/ember-application/tests/system/visit_test.js
@@ -4,6 +4,7 @@ import run from 'ember-metal/run_loop';
 import RSVP, { onerrorDefault } from 'ember-runtime/ext/rsvp';
 import Application from 'ember-application/system/application';
 import ApplicationInstance from 'ember-application/system/application-instance';
+import Engine from 'ember-application/system/engine';
 import Route from 'ember-routing/system/route';
 import Router from 'ember-routing/system/router';
 import Component from 'ember-templates/component';
@@ -336,6 +337,52 @@ QUnit.test('visit() returns a promise that resolves when the view has rendered',
   return run(App, 'visit', '/').then(instance => {
     assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
     assert.equal(jQuery('#qunit-fixture > .ember-view h1').text(), 'Hello world', 'the application was rendered once the promise resolves');
+  });
+});
+
+QUnit.test('visit() returns a promise that resolves without rendering when shouldRender is set to false', function(assert) {
+  assert.expect(3);
+
+  run(() => {
+    createApplication();
+
+    App.register('template:application', compile('<h1>Hello world</h1>'));
+  });
+
+  assert.strictEqual(jQuery('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
+
+  return run(App, 'visit', '/', { shouldRender: false }).then(instance => {
+    assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+    assert.strictEqual(jQuery('#qunit-fixture').children().length, 0, 'there are still no elements in the fixture element after visit');
+  });
+});
+
+QUnit.test('visit() returns a promise that resolves without rendering when shouldRender is set to false with Engines', function(assert) {
+  assert.expect(3);
+
+  run(() => {
+    createApplication();
+
+    App.register('template:application', compile('<h1>Hello world</h1>'));
+
+    // Register engine
+    let BlogEngine = Engine.extend();
+    App.register('engine:blog', BlogEngine);
+
+    // Register engine route map
+    let BlogMap = function() {};
+    App.register('route-map:blog', BlogMap);
+
+    App.Router.map(function() {
+      this.mount('blog');
+    });
+  });
+
+  assert.strictEqual(jQuery('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
+
+  return run(App, 'visit', '/blog', { shouldRender: false }).then(instance => {
+    assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+    assert.strictEqual(jQuery('#qunit-fixture').children().length, 0, 'there are still no elements in the fixture element after visit');
   });
 });
 

--- a/packages/ember-htmlbars/tests/integration/mount_test.js
+++ b/packages/ember-htmlbars/tests/integration/mount_test.js
@@ -40,6 +40,7 @@ function commonSetup() {
     app.register('component-lookup:main', ComponentLookup);
 
     appInstance = app.buildInstance();
+    appInstance.setupRegistry();
   });
 }
 


### PR DESCRIPTION
Addressing #14015.

There are two commits here. The first simply adds two tests to verify the behavior of `shouldRender: false` in the `visit` API. The latter of those tests failed with an error due to attempting to render when it shouldn't (as described in the issue).

The second commit fixes the failing test by passing `-environment:main` from the parent into an EngineInstance. This also resulted in needing to update some tests to setup the registry in an ApplicationInstance that constructs the EngineInstance. I assume this will always happen in a real application, so I figured it made sense to do in the tests.
