### PR TITLE
[DOC] Document setupController hook behavior when model is undefined

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1703,7 +1703,8 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     model supplied by the `model` hook.
 
     By default, the `setupController` hook sets the `model` property of
-    the controller to the `model`.
+    the controller to the `model`. If `model` is `undefined`, the default
+    implementation will _not_ update the `model` property of the controller.
 
     If you implement the `setupController` hook in your Route, it will
     prevent this default behavior. If you want to preserve that behavior

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1703,8 +1703,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     model supplied by the `model` hook.
 
     By default, the `setupController` hook sets the `model` property of
-    the controller to the `model`. If `model` is `undefined`, the default
-    implementation will _not_ update the `model` property of the controller.
+    the controller to the specified `model` when it is not `undefined`.
 
     If you implement the `setupController` hook in your Route, it will
     prevent this default behavior. If you want to preserve that behavior


### PR DESCRIPTION
The default hook implementation doesn't update the `model` property of the controller
if the resolved model is undefined, and I don't think that behavior is recorded anywhere except the source itself.  