### PR TITLE
Fix misspellings

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -775,7 +775,7 @@ const Application = Engine.extend({
     Boot a new instance of `Ember.ApplicationInstance` for the current
     application and navigate it to the given `url`. Returns a `Promise` that
     resolves with the instance when the initial routing and rendering is
-    complete, or rejects with any error that occured during the boot process.
+    complete, or rejects with any error that occurred during the boot process.
 
     When `autoboot` is disabled, calling `visit` would first cause the
     application to boot, which runs the application initializers.
@@ -800,7 +800,7 @@ const Application = Engine.extend({
     result in unexpected behavior.
 
     For example, booting the instance in the full browser environment
-    while specifying a foriegn `document` object (e.g. `{ isBrowser: true,
+    while specifying a foreign `document` object (e.g. `{ isBrowser: true,
     document: iframe.contentDocument }`) does not work correctly today,
     largely due to Ember's jQuery dependency.
 
@@ -903,7 +903,7 @@ const Application = Engine.extend({
 
     This setup allows you to run the routing layer of your Ember app in a server
     environment using Node.js and completely disable rendering. This allows you
-    to simulate and discover the resources (i.e. AJAX requests) needed to fufill
+    to simulate and discover the resources (i.e. AJAX requests) needed to fulfill
     a given request and eagerly "push" these resources to the client.
 
     ```app/initializers/network-service.js
@@ -911,7 +911,7 @@ const Application = Engine.extend({
     import NodeNetworkService from 'app/services/network/node';
 
     // Inject a (hypothetical) service for abstracting all AJAX calls and use
-    // the appropiate implementaion on the client/server. This also allows the
+    // the appropriate implementation on the client/server. This also allows the
     // server to log all the AJAX calls made during a particular request and use
     // that for resource-discovery purpose.
 

--- a/packages/ember-application/tests/system/visit_test.js
+++ b/packages/ember-application/tests/system/visit_test.js
@@ -256,7 +256,7 @@ QUnit.test('visit() follows redirects', function(assert) {
   });
 });
 
-QUnit.test('visit() rejects if an error occured during a transition', function(assert) {
+QUnit.test('visit() rejects if an error occurred during a transition', function(assert) {
   run(() => {
     createApplication();
 

--- a/packages/ember-glimmer/lib/syntax/input.js
+++ b/packages/ember-glimmer/lib/syntax/input.js
@@ -54,7 +54,7 @@ function buildTextFieldSyntax(params, hash, builder) {
   {{input value=searchWord}}
   ```
 
-  In this example, the inital value in the `<input />` will be set to the value of `searchWord`.
+  In this example, the initial value in the `<input />` will be set to the value of `searchWord`.
   If the user changes the text, the value of `searchWord` will also be updated.
 
   ### Actions

--- a/packages/ember-glimmer/lib/template_registry.js
+++ b/packages/ember-glimmer/lib/template_registry.js
@@ -1,4 +1,4 @@
-// STATE within a module is frowned apon, this exists
+// STATE within a module is frowned upon, this exists
 // to support Ember.TEMPLATES but shield ember internals from this legacy
 // global API.
 let TEMPLATES = {};

--- a/packages/ember-glimmer/tests/integration/event-dispatcher-test.js
+++ b/packages/ember-glimmer/tests/integration/event-dispatcher-test.js
@@ -125,7 +125,7 @@ moduleFor('EventDispatcher#setup', class extends RenderingTest {
     this.dispatcher = this.owner.lookup('event_dispatcher:main');
   }
 
-  ['@test additonal events can be specified'](assert) {
+  ['@test additional events can be specified'](assert) {
     this.dispatcher.setup({ myevent: 'myEvent' });
 
     this.registerComponent('x-foo', {

--- a/packages/ember-metal/tests/chains_test.js
+++ b/packages/ember-metal/tests/chains_test.js
@@ -22,7 +22,7 @@ QUnit.test('finishChains should properly copy chains from prototypes to instance
   ok(peekMeta(obj) !== peekMeta(childObj).readableChains(), 'The chains object is copied');
 });
 
-QUnit.test('does not observe primative values', function(assert) {
+QUnit.test('does not observe primitive values', function(assert) {
   let obj = {
     foo: { bar: 'STRING' }
   };

--- a/packages/ember-metal/tests/main_test.js
+++ b/packages/ember-metal/tests/main_test.js
@@ -21,7 +21,7 @@ QUnit.test('SEMVER_REGEX properly validates and invalidates version numbers', fu
     equal(SEMVER_REGEX.test(versionString), expectedResult);
   }
 
-  // Postive test cases
+  // Positive test cases
   validateVersionString('1.11.3', true);
   validateVersionString('1.0.0-beta.16.1', true);
   validateVersionString('1.12.1+canary.aba1412', true);

--- a/packages/ember-routing/lib/ext/controller.js
+++ b/packages/ember-routing/lib/ext/controller.js
@@ -40,10 +40,10 @@ ControllerMixin.reopen({
    the sanity of future travelers:
 
    * `inactive` - This state is used when this controller instance is not part of the active
-     route heirarchy. Set in `Ember.Route.prototype._reset` (a `router.js` microlib hook) and
+     route hierarchy. Set in `Ember.Route.prototype._reset` (a `router.js` microlib hook) and
      `Ember.Route.prototype.actions.finalizeQueryParamChange`.
    * `active` - This state is used when this controller instance is part of the active
-     route heirarchy. Set in `Ember.Route.prototype.actions.finalizeQueryParamChange`.
+     route hierarchy. Set in `Ember.Route.prototype.actions.finalizeQueryParamChange`.
    * `allowOverrides` - This state is used in `Ember.Route.prototype.setup` (`route.js` microlib hook).
 
     @method _qpDelegate

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -802,7 +802,7 @@ const EmberRouter = EmberObject.extend(Evented, {
     }
 
     // We need to fully scope queryParams so that we can create one object
-    // that represents both pased in queryParams and ones that aren't changed
+    // that represents both passed-in queryParams and ones that aren't changed
     // from the active transition.
     this._fullyScopeQueryParams(targetRouteName, models, _queryParams);
     this._fullyScopeQueryParams(targetRouteName, models, unchangedQPs);

--- a/packages/ember-routing/lib/utils.js
+++ b/packages/ember-routing/lib/utils.js
@@ -50,7 +50,7 @@ export function stashParamNames(router, handlerInfos) {
 }
 
 function _calculateCacheValuePrefix(prefix, part) {
-  // calculates the dot seperated sections from prefix that are also
+  // calculates the dot separated sections from prefix that are also
   // at the start of part - which gives us the route name
 
   // given : prefix = site.article.comments, part = site.article.id

--- a/packages/ember-runtime/lib/string_registry.js
+++ b/packages/ember-runtime/lib/string_registry.js
@@ -1,4 +1,4 @@
-// STATE within a module is frowned apon, this exists
+// STATE within a module is frowned upon, this exists
 // to support Ember.STRINGS but shield ember internals from this legacy global
 // API.
 let STRINGS = {};

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -243,7 +243,7 @@ CoreObject.PrototypeMixin = Mixin.create({
   */
   init() {},
 
-  [POST_INIT]() { }, // Private, and only for didInitAttrs willRecieveAttrs
+  [POST_INIT]() { }, // Private, and only for didInitAttrs willReceiveAttrs
 
   __defineNonEnumerable(property) {
     Object.defineProperty(this, property.name, property.descriptor);

--- a/packages/ember/tests/controller_test.js
+++ b/packages/ember/tests/controller_test.js
@@ -15,7 +15,7 @@ moduleFor('Template scoping examples', class extends ApplicationTestCase {
     this.add('controller:index', Controller.extend({
       actions: {
         componentAction() {
-          assert.ok(true, 'controller recieved the action');
+          assert.ok(true, 'controller received the action');
         }
       }
     }));

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -3697,7 +3697,7 @@ QUnit.test('Doesnt swallow exception thrown from willTransition', function() {
 
   throws(() => {
     run(() => router.handleURL('/other'));
-  }, /boom/, 'expected an exception that didn\'t happen');
+  }, /boom/, 'expected an exception but none was thrown');
 });
 
 QUnit.test('Exception if outlet name is undefined in render and disconnectOutlet', function(assert) {

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -3697,7 +3697,7 @@ QUnit.test('Doesnt swallow exception thrown from willTransition', function() {
 
   throws(() => {
     run(() => router.handleURL('/other'));
-  }, /boom/, 'expected an exception that didnt happen');
+  }, /boom/, 'expected an exception that didn\'t happen');
 });
 
 QUnit.test('Exception if outlet name is undefined in render and disconnectOutlet', function(assert) {

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -62,7 +62,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
             return;
           });
         } else if (indexModelCount === 3) {
-          assert.deepEqual(params, { omg: 'hello' }, 'Model hook reruns even if the previous one didnt finish');
+          assert.deepEqual(params, { omg: 'hello' }, 'Model hook reruns even if the previous one didn\'t finish');
         }
       }
     }));

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -558,7 +558,7 @@ QUnit.test('Handled errors that bubble can be handled at a higher level', functi
       error(err) {
         step(3, 'MomRoute#error');
 
-        equal(err, handledError, 'error handled and rebubbled is handleable at heigher route');
+        equal(err, handledError, 'error handled and rebubbled is handleable at higher route');
       }
     }
   });


### PR DESCRIPTION
This PR fixes a few misspellings.

I used the [misspellings](https://pypi.python.org/pypi/misspellings) tool to locate these:

```
$ find . | misspellings -f -
```