### PR TITLE
Disable costly eventManager support when unused.

### DIFF
--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -1,4 +1,4 @@
-import { guidFor } from 'ember-utils';
+import { guidFor, getOwner } from 'ember-utils';
 import { assert, deprecate, descriptor, Mixin } from 'ember-metal';
 import { environment } from 'ember-environment';
 import { matches } from '../system/utils';
@@ -439,6 +439,18 @@ export default Mixin.create({
 
     if (!this.elementId && this.tagName !== '') {
       this.elementId = guidFor(this);
+    }
+
+    // if we find an `eventManager` property, deopt the
+    // `EventDispatcher`'s `canDispatchToEventManager` property
+    // if `null`
+    if (this.eventManager) {
+      let owner = getOwner(this);
+      let dispatcher = owner && owner.lookup('event_dispatcher:main');
+
+      if (dispatcher && dispatcher.canDispatchToEventManager === null) {
+        dispatcher.canDispatchToEventManager = true;
+      }
     }
 
     deprecate(

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -126,11 +126,11 @@ export default EmberObject.extend({
 
     @property canDispatchToEventManager
     @type boolean
-    @default 'true'
+    @default false
     @since 1.7.0
     @private
   */
-  canDispatchToEventManager: true,
+  canDispatchToEventManager: null,
 
   init() {
     this._super();


### PR DESCRIPTION
For every event that we observe (which is basically all bubbling events in the DOM) we would iterate the entire `parentView` structure of the target elements view looking for an `eventManager` (and then we would dispatch the event to the `eventManager` instead of the view itself).

This support has existed for a *very* long time, and is generally unused in most applications. Unfortunately, the iteration upwards through the view heirarchy is much more costly than we would like. This is currently being done for events like `mouseenter` and  `mousemove` and that very very very few applications (if any) actually take advantage of this support.

This changes the `EventDispatcher` to (by default) disable support for `eventManager`'s (and avoids the costly `parentView` iteration) until we actually instantiate a component that has an `eventManager` property.

In the future, we should deprecate specifying an `eventManager`, but this makes the feature much more "pay as you go".

Related to https://github.com/emberjs/ember.js/issues/14754