### PR TITLE
[FEATURE beta] Assert key in `Ember.get` is not empty

### DIFF
--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -52,6 +52,7 @@ export function get(obj, keyName) {
   assert(`Cannot call get with '${keyName}' on an undefined object.`, obj !== undefined && obj !== null);
   assert(`The key provided to get must be a string, you passed ${keyName}`, typeof keyName === 'string');
   assert(`'this' in paths is not supported`, !hasThis(keyName));
+  assert('Cannot call `Ember.get` with an empty string', keyName !== '');
 
   let value = obj[keyName];
   let desc = (value !== null && typeof value === 'object' && value.isDescriptor) ? value : undefined;

--- a/packages/ember-metal/tests/accessors/get_test.js
+++ b/packages/ember-metal/tests/accessors/get_test.js
@@ -39,14 +39,6 @@ QUnit.test('should not access a property more than once', function() {
   equal(count, 1);
 });
 
-QUnit.test('should be able to use an empty string as a property', function(assert) {
-  let obj = { '': 'empty string' };
-
-  let result = get(obj, '');
-
-  assert.equal(result, obj['']);
-});
-
 testBoth('should call unknownProperty on watched values if the value is undefined', function(get, set) {
   let obj = {
     count: 0,
@@ -114,6 +106,7 @@ QUnit.test('warn on attempts to use get with an unsupported property path', func
   expectAssertion(() => get(obj, undefined), /The key provided to get must be a string, you passed undefined/);
   expectAssertion(() => get(obj, false),     /The key provided to get must be a string, you passed false/);
   expectAssertion(() => get(obj, 42),        /The key provided to get must be a string, you passed 42/);
+  expectAssertion(() => get(obj, ''), /Cannot call `Ember.get` with an empty string/);
 });
 
 // ..........................................................


### PR DESCRIPTION
This adds an assertion to let the user know when they are using an empty
string as key for `Ember.get`.

Addresses [this comment](https://github.com/emberjs/ember.js/issues/14572#issuecomment-258202256) in #14572