### PR TITLE
Fixed string capitalize for accented characters

### DIFF
--- a/packages/ember-runtime/lib/system/string.js
+++ b/packages/ember-runtime/lib/system/string.js
@@ -60,7 +60,7 @@ const UNDERSCORE_CACHE = new Cache(1000, function(str) {
     replace(STRING_UNDERSCORE_REGEXP_2, '_').toLowerCase();
 });
 
-const STRING_CAPITALIZE_REGEXP = (/(^|\/)([a-z])/g);
+const STRING_CAPITALIZE_REGEXP = (/(^|\/)([a-z\u00C0-\u024F])/g);
 
 const CAPITALIZE_CACHE = new Cache(1000, function(str) {
   return str.replace(STRING_CAPITALIZE_REGEXP, function(match, separator, chr) {

--- a/packages/ember-runtime/tests/system/string/capitalize_test.js
+++ b/packages/ember-runtime/tests/system/string/capitalize_test.js
@@ -64,3 +64,10 @@ QUnit.test('capitalize namespaced dasherized string', function() {
     deepEqual('private-docs/owner-invoice'.capitalize(), 'Private-docs/Owner-invoice');
   }
 });
+
+QUnit.test('capitalize string with accent character', function() {
+  deepEqual(capitalize('šabc'), 'Šabc');
+  if (ENV.EXTEND_PROTOTYPES.String) {
+    deepEqual('šabc'.capitalize(), 'Šabc');
+  }
+});


### PR DESCRIPTION
String capitalize function did not work properly, when first character is  accented (e.g. ščťžý)