### PR TITLE
Remove unneeded check as `data-ember-action` no longer contains a value

### DIFF
--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -218,33 +218,23 @@ export default EmberObject.extend({
     });
 
     rootElement.on(`${event}.ember`, '[data-ember-action]', evt => {
-      let actionId = jQuery(evt.currentTarget).attr('data-ember-action');
-      let actions = ActionManager.registeredActions[actionId];
+      let attributes = evt.currentTarget.attributes;
+      let attributeCount = attributes.length;
+      let actions = [];
 
-      // In Glimmer2 this attribute is set to an empty string and an additional
-      // attribute it set for each action on a given element. In this case, the
-      // attributes need to be read so that a proper set of action handlers can
-      // be coalesced.
-      if (actionId === '') {
-        let attributes = evt.currentTarget.attributes;
-        let attributeCount = attributes.length;
+      for (let i = 0; i < attributeCount; i++) {
+        let attr = attributes.item(i);
+        let attrName = attr.name;
 
-        actions = [];
-
-        for (let i = 0; i < attributeCount; i++) {
-          let attr = attributes.item(i);
-          let attrName = attr.name;
-
-          if (attrName.indexOf('data-ember-action-') === 0) {
-            actions = actions.concat(ActionManager.registeredActions[attr.value]);
-          }
+        if (attrName.indexOf('data-ember-action-') === 0) {
+          actions = actions.concat(ActionManager.registeredActions[attr.value]);
         }
       }
 
       // We have to check for actions here since in some cases, jQuery will trigger
       // an event on `removeChild` (i.e. focusout) after we've already torn down the
       // action handlers for the view.
-      if (!actions) {
+      if (actions.length === 0) {
         return;
       }
 


### PR DESCRIPTION
The Glimmer 2 action helper [doesn't set a value for `data-ember-action`](https://github.com/emberjs/ember.js/blob/b0801b77dce8c546074322f3fed1c9f7ab4df2bb/packages/ember-glimmer/lib/modifiers/action.js#L223-L224), so we no longer need to compare it to `""`.