### PR TITLE
[BUGFIX beta] Avoid error while parsing array QP

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -17,7 +17,8 @@ import {
   Error as EmberError,
   deprecate,
   assert,
-  info
+  info,
+  warn
 } from 'ember-debug';
 import {
   Object as EmberObject,
@@ -742,9 +743,27 @@ const EmberRouter = EmberObject.extend(Evented, {
     } else if (defaultType === 'number') {
       return (Number(value)).valueOf();
     } else if (defaultType === 'array') {
-      return emberA(JSON.parse(value));
+      return emberA(this._deserializeArrayQueryParam(value));
     }
     return value;
+  },
+
+  /**
+    Deserializes an array, returning an empty array if current value cannot be
+    deserialized.
+
+    @private
+    @method _deserializeArrayQueryParam
+    @param {String} value
+    @return {Array}
+  */
+  _deserializeArrayQueryParam(value) {
+    try {
+      return JSON.parse(value);
+    } catch (_) {
+      info(`Value ${value} could not be deserialized as an array. Returning an empty array instead.`);
+      return [];
+    }
   },
 
   /**

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -1044,6 +1044,19 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
     });
   }
 
+  ['@test GH#15306 non-array value does not break the app'](assert) {
+    assert.expect(3);
+
+    this.setSingleQPController('index', 'foo', [1]);
+
+    return this.visitAndAssert('/?foo=bar').then(() => {
+      let controller = this.getController('index');
+
+      this.assertCurrentPath('/?foo=bar', 'returns empty array if not parseable but URL does not change');
+      assert.deepEqual(controller.get('foo'), []);
+    });
+  }
+
   ['@test Url with array query param sets controller property to array'](assert) {
     assert.expect(1);
 


### PR DESCRIPTION
While deserializing an array query parameter, `JSON.parse` is used. If
it throws an error, the application cannot be easily recovered.

This array catches that exception, returns an empty array and shows
information about the error.

Fixes #15306