### PR TITLE
[GLIMMER] Prevent auto-run assertion for objects not rendered.

### DIFF
--- a/packages/ember-metal/lib/tags.js
+++ b/packages/ember-metal/lib/tags.js
@@ -41,9 +41,12 @@ if (hasGlimmer) {
   makeTag = () => new DirtyableTag();
 
   markObjectAsDirty = function(meta) {
-    ensureRunloop();
-    let tag = (meta && meta.readableTag()) || CURRENT_TAG;
-    tag.dirty();
+    let tag = meta && meta.readableTag();
+
+    if (tag) {
+      ensureRunloop();
+      tag.dirty();
+    }
   };
 } else {
   markObjectAsDirty = function() {};

--- a/packages/ember-metal/tests/accessors/set_test.js
+++ b/packages/ember-metal/tests/accessors/set_test.js
@@ -1,7 +1,12 @@
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
+import { setHasViews } from 'ember-metal/tags';
 
-QUnit.module('set');
+QUnit.module('set', {
+  teardown() {
+    setHasViews(() => false);
+  }
+});
 
 QUnit.test('should set arbitrary properties on an object', function() {
   let obj = {
@@ -68,4 +73,13 @@ QUnit.test('warn on attempts of calling set on a destroyed object', function() {
   let obj = { isDestroyed: true };
 
   expectAssertion(() => set(obj, 'favoriteFood', 'hot dogs'), 'calling set on destroyed object: [object Object].favoriteFood = hot dogs');
+});
+
+QUnit.test('does not trigger auto-run assertion for objects that have not been tagged', function(assert) {
+  setHasViews(() => true);
+  let obj = {};
+
+  set(obj, 'foo', 'bar');
+
+  assert.equal(obj.foo, 'bar');
 });


### PR DESCRIPTION
Like #14091, but skip bumping revision altogether.

One of the invariants of the validators system is that whenever anything in the system has changed, the global revision must be incremented. However, we could define "the system" to be "the templating system", which restricts "anything in the system" to "anything objects _observable_ from the templating system".

Since we always put a tag on everything the templating system cares about (i.e. we don't rely on `CURRENT_TAG` as a safety net anymore), if an object does not already have a tag, it must mean that the view system doesn't care about it (yet).
