### PR TITLE
[BUGFIX release] this.$() undefined in willDestroyElement hook 

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/will-destroy-element-hook-test.js
+++ b/packages/ember-glimmer/tests/integration/components/will-destroy-element-hook-test.js
@@ -1,6 +1,8 @@
 import { set } from 'ember-metal';
 import { Component } from '../../utils/helpers';
 import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { tryInvoke } from 'ember-utils';
+import { runAppend } from 'internal-test-helpers';
 
 moduleFor('Component willDestroyElement hook', class extends RenderingTest {
   ['@test it calls willDestroyElement when removed by if'](assert) {
@@ -30,5 +32,26 @@ moduleFor('Component willDestroyElement hook', class extends RenderingTest {
     assert.equal(willDestroyElementCount, 1, 'willDestroyElement was called once');
 
     this.assertText('');
+  }
+  ['@test still has access to this.$()'](assert) {
+    assert.expect(2);
+    let component;
+    let FooBarComponent = Component.extend({
+      tagName: 'div',
+      didInsertElement() {
+        component = this;
+      },
+      willDestroyElement() {
+        assert.ok(this.$(), 'willDestroyElement has access to element via this.$()');
+      },
+      didDestroyElement() {
+        assert.notOk(this.$(), 'didDestroyElement does not have access to element via this.$()');
+      }
+    });
+    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: 'hello' });
+    let { owner } = this;
+    let comp = owner.lookup('component:foo-bar');
+    runAppend(comp);
+    this.runTask(() => tryInvoke(component, 'destroy'));
   }
 });

--- a/packages/ember-views/lib/views/states/destroying.js
+++ b/packages/ember-views/lib/views/states/destroying.js
@@ -1,6 +1,7 @@
 import { assign } from 'ember-utils';
 import { Error as EmberError } from 'ember-metal';
 import _default from './default';
+import jQuery from '../../system/jquery';
 /**
 @module ember
 @submodule ember-views
@@ -9,6 +10,12 @@ import _default from './default';
 const destroying = Object.create(_default);
 
 assign(destroying, {
+  $(view, sel) {
+    let elem = view.element;
+    if (elem) {
+      return sel ? jQuery(sel, elem) : jQuery(elem);
+    }
+  },
   appendChild() {
     throw new EmberError('You can\'t call appendChild on a view being destroyed');
   },


### PR DESCRIPTION
Trying to access `this.$()` in `willDestroyElement` now returns `undefined` as `willDestroyElement` hook is run after the component enters the `destroying` state since 3dcde0f was merged (2.9.0-beta.1). In versions before that `willDestroyElement` was called before transitioning to `destroying` state so the component was using `inDom` state object that would process `this.$()` properly.

Technically the element is still accessible but we have to use `$(this.element)` instead of `this.$()` which makes upgrading cumbersome as it is breaking apps that utilise `willDestroyElement` to deregister eventHandlers previously registered on component element. 