### PR TITLE
[BUGFix beta] Fix basic component and helper resolution in engines

### DIFF
--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -484,6 +484,7 @@ BootOptions.prototype.toEnvironment = function() {
   let env = assign({}, environment);
   // For compatibility with existing code
   env.hasDOM = this.isBrowser;
+  env.isInteractive = this.isInteractive;
   env.options = this;
   return env;
 };

--- a/packages/ember-application/lib/system/engine-instance.js
+++ b/packages/ember-application/lib/system/engine-instance.js
@@ -170,18 +170,29 @@ if (isEnabled('ember-application-engines')) {
     cloneParentDependencies() {
       let parent = getEngineParent(this);
 
-      [
+      let registrations = [
         'route:basic',
         'event_dispatcher:main',
         'service:-routing'
-      ].forEach(key => this.register(key, parent.resolveRegistration(key)));
+      ];
 
-      [
+      if (isEnabled('ember-glimmer')) {
+        registrations.push('service:-glimmer-environment');
+      }
+
+      registrations.forEach(key => this.register(key, parent.resolveRegistration(key)));
+
+      let env = parent.lookup('-environment:main');
+      this.register('-environment:main', env, { instantiate: false });
+
+      let singletons = [
         'router:main',
         P`-bucket-cache:main`,
         '-view-registry:main',
-        '-environment:main'
-      ].forEach(key => this.register(key, parent.lookup(key), { instantiate: false }));
+        `renderer:-${env.isInteractive ? 'dom' : 'inert'}`
+      ];
+
+      singletons.forEach(key => this.register(key, parent.lookup(key), { instantiate: false }));
 
       this.inject('view', '_environment', '-environment:main');
       this.inject('route', '_environment', '-environment:main');

--- a/packages/ember-application/tests/system/application_instance_test.js
+++ b/packages/ember-application/tests/system/application_instance_test.js
@@ -141,7 +141,7 @@ QUnit.test('unregistering a factory clears all cached instances of that factory'
 
 if (isEnabled('ember-application-engines')) {
   QUnit.test('can build and boot a registered engine', function(assert) {
-    assert.expect(8);
+    assert.expect(isEnabled('ember-glimmer') ? 10 : 9);
 
     let ChatEngine = Engine.extend();
     let chatEngineInstance;
@@ -158,23 +158,34 @@ if (isEnabled('ember-application-engines')) {
       .then(() => {
         assert.ok(true, 'boot successful');
 
-        [
+        let registrations = [
           'route:basic',
           'event_dispatcher:main',
           'service:-routing'
-        ].forEach(key => {
+        ];
+
+        if (isEnabled('ember-glimmer')) {
+          registrations.push('service:-glimmer-environment');
+        }
+
+        registrations.forEach(key => {
           assert.strictEqual(
             chatEngineInstance.resolveRegistration(key),
             appInstance.resolveRegistration(key),
             `Engine and parent app share registrations for '${key}'`);
         });
 
-        [
+        let singletons = [
           'router:main',
           P`-bucket-cache:main`,
           '-view-registry:main',
           '-environment:main'
-        ].forEach(key => {
+        ];
+
+        let env = appInstance.lookup('-environment:main');
+        singletons.push(env.isInteractive ? 'renderer:-dom' : 'renderer:-inert');
+
+        singletons.forEach(key => {
           assert.strictEqual(
             chatEngineInstance.lookup(key),
             appInstance.lookup(key),

--- a/packages/ember-application/tests/system/visit_test.js
+++ b/packages/ember-application/tests/system/visit_test.js
@@ -9,6 +9,7 @@ import Route from 'ember-routing/system/route';
 import Router from 'ember-routing/system/router';
 import Component from 'ember-templates/component';
 import { compile } from 'ember-template-compiler/tests/utils/helpers';
+import { helper } from 'ember-templates/helper';
 import jQuery from 'ember-views/system/jquery';
 
 let App = null;
@@ -383,6 +384,75 @@ QUnit.test('visit() returns a promise that resolves without rendering when shoul
   return run(App, 'visit', '/blog', { shouldRender: false }).then(instance => {
     assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
     assert.strictEqual(jQuery('#qunit-fixture').children().length, 0, 'there are still no elements in the fixture element after visit');
+  });
+});
+
+QUnit.test('visit() on engine resolves engine component', function(assert) {
+  assert.expect(2);
+
+  run(() => {
+    createApplication();
+
+    // Register engine
+    let BlogEngine = Engine.extend({
+      init(...args) {
+        this._super.apply(this, args);
+        this.register('template:application', compile('{{cache-money}}'));
+        this.register('template:components/cache-money', compile(`
+          <p>Dis cache money</p>
+        `));
+        this.register('component:cache-money', Component.extend({}));
+      }
+    });
+    App.register('engine:blog', BlogEngine);
+
+    // Register engine route map
+    let BlogMap = function() {};
+    App.register('route-map:blog', BlogMap);
+
+    App.Router.map(function() {
+      this.mount('blog');
+    });
+  });
+
+  assert.strictEqual(jQuery('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
+
+  return run(App, 'visit', '/blog', { shouldRender: true }).then(instance => {
+    assert.strictEqual(jQuery('#qunit-fixture').find('p').text(), 'Dis cache money', 'Engine component is resolved');
+  });
+});
+
+QUnit.test('visit() on engine resolves engine helper', function(assert) {
+  assert.expect(2);
+
+  run(() => {
+    createApplication();
+
+    // Register engine
+    let BlogEngine = Engine.extend({
+      init(...args) {
+        this._super.apply(this, args);
+        this.register('template:application', compile('{{swag}}'));
+        this.register('helper:swag', helper(function() {
+          return 'turnt up';
+        }));
+      }
+    });
+    App.register('engine:blog', BlogEngine);
+
+    // Register engine route map
+    let BlogMap = function() {};
+    App.register('route-map:blog', BlogMap);
+
+    App.Router.map(function() {
+      this.mount('blog');
+    });
+  });
+
+  assert.strictEqual(jQuery('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
+
+  return run(App, 'visit', '/blog', { shouldRender: true }).then(instance => {
+    assert.strictEqual(jQuery('#qunit-fixture').text(), 'turnt up', 'Engine component is resolved');
   });
 });
 

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -133,12 +133,12 @@ export default class Environment extends GlimmerEnvironment {
 
     this.uselessAnchor = document.createElement('a');
 
-    this._definitionCache = new Cache(2000, ({ name, source }) => {
+    this._definitionCache = new Cache(2000, ({ name, source, owner }) => {
       let { component: ComponentClass, layout } = lookupComponent(owner, name, { source });
       if (ComponentClass || layout) {
         return new CurlyComponentDefinition(name, ComponentClass, layout);
       }
-    }, ({ name, source }) => {
+    }, ({ name, source, owner }) => {
       return source && owner._resolveLocalLookupName(name, source) || name;
     });
 
@@ -268,8 +268,9 @@ export default class Environment extends GlimmerEnvironment {
 
   getComponentDefinition(path, parentMeta) {
     let name = path[0];
+    let owner = !!(parentMeta && parentMeta.owner) ? parentMeta.owner : this.owner;
     let source = parentMeta && `template:${parentMeta.moduleName}`;
-    return this._definitionCache.get({ name, source });
+    return this._definitionCache.get({ name, source, owner });
   }
 
   // normally templates should be exported at the proper module name
@@ -302,17 +303,19 @@ export default class Environment extends GlimmerEnvironment {
   }
 
   hasHelper(name, parentMeta) {
+    let owner = !!(parentMeta && parentMeta.owner) ? parentMeta.owner : this.owner;
     let options = parentMeta && { source: `template:${parentMeta.moduleName}` } || {};
     return !!builtInHelpers[name[0]] ||
-      this.owner.hasRegistration(`helper:${name}`, options) ||
-      this.owner.hasRegistration(`helper:${name}`);
+      owner.hasRegistration(`helper:${name}`, options) ||
+      owner.hasRegistration(`helper:${name}`);
   }
 
   lookupHelper(name, parentMeta) {
+    let owner = !!(parentMeta && parentMeta.owner) ? parentMeta.owner : this.owner;
     let options = parentMeta && { source: `template:${parentMeta.moduleName}` } || {};
     let helper = builtInHelpers[name[0]] ||
-      this.owner.lookup(`helper:${name}`, options) ||
-      this.owner.lookup(`helper:${name}`);
+      owner.lookup(`helper:${name}`, options) ||
+      owner.lookup(`helper:${name}`);
     // TODO: try to unify this into a consistent protocol to avoid wasteful closure allocations
     if (helper.isInternalHelper) {
       return (vm, args) => helper.toReference(args, this);

--- a/packages/ember-glimmer/lib/template.js
+++ b/packages/ember-glimmer/lib/template.js
@@ -2,6 +2,14 @@ import { Template } from 'glimmer-runtime';
 
 class Wrapper {
   constructor(id, env, spec) {
+    let { owner } = env;
+    if (spec.meta) {
+      spec.meta.owner = owner;
+    } else {
+      spec.meta = {
+        owner
+      };
+    }
     this.id = id;
     this.env = env;
     this.spec = spec;

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -446,12 +446,6 @@ const EmberRouter = EmberObject.extend(Evented, {
   },
 
   willDestroy() {
-    if (this._toplevelView) {
-      this._toplevelView.destroy();
-      this._toplevelView = null;
-    }
-    this._super(...arguments);
-
     if (isEnabled('ember-application-engines')) {
       let instances = this._engineInstances;
       for (let name in instances) {
@@ -460,6 +454,12 @@ const EmberRouter = EmberObject.extend(Evented, {
         }
       }
     }
+
+    if (this._toplevelView) {
+      this._toplevelView.destroy();
+      this._toplevelView = null;
+    }
+    this._super(...arguments);
 
     this.reset();
   },


### PR DESCRIPTION
A rebase and extension of #14055, this contains the following fixes:
- Clone additional parent dependencies into engine instances. Specifically `service:-glimmer-environment` (only for glimmer) and `renderer:-dom` or `renderer:-inert`
- Ensure that Cache lookups are performed using the correct owner.
- Ensure that engines are destroyed _before_ top-level views so that top-level
  views are not re-instantiated during engine teardown.
