### PR TITLE
remove “no use strict”

### DIFF
--- a/packages/ember-metal/lib/dependent_keys.js
+++ b/packages/ember-metal/lib/dependent_keys.js
@@ -1,7 +1,3 @@
-'no use strict';
-// Remove "use strict"; from transpiled module until
-// https://bugs.webkit.org/show_bug.cgi?id=138038 is fixed
-
 import {
   watch,
   unwatch

--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -1,7 +1,3 @@
-'no use strict';
-// Remove "use strict"; from transpiled module until
-// https://bugs.webkit.org/show_bug.cgi?id=138038 is fixed
-
 /**
 @module ember
 @submodule ember-metal

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -1,7 +1,3 @@
-'no use strict';
-// Remove "use strict"; from transpiled module until
-// https://bugs.webkit.org/show_bug.cgi?id=138038 is fixed
-
 import {
   HAS_NATIVE_WEAKMAP,
   EmptyObject,

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -1,7 +1,3 @@
-'no use strict';
-// Remove "use strict"; from transpiled module until
-// https://bugs.webkit.org/show_bug.cgi?id=138038 is fixed
-
 /**
 @module ember
 @submodule ember-metal

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -1,7 +1,3 @@
-'no use strict';
-// Remove "use strict"; from transpiled module until
-// https://bugs.webkit.org/show_bug.cgi?id=138038 is fixed
-
 /**
   @module ember
   @submodule ember-runtime


### PR DESCRIPTION
Thanks to @givanse for doing the investigation to confirm this can now be removed https://github.com/emberjs/ember.js/pull/14624

@krisselden was reminded of this, as it may address one of our more mysterious deopts (Bad value context for arguments value) as this causes us to mix both use strict and non use strict code (making the functions have a different shape).... source: http://benediktmeurer.de/2017/03/01/v8-behind-the-scenes-february-edition/ cc @benedikt 