### PR TITLE
[Bugfix beta] Guard _object on meta from being set for primitives

### DIFF
--- a/packages/ember-metal/tests/chains_test.js
+++ b/packages/ember-metal/tests/chains_test.js
@@ -19,6 +19,16 @@ QUnit.test('finishChains should properly copy chains from prototypes to instance
   ok(peekMeta(obj) !== peekMeta(childObj).readableChains(), 'The chains object is copied');
 });
 
+QUnit.test('does not observe primative values', function(assert) {
+  let obj = {
+    foo: { bar: 'STRING' }
+  };
+
+  addObserver(obj, 'foo.bar.baz', null, function() {});
+  let meta = peekMeta(obj);
+  assert.notOk(meta._object);
+});
+
 
 QUnit.test('observer and CP chains', function() {
   let obj = { };


### PR DESCRIPTION
This effects node 0.12.0, because the WeakMap implementation is not to spec. Also we should never observe a primative type.
