### PR TITLE
[BUGFIX beta] Return stable object from hash helper

### DIFF
--- a/packages/ember-glimmer/lib/helpers/hash.js
+++ b/packages/ember-glimmer/lib/helpers/hash.js
@@ -2,6 +2,54 @@
 @module ember
 @submodule ember-glimmer
 */
+import { set } from 'ember-metal';
+import { PrimitiveReference } from '../utils/references';
+
+class HashReference extends PrimitiveReference {
+
+  constructor(args) {
+    super();
+
+    this.tag = args.tag;
+    this.args = args;
+
+    this.hash = null;
+  }
+
+  value() {
+    let { args, hash } = this;
+    let { keys, values } = args;
+
+    if (!hash) {
+      this.hash = hash = args.value();
+
+      let lastRevisions = this._lastRevisions = new Array(keys.length);
+      for (let i = 0; i < keys.length; i++) {
+        let ref = values[i];
+        lastRevisions[i] = ref.tag.value();
+      }
+    } else {
+      let { _lastRevisions:lastRevisions } = this;
+
+      for (let i = 0; i < keys.length; i++) {
+        let ref = values[i];
+        let rev = lastRevisions[i];
+        if (!ref.tag.validate(rev)) {
+          let key = keys[i];
+          lastRevisions[i] = ref.tag.value();
+          set(hash, key, ref.value());
+        }
+      }
+    }
+
+    return hash;
+  }
+
+  get(path) {
+    let { args } = this;
+    return args.get(path);
+  }
+}
 
 /**
    Use the `{{hash}}` helper to create a hash to pass as an option to your
@@ -31,5 +79,5 @@
  */
 
 export default function(vm, args) {
-  return args.named;
+  return new HashReference(args.named);
 }


### PR DESCRIPTION
The hash helper needs to return a stable object.

This is done by wrapping the previous EvaluatedNamedArgs in a new HashReference class, updating the values as they are invalidated.

This also fixes #14362.
