### PR TITLE
Use `didReceiveAttrs` (instead of `willRender`) in `{{link-to}}`

### DIFF
--- a/packages/ember-htmlbars/lib/components/link-to.js
+++ b/packages/ember-htmlbars/lib/components/link-to.js
@@ -767,7 +767,7 @@ const LinkComponent = EmberComponent.extend({
   */
   loadingHref: '#',
 
-  willRender() {
+  didReceiveAttrs() {
     let queryParams;
 
     let params = get(this, 'params');


### PR DESCRIPTION
This code only need to run when the arguments/attrs change, not before every re-render. At least on the Glimmer side, the latter run more often than the first, so this is unnecessarily doing a bunch of extra work, invalidating expensive CPs, etc.
