### PR TITLE
Avoid using `Function.prototype.bind` needlessly.

### DIFF
--- a/packages/ember-glimmer/lib/syntax/dynamic-component.js
+++ b/packages/ember-glimmer/lib/syntax/dynamic-component.js
@@ -8,11 +8,10 @@ import {
 import { UNDEFINED_REFERENCE } from 'glimmer-reference';
 import { assert } from 'ember-metal/debug';
 
-function dynamicComponentFor(vm) {
+function dynamicComponentFor(vm, symbolTable) {
   let env     = vm.env;
   let args    = vm.getArgs();
   let nameRef = args.positional.at(0);
-  let { symbolTable } = this;
 
   return new DynamicComponentReference({ nameRef, env, symbolTable });
 }
@@ -38,7 +37,7 @@ export class DynamicComponentSyntax extends StatementSyntax {
 
   constructor(definitionArgs, args, templates, symbolTable) {
     super();
-    this.definition = dynamicComponentFor.bind(this);
+    this.definition = dynamicComponentFor;
     this.definitionArgs = definitionArgs;
     this.args = args;
     this.templates = templates;


### PR DESCRIPTION
The definition function receives `symbolTable` now, there is no need to bind it to the syntax instance.

---

This removes the primary issue with running tests against canary from Phantom 1.9.  It is not obvious that we do or do not support Phantom 1.9, but it would be preferable to make an official decision rather than break it accidentally.

Example error message when running under Phantom 1.9:

```
not ok 3 PhantomJS 1.9 - Acceptance: title: the default configuration works
    ---
        actual: >
            false
        expected: >
            true
        stack: >
                at http://localhost:7357/assets/test-support.js:3854
                at http://localhost:7357/assets/test-support.js:4584
                at http://localhost:7357/assets/vendor.js:46336
                at adapterDispatch (http://localhost:7357/assets/vendor.js:47443)
                at dispatchError (http://localhost:7357/assets/vendor.js:25423)
                at onerrorDefault (http://localhost:7357/assets/vendor.js:39342)
                at http://localhost:7357/assets/vendor.js:65478
                at http://localhost:7357/assets/vendor.js:66470
                at http://localhost:7357/assets/vendor.js:11193
                at http://localhost:7357/assets/vendor.js:11257
                at http://localhost:7357/assets/vendor.js:11065
                at http://localhost:7357/assets/vendor.js:10379
                at http://localhost:7357/assets/vendor.js:10945
        message: >
            TypeError: 'undefined' is not a function (evaluating 'dynamicComponentFor.bind(this)')
        Log: |
```
