### PR TITLE
sync initializer and instance-initializer blueprints

### DIFF
--- a/blueprints/initializer-test/mocha-files/tests/unit/initializers/__name__-test.js
+++ b/blueprints/initializer-test/mocha-files/tests/unit/initializers/__name__-test.js
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
 import Ember from 'ember';
-import <%= classifiedModuleName %>Initializer from '<%= dasherizedModulePrefix %>/initializers/<%= dasherizedModuleName %>';
+import { initialize } from '<%= dasherizedModulePrefix %>/initializers/<%= dasherizedModuleName %>';
+import destroyApp from '../../helpers/destroy-app';
 
 describe('<%= friendlyTestName %>', function() {
   let application;
@@ -13,9 +14,13 @@ describe('<%= friendlyTestName %>', function() {
     });
   });
 
+  afterEach(function() {
+    destroyApp(application);
+  });
+
   // Replace this with your real tests.
   it('works', function() {
-    <%= classifiedModuleName %>Initializer.initialize(application);
+    initialize(application);
 
     // you would normally confirm the results of the initializer here
     expect(true).to.be.ok;

--- a/blueprints/initializer-test/qunit-files/tests/unit/initializers/__name__-test.js
+++ b/blueprints/initializer-test/qunit-files/tests/unit/initializers/__name__-test.js
@@ -1,21 +1,23 @@
 import Ember from 'ember';
-import <%= classifiedModuleName %>Initializer from '<%= dasherizedModulePrefix %>/initializers/<%= dasherizedModuleName %>';
+import { initialize } from '<%= dasherizedModulePrefix %>/initializers/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
-
-let application;
+import destroyApp from '../../helpers/destroy-app';
 
 module('<%= friendlyTestName %>', {
   beforeEach() {
-    Ember.run(function() {
-      application = Ember.Application.create();
-      application.deferReadiness();
+    Ember.run(() => {
+      this.application = Ember.Application.create();
+      this.application.deferReadiness();
     });
+  },
+  afterEach() {
+    destroyApp(this.application);
   }
 });
 
 // Replace this with your real tests.
 test('it works', function(assert) {
-  <%= classifiedModuleName %>Initializer.initialize(application);
+  initialize(this.application);
 
   // you would normally confirm the results of the initializer here
   assert.ok(true);

--- a/node-tests/blueprints/initializer-test.js
+++ b/node-tests/blueprints/initializer-test.js
@@ -29,7 +29,7 @@ describe('Acceptance: ember generate and destroy initializer', function() {
                       "};");
 
         expect(_file('tests/unit/initializers/foo-test.js'))
-          .to.contain("import FooInitializer from 'my-app/initializers/foo';");
+          .to.contain("import { initialize } from 'my-app/initializers/foo';");
       }));
   });
 
@@ -49,7 +49,7 @@ describe('Acceptance: ember generate and destroy initializer', function() {
                       "};");
 
         expect(_file('tests/unit/initializers/foo/bar-test.js'))
-          .to.contain("import FooBarInitializer from 'my-app/initializers/foo/bar';");
+          .to.contain("import { initialize } from 'my-app/initializers/foo/bar';");
       }));
   });
 
@@ -271,10 +271,10 @@ describe('Acceptance: ember generate and destroy initializer', function() {
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/unit/initializers/foo-test.js'))
-          .to.contain("import FooInitializer from 'my-app/initializers/foo';")
+          .to.contain("import { initialize } from 'my-app/initializers/foo';")
           .to.contain("module('Unit | Initializer | foo'")
           .to.contain("application = Ember.Application.create();")
-          .to.contain("FooInitializer.initialize(application);");
+          .to.contain("initialize(this.application);");
       }));
   });
 
@@ -284,10 +284,10 @@ describe('Acceptance: ember generate and destroy initializer', function() {
     return emberNew({ target: 'addon' })
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/unit/initializers/foo-test.js'))
-          .to.contain("import FooInitializer from 'dummy/initializers/foo';")
+          .to.contain("import { initialize } from 'dummy/initializers/foo';")
           .to.contain("module('Unit | Initializer | foo'")
           .to.contain("application = Ember.Application.create();")
-          .to.contain("FooInitializer.initialize(application);");
+          .to.contain("initialize(this.application);");
       }));
   });
 
@@ -301,10 +301,10 @@ describe('Acceptance: ember generate and destroy initializer', function() {
       ]))
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/unit/initializers/foo-test.js'))
-          .to.contain("import FooInitializer from 'my-app/initializers/foo';")
+          .to.contain("import { initialize } from 'my-app/initializers/foo';")
           .to.contain("describe('Unit | Initializer | foo', function() {")
           .to.contain("application = Ember.Application.create();")
-          .to.contain("FooInitializer.initialize(application);");
+          .to.contain("initialize(application);");
       }));
   });
 });


### PR DESCRIPTION
This unifies the older style in initializer-test with the newer style in [instance-initializer-test](https://github.com/emberjs/ember.js/blob/39b2707900a31f9de541f080817f2102e2c9323c/blueprints/instance-initializer-test/qunit-files/tests/unit/instance-initializers/__name__-test.js). The only logic change is that it now calls `destroyApp` like the instance-initializer-test does. That bit should be determined if it is needed.