### PR TITLE
[Doc] Fix example for nested usage of component helper

### DIFF
--- a/packages/ember-glimmer/lib/helpers/component.js
+++ b/packages/ember-glimmer/lib/helpers/component.js
@@ -73,7 +73,7 @@ import { assert } from 'ember-metal';
 
   ```
   {{#person-form as |form|}}
-    {{component form.nameInput placeholder="Username"}}
+    {{form.nameInput placeholder="Username"}}
   {{/person-form}}
   ```
 


### PR DESCRIPTION
Removes erroneous use of `component` keyword, addressing https://github.com/emberjs/ember.js/issues/14503
