### PR TITLE
Avoid raising _lookupFactory deprecation during lookup

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -173,7 +173,7 @@ Container.prototype = {
         throw new Error('If ember-no-double-extend is enabled, ember-factory-for must also be enabled');
       }
     }
-    let factory = this.lookupFactory(fullName, options);
+    let factory = this[LOOKUP_FACTORY](fullName, options);
     if (factory === undefined) { return; }
     let manager = new DeprecatedFactoryManager(this, factory, fullName);
 

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -3,7 +3,7 @@ import { ENV } from 'ember-environment';
 import { get, isFeatureEnabled } from 'ember-metal';
 import { Registry } from '../index';
 import { factory } from 'internal-test-helpers';
-import { FACTORY_FOR } from 'container';
+import { LOOKUP_FACTORY, FACTORY_FOR } from 'container';
 
 let originalModelInjections;
 
@@ -17,16 +17,7 @@ QUnit.module('Container', {
 });
 
 function lookupFactory(name, container, options) {
-  let factory;
-  if (isFeatureEnabled('ember-no-double-extend')) {
-    ignoreDeprecation(() => {
-      factory = container.lookupFactory(name, options);
-    });
-  } else {
-    factory = container.lookupFactory(name, options);
-  }
-
-  return factory;
+  return container[LOOKUP_FACTORY](name, options);
 }
 
 QUnit.test('A registered factory returns the same instance each time', function() {
@@ -709,7 +700,7 @@ QUnit.test('#[FACTORY_FOR] class is the injected factory', (assert) => {
   if (isFeatureEnabled('ember-no-double-extend')) {
     assert.deepEqual(factoryCreator.class, Component, 'No double extend');
   } else {
-    assert.deepEqual(factoryCreator.class, container.lookupFactory('component:foo-bar'), 'Double extended class');
+    assert.deepEqual(factoryCreator.class, lookupFactory('component:foo-bar', container), 'Double extended class');
   }
 });
 

--- a/packages/ember-routing/tests/system/controller_for_test.js
+++ b/packages/ember-routing/tests/system/controller_for_test.js
@@ -103,6 +103,10 @@ QUnit.test('generateController should return controller:basic if provided', func
   if (isFeatureEnabled('ember-no-double-extend')) {
     ok(controller instanceof BasicController, 'should return base class of controller');
   } else {
-    ok(controller instanceof appInstance._lookupFactory('controller:basic'), 'should return double-extended controller');
+    let doubleExtendedFactory;
+    ignoreDeprecation(() => {
+      doubleExtendedFactory = appInstance._lookupFactory('controller:basic');
+    });
+    ok(controller instanceof doubleExtendedFactory, 'should return double-extended controller');
   }
 });


### PR DESCRIPTION
The entire `container.lookupFactory` API is deprecated, however it was also being [used in `lookup`](https://github.com/mixonic/ember.js/blob/333f4b05c0504d2b3be9002c796bd2f11f7fefe7/packages/container/lib/container.js#L144) and thus caused deprecation messaged to be raise at times other than when we wanted.

