### PR TITLE
Register x-handlebars scripts into the container

### DIFF
--- a/packages/ember-application/lib/initializers/dom-templates.js
+++ b/packages/ember-application/lib/initializers/dom-templates.js
@@ -1,8 +1,4 @@
 import require, { has } from 'require';
-import {
-  hasTemplate,
-  setTemplate
-} from 'ember-glimmer';
 import { environment } from 'ember-environment';
 import Application from '../system/application';
 
@@ -10,7 +6,7 @@ let bootstrap = function() { };
 
 Application.initializer({
   name: 'domTemplates',
-  initialize() {
+  initialize(application) {
     let bootstrapModuleId = 'ember-template-compiler/system/bootstrap';
     let context;
     if (environment.hasDOM && has(bootstrapModuleId)) {
@@ -18,6 +14,6 @@ Application.initializer({
       context = document;
     }
 
-    bootstrap({ context, hasTemplate, setTemplate });
+    bootstrap({ context, application });
   }
 });

--- a/packages/ember-template-compiler/lib/system/bootstrap.js
+++ b/packages/ember-template-compiler/lib/system/bootstrap.js
@@ -7,8 +7,8 @@ import { Error as EmberError } from 'ember-debug';
 import compile from './compile';
 
 /**
-  Find templates stored in the head tag as script tags and make them available
-  to `Ember.CoreView` in the global `Ember.TEMPLATES` object.
+  Find templates stored in the head tag as script tags and register them
+  into an application registry.
 
   Script tags with `text/x-handlebars` will be compiled
   with Ember's template compiler and are suitable for use as a view's template.
@@ -19,7 +19,7 @@ import compile from './compile';
   @static
   @param ctx
 */
-function bootstrap({ context, hasTemplate, setTemplate }) {
+function bootstrap({ context, application }) {
   if (!context) {
     context = document;
   }
@@ -41,13 +41,14 @@ function bootstrap({ context, hasTemplate, setTemplate }) {
       moduleName: templateName
     });
 
+    let registrationName = `template:${templateName}`;
     // Check if template of same name already exists.
-    if (hasTemplate(templateName)) {
+    if (application.hasRegistration(registrationName)) {
       throw new EmberError(`Template named "${templateName}" already exists.`);
     }
 
     // For templates which have a name, we save them and then remove them from the DOM.
-    setTemplate(templateName, template);
+    application.register(registrationName, template);
 
     // Remove script tag from DOM.
     script.parentNode.removeChild(script);


### PR DESCRIPTION
Ember templates detected in the DOM have long been added to `Ember.TEMPLATES`. This made them available to applications via the `Ember.DefaultResolver`.

With the aim of eventually dropping the `DefaultResolver`, we need to add these templates elsewhere. This commit changes them to register directly into an application's registry. As a result, one could use a custom resolver (without `Ember.TEMPLATES` support) and still leverage templates stored in the DOM.

**Alternative:** Instead of ensuring DOM-loaded templates work regardless of resolver, there may be a way to only register them if the `DefaultResolver` is being used. For example the `Resolver` would be checked during initialization to confirm it is an `instanceof` `DefaultResolver`, and only then would templates be added to `TEMPLATES`. Apps without the default resolver would then *not* support DOM-loaded templates.