### PR TITLE
[BUGFIX beta] Allow boolean values for current-when

### DIFF
--- a/packages/ember-glimmer/lib/components/link-to.js
+++ b/packages/ember-glimmer/lib/components/link-to.js
@@ -549,8 +549,12 @@ const LinkComponent = EmberComponent.extend({
     let routing = get(this, '_routing');
     let models = get(this, 'models');
     let resolvedQueryParams = get(this, 'resolvedQueryParams');
-
     let currentWhen = get(this, 'current-when');
+
+    if (typeof currentWhen === 'boolean') {
+      return currentWhen ? get(this, 'activeClass') : false;
+    }
+
     let isCurrentWhenSpecified = !!currentWhen;
     currentWhen = currentWhen || get(this, 'qualifiedRouteName');
     currentWhen = currentWhen.split(' ');

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -527,6 +527,22 @@ moduleFor('The {{link-to}} helper - nested routes and link-to arguments', class 
     assert.equal(this.$('#link3.active').length, 0, 'The link is not active since current-when does not contain the active route');
   }
 
+  ['@test The {{link-to}} helper supports boolean values for current-when'](assert) {
+    this.router.map(function(match) {
+      this.route('index', { path: '/' }, function() {
+        this.route('about');
+      });
+      this.route('item');
+    });
+
+    this.addTemplate('index', `<h3>Home</h3>{{outlet}}`);
+    this.addTemplate('index.about', `{{#link-to 'item' id='other-link' current-when=true}}ITEM{{/link-to}}`);
+
+    this.visit('/about');
+
+    assert.equal(this.$('#other-link').length, 1, 'The link is active since current-when is true');
+  }
+
   ['@test The {{link-to}} helper defaults to bubbling'](assert) {
     this.addTemplate('about', `
       <div {{action 'hide'}}>


### PR DESCRIPTION
[Quote](https://github.com/emberjs/ember.js/blob/v2.12.0/packages/ember-glimmer/lib/components/link-to.js#L157-L158) from the docs for `current-when`:

```
A link will be active if `current-when` is `true` or the current
route is the route this link would transition to.
```

But currently using a boolean value produces a TypeError.

Looks like this might have been broken since 1.13 and https://github.com/emberjs/ember.js/pull/12344 did not seem to actually fix this particular issue.

Related issues: https://github.com/emberjs/ember.js/issues/12512, https://github.com/emberjs/ember.js/pull/12630 (fix was not merged), https://github.com/emberjs/ember.js/issues/12296