### PR TITLE
[BUGFIX LTS] Warn about invalid properties

### DIFF
--- a/packages/ember-metal/lib/expand_properties.js
+++ b/packages/ember-metal/lib/expand_properties.js
@@ -64,8 +64,7 @@ export default function expandProperties(pattern, callback) {
     })(pattern));
 
   warn(
-    `You used the key "${pattern}" which is invalid and is not longer expanding on Ember 2.13.`,
-    ((str) => {
+    ...((str, opts) => {
       let inBrace = 0;
       let char;
       for (let i = 0; i < str.length; i++) {
@@ -76,16 +75,28 @@ export default function expandProperties(pattern, callback) {
         } else if (char === '}') {
           inBrace--;
         } else if (char === ',' && inBrace === 0) {
-          return false;
+          return [
+            `You are using a comma outside braces in ${str} that was unintentionally being expanded. This property will no longer expand on Ember 2.13.`,
+            false,
+            opts
+          ];
         }
 
         if (inBrace > 1 || inBrace < 0) {
-          return false;
+          return [
+            `You have nested or unbalanced properties in ${str} that was unintentionally being expanded. This property will no longer expand on Ember 2.13.`,
+            false,
+            opts
+          ];
         }
       }
 
-      return inBrace === 0;
-    })(pattern), { id: 'ember-metal.invalid-expand-properties' });
+      return [
+        `The property ${str} ended with unbalanced braces. This property will no longer expand on Ember 2.13.`,
+        inBrace === 0,
+        opts
+      ];
+    })(pattern, { id: 'ember-metal.invalid-expand-properties' }));
 
   let parts = pattern.split(SPLIT_REGEX);
   let properties = [parts];

--- a/packages/ember-metal/lib/expand_properties.js
+++ b/packages/ember-metal/lib/expand_properties.js
@@ -1,4 +1,4 @@
-import { assert } from './debug';
+import { assert, warn } from './debug';
 
 /**
 @module ember
@@ -62,6 +62,30 @@ export default function expandProperties(pattern, callback) {
 
       return true;
     })(pattern));
+
+  warn(
+    `You used the key "${pattern}" which is invalid and is not longer expanding on Ember 2.13.`,
+    ((str) => {
+      let inBrace = 0;
+      let char;
+      for (let i = 0; i < str.length; i++) {
+        char = str.charAt(i);
+
+        if (char === '{') {
+          inBrace++;
+        } else if (char === '}') {
+          inBrace--;
+        } else if (char === ',' && inBrace === 0) {
+          return false;
+        }
+
+        if (inBrace > 1 || inBrace < 0) {
+          return false;
+        }
+      }
+
+      return inBrace === 0;
+    })(pattern), { id: 'ember-metal.invalid-expand-properties' });
 
   let parts = pattern.split(SPLIT_REGEX);
   let properties = [parts];

--- a/packages/ember-metal/tests/expand_properties_test.js
+++ b/packages/ember-metal/tests/expand_properties_test.js
@@ -107,7 +107,7 @@ QUnit.test('unbalanced braces are warned', function() {
   invalidBraceProperties.forEach((invalidProperties) =>
     expectWarning(() => {
       expandProperties(invalidProperties, addProperty)
-    }, / which is invalid and is not longer expanding on Ember 2\.13\./)
+    }, / no longer expand on Ember 2\.13\./)
   );
 });
 

--- a/packages/ember-metal/tests/expand_properties_test.js
+++ b/packages/ember-metal/tests/expand_properties_test.js
@@ -97,6 +97,20 @@ QUnit.test('A pattern must be a string', function() {
   }, /A computed property key must be a string/);
 });
 
+QUnit.test('unbalanced braces are warned', function() {
+  let invalidBraceProperties = [
+    'model.{baz,bar',
+    'model.bar,bar',
+    'model.{bar'
+  ];
+
+  invalidBraceProperties.forEach((invalidProperties) =>
+    expectWarning(() => {
+      expandProperties(invalidProperties, addProperty)
+    }, / which is invalid and is not longer expanding on Ember 2\.13\./)
+  );
+});
+
 QUnit.test('A pattern must not contain a space', function() {
   expect(1);
 


### PR DESCRIPTION
There was a bug in the brace expansion implementation before 2.13 that
admitted expressions like `a.{b,c` and `a.b,c` in property expansion
without failing.

On February 2017, #13231 was merged improving the implementation of
`expandProperties` and fixing the previous issue.

Sadly, people upgrading from 2.12 are having problems with this. We have
two options here:

- Backporting #13231 fixes it and can be done, as of today, without any
  problem just by cherry-picking its two commits. Sadly, this would
  break people apps in a patch version, and this bug does not seem like
  a critical bugfix.

- Adding a warning if a user is using invalid properties. I went with
  this option since it looks like the less intrusive one while letting
  the users know that their apps will break in the next update.