### PR TITLE
[BUGFIX beta] [FIXES #14447] fix didDestroyElement

### DIFF
--- a/packages/ember-glimmer/lib/renderer.js
+++ b/packages/ember-glimmer/lib/renderer.js
@@ -92,6 +92,7 @@ class RootState {
     this.destroyed = true;
 
     this.env = null;
+    let root = this.root;
     this.root = null;
     this.result = null;
     this.render = null;
@@ -116,6 +117,10 @@ class RootState {
       result.destroy();
 
       if (needsTransaction) {
+        if (typeof root.trigger === 'function') {
+          // when in append mode, the root is the component we must trigger destroy on.
+          root.trigger('didDestroyElement');
+        }
         env.commit();
       }
     }
@@ -221,7 +226,9 @@ class Renderer {
 
     setViewElement(view, null);
 
-    if (this._destinedForDOM) {
+    if (this._destinedForDOM && view.parentView !== null) {
+      // trigger only for non root views, if the root is a view (during
+      // appendTo) env.commit() handles this...
       view.trigger('didDestroyElement');
     }
 
@@ -243,7 +250,6 @@ class Renderer {
     let i = this._roots.length;
     while (i--) {
       let root = roots[i];
-      // check if the view being removed is a root view
       if (root.isFor(view)) {
         root.destroy();
       }

--- a/packages/ember-glimmer/tests/integration/components/append-test.js
+++ b/packages/ember-glimmer/tests/integration/components/append-test.js
@@ -241,21 +241,21 @@ class AbstractAppendTest extends RenderingTest {
 
     hooks.length = 0;
 
-    // TODO: deletion needs to be tested, but has other issues and will join us in a later PR
-    // this.runTask(() => this.component.destroy());
+    this.runTask(() => this.component.destroy());
 
-    // assert.deepEqual(hooks, [
-    //   [ 'x-parent', 'didDestroyElement' ],
-    //   [ 'x-parent', 'willDestroyElement' ],
-    //   [ 'x-parent', 'willClearRender' ],
+    assert.deepEqual(hooks, [
+      ['x-parent', 'willDestroyElement'],
+      ['x-parent', 'willClearRender'],
 
-    //   [ 'x-child', 'willDestroyElement' ],
-    //   [ 'x-child', 'willClearRender' ],
-    //   [ 'x-child', 'didDestroyElement' ],
+      ['x-child', 'willDestroyElement'],
+      ['x-child', 'willClearRender'],
 
-    //   [ 'x-parent', 'willDestroy' ],
-    //   [ 'x-child', 'willDestroy' ]
-    // ], 'destroy');
+      ['x-parent', 'didDestroyElement'],
+      ['x-child', 'didDestroyElement'],
+
+      ['x-parent', 'willDestroy'],
+      ['x-child', 'willDestroy']
+    ], 'destroy');
   }
 
   ['@test appending, updating and destroying a single component'](assert) {


### PR DESCRIPTION
Components via appendTo, must behave the same when torn down via destroy, and the regular rendering system tearing them down. This code-path isn’t as first class as it likely should be, as it only exists for supporting the more legacy style of unit testing. Using the component integration tests, the typical code path is taken.
