### PR TITLE
Fix linking glimmer master.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -202,10 +202,13 @@ var glimmerEngine = require('glimmer-engine/ember-cli-build')({
   stripRuntimeChecks: true
 });
 
-var find = require('broccoli-stew').find;
-
 function glimmerPackage(name) {
-  return replace(find(glimmerEngine, 'named-amd/' + name + '/**/*.js'), {
+  return replace(new Funnel(glimmerEngine, {
+    include: [
+      'named-amd/' + name + '.js',
+      'named-amd/' + name + '/**/*.js'
+    ]
+  }), {
     files: ['**/*.js'],
     pattern: {
       match: /\/\/#\s+sourceMappingURL.*/g,


### PR DESCRIPTION
Allows for `named-amd/package.js` in addition to `named-amd/package/**/*.js`