### PR TITLE
Fix documentation

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1854,7 +1854,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     export default Router;
     ```
 
-    ```app/routes/comments.js
+    ```app/routes/post/comments.js
     import Ember from 'ember';
 
     export default Ember.Route.extend({


### PR DESCRIPTION
This is the Router used in the documentation:
```
     Router.map(function() {
       this.route('post', { path: '/posts/:post_id' }, function() {
         this.route('comments');
       });
     });
```