### PR TITLE
[BUGFIX beta] Do not call set on PromiseProxy if destroyed.

### DIFF
--- a/packages/ember-runtime/lib/mixins/promise_proxy.js
+++ b/packages/ember-runtime/lib/mixins/promise_proxy.js
@@ -19,16 +19,20 @@ function tap(proxy, promise) {
   });
 
   return promise.then(value => {
-    setProperties(proxy, {
-      content: value,
-      isFulfilled: true
-    });
+    if (!proxy.isDestroyed && !proxy.isDestroying) {
+      setProperties(proxy, {
+        content: value,
+        isFulfilled: true
+      });
+    }
     return value;
   }, reason => {
-    setProperties(proxy, {
-      reason: reason,
-      isRejected: true
-    });
+    if (!proxy.isDestroyed && !proxy.isDestroying) {
+      setProperties(proxy, {
+        reason: reason,
+        isRejected: true
+      });
+    }
     throw reason;
   }, 'Ember: PromiseProxy');
 }

--- a/packages/ember-runtime/tests/mixins/promise_proxy_test.js
+++ b/packages/ember-runtime/tests/mixins/promise_proxy_test.js
@@ -256,3 +256,83 @@ QUnit.test('should have reason when isRejected is set', function() {
     equal(e, error);
   }
 });
+
+QUnit.test('should not error if promise is resolved after proxy has been destroyed', function() {
+  let deferred = EmberRSVP.defer();
+
+  let proxy = ObjectPromiseProxy.create({
+    promise: deferred.promise
+  });
+
+  proxy.then(() => {}, () => {});
+
+  run(proxy, 'destroy');
+
+  run(deferred, 'resolve', true);
+
+  ok(true, 'resolving the promise after the proxy has been destroyed does not raise an error');
+});
+
+QUnit.test('should not error if promise is rejected after proxy has been destroyed', function() {
+  let deferred = EmberRSVP.defer();
+
+  let proxy = ObjectPromiseProxy.create({
+    promise: deferred.promise
+  });
+
+  proxy.then(() => {}, () => {});
+
+  run(proxy, 'destroy');
+
+  run(deferred, 'reject', 'some reason');
+
+  ok(true, 'rejecting the promise after the proxy has been destroyed does not raise an error');
+});
+
+QUnit.test('promise chain is not broken if promised is resolved after proxy has been destroyed', function() {
+  let deferred = EmberRSVP.defer();
+  let expectedValue = {};
+  let receivedValue;
+  let didResolveCount = 0;
+
+  let proxy = ObjectPromiseProxy.create({
+    promise: deferred.promise
+  });
+
+  proxy.then((value) => {
+    receivedValue = value;
+    didResolveCount++;
+  }, () => {});
+
+  run(proxy, 'destroy');
+
+  run(deferred, 'resolve', expectedValue);
+
+  equal(didResolveCount, 1, 'callback called');
+  equal(receivedValue, expectedValue, 'passed value is the value the promise was resolved with');
+});
+
+QUnit.test('promise chain is not broken if promised is rejected after proxy has been destroyed', function() {
+  let deferred = EmberRSVP.defer();
+  let expectedReason = 'some reason';
+  let receivedReason;
+  let didRejectCount = 0;
+
+  let proxy = ObjectPromiseProxy.create({
+    promise: deferred.promise
+  });
+
+  proxy.then(
+    () => {},
+    (reason) => {
+      receivedReason = reason;
+      didRejectCount++;
+    });
+
+  run(proxy, 'destroy');
+
+  run(deferred, 'reject', expectedReason);
+
+  equal(didRejectCount, 1, 'callback called');
+  equal(receivedReason, expectedReason, 'passed reason is the reason the promise was rejected for');
+});


### PR DESCRIPTION
Given an object including `PromiseProxy`, if such object is destroyed
before de promise is fullfill, an error is raised. This error is not
obvious from a user point of view.

This PR avoids setting anything if the proxy has been destroyed while
keeping the promise chain intact.

Fixes #14250
