### PR TITLE
😪 Make `view.childViews` lazy

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -4,6 +4,7 @@
 */
 import { ENV } from 'ember-environment';
 import { assert, debug } from 'ember-metal/debug';
+import dictionary from 'ember-metal/dictionary';
 import libraries from 'ember-metal/libraries';
 import { isTesting } from 'ember-metal/testing';
 import { get } from 'ember-metal/property_get';
@@ -1037,7 +1038,7 @@ Application.reopenClass({
 });
 
 function commonSetupRegistry(registry) {
-  registry.register('-view-registry:main', { create() { return {}; } });
+  registry.register('-view-registry:main', { create() { return dictionary(null); } });
 
   registry.register('route:basic', Route);
   registry.register('event_dispatcher:main', EventDispatcher);

--- a/packages/ember-glimmer/lib/renderer.js
+++ b/packages/ember-glimmer/lib/renderer.js
@@ -8,6 +8,7 @@ import _runInTransaction from 'ember-metal/transaction';
 import isEnabled from 'ember-metal/features';
 import { BOUNDS } from './component';
 import { RootComponentDefinition } from './syntax/curly-component';
+import { getViewId } from 'ember-views/system/utils';
 
 let runInTransaction;
 
@@ -101,14 +102,14 @@ class Renderer {
     let self = new RootReference(view);
     let targetObject = view.outletState.render.controller;
     let ref = view.toReference();
-    let dynamicScope = new DynamicScope(view, ref, ref, true, targetObject);
+    let dynamicScope = new DynamicScope(null, ref, ref, true, targetObject);
     this._renderRoot(view, view.template, self, target, dynamicScope);
   }
 
   appendTo(view, target) {
     let rootDef = new RootComponentDefinition(view);
     let self = new RootReference(rootDef);
-    let dynamicScope = new DynamicScope(view, UNDEFINED_REFERENCE, UNDEFINED_REFERENCE, true, null);
+    let dynamicScope = new DynamicScope(null, UNDEFINED_REFERENCE, UNDEFINED_REFERENCE, true, null);
     this._renderRoot(view, this._rootTemplate, self, target, dynamicScope);
   }
 
@@ -126,12 +127,13 @@ class Renderer {
   }
 
   register(view) {
-    assert('Attempted to register a view with an id already in use: ' + view.elementId, !this._viewRegistry[view.elementId]);
-    this._viewRegistry[view.elementId] = view;
+    let id = getViewId(view);
+    assert('Attempted to register a view with an id already in use: ' + id, !this._viewRegistry[id]);
+    this._viewRegistry[id] = view;
   }
 
   unregister(view) {
-    delete this._viewRegistry[view.elementId];
+    delete this._viewRegistry[getViewId(view)];
   }
 
   remove(view) {

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -200,7 +200,9 @@ class CurlyComponentManager {
     dynamicScope.view = component;
     dynamicScope.targetObject = component;
 
-    parentView.appendChild(component);
+    if (parentView !== null) {
+      parentView.appendChild(component);
+    }
 
     component.trigger('didInitAttrs', { attrs });
     component.trigger('didReceiveAttrs', { newAttrs: attrs });

--- a/packages/ember-glimmer/lib/views/outlet.js
+++ b/packages/ember-glimmer/lib/views/outlet.js
@@ -131,8 +131,6 @@ export default class OutletView {
   }
 
   appendChild(instance) {
-    instance.parentView = this;
-    instance.ownerView = this;
   }
 
   rerender() {

--- a/packages/ember-glimmer/lib/views/outlet.js
+++ b/packages/ember-glimmer/lib/views/outlet.js
@@ -130,9 +130,6 @@ export default class OutletView {
     this._renderResult = this.renderer.appendOutletView(this, target);
   }
 
-  appendChild(instance) {
-  }
-
   rerender() {
     if (this._renderResult) { this.renderer.rerender(this); }
   }

--- a/packages/ember-glimmer/tests/integration/components/life-cycle-test.js
+++ b/packages/ember-glimmer/tests/integration/components/life-cycle-test.js
@@ -2,6 +2,7 @@ import { set } from 'ember-metal/property_set';
 import { Component } from '../../utils/helpers';
 import { strip } from '../../utils/abstract-test-case';
 import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { getViewId } from 'ember-views/system/utils';
 import run from 'ember-metal/run_loop';
 
 class LifeCycleHooksTest extends RenderingTest {
@@ -45,8 +46,9 @@ class LifeCycleHooksTest extends RenderingTest {
 
   assertRegisteredViews(label) {
     let viewRegistry = this.owner.lookup('-view-registry:main');
-    let actual = Object.keys(viewRegistry).sort();
-    let expected = this.componentRegistry.slice().sort();
+    let topLevelId = getViewId(this.component);
+    let actual = Object.keys(viewRegistry).sort().filter(id => id !== topLevelId);
+    let expected = this.componentRegistry.sort();
 
     this.assert.deepEqual(actual, expected, 'registered views - ' + label);
   }
@@ -54,7 +56,7 @@ class LifeCycleHooksTest extends RenderingTest {
   registerComponent(name, { template = null }) {
     let pushComponent = (instance) => {
       this.components[name] = instance;
-      this.componentRegistry.push(instance.elementId);
+      this.componentRegistry.push(getViewId(instance));
     };
 
     let removeComponent = (instance) => {

--- a/packages/ember-glimmer/tests/integration/components/life-cycle-test.js
+++ b/packages/ember-glimmer/tests/integration/components/life-cycle-test.js
@@ -69,8 +69,10 @@ class LifeCycleHooksTest extends RenderingTest {
     };
 
     let assertParentView = (hookName, instance) => {
-      if (!instance.parentView) {
-        this.assert.ok(false, `parentView should be present in ${hookName}`);
+      this.assert.ok(instance.parentView, `parentView should be present in ${hookName}`);
+
+      if (this.isHTMLBars) {
+        this.assert.ok(instance.ownerView, `ownerView should be present in ${hookName}`);
       }
     };
 

--- a/packages/ember-glimmer/tests/integration/components/link-to-test.js
+++ b/packages/ember-glimmer/tests/integration/components/link-to-test.js
@@ -2,16 +2,11 @@ import { moduleFor, ApplicationTest } from '../../utils/test-case';
 import Controller from 'ember-runtime/controllers/controller';
 import Route from 'ember-routing/system/route';
 import { set } from 'ember-metal/property_set';
-import run from 'ember-metal/run_loop';
 import { LinkTo } from '../../utils/helpers';
 import { classes as classMatcher } from '../../utils/test-helpers';
 import isEnabled from 'ember-metal/features';
 
 moduleFor('Link-to component', class extends ApplicationTest {
-  runTask(fn) {
-    run(fn);
-  }
-
   visitWithDeprecation(path, deprecation) {
     let p;
 
@@ -170,10 +165,6 @@ moduleFor('Link-to component with query-params', class extends ApplicationTest {
         bar: 'yes'
       }));
     }
-  }
-
-  runTask(fn) {
-    run(fn);
   }
 
   ['@test populates href with fully supplied query param values'](assert) {

--- a/packages/ember-glimmer/tests/integration/components/utils-test.js
+++ b/packages/ember-glimmer/tests/integration/components/utils-test.js
@@ -1,10 +1,240 @@
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import Controller from 'ember-runtime/controllers/controller';
+import $ from 'ember-views/system/jquery';
+import { moduleFor, ApplicationTest, RenderingTest } from '../../utils/test-case';
 import { Component } from '../../utils/helpers';
 import {
+  getRootViews,
+  getChildViews,
   getViewBounds,
   getViewClientRects,
   getViewBoundingClientRect
 } from 'ember-views/system/utils';
+
+moduleFor('View tree tests', class extends ApplicationTest {
+
+  constructor() {
+    super();
+
+    this.registerComponent('x-tagless', {
+      ComponentClass: Component.extend({
+        tagName: ''
+      }),
+
+      template: '<div id="{{id}}">[{{id}}] {{#if isShowing}}{{yield}}{{/if}}</div>'
+    });
+
+    this.registerComponent('x-toggle', {
+      ComponentClass: Component.extend({
+        isExpanded: true,
+
+        click() {
+          this.toggleProperty('isExpanded');
+          return false;
+        }
+      }),
+
+      template: '[{{id}}] {{#if isExpanded}}{{yield}}{{/if}}'
+    });
+
+    let ToggleController = Controller.extend({
+      isExpanded: true,
+
+      actions: {
+        toggle: function() {
+          this.toggleProperty('isExpanded');
+        }
+      }
+    });
+
+    this.registerController('application', ToggleController);
+
+    this.registerTemplate('application', `
+      {{x-tagless id="root-1"}}
+
+      {{#x-toggle id="root-2"}}
+        {{x-toggle id="inner-1"}}
+
+        {{#x-toggle id="inner-2"}}
+          {{x-toggle id="inner-3"}}
+        {{/x-toggle}}
+      {{/x-toggle}}
+
+      <button id="toggle-application" {{action "toggle"}}>Toggle</button>
+
+      {{#if isExpanded}}
+        {{x-toggle id="root-3"}}
+      {{/if}}
+
+      {{outlet}}
+    `);
+
+    this.registerController('index', ToggleController.extend({
+      isExpanded: false
+    }));
+
+    this.registerTemplate('index', `
+      {{x-tagless id="root-4"}}
+
+      {{#x-toggle id="root-5" isExpanded=false}}
+        {{x-toggle id="inner-4"}}
+
+        {{#x-toggle id="inner-5"}}
+          {{x-toggle id="inner-6"}}
+        {{/x-toggle}}
+      {{/x-toggle}}
+
+      <button id="toggle-index" {{action "toggle"}}>Toggle</button>
+
+      {{#if isExpanded}}
+        {{x-toggle id="root-6"}}
+      {{/if}}
+    `);
+
+    this.registerTemplate('zomg', `
+      {{x-tagless id="root-7"}}
+
+      {{#x-toggle id="root-8"}}
+        {{x-toggle id="inner-7"}}
+
+        {{#x-toggle id="inner-8"}}
+          {{x-toggle id="inner-9"}}
+        {{/x-toggle}}
+      {{/x-toggle}}
+
+      {{#x-toggle id="root-9"}}
+        {{outlet}}
+      {{/x-toggle}}
+    `);
+
+    this.registerTemplate('zomg.lol', `
+      {{x-toggle id="inner-10"}}
+    `);
+
+    this.router.map(function() {
+      this.route('zomg', function() {
+        this.route('lol');
+      });
+    });
+  }
+
+  ['@test getRootViews'](assert) {
+    return this.visit('/').then(() => {
+      this.assertRootViews(['root-1', 'root-2', 'root-3', 'root-4', 'root-5']);
+
+      this.runTask(() => $('#toggle-application').click());
+
+      this.assertRootViews(['root-1', 'root-2', 'root-4', 'root-5']);
+
+      this.runTask(() => {
+        $('#toggle-application').click();
+        $('#toggle-index').click();
+      });
+
+      this.assertRootViews(['root-1', 'root-2', 'root-3', 'root-4', 'root-5', 'root-6']);
+
+      return this.visit('/zomg/lol');
+    }).then(() => {
+      this.assertRootViews(['root-1', 'root-2', 'root-3', 'root-7', 'root-8', 'root-9']);
+
+      return this.visit('/');
+    }).then(() => {
+      this.assertRootViews(['root-1', 'root-2', 'root-3', 'root-4', 'root-5', 'root-6']);
+    });
+  }
+
+  assertRootViews(ids) {
+    let owner = this.applicationInstance;
+    let actual = getRootViews(owner).map(view => view.id).sort();
+
+    if (this.isGlimmer) {
+      let expected = ids.sort();
+      this.assert.deepEqual(actual, expected, 'root views');
+    } else {
+      let rootView = owner.lookup('router:main')._toplevelView;
+      this.assert.deepEqual(actual, [rootView.id], 'root views');
+    }
+  }
+
+  ['@test getChildViews'](assert) {
+    return this.visit('/').then(() => {
+      this.assertChildViews('root-2', ['inner-1', 'inner-2']);
+      this.assertChildViews('root-5', []);
+      this.assertChildViews('inner-2', ['inner-3']);
+
+      this.runTask(() => $('#root-2').click());
+
+      this.assertChildViews('root-2', []);
+
+      this.runTask(() => $('#root-5').click());
+
+      this.assertChildViews('root-5', ['inner-4', 'inner-5']);
+      this.assertChildViews('inner-5', ['inner-6']);
+
+      return this.visit('/zomg');
+    }).then(() => {
+      this.assertChildViews('root-2', []);
+      this.assertChildViews('root-8', ['inner-7', 'inner-8']);
+      this.assertChildViews('inner-8', ['inner-9']);
+      this.assertChildViews('root-9', []);
+
+      this.runTask(() => $('#root-8').click());
+
+      this.assertChildViews('root-8', []);
+
+      return this.visit('/zomg/lol');
+    }).then(() => {
+      this.assertChildViews('root-2', []);
+      this.assertChildViews('root-8', []);
+      this.assertChildViews('root-9', ['inner-10']);
+
+      return this.visit('/');
+    }).then(() => {
+      this.assertChildViews('root-2', []);
+      this.assertChildViews('root-5', []);
+
+      this.runTask(() => $('#root-2').click());
+      this.runTask(() => $('#inner-2').click());
+
+      this.assertChildViews('root-2', ['inner-1', 'inner-2']);
+      this.assertChildViews('inner-2', []);
+    });
+  }
+
+  ['@test getChildViews does not return duplicates'](assert) {
+    return this.visit('/').then(() => {
+      this.assertChildViews('root-2', ['inner-1', 'inner-2']);
+
+      this.runTask(() => $('#root-2').click());
+      this.runTask(() => $('#root-2').click());
+      this.runTask(() => $('#root-2').click());
+      this.runTask(() => $('#root-2').click());
+      this.runTask(() => $('#root-2').click());
+      this.runTask(() => $('#root-2').click());
+      this.runTask(() => $('#root-2').click());
+      this.runTask(() => $('#root-2').click());
+      this.runTask(() => $('#root-2').click());
+      this.runTask(() => $('#root-2').click());
+
+      this.assertChildViews('root-2', ['inner-1', 'inner-2']);
+    });
+  }
+
+  assertChildViews(parentId, childIds) {
+    let parentView = this.viewFor(parentId);
+    let childViews = getChildViews(parentView);
+
+    let actual = childViews.map(view => view.id).sort();
+    let expected = childIds.sort();
+
+    this.assert.deepEqual(actual, expected, `child views for #${parentId}`);
+  }
+
+  viewFor(id) {
+    let owner = this.applicationInstance;
+    let registry = owner.lookup('-view-registry:main');
+    return registry[id];
+  }
+});
 
 let hasGetClientRects, hasGetBoundingClientRect;
 let ClientRectListCtor, ClientRectCtor;
@@ -27,7 +257,7 @@ let ClientRectListCtor, ClientRectCtor;
   }
 })();
 
-moduleFor('ember-views/system/utils', class extends RenderingTest {
+moduleFor('Bounds tests', class extends RenderingTest {
   ['@test getViewBounds on a regular component'](assert) {
     let component;
     this.registerComponent('hi-mom', {

--- a/packages/ember-glimmer/tests/utils/abstract-test-case.js
+++ b/packages/ember-glimmer/tests/utils/abstract-test-case.js
@@ -109,6 +109,10 @@ export class TestCase {
 
   teardown() {}
 
+  runTask(callback) {
+    run(callback);
+  }
+
   // The following methods require `this.element` to work
 
   get firstChild() {
@@ -373,10 +377,6 @@ export class AbstractRenderingTest extends TestCase {
 
   rerender() {
     this.component.rerender();
-  }
-
-  runTask(callback) {
-    run(callback);
   }
 
   registerHelper(name, funcOrClassBody) {

--- a/packages/ember-glimmer/tests/utils/helpers.js
+++ b/packages/ember-glimmer/tests/utils/helpers.js
@@ -18,6 +18,7 @@ export { DOMChanges } from 'glimmer-runtime';
 export { InteractiveRenderer, InertRenderer } from 'ember-glimmer/renderer';
 export { default as makeBoundHelper } from 'ember-glimmer/make-bound-helper';
 export { htmlSafe, SafeString } from 'ember-glimmer/utils/string';
+import dictionary from 'ember-metal/dictionary';
 
 export function buildOwner(options) {
   let owner = _buildOwner(options);
@@ -37,7 +38,7 @@ export function buildOwner(options) {
   owner.inject('component', 'renderer', 'renderer:-dom');
   owner.inject('template', 'env', 'service:-glimmer-environment');
 
-  owner.register('-view-registry:main', { create() { return {}; } });
+  owner.register('-view-registry:main', { create() { return dictionary(null); } });
   owner.inject('renderer', '_viewRegistry', '-view-registry:main');
 
   owner.register('template:-root', RootTemplate);

--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -37,6 +37,7 @@ ComponentNodeManager.create = function ComponentNodeManager_create(renderNode, e
 
   let createOptions = {
     parentView,
+    ownerView: parentView.ownerView,
     [HAS_BLOCK]: !!templates.default
   };
 

--- a/packages/ember-htmlbars/lib/renderer.js
+++ b/packages/ember-htmlbars/lib/renderer.js
@@ -8,6 +8,7 @@ import { environment } from 'ember-environment';
 import { internal } from 'htmlbars-runtime';
 import { renderHTMLBarsBlock } from 'ember-htmlbars/system/render-view';
 import fallbackViewRegistry from 'ember-views/compat/fallback-view-registry';
+import { getViewId } from 'ember-views/system/utils';
 import { assert } from 'ember-metal/debug';
 import { getOwner } from 'container/owner';
 
@@ -289,12 +290,13 @@ Renderer.prototype.getBounds = function (view) {
 };
 
 Renderer.prototype.register = function Renderer_register(view) {
-  assert('Attempted to register a view with an id already in use: ' + view.elementId, !this._viewRegistry[view.elementId]);
-  this._viewRegistry[view.elementId] = view;
+  let id = getViewId(view);
+  assert('Attempted to register a view with an id already in use: ' + id, !this._viewRegistry[id]);
+  this._viewRegistry[id] = view;
 };
 
 Renderer.prototype.unregister = function Renderer_unregister(view) {
-  delete this._viewRegistry[view.elementId];
+  delete this._viewRegistry[getViewId(view)];
 };
 
 export const InertRenderer = {

--- a/packages/ember-htmlbars/tests/utils/helpers.js
+++ b/packages/ember-htmlbars/tests/utils/helpers.js
@@ -18,6 +18,7 @@ export { default as LinkTo } from 'ember-htmlbars/components/link-to';
 export { InteractiveRenderer, InertRenderer } from 'ember-htmlbars/renderer';
 export { default as makeBoundHelper } from 'ember-glimmer/make-bound-helper';
 export { htmlSafe, SafeString } from 'ember-htmlbars/utils/string';
+import dictionary from 'ember-metal/dictionary';
 
 export function buildOwner(options) {
   let owner = _buildOwner(options);
@@ -27,7 +28,7 @@ export function buildOwner(options) {
   owner.inject('service:-htmlbars-environment', 'dom', 'service:-dom-helper');
 
   owner.register('service:-document', document, { instantiate: false });
-  owner.register('-view-registry:main', { create() { return {}; } });
+  owner.register('-view-registry:main', { create() { return dictionary(null); } });
   owner.inject('renderer', '_viewRegistry', '-view-registry:main');
   owner.inject('renderer', 'dom', 'service:-dom-helper');
   owner.inject('component', 'renderer', 'renderer:-dom');

--- a/packages/ember-metal/lib/descriptor.js
+++ b/packages/ember-metal/lib/descriptor.js
@@ -1,0 +1,27 @@
+import { Descriptor as EmberDescriptor } from 'ember-metal/properties';
+
+export default function descriptor(desc) {
+  return new Descriptor(desc);
+}
+
+/**
+  A wrapper for a native ES5 descriptor. In an ideal world, we wouldn't need
+  this at all, however, the way we currently flatten/merge our mixins require
+  a special value to denote a descriptor.
+
+  @class Descriptor
+  @private
+*/
+class Descriptor extends EmberDescriptor {
+  constructor(desc) {
+    super();
+    this.desc = desc;
+  }
+
+  setup(obj, key) {
+    Object.defineProperty(obj, key, this.desc);
+  }
+
+  teardown(obj, key) {
+  }
+}

--- a/packages/ember-metal/tests/descriptor_test.js
+++ b/packages/ember-metal/tests/descriptor_test.js
@@ -1,0 +1,352 @@
+import EmberObject from 'ember-runtime/system/object';
+import { Mixin } from 'ember-metal/mixin';
+import { defineProperty } from 'ember-metal/properties';
+import descriptor from 'ember-metal/descriptor';
+
+class DescriptorTest {
+
+  /* abstract static module(title: string); */
+
+  static test(title, callback) {
+    QUnit.test(title, assert => {
+      callback(assert, new this(assert));
+    });
+  }
+
+  constructor(assert) {
+    this.assert = assert;
+  }
+
+  /* abstract install(key: string, desc: Descriptor); */
+
+  /* abstract set(key: string, value: any); */
+
+  /* abstract finalize(): Object; */
+}
+
+let classes = [
+
+  class extends DescriptorTest {
+    static module(title) {
+      QUnit.module(`${title}: using defineProperty on an object directly`);
+    }
+
+    constructor(assert) {
+      super(assert);
+      this.object = {};
+    }
+
+    install(key, desc) {
+      let { object, assert } = this;
+
+      defineProperty(object, key, desc);
+
+      assert.ok(object.hasOwnProperty(key));
+    }
+
+    set(key, value) {
+      this.object[key] = value;
+    }
+
+    finalize() {
+      return this.object;
+    }
+
+    source() {
+      return this.object;
+    }
+  },
+
+  class extends DescriptorTest {
+    static module(title) {
+      QUnit.module(`${title}: using defineProperty on a prototype`);
+    }
+
+    constructor(assert) {
+      super(assert);
+      this.proto = {};
+    }
+
+    install(key, desc) {
+      let { proto, assert } = this;
+
+      defineProperty(proto, key, desc);
+
+      assert.ok(proto.hasOwnProperty(key));
+    }
+
+    set(key, value) {
+      this.proto[key] = value;
+    }
+
+    finalize() {
+      return Object.create(this.proto);
+    }
+
+    source() {
+      return this.proto;
+    }
+  },
+
+  class extends DescriptorTest {
+    static module(title) {
+      QUnit.module(`${title}: in EmberObject.extend()`);
+    }
+
+    constructor(assert) {
+      super(assert);
+      this.klass = null;
+      this.props = {};
+    }
+
+    install(key, desc) {
+      this.props[key] = desc;
+    }
+
+    set(key, value) {
+      this.props[key] = value;
+    }
+
+    finalize() {
+      this.klass = EmberObject.extend(this.props);
+      return this.klass.create();
+    }
+
+    source() {
+      return this.klass.prototype;
+    }
+  },
+
+  class extends DescriptorTest {
+    static module(title) {
+      QUnit.module(`${title}: in EmberObject.extend() through a mixin`);
+    }
+
+    constructor(assert) {
+      super(assert);
+      this.klass = null;
+      this.props = {};
+    }
+
+    install(key, desc) {
+      this.props[key] = desc;
+    }
+
+    set(key, value) {
+      this.props[key] = value;
+    }
+
+    finalize() {
+      this.klass = EmberObject.extend(Mixin.create(this.props));
+      return this.klass.create();
+    }
+
+    source() {
+      return this.klass.prototype;
+    }
+  },
+
+  class extends DescriptorTest {
+    static module(title) {
+      QUnit.module(`${title}: inherited from another EmberObject super class`);
+    }
+
+    constructor(assert) {
+      super(assert);
+      this.superklass = null;
+      this.props = {};
+    }
+
+    install(key, desc) {
+      this.props[key] = desc;
+    }
+
+    set(key, value) {
+      this.props[key] = value;
+    }
+
+    finalize() {
+      this.superklass = EmberObject.extend(this.props);
+      return this.superklass.extend().create();
+    }
+
+    source() {
+      return this.superklass.prototype;
+    }
+  }
+
+];
+
+classes.forEach(TestClass => {
+  TestClass.module('ember-metal/descriptor');
+
+  TestClass.test('defining a configurable property', function(assert, factory) {
+    factory.install('foo', descriptor({ configurable: true, value: 'bar' }));
+
+    let obj = factory.finalize();
+
+    assert.equal(obj.foo, 'bar');
+
+    let source = factory.source();
+
+    delete source.foo;
+
+    assert.strictEqual(obj.foo, undefined);
+
+    Object.defineProperty(source, 'foo', { configurable: true, value: 'baz' });
+
+    assert.equal(obj.foo, 'baz');
+  });
+
+  TestClass.test('defining a non-configurable property', function(assert, factory) {
+    factory.install('foo', descriptor({ configurable: false, value: 'bar' }));
+
+    let obj = factory.finalize();
+
+    assert.equal(obj.foo, 'bar');
+
+    let source = factory.source();
+
+    assert.throws(() => delete source.foo, TypeError);
+
+    assert.throws(() => Object.defineProperty(source, 'foo', { configurable: true, value: 'baz' }), TypeError);
+  });
+
+  TestClass.test('defining an enumerable property', function(assert, factory) {
+    factory.install('foo', descriptor({ enumerable: true, value: 'bar' }));
+
+    let obj = factory.finalize();
+
+    assert.equal(obj.foo, 'bar');
+
+    let source = factory.source();
+
+    assert.ok(Object.keys(source).indexOf('foo') !== -1);
+  });
+
+  TestClass.test('defining a non-enumerable property', function(assert, factory) {
+    factory.install('foo', descriptor({ enumerable: false, value: 'bar' }));
+
+    let obj = factory.finalize();
+
+    assert.equal(obj.foo, 'bar');
+
+    let source = factory.source();
+
+    assert.ok(Object.keys(source).indexOf('foo') === -1);
+  });
+
+  TestClass.test('defining a writable property', function(assert, factory) {
+    factory.install('foo', descriptor({ writable: true, value: 'bar' }));
+
+    let obj = factory.finalize();
+
+    assert.equal(obj.foo, 'bar');
+
+    let source = factory.source();
+
+    source.foo = 'baz';
+
+    assert.equal(obj.foo, 'baz');
+
+    obj.foo = 'bat';
+
+    assert.equal(obj.foo, 'bat');
+  });
+
+  TestClass.test('defining a non-writable property', function(assert, factory) {
+    factory.install('foo', descriptor({ writable: false, value: 'bar' }));
+
+    let obj = factory.finalize();
+
+    assert.equal(obj.foo, 'bar');
+
+    let source = factory.source();
+
+    assert.throws(() => source.foo = 'baz', TypeError);
+
+    assert.throws(() => obj.foo = 'baz', TypeError);
+  });
+
+  TestClass.test('defining a getter', function(assert, factory) {
+    factory.install('foo', descriptor({
+      get: function() {
+        return this.__foo__;
+      }
+    }));
+
+    factory.set('__foo__', 'bar');
+
+    let obj = factory.finalize();
+
+    assert.equal(obj.foo, 'bar');
+
+    obj.__foo__ = 'baz';
+
+    assert.equal(obj.foo, 'baz');
+  });
+
+  TestClass.test('defining a setter', function(assert, factory) {
+    factory.install('foo', descriptor({
+      set: function(value) {
+        this.__foo__ = value;
+      }
+    }));
+
+    factory.set('__foo__', 'bar');
+
+    let obj = factory.finalize();
+
+    assert.equal(obj.__foo__, 'bar');
+
+    obj.foo = 'baz';
+
+    assert.equal(obj.__foo__, 'baz');
+  });
+
+  TestClass.test('combining multiple setter and getters', function(assert, factory) {
+    factory.install('foo', descriptor({
+      get: function() {
+        return this.__foo__;
+      },
+
+      set: function(value) {
+        this.__foo__ = value;
+      }
+    }));
+
+    factory.set('__foo__', 'foo');
+
+    factory.install('bar', descriptor({
+      get: function() {
+        return this.__bar__;
+      },
+
+      set: function(value) {
+        this.__bar__ = value;
+      }
+    }));
+
+    factory.set('__bar__', 'bar');
+
+    factory.install('fooBar', descriptor({
+      get: function() {
+        return this.foo + '-' + this.bar;
+      }
+    }));
+
+    let obj = factory.finalize();
+
+    assert.equal(obj.fooBar, 'foo-bar');
+
+    obj.foo = 'FOO';
+
+    assert.equal(obj.fooBar, 'FOO-bar');
+
+    obj.__bar__ = 'BAR';
+
+    assert.equal(obj.fooBar, 'FOO-BAR');
+
+    assert.throws(() => obj.fooBar = 'foobar', TypeError);
+  });
+});

--- a/packages/ember-views/lib/mixins/child_views_support.js
+++ b/packages/ember-views/lib/mixins/child_views_support.js
@@ -18,7 +18,6 @@ export default Mixin.create({
       @private
     */
     this.childViews = [];
-    this.ownerView = this.ownerView || this;
   },
 
   appendChild(view) {
@@ -30,8 +29,5 @@ export default Mixin.create({
     if (!instance[OWNER]) {
       setOwner(instance, getOwner(this));
     }
-
-    instance.parentView = this;
-    instance.ownerView = this.ownerView;
   }
 });

--- a/packages/ember-views/lib/mixins/child_views_support.js
+++ b/packages/ember-views/lib/mixins/child_views_support.js
@@ -3,30 +3,39 @@
 @submodule ember-views
 */
 import { Mixin } from 'ember-metal/mixin';
-import { getOwner, setOwner, OWNER } from 'container/owner';
+import { getOwner, setOwner } from 'container/owner';
+import descriptor from 'ember-metal/descriptor';
+import { initChildViews, getChildViews, addChildView } from '../system/utils';
 
 export default Mixin.create({
   init() {
     this._super(...arguments);
-
-    /**
-      Array of child views. You should never edit this array directly.
-
-      @property childViews
-      @type Array
-      @default []
-      @private
-    */
-    this.childViews = [];
+    initChildViews(this);
   },
+
+  /**
+    Array of child views. You should never edit this array directly.
+
+    @property childViews
+    @type Array
+    @default []
+    @private
+  */
+  childViews: descriptor({
+    configurable: false,
+    enumerable: false,
+    get() {
+      return getChildViews(this);
+    }
+  }),
 
   appendChild(view) {
     this.linkChild(view);
-    this.childViews.push(view);
+    addChildView(this, view);
   },
 
   linkChild(instance) {
-    if (!instance[OWNER]) {
+    if (!getOwner(instance)) {
       setOwner(instance, getOwner(this));
     }
   }

--- a/packages/ember-views/lib/mixins/child_views_support.js
+++ b/packages/ember-views/lib/mixins/child_views_support.js
@@ -26,36 +26,6 @@ export default Mixin.create({
     this.childViews.push(view);
   },
 
-  destroyChild(view) {
-    view.destroy();
-  },
-
-  /**
-    Removes the child view from the parent view.
-
-    @method removeChild
-    @param {Ember.View} view
-    @return {Ember.View} receiver
-    @private
-  */
-  removeChild(view) {
-    // If we're destroying, the entire subtree will be
-    // freed, and the DOM will be handled separately,
-    // so no need to mess with childViews.
-    if (this.isDestroying) { return; }
-
-    // update parent node
-    this.unlinkChild(view);
-
-    // remove view from childViews array.
-    let { childViews } = this;
-
-    let index = childViews.indexOf(view);
-    if (index !== -1) { childViews.splice(index, 1); }
-
-    return this;
-  },
-
   linkChild(instance) {
     if (!instance[OWNER]) {
       setOwner(instance, getOwner(this));
@@ -63,9 +33,5 @@ export default Mixin.create({
 
     instance.parentView = this;
     instance.ownerView = this.ownerView;
-  },
-
-  unlinkChild(instance) {
-    instance.parentView = null;
   }
 });

--- a/packages/ember-views/lib/views/states/in_dom.js
+++ b/packages/ember-views/lib/views/states/in_dom.js
@@ -15,9 +15,7 @@ assign(inDOM, {
   enter(view) {
     // Register the view for event handling. This hash is used by
     // Ember.EventDispatcher to dispatch incoming events.
-    if (view.tagName !== '') {
-      view.renderer.register(view);
-    }
+    view.renderer.register(view);
 
     runInDebug(() => {
       _addBeforeObserver(view, 'elementId', () => {
@@ -27,9 +25,7 @@ assign(inDOM, {
   },
 
   exit(view) {
-    if (view.tagName !== '') {
-      view.renderer.unregister(view);
-    }
+    view.renderer.unregister(view);
   }
 });
 

--- a/packages/ember/tests/component_registration_test.js
+++ b/packages/ember/tests/component_registration_test.js
@@ -363,27 +363,29 @@ QUnit.test('Components trigger actions in the components context when called fro
   jQuery('#fizzbuzz', '#wrapper').click();
 });
 
-QUnit.test('Components receive the top-level view as their ownerView', function(assert) {
-  setTemplate('application', compile('{{outlet}}'));
-  setTemplate('index', compile('{{my-component}}'));
-  setTemplate('components/my-component', compile('<div></div>'));
+if (!isEnabled('ember-glimmer')) {
+  QUnit.test('Components receive the top-level view as their ownerView', function(assert) {
+    setTemplate('application', compile('{{outlet}}'));
+    setTemplate('index', compile('{{my-component}}'));
+    setTemplate('components/my-component', compile('<div></div>'));
 
-  let component;
+    let component;
 
-  boot(() => {
-    appInstance.register('component:my-component', Component.extend({
-      init() {
-        this._super();
-        component = this;
-      }
-    }));
+    boot(() => {
+      appInstance.register('component:my-component', Component.extend({
+        init() {
+          this._super();
+          component = this;
+        }
+      }));
+    });
+
+    // Theses tests are intended to catch a regression where the owner view was
+    // not configured properly. Future refactors may break these tests, which
+    // should not be considered a breaking change to public APIs.
+    let ownerView = component.ownerView;
+    assert.ok(ownerView, 'owner view was set');
+    assert.ok(ownerView instanceof OutletView, 'owner view has no parent view');
+    assert.notStrictEqual(component, ownerView, 'owner view is not itself');
   });
-
-  // Theses tests are intended to catch a regression where the owner view was
-  // not configured properly. Future refactors may break these tests, which
-  // should not be considered a breaking change to public APIs.
-  let ownerView = component.ownerView;
-  assert.ok(ownerView, 'owner view was set');
-  assert.ok(ownerView instanceof OutletView, 'owner view has no parent view');
-  assert.notStrictEqual(component, ownerView, 'owner view is not itself');
-});
+}


### PR DESCRIPTION
:new: `getRootViews` returns an array of “top-level” components
:new: `getChildViews` to replace `view.childViews` (to be deprecated :soon:)
:new: “tagless” components are registered in the view-registry with a GUID
:cool: `view.childViews` is now a getter that delegates to `getChildViews`
:free: `view.childViews` no longer leak destroyed components (bug in beta)
:back: `view.childViews` now tracks updates (components added or removed during updates) correctly, which was unreliable since 1.13

Instead of tracking `childView` instances, we now track a list of IDs that can be used to look them up in the view registry. This has the benefit of not holding a reference to the view instance – thus do not require cleanup when the child views are destroyed.

When requested, we lazily query the view registry to reify the (still) live children and cleanup and stale IDs while we are at it.

This approach does leak the string IDs of destroyed components, however the effect is believed to be minimal. If this ended up causing problems, we can be smarter about this, such as tracking the number of removals and schedule a collection (outside of the render loop) when a view has accumulated enough removals.
