### PR TITLE
Prevent invalid markup error

### DIFF
--- a/packages/ember-testing/lib/support.js
+++ b/packages/ember-testing/lib/support.js
@@ -19,7 +19,9 @@ const $ = jQuery;
   @method testCheckboxClick
 */
 function testCheckboxClick(handler) {
-  $('<input type="checkbox">')
+  let input = document.createElement('input');
+  $(input)
+    .attr('type', 'checkbox')
     .css({ position: 'absolute', left: '-1000px', top: '-1000px' })
     .appendTo('body')
     .on('click', handler)


### PR DESCRIPTION
I opened an issue some months ago but nobody answered to my example (#12745).

The first link produces a DOMException, the second doesn't.
Both files are identical.

https://charlesbourasseau.com/invalid-markup.xhtml
https://charlesbourasseau.com/invalid-markup.html

Please consider to merge this pull request.
