### PR TITLE
Refactor guidFor to use WeakMap if present.

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "babel-plugin-transform-proto-to-assign": "^6.23.0",
     "babel-template": "^6.23.0",
-    "backburner.js": "^0.4.0",
+    "backburner.js": "github:rwjblue/backburner.js#peek-guid-check-in-dist",
     "broccoli-babel-transpiler": "next",
     "broccoli-concat": "^3.2.2",
     "broccoli-file-creator": "^1.1.1",

--- a/packages/ember-glimmer/lib/syntax/outlet.js
+++ b/packages/ember-glimmer/lib/syntax/outlet.js
@@ -245,7 +245,7 @@ class TopLevelOutletLayoutCompiler {
   compile(builder) {
     builder.wrapLayout(this.template.asLayout());
     builder.tag.static('div');
-    builder.attrs.static('id', guidFor(this));
+    builder.attrs.static('id', 'ember' + guidFor(this));
     builder.attrs.static('class', 'ember-view');
   }
 }

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -9,7 +9,8 @@ import {
   NAME_KEY,
   ROOT,
   wrap,
-  makeArray
+  makeArray,
+  HAS_NATIVE_WEAKMAP
 } from 'ember-utils';
 import {
   debugSeal,
@@ -490,7 +491,9 @@ export default class Mixin {
     }
     this.ownerConstructor = undefined;
     this._without = undefined;
-    this[GUID_KEY] = null;
+    if (!HAS_NATIVE_WEAKMAP) {
+      this[GUID_KEY] = null;
+    }
     this[NAME_KEY] = null;
     debugSeal(this);
   }

