### PR TITLE
[BUGFIX lts] Prefix internal symbols with underscores

### DIFF
--- a/packages/ember-utils/lib/symbol.js
+++ b/packages/ember-utils/lib/symbol.js
@@ -5,6 +5,6 @@ export default function symbol(debugName) {
   // TODO: Investigate using platform symbols, but we do not
   // want to require non-enumerability for this API, which
   // would introduce a large cost.
-
-  return intern(debugName + ' [id=' + GUID_KEY + Math.floor(Math.random() * new Date()) + ']');
+  let id = GUID_KEY + Math.floor(Math.random() * new Date());
+  return intern(`__${debugName}__ [id=${id}]`);
 }


### PR DESCRIPTION
This provides a strong hint for tools like Ember inspector to ignore them in the debug output.

Fixes emberjs/ember-inspector#618