### PR TITLE
[BUGFIX lts-2-8] Fix JSHint issue with referencing `Symbol`.

### DIFF
--- a/packages/ember-metal/tests/utils_test.js
+++ b/packages/ember-metal/tests/utils_test.js
@@ -8,11 +8,7 @@ import {
 QUnit.module('Ember Metal Utils');
 
 QUnit.test('inspect outputs the toString() representation of Symbols', function() {
-  // Symbol is not defined on pre-ES2015 runtimes, so this let's us safely test
-  // for it's existence (where a simple `if (Symbol)` would ReferenceError)
-  let Symbol = Symbol || null;
-
-  if (Symbol) {
+  if (typeof Symbol !== 'undefined') {
     let symbol = Symbol('test');
     equal(inspect(symbol), 'Symbol(test)');
   } else {


### PR DESCRIPTION
The guard for using `Symbol` should not have been setup this way (`let
Symbol = Symbol || null` will never be defined AFAICT since the
transpilation would use `var` which hoists).

Either way, there is no need for the local `Symbol` variable since we
can just check if it is defined as the guard.
