### PR TITLE
[BUGFIX beta] Lazily require `broccoli-stew` when needed.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 /* jshint node: true */
 'use strict';
-var stew = require('broccoli-stew');
 var path = require('path');
 var resolve = require('resolve');
 
@@ -33,7 +32,9 @@ module.exports = {
   name: 'ember-source',
   paths: paths,
   absolutePaths: absolutePaths,
+
   treeForVendor: function() {
+    var stew = require('broccoli-stew');
 
     var jqueryPath;
     try {


### PR DESCRIPTION
`require('broccoli-stew')` takes approximately 150ms, and there is no need to require it eagerly when it is only needed for build related commands.