### PR TITLE
Templates cannot read a property from a function

### DIFF
--- a/packages/ember-glimmer/tests/integration/content-test.js
+++ b/packages/ember-glimmer/tests/integration/content-test.js
@@ -482,6 +482,30 @@ class DynamicContentTest extends RenderingTest {
     this.assertContent('hello');
     this.assertInvariants();
   }
+
+  ['@test it can render a property on a function']() {
+    let func = () => {};
+    func.aProp = 'this is a property on a function';
+
+    this.renderPath('func.aProp', { func });
+
+    this.assertContent('this is a property on a function');
+
+    this.assertStableRerender();
+
+    this.runTask(() => set(func, 'aProp', 'still a property on a function'));
+
+    this.assertContent('still a property on a function');
+    this.assertInvariants();
+
+    func = () => {};
+    func.aProp = 'a prop on a new function';
+
+    this.runTask(() => set(this.context, 'func', func));
+
+    this.assertContent('a prop on a new function');
+    this.assertInvariants();
+  }
 }
 
 const EMPTY = {};


### PR DESCRIPTION
We ran into this when trying to upgrade our app that uses https://github.com/LocusEnergy/ember-d3-helpers to 2.10.

Specifically, we were trying to get the `bandwidth` function property off a band scale, which comes from D3 and is itself a function (`options.xScale.bandwidth`).

`Ember.get(options, 'xScale.bandwidth')` works just fine.

I've included a failing test case.