### PR TITLE
[BUGFIX release] Fix overwriting rest positional parameters when passed as named  parameters.

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/closure-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/closure-components-test.js
@@ -3,6 +3,7 @@ import { applyMixins, strip } from '../../utils/abstract-test-case';
 import { moduleFor, RenderingTest } from '../../utils/test-case';
 import assign from 'ember-metal/assign';
 import isEmpty from 'ember-metal/is_empty';
+import { A as emberA } from 'ember-runtime/system/native_array';
 
 moduleFor('@htmlbars Components test: closure components', class extends RenderingTest {
   ['@test renders with component helper']() {
@@ -767,6 +768,83 @@ moduleFor('@htmlbars Components test: closure components', class extends Renderi
     assert.equal(this.$().text(), '');
   }
 
+  ['@test GH#14508 rest positional params are received when passed as named parameter']() {
+    this.registerComponent('my-link', {
+      ComponentClass: Component.extend().reopenClass({
+        positionalParams: 'params'
+      }),
+      template: '{{#each params as |p|}}{{p}}{{/each}}'
+    });
+
+    this.render('{{component (component "my-link") params=allParams}}', {
+      allParams: emberA(['a', 'b'])
+    });
+
+    this.assertText('ab');
+
+    this.runTask(() => this.rerender());
+
+    this.assertText('ab');
+
+    this.runTask(() => this.context.get('allParams').pushObject('c'));
+
+    this.assertText('abc');
+
+    this.runTask(() => this.context.get('allParams').popObject());
+
+    this.assertText('ab');
+
+    this.runTask(() => this.context.get('allParams').clear());
+
+    this.assertText('');
+
+    this.runTask(() => this.context.set('allParams', emberA(['1', '2'])));
+
+    this.assertText('12');
+
+    this.runTask(() => this.context.set('allParams', emberA(['a', 'b'])));
+
+    this.assertText('ab');
+  }
+
+  ['@test GH#14508 rest positional params are received when passed as named parameter with dot notation']() {
+    this.registerComponent('my-link', {
+      ComponentClass: Component.extend().reopenClass({
+        positionalParams: 'params'
+      }),
+      template: '{{#each params as |p|}}{{p}}{{/each}}'
+    });
+
+    this.render('{{#with (hash link=(component "my-link")) as |c|}}{{c.link params=allParams}}{{/with}}', {
+      allParams: emberA(['a', 'b'])
+    });
+
+    this.assertText('ab');
+
+    this.runTask(() => this.rerender());
+
+    this.assertText('ab');
+
+    this.runTask(() => this.context.get('allParams').pushObject('c'));
+
+    this.assertText('abc');
+
+    this.runTask(() => this.context.get('allParams').popObject());
+
+    this.assertText('ab');
+
+    this.runTask(() => this.context.get('allParams').clear());
+
+    this.assertText('');
+
+    this.runTask(() => this.context.set('allParams', emberA(['1', '2'])));
+
+    this.assertText('12');
+
+    this.runTask(() => this.context.set('allParams', emberA(['a', 'b'])));
+
+    this.assertText('ab');
+  }
 });
 
 class ClosureComponentMutableParamsTest extends RenderingTest {

--- a/packages/ember-htmlbars/lib/hooks/component.js
+++ b/packages/ember-htmlbars/lib/hooks/component.js
@@ -44,6 +44,7 @@ export default function componentHook(renderNode, env, scope, _tagName, params, 
       processPositionalParamsFromCell(componentCell, params, newAttrs);
       attrs = mergeInNewHash(componentCell[COMPONENT_HASH],
                              newAttrs,
+                             env,
                              componentCell[COMPONENT_POSITIONAL_PARAMS],
                              params);
       params = [];

--- a/packages/ember-htmlbars/lib/hooks/link-render-node.js
+++ b/packages/ember-htmlbars/lib/hooks/link-render-node.js
@@ -35,7 +35,7 @@ export default function linkRenderNode(renderNode, env, scope, path, params, has
     let componentCell = stream.value();
 
     if (isComponentCell(componentCell)) {
-      let closureAttrs = mergeInNewHash(componentCell[COMPONENT_HASH], hash);
+      let closureAttrs = mergeInNewHash(componentCell[COMPONENT_HASH], hash, env);
 
       for (let key in closureAttrs) {
         subscribe(renderNode, env, scope, closureAttrs[key]);

--- a/packages/ember-htmlbars/lib/keywords/element-component.js
+++ b/packages/ember-htmlbars/lib/keywords/element-component.js
@@ -73,6 +73,7 @@ function render(morph, env, scope, [path, ...params], hash, template, inverse, v
     processPositionalParamsFromCell(closureComponent, params, hash);
     hash = mergeInNewHash(closureComponent[COMPONENT_HASH],
                           hash,
+                          env,
                           closureComponent[COMPONENT_POSITIONAL_PARAMS],
                           params);
     params = [];


### PR DESCRIPTION
If rest positional parameters are passed as named arguments, it might
not be passed to the component when called with a contextual component.

Example:

``` hbs
{{component (component "link-to") params=someParams}}
```

Fix #14508
