### PR TITLE
[BUGFIX beta] Ensure params and hash are frozen in debug builds.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -186,8 +186,8 @@ function babelConfigFor(environment) {
   if (isProduction) {
     includeDevHelpers = false;
     plugins.push(filterImports({
-      'ember-metal/debug': ['assert', 'debug', 'deprecate', 'info', 'runInDebug', 'warn', 'debugSeal'],
-      'ember-metal': ['assert', 'debug', 'deprecate', 'info', 'runInDebug', 'warn', 'debugSeal']
+      'ember-metal/debug': ['assert', 'debug', 'deprecate', 'info', 'runInDebug', 'warn', 'debugSeal', 'debugFreeze'],
+      'ember-metal': ['assert', 'debug', 'deprecate', 'info', 'runInDebug', 'warn', 'debugSeal', 'debugFreeze']
     }));
   }
 

--- a/packages/ember-debug/lib/index.js
+++ b/packages/ember-debug/lib/index.js
@@ -153,6 +153,10 @@ setDebugFunction('debugSeal', function debugSeal(obj) {
   Object.seal(obj);
 });
 
+setDebugFunction('debugFreeze', function debugFreeze(obj) {
+  Object.freeze(obj);
+});
+
 setDebugFunction('deprecate', _deprecate);
 
 setDebugFunction('warn', _warn);

--- a/packages/ember-glimmer/lib/utils/references.js
+++ b/packages/ember-glimmer/lib/utils/references.js
@@ -7,7 +7,8 @@ import {
   EmptyObject,
   meta as metaFor,
   watchKey,
-  isFeatureEnabled
+  isFeatureEnabled,
+  runInDebug
 } from 'ember-metal';
 import { CONSTANT_TAG, ConstReference, DirtyableTag, UpdatableTag, combine, isConst } from 'glimmer-reference';
 import { ConditionalReference as GlimmerConditionalReference, NULL_REFERENCE, UNDEFINED_REFERENCE } from 'glimmer-runtime';
@@ -276,7 +277,16 @@ export class SimpleHelperReference extends CachedReference {
   static create(helper, args) {
     if (isConst(args)) {
       let { positional, named } = args;
-      let result = helper(positional.value(), named.value());
+
+      let positionalValue = positional.value();
+      let namedValue = named.value();
+
+      runInDebug(() => {
+        Object.freeze(positionalValue);
+        Object.freeze(namedValue);
+      });
+
+      let result = helper(positionalValue, namedValue);
 
       if (result === null) {
         return NULL_REFERENCE;
@@ -302,7 +312,16 @@ export class SimpleHelperReference extends CachedReference {
 
   compute() {
     let { helper, args: { positional, named } } = this;
-    return helper(positional.value(), named.value());
+
+    let positionalValue = positional.value();
+    let namedValue = named.value();
+
+    runInDebug(() => {
+      Object.freeze(positionalValue);
+      Object.freeze(namedValue);
+    });
+
+    return helper(positionalValue, namedValue);
   }
 }
 
@@ -323,7 +342,16 @@ export class ClassBasedHelperReference extends CachedReference {
 
   compute() {
     let { instance, args: { positional, named } } = this;
-    return instance.compute(positional.value(), named.value());
+
+    let positionalValue = positional.value();
+    let namedValue = named.value();
+
+    runInDebug(() => {
+      Object.freeze(positionalValue);
+      Object.freeze(namedValue);
+    });
+
+    return instance.compute(positionalValue, namedValue);
   }
 }
 

--- a/packages/ember-metal/lib/debug.js
+++ b/packages/ember-metal/lib/debug.js
@@ -6,7 +6,8 @@ export let debugFunctions = {
   deprecate() {},
   deprecateFunc(...args) { return args[args.length - 1]; },
   runInDebug() {},
-  debugSeal() {}
+  debugSeal() {},
+  debugFreeze() {}
 };
 
 export function getDebugFunction(name) {
@@ -47,4 +48,8 @@ export function runInDebug() {
 
 export function debugSeal() {
   return debugFunctions.debugSeal.apply(undefined, arguments);
+}
+
+export function debugFreeze() {
+  return debugFunctions.debugFreeze.apply(undefined, arguments);
 }

--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -21,7 +21,9 @@ export {
   deprecateFunc,
   runInDebug,
   setDebugFunction,
-  getDebugFunction
+  getDebugFunction,
+  debugSeal,
+  debugFreeze
 } from './debug';
 export {
   instrument,


### PR DESCRIPTION
This ensures that `params` and `hash` are both ran through `Object.freeze` in debug builds, but tries to leave the codepaths as simple as possible so that when the `runInDebug`'s are removed the production code can be optimized the same way as prior to this change.

Closes #14189.
