### PR TITLE
Clearing references resolve memory leaks

### DIFF
--- a/packages/ember-glimmer/lib/component.js
+++ b/packages/ember-glimmer/lib/component.js
@@ -575,6 +575,13 @@ const Component = CoreView.extend(
       assert(`You cannot use a computed property for the component's \`tagName\` (${this}).`, !(this.tagName && this.tagName.isDescriptor));
     },
 
+    destroy: function () {
+      this._super(...arguments);
+
+      this[ROOT_REF] = undefined;
+      this[BOUNDS] = undefined;
+    },
+
     rerender() {
       this[DIRTY_TAG].dirty();
       this._super();

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -171,6 +171,20 @@ export class Meta {
     }
 
     this.setMetaDestroyed();
+
+    this._weak = undefined;
+    this._watching = undefined;
+    this._mixins = undefined;
+    this._bindings = undefined;
+    this._values = undefined;
+    this._deps = undefined;
+    this._chainWatchers = undefined;
+    this._chains = undefined;
+    this._tag = undefined;
+    this._tags = undefined;
+    this.parent = undefined;
+    this._lastRenderedReferenceMap = undefined;
+    this._listeners = undefined;
   }
 
   isSourceDestroying() {


### PR DESCRIPTION
Maintaining these references results in detached DOM trees