### PR TITLE
Simplify action event handler

### DIFF
--- a/packages/ember-glimmer/lib/modifiers/action.js
+++ b/packages/ember-glimmer/lib/modifiers/action.js
@@ -38,34 +38,16 @@ export let ActionHelper = {
 
   registerAction(actionState) {
     let { actionId } = actionState;
-    let actions = ActionManager.registeredActions[actionId];
 
-    if (!actions) {
-      actions = ActionManager.registeredActions[actionId] = [];
-    }
-
-    actions.push(actionState);
+    ActionManager.registeredActions[actionId] = actionState;
 
     return actionId;
   },
 
   unregisterAction(actionState) {
     let { actionId } = actionState;
-    let actions = ActionManager.registeredActions[actionId];
 
-    if (!actions) {
-      return;
-    }
-
-    let index = actions.indexOf(actionState);
-
-    if (index !== -1) {
-      actions.splice(index, 1);
-    }
-
-    if (actions.length === 0) {
-      delete ActionManager.registeredActions[actionId];
-    }
+    delete ActionManager.registeredActions[actionId];
   }
 };
 

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -219,30 +219,17 @@ export default EmberObject.extend({
 
     rootElement.on(`${event}.ember`, '[data-ember-action]', evt => {
       let attributes = evt.currentTarget.attributes;
-      let attributeCount = attributes.length;
-      let actions = [];
 
-      for (let i = 0; i < attributeCount; i++) {
+      for (let i = 0; i < attributes.length; i++) {
         let attr = attributes.item(i);
         let attrName = attr.name;
 
-        if (attrName.indexOf('data-ember-action-') === 0) {
-          actions = actions.concat(ActionManager.registeredActions[attr.value]);
-        }
-      }
+        if (attrName.lastIndexOf('data-ember-action-', 0) !== -1) {
+          let action = ActionManager.registeredActions[attr.value];
 
-      // We have to check for actions here since in some cases, jQuery will trigger
-      // an event on `removeChild` (i.e. focusout) after we've already torn down the
-      // action handlers for the view.
-      if (actions.length === 0) {
-        return;
-      }
-
-      for (let index = 0; index < actions.length; index++) {
-        let action = actions[index];
-
-        if (action && action.eventName === eventName) {
-          return action.handler(evt);
+          if (action.eventName === eventName) {
+            action.handler(evt);
+          }
         }
       }
     });


### PR DESCRIPTION
As [@rwjblue notes](https://github.com/emberjs/ember.js/pull/14872#discussion_r97623843), the pre-glimmer 2 implementation had a single `data-ember-action="someid"` and multiple actions would be registered on that id.

Glimmer 2 has a [unique action id per action registration](https://github.com/emberjs/ember.js/blob/b0801b77dce8c546074322f3fed1c9f7ab4df2bb/packages/ember-glimmer/lib/modifiers/action.js#L223-L224) so we no longer need to store the registered actions in an array.

TODO:

 * [x] [check if we're breaking any addons](https://emberobserver.com/code-search?codeQuery=registeredActions) (just one it seems: [ember-native-dom-event-dispatcher](https://github.com/rwjblue/ember-native-dom-event-dispatcher/blob/d970bece76583f8932fc92d664a38c7d002fb6df/addon/index.js#L76-L114))