### PR TITLE
[DOC release] Fix dead module references

### DIFF
--- a/packages/ember-runtime/lib/system/object_proxy.js
+++ b/packages/ember-runtime/lib/system/object_proxy.js
@@ -67,7 +67,7 @@ import _ProxyMixin from '../mixins/-proxy';
   @class ObjectProxy
   @namespace Ember
   @extends Ember.Object
-  @extends Ember._ProxyMixin
+  @uses Ember.ProxyMixin
   @public
 */
 

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -8,9 +8,6 @@
   @namespace Ember
   @extends Ember.CoreView
   @deprecated See http://emberjs.com/deprecations/v1.x/#toc_ember-view
-  @uses Ember.ViewSupport
-  @uses Ember.ChildViewsSupport
   @uses Ember.ClassNamesSupport
-  @uses Ember.AttributeBindingsSupport
   @private
 */


### PR DESCRIPTION
Eliminated obsolete ones and corrected spelling and `@uses` usage on another.