### PR TITLE
[BUGIX release] [Fixes #14925] remove duplicate `/` in pathname

### DIFF
--- a/packages/ember-routing/lib/location/history_location.js
+++ b/packages/ember-routing/lib/location/history_location.js
@@ -101,7 +101,8 @@ export default EmberObject.extend({
     // remove baseURL and rootURL from start of path
     let url = path
       .replace(new RegExp(`^${baseURL}(?=/|$)`), '')
-      .replace(new RegExp(`^${rootURL}(?=/|$)`), '');
+      .replace(new RegExp(`^${rootURL}(?=/|$)`), '')
+      .replace(/\/\/$/g,'/'); // remove extra slashes
 
     let search = location.search || '';
     url += search + this.getHash();

--- a/packages/ember-routing/tests/location/history_location_test.js
+++ b/packages/ember-routing/tests/location/history_location_test.js
@@ -333,3 +333,21 @@ QUnit.test('HistoryLocation.getURL() includes location.hash and location.search'
 
   equal(location.getURL(), '/foo/bar?time=morphin#pink-power-ranger');
 });
+
+
+QUnit.test('HistoryLocation.getURL() drops duplicate slashes', function() {
+  expect(1);
+
+  HistoryTestLocation.reopen({
+    init() {
+      this._super(...arguments);
+      let location = mockBrowserLocation('//');
+      location.pathname = '//'; // mockBrowserLocation does not allow for `//`, so force it
+      set(this, 'location', location);
+    }
+  });
+
+  createLocation();
+
+  equal(location.getURL(), '/');
+});


### PR DESCRIPTION
[Fixes #14925]

This avoids a DOMException, which interprets duplicate `/` as a security violation and prevents the associated history state modifications.

error in question:
<img width="1483" alt="screen shot 2017-02-24 at 11 32 53 pm" src="https://cloud.githubusercontent.com/assets/1377/23329503/de7049b8-faee-11e6-80e2-99034de80410.png">


---

I'm not totally sure this is the appropriate fix, so maybe someone else should sanity check this one.