### PR TITLE
[BUGFIX beta] Ensure `id` attribute bindings of `undefined` are handled properly.

### DIFF
--- a/packages/ember-glimmer/lib/utils/bindings.js
+++ b/packages/ember-glimmer/lib/utils/bindings.js
@@ -55,7 +55,11 @@ export const AttributeBinding = {
     let [prop, attribute, isSimple] = parsed;
 
     if (attribute === 'id') {
-      operations.addStaticAttribute(element, 'id', get(component, prop));
+      let elementId = get(component, prop);
+      if (elementId === undefined || elementId === null) {
+        elementId = component.elementId;
+      }
+      operations.addStaticAttribute(element, 'id', elementId);
       return;
     }
 

--- a/packages/ember-glimmer/tests/integration/components/attribute-bindings-test.js
+++ b/packages/ember-glimmer/tests/integration/components/attribute-bindings-test.js
@@ -517,4 +517,54 @@ moduleFor('Attribute bindings integration', class extends RenderingTest {
 
     this.assertComponentElement(this.firstChild, { tagName: 'div' });
   }
+
+  ['@test component with an `id` attribute binding of undefined']() {
+    this.registerComponent('foo-bar', {
+      ComponentClass: Component.extend({
+        attributeBindings: ['id'],
+
+        id: undefined
+      })
+    });
+
+    this.registerComponent('baz-qux', {
+      ComponentClass: Component.extend({
+        attributeBindings: ['somethingUndefined:id'],
+
+        somethingUndefined: undefined
+      })
+    });
+    this.render(`{{foo-bar}}{{baz-qux}}`);
+
+    this.assertComponentElement(this.nthChild(0), { content: '' });
+    this.assertComponentElement(this.nthChild(1), { content: '' });
+
+    this.assert.ok(this.nthChild(0).id.match(/ember\d+/), 'a valid `id` was used');
+    this.assert.ok(this.nthChild(1).id.match(/ember\d+/), 'a valid `id` was used');
+  }
+
+  ['@test component with an `id` attribute binding of null']() {
+    this.registerComponent('foo-bar', {
+      ComponentClass: Component.extend({
+        attributeBindings: ['id'],
+
+        id: null
+      })
+    });
+
+    this.registerComponent('baz-qux', {
+      ComponentClass: Component.extend({
+        attributeBindings: ['somethingNull:id'],
+
+        somethingNull: null
+      })
+    });
+    this.render(`{{foo-bar}}{{baz-qux}}`);
+
+    this.assertComponentElement(this.nthChild(0), { content: '' });
+    this.assertComponentElement(this.nthChild(1), { content: '' });
+
+    this.assert.ok(this.nthChild(0).id.match(/ember\d+/), 'a valid `id` was used');
+    this.assert.ok(this.nthChild(1).id.match(/ember\d+/), 'a valid `id` was used');
+  }
 });


### PR DESCRIPTION
When `attributeBindings: ['id']` is set and the `id` property was undefined, earlier versions of 2.9 would set the actual attribute value to `"undefined"`.

This changes it to ensure that if `null` or `undefined` values are found for `id`, we default back to `elementId`.

Fixes #14278
