### PR TITLE
Fix isObject deopt

### DIFF
--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -10,7 +10,7 @@ function firstKey(path) {
 }
 
 function isObject(obj) {
-  return obj && (typeof obj === 'object');
+  return typeof obj === 'object' && obj;
 }
 
 function isVolatile(obj) {


### PR DESCRIPTION
This deopts the ChainNode constructor because inlining

![img](https://cl.ly/1H2g0b0P2o1L/mrale_ph_irhydra_2__phase-82-0.png)

Fixes #14113 
