### PR TITLE
Improve fastboot debugger/repl experience

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -214,7 +214,10 @@ function wrapManagerInDeprecationProxy(manager) {
   if (HAS_NATIVE_PROXY) {
     let validator = {
       get(obj, prop) {
-        if (prop !== 'class' && prop !== 'create') {
+        if (typeof prop === 'symbol') { return obj[prop]; }
+        if (prop === 'inspect') { return undefined; /* for nodes formatter */ }
+       
+        if (prop !== 'class' && prop !== 'create' && prop !== 'toString') {
           throw new Error(`You attempted to access "${prop}" on a factory manager created by container#factoryFor. "${prop}" is not a member of a factory manager."`);
         }
 


### PR DESCRIPTION
FactoryManager debug proxy and nodes formatValue don't play nicely. Basically, we throw when they legitimately try to inspect these objects.

I'm not terribly happy with this solution, we can likely improve it. Maybe we should chat with the node folks to get there pulse on this...

Original issue (this fixes) was from @locks -> https://github.com/stefanpenner/ember-console/issues/8

Log:
<details>
  <summary>TypeError: Cannot convert a Symbol value to a string</summary>

```
> app.instance
TypeError: Cannot convert a Symbol value to a string
    at Object.get (/Users/ricardomendes/src/--ember/ember-cli-developer-tools/dist/assets/vendor/ember/ember.debug.js:9750:1)
    at formatValue (util.js:362:37)
    at formatProperty (util.js:822:15)
    at util.js:681:12
    at Array.map (native)
    at formatObject (util.js:680:15)
    at formatValue (util.js:620:16)
    at formatProperty (util.js:822:15)
    at util.js:681:12
    at Array.map (native)
    at formatObject (util.js:680:15)
    at formatValue (util.js:620:16)
    at formatProperty (util.js:822:15)
    at util.js:681:12
    at Array.map (native)
    at formatObject (util.js:680:15)
    at formatValue (util.js:620:16)
    at Object.inspect (util.js:203:10)
    at REPLServer.self.writer (repl.js:459:19)
    at finish (repl.js:584:38)
    at REPLServer.defaultEval (repl.js:377:5)
    at bound (domain.js:280:14)
    at REPLServer.runBound (domain.js:293:12)
    at REPLServer.eval (/Users/ricardomendes/src/--ember/ember-cli-developer-tools/node_modules/await-outside/index.js:136:29)
    at REPLServer.onLine (repl.js:536:10)
    at emitOne (events.js:96:13)
    at REPLServer.emit (events.js:191:7)
    at REPLServer.Interface._onLine (readline.js:241:10)
    at REPLServer.Interface._line (readline.js:590:8)
    at REPLServer.Interface._ttyWrite (readline.js:869:14)
    at REPLServer.self._ttyWrite (repl.js:609:7)
    at ReadStream.onkeypress (readline.js:120:10)
    at emitTwo (events.js:106:13)
    at ReadStream.emit (events.js:194:7)
    at emitKeys (internal/readline.js:402:14)
    at emitKeys.next (<anonymous>)
    at ReadStream.onData (readline.js:980:36)
    at emitOne (events.js:96:13)
    at ReadStream.emit (events.js:191:7)
    at readableAddChunk (_stream_readable.js:178:18)
    at ReadStream.Readable.push (_stream_readable.js:136:10)
    at TTY.onread (net.js:561:20)
```
</details>