### PR TITLE
[DOC] Add an example for block syntax to component helper docs

### DIFF
--- a/packages/ember-glimmer/lib/helpers/component.js
+++ b/packages/ember-glimmer/lib/helpers/component.js
@@ -22,17 +22,19 @@ import { assert } from 'ember-metal';
   additional information on how a `Component` functions.
   `{{component}}`'s primary use is for cases where you want to dynamically
   change which type of component is rendered as the state of your application
-  changes. The provided block will be applied as the template for the component.
-  Given an empty `<body>` the following template:
+  changes. This helper has three modes: inline, block, and nested.
 
-  ```handlebars
-  {{! application.hbs }}
+  ### Inline Form
+
+  Given the following template:
+
+  ```app/application.hbs
   {{component infographicComponentName}}
   ```
 
   And the following application code:
 
-  ```javascript
+  ```app/controllers/application.js
   export default Ember.Controller.extend({
     infographicComponentName: computed('isMarketOpen', {
       get() {
@@ -53,18 +55,57 @@ import { assert } from 'ember-metal';
   Note: You should not use this helper when you are consistently rendering the same
   component. In that case, use standard component syntax, for example:
 
-  ```handlebars
-  {{! application.hbs }}
+  ```app/templates/application.hbs
   {{live-updating-chart}}
   ```
 
-  ## Nested Usage
+  ### Block Form
+
+  Using the block form of this helper is similar to using the block form
+  of a component. Given the following application template:
+
+  ```app/templates/application.hbs
+  {{#component infographicComponentName}}
+    Last update: {{lastUpdateTimestamp}}
+  {{/component}}
+  ```
+
+  The following controller code:
+
+  ```app/controllers/application.js
+  export default Ember.Controller.extend({
+    lastUpdateTimestamp: computed(function() {
+      return new Date();
+    }),
+
+    infographicComponentName: computed('isMarketOpen', {
+      get() {
+        if (this.get('isMarketOpen')) {
+          return 'live-updating-chart';
+        } else {
+          return 'market-close-summary';
+        }
+      }
+    })
+  });
+  ```
+
+  And the following component template:
+
+  ```app/templates/components/live-updating-chart.hbs
+  {{! chart }}
+  {{yield}}
+  ```
+
+  The `Last Update: {{lastUpdateTimestamp}}` will be rendered in place of the `{{yield}}`.
+
+  ### Nested Usage
 
   The `component` helper can be used to package a component path with initial attrs.
   The included attrs can then be merged during the final invocation.
   For example, given a `person-form` component with the following template:
 
-  ```handlebars
+  ```app/templates/components/person-form.hbs
   {{yield (hash
     nameInput=(component "my-input-component" value=model.name placeholder="First Name")
   )}}


### PR DESCRIPTION
Although the docs for the component helper shortly mention block syntax in one sentence ("The provided block will be applied as the template for the component.") this can easily be overlooked and no example is provided. While this may seem trivial if you know what you're looking for, it took me quite some time to figure out that it is possible to use the component helper in combination with block syntax. 
