### PR TITLE
Update babel-plugin-feature-flags to 0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "aws-sdk": "~2.2.43",
-    "babel-plugin-feature-flags": "ember-cli/babel-plugin-feature-flags#4c1b786",
+    "babel-plugin-feature-flags": "^0.2.3",
     "babel-plugin-filter-imports": "~0.2.0",
     "backburner.js": "^0.3.1",
     "bower": "~1.7.7",


### PR DESCRIPTION
Support was added to support multiple modules (which we need due to using both `ember-metal` and `ember-metal/features`).

Follow up for #14367.
