### PR TITLE
[BUGFIX beta] Avoid rerendering outlet state during router destruction.

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -140,6 +140,10 @@ const EmberRouter = EmberObject.extend(Evented, {
       this._engineInstances = new EmptyObject();
       this._engineInfoByRoute = new EmptyObject();
     }
+
+    // avoid shaping issues with checks during `_setOutlets`
+    this.isDestroyed = false;
+    this.isDestroying = false;
   },
 
   /*
@@ -266,6 +270,11 @@ const EmberRouter = EmberObject.extend(Evented, {
   },
 
   _setOutlets() {
+    // This is triggered async during Ember.Route#willDestroy.
+    // If the router is also being destroyed we do not want to
+    // to create another this._toplevelView (and leak the renderer)
+    if (this.isDestroying || this.isDestroyed) { return; }
+
     let handlerInfos = this.router.currentHandlerInfos;
     let route;
     let defaultParentState;

--- a/packages/ember/tests/application_lifecycle_test.js
+++ b/packages/ember/tests/application_lifecycle_test.js
@@ -125,6 +125,34 @@ QUnit.test('Destroying the application resets the router before the appInstance 
   equal(controllerFor(appInstance, 'application').get('selectedMenuItem'), null);
 });
 
+QUnit.test('Destroying a route after the router does create an undestroyed `toplevelView`', function() {
+  App.Router.map(function() {
+    this.route('home', { path: '/' });
+  });
+
+  setTemplates({
+    index: compile('Index!'),
+    application: compile('Application! {{outlet}}')
+  });
+
+  App.IndexRoute = Route.extend();
+  run(App, 'advanceReadiness');
+
+  handleURL('/');
+
+  let router = appInstance.lookup('router:main');
+  let route = appInstance.lookup('route:index');
+
+  run(router, 'destroy');
+  equal(router._toplevelView, null, 'the toplevelView was cleared');
+
+  run(route, 'destroy');
+  equal(router._toplevelView, null, 'the toplevelView was not reinitialized');
+
+  run(App, 'destroy');
+  equal(router._toplevelView, null, 'the toplevelView was not reinitialized');
+});
+
 QUnit.test('initializers can augment an applications customEvents hash', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
During each `Ember.Route`'s `willDestroy` we trigger a `run.once(this.router, '_setOutlets');`. This is so that the routes views are destroyed properly (by removing them from the outlet state).

During `Ember.Router`'s `willDestroy` we clear `this._toplevelView` (along with a bunch of other cleanup).

These two things combined can mean that `this._toplevelView` is `null` when `_setOutlets` is called again (during the `Router`'s destruction). In that scenario we are actually creating another `this._toplevelView` and setting up another rendered root (since one doesn't exist). When this happens the newly created root is never cleaned up, since the Router's `willDestroy` has already ran and can no longer clean up after itself.

---

This fixes a number of test failures that crop up when doing fuzz testing (via `seed` URL param with QUnit).
