### PR TITLE
[FEATURE ember-engines-mount-params] Allow {{mount}} syntax to accept parameters

### DIFF
--- a/features.json
+++ b/features.json
@@ -5,7 +5,8 @@
     "ember-improved-instrumentation": null,
     "ember-metal-weakmap": null,
     "ember-glimmer-allow-backtracking-rerender": null,
-    "ember-routing-router-service": null
+    "ember-routing-router-service": null,
+    "ember-engines-mount-params": null
   },
   "deprecations": {
     "container-lookupFactory": "2.12.0",


### PR DESCRIPTION
Implements ember-engines/ember-engines#98 for routeless engines behind the `ember-engines-mount-params` feature flag.

Parameters passed into `{{mount}}` will be accessible within the engine as the model on the engines application controller/template.

RFC Link: https://github.com/emberjs/rfcs/pull/225

Example:

```hbs
{{!-- app/templates/application.hbs --}}
{{mount "foo" bar="baz"}}
```

```hbs
{{!-- foo/templates/application.hbs --}}
{{model.bar}}
```