### PR TITLE
[Bugfix Beta] Don't delete moduleName from options

### DIFF
--- a/packages/ember-template-compiler/lib/system/compile-options.js
+++ b/packages/ember-template-compiler/lib/system/compile-options.js
@@ -10,8 +10,6 @@ export default function compileOptions(_options) {
   if (options.moduleName) {
     let meta = options.meta;
     meta.moduleName = options.moduleName;
-
-    delete options.moduleName;
   }
 
   if (!options.plugins) {


### PR DESCRIPTION
This is used by some AST plugins and was previously passed.
