### PR TITLE
Fix `eachPackageTests` to actually run for each package.

### DIFF
--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -3,7 +3,8 @@
 var RSVP  = require('rsvp');
 var spawn = require('child_process').spawn;
 var chalk = require('chalk');
-var packages = require('../lib/packages');
+var getFeatures = require('../ember-cli-build').getFeatures;
+var getPackages = require('../lib/packages');
 var runInSequence = require('../lib/run-in-sequence');
 
 var finalhandler = require('finalhandler');
@@ -89,6 +90,9 @@ function runInPhantom(url, retries, resolve, reject) {
 var testFunctions = [];
 
 function generateEachPackageTests() {
+  var features = getFeatures();
+  var packages = getPackages(features);
+
   Object.keys(packages).forEach(function(packageName) {
     if (packages[packageName].skipTests) { return; }
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -151,3 +151,5 @@ module.exports = function() {
 
   return emberBuild.getDistTrees();
 };
+
+module.exports.getFeatures = getFeatures;


### PR DESCRIPTION
When `lib/packages.js` was refactored to be a function, this iteration
in the each package tests was missed.
