### PR TITLE
[BUGFIX beta] Trim whitespace in Ember.String.w()

### DIFF
--- a/packages/ember-runtime/lib/system/string.js
+++ b/packages/ember-runtime/lib/system/string.js
@@ -113,7 +113,7 @@ function loc(str, formats) {
 }
 
 function w(str) {
-  return str.split(/\s+/);
+  return str.trim().split(/\s+/);
 }
 
 function decamelize(str) {

--- a/packages/ember-runtime/tests/system/string/w_test.js
+++ b/packages/ember-runtime/tests/system/string/w_test.js
@@ -29,3 +29,10 @@ QUnit.test('\'one two three\'.w() with tabs', function() {
     deepEqual('one\ttwo  three'.w(), ['one', 'two', 'three']);
   }
 });
+
+QUnit.test('\' one two three \'.w() with leading and trailing whitespace => [\'one\',\'two\', \'three\']', function() {
+  deepEqual(w(' one two three '), ['one', 'two', 'three']);
+  if (ENV.EXTEND_PROTOTYPES.String) {
+    deepEqual(' one two three '.w(), ['one', 'two', 'three']);
+  }
+});


### PR DESCRIPTION
Currently, `Ember.String.w()` has a bit of unexpected behavior when used in the context of the `needs` property of a `moduleFor` helper. For instance, one might write the following code:
```javascript
  moduleFor("controller:foo/bar", "foo bar Controller", {
    needs: Ember.String.w(`
             controller:application
             controller:foo
             controller:bar/index
           `)
  });
```
and expect the result of `Ember.String.w()` to be `["controller:application", "controller:foo", "controller:bar/index"]`.

Surprisingly, the result is `["", "controller:application", "controller:foo", "controller:bar/index", ""]`, which might be fine in and of itself, but blows the call stack of `moduleFor` :(

This PR suggests that `Ember.String.w()` trim whitespace before attempting to split on whitespace. It provides the end user a bit more flexibility with whitespacing of the argument string.

I realize that much of the specific pain I encountered could be solved with better whitespacing in the first place, but it does seem a bit odd that `Ember.String.w()` interprets leading and trailing whitespace as elements of the subsequent list to be respected.

NB: I tagged this as a BUGFIX, but by all rights it could be a feature request. There's nothing _broken_ per se about the behavior as is, but it does seem a bit surprising, especially when compared to other languages that support collection literals (e.g. ruby's percent strings). That said, I'm fairly novice to both the usage and architecture of ember, so if this isn't a behavior that would be desirable, feel free to disagree.
