### PR TITLE
[BUGFIX beta] Update babel-plugin-debug-macros to 0.1.10.

### DIFF
--- a/broccoli/to-es5.js
+++ b/broccoli/to-es5.js
@@ -20,7 +20,8 @@ module.exports = function toES5(tree, _options) {
     injectBabelHelpers,
     ['debug-macros', {
       debugTools: {
-        source: 'ember-debug'
+        source: 'ember-debug',
+        assertPredicateIndex: 1
       },
       envFlags: {
         source: 'ember-env-flags',

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "devDependencies": {
     "aws-sdk": "^2.46.0",
     "babel-plugin-check-es2015-constants": "^6.22.0",
-    "babel-plugin-debug-macros": "^0.1.7",
+    "babel-plugin-debug-macros": "^0.1.10",
     "babel-plugin-feature-flags": "^0.3.1",
     "babel-plugin-filter-imports": "^0.3.1",
     "babel-plugin-minify-dead-code-elimination": "^0.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -590,9 +590,9 @@ babel-plugin-dead-code-elimination@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz#5f7c451274dcd7cccdbfbb3e0b85dd28121f0f65"
 
-babel-plugin-debug-macros@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.7.tgz#69f5a3dc7d72f781354f18c611a3b007bb223511"
+babel-plugin-debug-macros@^0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.10.tgz#dd077ad6e1cc0a8f9bbc6405c561392ebfc9a01c"
   dependencies:
     semver "^5.3.0"
 


### PR DESCRIPTION
The primary changes in this version allow us to avoid costly assertion message generation when the assert predicate would not trigger an assertion.

Fixes https://github.com/emberjs/ember.js/issues/15299