### PR TITLE
[BUGFIX release] Don't publish ember's test bundles, qunit, jquery (5.8MB)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "dist",
     "!dist/ember-tests.prod.js",
     "!dist/ember-tests.js",
+    "!dist/qunit",
+    "!dist/jquery",
     "!dist/tests",
     "vendor/ember",
     "index.js"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "files": [
     "blueprints",
     "dist",
+    "!dist/ember-tests.prod.js",
+    "!dist/ember-tests.js",
     "!dist/tests",
     "vendor/ember",
     "index.js"


### PR DESCRIPTION
Looking through node_modules on a new Ember app I noticed that ember-source ends up with these files included.  This PR just ensures we don't pollute the size of node_modules with things we only need for local testing.

```
2.7M	./node_modules/ember-source/dist/ember-tests.prod.js
2.7M	./node_modules/ember-source/dist/ember-tests.js
264K	./node_modules/ember-source/dist/jquery/jquery.js
116K	./node_modules/ember-source/dist/qunit/qunit.js
```