### PR TITLE
Beef up tests around `owner.unregister`.

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -108,12 +108,13 @@ Container.prototype = {
 
   /**
    Clear either the entire cache or just the cache for a particular key.
-    @private
+
+   @private
    @method reset
    @param {String} fullName optional key to reset; if missing, resets everything
-   */
+  */
   reset(fullName) {
-    if (arguments.length > 0) {
+    if (fullName !== undefined) {
       resetMember(this, this.registry.normalize(fullName));
     } else {
       resetCache(this);

--- a/packages/ember-application/tests/system/application_instance_test.js
+++ b/packages/ember-application/tests/system/application_instance_test.js
@@ -111,22 +111,27 @@ QUnit.test('customEvents added to the application instance before setupEventDisp
 });
 
 QUnit.test('unregistering a factory clears all cached instances of that factory', function(assert) {
-  assert.expect(3);
+  assert.expect(5);
 
   appInstance = run(() => ApplicationInstance.create({ application }));
 
-  let PostController = factory();
+  let PostController1 = factory();
+  let PostController2 = factory();
 
-  appInstance.register('controller:post', PostController);
+  appInstance.register('controller:post', PostController1);
 
   let postController1 = appInstance.lookup('controller:post');
-  assert.ok(postController1, 'lookup creates instance');
+  let postController1Factory = appInstance.factoryFor('controller:post');
+  assert.ok(postController1 instanceof PostController1, 'precond - lookup creates instance');
+  assert.equal(PostController1, postController1Factory.class, 'precond - factoryFor().class matches')
 
   appInstance.unregister('controller:post');
-  appInstance.register('controller:post', PostController);
+  appInstance.register('controller:post', PostController2);
 
   let postController2 = appInstance.lookup('controller:post');
-  assert.ok(postController2, 'lookup creates instance');
+  let postController2Factory = appInstance.factoryFor('controller:post');
+  assert.ok(postController2 instanceof PostController2, 'lookup creates instance');
+  assert.equal(PostController2, postController2Factory.class, 'factoryFor().class matches')
 
   assert.notStrictEqual(postController1, postController2, 'lookup creates a brand new instance, because the previous one was reset');
 });


### PR DESCRIPTION
While attempting to run down a reported issue around `owner.unregister` I updated this test to have more assertions/scenarios just to confirm all was working properly.

Seems fine to keep around...