### PR TITLE
[FEATURE ember-no-double-extend] Enable by default

### DIFF
--- a/features.json
+++ b/features.json
@@ -7,7 +7,7 @@
     "ember-glimmer-allow-backtracking-rerender": null,
     "ember-testing-resume-test": null,
     "ember-factory-for": true,
-    "ember-no-double-extend": null,
+    "ember-no-double-extend": true,
     "ember-routing-router-service": null,
     "ember-unique-location-history-state": null
   }


### PR DESCRIPTION
As the second phase to the `.factoryFor` rollout, this updates canary (targeted at ember-source@2.13) to disable the double extend.