### PR TITLE
[BUGFIX beta] Remove `isTopLevel` flag in `DynamicScope`.

### DIFF
--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -96,10 +96,12 @@ export default class Environment extends GlimmerEnvironment {
     }, ({ Template, owner }) => guidFor(owner) + '|' + Template.id);
 
     this._compilerCache = new Cache(10, Compiler => {
-      return new Cache(2000, template => {
+      return new Cache(2000, ({ template }) => {
         let compilable = new Compiler(template);
         return compileLayout(compilable, this);
-      }, template => template.id);
+      }, ({ template, owner })=> {
+        return guidFor(owner) + '|' + template.id;
+      });
     }, Compiler => Compiler.id);
 
     this.builtInModifiers = {
@@ -252,7 +254,7 @@ export default class Environment extends GlimmerEnvironment {
   // a Compiler can wrap the template so it needs its own cache
   getCompiledBlock(Compiler, template, owner) {
     let compilerCache = this._compilerCache.get(Compiler);
-    return compilerCache.get(template, owner);
+    return compilerCache.get({ template, owner });
   }
 
   hasPartial(name, symbolTable) {

--- a/packages/ember-glimmer/lib/views/outlet.js
+++ b/packages/ember-glimmer/lib/views/outlet.js
@@ -5,6 +5,7 @@
 import { assign, EmptyObject } from 'ember-utils';
 import { DirtyableTag } from 'glimmer-reference';
 import { environment } from 'ember-environment';
+import { OWNER } from 'ember-utils';
 
 class OutletStateReference {
   constructor(outletView) {
@@ -18,10 +19,6 @@ class OutletStateReference {
 
   value() {
     return this.outletView.outletState;
-  }
-
-  get isTopLevel() {
-    return true;
   }
 
   getOrphan(name) {
@@ -46,7 +43,7 @@ class OrphanedOutletStateReference extends OutletStateReference {
   value() {
     let rootState = this.root.value();
 
-    let orphans = rootState.outlets.__ember_orphans__;
+    let orphans = rootState.outlets.main.outlets.__ember_orphans__;
 
     if (!orphans) {
       return null;
@@ -79,10 +76,6 @@ class ChildOutletStateReference {
   value() {
     return this.parent.value()[this.key];
   }
-
-  get isTopLevel() {
-    return false;
-  }
 }
 
 export default class OutletView {
@@ -102,13 +95,16 @@ export default class OutletView {
     assign(this, injections);
   }
 
-  static create({ _environment, renderer, template }) {
-    return new OutletView(_environment, renderer, template);
+  static create(options) {
+    let { _environment, renderer, template } = options;
+    let owner = options[OWNER];
+    return new OutletView(_environment, renderer, owner, template);
   }
 
-  constructor(_environment, renderer, template) {
+  constructor(_environment, renderer, owner, template) {
     this._environment = _environment;
     this.renderer = renderer;
+    this.owner = owner;
     this.template = template;
     this.outletState = null;
     this._renderResult = null;
@@ -133,7 +129,20 @@ export default class OutletView {
   }
 
   setOutletState(state) {
-    this.outletState = state;
+    this.outletState = {
+      outlets: {
+        main: state
+      },
+      render: {
+        owner: undefined,
+        into: undefined,
+        outlet: 'main',
+        name: '-top-level',
+        controller: undefined,
+        ViewClass: undefined,
+        template: undefined
+      }
+    };
     this._tag.dirty();
   }
 

--- a/packages/ember-glimmer/tests/integration/outlet-test.js
+++ b/packages/ember-glimmer/tests/integration/outlet-test.js
@@ -315,7 +315,7 @@ moduleFor('outlet view', class extends RenderingTest {
       }
     };
 
-    this.runTask(() => this.component.setOutletState({ render: {}, outlets: { main: outletState } }) );
+    this.runTask(() => this.component.setOutletState(outletState) );
 
     runAppend(this.component);
 


### PR DESCRIPTION
Remove the need for `DynamicScope#isTopLevel` to be threaded throughout the full system, and rely on the same setup that we recently added for `Component#appendTo`.

This sets the stage for sharing a single root template with an `{{#each` and removing the root iteration in the `Renderer`.

/cc @krisselden 
