### PR TITLE
[BUGFIX beta] Improve error when using `input` and `textarea` with contextual components

### DIFF
--- a/packages/ember-glimmer/lib/helpers/component.js
+++ b/packages/ember-glimmer/lib/helpers/component.js
@@ -173,6 +173,8 @@ export class ClosureComponentReference extends CachedReference {
     this.lastName = nameOrDef;
 
     if (typeof nameOrDef === 'string') {
+      assert('You cannot use the input helper as a contextual helper. Please extend Ember.TextField or Ember.Checkbox to use it as a contextual component.', nameOrDef !== 'input');
+      assert('You cannot use the textarea helper as a contextual helper. Please extend Ember.TextArea to use it as a contextual component.', nameOrDef !== 'textarea');
       definition = env.getComponentDefinition([nameOrDef], symbolTable);
       assert(`The component helper cannot be used without a valid component name. You used "${nameOrDef}" via (component "${nameOrDef}")`, definition);
     } else if (isComponentDefinition(nameOrDef)) {

--- a/packages/ember-glimmer/tests/integration/components/contextual-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/contextual-components-test.js
@@ -1079,6 +1079,18 @@ moduleFor('Components test: contextual components', class extends RenderingTest 
 
     this.assertText('ab');
   }
+
+  ['@test GH#14632 give useful warning when calling contextual components with input as a name']() {
+    expectAssertion(() => {
+      this.render('{{component (component "input" type="text")}}');
+    }, 'You cannot use the input helper as a contextual helper. Please extend Ember.TextField or Ember.Checkbox to use it as a contextual component.');
+  }
+
+  ['@test GH#14632 give useful warning when calling contextual components with textarea as a name']() {
+    expectAssertion(() => {
+      this.render('{{component (component "textarea" type="text")}}');
+    }, 'You cannot use the textarea helper as a contextual helper. Please extend Ember.TextArea to use it as a contextual component.');
+  }
 });
 
 class ContextualComponentMutableParamsTest extends RenderingTest {


### PR DESCRIPTION
`{{input}}` and `{{textarea}}` are not components though they behave
like one. Thus, they cannot be used as the name for a contextual
component.

This PR improves the error message in this case.

Fixes #14632