### PR TITLE
Restructure code to avoid awkward compilation

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -2266,9 +2266,9 @@ function deprecateQueryParamDefaultValuesSetOnController(controllerName, routeNa
 
   @private
 */
-function prefixRouteNameArg(...args) {
+function prefixRouteNameArg(route, args) {
   let routeName = args[0];
-  let owner = getOwner(this);
+  let owner = getOwner(route);
   let prefix = owner.mountPoint;
 
   // only alter the routeName if it's actually referencing a route.
@@ -2296,11 +2296,11 @@ function resemblesURL(str) {
 if (isEnabled('ember-application-engines')) {
   Route.reopen({
     replaceWith(...args) {
-      return this._super.apply(this, (prefixRouteNameArg.call(this, ...args)));
+      return this._super.apply(this, prefixRouteNameArg(this, args));
     },
 
     transitionTo(...args) {
-      return this._super.apply(this, (prefixRouteNameArg.call(this, ...args)));
+      return this._super.apply(this, prefixRouteNameArg(this, args));
     },
 
     modelFor(_routeName, ...args) {


### PR DESCRIPTION
Before:

``` js
Route.reopen({
  replaceWith: function () {
    for (var _len3 = arguments.length, args = Array(_len3), _key3 = 0; _key3 < _len3; _key3++) {
      args[_key3] = arguments[_key3];
    }

    return this._super.apply(this, prefixRouteNameArg.call.apply(prefixRouteNameArg, [this].concat(args)));
  },

  transitionTo: function () {
    for (var _len4 = arguments.length, args = Array(_len4), _key4 = 0; _key4 < _len4; _key4++) {
      args[_key4] = arguments[_key4];
    }

    return this._super.apply(this, prefixRouteNameArg.call.apply(prefixRouteNameArg, [this].concat(args)));
  },

  ...
});
```

After:

``` js
Route.reopen({
  replaceWith: function () {
    for (var _len3 = arguments.length, args = Array(_len3), _key3 = 0; _key3 < _len3; _key3++) {
      args[_key3] = arguments[_key3];
    }

    return this._super.apply(this, prefixRouteNameArg(this,args));
  },

  transitionTo: function () {
    for (var _len4 = arguments.length, args = Array(_len4), _key4 = 0; _key4 < _len4; _key4++) {
      args[_key4] = arguments[_key4];
    }

    return this._super.apply(this, prefixRouteNameArg(this,args));
  },

  ...
});
```

Which is more readable and avoid a needless allocation from the `concat`
(and presumably `.call.apply` is rather inefficient).

As a bonus, it also removes the splatting in `prefixRouteNameArg`.
