### PR TITLE
[DEPRECATION] (WIP) calling `this._super` when there is no method on parent class

### DIFF
--- a/packages/ember-glimmer/lib/component.js
+++ b/packages/ember-glimmer/lib/component.js
@@ -637,7 +637,7 @@ const Component = CoreView.extend(
     readDOMAttr(name) {
       let element = getViewElement(this);
       return readDOMAttr(element, name);
-    }
+    },
 
     /**
      The WAI-ARIA role of the control represented by this view. For example, a
@@ -717,24 +717,7 @@ const Component = CoreView.extend(
      @public
      @since 1.13.0
      */
-
-    /**
-     Called when the attributes passed into the component have been updated.
-     Called both during the initial render of a container and during a rerender.
-     Can be used in place of an observer; code placed here will be executed
-     every time any attribute updates.
-     @event didReceiveAttrs
-     @public
-     @since 1.13.0
-     */
-
-    /**
-     Called after a component has been rendered, both on initial render and
-     in subsequent rerenders.
-     @method didRender
-     @public
-     @since 1.13.0
-     */
+    didReceiveAttrs() {},
 
     /**
      Called after a component has been rendered, both on initial render and
@@ -743,14 +726,7 @@ const Component = CoreView.extend(
      @public
      @since 1.13.0
      */
-
-    /**
-     Called before a component has been rendered, both on initial render and
-     in subsequent rerenders.
-     @method willRender
-     @public
-     @since 1.13.0
-     */
+    didRender() {},
 
     /**
      Called before a component has been rendered, both on initial render and
@@ -759,6 +735,7 @@ const Component = CoreView.extend(
      @public
      @since 1.13.0
      */
+    willRender() {},
 
     /**
      Called when the attributes passed into the component have been changed.
@@ -767,14 +744,7 @@ const Component = CoreView.extend(
      @public
      @since 1.13.0
      */
-
-    /**
-     Called when the attributes passed into the component have been changed.
-     Called only during a rerender, not during an initial render.
-     @event didUpdateAttrs
-     @public
-     @since 1.13.0
-     */
+    didUpdateAttrs() {},
 
     /**
      Called when the component is about to update and rerender itself.
@@ -783,14 +753,7 @@ const Component = CoreView.extend(
      @public
      @since 1.13.0
      */
-
-    /**
-     Called when the component is about to update and rerender itself.
-     Called only during a rerender, not during an initial render.
-     @event willUpdate
-     @public
-     @since 1.13.0
-     */
+    willUpdate() {},
 
     /**
      Called when the component has updated and rerendered itself.
@@ -799,14 +762,14 @@ const Component = CoreView.extend(
      @public
      @since 1.13.0
      */
+    didUpdate() {},
 
     /**
-     Called when the component has updated and rerendered itself.
-     Called only during a rerender, not during an initial render.
-     @event didUpdate
+     @event didDestroyElement
      @public
-     @since 1.13.0
+     @since 2.13.0
      */
+    didDestroyElement() {}
 
     /**
       A component may contain a layout. A layout is a regular template but

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -95,6 +95,15 @@ function giveDescriptorSuper(meta, key, property, values, descs, base) {
   }
 
   if (superProperty === undefined || !(superProperty instanceof ComputedProperty)) {
+    /*
+    deprecate(
+      'Calling `_super` when there is no computed on the parent class is deprecated.',
+      false,
+      { id: 'ember-metal.missing-super-computed', until: '3.0.0' }
+    );
+    */
+    console.warn('no super computed');
+
     return property;
   }
 
