### PR TITLE
Add failing test for appendTo while rendering

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/append-test.js
+++ b/packages/ember-glimmer/tests/integration/components/append-test.js
@@ -251,6 +251,41 @@ moduleFor('appendTo: an element', class extends AbstractAppendTest {
 
 });
 
+moduleFor('appendTo: with multiple components', class extends AbstractAppendTest {
+
+  append(component) {
+    this.runTask(() => component.appendTo('#qunit-fixture'));
+    this.didAppend(component);
+    return jQuery('#qunit-fixture')[0];
+  }
+
+  ['@test can appendTo while rendering'](assert) {
+    assert.expect(0);
+
+    let owner = this.owner;
+
+    this.registerComponent('first-component', {
+      ComponentClass: Component.extend({
+        layoutName: 'components/component-one',
+
+        didInsertElement() {
+          let SecondComponent = owner._lookupFactory('component:second-component');
+          SecondComponent.create().appendTo('#qunit-fixture');
+        }
+      })
+    });
+
+    this.registerComponent('second-component', {
+      ComponentClass: Component.extend()
+    });
+
+    let FirstComponent = this.owner._lookupFactory('component:first-component');
+
+    this.append(FirstComponent.create());
+  }
+
+});
+
 moduleFor('renderToElement: no arguments (defaults to a body context)', class extends AbstractAppendTest {
 
   append(component) {


### PR DESCRIPTION
@rwjblue Here is a failing test for the behavior I'm seeing in https://github.com/mitchlloyd/ember-islands/pull/29 where `Renderer.commit()` is being called twice in a row and throwing an error.
