### PR TITLE
Cache the caches to avoid some npm bizarreness when bumping packages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ addons:
 
 cache:
   directories:
-    - node_modules
-    - bower_components
+    - $HOME/.npm
+    - $HOME/.cache # includes bowers cache
 
 before_install:
   - "npm config set spin false"


### PR DESCRIPTION
This changes the Travis caching setup to cache the `.npm` and `.cache` directories, instead of caching the output of `node_modules` / `bower_components`. It should still reduce the network time, but allow the npm installs to work properly when there are package bumps.

Follow suit with https://github.com/ember-cli/ember-cli/pull/6279.

Can't make it worse  ¯\_(ツ)_/¯...
