### PR TITLE
[FEATURE glimmer-custom-component-manager] Custom Component Manager

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -21,3 +21,8 @@ for a detailed explanation.
 * `ember-testing-resume-test`
 
   Introduces the `resumeTest` testing helper to complement the `pauseTest` helper.
+
+* `glimmer-custom-component-manager`
+
+  Adds an ability to for developers to integrate their own custom component managers
+  into Ember Applications per [RFC](https://github.com/emberjs/rfcs/blob/custom-components/text/0000-custom-components.md).

--- a/features.json
+++ b/features.json
@@ -6,7 +6,8 @@
     "ember-metal-weakmap": null,
     "ember-glimmer-allow-backtracking-rerender": null,
     "ember-routing-router-service": null,
-    "ember-engines-mount-params": null
+    "ember-engines-mount-params": null,
+    "glimmer-custom-component-manager": null
   },
   "deprecations": {
     "container-lookupFactory": "2.12.0",

--- a/packages/ember-glimmer/lib/component-managers/curly.js
+++ b/packages/ember-glimmer/lib/component-managers/curly.js
@@ -1,0 +1,308 @@
+import { OWNER } from 'ember-utils';
+import {
+  PrimitiveReference
+} from '@glimmer/runtime';
+import {
+  assert
+} from 'ember-debug';
+import { DEBUG } from 'ember-env-flags';
+import {
+  ROOT_REF,
+  DIRTY_TAG,
+  IS_DISPATCHING_ATTRS,
+  HAS_BLOCK,
+  BOUNDS
+} from '../component';
+import {
+  AttributeBinding,
+  ClassNameBinding,
+  IsVisibleBinding
+} from '../utils/bindings';
+import {
+  get,
+  _instrumentStart
+} from 'ember-metal';
+import {
+  gatherArgs,
+  ComponentArgs
+} from '../utils/process-args';
+import {
+  dispatchLifeCycleHook,
+  setViewElement
+} from 'ember-views';
+import { privatize as P } from 'container';
+import AbstractManager from '../syntax/abstract-manager';
+import ComponentStateBucket from '../syntax/component-state-bucket';
+import {
+  initialRenderInstrumentDetails,
+  rerenderInstrumentDetails,
+  validatePositionalParameters,
+  processComponentInitializationAssertions
+} from '../syntax/curly-component';
+
+const DEFAULT_LAYOUT = P`template:components/-default`;
+
+function aliasIdToElementId(args, props) {
+  if (args.named.has('id')) {
+    assert(`You cannot invoke a component with both 'id' and 'elementId' at the same time.`, !args.named.has('elementId'));
+    props.elementId = props.id;
+  }
+}
+
+// We must traverse the attributeBindings in reverse keeping track of
+// what has already been applied. This is essentially refining the concated
+// properties applying right to left.
+function applyAttributeBindings(element, attributeBindings, component, operations) {
+  let seen = [];
+  let i = attributeBindings.length - 1;
+
+  while (i !== -1) {
+    let binding = attributeBindings[i];
+    let parsed = AttributeBinding.parse(binding);
+    let attribute = parsed[1];
+
+    if (seen.indexOf(attribute) === -1) {
+      seen.push(attribute);
+      AttributeBinding.install(element, component, parsed, operations);
+    }
+
+    i--;
+  }
+
+  if (seen.indexOf('id') === -1) {
+    operations.addStaticAttribute(element, 'id', component.elementId);
+  }
+
+  if (seen.indexOf('style') === -1) {
+    IsVisibleBinding.install(element, component, operations);
+  }
+}
+
+function tagName(vm) {
+  let { tagName } = vm.dynamicScope().view;
+
+  return PrimitiveReference.create(tagName === '' ? null : tagName || 'div');
+}
+
+function ariaRole(vm) {
+  return vm.getSelf().get('ariaRole');
+}
+
+class CurlyComponentLayoutCompiler {
+  constructor(template) {
+    this.template = template;
+  }
+
+  compile(builder) {
+    builder.wrapLayout(this.template.asLayout());
+    builder.tag.dynamic(tagName);
+    builder.attrs.dynamic('role', ariaRole);
+    builder.attrs.static('class', 'ember-view');
+  }
+}
+
+CurlyComponentLayoutCompiler.id = 'curly';
+
+export default class CurlyComponentManager extends AbstractManager {
+  prepareArgs(definition, args) {
+    if (definition.ComponentClass) {
+      validatePositionalParameters(args.named, args.positional.values, definition.ComponentClass.class.positionalParams);
+    }
+
+    return gatherArgs(args, definition);
+  }
+
+  create(environment, definition, args, dynamicScope, callerSelfRef, hasBlock) {
+    if (DEBUG) {
+      this._pushToDebugStack(`component:${definition.name}`, environment)
+    }
+
+    let parentView = dynamicScope.view;
+
+    let factory = definition.ComponentClass;
+
+    let processedArgs = ComponentArgs.create(args);
+    let { props } = processedArgs.value();
+
+    aliasIdToElementId(args, props);
+
+    props.parentView = parentView;
+    props[HAS_BLOCK] = hasBlock;
+
+    props._targetObject = callerSelfRef.value();
+
+    let component = factory.create(props);
+
+    let finalizer = _instrumentStart('render.component', initialRenderInstrumentDetails, component);
+
+    dynamicScope.view = component;
+
+    if (parentView !== null) {
+      parentView.appendChild(component);
+    }
+
+    // We usually do this in the `didCreateElement`, but that hook doesn't fire for tagless components
+    if (component.tagName === '') {
+      if (environment.isInteractive) {
+        component.trigger('willRender');
+      }
+
+      component._transitionTo('hasElement');
+
+      if (environment.isInteractive) {
+        component.trigger('willInsertElement');
+      }
+    }
+
+    let bucket = new ComponentStateBucket(environment, component, processedArgs, finalizer);
+
+    if (args.named.has('class')) {
+      bucket.classRef = args.named.get('class');
+    }
+
+    if (DEBUG) {
+      processComponentInitializationAssertions(component, props);
+    }
+
+    if (environment.isInteractive && component.tagName !== '') {
+      component.trigger('willRender');
+    }
+
+    return bucket;
+  }
+
+  layoutFor(definition, bucket, env) {
+    let template = definition.template;
+    if (!template) {
+      let { component } = bucket;
+      template = this.templateFor(component, env);
+    }
+    return env.getCompiledBlock(CurlyComponentLayoutCompiler, template);
+  }
+
+  templateFor(component, env) {
+    let Template = get(component, 'layout');
+    let owner = component[OWNER];
+    if (Template) {
+      return env.getTemplate(Template, owner);
+    }
+    let layoutName = get(component, 'layoutName');
+    if (layoutName) {
+      let template = owner.lookup('template:' + layoutName);
+      if (template) {
+        return template;
+      }
+    }
+    return owner.lookup(DEFAULT_LAYOUT);
+  }
+
+  getSelf({ component }) {
+    return component[ROOT_REF];
+  }
+
+  didCreateElement({ component, classRef, environment }, element, operations) {
+    setViewElement(component, element);
+
+    let { attributeBindings, classNames, classNameBindings } = component;
+
+    if (attributeBindings && attributeBindings.length) {
+      applyAttributeBindings(element, attributeBindings, component, operations);
+    } else {
+      operations.addStaticAttribute(element, 'id', component.elementId);
+      IsVisibleBinding.install(element, component, operations);
+    }
+
+    if (classRef) {
+      operations.addDynamicAttribute(element, 'class', classRef);
+    }
+
+    if (classNames && classNames.length) {
+      classNames.forEach(name => {
+        operations.addStaticAttribute(element, 'class', name);
+      });
+    }
+
+    if (classNameBindings && classNameBindings.length) {
+      classNameBindings.forEach(binding => {
+        ClassNameBinding.install(element, component, binding, operations);
+      });
+    }
+
+    component._transitionTo('hasElement');
+
+    if (environment.isInteractive) {
+      component.trigger('willInsertElement');
+    }
+  }
+
+  didRenderLayout(bucket, bounds) {
+    bucket.component[BOUNDS] = bounds;
+    bucket.finalize();
+
+    if (DEBUG) {
+      this.debugStack.pop();
+    }
+  }
+
+  getTag({ component }) {
+    return component[DIRTY_TAG];
+  }
+
+  didCreate({ component, environment }) {
+    if (environment.isInteractive) {
+      component._transitionTo('inDOM');
+      component.trigger('didInsertElement');
+      component.trigger('didRender');
+    }
+  }
+
+  update(bucket, _, dynamicScope) {
+    let { component, args, argsRevision, environment } = bucket;
+
+    if (DEBUG) {
+       this._pushToDebugStack(component._debugContainerKey, environment)
+    }
+
+    bucket.finalizer = _instrumentStart('render.component', rerenderInstrumentDetails, component);
+
+    if (!args.tag.validate(argsRevision)) {
+      let { attrs, props } = args.value();
+
+      bucket.argsRevision = args.tag.value();
+
+      let oldAttrs = component.attrs;
+      let newAttrs = attrs;
+
+      component[IS_DISPATCHING_ATTRS] = true;
+      component.setProperties(props);
+      component[IS_DISPATCHING_ATTRS] = false;
+
+      dispatchLifeCycleHook(component, 'didUpdateAttrs', oldAttrs, newAttrs);
+      dispatchLifeCycleHook(component, 'didReceiveAttrs', oldAttrs, newAttrs);
+    }
+
+    if (environment.isInteractive) {
+      component.trigger('willUpdate');
+      component.trigger('willRender');
+    }
+  }
+
+  didUpdateLayout(bucket) {
+    bucket.finalize();
+
+    if (DEBUG) {
+      this.debugStack.pop();
+    }
+  }
+
+  didUpdate({ component, environment }) {
+    if (environment.isInteractive) {
+      component.trigger('didUpdate');
+      component.trigger('didRender');
+    }
+  }
+
+  getDestructor(stateBucket) {
+    return stateBucket;
+  }
+}

--- a/packages/ember-glimmer/lib/syntax/component-state-bucket.js
+++ b/packages/ember-glimmer/lib/syntax/component-state-bucket.js
@@ -1,0 +1,40 @@
+function NOOP() {}
+
+/**
+  @module ember
+  @submodule ember-glimmer
+*/
+
+/**
+  Represents the internal state of the component.
+
+  @class ComponentStateBucket
+  @private
+*/
+export default class ComponentStateBucket {
+  constructor(environment, component, args, finalizer) {
+    this.environment = environment;
+    this.component = component;
+    this.classRef = null;
+    this.args = args;
+    this.argsRevision = args.tag.value();
+    this.finalizer = finalizer;
+  }
+
+  destroy() {
+    let { component, environment } = this;
+
+    if (environment.isInteractive) {
+      component.trigger('willDestroyElement');
+      component.trigger('willClearRender');
+    }
+
+    environment.destroyedComponents.push(component);
+  }
+
+  finalize() {
+    let { finalizer } = this;
+    finalizer();
+    this.finalizer = NOOP;
+  }
+}

--- a/packages/ember-glimmer/lib/syntax/curly-component.js
+++ b/packages/ember-glimmer/lib/syntax/curly-component.js
@@ -1,20 +1,6 @@
-import { OWNER } from 'ember-utils';
 import {
-  PrimitiveReference,
   ComponentDefinition
 } from '@glimmer/runtime';
-import {
-  AttributeBinding,
-  ClassNameBinding,
-  IsVisibleBinding
-} from '../utils/bindings';
-import {
-  ROOT_REF,
-  DIRTY_TAG,
-  IS_DISPATCHING_ATTRS,
-  HAS_BLOCK,
-  BOUNDS
-} from '../component';
 import {
   get,
   _instrumentStart
@@ -23,46 +9,8 @@ import {
   assert
 } from 'ember-debug';
 import { DEBUG } from 'ember-env-flags';
-import {
-  dispatchLifeCycleHook,
-  setViewElement
-} from 'ember-views';
-import {
-  gatherArgs,
-  ComponentArgs
-} from '../utils/process-args';
-import { privatize as P } from 'container';
-import AbstractManager from './abstract-manager';
-
-const DEFAULT_LAYOUT = P`template:components/-default`;
-
-function processComponentInitializationAssertions(component, props) {
-  assert(`classNameBindings must not have spaces in them: ${component.toString()}`, (() => {
-    let { classNameBindings } = component;
-    for (let i = 0; i < classNameBindings.length; i++) {
-      let binding = classNameBindings[i];
-      if (binding.split(' ').length > 1) {
-        return false;
-      }
-    }
-    return true;
-  })());
-
-  assert('You cannot use `classNameBindings` on a tag-less component: ' + component.toString(), (() => {
-    let { classNameBindings, tagName } = component;
-    return tagName !== '' || !classNameBindings || classNameBindings.length === 0;
-  })());
-
-  assert('You cannot use `elementId` on a tag-less component: ' + component.toString(), (() => {
-    let { elementId, tagName } = component;
-    return tagName !== '' || props.id === elementId || (!elementId && elementId !== '');
-  })());
-
-  assert('You cannot use `attributeBindings` on a tag-less component: ' + component.toString(), (() => {
-    let { attributeBindings, tagName } = component;
-    return tagName !== '' || !attributeBindings || attributeBindings.length === 0;
-  })());
-}
+import ComponentStateBucket from './component-state-bucket';
+import CurlyComponentManager from '../component-managers/curly';
 
 export function validatePositionalParameters(named, positional, positionalParamsDefinition) {
   if (DEBUG) {
@@ -91,285 +39,42 @@ export function validatePositionalParameters(named, positional, positionalParams
   }
 }
 
-function aliasIdToElementId(args, props) {
-  if (args.named.has('id')) {
-    assert(`You cannot invoke a component with both 'id' and 'elementId' at the same time.`, !args.named.has('elementId'));
-    props.elementId = props.id;
-  }
-}
-
-// We must traverse the attributeBindings in reverse keeping track of
-// what has already been applied. This is essentially refining the concated
-// properties applying right to left.
-function applyAttributeBindings(element, attributeBindings, component, operations) {
-  let seen = [];
-  let i = attributeBindings.length - 1;
-
-  while (i !== -1) {
-    let binding = attributeBindings[i];
-    let parsed = AttributeBinding.parse(binding);
-    let attribute = parsed[1];
-
-    if (seen.indexOf(attribute) === -1) {
-      seen.push(attribute);
-      AttributeBinding.install(element, component, parsed, operations);
+export function processComponentInitializationAssertions(component, props) {
+  assert(`classNameBindings must not have spaces in them: ${component.toString()}`, (() => {
+    let { classNameBindings } = component;
+    for (let i = 0; i < classNameBindings.length; i++) {
+      let binding = classNameBindings[i];
+      if (binding.split(' ').length > 1) {
+        return false;
+      }
     }
+    return true;
+  })());
 
-    i--;
-  }
+  assert('You cannot use `classNameBindings` on a tag-less component: ' + component.toString(), (() => {
+    let { classNameBindings, tagName } = component;
+    return tagName !== '' || !classNameBindings || classNameBindings.length === 0;
+  })());
 
-  if (seen.indexOf('id') === -1) {
-    operations.addStaticAttribute(element, 'id', component.elementId);
-  }
+  assert('You cannot use `elementId` on a tag-less component: ' + component.toString(), (() => {
+    let { elementId, tagName } = component;
+    return tagName !== '' || props.id === elementId || (!elementId && elementId !== '');
+  })());
 
-  if (seen.indexOf('style') === -1) {
-    IsVisibleBinding.install(element, component, operations);
-  }
+  assert('You cannot use `attributeBindings` on a tag-less component: ' + component.toString(), (() => {
+    let { attributeBindings, tagName } = component;
+    return tagName !== '' || !attributeBindings || attributeBindings.length === 0;
+  })());
 }
 
-function NOOP() {}
-
-class ComponentStateBucket {
-  constructor(environment, component, args, finalizer) {
-    this.environment = environment;
-    this.component = component;
-    this.classRef = null;
-    this.args = args;
-    this.argsRevision = args.tag.value();
-    this.finalizer = finalizer;
-  }
-
-  destroy() {
-    let { component, environment } = this;
-
-    if (environment.isInteractive) {
-      component.trigger('willDestroyElement');
-      component.trigger('willClearRender');
-    }
-
-    environment.destroyedComponents.push(component);
-  }
-
-  finalize() {
-    let { finalizer } = this;
-    finalizer();
-    this.finalizer = NOOP;
-  }
-}
-
-function initialRenderInstrumentDetails(component) {
+export function initialRenderInstrumentDetails(component) {
   return component.instrumentDetails({ initialRender: true });
 }
 
-function rerenderInstrumentDetails(component) {
+export function rerenderInstrumentDetails(component) {
   return component.instrumentDetails({ initialRender: false });
 }
 
-class CurlyComponentManager extends AbstractManager {
-  prepareArgs(definition, args) {
-    if (definition.ComponentClass) {
-      validatePositionalParameters(args.named, args.positional.values, definition.ComponentClass.class.positionalParams);
-    }
-
-    return gatherArgs(args, definition);
-  }
-
-  create(environment, definition, args, dynamicScope, callerSelfRef, hasBlock) {
-    if (DEBUG) {
-      this._pushToDebugStack(`component:${definition.name}`, environment)
-    }
-
-    let parentView = dynamicScope.view;
-
-    let factory = definition.ComponentClass;
-
-    let processedArgs = ComponentArgs.create(args);
-    let { props } = processedArgs.value();
-
-    aliasIdToElementId(args, props);
-
-    props.parentView = parentView;
-    props[HAS_BLOCK] = hasBlock;
-
-    props._targetObject = callerSelfRef.value();
-
-    let component = factory.create(props);
-
-    let finalizer = _instrumentStart('render.component', initialRenderInstrumentDetails, component);
-
-    dynamicScope.view = component;
-
-    if (parentView !== null) {
-      parentView.appendChild(component);
-    }
-
-    // We usually do this in the `didCreateElement`, but that hook doesn't fire for tagless components
-    if (component.tagName === '') {
-      if (environment.isInteractive) {
-        component.trigger('willRender');
-      }
-
-      component._transitionTo('hasElement');
-
-      if (environment.isInteractive) {
-        component.trigger('willInsertElement');
-      }
-    }
-
-    let bucket = new ComponentStateBucket(environment, component, processedArgs, finalizer);
-
-    if (args.named.has('class')) {
-      bucket.classRef = args.named.get('class');
-    }
-
-    if (DEBUG) {
-      processComponentInitializationAssertions(component, props);
-    }
-
-    if (environment.isInteractive && component.tagName !== '') {
-      component.trigger('willRender');
-    }
-
-    return bucket;
-  }
-
-  layoutFor(definition, bucket, env) {
-    let template = definition.template;
-    if (!template) {
-      let { component } = bucket;
-      template = this.templateFor(component, env);
-    }
-    return env.getCompiledBlock(CurlyComponentLayoutCompiler, template);
-  }
-
-  templateFor(component, env) {
-    let Template = get(component, 'layout');
-    let owner = component[OWNER];
-    if (Template) {
-      return env.getTemplate(Template, owner);
-    }
-    let layoutName = get(component, 'layoutName');
-    if (layoutName) {
-      let template = owner.lookup('template:' + layoutName);
-      if (template) {
-        return template;
-      }
-    }
-    return owner.lookup(DEFAULT_LAYOUT);
-  }
-
-  getSelf({ component }) {
-    return component[ROOT_REF];
-  }
-
-  didCreateElement({ component, classRef, environment }, element, operations) {
-    setViewElement(component, element);
-
-    let { attributeBindings, classNames, classNameBindings } = component;
-
-    if (attributeBindings && attributeBindings.length) {
-      applyAttributeBindings(element, attributeBindings, component, operations);
-    } else {
-      operations.addStaticAttribute(element, 'id', component.elementId);
-      IsVisibleBinding.install(element, component, operations);
-    }
-
-    if (classRef) {
-      operations.addDynamicAttribute(element, 'class', classRef);
-    }
-
-    if (classNames && classNames.length) {
-      classNames.forEach(name => {
-        operations.addStaticAttribute(element, 'class', name);
-      });
-    }
-
-    if (classNameBindings && classNameBindings.length) {
-      classNameBindings.forEach(binding => {
-        ClassNameBinding.install(element, component, binding, operations);
-      });
-    }
-
-    component._transitionTo('hasElement');
-
-    if (environment.isInteractive) {
-      component.trigger('willInsertElement');
-    }
-  }
-
-  didRenderLayout(bucket, bounds) {
-    bucket.component[BOUNDS] = bounds;
-    bucket.finalize();
-
-    if (DEBUG) {
-      this.debugStack.pop();
-    }
-  }
-
-  getTag({ component }) {
-    return component[DIRTY_TAG];
-  }
-
-  didCreate({ component, environment }) {
-    if (environment.isInteractive) {
-      component._transitionTo('inDOM');
-      component.trigger('didInsertElement');
-      component.trigger('didRender');
-    }
-  }
-
-  update(bucket, _, dynamicScope) {
-    let { component, args, argsRevision, environment } = bucket;
-
-    if (DEBUG) {
-       this._pushToDebugStack(component._debugContainerKey, environment)
-    }
-
-    bucket.finalizer = _instrumentStart('render.component', rerenderInstrumentDetails, component);
-
-    if (!args.tag.validate(argsRevision)) {
-      let { attrs, props } = args.value();
-
-      bucket.argsRevision = args.tag.value();
-
-      let oldAttrs = component.attrs;
-      let newAttrs = attrs;
-
-      component[IS_DISPATCHING_ATTRS] = true;
-      component.setProperties(props);
-      component[IS_DISPATCHING_ATTRS] = false;
-
-      dispatchLifeCycleHook(component, 'didUpdateAttrs', oldAttrs, newAttrs);
-      dispatchLifeCycleHook(component, 'didReceiveAttrs', oldAttrs, newAttrs);
-    }
-
-    if (environment.isInteractive) {
-      component.trigger('willUpdate');
-      component.trigger('willRender');
-    }
-  }
-
-  didUpdateLayout(bucket) {
-    bucket.finalize();
-
-    if (DEBUG) {
-      this.debugStack.pop();
-    }
-  }
-
-  didUpdate({ component, environment }) {
-    if (environment.isInteractive) {
-      component.trigger('didUpdate');
-      component.trigger('didRender');
-    }
-  }
-
-  getDestructor(stateBucket) {
-    return stateBucket;
-  }
-}
-
-const MANAGER = new CurlyComponentManager();
 
 class TopComponentManager extends CurlyComponentManager {
   create(environment, definition, args, dynamicScope, currentScope, hasBlock) {
@@ -404,25 +109,17 @@ class TopComponentManager extends CurlyComponentManager {
   }
 }
 
-const ROOT_MANAGER = new TopComponentManager();
-
-function tagName(vm) {
-  let { tagName } = vm.dynamicScope().view;
-
-  return PrimitiveReference.create(tagName === '' ? null : tagName || 'div');
-}
-
-function ariaRole(vm) {
-  return vm.getSelf().get('ariaRole');
-}
+const MANAGER = new CurlyComponentManager();
 
 export class CurlyComponentDefinition extends ComponentDefinition {
-  constructor(name, ComponentClass, template, args) {
-    super(name, MANAGER, ComponentClass);
+  constructor(name, ComponentClass, template, args, customManager) {
+    super(name, customManager || MANAGER, ComponentClass);
     this.template = template;
     this.args = args;
   }
 }
+
+const ROOT_MANAGER = new TopComponentManager();
 
 export class RootComponentDefinition extends ComponentDefinition {
   constructor(instance) {
@@ -436,18 +133,3 @@ export class RootComponentDefinition extends ComponentDefinition {
     this.args = undefined;
   }
 }
-
-class CurlyComponentLayoutCompiler {
-  constructor(template) {
-    this.template = template;
-  }
-
-  compile(builder) {
-    builder.wrapLayout(this.template.asLayout());
-    builder.tag.dynamic(tagName);
-    builder.attrs.dynamic('role', ariaRole);
-    builder.attrs.static('class', 'ember-view');
-  }
-}
-
-CurlyComponentLayoutCompiler.id = 'curly';

--- a/packages/ember-glimmer/tests/integration/custom-component-manager-test.js
+++ b/packages/ember-glimmer/tests/integration/custom-component-manager-test.js
@@ -1,0 +1,83 @@
+import {
+  compileLayout,
+  PrimitiveReference
+} from '@glimmer/runtime';
+import { moduleFor, RenderingTest } from '../utils/test-case';
+import {
+  EMBER_GLIMMER_ALLOW_BACKTRACKING_RERENDER,
+  GLIMMER_CUSTOM_COMPONENT_MANAGER,
+  MANDATORY_SETTER
+} from 'ember/features';
+
+import ExperimentalComponentManager from 'ember-glimmer/component-managers/curly'
+
+if (GLIMMER_CUSTOM_COMPONENT_MANAGER) {
+  /*
+    Custom layout compiler. Exists mostly to inject
+    class and attributes for testing purposes.
+  */
+  class TestLayoutCompiler {
+    constructor(template) {
+      this.template = template;
+    }
+
+    compile(builder) {
+      builder.wrapLayout(this.template.asLayout());
+      builder.tag.dynamic(() => {
+        return PrimitiveReference.create('p');
+      });
+      builder.attrs.static('class', 'hey-oh-lets-go');
+      builder.attrs.static('manager-id', 'test');
+    }
+  }
+
+  /*
+    Implementation of custom component manager, `ComponentManager` interface
+  */
+  class TestComponentManager {
+    prepareArgs(definition, args) { return args; }
+
+    create(env, definition, args, dynamicScope, caller, hasBlock) {
+      return definition.ComponentClass.create();
+    }
+
+    layoutFor(definition, bucket, env) {
+      return env.getCompiledBlock(TestLayoutCompiler, definition.template);
+    }
+
+    getSelf({ component }) { return component; }
+
+    didCreateElement(component, element, operations) { }
+
+    didRenderLayout(component, bounds) { }
+
+    didCreate(component) { }
+
+    getTag({ component }) { return null; }
+
+    update(component, dynamicScope) { }
+
+    didUpdateLayout(component, bounds) { }
+
+    didUpdate(component) { }
+
+    getDestructor(component) { }
+  }
+
+  moduleFor('Components test: curly components with custom manager', class extends RenderingTest {
+    ['@test it can render a basic component with custom component manager'](assert) {
+      let managerId = 'test';
+      this.owner.register(`component-manager:${managerId}`, new TestComponentManager());
+      this.registerComponent('foo-bar', {
+        template: `{{use-component-manager "${managerId}"}}hello`,
+        managerId
+      });
+
+      this.render('{{foo-bar}}');
+
+      assert.equal(this.firstChild.className, 'hey-oh-lets-go', 'class name was set correctly');
+      assert.equal(this.firstChild.tagName, 'P', 'tag name was set correctly');
+      assert.equal(this.firstChild.getAttribute('manager-id'), managerId, 'custom attribute was set correctly');
+    }
+  });
+}

--- a/packages/ember-template-compiler/lib/plugins/extract-pragma-tag.js
+++ b/packages/ember-template-compiler/lib/plugins/extract-pragma-tag.js
@@ -1,0 +1,26 @@
+const PRAGMA_TAG = 'use-component-manager';
+
+// Custom Glimmer AST transform to extract custom component
+// manager id from the template
+export default class ExtractPragmaPlugin {
+  constructor(options) {
+    this.options = options;
+  }
+
+  transform(ast) {
+    let options = this.options;
+
+    this.syntax.traverse(ast, {
+      MustacheStatement: {
+        enter(node) {
+          if (node.path.type === 'PathExpression' && node.path.original === PRAGMA_TAG) {
+            options.meta.managerId = node.params[0].value;
+            return null;
+          }
+        }
+      }
+    });
+
+    return ast;
+  }
+}

--- a/packages/ember-template-compiler/lib/plugins/index.js
+++ b/packages/ember-template-compiler/lib/plugins/index.js
@@ -15,8 +15,12 @@ import TransformAttrsIntoArgs from './transform-attrs-into-args';
 import TransformEachInIntoEach from './transform-each-in-into-each';
 import TransformHasBlockSyntax from './transform-has-block-syntax';
 import TransformDotComponentInvocation from './transform-dot-component-invocation';
+import ExtractPragmaTag from './extract-pragma-tag';
+import {
+  GLIMMER_CUSTOM_COMPONENT_MANAGER
+} from 'ember/features';
 
-export default Object.freeze([
+const transforms = [
   TransformDotComponentInvocation,
   TransformOldBindingSyntax,
   TransformItemClass,
@@ -34,4 +38,10 @@ export default Object.freeze([
   TransformAttrsIntoArgs,
   TransformEachInIntoEach,
   TransformHasBlockSyntax
-]);
+];
+
+if (GLIMMER_CUSTOM_COMPONENT_MANAGER) {
+  transforms.push(ExtractPragmaTag);
+}
+
+export default Object.freeze(transforms);


### PR DESCRIPTION
This is the first step towards opening up new APIs for Ember.js community as per
[Custom Components RFC](https://github.com/emberjs/rfcs/blob/custom-components/text/0000-custom-components.md).

This will allow the following:

+ add-on authors can now start experimenting with Glimmer API while continue to support existing Ember.js components
+ developers will be able to _opt into_ using custom component managers

This change should be considered cutting-edge and introduced behind a feature flag `GLIMMER_CUSTOM_COMPONENT_MANAGER`.

To enable this feature flag in `config/environment.js` of your Ember application:

```js
module.exports = function(environment) {
  let ENV = {
    ...
    EmberENV: {
      FEATURES: {
        'glimmer-custom-component-manager': true
      }
    }
  };

  ...

  return ENV;
};
```

Or in Glimmer application, `config/environment.js`:

```js
module.exports = function(environment) {
  let ENV = {
    ...

    GlimmerENV: {
      FEATURES: {
        'glimmer-custom-component-manager': true
      }
    }
  };

  return ENV;
};
```

After that, you should be able to opt into registering your own component managers:

+ for applications

App with classic structure:

```
my-app/
  component-managers/
    nyan.js
  components/
  templates/
    components/
      nyan-cat.hbs
```

```hbs
{{!- tempates/components/nyan-cat.hbs -}}
{{use-component-manager "nyan"}}

<h1>🐱</h1>
```

App with Module Unification:

```
my-app/
  src/
    ui/
      component-managers/
        nyan.js
      components/
        nyan-cat/
          template.hbs
```

```hbs
{{!- src/ui/components/nyan-cat.hbs -}}
{{use-component-manager "nyan"}}

<h1>🐱</h1>
```

+ for add-ons

```
nyan-cat-addon/
  addon/
    component-managers/
      glimmer.js
  app/
    templates/
      components/
        nyan-cat.hbs
```