### PR TITLE
[DOC canary] Several cleanups in test helpers

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -93,8 +93,16 @@ asyncHelper('fillIn', fillIn);
   var $el = find('.my-selector');
   ```
 
+  With the `context` param:
+
+  ```javascript
+  var $el = find('.my-selector', '.parent-element-class');
+  ```
+
   @method find
   @param {String} selector jQuery string selector for element lookup
+  @param {String} [context] (optional) jQuery selector that will limit the selector
+                            argument to find only within the context's children
   @return {Object} jQuery object representing the results of the query
   @public
 */

--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -16,165 +16,17 @@ import triggerEvent from './helpers/trigger_event';
 import visit from './helpers/visit';
 import wait from './helpers/wait';
 
-/**
-@module ember
-@submodule ember-testing
-*/
-
-/**
-  Loads a route, sets up any controllers, and renders any templates associated
-  with the route as though a real user had triggered the route change while
-  using your app.
-
-  Example:
-
-  ```javascript
-  visit('posts/index').then(function() {
-    // assert something
-  });
-  ```
-
-  @method visit
-  @param {String} url the name of the route
-  @return {RSVP.Promise}
-  @public
-*/
 asyncHelper('visit', visit);
-
-/**
-  Clicks an element and triggers any actions triggered by the element's `click`
-  event.
-
-  Example:
-
-  ```javascript
-  click('.some-jQuery-selector').then(function() {
-    // assert something
-  });
-  ```
-
-  @method click
-  @param {String} selector jQuery selector for finding element on the DOM
-  @param {Object} context A DOM Element, Document, or jQuery to use as context
-  @return {RSVP.Promise}
-  @public
-*/
 asyncHelper('click', click);
-
 asyncHelper('keyEvent', keyEvent);
-
-/**
-  Fills in an input element with some text.
-
-  Example:
-
-  ```javascript
-  fillIn('#email', 'you@example.com').then(function() {
-    // assert something
-  });
-  ```
-
-  @method fillIn
-  @param {String} selector jQuery selector finding an input element on the DOM
-  to fill text with
-  @param {String} text text to place inside the input element
-  @return {RSVP.Promise}
-  @public
-*/
 asyncHelper('fillIn', fillIn);
-
-/**
-  Finds an element in the context of the app's container element. A simple alias
-  for `app.$(selector)`.
-
-  Example:
-
-  ```javascript
-  var $el = find('.my-selector');
-  ```
-
-  With the `context` param:
-
-  ```javascript
-  var $el = find('.my-selector', '.parent-element-class');
-  ```
-
-  @method find
-  @param {String} selector jQuery string selector for element lookup
-  @param {String} [context] (optional) jQuery selector that will limit the selector
-                            argument to find only within the context's children
-  @return {Object} jQuery object representing the results of the query
-  @public
-*/
-helper('find', find);
-
-helper('findWithAssert', findWithAssert);
-
-/**
-  Causes the run loop to process any pending events. This is used to ensure that
-  any async operations from other helpers (or your assertions) have been processed.
-
-  This is most often used as the return value for the helper functions (see 'click',
-  'fillIn','visit',etc).
-
-  Example:
-
-  ```javascript
-  Ember.Test.registerAsyncHelper('loginUser', function(app, username, password) {
-    visit('secured/path/here')
-    .fillIn('#username', username)
-    .fillIn('#password', password)
-    .click('.submit')
-
-    return app.testHelpers.wait();
-  });
-
-  @method wait
-  @param {Object} value The value to be returned.
-  @return {RSVP.Promise}
-  @public
-*/
 asyncHelper('wait', wait);
 asyncHelper('andThen', andThen);
-helper('currentRouteName', currentRouteName);
-/**
-  Returns the current path.
-
-Example:
-
-```javascript
-function validateURL() {
-  equal(currentPath(), 'some.path.index', "correct path was transitioned into.");
-}
-
-click('#some-link-id').then(validateURL);
-```
-
-@method currentPath
-@return {Object} The currently active path.
-@since 1.5.0
-@public
-*/
-helper('currentPath', currentPath);
-
-/**
-  Returns the current URL.
-
-Example:
-
-```javascript
-function validateURL() {
-  equal(currentURL(), '/some/path', "correct URL was transitioned into.");
-}
-
-click('#some-link-id').then(validateURL);
-```
-
-@method currentURL
-@return {Object} The currently active URL.
-@since 1.5.0
-@public
-*/
-helper('currentURL', currentURL);
 asyncHelper('pauseTest', pauseTest);
 asyncHelper('triggerEvent', triggerEvent);
