### PR TITLE
[BUGFIX] controller `replaceRoute` considers engine's mount point

### DIFF
--- a/packages/ember-routing/lib/ext/controller.js
+++ b/packages/ember-routing/lib/ext/controller.js
@@ -211,7 +211,7 @@ ControllerMixin.reopen({
     // target may be either another controller or a router
     let target = get(this, 'target');
     let method = target.replaceRoute || target.replaceWith;
-    return method.apply(target, prefixRouteNameArg(target, args));
+    return method.apply(target, prefixRouteNameArg(this, args));
   }
 });
 

--- a/packages/ember-routing/tests/ext/controller_test.js
+++ b/packages/ember-routing/tests/ext/controller_test.js
@@ -30,3 +30,30 @@ QUnit.test('transitionToRoute considers an engine\'s mountPoint', function() {
   let queryParams = {};
   strictEqual(controller.transitionToRoute(queryParams), queryParams, 'passes query param only transitions through');
 });
+
+QUnit.test('replaceRoute considers an engine\'s mountPoint', function() {
+  expect(4);
+
+  let router = {
+    replaceWith(route) {
+      return route;
+    }
+  };
+
+  let engineInstance = buildOwner({
+    ownerOptions: {
+      routable: true,
+      mountPoint: 'foo.bar'
+    }
+  });
+
+  let controller = Controller.create({ target: router });
+  setOwner(controller, engineInstance);
+
+  strictEqual(controller.replaceRoute('application'), 'foo.bar.application', 'properly prefixes application route');
+  strictEqual(controller.replaceRoute('posts'), 'foo.bar.posts', 'properly prefixes child routes');
+  throws(() => controller.replaceRoute('/posts'), 'throws when trying to use a url');
+
+  let queryParams = {};
+  strictEqual(controller.replaceRoute(queryParams), queryParams, 'passes query param only transitions through');
+});


### PR DESCRIPTION
Seems like there was a small error and a missing test when using `replaceRoute` from a controller that is inside of an engine. This change mirrors the same for `transitionToRoute. 