### PR TITLE
Improved backtracking re-render assertion message

### DIFF
--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -25,6 +25,7 @@ import {
   SimpleHelperReference,
   ClassBasedHelperReference
 } from './utils/references';
+import DebugStack from './utils/debug-stack';
 
 import {
   inlineIf,
@@ -133,6 +134,8 @@ export default class Environment extends GlimmerEnvironment {
       '-html-safe': htmlSafeHelper,
       '-get-dynamic-var': getDynamicVar
     };
+
+    runInDebug(() => this.debugStack = new DebugStack());
   }
 
   // Hello future traveler, welcome to the world of syntax refinement.

--- a/packages/ember-glimmer/lib/syntax/mount.js
+++ b/packages/ember-glimmer/lib/syntax/mount.js
@@ -8,7 +8,7 @@ import {
   ComponentDefinition
 } from 'glimmer-runtime';
 import { UNDEFINED_REFERENCE } from 'glimmer-reference';
-import { assert } from 'ember-metal';
+import { assert, runInDebug } from 'ember-metal';
 import { RootReference } from '../utils/references';
 import { generateControllerFactory } from 'ember-routing';
 import { OutletLayoutCompiler } from './outlet';
@@ -74,6 +74,8 @@ class MountManager {
   }
 
   create(environment, { name, env }, args, dynamicScope) {
+    runInDebug(() => this._pushToDebugStack(`engine:${name}`, env));
+
     dynamicScope.outletState = UNDEFINED_REFERENCE;
 
     let engine = env.owner.buildChildEngineInstance(name);
@@ -103,12 +105,23 @@ class MountManager {
   }
 
   didCreateElement() {}
-  didRenderLayout() {}
+
+  didRenderLayout() {
+    runInDebug(() => this.debugStack.pop());
+  }
+
   didCreate(state) {}
   update(state, args, dynamicScope) {}
   didUpdateLayout() {}
   didUpdate(state) {}
 }
+
+runInDebug(() => {
+  MountManager.prototype._pushToDebugStack = function(name, environment) {
+    this.debugStack = environment.debugStack;
+    this.debugStack.pushEngine(name);
+  };
+});
 
 const MOUNT_MANAGER = new MountManager();
 

--- a/packages/ember-glimmer/lib/utils/debug-stack.js
+++ b/packages/ember-glimmer/lib/utils/debug-stack.js
@@ -1,0 +1,66 @@
+import { runInDebug } from 'ember-metal';
+
+let DebugStack;
+
+runInDebug(function() {
+  class Element {
+    constructor(name) {
+      this.name = name;
+    }
+  }
+
+  class TemplateElement extends Element { }
+  class EngineElement extends Element { }
+
+  DebugStack = class DebugStack {
+    constructor() {
+      this._stack = [];
+    }
+
+    push(name) {
+      this._stack.push(new TemplateElement(name));
+    }
+
+    pushEngine(name) {
+      this._stack.push(new EngineElement(name));
+    }
+
+    pop() {
+      let element = this._stack.pop();
+
+      if (element) {
+        return element.name;
+      }
+    }
+
+    peek() {
+      let template = this._currentTemplate();
+      let engine = this._currentEngine();
+
+      if (engine) {
+        return `"${template}" (in "${engine}")`;
+      } else if (template) {
+        return `"${template}"`;
+      }
+    }
+
+    _currentTemplate() {
+      return this._getCurrentByType(TemplateElement);
+    }
+
+    _currentEngine() {
+      return this._getCurrentByType(EngineElement);
+    }
+
+    _getCurrentByType(type) {
+      for (let i = this._stack.length; i >= 0; i--) {
+        let element = this._stack[i];
+        if (element instanceof type) {
+          return element.name;
+        }
+      }
+    }
+  };
+});
+
+export default DebugStack;

--- a/packages/ember-glimmer/tests/integration/application/rendering-test.js
+++ b/packages/ember-glimmer/tests/integration/application/rendering-test.js
@@ -2,6 +2,8 @@ import { Controller } from 'ember-runtime';
 import { moduleFor, ApplicationTest } from '../../utils/test-case';
 import { strip } from '../../utils/abstract-test-case';
 import { Route } from 'ember-routing';
+import { isFeatureEnabled } from 'ember-metal';
+import { Component } from 'ember-glimmer';
 
 moduleFor('Application test: rendering', class extends ApplicationTest {
 
@@ -371,5 +373,42 @@ moduleFor('Application test: rendering', class extends ApplicationTest {
         content: `Hello from A!`
       });
     });
