### PR TITLE
[Cleanup] Introduce a tiny bit more debugging data to warnings about CP dependencies

### DIFF
--- a/packages/ember-metal/lib/expand_properties.js
+++ b/packages/ember-metal/lib/expand_properties.js
@@ -35,7 +35,7 @@ var END_WITH_EACH_REGEX = /\.@each$/;
   expansion, and is passed the expansion.
 */
 export default function expandProperties(pattern, callback) {
-  assert('A computed property key must be a string', typeof pattern === 'string');
+  assert(`A computed property key must be a string, you passed ${typeof pattern} ${pattern}`, typeof pattern === 'string');
   assert(
     'Brace expanded properties cannot contain spaces, e.g. "user.{firstName, lastName}" should be "user.{firstName,lastName}"',
     pattern.indexOf(' ') === -1

--- a/packages/ember-metal/tests/expand_properties_test.js
+++ b/packages/ember-metal/tests/expand_properties_test.js
@@ -101,7 +101,7 @@ QUnit.test('A pattern must be a string', function() {
   expect(1);
 
   expectAssertion(() => {
-    expandProperties([], addProperty);
+    expandProperties([1, 2], addProperty);
   }, /A computed property key must be a string/);
 });
 


### PR DESCRIPTION
I ran across this updating an app from 2.4LTS to 2.5. 

We started with code a bit like this:

```
const foos = 'abc';
computed('model.@each', foos, function() {})
```

And mutated to:

```
const foos = ['abc', 'def'];
// !!! -> `foos` not properly tracking because it is now an array, not a string. 
computed('model.@each', foos, function() {})
```

Then we started the 2.4 -> 2.5 update in our app.

In 2.5, Ember started protecting from this error by checking `typeof` for dependencies and asserting if you passed other types. It was a little rough to track down with only "A computed property key must be a string" as a guide. 

This PR updates the assertion with a tiny bit more debugging data.