### PR TITLE
[BUG beta] blueprints/acceptance-test/mocha: Return last async helper from test function

### DIFF
--- a/blueprints/acceptance-test/mocha-files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/mocha-files/tests/acceptance/__name__-test.js
@@ -17,7 +17,7 @@ describe('<%= friendlyTestName %>', function() {
   it('can visit /<%= dasherizedModuleName %>', function() {
     visit('/<%= dasherizedModuleName %>');
 
-    andThen(function() {
+    return andThen(() => {
       expect(currentURL()).to.equal('/<%= dasherizedModuleName %>');
     });
   });

--- a/node-tests/blueprints/acceptance-test-test.js
+++ b/node-tests/blueprints/acceptance-test-test.js
@@ -78,7 +78,7 @@ describe('Acceptance: ember generate and destroy acceptance-test', function() {
           .to.contain("describe('Acceptance | foo', function() {")
           .to.contain("it('can visit /foo', function() {")
           .to.contain("visit('/foo');")
-          .to.contain("andThen(function() {")
+          .to.contain("return andThen(() => {")
           .to.contain("expect(currentURL()).to.equal('/foo');");
       }));
   });


### PR DESCRIPTION
This is recommended by `ember-mocha`, now that https://github.com/emberjs/ember-mocha/pull/121 is merged. Compared to the originally proposed solution using a wrapper function, this solution is backwards-compatible and will also work with older `ember-mocha` releases.

/cc @rwjblue 