### PR TITLE
[performance] avoid a `get` if `rootElement` is known

### DIFF
--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -153,11 +153,13 @@ export default EmberObject.extend({
     let event;
     let events = this._finalEvents = assign({}, get(this, 'events'), addedEvents);
 
-    if (!isNone(rootElement)) {
+    if (isNone(rootElement)) {
+      rootElement = get(this, 'rootElement');
+    } else {
       set(this, 'rootElement', rootElement);
     }
 
-    rootElement = jQuery(get(this, 'rootElement'));
+    rootElement = jQuery(rootElement);
 
     assert(`You cannot use the same root element (${rootElement.selector || rootElement[0].tagName}) multiple times in an Ember.Application`, !rootElement.is(ROOT_ELEMENT_SELECTOR));
     assert('You cannot make a new Ember.Application using a root element that is a descendent of an existing Ember.Application', !rootElement.closest(ROOT_ELEMENT_SELECTOR).length);


### PR DESCRIPTION
If we're `set`ting the `routeElement`, we don't need to `get` it immediately afterwards