### PR TITLE
remove unused `_suppressDeferredDeprecation`

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -194,8 +194,6 @@ let librariesRegistered = false;
 */
 
 const Application = Engine.extend({
-  _suppressDeferredDeprecation: true,
-
   /**
     The root DOM element of the Application. This can be specified as an
     element or a


### PR DESCRIPTION
This seems to be a relic from an old deprecation: https://github.com/emberjs/ember.js/pull/5215