### PR TITLE
[BUGFIX beta] Avoid clobbering `require`.

### DIFF
--- a/packages/loader/lib/index.js
+++ b/packages/loader/lib/index.js
@@ -1,4 +1,4 @@
-var enifed, requireModule, require, Ember;
+var enifed, requireModule, Ember;
 var mainContext = this;
 
 (function() {
@@ -29,14 +29,14 @@ var mainContext = this;
       registry[name] = value;
     };
 
-    require = requireModule = function(name) {
+    requireModule = function(name) {
       return internalRequire(name, null);
     };
 
     // setup `require` module
-    require['default'] = require;
+    requireModule['default'] = requireModule;
 
-    require.has = function registryHas(moduleName) {
+    requireModule.has = function registryHas(moduleName) {
       return !!registry[moduleName] || !!registry[moduleName + '/index'];
     };
 
@@ -77,7 +77,7 @@ var mainContext = this;
         if (deps[i] === 'exports') {
           reified[i] = exports;
         } else if (deps[i] === 'require') {
-          reified[i] = require;
+          reified[i] = requireModule;
         } else {
           reified[i] = internalRequire(deps[i], name);
         }
@@ -92,11 +92,11 @@ var mainContext = this;
 
     Ember.__loader = {
       define: enifed,
-      require: require,
+      require: requireModule,
       registry: registry
     };
   } else {
     enifed = Ember.__loader.define;
-    require = requireModule = Ember.__loader.require;
+    requireModule = Ember.__loader.require;
   }
 })();

--- a/tests/node/template-compiler-test.js
+++ b/tests/node/template-compiler-test.js
@@ -40,3 +40,9 @@ test('can access _Ember.FEATURES (private API used by ember-cli-htmlbars)', func
 test('can access _Ember.VERSION (private API used by ember-cli-htmlbars)', function(assert) {
   assert.equal(typeof templateCompiler._Ember.VERSION, 'string', '_Ember.VERSION is present');
 });
+
+test('can generate a template with a server side generated `id`', function(assert) {
+  var TemplateJSON = JSON.parse(templateCompiler.precompile('<div>simple text</div>'));
+
+  assert.ok(TemplateJSON.id, 'an `id` was generated');
+});


### PR DESCRIPTION
The ember-template-compiler will use the native `crypto` library to generate a template `id` on the server (instead of a client generated `id` at runtime). If `require` is present and a function, it will attempt to `require('crypto')` to generate a SHA1 for the template's `id`.

Unfortunately, when `ember-template-compiler.js` is built it is wrapped inside an IIFE with this `var require` in the outermost scope, which prevents the template compiler from being able to build a template `id` while compiling the template.

This change removes the unused `require` variable from the outermost scope, and allows the server side template `id` generation to function as designed.

---

I also tested this in an ember-cli context to confirm things work end to end:

```js
define("dummy/templates/application", ["exports"], function (exports) {
  exports["default"] = Ember.HTMLBars.template({ "id": "GGv2QrBb", "block": "{\"statements\":[],\"locals\":[],\"named\":[],\"yields\":[],\"blocks\":[],\"hasPartials\":false}", "meta": { "moduleName": "dummy/templates/application.hbs" } });
});
```