### PR TITLE
Default the template helper test blueprint to integration style

### DIFF
--- a/blueprints/helper-test/index.js
+++ b/blueprints/helper-test/index.js
@@ -12,7 +12,7 @@ module.exports = useTestFrameworkDetector({
     {
       name: 'test-type',
       type: ['integration', 'unit'],
-      default: 'unit',
+      default: 'integration',
       aliases: [
         { 'i': 'integration' },
         { 'u': 'unit' },
@@ -25,13 +25,13 @@ module.exports = useTestFrameworkDetector({
   fileMapTokens: function() {
     return {
       __testType__: function(options) {
-        return options.locals.testType || 'unit';
+        return options.locals.testType || 'integration';
       }
     };
   },
 
   locals: function(options) {
-    var testType = options.testType || 'unit';
+    var testType = options.testType || 'integration';
     var testName = testType === 'integration' ? 'Integration' : 'Unit';
     var friendlyTestName = testInfo.name(options.entity.name, testName, 'Helper');
 

--- a/node-tests/blueprints/helper-test.js
+++ b/node-tests/blueprints/helper-test.js
@@ -27,8 +27,8 @@ describe('Acceptance: ember generate and destroy helper', function() {
                       "}\n\n" +
                       "export default Ember.Helper.helper(fooBarBaz);");
 
-        expect(_file('tests/unit/helpers/foo/bar-baz-test.js'))
-          .to.contain("import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';");
+        expect(_file('tests/integration/helpers/foo/bar-baz-test.js'))
+          .to.contain("moduleForComponent('foo/bar-baz', 'helper:foo/bar-baz', {");
       }));
   });
 
@@ -46,8 +46,8 @@ describe('Acceptance: ember generate and destroy helper', function() {
 
         expect(_file('app/helpers/foo-bar.js'))
           .to.contain("export { default, fooBar } from 'my-addon/helpers/foo-bar';");
-        expect(_file('tests/unit/helpers/foo-bar-test.js'))
-          .to.contain("import { fooBar } from 'dummy/helpers/foo-bar';");
+        expect(_file('tests/integration/helpers/foo-bar-test.js'))
+          .to.contain("moduleForComponent('foo-bar', 'helper:foo-bar', {");
       }));
   });
 
@@ -65,8 +65,8 @@ describe('Acceptance: ember generate and destroy helper', function() {
 
         expect(_file('app/helpers/foo/bar-baz.js'))
           .to.contain("export { default, fooBarBaz } from 'my-addon/helpers/foo/bar-baz';");
-        expect(_file('tests/unit/helpers/foo/bar-baz-test.js'))
-          .to.contain("import { fooBarBaz } from 'dummy/helpers/foo/bar-baz';");
+        expect(_file('tests/integration/helpers/foo/bar-baz-test.js'))
+          .to.contain("moduleForComponent('foo/bar-baz', 'helper:foo/bar-baz', {");
       }));
   });
 
@@ -84,7 +84,7 @@ describe('Acceptance: ember generate and destroy helper', function() {
 
         expect(_file('app/helpers/foo-bar.js'))
           .to.not.exist;
-        expect(_file('tests/unit/helpers/foo-bar-test.js'))
+        expect(_file('tests/integration/helpers/foo-bar-test.js'))
           .to.not.exist;
       }));
   });
@@ -103,7 +103,7 @@ describe('Acceptance: ember generate and destroy helper', function() {
 
         expect(_file('app/helpers/foo/bar-baz.js'))
           .to.not.exist;
-        expect(_file('tests/unit/helpers/foo/bar-baz-test.js'))
+        expect(_file('tests/integration/helpers/foo/bar-baz-test.js'))
           .to.not.exist;
       }));
   });
@@ -122,8 +122,8 @@ describe('Acceptance: ember generate and destroy helper', function() {
 
         expect(_file('lib/my-addon/app/helpers/foo-bar.js'))
           .to.contain("export { default, fooBar } from 'my-addon/helpers/foo-bar';");
-        expect(_file('tests/unit/helpers/foo-bar-test.js'))
-          .to.contain("import { fooBar } from 'my-app/helpers/foo-bar';");
+        expect(_file('tests/integration/helpers/foo-bar-test.js'))
+          .to.contain("moduleForComponent('foo-bar', 'helper:foo-bar', {");
       }));
   });
 
@@ -141,8 +141,8 @@ describe('Acceptance: ember generate and destroy helper', function() {
 
         expect(_file('lib/my-addon/app/helpers/foo/bar-baz.js'))
           .to.contain("export { default, fooBarBaz } from 'my-addon/helpers/foo/bar-baz';");
-        expect(_file('tests/unit/helpers/foo/bar-baz-test.js'))
-          .to.contain("import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';");
+        expect(_file('tests/integration/helpers/foo/bar-baz-test.js'))
+          .to.contain("moduleForComponent('foo/bar-baz', 'helper:foo/bar-baz', {");
       }));
   });
 
