### PR TITLE
Decouple test from the default resolver for routing/toplevel_dom

### DIFF
--- a/packages/ember/tests/routing/toplevel_dom_test.js
+++ b/packages/ember/tests/routing/toplevel_dom_test.js
@@ -1,56 +1,11 @@
-import { run } from 'ember-metal';
-import { compile } from 'ember-template-compiler';
-import { Application } from 'ember-application';
-import { jQuery } from 'ember-views';
-import { NoneLocation } from 'ember-routing';
-import { setTemplates, setTemplate } from 'ember-glimmer';
+import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
 
-let App, templates, container;
+moduleFor('Top Level DOM Structure', class extends ApplicationTestCase {
+  ['@test Topmost template always get an element'](assert) {
+    this.addTemplate('application', 'hello world');
 
-function bootApplication() {
-  for (let name in templates) {
-    setTemplate(name, compile(templates[name]));
-  }
-  container.lookup('router:main');
-  run(App, 'advanceReadiness');
-}
-
-QUnit.module('Top Level DOM Structure', {
-  setup() {
-    run(() => {
-      App = Application.create({
-        name: 'App',
-        rootElement: '#qunit-fixture'
-      });
-
-      App.deferReadiness();
-
-      App.Router.reopen({
-        location: 'none'
-      });
-
-      container = App.__container__;
-
-      templates = {
-        application: 'hello world'
-      };
-    });
-  },
-
-  teardown() {
-    run(() => {
-      App.destroy();
-      App = null;
-      setTemplates({});
-    });
-
-    NoneLocation.reopen({
-      path: ''
+    return this.visit('/').then(() => {
+      assert.equal(this.$('> .ember-view').text(), 'hello world');
     });
   }
-});
-
-QUnit.test('Topmost template always get an element', function() {
-  bootApplication();
-  equal(jQuery('#qunit-fixture > .ember-view').text(), 'hello world');
 });


### PR DESCRIPTION
This PR is to help remove the usage of the default resolver from the tests, which is described in  #15058. 

I think this covers the guideline from the [EPIC description](https://github.com/emberjs/ember.js/issues/15058), let me know if I have missed something.