### PR TITLE
[WIP] [BUGFIX beta] Support concatenatedProperties in contextual components

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/contextual-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/contextual-components-test.js
@@ -1091,6 +1091,27 @@ moduleFor('Components test: contextual components', class extends RenderingTest 
       this.render('{{component (component "textarea" type="text")}}');
     }, 'You cannot use the textarea helper as a contextual helper. Please extend Ember.TextArea to use it as a contextual component.');
   }
+
+  ['@test GH#14914 concatenate concatenated properties in contextual components'](assert) {
+    this.registerComponent('my-comp', {
+      ComponentClass: Component.extend({
+        concatenatedProperties: ['foo'],
+        foo: 'first',
+        init() {
+          this._super();
+        }
+      }),
+      template: '{{#each foo as |f|}}{{f}} {{/each}}'
+    });
+
+    this.render('{{component (component (component (component "my-comp" foo=second) foo=third) foo=fourth)}}', {
+      second: ['second'],
+      third: 'third',
+      fourth: 'fourth'
+    });
+
+    this.assertText('first second third fourth ');
+  }
 });
 
 class ContextualComponentMutableParamsTest extends RenderingTest {


### PR DESCRIPTION
Given a component `my-comp` with a `concatenatedProperties: ['foo']` this:

```hbs
{{component (component (component "my-comp" foo=1) foo=2)}}
```

should produce `foo: [1, 2]` (unless there are other values in the class, then
those values would be concatenated as well).

This is not happening due to `curryArgs` does not take into account the
`concatenatedProperties` and `mergedProperties` properties. One of the problems
with current implementation is that these properties work at mixin level, thus
making them only accessible working out the `proto` (see emberjs/rfcs#209 for
more details.

This initial draft does not fully work. For this to continue I need to know
some details:

1. Is there an implemented way in glimmer to create an Reference that is
   a collection of reference? I need to concatenate two references/array of
   references into an array.
2. Is the `proto` method expensive enough not to continue?