### PR TITLE
Bower: Fix "invalid-meta" warning

### DIFF
--- a/config/package_manager_files/bower.json
+++ b/config/package_manager_files/bower.json
@@ -4,8 +4,7 @@
   "license": "MIT",
   "homepage": "https://github.com/emberjs/ember.js",
   "main": [
-    "./ember.debug.js",
-    "./ember-template-compiler.js"
+    "./ember.debug.js"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
```
The "main" field has to contain only 1 file per filetype; found multiple .js files: ["./ember.debug.js","./ember-template-compiler.js"]
```

/cc @rwjblue 
