### PR TITLE
[BUGFIX beta] Fix tagless `willInsertElement`

### DIFF
--- a/packages/ember-glimmer/lib/helper.js
+++ b/packages/ember-glimmer/lib/helper.js
@@ -4,10 +4,7 @@
 */
 
 import { symbol } from 'ember-utils';
-import {
-  Object as EmberObject,
-  POST_INIT
-} from 'ember-runtime';
+import { FrameworkObject } from 'ember-runtime';
 import { DirtyableTag } from 'glimmer-reference';
 
 export const RECOMPUTE_TAG = symbol('RECOMPUTE_TAG');
@@ -52,10 +49,11 @@ export const RECOMPUTE_TAG = symbol('RECOMPUTE_TAG');
   @public
   @since 1.13.0
 */
-var Helper = EmberObject.extend({
+var Helper = FrameworkObject.extend({
   isHelperInstance: true,
 
-  [POST_INIT]() {
+  init() {
+    this._super(...arguments);
     this[RECOMPUTE_TAG] = new DirtyableTag();
   },
 

--- a/packages/ember-glimmer/lib/renderer.js
+++ b/packages/ember-glimmer/lib/renderer.js
@@ -206,10 +206,6 @@ class Renderer {
     this._scheduleRevalidate();
   }
 
-  componentInitAttrs() {
-    // TODO: Remove me
-  }
-
   ensureViewNotRendering() {
     // TODO: Implement this
     // throw new Error('Something you did caused a view to re-render after it rendered but before it was inserted into the DOM.');

--- a/packages/ember-glimmer/lib/renderer.js
+++ b/packages/ember-glimmer/lib/renderer.js
@@ -206,11 +206,6 @@ class Renderer {
     this._scheduleRevalidate();
   }
 
-  ensureViewNotRendering() {
-    // TODO: Implement this
-    // throw new Error('Something you did caused a view to re-render after it rendered but before it was inserted into the DOM.');
-  }
-
   register(view) {
     let id = getViewId(view);
     assert('Attempted to register a view with an id already in use: ' + id, !this._viewRegistry[id]);

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -211,8 +211,14 @@ class CurlyComponentManager {
     component.trigger('didInitAttrs', { attrs });
     component.trigger('didReceiveAttrs', { newAttrs: attrs });
 
-    if (environment.isInteractive) {
-      component.trigger('willRender');
+    // We usually do this in the `didCreateElement`, but that hook doesn't fire for tagless components
+    if (component.tagName === '') {
+      component._transitionTo('hasElement');
+
+      if (environment.isInteractive) {
+        component.trigger('willInsertElement');
+        component.trigger('willRender');
+      }
     }
 
     let bucket = new ComponentStateBucket(environment, component, processedArgs, finalizer);
@@ -287,6 +293,7 @@ class CurlyComponentManager {
 
     if (environment.isInteractive) {
       component.trigger('willInsertElement');
+      component.trigger('willRender');
     }
   }
 
@@ -363,8 +370,14 @@ class TopComponentManager extends CurlyComponentManager {
     component.trigger('didInitAttrs');
     component.trigger('didReceiveAttrs');
 
-    if (environment.isInteractive) {
-      component.trigger('willRender');
+    // We usually do this in the `didCreateElement`, but that hook doesn't fire for tagless components
+    if (component.tagName === '') {
+      component._transitionTo('hasElement');
+
+      if (environment.isInteractive) {
+        component.trigger('willInsertElement');
+        component.trigger('willRender');
+      }
     }
 
     processComponentInitializationAssertions(component, {});

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -2458,7 +2458,7 @@ moduleFor('Components test: curly components', class extends RenderingTest {
 
     expectAssertion(() => {
       this.render('{{foo-bar}}');
-    }, /You must call `this._super\(...arguments\);` when implementing `init` in a component. Please update .* to call `this._super` from `init`/);
+    }, /You must call `this._super\(...arguments\);` when overriding `init` on a framework object. Please update .* to call `this._super\(...arguments\);` from `init`./);
   }
 
   ['@test should toggle visibility with isVisible'](assert) {

--- a/packages/ember-glimmer/tests/integration/components/life-cycle-test.js
+++ b/packages/ember-glimmer/tests/integration/components/life-cycle-test.js
@@ -164,25 +164,26 @@ class LifeCycleHooksTest extends RenderingTest {
         }
       },
 
-      willRender() {
-        pushHook('willRender');
-        assertParentView('willRender', this);
-
-        if (this.isInitialRender) {
-          assertNoElement('willRender', this);
-          assertState('willRender', 'preRender', this);
-        } else {
-          assertElement('willRender', this);
-          assertState('willRender', 'inDOM', this);
-        }
-      },
-
       willInsertElement() {
         pushHook('willInsertElement');
         assertParentView('willInsertElement', this);
         assertElement('willInsertElement', this, false);
         assertState('willInsertElement', 'hasElement', this);
       },
+
+      willRender() {
+        pushHook('willRender');
+        assertParentView('willRender', this);
+
+        if (this.isInitialRender) {
+          assertElement('willRender', this, false);
+          assertState('willRender', 'hasElement', this);
+        } else {
+          assertElement('willRender', this);
+          assertState('willRender', 'inDOM', this);
+        }
+      },
+
 
       didInsertElement() {
         pushHook('didInsertElement');
@@ -302,20 +303,20 @@ class LifeCycleHooksTest extends RenderingTest {
         ['the-top', 'init'],
         ['the-top', 'didInitAttrs',       { attrs: topAttrs }],
         ['the-top', 'didReceiveAttrs',    { newAttrs: topAttrs }],
-        ['the-top', 'willRender'],
         ['the-top', 'willInsertElement'],
+        ['the-top', 'willRender'],
 
         ['the-middle', 'init'],
         ['the-middle', 'didInitAttrs',    { attrs: middleAttrs }],
         ['the-middle', 'didReceiveAttrs', { newAttrs: middleAttrs }],
-        ['the-middle', 'willRender'],
         ['the-middle', 'willInsertElement'],
+        ['the-middle', 'willRender'],
 
         ['the-bottom', 'init'],
         ['the-bottom', 'didInitAttrs',    { attrs: bottomAttrs }],
         ['the-bottom', 'didReceiveAttrs', { newAttrs: bottomAttrs }],
-        ['the-bottom', 'willRender'],
         ['the-bottom', 'willInsertElement'],
+        ['the-bottom', 'willRender'],
 
         // Async hooks
 
@@ -539,26 +540,26 @@ class LifeCycleHooksTest extends RenderingTest {
         ['the-parent', 'init'],
         ['the-parent', 'didInitAttrs',          { attrs: parentAttrs }],
         ['the-parent', 'didReceiveAttrs',       { newAttrs: parentAttrs }],
-        ['the-parent', 'willRender'],
         ['the-parent', 'willInsertElement'],
+        ['the-parent', 'willRender'],
 
         ['the-first-child', 'init'],
         ['the-first-child', 'didInitAttrs',     { attrs: firstAttrs }],
         ['the-first-child', 'didReceiveAttrs',  { newAttrs: firstAttrs }],
-        ['the-first-child', 'willRender'],
         ['the-first-child', 'willInsertElement'],
+        ['the-first-child', 'willRender'],
 
         ['the-second-child', 'init'],
         ['the-second-child', 'didInitAttrs',    { attrs: secondAttrs }],
         ['the-second-child', 'didReceiveAttrs', { newAttrs: secondAttrs }],
-        ['the-second-child', 'willRender'],
         ['the-second-child', 'willInsertElement'],
+        ['the-second-child', 'willRender'],
 
         ['the-last-child', 'init'],
         ['the-last-child', 'didInitAttrs',      { attrs: lastAttrs }],
         ['the-last-child', 'didReceiveAttrs',   { newAttrs: lastAttrs }],
-        ['the-last-child', 'willRender'],
         ['the-last-child', 'willInsertElement'],
+        ['the-last-child', 'willRender'],
 
         // Async hooks
 
@@ -856,20 +857,20 @@ class LifeCycleHooksTest extends RenderingTest {
         ['the-top', 'init'],
         ['the-top', 'didInitAttrs',       { attrs: topAttrs }],
         ['the-top', 'didReceiveAttrs',    { newAttrs: topAttrs }],
-        ['the-top', 'willRender'],
         ['the-top', 'willInsertElement'],
+        ['the-top', 'willRender'],
 
         ['the-middle', 'init'],
         ['the-middle', 'didInitAttrs',    { attrs: middleAttrs }],
         ['the-middle', 'didReceiveAttrs', { newAttrs: middleAttrs }],
-        ['the-middle', 'willRender'],
         ['the-middle', 'willInsertElement'],
+        ['the-middle', 'willRender'],
 
         ['the-bottom', 'init'],
         ['the-bottom', 'didInitAttrs',    { attrs: bottomAttrs }],
         ['the-bottom', 'didReceiveAttrs', { newAttrs: bottomAttrs }],
-        ['the-bottom', 'willRender'],
         ['the-bottom', 'willInsertElement'],
+        ['the-bottom', 'willRender'],
 
         // Async hooks
 
@@ -1041,8 +1042,8 @@ class LifeCycleHooksTest extends RenderingTest {
       ];
       if (this.isInteractive) {
         ret.push(
-          ['an-item', 'willRender'],
-          ['an-item', 'willInsertElement']
+          ['an-item', 'willInsertElement'],
+          ['an-item', 'willRender']
         );
       }
       ret.push(
@@ -1052,8 +1053,8 @@ class LifeCycleHooksTest extends RenderingTest {
       );
       if (this.isInteractive) {
         ret.push(
-          ['nested-item', 'willRender'],
-          ['nested-item', 'willInsertElement']
+          ['nested-item', 'willInsertElement'],
+          ['nested-item', 'willRender']
         );
       }
       return ret;
@@ -1150,15 +1151,15 @@ class LifeCycleHooksTest extends RenderingTest {
         ['no-items', 'init'],
         ['no-items', 'didInitAttrs',       { attrs: { } }],
         ['no-items', 'didReceiveAttrs',    { newAttrs: { } }],
-        ['no-items', 'willRender'],
         ['no-items', 'willInsertElement'],
+        ['no-items', 'willRender'],
 
 
         ['nested-item', 'init'],
         ['nested-item', 'didInitAttrs',       { attrs: { } }],
         ['nested-item', 'didReceiveAttrs',    { newAttrs: { } }],
-        ['nested-item', 'willRender'],
         ['nested-item', 'willInsertElement'],
+        ['nested-item', 'willRender'],
 
         ['an-item', 'didDestroyElement'],
         ['nested-item', 'didDestroyElement'],
@@ -1238,65 +1239,70 @@ class LifeCycleHooksTest extends RenderingTest {
   }
 }
 
-moduleFor('Components test: interactive lifecycle hooks (curly components)', class extends LifeCycleHooksTest {
-
+class CurlyComponentsTest extends LifeCycleHooksTest {
   get ComponentClass() {
     return Component;
+  }
+
+  invocationFor(name, namedArgs = {}) {
+    let attrs = Object.keys(namedArgs).map(k => `${k}=${this.val(namedArgs[k])}`).join(' ');
+    return `{{${name} ${attrs}}}`;
+  }
+
+  attrFor(name) {
+    return `${name}`;
+  }
+
+  /* private */
+  val(value) {
+    if (value.isString) {
+      return JSON.stringify(value.value);
+    } else if (value.isExpr) {
+      return `(readonly ${value.value})`;
+    } else {
+      throw new Error(`Unknown value: ${value}`);
+    }
+  }
+}
+
+moduleFor('Components test: interactive lifecycle hooks (curly components)', class extends CurlyComponentsTest {
+
+  get isInteractive() {
+    return true;
+  }
+
+});
+
+moduleFor('Components test: non-interactive lifecycle hooks (curly components)', class extends CurlyComponentsTest {
+
+  get isInteractive() {
+    return false;
+  }
+
+});
+
+moduleFor('Components test: interactive lifecycle hooks (tagless curly components)', class extends CurlyComponentsTest {
+
+  get ComponentClass() {
+    return Component.extend({ tagName: '' });
   }
 
   get isInteractive() {
     return true;
   }
 
-  invocationFor(name, namedArgs = {}) {
-    let attrs = Object.keys(namedArgs).map(k => `${k}=${this.val(namedArgs[k])}`).join(' ');
-    return `{{${name} ${attrs}}}`;
-  }
-
-  attrFor(name) {
-    return `${name}`;
-  }
-
-  /* private */
-  val(value) {
-    if (value.isString) {
-      return JSON.stringify(value.value);
-    } else if (value.isExpr) {
-      return `(readonly ${value.value})`;
-    } else {
-      throw new Error(`Unknown value: ${value}`);
-    }
-  }
 });
 
-moduleFor('Components test: non-interactive lifecycle hooks (curly components)', class extends LifeCycleHooksTest {
+moduleFor('Components test: non-interactive lifecycle hooks (tagless curly components)', class extends CurlyComponentsTest {
+
   get ComponentClass() {
-    return Component;
+    return Component.extend({ tagName: '' });
   }
 
   get isInteractive() {
     return false;
   }
 
-  invocationFor(name, namedArgs = {}) {
-    let attrs = Object.keys(namedArgs).map(k => `${k}=${this.val(namedArgs[k])}`).join(' ');
-    return `{{${name} ${attrs}}}`;
-  }
-
-  attrFor(name) {
-    return `${name}`;
-  }
-
-  /* private */
-  val(value) {
-    if (value.isString) {
-      return JSON.stringify(value.value);
-    } else if (value.isExpr) {
-      return `(readonly ${value.value})`;
-    } else {
-      throw new Error(`Unknown value: ${value}`);
-    }
-  }
 });
 
 moduleFor('Run loop and lifecycle hooks', class extends RenderingTest {

--- a/packages/ember-glimmer/tests/integration/helpers/custom-helper-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/custom-helper-test.js
@@ -96,6 +96,16 @@ moduleFor('Helpers test: custom helpers', class extends RenderingTest {
     this.assertText('hello | hello world');
   }
 
+  ['@test throws if `this._super` is not called from `init`']() {
+    this.registerHelper('hello-world', {
+      init() {}
+    });
+
+    expectAssertion(() => {
+      this.render('{{hello-world}}');
+    }, /You must call `this._super\(...arguments\);` when overriding `init` on a framework object. Please update .* to call `this._super\(...arguments\);` from `init`./);
+  }
+
   ['@test class-based helper can recompute a new value']() {
     let destroyCount = 0;
     let computeCount = 0;

--- a/packages/ember-metal/lib/tags.js
+++ b/packages/ember-metal/lib/tags.js
@@ -1,22 +1,18 @@
+import { CONSTANT_TAG, DirtyableTag } from 'glimmer-reference';
 import { meta as metaFor } from './meta';
-import require, { has } from 'require';
-
-const hasGlimmer = has('glimmer-reference');
-
-let CONSTANT_TAG, CURRENT_TAG, DirtyableTag, makeTag, run;
+import require from 'require';
 
 let hasViews = () => false;
+
 export function setHasViews(fn) {
   hasViews = fn;
 }
 
-export let markObjectAsDirty;
+function makeTag() {
+  return new DirtyableTag();
+}
 
 export function tagFor(object, _meta) {
-  if (!hasGlimmer) {
-    throw new Error('Cannot call tagFor without Glimmer');
-  }
-
   if (typeof object === 'object' && object) {
     let meta = _meta || metaFor(object);
     return meta.writableTag(makeTag);
@@ -25,7 +21,19 @@ export function tagFor(object, _meta) {
   }
 }
 
+export function markObjectAsDirty(meta) {
+  let tag = meta && meta.readableTag();
+
+  if (tag) {
+    ensureRunloop();
+    tag.dirty();
+  }
+}
+
+let run;
+
 function K() {}
+
 function ensureRunloop() {
   if (!run) {
     run = require('ember-metal/run_loop').default;
@@ -34,20 +42,4 @@ function ensureRunloop() {
   if (hasViews() && !run.backburner.currentInstance) {
     run.schedule('actions', K);
   }
-}
-
-if (hasGlimmer) {
-  ({ DirtyableTag, CONSTANT_TAG, CURRENT_TAG } = require('glimmer-reference'));
-  makeTag = () => new DirtyableTag();
-
-  markObjectAsDirty = function(meta) {
-    let tag = meta && meta.readableTag();
-
-    if (tag) {
-      ensureRunloop();
-      tag.dirty();
-    }
-  };
-} else {
-  markObjectAsDirty = function() {};
 }

--- a/packages/ember-runtime/lib/index.js
+++ b/packages/ember-runtime/lib/index.js
@@ -3,7 +3,7 @@
 @submodule ember-runtime
 */
 
-export { default as Object } from './system/object';
+export { default as Object, FrameworkObject } from './system/object';
 export { default as String } from './system/string';
 export {
   default as RegistryProxyMixin,
@@ -31,10 +31,7 @@ export {
 } from './system/namespace';
 export { default as ArrayProxy } from './system/array_proxy';
 export { default as ObjectProxy } from './system/object_proxy';
-export {
-  default as CoreObject,
-  POST_INIT
-} from './system/core_object';
+export { default as CoreObject } from './system/core_object';
 export { default as NativeArray, A } from './system/native_array';
 export {
   default as ActionHandler,

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -13,9 +13,8 @@ import {
   assign,
   guidFor,
   generateGuid,
-  GUID_KEY_PROPERTY,
   makeArray,
-  symbol
+  GUID_KEY_PROPERTY
 } from 'ember-utils';
 import {
   assert,
@@ -41,7 +40,6 @@ import {
 import ActionHandler from '../mixins/action_handler';
 import { validatePropertyInjections } from '../inject';
 
-export let POST_INIT = symbol('POST_INIT');
 var schedule = run.schedule;
 var applyMixin = Mixin._apply;
 var finishPartial = Mixin.finishPartial;
@@ -166,8 +164,6 @@ function makeCtor() {
 
     this.init.apply(this, arguments);
 
-    this[POST_INIT]();
-
     m.proto = proto;
     finishChains(this);
     sendEvent(this, 'init');
@@ -242,8 +238,6 @@ CoreObject.PrototypeMixin = Mixin.create({
     @public
   */
   init() {},
-
-  [POST_INIT]: function() { },
 
   __defineNonEnumerable(property) {
     Object.defineProperty(this, property.name, property.descriptor);

--- a/packages/ember-runtime/lib/system/object.js
+++ b/packages/ember-runtime/lib/system/object.js
@@ -3,6 +3,8 @@
 @submodule ember-runtime
 */
 
+import { symbol } from 'ember-utils';
+import { assert, on, runInDebug } from 'ember-metal';
 import CoreObject from './core_object';
 import Observable from '../mixins/observable';
 
@@ -19,5 +21,26 @@ import Observable from '../mixins/observable';
 */
 const EmberObject = CoreObject.extend(Observable);
 EmberObject.toString = () => 'Ember.Object';
+
+export let FrameworkObject = EmberObject;
+
+runInDebug(() => {
+  let INIT_WAS_CALLED = symbol('INIT_WAS_CALLED');
+  let ASSERT_INIT_WAS_CALLED = symbol('ASSERT_INIT_WAS_CALLED');
+
+  FrameworkObject = EmberObject.extend({
+    init() {
+      this._super(...arguments);
+      this[INIT_WAS_CALLED] = true;
+    },
+
+    [ASSERT_INIT_WAS_CALLED]: on('init', function() {
+      assert(
+        `You must call \`this._super(...arguments);\` when overriding \`init\` on a framework object. Please update ${this} to call \`this._super(...arguments);\` from \`init\`.`,
+        this[INIT_WAS_CALLED]
+      );
+    })
+  });
+});
 
 export default EmberObject;

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -421,17 +421,15 @@ export default Mixin.create({
       this.elementId = guidFor(this);
     }
 
-    if (typeof(this.didInitAttrs) === 'function') {
-      deprecate(
-        `[DEPRECATED] didInitAttrs called in ${this.toString()}.`,
-        false,
-        {
-          id: 'ember-views.did-init-attrs',
-          until: '3.0.0',
-          url: 'http://emberjs.com/deprecations/v2.x#toc_ember-component-didinitattrs'
-        }
-      );
-    }
+    deprecate(
+      `[DEPRECATED] didInitAttrs called in ${this.toString()}.`,
+      typeof(this.didInitAttrs) !== 'function',
+      {
+        id: 'ember-views.did-init-attrs',
+        until: '3.0.0',
+        url: 'http://emberjs.com/deprecations/v2.x#toc_ember-component-didinitattrs'
+      }
+    );
 
     assert(
       'Using a custom `.render` function is no longer supported.',

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -460,8 +460,6 @@ export default Mixin.create({
       `You must call \`this._super(...arguments);\` when implementing \`init\` in a component. Please update ${this} to call \`this._super\` from \`init\`.`,
       this[INIT_WAS_CALLED]
     );
-
-    this.renderer.componentInitAttrs(this, this.attrs || {});
   },
 
   __defineNonEnumerable(property) {

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -1,10 +1,7 @@
-import { guidFor, symbol } from 'ember-utils';
+import { guidFor } from 'ember-utils';
 import { assert, deprecate, descriptor, Mixin } from 'ember-metal';
-import { POST_INIT } from 'ember-runtime';
 import { environment } from 'ember-environment';
 import { matches } from '../system/utils';
-
-const INIT_WAS_CALLED = symbol('INIT_WAS_CALLED');
 
 import jQuery from '../system/jquery';
 
@@ -424,8 +421,6 @@ export default Mixin.create({
       this.elementId = guidFor(this);
     }
 
-    this[INIT_WAS_CALLED] = true;
-
     if (typeof(this.didInitAttrs) === 'function') {
       deprecate(
         `[DEPRECATED] didInitAttrs called in ${this.toString()}.`,
@@ -441,24 +436,6 @@ export default Mixin.create({
     assert(
       'Using a custom `.render` function is no longer supported.',
       !this.render
-    );
-  },
-
-  /*
-   This is a special hook implemented in CoreObject, that allows Views/Components
-   to have a way to ensure that `init` fires before `didInitAttrs` / `didReceiveAttrs`
-   (so that `this._super` in init does not trigger `didReceiveAttrs` before the classes
-   own `init` is finished).
-
-   @method __postInitInitialization
-   @private
-   */
-  [POST_INIT]: function() {
-    this._super();
-
-    assert(
-      `You must call \`this._super(...arguments);\` when implementing \`init\` in a component. Please update ${this} to call \`this._super\` from \`init\`.`,
-      this[INIT_WAS_CALLED]
     );
   },
 

--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -1,7 +1,7 @@
 import {
-  Object as EmberObject,
-  Evented,
   ActionHandler,
+  Evented,
+  FrameworkObject,
   deprecateUnderscoreActions,
   typeOf
 } from 'ember-runtime';
@@ -24,7 +24,7 @@ import { cloneStates, states } from './states';
   @uses Ember.ActionHandler
   @private
 */
-const CoreView = EmberObject.extend(Evented, ActionHandler, {
+const CoreView = FrameworkObject.extend(Evented, ActionHandler, {
   isView: true,
 
   _states: cloneStates(states),

--- a/packages/ember-views/lib/views/states/default.js
+++ b/packages/ember-views/lib/views/states/default.js
@@ -21,9 +21,7 @@ export default {
     return true; // continue event propagation
   },
 
-  destroy() { },
+  rerender() { },
 
-  rerender(view) {
-    view.renderer.ensureViewNotRendering(view);
-  }
+  destroy() { }
 };

--- a/packages/ember-views/lib/views/states/has_element.js
+++ b/packages/ember-views/lib/views/states/has_element.js
@@ -11,10 +11,7 @@ assign(hasElement, {
     return sel ? jQuery(sel, elem) : jQuery(elem);
   },
 
-  // once the view has been inserted into the DOM, rerendering is
-  // deferred to allow bindings to synchronize.
   rerender(view) {
-    view.renderer.ensureViewNotRendering(view);
     view.renderer.rerender(view);
   },
 


### PR DESCRIPTION
- Transition into `hasElement` state for tagless components
- Fire `willInsertElement` on tagless components
- Fire `willInsertElement` before firing `willRender` (thus ensuring `willRender` gets the element as well)
- Add lifecycle tests for tagless components
- Refactor the lifecycle tests to remove some duplications

Fixes #14398
