### PR TITLE
[BUGFIX beta] Preserve current history state on app boot

### DIFF
--- a/packages/ember-routing/lib/location/history_location.js
+++ b/packages/ember-routing/lib/location/history_location.js
@@ -84,7 +84,14 @@ export default EmberObject.extend({
       this.supportsHistory = true;
     }
 
-    this.replaceState(this.formatURL(this.getURL()));
+    let state = this.getState();
+    let path = this.formatURL(this.getURL());
+    if (state && state.path === path) { // preserve existing state
+      // used for webkit workaround, since there will be no initial popstate event
+      this._previousURL = this.getURL();
+    } else {
+      this.replaceState(path);
+    }
   },
 
   /**

--- a/packages/ember-routing/tests/location/history_location_test.js
+++ b/packages/ember-routing/tests/location/history_location_test.js
@@ -304,3 +304,25 @@ QUnit.test('HistoryLocation.getURL() drops duplicate slashes', function() {
 
   equal(location.getURL(), '/');
 });
+
+QUnit.test('Existing state is preserved on init', function() {
+  expect(1);
+
+  let existingState = {
+    path: '/route/path',
+    uuid: 'abcd'
+  };
+
+  FakeHistory.state = existingState;
+
+  HistoryTestLocation.reopen({
+    init() {
+      this._super(...arguments);
+      set(this, 'location', mockBrowserLocation('/route/path'));
+    }
+  });
+
+  createLocation();
+  location.initState();
+  deepEqual(location.getState(), existingState);
+});


### PR DESCRIPTION
RFC #186 introduced per-history-entry unique ids to the HistoryLocation.

But currently on app boot, a new uuid is always generated. This means that when refreshing the page, the same history entry is given a new uuid.