### PR TITLE
Sets _qpDelegate before running code which could trigger _qpChanged

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1316,6 +1316,9 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     let queryParams = get(this, '_qp');
 
     let states = queryParams.states;
+
+    controller._qpDelegate = states.allowOverrides;
+
     if (transition) {
       // Update the model dep values used to calculate cache keys.
       stashParamNames(this.router, transition.state.handlerInfos);
@@ -1336,8 +1339,6 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
         }
       });
     }
-
-    controller._qpDelegate = states.allowOverrides;
 
     if (transition) {
       let qpValues = getQueryParamsFor(this, transition.state);

--- a/packages/ember/tests/routing/query_params_test/shared_state_test.js
+++ b/packages/ember/tests/routing/query_params_test/shared_state_test.js
@@ -1,0 +1,76 @@
+import {
+  Controller,
+  Service
+} from 'ember-runtime';
+import Ember from 'ember';
+import { run } from 'ember-metal';
+import { jQuery } from 'ember-views';
+import { QueryParamTestCase, moduleFor } from 'internal-test-helpers';
+
+moduleFor('Query Params - shared service state', class extends QueryParamTestCase {
+
+  boot() {
+    this.setupApplication();
+    return this.visitApplication();
+  }
+
+  setupApplication() {
+    this.router.map(function() {
+      this.route('home', { path: '/' });
+      this.route('dashboard');
+    });
+
+    this.application.register('service:filters', Service.extend({
+      shared: true
+    }));
+
+    this.registerController('home', Controller.extend({
+      filters: Ember.inject.service()
+    }));
+
+    this.registerController('dashboard', Controller.extend({
+      filters: Ember.inject.service(),
+      queryParams: [
+        { 'filters.shared': 'shared' }
+      ]
+    }));
+
+    this.registerTemplate('application', `{{link-to 'Home' 'home' }} <div> {{outlet}} </div>`);
+    this.registerTemplate('home', `{{link-to 'Dashboard' 'dashboard' }}{{input type="checkbox" id='filters-checkbox' checked=(mut filters.shared) }}`);
+    this.registerTemplate('dashboard', `{{link-to 'Home' 'home' }}`);
+  }
+  visitApplication() {
+    return this.visit('/');
+  }
+
+  ['@test can modify shared state before transition'](assert) {
+    assert.expect(1);
+
+    return this.boot().then(() => {
+      this.$input = jQuery('#filters-checkbox');
+
+      // click the checkbox once to set filters.shared to false
+      run(this.$input, 'click');
+
+      return this.visit('/dashboard').then(() => {
+        assert.ok(true, 'expecting navigating to dashboard to succeed');
+      });
+    });
+  }
+
+  ['@test can modify shared state back to the default value before transition'](assert) {
+    assert.expect(1);
+
+    return this.boot().then(() => {
+      this.$input = jQuery('#filters-checkbox');
+
+      // click the checkbox twice to set filters.shared to false and back to true
+      run(this.$input, 'click');
+      run(this.$input, 'click');
+
+      return this.visit('/dashboard').then(() => {
+        assert.ok(true, 'expecting navigating to dashboard to succeed');
+      });
+    });
+  }
+});


### PR DESCRIPTION
In scenarios where you are sharing query params across routes, let's say in a service. 

Transitioning between routes, if you've made a state change that would trigger _qpChanged to fire, the route will throw an exception 

```
TypeError: delegate is not a function
```

<details>
```
ember.debug.js:30007 TypeError: delegate is not a function
    at Class._qpChanged (https://cdnjs.cloudflare.com/ajax/libs/ember.js/2.1.2/ember.debug.js:23829:7)
    at Object.apply (https://cdnjs.cloudflare.com/ajax/libs/ember.js/2.1.2/ember.debug.js:21790:18)
    at Object.sendEvent (https://cdnjs.cloudflare.com/ajax/libs/ember.js/2.1.2/ember.debug.js:15616:28)
    at notifyObservers (https://cdnjs.cloudflare.com/ajax/libs/ember.js/2.1.2/ember.debug.js:19247:25)
    at propertyDidChange (https://cdnjs.cloudflare.com/ajax/libs/ember.js/2.1.2/ember.debug.js:19057:5)
    at Object.notify (https://cdnjs.cloudflare.com/ajax/libs/ember.js/2.1.2/ember.debug.js:13310:9)
    at chainsDidChange (https://cdnjs.cloudflare.com/ajax/libs/ember.js/2.1.2/ember.debug.js:19163:9)
    at Object.propertyDidChange (https://cdnjs.cloudflare.com/ajax/libs/ember.js/2.1.2/ember.debug.js:19056:5)
    at set (https://cdnjs.cloudflare.com/ajax/libs/ember.js/2.1.2/ember.debug.js:19495:38)
    at setPath (https://cdnjs.cloudflare.com/ajax/libs/ember.js/2.1.2/ember.debug.js:19534:12)
```
</details>

I've created a scaled down [twiddle](https://ember-twiddle.com/6eba729783b5b955ac13b9ce91b5b998) that you can reproduce the error in. 

An example of usage in the "real world", in HuBoard a side panel with filters in it. Those filters are synced to query params.  Our `index` route shows a task board, but if you transition over to the `milestones` route, we show a similar drag and drop board but we preserve your current filtered down subset of issues between the two routes. 

Kind of like in Trello does, if you add filters on your board and then your transition over to the "calendar" view your filters are still active. 