### PR TITLE
add test verifying that registering an unknown service raises an exception

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -405,7 +405,9 @@ function buildInjections(/* container, ...injections */) {
       }
     }
 
-    container.registry.validateInjections(injections);
+    runInDebug(() => {
+      container.registry.validateInjections(injections);
+    });
 
     for (let i = 0; i < injections.length; i++) {
       injection = injections[i];

--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -708,9 +708,7 @@ Registry.prototype = {
     for (let i = 0; i < injections.length; i++) {
       fullName = injections[i].fullName;
 
-      if (!this.has(fullName)) {
-        throw new Error(`Attempting to inject an unknown injection: '${fullName}'`);
-      }
+      assert(`Attempting to inject an unknown injection: '${fullName}'`, this.has(fullName));
     }
   },
 

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -2483,6 +2483,18 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     this.assertText('Jackson');
   }
 
+  ['@test injecting an unknown service raises an exception'](assert) {
+    this.registerComponent('foo-bar', {
+      ComponentClass: Component.extend({
+        missingService: inject.service()
+      })
+    });
+
+    expectAssertion(() => {
+      this.render('{{foo-bar}}');
+    }, 'Attempting to inject an unknown injection: \'service:missingService\'');
+  }
+
   ['@test can access `actions` hash via `_actions` [DEPRECATED]']() {
     let component;
 


### PR DESCRIPTION
This now passes, but didn't in Ember 2.10. I git bisected the test and it passes since https://github.com/emberjs/ember.js/pull/14360

