### PR TITLE
Deprecate ApplicationInstance.didCreateRootView

### DIFF
--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -153,7 +153,7 @@ const ApplicationInstance = EngineInstance.extend({
     deprecate(
       'Using `ApplicationInstance.didCreateRootView` is deprecated.',
       false, {
-        id: 'ember-application.app-instance-didCreateRootView',
+        id: 'ember-application.app-instance.did-create-root-view',
         until: '3.0.0',
       }
     );

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -154,7 +154,7 @@ const ApplicationInstance = EngineInstance.extend({
       'Using `ApplicationInstance.didCreateRootView` is deprecated.',
       false, {
         id: 'ember-application.app-instance.did-create-root-view',
-        until: '3.0.0',
+        until: '2.16.0',
       }
     );
     view.appendTo(this.rootElement);

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -150,6 +150,13 @@ const ApplicationInstance = EngineInstance.extend({
     @private
   */
   didCreateRootView(view) {
+    deprecate(
+      'Using `ApplicationInstance.didCreateRootView` is deprecated.',
+      false, {
+        id: 'ember-application.app-instance-didCreateRootView',
+        until: '3.0.0',
+      }
+    );
     view.appendTo(this.rootElement);
   },
 

--- a/packages/ember-application/tests/system/application_instance_test.js
+++ b/packages/ember-application/tests/system/application_instance_test.js
@@ -200,3 +200,11 @@ QUnit.test('can build a registry via Ember.ApplicationInstance.setupRegistry() -
 
   assert.equal(registry.resolve('service:-document'), document);
 });
+
+QUnit.test('attempts to use ApplicationInstance.didCreateRootView get deprecation message', function(assert) {
+  appInstance = run(() => ApplicationInstance.create({ application }));
+
+  let fakeView = { appendTo () {} };
+  expectDeprecation(/Using `ApplicationInstance.didCreateRootView` is deprecated/);
+  appInstance.didCreateRootView(fakeView);
+});

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -323,7 +323,7 @@ const EmberRouter = EmberObject.extend(Evented, {
       this._toplevelView = OutletView.create();
       this._toplevelView.setOutletState(liveRoutes);
       let instance = owner.lookup('-application-instance:main');
-      instance.didCreateRootView(this._toplevelView);
+      this._toplevelView.appendTo(instance.rootElement);
     } else {
       this._toplevelView.setOutletState(liveRoutes);
     }


### PR DESCRIPTION
# Fix #14136 

## Meta / Questions

Disclaimer I'm a first time contributor 😅 So I have a few remaining questions regarding my PR

- Should I include the yarn.lock file? I didn't modify any dependencies but there appears to be some changes...
- Is there a url this PR deprecation should include?
- Is there an alternative API this message should suggest to use in this features place
- Is the chosen id for the deprecation appropriate?
- Is this PR pointed at the right branch? The Contributing.md mentions some stuff but not sure where adding deprecations fits in

## Changes

- Wrote a test that checks that the deprecation warning has been fired, however I'm personally not sure if this is the type of thing tests should check or not

- Added the deprecation warning in the designated location

- Refactor the remaining usage (a single function call, in the routes) by inlining the exact
   functionality of the method (which is a single line) to where it was being called.
  - I think this is okay because there is no accessing of private fields within the original method.
  - In the same breath I do feel this is the most sketchiest piece of this PR, so i'm seeking input on that part specifically 
 