### PR TITLE
Correct -normalize-class and AST plugin

### DIFF
--- a/packages/ember-glimmer/lib/helpers/-normalize-class.js
+++ b/packages/ember-glimmer/lib/helpers/-normalize-class.js
@@ -2,40 +2,16 @@ import { InternalHelperReference } from '../utils/references';
 import { dasherize } from 'ember-runtime/system/string';
 
 function normalizeClass({ positional, named }) {
+  let classNameParts = positional.at(0).value().split('.');
+  let className = classNameParts[classNameParts.length - 1];
   let value = positional.at(1).value();
-  let activeClass = named.at('activeClass').value();
-  let inactiveClass = named.at('inactiveClass').value();
 
-  // When using the colon syntax, evaluate the truthiness or falsiness
-  // of the value to determine which className to return.
-  if (activeClass || inactiveClass) {
-    if (!!value) {
-      return activeClass;
-    } else {
-      return inactiveClass;
-    }
-
-  // If value is a Boolean and true, return the dasherized property
-  // name.
-  } else if (value === true) {
-    let propName = positional.at(0);
-    // Only apply to last segment in the path.
-    if (propName) {
-      let segments = propName.split('.');
-      propName = segments[segments.length - 1];
-    }
-
-    return dasherize(propName);
-
-  // If the value is not false, undefined, or null, return the current
-  // value of the property.
-  } else if (value !== false && value != null) {
-    return value;
-
-  // Nothing to display. Return null so that the old class is removed
-  // but no new class is added.
+  if (value === true) {
+    return dasherize(className);
+  } else if (!value && value !== 0) {
+    return '';
   } else {
-    return null;
+    return String(value);
   }
 }
 

--- a/packages/ember-glimmer/tests/integration/components/class-bindings-test.js
+++ b/packages/ember-glimmer/tests/integration/components/class-bindings-test.js
@@ -48,51 +48,58 @@ moduleFor('ClassNameBindings integration', class extends RenderingTest {
   ['@test it can have class name bindings in the template']() {
     this.registerComponent('foo-bar', { template: 'hello' });
 
-    this.render('{{foo-bar classNameBindings="someInitiallyTrueProperty someInitiallyFalseProperty someInitiallyUndefinedProperty :static isBig:big isOpen:open:closed isUp::down"}}', {
-      someInitiallyTrueProperty: true,
-      someInitiallyFalseProperty: false,
-      isBig: true,
-      isOpen: false,
-      isUp: true
+    this.render('{{foo-bar classNameBindings="model.someInitiallyTrueProperty model.someInitiallyFalseProperty model.someInitiallyUndefinedProperty :static model.isBig:big model.isOpen:open:closed model.isUp::down model.bar:isTruthy:isFalsy"}}', {
+      model: {
+        someInitiallyTrueProperty: true,
+        someInitiallyFalseProperty: false,
+        isBig: true,
+        isOpen: false,
+        isUp: true,
+        bar: true
+      }
     });
 
     this.assertComponentElement(this.firstChild, {
-      attrs: { 'class': classes('ember-view some-initially-true-property static big closed') },
+      attrs: { 'class': classes('ember-view some-initially-true-property static big closed isTruthy') },
       content: 'hello'
     });
 
     this.runTask(() => this.rerender());
 
     this.assertComponentElement(this.firstChild, {
-      attrs: { 'class': classes('ember-view some-initially-true-property static big closed') },
+      attrs: { 'class': classes('ember-view some-initially-true-property static big closed isTruthy') },
       content: 'hello'
     });
 
     this.runTask(() => {
-      set(this.context, 'someInitiallyTrueProperty', false);
-      set(this.context, 'someInitiallyFalseProperty', true);
-      set(this.context, 'someInitiallyUndefinedProperty', true);
-      set(this.context, 'isBig', false);
-      set(this.context, 'isOpen', true);
-      set(this.context, 'isUp', false);
+      set(this.context, 'model.someInitiallyTrueProperty', false);
+      set(this.context, 'model.someInitiallyFalseProperty', true);
+      set(this.context, 'model.someInitiallyUndefinedProperty', true);
+      set(this.context, 'model.isBig', false);
+      set(this.context, 'model.isOpen', true);
+      set(this.context, 'model.isUp', false);
+      set(this.context, 'model.bar', false);
     });
 
     this.assertComponentElement(this.firstChild, {
-      attrs: { 'class': classes('ember-view some-initially-false-property some-initially-undefined-property static open down') },
+      attrs: { 'class': classes('ember-view some-initially-false-property some-initially-undefined-property static open down isFalsy') },
       content: 'hello'
     });
 
     this.runTask(() => {
-      set(this.context, 'someInitiallyTrueProperty', true);
-      set(this.context, 'someInitiallyFalseProperty', false);
-      set(this.context, 'someInitiallyUndefinedProperty', undefined);
-      set(this.context, 'isBig', true);
-      set(this.context, 'isOpen', false);
-      set(this.context, 'isUp', true);
+      set(this.context, 'model', {
+        someInitiallyTrueProperty: true,
+        someInitiallyFalseProperty: false,
+        someInitiallyUndefinedProperty: undefined,
+        isBig: true,
+        isOpen: false,
+        isUp: true,
+        bar: true
+      });
     });
 
     this.assertComponentElement(this.firstChild, {
-      attrs: { 'class': classes('ember-view some-initially-true-property static big closed') },
+      attrs: { 'class': classes('ember-view some-initially-true-property static big closed isTruthy') },
       content: 'hello'
     });
   }

--- a/packages/ember-glimmer/tests/integration/components/class-bindings-test.js
+++ b/packages/ember-glimmer/tests/integration/components/class-bindings-test.js
@@ -7,7 +7,7 @@ import computed from 'ember-metal/computed';
 
 moduleFor('ClassNameBindings integration', class extends RenderingTest {
 
-  ['@test it can have class name bindings']() {
+  ['@test it can have class name bindings on the class definition']() {
     let FooBarComponent = Component.extend({
       classNameBindings: ['foo', 'isEnabled:enabled', 'isHappy:happy:sad']
     });
@@ -43,6 +43,58 @@ moduleFor('ClassNameBindings integration', class extends RenderingTest {
     });
 
     this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { 'class': classes('ember-view foo enabled sad') }, content: 'hello' });
+  }
+
+  ['@test it can have class name bindings in the template']() {
+    this.registerComponent('foo-bar', { template: 'hello' });
+
+    this.render('{{foo-bar classNameBindings="someInitiallyTrueProperty someInitiallyFalseProperty someInitiallyUndefinedProperty :static isBig:big isOpen:open:closed isUp::down"}}', {
+      someInitiallyTrueProperty: true,
+      someInitiallyFalseProperty: false,
+      isBig: true,
+      isOpen: false,
+      isUp: true
+    });
+
+    this.assertComponentElement(this.firstChild, {
+      attrs: { 'class': classes('ember-view some-initially-true-property static big closed') },
+      content: 'hello'
+    });
+
+    this.runTask(() => this.rerender());
+
+    this.assertComponentElement(this.firstChild, {
+      attrs: { 'class': classes('ember-view some-initially-true-property static big closed') },
+      content: 'hello'
+    });
+
+    this.runTask(() => {
+      set(this.context, 'someInitiallyTrueProperty', false);
+      set(this.context, 'someInitiallyFalseProperty', true);
+      set(this.context, 'someInitiallyUndefinedProperty', true);
+      set(this.context, 'isBig', false);
+      set(this.context, 'isOpen', true);
+      set(this.context, 'isUp', false);
+    });
+
+    this.assertComponentElement(this.firstChild, {
+      attrs: { 'class': classes('ember-view some-initially-false-property some-initially-undefined-property static open down') },
+      content: 'hello'
+    });
+
+    this.runTask(() => {
+      set(this.context, 'someInitiallyTrueProperty', true);
+      set(this.context, 'someInitiallyFalseProperty', false);
+      set(this.context, 'someInitiallyUndefinedProperty', undefined);
+      set(this.context, 'isBig', true);
+      set(this.context, 'isOpen', false);
+      set(this.context, 'isUp', true);
+    });
+
+    this.assertComponentElement(this.firstChild, {
+      attrs: { 'class': classes('ember-view some-initially-true-property static big closed') },
+      content: 'hello'
+    });
   }
 
   ['@test it can have class name bindings with nested paths']() {

--- a/packages/ember-template-compiler/lib/plugins/transform-old-class-binding-syntax.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-old-class-binding-syntax.js
@@ -87,7 +87,7 @@ function buildSexprs(microsyntax, sexprs, b) {
           hash.pairs.push(b.pair('inactiveClass', b.string(inactiveClass)));
         }
 
-        params.push(b.sexpr(b.string('-normalize-class'), sexprParams, hash));
+        params.push(b.sexpr(b.path('-normalize-class'), sexprParams, hash));
       }
 
       if (inactiveClass || inactiveClass === '') {


### PR DESCRIPTION
Codegen in HTMLBars seemed ok with PathExpressions being StringLiterals, however sense we have an interpreter in Glimmer these semantics actually matter. Also in Glimmer we appear to be actually expanding the AST into an sexpr with only positional args for `-normalize-class`.
