### PR TITLE
[DOC] Fix typo in the description of Ember.Route#setupController

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1701,7 +1701,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     `_super`:
 
     ```app/routes/photos.js
-    import Ember from 'ebmer';
+    import Ember from 'ember';
 
     export default Ember.Route.extend({
       model() {


### PR DESCRIPTION
I fixed a typo in the description of Ember.Route#setupController. 
Related: emberjs/website#2831