### PR TITLE
[BUGFIX] Changed backburner's error handler to use `dispatchError` instead of `onError`

### DIFF
--- a/packages/ember-metal/lib/error_handler.js
+++ b/packages/ember-metal/lib/error_handler.js
@@ -34,6 +34,9 @@ export function dispatchError(error) {
 }
 
 // allows testing adapter to override dispatch
+export function getDispatchOverride() {
+  return dispatchOverride;
+}
 export function setDispatchOverride(handler) {
   dispatchOverride = handler;
 }

--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -2,7 +2,7 @@ import { GUID_KEY } from 'ember-utils';
 import { assert } from './debug';
 import { isTesting } from './testing';
 import {
-  getOnerror,
+  dispatchError,
   setOnerror
 } from './error_handler';
 import {
@@ -21,7 +21,7 @@ function onEnd(current, next) {
 
 const onErrorTarget = {
   get onerror() {
-    return getOnerror();
+    return dispatchError;
   },
   set onerror(handler) {
     return setOnerror(handler);

--- a/packages/ember-metal/tests/run_loop/onerror_test.js
+++ b/packages/ember-metal/tests/run_loop/onerror_test.js
@@ -1,5 +1,6 @@
 import run from '../../run_loop';
-import { setOnerror, getOnerror } from '../../error_handler';
+import { setOnerror, getOnerror, setDispatchOverride, getDispatchOverride } from '../../error_handler';
+import { isTesting, setTesting } from '../../testing';
 
 QUnit.module('system/run_loop/onerror_test');
 
@@ -23,13 +24,20 @@ QUnit.test('With Ember.onerror undefined, errors in Ember.run are thrown', funct
 QUnit.test('With Ember.onerror set, errors in Ember.run are caught', function () {
   let thrown = new Error('Boom!');
   let original = getOnerror();
+  let originalDispatchOverride = getDispatchOverride();
+  let originalIsTesting = isTesting();
 
   let caught;
   setOnerror(error => { caught = error; });
+  setDispatchOverride(null);
+  setTesting(false);
+
   try {
     run(() => { throw thrown; });
   } finally {
     setOnerror(original);
+    setDispatchOverride(originalDispatchOverride);
+    setTesting(originalIsTesting);
   }
 
   deepEqual(caught, thrown);

--- a/packages/ember-testing/tests/adapters_test.js
+++ b/packages/ember-testing/tests/adapters_test.js
@@ -12,9 +12,11 @@ QUnit.module('ember-testing Adapters', {
     originalQUnit = window.QUnit;
   },
   teardown() {
-    run(App, App.destroy);
-    App.removeTestHelpers();
-    App = null;
+    if (App) {
+      run(App, App.destroy);
+      App.removeTestHelpers();
+      App = null;
+    }
 
     Test.adapter = originalAdapter;
     window.QUnit = originalQUnit;
@@ -67,4 +69,19 @@ QUnit.test('Adapter is used by default (if QUnit is not available)', function() 
 
   ok(Test.adapter instanceof Adapter);
   ok(!(Test.adapter instanceof QUnitAdapter));
+});
+
+QUnit.test('With Ember.Test.adapter set, errors in Ember.run are caught', function () {
+  let thrown = new Error('Boom!');
+
+  let caught;
+  Test.adapter = QUnitAdapter.create({
+    exception(error) {
+      caught = error;
+    }
+  });
+
+  run(() => { throw thrown; });
+
+  deepEqual(caught, thrown);
 });


### PR DESCRIPTION
This is so that backburner errors can be caught by the `Test.adapter`. Fixes #14864 (more details about the reason for this change in the issue).