### PR TITLE
[BUGFIX beta] Fix issues with revalidation during teardown.

### DIFF
--- a/packages/ember-htmlbars/lib/renderer.js
+++ b/packages/ember-htmlbars/lib/renderer.js
@@ -62,7 +62,7 @@ Renderer.prototype.renderTopLevelView =
 Renderer.prototype.revalidateTopLevelView =
   function Renderer_revalidateTopLevelView(view) {
     // This guard prevents revalidation on an already-destroyed view.
-    if (view._renderNode.lastResult) {
+    if (view._renderNode && view._renderNode.lastResult) {
       view._renderNode.lastResult.revalidate(view._env);
       this.dispatchLifecycleHooks(view._env);
       this.clearRenderedViews(view._env);
@@ -241,6 +241,7 @@ Renderer.prototype.remove = function (view, shouldDestroy) {
     if (lastResult) {
       internal.clearMorph(renderNode, lastResult.env, shouldDestroy !== false);
     }
+
     if (!shouldDestroy) {
       view._transitionTo('preRender');
     }

--- a/packages/ember-htmlbars/lib/utils/subscribe.js
+++ b/packages/ember-htmlbars/lib/utils/subscribe.js
@@ -21,6 +21,13 @@ export default function subscribe(node, env, scope, stream) {
       node.shouldReceiveAttrs = true;
     }
 
-    node.ownerNode.emberView.scheduleRevalidate(node, labelFor(stream));
+    // When the toplevelView (aka ownerView) is being torn
+    // down (generally in tests), `ownerNode.emberView` will be
+    // set to `null` (to prevent further work while tearing down)
+    // so we need to guard against that case here
+    let ownerView = node.ownerNode.emberView;
+    if (ownerView) {
+      ownerView.scheduleRevalidate(node, labelFor(stream));
+    }
   }));
 }


### PR DESCRIPTION
When the toplevelView (aka `ownerView`) is being destroyed (during test teardown generally) an error was ocurring under certain "special" circumstances. Specifically, if removal of a sibling node triggered a revalidation of one still attached.

Consider the following example:

``` hbs
{{#x-select as |select|}}
 {{#select.option value="1"}}{/select.option}}
 {{#select.option value="2"}}{/select.option}}
{{/x-select}}
```

The components in question are using the registration pattern so that the children notify/register with the parent upon `didInsertElement` (and `willDestroyElement`).

When a new option is added or removed from the parent, it updates its `value` property which is bound to each options `selected` attribute (to toggle the selection state in the DOM).

The specific mechanism that causes the DOM to get updated when the various computed properties change is that a Stream object calls `ownerNode.emberView.scheduleRevalidate`.  This tells the rest of the system to start walking the tree to flush out any updates to the DOM.

When a view is being removed, we set the `emberView` property of its `renderNode` to `null` before traversing the subtree of children. This means, that as the children are removed (and therefore cause the `value` of the parent to change) the `selected` attribute binding attempts to call `ownerNode.emberView.scheduleRevalidation()`.

Unfortunately, when we are actually tearing down the `ownerNode.emberView` itself that invocation results in an error ( cannot call `scheduleRevalidation` on `null`).

---

This change adds a simple guard to avoid calling `scheduleRevalidation` when the `ownerNode.emberView` is being torn down.

Fixes https://github.com/emberjs/ember.js/issues/13846.
Fixes https://github.com/emberjs/ember.js/issues/13968.