+  }
+
+  ['@test it emits a useful backtracking re-render assertion message'](assert) {
+    this.router.map(function() {
+      this.route('routeWithError');
+    });
+
+    this.registerRoute('routeWithError', Route.extend({
+      model() {
+        return { name: 'Alex' };
+      }
+    }));
+
+    this.registerTemplate('routeWithError', 'Hi {{model.name}} {{x-foo person=model}}');
+
+    this.registerComponent('x-foo', {
+      ComponentClass: Component.extend({
+        init() {
+          this._super(...arguments);
+          this.set('person.name', 'Ben');
+        }
+      }),
+      template: 'Hi {{person.name}} from component'
+    });
+
+    let expectedBacktrackingMessage = /modified "model\.name" twice on \[object Object\] in a single render\. It was rendered in "template:routeWithError" and modified in "component:x-foo"/;
+
+    if (isFeatureEnabled('ember-glimmer-allow-backtracking-rerender')) {
+      expectDeprecation(expectedBacktrackingMessage);
+      return this.visit('/routeWithError');
+    } else {
+      return this.visit('/').then(() => {
+        expectAssertion(() => {
+          this.visit('/routeWithError');
+        }, expectedBacktrackingMessage);
+      });
+    }
   }
 });

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -2089,10 +2089,6 @@ moduleFor('Components test: curly components', class extends RenderingTest {
   }
 
   ['@test when a property is changed during children\'s rendering'](assert) {
-    if (isFeatureEnabled('ember-glimmer-allow-backtracking-rerender')) {
-      expectDeprecation(/modified value twice on <\(.+> in a single render/);
-    }
-
     let outer, middle;
 
     this.registerComponent('x-outer', {
@@ -2137,14 +2133,17 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     assert.equal(this.$('#inner-value').text(), '1', 'initial render of inner');
     assert.equal(this.$('#middle-value').text(), '', 'initial render of middle (observers do not run during init)');
 
-    if (!isFeatureEnabled('ember-glimmer-allow-backtracking-rerender')) {
+    let expectedBacktrackingMessage = /modified "value" twice on <\(.+> in a single render\. It was rendered in "component:x-middle" and modified in "component:x-inner"/;
+
+    if (isFeatureEnabled('ember-glimmer-allow-backtracking-rerender')) {
+      expectDeprecation(expectedBacktrackingMessage);
+      this.runTask(() => outer.set('value', 2));
+    } else {
       expectAssertion(() => {
         this.runTask(() => outer.set('value', 2));
-      }, /modified value twice on <\(.+> in a single render/);
+      }, expectedBacktrackingMessage);
 
       return;
-    } else {
-      this.runTask(() => outer.set('value', 2));
     }
 
     assert.equal(this.$('#inner-value').text(), '2', 'second render of inner');
@@ -2162,10 +2161,6 @@ moduleFor('Components test: curly components', class extends RenderingTest {
   }
 
   ['@test when a shared dependency is changed during children\'s rendering'](assert) {
-    if (isFeatureEnabled('ember-glimmer-allow-backtracking-rerender')) {
-      expectDeprecation(/modified wrapper.content twice on <Ember.Object.+> in a single render/);
-    }
-
     let outer;
 
     this.registerComponent('x-outer', {
@@ -2190,14 +2185,17 @@ moduleFor('Components test: curly components', class extends RenderingTest {
       template: '<div id="inner-value">{{wrapper.content}}</div>'
     });
 
-    if (!isFeatureEnabled('ember-glimmer-allow-backtracking-rerender')) {
+    let expectedBacktrackingMessage = /modified "wrapper\.content" twice on <Ember\.Object.+> in a single render\. It was rendered in "component:x-outer" and modified in "component:x-inner"/;
+
+    if (isFeatureEnabled('ember-glimmer-allow-backtracking-rerender')) {
+      expectDeprecation(expectedBacktrackingMessage);
+      this.render('{{x-outer}}');
+    } else {
       expectAssertion(() => {
         this.render('{{x-outer}}');
-      }, /modified wrapper.content twice on <Ember.Object.+> in a single render/);
+      }, expectedBacktrackingMessage);
 
       return;
-    } else {
-      this.render('{{x-outer}}');
     }
 
     assert.equal(this.$('#inner-value').text(), '1', 'initial render of inner');

--- a/packages/ember-glimmer/tests/integration/components/dynamic-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/dynamic-components-test.js
@@ -2,6 +2,7 @@ import { set, computed } from 'ember-metal';
 import { Component } from '../../utils/helpers';
 import { strip } from '../../utils/abstract-test-case';
 import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { isFeatureEnabled } from 'ember-metal';
 
 moduleFor('Components test: dynamic components', class extends RenderingTest {
 
@@ -705,5 +706,38 @@ moduleFor('Components test: dynamic components', class extends RenderingTest {
     });
 
     this.assertText('Foo4');
+  }
+
+  ['@test component helper emits useful backtracking re-render assertion message'](assert) {
+    this.registerComponent('outer-component', {
+      ComponentClass: Component.extend({
+        init() {
+          this._super(...arguments);
+          this.set('person', { name: 'Alex' });
+        }
+      }),
+      template: `Hi {{person.name}}! {{component "error-component" person=person}}`
+    });
+
+    this.registerComponent('error-component', {
+      ComponentClass: Component.extend({
+        init() {
+          this._super(...arguments);
+          this.set('person.name', { name: 'Ben' });
+        }
+      }),
+      template: '{{person.name}}'
+    });
+
+    let expectedBacktrackingMessage = /modified "person\.name" twice on \[object Object\] in a single render\. It was rendered in "component:outer-component" and modified in "component:error-component"/;
+
+    if (isFeatureEnabled('ember-glimmer-allow-backtracking-rerender')) {
+      expectDeprecation(expectedBacktrackingMessage);
+      this.render('{{component componentName}}', { componentName: 'outer-component' });
+    } else {
+      expectAssertion(() => {
+        this.render('{{component componentName}}', { componentName: 'outer-component' });
+      }, expectedBacktrackingMessage);
+    }
   }
 });

--- a/packages/ember-glimmer/tests/integration/helpers/render-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/render-test.js
@@ -1,4 +1,4 @@
-import { observer, set } from 'ember-metal';
+import { observer, set, computed, isFeatureEnabled } from 'ember-metal';
 import { Controller } from 'ember-runtime';
 import { RenderingTest, moduleFor } from '../../utils/test-case';
 
@@ -431,5 +431,33 @@ moduleFor('Helpers test: {{render}}', class extends RenderingTest {
     }, /Please refactor [\w\{\}"` ]+ to a component/);
 
     postController.send('someAction');
+  }
+
+  ['@test render helper emits useful backtracking re-render assertion message'](assert) {
+    this.owner.register('controller:outer', Controller.extend());
+    this.owner.register('controller:inner', Controller.extend({
+      propertyWithError: computed(function() {
+        this.set('model.name', 'this will cause a backtracking error');
+        return 'foo';
+      })
+    }));
+
+    let expectedBacktrackingMessage = /modified "model\.name" twice on \[object Object\] in a single render\. It was rendered in "controller:outer \(with the render helper\)" and modified in "controller:inner \(with the render helper\)"/;
+
+    expectDeprecation(() => {
+      let person = { name: 'Ben' };
+
+      this.registerTemplate('outer', `Hi {{model.name}} | {{render 'inner' model}}`);
+      this.registerTemplate('inner', `Hi {{propertyWithError}}`);
+
+      if (isFeatureEnabled('ember-glimmer-allow-backtracking-rerender')) {
+        expectDeprecation(expectedBacktrackingMessage);
+        this.render(`{{render 'outer' person}}`, { person });
+      } else {
+        expectAssertion(() => {
+          this.render(`{{render 'outer' person}}`, { person });
+        }, expectedBacktrackingMessage);
+      }
+    });
   }
 });

--- a/packages/ember-glimmer/tests/integration/mount-test.js
+++ b/packages/ember-glimmer/tests/integration/mount-test.js
@@ -4,9 +4,9 @@ import {
   ApplicationTest,
   RenderingTest
 } from '../utils/test-case';
-import { compile } from '../utils/helpers';
+import { compile, Component } from '../utils/helpers';
 import { Controller } from 'ember-runtime';
-import { set } from 'ember-metal';
+import { set, isFeatureEnabled } from 'ember-metal';
 import { Engine, getEngineParent } from 'ember-application';
 
 moduleFor('{{mount}} assertions', class extends RenderingTest {
@@ -80,5 +80,40 @@ moduleFor('{{mount}} test', class extends ApplicationTest {
 
       this.assertComponentElement(this.firstChild, { content: '<h2>Chat here, dgeb</h2>' });
     });
+  }
+
+  ['@test it emits a useful backtracking re-render assertion message'](assert) {
+    this.router.map(function() {
+      this.route('route-with-mount');
+    });
+
+    this.registerTemplate('index', '');
+    this.registerTemplate('route-with-mount', '{{mount "chat"}}');
+
+    this.engineRegistrations['template:application'] = compile('hi {{person.name}} [{{component-with-backtracking-set person=person}}]', { moduleName: 'application' });
+    this.engineRegistrations['controller:application'] = Controller.extend({
+      person: { name: 'Alex' }
+    });
+
+    this.engineRegistrations['template:components/component-with-backtracking-set'] = compile('[component {{person.name}}]', { moduleName: 'components/component-with-backtracking-set' });
+    this.engineRegistrations['component:component-with-backtracking-set'] = Component.extend({
+      init() {
+        this._super(...arguments);
+        this.set('person.name', 'Ben');
+      }
+    });
+
+    let expectedBacktrackingMessage = /modified "person\.name" twice on \[object Object\] in a single render\. It was rendered in "template:route-with-mount" \(in "engine:chat"\) and modified in "component:component-with-backtracking-set" \(in "engine:chat"\)/;
+
+    if (isFeatureEnabled('ember-glimmer-allow-backtracking-rerender')) {
+      expectDeprecation(expectedBacktrackingMessage);
+      return this.visit('/route-with-mount');
+    } else {
+      return this.visit('/').then(() => {
+        expectAssertion(() => {
+          this.visit('/route-with-mount');
+        }, expectedBacktrackingMessage);
+      });
+    }
   }
 });

--- a/packages/ember-glimmer/tests/unit/utils/debug-stack-test.js
+++ b/packages/ember-glimmer/tests/unit/utils/debug-stack-test.js
@@ -1,0 +1,32 @@
+import DebugStack from 'ember-glimmer/utils/debug-stack';
+import { runInDebug } from 'ember-metal';
+
+runInDebug(() => {
+  QUnit.module('Glimmer DebugStack');
+
+  QUnit.test('pushing and popping', function(assert) {
+    let stack = new DebugStack();
+
+    assert.equal(stack.peek(), undefined);
+
+    stack.push('template:application');
+
+    assert.equal(stack.peek(), '"template:application"');
+
+    stack.push('component:top-level-component');
+
+    assert.equal(stack.peek(), '"component:top-level-component"');
+
+    stack.pushEngine('engine:my-engine');
+    stack.push('component:component-in-engine');
+
+    assert.equal(stack.peek(), '"component:component-in-engine" (in "engine:my-engine")');
+
+    stack.pop();
+    stack.pop();
+    let item = stack.pop();
+
+    assert.equal(item, 'component:top-level-component');
+    assert.equal(stack.peek(), '"template:application"');
+  });
+});

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -14,6 +14,7 @@ import { runInDebug, assert } from './debug';
 import {
   removeChainWatcher
 } from './chains';
+import { has } from 'require';
 
 let counters = {
   peekCalls: 0,
@@ -72,7 +73,10 @@ const IS_PROXY = 1 << 4;
 if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
     isEnabled('ember-glimmer-allow-backtracking-rerender')) {
   members.lastRendered = ownMap;
-  members.lastRenderedFrom = ownMap; // FIXME: not used in production, remove me from prod builds
+  if (has('ember-debug')) { //https://github.com/emberjs/ember.js/issues/14732
+    members.lastRenderedReferenceMap = ownMap;
+    members.lastRenderedTemplateMap = ownMap;
+  }
 }
 
 let memberNames = Object.keys(members);
@@ -113,7 +117,10 @@ export function Meta(obj, parentMeta) {
   if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
       isEnabled('ember-glimmer-allow-backtracking-rerender')) {
     this._lastRendered = undefined;
-    this._lastRenderedFrom = undefined; // FIXME: not used in production, remove me from prod builds
+    runInDebug(() => {
+      this._lastRenderedReferenceMap = undefined;
+      this._lastRenderedTemplateMap = undefined;
+    });
   }
 
   this._initializeListeners();

--- a/packages/ember-metal/lib/transaction.js
+++ b/packages/ember-metal/lib/transaction.js
@@ -23,10 +23,14 @@ if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
   let counter = 0;
   let inTransaction = false;
   let shouldReflush;
+  let debugStack;
 
   runInTransaction = function(context, methodName) {
     shouldReflush = false;
     inTransaction = true;
+    runInDebug(() => {
+      debugStack = context.env.debugStack;
+    });
     context[methodName]();
     inTransaction = false;
     counter++;
@@ -40,8 +44,13 @@ if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
     lastRendered[key] = counter;
 
     runInDebug(() => {
-      let lastRenderedFrom = meta.writableLastRenderedFrom();
-      lastRenderedFrom[key] = reference;
+      let referenceMap = meta.writableLastRenderedReferenceMap();
+      referenceMap[key] = reference;
+
+      let templateMap = meta.writableLastRenderedTemplateMap();
+      if (templateMap[key] === undefined) {
+        templateMap[key] = debugStack.peek();
+      }
     });
   };
 
@@ -52,10 +61,13 @@ if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
     if (lastRendered && lastRendered[key] === counter) {
       raise(
         (function() {
-          let ref = meta.readableLastRenderedFrom();
-          let parts = [];
-          let lastRef = ref[key];
+          let templateMap = meta.readableLastRenderedTemplateMap();
+          let lastRenderedIn = templateMap[key];
+          let currentlyIn = debugStack.peek();
 
+          let referenceMap = meta.readableLastRenderedReferenceMap();
+          let lastRef = referenceMap[key];
+          let parts = [];
           let label;
 
           if (lastRef) {
@@ -64,12 +76,12 @@ if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
               lastRef = lastRef._parentReference;
             }
 
-            label = parts.join();
+            label = parts.join('.');
           } else {
             label = 'the same value';
           }
 
-          return `You modified ${label} twice on ${object} in a single render. This was unreliable and slow in Ember 1.x and ${implication}`;
+          return `You modified "${label}" twice on ${object} in a single render. It was rendered in ${lastRenderedIn} and modified in ${currentlyIn}. This was unreliable and slow in Ember 1.x and ${implication}`;
         }()),
         false);
 


### PR DESCRIPTION
Closes https://github.com/emberjs/ember.js/issues/14709

This improves the backtracking re-render assertion message.

**Before:**

You modified `message.message_goal.description` twice on `<(subclass of Ember.Model):ember3486>` in a single render. This was unreliable and slow in Ember 1.x and is no longer supported. See https://github.com/emberjs/ember.js/issues/13948 for more details.

**After:**

You modified `message.message_goal.description` twice on `<(subclass of Ember.Model):ember3486>` in a single render. It was rendered in `component:message-edit-expanding-container-component` and modified in `component:rules/predicate-date-value-component`. This was unreliable and slow in Ember 1.x and is no longer supported. See #13948 for more details.

**[Feedback](https://github.com/emberjs/ember.js/pull/14723#issuecomment-267797046) TODOs:**

* [x] Allow `runInDebug` to work [here](https://github.com/emberjs/ember.js/blob/bbc79f0f80b2ea6f7909d30826856f0854bb6ab3/packages/ember-metal/lib/meta.js#L75)
  * [x] Open an issue : https://github.com/emberjs/ember.js/issues/14732
  * [x] Fix : **here's a workaround which should allow us to unblock:** https://github.com/emberjs/ember.js/pull/14723/commits/8c5b6e1b4720929d232b6aeebf0326cedc4eb85c
  * [x] ~~Rebase~~
* [x] Verify that `this._lastRendered = undefined` is correct (vs `this.lastRendered = undefined`)
* [x] Split assertion message into two sentences
* [x] Allow others to try this in their app
  * [x] Publish custom `2.10.2-with-improved-backtracking-assertion` build : https://github.com/intercom/ember/pull/11
  * [x] Invite others to try it out : https://github.com/emberjs/ember.js/issues/13948#issuecomment-267820392
* [x] ensure that we're not including debug code in production builds
* [x] other managers and helpers
  * [x] route templates
    * [x] tests
  * [x] dynamic components
    * [x] tests
    * [x] ~~debug stack~~ not needed, `CurleyComponentManager` is ultimately invoked
  * [x] render helper
    * [x] tests
    * [x] debug stack
  * [x] mount helper
    * [x] tests
    * [x] debug stack
* [x] address `_debugContainerKey` CI test failures (likely related to [`factoryFor`](https://github.com/emberjs/ember.js/pull/14360) changes) **:beers: @rwjblue**
* [x] fix `undefined` in example 1: https://github.com/GavinJoyce/backtracking/pull/10#issuecomment-269032417
* [x] fix issue with missing `pop` : https://github.com/emberjs/ember.js/pull/14723#issuecomment-270081078 


 