### PR TITLE
Router not part of default resolver

### DIFF
--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -103,6 +103,20 @@ const ApplicationInstance = EngineInstance.extend({
   _bootSync(options) {
     if (this._booted) { return this; }
 
+    /*
+     * router:main is always an instance of `App.Router`. In the past, this
+     * was because the container resolved the 'main' by looking to `App[type]`.
+     * By registering it explicitly, the dependency on the DefaultResolver is
+     * avoided.
+     *
+     * A copy is registered on the application instance since a new value for
+     * App.Router may have been set after the value registered on the
+     * application.
+     */
+    if (!this.resolveRegistration('router:main')) {
+      this.register('router:main', this.base.Router);
+    }
+
     options = new BootOptions(options);
 
     this.setupRegistry(options);

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -576,7 +576,19 @@ const Application = Engine.extend({
   _bootSync() {
     if (this._booted) { return; }
 
-
+    /*
+     * router:main is always an instance of `App.Router`. In the past, this
+     * was because the container resolved the 'main' by looking to `App[type]`.
+     * By registering it explicitly, the dependency on the DefaultResolver is
+     * avoided.
+     *
+     * A copy is registered on the application since it may be requested by
+     * access to the container before the application instance has booted.
+     * App.Router is not gaurenteed to be set at this point, however.
+     */
+    if (!this.resolveRegistration('router:main') && this.Router) {
+      this.register('router:main', this.Router);
+    }
 
     // Even though this returns synchronously, we still need to make sure the
     // boot promise exists for book-keeping purposes: if anything went wrong in

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -46,7 +46,7 @@ let originalLookup, originalDebug, originalWarn, resolver;
  *   - MyApplication, an alternative Application class to create()
  */
 function buildApplication(options, MyApplication=Application) {
-  let myOptions = assign({ Resolver: TestResolver}, options);
+  let myOptions = assign({ Resolver: TestResolver }, options);
   let applicationInstance = MyApplication.create(myOptions);
   applications.push(applicationInstance);
   resolver = myOptions.Resolver.lastInstance;
@@ -133,7 +133,11 @@ QUnit.test('with DefaultResolver acts like a namespace', function() {
   let lookup = context.lookup = {};
 
   let application = run(() => {
-    return lookup.TestApp = Application.create({ rootElement: '#two', router: false });
+    return lookup.TestApp = buildApplication({
+      rootElement: '#two',
+      router: false,
+      Resolver: DefaultResolver
+    });
   });
 
   setNamespaceSearchDisabled(false);

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -17,6 +17,7 @@ import {
   Route as EmberRoute
 } from 'ember-routing';
 import { jQuery } from 'ember-views';
+import { assign } from 'ember-utils';
 import {
   Controller,
   Object as EmberObject,
@@ -30,19 +31,55 @@ import {
   verifyInjection,
   verifyRegistration
 } from '../test-helpers/registry-check';
+import { TestResolver } from 'internal-test-helpers';
 
 let { trim } = jQuery;
 
-let app, application, originalLookup, originalDebug, originalWarn;
+let applications = [];
+let originalLookup, originalDebug, originalWarn, resolver;
+
+/*
+ * create an application and register it for teardown. Applications
+ * built will have the TestResolver by default. Arguments:
+ *
+ *   - options, an object passed to create()
+ *   - MyApplication, an alternative Application class to create()
+ */
+function buildApplication(options, MyApplication=Application) {
+  let myOptions = assign({ Resolver: TestResolver}, options);
+  let applicationInstance = MyApplication.create(myOptions);
+  applications.push(applicationInstance);
+  resolver = myOptions.Resolver.lastInstance;
+  return applicationInstance;
+}
+
+/*
+ * run buildApplication in a runloop
+ */
+function runBuildApplication(options) {
+  return run(() => buildApplication(options));
+}
+
+/*
+ * Teardown application instances created by buildApplication
+ */
+function destroyApplications() {
+  applications.forEach(application => {
+    if (!application.isDestroyed) {
+      run(application, 'destroy');
+    }
+  });
+  applications.length = 0;
+}
 
 QUnit.module('Ember.Application', {
   setup() {
     originalLookup = context.lookup;
     originalDebug = getDebugFunction('debug');
     originalWarn = getDebugFunction('warn');
+    resolver = null;
 
     jQuery('#qunit-fixture').html('<div id=\'one\'><div id=\'one-child\'>HI</div></div><div id=\'two\'>HI</div>');
-    application = run(() => Application.create({ rootElement: '#one', router: null }));
   },
 
   teardown() {
@@ -52,61 +89,61 @@ QUnit.module('Ember.Application', {
 
     context.lookup = originalLookup;
 
-    if (application) {
-      run(application, 'destroy');
-    }
-
-    if (app) {
-      run(app, 'destroy');
-    }
+    destroyApplications();
   }
 });
 
 QUnit.test('you can make a new application in a non-overlapping element', function() {
-  app = run(() => Application.create({ rootElement: '#two', router: null }));
+  runBuildApplication({ rootElement: '#one', router: null });
+  let application = runBuildApplication({ rootElement: '#two', router: null });
 
-  run(app, 'destroy');
+  run(application, 'destroy');
   ok(true, 'should not raise');
 });
 
 QUnit.test('you cannot make a new application that is a parent of an existing application', function() {
+  runBuildApplication({ rootElement: '#one', router: null });
   expectAssertion(() => {
-    run(() => Application.create({ rootElement: '#qunit-fixture' }));
+    runBuildApplication({ rootElement: '#qunit-fixture' });
   });
 });
 
 QUnit.test('you cannot make a new application that is a descendant of an existing application', function() {
+  runBuildApplication({ rootElement: '#one', router: null });
   expectAssertion(() => {
-    run(() => Application.create({ rootElement: '#one-child' }));
+    runBuildApplication({ rootElement: '#one-child' });
   });
 });
 
 QUnit.test('you cannot make a new application that is a duplicate of an existing application', function() {
+  runBuildApplication({ rootElement: '#one', router: null });
   expectAssertion(() => {
-    run(() => Application.create({ rootElement: '#one' }));
+    runBuildApplication({ rootElement: '#one' });
   });
 });
 
 QUnit.test('you cannot make two default applications without a rootElement error', function() {
+  runBuildApplication({ rootElement: '#one', router: null });
   expectAssertion(() => {
-    run(() => Application.create({ router: false }));
+    runBuildApplication({ router: false });
   });
 });
 
-QUnit.test('acts like a namespace', function() {
+QUnit.test('with DefaultResolver acts like a namespace', function() {
   let lookup = context.lookup = {};
 
-  app = run(() => {
+  let application = run(() => {
     return lookup.TestApp = Application.create({ rootElement: '#two', router: false });
   });
 
   setNamespaceSearchDisabled(false);
-  app.Foo = EmberObject.extend();
-  equal(app.Foo.toString(), 'TestApp.Foo', 'Classes pick up their parent namespace');
+  application.Foo = EmberObject.extend();
+  equal(application.Foo.toString(), 'TestApp.Foo', 'Classes pick up their parent namespace');
 });
 
 QUnit.test('includes deprecated access to `application.registry`', function() {
   expect(3);
+  let application = runBuildApplication({ rootElement: '#one', router: null });
 
   ok(typeof application.registry.register === 'function', '#registry.register is available as a function');
 
@@ -120,6 +157,8 @@ QUnit.test('includes deprecated access to `application.registry`', function() {
 });
 
 QUnit.test('builds a registry', function() {
+  let application = runBuildApplication({ rootElement: '#one', router: null });
+
   strictEqual(application.resolveRegistration('application:main'), application, `application:main is registered`);
   deepEqual(application.registeredOptionsForType('component'), { singleton: false }, `optionsForType 'component'`);
   deepEqual(application.registeredOptionsForType('view'), { singleton: false }, `optionsForType 'view'`);
@@ -181,9 +220,7 @@ const originalLogVersion = ENV.LOG_VERSION;
 
 QUnit.module('Ember.Application initialization', {
   teardown() {
-    if (app) {
-      run(app, 'destroy');
-    }
+    destroyApplications();
     setTemplates({});
     ENV.LOG_VERSION = originalLogVersion;
   }
@@ -191,21 +228,19 @@ QUnit.module('Ember.Application initialization', {
 
 QUnit.test('initialized application goes to initial route', function() {
   run(() => {
-    app = Application.create({
+    let application = buildApplication({
       rootElement: '#qunit-fixture'
     });
 
-    app.Router.reopen({
+    application.Router.reopen({
       location: 'none'
     });
 
-    app.register('template:application',
+    application.register('template:application',
       compile('{{outlet}}')
     );
 
-    setTemplate('index', compile(
-      '<h1>Hi from index</h1>'
-    ));
+    resolver.addTemplate('index', '<h1>Hi from index</h1>');
   });
 
   equal(jQuery('#qunit-fixture h1').text(), 'Hi from index');
@@ -215,12 +250,12 @@ QUnit.test('ready hook is called before routing begins', function() {
   expect(2);
 
   run(() => {
-    function registerRoute(application, name, callback) {
+    function registerRoute(_application, name, callback) {
       let route = EmberRoute.extend({
         activate: callback
       });
 
-      application.register('route:' + name, route);
+      _application.register('route:' + name, route);
     }
 
     let MyApplication = Application.extend({
@@ -231,69 +266,70 @@ QUnit.test('ready hook is called before routing begins', function() {
       }
     });
 
-    app = MyApplication.create({
-      rootElement: '#qunit-fixture'
-    });
+    let application = buildApplication({
+      rootElement: '#qunit-fixture',
+      Resolver: TestResolver
+    }, MyApplication);
 
-    app.Router.reopen({
+    application.Router.reopen({
       location: 'none'
     });
 
-    registerRoute(app, 'application', () => ok(true, 'normal route is activated'));
+    registerRoute(application, 'application', () => ok(true, 'normal route is activated'));
   });
 });
 
 QUnit.test('initialize application via initialize call', function() {
+  let application;
   run(() => {
-    app = Application.create({
+    application = buildApplication({
       rootElement: '#qunit-fixture'
     });
 
-    app.Router.reopen({
+    application.Router.reopen({
       location: 'none'
     });
 
-    setTemplate('application', compile(
-      '<h1>Hello!</h1>'
-    ));
+    resolver.addTemplate('application', '<h1>Hello!</h1>');
   });
 
   // This is not a public way to access the container; we just
   // need to make some assertions about the created router
-  let router = app.__container__.lookup('router:main');
+  let router = application.__container__.lookup('router:main');
   equal(router instanceof Router, true, 'Router was set from initialize call');
   equal(router.location instanceof NoneLocation, true, 'Location was set from location implementation name');
 });
 
 QUnit.test('initialize application with stateManager via initialize call from Router class', function() {
+  let application;
   run(() => {
-    app = Application.create({
+    application = buildApplication({
       rootElement: '#qunit-fixture'
     });
 
-    app.Router.reopen({
+    application.Router.reopen({
       location: 'none'
     });
 
-    app.register('template:application', compile('<h1>Hello!</h1>'));
+    application.register('template:application', compile('<h1>Hello!</h1>'));
   });
 
-  let router = app.__container__.lookup('router:main');
+  let router = application.__container__.lookup('router:main');
   equal(router instanceof Router, true, 'Router was set from initialize call');
   equal(jQuery('#qunit-fixture h1').text(), 'Hello!');
 });
 
 QUnit.test('ApplicationView is inserted into the page', function() {
   run(() => {
-    app = Application.create({
+    let application = buildApplication({
       rootElement: '#qunit-fixture'
     });
 
-    setTemplate('application', compile('<h1>Hello!</h1>'));
+    resolver.addTemplate('application', '<h1>Hello!</h1>');
 
-    app.ApplicationController = Controller.extend();
+    resolver.add('controller:application', Controller.extend());
 
-    app.Router.reopen({
+    application.Router.reopen({
       location: 'none'
     });
   });
@@ -301,12 +337,11 @@ QUnit.test('ApplicationView is inserted into the page', function() {
   equal(jQuery('#qunit-fixture h1').text(), 'Hello!');
 });
 
-QUnit.test('Minimal Application initialized with just an application template', function() {
+QUnit.test('Minimal Application initialized with just a default resolved application template', function() {
   jQuery('#qunit-fixture').html('<script type="text/x-handlebars">Hello World</script>');
-  app = run(() => {
-    return Application.create({
-      rootElement: '#qunit-fixture'
-    });
+  runBuildApplication({
+    rootElement: '#qunit-fixture',
+    Resolver: DefaultResolver
   });
 
   equal(trim(jQuery('#qunit-fixture').text()), 'Hello World');
@@ -326,10 +361,8 @@ QUnit.test('enable log of libraries with an ENV var', function() {
 
   libraries.register('my-lib', '2.0.0a');
 
-  app = run(() => {
-    return Application.create({
-      rootElement: '#qunit-fixture'
-    });
+  runBuildApplication({
+    rootElement: '#qunit-fixture'
   });
 
   equal(messages[1], 'Ember  : ' + VERSION);
@@ -349,11 +382,11 @@ QUnit.test('disable log version of libraries with an ENV var', function() {
   jQuery('#qunit-fixture').empty();
 
   run(() => {
-    app = Application.create({
+    let application = buildApplication({
       rootElement: '#qunit-fixture'
     });
 
-    app.Router.reopen({
+    application.Router.reopen({
       location: 'none'
     });
   });
@@ -374,30 +407,24 @@ QUnit.test('can resolve custom router', function() {
     }
   });
 
-  app = run(() => {
-    return Application.create({
-      Resolver
-    });
-  });
+  let application = runBuildApplication({ Resolver });
 
-  ok(app.__container__.lookup('router:main') instanceof CustomRouter, 'application resolved the correct router');
+  ok(application.__container__.lookup('router:main') instanceof CustomRouter, 'application resolved the correct router');
 });
 
 QUnit.test('can specify custom router', function() {
-  app = run(() => {
-    return Application.create({
-      Router: Router.extend()
-    });
+  let application = runBuildApplication({
+    Router: Router.extend()
   });
 
-  ok(app.__container__.lookup('router:main') instanceof Router, 'application resolved the correct router');
+  ok(application.__container__.lookup('router:main') instanceof Router, 'application resolved the correct router');
 });
 
 QUnit.test('does not leak itself in onLoad._loaded', function() {
   equal(_loaded.application, undefined);
-  let app = run(Application, 'create');
-  equal(_loaded.application, app);
-  run(app, 'destroy');
+  let application = runBuildApplication();
+  equal(_loaded.application, application);
+  run(application, 'destroy');
   equal(_loaded.application, undefined);
 });
 

--- a/packages/ember-glimmer/tests/integration/application/engine-test.js
+++ b/packages/ember-glimmer/tests/integration/application/engine-test.js
@@ -366,7 +366,6 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
     assert.expect(2);
 
     this.setupAppAndRoutableEngine();
-    this.application.__registry__.resolver.moduleBasedResolver = true;
     this.additionalEngineRegistrations(function() {
       this.register('template:application_error', compile('Error! {{model.message}}'));
       this.register('route:post', Route.extend({
@@ -388,7 +387,6 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
     assert.expect(2);
 
     this.setupAppAndRoutableEngine();
-    this.application.__registry__.resolver.moduleBasedResolver = true;
     this.additionalEngineRegistrations(function() {
       this.register('template:error', compile('Error! {{model.message}}'));
       this.register('route:post', Route.extend({
@@ -410,7 +408,6 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
     assert.expect(2);
 
     this.setupAppAndRoutableEngine();
-    this.application.__registry__.resolver.moduleBasedResolver = true;
     this.additionalEngineRegistrations(function() {
       this.register('template:post_error', compile('Error! {{model.message}}'));
       this.register('route:post', Route.extend({
@@ -432,7 +429,6 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
     assert.expect(2);
 
     this.setupAppAndRoutableEngine();
-    this.application.__registry__.resolver.moduleBasedResolver = true;
     this.additionalEngineRegistrations(function() {
       this.register('template:post.error', compile('Error! {{model.message}}'));
       this.register('route:post.comments', Route.extend({
@@ -456,7 +452,6 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
     let resolveLoading;
 
     this.setupAppAndRoutableEngine();
-    this.application.__registry__.resolver.moduleBasedResolver = true;
     this.additionalEngineRegistrations(function() {
       this.register('template:application_loading', compile('Loading'));
       this.register('template:post', compile('Post'));
@@ -523,7 +518,6 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
     let resolveLoading;
 
     this.setupAppAndRoutableEngine();
-    this.application.__registry__.resolver.moduleBasedResolver = true;
     this.additionalEngineRegistrations(function() {
       this.register('template:post', compile('{{outlet}}'));
       this.register('template:post.comments', compile('Comments'));

--- a/packages/internal-test-helpers/lib/index.js
+++ b/packages/internal-test-helpers/lib/index.js
@@ -28,3 +28,8 @@ export { default as QueryParamTestCase } from './test-cases/query-param';
 export { default as AbstractRenderingTestCase } from './test-cases/abstract-rendering';
 export { default as RenderingTestCase } from './test-cases/rendering';
 export { default as RouterTestCase } from './test-cases/router';
+
+export {
+  default as TestResolver,
+  ModuleBasedResolver as ModuleBasedTestResolver
+} from './test-resolver';

--- a/packages/internal-test-helpers/lib/test-cases/abstract-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract-application.js
@@ -7,6 +7,8 @@ import { compile } from 'ember-template-compiler';
 import AbstractTestCase from './abstract';
 import { runDestroy } from '../run';
 
+import { ModuleBasedResolver } from '../test-resolver';
+
 export default class AbstractApplicationTestCase extends AbstractTestCase {
   constructor() {
     super();
@@ -16,6 +18,7 @@ export default class AbstractApplicationTestCase extends AbstractTestCase {
     this.application = run(Application, 'create', this.applicationOptions);
 
     this.router = this.application.Router = Router.extend(this.routerOptions);
+    this.resolver = this.applicationOptions.Resolver.lastInstance;
 
     this.applicationInstance = null;
   }
@@ -23,7 +26,8 @@ export default class AbstractApplicationTestCase extends AbstractTestCase {
   get applicationOptions() {
     return {
       rootElement: '#qunit-fixture',
-      autoboot: false
+      autoboot: false,
+      Resolver: ModuleBasedResolver
     };
   }
 
@@ -66,32 +70,32 @@ export default class AbstractApplicationTestCase extends AbstractTestCase {
   }
 
   registerRoute(name, route) {
-    this.application.register(`route:${name}`, route);
+    this.resolver.add(`route:${name}`, route);
   }
 
   registerTemplate(name, template) {
-    this.application.register(`template:${name}`, this.compile(template, {
+    this.resolver.add(`template:${name}`, this.compile(template, {
       moduleName: name
     }));
   }
 
   registerComponent(name, { ComponentClass = null, template = null }) {
     if (ComponentClass) {
-      this.application.register(`component:${name}`, ComponentClass);
+      this.resolver.add(`component:${name}`, ComponentClass);
     }
 
     if (typeof template === 'string') {
-      this.application.register(`template:components/${name}`, this.compile(template, {
+      this.resolver.add(`template:components/${name}`, this.compile(template, {
         moduleName: `components/${name}`
       }));
     }
   }
 
   registerController(name, controller) {
-    this.application.register(`controller:${name}`, controller);
+    this.resolver.add(`controller:${name}`, controller);
   }
 
   registerEngine(name, engine) {
-    this.application.register(`engine:${name}`, engine);
+    this.resolver.add(`engine:${name}`, engine);
   }
 }

--- a/packages/internal-test-helpers/lib/test-resolver.js
+++ b/packages/internal-test-helpers/lib/test-resolver.js
@@ -1,0 +1,38 @@
+import { compile } from 'ember-template-compiler';
+
+class Resolver {
+  constructor() {
+    this._registered = {};
+    this.constructor.lastInstance = this;
+  }
+  resolve(specifier) {
+    return this._registered[specifier];
+  }
+  add(specifier, factory) {
+    return this._registered[specifier] = factory;
+  }
+  addTemplate(specifier, template) {
+    let templateType = typeof template;
+    if (templateType !== 'string') {
+      throw new Error(`You called addTemplate with a template argument of type of '${templateType}'. addTemplate expects an argument of an uncompiled template as a string.`);
+    }
+    return this._registered[`template:${specifier}`] = compile(template);
+  }
+  static create() {
+    return new this();
+  }
+}
+
+export default Resolver;
+
+/*
+ * A resolver with moduleBasedResolver = true handles error and loading
+ * substates differently than a standard resolver.
+ */
+class ModuleBasedResolver extends Resolver {
+  get moduleBasedResolver() {
+    return true;
+  }
+}
+
+export { ModuleBasedResolver }


### PR DESCRIPTION
`App.Router` is not part of the global-based default resolver API (e.g. `App.FooController`), but part of Ember's own API (e.g. `App.Resolver`). This change registers the `Router` class into the container instead of relying on resolution, removing a dependency on the default resolver
from applications that use `App.Router`.

Commits:

* The first commit in this PR passes tests, however the goal is that individual test can be migrated away from the default resolver.
* The second commit in this PR migrates the application tests away from the default resolver.
* Third commit changes the default resolver for `ApplicationTest` in ember-glimmer. Turns out most tests in this system use register instead of resolving templates, and that is also changed in this commit.
* Fourth commit migrates acceptance test tests to use the `TestResolver`