### PR TITLE
Fix access to service:-document in ember-engines

### DIFF
--- a/packages/ember-application/lib/system/engine-instance.js
+++ b/packages/ember-application/lib/system/engine-instance.js
@@ -188,7 +188,8 @@ const EngineInstance = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixi
       'router:main',
       P`-bucket-cache:main`,
       '-view-registry:main',
-      `renderer:-${env.isInteractive ? 'dom' : 'inert'}`
+      `renderer:-${env.isInteractive ? 'dom' : 'inert'}`,
+      'service:-document'
     ];
 
     singletons.forEach(key => this.register(key, parent.lookup(key), { instantiate: false }));

--- a/packages/ember-application/tests/system/application_instance_test.js
+++ b/packages/ember-application/tests/system/application_instance_test.js
@@ -139,7 +139,7 @@ QUnit.test('unregistering a factory clears all cached instances of that factory'
 });
 
 QUnit.test('can build and boot a registered engine', function(assert) {
-  assert.expect(10);
+  assert.expect(11);
 
   let ChatEngine = Engine.extend();
   let chatEngineInstance;
@@ -174,7 +174,8 @@ QUnit.test('can build and boot a registered engine', function(assert) {
         'router:main',
         P`-bucket-cache:main`,
         '-view-registry:main',
-        '-environment:main'
+        '-environment:main',
+        'service:-document'
       ];
 
       let env = appInstance.lookup('-environment:main');


### PR DESCRIPTION
Run into some problems trying to get some code to render server-side. I think the problem was related to `ember-wormhole`, although the addon currently doesn't have a good way to work in server-side at all, but it still required a reference to the document service to be able to initialize.

Although this can be fixed in ember-wormhole, I think it's good idea to allow components in engines to get access to the document if they need to and cover future problems.

Not sure whether enhancing the application instance test is enough, but not sure where to put a test, which says components in `ember-engines` must have access to the `service:-document` in applications, which uses `ember-cli-fastboot`.