### PR TITLE
Remove space from generated unit-tests

### DIFF
--- a/blueprints/component-test/qunit-files/tests/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/qunit-files/tests/__testType__/__path__/__test__.js
@@ -8,7 +8,8 @@ moduleForComponent('<%= componentPathName %>', '<%= friendlyTestDescription %>',
 });
 
 test('it renders', function(assert) {
-  <% if (testType === 'integration' ) { %>// Set any properties with this.set('myProperty', 'value');
+<% if (testType === 'integration' ) { %>
+  // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
 
   this.render(hbs`{{<%= componentPathName %>}}`);


### PR DESCRIPTION
When generating a unit-test for a component, a blank line with a space is generated, which causes linting to fail. Related PR in ember-cli-legacy-blueprints: https://github.com/ember-cli/ember-cli-legacy-blueprints/pull/67.
