### PR TITLE
Avoid a couple of redundant property loads.

### DIFF
--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -208,8 +208,9 @@ export class Meta {
   _getInherited(key) {
     let pointer = this;
     while (pointer !== undefined) {
-      if (pointer[key]) {
-        return pointer[key];
+      let map = pointer[key];
+      if (map) {
+        return map;
       }
       pointer = pointer.parent;
     }
@@ -249,8 +250,9 @@ export class Meta {
       if (map) {
         let value = map[subkey];
         if (value) {
-          if (value[itemkey] !== undefined) {
-            return value[itemkey];
+          let itemvalue = value[itemkey];
+          if (itemvalue !== undefined) {
+            return itemvalue;
           }
         }
       }
@@ -308,7 +310,7 @@ export class Meta {
       if (map) {
         let value = map[subkey];
         if (value !== undefined || subkey in map) {
-          return map[subkey];
+          return value;
         }
       }
       pointer = pointer.parent;
@@ -475,7 +477,7 @@ if (isEnabled('mandatory-setter')) {
       if (map) {
         let value = map[subkey];
         if (value !== undefined || subkey in map) {
-          return map[subkey];
+          return value;
         }
       }
       pointer = pointer.parent;


### PR DESCRIPTION
Due to the generally high level of polymorphism, these redundant property loads cannot be optimized appropriately by the JavaScript engines. So better just avoid them in the first place.