### PR TITLE
[BUGFIX beta] [PERF] Cleanup Proxy

### DIFF
--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -131,6 +131,14 @@ export class Meta {
     return this.proto !== obj;
   }
 
+  setTag(tag) {
+    this._tag = tag;
+  }
+
+  getTag(tag) {
+    return this._tag;
+  }
+
   destroy() {
     if (this.isMetaDestroyed()) { return; }
 

--- a/packages/ember-runtime/lib/mixins/-proxy.js
+++ b/packages/ember-runtime/lib/mixins/-proxy.js
@@ -84,21 +84,12 @@ export default Mixin.create({
 
   init() {
     this._super(...arguments);
-    meta(this).setProxy();
+    let m = meta(this);
+    m.setProxy();
+    m.setTag(new ProxyTag(this));
   },
 
-  _initializeTag: on('init', function() {
-    meta(this)._tag = new ProxyTag(this);
-  }),
-
-  _contentDidChange: observer('content', function() {
-    assert('Can\'t set Proxy\'s content to itself', get(this, 'content') !== this);
-    tagFor(this).contentDidChange();
-  }),
-
   isTruthy: bool('content'),
-
-  _debugContainerKey: null,
 
   willWatchProperty(key) {
     let contentKey = `content.${key}`;
@@ -126,6 +117,7 @@ export default Mixin.create({
 
   setUnknownProperty(key, value) {
     let m = meta(this);
+
     if (m.proto === this) {
       // if marked as prototype then just defineProperty
       // rather than delegate
@@ -141,6 +133,7 @@ export default Mixin.create({
       !this.isController,
       { id: 'ember-runtime.controller-proxy', until: '3.0.0' }
     );
+
     return set(content, key, value);
   }
 });


### PR DESCRIPTION
* remove `on(‘init`, just use the existing `init`
* remove redundant meta lookups
* remove observer (notify proxy change from a unified place, within markObjectAsDirty)
* remove double `tag` lookups
* remove redundant meta guards
* misc cleanup