### PR TITLE
blueprints: remove explicit names from initializers.

### DIFF
--- a/blueprints/initializer/files/__root__/initializers/__name__.js
+++ b/blueprints/initializer/files/__root__/initializers/__name__.js
@@ -3,6 +3,5 @@ export function initialize(/* application */) {
 }
 
 export default {
-  name: '<%= dasherizedModuleName %>',
   initialize
 };

--- a/blueprints/instance-initializer/files/__root__/instance-initializers/__name__.js
+++ b/blueprints/instance-initializer/files/__root__/instance-initializers/__name__.js
@@ -3,6 +3,5 @@ export function initialize(/* appInstance */) {
 }
 
 export default {
-  name: '<%= dasherizedModuleName %>',
   initialize
 };

--- a/node-tests/blueprints/initializer-test.js
+++ b/node-tests/blueprints/initializer-test.js
@@ -24,7 +24,6 @@ describe('Acceptance: ember generate and destroy initializer', function() {
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo',\n" +
                       "  initialize\n" +
                       "};");
 
@@ -44,7 +43,6 @@ describe('Acceptance: ember generate and destroy initializer', function() {
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo/bar',\n" +
                       "  initialize\n" +
                       "};");
 
@@ -64,7 +62,6 @@ describe('Acceptance: ember generate and destroy initializer', function() {
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo',\n" +
                       "  initialize\n" +
                       "};");
 
@@ -87,7 +84,6 @@ describe('Acceptance: ember generate and destroy initializer', function() {
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo/bar',\n" +
                       "  initialize\n" +
                       "};");
 
@@ -110,7 +106,6 @@ describe('Acceptance: ember generate and destroy initializer', function() {
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo',\n" +
                       "  initialize\n" +
                       "};");
 
@@ -133,7 +128,6 @@ describe('Acceptance: ember generate and destroy initializer', function() {
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo/bar',\n" +
                       "  initialize\n" +
                       "};");
 
@@ -156,7 +150,6 @@ describe('Acceptance: ember generate and destroy initializer', function() {
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo',\n" +
                       "  initialize\n" +
                       "};");
 
@@ -179,7 +172,6 @@ describe('Acceptance: ember generate and destroy initializer', function() {
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo/bar',\n" +
                       "  initialize\n" +
                       "};");
 
@@ -204,7 +196,6 @@ describe('Acceptance: ember generate and destroy initializer', function() {
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo',\n" +
                       "  initialize\n" +
                       "};");
       }));
@@ -222,7 +213,6 @@ describe('Acceptance: ember generate and destroy initializer', function() {
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo',\n" +
                       "  initialize\n" +
                       "};");
       }));
@@ -239,7 +229,6 @@ describe('Acceptance: ember generate and destroy initializer', function() {
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo/bar',\n" +
                       "  initialize\n" +
                       "};");
       }));
@@ -258,7 +247,6 @@ describe('Acceptance: ember generate and destroy initializer', function() {
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo/bar',\n" +
                       "  initialize\n" +
                       "};");
       }));

--- a/node-tests/blueprints/instance-initializer-test.js
+++ b/node-tests/blueprints/instance-initializer-test.js
@@ -24,7 +24,6 @@ describe('Acceptance: ember generate and destroy instance-initializer', function
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo',\n" +
                       "  initialize\n" +
                       "};");
 
@@ -44,7 +43,6 @@ describe('Acceptance: ember generate and destroy instance-initializer', function
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo/bar',\n" +
                       "  initialize\n" +
                       "};");
 
@@ -64,7 +62,6 @@ describe('Acceptance: ember generate and destroy instance-initializer', function
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo',\n" +
                       "  initialize\n" +
                       "};");
 
@@ -86,7 +83,6 @@ describe('Acceptance: ember generate and destroy instance-initializer', function
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo/bar',\n" +
                       "  initialize\n" +
                       "};");
 
@@ -108,7 +104,6 @@ describe('Acceptance: ember generate and destroy instance-initializer', function
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo',\n" +
                       "  initialize\n" +
                       "};");
 
@@ -131,7 +126,6 @@ describe('Acceptance: ember generate and destroy instance-initializer', function
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo/bar',\n" +
                       "  initialize\n" +
                       "};");
 
@@ -154,7 +148,6 @@ describe('Acceptance: ember generate and destroy instance-initializer', function
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo',\n" +
                       "  initialize\n" +
                       "};");
 
@@ -177,7 +170,6 @@ describe('Acceptance: ember generate and destroy instance-initializer', function
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo/bar',\n" +
                       "  initialize\n" +
                       "};");
 
@@ -202,7 +194,6 @@ describe('Acceptance: ember generate and destroy instance-initializer', function
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo',\n" +
                       "  initialize\n" +
                       "};");
       }));
@@ -220,7 +211,6 @@ describe('Acceptance: ember generate and destroy instance-initializer', function
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo',\n" +
                       "  initialize\n" +
                       "};");
       }));
@@ -237,7 +227,6 @@ describe('Acceptance: ember generate and destroy instance-initializer', function
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo/bar',\n" +
                       "  initialize\n" +
                       "};");
       }));
@@ -256,7 +245,6 @@ describe('Acceptance: ember generate and destroy instance-initializer', function
                       "}\n" +
                       "\n" +
                       "export default {\n" +
-                      "  name: 'foo/bar',\n" +
                       "  initialize\n" +
                       "};");
       }));


### PR DESCRIPTION
See https://github.com/emberjs/guides/pull/1654 and https://github.com/ember-cli/ember-cli-legacy-blueprints/pull/54.