@@ -129,6 +138,23 @@ function giveMethodSuper(obj, key, method, values, descs) {
 
   // Only wrap the new method if the original method was a function
   if (superMethod === undefined || 'function' !== typeof superMethod) {
+    /*
+    deprecate(
+      'Calling `_super` when there is no method on the parent class is deprecated.',
+      false,
+      { id: 'ember-metal.missing-super-computed', until: '3.0.0' }
+    );
+    *
+    */
+    /*
+    deprecate(
+      'Ember.required is deprecated as its behavior is inconsistent and unreliable.',
+      false,
+      { id: 'ember-metal.required', until: '3.0.0' }
+    );
+    */
+    console.warn('no super method');
+
     return method;
   }
 

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -95,16 +95,15 @@ function giveDescriptorSuper(meta, key, property, values, descs, base) {
   }
 
   if (superProperty === undefined || !(superProperty instanceof ComputedProperty)) {
-    /*
-    deprecate(
-      'Calling `_super` when there is no computed on the parent class is deprecated.',
-      false,
-      { id: 'ember-metal.missing-super-computed', until: '3.0.0' }
-    );
-    */
-    console.warn('no super computed');
-
-    return property;
+    superProperty = {
+      _getter: function() {
+        deprecate(
+          `Calling \`_super\` when there is no computed \`${key}\` on the parent class is deprecated.`,
+          false,
+          { id: 'ember-metal.missing-super-computed', until: '3.0.0' }
+        );
+      }
+    };
   }
 
   // Since multiple mixins may inherit from the same parent, we need
@@ -138,24 +137,13 @@ function giveMethodSuper(obj, key, method, values, descs) {
 
   // Only wrap the new method if the original method was a function
   if (superMethod === undefined || 'function' !== typeof superMethod) {
-    /*
-    deprecate(
-      'Calling `_super` when there is no method on the parent class is deprecated.',
-      false,
-      { id: 'ember-metal.missing-super-computed', until: '3.0.0' }
-    );
-    *
-    */
-    /*
-    deprecate(
-      'Ember.required is deprecated as its behavior is inconsistent and unreliable.',
-      false,
-      { id: 'ember-metal.required', until: '3.0.0' }
-    );
-    */
-    console.warn('no super method');
-
-    return method;
+    superMethod = function() {
+      deprecate(
+        `Calling \`_super\` when there is no method \`${key}\` on the parent class is deprecated.`,
+        false,
+        { id: 'ember-metal.missing-super-method', until: '3.0.0' }
+      );
+    };
   }
 
   return wrap(method, superMethod);

--- a/packages/ember-metal/tests/mixin/computed_test.js
+++ b/packages/ember-metal/tests/mixin/computed_test.js
@@ -143,14 +143,15 @@ QUnit.test('setter behavior works properly when overriding computed properties',
 });
 
 QUnit.test('calling _super when there is no computed on parent class is deprecated', function() {
-  expectDeprecation('Calling `_super` when there is no computed on the parent class is deprecated.');
+  expectDeprecation('Calling `_super` when there is no computed `foo` on the parent class is deprecated.');
 
   let SuperMixin = Mixin.create({});
 
   let SubMixin = Mixin.create(SuperMixin, {
     foo: computed({
-      get(key) { return this._super(...arguments); },
-      set(key, value) { return this._super(...arguments); }
+      get(key) { return this._super(...arguments); }
     })
   });
+
+  SubMixin.get('foo');
 });

--- a/packages/ember-metal/tests/mixin/computed_test.js
+++ b/packages/ember-metal/tests/mixin/computed_test.js
@@ -148,10 +148,12 @@ QUnit.test('calling _super when there is no computed on parent class is deprecat
   let SuperMixin = Mixin.create({});
 
   let SubMixin = Mixin.create(SuperMixin, {
-    foo: computed({
-      get(key) { return this._super(...arguments); }
+    foo: computed(function() {
+      return this._super(...arguments);
     })
   });
 
-  SubMixin.get('foo');
+  let obj = {};
+  SubMixin.apply(obj);
+  get(obj, 'foo');
 });

--- a/packages/ember-metal/tests/mixin/computed_test.js
+++ b/packages/ember-metal/tests/mixin/computed_test.js
@@ -141,3 +141,16 @@ QUnit.test('setter behavior works properly when overriding computed properties',
   equal(get(obj, 'cpWithoutSetter'), 'test', 'The default setter was called, the value is correct');
   ok(!cpWasCalled, 'The default setter was called, not the CP itself');
 });
+
+QUnit.test('calling _super when there is no computed on parent class is deprecated', function() {
+  expectDeprecation('Calling `_super` when there is no computed on the parent class is deprecated.');
+
+  let SuperMixin = Mixin.create({});
+
+  let SubMixin = Mixin.create(SuperMixin, {
+    foo: computed({
+      get(key) { return this._super(...arguments); },
+      set(key, value) { return this._super(...arguments); }
+    })
+  });
+});

--- a/packages/ember-metal/tests/mixin/method_test.js
+++ b/packages/ember-metal/tests/mixin/method_test.js
@@ -155,8 +155,6 @@ QUnit.test('_super from a first-of-two mixins with no superclass function does n
 });
 
 QUnit.test('calling _super when there is no method on parent class is deprecated', function() {
-  expectDeprecation('Calling `_super` when there is no method on the parent class is deprecated.');
-
   let MixinA = Mixin.create({});
 
   let MixinB = Mixin.create(MixinA, {
@@ -164,6 +162,12 @@ QUnit.test('calling _super when there is no method on parent class is deprecated
       this._super(...arguments);
     }
   });
+
+  let obj = {};
+  MixinB.apply(obj);
+
+  expectDeprecation('Calling `_super` when there is no method `foo` on the parent class is deprecated.');
+  obj.foo();
 });
 
 // ..........................................................

