### PR TITLE
Experiment with removing string / number cache for guidFor

### DIFF
--- a/packages/ember-utils/lib/guid.js
+++ b/packages/ember-utils/lib/guid.js
@@ -31,10 +31,6 @@ export function uuid() {
  */
 const GUID_PREFIX = 'ember';
 
-// Used for guid generation...
-const numberCache  = [];
-const stringCache  = {};
-
 /**
   A unique key used to assign guids and other private metadata to objects.
   If you inspect an object in your browser debugger you will often see these.
@@ -144,24 +140,8 @@ export function guidFor(obj) {
 
   // Don't allow prototype changes to String etc. to change the guidFor
   switch (type) {
-    case 'number':
-      ret = numberCache[obj];
-
-      if (!ret) {
-        ret = numberCache[obj] = `nu${obj}`;
-      }
-
-      return ret;
-
-    case 'string':
-      ret = stringCache[obj];
-
-      if (!ret) {
-        ret = stringCache[obj] = `st${uuid()}`;
-      }
-
-      return ret;
-
+    case 'number': return '' + obj;
+    case 'string': return obj;
     case 'boolean':
       return obj ? '(true)' : '(false)';
 

--- a/packages/ember-utils/tests/guid_for_test.js
+++ b/packages/ember-utils/tests/guid_for_test.js
@@ -12,18 +12,12 @@ function diffGuid(a, b, message) {
   ok(guidFor(a) !== guidFor(b), message);
 }
 
-function nanGuid(obj) {
-  let type = typeof obj;
-  ok(isNaN(parseInt(guidFor(obj), 0)), 'guids for ' + type + 'don\'t parse to numbers');
-}
-
 QUnit.test('Object', function() {
   let a = {};
   let b = {};
 
   sameGuid(a, a, 'same object always yields same guid');
   diffGuid(a, b, 'different objects yield different guids');
-  nanGuid(a);
 });
 
 QUnit.test('strings', function() {
@@ -34,7 +28,6 @@ QUnit.test('strings', function() {
   sameGuid(a, a, 'same string always yields same guid');
   sameGuid(a, aprime, 'identical strings always yield the same guid');
   diffGuid(a, b, 'different strings yield different guids');
-  nanGuid(a);
 });
 
 QUnit.test('numbers', function() {
@@ -45,7 +38,6 @@ QUnit.test('numbers', function() {
   sameGuid(a, a, 'same numbers always yields same guid');
   sameGuid(a, aprime, 'identical numbers always yield the same guid');
   diffGuid(a, b, 'different numbers yield different guids');
-  nanGuid(a);
 });
 
 QUnit.test('numbers', function() {
@@ -56,8 +48,6 @@ QUnit.test('numbers', function() {
   sameGuid(a, a, 'same booleans always yields same guid');
   sameGuid(a, aprime, 'identical booleans always yield the same guid');
   diffGuid(a, b, 'different boolean yield different guids');
-  nanGuid(a);
-  nanGuid(b);
 });
 
 QUnit.test('null and undefined', function() {
@@ -69,8 +59,6 @@ QUnit.test('null and undefined', function() {
   sameGuid(b, b, 'undefined always returns the same guid');
   sameGuid(a, aprime, 'different nulls return the same guid');
   diffGuid(a, b, 'null and undefined return different guids');
-  nanGuid(a);
-  nanGuid(b);
 });
 
 QUnit.test('arrays', function() {
@@ -81,5 +69,4 @@ QUnit.test('arrays', function() {
   sameGuid(a, a, 'same instance always yields same guid');
   diffGuid(a, aprime, 'identical arrays always yield the same guid');
   diffGuid(a, b, 'different arrays yield different guids');
-  nanGuid(a);
 });


### PR DESCRIPTION
now:

```js
guidFor(1) // => '1'
guidFor('string') // => 'string'
```

before:

```js
guidFor(1) => 'nu1';
guidFor('string') => 'st-123123'
```

I think the only real API constraint is that `guidFor` returns a string, and that `guidFor(x) === guidFor(x)` which this still upholds.