### PR TITLE
[DOC relase] Improve `mut` documentation

### DIFF
--- a/packages/ember-glimmer/lib/helpers/mut.js
+++ b/packages/ember-glimmer/lib/helpers/mut.js
@@ -7,22 +7,20 @@ import { INVOKE } from './action';
   The `mut` helper lets you __clearly specify__ that a child `Component` can update the
   (mutable) value passed to it, which will __change the value of the parent component__.
 
-  This is very helpful for passing mutable values to a `Component` of any size, but
-  critical to understanding the logic of a large/complex `Component`.
-
   To specify that a parameter is mutable, when invoking the child `Component`:
 
   ```handlebars
   {{my-child childClickCount=(mut totalClicks)}}
   ```
 
-  The child `Component` can then modify the parent's value as needed:
+  The child `Component` can then modify the parent's value just by modifying its own
+  property:
 
   ```javascript
   // my-child.js
   export default Component.extend({
     click() {
-      this.get('childClickCount').update(this.get('childClickCount').value + 1);
+      this.incrementProperty('childClickCount');
     }
   });
   ```
@@ -46,9 +44,6 @@ import { INVOKE } from './action';
   ```
 
   The `mut` helper changes the `totalClicks` value to what was provided as the action argument.
-
-  See a [2.0 blog post](http://emberjs.com/blog/2015/05/10/run-up-to-two-oh.html#toc_the-code-mut-code-helper) for
-  additional information on using `{{mut}}`.
 
   @method mut
   @param {Object} [attr] the "two-way" attribute that can be modified.


### PR DESCRIPTION
`mut` documentation contains code that does not work. It also references a blog
post with outdated information.

This PR fixes the code with the right behaviour and remove the link to avoid
confussion. It also adds a section about _Legacy behaviour_ of this helper.

Fixes #14057
