### PR TITLE
[BUGFIX release] fix RSVP memory leak

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "handlebars": "^4.0.6",
     "jquery": "^3.1.1",
     "resolve": "^1.1.7",
-    "rsvp": "^3.3.3",
+    "rsvp": "^3.4.0",
     "simple-dom": "^0.3.0",
     "simple-html-tokenizer": "^0.3.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4939,6 +4939,10 @@ rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.3.3.tgz#34633caaf8bc66ceff4be3c2e1dffd032538a813"
 
+rsvp@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.npmjs.org/rsvp/-/rsvp-3.4.0.tgz#96f397d9c7e294351b3c1456a74b3d0e7542988d"
+
 rsvp@~3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.2.1.tgz#07cb4a5df25add9e826ebc67dcc9fd89db27d84a"


### PR DESCRIPTION
This fixes two leaks:

* the last error getting `then` created (mega rare)
* the last rejection reason (more common, and lead to retaining the whole container once in ember-data’s tests)