### PR TITLE
Remove blank line from qunit component-test file

### DIFF
--- a/blueprints/component-test/qunit-files/tests/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/qunit-files/tests/__testType__/__path__/__test__.js
@@ -8,8 +8,7 @@ moduleForComponent('<%= componentPathName %>', '<%= friendlyTestDescription %>',
 });
 
 test('it renders', function(assert) {
-<% if (testType === 'integration' ) { %>
-  // Set any properties with this.set('myProperty', 'value');
+  <% if (testType === 'integration' ) { %>// Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
 
   this.render(hbs`{{<%= componentPathName %>}}`);


### PR DESCRIPTION
Prevents eslint errors if using the no padding rule.