### PR TITLE
[BUGFIX release] Correct `until` values for `this.container` deprecations.

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -521,12 +521,12 @@ const INJECTED_DEPRECATED_CONTAINER_DESC = {
   configurable: true,
   enumerable: false,
   get() {
-    deprecate('Using the injected `container` is deprecated. Please use the `getOwner` helper instead to access the owner of this object.', false, { id: 'ember-application.injected-container', until: '3.0.0', url: 'http://emberjs.com/deprecations/v2.x#toc_injected-container-access' });
+    deprecate('Using the injected `container` is deprecated. Please use the `getOwner` helper instead to access the owner of this object.', false, { id: 'ember-application.injected-container', until: '2.13.0', url: 'http://emberjs.com/deprecations/v2.x#toc_injected-container-access' });
     return this[CONTAINER_OVERRIDE] || getOwner(this).__container__;
   },
 
   set(value) {
-    deprecate(`Providing the \`container\` property to ${this} is deprecated. Please use \`Ember.setOwner\` or \`owner.ownerInjection()\` instead to provide an owner to the instance being created.`, false, { id: 'ember-application.injected-container', until: '3.0.0', url: 'http://emberjs.com/deprecations/v2.x#toc_injected-container-access' });
+    deprecate(`Providing the \`container\` property to ${this} is deprecated. Please use \`Ember.setOwner\` or \`owner.ownerInjection()\` instead to provide an owner to the instance being created.`, false, { id: 'ember-application.injected-container', until: '2.13.0', url: 'http://emberjs.com/deprecations/v2.x#toc_injected-container-access' });
 
     this[CONTAINER_OVERRIDE] = value;
 
@@ -591,7 +591,7 @@ function buildFakeContainerFunction(container, containerProperty, ownerProperty)
   return function () {
     deprecate(`Using the injected \`container\` is deprecated. Please use the \`getOwner\` helper to access the owner of this object and then call \`${ownerProperty}\` instead.`, false, {
       id: 'ember-application.injected-container',
-      until: '3.0.0',
+      until: '2.13.0',
       url: 'http://emberjs.com/deprecations/v2.x#toc_injected-container-access'
     });
     return container[containerProperty](...arguments);

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -503,7 +503,7 @@ Object.defineProperty(ApplicationInstance.prototype, 'container', {
           'Using `ApplicationInstance.container.lookup` is deprecated. Please use `ApplicationInstance.lookup` instead.',
           false, {
             id: 'ember-application.app-instance-container',
-            until: '3.0.0',
+            until: '2.13.0',
             url: 'http://emberjs.com/deprecations/v2.x/#toc_ember-applicationinstance-container'
           }
         );


### PR DESCRIPTION
These deprecations were added in the Ember 2.3 cycle, before we had established the LTS system and how private API deprecations are handled. Per the rules we created around private API deprecations, the `until` value is supposed to be the version just after the next LTS. In theory, that means this could have been 2.5.0 originally, but I'm updating to 2.13.0 because 2.12 was also an LTS.

An emberobserver.com search shows little usage (other than fallbacks when owner is not found), and very few issues are still open around this sort of `.container` deprecation.