### PR TITLE
[BUGFIX release] Avoid assertion when bound `id` provided to tagless component

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/fragment-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/fragment-components-test.js
@@ -165,6 +165,19 @@ moduleFor('Components test: fragment components', class extends RenderingTest {
     this.assertText('baz');
   }
 
+  ['@test does not throw an error if `tagName` is an empty string and `id` is bound property specified via template']() {
+    let template = `{{id}}`;
+    let FooBarComponent = Component.extend({
+      tagName: ''
+    });
+
+    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template });
+
+    this.render(`{{#foo-bar id=fooBarId}}{{/foo-bar}}`, { fooBarId: 'baz' });
+
+    this.assertText('baz');
+  }
+
   ['@test throws an error if when $() is accessed on component where `tagName` is an empty string']() {
     let template = `hit dem folks`;
     let FooBarComponent = Component.extend({

--- a/packages/ember-htmlbars/lib/system/build-component-template.js
+++ b/packages/ember-htmlbars/lib/system/build-component-template.js
@@ -41,7 +41,7 @@ export default function buildComponentTemplate({ component, tagName, layout, out
 
     assert('You cannot use `elementId` on a tag-less component: ' + component.toString(), (() => {
       let { elementId } = component;
-      return tagName !== '' || attrs.id === elementId || (!elementId && elementId !== '');
+      return tagName !== '' || getValue(attrs.id) === elementId || (!elementId && elementId !== '');
     })());
 
     assert('You cannot use `attributeBindings` on a tag-less component: ' + component.toString(), (() => {


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember.js/issues/14369

I'm not totally sure about the protocol for submitting this change. The code fix is for code that is totally gone in 2.9+ but the test might still be useful to have around in later versions.

@chancancode is this what you were thinking?
