### PR TITLE
Prevent JIT related issue with Safari + method named apply.

### DIFF
--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -59,7 +59,7 @@ function applyAttributeBindings(element, attributeBindings, component, operation
 
     if (seen.indexOf(attribute) === -1) {
       seen.push(attribute);
-      AttributeBinding.apply(element, component, parsed, operations);
+      AttributeBinding.install(element, component, parsed, operations);
     }
 
     i--;
@@ -70,7 +70,7 @@ function applyAttributeBindings(element, attributeBindings, component, operation
   }
 
   if (seen.indexOf('style') === -1) {
-    IsVisibleBinding.apply(element, component, operations);
+    IsVisibleBinding.install(element, component, operations);
   }
 }
 
@@ -232,7 +232,7 @@ class CurlyComponentManager {
       applyAttributeBindings(element, attributeBindings, component, operations);
     } else {
       operations.addStaticAttribute(element, 'id', component.elementId);
-      IsVisibleBinding.apply(element, component, operations);
+      IsVisibleBinding.install(element, component, operations);
     }
 
     if (classRef) {
@@ -247,7 +247,7 @@ class CurlyComponentManager {
 
     if (classNameBindings && classNameBindings.length) {
       classNameBindings.forEach(binding => {
-        ClassNameBinding.apply(element, component, binding, operations);
+        ClassNameBinding.install(element, component, binding, operations);
       });
     }
 

--- a/packages/ember-glimmer/lib/utils/bindings.js
+++ b/packages/ember-glimmer/lib/utils/bindings.js
@@ -30,7 +30,7 @@ export const AttributeBinding = {
     }
   },
 
-  apply(element, component, parsed, operations) {
+  install(element, component, parsed, operations) {
     let [prop, attribute, isSimple] = parsed;
 
     if (attribute === 'id') {
@@ -104,7 +104,7 @@ class StyleBindingReference extends CachedReference {
 }
 
 export const IsVisibleBinding = {
-  apply(element, component, operations) {
+  install(element, component, operations) {
     operations.addDynamicAttribute(element, 'style', map(referenceForKey(component, 'isVisible'), this.mapStyleValue));
   },
 
@@ -114,7 +114,7 @@ export const IsVisibleBinding = {
 };
 
 export const ClassNameBinding = {
-  apply(element, component, microsyntax, operations) {
+  install(element, component, microsyntax, operations) {
     let [ prop, truthy, falsy ] = microsyntax.split(':');
     let isPath = prop.indexOf('.') > -1;
     let parts = isPath && prop.split('.');


### PR DESCRIPTION
When this test URL is ran in Safari with the devtools closed:

```
/tests/index.html?hideskipped&hidepassed&enableoptionalfeatures&seed=5rbluti5zsr&notrycatch
```

Against ffde3384b65647790de00aaf712e23e92ac38258

The following error is thrown:

```
TypeError: undefined is not an object (evaluating 'parsed[0]')

apply@http://localhost:7200/ember.debug.js:12504:24
applyAttributeBindings@http://localhost:7200/ember.debug.js:11478:58
didCreateElement@http://localhost:7200/ember.debug.js:11680:31
evaluate@http://localhost:7200/ember.debug.js:57533:37
execute@http://localhost:7200/ember.debug.js:63697:36
render@http://localhost:7200/ember.debug.js:63246:30
render@http://localhost:7200/ember.debug.js:11258:52
runInTransaction@http://localhost:7200/ember.debug.js:30852:17
transaction@http://localhost:7200/ember.debug.js:11280:43
_transaction@http://localhost:7200/ember.debug.js:11287:22
_renderRoot@http://localhost:7200/ember.debug.js:11295:24
appendOutletView@http://localhost:7200/ember.debug.js:11176:23
appendTo@http://localhost:7200/ember.debug.js:13986:58
didCreateRootView@http://localhost:7200/ember.debug.js:4003:20
_setOutlets@http://localhost:7200/ember.debug.js:36065:35
invoke@http://localhost:7200/ember.debug.js:1068:20
flush@http://localhost:7200/ember.debug.js:1132:17
flush@http://localhost:7200/ember.debug.js:938:22
end@http://localhost:7200/ember.debug.js:250:30
run@http://localhost:7200/ember.debug.js:372:21
run@http://localhost:7200/ember.debug.js:30055:32
bootApplication@http://localhost:7200/ember-tests.js:97711:32
http://localhost:7200/ember-tests.js:98835:20
runTest@http://localhost:7200/qunit/qunit.js:843:32
run@http://localhost:7200/qunit/qunit.js:823:11
http://localhost:7200/qunit/qunit.js:970:14
process@http://localhost:7200/qunit/qunit.js:629:24
begin@http://localhost:7200/qunit/qunit.js:611:9
http://localhost:7200/qunit/qunit.js:671:9
```

It seems that all arguments to `AttributeBindings.apply` after the
second (`parsed` and `operations` in this case) are `undefined`.
Renaming the method from `apply` to `install` resolves the error.

:sob: :sob: :sob: :sob: :sob: :sob: :sob: :sob:
