### PR TITLE
[CLEANUP] Remove ember-routing-route-configured-query-params feature flag

### DIFF
--- a/features.json
+++ b/features.json
@@ -1,7 +1,6 @@
 {
   "features": {
     "features-stripped-test": null,
-    "ember-routing-route-configured-query-params": null,
     "ember-libraries-isregistered": null,
     "ember-runtime-computed-uniq-by": true,
     "ember-improved-instrumentation": null,

--- a/packages/ember-glimmer/tests/integration/components/link-to-test.js
+++ b/packages/ember-glimmer/tests/integration/components/link-to-test.js
@@ -1,7 +1,6 @@
 import { moduleFor, ApplicationTest } from '../../utils/test-case';
 import { Controller } from 'ember-runtime';
-import { Route } from 'ember-routing';
-import { set, isFeatureEnabled } from 'ember-metal';
+import { set } from 'ember-metal';
 import { LinkComponent } from '../../utils/helpers';
 import { classes as classMatcher } from '../../utils/test-helpers';
 
@@ -146,24 +145,11 @@ moduleFor('Link-to component with query-params', class extends ApplicationTest {
   constructor() {
     super(...arguments);
 
-    if (isFeatureEnabled('ember-routing-route-configured-query-params')) {
-      this.registerRoute('index', Route.extend({
-        queryParams: {
-          foo: {
-            defaultValue: '123'
-          },
-          bar: {
-            defaultValue: 'yes'
-          }
-        }
-      }));
-    } else {
-      this.registerController('index', Controller.extend({
-        queryParams: ['foo'],
-        foo: '123',
-        bar: 'yes'
-      }));
-    }
+    this.registerController('index', Controller.extend({
+      queryParams: ['foo'],
+      foo: '123',
+      bar: 'yes'
+    }));
   }
 
   ['@test populates href with fully supplied query param values'](assert) {

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1300,20 +1300,10 @@ QUnit.test('{{link-to}} active property respects changing parent route context',
 
 
 QUnit.test('{{link-to}} populates href with default query param values even without query-params object', function() {
-  if (isFeatureEnabled('ember-routing-route-configured-query-params')) {
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: '123'
-        }
-      }
-    });
-  } else {
-    App.IndexController = Controller.extend({
-      queryParams: ['foo'],
-      foo: '123'
-    });
-  }
+  App.IndexController = Controller.extend({
+    queryParams: ['foo'],
+    foo: '123'
+  });
 
   setTemplate('index', compile("{{#link-to 'index' id='the-link'}}Index{{/link-to}}"));
   bootApplication();
@@ -1321,20 +1311,10 @@ QUnit.test('{{link-to}} populates href with default query param values even with
 });
 
 QUnit.test('{{link-to}} populates href with default query param values with empty query-params object', function() {
-  if (isFeatureEnabled('ember-routing-route-configured-query-params')) {
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: '123'
-        }
-      }
-    });
-  } else {
-    App.IndexController = Controller.extend({
-      queryParams: ['foo'],
-      foo: '123'
-    });
-  }
+  App.IndexController = Controller.extend({
+    queryParams: ['foo'],
+    foo: '123'
+  });
 
   setTemplate('index', compile("{{#link-to 'index' (query-params) id='the-link'}}Index{{/link-to}}"));
   bootApplication();
@@ -1346,24 +1326,11 @@ QUnit.test('{{link-to}} with only query-params and a block updates when route ch
     this.route('about');
   });
 
-  if (isFeatureEnabled('ember-routing-route-configured-query-params')) {
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: '123'
-        },
-        bar: {
-          defaultValue: 'yes'
-        }
-      }
-    });
-  } else {
-    App.ApplicationController = Controller.extend({
-      queryParams: ['foo', 'bar'],
-      foo: '123',
-      bar: 'yes'
-    });
-  }
+  App.ApplicationController = Controller.extend({
+    queryParams: ['foo', 'bar'],
+    foo: '123',
+    bar: 'yes'
+  });
 
   setTemplate('application', compile(`{{#link-to (query-params foo='456' bar='NAW') id='the-link'}}Index{{/link-to}}`));
   bootApplication();
@@ -1379,24 +1346,11 @@ QUnit.test('Block-less {{link-to}} with only query-params updates when route cha
     this.route('about');
   });
 
-  if (isFeatureEnabled('ember-routing-route-configured-query-params')) {
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: '123'
-        },
-        bar: {
-          defaultValue: 'yes'
-        }
-      }
-    });
-  } else {
-    App.ApplicationController = Controller.extend({
-      queryParams: ['foo', 'bar'],
-      foo: '123',
-      bar: 'yes'
-    });
-  }
+  App.ApplicationController = Controller.extend({
+    queryParams: ['foo', 'bar'],
+    foo: '123',
+    bar: 'yes'
+  });
 
   setTemplate('application', compile(`{{link-to "Index" (query-params foo='456' bar='NAW') id='the-link'}}`));
   bootApplication();

--- a/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
+++ b/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
@@ -1,4 +1,4 @@
-import { set, run, isFeatureEnabled } from 'ember-metal';
+import { set, run } from 'ember-metal';
 import { Controller, RSVP } from 'ember-runtime';
 import { Route, NoneLocation } from 'ember-routing';
 import { compile } from 'ember-template-compiler';
@@ -62,874 +62,445 @@ function sharedTeardown() {
   setTemplates({});
 }
 
