### PR TITLE
Remove use of private method makeArray in examples

### DIFF
--- a/packages/ember-runtime/lib/utils.js
+++ b/packages/ember-runtime/lib/utils.js
@@ -89,7 +89,7 @@ export function isArray(obj) {
   Ember.typeOf(new Number(101));        // 'number'
   Ember.typeOf(true);                   // 'boolean'
   Ember.typeOf(new Boolean(true));      // 'boolean'
-  Ember.typeOf(Ember.makeArray);        // 'function'
+  Ember.typeOf(Ember.A);                // 'function'
   Ember.typeOf([1, 2, 90]);             // 'array'
   Ember.typeOf(/abc/);                  // 'regexp'
   Ember.typeOf(new Date());             // 'date'


### PR DESCRIPTION
`Ember.makeArray` is [marked as private](https://github.com/emberjs/ember.js/blob/52d9cf213f802f5612e05a880480594e32fc64f8/packages/ember-utils/lib/make-array.js#L24). This PR removes the use of it in the `Ember.typeOf` documentation example.