### PR TITLE
[CLEANUP] Output correct `console.log` for `bin/run-tests`

### DIFF
--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -171,7 +171,7 @@ switch (process.env.TEST_SUITE) {
     server.close();
     return;
   case 'travis-browsers':
-    console.log('suite: sauce');
+    console.log('suite: travis-browsers');
     require('./run-travis-browser-tests');
     return;
 


### PR DESCRIPTION
Super small update here. This just applies for the 'travis-browsers' case.