### PR TITLE
[DOCS] fix NativeArray.clear example

### DIFF
--- a/packages/ember-runtime/lib/mixins/mutable_array.js
+++ b/packages/ember-runtime/lib/mixins/mutable_array.js
@@ -85,9 +85,9 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
     ```javascript
     let colors = ['red', 'green', 'blue'];
 
-    color.length();   //  3
-    colors.clear();   //  []
-    colors.length();  //  0
+    colors.length;  // 3
+    colors.clear(); // []
+    colors.length;  // 0
     ```
 
     @method clear


### PR DESCRIPTION
`length` isn't a function, and `colors` had a typo.