### PR TITLE
Deprecate {{render helper

### DIFF
--- a/packages/ember-glimmer/tests/integration/helpers/render-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/render-test.js
@@ -7,7 +7,9 @@ moduleFor('Helpers test: {{render}}', class extends RenderingTest {
     this.owner.register('controller:home', Controller.extend());
     this.registerTemplate('home', '<p>BYE</p>');
 
-    this.render(`<h1>HI</h1>{{render 'home'}}`);
+    expectDeprecation(() => {
+      this.render(`<h1>HI</h1>{{render 'home'}}`);
+    }, /Please refactor [\w\{\}"` ]+ to a component/);
 
     this.assertText('HIBYE');
   }
@@ -19,20 +21,25 @@ moduleFor('Helpers test: {{render}}', class extends RenderingTest {
     this.owner.register('controller:baz', Controller.extend());
 
     this.registerTemplate('home', '<p>BYE</p>');
-    this.registerTemplate('foo', `<p>FOO</p>{{render 'bar'}}`);
-    this.registerTemplate('bar', `<p>BAR</p>{{render 'baz'}}`);
     this.registerTemplate('baz', `<p>BAZ</p>`);
 
-    this.render('<h1>HI</h1>{{render \'foo\'}}');
+    expectDeprecation(() => {
+      this.registerTemplate('foo', `<p>FOO</p>{{render 'bar'}}`);
+      this.registerTemplate('bar', `<p>BAR</p>{{render 'baz'}}`);
+      this.render('<h1>HI</h1>{{render \'foo\'}}');
+    }, /Please refactor [\w\{\}"` ]+ to a component/);
+
     this.assertText('HIFOOBARBAZ');
   }
 
   ['@test should have assertion if the template does not exist']() {
     this.owner.register('controller:oops', Controller.extend());
 
-    expectAssertion(() => {
-      this.render(`<h1>HI</h1>{{render 'oops'}}`);
-    }, 'You used `{{render \'oops\'}}`, but \'oops\' can not be found as a template.');
+    expectDeprecation(() => {
+      expectAssertion(() => {
+        this.render(`<h1>HI</h1>{{render 'oops'}}`);
+      }, 'You used `{{render \'oops\'}}`, but \'oops\' can not be found as a template.');
+    }, /Please refactor [\w\{\}"` ]+ to a component/);
   }
 
   ['@test should render given template with the singleton controller as its context']() {
@@ -43,7 +50,9 @@ moduleFor('Helpers test: {{render}}', class extends RenderingTest {
     }));
     this.registerTemplate('post', '<p>{{title}}</p>');
 
-    this.render(`<h1>HI</h1>{{render 'post'}}`);
+    expectDeprecation(() => {
+      this.render(`<h1>HI</h1>{{render 'post'}}`);
+    }, /Please refactor [\w\{\}"` ]+ to a component/);
 
     this.assertText(`HIIt's Simple Made Easy`);
 
@@ -78,7 +87,9 @@ moduleFor('Helpers test: {{render}}', class extends RenderingTest {
 
     this.registerTemplate('post', '<p>{{title}}</p>');
 
-    this.render(`{{#if showPost}}{{render 'post'}}{{else}}Nothing here{{/if}}`, { showPost: false });
+    expectDeprecation(() => {
+      this.render(`{{#if showPost}}{{render 'post'}}{{else}}Nothing here{{/if}}`, { showPost: false });
+    }, /Please refactor [\w\{\}"` ]+ to a component/);
 
     this.assertText(`Nothing here`);
 
@@ -212,9 +223,12 @@ moduleFor('Helpers test: {{render}}', class extends RenderingTest {
   ['@test should raise an error when a given controller name does not resolve to a controller']() {
     this.registerTemplate('home', '<p>BYE</p>');
     this.owner.register('controller:posts', Controller.extend());
-    expectAssertion(() => {
-      this.render(`<h1>HI</h1>{{render "home" controller="postss"}}`);
-    }, /The controller name you supplied \'postss\' did not resolve to a controller./);
+
+    expectDeprecation(() => {
+      expectAssertion(() => {
+        this.render(`<h1>HI</h1>{{render "home" controller="postss"}}`);
+      }, /The controller name you supplied \'postss\' did not resolve to a controller./);
+    }, /Please refactor [\w\{\}"` ]+ to a component/);
   }
 
   ['@test should render with given controller'](assert) {
@@ -231,7 +245,10 @@ moduleFor('Helpers test: {{render}}', class extends RenderingTest {
       }
     }));
 
-    this.render('{{render "home" controller="posts"}}');
+    expectDeprecation(() => {
+      this.render('{{render "home" controller="posts"}}');
+    }, /Please refactor [\w\{\}"` ]+ to a component/);
+
     let renderedController = this.owner.lookup('controller:posts');
     let uniqueId = renderedController.get('uniqueId');
     let renderedModel = renderedController.get('model');
@@ -331,7 +348,9 @@ moduleFor('Helpers test: {{render}}', class extends RenderingTest {
       }
     }));
 
-    this.render('{{render "blog.post"}}');
+    expectDeprecation(() => {
+      this.render('{{render "blog.post"}}');
+    }, /Please refactor [\w\.{\}"` ]+ to a component/);
 
     this.assertText(`0`);
   }

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -14,7 +14,8 @@ import {
   set,
   defineProperty,
   computed,
-  run
+  run,
+  deprecate
 } from 'ember-metal';
 import {
   Object as EmberObject,
@@ -1311,6 +1312,16 @@ function appendLiveRoute(liveRoutes, defaultParentState, renderOptions) {
     set(target.outlets, renderOptions.outlet, myState);
   } else {
     if (renderOptions.into) {
+      deprecate(
+        `Rendering into a {{render}} helper that resolves to an {{outlet}} is deprecated.`,
+        false,
+        {
+          id: 'ember-routing.top-level-render-helper',
+          until: '3.0.0',
+          url: 'http://emberjs.com/deprecations/v2.x/#toc_rendering-into-a-render-helper-that-resolves-to-an-outlet'
+        }
+      );
+
       // Megahax time. Post-3.0-breaking-changes, we will just assert
       // right here that the user tried to target a nonexistent
       // thing. But for now we still need to support the `render`

--- a/packages/ember-template-compiler/lib/plugins/deprecate-render.js
+++ b/packages/ember-template-compiler/lib/plugins/deprecate-render.js
@@ -1,0 +1,51 @@
+import { deprecate } from 'ember-metal';
+import calculateLocationDisplay from '../system/calculate-location-display';
+
+export default function DeprecateRender(options) {
+  this.syntax = null;
+  this.options = options;
+}
+
+DeprecateRender.prototype.transform =
+  function DeprecateRender_transform(ast) {
+  let moduleName = this.options.meta.moduleName;
+  let walker = new this.syntax.Walker();
+
+  walker.visit(ast, function(node) {
+    if (!validate(node)) { return; }
+
+    each(node.params, (param) => {
+      if (param.type !== 'StringLiteral') { return; }
+
+      deprecate(deprecationMessage(moduleName, node), false, {
+        id: 'ember-template-compiler.deprecate-render',
+        until: '3.0.0',
+        url: 'http://emberjs.com/deprecations/v2.x#toc_code-render-code-helper'
+      });
+    });
+  });
+
+  return ast;
+};
+
+function validate(node) {
+  return (node.type === 'MustacheStatement') &&
+    (node.path.original === 'render') &&
+    (node.params.length === 1);
+}
+
+function each(list, callback) {
+  for (let i = 0, l = list.length; i < l; i++) {
+    callback(list[i]);
+  }
+}
+
+function deprecationMessage(moduleName, node) {
+  let sourceInformation = calculateLocationDisplay(moduleName, node.loc);
+  let componentName = node.params[0].original;
+  let original = `{{render "${componentName}"}}`;
+  let preferred = `{{${componentName}}}`;
+
+  return `Please refactor \`${original}\` to a component and invoke via` +
+    ` \`${preferred}\`. ${sourceInformation}`;
+}

--- a/packages/ember-template-compiler/lib/plugins/index.js
+++ b/packages/ember-template-compiler/lib/plugins/index.js
@@ -6,6 +6,7 @@ import TransformTopLevelComponents from './transform-top-level-components';
 import TransformInlineLinkTo from './transform-inline-link-to';
 import TransformOldClassBindingSyntax from './transform-old-class-binding-syntax';
 import DeprecateRenderModel from './deprecate-render-model';
+import DeprecateRender from './deprecate-render';
 import AssertReservedNamedArguments from './assert-reserved-named-arguments';
 import TransformActionSyntax from './transform-action-syntax';
 import TransformInputTypeSyntax from './transform-input-type-syntax';
@@ -22,6 +23,7 @@ export default Object.freeze([
   TransformInlineLinkTo,
   TransformOldClassBindingSyntax,
   DeprecateRenderModel,
+  DeprecateRender,
   AssertReservedNamedArguments,
   TransformActionSyntax,
   TransformInputTypeSyntax,

--- a/packages/ember-template-compiler/tests/plugins/deprecate-render-test.js
+++ b/packages/ember-template-compiler/tests/plugins/deprecate-render-test.js
@@ -1,0 +1,17 @@
+import { compile } from '../../index';
+
+QUnit.module('ember-template-compiler: deprecate-render');
+
+QUnit.test('Using `{{render` without a model provides a deprecation', function() {
+  expect(1);
+
+  let expectedMessage =
+    `Please refactor \`{{render "foo-bar"}}\` to a component and` +
+    ` invoke via \`{{foo-bar}}\`. ('baz/foo-bar' @ L1:C0) `;
+
+  expectDeprecation(() => {
+    compile('{{render "foo-bar"}}', {
+      moduleName: 'baz/foo-bar'
+    });
+  }, expectedMessage);
+});

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -2290,6 +2290,8 @@ QUnit.test('Route should tear down multiple outlets', function() {
 
 
 QUnit.test('Route will assert if you try to explicitly render {into: ...} a missing template', function () {
+  expectDeprecation(/Rendering into a {{render}} helper that resolves to an {{outlet}} is deprecated./);
+
   Router.map(function() {
     this.route('home', { path: '/' });
   });
@@ -3441,7 +3443,12 @@ QUnit.test('Allows any route to disconnectOutlet another route\'s templates', fu
 });
 
 QUnit.test('Can this.render({into:...}) the render helper', function() {
-  setTemplate('application', compile('{{render "sidebar"}}'));
+  expectDeprecation(/Rendering into a {{render}} helper that resolves to an {{outlet}} is deprecated./);
+
+  expectDeprecation(() => {
+    setTemplate('application', compile('{{render "sidebar"}}'));
+  }, /Please refactor [\w\{\}"` ]+ to a component/);
+
   setTemplate('sidebar', compile('<div class="sidebar">{{outlet}}</div>'));
   setTemplate('index', compile('other'));
   setTemplate('bar', compile('bar'));
@@ -3468,7 +3475,12 @@ QUnit.test('Can this.render({into:...}) the render helper', function() {
 });
 
 QUnit.test('Can disconnect from the render helper', function() {
-  setTemplate('application', compile('{{render "sidebar"}}'));
+  expectDeprecation(/Rendering into a {{render}} helper that resolves to an {{outlet}} is deprecated./);
+
+  expectDeprecation(() => {
+    setTemplate('application', compile('{{render "sidebar"}}'));
+  }, /Please refactor [\w\{\}"` ]+ to a component/);
+
   setTemplate('sidebar', compile('<div class="sidebar">{{outlet}}</div>'));
   setTemplate('index', compile('other'));
 
@@ -3493,7 +3505,12 @@ QUnit.test('Can disconnect from the render helper', function() {
 });
 
 QUnit.test('Can this.render({into:...}) the render helper\'s children', function() {
-  setTemplate('application', compile('{{render "sidebar"}}'));
+  expectDeprecation(/Rendering into a {{render}} helper that resolves to an {{outlet}} is deprecated./);
+
+  expectDeprecation(() => {
+    setTemplate('application', compile('{{render "sidebar"}}'));
+  }, /Please refactor [\w\{\}"` ]+ to a component/);
+
   setTemplate('sidebar', compile('<div class="sidebar">{{outlet}}</div>'));
   setTemplate('index', compile('<div class="index">{{outlet}}</div>'));
   setTemplate('other', compile('other'));
@@ -3522,7 +3539,12 @@ QUnit.test('Can this.render({into:...}) the render helper\'s children', function
 });
 
 QUnit.test('Can disconnect from the render helper\'s children', function() {
-  setTemplate('application', compile('{{render "sidebar"}}'));
+  expectDeprecation(/Rendering into a {{render}} helper that resolves to an {{outlet}} is deprecated./);
+
+  expectDeprecation(() => {
+    setTemplate('application', compile('{{render "sidebar"}}'));
+  }, /Please refactor [\w\{\}"` ]+ to a component/);
+
   setTemplate('sidebar', compile('<div class="sidebar">{{outlet}}</div>'));
   setTemplate('index', compile('<div class="index">{{outlet}}</div>'));
   setTemplate('other', compile('other'));
@@ -3549,8 +3571,16 @@ QUnit.test('Can disconnect from the render helper\'s children', function() {
 });
 
 QUnit.test('Can this.render({into:...}) nested render helpers', function() {
-  setTemplate('application', compile('{{render "sidebar"}}'));
-  setTemplate('sidebar', compile('<div class="sidebar">{{render "cart"}}</div>'));
+  expectDeprecation(/Rendering into a {{render}} helper that resolves to an {{outlet}} is deprecated./);
+
+  expectDeprecation(() => {
+    setTemplate('application', compile('{{render "sidebar"}}'));
+  }, /Please refactor [\w\{\}"` ]+ to a component/);
+
+  expectDeprecation(() => {
+    setTemplate('sidebar', compile('<div class="sidebar">{{render "cart"}}</div>'));
+  }, /Please refactor [\w\{\}"` ]+ to a component/);
+
   setTemplate('cart', compile('<div class="cart">{{outlet}}</div>'));
   setTemplate('index', compile('other'));
   setTemplate('baz', compile('baz'));
@@ -3577,8 +3607,16 @@ QUnit.test('Can this.render({into:...}) nested render helpers', function() {
 });
 
 QUnit.test('Can disconnect from nested render helpers', function() {
-  setTemplate('application', compile('{{render "sidebar"}}'));
-  setTemplate('sidebar', compile('<div class="sidebar">{{render "cart"}}</div>'));
+  expectDeprecation(/Rendering into a {{render}} helper that resolves to an {{outlet}} is deprecated./);
+
+  expectDeprecation(() => {
+    setTemplate('application', compile('{{render "sidebar"}}'));
+  }, /Please refactor [\w\{\}"` ]+ to a component/);
+
+  expectDeprecation(() => {
+    setTemplate('sidebar', compile('<div class="sidebar">{{render "cart"}}</div>'));
+  }, /Please refactor [\w\{\}"` ]+ to a component/);
+
   setTemplate('cart', compile('<div class="cart">{{outlet}}</div>'));
   setTemplate('index', compile('other'));
 


### PR DESCRIPTION
This implements #13583.

Here is the TODO list from @mixonic.
- [x] Add the deprecation of {{render 'foo'}} in a PR.
- [x]  Add tests for the deprecation of {{render 'foo'}}.
- [x]  Update any tests that still use {{render 'foo'}} to test unrelated behavior to use modern idioms (components).
- [x]  Audit the codebase for any remaining usage, for example in documentation, and refactor that to modern idioms.
- [x]  Audit the guides for any remaining usage of {{render that can be removed.
- [x]  Open a deprecation guide PR on the website.

I'm happy to work in the other items as well, but I'm not sure what to do with the current tests we have. Note that we have quite a few tests around `render into` from a route e.g. https://github.com/emberjs/ember.js/blob/master/packages/ember/tests/routing/basic_test.js#L1813
Also, there are several test failures because of the deprecation. Would love to get some guidance on how to update these tests and migrate the render into tests.

@ErikCH any change you still are interested in taking on some documentation? 
