### PR TITLE
Support query params in asynchronously loaded routes

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -421,10 +421,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     // urlKey isn't used here, but anyone overriding
     // can use it to provide serialization specific
     // to a certain query param.
-    if (defaultValueType === 'array') {
-      return JSON.stringify(value);
-    }
-    return `${value}`;
+    return this.router._serializeQueryParam(value, defaultValueType);
   },
 
   /**
@@ -440,17 +437,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     // urlKey isn't used here, but anyone overriding
     // can use it to provide deserialization specific
     // to a certain query param.
-
-    // Use the defaultValueType of the default value (the initial value assigned to a
-    // controller query param property), to intelligently deserialize and cast.
-    if (defaultValueType === 'boolean') {
-      return (value === 'true') ? true : false;
-    } else if (defaultValueType === 'number') {
-      return (Number(value)).valueOf();
-    } else if (defaultValueType === 'array') {
-      return emberA(JSON.parse(value));
-    }
-    return value;
+    return this.router._deserializeQueryParam(value, defaultValueType);
   },
 
   /**

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -811,7 +811,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
 
       let handlerInfos = transition.state.handlerInfos;
       let router = this.router;
-      let qpMeta = router._queryParamsFor(handlerInfos[handlerInfos.length - 1].name);
+      let qpMeta = router._queryParamsFor(handlerInfos);
       let changes = router._qpUpdates;
       let replaceUrl;
 
@@ -2213,8 +2213,7 @@ function getFullQueryParams(router, state) {
   state.fullQueryParams = {};
   assign(state.fullQueryParams, state.queryParams);
 
-  let targetRouteName = state.handlerInfos[state.handlerInfos.length - 1].name;
-  router._deserializeQueryParams(targetRouteName, state.fullQueryParams);
+  router._deserializeQueryParams(state.handlerInfos, state.fullQueryParams);
   return state.fullQueryParams;
 }
 

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -142,6 +142,19 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
   */
 
   /**
+    Sets the name for this route, including a fully resolved name for routes
+    inside engines.
+
+    @private
+    @method _setRouteName
+    @param {String} name
+  */
+  _setRouteName(name) {
+    this.routeName = name;
+    this.fullRouteName = getEngineRouteName(getOwner(this), name);
+  },
+
+  /**
     @private
 
     @property _qp
@@ -149,7 +162,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
   _qp: computed(function() {
     let controllerProto, combinedQueryParameterConfiguration;
 
-    let controllerName = this.controllerName || this.routeName;
+    let controllerName = this.controllerName || this.fullRouteName;
     let definedControllerClass = getOwner(this)._lookupFactory(`controller:${controllerName}`);
     let queryParameterConfiguraton = get(this, 'queryParams');
     let hasRouterDefinedQueryParams = !!Object.keys(queryParameterConfiguraton).length;
@@ -373,7 +386,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     let transition = this.router.router.activeTransition;
     let state = transition ? transition.state : this.router.router.state;
 
-    let fullName = getEngineRouteName(getOwner(this), name);
+    let fullName = route.fullRouteName;
     let params = assign({}, state.params[fullName]);
     let queryParams = getQueryParamsFor(route, state);
 
@@ -791,7 +804,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     },
 
     finalizeQueryParamChange(params, finalParams, transition) {
-      if (this.routeName !== 'application') { return true; }
+      if (this.fullRouteName !== 'application') { return true; }
 
       // Transition object is absent for intermediate transitions.
       if (!transition) { return; }
@@ -2207,9 +2220,7 @@ function getFullQueryParams(router, state) {
 
 function getQueryParamsFor(route, state) {
   state.queryParamsFor = state.queryParamsFor || {};
-  let name = route.routeName;
-
-  name = getEngineRouteName(getOwner(route), name);
+  let name = route.fullRouteName;
 
   if (state.queryParamsFor[name]) { return state.queryParamsFor[name]; }
 

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -155,6 +155,16 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
   },
 
   /**
+    Populates the QP meta information in the BucketCache.
+
+    @private
+    @method _populateQPMeta
+  */
+  _populateQPMeta() {
+    this._bucketCache.stash('route-meta', this.fullRouteName, this.get('_qp'));
+  },
+
+  /**
     @private
 
     @property _qp

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -596,6 +596,7 @@ const EmberRouter = EmberObject.extend(Evented, {
       }
 
       handler._setRouteName(routeName);
+      handler._populateQPMeta();
 
       if (engineInfo && !hasDefaultSerialize(handler)) {
         throw new Error('Defining a custom serialize method on an Engine route is not supported.');

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -1169,10 +1169,13 @@ function calculatePostTransitionState(emberRouter, leafRouteName, contexts) {
 
   for (let i = 0; i < handlerInfos.length; ++i) {
     let handlerInfo = handlerInfos[i];
+
+    // If the handlerInfo is not resolved, we serialize the context into params
     if (!handlerInfo.isResolved) {
-      handlerInfo = handlerInfo.becomeResolved(null, handlerInfo.context);
+      params[handlerInfo.name] = handlerInfo.serialize(handlerInfo.context);
+    } else {
+      params[handlerInfo.name] = handlerInfo.params;
     }
-    params[handlerInfo.name] = handlerInfo.params;
   }
   return state;
 }

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -594,7 +594,7 @@ const EmberRouter = EmberObject.extend(Evented, {
         }
       }
 
-      handler.routeName = routeName;
+      handler._setRouteName(routeName);
 
       if (engineInfo && !hasDefaultSerialize(handler)) {
         throw new Error('Defining a custom serialize method on an Engine route is not supported.');

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -361,8 +361,8 @@ QUnit.test('paramsFor considers an engine\'s mountPoint', function(assert) {
     }
   });
 
-  let applicationRoute = EmberRoute.create({ router, routeName: 'application' });
-  let postsRoute = EmberRoute.create({ router, routeName: 'posts' });
+  let applicationRoute = EmberRoute.create({ router, routeName: 'application', fullRouteName: 'foo.bar' });
+  let postsRoute = EmberRoute.create({ router, routeName: 'posts', fullRouteName: 'foo.bar.posts' });
   let route = EmberRoute.create({ router });
 
   setOwner(applicationRoute, engineInstance);

--- a/packages/ember/tests/routing/query_params_test/query_param_async_get_handler_test.js
+++ b/packages/ember/tests/routing/query_params_test/query_param_async_get_handler_test.js
@@ -1,0 +1,179 @@
+import { RSVP } from 'ember-runtime';
+
+import { QueryParamTestCase, moduleFor } from 'internal-test-helpers';
+
+// These tests mimic what happens with lazily loaded Engines.
+moduleFor('Query Params - async get handler', class extends QueryParamTestCase {
+  get routerOptions() {
+    let fetchedHandlers = this.fetchedHandlers = [];
+
+    return {
+      location: 'test',
+
+      _getQPMeta(handlerInfo) {
+        return this._bucketCache.lookup('route-meta', handlerInfo.name);
+      },
+
+      _getHandlerFunction() {
+        let getHandler = this._super(...arguments);
+        let cache = {};
+
+        return (routeName) => {
+          fetchedHandlers.push(routeName);
+
+          // Cache the returns so we don't have more than one Promise for a
+          // given handler.
+          return cache[routeName] || (cache[routeName] = new RSVP.Promise((resolve) => {
+            setTimeout(() => resolve(getHandler(routeName)), 10);
+          }));
+        };
+      }
+    };
+  }
+
+  ['@test can render a link to an asynchronously loaded route without fetching the route'](assert) {
+    assert.expect(4);
+
+    this.router.map(function() {
+      this.route('post', { path: '/post/:id' });
+    });
+
+    this.setSingleQPController('post');
+
+    let setupAppTemplate = () => {
+      this.registerTemplate('application', `
+        {{link-to 'Post' 'post' 1337 (query-params foo='bar') class='post-link'}}
+        {{link-to 'Post' 'post' 7331 (query-params foo='boo') class='post-link'}}
+        {{outlet}}
+      `);
+    };
+
+    setupAppTemplate();
+
+    return this.visitAndAssert('/').then(() => {
+      assert.equal(this.$('.post-link').eq(0).attr('href'), '/post/1337?foo=bar', 'renders correctly with default QP value');
+      assert.equal(this.$('.post-link').eq(1).attr('href'), '/post/7331?foo=boo', 'renders correctly with non-default QP value');
+      assert.deepEqual(this.fetchedHandlers, ['application', 'index'], `only fetched the handlers for the route we're on`);
+    });
+  }
+
+  ['@test can transitionTo to an asynchronously loaded route with simple query params'](assert) {
+    assert.expect(6);
+
+    this.router.map(function() {
+      this.route('post', { path: '/post/:id' });
+      this.route('posts');
+    });
+
+    this.setSingleQPController('post');
+
+    let postController;
+    return this.visitAndAssert('/').then(() => {
+      postController = this.getController('post');
+
+      return this.transitionTo('posts').then(() => {
+        this.assertCurrentPath('/posts');
+      });
+    }).then(() => {
+      return this.transitionTo('post', 1337, { queryParams: { foo: 'boo' } }).then(() => {
+        assert.equal(postController.get('foo'), 'boo', 'simple QP is correctly set on controller');
+        this.assertCurrentPath('/post/1337?foo=boo');
+      });
+    }).then(() => {
+      return this.transitionTo('post', 1337, { queryParams: { foo: 'bar' } }).then(() => {
+        assert.equal(postController.get('foo'), 'bar', 'simple QP is correctly set with default value');
+        this.assertCurrentPath('/post/1337');
+      });
+    });
+  }
+
+  ['@test can transitionTo to an asynchronously loaded route with array query params'](assert) {
+    assert.expect(5);
+
+    this.router.map(function() {
+      this.route('post', { path: '/post/:id' });
+    });
+
+    this.setSingleQPController('post', 'comments', []);
+
+    let postController;
+    return this.visitAndAssert('/').then(() => {
+      postController = this.getController('post');
+      return this.transitionTo('post', 1337, { queryParams: { comments: [1, 2] } }).then(() => {
+        assert.deepEqual(postController.get('comments'), [1, 2], 'array QP is correctly set with default value');
+        this.assertCurrentPath('/post/1337?comments=%5B1%2C2%5D');
+      });
+    }).then(() => {
+      return this.transitionTo('post', 1338).then(() => {
+        assert.deepEqual(postController.get('comments'), [], 'array QP is correctly set on controller');
+        this.assertCurrentPath('/post/1338');
+      });
+    });
+  }
+
+  ['@test can transitionTo to an asynchronously loaded route with mapped query params'](assert) {
+    assert.expect(7);
+
+    this.router.map(function() {
+      this.route('post', { path: '/post/:id' }, function() {
+        this.route('index', { path: '/' });
+      });
+    });
+
+    this.setSingleQPController('post');
+    this.setMappedQPController('post.index', 'comment', 'note');
+
+    let postController;
+    let postIndexController;
+
+    return this.visitAndAssert('/').then(() => {
+      postController = this.getController('post');
+      postIndexController = this.getController('post.index');
+
+      return this.transitionTo('post.index', 1337, { queryParams: { note: 6, foo: 'boo' } }).then(() => {
+        assert.equal(postController.get('foo'), 'boo', 'simple QP is correctly set on controller');
+        assert.equal(postIndexController.get('comment'), 6, 'mapped QP is correctly set on controller');
+        this.assertCurrentPath('/post/1337?foo=boo&note=6');
+      });
+    }).then(() => {
+      return this.transitionTo('post', 1337, { queryParams: { foo: 'bar' } }).then(() => {
+        assert.equal(postController.get('foo'), 'bar', 'simple QP is correctly set with default value');
+        assert.equal(postIndexController.get('comment'), 6, 'mapped QP retains value scoped to model');
+        this.assertCurrentPath('/post/1337?note=6');
+      });
+    });
+  }
+
+  ['@test can transitionTo with a URL'](assert) {
+    assert.expect(7);
+
+    this.router.map(function() {
+      this.route('post', { path: '/post/:id' }, function() {
+        this.route('index', { path: '/' });
+      });
+    });
+
+    this.setSingleQPController('post');
+    this.setMappedQPController('post.index', 'comment', 'note');
+
+    let postController;
+    let postIndexController;
+
+    return this.visitAndAssert('/').then(() => {
+      postController = this.getController('post');
+      postIndexController = this.getController('post.index');
+
+      return this.transitionTo('/post/1337?foo=boo&note=6').then(() => {
+        assert.equal(postController.get('foo'), 'boo', 'simple QP is correctly deserialized on controller');
+        assert.equal(postIndexController.get('comment'), 6, 'mapped QP is correctly deserialized on controller');
+        this.assertCurrentPath('/post/1337?foo=boo&note=6');
+      });
+    }).then(() => {
+      return this.transitionTo('/post/1337?note=6').then(() => {
+        assert.equal(postController.get('foo'), 'bar', 'simple QP is correctly deserialized with default value');
+        assert.equal(postIndexController.get('comment'), 6, 'mapped QP retains value scoped to model');
+        this.assertCurrentPath('/post/1337?note=6');
+      });
+    });
+  }
+});


### PR DESCRIPTION
This PR enables support for query params in routes that are lazily loaded while not altering existing behavior. There are lots of details about the changes in the individual commit messages.

The bulk of the changes center on two key themes:
1. Not using the `handler` (route) before it is absolutely needed
2. Making it possible to decouple the Router's logic from the presence of Routes
