### PR TITLE
ensure that containerKey is present

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/instrumentation-test.js
+++ b/packages/ember-glimmer/tests/integration/components/instrumentation-test.js
@@ -130,6 +130,7 @@ moduleFor('Components instrumentation', class extends RenderingTest {
 
   assertPayload(payload, component, initialRender) {
     this.assert.equal(payload.object, component.toString(), 'payload.object');
+    this.assert.ok(payload.containerKey, 'the container key should be present');
     this.assert.equal(payload.containerKey, component._debugContainerKey, 'payload.containerKey');
     this.assert.equal(payload.view, component, 'payload.view');
     this.assert.strictEqual(payload.initialRender, initialRender, 'payload.initialRender');


### PR DESCRIPTION
This brings a small improvement to the test, it now ensures that we're not comparing `undefined`

<img width="933" alt="screen shot 2016-12-24 at 22 29 49" src="https://cloud.githubusercontent.com/assets/2526/21468951/8513a802-ca28-11e6-9d58-a355720e365f.png">
