### PR TITLE
[WIP] Ensure using no-double-extend does not modify an object's own keys.

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -420,6 +420,8 @@ function deprecatedFactoryFor(container, fullName, options = {}) {
     let cacheable = !areInjectionsDynamic(injections) && !areInjectionsDynamic(factoryInjections);
 
     factoryInjections[NAME_KEY] = registry.makeToString(factory, fullName);
+    factoryInjections._debugContainerKey = fullName;
+    injections._debugContainerKey = fullName;
 
     let injectedFactory = factory.extend(injections);
 
@@ -445,7 +447,6 @@ function injectionsFor(container, fullName) {
   let type = splitName[0];
 
   let injections = buildInjections(container, registry.getTypeInjections(type), registry.getInjections(fullName));
-  injections._debugContainerKey = fullName;
 
   setOwner(injections, container.owner);
 
@@ -508,13 +509,14 @@ function instantiate(factory, props, container, fullName) {
   }
 }
 
+// only used to support the `deprecatedFactoryFor` scenario
+// this is where `owner.lookupFactory` is called directly
 function factoryInjectionsFor(container, fullName) {
   let registry = container.registry;
   let splitName = fullName.split(':');
   let type = splitName[0];
 
   let factoryInjections = buildInjections(container, registry.getFactoryTypeInjections(type), registry.getFactoryInjections(fullName));
-  factoryInjections._debugContainerKey = fullName;
 
   return factoryInjections;
 }

--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -8,7 +8,9 @@ import {
   OWNER,
   assign,
   NAME_KEY,
-  HAS_NATIVE_PROXY
+  HAS_NATIVE_PROXY,
+  HAS_NATIVE_WEAKMAP,
+  isObject
 } from 'ember-utils';
 import { ENV } from 'ember-environment';
 import {
@@ -651,6 +653,14 @@ class FactoryManager {
     }
   }
 
+  toString() {
+    if (!this.madeToString) {
+      this.madeToString = this.container.registry.makeToString(this.class, this.fullName);
+    }
+
+    return this.madeToString;
+  }
+
   create(options = {}) {
 
     let injections = this.injections;
@@ -661,8 +671,6 @@ class FactoryManager {
       }
     }
     let props = assign({}, injections, options);
-
-    props[NAME_KEY] = this.madeToString || (this.madeToString = this.container.registry.makeToString(this.class, this.fullName));
 
     if (DEBUG) {
       let lazyInjections;

--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -647,10 +647,6 @@ class FactoryManager {
     this.normalizedName = normalizedName;
     this.madeToString = undefined;
     this.injections = undefined;
-
-    if (isObject(factory)) {
-      setFactoryManager(factory, this);
-    }
   }
 
   toString() {
@@ -695,6 +691,10 @@ class FactoryManager {
       injectDeprecatedContainer(prototype, this.container);
     }
 
-    return this.class.create(props);
+    let instance = this.class.create(props);
+
+    setFactoryManager(instance, this);
+
+    return instance;
   }
 }

--- a/packages/container/lib/index.js
+++ b/packages/container/lib/index.js
@@ -10,5 +10,7 @@ export {
   default as Container,
   buildFakeContainerWithDeprecations,
   FACTORY_FOR,
-  LOOKUP_FACTORY
+  LOOKUP_FACTORY,
+  peekFactoryManager,
+  setFactoryManager
 } from './container';

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -3,7 +3,7 @@ import { ENV } from 'ember-environment';
 import { Registry } from '..';
 import { factory } from 'internal-test-helpers';
 import { EMBER_NO_DOUBLE_EXTEND } from 'ember/features';
-import { LOOKUP_FACTORY, FACTORY_FOR } from 'container';
+import { LOOKUP_FACTORY, FACTORY_FOR, peekFactoryManager } from 'container';
 
 let originalModelInjections;
 
@@ -60,7 +60,7 @@ QUnit.test('A registered factory is returned from lookupFactory is the same fact
   deepEqual(Post1, Post2, 'The return of lookupFactory is always the same');
 });
 
