### PR TITLE
[FEATURE beta] Assert expand properties are balanced and not nested

### DIFF
--- a/packages/ember-metal/lib/expand_properties.js
+++ b/packages/ember-metal/lib/expand_properties.js
@@ -41,6 +41,27 @@ export default function expandProperties(pattern, callback) {
     'Brace expanded properties cannot contain spaces, e.g. "user.{firstName, lastName}" should be "user.{firstName,lastName}"',
     pattern.indexOf(' ') === -1
   );
+  assert(
+    `Brace expanded properties have to be balanced and cannot be nested, pattern: ${pattern}`,
+    ((str) => {
+      let inBrace = 0;
+      let char;
+      for (let i = 0; i < str.length; i++) {
+        char = str.charAt(i);
+
+        if (char === '{') {
+          inBrace++;
+        } else if (char === '}') {
+          inBrace--;
+        }
+
+        if (inBrace > 1 || inBrace < 0) {
+          return false;
+        }
+      }
+
+      return true;
+    })(pattern));
 
   let parts = pattern.split(SPLIT_REGEX);
   let properties = [parts];

--- a/packages/ember-metal/tests/expand_properties_test.js
+++ b/packages/ember-metal/tests/expand_properties_test.js
@@ -75,6 +75,20 @@ QUnit.test('A property with only brace expansions expands correctly', function()
   deepEqual(expected.sort(), foundProperties.sort());
 });
 
+QUnit.test('Nested brace expansions are not allowed', function() {
+  let nestedBraceProperties = [
+    'a.{b.{c,d}}',
+    'a.{{b}.c}',
+    'a.{b,c}.{d.{e,f}.g',
+    'a.{b.{c}',
+    'a.{b,c}}'
+  ];
+
+  nestedBraceProperties.forEach((invalidProperties) => {
+    expectAssertion(() => expandProperties(invalidProperties, addProperty));
+  }, /Brace expanded properties have to be balanced and cannot be nested/);
+});
+
 QUnit.test('A pattern must be a string', function() {
   expect(1);
 


### PR DESCRIPTION
In #13693, it is asked to error for an unsupported feature. Though we
don't say that this is not supported, it would be nice if we could let
the user know that what he is trying to do will not work instead of
silently fail.

Fixes #13693