### PR TITLE
Add passing regression test to confirm setting in willDestroyElement works.

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -2687,6 +2687,31 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     this.assert.ok(true, 'no errors during teardown');
   }
 
+  ['@test setting a property in willDestroyElement does not assert (GH#14273)'](assert) {
+    assert.expect(2);
+
+    this.registerComponent('foo-bar', {
+      ComponentClass: Component.extend({
+        init() {
+          this._super(...arguments);
+          this.showFoo = true;
+        },
+
+        willDestroyElement() {
+          this.set('showFoo', false);
+          assert.ok(true, 'willDestroyElement was fired');
+          this._super(...arguments);
+        }
+      }),
+
+      template: `{{#if showFoo}}things{{/if}}`
+    });
+
+    this.render(`{{foo-bar}}`);
+
+    this.assertText('things');
+  }
+
   ['@test using didInitAttrs as an event is deprecated'](assert) {
     this.registerComponent('foo-bar', {
       ComponentClass: Component.extend({

--- a/packages/ember-glimmer/tests/utils/abstract-test-case.js
+++ b/packages/ember-glimmer/tests/utils/abstract-test-case.js
@@ -152,7 +152,7 @@ export class TestCase {
   }
 
   assertText(text) {
-    this.assert.strictEqual(this.textValue(), text, '#qunit-fixture content');
+    this.assert.strictEqual(this.textValue(), text, `#qunit-fixture content should be: \`${text}\``);
   }
 
   assertInnerHTML(html) {
@@ -160,7 +160,7 @@ export class TestCase {
   }
 
   assertHTML(html) {
-    equalTokens(this.element, html, '#qunit-fixture content');
+    equalTokens(this.element, html, `#qunit-fixture content should be: \`${html}\``);
   }
 
   assertElement(node, { ElementType = HTMLElement, tagName, attrs = null, content = null }) {


### PR DESCRIPTION
This test is passing on 2.9+, but I'd like to have a test in the test suite to ensure we don't regress in the future.

Related to #14273.
