### PR TITLE
Update more packages to use entry points for imports.

### DIFF
--- a/packages/ember-glimmer/lib/component.js
+++ b/packages/ember-glimmer/lib/component.js
@@ -1,19 +1,24 @@
-import CoreView from 'ember-views/views/core_view';
-import ClassNamesSupport from 'ember-views/mixins/class_names_support';
-import ChildViewsSupport from 'ember-views/mixins/child_views_support';
-import ViewStateSupport from 'ember-views/mixins/view_state_support';
-import ViewMixin from 'ember-views/mixins/view_support';
-import ActionSupport from 'ember-views/mixins/action_support';
-import TargetActionSupport from 'ember-runtime/mixins/target_action_support';
-import symbol from 'ember-metal/symbol';
-import { get } from 'ember-metal/property_get';
-import { PROPERTY_DID_CHANGE } from 'ember-metal/property_events';
-import { getAttrFor } from 'ember-views/compat/attrs-proxy';
+import {
+  CoreView,
+  ClassNamesSupport,
+  ChildViewsSupport,
+  ViewStateSupport,
+  ViewMixin,
+  ActionSupport,
+  getAttrFor
+} from 'ember-views';
+import { TargetActionSupport } from 'ember-runtime';
+import {
+  symbol,
+  get,
+  PROPERTY_DID_CHANGE,
+  assert,
+  deprecate,
+  NAME_KEY
+} from 'ember-metal';
 import { UPDATE, RootReference } from './utils/references';
 import { DirtyableTag } from 'glimmer-reference';
 import { readDOMAttr } from 'glimmer-runtime';
-import { assert, deprecate } from 'ember-metal/debug';
-import { NAME_KEY } from 'ember-metal/mixin';
 import { getOwner } from 'container';
 
 export const DIRTY_TAG = symbol('DIRTY_TAG');
@@ -22,7 +27,6 @@ export const ROOT_REF = symbol('ROOT_REF');
 export const IS_DISPATCHING_ATTRS = symbol('IS_DISPATCHING_ATTRS');
 export const HAS_BLOCK = symbol('HAS_BLOCK');
 export const BOUNDS = symbol('BOUNDS');
-
 
 /**
 @module ember

--- a/packages/ember-glimmer/lib/components/checkbox.js
+++ b/packages/ember-glimmer/lib/components/checkbox.js
@@ -1,5 +1,4 @@
-import { get } from 'ember-metal/property_get';
-import { set } from 'ember-metal/property_set';
+import { get, set } from 'ember-metal';
 import EmberComponent from '../component';
 import layout from '../templates/empty';
 

--- a/packages/ember-glimmer/lib/components/link-to.js
+++ b/packages/ember-glimmer/lib/components/link-to.js
@@ -313,17 +313,21 @@
 
 import Logger from 'ember-console';
 
-import { assert, deprecate } from 'ember-metal/debug';
-import { get } from 'ember-metal/property_get';
-import { computed } from 'ember-metal/computed';
-import { deprecatingAlias } from 'ember-runtime/computed/computed_macros';
-import { isSimpleClick } from 'ember-views/system/utils';
-import inject from 'ember-runtime/inject';
-import 'ember-runtime/system/service'; // creates inject.service
-import ControllerMixin from 'ember-runtime/mixins/controller';
+import {
+  assert,
+  deprecate,
+  get,
+  computed,
+  flaggedInstrument
+} from 'ember-metal';
+import {
+  deprecatingAlias,
+  inject,
+  ControllerMixin
+} from 'ember-runtime';
+import { isSimpleClick } from 'ember-views';
 import layout from '../templates/link-to';
 import EmberComponent, { HAS_BLOCK } from '../component';
-import { flaggedInstrument } from 'ember-metal/instrumentation';
 
 
 /**

--- a/packages/ember-glimmer/lib/components/text_area.js
+++ b/packages/ember-glimmer/lib/components/text_area.js
@@ -3,7 +3,7 @@
 @submodule ember-views
 */
 import Component from '../component';
-import TextSupport from 'ember-views/mixins/text_support';
+import { TextSupport } from 'ember-views';
 import layout from '../templates/empty';
 
 /**

--- a/packages/ember-glimmer/lib/components/text_field.js
+++ b/packages/ember-glimmer/lib/components/text_field.js
@@ -2,12 +2,11 @@
 @module ember
 @submodule ember-views
 */
-import { computed } from 'ember-metal/computed';
+import { computed, EmptyObject } from 'ember-metal';
 import { environment } from 'ember-environment';
 import Component from '../component';
 import layout from '../templates/empty';
