### PR TITLE
Update Glimmer to 0.11.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "git-repo-info": "^1.1.4",
     "git-repo-version": "^0.3.1",
     "github": "^0.2.3",
-    "glimmer-engine": "0.10.2",
+    "glimmer-engine": "0.11.0",
     "glob": "^5.0.13",
     "htmlbars": "0.14.24",
     "mocha": "^2.4.5",

--- a/packages/ember-glimmer/lib/helpers/component.js
+++ b/packages/ember-glimmer/lib/helpers/component.js
@@ -5,16 +5,16 @@ import { assert } from 'ember-metal/debug';
 import assign from 'ember-metal/assign';
 
 export class ClosureComponentReference extends CachedReference {
-  static create(args, blockMeta, env) {
-    return new ClosureComponentReference(args, blockMeta, env);
+  static create(args, symbolTable, env) {
+    return new ClosureComponentReference(args, symbolTable, env);
   }
 
-  constructor(args, blockMeta, env) {
+  constructor(args, symbolTable, env) {
     super();
     this.defRef = args.positional.at(0);
     this.env = env;
     this.tag = args.positional.at(0).tag;
-    this.blockMeta = blockMeta;
+    this.symbolTable = symbolTable;
     this.args = args;
     this.lastDefinition = undefined;
     this.lastName = undefined;
@@ -24,7 +24,7 @@ export class ClosureComponentReference extends CachedReference {
     // TODO: Figure out how to extract this because it's nearly identical to
     // DynamicComponentReference::compute(). The only differences besides
     // currying are in the assertion messages.
-    let { args, defRef, env, blockMeta, lastDefinition, lastName } = this;
+    let { args, defRef, env, symbolTable, lastDefinition, lastName } = this;
     let nameOrDef = defRef.value();
     let definition = null;
 
@@ -35,7 +35,7 @@ export class ClosureComponentReference extends CachedReference {
     this.lastName = nameOrDef;
 
     if (typeof nameOrDef === 'string') {
-      definition = env.getComponentDefinition([nameOrDef], blockMeta);
+      definition = env.getComponentDefinition([nameOrDef], symbolTable);
       assert(`The component helper cannot be used without a valid component name. You used "${nameOrDef}" via (component "${nameOrDef}")`, definition);
     } else if (isComponentDefinition(nameOrDef)) {
       definition = nameOrDef;
@@ -127,7 +127,7 @@ export default {
   isInternalHelper: true,
 
   toReference(args, env) {
-    // TODO: Need to figure out what to do about blockMeta here.
+    // TODO: Need to figure out what to do about symbolTable here.
     return ClosureComponentReference.create(args, null, env);
   }
 };

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -104,16 +104,17 @@ function applyAttributeBindings(element, attributeBindings, component, operation
 }
 
 export class CurlyComponentSyntax extends StatementSyntax {
-  constructor({ args, definition, templates }) {
+  constructor({ args, definition, templates, symbolTable }) {
     super();
     this.args = args;
     this.definition = definition;
     this.templates = templates;
+    this.symbolTable = symbolTable;
     this.shadow = null;
   }
 
   compile(builder) {
-    builder.component.static(this);
+    builder.component.static(this.definition, this.args, this.templates, this.symbolTable, this.shadow);
   }
 }
 

--- a/packages/ember-glimmer/lib/syntax/dynamic-component.js
+++ b/packages/ember-glimmer/lib/syntax/dynamic-component.js
@@ -12,59 +12,59 @@ function dynamicComponentFor(vm) {
   let env     = vm.env;
   let args    = vm.getArgs();
   let nameRef = args.positional.at(0);
-  let { blockMeta } = this;
+  let { symbolTable } = this;
 
-  return new DynamicComponentReference({ nameRef, env, blockMeta });
+  return new DynamicComponentReference({ nameRef, env, symbolTable });
 }
 
 export class DynamicComponentSyntax extends StatementSyntax {
   // for {{component componentName}}
-  static create({ args, templates, blockMeta }) {
+  static create({ args, templates, symbolTable }) {
     let definitionArgs = ArgsSyntax.fromPositionalArgs(args.positional.slice(0, 1));
     let invocationArgs = ArgsSyntax.build(args.positional.slice(1), args.named);
-    return new this({ definitionArgs, args: invocationArgs, templates, blockMeta });
+    return new this({ definitionArgs, args: invocationArgs, templates, symbolTable });
   }
 
   // Transforms {{foo.bar with=args}} or {{#foo.bar with=args}}{{/foo.bar}}
   // into {{component foo.bar with=args}} or
   // {{#component foo.bar with=args}}{{/component}}
   // with all of it's arguments
-  static fromPath({ path, args, templates, blockMeta }) {
+  static fromPath({ path, args, templates, symbolTable }) {
     let positional = ArgsSyntax.fromPositionalArgs(PositionalArgsSyntax.build([GetSyntax.build(path.join('.'))]));
 
-    return new this({ definitionArgs: positional, args, templates, blockMeta });
+    return new this({ definitionArgs: positional, args, templates, symbolTable });
   }
 
-  constructor({ definitionArgs, args, templates, blockMeta }) {
+  constructor({ definitionArgs, args, templates, symbolTable }) {
     super();
     this.definition = dynamicComponentFor.bind(this);
     this.definitionArgs = definitionArgs;
     this.args = args;
     this.templates = templates;
+    this.symbolTable = symbolTable;
     this.shadow = null;
-    this.blockMeta = blockMeta;
   }
 
   compile(builder) {
-    builder.component.dynamic(this);
+    builder.component.dynamic(this.definitionArgs, this.definition, this.args, this.templates, this.symbolTable, this.shadow);
   }
 }
 
 class DynamicComponentReference {
-  constructor({ nameRef, env, blockMeta, args }) {
+  constructor({ nameRef, env, symbolTable, args }) {
     this.tag = nameRef.tag;
     this.nameRef = nameRef;
     this.env = env;
-    this.blockMeta = blockMeta;
+    this.symbolTable = symbolTable;
     this.args = args;
   }
 
   value() {
-    let { env, nameRef, blockMeta } = this;
+    let { env, nameRef, symbolTable } = this;
     let nameOrDef = nameRef.value();
 
     if (typeof nameOrDef === 'string') {
-      let definition = env.getComponentDefinition([nameOrDef], blockMeta);
+      let definition = env.getComponentDefinition([nameOrDef], symbolTable);
 
       assert(`Could not find component named "${nameOrDef}" (no component or template with that name was found)`, definition);
 

--- a/packages/ember-glimmer/lib/syntax/outlet.js
+++ b/packages/ember-glimmer/lib/syntax/outlet.js
@@ -16,17 +16,18 @@ function outletComponentFor(vm) {
 }
 
 export class OutletSyntax extends StatementSyntax {
-  constructor({ args }) {
+  constructor({ args, symbolTable }) {
     super();
     this.definitionArgs = args;
     this.definition = outletComponentFor;
     this.args = ArgsSyntax.empty();
+    this.symbolTable = symbolTable;
     this.templates = null;
     this.shadow = null;
   }
 
   compile(builder) {
-    builder.component.dynamic(this);
+    builder.component.dynamic(this.definitionArgs, this.definition, this.args, this.templates, this.symbolTable, this.shadow);
   }
 }
 

--- a/packages/ember-glimmer/lib/syntax/render.js
+++ b/packages/ember-glimmer/lib/syntax/render.js
@@ -41,17 +41,18 @@ function makeComponentDefinition(vm) {
 }
 
 export class RenderSyntax extends StatementSyntax {
-  constructor({ args }) {
+  constructor({ args, symbolTable }) {
     super();
     this.definitionArgs = args;
     this.definition = makeComponentDefinition;
     this.args = ArgsSyntax.fromPositionalArgs(args.positional.slice(1, 2));
     this.templates = null;
+    this.symbolTable = symbolTable;
     this.shadow = null;
   }
 
   compile(builder) {
-    builder.component.dynamic(this);
+    builder.component.dynamic(this.definitionArgs, this.definition, this.args, this.templates, this.symbolTable, this.shadow);
   }
 }
 


### PR DESCRIPTION
- Threads `SymbolTable` throughout the system instead of `blockMeta`.
- Change a few argument signatures for Glimmer syntax's (moving from
  options hash to positional, etc).
