### PR TITLE
Add filter for undefined options.path during component-test blueprint/generator

### DIFF
--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -44,7 +44,7 @@ module.exports = useTestFrameworkDetector({
     var friendlyTestDescription = testInfo.description(options.entity.name, 'Integration', 'Component');
 
     if (options.pod && options.path !== 'components' && options.path !== '') {
-      componentPathName = [options.path, dasherizedModuleName].join('/');
+      componentPathName = [options.path, dasherizedModuleName].filter(Boolean).join('/');
     }
 
     if (options.testType === 'unit') {

--- a/node-tests/blueprints/component-test.js
+++ b/node-tests/blueprints/component-test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var fs = require('fs');
+
 var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
 var setupTestHooks = blueprintHelpers.setupTestHooks;
 var emberNew = blueprintHelpers.emberNew;
@@ -727,6 +729,29 @@ describe('Acceptance: ember generate component', function() {
           .to.contain("{{#x-foo}}");
       }));
   });
+
+  describe('usePods: true', function() {
+    it('component-test x-foo', function() {
+      var args = ['component-test', 'x-foo'];
+
+      return emberNew()
+        .then(() => {
+          fs.writeFileSync('.ember-cli', `{
+            "disableAnalytics": false,
+            "usePods": true
+          }`);
+        })
+        .then(() => emberGenerateDestroy(args, _file => {
+          expect(_file('tests/integration/components/x-foo/component-test.js'))
+            .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+            .to.contain("import hbs from 'htmlbars-inline-precompile';")
+            .to.contain("moduleForComponent('x-foo'")
+            .to.contain("integration: true")
+            .to.contain("{{x-foo}}")
+            .to.contain("{{#x-foo}}");
+        }));
+    });
+  })
 
   it('component-test x-foo --unit', function() {
     var args = ['component-test', 'x-foo', '--unit'];


### PR DESCRIPTION
Howdy folks 👋 

I don't know the root cause of this issue but I thought I thought I would open the discussion with a PR that actually fixes it for me. 

The issue occurs when I use `ember g component-test super-component` from the command line. The render calls in the generated tests have the component name prepended with a `/` for some reason. Here is what it looks like: 

```
  this.render(hbs`{{/super-component}}`);

  this.render(hbs`
    {{#/super-component}}
      template block text
    {{//super-component}}
  `);
```

Doing a bit of debugging I found that `options.path` was undefined when coming into the generator, but like I said I don't know **why** that might be the case. All I know is that the fix in this PR works for me now 👍 

I didn't include any tests or anything because at first glance I didn't see any test harness that actually exercises the generators. Let me know if there is one and I'll create whatever tests are required. 

As ever if you have any questions just let me know 👍 