### PR TITLE
ember-source related cleanup

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,33 @@
 node-tests/
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+FEATURES.md
+STYLEGUIDE.md
+VERSION
+bin
+blueprints
+bower.json
+bower_components
+config
+ember-cli-build.js
+ember-source.gemspec
+features.json
+generators
+lib
+node-tests
+node_modules
+packages
+scripts
+server
+testem.dist.json
+testem.json
+testem.travis-browsers.js
+tests
+tmp
+vendor
+!vendor/ember/
+yarn.lock
+yuidoc.json
+
+# In the future we will likely want to restrict exactly
+# which parts of `/dist` we want to include.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:blueprints": "node node-tests/nodetest-runner.js",
     "start": "ember serve",
     "docs": "ember ember-cli-yuidoc",
-    "sauce:launch": "ember sauce:launch"
+    "sauce:launch": "ember sauce:launch",
+    "release": "node scripts/release.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,0 +1,4 @@
+var execSync = require('child_process').execSync;
+
+execSync("ember build --environment production");
+execSync("npm publish");


### PR DESCRIPTION
Fixes #14434. See issue for checklist.
- [x] Fix `prepublish` script in ember to do `ember build -prod`
- [x] Fix `.npmignore` (we are including waaaaaayyyyy to much in the tar.gz right now)
- [x] Fix `ember-cli-htmlbars` for the ember-source name change https://github.com/ember-cli/ember-cli-htmlbars/pull/98
- [x] use node + `execSync` for release script
