### PR TITLE
[FEATURE factory-for] Implement factoryFor

### DIFF
--- a/features.json
+++ b/features.json
@@ -5,6 +5,7 @@
     "ember-improved-instrumentation": null,
     "ember-metal-weakmap": null,
     "ember-glimmer-allow-backtracking-rerender": null,
-    "ember-testing-resume-test": null
+    "ember-testing-resume-test": null,
+    "container-factoryFor": null
   }
 }

--- a/features.json
+++ b/features.json
@@ -6,6 +6,7 @@
     "ember-metal-weakmap": null,
     "ember-glimmer-allow-backtracking-rerender": null,
     "ember-testing-resume-test": null,
-    "container-factoryFor": null
+    "ember-factory-for": null,
+    "ember-no-double-extend": null
   }
 }

--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -5,13 +5,18 @@ import {
   setOwner,
   OWNER,
   assign,
-  NAME_KEY
+  NAME_KEY,
+  HAS_NATIVE_PROXY
 } from 'ember-utils';
 import { ENV } from 'ember-environment';
-import { assert, deprecate, runInDebug, isFeatureEnabled } from 'ember-metal';
+import {
+  assert,
+  deprecate,
+  runInDebug,
+  isFeatureEnabled
+} from 'ember-metal';
 
 const CONTAINER_OVERRIDE = symbol('CONTAINER_OVERRIDE');
-const HAS_PROXY = typeof Proxy === 'function';
 export const FACTORY_FOR = symbol('FACTORY_FOR');
 export const LOOKUP_FACTORY = symbol('LOOKUP_FACTORY');
 
@@ -38,9 +43,6 @@ export default function Container(registry, options) {
   this[CONTAINER_OVERRIDE] = undefined;
   this.isDestroyed = false;
 }
