### PR TITLE
[DOC release] Use `Ember.computed`

### DIFF
--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -110,9 +110,9 @@ export default Mixin.create({
     declared at the end, such as:
 
     ```javascript
-    fullName: function() {
+    fullName: Ember.computed('firstName', 'lastName', function() {
       return this.get('firstName') + ' ' + this.get('lastName');
-    }.property('firstName', 'lastName')
+    })
     ```
 
     When you call `get` on a computed property, the function will be

--- a/packages/ember-runtime/lib/system/object_proxy.js
+++ b/packages/ember-runtime/lib/system/object_proxy.js
@@ -44,14 +44,14 @@ import _ProxyMixin from '../mixins/-proxy';
 
   ```javascript
   ProxyWithComputedProperty = Ember.ObjectProxy.extend({
-    fullName: function() {
+    fullName: Ember.computed('firstName', 'lastName', function() {
       var firstName = this.get('firstName'),
           lastName = this.get('lastName');
       if (firstName && lastName) {
         return firstName + ' ' + lastName;
       }
       return firstName || lastName;
-    }.property('firstName', 'lastName')
+    })
   });
 
   proxy = ProxyWithComputedProperty.create();


### PR DESCRIPTION
Replace function prototype extension with  `Ember.computed`
