### PR TITLE
[BUGFIX beta] Fix basic component and helper resolution in engines.

### DIFF
--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -484,6 +484,7 @@ BootOptions.prototype.toEnvironment = function() {
   let env = assign({}, environment);
   // For compatibility with existing code
   env.hasDOM = this.isBrowser;
+  env.isInteractive = this.isInteractive;
   env.options = this;
   return env;
 };

--- a/packages/ember-application/lib/system/engine-instance.js
+++ b/packages/ember-application/lib/system/engine-instance.js
@@ -13,6 +13,7 @@ import { getEngineParent, setEngineParent } from 'ember-application/system/engin
 import { assert } from 'ember-metal/debug';
 import run from 'ember-metal/run_loop';
 import RSVP from 'ember-runtime/ext/rsvp';
+import { guidFor } from 'ember-metal/utils';
 import isEnabled from 'ember-metal/features';
 
 /**
@@ -38,6 +39,8 @@ const EngineInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
 
   init() {
     this._super(...arguments);
+
+    guidFor(this);
 
     let base = this.base;
 

--- a/packages/ember-application/lib/system/engine-instance.js
+++ b/packages/ember-application/lib/system/engine-instance.js
@@ -170,18 +170,29 @@ if (isEnabled('ember-application-engines')) {
     cloneParentDependencies() {
       let parent = getEngineParent(this);
 
-      [
+      let registrations = [
         'route:basic',
         'event_dispatcher:main',
         'service:-routing'
-      ].forEach(key => this.register(key, parent.resolveRegistration(key)));
+      ];
 
-      [
+      if (isEnabled('ember-glimmer')) {
+        registrations.push('service:-glimmer-environment');
+      }
+
+      registrations.forEach(key => this.register(key, parent.resolveRegistration(key)));
+
+      let env = parent.lookup('-environment:main');
+      this.register('-environment:main', env, { instantiate: false });
+
+      let singletons = [
         'router:main',
         P`-bucket-cache:main`,
         '-view-registry:main',
-        '-environment:main'
-      ].forEach(key => this.register(key, parent.lookup(key), { instantiate: false }));
+        `renderer:-${env.isInteractive ? 'dom' : 'inert'}`
+      ];
+
+      singletons.forEach(key => this.register(key, parent.lookup(key), { instantiate: false }));
 
       this.inject('view', '_environment', '-environment:main');
       this.inject('route', '_environment', '-environment:main');

--- a/packages/ember-application/tests/system/application_instance_test.js
+++ b/packages/ember-application/tests/system/application_instance_test.js
@@ -141,7 +141,7 @@ QUnit.test('unregistering a factory clears all cached instances of that factory'
 
 if (isEnabled('ember-application-engines')) {
   QUnit.test('can build and boot a registered engine', function(assert) {
-    assert.expect(8);
+    assert.expect(isEnabled('ember-glimmer') ? 10 : 9);
 
     let ChatEngine = Engine.extend();
     let chatEngineInstance;
@@ -158,23 +158,34 @@ if (isEnabled('ember-application-engines')) {
       .then(() => {
         assert.ok(true, 'boot successful');
 
-        [
+        let registrations = [
           'route:basic',
           'event_dispatcher:main',
           'service:-routing'
-        ].forEach(key => {
+        ];
+
+        if (isEnabled('ember-glimmer')) {
+          registrations.push('service:-glimmer-environment');
+        }
+
+        registrations.forEach(key => {
           assert.strictEqual(
             chatEngineInstance.resolveRegistration(key),
             appInstance.resolveRegistration(key),
             `Engine and parent app share registrations for '${key}'`);
         });
 
-        [
+        let singletons = [
           'router:main',
           P`-bucket-cache:main`,
           '-view-registry:main',
           '-environment:main'
-        ].forEach(key => {
+        ];
+
+        let env = appInstance.lookup('-environment:main');
+        singletons.push(env.isInteractive ? 'renderer:-dom' : 'renderer:-inert');
+
+        singletons.forEach(key => {
           assert.strictEqual(
             chatEngineInstance.lookup(key),
             appInstance.lookup(key),

--- a/packages/ember-application/tests/system/visit_test.js
+++ b/packages/ember-application/tests/system/visit_test.js
@@ -9,6 +9,7 @@ import Route from 'ember-routing/system/route';
 import Router from 'ember-routing/system/router';
 import Component from 'ember-templates/component';
 import { compile } from 'ember-template-compiler/tests/utils/helpers';
+import { helper } from 'ember-templates/helper';
 import jQuery from 'ember-views/system/jquery';
 
 let App = null;
@@ -383,6 +384,75 @@ QUnit.test('visit() returns a promise that resolves without rendering when shoul
   return run(App, 'visit', '/blog', { shouldRender: false }).then(instance => {
     assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
     assert.strictEqual(jQuery('#qunit-fixture').children().length, 0, 'there are still no elements in the fixture element after visit');
+  });
+});
+
+QUnit.test('visit() on engine resolves engine component', function(assert) {
+  assert.expect(2);
+
+  run(() => {
+    createApplication();
+
+    // Register engine
+    let BlogEngine = Engine.extend({
+      init(...args) {
+        this._super.apply(this, args);
+        this.register('template:application', compile('{{cache-money}}'));
+        this.register('template:components/cache-money', compile(`
+          <p>Dis cache money</p>
+        `));
+        this.register('component:cache-money', Component.extend({}));
+      }
+    });
+    App.register('engine:blog', BlogEngine);
+
+    // Register engine route map
+    let BlogMap = function() {};
+    App.register('route-map:blog', BlogMap);
+
+    App.Router.map(function() {
+      this.mount('blog');
+    });
+  });
+
+  assert.strictEqual(jQuery('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
+
+  return run(App, 'visit', '/blog', { shouldRender: true }).then(instance => {
+    assert.strictEqual(jQuery('#qunit-fixture').find('p').text(), 'Dis cache money', 'Engine component is resolved');
+  });
+});
+
+QUnit.test('visit() on engine resolves engine helper', function(assert) {
+  assert.expect(2);
+
+  run(() => {
+    createApplication();
+
+    // Register engine
+    let BlogEngine = Engine.extend({
+      init(...args) {
+        this._super.apply(this, args);
+        this.register('template:application', compile('{{swag}}'));
+        this.register('helper:swag', helper(function() {
+          return 'turnt up';
+        }));
+      }
+    });
+    App.register('engine:blog', BlogEngine);
+
+    // Register engine route map
+    let BlogMap = function() {};
+    App.register('route-map:blog', BlogMap);
+
+    App.Router.map(function() {
+      this.mount('blog');
+    });
+  });
+
+  assert.strictEqual(jQuery('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
+
+  return run(App, 'visit', '/blog', { shouldRender: true }).then(instance => {
+    assert.strictEqual(jQuery('#qunit-fixture').text(), 'turnt up', 'Engine component is resolved');
   });
 });
 

--- a/packages/ember-glimmer/lib/helpers/component.js
+++ b/packages/ember-glimmer/lib/helpers/component.js
@@ -126,8 +126,7 @@ function curryArgs(definition, newArgs) {
 export default {
   isInternalHelper: true,
 
-  toReference(args, env) {
-    // TODO: Need to figure out what to do about symbolTable here.
-    return ClosureComponentReference.create(args, null, env);
+  toReference(args, env, symbolTable) {
+    return ClosureComponentReference.create(args, symbolTable, env);
   }
 };

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -9,6 +9,7 @@ import get from 'ember-metal/property_get';
 import { _instrumentStart } from 'ember-metal/instrumentation';
 import { ComponentDefinition } from 'glimmer-runtime';
 import Component from '../component';
+import { OWNER } from 'container/owner';
 
 const DEFAULT_LAYOUT = P`template:components/-default`;
 
@@ -230,10 +231,10 @@ class CurlyComponentManager {
 
   templateFor(component, env) {
     let Template = component.layout;
+    let owner = component[OWNER];
     if (Template) {
-      return env.getTemplate(Template);
+      return env.getTemplate(Template, owner);
     }
-    let { owner } = env;
     let layoutName = get(component, 'layoutName');
     if (layoutName) {
       let template = owner.lookup('template:' + layoutName);

--- a/packages/ember-glimmer/lib/template.js
+++ b/packages/ember-glimmer/lib/template.js
@@ -1,8 +1,8 @@
 import { Template } from 'glimmer-runtime';
+import { OWNER } from 'container/owner';
 
 class Wrapper {
-  constructor(id, env, spec) {
-    let { owner } = env;
+  constructor(id, env, owner, spec) {
     if (spec.meta) {
       spec.meta.owner = owner;
     } else {
@@ -39,8 +39,11 @@ export default function template(json) {
   let id = ++templateId;
   return {
     id,
-    create({ env }) {
-      return new Wrapper(id, env, JSON.parse(json));
+    create(options) {
+      let env = options.env;
+      let owner = options[OWNER];
+
+      return new Wrapper(id, env, owner, JSON.parse(json));
     }
   };
 }

--- a/packages/ember-glimmer/lib/template.js
+++ b/packages/ember-glimmer/lib/template.js
@@ -2,6 +2,14 @@ import { Template } from 'glimmer-runtime';
 
 class Wrapper {
   constructor(id, env, spec) {
+    let { owner } = env;
+    if (spec.meta) {
+      spec.meta.owner = owner;
+    } else {
+      spec.meta = {
+        owner
+      };
+    }
     this.id = id;
     this.env = env;
     this.spec = spec;

--- a/packages/ember-glimmer/tests/integration/application/engine-test.js
+++ b/packages/ember-glimmer/tests/integration/application/engine-test.js
@@ -1,0 +1,60 @@
+import packageName from '../../utils/package-name';
+import { moduleFor, ApplicationTest } from '../../utils/test-case';
+import { strip } from '../../utils/abstract-test-case';
+import { compile } from '../../utils/helpers';
+import Controller from 'ember-runtime/controllers/controller';
+import Engine from 'ember-application/system/engine';
+import isEnabled from 'ember-metal/features';
+
+// only run these tests for ember-glimmer when the feature is enabled, or for
+// ember-htmlbars when the feature is not enabled
+const shouldRun = isEnabled('ember-application-engines') && (
+  (
+    (isEnabled('ember-glimmer') && packageName === 'glimmer') ||
+    (!isEnabled('ember-glimmer') && packageName === 'htmlbars')
+  )
+);
+
+if (shouldRun) {
+  moduleFor('Application test: engine rendering', class extends ApplicationTest {
+    ['@test sharing a template between engine and application has separate refinements']() {
+      this.assert.expect(1);
+
+      let sharedTemplate = compile(strip`
+        <h1>{{contextType}}</h1>
+        {{ambiguous-curlies}}
+
+        {{outlet}}
+      `);
+
+      this.application.register('template:application', sharedTemplate);
+      this.registerController('application', Controller.extend({
+        contextType: 'Application',
+        'ambiguous-curlies': 'Controller Data!'
+      }));
+
+      this.router.map(function() {
+        this.mount('blog');
+      });
+      this.application.register('route-map:blog', function() { });
+
+      this.registerEngine('blog', Engine.extend({
+        init() {
+          this._super(...arguments);
+
+          this.register('controller:application', Controller.extend({
+            contextType: 'Engine'
+          }));
+          this.register('template:application', sharedTemplate);
+          this.register('template:components/ambiguous-curlies', compile(strip`
+          <p>Component!</p>
+        `));
+        }
+      }));
+
+      return this.visit('/blog').then(() => {
+        this.assertText('ApplicationController Data!EngineComponent!');
+      });
+    }
+  });
+}

--- a/packages/ember-glimmer/tests/unit/layout-cache-test.js
+++ b/packages/ember-glimmer/tests/unit/layout-cache-test.js
@@ -51,7 +51,7 @@ moduleFor('Layout cache test', class extends RenderingTest {
 
   templateFor(content) {
     let Factory = this.compile(content);
-    return this.env.getTemplate(Factory);
+    return this.env.getTemplate(Factory, this.owner);
   }
 
   ['@test each template is only compiled once'](assert) {

--- a/packages/ember-glimmer/tests/unit/template-factory-test.js
+++ b/packages/ember-glimmer/tests/unit/template-factory-test.js
@@ -28,12 +28,12 @@ moduleFor('Template factory test', class extends RenderingTest {
     assert.equal(env._templateCache.misses, 0, 'misses 0');
     assert.equal(env._templateCache.hits, 0, 'hits 0');
 
-    let precompiled = env.getTemplate(Precompiled);
+    let precompiled = env.getTemplate(Precompiled, env.owner);
 
     assert.equal(env._templateCache.misses, 1, 'misses 1');
     assert.equal(env._templateCache.hits, 0, 'hits 0');
 
-    let compiled = env.getTemplate(Compiled);
+    let compiled = env.getTemplate(Compiled, env.owner);
 
     assert.equal(env._templateCache.misses, 2, 'misses 2');
     assert.equal(env._templateCache.hits, 0, 'hits 0');

--- a/packages/ember-glimmer/tests/utils/abstract-test-case.js
+++ b/packages/ember-glimmer/tests/utils/abstract-test-case.js
@@ -307,6 +307,10 @@ export class AbstractApplicationTest extends TestCase {
   registerController(name, controller) {
     this.application.register(`controller:${name}`, controller);
   }
+
+  registerEngine(name, engine) {
+    this.application.register(`engine:${name}`, engine);
+  }
 }
 
 export class AbstractRenderingTest extends TestCase {

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -455,12 +455,6 @@ const EmberRouter = EmberObject.extend(Evented, {
   },
 
   willDestroy() {
-    if (this._toplevelView) {
-      this._toplevelView.destroy();
-      this._toplevelView = null;
-    }
-    this._super(...arguments);
-
     if (isEnabled('ember-application-engines')) {
       let instances = this._engineInstances;
       for (let name in instances) {
@@ -469,6 +463,12 @@ const EmberRouter = EmberObject.extend(Evented, {
         }
       }
     }
+
+    if (this._toplevelView) {
+      this._toplevelView.destroy();
+      this._toplevelView = null;
+    }
+    this._super(...arguments);
 
     this.reset();
   },


### PR DESCRIPTION
Rebase and update of https://github.com/emberjs/ember.js/pull/14112 (to use `symbolTable` throughout) which is a rebase of https://github.com/emberjs/ember.js/pull/14055.

Contains the following fixes:
- Clone additional parent dependencies into engine instances. Specifically service:-glimmer-environment (only for glimmer) and renderer:-dom or renderer:-inert
- Ensure that Cache lookups are performed using the correct owner.
- Ensure that engines are destroyed before top-level views so that top-level
  views are not re-instantiated during engine teardown.
