### PR TITLE
Ensure QUnit.test callbacks have proper scope

### DIFF
--- a/packages/internal-test-helpers/lib/test-groups.js
+++ b/packages/internal-test-helpers/lib/test-groups.js
@@ -12,11 +12,11 @@ export function testBoth(testname, callback) {
   function aget(x, y) { return x[y]; }
   function aset(x, y, z) { return (x[y] = z); }
 
-  QUnit.test(`${testname} using getFromEmberMetal()/Ember.set()`, () => {
+  QUnit.test(`${testname} using getFromEmberMetal()/Ember.set()`, function() {
     callback(emberget, emberset);
   });
 
-  QUnit.test(`${testname} using accessors`, () => {
+  QUnit.test(`${testname} using accessors`, function() {
     if (ENV.USES_ACCESSORS) {
       callback(aget, aset);
     } else {
@@ -33,23 +33,23 @@ export function testWithDefault(testname, callback) {
   function aget(x, y) { return x[y]; }
   function aset(x, y, z) { return (x[y] = z); }
 
-  QUnit.test(`${testname} using obj.get()`, () => {
+  QUnit.test(`${testname} using obj.get()`, function() {
     callback(emberget, emberset);
   });
 
-  QUnit.test(`${testname} using obj.getWithDefault()`, () => {
+  QUnit.test(`${testname} using obj.getWithDefault()`, function() {
     callback(getwithdefault, emberset);
   });
 
-  QUnit.test(`${testname} using getFromEmberMetal()`, () => {
+  QUnit.test(`${testname} using getFromEmberMetal()`, function() {
     callback(emberget, emberset);
   });
 
-  QUnit.test(`${testname} using Ember.getWithDefault()`, () => {
+  QUnit.test(`${testname} using Ember.getWithDefault()`, function() {
     callback(embergetwithdefault, emberset);
   });
 
-  QUnit.test(`${testname} using accessors`, () => {
+  QUnit.test(`${testname} using accessors`, function() {
     if (ENV.USES_ACCESSORS) {
       callback(aget, aset);
     } else {


### PR DESCRIPTION
Turn arrow functions back into regular function syntax so that the test
has the expected scoping.
Spurred by seeing comments by rwjblue after having merged a PR.