### PR TITLE
[BUGFIX beta] Ensure `{{render` always has a controller.

### DIFF
--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -197,7 +197,7 @@ export default class Environment extends GlimmerEnvironment {
 
       if (internalKey) {
         definition = this.getComponentDefinition([internalKey], symbolTable);
-      } else if (key.indexOf('-') >= 0) {
+      } else if (typeof key === 'string' && key.indexOf('-') >= 0) {
         definition = this.getComponentDefinition(path, symbolTable);
       }
 

--- a/packages/ember-glimmer/lib/syntax/render.js
+++ b/packages/ember-glimmer/lib/syntax/render.js
@@ -10,7 +10,7 @@ import {
 import { ConstReference, isConst } from 'glimmer-reference';
 import { assert } from 'ember-metal';
 import { RootReference } from '../utils/references';
-import { generateControllerFactory } from 'ember-routing';
+import { generateController, generateControllerFactory } from 'ember-routing';
 import { OutletLayoutCompiler } from './outlet';
 
 function makeComponentDefinition(vm) {
@@ -171,7 +171,7 @@ class AbstractRenderManager {
 class SingletonRenderManager extends AbstractRenderManager {
   create(environment, definition, args, dynamicScope) {
     let { name, env } = definition;
-    let controller = env.owner.lookup(`controller:${name}`);
+    let controller = env.owner.lookup(`controller:${name}`) || generateController(env.owner, name);
 
     if (dynamicScope.rootOutletState) {
       dynamicScope.outletState = dynamicScope.rootOutletState.getOrphan(name);

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -2985,4 +2985,53 @@ moduleFor('Components test: curly components', class extends RenderingTest {
 
     this.assertText('MyVar1: 1 1 MyVar2: 2 2');
   }
+
+  ['@test can use `{{this}}` to emit the component\'s toString value [GH#14581]'](assert) {
+    this.registerComponent('foo-bar', {
+      ComponentClass: Component.extend({
+        toString() {
+          return 'special sauce goes here!';
+        }
+      }),
+      template: '{{this}}'
+    });
+
+    this.render('{{foo-bar}}');
+
+    this.assertText('special sauce goes here!');
+  }
+
+  ['@test can use `{{this` to access paths on current context [GH#14581]'](assert) {
+    let instance;
+    this.registerComponent('foo-bar', {
+      ComponentClass: Component.extend({
+        init() {
+          this._super(...arguments);
+
+          instance = this;
+        },
+
+        foo: {
+          bar: {
+            baz: 'huzzah!'
+          }
+        }
+      }),
+      template: '{{this.foo.bar.baz}}'
+    });
+
+    this.render('{{foo-bar}}');
+
+    this.assertText('huzzah!');
+
+    this.assertStableRerender();
+
+    this.runTask(() => set(instance, 'foo.bar.baz', 'yippie!'));
+
+    this.assertText('yippie!');
+
+    this.runTask(() => set(instance, 'foo.bar.baz', 'huzzah!'));
+
+    this.assertText('huzzah!');
+  }
 });

--- a/packages/ember-glimmer/tests/integration/helpers/render-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/render-test.js
@@ -4,12 +4,39 @@ import { RenderingTest, moduleFor } from '../../utils/test-case';
 
 moduleFor('Helpers test: {{render}}', class extends RenderingTest {
   ['@test should render given template']() {
-    this.owner.register('controller:home', Controller.extend());
     this.registerTemplate('home', '<p>BYE</p>');
 
     this.render(`<h1>HI</h1>{{render 'home'}}`);
 
     this.assertText('HIBYE');
+  }
+
+  ['@test uses `controller:basic` as the basis for a generated controller when none exists for specified name']() {
+    this.owner.register('controller:basic', Controller.extend({
+      isBasicController: true
+    }));
+    this.registerTemplate('home', '{{isBasicController}}');
+
+    this.render(`{{render 'home'}}`);
+
+    this.assertText('true');
+  }
+
+  ['@test generates a controller if none exists']() {
+    this.registerTemplate('home', '<p>{{this}}</p>');
+
+    this.render(`<h1>HI</h1>{{render 'home'}}`);
+
+    this.assertText('HI(generated home controller)');
+  }
+
+  ['@test should use controller with the same name as template if present']() {
+    this.owner.register('controller:home', Controller.extend({ name: 'home' }));
+    this.registerTemplate('home', '{{name}}<p>BYE</p>');
+
+    this.render(`<h1>HI</h1>{{render 'home'}}`);
+
+    this.assertText('HIhomeBYE');
   }
 
   ['@test should render nested helpers']() {

--- a/packages/ember-routing/lib/index.js
+++ b/packages/ember-routing/lib/index.js
@@ -13,8 +13,10 @@ export { default as HashLocation } from './location/hash_location';
 export { default as HistoryLocation } from './location/history_location';
 export { default as AutoLocation } from './location/auto_location';
 
-export { default as generateController } from './system/generate_controller';
-export { generateControllerFactory } from './system/generate_controller';
+export {
+  default as generateController,
+  generateControllerFactory
+} from './system/generate_controller';
 export { default as controllerFor } from './system/controller_for';
 export { default as RouterDSL } from './system/dsl';
 export { default as Router } from './system/router';


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember.js/issues/14581.
Fixes https://github.com/emberjs/ember.js/issues/14573.