### PR TITLE
Fix for local lookup of closure components

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/local-lookup-test.js
+++ b/packages/ember-glimmer/tests/integration/components/local-lookup-test.js
@@ -118,6 +118,68 @@ moduleFor('Components test: local lookup', class extends RenderingTest {
     this.assertText('yall finished or yall done?');
   }
 
+  ['@test it can local lookup a dynamic component from a passed named argument']() {
+    this.registerComponent('parent-foo', { template: `yall finished {{global-biz baz=(component 'local-bar')}}` });
+    this.registerComponent('global-biz', { template: 'or {{component baz}}' });
+    this.registerComponent('parent-foo/local-bar', { template: 'yall done?' });
+
+    this.render('{{parent-foo}}');
+
+    this.assertText('yall finished or yall done?');
+
+    this.runTask(() => this.rerender());
+
+    this.assertText('yall finished or yall done?');
+  }
+
+  ['@test it can local lookup a re-wrapped dynamic component from a passed named argument']() {
+    this.registerComponent('parent-foo', { template: `yall finished {{global-x comp=(component 'local-bar')}}` });
+    this.registerComponent('global-x', { template: `or {{global-y comp=(component comp phrase='done')}}` });
+    this.registerComponent('global-y', { template: `{{component comp}}?` });
+    this.registerComponent('parent-foo/local-bar', { template: 'yall {{phrase}}' });
+
+    this.render('{{parent-foo}}');
+
+    this.assertText('yall finished or yall done?');
+
+    this.runTask(() => this.rerender());
+
+    this.assertText('yall finished or yall done?');
+  }
+
+  ['@test it can nest local lookups of dynamic components from a passed named argument']() {
+    this.registerComponent('parent-foo', { template: `yall finished {{global-x comp=(component 'local-bar')}}` });
+    this.registerComponent('global-x', { template: `or {{global-y comp=(component comp phrase='done')}}` });
+    this.registerComponent('global-y', { template: `{{component comp}}{{component 'local-bar'}}` });
+    this.registerComponent('parent-foo/local-bar', { template: 'yall {{phrase}}' });
+    this.registerComponent('global-y/local-bar', { template: `?` });
+
+    this.render('{{parent-foo}}');
+
+    this.assertText('yall finished or yall done?');
+
+    this.runTask(() => this.rerender());
+
+    this.assertText('yall finished or yall done?');
+  }
+
+  ['@test it can switch from local to global lookups of dynamic components from a passed named argument']() {
+    this.registerComponent('parent-foo', { template: `yall finished {{global-x comp=(component bar)}}` });
+    this.registerComponent('global-x', { template: `or yall {{component comp}}` });
+    this.registerComponent('parent-foo/local-bar', { template: 'done?' });
+    this.registerComponent('global-bar', { template: `ready?` });
+
+    this.render('{{parent-foo bar=bar}}', { bar: 'local-bar' });
+
+    this.assertText('yall finished or yall done?');
+
+    this.runTask(() => this.context.set('bar', 'global-bar'));
+
+    this.runTask(() => this.rerender());
+
+    this.assertText('yall finished or yall ready?');
+  }
+
   ['@test it can lookup a local helper']() {
     this.registerHelper('x-outer/x-helper', () => {
       return 'Who dis?';

--- a/packages/ember-htmlbars/lib/keywords/closure-component.js
+++ b/packages/ember-htmlbars/lib/keywords/closure-component.js
@@ -20,6 +20,7 @@ export const COMPONENT_CELL = symbol('COMPONENT_CELL');
 export const COMPONENT_PATH = symbol('COMPONENT_PATH');
 export const COMPONENT_POSITIONAL_PARAMS = symbol('COMPONENT_POSITIONAL_PARAMS');
 export const COMPONENT_HASH = symbol('COMPONENT_HASH');
+export const COMPONENT_SOURCE = symbol('COMPONENT_SOURCE');
 
 const ClosureComponentStream = BasicStream.extend({
   init(env, path, params, hash) {
@@ -68,7 +69,7 @@ function createClosureComponentCell(env, originalComponentPath, params, hash, la
 }
 
 function isValidComponentPath(env, path) {
-  let result = lookupComponent(env.owner, path);
+  let result = lookupComponent(env.owner, path, { source: env.meta.moduleName && `template:${env.meta.moduleName}` });
 
   return !!(result.component || result.layout);
 }
@@ -83,6 +84,7 @@ function createNestedClosureComponentCell(componentCell, params, hash) {
 
   return {
     [COMPONENT_PATH]: componentCell[COMPONENT_PATH],
+    [COMPONENT_SOURCE]: componentCell[COMPONENT_SOURCE],
     [COMPONENT_HASH]: mergeInNewHash(componentCell[COMPONENT_HASH],
                                      hash,
                                      componentCell[COMPONENT_POSITIONAL_PARAMS],
@@ -106,6 +108,7 @@ function createNewClosureComponentCell(env, componentPath, params, hash) {
 
   return {
     [COMPONENT_PATH]: componentPath,
+    [COMPONENT_SOURCE]: env.meta.moduleName,
     [COMPONENT_HASH]: hash,
     [COMPONENT_POSITIONAL_PARAMS]: positionalParams,
     [COMPONENT_CELL]: true

--- a/packages/ember-htmlbars/lib/keywords/element-component.js
+++ b/packages/ember-htmlbars/lib/keywords/element-component.js
@@ -1,5 +1,6 @@
 import assign from 'ember-metal/assign';
 import {
+  COMPONENT_SOURCE,
   COMPONENT_HASH,
   COMPONENT_PATH,
   COMPONENT_POSITIONAL_PARAMS,
@@ -75,6 +76,9 @@ function render(morph, env, scope, [path, ...params], hash, template, inverse, v
                           closureComponent[COMPONENT_POSITIONAL_PARAMS],
                           params);
     params = [];
+    env = env.childWithMeta(assign({}, env.meta,
+      { moduleName: closureComponent[COMPONENT_SOURCE] }
+    ));
   }
 
   let templates = { default: template, inverse };


### PR DESCRIPTION
The source/module in the env when creating a closure component is correct, but wasn't accessible/used when rendering the closure component in a child context.  This fix retains the source/module and sets the env appropriately when a closure component is rendered.
