### PR TITLE
Add helpful assertion when template is missing.

### DIFF
--- a/packages/ember-glimmer/lib/renderer.js
+++ b/packages/ember-glimmer/lib/renderer.js
@@ -180,6 +180,8 @@ class Renderer {
     };
     let { _env: env } = this;
     let render = () => {
+      assert(`You cannot render \`${self.value()}\` without a template.`, template);
+
       let result = template.asEntryPoint().render(self, env, {
         appendTo: parentElement,
         dynamicScope


### PR DESCRIPTION
Prior to this change, calling `component.appendTo()` when there was no `template` would trigger an unhelpful error:

```
Cannot read property 'asEntryPoint' of undefined
```

After this change, it will at least point you in the direction of the offending component:

```
You cannot render `<dummy@component:foo-bar::ember168>` without a template.
```
