### PR TITLE
[performance] only `logLibraryVersions` in debug mode

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -10,7 +10,8 @@ import {
   libraries,
   isTesting,
   get,
-  run
+  run,
+  runInDebug
 } from 'ember-metal';
 import {
   Namespace,
@@ -339,7 +340,7 @@ const Application = Engine.extend({
     }
 
     registerLibraries();
-    logLibraryVersions();
+    runInDebug(() => logLibraryVersions());
 
     // Start off the number of deferrals at 1. This will be decremented by
     // the Application's own `boot` method.
@@ -1050,23 +1051,25 @@ function registerLibraries() {
 }
 
 function logLibraryVersions() {
-  if (ENV.LOG_VERSION) {
-    // we only need to see this once per Application#init
-    ENV.LOG_VERSION = false;
-    let libs = libraries._registry;
+  runInDebug(() => {
+    if (ENV.LOG_VERSION) {
+      // we only need to see this once per Application#init
+      ENV.LOG_VERSION = false;
+      let libs = libraries._registry;
 
-    let nameLengths = libs.map(item => get(item, 'name.length'));
+      let nameLengths = libs.map(item => get(item, 'name.length'));
 
-    let maxNameLength = Math.max.apply(this, nameLengths);
+      let maxNameLength = Math.max.apply(this, nameLengths);
 
-    debug('-------------------------------');
-    for (let i = 0; i < libs.length; i++) {
-      let lib = libs[i];
-      let spaces = new Array(maxNameLength - lib.name.length + 1).join(' ');
-      debug([lib.name, spaces, ' : ', lib.version].join(''));
+      debug('-------------------------------');
+      for (let i = 0; i < libs.length; i++) {
+        let lib = libs[i];
+        let spaces = new Array(maxNameLength - lib.name.length + 1).join(' ');
+        debug([lib.name, spaces, ' : ', lib.version].join(''));
+      }
+      debug('-------------------------------');
     }
-    debug('-------------------------------');
-  }
+  });
 }
 
 export default Application;


### PR DESCRIPTION
<img width="1024" alt="screen shot 2017-01-12 at 16 48 14" src="https://cloud.githubusercontent.com/assets/2526/21899094/f31ad8ee-d8e6-11e6-9f63-3c8d59f0fa1e.png">

TODO:

 * [x] verify that the ember inspector continues to work: https://github.com/emberjs/ember-inspector/blob/679643037032fab3e4388a8dcb8cd0f20d1cc660/shared/in-page-script.js#L15