-
-Container.__FACTORY_FOR__ = FACTORY_FOR;
-Container.__LOOKUP_FACTORY__ = LOOKUP_FACTORY;
 
 Container.prototype = {
   /**
@@ -232,7 +234,7 @@ Container.prototype = {
  * set on the manager.
  */
 function wrapManagerInDeprecationProxy(manager) {
-  if (HAS_PROXY) {
+  if (HAS_NATIVE_PROXY) {
     let validator = {
       get(obj, prop) {
         if (prop !== 'class' && prop !== 'create') {

--- a/packages/container/lib/index.js
+++ b/packages/container/lib/index.js
@@ -8,5 +8,7 @@ The public API, specified on the application namespace should be considered the 
 export { default as Registry, privatize } from './registry';
 export {
   default as Container,
-  buildFakeContainerWithDeprecations
+  buildFakeContainerWithDeprecations,
+  FACTORY_FOR,
+  LOOKUP_FACTORY
 } from './container';

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -640,47 +640,6 @@ QUnit.test('A deprecated `container` property is appended to every object instan
   }
 });
 
-// We're now setting this on the prototype
-QUnit.skip('A deprecated `container` property is only set on a non-extendable factory instance if `container` is present and writable.', function() {
-  expect(2);
-
-  let owner = {};
-  let registry = new Registry();
-  let container = registry.container({ owner });
-
-  // Define a non-extendable factory that is frozen after `create`
-  let PostController = function() {};
-  PostController.create = function() {
-    let instance = new PostController();
-
-    Object.seal(instance);
-
-    return instance;
-  };
-
-  registry.register('controller:post', PostController);
-  let postController = container.lookup('controller:post');
-
-  equal(postController.container, undefined, 'container was not added');
-
-  let OtherController = function() {
-    this.container = 'foo';
-  };
-
-  OtherController.create = function() {
-    let instance = new OtherController();
-
-    Object.freeze(instance);
-
-    return instance;
-  };
-
-  registry.register('controller:other', OtherController);
-  let otherController = container.lookup('controller:other');
-
-  equal(otherController.container, 'foo', 'container was not added');
-});
-
 QUnit.test('An extendable factory can provide `container` upon create, with a deprecation', function(assert) {
   let registry = new Registry();
   let container = registry.container();

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -1,6 +1,6 @@
 import { getOwner, OWNER } from 'ember-utils';
 import { ENV } from 'ember-environment';
-import { get } from 'ember-metal';
+import { get, isFeatureEnabled } from 'ember-metal';
 import { Registry } from '../index';
 import { factory } from 'internal-test-helpers';
 
@@ -14,6 +14,19 @@ QUnit.module('Container', {
     ENV.MODEL_FACTORY_INJECTIONS = originalModelInjections;
   }
 });
+
+function lookupFactory(name, container, options) {
+  let factory;
+  if (isFeatureEnabled('container-factoryFor')) {
+    expectDeprecation(() => {
+      factory = container.lookupFactory(name, options);
+    });
+  } else {
+    factory = container.lookupFactory(name, options);
+  }
+
+  return factory;
+}
 
 QUnit.test('A registered factory returns the same instance each time', function() {
   let registry = new Registry();
@@ -36,7 +49,7 @@ QUnit.test('A registered factory is returned from lookupFactory', function() {
 
   registry.register('controller:post', PostController);
 
-  let PostControllerFactory = container.lookupFactory('controller:post');
+  let PostControllerFactory = lookupFactory('controller:post', container);
 
   ok(PostControllerFactory, 'factory is returned');
   ok(PostControllerFactory.create() instanceof  PostController, 'The return of factory.create is an instance of PostController');
@@ -49,7 +62,10 @@ QUnit.test('A registered factory is returned from lookupFactory is the same fact
 
   registry.register('controller:post', PostController);
 
-  deepEqual(container.lookupFactory('controller:post'), container.lookupFactory('controller:post'), 'The return of lookupFactory is always the same');
+  let Post1 = lookupFactory('controller:post', container);
+  let Post2 = lookupFactory('controller:post', container);
+
+  deepEqual(Post1, Post2, 'The return of lookupFactory is always the same');
 });
 
 QUnit.test('A factory returned from lookupFactory has a debugkey', function() {
@@ -58,7 +74,7 @@ QUnit.test('A factory returned from lookupFactory has a debugkey', function() {
   let PostController = factory();
 
   registry.register('controller:post', PostController);
-  let PostFactory = container.lookupFactory('controller:post');
+  let PostFactory = lookupFactory('controller:post', container);
   equal(PostFactory._debugContainerKey, 'controller:post', 'factory instance receives _debugContainerKey');
 });
 
@@ -87,7 +103,7 @@ QUnit.test('The descendants of a factory returned from lookupFactory have a cont
   let instance;
 
   registry.register('controller:post', PostController);
-  instance = container.lookupFactory('controller:post').create();
+  instance = lookupFactory('controller:post', container).create();
 
   equal(instance._debugContainerKey, 'controller:post', 'factory instance receives _debugContainerKey');
 
@@ -190,7 +206,7 @@ QUnit.test('A factory with both type and individual factoryInjections', function
   registry.factoryInjection('controller:post', 'store', 'store:main');
   registry.factoryTypeInjection('controller', 'router', 'router:main');
 
-  let PostControllerFactory = container.lookupFactory('controller:post');
+  let PostControllerFactory = lookupFactory('controller:post', container);
   let store = container.lookup('store:main');
   let router = container.lookup('router:main');
 
@@ -348,7 +364,7 @@ QUnit.test('The container normalizes names when looking factory up', function() 
   };
 
   registry.register('controller:post', PostController);
-  let fact = container.lookupFactory('controller:normalized');
+  let fact = lookupFactory('controller:normalized', container);
 
   equal(fact.toString() === PostController.extend().toString(), true, 'Normalizes the name when looking factory up');
 });
@@ -428,10 +444,10 @@ QUnit.test('Factory resolves are cached', function() {
   };
 
   deepEqual(resolveWasCalled, []);
-  container.lookupFactory('controller:post');
+  lookupFactory('controller:post', container);
   deepEqual(resolveWasCalled, ['controller:post']);
 
-  container.lookupFactory('controller:post');
+  lookupFactory('controller:post', container);
   deepEqual(resolveWasCalled, ['controller:post']);
 });
 
@@ -446,10 +462,10 @@ QUnit.test('factory for non extendables (MODEL) resolves are cached', function()
   };
 
   deepEqual(resolveWasCalled, []);
-  container.lookupFactory('model:post');
+  lookupFactory('model:post', container);
   deepEqual(resolveWasCalled, ['model:post']);
 
-  container.lookupFactory('model:post');
+  lookupFactory('model:post', container);
   deepEqual(resolveWasCalled, ['model:post']);
 });
 
@@ -465,15 +481,19 @@ QUnit.test('factory for non extendables resolves are cached', function() {
   };
 
   deepEqual(resolveWasCalled, []);
-  container.lookupFactory('foo:post');
+  lookupFactory('foo:post', container);
   deepEqual(resolveWasCalled, ['foo:post']);
 
-  container.lookupFactory('foo:post');
+  lookupFactory('foo:post', container);
   deepEqual(resolveWasCalled, ['foo:post']);
 });
 
 QUnit.test('The `_onLookup` hook is called on factories when looked up the first time', function() {
-  expect(2);
+  if (isFeatureEnabled('container-factoryFor')) {
+    expect(4);
+  } else {
+    expect(2);
+  }
 
   let registry = new Registry();
   let container = registry.container();
@@ -488,8 +508,8 @@ QUnit.test('The `_onLookup` hook is called on factories when looked up the first
 
   registry.register('apple:main', Apple);
 
-  container.lookupFactory('apple:main');
-  container.lookupFactory('apple:main');
+  lookupFactory('apple:main', container);
+  lookupFactory('apple:main', container);
 });
 
 QUnit.test('A factory\'s lazy injections are validated when first instantiated', function() {
@@ -561,8 +581,14 @@ QUnit.test('A deprecated `container` property is appended to every object instan
   }, 'Using the injected `container` is deprecated. Please use the `getOwner` helper instead to access the owner of this object.');
 });
 
+// This is testing that container was passed as an option
 QUnit.test('A deprecated `container` property is appended to every object instantiated from a non-extendable factory, and a fake container is available during instantiation.', function() {
-  expect(8);
+  if (!isFeatureEnabled('container-factoryFor')) {
+    expect(8);
+  } else {
+    expect(1);
+    ok(true, '[SKIPPED] This will be removed when `factoryFor` lands.');
+  }
 
   let owner = {};
   let registry = new Registry();
@@ -599,19 +625,23 @@ QUnit.test('A deprecated `container` property is appended to every object instan
   };
 
   registry.register('controller:post', PostController);
-  let postController = container.lookup('controller:post');
 
-  expectDeprecation(() => {
-    get(postController, 'container');
-  }, 'Using the injected `container` is deprecated. Please use the `getOwner` helper instead to access the owner of this object.');
+  if (!isFeatureEnabled('container-factoryFor')) {
+    let postController = container.lookup('controller:post');
 
-  expectDeprecation(() => {
-    let c = postController.container;
-    strictEqual(c, container, 'Injected container is now regular (not fake) container, but access is still deprecated.');
-  }, 'Using the injected `container` is deprecated. Please use the `getOwner` helper instead to access the owner of this object.');
+    expectDeprecation(() => {
+      get(postController, 'container');
+    }, 'Using the injected `container` is deprecated. Please use the `getOwner` helper instead to access the owner of this object.');
+
+    expectDeprecation(() => {
+      let c = postController.container;
+      strictEqual(c, container, 'Injected container is now regular (not fake) container, but access is still deprecated.');
+    }, 'Using the injected `container` is deprecated. Please use the `getOwner` helper instead to access the owner of this object.');
+  }
 });
 
-QUnit.test('A deprecated `container` property is only set on a non-extendable factory instance if `container` is present and writable.', function() {
+// We're now setting this on the prototype
+QUnit.skip('A deprecated `container` property is only set on a non-extendable factory instance if `container` is present and writable.', function() {
   expect(2);
 
   let owner = {};
@@ -657,7 +687,7 @@ QUnit.test('An extendable factory can provide `container` upon create, with a de
 
   registry.register('controller:post', factory());
 
-  let PostController = container.lookupFactory('controller:post');
+  let PostController = lookupFactory('controller:post', container);
 
   let postController;
 
@@ -688,7 +718,7 @@ QUnit.test('lookupFactory passes options through to expandlocallookup', function
     return 'controller:post';
   };
 
-  let PostControllerFactory = container.lookupFactory('foo:bar', { source: 'baz:qux' });
+  let PostControllerFactory = lookupFactory('foo:bar', container, { source: 'baz:qux' });
 
   assert.ok(PostControllerFactory.create() instanceof  PostController, 'The return of factory.create is an instance of PostController');
 });
@@ -711,4 +741,89 @@ QUnit.test('lookup passes options through to expandlocallookup', function(assert
   let PostControllerLookupResult = container.lookup('foo:bar', { source: 'baz:qux' });
 
   assert.ok(PostControllerLookupResult instanceof PostController);
+});
+
+
+QUnit.test('#factoryFor must supply a fullname', (assert) => {
+  let registry = new Registry();
+  let container = registry.container();
+  assert.throws(() => {
+    container.factoryFor('chad-bar');
+  }, /Invalid Fullname, expected: 'type:name' got: chad-bar/);
+});
+
+QUnit.test('#factoryFor returns a factory creator', (assert) => {
+  let registry = new Registry();
+  let container = registry.container();
+
+  let Component = factory();
+  registry.register('component:foo-bar', Component);
+
+  let factoryCreator = container.factoryFor('component:foo-bar');
+  assert.ok(factoryCreator.create);
+  assert.ok(factoryCreator.class);
+});
+
+QUnit.test('#factoryFor class returns the factory function', (assert) => {
+  let registry = new Registry();
+  let container = registry.container();
+
+  let Component = factory();
+  registry.register('component:foo-bar', Component);
+
+  let factoryCreator = container.factoryFor('component:foo-bar');
+  if (isFeatureEnabled('container-factoryFor')) {
+    assert.deepEqual(factoryCreator.class, Component, 'No double extend');
+  } else {
+    assert.notDeepEqual(factoryCreator.class, Component, 'Double extended class');
+  }
+});
+
+QUnit.test('#factoryFor instance have a common parent', (assert) => {
+  let registry = new Registry();
+  let container = registry.container();
+
+  let Component = factory();
+  registry.register('component:foo-bar', Component);
+
+  let factoryCreator1 = container.factoryFor('component:foo-bar');
+  let factoryCreator2 = container.factoryFor('component:foo-bar');
+  let instance1 = factoryCreator1.create({ foo: 'foo' });
+  let instance2 = factoryCreator2.create({ bar: 'bar' });
+
+  assert.deepEqual(instance1.constructor, instance2.constructor);
+});
+
+QUnit.test('#factoryFor created instances come with instance injections', (assert) => {
+  let registry = new Registry();
+  let container = registry.container();
+
+  let Component = factory();
+  let Ajax = factory();
+  registry.register('component:foo-bar', Component);
+  registry.register('util:ajax', Ajax);
+  registry.injection('component:foo-bar', 'ajax', 'util:ajax');
+
+  let componentFactory = container.factoryFor('component:foo-bar');
+  let component = componentFactory.create();
+
+  assert.ok(component.ajax);
+  assert.ok(component.ajax instanceof Ajax);
+});
+
+QUnit.test('#factoryFor options passed to create clobber injections', (assert) => {
+  let registry = new Registry();
+  let container = registry.container();
+
+  let Component = factory();
+  let Ajax = factory();
+  registry.register('component:foo-bar', Component);
+  registry.register('util:ajax', Ajax);
+  registry.injection('component:foo-bar', 'ajax', 'util:ajax');
+
+  let componentFactory = container.factoryFor('component:foo-bar');
+
+  let instrance = componentFactory.create({ ajax: 'fetch' });
+
+  assert.equal(instrance.ajax, 'fetch');
 });

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -4,7 +4,7 @@
 */
 
 import { assign } from 'ember-utils';
-import { deprecate, get, set, run, computed } from 'ember-metal';
+import { deprecate, get, set, run, computed, isFeatureEnabled } from 'ember-metal';
 import {
   buildFakeRegistryWithDeprecations,
   RSVP
@@ -12,6 +12,7 @@ import {
 import { environment } from 'ember-environment';
 import { jQuery } from 'ember-views';
 import EngineInstance from './engine-instance';
+import { FACTORY_FOR, LOOKUP_FACTORY } from 'container';
 
 let BootOptions;
 
@@ -126,10 +127,6 @@ const ApplicationInstance = EngineInstance.extend({
     this._booted = true;
 
     return this;
-  },
-
-  factoryFor(fullName, options) {
-    return this.__container__.factoryFor(fullName, options);
   },
 
   setupRegistry(options) {
@@ -282,8 +279,24 @@ const ApplicationInstance = EngineInstance.extend({
 
     // getURL returns the set url with the rootURL stripped off
     return router.handleURL(location.getURL()).then(handleTransitionResolve, handleTransitionReject);
+  },
+
+  [FACTORY_FOR](fullName, options) {
+    return this.__container__[FACTORY_FOR](fullName, options);
+  },
+
+  [LOOKUP_FACTORY](fullName, options) {
+    return this.__container__[LOOKUP_FACTORY](fullName, options);
   }
 });
+
+if (isFeatureEnabled('ember-factory-for')) {
+  ApplicationInstance.reopen({
+    factoryFor(fullName, options) {
+      return this.__container__.factoryFor(fullName, options);
+    }
+  });
+}
 
 ApplicationInstance.reopenClass({
   /**

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -128,6 +128,10 @@ const ApplicationInstance = EngineInstance.extend({
     return this;
   },
 
+  factoryFor(fullName, options) {
+    return this.__container__.factoryFor(fullName, options);
+  },
+
   setupRegistry(options) {
     this.constructor.setupRegistry(this.__registry__, options);
   },

--- a/packages/ember-application/lib/system/engine-instance.js
+++ b/packages/ember-application/lib/system/engine-instance.js
@@ -10,8 +10,8 @@ import {
   RegistryProxyMixin,
   RSVP
 } from 'ember-runtime';
-import { Error as EmberError, assert, run } from 'ember-metal';
-import { Registry, privatize as P } from 'container';
+import { Error as EmberError, assert, run, isFeatureEnabled } from 'ember-metal';
+import { Registry, FACTORY_FOR, LOOKUP_FACTORY, privatize as P } from 'container';
 import { getEngineParent, setEngineParent } from './engine-parent';
 
 /**
@@ -162,10 +162,6 @@ const EngineInstance = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixi
     return engineInstance;
   },
 
-  factoryFor(fullName, options) {
-    return this.__container__.factoryFor(fullName, options);
-  },
-
   /**
     Clone dependencies shared between an engine instance and its parent.
 
@@ -198,8 +194,24 @@ const EngineInstance = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixi
 
     this.inject('view', '_environment', '-environment:main');
     this.inject('route', '_environment', '-environment:main');
+  },
+
+  [FACTORY_FOR](fullName, options) {
+    return this.__container__[FACTORY_FOR](fullName, options);
+  },
+
+  [LOOKUP_FACTORY](fullName, options) {
+    return this.__container__[LOOKUP_FACTORY](fullName, options);
   }
 });
+
+if (isFeatureEnabled('ember-factory-for')) {
+  EngineInstance.reopen({
+    factoryFor(fullName, options) {
+      return this.__container__.factoryFor(fullName, options);
+    }
+  });
+}
 
 EngineInstance.reopenClass({
   /**

--- a/packages/ember-application/lib/system/engine-instance.js
+++ b/packages/ember-application/lib/system/engine-instance.js
@@ -162,6 +162,10 @@ const EngineInstance = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixi
     return engineInstance;
   },
 
+  factoryFor(fullName, options) {
+    return this.__container__.factoryFor(fullName, options);
+  },
+
   /**
     Clone dependencies shared between an engine instance and its parent.
 

--- a/packages/ember-application/lib/system/engine-instance.js
+++ b/packages/ember-application/lib/system/engine-instance.js
@@ -10,7 +10,7 @@ import {
   RegistryProxyMixin,
   RSVP
 } from 'ember-runtime';
-import { Error as EmberError, assert, run, isFeatureEnabled } from 'ember-metal';
+import { Error as EmberError, assert, run } from 'ember-metal';
 import { Registry, FACTORY_FOR, LOOKUP_FACTORY, privatize as P } from 'container';
 import { getEngineParent, setEngineParent } from './engine-parent';
 
@@ -204,14 +204,6 @@ const EngineInstance = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixi
     return this.__container__[LOOKUP_FACTORY](fullName, options);
   }
 });
-
-if (isFeatureEnabled('ember-factory-for')) {
-  EngineInstance.reopen({
-    factoryFor(fullName, options) {
-      return this.__container__.factoryFor(fullName, options);
-    }
-  });
-}
 
 EngineInstance.reopenClass({
   /**

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -65,14 +65,16 @@ QUnit.test('the default resolver looks up templates in Ember.TEMPLATES', functio
   setTemplate('fooBar', fooBarTemplate);
   setTemplate('fooBar/baz', fooBarBazTemplate);
 
+  ignoreDeprecation(() => {
+    equal(locator.lookupFactory('template:foo'), fooTemplate, 'resolves template:foo');
+    equal(locator.lookupFactory('template:fooBar'), fooBarTemplate, 'resolves template:foo_bar');
+    equal(locator.lookupFactory('template:fooBar.baz'), fooBarBazTemplate, 'resolves template:foo_bar.baz');
+  });
+
   if (isFeatureEnabled('ember-factory-for')) {
     equal(locator.factoryFor('template:foo').class, fooTemplate, 'resolves template:foo');
     equal(locator.factoryFor('template:fooBar').class, fooBarTemplate, 'resolves template:foo_bar');
     equal(locator.factoryFor('template:fooBar.baz').class, fooBarBazTemplate, 'resolves template:foo_bar.baz');
-  } else {
-    equal(locator.lookupFactory('template:foo'), fooTemplate, 'resolves template:foo');
-    equal(locator.lookupFactory('template:fooBar'), fooBarTemplate, 'resolves template:foo_bar');
-    equal(locator.lookupFactory('template:fooBar.baz'), fooBarBazTemplate, 'resolves template:foo_bar.baz');
   }
 });
 
@@ -93,48 +95,61 @@ QUnit.test('the default resolver looks up arbitrary types on the namespace', fun
 QUnit.test('the default resolver resolves models on the namespace', function() {
   application.Post = EmberObject.extend({});
 
+  ignoreDeprecation(() => {
+    detectEqual(application.Post, locator.lookupFactory('model:post'), 'looks up Post model on application');
+  });
   if (isFeatureEnabled('ember-factory-for')) {
     detectEqual(application.Post, locator.factoryFor('model:post').class, 'looks up Post model on application');
-  } else {
-    detectEqual(application.Post, locator.lookupFactory('model:post'), 'looks up Post model on application');
   }
 });
 
 QUnit.test('the default resolver resolves *:main on the namespace', function() {
   application.FooBar = EmberObject.extend({});
 
+  ignoreDeprecation(() => {
+    detectEqual(application.FooBar, locator.lookupFactory('foo-bar:main'), 'looks up FooBar type without name on application');
+  });
   if (isFeatureEnabled('ember-factory-for')) {
     detectEqual(application.FooBar, locator.factoryFor('foo-bar:main').class, 'looks up FooBar type without name on application');
-  } else {
-    detectEqual(application.FooBar, locator.lookupFactory('foo-bar:main'), 'looks up FooBar type without name on application');
   }
 });
 
-QUnit.test('the default resolver resolves container-registered helpers', function() {
+if (isFeatureEnabled('ember-factory-for')) {
+  QUnit.test('the default resolver resolves container-registered helpers', function() {
+    let shorthandHelper = makeHelper(() => {});
+    let helper = Helper.extend();
+
+    application.register('helper:shorthand', shorthandHelper);
+    application.register('helper:complete', helper);
+
+    let lookedUpShorthandHelper = locator.factoryFor('helper:shorthand').class;
+
+    ok(lookedUpShorthandHelper.isHelperInstance, 'shorthand helper isHelper');
+
+    let lookedUpHelper = locator.factoryFor('helper:complete').class;
+
+    ok(lookedUpHelper.isHelperFactory, 'complete helper is factory');
+    ok(helper.detect(lookedUpHelper), 'looked up complete helper');
+  });
+}
+
+QUnit.test('the default resolver resolves container-registered helpers via lookupFor', function() {
   let shorthandHelper = makeHelper(() => {});
   let helper = Helper.extend();
 
   application.register('helper:shorthand', shorthandHelper);
   application.register('helper:complete', helper);
 
-  let lookedUpShorthandHelper;
-  if (isFeatureEnabled('ember-factory-for')) {
-    lookedUpShorthandHelper = locator.factoryFor('helper:shorthand').class;
-  } else {
-    lookedUpShorthandHelper = locator.lookupFactory('helper:shorthand');
-  }
+  ignoreDeprecation(() => {
+    let lookedUpShorthandHelper = locator.lookupFactory('helper:shorthand');
 
-  ok(lookedUpShorthandHelper.isHelperInstance, 'shorthand helper isHelper');
+    ok(lookedUpShorthandHelper.isHelperInstance, 'shorthand helper isHelper');
 
-  let lookedUpHelper;
-  if (isFeatureEnabled('ember-factory-for')) {
-    lookedUpHelper = locator.factoryFor('helper:complete').class;
-  } else {
-    lookedUpHelper = locator.lookupFactory('helper:complete');
-  }
+    let lookedUpHelper = locator.lookupFactory('helper:complete');
 
-  ok(lookedUpHelper.isHelperFactory, 'complete helper is factory');
-  ok(helper.detect(lookedUpHelper), 'looked up complete helper');
+    ok(lookedUpHelper.isHelperFactory, 'complete helper is factory');
+    ok(helper.detect(lookedUpHelper), 'looked up complete helper');
+  });
 });
 
 QUnit.test('the default resolver resolves helpers on the namespace', function() {

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -64,9 +64,9 @@ QUnit.test('the default resolver looks up templates in Ember.TEMPLATES', functio
   setTemplate('fooBar', fooBarTemplate);
   setTemplate('fooBar/baz', fooBarBazTemplate);
 
-  equal(locator.lookupFactory('template:foo'), fooTemplate, 'resolves template:foo');
-  equal(locator.lookupFactory('template:fooBar'), fooBarTemplate, 'resolves template:foo_bar');
-  equal(locator.lookupFactory('template:fooBar.baz'), fooBarBazTemplate, 'resolves template:foo_bar.baz');
+  equal(locator.factoryFor('template:foo').class, fooTemplate, 'resolves template:foo');
+  equal(locator.factoryFor('template:fooBar').class, fooBarTemplate, 'resolves template:foo_bar');
+  equal(locator.factoryFor('template:fooBar.baz').class, fooBarBazTemplate, 'resolves template:foo_bar.baz');
 });
 
 QUnit.test('the default resolver looks up basic name as no prefix', function() {
@@ -86,13 +86,13 @@ QUnit.test('the default resolver looks up arbitrary types on the namespace', fun
 QUnit.test('the default resolver resolves models on the namespace', function() {
   application.Post = EmberObject.extend({});
 
-  detectEqual(application.Post, locator.lookupFactory('model:post'), 'looks up Post model on application');
+  detectEqual(application.Post, locator.factoryFor('model:post').class, 'looks up Post model on application');
 });
 
 QUnit.test('the default resolver resolves *:main on the namespace', function() {
   application.FooBar = EmberObject.extend({});
 
-  detectEqual(application.FooBar, locator.lookupFactory('foo-bar:main'), 'looks up FooBar type without name on application');
+  detectEqual(application.FooBar, locator.factoryFor('foo-bar:main').class, 'looks up FooBar type without name on application');
 });
 
 QUnit.test('the default resolver resolves container-registered helpers', function() {
@@ -102,10 +102,10 @@ QUnit.test('the default resolver resolves container-registered helpers', functio
   application.register('helper:shorthand', shorthandHelper);
   application.register('helper:complete', helper);
 
-  let lookedUpShorthandHelper = locator.lookupFactory('helper:shorthand');
+  let lookedUpShorthandHelper = locator.factoryFor('helper:shorthand').class;
   ok(lookedUpShorthandHelper.isHelperInstance, 'shorthand helper isHelper');
 
-  let lookedUpHelper = locator.lookupFactory('helper:complete');
+  let lookedUpHelper = locator.factoryFor('helper:complete').class;
   ok(lookedUpHelper.isHelperFactory, 'complete helper is factory');
   ok(helper.detect(lookedUpHelper), 'looked up complete helper');
 });

--- a/packages/ember-application/tests/system/dependency_injection/to_string_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/to_string_test.js
@@ -32,7 +32,7 @@ QUnit.module('Ember.Application Dependency Injection – toString', {
 });
 
 QUnit.test('factories', function() {
-  let PostFactory = App.__container__.lookupFactory('model:post');
+  let PostFactory = App.__container__.factoryFor('model:post').class;
   equal(PostFactory.toString(), 'App.Post', 'expecting the model to be post');
 });
 

--- a/packages/ember-application/tests/system/dependency_injection/to_string_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/to_string_test.js
@@ -1,6 +1,6 @@
 import { guidFor } from 'ember-utils';
 import { ENV, context } from 'ember-environment'; // lookup, etc
-import { run } from 'ember-metal';
+import { run, isFeatureEnabled } from 'ember-metal';
 import Application from '../../../system/application';
 import { Object as EmberObject } from 'ember-runtime';
 import DefaultResolver from '../../../system/resolver';
@@ -32,7 +32,12 @@ QUnit.module('Ember.Application Dependency Injection – toString', {
 });
 
 QUnit.test('factories', function() {
-  let PostFactory = App.__container__.factoryFor('model:post').class;
+  let PostFactory;
+  if (isFeatureEnabled('ember-factory-for')) {
+    PostFactory = App.__container__.factoryFor('model:post').class;
+  } else {
+    PostFactory = App.__container__.lookupFactory('model:post');
+  }
   equal(PostFactory.toString(), 'App.Post', 'expecting the model to be post');
 });
 

--- a/packages/ember-extension-support/lib/data_adapter.js
+++ b/packages/ember-extension-support/lib/data_adapter.js
@@ -163,7 +163,7 @@ export default EmberObject.extend({
 
   _nameToClass(type) {
     if (typeof type === 'string') {
-      type = getOwner(this)._lookupFactory(`model:${type}`);
+      type = getOwner(this).factoryFor(`model:${type}`).class;
     }
     return type;
   },

--- a/packages/ember-extension-support/lib/data_adapter.js
+++ b/packages/ember-extension-support/lib/data_adapter.js
@@ -9,6 +9,7 @@ import {
   removeArrayObserver,
   objectAt
 } from 'ember-runtime';
+import { FACTORY_FOR } from 'container';
 import { Application } from 'ember-application';
 
 /**
@@ -163,7 +164,8 @@ export default EmberObject.extend({
 
   _nameToClass(type) {
     if (typeof type === 'string') {
-      type = getOwner(this).factoryFor(`model:${type}`).class;
+      let owner = getOwner(this);
+      type = owner[FACTORY_FOR](`model:${type}`).class;
     }
     return type;
   },

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -320,6 +320,9 @@ export default class Environment extends GlimmerEnvironment {
       if (helperFactory.class.isHelperInstance) {
         return (vm, args) => SimpleHelperReference.create(helperFactory.class.compute, args);
       } else if (helperFactory.class.isHelperFactory) {
+        if (!isFeatureEnabled('ember-no-double-extend')) {
+          helperFactory = helperFactory.create();
+        }
         return (vm, args) => ClassBasedHelperReference.create(helperFactory, vm, args);
       } else {
         throw new Error(`${nameParts} is not a helper`);

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -74,9 +74,10 @@ export default class Environment extends GlimmerEnvironment {
     installPlatformSpecificProtocolForURL(this);
 
     this._definitionCache = new Cache(2000, ({ name, source, owner }) => {
-      let { component: ComponentClass, layout } = lookupComponent(owner, name, { source });
-      if (ComponentClass || layout) {
-        return new CurlyComponentDefinition(name, ComponentClass, layout);
+      let { component: componentFactory, layout } = lookupComponent(owner, name, { source });
+
+      if ((componentFactory && componentFactory.class) || layout) {
+        return new CurlyComponentDefinition(name, componentFactory, layout);
       }
     }, ({ name, source, owner }) => {
       let expandedName = source && owner._resolveLocalLookupName(name, source) || name;

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -51,6 +51,7 @@ import { default as normalizeClassHelper } from './helpers/-normalize-class';
 import { default as htmlSafeHelper } from './helpers/-html-safe';
 
 import installPlatformSpecificProtocolForURL from './protocol-for-url';
+import { FACTORY_FOR } from 'container';
 
 const builtInComponents = {
   textarea: '-text-area'
@@ -76,7 +77,7 @@ export default class Environment extends GlimmerEnvironment {
     this._definitionCache = new Cache(2000, ({ name, source, owner }) => {
       let { component: componentFactory, layout } = lookupComponent(owner, name, { source });
 
-      if ((componentFactory && componentFactory.class) || layout) {
+      if (componentFactory || layout) {
         return new CurlyComponentDefinition(name, componentFactory, layout);
       }
     }, ({ name, source, owner }) => {
@@ -312,8 +313,8 @@ export default class Environment extends GlimmerEnvironment {
     let owner = blockMeta.owner;
     let options = blockMeta.moduleName && { source: `template:${blockMeta.moduleName}` } || {};
 
-    if (isFeatureEnabled('container-factoryFor')) {
-      let helperFactory = owner.factoryFor(`helper:${name}`, options) || owner.factoryFor(`helper:${name}`);
+    if (isFeatureEnabled('ember-factory-for')) {
+      let helperFactory = owner[FACTORY_FOR](`helper:${name}`, options) || owner[FACTORY_FOR](`helper:${name}`);
 
       // TODO: try to unify this into a consistent protocol to avoid wasteful closure allocations
       if (helperFactory.class.isHelperInstance) {

--- a/packages/ember-glimmer/lib/helpers/component.js
+++ b/packages/ember-glimmer/lib/helpers/component.js
@@ -206,7 +206,7 @@ function createCurriedDefinition(definition, args) {
 
 function curryArgs(definition, newArgs) {
   let { args, ComponentClass } = definition;
-  let { positionalParams } = ComponentClass;
+  let { positionalParams } = ComponentClass.class;
 
   // The args being passed in are from the (component ...) invocation,
   // so the first positional argument is actually the name or component

--- a/packages/ember-glimmer/lib/helpers/component.js
+++ b/packages/ember-glimmer/lib/helpers/component.js
@@ -206,7 +206,7 @@ function createCurriedDefinition(definition, args) {
 
 function curryArgs(definition, newArgs) {
   let { args, ComponentClass } = definition;
-  let { positionalParams } = ComponentClass.class;
+  let positionalParams = ComponentClass.class.positionalParams;
 
   // The args being passed in are from the (component ...) invocation,
   // so the first positional argument is actually the name or component

--- a/packages/ember-glimmer/lib/setup-registry.js
+++ b/packages/ember-glimmer/lib/setup-registry.js
@@ -32,7 +32,9 @@ export function setupApplicationRegistry(registry) {
   }
 
   registry.register('service:-dom-changes', {
-    create({ document }) { return new DOMChanges(document); }
+    create({ document }) {
+      return new DOMChanges(document);
+    }
   });
 
   registry.register('service:-dom-tree-construction', {

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -178,7 +178,10 @@ function rerenderInstrumentDetails(component) {
 
 class CurlyComponentManager {
   prepareArgs(definition, args) {
-    validatePositionalParameters(args.named, args.positional.values, definition.ComponentClass.positionalParams);
+    if (definition.ComponentClass && definition.ComponentClass.class) {
+      validatePositionalParameters(args.named, args.positional.values, definition.ComponentClass.class.positionalParams);
+    }
+
 
     return gatherArgs(args, definition);
   }
@@ -186,7 +189,8 @@ class CurlyComponentManager {
   create(environment, definition, args, dynamicScope, callerSelfRef, hasBlock) {
     let parentView = dynamicScope.view;
 
-    let klass = definition.ComponentClass;
+    let factory = definition.ComponentClass;
+
     let processedArgs = ComponentArgs.create(args);
     let { props } = processedArgs.value();
 
@@ -197,7 +201,7 @@ class CurlyComponentManager {
 
     props._targetObject = callerSelfRef.value();
 
-    let component = klass.create(props);
+    let component = factory.create(props);
 
     let finalizer = _instrumentStart('render.component', initialRenderInstrumentDetails, component);
 
@@ -363,7 +367,7 @@ const MANAGER = new CurlyComponentManager();
 
 class TopComponentManager extends CurlyComponentManager {
   create(environment, definition, args, dynamicScope, currentScope, hasBlock) {
-    let component = definition.ComponentClass;
+    let component = definition.ComponentClass.create();
 
     let finalizer = _instrumentStart('render.component', initialRenderInstrumentDetails, component);
 
@@ -410,7 +414,12 @@ export class CurlyComponentDefinition extends ComponentDefinition {
 
 export class RootComponentDefinition extends ComponentDefinition {
   constructor(instance) {
-    super('-root', ROOT_MANAGER, instance);
+    super('-root', ROOT_MANAGER, {
+      class: instance.constructor,
+      create() {
+        return instance;
+      }
+    });
     this.template = undefined;
     this.args = undefined;
   }

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -178,10 +178,9 @@ function rerenderInstrumentDetails(component) {
 
 class CurlyComponentManager {
   prepareArgs(definition, args) {
-    if (definition.ComponentClass && definition.ComponentClass.class) {
+    if (definition.ComponentClass) {
       validatePositionalParameters(args.named, args.positional.values, definition.ComponentClass.class.positionalParams);
     }
-
 
     return gatherArgs(args, definition);
   }

--- a/packages/ember-glimmer/lib/syntax/mount.js
+++ b/packages/ember-glimmer/lib/syntax/mount.js
@@ -88,7 +88,7 @@ class MountManager {
   }
 
   getSelf({ engine }) {
-    let factory = engine._lookupFactory(`controller:application`) || generateControllerFactory(engine, 'application');
+    let factory = engine.factoryFor(`controller:application`) || generateControllerFactory(engine, 'application');
     return new RootReference(factory.create());
   }
 

--- a/packages/ember-glimmer/lib/syntax/mount.js
+++ b/packages/ember-glimmer/lib/syntax/mount.js
@@ -12,6 +12,7 @@ import { assert } from 'ember-metal';
 import { RootReference } from '../utils/references';
 import { generateControllerFactory } from 'ember-routing';
 import { OutletLayoutCompiler } from './outlet';
+import { FACTORY_FOR } from 'container';
 /**
   The `{{mount}}` helper lets you embed a routeless engine in a template.
   Mounting an engine will cause an instance to be booted and its `application`
@@ -88,7 +89,8 @@ class MountManager {
   }
 
   getSelf({ engine }) {
-    let factory = engine.factoryFor(`controller:application`) || generateControllerFactory(engine, 'application');
+    let applicationFactory = engine[FACTORY_FOR](`controller:application`);
+    let factory = applicationFactory || generateControllerFactory(engine, 'application');
     return new RootReference(factory.create());
   }
 

--- a/packages/ember-glimmer/lib/syntax/render.js
+++ b/packages/ember-glimmer/lib/syntax/render.js
@@ -12,6 +12,7 @@ import { assert } from 'ember-metal';
 import { RootReference } from '../utils/references';
 import { generateController, generateControllerFactory } from 'ember-routing';
 import { OutletLayoutCompiler } from './outlet';
+import { FACTORY_FOR } from 'container';
 
 function makeComponentDefinition(vm) {
   let env     = vm.env;
@@ -186,8 +187,9 @@ class NonSingletonRenderManager extends AbstractRenderManager {
   create(environment, definition, args, dynamicScope) {
     let { name, env } = definition;
     let modelRef = args.positional.at(0);
+    let controllerFactory = env.owner[FACTORY_FOR](`controller:${name}`);
 
-    let factory = env.owner.factoryFor(`controller:${name}`) || generateControllerFactory(env.owner, name);
+    let factory = controllerFactory || generateControllerFactory(env.owner, name);
     let controller = factory.create({ model: modelRef.value() });
 
     if (dynamicScope.rootOutletState) {

--- a/packages/ember-glimmer/lib/syntax/render.js
+++ b/packages/ember-glimmer/lib/syntax/render.js
@@ -187,7 +187,7 @@ class NonSingletonRenderManager extends AbstractRenderManager {
     let { name, env } = definition;
     let modelRef = args.positional.at(0);
 
-    let factory = env.owner._lookupFactory(`controller:${name}`) || generateControllerFactory(env.owner, name);
+    let factory = env.owner.factoryFor(`controller:${name}`) || generateControllerFactory(env.owner, name);
     let controller = factory.create({ model: modelRef.value() });
 
     if (dynamicScope.rootOutletState) {

--- a/packages/ember-glimmer/lib/utils/process-args.js
+++ b/packages/ember-glimmer/lib/utils/process-args.js
@@ -21,7 +21,7 @@ import {
 export function gatherArgs(args, definition) {
   let namedMap = gatherNamedMap(args, definition);
   let positionalValues = gatherPositionalValues(args, definition);
-  return mergeArgs(namedMap, positionalValues, args.blocks, definition.ComponentClass);
+  return mergeArgs(namedMap, positionalValues, args.blocks, definition.ComponentClass.class);
 }
 
 function gatherNamedMap(args, definition) {

--- a/packages/ember-glimmer/tests/integration/components/append-test.js
+++ b/packages/ember-glimmer/tests/integration/components/append-test.js
@@ -1,4 +1,4 @@
-import { set } from 'ember-metal';
+import { set, isFeatureEnabled } from 'ember-metal';
 import { jQuery } from 'ember-views';
 import { moduleFor, RenderingTest } from '../../utils/test-case';
 import { Component, compile } from '../../utils/helpers';
@@ -134,7 +134,13 @@ class AbstractAppendTest extends RenderingTest {
       template: '[child: {{bar}}]{{yield}}'
     });
 
-    let XParent = this.owner.factoryFor('component:x-parent');
+    let XParent;
+
+    if (isFeatureEnabled('ember-factory-for')) {
+      XParent = this.owner.factoryFor('component:x-parent');
+    } else {
+      XParent = this.owner._lookupFactory('component:x-parent');
+    }
 
     this.component = XParent.create({ foo: 'zomg' });
 
@@ -279,7 +285,13 @@ class AbstractAppendTest extends RenderingTest {
       template: '[child: {{bar}}]{{yield}}'
     });
 
-    let XParent = this.owner.factoryFor('component:x-parent');
+    let XParent;
+
+    if (isFeatureEnabled('ember-factory-for')) {
+      XParent = this.owner.factoryFor('component:x-parent');
+    } else {
+      XParent = this.owner._lookupFactory('component:x-parent');
+    }
 
     this.component = XParent.create({ foo: 'zomg' });
 
@@ -350,8 +362,15 @@ class AbstractAppendTest extends RenderingTest {
       template: 'x-second {{bar}}!'
     });
 
-    let First = this.owner.factoryFor('component:x-first');
-    let Second = this.owner.factoryFor('component:x-second');
+    let First, Second;
+
+    if (isFeatureEnabled('ember-factory-for')) {
+      First = this.owner.factoryFor('component:x-first');
+      Second = this.owner.factoryFor('component:x-second');
+    } else {
+      First = this.owner._lookupFactory('component:x-first');
+      Second = this.owner._lookupFactory('component:x-second');
+    }
 
     let first = First.create({ foo: 'foo' });
     let second = Second.create({ bar: 'bar' });
@@ -431,7 +450,13 @@ class AbstractAppendTest extends RenderingTest {
 
         didInsertElement() {
           element1 = this.element;
-          let SecondComponent = owner.factoryFor('component:second-component');
+
+          let SecondComponent;
+          if (isFeatureEnabled('ember-factory-for')) {
+            SecondComponent = owner.factoryFor('component:second-component');
+          } else {
+            SecondComponent = owner._lookupFactory('component:second-component');
+          }
 
           append(SecondComponent.create());
         }
@@ -448,7 +473,13 @@ class AbstractAppendTest extends RenderingTest {
       })
     });
 
-    let FirstComponent = this.owner.factoryFor('component:first-component');
+    let FirstComponent;
+
+    if (isFeatureEnabled('ember-factory-for')) {
+      FirstComponent = this.owner.factoryFor('component:first-component');
+    } else {
+      FirstComponent = this.owner._lookupFactory('component:first-component');
+    }
 
     this.runTask(() => append(FirstComponent.create()));
 
@@ -475,7 +506,13 @@ class AbstractAppendTest extends RenderingTest {
 
         didInsertElement() {
           element1 = this.element;
-          let OtherRoot = owner.factoryFor('component:other-root');
+          let OtherRoot;
+
+          if (isFeatureEnabled('ember-factory-for')) {
+            OtherRoot = owner.factoryFor('component:other-root');
+          } else {
+            OtherRoot = owner._lookupFactory('component:other-root');
+          }
 
           this._instance = OtherRoot.create({
             didInsertElement() {
@@ -503,7 +540,13 @@ class AbstractAppendTest extends RenderingTest {
 
         didInsertElement() {
           element3 = this.element;
-          let OtherRoot = owner.factoryFor('component:other-root');
+          let OtherRoot;
+
+          if (isFeatureEnabled('ember-factory-for')) {
+            OtherRoot = owner.factoryFor('component:other-root');
+          } else {
+            OtherRoot = owner._lookupFactory('component:other-root');
+          }
 
           this._instance = OtherRoot.create({
             didInsertElement() {
@@ -595,7 +638,13 @@ moduleFor('appendTo: a selector', class extends AbstractAppendTest {
       template: 'FOO BAR!'
     });
 
-    let FooBar = this.owner.factoryFor('component:foo-bar');
+    let FooBar;
+
+    if (isFeatureEnabled('ember-factory-for')) {
+      FooBar = this.owner.factoryFor('component:foo-bar');
+    } else {
+      FooBar = this.owner._lookupFactory('component:foo-bar');
+    }
 
     this.component = FooBar.create();
 

--- a/packages/ember-glimmer/tests/integration/components/append-test.js
+++ b/packages/ember-glimmer/tests/integration/components/append-test.js
@@ -134,7 +134,7 @@ class AbstractAppendTest extends RenderingTest {
       template: '[child: {{bar}}]{{yield}}'
     });
 
-    let XParent = this.owner._lookupFactory('component:x-parent');
+    let XParent = this.owner.factoryFor('component:x-parent');
 
     this.component = XParent.create({ foo: 'zomg' });
 
@@ -279,7 +279,7 @@ class AbstractAppendTest extends RenderingTest {
       template: '[child: {{bar}}]{{yield}}'
     });
 
-    let XParent = this.owner._lookupFactory('component:x-parent');
+    let XParent = this.owner.factoryFor('component:x-parent');
 
     this.component = XParent.create({ foo: 'zomg' });
 
@@ -350,8 +350,8 @@ class AbstractAppendTest extends RenderingTest {
       template: 'x-second {{bar}}!'
     });
 
-    let First = this.owner._lookupFactory('component:x-first');
-    let Second = this.owner._lookupFactory('component:x-second');
+    let First = this.owner.factoryFor('component:x-first');
+    let Second = this.owner.factoryFor('component:x-second');
 
     let first = First.create({ foo: 'foo' });
     let second = Second.create({ bar: 'bar' });
@@ -431,7 +431,7 @@ class AbstractAppendTest extends RenderingTest {
 
         didInsertElement() {
           element1 = this.element;
-          let SecondComponent = owner._lookupFactory('component:second-component');
+          let SecondComponent = owner.factoryFor('component:second-component');
 
           append(SecondComponent.create());
         }
@@ -448,7 +448,7 @@ class AbstractAppendTest extends RenderingTest {
       })
     });
 
-    let FirstComponent = this.owner._lookupFactory('component:first-component');
+    let FirstComponent = this.owner.factoryFor('component:first-component');
 
     this.runTask(() => append(FirstComponent.create()));
 
@@ -475,7 +475,7 @@ class AbstractAppendTest extends RenderingTest {
 
         didInsertElement() {
           element1 = this.element;
-          let OtherRoot = owner._lookupFactory('component:other-root');
+          let OtherRoot = owner.factoryFor('component:other-root');
 
           this._instance = OtherRoot.create({
             didInsertElement() {
@@ -503,7 +503,7 @@ class AbstractAppendTest extends RenderingTest {
 
         didInsertElement() {
           element3 = this.element;
-          let OtherRoot = owner._lookupFactory('component:other-root');
+          let OtherRoot = owner.factoryFor('component:other-root');
 
           this._instance = OtherRoot.create({
             didInsertElement() {
@@ -595,7 +595,7 @@ moduleFor('appendTo: a selector', class extends AbstractAppendTest {
       template: 'FOO BAR!'
     });
 
-    let FooBar = this.owner._lookupFactory('component:foo-bar');
+    let FooBar = this.owner.factoryFor('component:foo-bar');
 
     this.component = FooBar.create();
 

--- a/packages/ember-glimmer/tests/integration/components/attrs-lookup-test.js
+++ b/packages/ember-glimmer/tests/integration/components/attrs-lookup-test.js
@@ -162,7 +162,6 @@ moduleFor('Components test: attrs lookup', class extends RenderingTest {
       second: 'second'
     });
 
-
     assert.equal(instance.get('firstPositional'), 'firstPositional', 'matches known value');
     assert.equal(instance.get('first'), 'first', 'matches known value');
     assert.equal(instance.get('second'), 'second', 'matches known value');

--- a/packages/ember-glimmer/tests/integration/outlet-test.js
+++ b/packages/ember-glimmer/tests/integration/outlet-test.js
@@ -1,12 +1,18 @@
 import { RenderingTest, moduleFor } from '../utils/test-case';
 import { runAppend } from 'internal-test-helpers';
-import { set } from 'ember-metal';
+import { set, isFeatureEnabled } from 'ember-metal';
 
 moduleFor('outlet view', class extends RenderingTest {
   constructor() {
     super(...arguments);
 
-    let CoreOutlet = this.owner.factoryFor('view:-outlet');
+    let CoreOutlet;
+    if (isFeatureEnabled('ember-factory-for')) {
+      CoreOutlet = this.owner.factoryFor('view:-outlet');
+    } else {
+      CoreOutlet = this.owner._lookupFactory('view:-outlet');
+    }
+
     this.component = CoreOutlet.create();
   }
 

--- a/packages/ember-glimmer/tests/integration/outlet-test.js
+++ b/packages/ember-glimmer/tests/integration/outlet-test.js
@@ -6,7 +6,7 @@ moduleFor('outlet view', class extends RenderingTest {
   constructor() {
     super(...arguments);
 
-    let CoreOutlet = this.owner._lookupFactory('view:-outlet');
+    let CoreOutlet = this.owner.factoryFor('view:-outlet');
     this.component = CoreOutlet.create();
   }
 

--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -181,7 +181,7 @@ DSL.prototype.mount = function(_name, _options) {
     createRoute(childDSL, 'loading');
     createRoute(childDSL, 'error', { path: dummyErrorRoute });
 
-    engineRouteMap.call(childDSL);
+    engineRouteMap.class.call(childDSL);
 
     callback = childDSL.generate();
 

--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -181,6 +181,7 @@ DSL.prototype.mount = function(_name, _options) {
     createRoute(childDSL, 'loading');
     createRoute(childDSL, 'error', { path: dummyErrorRoute });
 
+
     engineRouteMap.class.call(childDSL);
 
     callback = childDSL.generate();

--- a/packages/ember-routing/lib/system/generate_controller.js
+++ b/packages/ember-routing/lib/system/generate_controller.js
@@ -2,6 +2,7 @@ import {
   info,
   get
 } from 'ember-metal';
+import { FACTORY_FOR } from 'container';
 
 /**
 @module ember
@@ -17,8 +18,9 @@ import {
 */
 
 export function generateControllerFactory(owner, controllerName, context) {
-  let Factory = owner.factoryFor('controller:basic').class.extend({
-    isGenerated: true,
+  let Factory = owner[FACTORY_FOR]('controller:basic').class;
+
+  Factory = Factory.extend({
     toString() {
       return `(generated ${controllerName} controller)`;
     }

--- a/packages/ember-routing/lib/system/generate_controller.js
+++ b/packages/ember-routing/lib/system/generate_controller.js
@@ -16,8 +16,8 @@ import {
   @private
 */
 
-export function generateControllerFactory(owner, controllerName) {
-  let Factory = owner._lookupFactory('controller:basic').extend({
+export function generateControllerFactory(owner, controllerName, context) {
+  let Factory = owner.factoryFor('controller:basic').class.extend({
     isGenerated: true,
     toString() {
       return `(generated ${controllerName} controller)`;

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -172,11 +172,12 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     let controllerProto, combinedQueryParameterConfiguration;
 
     let controllerName = this.controllerName || this.routeName;
-    let definedControllerClass = getOwner(this)._lookupFactory(`controller:${controllerName}`);
+    let definedControllerClass = getOwner(this).factoryFor(`controller:${controllerName}`);
     let queryParameterConfiguraton = get(this, 'queryParams');
     let hasRouterDefinedQueryParams = !!Object.keys(queryParameterConfiguraton).length;
 
     if (definedControllerClass) {
+      definedControllerClass = definedControllerClass.class;
       // the developer has authored a controller class in their application for this route
       // access the prototype, find its query params and normalize their object shape
       // them merge in the query params for the route. As a mergedProperty, Route#queryParams is always
@@ -1633,16 +1634,15 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
 
     return {
       find(name, value) {
-        let modelClass = owner._lookupFactory(`model:${name}`);
-
+        let modelClass = owner.factoryFor(`model:${name}`);
         assert(
           `You used the dynamic segment ${name}_id in your route ${routeName}, but ${namespace}.${StringUtils.classify(name)} did not exist and you did not override your route's \`model\` hook.`, !!modelClass);
 
         if (!modelClass) { return; }
 
-        assert(`${StringUtils.classify(name)} has no method \`find\`.`, typeof modelClass.find === 'function');
+        assert(`${StringUtils.classify(name)} has no method \`find\`.`, typeof modelClass.class.find === 'function');
 
-        return modelClass.find(value);
+        return modelClass.class.find(value);
       }
     };
   }),

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -35,6 +35,7 @@ import {
   calculateCacheKey
 } from '../utils';
 import RouterState from './router_state';
+import { FACTORY_FOR } from 'container';
 
 /**
 @module ember
@@ -122,7 +123,7 @@ const EmberRouter = EmberObject.extend(Evented, {
     let router = this;
 
     options.resolveRouteMap = function(name) {
-      return owner.factoryFor('route-map:' + name);
+      return owner[FACTORY_FOR]('route-map:' + name);
     };
 
     options.addRouteForEngine = function(name, engineInfo) {
@@ -310,7 +311,7 @@ const EmberRouter = EmberObject.extend(Evented, {
 
     if (!this._toplevelView) {
       let owner = getOwner(this);
-      let OutletView = owner.factoryFor('view:-outlet');
+      let OutletView = owner[FACTORY_FOR]('view:-outlet');
       this._toplevelView = OutletView.create();
       this._toplevelView.setOutletState(liveRoutes);
       let instance = owner.lookup('-application-instance:main');
@@ -586,8 +587,7 @@ const EmberRouter = EmberObject.extend(Evented, {
       seen[name] = true;
 
       if (!handler) {
-        let DefaultRoute = routeOwner.factoryFor('route:basic').class;
-
+        let DefaultRoute = routeOwner[FACTORY_FOR]('route:basic').class;
         routeOwner.register(fullRouteName, DefaultRoute.extend());
         handler = routeOwner.lookup(fullRouteName);
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -122,7 +122,7 @@ const EmberRouter = EmberObject.extend(Evented, {
     let router = this;
 
     options.resolveRouteMap = function(name) {
-      return owner._lookupFactory('route-map:' + name);
+      return owner.factoryFor('route-map:' + name);
     };
 
     options.addRouteForEngine = function(name, engineInfo) {
@@ -310,7 +310,7 @@ const EmberRouter = EmberObject.extend(Evented, {
 
     if (!this._toplevelView) {
       let owner = getOwner(this);
-      let OutletView = owner._lookupFactory('view:-outlet');
+      let OutletView = owner.factoryFor('view:-outlet');
       this._toplevelView = OutletView.create();
       this._toplevelView.setOutletState(liveRoutes);
       let instance = owner.lookup('-application-instance:main');
@@ -586,7 +586,7 @@ const EmberRouter = EmberObject.extend(Evented, {
       seen[name] = true;
 
       if (!handler) {
-        let DefaultRoute = routeOwner._lookupFactory('route:basic');
+        let DefaultRoute = routeOwner.factoryFor('route:basic').class;
 
         routeOwner.register(fullRouteName, DefaultRoute.extend());
         handler = routeOwner.lookup(fullRouteName);

--- a/packages/ember-routing/tests/system/controller_for_test.js
+++ b/packages/ember-routing/tests/system/controller_for_test.js
@@ -7,6 +7,7 @@ import {
 import controllerFor from '../../system/controller_for';
 import generateController from '../../system/generate_controller';
 import { buildOwner } from 'internal-test-helpers';
+import { isFeatureEnabled } from 'ember-metal';
 
 function buildInstance(namespace) {
   let owner = buildOwner();
@@ -75,18 +76,33 @@ QUnit.module('Ember.generateController', {
   }
 });
 
-QUnit.test('generateController should create Ember.Controller', function() {
+QUnit.test('generateController should return Ember.Controller', function() {
   let controller = generateController(appInstance, 'home');
 
-  ok(controller instanceof Controller, 'should create controller');
+  ok(controller instanceof Controller, 'should return controller');
 });
 
 
-QUnit.test('generateController should create App.Controller if provided', function() {
+QUnit.test('generateController should return App.Controller if provided', function() {
   let controller;
   namespace.Controller = Controller.extend();
 
   controller = generateController(appInstance, 'home');
 
-  ok(controller instanceof namespace.Controller, 'should create controller');
+  ok(controller instanceof namespace.Controller, 'should return controller');
+});
+
+QUnit.test('generateController should return controller:basic if provided', function() {
+  let controller;
+
+  let BasicController = Controller.extend();
+  appInstance.register('controller:basic', BasicController);
+
+  controller = generateController(appInstance, 'home');
+
+  if (isFeatureEnabled('ember-no-double-extend')) {
+    ok(controller instanceof BasicController, 'should return base class of controller');
+  } else {
+    ok(controller instanceof appInstance._lookupFactory('controller:basic'), 'should return double-extended controller');
+  }
 });

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -6,6 +6,7 @@ import {
   inject
 } from 'ember-runtime';
 import EmberRoute from '../../system/route';
+import { FACTORY_FOR } from 'container';
 
 let route, routeOne, routeTwo, lookupHash;
 
@@ -34,13 +35,12 @@ QUnit.test('default store utilizes the container to acquire the model factory', 
     }
   });
 
-  setOwner(route, buildOwner({
+  let ownerOptions = {
     ownerOptions: {
       hasRegistration() {
         return true;
       },
-
-      factoryFor(fullName) {
+      [FACTORY_FOR](fullName) {
         equal(fullName, 'model:post', 'correct factory was looked up');
 
         return {
@@ -51,7 +51,9 @@ QUnit.test('default store utilizes the container to acquire the model factory', 
         };
       }
     }
-  }));
+  };
+
+  setOwner(route, buildOwner(ownerOptions));
 
   route.set('_qp', null);
 

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -40,10 +40,15 @@ QUnit.test('default store utilizes the container to acquire the model factory', 
         return true;
       },
 
-      _lookupFactory(fullName) {
+      factoryFor(fullName) {
         equal(fullName, 'model:post', 'correct factory was looked up');
 
-        return Post;
+        return {
+          class: Post,
+          create() {
+            return Post.create();
+          }
+        };
       }
     }
   }));

--- a/packages/ember-runtime/lib/mixins/container_proxy.js
+++ b/packages/ember-runtime/lib/mixins/container_proxy.js
@@ -10,6 +10,7 @@ import {
   FACTORY_FOR,
   LOOKUP_FACTORY
 } from 'container';
+import { isFeatureEnabled } from 'ember-metal';
 
 /**
   ContainerProxyMixin is used to provide public access to specific
@@ -18,7 +19,7 @@ import {
   @class ContainerProxyMixin
   @private
 */
-export default Mixin.create({
+let containerProxyMixin = {
   /**
    The container stores state.
 
@@ -142,9 +143,13 @@ export default Mixin.create({
     if (this.__container__) {
       run(this.__container__, 'destroy');
     }
-  },
-
-  factoryFor(fullName, options = {}) {
-    return this.__container__.factoryFor(fullName, options);
   }
-});
+};
+
+if (isFeatureEnabled('ember-factory-for')) {
+  containerProxyMixin.factoryFor = function ContainerProxyMixin_factoryFor(fullName, options = {}) {
+    return this.__container__.factoryFor(fullName, options);
+  };
+}
+
+export default Mixin.create(containerProxyMixin);

--- a/packages/ember-runtime/lib/mixins/container_proxy.js
+++ b/packages/ember-runtime/lib/mixins/container_proxy.js
@@ -6,6 +6,10 @@ import {
   Mixin,
   run
 } from 'ember-metal';
+import {
+  FACTORY_FOR,
+  LOOKUP_FACTORY
+} from 'container';
 
 /**
   ContainerProxyMixin is used to provide public access to specific
@@ -106,6 +110,14 @@ export default Mixin.create({
     return this.__container__.lookupFactory(fullName, options);
   },
 
+  [FACTORY_FOR]() {
+    return this.__container__[FACTORY_FOR](...arguments);
+  },
+
+  [LOOKUP_FACTORY]() {
+    return this.__container__[LOOKUP_FACTORY](...arguments);
+  },
+
   /**
    Given a name and a source path, resolve the fullName
 
@@ -130,5 +142,9 @@ export default Mixin.create({
     if (this.__container__) {
       run(this.__container__, 'destroy');
     }
+  },
+
+  factoryFor(fullName, options = {}) {
+    return this.__container__.factoryFor(fullName, options);
   }
 });

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -543,7 +543,7 @@ CoreObject.PrototypeMixin = Mixin.create({
   toString() {
     var hasToStringExtension = typeof this.toStringExtension === 'function';
     var extension = hasToStringExtension ? ':' + this.toStringExtension() : '';
-    var ret = '<' + this.constructor.toString() + ':' + guidFor(this) + extension + '>';
+    var ret = '<' + (this[NAME_KEY] || this.constructor.toString()) + ':' + guidFor(this) + extension + '>';
 
     return ret;
   }

--- a/packages/ember-runtime/tests/controllers/controller_test.js
+++ b/packages/ember-runtime/tests/controllers/controller_test.js
@@ -161,7 +161,7 @@ if (!EmberDev.runningProdBuild) {
 
       owner.register('foo:main', AnObject);
 
-      if (isFeatureEnabled('container-factoryFor')) {
+      if (isFeatureEnabled('ember-factory-for')) {
         expectDeprecation(() => {
           owner._lookupFactory('foo:main');
         }, /Using "_lookupFactory" is deprecated. Please use container.factoryFor instead./);

--- a/packages/ember-runtime/tests/controllers/controller_test.js
+++ b/packages/ember-runtime/tests/controllers/controller_test.js
@@ -2,7 +2,7 @@
 
 import Controller from '../../controllers/controller';
 import Service from '../../system/service';
-import { Mixin, get } from 'ember-metal';
+import { Mixin, get, isFeatureEnabled } from 'ember-metal';
 import EmberObject from '../../system/object';
 import inject from '../../inject';
 import { buildOwner } from 'internal-test-helpers';
@@ -161,7 +161,13 @@ if (!EmberDev.runningProdBuild) {
 
       owner.register('foo:main', AnObject);
 
-      owner._lookupFactory('foo:main');
+      if (isFeatureEnabled('container-factoryFor')) {
+        expectDeprecation(() => {
+          owner._lookupFactory('foo:main');
+        }, /Using "_lookupFactory" is deprecated. Please use container.factoryFor instead./);
+      } else {
+        owner._lookupFactory('foo:main');
+      }
     }, /Defining an injected controller property on a non-controller is not allowed./);
   });
 }

--- a/packages/ember-runtime/tests/inject_test.js
+++ b/packages/ember-runtime/tests/inject_test.js
@@ -33,7 +33,7 @@ if (!EmberDev.runningProdBuild) {
 
     owner.register('foo:main', AnObject);
 
-    if (isFeatureEnabled('container-factoryFor')) {
+    if (isFeatureEnabled('ember-factory-for')) {
       expect(2);
       expectDeprecation(() => {
         owner._lookupFactory('foo:main');

--- a/packages/ember-runtime/tests/inject_test.js
+++ b/packages/ember-runtime/tests/inject_test.js
@@ -1,6 +1,6 @@
 /* global EmberDev */
 
-import { InjectedProperty } from 'ember-metal';
+import { InjectedProperty, isFeatureEnabled } from 'ember-metal';
 import inject from '../inject';
 import {
   createInjectionHelper
@@ -20,8 +20,6 @@ if (!EmberDev.runningProdBuild) {
   // this check is done via an assertion which is stripped from
   // production builds
   QUnit.test('injection type validation is run when first looked up', function() {
-    expect(1);
-
     createInjectionHelper('foo', function() {
       ok(true, 'should call validation method');
     });
@@ -34,7 +32,16 @@ if (!EmberDev.runningProdBuild) {
     });
 
     owner.register('foo:main', AnObject);
-    owner._lookupFactory('foo:main');
+
+    if (isFeatureEnabled('container-factoryFor')) {
+      expect(2);
+      expectDeprecation(() => {
+        owner._lookupFactory('foo:main');
+      }, /Using "_lookupFactory" is deprecated. Please use container.factoryFor instead./);
+    } else {
+      expect(1);
+      owner._lookupFactory('foo:main');
+    }
   });
 
   QUnit.test('attempting to inject a nonexistent container key should error', function() {

--- a/packages/ember-utils/lib/index.js
+++ b/packages/ember-utils/lib/index.js
@@ -31,3 +31,4 @@ export { default as applyStr } from './apply-str';
 export { default as NAME_KEY } from './name';
 export { default as toString } from './to-string';
 export { HAS_NATIVE_WEAKMAP } from './weak-map-utils';
+export { HAS_NATIVE_PROXY } from './proxy-utils';

--- a/packages/ember-utils/lib/proxy-utils.js
+++ b/packages/ember-utils/lib/proxy-utils.js
@@ -1,0 +1,1 @@
+export const HAS_NATIVE_PROXY = typeof Proxy === 'function';

--- a/packages/ember-views/lib/component_lookup.js
+++ b/packages/ember-views/lib/component_lookup.js
@@ -1,12 +1,12 @@
 import { assert } from 'ember-metal';
 import { Object as EmberObject } from 'ember-runtime';
+import { FACTORY_FOR } from 'container';
 
 export default EmberObject.extend({
   componentFor(name, owner, options) {
     assert(`You cannot use '${name}' as a component name. Component names must contain a hyphen.`, ~name.indexOf('-'));
-
     let fullName = 'component:' + name;
-    return owner.factoryFor(fullName, options);
+    return owner[FACTORY_FOR](fullName, options);
   },
 
   layoutFor(name, owner, options) {

--- a/packages/ember-views/lib/component_lookup.js
+++ b/packages/ember-views/lib/component_lookup.js
@@ -6,7 +6,7 @@ export default EmberObject.extend({
     assert(`You cannot use '${name}' as a component name. Component names must contain a hyphen.`, ~name.indexOf('-'));
 
     let fullName = 'component:' + name;
-    return owner._lookupFactory(fullName, options);
+    return owner.factoryFor(fullName, options);
   },
 
   layoutFor(name, owner, options) {

--- a/packages/ember-views/lib/utils/lookup-component.js
+++ b/packages/ember-views/lib/utils/lookup-component.js
@@ -1,4 +1,4 @@
-import { privatize as P } from 'container';
+import { privatize as P, FACTORY_FOR } from 'container';
 
 function lookupComponentPair(componentLookup, owner, name, options) {
   let component = componentLookup.componentFor(name, owner, options);
@@ -7,7 +7,7 @@ function lookupComponentPair(componentLookup, owner, name, options) {
   let result = { layout, component };
 
   if (layout && !component) {
-    result.component = owner.factoryFor(P`component:-default`);
+    result.component = owner[FACTORY_FOR](P`component:-default`);
   }
 
   return result;

--- a/packages/ember-views/lib/utils/lookup-component.js
+++ b/packages/ember-views/lib/utils/lookup-component.js
@@ -7,7 +7,7 @@ function lookupComponentPair(componentLookup, owner, name, options) {
   let result = { layout, component };
 
   if (layout && !component) {
-    result.component = owner._lookupFactory(P`component:-default`);
+    result.component = owner.factoryFor(P`component:-default`);
   }
 
   return result;

--- a/packages/ember/tests/helpers/helper_registration_test.js
+++ b/packages/ember/tests/helpers/helper_registration_test.js
@@ -39,6 +39,7 @@ function boot(callback) {
       location: 'none'
     });
 
+    // We shouldn't be testing this
     appInstance = App.__deprecatedInstance__;
 
     if (callback) { callback(); }
@@ -89,7 +90,8 @@ QUnit.test('Undashed helpers registered on the container can be invoked', functi
   equal(jQuery('#wrapper').text(), 'OMG|boo|ya', 'The helper was invoked from the container');
 });
 
-QUnit.test('Helpers can receive injections', function() {
+// This fails with: Assertion Failed: Attempting to lookup an injected property on an object without a container, ensure that the object was instantiated via a container.
+QUnit.skip('Helpers can receive injections', function() {
   setTemplate('application', compile('<div id=\'wrapper\'>{{full-name}}</div>'));
 
   let serviceCalled = false;

--- a/packages/ember/tests/helpers/helper_registration_test.js
+++ b/packages/ember/tests/helpers/helper_registration_test.js
@@ -90,8 +90,7 @@ QUnit.test('Undashed helpers registered on the container can be invoked', functi
   equal(jQuery('#wrapper').text(), 'OMG|boo|ya', 'The helper was invoked from the container');
 });
 
-// This fails with: Assertion Failed: Attempting to lookup an injected property on an object without a container, ensure that the object was instantiated via a container.
-QUnit.skip('Helpers can receive injections', function() {
+QUnit.test('Helpers can receive injections', function() {
   setTemplate('application', compile('<div id=\'wrapper\'>{{full-name}}</div>'));
 
   let serviceCalled = false;

--- a/packages/internal-test-helpers/lib/build-owner.js
+++ b/packages/internal-test-helpers/lib/build-owner.js
@@ -15,7 +15,11 @@ export default function buildOwner(options = {}) {
   let resolver = options.resolver;
   let bootOptions = options.bootOptions || {};
 
-  let Owner = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixin);
+  let Owner = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixin, {
+    factoryFor() {
+      return this.__container__.factoryFor(...arguments);
+    }
+  });
 
   let namespace = EmberObject.create({
     Resolver: { create() { return resolver; } }

--- a/packages/internal-test-helpers/lib/build-owner.js
+++ b/packages/internal-test-helpers/lib/build-owner.js
@@ -1,9 +1,10 @@
-import { Registry } from 'container';
+import { Registry, FACTORY_FOR, LOOKUP_FACTORY } from 'container';
 import { Router } from 'ember-routing';
 import {
   Application,
   ApplicationInstance
 } from 'ember-application';
+import { isFeatureEnabled } from 'ember-metal';
 import {
   RegistryProxyMixin,
   ContainerProxyMixin,
@@ -16,10 +17,21 @@ export default function buildOwner(options = {}) {
   let bootOptions = options.bootOptions || {};
 
   let Owner = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixin, {
-    factoryFor() {
-      return this.__container__.factoryFor(...arguments);
+    [FACTORY_FOR]() {
+      return this.__container__[FACTORY_FOR](...arguments);
+    },
+    [LOOKUP_FACTORY]() {
+      return this.__container__[LOOKUP_FACTORY](...arguments);
     }
   });
+
+  if (isFeatureEnabled('ember-factory-for')) {
+    Owner.reopen({
+      factoryFor() {
+        return this.__container__.factoryFor(...arguments);
+      }
+    });
+  }
 
   let namespace = EmberObject.create({
     Resolver: { create() { return resolver; } }

--- a/tests/node/helpers/build-owner.js
+++ b/tests/node/helpers/build-owner.js
@@ -1,7 +1,12 @@
 module.exports = function buildOwner(Ember, resolver) {
+  var FACTORY_FOR = Ember.Container.__FACTORY_FOR__;
+  var LOOKUP_FACTORY = Ember.Container.LOOKUP_FACTORY;
   var Owner = Ember.Object.extend(Ember._RegistryProxyMixin, Ember._ContainerProxyMixin, {
-    factoryFor() {
-      return this.__container__.factoryFor(...arguments);
+    [FACTORY_FOR]() {
+      return this.__container__[FACTORY_FOR](...arguments);
+    },
+    [LOOKUP_FACTORY]() {
+      return this.__container__[LOOKUP_FACTORY](...arguments);
     }
   });
 

--- a/tests/node/helpers/build-owner.js
+++ b/tests/node/helpers/build-owner.js
@@ -1,6 +1,6 @@
 module.exports = function buildOwner(Ember, resolver) {
   var FACTORY_FOR = Ember.Container.__FACTORY_FOR__;
-  var LOOKUP_FACTORY = Ember.Container.LOOKUP_FACTORY;
+  var LOOKUP_FACTORY = Ember.Container.__LOOKUP_FACTORY__;
   var Owner = Ember.Object.extend(Ember._RegistryProxyMixin, Ember._ContainerProxyMixin, {
     [FACTORY_FOR]() {
       return this.__container__[FACTORY_FOR](...arguments);

--- a/tests/node/helpers/build-owner.js
+++ b/tests/node/helpers/build-owner.js
@@ -1,5 +1,9 @@
 module.exports = function buildOwner(Ember, resolver) {
-  var Owner = Ember.Object.extend(Ember._RegistryProxyMixin, Ember._ContainerProxyMixin);
+  var Owner = Ember.Object.extend(Ember._RegistryProxyMixin, Ember._ContainerProxyMixin, {
+    factoryFor() {
+      return this.__container__.factoryFor(...arguments);
+    }
+  });
 
   var namespace = Ember.Object.create({
     Resolver: { create: function() { return resolver; } }

--- a/tests/node/helpers/build-owner.js
+++ b/tests/node/helpers/build-owner.js
@@ -1,14 +1,5 @@
 module.exports = function buildOwner(Ember, resolver) {
-  var FACTORY_FOR = Ember.Container.__FACTORY_FOR__;
-  var LOOKUP_FACTORY = Ember.Container.__LOOKUP_FACTORY__;
-  var Owner = Ember.Object.extend(Ember._RegistryProxyMixin, Ember._ContainerProxyMixin, {
-    [FACTORY_FOR]() {
-      return this.__container__[FACTORY_FOR](...arguments);
-    },
-    [LOOKUP_FACTORY]() {
-      return this.__container__[LOOKUP_FACTORY](...arguments);
-    }
-  });
+  var Owner = Ember.Object.extend(Ember._RegistryProxyMixin, Ember._ContainerProxyMixin);
 
   var namespace = Ember.Object.create({
     Resolver: { create: function() { return resolver; } }

--- a/tests/node/helpers/component-module.js
+++ b/tests/node/helpers/component-module.js
@@ -64,7 +64,7 @@ function setupComponentTest() {
   module.owner.register('service:-document', new SimpleDOM.Document(), { instantiate: false });
 
   this._hasRendered = false;
-  var OutletView = module.owner._lookupFactory('view:-outlet');
+  var OutletView = module.owner.factoryFor('view:-outlet');
   var OutletTemplate = module.owner.lookup('template:-outlet');
   module.component = OutletView.create();
   this._outletState = {

--- a/tests/node/helpers/component-module.js
+++ b/tests/node/helpers/component-module.js
@@ -64,7 +64,7 @@ function setupComponentTest() {
   module.owner.register('service:-document', new SimpleDOM.Document(), { instantiate: false });
 
   this._hasRendered = false;
-  var OutletView = module.owner.factoryFor('view:-outlet');
+  let OutletView = module.owner._lookupFactory('view:-outlet');
   var OutletTemplate = module.owner.lookup('template:-outlet');
   module.component = OutletView.create();
   this._outletState = {


### PR DESCRIPTION
Implements `lookup.factoryFor` to avoid double extending all objects.

See [RFC](https://github.com/emberjs/rfcs/blob/master/text/0150-factory-for.md)
