### PR TITLE
[FEATURE ember-no-double-extend] Remove feature flagging and cleanup.

### DIFF
--- a/features.json
+++ b/features.json
@@ -7,7 +7,6 @@
     "ember-glimmer-allow-backtracking-rerender": null,
     "ember-testing-resume-test": true,
     "ember-factory-for": true,
-    "ember-no-double-extend": true,
     "ember-routing-router-service": null,
     "ember-unique-location-history-state": true
   },

--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -14,7 +14,6 @@ import {
 import { ENV } from 'ember-environment';
 
 const CONTAINER_OVERRIDE = symbol('CONTAINER_OVERRIDE');
-export const LOOKUP_FACTORY = symbol('LOOKUP_FACTORY');
 
 /**
  A container used to instantiate and cache objects.
@@ -118,11 +117,6 @@ Container.prototype = {
 
     deprecate('Using "_lookupFactory" is deprecated. Please use container.factoryFor instead.', false, { id: 'container-lookupFactory', until: '2.13.0', url: 'http://emberjs.com/deprecations/v2.x/#toc_migrating-from-_lookupfactory-to-factoryfor' });
 
-    return deprecatedFactoryFor(this, this.registry.normalize(fullName), options);
-  },
-
-  [LOOKUP_FACTORY](fullName, options) {
-    assert('fullName must be a proper full name', this.registry.validateFullName(fullName));
     return deprecatedFactoryFor(this, this.registry.normalize(fullName), options);
   },
 

--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -14,7 +14,6 @@ import {
 import { ENV } from 'ember-environment';
 
 const CONTAINER_OVERRIDE = symbol('CONTAINER_OVERRIDE');
-export const FACTORY_FOR = symbol('FACTORY_FOR');
 export const LOOKUP_FACTORY = symbol('LOOKUP_FACTORY');
 
 /**
@@ -125,16 +124,6 @@ Container.prototype = {
   [LOOKUP_FACTORY](fullName, options) {
     assert('fullName must be a proper full name', this.registry.validateFullName(fullName));
     return deprecatedFactoryFor(this, this.registry.normalize(fullName), options);
-  },
-
-  /*
-   * This internal version of factoryFor swaps between the public API for
-   * factoryFor (class is the registered class) and a transition implementation
-   * (class is the double-extended class). It is *not* the public API version
-   * of factoryFor, which always returns the registered class.
-   */
-  [FACTORY_FOR](fullName, options = {}) {
-    return this.factoryFor(fullName, options);
   },
 
   /**
@@ -298,7 +287,7 @@ function isFactoryInstance(container, fullName, { instantiate, singleton }) {
 }
 
 function instantiateFactory(container, fullName, options) {
-  let factoryManager = container[FACTORY_FOR](fullName);
+  let factoryManager = container.factoryFor(fullName);
 
   if (factoryManager === undefined) {
     return;

--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -12,9 +12,6 @@ import {
   HAS_NATIVE_PROXY
 } from 'ember-utils';
 import { ENV } from 'ember-environment';
-import {
-  EMBER_NO_DOUBLE_EXTEND
-} from 'ember/features';
 
 const CONTAINER_OVERRIDE = symbol('CONTAINER_OVERRIDE');
 export const FACTORY_FOR = symbol('FACTORY_FOR');
@@ -137,20 +134,7 @@ Container.prototype = {
    * of factoryFor, which always returns the registered class.
    */
   [FACTORY_FOR](fullName, options = {}) {
-    if (EMBER_NO_DOUBLE_EXTEND) {
-      return this.factoryFor(fullName, options);
-    }
-    let factory = this[LOOKUP_FACTORY](fullName, options);
-    if (factory === undefined) {
-      return;
-    }
-    let manager = new DeprecatedFactoryManager(this, factory, fullName);
-
-    if (DEBUG) {
-      manager = wrapManagerInDeprecationProxy(manager);
-    }
-
-    return manager;
+    return this.factoryFor(fullName, options);
   },
 
   /**

--- a/packages/container/lib/index.js
+++ b/packages/container/lib/index.js
@@ -8,6 +8,5 @@ The public API, specified on the application namespace should be considered the 
 export { default as Registry, privatize } from './registry';
 export {
   default as Container,
-  buildFakeContainerWithDeprecations,
-  LOOKUP_FACTORY
+  buildFakeContainerWithDeprecations
 } from './container';

--- a/packages/container/lib/index.js
+++ b/packages/container/lib/index.js
@@ -9,6 +9,5 @@ export { default as Registry, privatize } from './registry';
 export {
   default as Container,
   buildFakeContainerWithDeprecations,
-  FACTORY_FOR,
   LOOKUP_FACTORY
 } from './container';

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -3,7 +3,7 @@ import { ENV } from 'ember-environment';
 import { get } from 'ember-metal';
 import { Registry } from '..';
 import { factory } from 'internal-test-helpers';
-import { LOOKUP_FACTORY, FACTORY_FOR } from 'container';
+import { LOOKUP_FACTORY } from 'container';
 
 let originalModelInjections;
 
@@ -627,7 +627,7 @@ QUnit.test('lookup passes options through to expandlocallookup', function(assert
   assert.ok(PostControllerLookupResult instanceof PostController);
 });
 
-QUnit.test('#[FACTORY_FOR] class is the injected factory', (assert) => {
+QUnit.test('#factoryFor class is registered class', (assert) => {
   let registry = new Registry();
   let container = registry.container();
 

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -3,7 +3,6 @@ import { ENV } from 'ember-environment';
 import { get } from 'ember-metal';
 import { Registry } from '..';
 import { factory } from 'internal-test-helpers';
-import { EMBER_NO_DOUBLE_EXTEND } from 'ember/features';
 import { LOOKUP_FACTORY, FACTORY_FOR } from 'container';
 
 let originalModelInjections;
@@ -635,12 +634,8 @@ QUnit.test('#[FACTORY_FOR] class is the injected factory', (assert) => {
   let Component = factory();
   registry.register('component:foo-bar', Component);
 
-  let factoryManager = container[FACTORY_FOR]('component:foo-bar');
-  if (EMBER_NO_DOUBLE_EXTEND) {
-    assert.deepEqual(factoryManager.class, Component, 'No double extend');
-  } else {
-    assert.deepEqual(factoryManager.class, lookupFactory('component:foo-bar', container), 'Double extended class');
-  }
+  let factoryManager = container.factoryFor('component:foo-bar');
+  assert.deepEqual(factoryManager.class, Component, 'No double extend');
 });
 
 QUnit.test('#factoryFor must supply a fullname', (assert) => {

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -3,7 +3,6 @@ import { ENV } from 'ember-environment';
 import { get } from 'ember-metal';
 import { Registry } from '..';
 import { factory } from 'internal-test-helpers';
-import { LOOKUP_FACTORY } from 'container';
 
 let originalModelInjections;
 
@@ -17,7 +16,12 @@ QUnit.module('Container', {
 });
 
 function lookupFactory(name, container, options) {
-  return container[LOOKUP_FACTORY](name, options);
+  let factory;
+  expectDeprecation(() => {
+    factory = container.lookupFactory(name, options);
+  }, 'Using "_lookupFactory" is deprecated. Please use container.factoryFor instead.');
+
+  return factory;
 }
 
 QUnit.test('A registered factory returns the same instance each time', function() {
@@ -477,7 +481,7 @@ QUnit.test('factory for non extendables resolves are cached', function() {
 });
 
 QUnit.test('The `_onLookup` hook is called on factories when looked up the first time', function() {
-  expect(2);
+  expect(4); // 2 are from expectDeprecation in `lookupFactory`
 
   let registry = new Registry();
   let container = registry.container();

--- a/packages/ember-application/lib/system/engine-instance.js
+++ b/packages/ember-application/lib/system/engine-instance.js
@@ -12,7 +12,7 @@ import {
 } from 'ember-runtime';
 import { assert, Error as EmberError } from 'ember-debug';
 import { run } from 'ember-metal';
-import { Registry, FACTORY_FOR, LOOKUP_FACTORY, privatize as P } from 'container';
+import { Registry, LOOKUP_FACTORY, privatize as P } from 'container';
 import { getEngineParent, setEngineParent } from './engine-parent';
 
 /**
@@ -195,10 +195,6 @@ const EngineInstance = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixi
 
     this.inject('view', '_environment', '-environment:main');
     this.inject('route', '_environment', '-environment:main');
-  },
-
-  [FACTORY_FOR](fullName, options) {
-    return this.__container__[FACTORY_FOR](fullName, options);
   },
 
   [LOOKUP_FACTORY](fullName, options) {

--- a/packages/ember-application/lib/system/engine-instance.js
+++ b/packages/ember-application/lib/system/engine-instance.js
@@ -12,7 +12,7 @@ import {
 } from 'ember-runtime';
 import { assert, Error as EmberError } from 'ember-debug';
 import { run } from 'ember-metal';
-import { Registry, LOOKUP_FACTORY, privatize as P } from 'container';
+import { Registry, privatize as P } from 'container';
 import { getEngineParent, setEngineParent } from './engine-parent';
 
 /**
@@ -195,10 +195,6 @@ const EngineInstance = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixi
 
     this.inject('view', '_environment', '-environment:main');
     this.inject('route', '_environment', '-environment:main');
-  },
-
-  [LOOKUP_FACTORY](fullName, options) {
-    return this.__container__[LOOKUP_FACTORY](fullName, options);
   }
 });
 

--- a/packages/ember-extension-support/lib/data_adapter.js
+++ b/packages/ember-extension-support/lib/data_adapter.js
@@ -9,7 +9,6 @@ import {
   removeArrayObserver,
   objectAt
 } from 'ember-runtime';
-import { FACTORY_FOR } from 'container';
 
 /**
 @module ember
@@ -164,7 +163,7 @@ export default EmberObject.extend({
   _nameToClass(type) {
     if (typeof type === 'string') {
       let owner = getOwner(this);
-      let Factory = owner[FACTORY_FOR](`model:${type}`);
+      let Factory = owner.factoryFor(`model:${type}`);
       type = Factory && Factory.class;
     }
     return type;

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -51,8 +51,6 @@ import { default as normalizeClassHelper } from './helpers/-normalize-class';
 import { default as htmlSafeHelper } from './helpers/-html-safe';
 
 import installPlatformSpecificProtocolForURL from './protocol-for-url';
-import { FACTORY_FOR } from 'container';
-
 import { default as ActionModifierManager } from './modifiers/action';
 
 function instrumentationPayload(name) {
@@ -213,7 +211,7 @@ export default class Environment extends GlimmerEnvironment {
     let blockMeta = symbolTable.getMeta();
     let owner = blockMeta.owner;
     let options = blockMeta.moduleName && { source: `template:${blockMeta.moduleName}` } || {};
-    let helperFactory = owner[FACTORY_FOR](`helper:${name}`, options) || owner[FACTORY_FOR](`helper:${name}`);
+    let helperFactory = owner.factoryFor(`helper:${name}`, options) || owner.factoryFor(`helper:${name}`);
 
     // TODO: try to unify this into a consistent protocol to avoid wasteful closure allocations
     if (helperFactory.class.isHelperInstance) {

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -2,7 +2,6 @@ import { guidFor, OWNER } from 'ember-utils';
 import { Cache, _instrumentStart } from 'ember-metal';
 import { assert, warn } from 'ember-debug';
 import { DEBUG } from 'ember-env-flags';
-import { EMBER_NO_DOUBLE_EXTEND } from 'ember/features';
 import {
   lookupPartial,
   hasPartial,
@@ -220,9 +219,6 @@ export default class Environment extends GlimmerEnvironment {
     if (helperFactory.class.isHelperInstance) {
       return (vm, args) => SimpleHelperReference.create(helperFactory.class.compute, args);
     } else if (helperFactory.class.isHelperFactory) {
-      if (!EMBER_NO_DOUBLE_EXTEND) {
-        helperFactory = helperFactory.create();
-      }
       return (vm, args) => ClassBasedHelperReference.create(helperFactory, vm, args);
     } else {
       throw new Error(`${name} is not a helper`);

--- a/packages/ember-glimmer/lib/syntax/mount.js
+++ b/packages/ember-glimmer/lib/syntax/mount.js
@@ -10,7 +10,6 @@ import { assert } from 'ember-debug';
 import { RootReference } from '../utils/references';
 import { generateControllerFactory } from 'ember-routing';
 import { OutletLayoutCompiler } from './outlet';
-import { FACTORY_FOR } from 'container';
 import AbstractManager from './abstract-manager';
 import { DEBUG } from 'ember-env-flags';
 
@@ -122,7 +121,7 @@ class MountManager extends AbstractManager {
   }
 
   getSelf(engine) {
-    let applicationFactory = engine[FACTORY_FOR](`controller:application`);
+    let applicationFactory = engine.factoryFor(`controller:application`);
     let factory = applicationFactory || generateControllerFactory(engine, 'application');
     return new RootReference(factory.create());
   }

--- a/packages/ember-glimmer/lib/syntax/render.js
+++ b/packages/ember-glimmer/lib/syntax/render.js
@@ -11,7 +11,6 @@ import { DEBUG } from 'ember-env-flags';
 import { RootReference } from '../utils/references';
 import { generateController, generateControllerFactory } from 'ember-routing';
 import { OutletLayoutCompiler } from './outlet';
-import { FACTORY_FOR } from 'container';
 import AbstractManager from './abstract-manager';
 
 function makeComponentDefinition(vm) {
@@ -189,7 +188,7 @@ class NonSingletonRenderManager extends AbstractRenderManager {
   create(environment, definition, args, dynamicScope) {
     let { name, env } = definition;
     let modelRef = args.positional.at(0);
-    let controllerFactory = env.owner[FACTORY_FOR](`controller:${name}`);
+    let controllerFactory = env.owner.factoryFor(`controller:${name}`);
 
     let factory = controllerFactory || generateControllerFactory(env.owner, name);
     let controller = factory.create({ model: modelRef.value() });

--- a/packages/ember-routing/lib/system/generate_controller.js
+++ b/packages/ember-routing/lib/system/generate_controller.js
@@ -1,5 +1,4 @@
 import { get } from 'ember-metal';
-import { FACTORY_FOR } from 'container';
 import { info } from 'ember-debug';
 import { DEBUG } from 'ember-env-flags';
 /**
@@ -16,7 +15,7 @@ import { DEBUG } from 'ember-env-flags';
 */
 
 export function generateControllerFactory(owner, controllerName, context) {
-  let Factory = owner[FACTORY_FOR]('controller:basic').class;
+  let Factory = owner.factoryFor('controller:basic').class;
 
   Factory = Factory.extend({
     toString() {

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -27,7 +27,6 @@ import {
   calculateCacheKey,
   prefixRouteNameArg
 } from '../utils';
-import { FACTORY_FOR } from 'container';
 const { slice } = Array.prototype;
 
 function K() { return this; }
@@ -1617,7 +1616,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
 
     return {
       find(name, value) {
-        let modelClass = owner[FACTORY_FOR](`model:${name}`);
+        let modelClass = owner.factoryFor(`model:${name}`);
 
         assert(
           `You used the dynamic segment ${name}_id in your route ${routeName}, but ${namespace}.${StringUtils.classify(name)} did not exist and you did not override your route's \`model\` hook.`, !!modelClass);

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -37,7 +37,6 @@ import {
   calculateCacheKey
 } from '../utils';
 import RouterState from './router_state';
-import { FACTORY_FOR } from 'container';
 import { DEBUG } from 'ember-env-flags';
 
 /**
@@ -127,7 +126,7 @@ const EmberRouter = EmberObject.extend(Evented, {
     let owner = getOwner(this);
     let router = this;
 
-    options.resolveRouteMap = name => owner[FACTORY_FOR](`route-map:${name}`);
+    options.resolveRouteMap = name => owner.factoryFor(`route-map:${name}`);
 
     options.addRouteForEngine = (name, engineInfo) => {
       if (!router._engineInfoByRoute[name]) {
@@ -319,7 +318,7 @@ const EmberRouter = EmberObject.extend(Evented, {
 
     if (!this._toplevelView) {
       let owner = getOwner(this);
-      let OutletView = owner[FACTORY_FOR]('view:-outlet');
+      let OutletView = owner.factoryFor('view:-outlet');
       this._toplevelView = OutletView.create();
       this._toplevelView.setOutletState(liveRoutes);
       let instance = owner.lookup('-application-instance:main');
@@ -598,7 +597,7 @@ const EmberRouter = EmberObject.extend(Evented, {
       seen[name] = true;
 
       if (!handler) {
-        let DefaultRoute = routeOwner[FACTORY_FOR]('route:basic').class;
+        let DefaultRoute = routeOwner.factoryFor('route:basic').class;
         routeOwner.register(fullRouteName, DefaultRoute.extend());
         handler = routeOwner.lookup(fullRouteName);
 

--- a/packages/ember-routing/tests/system/controller_for_test.js
+++ b/packages/ember-routing/tests/system/controller_for_test.js
@@ -3,7 +3,6 @@ import {
 } from 'ember-runtime';
 import controllerFor from '../../system/controller_for';
 import generateController from '../../system/generate_controller';
-import { EMBER_NO_DOUBLE_EXTEND } from 'ember/features';
 import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
 
 moduleFor('Ember.controllerFor', class extends ApplicationTestCase {
@@ -44,15 +43,7 @@ moduleFor('Ember.generateController', class extends ApplicationTestCase {
     return this.visit('/').then(() => {
       let controller = generateController(this.applicationInstance, 'home');
 
-      if (EMBER_NO_DOUBLE_EXTEND) {
-        assert.ok(controller instanceof BasicController, 'should return base class of controller');
-      } else {
-        let doubleExtendedFactory;
-        ignoreDeprecation(() => {
-          doubleExtendedFactory = this.applicationInstance._lookupFactory('controller:basic');
-        });
-        assert.ok(controller instanceof doubleExtendedFactory, 'should return double-extended controller');
-      }
+      assert.ok(controller instanceof BasicController, 'should return base class of controller');
     });
   }
 });

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -6,7 +6,6 @@ import {
   inject
 } from 'ember-runtime';
 import EmberRoute from '../../system/route';
-import { FACTORY_FOR } from 'container';
 
 let route, routeOne, routeTwo, lookupHash;
 
@@ -40,7 +39,7 @@ QUnit.test('default store utilizes the container to acquire the model factory', 
       hasRegistration() {
         return true;
       },
-      [FACTORY_FOR](fullName) {
+      factoryFor(fullName) {
         equal(fullName, 'model:post', 'correct factory was looked up');
 
         return {

--- a/packages/ember-runtime/lib/mixins/container_proxy.js
+++ b/packages/ember-runtime/lib/mixins/container_proxy.js
@@ -6,9 +6,6 @@ import {
   Mixin,
   run
 } from 'ember-metal';
-import {
-  LOOKUP_FACTORY
-} from 'container';
 
 /**
   ContainerProxyMixin is used to provide public access to specific
@@ -108,10 +105,6 @@ let containerProxyMixin = {
    */
   _lookupFactory(fullName, options) {
     return this.__container__.lookupFactory(fullName, options);
-  },
-
-  [LOOKUP_FACTORY]() {
-    return this.__container__[LOOKUP_FACTORY](...arguments);
   },
 
   /**

--- a/packages/ember-runtime/lib/mixins/container_proxy.js
+++ b/packages/ember-runtime/lib/mixins/container_proxy.js
@@ -7,7 +7,6 @@ import {
   run
 } from 'ember-metal';
 import {
-  FACTORY_FOR,
   LOOKUP_FACTORY
 } from 'container';
 
@@ -109,10 +108,6 @@ let containerProxyMixin = {
    */
   _lookupFactory(fullName, options) {
     return this.__container__.lookupFactory(fullName, options);
-  },
-
-  [FACTORY_FOR]() {
-    return this.__container__[FACTORY_FOR](...arguments);
   },
 
   [LOOKUP_FACTORY]() {

--- a/packages/ember-views/lib/component_lookup.js
+++ b/packages/ember-views/lib/component_lookup.js
@@ -1,12 +1,11 @@
 import { assert } from 'ember-debug';
 import { Object as EmberObject } from 'ember-runtime';
-import { FACTORY_FOR } from 'container';
 
 export default EmberObject.extend({
   componentFor(name, owner, options) {
     assert(`You cannot use '${name}' as a component name. Component names must contain a hyphen.`, ~name.indexOf('-'));
     let fullName = `component:${name}`;
-    return owner[FACTORY_FOR](fullName, options);
+    return owner.factoryFor(fullName, options);
   },
 
   layoutFor(name, owner, options) {

--- a/packages/ember-views/lib/utils/lookup-component.js
+++ b/packages/ember-views/lib/utils/lookup-component.js
@@ -1,4 +1,4 @@
-import { privatize as P, FACTORY_FOR } from 'container';
+import { privatize as P } from 'container';
 
 function lookupComponentPair(componentLookup, owner, name, options) {
   let component = componentLookup.componentFor(name, owner, options);
@@ -7,7 +7,7 @@ function lookupComponentPair(componentLookup, owner, name, options) {
   let result = { layout, component };
 
   if (layout && !component) {
-    result.component = owner[FACTORY_FOR](P`component:-default`);
+    result.component = owner.factoryFor(P`component:-default`);
   }
 
   return result;

--- a/packages/internal-test-helpers/lib/build-owner.js
+++ b/packages/internal-test-helpers/lib/build-owner.js
@@ -1,4 +1,4 @@
-import { Registry, FACTORY_FOR, LOOKUP_FACTORY } from 'container';
+import { Registry, LOOKUP_FACTORY } from 'container';
 import { Router } from 'ember-routing';
 import {
   Application,
@@ -16,9 +16,6 @@ export default function buildOwner(options = {}) {
   let bootOptions = options.bootOptions || {};
 
   let Owner = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixin, {
-    [FACTORY_FOR]() {
-      return this.__container__[FACTORY_FOR](...arguments);
-    },
     [LOOKUP_FACTORY]() {
       return this.__container__[LOOKUP_FACTORY](...arguments);
     }

--- a/packages/internal-test-helpers/lib/build-owner.js
+++ b/packages/internal-test-helpers/lib/build-owner.js
@@ -1,4 +1,4 @@
-import { Registry, LOOKUP_FACTORY } from 'container';
+import { Registry } from 'container';
 import { Router } from 'ember-routing';
 import {
   Application,
@@ -15,17 +15,7 @@ export default function buildOwner(options = {}) {
   let resolver = options.resolver;
   let bootOptions = options.bootOptions || {};
 
-  let Owner = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixin, {
-    [LOOKUP_FACTORY]() {
-      return this.__container__[LOOKUP_FACTORY](...arguments);
-    }
-  });
-
-  Owner.reopen({
-    factoryFor() {
-      return this.__container__.factoryFor(...arguments);
-    }
-  });
+  let Owner = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixin);
 
   let namespace = EmberObject.create({
     Resolver: { create() { return resolver; } }


### PR DESCRIPTION
* Remove `FACTORY_FOR` symbol. This was created as a way to internally use the new `.factoryFor` system, and not worry if `no-double-extend` feature was enabled or disabled.
* Remove `LOOKUP_FACTORY` symbol. This was added as a "backdoor" to use `container.lookupFactory` (and its double extend semantics) without triggering a deprecation.