### PR TITLE
[BUGFIX beta] Expose private "in-element" API.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "git-repo-info": "^1.1.4",
     "git-repo-version": "^0.3.1",
     "github": "^0.2.3",
-    "glimmer-engine": "0.17.3",
+    "glimmer-engine": "0.17.4",
     "glob": "^5.0.13",
     "html-differ": "^1.3.4",
     "mocha": "^2.4.5",

--- a/packages/ember-glimmer/lib/syntax.js
+++ b/packages/ember-glimmer/lib/syntax.js
@@ -3,7 +3,10 @@ import { OutletSyntax } from './syntax/outlet';
 import { MountSyntax } from './syntax/mount';
 import { DynamicComponentSyntax } from './syntax/dynamic-component';
 import { InputSyntax } from './syntax/input';
-import { WithDynamicVarsSyntax } from 'glimmer-runtime';
+import {
+  WithDynamicVarsSyntax,
+  InElementSyntax
+} from 'glimmer-runtime';
 
 
 let syntaxKeys = [];
@@ -27,8 +30,15 @@ registerSyntax('outlet', OutletSyntax);
 registerSyntax('mount', MountSyntax);
 registerSyntax('component', DynamicComponentSyntax);
 registerSyntax('input', InputSyntax);
+
 registerSyntax('-with-dynamic-vars', class {
   static create(environment, args, templates, symbolTable) {
     return new WithDynamicVarsSyntax({ args, templates });
+  }
+});
+
+registerSyntax('-in-element', class {
+  static create(environment, args, templates, symbolTable) {
+    return new InElementSyntax({ args, templates });
   }
 });

--- a/packages/ember-glimmer/tests/integration/syntax/in-element-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/in-element-test.js
@@ -1,0 +1,94 @@
+import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { equalTokens } from '../../utils/test-helpers';
+import { strip } from '../../utils/abstract-test-case';
+import Component from '../../../component';
+import { set } from 'ember-metal';
+
+moduleFor('{{-in-element}}', class extends RenderingTest {
+  ['@test allows rendering into an external element'](assert) {
+    let someElement = document.createElement('div');
+
+    this.render(strip`
+      {{#-in-element someElement}}
+        {{text}}
+      {{/-in-element}}
+    `, {
+      someElement,
+      text: 'Whoop!'
+    });
+
+    equalTokens(this.element, '<!---->');
+    equalTokens(someElement, 'Whoop!');
+
+    this.assertStableRerender();
+
+    this.runTask(() => set(this.context, 'text', 'Huzzah!!'));
+
+    equalTokens(this.element, '<!---->');
+    equalTokens(someElement, 'Huzzah!!');
+
+    this.runTask(() => set(this.context, 'text', 'Whoop!'));
+
+    equalTokens(this.element, '<!---->');
+    equalTokens(someElement, 'Whoop!');
+  }
+
+  ['@test components are cleaned up properly'](assert) {
+    let hooks = [ ];
+
+    let someElement = document.createElement('div');
+
+    this.registerComponent('modal-display', {
+      ComponentClass: Component.extend({
+        didInsertElement() {
+          hooks.push('didInsertElement');
+        },
+
+        willDestroyElement() {
+          hooks.push('willDestroyElement');
+        }
+      }),
+
+      template: `{{text}}`
+    });
+
+    this.render(strip`
+      {{#if showModal}}
+        {{#-in-element someElement}}
+          {{modal-display text=text}}
+        {{/-in-element}}
+      {{/if}}
+    `, {
+      someElement,
+      text: 'Whoop!',
+      showModal: false
+    });
+
+    equalTokens(this.element, '<!---->');
+    equalTokens(someElement, '');
+
+    this.assertStableRerender();
+
+    this.runTask(() => set(this.context, 'showModal', true));
+
+    equalTokens(this.element, '<!---->');
+    this.assertComponentElement(someElement.firstChild, { content: 'Whoop!' });
+
+    this.runTask(() => set(this.context, 'text', 'Huzzah!'));
+
+    equalTokens(this.element, '<!---->');
+    this.assertComponentElement(someElement.firstChild, { content: 'Huzzah!' });
+
+    this.runTask(() => set(this.context, 'text', 'Whoop!'));
+
+    equalTokens(this.element, '<!---->');
+    this.assertComponentElement(someElement.firstChild, { content: 'Whoop!' });
+
+    this.runTask(() => set(this.context, 'showModal', false));
+
+    equalTokens(this.element, '<!---->');
+    equalTokens(someElement, '');
+
+    assert.deepEqual(hooks, ['didInsertElement', 'willDestroyElement']);
+  }
+});


### PR DESCRIPTION
This should allow ember-wormhole and flexi addons to properly handle dynamic content in the root of thier blocks, and get unblocked in Ember 2.9+.

There will be future RFC work to expose this as public API.
