### PR TITLE
Do not slice `classNames` and `classNameBindings` speculatively.

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/class-bindings-test.js
+++ b/packages/ember-glimmer/tests/integration/components/class-bindings-test.js
@@ -300,7 +300,7 @@ moduleFor('ClassNameBindings integration', class extends RenderingTest {
       init() {
         this._super();
 
-        let bindings = this.classNameBindings;
+        let bindings = this.classNameBindings = this.classNameBindings.slice();
 
         if (this.get('bindIsEnabled')) {
           bindings.push('isEnabled:enabled');

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -340,6 +340,7 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     let FooBarComponent = Component.extend({
       init() {
         this._super();
+        this.classNames = this.classNames.slice();
         this.classNames.push('foo', 'bar', `outside-${this.get('extraClass')}`);
       }
     });

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -143,20 +143,32 @@ function giveMethodSuper(obj, key, method, values, descs) {
 
 function applyConcatenatedProperties(obj, key, value, values) {
   let baseValue = values[key] || obj[key];
+  let ret;
 
   if (baseValue) {
     if ('function' === typeof baseValue.concat) {
       if (value === null || value === undefined) {
-        return baseValue;
+        ret = baseValue;
       } else {
-        return baseValue.concat(value);
+        ret = baseValue.concat(value);
       }
     } else {
-      return makeArray(baseValue).concat(value);
+      ret = makeArray(baseValue).concat(value);
     }
   } else {
-    return makeArray(value);
+    ret = makeArray(value);
   }
+
+  runInDebug(() => {
+    // it is possible to use concatenatedProperties with strings (which cannot be frozen)
+    // only freeze objects...
+    if (typeof ret === 'object' && ret !== null) {
+      // prevent mutating `concatenatedProperties` array after it is applied
+      Object.freeze(ret);
+    }
+  });
+
+  return ret;
 }
 
 function applyMergedProperties(obj, key, value, values) {

--- a/packages/ember-routing/lib/utils.js
+++ b/packages/ember-routing/lib/utils.js
@@ -130,11 +130,7 @@ export function calculateCacheKey(prefix, _parts, values) {
   'Array of fully defined objects' style.
 */
 export function normalizeControllerQueryParams(queryParams) {
-  if (queryParams._qpMap) {
-    return queryParams._qpMap;
-  }
-
-  let qpMap = queryParams._qpMap = {};
+  let qpMap = {};
 
   for (let i = 0; i < queryParams.length; ++i) {
     accumulateQueryParamDescriptors(queryParams[i], qpMap);

--- a/packages/ember-routing/tests/utils_test.js
+++ b/packages/ember-routing/tests/utils_test.js
@@ -5,15 +5,6 @@ import {
 
 QUnit.module('Routing query parameter utils - normalizeControllerQueryParams');
 
-QUnit.test('returns the cached value if that has been previously set', function(assert) {
-  let cached = {};
-  let params = ['foo'];
-  params._qpMap = cached;
-
-  let normalized = normalizeControllerQueryParams(params);
-  equal(cached, normalized, 'cached value returned if previously set');
-});
-
 QUnit.test('converts array style into verbose object style', function(assert) {
   let paramName = 'foo';
   let params = [paramName];

--- a/packages/ember-views/lib/mixins/class_names_support.js
+++ b/packages/ember-views/lib/mixins/class_names_support.js
@@ -22,10 +22,7 @@ export default Mixin.create({
     this._super(...arguments);
 
     assert(`Only arrays are allowed for 'classNameBindings'`, Array.isArray(this.classNameBindings));
-    this.classNameBindings = this.classNameBindings.slice();
-
     assert(`Only arrays of static class strings are allowed for 'classNames'. For dynamic classes, use 'classNameBindings'.`, Array.isArray(this.classNames));
-    this.classNames = this.classNames.slice();
   },
 
   /**


### PR DESCRIPTION
The vast majority of the time these arrays are completely static on the prototype, there are relatively few instances where we actually need to slice them but we were speculatively doing this "just in case" you wanted it.

This change does not remove the ability to have custom `classNames` / `classNameBindings` per instance, but it does make it so that folks wanting to do this would need to do `this.classNames.slice()` first.

This avoids many extraneous array allocations, and one more layer of wasted work during initial render.
