### PR TITLE
Remove `_lookupFactory` support.

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -166,6 +166,10 @@ Container.prototype = {
       return;
     }
 
+    if (DEBUG && factory && typeof factory._onLookup === 'function') {
+      factory._onLookup(fullName);
+    }
+
     let manager = new FactoryManager(this, factory, fullName, normalizedName);
 
     if (DEBUG) {

--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -32,8 +32,6 @@ export default function Registry(options) {
 
   this._typeInjections        = dictionary(null);
   this._injections            = dictionary(null);
-  this._factoryTypeInjections = dictionary(null);
-  this._factoryInjections     = dictionary(null);
 
   this._localLookupCache      = Object.create(null);
   this._normalizeCache        = dictionary(null);
@@ -85,22 +83,6 @@ Registry.prototype = {
    @type InheritingDict
    */
   _injections: null,
-
-  /**
-   @private
-
-   @property _factoryTypeInjections
-   @type InheritingDict
-   */
-  _factoryTypeInjections: null,
-
-  /**
-   @private
-
-   @property _factoryInjections
-   @type InheritingDict
-   */
-  _factoryInjections: null,
 
   /**
    @private
@@ -549,115 +531,6 @@ Registry.prototype = {
     });
   },
 
-
-  /**
-   Used only via `factoryInjection`.
-
-   Provides a specialized form of injection, specifically enabling
-   all factory of one type to be injected with a reference to another
-   object.
-
-   For example, provided each factory of type `model` needed a `store`.
-   one would do the following:
-
-   ```javascript
-   let registry = new Registry();
-
-   registry.register('store:main', SomeStore);
-
-   registry.factoryTypeInjection('model', 'store', 'store:main');
-
-   let store = registry.lookup('store:main');
-   let UserFactory = registry.lookupFactory('model:user');
-
-   UserFactory.store instanceof SomeStore; //=> true
-   ```
-
-   @private
-   @method factoryTypeInjection
-   @param {String} type
-   @param {String} property
-   @param {String} fullName
-   */
-  factoryTypeInjection(type, property, fullName) {
-    let injections = this._factoryTypeInjections[type] ||
-                     (this._factoryTypeInjections[type] = []);
-
-    injections.push({
-      property: property,
-      fullName: this.normalize(fullName)
-    });
-  },
-
-  /**
-   Defines factory injection rules.
-
-   Similar to regular injection rules, but are run against factories, via
-   `Registry#lookupFactory`.
-
-   These rules are used to inject objects onto factories when they
-   are looked up.
-
-   Two forms of injections are possible:
-
-   * Injecting one fullName on another fullName
-   * Injecting one fullName on a type
-
-   Example:
-
-   ```javascript
-   let registry = new Registry();
-   let container = registry.container();
-
-   registry.register('store:main', Store);
-   registry.register('store:secondary', OtherStore);
-   registry.register('model:user', User);
-   registry.register('model:post', Post);
-
-   // injecting one fullName on another type
-   registry.factoryInjection('model', 'store', 'store:main');
-
-   // injecting one fullName on another fullName
-   registry.factoryInjection('model:post', 'secondaryStore', 'store:secondary');
-
-   let UserFactory = container.lookupFactory('model:user');
-   let PostFactory = container.lookupFactory('model:post');
-   let store = container.lookup('store:main');
-
-   UserFactory.store instanceof Store; //=> true
-   UserFactory.secondaryStore instanceof OtherStore; //=> false
-
-   PostFactory.store instanceof Store; //=> true
-   PostFactory.secondaryStore instanceof OtherStore; //=> true
-
-   // and both models share the same source instance
-   UserFactory.store === PostFactory.store; //=> true
-   ```
-
-   @private
-   @method factoryInjection
-   @param {String} factoryName
-   @param {String} property
-   @param {String} injectionName
-   */
-  factoryInjection(fullName, property, injectionName) {
-    let normalizedName = this.normalize(fullName);
-    let normalizedInjectionName = this.normalize(injectionName);
-
-    this.validateFullName(injectionName);
-
-    if (fullName.indexOf(':') === -1) {
-      return this.factoryTypeInjection(normalizedName, property, normalizedInjectionName);
-    }
-
-    let injections = this._factoryInjections[normalizedName] || (this._factoryInjections[normalizedName] = []);
-
-    injections.push({
-      property: property,
-      fullName: normalizedInjectionName
-    });
-  },
-
   /**
    @private
    @method knownForType
@@ -741,22 +614,6 @@ Registry.prototype = {
     let injections = this._typeInjections[type] || [];
     if (this.fallback) {
       injections = injections.concat(this.fallback.getTypeInjections(type));
-    }
-    return injections;
-  },
-
-  getFactoryInjections(fullName) {
-    let injections = this._factoryInjections[fullName] || [];
-    if (this.fallback) {
-      injections = injections.concat(this.fallback.getFactoryInjections(fullName));
-    }
-    return injections;
-  },
-
-  getFactoryTypeInjections(type) {
-    let injections = this._factoryTypeInjections[type] || [];
-    if (this.fallback) {
-      injections = injections.concat(this.fallback.getFactoryTypeInjections(type));
     }
     return injections;
   }

--- a/packages/container/tests/registry_test.js
+++ b/packages/container/tests/registry_test.js
@@ -436,29 +436,6 @@ QUnit.test('`getTypeInjections` includes type injections from a fallback registr
   equal(registry.getTypeInjections('model').length, 1, 'Injections from the fallback registry are merged');
 });
 
-QUnit.test('`getFactoryInjections` includes factory injections from a fallback registry', function() {
-  let fallback = new Registry();
-  let registry = new Registry({ fallback: fallback });
-
-  equal(registry.getFactoryInjections('model:user').length, 0, 'No factory injections in the primary registry');
-
-  fallback.factoryInjection('model:user', 'store', 'store:main');
-
-  equal(registry.getFactoryInjections('model:user').length, 1, 'Factory injections from the fallback registry are merged');
-});
-
-
-QUnit.test('`getFactoryTypeInjections` includes factory type injections from a fallback registry', function() {
-  let fallback = new Registry();
-  let registry = new Registry({ fallback: fallback });
-
-  equal(registry.getFactoryTypeInjections('model').length, 0, 'No factory type injections in the primary registry');
-
-  fallback.factoryInjection('model', 'store', 'store:main');
-
-  equal(registry.getFactoryTypeInjections('model').length, 1, 'Factory type injections from the fallback registry are merged');
-});
-
 QUnit.test('`knownForType` contains keys for each item of a given type', function() {
   let registry = new Registry();
 

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -60,12 +60,6 @@ QUnit.test('the default resolver looks up templates in Ember.TEMPLATES', functio
   setTemplate('fooBar', fooBarTemplate);
   setTemplate('fooBar/baz', fooBarBazTemplate);
 
-  ignoreDeprecation(() => {
-    equal(locator.lookupFactory('template:foo'), fooTemplate, 'resolves template:foo');
-    equal(locator.lookupFactory('template:fooBar'), fooBarTemplate, 'resolves template:foo_bar');
-    equal(locator.lookupFactory('template:fooBar.baz'), fooBarBazTemplate, 'resolves template:foo_bar.baz');
-  });
-
   equal(locator.factoryFor('template:foo').class, fooTemplate, 'resolves template:foo');
   equal(locator.factoryFor('template:fooBar').class, fooBarTemplate, 'resolves template:foo_bar');
   equal(locator.factoryFor('template:fooBar.baz').class, fooBarBazTemplate, 'resolves template:foo_bar.baz');
@@ -88,19 +82,11 @@ QUnit.test('the default resolver looks up arbitrary types on the namespace', fun
 QUnit.test('the default resolver resolves models on the namespace', function() {
   application.Post = EmberObject.extend({});
 
-  ignoreDeprecation(() => {
-    detectEqual(application.Post, locator.lookupFactory('model:post'), 'looks up Post model on application');
-  });
-
   detectEqual(application.Post, locator.factoryFor('model:post').class, 'looks up Post model on application');
 });
 
 QUnit.test('the default resolver resolves *:main on the namespace', function() {
   application.FooBar = EmberObject.extend({});
-
-  ignoreDeprecation(() => {
-    detectEqual(application.FooBar, locator.lookupFactory('foo-bar:main'), 'looks up FooBar type without name on application');
-  });
 
   detectEqual(application.FooBar, locator.factoryFor('foo-bar:main').class, 'looks up FooBar type without name on application');
 });
@@ -130,16 +116,14 @@ QUnit.test('the default resolver resolves container-registered helpers via looku
   application.register('helper:shorthand', shorthandHelper);
   application.register('helper:complete', helper);
 
-  ignoreDeprecation(() => {
-    let lookedUpShorthandHelper = locator.lookupFactory('helper:shorthand');
+  let lookedUpShorthandHelper = locator.factoryFor('helper:shorthand').class;
 
-    ok(lookedUpShorthandHelper.isHelperInstance, 'shorthand helper isHelper');
+  ok(lookedUpShorthandHelper.isHelperInstance, 'shorthand helper isHelper');
 
-    let lookedUpHelper = locator.lookupFactory('helper:complete');
+  let lookedUpHelper = locator.factoryFor('helper:complete').class;
 
-    ok(lookedUpHelper.isHelperFactory, 'complete helper is factory');
-    ok(helper.detect(lookedUpHelper), 'looked up complete helper');
-  });
+  ok(lookedUpHelper.isHelperFactory, 'complete helper is factory');
+  ok(helper.detect(lookedUpHelper), 'looked up complete helper');
 });
 
 QUnit.test('the default resolver resolves helpers on the namespace', function() {

--- a/packages/ember-runtime/lib/system/object.js
+++ b/packages/ember-runtime/lib/system/object.js
@@ -36,12 +36,6 @@ const EmberObject = CoreObject.extend(Observable, {
       let { factory } = meta;
 
       return factory && factory.fullName;
-    },
-
-    // we need a setter here largely to support the legacy
-    // `owner._lookupFactory` and its double extend
-    set(value) {
-      this[OVERRIDE_CONTAINER_KEY] = value;
     }
   }),
 
@@ -58,8 +52,8 @@ const EmberObject = CoreObject.extend(Observable, {
       return factory && factory.owner;
     },
 
-    // we need a setter here largely to support the legacy
-    // `owner._lookupFactory` and its double extend
+    // we need a setter here largely to support
+    // folks calling `owner.ownerInjection()` API
     set(value) {
       this[OVERRIDE_OWNER] = value;
     }

--- a/packages/ember-runtime/tests/controllers/controller_test.js
+++ b/packages/ember-runtime/tests/controllers/controller_test.js
@@ -159,12 +159,10 @@ if (!EmberDev.runningProdBuild) {
         foo: inject.controller('bar')
       });
 
+      owner.register('controller:bar', EmberObject.extend());
       owner.register('foo:main', AnObject);
 
-      expectDeprecation(() => {
-        owner._lookupFactory('foo:main');
-      }, /Using "_lookupFactory" is deprecated. Please use container.factoryFor instead./);
-
+      owner.lookup('foo:main');
     }, /Defining an injected controller property on a non-controller is not allowed./);
   });
 }

--- a/packages/ember-runtime/tests/inject_test.js
+++ b/packages/ember-runtime/tests/inject_test.js
@@ -32,11 +32,11 @@ if (!EmberDev.runningProdBuild) {
     });
 
     owner.register('foo:main', AnObject);
+    owner.register('foo:bar', EmberObject.extend());
+    owner.register('foo:baz', EmberObject.extend());
 
-    expect(2);
-    expectDeprecation(() => {
-      owner._lookupFactory('foo:main');
-    }, /Using "_lookupFactory" is deprecated. Please use container.factoryFor instead./);
+    expect(1);
+    owner.lookup('foo:main');
   });
 
   QUnit.test('attempting to inject a nonexistent container key should error', function() {

--- a/tests/node/helpers/component-module.js
+++ b/tests/node/helpers/component-module.js
@@ -64,7 +64,7 @@ function setupComponentTest() {
   module.owner.register('service:-document', new SimpleDOM.Document(), { instantiate: false });
 
   this._hasRendered = false;
-  let OutletView = module.owner._lookupFactory('view:-outlet');
+  let OutletView = module.owner.factoryFor('view:-outlet');
   var OutletTemplate = module.owner.lookup('template:-outlet');
   module.component = OutletView.create();
   this._outletState = {


### PR DESCRIPTION
This was deprecated in Ember 2.12 (which was an LTS version).

This removes `owner._lookupFactory` APIs completely. It also includes
factory injections, and factory type injections.