### PR TITLE
Decouple controller lookup from URL generation.

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -155,16 +155,6 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
   },
 
   /**
-    Populates the QP meta information in the BucketCache.
-
-    @private
-    @method _populateQPMeta
-  */
-  _populateQPMeta() {
-    this._bucketCache.stash('route-meta', this.fullRouteName, this.get('_qp'));
-  },
-
-  /**
     @private
 
     @property _qp

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -609,7 +609,6 @@ const EmberRouter = EmberObject.extend(Evented, {
       }
 
       handler._setRouteName(routeName);
-      handler._populateQPMeta();
 
       if (engineInfo && !hasDefaultSerialize(handler)) {
         throw new Error('Defining a custom serialize method on an Engine route is not supported.');

--- a/packages/ember/tests/routing/query_params_test/query_param_async_get_handler_test.js
+++ b/packages/ember/tests/routing/query_params_test/query_param_async_get_handler_test.js
@@ -1,3 +1,4 @@
+import { get } from 'ember-metal';
 import { RSVP } from 'ember-runtime';
 import { Route } from 'ember-routing';
 
@@ -11,21 +12,37 @@ moduleFor('Query Params - async get handler', class extends QueryParamTestCase {
     return {
       location: 'test',
 
+      init() {
+        this._super(...arguments);
+        this._seenHandlers = Object.create(null);
+        this._handlerPromises = Object.create(null);
+      },
+
       _getQPMeta(handlerInfo) {
-        return this._bucketCache.lookup('route-meta', handlerInfo.name);
+        let handler = this._seenHandlers[handlerInfo.name];
+        if (handler) {
+          return get(handler, '_qp');
+        }
       },
 
       _getHandlerFunction() {
         let getHandler = this._super(...arguments);
-        let cache = {};
+        let handlerPromises = this._handlerPromises;
+        let seenHandlers = this._seenHandlers;
 
         return (routeName) => {
           fetchedHandlers.push(routeName);
 
           // Cache the returns so we don't have more than one Promise for a
           // given handler.
-          return cache[routeName] || (cache[routeName] = new RSVP.Promise((resolve) => {
-            setTimeout(() => resolve(getHandler(routeName)), 10);
+          return handlerPromises[routeName] || (handlerPromises[routeName] = new RSVP.Promise((resolve) => {
+            setTimeout(() => {
+              let handler = getHandler(routeName);
+
+              seenHandlers[routeName] = handler;
+
+              resolve(handler);
+            }, 10);
           }));
         };
       }


### PR DESCRIPTION
Currently, calling `emberRouter.routerMicrolib.generate('somethign');` will force both `something` route and `something` controller to be looked up. We do this so that we can properly handle any query params within that route/controller pair.

The `ember-routing-router-service` work is adding a `urlFor` method, that will ultimately allow users to generate urls without forcing the controllers to be looked up eagerly. Unfortunately, at the moment the eager controller lookup is completely entangled with the `getHandler` function that we provide to the router microlib.

This commit removes the forced eager evaluation of `_qp` on a route within the `getHandler` function, while still supporting the current implementation of `{{link-to}}` (which still utilizes the eager `_qp` evaluation to generate `href`'s).

Some work is needed in ember-engines to support this PR, which I am working on now...

I did emberobserver.com searches for the following:

* [route-meta](https://emberobserver.com/code-search?codeQuery=route-meta) - Only one real usage outside of Ember itself (ember-engines).
* [_populateQPMeta](https://emberobserver.com/code-search?codeQuery=_populateQPMeta) - Two usages (ember-engines and ember-cli-bundle-loader).

TODO: 

- [x] PR to make ember-engines compatible (https://github.com/ember-engines/ember-engines/pull/353)
- [x] PR to make ember-cli-bundle-loader compatible (https://github.com/MiguelMadero/ember-cli-bundle-loader/issues/30)