### PR TITLE
[BUGFIX beta] Ensure substates properly work with resetNamespace

### DIFF
--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -40,7 +40,7 @@ DSL.prototype = {
 
     if (this.enableLoadingSubstates) {
       createRoute(this, `${name}_loading`, { resetNamespace: options.resetNamespace });
-      createRoute(this, `${name}_error`, { path: dummyErrorRoute });
+      createRoute(this, `${name}_error`, { resetNamespace: options.resetNamespace, path: dummyErrorRoute });
     }
 
     if (callback) {
@@ -193,7 +193,7 @@ if (isEnabled('ember-application-engines')) {
     if (this.enableLoadingSubstates) {
       let dummyErrorRoute = `/_unused_dummy_error_path_route_${name}/:error`;
       createRoute(this, `${name}_loading`, { resetNamespace: options.resetNamespace });
-      createRoute(this, `${name}_error`, { path: dummyErrorRoute });
+      createRoute(this, `${name}_error`, { resetNamespace: options.resetNamespace, path: dummyErrorRoute });
     }
 
     let localFullName = 'application';

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -1014,16 +1014,24 @@ function findChildRouteName(parentRoute, originatingChildRoute, name) {
     }
   }
 
-  let targetChildRouteName = originatingChildRouteName.split('.').pop();
-  let namespace = parentRoute.routeName === 'application' ? '' : parentRoute.routeName + '.';
-
-  // First, try a named loading state, e.g. 'foo_loading'
-  childName = namespace + targetChildRouteName + '_' + name;
+  // First, try a named loading state of the route, e.g. 'foo_loading'
+  childName = originatingChildRouteName + '_' + name;
   if (routeHasBeenDefined(router, childName)) {
     return childName;
   }
 
-  // Second, try general loading state, e.g. 'loading'
+  // Second, try general loading state of the parent, e.g. 'loading'
+  let originatingChildRouteParts = originatingChildRouteName.split('.').slice(0, -1);
+  let namespace;
+
+  // If there is a namespace on the route, then we use that, otherwise we use
+  // the parent route as the namespace.
+  if (originatingChildRouteParts.length) {
+    namespace = originatingChildRouteParts.join('.') + '.';
+  } else {
+    namespace = parentRoute.routeName === 'application' ? '' : parentRoute.routeName + '.';
+  }
+
   childName = namespace + name;
   if (routeHasBeenDefined(router, childName)) {
     return childName;

--- a/packages/ember-routing/tests/system/dsl_test.js
+++ b/packages/ember-routing/tests/system/dsl_test.js
@@ -114,6 +114,33 @@ QUnit.test('should not add loading and error routes if _isRouterMapResult is fal
   ok(!router.router.recognizer.names['blork_error'], 'error route was not added');
 });
 
+QUnit.test('should reset namespace of loading and error routes for routes with resetNamespace', function() {
+  Router.map(function() {
+    this.route('blork', function() {
+      this.route('blorp');
+      this.route('bleep', { resetNamespace: true });
+    });
+  });
+
+  let router = Router.create({
+    _hasModuleBasedResolver() { return true; }
+  });
+
+  router._initRouterJs();
+
+  ok(router.router.recognizer.names['blork.blorp'], 'nested route was created');
+  ok(router.router.recognizer.names['blork.blorp_loading'], 'nested loading route was added');
+  ok(router.router.recognizer.names['blork.blorp_error'], 'nested error route was added');
+
+  ok(router.router.recognizer.names['bleep'], 'reset route was created');
+  ok(router.router.recognizer.names['bleep_loading'], 'reset loading route was added');
+  ok(router.router.recognizer.names['bleep_error'], 'reset error route was added');
+
+  ok(!router.router.recognizer.names['blork.bleep'], 'nested reset route was not created');
+  ok(!router.router.recognizer.names['blork.bleep_loading'], 'nested reset loading route was not added');
+  ok(!router.router.recognizer.names['blork.bleep_error'], 'nested reset error route was not added');
+});
+
 if (isEnabled('ember-application-engines')) {
   QUnit.test('should throw an error when defining a route serializer outside an engine', function() {
     Router.map(function() {
@@ -266,5 +293,36 @@ if (isEnabled('ember-application-engines')) {
     ok(router.router.recognizer.names['chat'], 'main route was created');
     ok(!router.router.recognizer.names['chat_loading'], 'loading route was not added');
     ok(!router.router.recognizer.names['chat_error'], 'error route was not added');
+  });
+
+  QUnit.test('should reset namespace of loading and error routes for mounts with resetNamespace', function() {
+    Router.map(function() {
+      this.route('news', function() {
+        this.mount('chat');
+        this.mount('blog', { resetNamespace: true });
+      });
+    });
+
+    let engineInstance = buildOwner({
+      routable: true
+    });
+
+    let router = Router.create({
+      _hasModuleBasedResolver() { return true; }
+    });
+    setOwner(router, engineInstance);
+    router._initRouterJs();
+
+    ok(router.router.recognizer.names['news.chat'], 'nested route was created');
+    ok(router.router.recognizer.names['news.chat_loading'], 'nested loading route was added');
+    ok(router.router.recognizer.names['news.chat_error'], 'nested error route was added');
+
+    ok(router.router.recognizer.names['blog'], 'reset route was created');
+    ok(router.router.recognizer.names['blog_loading'], 'reset loading route was added');
+    ok(router.router.recognizer.names['blog_error'], 'reset error route was added');
+
+    ok(!router.router.recognizer.names['news.blog'], 'nested reset route was not created');
+    ok(!router.router.recognizer.names['news.blog_loading'], 'nested reset loading route was not added');
+    ok(!router.router.recognizer.names['news.blog_error'], 'nested reset error route was not added');
   });
 }


### PR DESCRIPTION
This fixes two apparent issues with substates. The first was discovered when [enabling substates for the `mount` keyword](https://github.com/emberjs/ember.js/pull/13818), but while fixing that a second seems to have been uncovered.

When looking up substates, the `findChildRouteName` method was always applying the parent route's namespace, even if the current route had `resetNamespace` applied. Some of the tests even seemed to be explicitly working around this issue (such as [here](https://github.com/emberjs/ember.js/blob/6558db677105a15efda5f35dcc7d9a70beff1984/packages/ember/tests/routing/substates_test.js#L797-L801) and [here](https://github.com/emberjs/ember.js/blob/6558db677105a15efda5f35dcc7d9a70beff1984/packages/ember/tests/routing/substates_test.js#L840-L845)), so maybe this was intended, but per the discussion in the other thread, it seems like no one currently expects it.

Additionally, `_loading` substates were having `resetNamespace` applied, but `_error` ones were not. This leads to inconsistent and unintuitive behavior. Again, maybe intended, but seems wrong.
