### PR TITLE
Ensure constness of this property does not change

### DIFF
--- a/packages/ember-metal/lib/cache.js
+++ b/packages/ember-metal/lib/cache.js
@@ -1,4 +1,5 @@
 import { EmptyObject } from 'ember-utils';
+import { UNDEFINED } from './meta';
 
 export default class Cache {
   constructor(limit, func, key, store) {
@@ -53,8 +54,6 @@ export default class Cache {
     this.misses = 0;
   }
 }
-
-function UNDEFINED() {}
 
 class DefaultStore {
   constructor() {

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -1,7 +1,7 @@
 import { inspect } from 'ember-utils';
 import { assert, warn } from './debug';
 import { set } from './property_set';
-import { meta as metaFor, peekMeta } from './meta';
+import { meta as metaFor, peekMeta, UNDEFINED } from './meta';
 import expandProperties from './expand_properties';
 import EmberError from './error';
 import {
@@ -21,9 +21,6 @@ import {
 @module ember
 @submodule ember-metal
 */
-
-
-function UNDEFINED() { }
 
 const DEEP_EACH_REGEX = /\.@each\.[^.]+\./;
 

--- a/packages/ember-metal/lib/weak_map.js
+++ b/packages/ember-metal/lib/weak_map.js
@@ -1,11 +1,11 @@
 import { GUID_KEY } from 'ember-utils';
 import {
   peekMeta,
-  meta as metaFor
+  meta as metaFor,
+  UNDEFINED
 } from './meta';
 
 let id = 0;
-function UNDEFINED() {}
 
 // Returns whether Type(value) is Object according to the terminology in the spec
 function isObject(value) {


### PR DESCRIPTION
As it turns out, V8 stores the following information about properties:
- kind: (raw data, or accessor)
- constness: (const or mutable)
- value: Smi, Double, HeapObject, Tagged

"Currently, V8 tracks constant values only for properties containing JS functions."
source: https://docs.google.com/document/d/1VEeXn6BfKmVkYpfMuxNs3otLLNPIxIVA1cLoSwGMIxI/edit#

So rather then making our UNDEFINED sentinal a function, we make it a very
unique string (which we already do in other parts of the system.

---

Note: I am not actually sure this makes much of a difference. I will do more research and see, regardless it does seem like a good cleanup.
