### PR TITLE
[BUGFIX release] Remove reference to `dist/ember.js` file.

### DIFF
--- a/config/s3ProjectConfig.js
+++ b/config/s3ProjectConfig.js
@@ -1,6 +1,5 @@
 function fileMap(revision, tag, date) {
   return {
-    "ember.js":                   fileObject("ember",                   ".js",   "text/javascript",  revision, tag, date),
     "ember.debug.js":             fileObject("ember.debug",             ".js",   "text/javascript",  revision, tag, date),
     "ember-testing.js":           fileObject("ember-testing",           ".js",   "text/javascript",  revision, tag, date),
     "ember-tests.js":             fileObject("ember-tests",             ".js",   "text/javascript",  revision, tag, date),

--- a/packages/ember-debug/lib/index.js
+++ b/packages/ember-debug/lib/index.js
@@ -265,19 +265,6 @@ if (DEBUG && !isTesting()) {
   }
 }
 
-/*
-  We are transitioning away from `ember.js` to `ember.debug.js` to make
-  it much clearer that it is only for local development purposes.
-
-  This flag value is changed by the tooling (by a simple string replacement)
-  so that if `ember.js` (which must be output for backwards compat reasons) is
-  used a nice helpful warning message will be printed out.
-*/
-export let runningNonEmberDebugJS = false;
-if (runningNonEmberDebugJS) {
-  warn('Please use `ember.debug.js` instead of `ember.js` for development and debugging.');
-}
-
 export {
   assert,
   info,


### PR DESCRIPTION
This file is no longer emitted and it being referenced in the S3 upload script but not actually present caused our S3 uploading to fail.

Before this change the following error occurs during the S3 publishing step:

```
Error: FilePath: '/home/travis/build/emberjs/ember.js/dist/ember.js' doesn't exist!
    at S3Publisher.uploader (/home/travis/build/emberjs/ember.js/node_modules/ember-publisher/index.js:63:11)
    at S3Publisher.<anonymous> (/home/travis/build/emberjs/ember.js/node_modules/ember-publisher/index.js:81:55)
    at Array.forEach (native)
    at S3Publisher.publish (/home/travis/build/emberjs/ember.js/node_modules/ember-publisher/index.js:81:18)
    at Object.<anonymous> (/home/travis/build/emberjs/ember.js/bin/publish_to_s3.js:32:11)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
```