### PR TITLE
Decouple test from the default resolver

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -1024,6 +1024,7 @@ Application.reopenClass({
 });
 
 function commonSetupRegistry(registry) {
+  registry.register('router:main', Router);
   registry.register('-view-registry:main', { create() { return dictionary(null); } });
 
   registry.register('route:basic', Route);

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -24,389 +24,404 @@ import {
   _loaded
 } from 'ember-runtime';
 import { compile } from 'ember-template-compiler';
-import { setTemplates, setTemplate } from 'ember-glimmer';
+import { setTemplates } from 'ember-glimmer';
 import { privatize as P } from 'container';
 import {
   verifyInjection,
   verifyRegistration
 } from '../test-helpers/registry-check';
+import { assign } from 'ember-utils';
+import {
+  moduleFor,
+  ApplicationTestCase,
+  AbstractTestCase,
+  AutobootApplicationTestCase
+} from 'internal-test-helpers';
 
 let { trim } = jQuery;
+let secondApp;
 
-let app, application, originalLookup, originalDebug, originalWarn;
+moduleFor('Ember.Application, autobooting multiple apps', class extends ApplicationTestCase {
+  constructor() {
+    jQuery('#qunit-fixture').html(`
+      <div id="one">
+        <div id="one-child">HI</div>
+      </div>
+      <div id="two">HI</div>
+    `);
+    super();
+  }
 
-QUnit.module('Ember.Application', {
-  setup() {
-    originalLookup = context.lookup;
-    originalDebug = getDebugFunction('debug');
-    originalWarn = getDebugFunction('warn');
+  get applicationOptions() {
+    return assign(super.applicationOptions, {
+      rootElement: '#one',
+      router: null,
+      autoboot: true
+    });
+  }
 
-    jQuery('#qunit-fixture').html('<div id=\'one\'><div id=\'one-child\'>HI</div></div><div id=\'two\'>HI</div>');
-    application = run(() => Application.create({ rootElement: '#one', router: null }));
-  },
+  buildSecondApplication(options) {
+    let myOptions = assign(this.applicationOptions, options);
+    return this.secondApp = Application.create(myOptions);
+  }
 
   teardown() {
-    jQuery('#qunit-fixture').empty();
-    setDebugFunction('debug', originalDebug);
-    setDebugFunction('warn', originalWarn);
+    super.teardown();
 
-    context.lookup = originalLookup;
-
-    if (application) {
-      run(application, 'destroy');
+    if (this.secondApp) {
+      run(this.secondApp, 'destroy');
     }
+  }
 
-    if (app) {
-      run(app, 'destroy');
-    }
+  [`@test you can make a new application in a non-overlapping element`](assert) {
+    let app = run(() => this.buildSecondApplication({
+      rootElement: '#two'
+    }));
+
+    run(app, 'destroy');
+    assert.ok(true, 'should not raise');
+  }
+
+  [`@test you cannot make a new application that is a parent of an existing application`]() {
+    expectAssertion(() => {
+      run(() => this.buildSecondApplication({
+        rootElement: '#qunit-fixture'
+      }));
+    });
+  }
+
+  [`@test you cannot make a new application that is a descendant of an existing application`]() {
+    expectAssertion(() => {
+      run(() => this.buildSecondApplication({
+        rootElement: '#one-child'
+      }));
+    });
+  }
+
+  [`@test you cannot make a new application that is a duplicate of an existing application`]() {
+    expectAssertion(() => {
+      run(() => this.buildSecondApplication({
+        rootElement: '#one'
+      }));
+    });
+  }
+
+  [`@test you cannot make two default applications without a rootElement error`]() {
+    expectAssertion(() => {
+      run(() => this.buildSecondApplication());
+    });
   }
 });
 
-QUnit.test('you can make a new application in a non-overlapping element', function() {
-  app = run(() => Application.create({ rootElement: '#two', router: null }));
+moduleFor('Ember.Application', class extends ApplicationTestCase {
 
-  run(app, 'destroy');
-  ok(true, 'should not raise');
+  ['@test includes deprecated access to `application.registry`'](assert) {
+    assert.expect(3);
+
+    assert.ok(typeof this.application.registry.register === 'function', '#registry.register is available as a function');
+
+    this.application.__registry__.register = function() {
+      assert.ok(true, '#register alias is called correctly');
+    };
+
+    expectDeprecation(() => {
+      this.application.registry.register();
+    }, /Using `Application.registry.register` is deprecated. Please use `Application.register` instead./);
+  }
+
+  [`@test builds a registry`](assert) {
+    let {application} = this;
+    assert.strictEqual(application.resolveRegistration('application:main'), application, `application:main is registered`);
+    assert.deepEqual(application.registeredOptionsForType('component'), { singleton: false }, `optionsForType 'component'`);
+    assert.deepEqual(application.registeredOptionsForType('view'), { singleton: false }, `optionsForType 'view'`);
+    verifyRegistration(application, 'controller:basic');
+    verifyRegistration(application, '-view-registry:main');
+    verifyInjection(application, 'view', '_viewRegistry', '-view-registry:main');
+    verifyInjection(application, 'route', '_topLevelViewTemplate', 'template:-outlet');
+    verifyRegistration(application, 'route:basic');
+    verifyRegistration(application, 'event_dispatcher:main');
+    verifyInjection(application, 'router:main', 'namespace', 'application:main');
+    verifyInjection(application, 'view:-outlet', 'namespace', 'application:main');
+
+    verifyRegistration(application, 'location:auto');
+    verifyRegistration(application, 'location:hash');
+    verifyRegistration(application, 'location:history');
+    verifyRegistration(application, 'location:none');
+
+    verifyInjection(application, 'controller', 'target', 'router:main');
+    verifyInjection(application, 'controller', 'namespace', 'application:main');
+
+    verifyRegistration(application, P`-bucket-cache:main`);
+    verifyInjection(application, 'router', '_bucketCache', P`-bucket-cache:main`);
+    verifyInjection(application, 'route', '_bucketCache', P`-bucket-cache:main`);
+
+    verifyInjection(application, 'route', 'router', 'router:main');
+
+    verifyRegistration(application, 'component:-text-field');
+    verifyRegistration(application, 'component:-text-area');
+    verifyRegistration(application, 'component:-checkbox');
+    verifyRegistration(application, 'component:link-to');
+
+    verifyRegistration(application, 'service:-routing');
+    verifyInjection(application, 'service:-routing', 'router', 'router:main');
+
+    // DEBUGGING
+    verifyRegistration(application, 'resolver-for-debugging:main');
+    verifyInjection(application, 'container-debug-adapter:main', 'resolver', 'resolver-for-debugging:main');
+    verifyInjection(application, 'data-adapter:main', 'containerDebugAdapter', 'container-debug-adapter:main');
+    verifyRegistration(application, 'container-debug-adapter:main');
+    verifyRegistration(application, 'component-lookup:main');
+
+    verifyRegistration(application, 'service:-glimmer-environment');
+    verifyRegistration(application, 'service:-dom-changes');
+    verifyRegistration(application, 'service:-dom-tree-construction');
+    verifyInjection(application, 'service:-glimmer-environment', 'appendOperations', 'service:-dom-tree-construction');
+    verifyInjection(application, 'service:-glimmer-environment', 'updateOperations', 'service:-dom-changes');
+    verifyInjection(application, 'renderer', 'env', 'service:-glimmer-environment');
+    verifyRegistration(application, 'view:-outlet');
+    verifyRegistration(application, 'renderer:-dom');
+    verifyRegistration(application, 'renderer:-inert');
+    verifyRegistration(application, P`template:components/-default`);
+    verifyRegistration(application, 'template:-outlet');
+    verifyInjection(application, 'view:-outlet', 'template', 'template:-outlet');
+    verifyInjection(application, 'template', 'env', 'service:-glimmer-environment');
+    assert.deepEqual(application.registeredOptionsForType('helper'), { instantiate: false }, `optionsForType 'helper'`);
+  }
+
 });
 
-QUnit.test('you cannot make a new application that is a parent of an existing application', function() {
-  expectAssertion(() => {
-    run(() => Application.create({ rootElement: '#qunit-fixture' }));
-  });
-});
+moduleFor('Ember.Application, default resolver with autoboot', class extends AutobootApplicationTestCase {
 
-QUnit.test('you cannot make a new application that is a descendant of an existing application', function() {
-  expectAssertion(() => {
-    run(() => Application.create({ rootElement: '#one-child' }));
-  });
-});
+  constructor() {
+    super();
+    this.originalLookup = context.lookup;
+  }
 
-QUnit.test('you cannot make a new application that is a duplicate of an existing application', function() {
-  expectAssertion(() => {
-    run(() => Application.create({ rootElement: '#one' }));
-  });
-});
-
-QUnit.test('you cannot make two default applications without a rootElement error', function() {
-  expectAssertion(() => {
-    run(() => Application.create({ router: false }));
-  });
-});
-
-QUnit.test('acts like a namespace', function() {
-  let lookup = context.lookup = {};
-
-  app = run(() => {
-    return lookup.TestApp = Application.create({ rootElement: '#two', router: false });
-  });
-
-  setNamespaceSearchDisabled(false);
-  app.Foo = EmberObject.extend();
-  equal(app.Foo.toString(), 'TestApp.Foo', 'Classes pick up their parent namespace');
-});
-
-QUnit.test('includes deprecated access to `application.registry`', function() {
-  expect(3);
-
-  ok(typeof application.registry.register === 'function', '#registry.register is available as a function');
-
-  application.__registry__.register = function() {
-    ok(true, '#register alias is called correctly');
-  };
-
-  expectDeprecation(() => {
-    application.registry.register();
-  }, /Using `Application.registry.register` is deprecated. Please use `Application.register` instead./);
-});
-
-QUnit.test('builds a registry', function() {
-  strictEqual(application.resolveRegistration('application:main'), application, `application:main is registered`);
-  deepEqual(application.registeredOptionsForType('component'), { singleton: false }, `optionsForType 'component'`);
-  deepEqual(application.registeredOptionsForType('view'), { singleton: false }, `optionsForType 'view'`);
-  verifyRegistration(application, 'controller:basic');
-  verifyRegistration(application, '-view-registry:main');
-  verifyInjection(application, 'view', '_viewRegistry', '-view-registry:main');
-  verifyInjection(application, 'route', '_topLevelViewTemplate', 'template:-outlet');
-  verifyRegistration(application, 'route:basic');
-  verifyRegistration(application, 'event_dispatcher:main');
-  verifyInjection(application, 'router:main', 'namespace', 'application:main');
-  verifyInjection(application, 'view:-outlet', 'namespace', 'application:main');
-
-  verifyRegistration(application, 'location:auto');
-  verifyRegistration(application, 'location:hash');
-  verifyRegistration(application, 'location:history');
-  verifyRegistration(application, 'location:none');
-
-  verifyInjection(application, 'controller', 'target', 'router:main');
-  verifyInjection(application, 'controller', 'namespace', 'application:main');
-
-  verifyRegistration(application, P`-bucket-cache:main`);
-  verifyInjection(application, 'router', '_bucketCache', P`-bucket-cache:main`);
-  verifyInjection(application, 'route', '_bucketCache', P`-bucket-cache:main`);
-
-  verifyInjection(application, 'route', 'router', 'router:main');
-
-  verifyRegistration(application, 'component:-text-field');
-  verifyRegistration(application, 'component:-text-area');
-  verifyRegistration(application, 'component:-checkbox');
-  verifyRegistration(application, 'component:link-to');
-
-  verifyRegistration(application, 'service:-routing');
-  verifyInjection(application, 'service:-routing', 'router', 'router:main');
-
-  // DEBUGGING
-  verifyRegistration(application, 'resolver-for-debugging:main');
-  verifyInjection(application, 'container-debug-adapter:main', 'resolver', 'resolver-for-debugging:main');
-  verifyInjection(application, 'data-adapter:main', 'containerDebugAdapter', 'container-debug-adapter:main');
-  verifyRegistration(application, 'container-debug-adapter:main');
-  verifyRegistration(application, 'component-lookup:main');
-
-  verifyRegistration(application, 'service:-glimmer-environment');
-  verifyRegistration(application, 'service:-dom-changes');
-  verifyRegistration(application, 'service:-dom-tree-construction');
-  verifyInjection(application, 'service:-glimmer-environment', 'appendOperations', 'service:-dom-tree-construction');
-  verifyInjection(application, 'service:-glimmer-environment', 'updateOperations', 'service:-dom-changes');
-  verifyInjection(application, 'renderer', 'env', 'service:-glimmer-environment');
-  verifyRegistration(application, 'view:-outlet');
-  verifyRegistration(application, 'renderer:-dom');
-  verifyRegistration(application, 'renderer:-inert');
-  verifyRegistration(application, P`template:components/-default`);
-  verifyRegistration(application, 'template:-outlet');
-  verifyInjection(application, 'view:-outlet', 'template', 'template:-outlet');
-  verifyInjection(application, 'template', 'env', 'service:-glimmer-environment');
-  deepEqual(application.registeredOptionsForType('helper'), { instantiate: false }, `optionsForType 'helper'`);
-});
-
-const originalLogVersion = ENV.LOG_VERSION;
-
-QUnit.module('Ember.Application initialization', {
   teardown() {
-    if (app) {
-      run(app, 'destroy');
-    }
+    context.lookup = this.originalLookup;
+    super.teardown();
     setTemplates({});
-    ENV.LOG_VERSION = originalLogVersion;
   }
-});
 
-QUnit.test('initialized application goes to initial route', function() {
-  run(() => {
-    app = Application.create({
-      rootElement: '#qunit-fixture'
+  createApplication(options) {
+    let myOptions = assign({
+      Resolver: DefaultResolver
+    }, options);
+    return super.createApplication(myOptions);
+  }
+
+  [`@test acts like a namespace`](assert) {
+    let lookup = context.lookup = {};
+
+    run(() => {
+      lookup.TestApp = this.createApplication();
     });
 
-    app.Router.reopen({
-      location: 'none'
-    });
+    setNamespaceSearchDisabled(false);
+    let Foo = this.application.Foo = EmberObject.extend();
+    assert.equal(Foo.toString(), 'TestApp.Foo', 'Classes pick up their parent namespace');
+  }
 
-    app.register('template:application',
-      compile('{{outlet}}')
+  [`@test can specify custom router`](assert) {
+    let MyRouter = Router.extend();
+    run(() => {
+      let app = this.createApplication();
+      app.Router = MyRouter;
+    });
+    assert.ok(
+      this.application.__deprecatedInstance__.lookup('router:main') instanceof MyRouter,
+      'application resolved the correct router'
     );
+  }
 
-    setTemplate('index', compile(
-      '<h1>Hi from index</h1>'
-    ));
-  });
+  [`@test Minimal Application initialized with just an application template`](assert) {
+    jQuery('#qunit-fixture').html('<script type="text/x-handlebars">Hello World</script>');
+    run(() => {
+      this.createApplication();
+    });
 
-  equal(jQuery('#qunit-fixture h1').text(), 'Hi from index');
+    equal(trim(jQuery('#qunit-fixture').text()), 'Hello World');
+  }
+
 });
 
-QUnit.test('ready hook is called before routing begins', function() {
-  expect(2);
+moduleFor('Ember.Application, autobooting', class extends AutobootApplicationTestCase {
 
-  run(() => {
-    function registerRoute(application, name, callback) {
-      let route = EmberRoute.extend({
-        activate: callback
+  constructor() {
+    super();
+    this.originalLogVersion = ENV.LOG_VERSION;
+    this.originalDebug = getDebugFunction('debug');
+    this.originalWarn = getDebugFunction('warn');
+  }
+
+  teardown() {
+    setDebugFunction('warn', this.originalWarn);
+    setDebugFunction('debug', this.originalDebug);
+    ENV.LOG_VERSION = this.originalLogVersion;
+    super.teardown();
+  }
+
+  createApplication(options, MyApplication) {
+    let application = super.createApplication(options, MyApplication);
+    this.add('router:main', Router.extend({
+      location: 'none'
+    }));
+    return application;
+  }
+
+  [`@test initialized application goes to initial route`](assert) {
+    run(() => {
+      this.createApplication();
+      this.addTemplate('application', '{{outlet}}');
+      this.addTemplate('index', '<h1>Hi from index</h1>');
+    });
+
+    assert.equal(jQuery('#qunit-fixture h1').text(), 'Hi from index');
+  }
+
+  [`@test ready hook is called before routing begins`](assert) {
+    assert.expect(2);
+
+    run(() => {
+      function registerRoute(application, name, callback) {
+        let route = EmberRoute.extend({
+          activate: callback
+        });
+
+        application.register('route:' + name, route);
+      }
+
+      let MyApplication = Application.extend({
+        ready() {
+          registerRoute(this, 'index', () => {
+            assert.ok(true, 'last-minute route is activated');
+          });
+        }
       });
 
-      application.register('route:' + name, route);
-    }
+      let app = this.createApplication({}, MyApplication);
 
-    let MyApplication = Application.extend({
-      ready() {
-        registerRoute(this, 'index', () => {
-          ok(true, 'last-minute route is activated');
-        });
-      }
+      registerRoute(app, 'application', () => ok(true, 'normal route is activated'));
     });
-
-    app = MyApplication.create({
-      rootElement: '#qunit-fixture'
-    });
-
-    app.Router.reopen({
-      location: 'none'
-    });
-
-    registerRoute(app, 'application', () => ok(true, 'normal route is activated'));
-  });
-});
-
-QUnit.test('initialize application via initialize call', function() {
-  run(() => {
-    app = Application.create({
-      rootElement: '#qunit-fixture'
-    });
-
-    app.Router.reopen({
-      location: 'none'
-    });
-
-    setTemplate('application', compile(
-      '<h1>Hello!</h1>'
-    ));
-  });
-
-  // This is not a public way to access the container; we just
-  // need to make some assertions about the created router
-  let router = app.__container__.lookup('router:main');
-  equal(router instanceof Router, true, 'Router was set from initialize call');
-  equal(router.location instanceof NoneLocation, true, 'Location was set from location implementation name');
-});
-
-QUnit.test('initialize application with stateManager via initialize call from Router class', function() {
-  run(() => {
-    app = Application.create({
-      rootElement: '#qunit-fixture'
-    });
-
-    app.Router.reopen({
-      location: 'none'
-    });
-
-    app.register('template:application', compile('<h1>Hello!</h1>'));
-  });
-
-  let router = app.__container__.lookup('router:main');
-  equal(router instanceof Router, true, 'Router was set from initialize call');
-  equal(jQuery('#qunit-fixture h1').text(), 'Hello!');
-});
-
-QUnit.test('ApplicationView is inserted into the page', function() {
-  run(() => {
-    app = Application.create({
-      rootElement: '#qunit-fixture'
-    });
-
-    setTemplate('application', compile('<h1>Hello!</h1>'));
-
-    app.ApplicationController = Controller.extend();
-
-    app.Router.reopen({
-      location: 'none'
-    });
-  });
-
-  equal(jQuery('#qunit-fixture h1').text(), 'Hello!');
-});
-
-QUnit.test('Minimal Application initialized with just an application template', function() {
-  jQuery('#qunit-fixture').html('<script type="text/x-handlebars">Hello World</script>');
-  app = run(() => {
-    return Application.create({
-      rootElement: '#qunit-fixture'
-    });
-  });
-
-  equal(trim(jQuery('#qunit-fixture').text()), 'Hello World');
-});
-
-QUnit.test('enable log of libraries with an ENV var', function() {
-  if (EmberDev && EmberDev.runningProdBuild) {
-    ok(true, 'Logging does not occur in production builds');
-    return;
   }
 
-  let messages = [];
-
-  ENV.LOG_VERSION = true;
-
-  setDebugFunction('debug', message => messages.push(message));
-
-  libraries.register('my-lib', '2.0.0a');
-
-  app = run(() => {
-    return Application.create({
-      rootElement: '#qunit-fixture'
+  [`@test initialize application via initialize call`](assert) {
+    run(() => {
+      this.createApplication();
     });
-  });
+    // This is not a public way to access the container; we just
+    // need to make some assertions about the created router
+    let router = this.application.__deprecatedInstance__.lookup('router:main');
+    assert.equal(router instanceof Router, true, 'Router was set from initialize call');
+    assert.equal(router.location instanceof NoneLocation, true, 'Location was set from location implementation name');
+  }
 
-  equal(messages[1], 'Ember  : ' + VERSION);
-  equal(messages[2], 'jQuery : ' + jQuery().jquery);
-  equal(messages[3], 'my-lib : ' + '2.0.0a');
-
-  libraries.deRegister('my-lib');
-});
-
-QUnit.test('disable log version of libraries with an ENV var', function() {
-  let logged = false;
-
-  ENV.LOG_VERSION = false;
-
-  setDebugFunction('debug', () => logged = true);
-
-  jQuery('#qunit-fixture').empty();
-
-  run(() => {
-    app = Application.create({
-      rootElement: '#qunit-fixture'
+  [`@test initialize application with stateManager via initialize call from Router class`](assert) {
+    run(() => {
+      this.createApplication();
+      this.addTemplate('application', '<h1>Hello!</h1>');
     });
+    // This is not a public way to access the container; we just
+    // need to make some assertions about the created router
+    let router = this.application.__deprecatedInstance__.lookup('router:main');
+    assert.equal(router instanceof Router, true, 'Router was set from initialize call');
+    assert.equal(jQuery('#qunit-fixture h1').text(), 'Hello!');
+  }
 
-    app.Router.reopen({
-      location: 'none'
+  [`@test Application Controller backs the appplication template`](assert) {
+    run(() => {
+      this.createApplication();
+      this.addTemplate('application', '<h1>{{greeting}}</h1>');
+      this.add('controller:application', Controller.extend({
+        greeting: 'Hello!'
+      }));
     });
-  });
+    assert.equal(jQuery('#qunit-fixture h1').text(), 'Hello!');
+  }
 
-  ok(!logged, 'library version logging skipped');
-});
-
-QUnit.test('can resolve custom router', function() {
-  let CustomRouter = Router.extend();
-
-  let Resolver = DefaultResolver.extend({
-    resolveMain(parsedName) {
-      if (parsedName.type === 'router') {
-        return CustomRouter;
-      } else {
-        return this._super(parsedName);
-      }
+  [`@test enable log of libraries with an ENV var`](assert) {
+    if (EmberDev && EmberDev.runningProdBuild) {
+      assert.ok(true, 'Logging does not occur in production builds');
+      return;
     }
-  });
 
-  app = run(() => {
-    return Application.create({
-      Resolver
+    let messages = [];
+
+    ENV.LOG_VERSION = true;
+
+    setDebugFunction('debug', message => messages.push(message));
+
+    libraries.register('my-lib', '2.0.0a');
+
+    run(() => {
+      this.createApplication();
     });
-  });
 
-  ok(app.__container__.lookup('router:main') instanceof CustomRouter, 'application resolved the correct router');
-});
+    assert.equal(messages[1], 'Ember  : ' + VERSION);
+    assert.equal(messages[2], 'jQuery : ' + jQuery().jquery);
+    assert.equal(messages[3], 'my-lib : ' + '2.0.0a');
 
-QUnit.test('can specify custom router', function() {
-  app = run(() => {
-    return Application.create({
-      Router: Router.extend()
+    libraries.deRegister('my-lib');
+  }
+
+  [`@test disable log of version of libraries with an ENV var`](assert) {
+    let logged = false;
+
+    ENV.LOG_VERSION = false;
+
+    setDebugFunction('debug', () => logged = true);
+
+    run(() => {
+      this.createApplication();
     });
-  });
 
-  ok(app.__container__.lookup('router:main') instanceof Router, 'application resolved the correct router');
+    assert.ok(!logged, 'library version logging skipped');
+  }
+
+  [`@test can resolve custom router`](assert) {
+    let CustomRouter = Router.extend();
+
+    run(() => {
+      this.createApplication();
+      this.add('router:main', CustomRouter);
+    });
+
+    assert.ok(
+      this.application.__deprecatedInstance__.lookup('router:main') instanceof CustomRouter,
+      'application resolved the correct router'
+    );
+  }
+
+  [`@test does not leak itself in onLoad._loaded`](assert) {
+    assert.equal(_loaded.application, undefined);
+    run(() => this.createApplication());
+    assert.equal(_loaded.application, this.application);
+    run(this.application, 'destroy');
+    assert.equal(_loaded.application, undefined);
+  }
+
+  [`@test can build a registry via Ember.Application.buildRegistry() --- simulates ember-test-helpers`](assert) {
+    let namespace = EmberObject.create({
+      Resolver: { create: function() { } }
+    });
+
+    let registry = Application.buildRegistry(namespace);
+
+    assert.equal(registry.resolve('application:main'), namespace);
+  }
+
 });
 
-QUnit.test('does not leak itself in onLoad._loaded', function() {
-  equal(_loaded.application, undefined);
-  let app = run(Application, 'create');
-  equal(_loaded.application, app);
-  run(app, 'destroy');
-  equal(_loaded.application, undefined);
-});
+moduleFor('Ember.Application#buildRegistry', class extends AbstractTestCase {
 
-QUnit.test('can build a registry via Ember.Application.buildRegistry() --- simulates ember-test-helpers', function(assert) {
-  let namespace = EmberObject.create({
-    Resolver: { create: function() { } }
-  });
+  [`@test can build a registry via Ember.Application.buildRegistry() --- simulates ember-test-helpers`](assert) {
+    let namespace = EmberObject.create({
+      Resolver: { create() { } }
+    });
 
-  let registry = Application.buildRegistry(namespace);
+    let registry = Application.buildRegistry(namespace);
 
-  assert.equal(registry.resolve('application:main'), namespace);
+    assert.equal(registry.resolve('application:main'), namespace);
+  }
+
 });

--- a/packages/ember-glimmer/tests/integration/application/actions-test.js
+++ b/packages/ember-glimmer/tests/integration/application/actions-test.js
@@ -6,7 +6,7 @@ moduleFor('Application test: actions', class extends ApplicationTest {
   ['@test actions in top level template application template target application controller'](assert) {
     assert.expect(1);
 
-    this.registerController('application', Controller.extend({
+    this.add('controller:application', Controller.extend({
       actions: {
         handleIt(arg) {
           assert.ok(true, 'controller received action properly');
@@ -14,7 +14,7 @@ moduleFor('Application test: actions', class extends ApplicationTest {
       }
     }));
 
-    this.registerTemplate('application', '<button id="handle-it" {{action "handleIt"}}>Click!</button>');
+    this.addTemplate('application', '<button id="handle-it" {{action "handleIt"}}>Click!</button>');
 
     return this.visit('/')
       .then(() => {
@@ -25,7 +25,7 @@ moduleFor('Application test: actions', class extends ApplicationTest {
   ['@test actions in nested outlet template target their controller'](assert) {
     assert.expect(1);
 
-    this.registerController('application', Controller.extend({
+    this.add('controller:application', Controller.extend({
       actions: {
         handleIt(arg) {
           assert.ok(false, 'application controller should not have received action!');
@@ -33,7 +33,7 @@ moduleFor('Application test: actions', class extends ApplicationTest {
       }
     }));
 
-    this.registerController('index', Controller.extend({
+    this.add('controller:index', Controller.extend({
       actions: {
         handleIt(arg) {
           assert.ok(true, 'controller received action properly');
@@ -41,7 +41,7 @@ moduleFor('Application test: actions', class extends ApplicationTest {
       }
     }));
 
-    this.registerTemplate('index', '<button id="handle-it" {{action "handleIt"}}>Click!</button>');
+    this.addTemplate('index', '<button id="handle-it" {{action "handleIt"}}>Click!</button>');
 
     return this.visit('/')
       .then(() => {

--- a/packages/ember-glimmer/tests/integration/application/engine-test.js
+++ b/packages/ember-glimmer/tests/integration/application/engine-test.js
@@ -10,12 +10,12 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
   setupAppAndRoutableEngine(hooks = []) {
     let self = this;
 
-    this.application.register('template:application', compile('Application{{outlet}}'));
+    this.addTemplate('application', 'Application{{outlet}}');
 
     this.router.map(function() {
       this.mount('blog');
     });
-    this.application.register('route-map:blog', function() {
+    this.add('route-map:blog', function() {
       this.route('post', function() {
         this.route('comments');
         this.route('likes');
@@ -23,13 +23,13 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
       this.route('category', {path: 'category/:id'});
       this.route('author', {path: 'author/:id'});
     });
-    this.registerRoute('application', Route.extend({
+    this.add('route:application', Route.extend({
       model() {
         hooks.push('application - application');
       }
     }));
 
-    this.registerEngine('blog', Engine.extend({
+    this.add('engine:blog', Engine.extend({
       init() {
         this._super(...arguments);
         this.register('controller:application', Controller.extend({
@@ -62,7 +62,7 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
   setupAppAndRoutelessEngine(hooks) {
     this.setupRoutelessEngine(hooks);
 
-    this.registerEngine('chat-engine', Engine.extend({
+    this.add('engine:chat-engine', Engine.extend({
       init() {
         this._super(...arguments);
         this.register('template:application', compile('Engine'));
@@ -77,19 +77,19 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
   }
 
   setupAppAndRoutableEngineWithPartial(hooks) {
-    this.application.register('template:application', compile('Application{{outlet}}'));
+    this.addTemplate('application', 'Application{{outlet}}');
 
     this.router.map(function() {
       this.mount('blog');
     });
-    this.application.register('route-map:blog', function() { });
-    this.registerRoute('application', Route.extend({
+    this.add('route-map:blog', function() { });
+    this.add('route:application', Route.extend({
       model() {
         hooks.push('application - application');
       }
     }));
 
-    this.registerEngine('blog', Engine.extend({
+    this.add('engine:blog', Engine.extend({
       init() {
         this._super(...arguments);
         this.register('template:foo', compile('foo partial'));
@@ -104,8 +104,8 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
   }
 
   setupRoutelessEngine(hooks) {
-    this.application.register('template:application', compile('Application{{mount "chat-engine"}}'));
-    this.registerRoute('application', Route.extend({
+    this.addTemplate('application', 'Application{{mount "chat-engine"}}');
+    this.add('route:application', Route.extend({
       model() {
         hooks.push('application - application');
       }
@@ -115,7 +115,7 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
   setupAppAndRoutlessEngineWithPartial(hooks) {
     this.setupRoutelessEngine(hooks);
 
-    this.registerEngine('chat-engine', Engine.extend({
+    this.add('engine:chat-engine', Engine.extend({
       init() {
         this._super(...arguments);
         this.register('template:foo', compile('foo partial'));
@@ -135,9 +135,9 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
   }
 
   setupEngineWithAttrs(hooks) {
-    this.application.register('template:application', compile('Application{{mount "chat-engine"}}'));
+    this.addTemplate('application', 'Application{{mount "chat-engine"}}');
 
-    this.registerEngine('chat-engine', Engine.extend({
+    this.add('engine:chat-engine', Engine.extend({
       init() {
         this._super(...arguments);
         this.register('template:components/foo-bar', compile(`{{partial "troll"}}`));
@@ -172,8 +172,8 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
       {{outlet}}
     `);
 
-    this.application.register('template:application', sharedTemplate);
-    this.registerController('application', Controller.extend({
+    this.add('template:application', sharedTemplate);
+    this.add('controller:application', Controller.extend({
       contextType: 'Application',
       'ambiguous-curlies': 'Controller Data!'
     }));
@@ -181,9 +181,9 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
     this.router.map(function() {
       this.mount('blog');
     });
-    this.application.register('route-map:blog', function() { });
+    this.add('route-map:blog', function() { });
 
-    this.registerEngine('blog', Engine.extend({
+    this.add('engine:blog', Engine.extend({
       init() {
         this._super(...arguments);
 
@@ -213,20 +213,20 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
       layout: sharedLayout
     });
 
-    this.application.register('template:application', compile(strip`
+    this.addTemplate('application', strip`
       <h1>Application</h1>
       {{my-component ambiguous-curlies="Local Data!"}}
       {{outlet}}
-    `));
+    `);
 
-    this.application.register('component:my-component', sharedComponent);
+    this.add('component:my-component', sharedComponent);
 
     this.router.map(function() {
       this.mount('blog');
     });
-    this.application.register('route-map:blog', function() { });
+    this.add('route-map:blog', function() { });
 
-    this.registerEngine('blog', Engine.extend({
+    this.add('engine:blog', Engine.extend({
       init() {
         this._super(...arguments);
         this.register('template:application', compile(strip`
@@ -336,7 +336,7 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
 
     this.setupAppAndRoutableEngine();
 
-    this.registerEngine('blog', Engine.extend({
+    this.add('engine:blog', Engine.extend({
       init() {
         this._super(...arguments);
         this.register('template:application', compile('Engine{{outlet}}'));
@@ -366,7 +366,6 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
     assert.expect(2);
 
     this.setupAppAndRoutableEngine();
-    this.application.__registry__.resolver.moduleBasedResolver = true;
     this.additionalEngineRegistrations(function() {
       this.register('template:application_error', compile('Error! {{model.message}}'));
       this.register('route:post', Route.extend({
@@ -388,7 +387,6 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
     assert.expect(2);
 
     this.setupAppAndRoutableEngine();
-    this.application.__registry__.resolver.moduleBasedResolver = true;
     this.additionalEngineRegistrations(function() {
       this.register('template:error', compile('Error! {{model.message}}'));
       this.register('route:post', Route.extend({
@@ -410,7 +408,6 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
     assert.expect(2);
 
     this.setupAppAndRoutableEngine();
-    this.application.__registry__.resolver.moduleBasedResolver = true;
     this.additionalEngineRegistrations(function() {
       this.register('template:post_error', compile('Error! {{model.message}}'));
       this.register('route:post', Route.extend({
@@ -432,7 +429,6 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
     assert.expect(2);
 
     this.setupAppAndRoutableEngine();
-    this.application.__registry__.resolver.moduleBasedResolver = true;
     this.additionalEngineRegistrations(function() {
       this.register('template:post.error', compile('Error! {{model.message}}'));
       this.register('route:post.comments', Route.extend({
@@ -456,7 +452,6 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
     let resolveLoading;
 
     this.setupAppAndRoutableEngine();
-    this.application.__registry__.resolver.moduleBasedResolver = true;
     this.additionalEngineRegistrations(function() {
       this.register('template:application_loading', compile('Loading'));
       this.register('template:post', compile('Post'));
@@ -523,7 +518,6 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
     let resolveLoading;
 
     this.setupAppAndRoutableEngine();
-    this.application.__registry__.resolver.moduleBasedResolver = true;
     this.additionalEngineRegistrations(function() {
       this.register('template:post', compile('{{outlet}}'));
       this.register('template:post.comments', compile('Comments'));

--- a/packages/ember-glimmer/tests/integration/application/rendering-test.js
+++ b/packages/ember-glimmer/tests/integration/application/rendering-test.js
@@ -8,7 +8,7 @@ import { Component } from 'ember-glimmer';
 moduleFor('Application test: rendering', class extends ApplicationTest {
 
   ['@test it can render the application template'](assert) {
-    this.registerTemplate('application', 'Hello world!');
+    this.addTemplate('application', 'Hello world!');
 
     return this.visit('/').then(() => {
       this.assertText('Hello world!');
@@ -16,13 +16,13 @@ moduleFor('Application test: rendering', class extends ApplicationTest {
   }
 
   ['@test it can access the model provided by the route'](assert) {
-    this.registerRoute('application', Route.extend({
+    this.add('route:application', Route.extend({
       model() {
         return ['red', 'yellow', 'blue'];
       }
     }));
 
-    this.registerTemplate('application', strip`
+    this.addTemplate('application', strip`
       <ul>
         {{#each model as |item|}}
           <li>{{item}}</li>
@@ -53,13 +53,13 @@ moduleFor('Application test: rendering', class extends ApplicationTest {
     });
 
     // The "favorite" route will inherit the model
-    this.registerRoute('lists.colors', Route.extend({
+    this.add('route:lists.colors', Route.extend({
       model() {
         return ['red', 'yellow', 'blue'];
       }
     }));
 
-    this.registerTemplate('lists.colors.favorite', strip`
+    this.addTemplate('lists.colors.favorite', strip`
       <ul>
         {{#each model as |item|}}
           <li>{{item}}</li>
@@ -85,16 +85,16 @@ moduleFor('Application test: rendering', class extends ApplicationTest {
       this.route('colors');
     });
 
-    this.registerTemplate('application', strip`
+    this.addTemplate('application', strip`
       <nav>{{outlet "nav"}}</nav>
       <main>{{outlet}}</main>
     `);
 
-    this.registerTemplate('nav', strip`
+    this.addTemplate('nav', strip`
       <a href="http://emberjs.com/">Ember</a>
     `);
 
-    this.registerRoute('application', Route.extend({
+    this.add('route:application', Route.extend({
       renderTemplate() {
         this.render();
         this.render('nav', {
@@ -104,13 +104,13 @@ moduleFor('Application test: rendering', class extends ApplicationTest {
       }
     }));
 
-    this.registerRoute('colors', Route.extend({
+    this.add('route:colors', Route.extend({
       model() {
         return ['red', 'yellow', 'blue'];
       }
     }));
 
-    this.registerTemplate('colors', strip`
+    this.addTemplate('colors', strip`
       <ul>
         {{#each model as |item|}}
           <li>{{item}}</li>
@@ -141,16 +141,16 @@ moduleFor('Application test: rendering', class extends ApplicationTest {
       this.route('colors');
     });
 
-    this.registerTemplate('application', strip`
+    this.addTemplate('application', strip`
       <nav>{{outlet "nav"}}</nav>
       <main>{{outlet}}</main>
     `);
 
-    this.registerTemplate('nav', strip`
+    this.addTemplate('nav', strip`
       <a href="http://emberjs.com/">Ember</a>
     `);
 
-    this.registerRoute('application', Route.extend({
+    this.add('route:application', Route.extend({
       renderTemplate() {
         this.render();
         this.render('nav', {
@@ -160,13 +160,13 @@ moduleFor('Application test: rendering', class extends ApplicationTest {
       }
     }));
 
-    this.registerRoute('colors', Route.extend({
+    this.add('route:colors', Route.extend({
       model() {
         return ['red', 'yellow', 'blue'];
       }
     }));
 
-    this.registerTemplate('colors', strip`
+    this.addTemplate('colors', strip`
       <ul>
         {{#each model as |item|}}
           <li>{{item}}</li>
@@ -201,10 +201,10 @@ moduleFor('Application test: rendering', class extends ApplicationTest {
       });
     });
 
-    this.registerTemplate('a', 'A{{outlet}}');
-    this.registerTemplate('b', 'B{{outlet}}');
-    this.registerTemplate('b.c', 'C');
-    this.registerTemplate('b.d', 'D');
+    this.addTemplate('a', 'A{{outlet}}');
+    this.addTemplate('b', 'B{{outlet}}');
+    this.addTemplate('b.c', 'C');
+    this.addTemplate('b.d', 'D');
 
     return this.visit('/b/c').then(() => {
       // this.assertComponentElement(this.firstChild, { content: 'BC' });
@@ -225,13 +225,13 @@ moduleFor('Application test: rendering', class extends ApplicationTest {
       this.route('color', { path: '/colors/:color' });
     });
 
-    this.registerRoute('color', Route.extend({
+    this.add('route:color', Route.extend({
       model(params) {
         return params.color;
       }
     }));
 
-    this.registerTemplate('color', 'color: {{model}}');
+    this.addTemplate('color', 'color: {{model}}');
 
     return this.visit('/colors/red').then(() => {
       this.assertComponentElement(this.firstChild, { content: 'color: red' });
@@ -249,16 +249,16 @@ moduleFor('Application test: rendering', class extends ApplicationTest {
       this.route('b');
     });
 
-    this.registerController('a', Controller.extend({
+    this.add('controller:a', Controller.extend({
       value: 'a'
     }));
 
-    this.registerController('b', Controller.extend({
+    this.add('controller:b', Controller.extend({
       value: 'b'
     }));
 
-    this.registerTemplate('a', '{{value}}');
-    this.registerTemplate('b', '{{value}}');
+    this.addTemplate('a', '{{value}}');
+    this.addTemplate('b', '{{value}}');
 
     return this.visit('/a').then(() => {
       this.assertText('a');
@@ -271,7 +271,7 @@ moduleFor('Application test: rendering', class extends ApplicationTest {
       this.route('color', { path: '/colors/:color' });
     });
 
-    this.registerRoute('color', Route.extend({
+    this.add('route:color', Route.extend({
       model(params) {
         return { color: params.color };
       },
@@ -281,15 +281,15 @@ moduleFor('Application test: rendering', class extends ApplicationTest {
       }
     }));
 
-    this.registerController('red', Controller.extend({
+    this.add('controller:red', Controller.extend({
       color: 'red'
     }));
 
-    this.registerController('green', Controller.extend({
+    this.add('controller:green', Controller.extend({
       color: 'green'
     }));
 
-    this.registerTemplate('color', 'model color: {{model.color}}, controller color: {{color}}');
+    this.addTemplate('color', 'model color: {{model.color}}, controller color: {{color}}');
 
     return this.visit('/colors/red').then(() => {
       this.assertComponentElement(this.firstChild, { content: 'model color: red, controller color: red' });
@@ -307,7 +307,7 @@ moduleFor('Application test: rendering', class extends ApplicationTest {
       this.route('b');
     });
 
-    this.registerRoute('a', Route.extend({
+    this.add('route:a', Route.extend({
       model() {
         return 'A';
       },
@@ -317,7 +317,7 @@ moduleFor('Application test: rendering', class extends ApplicationTest {
       }
     }));
 
-    this.registerRoute('b', Route.extend({
+    this.add('route:b', Route.extend({
       model() {
         return 'B';
       },
@@ -327,11 +327,11 @@ moduleFor('Application test: rendering', class extends ApplicationTest {
       }
     }));
 
-    this.registerController('common', Controller.extend({
+    this.add('controller:common', Controller.extend({
       prefix: 'common'
     }));
 
-    this.registerTemplate('common', '{{prefix}} {{model}}');
+    this.addTemplate('common', '{{prefix}} {{model}}');
 
     return this.visit('/a').then(() => {
       this.assertComponentElement(this.firstChild, { content: 'common A' });
@@ -348,8 +348,8 @@ moduleFor('Application test: rendering', class extends ApplicationTest {
   // I wish there was a way to assert that the OutletComponentManager did not
   // receive a didCreateElement.
   ['@test a child outlet is always a fragment']() {
-    this.registerTemplate('application', '{{outlet}}');
-    this.registerTemplate('index', '{{#if true}}1{{/if}}<div>2</div>');
+    this.addTemplate('application', '{{outlet}}');
+    this.addTemplate('index', '{{#if true}}1{{/if}}<div>2</div>');
     return this.visit('/').then(() => {
       this.assertComponentElement(this.firstChild, { content: '1<div>2</div>' });
     });
@@ -360,13 +360,13 @@ moduleFor('Application test: rendering', class extends ApplicationTest {
       this.route('a');
     });
 
-    this.registerRoute('index', Route.extend({
+    this.add('route:index', Route.extend({
       activate() {
         this.transitionTo('a');
       }
     }));
 
-    this.registerTemplate('a', 'Hello from A!');
+    this.addTemplate('a', 'Hello from A!');
 
     return this.visit('/').then(() => {
       this.assertComponentElement(this.firstChild, {
@@ -380,15 +380,15 @@ moduleFor('Application test: rendering', class extends ApplicationTest {
       this.route('routeWithError');
     });
 
-    this.registerRoute('routeWithError', Route.extend({
+    this.add('route:routeWithError', Route.extend({
       model() {
         return { name: 'Alex' };
       }
     }));
 
-    this.registerTemplate('routeWithError', 'Hi {{model.name}} {{x-foo person=model}}');
+    this.addTemplate('routeWithError', 'Hi {{model.name}} {{x-foo person=model}}');
 
-    this.registerComponent('x-foo', {
+    this.addComponent('x-foo', {
       ComponentClass: Component.extend({
         init() {
           this._super(...arguments);

--- a/packages/ember-glimmer/tests/integration/components/link-to-test.js
+++ b/packages/ember-glimmer/tests/integration/components/link-to-test.js
@@ -17,7 +17,7 @@ moduleFor('Link-to component', class extends ApplicationTest {
 
   ['@test accessing `currentWhen` triggers a deprecation'](assert) {
     let component;
-    this.registerComponent('link-to', {
+    this.addComponent('link-to', {
       ComponentClass: LinkComponent.extend({
         init() {
           this._super(...arguments);
@@ -26,7 +26,7 @@ moduleFor('Link-to component', class extends ApplicationTest {
       })
     });
 
-    this.registerTemplate('application', `{{link-to 'Index' 'index'}}`);
+    this.addTemplate('application', `{{link-to 'Index' 'index'}}`);
 
     return this.visit('/').then(() => {
       expectDeprecation(() => {
@@ -36,7 +36,7 @@ moduleFor('Link-to component', class extends ApplicationTest {
   }
 
   ['@test should be able to be inserted in DOM when the router is not present']() {
-    this.registerTemplate('application', `{{#link-to 'index'}}Go to Index{{/link-to}}`);
+    this.addTemplate('application', `{{#link-to 'index'}}Go to Index{{/link-to}}`);
 
     return this.visit('/').then(() => {
       this.assertText('Go to Index');
@@ -46,8 +46,8 @@ moduleFor('Link-to component', class extends ApplicationTest {
   ['@test re-renders when title changes']() {
     let controller;
 
-    this.registerTemplate('application', '{{link-to title routeName}}');
-    this.registerController('application', Controller.extend({
+    this.addTemplate('application', '{{link-to title routeName}}');
+    this.add('controller:application', Controller.extend({
       init() {
         this._super(...arguments);
         controller = this;
@@ -64,8 +64,8 @@ moduleFor('Link-to component', class extends ApplicationTest {
   }
 
   ['@test escaped inline form (double curlies) escapes link title']() {
-    this.registerTemplate('application', `{{link-to title 'index'}}`);
-    this.registerController('application', Controller.extend({
+    this.addTemplate('application', `{{link-to title 'index'}}`);
+    this.add('controller:application', Controller.extend({
       title: '<b>blah</b>'
     }));
 
@@ -75,8 +75,8 @@ moduleFor('Link-to component', class extends ApplicationTest {
   }
 
   ['@test escaped inline form with (-html-safe) does not escape link title'](assert) {
-    this.registerTemplate('application', `{{link-to (-html-safe title) 'index'}}`);
-    this.registerController('application', Controller.extend({
+    this.addTemplate('application', `{{link-to (-html-safe title) 'index'}}`);
+    this.add('controller:application', Controller.extend({
       title: '<b>blah</b>'
     }));
 
@@ -87,8 +87,8 @@ moduleFor('Link-to component', class extends ApplicationTest {
   }
 
   ['@test unescaped inline form (triple curlies) does not escape link title'](assert) {
-    this.registerTemplate('application', `{{{link-to title 'index'}}}`);
-    this.registerController('application', Controller.extend({
+    this.addTemplate('application', `{{{link-to title 'index'}}}`);
+    this.add('controller:application', Controller.extend({
       title: '<b>blah</b>'
     }));
 
@@ -102,8 +102,8 @@ moduleFor('Link-to component', class extends ApplicationTest {
     this.router.map(function() {
       this.route('profile', { path: '/profile/:id' });
     });
-    this.registerTemplate('application', `{{#link-to 'profile' otherController}}Text{{/link-to}}`);
-    this.registerController('application', Controller.extend({
+    this.addTemplate('application', `{{#link-to 'profile' otherController}}Text{{/link-to}}`);
+    this.add('controller:application', Controller.extend({
       otherController: Controller.create({
         model: 'foo'
       })
@@ -117,9 +117,9 @@ moduleFor('Link-to component', class extends ApplicationTest {
   }
 
   ['@test able to safely extend the built-in component and use the normal path']() {
-    this.registerComponent('custom-link-to', { ComponentClass: LinkComponent.extend() });
-    this.registerTemplate('application', `{{#custom-link-to 'index'}}{{title}}{{/custom-link-to}}`);
-    this.registerController('application', Controller.extend({
+    this.addComponent('custom-link-to', { ComponentClass: LinkComponent.extend() });
+    this.addTemplate('application', `{{#custom-link-to 'index'}}{{title}}{{/custom-link-to}}`);
+    this.add('controller:application', Controller.extend({
       title: 'Hello'
     }));
 
@@ -129,9 +129,9 @@ moduleFor('Link-to component', class extends ApplicationTest {
   }
 
   ['@test [GH#13432] able to safely extend the built-in component and invoke it inline']() {
-    this.registerComponent('custom-link-to', { ComponentClass: LinkComponent.extend() });
-    this.registerTemplate('application', `{{custom-link-to title 'index'}}`);
-    this.registerController('application', Controller.extend({
+    this.addComponent('custom-link-to', { ComponentClass: LinkComponent.extend() });
+    this.addTemplate('application', `{{custom-link-to title 'index'}}`);
+    this.add('controller:application', Controller.extend({
       title: 'Hello'
     }));
 
@@ -145,7 +145,7 @@ moduleFor('Link-to component with query-params', class extends ApplicationTest {
   constructor() {
     super(...arguments);
 
-    this.registerController('index', Controller.extend({
+    this.add('controller:index', Controller.extend({
       queryParams: ['foo'],
       foo: '123',
       bar: 'yes'
@@ -153,7 +153,7 @@ moduleFor('Link-to component with query-params', class extends ApplicationTest {
   }
 
   ['@test populates href with fully supplied query param values'](assert) {
-    this.registerTemplate('index', `{{#link-to 'index' (query-params foo='456' bar='NAW')}}Index{{/link-to}}`);
+    this.addTemplate('index', `{{#link-to 'index' (query-params foo='456' bar='NAW')}}Index{{/link-to}}`);
 
     return this.visit('/').then(() => {
       this.assertComponentElement(this.firstChild.firstElementChild, {
@@ -165,7 +165,7 @@ moduleFor('Link-to component with query-params', class extends ApplicationTest {
   }
 
   ['@test populates href with partially supplied query param values, but omits if value is default value']() {
-    this.registerTemplate('index', `{{#link-to 'index' (query-params foo='123')}}Index{{/link-to}}`);
+    this.addTemplate('index', `{{#link-to 'index' (query-params foo='123')}}Index{{/link-to}}`);
 
     return this.visit('/').then(() => {
       this.assertComponentElement(this.firstChild.firstElementChild, {

--- a/packages/ember-glimmer/tests/integration/components/target-action-test.js
+++ b/packages/ember-glimmer/tests/integration/components/target-action-test.js
@@ -277,7 +277,7 @@ moduleFor('Components test: sendAction to a controller', class extends Applicati
       });
     });
 
-    this.registerComponent('foo-bar', {
+    this.addComponent('foo-bar', {
       ComponentClass: Component.extend({
         init() {
           this._super(...arguments);
@@ -287,15 +287,15 @@ moduleFor('Components test: sendAction to a controller', class extends Applicati
       template: `{{val}}`
     });
 
-    this.registerController('a', Controller.extend({
+    this.add('controller:a', Controller.extend({
       send(actionName, actionContext) {
         assert.equal(actionName, 'poke', 'send() method was invoked from a top level controller');
         assert.equal(actionContext, 'top', 'action arguments were passed into the top level controller');
       }
     }));
-    this.registerTemplate('a', '{{foo-bar val="a" poke="poke"}}');
+    this.addTemplate('a', '{{foo-bar val="a" poke="poke"}}');
 
-    this.registerRoute('b', Route.extend({
+    this.add('route:b', Route.extend({
       actions: {
         poke(actionContext) {
           assert.ok(true, 'Unhandled action sent to route');
@@ -303,9 +303,9 @@ moduleFor('Components test: sendAction to a controller', class extends Applicati
         }
       }
     }));
-    this.registerTemplate('b', '{{foo-bar val="b" poke="poke"}}');
+    this.addTemplate('b', '{{foo-bar val="b" poke="poke"}}');
 
-    this.registerRoute('c', Route.extend({
+    this.add('route:c', Route.extend({
       actions: {
         poke(actionContext) {
           assert.ok(true, 'Unhandled action sent to route');
@@ -313,19 +313,19 @@ moduleFor('Components test: sendAction to a controller', class extends Applicati
         }
       }
     }));
-    this.registerTemplate('c', '{{foo-bar val="c" poke="poke"}}{{outlet}}');
+    this.addTemplate('c', '{{foo-bar val="c" poke="poke"}}{{outlet}}');
 
-    this.registerRoute('c.d', Route.extend({}));
+    this.add('route:c.d', Route.extend({}));
 
-    this.registerController('c.d', Controller.extend({
+    this.add('controller:c.d', Controller.extend({
       send(actionName, actionContext) {
         assert.equal(actionName, 'poke', 'send() method was invoked from a nested controller');
         assert.equal(actionContext, 'nested', 'action arguments were passed into the nested controller');
       }
     }));
-    this.registerTemplate('c.d', '{{foo-bar val=".d" poke="poke"}}');
+    this.addTemplate('c.d', '{{foo-bar val=".d" poke="poke"}}');
 
-    this.registerRoute('c.e', Route.extend({
+    this.add('route:c.e', Route.extend({
       actions: {
         poke(actionContext) {
           assert.ok(true, 'Unhandled action sent to route');
@@ -333,7 +333,7 @@ moduleFor('Components test: sendAction to a controller', class extends Applicati
         }
       }
     }));
-    this.registerTemplate('c.e', '{{foo-bar val=".e" poke="poke"}}');
+    this.addTemplate('c.e', '{{foo-bar val=".e" poke="poke"}}');
 
     return this.visit('/a')
       .then(() => component.sendAction('poke', 'top'))
@@ -365,7 +365,7 @@ moduleFor('Components test: sendAction to a controller', class extends Applicati
 
     let component;
 
-    this.registerComponent('x-parent', {
+    this.addComponent('x-parent', {
       ComponentClass: Component.extend({
         actions: {
           poke() {
@@ -376,7 +376,7 @@ moduleFor('Components test: sendAction to a controller', class extends Applicati
       template: '{{x-child poke="poke"}}'
     });
 
-    this.registerComponent('x-child', {
+    this.addComponent('x-child', {
       ComponentClass: Component.extend({
         init() {
           this._super(...arguments);
@@ -385,8 +385,8 @@ moduleFor('Components test: sendAction to a controller', class extends Applicati
       })
     });
 
-    this.registerTemplate('application', '{{x-parent}}');
-    this.registerController('application', Controller.extend({
+    this.addTemplate('application', '{{x-parent}}');
+    this.add('controller:application', Controller.extend({
       send(actionName) {
         throw new Error('controller action should not be called');
       }

--- a/packages/ember-glimmer/tests/integration/components/utils-test.js
+++ b/packages/ember-glimmer/tests/integration/components/utils-test.js
@@ -19,7 +19,7 @@ moduleFor('View tree tests', class extends ApplicationTest {
   constructor() {
     super();
 
-    this.registerComponent('x-tagless', {
+    this.addComponent('x-tagless', {
       ComponentClass: Component.extend({
         tagName: ''
       }),
@@ -27,7 +27,7 @@ moduleFor('View tree tests', class extends ApplicationTest {
       template: '<div id="{{id}}">[{{id}}] {{#if isShowing}}{{yield}}{{/if}}</div>'
     });
 
-    this.registerComponent('x-toggle', {
+    this.addComponent('x-toggle', {
       ComponentClass: Component.extend({
         isExpanded: true,
 
@@ -50,9 +50,9 @@ moduleFor('View tree tests', class extends ApplicationTest {
       }
     });
 
-    this.registerController('application', ToggleController);
+    this.add('controller:application', ToggleController);
 
-    this.registerTemplate('application', `
+    this.addTemplate('application', `
       {{x-tagless id="root-1"}}
 
       {{#x-toggle id="root-2"}}
@@ -72,11 +72,11 @@ moduleFor('View tree tests', class extends ApplicationTest {
       {{outlet}}
     `);
 
-    this.registerController('index', ToggleController.extend({
+    this.add('controller:index', ToggleController.extend({
       isExpanded: false
     }));
 
-    this.registerTemplate('index', `
+    this.addTemplate('index', `
       {{x-tagless id="root-4"}}
 
       {{#x-toggle id="root-5" isExpanded=false}}
@@ -94,7 +94,7 @@ moduleFor('View tree tests', class extends ApplicationTest {
       {{/if}}
     `);
 
-    this.registerTemplate('zomg', `
+    this.addTemplate('zomg', `
       {{x-tagless id="root-7"}}
 
       {{#x-toggle id="root-8"}}
@@ -110,7 +110,7 @@ moduleFor('View tree tests', class extends ApplicationTest {
       {{/x-toggle}}
     `);
 
-    this.registerTemplate('zomg.lol', `
+    this.addTemplate('zomg.lol', `
       {{x-toggle id="inner-10"}}
     `);
 

--- a/packages/ember-glimmer/tests/integration/mount-test.js
+++ b/packages/ember-glimmer/tests/integration/mount-test.js
@@ -36,7 +36,7 @@ moduleFor('{{mount}} test', class extends ApplicationTest {
 
     let engineRegistrations = this.engineRegistrations = {};
 
-    this.registerEngine('chat', Engine.extend({
+    this.add('engine:chat', Engine.extend({
       router: null,
 
       init() {
@@ -48,7 +48,7 @@ moduleFor('{{mount}} test', class extends ApplicationTest {
       }
     }));
 
-    this.registerTemplate('index', '{{mount "chat"}}');
+    this.addTemplate('index', '{{mount "chat"}}');
   }
 
   ['@test it boots an engine, instantiates its application controller, and renders its application template'](assert) {
@@ -88,8 +88,8 @@ moduleFor('{{mount}} test', class extends ApplicationTest {
       this.route('route-with-mount');
     });
 
-    this.registerTemplate('index', '');
-    this.registerTemplate('route-with-mount', '{{mount "chat"}}');
+    this.addTemplate('index', '');
+    this.addTemplate('route-with-mount', '{{mount "chat"}}');
 
     this.engineRegistrations['template:application'] = compile('hi {{person.name}} [{{component-with-backtracking-set person=person}}]', { moduleName: 'application' });
     this.engineRegistrations['controller:application'] = Controller.extend({
@@ -123,23 +123,23 @@ moduleFor('{{mount}} test', class extends ApplicationTest {
       this.route('bound-engine-name');
     });
     let controller;
-    this.registerController('bound-engine-name', Controller.extend({
+    this.add('controller:bound-engine-name', Controller.extend({
       engineName: null,
       init() {
         this._super();
         controller = this;
       }
     }));
-    this.registerTemplate('bound-engine-name', '{{mount engineName}}');
+    this.addTemplate('bound-engine-name', '{{mount engineName}}');
 
-    this.registerEngine('foo', Engine.extend({
+    this.add('engine:foo', Engine.extend({
       router: null,
       init() {
         this._super(...arguments);
         this.register('template:application', compile('<h2>Foo Engine</h2>', { moduleName: 'application' }));
       }
     }));
-    this.registerEngine('bar', Engine.extend({
+    this.add('engine:bar', Engine.extend({
       router: null,
       init() {
         this._super(...arguments);

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -25,7 +25,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
     let appModelCount = 0;
     let promiseResolve;
 
-    this.registerRoute('application', Route.extend({
+    this.add('route:application', Route.extend({
       queryParams: {
         appomg: {
           defaultValue: 'applol'
@@ -42,7 +42,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
 
     let actionName = typeof loadingReturn !== 'undefined' ? 'loading' : 'ignore';
     let indexModelCount = 0;
-    this.registerRoute('index', Route.extend({
+    this.add('route:index', Route.extend({
       queryParams: {
         omg: {
           refreshModel: true
@@ -107,7 +107,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
       });
     });
 
-    this.registerRoute('parent.child', Route.extend({
+    this.add('route:parent.child', Route.extend({
       afterModel() {
         this.transitionTo('parent.sibling');
       }
@@ -144,7 +144,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
   ['@test Query params can map to different url keys configured on the controller'](assert) {
     assert.expect(6);
 
-    this.registerController('index', Controller.extend({
+    this.add('controller:index', Controller.extend({
       queryParams: [{ foo: 'other_foo', bar: { as: 'other_bar' } }],
       foo: 'FOO',
       bar: 'BAR'
@@ -173,7 +173,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
   ['@test Routes have a private overridable serializeQueryParamKey hook'](assert) {
     assert.expect(2);
 
-    this.registerRoute('index', Route.extend({
+    this.add('route:index', Route.extend({
       serializeQueryParamKey: StringUtils.dasherize
     }));
 
@@ -232,7 +232,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
 
     this.setSingleQPController('index');
 
-    this.registerRoute('index', Route.extend({
+    this.add('route:index', Route.extend({
       model(params) {
         assert.deepEqual(params, { foo: 'bar' });
       }
@@ -250,7 +250,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
 
     this.setSingleQPController('index');
 
-    this.registerRoute('index', Route.extend({
+    this.add('route:index', Route.extend({
       model(params) {
         assert.deepEqual(params, { foo: 'bar', id: 'baz' });
       }
@@ -268,7 +268,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
 
     this.setSingleQPController('index');
 
-    this.registerRoute('index', Route.extend({
+    this.add('route:index', Route.extend({
       model(params) {
         assert.deepEqual(params, { foo: 'baz', id: 'boo' });
       }
@@ -302,15 +302,15 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
       this.route('about');
     });
 
-    this.registerTemplate('home', `<h3>{{link-to 'About' 'about' (query-params lol='wat') id='link-to-about'}}</h3>`);
-    this.registerTemplate('about', `<h3>{{link-to 'Home' 'home'  (query-params foo='naw')}}</h3>`);
-    this.registerTemplate('cats.index', `<h3>{{link-to 'Cats' 'cats'  (query-params name='domino') id='cats-link'}}</h3>`);
+    this.addTemplate('home', `<h3>{{link-to 'About' 'about' (query-params lol='wat') id='link-to-about'}}</h3>`);
+    this.addTemplate('about', `<h3>{{link-to 'Home' 'home'  (query-params foo='naw')}}</h3>`);
+    this.addTemplate('cats.index', `<h3>{{link-to 'Cats' 'cats'  (query-params name='domino') id='cats-link'}}</h3>`);
 
     let homeShouldBeCreated = false;
     let aboutShouldBeCreated = false;
     let catsIndexShouldBeCreated = false;
 
-    this.registerRoute('home', Route.extend({
+    this.add('route:home', Route.extend({
       setup() {
         homeShouldBeCreated = true;
         this._super(...arguments);
@@ -324,7 +324,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
       }
     });
 
-    this.registerRoute('about', Route.extend({
+    this.add('route:about', Route.extend({
       setup() {
         aboutShouldBeCreated = true;
         this._super(...arguments);
@@ -338,7 +338,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
       }
     });
 
-    this.registerRoute('cats.index', Route.extend({
+    this.add('route:cats.index', Route.extend({
       model() {
         return [];
       },
@@ -351,7 +351,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
       }
     }));
 
-    this.registerController('cats.index', Controller.extend({
+    this.add('controller:cats.index', Controller.extend({
       queryParams: ['breed', 'name'],
       breed: 'Golden',
       name: null,
@@ -385,7 +385,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
 
     this.setSingleQPController('application');
 
-    this.registerRoute('application', Route.extend({
+    this.add('route:application', Route.extend({
       setupController(controller) {
         assert.equal(controller.get('foo'), 'YEAH', 'controller\'s foo QP property set before setupController called');
       }
@@ -399,7 +399,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
 
     this.setSingleQPController('application', { faz: 'foo' });
 
-    this.registerRoute('application', Route.extend({
+    this.add('route:application', Route.extend({
       setupController(controller) {
         assert.equal(controller.get('faz'), 'YEAH', 'controller\'s foo QP property set before setupController called');
       }
@@ -417,7 +417,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
 
     this.setSingleQPController('index');
 
-    this.registerRoute('index', Route.extend({
+    this.add('route:index', Route.extend({
       model(params, transition) {
         assert.deepEqual(this.paramsFor('index'), { something: 'baz', foo: 'bar' }, 'could retrieve params for index');
       }
@@ -435,7 +435,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
 
     this.setSingleQPController('index');
 
-    this.registerRoute('index', Route.extend({
+    this.add('route:index', Route.extend({
       model(params, transition) {
         assert.deepEqual(this.paramsFor('index'), { something: 'baz', foo: 'boo' }, 'could retrieve params for index');
       }
@@ -453,7 +453,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
 
     this.setSingleQPController('index', 'foo', false);
 
-    this.registerRoute('index', Route.extend({
+    this.add('route:index', Route.extend({
       model(params, transition) {
         assert.deepEqual(this.paramsFor('index'), { something: 'baz', foo: false }, 'could retrieve params for index');
       }
@@ -471,7 +471,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
 
     this.setSingleQPController('index', 'foo', true);
 
-    this.registerRoute('index', Route.extend({
+    this.add('route:index', Route.extend({
       model(params, transition) {
         assert.deepEqual(this.paramsFor('index'), { something: 'baz', foo: false }, 'could retrieve params for index');
       }
@@ -486,13 +486,13 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
     this.setSingleQPController('application', 'appomg', 'applol');
     this.setSingleQPController('index', 'omg', 'lol');
 
-    this.registerRoute('application', Route.extend({
+    this.add('route:application', Route.extend({
       model(params) {
         assert.deepEqual(params, { appomg: 'applol' });
       }
     }));
 
-    this.registerRoute('index', Route.extend({
+    this.add('route:index', Route.extend({
       model(params) {
         assert.deepEqual(params, { omg: 'lol' });
         assert.deepEqual(this.paramsFor('application'), { appomg: 'applol' });
@@ -508,13 +508,13 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
     this.setSingleQPController('application', 'appomg', 'applol');
     this.setSingleQPController('index', 'omg', 'lol');
 
-    this.registerRoute('application', Route.extend({
+    this.add('route:application', Route.extend({
       model(params) {
         assert.deepEqual(params, { appomg: 'appyes' });
       }
     }));
 
-    this.registerRoute('index', Route.extend({
+    this.add('route:index', Route.extend({
       model(params) {
         assert.deepEqual(params, { omg: 'yes' });
         assert.deepEqual(this.paramsFor('application'), { appomg: 'appyes' });
@@ -531,14 +531,14 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
     this.setSingleQPController('index', 'omg', 'lol');
 
     let appModelCount = 0;
-    this.registerRoute('application', Route.extend({
+    this.add('route:application', Route.extend({
       model(params) {
         appModelCount++;
       }
     }));
 
     let indexModelCount = 0;
-    this.registerRoute('index', Route.extend({
+    this.add('route:index', Route.extend({
       queryParams: {
         omg: {
           refreshModel: true
@@ -574,7 +574,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
     this.setSingleQPController('index', 'steely', 'lel');
 
     let refreshCount = 0;
-    this.registerRoute('index', Route.extend({
+    this.add('route:index', Route.extend({
       queryParams: {
         alex: {
           refreshModel: true
@@ -601,7 +601,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
     this.setSingleQPController('application', 'appomg', 'applol');
     this.setSingleQPController('index', 'omg', 'lol');
 
-    this.registerRoute('index', Route.extend({
+    this.add('route:index', Route.extend({
       queryParams: {
         omg: {
           refreshModel: true
@@ -616,7 +616,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
   }
 
   ['@test queryParams are updated when a controller property is set and the route is refreshed. Issue #13263  '](assert) {
-    this.registerTemplate('application', '<button id="test-button" {{action \'increment\'}}>Increment</button><span id="test-value">{{foo}}</span>{{outlet}}');
+    this.addTemplate('application', '<button id="test-button" {{action \'increment\'}}>Increment</button><span id="test-value">{{foo}}</span>{{outlet}}');
 
     this.setSingleQPController('application', 'foo', 1, {
       actions: {
@@ -627,7 +627,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
       }
     });
 
-    this.registerRoute('application', Route.extend({
+    this.add('route:application', Route.extend({
       actions: {
         refreshRoute() {
           this.refresh();
@@ -655,14 +655,14 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
     this.setSingleQPController('index', 'omg', 'lol');
 
     let appModelCount = 0;
-    this.registerRoute('application', Route.extend({
+    this.add('route:application', Route.extend({
       model(params) {
         appModelCount++;
       }
     }));
 
     let indexModelCount = 0;
-    this.registerRoute('index', Route.extend({
+    this.add('route:index', Route.extend({
       queryParams: EmberObject.create({
         unknownProperty(keyName) {
           return { refreshModel: true };
@@ -697,7 +697,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
     this.setSingleQPController('index', 'omg', 'lol');
 
     let indexModelCount = 0;
-    this.registerRoute('index', Route.extend({
+    this.add('route:index', Route.extend({
       queryParams: {
         omg: {
           refreshModel: true
@@ -730,7 +730,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
 
     this.setSingleQPController('application', 'alex', 'matchneer');
 
-    this.registerRoute('application', Route.extend({
+    this.add('route:application', Route.extend({
       queryParams: {
         alex: {
           replace: true
@@ -748,11 +748,11 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
   ['@test Route query params config can be configured using property name instead of URL key'](assert) {
     assert.expect(2);
 
-    this.registerController('application', Controller.extend({
+    this.add('controller:application', Controller.extend({
       queryParams: [{ commitBy: 'commit_by' }]
     }));
 
-    this.registerRoute('application', Route.extend({
+    this.add('route:application', Route.extend({
       queryParams: {
         commitBy: {
           replace: true
@@ -770,13 +770,13 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
   ['@test An explicit replace:false on a changed QP always wins and causes a pushState'](assert) {
     assert.expect(3);
 
-    this.registerController('application', Controller.extend({
+    this.add('controller:application', Controller.extend({
       queryParams: ['alex', 'steely'],
       alex: 'matchneer',
       steely: 'dan'
     }));
 
-    this.registerRoute('application', Route.extend({
+    this.add('route:application', Route.extend({
       queryParams: {
         alex: {
           replace: true
@@ -801,8 +801,8 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
   }
 
   ['@test can opt into full transition by setting refreshModel in route queryParams when transitioning from child to parent'](assert) {
-    this.registerTemplate('parent', '{{outlet}}');
-    this.registerTemplate('parent.child', '{{link-to \'Parent\' \'parent\' (query-params foo=\'change\') id=\'parent-link\'}}');
+    this.addTemplate('parent', '{{outlet}}');
+    this.addTemplate('parent.child', '{{link-to \'Parent\' \'parent\' (query-params foo=\'change\') id=\'parent-link\'}}');
 
     this.router.map(function() {
       this.route('parent', function() {
@@ -811,7 +811,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
     });
 
     let parentModelCount = 0;
-    this.registerRoute('parent', Route.extend({
+    this.add('route:parent', Route.extend({
       model() {
         parentModelCount++;
       },
@@ -837,7 +837,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
 
     this.setSingleQPController('application', 'alex', 'matchneer');
 
-    this.registerRoute('application', Route.extend({
+    this.add('route:application', Route.extend({
       queryParams: EmberObject.create({
         unknownProperty(keyName) {
           // We are simulating all qps requiring refresh
@@ -862,7 +862,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
 
     this.setSingleQPController('index', 'omg', 'lol');
 
-    this.registerRoute('index', Route.extend({
+    this.add('route:index', Route.extend({
       setupController(controller) {
         assert.ok(true, 'setupController called');
         controller.set('omg', 'OVERRIDE');
@@ -889,7 +889,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
 
     this.setSingleQPController('index', 'omg', ['lol']);
 
-    this.registerRoute('index', Route.extend({
+    this.add('route:index', Route.extend({
       setupController(controller) {
         assert.ok(true, 'setupController called');
         controller.set('omg', ['OVERRIDE']);
@@ -930,7 +930,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
       });
     });
 
-    this.registerTemplate('application', '{{link-to \'A\' \'abc.def\' (query-params foo=\'123\') id=\'one\'}}{{link-to \'B\' \'abc.def.zoo\' (query-params foo=\'123\' bar=\'456\') id=\'two\'}}{{outlet}}');
+    this.addTemplate('application', '{{link-to \'A\' \'abc.def\' (query-params foo=\'123\') id=\'one\'}}{{link-to \'B\' \'abc.def.zoo\' (query-params foo=\'123\' bar=\'456\') id=\'two\'}}{{outlet}}');
 
     this.setSingleQPController('abc.def', 'foo', 'lol');
     this.setSingleQPController('abc.def.zoo', 'bar', 'haha');
@@ -966,7 +966,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
   }
 
   ['@test transitionTo supports query params (multiple)'](assert) {
-    this.registerController('index', Controller.extend({
+    this.add('controller:index', Controller.extend({
       queryParams: ['foo', 'bar'],
       foo: 'lol',
       bar: 'wat'
@@ -1003,7 +1003,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
   ['@test setting QP to empty string doesn\'t generate null in URL'](assert) {
     assert.expect(1);
 
-    this.registerRoute('index', Route.extend({
+    this.add('route:index', Route.extend({
       queryParams: {
         foo: {
           defaultValue: '123'
@@ -1024,7 +1024,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
 
     this.setSingleQPController('index', 'foo', false);
 
-    this.registerRoute('index', Route.extend({
+    this.add('route:index', Route.extend({
       model(params) {
         assert.equal(params.foo, true, 'model hook received foo as boolean true');
       }
@@ -1042,7 +1042,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
   ['@test Query param without value are empty string'](assert) {
     assert.expect(1);
 
-    this.registerController('index', Controller.extend({
+    this.add('controller:index', Controller.extend({
       queryParams: ['foo'],
       foo: ''
     }));
@@ -1153,7 +1153,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
     });
 
     let modelCount = 0;
-    this.registerRoute('home', Route.extend({
+    this.add('route:home', Route.extend({
       model() {
         modelCount++;
       }
@@ -1185,7 +1185,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
     // unless we return a copy of the params hash.
     this.setSingleQPController('application', 'woot', 'wat');
 
-    this.registerRoute('other', Route.extend({
+    this.add('route:other', Route.extend({
       model(p, trans) {
         let m = meta(trans.params.application);
         assert.ok(!m.peekWatching('woot'), 'A meta object isn\'t constructed for this params POJO');
@@ -1204,13 +1204,13 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
       woot: undefined
     });
 
-    this.registerRoute('application', Route.extend({
+    this.add('route:application', Route.extend({
       model(p, trans) {
         return { woot: true };
       }
     }));
 
-    this.registerRoute('index', Route.extend({
+    this.add('route:index', Route.extend({
       setupController(controller, model) {
         assert.deepEqual(model, { woot: true }, 'index route inherited model route from parent route');
       }
@@ -1222,7 +1222,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
   ['@test opting into replace does not affect transitions between routes'](assert) {
     assert.expect(5);
 
-    this.registerTemplate('application', '{{link-to \'Foo\' \'foo\' id=\'foo-link\'}}{{link-to \'Bar\' \'bar\' id=\'bar-no-qp-link\'}}{{link-to \'Bar\' \'bar\' (query-params raytiley=\'isthebest\') id=\'bar-link\'}}{{outlet}}');
+    this.addTemplate('application', '{{link-to \'Foo\' \'foo\' id=\'foo-link\'}}{{link-to \'Bar\' \'bar\' id=\'bar-no-qp-link\'}}{{link-to \'Bar\' \'bar\' (query-params raytiley=\'isthebest\') id=\'bar-link\'}}{{outlet}}');
 
     this.router.map(function() {
       this.route('foo');
@@ -1231,7 +1231,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
 
     this.setSingleQPController('bar', 'raytiley', 'israd');
 
-    this.registerRoute('bar', Route.extend({
+    this.add('route:bar', Route.extend({
       queryParams: {
         raytiley: {
           replace: true
@@ -1266,13 +1266,13 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
       this.route('example');
     });
 
-    this.registerTemplate('application', '{{link-to \'Example\' \'example\' (query-params foo=undefined) id=\'the-link\'}}');
+    this.addTemplate('application', '{{link-to \'Example\' \'example\' (query-params foo=undefined) id=\'the-link\'}}');
 
     this.setSingleQPController('example', 'foo', undefined, {
       foo: undefined
     });
 
-    this.registerRoute('example', Route.extend({
+    this.add('route:example', Route.extend({
       model(params) {
         assert.deepEqual(params, { foo: undefined });
       }
@@ -1302,7 +1302,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
   ['@test warn user that Route\'s queryParams configuration must be an Object, not an Array'](assert) {
     assert.expect(1);
 
-    this.registerRoute('application', Route.extend({
+    this.add('route:application', Route.extend({
       queryParams: [
         { commitBy: { replace: true } }
       ]
@@ -1320,7 +1320,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
       this.route('constructor');
     });
 
-    this.registerRoute('constructor', Route.extend({
+    this.add('route:constructor', Route.extend({
       queryParams: {
         foo: {
           defaultValue: '123'

--- a/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
@@ -94,7 +94,7 @@ class ModelDependentQPTestCase extends QueryParamTestCase {
 
     assert.expect(32);
 
-    this.registerTemplate('application', `{{#each articles as |a|}} {{link-to 'Article' '${articleLookup}' a.id id=a.id}} {{/each}}`);
+    this.addTemplate('application', `{{#each articles as |a|}} {{link-to 'Article' '${articleLookup}' a.id id=a.id}} {{/each}}`);
 
     return this.boot().then(() => {
       this.expectedModelHookParams = { id: 'a-1', q: 'wat', z: 0 };
@@ -233,7 +233,7 @@ class ModelDependentQPTestCase extends QueryParamTestCase {
       }
     });
 
-    this.registerTemplate('about', `{{link-to 'A' '${commentsLookup}' 'a-1' id='one'}} {{link-to 'B' '${commentsLookup}' 'a-2' id='two'}}`);
+    this.addTemplate('about', `{{link-to 'A' '${commentsLookup}' 'a-1' id='one'}} {{link-to 'B' '${commentsLookup}' 'a-2' id='two'}}`);
 
     return this.visitApplication().then(() => {
       this.transitionTo(commentsLookup, 'a-1');
@@ -272,13 +272,13 @@ moduleFor('Query Params - model-dependent state', class extends ModelDependentQP
 
     let articles = emberA([{ id: 'a-1' }, { id: 'a-2' }, { id: 'a-3' }]);
 
-    this.registerController('application', Controller.extend({
+    this.add('controller:application', Controller.extend({
       articles
     }));
 
     let self = this;
     let assert = this.assert;
-    this.registerRoute('article', Route.extend({
+    this.add('route:article', Route.extend({
       model(params) {
         if (self.expectedModelHookParams) {
           assert.deepEqual(params, self.expectedModelHookParams, 'the ArticleRoute model hook received the expected merged dynamic segment + query params hash');
@@ -288,18 +288,18 @@ moduleFor('Query Params - model-dependent state', class extends ModelDependentQP
       }
     }));
 
-    this.registerController('article', Controller.extend({
+    this.add('controller:article', Controller.extend({
       queryParams: ['q', 'z'],
       q: 'wat',
       z: 0
     }));
 
-    this.registerController('comments', Controller.extend({
+    this.add('controller:comments', Controller.extend({
       queryParams: 'page',
       page: 1
     }));
 
-    this.registerTemplate('application', '{{#each articles as |a|}} 1{{link-to \'Article\' \'article\' a id=a.id}} {{/each}} {{outlet}}');
+    this.addTemplate('application', '{{#each articles as |a|}} 1{{link-to \'Article\' \'article\' a id=a.id}} {{/each}} {{outlet}}');
   }
 
   visitApplication() {
@@ -356,13 +356,13 @@ moduleFor('Query Params - model-dependent state (nested)', class extends ModelDe
 
     let site_articles = emberA([{ id: 'a-1' }, { id: 'a-2' }, { id: 'a-3' }]);
 
-    this.registerController('application', Controller.extend({
+    this.add('controller:application', Controller.extend({
       articles: site_articles
     }));
 
     let self = this;
     let assert = this.assert;
-    this.registerRoute('site.article', Route.extend({
+    this.add('route:site.article', Route.extend({
       model(params) {
         if (self.expectedModelHookParams) {
           assert.deepEqual(params, self.expectedModelHookParams, 'the ArticleRoute model hook received the expected merged dynamic segment + query params hash');
@@ -372,18 +372,18 @@ moduleFor('Query Params - model-dependent state (nested)', class extends ModelDe
       }
     }));
 
-    this.registerController('site.article', Controller.extend({
+    this.add('controller:site.article', Controller.extend({
       queryParams: ['q', 'z'],
       q: 'wat',
       z: 0
     }));
 
-    this.registerController('site.article.comments', Controller.extend({
+    this.add('controller:site.article.comments', Controller.extend({
       queryParams: 'page',
       page: 1
     }));
 
-    this.registerTemplate('application', '{{#each articles as |a|}} {{link-to \'Article\' \'site.article\' a id=a.id}} {{/each}} {{outlet}}');
+    this.addTemplate('application', '{{#each articles as |a|}} {{link-to \'Article\' \'site.article\' a id=a.id}} {{/each}} {{outlet}}');
   }
 
   visitApplication() {
@@ -440,7 +440,7 @@ moduleFor('Query Params - model-dependent state (nested & more than 1 dynamic se
     let sites = emberA([{ id: 's-1' }, { id: 's-2' }, { id: 's-3' }]);
     let site_articles = emberA([{ id: 'a-1' }, { id: 'a-2' }, { id: 'a-3' }]);
 
-    this.registerController('application', Controller.extend({
+    this.add('controller:application', Controller.extend({
       siteArticles: site_articles,
       sites,
       allSitesAllArticles: computed({
@@ -460,7 +460,7 @@ moduleFor('Query Params - model-dependent state (nested & more than 1 dynamic se
 
     let self = this;
     let assert = this.assert;
-    this.registerRoute('site', Route.extend({
+    this.add('route:site', Route.extend({
       model(params) {
         if (self.expectedSiteModelHookParams) {
           assert.deepEqual(params, self.expectedSiteModelHookParams, 'the SiteRoute model hook received the expected merged dynamic segment + query params hash');
@@ -470,7 +470,7 @@ moduleFor('Query Params - model-dependent state (nested & more than 1 dynamic se
       }
     }));
 
-    this.registerRoute('site.article', Route.extend({
+    this.add('route:site.article', Route.extend({
       model(params) {
         if (self.expectedArticleModelHookParams) {
           assert.deepEqual(params, self.expectedArticleModelHookParams, 'the SiteArticleRoute model hook received the expected merged dynamic segment + query params hash');
@@ -480,23 +480,23 @@ moduleFor('Query Params - model-dependent state (nested & more than 1 dynamic se
       }
     }));
 
-    this.registerController('site', Controller.extend({
+    this.add('controller:site', Controller.extend({
       queryParams: ['country'],
       country: 'au'
     }));
 
-    this.registerController('site.article', Controller.extend({
+    this.add('controller:site.article', Controller.extend({
       queryParams: ['q', 'z'],
       q: 'wat',
       z: 0
     }));
 
-    this.registerController('site.article.comments', Controller.extend({
+    this.add('controller:site.article.comments', Controller.extend({
       queryParams: ['page'],
       page: 1
     }));
 
-    this.registerTemplate('application', '{{#each allSitesAllArticles as |a|}} {{#link-to \'site.article\' a.site_id a.article_id id=a.id}}Article [{{a.site_id}}] [{{a.article_id}}]{{/link-to}} {{/each}} {{outlet}}');
+    this.addTemplate('application', '{{#each allSitesAllArticles as |a|}} {{#link-to \'site.article\' a.site_id a.article_id id=a.id}}Article [{{a.site_id}}] [{{a.article_id}}]{{/link-to}} {{/each}} {{outlet}}');
   }
 
   visitApplication() {

--- a/packages/ember/tests/routing/query_params_test/overlapping_query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test/overlapping_query_params_test.js
@@ -113,8 +113,8 @@ moduleFor('Query Params - overlapping query param property names', class extends
     let parentController = Controller.extend({
       queryParams: { page: 'page' }
     });
-    this.registerController('parent', parentController);
-    this.registerRoute('parent.child', Route.extend({controllerName: 'parent'}));
+    this.add('controller:parent', parentController);
+    this.add('route:parent.child', Route.extend({controllerName: 'parent'}));
 
     return this.setupBase('/parent').then(() => {
       this.transitionTo('parent.child', { queryParams: { page: 2 } });
@@ -140,11 +140,11 @@ moduleFor('Query Params - overlapping query param property names', class extends
       page: 1
     });
 
-    this.registerController('parent', Controller.extend(HasPage, {
+    this.add('controller:parent', Controller.extend(HasPage, {
       queryParams: { page: 'yespage' }
     }));
 
-    this.registerController('parent.child', Controller.extend(HasPage));
+    this.add('controller:parent.child', Controller.extend(HasPage));
 
     return this.setupBase().then(() => {
       this.assertCurrentPath('/parent/child');

--- a/packages/ember/tests/routing/query_params_test/query_param_async_get_handler_test.js
+++ b/packages/ember/tests/routing/query_params_test/query_param_async_get_handler_test.js
@@ -59,7 +59,7 @@ moduleFor('Query Params - async get handler', class extends QueryParamTestCase {
     this.setSingleQPController('post');
 
     let setupAppTemplate = () => {
-      this.registerTemplate('application', `
+      this.addTemplate('application', `
         {{link-to 'Post' 'post' 1337 (query-params foo='bar') class='post-link'}}
         {{link-to 'Post' 'post' 7331 (query-params foo='boo') class='post-link'}}
         {{outlet}}
@@ -202,13 +202,13 @@ moduleFor('Query Params - async get handler', class extends QueryParamTestCase {
       this.route('example');
     });
 
-    this.registerTemplate('application', '{{link-to \'Example\' \'example\' (query-params foo=undefined) id=\'the-link\'}}');
+    this.addTemplate('application', '{{link-to \'Example\' \'example\' (query-params foo=undefined) id=\'the-link\'}}');
 
     this.setSingleQPController('example', 'foo', undefined, {
       foo: undefined
     });
 
-    this.registerRoute('example', Route.extend({
+    this.add('route:example', Route.extend({
       model(params) {
         assert.deepEqual(params, { foo: undefined });
       }

--- a/packages/ember/tests/routing/query_params_test/query_params_paramless_link_to_test.js
+++ b/packages/ember/tests/routing/query_params_test/query_params_paramless_link_to_test.js
@@ -6,9 +6,9 @@ moduleFor('Query Params - paramless link-to', class extends QueryParamTestCase {
   testParamlessLinks(assert, routeName) {
     assert.expect(1);
 
-    this.registerTemplate(routeName, '{{link-to \'index\' \'index\' id=\'index-link\'}}');
+    this.addTemplate(routeName, '{{link-to \'index\' \'index\' id=\'index-link\'}}');
 
-    this.registerController(routeName, Controller.extend({
+    this.add(`controller:${routeName}`, Controller.extend({
       queryParams: ['foo'],
       foo: 'wat'
     }));

--- a/packages/ember/tests/routing/query_params_test/shared_state_test.js
+++ b/packages/ember/tests/routing/query_params_test/shared_state_test.js
@@ -20,24 +20,24 @@ moduleFor('Query Params - shared service state', class extends QueryParamTestCas
       this.route('dashboard');
     });
 
-    this.application.register('service:filters', Service.extend({
+    this.add('service:filters', Service.extend({
       shared: true
     }));
 
-    this.registerController('home', Controller.extend({
+    this.add('controller:home', Controller.extend({
       filters: Ember.inject.service()
     }));
 
-    this.registerController('dashboard', Controller.extend({
+    this.add('controller:dashboard', Controller.extend({
       filters: Ember.inject.service(),
       queryParams: [
         { 'filters.shared': 'shared' }
       ]
     }));
 
-    this.registerTemplate('application', `{{link-to 'Home' 'home' }} <div> {{outlet}} </div>`);
-    this.registerTemplate('home', `{{link-to 'Dashboard' 'dashboard' }}{{input type="checkbox" id='filters-checkbox' checked=(mut filters.shared) }}`);
-    this.registerTemplate('dashboard', `{{link-to 'Home' 'home' }}`);
+    this.addTemplate('application', `{{link-to 'Home' 'home' }} <div> {{outlet}} </div>`);
+    this.addTemplate('home', `{{link-to 'Dashboard' 'dashboard' }}{{input type="checkbox" id='filters-checkbox' checked=(mut filters.shared) }}`);
+    this.addTemplate('dashboard', `{{link-to 'Home' 'home' }}`);
   }
   visitApplication() {
     return this.visit('/');

--- a/packages/ember/tests/routing/router_service_test/basic_test.js
+++ b/packages/ember/tests/routing/router_service_test/basic_test.js
@@ -72,7 +72,7 @@ if (isFeatureEnabled('ember-routing-router-service')) {
     ['@test RouterService#rootURL is correctly set to a custom value'](assert) {
       assert.expect(1);
 
-      this.registerRoute('parent.index', Route.extend({
+      this.add('route:parent.index', Route.extend({
         init() {
           this._super();
           set(this.router, 'rootURL', '/homepage');

--- a/packages/ember/tests/routing/router_service_test/currenturl_lifecycle_test.js
+++ b/packages/ember/tests/routing/router_service_test/currenturl_lifecycle_test.js
@@ -43,11 +43,11 @@ if (isFeatureEnabled('ember-routing-router-service')) {
 
       ROUTE_NAMES.forEach((name) => {
         let routeName = `parent.${name}`;
-        this.registerRoute(routeName, InstrumentedRoute.extend());
-        this.registerTemplate(routeName, '{{current-url}}');
+        this.add(`route:${routeName}`, InstrumentedRoute.extend());
+        this.addTemplate(routeName, '{{current-url}}');
       });
 
-      this.registerComponent('current-url', {
+      this.addComponent('current-url', {
         ComponentClass: Component.extend({
           routerService: inject.service('router'),
           currentURL: readOnly('routerService.currentURL')

--- a/packages/ember/tests/routing/router_service_test/replaceWith_test.js
+++ b/packages/ember/tests/routing/router_service_test/replaceWith_test.js
@@ -15,7 +15,7 @@ if (isFeatureEnabled('ember-routing-router-service')) {
       let testCase = this;
       testCase.state = [];
 
-      this.application.register('location:test', NoneLocation.extend({
+      this.add('location:test', NoneLocation.extend({
         setURL(path) {
           testCase.state.push(path);
           this.set('path', path);

--- a/packages/ember/tests/routing/router_service_test/transitionTo_test.js
+++ b/packages/ember/tests/routing/router_service_test/transitionTo_test.js
@@ -22,7 +22,7 @@ if (isFeatureEnabled('ember-routing-router-service')) {
       let testCase = this;
       testCase.state = [];
 
-      this.application.register('location:test', NoneLocation.extend({
+      this.add('location:test', NoneLocation.extend({
         setURL(path) {
           testCase.state.push(path);
           this.set('path', path);
@@ -100,9 +100,9 @@ if (isFeatureEnabled('ember-routing-router-service')) {
 
       let componentInstance;
 
-      this.registerTemplate('parent.index', '{{foo-bar}}');
+      this.addTemplate('parent.index', '{{foo-bar}}');
 
-      this.registerComponent('foo-bar', {
+      this.addComponent('foo-bar', {
         ComponentClass: Component.extend({
           routerService: inject.service('router'),
           init() {
@@ -132,9 +132,9 @@ if (isFeatureEnabled('ember-routing-router-service')) {
 
       let componentInstance;
 
-      this.registerTemplate('parent.index', '{{foo-bar}}');
+      this.addTemplate('parent.index', '{{foo-bar}}');
 
-      this.registerComponent('foo-bar', {
+      this.addComponent('foo-bar', {
         ComponentClass: Component.extend({
           routerService: inject.service('router'),
           init() {
@@ -165,10 +165,10 @@ if (isFeatureEnabled('ember-routing-router-service')) {
       let componentInstance;
       let dynamicModel = { id: 1, contents: 'much dynamicism' };
 
-      this.registerTemplate('parent.index', '{{foo-bar}}');
-      this.registerTemplate('dynamic', '{{model.contents}}');
+      this.addTemplate('parent.index', '{{foo-bar}}');
+      this.addTemplate('dynamic', '{{model.contents}}');
 
-      this.registerComponent('foo-bar', {
+      this.addComponent('foo-bar', {
         ComponentClass: Component.extend({
           routerService: inject.service('router'),
           init() {
@@ -201,16 +201,16 @@ if (isFeatureEnabled('ember-routing-router-service')) {
       let componentInstance;
       let dynamicModel = { id: 1, contents: 'much dynamicism' };
 
-      this.registerRoute('dynamic', Route.extend({
+      this.add('route:dynamic', Route.extend({
         model() {
           return dynamicModel;
         }
       }));
 
-      this.registerTemplate('parent.index', '{{foo-bar}}');
-      this.registerTemplate('dynamic', '{{model.contents}}');
+      this.addTemplate('parent.index', '{{foo-bar}}');
+      this.addTemplate('dynamic', '{{model.contents}}');
 
-      this.registerComponent('foo-bar', {
+      this.addComponent('foo-bar', {
         ComponentClass: Component.extend({
           routerService: inject.service('router'),
           init() {

--- a/packages/ember/tests/routing/router_service_test/urlFor_test.js
+++ b/packages/ember/tests/routing/router_service_test/urlFor_test.js
@@ -176,7 +176,7 @@ if (isFeatureEnabled('ember-routing-router-service')) {
       let expectedURL;
       let dynamicModel = { id: 1 };
 
-      this.registerRoute('dynamic', Route.extend({
+      this.add('route:dynamic', Route.extend({
         model() {
           return dynamicModel;
         }
@@ -221,7 +221,7 @@ if (isFeatureEnabled('ember-routing-router-service')) {
       let queryParams = buildQueryParams({ foo: 'bar' });
       let dynamicModel = { id: 1 };
 
-      this.registerRoute('dynamic', Route.extend({
+      this.add('route:dynamic', Route.extend({
         model() {
           return dynamicModel;
         }

--- a/packages/internal-test-helpers/lib/index.js
+++ b/packages/internal-test-helpers/lib/index.js
@@ -28,3 +28,9 @@ export { default as QueryParamTestCase } from './test-cases/query-param';
 export { default as AbstractRenderingTestCase } from './test-cases/abstract-rendering';
 export { default as RenderingTestCase } from './test-cases/rendering';
 export { default as RouterTestCase } from './test-cases/router';
+export { default as AutobootApplicationTestCase } from './test-cases/autoboot-application';
+
+export {
+  default as TestResolver,
+  ModuleBasedResolver as ModuleBasedTestResolver
+} from './test-resolver';

--- a/packages/internal-test-helpers/lib/test-cases/autoboot-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/autoboot-application.js
@@ -1,0 +1,33 @@
+import AbstractTestCase from './abstract';
+import TestResolver from '../test-resolver';
+import { Application } from 'ember-application';
+import { assign } from 'ember-utils';
+import { runDestroy } from '../run';
+
+export default class AutobootApplicationTestCase extends AbstractTestCase {
+
+  teardown() {
+    runDestroy(this.application);
+    super.teardown();
+  }
+
+  createApplication(options, MyApplication=Application) {
+    let myOptions = assign({
+      rootElement: '#qunit-fixture',
+      Resolver: TestResolver
+    }, options);
+    let application = this.application = MyApplication.create(myOptions);
+    this.resolver = myOptions.Resolver.lastInstance;
+    return application;
+  }
+
+  add(specifier, factory) {
+    this.resolver.add(specifier, factory);
+  }
+
+  addTemplate(templateName, templateString) {
+    this.resolver.addTemplate(templateName, templateString);
+  }
+
+}
+

--- a/packages/internal-test-helpers/lib/test-cases/query-param.js
+++ b/packages/internal-test-helpers/lib/test-cases/query-param.js
@@ -11,7 +11,7 @@ export default class QueryParamTestCase extends ApplicationTestCase {
     let testCase = this;
     testCase.expectedPushURL = null;
     testCase.expectedReplaceURL = null;
-    this.application.register('location:test', NoneLocation.extend({
+    this.add('location:test', NoneLocation.extend({
       setURL(path) {
         if (testCase.expectedReplaceURL) {
           testCase.assert.ok(false, 'pushState occurred but a replaceState was expected');
@@ -76,7 +76,7 @@ export default class QueryParamTestCase extends ApplicationTestCase {
     @method setSingleQPController
   */
   setSingleQPController(routeName, param = 'foo', defaultValue = 'bar', options = {}) {
-    this.registerController(routeName, Controller.extend({
+    this.add(`controller:${routeName}`, Controller.extend({
       queryParams: [param],
       [param]: defaultValue
     }, options));
@@ -89,7 +89,7 @@ export default class QueryParamTestCase extends ApplicationTestCase {
     @method setMappedQPController
   */
   setMappedQPController(routeName, prop = 'page', urlKey = 'parentPage', defaultValue = 1, options = {}) {
-    this.registerController(routeName, Controller.extend({
+    this.add(`controller:${routeName}`, Controller.extend({
       queryParams: {
         [prop]: urlKey
       },

--- a/packages/internal-test-helpers/lib/test-resolver.js
+++ b/packages/internal-test-helpers/lib/test-resolver.js
@@ -1,0 +1,40 @@
+import { compile } from 'ember-template-compiler';
+
+class Resolver {
+  constructor() {
+    this._registered = {};
+    this.constructor.lastInstance = this;
+  }
+  resolve(specifier) {
+    return this._registered[specifier];
+  }
+  add(specifier, factory) {
+    return this._registered[specifier] = factory;
+  }
+  addTemplate(templateName, template) {
+    let templateType = typeof template;
+    if (templateType !== 'string') {
+      throw new Error(`You called addTemplate for "${templateName}" with a template argument of type of '${templateType}'. addTemplate expects an argument of an uncompiled template as a string.`);
+    }
+    return this._registered[`template:${templateName}`] = compile(template, {
+      moduleName: templateName
+    });
+  }
+  static create() {
+    return new this();
+  }
+}
+
+export default Resolver;
+
+/*
+ * A resolver with moduleBasedResolver = true handles error and loading
+ * substates differently than a standard resolver.
+ */
+class ModuleBasedResolver extends Resolver {
+  get moduleBasedResolver() {
+    return true;
+  }
+}
+
+export { ModuleBasedResolver }

--- a/packages/internal-test-helpers/lib/test-resolver.js
+++ b/packages/internal-test-helpers/lib/test-resolver.js
@@ -9,6 +9,9 @@ class Resolver {
     return this._registered[specifier];
   }
   add(specifier, factory) {
+    if (specifier.indexOf(':') === -1) {
+      throw new Error('Specifiers added to the resolver must be in the format of type:name');
+    }
     return this._registered[specifier] = factory;
   }
   addTemplate(templateName, template) {


### PR DESCRIPTION
The Ember test suite is very coupled to the default globals-mode resolver. For example:

* Tests often make a controller available to an application as `App.FooController`
* Tests often use `setTemplates` to set a template onto `Ember.TEMPLATES`
* Even more tests use `App.Router` to set location or other configuration

All of these ways of passing things to Ember are considered part of the globals-mode resolver API.

At some far future date, we would like to drop the default resolver and its globals API from Ember. Nearly all (but not all) Ember apps are built using Ember-CLI. Those applications (with a few minor tweaks) do not need the default resolver. Already they use the [ember-resolver](https://github.com/ember-cli/ember-resolver), however this itself is a subclass of the default resolver and retains globals loading as a fallback behavior.

With this goal in mind, these commits start the process of migrating the Ember test suite away from the globals mode resolver and toward a `TestResolver` that provides the minimal interface for an Ember resolver. The `TestResolver` also provides a mechanism to add modules during test.

Combined with the newer class-based testing interface introduced to the codebase during the Glimmer2 merge cycle, we have a pretty decent test interface coming together here. For example:

```js
// These modules are also available via the internal-test-helpers package
import { moduleFor, ApplicationTest } from '../../utils/test-case';

moduleFor('Link-to component', class extends ApplicationTest {

  ['@test should be able to be inserted in DOM when the router is not present']() {
    this.addTemplate('application', `{{#link-to 'index'}}Go to Index{{/link-to}}`);

    return this.visit('/').then(() => {
      this.assertText('Go to Index');
    });
  }

});
```
[source](https://github.com/mixonic/ember.js/blob/e536c5d4fb4c20ebe38dde36b80f1fc5dde62b8b/packages/ember-glimmer/tests/integration/components/link-to-test.js#L38-L44)

This PR:

* Changes `ApplicationTest` to use the `TestResolver` instead of the default resolver.
* The core team has consensus that we would like to test the *resolve* path over the *registry* path in our suite, so this PR also drops the test API of `this.registerController(Thing)` and family in favor of `this.add('type:name', Thing)`. `add` is backed by the `TestResolver`.
* Of course some test cases are not covered by `ApplicationTest`. This PR introduces a new test case `AutobootApplicationTestCase` for testing the timing of an autobooted application and uses it in `application_test`. This is a big diff, give it a look. *Some* tests here actually test behavior of the default resolver, and they are now flagged as such at the test module level.
* During `commonRegistrySetup` on the `Application`, `'router:main'` is now registered with the default value of `Router`. With the default resolver, `App.Router` is always found as a fallback. Without that fallback, we still require a default router at the `'router:main'` lookup. For default resolver apps this change should have no impact.

Once we have alignment on these API changes, I will create an epic to track further migration of the testing codebase away from the default resolver and registry.