### PR TITLE
[DOC release] Remove context arg from `generateController`.

### DIFF
--- a/packages/ember-routing/lib/system/generate_controller.js
+++ b/packages/ember-routing/lib/system/generate_controller.js
@@ -16,7 +16,7 @@ import {
   @private
 */
 
-export function generateControllerFactory(owner, controllerName, context) {
+export function generateControllerFactory(owner, controllerName) {
   let Factory = owner._lookupFactory('controller:basic').extend({
     isGenerated: true,
     toString() {
@@ -32,20 +32,16 @@ export function generateControllerFactory(owner, controllerName, context) {
 }
 
 /**
-  Generates and instantiates a controller.
-
-  The type of the generated controller factory is derived
-  from the context. If the context is an array an array controller
-  is generated, if an object, an object controller otherwise, a basic
-  controller is generated.
+  Generates and instantiates a controller extending from `controller:basic`
+  if present, or `Ember.Controller` if not.
 
   @for Ember
   @method generateController
   @private
   @since 1.3.0
 */
-export default function generateController(owner, controllerName, context) {
-  generateControllerFactory(owner, controllerName, context);
+export default function generateController(owner, controllerName) {
+  generateControllerFactory(owner, controllerName);
 
   let fullName = `controller:${controllerName}`;
   let instance = owner.lookup(fullName);

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1300,7 +1300,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     let definedController = this.controllerFor(controllerName, true);
 
     if (!definedController) {
-      controller =  this.generateController(controllerName, context);
+      controller =  this.generateController(controllerName);
     } else {
       controller = definedController;
     }
@@ -1822,22 +1822,19 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     export default Ember.Route.extend({
       setupController(controller, post) {
         this._super(controller, post);
-        this.generateController('posts', post);
+        this.generateController('posts');
       }
     });
     ```
 
     @method generateController
     @param {String} name the name of the controller
-    @param {Object} model the model to infer the type of the controller (optional)
     @private
   */
-  generateController(name, model) {
+  generateController(name) {
     let owner = getOwner(this);
 
-    model = model || this.modelFor(name);
-
-    return generateController(owner, name, model);
+    return generateController(owner, name);
   },
 
   /**


### PR DESCRIPTION
In Ember 1.x the type of controller returned differed based on the type of input object (if it was an array you would get an `Ember.ArrayController` or an object you would get `Ember.ObjectController`), but as of Ember 2.0.0 the type of controller does not change based on the type of "context".