### PR TITLE
[BUGFIX release] don’t leak last destroyedComponents

### DIFF
--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -64,7 +64,7 @@ export default class Environment extends GlimmerEnvironment {
     this.isInteractive = owner.lookup('-environment:main').isInteractive;
 
     // can be removed once https://github.com/tildeio/glimmer/pull/305 lands
-    this.destroyedComponents = undefined;
+    this.destroyedComponents = [];
 
     installPlatformSpecificProtocolForURL(this);
 
@@ -275,16 +275,16 @@ export default class Environment extends GlimmerEnvironment {
     this.inTransaction = true;
 
     super.begin();
-
-    this.destroyedComponents = [];
   }
 
   commit() {
+    let destroyedComponents = this.destroyedComponents;
+    this.destroyedComponents = [];
     // components queued for destruction must be destroyed before firing
     // `didCreate` to prevent errors when removing and adding a component
     // with the same name (would throw an error when added to view registry)
-    for (let i = 0; i < this.destroyedComponents.length; i++) {
-      this.destroyedComponents[i].destroy();
+    for (let i = 0; i < destroyedComponents.length; i++) {
+      destroyedComponents[i].destroy();
     }
 
     super.commit();

--- a/packages/ember-glimmer/tests/integration/components/destroy-test.js
+++ b/packages/ember-glimmer/tests/integration/components/destroy-test.js
@@ -1,0 +1,21 @@
+import { set } from 'ember-metal';
+import { Component } from '../../utils/helpers';
+import { moduleFor, RenderingTest } from '../../utils/test-case';
+
+moduleFor('Component destroy', class extends RenderingTest {
+  ['@test it correctly releases the destroyed components'](assert) {
+    let FooBarComponent = Component.extend({});
+
+    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: 'hello' });
+
+    this.render('{{#if switch}}{{#foo-bar}}{{foo-bar}}{{/foo-bar}}{{/if}}', { switch: true });
+
+    this.assertComponentElement(this.firstChild, { content: 'hello' });
+
+    this.runTask(() => set(this.context, 'switch', false));
+
+    this.assertText('');
+
+    assert.equal(this.env.destroyedComponents.length, 0, 'enviroment.destroyedComponents should be empty');
+  }
+});


### PR DESCRIPTION
Ensure we don’t retain the previous set of destroyed components.

---


Although `commit` did reset the `destroyedComponents` array, it does seem strange to retain the last set of `destroyedComponents` until the next render.