### PR TITLE
[BUGFIX release] Fix component action bubbling semantics.

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -2725,4 +2725,57 @@ moduleFor('Components test: curly components', class extends RenderingTest {
       this.render('{{foo-bar}}');
     }, /didInitAttrs called/);
   }
+
+  ['@test returning `true` from an action does not bubble if `target` is not specified (GH#14275)'](assert) {
+    this.registerComponent('display-toggle', {
+      ComponentClass: Component.extend({
+        actions: {
+          show() {
+            assert.ok(true, 'display-toggle show action was called');
+            return true;
+          }
+        }
+      }),
+
+      template: `<button {{action 'show'}}>Show</button>`
+    });
+
+    this.render(`{{display-toggle}}`, {
+      send() {
+        assert.notOk(true, 'send should not be called when action is not "subscribed" to');
+      }
+    });
+
+    this.assertText('Show');
+
+    this.runTask(() => this.$('button').click());
+  }
+
+  ['@test returning `true` from an action bubbles to the `target` if specified'](assert) {
+    assert.expect(4);
+
+    this.registerComponent('display-toggle', {
+      ComponentClass: Component.extend({
+        actions: {
+          show() {
+            assert.ok(true, 'display-toggle show action was called');
+            return true;
+          }
+        }
+      }),
+
+      template: `<button {{action 'show'}}>Show</button>`
+    });
+
+    this.render(`{{display-toggle target=this}}`, {
+      send(actionName) {
+        assert.ok(true, 'send should be called when action is "subscribed" to');
+        assert.equal(actionName, 'show');
+      }
+    });
+
+    this.assertText('Show');
+
+    this.runTask(() => this.$('button').click());
+  }
 });

--- a/packages/ember-views/lib/mixins/action_support.js
+++ b/packages/ember-views/lib/mixins/action_support.js
@@ -137,7 +137,7 @@ export default Mixin.create({
       if (!shouldBubble) { return; }
     }
 
-    target = get(this, 'target') || get(this, '_targetObject');
+    target = get(this, 'target');
 
     if (target) {
       assert(


### PR DESCRIPTION
When a component action returns `true` we should not bubble the action upwards (this is a significant difference between `Component#send` and `Controller#send` / `Route#send`). The only way to get bubbling from within a component is to call `Component#sendAction`.

This removes an invalid fallback in `ActionSupport` mixin that allowed all component actions to bubble, and adds a few tests to help ensure we do not regress in future refactors.

Fixes #14275.
