### PR TITLE
Decouple test from the default resolver for helpers/helper_registration

### DIFF
--- a/packages/ember/tests/helpers/helper_registration_test.js
+++ b/packages/ember/tests/helpers/helper_registration_test.js
@@ -1,112 +1,67 @@
+import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
 import { Controller, Service, inject } from 'ember-runtime';
-import { run } from 'ember-metal';
-import { compile } from 'ember-template-compiler';
-import {
-  Helper,
-  helper,
-  setTemplates,
-  setTemplate
-} from 'ember-glimmer';
-import { Application } from 'ember-application';
-import { Router } from 'ember-routing';
-import { jQuery } from 'ember-views';
+import { Helper, helper } from 'ember-glimmer';
 
-let App, appInstance;
+moduleFor('Application Lifecycle - Helper Registration', class extends ApplicationTestCase {
+  ['@test Unbound dashed helpers registered on the container can be late-invoked'](assert) {
+    this.addTemplate('application', `<div id='wrapper'>{{x-borf}} {{x-borf 'YES'}}</div>`);
 
-QUnit.module('Application Lifecycle - Helper Registration', {
-  teardown() {
-    run(() => {
-      if (App) {
-        App.destroy();
-      }
+    let myHelper = helper(params => params[0] || 'BORF');
+    this.application.register('helper:x-borf', myHelper);
 
-      App = appInstance = null;
-      setTemplates({});
+    return this.visit('/').then(() => {
+      assert.equal(this.$('#wrapper').text(), 'BORF YES', 'The helper was invoked from the container');
     });
   }
-});
 
-function boot(callback) {
-  run(() => {
-    App = Application.create({
-      name: 'App',
-      rootElement: '#qunit-fixture'
-    });
+  ['@test Bound helpers registered on the container can be late-invoked'](assert) {
+    this.addTemplate('application', `<div id='wrapper'>{{x-reverse}} {{x-reverse foo}}</div>`);
 
-    App.deferReadiness();
-
-    App.Router = Router.extend({
-      location: 'none'
-    });
-
-    // We shouldn't be testing this
-    appInstance = App.__deprecatedInstance__;
-
-    if (callback) { callback(); }
-  });
-
-  let router = appInstance.lookup('router:main');
-
-  run(App, 'advanceReadiness');
-  run(() => router.handleURL('/'));
-}
-
-QUnit.test('Unbound dashed helpers registered on the container can be late-invoked', function() {
-  setTemplate('application', compile('<div id=\'wrapper\'>{{x-borf}} {{x-borf \'YES\'}}</div>'));
-  let myHelper = helper(params => params[0] || 'BORF');
-
-  boot(() => {
-    App.register('helper:x-borf', myHelper);
-  });
-
-  equal(jQuery('#wrapper').text(), 'BORF YES', 'The helper was invoked from the container');
-});
-
-QUnit.test('Bound helpers registered on the container can be late-invoked', function() {
-  setTemplate('application', compile('<div id=\'wrapper\'>{{x-reverse}} {{x-reverse foo}}</div>'));
-
-  boot(() => {
-    appInstance.register('controller:application', Controller.extend({
+    this.add('controller:application', Controller.extend({
       foo: 'alex'
     }));
 
-    appInstance.register('helper:x-reverse', helper(function([ value ]) {
+    this.application.register('helper:x-reverse', helper(function([ value ]) {
       return value ? value.split('').reverse().join('') : '--';
     }));
-  });
 
-  equal(jQuery('#wrapper').text(), '-- xela', 'The bound helper was invoked from the container');
-});
+    return this.visit('/').then(() => {
+      assert.equal(this.$('#wrapper').text(), '-- xela', 'The bound helper was invoked from the container');
+    });
+  }
 
-QUnit.test('Undashed helpers registered on the container can be invoked', function() {
-  setTemplate('application', compile('<div id=\'wrapper\'>{{omg}}|{{yorp \'boo\'}}|{{yorp \'ya\'}}</div>'));
+  ['@test Undashed helpers registered on the container can be invoked'](assert) {
+    this.addTemplate('application', `<div id='wrapper'>{{omg}}|{{yorp 'boo'}}|{{yorp 'ya'}}</div>`);
 
-  boot(() => {
-    appInstance.register('helper:omg', helper(() => 'OMG'));
+    this.application.register('helper:omg', helper(() => 'OMG'));
 
-    appInstance.register('helper:yorp', helper(([ value ]) => value));
-  });
+    this.application.register('helper:yorp', helper(([ value ]) => value));
 
-  equal(jQuery('#wrapper').text(), 'OMG|boo|ya', 'The helper was invoked from the container');
-});
+    return this.visit('/').then(() => {
+      assert.equal(this.$('#wrapper').text(), 'OMG|boo|ya', 'The helper was invoked from the container');
+    });
+  }
 
-QUnit.test('Helpers can receive injections', function() {
-  setTemplate('application', compile('<div id=\'wrapper\'>{{full-name}}</div>'));
+  ['@test Helpers can receive injections'](assert) {
+    this.addTemplate('application', `<div id='wrapper'>{{full-name}}</div>`);
 
-  let serviceCalled = false;
-  boot(() => {
-    appInstance.register('service:name-builder', Service.extend({
+    let serviceCalled = false;
+
+    this.add('service:name-builder', Service.extend({
       build() {
         serviceCalled = true;
       }
     }));
-    appInstance.register('helper:full-name', Helper.extend({
+
+    this.add('helper:full-name', Helper.extend({
       nameBuilder: inject.service('name-builder'),
       compute() {
         this.get('nameBuilder').build();
       }
     }));
-  });
 
-  ok(serviceCalled, 'service was injected, method called');
+    return this.visit('/').then(() => {
+      assert.ok(serviceCalled, 'service was injected, method called');
+    });
+  }
 });


### PR DESCRIPTION
Part of #15058.

I wasn't sure if I should use `AutobootApplicationTestCase` or `ApplicationTestCase`, so I went with the simpler version: `ApplicationTestCase`. 