### PR TITLE
[BUGFIX beta] Check that handler exists before triggering event

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -1059,7 +1059,7 @@ export function triggerEvent(handlerInfos, ignoreFailure, args) {
     handlerInfo = handlerInfos[i];
     handler = handlerInfo.handler;
 
-    if (handler.actions && handler.actions[name]) {
+    if (handler && handler.actions && handler.actions[name]) {
       if (handler.actions[name].apply(handler, args) === true) {
         eventWasHandled = true;
       } else {

--- a/packages/ember-routing/tests/system/router_test.js
+++ b/packages/ember-routing/tests/system/router_test.js
@@ -2,7 +2,7 @@ import HashLocation from 'ember-routing/location/hash_location';
 import HistoryLocation from 'ember-routing/location/history_location';
 import AutoLocation from 'ember-routing/location/auto_location';
 import NoneLocation from 'ember-routing/location/none_location';
-import Router from 'ember-routing/system/router';
+import Router, { triggerEvent } from 'ember-routing/system/router';
 import { runDestroy } from 'ember-runtime/tests/utils';
 import buildOwner from 'container/tests/test-helpers/build-owner';
 import { setOwner } from 'container/owner';
@@ -191,4 +191,68 @@ QUnit.test('Router#handleURL should remove any #hashes before doing URL transiti
   });
 
   router.handleURL('/foo/bar?time=morphin#pink-power-ranger');
+});
+
+QUnit.test('Router#triggerEvent allows actions to bubble when returning true', function(assert) {
+  assert.expect(2);
+
+  let handlerInfos = [
+    {
+      name: 'application',
+      handler: {
+        actions: {
+          loading() {
+            assert.ok(false, 'loading not handled by application route');
+          }
+        }
+      }
+    },
+    {
+      name: 'about',
+      handler: {
+        actions: {
+          loading() {
+            assert.ok(true, 'loading handled by about route');
+            return false;
+          }
+        }
+      }
+    },
+    {
+      name: 'about.me',
+      handler: {
+        actions: {
+          loading() {
+            assert.ok(true, 'loading handled by about.me route');
+            return true;
+          }
+        }
+      }
+    }
+  ];
+
+  triggerEvent(handlerInfos, false, ['loading']);
+});
+
+QUnit.test('Router#triggerEvent ignores handlers that have not loaded yet', function(assert) {
+  assert.expect(1);
+
+  let handlerInfos = [
+    {
+      name: 'about',
+      handler: {
+        actions: {
+          loading() {
+            assert.ok(true, 'loading handled by about route');
+          }
+        }
+      }
+    },
+    {
+      name: 'about.me',
+      handler: undefined
+    }
+  ];
+
+  triggerEvent(handlerInfos, false, ['loading']);
 });


### PR DESCRIPTION
This is necessary for lazily-loaded routes where the handler is not
available synchronously. This includes events like loading and
queryParamsDidChange which trigger synchronously after starting a
transition, in those cases we should by-pass handlers that are not
yet loaded.

cc/ @rwjblue @nathanhammond @dgeb 

Note: I feel like I should add a test for this, but I feel like it makes more
sense to just test this in the ember-engines repo, since this code path is
impossible to hit normally.
