### PR TITLE
[BUGFIX beta] reuse positional argument

### DIFF
--- a/packages/ember-glimmer/lib/helpers/component.js
+++ b/packages/ember-glimmer/lib/helpers/component.js
@@ -149,8 +149,8 @@ export class ClosureComponentReference extends CachedReference {
   constructor(args, symbolTable, env) {
     super();
     this.defRef = args.positional.at(0);
+    this.tag = this.defRef.tag;
     this.env = env;
-    this.tag = args.positional.at(0).tag;
     this.symbolTable = symbolTable;
     this.args = args;
     this.lastDefinition = undefined;


### PR DESCRIPTION
no need to `args.positional.at(0)` twice