### PR TITLE
[BUGFIX beta] Fix issues causing unneeded rerenders with closure actions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "git-repo-info": "^1.1.4",
     "git-repo-version": "^0.3.1",
     "github": "^0.2.3",
-    "glimmer-engine": "0.17.1",
+    "glimmer-engine": "0.17.2",
     "glob": "^5.0.13",
     "html-differ": "^1.3.4",
     "mocha": "^2.4.5",

--- a/packages/ember-glimmer/lib/utils/bindings.js
+++ b/packages/ember-glimmer/lib/utils/bindings.js
@@ -116,18 +116,24 @@ export const IsVisibleBinding = {
 export const ClassNameBinding = {
   install(element, component, microsyntax, operations) {
     let [ prop, truthy, falsy ] = microsyntax.split(':');
-    let isPath = prop.indexOf('.') > -1;
-    let parts = isPath && prop.split('.');
-    let value = isPath ? referenceForParts(component, parts) : referenceForKey(component, prop);
-    let ref;
+    let isStatic = prop === '';
 
-    if (truthy === undefined) {
-      ref = new SimpleClassNameBindingReference(value, isPath ? parts[parts.length - 1] : prop);
+    if (isStatic) {
+      operations.addStaticAttribute(element, 'class', truthy);
     } else {
-      ref = new ColonClassNameBindingReference(value, truthy, falsy);
-    }
+      let isPath = prop.indexOf('.') > -1;
+      let parts = isPath && prop.split('.');
+      let value = isPath ? referenceForParts(component, parts) : referenceForKey(component, prop);
+      let ref;
 
-    operations.addDynamicAttribute(element, 'class', ref);
+      if (truthy === undefined) {
+        ref = new SimpleClassNameBindingReference(value, isPath ? parts[parts.length - 1] : prop);
+      } else {
+        ref = new ColonClassNameBindingReference(value, truthy, falsy);
+      }
+
+      operations.addDynamicAttribute(element, 'class', ref);
+    }
   }
 };
 

--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -49,11 +49,6 @@ export function get(obj, keyName) {
   assert(`The key provided to get must be a string, you passed ${keyName}`, typeof keyName === 'string');
   assert(`'this' in paths is not supported`, !hasThis(keyName));
 
-  // Helpers that operate with 'this' within an #each
-  if (keyName === '') {
-    return obj;
-  }
-
   let value = obj[keyName];
   let desc = (value !== null && typeof value === 'object' && value.isDescriptor) ? value : undefined;
   let ret;

--- a/packages/ember-metal/tests/accessors/get_test.js
+++ b/packages/ember-metal/tests/accessors/get_test.js
@@ -39,6 +39,14 @@ QUnit.test('should not access a property more than once', function() {
   equal(count, 1);
 });
 
+QUnit.test('should be able to use an empty string as a property', function(assert) {
+  let obj = { '': 'empty string' };
+
+  let result = get(obj, '');
+
+  assert.equal(result, obj['']);
+});
+
 testBoth('should call unknownProperty on watched values if the value is undefined', function(get, set) {
   let obj = {
     count: 0,

--- a/packages/ember-template-compiler/lib/plugins/transform-action-syntax.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-action-syntax.js
@@ -63,5 +63,5 @@ function isAction(node) {
 }
 
 function insertThisAsFirstParam(node, builders) {
-  node.params.unshift(builders.path(''));
+  node.params.unshift(builders.path('this'));
 }


### PR DESCRIPTION
To properly handle actions (which need access to the current `{{this}}` so that we can properly bind the function that is invoked) we use an AST transform to transform from:

``` hbs
{{foo-bar submit=(action 'derp')}}
```

To:

``` hbs
{{foo-bar submit=(action this 'derp')}}
```

Normally, when you use `{{this}}` in a template we properly understand that as a constant value (even though the tag for the `{{this}}` may change, it is still the same _value_). This means that `(action this 'derp')` should be considered a constant (and therefore not need additional rerenders).

Due to a bug in Glimmer's AST syntax builder helper methods, we were actually representing that as `''` (which internally in Handlebars is how `{{this}}` is actually viewed). This bug caused the AST syntax builder to handle `{{this}}` differently than if you had actually typed
`{{this}}` in an actual template.

This PR fixes a number of issues identified:
- `Ember.get` was special casing `''` as always returning the
  object (`get`'s first argument);
- `(action` was always invalidating for any properties set in the host
  object.
- `classNameBindings: [':foo']` was doing extra work.

Fixes #14335
Fixes #14305
