### PR TITLE
Clarify Ember.NativeArray docs

### DIFF
--- a/packages/ember-runtime/lib/system/native_array.js
+++ b/packages/ember-runtime/lib/system/native_array.js
@@ -108,7 +108,7 @@ NativeArray = NativeArray.without(...ignore);
 
 /**
   Creates an `Ember.NativeArray` from an Array like object.
-  Does not modify the original object. Ember.A is not needed if
+  Does not modify the original object's contents. Ember.A is not needed if
   `EmberENV.EXTEND_PROTOTYPES` is `true` (the default value). However,
   it is recommended that you use Ember.A when creating addons for
   ember or when you can not guarantee that `EmberENV.EXTEND_PROTOTYPES`


### PR DESCRIPTION
This clarifies the docs for `Ember.NativeArray` a bit, making clear that `Ember.A` does not modify the original object's contents (it does actually modify the object itself, see #15020).