### PR TITLE
[BUGFIX release] Make ember-template-compiler handle {{input}} helpers with sub-expression "type"

### DIFF
--- a/packages/ember-glimmer/tests/integration/helpers/input-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/input-test.js
@@ -436,6 +436,27 @@ moduleFor('Helpers test: {{input}} with dynamic type', class extends InputRender
     this.assertAttr('type', 'password');
   }
 
+  ['@test a subexpression can be used to determine type']() {
+    this.render(`{{input type=(if isTruthy trueType falseType)}}`, {
+      isTruthy: true,
+      trueType: 'text',
+      falseType: 'password'
+    });
+
+    this.assertAttr('type', 'text');
+
+    this.runTask(() => this.rerender());
+
+    this.assertAttr('type', 'text');
+
+    this.runTask(() => set(this.context, 'isTruthy', false));
+
+    this.assertAttr('type', 'password');
+
+    this.runTask(() => set(this.context, 'isTruthy', true));
+
+    this.assertAttr('type', 'text');
+  }
 });
 
 moduleFor(`Helpers test: {{input type='checkbox'}}`, class extends InputRenderingTest {

--- a/packages/ember-template-compiler/lib/plugins/transform-input-type-syntax.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-input-type-syntax.js
@@ -62,6 +62,8 @@ function insertTypeHelperParameter(node, builders) {
     }
   }
   if (pair && pair.value.type !== 'StringLiteral') {
-    node.params.unshift(builders.sexpr('-input-type', [builders.path(pair.value.original, pair.loc)], null, pair.loc));
+    let path = pair.value.path ? pair.value.path.original : pair.value.original;
+
+    node.params.unshift(builders.sexpr('-input-type', [builders.path(path, pair.loc)], null, pair.loc));
   }
 }

--- a/packages/ember-template-compiler/lib/plugins/transform-input-type-syntax.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-input-type-syntax.js
@@ -62,8 +62,6 @@ function insertTypeHelperParameter(node, builders) {
     }
   }
   if (pair && pair.value.type !== 'StringLiteral') {
-    let path = pair.value.path ? pair.value.path.original : pair.value.original;
-
-    node.params.unshift(builders.sexpr('-input-type', [builders.path(path, pair.loc)], null, pair.loc));
+    node.params.unshift(builders.sexpr('-input-type', [pair.value], null, pair.loc));
   }
 }

--- a/packages/ember-template-compiler/tests/plugins/transform-input-type-syntax-test.js
+++ b/packages/ember-template-compiler/tests/plugins/transform-input-type-syntax-test.js
@@ -1,0 +1,21 @@
+import { compile } from '../../index';
+
+QUnit.module('ember-template-compiler: input type syntax');
+
+QUnit.test('Can compile an {{input}} helper that has a sub-expression value as its type', function() {
+  expect(0);
+
+  compile(`{{input type=(if true 'password' 'text')}}`);
+});
+
+QUnit.test('Can compile an {{input}} helper with a string literal type', function() {
+  expect(0);
+
+  compile(`{{input type='text'}}`);
+});
+
+QUnit.test('Can compile an {{input}} helper with a type stored in a var', function() {
+  expect(0);
+
+  compile(`{{input type=_type}}`);
+});


### PR DESCRIPTION
- Allow {{input}} with a SubExpression type (e.g., {{input type=(if true 'password' 'text')}})
  to be compiled.

Started failing in 2.10.
jsbin repro: http://jsbin.com/kedozaf/edit?html,js,output