### PR TITLE
Remove support for deprecated `.container` property on objects.

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -1,6 +1,6 @@
+/* globals Proxy */
 import { assert, deprecate } from 'ember-debug';
 import { DEBUG } from 'ember-env-flags';
-/* globals Proxy */
 import {
   dictionary,
   symbol,
@@ -35,7 +35,6 @@ export default function Container(registry, options) {
   this.factoryCache    = dictionary(options && options.factoryCache ? options.factoryCache : null);
   this.factoryManagerCache = dictionary(options && options.factoryManagerCache ? options.factoryManagerCache : null);
   this.validationCache = dictionary(options && options.validationCache ? options.validationCache : null);
-  this._fakeContainerToInject = buildFakeContainerWithDeprecations(this);
   this[CONTAINER_OVERRIDE] = undefined;
   this.isDestroyed = false;
 }
@@ -390,8 +389,6 @@ function deprecatedFactoryFor(container, fullName, options = {}) {
 
     let injectedFactory = factory.extend(injections);
 
-    // TODO - remove all `container` injections when Ember reaches v3.0.0
-    injectDeprecatedContainer(injectedFactory.prototype, container);
     injectedFactory.reopenClass(factoryInjections);
 
     if (factory && typeof factory._onLookup === 'function') {
@@ -484,29 +481,6 @@ function factoryInjectionsFor(container, fullName) {
   return factoryInjections;
 }
 
-const INJECTED_DEPRECATED_CONTAINER_DESC = {
-  configurable: true,
-  enumerable: false,
-  get() {
-    deprecate('Using the injected `container` is deprecated. Please use the `getOwner` helper instead to access the owner of this object.', false, { id: 'ember-application.injected-container', until: '2.13.0', url: 'http://emberjs.com/deprecations/v2.x#toc_injected-container-access' });
-    return this[CONTAINER_OVERRIDE] || getOwner(this).__container__;
-  },
-
-  set(value) {
-    deprecate(`Providing the \`container\` property to ${this} is deprecated. Please use \`Ember.setOwner\` or \`owner.ownerInjection()\` instead to provide an owner to the instance being created.`, false, { id: 'ember-application.injected-container', until: '2.13.0', url: 'http://emberjs.com/deprecations/v2.x#toc_injected-container-access' });
-
-    this[CONTAINER_OVERRIDE] = value;
-
-    return value;
-  }
-};
-
-// TODO - remove when Ember reaches v3.0.0
-function injectDeprecatedContainer(object, container) {
-  if ('container' in object) { return; }
-  Object.defineProperty(object, 'container', INJECTED_DEPRECATED_CONTAINER_DESC);
-}
-
 function destroyDestroyables(container) {
   let cache = container.cache;
   let keys = Object.keys(cache);
@@ -538,31 +512,6 @@ function resetMember(container, fullName) {
       member.destroy();
     }
   }
-}
-
-export function buildFakeContainerWithDeprecations(container) {
-  let fakeContainer = {};
-  let propertyMappings = {
-    lookup: 'lookup',
-    lookupFactory: '_lookupFactory'
-  };
-
-  for (let containerProperty in propertyMappings) {
-    fakeContainer[containerProperty] = buildFakeContainerFunction(container, containerProperty, propertyMappings[containerProperty]);
-  }
-
-  return fakeContainer;
-}
-
-function buildFakeContainerFunction(container, containerProperty, ownerProperty) {
-  return function () {
-    deprecate(`Using the injected \`container\` is deprecated. Please use the \`getOwner\` helper to access the owner of this object and then call \`${ownerProperty}\` instead.`, false, {
-      id: 'ember-application.injected-container',
-      until: '2.13.0',
-      url: 'http://emberjs.com/deprecations/v2.x#toc_injected-container-access'
-    });
-    return container[containerProperty](...arguments);
-  };
 }
 
 class DeprecatedFactoryManager {
@@ -624,11 +573,6 @@ class FactoryManager {
 
     if (!this.class.create) {
       throw new Error(`Failed to create an instance of '${this.normalizedName}'. Most likely an improperly defined class or` + ` an invalid module export.`);
-    }
-
-    let prototype = this.class.prototype;
-    if (prototype) {
-      injectDeprecatedContainer(prototype, this.container);
     }
 
     // required to allow access to things like

--- a/packages/container/lib/index.js
+++ b/packages/container/lib/index.js
@@ -7,6 +7,5 @@ The public API, specified on the application namespace should be considered the 
 
 export { default as Registry, privatize } from './registry';
 export {
-  default as Container,
-  buildFakeContainerWithDeprecations
+  default as Container
 } from './container';

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -552,46 +552,6 @@ QUnit.test('An object with its owner pre-set should be returned from ownerInject
   equal(result[OWNER], owner, 'owner is properly included');
 });
 
-QUnit.test('A deprecated `container` property is appended to every object instantiated from an extendable factory', function() {
-  let owner = { };
-  let registry = new Registry();
-  let container = owner.__container__ = registry.container({ owner });
-  let PostController = factory();
-  registry.register('controller:post', PostController);
-  let postController = container.lookup('controller:post');
-
-  expectDeprecation(() => {
-    get(postController, 'container');
-  }, 'Using the injected `container` is deprecated. Please use the `getOwner` helper instead to access the owner of this object.');
-
-  expectDeprecation(() => {
-    let c = postController.container;
-    strictEqual(c, container);
-  }, 'Using the injected `container` is deprecated. Please use the `getOwner` helper instead to access the owner of this object.');
-});
-
-QUnit.test('An extendable factory can provide `container` upon create, with a deprecation', function(assert) {
-  let registry = new Registry();
-  let container = registry.container();
-
-  registry.register('controller:post', factory());
-
-  let PostController = lookupFactory('controller:post', container);
-
-  let postController;
-
-  expectDeprecation(() => {
-    postController = PostController.create({
-      container: 'foo'
-    });
-  }, /Providing the \`container\` property to .+ is deprecated. Please use \`Ember.setOwner\` or \`owner.ownerInjection\(\)\` instead to provide an owner to the instance being created/);
-
-  expectDeprecation(() => {
-    let c = postController.container;
-    assert.equal(c, 'foo', 'the `container` provided to `.create`was used');
-  }, 'Using the injected `container` is deprecated. Please use the `getOwner` helper instead to access the owner of this object.');
-});
-
 QUnit.test('lookupFactory passes options through to expandlocallookup', function(assert) {
   let registry = new Registry();
   let container = registry.container();


### PR DESCRIPTION
This has been deprecated since Ember 2.3 (through multiple LTS releases).