### PR TITLE
[BUGFIX release] Ensure Ember.Test globals setup when including ember-testing.js

### DIFF
--- a/broccoli/concat-bundle.js
+++ b/broccoli/concat-bundle.js
@@ -4,7 +4,7 @@
 const concat = require('broccoli-concat');
 
 module.exports = function(tree, options) {
-  let { outputFile, hasBootstrap } = options;
+  let { outputFile, hasBootstrap, footer } = options;
 
   if (typeof hasBootstrap !== 'boolean') {
     hasBootstrap = true;
@@ -16,6 +16,10 @@ module.exports = function(tree, options) {
     footerFiles = ['bootstrap']
   }
 
+  if (!footer) {
+    footer = '';
+  }
+
   return concat(tree, {
     header: '(function() {',
     outputFile: outputFile,
@@ -23,6 +27,6 @@ module.exports = function(tree, options) {
     footerFiles: footerFiles,
     inputFiles: ['**/*'],
     annotation: outputFile,
-    footer: '}());'
+    footer: footer + '\n}());'
   });
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -6,6 +6,7 @@
 //
 // DISABLE_ES3=true DISABLE_JSCS=true DISABLE_JSHINT=true DISABLE_MIN=true DISABLE_DEREQUIRE=true ember serve --environment=production
 
+const stripIndent = require('common-tags').stripIndent;
 const MergeTrees = require('broccoli-merge-trees');
 const babelHelpers = require('./broccoli/babel-helpers');
 const bootstrapModule = require('./broccoli/bootstrap-modules');
@@ -275,8 +276,7 @@ module.exports = function(options) {
     license,
     loader,
     emberTestingAMD,
-    nodeModule,
-    bootstrapModule('ember-testing')
+    nodeModule
   ]);
 
   let emberTestsBundle = new MergeTrees([
@@ -300,7 +300,15 @@ module.exports = function(options) {
   });
 
   emberTestingBundle = concat(emberTestingBundle, {
-    outputFile: 'ember-testing.js'
+    outputFile: 'ember-testing.js',
+    hasBootstrap: false,
+    footer: stripIndent`
+      var testing = requireModule('ember-testing');
+      Ember.Test = testing.Test;
+      Ember.Test.Adapter = testing.Adapter;
+      Ember.Test.QUnitAdapter = testing.QUnitAdapter;
+      Ember.setupForTesting = testing.setupForTesting;
+    `
   });
 
   let prodDist = [];

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ function add(paths, name, path) {
 
 add(paths, 'prod',  'vendor/ember/ember.prod.js');
 add(paths, 'debug', 'vendor/ember/ember.debug.js');
+add(paths, 'testing', 'vendor/ember/ember-testing.js');
 add(paths, 'jquery', 'vendor/ember/jquery/jquery.js');
 
 add(absolutePaths, 'templateCompiler', __dirname + '/dist/ember-template-compiler.js');


### PR DESCRIPTION
Addressing one part of https://github.com/ember-cli/ember-cli/issues/6870.

After this, it looks like there are other errors that pop-up, but those will be handled in a separate PR.