### PR TITLE
Refactor ember-metal exports.

### DIFF
--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -3,30 +3,31 @@
 @submodule ember-metal
 */
 
+export { default } from './core'; // reexports
 export {
   default as computed,
   cacheFor,
   ComputedProperty
 } from './computed';
-
 export { default as alias } from './alias';
-
-// BEGIN IMPORTS
-import require, { has } from 'require';
-import { ENV, context } from 'ember-environment';
-import VERSION from 'ember/version';
-import Ember from './core'; // reexports
-import { deprecate, deprecateFunc } from './debug';
-import isEnabled, { FEATURES } from './features';
-import assign from './assign';
-import merge from './merge';
-import {
+export { deprecate } from './debug';
+export { default as assign } from './assign';
+export { default as merge } from './merge';
+export {
+  assert,
+  warn,
+  debug,
+  deprecate,
+  deprecateFunc,
+  runInDebug
+} from './debug';
+export {
   instrument,
   reset as instrumentationReset,
   subscribe as instrumentationSubscribe,
   unsubscribe as instrumentationUnsubscribe
 } from './instrumentation';
-import {
+export {
   GUID_KEY,
   apply,
   applyStr,
@@ -40,21 +41,32 @@ import {
   uuid,
   wrap
 } from './utils';
-import {
+export {
+  isTesting,
+  setTesting
+} from './testing';
+export {
+  getOnerror,
+  setOnerror
+} from './error_handler';
+export {
   META_DESC,
   meta
 } from './meta';
-import EmberError from './error';
-import Cache from './cache';
-import Logger from 'ember-console';
-
-import {
+export { default as Error } from './error';
+export { default as Cache } from './cache';
+export { default as isFeatureEnabled, FEATURES } from './features';
+export {
   _getPath,
   get,
   getWithDefault
 } from './property_get';
-
-import {
+export {
+  set,
+  trySet
+} from './property_set';
+export { default as WeakMap } from './weak_map';
+export {
   accumulateListeners,
   addListener,
   hasListeners,
@@ -67,9 +79,13 @@ import {
   watchedEvents
 } from './events';
 
-import ObserverSet from './observer_set';
-
-import {
+export { default as isNone } from './is_none';
+export { default as isEmpty } from './is_empty';
+export { default as isBlank } from './is_blank';
+export { default as isPresent } from './is_present';
+export { default as run } from './run_loop';
+export { default as ObserverSet } from './observer_set';
+export {
   beginPropertyChanges,
   changeProperties,
   endPropertyChanges,
@@ -77,54 +93,47 @@ import {
   propertyDidChange,
   propertyWillChange
 } from './property_events';
-
-import {
+export {
   defineProperty
 } from './properties';
-import {
-  set,
-  trySet
-} from './property_set';
-
-import WeakMap from './weak_map';
-import {
-  Map,
-  MapWithDefault,
-  OrderedSet
-} from './map';
-
-import getProperties from './get_properties';
-import setProperties from './set_properties';
-import {
+export {
   watchKey,
   unwatchKey
 } from './watch_key';
-import {
+export {
   ChainNode,
   finishChains,
   removeChainWatcher
 } from './chains';
-import {
+export {
   watchPath,
   unwatchPath
 } from './watch_path';
-import {
+export {
   destroy,
   isWatching,
   rewatch,
   unwatch,
   watch
 } from './watching';
-import expandProperties from './expand_properties';
+export { default as libraries } from './libraries';
+export {
+  Map,
+  MapWithDefault,
+  OrderedSet
+} from './map';
+export { default as getProperties } from './get_properties';
+export { default as setProperties } from './set_properties';
+export { default as expandProperties } from './expand_properties';
 
-import {
+export {
   _suspendObserver,
   _suspendObservers,
   addObserver,
   observersFor,
   removeObserver
 } from './observer';
-import {
+export {
   NAME_KEY,
   Mixin,
   aliasMethod,
@@ -133,311 +142,20 @@ import {
   observer,
   required
 } from './mixin';
-import {
+export {
   Binding,
   bind
 } from './binding';
-import {
+export {
   isGlobalPath
 } from './path_cache';
 
-import {
-  isTesting,
-  setTesting
-} from './testing';
-import {
-  getOnerror,
-  setOnerror
-} from './error_handler';
 
-import run from './run_loop';
-import libraries from './libraries';
-import isNone from './is_none';
-import isEmpty from './is_empty';
-import isBlank from './is_blank';
-import isPresent from './is_present';
-import Backburner from 'backburner';
-
-// END IMPORTS
-
-// BEGIN EXPORTS
-const EmberInstrumentation = Ember.Instrumentation = {};
-EmberInstrumentation.instrument = instrument;
-EmberInstrumentation.subscribe = instrumentationSubscribe;
-EmberInstrumentation.unsubscribe = instrumentationUnsubscribe;
-EmberInstrumentation.reset  = instrumentationReset;
-
-Ember.instrument = instrument;
-Ember.subscribe = instrumentationSubscribe;
-
-Ember._Cache = Cache;
-
-Ember.generateGuid    = generateGuid;
-Ember.GUID_KEY        = GUID_KEY;
-Ember.NAME_KEY        = NAME_KEY;
-Ember.platform        = {
-  defineProperty: true,
-  hasPropertyAccessors: true
-};
-
-Ember.Error           = EmberError;
-Ember.guidFor         = guidFor;
-Ember.META_DESC       = META_DESC;
-Ember.meta            = meta;
-Ember.inspect         = inspect;
-
-Ember.tryCatchFinally = deprecatedTryCatchFinally;
-Ember.makeArray       = makeArray;
-Ember.canInvoke       = canInvoke;
-Ember.tryInvoke       = tryInvoke;
-Ember.wrap            = wrap;
-Ember.apply           = apply;
-Ember.applyStr        = applyStr;
-Ember.uuid            = uuid;
-
-Ember.Logger = Logger;
-
-Ember.get            = get;
-Ember.getWithDefault = getWithDefault;
-Ember._getPath       = _getPath;
-
-Ember.on                  = on;
-Ember.addListener         = addListener;
-Ember.removeListener      = removeListener;
-Ember._suspendListener    = suspendListener;
-Ember._suspendListeners   = suspendListeners;
-Ember.sendEvent           = sendEvent;
-Ember.hasListeners        = hasListeners;
-Ember.watchedEvents       = watchedEvents;
-Ember.listenersFor        = listenersFor;
-Ember.accumulateListeners = accumulateListeners;
-
-Ember._ObserverSet = ObserverSet;
-
-Ember.propertyWillChange = propertyWillChange;
-Ember.propertyDidChange = propertyDidChange;
-Ember.overrideChains = overrideChains;
-Ember.beginPropertyChanges = beginPropertyChanges;
-Ember.endPropertyChanges = endPropertyChanges;
-Ember.changeProperties = changeProperties;
-
-Ember.defineProperty = defineProperty;
-
-Ember.set    = set;
-Ember.trySet = trySet;
-
-if (isEnabled('ember-metal-weakmap')) {
-  Ember.WeakMap = WeakMap;
-}
-Ember.OrderedSet = OrderedSet;
-Ember.Map = Map;
-Ember.MapWithDefault = MapWithDefault;
-
-Ember.getProperties = getProperties;
-Ember.setProperties = setProperties;
-
-Ember.watchKey   = watchKey;
-Ember.unwatchKey = unwatchKey;
-
-Ember.removeChainWatcher = removeChainWatcher;
-Ember._ChainNode = ChainNode;
-Ember.finishChains = finishChains;
-
-Ember.watchPath = watchPath;
-Ember.unwatchPath = unwatchPath;
-
-Ember.watch = watch;
-Ember.isWatching = isWatching;
-Ember.unwatch = unwatch;
-Ember.rewatch = rewatch;
-Ember.destroy = destroy;
-
-Ember.expandProperties = expandProperties;
-
-Ember.addObserver = addObserver;
-Ember.observersFor = observersFor;
-Ember.removeObserver = removeObserver;
-Ember._suspendObserver = _suspendObserver;
-Ember._suspendObservers = _suspendObservers;
-
-Ember.required = required;
-Ember.aliasMethod = aliasMethod;
-Ember.observer = observer;
-Ember.immediateObserver = _immediateObserver;
-Ember.mixin = mixin;
-Ember.Mixin = Mixin;
-
-Ember.bind = bind;
-Ember.Binding = Binding;
-Ember.isGlobalPath = isGlobalPath;
-
-Ember.run = run;
-
-/**
-@class Backburner
-@for Ember
-@private
-*/
-Ember.Backburner = function() {
-  deprecate(
-    'Usage of Ember.Backburner is deprecated.',
-    false,
-    {
-      id: 'ember-metal.ember-backburner',
-      until: '2.8.0',
-      url: 'http://emberjs.com/deprecations/v2.x/#toc_ember-backburner'
-    }
-  );
-
-  function BackburnerAlias(args) {
-    return Backburner.apply(this, args);
-  }
-
-  BackburnerAlias.prototype = Backburner.prototype;
-
-  return new BackburnerAlias(arguments);
-};
-
-Ember._Backburner = Backburner;
-
-/**
-  The semantic version
-  @property VERSION
-  @type String
-  @public
- */
-Ember.VERSION = VERSION;
-
-Ember.libraries = libraries;
-
-libraries.registerCoreLibrary('Ember', Ember.VERSION);
-
-Ember.isNone = isNone;
-Ember.isEmpty = isEmpty;
-Ember.isBlank = isBlank;
-Ember.isPresent = isPresent;
-
-Ember.assign = Object.assign || assign;
-Ember.merge = merge;
-
-Ember.FEATURES = FEATURES;
-Ember.FEATURES.isEnabled = isEnabled;
-
-Ember.EXTEND_PROTOTYPES = ENV.EXTEND_PROTOTYPES;
-
-// BACKWARDS COMPAT ACCESSORS FOR ENV FLAGS
-Object.defineProperty(Ember, 'LOG_STACKTRACE_ON_DEPRECATION', {
-  get()      { return ENV.LOG_STACKTRACE_ON_DEPRECATION;    },
-  set(value) { ENV.LOG_STACKTRACE_ON_DEPRECATION = !!value; },
-  enumerable: false
-});
-
-Object.defineProperty(Ember, 'LOG_VERSION', {
-  get()      { return ENV.LOG_VERSION;   },
-  set(value) { ENV.LOG_VERSION = !!value; },
-  enumerable: false
-});
-
-Object.defineProperty(Ember, 'MODEL_FACTORY_INJECTIONS', {
-  get()      { return ENV.MODEL_FACTORY_INJECTIONS;    },
-  set(value) { ENV.MODEL_FACTORY_INJECTIONS = !!value;  },
-  enumerable: false
-});
-
-Object.defineProperty(Ember, 'LOG_BINDINGS', {
-  get()      { return ENV.LOG_BINDINGS;    },
-  set(value) { ENV.LOG_BINDINGS = !!value; },
-  enumerable: false
-});
-
-Object.defineProperty(Ember, 'ENV', {
-  get() { return ENV; },
-  enumerable: false
-});
-
-/**
-  The context that Ember searches for namespace instances on.
-
-  @private
- */
-Object.defineProperty(Ember, 'lookup', {
-  get()      { return context.lookup; },
-  set(value) { context.lookup = value; },
-  enumerable: false
-});
-
-Object.defineProperty(Ember, 'testing', {
-  get: isTesting,
-  set: setTesting,
-  enumerable: false
-});
-
-/**
-  A function may be assigned to `Ember.onerror` to be called when Ember
-  internals encounter an error. This is useful for specialized error handling
-  and reporting code.
-
-  ```javascript
-  Ember.onerror = function(error) {
-    Em.$.ajax('/report-error', 'POST', {
-      stack: error.stack,
-      otherInformation: 'whatever app state you want to provide'
-    });
-  };
-  ```
-
-  Internally, `Ember.onerror` is used as Backburner's error handler.
-
-  @event onerror
-  @for Ember
-  @param {Exception} error the error object
-  @public
-*/
-Object.defineProperty(Ember, 'onerror', {
-  get: getOnerror,
-  set: setOnerror,
-  enumerable: false
-});
-
-/**
-  An empty function useful for some operations. Always returns `this`.
-
-  @method K
-  @return {Object}
-  @public
-*/
-Ember.K = function K() { return this; };
-
-// The debug functions are exported to globals with `require` to
-// prevent babel-plugin-filter-imports from removing them.
-let debugModule = require('ember-metal/debug');
-Ember.assert = debugModule.assert;
-Ember.warn = debugModule.warn;
-Ember.debug = debugModule.debug;
-Ember.deprecate = debugModule.deprecate;
-Ember.deprecateFunc = debugModule.deprecateFunc;
-Ember.runInDebug = debugModule.runInDebug;
-// END EXPORTS
-
+// TODO: this needs to be deleted once we refactor the build tooling
 // do this for side-effects of updating Ember.assert, warn, etc when
 // ember-debug is present
 // This needs to be called before any deprecateFunc
+import require, { has } from 'require';
 if (has('ember-debug')) {
   require('ember-debug');
-} else {
-  Ember.Debug = { };
-  Ember.Debug.registerDeprecationHandler = function() { };
-  Ember.Debug.registerWarnHandler = function() { };
 }
-
-Ember.create = deprecateFunc('Ember.create is deprecated in favor of Object.create', { id: 'ember-metal.ember-create', until: '3.0.0' }, Object.create);
-Ember.keys = deprecateFunc('Ember.keys is deprecated in favor of Object.keys', { id: 'ember-metal.ember.keys', until: '3.0.0' }, Object.keys);
-
-/* globals module */
-if (typeof module === 'object' && module.exports) {
-  module.exports = Ember;
-} else {
-  context.exports.Ember = context.exports.Em = Ember;
-}
-
-export default Ember;

--- a/packages/ember/lib/index.js
+++ b/packages/ember/lib/index.js
@@ -1,20 +1,248 @@
 import require, { has } from 'require';
 import isEnabled from 'ember-metal/features';
 
-import { ENV } from 'ember-environment';
+// ****ember-environment****
+import { ENV, context } from 'ember-environment';
 
-import {
-  default as Ember,
-  computed,
-  alias,
-  ComputedProperty,
-  cacheFor
-} from 'ember-metal';
 
-computed.alias = alias;
+// ****ember-metal****
+import Ember, * as metal from 'ember-metal';
+import { deprecate, deprecateFunc } from 'ember-metal';
+
+const computed = metal.computed;
+computed.alias = metal.alias;
 Ember.computed = computed;
-Ember.ComputedProperty = ComputedProperty;
-Ember.cacheFor = cacheFor;
+Ember.ComputedProperty = metal.ComputedProperty;
+Ember.cacheFor = metal.cacheFor;
+
+Ember.assert = metal.assert;
+Ember.warn = metal.warn;
+Ember.debug = metal.debug;
+Ember.deprecate = metal.deprecate;
+Ember.deprecateFunc = metal.deprecateFunc;
+Ember.runInDebug = metal.runInDebug;
+Ember.assign = Object.assign || metal.assign;
+Ember.merge = metal.merge;
+
+Ember.instrument = metal.instrument;
+Ember.subscribe = metal.instrumentationSubscribe;
+Ember.Instrumentation = {
+  instrument: metal.instrument,
+  subscribe: metal.instrumentationSubscribe,
+  unsubscribe: metal.instrumentationUnsubscribe,
+  reset: metal.instrumentationReset
+};
+
+Ember.generateGuid = metal.generateGuid;
+Ember.GUID_KEY = metal.GUID_KEY;
+Ember.guidFor = metal.guidFor;
+Ember.inspect = metal.inspect;
+
+Ember.tryCatchFinally = metal.deprecatedTryCatchFinally;
+Ember.makeArray = metal.makeArray;
+Ember.canInvoke = metal.canInvoke;
+Ember.tryInvoke = metal.tryInvoke;
+Ember.wrap = metal.wrap;
+Ember.apply = metal.apply;
+Ember.applyStr = metal.applyStr;
+Ember.uuid = metal.uuid;
+Ember.Error = metal.Error;
+Ember.META_DESC = metal.META_DESC;
+Ember.meta = metal.meta;
+Ember.get = metal.get;
+Ember.getWithDefault = metal.getWithDefault;
+Ember._getPath = metal._getPath;
+Ember.set = metal.set;
+Ember.trySet = metal.trySet;
+Ember.FEATURES = metal.FEATURES;
+Ember.FEATURES.isEnabled = metal.isFeatureEnabled;
+Ember._Cache = metal.Cache;
+Ember.on = metal.on;
+Ember.addListener = metal.addListener;
+Ember.removeListener = metal.removeListener;
+Ember._suspendListener = metal.suspendListener;
+Ember._suspendListeners = metal.suspendListeners;
+Ember.sendEvent = metal.sendEvent;
+Ember.hasListeners = metal.hasListeners;
+Ember.watchedEvents = metal.watchedEvents;
+Ember.listenersFor = metal.listenersFor;
+Ember.accumulateListeners = metal.accumulateListeners;
+Ember.isNone = metal.isNone;
+Ember.isEmpty = metal.isEmpty;
+Ember.isBlank = metal.isBlank;
+Ember.isPresent = metal.isPresent;
+Ember.run = metal.run;
+Ember._ObserverSet = metal.ObserverSet;
+Ember.propertyWillChange = metal.propertyWillChange;
+Ember.propertyDidChange = metal.propertyDidChange;
+Ember.overrideChains = metal.overrideChains;
+Ember.beginPropertyChanges = metal.beginPropertyChanges;
+Ember.endPropertyChanges = metal.endPropertyChanges;
+Ember.changeProperties = metal.changeProperties;
+Ember.platform        = {
+  defineProperty: true,
+  hasPropertyAccessors: true
+};
+Ember.defineProperty = metal.defineProperty;
+Ember.watchKey = metal.watchKey;
+Ember.unwatchKey = metal.unwatchKey;
+Ember.removeChainWatcher = metal.removeChainWatcher;
+Ember._ChainNode = metal.ChainNode;
+Ember.finishChains = metal.finishChains;
+Ember.watchPath = metal.watchPath;
+Ember.unwatchPath = metal.unwatchPath;
+Ember.watch = metal.watch;
+Ember.isWatching = metal.isWatching;
+Ember.unwatch = metal.unwatch;
+Ember.rewatch = metal.rewatch;
+Ember.destroy = metal.destroy;
+Ember.libraries = metal.libraries;
+Ember.OrderedSet = metal.OrderedSet;
+Ember.Map = metal.Map;
+Ember.MapWithDefault = metal.MapWithDefault;
+Ember.getProperties = metal.getProperties;
+Ember.setProperties = metal.setProperties;
+Ember.expandProperties = metal.expandProperties;
+Ember.NAME_KEY = metal.NAME_KEY;
+Ember.addObserver = metal.addObserver;
+Ember.observersFor = metal.observersFor;
+Ember.removeObserver = metal.removeObserver;
+Ember._suspendObserver = metal._suspendObserver;
+Ember._suspendObservers = metal._suspendObservers;
+Ember.required = metal.required;
+Ember.aliasMethod = metal.aliasMethod;
+Ember.observer = metal.observer;
+Ember.immediateObserver = metal._immediateObserver;
+Ember.mixin = metal.mixin;
+Ember.Mixin = metal.Mixin;
+Ember.bind = metal.bind;
+Ember.Binding = metal.Binding;
+Ember.isGlobalPath = metal.isGlobalPath;
+
+if (isEnabled('ember-metal-weakmap')) {
+  Ember.WeakMap = metal.WeakMap;
+}
+
+Object.defineProperty(Ember, 'ENV', {
+  get() { return ENV; },
+  enumerable: false
+});
+
+/**
+ The context that Ember searches for namespace instances on.
+
+ @private
+ */
+Object.defineProperty(Ember, 'lookup', {
+  get()      { return context.lookup; },
+  set(value) { context.lookup = value; },
+  enumerable: false
+});
+
+Ember.EXTEND_PROTOTYPES = ENV.EXTEND_PROTOTYPES;
+
+// BACKWARDS COMPAT ACCESSORS FOR ENV FLAGS
+Object.defineProperty(Ember, 'LOG_STACKTRACE_ON_DEPRECATION', {
+  get()      { return ENV.LOG_STACKTRACE_ON_DEPRECATION;    },
+  set(value) { ENV.LOG_STACKTRACE_ON_DEPRECATION = !!value; },
+  enumerable: false
+});
+
+Object.defineProperty(Ember, 'LOG_VERSION', {
+  get()      { return ENV.LOG_VERSION;   },
+  set(value) { ENV.LOG_VERSION = !!value; },
+  enumerable: false
+});
+
+Object.defineProperty(Ember, 'MODEL_FACTORY_INJECTIONS', {
+  get()      { return ENV.MODEL_FACTORY_INJECTIONS;    },
+  set(value) { ENV.MODEL_FACTORY_INJECTIONS = !!value;  },
+  enumerable: false
+});
+
+Object.defineProperty(Ember, 'LOG_BINDINGS', {
+  get()      { return ENV.LOG_BINDINGS;    },
+  set(value) { ENV.LOG_BINDINGS = !!value; },
+  enumerable: false
+});
+
+/**
+  A function may be assigned to `Ember.onerror` to be called when Ember
+  internals encounter an error. This is useful for specialized error handling
+  and reporting code.
+
+  ```javascript
+  Ember.onerror = function(error) {
+    Em.$.ajax('/report-error', 'POST', {
+      stack: error.stack,
+      otherInformation: 'whatever app state you want to provide'
+    });
+  };
+  ```
+
+  Internally, `Ember.onerror` is used as Backburner's error handler.
+
+  @event onerror
+  @for Ember
+  @param {Exception} error the error object
+  @public
+*/
+Object.defineProperty(Ember, 'onerror', {
+  get: metal.getOnerror,
+  set: metal.setOnerror,
+  enumerable: false
+});
+
+/**
+  An empty function useful for some operations. Always returns `this`.
+
+  @method K
+  @return {Object}
+  @public
+*/
+Ember.K = function K() { return this; };
+
+Object.defineProperty(Ember, 'testing', {
+  get: metal.isTesting,
+  set: metal.setTesting,
+  enumerable: false
+});
+
+if (!has('ember-debug')) {
+  Ember.Debug = {
+    registerDeprecationHandler() {},
+    registerWarnHandler() {}
+  };
+}
+
+import Backburner from 'backburner';
+
+/**
+ @class Backburner
+ @for Ember
+ @private
+ */
+Ember.Backburner = function() {
+  deprecate(
+    'Usage of Ember.Backburner is deprecated.',
+    false,
+    {
+      id: 'ember-metal.ember-backburner',
+      until: '2.8.0',
+      url: 'http://emberjs.com/deprecations/v2.x/#toc_ember-backburner'
+    }
+  );
+
+  function BackburnerAlias(args) {
+    return Backburner.apply(this, args);
+  }
+
+  BackburnerAlias.prototype = Backburner.prototype;
+
+  return new BackburnerAlias(arguments);
+};
+
+Ember._Backburner = Backburner;
 
 import {
   Registry,
@@ -27,6 +255,12 @@ Ember.Container = Container;
 Ember.Registry = Registry;
 Ember.getOwner = getOwner;
 Ember.setOwner = setOwner;
+
+import Logger from 'ember-console';
+
+Ember.Logger = Logger;
+
+// ****ember-runtime****
 
 import {
   String as EmberString,
@@ -287,6 +521,21 @@ Object.defineProperty(Ember, 'TEMPLATES', {
   enumerable: false
 });
 
+import VERSION from './version';
+
+/**
+ The semantic version
+ @property VERSION
+ @type String
+ @public
+ */
+Ember.VERSION = VERSION;
+
+metal.libraries.registerCoreLibrary('Ember', VERSION);
+
+Ember.create = deprecateFunc('Ember.create is deprecated in favor of Object.create', { id: 'ember-metal.ember-create', until: '3.0.0' }, Object.create);
+Ember.keys = deprecateFunc('Ember.keys is deprecated in favor of Object.keys', { id: 'ember-metal.ember.keys', until: '3.0.0' }, Object.keys);
+
 // require the main entry points for each of these packages
 // this is so that the global exports occur properly
 import 'ember-views';
@@ -310,3 +559,10 @@ runLoadHooks('Ember');
 @module ember
 */
 export default Ember;
+
+/* globals module */
+if (typeof module === 'object' && module.exports) {
+  module.exports = Ember;
+} else {
+  context.exports.Ember = context.exports.Em = Ember;
+}

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -5,11 +5,119 @@ import require from 'require';
 QUnit.module('ember reexports');
 
 [
+  // ember-environment
+  // ['ENV', 'ember-environment', 'ENV'], TODO: fix this, its failing because we are hitting the getter
+
   // container
   ['getOwner', 'container', 'getOwner'],
   ['setOwner', 'container', 'setOwner'],
   ['Registry', 'container', 'Registry'],
   ['Container', 'container', 'Container'],
+
+  // ember-metal
+  ['computed', 'ember-metal'],
+  ['computed.alias', 'ember-metal', 'alias'],
+  ['ComputedProperty', 'ember-metal'],
+  ['cacheFor', 'ember-metal'],
+  ['deprecate', 'ember-metal'],
+  ['deprecateFunc', 'ember-metal'],
+  ['assert', 'ember-metal'],
+  ['warn', 'ember-metal'],
+  ['debug', 'ember-metal'],
+  ['runInDebug', 'ember-metal'],
+  // ['assign', 'ember-metal'], TODO: fix this test, we use `Object.assign` if present
+  ['merge', 'ember-metal'],
+  ['instrument', 'ember-metal'],
+  ['Instrumentation.instrument', 'ember-metal', 'instrument'],
+  ['Instrumentation.subscribe', 'ember-metal', 'instrumentationSubscribe'],
+  ['Instrumentation.unsubscribe', 'ember-metal', 'instrumentationUnsubscribe'],
+  ['Instrumentation.reset', 'ember-metal', 'instrumentationReset'],
+  ['generateGuid', 'ember-metal'],
+  ['GUID_KEY', 'ember-metal'],
+  ['guidFor', 'ember-metal'],
+  ['inspect', 'ember-metal'],
+  ['tryCatchFinally', 'ember-metal', 'deprecatedTryCatchFinally'],
+  ['makeArray', 'ember-metal'],
+  ['canInvoke', 'ember-metal'],
+  ['tryInvoke', 'ember-metal'],
+  ['wrap', 'ember-metal'],
+  ['apply', 'ember-metal'],
+  ['applyStr', 'ember-metal'],
+  ['uuid', 'ember-metal'],
+  ['testing', 'ember-metal', { get: 'isTesting', set: 'setTesting' }],
+  ['onerror', 'ember-metal', { get: 'getOnerror', set: 'setOnerror' }],
+  // ['create'], TODO: figure out what to do here
+  // ['keys'], TODO: figure out what to do here
+  ['FEATURES', 'ember-metal'],
+  ['FEATURES.isEnabled', 'ember-metal', 'isFeatureEnabled'],
+  ['Error', 'ember-metal'],
+  ['META_DESC', 'ember-metal'],
+  ['meta', 'ember-metal'],
+  ['get', 'ember-metal'],
+  ['set', 'ember-metal'],
+  ['_getPath', 'ember-metal'],
+  ['getWithDefault', 'ember-metal'],
+  ['trySet', 'ember-metal'],
+  ['_Cache', 'ember-metal', 'Cache'],
+  ['on', 'ember-metal'],
+  ['addListener', 'ember-metal'],
+  ['removeListener', 'ember-metal'],
+  ['_suspendListener', 'ember-metal', 'suspendListener'],
+  ['_suspendListeners', 'ember-metal', 'suspendListeners'],
+  ['sendEvent', 'ember-metal'],
+  ['hasListeners', 'ember-metal'],
+  ['watchedEvents', 'ember-metal'],
+  ['listenersFor', 'ember-metal'],
+  ['accumulateListeners', 'ember-metal'],
+  ['isNone', 'ember-metal'],
+  ['isEmpty', 'ember-metal'],
+  ['isBlank', 'ember-metal'],
+  ['isPresent', 'ember-metal'],
+  ['_Backburner', 'backburner', 'default'],
+  ['run', 'ember-metal'],
+  ['_ObserverSet', 'ember-metal', 'ObserverSet'],
+  ['propertyWillChange', 'ember-metal'],
+  ['propertyDidChange', 'ember-metal'],
+  ['overrideChains', 'ember-metal'],
+  ['beginPropertyChanges', 'ember-metal'],
+  ['beginPropertyChanges', 'ember-metal'],
+  ['endPropertyChanges', 'ember-metal'],
+  ['changeProperties', 'ember-metal'],
+  ['defineProperty', 'ember-metal'],
+  ['watchKey', 'ember-metal'],
+  ['unwatchKey', 'ember-metal'],
+  ['removeChainWatcher', 'ember-metal'],
+  ['_ChainNode', 'ember-metal', 'ChainNode'],
+  ['finishChains', 'ember-metal'],
+  ['watchPath', 'ember-metal'],
+  ['unwatchPath', 'ember-metal'],
+  ['watch', 'ember-metal'],
+  ['isWatching', 'ember-metal'],
+  ['unwatch', 'ember-metal'],
+  ['rewatch', 'ember-metal'],
+  ['destroy', 'ember-metal'],
+  ['libraries', 'ember-metal'],
+  ['OrderedSet', 'ember-metal'],
+  ['Map', 'ember-metal'],
+  ['MapWithDefault', 'ember-metal'],
+  ['getProperties', 'ember-metal'],
+  ['setProperties', 'ember-metal'],
+  ['expandProperties', 'ember-metal'],
+  ['NAME_KEY', 'ember-metal'],
+  ['addObserver', 'ember-metal'],
+  ['observersFor', 'ember-metal'],
+  ['removeObserver', 'ember-metal'],
+  ['_suspendObserver', 'ember-metal'],
+  ['_suspendObservers', 'ember-metal'],
+  ['required', 'ember-metal'],
+  ['aliasMethod', 'ember-metal'],
+  ['observer', 'ember-metal'],
+  ['immediateObserver', 'ember-metal', '_immediateObserver'],
+  ['mixin', 'ember-metal'],
+  ['Mixin', 'ember-metal'],
+  ['bind', 'ember-metal'],
+  ['Binding', 'ember-metal'],
+  ['isGlobalPath', 'ember-metal'],
 
   // ember-glimmer
   ['_Renderer',     'ember-glimmer', '_Renderer'],
@@ -85,8 +193,15 @@ if (isEnabled('ember-string-ishtmlsafe')) {
   });
 }
 
+if (isEnabled('ember-metal-weakmap')) {
+  QUnit.test('Ember.WeakMap exports correctly', function(assert) {
+    confirmExport(assert, 'WeakMap', 'ember-metal', 'WeakMap');
+  });
+}
 function confirmExport(assert, path, moduleId, exportName) {
   let desc = getDescriptor(Ember, path);
+  assert.ok(desc, 'the property exists on the global');
+
   let mod = require(moduleId);
   if (typeof exportName === 'string') {
     assert.equal(desc.value, mod[exportName], `Ember.${path} is exported correctly`);


### PR DESCRIPTION
- Use `ember` module for all exports.
- Add tests for global exports.
