### PR TITLE
[BUGFIX beta] Ensure feature flags are stripped

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -178,7 +178,10 @@ function babelConfigFor(environment) {
   var includeDevHelpers = true;
 
   plugins.push(applyFeatureFlags({
-    import: { module: 'ember-metal/features' },
+    imports: [
+      { module: 'ember-metal/features' },
+      { module: 'ember-metal', name: 'isFeatureEnabled' },
+    ],
     features: features
   }));
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "aws-sdk": "~2.2.43",
-    "babel-plugin-feature-flags": "~0.2.1",
+    "babel-plugin-feature-flags": "ember-cli/babel-plugin-feature-flags#4c1b786",
     "babel-plugin-filter-imports": "~0.2.0",
     "backburner.js": "^0.3.1",
     "bower": "~1.7.7",


### PR DESCRIPTION
This requires releasing the features transform plugin, but I don't think have access to that (on NPM).

The renaming of the `isEnabled` import caused the feature flag transform to stop working. This fixes the problem.

Before:

```
File sizes:
 - ember.debug.js: 2.65 MB (610.65 KB gzipped)
 - ember.js: 2.65 MB (610.65 KB gzipped)
 - ember.min.js: 495.83 KB (123.13 KB gzipped)
 - ember.prod.js: 2.54 MB (584.96 KB gzipped)
```

After:

```
File sizes:
 - ember.debug.js: 2.65 MB (610.45 KB gzipped)
 - ember.js: 2.65 MB (610.45 KB gzipped)
 - ember.min.js: 493.53 KB (122.67 KB gzipped)
 - ember.prod.js: 2.53 MB (584.74 KB gzipped)
```

Diff (ember.prod.js):

``` diff
diff --git a/dist-before/ember.prod.js b/dist-after/ember.prod.js
index 6d8ecf5..5a682c4 100644
--- a/dist-before/ember.prod.js
+++ b/dist-after/ember.prod.js
@@ -10374,7 +10374,7 @@ enifed('ember-glimmer/renderer', ['exports', 'ember-glimmer/utils/references', '

   var runInTransaction = undefined;

-  if (_emberMetal.isFeatureEnabled('ember-glimmer-detect-backtracking-rerender') || _emberMetal.isFeatureEnabled('ember-glimmer-allow-backtracking-rerender')) {
+  if (false || false) {
     runInTransaction = _emberMetal.runInTransaction;
   } else {
     runInTransaction = function (context, methodName) {
@@ -13168,7 +13168,7 @@ enifed('ember-glimmer/utils/references', ['exports', 'ember-utils', 'ember-metal

   var TwoWayFlushDetectionTag = undefined;

-  if (_emberMetal.isFeatureEnabled('ember-glimmer-detect-backtracking-rerender') || _emberMetal.isFeatureEnabled('ember-glimmer-allow-backtracking-rerender')) {
+  if (false || false) {
     TwoWayFlushDetectionTag = (function () {
       function _class(tag, key, ref) {
         this.tag = tag;
@@ -13236,13 +13236,13 @@ enifed('ember-glimmer/utils/references', ['exports', 'ember-utils', 'ember-metal
       this._parentValue = parentValue;
       this._propertyKey = propertyKey;

-      if (_emberMetal.isFeatureEnabled('ember-glimmer-detect-backtracking-rerender') || _emberMetal.isFeatureEnabled('ember-glimmer-allow-backtracking-rerender')) {
+      if (false || false) {
         this.tag = new TwoWayFlushDetectionTag(_emberMetal.tagFor(parentValue), propertyKey, this);
       } else {
         this.tag = _emberMetal.tagFor(parentValue);
       }

-      if (_emberMetal.isFeatureEnabled('mandatory-setter')) {
+      if (false) {
         _emberMetal.watchKey(parentValue, propertyKey);
       }
     }
@@ -13251,7 +13251,7 @@ enifed('ember-glimmer/utils/references', ['exports', 'ember-utils', 'ember-metal
       var _parentValue = this._parentValue;
       var _propertyKey = this._propertyKey;

-      if (_emberMetal.isFeatureEnabled('ember-glimmer-detect-backtracking-rerender') || _emberMetal.isFeatureEnabled('ember-glimmer-allow-backtracking-rerender')) {
+      if (false || false) {
         this.tag.didCompute(_parentValue);
       }

@@ -13280,7 +13280,7 @@ enifed('ember-glimmer/utils/references', ['exports', 'ember-utils', 'ember-metal
       this._parentObjectTag = parentObjectTag;
       this._propertyKey = propertyKey;

-      if (_emberMetal.isFeatureEnabled('ember-glimmer-detect-backtracking-rerender') || _emberMetal.isFeatureEnabled('ember-glimmer-allow-backtracking-rerender')) {
+      if (false || false) {
         var tag = _glimmerReference.combine([parentReferenceTag, parentObjectTag]);
         this.tag = new TwoWayFlushDetectionTag(tag, propertyKey, this);
       } else {
@@ -13298,11 +13298,11 @@ enifed('ember-glimmer/utils/references', ['exports', 'ember-utils', 'ember-metal
       _parentObjectTag.update(_emberMetal.tagFor(parentValue));

       if (typeof parentValue === 'object' && parentValue) {
-        if (_emberMetal.isFeatureEnabled('mandatory-setter')) {
+        if (false) {
           _emberMetal.watchKey(parentValue, _propertyKey);
         }

-        if (_emberMetal.isFeatureEnabled('ember-glimmer-detect-backtracking-rerender') || _emberMetal.isFeatureEnabled('ember-glimmer-allow-backtracking-rerender')) {
+        if (false || false) {
           this.tag.didCompute(parentValue);
         }

@@ -23292,7 +23292,7 @@ enifed('ember-routing/system/route', ['exports', 'ember-utils', 'ember-metal', '
         var normalizedControllerQueryParameterConfiguration = _emberRoutingUtils.normalizeControllerQueryParams(controllerDefinedQueryParameterConfiguration);
         combinedQueryParameterConfiguration = mergeEachQueryParams(normalizedControllerQueryParameterConfiguration, queryParameterConfiguraton);

-        if (_emberMetal.isFeatureEnabled('ember-routing-route-configured-query-params')) {
+        if (false) {
           if (controllerDefinedQueryParameterConfiguration.length) {}
         }
       } else if (hasRouterDefinedQueryParams) {
@@ -23321,7 +23321,7 @@ enifed('ember-routing/system/route', ['exports', 'ember-utils', 'ember-metal', '

         var desc = combinedQueryParameterConfiguration[propName];

-        if (_emberMetal.isFeatureEnabled('ember-routing-route-configured-query-params')) {
+        if (false) {
           // apply default values to controllers
           // detect that default value defined on router config
           if (desc.hasOwnProperty('defaultValue')) {
@@ -25200,7 +25200,7 @@ enifed('ember-routing/system/route', ['exports', 'ember-utils', 'ember-metal', '
     var keysAlreadyMergedOrSkippable = undefined;
     var qps = {};

-    if (_emberMetal.isFeatureEnabled('ember-routing-route-configured-query-params')) {
+    if (false) {
       keysAlreadyMergedOrSkippable = {};
     } else {
       keysAlreadyMergedOrSkippable = {
@@ -29733,7 +29733,7 @@ enifed('ember-runtime/mixins/array', ['exports', 'ember-utils', 'ember-metal', '
   }).readOnly(), _Mixin$create.lastObject = _emberMetal.computed(function () {
     return objectAt(this, _emberMetal.get(this, 'length') - 1);
   }).readOnly(), _Mixin$create.contains = function (obj) {
-    if (_emberMetal.isFeatureEnabled('ember-runtime-enumerable-includes')) {}
+    if (true) {}

     return this.indexOf(obj) >= 0;
   }, _Mixin$create.slice = function (beginIndex, endIndex) {
@@ -29816,7 +29816,7 @@ enifed('ember-runtime/mixins/array', ['exports', 'ember-utils', 'ember-metal', '
     return this.__each;
   }).volatile(), _Mixin$create));

-  if (_emberMetal.isFeatureEnabled('ember-runtime-enumerable-includes')) {
+  if (true) {
     ArrayMixin.reopen({
       /**
         Returns `true` if the passed object can be found in the array.
@@ -30573,7 +30573,7 @@ enifed('ember-runtime/mixins/enumerable', ['exports', 'ember-utils', 'ember-meta
       @public
     */
     contains: function (obj) {
-      if (_emberMetal.isFeatureEnabled('ember-runtime-enumerable-includes')) {}
+      if (true) {}

       var found = this.find(function (item) {
         return item === obj;
@@ -31359,7 +31359,7 @@ enifed('ember-runtime/mixins/enumerable', ['exports', 'ember-utils', 'ember-meta
     }
   });

-  if (_emberMetal.isFeatureEnabled('ember-runtime-computed-uniq-by')) {
+  if (true) {
     Enumerable.reopen({
       /**
         Returns a new enumerable that contains only items containing a unique property value.
@@ -31390,7 +31390,7 @@ enifed('ember-runtime/mixins/enumerable', ['exports', 'ember-utils', 'ember-meta
     });
   }

-  if (_emberMetal.isFeatureEnabled('ember-runtime-enumerable-includes')) {
+  if (true) {
     Enumerable.reopen({
       /**
         Returns `true` if the passed object can be found in the enumerable.
@@ -32042,7 +32042,7 @@ enifed('ember-runtime/mixins/mutable_array', ['exports', 'ember-metal', 'ember-r
     addObject: function (obj) {
       var included = undefined;

-      if (_emberMetal.isFeatureEnabled('ember-runtime-enumerable-includes')) {
+      if (true) {
         included = this.includes(obj);
       } else {
         included = this.contains(obj);
@@ -33697,7 +33697,7 @@ enifed('ember-runtime/system/core_object', ['exports', 'ember-utils', 'ember-met
               if (typeof this.setUnknownProperty === 'function' && !(keyName in this)) {
                 this.setUnknownProperty(keyName, value);
               } else {
-                if (_emberMetal.isFeatureEnabled('mandatory-setter')) {
+                if (false) {
                   _emberMetal.defineProperty(this, keyName, null, value); // setup mandatory setter
                 } else {
                     this[keyName] = value;
@@ -38940,7 +38940,7 @@ enifed('ember/index', ['exports', 'require', 'ember-environment', 'ember-utils',
   _emberMetal.default.Binding = _emberMetal.Binding;
   _emberMetal.default.isGlobalPath = _emberMetal.isGlobalPath;

-  if (_emberMetal.isFeatureEnabled('ember-metal-weakmap')) {
+  if (false) {
     _emberMetal.default.WeakMap = _emberMetal.WeakMap;
   }

@@ -39150,7 +39150,7 @@ enifed('ember/index', ['exports', 'require', 'ember-environment', 'ember-utils',
   computed.filterBy = _emberRuntime.filterBy;
   computed.uniq = _emberRuntime.uniq;

-  if (_emberMetal.isFeatureEnabled('ember-runtime-computed-uniq-by')) {
+  if (true) {
     computed.uniqBy = _emberRuntime.uniqBy;
   }
   computed.union = _emberRuntime.union;
@@ -39220,7 +39220,7 @@ enifed('ember/index', ['exports', 'require', 'ember-environment', 'ember-utils',
   EmberHandleBarsUtils.escapeExpression = _emberGlimmer.escapeExpression;
   _emberRuntime.String.htmlSafe = _emberGlimmer.htmlSafe;

-  if (_emberMetal.isFeatureEnabled('ember-string-ishtmlsafe')) {
+  if (true) {
     _emberRuntime.String.isHTMLSafe = _emberGlimmer.isHTMLSafe;
   }
   EmberHTMLBars.makeBoundHelper = _emberGlimmer.makeBoundHelper;
```
