### PR TITLE
[BUGFIX beta] PromiseProxyMixin: wrap calls to setProperties in run

### DIFF
--- a/packages/ember-runtime/lib/mixins/promise_proxy.js
+++ b/packages/ember-runtime/lib/mixins/promise_proxy.js
@@ -1,5 +1,6 @@
 import {
   get,
+  run,
   setProperties,
   computed,
   Mixin
@@ -20,17 +21,21 @@ function tap(proxy, promise) {
 
   return promise.then(value => {
     if (!proxy.isDestroyed && !proxy.isDestroying) {
-      setProperties(proxy, {
-        content: value,
-        isFulfilled: true
-      });
+      run(() => {
+        setProperties(proxy, {
+          content: value,
+          isFulfilled: true
+        });
+      })
     }
     return value;
   }, reason => {
     if (!proxy.isDestroyed && !proxy.isDestroying) {
-      setProperties(proxy, {
-        reason,
-        isRejected: true
+      run(() => { 
+        setProperties(proxy, {
+          reason,
+          isRejected: true
+        });
       });
     }
     throw reason;


### PR DESCRIPTION
Similar to https://github.com/emberjs/ember.js/issues/13216

Using the PromiseProxyMixin in a test will throw
"Assertion Failed: You have turned on testing mode, which disabled the run-loop's autorun. You will need to wrap any code with asynchronous side-effects in a run"

see https://ember-twiddle.com/e94c8ac10b1a5705c5a66eecd5e66fcc for example test, error in console