### PR TITLE
[BUGFIX beta] Prevent errors when transitioning prior to initial render.

### DIFF
--- a/packages/ember-glimmer/tests/integration/application/rendering-test.js
+++ b/packages/ember-glimmer/tests/integration/application/rendering-test.js
@@ -352,4 +352,24 @@ moduleFor('Application test: rendering', class extends ApplicationTest {
       this.assertComponentElement(this.firstChild, { content: '1<div>2</div>' });
     });
   }
+
+  ['@test it allows a transition during route activate'](assert) {
+    this.router.map(function() {
+      this.route('a');
+    });
+
+    this.registerRoute('index', Route.extend({
+      activate() {
+        this.transitionTo('a');
+      }
+    }));
+
+    this.registerTemplate('a', 'Hello from A!');
+
+    return this.visit('/').then(() => {
+      this.assertComponentElement(this.firstChild, {
+        content: `Hello from A!`
+      });
+    });
+  }
 });

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -297,6 +297,16 @@ const EmberRouter = EmberObject.extend(Evented, {
       }
       defaultParentState = ownState;
     }
+
+    // when a transitionTo happens after the validation phase
+    // during the initial transition _setOutlets is called
+    // when no routes are active. However, it will get called
+    // again with the correct values during the next turn of
+    // the runloop
+    if (!liveRoutes) {
+      return;
+    }
+
     if (!this._toplevelView) {
       let owner = getOwner(this);
       let OutletView = owner._lookupFactory('view:-outlet');


### PR DESCRIPTION
During a routes `render` cycle, it calls `run.once(this.router, '_setOutlets')` to queue up the top level view to be appended during initial render or to update the outlet state on subsequent renders.

If a transition happens after the validation phase (`beforeModel`, `model`, `afterModel`) in another hook (i.e. `activate`) a second `run.once` is queued, but the first has already ran without any active routes. The lack of active routes means the outlet states are incorrect.

This guards calling `setOutletState` without an outlet state.

Fixes #14248
