### PR TITLE
failing test for #14704

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -2578,6 +2578,49 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     });
   }
 
+  ['@test isVisible does not overwrite component style with DOM style changes (#14704)'](assert) {
+    this.registerComponent('foo-bar', {
+      ComponentClass: Component.extend({
+        attributeBindings: ['style'],
+        style: htmlSafe('color: blue;')
+      }),
+
+      template: `<p>foo</p>`
+    });
+
+    this.render(`{{foo-bar id="foo-bar" isVisible=visible}}`, {
+      visible: false
+    });
+
+    this.assertComponentElement(this.firstChild, {
+      tagName: 'div',
+      attrs: { id: 'foo-bar',  style: styles('color: blue; display: none;') }
+    });
+
+    this.firstChild.style.padding = '20px';
+
+    this.assertComponentElement(this.firstChild, {
+      tagName: 'div',
+      attrs: { id: 'foo-bar',  style: styles('color: blue; display: none; padding: 20px') }
+    });
+
+    this.assertStableRerender();
+
+    this.runTask(() => { set(this.context, 'visible', true); });
+
+    this.assertComponentElement(this.firstChild, {
+      tagName: 'div',
+      attrs: { id: 'foo-bar', style: styles('color: blue; padding: 20px') }
+    });
+
+    this.runTask(() => { set(this.context, 'visible', false); });
+
+    this.assertComponentElement(this.firstChild, {
+      tagName: 'div',
+      attrs: { id: 'foo-bar',  style: styles('color: blue; display: none; padding: 20px') }
+    });
+  }
+
   ['@test adds isVisible binding when style binding is missing and other bindings exist'](assert) {
     let assertStyle = (expected) => {
       let matcher = styles(expected);


### PR DESCRIPTION
I'm not sure that this is something that we intend to support, but here is a failing test for https://github.com/emberjs/ember.js/issues/14704

It's failing as the [`StyleBindingReference`](https://github.com/emberjs/ember.js/blob/bb46126d07f79edcde330be45bade5ad17fd400c/packages/ember-glimmer/lib/utils/bindings.js#L94-L116) doesn't update when the style is changed directly using the DOM (or when resizing a textarea by dragging it). I'm not certain, but I don't believe the direct DOM manipulations like these are intended to be supported.

