### PR TITLE
[DOC] Fix controllerFor typo

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1762,7 +1762,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
   },
 
   /**
-    Returns the resolved controller of the current route, or a parent (or any ancestor)
+    Returns the controller of the current route, or a parent (or any ancestor)
     route in a route hierarchy.
 
     The controller instance must already have been created, either through entering the

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1762,7 +1762,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
   },
 
   /**
-    Returns the resolved model of the current route, or a parent (or any ancestor)
+    Returns the resolved controller of the current route, or a parent (or any ancestor)
     route in a route hierarchy.
 
     The controller instance must already have been created, either through entering the


### PR DESCRIPTION
`Ember.route#controllerFor` was documented as returning a model instead of a controller. This PR corrects that.