### PR TITLE
[BUGFIX beta] Allow `layout` to be injected.

### DIFF
--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -86,7 +86,13 @@ export default class Environment extends GlimmerEnvironment {
     });
 
     this._templateCache = new Cache(1000, ({ Template, owner }) => {
-      return Template.create({ env: this, [OWNER]: owner });
+      if (Template.create) {
+        // we received a factory
+        return Template.create({ env: this, [OWNER]: owner });
+      } else {
+        // we were provided an instance already
+        return Template;
+      }
     }, ({ Template, owner }) => guidFor(owner) + '|' + Template.id);
 
     this._compilerCache = new Cache(10, Compiler => {

--- a/packages/ember-glimmer/tests/unit/layout-cache-test.js
+++ b/packages/ember-glimmer/tests/unit/layout-cache-test.js
@@ -1,6 +1,7 @@
 import { EmptyObject } from 'ember-utils';
 import { RenderingTest, moduleFor } from '../utils/test-case';
 import { CompiledBlock } from 'glimmer-runtime';
+import { OWNER } from 'ember-utils';
 
 class Counter {
   constructor() {
@@ -123,4 +124,18 @@ moduleFor('Layout cache test', class extends RenderingTest {
     assert.strictEqual(COUNTER.total, 2);
   }
 
+  ['@test a template instance is returned (ensures templates can be injected into layout property)'](assert) {
+    let { owner, env } = this;
+
+    let templateInstanceFor = (content) => {
+      let Factory = this.compile(content);
+      return Factory.create({ [OWNER]: owner, env });
+    };
+
+    let template1 = templateInstanceFor('Hello world!');
+    let template2 = templateInstanceFor('{{foo}} {{bar}}');
+
+    assert.ok(env.getCompiledBlock(TypeOneCompiler, template1) instanceof CompiledBlock, 'should return a CompiledBlock');
+    assert.ok(env.getCompiledBlock(TypeOneCompiler, template2) instanceof CompiledBlock, 'should return a CompiledBlock');
+  }
 });


### PR DESCRIPTION
In prior versions of Ember templates were not instantiated, and it was common to inject the layout into the component before looking it up (this was actually what the framework itself did until relatively recently). There are a number of addons (as well as component unit tests in ember-test-helpers) that rely on this behavior.

This change brings back the ability for the template cache system to handle `layout` as either a factory (commonly done by addons when importing a template and adding it as a layout property) or instance (when using registry injection).

Partially addresses the issues referenced in #14310 and should fix #14286.
