### PR TITLE
More robustly fully scope query params

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -791,6 +791,10 @@ const EmberRouter = EmberObject.extend(Evented, {
     var handlerInfos = state.handlerInfos;
     stashParamNames(this, handlerInfos);
 
+    if (typeof queryParams === 'undefined') {
+      return;
+    }
+
     for (var i = 0, len = handlerInfos.length; i < len; ++i) {
       var route = handlerInfos[i].handler;
       var qpMeta = get(route, '_qp');

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -3389,3 +3389,37 @@ QUnit.test('handle routes names that clash with Object.prototype properties', fu
   let controller = container.lookup('controller:constructor');
   equal(get(controller, 'foo'), '999');
 });
+
+QUnit.test('undefined queryParams is treated as empty object', function() {
+  expect(1);
+
+  App.Router.map(function() {
+    this.route('foo');
+    this.route('bar');
+  });
+
+  App.FooRoute = Route.extend({
+    beforeModel() {
+      this.transitionTo('bar', { queryParams: undefined });
+    }
+  });
+
+  App.BarController = Controller.extend({
+    queryParams: ['a']
+  });
+
+  App.BarRoute = Route.extend({
+    queryParams: {
+      a: {
+        defaultValue: 'xyz'
+      }
+    }
+  });
+
+  bootApplication();
+
+  run(router, 'transitionTo', 'foo', { queryParams: { a: '123' } });
+
+  let barController = container.lookup('controller:bar');
+  equal(get(barController, 'a'), '123');
+});

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -3351,6 +3351,40 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
       promiseResolve();
     });
   });
+
+  QUnit.test('undefined queryParams is treated as empty object', function() {
+    expect(1);
+
+    App.Router.map(function() {
+      this.route('foo');
+      this.route('bar');
+    });
+
+    App.FooRoute = Route.extend({
+      beforeModel() {
+        this.transitionTo('bar', { queryParams: undefined });
+      }
+    });
+
+    App.BarController = Controller.extend({
+      queryParams: ['a']
+    });
+
+    App.BarRoute = Route.extend({
+      queryParams: {
+        a: {
+          defaultValue: 'xyz'
+        }
+      }
+    });
+
+    bootApplication();
+
+    run(router, 'transitionTo', 'foo', { queryParams: { a: '123' } });
+
+    let barController = container.lookup('controller:bar');
+    equal(get(barController, 'a'), '123');
+  });
 }
 
 QUnit.test('warn user that routes query params configuration must be an Object, not an Array', function() {
@@ -3388,38 +3422,4 @@ QUnit.test('handle routes names that clash with Object.prototype properties', fu
 
   let controller = container.lookup('controller:constructor');
   equal(get(controller, 'foo'), '999');
-});
-
-QUnit.test('undefined queryParams is treated as empty object', function() {
-  expect(1);
-
-  App.Router.map(function() {
-    this.route('foo');
-    this.route('bar');
-  });
-
-  App.FooRoute = Route.extend({
-    beforeModel() {
-      this.transitionTo('bar', { queryParams: undefined });
-    }
-  });
-
-  App.BarController = Controller.extend({
-    queryParams: ['a']
-  });
-
-  App.BarRoute = Route.extend({
-    queryParams: {
-      a: {
-        defaultValue: 'xyz'
-      }
-    }
-  });
-
-  bootApplication();
-
-  run(router, 'transitionTo', 'foo', { queryParams: { a: '123' } });
-
-  let barController = container.lookup('controller:bar');
-  equal(get(barController, 'a'), '123');
 });


### PR DESCRIPTION
Fixes #14010.

Unfortunately I can't add a test for this change, as I don't have a reliable reproduction for the bug. But in production I'm seeing exceptions indicating that `queryParams` is undefined in some cases, and it seems reasonable for this function to be robust to that case by shortcut-return.
