### PR TITLE
[BUGFIX beta] Improve behavior for QPs with undefined values

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -669,6 +669,8 @@ const EmberRouter = EmberObject.extend(Evented, {
       if (qp) {
         delete queryParams[key];
         queryParams[qp.urlKey] = qp.route.serializeQueryParam(value, qp.urlKey, qp.type);
+      } else if (value === undefined) {
+        return; // We don't serialize undefined values
       } else {
         queryParams[key] = this._serializeQueryParam(value, typeOf(value));
       }

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -1231,14 +1231,14 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
     });
   }
 
-  ['@test Undefined isn\'t deserialized into a string'](assert) {
-    assert.expect(3);
+  ['@test undefined isn\'t serialized or deserialized into a string'](assert) {
+    assert.expect(4);
 
     this.router.map(function() {
       this.route('example');
     });
 
-    this.registerTemplate('application', '{{link-to \'Example\' \'example\' id=\'the-link\'}}');
+    this.registerTemplate('application', '{{link-to \'Example\' \'example\' (query-params foo=undefined) id=\'the-link\'}}');
 
     this.setSingleQPController('example', 'foo', undefined, {
       foo: undefined
@@ -1250,13 +1250,12 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
       }
     }));
 
-    return this.visit('/').then(() => {
-      let $link = jQuery('#the-link');
-      assert.equal($link.attr('href'), '/example');
-      run($link, 'click');
+    return this.visitAndAssert('/').then(() => {
+      assert.equal(this.$('#the-link').attr('href'), '/example', 'renders without undefined qp serialized');
 
-      let controller = this.getController('example');
-      assert.equal(get(controller, 'foo'), undefined);
+      return this.transitionTo('example', { queryParams: { foo: undefined } }).then(() => {
+        this.assertCurrentPath('/example');
+      });
     });
   }
 

--- a/packages/ember/tests/routing/query_params_test/query_param_async_get_handler_test.js
+++ b/packages/ember/tests/routing/query_params_test/query_param_async_get_handler_test.js
@@ -1,4 +1,5 @@
 import { RSVP } from 'ember-runtime';
+import { Route } from 'ember-routing';
 
 import { QueryParamTestCase, moduleFor } from 'internal-test-helpers';
 
@@ -173,6 +174,34 @@ moduleFor('Query Params - async get handler', class extends QueryParamTestCase {
         assert.equal(postController.get('foo'), 'bar', 'simple QP is correctly deserialized with default value');
         assert.equal(postIndexController.get('comment'), 6, 'mapped QP retains value scoped to model');
         this.assertCurrentPath('/post/1337?note=6');
+      });
+    });
+  }
+
+  ['@test undefined isn\'t serialized or deserialized into a string'](assert) {
+    assert.expect(4);
+
+    this.router.map(function() {
+      this.route('example');
+    });
+
+    this.registerTemplate('application', '{{link-to \'Example\' \'example\' (query-params foo=undefined) id=\'the-link\'}}');
+
+    this.setSingleQPController('example', 'foo', undefined, {
+      foo: undefined
+    });
+
+    this.registerRoute('example', Route.extend({
+      model(params) {
+        assert.deepEqual(params, { foo: undefined });
+      }
+    }));
+
+    return this.visitAndAssert('/').then(() => {
+      assert.equal(this.$('#the-link').attr('href'), '/example', 'renders without undefined qp serialized');
+
+      return this.transitionTo('example', { queryParams: { foo: undefined } }).then(() => {
+        this.assertCurrentPath('/example');
       });
     });
   }


### PR DESCRIPTION
For the case of lazy loading Engines, all QPs get serialized into the URL initially. `undefined` shouldn't get serialized to a string, so that when it gets pulled out the value is not a string.

cc @nathanhammond
