### PR TITLE
ember-testing/setup_for_testing: Use Ember.Test.Adapter if QUnit is unavailable

### DIFF
--- a/packages/ember-testing/lib/setup_for_testing.js
+++ b/packages/ember-testing/lib/setup_for_testing.js
@@ -1,3 +1,5 @@
+/* global self */
+
 import { setTesting } from 'ember-metal';
 import { jQuery } from 'ember-views';
 import {
@@ -9,6 +11,7 @@ import {
   decrementPendingRequests,
   clearPendingRequests
 } from './test/pending_requests';
+import Adapter from './adapters/adapter';
 import QUnitAdapter from './adapters/qunit';
 
 /**
@@ -29,7 +32,7 @@ export default function setupForTesting() {
   let adapter = getAdapter();
   // if adapter is not manually set default to QUnit
   if (!adapter) {
-    setAdapter(new QUnitAdapter());
+    setAdapter((typeof self.QUnit === 'undefined') ? new Adapter() : new QUnitAdapter());
   }
 
   jQuery(document).off('ajaxSend', incrementPendingRequests);

--- a/packages/ember-testing/tests/adapters_test.js
+++ b/packages/ember-testing/tests/adapters_test.js
@@ -4,11 +4,12 @@ import Adapter from '../adapters/adapter';
 import QUnitAdapter from '../adapters/qunit';
 import { Application as EmberApplication } from 'ember-application';
 
-var App, originalAdapter;
+var App, originalAdapter, originalQUnit;
 
 QUnit.module('ember-testing Adapters', {
   setup() {
     originalAdapter = Test.adapter;
+    originalQUnit = window.QUnit;
   },
   teardown() {
     run(App, App.destroy);
@@ -16,6 +17,7 @@ QUnit.module('ember-testing Adapters', {
     App = null;
 
     Test.adapter = originalAdapter;
+    window.QUnit = originalQUnit;
   }
 });
 
@@ -38,7 +40,7 @@ QUnit.test('Setting a test adapter manually', function() {
   Test.adapter.asyncStart();
 });
 
-QUnit.test('QUnitAdapter is used by default', function() {
+QUnit.test('QUnitAdapter is used by default (if QUnit is available)', function() {
   expect(1);
 
   Test.adapter = null;
@@ -49,4 +51,20 @@ QUnit.test('QUnitAdapter is used by default', function() {
   });
 
   ok(Test.adapter instanceof QUnitAdapter);
+});
+
+QUnit.test('Adapter is used by default (if QUnit is not available)', function() {
+  expect(2);
+
+  delete window.QUnit;
+
+  Test.adapter = null;
+
+  run(function() {
+    App = EmberApplication.create();
+    App.setupForTesting();
+  });
+
+  ok(Test.adapter instanceof Adapter);
+  ok(!(Test.adapter instanceof QUnitAdapter));
 });


### PR DESCRIPTION
Resolves #14628 

/cc @rwjblue @trentmwillis 