### PR TITLE
[BUGFIX] Retry transition created with `replaceWith` causes a history replacement

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "qunit-phantomjs-runner": "^2.2.0",
     "qunitjs": "^1.22.0",
     "route-recognizer": "^0.3.0",
-    "router_js": "^1.2.4",
+    "router_js": "^1.2.7",
     "semver": "^5.3.0",
     "serve-static": "^1.10.0",
     "simple-dom": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2299,14 +2299,14 @@ error@^7.0.0:
     string-template "~0.2.1"
     xtend "~4.0.0"
 
-es5-ext@^0.10.14, es5-ext@^0.10.7, es5-ext@^0.10.9, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.7:
+es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
   version "0.10.14"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.14.tgz#625bc9ab9cac0f6fb9dc271525823d1800b3d360"
   dependencies:
     es6-iterator "2"
     es6-symbol "~3.1"
 
-es5-ext@~0.10.11:
+es5-ext@^0.10.7, es5-ext@~0.10.11, es5-ext@~0.10.2, es5-ext@~0.10.7:
   version "0.10.12"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.12.tgz#aa84641d4db76b62abba5e45fd805ecbab140047"
   dependencies:
@@ -2350,19 +2350,19 @@ es6-set@~0.1.3:
     es6-symbol "3"
     event-emitter "~0.3.4"
 
-es6-symbol@3, es6-symbol@^3.0.2, es6-symbol@^3.1, es6-symbol@^3.1.1, es6-symbol@~3.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-
-es6-symbol@~3.1.0:
+es6-symbol@3, es6-symbol@~3.1, es6-symbol@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.0.tgz#94481c655e7a7cad82eba832d97d5433496d7ffa"
   dependencies:
     d "~0.1.1"
     es5-ext "~0.10.11"
+
+es6-symbol@^3.0.2, es6-symbol@^3.1, es6-symbol@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
 
 es6-weak-map@^2.0.1:
   version "2.0.2"
@@ -5204,9 +5204,9 @@ route-recognizer@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/route-recognizer/-/route-recognizer-0.3.0.tgz#75081992378fa3a61ab538a41b2f3a5b73fb325b"
 
-router_js@^1.2.4:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/router_js/-/router_js-1.2.5.tgz#ea211eddada3f3d92f5e6d9c24a5b57288752f75"
+router_js@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/router_js/-/router_js-1.2.7.tgz#f5cd153d87e31941d3a2bbd81700d5884c7bfc44"
 
 rsvp@3.0.14, rsvp@~3.0.6:
   version "3.0.14"


### PR DESCRIPTION
This issue was fixed upstream in router.js, I'm just repeating the information here
for context.
Before this change the next code:

```js
let transition = this.replaceWith('new.route')
transition.abort()
transition.retry();
```

caused the app to transition to `'new.route'` without replacing the previous history entry.
After this change, `Transition#retry` respects the intention of the original transition. In
the snippet above `'new.route'` will now replace the previous route in the history.