### PR TITLE
[BUGFIX beta] Fix block params named `component`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "git-repo-info": "^1.1.4",
     "git-repo-version": "^0.3.1",
     "github": "^0.2.3",
-    "glimmer-engine": "^0.17.7",
+    "glimmer-engine": "^0.17.9",
     "glob": "^5.0.13",
     "html-differ": "^1.3.4",
     "jquery": "^3.1.1",

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -184,7 +184,7 @@ export default class Environment extends GlimmerEnvironment {
 
     assert(`You attempted to overwrite the built-in helper "${key}" which is not allowed. Please rename the helper.`, !(this.builtInHelpers[key] && this.owner.hasRegistration(`helper:${key}`)));
 
-    if (isSimple && (isInline || isBlock)) {
+    if (isSimple && (isInline || isBlock) && appendType !== 'get') {
       // 2. built-in syntax
 
       let RefinedSyntax = findSyntaxBuilder(key);
@@ -197,7 +197,7 @@ export default class Environment extends GlimmerEnvironment {
 
       if (internalKey) {
         definition = this.getComponentDefinition([internalKey], symbolTable);
-      } else if (typeof key === 'string' && key.indexOf('-') >= 0) {
+      } else if (key.indexOf('-') >= 0) {
         definition = this.getComponentDefinition(path, symbolTable);
       }
 
@@ -210,7 +210,7 @@ export default class Environment extends GlimmerEnvironment {
       assert(`A component or helper named "${key}" could not be found`, !isBlock || this.hasHelper(path, symbolTable));
     }
 
-    if (!isSimple && appendType === 'unknown') {
+    if (isInline && !isSimple && appendType !== 'helper') {
       return statement.original.deopt();
     }
 

--- a/packages/ember-glimmer/tests/integration/refinements-test.js
+++ b/packages/ember-glimmer/tests/integration/refinements-test.js
@@ -1,0 +1,67 @@
+import { RenderingTest, moduleFor } from '../utils/test-case';
+import { strip } from '../utils/abstract-test-case';
+import { set } from 'ember-metal';
+
+moduleFor('syntax refinements', class extends RenderingTest {
+  ['@test block params should not be refined']() {
+    this.registerHelper('foo', () => 'bar helper');
+
+    this.render(strip`
+      {{#with var as |foo|}}
+        {{foo}}
+      {{/with}}
+
+      ---
+
+      {{#with var as |render|}}
+        {{render}}
+      {{/with}}
+
+      ---
+
+      {{#with var as |outlet|}}
+        {{outlet}}
+      {{/with}}
+
+      ---
+
+      {{#with var as |mount|}}
+        {{mount}}
+      {{/with}}
+
+      ---
+
+      {{#with var as |component|}}
+        {{component}}
+      {{/with}}
+
+      ---
+
+      {{#with var as |input|}}
+        {{input}}
+      {{/with}}
+
+      ---
+
+      {{#with var as |-with-dynamic-vars|}}
+        {{-with-dynamic-vars}}
+      {{/with}}
+
+      ---
+
+      {{#with var as |-in-element|}}
+        {{-in-element}}
+      {{/with}}`, { var: 'var' });
+
+    this.assertText('var---var---var---var---var---var---var---var');
+
+    this.runTask(() => set(this.context, 'var', 'RARRR!!!'));
+
+    this.assertText('RARRR!!!---RARRR!!!---RARRR!!!---RARRR!!!---RARRR!!!---RARRR!!!---RARRR!!!---RARRR!!!');
+
+    this.runTask(() => set(this.context, 'var', 'var'));
+
+    this.assertText('var---var---var---var---var---var---var---var');
+  }
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2700,8 +2700,8 @@ github@^0.2.3:
     mime "^1.2.11"
 
 glimmer-engine:
-  version "0.17.7"
-  resolved "https://registry.yarnpkg.com/glimmer-engine/-/glimmer-engine-0.17.7.tgz#d0657a23fc49fa0ec4ff73e68132ac6d38c70787"
+  version "0.17.9"
+  resolved "https://registry.yarnpkg.com/glimmer-engine/-/glimmer-engine-0.17.9.tgz#2775df73ce06c51d7f73a10c6ca64a254baf8432"
   dependencies:
     broccoli-concat "^2.1.0"
     broccoli-funnel "^1.0.1"


### PR DESCRIPTION
...and `input`, `outlet`, etc. Block params (local variables) should always win over helpers and built-in syntaxes.

Fixes #14413