### PR TITLE
[BUGFIX lts] Fix double container destroy

### DIFF
--- a/packages/ember-application/lib/system/engine-instance.js
+++ b/packages/ember-application/lib/system/engine-instance.js
@@ -130,14 +130,6 @@ const EngineInstance = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixi
   },
 
   /**
-    @private
-  */
-  willDestroy() {
-    this._super(...arguments);
-    run(this.__container__, 'destroy');
-  },
-
-  /**
     Build a new `Ember.EngineInstance` that's a child of this instance.
 
     Engines must be registered by name with their parent engine


### PR DESCRIPTION
This code on the Engine Instance is not needed as it includes the
`ContainerProxyMixin`, which already takes care of destroying the 
container.

This duplicated destroy step was causing ember-cp-validations to
attempt to destroy validators twice. This destroy process tries to 
nullify some property with `o.set(‘model’, null)` on an object that is
already destroyed.