### PR TITLE
[CLEANUP+BUGFIX] Refactor query params tests

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -375,14 +375,15 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     let transition = this.router.router.activeTransition;
     let state = transition ? transition.state : this.router.router.state;
 
-    let params = {};
     let fullName = getEngineRouteName(getOwner(this), name);
+    let params = assign({}, state.params[fullName]);
+    let queryParams = getQueryParamsFor(route, state);
 
-    assign(params, state.params[fullName]);
-
-    assign(params, getQueryParamsFor(route, state));
-
-    return params;
+    return Object.keys(queryParams).reduce((params, key) => {
+      assert(`The route '${this.routeName}' has both a dynamic segment and query param with name '${key}'. Please rename one to avoid collisions.`, !params[key]);
+      params[key] = queryParams[key];
+      return params;
+    }, params);
   },
 
   /**

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -5,1489 +5,1370 @@ import {
   A as emberA,
   String as StringUtils
 } from 'ember-runtime';
-import { Route, NoneLocation } from 'ember-routing';
 import {
   run,
   get,
   computed,
-  Mixin,
   meta
 } from 'ember-metal';
-import { compile } from 'ember-template-compiler';
-import { Application } from 'ember-application';
+import { Route } from 'ember-routing';
 import { jQuery } from 'ember-views';
-import { setTemplates } from 'ember-glimmer';
 
-let App, router, container;
+import { QueryParamTestCase, moduleFor } from 'internal-test-helpers';
 
-function bootApplication() {
-  router = container.lookup('router:main');
-  run(App, 'advanceReadiness');
-}
-
-function handleURL(path) {
-  return run(() => {
-    return router.handleURL(path).then(function(value) {
-      ok(true, 'url: `' + path + '` was handled');
-      return value;
-    }, function(reason) {
-      ok(false, 'failed to visit:`' + path + '` reason: `' + QUnit.jsDump.parse(reason));
-      throw reason;
-    });
-  });
-}
-
-let startingURL = '';
-let expectedReplaceURL, expectedPushURL;
-
-function setAndFlush(obj, prop, value) {
-  run(obj, 'set', prop, value);
-}
-
-const TestLocation = NoneLocation.extend({
-  initState() {
-    this.set('path', startingURL);
-  },
-
-  setURL(path) {
-    if (expectedReplaceURL) {
-      ok(false, 'pushState occurred but a replaceState was expected');
-    }
-    if (expectedPushURL) {
-      equal(path, expectedPushURL, 'an expected pushState occurred');
-      expectedPushURL = null;
-    }
-    this.set('path', path);
-  },
-
-  replaceURL(path) {
-    if (expectedPushURL) {
-      ok(false, 'replaceState occurred but a pushState was expected');
-    }
-    if (expectedReplaceURL) {
-      equal(path, expectedReplaceURL, 'an expected replaceState occurred');
-      expectedReplaceURL = null;
-    }
-    this.set('path', path);
+moduleFor('Query Params - main', class extends QueryParamTestCase {
+  // Sets up a controller with a single query param
+  setSingleQPController(routeName, param = 'foo', defaultValue = 'bar', options = {}) {
+    this.registerController(routeName, Controller.extend({
+      queryParams: [param],
+      [param]: defaultValue
+    }, options));
   }
-});
 
-function sharedSetup() {
-  run(() => {
-    App = Application.create({
-      name: 'App',
-      rootElement: '#qunit-fixture'
-    });
+  ['@test No replaceURL occurs on startup because default values don\'t show up in URL'](assert) {
+    assert.expect(1);
 
-    App.deferReadiness();
+    this.setSingleQPController('index');
 
-    container = App.__container__;
-
-    App.register('location:test', TestLocation);
-
-    startingURL = expectedReplaceURL = expectedPushURL = '';
-
-    App.Router.reopen({
-      location: 'test'
-    });
-
-    App.LoadingRoute = Route.extend({
-    });
-
-    App.register('template:application', compile('{{outlet}}'));
-    App.register('template:home', compile('<h3>Hours</h3>'));
-  });
-}
-
-function sharedTeardown() {
-  try {
-    run(() => {
-      App.destroy();
-      App = null;
-    });
-  } finally {
-    setTemplates({});
+    return this.visitAndAssert('/');
   }
-}
 
-// jscs:disable
+  ['@test Calling transitionTo does not lose query params already on the activeTransition'](assert) {
+    assert.expect(2);
 
-QUnit.module('Routing with Query Params', {
-  setup() {
-    sharedSetup();
-  },
+    this.router.map(function() {
+      this.route('parent', function() {
+        this.route('child');
+        this.route('sibling');
+      });
+    });
 
-  teardown() {
-    sharedTeardown();
+    this.registerRoute('parent.child', Route.extend({
+      afterModel() {
+        this.transitionTo('parent.sibling');
+      }
+    }));
+
+    this.setSingleQPController('parent');
+
+    return this.visit('/parent/child?foo=lol').then(() => {
+      this.assertCurrentPath('/parent/sibling?foo=lol', 'redirected to the sibling route, instead of child route');
+      assert.equal(this.getController('parent').get('foo'), 'lol', 'controller has value from the active transition');
+    });
   }
-});
 
-QUnit.test('Calling transitionTo does not lose query params already on the activeTransition', function() {
-  expect(2);
-  App.Router.map(function() {
-    this.route('parent', function() {
-      this.route('child');
-      this.route('sibling');
+  ['@test Single query params can be set on the controller and reflected in the url'](assert) {
+    assert.expect(3);
+
+    this.router.map(function() {
+      this.route('home', { path: '/' });
     });
-  });
 
-  App.ParentChildRoute = Route.extend({
-    afterModel: function() {
-      ok(true, 'The after model hook was called');
-      this.transitionTo('parent.sibling');
-    }
-  });
+    this.setSingleQPController('home');
 
-  App.ParentController = Controller.extend({
-    queryParams: ['foo'],
-    foo: 'bar'
-  });
+    return this.visitAndAssert('/').then(() => {
+      let controller = this.getController('home');
 
-  startingURL = '/parent/child?foo=lol';
-  bootApplication();
+      this.setAndFlush(controller, 'foo', '456');
+      this.assertCurrentPath('/?foo=456');
 
-  let parentController = container.lookup('controller:parent');
-
-  equal(parentController.get('foo'), 'lol');
-});
-
-QUnit.test('Single query params can be set on the controller [DEPRECATED]', function() {
-  App.Router.map(function() {
-    this.route('home', { path: '/' });
-  });
-
-  App.HomeController = Controller.extend({
-    queryParams: ['foo'],
-    foo: '123'
-  });
-
-  bootApplication();
-
-  let controller = container.lookup('controller:home');
-
-  setAndFlush(controller, 'foo', '456');
-
-  equal(router.get('location.path'), '/?foo=456');
-
-  setAndFlush(controller, 'foo', '987');
-  equal(router.get('location.path'), '/?foo=987');
-});
-
-QUnit.test('Single query params can be set on the controller [DEPRECATED]', function() {
-  App.Router.map(function() {
-    this.route('home', { path: '/' });
-  });
-
-  App.HomeController = Controller.extend({
-    queryParams: ['foo'],
-    foo: '123'
-  });
-
-  bootApplication();
-
-  let controller = container.lookup('controller:home');
-
-  setAndFlush(controller, 'foo', '456');
-
-  equal(router.get('location.path'), '/?foo=456');
-
-  setAndFlush(controller, 'foo', '987');
-  equal(router.get('location.path'), '/?foo=987');
-});
-
-QUnit.test('Query params can map to different url keys configured on the controller [DEPRECATED]', function() {
-  App.IndexController = Controller.extend({
-    queryParams: [{ foo: 'other_foo', bar: { as: 'other_bar' } }],
-    foo: 'FOO',
-    bar: 'BAR'
-  });
-
-  bootApplication();
-  equal(router.get('location.path'), '');
-
-  let controller = container.lookup('controller:index');
-  setAndFlush(controller, 'foo', 'LEX');
-
-  equal(router.get('location.path'), '/?other_foo=LEX');
-  setAndFlush(controller, 'foo', 'WOO');
-  equal(router.get('location.path'), '/?other_foo=WOO');
-
-  run(router, 'transitionTo', '/?other_foo=NAW');
-  equal(controller.get('foo'), 'NAW');
-
-  setAndFlush(controller, 'bar', 'NERK');
-  run(router, 'transitionTo', '/?other_bar=NERK&other_foo=NAW');
-});
-
-QUnit.test('Routes have overridable serializeQueryParamKey hook', function() {
-  App.IndexRoute = Route.extend({
-    serializeQueryParamKey: StringUtils.dasherize
-  });
-
-  App.IndexController = Controller.extend({
-    queryParams: 'funTimes',
-    funTimes: ''
-  });
-
-  bootApplication();
-  equal(router.get('location.path'), '');
-
-  let controller = container.lookup('controller:index');
-  setAndFlush(controller, 'funTimes', 'woot');
-
-  equal(router.get('location.path'), '/?fun-times=woot');
-});
-
-QUnit.test('No replaceURL occurs on startup because default values don\'t show up in URL', function() {
-  expect(0);
-
-  App.IndexController = Controller.extend({
-    queryParams: ['foo'],
-    foo: '123'
-  });
-
-  expectedReplaceURL = '/?foo=123';
-
-  bootApplication();
-});
-
-QUnit.test('Can override inherited QP behavior by specifying queryParams as a computed property', function() {
-  expect(0);
-  let SharedMixin = Mixin.create({
-    queryParams: ['a'],
-    a: 0
-  });
-
-  App.IndexController = Controller.extend(SharedMixin, {
-    queryParams: computed(function() {
-      return ['c'];
-    }),
-    c: true
-  });
-
-  bootApplication();
-  let indexController = container.lookup('controller:index');
-
-  expectedReplaceURL = 'not gonna happen';
-  run(indexController, 'set', 'a', 1);
-});
-
-QUnit.test('model hooks receives query params', function() {
-  App.IndexController = Controller.extend({
-    queryParams: ['omg'],
-    omg: 'lol'
-  });
-
-  App.IndexRoute = Route.extend({
-    model(params) {
-      deepEqual(params, { omg: 'lol' });
-    }
-  });
-
-  bootApplication();
-
-  equal(router.get('location.path'), '');
-});
-
-QUnit.test('controllers won\'t be eagerly instantiated by internal query params logic', function() {
-  expect(10);
-  App.Router.map(function() {
-    this.route('cats', function() {
-      this.route('index', { path: '/' });
+      this.setAndFlush(controller, 'foo', '987');
+      this.assertCurrentPath('/?foo=987');
     });
-    this.route('home', { path: '/' });
-    this.route('about');
-  });
+  }
 
-  App.register('template:home',       compile("<h3>{{link-to 'About' 'about' (query-params lol='wat') id='link-to-about'}}</h3>"));
-  App.register('template:about',      compile("<h3>{{link-to 'Home' 'home'  (query-params foo='naw')}}</h3>"));
-  App.register('template:cats.index', compile("<h3>{{link-to 'Cats' 'cats'  (query-params name='domino') id='cats-link'}}</h3>"));
+  ['@test Query params can map to different url keys configured on the controller'](assert) {
+    assert.expect(6);
 
-  let homeShouldBeCreated = false;
-  let aboutShouldBeCreated = false;
-  let catsIndexShouldBeCreated = false;
+    this.registerController('index', Controller.extend({
+      queryParams: [{ foo: 'other_foo', bar: { as: 'other_bar' } }],
+      foo: 'FOO',
+      bar: 'BAR'
+    }));
 
-  App.HomeRoute = Route.extend({
-    setup() {
-      homeShouldBeCreated = true;
-      this._super(...arguments);
-    }
-  });
+    return this.visitAndAssert('/').then(() => {
+      let controller = this.getController('index');
 
-  App.HomeController = Controller.extend({
-    queryParams: ['foo'],
-    foo: '123',
-    init() {
-      this._super(...arguments);
-      ok(homeShouldBeCreated, 'HomeController should be created at this time');
-    }
-  });
+      this.setAndFlush(controller, 'foo', 'LEX');
+      this.assertCurrentPath('/?other_foo=LEX', 'QP mapped correctly without \'as\'');
 
-  App.AboutRoute = Route.extend({
-    setup() {
-      aboutShouldBeCreated = true;
-      this._super(...arguments);
-    }
-  });
+      this.setAndFlush(controller, 'foo', 'WOO');
+      this.assertCurrentPath('/?other_foo=WOO', 'QP updated correctly without \'as\'');
 
-  App.AboutController = Controller.extend({
-    queryParams: ['lol'],
-    lol: 'haha',
-    init() {
-      this._super(...arguments);
-      ok(aboutShouldBeCreated, 'AboutController should be created at this time');
-    }
-  });
+      this.transitionTo('/?other_foo=NAW');
+      assert.equal(controller.get('foo'), 'NAW', 'QP managed correctly on URL transition');
 
-  App.CatsIndexRoute = Route.extend({
-    model() {
-      return [];
-    },
-    setup() {
-      catsIndexShouldBeCreated = true;
-      this._super(...arguments);
-    },
-    setupController(controller, context) {
-      controller.set('model', context);
-    }
-  });
+      this.setAndFlush(controller, 'bar', 'NERK');
+      this.assertCurrentPath('/?other_bar=NERK&other_foo=NAW', 'QP mapped correctly with \'as\'');
 
-  App.CatsIndexController = Controller.extend({
-    queryParams: ['breed', 'name'],
-    breed: 'Golden',
-    name: null,
-    init() {
-      this._super(...arguments);
-      ok(catsIndexShouldBeCreated, 'CatsIndexController should be created at this time');
-    }
-  });
+      this.setAndFlush(controller, 'bar', 'NUKE');
+      this.assertCurrentPath('/?other_bar=NUKE&other_foo=NAW', 'QP updated correctly with \'as\'');
+    });
+  }
 
-  bootApplication();
+  ['@test Routes have a private overridable serializeQueryParamKey hook'](assert) {
+    assert.expect(2);
 
-  equal(router.get('location.path'), '', 'url is correct');
-  let controller = container.lookup('controller:home');
-  setAndFlush(controller, 'foo', '456');
-  equal(router.get('location.path'), '/?foo=456', 'url is correct');
-  equal(jQuery('#link-to-about').attr('href'), '/about?lol=wat', 'link to about is correct');
+    this.registerRoute('index', Route.extend({
+      serializeQueryParamKey: StringUtils.dasherize
+    }));
 
-  run(router, 'transitionTo', 'about');
-  equal(router.get('location.path'), '/about', 'url is correct');
+    this.setSingleQPController('index', 'funTimes', '');
 
-  run(router, 'transitionTo', 'cats');
+    return this.visitAndAssert('/').then(() => {
+      let controller = this.getController('index');
 
-  equal(router.get('location.path'), '/cats', 'url is correct');
-  equal(jQuery('#cats-link').attr('href'), '/cats?name=domino', 'link to cats is correct');
-  run(jQuery('#cats-link'), 'click');
-  equal(router.get('location.path'), '/cats?name=domino', 'url is correct');
-});
+      this.setAndFlush(controller, 'funTimes', 'woot');
+      this.assertCurrentPath('/?fun-times=woot');
+    });
+  }
 
-QUnit.test('query params have been set by the time setupController is called', function() {
-  expect(1);
+  ['@test Can override inherited QP behavior by specifying queryParams as a computed property'](assert) {
+    assert.expect(3);
 
-  App.ApplicationController = Controller.extend({
-    queryParams: ['foo'],
-    foo: 'wat'
-  });
+    this.setSingleQPController('index', 'a', 0, {
+      queryParams: computed(function() {
+        return ['c'];
+      }),
+      c: true
+    });
 
-  App.ApplicationRoute = Route.extend({
-    setupController(controller) {
-      equal(controller.get('foo'), 'YEAH', 'controller\'s foo QP property set before setupController called');
-    }
-  });
+    return this.visitAndAssert('/').then(() => {
+      let indexController = this.getController('index');
 
-  startingURL = '/?foo=YEAH';
-  bootApplication();
-});
+      this.setAndFlush(indexController, 'a', 1);
+      this.assertCurrentPath('/', 'QP did not update due to being overriden');
 
-QUnit.test('model hooks receives query params (overridden by incoming url value)', function() {
-  App.IndexController = Controller.extend({
-    queryParams: ['omg'],
-    omg: 'lol'
-  });
+      this.setAndFlush(indexController, 'c', false);
+      this.assertCurrentPath('/?c=false', 'QP updated with overriden param');
+    });
+  }
 
-  App.IndexRoute = Route.extend({
-    model(params) {
-      deepEqual(params, { omg: 'yes' });
-    }
-  });
+  ['@test Can concatenate inherited QP behavior by specifying queryParams as an array'](assert) {
+    assert.expect(3);
 
-  startingURL = '/?omg=yes';
-  bootApplication();
+    this.setSingleQPController('index', 'a', 0, {
+      queryParams: ['c'],
+      c: true
+    });
 
-  equal(router.get('location.path'), '/?omg=yes');
-});
+    return this.visitAndAssert('/').then(() => {
+      let indexController = this.getController('index');
 
-QUnit.test('Route#paramsFor fetches query params', function() {
-  expect(1);
+      this.setAndFlush(indexController, 'a', 1);
+      this.assertCurrentPath('/?a=1', 'Inherited QP did update');
 
-  App.Router.map(function() {
-    this.route('index', { path: '/:something' });
-  });
+      this.setAndFlush(indexController, 'c', false);
+      this.assertCurrentPath('/?a=1&c=false', 'New QP did update');
+    });
+  }
 
-  App.IndexController = Controller.extend({
-    queryParams: ['foo'],
-    foo: 'fooapp'
-  });
+  ['@test model hooks receives query params'](assert) {
+    assert.expect(2);
 
-  App.IndexRoute = Route.extend({
-    model(params, transition) {
-      deepEqual(this.paramsFor('index'), { something: 'omg', foo: 'fooapp' }, 'could retrieve params for index');
-    }
-  });
+    this.setSingleQPController('index');
 
-  startingURL = '/omg';
-  bootApplication();
-});
-
-QUnit.test('model hook can query prefix-less application params (overridden by incoming url value)', function() {
-  App.ApplicationController = Controller.extend({
-    queryParams: ['appomg'],
-    appomg: 'applol'
-  });
-
-  App.IndexController = Controller.extend({
-    queryParams: ['omg'],
-    omg: 'lol'
-  });
-
-  App.ApplicationRoute = Route.extend({
-    model(params) {
-      deepEqual(params, { appomg: 'appyes' });
-    }
-  });
-
-  App.IndexRoute = Route.extend({
-    model(params) {
-      deepEqual(params, { omg: 'yes' });
-      deepEqual(this.paramsFor('application'), { appomg: 'appyes' });
-    }
-  });
-
-  startingURL = '/?appomg=appyes&omg=yes';
-  bootApplication();
-
-  equal(router.get('location.path'), '/?appomg=appyes&omg=yes');
-});
-
-
-QUnit.test('Route#paramsFor fetches falsy query params', function() {
-  expect(1);
-
-  App.IndexController = Controller.extend({
-    queryParams: ['foo'],
-    foo: true
-  });
-
-  App.IndexRoute = Route.extend({
-    model(params, transition) {
-      equal(params.foo, false);
-    }
-  });
-
-  startingURL = '/?foo=false';
-  bootApplication();
-});
-
-QUnit.test('model hook can query prefix-less application params', function() {
-  App.ApplicationController = Controller.extend({
-    queryParams: ['appomg'],
-    appomg: 'applol'
-  });
-
-  App.IndexController = Controller.extend({
-    queryParams: ['omg'],
-    omg: 'lol'
-  });
-
-  App.ApplicationRoute = Route.extend({
-    model(params) {
-      deepEqual(params, { appomg: 'applol' });
-    }
-  });
-
-  App.IndexRoute = Route.extend({
-    model(params) {
-      deepEqual(params, { omg: 'lol' });
-      deepEqual(this.paramsFor('application'), { appomg: 'applol' });
-    }
-  });
-
-  bootApplication();
-
-  equal(router.get('location.path'), '');
-});
-
-QUnit.test('can opt into full transition by setting refreshModel in route queryParams', function() {
-  expect(6);
-  App.ApplicationController = Controller.extend({
-    queryParams: ['appomg'],
-    appomg: 'applol'
-  });
-
-  App.IndexController = Controller.extend({
-    queryParams: ['omg'],
-    omg: 'lol'
-  });
-
-  let appModelCount = 0;
-  App.ApplicationRoute = Route.extend({
-    model(params) {
-      appModelCount++;
-    }
-  });
-
-  let indexModelCount = 0;
-  App.IndexRoute = Route.extend({
-    queryParams: {
-      omg: {
-        refreshModel: true
+    this.registerRoute('index', Route.extend({
+      model(params) {
+        assert.deepEqual(params, { foo: 'bar' });
       }
-    },
-    model(params) {
-      indexModelCount++;
+    }));
 
-      if (indexModelCount === 1) {
-        deepEqual(params, { omg: 'lol' });
-      } else if (indexModelCount === 2) {
-        deepEqual(params, { omg: 'lex' });
+    return this.visitAndAssert('/');
+  }
+
+  ['@test model hooks receives query params with dynamic segment params'](assert) {
+    assert.expect(2);
+
+    this.router.map(function() {
+      this.route('index', { path: '/:id' });
+    });
+
+    this.setSingleQPController('index');
+
+    this.registerRoute('index', Route.extend({
+      model(params) {
+        assert.deepEqual(params, { foo: 'bar', id: 'baz' });
       }
-    }
-  });
+    }));
 
-  bootApplication();
+    return this.visitAndAssert('/baz');
+  }
 
-  equal(appModelCount, 1);
-  equal(indexModelCount, 1);
+  ['@test model hooks receives query params (overridden by incoming url value)'](assert) {
+    assert.expect(2);
 
-  let indexController = container.lookup('controller:index');
-  setAndFlush(indexController, 'omg', 'lex');
+    this.router.map(function() {
+      this.route('index', { path: '/:id' });
+    });
 
-  equal(appModelCount, 1);
-  equal(indexModelCount, 2);
-});
+    this.setSingleQPController('index');
 
-QUnit.test('refreshModel does not cause a second transition during app boot ', function() {
-  expect(0);
-  App.ApplicationController = Controller.extend({
-    queryParams: ['appomg'],
-    appomg: 'applol'
-  });
-
-  App.IndexController = Controller.extend({
-    queryParams: ['omg'],
-    omg: 'lol'
-  });
-
-  App.IndexRoute = Route.extend({
-    queryParams: {
-      omg: {
-        refreshModel: true
+    this.registerRoute('index', Route.extend({
+      model(params) {
+        assert.deepEqual(params, { foo: 'baz', id: 'boo' });
       }
-    },
-    refresh() {
-      ok(false);
-    }
-  });
+    }));
 
-  startingURL = '/?appomg=hello&omg=world';
-  bootApplication();
-});
+    return this.visitAndAssert('/boo?foo=baz');
+  }
 
-QUnit.test('queryParams are updated when a controller property is set and the route is refreshed. Issue #13263  ', function() {
-  setTemplates({
-    application: compile(
-      '<button id="test-button" {{action \'increment\'}}>Increment</button>' +
-      '<span id="test-value">{{foo}}</span>' +
-      '{{outlet}}'
-    )
-  });
-  App.ApplicationController = Controller.extend({
-    queryParams: ['foo'],
-    foo: 1,
-    actions: {
-      increment: function() {
-        this.incrementProperty('foo');
-        this.send('refreshRoute');
+  // FIXME: What is the correct behavior below?
+  ['@skip dynamic segment and query param have same name'](assert) {
+    assert.expect(2);
+
+    this.router.map(function() {
+      this.route('index', { path: '/:foo' });
+    });
+
+    this.setSingleQPController('index');
+
+    this.registerRoute('index', Route.extend({
+      model(params) {
+        assert.deepEqual(params, { foo: 'boo' });
       }
-    }
-  });
+    }));
 
-  App.ApplicationRoute = Route.extend({
-    actions: {
-      refreshRoute: function() {
-        this.refresh();
+    return this.visitAndAssert('/boo?foo=baz');
+  }
+
+  ['@test controllers won\'t be eagerly instantiated by internal query params logic'](assert) {
+    assert.expect(10);
+
+    this.router.map(function() {
+      this.route('cats', function() {
+        this.route('index', { path: '/' });
+      });
+      this.route('home', { path: '/' });
+      this.route('about');
+    });
+
+    this.registerTemplate('home', `<h3>{{link-to 'About' 'about' (query-params lol='wat') id='link-to-about'}}</h3>`);
+    this.registerTemplate('about', `<h3>{{link-to 'Home' 'home'  (query-params foo='naw')}}</h3>`);
+    this.registerTemplate('cats.index', `<h3>{{link-to 'Cats' 'cats'  (query-params name='domino') id='cats-link'}}</h3>`);
+
+    let homeShouldBeCreated = false;
+    let aboutShouldBeCreated = false;
+    let catsIndexShouldBeCreated = false;
+
+    this.registerRoute('home', Route.extend({
+      setup() {
+        homeShouldBeCreated = true;
+        this._super(...arguments);
       }
-    }
-  });
+    }));
 
-  startingURL = '/';
-  bootApplication();
-  equal(jQuery('#test-value').text().trim(), '1');
-  equal(router.get('location.path'), '/', 'url is correct');
-  run(jQuery('#test-button'), 'click');
-  equal(jQuery('#test-value').text().trim(), '2');
-  equal(router.get('location.path'), '/?foo=2', 'url is correct');
-  run(jQuery('#test-button'), 'click');
-  equal(jQuery('#test-value').text().trim(), '3');
-  equal(router.get('location.path'), '/?foo=3', 'url is correct');
-});
-
-QUnit.test('Use Ember.get to retrieve query params \'refreshModel\' configuration', function() {
-  expect(6);
-  App.ApplicationController = Controller.extend({
-    queryParams: ['appomg'],
-    appomg: 'applol'
-  });
-
-  App.IndexController = Controller.extend({
-    queryParams: ['omg'],
-    omg: 'lol'
-  });
-
-  let appModelCount = 0;
-  App.ApplicationRoute = Route.extend({
-    model(params) {
-      appModelCount++;
-    }
-  });
-
-  let indexModelCount = 0;
-  App.IndexRoute = Route.extend({
-    queryParams: EmberObject.create({
-      unknownProperty(keyName) {
-        return { refreshModel: true };
+    this.setSingleQPController('home', 'foo', '123', {
+      init() {
+        this._super(...arguments);
+        assert.ok(homeShouldBeCreated, 'HomeController should be created at this time');
       }
-    }),
-    model(params) {
-      indexModelCount++;
+    });
 
-      if (indexModelCount === 1) {
-        deepEqual(params, { omg: 'lol' });
-      } else if (indexModelCount === 2) {
-        deepEqual(params, { omg: 'lex' });
+    this.registerRoute('about', Route.extend({
+      setup() {
+        aboutShouldBeCreated = true;
+        this._super(...arguments);
       }
-    }
-  });
+    }));
 
-  bootApplication();
-
-  equal(appModelCount, 1);
-  equal(indexModelCount, 1);
-
-  let indexController = container.lookup('controller:index');
-  setAndFlush(indexController, 'omg', 'lex');
-
-  equal(appModelCount, 1);
-  equal(indexModelCount, 2);
-});
-
-QUnit.test('can use refreshModel even w URL changes that remove QPs from address bar', function() {
-  expect(4);
-
-  App.IndexController = Controller.extend({
-    queryParams: ['omg'],
-    omg: 'lol'
-  });
-
-  let indexModelCount = 0;
-  App.IndexRoute = Route.extend({
-    queryParams: {
-      omg: {
-        refreshModel: true
+    this.setSingleQPController('about', 'lol', 'haha', {
+      init() {
+        this._super(...arguments);
+        assert.ok(aboutShouldBeCreated, 'AboutController should be created at this time');
       }
-    },
-    model(params) {
-      indexModelCount++;
+    });
 
-      let data;
-      if (indexModelCount === 1) {
-        data = 'foo';
-      } else if (indexModelCount === 2) {
-        data = 'lol';
-      }
-
-      deepEqual(params, { omg: data }, 'index#model receives right data');
-    }
-  });
-
-  startingURL = '/?omg=foo';
-  bootApplication();
-  handleURL('/');
-
-  let indexController = container.lookup('controller:index');
-  equal(indexController.get('omg'), 'lol');
-});
-
-QUnit.test('can opt into a replace query by specifying replace:true in the Router config hash', function() {
-  expect(2);
-  App.ApplicationController = Controller.extend({
-    queryParams: ['alex'],
-    alex: 'matchneer'
-  });
-
-  App.ApplicationRoute = Route.extend({
-    queryParams: {
-      alex: {
-        replace: true
-      }
-    }
-  });
-
-  bootApplication();
-
-  equal(router.get('location.path'), '');
-
-  let appController = container.lookup('controller:application');
-  expectedReplaceURL = '/?alex=wallace';
-  setAndFlush(appController, 'alex', 'wallace');
-});
-
-QUnit.test('Route query params config can be configured using property name instead of URL key', function() {
-  expect(2);
-  App.ApplicationController = Controller.extend({
-    queryParams: [
-      { commitBy: 'commit_by' }
-    ]
-  });
-
-  App.ApplicationRoute = Route.extend({
-    queryParams: {
-      commitBy: {
-        replace: true
-      }
-    }
-  });
-
-  bootApplication();
-
-  equal(router.get('location.path'), '');
-
-  let appController = container.lookup('controller:application');
-  expectedReplaceURL = '/?commit_by=igor_seb';
-  setAndFlush(appController, 'commitBy', 'igor_seb');
-});
-
-
-QUnit.test('An explicit replace:false on a changed QP always wins and causes a pushState', function() {
-  expect(3);
-  App.ApplicationController = Controller.extend({
-    queryParams: ['alex', 'steely'],
-    alex: 'matchneer',
-    steely: 'dan'
-  });
-
-  App.ApplicationRoute = Route.extend({
-    queryParams: {
-      alex: {
-        replace: true
+    this.registerRoute('cats.index', Route.extend({
+      model() {
+        return [];
       },
-      steely: {
-        replace: false
+      setup() {
+        catsIndexShouldBeCreated = true;
+        this._super(...arguments);
+      },
+      setupController(controller, context) {
+        controller.set('model', context);
       }
-    }
-  });
+    }));
 
-  bootApplication();
+    this.registerController('cats.index', Controller.extend({
+      queryParams: ['breed', 'name'],
+      breed: 'Golden',
+      name: null,
+      init() {
+        this._super(...arguments);
+        assert.ok(catsIndexShouldBeCreated, 'CatsIndexController should be created at this time');
+      }
+    }));
 
-  let appController = container.lookup('controller:application');
-  expectedPushURL = '/?alex=wallace&steely=jan';
-  run(appController, 'setProperties', { alex: 'wallace', steely: 'jan' });
+    return this.visitAndAssert('/').then(() => {
+      let controller = this.getController('home');
 
-  expectedPushURL = '/?alex=wallace&steely=fran';
-  run(appController, 'setProperties', { steely: 'fran' });
+      this.setAndFlush(controller, 'foo', '456');
+      this.assertCurrentPath('/?foo=456');
+      assert.equal(jQuery('#link-to-about').attr('href'), '/about?lol=wat', 'link to about is correct');
 
-  expectedReplaceURL = '/?alex=sriracha&steely=fran';
-  run(appController, 'setProperties', { alex: 'sriracha' });
-});
+      this.transitionTo('about');
+      this.assertCurrentPath('/about');
 
-QUnit.test('can opt into full transition by setting refreshModel in route queryParams when transitioning from child to parent', function() {
-  App.register('template:parent', compile('{{outlet}}'));
-  App.register('template:parent.child', compile('{{link-to \'Parent\' \'parent\' (query-params foo=\'change\') id=\'parent-link\'}}'));
+      this.transitionTo('cats');
+      this.assertCurrentPath('/cats');
+      assert.equal(jQuery('#cats-link').attr('href'), '/cats?name=domino', 'link to cats is correct');
 
-  App.Router.map(function() {
-    this.route('parent', function() {
-      this.route('child');
+      run(jQuery('#cats-link'), 'click');
+      this.assertCurrentPath('/cats?name=domino');
     });
-  });
+  }
 
-  let parentModelCount = 0;
-  App.ParentRoute = Route.extend({
-    model() {
-      parentModelCount++;
-    },
-    queryParams: {
-      foo: {
-        refreshModel: true
+  ['@test query params have been set by the time setupController is called'](assert) {
+    assert.expect(2);
+
+    this.setSingleQPController('application');
+
+    this.registerRoute('application', Route.extend({
+      setupController(controller) {
+        assert.equal(controller.get('foo'), 'YEAH', 'controller\'s foo QP property set before setupController called');
       }
-    }
-  });
+    }));
 
-  App.ParentController = Controller.extend({
-    queryParams: ['foo'],
-    foo: 'abc'
-  });
+    return this.visitAndAssert('/?foo=YEAH');
+  }
 
-  startingURL = '/parent/child?foo=lol';
-  bootApplication();
+  ['@test mapped query params have been set by the time setupController is called'](assert) {
+    assert.expect(2);
 
-  equal(parentModelCount, 1);
+    this.setSingleQPController('application', { faz: 'foo' });
 
-  container.lookup('controller:parent');
-
-  run(jQuery('#parent-link'), 'click');
-
-  equal(parentModelCount, 2);
-});
-
-QUnit.test('Use Ember.get to retrieve query params \'replace\' configuration', function() {
-  expect(2);
-  App.ApplicationController = Controller.extend({
-    queryParams: ['alex'],
-    alex: 'matchneer'
-  });
-
-  App.ApplicationRoute = Route.extend({
-    queryParams: EmberObject.create({
-      unknownProperty(keyName) {
-        // We are simulating all qps requiring refresh
-        return { replace: true };
+    this.registerRoute('application', Route.extend({
+      setupController(controller) {
+        assert.equal(controller.get('faz'), 'YEAH', 'controller\'s foo QP property set before setupController called');
       }
-    })
-  });
+    }));
 
-  bootApplication();
+    return this.visitAndAssert('/?foo=YEAH');
+  }
 
-  equal(router.get('location.path'), '');
+  ['@test Route#paramsFor fetches query params with default value'](assert) {
+    assert.expect(2);
 
-  let appController = container.lookup('controller:application');
-  expectedReplaceURL = '/?alex=wallace';
-  setAndFlush(appController, 'alex', 'wallace');
-});
-
-QUnit.test('can override incoming QP values in setupController', function() {
-  expect(3);
-
-  App.Router.map(function() {
-    this.route('about');
-  });
-
-  App.IndexController = Controller.extend({
-    queryParams: ['omg'],
-    omg: 'lol'
-  });
-
-  App.IndexRoute = Route.extend({
-    setupController(controller) {
-      ok(true, 'setupController called');
-      controller.set('omg', 'OVERRIDE');
-    },
-    actions: {
-      queryParamsDidChange() {
-        ok(false, 'queryParamsDidChange shouldn\'t fire');
-      }
-    }
-  });
-
-  startingURL = '/about';
-  bootApplication();
-  equal(router.get('location.path'), '/about');
-  run(router, 'transitionTo', 'index');
-  equal(router.get('location.path'), '/?omg=OVERRIDE');
-});
-
-QUnit.test('can override incoming QP array values in setupController', function() {
-  expect(3);
-
-  App.Router.map(function() {
-    this.route('about');
-  });
-
-  App.IndexController = Controller.extend({
-    queryParams: ['omg'],
-    omg: ['lol']
-  });
-
-  App.IndexRoute = Route.extend({
-    setupController(controller) {
-      ok(true, 'setupController called');
-      controller.set('omg', ['OVERRIDE']);
-    },
-    actions: {
-      queryParamsDidChange() {
-        ok(false, 'queryParamsDidChange shouldn\'t fire');
-      }
-    }
-  });
-
-  startingURL = '/about';
-  bootApplication();
-  equal(router.get('location.path'), '/about');
-  run(router, 'transitionTo', 'index');
-  equal(router.get('location.path'), '/?omg=' + encodeURIComponent(JSON.stringify(['OVERRIDE'])));
-});
-
-QUnit.test('URL transitions that remove QPs still register as QP changes', function() {
-  expect(2);
-
-  App.IndexController = Controller.extend({
-    queryParams: ['omg'],
-    omg: 'lol'
-  });
-
-  startingURL = '/?omg=borf';
-  bootApplication();
-
-  let indexController = container.lookup('controller:index');
-  equal(indexController.get('omg'), 'borf');
-  run(router, 'transitionTo', '/');
-  equal(indexController.get('omg'), 'lol');
-});
-
-QUnit.test('Subresource naming style is supported', function() {
-  App.Router.map(function() {
-    this.route('abc.def', { path: '/abcdef' }, function() {
-      this.route('zoo');
+    this.router.map(function() {
+      this.route('index', { path: '/:something' });
     });
-  });
 
-  App.register('template:application', compile('{{link-to \'A\' \'abc.def\' (query-params foo=\'123\') id=\'one\'}}{{link-to \'B\' \'abc.def.zoo\' (query-params foo=\'123\' bar=\'456\') id=\'two\'}}{{outlet}}'));
+    this.setSingleQPController('index');
 
-  App.AbcDefController = Controller.extend({
-    queryParams: ['foo'],
-    foo: 'lol'
-  });
-
-  App.AbcDefZooController = Controller.extend({
-    queryParams: ['bar'],
-    bar: 'haha'
-  });
-
-  bootApplication();
-  equal(router.get('location.path'), '');
-  equal(jQuery('#one').attr('href'), '/abcdef?foo=123');
-  equal(jQuery('#two').attr('href'), '/abcdef/zoo?bar=456&foo=123');
-
-  run(jQuery('#one'), 'click');
-  equal(router.get('location.path'), '/abcdef?foo=123');
-  run(jQuery('#two'), 'click');
-  equal(router.get('location.path'), '/abcdef/zoo?bar=456&foo=123');
-});
-
-QUnit.test('transitionTo supports query params', function() {
-  App.IndexController = Controller.extend({
-    queryParams: ['foo'],
-    foo: 'lol'
-  });
-
-  bootApplication();
-
-  equal(router.get('location.path'), '');
-
-  run(router, 'transitionTo', { queryParams: { foo: 'borf' } });
-  equal(router.get('location.path'), '/?foo=borf', 'shorthand supported');
-  run(router, 'transitionTo', { queryParams: { 'index:foo': 'blaf' } });
-  equal(router.get('location.path'), '/?foo=blaf', 'longform supported');
-  run(router, 'transitionTo', { queryParams: { 'index:foo': false } });
-  equal(router.get('location.path'), '/?foo=false', 'longform supported (bool)');
-  run(router, 'transitionTo', { queryParams: { foo: false } });
-  equal(router.get('location.path'), '/?foo=false', 'shorhand supported (bool)');
-});
-
-QUnit.test('transitionTo supports query params (multiple)', function() {
-  App.IndexController = Controller.extend({
-    queryParams: ['foo', 'bar'],
-    foo: 'lol',
-    bar: 'wat'
-  });
-
-  bootApplication();
-
-  equal(router.get('location.path'), '');
-
-  run(router, 'transitionTo', { queryParams: { foo: 'borf' } });
-  equal(router.get('location.path'), '/?foo=borf', 'shorthand supported');
-  run(router, 'transitionTo', { queryParams: { 'index:foo': 'blaf' } });
-  equal(router.get('location.path'), '/?foo=blaf', 'longform supported');
-  run(router, 'transitionTo', { queryParams: { 'index:foo': false } });
-  equal(router.get('location.path'), '/?foo=false', 'longform supported (bool)');
-  run(router, 'transitionTo', { queryParams: { foo: false } });
-  equal(router.get('location.path'), '/?foo=false', 'shorhand supported (bool)');
-});
-
-QUnit.test('setting controller QP to empty string doesn\'t generate null in URL', function() {
-  expect(1);
-  App.IndexController = Controller.extend({
-    queryParams: ['foo'],
-    foo: '123'
-  });
-
-  bootApplication();
-  let controller = container.lookup('controller:index');
-
-  expectedPushURL = '/?foo=';
-  setAndFlush(controller, 'foo', '');
-});
-
-QUnit.test('setting QP to empty string doesn\'t generate null in URL', function() {
-  expect(1);
-  App.IndexRoute = Route.extend({
-    queryParams: {
-      foo: {
-        defaultValue: '123'
+    this.registerRoute('index', Route.extend({
+      model(params, transition) {
+        assert.deepEqual(this.paramsFor('index'), { something: 'baz', foo: 'bar' }, 'could retrieve params for index');
       }
-    }
-  });
+    }));
 
-  bootApplication();
-  let controller = container.lookup('controller:index');
+    return this.visitAndAssert('/baz');
+  }
 
-  expectedPushURL = '/?foo=';
-  setAndFlush(controller, 'foo', '');
-});
+  ['@test Route#paramsFor fetches query params with non-default value'](assert) {
+    assert.expect(2);
 
-QUnit.test('A default boolean value deserializes QPs as booleans rather than strings', function() {
-  App.IndexController = Controller.extend({
-    queryParams: ['foo'],
-    foo: false
-  });
+    this.router.map(function() {
+      this.route('index', { path: '/:something' });
+    });
 
-  App.IndexRoute = Route.extend({
-    model(params) {
-      equal(params.foo, true, 'model hook received foo as boolean true');
-    }
-  });
+    this.setSingleQPController('index');
 
-  startingURL = '/?foo=true';
-  bootApplication();
-
-  let controller = container.lookup('controller:index');
-  equal(controller.get('foo'), true);
-
-  handleURL('/?foo=false');
-  equal(controller.get('foo'), false);
-});
-
-QUnit.test('Query param without value are empty string', function() {
-  App.IndexController = Controller.extend({
-    queryParams: ['foo'],
-    foo: ''
-  });
-
-  startingURL = '/?foo=';
-  bootApplication();
-
-  let controller = container.lookup('controller:index');
-  equal(controller.get('foo'), '');
-});
-
-QUnit.test('Array query params can be set', function() {
-  App.Router.map(function() {
-    this.route('home', { path: '/' });
-  });
-
-  App.HomeController = Controller.extend({
-    queryParams: ['foo'],
-    foo: []
-  });
-
-  bootApplication();
-
-  let controller = container.lookup('controller:home');
-
-  setAndFlush(controller, 'foo', [1, 2]);
-
-  equal(router.get('location.path'), '/?foo=%5B1%2C2%5D');
-
-  setAndFlush(controller, 'foo', [3, 4]);
-  equal(router.get('location.path'), '/?foo=%5B3%2C4%5D');
-});
-
-QUnit.test('(de)serialization: arrays', function() {
-  App.IndexController = Controller.extend({
-    queryParams: ['foo'],
-    foo: [1]
-  });
-
-  bootApplication();
-
-  equal(router.get('location.path'), '');
-
-  run(router, 'transitionTo', { queryParams: { foo: [2, 3] } });
-  equal(router.get('location.path'), '/?foo=%5B2%2C3%5D', 'shorthand supported');
-  run(router, 'transitionTo', { queryParams: { 'index:foo': [4, 5] } });
-  equal(router.get('location.path'), '/?foo=%5B4%2C5%5D', 'longform supported');
-  run(router, 'transitionTo', { queryParams: { foo: [] } });
-  equal(router.get('location.path'), '/?foo=%5B%5D', 'longform supported');
-});
-
-QUnit.test('Url with array query param sets controller property to array', function() {
-  App.IndexController = Controller.extend({
-    queryParams: ['foo'],
-    foo: ''
-  });
-
-  startingURL = '/?foo[]=1&foo[]=2&foo[]=3';
-  bootApplication();
-
-  let controller = container.lookup('controller:index');
-  deepEqual(controller.get('foo'), ['1', '2', '3']);
-});
-
-QUnit.test('Array query params can be pushed/popped', function() {
-  App.Router.map(function() {
-    this.route('home', { path: '/' });
-  });
-
-  App.HomeController = Controller.extend({
-    queryParams: ['foo'],
-    foo: emberA()
-  });
-
-  bootApplication();
-
-  equal(router.get('location.path'), '');
-
-  let controller = container.lookup('controller:home');
-
-  run(controller.foo, 'pushObject', 1);
-  equal(router.get('location.path'), '/?foo=%5B1%5D');
-  deepEqual(controller.foo, [1]);
-  run(controller.foo, 'popObject');
-  equal(router.get('location.path'), '/');
-  deepEqual(controller.foo, []);
-  run(controller.foo, 'pushObject', 1);
-  equal(router.get('location.path'), '/?foo=%5B1%5D');
-  deepEqual(controller.foo, [1]);
-  run(controller.foo, 'popObject');
-  equal(router.get('location.path'), '/');
-  deepEqual(controller.foo, []);
-  run(controller.foo, 'pushObject', 1);
-  equal(router.get('location.path'), '/?foo=%5B1%5D');
-  deepEqual(controller.foo, [1]);
-  run(controller.foo, 'pushObject', 2);
-  equal(router.get('location.path'), '/?foo=%5B1%2C2%5D');
-  deepEqual(controller.foo, [1, 2]);
-  run(controller.foo, 'popObject');
-  equal(router.get('location.path'), '/?foo=%5B1%5D');
-  deepEqual(controller.foo, [1]);
-  run(controller.foo, 'unshiftObject', 'lol');
-  equal(router.get('location.path'), '/?foo=%5B%22lol%22%2C1%5D');
-  deepEqual(controller.foo, ['lol', 1]);
-});
-
-QUnit.test('Overwriting with array with same content shouldn\'t refire update', function() {
-  expect(3);
-  let modelCount = 0;
-
-  App.Router.map(function() {
-    this.route('home', { path: '/' });
-  });
-
-  App.HomeRoute = Route.extend({
-    model() {
-      modelCount++;
-    }
-  });
-
-  App.HomeController = Controller.extend({
-    queryParams: ['foo'],
-    foo: emberA([1])
-  });
-
-  bootApplication();
-
-  equal(modelCount, 1);
-  let controller = container.lookup('controller:home');
-  setAndFlush(controller, 'model', emberA([1]));
-  equal(modelCount, 1);
-  equal(router.get('location.path'), '');
-});
-
-QUnit.test('Defaulting to params hash as the model should not result in that params object being watched', function() {
-  expect(1);
-
-  App.Router.map(function() {
-    this.route('other');
-  });
-
-  // This causes the params hash, which is returned as a route's
-  // model if no other model could be resolved given the provided
-  // params (and no custom model hook was defined), to be watched,
-  // unless we return a copy of the params hash.
-  App.ApplicationController = Controller.extend({
-    queryParams: ['woot'],
-    woot: 'wat'
-  });
-
-  App.OtherRoute = Route.extend({
-    model(p, trans) {
-      let m = meta(trans.params.application);
-      ok(!m.peekWatching('woot'), 'A meta object isn\'t constructed for this params POJO');
-    }
-  });
-
-  bootApplication();
-
-  run(router, 'transitionTo', 'other');
-});
-
-QUnit.test('A child of a resource route still defaults to parent route\'s model even if the child route has a query param', function() {
-  expect(1);
-
-  App.IndexController = Controller.extend({
-    queryParams: ['woot']
-  });
-
-  App.ApplicationRoute = Route.extend({
-    model(p, trans) {
-      return { woot: true };
-    }
-  });
-
-  App.IndexRoute = Route.extend({
-    setupController(controller, model) {
-      deepEqual(model, { woot: true }, 'index route inherited model route from parent route');
-    }
-  });
-
-  bootApplication();
-});
-
-QUnit.test('opting into replace does not affect transitions between routes', function() {
-  expect(5);
-  App.register('template:application', compile(
-    '{{link-to \'Foo\' \'foo\' id=\'foo-link\'}}' +
-    '{{link-to \'Bar\' \'bar\' id=\'bar-no-qp-link\'}}' +
-    '{{link-to \'Bar\' \'bar\' (query-params raytiley=\'isthebest\') id=\'bar-link\'}}' +
-    '{{outlet}}'
-  ));
-  App.Router.map(function() {
-    this.route('foo');
-    this.route('bar');
-  });
-
-  App.BarController = Controller.extend({
-    queryParams: ['raytiley'],
-    raytiley: 'israd'
-  });
-
-  App.BarRoute = Route.extend({
-    queryParams: {
-      raytiley: {
-        replace: true
+    this.registerRoute('index', Route.extend({
+      model(params, transition) {
+        assert.deepEqual(this.paramsFor('index'), { something: 'baz', foo: 'boo' }, 'could retrieve params for index');
       }
-    }
-  });
+    }));
 
-  bootApplication();
-  let controller = container.lookup('controller:bar');
+    return this.visitAndAssert('/baz?foo=boo');
+  }
 
-  expectedPushURL = '/foo';
-  run(jQuery('#foo-link'), 'click');
+  ['@test Route#paramsFor fetches default falsy query params'](assert) {
+    assert.expect(2);
 
-  expectedPushURL = '/bar';
-  run(jQuery('#bar-no-qp-link'), 'click');
+    this.router.map(function() {
+      this.route('index', { path: '/:something' });
+    });
 
-  expectedReplaceURL = '/bar?raytiley=woot';
-  setAndFlush(controller, 'raytiley', 'woot');
+    this.setSingleQPController('index', 'foo', false);
 
-  expectedPushURL = '/foo';
-  run(jQuery('#foo-link'), 'click');
-
-  expectedPushURL = '/bar?raytiley=isthebest';
-  run(jQuery('#bar-link'), 'click');
-});
-
-QUnit.test('Undefined isn\'t deserialized into a string', function() {
-  expect(3);
-  App.Router.map(function() {
-    this.route('example');
-  });
-
-  App.register('template:application', compile('{{link-to \'Example\' \'example\' id=\'the-link\'}}'));
-
-  App.ExampleController = Controller.extend({
-    queryParams: ['foo']
-    // uncommon to not support default value, but should assume undefined.
-  });
-
-  App.ExampleRoute = Route.extend({
-    model(params) {
-      deepEqual(params, { foo: undefined });
-    }
-  });
-
-  bootApplication();
-
-  let $link = jQuery('#the-link');
-  equal($link.attr('href'), '/example');
-  run($link, 'click');
-
-  let controller = container.lookup('controller:example');
-  equal(get(controller, 'foo'), undefined);
-});
-
-QUnit.test('when refreshModel is true and loading action returns false, model hook will rerun when QPs change even if previous did not finish', function() {
-  expect(6);
-
-  var appModelCount = 0;
-  var promiseResolve;
-
-  App.ApplicationRoute = Route.extend({
-    queryParams: {
-      'appomg': {
-        defaultValue: 'applol'
+    this.registerRoute('index', Route.extend({
+      model(params, transition) {
+        assert.deepEqual(this.paramsFor('index'), { something: 'baz', foo: false }, 'could retrieve params for index');
       }
-    },
-    model(params) {
-      appModelCount++;
-    }
-  });
+    }));
 
-  App.IndexController = Controller.extend({
-    queryParams: ['omg']
-    // uncommon to not support default value, but should assume undefined.
-  });
+    return this.visitAndAssert('/baz');
+  }
 
-  var indexModelCount = 0;
-  App.IndexRoute = Route.extend({
-    queryParams: {
-      omg: {
-        refreshModel: true
+  ['@test Route#paramsFor fetches non-default falsy query params'](assert) {
+    assert.expect(2);
+
+    this.router.map(function() {
+      this.route('index', { path: '/:something' });
+    });
+
+    this.setSingleQPController('index', 'foo', true);
+
+    this.registerRoute('index', Route.extend({
+      model(params, transition) {
+        assert.deepEqual(this.paramsFor('index'), { something: 'baz', foo: false }, 'could retrieve params for index');
       }
-    },
-    actions: {
-      loading: function() {
-        return false;
+    }));
+
+    return this.visitAndAssert('/baz?foo=false');
+  }
+
+  ['@test model hook can query prefix-less application params'](assert) {
+    assert.expect(4);
+
+    this.setSingleQPController('application', 'appomg', 'applol');
+    this.setSingleQPController('index', 'omg', 'lol');
+
+    this.registerRoute('application', Route.extend({
+      model(params) {
+        assert.deepEqual(params, { appomg: 'applol' });
       }
-    },
-    model(params) {
-      indexModelCount++;
-      if (indexModelCount === 2) {
-        deepEqual(params, { omg: 'lex' });
-        return new RSVP.Promise(function(resolve) {
-          promiseResolve = resolve;
-          return;
-        });
-      } else if (indexModelCount === 3) {
-        deepEqual(params, { omg: 'hello' }, 'Model hook reruns even if the previous one didnt finish');
+    }));
+
+    this.registerRoute('index', Route.extend({
+      model(params) {
+        assert.deepEqual(params, { omg: 'lol' });
+        assert.deepEqual(this.paramsFor('application'), { appomg: 'applol' });
       }
-    }
-  });
+    }));
 
-  bootApplication();
+    return this.visitAndAssert('/');
+  }
 
-  equal(indexModelCount, 1);
+  ['@test model hook can query prefix-less application params (overridden by incoming url value)'](assert) {
+    assert.expect(4);
 
-  var indexController = container.lookup('controller:index');
-  setAndFlush(indexController, 'omg', 'lex');
-  equal(indexModelCount, 2);
+    this.setSingleQPController('application', 'appomg', 'applol');
+    this.setSingleQPController('index', 'omg', 'lol');
 
-  setAndFlush(indexController, 'omg', 'hello');
-  equal(indexModelCount, 3);
-  run(function() {
-    promiseResolve();
-  });
-  equal(get(indexController, 'omg'), 'hello', 'At the end last value prevails');
-});
-
-QUnit.test('when refreshModel is true and loading action does not return false, model hook will not rerun when QPs change even if previous did not finish', function() {
-  expect(7);
-
-  var appModelCount = 0;
-  var promiseResolve;
-
-  App.ApplicationRoute = Route.extend({
-    queryParams: {
-      'appomg': {
-        defaultValue: 'applol'
+    this.registerRoute('application', Route.extend({
+      model(params) {
+        assert.deepEqual(params, { appomg: 'appyes' });
       }
-    },
-    model(params) {
-      appModelCount++;
-    }
-  });
+    }));
 
-  App.IndexController = Controller.extend({
-    queryParams: ['omg']
-    // uncommon to not support default value, but should assume undefined.
-  });
-
-  var indexModelCount = 0;
-  App.IndexRoute = Route.extend({
-    queryParams: {
-      omg: {
-        refreshModel: true
+    this.registerRoute('index', Route.extend({
+      model(params) {
+        assert.deepEqual(params, { omg: 'yes' });
+        assert.deepEqual(this.paramsFor('application'), { appomg: 'appyes' });
       }
-    },
-    model(params) {
-      indexModelCount++;
+    }));
 
-      if (indexModelCount === 2) {
-        deepEqual(params, { omg: 'lex' });
-        return new RSVP.Promise(function(resolve) {
-          promiseResolve = resolve;
-          return;
-        });
-      } else if (indexModelCount === 3) {
-        ok(false, 'shouldnt get here');
+    return this.visitAndAssert('/?appomg=appyes&omg=yes');
+  }
+
+  ['@test can opt into full transition by setting refreshModel in route queryParams'](assert) {
+    assert.expect(7);
+
+    this.setSingleQPController('application', 'appomg', 'applol');
+    this.setSingleQPController('index', 'omg', 'lol');
+
+    let appModelCount = 0;
+    this.registerRoute('application', Route.extend({
+      model(params) {
+        appModelCount++;
       }
-    }
-  });
+    }));
 
-  bootApplication();
+    let indexModelCount = 0;
+    this.registerRoute('index', Route.extend({
+      queryParams: {
+        omg: {
+          refreshModel: true
+        }
+      },
+      model(params) {
+        indexModelCount++;
 
-  equal(appModelCount, 1);
-  equal(indexModelCount, 1);
-
-  var indexController = container.lookup('controller:index');
-  setAndFlush(indexController, 'omg', 'lex');
-
-  equal(appModelCount, 1);
-  equal(indexModelCount, 2);
-
-  setAndFlush(indexController, 'omg', 'hello');
-  equal(get(indexController, 'omg'), 'hello', ' value was set');
-  equal(indexModelCount, 2);
-  run(function() {
-    promiseResolve();
-  });
-});
-
-
-QUnit.test('warn user that routes query params configuration must be an Object, not an Array', function() {
-  expect(1);
-
-  App.ApplicationRoute = Route.extend({
-    queryParams: [
-      { commitBy: { replace: true } }
-    ]
-  });
-
-  expectAssertion(function() {
-    bootApplication();
-  }, 'You passed in `[{"commitBy":{"replace":true}}]` as the value for `queryParams` but `queryParams` cannot be an Array');
-});
-
-QUnit.test('handle routes names that clash with Object.prototype properties', function() {
-  expect(1);
-
-  App.Router.map(function() {
-    this.route('constructor');
-  });
-
-  App.ConstructorRoute = Route.extend({
-    queryParams: {
-      foo: {
-        defaultValue: '123'
+        if (indexModelCount === 1) {
+          assert.deepEqual(params, { omg: 'lol' }, 'params are correct on first pass');
+        } else if (indexModelCount === 2) {
+          assert.deepEqual(params, { omg: 'lex' }, 'params are correct on second pass');
+        }
       }
-    }
-  });
+    }));
 
-  bootApplication();
+    return this.visitAndAssert('/').then(() => {
+      assert.equal(appModelCount, 1, 'app model hook ran');
+      assert.equal(indexModelCount, 1, 'index model hook ran');
 
-  run(router, 'transitionTo', 'constructor', { queryParams: { foo: '999' } });
+      let indexController = this.getController('index');
+      this.setAndFlush(indexController, 'omg', 'lex');
 
-  let controller = container.lookup('controller:constructor');
-  equal(get(controller, 'foo'), '999');
+      assert.equal(appModelCount, 1, 'app model hook did not run again');
+      assert.equal(indexModelCount, 2, 'index model hook ran again due to refreshModel');
+    });
+  }
+
+  ['@test refreshModel does not cause a second transition during app boot '](assert) {
+    assert.expect(1);
+
+    this.setSingleQPController('application', 'appomg', 'applol');
+    this.setSingleQPController('index', 'omg', 'lol');
+
+    this.registerRoute('index', Route.extend({
+      queryParams: {
+        omg: {
+          refreshModel: true
+        }
+      },
+      refresh() {
+        assert.ok(false);
+      }
+    }));
+
+    return this.visitAndAssert('/?appomg=hello&omg=world');
+  }
+
+  ['@test queryParams are updated when a controller property is set and the route is refreshed. Issue #13263  '](assert) {
+    this.registerTemplate('application', '<button id="test-button" {{action \'increment\'}}>Increment</button><span id="test-value">{{foo}}</span>{{outlet}}');
+
+    this.setSingleQPController('application', 'foo', 1, {
+      actions: {
+        increment() {
+          this.incrementProperty('foo');
+          this.send('refreshRoute');
+        }
+      }
+    });
+
+    this.registerRoute('application', Route.extend({
+      actions: {
+        refreshRoute() {
+          this.refresh();
+        }
+      }
+    }));
+
+    return this.visitAndAssert('/').then(() => {
+      assert.equal(jQuery('#test-value').text().trim(), '1');
+
+      run(jQuery('#test-button'), 'click');
+      assert.equal(jQuery('#test-value').text().trim(), '2');
+      this.assertCurrentPath('/?foo=2');
+
+      run(jQuery('#test-button'), 'click');
+      assert.equal(jQuery('#test-value').text().trim(), '3');
+      this.assertCurrentPath('/?foo=3');
+    });
+  }
+
+  ['@test Use Ember.get to retrieve query params \'refreshModel\' configuration'](assert) {
+    assert.expect(7);
+
+    this.setSingleQPController('application', 'appomg', 'applol');
+    this.setSingleQPController('index', 'omg', 'lol');
+
+    let appModelCount = 0;
+    this.registerRoute('application', Route.extend({
+      model(params) {
+        appModelCount++;
+      }
+    }));
+
+    let indexModelCount = 0;
+    this.registerRoute('index', Route.extend({
+      queryParams: EmberObject.create({
+        unknownProperty(keyName) {
+          return { refreshModel: true };
+        }
+      }),
+      model(params) {
+        indexModelCount++;
+
+        if (indexModelCount === 1) {
+          assert.deepEqual(params, { omg: 'lol' });
+        } else if (indexModelCount === 2) {
+          assert.deepEqual(params, { omg: 'lex' });
+        }
+      }
+    }));
+
+    return this.visitAndAssert('/').then(() => {
+      assert.equal(appModelCount, 1);
+      assert.equal(indexModelCount, 1);
+
+      let indexController = this.getController('index');
+      this.setAndFlush(indexController, 'omg', 'lex');
+
+      assert.equal(appModelCount, 1);
+      assert.equal(indexModelCount, 2);
+    });
+  }
+
+  ['@test can use refreshModel even with URL changes that remove QPs from address bar'](assert) {
+    assert.expect(4);
+
+    this.setSingleQPController('index', 'omg', 'lol');
+
+    let indexModelCount = 0;
+    this.registerRoute('index', Route.extend({
+      queryParams: {
+        omg: {
+          refreshModel: true
+        }
+      },
+      model(params) {
+        indexModelCount++;
+
+        let data;
+        if (indexModelCount === 1) {
+          data = 'foo';
+        } else if (indexModelCount === 2) {
+          data = 'lol';
+        }
+
+        assert.deepEqual(params, { omg: data }, 'index#model receives right data');
+      }
+    }));
+
+    return this.visitAndAssert('/?omg=foo').then(() => {
+      this.transitionTo('/');
+
+      let indexController = this.getController('index');
+      assert.equal(indexController.get('omg'), 'lol');
+    });
+  }
+
+  ['@test can opt into a replace query by specifying replace:true in the Route config hash'](assert) {
+    assert.expect(2);
+
+    this.setSingleQPController('application', 'alex', 'matchneer');
+
+    this.registerRoute('application', Route.extend({
+      queryParams: {
+        alex: {
+          replace: true
+        }
+      }
+    }));
+
+    return this.visitAndAssert('/').then(() => {
+      let appController = this.getController('application');
+      this.expectedReplaceURL = '/?alex=wallace';
+      this.setAndFlush(appController, 'alex', 'wallace');
+    });
+  }
+
+  ['@test Route query params config can be configured using property name instead of URL key'](assert) {
+    assert.expect(2);
+
+    this.registerController('application', Controller.extend({
+      queryParams: [{ commitBy: 'commit_by' }]
+    }));
+
+    this.registerRoute('application', Route.extend({
+      queryParams: {
+        commitBy: {
+          replace: true
+        }
+      }
+    }));
+
+    return this.visitAndAssert('/').then(() => {
+      let appController = this.getController('application');
+      this.expectedReplaceURL = '/?commit_by=igor_seb';
+      this.setAndFlush(appController, 'commitBy', 'igor_seb');
+    });
+  }
+
+  ['@test An explicit replace:false on a changed QP always wins and causes a pushState'](assert) {
+    assert.expect(3);
+
+    this.registerController('application', Controller.extend({
+      queryParams: ['alex', 'steely'],
+      alex: 'matchneer',
+      steely: 'dan'
+    }));
+
+    this.registerRoute('application', Route.extend({
+      queryParams: {
+        alex: {
+          replace: true
+        },
+        steely: {
+          replace: false
+        }
+      }
+    }));
+
+    return this.visit('/').then(() => {
+      let appController = this.getController('application');
+      this.expectedPushURL = '/?alex=wallace&steely=jan';
+      run(appController, 'setProperties', { alex: 'wallace', steely: 'jan' });
+
+      this.expectedPushURL = '/?alex=wallace&steely=fran';
+      run(appController, 'setProperties', { steely: 'fran' });
+
+      this.expectedReplaceURL = '/?alex=sriracha&steely=fran';
+      run(appController, 'setProperties', { alex: 'sriracha' });
+    });
+  }
+
+  ['@test can opt into full transition by setting refreshModel in route queryParams when transitioning from child to parent'](assert) {
+    this.registerTemplate('parent', '{{outlet}}');
+    this.registerTemplate('parent.child', '{{link-to \'Parent\' \'parent\' (query-params foo=\'change\') id=\'parent-link\'}}');
+
+    this.router.map(function() {
+      this.route('parent', function() {
+        this.route('child');
+      });
+    });
+
+    let parentModelCount = 0;
+    this.registerRoute('parent', Route.extend({
+      model() {
+        parentModelCount++;
+      },
+      queryParams: {
+        foo: {
+          refreshModel: true
+        }
+      }
+    }));
+
+    this.setSingleQPController('parent', 'foo', 'abc');
+
+    return this.visit('/parent/child?foo=lol').then(() => {
+      assert.equal(parentModelCount, 1);
+
+      run(jQuery('#parent-link'), 'click');
+      assert.equal(parentModelCount, 2);
+    });
+  }
+
+  ['@test Use Ember.get to retrieve query params \'replace\' configuration'](assert) {
+    assert.expect(2);
+
+    this.setSingleQPController('application', 'alex', 'matchneer');
+
+    this.registerRoute('application', Route.extend({
+      queryParams: EmberObject.create({
+        unknownProperty(keyName) {
+          // We are simulating all qps requiring refresh
+          return { replace: true };
+        }
+      })
+    }));
+
+    return this.visitAndAssert('/').then(() => {
+      let appController = this.getController('application');
+      this.expectedReplaceURL = '/?alex=wallace';
+      this.setAndFlush(appController, 'alex', 'wallace');
+    });
+  }
+
+  ['@test can override incoming QP values in setupController'](assert) {
+    assert.expect(3);
+
+    this.router.map(function() {
+      this.route('about');
+    });
+
+    this.setSingleQPController('index', 'omg', 'lol');
+
+    this.registerRoute('index', Route.extend({
+      setupController(controller) {
+        assert.ok(true, 'setupController called');
+        controller.set('omg', 'OVERRIDE');
+      },
+      actions: {
+        queryParamsDidChange() {
+          assert.ok(false, 'queryParamsDidChange shouldn\'t fire');
+        }
+      }
+    }));
+
+    return this.visitAndAssert('/about').then(() => {
+      this.transitionTo('index');
+      this.assertCurrentPath('/?omg=OVERRIDE');
+    });
+  }
+
+  ['@test can override incoming QP array values in setupController'](assert) {
+    assert.expect(3);
+
+    this.router.map(function() {
+      this.route('about');
+    });
+
+    this.setSingleQPController('index', 'omg', ['lol']);
+
+    this.registerRoute('index', Route.extend({
+      setupController(controller) {
+        assert.ok(true, 'setupController called');
+        controller.set('omg', ['OVERRIDE']);
+      },
+      actions: {
+        queryParamsDidChange() {
+          assert.ok(false, 'queryParamsDidChange shouldn\'t fire');
+        }
+      }
+    }));
+
+    return this.visitAndAssert('/about').then(() => {
+      this.transitionTo('index');
+      this.assertCurrentPath('/?omg=' + encodeURIComponent(JSON.stringify(['OVERRIDE'])));
+    });
+  }
+
+  ['@test URL transitions that remove QPs still register as QP changes'](assert) {
+    assert.expect(2);
+
+    this.setSingleQPController('index', 'omg', 'lol');
+
+    return this.visit('/?omg=borf').then(() => {
+      let indexController = this.getController('index');
+      assert.equal(indexController.get('omg'), 'borf');
+
+      this.transitionTo('/');
+      assert.equal(indexController.get('omg'), 'lol');
+    });
+  }
+
+  ['@test Subresource naming style is supported'](assert) {
+    assert.expect(5);
+
+    this.router.map(function() {
+      this.route('abc.def', { path: '/abcdef' }, function() {
+        this.route('zoo');
+      });
+    });
+
+    this.registerTemplate('application', '{{link-to \'A\' \'abc.def\' (query-params foo=\'123\') id=\'one\'}}{{link-to \'B\' \'abc.def.zoo\' (query-params foo=\'123\' bar=\'456\') id=\'two\'}}{{outlet}}');
+
+    this.setSingleQPController('abc.def', 'foo', 'lol');
+    this.setSingleQPController('abc.def.zoo', 'bar', 'haha');
+
+    return this.visitAndAssert('/').then(() => {
+      assert.equal(jQuery('#one').attr('href'), '/abcdef?foo=123');
+      assert.equal(jQuery('#two').attr('href'), '/abcdef/zoo?bar=456&foo=123');
+
+      run(jQuery('#one'), 'click');
+      this.assertCurrentPath('/abcdef?foo=123');
+
+      run(jQuery('#two'), 'click');
+      this.assertCurrentPath('/abcdef/zoo?bar=456&foo=123');
+    });
+  }
+
+  ['@test transitionTo supports query params'](assert) {
+    this.setSingleQPController('index', 'foo', 'lol');
+
+    return this.visitAndAssert('/').then(() => {
+      this.transitionTo({ queryParams: { foo: 'borf' } });
+      this.assertCurrentPath('/?foo=borf', 'shorthand supported');
+
+      this.transitionTo({ queryParams: { 'index:foo': 'blaf' } });
+      this.assertCurrentPath('/?foo=blaf', 'longform supported');
+
+      this.transitionTo({ queryParams: { 'index:foo': false } });
+      this.assertCurrentPath('/?foo=false', 'longform supported (bool)');
+
+      this.transitionTo({ queryParams: { foo: false } });
+      this.assertCurrentPath('/?foo=false', 'shorhand supported (bool)');
+    });
+  }
+
+  ['@test transitionTo supports query params (multiple)'](assert) {
+    this.registerController('index', Controller.extend({
+      queryParams: ['foo', 'bar'],
+      foo: 'lol',
+      bar: 'wat'
+    }));
+
+    return this.visitAndAssert('/').then(() => {
+      this.transitionTo({ queryParams: { foo: 'borf' } });
+      this.assertCurrentPath('/?foo=borf', 'shorthand supported');
+
+      this.transitionTo({ queryParams: { 'index:foo': 'blaf' } });
+      this.assertCurrentPath('/?foo=blaf', 'longform supported');
+
+      this.transitionTo({ queryParams: { 'index:foo': false } });
+      this.assertCurrentPath('/?foo=false', 'longform supported (bool)');
+
+      this.transitionTo({ queryParams: { foo: false } });
+      this.assertCurrentPath('/?foo=false', 'shorhand supported (bool)');
+    });
+  }
+
+  ['@test setting controller QP to empty string doesn\'t generate null in URL'](assert) {
+    assert.expect(1);
+
+    this.setSingleQPController('index', 'foo', '123');
+
+    return this.visit('/').then(() => {
+      let controller = this.getController('index');
+
+      this.expectedPushURL = '/?foo=';
+      this.setAndFlush(controller, 'foo', '');
+    });
+  }
+
+  ['@test setting QP to empty string doesn\'t generate null in URL'](assert) {
+    assert.expect(1);
+
+    this.registerRoute('index', Route.extend({
+      queryParams: {
+        foo: {
+          defaultValue: '123'
+        }
+      }
+    }));
+
+    return this.visit('/').then(() => {
+      let controller = this.getController('index');
+
+      this.expectedPushURL = '/?foo=';
+      this.setAndFlush(controller, 'foo', '');
+    });
+  }
+
+  ['@test A default boolean value deserializes QPs as booleans rather than strings'](assert) {
+    assert.expect(3);
+
+    this.setSingleQPController('index', 'foo', false);
+
+    this.registerRoute('index', Route.extend({
+      model(params) {
+        assert.equal(params.foo, true, 'model hook received foo as boolean true');
+      }
+    }));
+
+    return this.visit('/?foo=true').then(() => {
+      let controller = this.getController('index');
+      assert.equal(controller.get('foo'), true);
+
+      this.transitionTo('/?foo=false');
+      assert.equal(controller.get('foo'), false);
+    });
+  }
+
+  ['@test Query param without value are empty string'](assert) {
+    assert.expect(1);
+
+    this.registerController('index', Controller.extend({
+      queryParams: ['foo'],
+      foo: ''
+    }));
+
+    return this.visit('/?foo=').then(() => {
+      let controller = this.getController('index');
+      assert.equal(controller.get('foo'), '');
+    });
+  }
+
+  ['@test Array query params can be set'](assert) {
+    assert.expect(2);
+
+    this.router.map(function() {
+      this.route('home', { path: '/' });
+    });
+
+    this.setSingleQPController('home', 'foo', []);
+
+    return this.visit('/').then(() => {
+      let controller = this.getController('home');
+
+      this.setAndFlush(controller, 'foo', [1, 2]);
+      this.assertCurrentPath('/?foo=%5B1%2C2%5D');
+
+      this.setAndFlush(controller, 'foo', [3, 4]);
+      this.assertCurrentPath('/?foo=%5B3%2C4%5D');
+    });
+  }
+
+  ['@test (de)serialization: arrays'](assert) {
+    assert.expect(4);
+
+    this.setSingleQPController('index', 'foo', [1]);
+
+    return this.visitAndAssert('/').then(() => {
+      this.transitionTo({ queryParams: { foo: [2, 3] } });
+      this.assertCurrentPath('/?foo=%5B2%2C3%5D', 'shorthand supported');
+      this.transitionTo({ queryParams: { 'index:foo': [4, 5] } });
+      this.assertCurrentPath('/?foo=%5B4%2C5%5D', 'longform supported');
+      this.transitionTo({ queryParams: { foo: [] } });
+      this.assertCurrentPath('/?foo=%5B%5D', 'longform supported');
+    });
+  }
+
+  ['@test Url with array query param sets controller property to array'](assert) {
+    assert.expect(1);
+
+    this.setSingleQPController('index', 'foo', '');
+
+    return this.visit('/?foo[]=1&foo[]=2&foo[]=3').then(() => {
+      let controller = this.getController('index');
+      assert.deepEqual(controller.get('foo'), ['1', '2', '3']);
+    });
+  }
+
+  ['@test Array query params can be pushed/popped'](assert) {
+    assert.expect(17);
+
+    this.router.map(function() {
+      this.route('home', { path: '/' });
+    });
+
+    this.setSingleQPController('home', 'foo', emberA());
+
+    return this.visitAndAssert('/').then(() => {
+      let controller = this.getController('home');
+
+      run(controller.foo, 'pushObject', 1);
+      this.assertCurrentPath('/?foo=%5B1%5D');
+      assert.deepEqual(controller.foo, [1]);
+
+      run(controller.foo, 'popObject');
+      this.assertCurrentPath('/');
+      assert.deepEqual(controller.foo, []);
+
+      run(controller.foo, 'pushObject', 1);
+      this.assertCurrentPath('/?foo=%5B1%5D');
+      assert.deepEqual(controller.foo, [1]);
+
+      run(controller.foo, 'popObject');
+      this.assertCurrentPath('/');
+      assert.deepEqual(controller.foo, []);
+
+      run(controller.foo, 'pushObject', 1);
+      this.assertCurrentPath('/?foo=%5B1%5D');
+      assert.deepEqual(controller.foo, [1]);
+
+      run(controller.foo, 'pushObject', 2);
+      this.assertCurrentPath('/?foo=%5B1%2C2%5D');
+      assert.deepEqual(controller.foo, [1, 2]);
+
+      run(controller.foo, 'popObject');
+      this.assertCurrentPath('/?foo=%5B1%5D');
+      assert.deepEqual(controller.foo, [1]);
+
+      run(controller.foo, 'unshiftObject', 'lol');
+      this.assertCurrentPath('/?foo=%5B%22lol%22%2C1%5D');
+      assert.deepEqual(controller.foo, ['lol', 1]);
+    });
+  }
+
+  ['@test Overwriting with array with same content shouldn\'t refire update'](assert) {
+    assert.expect(4);
+
+    this.router.map(function() {
+      this.route('home', { path: '/' });
+    });
+
+    let modelCount = 0;
+    this.registerRoute('home', Route.extend({
+      model() {
+        modelCount++;
+      }
+    }));
+
+    this.setSingleQPController('home', 'foo', emberA([1]));
+
+    return this.visitAndAssert('/').then(() => {
+      assert.equal(modelCount, 1);
+
+      let controller = this.getController('home');
+      this.setAndFlush(controller, 'model', emberA([1]));
+
+      assert.equal(modelCount, 1);
+      this.assertCurrentPath('/');
+    });
+  }
+
+  ['@test Defaulting to params hash as the model should not result in that params object being watched'](assert) {
+    assert.expect(1);
+
+    this.router.map(function() {
+      this.route('other');
+    });
+
+    // This causes the params hash, which is returned as a route's
+    // model if no other model could be resolved given the provided
+    // params (and no custom model hook was defined), to be watched,
+    // unless we return a copy of the params hash.
+    this.setSingleQPController('application', 'woot', 'wat');
+
+    this.registerRoute('other', Route.extend({
+      model(p, trans) {
+        let m = meta(trans.params.application);
+        assert.ok(!m.peekWatching('woot'), 'A meta object isn\'t constructed for this params POJO');
+      }
+    }));
+
+    return this.visit('/').then(() => {
+      this.transitionTo('other');
+    });
+  }
+
+  ['@test A child of a resource route still defaults to parent route\'s model even if the child route has a query param'](assert) {
+    assert.expect(2);
+
+    this.setSingleQPController('index', 'woot', undefined, {
+      woot: undefined
+    });
+
+    this.registerRoute('application', Route.extend({
+      model(p, trans) {
+        return { woot: true };
+      }
+    }));
+
+    this.registerRoute('index', Route.extend({
+      setupController(controller, model) {
+        assert.deepEqual(model, { woot: true }, 'index route inherited model route from parent route');
+      }
+    }));
+
+    return this.visitAndAssert('/');
+  }
+
+  ['@test opting into replace does not affect transitions between routes'](assert) {
+    assert.expect(5);
+
+    this.registerTemplate('application', '{{link-to \'Foo\' \'foo\' id=\'foo-link\'}}{{link-to \'Bar\' \'bar\' id=\'bar-no-qp-link\'}}{{link-to \'Bar\' \'bar\' (query-params raytiley=\'isthebest\') id=\'bar-link\'}}{{outlet}}');
+
+    this.router.map(function() {
+      this.route('foo');
+      this.route('bar');
+    });
+
+    this.setSingleQPController('bar', 'raytiley', 'israd');
+
+    this.registerRoute('bar', Route.extend({
+      queryParams: {
+        raytiley: {
+          replace: true
+        }
+      }
+    }));
+
+    return this.visit('/').then(() => {
+      let controller = this.getController('bar');
+
+      this.expectedPushURL = '/foo';
+      run(jQuery('#foo-link'), 'click');
+
+      this.expectedPushURL = '/bar';
+      run(jQuery('#bar-no-qp-link'), 'click');
+
+      this.expectedReplaceURL = '/bar?raytiley=woot';
+      this.setAndFlush(controller, 'raytiley', 'woot');
+
+      this.expectedPushURL = '/foo';
+      run(jQuery('#foo-link'), 'click');
+
+      this.expectedPushURL = '/bar?raytiley=isthebest';
+      run(jQuery('#bar-link'), 'click');
+    });
+  }
+
+  ['@test Undefined isn\'t deserialized into a string'](assert) {
+    assert.expect(3);
+
+    this.router.map(function() {
+      this.route('example');
+    });
+
+    this.registerTemplate('application', '{{link-to \'Example\' \'example\' id=\'the-link\'}}');
+
+    this.setSingleQPController('example', 'foo', undefined, {
+      foo: undefined
+    });
+
+    this.registerRoute('example', Route.extend({
+      model(params) {
+        assert.deepEqual(params, { foo: undefined });
+      }
+    }));
+
+    return this.visit('/').then(() => {
+      let $link = jQuery('#the-link');
+      assert.equal($link.attr('href'), '/example');
+      run($link, 'click');
+
+      let controller = this.getController('example');
+      assert.equal(get(controller, 'foo'), undefined);
+    });
+  }
+
+  ['@test when refreshModel is true and loading action returns false, model hook will rerun when QPs change even if previous did not finish'](assert) {
+    assert.expect(9);
+
+    let appModelCount = 0;
+    let promiseResolve;
+
+    this.registerRoute('application', Route.extend({
+      queryParams: {
+        appomg: {
+          defaultValue: 'applol'
+        }
+      },
+      model(params) {
+        appModelCount++;
+      }
+    }));
+
+    this.setSingleQPController('index', 'omg', undefined, {
+      omg: undefined
+    });
+
+    let indexModelCount = 0;
+    this.registerRoute('index', Route.extend({
+      queryParams: {
+        omg: {
+          refreshModel: true
+        }
+      },
+      actions: {
+        loading: function() {
+          return false;
+        }
+      },
+      model(params) {
+        indexModelCount++;
+        if (indexModelCount === 2) {
+          assert.deepEqual(params, { omg: 'lex' });
+          return new RSVP.Promise(function(resolve) {
+            promiseResolve = resolve;
+            return;
+          });
+        } else if (indexModelCount === 3) {
+          assert.deepEqual(params, { omg: 'hello' }, 'Model hook reruns even if the previous one didnt finish');
+        }
+      }
+    }));
+
+    return this.visit('/').then(() => {
+      assert.equal(appModelCount, 1, 'appModelCount is 1');
+      assert.equal(indexModelCount, 1);
+
+      let indexController = this.getController('index');
+      this.setAndFlush(indexController, 'omg', 'lex');
+
+      assert.equal(appModelCount, 1, 'appModelCount is 1');
+      assert.equal(indexModelCount, 2);
+
+      this.setAndFlush(indexController, 'omg', 'hello');
+      assert.equal(appModelCount, 1, 'appModelCount is 1');
+      assert.equal(indexModelCount, 3);
+
+      run(function() {
+        promiseResolve();
+      });
+
+      assert.equal(get(indexController, 'omg'), 'hello', 'At the end last value prevails');
+    });
+  }
+
+  ['@skip when refreshModel is true and loading action does not return false, model hook will not rerun when QPs change even if previous did not finish'](assert) {
+    assert.expect(9);
+
+    let appModelCount = 0;
+    let promiseResolve;
+
+    this.registerRoute('application', Route.extend({
+      queryParams: {
+        'appomg': {
+          defaultValue: 'applol'
+        }
+      },
+      model(params) {
+        appModelCount++;
+      }
+    }));
+
+    this.setSingleQPController('index', 'omg', undefined, {
+      omg: undefined
+    });
+
+    let indexModelCount = 0;
+    this.registerRoute('index', Route.extend({
+      queryParams: {
+        omg: {
+          refreshModel: true
+        }
+      },
+      model(params) {
+        indexModelCount++;
+
+        if (indexModelCount === 2) {
+          assert.deepEqual(params, { omg: 'lex' }, 'params are correct');
+          return new RSVP.Promise(function(resolve) {
+            promiseResolve = resolve;
+            return;
+          });
+        } else if (indexModelCount === 3) {
+          console.log('not here!');
+          assert.ok(false, 'shouldnt get here');
+        }
+      }
+    }));
+
+    return this.visitAndAssert('/').then(() => {
+      assert.equal(appModelCount, 1, 'appModelCount is 1');
+      assert.equal(indexModelCount, 1);
+
+      let indexController = this.getController('index');
+      this.setAndFlush(indexController, 'omg', 'lex');
+
+      assert.equal(appModelCount, 1, 'appModelCount is 1');
+      assert.equal(indexModelCount, 2);
+
+      this.setAndFlush(indexController, 'omg', 'hello');
+      assert.equal(appModelCount, 1, 'appModelCount is 1');
+      assert.equal(indexModelCount, 2);
+
+      run(function() {
+        promiseResolve();
+      });
+
+      assert.equal(get(indexController, 'omg'), 'hello', 'At the end last value prevails');
+    });
+  }
+
+  ['@test warn user that Route\'s queryParams configuration must be an Object, not an Array'](assert) {
+    assert.expect(1);
+
+    this.registerRoute('application', Route.extend({
+      queryParams: [
+        { commitBy: { replace: true } }
+      ]
+    }));
+
+    expectAssertion(() => {
+      this.visit('/');
+    }, 'You passed in `[{"commitBy":{"replace":true}}]` as the value for `queryParams` but `queryParams` cannot be an Array');
+  }
+
+  ['@test handle route names that clash with Object.prototype properties'](assert) {
+    assert.expect(1);
+
+    this.router.map(function() {
+      this.route('constructor');
+    });
+
+    this.registerRoute('constructor', Route.extend({
+      queryParams: {
+        foo: {
+          defaultValue: '123'
+        }
+      }
+    }));
+
+    return this.visit('/').then(() => {
+      this.transitionTo('constructor', { queryParams: { foo: '999' } });
+      let controller = this.getController('constructor');
+      assert.equal(get(controller, 'foo'), '999');
+    });
+  }
 });

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -213,9 +213,8 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
     return this.visitAndAssert('/boo?foo=baz');
   }
 
-  // FIXME: What is the correct behavior below?
-  ['@skip dynamic segment and query param have same name'](assert) {
-    assert.expect(2);
+  ['@test error is thrown if dynamic segment and query param have same name'](assert) {
+    assert.expect(1);
 
     this.router.map(function() {
       this.route('index', { path: '/:foo' });
@@ -223,13 +222,9 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
 
     this.setSingleQPController('index');
 
-    this.registerRoute('index', Route.extend({
-      model(params) {
-        assert.deepEqual(params, { foo: 'boo' });
-      }
-    }));
-
-    return this.visitAndAssert('/boo?foo=baz');
+    expectAssertion(() => {
+      this.visitAndAssert('/boo?foo=baz');
+    }, `The route 'index' has both a dynamic segment and query param with name 'foo'. Please rename one to avoid collisions.`);
   }
 
   ['@test controllers won\'t be eagerly instantiated by internal query params logic'](assert) {

--- a/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
@@ -1,291 +1,230 @@
 import {
   Controller,
-  A as emberA,
-  String as StringUtils
+  A as emberA
 } from 'ember-runtime';
-import { Route, NoneLocation } from 'ember-routing';
+import { Route } from 'ember-routing';
 import { run, computed } from 'ember-metal';
-import { compile } from 'ember-template-compiler';
-import { Application } from 'ember-application';
 import { jQuery } from 'ember-views';
-import { setTemplates } from 'ember-glimmer';
+import { QueryParamTestCase, moduleFor } from 'internal-test-helpers';
 
-let App, router, registry, container;
-
-function bootApplication() {
-  router = container.lookup('router:main');
-  run(App, 'advanceReadiness');
-}
-
-function handleURL(path) {
-  return run(function() {
-    return router.handleURL(path).then(function(value) {
-      ok(true, 'url: `' + path + '` was handled');
-      return value;
-    }, function(reason) {
-      ok(false, 'failed to visit:`' + path + '` reason: `' + QUnit.jsDump.parse(reason));
-      throw reason;
-    });
-  });
-}
-
-let startingURL = '';
-let expectedReplaceURL, expectedPushURL;
-
-function setAndFlush(obj, prop, value) {
-  run(obj, 'set', prop, value);
-}
-
-let TestLocation = NoneLocation.extend({
-  initState() {
-    this.set('path', startingURL);
-  },
-
-  setURL(path) {
-    if (expectedReplaceURL) {
-      ok(false, 'pushState occurred but a replaceState was expected');
-    }
-    if (expectedPushURL) {
-      equal(path, expectedPushURL, 'an expected pushState occurred');
-      expectedPushURL = null;
-    }
-    this.set('path', path);
-  },
-
-  replaceURL(path) {
-    if (expectedPushURL) {
-      ok(false, 'replaceState occurred but a pushState was expected');
-    }
-    if (expectedReplaceURL) {
-      equal(path, expectedReplaceURL, 'an expected replaceState occurred');
-      expectedReplaceURL = null;
-    }
-    this.set('path', path);
+class ModelDependentQPTestCase extends QueryParamTestCase {
+  boot() {
+    this.setupApplication();
+    return this.visitApplication();
   }
-});
 
-function sharedSetup() {
-  run(function() {
-    App = Application.create({
-      name: 'App',
-      rootElement: '#qunit-fixture'
+  teardown() {
+    super(...arguments);
+    this.assert.ok(!this.expectedModelHookParams, 'there should be no pending expectation of expected model hook params');
+  }
+
+  reopenController(name, options) {
+    this.application.resolveRegistration(`controller:${name}`).reopen(options);
+  }
+
+  reopenRoute(name, options) {
+    this.application.resolveRegistration(`route:${name}`).reopen(options);
+  }
+
+  queryParamsStickyTest1(urlPrefix) {
+    let assert = this.assert;
+
+    assert.expect(14);
+
+    return this.boot().then(() => {
+      run(this.$link1, 'click');
+      this.assertCurrentPath(`${urlPrefix}/a-1`);
+
+      this.setAndFlush(this.controller, 'q', 'lol');
+
+      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
+      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2`);
+      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
+
+      run(this.$link2, 'click');
+
+      assert.equal(this.controller.get('q'), 'wat');
+      assert.equal(this.controller.get('z'), 0);
+      assert.deepEqual(this.controller.get('model'), { id: 'a-2' });
+      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
+      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2`);
+      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
     });
+  }
 
-    App.deferReadiness();
+  queryParamsStickyTest2(urlPrefix) {
+    let assert = this.assert;
 
-    registry = App.__registry__;
-    container = App.__container__;
+    assert.expect(24);
 
-    registry.register('location:test', TestLocation);
+    return this.boot().then(() => {
+      this.expectedModelHookParams = { id: 'a-1', q: 'lol', z: 0 };
+      this.transitionTo(`${urlPrefix}/a-1?q=lol`);
 
-    startingURL = expectedReplaceURL = expectedPushURL = '';
+      assert.deepEqual(this.controller.get('model'), { id: 'a-1' });
+      assert.equal(this.controller.get('q'), 'lol');
+      assert.equal(this.controller.get('z'), 0);
+      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
+      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2`);
+      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
 
-    App.Router.reopen({
-      location: 'test'
+      this.expectedModelHookParams = { id: 'a-2', q: 'lol', z: 0 };
+      this.transitionTo(`${urlPrefix}/a-2?q=lol`);
+
+      assert.deepEqual(this.controller.get('model'), { id: 'a-2' }, 'controller\'s model changed to a-2');
+      assert.equal(this.controller.get('q'), 'lol');
+      assert.equal(this.controller.get('z'), 0);
+      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
+      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`); // fail
+      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
+
+      this.expectedModelHookParams = { id: 'a-3', q: 'lol', z: 123 };
+      this.transitionTo(`${urlPrefix}/a-3?q=lol&z=123`);
+
+      assert.equal(this.controller.get('q'), 'lol');
+      assert.equal(this.controller.get('z'), 123);
+      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
+      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`);
+      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=lol&z=123`);
     });
+  }
 
-    App.LoadingRoute = Route.extend({
+  queryParamsStickyTest3(urlPrefix, articleLookup) {
+    let assert = this.assert;
+
+    assert.expect(32);
+
+    this.registerTemplate('application', `{{#each articles as |a|}} {{link-to 'Article' '${articleLookup}' a.id id=a.id}} {{/each}}`);
+
+    return this.boot().then(() => {
+      this.expectedModelHookParams = { id: 'a-1', q: 'wat', z: 0 };
+      this.transitionTo(articleLookup, 'a-1');
+
+      assert.deepEqual(this.controller.get('model'), { id: 'a-1' });
+      assert.equal(this.controller.get('q'), 'wat');
+      assert.equal(this.controller.get('z'), 0);
+      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1`);
+      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2`);
+      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
+
+      this.expectedModelHookParams = { id: 'a-2', q: 'lol', z: 0 };
+      this.transitionTo(articleLookup, 'a-2', { queryParams: { q: 'lol' } });
+
+      assert.deepEqual(this.controller.get('model'), { id: 'a-2' });
+      assert.equal(this.controller.get('q'), 'lol');
+      assert.equal(this.controller.get('z'), 0);
+      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1`);
+      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`);
+      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
+
+      this.expectedModelHookParams = { id: 'a-3', q: 'hay', z: 0 };
+      this.transitionTo(articleLookup, 'a-3', { queryParams: { q: 'hay' } });
+
+      assert.deepEqual(this.controller.get('model'), { id: 'a-3' });
+      assert.equal(this.controller.get('q'), 'hay');
+      assert.equal(this.controller.get('z'), 0);
+      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1`);
+      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`);
+      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=hay`);
+
+      this.expectedModelHookParams = { id: 'a-2', q: 'lol', z: 1 };
+      this.transitionTo(articleLookup, 'a-2', { queryParams: { z: 1 } });
+
+      assert.deepEqual(this.controller.get('model'), { id: 'a-2' });
+      assert.equal(this.controller.get('q'), 'lol');
+      assert.equal(this.controller.get('z'), 1);
+      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1`);
+      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol&z=1`);
+      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=hay`);
     });
+  }
 
-    registry.register('template:application', compile('{{outlet}}'));
-    registry.register('template:home', compile('<h3>Hours</h3>'));
-  });
-}
+  queryParamsStickyTest4(urlPrefix, articleLookup) {
+    let assert = this.assert;
 
-function sharedTeardown() {
-  run(function() {
-    App.destroy();
-    App = null;
-    setTemplates({});
-  });
-}
+    assert.expect(24);
 
-function queryParamsStickyTest1(urlPrefix) {
-  return function() {
-    this.boot();
+    this.setupApplication();
 
-    run(this.$link1, 'click');
-    equal(router.get('location.path'), `${urlPrefix}/a-1`);
-
-    setAndFlush(this.controller, 'q', 'lol');
-
-    equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
-    equal(this.$link2.attr('href'), `${urlPrefix}/a-2`);
-    equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
-
-    run(this.$link2, 'click');
-
-    equal(this.controller.get('q'), 'wat');
-    equal(this.controller.get('z'), 0);
-    deepEqual(this.controller.get('model'), { id: 'a-2' });
-    equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
-    equal(this.$link2.attr('href'), `${urlPrefix}/a-2`);
-    equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
-  };
-}
-
-function queryParamsStickyTest2(urlPrefix) {
-  return function() {
-    this.boot();
-
-    this.expectedModelHookParams = { id: 'a-1', q: 'lol', z: 0 };
-    handleURL(`${urlPrefix}/a-1?q=lol`);
-
-    deepEqual(this.controller.get('model'), { id: 'a-1' });
-    equal(this.controller.get('q'), 'lol');
-    equal(this.controller.get('z'), 0);
-    equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
-    equal(this.$link2.attr('href'), `${urlPrefix}/a-2`);
-    equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
-
-    this.expectedModelHookParams = { id: 'a-2', q: 'lol', z: 0 };
-    handleURL(`${urlPrefix}/a-2?q=lol`);
-
-    deepEqual(this.controller.get('model'), { id: 'a-2' }, 'controller\'s model changed to a-2');
-    equal(this.controller.get('q'), 'lol');
-    equal(this.controller.get('z'), 0);
-    equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
-    equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`); // fail
-    equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
-
-    this.expectedModelHookParams = { id: 'a-3', q: 'lol', z: 123 };
-    handleURL(`${urlPrefix}/a-3?q=lol&z=123`);
-
-    equal(this.controller.get('q'), 'lol');
-    equal(this.controller.get('z'), 123);
-    equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
-    equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`);
-    equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=lol&z=123`);
-  };
-}
-
-function queryParamsStickyTest3(urlPrefix, articleLookup) {
-  return function() {
-    registry.register('template:application', compile(`{{#each articles as |a|}} {{link-to 'Article' '${articleLookup}' a.id id=a.id}} {{/each}}`));
-
-    this.boot();
-
-    this.expectedModelHookParams = { id: 'a-1', q: 'wat', z: 0 };
-    run(router, 'transitionTo', articleLookup, 'a-1');
-
-    deepEqual(this.controller.get('model'), { id: 'a-1' });
-    equal(this.controller.get('q'), 'wat');
-    equal(this.controller.get('z'), 0);
-    equal(this.$link1.attr('href'), `${urlPrefix}/a-1`);
-    equal(this.$link2.attr('href'), `${urlPrefix}/a-2`);
-    equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
-
-    this.expectedModelHookParams = { id: 'a-2', q: 'lol', z: 0 };
-    run(router, 'transitionTo', articleLookup, 'a-2', { queryParams: { q: 'lol' } });
-
-    deepEqual(this.controller.get('model'), { id: 'a-2' });
-    equal(this.controller.get('q'), 'lol');
-    equal(this.controller.get('z'), 0);
-    equal(this.$link1.attr('href'), `${urlPrefix}/a-1`);
-    equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`);
-    equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
-
-    this.expectedModelHookParams = { id: 'a-3', q: 'hay', z: 0 };
-    run(router, 'transitionTo', articleLookup, 'a-3', { queryParams: { q: 'hay' } });
-
-    deepEqual(this.controller.get('model'), { id: 'a-3' });
-    equal(this.controller.get('q'), 'hay');
-    equal(this.controller.get('z'), 0);
-    equal(this.$link1.attr('href'), `${urlPrefix}/a-1`);
-    equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`);
-    equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=hay`);
-
-    this.expectedModelHookParams = { id: 'a-2', q: 'lol', z: 1 };
-    run(router, 'transitionTo', articleLookup, 'a-2', { queryParams: { z: 1 } });
-
-    deepEqual(this.controller.get('model'), { id: 'a-2' });
-    equal(this.controller.get('q'), 'lol');
-    equal(this.controller.get('z'), 1);
-    equal(this.$link1.attr('href'), `${urlPrefix}/a-1`);
-    equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol&z=1`);
-    equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=hay`);
-  };
-}
-
-function queryParamsStickyTest4(urlPrefix, articleLookup) {
-  return function() {
-    let articleClass = StringUtils.classify(articleLookup);
-
-    App[`${articleClass}Controller`].reopen({
+    this.reopenController(articleLookup, {
       queryParams: { q: { scope: 'controller' } }
     });
 
-    this.boot();
+    return this.visitApplication().then(() => {
+      run(this.$link1, 'click');
+      this.assertCurrentPath(`${urlPrefix}/a-1`);
 
-    run(this.$link1, 'click');
-    equal(router.get('location.path'), `${urlPrefix}/a-1`);
+      this.setAndFlush(this.controller, 'q', 'lol');
 
-    setAndFlush(this.controller, 'q', 'lol');
+      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
+      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`);
+      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=lol`);
 
-    equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
-    equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`);
-    equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=lol`);
+      run(this.$link2, 'click');
 
-    run(this.$link2, 'click');
+      assert.equal(this.controller.get('q'), 'lol');
+      assert.equal(this.controller.get('z'), 0);
+      assert.deepEqual(this.controller.get('model'), { id: 'a-2' });
 
-    equal(this.controller.get('q'), 'lol');
-    equal(this.controller.get('z'), 0);
-    deepEqual(this.controller.get('model'), { id: 'a-2' });
+      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
+      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`);
+      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=lol`);
 
-    equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
-    equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`);
-    equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=lol`);
+      this.expectedModelHookParams = { id: 'a-3', q: 'haha', z: 123 };
+      this.transitionTo(`${urlPrefix}/a-3?q=haha&z=123`);
 
-    this.expectedModelHookParams = { id: 'a-3', q: 'haha', z: 123 };
-    handleURL(`${urlPrefix}/a-3?q=haha&z=123`);
+      assert.deepEqual(this.controller.get('model'), { id: 'a-3' });
+      assert.equal(this.controller.get('q'), 'haha');
+      assert.equal(this.controller.get('z'), 123);
 
-    deepEqual(this.controller.get('model'), { id: 'a-3' });
-    equal(this.controller.get('q'), 'haha');
-    equal(this.controller.get('z'), 123);
+      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=haha`);
+      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=haha`);
+      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=haha&z=123`);
 
-    equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=haha`);
-    equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=haha`);
-    equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=haha&z=123`);
+      this.setAndFlush(this.controller, 'q', 'woot');
 
-    setAndFlush(this.controller, 'q', 'woot');
+      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=woot`);
+      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=woot`);
+      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=woot&z=123`);
+    });
+  }
 
-    equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=woot`);
-    equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=woot`);
-    equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=woot&z=123`);
-  };
-}
+  queryParamsStickyTest5(urlPrefix, commentsLookupKey) {
+    let assert = this.assert;
 
-function queryParamsStickyTest5(urlPrefix, commentsLookupKey) {
-  return function() {
-    this.boot();
+    assert.expect(12);
 
-    run(router, 'transitionTo', commentsLookupKey, 'a-1');
+    return this.boot().then(() => {
+      this.transitionTo(commentsLookupKey, 'a-1');
 
-    let commentsCtrl = container.lookup(`controller:${commentsLookupKey}`);
-    equal(commentsCtrl.get('page'), 1);
-    equal(router.get('location.path'), `${urlPrefix}/a-1/comments`);
+      let commentsCtrl = this.getController(commentsLookupKey);
+      assert.equal(commentsCtrl.get('page'), 1);
+      this.assertCurrentPath(`${urlPrefix}/a-1/comments`);
 
-    setAndFlush(commentsCtrl, 'page', 2);
-    equal(router.get('location.path'), `${urlPrefix}/a-1/comments?page=2`);
+      this.setAndFlush(commentsCtrl, 'page', 2);
+      this.assertCurrentPath(`${urlPrefix}/a-1/comments?page=2`);
 
-    setAndFlush(commentsCtrl, 'page', 3);
-    equal(router.get('location.path'), `${urlPrefix}/a-1/comments?page=3`);
+      this.setAndFlush(commentsCtrl, 'page', 3);
+      this.assertCurrentPath(`${urlPrefix}/a-1/comments?page=3`);
 
-    run(router, 'transitionTo', commentsLookupKey, 'a-2');
-    equal(commentsCtrl.get('page'), 1);
-    equal(router.get('location.path'), `${urlPrefix}/a-2/comments`);
+      this.transitionTo(commentsLookupKey, 'a-2');
+      assert.equal(commentsCtrl.get('page'), 1);
+      this.assertCurrentPath(`${urlPrefix}/a-2/comments`);
 
-    run(router, 'transitionTo', commentsLookupKey, 'a-1');
-    equal(commentsCtrl.get('page'), 3);
-    equal(router.get('location.path'), `${urlPrefix}/a-1/comments?page=3`);
-  };
-}
+      this.transitionTo(commentsLookupKey, 'a-1');
+      assert.equal(commentsCtrl.get('page'), 3);
+      this.assertCurrentPath(`${urlPrefix}/a-1/comments?page=3`);
+    });
+  }
 
-function queryParamsStickyTest6(urlPrefix, articleLookup, commentsLookup) {
-  return function() {
-    let articleClass = StringUtils.classify(articleLookup);
+  queryParamsStickyTest6(urlPrefix, articleLookup, commentsLookup) {
+    let assert = this.assert;
 
-    App[`${articleClass}Route`].reopen({
+    assert.expect(13);
+
+    this.setupApplication();
+
+    this.reopenRoute(articleLookup, {
       resetController(controller, isExiting) {
         this.controllerFor(commentsLookup).set('page', 1);
         if (isExiting) {
@@ -294,115 +233,119 @@ function queryParamsStickyTest6(urlPrefix, articleLookup, commentsLookup) {
       }
     });
 
-    registry.register('template:about', compile(`{{link-to 'A' '${commentsLookup}' 'a-1' id='one'}} {{link-to 'B' '${commentsLookup}' 'a-2' id='two'}}`));
+    this.registerTemplate('about', `{{link-to 'A' '${commentsLookup}' 'a-1' id='one'}} {{link-to 'B' '${commentsLookup}' 'a-2' id='two'}}`);
 
-    this.boot();
+    return this.visitApplication().then(() => {
+      this.transitionTo(commentsLookup, 'a-1');
 
-    run(router, 'transitionTo', commentsLookup, 'a-1');
+      let commentsCtrl = this.getController(commentsLookup);
+      assert.equal(commentsCtrl.get('page'), 1);
+      this.assertCurrentPath(`${urlPrefix}/a-1/comments`);
 
-    let commentsCtrl = container.lookup(`controller:${commentsLookup}`);
-    equal(commentsCtrl.get('page'), 1);
-    equal(router.get('location.path'), `${urlPrefix}/a-1/comments`);
+      this.setAndFlush(commentsCtrl, 'page', 2);
+      this.assertCurrentPath(`${urlPrefix}/a-1/comments?page=2`);
 
-    setAndFlush(commentsCtrl, 'page', 2);
-    equal(router.get('location.path'), `${urlPrefix}/a-1/comments?page=2`);
+      this.transitionTo(commentsLookup, 'a-2');
+      assert.equal(commentsCtrl.get('page'), 1);
+      assert.equal(this.controller.get('q'), 'wat');
 
-    run(router, 'transitionTo', commentsLookup, 'a-2');
-    equal(commentsCtrl.get('page'), 1);
-    equal(this.controller.get('q'), 'wat');
+      this.transitionTo(commentsLookup, 'a-1');
 
-    run(router, 'transitionTo', commentsLookup, 'a-1');
+      this.assertCurrentPath(`${urlPrefix}/a-1/comments`);
+      assert.equal(commentsCtrl.get('page'), 1);
 
-    equal(router.get('location.path'), `${urlPrefix}/a-1/comments`);
-    equal(commentsCtrl.get('page'), 1);
-
-    run(router, 'transitionTo', 'about');
-
-    equal(jQuery('#one').attr('href'), `${urlPrefix}/a-1/comments?q=imdone`);
-    equal(jQuery('#two').attr('href'), `${urlPrefix}/a-2/comments`);
-  };
+      this.transitionTo('about');
+      assert.equal(jQuery('#one').attr('href'), `${urlPrefix}/a-1/comments?q=imdone`);
+      assert.equal(jQuery('#two').attr('href'), `${urlPrefix}/a-2/comments`);
+    });
+  }
 }
 
-
-QUnit.module('Model Dep Query Params', {
-  setup() {
-    sharedSetup();
-
-    App.Router.map(function() {
+moduleFor('Query Params - model-dependent state', class extends ModelDependentQPTestCase {
+  setupApplication() {
+    this.router.map(function() {
       this.route('article', { path: '/a/:id' }, function() {
         this.route('comments', { resetNamespace: true });
       });
       this.route('about');
     });
 
-    let articles = this.articles = emberA([{ id: 'a-1' }, { id: 'a-2' }, { id: 'a-3' }]);
+    let articles = emberA([{ id: 'a-1' }, { id: 'a-2' }, { id: 'a-3' }]);
 
-    App.ApplicationController = Controller.extend({
-      articles: this.articles
-    });
+    this.registerController('application', Controller.extend({
+      articles
+    }));
 
     let self = this;
-    App.ArticleRoute = Route.extend({
+    let assert = this.assert;
+    this.registerRoute('article', Route.extend({
       model(params) {
         if (self.expectedModelHookParams) {
-          deepEqual(params, self.expectedModelHookParams, 'the ArticleRoute model hook received the expected merged dynamic segment + query params hash');
+          assert.deepEqual(params, self.expectedModelHookParams, 'the ArticleRoute model hook received the expected merged dynamic segment + query params hash');
           self.expectedModelHookParams = null;
         }
         return articles.findBy('id', params.id);
       }
-    });
+    }));
 
-    App.ArticleController = Controller.extend({
+    this.registerController('article', Controller.extend({
       queryParams: ['q', 'z'],
       q: 'wat',
       z: 0
-    });
+    }));
 
-    App.CommentsController = Controller.extend({
+    this.registerController('comments', Controller.extend({
       queryParams: 'page',
       page: 1
+    }));
+
+    this.registerTemplate('application', '{{#each articles as |a|}} 1{{link-to \'Article\' \'article\' a id=a.id}} {{/each}} {{outlet}}');
+  }
+
+  visitApplication() {
+    return this.visit('/').then(() => {
+      let assert = this.assert;
+
+      this.$link1 = jQuery('#a-1');
+      this.$link2 = jQuery('#a-2');
+      this.$link3 = jQuery('#a-3');
+
+      assert.equal(this.$link1.attr('href'), '/a/a-1');
+      assert.equal(this.$link2.attr('href'), '/a/a-2');
+      assert.equal(this.$link3.attr('href'), '/a/a-3');
+
+      this.controller = this.getController('article');
     });
+  }
 
-    registry.register('template:application', compile('{{#each articles as |a|}} {{link-to \'Article\' \'article\' a id=a.id}} {{/each}} {{outlet}}'));
+  ['@test query params have \'model\' stickiness by default']() {
+    return this.queryParamsStickyTest1('/a');
+  }
 
-    this.boot = function() {
-      bootApplication();
+  ['@test query params have \'model\' stickiness by default (url changes)']() {
+    return this.queryParamsStickyTest2('/a');
+  }
 
-      self.$link1 = jQuery('#a-1');
-      self.$link2 = jQuery('#a-2');
-      self.$link3 = jQuery('#a-3');
+  ['@test query params have \'model\' stickiness by default (params-based transitions)']() {
+    return this.queryParamsStickyTest3('/a', 'article');
+  }
 
-      equal(self.$link1.attr('href'), '/a/a-1');
-      equal(self.$link2.attr('href'), '/a/a-2');
-      equal(self.$link3.attr('href'), '/a/a-3');
+  ['@test \'controller\' stickiness shares QP state between models']() {
+    return this.queryParamsStickyTest4('/a', 'article');
+  }
 
-      self.controller = container.lookup('controller:article');
-    };
-  },
+  ['@test \'model\' stickiness is scoped to current or first dynamic parent route']() {
+    return this.queryParamsStickyTest5('/a', 'comments');
+  }
 
-  teardown() {
-    sharedTeardown();
-    ok(!this.expectedModelHookParams, 'there should be no pending expectation of expected model hook params');
+  ['@test can reset query params using the resetController hook']() {
+    return this.queryParamsStickyTest6('/a', 'article', 'comments');
   }
 });
 
-QUnit.test('query params have \'model\' stickiness by default', queryParamsStickyTest1('/a'));
-
-QUnit.test('query params have \'model\' stickiness by default (url changes)', queryParamsStickyTest2('/a'));
-
-QUnit.test('query params have \'model\' stickiness by default (params-based transitions)', queryParamsStickyTest3('/a', 'article'));
-
-QUnit.test('\'controller\' stickiness shares QP state between models', queryParamsStickyTest4('/a', 'article'));
-
-QUnit.test('\'model\' stickiness is scoped to current or first dynamic parent route', queryParamsStickyTest5('/a', 'comments'));
-
-QUnit.test('can reset query params using the resetController hook', queryParamsStickyTest6('/a', 'article', 'comments'));
-
-QUnit.module('Model Dep Query Params (nested)', {
-  setup() {
-    sharedSetup();
-
-    App.Router.map(function() {
+moduleFor('Query Params - model-dependent state (nested)', class extends ModelDependentQPTestCase {
+  setupApplication() {
+    this.router.map(function() {
       this.route('site', function() {
         this.route('article', { path: '/a/:id' }, function() {
           this.route('comments');
@@ -411,74 +354,82 @@ QUnit.module('Model Dep Query Params (nested)', {
       this.route('about');
     });
 
-    let site_articles = this.site_articles = emberA([{ id: 'a-1' }, { id: 'a-2' }, { id: 'a-3' }]);
+    let site_articles = emberA([{ id: 'a-1' }, { id: 'a-2' }, { id: 'a-3' }]);
 
-    App.ApplicationController = Controller.extend({
-      articles: this.site_articles
-    });
+    this.registerController('application', Controller.extend({
+      articles: site_articles
+    }));
 
     let self = this;
-    App.SiteArticleRoute = Route.extend({
+    let assert = this.assert;
+    this.registerRoute('site.article', Route.extend({
       model(params) {
         if (self.expectedModelHookParams) {
-          deepEqual(params, self.expectedModelHookParams, 'the ArticleRoute model hook received the expected merged dynamic segment + query params hash');
+          assert.deepEqual(params, self.expectedModelHookParams, 'the ArticleRoute model hook received the expected merged dynamic segment + query params hash');
           self.expectedModelHookParams = null;
         }
         return site_articles.findBy('id', params.id);
       }
-    });
+    }));
 
-    App.SiteArticleController = Controller.extend({
+    this.registerController('site.article', Controller.extend({
       queryParams: ['q', 'z'],
       q: 'wat',
       z: 0
-    });
+    }));
 
-    App.SiteArticleCommentsController = Controller.extend({
+    this.registerController('site.article.comments', Controller.extend({
       queryParams: 'page',
       page: 1
+    }));
+
+    this.registerTemplate('application', '{{#each articles as |a|}} {{link-to \'Article\' \'site.article\' a id=a.id}} {{/each}} {{outlet}}');
+  }
+
+  visitApplication() {
+    return this.visit('/').then(() => {
+      let assert = this.assert;
+
+      this.$link1 = jQuery('#a-1');
+      this.$link2 = jQuery('#a-2');
+      this.$link3 = jQuery('#a-3');
+
+      assert.equal(this.$link1.attr('href'), '/site/a/a-1');
+      assert.equal(this.$link2.attr('href'), '/site/a/a-2');
+      assert.equal(this.$link3.attr('href'), '/site/a/a-3');
+
+      this.controller = this.getController('site.article');
     });
+  }
 
-    registry.register('template:application', compile('{{#each articles as |a|}} {{link-to \'Article\' \'site.article\' a id=a.id}} {{/each}} {{outlet}}'));
+  ['@test query params have \'model\' stickiness by default']() {
+    return this.queryParamsStickyTest1('/site/a');
+  }
 
-    this.boot = function() {
-      bootApplication();
+  ['@test query params have \'model\' stickiness by default (url changes)']() {
+    return this.queryParamsStickyTest2('/site/a');
+  }
 
-      self.$link1 = jQuery('#a-1');
-      self.$link2 = jQuery('#a-2');
-      self.$link3 = jQuery('#a-3');
+  ['@test query params have \'model\' stickiness by default (params-based transitions)']() {
+    return this.queryParamsStickyTest3('/site/a', 'site.article');
+  }
 
-      equal(self.$link1.attr('href'), '/site/a/a-1');
-      equal(self.$link2.attr('href'), '/site/a/a-2');
-      equal(self.$link3.attr('href'), '/site/a/a-3');
+  ['@test \'controller\' stickiness shares QP state between models']() {
+    return this.queryParamsStickyTest4('/site/a', 'site.article');
+  }
 
-      self.controller = container.lookup('controller:site.article');
-    };
-  },
+  ['@test \'model\' stickiness is scoped to current or first dynamic parent route']() {
+    return this.queryParamsStickyTest5('/site/a', 'site.article.comments');
+  }
 
-  teardown() {
-    sharedTeardown();
-    ok(!this.expectedModelHookParams, 'there should be no pending expectation of expected model hook params');
+  ['@test can reset query params using the resetController hook']() {
+    return this.queryParamsStickyTest6('/site/a', 'site.article', 'site.article.comments');
   }
 });
 
-QUnit.test('query params have \'model\' stickiness by default', queryParamsStickyTest1('/site/a'));
-
-QUnit.test('query params have \'model\' stickiness by default (url changes)', queryParamsStickyTest2('/site/a'));
-
-QUnit.test('query params have \'model\' stickiness by default (params-based transitions)', queryParamsStickyTest3('/site/a', 'site.article'));
-
-QUnit.test('\'controller\' stickiness shares QP state between models', queryParamsStickyTest4('/site/a', 'site.article'));
-
-QUnit.test('\'model\' stickiness is scoped to current or first dynamic parent route', queryParamsStickyTest5('/site/a', 'site.article.comments'));
-
-QUnit.test('can reset query params using the resetController hook', queryParamsStickyTest6('/site/a', 'site.article', 'site.article.comments'));
-
-QUnit.module('Model Dep Query Params (nested & more than 1 dynamic segment)', {
-  setup() {
-    sharedSetup();
-
-    App.Router.map(function() {
+moduleFor('Query Params - model-dependent state (nested & more than 1 dynamic segment)', class extends ModelDependentQPTestCase {
+  setupApplication() {
+    this.router.map(function() {
       this.route('site', { path: '/site/:site_id' }, function() {
         this.route('article', { path: '/a/:article_id' }, function() {
           this.route('comments');
@@ -486,12 +437,12 @@ QUnit.module('Model Dep Query Params (nested & more than 1 dynamic segment)', {
       });
     });
 
-    let sites = this.sites = emberA([{ id: 's-1' }, { id: 's-2' }, { id: 's-3' }]);
-    let site_articles = this.site_articles = emberA([{ id: 'a-1' }, { id: 'a-2' }, { id: 'a-3' }]);
+    let sites = emberA([{ id: 's-1' }, { id: 's-2' }, { id: 's-3' }]);
+    let site_articles = emberA([{ id: 'a-1' }, { id: 'a-2' }, { id: 'a-3' }]);
 
-    App.ApplicationController = Controller.extend({
-      siteArticles: this.site_articles,
-      sites: this.sites,
+    this.registerController('application', Controller.extend({
+      siteArticles: site_articles,
+      sites,
       allSitesAllArticles: computed({
         get() {
           let ret = [];
@@ -505,379 +456,385 @@ QUnit.module('Model Dep Query Params (nested & more than 1 dynamic segment)', {
           return ret;
         }
       })
-    });
+    }));
 
     let self = this;
-    App.SiteRoute = Route.extend({
+    let assert = this.assert;
+    this.registerRoute('site', Route.extend({
       model(params) {
         if (self.expectedSiteModelHookParams) {
-          deepEqual(params, self.expectedSiteModelHookParams, 'the SiteRoute model hook received the expected merged dynamic segment + query params hash');
+          assert.deepEqual(params, self.expectedSiteModelHookParams, 'the SiteRoute model hook received the expected merged dynamic segment + query params hash');
           self.expectedSiteModelHookParams = null;
         }
         return sites.findBy('id', params.site_id);
       }
-    });
-    App.SiteArticleRoute = Route.extend({
+    }));
+
+    this.registerRoute('site.article', Route.extend({
       model(params) {
         if (self.expectedArticleModelHookParams) {
-          deepEqual(params, self.expectedArticleModelHookParams, 'the SiteArticleRoute model hook received the expected merged dynamic segment + query params hash');
+          assert.deepEqual(params, self.expectedArticleModelHookParams, 'the SiteArticleRoute model hook received the expected merged dynamic segment + query params hash');
           self.expectedArticleModelHookParams = null;
         }
         return site_articles.findBy('id', params.article_id);
       }
-    });
+    }));
 
-    App.SiteController = Controller.extend({
+    this.registerController('site', Controller.extend({
       queryParams: ['country'],
       country: 'au'
-    });
+    }));
 
-    App.SiteArticleController = Controller.extend({
+    this.registerController('site.article', Controller.extend({
       queryParams: ['q', 'z'],
       q: 'wat',
       z: 0
-    });
+    }));
 
-    App.SiteArticleCommentsController = Controller.extend({
+    this.registerController('site.article.comments', Controller.extend({
       queryParams: ['page'],
       page: 1
-    });
+    }));
 
-    registry.register('template:application', compile('{{#each allSitesAllArticles as |a|}} {{#link-to \'site.article\' a.site_id a.article_id id=a.id}}Article [{{a.site_id}}] [{{a.article_id}}]{{/link-to}} {{/each}} {{outlet}}'));
-
-    this.boot = function() {
-      bootApplication();
-      self.links = {};
-      self.links['s-1-a-1'] = jQuery('#s-1-a-1');
-      self.links['s-1-a-2'] = jQuery('#s-1-a-2');
-      self.links['s-1-a-3'] = jQuery('#s-1-a-3');
-      self.links['s-2-a-1'] = jQuery('#s-2-a-1');
-      self.links['s-2-a-2'] = jQuery('#s-2-a-2');
-      self.links['s-2-a-3'] = jQuery('#s-2-a-3');
-      self.links['s-3-a-1'] = jQuery('#s-3-a-1');
-      self.links['s-3-a-2'] = jQuery('#s-3-a-2');
-      self.links['s-3-a-3'] = jQuery('#s-3-a-3');
-
-      equal(self.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
-      equal(self.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2');
-      equal(self.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
-      equal(self.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1');
-      equal(self.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
-      equal(self.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
-      equal(self.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
-      equal(self.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
-      equal(self.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
-
-      self.site_controller = container.lookup('controller:site');
-      self.article_controller = container.lookup('controller:site.article');
-    };
-  },
-
-  teardown() {
-    sharedTeardown();
-    ok(!this.expectedModelHookParams, 'there should be no pending expectation of expected model hook params');
+    this.registerTemplate('application', '{{#each allSitesAllArticles as |a|}} {{#link-to \'site.article\' a.site_id a.article_id id=a.id}}Article [{{a.site_id}}] [{{a.article_id}}]{{/link-to}} {{/each}} {{outlet}}');
   }
-});
 
-QUnit.test('query params have \'model\' stickiness by default', function() {
-  this.boot();
+  visitApplication() {
+    return this.visit('/').then(() => {
+      let assert = this.assert;
 
-  run(this.links['s-1-a-1'], 'click');
-  deepEqual(this.site_controller.get('model'), { id: 's-1' });
-  deepEqual(this.article_controller.get('model'), { id: 'a-1' });
-  equal(router.get('location.path'), '/site/s-1/a/a-1');
+      this.links = {};
+      this.links['s-1-a-1'] = jQuery('#s-1-a-1');
+      this.links['s-1-a-2'] = jQuery('#s-1-a-2');
+      this.links['s-1-a-3'] = jQuery('#s-1-a-3');
+      this.links['s-2-a-1'] = jQuery('#s-2-a-1');
+      this.links['s-2-a-2'] = jQuery('#s-2-a-2');
+      this.links['s-2-a-3'] = jQuery('#s-2-a-3');
+      this.links['s-3-a-1'] = jQuery('#s-3-a-1');
+      this.links['s-3-a-2'] = jQuery('#s-3-a-2');
+      this.links['s-3-a-3'] = jQuery('#s-3-a-3');
 
-  setAndFlush(this.article_controller, 'q', 'lol');
+      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
+      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2');
+      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
+      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1');
+      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
+      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
+      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
+      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
+      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
 
-  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
-  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2');
-  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
-  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?q=lol');
-  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
-  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
-  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
-  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
-  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+      this.site_controller = this.getController('site');
+      this.article_controller = this.getController('site.article');
+    });
+  }
 
-  setAndFlush(this.site_controller, 'country', 'us');
+  ['@test query params have \'model\' stickiness by default'](assert) {
+    assert.expect(59); // Insane.
 
-  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?country=us&q=lol');
-  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?country=us');
-  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?country=us');
-  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?q=lol');
-  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
-  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
-  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
-  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
-  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+    return this.boot().then(() => {
+      run(this.links['s-1-a-1'], 'click');
+      assert.deepEqual(this.site_controller.get('model'), { id: 's-1' });
+      assert.deepEqual(this.article_controller.get('model'), { id: 'a-1' });
+      this.assertCurrentPath('/site/s-1/a/a-1');
 
-  run(this.links['s-1-a-2'], 'click');
+      this.setAndFlush(this.article_controller, 'q', 'lol');
 
-  equal(this.site_controller.get('country'), 'us');
-  equal(this.article_controller.get('q'), 'wat');
-  equal(this.article_controller.get('z'), 0);
-  deepEqual(this.site_controller.get('model'), { id: 's-1' });
-  deepEqual(this.article_controller.get('model'), { id: 'a-2' });
-  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?country=us&q=lol');
-  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?country=us');
-  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?country=us');
-  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?q=lol');
-  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
-  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
-  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
-  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
-  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
+      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2');
+      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
+      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?q=lol');
+      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
+      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
+      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
+      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
+      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
 
-  run(this.links['s-2-a-2'], 'click');
+      this.setAndFlush(this.site_controller, 'country', 'us');
 
-  equal(this.site_controller.get('country'), 'au');
-  equal(this.article_controller.get('q'), 'wat');
-  equal(this.article_controller.get('z'), 0);
-  deepEqual(this.site_controller.get('model'), { id: 's-2' });
-  deepEqual(this.article_controller.get('model'), { id: 'a-2' });
-  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?country=us&q=lol');
-  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?country=us');
-  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?country=us');
-  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?q=lol');
-  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
-  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
-  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
-  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
-  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
-});
+      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?country=us&q=lol');
+      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?country=us');
+      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?country=us');
+      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?q=lol');
+      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
+      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
+      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
+      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
+      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
 
-QUnit.test('query params have \'model\' stickiness by default (url changes)', function() {
-  this.boot();
+      run(this.links['s-1-a-2'], 'click');
 
-  this.expectedSiteModelHookParams = { site_id: 's-1', country: 'au' };
-  this.expectedArticleModelHookParams = { article_id: 'a-1', q: 'lol', z: 0 };
-  handleURL('/site/s-1/a/a-1?q=lol');
+      assert.equal(this.site_controller.get('country'), 'us');
+      assert.equal(this.article_controller.get('q'), 'wat');
+      assert.equal(this.article_controller.get('z'), 0);
+      assert.deepEqual(this.site_controller.get('model'), { id: 's-1' });
+      assert.deepEqual(this.article_controller.get('model'), { id: 'a-2' });
+      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?country=us&q=lol');
+      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?country=us');
+      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?country=us');
+      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?q=lol');
+      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
+      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
+      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
+      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
+      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
 
-  deepEqual(this.site_controller.get('model'), { id: 's-1' }, 'site controller\'s model is s-1');
-  deepEqual(this.article_controller.get('model'), { id: 'a-1' }, 'article controller\'s model is a-1');
-  equal(this.site_controller.get('country'), 'au');
-  equal(this.article_controller.get('q'), 'lol');
-  equal(this.article_controller.get('z'), 0);
-  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
-  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2');
-  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
-  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?q=lol');
-  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
-  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
-  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
-  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
-  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+      run(this.links['s-2-a-2'], 'click');
 
-  this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
-  this.expectedArticleModelHookParams = { article_id: 'a-1', q: 'lol', z: 0 };
-  handleURL('/site/s-2/a/a-1?country=us&q=lol');
+      assert.equal(this.site_controller.get('country'), 'au');
+      assert.equal(this.article_controller.get('q'), 'wat');
+      assert.equal(this.article_controller.get('z'), 0);
+      assert.deepEqual(this.site_controller.get('model'), { id: 's-2' });
+      assert.deepEqual(this.article_controller.get('model'), { id: 'a-2' });
+      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?country=us&q=lol');
+      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?country=us');
+      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?country=us');
+      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?q=lol');
+      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
+      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
+      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
+      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
+      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+    });
+  }
 
-  deepEqual(this.site_controller.get('model'), { id: 's-2' }, 'site controller\'s model is s-2');
-  deepEqual(this.article_controller.get('model'), { id: 'a-1' }, 'article controller\'s model is a-1');
-  equal(this.site_controller.get('country'), 'us');
-  equal(this.article_controller.get('q'), 'lol');
-  equal(this.article_controller.get('z'), 0);
-  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
-  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2');
-  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
-  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=lol');
-  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us');
-  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us');
-  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
-  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
-  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+  ['@test query params have \'model\' stickiness by default (url changes)'](assert) {
+    assert.expect(88); // INSANE.
 
-  this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
-  this.expectedArticleModelHookParams = { article_id: 'a-2', q: 'lol', z: 0 };
-  handleURL('/site/s-2/a/a-2?country=us&q=lol');
+    return this.boot().then(() => {
+      this.expectedSiteModelHookParams = { site_id: 's-1', country: 'au' };
+      this.expectedArticleModelHookParams = { article_id: 'a-1', q: 'lol', z: 0 };
+      this.transitionTo('/site/s-1/a/a-1?q=lol');
 
-  deepEqual(this.site_controller.get('model'), { id: 's-2' }, 'site controller\'s model is s-2');
-  deepEqual(this.article_controller.get('model'), { id: 'a-2' }, 'article controller\'s model is a-2');
-  equal(this.site_controller.get('country'), 'us');
-  equal(this.article_controller.get('q'), 'lol');
-  equal(this.article_controller.get('z'), 0);
-  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
-  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol');
-  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
-  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=lol');
-  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol');
-  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us');
-  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
-  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol');
-  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+      assert.deepEqual(this.site_controller.get('model'), { id: 's-1' }, 'site controller\'s model is s-1');
+      assert.deepEqual(this.article_controller.get('model'), { id: 'a-1' }, 'article controller\'s model is a-1');
+      assert.equal(this.site_controller.get('country'), 'au');
+      assert.equal(this.article_controller.get('q'), 'lol');
+      assert.equal(this.article_controller.get('z'), 0);
+      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
+      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2');
+      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
+      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?q=lol');
+      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
+      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
+      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
+      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
+      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
 
-  this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
-  this.expectedArticleModelHookParams = { article_id: 'a-3', q: 'lol', z: 123 };
-  handleURL('/site/s-2/a/a-3?country=us&q=lol&z=123');
+      this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
+      this.expectedArticleModelHookParams = { article_id: 'a-1', q: 'lol', z: 0 };
+      this.transitionTo('/site/s-2/a/a-1?country=us&q=lol');
 
-  deepEqual(this.site_controller.get('model'), { id: 's-2' }, 'site controller\'s model is s-2');
-  deepEqual(this.article_controller.get('model'), { id: 'a-3' }, 'article controller\'s model is a-3');
-  equal(this.site_controller.get('country'), 'us');
-  equal(this.article_controller.get('q'), 'lol');
-  equal(this.article_controller.get('z'), 123);
-  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
-  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol');
-  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=lol&z=123');
-  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=lol');
-  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol');
-  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us&q=lol&z=123');
-  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
-  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol');
-  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?q=lol&z=123');
+      assert.deepEqual(this.site_controller.get('model'), { id: 's-2' }, 'site controller\'s model is s-2');
+      assert.deepEqual(this.article_controller.get('model'), { id: 'a-1' }, 'article controller\'s model is a-1');
+      assert.equal(this.site_controller.get('country'), 'us');
+      assert.equal(this.article_controller.get('q'), 'lol');
+      assert.equal(this.article_controller.get('z'), 0);
+      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
+      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2');
+      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
+      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=lol');
+      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us');
+      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us');
+      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
+      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
+      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
 
-  this.expectedSiteModelHookParams = { site_id: 's-3', country: 'nz' };
-  this.expectedArticleModelHookParams = { article_id: 'a-3', q: 'lol', z: 123 };
-  handleURL('/site/s-3/a/a-3?country=nz&q=lol&z=123');
+      this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
+      this.expectedArticleModelHookParams = { article_id: 'a-2', q: 'lol', z: 0 };
+      this.transitionTo('/site/s-2/a/a-2?country=us&q=lol');
 
-  deepEqual(this.site_controller.get('model'), { id: 's-3' }, 'site controller\'s model is s-3');
-  deepEqual(this.article_controller.get('model'), { id: 'a-3' }, 'article controller\'s model is a-3');
-  equal(this.site_controller.get('country'), 'nz');
-  equal(this.article_controller.get('q'), 'lol');
-  equal(this.article_controller.get('z'), 123);
-  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
-  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol');
-  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=lol&z=123');
-  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=lol');
-  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol');
-  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us&q=lol&z=123');
-  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?country=nz&q=lol');
-  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?country=nz&q=lol');
-  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?country=nz&q=lol&z=123');
-});
+      assert.deepEqual(this.site_controller.get('model'), { id: 's-2' }, 'site controller\'s model is s-2');
+      assert.deepEqual(this.article_controller.get('model'), { id: 'a-2' }, 'article controller\'s model is a-2');
+      assert.equal(this.site_controller.get('country'), 'us');
+      assert.equal(this.article_controller.get('q'), 'lol');
+      assert.equal(this.article_controller.get('z'), 0);
+      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
+      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol');
+      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
+      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=lol');
+      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol');
+      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us');
+      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
+      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol');
+      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
 
-QUnit.test('query params have \'model\' stickiness by default (params-based transitions)', function() {
-  this.boot();
+      this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
+      this.expectedArticleModelHookParams = { article_id: 'a-3', q: 'lol', z: 123 };
+      this.transitionTo('/site/s-2/a/a-3?country=us&q=lol&z=123');
 
-  this.expectedSiteModelHookParams = { site_id: 's-1', country: 'au' };
-  this.expectedArticleModelHookParams = { article_id: 'a-1', q: 'wat', z: 0 };
-  run(router, 'transitionTo', 'site.article', 's-1', 'a-1');
+      assert.deepEqual(this.site_controller.get('model'), { id: 's-2' }, 'site controller\'s model is s-2');
+      assert.deepEqual(this.article_controller.get('model'), { id: 'a-3' }, 'article controller\'s model is a-3');
+      assert.equal(this.site_controller.get('country'), 'us');
+      assert.equal(this.article_controller.get('q'), 'lol');
+      assert.equal(this.article_controller.get('z'), 123);
+      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
+      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol');
+      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=lol&z=123');
+      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=lol');
+      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol');
+      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us&q=lol&z=123');
+      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
+      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol');
+      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?q=lol&z=123');
 
-  deepEqual(this.site_controller.get('model'), { id: 's-1' });
-  deepEqual(this.article_controller.get('model'), { id: 'a-1' });
-  equal(this.site_controller.get('country'), 'au');
-  equal(this.article_controller.get('q'), 'wat');
-  equal(this.article_controller.get('z'), 0);
-  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
-  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2');
-  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
-  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1');
-  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
-  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
-  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
-  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
-  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+      this.expectedSiteModelHookParams = { site_id: 's-3', country: 'nz' };
+      this.expectedArticleModelHookParams = { article_id: 'a-3', q: 'lol', z: 123 };
+      this.transitionTo('/site/s-3/a/a-3?country=nz&q=lol&z=123');
 
-  this.expectedSiteModelHookParams = { site_id: 's-1', country: 'au' };
-  this.expectedArticleModelHookParams = { article_id: 'a-2', q: 'lol', z: 0 };
-  run(router, 'transitionTo', 'site.article', 's-1', 'a-2', { queryParams: { q: 'lol' } });
+      assert.deepEqual(this.site_controller.get('model'), { id: 's-3' }, 'site controller\'s model is s-3');
+      assert.deepEqual(this.article_controller.get('model'), { id: 'a-3' }, 'article controller\'s model is a-3');
+      assert.equal(this.site_controller.get('country'), 'nz');
+      assert.equal(this.article_controller.get('q'), 'lol');
+      assert.equal(this.article_controller.get('z'), 123);
+      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
+      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol');
+      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=lol&z=123');
+      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=lol');
+      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol');
+      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us&q=lol&z=123');
+      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?country=nz&q=lol');
+      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?country=nz&q=lol');
+      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?country=nz&q=lol&z=123');
+    });
+  }
 
-  deepEqual(this.site_controller.get('model'), { id: 's-1' });
-  deepEqual(this.article_controller.get('model'), { id: 'a-2' });
-  equal(this.site_controller.get('country'), 'au');
-  equal(this.article_controller.get('q'), 'lol');
-  equal(this.article_controller.get('z'), 0);
-  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
-  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol');
-  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
-  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1');
-  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?q=lol');
-  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
-  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
-  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol');
-  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+  ['@test query params have \'model\' stickiness by default (params-based transitions)'](assert) {
+    assert.expect(118); // <-- INSANE! Like why is this even a thing?
 
-  this.expectedSiteModelHookParams = { site_id: 's-1', country: 'au' };
-  this.expectedArticleModelHookParams = { article_id: 'a-3', q: 'hay', z: 0 };
-  run(router, 'transitionTo', 'site.article', 's-1', 'a-3', { queryParams: { q: 'hay' } });
+    return this.boot().then(() => {
+      this.expectedSiteModelHookParams = { site_id: 's-1', country: 'au' };
+      this.expectedArticleModelHookParams = { article_id: 'a-1', q: 'wat', z: 0 };
+      this.transitionTo('site.article', 's-1', 'a-1');
 
-  deepEqual(this.site_controller.get('model'), { id: 's-1' });
-  deepEqual(this.article_controller.get('model'), { id: 'a-3' });
-  equal(this.site_controller.get('country'), 'au');
-  equal(this.article_controller.get('q'), 'hay');
-  equal(this.article_controller.get('z'), 0);
-  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
-  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol');
-  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=hay');
-  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1');
-  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?q=lol');
-  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?q=hay');
-  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
-  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol');
-  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?q=hay');
+      assert.deepEqual(this.site_controller.get('model'), { id: 's-1' });
+      assert.deepEqual(this.article_controller.get('model'), { id: 'a-1' });
+      assert.equal(this.site_controller.get('country'), 'au');
+      assert.equal(this.article_controller.get('q'), 'wat');
+      assert.equal(this.article_controller.get('z'), 0);
+      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
+      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2');
+      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
+      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1');
+      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
+      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
+      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
+      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
+      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
 
-  this.expectedSiteModelHookParams = { site_id: 's-1', country: 'au' };
-  this.expectedArticleModelHookParams = { article_id: 'a-2', q: 'lol', z: 1 };
-  run(router, 'transitionTo', 'site.article', 's-1', 'a-2', { queryParams: { z: 1 } });
+      this.expectedSiteModelHookParams = { site_id: 's-1', country: 'au' };
+      this.expectedArticleModelHookParams = { article_id: 'a-2', q: 'lol', z: 0 };
+      this.transitionTo('site.article', 's-1', 'a-2', { queryParams: { q: 'lol' } });
 
-  deepEqual(this.site_controller.get('model'), { id: 's-1' });
-  deepEqual(this.article_controller.get('model'), { id: 'a-2' });
-  equal(this.site_controller.get('country'), 'au');
-  equal(this.article_controller.get('q'), 'lol');
-  equal(this.article_controller.get('z'), 1);
-  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
-  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol&z=1');
-  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=hay');
-  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1');
-  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?q=lol&z=1');
-  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?q=hay');
-  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
-  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol&z=1');
-  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?q=hay');
+      assert.deepEqual(this.site_controller.get('model'), { id: 's-1' });
+      assert.deepEqual(this.article_controller.get('model'), { id: 'a-2' });
+      assert.equal(this.site_controller.get('country'), 'au');
+      assert.equal(this.article_controller.get('q'), 'lol');
+      assert.equal(this.article_controller.get('z'), 0);
+      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
+      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol');
+      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
+      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1');
+      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?q=lol');
+      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
+      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
+      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol');
+      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
 
-  this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
-  this.expectedArticleModelHookParams = { article_id: 'a-2', q: 'lol', z: 1 };
-  run(router, 'transitionTo', 'site.article', 's-2', 'a-2', { queryParams: { country: 'us' } });
+      this.expectedSiteModelHookParams = { site_id: 's-1', country: 'au' };
+      this.expectedArticleModelHookParams = { article_id: 'a-3', q: 'hay', z: 0 };
+      this.transitionTo('site.article', 's-1', 'a-3', { queryParams: { q: 'hay' } });
 
-  deepEqual(this.site_controller.get('model'), { id: 's-2' });
-  deepEqual(this.article_controller.get('model'), { id: 'a-2' });
-  equal(this.site_controller.get('country'), 'us');
-  equal(this.article_controller.get('q'), 'lol');
-  equal(this.article_controller.get('z'), 1);
-  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
-  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol&z=1');
-  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=hay');
-  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us');
-  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol&z=1');
-  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us&q=hay');
-  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
-  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol&z=1');
-  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?q=hay');
+      assert.deepEqual(this.site_controller.get('model'), { id: 's-1' });
+      assert.deepEqual(this.article_controller.get('model'), { id: 'a-3' });
+      assert.equal(this.site_controller.get('country'), 'au');
+      assert.equal(this.article_controller.get('q'), 'hay');
+      assert.equal(this.article_controller.get('z'), 0);
+      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
+      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol');
+      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=hay');
+      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1');
+      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?q=lol');
+      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?q=hay');
+      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
+      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol');
+      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?q=hay');
 
-  this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
-  this.expectedArticleModelHookParams = { article_id: 'a-1', q: 'yeah', z: 0 };
-  run(router, 'transitionTo', 'site.article', 's-2', 'a-1', { queryParams: { q: 'yeah' } });
+      this.expectedSiteModelHookParams = { site_id: 's-1', country: 'au' };
+      this.expectedArticleModelHookParams = { article_id: 'a-2', q: 'lol', z: 1 };
+      this.transitionTo('site.article', 's-1', 'a-2', { queryParams: { z: 1 } });
 
-  deepEqual(this.site_controller.get('model'), { id: 's-2' });
-  deepEqual(this.article_controller.get('model'), { id: 'a-1' });
-  equal(this.site_controller.get('country'), 'us');
-  equal(this.article_controller.get('q'), 'yeah');
-  equal(this.article_controller.get('z'), 0);
-  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=yeah');
-  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol&z=1');
-  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=hay');
-  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=yeah');
-  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol&z=1');
-  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us&q=hay');
-  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=yeah');
-  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol&z=1');
-  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?q=hay');
+      assert.deepEqual(this.site_controller.get('model'), { id: 's-1' });
+      assert.deepEqual(this.article_controller.get('model'), { id: 'a-2' });
+      assert.equal(this.site_controller.get('country'), 'au');
+      assert.equal(this.article_controller.get('q'), 'lol');
+      assert.equal(this.article_controller.get('z'), 1);
+      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
+      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol&z=1');
+      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=hay');
+      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1');
+      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?q=lol&z=1');
+      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?q=hay');
+      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
+      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol&z=1');
+      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?q=hay');
 
-  this.expectedSiteModelHookParams = { site_id: 's-3', country: 'nz' };
-  this.expectedArticleModelHookParams = { article_id: 'a-3', q: 'hay', z: 3 };
-  run(router, 'transitionTo', 'site.article', 's-3', 'a-3', { queryParams: { country: 'nz', z: 3 } });
+      this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
+      this.expectedArticleModelHookParams = { article_id: 'a-2', q: 'lol', z: 1 };
+      this.transitionTo('site.article', 's-2', 'a-2', { queryParams: { country: 'us' } });
 
-  deepEqual(this.site_controller.get('model'), { id: 's-3' });
-  deepEqual(this.article_controller.get('model'), { id: 'a-3' });
-  equal(this.site_controller.get('country'), 'nz');
-  equal(this.article_controller.get('q'), 'hay');
-  equal(this.article_controller.get('z'), 3);
-  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=yeah');
-  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol&z=1');
-  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=hay&z=3');
-  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=yeah');
-  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol&z=1');
-  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us&q=hay&z=3');
-  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?country=nz&q=yeah');
-  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?country=nz&q=lol&z=1');
-  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?country=nz&q=hay&z=3');
+      assert.deepEqual(this.site_controller.get('model'), { id: 's-2' });
+      assert.deepEqual(this.article_controller.get('model'), { id: 'a-2' });
+      assert.equal(this.site_controller.get('country'), 'us');
+      assert.equal(this.article_controller.get('q'), 'lol');
+      assert.equal(this.article_controller.get('z'), 1);
+      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
+      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol&z=1');
+      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=hay');
+      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us');
+      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol&z=1');
+      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us&q=hay');
+      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
+      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol&z=1');
+      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?q=hay');
+
+      this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
+      this.expectedArticleModelHookParams = { article_id: 'a-1', q: 'yeah', z: 0 };
+      this.transitionTo('site.article', 's-2', 'a-1', { queryParams: { q: 'yeah' } });
+
+      assert.deepEqual(this.site_controller.get('model'), { id: 's-2' });
+      assert.deepEqual(this.article_controller.get('model'), { id: 'a-1' });
+      assert.equal(this.site_controller.get('country'), 'us');
+      assert.equal(this.article_controller.get('q'), 'yeah');
+      assert.equal(this.article_controller.get('z'), 0);
+      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=yeah');
+      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol&z=1');
+      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=hay');
+      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=yeah');
+      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol&z=1');
+      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us&q=hay');
+      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=yeah');
+      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol&z=1');
+      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?q=hay');
+
+      this.expectedSiteModelHookParams = { site_id: 's-3', country: 'nz' };
+      this.expectedArticleModelHookParams = { article_id: 'a-3', q: 'hay', z: 3 };
+      this.transitionTo('site.article', 's-3', 'a-3', { queryParams: { country: 'nz', z: 3 } });
+
+      assert.deepEqual(this.site_controller.get('model'), { id: 's-3' });
+      assert.deepEqual(this.article_controller.get('model'), { id: 'a-3' });
+      assert.equal(this.site_controller.get('country'), 'nz');
+      assert.equal(this.article_controller.get('q'), 'hay');
+      assert.equal(this.article_controller.get('z'), 3);
+      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=yeah');
+      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol&z=1');
+      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=hay&z=3');
+      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=yeah');
+      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol&z=1');
+      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us&q=hay&z=3');
+      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?country=nz&q=yeah');
+      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?country=nz&q=lol&z=1');
+      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?country=nz&q=hay&z=3');
+    });
+  }
 });

--- a/packages/ember/tests/routing/query_params_test/overlapping_query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test/overlapping_query_params_test.js
@@ -56,7 +56,6 @@ moduleFor('Query Params - overlapping query param property names', class extends
     });
   }
 
-  // FIXME: The error should throw without having to do `transitionTo`.
   ['@test query params in the same route hierarchy with the same url key get auto-scoped'](assert) {
     this.registerController('parent', Controller.extend({
       queryParams: { foo: 'shared' },
@@ -68,11 +67,9 @@ moduleFor('Query Params - overlapping query param property names', class extends
       bar: 1
     }));
 
-    return this.setupBase().then((...args) => {
-      expectAssertion(() => {
-        this.transitionTo('parent.child');
-      }, 'You\'re not allowed to have more than one controller property map to the same query param key, but both `parent:foo` and `parent.child:bar` map to `shared`. You can fix this by mapping one of the controller properties to a different query param key via the `as` config option, e.g. `foo: { as: \'other-foo\' }`');
-    });
+    expectAssertion(() => {
+      this.setupBase();
+    }, 'You\'re not allowed to have more than one controller property map to the same query param key, but both `parent:foo` and `parent.child:bar` map to `shared`. You can fix this by mapping one of the controller properties to a different query param key via the `as` config option, e.g. `foo: { as: \'other-foo\' }`');
   }
 
   ['@test Support shared but overridable mixin pattern'](assert) {

--- a/packages/ember/tests/routing/query_params_test/overlapping_query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test/overlapping_query_params_test.js
@@ -1,197 +1,107 @@
 import { Controller } from 'ember-runtime';
-import { Route, NoneLocation } from 'ember-routing';
 import { run, Mixin } from 'ember-metal';
-import { compile } from 'ember-template-compiler';
-import { Application } from 'ember-application';
-import { setTemplates, setTemplate } from 'ember-glimmer';
+import { QueryParamTestCase, moduleFor } from 'internal-test-helpers';
 
-let App, router, registry, container;
-
-function bootApplication() {
-  router = container.lookup('router:main');
-  run(App, 'advanceReadiness');
-}
-
-let startingURL = '';
-let expectedReplaceURL, expectedPushURL;
-
-function setAndFlush(obj, prop, value) {
-  run(obj, 'set', prop, value);
-}
-
-const TestLocation = NoneLocation.extend({
-  initState() {
-    this.set('path', startingURL);
-  },
-
-  setURL(path) {
-    if (expectedReplaceURL) {
-      ok(false, 'pushState occurred but a replaceState was expected');
-    }
-    if (expectedPushURL) {
-      equal(path, expectedPushURL, 'an expected pushState occurred');
-      expectedPushURL = null;
-    }
-    this.set('path', path);
-  },
-
-  replaceURL(path) {
-    if (expectedPushURL) {
-      ok(false, 'replaceState occurred but a pushState was expected');
-    }
-    if (expectedReplaceURL) {
-      equal(path, expectedReplaceURL, 'an expected replaceState occurred');
-      expectedReplaceURL = null;
-    }
-    this.set('path', path);
-  }
-});
-
-function sharedSetup() {
-  run(() => {
-    App = Application.create({
-      name: 'App',
-      rootElement: '#qunit-fixture'
-    });
-
-    App.deferReadiness();
-
-    registry = App.__registry__;
-    container = App.__container__;
-
-    registry.register('location:test', TestLocation);
-
-    startingURL = expectedReplaceURL = expectedPushURL = '';
-
-    App.Router.reopen({
-      location: 'test'
-    });
-
-    App.LoadingRoute = Route.extend({
-    });
-
-    setTemplate('application', compile('{{outlet}}'));
-    setTemplate('home', compile('<h3>Hours</h3>'));
-  });
-}
-
-function sharedTeardown() {
-  run(() => {
-    App.destroy();
-    App = null;
-
-    setTemplates({});
-  });
-}
-
-
-QUnit.module('Query Params - overlapping query param property names', {
-  setup() {
-    sharedSetup();
-
-    App.Router.map(function() {
+moduleFor('Query Params - overlapping query param property names', class extends QueryParamTestCase {
+  setupBase() {
+    this.router.map(function() {
       this.route('parent', function() {
         this.route('child');
       });
     });
 
-    this.boot = function() {
-      bootApplication();
-      run(router, 'transitionTo', 'parent.child');
-    };
-  },
-
-  teardown() {
-    sharedTeardown();
+    return this.visit('/parent/child');
   }
-});
 
-QUnit.test('can remap same-named qp props', function() {
-  App.ParentController = Controller.extend({
-    queryParams: { page: 'parentPage' },
-    page: 1
-  });
+  ['@test can remap same-named qp props'](assert) {
+    this.registerController('parent', Controller.extend({
+      queryParams: { page: 'parentPage' },
+      page: 1
+    }));
 
-  App.ParentChildController = Controller.extend({
-    queryParams: { page: 'childPage' },
-    page: 1
-  });
+    this.registerController('parent.child', Controller.extend({
+      queryParams: { page: 'childPage' },
+      page: 1
+    }));
 
-  this.boot();
+    return this.setupBase().then(() => {
+      this.assertCurrentPath('/parent/child');
 
-  equal(router.get('location.path'), '/parent/child');
+      let parentController = this.getController('parent');
+      let parentChildController = this.getController('parent.child');
 
-  let parentController = container.lookup('controller:parent');
-  let parentChildController = container.lookup('controller:parent.child');
+      this.setAndFlush(parentController, 'page', 2);
+      this.assertCurrentPath('/parent/child?parentPage=2');
+      this.setAndFlush(parentController, 'page', 1);
+      this.assertCurrentPath('/parent/child');
 
-  setAndFlush(parentController, 'page', 2);
-  equal(router.get('location.path'), '/parent/child?parentPage=2');
-  setAndFlush(parentController, 'page', 1);
-  equal(router.get('location.path'), '/parent/child');
+      this.setAndFlush(parentChildController, 'page', 2);
+      this.assertCurrentPath('/parent/child?childPage=2');
+      this.setAndFlush(parentChildController, 'page', 1);
+      this.assertCurrentPath('/parent/child');
 
-  setAndFlush(parentChildController, 'page', 2);
-  equal(router.get('location.path'), '/parent/child?childPage=2');
-  setAndFlush(parentChildController, 'page', 1);
-  equal(router.get('location.path'), '/parent/child');
+      run(() => {
+        parentController.set('page', 2);
+        parentChildController.set('page', 2);
+      });
 
-  run(() => {
-    parentController.set('page', 2);
-    parentChildController.set('page', 2);
-  });
+      this.assertCurrentPath('/parent/child?childPage=2&parentPage=2');
 
-  equal(router.get('location.path'), '/parent/child?childPage=2&parentPage=2');
+      run(() => {
+        parentController.set('page', 1);
+        parentChildController.set('page', 1);
+      });
 
-  run(() => {
-    parentController.set('page', 1);
-    parentChildController.set('page', 1);
-  });
+      this.assertCurrentPath('/parent/child');
+    });
+  }
 
-  equal(router.get('location.path'), '/parent/child');
-});
+  // FIXME: The error should throw without having to do `transitionTo`.
+  ['@test query params in the same route hierarchy with the same url key get auto-scoped'](assert) {
+    this.registerController('parent', Controller.extend({
+      queryParams: { foo: 'shared' },
+      foo: 1
+    }));
 
-QUnit.test('query params in the same route hierarchy with the same url key get auto-scoped', function() {
-  App.ParentController = Controller.extend({
-    queryParams: { foo: 'shared' },
-    foo: 1
-  });
+    this.registerController('parent.child', Controller.extend({
+      queryParams: { bar: 'shared' },
+      bar: 1
+    }));
 
-  App.ParentChildController = Controller.extend({
-    queryParams: { bar: 'shared' },
-    bar: 1
-  });
+    return this.setupBase().then((...args) => {
+      expectAssertion(() => {
+        this.transitionTo('parent.child');
+      }, 'You\'re not allowed to have more than one controller property map to the same query param key, but both `parent:foo` and `parent.child:bar` map to `shared`. You can fix this by mapping one of the controller properties to a different query param key via the `as` config option, e.g. `foo: { as: \'other-foo\' }`');
+    });
+  }
 
-  let self = this;
-  expectAssertion(() => {
-    self.boot();
-  }, 'You\'re not allowed to have more than one controller property map to the same query param key, but both `parent:foo` and `parent.child:bar` map to `shared`. You can fix this by mapping one of the controller properties to a different query param key via the `as` config option, e.g. `foo: { as: \'other-foo\' }`');
-});
+  ['@test Support shared but overridable mixin pattern'](assert) {
+    let HasPage = Mixin.create({
+      queryParams: 'page',
+      page: 1
+    });
 
-QUnit.test('Support shared but overridable mixin pattern', function() {
-  let HasPage = Mixin.create({
-    queryParams: 'page',
-    page: 1
-  });
+    this.registerController('parent', Controller.extend(HasPage, {
+      queryParams: { page: 'yespage' }
+    }));
 
-  App.ParentController = Controller.extend(HasPage, {
-    queryParams: { page: 'yespage' }
-  });
+    this.registerController('parent.child', Controller.extend(HasPage));
 
-  App.ParentChildController = Controller.extend(HasPage);
+    return this.setupBase().then(() => {
+      this.assertCurrentPath('/parent/child');
 
-  this.boot();
+      let parentController = this.getController('parent');
+      let parentChildController = this.getController('parent.child');
 
-  equal(router.get('location.path'), '/parent/child');
+      this.setAndFlush(parentChildController, 'page', 2);
+      this.assertCurrentPath('/parent/child?page=2');
+      assert.equal(parentController.get('page'), 1);
+      assert.equal(parentChildController.get('page'), 2);
 
-  let parentController = container.lookup('controller:parent');
-  let parentChildController = container.lookup('controller:parent.child');
-
-  setAndFlush(parentChildController, 'page', 2);
-  equal(router.get('location.path'), '/parent/child?page=2');
-  equal(parentController.get('page'), 1);
-  equal(parentChildController.get('page'), 2);
-
-  setAndFlush(parentController, 'page', 2);
-  equal(router.get('location.path'), '/parent/child?page=2&yespage=2');
-  equal(parentController.get('page'), 2);
-  equal(parentChildController.get('page'), 2);
+      this.setAndFlush(parentController, 'page', 2);
+      this.assertCurrentPath('/parent/child?page=2&yespage=2');
+      assert.equal(parentController.get('page'), 2);
+      assert.equal(parentChildController.get('page'), 2);
+    });
+  }
 });

--- a/packages/ember/tests/routing/query_params_test/query_params_paramless_link_to_test.js
+++ b/packages/ember/tests/routing/query_params_test/query_params_paramless_link_to_test.js
@@ -1,113 +1,28 @@
-import { Controller, String as StringUtils } from 'ember-runtime';
-import { Route, NoneLocation } from 'ember-routing';
-import { run } from 'ember-metal';
-import { compile } from 'ember-template-compiler';
-import { Application } from 'ember-application';
+import { Controller } from 'ember-runtime';
 import { jQuery } from 'ember-views';
-import { setTemplates, setTemplate } from 'ember-glimmer';
+import { QueryParamTestCase, moduleFor } from 'internal-test-helpers';
 
-let App, container, router, registry;
-let expectedReplaceURL, expectedPushURL;
+moduleFor('Query Params - paramless link-to', class extends QueryParamTestCase {
+  testParamlessLinks(assert, routeName) {
+    assert.expect(1);
 
+    this.registerTemplate(routeName, '{{link-to \'index\' \'index\' id=\'index-link\'}}');
 
-let TestLocation = NoneLocation.extend({
-  initState() {
-    this.set('path', startingURL);
-  },
-
-  setURL(path) {
-    if (expectedReplaceURL) {
-      ok(false, 'pushState occurred but a replaceState was expected');
-    }
-    if (expectedPushURL) {
-      equal(path, expectedPushURL, 'an expected pushState occurred');
-      expectedPushURL = null;
-    }
-    this.set('path', path);
-  },
-
-  replaceURL(path) {
-    if (expectedPushURL) {
-      ok(false, 'replaceState occurred but a pushState was expected');
-    }
-    if (expectedReplaceURL) {
-      equal(path, expectedReplaceURL, 'an expected replaceState occurred');
-      expectedReplaceURL = null;
-    }
-    this.set('path', path);
-  }
-});
-
-function bootApplication() {
-  router = container.lookup('router:main');
-  run(App, 'advanceReadiness');
-}
-
-function sharedSetup() {
-  run(() => {
-    App = Application.create({
-      name: 'App',
-      rootElement: '#qunit-fixture'
-    });
-
-    App.deferReadiness();
-
-    registry = App.__registry__;
-    container = App.__container__;
-
-    registry.register('location:test', TestLocation);
-
-    startingURL = expectedReplaceURL = expectedPushURL = '';
-
-    App.Router.reopen({
-      location: 'test'
-    });
-
-    App.LoadingRoute = Route.extend({
-    });
-
-    setTemplate('application', compile('{{outlet}}'));
-    setTemplate('home', compile('<h3>Hours</h3>'));
-  });
-}
-
-function sharedTeardown() {
-  run(() => {
-    App.destroy();
-    App = null;
-    setTemplates({});
-  });
-}
-
-QUnit.module('Routing with Query Params', {
-  setup() {
-    sharedSetup();
-  },
-
-  teardown() {
-    sharedTeardown();
-  }
-});
-
-let startingURL = '';
-
-function testParamlessLinks(routeName) {
-  QUnit.test('param-less links in an app booted with query params in the URL don\'t reset the query params: ' + routeName, function() {
-    expect(1);
-
-    setTemplate(routeName, compile('{{link-to \'index\' \'index\' id=\'index-link\'}}'));
-
-    App[StringUtils.capitalize(routeName) + 'Controller'] = Controller.extend({
+    this.registerController(routeName, Controller.extend({
       queryParams: ['foo'],
       foo: 'wat'
+    }));
+
+    return this.visit('/?foo=YEAH').then(() => {
+      assert.equal(jQuery('#index-link').attr('href'), '/?foo=YEAH');
     });
+  }
 
-    startingURL = '/?foo=YEAH';
-    bootApplication();
+  ['@test param-less links in an app booted with query params in the URL don\'t reset the query params: application'](assert) {
+    return this.testParamlessLinks(assert, 'application');
+  }
 
-    equal(jQuery('#index-link').attr('href'), '/?foo=YEAH');
-  });
-}
-
-testParamlessLinks('application');
-testParamlessLinks('index');
+  ['@test param-less links in an app booted with query params in the URL don\'t reset the query params: index'](assert) {
+    return this.testParamlessLinks(assert, 'index');
+  }
+});

--- a/packages/internal-test-helpers/lib/index.js
+++ b/packages/internal-test-helpers/lib/index.js
@@ -24,5 +24,6 @@ export {
 export { default as AbstractTestCase } from './test-cases/abstract';
 export { default as AbstractApplicationTestCase } from './test-cases/abstract-application';
 export { default as ApplicationTestCase } from './test-cases/application';
+export { default as QueryParamTestCase } from './test-cases/query-param';
 export { default as AbstractRenderingTestCase } from './test-cases/abstract-rendering';
 export { default as RenderingTestCase } from './test-cases/rendering';

--- a/packages/internal-test-helpers/lib/test-cases/abstract-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract-application.js
@@ -15,9 +15,7 @@ export default class AbstractApplicationTestCase extends AbstractTestCase {
 
     this.application = run(Application, 'create', this.applicationOptions);
 
-    this.router = this.application.Router = Router.extend({
-      location: 'none'
-    });
+    this.router = this.application.Router = Router.extend(this.routerOptions);
 
     this.applicationInstance = null;
   }
@@ -26,6 +24,12 @@ export default class AbstractApplicationTestCase extends AbstractTestCase {
     return {
       rootElement: '#qunit-fixture',
       autoboot: false
+    };
+  }
+
+  get routerOptions() {
+    return {
+      location: 'none'
     };
   }
 

--- a/packages/internal-test-helpers/lib/test-cases/query-param.js
+++ b/packages/internal-test-helpers/lib/test-cases/query-param.js
@@ -1,0 +1,77 @@
+import { NoneLocation } from 'ember-routing';
+import { run } from 'ember-metal';
+
+import ApplicationTestCase from './application';
+
+export default class QueryParamTestCase extends ApplicationTestCase {
+  constructor() {
+    super();
+
+    let testCase = this;
+    testCase.expectedPushURL = null;
+    testCase.expectedReplaceURL = null;
+    this.application.register('location:test', NoneLocation.extend({
+      setURL(path) {
+        if (testCase.expectedReplaceURL) {
+          testCase.assert.ok(false, 'pushState occurred but a replaceState was expected');
+        }
+
+        if (testCase.expectedPushURL) {
+          testCase.assert.equal(path, testCase.expectedPushURL, 'an expected pushState occurred');
+          testCase.expectedPushURL = null;
+        }
+
+        this.set('path', path);
+      },
+
+      replaceURL(path) {
+        if (testCase.expectedPushURL) {
+          testCase.assert.ok(false, 'replaceState occurred but a pushState was expected');
+        }
+
+        if (testCase.expectedReplaceURL) {
+          testCase.assert.equal(path, testCase.expectedReplaceURL, 'an expected replaceState occurred');
+          testCase.expectedReplaceURL = null;
+        }
+
+        this.set('path', path);
+      }
+    }));
+  }
+
+  visitAndAssert(path) {
+    return this.visit(...arguments).then(() => {
+      this.assertCurrentPath(path);
+    });
+  }
+
+  getController(name) {
+    return this.applicationInstance.lookup(`controller:${name}`);
+  }
+
+  getRoute(name) {
+    return this.applicationInstance.lookup(`route:${name}`);
+  }
+
+  get appRouter() {
+    return this.applicationInstance.lookup('router:main');
+  }
+
+  get routerOptions() {
+    return {
+      location: 'test'
+    };
+  }
+
+  setAndFlush(obj, prop, value) {
+    return run(obj, 'set', prop, value);
+  }
+
+  assertCurrentPath(path, message = `current path equals '${path}'`) {
+    this.assert.equal(this.appRouter.get('location.path'), path, message);
+  }
+
+  transitionTo() {
+    return run(this.appRouter, 'transitionTo', ...arguments);
+  }
+}


### PR DESCRIPTION
This PR refactors the Query Param tests to use a setup similar to the `ember-glimmer` tests. It also adds a few tests that were identified as gaps in the original coverage. The primary goal is to provide a set of abstractions to make writing/maintaining these tests easier.

The follow-up to this PR will be to better organize these tests so that we can more easily identify potential gaps in coverage.
