### PR TITLE
[DOC release] Add @since tags to Ember.deprecate(), .warn() and .assert()

### DIFF
--- a/packages/ember-debug/lib/deprecate.js
+++ b/packages/ember-debug/lib/deprecate.js
@@ -115,6 +115,7 @@ export let missingOptionsUntilDeprecation = 'When calling `Ember.deprecate` you 
     emberjs.com website.
   @for Ember
   @public
+  @since 1.0.0
 */
 export default function deprecate(message, test, options) {
   if (!options || (!options.id && !options.until)) {

--- a/packages/ember-debug/lib/index.js
+++ b/packages/ember-debug/lib/index.js
@@ -50,6 +50,7 @@ import _warn, {
   @param {Boolean} test Must be truthy for the assertion to pass. If
     falsy, an exception will be thrown.
   @public
+  @since 1.0.0
 */
 setDebugFunction('assert', function assert(desc, test) {
   if (!test) {

--- a/packages/ember-debug/lib/warn.js
+++ b/packages/ember-debug/lib/warn.js
@@ -39,6 +39,7 @@ export let missingOptionsIdDeprecation = 'When calling `Ember.warn` you must pro
     The `id` should be namespaced by dots, e.g. "ember-debug.feature-flag-with-features-stripped"
   @for Ember
   @public
+  @since 1.0.0
 */
 export default function warn(message, test, options) {
   if (!options) {


### PR DESCRIPTION
Resolves another small amount of #14692

/cc @locks 