### PR TITLE
Collapse multiple arguments in `CoreObject.create` rather than inside of `makeCtor`

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -62,7 +62,7 @@ function makeCtor() {
     }
 
     if (arguments.length > 0) {
-      initProperties = [arguments[0]];
+      initProperties = arguments[0];
     }
 
     this.__defineNonEnumerable(GUID_KEY_PROPERTY);
@@ -71,91 +71,85 @@ function makeCtor() {
     m.proto = this;
     if (initProperties) {
       // capture locally so we can clear the closed over variable
-      var props = initProperties;
+      var properties = initProperties;
       initProperties = null;
 
       var concatenatedProperties = this.concatenatedProperties;
       var mergedProperties = this.mergedProperties;
 
-      for (var i = 0; i < props.length; i++) {
-        var properties = props[i];
+      assert(
+        'Ember.Object.create no longer supports mixing in other ' +
+        'definitions, use .extend & .create separately instead.',
+        !(properties instanceof Mixin)
+      );
 
-        assert(
-          'Ember.Object.create no longer supports mixing in other ' +
-          'definitions, use .extend & .create separately instead.',
-          !(properties instanceof Mixin)
-        );
+      if (typeof properties !== 'object' && properties !== undefined) {
+        throw new EmberError('Ember.Object.create only accepts objects.');
+      }
 
-        if (typeof properties !== 'object' && properties !== undefined) {
-          throw new EmberError('Ember.Object.create only accepts objects.');
+      var keyNames = Object.keys(properties);
+
+      for (var i = 0; i < keyNames.length; i++) {
+        var keyName = keyNames[i];
+        var value = properties[keyName];
+
+        if (detectBinding(keyName)) {
+          m.writeBindings(keyName, value);
         }
 
-        if (!properties) { continue; }
+        var possibleDesc = this[keyName];
+        var desc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
 
-        var keyNames = Object.keys(properties);
+        assert(
+          'Ember.Object.create no longer supports defining computed ' +
+          'properties. Define computed properties using extend() or reopen() ' +
+          'before calling create().',
+          !(value instanceof ComputedProperty)
+        );
+        assert(
+          'Ember.Object.create no longer supports defining methods that call _super.',
+          !(typeof value === 'function' && value.toString().indexOf('._super') !== -1)
+        );
+        assert(
+          '`actions` must be provided at extend time, not at create time, ' +
+          'when Ember.ActionHandler is used (i.e. views, controllers & routes).',
+          !((keyName === 'actions') && ActionHandler.detect(this))
+        );
 
-        for (var j = 0; j < keyNames.length; j++) {
-          var keyName = keyNames[j];
-          var value = properties[keyName];
+        if (concatenatedProperties &&
+            concatenatedProperties.length > 0 &&
+            concatenatedProperties.indexOf(keyName) >= 0) {
+          var baseValue = this[keyName];
 
-          if (detectBinding(keyName)) {
-            m.writeBindings(keyName, value);
-          }
-
-          var possibleDesc = this[keyName];
-          var desc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
-
-          assert(
-            'Ember.Object.create no longer supports defining computed ' +
-            'properties. Define computed properties using extend() or reopen() ' +
-            'before calling create().',
-            !(value instanceof ComputedProperty)
-          );
-          assert(
-            'Ember.Object.create no longer supports defining methods that call _super.',
-            !(typeof value === 'function' && value.toString().indexOf('._super') !== -1)
-          );
-          assert(
-            '`actions` must be provided at extend time, not at create time, ' +
-            'when Ember.ActionHandler is used (i.e. views, controllers & routes).',
-            !((keyName === 'actions') && ActionHandler.detect(this))
-          );
-
-          if (concatenatedProperties &&
-              concatenatedProperties.length > 0 &&
-              concatenatedProperties.indexOf(keyName) >= 0) {
-            var baseValue = this[keyName];
-
-            if (baseValue) {
-              if ('function' === typeof baseValue.concat) {
-                value = baseValue.concat(value);
-              } else {
-                value = makeArray(baseValue).concat(value);
-              }
+          if (baseValue) {
+            if ('function' === typeof baseValue.concat) {
+              value = baseValue.concat(value);
             } else {
-              value = makeArray(value);
+              value = makeArray(baseValue).concat(value);
             }
-          }
-
-          if (mergedProperties &&
-              mergedProperties.length &&
-              mergedProperties.indexOf(keyName) >= 0) {
-            var originalValue = this[keyName];
-
-            value = assign({}, originalValue, value);
-          }
-
-          if (desc) {
-            desc.set(this, keyName, value);
           } else {
-            if (typeof this.setUnknownProperty === 'function' && !(keyName in this)) {
-              this.setUnknownProperty(keyName, value);
+            value = makeArray(value);
+          }
+        }
+
+        if (mergedProperties &&
+            mergedProperties.length &&
+            mergedProperties.indexOf(keyName) >= 0) {
+          var originalValue = this[keyName];
+
+          value = assign({}, originalValue, value);
+        }
+
+        if (desc) {
+          desc.set(this, keyName, value);
+        } else {
+          if (typeof this.setUnknownProperty === 'function' && !(keyName in this)) {
+            this.setUnknownProperty(keyName, value);
+          } else {
+            if (isFeatureEnabled('mandatory-setter')) {
+              defineProperty(this, keyName, null, value); // setup mandatory setter
             } else {
-              if (isFeatureEnabled('mandatory-setter')) {
-                defineProperty(this, keyName, null, value); // setup mandatory setter
-              } else {
-                this[keyName] = value;
-              }
+              this[keyName] = value;
             }
           }
         }
@@ -708,10 +702,53 @@ var ClassMixinProps = {
   */
   create(...args) {
     var C = this;
-    if (args.length > 0) {
-      this._initProperties(args);
+    if (args.length === 0) {
+      return new C();
+    } else if (args.length === 1) {
+      return new C(args[0]);
+    } else if (args.length > 1) {
+      let concatenatedProperties = this.concatenatedProperties;
+      let mergedProperties = this.mergedProperties;
+      let props = {};
+
+      for (let i = 0; i < args.length; i++) {
+        let currentArg = args[i];
+        let keyNames = Object.keys(currentArg);
+
+        for (let j = 0, k = keyNames.length; j < k; j++) {
+          let keyName = keyNames[j];
+          let value = currentArg[keyName];
+
+          if (concatenatedProperties &&
+              concatenatedProperties.length > 0 &&
+              concatenatedProperties.indexOf(keyName) >= 0) {
+            var baseValue = props[keyName];
+
+            if (baseValue) {
+              if ('function' === typeof baseValue.concat) {
+                value = baseValue.concat(value);
+              } else {
+                value = makeArray(baseValue).concat(value);
+              }
+            } else {
+              value = makeArray(value);
+            }
+          }
+
+          if (mergedProperties &&
+              mergedProperties.length &&
+              mergedProperties.indexOf(keyName) >= 0) {
+            var originalValue = props[keyName];
+
+            value = assign({}, originalValue, value);
+          }
+
+          props[keyName] = value;
+        }
+      }
+
+      return new C(props);
     }
-    return new C();
   },
 
   /**

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -700,19 +700,19 @@ var ClassMixinProps = {
     @param [arguments]*
     @public
   */
-  create(...args) {
+  create() {
     var C = this;
-    if (args.length === 0) {
+    if (arguments.length === 0) {
       return new C();
-    } else if (args.length === 1) {
-      return new C(args[0]);
-    } else if (args.length > 1) {
+    } else if (arguments.length === 1) {
+      return new C(arguments[0]);
+    } else if (arguments.length > 1) {
       let concatenatedProperties = this.concatenatedProperties;
       let mergedProperties = this.mergedProperties;
       let props = {};
 
-      for (let i = 0; i < args.length; i++) {
-        let currentArg = args[i];
+      for (let i = 0; i < arguments.length; i++) {
+        let currentArg = arguments[i];
         let keyNames = Object.keys(currentArg);
 
         for (let j = 0, k = keyNames.length; j < k; j++) {

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -702,10 +702,8 @@ var ClassMixinProps = {
   */
   create() {
     var C = this;
-    if (arguments.length === 0) {
-      return new C();
-    } else if (arguments.length === 1) {
-      return new C(arguments[0]);
+    if (arguments.length === 1) {
+      this._initProperties(arguments[0]);
     } else if (arguments.length > 1) {
       let concatenatedProperties = this.concatenatedProperties;
       let mergedProperties = this.mergedProperties;
@@ -747,8 +745,10 @@ var ClassMixinProps = {
         }
       }
 
-      return new C(props);
+      this._initProperties(props);
     }
+
+    return new C();
   },
 
   /**

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -702,8 +702,10 @@ var ClassMixinProps = {
   */
   create() {
     var C = this;
-    if (arguments.length === 1) {
-      this._initProperties(arguments[0]);
+    if (arguments.length === 0) {
+      return new C();
+    } else if (arguments.length === 1) {
+      return new C(arguments[0]);
     } else if (arguments.length > 1) {
       let concatenatedProperties = this.concatenatedProperties;
       let mergedProperties = this.mergedProperties;
@@ -745,10 +747,8 @@ var ClassMixinProps = {
         }
       }
 
-      this._initProperties(props);
+      return new C(props);
     }
-
-    return new C();
   },
 
   /**

--- a/packages/ember-runtime/tests/mixins/array_test.js
+++ b/packages/ember-runtime/tests/mixins/array_test.js
@@ -24,8 +24,8 @@ import { A as emberA } from '../../system/native_array';
 const TestArray = EmberObject.extend(EmberArray, {
   _content: null,
 
-  init(ary = []) {
-    this._content = ary;
+  init() {
+    this._content = this._content || [];
   },
 
   // some methods to modify the array so we can test changes.  Note that
@@ -60,7 +60,7 @@ ArrayTests.extend({
 
   newObject(ary) {
     ary = ary ? ary.slice() : this.newFixture(3);
-    return new TestArray(ary);
+    return TestArray.create({ _content: ary });
   },
 
   // allows for testing of the basic enumerable after an internal mutation
@@ -83,7 +83,7 @@ QUnit.test('the return value of slice has Ember.Array applied', function() {
 });
 
 QUnit.test('slice supports negative index arguments', function() {
-  let testArray = new TestArray([1, 2, 3, 4]);
+  let testArray = new TestArray({ _content: [1, 2, 3, 4] });
 
   deepEqual(testArray.slice(-2), [3, 4], 'slice(-2)');
   deepEqual(testArray.slice(-2, -1), [3], 'slice(-2, -1');
@@ -320,12 +320,14 @@ let ary;
 
 QUnit.module('EmberArray.@each support', {
   setup() {
-    ary = new TestArray([
-      { isDone: true, desc: 'Todo 1' },
-      { isDone: false, desc: 'Todo 2' },
-      { isDone: true, desc: 'Todo 3' },
-      { isDone: false, desc: 'Todo 4' }
-    ]);
+    ary = new TestArray({
+      _content: [
+        { isDone: true, desc: 'Todo 1' },
+        { isDone: false, desc: 'Todo 2' },
+        { isDone: true, desc: 'Todo 3' },
+        { isDone: false, desc: 'Todo 4' }
+      ]
+    });
   },
 
   teardown() {


### PR DESCRIPTION
@rwjblue @krisselden 

TODOs/open questions:
- [ ] Benchmark
- [x] Should we avoid splat args? @krisselden says yes
- [ ] Should we try to reduce the code duplication? Yes, but let's benchmark this first
- [ ] Try using `this` instead of `C` in `CoreObject.create`
- [ ] Try to refactor out `initProperties`
