### PR TITLE
[PERF] [BUGFIX Beta] cache factoryFor injections when possible

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -642,10 +642,18 @@ class FactoryManager {
     this.fullName = fullName;
     this.normalizedName = normalizedName;
     this.madeToString = undefined;
+    this.injections = undefined;
   }
 
   create(options = {}) {
-    let injections = injectionsFor(this.container, this.normalizedName);
+
+    let injections = this.injections;
+    if (injections === undefined) {
+      injections = injectionsFor(this.container, this.normalizedName);
+      if (areInjectionsDynamic(injections) === false) {
+        this.injections = injections;
+      }
+    }
     let props = assign({}, injections, options);
 
     props[NAME_KEY] = this.madeToString || (this.madeToString = this.container.registry.makeToString(this.class, this.fullName));


### PR DESCRIPTION
reduces injection time from 5% -> 0.1%  on emberaddons.com (it has like 3500 ember-data models)