### PR TITLE
{{#each}} and {{#each-in}} helpers with sparse array tests

### DIFF
--- a/packages/ember-glimmer/tests/integration/syntax/each-in-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/each-in-test.js
@@ -443,6 +443,21 @@ moduleFor('Syntax test: {{#each-in}}', class extends BasicEachInTest {
     this.assertText('[0:1][1:2][2:3][foo:bar]');
   }
 
+  ['@test it skips holes in sparse arrays'](assert) {
+    let arr = [];
+    arr[5] = 'foo';
+    arr[6] = 'bar';
+
+    this.render(strip`
+      {{#each-in arr as |key value|}}
+        [{{key}}:{{value}}]
+      {{/each-in}}`, { arr });
+
+    this.assertText('[5:foo][6:bar]');
+
+    this.assertStableRerender();
+  }
+
 });
 
 class EachInEdgeCasesTest extends EachInTest {}

--- a/packages/ember-glimmer/tests/integration/syntax/each-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/each-test.js
@@ -928,6 +928,30 @@ moduleFor('Syntax test: {{#each as}} undefined path', class extends RenderingTes
   }
 });
 
+moduleFor('Syntax test: {{#each}} with sparse arrays', class extends RenderingTest {
+  ['@test it should itterate over holes'](assert) {
+    let sparseArray = [];
+    sparseArray[3] = 'foo';
+    sparseArray[4] = 'bar';
+
+    this.render(strip`
+      {{#each list as |value key|}}
+        [{{key}}:{{value}}]
+      {{/each}}`, { list: emberA(sparseArray) });
+
+    this.assertText('[0:][1:][2:][3:foo][4:bar]');
+
+    this.assertStableRerender();
+
+    this.runTask(() => {
+      let list = get(this.context, 'list');
+      list.pushObject('baz');
+    });
+
+    this.assertText('[0:][1:][2:][3:foo][4:bar][5:baz]');
+  }
+});
+
 /* globals MutationObserver: false */
 if (typeof MutationObserver === 'function') {
   moduleFor('Syntax test: {{#each as}} DOM mutation test', class extends RenderingTest {


### PR DESCRIPTION
Related issue https://github.com/emberjs/ember.js/issues/14725