### PR TITLE
Remove `testModule` from `skip-if-glimmer`.

### DIFF
--- a/packages/ember-htmlbars/tests/integration/mount_test.js
+++ b/packages/ember-htmlbars/tests/integration/mount_test.js
@@ -10,7 +10,7 @@ import run from 'ember-metal/run_loop';
 import { OWNER, getOwner } from 'container/owner';
 import isEnabled from 'ember-metal/features';
 import { getEngineParent } from 'ember-application/system/engine-parent';
-import { test, testModule } from 'internal-test-helpers/tests/skip-if-glimmer';
+import { test } from 'internal-test-helpers/tests/skip-if-glimmer';
 
 let App,
     app,
@@ -51,7 +51,7 @@ function commonTeardown() {
 }
 
 if (isEnabled('ember-application-engines')) {
-  testModule('mount keyword', {
+  QUnit.module('mount keyword', {
     setup() {
       commonSetup();
     },

--- a/packages/ember-views/tests/views/view/append_to_test.js
+++ b/packages/ember-views/tests/views/view/append_to_test.js
@@ -8,7 +8,7 @@ import Component from 'ember-templates/component';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
 import buildOwner from 'container/tests/test-helpers/build-owner';
 import { OWNER } from 'container/owner';
-import { test, testModule } from 'internal-test-helpers/tests/skip-if-glimmer';
+import { test } from 'internal-test-helpers/tests/skip-if-glimmer';
 import require from 'require';
 
 let compile, owner, View, view, otherView, willDestroyCalled;
@@ -23,7 +23,7 @@ function commonSetup() {
   compile = require('ember-htmlbars-template-compiler').compile;
 }
 
-testModule('EmberView - append() and appendTo()', {
+QUnit.module('EmberView - append() and appendTo()', {
   setup() {
     commonSetup();
     View = EmberView.extend({});
@@ -115,7 +115,7 @@ test('destroy more forcibly removes the view', function() {
   equal(willDestroyCalled, 1, 'the willDestroyElement hook was called once');
 });
 
-testModule('EmberView - append() and appendTo() in a view hierarchy', {
+QUnit.module('EmberView - append() and appendTo() in a view hierarchy', {
   setup() {
     commonSetup();
 

--- a/packages/ember-views/tests/views/view/render_to_element_test.js
+++ b/packages/ember-views/tests/views/view/render_to_element_test.js
@@ -2,12 +2,12 @@ import { get } from 'ember-metal/property_get';
 import run from 'ember-metal/run_loop';
 import EmberView from 'ember-views/views/view';
 
-import { test, testModule } from 'internal-test-helpers/tests/skip-if-glimmer';
+import { test } from 'internal-test-helpers/tests/skip-if-glimmer';
 import require from 'require';
 
 let View, view, compile;
 
-testModule('EmberView - renderToElement()', {
+QUnit.module('EmberView - renderToElement()', {
   setup() {
     compile = compile || require('ember-htmlbars-template-compiler').compile;
     View = EmberView.extend({

--- a/packages/ember/tests/view_instrumentation_test.js
+++ b/packages/ember/tests/view_instrumentation_test.js
@@ -4,7 +4,7 @@ import Application from 'ember-application/system/application';
 import { subscribe, reset } from 'ember-metal/instrumentation';
 import { compile } from 'ember-template-compiler/tests/utils/helpers';
 import { setTemplates, set as setTemplate } from 'ember-templates/template_registry';
-import { test, testModule } from 'internal-test-helpers/tests/skip-if-glimmer';
+import { test } from 'internal-test-helpers/tests/skip-if-glimmer';
 
 let App, $fixture;
 
@@ -24,7 +24,7 @@ function handleURL(path) {
   return run(router, 'handleURL', path);
 }
 
-testModule('View Instrumentation', {
+QUnit.module('View Instrumentation', {
   setup() {
     run(() => {
       App = Application.create({

--- a/packages/internal-test-helpers/tests/skip-if-glimmer.js
+++ b/packages/internal-test-helpers/tests/skip-if-glimmer.js
@@ -4,19 +4,13 @@ export function test(name, fn) {
   if (isEnabled('ember-glimmer')) {
     QUnit.skip('[SKIPPED IN GLIMMER] ' + name, fn);
   } else {
-    QUnit.test('[SKIPPED IN GLIMMER] ' + name, fn);
-  }
-}
-
-export function testModule(name, setup) {
-  if (!isEnabled('ember-glimmer')) {
-    QUnit.module(name, setup);
+    QUnit.test(name, fn);
   }
 }
 
 export function asyncTest(name, fn) {
   if (isEnabled('ember-glimmer')) {
-    QUnit.skip('[GLIMMER] ' + name, fn);
+    QUnit.skip('[SKIPPED IN GLIMMER] ' + name, fn);
   } else {
     QUnit.asyncTest(name, fn);
   }


### PR DESCRIPTION
Conditionally calling `QUnit.module` leads to bizarre test names. Since `testModule` was only calling `QUnit.module` when not using `ember-glimmer`, but `test` was just swapping between `QUnit.test` and `QUnit.skip` we ended up "sharing" the previously ran `QUnit.module'`s name as a prefix to skipped tests.

![screenshot](http://assets.rwjblue.com/snapshots/2016-08-19-12-05-06__Ember.png)
