### PR TITLE
Decouple test from the default resolver for system/bootstrap-test

### DIFF
--- a/packages/ember-application/tests/system/bootstrap-test.js
+++ b/packages/ember-application/tests/system/bootstrap-test.js
@@ -1,35 +1,37 @@
-import { run } from 'ember-metal';
-import Application from '../../system/application';
 import { Router } from 'ember-routing';
+import { assign } from 'ember-utils';
 import { jQuery } from 'ember-views';
+import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
 import { setTemplates } from 'ember-glimmer';
+import DefaultResolver from '../../system/resolver';
 
-let app;
+moduleFor('Ember.Application with default resolver and autoboot', class extends ApplicationTestCase {
+  constructor() {
+    jQuery('#qunit-fixture').html(`
+      <div id="app"></div>
 
-QUnit.module('Ember.Application', {
+      <script type="text/x-handlebars">Hello {{outlet}}</script>
+      <script type="text/x-handlebars" id="index">World!</script>
+    `);
+    super();
+  }
+
   teardown() {
-    if (app) {
-      run(app, 'destroy');
-    }
-
     setTemplates({});
   }
-});
 
-QUnit.test('templates in script tags are extracted at application creation', function(assert) {
-  jQuery('#qunit-fixture').html(`
-    <div id="app"></div>
+  get applicationOptions() {
+    return assign(super.applicationOptions, {
+      autoboot: true,
+      rootElement: '#app',
+      Resolver: DefaultResolver,
+      Router: Router.extend({
+        location: 'none'
+      })
+    });
+  }
 
-    <script type="text/x-handlebars">Hello {{outlet}}</script>
-    <script type="text/x-handlebars" id="index">World!</script>
-  `);
-
-  let application = Application.extend();
-  application.Router = Router.extend({
-    location: 'none'
-  });
-
-  app = run(() => application.create({ rootElement: '#app' }));
-
-  assert.equal(jQuery('#app').text(), 'Hello World!');
+  ['@test templates in script tags are extracted at application creation'](assert) {
+    assert.equal(jQuery('#app').text(), 'Hello World!');
+  }
 });

--- a/packages/internal-test-helpers/lib/test-cases/abstract-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract-application.js
@@ -19,7 +19,9 @@ export default class AbstractApplicationTestCase extends AbstractTestCase {
 
     this.resolver = applicationOptions.Resolver.lastInstance;
 
-    this.add('router:main', Router.extend(this.routerOptions));
+    if (this.resolver) {
+      this.resolver.add('router:main', Router.extend(this.routerOptions));
+    }
 
     this.applicationInstance = null;
   }


### PR DESCRIPTION
This was done at the EmberConf contributors workshop as part of https://github.com/emberjs/ember.js/issues/15058