### PR TITLE
Ensure `_Ember.FEATURES` is setup for template compiler.

### DIFF
--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -1,4 +1,4 @@
-import { context, ENV } from 'ember-environment';
+import { context } from 'ember-environment';
 
 /**
 @module ember
@@ -24,7 +24,6 @@ const Ember = (typeof context.imports.Ember === 'object' && context.imports.Embe
 
 // Make sure these are set whether Ember was already defined or not
 Ember.isNamespace = true;
-Ember.ENV = ENV;
 Ember.toString = function() { return 'Ember'; };
 
 // ..........................................................

--- a/packages/ember-template-compiler/lib/index.js
+++ b/packages/ember-template-compiler/lib/index.js
@@ -1,6 +1,16 @@
 import 'container';
 
-export { default as _Ember } from 'ember-metal'; // Is this still needed
+import _Ember, { FEATURES } from 'ember-metal';
+import { ENV } from 'ember-environment';
+import VERSION from 'ember/version';
+
+// private API used by ember-cli-htmlbars to setup ENV and FEATURES
+if (!_Ember.ENV) { _Ember.ENV = ENV; }
+if (!_Ember.FEATURES) { _Ember.FEATURES = FEATURES; }
+if (!_Ember.VERSION) { _Ember.VERSION = VERSION; }
+
+export { _Ember };
+
 export { default as precompile } from './system/precompile';
 export { default as compile } from './system/compile';
 export {

--- a/tests/node/template-compiler-test.js
+++ b/tests/node/template-compiler-test.js
@@ -9,14 +9,11 @@ var templateCompilerPath = path.join(distPath, 'ember-template-compiler');
 var module = QUnit.module;
 var test = QUnit.test;
 
-var distPath = path.join(__dirname, '../../dist');
-var templateCompiler = require(path.join(distPath, 'ember-template-compiler'));
-
 var compile;
 
 module('ember-template-compiler.js', {
   setup: function() {
-    compile = require(templateCompilerPath).compile;
+    templateCompiler = require(templateCompilerPath);
   },
 
   teardown: function() {
@@ -28,4 +25,18 @@ module('ember-template-compiler.js', {
 test('can be required', function(assert) {
   assert.ok(typeof templateCompiler.precompile === 'function', 'precompile function is present');
   assert.ok(typeof templateCompiler.compile === 'function', 'compile function is present');
+});
+
+test('can access _Ember.ENV (private API used by ember-cli-htmlbars)', function(assert) {
+  assert.equal(typeof templateCompiler._Ember.ENV, 'object', '_Ember.ENV is present');
+  assert.notEqual(typeof templateCompiler._Ember.ENV, null, '_Ember.ENV is not null');
+});
+
+test('can access _Ember.FEATURES (private API used by ember-cli-htmlbars)', function(assert) {
+  assert.equal(typeof templateCompiler._Ember.FEATURES, 'object', '_Ember.FEATURES is present');
+  assert.notEqual(typeof templateCompiler._Ember.FEATURES, null, '_Ember.FEATURES is not null');
+});
+
+test('can access _Ember.VERSION (private API used by ember-cli-htmlbars)', function(assert) {
+  assert.equal(typeof templateCompiler._Ember.VERSION, 'string', '_Ember.VERSION is present');
 });


### PR DESCRIPTION
`_Ember.FEATURES` and `_Ember.ENV` are required by ember-cli-htmlbars (though a future refactor should allow that to remove this requirement).

Fixes #14218.
