### PR TITLE
Refactor duplicate `_pushToDebugStack` methods

### DIFF
--- a/packages/ember-glimmer/lib/syntax/abstract-manager.js
+++ b/packages/ember-glimmer/lib/syntax/abstract-manager.js
@@ -1,0 +1,19 @@
+import { runInDebug } from 'ember-metal';
+
+class AbstractManager {
+
+}
+
+runInDebug(() => {
+  AbstractManager.prototype._pushToDebugStack = function(name, environment) {
+    this.debugStack = environment.debugStack;
+    this.debugStack.push(name);
+  };
+
+  AbstractManager.prototype._pushEngineToDebugStack = function(name, environment) {
+    this.debugStack = environment.debugStack;
+    this.debugStack.pushEngine(name);
+  };
+});
+
+export default AbstractManager;

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -30,6 +30,7 @@ import {
   ComponentArgs
 } from '../utils/process-args';
 import { privatize as P } from 'container';
+import AbstractManager from './abstract-manager';
 
 const DEFAULT_LAYOUT = P`template:components/-default`;
 
@@ -176,7 +177,7 @@ function rerenderInstrumentDetails(component) {
   return component.instrumentDetails({ initialRender: false });
 }
 
-class CurlyComponentManager {
+class CurlyComponentManager extends AbstractManager {
   prepareArgs(definition, args) {
     if (definition.ComponentClass) {
       validatePositionalParameters(args.named, args.positional.values, definition.ComponentClass.class.positionalParams);
@@ -369,13 +370,6 @@ class CurlyComponentManager {
     return stateBucket;
   }
 }
-
-runInDebug(() => {
-  CurlyComponentManager.prototype._pushToDebugStack = function(name, environment) {
-    this.debugStack = environment.debugStack;
-    this.debugStack.push(name);
-  };
-});
 
 const MANAGER = new CurlyComponentManager();
 

--- a/packages/ember-glimmer/lib/syntax/mount.js
+++ b/packages/ember-glimmer/lib/syntax/mount.js
@@ -13,6 +13,8 @@ import { RootReference } from '../utils/references';
 import { generateControllerFactory } from 'ember-routing';
 import { OutletLayoutCompiler } from './outlet';
 import { FACTORY_FOR } from 'container';
+import AbstractManager from './abstract-manager';
+
 /**
   The `{{mount}}` helper lets you embed a routeless engine in a template.
   Mounting an engine will cause an instance to be booted and its `application`
@@ -68,13 +70,13 @@ export class MountSyntax extends StatementSyntax {
   }
 }
 
-class MountManager {
+class MountManager extends AbstractManager {
   prepareArgs(definition, args) {
     return args;
   }
 
   create(environment, { name, env }, args, dynamicScope) {
-    runInDebug(() => this._pushToDebugStack(`engine:${name}`, env));
+    runInDebug(() => this._pushEngineToDebugStack(`engine:${name}`, env));
 
     dynamicScope.outletState = UNDEFINED_REFERENCE;
 
@@ -115,13 +117,6 @@ class MountManager {
   didUpdateLayout() {}
   didUpdate(state) {}
 }
-
-runInDebug(() => {
-  MountManager.prototype._pushToDebugStack = function(name, environment) {
-    this.debugStack = environment.debugStack;
-    this.debugStack.pushEngine(name);
-  };
-});
 
 const MOUNT_MANAGER = new MountManager();
 

--- a/packages/ember-glimmer/lib/syntax/outlet.js
+++ b/packages/ember-glimmer/lib/syntax/outlet.js
@@ -15,6 +15,7 @@ import {
   ConstReference,
   combine
 } from 'glimmer-reference';
+import AbstractManager from './abstract-manager';
 
 function outletComponentFor(vm) {
   let { outletState } = vm.dynamicScope();
@@ -174,7 +175,7 @@ class StateBucket {
   }
 }
 
-class OutletComponentManager {
+class OutletComponentManager extends AbstractManager {
   prepareArgs(definition, args) {
     return args;
   }
@@ -215,13 +216,6 @@ class OutletComponentManager {
   didUpdateLayout(bucket) {}
   didUpdate(state) {}
 }
-
-runInDebug(() => {
-  OutletComponentManager.prototype._pushToDebugStack = function(name, environment) {
-    this.debugStack = environment.debugStack;
-    this.debugStack.push(name);
-  };
-});
 
 const MANAGER = new OutletComponentManager();
 

--- a/packages/ember-glimmer/lib/syntax/render.js
+++ b/packages/ember-glimmer/lib/syntax/render.js
@@ -13,6 +13,7 @@ import { RootReference } from '../utils/references';
 import { generateController, generateControllerFactory } from 'ember-routing';
 import { OutletLayoutCompiler } from './outlet';
 import { FACTORY_FOR } from 'container';
+import AbstractManager from './abstract-manager';
 
 function makeComponentDefinition(vm) {
   let env     = vm.env;
@@ -137,7 +138,7 @@ export class RenderSyntax extends StatementSyntax {
   }
 }
 
-class AbstractRenderManager {
+class AbstractRenderManager extends AbstractManager {
   prepareArgs(definition, args) {
     return args;
   }
@@ -171,11 +172,6 @@ class AbstractRenderManager {
 runInDebug(() => {
   AbstractRenderManager.prototype.didRenderLayout = function() {
     this.debugStack.pop();
-  };
-
-  AbstractRenderManager.prototype._pushToDebugStack = function(name, environment) {
-    this.debugStack = environment.debugStack;
-    this.debugStack.push(name);
   };
 });
 


### PR DESCRIPTION
A follow up to https://github.com/emberjs/ember.js/pull/14723#discussion_r94973568, this extracts the duplicate `_pushToDebugStack` methods into a common base class.

/cc @rwjblue 