--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -1,4 +1,4 @@
-import { GUID_KEY } from 'ember-utils';
+import { peekGuid } from 'ember-utils';
 import { assert, isTesting } from 'ember-debug';
 import {
   dispatchError,
@@ -28,7 +28,7 @@ const onErrorTarget = {
 };
 
 const backburner = new Backburner(['sync', 'actions', 'destroy'], {
-  GUID_KEY: GUID_KEY,
+  peekGuid: peekGuid,
   sync: {
     before: beginPropertyChanges,
     after: endPropertyChanges

--- a/packages/ember-metal/lib/weak_map.js
+++ b/packages/ember-metal/lib/weak_map.js
@@ -1,4 +1,4 @@
-import { GUID_KEY } from 'ember-utils';
+import { isObject } from 'ember-utils';
 import {
   peekMeta,
   meta as metaFor,
@@ -6,11 +6,6 @@ import {
 } from './meta';
 
 let id = 0;
-
-// Returns whether Type(value) is Object according to the terminology in the spec
-function isObject(value) {
-  return (typeof value === 'object' && value !== null) || typeof value === 'function';
-}
 
 /*
  * @class Ember.WeakMap
@@ -30,7 +25,7 @@ export default function WeakMap(iterable) {
     throw new TypeError(`Constructor WeakMap requires 'new'`);
   }
 
-  this._id = GUID_KEY + (id++);
+  this._id = id++;
 
   if (iterable === null || iterable === undefined) {
     return;

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -119,7 +119,7 @@ QUnit.test('asserts if model class is not found', function() {
 
   expectAssertion(function() {
     route.model({ post_id: 1 });
-  }, /You used the dynamic segment post_id in your route undefined, but <Ember.Object:ember\d+>.Post did not exist and you did not override your route\'s `model` hook./);
+  }, /You used the dynamic segment post_id in your route undefined, but <Ember.Object:.+>.Post did not exist and you did not override your route\'s `model` hook./);
 });
 
 QUnit.test('\'store\' does not need to be injected', function() {

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -10,6 +10,7 @@ import {
   guidFor,
   generateGuid,
   makeArray,
+  HAS_NATIVE_WEAKMAP,
   GUID_KEY_PROPERTY,
   symbol,
   NAME_KEY,
@@ -64,7 +65,9 @@ function makeCtor() {
         initProperties = [arguments[0]];
       }
 
-      this.__defineNonEnumerable(GUID_KEY_PROPERTY);
+      if (!HAS_NATIVE_WEAKMAP) {
+        this.__defineNonEnumerable(GUID_KEY_PROPERTY);
+      }
       let m = meta(this);
       let proto = m.proto;
       m.proto = this;
@@ -560,7 +563,7 @@ let ClassMixinProps = {
 
   isMethod: false,
   [NAME_KEY]: null,
-  [GUID_KEY]: null,
+
   /**
     Creates a new subclass.
 
@@ -907,6 +910,10 @@ let ClassMixinProps = {
     }
   }
 };
+
+if (!HAS_NATIVE_WEAKMAP) {
+  ClassMixinProps[GUID_KEY] = null;
+}
 
 function injectedPropertyAssertion() {
   assert('Injected properties are invalid', validatePropertyInjections(this));

--- a/packages/ember-utils/lib/guid.js
+++ b/packages/ember-utils/lib/guid.js
@@ -21,19 +21,16 @@ export function uuid() {
   return ++_uuid;
 }
 
-/**
- Prefix used for guids through out Ember.
- @private
- @property GUID_PREFIX
- @for Ember
- @type String
- @final
- */
-const GUID_PREFIX = 'ember';
-
 // Used for guid generation...
-const numberCache  = [];
-const stringCache  = {};
+const NUMBER_CACHE = [];
+const STRING_CACHE = {};
+
+const TRUE_UUID = uuid();
+const FALSE_UUID = uuid();
+const OBJECT_UUID = uuid();
+const ARRAY_UUID = uuid();
+const NULL_UUID = uuid();
+const UNDEFINED_UUID = uuid();
 
 /**
   A unique key used to assign guids and other private metadata to objects.
@@ -88,11 +85,13 @@ export let GUID_KEY_PROPERTY = {
   @return {String} the guid
 */
 export function generateGuid(obj, prefix) {
-  if (!prefix) {
-    prefix = GUID_PREFIX;
+  let ret;
+  if (prefix) {
+    ret = prefix + uuid();
+  } else {
+    ret = uuid();
   }
 
-  let ret = (prefix + uuid());
   if (obj) {
     if (obj[GUID_KEY] === null) {
       obj[GUID_KEY] = ret;
@@ -133,11 +132,11 @@ export function guidFor(obj) {
 
   // special cases where we don't want to add a key to object
   if (obj === undefined) {
-    return '(undefined)';
+    return UNDEFINED_UUID;
   }
 
   if (obj === null) {
-    return '(null)';
+    return NULL_UUID;
   }
 
   let ret;
@@ -145,36 +144,36 @@ export function guidFor(obj) {
   // Don't allow prototype changes to String etc. to change the guidFor
   switch (type) {
     case 'number':
-      ret = numberCache[obj];
+      ret = NUMBER_CACHE[obj];
 
       if (!ret) {
-        ret = numberCache[obj] = `nu${obj}`;
+        ret = NUMBER_CACHE[obj] = uuid();
       }
 
       return ret;
 
     case 'string':
-      ret = stringCache[obj];
+      ret = STRING_CACHE[obj];
 
       if (!ret) {
-        ret = stringCache[obj] = `st${uuid()}`;
+        ret = STRING_CACHE[obj] = uuid();
       }
 
       return ret;
 
     case 'boolean':
-      return obj ? '(true)' : '(false)';
+      return obj ? TRUE_UUID : FALSE_UUID;
 
     default:
       if (obj === Object) {
-        return '(Object)';
+        return OBJECT_UUID;
       }
 
       if (obj === Array) {
-        return '(Array)';
+        return ARRAY_UUID;
       }
 
-      ret = GUID_PREFIX + uuid();
+      ret = uuid();
 
       if (obj[GUID_KEY] === null) {
         obj[GUID_KEY] = ret;

--- a/packages/ember-utils/lib/index.js
+++ b/packages/ember-utils/lib/index.js
@@ -21,7 +21,8 @@ export {
   GUID_DESC,
   GUID_KEY_PROPERTY,
   generateGuid,
-  guidFor
+  guidFor,
+  peekGuid
 } from './guid';
 export { default as intern } from './intern';
 export { checkHasSuper, ROOT, wrap } from './super';
@@ -32,5 +33,5 @@ export { default as makeArray } from './make-array';
 export { default as applyStr } from './apply-str';
 export { default as NAME_KEY } from './name';
 export { default as toString } from './to-string';
-export { HAS_NATIVE_WEAKMAP } from './weak-map-utils';
+export { HAS_NATIVE_WEAKMAP, isObject } from './weak-map-utils';
 export { HAS_NATIVE_PROXY } from './proxy-utils';

--- a/packages/ember-utils/lib/weak-map-utils.js
+++ b/packages/ember-utils/lib/weak-map-utils.js
@@ -8,3 +8,9 @@ export const HAS_NATIVE_WEAKMAP = ((() => {
   // polyfills as native weakmaps
   return Object.prototype.toString.call(instance) === '[object WeakMap]';
 }))();
+
+// Returns whether Type(value) is Object according to the terminology in the spec
+export function isObject(value) {
+  let type = typeof value;
+  return (type === 'object' && value !== null) || type === 'function';
+}

--- a/packages/ember-utils/tests/guid_for_test.js
+++ b/packages/ember-utils/tests/guid_for_test.js
@@ -12,18 +12,12 @@ function diffGuid(a, b, message) {
   ok(guidFor(a) !== guidFor(b), message);
 }
 
-function nanGuid(obj) {
-  let type = typeof obj;
-  ok(isNaN(parseInt(guidFor(obj), 0)), 'guids for ' + type + 'don\'t parse to numbers');
-}
-
 QUnit.test('Object', function() {
   let a = {};
   let b = {};
 
   sameGuid(a, a, 'same object always yields same guid');
   diffGuid(a, b, 'different objects yield different guids');
-  nanGuid(a);
 });
 
 QUnit.test('strings', function() {
@@ -34,7 +28,6 @@ QUnit.test('strings', function() {
   sameGuid(a, a, 'same string always yields same guid');
   sameGuid(a, aprime, 'identical strings always yield the same guid');
   diffGuid(a, b, 'different strings yield different guids');
-  nanGuid(a);
 });
 
 QUnit.test('numbers', function() {
@@ -45,7 +38,6 @@ QUnit.test('numbers', function() {
   sameGuid(a, a, 'same numbers always yields same guid');
   sameGuid(a, aprime, 'identical numbers always yield the same guid');
   diffGuid(a, b, 'different numbers yield different guids');
-  nanGuid(a);
 });
 
 QUnit.test('numbers', function() {
@@ -56,8 +48,6 @@ QUnit.test('numbers', function() {
   sameGuid(a, a, 'same booleans always yields same guid');
   sameGuid(a, aprime, 'identical booleans always yield the same guid');
   diffGuid(a, b, 'different boolean yield different guids');
-  nanGuid(a);
-  nanGuid(b);
 });
 
 QUnit.test('null and undefined', function() {
@@ -69,8 +59,6 @@ QUnit.test('null and undefined', function() {
   sameGuid(b, b, 'undefined always returns the same guid');
   sameGuid(a, aprime, 'different nulls return the same guid');
   diffGuid(a, b, 'null and undefined return different guids');
-  nanGuid(a);
-  nanGuid(b);
 });
 
 QUnit.test('arrays', function() {
@@ -79,7 +67,6 @@ QUnit.test('arrays', function() {
   let b = ['1', '2', '3'];
 
   sameGuid(a, a, 'same instance always yields same guid');
-  diffGuid(a, aprime, 'identical arrays always yield the same guid');
+  diffGuid(a, aprime, 'identical arrays always yield different guids');
   diffGuid(a, b, 'different arrays yield different guids');
-  nanGuid(a);
 });

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -503,7 +503,7 @@ export default Mixin.create({
     this._super(...arguments);
 
     if (!this.elementId && this.tagName !== '') {
-      this.elementId = guidFor(this);
+      this.elementId = 'ember' + guidFor(this);
     }
 
     // if we find an `eventManager` property, deopt the

--- a/packages/ember-views/lib/system/utils.js
+++ b/packages/ember-views/lib/system/utils.js
@@ -50,9 +50,9 @@ export function getRootViews(owner) {
  */
 export function getViewId(view) {
   if (view.tagName === '') {
-    return guidFor(view);
+    return 'ember' + guidFor(view);
   } else {
-    return view.elementId || guidFor(view);
+    return view.elementId;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -829,9 +829,9 @@ backbone@^1.1.2:
   dependencies:
     underscore ">=1.8.3"
 
-backburner.js@^0.4.0:
+"backburner.js@github:rwjblue/backburner.js#peek-guid-check-in-dist":
   version "0.4.0"
-  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-0.4.0.tgz#fabf211381b8c17309fda1fbea698b4204f447b5"
+  resolved "https://codeload.github.com/rwjblue/backburner.js/tar.gz/330018a86941be85e6d43902f12c97ce0fac20a2"
 
 backo2@1.0.2:
   version "1.0.2"
@@ -2299,14 +2299,14 @@ error@^7.0.0:
     string-template "~0.2.1"
     xtend "~4.0.0"
 
-es5-ext@^0.10.14, es5-ext@^0.10.7, es5-ext@^0.10.9, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.7:
+es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
   version "0.10.14"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.14.tgz#625bc9ab9cac0f6fb9dc271525823d1800b3d360"
   dependencies:
     es6-iterator "2"
     es6-symbol "~3.1"
 
-es5-ext@~0.10.11:
+es5-ext@^0.10.7, es5-ext@~0.10.11, es5-ext@~0.10.2, es5-ext@~0.10.7:
   version "0.10.12"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.12.tgz#aa84641d4db76b62abba5e45fd805ecbab140047"
   dependencies:
@@ -2350,19 +2350,19 @@ es6-set@~0.1.3:
     es6-symbol "3"
     event-emitter "~0.3.4"
 
-es6-symbol@3, es6-symbol@^3.0.2, es6-symbol@^3.1, es6-symbol@^3.1.1, es6-symbol@~3.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-
-es6-symbol@~3.1.0:
+es6-symbol@3, es6-symbol@~3.1, es6-symbol@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.0.tgz#94481c655e7a7cad82eba832d97d5433496d7ffa"
   dependencies:
     d "~0.1.1"
     es5-ext "~0.10.11"
+
+es6-symbol@^3.0.2, es6-symbol@^3.1, es6-symbol@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
 
 es6-weak-map@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
- Refactor `Ember.guidFor` to always return a number (avoid extraneous string allocations, easier to compare, etc)
- Move guid storage from a property on the object (using `obj.__defineNonEmumerable` or `Object.defineProperty`) into a `WeakMap` when native WeakMap's are available, where not supported fall back to setting `GUID_KEY`.

TODO:

- [x] Update Backburner to allow passing a `getGuid` function (instead of only a `GUID_KEY`) (https://github.com/BackburnerJS/backburner.js/pull/211)