### PR TITLE
Make `getViewBounds` return a snapshot

### DIFF
--- a/packages/ember-glimmer/lib/renderer.js
+++ b/packages/ember-glimmer/lib/renderer.js
@@ -157,7 +157,13 @@ class Renderer {
   }
 
   getBounds(view) {
-    return view[BOUNDS];
+    let bounds = view[BOUNDS];
+
+    let parentElement = bounds.parentElement();
+    let firstNode = bounds.firstNode();
+    let lastNode = bounds.lastNode();
+
+    return { parentElement, firstNode, lastNode };
   }
 
   _renderRoot(root, template, self, parentElement, dynamicScope) {

--- a/packages/ember-glimmer/tests/integration/components/utils-test.js
+++ b/packages/ember-glimmer/tests/integration/components/utils-test.js
@@ -42,10 +42,11 @@ moduleFor('ember-views/system/utils', class extends RenderingTest {
 
     this.render(`{{hi-mom}}`);
 
-    let bounds = getViewBounds(component);
+    let { parentElement, firstNode, lastNode } = getViewBounds(component);
 
-    assert.equal(bounds.firstNode(), component.element, 'a regular component should have a single node that is its element');
-    assert.equal(bounds.lastNode(), component.element, 'a regular component should have a single node that is its element');
+    assert.equal(parentElement, this.element, 'a regular component should have the right parentElement');
+    assert.equal(firstNode, component.element, 'a regular component should have a single node that is its element');
+    assert.equal(lastNode, component.element, 'a regular component should have a single node that is its element');
   }
 
   ['@test getViewBounds on a tagless component'](assert) {
@@ -63,10 +64,11 @@ moduleFor('ember-views/system/utils', class extends RenderingTest {
 
     this.render(`{{hi-mom}}`);
 
-    let bounds = getViewBounds(component);
+    let { parentElement, firstNode, lastNode } = getViewBounds(component);
 
-    assert.equal(bounds.firstNode(), this.$('#start-node')[0], 'a tagless component should have a range enclosing all of its nodes');
-    assert.equal(bounds.lastNode(), this.$('#before-end-node')[0].nextSibling, 'a tagless component should have a range enclosing all of its nodes');
+    assert.equal(parentElement, this.element, 'a regular component should have the right parentElement');
+    assert.equal(firstNode, this.$('#start-node')[0], 'a tagless component should have a range enclosing all of its nodes');
+    assert.equal(lastNode, this.$('#before-end-node')[0].nextSibling, 'a tagless component should have a range enclosing all of its nodes');
   }
 
   ['@test getViewClientRects'](assert) {
@@ -91,7 +93,7 @@ moduleFor('ember-views/system/utils', class extends RenderingTest {
     assert.ok(getViewClientRects(component) instanceof ClientRectListCtor);
   }
 
-  ['@test getViewBoudningClientRect'](assert) {
+  ['@test getViewBoundingClientRect'](assert) {
     if (!hasGetBoundingClientRect || !ClientRectCtor) {
       assert.ok(true, 'The test environment does not support the DOM API required to run this test.');
       return;

--- a/packages/ember-htmlbars/lib/renderer.js
+++ b/packages/ember-htmlbars/lib/renderer.js
@@ -282,31 +282,10 @@ Renderer.prototype.didDestroyElement = function (view) {
   }
 };
 
-class ConcreteBounds {
-  constructor(parent, first, last) {
-    this.parent = parent;
-    this.first  = first;
-    this.last   = last;
-  }
-
-  parentElement() {
-    return this.parent;
-  }
-
-  firstNode() {
-    return this.first;
-  }
-
-  lastNode() {
-    return this.last;
-  }
-}
-
 Renderer.prototype.getBounds = function (view) {
-  let first = view._renderNode.firstNode;
-  let last = view._renderNode.lastNode;
-  let parent = first.parentElement;
-  return new ConcreteBounds(parent, first, last);
+  let { firstNode, lastNode } = view._renderNode;
+  let parentElement = firstNode.parentElement;
+  return { parentElement, firstNode, lastNode };
 };
 
 Renderer.prototype.register = function Renderer_register(view) {

--- a/packages/ember-views/lib/system/utils.js
+++ b/packages/ember-views/lib/system/utils.js
@@ -36,8 +36,8 @@ export function getViewRange(view) {
   let bounds = getViewBounds(view);
 
   let range = document.createRange();
-  range.setStartBefore(bounds.firstNode());
-  range.setEndAfter(bounds.lastNode());
+  range.setStartBefore(bounds.firstNode);
+  range.setEndAfter(bounds.lastNode);
 
   return range;
 }


### PR DESCRIPTION
This avoids leaking the internals on the RenderNode (htmlbars) and Tracker (glimmer) objects, and works for all the known use cases (Ember Inspector and Liquid Fire).

cc @teddyzeenny @ef4 
