### PR TITLE
[BUGFIX beta] Improve error for improper invocations of link-to.

### DIFF
--- a/packages/ember-glimmer/lib/components/link-to.js
+++ b/packages/ember-glimmer/lib/components/link-to.js
@@ -313,7 +313,8 @@ import {
   deprecate,
   get,
   computed,
-  flaggedInstrument
+  flaggedInstrument,
+  runInDebug
 } from 'ember-metal';
 import {
   deprecatingAlias,
@@ -711,6 +712,26 @@ const LinkComponent = EmberComponent.extend({
 
     let routing = get(this, '_routing');
     let queryParams = get(this, 'queryParams.values');
+
+    runInDebug(() => {
+      /*
+       * Unfortunately, to get decent error messages, we need to do this.
+       * In some future state we should be able to use a "feature flag"
+       * which allows us to strip this without needing to call it twice.
+       *
+       * if (isDebugBuild()) {
+       *   // Do the useful debug thing, probably including try/catch.
+       * } else {
+       *   // Do the performant thing.
+       * }
+       */
+      try {
+        routing.generateURL(qualifiedRouteName, models, queryParams);
+      } catch (e) {
+        assert('You attempted to define a `{{link-to "' + qualifiedRouteName + '"}}` but did not pass the parameters required for generating its dynamic segments. ' + e.message);
+      }
+    });
+
     return routing.generateURL(qualifiedRouteName, models, queryParams);
   }),
 

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1249,6 +1249,20 @@ QUnit.test('the {{link-to}} helper does not call preventDefault if `preventDefau
   equal(event.isDefaultPrevented(), false, 'should not preventDefault');
 });
 
+QUnit.test('the {{link-to}} helper throws a useful error if you invoke it wrong', function() {
+  expect(1);
+
+  setTemplate('application', compile("{{#link-to 'post'}}Post{{/link-to}}"));
+
+  Router.map(function() {
+    this.route('post', { path: 'post/:post_id' });
+  });
+
+  QUnit.throws(function() {
+    bootApplication();
+  }, /(You attempted to define a `\{\{link-to "post"\}\}` but did not pass the parameters required for generating its dynamic segments.|You must provide param `post_id` to `generate`)/);
+});
+
 QUnit.test('the {{link-to}} helper does not throw an error if its route has exited', function() {
   expect(0);
 


### PR DESCRIPTION
Unfortunately, to get decent error messages, we need to do something like this. In some future state we should be able to use a "feature flag" which allows us to strip this without needing to call it twice.

``` javascript
if (isProdBuild()) {
  // Do the useful debug thing, probably including try/catch.
} else {
  // Do the performant thing.
}
```
