### PR TITLE
[BUGFIX beta] private registry entries should have names that don’t n…

### DIFF
--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -718,7 +718,7 @@ function has(registry, fullName, source) {
 }
 
 const privateNames = dictionary(null);
-const privateSuffix = `${Math.random()}${Date.now()}`;
+const privateSuffix = `${Math.random()}${Date.now()}`.replace('.', '');
 
 export function privatize([fullName]) {
   let name = privateNames[fullName];

--- a/packages/container/tests/registry_test.js
+++ b/packages/container/tests/registry_test.js
@@ -1,4 +1,4 @@
-import { Registry } from '..';
+import { Registry, privatize } from '..';
 import { factory } from 'internal-test-helpers';
 
 QUnit.module('Registry');
@@ -724,4 +724,16 @@ QUnit.test('has uses expandLocalLookup', function(assert) {
   assert.ok(!result, 'foo:baz/qux not found');
 
   assert.deepEqual(['foo:qux/bar'], resolvedFullNames);
+});
+
+QUnit.module('Registry privatize');
+
+QUnit.test('valid format', function(assert) {
+  let privatized = privatize(['secret:factory']);
+  let matched = privatized.match(/^([^:]+):([^:]+)-(\d+)$/);
+
+  assert.ok(matched, 'privatized format was recognized');
+  assert.equal(matched[1], 'secret');
+  assert.equal(matched[2], 'factory');
+  assert.ok(/^\d+$/.test(matched[3]));
 });


### PR DESCRIPTION
…eed to be normalized

Previously they contained a `.`

---

Bonus this function is now throughly tested.