### PR TITLE
[BUGFIX release] Ensure Engine Routes are deactivated before destruction

### DIFF
--- a/packages/ember-glimmer/tests/integration/application/engine-test.js
+++ b/packages/ember-glimmer/tests/integration/application/engine-test.js
@@ -227,4 +227,27 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
       ], 'the expected hooks were fired');
     });
   }
+
+  ['@test deactivate should be called on Engine Routes before destruction'](assert) {
+    assert.expect(3);
+
+    this.setupAppAndRoutableEngine();
+
+    this.registerEngine('blog', Engine.extend({
+      init() {
+        this._super(...arguments);
+        this.register('template:application', compile('Engine{{outlet}}'));
+        this.register('route:application', Route.extend({
+          deactivate() {
+            assert.notOk(this.isDestroyed, 'Route is not destroyed');
+            assert.notOk(this.isDestroying, 'Route is not being destroyed');
+          }
+        }));
+      }
+    }));
+
+    return this.visit('/blog').then(() => {
+      this.assertText('ApplicationEngine');
+    });
+  }
 });

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -452,20 +452,21 @@ const EmberRouter = EmberObject.extend(Evented, {
   },
 
   willDestroy() {
+    if (this._toplevelView) {
+      this._toplevelView.destroy();
+      this._toplevelView = null;
+    }
+
+    this._super(...arguments);
+
+    this.reset();
+
     let instances = this._engineInstances;
     for (let name in instances) {
       for (let id in instances[name]) {
         run(instances[name][id], 'destroy');
       }
     }
-
-    if (this._toplevelView) {
-      this._toplevelView.destroy();
-      this._toplevelView = null;
-    }
-    this._super(...arguments);
-
-    this.reset();
   },
 
   /*


### PR DESCRIPTION
Makes tests fail to reproduce #14234.

Causes some existing tests to fail, though I can add a totally separate tests for this if needed.