-if (isFeatureEnabled('ember-routing-route-configured-query-params')) {
-  QUnit.module('The {{link-to}} helper: invoking with query params when defined on a route', {
-    setup() {
-      run(() => {
-        sharedSetup();
-        App.IndexController = Controller.extend({
-          boundThing: 'OMG'
-        });
-
-        App.IndexRoute = Route.extend({
-          queryParams: {
-            foo: {
-              defaultValue: '123'
-            },
-            bar: {
-              defaultValue: 'abc'
-            },
-            abool: {
-              defaultValue: true
-            }
-          }
-        });
-
-        App.AboutRoute = Route.extend({
-          queryParams: {
-            baz: {
-              defaultValue: 'alex'
-            },
-            bat: {
-              defaultValue: 'borf'
-            }
-          }
-        });
-
-        registry.unregister('router:main');
-        registry.register('router:main', Router);
-      });
-    },
-
-    teardown: sharedTeardown
-  });
-
-  // jscs:disable
-
-  QUnit.test("doesn't update controller QP properties on current route when invoked", function() {
-    setTemplate('index', compile("{{#link-to 'index' id='the-link'}}Index{{/link-to}}"));
-    bootApplication();
-
-    run(jQuery('#the-link'), 'click');
-    let indexController = container.lookup('controller:index');
-    deepEqual(indexController.getProperties('foo', 'bar'), { foo: '123', bar: 'abc' }, 'controller QP properties not');
-  });
-
-  QUnit.test("doesn't update controller QP properties on current route when invoked (empty query-params obj)", function() {
-    setTemplate('index', compile("{{#link-to 'index' (query-params) id='the-link'}}Index{{/link-to}}"));
-    bootApplication();
-
-    run(jQuery('#the-link'), 'click');
-    let indexController = container.lookup('controller:index');
-    deepEqual(indexController.getProperties('foo', 'bar'), { foo: '123', bar: 'abc' }, 'controller QP properties not');
-  });
-
-  QUnit.test('link-to with no params throws', function() {
-    setTemplate('index', compile("{{#link-to id='the-link'}}Index{{/link-to}}"));
-    expectAssertion(function() {
-      bootApplication();
-    }, /one or more/);
-  });
-
-  QUnit.test("doesn't update controller QP properties on current route when invoked (empty query-params obj, inferred route)", function() {
-    setTemplate('index', compile("{{#link-to (query-params) id='the-link'}}Index{{/link-to}}"));
-    bootApplication();
-
-    run(jQuery('#the-link'), 'click');
-    let indexController = container.lookup('controller:index');
-    deepEqual(indexController.getProperties('foo', 'bar'), { foo: '123', bar: 'abc' }, 'controller QP properties not');
-  });
-
-  QUnit.test('updates controller QP properties on current route when invoked', function() {
-    setTemplate('index', compile("{{#link-to 'index' (query-params foo='456') id='the-link'}}Index{{/link-to}}"));
-    bootApplication();
-
-    run(jQuery('#the-link'), 'click');
-    let indexController = container.lookup('controller:index');
-    deepEqual(indexController.getProperties('foo', 'bar'), { foo: '456', bar: 'abc' }, 'controller QP properties updated');
-  });
-
-  QUnit.test('updates controller QP properties on current route when invoked (inferred route)', function() {
-    setTemplate('index', compile("{{#link-to (query-params foo='456') id='the-link'}}Index{{/link-to}}"));
-    bootApplication();
-
-    run(jQuery('#the-link'), 'click');
-    let indexController = container.lookup('controller:index');
-    deepEqual(indexController.getProperties('foo', 'bar'), { foo: '456', bar: 'abc' }, 'controller QP properties updated');
-  });
-
-  QUnit.test('updates controller QP properties on other route after transitioning to that route', function() {
-    Router.map(function() {
-      this.route('about');
-    });
-
-    setTemplate('index', compile("{{#link-to 'about' (query-params baz='lol') id='the-link'}}About{{/link-to}}"));
-    bootApplication();
-
-    equal(jQuery('#the-link').attr('href'), '/about?baz=lol');
-    run(jQuery('#the-link'), 'click');
-    let aboutController = container.lookup('controller:about');
-    deepEqual(aboutController.getProperties('baz', 'bat'), { baz: 'lol', bat: 'borf' }, 'about controller QP properties updated');
-
-    equal(container.lookup('controller:application').get('currentPath'), 'about');
-  });
-
-  QUnit.test('supplied QP properties can be bound', function() {
-    setTemplate('index', compile("{{#link-to (query-params foo=boundThing) id='the-link'}}Index{{/link-to}}"));
-    bootApplication();
-
-    let indexController = container.lookup('controller:index');
-
-
-    equal(jQuery('#the-link').attr('href'), '/?foo=OMG');
-    run(indexController, 'set', 'boundThing', 'ASL');
-    equal(jQuery('#the-link').attr('href'), '/?foo=ASL');
-  });
-
-  QUnit.test('supplied QP properties can be bound (booleans)', function() {
-    let indexController = container.lookup('controller:index');
-    setTemplate('index', compile("{{#link-to (query-params abool=boundThing) id='the-link'}}Index{{/link-to}}"));
-
-    bootApplication();
-
-    equal(jQuery('#the-link').attr('href'), '/?abool=OMG');
-    run(indexController, 'set', 'boundThing', false);
-    equal(jQuery('#the-link').attr('href'), '/?abool=false');
-
-    run(jQuery('#the-link'), 'click');
-
-    deepEqual(indexController.getProperties('foo', 'bar', 'abool'), { foo: '123', bar: 'abc', abool: false });
-  });
-
-  QUnit.test('href updates when unsupplied controller QP props change', function() {
-    setTemplate('index', compile("{{#link-to (query-params foo='lol') id='the-link'}}Index{{/link-to}}"));
-
-    bootApplication();
-
-    let indexController = container.lookup('controller:index');
-
-    equal(jQuery('#the-link').attr('href'), '/?foo=lol');
-    run(indexController, 'set', 'bar', 'BORF');
-    equal(jQuery('#the-link').attr('href'), '/?bar=BORF&foo=lol');
-    run(indexController, 'set', 'foo', 'YEAH');
-    equal(jQuery('#the-link').attr('href'), '/?bar=BORF&foo=lol');
-  });
-
-  QUnit.test('The {{link-to}} with only query params always transitions to the current route with the query params applied', function() {
-    // Test harness for bug #12033
-
-    setTemplate('cars', compile(
-      "{{#link-to 'cars.create' id='create-link'}}Create new car{{/link-to}} " +
-      "{{#link-to (query-params page='2') id='page2-link'}}Page 2{{/link-to}}" +
-      '{{outlet}}'
-    ));
-
-    setTemplate('cars/create', compile(
-      "{{#link-to 'cars' id='close-link'}}Close create form{{/link-to}}"
-    ));
-
-    Router.map(function() {
-      this.route('cars', function() {
-        this.route('create');
-      });
-    });
-
-    App.CarsRoute = Route.extend({
-      queryParams: {
-        page: { defaultValue: 1 }
-      }
-    });
-
-    bootApplication();
-
-    run(() => router.handleURL('/cars/create'));
-
+QUnit.module('The {{link-to}} helper: invoking with query params', {
+  setup() {
     run(() => {
-      equal(router.currentRouteName, 'cars.create');
-      jQuery('#close-link').click();
-    });
+      sharedSetup();
 
-    run(() => {
-      equal(router.currentRouteName, 'cars.index');
-      equal(router.get('url'), '/cars');
-      equal(container.lookup('controller:cars').get('page'), 1, 'The page query-param is 1');
-      jQuery('#page2-link').click();
-    });
-
-    run(() => {
-      equal(router.currentRouteName, 'cars.index', 'The active route is still cars');
-      equal(router.get('url'), '/cars?page=2', 'The url has been updated');
-      equal(container.lookup('controller:cars').get('page'), 2, 'The query params have been updated');
-    });
-  });
-
-  QUnit.test('The {{link-to}} applies activeClass when query params are not changed', function() {
-    setTemplate('index', compile(
-      "{{#link-to (query-params foo='cat') id='cat-link'}}Index{{/link-to}} " +
-      "{{#link-to (query-params foo='dog') id='dog-link'}}Index{{/link-to}} " +
-      "{{#link-to 'index' id='change-nothing'}}Index{{/link-to}}"
-    ));
-
-    setTemplate('search', compile(
-      "{{#link-to (query-params search='same') id='same-search'}}Index{{/link-to}} " +
-      "{{#link-to (query-params search='change') id='change-search'}}Index{{/link-to}} " +
-      "{{#link-to (query-params search='same' archive=true) id='same-search-add-archive'}}Index{{/link-to}} " +
-      "{{#link-to (query-params archive=true) id='only-add-archive'}}Index{{/link-to}} " +
-      "{{#link-to (query-params search='same' archive=true) id='both-same'}}Index{{/link-to}} " +
-      "{{#link-to (query-params search='different' archive=true) id='change-one'}}Index{{/link-to}} " +
-      "{{#link-to (query-params search='different' archive=false) id='remove-one'}}Index{{/link-to}} " +
-      '{{outlet}}'
-    ));
-
-    setTemplate('search/results', compile(
-      "{{#link-to (query-params sort='title') id='same-sort-child-only'}}Index{{/link-to}} " +
-      "{{#link-to (query-params search='same') id='same-search-parent-only'}}Index{{/link-to}} " +
-      "{{#link-to (query-params search='change') id='change-search-parent-only'}}Index{{/link-to}} " +
-      "{{#link-to (query-params search='same' sort='title') id='same-search-same-sort-child-and-parent'}}Index{{/link-to}} " +
-      "{{#link-to (query-params search='same' sort='author') id='same-search-different-sort-child-and-parent'}}Index{{/link-to}} " +
-      "{{#link-to (query-params search='change' sort='title') id='change-search-same-sort-child-and-parent'}}Index{{/link-to}} " +
-      "{{#link-to (query-params foo='dog') id='dog-link'}}Index{{/link-to}} "
-    ));
-
-    Router.map(function() {
-      this.route('search', function() {
-        this.route('results');
+      App.IndexController = Controller.extend({
+        queryParams: ['foo', 'bar', 'abool'],
+        foo: '123',
+        bar: 'abc',
+        boundThing: 'OMG',
+        abool: true
       });
-    });
 
-    App.SearchRoute = Route.extend({
-      queryParams: {
-        search: {
-          defaultValue: ''
-        },
-        archive: {
-          defaultValue: false
-        }
-      }
-    });
-
-    App.SearchResultsRoute = Route.extend({
-      queryParams: {
-        sort: {
-          defaultValue: 'title'
-        },
-        showDetails: {
-          defaultValue: true
-        }
-      }
-    });
-
-    bootApplication();
-
-    //Basic tests
-    shouldNotBeActive('#cat-link');
-    shouldNotBeActive('#dog-link');
-    run(router, 'handleURL', '/?foo=cat');
-    shouldBeActive('#cat-link');
-    shouldNotBeActive('#dog-link');
-    run(router, 'handleURL', '/?foo=dog');
-    shouldBeActive('#dog-link');
-    shouldNotBeActive('#cat-link');
-    shouldBeActive('#change-nothing');
-
-    //Multiple params
-    run(() => router.handleURL('/search?search=same'));
-
-    shouldBeActive('#same-search');
-    shouldNotBeActive('#change-search');
-    shouldNotBeActive('#same-search-add-archive');
-    shouldNotBeActive('#only-add-archive');
-    shouldNotBeActive('#remove-one');
-
-    run(() => router.handleURL('/search?search=same&archive=true'));
-
-    shouldBeActive('#both-same');
-    shouldNotBeActive('#change-one');
-
-    //Nested Controllers
-    run(() => {
-      // Note: this is kind of a strange case; sort's default value is 'title',
-      // so this URL shouldn't have been generated in the first place, but
-      // we should also be able to gracefully handle these cases.
-      router.handleURL('/search/results?search=same&sort=title&showDetails=true');
-    });
-    //shouldBeActive('#same-sort-child-only');
-    shouldBeActive('#same-search-parent-only');
-    shouldNotBeActive('#change-search-parent-only');
-    shouldBeActive('#same-search-same-sort-child-and-parent');
-    shouldNotBeActive('#same-search-different-sort-child-and-parent');
-    shouldNotBeActive('#change-search-same-sort-child-and-parent');
-  });
-
-  QUnit.test('The {{link-to}} applies active class when query-param is number', function() {
-    setTemplate('index', compile(
-      "{{#link-to (query-params page=pageNumber) id='page-link'}}Index{{/link-to}} "));
-
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        page: {
-          defaultValue: 1
-        }
-      }
-    });
-
-    App.IndexController = Controller.extend({
-      pageNumber: 5
-    });
-
-    bootApplication();
-
-    shouldNotBeActive('#page-link');
-    run(router, 'handleURL', '/?page=5');
-    shouldBeActive('#page-link');
-  });
-
-  QUnit.test('The {{link-to}} applies active class when query-param is array', function() {
-    setTemplate('index', compile(
-      "{{#link-to (query-params pages=pagesArray) id='array-link'}}Index{{/link-to}} " +
-      "{{#link-to (query-params pages=biggerArray) id='bigger-link'}}Index{{/link-to}} " +
-      "{{#link-to (query-params pages=emptyArray) id='empty-link'}}Index{{/link-to}} "
-    ));
-
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        pages: {
-          defaultValue: []
-        }
-      }
-    });
-
-    App.IndexController = Controller.extend({
-      pagesArray: [1, 2],
-      biggerArray: [1, 2, 3],
-      emptyArray: []
-    });
-
-
-    bootApplication();
-
-    shouldNotBeActive('#array-link');
-    run(router, 'handleURL', '/?pages=%5B1%2C2%5D');
-    shouldBeActive('#array-link');
-    shouldNotBeActive('#bigger-link');
-    shouldNotBeActive('#empty-link');
-    run(router, 'handleURL', '/?pages=%5B2%2C1%5D');
-    shouldNotBeActive('#array-link');
-    shouldNotBeActive('#bigger-link');
-    shouldNotBeActive('#empty-link');
-    run(router, 'handleURL', '/?pages=%5B1%2C2%2C3%5D');
-    shouldBeActive('#bigger-link');
-    shouldNotBeActive('#array-link');
-    shouldNotBeActive('#empty-link');
-  });
-
-  QUnit.test('The {{link-to}} helper applies active class to parent route', function() {
-    App.Router.map(function() {
-      this.route('parent', function() {
-        this.route('child');
+      App.AboutController = Controller.extend({
+        queryParams: ['baz', 'bat'],
+        baz: 'alex',
+        bat: 'borf'
       });
+
+      registry.unregister('router:main');
+      registry.register('router:main', Router);
     });
+  },
 
-    setTemplate('application', compile(
-      "{{#link-to 'parent' id='parent-link'}}Parent{{/link-to}} " +
-      "{{#link-to 'parent.child' id='parent-child-link'}}Child{{/link-to}} " +
-      "{{#link-to 'parent' (query-params foo=cat) id='parent-link-qp'}}Parent{{/link-to}} " +
-      '{{outlet}}'
-    ));
+  teardown: sharedTeardown
+});
 
-    App.ParentChildRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: 'bar'
-        }
-      }
-    });
+QUnit.test('doesn\'t update controller QP properties on current route when invoked', function() {
+  setTemplate('index', compile(`{{#link-to 'index' id='the-link'}}Index{{/link-to}}`));
+  bootApplication();
 
-    bootApplication();
-    shouldNotBeActive('#parent-link');
-    shouldNotBeActive('#parent-child-link');
-    shouldNotBeActive('#parent-link-qp');
-    run(router, 'handleURL', '/parent/child?foo=dog');
-    shouldBeActive('#parent-link');
-    shouldNotBeActive('#parent-link-qp');
+  run(jQuery('#the-link'), 'click');
+  let indexController = container.lookup('controller:index');
+  deepEqual(indexController.getProperties('foo', 'bar'), { foo: '123', bar: 'abc' }, 'controller QP properties not');
+});
+
+QUnit.test('doesn\'t update controller QP properties on current route when invoked (empty query-params obj)', function() {
+  setTemplate('index', compile(`{{#link-to 'index' (query-params) id='the-link'}}Index{{/link-to}}`));
+  bootApplication();
+
+  run(jQuery('#the-link'), 'click');
+  let indexController = container.lookup('controller:index');
+  deepEqual(indexController.getProperties('foo', 'bar'), { foo: '123', bar: 'abc' }, 'controller QP properties not');
+});
+
+QUnit.test('link-to with no params throws', function() {
+  setTemplate('index', compile(`{{#link-to id='the-link'}}Index{{/link-to}}`));
+  expectAssertion(() => bootApplication(), /one or more/);
+});
+
+QUnit.test('doesn\'t update controller QP properties on current route when invoked (empty query-params obj, inferred route)', function() {
+  setTemplate('index', compile(`{{#link-to (query-params) id='the-link'}}Index{{/link-to}}`));
+  bootApplication();
+
+  run(jQuery('#the-link'), 'click');
+  let indexController = container.lookup('controller:index');
+  deepEqual(indexController.getProperties('foo', 'bar'), { foo: '123', bar: 'abc' }, 'controller QP properties not');
+});
+
+QUnit.test('updates controller QP properties on current route when invoked', function() {
+  setTemplate('index', compile(`{{#link-to 'index' (query-params foo='456') id='the-link'}}Index{{/link-to}}`));
+  bootApplication();
+
+  run(jQuery('#the-link'), 'click');
+  let indexController = container.lookup('controller:index');
+  deepEqual(indexController.getProperties('foo', 'bar'), { foo: '456', bar: 'abc' }, 'controller QP properties updated');
+});
+
+QUnit.test('updates controller QP properties on current route when invoked (inferred route)', function() {
+  setTemplate('index', compile(`{{#link-to (query-params foo='456') id='the-link'}}Index{{/link-to}}`));
+  bootApplication();
+
+  run(jQuery('#the-link'), 'click');
+  let indexController = container.lookup('controller:index');
+  deepEqual(indexController.getProperties('foo', 'bar'), { foo: '456', bar: 'abc' }, 'controller QP properties updated');
+});
+
+QUnit.test('updates controller QP properties on other route after transitioning to that route', function() {
+  Router.map(function() {
+    this.route('about');
   });
 
-  QUnit.test('The {{link-to}} helper disregards query-params in activeness computation when current-when specified', function() {
-    App.Router.map(function() {
-      this.route('parent');
-    });
+  setTemplate('index', compile(`{{#link-to 'about' (query-params baz='lol') id='the-link'}}About{{/link-to}}`));
+  bootApplication();
 
-    setTemplate('application', compile(
-      "{{#link-to 'parent' (query-params page=1) current-when='parent' id='app-link'}}Parent{{/link-to}} {{outlet}}"));
-    setTemplate('parent', compile(
-      "{{#link-to 'parent' (query-params page=1) current-when='parent' id='parent-link'}}Parent{{/link-to}} {{outlet}}"));
+  equal(jQuery('#the-link').attr('href'), '/about?baz=lol');
+  run(jQuery('#the-link'), 'click');
+  let aboutController = container.lookup('controller:about');
+  deepEqual(aboutController.getProperties('baz', 'bat'), { baz: 'lol', bat: 'borf' }, 'about controller QP properties updated');
 
-    App.ParentRoute = Route.extend({
-      queryParams: {
-        page: {
-          defaultValue: 1
-        }
-      }
-    });
+  equal(container.lookup('controller:application').get('currentPath'), 'about');
+});
 
-    bootApplication();
-    equal(jQuery('#app-link').attr('href'), '/parent');
-    shouldNotBeActive('#app-link');
+QUnit.test('supplied QP properties can be bound', function() {
+  let indexController = container.lookup('controller:index');
+  setTemplate('index', compile(`{{#link-to (query-params foo=boundThing) id='the-link'}}Index{{/link-to}}`));
 
-    run(router, 'handleURL', '/parent?page=2');
-    equal(jQuery('#app-link').attr('href'), '/parent');
-    shouldBeActive('#app-link');
-    equal(jQuery('#parent-link').attr('href'), '/parent');
-    shouldBeActive('#parent-link');
+  bootApplication();
 
-    let parentController = container.lookup('controller:parent');
-    equal(parentController.get('page'), 2);
-    run(parentController, 'set', 'page', 3);
-    equal(router.get('location.path'), '/parent?page=3');
-    shouldBeActive('#app-link');
-    shouldBeActive('#parent-link');
+  equal(jQuery('#the-link').attr('href'), '/?foo=OMG');
+  run(indexController, 'set', 'boundThing', 'ASL');
+  equal(jQuery('#the-link').attr('href'), '/?foo=ASL');
+});
 
-    jQuery('#app-link').click();
-    equal(router.get('location.path'), '/parent');
-  });
-} else {
-  QUnit.module('The {{link-to}} helper: invoking with query params', {
-    setup() {
-      run(() => {
-        sharedSetup();
+QUnit.test('supplied QP properties can be bound (booleans)', function() {
+  let indexController = container.lookup('controller:index');
+  setTemplate('index', compile(`{{#link-to (query-params abool=boundThing) id='the-link'}}Index{{/link-to}}`));
 
-        App.IndexController = Controller.extend({
-          queryParams: ['foo', 'bar', 'abool'],
-          foo: '123',
-          bar: 'abc',
-          boundThing: 'OMG',
-          abool: true
-        });
+  bootApplication();
 
-        App.AboutController = Controller.extend({
-          queryParams: ['baz', 'bat'],
-          baz: 'alex',
-          bat: 'borf'
-        });
+  equal(jQuery('#the-link').attr('href'), '/?abool=OMG');
+  run(indexController, 'set', 'boundThing', false);
+  equal(jQuery('#the-link').attr('href'), '/?abool=false');
 
-        registry.unregister('router:main');
-        registry.register('router:main', Router);
-      });
-    },
+  run(jQuery('#the-link'), 'click');
 
-    teardown: sharedTeardown
-  });
+  deepEqual(indexController.getProperties('foo', 'bar', 'abool'), { foo: '123', bar: 'abc', abool: false });
+});
 
-  QUnit.test("doesn't update controller QP properties on current route when invoked", function() {
-    setTemplate('index', compile("{{#link-to 'index' id='the-link'}}Index{{/link-to}}"));
-    bootApplication();
+QUnit.test('href updates when unsupplied controller QP props change', function() {
+  setTemplate('index', compile(`{{#link-to (query-params foo='lol') id='the-link'}}Index{{/link-to}}`));
 
-    run(jQuery('#the-link'), 'click');
-    let indexController = container.lookup('controller:index');
-    deepEqual(indexController.getProperties('foo', 'bar'), { foo: '123', bar: 'abc' }, 'controller QP properties not');
-  });
+  bootApplication();
+  let indexController = container.lookup('controller:index');
 
-  QUnit.test("doesn't update controller QP properties on current route when invoked (empty query-params obj)", function() {
-    setTemplate('index', compile("{{#link-to 'index' (query-params) id='the-link'}}Index{{/link-to}}"));
-    bootApplication();
+  equal(jQuery('#the-link').attr('href'), '/?foo=lol');
+  run(indexController, 'set', 'bar', 'BORF');
+  equal(jQuery('#the-link').attr('href'), '/?bar=BORF&foo=lol');
+  run(indexController, 'set', 'foo', 'YEAH');
+  equal(jQuery('#the-link').attr('href'), '/?bar=BORF&foo=lol');
+});
 
-    run(jQuery('#the-link'), 'click');
-    let indexController = container.lookup('controller:index');
-    deepEqual(indexController.getProperties('foo', 'bar'), { foo: '123', bar: 'abc' }, 'controller QP properties not');
-  });
+QUnit.test('The {{link-to}} with only query params always transitions to the current route with the query params applied', function() {
+  // Test harness for bug #12033
 
-  QUnit.test('link-to with no params throws', function() {
-    setTemplate('index', compile("{{#link-to id='the-link'}}Index{{/link-to}}"));
-    expectAssertion(() => bootApplication(), /one or more/);
-  });
+  setTemplate('cars', compile(`
+    {{#link-to 'cars.create' id='create-link'}}Create new car{{/link-to}}
+    {{#link-to (query-params page='2') id='page2-link'}}Page 2{{/link-to}}
+    {{outlet}}
+  `));
 
-  QUnit.test("doesn't update controller QP properties on current route when invoked (empty query-params obj, inferred route)", function() {
-    setTemplate('index', compile("{{#link-to (query-params) id='the-link'}}Index{{/link-to}}"));
-    bootApplication();
+  setTemplate('cars/create', compile(
+    `{{#link-to 'cars' id='close-link'}}Close create form{{/link-to}}`
+  ));
 
-    run(jQuery('#the-link'), 'click');
-    let indexController = container.lookup('controller:index');
-    deepEqual(indexController.getProperties('foo', 'bar'), { foo: '123', bar: 'abc' }, 'controller QP properties not');
-  });
-
-  QUnit.test('updates controller QP properties on current route when invoked', function() {
-    setTemplate('index', compile("{{#link-to 'index' (query-params foo='456') id='the-link'}}Index{{/link-to}}"));
-    bootApplication();
-
-    run(jQuery('#the-link'), 'click');
-    let indexController = container.lookup('controller:index');
-    deepEqual(indexController.getProperties('foo', 'bar'), { foo: '456', bar: 'abc' }, 'controller QP properties updated');
-  });
-
-  QUnit.test('updates controller QP properties on current route when invoked (inferred route)', function() {
-    setTemplate('index', compile("{{#link-to (query-params foo='456') id='the-link'}}Index{{/link-to}}"));
-    bootApplication();
-
-    run(jQuery('#the-link'), 'click');
-    let indexController = container.lookup('controller:index');
-    deepEqual(indexController.getProperties('foo', 'bar'), { foo: '456', bar: 'abc' }, 'controller QP properties updated');
-  });
-
-  QUnit.test('updates controller QP properties on other route after transitioning to that route', function() {
-    Router.map(function() {
-      this.route('about');
-    });
-
-    setTemplate('index', compile("{{#link-to 'about' (query-params baz='lol') id='the-link'}}About{{/link-to}}"));
-    bootApplication();
-
-    equal(jQuery('#the-link').attr('href'), '/about?baz=lol');
-    run(jQuery('#the-link'), 'click');
-    let aboutController = container.lookup('controller:about');
-    deepEqual(aboutController.getProperties('baz', 'bat'), { baz: 'lol', bat: 'borf' }, 'about controller QP properties updated');
-
-    equal(container.lookup('controller:application').get('currentPath'), 'about');
-  });
-
-  QUnit.test('supplied QP properties can be bound', function() {
-    let indexController = container.lookup('controller:index');
-    setTemplate('index', compile("{{#link-to (query-params foo=boundThing) id='the-link'}}Index{{/link-to}}"));
-
-    bootApplication();
-
-    equal(jQuery('#the-link').attr('href'), '/?foo=OMG');
-    run(indexController, 'set', 'boundThing', 'ASL');
-    equal(jQuery('#the-link').attr('href'), '/?foo=ASL');
-  });
-
-  QUnit.test('supplied QP properties can be bound (booleans)', function() {
-    let indexController = container.lookup('controller:index');
-    setTemplate('index', compile("{{#link-to (query-params abool=boundThing) id='the-link'}}Index{{/link-to}}"));
-
-    bootApplication();
-
-    equal(jQuery('#the-link').attr('href'), '/?abool=OMG');
-    run(indexController, 'set', 'boundThing', false);
-    equal(jQuery('#the-link').attr('href'), '/?abool=false');
-
-    run(jQuery('#the-link'), 'click');
-
-    deepEqual(indexController.getProperties('foo', 'bar', 'abool'), { foo: '123', bar: 'abc', abool: false });
-  });
-
-  QUnit.test('href updates when unsupplied controller QP props change', function() {
-    setTemplate('index', compile("{{#link-to (query-params foo='lol') id='the-link'}}Index{{/link-to}}"));
-
-    bootApplication();
-    let indexController = container.lookup('controller:index');
-
-    equal(jQuery('#the-link').attr('href'), '/?foo=lol');
-    run(indexController, 'set', 'bar', 'BORF');
-    equal(jQuery('#the-link').attr('href'), '/?bar=BORF&foo=lol');
-    run(indexController, 'set', 'foo', 'YEAH');
-    equal(jQuery('#the-link').attr('href'), '/?bar=BORF&foo=lol');
-  });
-
-  QUnit.test('The {{link-to}} with only query params always transitions to the current route with the query params applied', function() {
-    // Test harness for bug #12033
-
-    setTemplate('cars', compile(
-      "{{#link-to 'cars.create' id='create-link'}}Create new car{{/link-to}} " +
-      "{{#link-to (query-params page='2') id='page2-link'}}Page 2{{/link-to}}" +
-      '{{outlet}}'
-    ));
-
-    setTemplate('cars/create', compile(
-      "{{#link-to 'cars' id='close-link'}}Close create form{{/link-to}}"
-    ));
-
-    Router.map(function() {
-      this.route('cars', function() {
-        this.route('create');
-      });
-    });
-
-    App.CarsController = Controller.extend({
-      queryParams: ['page'],
-      page: 1
-    });
-
-    bootApplication();
-
-    let carsController = container.lookup('controller:cars');
-
-    run(() => router.handleURL('/cars/create'));
-
-    run(() => {
-      equal(router.currentRouteName, 'cars.create');
-      jQuery('#close-link').click();
-    });
-
-    run(() => {
-      equal(router.currentRouteName, 'cars.index');
-      equal(router.get('url'), '/cars');
-      equal(carsController.get('page'), 1, 'The page query-param is 1');
-      jQuery('#page2-link').click();
-    });
-
-    run(() => {
-      equal(router.currentRouteName, 'cars.index', 'The active route is still cars');
-      equal(router.get('url'), '/cars?page=2', 'The url has been updated');
-      equal(carsController.get('page'), 2, 'The query params have been updated');
+  Router.map(function() {
+    this.route('cars', function() {
+      this.route('create');
     });
   });
 
-  QUnit.test('The {{link-to}} applies activeClass when query params are not changed', function() {
-    setTemplate('index', compile(
-      "{{#link-to (query-params foo='cat') id='cat-link'}}Index{{/link-to}} " +
-      "{{#link-to (query-params foo='dog') id='dog-link'}}Index{{/link-to}} " +
-      "{{#link-to 'index' id='change-nothing'}}Index{{/link-to}}"
-    ));
-
-    setTemplate('search', compile(
-      "{{#link-to (query-params search='same') id='same-search'}}Index{{/link-to}} " +
-      "{{#link-to (query-params search='change') id='change-search'}}Index{{/link-to}} " +
-      "{{#link-to (query-params search='same' archive=true) id='same-search-add-archive'}}Index{{/link-to}} " +
-      "{{#link-to (query-params archive=true) id='only-add-archive'}}Index{{/link-to}} " +
-      "{{#link-to (query-params search='same' archive=true) id='both-same'}}Index{{/link-to}} " +
-      "{{#link-to (query-params search='different' archive=true) id='change-one'}}Index{{/link-to}} " +
-      "{{#link-to (query-params search='different' archive=false) id='remove-one'}}Index{{/link-to}} " +
-      '{{outlet}}'
-    ));
-
-    setTemplate('search/results', compile(
-      "{{#link-to (query-params sort='title') id='same-sort-child-only'}}Index{{/link-to}} " +
-      "{{#link-to (query-params search='same') id='same-search-parent-only'}}Index{{/link-to}} " +
-      "{{#link-to (query-params search='change') id='change-search-parent-only'}}Index{{/link-to}} " +
-      "{{#link-to (query-params search='same' sort='title') id='same-search-same-sort-child-and-parent'}}Index{{/link-to}} " +
-      "{{#link-to (query-params search='same' sort='author') id='same-search-different-sort-child-and-parent'}}Index{{/link-to}} " +
-      "{{#link-to (query-params search='change' sort='title') id='change-search-same-sort-child-and-parent'}}Index{{/link-to}} " +
-      "{{#link-to (query-params foo='dog') id='dog-link'}}Index{{/link-to}} "
-    ));
-
-    Router.map(function() {
-      this.route('search', function() {
-        this.route('results');
-      });
-    });
-
-    App.SearchController = Controller.extend({
-      queryParams: ['search', 'archive'],
-      search: '',
-      archive: false
-    });
-
-    App.SearchResultsController = Controller.extend({
-      queryParams: ['sort', 'showDetails'],
-      sort: 'title',
-      showDetails: true
-    });
-
-    bootApplication();
-
-    //Basic tests
-    shouldNotBeActive('#cat-link');
-    shouldNotBeActive('#dog-link');
-    run(router, 'handleURL', '/?foo=cat');
-    shouldBeActive('#cat-link');
-    shouldNotBeActive('#dog-link');
-    run(router, 'handleURL', '/?foo=dog');
-    shouldBeActive('#dog-link');
-    shouldNotBeActive('#cat-link');
-    shouldBeActive('#change-nothing');
-
-    //Multiple params
-    run(() => router.handleURL('/search?search=same'));
-    shouldBeActive('#same-search');
-    shouldNotBeActive('#change-search');
-    shouldNotBeActive('#same-search-add-archive');
-    shouldNotBeActive('#only-add-archive');
-    shouldNotBeActive('#remove-one');
-
-    run(() => router.handleURL('/search?search=same&archive=true'));
-
-    shouldBeActive('#both-same');
-    shouldNotBeActive('#change-one');
-
-    //Nested Controllers
-    run(() => {
-      // Note: this is kind of a strange case; sort's default value is 'title',
-      // so this URL shouldn't have been generated in the first place, but
-      // we should also be able to gracefully handle these cases.
-      router.handleURL('/search/results?search=same&sort=title&showDetails=true');
-    });
-    //shouldBeActive('#same-sort-child-only');
-    shouldBeActive('#same-search-parent-only');
-    shouldNotBeActive('#change-search-parent-only');
-    shouldBeActive('#same-search-same-sort-child-and-parent');
-    shouldNotBeActive('#same-search-different-sort-child-and-parent');
-    shouldNotBeActive('#change-search-same-sort-child-and-parent');
+  App.CarsController = Controller.extend({
+    queryParams: ['page'],
+    page: 1
   });
 
-  QUnit.test('The {{link-to}} applies active class when query-param is number', function() {
-    setTemplate('index', compile(
-      "{{#link-to (query-params page=pageNumber) id='page-link'}}Index{{/link-to}} "));
+  bootApplication();
 
-    App.IndexController = Controller.extend({
-      queryParams: ['page'],
-      page: 1,
-      pageNumber: 5
-    });
+  let carsController = container.lookup('controller:cars');
 
-    bootApplication();
+  run(() => router.handleURL('/cars/create'));
 
-    shouldNotBeActive('#page-link');
-    run(router, 'handleURL', '/?page=5');
-    shouldBeActive('#page-link');
+  run(() => {
+    equal(router.currentRouteName, 'cars.create');
+    jQuery('#close-link').click();
   });
 
-  QUnit.test('The {{link-to}} applies active class when query-param is array', function() {
-    setTemplate('index', compile(
-      "{{#link-to (query-params pages=pagesArray) id='array-link'}}Index{{/link-to}} " +
-      "{{#link-to (query-params pages=biggerArray) id='bigger-link'}}Index{{/link-to}} " +
-      "{{#link-to (query-params pages=emptyArray) id='empty-link'}}Index{{/link-to}} "
-    ));
-
-    App.IndexController = Controller.extend({
-      queryParams: ['pages'],
-      pages: [],
-      pagesArray: [1, 2],
-      biggerArray: [1, 2, 3],
-      emptyArray: []
-    });
-
-    bootApplication();
-
-    shouldNotBeActive('#array-link');
-    run(router, 'handleURL', '/?pages=%5B1%2C2%5D');
-    shouldBeActive('#array-link');
-    shouldNotBeActive('#bigger-link');
-    shouldNotBeActive('#empty-link');
-    run(router, 'handleURL', '/?pages=%5B2%2C1%5D');
-    shouldNotBeActive('#array-link');
-    shouldNotBeActive('#bigger-link');
-    shouldNotBeActive('#empty-link');
-    run(router, 'handleURL', '/?pages=%5B1%2C2%2C3%5D');
-    shouldBeActive('#bigger-link');
-    shouldNotBeActive('#array-link');
-    shouldNotBeActive('#empty-link');
+  run(() => {
+    equal(router.currentRouteName, 'cars.index');
+    equal(router.get('url'), '/cars');
+    equal(carsController.get('page'), 1, 'The page query-param is 1');
+    jQuery('#page2-link').click();
   });
 
-  QUnit.test('The {{link-to}} helper applies active class to parent route', function() {
-    App.Router.map(function() {
-      this.route('parent', function() {
-        this.route('child');
-      });
+  run(() => {
+    equal(router.currentRouteName, 'cars.index', 'The active route is still cars');
+    equal(router.get('url'), '/cars?page=2', 'The url has been updated');
+    equal(carsController.get('page'), 2, 'The query params have been updated');
+  });
+});
+
+QUnit.test('The {{link-to}} applies activeClass when query params are not changed', function() {
+  setTemplate('index', compile(`
+    {{#link-to (query-params foo='cat') id='cat-link'}}Index{{/link-to}}
+    {{#link-to (query-params foo='dog') id='dog-link'}}Index{{/link-to}}
+    {{#link-to 'index' id='change-nothing'}}Index{{/link-to}}
+  `));
+
+  setTemplate('search', compile(`
+    {{#link-to (query-params search='same') id='same-search'}}Index{{/link-to}}
+    {{#link-to (query-params search='change') id='change-search'}}Index{{/link-to}}
+    {{#link-to (query-params search='same' archive=true) id='same-search-add-archive'}}Index{{/link-to}}
+    {{#link-to (query-params archive=true) id='only-add-archive'}}Index{{/link-to}}
+    {{#link-to (query-params search='same' archive=true) id='both-same'}}Index{{/link-to}}
+    {{#link-to (query-params search='different' archive=true) id='change-one'}}Index{{/link-to}}
+    {{#link-to (query-params search='different' archive=false) id='remove-one'}}Index{{/link-to}}
+    {{outlet}}
+  `));
+
+  setTemplate('search/results', compile(`
+    {{#link-to (query-params sort='title') id='same-sort-child-only'}}Index{{/link-to}}
+    {{#link-to (query-params search='same') id='same-search-parent-only'}}Index{{/link-to}}
+    {{#link-to (query-params search='change') id='change-search-parent-only'}}Index{{/link-to}}
+    {{#link-to (query-params search='same' sort='title') id='same-search-same-sort-child-and-parent'}}Index{{/link-to}}
+    {{#link-to (query-params search='same' sort='author') id='same-search-different-sort-child-and-parent'}}Index{{/link-to}}
+    {{#link-to (query-params search='change' sort='title') id='change-search-same-sort-child-and-parent'}}Index{{/link-to}}
+    {{#link-to (query-params foo='dog') id='dog-link'}}Index{{/link-to}}
+  `));
+
+  Router.map(function() {
+    this.route('search', function() {
+      this.route('results');
     });
-
-    setTemplate('application', compile(
-      "{{#link-to 'parent' id='parent-link'}}Parent{{/link-to}} " +
-      "{{#link-to 'parent.child' id='parent-child-link'}}Child{{/link-to}} " +
-      "{{#link-to 'parent' (query-params foo=cat) id='parent-link-qp'}}Parent{{/link-to}} " +
-      '{{outlet}}'
-    ));
-
-    App.ParentChildController = Controller.extend({
-      queryParams: ['foo'],
-      foo: 'bar'
-    });
-
-    bootApplication();
-    shouldNotBeActive('#parent-link');
-    shouldNotBeActive('#parent-child-link');
-    shouldNotBeActive('#parent-link-qp');
-    run(router, 'handleURL', '/parent/child?foo=dog');
-    shouldBeActive('#parent-link');
-    shouldNotBeActive('#parent-link-qp');
   });
 
-  QUnit.test('The {{link-to}} helper disregards query-params in activeness computation when current-when specified', function() {
-    App.Router.map(function() {
-      this.route('parent');
-    });
-
-    setTemplate('application', compile(
-      "{{#link-to 'parent' (query-params page=1) current-when='parent' id='app-link'}}Parent{{/link-to}} {{outlet}}"));
-    setTemplate('parent', compile(
-      "{{#link-to 'parent' (query-params page=1) current-when='parent' id='parent-link'}}Parent{{/link-to}} {{outlet}}"));
-
-    App.ParentController = Controller.extend({
-      queryParams: ['page'],
-      page: 1
-    });
-
-    bootApplication();
-    equal(jQuery('#app-link').attr('href'), '/parent');
-    shouldNotBeActive('#app-link');
-
-    run(router, 'handleURL', '/parent?page=2');
-    equal(jQuery('#app-link').attr('href'), '/parent');
-    shouldBeActive('#app-link');
-    equal(jQuery('#parent-link').attr('href'), '/parent');
-    shouldBeActive('#parent-link');
-
-    let parentController = container.lookup('controller:parent');
-    equal(parentController.get('page'), 2);
-    run(parentController, 'set', 'page', 3);
-    equal(router.get('location.path'), '/parent?page=3');
-    shouldBeActive('#app-link');
-    shouldBeActive('#parent-link');
-
-    jQuery('#app-link').click();
-    equal(router.get('location.path'), '/parent');
+  App.SearchController = Controller.extend({
+    queryParams: ['search', 'archive'],
+    search: '',
+    archive: false
   });
 
-  QUnit.test('link-to default query params while in active transition regression test', function() {
-    App.Router.map(function() {
-      this.route('foos');
-      this.route('bars');
-    });
-    let foos = RSVP.defer();
-    let bars = RSVP.defer();
-
-    setTemplate('application', compile(`
-      {{link-to 'Foos' 'foos' id='foos-link'}}
-      {{link-to 'Baz Foos' 'foos' (query-params baz=true) id='baz-foos-link'}}
-      {{link-to 'Quux Bars' 'bars' (query-params quux=true) id='bars-link'}}
-    `));
-
-    App.FoosController = Controller.extend({
-      queryParams: ['status'],
-      baz: false
-    });
-
-    App.FoosRoute = Route.extend({
-      model() {
-        return foos.promise;
-      }
-    });
-
-    App.BarsController = Controller.extend({
-      queryParams: ['status'],
-      quux: false
-    });
-
-    App.BarsRoute = Route.extend({
-      model() {
-        return bars.promise;
-      }
-    });
-
-    bootApplication();
-    equal(jQuery('#foos-link').attr('href'), '/foos');
-    equal(jQuery('#baz-foos-link').attr('href'), '/foos?baz=true');
-    equal(jQuery('#bars-link').attr('href'), '/bars?quux=true');
-
-    equal(router.get('location.path'), '');
-
-    shouldNotBeActive('#foos-link');
-    shouldNotBeActive('#baz-foos-link');
-    shouldNotBeActive('#bars-link');
-
-    run(jQuery('#bars-link'), 'click');
-    shouldNotBeActive('#bars-link');
-
-    run(jQuery('#foos-link'), 'click');
-    shouldNotBeActive('#foos-link');
-
-    run(foos, 'resolve');
-
-    equal(router.get('location.path'), '/foos');
-    shouldBeActive('#foos-link');
+  App.SearchResultsController = Controller.extend({
+    queryParams: ['sort', 'showDetails'],
+    sort: 'title',
+    showDetails: true
   });
-}
+
+  bootApplication();
+
+  //Basic tests
+  shouldNotBeActive('#cat-link');
+  shouldNotBeActive('#dog-link');
+  run(router, 'handleURL', '/?foo=cat');
+  shouldBeActive('#cat-link');
+  shouldNotBeActive('#dog-link');
+  run(router, 'handleURL', '/?foo=dog');
+  shouldBeActive('#dog-link');
+  shouldNotBeActive('#cat-link');
+  shouldBeActive('#change-nothing');
+
+  //Multiple params
+  run(() => router.handleURL('/search?search=same'));
+  shouldBeActive('#same-search');
+  shouldNotBeActive('#change-search');
+  shouldNotBeActive('#same-search-add-archive');
+  shouldNotBeActive('#only-add-archive');
+  shouldNotBeActive('#remove-one');
+
+  run(() => router.handleURL('/search?search=same&archive=true'));
+
+  shouldBeActive('#both-same');
+  shouldNotBeActive('#change-one');
+
+  //Nested Controllers
+  run(() => {
+    // Note: this is kind of a strange case; sort's default value is 'title',
+    // so this URL shouldn't have been generated in the first place, but
+    // we should also be able to gracefully handle these cases.
+    router.handleURL('/search/results?search=same&sort=title&showDetails=true');
+  });
+  //shouldBeActive('#same-sort-child-only');
+  shouldBeActive('#same-search-parent-only');
+  shouldNotBeActive('#change-search-parent-only');
+  shouldBeActive('#same-search-same-sort-child-and-parent');
+  shouldNotBeActive('#same-search-different-sort-child-and-parent');
+  shouldNotBeActive('#change-search-same-sort-child-and-parent');
+});
+
+QUnit.test('The {{link-to}} applies active class when query-param is number', function() {
+  setTemplate('index', compile(`
+    {{#link-to (query-params page=pageNumber) id='page-link'}}Index{{/link-to}}
+  `));
+
+  App.IndexController = Controller.extend({
+    queryParams: ['page'],
+    page: 1,
+    pageNumber: 5
+  });
+
+  bootApplication();
+
+  shouldNotBeActive('#page-link');
+  run(router, 'handleURL', '/?page=5');
+  shouldBeActive('#page-link');
+});
+
+QUnit.test('The {{link-to}} applies active class when query-param is array', function() {
+  setTemplate('index', compile(`
+    {{#link-to (query-params pages=pagesArray) id='array-link'}}Index{{/link-to}}
+    {{#link-to (query-params pages=biggerArray) id='bigger-link'}}Index{{/link-to}}
+    {{#link-to (query-params pages=emptyArray) id='empty-link'}}Index{{/link-to}}
+  `));
+
+  App.IndexController = Controller.extend({
+    queryParams: ['pages'],
+    pages: [],
+    pagesArray: [1, 2],
+    biggerArray: [1, 2, 3],
+    emptyArray: []
+  });
+
+  bootApplication();
+
+  shouldNotBeActive('#array-link');
+  run(router, 'handleURL', '/?pages=%5B1%2C2%5D');
+  shouldBeActive('#array-link');
+  shouldNotBeActive('#bigger-link');
+  shouldNotBeActive('#empty-link');
+  run(router, 'handleURL', '/?pages=%5B2%2C1%5D');
+  shouldNotBeActive('#array-link');
+  shouldNotBeActive('#bigger-link');
+  shouldNotBeActive('#empty-link');
+  run(router, 'handleURL', '/?pages=%5B1%2C2%2C3%5D');
+  shouldBeActive('#bigger-link');
+  shouldNotBeActive('#array-link');
+  shouldNotBeActive('#empty-link');
+});
+
+QUnit.test('The {{link-to}} helper applies active class to parent route', function() {
+  App.Router.map(function() {
+    this.route('parent', function() {
+      this.route('child');
+    });
+  });
+
+  setTemplate('application', compile(`
+    {{#link-to 'parent' id='parent-link'}}Parent{{/link-to}}
+    {{#link-to 'parent.child' id='parent-child-link'}}Child{{/link-to}}
+    {{#link-to 'parent' (query-params foo=cat) id='parent-link-qp'}}Parent{{/link-to}}
+    {{outlet}}
+  `));
+
+  App.ParentChildController = Controller.extend({
+    queryParams: ['foo'],
+    foo: 'bar'
+  });
+
+  bootApplication();
+  shouldNotBeActive('#parent-link');
+  shouldNotBeActive('#parent-child-link');
+  shouldNotBeActive('#parent-link-qp');
+  run(router, 'handleURL', '/parent/child?foo=dog');
+  shouldBeActive('#parent-link');
+  shouldNotBeActive('#parent-link-qp');
+});
+
+QUnit.test('The {{link-to}} helper disregards query-params in activeness computation when current-when specified', function() {
+  App.Router.map(function() {
+    this.route('parent');
+  });
+
+  setTemplate('application', compile(`
+    {{#link-to 'parent' (query-params page=1) current-when='parent' id='app-link'}}Parent{{/link-to}} {{outlet}}
+  `));
+  setTemplate('parent', compile(`
+    {{#link-to 'parent' (query-params page=1) current-when='parent' id='parent-link'}}Parent{{/link-to}} {{outlet}}
+  `));
+
+  App.ParentController = Controller.extend({
+    queryParams: ['page'],
+    page: 1
+  });
+
+  bootApplication();
+  equal(jQuery('#app-link').attr('href'), '/parent');
+  shouldNotBeActive('#app-link');
+
+  run(router, 'handleURL', '/parent?page=2');
+  equal(jQuery('#app-link').attr('href'), '/parent');
+  shouldBeActive('#app-link');
+  equal(jQuery('#parent-link').attr('href'), '/parent');
+  shouldBeActive('#parent-link');
+
+  let parentController = container.lookup('controller:parent');
+  equal(parentController.get('page'), 2);
+  run(parentController, 'set', 'page', 3);
+  equal(router.get('location.path'), '/parent?page=3');
+  shouldBeActive('#app-link');
+  shouldBeActive('#parent-link');
+
+  jQuery('#app-link').click();
+  equal(router.get('location.path'), '/parent');
+});
+
+QUnit.test('link-to default query params while in active transition regression test', function() {
+  App.Router.map(function() {
+    this.route('foos');
+    this.route('bars');
+  });
+  let foos = RSVP.defer();
+  let bars = RSVP.defer();
+
+  setTemplate('application', compile(`
+    {{link-to 'Foos' 'foos' id='foos-link'}}
+    {{link-to 'Baz Foos' 'foos' (query-params baz=true) id='baz-foos-link'}}
+    {{link-to 'Quux Bars' 'bars' (query-params quux=true) id='bars-link'}}
+  `));
+
+  App.FoosController = Controller.extend({
+    queryParams: ['status'],
+    baz: false
+  });
+
+  App.FoosRoute = Route.extend({
+    model() {
+      return foos.promise;
+    }
+  });
+
+  App.BarsController = Controller.extend({
+    queryParams: ['status'],
+    quux: false
+  });
+
+  App.BarsRoute = Route.extend({
+    model() {
+      return bars.promise;
+    }
+  });
+
+  bootApplication();
+  equal(jQuery('#foos-link').attr('href'), '/foos');
+  equal(jQuery('#baz-foos-link').attr('href'), '/foos?baz=true');
+  equal(jQuery('#bars-link').attr('href'), '/bars?quux=true');
+
+  equal(router.get('location.path'), '');
+
+  shouldNotBeActive('#foos-link');
+  shouldNotBeActive('#baz-foos-link');
+  shouldNotBeActive('#bars-link');
+
+  run(jQuery('#bars-link'), 'click');
+  shouldNotBeActive('#bars-link');
+
+  run(jQuery('#foos-link'), 'click');
+  shouldNotBeActive('#foos-link');
+
+  run(foos, 'resolve');
+
+  equal(router.get('location.path'), '/foos');
+  shouldBeActive('#foos-link');
+});

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -9,7 +9,6 @@ import { Route, NoneLocation } from 'ember-routing';
 import {
   run,
   get,
-  isFeatureEnabled,
   computed,
   Mixin,
   meta
@@ -123,3238 +122,1338 @@ QUnit.module('Routing with Query Params', {
   }
 });
 
-if (isFeatureEnabled('ember-routing-route-configured-query-params')) {
-  QUnit.test('Single query params can be set on the route', function() {
-    App.Router.map(function() {
-      this.route('home', { path: '/' });
+QUnit.test('Calling transitionTo does not lose query params already on the activeTransition', function() {
+  expect(2);
+  App.Router.map(function() {
+    this.route('parent', function() {
+      this.route('child');
+      this.route('sibling');
     });
+  });
 
-    App.HomeRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: '123'
-        }
+  App.ParentChildRoute = Route.extend({
+    afterModel: function() {
+      ok(true, 'The after model hook was called');
+      this.transitionTo('parent.sibling');
+    }
+  });
+
+  App.ParentController = Controller.extend({
+    queryParams: ['foo'],
+    foo: 'bar'
+  });
+
+  startingURL = '/parent/child?foo=lol';
+  bootApplication();
+
+  let parentController = container.lookup('controller:parent');
+
+  equal(parentController.get('foo'), 'lol');
+});
+
+QUnit.test('Single query params can be set on the controller [DEPRECATED]', function() {
+  App.Router.map(function() {
+    this.route('home', { path: '/' });
+  });
+
+  App.HomeController = Controller.extend({
+    queryParams: ['foo'],
+    foo: '123'
+  });
+
+  bootApplication();
+
+  let controller = container.lookup('controller:home');
+
+  setAndFlush(controller, 'foo', '456');
+
+  equal(router.get('location.path'), '/?foo=456');
+
+  setAndFlush(controller, 'foo', '987');
+  equal(router.get('location.path'), '/?foo=987');
+});
+
+QUnit.test('Single query params can be set on the controller [DEPRECATED]', function() {
+  App.Router.map(function() {
+    this.route('home', { path: '/' });
+  });
+
+  App.HomeController = Controller.extend({
+    queryParams: ['foo'],
+    foo: '123'
+  });
+
+  bootApplication();
+
+  let controller = container.lookup('controller:home');
+
+  setAndFlush(controller, 'foo', '456');
+
+  equal(router.get('location.path'), '/?foo=456');
+
+  setAndFlush(controller, 'foo', '987');
+  equal(router.get('location.path'), '/?foo=987');
+});
+
+QUnit.test('Query params can map to different url keys configured on the controller [DEPRECATED]', function() {
+  App.IndexController = Controller.extend({
+    queryParams: [{ foo: 'other_foo', bar: { as: 'other_bar' } }],
+    foo: 'FOO',
+    bar: 'BAR'
+  });
+
+  bootApplication();
+  equal(router.get('location.path'), '');
+
+  let controller = container.lookup('controller:index');
+  setAndFlush(controller, 'foo', 'LEX');
+
+  equal(router.get('location.path'), '/?other_foo=LEX');
+  setAndFlush(controller, 'foo', 'WOO');
+  equal(router.get('location.path'), '/?other_foo=WOO');
+
+  run(router, 'transitionTo', '/?other_foo=NAW');
+  equal(controller.get('foo'), 'NAW');
+
+  setAndFlush(controller, 'bar', 'NERK');
+  run(router, 'transitionTo', '/?other_bar=NERK&other_foo=NAW');
+});
+
+QUnit.test('Routes have overridable serializeQueryParamKey hook', function() {
+  App.IndexRoute = Route.extend({
+    serializeQueryParamKey: StringUtils.dasherize
+  });
+
+  App.IndexController = Controller.extend({
+    queryParams: 'funTimes',
+    funTimes: ''
+  });
+
+  bootApplication();
+  equal(router.get('location.path'), '');
+
+  let controller = container.lookup('controller:index');
+  setAndFlush(controller, 'funTimes', 'woot');
+
+  equal(router.get('location.path'), '/?fun-times=woot');
+});
+
+QUnit.test('No replaceURL occurs on startup because default values don\'t show up in URL', function() {
+  expect(0);
+
+  App.IndexController = Controller.extend({
+    queryParams: ['foo'],
+    foo: '123'
+  });
+
+  expectedReplaceURL = '/?foo=123';
+
+  bootApplication();
+});
+
+QUnit.test('Can override inherited QP behavior by specifying queryParams as a computed property', function() {
+  expect(0);
+  let SharedMixin = Mixin.create({
+    queryParams: ['a'],
+    a: 0
+  });
+
+  App.IndexController = Controller.extend(SharedMixin, {
+    queryParams: computed(function() {
+      return ['c'];
+    }),
+    c: true
+  });
+
+  bootApplication();
+  let indexController = container.lookup('controller:index');
+
+  expectedReplaceURL = 'not gonna happen';
+  run(indexController, 'set', 'a', 1);
+});
+
+QUnit.test('model hooks receives query params', function() {
+  App.IndexController = Controller.extend({
+    queryParams: ['omg'],
+    omg: 'lol'
+  });
+
+  App.IndexRoute = Route.extend({
+    model(params) {
+      deepEqual(params, { omg: 'lol' });
+    }
+  });
+
+  bootApplication();
+
+  equal(router.get('location.path'), '');
+});
+
+QUnit.test('controllers won\'t be eagerly instantiated by internal query params logic', function() {
+  expect(10);
+  App.Router.map(function() {
+    this.route('cats', function() {
+      this.route('index', { path: '/' });
+    });
+    this.route('home', { path: '/' });
+    this.route('about');
+  });
+
+  App.register('template:home',       compile("<h3>{{link-to 'About' 'about' (query-params lol='wat') id='link-to-about'}}</h3>"));
+  App.register('template:about',      compile("<h3>{{link-to 'Home' 'home'  (query-params foo='naw')}}</h3>"));
+  App.register('template:cats.index', compile("<h3>{{link-to 'Cats' 'cats'  (query-params name='domino') id='cats-link'}}</h3>"));
+
+  let homeShouldBeCreated = false;
+  let aboutShouldBeCreated = false;
+  let catsIndexShouldBeCreated = false;
+
+  App.HomeRoute = Route.extend({
+    setup() {
+      homeShouldBeCreated = true;
+      this._super(...arguments);
+    }
+  });
+
+  App.HomeController = Controller.extend({
+    queryParams: ['foo'],
+    foo: '123',
+    init() {
+      this._super(...arguments);
+      ok(homeShouldBeCreated, 'HomeController should be created at this time');
+    }
+  });
+
+  App.AboutRoute = Route.extend({
+    setup() {
+      aboutShouldBeCreated = true;
+      this._super(...arguments);
+    }
+  });
+
+  App.AboutController = Controller.extend({
+    queryParams: ['lol'],
+    lol: 'haha',
+    init() {
+      this._super(...arguments);
+      ok(aboutShouldBeCreated, 'AboutController should be created at this time');
+    }
+  });
+
+  App.CatsIndexRoute = Route.extend({
+    model() {
+      return [];
+    },
+    setup() {
+      catsIndexShouldBeCreated = true;
+      this._super(...arguments);
+    },
+    setupController(controller, context) {
+      controller.set('model', context);
+    }
+  });
+
+  App.CatsIndexController = Controller.extend({
+    queryParams: ['breed', 'name'],
+    breed: 'Golden',
+    name: null,
+    init() {
+      this._super(...arguments);
+      ok(catsIndexShouldBeCreated, 'CatsIndexController should be created at this time');
+    }
+  });
+
+  bootApplication();
+
+  equal(router.get('location.path'), '', 'url is correct');
+  let controller = container.lookup('controller:home');
+  setAndFlush(controller, 'foo', '456');
+  equal(router.get('location.path'), '/?foo=456', 'url is correct');
+  equal(jQuery('#link-to-about').attr('href'), '/about?lol=wat', 'link to about is correct');
+
+  run(router, 'transitionTo', 'about');
+  equal(router.get('location.path'), '/about', 'url is correct');
+
+  run(router, 'transitionTo', 'cats');
+
+  equal(router.get('location.path'), '/cats', 'url is correct');
+  equal(jQuery('#cats-link').attr('href'), '/cats?name=domino', 'link to cats is correct');
+  run(jQuery('#cats-link'), 'click');
+  equal(router.get('location.path'), '/cats?name=domino', 'url is correct');
+});
+
+QUnit.test('query params have been set by the time setupController is called', function() {
+  expect(1);
+
+  App.ApplicationController = Controller.extend({
+    queryParams: ['foo'],
+    foo: 'wat'
+  });
+
+  App.ApplicationRoute = Route.extend({
+    setupController(controller) {
+      equal(controller.get('foo'), 'YEAH', 'controller\'s foo QP property set before setupController called');
+    }
+  });
+
+  startingURL = '/?foo=YEAH';
+  bootApplication();
+});
+
+QUnit.test('model hooks receives query params (overridden by incoming url value)', function() {
+  App.IndexController = Controller.extend({
+    queryParams: ['omg'],
+    omg: 'lol'
+  });
+
+  App.IndexRoute = Route.extend({
+    model(params) {
+      deepEqual(params, { omg: 'yes' });
+    }
+  });
+
+  startingURL = '/?omg=yes';
+  bootApplication();
+
+  equal(router.get('location.path'), '/?omg=yes');
+});
+
+QUnit.test('Route#paramsFor fetches query params', function() {
+  expect(1);
+
+  App.Router.map(function() {
+    this.route('index', { path: '/:something' });
+  });
+
+  App.IndexController = Controller.extend({
+    queryParams: ['foo'],
+    foo: 'fooapp'
+  });
+
+  App.IndexRoute = Route.extend({
+    model(params, transition) {
+      deepEqual(this.paramsFor('index'), { something: 'omg', foo: 'fooapp' }, 'could retrieve params for index');
+    }
+  });
+
+  startingURL = '/omg';
+  bootApplication();
+});
+
+QUnit.test('model hook can query prefix-less application params (overridden by incoming url value)', function() {
+  App.ApplicationController = Controller.extend({
+    queryParams: ['appomg'],
+    appomg: 'applol'
+  });
+
+  App.IndexController = Controller.extend({
+    queryParams: ['omg'],
+    omg: 'lol'
+  });
+
+  App.ApplicationRoute = Route.extend({
+    model(params) {
+      deepEqual(params, { appomg: 'appyes' });
+    }
+  });
+
+  App.IndexRoute = Route.extend({
+    model(params) {
+      deepEqual(params, { omg: 'yes' });
+      deepEqual(this.paramsFor('application'), { appomg: 'appyes' });
+    }
+  });
+
+  startingURL = '/?appomg=appyes&omg=yes';
+  bootApplication();
+
+  equal(router.get('location.path'), '/?appomg=appyes&omg=yes');
+});
+
+
+QUnit.test('Route#paramsFor fetches falsy query params', function() {
+  expect(1);
+
+  App.IndexController = Controller.extend({
+    queryParams: ['foo'],
+    foo: true
+  });
+
+  App.IndexRoute = Route.extend({
+    model(params, transition) {
+      equal(params.foo, false);
+    }
+  });
+
+  startingURL = '/?foo=false';
+  bootApplication();
+});
+
+QUnit.test('model hook can query prefix-less application params', function() {
+  App.ApplicationController = Controller.extend({
+    queryParams: ['appomg'],
+    appomg: 'applol'
+  });
+
+  App.IndexController = Controller.extend({
+    queryParams: ['omg'],
+    omg: 'lol'
+  });
+
+  App.ApplicationRoute = Route.extend({
+    model(params) {
+      deepEqual(params, { appomg: 'applol' });
+    }
+  });
+
+  App.IndexRoute = Route.extend({
+    model(params) {
+      deepEqual(params, { omg: 'lol' });
+      deepEqual(this.paramsFor('application'), { appomg: 'applol' });
+    }
+  });
+
+  bootApplication();
+
+  equal(router.get('location.path'), '');
+});
+
+QUnit.test('can opt into full transition by setting refreshModel in route queryParams', function() {
+  expect(6);
+  App.ApplicationController = Controller.extend({
+    queryParams: ['appomg'],
+    appomg: 'applol'
+  });
+
+  App.IndexController = Controller.extend({
+    queryParams: ['omg'],
+    omg: 'lol'
+  });
+
+  let appModelCount = 0;
+  App.ApplicationRoute = Route.extend({
+    model(params) {
+      appModelCount++;
+    }
+  });
+
+  let indexModelCount = 0;
+  App.IndexRoute = Route.extend({
+    queryParams: {
+      omg: {
+        refreshModel: true
       }
-    });
+    },
+    model(params) {
+      indexModelCount++;
 
-    bootApplication();
-
-    let controller = container.lookup('controller:home');
-
-    setAndFlush(controller, 'foo', '456');
-
-    equal(router.get('location.path'), '/?foo=456');
-
-    setAndFlush(controller, 'foo', '987');
-    equal(router.get('location.path'), '/?foo=987');
-  });
-
-  QUnit.test('a query param can have define a `type` for type casting', function() {
-    App.Router.map(function() {
-      this.route('home', { path: '/' });
-    });
-
-    App.HomeRoute = Route.extend({
-      queryParams: {
-        page: {
-          defaultValue: null,
-          type: 'number'
-        }
-      }
-    });
-
-    bootApplication();
-
-    let controller = container.lookup('controller:home');
-
-    run(router, 'transitionTo', 'home', { queryParams: { page: '4' } });
-    equal(controller.get('page'), 4);
-  });
-
-  QUnit.test('Query params can map to different url keys configured on the route', function() {
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: { as: 'other_foo', defaultValue: 'FOO' },
-        bar: { as: 'other_bar', defaultValue: 'BAR' }
-      }
-    });
-
-    bootApplication();
-    equal(router.get('location.path'), '');
-
-    let controller = container.lookup('controller:index');
-
-    setAndFlush(controller, 'foo', 'LEX');
-
-    equal(router.get('location.path'), '/?other_foo=LEX');
-    setAndFlush(controller, 'foo', 'WOO');
-    equal(router.get('location.path'), '/?other_foo=WOO');
-
-    run(router, 'transitionTo', '/?other_foo=NAW');
-    equal(controller.get('foo'), 'NAW');
-
-    setAndFlush(controller, 'bar', 'NERK');
-    run(router, 'transitionTo', '/?other_bar=NERK&other_foo=NAW');
-  });
-
-  QUnit.test('Routes have overridable serializeQueryParamKey hook and it works with route-configured query params', function() {
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        funTimes: {
-          defaultValue: ''
-        }
-      },
-      serializeQueryParamKey: StringUtils.dasherize
-    });
-
-    bootApplication();
-    equal(router.get('location.path'), '');
-
-    let controller = container.lookup('controller:index');
-    setAndFlush(controller, 'funTimes', 'woot');
-
-    equal(router.get('location.path'), '/?fun-times=woot');
-  });
-
-  QUnit.test('No replaceURL occurs on startup when configured via Route because default values don\'t show up in URL', function() {
-    expect(0);
-
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: '123'
-        }
-      }
-    });
-
-    expectedReplaceURL = '/?foo=123';
-
-    bootApplication();
-  });
-
-  QUnit.test('model hooks receives query params when configred on Route', function() {
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        omg: {
-          defaultValue: 'lol'
-        }
-      },
-      model(params) {
+      if (indexModelCount === 1) {
         deepEqual(params, { omg: 'lol' });
+      } else if (indexModelCount === 2) {
+        deepEqual(params, { omg: 'lex' });
       }
-    });
-
-    bootApplication();
-
-    equal(router.get('location.path'), '');
+    }
   });
 
-  QUnit.test('model hooks receives query params (overridden by incoming url value) when configured on route', function() {
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        omg: {
-          defaultValue: 'lol'
-        }
-      },
-      model(params) {
-        deepEqual(params, { omg: 'yes' });
-      }
-    });
+  bootApplication();
 
-    startingURL = '/?omg=yes';
-    bootApplication();
+  equal(appModelCount, 1);
+  equal(indexModelCount, 1);
 
-    equal(router.get('location.path'), '/?omg=yes');
+  let indexController = container.lookup('controller:index');
+  setAndFlush(indexController, 'omg', 'lex');
+
+  equal(appModelCount, 1);
+  equal(indexModelCount, 2);
+});
+
+QUnit.test('refreshModel does not cause a second transition during app boot ', function() {
+  expect(0);
+  App.ApplicationController = Controller.extend({
+    queryParams: ['appomg'],
+    appomg: 'applol'
   });
 
-  QUnit.test('Route#paramsFor fetches query params when configured on the route', function() {
-    expect(1);
-
-    App.Router.map(function() {
-      this.route('index', { path: '/:something' });
-    });
-
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: 'fooapp'
-        }
-      },
-      model(params, transition) {
-        deepEqual(this.paramsFor('index'), { something: 'omg', foo: 'fooapp' }, 'could retrieve params for index');
-      }
-    });
-
-    startingURL = '/omg';
-    bootApplication();
+  App.IndexController = Controller.extend({
+    queryParams: ['omg'],
+    omg: 'lol'
   });
 
-  QUnit.test('Route#paramsFor fetches falsy query params when they\'re configured on the route', function() {
-    expect(1);
-
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: true
-        }
-      },
-      model(params, transition) {
-        equal(params.foo, false);
+  App.IndexRoute = Route.extend({
+    queryParams: {
+      omg: {
+        refreshModel: true
       }
-    });
-
-    startingURL = '/?foo=false';
-    bootApplication();
+    },
+    refresh() {
+      ok(false);
+    }
   });
 
-  QUnit.test('model hook can query prefix-less application params when they\'re configured on the route', function() {
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        appomg: {
-          defaultValue: 'applol'
-        }
-      },
-      model(params) {
-        deepEqual(params, { appomg: 'applol' });
-      }
-    });
-
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        omg: {
-          defaultValue: 'lol'
-        }
-      },
-      model(params) {
-        deepEqual(params, { omg: 'lol' });
-        deepEqual(this.paramsFor('application'), { appomg: 'applol' });
-      }
-    });
-
-    bootApplication();
-
-    equal(router.get('location.path'), '');
-  });
-
-  QUnit.test('can opt into full transition by setting refreshModel in route queryParams when all configuration is in route', function() {
-    expect(6);
-
-    let appModelCount = 0;
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        'appomg': {
-          defaultValue: 'applol'
-        }
-      },
-      model(params) {
-        appModelCount++;
-      }
-    });
-
-    let indexModelCount = 0;
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        omg: {
-          refreshModel: true,
-          defaultValue: 'lol'
-        }
-      },
-      model(params) {
-        indexModelCount++;
-
-        if (indexModelCount === 1) {
-          deepEqual(params, { omg: 'lol' });
-        } else if (indexModelCount === 2) {
-          deepEqual(params, { omg: 'lex' });
-        }
-      }
-    });
-
-    bootApplication();
-
-    equal(appModelCount, 1);
-    equal(indexModelCount, 1);
-
-    let indexController = container.lookup('controller:index');
-    setAndFlush(indexController, 'omg', 'lex');
-
-    equal(appModelCount, 1);
-    equal(indexModelCount, 2);
-  });
-
-  QUnit.test('refreshModel does not cause a second transition during app boot ', function() {
-    expect(0);
-
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        appomg: {
-          defaultValue: 'applol'
-        }
-      }
-    });
-
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        omg: {
-          defaultValue: 'lol',
-          refreshModel: true
-        }
-      },
-      refresh() {
-        ok(false);
-      }
-    });
-
-    startingURL = '/?appomg=hello&omg=world';
-    bootApplication();
-  });
-
-  QUnit.test('can use refreshModel even w URL changes that remove QPs from address bar when QP configured on route', function() {
-    expect(4);
-
-    let indexModelCount = 0;
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        omg: {
-          defaultValue: 'lol',
-          refreshModel: true
-        }
-      },
-      model(params) {
-        indexModelCount++;
-
-        let data;
-        if (indexModelCount === 1) {
-          data = 'foo';
-        } else if (indexModelCount === 2) {
-          data = 'lol';
-        }
-
-        deepEqual(params, { omg: data }, 'index#model receives right data');
-      }
-    });
-
-    startingURL = '/?omg=foo';
-    bootApplication();
-    handleURL('/');
-
-    let indexController = container.lookup('controller:index');
-    equal(indexController.get('omg'), 'lol');
-  });
-
-  QUnit.test('can opt into a replace query by specifying replace:true in the Router config hash when all configuration lives on route', function() {
-    expect(2);
-
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        alex: {
-          defaultValue: 'matchneer',
-          replace: true
-        }
-      }
-    });
-
-    bootApplication();
-
-    equal(router.get('location.path'), '');
-
-    let appController = container.lookup('controller:application');
-    expectedReplaceURL = '/?alex=wallace';
-    setAndFlush(appController, 'alex', 'wallace');
-  });
-
-  QUnit.test('Route query params config can be configured using property name instead of URL key when configured on the route', function() {
-    expect(2);
-
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        commitBy: {
-          as: 'commit_by',
-          replace: true
-        }
-      }
-    });
-
-    bootApplication();
-
-    equal(router.get('location.path'), '');
-
-    let appController = container.lookup('controller:application');
-    expectedReplaceURL = '/?commit_by=igor_seb';
-    setAndFlush(appController, 'commitBy', 'igor_seb');
-  });
-
-  QUnit.test('An explicit replace:false on a changed QP always wins and causes a pushState even when configuration is all on the route', function() {
-    expect(3);
-
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        alex: {
-          replace: true,
-          defaultValue: 'matchneer'
-        },
-        steely: {
-          replace: false,
-          defaultValue: 'dan'
-        }
-      }
-    });
-
-    bootApplication();
-
-    let appController = container.lookup('controller:application');
-    expectedPushURL = '/?alex=wallace&steely=jan';
-    run(appController, 'setProperties', { alex: 'wallace', steely: 'jan' });
-
-    expectedPushURL = '/?alex=wallace&steely=fran';
-    run(appController, 'setProperties', { steely: 'fran' });
-
-    expectedReplaceURL = '/?alex=sriracha&steely=fran';
-    run(appController, 'setProperties', { alex: 'sriracha' });
-  });
-
-  QUnit.skip('can opt into full transition by setting refreshModel in route queryParams when transitioning from child to parent when all configuration is on route', function() {
-    App.register('template:parent', compile('{{outlet}}'));
-    App.register('template:parent/child', compile("{{link-to 'Parent' 'parent' (query-params foo='change') id='parent-link'}}"));
-
-    App.Router.map(function() {
-      this.route('parent', function() {
-        this.route('child');
-      });
-    });
-
-    let parentModelCount = 0;
-    App.ParentRoute = Route.extend({
-      model() {
-        parentModelCount++;
-      },
-      queryParams: {
-        foo: {
-          refreshModel: true,
-          defaultValue: 'abc'
-        }
-      }
-    });
-
-    startingURL = '/parent/child?foo=lol';
-    bootApplication();
-
-    equal(parentModelCount, 1);
-
-    container.lookup('controller:parent');
-
-    run(jQuery('#parent-link'), 'click');
-
-    equal(parentModelCount, 2);
-  });
-
-  QUnit.test('URL transitions that remove QPs still register as QP changes when configuration lives on the route', function() {
-    expect(2);
-
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        omg: {
-          defaultValue: 'lol'
-        }
-      }
-    });
-
-    startingURL = '/?omg=borf';
-    bootApplication();
-
-    let indexController = container.lookup('controller:index');
-    equal(indexController.get('omg'), 'borf');
-    run(router, 'transitionTo', '/');
-    equal(indexController.get('omg'), 'lol');
-  });
-
-  QUnit.test('Subresource naming style is supported when configuration is all on the route', function() {
-    App.Router.map(function() {
-      this.route('abc.def', { path: '/abcdef' }, function() {
-        this.route('zoo');
-      });
-    });
-
-    App.register('template:application', compile("{{link-to 'A' 'abc.def' (query-params foo='123') id='one'}}{{link-to 'B' 'abc.def.zoo' (query-params foo='123' bar='456') id='two'}}{{outlet}}"));
-
-    App.AbcDefRoute = Route.extend({
-      queryParams: {
-        foo: 'lol'
-      }
-    });
-
-    App.AbcDefZooRoute = Route.extend({
-      queryParams: {
-        bar: {
-          defaultValue: 'haha'
-        }
-      }
-    });
-
-    bootApplication();
-    equal(router.get('location.path'), '');
-    equal(jQuery('#one').attr('href'), '/abcdef?foo=123');
-    equal(jQuery('#two').attr('href'), '/abcdef/zoo?bar=456&foo=123');
-
-    run(jQuery('#one'), 'click');
-    equal(router.get('location.path'), '/abcdef?foo=123');
-    run(jQuery('#two'), 'click');
-    equal(router.get('location.path'), '/abcdef/zoo?bar=456&foo=123');
-  });
-
-  QUnit.test('transitionTo supports query params when configuration occurs on the route', function() {
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: 'lol'
-        }
-      }
-    });
-
-    bootApplication();
-
-    equal(router.get('location.path'), '');
-
-    run(router, 'transitionTo', { queryParams: { foo: 'borf' } });
-    equal(router.get('location.path'), '/?foo=borf', 'shorthand supported');
-    run(router, 'transitionTo', { queryParams: { 'index:foo': 'blaf' } });
-    equal(router.get('location.path'), '/?foo=blaf', 'longform supported');
-    run(router, 'transitionTo', { queryParams: { 'index:foo': false } });
-    equal(router.get('location.path'), '/?foo=false', 'longform supported (bool)');
-    run(router, 'transitionTo', { queryParams: { foo: false } });
-    equal(router.get('location.path'), '/?foo=false', 'shorhand supported (bool)');
-  });
-
-  QUnit.test('transitionTo supports query params (multiple) when configuration occurs on the route', function() {
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: 'lol'
-        },
-        bar: {
-          defaultValue: 'wat'
-        }
-      }
-    });
-
-    bootApplication();
-
-    equal(router.get('location.path'), '');
-
-    run(router, 'transitionTo', { queryParams: { foo: 'borf' } });
-    equal(router.get('location.path'), '/?foo=borf', 'shorthand supported');
-    run(router, 'transitionTo', { queryParams: { 'index:foo': 'blaf' } });
-    equal(router.get('location.path'), '/?foo=blaf', 'longform supported');
-    run(router, 'transitionTo', { queryParams: { 'index:foo': false } });
-    equal(router.get('location.path'), '/?foo=false', 'longform supported (bool)');
-    run(router, 'transitionTo', { queryParams: { foo: false } });
-    equal(router.get('location.path'), '/?foo=false', 'shorhand supported (bool)');
-  });
-
-  QUnit.test('A default boolean value deserializes QPs as booleans rather than strings when configuration occurs on the route', function() {
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: false
-        }
-      },
-      model(params) {
-        equal(params.foo, true, 'model hook received foo as boolean true');
-      }
-    });
-
-    startingURL = '/?foo=true';
-    bootApplication();
-
-    let controller = container.lookup('controller:index');
-    equal(controller.get('foo'), true);
-
-    handleURL('/?foo=false');
-    equal(controller.get('foo'), false);
-  });
-
-  QUnit.test('Query param without value are empty string when configuration occurs on the route', function() {
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: ''
-        }
-      }
-    });
-
-    startingURL = '/?foo=';
-    bootApplication();
-
-    let controller = container.lookup('controller:index');
-    equal(controller.get('foo'), '');
-  });
-
-  QUnit.test('Array query params can be set when configured on the route', function() {
-    App.Router.map(function() {
-      this.route('home', { path: '/' });
-    });
-
-    App.HomeRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: []
-        }
-      }
-    });
-
-    bootApplication();
-
-    let controller = container.lookup('controller:home');
-
-    setAndFlush(controller, 'foo', [1, 2]);
-
-    equal(router.get('location.path'), '/?foo=%5B1%2C2%5D');
-
-    setAndFlush(controller, 'foo', [3, 4]);
-    equal(router.get('location.path'), '/?foo=%5B3%2C4%5D');
-  });
-
-  QUnit.test('(de)serialization: arrays when configuration occurs on the route', function() {
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: [1]
-        }
-      }
-    });
-
-    bootApplication();
-
-    equal(router.get('location.path'), '');
-
-    run(router, 'transitionTo', { queryParams: { foo: [2, 3] } });
-    equal(router.get('location.path'), '/?foo=%5B2%2C3%5D', 'shorthand supported');
-    run(router, 'transitionTo', { queryParams: { 'index:foo': [4, 5] } });
-    equal(router.get('location.path'), '/?foo=%5B4%2C5%5D', 'longform supported');
-    run(router, 'transitionTo', { queryParams: { foo: [] } });
-    equal(router.get('location.path'), '/?foo=%5B%5D', 'longform supported');
-  });
-
-  QUnit.test('Url with array query param sets controller property to array when configuration occurs on the route', function() {
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: ''
-        }
-      }
-    });
-
-    startingURL = '/?foo[]=1&foo[]=2&foo[]=3';
-    bootApplication();
-
-    let controller = container.lookup('controller:index');
-    deepEqual(controller.get('foo'), ['1', '2', '3']);
-  });
-
-  QUnit.test('Url with array query param sets controller property to array when configuration occurs on the route and there is still a controller', function() {
-    App.IndexController = Controller.extend();
-
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: ''
-        }
-      }
-    });
-
-    startingURL = '/?foo[]=1&foo[]=2&foo[]=3';
-    bootApplication();
-
-    let controller = container.lookup('controller:index');
-    deepEqual(controller.get('foo'), ['1', '2', '3']);
-  });
-
-  QUnit.test('Array query params can be pushed/popped when configuration occurs on the route but there is still a controller', function() {
-    App.Router.map(function() {
-      this.route('home', { path: '/' });
-    });
-
-    App.HomeController = Controller.extend({
-      foo: emberA()
-    });
-
-    App.HomeRoute = Route.extend({
-      queryParams: {
-        foo: {}
-      }
-    });
-
-    bootApplication();
-
-    equal(router.get('location.path'), '');
-
-    let controller = container.lookup('controller:home');
-
-    run(controller.foo, 'pushObject', 1);
-    equal(router.get('location.path'), '/?foo=%5B1%5D');
-    deepEqual(controller.foo, [1]);
-    run(controller.foo, 'popObject');
-    equal(router.get('location.path'), '/');
-    deepEqual(controller.foo, []);
-    run(controller.foo, 'pushObject', 1);
-    equal(router.get('location.path'), '/?foo=%5B1%5D');
-    deepEqual(controller.foo, [1]);
-    run(controller.foo, 'popObject');
-    equal(router.get('location.path'), '/');
-    deepEqual(controller.foo, []);
-    run(controller.foo, 'pushObject', 1);
-    equal(router.get('location.path'), '/?foo=%5B1%5D');
-    deepEqual(controller.foo, [1]);
-    run(controller.foo, 'pushObject', 2);
-    equal(router.get('location.path'), '/?foo=%5B1%2C2%5D');
-    deepEqual(controller.foo, [1, 2]);
-    run(controller.foo, 'popObject');
-    equal(router.get('location.path'), '/?foo=%5B1%5D');
-    deepEqual(controller.foo, [1]);
-    run(controller.foo, 'unshiftObject', 'lol');
-    equal(router.get('location.path'), '/?foo=%5B%22lol%22%2C1%5D');
-    deepEqual(controller.foo, ['lol', 1]);
-  });
-
-  QUnit.test('Overwriting with array with same content shouldn\'t refire update when configuration occurs on router but there is still a controller', function() {
-    expect(3);
-    let modelCount = 0;
-
-    App.Router.map(function() {
-      this.route('home', { path: '/' });
-    });
-
-    App.HomeRoute = Route.extend({
-      queryParams: {
-        foo: {}
-      },
-      model() {
-        modelCount++;
-      }
-    });
-
-    App.HomeController = Controller.extend({
-      foo: emberA([1])
-    });
-
-    bootApplication();
-
-    equal(modelCount, 1);
-    let controller = container.lookup('controller:home');
-    setAndFlush(controller, 'model', emberA([1]));
-    equal(modelCount, 1);
-    equal(router.get('location.path'), '');
-  });
-
-  QUnit.test('A child of a resource route still defaults to parent route\'s model even if the child route has a query param when configuration occurs on the router', function() {
-    expect(1);
-
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        woot: {}
-      }
-    });
-
-    App.ApplicationRoute = Route.extend({
-      model(p, trans) {
-        return { woot: true };
-      }
-    });
-
-    App.IndexRoute = Route.extend({
-      setupController(controller, model) {
-        deepEqual(model, { woot: true }, 'index route inherited model route from parent route');
-      }
-    });
-
-    bootApplication();
-  });
-
-  QUnit.test('opting into replace does not affect transitions between routes when configuration occurs on the route', function() {
-    expect(5);
-    App.register('template:application', compile(
-      "{{link-to 'Foo' 'foo' id='foo-link'}}" +
-      "{{link-to 'Bar' 'bar' id='bar-no-qp-link'}}" +
-      "{{link-to 'Bar' 'bar' (query-params raytiley='isthebest') id='bar-link'}}" +
+  startingURL = '/?appomg=hello&omg=world';
+  bootApplication();
+});
+
+QUnit.test('queryParams are updated when a controller property is set and the route is refreshed. Issue #13263  ', function() {
+  setTemplates({
+    application: compile(
+      '<button id="test-button" {{action \'increment\'}}>Increment</button>' +
+      '<span id="test-value">{{foo}}</span>' +
       '{{outlet}}'
-    ));
-    App.Router.map(function() {
-      this.route('foo');
-      this.route('bar');
-    });
-
-    App.BarRoute = Route.extend({
-      queryParams: {
-        raytiley: {
-          replace: true,
-          defaultValue: 'israd'
-        }
+    )
+  });
+  App.ApplicationController = Controller.extend({
+    queryParams: ['foo'],
+    foo: 1,
+    actions: {
+      increment: function() {
+        this.incrementProperty('foo');
+        this.send('refreshRoute');
       }
-    });
-
-    bootApplication();
-    let controller = container.lookup('controller:bar');
-
-    expectedPushURL = '/foo';
-    run(jQuery('#foo-link'), 'click');
-
-    expectedPushURL = '/bar';
-    run(jQuery('#bar-no-qp-link'), 'click');
-
-    expectedReplaceURL = '/bar?raytiley=woot';
-    setAndFlush(controller, 'raytiley', 'woot');
-
-    expectedPushURL = '/foo';
-    run(jQuery('#foo-link'), 'click');
-
-    expectedPushURL = '/bar?raytiley=isthebest';
-    run(jQuery('#bar-link'), 'click');
+    }
   });
 
-  QUnit.test('Undefined isn\'t deserialized into a string when configuration occurs on the route', function() {
-    expect(3);
-    App.Router.map(function() {
-      this.route('example');
-    });
-
-    App.register('template:application', compile("{{link-to 'Example' 'example' id='the-link'}}"));
-
-    App.ExampleRoute = Route.extend({
-      queryParams: {
-        // uncommon to not support default value, but should assume undefined.
-        foo: {
-          defaultValue: undefined
-        }
-      },
-      model(params) {
-        deepEqual(params, { foo: undefined });
+  App.ApplicationRoute = Route.extend({
+    actions: {
+      refreshRoute: function() {
+        this.refresh();
       }
-    });
-
-    bootApplication();
-
-    let $link = jQuery('#the-link');
-    equal($link.attr('href'), '/example');
-    run($link, 'click');
-
-    let controller = container.lookup('controller:example');
-    equal(get(controller, 'foo'), undefined);
+    }
   });
 
-  QUnit.test('query params have been set by the time setupController is called when configuration occurs on the router', function() {
-    expect(1);
+  startingURL = '/';
+  bootApplication();
+  equal(jQuery('#test-value').text().trim(), '1');
+  equal(router.get('location.path'), '/', 'url is correct');
+  run(jQuery('#test-button'), 'click');
+  equal(jQuery('#test-value').text().trim(), '2');
+  equal(router.get('location.path'), '/?foo=2', 'url is correct');
+  run(jQuery('#test-button'), 'click');
+  equal(jQuery('#test-value').text().trim(), '3');
+  equal(router.get('location.path'), '/?foo=3', 'url is correct');
+});
 
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: 'wat'
-        }
-      },
-      setupController(controller) {
-        equal(controller.get('foo'), 'YEAH', 'controller\'s foo QP property set before setupController called');
-      }
-    });
-
-    startingURL = '/?foo=YEAH';
-    bootApplication();
+QUnit.test('Use Ember.get to retrieve query params \'refreshModel\' configuration', function() {
+  expect(6);
+  App.ApplicationController = Controller.extend({
+    queryParams: ['appomg'],
+    appomg: 'applol'
   });
 
-  QUnit.test('query params have been set by the time setupController is called when configuration occurs on the router and there is still a controller', function() {
-    expect(1);
-
-    App.ApplicationController = Controller.extend();
-
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: 'wat'
-        }
-      },
-      setupController(controller) {
-        equal(controller.get('foo'), 'YEAH', 'controller\'s foo QP property set before setupController called');
-      }
-    });
-
-    startingURL = '/?foo=YEAH';
-    bootApplication();
+  App.IndexController = Controller.extend({
+    queryParams: ['omg'],
+    omg: 'lol'
   });
 
-  QUnit.test('model hooks receives query params when configured on the route', function() {
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        omg: {
-          defaultValue: 'lol'
-        }
-      },
-      model(params) {
+  let appModelCount = 0;
+  App.ApplicationRoute = Route.extend({
+    model(params) {
+      appModelCount++;
+    }
+  });
+
+  let indexModelCount = 0;
+  App.IndexRoute = Route.extend({
+    queryParams: EmberObject.create({
+      unknownProperty(keyName) {
+        return { refreshModel: true };
+      }
+    }),
+    model(params) {
+      indexModelCount++;
+
+      if (indexModelCount === 1) {
         deepEqual(params, { omg: 'lol' });
+      } else if (indexModelCount === 2) {
+        deepEqual(params, { omg: 'lex' });
       }
-    });
-
-    bootApplication();
-
-    equal(router.get('location.path'), '');
+    }
   });
 
-  QUnit.test('Routes have overridable serializeQueryParamKey hook when configured on the route', function() {
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        funTimes: {
-          defaultValue: ''
-        }
+  bootApplication();
+
+  equal(appModelCount, 1);
+  equal(indexModelCount, 1);
+
+  let indexController = container.lookup('controller:index');
+  setAndFlush(indexController, 'omg', 'lex');
+
+  equal(appModelCount, 1);
+  equal(indexModelCount, 2);
+});
+
+QUnit.test('can use refreshModel even w URL changes that remove QPs from address bar', function() {
+  expect(4);
+
+  App.IndexController = Controller.extend({
+    queryParams: ['omg'],
+    omg: 'lol'
+  });
+
+  let indexModelCount = 0;
+  App.IndexRoute = Route.extend({
+    queryParams: {
+      omg: {
+        refreshModel: true
+      }
+    },
+    model(params) {
+      indexModelCount++;
+
+      let data;
+      if (indexModelCount === 1) {
+        data = 'foo';
+      } else if (indexModelCount === 2) {
+        data = 'lol';
+      }
+
+      deepEqual(params, { omg: data }, 'index#model receives right data');
+    }
+  });
+
+  startingURL = '/?omg=foo';
+  bootApplication();
+  handleURL('/');
+
+  let indexController = container.lookup('controller:index');
+  equal(indexController.get('omg'), 'lol');
+});
+
+QUnit.test('can opt into a replace query by specifying replace:true in the Router config hash', function() {
+  expect(2);
+  App.ApplicationController = Controller.extend({
+    queryParams: ['alex'],
+    alex: 'matchneer'
+  });
+
+  App.ApplicationRoute = Route.extend({
+    queryParams: {
+      alex: {
+        replace: true
+      }
+    }
+  });
+
+  bootApplication();
+
+  equal(router.get('location.path'), '');
+
+  let appController = container.lookup('controller:application');
+  expectedReplaceURL = '/?alex=wallace';
+  setAndFlush(appController, 'alex', 'wallace');
+});
+
+QUnit.test('Route query params config can be configured using property name instead of URL key', function() {
+  expect(2);
+  App.ApplicationController = Controller.extend({
+    queryParams: [
+      { commitBy: 'commit_by' }
+    ]
+  });
+
+  App.ApplicationRoute = Route.extend({
+    queryParams: {
+      commitBy: {
+        replace: true
+      }
+    }
+  });
+
+  bootApplication();
+
+  equal(router.get('location.path'), '');
+
+  let appController = container.lookup('controller:application');
+  expectedReplaceURL = '/?commit_by=igor_seb';
+  setAndFlush(appController, 'commitBy', 'igor_seb');
+});
+
+
+QUnit.test('An explicit replace:false on a changed QP always wins and causes a pushState', function() {
+  expect(3);
+  App.ApplicationController = Controller.extend({
+    queryParams: ['alex', 'steely'],
+    alex: 'matchneer',
+    steely: 'dan'
+  });
+
+  App.ApplicationRoute = Route.extend({
+    queryParams: {
+      alex: {
+        replace: true
       },
-      serializeQueryParamKey: StringUtils.dasherize
-    });
-
-    bootApplication();
-    equal(router.get('location.path'), '');
-
-    let controller = container.lookup('controller:index');
-    setAndFlush(controller, 'funTimes', 'woot');
-
-    equal(router.get('location.path'), '/?fun-times=woot');
-  });
-
-  QUnit.test('No replaceURL occurs on startup because default values don\'t show up in URL when configured on the route', function() {
-    expect(0);
-
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: '123'
-        }
+      steely: {
+        replace: false
       }
-    });
-
-    expectedReplaceURL = '/?foo=123';
-
-    bootApplication();
+    }
   });
