### PR TITLE
es6 syntax to match other blueprint

### DIFF
--- a/blueprints/instance-initializer-test/qunit-files/tests/unit/instance-initializers/__name__-test.js
+++ b/blueprints/instance-initializer-test/qunit-files/tests/unit/instance-initializers/__name__-test.js
@@ -4,13 +4,13 @@ import { module, test } from 'qunit';
 import destroyApp from '../../helpers/destroy-app';
 
 module('<%= friendlyTestName %>', {
-  beforeEach: function() {
+  beforeEach() {
     Ember.run(() => {
       this.application = Ember.Application.create();
       this.appInstance = this.application.buildInstance();
     });
   },
-  afterEach: function() {
+  afterEach() {
     Ember.run(this.appInstance, 'destroy');
     destroyApp(this.application);
   }


### PR DESCRIPTION
to match the initializer blueprint [here](https://github.com/emberjs/ember.js/blob/37591ce8ea504170191d80094ab927e847ae8c3a/blueprints/initializer-test/qunit-files/tests/unit/initializers/__name__-test.js#L8)