### PR TITLE
Integrate Glimmer Macros For Binary VM

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -89,7 +89,7 @@ function rsvp() {
 function routeRecognizer() {
   var packageJson = require('route-recognizer/package');
   var packageDir = path.dirname(require.resolve('route-recognizer/package'));
-  var entry = path.join(packageDir, packageJson['module'] || packageJson['js:next'] || packageJson['main'].replace(/dist\//, 'dist/es6/'));
+  var entry = path.join(packageDir, packageJson['module'] || packageJson['jsnext:main'] || packageJson['main'].replace(/dist\//, 'dist/es6/'));
   var basename = path.basename(entry);
   var es6 = new Funnel(path.dirname(entry), {
     files: [ basename ]
@@ -116,7 +116,7 @@ function buildPackage(name, options) {
     throw new Error('If resolving from a non-package.json entry point, you must supply the srcDirectory.');
   }
 
-  var entryModule = packageJson['module'] || packageJson['js:next'] || packageJson['main'].replace(/dist\//, 'dist/es6/');
+  var entryModule = packageJson['module'] || packageJson['jsnext:main'] || packageJson['main'].replace(/dist\//, 'dist/es6/');
   var funnelDir = path.join(packageDir, options.entry ? options.srcDir : path.dirname(entryModule));
   var sourceEntry = options.entry ? options.entry : path.basename(entryModule);
 
@@ -300,7 +300,7 @@ module.exports = function() {
     'router':                router(),
     'dag-map':               dag(),
     'route-recognizer':      routeRecognizer(),
-    'simple-html-tokenizer': htmlbarsPackage('simple-html-tokenizer', { libPath: 'node_modules/glimmer-engine/dist/es6' }),
+    'simple-html-tokenizer': buildPackage('simple-html-tokenizer'),
 
     '@glimmer/compiler':     buildPackage('@glimmer/compiler', {
                                external: ['@glimmer/syntax', '@glimmer/wire-format', '@glimmer/util']

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -17,12 +17,12 @@ module.exports = function(features) {
       templateCompilerVendor: [
         'simple-html-tokenizer',
         'backburner',
-        'glimmer-wire-format',
-        'glimmer-syntax',
-        'glimmer-util',
-        'glimmer-compiler',
-        'glimmer-reference',
-        'glimmer-runtime',
+        '@glimmer/wire-format',
+        '@glimmer/syntax',
+        '@glimmer/util',
+        '@glimmer/compiler',
+        '@glimmer/reference',
+        '@glimmer/runtime',
         'handlebars'
       ]
     },
@@ -37,12 +37,11 @@ module.exports = function(features) {
       requirements: ['container', 'ember-metal', 'ember-routing' ],
       hasTemplates: true,
       vendorRequirements: [
-        'glimmer',
-        'glimmer-runtime',
-        'glimmer-reference',
-        'glimmer-util',
-        'glimmer-wire-format',
-        'glimmer-node'
+        '@glimmer/runtime',
+        '@glimmer/reference',
+        '@glimmer/util',
+        '@glimmer/wire-format',
+        '@glimmer/node'
       ],
       testingVendorRequirements: []
     }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,11 @@
     "test:testem": "testem -f testem.dist.json"
   },
   "dependencies": {
+    "@glimmer/compiler": "^0.21.1",
+    "@glimmer/node": "^0.21.1",
+    "@glimmer/reference": "^0.21.0",
+    "@glimmer/runtime": "^0.21.1",
+    "@glimmer/util": "^0.21.0",
     "broccoli-stew": "^1.2.0",
     "ember-cli-get-component-path-option": "^1.0.0",
     "ember-cli-normalize-entity-name": "^1.0.0",
@@ -35,12 +40,14 @@
     "ember-cli-test-info": "^1.0.0",
     "ember-cli-valid-component-name": "^1.0.0",
     "ember-cli-version-checker": "^1.1.7",
+    "handlebars": "~3",
     "jquery": "^3.1.1",
     "resolve": "^1.1.7",
     "rsvp": "^3.3.3",
     "simple-dom": "^0.3.0"
   },
   "devDependencies": {
+    "@glimmer/test-helpers": "^0.21.1",
     "aws-sdk": "~2.2.43",
     "babel-plugin-feature-flags": "^0.2.3",
     "babel-plugin-filter-imports": "~0.2.0",
@@ -64,7 +71,7 @@
     "git-repo-info": "^1.1.4",
     "git-repo-version": "^0.3.1",
     "github": "^0.2.3",
-    "glimmer-engine": "^0.19.4",
+    "glimmer-engine": "^0.20.0",
     "glob": "^5.0.13",
     "html-differ": "^1.3.4",
     "mocha": "^2.4.5",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "jquery": "^3.1.1",
     "resolve": "^1.1.7",
     "rsvp": "^3.3.3",
-    "simple-dom": "^0.3.0"
+    "simple-dom": "^0.3.0",
+    "simple-html-tokenizer": "^0.3.0"
   },
   "devDependencies": {
     "@glimmer/test-helpers": "^0.21.1",
@@ -71,7 +72,6 @@
     "git-repo-info": "^1.1.4",
     "git-repo-version": "^0.3.1",
     "github": "^0.2.3",
-    "glimmer-engine": "^0.20.0",
     "glob": "^5.0.13",
     "html-differ": "^1.3.4",
     "mocha": "^2.4.5",

--- a/packages/ember-glimmer/lib/component.js
+++ b/packages/ember-glimmer/lib/component.js
@@ -16,8 +16,8 @@ import {
   deprecate
 } from 'ember-metal';
 import { UPDATE, RootReference } from './utils/references';
-import { DirtyableTag } from 'glimmer-reference';
-import { readDOMAttr } from 'glimmer-runtime';
+import { DirtyableTag } from '@glimmer/reference';
+import { readDOMAttr } from '@glimmer/runtime';
 
 export const DIRTY_TAG = symbol('DIRTY_TAG');
 export const ARGS = symbol('ARGS');

--- a/packages/ember-glimmer/lib/dom.js
+++ b/packages/ember-glimmer/lib/dom.js
@@ -1,2 +1,2 @@
-export { DOMChanges, DOMTreeConstruction } from 'glimmer-runtime';
-export { NodeDOMTreeConstruction } from 'glimmer-node';
+export { DOMChanges, DOMTreeConstruction } from '@glimmer/runtime';
+export { NodeDOMTreeConstruction } from '@glimmer/node';

--- a/packages/ember-glimmer/lib/helper.js
+++ b/packages/ember-glimmer/lib/helper.js
@@ -5,7 +5,7 @@
 
 import { symbol } from 'ember-utils';
 import { FrameworkObject } from 'ember-runtime';
-import { DirtyableTag } from 'glimmer-reference';
+import { DirtyableTag } from '@glimmer/reference';
 
 export const RECOMPUTE_TAG = symbol('RECOMPUTE_TAG');
 

--- a/packages/ember-glimmer/lib/helpers/action.js
+++ b/packages/ember-glimmer/lib/helpers/action.js
@@ -12,8 +12,8 @@ import {
   runInDebug
 } from 'ember-metal';
 import { UnboundReference } from '../utils/references';
-import { EvaluatedPositionalArgs } from 'glimmer-runtime';
-import { isConst } from 'glimmer-reference';
+import { EvaluatedPositionalArgs } from '@glimmer/runtime';
+import { isConst } from '@glimmer/reference';
 
 export const INVOKE = symbol('INVOKE');
 export const ACTION = symbol('ACTION');
@@ -378,7 +378,7 @@ function makeClosureAction(context, target, action, processArgs, debugKey) {
   }
 
   return function(...args) {
-    let payload = { target: self, args, label: 'glimmer-closure-action' };
+    let payload = { target: self, args, label: '@glimmer/closure-action' };
     return flaggedInstrument('interaction.ember-action', payload, () => {
       return run.join(self, fn, ...processArgs(args));
     });

--- a/packages/ember-glimmer/lib/helpers/component.js
+++ b/packages/ember-glimmer/lib/helpers/component.js
@@ -14,7 +14,7 @@ import {
   EvaluatedPositionalArgs,
   isComponentDefinition
 } from '@glimmer/runtime';
-import { assert } from 'ember-metal';
+import { assert, runInDebug } from 'ember-metal';
 
 /**
   The `{{component}}` helper lets you add instances of `Ember.Component` to a
@@ -205,10 +205,14 @@ function createCurriedDefinition(definition, args) {
   );
 }
 
-const EMPTY_BLOCKS = {
+let EMPTY_BLOCKS = {
   default: null,
   inverse: null
 };
+
+runInDebug(() => {
+  EMPTY_BLOCKS = Object.freeze(EMPTY_BLOCKS);
+});
 
 function curryArgs(definition, newArgs) {
   let { args, ComponentClass } = definition;

--- a/packages/ember-glimmer/lib/helpers/component.js
+++ b/packages/ember-glimmer/lib/helpers/component.js
@@ -9,12 +9,11 @@ import {
   validatePositionalParameters
 } from '../syntax/curly-component';
 import {
-  Blocks,
   EvaluatedArgs,
   EvaluatedNamedArgs,
   EvaluatedPositionalArgs,
   isComponentDefinition
-} from 'glimmer-runtime';
+} from '@glimmer/runtime';
 import { assert } from 'ember-metal';
 
 /**
@@ -206,6 +205,11 @@ function createCurriedDefinition(definition, args) {
   );
 }
 
+const EMPTY_BLOCKS = {
+  default: null,
+  inverse: null
+};
+
 function curryArgs(definition, newArgs) {
   let { args, ComponentClass } = definition;
   let positionalParams = ComponentClass.class.positionalParams;
@@ -258,7 +262,7 @@ function curryArgs(definition, newArgs) {
   let mergedArgs = EvaluatedArgs.create(
     EvaluatedPositionalArgs.create(mergedPositional),
     EvaluatedNamedArgs.create(mergedNamed),
-    Blocks.empty()
+    EMPTY_BLOCKS
   );
 
   return mergedArgs;

--- a/packages/ember-glimmer/lib/helpers/concat.js
+++ b/packages/ember-glimmer/lib/helpers/concat.js
@@ -1,5 +1,5 @@
 import { InternalHelperReference } from '../utils/references';
-import { normalizeTextValue } from 'glimmer-runtime';
+import { normalizeTextValue } from '@glimmer/runtime';
 
 /**
 @module ember

--- a/packages/ember-glimmer/lib/helpers/get.js
+++ b/packages/ember-glimmer/lib/helpers/get.js
@@ -6,7 +6,7 @@ import {
   combine,
   isConst,
   referenceFromParts
-} from 'glimmer-reference';
+} from '@glimmer/reference';
 
 /**
 @module ember

--- a/packages/ember-glimmer/lib/helpers/if-unless.js
+++ b/packages/ember-glimmer/lib/helpers/if-unless.js
@@ -14,7 +14,7 @@ import {
   UpdatableTag,
   combine,
   isConst
-} from 'glimmer-reference';
+} from '@glimmer/reference';
 
 
 /**

--- a/packages/ember-glimmer/lib/index.js
+++ b/packages/ember-glimmer/lib/index.js
@@ -200,7 +200,6 @@
 
 export { INVOKE } from './helpers/action';
 export { default as RootTemplate } from './templates/root';
-export { registerSyntax } from './syntax';
 export { default as template } from './template';
 export { default as Checkbox } from './components/checkbox';
 export { default as TextField } from './components/text_field';

--- a/packages/ember-glimmer/lib/renderer.js
+++ b/packages/ember-glimmer/lib/renderer.js
@@ -6,7 +6,7 @@ import {
   runInTransaction as _runInTransaction,
   isFeatureEnabled
 } from 'ember-metal';
-import { CURRENT_TAG, UNDEFINED_REFERENCE } from 'glimmer-reference';
+import { CURRENT_TAG, UNDEFINED_REFERENCE } from '@glimmer/reference';
 import {
   fallbackViewRegistry,
   getViewElement,

--- a/packages/ember-glimmer/lib/syntax.js
+++ b/packages/ember-glimmer/lib/syntax.js
@@ -1,44 +1,85 @@
-import { RenderSyntax } from './syntax/render';
-import { OutletSyntax } from './syntax/outlet';
-import { MountSyntax } from './syntax/mount';
-import { DynamicComponentSyntax } from './syntax/dynamic-component';
-import { InputSyntax } from './syntax/input';
+import { renderMacro } from './syntax/render';
+import { outletMacro } from './syntax/outlet';
+import { mountMacro } from './syntax/mount';
 import {
-  WithDynamicVarsSyntax,
-  InElementSyntax
-} from 'glimmer-runtime';
+  blockComponentMacro,
+  inlineComponentMacro,
+  closureComponentMacro
+} from './syntax/dynamic-component';
+import { wrapComponentClassAttribute } from './utils/bindings';
+import { _withDynamicVarsMacro } from './syntax/-with-dynamic-vars';
+import { _inElementMacro } from './syntax/-in-element';
+import { inputMacro } from './syntax/input';
+import { textAreaMacro } from './syntax/-text-area';
+import { assert } from 'ember-metal';
 
+function refineInlineSyntax(path, params, hash, builder) {
+  let [ name ] = path;
 
-let syntaxKeys = [];
-let syntaxes = [];
+  assert(`You attempted to overwrite the built-in helper "${name}" which is not allowed. Please rename the helper.`, !(builder.env.builtInHelpers[name] && builder.env.owner.hasRegistration(`helper:${name}`)));
 
-export function registerSyntax(key, syntax) {
-  syntaxKeys.push(key);
-  syntaxes.push(syntax);
+  if (path.length > 1) {
+    return closureComponentMacro(path, params, hash, null, null, builder);
+  }
+
+  let { symbolTable } = builder;
+
+  let definition;
+  if (name.indexOf('-') > -1) {
+    definition = builder.env.getComponentDefinition(path, symbolTable);
+  }
+
+  if (definition) {
+    wrapComponentClassAttribute(hash);
+    builder.component.static(definition, [params, hash, null, null], symbolTable);
+    return true;
+  }
+
+  return false;
 }
 
-export function findSyntaxBuilder(key) {
-  let index = syntaxKeys.indexOf(key);
+function refineBlockSyntax(sexp, builder) {
+  let [, path, params, hash, _default, inverse] = sexp;
+  let [ name ] = path;
 
-  if (index > -1) {
-    return syntaxes[index];
+  if (path.length > 1) {
+    return closureComponentMacro(path, params, hash, _default, inverse, builder);
   }
+
+  if (name.indexOf('-') === -1) {
+    return false;
+  }
+
+  let { symbolTable } = builder;
+  let definition;
+  if (name.indexOf('-') > -1) {
+    definition = builder.env.getComponentDefinition(path, symbolTable);
+  }
+
+  if (definition) {
+    wrapComponentClassAttribute(hash);
+    builder.component.static(definition, [params, hash, _default, inverse], symbolTable);
+    return true;
+  }
+
+  assert(`A component or helper named "${name}" could not be found`, builder.env.hasHelper(path, symbolTable));
+
+  assert(`Helpers may not be used in the block form, for example {{#${name}}}{{/${name}}}. Please use a component, or alternatively use the helper in combination with a built-in Ember helper, for example {{#if (${name})}}{{/if}}.`, !builder.env.hasHelper(path, symbolTable));
+
+  return false;
 }
 
-registerSyntax('render', RenderSyntax);
-registerSyntax('outlet', OutletSyntax);
-registerSyntax('mount', MountSyntax);
-registerSyntax('component', DynamicComponentSyntax);
-registerSyntax('input', InputSyntax);
-
-registerSyntax('-with-dynamic-vars', class {
-  static create(environment, args, symbolTable) {
-    return new WithDynamicVarsSyntax(args);
-  }
-});
-
-registerSyntax('-in-element', class {
-  static create(environment, args, symbolTable) {
-    return new InElementSyntax(args);
-  }
-});
+export function populateMacros(blocks, inlines) {
+  inlines.add('outlet', outletMacro);
+  inlines.add('component', inlineComponentMacro);
+  inlines.add('render', renderMacro);
+  inlines.add('mount', mountMacro);
+  inlines.add('input', inputMacro);
+  inlines.add('textarea', textAreaMacro);
+  inlines.addMissing(refineInlineSyntax);
+  blocks.add('component', blockComponentMacro);
+  blocks.add('-with-dynamic-vars', _withDynamicVarsMacro);
+  blocks.add('-in-element', _inElementMacro);
+  blocks.addMissing(refineBlockSyntax);
+  return { blocks, inlines };
+}

--- a/packages/ember-glimmer/lib/syntax.js
+++ b/packages/ember-glimmer/lib/syntax.js
@@ -69,6 +69,15 @@ function refineBlockSyntax(sexp, builder) {
   return false;
 }
 
+let experimentalMacros = [];
+
+// This is a private API to allow for expiremental macros
+// to be created in user space. Registering a macro should
+// should be done in an initializer.
+export function registerMacros(macro) {
+  experimentalMacros.push(macro);
+}
+
 export function populateMacros(blocks, inlines) {
   inlines.add('outlet', outletMacro);
   inlines.add('component', inlineComponentMacro);
@@ -81,5 +90,10 @@ export function populateMacros(blocks, inlines) {
   blocks.add('-with-dynamic-vars', _withDynamicVarsMacro);
   blocks.add('-in-element', _inElementMacro);
   blocks.addMissing(refineBlockSyntax);
+
+  for (let i = 0; i < experimentalMacros.length; i++) {
+    let macro = experimentalMacros[i];
+    macro(blocks, inlines);
+  }
   return { blocks, inlines };
 }

--- a/packages/ember-glimmer/lib/syntax.js
+++ b/packages/ember-glimmer/lib/syntax.js
@@ -95,5 +95,8 @@ export function populateMacros(blocks, inlines) {
     let macro = experimentalMacros[i];
     macro(blocks, inlines);
   }
+
+  experimentalMacros = [];
+
   return { blocks, inlines };
 }

--- a/packages/ember-glimmer/lib/syntax/-in-element.js
+++ b/packages/ember-glimmer/lib/syntax/-in-element.js
@@ -1,0 +1,23 @@
+import { BaselineSyntax, compileArgs } from '@glimmer/runtime';
+import { unwrap } from '@glimmer/util';
+
+const {
+  defaultBlock,
+  params,
+  hash
+} = BaselineSyntax.NestedBlock;
+
+export function _inElementMacro(sexp, builder) {
+  let block = defaultBlock(sexp);
+  let args = compileArgs(params(sexp), hash(sexp), builder);
+
+  builder.putArgs(args);
+  builder.test('simple');
+
+  builder.labelled(null, b => {
+    b.jumpUnless('END');
+    b.pushRemoteElement();
+    b.evaluate(unwrap(block));
+    b.popRemoteElement();
+  });
+}

--- a/packages/ember-glimmer/lib/syntax/-text-area.js
+++ b/packages/ember-glimmer/lib/syntax/-text-area.js
@@ -1,0 +1,8 @@
+import { wrapComponentClassAttribute } from '../utils/bindings';
+
+export function textAreaMacro(path, params, hash, builder) {
+  let definition = builder.env.getComponentDefinition(['-text-area'], builder.symbolTable);
+  wrapComponentClassAttribute(hash);
+  builder.component.static(definition, [params, hash, null, null], builder.symbolTable);
+  return true;
+}

--- a/packages/ember-glimmer/lib/syntax/-with-dynamic-vars.js
+++ b/packages/ember-glimmer/lib/syntax/-with-dynamic-vars.js
@@ -1,0 +1,21 @@
+import { BaselineSyntax, compileArgs } from '@glimmer/runtime';
+import { unwrap } from '@glimmer/util';
+
+const {
+  defaultBlock,
+  params,
+  hash
+} = BaselineSyntax.NestedBlock;
+
+export function _withDynamicVarsMacro(sexp, builder) {
+  let block = defaultBlock(sexp);
+  let args = compileArgs(params(sexp), hash(sexp), builder);
+
+  builder.unit(b => {
+    b.putArgs(args);
+    b.pushDynamicScope();
+    b.bindDynamicScope(args.named.keys);
+    b.evaluate(unwrap(block));
+    b.popDynamicScope();
+  });
+}

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -1,9 +1,8 @@
 import { OWNER } from 'ember-utils';
 import {
-  StatementSyntax,
   PrimitiveReference,
   ComponentDefinition
-} from 'glimmer-runtime';
+} from '@glimmer/runtime';
 import {
   AttributeBinding,
   ClassNameBinding,
@@ -123,20 +122,6 @@ function applyAttributeBindings(element, attributeBindings, component, operation
 
   if (seen.indexOf('style') === -1) {
     IsVisibleBinding.install(element, component, operations);
-  }
-}
-
-export class CurlyComponentSyntax extends StatementSyntax {
-  constructor(args, definition, symbolTable) {
-    super();
-    this.args = args;
-    this.definition = definition;
-    this.symbolTable = symbolTable;
-    this.shadow = null;
-  }
-
-  compile(builder) {
-    builder.component.static(this.definition, this.args, this.symbolTable, this.shadow);
   }
 }
 

--- a/packages/ember-glimmer/lib/syntax/dynamic-component.js
+++ b/packages/ember-glimmer/lib/syntax/dynamic-component.js
@@ -1,11 +1,7 @@
 import {
-  ArgsSyntax,
-  StatementSyntax,
-  GetSyntax,
-  PositionalArgsSyntax,
   isComponentDefinition
-} from 'glimmer-runtime';
-import { UNDEFINED_REFERENCE } from 'glimmer-reference';
+} from '@glimmer/runtime';
+import { UNDEFINED_REFERENCE } from '@glimmer/reference';
 import { assert } from 'ember-metal';
 
 function dynamicComponentFor(vm, symbolTable) {
@@ -16,37 +12,33 @@ function dynamicComponentFor(vm, symbolTable) {
   return new DynamicComponentReference({ nameRef, env, symbolTable });
 }
 
-export class DynamicComponentSyntax extends StatementSyntax {
-  // for {{component componentName}}
-  static create(environment, args, symbolTable) {
-    let definitionArgs = ArgsSyntax.fromPositionalArgs(args.positional.slice(0, 1));
-    let invocationArgs = ArgsSyntax.build(args.positional.slice(1), args.named, args.blocks);
+export function closureComponentMacro(path, params, hash, _default, inverse, builder) {
+  let definitionArgs = [[['get', path]], hash, _default, inverse];
+  let args = [params, hash, _default, inverse];
+  builder.component.dynamic(definitionArgs, dynamicComponentFor, args, builder.symbolTable);
+  return true;
+}
 
-    return new this(definitionArgs, invocationArgs, symbolTable);
-  }
+export function dynamicComponentMacro(params, hash, _default, inverse, builder) {
+  let definitionArgs = [params.slice(0, 1), null, null, null];
+  let args = [params.slice(1), hash, null, null];
+  builder.component.dynamic(definitionArgs, dynamicComponentFor, args, builder.symbolTable);
+  return true;
+}
 
-  // Transforms {{foo.bar with=args}} or {{#foo.bar with=args}}{{/foo.bar}}
-  // into {{component foo.bar with=args}} or
-  // {{#component foo.bar with=args}}{{/component}}
-  // with all of it's arguments
-  static fromPath(environment, path, args, symbolTable) {
-    let positional = ArgsSyntax.fromPositionalArgs(PositionalArgsSyntax.build([GetSyntax.build(path.join('.'))]));
+export function blockComponentMacro(sexp, builder) {
+  let [, , params, hash, _default, inverse] = sexp;
+  let definitionArgs = [params.slice(0, 1), null, null, null];
+  let args = [params.slice(1), hash, _default, inverse];
+  builder.component.dynamic(definitionArgs, dynamicComponentFor, args, builder.symbolTable);
+  return true;
+}
 
-    return new this(positional, args, symbolTable);
-  }
-
-  constructor(definitionArgs, args, symbolTable) {
-    super();
-    this.definition = dynamicComponentFor;
-    this.definitionArgs = definitionArgs;
-    this.args = args;
-    this.symbolTable = symbolTable;
-    this.shadow = null;
-  }
-
-  compile(builder) {
-    builder.component.dynamic(this.definitionArgs, this.definition, this.args, this.symbolTable, this.shadow);
-  }
+export function inlineComponentMacro(path, params, hash, builder) {
+  let definitionArgs = [params.slice(0, 1), null, null, null];
+  let args = [params.slice(1), hash, null, null];
+  builder.component.dynamic(definitionArgs, dynamicComponentFor, args, builder.symbolTable);
+  return true;
 }
 
 class DynamicComponentReference {

--- a/packages/ember-glimmer/lib/syntax/mount.js
+++ b/packages/ember-glimmer/lib/syntax/mount.js
@@ -3,11 +3,9 @@
 @submodule ember-glimmer
 */
 import {
-  ArgsSyntax,
-  StatementSyntax,
   ComponentDefinition
-} from 'glimmer-runtime';
-import { UNDEFINED_REFERENCE } from 'glimmer-reference';
+} from '@glimmer/runtime';
+import { UNDEFINED_REFERENCE } from '@glimmer/reference';
 import { assert, runInDebug } from 'ember-metal';
 import { RootReference } from '../utils/references';
 import { generateControllerFactory } from 'ember-routing';
@@ -35,39 +33,26 @@ import AbstractManager from './abstract-manager';
   @category ember-application-engines
   @public
 */
-export class MountSyntax extends StatementSyntax {
-  static create(env, args, symbolTable) {
-    assert(
-      'You can only pass a single argument to the {{mount}} helper, e.g. {{mount "chat-engine"}}.',
-      args.positional.length === 1 && args.named.length === 0
-    );
+export function mountMacro(path, params, hash, builder) {
+  assert(
+    'You can only pass a single argument to the {{mount}} helper, e.g. {{mount "chat-engine"}}.',
+    params.length === 1 && hash === null
+  );
 
-    assert(
-      'The first argument of {{mount}} must be quoted, e.g. {{mount "chat-engine"}}.',
-      args.positional.at(0).type === 'value' && typeof args.positional.at(0).inner() === 'string'
-    );
+  let name = params[0];
 
-    let name = args.positional.at(0).inner();
+  assert(
+    'The first argument of {{mount}} must be quoted, e.g. {{mount "chat-engine"}}.',
+    typeof name === 'string'
+  );
 
-    assert(
-      `You used \`{{mount '${name}'}}\`, but the engine '${name}' can not be found.`,
-      env.owner.hasRegistration(`engine:${name}`)
-    );
+  assert(
+    `You used \`{{mount '${name}'}}\`, but the engine '${name}' can not be found.`,
+    builder.env.owner.hasRegistration(`engine:${name}`)
+  );
 
-    let definition = new MountDefinition(name, env);
-
-    return new MountSyntax(definition, symbolTable);
-  }
-
-  constructor(definition, symbolTable) {
-    super();
-    this.definition = definition;
-    this.symbolTable = symbolTable;
-  }
-
-  compile(builder) {
-    builder.component.static(this.definition, ArgsSyntax.empty(), null, this.symbolTable, null);
-  }
+  builder.component.static(new MountDefinition(name, builder.env), [params, hash, null, null], builder.symbolTable);
+  return true;
 }
 
 class MountManager extends AbstractManager {

--- a/packages/ember-glimmer/lib/syntax/outlet.js
+++ b/packages/ember-glimmer/lib/syntax/outlet.js
@@ -4,18 +4,17 @@
 */
 import { generateGuid, guidFor } from 'ember-utils';
 import {
-  ArgsSyntax,
-  StatementSyntax,
-  ComponentDefinition
-} from 'glimmer-runtime';
-import { runInDebug, _instrumentStart } from 'ember-metal';
+  ComponentDefinition,
+  CompiledArgs
+} from '@glimmer/runtime';
+import { _instrumentStart, runInDebug } from 'ember-metal';
 import { RootReference } from '../utils/references';
+import AbstractManager from './abstract-manager';
 import {
   UpdatableTag,
   ConstReference,
   combine
-} from 'glimmer-reference';
-import AbstractManager from './abstract-manager';
+} from '@glimmer/reference';
 
 function outletComponentFor(vm) {
   let { outletState } = vm.dynamicScope();
@@ -30,6 +29,7 @@ function outletComponentFor(vm) {
 
   return new OutletComponentReference(outletNameRef, outletState);
 }
+
 
 /**
   The `{{outlet}}` helper lets you specify where a child route will render in
@@ -80,24 +80,13 @@ function outletComponentFor(vm) {
   @for Ember.Templates.helpers
   @public
 */
-export class OutletSyntax extends StatementSyntax {
-  static create(environment, args, symbolTable) {
-    let definitionArgs = ArgsSyntax.fromPositionalArgs(args.positional.slice(0, 1));
-    return new this(environment, definitionArgs, symbolTable);
+export function outletMacro(path, params, hash, builder) {
+  if (!params) {
+    params = [];
   }
-
-  constructor(environment, args, symbolTable) {
-    super();
-    this.definitionArgs = args;
-    this.definition = outletComponentFor;
-    this.args = ArgsSyntax.empty();
-    this.symbolTable = symbolTable;
-    this.shadow = null;
-  }
-
-  compile(builder) {
-    builder.component.dynamic(this.definitionArgs, this.definition, this.args, this.symbolTable, this.shadow);
-  }
+  let definitionArgs = [params.slice(0, 1), null, null, null];
+  builder.component.dynamic(definitionArgs, outletComponentFor, CompiledArgs.empty(), builder.symbolTable, null);
+  return true;
 }
 
 class OutletComponentReference {

--- a/packages/ember-glimmer/lib/syntax/render.js
+++ b/packages/ember-glimmer/lib/syntax/render.js
@@ -3,11 +3,9 @@
 @submodule ember-glimmer
 */
 import {
-  ArgsSyntax,
-  StatementSyntax,
   ComponentDefinition
-} from 'glimmer-runtime';
-import { ConstReference, isConst } from 'glimmer-reference';
+} from '@glimmer/runtime';
+import { ConstReference, isConst } from '@glimmer/reference';
 import { assert, runInDebug } from 'ember-metal';
 import { RootReference } from '../utils/references';
 import { generateController, generateControllerFactory } from 'ember-routing';
@@ -49,6 +47,7 @@ function makeComponentDefinition(vm) {
     return new ConstReference(new RenderDefinition(controllerName, template, env, NON_SINGLETON_RENDER_MANAGER));
   }
 }
+
 
 /**
   Calling ``{{render}}`` from within a template will insert another
@@ -119,23 +118,14 @@ function makeComponentDefinition(vm) {
   @return {String} HTML string
   @public
 */
-export class RenderSyntax extends StatementSyntax {
-  static create(environment, args, symbolTable) {
-    return new this(environment, args, symbolTable);
+export function renderMacro(path, params, hash, builder) {
+  if (!params) {
+    params = [];
   }
-
-  constructor(environment, args, symbolTable) {
-    super();
-    this.definitionArgs = args;
-    this.definition = makeComponentDefinition;
-    this.args = ArgsSyntax.fromPositionalArgs(args.positional.slice(1, 2));
-    this.symbolTable = symbolTable;
-    this.shadow = null;
-  }
-
-  compile(builder) {
-    builder.component.dynamic(this.definitionArgs, this.definition, this.args, this.symbolTable, this.shadow);
-  }
+  let definitionArgs = [params.slice(0), hash, null, null];
+  let args = [params.slice(1), hash, null, null];
+  builder.component.dynamic(definitionArgs, makeComponentDefinition, args, builder.symbolTable);
+  return true;
 }
 
 class AbstractRenderManager extends AbstractManager {

--- a/packages/ember-glimmer/lib/template.js
+++ b/packages/ember-glimmer/lib/template.js
@@ -1,5 +1,5 @@
 import { OWNER } from 'ember-utils';
-import { templateFactory } from 'glimmer-runtime';
+import { templateFactory } from '@glimmer/runtime';
 
 export default function template(json) {
   let factory = templateFactory(json);

--- a/packages/ember-glimmer/lib/utils/bindings.js
+++ b/packages/ember-glimmer/lib/utils/bindings.js
@@ -3,8 +3,7 @@ import {
   combine,
   map,
   referenceFromParts
-} from 'glimmer-reference';
-import { HelperSyntax } from 'glimmer-runtime';
+} from '@glimmer/reference';
 import { get, assert } from 'ember-metal';
 import { String as StringUtils } from 'ember-runtime';
 import { ROOT_REF } from '../component';
@@ -30,20 +29,26 @@ function referenceForParts(component, parts) {
 }
 
 // TODO we should probably do this transform at build time
-export function wrapComponentClassAttribute(args) {
-  let { named } = args;
-  let index = named.keys.indexOf('class');
+export function wrapComponentClassAttribute(hash) {
+  if (!hash) {
+    return hash;
+  }
+
+  let [ keys, values ] = hash;
+  let index = keys.indexOf('class');
 
   if (index !== -1) {
-    let { ref, type } = named.values[index];
+    let [ type ] = values[index];
 
     if (type === 'get') {
-      let propName = ref.parts[ref.parts.length - 1];
-      named.values[index] = HelperSyntax.fromSpec(['helper', ['-class'], [['get', ref.parts], propName], null]);
+      let getExp = values[index];
+      let path = getExp[1];
+      let propName = path[path.length - 1];
+      hash[1][index] = ['helper', ['-class'], [getExp, propName]];
     }
   }
 
-  return args;
+  return hash;
 }
 
 export const AttributeBinding = {

--- a/packages/ember-glimmer/lib/utils/iterable.js
+++ b/packages/ember-glimmer/lib/utils/iterable.js
@@ -13,7 +13,7 @@ import {
   CONSTANT_TAG,
   UpdatableTag,
   combine
-} from 'glimmer-reference';
+} from '@glimmer/reference';
 
 const ITERATOR_KEY_GUID = 'be277757-bbbe-4620-9fcb-213ef433cca2';
 

--- a/packages/ember-glimmer/lib/utils/process-args.js
+++ b/packages/ember-glimmer/lib/utils/process-args.js
@@ -5,7 +5,7 @@ import {
 } from 'ember-utils';
 import {
   CONSTANT_TAG
-} from 'glimmer-reference';
+} from '@glimmer/reference';
 import { ARGS } from '../component';
 import { UPDATE } from './references';
 import { MUTABLE_CELL } from 'ember-views';
@@ -13,7 +13,7 @@ import { ACTION } from '../helpers/action';
 import {
   EvaluatedArgs,
   EvaluatedPositionalArgs
-} from 'glimmer-runtime';
+} from '@glimmer/runtime';
 
 // Maps all variants of positional and dynamically scoped arguments
 // into the named arguments. Input `args` and return value are both

--- a/packages/ember-glimmer/lib/utils/references.js
+++ b/packages/ember-glimmer/lib/utils/references.js
@@ -21,19 +21,19 @@ import {
   UpdatableTag,
   combine,
   isConst
-} from 'glimmer-reference';
+} from '@glimmer/reference';
 import {
   ConditionalReference as GlimmerConditionalReference,
   PrimitiveReference,
   NULL_REFERENCE,
   UNDEFINED_REFERENCE
-} from 'glimmer-runtime';
+} from '@glimmer/runtime';
 import emberToBool from './to-bool';
 import { RECOMPUTE_TAG } from '../helper';
 
 export const UPDATE = symbol('UPDATE');
 
-export { NULL_REFERENCE, UNDEFINED_REFERENCE } from 'glimmer-runtime';
+export { NULL_REFERENCE, UNDEFINED_REFERENCE } from '@glimmer/runtime';
 
 // @abstract
 // @implements PathReference

--- a/packages/ember-glimmer/lib/views/outlet.js
+++ b/packages/ember-glimmer/lib/views/outlet.js
@@ -3,7 +3,7 @@
 @submodule ember-glimmer
 */
 import { assign, EmptyObject } from 'ember-utils';
-import { DirtyableTag } from 'glimmer-reference';
+import { DirtyableTag } from '@glimmer/reference';
 import { environment } from 'ember-environment';
 import { OWNER } from 'ember-utils';
 import { run } from 'ember-metal';

--- a/packages/ember-glimmer/tests/integration/helpers/custom-helper-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/custom-helper-test.js
@@ -417,9 +417,9 @@ moduleFor('Helpers test: custom helpers', class extends RenderingTest {
   ['@test simple helper not usable within element']() {
     this.registerHelper('some-helper', () => {});
 
-    expectAssertion(() => {
+    this.assert.throws(() => {
       this.render(`<div {{some-helper}}></div>`);
-    }, /Helpers may not be used in the element form/);
+    }, /Compile Error some-helper is not a modifier: Helpers may not be used in the element form/);
   }
 
   ['@test class-based helper not usable within element']() {
@@ -428,9 +428,9 @@ moduleFor('Helpers test: custom helpers', class extends RenderingTest {
       }
     });
 
-    expectAssertion(() => {
+    this.assert.throws(() => {
       this.render(`<div {{some-helper}}></div>`);
-    }, /Helpers may not be used in the element form/);
+    }, /Compile Error some-helper is not a modifier: Helpers may not be used in the element form/);
   }
 
   ['@test class-based helper is torn down']() {

--- a/packages/ember-glimmer/tests/integration/helpers/debugger-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/debugger-test.js
@@ -3,7 +3,7 @@ import { Component } from '../../utils/helpers';
 import {
   setDebuggerCallback,
   resetDebuggerCallback
-} from '../../../helpers/debugger';
+} from '@glimmer/runtime';
 import { set } from 'ember-metal';
 import { A as emberA } from 'ember-runtime';
 
@@ -150,7 +150,7 @@ moduleFor('Helpers test: {{debugger}}', class extends RenderingTest {
           this.zomg = 'zomg';
         }
       }),
-      template: `{{debugger not.here}}foo-bar`
+      template: `{{debugger}}foo-bar`
     });
 
     this.expectDebuggerCallback(

--- a/packages/ember-glimmer/tests/unit/layout-cache-test.js
+++ b/packages/ember-glimmer/tests/unit/layout-cache-test.js
@@ -1,6 +1,6 @@
 import { EmptyObject } from 'ember-utils';
 import { RenderingTest, moduleFor } from '../utils/test-case';
-import { CompiledBlock } from 'glimmer-runtime';
+import { CompiledBlock } from '@glimmer/runtime';
 import { OWNER } from 'ember-utils';
 
 class Counter {

--- a/packages/ember-metal/lib/tags.js
+++ b/packages/ember-metal/lib/tags.js
@@ -1,4 +1,4 @@
-import { CONSTANT_TAG, DirtyableTag } from 'glimmer-reference';
+import { CONSTANT_TAG, DirtyableTag } from '@glimmer/reference';
 import { meta as metaFor } from './meta';
 import require from 'require';
 import { isProxy } from './is_proxy';

--- a/packages/ember-runtime/lib/mixins/-proxy.js
+++ b/packages/ember-runtime/lib/mixins/-proxy.js
@@ -3,7 +3,7 @@
 @submodule ember-runtime
 */
 
-import { CachedTag, DirtyableTag, UpdatableTag } from 'glimmer-reference';
+import { CachedTag, DirtyableTag, UpdatableTag } from '@glimmer/reference';
 import {
   assert,
   deprecate,

--- a/packages/ember-template-compiler/lib/system/precompile.js
+++ b/packages/ember-template-compiler/lib/system/precompile.js
@@ -19,8 +19,8 @@ let glimmerPrecompile;
   @param {String} templateString This is the string to be compiled by HTMLBars.
 */
 export default function precompile(templateString, options) {
-  if (!glimmerPrecompile && has('glimmer-compiler')) {
-    glimmerPrecompile = require('glimmer-compiler').precompile;
+  if (!glimmerPrecompile && has('@glimmer/compiler')) {
+    glimmerPrecompile = require('@glimmer/compiler').precompile;
   }
 
   if (!glimmerPrecompile) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -51,7 +51,7 @@
   dependencies:
     "@glimmer/util" "^0.21.0"
 
-"@glimmer/runtime@^0.21.0", "@glimmer/runtime@^0.21.1":
+"@glimmer/runtime@^0.21.1":
   version "0.21.1"
   resolved "https://registry.yarnpkg.com/@glimmer/runtime/-/runtime-0.21.1.tgz#ae7207a9930ce0c26203dbc626d53c2fe78f8204"
   dependencies:
@@ -93,7 +93,7 @@
   dependencies:
     "@glimmer/util" "^0.21.0"
 
-abbrev@1, abbrev@1.0.x, abbrev@~1.0.9:
+abbrev@1, abbrev@~1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
 
@@ -260,10 +260,6 @@ argparse@^1.0.7, argparse@~1.0.2:
   dependencies:
     sprintf-js "~1.0.2"
 
-argsparser@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/argsparser/-/argsparser-0.0.6.tgz#ff45eb5b92c004225cf146a51d339dccb265be63"
-
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -371,10 +367,6 @@ async-disk-cache@^1.0.0:
     rimraf "^2.5.3"
     rsvp "^3.0.18"
 
-async@0.2.x, async@~0.2.6, async@~0.2.9:
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
-
 async@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/async/-/async-2.0.1.tgz#b709cc0280a9c36f09f4536be823c838a9049e25"
@@ -390,6 +382,10 @@ async@^2.0.0, async@^2.0.1, async@^2.1.2:
   resolved "https://registry.yarnpkg.com/async/-/async-2.1.4.tgz#2d2160c7788032e4dd6cbe2502f1f9a2c8f6cde4"
   dependencies:
     lodash "^4.14.0"
+
+async@~0.2.6, async@~0.2.9:
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
 
 async@~0.9.0:
   version "0.9.2"
@@ -763,7 +759,7 @@ broccoli-clean-css@^1.1.0:
     inline-source-map-comment "^1.0.5"
     json-stable-stringify "^1.0.0"
 
-broccoli-concat@^2.0.0, broccoli-concat@^2.1.0:
+broccoli-concat@^2.0.0:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/broccoli-concat/-/broccoli-concat-2.3.8.tgz#590cdcc021bb905b6c121d87c2d1d57df44a2a48"
   dependencies:
@@ -816,24 +812,11 @@ broccoli-file-creator@^1.0.0:
     rsvp "~3.0.6"
     symlink-or-copy "^1.0.1"
 
-broccoli-filter@^0.1.6:
-  version "0.1.14"
-  resolved "https://registry.yarnpkg.com/broccoli-filter/-/broccoli-filter-0.1.14.tgz#23cae3891ff9ebb7b4d7db00c6dcf03535daf7ad"
-  dependencies:
-    broccoli-kitchen-sink-helpers "^0.2.6"
-    broccoli-writer "^0.1.1"
-    mkdirp "^0.3.5"
-    promise-map-series "^0.2.1"
-    quick-temp "^0.1.2"
-    rsvp "^3.0.16"
-    symlink-or-copy "^1.0.1"
-    walk-sync "^0.1.3"
-
 broccoli-funnel-reducer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
 
-broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.2, broccoli-funnel@^1.0.6:
+broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.1.0.tgz#dfb91a37c902456456de4a40a1881948d65b27d9"
   dependencies:
@@ -983,34 +966,6 @@ broccoli-string-replace@0.1.1, broccoli-string-replace@^0.1.1:
     broccoli-persistent-filter "^1.1.5"
     minimatch "^2.0.8"
 
-broccoli-tslinter@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/broccoli-tslinter/-/broccoli-tslinter-2.0.0.tgz#0c155f2cdef7f979a55f3bebebc16b6e2afbe546"
-  dependencies:
-    broccoli-persistent-filter "^1.2.0"
-    chalk "^1.1.1"
-    exists-sync "0.0.3"
-
-broccoli-typescript-compiler@^0.6.0:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/broccoli-typescript-compiler/-/broccoli-typescript-compiler-0.6.2.tgz#dc26bce755787d2ba0f765da082bb2f6236a3ce7"
-  dependencies:
-    broccoli-funnel "^1.0.2"
-    broccoli-merge-trees "^1.1.1"
-    broccoli-persistent-filter "^1.0.1"
-    clone "^0.2.0"
-    findup "^0.1.5"
-    get-caller-file "^1.0.1"
-    json-stable-stringify "^1.0.0"
-    walk-sync "^0.2.6"
-
-broccoli-uglify-js@~0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/broccoli-uglify-js/-/broccoli-uglify-js-0.1.3.tgz#927621ea62cc2e63c2550ed95f4f508e7ab05238"
-  dependencies:
-    broccoli-filter "^0.1.6"
-    uglify-js "~2.4.11"
-
 broccoli-uglify-sourcemap@^1.0.1, broccoli-uglify-sourcemap@^1.4.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/broccoli-uglify-sourcemap/-/broccoli-uglify-sourcemap-1.5.1.tgz#9fd2e87f1c177b11a758e73c3a11d6a03d90d086"
@@ -1025,7 +980,7 @@ broccoli-uglify-sourcemap@^1.0.1, broccoli-uglify-sourcemap@^1.4.2:
     uglify-js "^2.7.0"
     walk-sync "^0.1.3"
 
-broccoli-writer@^0.1.1, broccoli-writer@~0.1.1:
+broccoli-writer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/broccoli-writer/-/broccoli-writer-0.1.1.tgz#d4d71aa8f2afbc67a3866b91a2da79084b96ab2d"
   dependencies:
@@ -1244,7 +1199,7 @@ cli-table2@^0.2.0:
   optionalDependencies:
     colors "^1.1.2"
 
-cli-table@^0.3.0, cli-table@^0.3.1:
+cli-table@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.1.tgz#f53b05266a8b1a0b934b3d0821e6e2dc5914ae23"
   dependencies:
@@ -1287,10 +1242,6 @@ cmd-shim@~2.0.2:
   dependencies:
     graceful-fs "^4.1.2"
     mkdirp "~0.5.0"
-
-co@^3.0.6:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/co/-/co-3.1.0.tgz#4ea54ea5a08938153185e15210c68d9092bc1b78"
 
 co@^4.6.0:
   version "4.6.0"
@@ -2043,31 +1994,6 @@ emberjs-build@0.19.0:
     json-stable-stringify "^1.0.1"
     lodash "^3.10.1"
 
-emberjs-build@chadhietala/emberjs-build#allow-interators:
-  version "0.19.0"
-  resolved "https://codeload.github.com/chadhietala/emberjs-build/tar.gz/700f74f7d1479d96ba85d64c2d9e9023885c3b29"
-  dependencies:
-    amd-name-resolver "0.0.4"
-    broccoli "0.16.3"
-    broccoli-babel-transpiler "^5.6.1"
-    broccoli-concat "^2.0.0"
-    broccoli-file-creator "^1.0.0"
-    broccoli-funnel "^1.0.1"
-    broccoli-kitchen-sink-helpers "^0.2.6"
-    broccoli-lint-eslint "^3.2.0"
-    broccoli-merge-trees "^1.1.1"
-    broccoli-persistent-filter "^1.0.8"
-    broccoli-source "^1.1.0"
-    broccoli-stew "^1.1.1"
-    broccoli-string-replace "0.1.1"
-    broccoli-uglify-sourcemap "^1.0.1"
-    core-object "0.0.4"
-    ember-cli-yuidoc " 0.8.4"
-    git-repo-version "0.3.0"
-    js-string-escape "^1.0.0"
-    json-stable-stringify "^1.0.1"
-    lodash "^3.10.1"
-
 encodeurl@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.1.tgz#79e3d58655346909fe6f0f45a5de68103b294d20"
@@ -2202,16 +2128,6 @@ escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
-escodegen@1.2.x:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.2.0.tgz#09de7967791cc958b7f89a2ddb6d23451af327e1"
-  dependencies:
-    esprima "~1.0.4"
-    estraverse "~1.5.0"
-    esutils "~1.0.0"
-  optionalDependencies:
-    source-map "~0.1.30"
-
 escope@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
@@ -2279,14 +2195,6 @@ esprima@^2.6.0:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
 
-"esprima@git://github.com/ariya/esprima.git#harmony":
-  version "1.1.0-dev-harmony"
-  resolved "git://github.com/ariya/esprima.git#a65a3eb93b9a5dce9a1184ca2d1bd0b184c6b8fd"
-
-esprima@~1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.0.4.tgz#9f557e08fc3b4d26ece9dd34f8fbf476b62585ad"
-
 esprima@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.0.0.tgz#53cf247acda77313e551c3aa2e73342d3fb4f7d9"
@@ -2306,10 +2214,6 @@ estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
-estraverse@~1.5.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.5.1.tgz#867a3e8e58a9f84618afb6c2ddbcd916b7cbaf71"
-
 estraverse@~4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.1.1.tgz#f6caca728933a850ef90661d0e17982ba47111a2"
@@ -2317,10 +2221,6 @@ estraverse@~4.1.0:
 esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
-
-esutils@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-1.0.0.tgz#8151d358e20c8acc7fb745e7472c0025fe496570"
 
 etag@~1.7.0:
   version "1.7.0"
@@ -2486,13 +2386,6 @@ file-entry-cache@^2.0.0:
 filename-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.0.tgz#996e3e80479b98b9897f15a8a58b3d084e926775"
-
-fileset@0.1.x:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/fileset/-/fileset-0.1.8.tgz#506b91a9396eaa7e32fb42a84077c7a0c736b741"
-  dependencies:
-    glob "3.x"
-    minimatch "0.x"
 
 filesize@^3.1.3:
   version "3.3.0"
@@ -2764,7 +2657,7 @@ generate-object-property@^1.1.0:
   dependencies:
     is-property "^1.0.0"
 
-get-caller-file@^1.0.0, get-caller-file@^1.0.1:
+get-caller-file@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
@@ -2794,12 +2687,6 @@ git-repo-version@0.3.0:
   dependencies:
     git-repo-info "^1.0.4"
 
-git-repo-version@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/git-repo-version/-/git-repo-version-0.1.2.tgz#8dd89fc818034a5341e1b0fae12f312c2ac4e505"
-  dependencies:
-    git-repo-info "^1.0.4"
-
 git-repo-version@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/git-repo-version/-/git-repo-version-0.3.1.tgz#829a24d5973716dae90e222a148fb5ded9492092"
@@ -2811,25 +2698,6 @@ github@^0.2.3:
   resolved "https://registry.yarnpkg.com/github/-/github-0.2.4.tgz#24fa7f0e13fa11b946af91134c51982a91ce538b"
   dependencies:
     mime "^1.2.11"
-
-glimmer-engine@^0.20.0:
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/glimmer-engine/-/glimmer-engine-0.20.0.tgz#fb2ad96a34df6a712d7f0e8d84043d08ec994388"
-  dependencies:
-    broccoli-concat "^2.1.0"
-    broccoli-funnel "^1.0.1"
-    broccoli-merge-trees "^1.1.1"
-    broccoli-stew "^1.2.0"
-    broccoli-tslinter "^2.0.0"
-    broccoli-typescript-compiler "^0.6.0"
-    broccoli-uglify-js "~0.1.3"
-    emberjs-build chadhietala/emberjs-build#allow-interators
-    exists-sync "0.0.3"
-    git-repo-version "^0.1.2"
-    handlebars "^3.0.2"
-    qunit "^0.9.1"
-    simple-dom "^0.3.0"
-    simple-html-tokenizer "^0.2.5"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -2844,7 +2712,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@3.2.11, glob@3.x:
+glob@3.2.11:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/glob/-/glob-3.2.11.tgz#4a973f635b9190f715d10987d5c00fd2815ebe3d"
   dependencies:
@@ -2979,15 +2847,7 @@ growly@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
 
-handlebars@1.3.x:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-1.3.0.tgz#9e9b130a93e389491322d975cf3ec1818c37ce34"
-  dependencies:
-    optimist "~0.3"
-  optionalDependencies:
-    uglify-js "~2.3"
-
-handlebars@^3.0.1, handlebars@^3.0.2, handlebars@^3.0.3, handlebars@~3:
+handlebars@^3.0.1, handlebars@^3.0.3, handlebars@~3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-3.0.3.tgz#0e09651a2f0fb3c949160583710d551f92e6d2ad"
   dependencies:
@@ -3456,23 +3316,6 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-"istanbul@https://github.com/gotwarlost/istanbul/tarball/harmony":
-  version "0.2.5"
-  resolved "https://github.com/gotwarlost/istanbul/tarball/harmony#02dabfd3743b695942d170a809171d3924466331"
-  dependencies:
-    abbrev "1.0.x"
-    async "0.2.x"
-    escodegen "1.2.x"
-    esprima "git://github.com/ariya/esprima.git#harmony"
-    fileset "0.1.x"
-    handlebars "1.3.x"
-    js-yaml "3.x"
-    mkdirp "0.3.x"
-    nopt "2.2.x"
-    resolve "0.6.x"
-    which "1.0.x"
-    wordwrap "0.0.x"
-
 istextorbinary@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/istextorbinary/-/istextorbinary-2.1.0.tgz#dbed2a6f51be2f7475b68f89465811141b758874"
@@ -3514,7 +3357,7 @@ js-tokens@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-2.0.0.tgz#79903f5563ee778cc1162e6dcf1a0027c97f9cb5"
 
-js-yaml@3.x, js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.5.1, js-yaml@^3.6.1:
+js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.5.1, js-yaml@^3.6.1:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
   dependencies:
@@ -4048,7 +3891,7 @@ mime@~1.2.11:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.2.11.tgz#58203eed86e3a5ef17aed2b7d9ebd47f0a60dd10"
 
-minimatch@0.3, minimatch@0.x:
+minimatch@0.3:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-0.3.0.tgz#275d8edaac4f1bb3326472089e7949c8394699dd"
   dependencies:
@@ -4089,7 +3932,7 @@ minimist@^1.1.0, minimist@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-mkdirp@0.3.0, mkdirp@0.3.x:
+mkdirp@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
 
@@ -4099,7 +3942,7 @@ mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdi
   dependencies:
     minimist "0.0.8"
 
-mkdirp@^0.3.5, mkdirp@~0.3.5:
+mkdirp@~0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.5.tgz#de3e5f8961c88c787ee1368df849ac4413eca8d7"
 
@@ -4231,12 +4074,6 @@ node-uuid@^1.4.3, node-uuid@~1.4.0, node-uuid@~1.4.7:
 "nopt@2 || 3", nopt@^3.0.1, nopt@~3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
-  dependencies:
-    abbrev "1"
-
-nopt@2.2.x:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-2.2.1.tgz#2aa09b7d1768487b3b89a9c5aa52335bff0baea7"
   dependencies:
     abbrev "1"
 
@@ -4452,7 +4289,7 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-optimist@~0.3, optimist@~0.3.5:
+optimist@~0.3.5:
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.3.7.tgz#c90941ad59e4273328923074d2cf2e7cbc6ec0d9"
   dependencies:
@@ -4704,23 +4541,6 @@ qunit-extras@^1.5.0:
 qunit-phantomjs-runner@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/qunit-phantomjs-runner/-/qunit-phantomjs-runner-2.2.0.tgz#557a0f55d7d83c315312d1b7048ed972ffea4549"
-
-qunit@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/qunit/-/qunit-0.9.1.tgz#a985244d140fa5715c1b88b42dc4ebed8519a265"
-  dependencies:
-    argsparser "^0.0.6"
-    cli-table "^0.3.0"
-    co "^3.0.6"
-    qunitjs "1.10.0"
-    tracejs "^0.1.8"
-    underscore "^1.6.0"
-  optionalDependencies:
-    istanbul "https://github.com/gotwarlost/istanbul/tarball/harmony"
-
-qunitjs@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/qunitjs/-/qunitjs-1.10.0.tgz#a01918dad03476557254f40bc02a2fc66d76af78"
 
 qunitjs@^1.22.0:
   version "1.23.1"
@@ -5042,10 +4862,6 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
-resolve@0.6.x:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-0.6.3.tgz#dd957982e7e736debdf53b58a4dd91754575dd46"
-
 resolve@^1.1.2, resolve@^1.1.6, resolve@^1.1.7:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.2.0.tgz#9589c3f2f6149d1417a40becc1663db6ec6bc26c"
@@ -5267,10 +5083,6 @@ simple-fmt@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/simple-fmt/-/simple-fmt-0.1.0.tgz#191bf566a59e6530482cb25ab53b4a8dc85c3a6b"
 
-simple-html-tokenizer@^0.2.5:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.2.6.tgz#a6efab7bc705cf3a96f1aaeaa1a76365f0d16c33"
-
 simple-html-tokenizer@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.3.0.tgz#9b8b5559d80e331a544dd13dd59382e5d0d94411"
@@ -5383,19 +5195,13 @@ source-map@0.1.32:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@0.1.34:
-  version "0.1.34"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.34.tgz#a7cfe89aec7b1682c3b198d0acfb47d7d090566b"
-  dependencies:
-    amdefine ">=0.0.4"
-
 source-map@0.4.x, source-map@^0.4.2, source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.1.40, source-map@~0.1.30, source-map@~0.1.7:
+source-map@^0.1.40, source-map@~0.1.7:
   version "0.1.43"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
   dependencies:
@@ -5694,10 +5500,6 @@ tough-cookie@>=0.12.0, tough-cookie@~2.3.0:
   dependencies:
     punycode "^1.4.1"
 
-tracejs@^0.1.8:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/tracejs/-/tracejs-0.1.8.tgz#6c26787b1853f1371634622c1c80bc44026c5d70"
-
 tree-sync@^1.1.4:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/tree-sync/-/tree-sync-1.2.1.tgz#35619b7c310f5dfb4091601c013e8a72da67937a"
@@ -5778,15 +5580,6 @@ uglify-js@~2.3:
     optimist "~0.3.5"
     source-map "~0.1.7"
 
-uglify-js@~2.4.11:
-  version "2.4.24"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.4.24.tgz#fad5755c1e1577658bb06ff9ab6e548c95bebd6e"
-  dependencies:
-    async "~0.2.6"
-    source-map "0.1.34"
-    uglify-to-browserify "~1.0.0"
-    yargs "~3.5.4"
-
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
@@ -5814,7 +5607,7 @@ underscore.string@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.3.3.tgz#71c08bf6b428b1133f37e78fa3a21c82f7329b0d"
 
-underscore@>=1.8.3, underscore@^1.6.0:
+underscore@>=1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
@@ -5913,7 +5706,7 @@ walk-sync@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.1.3.tgz#8a07261a00bda6cfb1be25e9f100fad57546f583"
 
-walk-sync@^0.2.0, walk-sync@^0.2.5, walk-sync@^0.2.6, walk-sync@^0.2.7:
+walk-sync@^0.2.0, walk-sync@^0.2.5, walk-sync@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.2.7.tgz#b49be4ee6867657aeb736978b56a29d10fa39969"
   dependencies:
@@ -5971,10 +5764,6 @@ which@1, which@^1.0.5, which@^1.2.12, which@^1.2.9, which@~1.2.11:
   dependencies:
     isexe "^1.1.1"
 
-which@1.0.x:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.0.9.tgz#460c1da0f810103d0321a9b633af9e575e64486f"
-
 wide-align@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.0.tgz#40edde802a71fea1f070da3e62dcda2e7add96ad"
@@ -5989,7 +5778,7 @@ window-size@^0.1.2:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.4.tgz#f8e1aa1ee5a53ec5bf151ffa09742a6ad7697876"
 
-wordwrap@0.0.2, wordwrap@0.0.x, wordwrap@~0.0.2:
+wordwrap@0.0.2, wordwrap@~0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
 
@@ -6091,15 +5880,6 @@ yargs@~3.27.0:
     os-locale "^1.4.0"
     window-size "^0.1.2"
     y18n "^3.2.0"
-
-yargs@~3.5.4:
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.5.4.tgz#d8aff8f665e94c34bd259bdebd1bfaf0ddd35361"
-  dependencies:
-    camelcase "^1.0.2"
-    decamelize "^1.0.0"
-    window-size "0.1.0"
-    wordwrap "0.0.2"
 
 yeast@0.1.2:
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,96 @@
 # yarn lockfile v1
 
 
-"JSV@>= 4.0.x":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/JSV/-/JSV-4.0.2.tgz#d077f6825571f82132f9dffaed587b4029feff57"
+"@glimmer/compiler@^0.21.1":
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.21.1.tgz#0f248c0a39928a0940dbce1129c4e3352534096b"
+  dependencies:
+    "@glimmer/syntax" "^0.21.1"
+    "@glimmer/util" "^0.21.0"
+    "@glimmer/wire-format" "^0.21.0"
+    simple-html-tokenizer "^0.3.0"
+
+"@glimmer/interfaces@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.21.0.tgz#386b2c5bbe5bf6f54eda014937adf2e3927571bf"
+  dependencies:
+    "@glimmer/wire-format" "^0.21.0"
+
+"@glimmer/node@^0.21.1":
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/node/-/node-0.21.1.tgz#31690f141542ffca685fad497aaee49c44687763"
+  dependencies:
+    "@glimmer/runtime" "^0.21.1"
+    simple-dom "^0.3.0"
+
+"@glimmer/object-model@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/object-model/-/object-model-0.21.0.tgz#dba8779bbf7c57179b46e999ec6441d72b013a6a"
+  dependencies:
+    "@glimmer/reference" "^0.21.0"
+    "@glimmer/util" "^0.21.0"
+
+"@glimmer/object-reference@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/object-reference/-/object-reference-0.21.0.tgz#3feac2c4d700034bb27034a9e973a6113f0c7cfe"
+  dependencies:
+    "@glimmer/reference" "^0.21.0"
+    "@glimmer/util" "^0.21.0"
+
+"@glimmer/object@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/object/-/object-0.21.0.tgz#2ac659c0611fdd22da60b13e0a8c34665ab9b352"
+  dependencies:
+    "@glimmer/object-reference" "^0.21.0"
+    "@glimmer/util" "^0.21.0"
+
+"@glimmer/reference@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.21.0.tgz#8719a7a942654a33db7e6b1556fc06fac39e98c8"
+  dependencies:
+    "@glimmer/util" "^0.21.0"
+
+"@glimmer/runtime@^0.21.0", "@glimmer/runtime@^0.21.1":
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/runtime/-/runtime-0.21.1.tgz#ae7207a9930ce0c26203dbc626d53c2fe78f8204"
+  dependencies:
+    "@glimmer/interfaces" "^0.21.0"
+    "@glimmer/object" "^0.21.0"
+    "@glimmer/object-reference" "^0.21.0"
+    "@glimmer/reference" "^0.21.0"
+    "@glimmer/util" "^0.21.0"
+    "@glimmer/wire-format" "^0.21.0"
+
+"@glimmer/syntax@^0.21.1":
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.21.1.tgz#020c7b5816bbdc0004c663fe3c51856e6d86ed62"
+  dependencies:
+    handlebars "^3.0.3"
+    simple-html-tokenizer "^0.3.0"
+
+"@glimmer/test-helpers@^0.21.1":
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/test-helpers/-/test-helpers-0.21.1.tgz#c113e542a6205fd54c6c736c6e50475ea1e1947a"
+  dependencies:
+    "@glimmer/compiler" "^0.21.1"
+    "@glimmer/interfaces" "^0.21.0"
+    "@glimmer/object" "^0.21.0"
+    "@glimmer/object-model" "^0.21.0"
+    "@glimmer/object-reference" "^0.21.0"
+    "@glimmer/reference" "^0.21.0"
+    "@glimmer/runtime" "^0.21.1"
+    "@glimmer/util" "^0.21.0"
+    "@glimmer/wire-format" "^0.21.0"
+
+"@glimmer/util@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.21.0.tgz#86c1e972e2f777f5af664b59c5bc037b71e9ef00"
+
+"@glimmer/wire-format@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.21.0.tgz#ec97adafaf6d1bbd4d1fcf0cbd0a9df2784a22d5"
+  dependencies:
+    "@glimmer/util" "^0.21.0"
 
 abbrev@1, abbrev@1.0.x, abbrev@~1.0.9:
   version "1.0.9"
@@ -109,10 +196,6 @@ ansi-styles@^2.0.1, ansi-styles@^2.1.0, ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
-
 ansicolors@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.2.1.tgz#be089599097b74a5c9c4a84a0cdbcdb62bd87aef"
@@ -171,7 +254,7 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.0 || ^1.1.13"
 
-argparse@^1.0.2, argparse@^1.0.7, argparse@~1.0.2:
+argparse@^1.0.7, argparse@~1.0.2:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
   dependencies:
@@ -344,7 +427,7 @@ babel-code-frame@^6.16.0:
     esutils "^2.0.2"
     js-tokens "^2.0.0"
 
-babel-core@^5.0.0, babel-core@~5.8.3:
+babel-core@^5.0.0:
   version "5.8.38"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-5.8.38.tgz#1fcaee79d7e61b750b00b8e54f6dfc9d0af86558"
   dependencies:
@@ -394,13 +477,6 @@ babel-core@^5.0.0, babel-core@~5.8.3:
     to-fast-properties "^1.0.0"
     trim-right "^1.0.0"
     try-resolve "^1.0.0"
-
-babel-jscs@^2.0.0:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/babel-jscs/-/babel-jscs-2.0.5.tgz#0a347046b48145acbca56e8c8ed5f736bc54f9d0"
-  dependencies:
-    babel-core "~5.8.3"
-    lodash.assign "^3.2.0"
 
 babel-plugin-constant-folding@^1.0.1:
   version "1.0.1"
@@ -776,31 +852,6 @@ broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.2, broccoli
     symlink-or-copy "^1.0.0"
     walk-sync "^0.3.1"
 
-broccoli-jscs@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/broccoli-jscs/-/broccoli-jscs-1.4.1.tgz#075bfff902274db8b5ea7b4514b5b78973a76909"
-  dependencies:
-    broccoli-funnel "^1.0.1"
-    broccoli-merge-trees "^1.1.1"
-    broccoli-persistent-filter "^1.0.0"
-    ember-cli-version-checker "^1.0.2"
-    findup-sync "^0.4.0"
-    js-string-escape "^1.0.0"
-    jscs "^2.0.0"
-    json-stable-stringify "^1.0.0"
-    minimatch "^3.0.0"
-
-broccoli-jshint@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/broccoli-jshint/-/broccoli-jshint-1.2.0.tgz#8cd565d11a04bfd32cb8f85a0f7ede1e5be7a6a2"
-  dependencies:
-    broccoli-persistent-filter "^1.2.0"
-    chalk "~0.4.0"
-    findup-sync "^0.3.0"
-    jshint "^2.7.0"
-    json-stable-stringify "^1.0.0"
-    mkdirp "~0.4.0"
-
 broccoli-kitchen-sink-helpers@^0.2.5, broccoli-kitchen-sink-helpers@^0.2.6, broccoli-kitchen-sink-helpers@~0.2.0:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz#a5e0986ed8d76fb5984b68c3f0450d3a96e36ecc"
@@ -846,7 +897,7 @@ broccoli-middleware@^0.18.1:
     handlebars "^4.0.4"
     mime "^1.2.11"
 
-broccoli-persistent-filter@^1.0.0, broccoli-persistent-filter@^1.0.1, broccoli-persistent-filter@^1.0.8, broccoli-persistent-filter@^1.1.5, broccoli-persistent-filter@^1.1.6, broccoli-persistent-filter@^1.2.0:
+broccoli-persistent-filter@^1.0.1, broccoli-persistent-filter@^1.0.8, broccoli-persistent-filter@^1.1.5, broccoli-persistent-filter@^1.1.6, broccoli-persistent-filter@^1.2.0:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/broccoli-persistent-filter/-/broccoli-persistent-filter-1.2.11.tgz#95cc6b0b0eb0dcce5f8e6ae18f6a3cc45a06bf40"
   dependencies:
@@ -932,15 +983,13 @@ broccoli-string-replace@0.1.1, broccoli-string-replace@^0.1.1:
     broccoli-persistent-filter "^1.1.5"
     minimatch "^2.0.8"
 
-broccoli-tslinter@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/broccoli-tslinter/-/broccoli-tslinter-1.0.2.tgz#de4b79e556c57543148b724a9e63dad5a3eadf80"
+broccoli-tslinter@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-tslinter/-/broccoli-tslinter-2.0.0.tgz#0c155f2cdef7f979a55f3bebebc16b6e2afbe546"
   dependencies:
     broccoli-persistent-filter "^1.2.0"
     chalk "^1.1.1"
     exists-sync "0.0.3"
-    tslint "^3.5.0"
-    typescript "^1.8.7"
 
 broccoli-typescript-compiler@^0.6.0:
   version "0.6.2"
@@ -1129,7 +1178,7 @@ chalk@^0.5.1:
     strip-ansi "^0.3.0"
     supports-color "^0.2.0"
 
-chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3, chalk@~1.1.0:
+chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -1138,14 +1187,6 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3, chalk@~1.1.0:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
-
-chalk@~0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
-  dependencies:
-    ansi-styles "~1.0.0"
-    has-color "~0.1.0"
-    strip-ansi "~0.1.0"
 
 charm@^1.0.0:
   version "1.0.2"
@@ -1203,7 +1244,7 @@ cli-table2@^0.2.0:
   optionalDependencies:
     colors "^1.1.2"
 
-cli-table@^0.3.0, cli-table@^0.3.1, cli-table@~0.3.1:
+cli-table@^0.3.0, cli-table@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.1.tgz#f53b05266a8b1a0b934b3d0821e6e2dc5914ae23"
   dependencies:
@@ -1219,13 +1260,6 @@ cli-usage@^0.1.1:
 cli-width@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.1.0.tgz#b234ca209b29ef66fc518d9b98d5847b00edf00a"
-
-cli@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/cli/-/cli-1.0.1.tgz#22817534f24bfa4950c34d532d48ecbc621b8c14"
-  dependencies:
-    exit "0.1.2"
-    glob "^7.1.1"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -1272,10 +1306,6 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-colors@0.6.x, colors@~0.6.0-1:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-0.6.2.tgz#2423fe6678ac0c5dae8852e5d0e5be08c997abcc"
-
 colors@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
@@ -1283,6 +1313,10 @@ colors@1.0.3:
 colors@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
+
+colors@~0.6.0-1:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-0.6.2.tgz#2423fe6678ac0c5dae8852e5d0e5be08c997abcc"
 
 columnify@~1.5.4:
   version "1.5.4"
@@ -1317,7 +1351,7 @@ commander@2.8.x:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@^2.5.0, commander@^2.6.0, commander@^2.9.0, commander@~2.9.0:
+commander@^2.5.0, commander@^2.6.0, commander@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -1326,12 +1360,6 @@ commander@^2.5.0, commander@^2.6.0, commander@^2.9.0, commander@~2.9.0:
 commander@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.1.0.tgz#d121bbae860d9992a3d517ba96f56588e47c6781"
-
-comment-parser@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-0.3.1.tgz#fd657aac8c1492d308c9a6100fc9b49d2435aba1"
-  dependencies:
-    readable-stream "^2.0.4"
 
 commoner@~0.10.3:
   version "0.10.8"
@@ -1431,12 +1459,6 @@ connect@^3.3.3:
     parseurl "~1.3.1"
     utils-merge "1.0.0"
 
-console-browserify@1.1.x:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10"
-  dependencies:
-    date-now "^0.1.4"
-
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
@@ -1530,10 +1552,6 @@ ctype@0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/ctype/-/ctype-0.5.3.tgz#82c18c2461f74114ef16c135224ad0b9144ca12f"
 
-cycle@1.0.x:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/cycle/-/cycle-1.0.3.tgz#21e80b2be8580f98b468f379430662b046c34ad2"
-
 d@^0.1.1, d@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/d/-/d-0.1.1.tgz#da184c535d18d8ee7ba2aa229b914009fae11309"
@@ -1549,10 +1567,6 @@ dashdash@^1.12.0:
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
-
-date-now@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
 debug@2, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0:
   version "2.5.2"
@@ -1585,10 +1599,6 @@ deep-eql@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
   dependencies:
     type-detect "0.1.1"
-
-deep-equal@*:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -1687,44 +1697,12 @@ diff@1.4.0, diff@^1.3.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
 
-diff@^2.2.1:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-2.2.3.tgz#60eafd0d28ee906e4e8ff0a52c1229521033bf99"
-
 doctrine@^1.2.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
   dependencies:
     esutils "^2.0.2"
     isarray "^1.0.0"
-
-dom-serializer@0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
-  dependencies:
-    domelementtype "~1.1.1"
-    entities "~1.1.1"
-
-domelementtype@1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
-
-domelementtype@~1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
-
-domhandler@2.3:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.3.0.tgz#2de59a0822d5027fabff6f032c2b25a2a8abe738"
-  dependencies:
-    domelementtype "1"
-
-domutils@1.5:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
 
 dot-prop@^3.0.0:
   version "3.0.0"
@@ -2065,9 +2043,9 @@ emberjs-build@0.19.0:
     json-stable-stringify "^1.0.1"
     lodash "^3.10.1"
 
-emberjs-build@^0.15.0:
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/emberjs-build/-/emberjs-build-0.15.2.tgz#5904f0e439e8aeb9f0ad5d254fe8ad1236a0e040"
+emberjs-build@chadhietala/emberjs-build#allow-interators:
+  version "0.19.0"
+  resolved "https://codeload.github.com/chadhietala/emberjs-build/tar.gz/700f74f7d1479d96ba85d64c2d9e9023885c3b29"
   dependencies:
     amd-name-resolver "0.0.4"
     broccoli "0.16.3"
@@ -2075,9 +2053,8 @@ emberjs-build@^0.15.0:
     broccoli-concat "^2.0.0"
     broccoli-file-creator "^1.0.0"
     broccoli-funnel "^1.0.1"
-    broccoli-jscs "^1.4.1"
-    broccoli-jshint "^1.1.0"
     broccoli-kitchen-sink-helpers "^0.2.6"
+    broccoli-lint-eslint "^3.2.0"
     broccoli-merge-trees "^1.1.1"
     broccoli-persistent-filter "^1.0.8"
     broccoli-source "^1.1.0"
@@ -2149,10 +2126,6 @@ engine.io@1.8.0:
 ensure-posix-path@^1.0.0, ensure-posix-path@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ensure-posix-path/-/ensure-posix-path-1.0.2.tgz#a65b3e42d0b71cfc585eb774f9943c8d9b91b0c2"
-
-entities@1.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-1.0.0.tgz#b2987aa3821347fcde642b24fdfc9e4fb712bf26"
 
 entities@~1.1.1:
   version "1.1.1"
@@ -2239,7 +2212,7 @@ escodegen@1.2.x:
   optionalDependencies:
     source-map "~0.1.30"
 
-escope@^3.2.0, escope@^3.6.0:
+escope@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
   dependencies:
@@ -2302,7 +2275,7 @@ esprima-fb@~15001.1001.0-dev-harmony-fb:
   version "15001.1001.0-dev-harmony-fb"
   resolved "https://registry.yarnpkg.com/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz#43beb57ec26e8cf237d3dd8b33e42533577f2659"
 
-esprima@^2.6.0, esprima@~2.7.0:
+esprima@^2.6.0:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
 
@@ -2329,7 +2302,7 @@ esrecurse@^4.1.0:
     estraverse "~4.1.0"
     object-assign "^4.0.1"
 
-estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
@@ -2386,7 +2359,7 @@ exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
 
-exit@0.1.2, exit@0.1.x, exit@^0.1.2, exit@~0.1.2:
+exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
 
@@ -2460,10 +2433,6 @@ extglob@^0.3.1:
 extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
-
-eyes@0.1.x:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -2571,13 +2540,7 @@ findup-sync@^0.2.1:
   dependencies:
     glob "~4.3.0"
 
-findup-sync@^0.3.0, findup-sync@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-0.3.0.tgz#37930aa5d816b777c03445e1966cc6790a4c0b16"
-  dependencies:
-    glob "~5.0.0"
-
-findup-sync@^0.4.0, findup-sync@^0.4.2:
+findup-sync@^0.4.2:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-0.4.3.tgz#40043929e7bc60adf0b7f4827c4c6e75a0deca12"
   dependencies:
@@ -2849,25 +2812,24 @@ github@^0.2.3:
   dependencies:
     mime "^1.2.11"
 
-glimmer-engine@^0.19.4:
-  version "0.19.4"
-  resolved "https://registry.yarnpkg.com/glimmer-engine/-/glimmer-engine-0.19.4.tgz#7dc29f30efa4ab4682e8131e0418dcc3ba3dc8e3"
+glimmer-engine@^0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/glimmer-engine/-/glimmer-engine-0.20.0.tgz#fb2ad96a34df6a712d7f0e8d84043d08ec994388"
   dependencies:
     broccoli-concat "^2.1.0"
     broccoli-funnel "^1.0.1"
     broccoli-merge-trees "^1.1.1"
     broccoli-stew "^1.2.0"
-    broccoli-tslinter "^1.0.2"
+    broccoli-tslinter "^2.0.0"
     broccoli-typescript-compiler "^0.6.0"
     broccoli-uglify-js "~0.1.3"
-    emberjs-build "^0.15.0"
+    emberjs-build chadhietala/emberjs-build#allow-interators
     exists-sync "0.0.3"
     git-repo-version "^0.1.2"
     handlebars "^3.0.2"
     qunit "^0.9.1"
     simple-dom "^0.3.0"
     simple-html-tokenizer "^0.2.5"
-    typescript "~2.0.9"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -2896,7 +2858,7 @@ glob@3.2.8:
     inherits "2"
     minimatch "~0.2.11"
 
-glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5, glob@^7.1.1:
+glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -2907,7 +2869,7 @@ glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5, glob@^7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^5.0.1, glob@^5.0.10, glob@^5.0.13, glob@^5.0.15, glob@~5.0.0:
+glob@^5.0.10, glob@^5.0.13, glob@^5.0.15:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
   dependencies:
@@ -3025,7 +2987,7 @@ handlebars@1.3.x:
   optionalDependencies:
     uglify-js "~2.3"
 
-handlebars@^3.0.1, handlebars@^3.0.2:
+handlebars@^3.0.1, handlebars@^3.0.2, handlebars@^3.0.3, handlebars@~3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-3.0.3.tgz#0e09651a2f0fb3c949160583710d551f92e6d2ad"
   dependencies:
@@ -3084,7 +3046,7 @@ has-binary@0.1.7:
   dependencies:
     isarray "0.0.1"
 
-has-color@^0.1.7, has-color@~0.1.0:
+has-color@^0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/has-color/-/has-color-0.1.7.tgz#67144a5260c34fc3cca677d041daf52fe7b78b2f"
 
@@ -3179,16 +3141,6 @@ html-differ@^1.3.4:
     vow "0.4.3"
     vow-fs "0.3.1"
 
-htmlparser2@3.8.3, htmlparser2@3.8.x:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.8.3.tgz#996c28b191516a8be86501a7d79757e5c70c1068"
-  dependencies:
-    domelementtype "1"
-    domhandler "2.3"
-    domutils "1.5"
-    entities "1.0"
-    readable-stream "1.1"
-
 http-errors@~1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.5.1.tgz#788c0d2c1de2c81b9e6e8c01843b6b97eb920750"
@@ -3228,10 +3180,6 @@ https-proxy-agent@~1.0.0:
     debug "2"
     extend "3"
 
-i@0.3.x:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/i/-/i-0.3.5.tgz#1d2b854158ec8169113c6cb7f6b6801e99e211d5"
-
 iconv-lite@^0.4.5, iconv-lite@~0.4.13:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
@@ -3266,10 +3214,6 @@ inflight@^1.0.4, inflight@~1.0.5:
   dependencies:
     once "^1.3.0"
     wrappy "1"
-
-inherit@^2.2.2:
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/inherit/-/inherit-2.2.6.tgz#f1614b06c8544e8128e4229c86347db73ad9788d"
 
 inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
@@ -3482,10 +3426,6 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
-is-utf8@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
-
 is-windows@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
@@ -3512,7 +3452,7 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
-isstream@0.1.x, isstream@~0.1.2:
+isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
@@ -3581,84 +3521,13 @@ js-yaml@3.x, js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.5.1, js-yaml@^3.6.1:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
-js-yaml@~3.4.0:
-  version "3.4.6"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.4.6.tgz#6be1b23f6249f53d293370fd4d1aaa63ce1b4eb0"
-  dependencies:
-    argparse "^1.0.2"
-    esprima "^2.6.0"
-    inherit "^2.2.2"
-
 jsbn@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.0.tgz#650987da0dd74f4ebf5a11377a2aa2d273e97dfd"
 
-jscs-jsdoc@^1.3.1:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/jscs-jsdoc/-/jscs-jsdoc-1.3.2.tgz#1f2c82b6ab4b97524da958f46b4e562e0305f9a7"
-  dependencies:
-    comment-parser "^0.3.1"
-    jsdoctypeparser "~1.2.0"
-
-jscs-preset-wikimedia@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/jscs-preset-wikimedia/-/jscs-preset-wikimedia-1.0.0.tgz#fff563342038fc2e8826b7bb7309c3ae3406fc7e"
-
-jscs@^2.0.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/jscs/-/jscs-2.11.0.tgz#6e11ef0caaa07731f9dcc2b2b27d8ecee1ddbcb6"
-  dependencies:
-    babel-jscs "^2.0.0"
-    chalk "~1.1.0"
-    cli-table "~0.3.1"
-    commander "~2.9.0"
-    escope "^3.2.0"
-    esprima "~2.7.0"
-    estraverse "^4.1.0"
-    exit "~0.1.2"
-    glob "^5.0.1"
-    htmlparser2 "3.8.3"
-    js-yaml "~3.4.0"
-    jscs-jsdoc "^1.3.1"
-    jscs-preset-wikimedia "~1.0.0"
-    jsonlint "~1.6.2"
-    lodash "~3.10.0"
-    minimatch "~3.0.0"
-    natural-compare "~1.2.2"
-    pathval "~0.1.1"
-    prompt "~0.2.14"
-    reserved-words "^0.1.1"
-    resolve "^1.1.6"
-    strip-bom "^2.0.0"
-    strip-json-comments "~1.0.2"
-    to-double-quotes "^2.0.0"
-    to-single-quotes "^2.0.0"
-    vow "~0.4.8"
-    vow-fs "~0.3.4"
-    xmlbuilder "^3.1.0"
-
-jsdoctypeparser@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/jsdoctypeparser/-/jsdoctypeparser-1.2.0.tgz#e7dedc153a11849ffc5141144ae86a7ef0c25392"
-  dependencies:
-    lodash "^3.7.0"
-
 jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
-
-jshint@^2.7.0:
-  version "2.9.4"
-  resolved "https://registry.yarnpkg.com/jshint/-/jshint-2.9.4.tgz#5e3ba97848d5290273db514aee47fe24cf592934"
-  dependencies:
-    cli "~1.0.0"
-    console-browserify "1.1.x"
-    exit "0.1.x"
-    htmlparser2 "3.8.x"
-    lodash "3.7.x"
-    minimatch "~3.0.2"
-    shelljs "0.3.x"
-    strip-json-comments "1.0.x"
 
 json-parse-helpfulerror@^1.0.2:
   version "1.0.3"
@@ -3697,13 +3566,6 @@ jsonfile@^2.1.0:
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
-
-jsonlint@~1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/jsonlint/-/jsonlint-1.6.2.tgz#5737045085f55eb455c68b1ff4ebc01bd50e8830"
-  dependencies:
-    JSV ">= 4.0.x"
-    nomnom ">= 1.5.x"
 
 jsonpointer@^4.0.0:
   version "4.0.1"
@@ -4015,15 +3877,11 @@ lodash@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.1.tgz#5b7723034dda4d262e5a46fb2c58d7cc22f71420"
 
-lodash@3.7.x:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.7.0.tgz#3678bd8ab995057c07ade836ed2ef087da811d45"
-
 lodash@4.16.2:
   version "4.16.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.2.tgz#3e626db827048a699281a8a125226326cfc0e652"
 
-lodash@^3.10.0, lodash@^3.10.1, lodash@^3.5.0, lodash@^3.7.0, lodash@^3.9.3, lodash@~3.10.0:
+lodash@^3.10.0, lodash@^3.10.1, lodash@^3.9.3:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
@@ -4197,7 +4055,7 @@ minimatch@0.3, minimatch@0.x:
     lru-cache "2"
     sigmund "~1.0.0"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@~3.0.0, minimatch@~3.0.2:
+"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
   dependencies:
@@ -4231,25 +4089,19 @@ minimist@^1.1.0, minimist@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-mkdirp@0.3.0:
+mkdirp@0.3.0, mkdirp@0.3.x:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
 
-mkdirp@0.3.x, mkdirp@^0.3.5, mkdirp@~0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.5.tgz#de3e5f8961c88c787ee1368df849ac4413eca8d7"
-
-mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@0.x.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
 
-mkdirp@~0.4.0:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.4.2.tgz#427c8c18ece398b932f6f666f4e1e5b7740e78c8"
-  dependencies:
-    minimist "0.0.8"
+mkdirp@^0.3.5, mkdirp@~0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.5.tgz#de3e5f8961c88c787ee1368df849ac4413eca8d7"
 
 mktemp@~0.4.0:
   version "0.4.0"
@@ -4311,14 +4163,6 @@ natives@^1.1.0:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
-
-natural-compare@~1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.2.2.tgz#1f96d60e3141cac1b6d05653ce0daeac763af6aa"
-
-ncp@0.4.x:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/ncp/-/ncp-0.4.2.tgz#abcc6cbd3ec2ed2a729ff6e7c1fa8f01784a8574"
 
 negotiator@0.6.1:
   version "0.6.1"
@@ -4383,13 +4227,6 @@ node-uuid@1.4.0:
 node-uuid@^1.4.3, node-uuid@~1.4.0, node-uuid@~1.4.7:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.7.tgz#6da5a17668c4b3dd59623bda11cf7fa4c1f60a6f"
-
-"nomnom@>= 1.5.x":
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.8.1.tgz#2151f722472ba79e50a76fc125bb8c8f2e4dc2a7"
-  dependencies:
-    chalk "~0.4.0"
-    underscore "~1.6.0"
 
 "nopt@2 || 3", nopt@^3.0.1, nopt@~3.0.6:
   version "3.0.6"
@@ -4608,7 +4445,7 @@ opener@~1.4.1:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.4.2.tgz#b32582080042af8680c389a499175b4c54fff523"
 
-optimist@^0.6.1, optimist@~0.6.0:
+optimist@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
   dependencies:
@@ -4749,10 +4586,6 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
-pathval@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/pathval/-/pathval-0.1.1.tgz#08f911cdca9cce5942880da7817bc0b723b66d82"
-
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -4766,14 +4599,6 @@ pinkie-promise@^2.0.0:
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
-
-pkginfo@0.3.x:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.3.1.tgz#5b29f6a81f70717142e09e765bbeab97b4f81e21"
-
-pkginfo@0.x.x:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.0.tgz#349dbb7ffd38081fcadc0853df687f0c7744cd65"
 
 pluralize@^1.2.1:
   version "1.2.1"
@@ -4822,16 +4647,6 @@ promise-map-series@^0.2.1:
   resolved "https://registry.yarnpkg.com/promise-map-series/-/promise-map-series-0.2.3.tgz#c2d377afc93253f6bd03dbb77755eb88ab20a847"
   dependencies:
     rsvp "^3.0.14"
-
-prompt@~0.2.14:
-  version "0.2.14"
-  resolved "https://registry.yarnpkg.com/prompt/-/prompt-0.2.14.tgz#57754f64f543fd7b0845707c818ece618f05ffdc"
-  dependencies:
-    pkginfo "0.x.x"
-    read "1.0.x"
-    revalidator "0.1.x"
-    utile "0.2.x"
-    winston "0.8.x"
 
 promzard@^0.3.0:
   version "0.3.0"
@@ -4968,7 +4783,7 @@ read-package-tree@~5.1.5:
     read-package-json "^2.0.0"
     readdir-scoped-modules "^1.0.0"
 
-read@1, read@1.0.x, read@~1.0.1, read@~1.0.7:
+read@1, read@~1.0.1, read@~1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
   dependencies:
@@ -4986,16 +4801,7 @@ read@1, read@1.0.x, read@~1.0.1, read@~1.0.7:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-readable-stream@1.1:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.13.tgz#f6eef764f514c89e2b9e23146a75ba106756d23e"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
-
-readable-stream@^2.0.0, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.2.2:
+readable-stream@^2.0.0, readable-stream@^2.0.5, readable-stream@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.2.tgz#a9e6fec3c7dda85f8bb1b3ba7028604556fc825e"
   dependencies:
@@ -5225,10 +5031,6 @@ requires-port@1.x.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
-reserved-words@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/reserved-words/-/reserved-words-0.1.1.tgz#6f7c15e5e5614c50da961630da46addc87c0cef2"
-
 resolve-dir@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-0.1.1.tgz#b219259a5602fac5c5c496ad894a6e8cc430261e"
@@ -5259,17 +5061,13 @@ retry@^0.10.0, retry@~0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
 
-revalidator@0.1.x:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/revalidator/-/revalidator-0.1.8.tgz#fece61bfa0c1b52a206bd6b18198184bdd523a3b"
-
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@2.x.x, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.1, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.2, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@~2.5.4:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.1, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.2, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@~2.5.4:
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
   dependencies:
@@ -5435,10 +5233,6 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shelljs@0.3.x:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.3.0.tgz#3596e6307a781544f591f37da618360f31db57b1"
-
 shelljs@^0.7.5:
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.5.tgz#2eef7a50a21e1ccf37da00df767ec69e30ad0675"
@@ -5476,6 +5270,10 @@ simple-fmt@~0.1.0:
 simple-html-tokenizer@^0.2.5:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.2.6.tgz#a6efab7bc705cf3a96f1aaeaa1a76365f0d16c33"
+
+simple-html-tokenizer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.3.0.tgz#9b8b5559d80e331a544dd13dd59382e5d0d94411"
 
 simple-is@~0.2.0:
   version "0.2.0"
@@ -5655,10 +5453,6 @@ stable@~0.1.3:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.5.tgz#08232f60c732e9890784b5bed0734f8b32a887b9"
 
-stack-trace@0.0.x:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.9.tgz#a8f6eaeca90674c333e7c43953f275b451510695"
-
 "statuses@>= 1.3.1 < 2", statuses@~1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
@@ -5720,21 +5514,11 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1, strip-ansi@~3.0.1:
   dependencies:
     ansi-regex "^2.0.0"
 
-strip-ansi@~0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.1.1.tgz#39e8a98d044d150660abe4a6808acf70bb7bc991"
-
-strip-bom@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
-  dependencies:
-    is-utf8 "^0.2.0"
-
 strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 
-strip-json-comments@1.0.x, strip-json-comments@~1.0.1, strip-json-comments@~1.0.2:
+strip-json-comments@~1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
 
@@ -5896,10 +5680,6 @@ to-array@0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/to-array/-/to-array-0.1.4.tgz#17e6c11f73dd4f3d74cda7a4ff3238e9ad9bf890"
 
-to-double-quotes@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/to-double-quotes/-/to-double-quotes-2.0.0.tgz#aaf231d6fa948949f819301bbab4484d8588e4a7"
-
 to-fast-properties@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.2.tgz#f3f5c0c3ba7299a7ef99427e44633257ade43320"
@@ -5907,10 +5687,6 @@ to-fast-properties@^1.0.0:
 to-iso-string@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/to-iso-string/-/to-iso-string-0.0.2.tgz#4dc19e664dfccbe25bd8db508b00c6da158255d1"
-
-to-single-quotes@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/to-single-quotes/-/to-single-quotes-2.0.1.tgz#7cc29151f0f5f2c41946f119f5932fe554170125"
 
 tough-cookie@>=0.12.0, tough-cookie@~2.3.0:
   version "2.3.2"
@@ -5948,18 +5724,6 @@ tryor@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/tryor/-/tryor-0.1.2.tgz#8145e4ca7caff40acde3ccf946e8b8bb75b4172b"
 
-tslint@^3.5.0:
-  version "3.15.1"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-3.15.1.tgz#da165ca93d8fdc2c086b51165ee1bacb48c98ea5"
-  dependencies:
-    colors "^1.1.2"
-    diff "^2.2.1"
-    findup-sync "~0.3.0"
-    glob "^7.0.3"
-    optimist "~0.6.0"
-    resolve "^1.1.7"
-    underscore.string "^3.3.4"
-
 tunnel-agent@~0.4.0, tunnel-agent@~0.4.1:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.4.3.tgz#6373db76909fe570e08d73583365ed828a74eeeb"
@@ -5992,14 +5756,6 @@ type-is@~1.6.13:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
-
-typescript@^1.8.7:
-  version "1.8.10"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-1.8.10.tgz#b475d6e0dff0bf50f296e5ca6ef9fbb5c7320f1e"
-
-typescript@~2.0.9:
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.0.10.tgz#ccdd4ed86fd5550a407101a0814012e1b3fac3dd"
 
 uc.micro@^1.0.0, uc.micro@^1.0.1, uc.micro@^1.0.3:
   version "1.0.3"
@@ -6047,7 +5803,7 @@ umask@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
 
-underscore.string@3.3.4, underscore.string@^3.3.4:
+underscore.string@3.3.4:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-3.3.4.tgz#2c2a3f9f83e64762fdc45e6ceac65142864213db"
   dependencies:
@@ -6061,10 +5817,6 @@ underscore.string@~2.3.3:
 underscore@>=1.8.3, underscore@^1.6.0:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
-
-underscore@~1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
 
 unique-filename@~1.1.0:
   version "1.1.0"
@@ -6106,22 +5858,11 @@ util-extend@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/util-extend/-/util-extend-1.0.3.tgz#a7c216d267545169637b3b6edc6ca9119e2ff93f"
 
-utile@0.2.x:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/utile/-/utile-0.2.1.tgz#930c88e99098d6220834c356cbd9a770522d90d7"
-  dependencies:
-    async "~0.2.9"
-    deep-equal "*"
-    i "0.3.x"
-    mkdirp "0.x.x"
-    ncp "0.4.x"
-    rimraf "2.x.x"
-
 utils-merge@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
 
-uuid@^2.0.1, uuid@^2.0.2:
+uuid@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
@@ -6160,32 +5901,13 @@ vow-fs@0.3.1:
     node-uuid "1.4.0"
     vow-queue "0.1.0"
 
-vow-fs@~0.3.4:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/vow-fs/-/vow-fs-0.3.6.tgz#2d4c59be22e2bf2618ddf597ab4baa923be7200d"
-  dependencies:
-    glob "^7.0.5"
-    uuid "^2.0.2"
-    vow "^0.4.7"
-    vow-queue "^0.4.1"
-
 vow-queue@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/vow-queue/-/vow-queue-0.1.0.tgz#a9b561477c7ea5d563b0caaa52e40e668de0c238"
 
-vow-queue@^0.4.1:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/vow-queue/-/vow-queue-0.4.2.tgz#e7fe17160e15c7c4184d1b666a9bc64e18e30184"
-  dependencies:
-    vow "~0.4.0"
-
 vow@0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/vow/-/vow-0.4.3.tgz#d5c394d4f1e844c988100b57b540956c4a005ba6"
-
-vow@^0.4.7, vow@~0.4.0, vow@~0.4.8:
-  version "0.4.13"
-  resolved "https://registry.yarnpkg.com/vow/-/vow-0.4.13.tgz#e7c14f1bd9c8be0e7359a4597fe2d1ef6d1a7e88"
 
 walk-sync@^0.1.3:
   version "0.1.3"
@@ -6267,18 +5989,6 @@ window-size@^0.1.2:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.4.tgz#f8e1aa1ee5a53ec5bf151ffa09742a6ad7697876"
 
-winston@0.8.x:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-0.8.3.tgz#64b6abf4cd01adcaefd5009393b1d8e8bec19db0"
-  dependencies:
-    async "0.2.x"
-    colors "0.6.x"
-    cycle "1.0.x"
-    eyes "0.1.x"
-    isstream "0.1.x"
-    pkginfo "0.3.x"
-    stack-trace "0.0.x"
-
 wordwrap@0.0.2, wordwrap@0.0.x, wordwrap@~0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
@@ -6334,12 +6044,6 @@ xmlbuilder@2.6.2, xmlbuilder@>=2.4.6:
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-2.6.2.tgz#f916f6d10d45dc171b1be2e6e673fb6e0cc35d0a"
   dependencies:
     lodash "~3.5.0"
-
-xmlbuilder@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-3.1.0.tgz#2c86888f2d4eade850fa38ca7f7223f7209516e1"
-  dependencies:
-    lodash "^3.5.0"
 
 xmldom@^0.1.19:
   version "0.1.27"


### PR DESCRIPTION
This moves Ember over to the new Binary VM in glimmer (Requires [this branch](https://github.com/tildeio/glimmer/commits/runtime-null-checks)). Notable changes:

- `{{debugger}}` is now implemented as a built-in Glimmer statement syntax due to the fact it needs access to the `SymbolTable` and other information from the VM. Also we now hard error if the debugger is passed an expression, from what I can tell this just failed silently is we did nothing with the positional or named params.
- `refineStatement` on the `Environment` is no more in favor of `populateMacros` and `block|inlines.addMissing`.
- No more syntax objects but now byte arrays. 😎 