### PR TITLE
[DOC] fix Action Helpers documentation to display file paths

### DIFF
--- a/packages/ember-glimmer/lib/helpers/action.js
+++ b/packages/ember-glimmer/lib/helpers/action.js
@@ -68,6 +68,8 @@ export const ACTION = symbol('ACTION');
   Here is an example action handler on a component:
 
   ```js
+  import Ember from 'ember';
+
   export default Ember.Component.extend({
     actions: {
       save() {
@@ -116,7 +118,9 @@ export const ACTION = symbol('ACTION');
   Actions invoked with `sendAction` have the same currying behavior as demonstrated
   with `on-input` above. For example:
 
-  ```js
+  ```app/components/my-input.js
+  import Ember from 'ember';
+
   export default Ember.Component.extend({
     actions: {
       setName(model, name) {
@@ -130,8 +134,9 @@ export const ACTION = symbol('ACTION');
   {{my-input submit=(action 'setName' model)}}
   ```
 
-  ```js
-  // app/components/my-component.js
+  ```app/components/my-component.js
+  import Ember from 'ember';
+
   export default Ember.Component.extend({
     click() {
       // Note that model is not passed, it was curried in the template
@@ -187,9 +192,9 @@ export const ACTION = symbol('ACTION');
   <div onclick={{disable-bubbling (action "sayHello")}}>Hello</div>
   ```
 
-  ```js
-  // app/helpers/disable-bubbling.js
+  ```app/helpers/disable-bubbling.js
   import Ember from 'ember';
+
   export function disableBubbling([action]) {
     return function(event) {
       event.stopPropagation();
@@ -246,15 +251,15 @@ export const ACTION = symbol('ACTION');
   which object will receive the method call. This option must be a path
   to an object, accessible in the current context:
 
-  ```handlebars
-  {{! app/templates/application.hbs }}
+  ```app/templates/application.hbs
   <div {{action "anActionName" target=someService}}>
     click me
   </div>
   ```
 
-  ```javascript
-  // app/controllers/application.js
+  ```app/controllers/application.js
+  import Ember from 'ember';
+
   export default Ember.Controller.extend({
     someService: Ember.inject.service()
   });


### PR DESCRIPTION
....and demonstrate imports

Addresses this issue: https://github.com/emberjs/ember.js/issues/14834

QUnit 1.23.1; Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6)
AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 Safari/537.36
Tests completed in 448639 milliseconds.
29742 assertions of 29742 passed, 0 failed.
skippedEmber.Application - visit() Integration Tests: SKIPPED: Test
setup (0)Rerun
skippedEmber.Application - visit() Integration Tests: SKIPPED: iframe
setup (0)Rerun
skippedHelpers test: {{unbound}}: SKIPPED: helper form updates on
parent re-render (0)Rerun
skippedEmberObject ES Compatibility: SKIPPED: calling extend on an ES
subclass of EmberObject (0)Rerun