### PR TITLE
[BUGFIX beta] Remove unused method on private routing service.

### DIFF
--- a/packages/ember-routing/lib/services/routing.js
+++ b/packages/ember-routing/lib/services/routing.js
@@ -31,10 +31,6 @@ export default Service.extend({
   currentRouteName: readOnly('router.currentRouteName'),
   currentPath: readOnly('router.currentPath'),
 
-  availableRoutes() {
-    return Object.keys(get(this, 'router').router.recognizer.names);
-  },
-
   hasRoute(routeName) {
     return get(this, 'router').hasRoute(routeName);
   },


### PR DESCRIPTION
This still referred to the non-existant `router.router` property (which was moved to `router._routerMicrolib` for Ember 2.13).