### PR TITLE
[BUGFIX beta] Avoid run.next in `app.visit` resolve handler.

### DIFF
--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -239,22 +239,31 @@ const ApplicationInstance = EngineInstance.extend({
   visit(url) {
     this.setupRouter();
 
+    let bootOptions = this.__container__.lookup('-environment:main');
+
     let router = get(this, 'router');
 
-    let handleResolve = () => {
-      // Resolve only after rendering is complete
-      return new RSVP.Promise((resolve) => {
-        // TODO: why is this necessary? Shouldn't 'actions' queue be enough?
-        // Also, aren't proimses supposed to be async anyway?
-        run.next(null, resolve, this);
-      });
+    let handleTransitionResolve = () => {
+      if (!bootOptions.options.shouldRender) {
+        // No rendering is needed, and routing has completed, simply return.
+        return this;
+      } else {
+        return new RSVP.Promise((resolve) => {
+          // Resolve once rendering is completed. `router.handleURL` returns the transition (as a thennable)
+          // which resolves once the transition is completed, but the transition completion only queues up
+          // a scheduled revalidation (into the `render` queue) in the Renderer.
+          //
+          // This uses `run.schedule('afterRender', ....)` to resolve after that rendering has completed.
+          run.schedule('afterRender', null, resolve, this);
+        });
+      }
     };
 
-    let handleReject = (error) => {
+    let handleTransitionReject = (error) => {
       if (error.error) {
         throw error.error;
       } else if (error.name === 'TransitionAborted' && router.router.activeTransition) {
-        return router.router.activeTransition.then(handleResolve, handleReject);
+        return router.router.activeTransition.then(handleTransitionResolve, handleTransitionReject);
       } else if (error.name === 'TransitionAborted') {
         throw new Error(error.message);
       } else {
@@ -268,7 +277,7 @@ const ApplicationInstance = EngineInstance.extend({
     location.setURL(url);
 
     // getURL returns the set url with the rootURL stripped off
-    return router.handleURL(location.getURL()).then(handleResolve, handleReject);
+    return router.handleURL(location.getURL()).then(handleTransitionResolve, handleTransitionReject);
   }
 });
 


### PR DESCRIPTION
The prior comment has been pointed to by a few different people in the FastBoot team meetings so I decided to dig into exactly what the TODO was talking about. Specifically, why do we need a `run.next` before resolving the visit promise?

The answer is basically that the `router.handleURL` transition promise being resolved does not actually guarantee that rendering is completed. Since the renderer schedules the actual revalidation and rendering into the `render` queue, we must wait for that to complete before resolving the promise.

This commit explains that in the inline comments, and changes the implementation to use `run.schedule('afterRender', ....)` instead of `run.next` (since resolving "after rendering is complete" is what we actually care about).