### PR TITLE
[PERF/Correctness] Remove global didDefineProperty

### DIFF
--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -73,7 +73,8 @@ export {
 } from './property_events';
 export {
   defineProperty,
-  Descriptor
+  Descriptor,
+  _hasCachedComputedProperties
 } from './properties';
 export {
   watchKey,

--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -127,21 +127,20 @@ export function INHERITING_GETTER_FUNCTION(name) {
     become the explicit value of this property.
 */
 export function defineProperty(obj, keyName, desc, data, meta) {
-  let possibleDesc, existingDesc, watching, value;
-
   if (!meta) {
     meta = metaFor(obj);
   }
   let watchEntry = meta.peekWatching(keyName);
-  possibleDesc = obj[keyName];
-  existingDesc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
+  let possibleDesc = obj[keyName];
+  let existingDesc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
 
-  watching = watchEntry !== undefined && watchEntry > 0;
+  let watching = watchEntry !== undefined && watchEntry > 0;
 
   if (existingDesc) {
     existingDesc.teardown(obj, keyName);
   }
 
+  let value;
   if (desc instanceof Descriptor) {
     value = desc;
     if (MANDATORY_SETTER) {
@@ -158,7 +157,10 @@ export function defineProperty(obj, keyName, desc, data, meta) {
     } else {
       obj[keyName] = value;
     }
-    if (desc.setup) { desc.setup(obj, keyName); }
+
+    didDefineComputedProperty(obj.constructor);
+
+    if (typeof desc.setup === 'function') { desc.setup(obj, keyName); }
   } else {
     if (desc == null) {
       value = data;
@@ -199,10 +201,25 @@ export function defineProperty(obj, keyName, desc, data, meta) {
 
   // The `value` passed to the `didDefineProperty` hook is
   // either the descriptor or data, whichever was passed.
-  if (obj.didDefineProperty) { obj.didDefineProperty(obj, keyName, value); }
+  if (typeof obj.didDefineProperty === 'function') { obj.didDefineProperty(obj, keyName, value); }
 
   return this;
 }
+
+let hasCachedComputedProperties = false;
+export function _hasCachedComputedProperties() {
+  hasCachedComputedProperties = true;
+}
+
+function didDefineComputedProperty(constructor) {
+  if (hasCachedComputedProperties === false) { return; }
+  let cache = metaFor(constructor).readableCache();
+
+  if (cache && cache._computedProperties !== undefined) {
+    cache._computedProperties = undefined;
+  }
+}
+
 
 function handleBrokenPhantomDefineProperty(obj, keyName, desc) {
   // https://github.com/ariya/phantomjs/issues/11856

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -30,7 +30,8 @@ import {
   InjectedProperty,
   run,
   destroy,
-  descriptor
+  descriptor,
+  _hasCachedComputedProperties
 } from 'ember-metal';
 import ActionHandler from '../mixins/action_handler';
 import { validatePropertyInjections } from '../inject';
@@ -42,7 +43,6 @@ let schedule = run.schedule;
 let applyMixin = Mixin._apply;
 let finishPartial = Mixin.finishPartial;
 let reopen = Mixin.prototype.reopen;
-let hasCachedComputedProperties = false;
 
 export const POST_INIT = symbol('POST_INIT');
 
@@ -867,7 +867,7 @@ let ClassMixinProps = {
   },
 
   _computedProperties: computed(function() {
-    hasCachedComputedProperties = true;
+    _hasCachedComputedProperties();
     let proto = this.proto();
     let property;
     let properties = [];
@@ -953,18 +953,4 @@ ClassMixin.ownerConstructor = CoreObject;
 CoreObject.ClassMixin = ClassMixin;
 
 ClassMixin.apply(CoreObject);
-
-CoreObject.reopen({
-  didDefineProperty(proto, key, value) {
-    if (hasCachedComputedProperties === false) { return; }
-    if (value instanceof ComputedProperty) {
-      let cache = meta(this.constructor).readableCache();
-
-      if (cache && cache._computedProperties !== undefined) {
-        cache._computedProperties = undefined;
-      }
-    }
-  }
-});
-
 export default CoreObject;


### PR DESCRIPTION
* removes an extra mixin from all Object Hierarchies
* only runs when actually defining a CP if actually defining a new computed property.
* misc cleanup