### PR TITLE
[BUGFIX beta] Fix issue with IE9 compatibility.

### DIFF
--- a/packages/ember-routing/lib/location/auto_location.js
+++ b/packages/ember-routing/lib/location/auto_location.js
@@ -70,9 +70,9 @@ export default EmberObject.extend({
 
    @since 1.11
    @property global
-   @default environment.global
+   @default window
   */
-  global: environment.global,
+  global: environment.window,
 
   /**
     @private

--- a/packages/ember-routing/tests/location/auto_location_test.js
+++ b/packages/ember-routing/tests/location/auto_location_test.js
@@ -1,3 +1,4 @@
+import { environment } from 'ember-environment';
 import { get, run, assign } from 'ember-metal';
 import AutoLocation from '../../location/auto_location';
 import {
@@ -58,6 +59,13 @@ QUnit.module('Ember.AutoLocation', {
       run(location, 'destroy');
     }
   }
+});
+
+QUnit.test('AutoLocation should have the `global`', function(assert) {
+  let location = AutoLocation.create();
+
+  assert.ok(location.global, 'has a global defined');
+  assert.strictEqual(location.global, environment.window, 'has the environments window global');
 });
 
 QUnit.test('AutoLocation should return concrete implementation\'s value for `getURL`', function() {


### PR DESCRIPTION
A past refactor left `AutoLocation` in a broken state under IE9. This fixes that error and adds a (somewhat silly) test.

Fixes #14006.
