### PR TITLE
Update a test to fail #14843

### DIFF
--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -142,17 +142,23 @@ export function arrayContentDidChange(array, startIdx, removeAmt, addAmt) {
   let cache = meta && meta.readableCache();
 
   if (cache) {
+    let length = get(array, 'length') + removeAmt - addAmt;
     if (cache.firstObject !== undefined &&
-        objectAt(array, 0) !== cacheFor.get(cache, 'firstObject')) {
+        ((startIdx === 0 && (addAmt > 0 || removeAmt > 0)) ||
+        (startIdx <= -length && (addAmt > 0 || removeAmt > 0)))) {
       propertyWillChange(array, 'firstObject');
       propertyDidChange(array, 'firstObject');
     }
+
     if (cache.lastObject !== undefined &&
-        objectAt(array, get(array, 'length') - 1) !== cacheFor.get(cache, 'lastObject')) {
+        ((startIdx >= length && addAmt > 0) ||
+        (startIdx >= 0 && (startIdx + removeAmt >= length)) ||
+        (startIdx < 0 && (removeAmt >= -startIdx)))) {
       propertyWillChange(array, 'lastObject');
       propertyDidChange(array, 'lastObject');
     }
   }
+
   return array;
 }
 

--- a/packages/ember-runtime/tests/suites/mutable_array/insertAt.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/insertAt.js
@@ -135,10 +135,21 @@ suite.test('[A,B,C].insertAt(1,X) => [A,X,B,C] + notify', function() {
   let after  = [before[0], item, before[1], before[2]];
   let obj = this.newObject(before);
   let observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
+  let objectAtCalls = [];
+
+  let objectAt = obj.objectAt;
+  obj.objectAt = (ix) => {
+    objectAtCalls.push(ix);
+    return objectAt.call(obj, ix);
+  }
 
   obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
 
+  objectAtCalls.splice(0, objectAtCalls.length);
+
   obj.insertAt(1, item);
+
+  deepEqual(objectAtCalls, [], 'objectAt is not called when only inserting items');
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(get(obj, 'length'), after.length, 'length');


### PR DESCRIPTION
Update a test to fail #14843 and provide example code to illustrate the change suggested in that issue.

Before this can be merged we'd need to decide to deprecate the current semantics of `firstObject` and `lastObject`.  The trade-off is between having `objectAt` called in nearly every case for array mutations, or not detecting that `[A, B].insertAt(0, A)` does not change `firstObject`.

If that tradeoff is made, we should probably feature flag & deprecate the existing behaviour.