### PR TITLE
Fix query param stickiness between models in ember-engines

### DIFF
--- a/packages/ember-glimmer/tests/integration/application/engine-test.js
+++ b/packages/ember-glimmer/tests/integration/application/engine-test.js
@@ -20,6 +20,7 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
         this.route('comments');
         this.route('likes');
       });
+      this.route('category', {path: 'category/:id'});
     });
     this.registerRoute('application', Route.extend({
       model() {
@@ -33,6 +34,9 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
         this.register('controller:application', Controller.extend({
           queryParams: ['lang'],
           lang: ''
+        }));
+        this.register('controller:category', Controller.extend({
+          queryParams: ['type'],
         }));
         this.register('template:application', compile('Engine{{lang}}{{outlet}}'));
         this.register('route:application', Route.extend({
@@ -570,6 +574,20 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
       return transition.then(() => {
         this.runTaskNext(() => this.assertText('ApplicationEngineLikes'));
       });
+    });
+  }
+
+  ['@test query params don\'t have stickiness by default between model'](assert) {
+    assert.expect(1);
+
+    this.setupAppAndRoutableEngine();
+    this.additionalEngineRegistrations(function() {
+      this.register('template:category', compile('{{#link-to "blog.category" 1337}}Category 1337{{/link-to}}'))
+    });
+
+    return this.visit('/blog/category/1?type=news').then(() => {
+      let href = this.element.querySelector('a').href;
+      assert.equal(href.match(/type=news/), null);
     });
   }
 });

--- a/packages/ember-glimmer/tests/integration/application/engine-test.js
+++ b/packages/ember-glimmer/tests/integration/application/engine-test.js
@@ -21,6 +21,7 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
         this.route('likes');
       });
       this.route('category', {path: 'category/:id'});
+      this.route('author', {path: 'author/:id'});
     });
     this.registerRoute('application', Route.extend({
       model() {
@@ -38,11 +39,17 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
         this.register('controller:category', Controller.extend({
           queryParams: ['type'],
         }));
+        this.register('controller:authorKtrl', Controller.extend({
+          queryParams: ['official'],
+        }));
         this.register('template:application', compile('Engine{{lang}}{{outlet}}'));
         this.register('route:application', Route.extend({
           model() {
             hooks.push('engine - application');
           }
+        }));
+        this.register('route:author', Route.extend({
+          controllerName: 'authorKtrl',
         }));
 
         if (self._additionalEngineRegistrations) {
@@ -141,6 +148,10 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
         this.register('template:application', compile('Engine {{foo-bar wat=contextType}}'));
       }
     }));
+  }
+
+  stringsEndWith(str, suffix) {
+    return str.indexOf(suffix, str.length - suffix.length) !== -1;
   }
 
   ['@test attrs in an engine']() {
@@ -579,15 +590,38 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
 
   ['@test query params don\'t have stickiness by default between model'](assert) {
     assert.expect(1);
-
+    let tmpl = '{{#link-to "blog.category" 1337}}Category 1337{{/link-to}}';
     this.setupAppAndRoutableEngine();
     this.additionalEngineRegistrations(function() {
-      this.register('template:category', compile('{{#link-to "blog.category" 1337}}Category 1337{{/link-to}}'))
+      this.register('template:category', compile(tmpl));
     });
 
     return this.visit('/blog/category/1?type=news').then(() => {
+      let suffix = '/blog/category/1337';
       let href = this.element.querySelector('a').href;
-      assert.equal(href.match(/type=news/), null);
+
+      // check if link ends with the suffix
+      assert.ok(this.stringsEndWith(href, suffix));
+    });
+  }
+
+  ['@test query params in customized controllerName have stickiness by default between model'](assert) {
+    assert.expect(2);
+    let tmpl = '{{#link-to "blog.author" 1337 class="author-1337"}}Author 1337{{/link-to}}{{#link-to "blog.author" 1 class="author-1"}}Author 1{{/link-to}}';
+    this.setupAppAndRoutableEngine();
+    this.additionalEngineRegistrations(function() {
+      this.register('template:author', compile(tmpl));
+    });
+
+    return this.visit('/blog/author/1?official=true').then(() => {
+      let suffix1 = '/blog/author/1?official=true';
+      let href1 = this.element.querySelector('.author-1').href;
+      let suffix1337 = '/blog/author/1337';
+      let href1337 = this.element.querySelector('.author-1337').href;
+
+      // check if link ends with the suffix
+      assert.ok(this.stringsEndWith(href1, suffix1));
+      assert.ok(this.stringsEndWith(href1337, suffix1337));
     });
   }
 });

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1334,7 +1334,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
         let aQp = queryParams.map[prop];
 
         aQp.values = params;
-        let cacheKey = calculateCacheKey(aQp.controllerName, aQp.parts, aQp.values);
+        let cacheKey = calculateCacheKey(aQp.route.fullRouteName, aQp.parts, aQp.values);
 
         if (cache) {
           let value = cache.lookup(cacheKey, prop, aQp.undecoratedDefaultValue);
@@ -1363,7 +1363,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
   _qpChanged(prop, value, qp) {
     if (!qp) { return; }
 
-    let cacheKey = calculateCacheKey(qp.controllerName, qp.parts, qp.values);
+    let cacheKey = calculateCacheKey(qp.route.fullRouteName, qp.parts, qp.values);
 
     // Update model-dep cache
     let cache = this._bucketCache;

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -953,7 +953,7 @@ const EmberRouter = EmberObject.extend(Evented, {
             delete queryParams[presentProp];
           }
         } else {
-          let cacheKey = calculateCacheKey(qp.controllerName, qp.parts, state.params);
+          let cacheKey = calculateCacheKey(qp.route.fullRouteName, qp.parts, state.params);
           queryParams[qp.scopedPropertyName] = appCache.lookup(cacheKey, qp.prop, qp.defaultValue);
         }
       }


### PR DESCRIPTION
See https://github.com/emberjs/ember.js/issues/14788

Summary:

In ember-engines, query param is sticky between different models (see generated link-to). This is not the behavior outside engine and as specified https://guides.emberjs.com/v2.10.0/routing/query-params/#toc_sticky-query-param-values

This is happening because they share the same cacheKey when controller is used as the prefix.