### PR TITLE
[BUGFIX beta] Add back mainContext to loader #14859

### DIFF
--- a/packages/loader/lib/index.js
+++ b/packages/loader/lib/index.js
@@ -1,4 +1,5 @@
 var enifed, requireModule, Ember;
+var mainContext = this; // Used in ember-environment/lib/global.js
 
 (function() {
   var isNode = typeof window === 'undefined' &&


### PR DESCRIPTION
Fixing #14859

After the ESLint warning cleanup the `mainContext` is undefined and brake the ember-template-compiler.js compilation in grunt environment.

This PR removes the rest of the `mainContext` reference from the `global.js`.

Previous conversation about this issue:
e24e403#diff-5b2ea89606fd2097e9e17d66ae54ed51L2

Opened issue in grunt-ember-templates repo: dgeb/grunt-ember-templates#94

cc @Turbo87 @andyhot