### PR TITLE
[BUGFIX release] Fixes `isEmpty` for non-Ember.Map object with size property

### DIFF
--- a/packages/ember-metal/lib/is_empty.js
+++ b/packages/ember-metal/lib/is_empty.js
@@ -1,5 +1,6 @@
 import { get } from './property_get';
 import isNone from './is_none';
+import EmberMap from './map';
 
 /**
   Verifies that a value is `null` or an empty string, empty array,
@@ -39,7 +40,7 @@ export default function isEmpty(obj) {
 
   let objectType = typeof obj;
 
-  if (objectType === 'object') {
+  if (objectType instanceof EmberMap) {
     let size = get(obj, 'size');
     if (typeof size === 'number') {
       return !size;

--- a/packages/ember-metal/tests/is_empty_test.js
+++ b/packages/ember-metal/tests/is_empty_test.js
@@ -33,6 +33,13 @@ QUnit.test('Ember.isEmpty Ember.Map', function() {
   equal(false, isEmpty(map), 'Map is not empty');
 });
 
+QUnit.test('Ember.isEmpty Object with size property', function() {
+  let obj = { size: 0 };
+  equal(false, isEmpty(obj), 'Object is empty');
+  obj.size = 1;
+  equal(false, isEmpty(obj), 'Object is empty');
+});
+
 QUnit.test('Ember.isEmpty Ember.OrderedSet', function() {
   let orderedSet = new OrderedSet();
   equal(true, isEmpty(orderedSet), 'Empty ordered set is empty');


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember.js/issues/14884
Relevant context: https://github.com/emberjs/ember.js/pull/9414