### PR TITLE
[BUGFIX] Set computed property constructor

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -159,6 +159,7 @@ function ComputedProperty(config, opts) {
 }
 
 ComputedProperty.prototype = new Descriptor();
+ComputedProperty.prototype.constructor = ComputedProperty;
 
 const ComputedPropertyPrototype = ComputedProperty.prototype;
 


### PR DESCRIPTION
Need this for class/extend keywords to work correctly.