@@ -158,8 +158,8 @@ describe('Acceptance: ember generate and destroy helper', function() {
                       "}\n\n" +
                       "export default Ember.Helper.helper(fooBar);");
 
-        expect(_file('tests/unit/helpers/foo-bar-test.js'))
-          .to.contain("import { fooBar } from 'my-app/helpers/foo-bar';");
+        expect(_file('tests/integration/helpers/foo-bar-test.js'))
+          .to.contain("moduleForComponent('foo-bar', 'helper:foo-bar', {");
       }));
   });
 
@@ -176,8 +176,8 @@ describe('Acceptance: ember generate and destroy helper', function() {
                       "}\n\n" +
                       "export default Ember.Helper.helper(fooBar);");
 
-        expect(_file('tests/unit/helpers/foo-bar-test.js'))
-          .to.contain("import { fooBar } from 'my-app/helpers/foo-bar';");
+        expect(_file('tests/integration/helpers/foo-bar-test.js'))
+          .to.contain("moduleForComponent('foo-bar', 'helper:foo-bar', {");
       }));
   });
 
@@ -193,8 +193,8 @@ describe('Acceptance: ember generate and destroy helper', function() {
                       "}\n\n" +
                       "export default Ember.Helper.helper(fooBarBaz);");
 
-        expect(_file('tests/unit/helpers/foo/bar-baz-test.js'))
-          .to.contain("import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';");
+        expect(_file('tests/integration/helpers/foo/bar-baz-test.js'))
+          .to.contain("moduleForComponent('foo/bar-baz', 'helper:foo/bar-baz', {");
       }));
   });
 
@@ -211,8 +211,8 @@ describe('Acceptance: ember generate and destroy helper', function() {
                       "}\n\n" +
                       "export default Ember.Helper.helper(fooBarBaz);");
 
-        expect(_file('tests/unit/helpers/foo/bar-baz-test.js'))
-          .to.contain("import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';");
+        expect(_file('tests/integration/helpers/foo/bar-baz-test.js'))
+          .to.contain("moduleForComponent('foo/bar-baz', 'helper:foo/bar-baz', {");
       }));
   });
 
@@ -222,7 +222,7 @@ describe('Acceptance: ember generate and destroy helper', function() {
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/integration/helpers/foo/bar-baz-test.js'))
-          .to.contain("import hbs from 'htmlbars-inline-precompile';");
+          .to.contain("moduleForComponent('foo/bar-baz', 'helper:foo/bar-baz', {");
       }));
   });
 
@@ -231,8 +231,8 @@ describe('Acceptance: ember generate and destroy helper', function() {
 
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
-        expect(_file('tests/unit/helpers/foo/bar-baz-test.js'))
-          .to.contain("import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';");
+        expect(_file('tests/integration/helpers/foo/bar-baz-test.js'))
+          .to.contain("moduleForComponent('foo/bar-baz', 'helper:foo/bar-baz', {");
       }));
   });
 
@@ -241,8 +241,8 @@ describe('Acceptance: ember generate and destroy helper', function() {
 
     return emberNew({ target: 'addon' })
       .then(() => emberGenerateDestroy(args, _file => {
-        expect(_file('tests/unit/helpers/foo-bar-test.js'))
-          .to.contain("import { fooBar } from 'dummy/helpers/foo-bar';");
+        expect(_file('tests/integration/helpers/foo-bar-test.js'))
+          .to.contain("moduleForComponent('foo-bar', 'helper:foo-bar', {");
       }));
   });
 
@@ -290,10 +290,10 @@ describe('Acceptance: ember generate and destroy helper', function() {
       ]))
       .then(() => generateFakePackageManifest('ember-cli-mocha', '0.12.0'))
       .then(() => emberGenerateDestroy(args, _file => {
-        expect(_file('tests/unit/helpers/foo/bar-baz-test.js'))
+        expect(_file('tests/integration/helpers/foo/bar-baz-test.js'))
           .to.contain("import { describe, it } from 'mocha';")
-          .to.contain("import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';")
-          .to.contain("describe('Unit | Helper | foo/bar baz', function() {");
+          .to.contain("setupComponentTest('foo/bar-baz', {")
+          .to.contain("describe('Integration | Helper | foo/bar baz', function() {");
       }));
   });
 });


### PR DESCRIPTION
Potentially bike-shedding, but I find integration style template-helper tests to be more useful in day-to-day use.  This commit only changes default behavior to integration.

Would love to have a discussion about the relative pros and cons of the proposed change.

Cheers!