### PR TITLE
[BUGFIX beta] Improve isArray detection

### DIFF
--- a/packages/ember-runtime/lib/utils.js
+++ b/packages/ember-runtime/lib/utils.js
@@ -49,7 +49,8 @@ export function isArray(obj) {
 
   let type = typeOf(obj);
   if ('array' === type) { return true; }
-  if ((obj.length !== undefined) && 'object' === type) { return true; }
+  let length = obj.length;
+  if (typeof length === 'number' && length === length && 'object' === type) { return true; }
   return false;
 }
 

--- a/packages/ember-runtime/tests/core/is_array_test.js
+++ b/packages/ember-runtime/tests/core/is_array_test.js
@@ -14,6 +14,7 @@ QUnit.test('Ember.isArray', function() {
   let string        = 'Hello';
   let object        = {};
   let length        = { length: 12 };
+  let strangeLength = { length: 'yes' };
   let fn            = function() {};
   let arrayProxy = ArrayProxy.create({ content: emberA() });
 
@@ -23,6 +24,7 @@ QUnit.test('Ember.isArray', function() {
   equal(isArray(string), false, '"Hello"');
   equal(isArray(object), false, '{}');
   equal(isArray(length), true, '{ length: 12 }');
+  equal(isArray(strangeLength), false, '{ length: "yes" }');
   equal(isArray(global), false, 'global');
   equal(isArray(fn), false, 'function() {}');
   equal(isArray(arrayProxy), true, '[]');


### PR DESCRIPTION
An object containing an arbitrary `length` property would be detected
as an array, even if said property was not a number.

Fixes #12094 and supersedes #12202