### PR TITLE
[DOC canary] Drop "View" references from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ example:
 
   * [Ember.js Runtime](http://localhost:4200/tests/index.html?package=ember-runtime)
   * [Ember.js Views](http://localhost:4200/tests/index.html?package=ember-views)
-  * [Ember.js Handlebars](http://localhost:4200/tests/index.html?package=ember-handlebars)
+  * [Ember.js Glimmer](http://localhost:4200/tests/index.html?package=ember-glimmer)
 
 To test multiple packages, you can separate them with commas.
 

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -403,8 +403,8 @@ export const NAME_KEY = GUID_KEY + '_name';
   added to other classes. For instance,
 
   ```javascript
-  App.Editable = Ember.Mixin.create({
-    edit: function() {
+  const EditableMixin = Ember.Mixin.create({
+    edit() {
       console.log('starting to edit');
       this.set('isEditing', true);
     },
@@ -412,13 +412,13 @@ export const NAME_KEY = GUID_KEY + '_name';
   });
 
   // Mix mixins into classes by passing them as the first arguments to
-  // .extend.
-  App.CommentView = Ember.View.extend(App.Editable, {
-    template: Ember.Handlebars.compile('{{#if view.isEditing}}...{{else}}...{{/if}}')
+  // `.extend.`
+  const Comment = Ember.Object.extend(EditableMixin, {
+    post: null
   });
 
-  commentView = App.CommentView.create();
-  commentView.edit(); // outputs 'starting to edit'
+  let comment = Comment.create(post: somePost);
+  comment.edit(); // outputs 'starting to edit'
   ```
 
   Note that Mixins are created with `Ember.Mixin.create`, not
@@ -430,19 +430,21 @@ export const NAME_KEY = GUID_KEY + '_name';
   it either as a computed property or have it be created on initialization of the object.
 
   ```javascript
-  //filters array will be shared amongst any object implementing mixin
-  App.Filterable = Ember.Mixin.create({
+  // filters array will be shared amongst any object implementing mixin
+  const FilterableMixin = Ember.Mixin.create({
     filters: Ember.A()
   });
 
-  //filters will be a separate  array for every object implementing the mixin
-  App.Filterable = Ember.Mixin.create({
-    filters: Ember.computed(function() {return Ember.A();})
+  // filters will be a separate array for every object implementing the mixin
+  const FilterableMixin = Ember.Mixin.create({
+    filters: Ember.computed(function() {
+      return Ember.A();
+    })
   });
 
-  //filters will be created as a separate array during the object's initialization
-  App.Filterable = Ember.Mixin.create({
-    init: function() {
+  // filters will be created as a separate array during the object's initialization
+  const Filterable = Ember.Mixin.create({
+    init() {
       this._super(...arguments);
       this.set("filters", Ember.A());
     }
@@ -799,30 +801,6 @@ export function _immediateObserver() {
 
   A `_beforeObserver` fires before a property changes.
 
-  A `_beforeObserver` is an alternative form of `.observesBefore()`.
-
-  ```javascript
-  App.PersonView = Ember.View.extend({
-    friends: [{ name: 'Tom' }, { name: 'Stefan' }, { name: 'Kris' }],
-
-    valueDidChange: Ember.observer('content.value', function(obj, keyName) {
-        // only run if updating a value already in the DOM
-        if (this.get('state') === 'inDOM') {
-          let color = obj.get(keyName) > this.changingFrom ? 'green' : 'red';
-          // logic
-        }
-    }),
-
-    friendsDidChange: Ember.observer('friends.@each.name', function(obj, keyName) {
-      // some logic
-      // obj.get(keyName) returns friends array
-    })
-  });
-  ```
-
-  Also available as `Function.prototype.observesBefore` if prototype extensions are
-  enabled.
-
   @method beforeObserver
   @for Ember
   @param {String} propertyNames*
@@ -853,7 +831,7 @@ export function _beforeObserver(...args) {
   }
 
   if (typeof func !== 'function') {
-    throw new EmberError('Ember.beforeObserver called without a function');
+    throw new EmberError('_beforeObserver called without a function');
   }
 
   func.__ember_observesBefore__ = paths;

--- a/packages/ember-runtime/lib/mixins/action_handler.js
+++ b/packages/ember-runtime/lib/mixins/action_handler.js
@@ -12,7 +12,7 @@ import {
 
 /**
   `Ember.ActionHandler` is available on some familiar classes including
-  `Ember.Route`, `Ember.View`, `Ember.Component`, and `Ember.Controller`.
+  `Ember.Route`, `Ember.Component`, and `Ember.Controller`.
   (Internally the mixin is used by `Ember.CoreView`, `Ember.ControllerMixin`,
   and `Ember.Route` and available to the above classes through
   inheritance.)
@@ -62,8 +62,8 @@ const ActionHandler = Mixin.create({
     this.send('playMusic');
     ```
 
-    Within a Controller, Route, View or Component's action handler,
-    the value of the `this` context is the Controller, Route, View or
+    Within a Controller, Route or Component's action handler,
+    the value of the `this` context is the Controller, Route or
     Component object:
 
     ```js

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -216,13 +216,13 @@ CoreObject.PrototypeMixin = Mixin.create({
     Example:
 
     ```javascript
-    App.Person = Ember.Object.extend({
-      init: function() {
-        alert('Name is ' + this.get('name'));
+    const Person = Ember.Object.extend({
+      init() {
+        alert(`Name is ${this.get('name')}`);
       }
     });
 
-    var steve = App.Person.create({
+    let steve = Person.create({
       name: "Steve"
     });
 
@@ -262,46 +262,50 @@ CoreObject.PrototypeMixin = Mixin.create({
     property and a normal one:
 
     ```javascript
-    App.BarView = Ember.View.extend({
+    const Bar = Ember.Object.extend({
+      // Configure which properties to concatenate
+      concatenatedProperties: ['concatenatedProperty'],
+
       someNonConcatenatedProperty: ['bar'],
-      classNames: ['bar']
+      concatenatedProperty: ['bar']
     });
 
-    App.FooBarView = App.BarView.extend({
+    const FooBar = Bar.extend({
       someNonConcatenatedProperty: ['foo'],
-      classNames: ['foo']
+      concatenatedProperty: ['foo']
     });
 
-    var fooBarView = App.FooBarView.create();
-    fooBarView.get('someNonConcatenatedProperty'); // ['foo']
-    fooBarView.get('classNames'); // ['ember-view', 'bar', 'foo']
+    let fooBar = FooBar.create();
+    fooBar.get('someNonConcatenatedProperty'); // ['foo']
+    fooBar.get('concatenatedProperty'); // ['bar', 'foo']
     ```
 
     This behavior extends to object creation as well. Continuing the
     above example:
 
     ```javascript
-    var view = App.FooBarView.create({
+    let fooBar = FooBar.create({
       someNonConcatenatedProperty: ['baz'],
-      classNames: ['baz']
+      concatenatedProperty: ['baz']
     })
-    view.get('someNonConcatenatedProperty'); // ['baz']
-    view.get('classNames'); // ['ember-view', 'bar', 'foo', 'baz']
+    fooBar.get('someNonConcatenatedProperty'); // ['baz']
+    fooBar.get('concatenatedProperty'); // ['bar', 'foo', 'baz']
     ```
+
     Adding a single property that is not an array will just add it in the array:
 
     ```javascript
-    var view = App.FooBarView.create({
-      classNames: 'baz'
+    let fooBar = FooBar.create({
+      concatenatedProperty: 'baz'
     })
-    view.get('classNames'); // ['ember-view', 'bar', 'foo', 'baz']
+    view.get('concatenatedProperty'); // ['bar', 'foo', 'baz']
     ```
 
     Using the `concatenatedProperties` property, we can tell Ember to mix the
     content of the properties.
 
-    In `Ember.View` the `classNameBindings` and `attributeBindings` properties
-    are also concatenated, in addition to `classNames`.
+    In `Ember.Component` the `classNames`, `classNameBindings` and
+    `attributeBindings` properties are concatenated.
 
     This feature is available for you to use throughout the Ember object model,
     although typical app developers are likely to use it infrequently. Since
@@ -331,34 +335,37 @@ CoreObject.PrototypeMixin = Mixin.create({
     property and a normal one:
 
     ```javascript
-    App.BarRoute = Ember.Route.extend({
+    const Bar = Ember.Object.extend({
+      // Configure which properties are to be merged
+      mergedProperties: ['mergedProperty'],
+
       someNonMergedProperty: {
         nonMerged: 'superclass value of nonMerged'
       },
-      queryParams: {
+      mergedProperty: {
         page: {replace: false},
         limit: {replace: true}
       }
     });
 
-    App.FooBarRoute = App.BarRoute.extend({
+    const FooBar = Bar.extend({
       someNonMergedProperty: {
         completelyNonMerged: 'subclass value of nonMerged'
       },
-      queryParams: {
+      mergedProperty: {
         limit: {replace: false}
       }
     });
 
-    var fooBarRoute = App.FooBarRoute.create();
+    let fooBar = FooBar.create();
 
-    fooBarRoute.get('someNonMergedProperty');
+    fooBar.get('someNonMergedProperty');
     // => { completelyNonMerged: 'subclass value of nonMerged' }
     //
     // Note the entire object, including the nonMerged property of
     // the superclass object, has been replaced
 
-    fooBarRoute.get('queryParams');
+    fooBar.get('mergedProperty');
     // => {
     //   page: {replace: false},
     //   limit: {replace: false}
@@ -371,6 +378,8 @@ CoreObject.PrototypeMixin = Mixin.create({
 
     This behavior is not available during object `create` calls. It is only
     available at `extend` time.
+
+    In `Ember.Route` the `queryParams` property is merged.
 
     This feature is available for you to use throughout the Ember object model,
     although typical app developers are likely to use it infrequently. Since
@@ -465,31 +474,31 @@ CoreObject.PrototypeMixin = Mixin.create({
     objects.
 
     ```javascript
-    App.Person = Em.Object.extend()
-    person = App.Person.create()
-    person.toString() //=> "<App.Person:ember1024>"
+    const Person = Ember.Object.extend()
+    person = Person.create()
+    person.toString() //=> "<Person:ember1024>"
     ```
 
     If the object's class is not defined on an Ember namespace, it will
     indicate it is a subclass of the registered superclass:
 
    ```javascript
-    Student = App.Person.extend()
-    student = Student.create()
-    student.toString() //=> "<(subclass of App.Person):ember1025>"
+    const Student = Person.extend()
+    let student = Student.create()
+    student.toString() //=> "<(subclass of Person):ember1025>"
     ```
 
     If the method `toStringExtension` is defined, its return value will be
     included in the output.
 
     ```javascript
-    App.Teacher = App.Person.extend({
-      toStringExtension: function() {
+    const Teacher = Person.extend({
+      toStringExtension() {
         return this.get('fullName');
       }
     });
-    teacher = App.Teacher.create()
-    teacher.toString(); //=> "<App.Teacher:ember1026:Tom Dale>"
+    teacher = Teacher.create()
+    teacher.toString(); //=> "<Teacher:ember1026:Tom Dale>"
     ```
 
     @method toString
@@ -523,20 +532,20 @@ var ClassMixinProps = {
     Creates a new subclass.
 
     ```javascript
-    App.Person = Ember.Object.extend({
-      say: function(thing) {
+    const Person = Ember.Object.extend({
+      say(thing) {
         alert(thing);
        }
     });
     ```
 
-    This defines a new subclass of Ember.Object: `App.Person`. It contains one method: `say()`.
+    This defines a new subclass of Ember.Object: `Person`. It contains one method: `say()`.
 
     You can also create a subclass from any existing class by calling its `extend()` method.
-    For example, you might want to create a subclass of Ember's built-in `Ember.View` class:
+    For example, you might want to create a subclass of Ember's built-in `Ember.Component` class:
 
     ```javascript
-    App.PersonView = Ember.View.extend({
+    const PersonComponent = Ember.Component.extend({
       tagName: 'li',
       classNameBindings: ['isAdministrator']
     });
@@ -546,56 +555,56 @@ var ClassMixinProps = {
     implementation of your parent class by calling the special `_super()` method:
 
     ```javascript
-    App.Person = Ember.Object.extend({
-      say: function(thing) {
+    const Person = Ember.Object.extend({
+      say(thing) {
         var name = this.get('name');
-        alert(name + ' says: ' + thing);
+        alert(`${name} says: ${thing}`);
       }
     });
 
-    App.Soldier = App.Person.extend({
-      say: function(thing) {
-        this._super(thing + ", sir!");
+    const Soldier = Person.extend({
+      say(thing) {
+        this._super(`${thing}, sir!`);
       },
-      march: function(numberOfHours) {
-        alert(this.get('name') + ' marches for ' + numberOfHours + ' hours.');
+      march(numberOfHours) {
+        alert(`${this.get('name')} marches for ${numberOfHours} hours.`);
       }
     });
 
-    var yehuda = App.Soldier.create({
+    let yehuda = Soldier.create({
       name: "Yehuda Katz"
     });
 
     yehuda.say("Yes");  // alerts "Yehuda Katz says: Yes, sir!"
     ```
 
-    The `create()` on line #17 creates an *instance* of the `App.Soldier` class.
-    The `extend()` on line #8 creates a *subclass* of `App.Person`. Any instance
-    of the `App.Person` class will *not* have the `march()` method.
+    The `create()` on line #17 creates an *instance* of the `Soldier` class.
+    The `extend()` on line #8 creates a *subclass* of `Person`. Any instance
+    of the `Person` class will *not* have the `march()` method.
 
     You can also pass `Mixin` classes to add additional properties to the subclass.
 
     ```javascript
-    App.Person = Ember.Object.extend({
-      say: function(thing) {
-        alert(this.get('name') + ' says: ' + thing);
+    const Person = Ember.Object.extend({
+      say(thing) {
+        alert(`${this.get('name')} says: ${thing}`);
       }
     });
 
-    App.SingingMixin = Mixin.create({
-      sing: function(thing){
-        alert(this.get('name') + ' sings: la la la ' + thing);
+    const SingingMixin = Mixin.create({
+      sing(thing){
+        alert(`${this.get('name')} sings: la la la ${thing}`);
       }
     });
 
-    App.BroadwayStar = App.Person.extend(App.SingingMixin, {
-      dance: function() {
-        alert(this.get('name') + ' dances: tap tap tap tap ');
+    const BroadwayStar = Person.extend(SingingMixin, {
+      dance() {
+        alert(`${this.get('name')} dances: tap tap tap tap `);
       }
     });
     ```
 
-    The `App.BroadwayStar` class contains three methods: `say()`, `sing()`, and `dance()`.
+    The `BroadwayStar` class contains three methods: `say()`, `sing()`, and `dance()`.
 
     @method extend
     @static
@@ -632,13 +641,13 @@ var ClassMixinProps = {
     containing values to initialize the newly instantiated object with.
 
     ```javascript
-    App.Person = Ember.Object.extend({
-      helloWorld: function() {
-        alert("Hi, my name is " + this.get('name'));
+    const Person = Ember.Object.extend({
+      helloWorld() {
+        alert(`Hi, my name is ${this.get('name')}`);
       }
     });
 
-    var tom = App.Person.create({
+    let tom = Person.create({
       name: 'Tom Dale'
     });
 
@@ -652,7 +661,7 @@ var ClassMixinProps = {
     instance during initialization:
 
     ```javascript
-    var noName = App.Person.create();
+    let noName = Person.create();
     noName.helloWorld(); // alerts undefined
     ```
 
@@ -678,7 +687,7 @@ var ClassMixinProps = {
     properties and functions:
 
     ```javascript
-    MyObject = Ember.Object.extend({
+    const MyObject = Ember.Object.extend({
       name: 'an object'
     });
 
@@ -686,7 +695,7 @@ var ClassMixinProps = {
     o.get('name'); // 'an object'
 
     MyObject.reopen({
-      say: function(msg){
+      say(msg){
         console.log(msg);
       }
     })
@@ -713,7 +722,7 @@ var ClassMixinProps = {
     Augments a constructor's own properties and functions:
 
     ```javascript
-    MyObject = Ember.Object.extend({
+    const MyObject = Ember.Object.extend({
       name: 'an object'
     });
 
@@ -729,34 +738,34 @@ var ClassMixinProps = {
     These are only available on the class and not on any instance of that class.
 
     ```javascript
-    App.Person = Ember.Object.extend({
-      name : "",
-      sayHello : function() {
+    const Person = Ember.Object.extend({
+      name: "",
+      sayHello() {
         alert("Hello. My name is " + this.get('name'));
       }
     });
 
-    App.Person.reopenClass({
-      species : "Homo sapiens",
-      createPerson: function(newPersonsName){
-        return App.Person.create({
+    Person.reopenClass({
+      species: "Homo sapiens",
+      createPerson(newPersonsName){
+        return Person.create({
           name:newPersonsName
         });
       }
     });
 
-    var tom = App.Person.create({
-      name : "Tom Dale"
+    let tom = Person.create({
+      name: "Tom Dale"
     });
-    var yehuda = App.Person.createPerson("Yehuda Katz");
+    let yehuda = Person.createPerson("Yehuda Katz");
 
     tom.sayHello(); // "Hello. My name is Tom Dale"
     yehuda.sayHello(); // "Hello. My name is Yehuda Katz"
-    alert(App.Person.species); // "Homo sapiens"
+    alert(Person.species); // "Homo sapiens"
     ```
 
     Note that `species` and `createPerson` are *not* valid on the `tom` and `yehuda`
-    variables. They are only valid on `App.Person`.
+    variables. They are only valid on `Person`.
 
     To add functions and properties to instances of
     a constructor by extending the constructor's prototype
@@ -793,10 +802,10 @@ var ClassMixinProps = {
     You can pass a hash of these values to a computed property like this:
 
     ```javascript
-    person: function() {
+    person: Ember.computed(function() {
       var personId = this.get('personId');
-      return App.Person.create({ id: personId });
-    }.property().meta({ type: App.Person })
+      return Person.create({ id: personId });
+    }).meta({ type: Person })
     ```
 
     Once you've done this, you can retrieve the values saved to the computed

--- a/packages/ember-views/lib/mixins/class_names_support.js
+++ b/packages/ember-views/lib/mixins/class_names_support.js
@@ -47,7 +47,7 @@ export default Mixin.create({
 
     ```javascript
     // Applies the 'high' class to the view element
-    Ember.View.extend({
+    Ember.Component.extend({
       classNameBindings: ['priority'],
       priority: 'high'
     });
@@ -58,7 +58,7 @@ export default Mixin.create({
 
     ```javascript
     // Applies the 'is-urgent' class to the view element
-    Ember.View.extend({
+    Ember.Component.extend({
       classNameBindings: ['isUrgent'],
       isUrgent: true
     });
@@ -69,13 +69,13 @@ export default Mixin.create({
 
     ```javascript
     // Applies the 'urgent' class to the view element
-    Ember.View.extend({
+    Ember.Component.extend({
       classNameBindings: ['isUrgent:urgent'],
       isUrgent: true
     });
     ```
 
-    This list of properties is inherited from the view's superclasses as well.
+    This list of properties is inherited from the component's superclasses as well.
 
     @property classNameBindings
     @type Array

--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -9,16 +9,16 @@ import { cloneStates, states } from './states';
 
 /**
   `Ember.CoreView` is an abstract class that exists to give view-like behavior
-  to both Ember's main view class `Ember.View` and other classes that don't need
-  the fully functionaltiy of `Ember.View`.
+  to both Ember's main view class `Ember.Component` and other classes that don't need
+  the fully functionaltiy of `Ember.Component`.
 
-  Unless you have specific needs for `CoreView`, you will use `Ember.View`
+  Unless you have specific needs for `CoreView`, you will use `Ember.Component`
   in your applications.
 
   @class CoreView
   @namespace Ember
   @extends Ember.Object
-  @deprecated Use `Ember.View` instead.
+  @deprecated Use `Ember.Component` instead.
   @uses Ember.Evented
   @uses Ember.ActionHandler
   @private


### PR DESCRIPTION
Across the codebase we still reference `Ember.View` in docs, even in places unrelated to views like the object model documentation. Clean this stuff up.
