### PR TITLE
Use index reexports from container instead of cross package deep imports.

### DIFF
--- a/packages/container/lib/index.js
+++ b/packages/container/lib/index.js
@@ -5,8 +5,6 @@ The public API, specified on the application namespace should be considered the 
   @private
 */
 
-import Registry from './registry';
-import Container from './container';
-import { getOwner, setOwner } from './owner';
-
-export { Registry, Container, getOwner, setOwner };
+export { default as Registry, privatize } from './registry';
+export { default as Container } from './container';
+export { OWNER, getOwner, setOwner } from './owner';

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -1,8 +1,11 @@
 import { ENV } from 'ember-environment';
 import { get } from 'ember-metal/property_get';
-import Registry from 'container/registry';
+import {
+  Registry,
+  getOwner,
+  OWNER
+} from 'container';
 import factory from 'container/tests/test-helpers/factory';
-import { getOwner, OWNER } from 'container/owner';
 
 let originalModelInjections;
 

--- a/packages/container/tests/owner_test.js
+++ b/packages/container/tests/owner_test.js
@@ -1,4 +1,4 @@
-import { getOwner, setOwner, OWNER } from 'container/owner';
+import { getOwner, setOwner, OWNER } from 'container';
 
 QUnit.module('Owner', {});
 

--- a/packages/container/tests/test-helpers/build-owner.js
+++ b/packages/container/tests/test-helpers/build-owner.js
@@ -1,5 +1,5 @@
 import EmberObject from 'ember-runtime/system/object';
-import Registry from 'container/registry';
+import { Registry } from 'container';
 import RegistryProxy from 'ember-runtime/mixins/registry_proxy';
 import ContainerProxy from 'ember-runtime/mixins/container_proxy';
 

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -25,7 +25,7 @@ import BucketCache from 'ember-routing/system/cache';
 import ApplicationInstance from './application-instance';
 import { _loaded } from 'ember-runtime/system/lazy_load';
 import { buildFakeRegistryWithDeprecations } from 'ember-runtime/mixins/registry_proxy';
-import { privatize as P } from 'container/registry';
+import { privatize as P } from 'container';
 import { environment } from 'ember-environment';
 import RSVP from 'ember-runtime/ext/rsvp';
 import Engine, { GLIMMER } from './engine';

--- a/packages/ember-application/lib/system/engine-instance.js
+++ b/packages/ember-application/lib/system/engine-instance.js
@@ -5,10 +5,10 @@
 
 import EmberObject from 'ember-runtime/system/object';
 import EmberError from 'ember-metal/error';
-import Registry from 'container/registry';
+import { Registry } from 'container';
 import ContainerProxy from 'ember-runtime/mixins/container_proxy';
 import RegistryProxy from 'ember-runtime/mixins/registry_proxy';
-import { privatize as P } from 'container/registry';
+import { privatize as P } from 'container';
 import { getEngineParent, setEngineParent } from './engine-parent';
 import { assert } from 'ember-metal/debug';
 import run from 'ember-metal/run_loop';

--- a/packages/ember-application/lib/system/engine.js
+++ b/packages/ember-application/lib/system/engine.js
@@ -3,8 +3,10 @@
 @submodule ember-application
 */
 import Namespace from 'ember-runtime/system/namespace';
-import Registry from 'container/registry';
-import { privatize as P } from 'container/registry';
+import {
+  Registry,
+  privatize as P
+} from 'container';
 import RegistryProxy from 'ember-runtime/mixins/registry_proxy';
 import DAG from 'dag-map';
 import { get } from 'ember-metal/property_get';

--- a/packages/ember-application/tests/system/application_instance_test.js
+++ b/packages/ember-application/tests/system/application_instance_test.js
@@ -5,7 +5,7 @@ import run from 'ember-metal/run_loop';
 import jQuery from 'ember-views/system/jquery';
 import factory from 'container/tests/test-helpers/factory';
 import isEnabled from 'ember-metal/features';
-import { privatize as P } from 'container/registry';
+import { privatize as P } from 'container';
 import EmberObject from 'ember-runtime/system/object';
 
 let application, appInstance;

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -18,7 +18,7 @@ import { compile } from 'ember-template-compiler/tests/utils/helpers';
 import { _loaded } from 'ember-runtime/system/lazy_load';
 import { getDebugFunction, setDebugFunction } from 'ember-metal/debug';
 import { setTemplates, set as setTemplate } from 'ember-templates/template_registry';
