### PR TITLE
[DOC] objectAtContent should be public

### DIFF
--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -103,7 +103,7 @@ export default EmberObject.extend(MutableArray, {
     @method objectAtContent
     @param {Number} idx The index to retrieve.
     @return {Object} the value or undefined if none found
-    @private
+    @public
   */
   objectAtContent(idx) {
     return objectAt(get(this, 'arrangedContent'), idx);


### PR DESCRIPTION
See lines 52-63 of this file, which document how to override this method.
https://github.com/ssured/ember.js/blob/95daad4d066cdd12ab961176b7e5f8ba92de2e26/packages/ember-runtime/lib/system/array_proxy.js#L52-L63
