### PR TITLE
[BUGFIX Beta] Bump router.js so that getHandlers is invoked lazily

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "backburner": "https://github.com/ebryn/backburner.js.git#b893c979cb38f9819f65561725907add1aed7b21",
     "rsvp": "https://github.com/tildeio/rsvp.js.git#3.0.20",
-    "router.js": "https://github.com/tildeio/router.js.git#7f2f7c16540570ad2c720f9bd9a7a55e4bcdc95c",
+    "router.js": "https://github.com/tildeio/router.js.git#b921fd3407064a77bd99f4f4eddc4377592ac93b",
     "dag-map": "https://github.com/krisselden/dag-map.git#1.0.2",
     "ember-dev": "https://github.com/emberjs/ember-dev.git#eace5340485bdb5e4223ab67fecf4aff31c1940c"
   }


### PR DESCRIPTION
This picks up recent changes from router.js. In particular, it makes `getHandler` lazy so that the work is not done upfront if it can be deferred until later (as is needed for lazy Engines). [See the PR for the changes here](https://github.com/tildeio/router.js/pull/187).

It also picks up [the shaping fixes](https://github.com/tildeio/router.js/pull/181) that @chadhietala made.

cc/ @rwjblue 
