### PR TITLE
[BUGFIX release] Ensure that it is possible to experiment with syntax.

### DIFF
--- a/packages/ember-glimmer/lib/index.js
+++ b/packages/ember-glimmer/lib/index.js
@@ -285,3 +285,4 @@ export {
 } from './template_registry';
 export { setupEngineRegistry, setupApplicationRegistry } from './setup-registry';
 export { DOMChanges, NodeDOMTreeConstruction, DOMTreeConstruction } from './dom';
+export { registerMacros as _registerMacros, experimentalMacros as _experimentalMacros } from './syntax';

--- a/packages/ember-glimmer/lib/syntax.js
+++ b/packages/ember-glimmer/lib/syntax.js
@@ -69,7 +69,7 @@ function refineBlockSyntax(sexp, builder) {
   return false;
 }
 
-let experimentalMacros = [];
+export const experimentalMacros = [];
 
 // This is a private API to allow for expiremental macros
 // to be created in user space. Registering a macro should
@@ -95,8 +95,6 @@ export function populateMacros(blocks, inlines) {
     let macro = experimentalMacros[i];
     macro(blocks, inlines);
   }
-
-  experimentalMacros = [];
 
   return { blocks, inlines };
 }

--- a/packages/ember-glimmer/tests/integration/syntax/experimental-syntax-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/experimental-syntax-test.js
@@ -1,0 +1,43 @@
+import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { strip } from '../../utils/abstract-test-case';
+import { _registerMacros, _experimentalMacros } from 'ember-glimmer';
+import { compileArgs } from '@glimmer/runtime';
+
+moduleFor('registerMacros', class extends RenderingTest {
+  constructor() {
+    let originalMacros = _experimentalMacros.slice();
+
+    _registerMacros((blocks, inlines) => {
+      blocks.add('-let', (sexp, builder) => {
+        let [,, params, hash, _default] = sexp;
+        let args = compileArgs(params, hash, builder);
+
+        builder.putArgs(args);
+
+        builder.labelled(null, b => {
+          b.evaluate(_default);
+        });
+      });
+    });
+
+    super();
+    this.originalMacros = originalMacros;
+  }
+
+  teardown() {
+    _experimentalMacros.length = 0;
+    this.originalMacros.forEach(macro => _experimentalMacros.push(macro));
+
+    super.teardown();
+  }
+
+  ['@test allows registering custom syntax via private API'](assert) {
+    this.render(strip`
+      {{#-let obj as |bar|}}
+        {{bar}}
+      {{/-let}}
+    `, { obj: 'hello world!'});
+
+    this.assertText('hello world!');
+  }
+});


### PR DESCRIPTION
This corrects an issue in 2.13 where `experimentalMacros` was being cleared once each callback had been ran once therefore making it impossible to add syntax that work across multiple tests.

This also adds a test to excercise the `registerMacros` concept, just to make sure that we maintain the general capability (though the APIs can certainly change).