### PR TITLE
Remove remaining `_lookupFactory` reference in container proxy.

### DIFF
--- a/packages/ember-runtime/lib/mixins/container_proxy.js
+++ b/packages/ember-runtime/lib/mixins/container_proxy.js
@@ -96,18 +96,6 @@ let containerProxyMixin = {
   },
 
   /**
-   Given a fullName return the corresponding factory.
-
-   @private
-   @method _lookupFactory
-   @param {String} fullName
-   @return {any}
-   */
-  _lookupFactory(fullName, options) {
-    return this.__container__.lookupFactory(fullName, options);
-  },
-
-  /**
    Given a name and a source path, resolve the fullName
 
    @private


### PR DESCRIPTION
This was missed in https://github.com/emberjs/ember.js/pull/15193.