### PR TITLE
Revert "[CLEANUP beta] Remove `CoreObject#POST_INIT`"

### DIFF
--- a/packages/ember-glimmer/lib/helper.js
+++ b/packages/ember-glimmer/lib/helper.js
@@ -4,7 +4,10 @@
 */
 
 import { symbol } from 'ember-utils';
-import { FrameworkObject } from 'ember-runtime';
+import {
+  Object as EmberObject,
+  POST_INIT
+} from 'ember-runtime';
 import { DirtyableTag } from 'glimmer-reference';
 
 export const RECOMPUTE_TAG = symbol('RECOMPUTE_TAG');
@@ -49,11 +52,10 @@ export const RECOMPUTE_TAG = symbol('RECOMPUTE_TAG');
   @public
   @since 1.13.0
 */
-var Helper = FrameworkObject.extend({
+var Helper = EmberObject.extend({
   isHelperInstance: true,
 
-  init() {
-    this._super(...arguments);
+  [POST_INIT]() {
     this[RECOMPUTE_TAG] = new DirtyableTag();
   },
 

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -2495,7 +2495,7 @@ moduleFor('Components test: curly components', class extends RenderingTest {
 
     expectAssertion(() => {
       this.render('{{foo-bar}}');
-    }, /You must call `this._super\(...arguments\);` when overriding `init` on a framework object. Please update .* to call `this._super\(...arguments\);` from `init`./);
+    }, /You must call `this._super\(...arguments\);` when implementing `init` in a component. Please update .* to call `this._super` from `init`/);
   }
 
   ['@test should toggle visibility with isVisible'](assert) {

--- a/packages/ember-glimmer/tests/integration/helpers/custom-helper-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/custom-helper-test.js
@@ -96,16 +96,6 @@ moduleFor('Helpers test: custom helpers', class extends RenderingTest {
     this.assertText('hello | hello world');
   }
 
-  ['@test throws if `this._super` is not called from `init`']() {
-    this.registerHelper('hello-world', {
-      init() {}
-    });
-
-    expectAssertion(() => {
-      this.render('{{hello-world}}');
-    }, /You must call `this._super\(...arguments\);` when overriding `init` on a framework object. Please update .* to call `this._super\(...arguments\);` from `init`./);
-  }
-
   ['@test class-based helper can recompute a new value']() {
     let destroyCount = 0;
     let computeCount = 0;

--- a/packages/ember-runtime/lib/index.js
+++ b/packages/ember-runtime/lib/index.js
@@ -3,7 +3,7 @@
 @submodule ember-runtime
 */
 
-export { default as Object, FrameworkObject } from './system/object';
+export { default as Object } from './system/object';
 export { default as String } from './system/string';
 export {
   default as RegistryProxyMixin,
@@ -31,7 +31,10 @@ export {
 } from './system/namespace';
 export { default as ArrayProxy } from './system/array_proxy';
 export { default as ObjectProxy } from './system/object_proxy';
-export { default as CoreObject } from './system/core_object';
+export {
+  default as CoreObject,
+  POST_INIT
+} from './system/core_object';
 export { default as NativeArray, A } from './system/native_array';
 export {
   default as ActionHandler,

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -13,8 +13,9 @@ import {
   assign,
   guidFor,
   generateGuid,
+  GUID_KEY_PROPERTY,
   makeArray,
-  GUID_KEY_PROPERTY
+  symbol
 } from 'ember-utils';
 import {
   assert,
@@ -40,6 +41,7 @@ import {
 import ActionHandler from '../mixins/action_handler';
 import { validatePropertyInjections } from '../inject';
 
+export let POST_INIT = symbol('POST_INIT');
 var schedule = run.schedule;
 var applyMixin = Mixin._apply;
 var finishPartial = Mixin.finishPartial;
@@ -164,6 +166,8 @@ function makeCtor() {
 
     this.init.apply(this, arguments);
 
+    this[POST_INIT]();
+
     m.proto = proto;
     finishChains(this);
     sendEvent(this, 'init');
@@ -238,6 +242,8 @@ CoreObject.PrototypeMixin = Mixin.create({
     @public
   */
   init() {},
+
+  [POST_INIT]: function() { },
 
   __defineNonEnumerable(property) {
     Object.defineProperty(this, property.name, property.descriptor);

--- a/packages/ember-runtime/lib/system/object.js
+++ b/packages/ember-runtime/lib/system/object.js
@@ -3,8 +3,6 @@
 @submodule ember-runtime
 */
 
-import { symbol } from 'ember-utils';
-import { assert, on, runInDebug } from 'ember-metal';
 import CoreObject from './core_object';
 import Observable from '../mixins/observable';
 
@@ -21,26 +19,5 @@ import Observable from '../mixins/observable';
 */
 const EmberObject = CoreObject.extend(Observable);
 EmberObject.toString = () => 'Ember.Object';
-
-export let FrameworkObject = EmberObject;
-
-runInDebug(() => {
-  let INIT_WAS_CALLED = symbol('INIT_WAS_CALLED');
-  let ASSERT_INIT_WAS_CALLED = symbol('ASSERT_INIT_WAS_CALLED');
-
-  FrameworkObject = EmberObject.extend({
-    init() {
-      this._super(...arguments);
-      this[INIT_WAS_CALLED] = true;
-    },
-
-    [ASSERT_INIT_WAS_CALLED]: on('init', function() {
-      assert(
-        `You must call \`this._super(...arguments);\` when overriding \`init\` on a framework object. Please update ${this} to call \`this._super(...arguments);\` from \`init\`.`,
-        this[INIT_WAS_CALLED]
-      );
-    })
-  });
-});
 
 export default EmberObject;

--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -1,7 +1,7 @@
 import {
-  ActionHandler,
+  Object as EmberObject,
   Evented,
-  FrameworkObject,
+  ActionHandler,
   deprecateUnderscoreActions,
   typeOf
 } from 'ember-runtime';
@@ -24,7 +24,7 @@ import { cloneStates, states } from './states';
   @uses Ember.ActionHandler
   @private
 */
-const CoreView = FrameworkObject.extend(Evented, ActionHandler, {
+const CoreView = EmberObject.extend(Evented, ActionHandler, {
   isView: true,
 
   _states: cloneStates(states),


### PR DESCRIPTION
This reverts commit e31de2c10106545bc7a570ea16e6dd3dc481d985.

I really dislike this hook and was very happy to see it go, but the issue is `didInitAttrs` / `didReceiveAttrs` explicitly moved to before `finishChains` so that during initial render they did not cause change event churn.

By moving these to sometime after `finishChains` we break existing code, and although it is likely micro perf win ends up being a macro loss as the number of change events increases. Some of these change events also have side-affects, which cause tests to fail. 
