### PR TITLE
[BUGFIX beta] `fillIn` only sets value to first match.

### DIFF
--- a/packages/ember-testing/lib/helpers/fill_in.js
+++ b/packages/ember-testing/lib/helpers/fill_in.js
@@ -11,7 +11,7 @@ export default function fillIn(app, selector, contextOrText, text) {
   el = $el[0];
   focus(el);
 
-  $el.val(text);
+  $el.eq(0).val(text);
   fireEvent(el, 'input');
   fireEvent(el, 'change');
 

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -722,6 +722,28 @@ QUnit.test('`fillIn` fires `input` and `change` events in the proper order', fun
   return wait();
 });
 
+QUnit.test('`fillIn` only sets the value in the first matched element', function() {
+  let fillIn, find, visit, andThen, wait;
+
+  setTemplate('index', compile('<input type="text" id="first" class="in-test"><input type="text" id="second" class="in-test">'));
+  run(App, App.advanceReadiness);
+
+  fillIn = App.testHelpers.fillIn;
+  find = App.testHelpers.find;
+  visit = App.testHelpers.visit;
+  andThen = App.testHelpers.andThen;
+  wait = App.testHelpers.wait;
+
+  visit('/');
+  fillIn('input.in-test', 'new value');
+  andThen(function() {
+    equal(find('#first').val(), 'new value');
+    equal(find('#second').val(), '');
+  });
+
+  return wait();
+});
+
 QUnit.test('`triggerEvent accepts an optional options hash and context', function() {
   expect(3);
 


### PR DESCRIPTION
Currently, `fillIn` sets the new value to all matches, though the events are
only fired for the first one, making Ember only aware of that one.

This can cause a problem while trying to _debug_ a test.

Fixes #14018
