### PR TITLE
[GLIMMER2] Optimize {{property}} PropertyReference

### DIFF
--- a/packages/ember-glimmer/lib/component.js
+++ b/packages/ember-glimmer/lib/component.js
@@ -47,6 +47,7 @@ const Component = CoreView.extend(
 
     init() {
       this._super(...arguments);
+      this[IS_DISPATCHING_ATTRS] = false;
       this[DIRTY_TAG] = new DirtyableTag();
       this[ROOT_REF] = null;
       this[REFS] = new EmptyObject();
@@ -94,8 +95,6 @@ const Component = CoreView.extend(
     __defineNonEnumerable(property) {
       this[property.name] = property.descriptor.value;
     },
-
-    [IS_DISPATCHING_ATTRS]: false,
 
     [PROPERTY_DID_CHANGE](key) {
       if (this[IS_DISPATCHING_ATTRS]) { return; }

--- a/packages/ember-glimmer/lib/component.js
+++ b/packages/ember-glimmer/lib/component.js
@@ -17,7 +17,7 @@ import {
   TO_ROOT_REFERENCE,
   REFERENCE_FOR_KEY,
   RootReference,
-  PropertyReference
+  RootPropertyReference
 } from './utils/references';
 import { DirtyableTag } from 'glimmer-reference';
 import { readDOMAttr } from 'glimmer-runtime';
@@ -137,7 +137,7 @@ const Component = CoreView.extend(
       if (ref) {
         return ref;
       } else {
-        return refs[key] = new PropertyReference(this[TO_ROOT_REFERENCE](), key);
+        return refs[key] = new RootPropertyReference(this, key);
       }
     }
   }

--- a/packages/ember-glimmer/lib/component.js
+++ b/packages/ember-glimmer/lib/component.js
@@ -8,17 +8,10 @@ import ViewMixin from 'ember-views/mixins/view_support';
 import ActionSupport from 'ember-views/mixins/action_support';
 import TargetActionSupport from 'ember-runtime/mixins/target_action_support';
 import symbol from 'ember-metal/symbol';
-import EmptyObject from 'ember-metal/empty_object';
 import { get } from 'ember-metal/property_get';
 import { PROPERTY_DID_CHANGE } from 'ember-metal/property_events';
 import { getAttrFor } from 'ember-views/compat/attrs-proxy';
-import {
-  UPDATE,
-  TO_ROOT_REFERENCE,
-  REFERENCE_FOR_KEY,
-  RootReference,
-  RootPropertyReference
-} from './utils/references';
+import { UPDATE, RootReference } from './utils/references';
 import { DirtyableTag } from 'glimmer-reference';
 import { readDOMAttr } from 'glimmer-runtime';
 import { assert, deprecate } from 'ember-metal/debug';
@@ -28,7 +21,6 @@ import { getOwner } from 'container/owner';
 export const DIRTY_TAG = symbol('DIRTY_TAG');
 export const ARGS = symbol('ARGS');
 export const ROOT_REF = symbol('ROOT_REF');
-export const REFS = symbol('REFS');
 export const IS_DISPATCHING_ATTRS = symbol('IS_DISPATCHING_ATTRS');
 export const HAS_BLOCK = symbol('HAS_BLOCK');
 
@@ -49,8 +41,7 @@ const Component = CoreView.extend(
       this._super(...arguments);
       this[IS_DISPATCHING_ATTRS] = false;
       this[DIRTY_TAG] = new DirtyableTag();
-      this[ROOT_REF] = null;
-      this[REFS] = new EmptyObject();
+      this[ROOT_REF] = new RootReference(this);
 
       // If a `defaultLayout` was specified move it to the `layout` prop.
       // `layout` is no longer a CP, so this just ensures that the `defaultLayout`
@@ -117,27 +108,6 @@ const Component = CoreView.extend(
 
     readDOMAttr(name) {
       return readDOMAttr(this.element, name);
-    },
-
-    [TO_ROOT_REFERENCE]() {
-      let ref = this[ROOT_REF];
-
-      if (!ref) {
-        ref = this[ROOT_REF] = new RootReference(this);
-      }
-
-      return ref;
-    },
-
-    [REFERENCE_FOR_KEY](key) {
-      let refs = this[REFS];
-      let ref = refs[key];
-
-      if (ref) {
-        return ref;
-      } else {
-        return refs[key] = new RootPropertyReference(this, key);
-      }
     }
   }
 );

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -1,7 +1,6 @@
 import { StatementSyntax, ValueReference, EvaluatedArgs, EvaluatedNamedArgs, EvaluatedPositionalArgs } from 'glimmer-runtime';
-import { TO_ROOT_REFERENCE } from '../utils/references';
 import { AttributeBinding, ClassNameBinding, IsVisibleBinding } from '../utils/bindings';
-import { DIRTY_TAG, IS_DISPATCHING_ATTRS, HAS_BLOCK } from '../component';
+import { ROOT_REF, DIRTY_TAG, IS_DISPATCHING_ATTRS, HAS_BLOCK } from '../component';
 import { assert, runInDebug } from 'ember-metal/debug';
 import processArgs from '../utils/process-args';
 import { privatize as P } from 'container/registry';
@@ -224,7 +223,7 @@ class CurlyComponentManager {
   }
 
   getSelf({ component }) {
-    return component[TO_ROOT_REFERENCE]();
+    return component[ROOT_REF];
   }
 
   didCreateElement({ component, classRef }, element, operations) {

--- a/packages/ember-glimmer/lib/utils/bindings.js
+++ b/packages/ember-glimmer/lib/utils/bindings.js
@@ -1,15 +1,15 @@
 import { assert } from 'ember-metal/debug';
 import { dasherize } from 'ember-runtime/system/string';
 import { CachedReference, map, referenceFromParts } from 'glimmer-reference';
-import { REFERENCE_FOR_KEY, TO_ROOT_REFERENCE } from './references';
+import { ROOT_REF } from '../component';
 import { htmlSafe, isHTMLSafe } from './string';
 
 function referenceForKey(component, key) {
-  return component[REFERENCE_FOR_KEY](key);
+  return component[ROOT_REF].get(key);
 }
 
 function referenceForParts(component, parts) {
-  return referenceFromParts(component[TO_ROOT_REFERENCE](), parts);
+  return referenceFromParts(component[ROOT_REF], parts);
 }
 
 export const AttributeBinding = {

--- a/packages/ember-glimmer/lib/utils/iterable.js
+++ b/packages/ember-glimmer/lib/utils/iterable.js
@@ -200,42 +200,18 @@ class EachInIterable extends AbstractIterable {
 
     let valueTag = this.valueTag = new UpdatableTag(CONSTANT_TAG);
 
-    this.wasProxy = false;
-    this.proxyWrapperTag = null;
-    this.proxyContentTag = null;
-
     this.tag = combine([ref.tag, valueTag]);
   }
 
   iterate() {
-    let { ref, keyFor, valueTag, wasProxy } = this;
+    let { ref, keyFor, valueTag } = this;
 
     let iterable = ref.value();
 
+    valueTag.update(tagFor(iterable));
+
     if (isProxy(iterable)) {
-      let proxy = iterable;
-      let content = get(proxy, 'content');
-
-      if (wasProxy) {
-        this.proxyWrapperTag.update(tagFor(proxy));
-        this.proxyContentTag.update(tagFor(content));
-      } else {
-        this.wasProxy = true;
-        let proxyWrapperTag = this.proxyWrapperTag = new UpdatableTag(tagFor(proxy));
-        let proxyContentTag = this.proxyContentTag = new UpdatableTag(tagFor(content));
-
-        valueTag.update(combine([proxyWrapperTag, proxyContentTag]));
-      }
-
-      iterable = content;
-    } else {
-      valueTag.update(tagFor(iterable));
-
-      if (wasProxy) {
-        this.wasProxy = true;
-        this.proxyWrapperTag = null;
-        this.proxyContentTag = null;
-      }
+      iterable = get(iterable, 'content');
     }
 
     let typeofIterable = typeof iterable;

--- a/packages/ember-metal/lib/tags.js
+++ b/packages/ember-metal/lib/tags.js
@@ -1,7 +1,8 @@
 import { meta as metaFor } from './meta';
 import require, { has } from 'require';
 
-let hasGlimmer = has('glimmer-reference');
+const hasGlimmer = has('glimmer-reference');
+
 let CONSTANT_TAG, CURRENT_TAG, DirtyableTag, makeTag, run;
 
 let hasViews = () => false;

--- a/packages/ember-metal/lib/transaction.js
+++ b/packages/ember-metal/lib/transaction.js
@@ -65,7 +65,7 @@ if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
           let label;
 
           if (lastRef) {
-            while (lastRef && lastRef._propertyKey && lastRef._parentReference) {
+            while (lastRef && lastRef._propertyKey) {
               parts.unshift(lastRef._propertyKey);
               lastRef = lastRef._parentReference;
             }

--- a/packages/ember-runtime/lib/mixins/-proxy.js
+++ b/packages/ember-runtime/lib/mixins/-proxy.js
@@ -18,9 +18,14 @@ import {
   propertyDidChange
 } from 'ember-metal/property_events';
 import { bool } from 'ember-runtime/computed/computed_macros';
+import { POST_INIT } from 'ember-runtime/system/core_object';
 import { defineProperty } from 'ember-metal/properties';
 import { Mixin, observer } from 'ember-metal/mixin';
+import { tagFor } from 'ember-metal/tags';
 import symbol from 'ember-metal/symbol';
+import require, { has } from 'require';
+
+const hasGlimmer = has('glimmer-reference');
 
 const IS_PROXY = symbol('IS_PROXY');
 
@@ -48,7 +53,7 @@ function contentPropertyDidChange(content, contentKey) {
   @namespace Ember
   @private
 */
-export default Mixin.create({
+const PROXY_MIXIN_PROPS = {
   [IS_PROXY]: true,
 
   /**
@@ -111,4 +116,40 @@ export default Mixin.create({
     );
     return set(content, key, value);
   }
-});
+};
+
+if (hasGlimmer) {
+  let { CachedTag, DirtyableTag, UpdatableTag } = require('glimmer-reference');
+
+  class ProxyTag extends CachedTag {
+    constructor(proxy, content) {
+      super();
+      this.proxyWrapperTag = new DirtyableTag();
+      this.proxyContentTag = new UpdatableTag(tagFor(content));
+    }
+
+    compute() {
+      return Math.max(this.proxyWrapperTag.value(), this.proxyContentTag.value());
+    }
+
+    dirty() {
+      this.proxyWrapperTag.dirty();
+    }
+
+    contentDidChange(content) {
+      this.proxyContentTag.update(tagFor(content));
+    }
+  }
+
+  PROXY_MIXIN_PROPS[POST_INIT] = function postInit() {
+    this._super();
+    meta(this)._tag = new ProxyTag(this, get(this, 'content'));
+  };
+
+  PROXY_MIXIN_PROPS._contentDidChange = observer('content', function() {
+    assert('Can\'t set Proxy\'s content to itself', get(this, 'content') !== this);
+    meta(this)._tag.contentDidChange(get(this, 'content'));
+  });
+}
+
+export default Mixin.create(PROXY_MIXIN_PROPS);

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -166,19 +166,7 @@ function makeCtor() {
 
     finishPartial(this, m);
 
-    if (arguments.length === 0) {
-      this.init();
-    } else if (arguments.length === 1) {
-      this.init(arguments[0]);
-    } else {
-      // v8 bug potentially incorrectly deopts this function: https://code.google.com/p/v8/issues/detail?id=3709
-      // we may want to keep this around till this ages out on mobile
-      var args = new Array(arguments.length);
-      for (var x = 0; x < arguments.length; x++) {
-        args[x] = arguments[x];
-      }
-      this.init.apply(this, args);
-    }
+    this.init.apply(this, arguments);
 
     this[POST_INIT]();
 

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -447,7 +447,7 @@ export default Mixin.create({
    @private
    */
   [POST_INIT]: function() {
-    this._super(...arguments);
+    this._super();
 
     assert(
       `You must call \`this._super(...arguments);\` when implementing \`init\` in a component. Please update ${this} to call \`this._super\` from \`init\`.`,


### PR DESCRIPTION
A quick survey in our app indicates ~77% of `PropertyReference` have a const parent. This is unsurprising, because most path lookup curlies are single-level (no dots in the path) lookup on the component directly.

This means we can do less work and book-keeping in those cases (checking if the parent is a proxy on every `compute`, etc).
