### PR TITLE
[Perf] Map/MapWithDefault/OrderedSet allocation

### DIFF
--- a/packages/ember-metal/tests/map_test.js
+++ b/packages/ember-metal/tests/map_test.js
@@ -24,9 +24,7 @@ function testMap(nameAndFunc) {
     theMap = theMap || map;
 
     let length = 0;
-    theMap.forEach(function() {
-      length++;
-    });
+    theMap.forEach(() => length++);
 
     equal(length, expected, 'map should contain ' + expected + ' items');
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2299,14 +2299,14 @@ error@^7.0.0:
     string-template "~0.2.1"
     xtend "~4.0.0"
 
-es5-ext@^0.10.14, es5-ext@^0.10.7, es5-ext@^0.10.9, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.7:
+es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
   version "0.10.14"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.14.tgz#625bc9ab9cac0f6fb9dc271525823d1800b3d360"
   dependencies:
     es6-iterator "2"
     es6-symbol "~3.1"
 
-es5-ext@~0.10.11:
+es5-ext@^0.10.7, es5-ext@~0.10.11, es5-ext@~0.10.2, es5-ext@~0.10.7:
   version "0.10.12"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.12.tgz#aa84641d4db76b62abba5e45fd805ecbab140047"
   dependencies:
@@ -2350,19 +2350,19 @@ es6-set@~0.1.3:
     es6-symbol "3"
     event-emitter "~0.3.4"
 
-es6-symbol@3, es6-symbol@^3.0.2, es6-symbol@^3.1, es6-symbol@^3.1.1, es6-symbol@~3.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-
-es6-symbol@~3.1.0:
+es6-symbol@3, es6-symbol@~3.1, es6-symbol@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.0.tgz#94481c655e7a7cad82eba832d97d5433496d7ffa"
   dependencies:
     d "~0.1.1"
     es5-ext "~0.10.11"
+
+es6-symbol@^3.0.2, es6-symbol@^3.1, es6-symbol@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
 
 es6-weak-map@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
# OrderedSet/Map/MapWithDefault improvements:

ember-data relies heavily on these structures, although improvements have been made to them. They can be tuned further, especially when we look at the most common usage patterns within ember apps.

This may also serve as a useful metric/benchmark for our JS runtime friends, as I suspect native Set could outperform our sets.


*note: work is also being done to remove some unneeded usage of them within ember-data, these efforts aim to be complementary*

Benchmarks: https://github.com/stefanpenner/perf-scratch/blob/master/sets/index.md

I welcome input, ideas, feedback etc.

A common distribution for allocation of OrderedSet sizes is:
```
size: 0 = 2763 <— this case is improved with the first commit
size: 1 = 4543 <— this case is improved with the second commit
size: 2 = 176  <— this may be next
size: 3 = 38
size: 4 = 40
size: 5 = 32
size: 6 = 6
size: 7 = 7
size: 9 = 2
size: 10 = 3
size: 24 = 3
size: 77 = 1
```

Plan:

- [x] reduce allocation cost (empty sets/map are common, but reducing the cost of alloc will improve all usages)
- [x] reduce the cost of 1 entries
- [ ] reduce the cost of 2 entries (should we?)
- [x] reduce the cost of small N sets (array is faster then the `{}` for lookup for small `n`)
- [x] fix NaN test

## Reduce the cost of Alloc

The first commit focuses on ensuring an OrderdSet can be allocated quickly. As it is common for the OrderedSet to be allocated, and left empty for some period of time (or forever).

* remove `new` guards in prod builds (3x allocation improvement)
* lazily allocate internal backing structures (alloc/usage of empty maps/OrderedSets is quite common and should be as fast as possible)
* fix inheritance issue with private Map.prototype.copy

```
alloc
benching...
  new FOSet() ... 54,465,109.11 op/s <— with these improvements (10 -> 11x)
  new OSet() ..... 5,341,231.25 op/s
```

benchmarks that helped inform this  https://github.com/stefanpenner/perf-scratch/blob/master/sets/index.md

----

## reduce the cost of very small 1 or 2 entry sets

[Perf] OrderdSet storage

Select appropriate backing storage based on size.

* for 1 element, use a slot on the ordered set
* for > 1 elements, use an array
* for > 50 elements, finally add the “presence set”

Allocating an array, to store 1 element is much slower (and quite a common use-case) compared to storing the property on the object itself

The presence set only being added after a larger threshold is due to:

For small N, checking existence is faster in an [] then in an {};
But for large N, checking existing (by doing a linear scan of [], is slower then {});

## Some benchmarks:

Create a data structure, and add N duplicates:

```
  duplicate [].push 1 ................ 23,309,335.28 op/s <- native array
  duplicate new Set().add 1 ........... 8,024,988.30 op/s <- native set
  duplicate new OSet().add 1 .......... 2,207,787.67 op/s <— before this PR
  duplicate new FOSet().add 1 ........ 42,111,612.80 op/s <— this PR
```

```
  duplicate [].push 10 ............... 10,647,490.26 op/s <- native array
  duplicate new Set().add 10 .......... 2,397,676.90 op/s <- native set
  duplicate new OSet().add 10 ........... 913,711.30 op/s <— before this PR
  duplicate new FOSet().add 10 ....... 17,377,505.55 op/s <— this PR
```

```
  duplicate [].push 100 ............... 1,683,452.98 op/s <- native array
  duplicate new Set().add 100 ........... 322,648.04 op/s <- native set
  duplicate new OSet().add 100 .......... 137,503.52 op/s <- before this PR
  duplicate new FOSet().add 100 ....... 3,553,678.44 op/s <— this PR
```

```
  duplicate [].push 10000 ................ 18,080.99 op/s <- native array
  duplicate new Set().add 10000 ........... 3,378.56 op/s <- native set
  duplicate new OSet().add 10000 .......... 1,513.17 op/s <- before this PR
  duplicate new FOSet().add 10000 ........ 44,523.74 op/s <— this PR
```

Create a data structure, and insert N unique entries (still needs some tuning)

```
  unique [].push 1 ................... 14,525,819.60 op/s <— native array
  unique new Set().add 1 .............. 4,714,445.72 op/s <— native set
  unique new OSet().add 1 ............. 2,196,971.03 op/s <- before this PR
  unique new FOSet().add 1 ........... 36,451,178.71 op/s <- this PR

  unique [].push 10 ................... 2,181,391.29 op/s <- native array
  unique new Set().add 10 ............... 458,479.29 op/s <— native set
  unique new OSet().add 10 .............. 886,216.65 op/s <— before this PR
  unique new FOSet().add 10 ........... 3,377,944.25 op/s <— this PR

  unique [].push 20 ..................... 750,840.21 op/s <— native array
  unique new Set().add 20 ............... 251,081.77 op/s <— native set
  unique new OSet().add 20 .............. 515,040.19 op/s <- before this PR
  unique new FOSet().add 20 ........... 1,076,916.42 op/s <- with this PR

  unique [].push 49 ..................... 177,299.25 op/s <- native array
  unique new Set().add 49 ............... 110,535.58 op/s <- native set
  unique new OSet().add 49 .............. 261,810.15 op/s <- before this PR
  unique new FOSet().add 49 ............. 266,532.57 op/s <- with this PR

  unique [].push 50 ..................... 174,298.26 op/s <- native array
  unique new Set().add 50 ............... 103,350.69 op/s <- native set
  unique new OSet().add 50 .............. 249,180.44 op/s <- before this PR
  unique new FOSet().add 50 ............. 250,087.45 op/s <- with this PR

  unique [].push 99 ...................... 54,270.65 op/s <- native array
  unique new Set().add 99 ................ 53,783.22 op/s <- native set
  unique new OSet().add 99 .............. 133,492.70 op/s <- before this PR
  unique new FOSet().add 99 .............. 84,505.91 op/s <- with this PR  (needs investigation)

  unique [].push 100 ..................... 54,221.77 op/s <- native array
  unique new Set().add 100 ............... 50,366.35 op/s <- native set
  unique new OSet().add 100 ............. 135,261.16 op/s <- before this PR
  unique new FOSet().add 100 ............. 83,759.84 op/s <- with this PR  (needs investigation)

  unique [].push 1000 ....................... 668.25 op/s <- native array
  unique new Set().add 1000 ............... 5,846.43 op/s <- native set
  unique new OSet().add 1000 ............. 14,322.24 op/s <- before this PR
  unique new FOSet().add 1000 ............. 9,200.26 op/s <- with this PR (needs investigation)

  unique [].push 10000 ........................ 6.85 op/s <- native array
  unique new Set().add 10000 ................ 481.21 op/s <- native set
  unique new OSet().add 10000 ............. 1,449.85 op/s <- before this PR
  unique new FOSet().add 10000 .............. 946.43 op/s <— this PR (needs investigation)
```