### PR TITLE
[BUGFIX beta] finishChains should operate on metas

### DIFF
--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -347,22 +347,16 @@ function lazyGet(obj, key) {
 
 import { makeChainNode } from './watch_path';
 
-export function finishChains(obj) {
-  // We only create meta if we really have to
-  let m = peekMeta(obj);
-  if (m !== undefined) {
-    m = metaFor(obj);
-
-    // finish any current chains node watchers that reference obj
-    let chainWatchers = m.readableChainWatchers();
-    if (chainWatchers !== undefined) {
-      chainWatchers.revalidateAll();
-    }
-    // ensure that if we have inherited any chains they have been
-    // copied onto our own meta.
-    if (m.readableChains() !== undefined) {
-      m.writableChains(makeChainNode);
-    }
+export function finishChains(meta) {
+  // finish any current chains node watchers that reference obj
+  let chainWatchers = meta.readableChainWatchers();
+  if (chainWatchers !== undefined) {
+    chainWatchers.revalidateAll();
+  }
+  // ensure that if we have inherited any chains they have been
+  // copied onto our own meta.
+  if (meta.readableChains() !== undefined) {
+    meta.writableChains(makeChainNode);
   }
 }
 

--- a/packages/ember-metal/tests/chains_test.js
+++ b/packages/ember-metal/tests/chains_test.js
@@ -6,7 +6,8 @@ import {
   defineProperty,
   computed,
   propertyDidChange,
-  peekMeta
+  peekMeta,
+  meta
 } from '..';
 
 QUnit.module('Chains');
@@ -18,8 +19,13 @@ QUnit.test('finishChains should properly copy chains from prototypes to instance
   addObserver(obj, 'foo.bar', null, didChange);
 
   let childObj = Object.create(obj);
-  finishChains(childObj);
-  ok(peekMeta(obj) !== peekMeta(childObj).readableChains(), 'The chains object is copied');
+
+  let parentMeta = meta(obj);
+  let childMeta = meta(childObj);
+
+  finishChains(childMeta);
+
+  ok(parentMeta.readableChains() !== childMeta.readableChains(), 'The chains object is copied');
 });
 
 QUnit.test('does not observe primitive values', function(assert) {

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -167,7 +167,7 @@ function makeCtor() {
       this[POST_INIT]();
 
       m.proto = proto;
-      finishChains(this);
+      finishChains(m);
       sendEvent(this, 'init');
     }
 


### PR DESCRIPTION
Previously, finishChains (run in every EmberObject creation) would have to lookup its own meta, even though the caller already has access to this meta.

* also fix an invalid test (I introduced the test bug here: https://github.com/emberjs/ember.js/commit/e46e056f1d5ed3136efbdf2136febebacd0461c6#commitcomment-21779571)