### PR TITLE
Add EventDispatcher tests for event bubbling

### DIFF
--- a/packages/ember-glimmer/tests/integration/event-dispatcher-test.js
+++ b/packages/ember-glimmer/tests/integration/event-dispatcher-test.js
@@ -37,6 +37,59 @@ moduleFor('EventDispatcher', class extends RenderingTest {
     assert.strictEqual(receivedEvent.target, this.$('#is-done')[0]);
   }
 
+  ['@test events bubble to parent view'](assert) {
+    let receivedEvent;
+
+    this.registerComponent('x-foo', {
+      ComponentClass: Component.extend({
+        change(event) {
+          receivedEvent = event;
+        }
+      }),
+      template: `{{yield}}`
+    });
+
+    this.registerComponent('x-bar', {
+      ComponentClass: Component.extend({
+        change() {}
+      }),
+      template: `<input id="is-done" type="checkbox">`
+    });
+
+    this.render(`{{#x-foo}}{{x-bar}}{{/x-foo}}`);
+
+    this.runTask(() => this.$('#is-done').trigger('change'));
+    assert.ok(receivedEvent, 'change event was triggered');
+    assert.strictEqual(receivedEvent.target, this.$('#is-done')[0]);
+  }
+
+  ['@test events bubbling up can be prevented'](assert) {
+    let hasReceivedEvent;
+
+    this.registerComponent('x-foo', {
+      ComponentClass: Component.extend({
+        change() {
+          hasReceivedEvent = true;
+        }
+      }),
+      template: `{{yield}}`
+    });
+
+    this.registerComponent('x-bar', {
+      ComponentClass: Component.extend({
+        change() {
+          return false;
+        }
+      }),
+      template: `<input id="is-done" type="checkbox">`
+    });
+
+    this.render(`{{#x-foo}}{{x-bar}}{{/x-foo}}`);
+
+    this.runTask(() => this.$('#is-done').trigger('change'));
+    assert.notOk(hasReceivedEvent, 'change event has not been received');
+  }
+
   ['@test dispatches to the nearest event manager'](assert) {
     let receivedEvent;
 


### PR DESCRIPTION
This adds some missing tests for asserting that events bubble up the view hierarchy, and being able to prevent this.

@rwjblue These should be the tests (they were missing) you mentioned in https://github.com/rwjblue/ember-native-dom-event-dispatcher/pull/10#issuecomment-303771206