### PR TITLE
[BUGFIX] Use routeName instead of fullRouteName in QP meta

### DIFF
--- a/packages/ember-glimmer/tests/integration/application/engine-test.js
+++ b/packages/ember-glimmer/tests/integration/application/engine-test.js
@@ -22,7 +22,11 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
     this.registerEngine('blog', Engine.extend({
       init() {
         this._super(...arguments);
-        this.register('template:application', compile('Engine{{outlet}}'));
+        this.register('controller:application', Controller.extend({
+          queryParams: ['lang'],
+          lang: ''
+        }));
+        this.register('template:application', compile('Engine{{lang}}{{outlet}}'));
         this.register('route:application', Route.extend({
           model() {
             hooks.push('engine - application');
@@ -272,6 +276,14 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
 
     return this.visit('/blog').then(() => {
       this.assertText('ApplicationEngine');
+    });
+  }
+
+  ['@test engine should lookup and use correct controller'](assert) {
+    this.setupAppAndRoutableEngine();
+
+    return this.visit('/blog?lang=English').then(() => {
+      this.assertText('ApplicationEngineEnglish');
     });
   }
 });

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -172,7 +172,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
   _qp: computed(function() {
     let controllerProto, combinedQueryParameterConfiguration;
 
-    let controllerName = this.controllerName || this.fullRouteName;
+    let controllerName = this.controllerName || this.routeName;
     let definedControllerClass = getOwner(this)._lookupFactory(`controller:${controllerName}`);
     let queryParameterConfiguraton = get(this, 'queryParams');
     let hasRouterDefinedQueryParams = !!Object.keys(queryParameterConfiguraton).length;


### PR DESCRIPTION
Accidentally broke the Controller lookup for QPs in Engines in the last round of changes. I mistakenly thought we should use `fullRouteName` inside of `_qp` to avoid potential collisions in the BucketCache, but that value is also used to look up the Route's Controller so it shouldn't be fully resolved.

Additionally, the BucketCache seems to be unique per engine-instance, so collisions shouldn't be an issue.

Edit: Added a bunch of tests in the ember-engines repo to verify everything works as expected with this change. See https://github.com/dgeb/ember-engines/pull/227 for more info.
