### PR TITLE
[BUGFIX release] Ensure nested custom elements render properly.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
     "link:glimmer": "node bin/yarn-link-glimmer.js"
   },
   "dependencies": {
-    "@glimmer/compiler": "^0.22.0",
-    "@glimmer/node": "^0.22.0",
-    "@glimmer/reference": "^0.22.0",
-    "@glimmer/runtime": "^0.22.0",
-    "@glimmer/util": "^0.22.0",
+    "@glimmer/compiler": "^0.22.1",
+    "@glimmer/node": "^0.22.1",
+    "@glimmer/reference": "^0.22.1",
+    "@glimmer/runtime": "^0.22.1",
+    "@glimmer/util": "^0.22.1",
     "broccoli-funnel": "^1.2.0",
     "broccoli-merge-trees": "^2.0.0",
     "ember-cli-get-component-path-option": "^1.0.0",

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -3130,4 +3130,24 @@ moduleFor('Components test: curly components', class extends RenderingTest {
 
     this.assertText('huzzah!');
   }
+
+  ['@test can use custom element in component layout'](assert) {
+    this.registerComponent('foo-bar', {
+      template: '<blah-zorz>Hi!</blah-zorz>'
+    });
+
+    this.render('{{foo-bar}}');
+
+    this.assertText('Hi!');
+  }
+
+  ['@test can use nested custom element in component layout'](assert) {
+    this.registerComponent('foo-bar', {
+      template: '<blah-zorz><hows-it-going>Hi!</hows-it-going></blah-zorz>'
+    });
+
+    this.render('{{foo-bar}}');
+
+    this.assertText('Hi!');
+  }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,75 +2,75 @@
 # yarn lockfile v1
 
 
-"@glimmer/compiler@^0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.22.0.tgz#8fd2e80e1e6fc6e355819f180feb189f457184f0"
+"@glimmer/compiler@^0.22.1":
+  version "0.22.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.22.1.tgz#70a8a3064ca4d62b15fc3c870ead11e6c7fb00bf"
   dependencies:
-    "@glimmer/syntax" "^0.22.0"
-    "@glimmer/util" "^0.22.0"
-    "@glimmer/wire-format" "^0.22.0"
+    "@glimmer/syntax" "^0.22.1"
+    "@glimmer/util" "^0.22.1"
+    "@glimmer/wire-format" "^0.22.1"
     simple-html-tokenizer "^0.3.0"
 
-"@glimmer/interfaces@^0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.22.0.tgz#69915fb6416e9cf024c73178ced513b475944baa"
+"@glimmer/interfaces@^0.22.1":
+  version "0.22.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.22.1.tgz#56410f35cc3097314c9c56eca01223714354a2f6"
   dependencies:
-    "@glimmer/wire-format" "^0.22.0"
+    "@glimmer/wire-format" "^0.22.1"
 
-"@glimmer/node@^0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/node/-/node-0.22.0.tgz#0ecea9fb3f45f985408f8c6010a9749f1312f057"
+"@glimmer/node@^0.22.1":
+  version "0.22.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/node/-/node-0.22.1.tgz#caf53983cb42ac0eff54c931a43d92430b8f6217"
   dependencies:
-    "@glimmer/runtime" "^0.22.0"
+    "@glimmer/runtime" "^0.22.1"
     simple-dom "^0.3.0"
 
-"@glimmer/object-reference@^0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/object-reference/-/object-reference-0.22.0.tgz#785170f02895a10ff580400b980ca71b81b4261a"
+"@glimmer/object-reference@^0.22.1":
+  version "0.22.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/object-reference/-/object-reference-0.22.1.tgz#f5f18ffe11f86140921977d6bff3e8d75818494a"
   dependencies:
-    "@glimmer/reference" "^0.22.0"
-    "@glimmer/util" "^0.22.0"
+    "@glimmer/reference" "^0.22.1"
+    "@glimmer/util" "^0.22.1"
 
-"@glimmer/object@^0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/object/-/object-0.22.0.tgz#62df92fab110449683f61283f9524f2f3e1e49f2"
+"@glimmer/object@^0.22.1":
+  version "0.22.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/object/-/object-0.22.1.tgz#f560eef3ac1eb4decc173368c44b6cdcc6d62e07"
   dependencies:
-    "@glimmer/object-reference" "^0.22.0"
-    "@glimmer/util" "^0.22.0"
+    "@glimmer/object-reference" "^0.22.1"
+    "@glimmer/util" "^0.22.1"
 
-"@glimmer/reference@^0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.22.0.tgz#1b3cf62f100caad14052c3844de8626a89601177"
+"@glimmer/reference@^0.22.1":
+  version "0.22.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.22.1.tgz#9aea78e63ddd83f13acad79bd24ae4c4c0457210"
   dependencies:
-    "@glimmer/util" "^0.22.0"
+    "@glimmer/util" "^0.22.1"
 
-"@glimmer/runtime@^0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/runtime/-/runtime-0.22.0.tgz#f6c6195ec5a8950ef37e8764eb5e62f3985bc30e"
+"@glimmer/runtime@^0.22.1":
+  version "0.22.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/runtime/-/runtime-0.22.1.tgz#90077df1b97ffb3efd0709f92fa70ede1301d198"
   dependencies:
-    "@glimmer/interfaces" "^0.22.0"
-    "@glimmer/object" "^0.22.0"
-    "@glimmer/object-reference" "^0.22.0"
-    "@glimmer/reference" "^0.22.0"
-    "@glimmer/util" "^0.22.0"
-    "@glimmer/wire-format" "^0.22.0"
+    "@glimmer/interfaces" "^0.22.1"
+    "@glimmer/object" "^0.22.1"
+    "@glimmer/object-reference" "^0.22.1"
+    "@glimmer/reference" "^0.22.1"
+    "@glimmer/util" "^0.22.1"
+    "@glimmer/wire-format" "^0.22.1"
 
-"@glimmer/syntax@^0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.22.0.tgz#20f5dbc8660437ecce941c3a32c2536688a4f2ea"
+"@glimmer/syntax@^0.22.1":
+  version "0.22.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.22.1.tgz#b4048738fa55c46e337278b2aeb37731509ae284"
   dependencies:
     handlebars "^4.0.6"
     simple-html-tokenizer "^0.3.0"
 
-"@glimmer/util@^0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.22.0.tgz#80883909d14b5b0e1701bca0acf5e4c580514f93"
+"@glimmer/util@^0.22.1":
+  version "0.22.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.22.1.tgz#7be751f77325ac857327f9c786ee2d02fba4d4e1"
 
-"@glimmer/wire-format@^0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.22.0.tgz#d1254f50b2b90ffe0cccb06111de986396c4393f"
+"@glimmer/wire-format@^0.22.1":
+  version "0.22.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.22.1.tgz#2673bbb1e89805194e9870064c6905af21406ffb"
   dependencies:
-    "@glimmer/util" "^0.22.0"
+    "@glimmer/util" "^0.22.1"
 
 abbrev@1, abbrev@~1.0.9:
   version "1.0.9"


### PR DESCRIPTION
A bug was introduced with the Glimmer update that was included in Ember 2.13 that caused an error to be thrown when using nested custom elements like:

```hbs
<foo-bar>
  <baz-qux></baz-qux>
</foo-bar>
```

The fix was done upstream in https://github.com/glimmerjs/glimmer-vm/pull/488.

Fixes https://github.com/emberjs/ember.js/issues/15221