### PR TITLE
[GLIMMER] Prevent auto-run assertion for objects not rendered.

### DIFF
--- a/packages/ember-metal/lib/tags.js
+++ b/packages/ember-metal/lib/tags.js
@@ -41,8 +41,14 @@ if (hasGlimmer) {
   makeTag = () => new DirtyableTag();
 
   markObjectAsDirty = function(meta) {
-    ensureRunloop();
-    let tag = (meta && meta.readableTag()) || CURRENT_TAG;
+    let tag = meta && meta.readableTag();
+
+    if (tag) {
+      ensureRunloop();
+    } else {
+      tag = CURRENT_TAG;
+    }
+
     tag.dirty();
   };
 } else {

--- a/packages/ember-metal/tests/accessors/set_test.js
+++ b/packages/ember-metal/tests/accessors/set_test.js
@@ -1,7 +1,12 @@
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
+import { setHasViews } from 'ember-metal/tags';
 
-QUnit.module('set');
+QUnit.module('set', {
+  teardown() {
+    setHasViews(() => false);
+  }
+});
 
 QUnit.test('should set arbitrary properties on an object', function() {
   let obj = {
@@ -68,4 +73,13 @@ QUnit.test('warn on attempts of calling set on a destroyed object', function() {
   let obj = { isDestroyed: true };
 
   expectAssertion(() => set(obj, 'favoriteFood', 'hot dogs'), 'calling set on destroyed object: [object Object].favoriteFood = hot dogs');
+});
+
+QUnit.test('does not trigger auto-run assertion for objects that have not been tagged', function(assert) {
+  setHasViews(() => true);
+  let obj = {};
+
+  set(obj, 'foo', 'bar');
+
+  assert.equal(obj.foo, 'bar');
 });


### PR DESCRIPTION
Prior to this change any `Ember.set` done after **any** rendering has been done during tests will trigger the auto-run assertion.

This change prevents the auto-run assertion when a given object has not been used in rendering process.
