### PR TITLE
Avoid using `let` in `ember-cli-build.js`

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -223,7 +223,7 @@ function getVersion() {
 
 // non bundled vendor
 function jquery() {
-  let jquery = require.resolve('jquery');
+  var jquery = require.resolve('jquery');
   return new Funnel(path.dirname(jquery), {
     files: ['jquery.js'],
     destDir: 'jquery',


### PR DESCRIPTION
"SyntaxError: Could not require 'ember-cli-build.js': Block-scoped declarations (let, const, function, class) not yet supported outside strict mode"