### PR TITLE
[BUGFIX beta] only defProp the deprecated container once per prototype

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -535,7 +535,7 @@ function instantiate(factory, props, container, fullName) {
       obj = factory.create(assign({}, injections, props));
 
       // TODO - remove when Ember reaches v3.0.0
-      if (!Object.isFrozen(obj) && 'container' in obj) {
+      if (!Object.isFrozen(obj)) {
         injectDeprecatedContainer(obj, container);
       }
     }
@@ -559,6 +559,7 @@ function factoryInjectionsFor(container, fullName) {
 
 // TODO - remove when Ember reaches v3.0.0
 function injectDeprecatedContainer(object, container) {
+  if ('container' in object) { return; }
   Object.defineProperty(object, 'container', {
     configurable: true,
     enumerable: false,
@@ -695,8 +696,9 @@ class FactoryManager {
                   ` an invalid module export.`);
     }
 
-    if (this.class.prototype) {
-      injectDeprecatedContainer(this.class.prototype, this.container);
+    let prototype = this.class.prototype;
+    if (prototype) {
+      injectDeprecatedContainer(prototype, this.container);
     }
 
     return this.class.create(props);


### PR DESCRIPTION
Currently we defProp once pre FactoryManager.prototype.create.

So if you have 3500 models of the same type, we defProp its class's prototype 3500 times instead of once.