### PR TITLE
[BUGFIX beta] Check state of router during transition

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1067,7 +1067,10 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
   */
   transitionTo(name, context) {
     let router = this.router;
-    return router.transitionTo(...prefixRouteNameArg(this, arguments));
+    if (router.router.oldState) {
+      return router.transitionTo(...prefixRouteNameArg(this, arguments));
+    }
+    return router.replaceWith(...prefixRouteNameArg(this, arguments));
   },
 
   /**
@@ -1151,6 +1154,9 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
   */
   replaceWith() {
     let router = this.router;
+    if (router.router.oldState) {
+      return router.transitionTo(...prefixRouteNameArg(this, arguments));
+    }
     return router.replaceWith(...prefixRouteNameArg(this, arguments));
   },
 


### PR DESCRIPTION
Currently, during transitions, the state of the router is not taken into
consideration. This change makes sure that both `transitionTo()` and
`replaceWith()` examine the state of the router and uses that information
to choose the appropriate method.

If there has never been a transition since the app loaded, `replaceWith()`
will be used. If there's been a transition already `transitionTo()` will
be used instead. Regardless of which method the  developer used.

Special thanks to @alexspeller. In so many ways this work belongs to him.
