### PR TITLE
Default queryParams for link-to must have values

### DIFF
--- a/packages/ember-glimmer/lib/components/link-to.js
+++ b/packages/ember-glimmer/lib/components/link-to.js
@@ -805,7 +805,7 @@ const LinkComponent = EmberComponent.extend({
     if (lastParam && lastParam.isQueryParams) {
       queryParams = params.pop();
     } else {
-      queryParams = {};
+      queryParams = { values: {} };
     }
     this.set('queryParams', queryParams);
 


### PR DESCRIPTION
When transitioning between two routes with query params, if the user interrupts the active transition due to a slow model by visiting a third route with no query params, this causes an exception to be raised.

The root cause is that `link-to` has a default/fallback `queryParams` of `{}`, but it needs to have a `values` field. Otherwise, we pass `undefined` to the router, which blows up as a result (see #14040).

This PR fixes #14010 at the correct level, and adds a better regression test than #14040.

Thanks to @rwjblue and @GavinJoyce for all their help!