+
+helper('find', find);
+helper('findWithAssert', findWithAssert);
+helper('currentRouteName', currentRouteName);
+helper('currentPath', currentPath);
+helper('currentURL', currentURL);

--- a/packages/ember-testing/lib/helpers/and_then.js
+++ b/packages/ember-testing/lib/helpers/and_then.js
@@ -1,3 +1,7 @@
+/**
+@module ember
+@submodule ember-testing
+*/
 export default function andThen(app, callback) {
   return app.testHelpers.wait(callback(app));
 }

--- a/packages/ember-testing/lib/helpers/click.js
+++ b/packages/ember-testing/lib/helpers/click.js
@@ -1,5 +1,27 @@
+/**
+@module ember
+@submodule ember-testing
+*/
 import { focus, fireEvent } from '../events';
 
+/**
+  Clicks an element and triggers any actions triggered by the element's `click`
+  event.
+
+  Example:
+
+  ```javascript
+  click('.some-jQuery-selector').then(function() {
+    // assert something
+  });
+  ```
+
+  @method click
+  @param {String} selector jQuery selector for finding element on the DOM
+  @param {Object} context A DOM Element, Document, or jQuery to use as context
+  @return {RSVP.Promise}
+  @public
+*/
 export default function click(app, selector, context) {
   let $el = app.testHelpers.findWithAssert(selector, context);
   let el = $el[0];

--- a/packages/ember-testing/lib/helpers/current_path.js
+++ b/packages/ember-testing/lib/helpers/current_path.js
@@ -1,5 +1,27 @@
+/**
+@module ember
+@submodule ember-testing
+*/
 import { get } from 'ember-metal/property_get';
 
+/**
+  Returns the current path.
+
+Example:
+
+```javascript
+function validateURL() {
+  equal(currentPath(), 'some.path.index', "correct path was transitioned into.");
+}
+
+click('#some-link-id').then(validateURL);
+```
+
+@method currentPath
+@return {Object} The currently active path.
+@since 1.5.0
+@public
+*/
 export default function currentPath(app) {
   let routingService = app.__container__.lookup('service:-routing');
   return get(routingService, 'currentPath');

--- a/packages/ember-testing/lib/helpers/current_url.js
+++ b/packages/ember-testing/lib/helpers/current_url.js
@@ -1,5 +1,27 @@
+/**
+@module ember
+@submodule ember-testing
+*/
 import { get } from 'ember-metal/property_get';
 
+/**
+  Returns the current URL.
+
+Example:
+
+```javascript
+function validateURL() {
+  equal(currentURL(), '/some/path', "correct URL was transitioned into.");
+}
+
+click('#some-link-id').then(validateURL);
+```
+
+@method currentURL
+@return {Object} The currently active URL.
+@since 1.5.0
+@public
+*/
 export default function currentURL(app) {
   let router = app.__container__.lookup('router:main');
   return get(router, 'location').getURL();

--- a/packages/ember-testing/lib/helpers/fill_in.js
+++ b/packages/ember-testing/lib/helpers/fill_in.js
@@ -1,5 +1,27 @@
+/**
+@module ember
+@submodule ember-testing
+*/
 import { focus, fireEvent } from '../events';
 
+/**
+  Fills in an input element with some text.
+
+  Example:
+
+  ```javascript
+  fillIn('#email', 'you@example.com').then(function() {
+    // assert something
+  });
+  ```
+
+  @method fillIn
+  @param {String} selector jQuery selector finding an input element on the DOM
+  to fill text with
+  @param {String} text text to place inside the input element
+  @return {RSVP.Promise}
+  @public
+*/
 export default function fillIn(app, selector, contextOrText, text) {
   let $el, el, context;
   if (typeof text === 'undefined') {

--- a/packages/ember-testing/lib/helpers/find.js
+++ b/packages/ember-testing/lib/helpers/find.js
@@ -1,5 +1,32 @@
+/**
+@module ember
+@submodule ember-testing
+*/
 import { get } from 'ember-metal/property_get';
 
+/**
+  Finds an element in the context of the app's container element. A simple alias
+  for `app.$(selector)`.
+
+  Example:
+
+  ```javascript
+  var $el = find('.my-selector');
+  ```
+
+  With the `context` param:
+
+  ```javascript
+  var $el = find('.my-selector', '.parent-element-class');
+  ```
+
+  @method find
+  @param {String} selector jQuery string selector for element lookup
+  @param {String} [context] (optional) jQuery selector that will limit the selector
+                            argument to find only within the context's children
+  @return {Object} jQuery object representing the results of the query
+  @public
+*/
 export default function find(app, selector, context) {
   let $el;
   context = context || get(app, 'rootElement');

--- a/packages/ember-testing/lib/helpers/find_with_assert.js
+++ b/packages/ember-testing/lib/helpers/find_with_assert.js
@@ -4,13 +4,24 @@
 */
 /**
   Like `find`, but throws an error if the element selector returns no results.
+
   Example:
+
   ```javascript
   var $el = findWithAssert('.doesnt-exist'); // throws error
   ```
+
+  With the `context` param:
+
+  ```javascript
+  var $el = findWithAssert('.selector-id', '.parent-element-class'); // assert will pass
+  ```
+
   @method findWithAssert
   @param {String} selector jQuery selector string for finding an element within
   the DOM
+  @param {String} [context] (optional) jQuery selector that will limit the
+  selector argument to find only within the context's children
   @return {Object} jQuery object representing the results of the query
   @throws {Error} throws error if jQuery object returned has a length of 0
   @public

--- a/packages/ember-testing/lib/helpers/visit.js
+++ b/packages/ember-testing/lib/helpers/visit.js
@@ -1,5 +1,27 @@
+/**
+@module ember
+@submodule ember-testing
+*/
 import run from 'ember-metal/run_loop';
 
+/**
+  Loads a route, sets up any controllers, and renders any templates associated
+  with the route as though a real user had triggered the route change while
+  using your app.
+
+  Example:
+
+  ```javascript
+  visit('posts/index').then(function() {
+    // assert something
+  });
+  ```
+
+  @method visit
+  @param {String} url the name of the route
+  @return {RSVP.Promise}
+  @public
+*/
 export default function visit(app, url) {
   let router = app.__container__.lookup('router:main');
   let shouldHandleURL = false;

--- a/packages/ember-testing/lib/helpers/wait.js
+++ b/packages/ember-testing/lib/helpers/wait.js
@@ -1,8 +1,36 @@
+/**
+@module ember
+@submodule ember-testing
+*/
 import { checkWaiters } from '../test/waiters';
 import RSVP from 'ember-runtime/ext/rsvp';
 import run from 'ember-metal/run_loop';
 import { pendingRequests } from '../test/pending_requests';
 
+/**
+  Causes the run loop to process any pending events. This is used to ensure that
+  any async operations from other helpers (or your assertions) have been processed.
+
+  This is most often used as the return value for the helper functions (see 'click',
+  'fillIn','visit',etc).
+
+  Example:
+
+  ```javascript
+  Ember.Test.registerAsyncHelper('loginUser', function(app, username, password) {
+    visit('secured/path/here')
+    .fillIn('#username', username)
+    .fillIn('#password', password)
+    .click('.submit')
+
+    return app.testHelpers.wait();
+  });
+
+  @method wait
+  @param {Object} value The value to be returned.
+  @return {RSVP.Promise}
+  @public
+*/
 export default function wait(app, value) {
   return new RSVP.Promise(function(resolve) {
     let router = app.__container__.lookup('router:main');


### PR DESCRIPTION
Improve the `findWithAssert` docs replacing https://github.com/emberjs/ember.js/pull/13641.

Per #13862, move the helper documentation into each file closer to the implementation.

Replaces:
- #13878
- #13876
- #13874
- #13873
