### PR TITLE
[Failing Test Beta] {{attrs.*}} in a partial within an engine blows up

### DIFF
--- a/packages/ember-glimmer/tests/integration/application/engine-test.js
+++ b/packages/ember-glimmer/tests/integration/application/engine-test.js
@@ -1,6 +1,6 @@
 import { moduleFor, ApplicationTest } from '../../utils/test-case';
 import { strip } from '../../utils/abstract-test-case';
-import { compile } from '../../utils/helpers';
+import { compile, Component } from '../../utils/helpers';
 import { Controller } from 'ember-runtime';
 import { Engine } from 'ember-application';
 import { Route } from 'ember-routing';
@@ -101,6 +101,30 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
         }));
       }
     }));
+  }
+
+  setupEngineWithAttrs(hooks) {
+    this.application.register('template:application', compile('Application{{mount "chat-engine"}}'));
+
+    this.registerEngine('chat-engine', Engine.extend({
+      init() {
+        this._super(...arguments);
+        this.register('template:components/foo-bar', compile(`{{partial "troll"}}`));
+        this.register('template:troll', compile('{{attrs.wat}}'));
+        this.register('controller:application', Controller.extend({
+          contextType: 'Engine'
+        }));
+        this.register('template:application', compile('Engine {{foo-bar wat=contextType}}'));
+      }
+    }));
+  }
+
+  ['@test attrs in an engine']() {
+    this.setupEngineWithAttrs([]);
+
+    return this.visit('/').then(() => {
+      this.assertText('ApplicationEngine Engine');
+    });
   }
 
   ['@test sharing a template between engine and application has separate refinements']() {


### PR DESCRIPTION
This is a failing test for a combo of engine -> component -> partial that uses `attrs`.

<img width="957" alt="screen shot 2016-09-09 at 1 53 04 pm" src="https://cloud.githubusercontent.com/assets/183799/18402553/c2d64f56-7694-11e6-8162-ff038653e307.png">
