### PR TITLE
[BUGFIX beta] Bump Glimmer

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "git-repo-info": "^1.1.4",
     "git-repo-version": "^0.3.1",
     "github": "^0.2.3",
-    "glimmer-engine": "^0.17.5",
+    "glimmer-engine": "^0.17.6",
     "glob": "^5.0.13",
     "html-differ": "^1.3.4",
     "mocha": "^2.4.5",

--- a/packages/ember-glimmer/lib/syntax/outlet.js
+++ b/packages/ember-glimmer/lib/syntax/outlet.js
@@ -114,7 +114,6 @@ class OutletComponentReference {
   value() {
     let { outletNameRef, parentOutletStateRef, definition, lastState } = this;
 
-
     let outletName = outletNameRef.value();
     let outletStateRef = parentOutletStateRef.get('outlets').get(outletName);
     let newState = this.lastState = outletStateRef.value();
@@ -130,7 +129,7 @@ class OutletComponentReference {
     } else if (hasTemplate) {
       return this.definition = new OutletComponentDefinition(outletName, newState.render.template);
     } else {
-      return null;
+      return this.definition = null;
     }
   }
 }


### PR DESCRIPTION
This pulls in two glimmer-engine bugfixes:
- local variables (block params) should always win over helpers
- stateful/class-based helpers used in `{{#if (my-helper ...)}}` and other block arguments position are destroyed when the block syntax switches from default to inverse (and vice versa)

Fixes #14351, #14413
