### PR TITLE
[DOC release] Consider making `Ember.expandProperties` public

### DIFF
--- a/packages/ember-metal/lib/expand_properties.js
+++ b/packages/ember-metal/lib/expand_properties.js
@@ -29,7 +29,7 @@ var END_WITH_EACH_REGEX = /\.@each$/;
 
   @method expandProperties
   @for Ember
-  @private
+  @public
   @param {String} pattern The property pattern to expand.
   @param {Function} callback The callback to invoke.  It is invoked once per
   expansion, and is passed the expansion.


### PR DESCRIPTION
Merging this PR would make `Ember.expandProperties` public.

Often when working on computed property macros, it is helpful to be able to parse dependent keys in a manner similar to how Ember does. Though special properties like `@each` and `[]` remain tricky, making `expandProperties` public would help greatly with consistent handling of brace expansion.

This private method has already been used in addons that provide computed property macros, such as [`ember-computed-decorators`](https://github.com/rwjblue/ember-computed-decorators), recently through [`ember-macro-helpers`](https://github.com/kellyselden/ember-macro-helpers).