### PR TITLE
[CLEANUP] Add test for brace expansion assertion

### DIFF
--- a/packages/ember-metal/tests/expand_properties_test.js
+++ b/packages/ember-metal/tests/expand_properties_test.js
@@ -81,7 +81,8 @@ QUnit.test('Nested brace expansions are not allowed', function() {
     'a.{{b}.c}',
     'a.{b,c}.{d.{e,f}.g',
     'a.{b.{c}',
-    'a.{b,c}}'
+    'a.{b,c}}',
+    'model.{bar,baz'
   ];
 
   nestedBraceProperties.forEach((invalidProperties) => {


### PR DESCRIPTION
Adding a case for a not allowed brace expansion. This case is failing in
2.12 as shown in #15201 but not in 2.13.

I'm adding this tests because, though the previous cases were added over
six months ago, they did not catch it.