### PR TITLE
[BUGFIX beta] Ensure `Ember.deprecate` is exported properly.

### DIFF
--- a/packages/ember/lib/index.js
+++ b/packages/ember/lib/index.js
@@ -45,6 +45,7 @@ Ember.cacheFor = metal.cacheFor;
 Ember.assert = EmberDebug.assert;
 Ember.warn = EmberDebug.warn;
 Ember.debug = EmberDebug.debug;
+Ember.deprecate = EmberDebug.deprecate;
 Ember.deprecateFunc = EmberDebug.deprecateFunc;
 Ember.runInDebug = EmberDebug.runInDebug;
 /**

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -27,16 +27,19 @@ QUnit.module('ember reexports');
   ['Registry', 'container', 'Registry'],
   ['Container', 'container', 'Container'],
 
+  // ember-debug
+  ['deprecateFunc', 'ember-debug'],
+  ['deprecate', 'ember-debug'],
+  ['assert', 'ember-debug'],
+  ['warn', 'ember-debug'],
+  ['debug', 'ember-debug'],
+  ['runInDebug', 'ember-debug'],
+
   // ember-metal
   ['computed', 'ember-metal'],
   ['computed.alias', 'ember-metal', 'alias'],
   ['ComputedProperty', 'ember-metal'],
   ['cacheFor', 'ember-metal'],
-  ['deprecateFunc', 'ember-debug'],
-  ['assert', 'ember-debug'],
-  ['warn', 'ember-debug'],
-  ['debug', 'ember-debug'],
-  ['runInDebug', 'ember-debug'],
   ['merge', 'ember-metal'],
   ['instrument', 'ember-metal'],
   ['Instrumentation.instrument', 'ember-metal', 'instrument'],


### PR DESCRIPTION
This fixes the reported issue (that `Ember.deprecate` was no longer being exported), and adds a test to confirm that it doesn't regress again in the future.

Fixes https://github.com/emberjs/ember.js/issues/15236