### PR TITLE
[BUGFIX beta] Lock route-recognizer to 0.2.7.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "mocha": "^2.4.5",
     "qunit-extras": "^1.5.0",
     "qunitjs": "^1.22.0",
-    "route-recognizer": "^0.2.7",
+    "route-recognizer": "0.2.7",
     "rsvp": "~3.2.1",
     "serve-static": "^1.10.0",
     "simple-dom": "^0.3.0",


### PR DESCRIPTION
0.2.8 now throws an error when attempting to call `generate` without all the required params (which is a good thing), but unfortunately something that Ember is doing in `{{link-to`'s `href` generation is causing us to call `.generate` when the object is already being destroyed (and our params are undefined).

Related to https://github.com/emberjs/ember.js/pull/14546#issuecomment-257120786.
