### PR TITLE
Fix non-interactive (FastBoot) hooks, and get them tested.

### DIFF
--- a/packages/ember-glimmer/lib/renderer.js
+++ b/packages/ember-glimmer/lib/renderer.js
@@ -216,7 +216,10 @@ export class Renderer {
     view._transitionTo('destroying');
 
     view.element = null;
-    view.trigger('didDestroyElement');
+
+    if (this._env.isInteractive) {
+      view.trigger('didDestroyElement');
+    }
 
     this.cleanupRootFor(view);
 

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -20,7 +20,6 @@ import {
   privatize as P,
   OWNER
 } from 'container';
-import { environment } from 'ember-environment';
 
 const DEFAULT_LAYOUT = P`template:components/-default`;
 
@@ -145,8 +144,10 @@ class ComponentStateBucket {
   destroy() {
     let { component, environment } = this;
 
-    component.trigger('willDestroyElement');
-    component.trigger('willClearRender');
+    if (environment.isInteractive) {
+      component.trigger('willDestroyElement');
+      component.trigger('willClearRender');
+    }
 
     environment.destroyedComponents.push(component);
   }
@@ -226,7 +227,7 @@ class CurlyComponentManager {
     component.trigger('didInitAttrs', { attrs });
     component.trigger('didReceiveAttrs', { newAttrs: attrs });
 
-    if (environment.hasDOM) {
+    if (environment.isInteractive) {
       component.trigger('willInsertElement');
     }
 
@@ -312,8 +313,8 @@ class CurlyComponentManager {
     return component[DIRTY_TAG];
   }
 
-  didCreate({ component }) {
-    if (environment.hasDOM) {
+  didCreate({ component, environment }) {
+    if (environment.isInteractive) {
       component.trigger('didInsertElement');
       component.trigger('didRender');
       component._transitionTo('inDOM');
@@ -349,9 +350,11 @@ class CurlyComponentManager {
     bucket.finalize();
   }
 
-  didUpdate({ component }) {
-    component.trigger('didUpdate');
-    component.trigger('didRender');
+  didUpdate({ component, environment }) {
+    if (environment.isInteractive) {
+      component.trigger('didUpdate');
+      component.trigger('didRender');
+    }
   }
 
   getDestructor(stateBucket) {
@@ -371,7 +374,11 @@ class TopComponentManager extends CurlyComponentManager {
 
     component.trigger('didInitAttrs');
     component.trigger('didReceiveAttrs');
-    component.trigger('willInsertElement');
+
+    if (environment.isInteractive) {
+      component.trigger('willInsertElement');
+    }
+
     component.trigger('willRender');
 
     processComponentInitializationAssertions(component, {});

--- a/packages/ember-glimmer/tests/utils/abstract-test-case.js
+++ b/packages/ember-glimmer/tests/utils/abstract-test-case.js
@@ -293,7 +293,11 @@ export class AbstractApplicationTest extends TestCase {
 export class AbstractRenderingTest extends TestCase {
   constructor() {
     super();
-    let owner = this.owner = buildOwner(this.getOwnerOptions(), this.getResolver());
+    let owner = this.owner = buildOwner({
+      ownerOptions: this.getOwnerOptions(),
+      bootOptions: this.getBootOptions(),
+      resolver: this.getResolver()
+    });
 
     this.renderer = this.owner.lookup('renderer:-dom');
     this.element = jQuery('#qunit-fixture')[0];
@@ -312,10 +316,8 @@ export class AbstractRenderingTest extends TestCase {
     return {};
   }
 
-  getOwnerOptions() {
-    return {};
-  }
-
+  getOwnerOptions() { }
+  getBootOptions() { }
   getResolver() { }
 
   teardown() {

--- a/packages/ember-routing/tests/system/dsl_test.js
+++ b/packages/ember-routing/tests/system/dsl_test.js
@@ -167,7 +167,7 @@ QUnit.test('should allow mounting of engines', function(assert) {
   });
 
   let engineInstance = buildOwner({
-    routable: true
+    ownerOptions: { routable: true }
   });
 
   let router = Router.create();
@@ -191,7 +191,7 @@ QUnit.test('should allow mounting of engines at a custom path', function(assert)
   });
 
   let engineInstance = buildOwner({
-    routable: true
+    ownerOptions: { routable: true }
   });
 
   let router = Router.create();
@@ -219,7 +219,7 @@ QUnit.test('should allow aliasing of engine names with `as`', function(assert) {
   });
 
   let engineInstance = buildOwner({
-    routable: true
+    ownerOptions: { routable: true }
   });
 
   let router = Router.create();
@@ -241,7 +241,7 @@ QUnit.test('should add loading and error routes to a mount if _isRouterMapResult
   });
 
   let engineInstance = buildOwner({
-    routable: true
+    ownerOptions: { routable: true }
   });
 
   let router = Router.create({
@@ -261,7 +261,7 @@ QUnit.test('should add loading and error routes to a mount alias if _isRouterMap
   });
 
   let engineInstance = buildOwner({
-    routable: true
+    ownerOptions: { routable: true }
   });
 
   let router = Router.create({
@@ -281,7 +281,7 @@ QUnit.test('should not add loading and error routes to a mount if _isRouterMapRe
   });
 
   let engineInstance = buildOwner({
-    routable: true
+    ownerOptions: { routable: true }
   });
 
   let router = Router.create();
@@ -302,7 +302,7 @@ QUnit.test('should reset namespace of loading and error routes for mounts with r
   });
 
   let engineInstance = buildOwner({
-    routable: true
+    ownerOptions: { routable: true }
   });
 
   let router = Router.create({

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -35,14 +35,16 @@ QUnit.test('default store utilizes the container to acquire the model factory', 
   });
 
   setOwner(route, buildOwner({
-    hasRegistration() {
-      return true;
-    },
+    ownerOptions: {
+      hasRegistration() {
+        return true;
+      },
 
-    _lookupFactory(fullName) {
-      equal(fullName, 'model:post', 'correct factory was looked up');
+      _lookupFactory(fullName) {
+        equal(fullName, 'model:post', 'correct factory was looked up');
 
-      return Post;
+        return Post;
+      }
     }
   }));
 
@@ -344,15 +346,17 @@ QUnit.test('paramsFor considers an engine\'s mountPoint', function(assert) {
   };
 
   let engineInstance = buildOwner({
-    routable: true,
+    ownerOptions: {
+      routable: true,
 
-    mountPoint: 'foo.bar',
+      mountPoint: 'foo.bar',
 
-    lookup(name) {
-      if (name === 'route:posts') {
-        return postsRoute;
-      } else if (name === 'route:application') {
-        return applicationRoute;
+      lookup(name) {
+        if (name === 'route:posts') {
+          return postsRoute;
+        } else if (name === 'route:application') {
+          return applicationRoute;
+        }
       }
     }
   });
@@ -387,15 +391,17 @@ QUnit.test('modelFor considers an engine\'s mountPoint', function() {
   };
 
   let engineInstance = buildOwner({
-    routable: true,
+    ownerOptions: {
+      routable: true,
 
-    mountPoint: 'foo.bar',
+      mountPoint: 'foo.bar',
 
-    lookup(name) {
-      if (name === 'route:posts') {
-        return postsRoute;
-      } else if (name === 'route:application') {
-        return applicationRoute;
+      lookup(name) {
+        if (name === 'route:posts') {
+          return postsRoute;
+        } else if (name === 'route:application') {
+          return applicationRoute;
+        }
       }
     }
   });

--- a/packages/internal-test-helpers/lib/index.js
+++ b/packages/internal-test-helpers/lib/index.js
@@ -24,8 +24,11 @@ import {
 
 import require from 'require';
 
-export function buildOwner(_createOptions, resolver) {
-  let createOptions = _createOptions || {};
+export function buildOwner(options = {}) {
+  let ownerOptions = options.ownerOptions || {};
+  let resolver = options.resolver;
+  let bootOptions = options.bootOptions || {};
+
   let Owner = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixin);
 
   let namespace = EmberObject.create({
@@ -39,12 +42,12 @@ export function buildOwner(_createOptions, resolver) {
     fallback: fallbackRegistry
   });
 
-  ApplicationInstance.setupRegistry(registry);
+  ApplicationInstance.setupRegistry(registry, bootOptions);
 
   let owner = Owner.create({
     __registry__: registry,
     __container__: null
-  }, createOptions);
+  }, ownerOptions);
 
   let container = registry.container({ owner: owner });
   owner.__container__ = container;


### PR DESCRIPTION
This refactors the lifecycle hook tests and fixes `CurlyComponentManager` to ensure that the hooks are fired correctly.

The following hooks are fired in all modes:
- `init`
- `didReceiveAttrs`
- `willRender`
- `didUpdateAttrs`
- `willUpdate`
- `willDestroy`

The following hooks are fired in interactive mode only:
- `didInsertElement`
- `didRender`
- `didUpdate`
- `willDestroyElement`
- `willClearRender`
