### PR TITLE
Deprecate renderToElement

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/append-test.js
+++ b/packages/ember-glimmer/tests/integration/components/append-test.js
@@ -635,6 +635,7 @@ moduleFor('appendTo: with multiple components', class extends AbstractAppendTest
 moduleFor('renderToElement: no arguments (defaults to a body context)', class extends AbstractAppendTest {
 
   append(component) {
+    expectDeprecation(/Using the `renderToElement` is deprecated in favor of `appendTo`. Called in/);
     let wrapper;
 
     this.runTask(() => wrapper = component.renderToElement());
@@ -652,6 +653,7 @@ moduleFor('renderToElement: no arguments (defaults to a body context)', class ex
 moduleFor('renderToElement: a div', class extends AbstractAppendTest {
 
   append(component) {
+    expectDeprecation(/Using the `renderToElement` is deprecated in favor of `appendTo`. Called in/);
     let wrapper;
 
     this.runTask(() => wrapper = component.renderToElement('div'));

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -215,10 +215,21 @@ export default Mixin.create({
     @method renderToElement
     @param {String} tagName The tag of the element to create and render into. Defaults to "body".
     @return {HTMLBodyElement} element
+    @deprecated Use appendTo instead.
     @private
   */
   renderToElement(tagName) {
     tagName = tagName || 'body';
+
+    deprecate(
+      `Using the \`renderToElement\` is deprecated in favor of \`appendTo\`. Called in ${this.toString()}`,
+      false,
+      {
+        id: 'ember-views.render-to-element',
+        until: '2.12.0',
+        url: 'http://emberjs.com/deprecations/v2.x#toc_code-rendertoelement-code'
+      }
+    );
 
     let element = this.renderer.createElement(tagName);
 


### PR DESCRIPTION
This implements #14158. 

Deprecation guide: emberjs/website#2702.
