### PR TITLE
[BUGFIX beta] layout now supports computed property

### DIFF
--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -262,7 +262,7 @@ class CurlyComponentManager {
   }
 
   templateFor(component, env) {
-    let Template = component.layout;
+    let Template = get(component, 'layout');
     let owner = component[OWNER];
     if (Template) {
       return env.getTemplate(Template, owner);

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -152,6 +152,25 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     this.assertText('so much layout wat hey');
   }
 
+  ['@test layout supports computed property']() {
+    let FooBarComponent = Component.extend({
+      elementId: 'blahzorz',
+      layout: computed(function () {
+        return compile('so much layout wat {{lulz}}');
+      }),
+      init() {
+        this._super(...arguments);
+        this.lulz = 'heyo';
+      }
+    });
+
+    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent });
+
+    this.render('{{foo-bar}}');
+
+    this.assertText('so much layout wat heyo');
+  }
+
   ['@test passing undefined elementId results in a default elementId'](assert) {
     let FooBarComponent = Component.extend({
       tagName: 'h1'


### PR DESCRIPTION
In the 2.9.0-beta.4 release layout breaks if you are using a computed property. This pull request will close out issue #14380 
