### PR TITLE
[BUGFIX beta] Fixes binding in input type=checkbox

### DIFF
--- a/packages/ember-glimmer/lib/components/checkbox.js
+++ b/packages/ember-glimmer/lib/components/checkbox.js
@@ -1,4 +1,4 @@
-import { get, set } from 'ember-metal';
+import { get, set, getProperties } from 'ember-metal';
 import EmberComponent from '../component';
 import layout from '../templates/empty';
 
@@ -51,9 +51,17 @@ export default EmberComponent.extend({
   ],
 
   type: 'checkbox',
-  checked: false,
   disabled: false,
   indeterminate: false,
+
+  init() {
+    this._super(...arguments);
+    let isCheckedUndefined = typeof get(this, 'checked') === 'undefined';
+
+    if (isCheckedUndefined) set(this, 'checked', false);
+
+    set(this, 'isCheckedBinded', !isCheckedUndefined);
+  },
 
   didInsertElement() {
     this._super(...arguments);
@@ -61,6 +69,15 @@ export default EmberComponent.extend({
   },
 
   change() {
-    set(this, 'checked', this.$().prop('checked'));
+    let {
+      checked,
+      isCheckedBinded
+    } = getProperties(this, 'checked', 'isCheckedBinded');
+
+    if (isCheckedBinded) {
+      this.$().prop('checked', checked);
+    } else {
+      set(this, 'checked', this.$().prop('checked'));
+    }
   }
 });

--- a/packages/ember-glimmer/tests/integration/helpers/input-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/input-test.js
@@ -535,6 +535,17 @@ moduleFor(`Helpers test: {{input type='checkbox'}}`, class extends InputRenderin
     this.assertCheckboxIsChecked();
   }
 
+  ['@test native click changes check property'](assert) {
+    this.render(`{{input type="checkbox"}}`);
+
+    this.assertSingleCheckbox();
+    this.assertCheckboxIsNotChecked();
+    this.$input()[0].click();
+    this.assertCheckboxIsChecked();
+    this.$input()[0].click();
+    this.assertCheckboxIsNotChecked();
+  }
+
   ['@test with static values'](assert) {
     this.render(`{{input type="checkbox" disabled=false tabindex=10 name="original-name" checked=false}}`);
 
@@ -552,7 +563,6 @@ moduleFor(`Helpers test: {{input type='checkbox'}}`, class extends InputRenderin
     this.assertAttr('tabindex', '10');
     this.assertAttr('name', 'original-name');
   }
-
 });
 
 moduleFor(`Helpers test: {{input type='text'}}`, class extends InputRenderingTest {


### PR DESCRIPTION
This PR fixes bug described in #14933.

Demo that shows bug is [here](https://ember-twiddle.com/5a5574717bf6475c56170381f83ba029?openFiles=controllers.application.js%2C)

When input has bound `check` property it should be possible to check/uncheck checkbox by controlling this property, but right now it is not possible when checkbox is clicked, because this property is overwrote by jQuery value.