### PR TITLE
access active link state in the context

### DIFF
--- a/packages/ember-glimmer/lib/templates/link-to.hbs
+++ b/packages/ember-glimmer/lib/templates/link-to.hbs
@@ -1,1 +1,1 @@
-{{#if linkTitle}}{{linkTitle}}{{else}}{{yield}}{{/if}}
+{{#if linkTitle}}{{linkTitle}}{{else}}{{yield this}}{{/if}}


### PR DESCRIPTION
I had a use-case where I needed a simple way to change an element inside {{#link-to}} so not to write additional css targeting that list. Exposing `this` helps to solve this.

```
{{#link-to 'foo' classNames="" as |l|}}
  <i class="Icon Icon--messages"></i>
  {{#unless l.active}}
    <span class="">
      bar
    </span>
  {{/unless}}
{{/link-to}}
```