### PR TITLE
[BUGFIX release] Fix array QP serialization

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -431,7 +431,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     // urlKey isn't used here, but anyone overriding
     // can use it to provide serialization specific
     // to a certain query param.
-    if (defaultValueType === 'array') {
+    if (defaultValueType === 'array' && Array.isArray(value)) {
       return JSON.stringify(value);
     }
     return `${value}`;

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -2530,6 +2530,25 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     equal(router.get('location.path'), '/?foo=3', 'url is correct');
   });
 
+  QUnit.test('previously set array queryParam is preserved when a controller property is set and the route is refreshed.', function() {
+   App.ApplicationController = Controller.extend({
+     queryParams: ['array', 'foo'],
+     array: [],
+     foo: null,
+   });
+
+   startingURL = '/';
+   bootApplication();
+   let applicationRoute = container.lookup('route:application');
+   let applicationController = container.lookup('controller:application');
+   run(applicationController, 'set', 'array', [1]);
+   run(() => {
+     applicationController.set('foo', 'bar');
+     applicationRoute.refresh();
+   });
+   equal(decodeURIComponent(router.get('location.path')), `/?array=[1]&foo=bar`, 'url is correct');
+ });
+
   QUnit.test('Use Ember.get to retrieve query params \'refreshModel\' configuration', function() {
     expect(6);
     App.ApplicationController = Controller.extend({


### PR DESCRIPTION
A twiddle reproducing the issue: https://ember-twiddle.com/c0f6b0efd71731ecb7e474ddedc7a7a4 - after a click on set array and then on refresh the array QP becomes a string.

`"[1]"` gets stringified in the second call to `serializeQueryParam`, resulting in the serialized param being `""[1]""` instead of `"[1]"`.

This fixes #13591 and is similar to #13816.
