### PR TITLE
[Docs] Change focus-in to focus-out

### DIFF
--- a/packages/ember-glimmer/lib/components/text_area.js
+++ b/packages/ember-glimmer/lib/components/text_area.js
@@ -153,7 +153,7 @@ import layout from '../templates/empty';
   you only need to setup the action name to the event name property.
 
   ```handlebars
-  {{textarea focus-in="alertMessage"}}
+  {{textarea focus-out="alertMessage"}}
   ```
 
   See more about [Text Support Actions](/api/classes/Ember.TextArea.html)


### PR DESCRIPTION
The docs says
 `For example, if you desire an action to be sent when the input is blurred,
  you only need to setup the action name to the event name property.`

So thought,  it should be focus-out