### PR TITLE
Ensure view registry entries can be unregistered properly.

### DIFF
--- a/packages/ember-glimmer/lib/renderer.js
+++ b/packages/ember-glimmer/lib/renderer.js
@@ -140,12 +140,12 @@ class Renderer {
   }
 
   register(view) {
-    assert('Attempted to register a view with an id already in use: ' + view.elementId, !this._viewRegistry[this.elementId]);
+    assert('Attempted to register a view with an id already in use: ' + view.elementId, !this._viewRegistry[view.elementId]);
     this._viewRegistry[view.elementId] = view;
   }
 
   unregister(view) {
-    delete this._viewRegistry[this.elementId];
+    delete this._viewRegistry[view.elementId];
   }
 
   remove(view) {

--- a/packages/ember-htmlbars/lib/renderer.js
+++ b/packages/ember-htmlbars/lib/renderer.js
@@ -276,12 +276,12 @@ Renderer.prototype.didDestroyElement = function (view) {
 
 
 Renderer.prototype.register = function Renderer_register(view) {
-  assert('Attempted to register a view with an id already in use: ' + view.elementId, !this._viewRegistry[this.elementId]);
+  assert('Attempted to register a view with an id already in use: ' + view.elementId, !this._viewRegistry[view.elementId]);
   this._viewRegistry[view.elementId] = view;
 };
 
 Renderer.prototype.unregister = function Renderer_unregister(view) {
-  delete this._viewRegistry[this.elementId];
+  delete this._viewRegistry[view.elementId];
 };
 
 export const InertRenderer = {


### PR DESCRIPTION
When the `register` / `unregister` functions were moved from the `ViewSupportMixin` to the renderer, I didn't properly update them to use the provided `view`'s `elementId` and was instead using `this.elementId` (on the renderer) which was obviously undefined.

This meant that we were holding on to a reference of all views/components ever created (since they were never being released from the `viewRegistry`). :sob:
