### PR TITLE
[BUGFIX lts-2-8] Allow canceling items queued by `run.schedule`.

### DIFF
--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -260,7 +260,7 @@ run.end = function() {
     will be resolved on the target object at the time the scheduled item is
     invoked allowing you to change the target function.
   @param {Object} [arguments*] Optional arguments to be passed to the queued method.
-  @return {void}
+  @return {*} Timer information for use in cancelling, see `run.cancel`.
   @public
 */
 run.schedule = function(/* queue, target, method */) {
@@ -269,7 +269,8 @@ run.schedule = function(/* queue, target, method */) {
     `You will need to wrap any code with asynchronous side-effects in a run`,
     run.currentRunLoop || !isTesting()
   );
-  backburner.schedule(...arguments);
+
+  return backburner.schedule(...arguments);
 };
 
 // Used by global test teardown

--- a/packages/ember-metal/tests/run_loop/schedule_test.js
+++ b/packages/ember-metal/tests/run_loop/schedule_test.js
@@ -14,6 +14,17 @@ QUnit.test('scheduling item in queue should defer until finished', function() {
   equal(cnt, 2, 'should flush actions now');
 });
 
+QUnit.test('a scheduled item can be canceled', function(assert) {
+  let hasRan = false;
+
+  run(() => {
+    let cancelId = run.schedule('actions', () => hasRan = true);
+    run.cancel(cancelId);
+  });
+
+  assert.notOk(hasRan, 'should not have ran callback run');
+});
+
 QUnit.test('nested runs should queue each phase independently', function() {
   let cnt = 0;
 


### PR DESCRIPTION
All of the scheduling related `Ember.run.*` methods return the backburner timer cancelation token with the exception of `Ember.run.schedule`. (this includes `run.next`, `run.later`, `run.debounce`, `run.throttle`, and `run.scheduleOnce`).

This seems like a fairly glaring mistake (and makes it impossible to avoid `if (this.isDestroying) { return; }` guards when using things like `run.schedule('afterRender'`), so I have marked it as `BUGFIX lts-2-8`. If others disagree with the severity here, I can change to a simple `[BUGFIX beta]`.
