### PR TITLE
[BREAKING BUGFIX] Fix positional params behavior to match Function#bind.

### DIFF
--- a/packages/ember-glimmer/lib/component-managers/curly.js
+++ b/packages/ember-glimmer/lib/component-managers/curly.js
@@ -112,12 +112,22 @@ export class PositionalArgumentReference {
   }
 }
 
+function positionalToNamed(positionalParamNames, positionalParams) {
+  let positionalToNamed = {};
+  for (let i = 0; i < positionalParams.length; i++) {
+    let name = positionalParamNames.shift();
+    positionalToNamed[name] = positionalParams[i];
+  }
+
+  return positionalToNamed;
+}
+
 export default class CurlyComponentManager extends AbstractManager {
   prepareArgs(definition, args) {
     let componentPositionalParamsDefinition = definition.ComponentClass.class.positionalParams;
 
     if (DEBUG && componentPositionalParamsDefinition) {
-      validatePositionalParameters(args.named, args.positional, componentPositionalParamsDefinition);
+      validatePositionalParameters(args.named, args.positional, definition);
     }
 
     let componentHasRestStylePositionalParams = typeof componentPositionalParamsDefinition === 'string';
@@ -130,36 +140,48 @@ export default class CurlyComponentManager extends AbstractManager {
     }
 
     let capturedArgs = args.capture();
-    // grab raw positional references array
-    let positional = capturedArgs.positional.references;
 
-    // handle prep for closure component with positional params
-    let curriedNamed;
-    if (definition.args) {
-      let remainingDefinitionPositionals = definition.args.positional.slice(positional.length);
-      positional = positional.concat(remainingDefinitionPositionals);
-      curriedNamed = definition.args.named;
+    let positional = [];
+    let named = [];
+
+    let positionalParamNames = !componentHasRestStylePositionalParams && [...componentPositionalParamsDefinition];
+
+    let curriedArgs = definition.args;
+    if (curriedArgs) {
+      for (let i = 0; i < curriedArgs.length; ) {
+        let layerPositional = curriedArgs[i];
+        let layerNamed = curriedArgs[i + 1];
+
+        if (componentHasPositionalParams && !componentHasRestStylePositionalParams) {
+          let layerPositionalToNamed = positionalToNamed(positionalParamNames, layerPositional);
+          named.push(layerPositionalToNamed);
+        } else if (componentHasRestStylePositionalParams){
+          positional.push(...layerPositional);
+        }
+
+        named.push(layerNamed);
+        i += 2;
+      }
     }
 
     // handle positionalParams
     let positionalParamsToNamed;
     if (componentHasRestStylePositionalParams) {
+      positional.push(...capturedArgs.positional.references);
       positionalParamsToNamed = {
         [componentPositionalParamsDefinition]: new PositionalArgumentReference(positional)
       };
-      positional = [];
+      named.push(positionalParamsToNamed);
     } else if (componentHasPositionalParams){
-      positionalParamsToNamed = {};
-      let length = Math.min(positional.length, componentPositionalParamsDefinition.length);
-      for (let i = 0; i < length; i++) {
-        let name = componentPositionalParamsDefinition[i];
-        positionalParamsToNamed[name] = positional[i];
-      }
+      let invocationPositionalToNamed = positionalToNamed(positionalParamNames, capturedArgs.positional.references);
+      named.push(invocationPositionalToNamed);
     }
 
-    let named = assign({}, curriedNamed, positionalParamsToNamed, capturedArgs.named.map);
+    named.push(capturedArgs.named.map);
 
-    return { positional, named };
+    let finalNamed = assign({}, ...named);
+
+    return { positional, named: finalNamed };
   }
 
   create(environment, definition, args, dynamicScope, callerSelfRef, hasBlock) {
@@ -354,8 +376,10 @@ export default class CurlyComponentManager extends AbstractManager {
   }
 }
 
-export function validatePositionalParameters(named, positional, positionalParamsDefinition) {
+export function validatePositionalParameters(named, positional, definition) {
   if (DEBUG) {
+    let positionalParamsDefinition = definition.ComponentClass.class.positionalParams;
+
     if (!named || !positional || !positional.length) {
       return;
     }
@@ -365,11 +389,23 @@ export function validatePositionalParameters(named, positional, positionalParams
     if (paramType === 'string') {
       assert(`You cannot specify positional parameters and the hash argument \`${positionalParamsDefinition}\`.`, !named.has(positionalParamsDefinition));
     } else {
-      if (positional.length < positionalParamsDefinition.length) {
-        positionalParamsDefinition = positionalParamsDefinition.slice(0, positional.length);
+      // copy the positional params
+      positionalParamsDefinition = positionalParamsDefinition.slice();
+
+      // if any args have been curried already, process them to ensure the remaining
+      // positional params are correct
+      let definitionArgs = definition.args;
+      if (definitionArgs) {
+        for (let i = 0; i < definitionArgs.length; i += 2) {
+          let layerPositionals = definitionArgs[i];
+          layerPositionals.forEach(() => positionalParamsDefinition.shift());
+        }
       }
 
-      for (let i = 0; i < positionalParamsDefinition.length; i++) {
+      // only check the positional params that are provided for this invocation/layer
+      let limit = Math.min(positionalParamsDefinition.length, positional.length);
+
+      for (let i = 0; i < limit; i++) {
         let name = positionalParamsDefinition[i];
 
         assert(


### PR DESCRIPTION
In general, the concept of contextual components (which is what required the creation of `(component` helper) was meant to simulate "closing over" prior arguments.

In the case of named arguments (aka "hash" arguments) the mechansim for that is fairly simple: merge all provided named arguments from each layer "upwards". This is what the majority of `(component` usages are relying on heavily today, and it works wonderfully!

How exactly to handle positional arguments was a bit less obvious. The original implementation was to treat each layer as able to overwrite the prior layers positional arguments.

For example, in this example the inner invocation (with `4 5 6` specified) would override the earlier passing of `1 2 3`:

```hbs
{{#with (component 'x-foo' 1 2 3) as |comp|}}
  {{component comp 4 5 6}}
{{/with}}
```

For the most part, this behavior has not been an issue. Most likely this is due to the fact that `positionalParams` with components are used fairly rarely, and when they are folks haven't noticed/used this clobbering behavior.

This commit changes the positional param behavior with contextual components to more closely match how `Function.prototype.bind` works (and more closely matches folks mental model of "closing over").

After these changes the snippet above would result in invoking `x-foo` with `1 2 3 4 5 6`.

As you can see, this now more closely resembles closing over the earlier values, and matches how the `action` helper handles positional parameters.

Unfortunately, this bug fix is also a breaking change to folks that have been using contextual components that have `postionalParams` set and are utilizing the clobbering behavior.