-import { privatize as P } from 'container/registry';
+import { privatize as P } from 'container';
 import { verifyInjection, verifyRegistration } from '../test-helpers/registry-check';
 
 let { trim } = jQuery;

--- a/packages/ember-application/tests/system/engine_test.js
+++ b/packages/ember-application/tests/system/engine_test.js
@@ -3,7 +3,7 @@ import isEnabled from 'ember-metal/features';
 import run from 'ember-metal/run_loop';
 import Engine from 'ember-application/system/engine';
 import EmberObject from 'ember-runtime/system/object';
-import { privatize as P } from 'container/registry';
+import { privatize as P } from 'container';
 import { verifyInjection, verifyRegistration } from '../test-helpers/registry-check';
 
 let engine;

--- a/packages/ember-application/tests/system/reset_test.js
+++ b/packages/ember-application/tests/system/reset_test.js
@@ -5,7 +5,7 @@ import EmberApplication from 'ember-application/system/application';
 import EmberObject from 'ember-runtime/system/object';
 import Router from 'ember-routing/system/router';
 import Controller from 'ember-runtime/controllers/controller';
-import Registry from 'container/registry';
+import { Registry } from 'container';
 
 let application, Application;
 

--- a/packages/ember-extension-support/lib/data_adapter.js
+++ b/packages/ember-extension-support/lib/data_adapter.js
@@ -5,7 +5,7 @@ import Namespace from 'ember-runtime/system/namespace';
 import EmberObject from 'ember-runtime/system/object';
 import { A as emberA } from 'ember-runtime/system/native_array';
 import Application from 'ember-application/system/application';
