### PR TITLE
Fix test failures when randomized.

### DIFF
--- a/packages/ember-runtime/tests/ext/rsvp_test.js
+++ b/packages/ember-runtime/tests/ext/rsvp_test.js
@@ -3,7 +3,13 @@ import { setOnerror, getOnerror } from 'ember-metal/error_handler';
 import run from 'ember-metal/run_loop';
 import RSVP from 'ember-runtime/ext/rsvp';
 
-QUnit.module('Ember.RSVP');
+const ORIGINAL_ONERROR = getOnerror();
+
+QUnit.module('Ember.RSVP', {
+  teardown() {
+    setOnerror(ORIGINAL_ONERROR);
+  }
+});
 
 QUnit.test('Ensure that errors thrown from within a promise are sent to the console', function() {
   let error = new Error('Error thrown in a promise for testing purposes.');

--- a/packages/ember-runtime/tests/mixins/promise_proxy_test.js
+++ b/packages/ember-runtime/tests/mixins/promise_proxy_test.js
@@ -17,6 +17,10 @@ QUnit.test('present on ember namespace', function() {
 QUnit.module('Ember.PromiseProxy - ObjectProxy', {
   setup() {
     ObjectPromiseProxy = ObjectProxy.extend(PromiseProxyMixin);
+  },
+
+  teardown() {
+    RSVP.on('error', onerrorDefault);
   }
 });
 

--- a/packages/ember-runtime/tests/system/lazy_load_test.js
+++ b/packages/ember-runtime/tests/system/lazy_load_test.js
@@ -1,7 +1,14 @@
 import run from 'ember-metal/run_loop';
-import {onLoad, runLoadHooks} from 'ember-runtime/system/lazy_load';
+import {onLoad, runLoadHooks, _loaded } from 'ember-runtime/system/lazy_load';
 
-QUnit.module('Lazy Loading');
+QUnit.module('Lazy Loading', {
+  teardown() {
+    let keys = Object.keys(_loaded);
+    for (let i = 0; i < keys.length; i++) {
+      delete _loaded[keys[i]];
+    }
+  }
+});
 
 QUnit.test('if a load hook is registered, it is executed when runLoadHooks are exected', function() {
   let count = 0;

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -17,6 +17,9 @@ QUnit.module('ember-testing Acceptance', {
   setup() {
     jQuery('<style>#ember-testing-container { position: absolute; background: white; bottom: 0; right: 0; width: 640px; height: 384px; overflow: auto; z-index: 9999; border: 1px solid #ccc; } #ember-testing { zoom: 50%; }</style>').appendTo('head');
     jQuery('<div id="ember-testing-container"><div id="ember-testing"></div></div>').appendTo('body');
+
+    originalAdapter = Test.adapter;
+
     run(function() {
       indexHitCount = 0;
 
@@ -86,8 +89,6 @@ QUnit.module('ember-testing Acceptance', {
     visit = window.visit;
     andThen = window.andThen;
     currentURL = window.currentURL;
-
-    originalAdapter = Test.adapter;
   },
 
   teardown() {

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -1018,10 +1018,7 @@ QUnit.module('can override built-in helpers', {
   },
 
   teardown() {
-    App.removeTestHelpers();
-    jQuery('#ember-testing-container, #ember-testing').remove();
-    run(App, App.destroy);
-    App = null;
+    cleanup();
 
     Test._helpers.visit = originalVisitHelper;
     Test._helpers.find  = originalFindHelper;

--- a/tests/index.html
+++ b/tests/index.html
@@ -162,6 +162,10 @@
         QUnit.config.urlConfig.push('nojshint');
         QUnit.config.urlConfig.push('forceskip');
 
+        if (QUnit.config.seed) {
+          QUnit.config.reorder = false;
+        }
+
         QUnit.begin(function() {
           if (QUnit.urlParams.hideskipped) {
             $('#qunit-tests').addClass('hideskipped');


### PR DESCRIPTION
- Fix a number of issues with tests not cleaning up properly.
- Prevent reordering when using `seed` URL config.
