### PR TITLE
avoid creating extra array in `qualifiedRouteName`

### DIFF
--- a/packages/ember-glimmer/lib/components/link-to.js
+++ b/packages/ember-glimmer/lib/components/link-to.js
@@ -662,12 +662,13 @@ const LinkComponent = EmberComponent.extend({
   queryParams: null,
 
   qualifiedRouteName: computed('targetRouteName', '_routing.currentState', function computeLinkToComponentQualifiedRouteName() {
-    let params = get(this, 'params').slice();
-    let lastParam = params[params.length - 1];
+    let params = get(this, 'params');
+    let paramsLength = params.length;
+    let lastParam = params[paramsLength - 1];
     if (lastParam && lastParam.isQueryParams) {
-      params.pop();
+      paramsLength--;
     }
-    let onlyQueryParamsSupplied = (this[HAS_BLOCK] ? params.length === 0 : params.length === 1);
+    let onlyQueryParamsSupplied = (this[HAS_BLOCK] ? paramsLength === 0 : paramsLength === 1);
     if (onlyQueryParamsSupplied) {
       return get(this, '_routing.currentRouteName');
     }


### PR DESCRIPTION
with `let params = get(this, 'params').slice();` shallow copy was created and only its `length` was used, so I am avoiding creating that shallow copy since you need only `length` for `onlyQueryParamsSupplied` 