### PR TITLE
Remove unused `withKeyCode` option for ActionHelper

### DIFF
--- a/packages/ember-htmlbars/lib/keywords/element-action.js
+++ b/packages/ember-htmlbars/lib/keywords/element-action.js
@@ -53,7 +53,6 @@ export default {
       eventName: hash.on || 'click',
       bubbles: hash.bubbles,
       preventDefault: hash.preventDefault,
-      withKeyCode: hash.withKeyCode,
       allowedKeys: hash.allowedKeys
     });
 


### PR DESCRIPTION
The ability to pass `withKeyCode` to `{{action}}` was removed in
4f5aa0632ffeccdaa17430748d16d3146b55bc36 when the use of a feature flag named
`"ember-routing-handlebars-action-with-key-code"` was reverted. The removal commit left
this unused `withKeyCode` option to `ActionHelpers.registerAction`.

The `withKeyCode` option remained after 4f5aa0632 in [`ember-routing-handlebars/lib/helpers/action.js`](https://github.com/emberjs/ember.js/blob/4f5aa0632ffeccdaa17430748d16d3146b55bc36/packages/ember-routing-handlebars/lib/helpers/action.js#L312) and [`ember-routing-htmlbars/lib/helpers/action.js`](https://github.com/emberjs/ember.js/blob/4f5aa0632ffeccdaa17430748d16d3146b55bc36/packages/ember-routing-htmlbars/lib/helpers/action.js#L302). It has been forward-ported from there through several file renames to its current spot in `ember-htmlbars/lib/keywords/element-action.js`.
