### PR TITLE
[DEPRECATION] Remove ember-metal/map

### DIFF
--- a/packages/ember-metal/lib/map.js
+++ b/packages/ember-metal/lib/map.js
@@ -20,6 +20,7 @@
   Map is mocked out to look like an Ember object, so you can do
   `Ember.Map.create()` for symmetry with other Ember classes.
 */
+import { deprecate } from 'ember-debug';
 import { guidFor } from 'ember-utils';
 
 function missingFunction(fn) {
@@ -62,8 +63,16 @@ function copyMap(original, newObject) {
   @constructor
   @private
 */
-function OrderedSet() {
+function OrderedSet(hideDeprecation = false) {
   if (this instanceof OrderedSet) {
+    deprecate(
+      'OrderedSet is being deprecated.',
+      hideDeprecation, {
+        id: 'ember-metal.map',
+        until: '2.16.0',
+        url: 'http://emberjs.com/deprecations/v2.x/#toc_ember-map'
+      }
+    );
     this.clear();
   } else {
     missingNew('OrderedSet');
@@ -76,10 +85,10 @@ function OrderedSet() {
   @return {Ember.OrderedSet}
   @private
 */
-OrderedSet.create = function() {
+OrderedSet.create = function(hideDeprecation = false) {
   let Constructor = this;
 
-  return new Constructor();
+  return new Constructor(hideDeprecation);
 };
 
 OrderedSet.prototype = {
@@ -236,9 +245,18 @@ OrderedSet.prototype = {
   @private
   @constructor
 */
-function Map() {
+function Map(hideDeprecation = false) {
   if (this instanceof Map) {
-    this._keys = OrderedSet.create();
+    deprecate(
+      'Map is being deprecated.',
+      hideDeprecation, {
+        id: 'ember-metal.map',
+        until: '2.16.0',
+        url: 'http://emberjs.com/deprecations/v2.x/#toc_ember-map'
+      }
+    );
+    this._keys = OrderedSet.create(true);
+    this._keys._silenceRemoveDeprecation = true;
     this._values = Object.create(null);
     this.size = 0;
   } else {
@@ -415,7 +433,7 @@ Map.prototype = {
     @param {*} [options.defaultValue]
 */
 function MapWithDefault(options) {
-  this._super$constructor();
+  this._super$constructor(true);
   this.defaultValue = options.defaultValue;
 }
 
@@ -429,10 +447,18 @@ function MapWithDefault(options) {
   @private
 */
 MapWithDefault.create = function(options) {
+  deprecate(
+    'MapWithDefault is being deprecated.',
+    false, {
+      id: 'ember-metal.map',
+      until: '2.16.0',
+      url: 'http://emberjs.com/deprecations/v2.x/#toc_ember-map'
+    }
+  );
   if (options) {
     return new MapWithDefault(options);
   } else {
-    return new Map();
+    return new Map(true);
   }
 };
 

--- a/packages/ember-metal/tests/is_empty_test.js
+++ b/packages/ember-metal/tests/is_empty_test.js
@@ -27,14 +27,16 @@ QUnit.test('Ember.isEmpty', function() {
 });
 
 QUnit.test('Ember.isEmpty Ember.Map', function() {
-  let map = new Map();
+  let map = null;
+  ignoreDeprecation(() => { map = new Map() });
   equal(true, isEmpty(map), 'Empty map is empty');
   map.set('foo', 'bar');
   equal(false, isEmpty(map), 'Map is not empty');
 });
 
 QUnit.test('Ember.isEmpty Ember.OrderedSet', function() {
-  let orderedSet = new OrderedSet();
+  let orderedSet = null;
+  ignoreDeprecation(() => orderedSet = new OrderedSet());
   equal(true, isEmpty(orderedSet), 'Empty ordered set is empty');
   orderedSet.add('foo');
   equal(false, isEmpty(orderedSet), 'Ordered set is not empty');

--- a/packages/ember-metal/tests/map_test.js
+++ b/packages/ember-metal/tests/map_test.js
@@ -16,7 +16,7 @@ function testMap(nameAndFunc) {
       number = 42;
       string = 'foo';
 
-      map = nameAndFunc[1].create();
+      ignoreDeprecation(() => map = nameAndFunc[1].create());
     }
   });
 
@@ -47,6 +47,12 @@ function testMap(nameAndFunc) {
   (function() {
     unboundThis = this;
   }());
+
+  QUnit.test('is deprecated', function() {
+    expectDeprecation(() => {
+      nameAndFunc[1].create();
+    }, `${nameAndFunc[0]} is being deprecated.`);
+  });
 
   QUnit.test('set', function() {
     map.set(object, 'winning');
@@ -146,7 +152,8 @@ function testMap(nameAndFunc) {
     map.set(number, 'winning');
     map.set(string, 'winning');
 
-    let map2 = map.copy();
+    let map2 = null;
+    ignoreDeprecation(() => map2 = map.copy());
 
     map2.set(object, 'losing');
     map2.set(number, 'losing');
@@ -170,7 +177,8 @@ function testMap(nameAndFunc) {
     map.set(number, 'winning');
     map.set(string, 'winning');
 
-    let map2 = map.copy();
+    let map2 = null;
+    ignoreDeprecation(() => map2 = map.copy());
 
     map2.delete(object);
     map2.delete(number);
@@ -202,7 +210,8 @@ function testMap(nameAndFunc) {
     equal(map.size, 2);
 
     //Check copy
-    let copy = map.copy();
+    let copy = null;
+    ignoreDeprecation(() => copy = map.copy());
     equal(copy.size, 2);
 
     //Remove a key twice
@@ -451,10 +460,13 @@ for (let i = 0;  i < varieties.length;  i++) {
 QUnit.module('MapWithDefault - default values');
 
 QUnit.test('Retrieving a value that has not been set returns and sets a default value', function() {
-  let map = MapWithDefault.create({
-    defaultValue(key) {
-      return [key];
-    }
+  let map = null;
+  ignoreDeprecation(() => {
+    map = MapWithDefault.create({
+      defaultValue(key) {
+        return [key];
+      }
+    });
   });
 
   let value = map.get('ohai');
@@ -464,7 +476,8 @@ QUnit.test('Retrieving a value that has not been set returns and sets a default 
 });
 
 QUnit.test('Map.prototype.constructor', function() {
-  let map = new Map();
+  let map = null
+  ignoreDeprecation(() => map = new Map());
   equal(map.constructor, Map);
 });
 
@@ -483,16 +496,20 @@ QUnit.test('MapWithDefault.prototype.constructor', function() {
 });
 
 QUnit.test('Copying a MapWithDefault copies the default value', function() {
-  let map = MapWithDefault.create({
-    defaultValue(key) {
-      return [key];
-    }
+  let map = null;
+  ignoreDeprecation(() => {
+    map = MapWithDefault.create({
+      defaultValue(key) {
+        return [key];
+      }
+    });
   });
 
   map.set('ohai', 1);
   map.get('bai');
 
-  let map2 = map.copy();
+  let map2 = null;
+  ignoreDeprecation(() => map2 = map.copy())
 
   equal(map2.get('ohai'), 1);
   deepEqual(map2.get('bai'), ['bai']);
@@ -515,14 +532,14 @@ QUnit.module('OrderedSet', {
     number = 42;
     string = 'foo';
 
-    map = OrderedSet.create();
+    ignoreDeprecation(() => map = OrderedSet.create());
   }
 });
 
 QUnit.test('OrderedSet() without `new`', function() {
   QUnit.throws(() => {
     // jshint newcap:false
-    OrderedSet();
+    ignoreDeprecation(() => OrderedSet());
   }, /Constructor OrderedSet requires 'new'/);
 });
 


### PR DESCRIPTION
`ember-metal/map` contains three private classes `OrderedSet`, `Map`,
`MapWithDefault`. They were not used anywhere in the codebase except for tests
or reexports, so they are being deprecated.

Ember Data team has been removing their usages.

Added emberjs/website#2884.

Fixes #15041
Fixes https://github.com/emberjs/ember.js/issues/13815