### PR TITLE
See if POJO QPs just work.

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -665,6 +665,7 @@ const EmberRouter = EmberObject.extend(Evented, {
     @return {Void}
   */
   _serializeQueryParams(handlerInfos, queryParams) {
+    queryParams = JSON.parse(JSON.stringify(queryParams));
     forEachQueryParam(this, handlerInfos, queryParams, (key, value, qp) => {
       if (qp) {
         delete queryParams[key];


### PR DESCRIPTION
Related to #14537. I'd like to force all values passed in as `queryParams` to be JSON serializable.

``` javascript
 _serializeQueryParams(handlerInfos, queryParams) {
  queryParams = JSON.parse(JSON.serialize(queryParams));
  // ...
```

This makes it possible for people to either pass arbitrary objects which implement `toJSON` as values to keys and also sets us up well for a world in which we do structured query params.

It also neatly sidesteps this issue:

``` javascript
JSON.parse(JSON.stringify({foo:undefined}));
// => {}
JSON.parse(JSON.stringify({foo:null}));
// => { foo: null }
```

---

Didn't run the tests, figured I'd let Travis do it for me. Curious if it "just works."
