### PR TITLE
[DOC release] Remove context from addObserver

### DIFF
--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -340,16 +340,9 @@ export default Mixin.create({
     value is set, regardless of whether it has actually changed. Your
     observer should be prepared to handle that.
 
-    You can also pass an optional context parameter to this method. The
-    context will be passed to your observer method whenever it is triggered.
-    Note that if you add the same target/method pair on a key multiple times
-    with different context parameters, your observer will only be called once
-    with the last context you passed.
-
     ### Observer Methods
 
-    Observer methods you pass should generally have the following signature if
-    you do not pass a `context` parameter:
+    Observer methods have the following signature:
 
     ```javascript
     export default Ember.Component.extend({
@@ -364,28 +357,12 @@ export default Mixin.create({
     });
     ```
 
-    The sender is the object that changed. The key is the property that
-    changes. The value property is currently reserved and unused. The rev
+    The `sender` is the object that changed. The `key` is the property that
+    changes. The `value` property is currently reserved and unused. The `rev`
     is the last property revision of the object when it changed, which you can
     use to detect if the key value has really changed or not.
 
-    If you pass a `context` parameter, the context will be passed before the
-    revision like so:
-
-    ```javascript
-    export default Ember.Component.extend({
-      init() {
-        this._super(...arguments);
-        this.addObserver('foo', this, 'fooDidChange');
-      },
-
-      fooDidChange(sender, key, value, context, rev) {
-        // your code
-      }
-    });
-    ```
-
-    Usually you will not need the value, context or revision parameters at
+    Usually you will not need the value or revision parameters at
     the end. In this case, it is common to write observer methods that take
     only a sender and key value as parameters or, if you aren't interested in
     any of these values, to write an observer that has no parameters at all.


### PR DESCRIPTION
References to `context` in the `addObserver` docs are invalid and were removed a while ago: https://github.com/emberjs/ember.js/blob/7819409b7b6559e9fc0300a29e66a16356fb67a7/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js#L22

cc @locks @rwjblue 