### PR TITLE
[DOC] update missing yield docs in api #14797

### DIFF
--- a/packages/ember-glimmer/lib/index.js
+++ b/packages/ember-glimmer/lib/index.js
@@ -135,6 +135,31 @@
    First name: <input type="text" />
   </label>
   ```
+
+  Additionally you can `yield` properties into the context for use by the consumer:
+
+  ```handlebars
+  <!-- application.hbs -->
+  {{#labeled-textfield value=someProperty validator=(action 'firstNameValidator') as |validationError|}}
+  {{#if validationError}}
+    <p class="error">{{ValidationError}}</p>
+  {{/if}}
+  First name:
+  {{/labeled-textfield}}
+  ```
+  ```handlebars
+  <!-- components/labeled-textfield.hbs -->
+  <label>
+   {{yield validationError}} {{input value=value}}
+  </label>
+  ```
+  Result:
+  ```html
+  <label>
+   <p class="error">First Name must be at least 3 characters long.</p>
+   First name: <input type="text" />
+  </label>
+  ```
   @method yield
   @for Ember.Templates.helpers
   @param {Hash} options

--- a/packages/ember-glimmer/lib/index.js
+++ b/packages/ember-glimmer/lib/index.js
@@ -110,6 +110,37 @@
   @public
  */
 
+/**
+  `{{yield}}` denotes an area of a template that will be rendered inside
+  of another template.
+
+  ### Use with Ember.Component
+  When designing components `{{yield}}` is used to denote where, inside the component's
+  template, an optional block passed to the component should render:
+  ```handlebars
+  <!-- application.hbs -->
+  {{#labeled-textfield value=someProperty}}
+   First name:
+  {{/labeled-textfield}}
+  ```
+  ```handlebars
+  <!-- components/labeled-textfield.hbs -->
+  <label>
+   {{yield}} {{input value=value}}
+  </label>
+  ```
+  Result:
+  ```html
+  <label>
+   First name: <input type="text" />
+  </label>
+  ```
+  @method yield
+  @for Ember.Templates.helpers
+  @param {Hash} options
+  @return {String} HTML string
+  @public
+ */
 
 /**
   Execute the `debugger` statement in the current template's context.

--- a/packages/ember-glimmer/lib/index.js
+++ b/packages/ember-glimmer/lib/index.js
@@ -115,49 +115,53 @@
   of another template.
 
   ### Use with Ember.Component
+
   When designing components `{{yield}}` is used to denote where, inside the component's
   template, an optional block passed to the component should render:
-  ```handlebars
-  <!-- application.hbs -->
+
+  ```application.hbs
   {{#labeled-textfield value=someProperty}}
-   First name:
+    First name:
   {{/labeled-textfield}}
   ```
-  ```handlebars
-  <!-- components/labeled-textfield.hbs -->
+
+  ```components/labeled-textfield.hbs
   <label>
-   {{yield}} {{input value=value}}
+    {{yield}} {{input value=value}}
   </label>
   ```
+
   Result:
+
   ```html
   <label>
-   First name: <input type="text" />
+    First name: <input type="text" />
   </label>
   ```
 
   Additionally you can `yield` properties into the context for use by the consumer:
 
-  ```handlebars
-  <!-- application.hbs -->
+  ```application.hbs
   {{#labeled-textfield value=someProperty validator=(action 'firstNameValidator') as |validationError|}}
-  {{#if validationError}}
-    <p class="error">{{ValidationError}}</p>
-  {{/if}}
-  First name:
+    {{#if validationError}}
+      <p class="error">{{ValidationError}}</p>
+    {{/if}}
+    First name:
   {{/labeled-textfield}}
   ```
-  ```handlebars
-  <!-- components/labeled-textfield.hbs -->
+
+  ```components/labeled-textfield.hbs
   <label>
-   {{yield validationError}} {{input value=value}}
+    {{yield validationError}} {{input value=value}}
   </label>
   ```
+
   Result:
+
   ```html
   <label>
-   <p class="error">First Name must be at least 3 characters long.</p>
-   First name: <input type="text" />
+    <p class="error">First Name must be at least 3 characters long.</p>
+    First name: <input type="text" />
   </label>
   ```
   @method yield


### PR DESCRIPTION
For [14979](https://github.com/emberjs/ember.js/issues/14797)

Just getting the ball running on these missing docs.  These are copied over from the old docs that were removed, with the section on Ember.View removed.  Let me know if you want anymore changes.