### PR TITLE
[DOC release] Boolean `attributeBindings` documentation updated

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -255,7 +255,7 @@ import ViewMixin from 'ember-views/mixins/view_support';
   ```
 
   If the return value of an `attributeBindings` monitored property is a boolean
-  the property's value will be set as a coerced string:
+  the attribute will be present or absent depending on the value:
 
   ```javascript
   MyTextInput = Ember.View.extend({
@@ -268,7 +268,7 @@ import ViewMixin from 'ember-views/mixins/view_support';
   Will result in a view instance with an HTML representation of:
 
   ```html
-  <input id="ember1" class="ember-view" disabled="false" />
+  <input id="ember1" class="ember-view" />
   ```
 
   `attributeBindings` can refer to computed properties:


### PR DESCRIPTION
From [HTML5, A vocabulary and associated APIs for HTML and
XHTML](https://www.w3.org/TR/html5/infrastructure.html#boolean-attributes):

```
A number of attributes are boolean attributes. The presence of a boolean
attribute on an element represents the true value, and the absence of the
attribute represents the false value.

**Note:** The values "true" and "false" are not allowed on boolean
attributes. To represent a false value, the attribute has to be omitted
altogether.
```

Fixes #14024
