### PR TITLE
Add support for multiple roots.

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/append-test.js
+++ b/packages/ember-glimmer/tests/integration/components/append-test.js
@@ -101,7 +101,7 @@ class AbstractAppendTest extends RenderingTest {
     this.assert.equal(willDestroyCalled, 1);
   }
 
-  ['@skip appending, updating and destroying multiple components'](assert) {
+  ['@test appending, updating and destroying multiple components'](assert) {
     let willDestroyCalled = 0;
 
     this.registerComponent('x-first', {

--- a/packages/ember-glimmer/tests/utils/test-case.js
+++ b/packages/ember-glimmer/tests/utils/test-case.js
@@ -18,9 +18,4 @@ export class RenderingTest extends AbstractRenderingTest {
     owner.registerOptionsForType('helper', { instantiate: false });
     owner.registerOptionsForType('component', { singleton: false });
   }
-
-  render(...args) {
-    super.render(...args);
-    this.renderer._root = this.component;
-  }
 }

--- a/packages/ember-metal/lib/transaction.js
+++ b/packages/ember-metal/lib/transaction.js
@@ -24,10 +24,10 @@ if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
   let inTransaction = false;
   let shouldReflush;
 
-  runInTransaction = function(callback) {
+  runInTransaction = function(context, methodName) {
     shouldReflush = false;
     inTransaction = true;
-    callback();
+    context[methodName]();
     inTransaction = false;
     counter++;
     return shouldReflush;


### PR DESCRIPTION
To support things like `ember-islands` we need to refactor the renderer to allow for multiple roots (in other words multiple components can call `appendTo`).
- [x] Refactor single root system
- [x] Add support for multiple roots
- [x] @krisselden r?
- [x] @chancancode r?
