### PR TITLE
Remove expired deprecations.

### DIFF
--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -492,27 +492,6 @@ BootOptions.prototype.toEnvironment = function() {
   return env;
 };
 
-Object.defineProperty(ApplicationInstance.prototype, 'container', {
-  configurable: true,
-  enumerable: false,
-  get() {
-    let instance = this;
-    return {
-      lookup() {
-        deprecate(
-          'Using `ApplicationInstance.container.lookup` is deprecated. Please use `ApplicationInstance.lookup` instead.',
-          false, {
-            id: 'ember-application.app-instance-container',
-            until: '2.13.0',
-            url: 'http://emberjs.com/deprecations/v2.x/#toc_ember-applicationinstance-container'
-          }
-        );
-        return instance.lookup(...arguments);
-      }
-    };
-  }
-});
-
 Object.defineProperty(ApplicationInstance.prototype, 'registry', {
   configurable: true,
   enumerable: false,

--- a/packages/ember-application/tests/system/application_instance_test.js
+++ b/packages/ember-application/tests/system/application_instance_test.js
@@ -36,7 +36,7 @@ QUnit.test('an application instance can be created based upon an application', f
 });
 
 QUnit.test('properties (and aliases) are correctly assigned for accessing the container and registry', function() {
-  expect(9);
+  expect(6);
 
   appInstance = run(() => ApplicationInstance.create({ application }));
 
@@ -44,17 +44,10 @@ QUnit.test('properties (and aliases) are correctly assigned for accessing the co
   ok(appInstance.__container__, '#__container__ is accessible');
   ok(appInstance.__registry__, '#__registry__ is accessible');
 
-  ok(typeof appInstance.container.lookup === 'function', '#container.lookup is available as a function');
-
   // stub with a no-op to keep deprecation test simple
   appInstance.__container__.lookup = function() {
     ok(true, '#loookup alias is called correctly');
   };
-
-  expectDeprecation(() => {
-    appInstance.container.lookup();
-  }, /Using `ApplicationInstance.container.lookup` is deprecated. Please use `ApplicationInstance.lookup` instead./);
-
 
   ok(typeof appInstance.registry.register === 'function', '#registry.register is available as a function');
   appInstance.__registry__.register = function() {

--- a/packages/ember-glimmer/tests/integration/components/append-test.js
+++ b/packages/ember-glimmer/tests/integration/components/append-test.js
@@ -640,38 +640,3 @@ moduleFor('appendTo: with multiple components', class extends AbstractAppendTest
     return jQuery('#qunit-fixture')[0];
   }
 });
-
-moduleFor('renderToElement: no arguments (defaults to a body context)', class extends AbstractAppendTest {
-
-  append(component) {
-    expectDeprecation(/Using the `renderToElement` is deprecated in favor of `appendTo`. Called in/);
-    let wrapper;
-
-    this.runTask(() => wrapper = component.renderToElement());
-    this.didAppend(component);
-
-    this.assert.equal(wrapper.tagName, 'BODY', 'wrapper is a body element');
-    this.assert.notEqual(wrapper, document.body, 'wrapper is not document.body');
-    this.assert.ok(!wrapper.parentNode, 'wrapper is detached');
-
-    return wrapper;
-  }
-
-});
-
-moduleFor('renderToElement: a div', class extends AbstractAppendTest {
-
-  append(component) {
-    expectDeprecation(/Using the `renderToElement` is deprecated in favor of `appendTo`. Called in/);
-    let wrapper;
-
-    this.runTask(() => wrapper = component.renderToElement('div'));
-    this.didAppend(component);
-
-    this.assert.equal(wrapper.tagName, 'DIV', 'wrapper is a body element');
-    this.assert.ok(!wrapper.parentNode, 'wrapper is detached');
-
-    return wrapper;
-  }
-
-});

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -2873,14 +2873,14 @@ moduleFor('Components test: curly components', class extends RenderingTest {
           this.didInit = true;
         },
 
-        didInitAttrs({ attrs }) {
+        didInitAttrs() {
           assert.ok(this.didInit, 'expected init to have run before didInitAttrs');
-          this.set('fooCopy', attrs.foo.value + 1);
+          this.set('fooCopy', this.attrs.foo.value + 1);
         },
 
-        didReceiveAttrs({ newAttrs }) {
+        didReceiveAttrs() {
           assert.ok(this.didInit, 'expected init to have run before didReceiveAttrs');
-          this.set('barCopy', newAttrs.bar.value + 1);
+          this.set('barCopy', this.attrs.bar.value + 1);
         },
 
         fooCopyDidChange: observer('fooCopy', () => { fooCopyDidChangeCount++; }),
@@ -2924,40 +2924,6 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     });
 
     this.render(`{{foo-bar foo=foo bar=bar}}`, { foo: 1, bar: 3 });
-  }
-
-  ['@test can access didReceiveAttrs arguments [DEPRECATED]'](assert) {
-    expectDeprecation(/didReceiveAttrs.*stop taking arguments/);
-
-    this.registerComponent('foo-bar', {
-      ComponentClass: Component.extend({
-        didReceiveAttrs({ attrs }) {
-          assert.equal(1, attrs.foo.value, 'expected attrs to have correct value')
-        }
-      }),
-
-      template: '{{foo}}-{{fooCopy}}-{{bar}}-{{barCopy}}'
-    });
-
-    this.render(`{{foo-bar foo=foo bar=bar}}`, { foo: 1, bar: 3 });
-  }
-
-  ['@test can access didUpdateAttrs arguments [DEPRECATED]'](assert) {
-    expectDeprecation(/didUpdateAttrs.*stop taking arguments/);
-
-    this.registerComponent('foo-bar', {
-      ComponentClass: Component.extend({
-        didUpdateAttrs({ newAttrs }) {
-          assert.equal(5, newAttrs.foo.value, "expected newAttrs to have new value");
-        }
-      }),
-
-      template: '{{foo}}-{{fooCopy}}-{{bar}}-{{barCopy}}'
-    });
-
-    this.render(`{{foo-bar foo=foo bar=bar}}`, { foo: 1, bar: 3 });
-
-    this.runTask(() => set(this.context, 'foo', 5));
   }
 
   ['@test overriding didUpdateAttrs does not trigger deprecation'](assert) {

--- a/packages/ember-glimmer/tests/integration/components/life-cycle-test.js
+++ b/packages/ember-glimmer/tests/integration/components/life-cycle-test.js
@@ -307,22 +307,22 @@ class LifeCycleHooksTest extends RenderingTest {
         // Sync hooks
 
         ['the-top', 'init'],
-        ['the-top', 'didInitAttrs',       { attrs: topAttrs, newAttrs: topAttrs }],
-        ['the-top', 'didReceiveAttrs',    { attrs: topAttrs, newAttrs: topAttrs }],
+        ['the-top', 'didInitAttrs'],
+        ['the-top', 'didReceiveAttrs'],
         ['the-top', 'on(init)'],
         ['the-top', 'willRender'],
         ['the-top', 'willInsertElement'],
 
         ['the-middle', 'init'],
-        ['the-middle', 'didInitAttrs',    { attrs: middleAttrs, newAttrs: middleAttrs }],
-        ['the-middle', 'didReceiveAttrs', { attrs: middleAttrs, newAttrs: middleAttrs }],
+        ['the-middle', 'didInitAttrs'],
+        ['the-middle', 'didReceiveAttrs'],
         ['the-middle', 'on(init)'],
         ['the-middle', 'willRender'],
         ['the-middle', 'willInsertElement'],
 
         ['the-bottom', 'init'],
-        ['the-bottom', 'didInitAttrs',    { attrs: bottomAttrs, newAttrs: bottomAttrs }],
-        ['the-bottom', 'didReceiveAttrs', { attrs: bottomAttrs, newAttrs: bottomAttrs }],
+        ['the-bottom', 'didInitAttrs'],
+        ['the-bottom', 'didReceiveAttrs'],
         ['the-bottom', 'on(init)'],
         ['the-bottom', 'willRender'],
         ['the-bottom', 'willInsertElement'],
@@ -343,18 +343,18 @@ class LifeCycleHooksTest extends RenderingTest {
       nonInteractive: [
         // Sync hooks
         ['the-top', 'init'],
-        ['the-top', 'didInitAttrs',       { attrs: topAttrs, newAttrs: topAttrs }],
-        ['the-top', 'didReceiveAttrs',    { attrs: topAttrs, newAttrs: topAttrs }],
+        ['the-top', 'didInitAttrs'],
+        ['the-top', 'didReceiveAttrs'],
         ['the-top', 'on(init)'],
 
         ['the-middle', 'init'],
-        ['the-middle', 'didInitAttrs',    { attrs: middleAttrs, newAttrs: middleAttrs }],
-        ['the-middle', 'didReceiveAttrs', { attrs: middleAttrs, newAttrs: middleAttrs }],
+        ['the-middle', 'didInitAttrs'],
+        ['the-middle', 'didReceiveAttrs'],
         ['the-middle', 'on(init)'],
 
         ['the-bottom', 'init'],
-        ['the-bottom', 'didInitAttrs',    { attrs: bottomAttrs, newAttrs: bottomAttrs }],
-        ['the-bottom', 'didReceiveAttrs', { attrs: bottomAttrs, newAttrs: bottomAttrs }],
+        ['the-bottom', 'didInitAttrs'],
+        ['the-bottom', 'didReceiveAttrs'],
         ['the-bottom', 'on(init)']
       ]
     });
@@ -452,16 +452,14 @@ class LifeCycleHooksTest extends RenderingTest {
     // the new attribute to rerender itself imperatively, that would result
     // in lifecycle hooks being invoked for the child.
 
-    topAttrs = { attrs: { twitter: '@horsetomdale' }, oldAttrs: { twitter: '@tomdale' }, newAttrs: { twitter: '@horsetomdale' } };
-
     this.assertHooks({
       label: 'after update',
 
       interactive: [
         // Sync hooks
 
-        ['the-top', 'didUpdateAttrs', topAttrs],
-        ['the-top', 'didReceiveAttrs', topAttrs],
+        ['the-top', 'didUpdateAttrs'],
+        ['the-top', 'didReceiveAttrs'],
 
         ['the-top', 'willUpdate'],
         ['the-top', 'willRender'],
@@ -474,8 +472,8 @@ class LifeCycleHooksTest extends RenderingTest {
 
       nonInteractive: [
         // Sync hooks
-        ['the-top', 'didUpdateAttrs', topAttrs],
-        ['the-top', 'didReceiveAttrs', topAttrs]
+        ['the-top', 'didUpdateAttrs'],
+        ['the-top', 'didReceiveAttrs']
       ]
     });
 
@@ -539,11 +537,6 @@ class LifeCycleHooksTest extends RenderingTest {
     this.assertText('Twitter: @tomdale|Name: Tom Dale|Website: tomdale.net');
     this.assertRegisteredViews('intial render');
 
-    let parentAttrs = { twitter: '@tomdale', name: 'Tom Dale', website: 'tomdale.net' };
-    let firstAttrs  = { twitter: '@tomdale' };
-    let secondAttrs = { name: 'Tom Dale' };
-    let lastAttrs = { website: 'tomdale.net' };
-
     this.assertHooks({
       label: 'after initial render',
 
@@ -551,30 +544,30 @@ class LifeCycleHooksTest extends RenderingTest {
         // Sync hooks
 
         ['the-parent', 'init'],
-        ['the-parent', 'didInitAttrs',          { attrs: parentAttrs, newAttrs: parentAttrs }],
-        ['the-parent', 'didReceiveAttrs',       { attrs: parentAttrs, newAttrs: parentAttrs }],
+        ['the-parent', 'didInitAttrs'],
+        ['the-parent', 'didReceiveAttrs'],
         ['the-parent', 'on(init)'],
         ['the-parent', 'willRender'],
         ['the-parent', 'willInsertElement'],
 
 
         ['the-first-child', 'init'],
-        ['the-first-child', 'didInitAttrs',     { attrs: firstAttrs, newAttrs: firstAttrs }],
-        ['the-first-child', 'didReceiveAttrs',  { attrs: firstAttrs, newAttrs: firstAttrs }],
+        ['the-first-child', 'didInitAttrs'],
+        ['the-first-child', 'didReceiveAttrs'],
         ['the-first-child', 'on(init)'],
         ['the-first-child', 'willRender'],
         ['the-first-child', 'willInsertElement'],
 
         ['the-second-child', 'init'],
-        ['the-second-child', 'didInitAttrs',    { attrs: secondAttrs, newAttrs: secondAttrs }],
-        ['the-second-child', 'didReceiveAttrs', { attrs: secondAttrs, newAttrs: secondAttrs }],
+        ['the-second-child', 'didInitAttrs'],
+        ['the-second-child', 'didReceiveAttrs'],
         ['the-second-child', 'on(init)'],
         ['the-second-child', 'willRender'],
         ['the-second-child', 'willInsertElement'],
 
         ['the-last-child', 'init'],
-        ['the-last-child', 'didInitAttrs',      { attrs: lastAttrs, newAttrs: lastAttrs }],
-        ['the-last-child', 'didReceiveAttrs',   { attrs: lastAttrs, newAttrs: lastAttrs }],
+        ['the-last-child', 'didInitAttrs'],
+        ['the-last-child', 'didReceiveAttrs'],
         ['the-last-child', 'on(init)'],
         ['the-last-child', 'willRender'],
         ['the-last-child', 'willInsertElement'],
@@ -598,23 +591,23 @@ class LifeCycleHooksTest extends RenderingTest {
         // Sync hooks
 
         ['the-parent', 'init'],
-        ['the-parent', 'didInitAttrs',          { attrs: parentAttrs, newAttrs: parentAttrs }],
-        ['the-parent', 'didReceiveAttrs',       { attrs: parentAttrs, newAttrs: parentAttrs }],
+        ['the-parent', 'didInitAttrs'],
+        ['the-parent', 'didReceiveAttrs'],
         ['the-parent', 'on(init)'],
 
         ['the-first-child', 'init'],
-        ['the-first-child', 'didInitAttrs',     { attrs: firstAttrs, newAttrs: firstAttrs }],
-        ['the-first-child', 'didReceiveAttrs',  { attrs: firstAttrs, newAttrs: firstAttrs }],
+        ['the-first-child', 'didInitAttrs'],
+        ['the-first-child', 'didReceiveAttrs'],
         ['the-first-child', 'on(init)'],
 
         ['the-second-child', 'init'],
-        ['the-second-child', 'didInitAttrs',    { attrs: secondAttrs, newAttrs: secondAttrs }],
-        ['the-second-child', 'didReceiveAttrs', { attrs: secondAttrs, newAttrs: secondAttrs }],
+        ['the-second-child', 'didInitAttrs'],
+        ['the-second-child', 'didReceiveAttrs'],
         ['the-second-child', 'on(init)'],
 
         ['the-last-child', 'init'],
-        ['the-last-child', 'didInitAttrs',      { attrs: lastAttrs, newAttrs: lastAttrs }],
-        ['the-last-child', 'didReceiveAttrs',   { attrs: lastAttrs, newAttrs: lastAttrs }],
+        ['the-last-child', 'didInitAttrs'],
+        ['the-last-child', 'didReceiveAttrs'],
         ['the-last-child', 'on(init)']
       ]
     });
@@ -733,41 +726,32 @@ class LifeCycleHooksTest extends RenderingTest {
 
     this.assertText('Twitter: @horsetomdale|Name: Horse Tom Dale|Website: horsetomdale.net');
 
-    parentAttrs = {
-      attrs:    { twitter: '@horsetomdale', name: 'Horse Tom Dale', website: 'horsetomdale.net' },
-      oldAttrs: { twitter: '@tomdale', name: 'Tom Dale', website: 'tomdale.net' },
-      newAttrs: { twitter: '@horsetomdale', name: 'Horse Tom Dale', website: 'horsetomdale.net' }
-    };
-    firstAttrs  = { attrs: { twitter: '@horsetomdale' }, oldAttrs: { twitter: '@tomdale' }, newAttrs: { twitter: '@horsetomdale' } };
-    secondAttrs = { attrs: { name: 'Horse Tom Dale' }, oldAttrs: { name: 'Tom Dale' }, newAttrs: { name: 'Horse Tom Dale' } };
-    lastAttrs = { attrs: { website: 'horsetomdale.net' }, oldAttrs: { website: 'tomdale.net' }, newAttrs: { website: 'horsetomdale.net' } };
-
     this.assertHooks({
       label: 'after update',
 
       interactive: [
         // Sync hooks
 
-        ['the-parent', 'didUpdateAttrs', parentAttrs],
-        ['the-parent', 'didReceiveAttrs', parentAttrs],
+        ['the-parent', 'didUpdateAttrs'],
+        ['the-parent', 'didReceiveAttrs'],
 
         ['the-parent', 'willUpdate'],
         ['the-parent', 'willRender'],
 
-        ['the-first-child', 'didUpdateAttrs', firstAttrs],
-        ['the-first-child', 'didReceiveAttrs', firstAttrs],
+        ['the-first-child', 'didUpdateAttrs'],
+        ['the-first-child', 'didReceiveAttrs'],
 
         ['the-first-child', 'willUpdate'],
         ['the-first-child', 'willRender'],
 
-        ['the-second-child', 'didUpdateAttrs', secondAttrs],
-        ['the-second-child', 'didReceiveAttrs', secondAttrs],
+        ['the-second-child', 'didUpdateAttrs'],
+        ['the-second-child', 'didReceiveAttrs'],
 
         ['the-second-child', 'willUpdate'],
         ['the-second-child', 'willRender'],
 
-        ['the-last-child', 'didUpdateAttrs', lastAttrs],
-        ['the-last-child', 'didReceiveAttrs', lastAttrs],
+        ['the-last-child', 'didUpdateAttrs'],
+        ['the-last-child', 'didReceiveAttrs'],
 
         ['the-last-child', 'willUpdate'],
         ['the-last-child', 'willRender'],
@@ -790,17 +774,17 @@ class LifeCycleHooksTest extends RenderingTest {
       nonInteractive: [
         // Sync hooks
 
-        ['the-parent', 'didUpdateAttrs', parentAttrs],
-        ['the-parent', 'didReceiveAttrs', parentAttrs],
+        ['the-parent', 'didUpdateAttrs'],
+        ['the-parent', 'didReceiveAttrs'],
 
-        ['the-first-child', 'didUpdateAttrs', firstAttrs],
-        ['the-first-child', 'didReceiveAttrs', firstAttrs],
+        ['the-first-child', 'didUpdateAttrs'],
+        ['the-first-child', 'didReceiveAttrs'],
 
-        ['the-second-child', 'didUpdateAttrs', secondAttrs],
-        ['the-second-child', 'didReceiveAttrs', secondAttrs],
+        ['the-second-child', 'didUpdateAttrs'],
+        ['the-second-child', 'didReceiveAttrs'],
 
-        ['the-last-child', 'didUpdateAttrs', lastAttrs],
-        ['the-last-child', 'didReceiveAttrs', lastAttrs]
+        ['the-last-child', 'didUpdateAttrs'],
+        ['the-last-child', 'didReceiveAttrs']
       ]
     });
 
@@ -867,10 +851,6 @@ class LifeCycleHooksTest extends RenderingTest {
     this.assertText('Top: Middle: Bottom: @tomdale');
     this.assertRegisteredViews('intial render');
 
-    let topAttrs = { twitter: '@tomdale' };
-    let middleAttrs = { twitterTop: '@tomdale' };
-    let bottomAttrs = { twitterMiddle: '@tomdale' };
-
     this.assertHooks({
       label: 'after initial render',
 
@@ -878,22 +858,22 @@ class LifeCycleHooksTest extends RenderingTest {
         // Sync hooks
 
         ['the-top', 'init'],
-        ['the-top', 'didInitAttrs',       { attrs: topAttrs, newAttrs: topAttrs }],
-        ['the-top', 'didReceiveAttrs',    { attrs: topAttrs, newAttrs: topAttrs }],
+        ['the-top', 'didInitAttrs'],
+        ['the-top', 'didReceiveAttrs'],
         ['the-top', 'on(init)'],
         ['the-top', 'willRender'],
         ['the-top', 'willInsertElement'],
 
         ['the-middle', 'init'],
-        ['the-middle', 'didInitAttrs',    { attrs: middleAttrs, newAttrs: middleAttrs }],
-        ['the-middle', 'didReceiveAttrs', { attrs: middleAttrs, newAttrs: middleAttrs }],
+        ['the-middle', 'didInitAttrs'],
+        ['the-middle', 'didReceiveAttrs'],
         ['the-middle', 'on(init)'],
         ['the-middle', 'willRender'],
         ['the-middle', 'willInsertElement'],
 
         ['the-bottom', 'init'],
-        ['the-bottom', 'didInitAttrs',    { attrs: bottomAttrs, newAttrs: bottomAttrs }],
-        ['the-bottom', 'didReceiveAttrs', { attrs: bottomAttrs, newAttrs: bottomAttrs }],
+        ['the-bottom', 'didInitAttrs'],
+        ['the-bottom', 'didReceiveAttrs'],
         ['the-bottom', 'on(init)'],
         ['the-bottom', 'willRender'],
         ['the-bottom', 'willInsertElement'],
@@ -914,18 +894,18 @@ class LifeCycleHooksTest extends RenderingTest {
         // Sync hooks
 
         ['the-top', 'init'],
-        ['the-top', 'didInitAttrs',       { attrs: topAttrs, newAttrs: topAttrs }],
-        ['the-top', 'didReceiveAttrs',    { attrs: topAttrs, newAttrs: topAttrs }],
+        ['the-top', 'didInitAttrs'],
+        ['the-top', 'didReceiveAttrs'],
         ['the-top', 'on(init)'],
 
         ['the-middle', 'init'],
-        ['the-middle', 'didInitAttrs',    { attrs: middleAttrs, newAttrs: middleAttrs }],
-        ['the-middle', 'didReceiveAttrs', { attrs: middleAttrs, newAttrs: middleAttrs }],
+        ['the-middle', 'didInitAttrs'],
+        ['the-middle', 'didReceiveAttrs'],
         ['the-middle', 'on(init)'],
 
         ['the-bottom', 'init'],
-        ['the-bottom', 'didInitAttrs',    { attrs: bottomAttrs, newAttrs: bottomAttrs }],
-        ['the-bottom', 'didReceiveAttrs', { attrs: bottomAttrs, newAttrs: bottomAttrs }],
+        ['the-bottom', 'didInitAttrs'],
+        ['the-bottom', 'didReceiveAttrs'],
         ['the-bottom', 'on(init)']
       ]
     });
@@ -937,30 +917,26 @@ class LifeCycleHooksTest extends RenderingTest {
     // Because the `twitter` attr is used by the all of the components,
     // the lifecycle hooks are invoked for all components.
 
-    topAttrs = { attrs: { twitter: '@horsetomdale' }, oldAttrs: { twitter: '@tomdale' }, newAttrs: { twitter: '@horsetomdale' } };
-    middleAttrs = { attrs: { twitterTop: '@horsetomdale' }, oldAttrs: { twitterTop: '@tomdale' }, newAttrs: { twitterTop: '@horsetomdale' } };
-    bottomAttrs = { attrs: { twitterMiddle: '@horsetomdale' }, oldAttrs: { twitterMiddle: '@tomdale' }, newAttrs: { twitterMiddle: '@horsetomdale' } };
-
     this.assertHooks({
       label: 'after updating (root)',
 
       interactive: [
         // Sync hooks
 
-        ['the-top', 'didUpdateAttrs', topAttrs],
-        ['the-top', 'didReceiveAttrs', topAttrs],
+        ['the-top', 'didUpdateAttrs'],
+        ['the-top', 'didReceiveAttrs'],
 
         ['the-top', 'willUpdate'],
         ['the-top', 'willRender'],
 
-        ['the-middle', 'didUpdateAttrs', middleAttrs],
-        ['the-middle', 'didReceiveAttrs', middleAttrs],
+        ['the-middle', 'didUpdateAttrs'],
+        ['the-middle', 'didReceiveAttrs'],
 
         ['the-middle', 'willUpdate'],
         ['the-middle', 'willRender'],
 
-        ['the-bottom', 'didUpdateAttrs', bottomAttrs],
-        ['the-bottom', 'didReceiveAttrs', bottomAttrs],
+        ['the-bottom', 'didUpdateAttrs'],
+        ['the-bottom', 'didReceiveAttrs'],
 
         ['the-bottom', 'willUpdate'],
         ['the-bottom', 'willRender'],
@@ -980,14 +956,14 @@ class LifeCycleHooksTest extends RenderingTest {
       nonInteractive: [
         // Sync hooks
 
-        ['the-top', 'didUpdateAttrs', topAttrs],
-        ['the-top', 'didReceiveAttrs', topAttrs],
+        ['the-top', 'didUpdateAttrs'],
+        ['the-top', 'didReceiveAttrs'],
 
-        ['the-middle', 'didUpdateAttrs', middleAttrs],
-        ['the-middle', 'didReceiveAttrs', middleAttrs],
+        ['the-middle', 'didUpdateAttrs'],
+        ['the-middle', 'didReceiveAttrs'],
 
-        ['the-bottom', 'didUpdateAttrs', bottomAttrs],
-        ['the-bottom', 'didReceiveAttrs', bottomAttrs]
+        ['the-bottom', 'didUpdateAttrs'],
+        ['the-bottom', 'didReceiveAttrs']
       ]
     });
 
@@ -996,10 +972,6 @@ class LifeCycleHooksTest extends RenderingTest {
     this.assertText('Top: Middle: Bottom: @horsetomdale');
 
     // In this case, because the attrs are passed down, all child components are invoked.
-
-    topAttrs = { attrs: { twitter: '@horsetomdale' }, oldAttrs: { twitter: '@horsetomdale' }, newAttrs: { twitter: '@horsetomdale' } };
-    middleAttrs = { attrs: { twitterTop: '@horsetomdale' }, oldAttrs: { twitterTop: '@horsetomdale' }, newAttrs: { twitterTop: '@horsetomdale' } };
-    bottomAttrs = { attrs: { twitterMiddle: '@horsetomdale' }, oldAttrs: { twitterMiddle: '@horsetomdale' }, newAttrs: { twitterMiddle: '@horsetomdale' } };
 
     this.assertHooks({
       label: 'after no-op rernder (root)',
@@ -1066,8 +1038,8 @@ class LifeCycleHooksTest extends RenderingTest {
     let initialHooks = (count) => {
       let ret = [
         ['an-item', 'init'],
-        ['an-item', 'didInitAttrs',       { attrs: { count }, newAttrs: { count } }],
-        ['an-item', 'didReceiveAttrs',    { attrs: { count }, newAttrs: { count } }],
+        ['an-item', 'didInitAttrs'],
+        ['an-item', 'didReceiveAttrs'],
         ['an-item', 'on(init)']
       ];
       if (this.isInteractive) {
@@ -1078,8 +1050,8 @@ class LifeCycleHooksTest extends RenderingTest {
       }
       ret.push(
         ['nested-item', 'init'],
-        ['nested-item', 'didInitAttrs',       { attrs: { }, newAttrs: { } }],
-        ['nested-item', 'didReceiveAttrs',    { attrs: { }, newAttrs: { } }],
+        ['nested-item', 'didInitAttrs'],
+        ['nested-item', 'didReceiveAttrs'],
         ['nested-item', 'on(init)']
       );
       if (this.isInteractive) {
@@ -1180,16 +1152,16 @@ class LifeCycleHooksTest extends RenderingTest {
         ['nested-item', 'willClearRender'],
 
         ['no-items', 'init'],
-        ['no-items', 'didInitAttrs',       { attrs: { }, newAttrs: { } }],
-        ['no-items', 'didReceiveAttrs',    { attrs: { }, newAttrs: { } }],
+        ['no-items', 'didInitAttrs'],
+        ['no-items', 'didReceiveAttrs'],
         ['no-items', 'on(init)'],
         ['no-items', 'willRender'],
         ['no-items', 'willInsertElement'],
 
 
         ['nested-item', 'init'],
-        ['nested-item', 'didInitAttrs',       { attrs: { }, newAttrs: { } }],
-        ['nested-item', 'didReceiveAttrs',    { attrs: { }, newAttrs: { } }],
+        ['nested-item', 'didInitAttrs'],
+        ['nested-item', 'didReceiveAttrs'],
         ['nested-item', 'on(init)'],
         ['nested-item', 'willRender'],
         ['nested-item', 'willInsertElement'],
@@ -1224,13 +1196,13 @@ class LifeCycleHooksTest extends RenderingTest {
 
       nonInteractive: [
         ['no-items', 'init'],
-        ['no-items', 'didInitAttrs',       { attrs: { }, newAttrs: { } }],
-        ['no-items', 'didReceiveAttrs',    { attrs: { }, newAttrs: { } }],
+        ['no-items', 'didInitAttrs'],
+        ['no-items', 'didReceiveAttrs'],
         ['no-items', 'on(init)'],
 
         ['nested-item', 'init'],
-        ['nested-item', 'didInitAttrs',       { attrs: { }, newAttrs: { } }],
-        ['nested-item', 'didReceiveAttrs',    { attrs: { }, newAttrs: { } }],
+        ['nested-item', 'didInitAttrs'],
+        ['nested-item', 'didReceiveAttrs'],
         ['nested-item', 'on(init)'],
 
         ['an-item', 'willDestroy'],

--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -16,8 +16,7 @@ import TestPromise, {
 import {
   checkWaiters,
   registerWaiter,
-  unregisterWaiter,
-  generateDeprecatedWaitersArray
+  unregisterWaiter
 } from './test/waiters';
 
 import {
@@ -82,10 +81,6 @@ const Test = {
 Object.defineProperty(Test, 'adapter', {
   get: getAdapter,
   set: setAdapter
-});
-
-Object.defineProperty(Test, 'waiters', {
-  get: generateDeprecatedWaitersArray
 });
 
 export default Test;

--- a/packages/ember-testing/lib/test/waiters.js
+++ b/packages/ember-testing/lib/test/waiters.js
@@ -108,21 +108,3 @@ function indexOf(context, callback) {
   }
   return -1;
 }
-
-export function generateDeprecatedWaitersArray() {
-  deprecate(
-    'Usage of `Ember.Test.waiters` is deprecated. Please refactor to `Ember.Test.checkWaiters`.',
-    false,
-    { until: '2.8.0', id: 'ember-testing.test-waiters' }
-  );
-
-  let array = new Array(callbacks.length);
-  for (let i = 0; i < callbacks.length; i++) {
-    let context = contexts[i];
-    let callback = callbacks[i];
-
-    array[i] = [context, callback];
-  }
-
-  return array;
-}

--- a/packages/ember-testing/tests/test/waiters-test.js
+++ b/packages/ember-testing/tests/test/waiters-test.js
@@ -1,8 +1,7 @@
 import {
   registerWaiter,
   unregisterWaiter,
-  checkWaiters,
-  generateDeprecatedWaitersArray
+  checkWaiters
 } from '../../test/waiters';
 
 class Waiters {
@@ -143,24 +142,4 @@ QUnit.test('checkWaiters short circuits after first falsey waiter', function(ass
   });
 
   assert.ok(this.waiters.check(), 'checkWaiters returns false if any waiters return false');
-});
-
-QUnit.test('generateDeprecatedWaitersArray provides deprecated access to waiters array', function(assert) {
-  let waiter1 = () => {};
-  let waiter2 = () => {};
-
-  this.waiters.add(waiter1);
-  this.waiters.add(waiter2);
-
-  this.waiters.register();
-
-  let waiters;
-  expectDeprecation(function() {
-    waiters = generateDeprecatedWaitersArray();
-  }, /Usage of `Ember.Test.waiters` is deprecated/);
-
-  assert.deepEqual(waiters, [
-    [null, waiter1],
-    [null, waiter2]
-  ]);
 });

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -9,51 +9,8 @@ import { DEBUG } from 'ember-env-flags';
 
 function K() { return this; }
 
-export let dispatchLifeCycleHook = (component, hook, oldAttrs, newAttrs) => {
-  component.trigger(hook, { attrs: newAttrs, oldAttrs, newAttrs });
-};
-
-if (DEBUG) {
-  class Attrs {
-    constructor(oldAttrs, newAttrs, message) {
-      this._oldAttrs = oldAttrs;
-      this._newAttrs = newAttrs;
-      this._message = message;
-    }
-
-    get attrs() {
-      return this.newAttrs;
-    }
-
-    get oldAttrs() {
-      deprecate(this._message, false, {
-        id: 'ember-views.lifecycle-hook-arguments',
-        until: '2.13.0',
-        url: 'http://emberjs.com/deprecations/v2.x/#toc_arguments-in-component-lifecycle-hooks'
-      });
-
-      return this._oldAttrs;
-    }
-
-    get newAttrs() {
-      deprecate(this._message, false, {
-        id: 'ember-views.lifecycle-hook-arguments',
-        until: '2.13.0',
-        url: 'http://emberjs.com/deprecations/v2.x/#toc_arguments-in-component-lifecycle-hooks'
-      });
-
-      return this._newAttrs;
-    }
-  }
-
-  dispatchLifeCycleHook = (component, hook, oldAttrs, newAttrs) => {
-    if (typeof component[hook] === 'function' && component[hook].length !== 0) {
-      // Already warned in init
-      component.trigger(hook, { attrs: newAttrs, oldAttrs, newAttrs });
-    } else {
-      component.trigger(hook, new Attrs(oldAttrs, newAttrs, `[DEPRECATED] Ember will stop passing arguments to component lifecycle hooks. Please change \`${component.toString()}#${hook}\` to stop taking arguments.`));
-    }
-  };
+export function dispatchLifeCycleHook(component, hook, oldAttrs, newAttrs) {
+  component.trigger(hook);
 }
 
 /**
@@ -534,36 +491,6 @@ export default Mixin.create({
         id: 'ember-views.did-init-attrs',
         until: '3.0.0',
         url: 'http://emberjs.com/deprecations/v2.x#toc_ember-component-didinitattrs'
-      }
-    );
-
-    deprecate(
-      `[DEPRECATED] Ember will stop passing arguments to component lifecycle hooks. Please change \`${this.toString()}#didInitAttrs\` to stop taking arguments.`,
-      typeof this.didInitAttrs !== 'function' || this.didInitAttrs.length === 0,
-      {
-        id: 'ember-views.lifecycle-hook-arguments',
-        until: '2.13.0',
-        url: 'http://emberjs.com/deprecations/v2.x/#toc_arguments-in-component-lifecycle-hooks'
-      }
-    );
-
-    deprecate(
-      `[DEPRECATED] Ember will stop passing arguments to component lifecycle hooks. Please change \`${this.toString()}#didReceiveAttrs\` to stop taking arguments.`,
-      typeof this.didReceiveAttrs !== 'function' || this.didReceiveAttrs.length === 0,
-      {
-        id: 'ember-views.lifecycle-hook-arguments',
-        until: '2.13.0',
-        url: 'http://emberjs.com/deprecations/v2.x/#toc_arguments-in-component-lifecycle-hooks'
-      }
-    );
-
-    deprecate(
-      `[DEPRECATED] Ember will stop passing arguments to component lifecycle hooks. Please change \`${this.toString()}#didUpdateAttrs\` to stop taking arguments.`,
-      typeof this.didUpdateAttrs !== 'function' || this.didUpdateAttrs.length === 0,
-      {
-        id: 'ember-views.lifecycle-hook-arguments',
-        until: '2.13.0',
-        url: 'http://emberjs.com/deprecations/v2.x/#toc_arguments-in-component-lifecycle-hooks'
       }
     );
 

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -227,66 +227,6 @@ export default Mixin.create({
   },
 
   /**
-    Creates a new DOM element, renders the view into it, then returns the
-    element.
-
-    By default, the element created and rendered into will be a `BODY` element,
-    since this is the default context that views are rendered into when being
-    inserted directly into the DOM.
-
-    ```js
-    let element = view.renderToElement();
-    element.tagName; // => "BODY"
-    ```
-
-    You can override the kind of element rendered into and returned by
-    specifying an optional tag name as the first argument.
-
-    ```js
-    let element = view.renderToElement('table');
-    element.tagName; // => "TABLE"
-    ```
-
-    This method is useful if you want to render the view into an element that
-    is not in the document's body. Instead, a new `body` element, detached from
-    the DOM is returned. FastBoot uses this to serialize the rendered view into
-    a string for transmission over the network.
-
-    ```js
-    app.visit('/').then(function(instance) {
-      let element;
-      Ember.run(function() {
-        element = renderToElement(instance);
-      });
-
-      res.send(serialize(element));
-    });
-    ```
-
-    @method renderToElement
-    @param {String} tagName The tag of the element to create and render into. Defaults to "body".
-    @return {HTMLBodyElement} element
-    @deprecated Use appendTo instead.
-    @private
-  */
-  renderToElement(tagName = 'body') {
-    deprecate(
-      `Using the \`renderToElement\` is deprecated in favor of \`appendTo\`. Called in ${this.toString()}`,
-      false,
-      {
-        id: 'ember-views.render-to-element',
-        until: '2.12.0',
-        url: 'http://emberjs.com/deprecations/v2.x#toc_code-rendertoelement-code'
-      }
-    );
-
-    let element = this.renderer.createElement(tagName);
-
-    this.renderer.appendTo(this, element);
-    return element;
-  },
-
-  /**
     Appends the view's element to the document body. If the view does
     not have an HTML representation yet
     the element will be generated automatically.


### PR DESCRIPTION
* `Ember.ApplicationInstance.prototype.container` (missed during removal of `.container`)
* Remove passing of arguments into lifecycle hooks
* Remove `Ember.Test.waiters` API
* Remove `Ember.Component.prototype.renderToElement`

All of these deprecations have lived passed their `until` versions, and the deprecation has been included in an LTS version.  👋 