-
-  QUnit.test("controllers won't be eagerly instantiated by internal query params logic when configured on the route", function() {
-    expect(10);
-    App.Router.map(function() {
-      this.route('cats', function() {
-        this.route('index', { path: '/' });
-      });
-      this.route('home', { path: '/' });
-      this.route('about');
-    });
-
-    App.register('template:home',       compile("<h3>{{link-to 'About' 'about' (query-params lol='wat') id='link-to-about'}}</h3>"));
-    App.register('template:about',      compile("<h3>{{link-to 'Home' 'home'  (query-params foo='naw')}}</h3>"));
-    App.register('template:cats.index', compile("<h3>{{link-to 'Cats' 'cats'  (query-params name='domino') id='cats-link'}}</h3>"));
-
-    let homeShouldBeCreated = false;
-    let aboutShouldBeCreated = false;
-    let catsIndexShouldBeCreated = false;
-
-    App.HomeRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: '123'
-        }
-      },
-      setup() {
-        homeShouldBeCreated = true;
-        this._super(...arguments);
-      }
-    });
-
-    App.HomeController = Controller.extend({
-      init() {
-        this._super(...arguments);
-        ok(homeShouldBeCreated, 'HomeController should be created at this time');
-      }
-    });
-
-    App.AboutRoute = Route.extend({
-      queryParams: {
-        lol: {
-          defaultValue: 'haha'
-        }
-      },
-      setup() {
-        aboutShouldBeCreated = true;
-        this._super(...arguments);
-      }
-    });
-
-    App.AboutController = Controller.extend({
-      init() {
-        this._super(...arguments);
-        ok(aboutShouldBeCreated, 'AboutController should be created at this time');
-      }
-    });
-
-    App.CatsIndexRoute = Route.extend({
-      queryParams: {
-        breed: {
-          defaultValue: 'Golden'
-        },
-        name: {
-          defaultValue: null
-        }
-      },
-      model() {
-        return [];
-      },
-      setup() {
-        catsIndexShouldBeCreated = true;
-        this._super(...arguments);
-      },
-      setupController(controller, context) {
-        controller.set('model', context);
-      }
-    });
-
-    App.CatsIndexController = Controller.extend({
-      init() {
-        this._super(...arguments);
-        ok(catsIndexShouldBeCreated, 'CatsIndexController should be created at this time');
-      }
-    });
 
