### PR TITLE
[BUGFIX release] Bump router.js to v1.2.1.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "rsvp": "https://github.com/tildeio/rsvp.js.git#v3.2.1",
-    "router.js": "https://github.com/tildeio/router.js.git#55d8b781bd8c137d1f258ee51d8493d7342e9631",
+    "router.js": "https://github.com/tildeio/router.js.git#f3ff6564cb817b2cdb620ab430964f19e67c4919",
     "ember-dev": "https://github.com/emberjs/ember-dev.git#eace5340485bdb5e4223ab67fecf4aff31c1940c"
   }
 }


### PR DESCRIPTION
[Change Diff](https://github.com/tildeio/router.js/compare/55d8b781bd8c137d1f258ee51d8493d7342e...f3ff6564cb817b2cdb620ab430964f19e67c)

Fixes https://github.com/emberjs/ember.js/issues/14268.
