### PR TITLE
Phase 3 of public Router Service - adding urlFor

### DIFF
--- a/packages/ember-routing/lib/services/router.js
+++ b/packages/ember-routing/lib/services/router.js
@@ -32,7 +32,7 @@ const RouterService = Service.extend({
 
      @method transitionTo
      @category ember-routing-router-service
-     @param {String} name the name of the route or a URL
+     @param {String} routeNameOrUrl the name of the route or a URL
      @param {...Object} models the model(s) or identifier(s) to be used while
        transitioning to the route.
      @param {Object} [options] optional hash with a queryParams property
@@ -41,7 +41,7 @@ const RouterService = Service.extend({
        attempted transition
      @public
    */
-  transitionTo() {
+  transitionTo(/* routeNameOrUrl, ...models, options */) {
     return this.router.transitionTo(...arguments);
   },
 
@@ -53,7 +53,7 @@ const RouterService = Service.extend({
 
      @method replaceWith
      @category ember-routing-router-service
-     @param {String} name the name of the route or a URL
+     @param {String} routeNameOrUrl the name of the route or a URL
      @param {...Object} models the model(s) or identifier(s) to be used while
        transitioning to the route.
      @param {Object} [options] optional hash with a queryParams property
@@ -62,8 +62,24 @@ const RouterService = Service.extend({
        attempted transition
      @public
    */
-  replaceWith() {
+  replaceWith(/* routeNameOrUrl, ...models, options */) {
     return this.router.replaceWith(...arguments);
+  },
+
+  /**
+     Generate a URL based on the supplied route name.
+
+     @method urlFor
+     @param {String} routeName the name of the route
+     @param {...Object} models the model(s) or identifier(s) to be used while
+       transitioning to the route.
+     @param {Object} [options] optional hash with a queryParams property
+       containing a mapping of query parameters
+     @return {String} the string representing the generated URL
+     @public
+   */
+  urlFor(/* routeName, ...models, options */) {
+    return this.router.generate(...arguments);
   }
 });
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -411,8 +411,8 @@ const EmberRouter = EmberObject.extend(Evented, {
     return this.transitionTo(...arguments).method('replace');
   },
 
-  generate(...args) {
-    let url = this._routerMicrolib.generate(...args);
+  generate() {
+    let url = this._routerMicrolib.generate(...arguments);
     return this.location.formatURL(url);
   },
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -411,8 +411,8 @@ const EmberRouter = EmberObject.extend(Evented, {
     return this.transitionTo(...arguments).method('replace');
   },
 
-  generate() {
-    let url = this._routerMicrolib.generate(...arguments);
+  generate(...args) {
+    let url = this._routerMicrolib.generate(...args);
     return this.location.formatURL(url);
   },
 

--- a/packages/ember/tests/routing/router_service_test/replaceWith_test.js
+++ b/packages/ember/tests/routing/router_service_test/replaceWith_test.js
@@ -67,6 +67,24 @@ if (isFeatureEnabled('ember-routing-router-service')) {
         });
     }
 
+    ['@test RouterService#replaceWith with basic route using URLs replaces location'](assert) {
+      assert.expect(1);
+
+      return this.visit('/')
+        .then(() => {
+          return this.routerService.transitionTo('/child');
+        })
+        .then(() => {
+          return this.routerService.transitionTo('/sister');
+        })
+        .then(() => {
+          return this.routerService.replaceWith('/brother');
+        })
+        .then(() => {
+          assert.deepEqual(this.state, ['/', '/child', '/brother']);
+        });
+    }
+
     ['@test RouterService#replaceWith transitioning back to previously visited route replaces location'](assert) {
       assert.expect(1);
 

--- a/packages/ember/tests/routing/router_service_test/transitionTo_test.js
+++ b/packages/ember/tests/routing/router_service_test/transitionTo_test.js
@@ -127,6 +127,38 @@ if (isFeatureEnabled('ember-routing-router-service')) {
       });
     }
 
+    ['@test RouterService#transitionTo with basic route using URL'](assert) {
+      assert.expect(1);
+
+      let componentInstance;
+
+      this.registerTemplate('parent.index', '{{foo-bar}}');
+
+      this.registerComponent('foo-bar', {
+        ComponentClass: Component.extend({
+          routerService: inject.service('router'),
+          init() {
+            this._super();
+            componentInstance = this;
+          },
+          actions: {
+            transitionToSister() {
+              get(this, 'routerService').transitionTo('/sister');
+            }
+          }
+        }),
+        template: `foo-bar`
+      });
+
+      return this.visit('/').then(() => {
+        run(function() {
+          componentInstance.send('transitionToSister');
+        });
+
+        assert.equal(this.routerService.get('currentRouteName'), 'parent.sister');
+      });
+    }
+
     ['@test RouterService#transitionTo with dynamic segment'](assert) {
       assert.expect(3);
 

--- a/packages/ember/tests/routing/router_service_test/urlFor_test.js
+++ b/packages/ember/tests/routing/router_service_test/urlFor_test.js
@@ -1,0 +1,67 @@
+import { inject } from 'ember-runtime';
+import { Component } from 'ember-glimmer';
+import { Route, NoneLocation } from 'ember-routing';
+import {
+  get,
+  set
+} from 'ember-metal';
+import {
+  RouterTestCase,
+  moduleFor
+} from 'internal-test-helpers';
+
+import { isFeatureEnabled } from 'ember-metal';
+
+if (isFeatureEnabled('ember-routing-router-service')) {
+  moduleFor('Router Service - urlFor', class extends RouterTestCase {
+    constructor() {
+      super();
+    }
+
+    ['@test RouterService#urlFor returns URL for simple route'](assert) {
+      assert.expect(1);
+
+      return this.visit('/').then(() => {
+        let expectedURL = this.routerService.urlFor('parent.child');
+
+        assert.equal('/child', expectedURL);
+      });
+    }
+
+    ['@test RouterService#urlFor returns URL for simple route with dynamic segments'](assert) {
+      assert.expect(1);
+
+      let dynamicModel = { id: 1, contents: 'much dynamicism' };
+
+      return this.visit('/').then(() => {
+        let expectedURL = this.routerService.urlFor('dynamic', dynamicModel);
+
+        assert.equal('/dynamic/1', expectedURL);
+      });
+    }
+
+    ['@test RouterService#urlFor returns URL for simple route with query params'](assert) {
+      assert.expect(1);
+
+      let queryParams = { queryParams: { foo: 'bar' } };
+
+      return this.visit('/').then(() => {
+        let expectedURL = this.routerService.urlFor('parent.child', queryParams);
+
+        assert.equal('/child?foo=bar', expectedURL);
+      });
+    }
+
+    ['@test RouterService#urlFor returns URL for simple route with dynamic segments and query params'](assert) {
+      assert.expect(1);
+
+      let queryParams = { queryParams: { foo: 'bar' } };
+
+      return this.visit('/').then(() => {
+        let expectedURL = this.routerService.urlFor('dynamic', { id: 1 }, queryParams);
+
+        assert.equal('/dynamic/1?foo=bar', expectedURL);
+      });
+    }
+  });
+}

--- a/packages/ember/tests/routing/router_service_test/urlFor_test.js
+++ b/packages/ember/tests/routing/router_service_test/urlFor_test.js
@@ -1,4 +1,8 @@
-import { inject } from 'ember-runtime';
+import {
+  Controller,
+  inject,
+  String
+} from 'ember-runtime';
 import { Component } from 'ember-glimmer';
 import { Route, NoneLocation } from 'ember-routing';
 import {
@@ -12,10 +16,23 @@ import {
 
 import { isFeatureEnabled } from 'ember-metal';
 
+function defineController(app, name) {
+  let controllerName = `${String.capitalize(name)}Controller`;
+
+  Object.defineProperty(app, controllerName, {
+    get() {
+      throw new Error(`Generating a URL should not require instantiation of a ${controllerName}.`);
+    }
+  });
+}
+
 if (isFeatureEnabled('ember-routing-router-service')) {
   moduleFor('Router Service - urlFor', class extends RouterTestCase {
     constructor() {
       super();
+
+      ['dynamic', 'child']
+        .forEach((name) => { defineController(this.application, name); });
     }
 
     ['@test RouterService#urlFor returns URL for simple route'](assert) {

--- a/packages/ember/tests/routing/router_service_test/urlFor_test.js
+++ b/packages/ember/tests/routing/router_service_test/urlFor_test.js
@@ -26,6 +26,12 @@ function defineController(app, name) {
   });
 }
 
+function buildQueryParams(queryParams) {
+  return {
+    queryParams
+  };
+}
+
 if (isFeatureEnabled('ember-routing-router-service')) {
   moduleFor('Router Service - urlFor', class extends RouterTestCase {
     constructor() {
@@ -57,10 +63,10 @@ if (isFeatureEnabled('ember-routing-router-service')) {
       });
     }
 
-    ['@test RouterService#urlFor returns URL for simple route with query params'](assert) {
+    ['@test RouterService#urlFor returns URL for simple route with basic query params'](assert) {
       assert.expect(1);
 
-      let queryParams = { queryParams: { foo: 'bar' } };
+      let queryParams = buildQueryParams({ foo: 'bar' });
 
       return this.visit('/').then(() => {
         let expectedURL = this.routerService.urlFor('parent.child', queryParams);
@@ -69,15 +75,87 @@ if (isFeatureEnabled('ember-routing-router-service')) {
       });
     }
 
-    ['@test RouterService#urlFor returns URL for simple route with dynamic segments and query params'](assert) {
+    ['@test RouterService#urlFor returns URL for simple route with array as query params'](assert) {
       assert.expect(1);
 
-      let queryParams = { queryParams: { foo: 'bar' } };
+      let queryParams = buildQueryParams({ selectedItems: ['a', 'b', 'c'] });
+
+      return this.visit('/').then(() => {
+        let expectedURL = this.routerService.urlFor('parent.child', queryParams);
+
+        assert.equal('/child?selectedItems[]=a&selectedItems[]=b&selectedItems[]=c', expectedURL);
+      });
+    }
+
+    ['@test RouterService#urlFor returns URL for simple route with null query params'](assert) {
+      assert.expect(1);
+
+      let queryParams = buildQueryParams({ foo: null });
+
+      return this.visit('/').then(() => {
+        let expectedURL = this.routerService.urlFor('parent.child', queryParams);
+
+        assert.equal('/child', expectedURL);
+      });
+    }
+
+    ['@test RouterService#urlFor returns URL for simple route with undefined query params'](assert) {
+      assert.expect(1);
+
+      let queryParams = buildQueryParams({ foo: undefined });
+
+      return this.visit('/').then(() => {
+        let expectedURL = this.routerService.urlFor('parent.child', queryParams);
+
+        assert.equal('/child', expectedURL);
+      });
+    }
+
+    ['@test RouterService#urlFor returns URL for simple route with dynamic segments and basic query params'](assert) {
+      assert.expect(1);
+
+      let queryParams = buildQueryParams({ foo: 'bar' });
 
       return this.visit('/').then(() => {
         let expectedURL = this.routerService.urlFor('dynamic', { id: 1 }, queryParams);
 
         assert.equal('/dynamic/1?foo=bar', expectedURL);
+      });
+    }
+
+    ['@test RouterService#urlFor returns URL for simple route with dynamic segments and array as query params'](assert) {
+      assert.expect(1);
+
+      let queryParams = buildQueryParams({ selectedItems: ['a', 'b', 'c'] });
+
+      return this.visit('/').then(() => {
+        let expectedURL = this.routerService.urlFor('dynamic', { id: 1 }, queryParams);
+
+        assert.equal('/dynamic/1?selectedItems[]=a&selectedItems[]=b&selectedItems[]=c', expectedURL);
+      });
+    }
+
+    ['@test RouterService#urlFor returns URL for simple route with dynamic segments and null query params'](assert) {
+      assert.expect(1);
+
+      let queryParams = buildQueryParams({ foo: null });
+
+      return this.visit('/').then(() => {
+        let expectedURL = this.routerService.urlFor('dynamic', { id: 1 }, queryParams);
+
+        assert.equal('/dynamic/1', expectedURL);
+      });
+    }
+
+    ['@test RouterService#urlFor returns URL for simple route with dynamic segments and undefined query params'](assert) {
+      assert.expect(1);
+
+      let queryParams = buildQueryParams({ foo: undefined });
+
+      return this.visit('/').then(() => {
+        let expectedURL = this.routerService.urlFor('dynamic', { id: 1 }, queryParams);
+
+        assert.equal('/dynamic/1', expectedURL);
       });
     }
   });

--- a/packages/internal-test-helpers/lib/test-cases/router.js
+++ b/packages/internal-test-helpers/lib/test-cases/router.js
@@ -11,7 +11,7 @@ export default class RouterTestCase extends ApplicationTestCase {
         this.route('sister');
         this.route('brother');
       });
-      this.route('dynamic', { path: '/dynamic/:post_id' });
+      this.route('dynamic', { path: '/dynamic/:dynamic_id' });
     });
   }
 


### PR DESCRIPTION
This PR represents the second phase of the public router service described in [this RFC](https://github.com/emberjs/rfcs/blob/master/text/0095-router-service.md).

It extends the API with:

- `urlFor`

**Status**: Work in progress

**Reviewers**: @locks @rwjblue @ef4

Changes:

- Added `urlFor` method in public router service
- Added tests for `urlFor` 
- Added some extra tests for `transitionTo` and `replaceWith` that cover URLs as the first parameter

**How to test drive this PR**:

yarn start
Open up 2 tabs pointing to http://localhost:4200/tests/index.html, one with Enable Opt Features checked, ensure tests pass