### PR TITLE
[BUGFIX release] Ensure `elementId` is initialized properly.

### DIFF
--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -8,6 +8,7 @@ import assign from 'ember-metal/assign';
 import get from 'ember-metal/property_get';
 import { ComponentDefinition } from 'glimmer-runtime';
 import Component from '../component';
+import { guidFor } from 'ember-metal/utils';
 
 const DEFAULT_LAYOUT = P`template:components/-default`;
 
@@ -42,6 +43,12 @@ function aliasIdToElementId(args, props) {
   if (args.named.has('id')) {
     assert(`You cannot invoke a component with both 'id' and 'elementId' at the same time.`, !args.named.has('elementId'));
     props.elementId = props.id;
+  }
+}
+
+function ensureElementId(component) {
+  if (component.elementId === undefined && component.tagName !== '') {
+    component.elementId = guidFor(component);
   }
 }
 
@@ -151,6 +158,8 @@ class CurlyComponentManager {
     props._targetObject = dynamicScope.targetObject;
 
     let component = klass.create(props);
+
+    ensureElementId(component);
 
     dynamicScope.view = component;
     dynamicScope.targetObject = component;
@@ -309,6 +318,7 @@ function tagName(vm) {
 
 function elementId(vm) {
   let component = vm.dynamicScope().view;
+
   return new ValueReference(component.elementId);
 }
 

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -2570,4 +2570,23 @@ moduleFor('Components test: curly components', class extends RenderingTest {
 
     assertElement('foo');
   }
+
+  ['@test it can set `tagName` after `this._super` in `init`']() {
+    this.registerComponent('foo-bar', {
+      ComponentClass: Component.extend({
+        tagName: '',
+
+        init() {
+          this._super(...arguments);
+          this.tagName = 'span';
+        }
+      }),
+      template: 'hello'
+    });
+
+    this.render('{{foo-bar}}{{foo-bar}}');
+
+    this.assertComponentElement(this.nthChild(0), { tagName: 'span', content: 'hello' });
+    this.assertComponentElement(this.nthChild(1), { tagName: 'span', content: 'hello' });
+  }
 });

--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -7,6 +7,7 @@ import { instrument } from 'ember-htmlbars/system/instrumentation-support';
 import EmberComponent, { HAS_BLOCK } from 'ember-htmlbars/component';
 import extractPositionalParams from 'ember-htmlbars/utils/extract-positional-params';
 import { setOwner, getOwner } from 'container/owner';
+import { guidFor } from 'ember-metal/utils';
 
 // In theory this should come through the env, but it should
 // be safe to import this until we make the hook system public
@@ -170,6 +171,8 @@ export function createComponent(_component, props, renderNode, env, attrs = {}) 
 
   let component = _component.create(props);
 
+  ensureElementId(component);
+
   if (props.parentView) {
     props.parentView.appendChild(component);
   }
@@ -177,7 +180,14 @@ export function createComponent(_component, props, renderNode, env, attrs = {}) 
   component._renderNode = renderNode;
   renderNode.emberView = component;
   renderNode.buildChildEnv = buildChildEnv;
+
   return component;
+}
+
+function ensureElementId(component) {
+  if (component.elementId === undefined && component.tagName !== '') {
+    component.elementId = guidFor(component);
+  }
 }
 
 function takeSnapshot(attrs) {

--- a/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
@@ -8,6 +8,7 @@ import getCellOrValue from 'ember-htmlbars/hooks/get-cell-or-value';
 import { instrument } from 'ember-htmlbars/system/instrumentation-support';
 import { takeLegacySnapshot } from 'ember-htmlbars/node-managers/component-node-manager';
 import { setOwner } from 'container/owner';
+import { guidFor } from 'ember-metal/utils';
 
 // In theory this should come through the env, but it should
 // be safe to import this until we make the hook system public
@@ -176,6 +177,7 @@ export function createOrUpdateComponent(component, options, createOptions, rende
     props.renderer = options.parentView ? options.parentView.renderer : owner && owner.lookup('renderer:-dom');
 
     component = component.create(props);
+    ensureElementId(component);
   } else {
     env.renderer.componentUpdateAttrs(component, snapshot);
     setProperties(component, props);
@@ -193,6 +195,12 @@ export function createOrUpdateComponent(component, options, createOptions, rende
 
   renderNode.emberView = component;
   return component;
+}
+
+function ensureElementId(component) {
+  if (component.elementId === undefined && component.tagName !== '') {
+    component.elementId = guidFor(component);
+  }
 }
 
 function takeSnapshot(attrs) {

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -411,9 +411,7 @@ export default Mixin.create({
   init() {
     this._super(...arguments);
 
-    if (!this.elementId && this.tagName !== '') {
-      this.elementId = guidFor(this);
-    }
+    this.elementId = this.elementId || undefined;
 
     this.scheduledRevalidation = false;
 


### PR DESCRIPTION
Prior to this change setting `tagName: ''` then updating `tagName` in your components `init` method (but after calling `this._super(...arguments)`) left the `elementId` being used as `null`.

This updates to set `elementId` on the component after it has completed instantiation but before it is inserted into DOM.

Fixes https://github.com/emberjs/ember.js/issues/14023.
