### PR TITLE
Local lookup component closure test

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/local-lookup-test.js
+++ b/packages/ember-glimmer/tests/integration/components/local-lookup-test.js
@@ -99,6 +99,20 @@ moduleFor('Components test: local lookup', class extends RenderingTest {
     this.assertText('yall finished or yall done?');
   }
 
+   ['@test it can local lookup a dynamic component from a passed named argument']() {
+    this.registerComponent('parent-foo', { template: `yall finished {{global-biz baz=(component 'local-bar')}}` });
+    this.registerComponent('global-biz', { template: 'or {{component baz}}' });
+    this.registerComponent('parent-foo/local-bar', { template: 'yall done?' });
+
+    this.render('{{parent-foo}}');
+
+    this.assertText('yall finished or yall done?');
+
+    this.runTask(() => this.rerender());
+
+    this.assertText('yall finished or yall done?');
+  }
+
   ['@test it can lookup a local helper']() {
     this.registerHelper('x-outer/x-helper', () => {
       return 'Who dis?';


### PR DESCRIPTION
Adds a local lookup test case for a component closure passed as a named argument to a component.

e.g. Given a local component:

`my-route/-components/local-component`

Usage in my-route.hbs:

``` hbs
{{global-component
  foo=(component 'local-component')
}}
```
