### PR TITLE
Fix yuidoc package paths

### DIFF
--- a/yuidoc.json
+++ b/yuidoc.json
@@ -17,10 +17,10 @@
       "packages/ember-testing/lib",
       "packages/ember-extension-support/lib",
       "packages/container/lib",
-      "bower_components/rsvp/lib",
-      "bower_components/router.js/lib/router"
+      "node_modules/rsvp/lib",
+      "node_modules/router_js/lib/router"
     ],
-    "exclude": "vendor,bower_components/router.js/lib/router/handler-info,bower_components/router.js/lib/router/transition-intent,bower_components/router.js/lib/router/router.js,bower_components/router.js/lib/router/transition-intent.js,bower_components/router.js/lib/router/transition-state.js,bower_components/router.js/lib/router/unrecognized-url-error.js,bower_components/router.js/lib/router/utils.js",
+    "exclude": "vendor,node_modules/router_js/lib/router/handler-info,node_modules/router_js/lib/router/transition-intent,node_modules/router_js/lib/router/router_js,node_modules/router_js/lib/router/transition-intent.js,node_modules/router_js/lib/router/transition-state.js,node_modules/router_js/lib/router/unrecognized-url-error.js,node_modules/router_js/lib/router/utils.js",
     "outdir":   "docs",
     "preprocessor": "bin/feature-flag-yuidoc-filter"
   }


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember.js/issues/14874.

This fixes one of the issues that we're seeing with the API docs. The RSVP classes are now displayed in the left hand nav:

**before**

<img width="700" alt="screen shot 2017-01-26 at 21 16 08" src="https://cloud.githubusercontent.com/assets/2526/22350753/e60c2fbe-e40c-11e6-80c4-efd2ebe07bd2.png">

**after**

<img width="757" alt="screen shot 2017-01-26 at 21 16 18" src="https://cloud.githubusercontent.com/assets/2526/22350761/e98c6848-e40c-11e6-837d-76bd7200d24f.png">
