### PR TITLE
[DEPRECATION] #14754 deprecate `canDispatchToEventManager`

### DIFF
--- a/packages/ember-glimmer/tests/integration/event-dispatcher-test.js
+++ b/packages/ember-glimmer/tests/integration/event-dispatcher-test.js
@@ -6,6 +6,7 @@ import {
   run
 } from 'ember-metal';
 import { EMBER_IMPROVED_INSTRUMENTATION } from 'ember/features';
+import { EventDispatcher } from 'ember-views';
 
 let canDataTransfer = !!document.createEvent('HTMLEvents').dataTransfer;
 
@@ -136,6 +137,34 @@ moduleFor('EventDispatcher#setup', class extends RenderingTest {
     this.render(`{{x-foo}}`);
 
     this.$('div').trigger('myevent');
+  }
+
+  ['@test canDispatchToEventManager is deprecated'](assert) {
+    this.dispatcher.canDispatchToEventManager = null;
+    this.registerComponent('x-foo', {
+      ComponentClass: Component.extend({
+        eventManager: {
+          myEvent() {}
+        }
+      }),
+      template: `<p>Hello!</p>`
+    });
+
+    expectDeprecation(() => {
+      this.render(`{{x-foo}}`);
+    }, '[DEPRECATED] `canDispatchToEventManager` has been deprecated.');
+
+    this.$('div').trigger('myevent');
+  }
+
+  ['@test canDispatchToEventManager is deprecated in EventDispatcher'](assert) {
+    let MyDispatcher = EventDispatcher.extend({
+      canDispatchToEventManager: null
+    });
+
+    expectDeprecation(() => {
+      MyDispatcher.create();
+    }, '[DEPRECATED] `canDispatchToEventManager` has been deprecated.');
   }
 
   ['@test a rootElement can be specified'](assert) {

--- a/packages/ember-glimmer/tests/integration/event-dispatcher-test.js
+++ b/packages/ember-glimmer/tests/integration/event-dispatcher-test.js
@@ -56,6 +56,8 @@ moduleFor('EventDispatcher', class extends RenderingTest {
       template: `<input id="is-done" type="checkbox">`
     });
 
+
+    expectDeprecation(/`eventManager` has been deprecated/);
     this.render(`{{x-foo}}`);
 
     this.runTask(() => this.$('#is-done').trigger('click'));
@@ -90,6 +92,7 @@ moduleFor('EventDispatcher', class extends RenderingTest {
       template: `<input id="is-done" type="checkbox">`
     });
 
+    expectDeprecation(/`eventManager` has been deprecated/);
     this.render(`{{x-foo}}`);
 
     this.runTask(() => this.$('#is-done').trigger('click'));
@@ -139,8 +142,7 @@ moduleFor('EventDispatcher#setup', class extends RenderingTest {
     this.$('div').trigger('myevent');
   }
 
-  ['@test canDispatchToEventManager is deprecated'](assert) {
-    this.dispatcher.canDispatchToEventManager = null;
+  ['@test eventManager is deprecated'](assert) {
     this.registerComponent('x-foo', {
       ComponentClass: Component.extend({
         eventManager: {
@@ -150,11 +152,8 @@ moduleFor('EventDispatcher#setup', class extends RenderingTest {
       template: `<p>Hello!</p>`
     });
 
-    expectDeprecation(() => {
-      this.render(`{{x-foo}}`);
-    }, '[DEPRECATED] `canDispatchToEventManager` has been deprecated.');
-
-    this.$('div').trigger('myevent');
+    expectDeprecation(/`eventManager` has been deprecated/);
+    this.render(`{{x-foo}}`);
   }
 
   ['@test canDispatchToEventManager is deprecated in EventDispatcher'](assert) {
@@ -162,9 +161,8 @@ moduleFor('EventDispatcher#setup', class extends RenderingTest {
       canDispatchToEventManager: null
     });
 
-    expectDeprecation(() => {
-      MyDispatcher.create();
-    }, '[DEPRECATED] `canDispatchToEventManager` has been deprecated.');
+    expectDeprecation(/`canDispatchToEventManager` has been deprecated/);
+    MyDispatcher.create();
   }
 
   ['@test a rootElement can be specified'](assert) {

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -539,11 +539,11 @@ export default Mixin.create({
       let dispatcher = owner && owner.lookup('event_dispatcher:main');
 
       deprecate(
-        `[DEPRECATED] \`canDispatchToEventManager\` has been deprecated.`,
-        !('canDispatchToEventManager' in dispatcher),
+        `\`eventManager\` has been deprecated in ${this}.`,
+        false,
         {
           id: 'ember-views.event-dispatcher.canDispatchToEventManager',
-          until: '3.0.0'
+          until: '2.16.0'
         }
       );
 

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -538,7 +538,16 @@ export default Mixin.create({
       let owner = getOwner(this);
       let dispatcher = owner && owner.lookup('event_dispatcher:main');
 
-      if (dispatcher && dispatcher.canDispatchToEventManager === null) {
+      deprecate(
+        `[DEPRECATED] \`canDispatchToEventManager\` has been deprecated.`,
+        !('canDispatchToEventManager' in dispatcher),
+        {
+          id: 'ember-views.event-dispatcher.canDispatchToEventManager',
+          until: '3.0.0'
+        }
+      );
+
+      if (dispatcher && !('canDispatchToEventManager' in dispatcher)) {
         dispatcher.canDispatchToEventManager = true;
       }
     }

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -139,11 +139,11 @@ export default EmberObject.extend({
     assert('EventDispatcher should never be instantiated in fastboot mode. Please report this as an Ember bug.', environment.hasDOM);
 
     deprecate(
-      `[DEPRECATED] \`canDispatchToEventManager\` has been deprecated.`,
+      `\`canDispatchToEventManager\` has been deprecated in ${this}.`,
       !('canDispatchToEventManager' in this),
       {
         id: 'ember-views.event-dispatcher.canDispatchToEventManager',
-        until: '3.0.0'
+        until: '2.16.0'
       }
     );
   },

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -6,6 +6,7 @@
 import { assign, getOwner } from 'ember-utils';
 import { assert } from 'ember-debug';
 import { get, set, isNone, run } from 'ember-metal';
+import { deprecate } from 'ember-debug';
 import { Object as EmberObject } from 'ember-runtime';
 import jQuery from './jquery';
 import ActionManager from './action_manager';
@@ -129,13 +130,22 @@ export default EmberObject.extend({
     @type boolean
     @default false
     @since 1.7.0
+    @deprecated
     @private
   */
-  canDispatchToEventManager: null,
 
   init() {
     this._super();
     assert('EventDispatcher should never be instantiated in fastboot mode. Please report this as an Ember bug.', environment.hasDOM);
+
+    deprecate(
+      `[DEPRECATED] \`canDispatchToEventManager\` has been deprecated.`,
+      !('canDispatchToEventManager' in this),
+      {
+        id: 'ember-views.event-dispatcher.canDispatchToEventManager',
+        until: '3.0.0'
+      }
+    );
   },
 
   /**


### PR DESCRIPTION
This is to address the deprecation in #14754.  I'm not sure if the deprecation message provides enough detail.