### PR TITLE
Fix release regressions.

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -2565,4 +2565,19 @@ moduleFor('Components test: curly components', class extends RenderingTest {
 
     this.assertText('things');
   }
+
+  ['@test using parentView in the template does not error during destruction']() {
+    this.registerComponent('foo-bar', {
+      ComponentClass: Component.extend({
+        title: computed('parentView.title', function() {
+          return this.get('parentView.title');
+        })
+      }),
+      template: `{{title}}`
+    });
+
+    this.render(`{{foo-bar}}`, { title: 'things' });
+
+    this.assertText('things');
+  }
 });

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -2540,4 +2540,29 @@ moduleFor('Components test: curly components', class extends RenderingTest {
 
     this.assert.ok(true, 'no errors during teardown');
   }
+
+  ['@test setting a property in willDestroyElement does not assert (GH#14273)'](assert) {
+    assert.expect(2);
+
+    this.registerComponent('foo-bar', {
+      ComponentClass: Component.extend({
+        init() {
+          this._super(...arguments);
+          this.showFoo = true;
+        },
+
+        willDestroyElement() {
+          run(() => this.set('showFoo', false));
+          assert.ok(true, 'willDestroyElement was fired');
+          this._super(...arguments);
+        }
+      }),
+
+      template: `{{#if showFoo}}things{{/if}}`
+    });
+
+    this.render(`{{foo-bar}}`);
+
+    this.assertText('things');
+  }
 });

--- a/packages/ember-htmlbars/lib/hooks/cleanup-render-node.js
+++ b/packages/ember-htmlbars/lib/hooks/cleanup-render-node.js
@@ -18,7 +18,6 @@ export default function cleanupRenderNode(renderNode) {
       if (view.parentView && view.parentView === env.view) {
         view.parentView.removeChild(view);
       }
-      view.parentView = null;
 
       view._transitionTo('preRender');
     });

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -454,6 +454,10 @@ export default Mixin.create({
   },
 
   scheduleRevalidate(node, label, manualRerender) {
+    if (this.isDestroying) {
+      return;
+    }
+
     if (node && !this._dispatching && this._env.renderedNodes.has(node)) {
       if (manualRerender) {
         deprecate(


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember.js/issues/14266.
Fixes https://github.com/emberjs/ember.js/issues/14273.

_Note_ This targets `release` directly (as HTMLBars is no longer part of master/beta branches).
