### PR TITLE
[BUGFIX beta] Make the ember-source build work.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 /* jshint node: true */
 'use strict';
 var stew = require('broccoli-stew');
+var path = require('path');
+var resolve = require('resolve');
 
 var paths = {};
 var absolutePaths = {};
@@ -32,6 +34,19 @@ module.exports = {
   paths: paths,
   absolutePaths: absolutePaths,
   treeForVendor: function() {
+
+    var jqueryPath;
+    try {
+      jqueryPath = path.dirname(resolve.sync('jquery/package.json', { basedir: this.project.root }));
+    } catch (error) {
+      jqueryPath = path.dirname(require.resolve('jquery/package.json'));
+    }
+
+    var jquery = stew.find(jqueryPath + '/dist', {
+      destDir: 'ember/jquery',
+      files: [ 'jquery.js' ]
+    });
+
     var ember = stew.find(__dirname + '/dist', {
       destDir: 'ember',
       files: [
@@ -40,8 +55,7 @@ module.exports = {
         'ember-testing.js',
         'ember.debug.js',
         'ember.min.js',
-        'ember.prod.js',
-        'jquery/jquery.js'
+        'ember.prod.js'
       ]
     });
 
@@ -52,7 +66,8 @@ module.exports = {
 
     return stew.find([
       ember,
-      shims
+      shims,
+      jquery
     ]);
   }
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "broccoli-funnel": "^1.0.6",
     "broccoli-merge-trees": "^1.1.4",
     "broccoli-rollup": "^1.0.3",
-    "broccoli-stew": "^1.2.0",
     "chalk": "^1.1.1",
     "dag-map": "^2.0.1",
     "ember-cli": "^2.6.1",
@@ -48,7 +47,6 @@
     "glimmer-engine": "^0.19.2",
     "glob": "^5.0.13",
     "html-differ": "^1.3.4",
-    "jquery": "^3.1.1",
     "mocha": "^2.4.5",
     "qunit-extras": "^1.5.0",
     "qunit-phantomjs-runner": "^2.2.0",
@@ -67,7 +65,9 @@
     "ember-cli-string-utils": "^1.0.0",
     "ember-cli-test-info": "^1.0.0",
     "ember-cli-valid-component-name": "^1.0.0",
+    "jquery": "^3.1.1",
     "rsvp": "^3.3.3",
+    "resolve": "^1.1.7",
     "simple-dom": "^0.3.0"
   },
   "ember-addon": {


### PR DESCRIPTION
The build in 2.11.0-beta.1 is "broken" as `dist` doesn't include jQuery. It should do so dynamically so that it gets SemVer drift instead of being hard-set bundled per build.

It should also prefer a user-installed version of `jquery` to the version bundled with `ember-source`.

This PR:
- [X] Fixes the jQuery version lockdown bug.
- [X] Default uses the specified jQuery from the project directory.
- [X] Falls back to the version bundled with `ember-source` if not user-specified.

---
I think we broke this here: https://github.com/emberjs/ember.js/pull/14556/files