### PR TITLE
fix missing 'afterEach' import

### DIFF
--- a/blueprints/initializer-test/mocha-files/tests/unit/initializers/__name__-test.js
+++ b/blueprints/initializer-test/mocha-files/tests/unit/initializers/__name__-test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
+import { describe, it, beforeEach, afterEach } from 'mocha';
 import Ember from 'ember';
 import { initialize } from '<%= dasherizedModulePrefix %>/initializers/<%= dasherizedModuleName %>';
 import destroyApp from '../../helpers/destroy-app';


### PR DESCRIPTION
I'm not using QUnit, but I guess [afterEach](https://github.com/emberjs/ember.js/blob/master/blueprints/initializer-test/qunit-files/tests/unit/initializers/__name__-test.js#L13) and [beforeEach](https://github.com/emberjs/ember.js/blob/master/blueprints/initializer-test/qunit-files/tests/unit/initializers/__name__-test.js#L7) imports are not missing ?