### PR TITLE
Support `target` option for closure actions

### DIFF
--- a/packages/ember-template-compiler/lib/plugins/transform-action-syntax.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-action-syntax.js
@@ -63,5 +63,35 @@ function isAction(node) {
 }
 
 function insertThisAsFirstParam(node, builders) {
-  node.params.unshift(builders.path('this'));
+  let contextPath = builders.path('this');
+  let target = hashPairForKey(node.hash, 'target');
+  if (target) {
+    contextPath = target.value;
+    removeFromHash(node.hash, target);
+  }
+  node.params.unshift(contextPath);
+}
+
+function hashPairForKey(hash, key) {
+  for (let i = 0; i < hash.pairs.length; i++) {
+    let pair = hash.pairs[i];
+    if (pair.key === key) {
+      return pair;
+    }
+  }
+
+  return false;
+}
+
+function removeFromHash(hash, pairToRemove) {
+  let newPairs = [];
+  for (let i = 0; i < hash.pairs.length; i++) {
+    let pair = hash.pairs[i];
+
+    if (pair !== pairToRemove) {
+      newPairs.push(pair);
+    }
+  }
+
+  hash.pairs = newPairs;
 }


### PR DESCRIPTION
This is a spike to support the `target` hash argument for closure actions.

**This is a Work In Progress** I am putting this WIP as a PR so I can get some comments on it. Specifically I need help with the following:
1.  The helper functions were copied from `packages/ember-template-compiler/lib/plugins/transform-input-on-to-onEvent.js`. Since now two files need these the same functions should be DRY. But I don't know the ember code well enough to know where such utility functions should go.
2.  How and where to test. The tests that touch this are in the glimmer package. There appears to be no tests for `transform-action-syntax.js` in the `ember-template-compiler` so I don't have a good ground to work from. Any help would be appreciated.

Related to issue #14469 
