### PR TITLE
Rename of Ember.Router.router to Ember.Router.routerMicrolib

### DIFF
--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -262,8 +262,8 @@ const ApplicationInstance = EngineInstance.extend({
     let handleTransitionReject = (error) => {
       if (error.error) {
         throw error.error;
-      } else if (error.name === 'TransitionAborted' && router.router.activeTransition) {
-        return router.router.activeTransition.then(handleTransitionResolve, handleTransitionReject);
+      } else if (error.name === 'TransitionAborted' && router._routerMicrolib.activeTransition) {
+        return router._routerMicrolib.activeTransition.then(handleTransitionResolve, handleTransitionReject);
       } else if (error.name === 'TransitionAborted') {
         throw new Error(error.message);
       } else {

--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -24,6 +24,7 @@ export {
   debugSeal,
   debugFreeze
 } from './debug';
+export { deprecateProperty } from './deprecate_property';
 export {
   instrument,
   flaggedInstrument,

--- a/packages/ember-routing/lib/services/routing.js
+++ b/packages/ember-routing/lib/services/routing.js
@@ -58,7 +58,7 @@ export default Service.extend({
 
   generateURL(routeName, models, queryParams) {
     let router = get(this, 'router');
-    if (!router.router) { return; }
+    if (!router._routerMicrolib) { return; }
 
     let visibleQueryParams = {};
     assign(visibleQueryParams, queryParams);
@@ -72,7 +72,7 @@ export default Service.extend({
   isActiveForRoute(contexts, queryParams, routeName, routerState, isCurrentWhenSpecified) {
     let router = get(this, 'router');
 
-    let handlers = router.router.recognizer.handlersFor(routeName);
+    let handlers = router._routerMicrolib.recognizer.handlersFor(routeName);
     let leafName = handlers[handlers.length - 1].handler;
     let maximumContexts = numberOfContextsAcceptedByHandler(routeName, handlers);
 

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -399,8 +399,8 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
       return {};
     }
 
-    let transition = this.router.router.activeTransition;
-    let state = transition ? transition.state : this.router.router.state;
+    let transition = this.router._routerMicrolib.activeTransition;
+    let state = transition ? transition.state : this.router._routerMicrolib.state;
 
     let fullName = route.fullRouteName;
     let params = assign({}, state.params[fullName]);
@@ -1180,7 +1180,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     @public
    */
   refresh() {
-    return this.router.router.refresh(this);
+    return this.router._routerMicrolib.refresh(this);
   },
 
   /**
@@ -1277,7 +1277,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     @public
   */
   send(...args) {
-    if ((this.router && this.router.router) || !isTesting()) {
+    if ((this.router && this.router._routerMicrolib) || !isTesting()) {
       this.router.send(...args);
     } else {
       let name = args[0];
@@ -1888,14 +1888,14 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
 
     // Only change the route name when there is an active transition.
     // Otherwise, use the passed in route name.
-    if (owner.routable && this.router && this.router.router.activeTransition) {
+    if (owner.routable && this.router && this.router._routerMicrolib.activeTransition) {
       name = getEngineRouteName(owner, _name);
     } else {
       name = _name;
     }
 
     let route = getOwner(this).lookup(`route:${name}`);
-    let transition = this.router ? this.router.router.activeTransition : null;
+    let transition = this.router ? this.router._routerMicrolib.activeTransition : null;
 
     // If we are mid-transition, we want to try and look up
     // resolved parent contexts on the current transitionEvent.
@@ -2165,12 +2165,12 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     parentView = parentView && parentView.replace(/\//g, '.');
     outletName = outletName || 'main';
     this._disconnectOutlet(outletName, parentView);
-    for (let i = 0; i < this.router.router.currentHandlerInfos.length; i++) {
+    for (let i = 0; i < this.router._routerMicrolib.currentHandlerInfos.length; i++) {
       // This non-local state munging is sadly necessary to maintain
       // backward compatibility with our existing semantics, which allow
       // any route to disconnectOutlet things originally rendered by any
       // other route. This should all get cut in 2.0.
-      this.router.router
+      this.router._routerMicrolib
         .currentHandlerInfos[i]
         .handler._disconnectOutlet(outletName, parentView);
     }
@@ -2228,7 +2228,7 @@ Route.reopenClass({
 });
 
 function parentRoute(route) {
-  let handlerInfo = handlerInfoFor(route, route.router.router.state.handlerInfos, -1);
+  let handlerInfo = handlerInfoFor(route, route.router._routerMicrolib.state.handlerInfos, -1);
   return handlerInfo && handlerInfo.handler;
 }
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -16,7 +16,8 @@ import {
   computed,
   run,
   runInDebug,
-  deprecate
+  deprecate,
+  deprecateProperty
 } from 'ember-metal';
 import {
   Object as EmberObject,
@@ -92,11 +93,11 @@ const EmberRouter = EmberObject.extend(Evented, {
   rootURL: '/',
 
   _initRouterJs() {
-    let router = this.router = new Router();
-    router.triggerEvent = triggerEvent;
+    let routerMicrolib = this._routerMicrolib = new Router();
+    routerMicrolib.triggerEvent = triggerEvent;
 
-    router._triggerWillChangeContext = K;
-    router._triggerWillLeave = K;
+    routerMicrolib._triggerWillChangeContext = K;
+    routerMicrolib._triggerWillLeave = K;
 
     let dslCallbacks = this.constructor.dslCallbacks || [K];
     let dsl = this._buildDSL();
@@ -109,11 +110,11 @@ const EmberRouter = EmberObject.extend(Evented, {
 
     runInDebug(() => {
       if (get(this, 'namespace.LOG_TRANSITIONS_INTERNAL')) {
-        router.log = Logger.debug;
+        routerMicrolib.log = Logger.debug;
       }
     });
 
-    router.map(dsl.generate());
+    routerMicrolib.map(dsl.generate());
   },
 
   _buildDSL() {
@@ -210,7 +211,6 @@ const EmberRouter = EmberObject.extend(Evented, {
     this._initRouterJs();
     this._setupLocation();
 
-    let router = this.router;
     let location = get(this, 'location');
 
     // Allow the Location class to cancel the router setup while it refreshes
@@ -219,7 +219,7 @@ const EmberRouter = EmberObject.extend(Evented, {
       return false;
     }
 
-    this._setupRouter(router, location);
+    this._setupRouter(location);
 
     location.onUpdateURL(url => {
       this.handleURL(url);
@@ -281,7 +281,7 @@ const EmberRouter = EmberObject.extend(Evented, {
     // to create another this._toplevelView (and leak the renderer)
     if (this.isDestroying || this.isDestroyed) { return; }
 
-    let handlerInfos = this.router.currentHandlerInfos;
+    let handlerInfos = this._routerMicrolib.currentHandlerInfos;
     let route;
     let defaultParentState;
     let liveRoutes = null;
@@ -356,7 +356,7 @@ const EmberRouter = EmberObject.extend(Evented, {
   },
 
   _doURLTransition(routerJsMethod, url) {
-    let transition = this.router[routerJsMethod](url || '/');
+    let transition = this._routerMicrolib[routerJsMethod](url || '/');
     didBeginTransition(transition, this);
     return transition;
   },
@@ -395,12 +395,12 @@ const EmberRouter = EmberObject.extend(Evented, {
   },
 
   intermediateTransitionTo() {
-    this.router.intermediateTransitionTo(...arguments);
+    this._routerMicrolib.intermediateTransitionTo(...arguments);
 
     updatePaths(this);
 
     runInDebug(() => {
-      let infos = this.router.currentHandlerInfos;
+      let infos = this._routerMicrolib.currentHandlerInfos;
       if (get(this, 'namespace').LOG_TRANSITIONS) {
         Logger.log(`Intermediate-transitioned into '${EmberRouter._routePath(infos)}'`);
       }
@@ -412,7 +412,7 @@ const EmberRouter = EmberObject.extend(Evented, {
   },
 
   generate() {
-    let url = this.router.generate(...arguments);
+    let url = this._routerMicrolib.generate(...arguments);
     return this.location.formatURL(url);
   },
 
@@ -425,8 +425,7 @@ const EmberRouter = EmberObject.extend(Evented, {
     @private
   */
   isActive(routeName) {
-    let router = this.router;
-    return router.isActive(...arguments);
+    return this._routerMicrolib.isActive(...arguments);
   },
 
   /**
@@ -447,7 +446,7 @@ const EmberRouter = EmberObject.extend(Evented, {
   },
 
   send(name, context) {
-    this.router.trigger(...arguments);
+    this._routerMicrolib.trigger(...arguments);
   },
 
   /**
@@ -458,7 +457,7 @@ const EmberRouter = EmberObject.extend(Evented, {
     @private
   */
   hasRoute(route) {
-    return this.router.hasRoute(route);
+    return this._routerMicrolib.hasRoute(route);
   },
 
   /**
@@ -469,8 +468,8 @@ const EmberRouter = EmberObject.extend(Evented, {
     @method reset
    */
   reset() {
-    if (this.router) {
-      this.router.reset();
+    if (this._routerMicrolib) {
+      this._routerMicrolib.reset();
     }
   },
 
@@ -633,19 +632,20 @@ const EmberRouter = EmberObject.extend(Evented, {
     };
   },
 
-  _setupRouter(router, location) {
+  _setupRouter(location) {
     let lastURL;
     let emberRouter = this;
+    let routerMicrolib = this._routerMicrolib;
 
-    router.getHandler = this._getHandlerFunction();
-    router.getSerializer = this._getSerializerFunction();
+    routerMicrolib.getHandler = this._getHandlerFunction();
+    routerMicrolib.getSerializer = this._getSerializerFunction();
 
     let doUpdateURL = () => {
       location.setURL(lastURL);
       set(emberRouter, 'currentURL', lastURL);
     };
 
-    router.updateURL = path => {
+    routerMicrolib.updateURL = path => {
       lastURL = path;
       run.once(doUpdateURL);
     };
@@ -656,17 +656,17 @@ const EmberRouter = EmberObject.extend(Evented, {
         set(emberRouter, 'currentURL', lastURL);
       };
 
-      router.replaceURL = path => {
+      routerMicrolib.replaceURL = path => {
         lastURL = path;
         run.once(doReplaceURL);
       };
     }
 
-    router.didTransition = infos => {
+    routerMicrolib.didTransition = infos => {
       emberRouter.didTransition(infos);
     };
 
-    router.willTransition = (oldInfos, newInfos, transition) => {
+    routerMicrolib.willTransition = (oldInfos, newInfos, transition) => {
       emberRouter.willTransition(oldInfos, newInfos, transition);
     };
   },
@@ -770,8 +770,8 @@ const EmberRouter = EmberObject.extend(Evented, {
   },
 
   _doTransition(_targetRouteName, models, _queryParams) {
-    let targetRouteName = _targetRouteName || getActiveTargetName(this.router);
-    assert(`The route ${targetRouteName} was not found`, targetRouteName && this.router.hasRoute(targetRouteName));
+    let targetRouteName = _targetRouteName || getActiveTargetName(this._routerMicrolib);
+    assert(`The route ${targetRouteName} was not found`, targetRouteName && this._routerMicrolib.hasRoute(targetRouteName));
 
     let queryParams = {};
 
@@ -781,7 +781,7 @@ const EmberRouter = EmberObject.extend(Evented, {
     this._prepareQueryParams(targetRouteName, models, queryParams);
 
     let transitionArgs = routeArgs(targetRouteName, models, queryParams);
-    let transition = this.router.transitionTo(...transitionArgs);
+    let transition = this._routerMicrolib.transitionTo(...transitionArgs);
 
     didBeginTransition(transition, this);
 
@@ -791,13 +791,13 @@ const EmberRouter = EmberObject.extend(Evented, {
   _processActiveTransitionQueryParams(targetRouteName, models, queryParams, _queryParams) {
     // merge in any queryParams from the active transition which could include
     // queryParams from the url on initial load.
-    if (!this.router.activeTransition) { return; }
+    if (!this._routerMicrolib.activeTransition) { return; }
 
     var unchangedQPs = {};
     var qpUpdates = this._qpUpdates || {};
-    for (var key in this.router.activeTransition.queryParams) {
+    for (var key in this._routerMicrolib.activeTransition.queryParams) {
       if (!qpUpdates[key]) {
-        unchangedQPs[key] = this.router.activeTransition.queryParams[key];
+        unchangedQPs[key] = this._routerMicrolib.activeTransition.queryParams[key];
       }
     }
 
@@ -985,7 +985,7 @@ const EmberRouter = EmberObject.extend(Evented, {
   targetState: null,
 
   _handleSlowTransition(transition, originRoute) {
-    if (!this.router.activeTransition) {
+    if (!this._routerMicrolib.activeTransition) {
       // Don't fire an event if we've since moved on from
       // the transition that put us in a loading state.
       return;
@@ -993,8 +993,8 @@ const EmberRouter = EmberObject.extend(Evented, {
 
     this.set('targetState', RouterState.create({
       emberRouter: this,
-      routerJs: this.router,
-      routerJsState: this.router.activeTransition.state
+      routerJs: this._routerMicrolib,
+      routerJsState: this._routerMicrolib.activeTransition.state
     }));
 
     transition.trigger(true, 'loading', transition, originRoute);
@@ -1283,8 +1283,8 @@ export function triggerEvent(handlerInfos, ignoreFailure, args) {
 }
 
 function calculatePostTransitionState(emberRouter, leafRouteName, contexts) {
-  let routerjs = emberRouter.router;
-  let state = routerjs.applyIntent(leafRouteName, contexts);
+  let routerMicrolib = emberRouter._routerMicrolib;
+  let state = routerMicrolib.applyIntent(leafRouteName, contexts);
   let handlerInfos = state.handlerInfos;
   let params = state.params;
 
@@ -1302,7 +1302,7 @@ function calculatePostTransitionState(emberRouter, leafRouteName, contexts) {
 }
 
 function updatePaths(router) {
-  let infos = router.router.currentHandlerInfos;
+  let infos = router._routerMicrolib.currentHandlerInfos;
   if (infos.length === 0) { return; }
 
   let path = EmberRouter._routePath(infos);
@@ -1429,7 +1429,7 @@ EmberRouter.reopenClass({
 function didBeginTransition(transition, router) {
   let routerState = RouterState.create({
     emberRouter: router,
-    routerJs: router.router,
+    routerJs: router._routerMicrolib,
     routerJsState: transition.state
   });
 
@@ -1562,5 +1562,11 @@ function representEmptyRoute(liveRoutes, defaultParentState, route) {
     return defaultParentState;
   }
 }
+
+deprecateProperty(EmberRouter.prototype, 'router', '_routerMicrolib', {
+  id: 'ember-router.router',
+  until: '2.16',
+  url: 'http://emberjs.com/deprecations/v2.x/#toc_ember-router-router-renamed-to-ember-router-_routerMicrolib'
+});
 
 export default EmberRouter;

--- a/packages/ember-routing/lib/utils.js
+++ b/packages/ember-routing/lib/utils.js
@@ -29,7 +29,7 @@ export function stashParamNames(router, handlerInfos) {
   // on whether a URL transition or named transition is happening.
   // Hopefully we can remove this in the future.
   let targetRouteName = handlerInfos[handlerInfos.length - 1].name;
-  let recogHandlers = router.router.recognizer.handlersFor(targetRouteName);
+  let recogHandlers = router._routerMicrolib.recognizer.handlersFor(targetRouteName);
   let dynamicParent = null;
 
   for (let i = 0; i < handlerInfos.length; ++i) {

--- a/packages/ember-routing/tests/system/dsl_test.js
+++ b/packages/ember-routing/tests/system/dsl_test.js
@@ -62,9 +62,9 @@ QUnit.test('should reset namespace if nested with resource', function() {
   let router = Router.create();
   router._initRouterJs();
 
-  ok(router.router.recognizer.names['bleep'], 'nested resources do not contain parent name');
-  ok(router.router.recognizer.names['bloop'], 'nested resources do not contain parent name');
-  ok(router.router.recognizer.names['blork'], 'nested resources do not contain parent name');
+  ok(router._routerMicrolib.recognizer.names['bleep'], 'nested resources do not contain parent name');
+  ok(router._routerMicrolib.recognizer.names['bloop'], 'nested resources do not contain parent name');
+  ok(router._routerMicrolib.recognizer.names['blork'], 'nested resources do not contain parent name');
 });
 
 QUnit.test('should retain resource namespace if nested with routes', function() {
@@ -79,9 +79,9 @@ QUnit.test('should retain resource namespace if nested with routes', function() 
   let router = Router.create();
   router._initRouterJs();
 
-  ok(router.router.recognizer.names['bleep'], 'parent name was used as base of nested routes');
-  ok(router.router.recognizer.names['bleep.bloop'], 'parent name was used as base of nested routes');
-  ok(router.router.recognizer.names['bleep.bloop.blork'], 'parent name was used as base of nested routes');
+  ok(router._routerMicrolib.recognizer.names['bleep'], 'parent name was used as base of nested routes');
+  ok(router._routerMicrolib.recognizer.names['bleep.bloop'], 'parent name was used as base of nested routes');
+  ok(router._routerMicrolib.recognizer.names['bleep.bloop.blork'], 'parent name was used as base of nested routes');
 });
 
 QUnit.test('should add loading and error routes if _isRouterMapResult is true', function() {
@@ -95,9 +95,9 @@ QUnit.test('should add loading and error routes if _isRouterMapResult is true', 
 
   router._initRouterJs();
 
-  ok(router.router.recognizer.names['blork'], 'main route was created');
-  ok(router.router.recognizer.names['blork_loading'], 'loading route was added');
-  ok(router.router.recognizer.names['blork_error'], 'error route was added');
+  ok(router._routerMicrolib.recognizer.names['blork'], 'main route was created');
+  ok(router._routerMicrolib.recognizer.names['blork_loading'], 'loading route was added');
+  ok(router._routerMicrolib.recognizer.names['blork_error'], 'error route was added');
 });
 
 QUnit.test('should not add loading and error routes if _isRouterMapResult is false', function() {
@@ -108,9 +108,9 @@ QUnit.test('should not add loading and error routes if _isRouterMapResult is fal
   let router = Router.create();
   router._initRouterJs(false);
 
-  ok(router.router.recognizer.names['blork'], 'main route was created');
-  ok(!router.router.recognizer.names['blork_loading'], 'loading route was not added');
-  ok(!router.router.recognizer.names['blork_error'], 'error route was not added');
+  ok(router._routerMicrolib.recognizer.names['blork'], 'main route was created');
+  ok(!router._routerMicrolib.recognizer.names['blork_loading'], 'loading route was not added');
+  ok(!router._routerMicrolib.recognizer.names['blork_error'], 'error route was not added');
 });
 
 QUnit.test('should reset namespace of loading and error routes for routes with resetNamespace', function() {
@@ -127,17 +127,17 @@ QUnit.test('should reset namespace of loading and error routes for routes with r
 
   router._initRouterJs();
 
-  ok(router.router.recognizer.names['blork.blorp'], 'nested route was created');
-  ok(router.router.recognizer.names['blork.blorp_loading'], 'nested loading route was added');
-  ok(router.router.recognizer.names['blork.blorp_error'], 'nested error route was added');
+  ok(router._routerMicrolib.recognizer.names['blork.blorp'], 'nested route was created');
+  ok(router._routerMicrolib.recognizer.names['blork.blorp_loading'], 'nested loading route was added');
+  ok(router._routerMicrolib.recognizer.names['blork.blorp_error'], 'nested error route was added');
 
-  ok(router.router.recognizer.names['bleep'], 'reset route was created');
-  ok(router.router.recognizer.names['bleep_loading'], 'reset loading route was added');
-  ok(router.router.recognizer.names['bleep_error'], 'reset error route was added');
+  ok(router._routerMicrolib.recognizer.names['bleep'], 'reset route was created');
+  ok(router._routerMicrolib.recognizer.names['bleep_loading'], 'reset loading route was added');
+  ok(router._routerMicrolib.recognizer.names['bleep_error'], 'reset error route was added');
 
-  ok(!router.router.recognizer.names['blork.bleep'], 'nested reset route was not created');
-  ok(!router.router.recognizer.names['blork.bleep_loading'], 'nested reset loading route was not added');
-  ok(!router.router.recognizer.names['blork.bleep_error'], 'nested reset error route was not added');
+  ok(!router._routerMicrolib.recognizer.names['blork.bleep'], 'nested reset route was not created');
+  ok(!router._routerMicrolib.recognizer.names['blork.bleep_loading'], 'nested reset loading route was not added');
+  ok(!router._routerMicrolib.recognizer.names['blork.bleep_error'], 'nested reset error route was not added');
 });
 
 QUnit.test('should throw an error when defining a route serializer outside an engine', function() {
@@ -174,9 +174,9 @@ QUnit.test('should allow mounting of engines', function(assert) {
   setOwner(router, engineInstance);
   router._initRouterJs();
 
-  assert.ok(router.router.recognizer.names['bleep'], 'parent name was used as base of nested routes');
-  assert.ok(router.router.recognizer.names['bleep.bloop'], 'parent name was used as base of nested routes');
-  assert.ok(router.router.recognizer.names['bleep.bloop.chat'], 'parent name was used as base of mounted engine');
+  assert.ok(router._routerMicrolib.recognizer.names['bleep'], 'parent name was used as base of nested routes');
+  assert.ok(router._routerMicrolib.recognizer.names['bleep.bloop'], 'parent name was used as base of nested routes');
+  assert.ok(router._routerMicrolib.recognizer.names['bleep.bloop.chat'], 'parent name was used as base of mounted engine');
 });
 
 QUnit.test('should allow mounting of engines at a custom path', function(assert) {
@@ -199,7 +199,7 @@ QUnit.test('should allow mounting of engines at a custom path', function(assert)
   router._initRouterJs();
 
   assert.deepEqual(
-    router.router.recognizer.names['bleep.bloop.chat']
+    router._routerMicrolib.recognizer.names['bleep.bloop.chat']
       .segments
       .slice(1, 4)
       .map(s => s.value),
@@ -227,7 +227,7 @@ QUnit.test('should allow aliasing of engine names with `as`', function(assert) {
   router._initRouterJs();
 
   assert.deepEqual(
-    router.router.recognizer.names['bleep.bloop.blork']
+    router._routerMicrolib.recognizer.names['bleep.bloop.blork']
       .segments
       .slice(1, 4)
       .map(s => s.value),
@@ -250,9 +250,9 @@ QUnit.test('should add loading and error routes to a mount if _isRouterMapResult
   setOwner(router, engineInstance);
   router._initRouterJs();
 
-  ok(router.router.recognizer.names['chat'], 'main route was created');
-  ok(router.router.recognizer.names['chat_loading'], 'loading route was added');
-  ok(router.router.recognizer.names['chat_error'], 'error route was added');
+  ok(router._routerMicrolib.recognizer.names['chat'], 'main route was created');
+  ok(router._routerMicrolib.recognizer.names['chat_loading'], 'loading route was added');
+  ok(router._routerMicrolib.recognizer.names['chat_error'], 'error route was added');
 });
 
 QUnit.test('should add loading and error routes to a mount alias if _isRouterMapResult is true', function() {
@@ -270,9 +270,9 @@ QUnit.test('should add loading and error routes to a mount alias if _isRouterMap
   setOwner(router, engineInstance);
   router._initRouterJs();
 
-  ok(router.router.recognizer.names['shoutbox'], 'main route was created');
-  ok(router.router.recognizer.names['shoutbox_loading'], 'loading route was added');
-  ok(router.router.recognizer.names['shoutbox_error'], 'error route was added');
+  ok(router._routerMicrolib.recognizer.names['shoutbox'], 'main route was created');
+  ok(router._routerMicrolib.recognizer.names['shoutbox_loading'], 'loading route was added');
+  ok(router._routerMicrolib.recognizer.names['shoutbox_error'], 'error route was added');
 });
 
 QUnit.test('should not add loading and error routes to a mount if _isRouterMapResult is false', function() {
@@ -288,9 +288,9 @@ QUnit.test('should not add loading and error routes to a mount if _isRouterMapRe
   setOwner(router, engineInstance);
   router._initRouterJs(false);
 
-  ok(router.router.recognizer.names['chat'], 'main route was created');
-  ok(!router.router.recognizer.names['chat_loading'], 'loading route was not added');
-  ok(!router.router.recognizer.names['chat_error'], 'error route was not added');
+  ok(router._routerMicrolib.recognizer.names['chat'], 'main route was created');
+  ok(!router._routerMicrolib.recognizer.names['chat_loading'], 'loading route was not added');
+  ok(!router._routerMicrolib.recognizer.names['chat_error'], 'error route was not added');
 });
 
 QUnit.test('should reset namespace of loading and error routes for mounts with resetNamespace', function() {
@@ -311,15 +311,15 @@ QUnit.test('should reset namespace of loading and error routes for mounts with r
   setOwner(router, engineInstance);
   router._initRouterJs();
 
-  ok(router.router.recognizer.names['news.chat'], 'nested route was created');
-  ok(router.router.recognizer.names['news.chat_loading'], 'nested loading route was added');
-  ok(router.router.recognizer.names['news.chat_error'], 'nested error route was added');
+  ok(router._routerMicrolib.recognizer.names['news.chat'], 'nested route was created');
+  ok(router._routerMicrolib.recognizer.names['news.chat_loading'], 'nested loading route was added');
+  ok(router._routerMicrolib.recognizer.names['news.chat_error'], 'nested error route was added');
 
-  ok(router.router.recognizer.names['blog'], 'reset route was created');
-  ok(router.router.recognizer.names['blog_loading'], 'reset loading route was added');
-  ok(router.router.recognizer.names['blog_error'], 'reset error route was added');
+  ok(router._routerMicrolib.recognizer.names['blog'], 'reset route was created');
+  ok(router._routerMicrolib.recognizer.names['blog_loading'], 'reset loading route was added');
+  ok(router._routerMicrolib.recognizer.names['blog_error'], 'reset error route was added');
 
-  ok(!router.router.recognizer.names['news.blog'], 'nested reset route was not created');
-  ok(!router.router.recognizer.names['news.blog_loading'], 'nested reset loading route was not added');
-  ok(!router.router.recognizer.names['news.blog_error'], 'nested reset error route was not added');
+  ok(!router._routerMicrolib.recognizer.names['news.blog'], 'nested reset route was not created');
+  ok(!router._routerMicrolib.recognizer.names['news.blog_loading'], 'nested reset loading route was not added');
+  ok(!router._routerMicrolib.recognizer.names['news.blog_error'], 'nested reset error route was not added');
 });

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -339,7 +339,7 @@ QUnit.test('paramsFor considers an engine\'s mountPoint', function(assert) {
 
   let router = {
     _deserializeQueryParams() {},
-    router: {
+    _routerMicrolib: {
       state: {
         handlerInfos: [
           { name: 'posts' }
@@ -387,7 +387,7 @@ QUnit.test('modelFor considers an engine\'s mountPoint', function() {
   let postsModel = { id: '2' };
 
   let router = {
-    router: {
+    _routerMicrolib: {
       activeTransition: {
         resolvedModels: {
           'foo.bar': applicationModel,

--- a/packages/ember-routing/tests/system/router_test.js
+++ b/packages/ember-routing/tests/system/router_test.js
@@ -48,7 +48,7 @@ QUnit.test('can create a router without an owner', function() {
 QUnit.test('should not create a router.js instance upon init', function() {
   let router = createRouter(null, { disableSetup: true });
 
-  ok(!router.router);
+  ok(!router._routerMicrolib);
 });
 
 QUnit.test('should not reify location until setupRouter is called', function() {
@@ -254,4 +254,22 @@ QUnit.test('Router#triggerEvent ignores handlers that have not loaded yet', func
   ];
 
   triggerEvent(handlerInfos, false, ['loading']);
+});
+
+QUnit.test('Router#router deprecates when called', function(assert) {
+  assert.expect(2);
+
+  let router = createRouter();
+
+  expectDeprecation(function() {
+    assert.equal(router.router, router._routerMicrolib);
+  }, 'Usage of `router` is deprecated, use `_routerMicrolib` instead.');
+});
+
+QUnit.test('Router#_routerMicrolib can be used without deprecation', function(assert) {
+  assert.expect(1);
+
+  let router = createRouter();
+
+  assert.ok(router._routerMicrolib, 'Router._routerMicrolib can be used without deprecation');
 });

--- a/packages/ember-testing/lib/helpers/wait.js
+++ b/packages/ember-testing/lib/helpers/wait.js
@@ -41,7 +41,7 @@ export default function wait(app, value) {
     // Every 10ms, poll for the async thing to have finished
     let watcher = setInterval(() => {
       // 1. If the router is loading, keep polling
-      let routerIsLoading = router.router && !!router.router.activeTransition;
+      let routerIsLoading = router._routerMicrolib && !!router._routerMicrolib.activeTransition;
       if (routerIsLoading) { return; }
 
       // 2. If there are pending Ajax requests, keep polling

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -3754,7 +3754,7 @@ QUnit.test('Route serializers work for Engines', function() {
 
   bootApplication();
 
-  equal(router.router.generate('blog.post', { id: '13' }), '/blog/post/13', 'url is generated properly');
+  equal(router._routerMicrolib.generate('blog.post', { id: '13' }), '/blog/post/13', 'url is generated properly');
 });
 
 QUnit.test('Defining a Route#serialize method in an Engine throws an error', function() {


### PR DESCRIPTION
The is an intermediate clean-up PR en route to finishing the router service RFC (see what I did there 👀 ).

**Related PRs**: 
https://github.com/emberjs/website/pull/2806
https://github.com/emberjs/website/pull/2808

**Reviewers**
@rwjblue @locks @ef4 

**Changes**
- renamed `Ember.router` to `Ember.routerMicrolib` to disambiguate which router we're referring to. This will help avoid code like `this.router.router...`
- added deprecation warning for the property
- added tests for the deprecation warning

**How to test drive**
- Checkout this branch
- `ember serve` and ensure tests pass for both **Enable Opt Features** enabled and disabled