-    bootApplication();
+  bootApplication();
 
-    equal(router.get('location.path'), '', 'url is correct');
-    let controller = container.lookup('controller:home');
-    setAndFlush(controller, 'foo', '456');
-    equal(router.get('location.path'), '/?foo=456', 'url is correct');
-    equal(jQuery('#link-to-about').attr('href'), '/about?lol=wat', 'link to about is correct');
+  let appController = container.lookup('controller:application');
+  expectedPushURL = '/?alex=wallace&steely=jan';
+  run(appController, 'setProperties', { alex: 'wallace', steely: 'jan' });
 
-    run(router, 'transitionTo', 'about');
-    equal(router.get('location.path'), '/about', 'url is correct');
+  expectedPushURL = '/?alex=wallace&steely=fran';
+  run(appController, 'setProperties', { steely: 'fran' });
 
-    run(router, 'transitionTo', 'cats');
+  expectedReplaceURL = '/?alex=sriracha&steely=fran';
+  run(appController, 'setProperties', { alex: 'sriracha' });
+});
 
-    equal(router.get('location.path'), '/cats', 'url is correct');
-    equal(jQuery('#cats-link').attr('href'), '/cats?name=domino', 'link to cats is correct');
-    run(jQuery('#cats-link'), 'click');
-    equal(router.get('location.path'), '/cats?name=domino', 'url is correct');
-  });
+QUnit.test('can opt into full transition by setting refreshModel in route queryParams when transitioning from child to parent', function() {
+  App.register('template:parent', compile('{{outlet}}'));
+  App.register('template:parent.child', compile('{{link-to \'Parent\' \'parent\' (query-params foo=\'change\') id=\'parent-link\'}}'));
 
-  QUnit.test('query params have been set by the time setupController is called when configured on the route', function() {
-    expect(1);
-
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: 'wat'
-        }
-      },
-      setupController(controller) {
-        equal(controller.get('foo'), 'YEAH', 'controller\'s foo QP property set before setupController called');
-      }
+  App.Router.map(function() {
+    this.route('parent', function() {
+      this.route('child');
     });
-
-    startingURL = '/?foo=YEAH';
-    bootApplication();
   });
 
-  QUnit.test('model hooks receives query params (overridden by incoming url value) when configured on the route', function() {
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        omg: {
-          defaultValue: 'lol'
-        }
-      },
-      model(params) {
-        deepEqual(params, { omg: 'yes' });
+  let parentModelCount = 0;
+  App.ParentRoute = Route.extend({
+    model() {
+      parentModelCount++;
+    },
+    queryParams: {
+      foo: {
+        refreshModel: true
       }
-    });
-
-    startingURL = '/?omg=yes';
-    bootApplication();
-
-    equal(router.get('location.path'), '/?omg=yes');
+    }
   });
-
-  QUnit.test('Route#paramsFor fetches query params when configured on the route', function() {
-    expect(1);
-
-    App.Router.map(function() {
-      this.route('index', { path: '/:something' });
-    });
-
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: 'fooapp'
-        }
-      },
-      model(params, transition) {
-        deepEqual(this.paramsFor('index'), { something: 'omg', foo: 'fooapp' }, 'could retrieve params for index');
-      }
-    });
 