--- a/packages/ember-metal/tests/mixin/method_test.js
+++ b/packages/ember-metal/tests/mixin/method_test.js
@@ -116,7 +116,8 @@ QUnit.test('Including the same mixin more than once will only run once', functio
   equal(cnt, 1, 'should invoke MixinA.foo one time');
 });
 
-QUnit.test('_super from a single mixin with no superclass does not error', function() {
+QUnit.test('_super from a single mixin with no superclass is deprecated', function() {
+  expectDeprecation('Calling `_super` when there is no method `foo` on the parent class is deprecated.');
   let MixinA = Mixin.create({
     foo() {
       this._super(...arguments);
@@ -127,10 +128,11 @@ QUnit.test('_super from a single mixin with no superclass does not error', funct
   MixinA.apply(obj);
 
   obj.foo();
-  ok(true);
 });
 
-QUnit.test('_super from a first-of-two mixins with no superclass function does not error', function() {
+QUnit.test('_super from a first-of-two mixins with no superclass function is deprecated', function() {
+  expectDeprecation('Calling `_super` when there is no method `foo` on the parent class is deprecated.');
+
   // _super was previously calling itself in the second assertion.
   // Use remaining count of calls to ensure it doesn't loop indefinitely.
   let remaining = 3;
@@ -155,6 +157,7 @@ QUnit.test('_super from a first-of-two mixins with no superclass function does n
 });
 
 QUnit.test('calling _super when there is no method on parent class is deprecated', function() {
+  expectDeprecation('Calling `_super` when there is no method `foo` on the parent class is deprecated.');
   let MixinA = Mixin.create({});
 
   let MixinB = Mixin.create(MixinA, {
@@ -166,7 +169,6 @@ QUnit.test('calling _super when there is no method on parent class is deprecated
   let obj = {};
   MixinB.apply(obj);
 
-  expectDeprecation('Calling `_super` when there is no method `foo` on the parent class is deprecated.');
   obj.foo();
 });
 

--- a/packages/ember-metal/tests/mixin/method_test.js
+++ b/packages/ember-metal/tests/mixin/method_test.js
@@ -154,6 +154,18 @@ QUnit.test('_super from a first-of-two mixins with no superclass function does n
   ok(true);
 });
 
+QUnit.test('calling _super when there is no method on parent class is deprecated', function() {
+  expectDeprecation('Calling `_super` when there is no method on the parent class is deprecated.');
+
+  let MixinA = Mixin.create({});
+
+  let MixinB = Mixin.create(MixinA, {
+    foo() {
+      this._super(...arguments);
+    }
+  });
+});
+
 // ..........................................................
 // CONFLICTS
 //


### PR DESCRIPTION
https://github.com/emberjs/ember.js/issues/14780

 - [ ] document  `didDestroyElement`, only available in interactive mode