### PR TITLE
[BUGFIX release] Don't leak babel helpers globally

### DIFF
--- a/packages/external-helpers/lib/external-helpers-dev.js
+++ b/packages/external-helpers/lib/external-helpers-dev.js
@@ -60,7 +60,7 @@ function defaults(obj, defaults) {
   return obj;
 }
 
-babelHelpers = {
+var babelHelpers = {
   classCallCheck: classCallCheck,
   inherits: inherits,
   taggedTemplateLiteralLoose: taggedTemplateLiteralLoose,

--- a/packages/external-helpers/lib/external-helpers-prod.js
+++ b/packages/external-helpers/lib/external-helpers-prod.js
@@ -50,7 +50,7 @@ function defaults(obj, defaults) {
   return obj;
 }
 
-babelHelpers = {
+var babelHelpers = {
   inherits: inherits,
   taggedTemplateLiteralLoose: taggedTemplateLiteralLoose,
   slice: Array.prototype.slice,


### PR DESCRIPTION
These  should not be global variables and will break other external babel helpers.