### PR TITLE
[DOC release] Fix registerOptionsForType example

### DIFF
--- a/packages/ember-runtime/lib/mixins/registry_proxy.js
+++ b/packages/ember-runtime/lib/mixins/registry_proxy.js
@@ -169,7 +169,7 @@ export default Mixin.create({
    let appInstance = App.buildInstance();
 
    // if all of type `connection` must not be singletons
-   appInstance.optionsForType('connection', { singleton: false });
+   appInstance.registerOptionsForType('connection', { singleton: false });
 
    appInstance.register('connection:twitter', TwitterConnection);
    appInstance.register('connection:facebook', FacebookConnection);


### PR DESCRIPTION
I could be wrong, but I believe that `optionsForType` is deprecated in favor of `registerOptionsForType`. The documented example for `registerOptionsForType` showed using `optionsForType`. This updates the example to use `registerOptionsForType`.