### PR TITLE
[BUGFIX beta] Allow calling `Ember.warn` without test.

### DIFF
--- a/packages/ember-debug/lib/warn.js
+++ b/packages/ember-debug/lib/warn.js
@@ -70,6 +70,10 @@ export let missingOptionsIdDeprecation = 'When calling `Ember.warn` you must pro
   @since 1.0.0
 */
 export default function warn(message, test, options) {
+  if (arguments.length === 2 && typeof test === 'object') {
+    options = test;
+    test = false;
+  }
   if (!options) {
     deprecate(
       missingOptionsDeprecation,
@@ -94,5 +98,5 @@ export default function warn(message, test, options) {
     );
   }
 
-  invoke('warn', ...arguments);
+  invoke('warn', message, test, options);
 }

--- a/packages/ember-debug/tests/main_test.js
+++ b/packages/ember-debug/tests/main_test.js
@@ -269,3 +269,31 @@ QUnit.test('warn without options.id triggers a deprecation', function(assert) {
 
   warn('foo', false, { });
 });
+
+QUnit.test('warn without options.id nor test triggers a deprecation', function(assert) {
+  assert.expect(2);
+
+  registerHandler(function(message) {
+    assert.equal(message, missingWarnOptionsIdDeprecation, 'deprecation is triggered when options is missing');
+  });
+
+  registerWarnHandler(function(message) {
+    assert.equal(message, 'foo', 'original warning is triggered');
+  });
+
+  warn('foo', { });
+});
+
+QUnit.test('warn without test but with options does not trigger a deprecation', function(assert) {
+  assert.expect(1);
+
+  registerHandler(function(message) {
+    assert.ok(false, `there should be no deprecation ${message}`);
+  });
+
+  registerWarnHandler(function(message) {
+    assert.equal(message, 'foo', 'warning was triggered');
+  });
+
+  warn('foo', { id: 'ember-debug.do-not-raise' });
+});


### PR DESCRIPTION
If `Ember.warn` is called without the `test` parameter, a deprecation message is triggered.

[RFC 65](https://github.com/emberjs/rfcs/blob/master/text/0065-deprecation-warning-handlers.md) makes the `test` parameter required for `Ember.deprecate` but not so for `Ember.warn`.

Fixes #15096