### PR TITLE
[BUGFIX beta] Adds a deprecation message when using targetObject

### DIFF
--- a/packages/ember-runtime/lib/mixins/target_action_support.js
+++ b/packages/ember-runtime/lib/mixins/target_action_support.js
@@ -7,9 +7,10 @@ import { context } from 'ember-environment';
 import {
   get,
   Mixin,
-  computed
+  computed,
+  descriptor
 } from 'ember-metal';
-import { assert } from 'ember-debug';
+import { assert, deprecate } from 'ember-debug';
 /**
 `Ember.TargetActionSupport` is a mixin that can be included in a class
 to add a `triggerAction` method with semantics similar to the Handlebars
@@ -24,6 +25,22 @@ doing more complex event handling in Components.
 */
 export default Mixin.create({
   target: null,
+  targetObject: descriptor({
+    configurable: true,
+    enumerable: false,
+    get() {
+      let message = `${this} Usage of \`targetObject\` is deprecated. Please use \`target\` instead.`;
+      let options = { id: 'ember-runtime.using-targetObject', until: '3.5.0' };
+      deprecate(message, false, options);
+      return this._targetObject;
+    },
+    set(value) {
+      let message = `${this} Usage of \`targetObject\` is deprecated. Please use \`target\` instead.`;
+      let options = { id: 'ember-runtime.using-targetObject', until: '3.5.0' };
+      deprecate(message, false, options);
+      this._targetObject = value;
+    }
+  }),
   action: null,
   actionContext: null,
 
@@ -121,16 +138,7 @@ export default Mixin.create({
 });
 
 function getTarget(instance) {
-  // TODO: Deprecate specifying `targetObject`
-  let target = get(instance, 'targetObject');
-
-  // if a `targetObject` CP was provided, use it
-  if (target) { return target; }
-
-  // if _targetObject use it
-  if (instance._targetObject) { return instance._targetObject; }
-
-  target = get(instance, 'target');
+  let target = get(instance, 'target');
   if (target) {
     if (typeof target === 'string') {
       let value = get(instance, target);
@@ -143,6 +151,12 @@ function getTarget(instance) {
       return target;
     }
   }
+
+  // if a `targetObject` CP was provided, use it
+  if (target) { return target; }
+
+  // if _targetObject use it
+  if (instance._targetObject) { return instance._targetObject; }
 
   return null;
 }

--- a/packages/ember-runtime/tests/mixins/target_action_support_test.js
+++ b/packages/ember-runtime/tests/mixins/target_action_support_test.js
@@ -89,6 +89,26 @@ QUnit.test('it should use an actionContext object specified as a property on the
   ok(true === obj.triggerAction(), 'a valid target and action were specified');
 });
 
+
+QUnit.test('it should raise a deprecation warning when targetObject is specified and used', function() {
+  expect(4);
+  let obj;
+  expectDeprecation(() => {
+    obj = EmberObject.extend(TargetActionSupport).create({
+      action: 'anEvent',
+      actionContext: {},
+      targetObject: EmberObject.create({
+        anEvent(ctx) {
+          ok(obj.actionContext === ctx, 'anEvent method was called with the expected context');
+        }
+      })
+    });
+  }, /Usage of `targetObject` is deprecated. Please use `target` instead./);
+  ok(true === obj.triggerAction(), 'a valid targetObject and action were specified');
+  expectDeprecation(() => obj.get('targetObject'),
+    /Usage of `targetObject` is deprecated. Please use `target` instead./);
+});
+
 QUnit.test('it should find an actionContext specified as a property path', function() {
   expect(2);
 


### PR DESCRIPTION
For https://github.com/emberjs/ember.js/issues/14168

@rwjblue is this enough or should we also assert when setting `targetObject`? If so, where might I add that check?