### PR TITLE
Small refactor of tracking pending requests in acceptance tests

### DIFF
--- a/packages/ember-testing/lib/helpers/wait.js
+++ b/packages/ember-testing/lib/helpers/wait.js
@@ -5,7 +5,7 @@
 import { checkWaiters } from '../test/waiters';
 import { RSVP } from 'ember-runtime';
 import { run } from 'ember-metal';
-import { pendingRequests } from '../test/pending_requests';
+import { checkPendingRequests } from '../test/pending_requests';
 
 /**
   Causes the run loop to process any pending events. This is used to ensure that
@@ -45,7 +45,7 @@ export default function wait(app, value) {
       if (routerIsLoading) { return; }
 
       // 2. If there are pending Ajax requests, keep polling
-      if (pendingRequests()) { return; }
+      if (checkPendingRequests()) { return; }
 
       // 3. If there are scheduled timers or we are inside of a run loop, keep polling
       if (run.hasScheduledTimers() || run.currentRunLoop) { return; }

--- a/packages/ember-testing/lib/test/pending_requests.js
+++ b/packages/ember-testing/lib/test/pending_requests.js
@@ -1,22 +1,17 @@
-let requests = [];
+let pendingRequestsCounter = 0;
 
-export function pendingRequests() {
-  return requests.length;
+export function checkPendingRequests() {
+  return pendingRequestsCounter > 0;
 }
 
 export function clearPendingRequests() {
-  requests.length = 0;
+  pendingRequestsCounter = 0;
 }
 
-export function incrementPendingRequests(_, xhr) {
-  requests.push(xhr);
+export function incrementPendingRequests() {
+  pendingRequestsCounter++;
 }
 
-export function decrementPendingRequests(_, xhr) {
-  for (let i = 0; i < requests.length; i++) {
-    if (xhr === requests[i]) {
-      requests.splice(i, 1);
-      break;
-    }
-  }
+export function decrementPendingRequests() {
+  pendingRequestsCounter--;
 }

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -21,7 +21,7 @@ import { Application as EmberApplication } from 'ember-application';
 import { compile } from 'ember-template-compiler';
 
 import {
-  pendingRequests,
+  checkPendingRequests,
   incrementPendingRequests,
   clearPendingRequests
 } from '../test/pending_requests';
@@ -887,7 +887,7 @@ QUnit.test('currentRouteName for \'/posts/new\'', function() {
   });
 });
 
-QUnit.module('ember-testing pendingRequests', {
+QUnit.module('ember-testing checkPendingRequests', {
   setup() {
     setupApp();
   },
@@ -897,39 +897,39 @@ QUnit.module('ember-testing pendingRequests', {
   }
 });
 
-QUnit.test('pendingRequests is maintained for ajaxSend and ajaxComplete events', function() {
-  equal(pendingRequests(), 0);
+QUnit.test('checkPendingRequests is maintained for ajaxSend and ajaxComplete events', function() {
+  equal(checkPendingRequests(), false);
   var xhr = { some: 'xhr' };
   jQuery(document).trigger('ajaxSend', xhr);
-  equal(pendingRequests(), 1, 'Ember.Test.pendingRequests was incremented');
+  equal(checkPendingRequests(), true, 'There is pending requests');
   jQuery(document).trigger('ajaxComplete', xhr);
-  equal(pendingRequests(), 0, 'Ember.Test.pendingRequests was decremented');
+  equal(checkPendingRequests(), false, 'There isn\'t any pending request');
 });
 
-QUnit.test('pendingRequests is ignores ajaxComplete events from past setupForTesting calls', function() {
-  equal(pendingRequests(), 0);
+QUnit.test('checkPendingRequests is ignores ajaxComplete events from past setupForTesting calls', function() {
+  equal(checkPendingRequests(), false);
   var xhr = { some: 'xhr' };
   jQuery(document).trigger('ajaxSend', xhr);
-  equal(pendingRequests(), 1, 'Ember.Test.pendingRequests was incremented');
+  equal(checkPendingRequests(), true, 'There is pending requests');
 
   run(function() {
     setupForTesting();
   });
-  equal(pendingRequests(), 0, 'Ember.Test.pendingRequests was reset');
+  equal(checkPendingRequests(), false, 'Pending requests have been reseted');
 
   var altXhr = { some: 'more xhr' };
   jQuery(document).trigger('ajaxSend', altXhr);
-  equal(pendingRequests(), 1, 'Ember.Test.pendingRequests was incremented');
+  equal(checkPendingRequests(), true, 'There is pending requests');
   jQuery(document).trigger('ajaxComplete', xhr);
-  equal(pendingRequests(), 1, 'Ember.Test.pendingRequests is not impressed with your unexpected complete');
+  equal(checkPendingRequests(), true, 'checkPendingRequests is not impressed with your unexpected complete');
 });
 
-QUnit.test('pendingRequests is reset by setupForTesting', function() {
+QUnit.test('checkPendingRequests is reset by setupForTesting', function() {
   incrementPendingRequests();
   run(function() {
     setupForTesting();
   });
-  equal(pendingRequests(), 0, 'pendingRequests is reset');
+  equal(checkPendingRequests(), false, 'The pending requests have been reseted');
 });
 
 QUnit.module('ember-testing async router', {


### PR DESCRIPTION
There is no need of putting requests in an array, we're only interested
in the amount of them.

I don't know how to label the PR since it's not a bugfix really.

/cc @rwjblue 