### PR TITLE
Fix deopt for the field load of `.concat`

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -43,7 +43,9 @@ import {
 function ROOT() {}
 ROOT.__hasSuper = false;
 
-const a_slice = [].slice;
+const a_slice = Array.prototype.slice;
+const a_concat = Array.prototype.concat;
+const isArray = Array.isArray;
 
 function isMethod(obj) {
   return 'function' === typeof obj &&
@@ -72,14 +74,11 @@ function mixinProperties(mixinsMeta, mixin) {
 }
 
 function concatenatedMixinProperties(concatProp, props, values, base) {
-  let concats;
-
   // reset before adding each new mixin to pickup concats from previous
-  concats = values[concatProp] || base[concatProp];
+  let concats = values[concatProp] || base[concatProp];
   if (props[concatProp]) {
-    concats = concats ? concats.concat(props[concatProp]) : props[concatProp];
+    concats = concats ? a_concat.call(concats, props[concatProp]) : props[concatProp];
   }
-
   return concats;
 }
 
@@ -146,18 +145,18 @@ function applyConcatenatedProperties(obj, key, value, values) {
   let baseValue = values[key] || obj[key];
   let ret;
 
-  if (baseValue) {
-    if ('function' === typeof baseValue.concat) {
+  if (baseValue === null || baseValue === undefined) {
+    ret = makeArray(value);
+  } else {
+    if (isArray(baseValue)) {
       if (value === null || value === undefined) {
         ret = baseValue;
       } else {
-        ret = baseValue.concat(value);
+        ret = a_concat.call(baseValue, value);
       }
     } else {
-      ret = makeArray(baseValue).concat(value);
+      ret = a_concat.call(makeArray(baseValue), value);
     }
-  } else {
-    ret = makeArray(value);
   }
 
   runInDebug(() => {
@@ -176,7 +175,7 @@ function applyMergedProperties(obj, key, value, values) {
   let baseValue = values[key] || obj[key];
 
   runInDebug(function() {
-    if (Array.isArray(value)) { // use conditional to avoid stringifying every time
+    if (isArray(value)) { // use conditional to avoid stringifying every time
       assert(`You passed in \`${JSON.stringify(value)}\` as the value for \`${key}\` but \`${key}\` cannot be an Array`, false);
     }
   });

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -45,7 +45,7 @@ ROOT.__hasSuper = false;
 
 const a_slice = Array.prototype.slice;
 const a_concat = Array.prototype.concat;
-const isArray = Array.isArray;
+const { isArray } = Array;
 
 function isMethod(obj) {
   return 'function' === typeof obj &&

--- a/packages/ember-metal/tests/mixin/concatenated_properties_test.js
+++ b/packages/ember-metal/tests/mixin/concatenated_properties_test.js
@@ -106,5 +106,5 @@ QUnit.test('adding a concatenable property that already has a defined value shou
   });
 
   let obj = mixin({}, mixinA, mixinB);
-  equal(get(obj, 'foobar'), 'foobar');
+  deepEqual(get(obj, 'foobar'), ['foo', 'bar']);
 });

--- a/packages/ember-utils/lib/make-array.js
+++ b/packages/ember-utils/lib/make-array.js
@@ -1,3 +1,5 @@
+const isArray = Array.isArray;
+
 /**
  Forces the passed object to be part of an array. If the object is already
  an array, it will return the object. Otherwise, it will add the object to
@@ -23,5 +25,5 @@
  */
 export default function makeArray(obj) {
   if (obj === null || obj === undefined) { return []; }
-  return Array.isArray(obj) ? obj : [obj];
+  return isArray(obj) ? obj : [obj];
 }

--- a/packages/ember-utils/lib/make-array.js
+++ b/packages/ember-utils/lib/make-array.js
@@ -1,4 +1,4 @@
-const isArray = Array.isArray;
+const { isArray } = Array;
 
 /**
  Forces the passed object to be part of an array. If the object is already


### PR DESCRIPTION
Removes polymorphic check of .concat and call that causes several deopts of mixin merge and apply.

This passed all meaningful tests, but there is one test that is asserting something I'm shocked about, that I'm going to submit this for review anyway.  If this were true we'd do things like call concat on a string with an array.

Which makes little sense to me.

I believe this test isn't testing a real thing.