### PR TITLE
[GLIMMER2] Implement `getViewBounds` for components

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "git-repo-info": "^1.1.4",
     "git-repo-version": "^0.3.1",
     "github": "^0.2.3",
-    "glimmer-engine": "0.9.2",
+    "glimmer-engine": "0.10.0",
     "glob": "^5.0.13",
     "htmlbars": "0.14.24",
     "mocha": "^2.4.5",

--- a/packages/ember-glimmer/lib/component.js
+++ b/packages/ember-glimmer/lib/component.js
@@ -23,6 +23,7 @@ export const ARGS = symbol('ARGS');
 export const ROOT_REF = symbol('ROOT_REF');
 export const IS_DISPATCHING_ATTRS = symbol('IS_DISPATCHING_ATTRS');
 export const HAS_BLOCK = symbol('HAS_BLOCK');
+export const BOUNDS = symbol('BOUNDS');
 
 const Component = CoreView.extend(
   ChildViewsSupport,
@@ -42,6 +43,7 @@ const Component = CoreView.extend(
       this[IS_DISPATCHING_ATTRS] = false;
       this[DIRTY_TAG] = new DirtyableTag();
       this[ROOT_REF] = new RootReference(this);
+      this[BOUNDS] = null;
 
       // If a `defaultLayout` was specified move it to the `layout` prop.
       // `layout` is no longer a CP, so this just ensures that the `defaultLayout`

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -381,11 +381,11 @@ runInDebug(() => {
     }
   };
 
-  Environment.prototype.attributeFor = function(element, attr, reference, isTrusting) {
-    if (attr === 'style' && !isTrusting) {
+  Environment.prototype.attributeFor = function(element, attribute, isTrusting, namespace) {
+    if (attribute === 'style' && !isTrusting) {
       return StyleAttributeChangeList;
     }
 
-    return GlimmerEnvironment.prototype.attributeFor.call(this, element, attr, reference, isTrusting);
+    return GlimmerEnvironment.prototype.attributeFor.call(this, element, attribute, isTrusting);
   };
 });

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -108,17 +108,18 @@ import { default as ActionModifierManager } from './modifiers/action';
 
 // TODO we should probably do this transform at build time
 function wrapClassAttribute(args) {
-  let hasClass = args.named.has('class');
+  let { named } = args;
+  let index = named.keys.indexOf('class');
 
-  if (hasClass) {
-    let { ref, type } = args.named.at('class');
+  if (index !== -1) {
+    let { ref, type } = named.values[index];
 
     if (type === 'get') {
       let propName = ref.parts[ref.parts.length - 1];
-      let syntax = HelperSyntax.fromSpec(['helper', ['-class'], [['get', ref.parts], propName], null]);
-      args.named.add('class', syntax);
+      named.values[index] = HelperSyntax.fromSpec(['helper', ['-class'], [['get', ref.parts], propName], null]);
     }
   }
+
   return args;
 }
 

--- a/packages/ember-glimmer/lib/helpers/-class.js
+++ b/packages/ember-glimmer/lib/helpers/-class.js
@@ -3,20 +3,19 @@ import { dasherize } from 'ember-runtime/system/string';
 
 function classHelper({ positional }) {
   let path = positional.at(0);
-  let truthyPropName = positional.at(1);
-  let falsyPropName = positional.at(2);
+  let args = positional.length;
   let value = path.value();
 
   if (value === true) {
-    if (truthyPropName) {
-      return dasherize(truthyPropName.value());
+    if (args > 1) {
+      return dasherize(positional.at(1).value());
     }
     return null;
   }
 
   if (value === false) {
-    if (falsyPropName) {
-      return dasherize(falsyPropName.value());
+    if (args > 2) {
+      return dasherize(positional.at(2).value());
     }
     return null;
   }

--- a/packages/ember-glimmer/lib/helpers/component.js
+++ b/packages/ember-glimmer/lib/helpers/component.js
@@ -128,14 +128,10 @@ function curryArgs(definition, newArgs) {
   // Merge named maps
   let mergedNamed = assign({}, oldNamed, positionalToNamedParams, newArgs.named.map);
 
-  let mergedArgs = EvaluatedArgs.create({
-    named: EvaluatedNamedArgs.create({
-      map: mergedNamed
-    }),
-    positional: EvaluatedPositionalArgs.create({
-      values: mergedPositional
-    })
-  });
+  let mergedArgs = EvaluatedArgs.create(
+    EvaluatedPositionalArgs.create(mergedPositional),
+    EvaluatedNamedArgs.create(mergedNamed)
+  );
 
   return mergedArgs;
 }

--- a/packages/ember-glimmer/lib/renderer.js
+++ b/packages/ember-glimmer/lib/renderer.js
@@ -6,6 +6,7 @@ import fallbackViewRegistry from 'ember-views/compat/fallback-view-registry';
 import { assert } from 'ember-metal/debug';
 import _runInTransaction from 'ember-metal/transaction';
 import isEnabled from 'ember-metal/features';
+import { BOUNDS } from './component';
 
 let runInTransaction;
 
@@ -167,6 +168,10 @@ class Renderer {
     }
     this._destroyed = true;
     this._clearRoot();
+  }
+
+  getBounds(view) {
+    return view[BOUNDS];
   }
 
   _renderRoot(root, template, self, parentElement, dynamicScope) {

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -1,6 +1,6 @@
 import { StatementSyntax, ValueReference, EvaluatedArgs, EvaluatedNamedArgs, EvaluatedPositionalArgs } from 'glimmer-runtime';
 import { AttributeBinding, ClassNameBinding, IsVisibleBinding } from '../utils/bindings';
-import { ROOT_REF, DIRTY_TAG, IS_DISPATCHING_ATTRS, HAS_BLOCK } from '../component';
+import { ROOT_REF, DIRTY_TAG, IS_DISPATCHING_ATTRS, HAS_BLOCK, BOUNDS } from '../component';
 import { assert, runInDebug } from 'ember-metal/debug';
 import processArgs from '../utils/process-args';
 import { privatize as P } from 'container/registry';
@@ -259,6 +259,10 @@ class CurlyComponentManager {
     }
 
     component._transitionTo('hasElement');
+  }
+
+  didRenderLayout({ component }, bounds) {
+    component[BOUNDS] = bounds;
   }
 
   getTag({ component }) {

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -119,17 +119,10 @@ class CurlyComponentManager {
 
       // THOUGHT: It might be nice to have a static method on EvaluatedArgs that
       // can merge two sets of args for us.
-      let mergedArgs = EvaluatedArgs.create({
-        named: EvaluatedNamedArgs.create({
-          map: mergedNamed
-        }),
-        positional: EvaluatedPositionalArgs.create({
-          values: mergedPositional
-        })
-      });
-
-      // Preserve the invocation args' `internal` storage.
-      mergedArgs.internal = args.internal;
+      let mergedArgs = EvaluatedArgs.create(
+        EvaluatedPositionalArgs.create(mergedPositional),
+        EvaluatedNamedArgs.create(mergedNamed)
+      );
 
       return mergedArgs;
     }

--- a/packages/ember-glimmer/lib/syntax/outlet.js
+++ b/packages/ember-glimmer/lib/syntax/outlet.js
@@ -116,6 +116,7 @@ class AbstractOutletComponentManager {
   }
 
   didCreateElement() {}
+  didRenderLayout() {}
   didCreate(state) {}
   update(state, args, dynamicScope) {}
   didUpdate(state) {}

--- a/packages/ember-glimmer/lib/syntax/render.js
+++ b/packages/ember-glimmer/lib/syntax/render.js
@@ -79,6 +79,7 @@ class AbstractRenderManager {
   }
 
   didCreateElement() {}
+  didRenderLayout() {}
   didCreate(state) {}
   update(state, args, dynamicScope) {}
   didUpdate(state) {}

--- a/packages/ember-glimmer/tests/integration/components/utils-test.js
+++ b/packages/ember-glimmer/tests/integration/components/utils-test.js
@@ -1,6 +1,7 @@
 import { moduleFor, RenderingTest } from '../../utils/test-case';
 import { Component } from '../../utils/helpers';
 import {
+  getViewBounds,
   getViewClientRects,
   getViewBoundingClientRect
 } from 'ember-views/system/utils';
@@ -27,7 +28,48 @@ let ClientRectListCtor, ClientRectCtor;
 })();
 
 moduleFor('ember-views/system/utils', class extends RenderingTest {
-  ['@htmlbars getViewClientRects'](assert) {
+  ['@test getViewBounds on a regular component'](assert) {
+    let component;
+    this.registerComponent('hi-mom', {
+      ComponentClass: Component.extend({
+        init() {
+          this._super(...arguments);
+          component = this;
+        }
+      }),
+      template: `<p>Hi, mom!</p>`
+    });
+
+    this.render(`{{hi-mom}}`);
+
+    let bounds = getViewBounds(component);
+
+    assert.equal(bounds.firstNode(), component.element, 'a regular component should have a single node that is its element');
+    assert.equal(bounds.lastNode(), component.element, 'a regular component should have a single node that is its element');
+  }
+
+  ['@test getViewBounds on a tagless component'](assert) {
+    let component;
+    this.registerComponent('hi-mom', {
+      ComponentClass: Component.extend({
+        tagName: '',
+        init() {
+          this._super(...arguments);
+          component = this;
+        }
+      }),
+      template: `<span id="start-node">Hi,</span> <em id="before-end-node">mom</em>!`
+    });
+
+    this.render(`{{hi-mom}}`);
+
+    let bounds = getViewBounds(component);
+
+    assert.equal(bounds.firstNode(), this.$('#start-node')[0], 'a tagless component should have a range enclosing all of its nodes');
+    assert.equal(bounds.lastNode(), this.$('#before-end-node')[0].nextSibling, 'a tagless component should have a range enclosing all of its nodes');
+  }
+
+  ['@test getViewClientRects'](assert) {
     if (!hasGetClientRects || !ClientRectListCtor) {
       assert.ok(true, 'The test environment does not support the DOM API required to run this test.');
       return;
@@ -49,7 +91,7 @@ moduleFor('ember-views/system/utils', class extends RenderingTest {
     assert.ok(getViewClientRects(component) instanceof ClientRectListCtor);
   }
 
-  ['@htmlbars getViewBoudningClientRect'](assert) {
+  ['@test getViewBoudningClientRect'](assert) {
     if (!hasGetBoundingClientRect || !ClientRectCtor) {
       assert.ok(true, 'The test environment does not support the DOM API required to run this test.');
       return;

--- a/packages/ember-htmlbars/lib/renderer.js
+++ b/packages/ember-htmlbars/lib/renderer.js
@@ -274,6 +274,32 @@ Renderer.prototype.didDestroyElement = function (view) {
   }
 };
 
+class ConcreteBounds {
+  constructor(parent, first, last) {
+    this.parent = parent;
+    this.first  = first;
+    this.last   = last;
+  }
+
+  parentElement() {
+    return this.parent;
+  }
+
+  firstNode() {
+    return this.first;
+  }
+
+  lastNode() {
+    return this.last;
+  }
+}
+
+Renderer.prototype.getBounds = function (view) {
+  let first = view._renderNode.firstNode;
+  let last = view._renderNode.lastNode;
+  let parent = first.parentElement;
+  return new ConcreteBounds(parent, first, last);
+};
 
 Renderer.prototype.register = function Renderer_register(view) {
   assert('Attempted to register a view with an id already in use: ' + view.elementId, !this._viewRegistry[view.elementId]);

--- a/packages/ember-views/lib/system/utils.js
+++ b/packages/ember-views/lib/system/utils.js
@@ -20,13 +20,25 @@ export const STYLE_WARNING = '' +
 
 /**
   @private
+  @method getViewBounds
+  @param {Ember.View} view
+*/
+export function getViewBounds(view) {
+  return view.renderer.getBounds(view);
+}
+
+/**
+  @private
   @method getViewRange
   @param {Ember.View} view
 */
-function getViewRange(view) {
+export function getViewRange(view) {
+  let bounds = getViewBounds(view);
+
   let range = document.createRange();
-  range.setStartBefore(view._renderNode.firstNode);
-  range.setEndAfter(view._renderNode.lastNode);
+  range.setStartBefore(bounds.firstNode());
+  range.setEndAfter(bounds.lastNode());
+
   return range;
 }
 


### PR DESCRIPTION
`getViewBounds` is the primitive that is used to implement `getViewRange`, `getViewClientRects`, etc