-    startingURL = '/omg';
-    bootApplication();
+  App.ParentController = Controller.extend({
+    queryParams: ['foo'],
+    foo: 'abc'
   });
 
-  QUnit.test('model hook can query prefix-less application params (overridden by incoming url value) when they\'re configured on the route', function() {
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        appomg: {
-          defaultValue: 'applol'
-        }
-      },
-      model(params) {
-        deepEqual(params, { appomg: 'appyes' });
-      }
-    });
+  startingURL = '/parent/child?foo=lol';
+  bootApplication();
 
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        omg: {
-          defaultValue: 'lol'
-        }
-      },
-      model(params) {
-        deepEqual(params, { omg: 'yes' });
-        deepEqual(this.paramsFor('application'), { appomg: 'appyes' });
-      }
-    });
+  equal(parentModelCount, 1);
 
-    startingURL = '/?appomg=appyes&omg=yes';
-    bootApplication();
+  container.lookup('controller:parent');
 
-    equal(router.get('location.path'), '/?appomg=appyes&omg=yes');
-  });
+  run(jQuery('#parent-link'), 'click');
 
-  QUnit.test('Route#paramsFor fetches falsy query params when configured on the route', function() {
-    expect(1);
-
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: true
-        }
-      },
-      model(params, transition) {
-        equal(params.foo, false);
-      }
-    });
+  equal(parentModelCount, 2);
+});
 
-    startingURL = '/?foo=false';
-    bootApplication();
+QUnit.test('Use Ember.get to retrieve query params \'replace\' configuration', function() {
+  expect(2);
+  App.ApplicationController = Controller.extend({
+    queryParams: ['alex'],
+    alex: 'matchneer'
   });
 
-  QUnit.test('model hook can query prefix-less application params when configured on the route', function() {
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        appomg: {
-          defaultValue: 'applol'
-        }
-      },
-      model(params) {
-        deepEqual(params, { appomg: 'applol' });
+  App.ApplicationRoute = Route.extend({
+    queryParams: EmberObject.create({
+      unknownProperty(keyName) {
+        // We are simulating all qps requiring refresh
+        return { replace: true };
       }
-    });
-
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        omg: {
-          defaultValue: 'lol'
-        }
-      },
-      model(params) {
-        deepEqual(params, { omg: 'lol' });
-        deepEqual(this.paramsFor('application'), { appomg: 'applol' });
-      }
-    });
-
-    bootApplication();
-
-    equal(router.get('location.path'), '');
+    })
   });
-
-  QUnit.test('can opt into full transition by setting refreshModel in route queryParams when configured on the route', function() {
-    expect(6);
-
-    let appModelCount = 0;
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        'appomg': {
-          defaultValue: 'applol'
-        }
-      },
-      model(params) {
-        appModelCount++;
-      }
-    });
 
-    let indexModelCount = 0;
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        omg: {
-          defaultValue: 'lol',
-          refreshModel: true
-        }
-      },
-      model(params) {
-        indexModelCount++;
-
-        if (indexModelCount === 1) {
-          deepEqual(params, { omg: 'lol' });
-        } else if (indexModelCount === 2) {
-          deepEqual(params, { omg: 'lex' });
-        }
-      }
-    });
+  bootApplication();
 
-    bootApplication();
+  equal(router.get('location.path'), '');
 
-    equal(appModelCount, 1);
-    equal(indexModelCount, 1);
+  let appController = container.lookup('controller:application');
+  expectedReplaceURL = '/?alex=wallace';
+  setAndFlush(appController, 'alex', 'wallace');
+});
 
-    let indexController = container.lookup('controller:index');
-    setAndFlush(indexController, 'omg', 'lex');
+QUnit.test('can override incoming QP values in setupController', function() {
+  expect(3);
 
-    equal(appModelCount, 1);
-    equal(indexModelCount, 2);
+  App.Router.map(function() {
+    this.route('about');
   });
-
-
-  QUnit.test('can use refreshModel even w URL changes that remove QPs from address bar when configured on the route', function() {
-    expect(4);
-
-    let indexModelCount = 0;
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        omg: {
-          refreshModel: true,
-          defaultValue: 'lol'
-        }
-      },
-      model(params) {
-        indexModelCount++;
-
-        let data;
-        if (indexModelCount === 1) {
-          data = 'foo';
-        } else if (indexModelCount === 2) {
-          data = 'lol';
-        }
-
-        deepEqual(params, { omg: data }, 'index#model receives right data');
-      }
-    });
-
-    startingURL = '/?omg=foo';
-    bootApplication();
-    handleURL('/');
 
-    let indexController = container.lookup('controller:index');
-    equal(indexController.get('omg'), 'lol');
+  App.IndexController = Controller.extend({
+    queryParams: ['omg'],
+    omg: 'lol'
   });
 
-  QUnit.test('can opt into a replace query by specifying replace:true in the Router config hash when configured on the route', function() {
-    expect(2);
-
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        alex: {
-          defaultValue: 'matchneer',
-          replace: true
-        }
+  App.IndexRoute = Route.extend({
+    setupController(controller) {
+      ok(true, 'setupController called');
+      controller.set('omg', 'OVERRIDE');
+    },
+    actions: {
+      queryParamsDidChange() {
+        ok(false, 'queryParamsDidChange shouldn\'t fire');
       }
-    });
-
-    bootApplication();
-
-    equal(router.get('location.path'), '');
-
-    let appController = container.lookup('controller:application');
-    expectedReplaceURL = '/?alex=wallace';
-    setAndFlush(appController, 'alex', 'wallace');
+    }
   });
 
-  QUnit.test('Route query params config can be configured using property name instead of URL key when configured on the route', function() {
-    expect(2);
-
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        commitBy: {
-          as: 'commit_by',
-          replace: true
-        }
-      }
-    });
+  startingURL = '/about';
+  bootApplication();
+  equal(router.get('location.path'), '/about');
+  run(router, 'transitionTo', 'index');
+  equal(router.get('location.path'), '/?omg=OVERRIDE');
+});
 
-    bootApplication();
+QUnit.test('can override incoming QP array values in setupController', function() {
+  expect(3);
 
-    equal(router.get('location.path'), '');
-
-    let appController = container.lookup('controller:application');
-    expectedReplaceURL = '/?commit_by=igor_seb';
-    setAndFlush(appController, 'commitBy', 'igor_seb');
+  App.Router.map(function() {
+    this.route('about');
   });
-
-  QUnit.test('An explicit replace:false on a changed QP always wins and causes a pushState when configured on the route', function() {
-    expect(3);
-
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        alex: {
-          replace: true,
-          defaultValue: 'matchneer'
-        },
-        steely: {
-          defaultValue: 'dan',
-          replace: false
-        }
-      }
-    });
-
-    bootApplication();
-
-    let appController = container.lookup('controller:application');
-    expectedPushURL = '/?alex=wallace&steely=jan';
-    run(appController, 'setProperties', { alex: 'wallace', steely: 'jan' });
 
-    expectedPushURL = '/?alex=wallace&steely=fran';
-    run(appController, 'setProperties', { steely: 'fran' });
-
-    expectedReplaceURL = '/?alex=sriracha&steely=fran';
-    run(appController, 'setProperties', { alex: 'sriracha' });
+  App.IndexController = Controller.extend({
+    queryParams: ['omg'],
+    omg: ['lol']
   });
-
-  QUnit.test('can opt into full transition by setting refreshModel in route queryParams when transitioning from child to parent when configured on the route', function() {
-    App.register('template:parent', compile('{{outlet}}'));
-    App.register('template:parent.child', compile("{{link-to 'Parent' 'parent' (query-params foo='change') id='parent-link'}}"));
-
-    App.Router.map(function() {
-      this.route('parent', function() {
-        this.route('child');
-      });
-    });
 
-    let parentModelCount = 0;
-    App.ParentRoute = Route.extend({
-      model() {
-        parentModelCount++;
-      },
-      queryParams: {
-        foo: {
-          refreshModel: true,
-          defaultValue: 'abc'
-        }
+  App.IndexRoute = Route.extend({
+    setupController(controller) {
+      ok(true, 'setupController called');
+      controller.set('omg', ['OVERRIDE']);
+    },
+    actions: {
+      queryParamsDidChange() {
+        ok(false, 'queryParamsDidChange shouldn\'t fire');
       }
-    });
-
-    startingURL = '/parent/child?foo=lol';
-    bootApplication();
-
-    equal(parentModelCount, 1);
+    }
+  });
 
-    container.lookup('controller:parent');
+  startingURL = '/about';
+  bootApplication();
+  equal(router.get('location.path'), '/about');
+  run(router, 'transitionTo', 'index');
+  equal(router.get('location.path'), '/?omg=' + encodeURIComponent(JSON.stringify(['OVERRIDE'])));
+});
 
-    run(jQuery('#parent-link'), 'click');
+QUnit.test('URL transitions that remove QPs still register as QP changes', function() {
+  expect(2);
 
-    equal(parentModelCount, 2);
+  App.IndexController = Controller.extend({
+    queryParams: ['omg'],
+    omg: 'lol'
   });
 
-  QUnit.test('can override incoming QP values in setupController when configured on the route', function() {
-    expect(3);
+  startingURL = '/?omg=borf';
+  bootApplication();
 
-    App.Router.map(function() {
-      this.route('about');
-    });
+  let indexController = container.lookup('controller:index');
+  equal(indexController.get('omg'), 'borf');
+  run(router, 'transitionTo', '/');
+  equal(indexController.get('omg'), 'lol');
+});
 
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        omg: {
-          defaultValue: 'lol'
-        }
-      },
-      setupController(controller) {
-        ok(true, 'setupController called');
-        controller.set('omg', 'OVERRIDE');
-      },
-      actions: {
-        queryParamsDidChange() {
-          ok(false, 'queryParamsDidChange shouldn\'t fire');
-        }
-      }
+QUnit.test('Subresource naming style is supported', function() {
+  App.Router.map(function() {
+    this.route('abc.def', { path: '/abcdef' }, function() {
+      this.route('zoo');
     });
-
-    startingURL = '/about';
-    bootApplication();
-    equal(router.get('location.path'), '/about');
-    run(router, 'transitionTo', 'index');
-    equal(router.get('location.path'), '/?omg=OVERRIDE');
   });
 
-  QUnit.test('can override incoming QP array values in setupController when configured on the route', function() {
-    expect(3);
-
-    App.Router.map(function() {
-      this.route('about');
-    });
+  App.register('template:application', compile('{{link-to \'A\' \'abc.def\' (query-params foo=\'123\') id=\'one\'}}{{link-to \'B\' \'abc.def.zoo\' (query-params foo=\'123\' bar=\'456\') id=\'two\'}}{{outlet}}'));
 
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        omg: {
-          defaultValue: ['lol']
-        }
-      },
-      setupController(controller) {
-        ok(true, 'setupController called');
-        controller.set('omg', ['OVERRIDE']);
-      },
-      actions: {
-        queryParamsDidChange() {
-          ok(false, 'queryParamsDidChange shouldn\'t fire');
-        }
-      }
-    });
+  App.AbcDefController = Controller.extend({
+    queryParams: ['foo'],
+    foo: 'lol'
+  });
 
-    startingURL = '/about';
-    bootApplication();
-    equal(router.get('location.path'), '/about');
-    run(router, 'transitionTo', 'index');
-    equal(router.get('location.path'), '/?omg=' + encodeURIComponent(JSON.stringify(['OVERRIDE'])));
+  App.AbcDefZooController = Controller.extend({
+    queryParams: ['bar'],
+    bar: 'haha'
   });
 
-  QUnit.test('URL transitions that remove QPs still register as QP changes when configured on the route', function() {
-    expect(2);
-
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        omg: {
-          defaultValue: 'lol'
-        }
-      }
-    });
+  bootApplication();
+  equal(router.get('location.path'), '');
+  equal(jQuery('#one').attr('href'), '/abcdef?foo=123');
+  equal(jQuery('#two').attr('href'), '/abcdef/zoo?bar=456&foo=123');
 
-    startingURL = '/?omg=borf';
-    bootApplication();
+  run(jQuery('#one'), 'click');
+  equal(router.get('location.path'), '/abcdef?foo=123');
+  run(jQuery('#two'), 'click');
+  equal(router.get('location.path'), '/abcdef/zoo?bar=456&foo=123');
+});
 
-    let indexController = container.lookup('controller:index');
-    equal(indexController.get('omg'), 'borf');
-    run(router, 'transitionTo', '/');
-    equal(indexController.get('omg'), 'lol');
+QUnit.test('transitionTo supports query params', function() {
+  App.IndexController = Controller.extend({
+    queryParams: ['foo'],
+    foo: 'lol'
   });
-
-  QUnit.test('Subresource naming style is supported when configured on the route', function() {
-    App.Router.map(function() {
-      this.route('abc.def', { path: '/abcdef' }, function() {
-        this.route('zoo');
-      });
-    });
 
-    App.register('template:application', compile("{{link-to 'A' 'abc.def' (query-params foo='123') id='one'}}{{link-to 'B' 'abc.def.zoo' (query-params foo='123' bar='456') id='two'}}{{outlet}}"));
+  bootApplication();
 
-    App.AbcDefRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: 'lol'
-        }
-      }
-    });
+  equal(router.get('location.path'), '');
 
-    App.AbcDefZooRoute = Route.extend({
-      queryParams: {
-        bar: {
-          defaultValue: 'haha'
-        }
-      }
-    });
+  run(router, 'transitionTo', { queryParams: { foo: 'borf' } });
+  equal(router.get('location.path'), '/?foo=borf', 'shorthand supported');
+  run(router, 'transitionTo', { queryParams: { 'index:foo': 'blaf' } });
+  equal(router.get('location.path'), '/?foo=blaf', 'longform supported');
+  run(router, 'transitionTo', { queryParams: { 'index:foo': false } });
+  equal(router.get('location.path'), '/?foo=false', 'longform supported (bool)');
+  run(router, 'transitionTo', { queryParams: { foo: false } });
+  equal(router.get('location.path'), '/?foo=false', 'shorhand supported (bool)');
+});
 
-    bootApplication();
-    equal(router.get('location.path'), '');
-    equal(jQuery('#one').attr('href'), '/abcdef?foo=123');
-    equal(jQuery('#two').attr('href'), '/abcdef/zoo?bar=456&foo=123');
-
-    run(jQuery('#one'), 'click');
-    equal(router.get('location.path'), '/abcdef?foo=123');
-    run(jQuery('#two'), 'click');
-    equal(router.get('location.path'), '/abcdef/zoo?bar=456&foo=123');
+QUnit.test('transitionTo supports query params (multiple)', function() {
+  App.IndexController = Controller.extend({
+    queryParams: ['foo', 'bar'],
+    foo: 'lol',
+    bar: 'wat'
   });
 
-  QUnit.test('transitionTo supports query params when configured on the route', function() {
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: 'lol'
-        }
-      }
-    });
+  bootApplication();
 
