### PR TITLE
[BUGFIX beta] Lazily add alias dependent keys.

### DIFF
--- a/packages/ember-metal/tests/alias_test.js
+++ b/packages/ember-metal/tests/alias_test.js
@@ -91,8 +91,9 @@ QUnit.test('an observer of the alias works if added before defining the alias', 
   equal(count, 1);
 });
 
-QUnit.test('object with alias is dirtied if interior object of alias is set', function () {
+QUnit.test('object with alias is dirtied if interior object of alias is set after consumption', function () {
   defineProperty(obj, 'bar', alias('foo.faz'));
+  get(obj, 'bar');
   assertDirty(obj, () => set(obj, 'foo.faz', 'BAR'), 'setting the aliased key should dirty the object');
 });
 


### PR DESCRIPTION
In Ember 2.8, an `Ember.computed.alias` will only call `addDependentKeys` / `removeDependentKeys` if it itself is being watched. This proved problematic during the Glimmer 2 refactor (2.9+) because in production builds an alias that is consumed in a template is not being watched (it is only watched in debug builds so that mandatory setter is setup).

In order to fix that bug (prod builds would never update a template for changes made to an aliased property), we made `Ember.computed.alias` eagerly setup dependent keys (even if never watched or consumed) (this was added in https://github.com/emberjs/ember.js/pull/14319). After some benchmarking in a few real world apps, it became obvious that this eager setup negatively impacted performance for scenarios where an alias is present but unused/unconsumed.  One such example is the `data` read only alias that Ember Data sets on on all model instances (mostly as a backwards compat shim), 90+% of apps are not using this alias but its mere presence in the object caused us to do more work per model instance created. The overall cost of adding a single dependent key and watch it is relatively low, but when you do that for each model and use thousands of models it adds up...

This change essentially reverts the changes that made all dependent key setup eager, and replaces it with logic to ensure that dependent keys are added both when watching (the prior behavior) and when an alias is consumed (this fixes the originally reported regression).

---

Fixes #14354.
