### PR TITLE
Refactor Descriptor

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -435,11 +435,10 @@ ComputedPropertyPrototype._set = function computedPropertySet(obj, keyName, valu
 };
 
 /* called before property is overridden */
-ComputedPropertyPrototype.teardown = function(obj, keyName) {
+ComputedPropertyPrototype.teardown = function(obj, keyName, isWatching, meta) {
   if (this._volatile) {
     return;
   }
-  let meta = metaFor(obj);
   let cache = meta.readableCache();
   if (cache && cache[keyName] !== undefined) {
     removeDependentKeys(this, obj, keyName, meta);

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -207,7 +207,7 @@ function applyMergedProperties(obj, key, value, values) {
 }
 
 function addNormalizedProperty(base, key, value, meta, descs, values, concats, mergings) {
-  if (value instanceof Descriptor) {
+  if (typeof value === 'object' && value && value.isDescriptor) {
     if (value === REQUIRED && descs[key]) { return CONTINUE; }
 
     // Wrap descriptor function to implement
@@ -661,8 +661,11 @@ Mixin.mixins = function(obj) {
   return ret;
 };
 
-const REQUIRED = new Descriptor();
-REQUIRED.toString = function() { return '(Required Property)'; };
+const REQUIRED = new (class extends Descriptor {
+  toString() {
+    return '(Required Property)';
+  }
+});
 
 /**
   Denotes a required property for a mixin
@@ -680,12 +683,12 @@ export function required() {
   return REQUIRED;
 }
 
-function Alias(methodName) {
-  this.isDescriptor = true;
-  this.methodName = methodName;
+class Alias extends Descriptor {
+  constructor() {
+    super();
+    this.methodName = methodName;
+  }
 }
-
-Alias.prototype = new Descriptor();
 
 /**
   Makes a method available via an additional name.


### PR DESCRIPTION
- Duck-type on `isDescriptor === true` instead of using `instanceof`
- Require all descriptors to have `setup` and `teardown`
- Refactored most descriptors to use ES6 classes except CP descriptors because it’s a big file and I ran out of time for it

cc @rwjblue @krisselden @stefanpenner 
