### PR TITLE
[BUGFIX beta] Ensure injections happen in engine instances.

### DIFF
--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -283,18 +283,9 @@ ApplicationInstance.reopenClass({
   */
   setupRegistry(registry, options = new BootOptions()) {
     registry.register('-environment:main', options.toEnvironment(), { instantiate: false });
-    registry.injection('view', '_environment', '-environment:main');
-    registry.injection('route', '_environment', '-environment:main');
-
     registry.register('service:-document', options.document, { instantiate: false });
 
-    if (options.isInteractive) {
-      registry.injection('view', 'renderer', 'renderer:-dom');
-      registry.injection('component', 'renderer', 'renderer:-dom');
-    } else {
-      registry.injection('view', 'renderer', 'renderer:-inert');
-      registry.injection('component', 'renderer', 'renderer:-inert');
-    }
+    this._super(registry, options);
   }
 });
 

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -272,7 +272,7 @@ export default class Environment extends GlimmerEnvironment {
     let name = path[0];
     let blockMeta = symbolTable.getMeta();
     let owner = blockMeta.owner;
-    let source = `template:${blockMeta.moduleName}`;
+    let source = blockMeta.moduleName && `template:${blockMeta.moduleName}`;
 
     return this._definitionCache.get({ name, source, owner });
   }

--- a/packages/ember-glimmer/lib/setup-registry.js
+++ b/packages/ember-glimmer/lib/setup-registry.js
@@ -6,6 +6,7 @@ import TextField from './components/text_field';
 import TextArea from './components/text_area';
 import Checkbox from './components/checkbox';
 import LinkToComponent from './components/link-to';
+import Component from './component';
 import ComponentTemplate from './templates/component';
 import RootTemplate from './templates/root';
 import OutletTemplate from './templates/outlet';
@@ -50,4 +51,5 @@ export function setupEngineRegistry(registry) {
   registry.register('component:-text-area', TextArea);
   registry.register('component:-checkbox', Checkbox);
   registry.register('component:link-to', LinkToComponent);
+  registry.register(P`component:-default`, Component);
 }

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -8,7 +8,6 @@ import assign from 'ember-metal/assign';
 import get from 'ember-metal/property_get';
 import { _instrumentStart } from 'ember-metal/instrumentation';
 import { ComponentDefinition } from 'glimmer-runtime';
-import Component from '../component';
 import { OWNER } from 'container/owner';
 
 const DEFAULT_LAYOUT = P`template:components/-default`;
@@ -369,7 +368,7 @@ function ariaRole(vm) {
 
 export class CurlyComponentDefinition extends ComponentDefinition {
   constructor(name, ComponentClass, template, args) {
-    super(name, MANAGER, ComponentClass || Component);
+    super(name, MANAGER, ComponentClass);
     this.template = template;
     this.args = args;
   }

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -188,7 +188,6 @@ class CurlyComponentManager {
     aliasIdToElementId(args, props);
 
     props.parentView = parentView;
-    props.renderer = parentView.renderer;
     props[HAS_BLOCK] = hasBlock;
 
     // dynamicScope here is inherited from the parent dynamicScope,

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -28,6 +28,18 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     this.assertComponentElement(this.firstChild, { content: 'hello' });
   }
 
+  ['@test it can render a template only component']() {
+    this.registerComponent('foo-bar', { template: 'hello' });
+
+    this.render('{{foo-bar}}');
+
+    this.assertComponentElement(this.firstChild, { content: 'hello' });
+
+    this.runTask(() => this.rerender());
+
+    this.assertComponentElement(this.firstChild, { content: 'hello' });
+  }
+
   ['@test it can have a custom id and it is not bound']() {
     this.registerComponent('foo-bar', { template: '{{id}} {{elementId}}' });
 

--- a/packages/ember-glimmer/tests/utils/abstract-test-case.js
+++ b/packages/ember-glimmer/tests/utils/abstract-test-case.js
@@ -266,13 +266,13 @@ export class AbstractApplicationTest extends TestCase {
     runDestroy(this.application);
   }
 
-  visit(url) {
+  visit(url, options) {
     let { applicationInstance } = this;
 
     if (applicationInstance) {
-      return run(applicationInstance, 'visit', url);
+      return run(applicationInstance, 'visit', url, options);
     } else {
-      return run(this.application, 'visit', url).then(instance => {
+      return run(this.application, 'visit', url, options).then(instance => {
         this.applicationInstance = instance;
       });
     }

--- a/packages/ember-htmlbars/lib/setup-registry.js
+++ b/packages/ember-htmlbars/lib/setup-registry.js
@@ -1,14 +1,15 @@
+import { privatize as P } from 'container/registry';
 import { InteractiveRenderer, InertRenderer } from 'ember-htmlbars/renderer';
 import HTMLBarsDOMHelper from 'ember-htmlbars/system/dom-helper';
 import topLevelViewTemplate from 'ember-htmlbars/templates/top-level-view';
 import { OutletView as HTMLBarsOutletView } from 'ember-htmlbars/views/outlet';
 import EmberView from 'ember-views/views/view';
+import Component from 'ember-htmlbars/component';
 import TextField from 'ember-htmlbars/components/text_field';
 import TextArea from 'ember-htmlbars/components/text_area';
 import Checkbox from 'ember-htmlbars/components/checkbox';
 import LinkToComponent from 'ember-htmlbars/components/link-to';
 import TemplateSupport from 'ember-views/mixins/template_support';
-
 
 export function setupApplicationRegistry(registry) {
   registry.register('renderer:-dom', InteractiveRenderer);
@@ -32,4 +33,6 @@ export function setupEngineRegistry(registry) {
   registry.register('component:-text-area', TextArea);
   registry.register('component:-checkbox', Checkbox);
   registry.register('component:link-to', LinkToComponent);
+
+  registry.register(P`component:-default`, Component);
 }

--- a/packages/ember-views/lib/utils/lookup-component.js
+++ b/packages/ember-views/lib/utils/lookup-component.js
@@ -1,10 +1,16 @@
+import { privatize as P } from 'container/registry';
+
 function lookupComponentPair(componentLookup, owner, name, options) {
   let component = componentLookup.componentFor(name, owner, options);
   let layout = componentLookup.layoutFor(name, owner, options);
-  return {
-    component,
-    layout
-  };
+
+  let result = { layout, component };
+
+  if (layout && !component) {
+    result.component = owner._lookupFactory(P`component:-default`);
+  }
+
+  return result;
 }
 
 export default function lookupComponent(owner, name, options) {


### PR DESCRIPTION
Prior to this `_environment` could not be relied upon in routes or views (which is used when `shouldRender: false` is used with `visit`).

The refactor uses the environment to determine what injections to setup in the engine-instance, and has the `application-instance` defer to the `engine-instance` to avoid duplication.

Also, removes manual threading of `props.renderer` (as requested in https://github.com/emberjs/ember.js/pull/14139).

---

Ensure that all components receive type injections. 

Prior to this change we were defaulting to `Ember.Component` which does not receive injections (which meant it was missing the `renderer`). This worked "ok" in HTMLBars since we created a default global renderer to handle components/views without a container/owner.

This change ensures that in the template only component case we fall back to using the default component looked up from the owner. This ensures that injections are present.
