### PR TITLE
[DOC release] Mark LinkComponent as public

### DIFF
--- a/packages/ember-glimmer/lib/components/link-to.js
+++ b/packages/ember-glimmer/lib/components/link-to.js
@@ -339,7 +339,7 @@ import EmberComponent, { HAS_BLOCK } from '../component';
   @namespace Ember
   @extends Ember.Component
   @see {Ember.Templates.helpers.link-to}
-  @private
+  @public
 **/
 const LinkComponent = EmberComponent.extend({
   layout,


### PR DESCRIPTION
As per discussion related to https://github.com/emberjs/rfcs/pull/176#issuecomment-267383628, LinkComponent should be changed to be a public class.