### PR TITLE
Move objects guid into Meta.

### DIFF
--- a/packages/ember-application/lib/system/engine-instance.js
+++ b/packages/ember-application/lib/system/engine-instance.js
@@ -3,14 +3,13 @@
 @submodule ember-application
 */
 
-import { guidFor } from 'ember-utils';
 import {
   Object as EmberObject,
   ContainerProxyMixin,
   RegistryProxyMixin,
   RSVP
 } from 'ember-runtime';
-import { Error as EmberError, assert, run } from 'ember-metal';
+import { Error as EmberError, assert, run, guidFor } from 'ember-metal';
 import { Registry, privatize as P } from 'container';
 import { getEngineParent, setEngineParent } from './engine-parent';
 

--- a/packages/ember-application/tests/system/dependency_injection/to_string_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/to_string_test.js
@@ -1,6 +1,5 @@
-import { guidFor } from 'ember-utils';
 import { ENV, context } from 'ember-environment'; // lookup, etc
-import { run } from 'ember-metal';
+import { run, guidFor } from 'ember-metal';
 import Application from '../../../system/application';
 import { Object as EmberObject } from 'ember-runtime';
 import DefaultResolver from '../../../system/resolver';

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -1,5 +1,5 @@
-import { guidFor, OWNER } from 'ember-utils';
-import { Cache, assert, warn, runInDebug } from 'ember-metal';
+import { OWNER } from 'ember-utils';
+import { guidFor, Cache, assert, warn, runInDebug } from 'ember-metal';
 import {
   lookupPartial,
   hasPartial,

--- a/packages/ember-glimmer/lib/modifiers/action.js
+++ b/packages/ember-glimmer/lib/modifiers/action.js
@@ -1,5 +1,4 @@
-import { uuid } from 'ember-utils';
-import { assert, run, flaggedInstrument } from 'ember-metal';
+import { uuid, assert, run, flaggedInstrument } from 'ember-metal';
 import {
   isSimpleClick,
   ActionManager

--- a/packages/ember-glimmer/lib/syntax/outlet.js
+++ b/packages/ember-glimmer/lib/syntax/outlet.js
@@ -252,7 +252,7 @@ class TopLevelOutletLayoutCompiler {
   compile(builder) {
     builder.wrapLayout(this.template.asLayout());
     builder.tag.static('div');
-    builder.attrs.static('id', guidFor(this));
+    builder.attrs.static('id', 'ember' + guidFor(this));
     builder.attrs.static('class', 'ember-view');
   }
 }

--- a/packages/ember-glimmer/lib/syntax/outlet.js
+++ b/packages/ember-glimmer/lib/syntax/outlet.js
@@ -2,13 +2,16 @@
 @module ember
 @submodule ember-glimmer
 */
-import { generateGuid, guidFor } from 'ember-utils';
 import {
   ArgsSyntax,
   StatementSyntax,
   ComponentDefinition
 } from 'glimmer-runtime';
-import { _instrumentStart } from 'ember-metal';
+import {
+  _instrumentStart,
+  generateGuid,
+  guidFor
+} from 'ember-metal';
 import { RootReference } from '../utils/references';
 import {
   UpdatableTag,

--- a/packages/ember-glimmer/lib/utils/iterable.js
+++ b/packages/ember-glimmer/lib/utils/iterable.js
@@ -1,5 +1,5 @@
-import { guidFor, EmptyObject } from 'ember-utils';
-import { get, tagFor } from 'ember-metal';
+import { EmptyObject } from 'ember-utils';
+import { guidFor, get, tagFor } from 'ember-metal';
 import {
   objectAt,
   isEmberArray,

--- a/packages/ember-metal/lib/binding.js
+++ b/packages/ember-metal/lib/binding.js
@@ -1,6 +1,6 @@
-import { guidFor } from 'ember-utils';
 import Logger from 'ember-console';
 import { context, ENV } from 'ember-environment';
+import { guidFor } from './guid';
 import run from './run_loop';
 import { assert, deprecate } from './debug';
 import { get } from './property_get';

--- a/packages/ember-metal/lib/guid.js
+++ b/packages/ember-metal/lib/guid.js
@@ -1,4 +1,7 @@
+import { intern } from 'ember-utils';
 import { meta as metaFor } from './meta';
+
+export const GUID_KEY = intern('__ember' + (+ new Date()));
 
 /**
  Previously we used `Ember.$.uuid`, however `$.uuid` has been removed from

--- a/packages/ember-metal/lib/guid.js
+++ b/packages/ember-metal/lib/guid.js
@@ -1,4 +1,4 @@
-import intern from './intern';
+import { intern } from 'ember-utils';
 
 /**
  Previously we used `Ember.$.uuid`, however `$.uuid` has been removed from

--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -171,9 +171,6 @@ export {
 export { default as descriptor } from './descriptor';
 export {
   uuid,
-  GUID_KEY,
-  GUID_DESC,
-  GUID_KEY_PROPERTY,
   generateGuid,
   guidFor
 } from './guid';

--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -169,7 +169,14 @@ export {
   assertNotRendered
 } from './transaction';
 export { default as descriptor } from './descriptor';
-
+export {
+  uuid,
+  GUID_KEY,
+  GUID_DESC,
+  GUID_KEY_PROPERTY,
+  generateGuid,
+  guidFor
+} from './guid';
 
 // TODO: this needs to be deleted once we refactor the build tooling
 // do this for side-effects of updating Ember.assert, warn, etc when

--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -43,7 +43,6 @@ export {
   setDispatchOverride
 } from './error_handler';
 export {
-  META_DESC,
   meta,
   peekMeta
 } from './meta';

--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -171,7 +171,8 @@ export { default as descriptor } from './descriptor';
 export {
   uuid,
   generateGuid,
-  guidFor
+  guidFor,
+  GUID_KEY
 } from './guid';
 
 // TODO: this needs to be deleted once we refactor the build tooling

--- a/packages/ember-metal/lib/map.js
+++ b/packages/ember-metal/lib/map.js
@@ -20,7 +20,8 @@
   Map is mocked out to look like an Ember object, so you can do
   `Ember.Map.create()` for symmetry with other Ember classes.
 */
-import { EmptyObject, guidFor } from 'ember-utils';
+import { EmptyObject } from 'ember-utils';
+import { guidFor } from './guid';
 
 function missingFunction(fn) {
   throw new TypeError(`${Object.prototype.toString.call(fn)} is not a function`);

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -9,6 +9,7 @@ import { runInDebug, assert } from './debug';
 import {
   removeChainWatcher
 } from './chains';
+import { uuid } from './guid';
 
 let counters = {
   peekCalls: 0,
@@ -73,6 +74,7 @@ const META_FIELD = '__ember_meta__';
 export function Meta(obj, parentMeta) {
   runInDebug(() => counters.metaInstantiated++);
 
+  this._guid = uuid();
   this._cache = undefined;
   this._weak = undefined;
   this._watching = undefined;
@@ -185,6 +187,10 @@ Meta.prototype.isMetaDestroyed = function isMetaDestroyed() {
 
 Meta.prototype.setMetaDestroyed = function setMetaDestroyed() {
   this._flags |= META_DESTROYED;
+};
+
+Meta.prototype.sourceGuid = function sourceGuid() {
+  return this._guid;
 };
 
 // Implements a member that is a lazily created, non-inheritable

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -69,7 +69,6 @@ if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
 }
 
 let memberNames = Object.keys(members);
-const META_FIELD = '__ember_meta__';
 
 export function Meta(obj, parentMeta) {
   runInDebug(() => counters.metaInstantiated++);
@@ -410,18 +409,6 @@ function capitalize(name) {
   return name.replace(/^\w/, m => m.toUpperCase());
 }
 
-export var META_DESC = {
-  writable: true,
-  configurable: true,
-  enumerable: false,
-  value: null
-};
-
-const EMBER_META_PROPERTY = {
-  name: META_FIELD,
-  descriptor: META_DESC
-};
-
 if (isEnabled('mandatory-setter')) {
   Meta.prototype.readInheritedValue = function(key, subkey) {
     let internalKey = `_${key}`;
@@ -502,6 +489,20 @@ if (HAS_NATIVE_WEAKMAP) {
     }
   };
 } else {
+  let META_FIELD = '__ember_meta__';
+
+  let META_DESC = {
+    writable: true,
+    configurable: true,
+    enumerable: false,
+    value: null
+  };
+
+  let EMBER_META_PROPERTY = {
+    name: META_FIELD,
+    descriptor: META_DESC
+  };
+
   setMeta = function Fallback_setMeta(obj, meta) {
     // if `null` already, just set it to the new value
     // otherwise define property first

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -8,12 +8,11 @@
 */
 import {
   assign,
-  guidFor,
-  GUID_KEY,
   wrap,
   makeArray
 } from 'ember-utils';
 import EmberError from './error';
+import { guidFor, GUID_KEY } from './guid';
 import {
   debugSeal,
   assert,

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -9,10 +9,11 @@
 import {
   assign,
   wrap,
-  makeArray
+  makeArray,
+  intern
 } from 'ember-utils';
 import EmberError from './error';
-import { guidFor, GUID_KEY } from './guid';
+import { guidFor } from './guid';
 import {
   debugSeal,
   assert,
@@ -399,7 +400,7 @@ export function mixin(obj, ...args) {
   return obj;
 }
 
-export const NAME_KEY = GUID_KEY + '_name';
+export const NAME_KEY = intern('__ember' + (+ new Date()) + '_name');
 
 /**
   The `Ember.Mixin` class allows you to create mixins, whose properties can be
@@ -481,8 +482,8 @@ export default function Mixin(args, properties) {
   }
   this.ownerConstructor = undefined;
   this._without = undefined;
-  this[GUID_KEY] = null;
   this[NAME_KEY] = null;
+  metaFor(this);
   debugSeal(this);
 }
 

--- a/packages/ember-metal/lib/observer_set.js
+++ b/packages/ember-metal/lib/observer_set.js
@@ -1,4 +1,4 @@
-import { guidFor } from 'ember-utils';
+import { guidFor } from './guid';
 import { sendEvent } from './events';
 
 /*

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -1,4 +1,5 @@
-import { guidFor, symbol } from 'ember-utils';
+import { symbol } from 'ember-utils';
+import { guidFor } from './guid';
 import {
   peekMeta
 } from './meta';

--- a/packages/ember-metal/lib/weak_map.js
+++ b/packages/ember-metal/lib/weak_map.js
@@ -1,10 +1,9 @@
-import { GUID_KEY } from 'ember-utils';
 import {
   peekMeta,
   meta as metaFor
 } from './meta';
+import { uuid } from './guid';
 
-let id = 0;
 function UNDEFINED() {}
 
 // Returns whether Type(value) is Object according to the terminology in the spec
@@ -30,7 +29,7 @@ export default function WeakMap(iterable) {
     throw new TypeError(`Constructor WeakMap requires 'new'`);
   }
 
-  this._id = GUID_KEY + (id++);
+  this._id = uuid();
 
   if (iterable === null || iterable === undefined) {
     return;

--- a/packages/ember-metal/tests/guid_for_test.js
+++ b/packages/ember-metal/tests/guid_for_test.js
@@ -1,5 +1,6 @@
 import {
-  guidFor
+  guidFor,
+  generateGuid
 } from '../index';
 
 QUnit.module('guidFor');
@@ -69,4 +70,12 @@ QUnit.test('arrays', function() {
   sameGuid(a, a, 'same instance always yields same guid');
   diffGuid(a, aprime, 'identical arrays always yield different guids');
   diffGuid(a, b, 'different arrays yield different guids');
+});
+
+QUnit.module('Ember.generateGuid');
+
+QUnit.test('Prefix', function() {
+  let a = {};
+
+  ok(generateGuid(a, 'tyrell').indexOf('tyrell') > -1, 'guid can be prefixed');
 });

--- a/packages/ember-metal/tests/mixin/introspection_test.js
+++ b/packages/ember-metal/tests/mixin/introspection_test.js
@@ -42,7 +42,7 @@ QUnit.module('Basic introspection', {
 
 QUnit.test('Ember.mixins()', function() {
   function mapGuids(ary) {
-    return ary.map(x => guidFor(x));
+    return ary.map(x => guidFor(x)).sort();
   }
 
   deepEqual(mapGuids(Mixin.mixins(obj)), mapGuids([PrivateProperty, PublicProperty, PrivateMethod, PublicMethod, Combined, BarProperties, BarMethods]), 'should return included mixins');

--- a/packages/ember-metal/tests/mixin/introspection_test.js
+++ b/packages/ember-metal/tests/mixin/introspection_test.js
@@ -2,7 +2,7 @@
 // as well as methods vs props.  We are just keeping these for testing; the
 // current impl doesn't care about the differences as much...
 
-import { guidFor } from 'ember-utils';
+import { guidFor } from '../../guid';
 import {
   mixin,
   Mixin

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -1,7 +1,6 @@
 import {
   EmptyObject,
   assign,
-  guidFor,
   dictionary,
   getOwner
 } from 'ember-utils';
@@ -14,7 +13,8 @@ import {
   set,
   defineProperty,
   computed,
-  run
+  run,
+  guidFor
 } from 'ember-metal';
 import {
   Object as EmberObject,

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -112,7 +112,7 @@ QUnit.test('asserts if model class is not found', function() {
 
   expectAssertion(function() {
     route.model({ post_id: 1 });
-  }, /You used the dynamic segment post_id in your route undefined, but <Ember.Object:ember\d+>.Post did not exist and you did not override your route\'s `model` hook./);
+  }, /You used the dynamic segment post_id in your route undefined, but <Ember.Object:.+>.Post did not exist and you did not override your route\'s `model` hook./);
 });
 
 QUnit.test('\'store\' does not need to be injected', function() {

--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -3,7 +3,7 @@
 @submodule ember-runtime
 */
 
-import { EmptyObject, guidFor } from 'ember-utils';
+import { EmptyObject } from 'ember-utils';
 import {
   assert,
   get,
@@ -14,7 +14,8 @@ import {
   removeObserver,
   isNone,
   getProperties,
-  WeakMap
+  WeakMap,
+  guidFor
 } from 'ember-metal';
 import compare from '../compare';
 import { isArray } from '../utils';

--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -7,7 +7,7 @@
 // HELPERS
 //
 
-import { guidFor, EmptyObject } from 'ember-utils';
+import { EmptyObject } from 'ember-utils';
 import {
   get,
   set,
@@ -22,7 +22,8 @@ import {
   sendEvent,
   hasListeners,
   assert,
-  deprecate
+  deprecate,
+  guidFor
 } from 'ember-metal';
 import compare from '../compare';
 import require from 'require';

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -36,7 +36,6 @@ import {
   descriptor,
   guidFor,
   generateGuid,
-  GUID_KEY_PROPERTY,
 } from 'ember-metal';
 import ActionHandler from '../mixins/action_handler';
 import { validatePropertyInjections } from '../inject';
@@ -65,7 +64,6 @@ function makeCtor() {
       initProperties = [arguments[0]];
     }
 
-    this.__defineNonEnumerable(GUID_KEY_PROPERTY);
     var m = meta(this);
     var proto = m.proto;
     m.proto = this;

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -11,9 +11,6 @@
 // if present
 import {
   assign,
-  guidFor,
-  generateGuid,
-  GUID_KEY_PROPERTY,
   makeArray,
   symbol
 } from 'ember-utils';
@@ -36,7 +33,10 @@ import {
   InjectedProperty,
   run,
   destroy,
-  descriptor
+  descriptor,
+  guidFor,
+  generateGuid,
+  GUID_KEY_PROPERTY,
 } from 'ember-metal';
 import ActionHandler from '../mixins/action_handler';
 import { validatePropertyInjections } from '../inject';

--- a/packages/ember-runtime/lib/system/namespace.js
+++ b/packages/ember-runtime/lib/system/namespace.js
@@ -2,13 +2,13 @@
 @module ember
 @submodule ember-runtime
 */
-import { guidFor } from 'ember-utils';
 import Ember, {
   get,
   Mixin,
   hasUnprocessedMixins,
   clearUnprocessedMixins,
-  NAME_KEY
+  NAME_KEY,
+  guidFor
 } from 'ember-metal'; // Preloaded into namespaces
 import { context } from 'ember-environment';
 

--- a/packages/ember-runtime/tests/mixins/copyable_test.js
+++ b/packages/ember-runtime/tests/mixins/copyable_test.js
@@ -1,9 +1,8 @@
-import { generateGuid } from 'ember-utils';
 import CopyableTests from '../suites/copyable';
 import Copyable from '../../mixins/copyable';
 import { Freezable } from '../../mixins/freezable';
 import EmberObject from '../../system/object';
-import { set, get } from 'ember-metal';
+import { set, get, generateGuid } from 'ember-metal';
 
 QUnit.module('Ember.Copyable.frozenCopy');
 

--- a/packages/ember-runtime/tests/suites/enumerable.js
+++ b/packages/ember-runtime/tests/suites/enumerable.js
@@ -1,11 +1,12 @@
-import { guidFor, generateGuid } from 'ember-utils';
 import { Suite } from './suite';
 import EmberObject from '../../system/object';
 import {
   computed,
   get,
   _addBeforeObserver,
-  isFeatureEnabled
+  isFeatureEnabled,
+  generateGuid,
+  guidFor
 } from 'ember-metal';
 
 const ObserverClass = EmberObject.extend({

--- a/packages/ember-runtime/tests/suites/enumerable/forEach.js
+++ b/packages/ember-runtime/tests/suites/enumerable/forEach.js
@@ -1,6 +1,5 @@
-import { guidFor } from 'ember-utils';
 import { SuiteModuleBuilder } from '../suite';
-import { get } from 'ember-metal';
+import { get, guidFor } from 'ember-metal';
 
 const suite = SuiteModuleBuilder.create();
 

--- a/packages/ember-runtime/tests/suites/enumerable/map.js
+++ b/packages/ember-runtime/tests/suites/enumerable/map.js
@@ -1,6 +1,5 @@
-import { guidFor } from 'ember-utils';
 import { SuiteModuleBuilder } from '../suite';
-import { get } from 'ember-metal';
+import { get, guidFor } from 'ember-metal';
 
 const suite = SuiteModuleBuilder.create();
 

--- a/packages/ember-runtime/tests/suites/suite.js
+++ b/packages/ember-runtime/tests/suites/suite.js
@@ -1,6 +1,5 @@
-import { guidFor } from 'ember-utils';
 import EmberObject from '../../system/object';
-import { get } from 'ember-metal';
+import { get, guidFor } from 'ember-metal';
 
 /*
   @class

--- a/packages/ember-runtime/tests/system/native_array/copyable_suite_test.js
+++ b/packages/ember-runtime/tests/system/native_array/copyable_suite_test.js
@@ -1,4 +1,4 @@
-import { generateGuid } from 'ember-utils';
+import { generateGuid } from 'ember-metal';
 import { A as emberA } from '../../../system/native_array';
 import CopyableTests from '../../suites/copyable';
 

--- a/packages/ember-runtime/tests/system/object/toString_test.js
+++ b/packages/ember-runtime/tests/system/object/toString_test.js
@@ -1,4 +1,4 @@
-import { guidFor, GUID_KEY } from 'ember-utils';
+import { guidFor, GUID_KEY } from 'ember-metal';
 import { context } from 'ember-environment';
 import EmberObject from '../../../system/object';
 import Namespace from '../../../system/namespace';

--- a/packages/ember-runtime/tests/system/object/toString_test.js
+++ b/packages/ember-runtime/tests/system/object/toString_test.js
@@ -1,4 +1,4 @@
-import { guidFor, GUID_KEY } from 'ember-metal';
+import { guidFor, NAME_KEY } from 'ember-metal';
 import { context } from 'ember-environment';
 import EmberObject from '../../../system/object';
 import Namespace from '../../../system/namespace';
@@ -89,8 +89,8 @@ QUnit.test('toString includes toStringExtension if defined', function() {
   let bar = Bar.create();
 
   // simulate these classes being defined on a Namespace
-  Foo[GUID_KEY + '_name'] = 'Foo';
-  Bar[GUID_KEY + '_name'] = 'Bar';
+  Foo[NAME_KEY] = 'Foo';
+  Bar[NAME_KEY] = 'Bar';
 
   equal(bar.toString(), '<Bar:' + guidFor(bar) + '>', 'does not include toStringExtension part');
   equal(foo.toString(), '<Foo:' + guidFor(foo) + ':fooey>', 'Includes toStringExtension result');

--- a/packages/ember-utils/lib/guid.js
+++ b/packages/ember-utils/lib/guid.js
@@ -21,19 +21,16 @@ export function uuid() {
   return ++_uuid;
 }
 
-/**
- Prefix used for guids through out Ember.
- @private
- @property GUID_PREFIX
- @for Ember
- @type String
- @final
- */
-const GUID_PREFIX = 'ember';
-
 // Used for guid generation...
-const numberCache  = [];
-const stringCache  = {};
+const NUMBER_CACHE = [];
+const STRING_CACHE = {};
+
+const TRUE_UUID = uuid();
+const FALSE_UUID = uuid();
+const OBJECT_UUID = uuid();
+const ARRAY_UUID = uuid();
+const NULL_UUID = uuid();
+const UNDEFINED_UUID = uuid();
 
 /**
   A unique key used to assign guids and other private metadata to objects.
@@ -88,11 +85,13 @@ export let GUID_KEY_PROPERTY = {
   @return {String} the guid
 */
 export function generateGuid(obj, prefix) {
-  if (!prefix) {
-    prefix = GUID_PREFIX;
+  let ret;
+  if (prefix) {
+    ret = prefix + uuid();
+  } else {
+    ret = uuid();
   }
 
-  let ret = (prefix + uuid());
   if (obj) {
     if (obj[GUID_KEY] === null) {
       obj[GUID_KEY] = ret;
@@ -133,11 +132,11 @@ export function guidFor(obj) {
 
   // special cases where we don't want to add a key to object
   if (obj === undefined) {
-    return '(undefined)';
+    return UNDEFINED_UUID;
   }
 
   if (obj === null) {
-    return '(null)';
+    return NULL_UUID;
   }
 
   let ret;
@@ -145,36 +144,36 @@ export function guidFor(obj) {
   // Don't allow prototype changes to String etc. to change the guidFor
   switch (type) {
     case 'number':
-      ret = numberCache[obj];
+      ret = NUMBER_CACHE[obj];
 
       if (!ret) {
-        ret = numberCache[obj] = 'nu' + obj;
+        ret = NUMBER_CACHE[obj] = uuid();
       }
 
       return ret;
 
     case 'string':
-      ret = stringCache[obj];
+      ret = STRING_CACHE[obj];
 
       if (!ret) {
-        ret = stringCache[obj] = 'st' + uuid();
+        ret = STRING_CACHE[obj] = uuid();
       }
 
       return ret;
 
     case 'boolean':
-      return obj ? '(true)' : '(false)';
+      return obj ? TRUE_UUID : FALSE_UUID;
 
     default:
       if (obj === Object) {
-        return '(Object)';
+        return OBJECT_UUID;
       }
 
       if (obj === Array) {
-        return '(Array)';
+        return ARRAY_UUID;
       }
 
-      ret = GUID_PREFIX + uuid();
+      ret = uuid();
 
       if (obj[GUID_KEY] === null) {
         obj[GUID_KEY] = ret;

--- a/packages/ember-utils/lib/index.js
+++ b/packages/ember-utils/lib/index.js
@@ -13,14 +13,6 @@ export { getOwner, setOwner, OWNER } from './owner';
 export { default as assign } from './assign';
 export { default as EmptyObject } from './empty-object';
 export { default as dictionary } from './dictionary';
-export {
-  uuid,
-  GUID_KEY,
-  GUID_DESC,
-  GUID_KEY_PROPERTY,
-  generateGuid,
-  guidFor
-} from './guid';
 export { default as intern } from './intern';
 export { checkHasSuper, ROOT, wrap } from './super';
 export { default as inspect } from './inspect';

--- a/packages/ember-utils/lib/symbol.js
+++ b/packages/ember-utils/lib/symbol.js
@@ -1,5 +1,6 @@
-import { GUID_KEY } from './guid';
 import intern from './intern';
+
+const GUID_KEY = 'ember';
 
 export default function symbol(debugName) {
   // TODO: Investigate using platform symbols, but we do not

--- a/packages/ember-utils/tests/generate_guid_test.js
+++ b/packages/ember-utils/tests/generate_guid_test.js
@@ -1,9 +1,0 @@
-import { generateGuid } from '../index';
-
-QUnit.module('Ember.generateGuid');
-
-QUnit.test('Prefix', function() {
-  let a = {};
-
-  ok(generateGuid(a, 'tyrell').indexOf('tyrell') > -1, 'guid can be prefixed');
-});

--- a/packages/ember-utils/tests/guid_for_test.js
+++ b/packages/ember-utils/tests/guid_for_test.js
@@ -12,18 +12,12 @@ function diffGuid(a, b, message) {
   ok(guidFor(a) !== guidFor(b), message);
 }
 
-function nanGuid(obj) {
-  let type = typeof obj;
-  ok(isNaN(parseInt(guidFor(obj), 0)), 'guids for ' + type + 'don\'t parse to numbers');
-}
-
 QUnit.test('Object', function() {
   let a = {};
   let b = {};
 
   sameGuid(a, a, 'same object always yields same guid');
   diffGuid(a, b, 'different objects yield different guids');
-  nanGuid(a);
 });
 
 QUnit.test('strings', function() {
@@ -34,7 +28,6 @@ QUnit.test('strings', function() {
   sameGuid(a, a, 'same string always yields same guid');
   sameGuid(a, aprime, 'identical strings always yield the same guid');
   diffGuid(a, b, 'different strings yield different guids');
-  nanGuid(a);
 });
 
 QUnit.test('numbers', function() {
@@ -45,7 +38,6 @@ QUnit.test('numbers', function() {
   sameGuid(a, a, 'same numbers always yields same guid');
   sameGuid(a, aprime, 'identical numbers always yield the same guid');
   diffGuid(a, b, 'different numbers yield different guids');
-  nanGuid(a);
 });
 
 QUnit.test('numbers', function() {
@@ -56,8 +48,6 @@ QUnit.test('numbers', function() {
   sameGuid(a, a, 'same booleans always yields same guid');
   sameGuid(a, aprime, 'identical booleans always yield the same guid');
   diffGuid(a, b, 'different boolean yield different guids');
-  nanGuid(a);
-  nanGuid(b);
 });
 
 QUnit.test('null and undefined', function() {
@@ -69,8 +59,6 @@ QUnit.test('null and undefined', function() {
   sameGuid(b, b, 'undefined always returns the same guid');
   sameGuid(a, aprime, 'different nulls return the same guid');
   diffGuid(a, b, 'null and undefined return different guids');
-  nanGuid(a);
-  nanGuid(b);
 });
 
 QUnit.test('arrays', function() {
@@ -79,7 +67,6 @@ QUnit.test('arrays', function() {
   let b = ['1', '2', '3'];
 
   sameGuid(a, a, 'same instance always yields same guid');
-  diffGuid(a, aprime, 'identical arrays always yield the same guid');
+  diffGuid(a, aprime, 'identical arrays always yield different guids');
   diffGuid(a, b, 'different arrays yield different guids');
-  nanGuid(a);
 });

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -421,7 +421,7 @@ export default Mixin.create({
     this._super(...arguments);
 
     if (!this.elementId && this.tagName !== '') {
-      this.elementId = guidFor(this);
+      this.elementId = 'ember' + guidFor(this);
     }
 
     this[INIT_WAS_CALLED] = true;

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -1,5 +1,5 @@
-import { guidFor, symbol } from 'ember-utils';
-import { assert, deprecate, descriptor, Mixin } from 'ember-metal';
+import { symbol } from 'ember-utils';
+import { assert, deprecate, descriptor, Mixin, guidFor } from 'ember-metal';
 import { POST_INIT } from 'ember-runtime';
 import { environment } from 'ember-environment';
 import { matches } from '../system/utils';

--- a/packages/ember-views/lib/system/utils.js
+++ b/packages/ember-views/lib/system/utils.js
@@ -47,9 +47,9 @@ export function getRootViews(owner) {
  */
 export function getViewId(view) {
   if (view.tagName === '') {
-    return guidFor(view);
+    return 'ember' + guidFor(view);
   } else {
-    return view.elementId || guidFor(view);
+    return view.elementId;
   }
 }
 

--- a/packages/ember-views/lib/system/utils.js
+++ b/packages/ember-views/lib/system/utils.js
@@ -1,5 +1,6 @@
 /* globals Element */
-import { guidFor, symbol, getOwner } from 'ember-utils';
+import { symbol, getOwner } from 'ember-utils';
+import { guidFor } from 'ember-metal';
 
 /**
 @module ember

--- a/packages/ember/lib/index.js
+++ b/packages/ember/lib/index.js
@@ -127,6 +127,7 @@ Ember.Binding = metal.Binding;
 Ember.isGlobalPath = metal.isGlobalPath;
 Ember.uuid = metal.uuid;
 Ember.generateGuid = metal.generateGuid;
+Ember.GUID_KEY = metal.GUID_KEY;
 Ember.guidFor = metal.guidFor;
 
 if (isFeatureEnabled('ember-metal-weakmap')) {

--- a/packages/ember/lib/index.js
+++ b/packages/ember/lib/index.js
@@ -128,7 +128,6 @@ Ember.Binding = metal.Binding;
 Ember.isGlobalPath = metal.isGlobalPath;
 Ember.uuid = metal.uuid;
 Ember.generateGuid = metal.generateGuid;
-Ember.GUID_KEY = metal.GUID_KEY;
 Ember.guidFor = metal.guidFor;
 
 if (isFeatureEnabled('ember-metal-weakmap')) {

--- a/packages/ember/lib/index.js
+++ b/packages/ember/lib/index.js
@@ -56,7 +56,6 @@ Ember.Instrumentation = {
 };
 
 Ember.Error = metal.Error;
-Ember.META_DESC = metal.META_DESC;
 Ember.meta = metal.meta;
 Ember.get = metal.get;
 Ember.getWithDefault = metal.getWithDefault;

--- a/packages/ember/lib/index.js
+++ b/packages/ember/lib/index.js
@@ -12,16 +12,12 @@ import Ember, * as metal from 'ember-metal';
 // ember-utils exports
 Ember.getOwner = utils.getOwner;
 Ember.setOwner = utils.setOwner;
-Ember.generateGuid = utils.generateGuid;
-Ember.GUID_KEY = utils.GUID_KEY;
-Ember.guidFor = utils.guidFor;
 Ember.inspect = utils.inspect;
 Ember.makeArray = utils.makeArray;
 Ember.canInvoke = utils.canInvoke;
 Ember.tryInvoke = utils.tryInvoke;
 Ember.wrap = utils.wrap;
 Ember.applyStr = utils.applyStr;
-Ember.uuid = utils.uuid;
 Ember.assign = Object.assign || utils.assign;
 
 // container exports
@@ -130,6 +126,10 @@ Ember.Mixin = metal.Mixin;
 Ember.bind = metal.bind;
 Ember.Binding = metal.Binding;
 Ember.isGlobalPath = metal.isGlobalPath;
+Ember.uuid = metal.uuid;
+Ember.generateGuid = metal.generateGuid;
+Ember.GUID_KEY = metal.GUID_KEY;
+Ember.guidFor = metal.guidFor;
 
 if (isFeatureEnabled('ember-metal-weakmap')) {
   Ember.WeakMap = metal.WeakMap;

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -47,7 +47,6 @@ QUnit.module('ember reexports');
   ['FEATURES', 'ember-metal'],
   ['FEATURES.isEnabled', 'ember-metal', 'isFeatureEnabled'],
   ['Error', 'ember-metal'],
-  ['META_DESC', 'ember-metal'],
   ['meta', 'ember-metal'],
   ['get', 'ember-metal'],
   ['set', 'ember-metal'],

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -113,7 +113,6 @@ QUnit.module('ember reexports');
   ['bind', 'ember-metal'],
   ['Binding', 'ember-metal'],
   ['isGlobalPath', 'ember-metal'],
-  ['GUID_KEY', 'ember-metal'],
   ['uuid', 'ember-metal'],
   ['generateGuid', 'ember-metal'],
   ['guidFor', 'ember-metal'],

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -9,10 +9,6 @@ QUnit.module('ember reexports');
   ['getOwner', 'ember-utils', 'getOwner'],
   ['setOwner', 'ember-utils', 'setOwner'],
   // ['assign', 'ember-metal'], TODO: fix this test, we use `Object.assign` if present
-  ['GUID_KEY', 'ember-utils'],
-  ['uuid', 'ember-utils'],
-  ['generateGuid', 'ember-utils'],
-  ['guidFor', 'ember-utils'],
   ['inspect', 'ember-utils'],
   ['makeArray', 'ember-utils'],
   ['canInvoke', 'ember-utils'],
@@ -117,6 +113,10 @@ QUnit.module('ember reexports');
   ['bind', 'ember-metal'],
   ['Binding', 'ember-metal'],
   ['isGlobalPath', 'ember-metal'],
+  ['GUID_KEY', 'ember-metal'],
+  ['uuid', 'ember-metal'],
+  ['generateGuid', 'ember-metal'],
+  ['guidFor', 'ember-metal'],
 
   // ember-views
   ['$', 'ember-views', 'jQuery'],

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -112,6 +112,7 @@ QUnit.module('ember reexports');
   ['bind', 'ember-metal'],
   ['Binding', 'ember-metal'],
   ['isGlobalPath', 'ember-metal'],
+  ['GUID_KEY', 'ember-metal'],
   ['uuid', 'ember-metal'],
   ['generateGuid', 'ember-metal'],
   ['guidFor', 'ember-metal'],


### PR DESCRIPTION
- Refactor `Ember.guidFor` to always return a number (avoid extraneous string allocations, easier to compare, etc)
- Move guid storage from a property on the object (using `obj.__defineNonEmumerable` or `Object.defineProperty`) into the meta instance for the object. Where supported this will use a native `WeakMap`, where not supported this results in only a single property on the object instead of two (`GUID_KEY` and `__ember_meta__`).
- Maintain support for `Ember.generateGuid` (even though private)
- Maintain support for `Ember.guidFor`
