### PR TITLE
Fix skipped tests related to outlets.

### DIFF
--- a/packages/ember-glimmer/lib/syntax/outlet.js
+++ b/packages/ember-glimmer/lib/syntax/outlet.js
@@ -58,11 +58,15 @@ class TopLevelOutletComponentReference {
   }
 
   value() {
-    let lastState = this.lastState;
-    let newState = this.outletReference.value();
+    let { lastState, outletReference, definition } = this;
+    let newState = outletReference.value();
 
-    if (lastState.render.name !== newState.render.name) {
-      return new TopLevelOutletComponentDefinition(newState.outlets.main.render.template);
+    definition = revalidate(definition, lastState, newState);
+
+    if (definition) {
+      return definition;
+    } else {
+      return new TopLevelOutletComponentDefinition(newState.render.template);
     }
 
     return this.definition;
@@ -184,7 +188,12 @@ class TopLevelOutletComponentManager extends AbstractOutletComponentManager {
   }
 
   layoutFor(definition, bucket, env) {
-    return env.getCompiledBlock(TopLevelOutletLayoutCompiler, definition.template);
+    let { template } = definition;
+    if (!template) {
+      template = env.owner.lookup('template:-outlet');
+    }
+
+    return env.getCompiledBlock(TopLevelOutletLayoutCompiler, template);
   }
 }
 

--- a/packages/ember-glimmer/lib/syntax/outlet.js
+++ b/packages/ember-glimmer/lib/syntax/outlet.js
@@ -3,6 +3,12 @@ import { generateGuid, guidFor } from 'ember-metal/utils';
 import { _instrumentStart } from 'ember-metal/instrumentation';
 import { RootReference } from '../utils/references';
 
+import {
+  UpdatableTag,
+  ConstReference,
+  combine
+} from 'glimmer-reference';
+
 function outletComponentFor(vm) {
   let { outletState, isTopLevel } = vm.dynamicScope();
 
@@ -10,14 +16,22 @@ function outletComponentFor(vm) {
     return new TopLevelOutletComponentReference(outletState);
   } else {
     let args = vm.getArgs();
-    let outletName = args.positional.at(0).value() || 'main';
-    return new OutletComponentReference(outletName, outletState.get(outletName));
+    let outletNameRef;
+    if (args.positional.length === 0) {
+      outletNameRef = new ConstReference('main');
+    } else {
+      outletNameRef = args.positional.at(0);
+    }
+
+    return new OutletComponentReference(outletNameRef, outletState);
   }
 }
 
 export class OutletSyntax extends StatementSyntax {
   static create(environment, args, templates, symbolTable) {
-    return new this(environment, args, templates, symbolTable);
+    let definitionArgs = ArgsSyntax.fromPositionalArgs(args.positional.slice(0, 1));
+
+    return new this(environment, definitionArgs, templates, symbolTable);
   }
 
   constructor(environment, args, templates, symbolTable) {
@@ -56,17 +70,25 @@ class TopLevelOutletComponentReference {
 }
 
 class OutletComponentReference {
-  constructor(outletName, reference) {
-    this.outletName = outletName;
-    this.reference = reference;
+  constructor(outletNameRef, parentOutletStateRef) {
+    this.outletNameRef = outletNameRef;
+    this.parentOutletStateRef = parentOutletStateRef;
     this.definition = null;
     this.lastState = null;
-    this.tag = reference.tag;
+    let outletStateTag = this.outletStateTag = new UpdatableTag(parentOutletStateRef.tag);
+    this.tag = combine([outletStateTag.tag, outletNameRef.tag]);
   }
 
   value() {
-    let { outletName, reference, definition, lastState } = this;
-    let newState = this.lastState = reference.value();
+    let { outletNameRef, parentOutletStateRef, definition, lastState } = this;
+
+
+    let outletName = outletNameRef.value();
+    let outletStateRef = parentOutletStateRef.get(outletName);
+    let newState = this.lastState = outletStateRef.value();
+
+    this.outletStateTag.update(outletStateRef.tag);
+
     definition = revalidate(definition, lastState, newState);
 
     let hasTemplate = newState && newState.render.template;

--- a/packages/ember-glimmer/tests/integration/outlet-test.js
+++ b/packages/ember-glimmer/tests/integration/outlet-test.js
@@ -156,7 +156,49 @@ moduleFor('outlet view', class extends RenderingTest {
     this.assertText('HIBYE');
   }
 
-  ['@skip should support bound outlet name']() {
+  ['@test does not default outlet name when positional argument is present']() {
+    this.registerTemplate('application', '<h1>HI</h1>{{outlet someUndefinedThing}}');
+    let outletState = {
+      render: {
+        owner: this.owner,
+        into: undefined,
+        outlet: 'main',
+        name: 'application',
+        controller: {},
+        ViewClass: undefined,
+        template: this.owner.lookup('template:application')
+      },
+      outlets: Object.create(null)
+    };
+
+    this.runTask(() => this.component.setOutletState(outletState));
+
+    runAppend(this.component);
+
+    this.assertText('HI');
+
+    this.assertStableRerender();
+
+    this.registerTemplate('special', '<p>BYE</p>');
+    outletState.outlets.main = {
+      render: {
+        owner: this.owner,
+        into: undefined,
+        outlet: 'main',
+        name: 'special',
+        controller: {},
+        ViewClass: undefined,
+        template: this.owner.lookup('template:special')
+      },
+      outlets: Object.create(null)
+    };
+
+    this.runTask(() => this.component.setOutletState(outletState));
+
+    this.assertText('HI');
+  }
+
+  ['@test should support bound outlet name']() {
     let controller = { outletName: 'foo' };
     this.registerTemplate('application', '<h1>HI</h1>{{outlet outletName}}');
     let outletState = {
@@ -165,7 +207,7 @@ moduleFor('outlet view', class extends RenderingTest {
         into: undefined,
         outlet: 'main',
         name: 'application',
-        controller: controller,
+        controller,
         ViewClass: undefined,
         template: this.owner.lookup('template:application')
       },

--- a/packages/ember-glimmer/tests/integration/outlet-test.js
+++ b/packages/ember-glimmer/tests/integration/outlet-test.js
@@ -10,9 +10,29 @@ moduleFor('outlet view', class extends RenderingTest {
     this.component = CoreOutlet.create();
   }
 
-  ['@skip should render the outlet when set after DOM insertion']() {
-    // fails in glimmer because of an attempt to access `.id` on
-    // the provided template (which is undefined)
+  ['@test should not error when initial rendered template is undefined']() {
+    let outletState = {
+      render: {
+        owner: this.owner,
+        into: undefined,
+        outlet: 'main',
+        name: 'application',
+        controller: undefined,
+        ViewClass: undefined,
+        template: undefined
+      },
+
+      outlets: Object.create(null)
+    };
+
+    this.runTask(() => this.component.setOutletState(outletState));
+
+    runAppend(this.component);
+
+    this.assertText('');
+  }
+
+  ['@test should render the outlet when set after DOM insertion']() {
     let outletState = {
       render: {
         owner: this.owner,


### PR DESCRIPTION
- Fix issue with setting outlet state after initial render.
  - When the initially rendered outlet state was `undefined` an error
    occurred (due to not handling the missing template case).
  - When a completely new outlet state object is setup, the `.value`
    calculation for `TopLevelOutletComponentReference` was completely
    incorrect (it was looking for `newState.outlets.main.render.template`
    instead of `newState.render.template`).
- Fix usage of bound outlet name. Previously, we were eagerly evaluating the bound reference and passing the final value around instead of the reference to the final outlet name value. This means that given `{{outlet foo}}` when the property `foo` changes then no updates would be made. The fix is to avoid eagerly evaluating the reference, band and ensure that the `ComponentDefition` includes a tag the represents both the outlet name and the outlet state. While debugging this, I also came across an untested scenario where we coerced any falsy values for outlet name into `'main'`. However, we should only be defaulting to `'main'` if no positional argument is present.

Addresses 2 more tests in https://github.com/emberjs/ember.js/issues/14170.
