### PR TITLE
added detection for backslash folder delimiter

### DIFF
--- a/broccoli/packages.js
+++ b/broccoli/packages.js
@@ -97,7 +97,7 @@ module.exports.handlebarsES = function _handlebars() {
 }
 
 function handlebarsFix() {
-  var HANDLEBARS_PARSER = /\/parser.js$/;
+  var HANDLEBARS_PARSER = /[\/\\]parser.js$/;
   return {
     load: function(id) {
       if (HANDLEBARS_PARSER.test(id)) {


### PR DESCRIPTION
`npm run build` currently fails here on platforms that don't use `/` to separate folders in paths.