### PR TITLE
[BUGFIX release] Bump route-recognizer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "mocha": "^2.4.5",
     "qunit-extras": "^1.5.0",
     "qunitjs": "^1.22.0",
-    "route-recognizer": "^0.2.6",
+    "route-recognizer": "^0.2.7",
     "rsvp": "~3.2.1",
     "serve-static": "^1.10.0",
     "simple-dom": "^0.3.0",


### PR DESCRIPTION
Trailing slashes with encoded chars did not previously work.

See: https://github.com/tildeio/route-recognizer/pull/114
