### PR TITLE
[Deprecated] Add deprecation for partials

### DIFF
--- a/packages/ember-glimmer/tests/integration/application/engine-test.js
+++ b/packages/ember-glimmer/tests/integration/application/engine-test.js
@@ -155,6 +155,7 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
   }
 
   ['@test attrs in an engine']() {
+    expectDeprecation(/Partials are now deprecated in favor of using components. Please change "troll" to a component./)
     this.setupEngineWithAttrs([]);
 
     return this.visit('/').then(() => {
@@ -298,7 +299,9 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
   }
 
   ['@test visit() with partials in routable engine'](assert) {
-    assert.expect(2);
+    expectDeprecation(/Partials are now deprecated in favor of using components. Please change "foo" to a component./)
+
+    assert.expect(3);
 
     let hooks = [];
 
@@ -315,7 +318,9 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
   }
 
   ['@test visit() with partials in non-routable engine'](assert) {
-    assert.expect(2);
+    expectDeprecation(/Partials are now deprecated in favor of using components. Please change "foo" to a component./)
+
+    assert.expect(3);
 
     let hooks = [];
 

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -601,7 +601,9 @@ moduleFor('Components test: curly components', class extends RenderingTest {
 
     this.registerComponent('foo-bar', { template: '{{partial "partialWithYield"}} - In component' });
 
-    this.render('{{#foo-bar}}hello{{/foo-bar}}');
+    expectDeprecation(() => {
+      this.render('{{#foo-bar}}hello{{/foo-bar}}');
+    }, /Partials are now deprecated in favor of using components. Please change "partialWithYield" to a component./)
 
     this.assertComponentElement(this.firstChild, { content: 'yielded: [hello] - In component' });
 
@@ -615,7 +617,9 @@ moduleFor('Components test: curly components', class extends RenderingTest {
 
     this.registerComponent('foo-bar', { template: '{{partial "partialWithYield"}} - In component' });
 
-    this.render('{{#foo-bar as |value|}}{{value}}{{/foo-bar}}');
+    expectDeprecation(() => {
+      this.render('{{#foo-bar as |value|}}{{value}}{{/foo-bar}}');
+    }, /Partials are now deprecated in favor of using components. Please change "partialWithYield" to a component./)
 
     this.assertComponentElement(this.firstChild, { content: 'yielded: [hello] - In component' });
 

--- a/packages/ember-glimmer/tests/integration/helpers/partial-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/partial-test.js
@@ -8,7 +8,9 @@ moduleFor('Helpers test: {{partial}}', class extends RenderingTest {
   ['@test should render other templates registered with the container']() {
     this.registerPartial('_subTemplateFromContainer', 'sub-template');
 
-    this.render(`This {{partial "subTemplateFromContainer"}} is pretty great.`);
+    expectDeprecation(() => {
+      this.render(`This {{partial "subTemplateFromContainer"}} is pretty great.`);
+    }, /Partials are now deprecated in favor of using components. Please change "subTemplateFromContainer" to a component\./);
 
     this.assertStableRerender();
 
@@ -18,7 +20,9 @@ moduleFor('Helpers test: {{partial}}', class extends RenderingTest {
   ['@test should render other slash-separated templates registered with the container']() {
     this.registerPartial('child/_subTemplateFromContainer', 'sub-template');
 
-    this.render(`This {{partial "child/subTemplateFromContainer"}} is pretty great.`);
+    expectDeprecation(() => {
+      this.render(`This {{partial "child/subTemplateFromContainer"}} is pretty great.`);
+    }, /Partials are now deprecated in favor of using components. Please change "child\/subTemplateFromContainer" to a component\./);
 
     this.assertStableRerender();
 
@@ -28,12 +32,14 @@ moduleFor('Helpers test: {{partial}}', class extends RenderingTest {
   ['@test should use the current context']() {
     this.registerPartial('_person_name', '{{model.firstName}} {{model.lastName}}');
 
-    this.render('Who is {{partial "person_name"}}?', {
-      model: {
-        firstName: 'Kris',
-        lastName: 'Selden'
-      }
-    });
+    expectDeprecation(() => {
+      this.render('Who is {{partial "person_name"}}?', {
+        model: {
+          firstName: 'Kris',
+          lastName: 'Selden'
+        }
+      });
+    }, /Partials are now deprecated in favor of using components. Please change "person_name" to a component\./);
 
     this.assertStableRerender();
 
@@ -52,15 +58,19 @@ moduleFor('Helpers test: {{partial}}', class extends RenderingTest {
     this.registerPartial('_subTemplate', 'sub-template');
     this.registerPartial('_otherTemplate', 'other-template');
 
-    this.render('This {{partial templates.partialName}} is pretty {{partial nonexistent}}great.', {
-      templates: { partialName: 'subTemplate' }
-    });
+    expectDeprecation(() => {
+      this.render('This {{partial templates.partialName}} is pretty {{partial nonexistent}}great.', {
+        templates: { partialName: 'subTemplate' }
+      });
+    }, /Partials are now deprecated in favor of using components. Please change "subTemplate" to a component\./);
 
     this.assertStableRerender();
 
     this.assertText('This sub-template is pretty great.');
 
-    this.runTask(() => set(this.context, 'templates.partialName', 'otherTemplate'));
+    expectDeprecation(() => {
+      this.runTask(() => set(this.context, 'templates.partialName', 'otherTemplate'));
+    }, /Partials are now deprecated in favor of using components. Please change "otherTemplate" to a component\./);
 
     this.assertText('This other-template is pretty great.');
 
@@ -68,12 +78,16 @@ moduleFor('Helpers test: {{partial}}', class extends RenderingTest {
 
     this.assertText('This  is pretty great.');
 
-    this.runTask(() => set(this.context, 'templates', { partialName: 'subTemplate' }));
+    expectDeprecation(() => {
+      this.runTask(() => set(this.context, 'templates', { partialName: 'subTemplate' }));
+    }, /Partials are now deprecated in favor of using components. Please change "subTemplate" to a component\./);
 
     this.assertText('This sub-template is pretty great.');
   }
 
   ['@test dynamic partials in {{#each}}']() {
+    expectDeprecation(/^Partials are now deprecated in favor of using components\./);
+
     this.registerPartial('_odd', 'ODD{{i}}');
     this.registerPartial('_even', 'EVEN{{i}}');
 
@@ -104,6 +118,8 @@ moduleFor('Helpers test: {{partial}}', class extends RenderingTest {
   }
 
   ['@test dynamic partials in {{#with}}']() {
+    expectDeprecation(/^Partials are now deprecated in favor of using components\./);
+
     this.registerPartial('_thing', '{{t}}');
 
     this.render(strip`

--- a/packages/ember-views/lib/system/lookup_partial.js
+++ b/packages/ember-views/lib/system/lookup_partial.js
@@ -1,5 +1,6 @@
 import {
   assert,
+  deprecate,
   Error as EmberError
 } from 'ember-metal';
 
@@ -21,6 +22,12 @@ export default function lookupPartial(templateName, owner) {
     `Unable to find partial with name "${templateName}"`,
     !!template
   );
+
+  deprecate(`Partials are now deprecated in favor of using components. Please change "${templateName}" to a component.`, false, {
+    id: 'ember-glimmer.partials',
+    since: '2.13.0',
+    until: '3.0.0'
+  });
 
   return template;
 }


### PR DESCRIPTION
This adds a deprecation for `{{partial}}`. Like `{{render}}` they go against the Ember's programming model.