-    bootApplication();
-
-    equal(router.get('location.path'), '');
-
-    run(router, 'transitionTo', { queryParams: { foo: 'borf' } });
-    equal(router.get('location.path'), '/?foo=borf', 'shorthand supported');
-    run(router, 'transitionTo', { queryParams: { 'index:foo': 'blaf' } });
-    equal(router.get('location.path'), '/?foo=blaf', 'longform supported');
-    run(router, 'transitionTo', { queryParams: { 'index:foo': false } });
-    equal(router.get('location.path'), '/?foo=false', 'longform supported (bool)');
-    run(router, 'transitionTo', { queryParams: { foo: false } });
-    equal(router.get('location.path'), '/?foo=false', 'shorhand supported (bool)');
-  });
+  equal(router.get('location.path'), '');
 
-  QUnit.test('transitionTo supports query params (multiple) when configured on the route', function() {
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: 'lol'
-        },
-        bar: {
-          defaultValue: 'wat'
-        }
-      }
-    });
+  run(router, 'transitionTo', { queryParams: { foo: 'borf' } });
+  equal(router.get('location.path'), '/?foo=borf', 'shorthand supported');
+  run(router, 'transitionTo', { queryParams: { 'index:foo': 'blaf' } });
+  equal(router.get('location.path'), '/?foo=blaf', 'longform supported');
+  run(router, 'transitionTo', { queryParams: { 'index:foo': false } });
+  equal(router.get('location.path'), '/?foo=false', 'longform supported (bool)');
+  run(router, 'transitionTo', { queryParams: { foo: false } });
+  equal(router.get('location.path'), '/?foo=false', 'shorhand supported (bool)');
+});
 
-    bootApplication();
-
-    equal(router.get('location.path'), '');
-
-    run(router, 'transitionTo', { queryParams: { foo: 'borf' } });
-    equal(router.get('location.path'), '/?foo=borf', 'shorthand supported');
-    run(router, 'transitionTo', { queryParams: { 'index:foo': 'blaf' } });
-    equal(router.get('location.path'), '/?foo=blaf', 'longform supported');
-    run(router, 'transitionTo', { queryParams: { 'index:foo': false } });
-    equal(router.get('location.path'), '/?foo=false', 'longform supported (bool)');
-    run(router, 'transitionTo', { queryParams: { foo: false } });
-    equal(router.get('location.path'), '/?foo=false', 'shorhand supported (bool)');
+QUnit.test('setting controller QP to empty string doesn\'t generate null in URL', function() {
+  expect(1);
+  App.IndexController = Controller.extend({
+    queryParams: ['foo'],
+    foo: '123'
   });
 
-  QUnit.test('setting controller QP to empty string doesn\'t generate null in URL when configured on the route', function() {
-    expect(1);
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: '123'
-        }
-      }
-    });
+  bootApplication();
+  let controller = container.lookup('controller:index');
 
-    bootApplication();
-    let controller = container.lookup('controller:index');
-
-    expectedPushURL = '/?foo=';
-    setAndFlush(controller, 'foo', '');
-  });
+  expectedPushURL = '/?foo=';
+  setAndFlush(controller, 'foo', '');
+});
 
-  QUnit.test('setting QP to empty string doesn\'t generate null in URL when configured on the route', function() {
-    expect(1);
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: '123'
-        }
+QUnit.test('setting QP to empty string doesn\'t generate null in URL', function() {
+  expect(1);
+  App.IndexRoute = Route.extend({
+    queryParams: {
+      foo: {
+        defaultValue: '123'
       }
-    });
-
-    bootApplication();
-    let controller = container.lookup('controller:index');
-
-    expectedPushURL = '/?foo=';
-    setAndFlush(controller, 'foo', '');
+    }
   });
-
-  QUnit.test('A default boolean value deserializes QPs as booleans rather than strings when configured on the route', function() {
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: false
-        }
-      },
-      model(params) {
-        equal(params.foo, true, 'model hook received foo as boolean true');
-      }
-    });
 
-    startingURL = '/?foo=true';
-    bootApplication();
+  bootApplication();
+  let controller = container.lookup('controller:index');
 
-    let controller = container.lookup('controller:index');
-    equal(controller.get('foo'), true);
+  expectedPushURL = '/?foo=';
+  setAndFlush(controller, 'foo', '');
+});
 
-    handleURL('/?foo=false');
-    equal(controller.get('foo'), false);
+QUnit.test('A default boolean value deserializes QPs as booleans rather than strings', function() {
+  App.IndexController = Controller.extend({
+    queryParams: ['foo'],
+    foo: false
   });
-
-  QUnit.test('Query param without value are empty string when configured on the route', function() {
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: ''
-        }
-      }
-    });
-
-    startingURL = '/?foo=';
-    bootApplication();
 
-    let controller = container.lookup('controller:index');
-    equal(controller.get('foo'), '');
+  App.IndexRoute = Route.extend({
+    model(params) {
+      equal(params.foo, true, 'model hook received foo as boolean true');
+    }
   });
-
-  QUnit.test('Array query params can be set when configured on the route', function() {
-    App.Router.map(function() {
-      this.route('home', { path: '/' });
-    });
 
-    App.HomeRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: []
-        }
-      }
-    });
-
-    bootApplication();
-
-    let controller = container.lookup('controller:home');
+  startingURL = '/?foo=true';
+  bootApplication();
 
-    setAndFlush(controller, 'foo', [1, 2]);
+  let controller = container.lookup('controller:index');
+  equal(controller.get('foo'), true);
 
-    equal(router.get('location.path'), '/?foo=%5B1%2C2%5D');
+  handleURL('/?foo=false');
+  equal(controller.get('foo'), false);
+});
 
-    setAndFlush(controller, 'foo', [3, 4]);
-    equal(router.get('location.path'), '/?foo=%5B3%2C4%5D');
+QUnit.test('Query param without value are empty string', function() {
+  App.IndexController = Controller.extend({
+    queryParams: ['foo'],
+    foo: ''
   });
 
-  QUnit.test('(de)serialization: arrays when configured on the route', function() {
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: [1]
-        }
-      }
-    });
+  startingURL = '/?foo=';
+  bootApplication();
 
-    bootApplication();
+  let controller = container.lookup('controller:index');
+  equal(controller.get('foo'), '');
+});
 
-    equal(router.get('location.path'), '');
-
-    run(router, 'transitionTo', { queryParams: { foo: [2, 3] } });
-    equal(router.get('location.path'), '/?foo=%5B2%2C3%5D', 'shorthand supported');
-    run(router, 'transitionTo', { queryParams: { 'index:foo': [4, 5] } });
-    equal(router.get('location.path'), '/?foo=%5B4%2C5%5D', 'longform supported');
-    run(router, 'transitionTo', { queryParams: { foo: [] } });
-    equal(router.get('location.path'), '/?foo=%5B%5D', 'longform supported');
+QUnit.test('Array query params can be set', function() {
+  App.Router.map(function() {
+    this.route('home', { path: '/' });
   });
-
-  QUnit.test('Url with array query param sets controller property to array when configured on the route', function() {
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: ''
-        }
-      }
-    });
 
-    startingURL = '/?foo[]=1&foo[]=2&foo[]=3';
-    bootApplication();
-
-    let controller = container.lookup('controller:index');
-    deepEqual(controller.get('foo'), ['1', '2', '3']);
+  App.HomeController = Controller.extend({
+    queryParams: ['foo'],
+    foo: []
   });
-
-  QUnit.test('Array query params can be pushed/popped when configured on the route', function() {
-    App.Router.map(function() {
-      this.route('home', { path: '/' });
-    });
-
-    App.HomeRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: emberA()
-        }
-      }
-    });
 
-    bootApplication();
-
-    equal(router.get('location.path'), '');
-
-    let controller = container.lookup('controller:home');
-
-    run(controller.foo, 'pushObject', 1);
-    equal(router.get('location.path'), '/?foo=%5B1%5D');
-    deepEqual(controller.foo, [1]);
-    run(controller.foo, 'popObject');
-    equal(router.get('location.path'), '/');
-    deepEqual(controller.foo, []);
-    run(controller.foo, 'pushObject', 1);
-    equal(router.get('location.path'), '/?foo=%5B1%5D');
-    deepEqual(controller.foo, [1]);
-    run(controller.foo, 'popObject');
-    equal(router.get('location.path'), '/');
-    deepEqual(controller.foo, []);
-    run(controller.foo, 'pushObject', 1);
-    equal(router.get('location.path'), '/?foo=%5B1%5D');
-    deepEqual(controller.foo, [1]);
-    run(controller.foo, 'pushObject', 2);
-    equal(router.get('location.path'), '/?foo=%5B1%2C2%5D');
-    deepEqual(controller.foo, [1, 2]);
-    run(controller.foo, 'popObject');
-    equal(router.get('location.path'), '/?foo=%5B1%5D');
-    deepEqual(controller.foo, [1]);
-    run(controller.foo, 'unshiftObject', 'lol');
-    equal(router.get('location.path'), '/?foo=%5B%22lol%22%2C1%5D');
-    deepEqual(controller.foo, ['lol', 1]);
-  });
+  bootApplication();
 
-  QUnit.test('Overwriting with array with same content shouldn\'t refire update when configured on the route', function() {
-    expect(3);
-    let modelCount = 0;
+  let controller = container.lookup('controller:home');
 
-    App.Router.map(function() {
-      this.route('home', { path: '/' });
-    });
+  setAndFlush(controller, 'foo', [1, 2]);
 
-    App.HomeRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: emberA([1])
-        }
-      },
-      model() {
-        modelCount++;
-      }
-    });
+  equal(router.get('location.path'), '/?foo=%5B1%2C2%5D');
 
-    bootApplication();
+  setAndFlush(controller, 'foo', [3, 4]);
+  equal(router.get('location.path'), '/?foo=%5B3%2C4%5D');
+});
 
-    equal(modelCount, 1);
-    let controller = container.lookup('controller:home');
-    setAndFlush(controller, 'model', emberA([1]));
-    equal(modelCount, 1);
-    equal(router.get('location.path'), '');
+QUnit.test('(de)serialization: arrays', function() {
+  App.IndexController = Controller.extend({
+    queryParams: ['foo'],
+    foo: [1]
   });
 
-  QUnit.test('Defaulting to params hash as the model should not result in that params object being watched when configured on the route', function() {
-    expect(1);
-
-    App.Router.map(function() {
-      this.route('other');
-    });
-
-    // This causes the params hash, which is returned as a route's
-    // model if no other model could be resolved given the provided
-    // params (and no custom model hook was defined), to be watched,
-    // unless we return a copy of the params hash.
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        woot: {
-          defaultValue: 'wat'
-        }
-      }
-    });
+  bootApplication();
 
-    App.OtherRoute = Route.extend({
-      model(p, trans) {
-        let m = meta(trans.params.application);
-        ok(!m.peekWatching('woot'), 'A meta object isn\'t constructed for this params POJO');
-      }
-    });
+  equal(router.get('location.path'), '');
 
-    bootApplication();
+  run(router, 'transitionTo', { queryParams: { foo: [2, 3] } });
+  equal(router.get('location.path'), '/?foo=%5B2%2C3%5D', 'shorthand supported');
+  run(router, 'transitionTo', { queryParams: { 'index:foo': [4, 5] } });
+  equal(router.get('location.path'), '/?foo=%5B4%2C5%5D', 'longform supported');
+  run(router, 'transitionTo', { queryParams: { foo: [] } });
+  equal(router.get('location.path'), '/?foo=%5B%5D', 'longform supported');
+});
 
-    run(router, 'transitionTo', 'other');
+QUnit.test('Url with array query param sets controller property to array', function() {
+  App.IndexController = Controller.extend({
+    queryParams: ['foo'],
+    foo: ''
   });
-
-  QUnit.test('A child of a resource route still defaults to parent route\'s model even if the child route has a query param when configured on the route', function() {
-    expect(1);
 
-    App.ApplicationRoute = Route.extend({
-      model(p, trans) {
-        return { woot: true };
-      }
-    });
+  startingURL = '/?foo[]=1&foo[]=2&foo[]=3';
+  bootApplication();
 
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        woot: {
-          defaultValue: undefined
-        }
-      },
-      setupController(controller, model) {
-        deepEqual(model, { woot: true }, 'index route inherited model route from parent route');
-      }
-    });
+  let controller = container.lookup('controller:index');
+  deepEqual(controller.get('foo'), ['1', '2', '3']);
+});
 
