### PR TITLE
Add queryParams to RouterService

### DIFF
--- a/packages/ember-routing/lib/services/router.js
+++ b/packages/ember-routing/lib/services/router.js
@@ -7,7 +7,7 @@ import {
   Service,
   readOnly
 } from 'ember-runtime';
-import { get } from 'ember-metal';
+import { get, computed } from 'ember-metal';
 import RouterDSL from '../system/dsl';
 
 /**
@@ -23,6 +23,13 @@ const RouterService = Service.extend({
   currentURL: readOnly('router.currentURL'),
   location: readOnly('router.location'),
   rootURL: readOnly('router.rootURL'),
+
+  params: readOnly('router.currentState.routerJsState.params'),
+  queryParams: readOnly('router.currentState.routerJsState.fullQueryParams'),
+
+  currentRouteParams: computed('currentRouteName', 'params', function() {
+    return this.get('params')[this.get('currentRouteName')];
+  }),
 
   /**
      Transition the application into another route. The route may

--- a/packages/ember/tests/routing/router_service_test/basic_test.js
+++ b/packages/ember/tests/routing/router_service_test/basic_test.js
@@ -93,5 +93,51 @@ if (isFeatureEnabled('ember-routing-router-service')) {
         assert.ok(location instanceof NoneLocation);
       });
     }
+
+    ['@test RouterService#queryParams are correctly set'](assert) {
+      assert.expect(2);
+
+      return this.visit('/?qp1=param1&qp2=param2').then(() => {
+        let queryParams = this.routerService.get('queryParams');
+        assert.deepEqual(queryParams, { qp1: "param1", qp2: "param2" });
+      }).then(() => {
+        this.visit('/child?qp1=param2&qp3=param3').then(() => {
+          let queryParams = this.routerService.get('queryParams');
+          assert.deepEqual(queryParams, { qp1: "param2", qp3: "param3" });
+        });
+      });
+    }
+
+    ['@test RouterService#params are correctly set'](assert) {
+      assert.expect(2);
+
+      this.add('route:dynamic', Route.extend({ model() {} }));
+
+      return this.visit('dynamic/1').then(() => {
+        let params = this.routerService.get('params');
+        assert.deepEqual(params, { "application": {}, "dynamic": { "dynamic_id": "1" } });
+      }).then(() => {
+        this.visit('dynamic/2').then(() => {
+          let params = this.routerService.get('params');
+          assert.deepEqual(params, { "application": {}, "dynamic": { "dynamic_id": "2" } });
+        });
+      });
+    }
+
+    ['@test RouterService#currentRouteParams are correctly set'](assert) {
+      assert.expect(2);
+
+      this.add('route:dynamic', Route.extend({ model() {} }));
+
+      return this.visit('dynamic/1').then(() => {
+        let currentRouteParams = this.routerService.get('currentRouteParams');
+        assert.deepEqual(currentRouteParams, { "dynamic_id": "1" });
+      }).then(() => {
+        this.visit('dynamic/2').then(() => {
+          let currentRouteParams = this.routerService.get('currentRouteParams');
+          assert.deepEqual(currentRouteParams, { "dynamic_id": "2" });
+        });
+      });
+    }
   });
 }


### PR DESCRIPTION
Can we add router params and queryParams to the public interface of RouterService? It will help in many cases when you try to access queryParams in the components.