### PR TITLE
Router.map variable declared twice with same value

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -119,8 +119,6 @@ const EmberRouter = EmberObject.extend(Evented, {
     let owner = getOwner(this);
     let router = this;
 
-    options.enableLoadingSubstates = !!moduleBasedResolver;
-
     options.resolveRouteMap = function(name) {
       return owner._lookupFactory('route-map:' + name);
     };


### PR DESCRIPTION
Minor, just noticed this while getting ready to send another PR to improve `Router.map`
