### PR TITLE
[CLEANUP] Remove BucketCache from Controllers

### DIFF
--- a/packages/ember-application/lib/system/engine.js
+++ b/packages/ember-application/lib/system/engine.js
@@ -479,7 +479,6 @@ function commonSetupRegistry(registry) {
 
   registry.injection('router', '_bucketCache', P`-bucket-cache:main`);
   registry.injection('route', '_bucketCache', P`-bucket-cache:main`);
-  registry.injection('controller', '_bucketCache', P`-bucket-cache:main`);
 
   registry.injection('route', 'router', 'router:main');
 

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -141,7 +141,6 @@ QUnit.test('builds a registry', function() {
   verifyRegistration(application, P`-bucket-cache:main`);
   verifyInjection(application, 'router', '_bucketCache', P`-bucket-cache:main`);
   verifyInjection(application, 'route', '_bucketCache', P`-bucket-cache:main`);
-  verifyInjection(application, 'controller', '_bucketCache', P`-bucket-cache:main`);
 
   verifyInjection(application, 'route', 'router', 'router:main');
 

--- a/packages/ember-application/tests/system/engine_test.js
+++ b/packages/ember-application/tests/system/engine_test.js
@@ -47,7 +47,6 @@ QUnit.test('builds a registry', function() {
 
   verifyInjection(engine, 'router', '_bucketCache', P`-bucket-cache:main`);
   verifyInjection(engine, 'route', '_bucketCache', P`-bucket-cache:main`);
-  verifyInjection(engine, 'controller', '_bucketCache', P`-bucket-cache:main`);
 
   verifyInjection(engine, 'route', 'router', 'router:main');
 


### PR DESCRIPTION
Does not seem to be used any longer. Part of cleaning up QPs.