-    bootApplication();
+QUnit.test('Array query params can be pushed/popped', function() {
+  App.Router.map(function() {
+    this.route('home', { path: '/' });
   });
 
-  QUnit.test('opting into replace does not affect transitions between routes when configured on route', function() {
-    expect(5);
-    App.register('template:application', compile(
-      "{{link-to 'Foo' 'foo' id='foo-link'}}" +
-      "{{link-to 'Bar' 'bar' id='bar-no-qp-link'}}" +
-      "{{link-to 'Bar' 'bar' (query-params raytiley='isthebest') id='bar-link'}}" +
-      '{{outlet}}'
-    ));
-    App.Router.map(function() {
-      this.route('foo');
-      this.route('bar');
-    });
-
-    App.BarRoute = Route.extend({
-      queryParams: {
-        raytiley: {
-          defaultValue: 'israd',
-          replace: true
-        }
-      }
-    });
+  App.HomeController = Controller.extend({
+    queryParams: ['foo'],
+    foo: emberA()
+  });
 
-    bootApplication();
-    let controller = container.lookup('controller:bar');
+  bootApplication();
 
-    expectedPushURL = '/foo';
-    run(jQuery('#foo-link'), 'click');
+  equal(router.get('location.path'), '');
 
-    expectedPushURL = '/bar';
-    run(jQuery('#bar-no-qp-link'), 'click');
+  let controller = container.lookup('controller:home');
 
-    expectedReplaceURL = '/bar?raytiley=woot';
-    setAndFlush(controller, 'raytiley', 'woot');
+  run(controller.foo, 'pushObject', 1);
+  equal(router.get('location.path'), '/?foo=%5B1%5D');
+  deepEqual(controller.foo, [1]);
+  run(controller.foo, 'popObject');
+  equal(router.get('location.path'), '/');
+  deepEqual(controller.foo, []);
+  run(controller.foo, 'pushObject', 1);
+  equal(router.get('location.path'), '/?foo=%5B1%5D');
+  deepEqual(controller.foo, [1]);
+  run(controller.foo, 'popObject');
+  equal(router.get('location.path'), '/');
+  deepEqual(controller.foo, []);
+  run(controller.foo, 'pushObject', 1);
+  equal(router.get('location.path'), '/?foo=%5B1%5D');
+  deepEqual(controller.foo, [1]);
+  run(controller.foo, 'pushObject', 2);
+  equal(router.get('location.path'), '/?foo=%5B1%2C2%5D');
+  deepEqual(controller.foo, [1, 2]);
+  run(controller.foo, 'popObject');
+  equal(router.get('location.path'), '/?foo=%5B1%5D');
+  deepEqual(controller.foo, [1]);
+  run(controller.foo, 'unshiftObject', 'lol');
+  equal(router.get('location.path'), '/?foo=%5B%22lol%22%2C1%5D');
+  deepEqual(controller.foo, ['lol', 1]);
+});
 
-    expectedPushURL = '/foo';
-    run(jQuery('#foo-link'), 'click');
+QUnit.test('Overwriting with array with same content shouldn\'t refire update', function() {
+  expect(3);
+  let modelCount = 0;
 
-    expectedPushURL = '/bar?raytiley=isthebest';
-    run(jQuery('#bar-link'), 'click');
+  App.Router.map(function() {
+    this.route('home', { path: '/' });
   });
-
-  QUnit.test('Undefined isn\'t deserialized into a string when configured on the route', function() {
-    expect(3);
-    App.Router.map(function() {
-      this.route('example');
-    });
-
-    App.register('template:application', compile("{{link-to 'Example' 'example' id='the-link'}}"));
-
-    App.ExampleRoute = Route.extend({
-      queryParams: {
-        // uncommon to not support default value, but should assume undefined.
-        foo: {}
-      },
-      model(params) {
-        deepEqual(params, { foo: undefined });
-      }
-    });
-
-    bootApplication();
-
-    let $link = jQuery('#the-link');
-    equal($link.attr('href'), '/example');
-    run($link, 'click');
 
-    let controller = container.lookup('controller:example');
-    equal(get(controller, 'foo'), undefined);
+  App.HomeRoute = Route.extend({
+    model() {
+      modelCount++;
+    }
   });
-
-  QUnit.test('Changing a query param property on a controller after navigating using a {{link-to}} should preserve the unchanged query params', function() {
-    expect(11);
-    App.Router.map(function() {
-      this.route('example');
-    });
-
-    App.register('template:application', compile(
-      "{{link-to 'Example' 'example' (query-params bar='abc' foo='def') id='the-link1'}}" +
-      "{{link-to 'Example' 'example' (query-params bar='123' foo='456') id='the-link2'}}"
-    ));
-
-    App.ExampleRoute = Route.extend({
-      queryParams: {
-        foo: { defaultValue: 'foo' },
-        bar: { defaultValue: 'bar' }
-      }
-    });
-
-    bootApplication();
-
-    let controller = container.lookup('controller:example');
-
-    let $link1 = jQuery('#the-link1');
-    let $link2 = jQuery('#the-link2');
-    equal($link1.attr('href'), '/example?bar=abc&foo=def');
-    equal($link2.attr('href'), '/example?bar=123&foo=456');
 
-    expectedPushURL = '/example?bar=abc&foo=def';
-    run($link1, 'click');
-    equal(get(controller, 'bar'), 'abc');
-    equal(get(controller, 'foo'), 'def');
-
-    expectedPushURL = '/example?bar=123&foo=456';
-    run($link2, 'click');
-    equal(get(controller, 'bar'), '123');
-    equal(get(controller, 'foo'), '456');
-
-    expectedPushURL = '/example?bar=rab&foo=456';
-    setAndFlush(controller, 'bar', 'rab');
-    equal(get(controller, 'bar'), 'rab');
-    equal(get(controller, 'foo'), '456');
+  App.HomeController = Controller.extend({
+    queryParams: ['foo'],
+    foo: emberA([1])
   });
-
-  QUnit.test('Calling transitionTo does not lose query params already on the activeTransition', function() {
-    expect(2);
-    App.Router.map(function() {
-      this.route('parent', function() {
-        this.route('child');
-        this.route('sibling');
-      });
-    });
 
-    App.ParentRoute = Route.extend({
-      queryParams: { foo: { defaultValue: 'bar' } }
-    });
-
-    App.ParentChildRoute = Route.extend({
-      afterModel: function() {
-        ok(true, 'The after model hook was called');
-        this.transitionTo('parent.sibling');
-      }
-    });
+  bootApplication();
 
-    startingURL = '/parent/child?foo=lol';
-    bootApplication();
+  equal(modelCount, 1);
+  let controller = container.lookup('controller:home');
+  setAndFlush(controller, 'model', emberA([1]));
+  equal(modelCount, 1);
+  equal(router.get('location.path'), '');
+});
 
-    let parentController = container.lookup('controller:parent');
+QUnit.test('Defaulting to params hash as the model should not result in that params object being watched', function() {
+  expect(1);
 
-    equal(parentController.get('foo'), 'lol');
+  App.Router.map(function() {
+    this.route('other');
   });
-} else {
-  QUnit.test('Calling transitionTo does not lose query params already on the activeTransition', function() {
-    expect(2);
-    App.Router.map(function() {
-      this.route('parent', function() {
-        this.route('child');
-        this.route('sibling');
-      });
-    });
-
-    App.ParentChildRoute = Route.extend({
-      afterModel: function() {
-        ok(true, 'The after model hook was called');
-        this.transitionTo('parent.sibling');
-      }
-    });
 
-    App.ParentController = Controller.extend({
-      queryParams: ['foo'],
-      foo: 'bar'
-    });
-
-    startingURL = '/parent/child?foo=lol';
-    bootApplication();
-
-    let parentController = container.lookup('controller:parent');
-
-    equal(parentController.get('foo'), 'lol');
+  // This causes the params hash, which is returned as a route's
+  // model if no other model could be resolved given the provided
+  // params (and no custom model hook was defined), to be watched,
+  // unless we return a copy of the params hash.
+  App.ApplicationController = Controller.extend({
+    queryParams: ['woot'],
+    woot: 'wat'
   });
-
-  QUnit.test('Single query params can be set on the controller [DEPRECATED]', function() {
-    App.Router.map(function() {
-      this.route('home', { path: '/' });
-    });
-
-    App.HomeController = Controller.extend({
-      queryParams: ['foo'],
-      foo: '123'
-    });
 
-    bootApplication();
-
-    let controller = container.lookup('controller:home');
-
-    setAndFlush(controller, 'foo', '456');
-
-    equal(router.get('location.path'), '/?foo=456');
-
-    setAndFlush(controller, 'foo', '987');
-    equal(router.get('location.path'), '/?foo=987');
+  App.OtherRoute = Route.extend({
+    model(p, trans) {
+      let m = meta(trans.params.application);
+      ok(!m.peekWatching('woot'), 'A meta object isn\'t constructed for this params POJO');
+    }
   });
-
-  QUnit.test('Single query params can be set on the controller [DEPRECATED]', function() {
-    App.Router.map(function() {
-      this.route('home', { path: '/' });
-    });
-
-    App.HomeController = Controller.extend({
-      queryParams: ['foo'],
-      foo: '123'
-    });
 
-    bootApplication();
+  bootApplication();
 
-    let controller = container.lookup('controller:home');
+  run(router, 'transitionTo', 'other');
+});
 
-    setAndFlush(controller, 'foo', '456');
+QUnit.test('A child of a resource route still defaults to parent route\'s model even if the child route has a query param', function() {
+  expect(1);
 
-    equal(router.get('location.path'), '/?foo=456');
-
-    setAndFlush(controller, 'foo', '987');
-    equal(router.get('location.path'), '/?foo=987');
+  App.IndexController = Controller.extend({
+    queryParams: ['woot']
   });
-
-  QUnit.test('Query params can map to different url keys configured on the controller [DEPRECATED]', function() {
-    App.IndexController = Controller.extend({
-      queryParams: [{ foo: 'other_foo', bar: { as: 'other_bar' } }],
-      foo: 'FOO',
-      bar: 'BAR'
-    });
-
-    bootApplication();
-    equal(router.get('location.path'), '');
 
-    let controller = container.lookup('controller:index');
-    setAndFlush(controller, 'foo', 'LEX');
+  App.ApplicationRoute = Route.extend({
+    model(p, trans) {
+      return { woot: true };
+    }
+  });
 
-    equal(router.get('location.path'), '/?other_foo=LEX');
-    setAndFlush(controller, 'foo', 'WOO');
-    equal(router.get('location.path'), '/?other_foo=WOO');
+  App.IndexRoute = Route.extend({
+    setupController(controller, model) {
+      deepEqual(model, { woot: true }, 'index route inherited model route from parent route');
+    }
+  });
 
-    run(router, 'transitionTo', '/?other_foo=NAW');
-    equal(controller.get('foo'), 'NAW');
+  bootApplication();
+});
 
-    setAndFlush(controller, 'bar', 'NERK');
-    run(router, 'transitionTo', '/?other_bar=NERK&other_foo=NAW');
+QUnit.test('opting into replace does not affect transitions between routes', function() {
+  expect(5);
+  App.register('template:application', compile(
+    '{{link-to \'Foo\' \'foo\' id=\'foo-link\'}}' +
+    '{{link-to \'Bar\' \'bar\' id=\'bar-no-qp-link\'}}' +
+    '{{link-to \'Bar\' \'bar\' (query-params raytiley=\'isthebest\') id=\'bar-link\'}}' +
+    '{{outlet}}'
+  ));
+  App.Router.map(function() {
+    this.route('foo');
+    this.route('bar');
   });
 
-  QUnit.test('Routes have overridable serializeQueryParamKey hook', function() {
-    App.IndexRoute = Route.extend({
-      serializeQueryParamKey: StringUtils.dasherize
-    });
+  App.BarController = Controller.extend({
+    queryParams: ['raytiley'],
+    raytiley: 'israd'
+  });
 
-    App.IndexController = Controller.extend({
-      queryParams: 'funTimes',
-      funTimes: ''
-    });
+  App.BarRoute = Route.extend({
+    queryParams: {
+      raytiley: {
+        replace: true
+      }
+    }
+  });
 
-    bootApplication();
-    equal(router.get('location.path'), '');
+  bootApplication();
+  let controller = container.lookup('controller:bar');
 
-    let controller = container.lookup('controller:index');
-    setAndFlush(controller, 'funTimes', 'woot');
+  expectedPushURL = '/foo';
+  run(jQuery('#foo-link'), 'click');
 
-    equal(router.get('location.path'), '/?fun-times=woot');
-  });
+  expectedPushURL = '/bar';
+  run(jQuery('#bar-no-qp-link'), 'click');
 
-  QUnit.test('No replaceURL occurs on startup because default values don\'t show up in URL', function() {
-    expect(0);
+  expectedReplaceURL = '/bar?raytiley=woot';
+  setAndFlush(controller, 'raytiley', 'woot');
 
-    App.IndexController = Controller.extend({
-      queryParams: ['foo'],
-      foo: '123'
-    });
+  expectedPushURL = '/foo';
+  run(jQuery('#foo-link'), 'click');
 
-    expectedReplaceURL = '/?foo=123';
+  expectedPushURL = '/bar?raytiley=isthebest';
+  run(jQuery('#bar-link'), 'click');
+});
 
-    bootApplication();
+QUnit.test('Undefined isn\'t deserialized into a string', function() {
+  expect(3);
+  App.Router.map(function() {
+    this.route('example');
   });
-
-  QUnit.test('Can override inherited QP behavior by specifying queryParams as a computed property', function() {
-    expect(0);
-    let SharedMixin = Mixin.create({
-      queryParams: ['a'],
-      a: 0
-    });
-
-    App.IndexController = Controller.extend(SharedMixin, {
-      queryParams: computed(function() {
-        return ['c'];
-      }),
-      c: true
-    });
 
-    bootApplication();
-    let indexController = container.lookup('controller:index');
+  App.register('template:application', compile('{{link-to \'Example\' \'example\' id=\'the-link\'}}'));
 
-    expectedReplaceURL = 'not gonna happen';
-    run(indexController, 'set', 'a', 1);
+  App.ExampleController = Controller.extend({
+    queryParams: ['foo']
+    // uncommon to not support default value, but should assume undefined.
   });
 
-  QUnit.test('model hooks receives query params', function() {
-    App.IndexController = Controller.extend({
-      queryParams: ['omg'],
-      omg: 'lol'
-    });
+  App.ExampleRoute = Route.extend({
+    model(params) {
+      deepEqual(params, { foo: undefined });
+    }
+  });
 
-    App.IndexRoute = Route.extend({
-      model(params) {
-        deepEqual(params, { omg: 'lol' });
-      }
-    });
+  bootApplication();
 
-    bootApplication();
+  let $link = jQuery('#the-link');
+  equal($link.attr('href'), '/example');
+  run($link, 'click');
 
-    equal(router.get('location.path'), '');
-  });
+  let controller = container.lookup('controller:example');
+  equal(get(controller, 'foo'), undefined);
+});
 
-  QUnit.test('controllers won\'t be eagerly instantiated by internal query params logic', function() {
-    expect(10);
-    App.Router.map(function() {
-      this.route('cats', function() {
-        this.route('index', { path: '/' });
-      });
-      this.route('home', { path: '/' });
-      this.route('about');
-    });
+QUnit.test('when refreshModel is true and loading action returns false, model hook will rerun when QPs change even if previous did not finish', function() {
+  expect(6);
 
-    App.register('template:home',       compile("<h3>{{link-to 'About' 'about' (query-params lol='wat') id='link-to-about'}}</h3>"));
-    App.register('template:about',      compile("<h3>{{link-to 'Home' 'home'  (query-params foo='naw')}}</h3>"));
-    App.register('template:cats.index', compile("<h3>{{link-to 'Cats' 'cats'  (query-params name='domino') id='cats-link'}}</h3>"));
-
-    let homeShouldBeCreated = false;
-    let aboutShouldBeCreated = false;
-    let catsIndexShouldBeCreated = false;
-
-    App.HomeRoute = Route.extend({
-      setup() {
-        homeShouldBeCreated = true;
-        this._super(...arguments);
-      }
-    });
+  var appModelCount = 0;
+  var promiseResolve;
 
-    App.HomeController = Controller.extend({
-      queryParams: ['foo'],
-      foo: '123',
-      init() {
-        this._super(...arguments);
-        ok(homeShouldBeCreated, 'HomeController should be created at this time');
+  App.ApplicationRoute = Route.extend({
+    queryParams: {
+      'appomg': {
+        defaultValue: 'applol'
       }
-    });
+    },
+    model(params) {
+      appModelCount++;
+    }
+  });
 
-    App.AboutRoute = Route.extend({
-      setup() {
-        aboutShouldBeCreated = true;
-        this._super(...arguments);
-      }
-    });
+  App.IndexController = Controller.extend({
+    queryParams: ['omg']
+    // uncommon to not support default value, but should assume undefined.
+  });
 
-    App.AboutController = Controller.extend({
-      queryParams: ['lol'],
-      lol: 'haha',
-      init() {
-        this._super(...arguments);
-        ok(aboutShouldBeCreated, 'AboutController should be created at this time');
+  var indexModelCount = 0;
+  App.IndexRoute = Route.extend({
+    queryParams: {
+      omg: {
+        refreshModel: true
       }
-    });
-
-    App.CatsIndexRoute = Route.extend({
-      model() {
-        return [];
-      },
-      setup() {
-        catsIndexShouldBeCreated = true;
-        this._super(...arguments);
-      },
-      setupController(controller, context) {
-        controller.set('model', context);
+    },
+    actions: {
+      loading: function() {
+        return false;
       }
-    });
-
-    App.CatsIndexController = Controller.extend({
-      queryParams: ['breed', 'name'],
-      breed: 'Golden',
-      name: null,
-      init() {
-        this._super(...arguments);
-        ok(catsIndexShouldBeCreated, 'CatsIndexController should be created at this time');
+    },
+    model(params) {
+      indexModelCount++;
+      if (indexModelCount === 2) {
+        deepEqual(params, { omg: 'lex' });
+        return new RSVP.Promise(function(resolve) {
+          promiseResolve = resolve;
+          return;
+        });
+      } else if (indexModelCount === 3) {
+        deepEqual(params, { omg: 'hello' }, 'Model hook reruns even if the previous one didnt finish');
       }
-    });
-
-    bootApplication();
+    }
+  });
 
-    equal(router.get('location.path'), '', 'url is correct');
-    let controller = container.lookup('controller:home');
-    setAndFlush(controller, 'foo', '456');
-    equal(router.get('location.path'), '/?foo=456', 'url is correct');
-    equal(jQuery('#link-to-about').attr('href'), '/about?lol=wat', 'link to about is correct');
+  bootApplication();
 
-    run(router, 'transitionTo', 'about');
-    equal(router.get('location.path'), '/about', 'url is correct');
+  equal(indexModelCount, 1);
 
-    run(router, 'transitionTo', 'cats');
+  var indexController = container.lookup('controller:index');
+  setAndFlush(indexController, 'omg', 'lex');
+  equal(indexModelCount, 2);
 
-    equal(router.get('location.path'), '/cats', 'url is correct');
-    equal(jQuery('#cats-link').attr('href'), '/cats?name=domino', 'link to cats is correct');
-    run(jQuery('#cats-link'), 'click');
-    equal(router.get('location.path'), '/cats?name=domino', 'url is correct');
+  setAndFlush(indexController, 'omg', 'hello');
+  equal(indexModelCount, 3);
+  run(function() {
+    promiseResolve();
   });
+  equal(get(indexController, 'omg'), 'hello', 'At the end last value prevails');
+});
 
-  QUnit.test('query params have been set by the time setupController is called', function() {
-    expect(1);
+QUnit.test('when refreshModel is true and loading action does not return false, model hook will not rerun when QPs change even if previous did not finish', function() {
+  expect(7);
 
-    App.ApplicationController = Controller.extend({
-      queryParams: ['foo'],
-      foo: 'wat'
-    });
+  var appModelCount = 0;
+  var promiseResolve;
 
-    App.ApplicationRoute = Route.extend({
-      setupController(controller) {
-        equal(controller.get('foo'), 'YEAH', 'controller\'s foo QP property set before setupController called');
+  App.ApplicationRoute = Route.extend({
+    queryParams: {
+      'appomg': {
+        defaultValue: 'applol'
       }
-    });
-
-    startingURL = '/?foo=YEAH';
-    bootApplication();
+    },
+    model(params) {
+      appModelCount++;
+    }
   });
 
-  QUnit.test('model hooks receives query params (overridden by incoming url value)', function() {
-    App.IndexController = Controller.extend({
-      queryParams: ['omg'],
-      omg: 'lol'
-    });
+  App.IndexController = Controller.extend({
+    queryParams: ['omg']
+    // uncommon to not support default value, but should assume undefined.
+  });
 
-    App.IndexRoute = Route.extend({
-      model(params) {
-        deepEqual(params, { omg: 'yes' });
+  var indexModelCount = 0;
+  App.IndexRoute = Route.extend({
+    queryParams: {
+      omg: {
+        refreshModel: true
       }
-    });
-
-    startingURL = '/?omg=yes';
-    bootApplication();
+    },
+    model(params) {
+      indexModelCount++;
 
-    equal(router.get('location.path'), '/?omg=yes');
+      if (indexModelCount === 2) {
+        deepEqual(params, { omg: 'lex' });
+        return new RSVP.Promise(function(resolve) {
+          promiseResolve = resolve;
+          return;
+        });
+      } else if (indexModelCount === 3) {
+        ok(false, 'shouldnt get here');
+      }
+    }
   });
 
-  QUnit.test('Route#paramsFor fetches query params', function() {
-    expect(1);
+  bootApplication();
 
-    App.Router.map(function() {
-      this.route('index', { path: '/:something' });
-    });
+  equal(appModelCount, 1);
+  equal(indexModelCount, 1);
 
-    App.IndexController = Controller.extend({
-      queryParams: ['foo'],
-      foo: 'fooapp'
-    });
+  var indexController = container.lookup('controller:index');
+  setAndFlush(indexController, 'omg', 'lex');
 
-    App.IndexRoute = Route.extend({
-      model(params, transition) {
-        deepEqual(this.paramsFor('index'), { something: 'omg', foo: 'fooapp' }, 'could retrieve params for index');
-      }
-    });
+  equal(appModelCount, 1);
+  equal(indexModelCount, 2);
 
-    startingURL = '/omg';
-    bootApplication();
+  setAndFlush(indexController, 'omg', 'hello');
+  equal(get(indexController, 'omg'), 'hello', ' value was set');
+  equal(indexModelCount, 2);
+  run(function() {
+    promiseResolve();
   });
-
-  QUnit.test('model hook can query prefix-less application params (overridden by incoming url value)', function() {
-    App.ApplicationController = Controller.extend({
-      queryParams: ['appomg'],
-      appomg: 'applol'
-    });
-
-    App.IndexController = Controller.extend({
-      queryParams: ['omg'],
-      omg: 'lol'
-    });
-
-    App.ApplicationRoute = Route.extend({
-      model(params) {
-        deepEqual(params, { appomg: 'appyes' });
-      }
-    });
+});
 
-    App.IndexRoute = Route.extend({
-      model(params) {
-        deepEqual(params, { omg: 'yes' });
-        deepEqual(this.paramsFor('application'), { appomg: 'appyes' });
-      }
-    });
-
-    startingURL = '/?appomg=appyes&omg=yes';
-    bootApplication();
-
-    equal(router.get('location.path'), '/?appomg=appyes&omg=yes');
-  });
-
-
-  QUnit.test('Route#paramsFor fetches falsy query params', function() {
-    expect(1);
-
-    App.IndexController = Controller.extend({
-      queryParams: ['foo'],
-      foo: true
-    });
-
-    App.IndexRoute = Route.extend({
-      model(params, transition) {
-        equal(params.foo, false);
-      }
-    });
-
-    startingURL = '/?foo=false';
-    bootApplication();
-  });
-
-  QUnit.test('model hook can query prefix-less application params', function() {
-    App.ApplicationController = Controller.extend({
-      queryParams: ['appomg'],
-      appomg: 'applol'
-    });
-
-    App.IndexController = Controller.extend({
-      queryParams: ['omg'],
-      omg: 'lol'
-    });
-
-    App.ApplicationRoute = Route.extend({
-      model(params) {
-        deepEqual(params, { appomg: 'applol' });
-      }
-    });
-
-    App.IndexRoute = Route.extend({
-      model(params) {
-        deepEqual(params, { omg: 'lol' });
-        deepEqual(this.paramsFor('application'), { appomg: 'applol' });
-      }
-    });
-
-    bootApplication();
-
-    equal(router.get('location.path'), '');
-  });
-
-  QUnit.test('can opt into full transition by setting refreshModel in route queryParams', function() {
-    expect(6);
-    App.ApplicationController = Controller.extend({
-      queryParams: ['appomg'],
-      appomg: 'applol'
-    });
-
-    App.IndexController = Controller.extend({
-      queryParams: ['omg'],
-      omg: 'lol'
-    });
-
-    let appModelCount = 0;
-    App.ApplicationRoute = Route.extend({
-      model(params) {
-        appModelCount++;
-      }
-    });
-
-    let indexModelCount = 0;
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        omg: {
-          refreshModel: true
-        }
-      },
-      model(params) {
-        indexModelCount++;
-
-        if (indexModelCount === 1) {
-          deepEqual(params, { omg: 'lol' });
-        } else if (indexModelCount === 2) {
-          deepEqual(params, { omg: 'lex' });
-        }
-      }
-    });
-
-    bootApplication();
-
-    equal(appModelCount, 1);
-    equal(indexModelCount, 1);
-
-    let indexController = container.lookup('controller:index');
-    setAndFlush(indexController, 'omg', 'lex');
-
-    equal(appModelCount, 1);
-    equal(indexModelCount, 2);
-  });
-
-  QUnit.test('refreshModel does not cause a second transition during app boot ', function() {
-    expect(0);
-    App.ApplicationController = Controller.extend({
-      queryParams: ['appomg'],
-      appomg: 'applol'
-    });
-
-    App.IndexController = Controller.extend({
-      queryParams: ['omg'],
-      omg: 'lol'
-    });
-
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        omg: {
-          refreshModel: true
-        }
-      },
-      refresh() {
-        ok(false);
-      }
-    });
-
-    startingURL = '/?appomg=hello&omg=world';
-    bootApplication();
-  });
-
-  QUnit.test('queryParams are updated when a controller property is set and the route is refreshed. Issue #13263  ', function() {
-    setTemplates({
-      application: compile(
-        '<button id="test-button" {{action \'increment\'}}>Increment</button>' +
-        '<span id="test-value">{{foo}}</span>' +
-        '{{outlet}}'
-      )
-    });
-    App.ApplicationController = Controller.extend({
-      queryParams: ['foo'],
-      foo: 1,
-      actions: {
-        increment: function() {
-          this.incrementProperty('foo');
-          this.send('refreshRoute');
-        }
-      }
-    });
-
-    App.ApplicationRoute = Route.extend({
-      actions: {
-        refreshRoute: function() {
-          this.refresh();
-        }
-      }
-    });
-
-    startingURL = '/';
-    bootApplication();
-    equal(jQuery('#test-value').text().trim(), '1');
-    equal(router.get('location.path'), '/', 'url is correct');
-    run(jQuery('#test-button'), 'click');
-    equal(jQuery('#test-value').text().trim(), '2');
-    equal(router.get('location.path'), '/?foo=2', 'url is correct');
-    run(jQuery('#test-button'), 'click');
-    equal(jQuery('#test-value').text().trim(), '3');
-    equal(router.get('location.path'), '/?foo=3', 'url is correct');
-  });
-
-  QUnit.test('Use Ember.get to retrieve query params \'refreshModel\' configuration', function() {
-    expect(6);
-    App.ApplicationController = Controller.extend({
-      queryParams: ['appomg'],
-      appomg: 'applol'
-    });
-
-    App.IndexController = Controller.extend({
-      queryParams: ['omg'],
-      omg: 'lol'
-    });
-
-    let appModelCount = 0;
-    App.ApplicationRoute = Route.extend({
-      model(params) {
-        appModelCount++;
-      }
-    });
-
-    let indexModelCount = 0;
-    App.IndexRoute = Route.extend({
-      queryParams: EmberObject.create({
-        unknownProperty(keyName) {
-          return { refreshModel: true };
-        }
-      }),
-      model(params) {
-        indexModelCount++;
-
-        if (indexModelCount === 1) {
-          deepEqual(params, { omg: 'lol' });
-        } else if (indexModelCount === 2) {
-          deepEqual(params, { omg: 'lex' });
-        }
-      }
-    });
-
-    bootApplication();
-
-    equal(appModelCount, 1);
-    equal(indexModelCount, 1);
-
-    let indexController = container.lookup('controller:index');
-    setAndFlush(indexController, 'omg', 'lex');
-
-    equal(appModelCount, 1);
-    equal(indexModelCount, 2);
-  });
-
-  QUnit.test('can use refreshModel even w URL changes that remove QPs from address bar', function() {
-    expect(4);
-
-    App.IndexController = Controller.extend({
-      queryParams: ['omg'],
-      omg: 'lol'
-    });
-
-    let indexModelCount = 0;
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        omg: {
-          refreshModel: true
-        }
-      },
-      model(params) {
-        indexModelCount++;
-
-        let data;
-        if (indexModelCount === 1) {
-          data = 'foo';
-        } else if (indexModelCount === 2) {
-          data = 'lol';
-        }
-
-        deepEqual(params, { omg: data }, 'index#model receives right data');
-      }
-    });
-
-    startingURL = '/?omg=foo';
-    bootApplication();
-    handleURL('/');
-
-    let indexController = container.lookup('controller:index');
-    equal(indexController.get('omg'), 'lol');
-  });
-
-  QUnit.test('can opt into a replace query by specifying replace:true in the Router config hash', function() {
-    expect(2);
-    App.ApplicationController = Controller.extend({
-      queryParams: ['alex'],
-      alex: 'matchneer'
-    });
-
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        alex: {
-          replace: true
-        }
-      }
-    });
-
-    bootApplication();
-
-    equal(router.get('location.path'), '');
-
-    let appController = container.lookup('controller:application');
-    expectedReplaceURL = '/?alex=wallace';
-    setAndFlush(appController, 'alex', 'wallace');
-  });
-
-  QUnit.test('Route query params config can be configured using property name instead of URL key', function() {
-    expect(2);
-    App.ApplicationController = Controller.extend({
-      queryParams: [
-        { commitBy: 'commit_by' }
-      ]
-    });
-
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        commitBy: {
-          replace: true
-        }
-      }
-    });
-
-    bootApplication();
-
-    equal(router.get('location.path'), '');
-
-    let appController = container.lookup('controller:application');
-    expectedReplaceURL = '/?commit_by=igor_seb';
-    setAndFlush(appController, 'commitBy', 'igor_seb');
-  });
-
-
-  QUnit.test('An explicit replace:false on a changed QP always wins and causes a pushState', function() {
-    expect(3);
-    App.ApplicationController = Controller.extend({
-      queryParams: ['alex', 'steely'],
-      alex: 'matchneer',
-      steely: 'dan'
-    });
-
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        alex: {
-          replace: true
-        },
-        steely: {
-          replace: false
-        }
-      }
-    });
-
-    bootApplication();
-
-    let appController = container.lookup('controller:application');
-    expectedPushURL = '/?alex=wallace&steely=jan';
-    run(appController, 'setProperties', { alex: 'wallace', steely: 'jan' });
-
-    expectedPushURL = '/?alex=wallace&steely=fran';
-    run(appController, 'setProperties', { steely: 'fran' });
-
-    expectedReplaceURL = '/?alex=sriracha&steely=fran';
-    run(appController, 'setProperties', { alex: 'sriracha' });
-  });
-
-  QUnit.test('can opt into full transition by setting refreshModel in route queryParams when transitioning from child to parent', function() {
-    App.register('template:parent', compile('{{outlet}}'));
-    App.register('template:parent.child', compile('{{link-to \'Parent\' \'parent\' (query-params foo=\'change\') id=\'parent-link\'}}'));
-
-    App.Router.map(function() {
-      this.route('parent', function() {
-        this.route('child');
-      });
-    });
-
-    let parentModelCount = 0;
-    App.ParentRoute = Route.extend({
-      model() {
-        parentModelCount++;
-      },
-      queryParams: {
-        foo: {
-          refreshModel: true
-        }
-      }
-    });
-
-    App.ParentController = Controller.extend({
-      queryParams: ['foo'],
-      foo: 'abc'
-    });
-
-    startingURL = '/parent/child?foo=lol';
-    bootApplication();
-
-    equal(parentModelCount, 1);
-
-    container.lookup('controller:parent');
-
-    run(jQuery('#parent-link'), 'click');
-
-    equal(parentModelCount, 2);
-  });
-
-  QUnit.test('Use Ember.get to retrieve query params \'replace\' configuration', function() {
-    expect(2);
-    App.ApplicationController = Controller.extend({
-      queryParams: ['alex'],
-      alex: 'matchneer'
-    });
-
-    App.ApplicationRoute = Route.extend({
-      queryParams: EmberObject.create({
-        unknownProperty(keyName) {
-          // We are simulating all qps requiring refresh
-          return { replace: true };
-        }
-      })
-    });
-
-    bootApplication();
-
-    equal(router.get('location.path'), '');
-
-    let appController = container.lookup('controller:application');
-    expectedReplaceURL = '/?alex=wallace';
-    setAndFlush(appController, 'alex', 'wallace');
-  });
-
-  QUnit.test('can override incoming QP values in setupController', function() {
-    expect(3);
-
-    App.Router.map(function() {
-      this.route('about');
-    });
-
-    App.IndexController = Controller.extend({
-      queryParams: ['omg'],
-      omg: 'lol'
-    });
-
-    App.IndexRoute = Route.extend({
-      setupController(controller) {
-        ok(true, 'setupController called');
-        controller.set('omg', 'OVERRIDE');
-      },
-      actions: {
-        queryParamsDidChange() {
-          ok(false, 'queryParamsDidChange shouldn\'t fire');
-        }
-      }
-    });
-
-    startingURL = '/about';
-    bootApplication();
-    equal(router.get('location.path'), '/about');
-    run(router, 'transitionTo', 'index');
-    equal(router.get('location.path'), '/?omg=OVERRIDE');
-  });
-
-  QUnit.test('can override incoming QP array values in setupController', function() {
-    expect(3);
-
-    App.Router.map(function() {
-      this.route('about');
-    });
-
-    App.IndexController = Controller.extend({
-      queryParams: ['omg'],
-      omg: ['lol']
-    });
-
-    App.IndexRoute = Route.extend({
-      setupController(controller) {
-        ok(true, 'setupController called');
-        controller.set('omg', ['OVERRIDE']);
-      },
-      actions: {
-        queryParamsDidChange() {
-          ok(false, 'queryParamsDidChange shouldn\'t fire');
-        }
-      }
-    });
-
-    startingURL = '/about';
-    bootApplication();
-    equal(router.get('location.path'), '/about');
-    run(router, 'transitionTo', 'index');
-    equal(router.get('location.path'), '/?omg=' + encodeURIComponent(JSON.stringify(['OVERRIDE'])));
-  });
-
-  QUnit.test('URL transitions that remove QPs still register as QP changes', function() {
-    expect(2);
-
-    App.IndexController = Controller.extend({
-      queryParams: ['omg'],
-      omg: 'lol'
-    });
-
-    startingURL = '/?omg=borf';
-    bootApplication();
-
-    let indexController = container.lookup('controller:index');
-    equal(indexController.get('omg'), 'borf');
-    run(router, 'transitionTo', '/');
-    equal(indexController.get('omg'), 'lol');
-  });
-
-  QUnit.test('Subresource naming style is supported', function() {
-    App.Router.map(function() {
-      this.route('abc.def', { path: '/abcdef' }, function() {
-        this.route('zoo');
-      });
-    });
-
-    App.register('template:application', compile('{{link-to \'A\' \'abc.def\' (query-params foo=\'123\') id=\'one\'}}{{link-to \'B\' \'abc.def.zoo\' (query-params foo=\'123\' bar=\'456\') id=\'two\'}}{{outlet}}'));
-
-    App.AbcDefController = Controller.extend({
-      queryParams: ['foo'],
-      foo: 'lol'
-    });
-
-    App.AbcDefZooController = Controller.extend({
-      queryParams: ['bar'],
-      bar: 'haha'
-    });
-
-    bootApplication();
-    equal(router.get('location.path'), '');
-    equal(jQuery('#one').attr('href'), '/abcdef?foo=123');
-    equal(jQuery('#two').attr('href'), '/abcdef/zoo?bar=456&foo=123');
-
-    run(jQuery('#one'), 'click');
-    equal(router.get('location.path'), '/abcdef?foo=123');
-    run(jQuery('#two'), 'click');
-    equal(router.get('location.path'), '/abcdef/zoo?bar=456&foo=123');
-  });
-
-  QUnit.test('transitionTo supports query params', function() {
-    App.IndexController = Controller.extend({
-      queryParams: ['foo'],
-      foo: 'lol'
-    });
-
-    bootApplication();
-
-    equal(router.get('location.path'), '');
-
-    run(router, 'transitionTo', { queryParams: { foo: 'borf' } });
-    equal(router.get('location.path'), '/?foo=borf', 'shorthand supported');
-    run(router, 'transitionTo', { queryParams: { 'index:foo': 'blaf' } });
-    equal(router.get('location.path'), '/?foo=blaf', 'longform supported');
-    run(router, 'transitionTo', { queryParams: { 'index:foo': false } });
-    equal(router.get('location.path'), '/?foo=false', 'longform supported (bool)');
-    run(router, 'transitionTo', { queryParams: { foo: false } });
-    equal(router.get('location.path'), '/?foo=false', 'shorhand supported (bool)');
-  });
-
-  QUnit.test('transitionTo supports query params (multiple)', function() {
-    App.IndexController = Controller.extend({
-      queryParams: ['foo', 'bar'],
-      foo: 'lol',
-      bar: 'wat'
-    });
-
-    bootApplication();
-
-    equal(router.get('location.path'), '');
-
-    run(router, 'transitionTo', { queryParams: { foo: 'borf' } });
-    equal(router.get('location.path'), '/?foo=borf', 'shorthand supported');
-    run(router, 'transitionTo', { queryParams: { 'index:foo': 'blaf' } });
-    equal(router.get('location.path'), '/?foo=blaf', 'longform supported');
-    run(router, 'transitionTo', { queryParams: { 'index:foo': false } });
-    equal(router.get('location.path'), '/?foo=false', 'longform supported (bool)');
-    run(router, 'transitionTo', { queryParams: { foo: false } });
-    equal(router.get('location.path'), '/?foo=false', 'shorhand supported (bool)');
-  });
-
-  QUnit.test('setting controller QP to empty string doesn\'t generate null in URL', function() {
-    expect(1);
-    App.IndexController = Controller.extend({
-      queryParams: ['foo'],
-      foo: '123'
-    });
-
-    bootApplication();
-    let controller = container.lookup('controller:index');
-
-    expectedPushURL = '/?foo=';
-    setAndFlush(controller, 'foo', '');
-  });
-
-  QUnit.test('setting QP to empty string doesn\'t generate null in URL', function() {
-    expect(1);
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: '123'
-        }
-      }
-    });
-
-    bootApplication();
-    let controller = container.lookup('controller:index');
-
-    expectedPushURL = '/?foo=';
-    setAndFlush(controller, 'foo', '');
-  });
-
-  QUnit.test('A default boolean value deserializes QPs as booleans rather than strings', function() {
-    App.IndexController = Controller.extend({
-      queryParams: ['foo'],
-      foo: false
-    });
-
-    App.IndexRoute = Route.extend({
-      model(params) {
-        equal(params.foo, true, 'model hook received foo as boolean true');
-      }
-    });
-
-    startingURL = '/?foo=true';
-    bootApplication();
-
-    let controller = container.lookup('controller:index');
-    equal(controller.get('foo'), true);
-
-    handleURL('/?foo=false');
-    equal(controller.get('foo'), false);
-  });
-
-  QUnit.test('Query param without value are empty string', function() {
-    App.IndexController = Controller.extend({
-      queryParams: ['foo'],
-      foo: ''
-    });
-
-    startingURL = '/?foo=';
-    bootApplication();
-
-    let controller = container.lookup('controller:index');
-    equal(controller.get('foo'), '');
-  });
-
-  QUnit.test('Array query params can be set', function() {
-    App.Router.map(function() {
-      this.route('home', { path: '/' });
-    });
-
-    App.HomeController = Controller.extend({
-      queryParams: ['foo'],
-      foo: []
-    });
-
-    bootApplication();
-
-    let controller = container.lookup('controller:home');
-
-    setAndFlush(controller, 'foo', [1, 2]);
-
-    equal(router.get('location.path'), '/?foo=%5B1%2C2%5D');
-
-    setAndFlush(controller, 'foo', [3, 4]);
-    equal(router.get('location.path'), '/?foo=%5B3%2C4%5D');
-  });
-
-  QUnit.test('(de)serialization: arrays', function() {
-    App.IndexController = Controller.extend({
-      queryParams: ['foo'],
-      foo: [1]
-    });
-
-    bootApplication();
-
-    equal(router.get('location.path'), '');
-
-    run(router, 'transitionTo', { queryParams: { foo: [2, 3] } });
-    equal(router.get('location.path'), '/?foo=%5B2%2C3%5D', 'shorthand supported');
-    run(router, 'transitionTo', { queryParams: { 'index:foo': [4, 5] } });
-    equal(router.get('location.path'), '/?foo=%5B4%2C5%5D', 'longform supported');
-    run(router, 'transitionTo', { queryParams: { foo: [] } });
-    equal(router.get('location.path'), '/?foo=%5B%5D', 'longform supported');
-  });
-
-  QUnit.test('Url with array query param sets controller property to array', function() {
-    App.IndexController = Controller.extend({
-      queryParams: ['foo'],
-      foo: ''
-    });
-
-    startingURL = '/?foo[]=1&foo[]=2&foo[]=3';
-    bootApplication();
-
-    let controller = container.lookup('controller:index');
-    deepEqual(controller.get('foo'), ['1', '2', '3']);
-  });
-
-  QUnit.test('Array query params can be pushed/popped', function() {
-    App.Router.map(function() {
-      this.route('home', { path: '/' });
-    });
-
-    App.HomeController = Controller.extend({
-      queryParams: ['foo'],
-      foo: emberA()
-    });
-
-    bootApplication();
-
-    equal(router.get('location.path'), '');
-
-    let controller = container.lookup('controller:home');
-
-    run(controller.foo, 'pushObject', 1);
-    equal(router.get('location.path'), '/?foo=%5B1%5D');
-    deepEqual(controller.foo, [1]);
-    run(controller.foo, 'popObject');
-    equal(router.get('location.path'), '/');
-    deepEqual(controller.foo, []);
-    run(controller.foo, 'pushObject', 1);
-    equal(router.get('location.path'), '/?foo=%5B1%5D');
-    deepEqual(controller.foo, [1]);
-    run(controller.foo, 'popObject');
-    equal(router.get('location.path'), '/');
-    deepEqual(controller.foo, []);
-    run(controller.foo, 'pushObject', 1);
-    equal(router.get('location.path'), '/?foo=%5B1%5D');
-    deepEqual(controller.foo, [1]);
-    run(controller.foo, 'pushObject', 2);
-    equal(router.get('location.path'), '/?foo=%5B1%2C2%5D');
-    deepEqual(controller.foo, [1, 2]);
-    run(controller.foo, 'popObject');
-    equal(router.get('location.path'), '/?foo=%5B1%5D');
-    deepEqual(controller.foo, [1]);
-    run(controller.foo, 'unshiftObject', 'lol');
-    equal(router.get('location.path'), '/?foo=%5B%22lol%22%2C1%5D');
-    deepEqual(controller.foo, ['lol', 1]);
-  });
-
-  QUnit.test('Overwriting with array with same content shouldn\'t refire update', function() {
-    expect(3);
-    let modelCount = 0;
-
-    App.Router.map(function() {
-      this.route('home', { path: '/' });
-    });
-
-    App.HomeRoute = Route.extend({
-      model() {
-        modelCount++;
-      }
-    });
-
-    App.HomeController = Controller.extend({
-      queryParams: ['foo'],
-      foo: emberA([1])
-    });
-
-    bootApplication();
-
-    equal(modelCount, 1);
-    let controller = container.lookup('controller:home');
-    setAndFlush(controller, 'model', emberA([1]));
-    equal(modelCount, 1);
-    equal(router.get('location.path'), '');
-  });
-
-  QUnit.test('Defaulting to params hash as the model should not result in that params object being watched', function() {
-    expect(1);
-
-    App.Router.map(function() {
-      this.route('other');
-    });
-
-    // This causes the params hash, which is returned as a route's
-    // model if no other model could be resolved given the provided
-    // params (and no custom model hook was defined), to be watched,
-    // unless we return a copy of the params hash.
-    App.ApplicationController = Controller.extend({
-      queryParams: ['woot'],
-      woot: 'wat'
-    });
-
-    App.OtherRoute = Route.extend({
-      model(p, trans) {
-        let m = meta(trans.params.application);
-        ok(!m.peekWatching('woot'), 'A meta object isn\'t constructed for this params POJO');
-      }
-    });
-
-    bootApplication();
-
-    run(router, 'transitionTo', 'other');
-  });
-
-  QUnit.test('A child of a resource route still defaults to parent route\'s model even if the child route has a query param', function() {
-    expect(1);
-
-    App.IndexController = Controller.extend({
-      queryParams: ['woot']
-    });
-
-    App.ApplicationRoute = Route.extend({
-      model(p, trans) {
-        return { woot: true };
-      }
-    });
-
-    App.IndexRoute = Route.extend({
-      setupController(controller, model) {
-        deepEqual(model, { woot: true }, 'index route inherited model route from parent route');
-      }
-    });
-
-    bootApplication();
-  });
-
-  QUnit.test('opting into replace does not affect transitions between routes', function() {
-    expect(5);
-    App.register('template:application', compile(
-      '{{link-to \'Foo\' \'foo\' id=\'foo-link\'}}' +
-      '{{link-to \'Bar\' \'bar\' id=\'bar-no-qp-link\'}}' +
-      '{{link-to \'Bar\' \'bar\' (query-params raytiley=\'isthebest\') id=\'bar-link\'}}' +
-      '{{outlet}}'
-    ));
-    App.Router.map(function() {
-      this.route('foo');
-      this.route('bar');
-    });
-
-    App.BarController = Controller.extend({
-      queryParams: ['raytiley'],
-      raytiley: 'israd'
-    });
-
-    App.BarRoute = Route.extend({
-      queryParams: {
-        raytiley: {
-          replace: true
-        }
-      }
-    });
-
-    bootApplication();
-    let controller = container.lookup('controller:bar');
-
-    expectedPushURL = '/foo';
-    run(jQuery('#foo-link'), 'click');
-
-    expectedPushURL = '/bar';
-    run(jQuery('#bar-no-qp-link'), 'click');
-
-    expectedReplaceURL = '/bar?raytiley=woot';
-    setAndFlush(controller, 'raytiley', 'woot');
-
-    expectedPushURL = '/foo';
-    run(jQuery('#foo-link'), 'click');
-
-    expectedPushURL = '/bar?raytiley=isthebest';
-    run(jQuery('#bar-link'), 'click');
-  });
-
-  QUnit.test('Undefined isn\'t deserialized into a string', function() {
-    expect(3);
-    App.Router.map(function() {
-      this.route('example');
-    });
-
-    App.register('template:application', compile('{{link-to \'Example\' \'example\' id=\'the-link\'}}'));
-
-    App.ExampleController = Controller.extend({
-      queryParams: ['foo']
-      // uncommon to not support default value, but should assume undefined.
-    });
-
-    App.ExampleRoute = Route.extend({
-      model(params) {
-        deepEqual(params, { foo: undefined });
-      }
-    });
-
-    bootApplication();
-
-    let $link = jQuery('#the-link');
-    equal($link.attr('href'), '/example');
-    run($link, 'click');
-
-    let controller = container.lookup('controller:example');
-    equal(get(controller, 'foo'), undefined);
-  });
-
-  QUnit.test('when refreshModel is true and loading action returns false, model hook will rerun when QPs change even if previous did not finish', function() {
-    expect(6);
-
-    var appModelCount = 0;
-    var promiseResolve;
-
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        'appomg': {
-          defaultValue: 'applol'
-        }
-      },
-      model(params) {
-        appModelCount++;
-      }
-    });
-
-    App.IndexController = Controller.extend({
-      queryParams: ['omg']
-      // uncommon to not support default value, but should assume undefined.
-    });
-
-    var indexModelCount = 0;
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        omg: {
-          refreshModel: true
-        }
-      },
-      actions: {
-        loading: function() {
-          return false;
-        }
-      },
-      model(params) {
-        indexModelCount++;
-        if (indexModelCount === 2) {
-          deepEqual(params, { omg: 'lex' });
-          return new RSVP.Promise(function(resolve) {
-            promiseResolve = resolve;
-            return;
-          });
-        } else if (indexModelCount === 3) {
-          deepEqual(params, { omg: 'hello' }, 'Model hook reruns even if the previous one didnt finish');
-        }
-      }
-    });
-
-    bootApplication();
-
-    equal(indexModelCount, 1);
-
-    var indexController = container.lookup('controller:index');
-    setAndFlush(indexController, 'omg', 'lex');
-    equal(indexModelCount, 2);
-
-    setAndFlush(indexController, 'omg', 'hello');
-    equal(indexModelCount, 3);
-    run(function() {
-      promiseResolve();
-    });
-    equal(get(indexController, 'omg'), 'hello', 'At the end last value prevails');
-  });
-
-  QUnit.test('when refreshModel is true and loading action does not return false, model hook will not rerun when QPs change even if previous did not finish', function() {
-    expect(7);
-
-    var appModelCount = 0;
-    var promiseResolve;
-
-    App.ApplicationRoute = Route.extend({
-      queryParams: {
-        'appomg': {
-          defaultValue: 'applol'
-        }
-      },
-      model(params) {
-        appModelCount++;
-      }
-    });
-
-    App.IndexController = Controller.extend({
-      queryParams: ['omg']
-      // uncommon to not support default value, but should assume undefined.
-    });
-
-    var indexModelCount = 0;
-    App.IndexRoute = Route.extend({
-      queryParams: {
-        omg: {
-          refreshModel: true
-        }
-      },
-      model(params) {
-        indexModelCount++;
-
-        if (indexModelCount === 2) {
-          deepEqual(params, { omg: 'lex' });
-          return new RSVP.Promise(function(resolve) {
-            promiseResolve = resolve;
-            return;
-          });
-        } else if (indexModelCount === 3) {
-          ok(false, 'shouldnt get here');
-        }
-      }
-    });
-
-    bootApplication();
-
-    equal(appModelCount, 1);
-    equal(indexModelCount, 1);
-
-    var indexController = container.lookup('controller:index');
-    setAndFlush(indexController, 'omg', 'lex');
-
-    equal(appModelCount, 1);
-    equal(indexModelCount, 2);
-
-    setAndFlush(indexController, 'omg', 'hello');
-    equal(get(indexController, 'omg'), 'hello', ' value was set');
-    equal(indexModelCount, 2);
-    run(function() {
-      promiseResolve();
-    });
-  });
-}
 
 QUnit.test('warn user that routes query params configuration must be an Object, not an Array', function() {
   expect(1);

--- a/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
@@ -4,7 +4,7 @@ import {
   String as StringUtils
 } from 'ember-runtime';
 import { Route, NoneLocation } from 'ember-routing';
-import { run, isFeatureEnabled, computed } from 'ember-metal';
+import { run, computed } from 'ember-metal';
 import { compile } from 'ember-template-compiler';
 import { Application } from 'ember-application';
 import { jQuery } from 'ember-views';
@@ -211,15 +211,9 @@ function queryParamsStickyTest4(urlPrefix, articleLookup) {
   return function() {
     let articleClass = StringUtils.classify(articleLookup);
 
-    if (isFeatureEnabled('ember-routing-route-configured-query-params')) {
-      App[`${articleClass}Route`].reopen({
-        queryParams: { q: { scope: 'controller' } }
-      });
-    } else {
-      App[`${articleClass}Controller`].reopen({
-        queryParams: { q: { scope: 'controller' } }
-      });
-    }
+    App[`${articleClass}Controller`].reopen({
+      queryParams: { q: { scope: 'controller' } }
+    });
 
     this.boot();
 
@@ -358,31 +352,16 @@ QUnit.module('Model Dep Query Params', {
       }
     });
 
-    if (isFeatureEnabled('ember-routing-route-configured-query-params')) {
-      App.ArticleRoute.reopen({
-        queryParams: {
-          q: { defaultValue: 'wat' },
-          z: { defaultValue: 0 }
-        }
-      });
+    App.ArticleController = Controller.extend({
+      queryParams: ['q', 'z'],
+      q: 'wat',
+      z: 0
+    });
 
-      App.CommentsRoute = Route.extend({
-        queryParams: {
-          page: { defaultValue: 1 }
-        }
-      });
-    } else {
-      App.ArticleController = Controller.extend({
-        queryParams: ['q', 'z'],
-        q: 'wat',
-        z: 0
-      });
-
-      App.CommentsController = Controller.extend({
-        queryParams: 'page',
-        page: 1
-      });
-    }
+    App.CommentsController = Controller.extend({
+      queryParams: 'page',
+      page: 1
+    });
 
     registry.register('template:application', compile('{{#each articles as |a|}} {{link-to \'Article\' \'article\' a id=a.id}} {{/each}} {{outlet}}'));
 
@@ -449,31 +428,17 @@ QUnit.module('Model Dep Query Params (nested)', {
       }
     });
 
-    if (isFeatureEnabled('ember-routing-route-configured-query-params')) {
-      App.SiteArticleRoute.reopen({
-        queryParams: {
-          q: { defaultValue: 'wat' },
-          z: { defaultValue: 0 }
-        }
-      });
+    App.SiteArticleController = Controller.extend({
+      queryParams: ['q', 'z'],
+      q: 'wat',
+      z: 0
+    });
 
-      App.SiteArticleCommentsRoute = Route.extend({
-        queryParams: {
-          page: { defaultValue: 1 }
-        }
-      });
-    } else {
-      App.SiteArticleController = Controller.extend({
-        queryParams: ['q', 'z'],
-        q: 'wat',
-        z: 0
-      });
+    App.SiteArticleCommentsController = Controller.extend({
+      queryParams: 'page',
+      page: 1
+    });
 
-      App.SiteArticleCommentsController = Controller.extend({
-        queryParams: 'page',
-        page: 1
-      });
-    }
     registry.register('template:application', compile('{{#each articles as |a|}} {{link-to \'Article\' \'site.article\' a id=a.id}} {{/each}} {{outlet}}'));
 
     this.boot = function() {
@@ -562,42 +527,21 @@ QUnit.module('Model Dep Query Params (nested & more than 1 dynamic segment)', {
       }
     });
 
-    if (isFeatureEnabled('ember-routing-route-configured-query-params')) {
-      App.SiteRoute.reopen({
-        queryParams: {
-          country: { defaultValue: 'au' }
-        }
-      });
+    App.SiteController = Controller.extend({
+      queryParams: ['country'],
+      country: 'au'
+    });
 
-      App.SiteArticleRoute.reopen({
-        queryParams: {
-          q: { defaultValue: 'wat' },
-          z: { defaultValue: 0 }
-        }
-      });
+    App.SiteArticleController = Controller.extend({
+      queryParams: ['q', 'z'],
+      q: 'wat',
+      z: 0
+    });
 
-      App.SiteArticleCommentsRoute = Route.extend({
-        queryParams: {
-          page: { defaultValue: 1 }
-        }
-      });
-    } else {
-      App.SiteController = Controller.extend({
-        queryParams: ['country'],
-        country: 'au'
-      });
-
-      App.SiteArticleController = Controller.extend({
-        queryParams: ['q', 'z'],
-        q: 'wat',
-        z: 0
-      });
-
-      App.SiteArticleCommentsController = Controller.extend({
-        queryParams: ['page'],
-        page: 1
-      });
-    }
+    App.SiteArticleCommentsController = Controller.extend({
+      queryParams: ['page'],
+      page: 1
+    });
 
     registry.register('template:application', compile('{{#each allSitesAllArticles as |a|}} {{#link-to \'site.article\' a.site_id a.article_id id=a.id}}Article [{{a.site_id}}] [{{a.article_id}}]{{/link-to}} {{/each}} {{outlet}}'));
 

--- a/packages/ember/tests/routing/query_params_test/query_params_paramless_link_to_test.js
+++ b/packages/ember/tests/routing/query_params_test/query_params_paramless_link_to_test.js
@@ -1,6 +1,6 @@
 import { Controller, String as StringUtils } from 'ember-runtime';
 import { Route, NoneLocation } from 'ember-routing';
-import { isFeatureEnabled, run } from 'ember-metal';
+import { run } from 'ember-metal';
 import { compile } from 'ember-template-compiler';
 import { Application } from 'ember-application';
 import { jQuery } from 'ember-views';
@@ -109,31 +109,5 @@ function testParamlessLinks(routeName) {
   });
 }
 
-function testParamlessLinksWithRouteConfig(routeName) {
-  QUnit.test('param-less links in an app booted with query params in the URL don\'t reset the query params: ' + routeName, function() {
-    expect(1);
-
-    setTemplate(routeName, compile('{{link-to \'index\' \'index\' id=\'index-link\'}}'));
-
-    App[StringUtils.capitalize(routeName) + 'Route'] = Route.extend({
-      queryParams: {
-        foo: {
-          defaultValue: 'wat'
-        }
-      }
-    });
-
-    startingURL = '/?foo=YEAH';
-    bootApplication();
-
-    equal(jQuery('#index-link').attr('href'), '/?foo=YEAH');
-  });
-}
-
-if (isFeatureEnabled('ember-routing-route-configured-query-params')) {
-  testParamlessLinksWithRouteConfig('application');
-  testParamlessLinksWithRouteConfig('index');
-} else {
-  testParamlessLinks('application');
-  testParamlessLinks('index');
-}
+testParamlessLinks('application');
+testParamlessLinks('index');


### PR DESCRIPTION
Per-discussion in the community Slack, this feature appears dead. Part of cleaning up QPs.
