### PR TITLE
package.json: Remove local "bower" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "babel-plugin-feature-flags": "^0.2.3",
     "babel-plugin-filter-imports": "~0.2.0",
     "backburner.js": "^0.3.1",
-    "bower": "~1.7.7",
     "broccoli-funnel": "^1.0.6",
     "broccoli-merge-trees": "^1.1.4",
     "broccoli-rollup": "^1.0.3",


### PR DESCRIPTION
We install `bower` globally anyway and `bower` is not used programmatically anywhere. This change is also in line with the default Ember CLI addon blueprint.