### PR TITLE
Fix ember-utils export ROOT and use it in ember-metal

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -11,6 +11,7 @@ import {
   guidFor,
   GUID_KEY,
   NAME_KEY,
+  ROOT,
   wrap,
   makeArray
 } from 'ember-utils';
@@ -39,9 +40,6 @@ import {
   addListener,
   removeListener
 } from './events';
-
-function ROOT() {}
-ROOT.__hasSuper = false;
 
 const a_slice = Array.prototype.slice;
 const a_concat = Array.prototype.concat;
@@ -431,10 +429,10 @@ export function mixin(obj, ...args) {
     post: null
   });
 
-  let comment = Comment.create({ 
-    post: somePost 
+  let comment = Comment.create({
+    post: somePost
   });
-  
+
   comment.edit(); // outputs 'starting to edit'
   ```
 

--- a/packages/ember-utils/lib/super.js
+++ b/packages/ember-utils/lib/super.js
@@ -17,7 +17,7 @@ export const checkHasSuper = ((() => {
   };
 })());
 
-function ROOT() {}
+export function ROOT() {}
 ROOT.__hasSuper = false;
 
 function hasSuper(func) {


### PR DESCRIPTION
Somehow `export ROOT` got missing but `ember-utils/index.js` exports it from `./super` [Code](https://github.com/emberjs/ember.js/blob/master/packages/ember-utils/lib/index.js#L25).
With the export in place we can use it in `ember-metal/mixin.js`