-import TextSupport from 'ember-views/mixins/text_support';
-import EmptyObject from 'ember-metal/empty_object';
+import { TextSupport } from 'ember-views';
 
 let inputTypeTestElement;
 const inputTypes = new EmptyObject();

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -1,5 +1,16 @@
-import { guidFor } from 'ember-metal/utils';
-import lookupPartial, { hasPartial } from 'ember-views/system/lookup_partial';
+import {
+  guidFor,
+  Cache,
+  assert,
+  warn,
+  runInDebug
+} from 'ember-metal';
+import {
+  lookupPartial,
+  hasPartial,
+  lookupComponent,
+  STYLE_WARNING
+} from 'ember-views';
 import {
   Environment as GlimmerEnvironment,
   AttributeChangeList,
@@ -7,13 +18,9 @@ import {
   compileLayout,
   getDynamicVar
 } from 'glimmer-runtime';
-import Cache from 'ember-metal/cache';
-import { assert, warn, runInDebug } from 'ember-metal/debug';
 import { CurlyComponentSyntax, CurlyComponentDefinition } from './syntax/curly-component';
 import { findSyntaxBuilder } from './syntax';
 import { DynamicComponentSyntax } from './syntax/dynamic-component';
-import lookupComponent from 'ember-views/utils/lookup-component';
-import { STYLE_WARNING } from 'ember-views/system/utils';
 import createIterable from './utils/iterable';
 import {
   ConditionalReference,

--- a/packages/ember-glimmer/lib/helper.js
+++ b/packages/ember-glimmer/lib/helper.js
@@ -3,9 +3,11 @@
 @submodule ember-templates
 */
 
-import symbol from 'ember-metal/symbol';
-import EmberObject from 'ember-runtime/system/object';
-import { POST_INIT } from 'ember-runtime/system/core_object';
+import { symbol } from 'ember-metal';
+import {
+  Object as EmberObject,
+  POST_INIT
+} from 'ember-runtime';
 import { DirtyableTag } from 'glimmer-reference';
 
 export const RECOMPUTE_TAG = symbol('RECOMPUTE_TAG');

--- a/packages/ember-glimmer/lib/helpers/-class.js
+++ b/packages/ember-glimmer/lib/helpers/-class.js
@@ -1,5 +1,5 @@
 import { InternalHelperReference } from '../utils/references';
-import { dasherize } from 'ember-runtime/system/string';
+import { String as StringUtils } from 'ember-runtime';
 
 function classHelper({ positional }) {
   let path = positional.at(0);
@@ -8,14 +8,14 @@ function classHelper({ positional }) {
 
   if (value === true) {
     if (args > 1) {
-      return dasherize(positional.at(1).value());
+      return StringUtils.dasherize(positional.at(1).value());
     }
     return null;
   }
 
   if (value === false) {
     if (args > 2) {
-      return dasherize(positional.at(2).value());
+      return StringUtils.dasherize(positional.at(2).value());
     }
     return null;
   }

--- a/packages/ember-glimmer/lib/helpers/-normalize-class.js
+++ b/packages/ember-glimmer/lib/helpers/-normalize-class.js
@@ -1,5 +1,5 @@
 import { InternalHelperReference } from '../utils/references';
-import { dasherize } from 'ember-runtime/system/string';
+import { String as StringUtils } from 'ember-runtime';
 
 function normalizeClass({ positional, named }) {
   let classNameParts = positional.at(0).value().split('.');
@@ -7,7 +7,7 @@ function normalizeClass({ positional, named }) {
   let value = positional.at(1).value();
 
   if (value === true) {
-    return dasherize(className);
+    return StringUtils.dasherize(className);
   } else if (!value && value !== 0) {
     return '';
   } else {

--- a/packages/ember-glimmer/lib/helpers/action.js
+++ b/packages/ember-glimmer/lib/helpers/action.js
@@ -1,10 +1,12 @@
 import { CachedReference } from '../utils/references';
-import EmberError from 'ember-metal/error';
-import symbol from 'ember-metal/symbol';
-import run from 'ember-metal/run_loop';
-import { get } from 'ember-metal/property_get';
-import { flaggedInstrument } from 'ember-metal/instrumentation';
-import isNone from 'ember-metal/is_none';
+import {
+  Error as EmberError,
+  symbol,
+  run,
+  get,
+  flaggedInstrument,
+  isNone
+} from 'ember-metal';
 
 export const INVOKE = symbol('INVOKE');
 

--- a/packages/ember-glimmer/lib/helpers/component.js
+++ b/packages/ember-glimmer/lib/helpers/component.js
@@ -1,8 +1,7 @@
 import { CachedReference } from '../utils/references';
 import { CurlyComponentDefinition, validatePositionalParameters } from '../syntax/curly-component';
 import { EvaluatedArgs, EvaluatedNamedArgs, EvaluatedPositionalArgs, isComponentDefinition } from 'glimmer-runtime';
-import { assert } from 'ember-metal/debug';
-import assign from 'ember-metal/assign';
+import { assert, assign } from 'ember-metal';
 
 export class ClosureComponentReference extends CachedReference {
   static create(args, symbolTable, env) {

--- a/packages/ember-glimmer/lib/helpers/each-in.js
+++ b/packages/ember-glimmer/lib/helpers/each-in.js
@@ -3,7 +3,7 @@
 @submodule ember-templates
 */
 
-import symbol from 'ember-metal/symbol';
+import { symbol } from 'ember-metal';
 
 /**
   The `{{each-in}}` helper loops over properties on an object.

--- a/packages/ember-glimmer/lib/helpers/get.js
+++ b/packages/ember-glimmer/lib/helpers/get.js
@@ -1,4 +1,4 @@
-import { set } from 'ember-metal/property_set';
+import { set } from 'ember-metal';
 import { CachedReference, UPDATE } from '../utils/references';
 import { CONSTANT_TAG, UpdatableTag, combine, isConst, referenceFromParts } from 'glimmer-reference';
 

--- a/packages/ember-glimmer/lib/helpers/if-unless.js
+++ b/packages/ember-glimmer/lib/helpers/if-unless.js
@@ -3,7 +3,7 @@
 @submodule ember-templates
 */
 
-import { assert } from 'ember-metal/debug';
+import { assert } from 'ember-metal';
 import { UNDEFINED_REFERENCE, CachedReference, ConditionalReference } from '../utils/references';
 import { CONSTANT_TAG, UpdatableTag, combine, isConst } from 'glimmer-reference';
 

--- a/packages/ember-glimmer/lib/helpers/loc.js
+++ b/packages/ember-glimmer/lib/helpers/loc.js
@@ -1,5 +1,5 @@
 import { helper } from '../helper';
-import { loc } from 'ember-runtime/system/string';
+import { String as StringUtils } from 'ember-runtime';
 
 /**
 @module ember
@@ -39,7 +39,7 @@ import { loc } from 'ember-runtime/system/string';
   @public
 */
 function locHelper(params) {
-  return loc.apply(null, params);
+  return StringUtils.loc.apply(null, params);
 }
 
 export default helper(locHelper);

--- a/packages/ember-glimmer/lib/helpers/mut.js
+++ b/packages/ember-glimmer/lib/helpers/mut.js
@@ -1,5 +1,4 @@
-import symbol from 'ember-metal/symbol';
-import { assert } from 'ember-metal/debug';
+import { symbol, assert } from 'ember-metal';
 import { UPDATE } from '../utils/references';
 import { INVOKE } from './action';
 

--- a/packages/ember-glimmer/lib/helpers/query-param.js
+++ b/packages/ember-glimmer/lib/helpers/query-param.js
@@ -1,7 +1,6 @@
 import { InternalHelperReference } from '../utils/references';
-import { assert } from 'ember-metal/debug';
-import QueryParams from 'ember-routing/system/query_params';
-import assign from 'ember-metal/assign';
+import { assert, assign } from 'ember-metal';
+import { QueryParams } from 'ember-routing';
 
 function queryParams({ positional, named }) {
   assert('The `query-params` helper only accepts hash parameters, e.g. (query-params queryParamPropertyName=\'foo\') as opposed to just (query-params \'foo\')', positional.value().length === 0);

--- a/packages/ember-glimmer/lib/helpers/unbound.js
+++ b/packages/ember-glimmer/lib/helpers/unbound.js
@@ -3,7 +3,7 @@
 @submodule ember-templates
 */
 
-import { assert } from 'ember-metal/debug';
+import { assert } from 'ember-metal';
 import { UnboundReference } from '../utils/references';
 
 /**

--- a/packages/ember-glimmer/lib/make-bound-helper.js
+++ b/packages/ember-glimmer/lib/make-bound-helper.js
@@ -2,7 +2,7 @@
 @module ember
 @submodule ember-templates
 */
-import { deprecate } from 'ember-metal/debug';
+import { deprecate } from 'ember-metal';
 import { helper } from './helper';
 
 /**

--- a/packages/ember-glimmer/lib/modifiers/action.js
+++ b/packages/ember-glimmer/lib/modifiers/action.js
@@ -1,9 +1,13 @@
-import { assert } from 'ember-metal/debug';
-import run from 'ember-metal/run_loop';
-import { uuid } from 'ember-metal/utils';
-import { isSimpleClick } from 'ember-views/system/utils';
-import ActionManager from 'ember-views/system/action_manager';
-import { flaggedInstrument } from 'ember-metal/instrumentation';
+import {
+  assert,
+  run,
+  uuid,
+  flaggedInstrument
+} from 'ember-metal';
+import {
+  isSimpleClick,
+  ActionManager
+} from 'ember-views';
 import { INVOKE } from '../helpers/action';
 
 const MODIFIERS = ['alt', 'shift', 'meta', 'ctrl'];

--- a/packages/ember-glimmer/lib/renderer.js
+++ b/packages/ember-glimmer/lib/renderer.js
@@ -1,19 +1,23 @@
 import { RootReference } from './utils/references';
-import run from 'ember-metal/run_loop';
-import { setHasViews } from 'ember-metal/tags';
+import {
+  run,
+  setHasViews,
+  assert,
+  runInTransaction as _runInTransaction,
+  isFeatureEnabled
+} from 'ember-metal';
 import { CURRENT_TAG, UNDEFINED_REFERENCE } from 'glimmer-reference';
-import fallbackViewRegistry from 'ember-views/compat/fallback-view-registry';
-import { assert } from 'ember-metal/debug';
-import _runInTransaction from 'ember-metal/transaction';
-import isEnabled from 'ember-metal/features';
+import {
+  fallbackViewRegistry,
+  getViewId
+} from 'ember-views';
 import { BOUNDS } from './component';
 import { RootComponentDefinition } from './syntax/curly-component';
-import { getViewId } from 'ember-views/system/utils';
 
 let runInTransaction;
 
-if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
-    isEnabled('ember-glimmer-allow-backtracking-rerender')) {
+if (isFeatureEnabled('ember-glimmer-detect-backtracking-rerender') ||
+    isFeatureEnabled('ember-glimmer-allow-backtracking-rerender')) {
   runInTransaction = _runInTransaction;
 } else {
   runInTransaction = (context, methodName) => {

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -1,14 +1,25 @@
-import { StatementSyntax, ValueReference, EvaluatedArgs, EvaluatedNamedArgs, EvaluatedPositionalArgs } from 'glimmer-runtime';
+import {
+  StatementSyntax,
+  ValueReference,
+  EvaluatedArgs,
+  EvaluatedNamedArgs,
+  EvaluatedPositionalArgs,
+  ComponentDefinition
+} from 'glimmer-runtime';
 import { AttributeBinding, ClassNameBinding, IsVisibleBinding } from '../utils/bindings';
 import { ROOT_REF, DIRTY_TAG, IS_DISPATCHING_ATTRS, HAS_BLOCK, BOUNDS } from '../component';
-import { assert, runInDebug } from 'ember-metal/debug';
+import {
+  assert,
+  runInDebug,
+  assign,
+  get,
+  _instrumentStart
+} from 'ember-metal';
 import processArgs from '../utils/process-args';
-import { privatize as P } from 'container';
-import assign from 'ember-metal/assign';
-import get from 'ember-metal/property_get';
-import { _instrumentStart } from 'ember-metal/instrumentation';
-import { ComponentDefinition } from 'glimmer-runtime';
-import { OWNER } from 'container';
+import {
+  privatize as P,
+  OWNER
+} from 'container';
 import { environment } from 'ember-environment';
 
 const DEFAULT_LAYOUT = P`template:components/-default`;

--- a/packages/ember-glimmer/lib/syntax/dynamic-component.js
+++ b/packages/ember-glimmer/lib/syntax/dynamic-component.js
@@ -6,7 +6,7 @@ import {
   isComponentDefinition
 } from 'glimmer-runtime';
 import { UNDEFINED_REFERENCE } from 'glimmer-reference';
-import { assert } from 'ember-metal/debug';
+import { assert } from 'ember-metal';
 
 function dynamicComponentFor(vm, symbolTable) {
   let env     = vm.env;

--- a/packages/ember-glimmer/lib/syntax/input.js
+++ b/packages/ember-glimmer/lib/syntax/input.js
@@ -1,4 +1,4 @@
-import { assert } from 'ember-metal/debug';
+import { assert } from 'ember-metal';
 import { CurlyComponentSyntax } from './curly-component';
 import { DynamicComponentSyntax } from './dynamic-component';
 import { wrapComponentClassAttribute } from '../utils/bindings';

--- a/packages/ember-glimmer/lib/syntax/mount.js
+++ b/packages/ember-glimmer/lib/syntax/mount.js
@@ -1,8 +1,12 @@
-import { ArgsSyntax, StatementSyntax } from 'glimmer-runtime';
+import {
+  ArgsSyntax,
+  StatementSyntax,
+  ComponentDefinition
+} from 'glimmer-runtime';
 import { UNDEFINED_REFERENCE } from 'glimmer-reference';
-import { assert } from 'ember-metal/debug';
+import { assert } from 'ember-metal';
 import { RootReference } from '../utils/references';
-import { generateControllerFactory } from 'ember-routing/system/generate_controller';
+import { generateControllerFactory } from 'ember-routing';
 import { OutletLayoutCompiler } from './outlet';
 
 export class MountSyntax extends StatementSyntax {
@@ -82,8 +86,6 @@ class MountManager {
 }
 
 const MOUNT_MANAGER = new MountManager();
-
-import { ComponentDefinition } from 'glimmer-runtime';
 
 class MountDefinition extends ComponentDefinition {
   constructor(name, env) {

--- a/packages/ember-glimmer/lib/syntax/outlet.js
+++ b/packages/ember-glimmer/lib/syntax/outlet.js
@@ -1,8 +1,14 @@
-import { ArgsSyntax, StatementSyntax } from 'glimmer-runtime';
-import { generateGuid, guidFor } from 'ember-metal/utils';
-import { _instrumentStart } from 'ember-metal/instrumentation';
+import {
+  ArgsSyntax,
+  StatementSyntax,
+  ComponentDefinition
+} from 'glimmer-runtime';
+import {
+  generateGuid,
+  guidFor,
+  _instrumentStart
+} from 'ember-metal';
 import { RootReference } from '../utils/references';
-
 import {
   UpdatableTag,
   ConstReference,
@@ -213,8 +219,6 @@ class OutletComponentManager extends AbstractOutletComponentManager {
 }
 
 const MANAGER = new OutletComponentManager();
-
-import { ComponentDefinition } from 'glimmer-runtime';
 
 class AbstractOutletComponentDefinition extends ComponentDefinition {
   constructor(manager, outletName, template) {

--- a/packages/ember-glimmer/lib/syntax/render.js
+++ b/packages/ember-glimmer/lib/syntax/render.js
@@ -1,8 +1,12 @@
-import { ArgsSyntax, StatementSyntax } from 'glimmer-runtime';
+import {
+  ArgsSyntax,
+  StatementSyntax,
+  ComponentDefinition
+} from 'glimmer-runtime';
 import { ConstReference, isConst } from 'glimmer-reference';
-import { assert } from 'ember-metal/debug';
+import { assert } from 'ember-metal';
 import { RootReference } from '../utils/references';
-import { generateControllerFactory } from 'ember-routing/system/generate_controller';
+import { generateControllerFactory } from 'ember-routing';
 import { OutletLayoutCompiler } from './outlet';
 
 function makeComponentDefinition(vm) {
@@ -127,8 +131,6 @@ class NonSingletonRenderManager extends AbstractRenderManager {
 }
 
 const NON_SINGLETON_RENDER_MANAGER = new NonSingletonRenderManager();
-
-import { ComponentDefinition } from 'glimmer-runtime';
 
 class RenderDefinition extends ComponentDefinition {
   constructor(name, template, env, manager) {

--- a/packages/ember-glimmer/lib/utils/bindings.js
+++ b/packages/ember-glimmer/lib/utils/bindings.js
@@ -1,7 +1,6 @@
 import { HelperSyntax } from 'glimmer-runtime';
-import get from 'ember-metal/property_get';
-import { assert } from 'ember-metal/debug';
-import { dasherize } from 'ember-runtime/system/string';
+import { get, assert } from 'ember-metal';
+import { String as StringUtils } from 'ember-runtime';
 import { CachedReference, map, referenceFromParts } from 'glimmer-reference';
 import { ROOT_REF } from '../component';
 import { htmlSafe, isHTMLSafe } from './string';
@@ -164,7 +163,7 @@ class SimpleClassNameBindingReference extends CachedReference {
 
     if (value === true) {
       let { path, dasherizedPath } = this;
-      return dasherizedPath || (this.dasherizedPath = dasherize(path));
+      return dasherizedPath || (this.dasherizedPath = StringUtils.dasherize(path));
     } else if (value || value === 0) {
       return value;
     } else {

--- a/packages/ember-glimmer/lib/utils/iterable.js
+++ b/packages/ember-glimmer/lib/utils/iterable.js
@@ -1,9 +1,14 @@
-import { get } from 'ember-metal/property_get';
-import { guidFor } from 'ember-metal/utils';
-import { tagFor } from 'ember-metal/tags';
-import Dict from 'ember-metal/empty_object';
-import { objectAt, isEmberArray } from 'ember-runtime/mixins/array';
-import { isProxy } from 'ember-runtime/mixins/-proxy';
+import {
+  get,
+  guidFor,
+  tagFor,
+  EmptyObject
+} from 'ember-metal';
+import {
+  objectAt,
+  isEmberArray,
+  isProxy
+} from 'ember-runtime';
 import { UpdatableReference, UpdatablePrimitiveReference } from './references';
 import { isEachIn } from '../helpers/each-in';
 import { CONSTANT_TAG, UpdatableTag, combine } from 'glimmer-reference';
@@ -77,7 +82,7 @@ class ArrayIterator {
     this.length = array.length;
     this.keyFor = keyFor;
     this.position = 0;
-    this.seen = new Dict();
+    this.seen = new EmptyObject();
   }
 
   isEmpty() {
@@ -105,7 +110,7 @@ class EmberArrayIterator {
     this.length = get(array, 'length');
     this.keyFor = keyFor;
     this.position = 0;
-    this.seen = new Dict();
+    this.seen = new EmptyObject();
   }
 
   isEmpty() {
@@ -133,7 +138,7 @@ class ObjectKeysIterator {
     this.values = values;
     this.keyFor = keyFor;
     this.position = 0;
-    this.seen = new Dict();
+    this.seen = new EmptyObject();
   }
 
   isEmpty() {

--- a/packages/ember-glimmer/lib/utils/process-args.js
+++ b/packages/ember-glimmer/lib/utils/process-args.js
@@ -1,9 +1,8 @@
 import { CONSTANT_TAG } from 'glimmer-reference';
-import symbol from 'ember-metal/symbol';
-import EmptyObject from 'ember-metal/empty_object';
+import { symbol, EmptyObject} from 'ember-metal';
 import { ARGS } from '../component';
 import { UPDATE } from './references';
-import { MUTABLE_CELL } from 'ember-views/compat/attrs-proxy';
+import { MUTABLE_CELL } from 'ember-views';
 
 export default function processArgs(args, positionalParamsDefinition) {
   if (!positionalParamsDefinition || positionalParamsDefinition.length === 0 || args.positional.length === 0) {

--- a/packages/ember-glimmer/lib/utils/references.js
+++ b/packages/ember-glimmer/lib/utils/references.js
@@ -1,17 +1,19 @@
-import { get } from 'ember-metal/property_get';
-import { set } from 'ember-metal/property_set';
-import { tagFor } from 'ember-metal/tags';
-import { didRender } from 'ember-metal/transaction';
-import symbol from 'ember-metal/symbol';
-import EmptyObject from 'ember-metal/empty_object';
+import {
+  get,
+  set,
+  tagFor,
+  didRender,
+  symbol,
+  EmptyObject,
+  meta as metaFor,
+  watchKey,
+  isFeatureEnabled
+} from 'ember-metal';
 import { CONSTANT_TAG, ConstReference, DirtyableTag, UpdatableTag, combine, isConst } from 'glimmer-reference';
 import { ConditionalReference as GlimmerConditionalReference, NULL_REFERENCE, UNDEFINED_REFERENCE } from 'glimmer-runtime';
 import emberToBool from './to-bool';
 import { RECOMPUTE_TAG } from '../helper';
-import { meta as metaFor } from 'ember-metal/meta';
-import { watchKey } from 'ember-metal/watch_key';
-import isEnabled from 'ember-metal/features';
-import { isProxy } from 'ember-runtime/mixins/-proxy';
+import { isProxy } from 'ember-runtime';
 
 export const UPDATE = symbol('UPDATE');
 
@@ -77,8 +79,8 @@ export class RootReference extends ConstReference {
 
 let TwoWayFlushDetectionTag;
 
-if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
-    isEnabled('ember-glimmer-allow-backtracking-rerender')) {
+if (isFeatureEnabled('ember-glimmer-detect-backtracking-rerender') ||
+    isFeatureEnabled('ember-glimmer-allow-backtracking-rerender')) {
   TwoWayFlushDetectionTag = class {
     constructor(tag, key, ref) {
       this.tag = tag;
@@ -131,14 +133,14 @@ export class RootPropertyReference extends PropertyReference {
     this._parentValue = parentValue;
     this._propertyKey = propertyKey;
 
-    if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
-        isEnabled('ember-glimmer-allow-backtracking-rerender')) {
+    if (isFeatureEnabled('ember-glimmer-detect-backtracking-rerender') ||
+        isFeatureEnabled('ember-glimmer-allow-backtracking-rerender')) {
       this.tag = new TwoWayFlushDetectionTag(tagFor(parentValue), propertyKey, this);
     } else {
       this.tag = tagFor(parentValue);
     }
 
-    if (isEnabled('mandatory-setter')) {
+    if (isFeatureEnabled('mandatory-setter')) {
       watchKey(parentValue, propertyKey, metaFor(parentValue));
     }
   }
@@ -146,8 +148,8 @@ export class RootPropertyReference extends PropertyReference {
   compute() {
     let { _parentValue, _propertyKey } = this;
 
-    if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
-        isEnabled('ember-glimmer-allow-backtracking-rerender')) {
+    if (isFeatureEnabled('ember-glimmer-detect-backtracking-rerender') ||
+        isFeatureEnabled('ember-glimmer-allow-backtracking-rerender')) {
       this.tag.didCompute(_parentValue);
     }
 
@@ -170,8 +172,8 @@ export class NestedPropertyReference extends PropertyReference {
     this._parentObjectTag = parentObjectTag;
     this._propertyKey = propertyKey;
 
-    if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
-        isEnabled('ember-glimmer-allow-backtracking-rerender')) {
+    if (isFeatureEnabled('ember-glimmer-detect-backtracking-rerender') ||
+        isFeatureEnabled('ember-glimmer-allow-backtracking-rerender')) {
       let tag = combine([parentReferenceTag, parentObjectTag]);
       this.tag = new TwoWayFlushDetectionTag(tag, propertyKey, this);
     } else {
@@ -187,13 +189,13 @@ export class NestedPropertyReference extends PropertyReference {
     _parentObjectTag.update(tagFor(parentValue));
 
     if (typeof parentValue === 'object' && parentValue) {
-      if (isEnabled('mandatory-setter')) {
+      if (isFeatureEnabled('mandatory-setter')) {
         let meta = metaFor(parentValue);
         watchKey(parentValue, _propertyKey, meta);
       }
 
-      if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
-          isEnabled('ember-glimmer-allow-backtracking-rerender')) {
+      if (isFeatureEnabled('ember-glimmer-detect-backtracking-rerender') ||
+          isFeatureEnabled('ember-glimmer-allow-backtracking-rerender')) {
         this.tag.didCompute(parentValue);
       }
 

--- a/packages/ember-glimmer/lib/utils/string.js
+++ b/packages/ember-glimmer/lib/utils/string.js
@@ -3,8 +3,7 @@
 @submodule ember-glimmer
 */
 
-import isEnabled from 'ember-metal/features';
-import { deprecate } from 'ember-metal/debug';
+import { isFeatureEnabled, deprecate } from 'ember-metal';
 
 export class SafeString {
   constructor(string) {
@@ -23,7 +22,7 @@ export class SafeString {
 export function getSafeString() {
   deprecate(
     'Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe',
-    !isEnabled('ember-string-ishtmlsafe'),
+    !isFeatureEnabled('ember-string-ishtmlsafe'),
     {
       id: 'ember-htmlbars.ember-handlebars-safestring',
       until: '3.0.0',

--- a/packages/ember-glimmer/lib/utils/to-bool.js
+++ b/packages/ember-glimmer/lib/utils/to-bool.js
@@ -1,5 +1,5 @@
-import { isArray } from 'ember-runtime/utils';
-import { get } from 'ember-metal/property_get';
+import { isArray } from 'ember-runtime';
+import { get } from 'ember-metal';
 
 export default function toBool(predicate) {
   if (!predicate) {

--- a/packages/ember-glimmer/lib/views/outlet.js
+++ b/packages/ember-glimmer/lib/views/outlet.js
@@ -1,6 +1,5 @@
-import assign from 'ember-metal/assign';
+import { assign, EmptyObject } from 'ember-metal';
 import { DirtyableTag } from 'glimmer-reference';
-import EmptyObject from 'ember-metal/empty_object';
 import { environment } from 'ember-environment';
 
 /**

--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -176,6 +176,7 @@ export {
   didRender,
   assertNotRendered
 } from './transaction';
+export { default as descriptor } from './descriptor';
 
 
 // TODO: this needs to be deleted once we refactor the build tooling

--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -23,6 +23,8 @@ export {
 } from './debug';
 export {
   instrument,
+  flaggedInstrument,
+  _instrumentStart,
   reset as instrumentationReset,
   subscribe as instrumentationSubscribe,
   unsubscribe as instrumentationUnsubscribe
@@ -92,7 +94,8 @@ export {
   endPropertyChanges,
   overrideChains,
   propertyDidChange,
-  propertyWillChange
+  propertyWillChange,
+  PROPERTY_DID_CHANGE
 } from './property_events';
 export {
   defineProperty,
@@ -162,8 +165,17 @@ export { default as symbol } from './symbol';
 export { default as dictionary } from './dictionary';
 export { default as EmptyObject } from './empty_object';
 export { default as InjectedProperty } from './injected_property';
-export { tagFor, markObjectAsDirty } from './tags';
+export {
+  setHasViews,
+  tagFor,
+  markObjectAsDirty
+} from './tags';
 export { default as replace } from './replace';
+export {
+  default as runInTransaction,
+  didRender,
+  assertNotRendered
+} from './transaction';
 
 
 // TODO: this needs to be deleted once we refactor the build tooling

--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -10,11 +10,11 @@ export {
   ComputedProperty
 } from './computed';
 export { default as alias } from './alias';
-export { deprecate } from './debug';
 export { default as assign } from './assign';
 export { default as merge } from './merge';
 export {
   assert,
+  info,
   warn,
   debug,
   deprecate,

--- a/packages/ember-routing/lib/ext/controller.js
+++ b/packages/ember-routing/lib/ext/controller.js
@@ -1,5 +1,5 @@
-import { get } from 'ember-metal/property_get';
-import ControllerMixin from 'ember-runtime/mixins/controller';
+import { get } from 'ember-metal';
+import { ControllerMixin } from 'ember-runtime';
 
 /**
 @module ember

--- a/packages/ember-routing/lib/ext/run_loop.js
+++ b/packages/ember-routing/lib/ext/run_loop.js
@@ -1,4 +1,4 @@
-import run from 'ember-metal/run_loop';
+import { run } from 'ember-metal';
 
 /**
 @module ember

--- a/packages/ember-routing/lib/index.js
+++ b/packages/ember-routing/lib/index.js
@@ -19,3 +19,4 @@ export { default as controllerFor } from './system/controller_for';
 export { default as RouterDSL } from './system/dsl';
 export { default as Router } from './system/router';
 export { default as Route } from './system/route';
+export { default as QueryParams } from './system/query_params';

--- a/packages/ember-routing/lib/location/api.js
+++ b/packages/ember-routing/lib/location/api.js
@@ -1,4 +1,4 @@
-import { assert } from 'ember-metal/debug';
+import { assert } from 'ember-metal';
 import { environment } from 'ember-environment';
 import { getHash } from './util';
 

--- a/packages/ember-routing/lib/location/auto_location.js
+++ b/packages/ember-routing/lib/location/auto_location.js
@@ -1,10 +1,12 @@
-import { assert } from 'ember-metal/debug';
-import { get } from 'ember-metal/property_get';
-import { set } from 'ember-metal/property_set';
-import { tryInvoke } from 'ember-metal/utils';
+import {
+  assert,
+  get,
+  set,
+  tryInvoke
+} from 'ember-metal';
 import { getOwner } from 'container';
 
-import EmberObject from 'ember-runtime/system/object';
+import { Object as EmberObject } from 'ember-runtime';
 import { environment } from 'ember-environment';
 
 import {

--- a/packages/ember-routing/lib/location/hash_location.js
+++ b/packages/ember-routing/lib/location/hash_location.js
@@ -1,8 +1,10 @@
-import { get } from 'ember-metal/property_get';
-import { set } from 'ember-metal/property_set';
-import run from 'ember-metal/run_loop';
+import {
+  get,
+  set,
+  run
+} from 'ember-metal';
 
-import EmberObject from 'ember-runtime/system/object';
+import { Object as EmberObject } from 'ember-runtime';
 import EmberLocation from './api';
 
 /**

--- a/packages/ember-routing/lib/location/history_location.js
+++ b/packages/ember-routing/lib/location/history_location.js
@@ -1,7 +1,9 @@
-import { get } from 'ember-metal/property_get';
-import { set } from 'ember-metal/property_set';
+import {
+  get,
+  set
+} from 'ember-metal';
 
-import EmberObject from 'ember-runtime/system/object';
+import { Object as EmberObject } from 'ember-runtime';
 import EmberLocation from './api';
 
 /**

--- a/packages/ember-routing/lib/location/none_location.js
+++ b/packages/ember-routing/lib/location/none_location.js
@@ -1,7 +1,9 @@
-import { assert } from 'ember-metal/debug';
-import { get } from 'ember-metal/property_get';
-import { set } from 'ember-metal/property_set';
-import EmberObject from 'ember-runtime/system/object';
+import {
+  assert,
+  get,
+  set
+} from 'ember-metal';
+import { Object as EmberObject } from 'ember-runtime';
 
 /**
 @module ember

--- a/packages/ember-routing/lib/services/routing.js
+++ b/packages/ember-routing/lib/services/routing.js
@@ -3,12 +3,16 @@
 @submodule ember-routing
 */
 
-import Service from 'ember-runtime/system/service';
+import {
+  Service,
+  readOnly
+} from 'ember-runtime';
 
-import { get } from 'ember-metal/property_get';
-import { readOnly } from 'ember-runtime/computed/computed_macros';
+import {
+  get,
+  assign
+} from 'ember-metal';
 import { routeArgs } from '../utils';
-import assign from 'ember-metal/assign';
 
 /**
   The Routing service is used by LinkComponent, and provides facilities for

--- a/packages/ember-routing/lib/system/cache.js
+++ b/packages/ember-routing/lib/system/cache.js
@@ -1,4 +1,4 @@
-import EmberObject from 'ember-runtime/system/object';
+import { Object as EmberObject } from 'ember-runtime';
 
 export default EmberObject.extend({
   init() {

--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -1,5 +1,8 @@
-import { assert, deprecate } from 'ember-metal/debug';
-import assign from 'ember-metal/assign';
+import {
+  assert,
+  deprecate,
+  assign
+} from 'ember-metal';
 
 /**
 @module ember

--- a/packages/ember-routing/lib/system/generate_controller.js
+++ b/packages/ember-routing/lib/system/generate_controller.js
@@ -1,5 +1,7 @@
-import { info } from 'ember-metal/debug';
-import { get } from 'ember-metal/property_get';
+import {
+  info,
+  get
+} from 'ember-metal';
 
 /**
 @module ember

--- a/packages/ember-routing/lib/system/query_params.js
+++ b/packages/ember-routing/lib/system/query_params.js
@@ -1,4 +1,4 @@
-import EmberObject from 'ember-runtime/system/object';
+import { Object as EmberObject } from 'ember-runtime';
 
 export default EmberObject.extend({
   isQueryParams: true,

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1,25 +1,30 @@
-import { assert, deprecate, info } from 'ember-metal/debug';
-import { isTesting } from 'ember-metal/testing';
-import isEnabled from 'ember-metal/features';
-import EmberError from 'ember-metal/error';
-import { get } from 'ember-metal/property_get';
-import { set } from 'ember-metal/property_set';
-import getProperties from 'ember-metal/get_properties';
-import isNone from 'ember-metal/is_none';
-import { computed } from 'ember-metal/computed';
-import assign from 'ember-metal/assign';
 import {
-  typeOf
-} from 'ember-runtime/utils';
-import run from 'ember-metal/run_loop';
-import copy from 'ember-runtime/copy';
+  assert,
+  deprecate,
+  info,
+  isTesting,
+  isFeatureEnabled,
+  Error as EmberError,
+  get,
+  set,
+  getProperties,
+  isNone,
+  computed,
+  assign,
+  run,
+  isEmpty,
+  symbol
+} from 'ember-metal';
 import {
-  classify
-} from 'ember-runtime/system/string';
-import EmberObject from 'ember-runtime/system/object';
-import { A as emberA } from 'ember-runtime/system/native_array';
-import Evented from 'ember-runtime/mixins/evented';
-import ActionHandler, { deprecateUnderscoreActions } from 'ember-runtime/mixins/action_handler';
+  typeOf,
+  copy,
+  String as StringUtils,
+  Object as EmberObject,
+  A as emberA,
+  Evented,
+  ActionHandler,
+  deprecateUnderscoreActions
+} from 'ember-runtime';
 import generateController from './generate_controller';
 import {
   generateControllerFactory
@@ -30,8 +35,6 @@ import {
   calculateCacheKey
 } from '../utils';
 import { getOwner } from 'container';
-import isEmpty from 'ember-metal/is_empty';
-import symbol from 'ember-metal/symbol';
 const { slice } = Array.prototype;
 
 function K() { return this; }
@@ -162,7 +165,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
       let normalizedControllerQueryParameterConfiguration = normalizeControllerQueryParams(controllerDefinedQueryParameterConfiguration);
       combinedQueryParameterConfiguration = mergeEachQueryParams(normalizedControllerQueryParameterConfiguration, queryParameterConfiguraton);
 
-      if (isEnabled('ember-routing-route-configured-query-params')) {
+      if (isFeatureEnabled('ember-routing-route-configured-query-params')) {
         if (controllerDefinedQueryParameterConfiguration.length) {
           deprecate(`Configuring query parameters on a controller is deprecated. Migrate the query parameters configuration from the '${controllerName}' controller to the '${this.routeName}' route: ${combinedQueryParameterConfiguration}`, false, { id: 'ember-routing.controller-configured-query-params', until: '3.0.0' });
         }
@@ -191,7 +194,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
 
       let desc = combinedQueryParameterConfiguration[propName];
 
-      if (isEnabled('ember-routing-route-configured-query-params')) {
+      if (isFeatureEnabled('ember-routing-route-configured-query-params')) {
         // apply default values to controllers
         // detect that default value defined on router config
         if (desc.hasOwnProperty('defaultValue')) {
@@ -1577,11 +1580,11 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
         let modelClass = owner._lookupFactory(`model:${name}`);
 
         assert(
-          `You used the dynamic segment ${name}_id in your route ${routeName}, but ${namespace}.${classify(name)} did not exist and you did not override your route's \`model\` hook.`, !!modelClass);
+          `You used the dynamic segment ${name}_id in your route ${routeName}, but ${namespace}.${StringUtils.classify(name)} did not exist and you did not override your route's \`model\` hook.`, !!modelClass);
 
         if (!modelClass) { return; }
 
-        assert(`${classify(name)} has no method \`find\`.`, typeof modelClass.find === 'function');
+        assert(`${StringUtils.classify(name)} has no method \`find\`.`, typeof modelClass.find === 'function');
 
         return modelClass.find(value);
       }
@@ -2248,7 +2251,7 @@ function mergeEachQueryParams(controllerQP, routeQP) {
   let keysAlreadyMergedOrSkippable;
   let qps = {};
 
-  if (isEnabled('ember-routing-route-configured-query-params')) {
+  if (isFeatureEnabled('ember-routing-route-configured-query-params')) {
     keysAlreadyMergedOrSkippable = {};
   } else {
     keysAlreadyMergedOrSkippable = {

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -1,15 +1,22 @@
 import Logger from 'ember-console';
-import { assert, info } from 'ember-metal/debug';
-import EmberError from 'ember-metal/error';
-import { get } from 'ember-metal/property_get';
-import { set } from 'ember-metal/property_set';
-import { defineProperty } from 'ember-metal/properties';
-import EmptyObject from 'ember-metal/empty_object';
-import { computed } from 'ember-metal/computed';
-import assign from 'ember-metal/assign';
-import run from 'ember-metal/run_loop';
-import EmberObject from 'ember-runtime/system/object';
-import Evented from 'ember-runtime/mixins/evented';
+import {
+  assert,
+  info,
+  Error as EmberError,
+  get,
+  set,
+  defineProperty,
+  EmptyObject,
+  computed,
+  assign,
+  run,
+  guidFor,
+  dictionary
+} from 'ember-metal';
+import {
+  Object as EmberObject,
+  Evented
+} from 'ember-runtime';
 import { defaultSerialize, hasDefaultSerialize } from './route';
 import EmberRouterDSL from './dsl';
 import EmberLocation from '../location/api';
@@ -19,10 +26,8 @@ import {
   stashParamNames,
   calculateCacheKey
 } from '../utils';
-import { guidFor } from 'ember-metal/utils';
 import RouterState from './router_state';
 import { getOwner } from 'container';
-import dictionary from 'ember-metal/dictionary';
 
 /**
 @module ember

--- a/packages/ember-routing/lib/system/router_state.js
+++ b/packages/ember-routing/lib/system/router_state.js
@@ -1,6 +1,8 @@
-import isEmpty from 'ember-metal/is_empty';
-import EmberObject from 'ember-runtime/system/object';
-import assign from 'ember-metal/assign';
+import {
+  isEmpty,
+  assign
+} from 'ember-metal';
+import { Object as EmberObject } from 'ember-runtime';
 
 export default EmberObject.extend({
   emberRouter: null,

--- a/packages/ember-routing/lib/utils.js
+++ b/packages/ember-routing/lib/utils.js
@@ -1,5 +1,4 @@
-import assign from 'ember-metal/assign';
-import { get } from 'ember-metal/property_get';
+import { assign, get } from 'ember-metal';
 
 const ALL_PERIODS_REGEX = /\./g;
 

--- a/packages/ember-runtime/lib/index.js
+++ b/packages/ember-runtime/lib/index.js
@@ -24,7 +24,10 @@ export { default as ArrayProxy } from './system/array_proxy';
 export { default as ObjectProxy } from './system/object_proxy';
 export { default as CoreObject } from './system/core_object';
 export { default as NativeArray, A } from './system/native_array';
-export { default as ActionHandler } from './mixins/action_handler';
+export {
+  default as ActionHandler,
+  deprecateUnderscoreActions
+} from './mixins/action_handler';
 export { default as Copyable } from './mixins/copyable';
 export { default as Enumerable } from './mixins/enumerable';
 export {

--- a/packages/ember-runtime/lib/index.js
+++ b/packages/ember-runtime/lib/index.js
@@ -13,7 +13,11 @@ export { default as copy } from './copy';
 export { default as inject } from './inject';
 export { default as compare } from './compare';
 export { default as isEqual } from './is-equal';
-export { default as Array } from './mixins/array';
+export {
+  default as Array,
+  objectAt,
+  isEmberArray
+} from './mixins/array';
 export { default as Comparable } from './mixins/comparable';
 export {
   default as Namespace,
@@ -22,7 +26,10 @@ export {
 } from './system/namespace';
 export { default as ArrayProxy } from './system/array_proxy';
 export { default as ObjectProxy } from './system/object_proxy';
-export { default as CoreObject } from './system/core_object';
+export {
+  default as CoreObject,
+  POST_INIT
+} from './system/core_object';
 export { default as NativeArray, A } from './system/native_array';
 export {
   default as ActionHandler,
@@ -34,7 +41,10 @@ export {
   Freezable,
   FROZEN_ERROR
 } from './mixins/freezable';
-export { default as _ProxyMixin } from './mixins/-proxy';
+export {
+  default as _ProxyMixin,
+  isProxy
+} from './mixins/-proxy';
 export {
   onLoad,
   runLoadHooks

--- a/packages/ember-views/lib/compat/attrs-proxy.js
+++ b/packages/ember-views/lib/compat/attrs-proxy.js
@@ -1,6 +1,8 @@
-import { Mixin } from 'ember-metal/mixin';
-import symbol from 'ember-metal/symbol';
-import { PROPERTY_DID_CHANGE } from 'ember-metal/property_events';
+import {
+  Mixin,
+  symbol,
+  PROPERTY_DID_CHANGE
+} from 'ember-metal';
 
 export function deprecation(key) {
   return `You tried to look up an attribute directly on the component. This is deprecated. Use attrs.${key} instead.`;

--- a/packages/ember-views/lib/compat/fallback-view-registry.js
+++ b/packages/ember-views/lib/compat/fallback-view-registry.js
@@ -1,3 +1,3 @@
-import dict from 'ember-metal/dictionary';
+import { dictionary } from 'ember-metal';
 
-export default dict(null);
+export default dictionary(null);

--- a/packages/ember-views/lib/component_lookup.js
+++ b/packages/ember-views/lib/component_lookup.js
@@ -1,5 +1,5 @@
-import { assert } from 'ember-metal/debug';
-import EmberObject from 'ember-runtime/system/object';
+import { assert } from 'ember-metal';
+import { Object as EmberObject } from 'ember-runtime';
 
 export default EmberObject.extend({
   componentFor(name, owner, options) {

--- a/packages/ember-views/lib/index.js
+++ b/packages/ember-views/lib/index.js
@@ -10,10 +10,29 @@ export {
   getViewClientRects,
   getViewBoundingClientRect,
   getRootViews,
-  getChildViews
+  getChildViews,
+  STYLE_WARNING,
+  getViewId
 } from './system/utils';
 export { default as EventDispatcher } from './system/event_dispatcher';
 export { default as ComponentLookup } from './component_lookup';
 export { default as TextSupport } from './mixins/text_support';
+export { default as CoreView } from './views/core_view';
+export { default as ClassNamesSupport } from './mixins/class_names_support';
+export { default as ChildViewsSupport } from './mixins/child_views_support';
+export { default as ViewStateSupport } from './mixins/view_state_support';
+export { default as ViewMixin } from './mixins/view_support';
+export { default as ActionSupport } from './mixins/action_support';
+export {
+  getAttrFor,
+  MUTABLE_CELL
+} from './compat/attrs-proxy';
+export {
+  default as lookupPartial,
+  hasPartial
+} from './system/lookup_partial';
+export { default as lookupComponent } from './utils/lookup-component';
+export { default as ActionManager } from './system/action_manager';
+export { default as fallbackViewRegistry } from './compat/fallback-view-registry';
 
 import './system/ext';  // for the side effect of extending Ember.run.queues

--- a/packages/ember-views/lib/mixins/action_support.js
+++ b/packages/ember-views/lib/mixins/action_support.js
@@ -2,12 +2,14 @@
  @module ember
  @submodule ember-views
 */
-import { Mixin } from 'ember-metal/mixin';
-import { get } from 'ember-metal/property_get';
-import isNone from 'ember-metal/is_none';
-import { assert } from 'ember-metal/debug';
+import {
+  Mixin,
+  get,
+  isNone,
+  assert,
+  inspect
+} from 'ember-metal';
 import { MUTABLE_CELL } from '../compat/attrs-proxy';
-import { inspect } from 'ember-metal/utils';
 
 function validateAction(component, actionName) {
   if (actionName && actionName[MUTABLE_CELL]) {

--- a/packages/ember-views/lib/mixins/child_views_support.js
+++ b/packages/ember-views/lib/mixins/child_views_support.js
@@ -2,9 +2,11 @@
 @module ember
 @submodule ember-views
 */
-import { Mixin } from 'ember-metal/mixin';
+import {
+  Mixin,
+  descriptor
+} from 'ember-metal';
 import { getOwner, setOwner } from 'container';
-import descriptor from 'ember-metal/descriptor';
 import { initChildViews, getChildViews, addChildView } from '../system/utils';
 
 export default Mixin.create({

--- a/packages/ember-views/lib/mixins/class_names_support.js
+++ b/packages/ember-views/lib/mixins/class_names_support.js
@@ -2,8 +2,11 @@
 @module ember
 @submodule ember-views
 */
-import { assert } from 'ember-metal/debug';
-import { Mixin } from 'ember-metal/mixin';
+
+import {
+  assert,
+  Mixin
+} from 'ember-metal';
 
 const EMPTY_ARRAY = Object.freeze([]);
 

--- a/packages/ember-views/lib/mixins/instrumentation_support.js
+++ b/packages/ember-views/lib/mixins/instrumentation_support.js
@@ -2,8 +2,10 @@
 @module ember
 @submodule ember-views
 */
-import { Mixin } from 'ember-metal/mixin';
-import { get } from 'ember-metal/property_get';
+import {
+  Mixin,
+  get
+} from 'ember-metal';
 
 /**
   @class InstrumentationSupport

--- a/packages/ember-views/lib/mixins/template_support.js
+++ b/packages/ember-views/lib/mixins/template_support.js
@@ -1,9 +1,11 @@
-import EmberError from 'ember-metal/error';
-import { computed } from 'ember-metal/computed';
+import {
+  Error as EmberError,
+  computed,
+  Mixin,
+  get,
+  assert
+} from 'ember-metal';
 import { getOwner } from 'container';
-import { Mixin } from 'ember-metal/mixin';
-import { get } from 'ember-metal/property_get';
-import { assert } from 'ember-metal/debug';
 
 export default Mixin.create({
   /**

--- a/packages/ember-views/lib/mixins/text_support.js
+++ b/packages/ember-views/lib/mixins/text_support.js
@@ -3,10 +3,12 @@
 @submodule ember-views
 */
 
-import { get } from 'ember-metal/property_get';
-import { set } from 'ember-metal/property_set';
-import { Mixin } from 'ember-metal/mixin';
-import TargetActionSupport from 'ember-runtime/mixins/target_action_support';
+import {
+  get,
+  set,
+  Mixin
+} from 'ember-metal';
+import { TargetActionSupport } from 'ember-runtime';
 
 const KEY_EVENTS = {
   13: 'insertNewline',

--- a/packages/ember-views/lib/mixins/view_state_support.js
+++ b/packages/ember-views/lib/mixins/view_state_support.js
@@ -2,7 +2,7 @@
 @module ember
 @submodule ember-views
 */
-import { Mixin } from 'ember-metal/mixin';
+import { Mixin } from 'ember-metal';
 
 export default Mixin.create({
   _transitionTo(state) {

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -1,9 +1,12 @@
-import { assert, deprecate } from 'ember-metal/debug';
-import run from 'ember-metal/run_loop';
-import { guidFor } from 'ember-metal/utils';
-import { Mixin } from 'ember-metal/mixin';
-import { POST_INIT } from 'ember-runtime/system/core_object';
-import symbol from 'ember-metal/symbol';
+import {
+  assert,
+  deprecate,
+  run,
+  guidFor,
+  Mixin,
+  symbol
+} from 'ember-metal';
+import { POST_INIT } from 'ember-runtime';
 import { environment } from 'ember-environment';
 import { matches } from '../system/utils';
 

--- a/packages/ember-views/lib/mixins/visibility_support.js
+++ b/packages/ember-views/lib/mixins/visibility_support.js
@@ -4,10 +4,10 @@
 */
 import {
   Mixin,
-  observer
-} from 'ember-metal/mixin';
-import { get } from 'ember-metal/property_get';
-import run from 'ember-metal/run_loop';
+  observer,
+  get,
+  run
+} from 'ember-metal';
 
 function K() { return this; }
 

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -3,15 +3,17 @@
 @submodule ember-views
 */
 
-import { assert } from 'ember-metal/debug';
-import { get } from 'ember-metal/property_get';
-import { set } from 'ember-metal/property_set';
-import isNone from 'ember-metal/is_none';
-import run from 'ember-metal/run_loop';
-import EmberObject from 'ember-runtime/system/object';
+import {
+  assert,
+  get,
+  set,
+  isNone,
+  run,
+  assign
+} from 'ember-metal';
+import { Object as EmberObject } from 'ember-runtime';
 import jQuery from './jquery';
 import ActionManager from './action_manager';
-import assign from 'ember-metal/assign';
 import { getOwner } from 'container';
 import { environment } from 'ember-environment';
 import fallbackViewRegistry from '../compat/fallback-view-registry';

--- a/packages/ember-views/lib/system/ext.js
+++ b/packages/ember-views/lib/system/ext.js
@@ -3,7 +3,7 @@
 @submodule ember-views
 */
 
-import run from 'ember-metal/run_loop';
+import { run } from 'ember-metal';
 
 // Add a new named queue for rendering views that happens
 // after bindings have synced, and a queue for scheduling actions

--- a/packages/ember-views/lib/system/lookup_partial.js
+++ b/packages/ember-views/lib/system/lookup_partial.js
@@ -1,5 +1,7 @@
-import { assert } from 'ember-metal/debug';
-import EmberError from 'ember-metal/error';
+import {
+  assert,
+  Error as EmberError
+} from 'ember-metal';
 
 function parseUnderscoredName(templateName) {
   let nameParts = templateName.split('/');

--- a/packages/ember-views/lib/system/utils.js
+++ b/packages/ember-views/lib/system/utils.js
@@ -1,8 +1,7 @@
 /* globals Element */
 
-import { guidFor } from 'ember-metal/utils';
+import { guidFor, symbol } from 'ember-metal';
 import { getOwner } from 'container';
-import symbol from 'ember-metal/symbol';
 
 /**
 @module ember

--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -1,9 +1,12 @@
-import { get } from 'ember-metal/property_get';
+import { get } from 'ember-metal';
 
-import EmberObject from 'ember-runtime/system/object';
-import Evented from 'ember-runtime/mixins/evented';
-import ActionHandler, { deprecateUnderscoreActions } from 'ember-runtime/mixins/action_handler';
-import { typeOf } from 'ember-runtime/utils';
+import {
+  Object as EmberObject,
+  Evented,
+  ActionHandler,
+  deprecateUnderscoreActions,
+  typeOf
+} from 'ember-runtime';
 import { cloneStates, states } from './states';
 
 /**

--- a/packages/ember-views/lib/views/states.js
+++ b/packages/ember-views/lib/views/states.js
@@ -1,4 +1,4 @@
-import assign from 'ember-metal/assign';
+import { assign } from 'ember-metal';
 import _default from './states/default';
 import preRender from './states/pre_render';
 import hasElement from './states/has_element';

--- a/packages/ember-views/lib/views/states/default.js
+++ b/packages/ember-views/lib/views/states/default.js
@@ -1,5 +1,7 @@
-import EmberError from 'ember-metal/error';
-import { get } from 'ember-metal/property_get';
+import {
+  Error as EmberError,
+  get
+} from 'ember-metal';
 import { MUTABLE_CELL } from '../../compat/attrs-proxy';
 
 /**

--- a/packages/ember-views/lib/views/states/destroying.js
+++ b/packages/ember-views/lib/views/states/destroying.js
@@ -1,6 +1,5 @@
-import assign from 'ember-metal/assign';
+import { assign, Error as EmberError } from 'ember-metal';
 import _default from './default';
-import EmberError from 'ember-metal/error';
 /**
 @module ember
 @submodule ember-views

--- a/packages/ember-views/lib/views/states/has_element.js
+++ b/packages/ember-views/lib/views/states/has_element.js
@@ -1,15 +1,11 @@
 import _default from './default';
-import assign from 'ember-metal/assign';
+import {
+  assign,
+  run,
+  flaggedInstrument,
+  get
+} from 'ember-metal';
 import jQuery from '../../system/jquery';
-import run from 'ember-metal/run_loop';
-import { flaggedInstrument } from 'ember-metal/instrumentation';
-
-/**
-@module ember
-@submodule ember-views
-*/
-
-import { get } from 'ember-metal/property_get';
 
 const hasElement = Object.create(_default);
 

--- a/packages/ember-views/lib/views/states/in_dom.js
+++ b/packages/ember-views/lib/views/states/in_dom.js
@@ -1,7 +1,9 @@
-import { runInDebug } from 'ember-metal/debug';
-import assign from 'ember-metal/assign';
-import EmberError from 'ember-metal/error';
-import { _addBeforeObserver } from 'ember-metal/observer';
+import {
+  runInDebug,
+  assign,
+  Error as EmberError,
+  _addBeforeObserver
+} from 'ember-metal';
 
 import hasElement from './has_element';
 /**

--- a/packages/ember-views/lib/views/states/pre_render.js
+++ b/packages/ember-views/lib/views/states/pre_render.js
@@ -1,5 +1,5 @@
 import _default from './default';
-import assign from 'ember-metal/assign';
+import { assign } from 'ember-metal';
 
 /**
 @module ember


### PR DESCRIPTION
- Use only main entry points from inside ember-views.
- Use only main entry points from inside ember-glimmer.
- Use only main entry points from inside ember-routing.
