### PR TITLE
[FEATURE ember-metal-meta-destructors]

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -58,3 +58,35 @@ for a detailed explanation.
 * `ember-testing-resume-test`
 
   Introduces the `resumeTest` testing helper to complement the `pauseTest` helper.
+
+* `ember-metal-meta-destructors`
+
+  Introduces a mechanism to add additional work to be done at object / meta destruction time.
+
+  Example:
+
+  ```js
+  // app/utils/run-later.js
+  export default function runLater(object, functionOrName, delay) {
+    let cancelId = run.later(object, functionOrName, delay);
+    Ember.meta(object).addDestructor(() => run.cancel(cancelId));
+  }
+  ```
+
+  ```js
+  // some component
+  export default Component.extend({
+    stuff() { },
+
+    actions: {
+      doStuff() {
+        runLater(this, this._stuff, 1000);
+      }
+    }
+  })
+  ```
+
+  When this component is destroyed, the scheduled task will be canceled. A number of popular addons do similar things
+  by monkey patching the objects `willDestroy` at runtime, but that is less than ideal (due to shape changes and whatnot).
+
+  This provides a mechanism to easily entangle cleanup tasks for objects from utility functions...

--- a/features.json
+++ b/features.json
@@ -9,6 +9,7 @@
     "ember-testing-check-waiters": true,
     "ember-metal-weakmap": null,
     "ember-glimmer-allow-backtracking-rerender": null,
-    "ember-testing-resume-test": null
+    "ember-testing-resume-test": null,
+    "ember-metal-meta-destructors": null
   }
 }

--- a/packages/ember-metal/tests/meta_test.js
+++ b/packages/ember-metal/tests/meta_test.js
@@ -1,6 +1,7 @@
 import {
   meta
 } from '../meta';
+import isEnabled from '../features';
 
 QUnit.module('Ember.meta');
 
@@ -75,3 +76,28 @@ QUnit.test('meta.listeners deduplication', function(assert) {
   assert.equal(matching.length, 3);
   assert.equal(matching[0], t);
 });
+
+if (isEnabled('ember-metal-meta-destructors')) {
+  QUnit.test('destructors added are invoked during destroy', function(assert) {
+    let m = meta({});
+
+    let calledDestructor;
+    m.addDestructor(() => {
+      calledDestructor = true;
+    });
+
+    m.destroy();
+
+    assert.ok(calledDestructor, 'expected destructor to be called');
+  });
+
+  QUnit.test('cannot add destructors after destroy', function(assert) {
+    let m = meta({});
+
+    m.destroy();
+
+    expectAssertion(() => {
+      m.addDestructor(() => {});
+    }, /Cannot call addDestructor after the object is destroyed/);
+  });
+}


### PR DESCRIPTION
Introduces a mechanism to add additional work to be done at object / meta destruction time.

Example:

```js
// app/utils/run-later.js
export default function runLater(object, functionOrName, delay) {
  let cancelId = run.later(object, functionOrName, delay);
  Ember.meta(object).addDestructor(() => run.cancel(cancelId));
}
```

```js
// some component
export default Component.extend({
  stuff() { },

  actions: {
    doStuff() {
      runLater(this, this._stuff, 1000);
    }
  }
})
```

When this component is destroyed, the scheduled task will be canceled. A number of popular addons do similar things by monkey patching the objects `willDestroy` at runtime, but that is less than ideal (due to shape changes and whatnot).

This provides a mechanism to easily entangle cleanup tasks for objects from utility functions...