### PR TITLE
[BUGFIX beta] Ensure roots added during rendering work properly.

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/append-test.js
+++ b/packages/ember-glimmer/tests/integration/components/append-test.js
@@ -251,6 +251,41 @@ moduleFor('appendTo: an element', class extends AbstractAppendTest {
 
 });
 
+moduleFor('appendTo: with multiple components', class extends AbstractAppendTest {
+
+  append(component) {
+    this.runTask(() => component.appendTo('#qunit-fixture'));
+    this.didAppend(component);
+    return jQuery('#qunit-fixture')[0];
+  }
+
+  ['@test can appendTo while rendering'](assert) {
+    assert.expect(0);
+
+    let owner = this.owner;
+
+    this.registerComponent('first-component', {
+      ComponentClass: Component.extend({
+        layoutName: 'components/component-one',
+
+        didInsertElement() {
+          let SecondComponent = owner._lookupFactory('component:second-component');
+          SecondComponent.create().appendTo('#qunit-fixture');
+        }
+      })
+    });
+
+    this.registerComponent('second-component', {
+      ComponentClass: Component.extend()
+    });
+
+    let FirstComponent = this.owner._lookupFactory('component:first-component');
+
+    this.append(FirstComponent.create());
+  }
+
+});
+
 moduleFor('renderToElement: no arguments (defaults to a body context)', class extends AbstractAppendTest {
 
   append(component) {


### PR DESCRIPTION
When a new root is added during the rendering process (i.e. from `didInsertElement` of one component you `.appendTo` another one), we need to:

1) Ensure that we do not initiate a new transaction (`env.begin()` / `env.commit()`)
2) Ensure that we trigger _renderRoots again if roots were added. This ensures the new roots are properly rendered.

Addresses issue reported in https://github.com/mitchlloyd/ember-islands/pull/29#issuecomment-245484407.
Closes #14230
Fixes https://github.com/emberjs/ember.js/issues/14287
