### PR TITLE
[BUGFIX beta] Fix unknownProperty key

### DIFF
--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -11,6 +11,12 @@ const ALLOWABLE_TYPES = {
   string: true
 };
 
+function canCallUnknownProperty(obj, key) {
+  return 'object' === typeof obj &&
+         !(key in obj) &&
+         'function' === typeof obj.unknownProperty;
+}
+
 // ..........................................................
 // GET AND SET
 //
@@ -55,23 +61,23 @@ export function get(obj, keyName) {
 
   let value = obj[keyName];
   let desc = (value !== null && typeof value === 'object' && value.isDescriptor) ? value : undefined;
-  let ret;
 
   if (desc === undefined && isPath(keyName)) {
-    return _getPath(obj, keyName);
+    if (canCallUnknownProperty(obj, keyName)) {
+      return obj.unknownProperty(keyName);
+    } else {
+      return _getPath(obj, keyName);
+    }
   }
 
   if (desc) {
     return desc.get(obj, keyName);
   } else {
-    ret = value;
-
-    if (ret === undefined &&
-        'object' === typeof obj && !(keyName in obj) && 'function' === typeof obj.unknownProperty) {
+    if (value === undefined && canCallUnknownProperty(obj, keyName)) {
       return obj.unknownProperty(keyName);
+    } else {
+      return value;
     }
-
-    return ret;
   }
 }
 

--- a/packages/ember-metal/tests/accessors/get_test.js
+++ b/packages/ember-metal/tests/accessors/get_test.js
@@ -172,6 +172,16 @@ QUnit.test('should call unknownProperty if defined and value is undefined', func
   equal(obj.count, 1, 'should have invoked');
 });
 
+QUnit.test('should call unknownProperty with original key', function() {
+  let obj = {
+    unknownProperty(key) {
+      return key;
+    }
+  };
+
+  equal(get(obj, 'foo.bar'), 'foo.bar');
+});
+
 testBoth('if unknownProperty is present, it is called', function(get, set) {
   let obj = {
     count: 0,

--- a/packages/ember-runtime/lib/mixins/-proxy.js
+++ b/packages/ember-runtime/lib/mixins/-proxy.js
@@ -111,6 +111,7 @@ export default Mixin.create({
   },
 
   unknownProperty(key) {
+    key = key.replace(/^content\./, '');
     let content = get(this, 'content');
     if (content) {
       deprecate(


### PR DESCRIPTION
Fixes #14491

When calling `get(obj, key)` allow deep keys to be passed
to unknownProperty

e.g.

```
let obj = {
  unknownProperty(key) {
    assert(key, 'foo.bar');
  }
}

get(obj, 'foo.bar');
```

Before only `foo` would have been passed.
