### PR TITLE
Call IsVisibleBinding only if no style binding

### DIFF
--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -65,7 +65,7 @@ function applyAttributeBindings(attributeBindings, component, operations) {
     i--;
   }
 
-  if (!seen['style']) {
+  if (seen.indexOf('style') === -1) {
     IsVisibleBinding.apply(component, operations);
   }
 }

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -2464,6 +2464,51 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     });
   }
 
+  ['@test adds isVisible binding when style binding is missing and other bindings exist'](assert) {
+    let assertStyle = (expected) => {
+      let matcher = styles(expected);
+      let actual = this.firstChild.getAttribute('style');
+
+      assert.pushResult({
+        result: matcher.match(actual),
+        message: matcher.message(),
+        actual,
+        expected
+      });
+    };
+
+    this.registerComponent('foo-bar', {
+      ComponentClass: Component.extend({
+        attributeBindings: ['foo'],
+        foo: 'bar'
+      }),
+      template: `<p>foo</p>`
+    });
+
+    this.render(`{{foo-bar id="foo-bar" foo=foo isVisible=visible}}`, {
+      visible: false,
+      foo: 'baz'
+    });
+
+    assertStyle('display: none;');
+
+    this.assertStableRerender();
+
+    this.runTask(() => {
+      set(this.context, 'visible', true);
+    });
+
+    assertStyle('');
+
+    this.runTask(() => {
+      set(this.context, 'visible', false);
+      set(this.context, 'foo', 'woo');
+    });
+
+    assertStyle('display: none;');
+    assert.equal(this.firstChild.getAttribute('foo'), 'woo');
+  }
+
   ['@test it can use readDOMAttr to read input value']() {
     let component;
     let assertElement = (expectedValue) => {


### PR DESCRIPTION
Previously, the `seen` variable was used as both an `Array` and a
hashmap (plain JavaScript object) when it was really an `Array`. The
`Array` would never return `true` for `seen['style']` in this code block
meaning that the `IsVisibleBinding` call would always be invoked,
regardless of whether there was an attribute binding for `style`. This
behavior is most likely a bug. The author intends to investigate unit /
integration tests for this case and add them in a separate commit.
# Unit Tests

The author is investigating tests now but wanted to submit this sooner rather than later in case it is important.
