### PR TITLE
[BUGFIX release] Only freeze params, hash when WeakMap available

### DIFF
--- a/packages/ember-glimmer/lib/utils/references.js
+++ b/packages/ember-glimmer/lib/utils/references.js
@@ -1,4 +1,8 @@
-import { symbol, EmptyObject } from 'ember-utils';
+import {
+  HAS_NATIVE_WEAKMAP,
+  symbol,
+  EmptyObject
+} from 'ember-utils';
 import {
   get,
   set,
@@ -289,8 +293,10 @@ export class SimpleHelperReference extends CachedReference {
       let namedValue = named.value();
 
       runInDebug(() => {
-        Object.freeze(positionalValue);
-        Object.freeze(namedValue);
+        if (HAS_NATIVE_WEAKMAP) {
+          Object.freeze(positionalValue);
+          Object.freeze(namedValue);
+        }
       });
 
       let result = helper(positionalValue, namedValue);
@@ -324,8 +330,10 @@ export class SimpleHelperReference extends CachedReference {
     let namedValue = named.value();
 
     runInDebug(() => {
-      Object.freeze(positionalValue);
-      Object.freeze(namedValue);
+      if (HAS_NATIVE_WEAKMAP) {
+        Object.freeze(positionalValue);
+        Object.freeze(namedValue);
+      }
     });
 
     return helper(positionalValue, namedValue);
@@ -354,8 +362,10 @@ export class ClassBasedHelperReference extends CachedReference {
     let namedValue = named.value();
 
     runInDebug(() => {
-      Object.freeze(positionalValue);
-      Object.freeze(namedValue);
+      if (HAS_NATIVE_WEAKMAP) {
+        Object.freeze(positionalValue);
+        Object.freeze(namedValue);
+      }
     });
 
     return instance.compute(positionalValue, namedValue);

--- a/packages/ember-glimmer/tests/integration/helpers/custom-helper-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/custom-helper-test.js
@@ -3,6 +3,7 @@ import { RenderingTest, moduleFor } from '../../utils/test-case';
 import { makeBoundHelper } from '../../utils/helpers';
 import { runDestroy } from 'internal-test-helpers';
 import { set } from 'ember-metal';
+import { HAS_NATIVE_WEAKMAP } from 'ember-utils';
 
 let assert = QUnit.assert;
 
@@ -172,6 +173,30 @@ moduleFor('Helpers test: custom helpers', class extends RenderingTest {
     this.assertText('2');
 
     assert.strictEqual(destroyCount, 0, 'destroy is not called on recomputation');
+  }
+
+  ['@test helper params can be returned']() {
+    this.registerHelper('hello-world', values => {
+      return values;
+    });
+
+    this.render('{{#each (hello-world model) as |item|}}({{item}}){{/each}}', {
+      model: ['bob']
+    });
+
+    this.assertText('(bob)');
+  }
+
+  ['@test helper hash can be returned']() {
+    this.registerHelper('hello-world', (_, hash) => {
+      return hash.model;
+    });
+
+    this.render(`{{get (hello-world model=model) 'name'}}`, {
+      model: { name: 'bob' }
+    });
+
+    this.assertText('bob');
   }
 
   ['@test simple helper is called for param changes']() {
@@ -602,7 +627,7 @@ let addingPropertyToFrozenObjectThrows = (() => {
   }
 })();
 
-if (!EmberDev.runningProdBuild && (
+if (!EmberDev.runningProdBuild && HAS_NATIVE_WEAKMAP && (
   pushingIntoFrozenArrayThrows ||
     assigningExistingFrozenPropertyThrows ||
     addingPropertyToFrozenObjectThrows

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -2,7 +2,12 @@
 // Remove "use strict"; from transpiled module until
 // https://bugs.webkit.org/show_bug.cgi?id=138038 is fixed
 
-import { EmptyObject, lookupDescriptor, symbol } from 'ember-utils';
+import {
+  HAS_NATIVE_WEAKMAP,
+  EmptyObject,
+  lookupDescriptor,
+  symbol
+} from 'ember-utils';
 import isEnabled from './features';
 import { protoMethods as listenerMethods } from './meta_listeners';
 import { runInDebug, assert } from './debug';
@@ -459,17 +464,6 @@ if (isEnabled('mandatory-setter')) {
     }
   };
 }
-
-const HAS_NATIVE_WEAKMAP = (function() {
-  // detect if `WeakMap` is even present
-  let hasWeakMap = typeof WeakMap === 'function';
-  if (!hasWeakMap) { return false; }
-
-  let instance = new WeakMap();
-  // use `Object`'s `.toString` directly to prevent us from detecting
-  // polyfills as native weakmaps
-  return Object.prototype.toString.call(instance) === '[object WeakMap]';
-})();
 
 let setMeta, peekMeta;
 

--- a/packages/ember-utils/lib/index.js
+++ b/packages/ember-utils/lib/index.js
@@ -30,3 +30,4 @@ export { default as makeArray } from './make-array';
 export { default as applyStr } from './apply-str';
 export { default as NAME_KEY } from './name';
 export { default as toString } from './to-string';
+export { HAS_NATIVE_WEAKMAP } from './weak-map-utils';

--- a/packages/ember-utils/lib/weak-map-utils.js
+++ b/packages/ember-utils/lib/weak-map-utils.js
@@ -1,0 +1,10 @@
+export const HAS_NATIVE_WEAKMAP = (function() {
+  // detect if `WeakMap` is even present
+  let hasWeakMap = typeof WeakMap === 'function';
+  if (!hasWeakMap) { return false; }
+
+  let instance = new WeakMap();
+  // use `Object`'s `.toString` directly to prevent us from detecting
+  // polyfills as native weakmaps
+  return Object.prototype.toString.call(instance) === '[object WeakMap]';
+})();


### PR DESCRIPTION
As of #14244 arguments to the helper methods are frozen in development mode. When those frozen values are then passed back to the rest of the rendering system they may have meta data tracked for them. In most modern browsers Ember uses a WeakMap to achieve this mapping, and the frozen object is not polluted with a property.

However in browsers which support `Object.freeze` but do *not* support `WeakMap`, we attempt to set a property on these frozen values resulting in the following error:

> Cannot define property '__ember_meta__': object is not extensible

Again, this is scoped to dev-mode and IE9, IE10, PhantomJS. However since PhantomJS is an extremely popular test runner and most apps run tests in dev mode, you may see this issue on continuous integration builds. It can be triggered by simple examples added as tests in this PR.

See also this issue: https://github.com/emberjs/ember.js/issues/14264

#### The real fix

The long-term fix is that Ember's object system should not use properties to track meta information. Ember already tracks meta via a WeakMap in browsers that support it, however we may be able to avoid adding a property lazily in many scenarios even without WeakMap. Completing the migration of Ember's object model to Glimmer2's reference/tag system would aid this effort, as would dropping support for browsers that do not support WeakMap.

This fix will take some significant time, and is part of a larger object model refactoring effort in Ember.

#### The quick fix

The quick fix centers on the fact that this frozen objects are really only a dev-mode dummy-check. We only need to freeze objects in browsers where we can reliably use those frozen objects through the whole rendering system. Currently Ember freezes argument object in dev mode as long as `Object.freeze` is supported- We should change it to only freeze if both `Object.freeze` and `WeakMap` are both present. IE9, IE10, PhantomJS would simply never freeze, however modern environments like Safari or Chrome would.

This fix should be achievable in a point release for 2.10. It is low-hanging fruit that significantly improves the backward compatibility of the 2.10 releases.

#### The workaround

Lastly, some apps may be eager to update to 2.10 and don't want to wait on a fix. As a work-around for this issue you can allocate a new object from a passed-in frozen object. For example:

```js
export default Ember.Helper.helper(params => params.slice())
```

This of course may have a performance impact in your application, so use this workaround wisely.