### PR TITLE
Run backtracking assertion only in debug mode

### DIFF
--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -113,10 +113,12 @@ function propertyDidChange(obj, keyName, _meta) {
 
   markObjectAsDirty(meta, keyName);
 
-  if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
-    isEnabled('ember-glimmer-allow-backtracking-rerender')) {
-    runInDebug(() => { assertNotRendered(obj, keyName, meta) });
-  }
+  runInDebug(() => {
+    if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
+      isEnabled('ember-glimmer-allow-backtracking-rerender')) {
+      assertNotRendered(obj, keyName, meta)
+    }
+  });
 }
 
 let WILL_SEEN, DID_SEEN;

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -1,4 +1,5 @@
 import { guidFor, symbol } from 'ember-utils';
+import { runInDebug } from 'ember-metal';
 import {
   peekMeta
 } from './meta';
@@ -113,8 +114,8 @@ function propertyDidChange(obj, keyName, _meta) {
   markObjectAsDirty(meta, keyName);
 
   if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
-      isEnabled('ember-glimmer-allow-backtracking-rerender')) {
-    assertNotRendered(obj, keyName, meta);
+    isEnabled('ember-glimmer-allow-backtracking-rerender')) {
+    runInDebug(() => { assertNotRendered(obj, keyName, meta) });
   }
 }
 


### PR DESCRIPTION
This wraps the `assertNotRendered` check in `runInDebug` so that it won't execute in production, even when either of the flags are enabled.