### PR TITLE
assert that a component `tagName` can not be a computed property

### DIFF
--- a/packages/ember-glimmer/lib/component.js
+++ b/packages/ember-glimmer/lib/component.js
@@ -167,6 +167,8 @@ const Component = CoreView.extend(
           }
         }
       )());
+
+      assert(`You cannot use a computed property for the component's \`tagName\` (${this}).`, !(this.tagName && this.tagName.isDescriptor));
     },
 
     rerender() {

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -266,6 +266,20 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     this.assertComponentElement(this.firstChild, { tagName: 'foo-bar', content: 'hello' });
   }
 
+  ['@test tagName can not be a computed property'](assert) {
+    let FooBarComponent = Component.extend({
+      tagName: computed(function() {
+        return 'foo-bar';
+      })
+    });
+
+    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: 'hello' });
+
+    expectAssertion(() => {
+      this.render('{{foo-bar}}');
+    }, /You cannot use a computed property for the component's `tagName` \(<\(.+>\)\./);
+  }
+
   ['@test class is applied before didInsertElement'](assert) {
     let componentClass;
     let FooBarComponent = Component.extend({


### PR DESCRIPTION
fixes https://github.com/emberjs/ember.js/issues/14749

```js
Component.extend({
  tagName: computed(function() {
    return 'foo-bar';
  })
});
```

Now produces an assertion:

```You cannot use a computed property for the component's `tagName` (<(subclass of Ember.Component):ember445>)```