-import { getOwner } from 'container/owner';
+import { getOwner } from 'container';
 import {
   addArrayObserver,
   removeArrayObserver,

--- a/packages/ember-glimmer/lib/component.js
+++ b/packages/ember-glimmer/lib/component.js
@@ -15,7 +15,7 @@ import { DirtyableTag } from 'glimmer-reference';
 import { readDOMAttr } from 'glimmer-runtime';
 import { assert, deprecate } from 'ember-metal/debug';
 import { NAME_KEY } from 'ember-metal/mixin';
-import { getOwner } from 'container/owner';
+import { getOwner } from 'container';
 
 export const DIRTY_TAG = symbol('DIRTY_TAG');
 export const ARGS = symbol('ARGS');

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -43,7 +43,7 @@ import { default as queryParams } from './helpers/query-param';
 import { default as eachIn } from './helpers/each-in';
 import { default as normalizeClassHelper } from './helpers/-normalize-class';
 import { default as htmlSafeHelper } from './helpers/-html-safe';
-import { OWNER } from 'container/owner';
+import { OWNER } from 'container';
 
 const builtInComponents = {
   textarea: '-text-area'

--- a/packages/ember-glimmer/lib/setup-registry.js
+++ b/packages/ember-glimmer/lib/setup-registry.js
@@ -1,4 +1,4 @@
-import { privatize as P } from 'container/registry';
+import { privatize as P } from 'container';
 import { InteractiveRenderer, InertRenderer } from './renderer';
 import { DOMChanges, DOMTreeConstruction } from './dom';
 import OutletView from './views/outlet';

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -3,12 +3,12 @@ import { AttributeBinding, ClassNameBinding, IsVisibleBinding } from '../utils/b
 import { ROOT_REF, DIRTY_TAG, IS_DISPATCHING_ATTRS, HAS_BLOCK, BOUNDS } from '../component';
 import { assert, runInDebug } from 'ember-metal/debug';
 import processArgs from '../utils/process-args';
-import { privatize as P } from 'container/registry';
+import { privatize as P } from 'container';
 import assign from 'ember-metal/assign';
 import get from 'ember-metal/property_get';
 import { _instrumentStart } from 'ember-metal/instrumentation';
 import { ComponentDefinition } from 'glimmer-runtime';
-import { OWNER } from 'container/owner';
+import { OWNER } from 'container';
 
 const DEFAULT_LAYOUT = P`template:components/-default`;
 

--- a/packages/ember-glimmer/lib/template.js
+++ b/packages/ember-glimmer/lib/template.js
@@ -1,5 +1,5 @@
 import { Template } from 'glimmer-runtime';
-import { OWNER } from 'container/owner';
+import { OWNER } from 'container';
 
 class Wrapper {
   constructor(id, env, owner, spec) {

--- a/packages/ember-htmlbars/lib/component.js
+++ b/packages/ember-htmlbars/lib/component.js
@@ -8,7 +8,7 @@ import View from 'ember-views/views/view';
 
 import { computed } from 'ember-metal/computed';
 
-import { getOwner } from 'container/owner';
+import { getOwner } from 'container';
 import symbol from 'ember-metal/symbol';
 
 export let HAS_BLOCK = symbol('HAS_BLOCK');

--- a/packages/ember-htmlbars/lib/keywords/mount.js
+++ b/packages/ember-htmlbars/lib/keywords/mount.js
@@ -6,7 +6,7 @@
 import ViewNodeManager from '../node-managers/view-node-manager';
 import RenderEnv from '../system/render-env';
 import { assert } from 'ember-metal/debug';
-import { getOwner, setOwner } from 'container/owner';
+import { getOwner, setOwner } from 'container';
 import { isOutletStable } from './outlet';
 import { childOutletState } from './render';
 

--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -6,7 +6,7 @@ import { MUTABLE_CELL } from 'ember-views/compat/attrs-proxy';
 import { instrument } from '../system/instrumentation-support';
 import EmberComponent, { HAS_BLOCK } from '../component';
 import extractPositionalParams from '../utils/extract-positional-params';
-import { setOwner, getOwner } from 'container/owner';
+import { setOwner, getOwner } from 'container';
 
 // In theory this should come through the env, but it should
 // be safe to import this until we make the hook system public

--- a/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
@@ -7,7 +7,7 @@ import { MUTABLE_CELL } from 'ember-views/compat/attrs-proxy';
 import getCellOrValue from '../hooks/get-cell-or-value';
 import { instrument } from '../system/instrumentation-support';
 import { takeLegacySnapshot } from './component-node-manager';
-import { setOwner } from 'container/owner';
+import { setOwner } from 'container';
 
 // In theory this should come through the env, but it should
 // be safe to import this until we make the hook system public

--- a/packages/ember-htmlbars/lib/renderer.js
+++ b/packages/ember-htmlbars/lib/renderer.js
@@ -10,7 +10,7 @@ import { renderHTMLBarsBlock } from './system/render-view';
 import fallbackViewRegistry from 'ember-views/compat/fallback-view-registry';
 import { getViewId } from 'ember-views/system/utils';
 import { assert } from 'ember-metal/debug';
-import { getOwner } from 'container/owner';
+import { getOwner } from 'container';
 
 export function Renderer(domHelper, { destinedForDOM, _viewRegistry } = {}) {
   this._dom = domHelper;

--- a/packages/ember-htmlbars/lib/setup-registry.js
+++ b/packages/ember-htmlbars/lib/setup-registry.js
@@ -1,4 +1,4 @@
-import { privatize as P } from 'container/registry';
+import { privatize as P } from 'container';
 import { InteractiveRenderer, InertRenderer } from './renderer';
 import HTMLBarsDOMHelper from './system/dom-helper';
 import topLevelViewTemplate from './templates/top-level-view';

--- a/packages/ember-htmlbars/lib/system/render-env.js
+++ b/packages/ember-htmlbars/lib/system/render-env.js
@@ -1,6 +1,6 @@
 import defaultEnv from '../env';
 import { MorphSet } from '../renderer';
-import { getOwner } from 'container/owner';
+import { getOwner } from 'container';
 
 export default function RenderEnv(options) {
   this.lifecycleHooks = options.lifecycleHooks || [];

--- a/packages/ember-htmlbars/tests/integration/mount_test.js
+++ b/packages/ember-htmlbars/tests/integration/mount_test.js
@@ -7,7 +7,7 @@ import Component from 'ember-htmlbars/component';
 import Controller from 'ember-runtime/controllers/controller';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
 import run from 'ember-metal/run_loop';
-import { OWNER, getOwner } from 'container/owner';
+import { OWNER, getOwner } from 'container';
 import isEnabled from 'ember-metal/features';
 import { getEngineParent } from 'ember-application/system/engine-parent';
 import { test } from 'internal-test-helpers/tests/skip-if-glimmer';

--- a/packages/ember-htmlbars/tests/system/lookup-helper_test.js
+++ b/packages/ember-htmlbars/tests/system/lookup-helper_test.js
@@ -1,7 +1,7 @@
 import lookupHelper, { findHelper } from 'ember-htmlbars/system/lookup-helper';
 import ComponentLookup from 'ember-views/component_lookup';
 import Helper, { helper as makeHelper } from 'ember-htmlbars/helper';
-import { OWNER } from 'container/owner';
+import { OWNER } from 'container';
 import buildOwner from 'container/tests/test-helpers/build-owner';
 
 function generateEnv(helpers, owner) {
@@ -127,4 +127,3 @@ QUnit.test('fails with a useful error when resolving a function', function() {
     actual = lookupHelper('some-name', view, env);
   }, 'Expected to find an Ember.Helper with the name helper:some-name, but found an object of type function instead.');
 });
-

--- a/packages/ember-htmlbars/tests/utils.js
+++ b/packages/ember-htmlbars/tests/utils.js
@@ -15,7 +15,7 @@ import {
 
 import HashLocation from 'ember-routing/location/hash_location';
 import EmberObject from 'ember-runtime/system/object';
-import Registry from 'container/registry';
+import { Registry } from 'container';
 import RegistryProxy from 'ember-runtime/mixins/registry_proxy';
 import ContainerProxy from 'ember-runtime/mixins/container_proxy';
 import { get as getTemplate, has as hasTemplate } from 'ember-templates/template_registry';

--- a/packages/ember-metal/lib/injected_property.js
+++ b/packages/ember-metal/lib/injected_property.js
@@ -2,7 +2,7 @@ import { assert } from './debug';
 import { ComputedProperty } from './computed';
 import { AliasedProperty } from './alias';
 import { Descriptor } from './properties';
-import { getOwner } from 'container/owner';
+import { getOwner } from 'container';
 
 /**
   Read-only property that returns the result of a container lookup.

--- a/packages/ember-metal/tests/injected_property_test.js
+++ b/packages/ember-metal/tests/injected_property_test.js
@@ -5,7 +5,7 @@ import {
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
 import InjectedProperty from 'ember-metal/injected_property';
-import { setOwner } from 'container/owner';
+import { setOwner } from 'container';
 
 QUnit.module('InjectedProperty');
 

--- a/packages/ember-routing/lib/location/auto_location.js
+++ b/packages/ember-routing/lib/location/auto_location.js
@@ -2,7 +2,7 @@ import { assert } from 'ember-metal/debug';
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
 import { tryInvoke } from 'ember-metal/utils';
-import { getOwner } from 'container/owner';
+import { getOwner } from 'container';
 
 import EmberObject from 'ember-runtime/system/object';
 import { environment } from 'ember-environment';

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -29,7 +29,7 @@ import {
   normalizeControllerQueryParams,
   calculateCacheKey
 } from '../utils';
-import { getOwner } from 'container/owner';
+import { getOwner } from 'container';
 import isEmpty from 'ember-metal/is_empty';
 import symbol from 'ember-metal/symbol';
 const { slice } = Array.prototype;

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -22,7 +22,7 @@ import {
 } from '../utils';
 import { guidFor } from 'ember-metal/utils';
 import RouterState from './router_state';
-import { getOwner } from 'container/owner';
+import { getOwner } from 'container';
 import dictionary from 'ember-metal/dictionary';
 
 /**

--- a/packages/ember-routing/tests/location/auto_location_test.js
+++ b/packages/ember-routing/tests/location/auto_location_test.js
@@ -10,7 +10,7 @@ import HistoryLocation from 'ember-routing/location/history_location';
 import HashLocation from 'ember-routing/location/hash_location';
 import NoneLocation from 'ember-routing/location/none_location';
 import buildOwner from 'container/tests/test-helpers/build-owner';
-import { OWNER } from 'container/owner';
+import { OWNER } from 'container';
 
 function mockBrowserLocation(overrides) {
   return assign({

--- a/packages/ember-routing/tests/system/dsl_test.js
+++ b/packages/ember-routing/tests/system/dsl_test.js
@@ -1,5 +1,5 @@
 import EmberRouter from 'ember-routing/system/router';
-import { setOwner } from 'container/owner';
+import { setOwner } from 'container';
 import buildOwner from 'container/tests/test-helpers/build-owner';
 import isEnabled from 'ember-metal/features';
 

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -4,7 +4,7 @@ import EmberObject from 'ember-runtime/system/object';
 import EmberRoute from 'ember-routing/system/route';
 import inject from 'ember-runtime/inject';
 import buildOwner from 'container/tests/test-helpers/build-owner';
-import { setOwner } from 'container/owner';
+import { setOwner } from 'container';
 import isEnabled from 'ember-metal/features';
 
 let route, routeOne, routeTwo, lookupHash;

--- a/packages/ember-routing/tests/system/router_test.js
+++ b/packages/ember-routing/tests/system/router_test.js
@@ -5,7 +5,7 @@ import NoneLocation from 'ember-routing/location/none_location';
 import Router, { triggerEvent } from 'ember-routing/system/router';
 import { runDestroy } from 'ember-runtime/tests/utils';
 import buildOwner from 'container/tests/test-helpers/build-owner';
-import { setOwner } from 'container/owner';
+import { setOwner } from 'container';
 
 let owner;
 

--- a/packages/ember-runtime/lib/system/container.js
+++ b/packages/ember-runtime/lib/system/container.js
@@ -1,7 +1,10 @@
+import {
+  Registry,
+  Container,
+  getOwner,
+  setOwner
+} from 'container';
 import { set } from 'ember-metal/property_set';
-import Registry from 'container/registry';
-import Container from 'container/container';
-import { getOwner, setOwner } from 'container/owner';
 
 Registry.set = set;
 Container.set = set;

--- a/packages/ember-runtime/tests/mixins/container_proxy_test.js
+++ b/packages/ember-runtime/tests/mixins/container_proxy_test.js
@@ -1,6 +1,8 @@
-import { OWNER } from 'container/owner';
-import Registry from 'container/registry';
-import Container from 'container/container';
+import {
+  Container,
+  Registry,
+  OWNER
+} from 'container';
 import ContainerProxy from 'ember-runtime/mixins/container_proxy';
 import EmberObject from 'ember-runtime/system/object';
 

--- a/packages/ember-views/lib/mixins/child_views_support.js
+++ b/packages/ember-views/lib/mixins/child_views_support.js
@@ -3,7 +3,7 @@
 @submodule ember-views
 */
 import { Mixin } from 'ember-metal/mixin';
-import { getOwner, setOwner } from 'container/owner';
+import { getOwner, setOwner } from 'container';
 import descriptor from 'ember-metal/descriptor';
 import { initChildViews, getChildViews, addChildView } from '../system/utils';
 

--- a/packages/ember-views/lib/mixins/template_support.js
+++ b/packages/ember-views/lib/mixins/template_support.js
@@ -1,6 +1,6 @@
 import EmberError from 'ember-metal/error';
 import { computed } from 'ember-metal/computed';
-import { getOwner } from 'container/owner';
+import { getOwner } from 'container';
 import { Mixin } from 'ember-metal/mixin';
 import { get } from 'ember-metal/property_get';
 import { assert } from 'ember-metal/debug';

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -12,7 +12,7 @@ import EmberObject from 'ember-runtime/system/object';
 import jQuery from './jquery';
 import ActionManager from './action_manager';
 import assign from 'ember-metal/assign';
-import { getOwner } from 'container/owner';
+import { getOwner } from 'container';
 import { environment } from 'ember-environment';
 import fallbackViewRegistry from '../compat/fallback-view-registry';
 

--- a/packages/ember-views/lib/system/utils.js
+++ b/packages/ember-views/lib/system/utils.js
@@ -1,7 +1,7 @@
 /* globals Element */
 
 import { guidFor } from 'ember-metal/utils';
-import { getOwner } from 'container/owner';
+import { getOwner } from 'container';
 import symbol from 'ember-metal/symbol';
 
 /**

--- a/packages/ember-views/lib/utils/lookup-component.js
+++ b/packages/ember-views/lib/utils/lookup-component.js
@@ -1,4 +1,4 @@
-import { privatize as P } from 'container/registry';
+import { privatize as P } from 'container';
 
 function lookupComponentPair(componentLookup, owner, name, options) {
   let component = componentLookup.componentFor(name, owner, options);

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -17,7 +17,7 @@ import Engine from 'ember-application/system/engine';
 import { A as emberA } from 'ember-runtime/system/native_array';
 import NoneLocation from 'ember-routing/location/none_location';
 import HistoryLocation from 'ember-routing/location/history_location';
-import { getOwner } from 'container/owner';
+import { getOwner } from 'container';
 import { Transition } from 'router/transition';
 import copy from 'ember-runtime/copy';
 import { addObserver } from 'ember-metal/observer';


### PR DESCRIPTION
As we implement this, we will be able to do much more intelligent build things.
