### PR TITLE
add a test to prevent regression of #14888

### DIFF
--- a/packages/ember-glimmer/tests/integration/helpers/element-action-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/element-action-test.js
@@ -1423,4 +1423,35 @@ moduleFor('Helpers test: element action', class extends RenderingTest {
 
     this.assertText('Click me');
   }
+
+  ['@test it supports non-registered actions [GH#14888]']() {
+    this.registerComponent('example-component', {
+      template: '{{yield}}'
+    });
+
+    this.render(`
+      {{#unless hide}}
+        {{#example-component}}
+          <button {{action (mut hide) true}}>hide ({{hide}})</button>
+        {{/example-component}}
+      {{else}}
+        <button {{action (mut hide) false}}>show ({{hide}})</button>
+      {{/unless}}
+    `, { hide: false });
+
+    //add a non-registered action to simulate the effect of jQuery triggering a
+    //`focusout` event on `removeChild` (see GH#14888)
+    this.$('button')[0].setAttribute('data-ember-action-999999999', 999999999);
+
+    this.assert.equal(this.$('button').text(), 'hide (false)');
+
+    this.runTask(() => this.$('button').click());
+
+    this.assert.equal(this.$('button').text(), 'show (true)');
+
+    this.runTask(() => this.$('button').click());
+
+    this.assert.equal(this.$('button').text(), 'hide (false)');
+  }
+
 });


### PR DESCRIPTION
I've had to resort to adding a non-existent `data-ember-action-999999999` attribute to the element as I couldn't find a way to exercise the [`if (action && action.eventName === eventName) {`](https://github.com/emberjs/ember.js/pull/14890/files#diff-c7b9de937661f47b233bb5e3101436e0R233) guard without it. The component test doesn't seem to result in a `focusout` event being raised when the element is removed as it does in a production app.

This isn't ideal, a change to how we attribute actions to elements mightn't result in this test failing.

/cc @rwjblue perhaps you have some ideas on how we could remove the brittleness from this test?


**here's the test failing without https://github.com/emberjs/ember.js/pull/14890:**

<img width="1148" alt="screen shot 2017-01-31 at 15 38 58" src="https://cloud.githubusercontent.com/assets/2526/22471849/8439a7fe-e7cb-11e6-8d4c-38889169220b.png">


