### PR TITLE
Refactor Meta and object destruction tracking.

### DIFF
--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -116,23 +116,23 @@ function addChainWatcher(obj, keyName, node) {
   watchKey(obj, keyName, m);
 }
 
-function removeChainWatcher(obj, keyName, node) {
+function removeChainWatcher(obj, keyName, node, _meta) {
   if (!isObject(obj)) {
     return;
   }
 
-  let m = peekMeta(obj);
+  let meta = _meta || peekMeta(obj);
 
-  if (!m || !m.readableChainWatchers()) {
+  if (!meta || !meta.readableChainWatchers()) {
     return;
   }
 
   // make meta writable
-  m = metaFor(obj);
+  meta = metaFor(obj);
 
-  m.readableChainWatchers().remove(keyName, node);
+  meta.readableChainWatchers().remove(keyName, node);
 
-  unwatchKey(obj, keyName, m);
+  unwatchKey(obj, keyName, meta);
 }
 
 // A ChainNode watches a single key on an object. If you provide a starting

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -39,14 +39,14 @@ let deferred = 0;
   @return {void}
   @private
 */
-function propertyWillChange(obj, keyName) {
-  let m = peekMeta(obj);
+function propertyWillChange(obj, keyName, _meta) {
+  let meta = _meta || peekMeta(obj);
 
-  if (m && !m.isInitialized(obj)) {
+  if (meta && !meta.isInitialized(obj)) {
     return;
   }
 
-  let watching = m && m.peekWatching(keyName) > 0;
+  let watching = meta && meta.peekWatching(keyName) > 0;
   let possibleDesc = obj[keyName];
   let desc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
 
@@ -55,9 +55,9 @@ function propertyWillChange(obj, keyName) {
   }
 
   if (watching) {
-    dependentKeysWillChange(obj, keyName, m);
-    chainsWillChange(obj, keyName, m);
-    notifyBeforeObservers(obj, keyName);
+    dependentKeysWillChange(obj, keyName, meta);
+    chainsWillChange(obj, keyName, meta);
+    notifyBeforeObservers(obj, keyName, meta);
   }
 }
 
@@ -74,17 +74,18 @@ function propertyWillChange(obj, keyName) {
   @for Ember
   @param {Object} obj The object with the property that will change
   @param {String} keyName The property key (or path) that will change.
+  @param {Meta} meta The objects meta.
   @return {void}
   @private
 */
-function propertyDidChange(obj, keyName) {
-  let m = peekMeta(obj);
+function propertyDidChange(obj, keyName, _meta) {
+  let meta = _meta || peekMeta(obj);
 
-  if (m && !m.isInitialized(obj)) {
+  if (meta && !meta.isInitialized(obj)) {
     return;
   }
 
-  let watching = m && m.peekWatching(keyName) > 0;
+  let watching = meta && meta.peekWatching(keyName) > 0;
   let possibleDesc = obj[keyName];
   let desc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
 
@@ -94,12 +95,12 @@ function propertyDidChange(obj, keyName) {
   }
 
   if (watching) {
-    if (m.hasDeps(keyName)) {
-      dependentKeysDidChange(obj, keyName, m);
+    if (meta.hasDeps(keyName)) {
+      dependentKeysDidChange(obj, keyName, meta);
     }
 
-    chainsDidChange(obj, keyName, m, false);
-    notifyObservers(obj, keyName);
+    chainsDidChange(obj, keyName, meta, false);
+    notifyObservers(obj, keyName, meta);
   }
 
 
@@ -107,12 +108,13 @@ function propertyDidChange(obj, keyName) {
     obj[PROPERTY_DID_CHANGE](keyName);
   }
 
-  if (obj.isDestroying) { return; }
-  markObjectAsDirty(m);
+  if (meta && meta.isSourceDestroying()) { return; }
+
+  markObjectAsDirty(meta);
 
   if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
       isEnabled('ember-glimmer-allow-backtracking-rerender')) {
-    assertNotRendered(obj, keyName, m);
+    assertNotRendered(obj, keyName, meta);
   }
 }
 
@@ -120,7 +122,7 @@ function propertyDidChange(obj, keyName) {
 let WILL_SEEN, DID_SEEN;
 // called whenever a property is about to change to clear the cache of any dependent keys (and notify those properties of changes, etc...)
 function dependentKeysWillChange(obj, depKey, meta) {
-  if (obj.isDestroying) { return; }
+  if (meta && meta.isSourceDestroying()) { return; }
 
   if (meta && meta.hasDeps(depKey)) {
     let seen = WILL_SEEN;
@@ -140,7 +142,7 @@ function dependentKeysWillChange(obj, depKey, meta) {
 
 // called whenever a property has just changed to update dependent keys
 function dependentKeysDidChange(obj, depKey, meta) {
-  if (obj.isDestroying) { return; }
+  if (meta && meta.isSourceDestroying()) { return; }
 
   if (meta && meta.hasDeps(depKey)) {
     let seen = DID_SEEN;
@@ -183,28 +185,28 @@ function iterDeps(method, obj, depKey, seen, meta) {
       return;
     }
 
-    method(obj, key);
+    method(obj, key, meta);
   });
 }
 
-function chainsWillChange(obj, keyName, m) {
-  let c = m.readableChainWatchers();
-  if (c) {
-    c.notify(keyName, false, propertyWillChange);
+function chainsWillChange(obj, keyName, meta) {
+  let chainWatchers = meta.readableChainWatchers();
+  if (chainWatchers) {
+    chainWatchers.notify(keyName, false, propertyWillChange);
   }
 }
 
-function chainsDidChange(obj, keyName, m) {
-  let c = m.readableChainWatchers();
-  if (c) {
-    c.notify(keyName, true, propertyDidChange);
+function chainsDidChange(obj, keyName, meta) {
+  let chainWatchers = meta.readableChainWatchers();
+  if (chainWatchers) {
+    chainWatchers.notify(keyName, true, propertyDidChange);
   }
 }
 
-function overrideChains(obj, keyName, m) {
-  let c = m.readableChainWatchers();
-  if (c) {
-    c.revalidate(keyName);
+function overrideChains(obj, keyName, meta) {
+  let chainWatchers = meta.readableChainWatchers();
+  if (chainWatchers) {
+    chainWatchers.revalidate(keyName);
   }
 }
 
@@ -254,8 +256,8 @@ function changeProperties(callback, binding) {
   }
 }
 
-function notifyBeforeObservers(obj, keyName) {
-  if (obj.isDestroying) { return; }
+function notifyBeforeObservers(obj, keyName, meta) {
+  if (meta && meta.isSourceDestroying()) { return; }
 
   let eventName = keyName + ':before';
   let listeners, added;
@@ -268,8 +270,8 @@ function notifyBeforeObservers(obj, keyName) {
   }
 }
 
-function notifyObservers(obj, keyName) {
-  if (obj.isDestroying) { return; }
+function notifyObservers(obj, keyName, meta) {
+  if (meta && meta.isSourceDestroying()) { return; }
 
   let eventName = keyName + ':change';
   let listeners;

--- a/packages/ember-metal/lib/watch_key.js
+++ b/packages/ember-metal/lib/watch_key.js
@@ -85,11 +85,15 @@ if (isEnabled('mandatory-setter')) {
 
 import { UNDEFINED } from './meta';
 
-export function unwatchKey(obj, keyName, meta) {
-  let m = meta || metaFor(obj);
-  let count = m.peekWatching(keyName);
+export function unwatchKey(obj, keyName, _meta) {
+  let meta = _meta || metaFor(obj);
+
+  // do nothing of this object has already been destroyed
+  if (meta.isSourceDestroyed()) { return; }
+
+  let count = meta.peekWatching(keyName);
   if (count === 1) {
-    m.writeWatching(keyName, 0);
+    meta.writeWatching(keyName, 0);
 
     let possibleDesc = obj[keyName];
     let desc = (possibleDesc !== null &&
@@ -116,7 +120,7 @@ export function unwatchKey(obj, keyName, meta) {
 
         if (maybeMandatoryDescriptor.set && maybeMandatoryDescriptor.set.isMandatorySetter) {
           if (maybeMandatoryDescriptor.get && maybeMandatoryDescriptor.get.isInheritingGetter) {
-            let possibleValue = m.readInheritedValue('values', keyName);
+            let possibleValue = meta.readInheritedValue('values', keyName);
             if (possibleValue === UNDEFINED) {
               delete obj[keyName];
               return;
@@ -127,13 +131,13 @@ export function unwatchKey(obj, keyName, meta) {
             configurable: true,
             enumerable: Object.prototype.propertyIsEnumerable.call(obj, keyName),
             writable: true,
-            value: m.peekValues(keyName)
+            value: meta.peekValues(keyName)
           });
-          m.deleteFromValues(keyName);
+          meta.deleteFromValues(keyName);
         }
       }
     }
   } else if (count > 1) {
-    m.writeWatching(keyName, count - 1);
+    meta.writeWatching(keyName, count - 1);
   }
 }

--- a/packages/ember-metal/lib/watching.js
+++ b/packages/ember-metal/lib/watching.js
@@ -3,9 +3,6 @@
 */
 
 import {
-  removeChainWatcher
-} from './chains';
-import {
   watchKey,
   unwatchKey
 } from './watch_key';
@@ -62,8 +59,6 @@ export function unwatch(obj, _keyPath, m) {
   }
 }
 
-const NODE_STACK = [];
-
 /**
   Tears down the meta on an object so that it can be garbage collected.
   Multiple calls will have no effect.
@@ -75,35 +70,5 @@ const NODE_STACK = [];
   @private
 */
 export function destroy(obj) {
-  let meta = peekMeta(obj);
-  let node, nodes, key, nodeObject;
-
-  if (meta) {
-    deleteMeta(obj);
-    // remove chainWatchers to remove circular references that would prevent GC
-    node = meta.readableChains();
-    if (node) {
-      NODE_STACK.push(node);
-      // process tree
-      while (NODE_STACK.length > 0) {
-        node = NODE_STACK.pop();
-        // push children
-        nodes = node._chains;
-        if (nodes) {
-          for (key in nodes) {
-            if (nodes[key] !== undefined) {
-              NODE_STACK.push(nodes[key]);
-            }
-          }
-        }
-        // remove chainWatcher in node object
-        if (node._watching) {
-          nodeObject = node._object;
-          if (nodeObject) {
-            removeChainWatcher(nodeObject, node._key, node);
-          }
-        }
-      }
-    }
-  }
+  deleteMeta(obj);
 }

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -140,10 +140,6 @@ const EmberRouter = EmberObject.extend(Evented, {
     this._handledErrors = dictionary(null);
     this._engineInstances = new EmptyObject();
     this._engineInfoByRoute = new EmptyObject();
-
-    // avoid shaping issues with checks during `_setOutlets`
-    this.isDestroyed = false;
-    this.isDestroying = false;
   },
 
   /*

--- a/packages/ember-runtime/tests/system/object/destroy_test.js
+++ b/packages/ember-runtime/tests/system/object/destroy_test.js
@@ -25,7 +25,6 @@ testBoth('should schedule objects to be destroyed at the end of the run loop', f
   });
 
   meta = peekMeta(obj);
-  ok(!meta, 'meta is destroyed after run loop finishes');
   ok(get(obj, 'isDestroyed'), 'object is destroyed after run loop finishes');
 });
 


### PR DESCRIPTION
- Moves the `isDestroying` and `isDestroyed` flags into meta
- Prevents recreating meta _while_ destroying the object (was happening
  during chain node removal)
- Allows reading values/caches after object destruction, but triggers an
  assertion if non-readable meta methods are called after the object is
  destroyed
- Avoids doing extra work when unwatching keys/paths for an object that
  is also destroyed
