### PR TITLE
[GLIMMER] Ensure willClearRender is called.

### DIFF
--- a/packages/ember-glimmer/lib/renderer.js
+++ b/packages/ember-glimmer/lib/renderer.js
@@ -150,6 +150,7 @@ class Renderer {
 
   remove(view) {
     view.trigger('willDestroyElement');
+    view.trigger('willClearRender');
     view._transitionTo('destroying');
 
     if (this._root === view) {

--- a/packages/ember-glimmer/tests/integration/components/life-cycle-test.js
+++ b/packages/ember-glimmer/tests/integration/components/life-cycle-test.js
@@ -135,6 +135,12 @@ class LifeCycleHooksTest extends RenderingTest {
         pushHook('willDestroyElement');
         assertParentView('willDestroyElement', this);
         assertElement('willDestroyElement', this);
+      },
+
+      willClearRender() {
+        pushHook('willClearRender');
+        assertParentView('willClearRender', this);
+        assertElement('willClearRender', this);
       }
     });
 
@@ -387,8 +393,11 @@ class LifeCycleHooksTest extends RenderingTest {
       this.assertHooks(
         'destroy',
         ['the-top', 'willDestroyElement'],
+        ['the-top', 'willClearRender'],
         ['the-middle', 'willDestroyElement'],
-        ['the-bottom', 'willDestroyElement']
+        ['the-middle', 'willClearRender'],
+        ['the-bottom', 'willDestroyElement'],
+        ['the-bottom', 'willClearRender']
       );
     });
   }
@@ -559,8 +568,11 @@ class LifeCycleHooksTest extends RenderingTest {
       this.assertHooks(
         'destroy',
         ['the-top', 'willDestroyElement'],
+        ['the-top', 'willClearRender'],
         ['the-middle', 'willDestroyElement'],
-        ['the-bottom', 'willDestroyElement']
+        ['the-middle', 'willClearRender'],
+        ['the-bottom', 'willDestroyElement'],
+        ['the-bottom', 'willClearRender']
       );
     });
   }
@@ -631,10 +643,15 @@ class LifeCycleHooksTest extends RenderingTest {
       'reset to empty array',
 
       ['an-item', 'willDestroyElement'],
+      ['an-item', 'willClearRender'],
       ['an-item', 'willDestroyElement'],
+      ['an-item', 'willClearRender'],
       ['an-item', 'willDestroyElement'],
+      ['an-item', 'willClearRender'],
       ['an-item', 'willDestroyElement'],
+      ['an-item', 'willClearRender'],
       ['an-item', 'willDestroyElement'],
+      ['an-item', 'willClearRender'],
 
       ['no-items', 'init'],
       ['no-items', 'didInitAttrs',       { attrs: { } }],
@@ -649,7 +666,8 @@ class LifeCycleHooksTest extends RenderingTest {
       this.assertHooks(
         'destroy',
 
-        ['no-items', 'willDestroyElement']
+        ['no-items', 'willDestroyElement'],
+        ['no-items', 'willClearRender']
       );
     });
   }


### PR DESCRIPTION
This hook is somewhat silly at this point, since the entire purpose makes very little sense today, but it is still invoked in HTMLBars (right after `willDestroyElement`) so we should keep it around for Glimmer2 as well.

I am absolutely in favor of deprecating and removing in future iterations.
