### PR TITLE
Fix attrs test

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -2785,8 +2785,8 @@ moduleFor('Components test: curly components', class extends RenderingTest {
   ['@test did{Init,Receive}Attrs fires after .init() but before observers become active'](assert) {
     expectDeprecation(/didInitAttrs called/);
 
-    let fooDidChangeCount = 0;
-    let barDidChangeCount = 0;
+    let fooCopyDidChangeCount = 0;
+    let barCopyDidChangeCount = 0;
 
     this.registerComponent('foo-bar', {
       ComponentClass: Component.extend({
@@ -2794,36 +2794,44 @@ moduleFor('Components test: curly components', class extends RenderingTest {
           this._super(...arguments);
           this.didInit = true;
         },
-        didInitAttrs(attrs) {
+
+        didInitAttrs({ attrs }) {
           assert.ok(this.didInit, 'expected init to have run before didInitAttrs');
-          this.set('foo', attrs.foo);
+          this.set('fooCopy', attrs.foo.value + 1);
         },
 
-        willReceieveAttrs(attrs) {
-          assert.ok(this.didInit, 'expected init to have run before willReceieveAttrs');
-          this.set('bar', attrs.bar);
+        didReceiveAttrs({ newAttrs }) {
+          assert.ok(this.didInit, 'expected init to have run before didReceiveAttrs');
+          this.set('barCopy', newAttrs.bar.value + 1);
         },
 
-        fooDidChange: observer('foo', () => { fooDidChangeCount++; }),
-        barDidChange: observer('bar', () => { barDidChangeCount++; })
+        fooCopyDidChange: observer('fooCopy', () => { fooCopyDidChangeCount++; }),
+        barCopyDidChange: observer('barCopy', () => { barCopyDidChangeCount++; })
       }),
-      template: ''
+
+      template: '{{foo}}-{{fooCopy}}-{{bar}}-{{barCopy}}'
     });
 
-    this.render(`{{foo-bar foo=foo bar=bar}}`, { foo: 1, bar: 1 });
+    this.render(`{{foo-bar foo=foo bar=bar}}`, { foo: 1, bar: 3 });
 
-    assert.equal(fooDidChangeCount, 0, 'expected NO observer firing for: foo');
-    assert.equal(barDidChangeCount, 0, 'expected NO observer firing for: bar');
+    this.assertText('1-2-3-4');
 
-    this.runTask(() => set(this.context, 'foo', 2));
+    assert.strictEqual(fooCopyDidChangeCount, 0, 'expected NO observer firing for: fooCopy');
+    assert.strictEqual(barCopyDidChangeCount, 0, 'expected NO observer firing for: barCopy');
 
-    assert.equal(fooDidChangeCount, 1, 'expected observer firing for: foo');
-    assert.equal(barDidChangeCount, 0, 'expected NO observer firing for: bar');
+    this.runTask(() => set(this.context, 'foo', 5));
 
-    this.runTask(() => set(this.context, 'bar', 2));
+    this.assertText('5-2-3-4');
 
-    assert.equal(fooDidChangeCount, 1, 'expected observer firing for: foo');
-    assert.equal(barDidChangeCount, 1, 'expected observer firing for: bar');
+    assert.strictEqual(fooCopyDidChangeCount, 0, 'expected observer firing for: fooCopy');
+    assert.strictEqual(barCopyDidChangeCount, 0, 'expected NO observer firing for: barCopy');
+
+    this.runTask(() => set(this.context, 'bar', 7));
+
+    this.assertText('5-2-7-8');
+
+    assert.strictEqual(fooCopyDidChangeCount, 0, 'expected observer firing for: fooCopy');
+    assert.strictEqual(barCopyDidChangeCount, 1, 'expected observer firing for: barCopy');
   }
 
   ['@test returning `true` from an action does not bubble if `target` is not specified (GH#14275)'](assert) {

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -2782,6 +2782,49 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     }, /didInitAttrs called/);
   }
 
+  // This test is a replication of the "component unit tests" scenario. When we deprecate
+  // and remove them, this test could be removed as well. This is not fully/intentionally
+  // supported, and it is unclear that this particular behavior is actually relied on.
+  // Since there is no real "invocation" here, it has other issues and inconsistencies,
+  // like there is no real "attrs" here, and there is no "update" pass.
+  ['@test did{Init,Receive}Attrs fires even if component is not rendered'](assert) {
+    expectDeprecation(/didInitAttrs called/);
+
+    let didInitAttrsCount = 0;
+    let didReceiveAttrsCount = 0;
+
+    this.registerComponent('foo-bar', {
+      ComponentClass: Component.extend({
+        init() {
+          this._super(...arguments);
+          this.didInit = true;
+        },
+
+        didInitAttrs() {
+          assert.ok(this.didInit, 'expected init to have run before didInitAttrs');
+          didInitAttrsCount++;
+        },
+
+        didReceiveAttrs() {
+          assert.ok(this.didInit, 'expected init to have run before didReceiveAttrs');
+          didReceiveAttrsCount++;
+        },
+
+        willRender() {
+          throw new Error('Unexpected render!');
+        }
+      })
+    });
+
+    assert.strictEqual(didInitAttrsCount, 0, 'precond: didInitAttrs is not fired');
+    assert.strictEqual(didReceiveAttrsCount, 0, 'precond: didReceiveAttrs is not fired');
+
+    this.runTask(() => this.component = this.owner.lookup('component:foo-bar'));
+
+    assert.strictEqual(didInitAttrsCount, 1, 'precond: didInitAttrs is fired');
+    assert.strictEqual(didReceiveAttrsCount, 1, 'precond: didReceiveAttrs is fired');
+  }
+
   ['@test did{Init,Receive}Attrs fires after .init() but before observers become active'](assert) {
     expectDeprecation(/didInitAttrs called/);
 


### PR DESCRIPTION
Turns out the new attrs tests added in #14442 were not working correctly – I noticed this because it was testing the wrong hook. They were only passing because of the attrs -> props alias, so I fixed to test to make sure it is actually testing the thing we intended.

Also added back the unit test replication which got lost in confusion.

cc @stefanpenner @rwjblue 
