### PR TITLE
Temporary fix for `{{action` usage in Fastboot.

### DIFF
--- a/packages/ember-glimmer/lib/modifiers/action.js
+++ b/packages/ember-glimmer/lib/modifiers/action.js
@@ -1,3 +1,4 @@
+import { environment } from 'ember-environment';
 import {
   assert,
   run,
@@ -168,6 +169,10 @@ export class ActionState {
 // implements ModifierManager<Action>
 export default class ActionModifierManager {
   install(element, args, dom, dynamicScope) {
+    if (!environment.hasDOM) {
+      return;
+    }
+
     let { named, positional } = args;
     let implicitTarget;
     let actionName;
@@ -213,6 +218,10 @@ export default class ActionModifierManager {
   }
 
   update(modifier, element, args, dom, dynamicScope) {
+    if (!environment.hasDOM) {
+      return;
+    }
+
     let { positional } = args;
 
     let actionNameRef = positional.at(1);

--- a/tests/node/app-boot-test.js
+++ b/tests/node/app-boot-test.js
@@ -101,3 +101,14 @@ QUnit.test("lifecycle hooks disabled", function(assert) {
 
   return this.renderToHTML('/');
 });
+
+QUnit.test("Should not attempt to render element modifiers GH#14220", function(assert) {
+  assert.expect(1);
+
+  this.template('application', "<div {{action 'foo'}}></div>");
+
+  return this.renderToHTML('/')
+    .then(function(html) {
+      assertHTMLMatches(html, '<body><div id="EMBER_ID" class="ember-view"><div></div></div></body>');
+    });
+});


### PR DESCRIPTION
This is a temporary fix to prevent errors when using `<div {{action 'foo'}}></div>` in FastBoot.

The longer term fix would be to implement the concept of a `ModifierManager` (roughly in the same vain as `ComponentManager`) that has hooks and can make the determination of when to fire `install` / `update` on the underlying modifier.

Addresses #14220.
