### PR TITLE
[BUGFIX release] MODEL_FACTORY_INJECTIONS is now always false.

### DIFF
--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -4,16 +4,7 @@ import { get } from 'ember-metal';
 import { Registry } from '..';
 import { factory } from 'internal-test-helpers';
 
-let originalModelInjections;
-
-QUnit.module('Container', {
-  setup() {
-    originalModelInjections = ENV.MODEL_FACTORY_INJECTIONS;
-  },
-  teardown() {
-    ENV.MODEL_FACTORY_INJECTIONS = originalModelInjections;
-  }
-});
+QUnit.module('Container');
 
 QUnit.test('A registered factory returns the same instance each time', function() {
   let registry = new Registry();
@@ -166,8 +157,6 @@ QUnit.test('An invalid factory throws an error', function() {
 });
 
 QUnit.test('Injecting a failed lookup raises an error', function() {
-  ENV.MODEL_FACTORY_INJECTIONS = true;
-
   let registry = new Registry();
   let container = registry.container();
 

--- a/packages/ember-application/tests/system/dependency_injection/to_string_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/to_string_test.js
@@ -5,13 +5,10 @@ import Application from '../../../system/application';
 import { Object as EmberObject } from 'ember-runtime';
 import DefaultResolver from '../../../system/resolver';
 
-let originalLookup, App, originalModelInjections;
+let originalLookup, App;
 
 QUnit.module('Ember.Application Dependency Injection – toString', {
   setup() {
-    originalModelInjections = ENV.MODEL_FACTORY_INJECTIONS;
-    ENV.MODEL_FACTORY_INJECTIONS = true;
-
     originalLookup = context.lookup;
 
     run(() => {
@@ -27,7 +24,6 @@ QUnit.module('Ember.Application Dependency Injection – toString', {
   teardown() {
     context.lookup = originalLookup;
     run(App, 'destroy');
-    ENV.MODEL_FACTORY_INJECTIONS = originalModelInjections;
   }
 });
 

--- a/packages/ember-application/tests/system/dependency_injection_test.js
+++ b/packages/ember-application/tests/system/dependency_injection_test.js
@@ -6,13 +6,10 @@ import Application from '../../system/application';
 let EmberApplication = Application;
 
 let originalLookup = context.lookup;
-let registry, locator, application, originalModelInjections;
+let registry, locator, application;
 
 QUnit.module('Ember.Application Dependency Injection', {
   setup() {
-    originalModelInjections = ENV.MODEL_FACTORY_INJECTIONS;
-    ENV.MODEL_FACTORY_INJECTIONS = true;
-
     application = run(EmberApplication, 'create');
 
     application.Person              = EmberObject.extend({});
@@ -36,7 +33,6 @@ QUnit.module('Ember.Application Dependency Injection', {
     run(application, 'destroy');
     application = locator = null;
     context.lookup = originalLookup;
-    ENV.MODEL_FACTORY_INJECTIONS = originalModelInjections;
   }
 });
 

--- a/packages/ember-environment/lib/index.js
+++ b/packages/ember-environment/lib/index.js
@@ -1,7 +1,6 @@
 /* globals module */
 import global from './global';
 import { defaultFalse, defaultTrue, normalizeExtendPrototypes } from './utils';
-
 /**
   The hash of environment variables used to control various configuration
   settings. To specify your own or override default settings, add the
@@ -65,9 +64,6 @@ ENV.LOG_STACKTRACE_ON_DEPRECATION = defaultTrue(ENV.LOG_STACKTRACE_ON_DEPRECATIO
   @public
 */
 ENV.LOG_VERSION = defaultTrue(ENV.LOG_VERSION);
-
-// default false
-ENV.MODEL_FACTORY_INJECTIONS = defaultFalse(ENV.MODEL_FACTORY_INJECTIONS);
 
 /**
   Debug parameter you can turn on. This will log all bindings that fire to

--- a/packages/ember-extension-support/lib/data_adapter.js
+++ b/packages/ember-extension-support/lib/data_adapter.js
@@ -386,7 +386,6 @@ export default EmberObject.extend({
         if (!namespace.hasOwnProperty(key)) { continue; }
         // Even though we will filter again in `getModelTypes`,
         // we should not call `lookupFactory` on non-models
-        // (especially when `EmberENV.MODEL_FACTORY_INJECTIONS` is `true`)
         if (!this.detect(namespace[key])) { continue; }
         let name = StringUtils.dasherize(key);
         types.push(name);

--- a/packages/ember-runtime/lib/mixins/registry_proxy.js
+++ b/packages/ember-runtime/lib/mixins/registry_proxy.js
@@ -241,11 +241,6 @@ export default Mixin.create({
     directly (via `create` or `new`) bypasses the dependency injection
     system.
 
-    **Note:** Ember-Data instantiates its models in a unique manner, and consequently
-    injections onto models (or all models) will not work as expected. Injections
-    on models can be enabled by setting `EmberENV.MODEL_FACTORY_INJECTIONS`
-    to `true`.
-
     @public
     @method inject
     @param  factoryNameOrType {String}

--- a/packages/ember/lib/index.js
+++ b/packages/ember/lib/index.js
@@ -1,4 +1,5 @@
 import require, { has } from 'require';
+import { DEBUG } from 'ember-env-flags';
 
 // ****ember-environment****
 import { ENV, context } from 'ember-environment';
@@ -174,11 +175,23 @@ Object.defineProperty(Ember, 'LOG_VERSION', {
   enumerable: false
 });
 
-Object.defineProperty(Ember, 'MODEL_FACTORY_INJECTIONS', {
-  get()      { return ENV.MODEL_FACTORY_INJECTIONS;    },
-  set(value) { ENV.MODEL_FACTORY_INJECTIONS = !!value;  },
-  enumerable: false
-});
+if (DEBUG) {
+  Object.defineProperty(Ember, 'MODEL_FACTORY_INJECTIONS', {
+    get()      { return false; },
+    set(value) {
+      deprecate(
+        'Ember.MODEL_FACTORY_INJECTIONS is no longer required',
+        false,
+        {
+          id: 'ember-metal.model_factory_injections',
+          until: '2.17.0',
+          url: 'http://emberjs.com/deprecations/v2.x#toc_code-ember-model-factory-injections'
+        }
+      );
+    },
+    enumerable: false
+  });
+}
 
 Object.defineProperty(Ember, 'LOG_BINDINGS', {
   get()      { return ENV.LOG_BINDINGS;    },

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -1,6 +1,7 @@
 import Ember from '../index';
 import { confirmExport } from 'internal-test-helpers';
 import { EMBER_METAL_WEAKMAP } from 'ember/features';
+import { DEBUG } from 'ember-env-flags';
 
 QUnit.module('ember reexports');
 
@@ -231,5 +232,20 @@ QUnit.test('Ember.String.isHTMLSafe exports correctly', function(assert) {
 if (EMBER_METAL_WEAKMAP) {
   QUnit.test('Ember.WeakMap exports correctly', function(assert) {
     confirmExport(Ember, assert, 'WeakMap', 'ember-metal', 'WeakMap');
+  });
+}
+
+if (DEBUG) {
+  QUnit.test('Ember.MODEL_FACTORY_INJECTIONS', function(assert) {
+    let descriptor = Object.getOwnPropertyDescriptor(Ember, 'MODEL_FACTORY_INJECTIONS');
+    assert.equal(descriptor.enumerable, false, 'descriptor is not enumerable');
+    assert.equal(descriptor.configurable, false, 'descriptor is not configurable');
+
+    assert.equal(Ember.MODEL_FACTORY_INJECTIONS, false)
+
+    expectDeprecation(function() {
+      Ember.MODEL_FACTORY_INJECTIONS = true;
+    }, 'Ember.MODEL_FACTORY_INJECTIONS is no longer required')
+    assert.equal(Ember.MODEL_FACTORY_INJECTIONS, false, 'writing to the property has no affect')
   });
 }


### PR DESCRIPTION
Double extend means this flag no longer means what it once did. To ensure ember-data functions correctly, we should now force it to always be false.

Code affect in ember-data is: https://github.com/emberjs/data/blob/e6cb564bdb33da4b3c15c3c668dc4b1fdafdf190/addon/-debug/index.js#L37-L39

---

- [x] add some tests ensuring the behavior is as expected
- [x] remove from ember-cli blueprints: ember-cli/ember-cli#7025
- [X] add to website's deprecations: https://github.com/emberjs/website/pull/2895