### PR TITLE
[BUGFIX beta] Make `this.getAttr` an alias for `this.get`.

### DIFF
--- a/packages/ember-glimmer/lib/component.js
+++ b/packages/ember-glimmer/lib/component.js
@@ -4,8 +4,7 @@ import {
   ChildViewsSupport,
   ViewStateSupport,
   ViewMixin,
-  ActionSupport,
-  getAttrFor
+  ActionSupport
 } from 'ember-views';
 import { TargetActionSupport } from 'ember-runtime';
 import {
@@ -194,9 +193,7 @@ const Component = CoreView.extend(
 
     getAttr(key) {
       // TODO Intimate API should be deprecated
-      let attrs = this.attrs;
-      if (!attrs) { return; }
-      return getAttrFor(attrs, key);
+      return this.get(key);
     },
 
     /**

--- a/packages/ember-glimmer/lib/utils/process-args.js
+++ b/packages/ember-glimmer/lib/utils/process-args.js
@@ -64,10 +64,6 @@ class SimpleArgs {
   }
 }
 
-export function isCell(val) {
-  return val && val[MUTABLE_CELL];
-}
-
 const REF = symbol('REF');
 
 class MutableCell {

--- a/packages/ember-glimmer/tests/integration/components/attrs-lookup-test.js
+++ b/packages/ember-glimmer/tests/integration/components/attrs-lookup-test.js
@@ -127,7 +127,7 @@ moduleFor('Components test: attrs lookup', class extends RenderingTest {
   }
 
   ['@test getAttr() should return the same value as get()'](assert) {
-    assert.expect(18);
+    assert.expect(33);
 
     let instance;
     let FooBarComponent = Component.extend({
@@ -137,27 +137,39 @@ moduleFor('Components test: attrs lookup', class extends RenderingTest {
       },
 
       didReceiveAttrs() {
+        let rootFirstPositional = this.get('firstPositional');
         let rootFirst = this.get('first');
         let rootSecond = this.get('second');
+        let attrFirstPositional = this.getAttr('firstPositional');
         let attrFirst = this.getAttr('first');
         let attrSecond = this.getAttr('second');
 
+        equal(rootFirstPositional, attrFirstPositional, 'root property matches attrs value');
         equal(rootFirst, attrFirst, 'root property matches attrs value');
         equal(rootSecond, attrSecond, 'root property matches attrs value');
       }
     });
+
+    FooBarComponent.reopenClass({
+      positionalParams: ['firstPositional']
+    });
+
     this.registerComponent('foo-bar', { ComponentClass: FooBarComponent });
 
-    this.render(`{{foo-bar first=first second=second}}`, {
+    this.render(`{{foo-bar firstPositional first=first second=second}}`, {
+      firstPositional: 'firstPositional',
       first: 'first',
       second: 'second'
     });
 
+
+    assert.equal(instance.get('firstPositional'), 'firstPositional', 'matches known value');
     assert.equal(instance.get('first'), 'first', 'matches known value');
     assert.equal(instance.get('second'), 'second', 'matches known value');
 
     this.runTask(() => this.rerender());
 
+    assert.equal(instance.get('firstPositional'), 'firstPositional', 'matches known value');
     assert.equal(instance.get('first'), 'first', 'matches known value');
     assert.equal(instance.get('second'), 'second', 'matches known value');
 
@@ -165,6 +177,7 @@ moduleFor('Components test: attrs lookup', class extends RenderingTest {
       set(this.context, 'first', 'third');
     });
 
+    assert.equal(instance.get('firstPositional'), 'firstPositional', 'matches known value');
     assert.equal(instance.get('first'), 'third', 'matches known value');
     assert.equal(instance.get('second'), 'second', 'matches known value');
 
@@ -172,14 +185,25 @@ moduleFor('Components test: attrs lookup', class extends RenderingTest {
       set(this.context, 'second', 'fourth');
     });
 
+    assert.equal(instance.get('firstPositional'), 'firstPositional', 'matches known value');
     assert.equal(instance.get('first'), 'third', 'matches known value');
     assert.equal(instance.get('second'), 'fourth', 'matches known value');
 
     this.runTask(() => {
+      set(this.context, 'firstPositional', 'fifth');
+    });
+
+    assert.equal(instance.get('firstPositional'), 'fifth', 'matches known value');
+    assert.equal(instance.get('first'), 'third', 'matches known value');
+    assert.equal(instance.get('second'), 'fourth', 'matches known value');
+
+    this.runTask(() => {
+      set(this.context, 'firstPositional', 'firstPositional');
       set(this.context, 'first', 'first');
       set(this.context, 'second', 'second');
     });
 
+    assert.equal(instance.get('firstPositional'), 'firstPositional', 'matches known value');
     assert.equal(instance.get('first'), 'first', 'matches known value');
     assert.equal(instance.get('second'), 'second', 'matches known value');
   }

--- a/packages/ember-glimmer/tests/integration/components/closure-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/closure-components-test.js
@@ -632,12 +632,12 @@ moduleFor('Components test: closure components', class extends RenderingTest {
     });
 
     this.render(strip`
-      {{#with (hash my-component=(component 'my-component')) as |c|}}
+      {{#with (hash my-component=(component 'my-component' first)) as |c|}}
         {{c.my-component}}
-      {{/with}}`
+      {{/with}}`, { first: 'first' }
     );
 
-    assert.ok(isEmpty(value), 'value is an empty parameter');
+    assert.equal(value, 'first', 'value is the expected parameter');
   }
 
   ['@test renders with dot path and updates attributes'](assert) {

--- a/packages/ember-views/lib/compat/attrs.js
+++ b/packages/ember-views/lib/compat/attrs.js
@@ -1,12 +1,3 @@
 import {symbol } from 'ember-metal';
 
 export let MUTABLE_CELL = symbol('MUTABLE_CELL');
-
-function isCell(val) {
-  return val && val[MUTABLE_CELL];
-}
-
-export function getAttrFor(attrs, key) {
-  let val = attrs[key];
-  return isCell(val) ? val.value : val;
-}


### PR DESCRIPTION
Prior to this, using `this.getAttr` and `this.get` would differ for postional params of closure components.

Fixes #14080.
