### PR TITLE
correct casing of _routermicrolib deprecation url

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -1565,7 +1565,7 @@ function representEmptyRoute(liveRoutes, defaultParentState, route) {
 deprecateProperty(EmberRouter.prototype, 'router', '_routerMicrolib', {
   id: 'ember-router.router',
   until: '2.16',
-  url: 'http://emberjs.com/deprecations/v2.x/#toc_ember-router-router-renamed-to-ember-router-_routerMicrolib'
+  url: 'http://emberjs.com/deprecations/v2.x/#toc_ember-router-router-renamed-to-ember-router-_routermicrolib'
 });
 
 export default EmberRouter;


### PR DESCRIPTION
The current link will not actually scroll down to the anchor specified because of the casing difference