### PR TITLE
Add @since tag to doc for the hash helper

### DIFF
--- a/packages/ember-glimmer/lib/helpers/hash.js
+++ b/packages/ember-glimmer/lib/helpers/hash.js
@@ -27,6 +27,7 @@
    @for Ember.Templates.helpers
    @param {Object} options
    @return {Object} Hash
+   @since 2.3.0
    @public
  */
 


### PR DESCRIPTION
This is a simple change to the documentation for the hash helper.