-QUnit.test('A factory returned from lookupFactory has a debugkey', function() {
+QUnit.test('A factory returned from lookupFactory has access to _debugContainerKey', function() {
   let registry = new Registry();
   let container = registry.container();
   let PostController = factory();
@@ -70,7 +70,7 @@ QUnit.test('A factory returned from lookupFactory has a debugkey', function() {
   equal(PostFactory._debugContainerKey, 'controller:post', 'factory instance receives _debugContainerKey');
 });
 
-QUnit.test('fallback for to create time injections if factory has no extend', function() {
+QUnit.test('fallback to create time injections if factory has no extend', function() {
   let registry = new Registry();
   let container = registry.container();
   let AppleController = factory();
@@ -83,12 +83,13 @@ QUnit.test('fallback for to create time injections if factory has no extend', fu
   registry.injection('controller:post', 'apple', 'controller:apple');
 
   let postController = container.lookup('controller:post');
+  let postControllerManager = peekFactoryManager(postController);
 
-  equal(postController._debugContainerKey, 'controller:post', 'instance receives _debugContainerKey');
+  equal(postControllerManager.fullName, 'controller:post', 'instance has access to fullName for debugging');
   ok(postController.apple instanceof AppleController, 'instance receives an apple of instance AppleController');
 });
 
-QUnit.test('The descendants of a factory returned from lookupFactory have a container and debugkey', function() {
+QUnit.test('The instances of a factory returned from lookupFactory have access to container and _debugContainerKey', function() {
   let registry = new Registry();
   let container = registry.container();
   let PostController = factory();
@@ -156,9 +157,11 @@ QUnit.test('An individual factory with a registered injection receives the injec
   let postController = container.lookup('controller:post');
   let store = container.lookup('store:main');
 
-  equal(store._debugContainerKey, 'store:main');
+  let storeManager = peekFactoryManager(store);
+  equal(storeManager.fullName, 'store:main');
 
-  equal(postController._debugContainerKey, 'controller:post');
+  let postControllerManager = peekFactoryManager(postController);
+  equal(postControllerManager.fullName, 'controller:post');
   equal(postController.store, store, 'has the correct store injected');
 });
 

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -741,3 +741,18 @@ QUnit.test('#factoryFor options passed to create clobber injections', (assert) =
   assert.equal(instrance.ajax, 'fetch');
 });
 
+QUnit.test('#factoryFor does not add properties to the object being instantiated', function(assert) {
+  let owner = {};
+  let registry = new Registry();
+  let container = registry.container();
+
+  let Component = factory();
+  registry.register('component:foo-bar', Component);
+
+  let componentFactory = container.factoryFor('component:foo-bar');
+  let instance = componentFactory.create();
+
+  // note: _guid and isDestroyed are being set in the `factory` constructor
+  // not via registry/container shenanigans
+  assert.deepEqual(Object.keys(instance), ['_guid', 'isDestroyed']);
+});

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -1,6 +1,5 @@
 import { getOwner, OWNER } from 'ember-utils';
 import { ENV } from 'ember-environment';
-import { get } from 'ember-metal';
 import { Registry } from '..';
 import { factory } from 'internal-test-helpers';
 import { EMBER_NO_DOUBLE_EXTEND } from 'ember/features';
@@ -561,7 +560,7 @@ QUnit.test('A deprecated `container` property is appended to every object instan
   let postController = container.lookup('controller:post');
 
   expectDeprecation(() => {
-    get(postController, 'container');
+    postController.container;
   }, 'Using the injected `container` is deprecated. Please use the `getOwner` helper instead to access the owner of this object.');
 
   expectDeprecation(() => {

--- a/packages/ember-metal/lib/weak_map.js
+++ b/packages/ember-metal/lib/weak_map.js
@@ -1,4 +1,4 @@
-import { GUID_KEY } from 'ember-utils';
+import { GUID_KEY, isObject } from 'ember-utils';
 import {
   peekMeta,
   meta as metaFor,
@@ -6,11 +6,6 @@ import {
 } from './meta';
 
 let id = 0;
-
-// Returns whether Type(value) is Object according to the terminology in the spec
-function isObject(value) {
-  return (typeof value === 'object' && value !== null) || typeof value === 'function';
-}
 
 /*
  * @class Ember.WeakMap

--- a/packages/ember-runtime/lib/mixins/-proxy.js
+++ b/packages/ember-runtime/lib/mixins/-proxy.js
@@ -98,8 +98,6 @@ export default Mixin.create({
 
   isTruthy: bool('content'),
 
-  _debugContainerKey: null,
-
   willWatchProperty(key) {
     let contentKey = `content.${key}`;
     _addBeforeObserver(this, contentKey, null, contentPropertyWillChange);

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -14,7 +14,8 @@ import {
   GUID_KEY
 } from 'ember-utils';
 import {
-  peekFactoryManager
+  peekFactoryManager,
+  setFactoryManager
 } from 'container';
 import {
   get,

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -3,8 +3,6 @@
   @submodule ember-runtime
 */
 
-// using ember-metal/lib/main here to ensure that ember-debug is setup
-// if present
 import {
   assign,
   guidFor,
@@ -15,6 +13,9 @@ import {
   NAME_KEY,
   GUID_KEY
 } from 'ember-utils';
+import {
+  peekFactoryManager
+} from 'container';
 import {
   get,
   meta,
@@ -540,7 +541,9 @@ CoreObject.PrototypeMixin = Mixin.create({
   toString() {
     let hasToStringExtension = typeof this.toStringExtension === 'function';
     let extension = hasToStringExtension ? `:${this.toStringExtension()}` : '';
-    let ret = `<${this[NAME_KEY] || this.constructor.toString()}:${guidFor(this)}${extension}>`;
+    let factoryManager = peekFactoryManager(this);
+    let factoryToString = this[NAME_KEY] || factoryManager;
+    let ret = `<${factoryToString || this.constructor.toString()}:${guidFor(this)}${extension}>`;
 
     return ret;
   }

--- a/packages/ember-runtime/lib/system/object.js
+++ b/packages/ember-runtime/lib/system/object.js
@@ -3,12 +3,15 @@
 @submodule ember-runtime
 */
 
+import { peekFactoryManager } from 'container';
 import { symbol } from 'ember-utils';
-import { on } from 'ember-metal';
+import { on, descriptor } from 'ember-metal';
 import CoreObject from './core_object';
 import Observable from '../mixins/observable';
 import { assert } from 'ember-debug';
 import { DEBUG } from 'ember-env-flags';
+
+let DEBUG_CONTAINER_KEY_OVERRIDE = symbol('DEBUG_CONTAINER_KEY_OVERRIDE');
 
 /**
   `Ember.Object` is the main base class for all Ember objects. It is a subclass
@@ -21,7 +24,23 @@ import { DEBUG } from 'ember-env-flags';
   @uses Ember.Observable
   @public
 */
-const EmberObject = CoreObject.extend(Observable);
+const EmberObject = CoreObject.extend(Observable, {
+  _debugContainerKey: descriptor({
+    get() {
+      if (this[DEBUG_CONTAINER_KEY_OVERRIDE]) {
+        return this[DEBUG_CONTAINER_KEY_OVERRIDE];
+      }
+
+      let factoryManager = peekFactoryManager(this);
+      return factoryManager && factoryManager.fullName;
+    },
+
+    set(value) {
+      this[DEBUG_CONTAINER_KEY_OVERRIDE] = value;
+    }
+  })
+});
+
 EmberObject.toString = () => 'Ember.Object';
 
 export let FrameworkObject = EmberObject;

--- a/packages/ember-utils/lib/index.js
+++ b/packages/ember-utils/lib/index.js
@@ -32,5 +32,5 @@ export { default as makeArray } from './make-array';
 export { default as applyStr } from './apply-str';
 export { default as NAME_KEY } from './name';
 export { default as toString } from './to-string';
-export { HAS_NATIVE_WEAKMAP } from './weak-map-utils';
+export { HAS_NATIVE_WEAKMAP, isObject } from './weak-map-utils';
 export { HAS_NATIVE_PROXY } from './proxy-utils';

--- a/packages/ember-utils/lib/weak-map-utils.js
+++ b/packages/ember-utils/lib/weak-map-utils.js
@@ -8,3 +8,8 @@ export const HAS_NATIVE_WEAKMAP = ((() => {
   // polyfills as native weakmaps
   return Object.prototype.toString.call(instance) === '[object WeakMap]';
 }))();
+
+// Returns whether Type(value) is Object according to the terminology in the spec
+export function isObject(value) {
+  return (typeof value === 'object' && value !== null) || typeof value === 'function';
+}


### PR DESCRIPTION
Given:

```js
owner.register('some:name', Ember.Object.extend());
let instance = owner.lookup('some:name');

assert.deepEqual(Object.keys(instance), []);
```

This assertion passes in Ember 2.12 and older, but not Ember 2.13.0 beta series. The cause of this regression was disabling `no-double-extend` feature and now some properties like `_debugContainerKey` and `NAME_KEY` are being set on new instances.