### PR TITLE
Ember utils polyfill

### DIFF
--- a/packages/ember-utils/lib/assign.js
+++ b/packages/ember-utils/lib/assign.js
@@ -15,7 +15,7 @@
   @return {Object}
   @public
 */
-export default function assign(original) {
+export function assign(original) {
   for (let i = 1; i < arguments.length; i++) {
     let arg = arguments[i];
     if (!arg) { continue; }
@@ -30,3 +30,5 @@ export default function assign(original) {
 
   return original;
 }
+
+export default Object.assign || assign;

--- a/packages/ember-utils/lib/index.js
+++ b/packages/ember-utils/lib/index.js
@@ -10,7 +10,10 @@
 */
 export { default as symbol } from './symbol';
 export { getOwner, setOwner, OWNER } from './owner';
-export { default as assign } from './assign';
+
+// Export `assignPolyfill` for testing
+export { default as assign, assign as assignPolyfill } from './assign';
+
 export { default as dictionary } from './dictionary';
 export {
   uuid,

--- a/packages/ember-utils/tests/assign_test.js
+++ b/packages/ember-utils/tests/assign_test.js
@@ -1,4 +1,4 @@
-import { assign } from '..';
+import { assignPolyfill as assign } from '..';
 
 QUnit.module('Ember.assign');
 

--- a/packages/ember-utils/tests/assign_test.js
+++ b/packages/ember-utils/tests/assign_test.js
@@ -2,16 +2,37 @@ import { assignPolyfill as assign } from '..';
 
 QUnit.module('Ember.assign');
 
-QUnit.test('Ember.assign', function() {
-  let a = { a: 1 };
-  let b = { b: 2 };
-  let c = { c: 3 };
-  let a2 = { a: 4 };
+QUnit.test('merging objects', function() {
+  let trgt = { a: 1 };
+  let src1 = { b: 2 };
+  let src2 = { c: 3 };
 
-  assign(a, b, c, a2);
+  assign(trgt, src1, src2);
 
-  deepEqual(a, { a: 4, b: 2, c: 3 });
-  deepEqual(b, { b: 2 });
-  deepEqual(c, { c: 3 });
-  deepEqual(a2, { a: 4 });
+  deepEqual(trgt, { a: 1, b: 2, c: 3 }, 'assign copies values from one or more source objects to a target object');
+  deepEqual(src1, { b: 2 }, 'assign does not change source object 1');
+  deepEqual(src2, { c: 3 }, 'assign does not change source object 2');
+});
+
+QUnit.test('merging objects with same property', function() {
+  let trgt = { a: 1, b: 1 };
+  let src1 = { a: 2, b: 2 };
+  let src2 = { a: 3 };
+
+  assign(trgt, src1, src2);
+  deepEqual(trgt, { a: 3, b: 2 }, 'properties are overwritten by other objects that have the same properties later in the parameters order');
+});
+
+QUnit.test('null', function() {
+  let trgt = { a: 1 };
+
+  assign(trgt, null);
+  deepEqual(trgt, { a: 1 }, 'null as a source parameter is ignored');
+});
+
+QUnit.test('undefined', function() {
+  let trgt = { a: 1 };
+
+  assign(trgt, null);
+  deepEqual(trgt, { a: 1 }, 'undefined as a source parameter is ignored');
 });

--- a/packages/ember/lib/index.js
+++ b/packages/ember/lib/index.js
@@ -25,7 +25,7 @@ Ember.tryInvoke = utils.tryInvoke;
 Ember.wrap = utils.wrap;
 Ember.applyStr = utils.applyStr;
 Ember.uuid = utils.uuid;
-Ember.assign = Object.assign || utils.assign;
+Ember.assign = utils.assign;
 
 // container exports
 Ember.Container = Container;

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -8,7 +8,7 @@ QUnit.module('ember reexports');
   // ember-utils
   ['getOwner', 'ember-utils', 'getOwner'],
   ['setOwner', 'ember-utils', 'setOwner'],
-  // ['assign', 'ember-metal'], TODO: fix this test, we use `Object.assign` if present
+  ['assign', 'ember-utils'],
   ['GUID_KEY', 'ember-utils'],
   ['uuid', 'ember-utils'],
   ['generateGuid', 'ember-utils'],


### PR DESCRIPTION
__Changes__

This PR resolves #14855 

 - Use native `Object.assign` instead of polyfill if available in `Ember.assign`
 - Expose `assignPolyfill` for direct testing
- Add test coverage to `Object.assign` polyfill

__TODO__
 - [ ] Run benchmarks to make sure that using native `Object.assign` doesn't cause regressions