### PR TITLE
Refactor `ember-metal/lib/transaction` module.

### DIFF
--- a/packages/ember-glimmer/lib/renderer.js
+++ b/packages/ember-glimmer/lib/renderer.js
@@ -3,8 +3,7 @@ import {
   run,
   setHasViews,
   assert,
-  runInTransaction as _runInTransaction,
-  isFeatureEnabled
+  runInTransaction
 } from 'ember-metal';
 import { CURRENT_TAG, UNDEFINED_REFERENCE } from '@glimmer/reference';
 import {
@@ -16,18 +15,6 @@ import {
 import { BOUNDS } from './component';
 import { RootComponentDefinition } from './syntax/curly-component';
 import { TopLevelOutletComponentDefinition } from './syntax/outlet';
-
-let runInTransaction;
-
-if (isFeatureEnabled('ember-glimmer-detect-backtracking-rerender') ||
-    isFeatureEnabled('ember-glimmer-allow-backtracking-rerender')) {
-  runInTransaction = _runInTransaction;
-} else {
-  runInTransaction = (context, methodName) => {
-    context[methodName]();
-    return false;
-  };
-}
 
 const { backburner } = run;
 

--- a/packages/ember-metal/lib/transaction.js
+++ b/packages/ember-metal/lib/transaction.js
@@ -4,20 +4,8 @@ import isEnabled from './features';
 
 let runInTransaction, didRender, assertNotRendered;
 
-let raise = assert;
-if (isEnabled('ember-glimmer-allow-backtracking-rerender')) {
-  raise = (message, test) => {
-    deprecate(message, test, { id: 'ember-views.render-double-modify', until: '3.0.0' });
-  };
-}
-
-let implication;
-if (isEnabled('ember-glimmer-allow-backtracking-rerender')) {
-  implication = 'will be removed in Ember 3.0.';
-} else if (isEnabled('ember-glimmer-detect-backtracking-rerender')) {
-  implication = 'is no longer supported. See https://github.com/emberjs/ember.js/issues/13948 for more details.';
-}
-
+// detect-backtracking-rerender by default is debug build only
+// detect-glimmer-allow-backtracking-rerender can be enabled in custom builds
 if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
     isEnabled('ember-glimmer-allow-backtracking-rerender')) {
   let counter = 0;
@@ -59,46 +47,44 @@ if (isEnabled('ember-glimmer-detect-backtracking-rerender') ||
     let lastRendered = meta.readableLastRendered();
 
     if (lastRendered && lastRendered[key] === counter) {
-      raise(
-        ((() => {
-          let templateMap = meta.readableLastRenderedTemplateMap();
-          let lastRenderedIn = templateMap[key];
-          let currentlyIn = debugStack.peek();
+      runInDebug(() => {
+        let templateMap = meta.readableLastRenderedTemplateMap();
+        let lastRenderedIn = templateMap[key];
+        let currentlyIn = debugStack.peek();
 
-          let referenceMap = meta.readableLastRenderedReferenceMap();
-          let lastRef = referenceMap[key];
-          let parts = [];
-          let label;
+        let referenceMap = meta.readableLastRenderedReferenceMap();
+        let lastRef = referenceMap[key];
+        let parts = [];
+        let label;
 
-          if (lastRef) {
-            while (lastRef && lastRef._propertyKey) {
-              parts.unshift(lastRef._propertyKey);
-              lastRef = lastRef._parentReference;
-            }
-
-            label = parts.join('.');
-          } else {
-            label = 'the same value';
+        if (lastRef) {
+          while (lastRef && lastRef._propertyKey) {
+            parts.unshift(lastRef._propertyKey);
+            lastRef = lastRef._parentReference;
           }
 
-          return `You modified "${label}" twice on ${object} in a single render. It was rendered in ${lastRenderedIn} and modified in ${currentlyIn}. This was unreliable and slow in Ember 1.x and ${implication}`;
-        })()),
-        false);
+          label = parts.join('.');
+        } else {
+          label = 'the same value';
+        }
+
+        let message = `You modified "${label}" twice on ${object} in a single render. It was rendered in ${lastRenderedIn} and modified in ${currentlyIn}. This was unreliable and slow in Ember 1.x and`;
+
+        if (isEnabled('ember-glimmer-allow-backtracking-rerender')) {
+          deprecate(`${message} will be removed in Ember 3.0.`, false, { id: 'ember-views.render-double-modify', until: '3.0.0' });
+        } else {
+          assert(`${message} is no longer supported. See https://github.com/emberjs/ember.js/issues/13948 for more details.`, false);
+        }
+      });
 
       shouldReflush = true;
     }
   };
 } else {
-  runInTransaction = () => {
-    throw new Error('Cannot call runInTransaction without Glimmer');
-  };
-
-  didRender = () => {
-    throw new Error('Cannot call didRender without Glimmer');
-  };
-
-  assertNotRendered = () => {
-    throw new Error('Cannot call assertNotRendered without Glimmer');
+  // in production do nothing to detect reflushes
+  runInTransaction = (context, methodName) => {
+    context[methodName]();
+    return false;
   };
 }
 


### PR DESCRIPTION
* Remove ambiguity around `raise` (is it an `assert` or is it a `deprecate` call).
* Remove dead code.
* Simplify ember-glimmer/lib/renderer by moving default implementation for `runInTransaction`
  into `ember-metal/lib/transaction`.