### PR TITLE
Use main package entry points for cross package imports.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -186,7 +186,8 @@ function babelConfigFor(environment) {
   if (isProduction) {
     includeDevHelpers = false;
     plugins.push(filterImports({
-      'ember-metal/debug': ['assert', 'debug', 'deprecate', 'info', 'runInDebug', 'warn', 'debugSeal']
+      'ember-metal/debug': ['assert', 'debug', 'deprecate', 'info', 'runInDebug', 'warn', 'debugSeal'],
+      'ember-metal': ['assert', 'debug', 'deprecate', 'info', 'runInDebug', 'warn', 'debugSeal']
     }));
   }
 

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -14,7 +14,7 @@ module.exports = function(features) {
     'ember-template-compiler': {
       trees: null,
       templateCompilerOnly: true,
-      requirements: ['ember-metal', 'ember-environment', 'ember-console', 'ember-glimmer-template-compiler'],
+      requirements: ['container', 'ember-metal', 'ember-environment', 'ember-console', 'ember-glimmer-template-compiler'],
       templateCompilerVendor: ['simple-html-tokenizer', 'backburner']
     },
     'ember-routing':              { trees: null,  vendorRequirements: ['router', 'route-recognizer'],

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ember-cli-sauce": "^1.4.2",
     "ember-cli-yuidoc": "0.8.4",
     "ember-publisher": "0.0.7",
-    "emberjs-build": "0.16.0",
+    "emberjs-build": "0.16.1",
     "express": "^4.5.0",
     "finalhandler": "^0.4.0",
     "git-repo-info": "^1.1.4",

--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -7,7 +7,6 @@ import {
   symbol
 } from 'ember-metal';
 import { setOwner, OWNER } from './owner';
-import { buildFakeContainerWithDeprecations } from 'ember-runtime';
 
 const CONTAINER_OVERRIDE = symbol('CONTAINER_OVERRIDE');
 
@@ -443,4 +442,33 @@ function resetMember(container, fullName) {
       member.destroy();
     }
   }
+}
+
+export function buildFakeContainerWithDeprecations(container) {
+  let fakeContainer = {};
+  let propertyMappings = {
+    lookup: 'lookup',
+    lookupFactory: '_lookupFactory'
+  };
+
+  for (let containerProperty in propertyMappings) {
+    fakeContainer[containerProperty] = buildFakeContainerFunction(container, containerProperty, propertyMappings[containerProperty]);
+  }
+
+  return fakeContainer;
+}
+
+function buildFakeContainerFunction(container, containerProperty, ownerProperty) {
+  return function() {
+    deprecate(
+      `Using the injected \`container\` is deprecated. Please use the \`getOwner\` helper to access the owner of this object and then call \`${ownerProperty}\` instead.`,
+      false,
+      {
+        id: 'ember-application.injected-container',
+        until: '3.0.0',
+        url: 'http://emberjs.com/deprecations/v2.x#toc_injected-container-access'
+      }
+    );
+    return container[containerProperty](...arguments);
+  };
 }

--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -1,9 +1,13 @@
 import { ENV } from 'ember-environment';
-import { assert, deprecate, runInDebug } from 'ember-metal/debug';
-import dictionary from 'ember-metal/dictionary';
+import {
+  assert,
+  deprecate,
+  runInDebug,
+  dictionary,
+  symbol
+} from 'ember-metal';
 import { setOwner, OWNER } from './owner';
-import { buildFakeContainerWithDeprecations } from 'ember-runtime/mixins/container_proxy';
-import symbol from 'ember-metal/symbol';
+import { buildFakeContainerWithDeprecations } from 'ember-runtime';
 
 const CONTAINER_OVERRIDE = symbol('CONTAINER_OVERRIDE');
 

--- a/packages/container/lib/index.js
+++ b/packages/container/lib/index.js
@@ -6,5 +6,8 @@ The public API, specified on the application namespace should be considered the 
 */
 
 export { default as Registry, privatize } from './registry';
-export { default as Container } from './container';
+export {
+  default as Container,
+  buildFakeContainerWithDeprecations
+} from './container';
 export { OWNER, getOwner, setOwner } from './owner';

--- a/packages/container/lib/owner.js
+++ b/packages/container/lib/owner.js
@@ -3,7 +3,7 @@
 @submodule ember-runtime
 */
 
-import symbol from 'ember-metal/symbol';
+import { symbol } from 'ember-metal';
 
 export const OWNER = symbol('OWNER');
 

--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -1,7 +1,11 @@
-import { assert, deprecate } from 'ember-metal/debug';
-import dictionary from 'ember-metal/dictionary';
-import EmptyObject from 'ember-metal/empty_object';
-import assign from 'ember-metal/assign';
+import {
+  assert,
+  deprecate,
+  dictionary,
+  EmptyObject,
+  assign,
+  intern,
+} from 'ember-metal';
 import Container from './container';
 
 const VALID_FULL_NAME_REGEXP = /^[^:]+:[^:]+$/;
@@ -864,10 +868,7 @@ function has(registry, fullName, source) {
   return registry.resolve(fullName, { source }) !== undefined;
 }
 
-import { intern } from 'ember-metal/utils';
-import dict from 'ember-metal/dictionary';
-
-const privateNames = dict(null);
+const privateNames = dictionary(null);
 const privateSuffix = `${Math.random()}${Date.now()}`;
 
 export function privatize([fullName]) {

--- a/packages/ember-metal/lib/descriptor.js
+++ b/packages/ember-metal/lib/descriptor.js
@@ -1,4 +1,4 @@
-import { Descriptor as EmberDescriptor } from 'ember-metal/properties';
+import { Descriptor as EmberDescriptor } from './properties';
 
 export default function descriptor(desc) {
   return new Descriptor(desc);

--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -95,7 +95,8 @@ export {
   propertyWillChange
 } from './property_events';
 export {
-  defineProperty
+  defineProperty,
+  Descriptor
 } from './properties';
 export {
   watchKey,

--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -28,6 +28,7 @@ export {
   unsubscribe as instrumentationUnsubscribe
 } from './instrumentation';
 export {
+  intern,
   GUID_KEY,
   apply,
   applyStr,
@@ -149,6 +150,9 @@ export {
 export {
   isGlobalPath
 } from './path_cache';
+export { default as symbol } from './symbol';
+export { default as dictionary } from './dictionary';
+export { default as EmptyObject } from './empty_object';
 
 
 // TODO: this needs to be deleted once we refactor the build tooling

--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -30,6 +30,7 @@ export {
 export {
   intern,
   GUID_KEY,
+  GUID_KEY_PROPERTY,
   apply,
   applyStr,
   canInvoke,
@@ -48,7 +49,8 @@ export {
 } from './testing';
 export {
   getOnerror,
-  setOnerror
+  setOnerror,
+  dispatchError
 } from './error_handler';
 export {
   META_DESC,
@@ -133,16 +135,23 @@ export {
   _suspendObservers,
   addObserver,
   observersFor,
-  removeObserver
+  removeObserver,
+  _addBeforeObserver,
+  _removeBeforeObserver
 } from './observer';
 export {
   NAME_KEY,
   Mixin,
   aliasMethod,
   _immediateObserver,
+  _beforeObserver,
   mixin,
   observer,
-  required
+  required,
+  REQUIRED,
+  hasUnprocessedMixins,
+  clearUnprocessedMixins,
+  detectBinding
 } from './mixin';
 export {
   Binding,
@@ -154,6 +163,9 @@ export {
 export { default as symbol } from './symbol';
 export { default as dictionary } from './dictionary';
 export { default as EmptyObject } from './empty_object';
+export { default as InjectedProperty } from './injected_property';
+export { tagFor, markObjectAsDirty } from './tags';
+export { default as replace } from './replace';
 
 
 // TODO: this needs to be deleted once we refactor the build tooling

--- a/packages/ember-runtime/lib/computed/computed_macros.js
+++ b/packages/ember-runtime/lib/computed/computed_macros.js
@@ -1,11 +1,14 @@
-import { assert, deprecate } from 'ember-metal/debug';
-import { get } from 'ember-metal/property_get';
-import { set } from 'ember-metal/property_set';
-import { computed } from 'ember-metal/computed';
-import isEmpty from 'ember-metal/is_empty';
-import isNone from 'ember-metal/is_none';
-import alias from 'ember-metal/alias';
-import expandProperties from 'ember-metal/expand_properties';
+import {
+  assert,
+  deprecate,
+  get,
+  set,
+  computed,
+  isEmpty,
+  isNone,
+  alias,
+  expandProperties
+} from 'ember-metal';
 
 /**
 @module ember

--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -3,19 +3,23 @@
 @submodule ember-runtime
 */
 
-import { assert } from 'ember-metal/debug';
-import { get } from 'ember-metal/property_get';
-import EmberError from 'ember-metal/error';
-import { ComputedProperty, computed } from 'ember-metal/computed';
-import { addObserver, removeObserver } from 'ember-metal/observer';
+import {
+  assert,
+  get,
+  Error as EmberError,
+  ComputedProperty,
+  computed,
+  addObserver,
+  removeObserver,
+  isNone,
+  getProperties,
+  EmptyObject,
+  guidFor,
+  WeakMap
+} from 'ember-metal';
 import compare from '../compare';
 import { isArray } from '../utils';
 import { A as emberA } from '../system/native_array';
-import isNone from 'ember-metal/is_none';
-import getProperties from 'ember-metal/get_properties';
-import EmptyObject from 'ember-metal/empty_object';
-import { guidFor } from 'ember-metal/utils';
-import WeakMap from 'ember-metal/weak_map';
 
 
 function reduceMacro(dependentKey, callback, initialValue) {

--- a/packages/ember-runtime/lib/controllers/controller.js
+++ b/packages/ember-runtime/lib/controllers/controller.js
@@ -1,4 +1,4 @@
-import { assert } from 'ember-metal/debug';
+import { assert } from 'ember-metal';
 import EmberObject from '../system/object';
 import Mixin from '../mixins/controller';
 import { createInjectionHelper } from '../inject';

--- a/packages/ember-runtime/lib/copy.js
+++ b/packages/ember-runtime/lib/copy.js
@@ -1,4 +1,4 @@
-import { assert } from 'ember-metal/debug';
+import { assert } from 'ember-metal';
 import EmberObject from './system/object';
 import Copyable from './mixins/copyable';
 

--- a/packages/ember-runtime/lib/ext/function.js
+++ b/packages/ember-runtime/lib/ext/function.js
@@ -4,9 +4,12 @@
 */
 
 import { ENV } from 'ember-environment';
-import { assert, deprecateFunc } from 'ember-metal/debug';
-import { computed } from 'ember-metal/computed';
-import { observer } from 'ember-metal/mixin';
+import {
+  assert,
+  deprecateFunc,
+  computed,
+  observer
+} from 'ember-metal';
 
 const a_slice = Array.prototype.slice;
 const FunctionPrototype = Function.prototype;

--- a/packages/ember-runtime/lib/ext/rsvp.js
+++ b/packages/ember-runtime/lib/ext/rsvp.js
@@ -1,7 +1,9 @@
 import * as RSVP from 'rsvp';
-import run from 'ember-metal/run_loop';
-import { assert } from 'ember-metal/debug';
-import { dispatchError } from 'ember-metal/error_handler';
+import {
+  run,
+  assert,
+  dispatchError
+} from 'ember-metal';
 
 const backburner = run.backburner;
 run._addQueue('rsvpAfter', 'destroy');

--- a/packages/ember-runtime/lib/index.js
+++ b/packages/ember-runtime/lib/index.js
@@ -6,7 +6,10 @@
 export { default as Object } from './system/object';
 export { default as String } from './system/string';
 export { default as RegistryProxyMixin } from './mixins/registry_proxy';
-export { default as ContainerProxyMixin } from './mixins/container_proxy';
+export {
+  default as ContainerProxyMixin,
+  buildFakeContainerWithDeprecations
+} from './mixins/container_proxy';
 export { default as copy } from './copy';
 export { default as inject } from './inject';
 export { default as compare } from './compare';

--- a/packages/ember-runtime/lib/index.js
+++ b/packages/ember-runtime/lib/index.js
@@ -7,8 +7,7 @@ export { default as Object } from './system/object';
 export { default as String } from './system/string';
 export { default as RegistryProxyMixin } from './mixins/registry_proxy';
 export {
-  default as ContainerProxyMixin,
-  buildFakeContainerWithDeprecations
+  default as ContainerProxyMixin
 } from './mixins/container_proxy';
 export { default as copy } from './copy';
 export { default as inject } from './inject';

--- a/packages/ember-runtime/lib/inject.js
+++ b/packages/ember-runtime/lib/inject.js
@@ -1,5 +1,7 @@
-import { assert } from 'ember-metal/debug';
-import InjectedProperty from 'ember-metal/injected_property';
+import {
+  assert,
+  InjectedProperty
+} from 'ember-metal';
 
 /**
   Namespace for injection helper methods.

--- a/packages/ember-runtime/lib/mixins/-proxy.js
+++ b/packages/ember-runtime/lib/mixins/-proxy.js
@@ -3,26 +3,26 @@
 @submodule ember-runtime
 */
 
-import { assert, deprecate } from 'ember-metal/debug';
-import { get } from 'ember-metal/property_get';
-import { set } from 'ember-metal/property_set';
-import { meta } from 'ember-metal/meta';
 import {
+  assert,
+  deprecate,
+  get,
+  set,
+  meta,
   addObserver,
   removeObserver,
   _addBeforeObserver,
-  _removeBeforeObserver
-} from 'ember-metal/observer';
-import {
+  _removeBeforeObserver,
   propertyWillChange,
-  propertyDidChange
-} from 'ember-metal/property_events';
+  propertyDidChange,
+  defineProperty,
+  Mixin,
+  observer,
+  tagFor,
+  symbol
+} from 'ember-metal';
 import { bool } from '../computed/computed_macros';
 import { POST_INIT } from '../system/core_object';
-import { defineProperty } from 'ember-metal/properties';
-import { Mixin, observer } from 'ember-metal/mixin';
-import { tagFor } from 'ember-metal/tags';
-import symbol from 'ember-metal/symbol';
 import require, { has } from 'require';
 
 const hasGlimmer = has('glimmer-reference');

--- a/packages/ember-runtime/lib/mixins/action_handler.js
+++ b/packages/ember-runtime/lib/mixins/action_handler.js
@@ -3,9 +3,12 @@
 @submodule ember-runtime
 */
 
-import { assert, deprecate } from 'ember-metal/debug';
-import { Mixin } from 'ember-metal/mixin';
-import { get } from 'ember-metal/property_get';
+import {
+  assert,
+  deprecate,
+  Mixin,
+  get
+} from 'ember-metal';
 
 /**
   `Ember.ActionHandler` is available on some familiar classes including

--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -6,32 +6,27 @@
 // ..........................................................
 // HELPERS
 //
-import Ember from 'ember-metal/core'; // ES6TODO: Ember.A
-
-import symbol from 'ember-metal/symbol';
-import { get } from 'ember-metal/property_get';
-import {
+import Ember, { // ES6TODO: Ember.A
+  symbol,
+  get,
   computed,
-  cacheFor
-} from 'ember-metal/computed';
-import isNone from 'ember-metal/is_none';
-import Enumerable from './enumerable';
-import { Mixin } from 'ember-metal/mixin';
-import {
+  cacheFor,
+  isNone,
+  Mixin,
   propertyWillChange,
-  propertyDidChange
-} from 'ember-metal/property_events';
-import {
+  propertyDidChange,
   addListener,
   removeListener,
   sendEvent,
-  hasListeners
-} from 'ember-metal/events';
-import { meta as metaFor } from 'ember-metal/meta';
-import { markObjectAsDirty } from 'ember-metal/tags';
+  hasListeners,
+  meta as metaFor,
+  markObjectAsDirty,
+  deprecate,
+  isFeatureEnabled
+} from 'ember-metal';
+
+import Enumerable from './enumerable';
 import EachProxy from '../system/each_proxy';
-import { deprecate } from 'ember-metal/debug';
-import isEnabled from 'ember-metal/features';
 
 function arrayObserversHelper(obj, target, opts, operation, notify) {
   let willChange = (opts && opts.willChange) || 'arrayWillChange';
@@ -309,7 +304,7 @@ const ArrayMixin = Mixin.create(Enumerable, {
 
   // optimized version from Enumerable
   contains(obj) {
-    if (isEnabled('ember-runtime-enumerable-includes')) {
+    if (isFeatureEnabled('ember-runtime-enumerable-includes')) {
       deprecate(
         '`Enumerable#contains` is deprecated, use `Enumerable#includes` instead.',
         false,
@@ -588,7 +583,7 @@ const ArrayMixin = Mixin.create(Enumerable, {
   }).volatile()
 });
 
-if (isEnabled('ember-runtime-enumerable-includes')) {
+if (isFeatureEnabled('ember-runtime-enumerable-includes')) {
   ArrayMixin.reopen({
     /**
       Returns `true` if the passed object can be found in the array.

--- a/packages/ember-runtime/lib/mixins/comparable.js
+++ b/packages/ember-runtime/lib/mixins/comparable.js
@@ -1,4 +1,4 @@
-import { Mixin } from 'ember-metal/mixin';
+import { Mixin } from 'ember-metal';
 
 /**
 @module ember

--- a/packages/ember-runtime/lib/mixins/container_proxy.js
+++ b/packages/ember-runtime/lib/mixins/container_proxy.js
@@ -2,9 +2,11 @@
 @module ember
 @submodule ember-runtime
 */
-import run from 'ember-metal/run_loop';
-import { deprecate } from 'ember-metal/debug';
-import { Mixin } from 'ember-metal/mixin';
+import {
+  deprecate,
+  Mixin,
+  run
+} from 'ember-metal';
 
 
 /**

--- a/packages/ember-runtime/lib/mixins/container_proxy.js
+++ b/packages/ember-runtime/lib/mixins/container_proxy.js
@@ -3,11 +3,9 @@
 @submodule ember-runtime
 */
 import {
-  deprecate,
   Mixin,
   run
 } from 'ember-metal';
-
 
 /**
   ContainerProxyMixin is used to provide public access to specific
@@ -134,32 +132,3 @@ export default Mixin.create({
     }
   }
 });
-
-export function buildFakeContainerWithDeprecations(container) {
-  let fakeContainer = {};
-  let propertyMappings = {
-    lookup: 'lookup',
-    lookupFactory: '_lookupFactory'
-  };
-
-  for (let containerProperty in propertyMappings) {
-    fakeContainer[containerProperty] = buildFakeContainerFunction(container, containerProperty, propertyMappings[containerProperty]);
-  }
-
-  return fakeContainer;
-}
-
-function buildFakeContainerFunction(container, containerProperty, ownerProperty) {
-  return function() {
-    deprecate(
-      `Using the injected \`container\` is deprecated. Please use the \`getOwner\` helper to access the owner of this object and then call \`${ownerProperty}\` instead.`,
-      false,
-      {
-        id: 'ember-application.injected-container',
-        until: '3.0.0',
-        url: 'http://emberjs.com/deprecations/v2.x#toc_injected-container-access'
-      }
-    );
-    return container[containerProperty](...arguments);
-  };
-}

--- a/packages/ember-runtime/lib/mixins/controller.js
+++ b/packages/ember-runtime/lib/mixins/controller.js
@@ -1,5 +1,4 @@
-import { Mixin } from 'ember-metal/mixin';
-import alias from 'ember-metal/alias';
+import { Mixin, alias } from 'ember-metal';
 import ActionHandler from './action_handler';
 import ControllerContentModelAliasDeprecation from './controller_content_model_alias_deprecation';
 

--- a/packages/ember-runtime/lib/mixins/controller_content_model_alias_deprecation.js
+++ b/packages/ember-runtime/lib/mixins/controller_content_model_alias_deprecation.js
@@ -1,5 +1,7 @@
-import { deprecate } from 'ember-metal/debug';
-import { Mixin } from 'ember-metal/mixin';
+import {
+  deprecate,
+  Mixin
+} from 'ember-metal';
 
 /*
   The ControllerContentModelAliasDeprecation mixin is used to provide a useful

--- a/packages/ember-runtime/lib/mixins/copyable.js
+++ b/packages/ember-runtime/lib/mixins/copyable.js
@@ -3,11 +3,13 @@
 @submodule ember-runtime
 */
 
-import { deprecate } from 'ember-metal/debug';
-import { get } from 'ember-metal/property_get';
-import { Mixin } from 'ember-metal/mixin';
+import {
+  deprecate,
+  get,
+  Mixin,
+  Error as EmberError
+} from 'ember-metal';
 import { Freezable } from './freezable';
-import EmberError from 'ember-metal/error';
 
 /**
   Implements some standard methods for copying an object. Add this mixin to

--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -7,29 +7,26 @@
 // HELPERS
 //
 
-import { get } from 'ember-metal/property_get';
-import { set } from 'ember-metal/property_set';
 import {
+  get,
+  set,
   Mixin,
-  aliasMethod
-} from 'ember-metal/mixin';
-import { guidFor } from 'ember-metal/utils';
-import { computed } from 'ember-metal/computed';
-import EmptyObject from 'ember-metal/empty_object';
-import isEnabled from 'ember-metal/features';
-import {
+  aliasMethod,
+  guidFor,
+  computed,
+  EmptyObject,
+  isFeatureEnabled,
   propertyWillChange,
-  propertyDidChange
-} from 'ember-metal/property_events';
-import {
+  propertyDidChange,
   addListener,
   removeListener,
   sendEvent,
-  hasListeners
-} from 'ember-metal/events';
+  hasListeners,
+  assert,
+  deprecate
+} from 'ember-metal';
 import compare from '../compare';
 import require from 'require';
-import { assert, deprecate } from 'ember-metal/debug';
 
 let _emberA;
 
@@ -233,7 +230,7 @@ const Enumerable = Mixin.create({
     @public
   */
   contains(obj) {
-    if (isEnabled('ember-runtime-enumerable-includes')) {
+    if (isFeatureEnabled('ember-runtime-enumerable-includes')) {
       deprecate(
         '`Enumerable#contains` is deprecated, use `Enumerable#includes` instead.',
         false,
@@ -1077,7 +1074,7 @@ const Enumerable = Mixin.create({
 });
 
 
-if (isEnabled('ember-runtime-computed-uniq-by')) {
+if (isFeatureEnabled('ember-runtime-computed-uniq-by')) {
   Enumerable.reopen({
     /**
       Returns a new enumerable that contains only items containing a unique property value.
@@ -1110,7 +1107,7 @@ if (isEnabled('ember-runtime-computed-uniq-by')) {
   });
 }
 
-if (isEnabled('ember-runtime-enumerable-includes')) {
+if (isFeatureEnabled('ember-runtime-enumerable-includes')) {
   Enumerable.reopen({
     /**
       Returns `true` if the passed object can be found in the enumerable.

--- a/packages/ember-runtime/lib/mixins/evented.js
+++ b/packages/ember-runtime/lib/mixins/evented.js
@@ -1,10 +1,10 @@
-import { Mixin } from 'ember-metal/mixin';
 import {
+  Mixin,
   addListener,
   removeListener,
   hasListeners,
   sendEvent
-} from 'ember-metal/events';
+} from 'ember-metal';
 
 /**
 @module ember

--- a/packages/ember-runtime/lib/mixins/freezable.js
+++ b/packages/ember-runtime/lib/mixins/freezable.js
@@ -3,10 +3,12 @@
 @submodule ember-runtime
 */
 
-import { deprecate } from 'ember-metal/debug';
-import { Mixin } from 'ember-metal/mixin';
-import { get } from 'ember-metal/property_get';
-import { set } from 'ember-metal/property_set';
+import {
+  deprecate,
+  Mixin,
+  get,
+  set
+} from 'ember-metal';
 
 /**
   The `Ember.Freezable` mixin implements some basic methods for marking an

--- a/packages/ember-runtime/lib/mixins/mutable_array.js
+++ b/packages/ember-runtime/lib/mixins/mutable_array.js
@@ -11,13 +11,15 @@ const EMPTY = [];
 // HELPERS
 //
 
-import { get } from 'ember-metal/property_get';
-import EmberError from 'ember-metal/error';
-import { Mixin } from 'ember-metal/mixin';
+import {
+  get,
+  Error as EmberError,
+  Mixin,
+  isFeatureEnabled
+} from 'ember-metal';
 import EmberArray, { objectAt } from './array';
 import MutableEnumerable from './mutable_enumerable';
 import Enumerable from './enumerable';
-import isEnabled from 'ember-metal/features';
 
 export function removeAt(array, start, len) {
   if ('number' === typeof start) {
@@ -388,7 +390,7 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
   addObject(obj) {
     let included;
 
-    if (isEnabled('ember-runtime-enumerable-includes')) {
+    if (isFeatureEnabled('ember-runtime-enumerable-includes')) {
       included = this.includes(obj);
     } else {
       included = this.contains(obj);

--- a/packages/ember-runtime/lib/mixins/mutable_enumerable.js
+++ b/packages/ember-runtime/lib/mixins/mutable_enumerable.js
@@ -1,6 +1,9 @@
 import Enumerable from './enumerable';
-import { Mixin } from 'ember-metal/mixin';
-import {beginPropertyChanges, endPropertyChanges} from 'ember-metal/property_events';
+import {
+  Mixin,
+  beginPropertyChanges,
+  endPropertyChanges
+} from 'ember-metal';
 
 /**
 @module ember

--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -3,29 +3,25 @@
 @submodule ember-runtime
 */
 
-import { assert } from 'ember-metal/debug';
 import {
+  assert,
   get,
-  getWithDefault
-} from 'ember-metal/property_get';
-import { set } from 'ember-metal/property_set';
-import getProperties from 'ember-metal/get_properties';
-import setProperties from 'ember-metal/set_properties';
-import { Mixin } from 'ember-metal/mixin';
-import { hasListeners } from 'ember-metal/events';
-import {
+  getWithDefault,
+  set,
+  getProperties,
+  setProperties,
+  Mixin,
+  hasListeners,
   beginPropertyChanges,
   propertyWillChange,
   propertyDidChange,
-  endPropertyChanges
-} from 'ember-metal/property_events';
-import {
+  endPropertyChanges,
   addObserver,
   removeObserver,
-  observersFor
-} from 'ember-metal/observer';
-import { cacheFor } from 'ember-metal/computed';
-import isNone from 'ember-metal/is_none';
+  observersFor,
+  cacheFor,
+  isNone
+} from 'ember-metal';
 
 /**
   ## Overview

--- a/packages/ember-runtime/lib/mixins/promise_proxy.js
+++ b/packages/ember-runtime/lib/mixins/promise_proxy.js
@@ -1,9 +1,11 @@
-import { get } from 'ember-metal/property_get';
-import setProperties from 'ember-metal/set_properties';
-import { computed } from 'ember-metal/computed';
+import {
+  get,
+  setProperties,
+  computed,
+  Mixin,
+  Error as EmberError
+} from 'ember-metal';
 import { not, or } from '../computed/computed_macros';
-import { Mixin } from 'ember-metal/mixin';
-import EmberError from 'ember-metal/error';
 
 /**
   @module ember

--- a/packages/ember-runtime/lib/mixins/registry_proxy.js
+++ b/packages/ember-runtime/lib/mixins/registry_proxy.js
@@ -3,8 +3,10 @@
 @submodule ember-runtime
 */
 
-import { deprecate } from 'ember-metal/debug';
-import { Mixin } from 'ember-metal/mixin';
+import {
+  deprecate,
+  Mixin
+} from 'ember-metal';
 
 /**
   RegistryProxyMixin is used to provide public access to specific

--- a/packages/ember-runtime/lib/mixins/target_action_support.js
+++ b/packages/ember-runtime/lib/mixins/target_action_support.js
@@ -4,10 +4,12 @@
 */
 
 import { context } from 'ember-environment';
-import { assert } from 'ember-metal/debug';
-import { get } from 'ember-metal/property_get';
-import { Mixin } from 'ember-metal/mixin';
-import { computed } from 'ember-metal/computed';
+import {
+  assert,
+  get,
+  Mixin,
+  computed
+} from 'ember-metal';
 
 /**
 `Ember.TargetActionSupport` is a mixin that can be included in a class

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -1,22 +1,20 @@
-import { assert } from 'ember-metal/debug';
-import { get } from 'ember-metal/property_get';
+import {
+  assert,
+  get,
+  computed,
+  _beforeObserver,
+  observer,
+  beginPropertyChanges,
+  endPropertyChanges,
+  Error as EmberError,
+  alias
+} from 'ember-metal';
 import {
   isArray
 } from '../utils';
-import { computed } from 'ember-metal/computed';
-import {
-  _beforeObserver,
-  observer
-} from 'ember-metal/mixin';
-import {
-  beginPropertyChanges,
-  endPropertyChanges
-} from 'ember-metal/property_events';
-import EmberError from 'ember-metal/error';
 import EmberObject from './object';
 import MutableArray from '../mixins/mutable_array';
 import Enumerable from '../mixins/enumerable';
-import alias from 'ember-metal/alias';
 import {
   addArrayObserver,
   removeArrayObserver,

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -9,39 +9,34 @@
 
 // using ember-metal/lib/main here to ensure that ember-debug is setup
 // if present
-import { assert, runInDebug } from 'ember-metal/debug';
-import isEnabled from 'ember-metal/features';
-import assign from 'ember-metal/assign';
-
-// NOTE: this object should never be included directly. Instead use `Ember.Object`.
-// We only define this separately so that `Ember.Set` can depend on it.
-import { get } from 'ember-metal/property_get';
 import {
-  guidFor
-} from 'ember-metal/utils';
-import {
+  assert,
+  runInDebug,
+  isFeatureEnabled,
+  assign,
+  get,
+  guidFor,
   generateGuid,
   GUID_KEY_PROPERTY,
-  makeArray
-} from 'ember-metal/utils';
-import { meta } from 'ember-metal/meta';
-import { finishChains } from 'ember-metal/chains';
-import { sendEvent } from 'ember-metal/events';
-import {
+  makeArray,
+  meta,
+  finishChains,
+  sendEvent,
   detectBinding,
   Mixin,
-  REQUIRED
-} from 'ember-metal/mixin';
-import EmberError from 'ember-metal/error';
+  REQUIRED,
+  Error as EmberError,
+  defineProperty,
+  Binding,
+  ComputedProperty,
+  computed,
+  InjectedProperty,
+  run,
+  destroy,
+  symbol
+} from 'ember-metal';
 import ActionHandler from '../mixins/action_handler';
-import { defineProperty } from 'ember-metal/properties';
-import { Binding } from 'ember-metal/binding';
-import { ComputedProperty, computed } from 'ember-metal/computed';
-import InjectedProperty from 'ember-metal/injected_property';
-import run from 'ember-metal/run_loop';
-import { destroy } from 'ember-metal/watching';
 import { validatePropertyInjections } from '../inject';
-import symbol from 'ember-metal/symbol';
 
 export let POST_INIT = symbol('POST_INIT');
 var schedule = run.schedule;
@@ -153,7 +148,7 @@ function makeCtor() {
             if (typeof this.setUnknownProperty === 'function' && !(keyName in this)) {
               this.setUnknownProperty(keyName, value);
             } else {
-              if (isEnabled('mandatory-setter')) {
+              if (isFeatureEnabled('mandatory-setter')) {
                 defineProperty(this, keyName, null, value); // setup mandatory setter
               } else {
                 this[keyName] = value;

--- a/packages/ember-runtime/lib/system/each_proxy.js
+++ b/packages/ember-runtime/lib/system/each_proxy.js
@@ -1,16 +1,14 @@
-import { assert } from 'ember-metal/debug';
-import { get } from 'ember-metal/property_get';
 import {
+  assert,
+  get,
   _addBeforeObserver,
   _removeBeforeObserver,
   addObserver,
-  removeObserver
-} from 'ember-metal/observer';
-import {
+  removeObserver,
   propertyDidChange,
-  propertyWillChange
-} from 'ember-metal/property_events';
-import EmptyObject from 'ember-metal/empty_object';
+  propertyWillChange,
+  EmptyObject
+} from 'ember-metal';
 import { objectAt } from '../mixins/array';
 
 /**

--- a/packages/ember-runtime/lib/system/namespace.js
+++ b/packages/ember-runtime/lib/system/namespace.js
@@ -2,18 +2,15 @@
 @module ember
 @submodule ember-runtime
 */
-import Ember from 'ember-metal/core'; // Preloaded into namespaces
-import { context } from 'ember-environment';
-import { get } from 'ember-metal/property_get';
-import {
-  guidFor
-} from 'ember-metal/utils';
-import {
+import Ember, {
+  get,
+  guidFor,
   Mixin,
   hasUnprocessedMixins,
   clearUnprocessedMixins,
   NAME_KEY
-} from 'ember-metal/mixin';
+} from 'ember-metal'; // Preloaded into namespaces
+import { context } from 'ember-environment';
 
 import EmberObject from './object';
 

--- a/packages/ember-runtime/lib/system/native_array.js
+++ b/packages/ember-runtime/lib/system/native_array.js
@@ -2,11 +2,12 @@
 @module ember
 @submodule ember-runtime
 */
-import Ember from 'ember-metal/core'; // Ember.A circular
+import Ember, { // Ember.A circular
+  replace,
+  get,
+  Mixin
+} from 'ember-metal';
 import { ENV } from 'ember-environment';
-import replace from 'ember-metal/replace';
-import { get } from 'ember-metal/property_get';
-import { Mixin } from 'ember-metal/mixin';
 import EmberArray, {
   arrayContentDidChange,
   arrayContentWillChange

--- a/packages/ember-runtime/lib/system/string.js
+++ b/packages/ember-runtime/lib/system/string.js
@@ -2,16 +2,15 @@
 @module ember
 @submodule ember-runtime
 */
-import { deprecate } from 'ember-metal/debug';
 import {
-  inspect as emberInspect
-} from 'ember-metal/utils';
+  deprecate,
+  inspect as emberInspect,
+  Cache
+} from 'ember-metal';
 import { isArray } from '../utils';
 import {
   get as getString
 } from '../string_registry';
-
-import Cache from 'ember-metal/cache';
 
 const STRING_DASHERIZE_REGEXP = (/[ _]/g);
 

--- a/packages/ember-template-compiler/lib/index.js
+++ b/packages/ember-template-compiler/lib/index.js
@@ -1,3 +1,5 @@
+import 'container';
+
 export { default as _Ember } from 'ember-metal'; // Is this still needed
 export { default as precompile } from 'ember-template-compiler/system/precompile';
 export { default as compile } from 'ember-template-compiler/system/compile';

--- a/packages/ember/lib/index.js
+++ b/packages/ember/lib/index.js
@@ -4,6 +4,12 @@ import isEnabled from 'ember-metal/features';
 // ****ember-environment****
 import { ENV, context } from 'ember-environment';
 
+import {
+  Registry,
+  Container,
+  getOwner,
+  setOwner
+} from 'container';
 
 // ****ember-metal****
 import Ember, * as metal from 'ember-metal';
@@ -244,12 +250,6 @@ Ember.Backburner = function() {
 
 Ember._Backburner = Backburner;
 
-import {
-  Registry,
-  Container,
-  getOwner,
-  setOwner
-} from 'container';
 
 Ember.Container = Container;
 Ember.Registry = Registry;


### PR DESCRIPTION
All external package imports for the following packages are updated:
- ember-runtime
- ember-metal
- container
