### PR TITLE
[BUGFIX beta] don’t assume a controller supports queryParams

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -3,6 +3,7 @@ import {
   get,
   set,
   getProperties,
+  setProperties,
   isNone,
   computed,
   run,
@@ -162,12 +163,12 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     let hasRouterDefinedQueryParams = !!Object.keys(queryParameterConfiguraton).length;
 
     if (controller) {
-      // the developer has authored a controller class in their application for this route
-      // access the prototype, find its query params and normalize their object shape
-      // them merge in the query params for the route. As a mergedProperty, Route#queryParams is always
-      // at least `{}`
+      // the developer has authored a controller class in their application for
+      // this route find its query params and normalize their object shape them
+      // merge in the query params for the route. As a mergedProperty,
+      // Route#queryParams is always at least `{}`
 
-      let controllerDefinedQueryParameterConfiguration = get(controller, 'queryParams');
+      let controllerDefinedQueryParameterConfiguration = get(controller, 'queryParams') || {};
       let normalizedControllerQueryParameterConfiguration = normalizeControllerQueryParams(controllerDefinedQueryParameterConfiguration);
       combinedQueryParameterConfiguration = mergeEachQueryParams(normalizedControllerQueryParameterConfiguration, queryParameterConfiguraton);
     } else if (hasRouterDefinedQueryParams) {
@@ -1327,7 +1328,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
 
     if (transition) {
       let qpValues = getQueryParamsFor(this, transition.state);
-      controller.setProperties(qpValues);
+      setProperties(controller, qpValues);
     }
 
     this.setupController(controller, context, transition);

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -305,6 +305,18 @@ QUnit.module('Ember.Route interaction', {
   }
 });
 
+
+QUnit.test('route._qp does not crash if the controller has no QP, or setProperties', function() {
+  lookupHash['controller:test'] = {};
+
+  routeOne.controllerName = 'test';
+  let qp = routeOne.get('_qp');
+
+  deepEqual(qp.map, {}, 'map should be empty');
+  deepEqual(qp.propertyNames, [], 'property names should be empty');
+  deepEqual(qp.qps, [], 'qps is should be empty');
+});
+
 QUnit.test('controllerFor uses route\'s controllerName if specified', function() {
   let testController = {};
   lookupHash['controller:test'] = testController;


### PR DESCRIPTION
* use setProperties helper over controller.setProperties
* default queryParams to {} if not present

- [x] needs test