### PR TITLE
[performance] avoid looking up viewRegistry n times

### DIFF
--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -169,9 +169,11 @@ export default EmberObject.extend({
       throw new TypeError(`Unable to add '${ROOT_ELEMENT_CLASS}' class to root element (${rootElement.selector || rootElement[0].tagName}). Make sure you set rootElement to the body or an element in the body.`);
     }
 
+    let viewRegistry = this._getViewRegistry();
+
     for (event in events) {
       if (events.hasOwnProperty(event)) {
-        this.setupHandler(rootElement, event, events[event]);
+        this.setupHandler(rootElement, event, events[event], viewRegistry);
       }
     }
   },
@@ -189,12 +191,10 @@ export default EmberObject.extend({
     @param {Element} rootElement
     @param {String} event the browser-originated event to listen to
     @param {String} eventName the name of the method to call on the view
+    @param {Object} viewRegistry
   */
-  setupHandler(rootElement, event, eventName) {
+  setupHandler(rootElement, event, eventName, viewRegistry) {
     let self = this;
-
-    let owner = getOwner(this);
-    let viewRegistry = owner && owner.lookup('-view-registry:main') || fallbackViewRegistry;
 
     if (eventName === null) {
       return;
@@ -286,6 +286,13 @@ export default EmberObject.extend({
 
   _bubbleEvent(view, evt, eventName) {
     return view.handleEvent(eventName, evt);
+  },
+
+  _getViewRegistry() {
+    let owner = getOwner(this);
+    let viewRegistry = owner && owner.lookup('-view-registry:main') || fallbackViewRegistry;
+
+    return viewRegistry;
   },
 
   destroy() {


### PR DESCRIPTION
This change avoids getting `owner` and looking up `viewRegistry` for each event at the slight complexity expense of an additional parameter to the `setupHandler` method. We setup [27 events by default](https://github.com/emberjs/ember.js/blob/master/packages/ember-views/lib/system/event_dispatcher.js#L59-L87) so this change is worth it IMO (provided that there are no other considerations that I'm missing).

Questions:

 * Is the perf win worth the more complicated interface?
 * Perhaps memoization be better? We'd get to keep the same method interface and with the slight expense of n function calls to the memoized function.
 * This function is marked private, but does anyone rely on it (internally or externally)
 * Are there any concerns with application testing?