### PR TITLE
[FEATURE ember-engines-mount-params] Constrain to `model` hash arg.

### DIFF
--- a/packages/ember-glimmer/lib/component-managers/mount.js
+++ b/packages/ember-glimmer/lib/component-managers/mount.js
@@ -29,7 +29,7 @@ class MountManager extends AbstractManager {
     let bucket = { engine };
 
     if (EMBER_ENGINES_MOUNT_PARAMS) {
-      bucket.args = args.capture();
+      bucket.modelReference = args.named.get('model');
     }
 
     return bucket;
@@ -41,15 +41,15 @@ class MountManager extends AbstractManager {
   }
 
   getSelf(bucket) {
-    let { engine, args } = bucket;
+    let { engine, modelReference } = bucket;
 
     let applicationFactory = engine.factoryFor(`controller:application`);
     let controllerFactory = applicationFactory || generateControllerFactory(engine, 'application');
     let controller = bucket.controller = controllerFactory.create();
 
     if (EMBER_ENGINES_MOUNT_PARAMS) {
-      let model = args.named.value();
-      bucket.argsRevision = args.tag.value();
+      let model = modelReference.value();
+      bucket.modelRevision = modelReference.tag.value();
       controller.set('model', model);
     }
 
@@ -68,11 +68,11 @@ class MountManager extends AbstractManager {
 
   update(bucket) {
     if (EMBER_ENGINES_MOUNT_PARAMS) {
-      let { controller, args, argsRevision } = bucket;
+      let { controller, modelReference, modelRevision } = bucket;
 
-      if (!args.tag.validate(argsRevision)) {
-        let model = args.named.value();
-        bucket.argsRevision = args.tag.value();
+      if (!modelReference.tag.validate(modelRevision)) {
+        let model = modelReference.value();
+        bucket.modelRevision = modelReference.tag.value();
         controller.set('model', model);
       }
     }

--- a/packages/ember-glimmer/tests/integration/mount-test.js
+++ b/packages/ember-glimmer/tests/integration/mount-test.js
@@ -208,7 +208,7 @@ if (EMBER_ENGINES_MOUNT_PARAMS) {
       this.router.map(function() {
         this.route('engine-params-static');
       });
-      this.addTemplate('engine-params-static', '{{mount "paramEngine" foo="bar"}}');
+      this.addTemplate('engine-params-static', '{{mount "paramEngine" model=(hash foo="bar")}}');
 
       return this.visit('/engine-params-static').then(() => {
         this.assertComponentElement(this.firstChild, { content: '<h2>Param Engine: bar</h2>' });
@@ -227,7 +227,7 @@ if (EMBER_ENGINES_MOUNT_PARAMS) {
           controller = this;
         }
       }));
-      this.addTemplate('engine-params-bound', '{{mount "paramEngine" foo=boundParamValue}}');
+      this.addTemplate('engine-params-bound', '{{mount "paramEngine" model=(hash foo=boundParamValue)}}');
 
       return this.visit('/engine-params-bound').then(() => {
         this.assertComponentElement(this.firstChild, { content: '<h2>Param Engine: </h2>' });
@@ -277,7 +277,7 @@ if (EMBER_ENGINES_MOUNT_PARAMS) {
           this.register('template:application', compile('{{model.foo}}', { moduleName: 'application' }));
         }
       }));
-      this.addTemplate('engine-params-contextual-component', '{{mount "componentParamEngine" foo=(component "foo-component")}}');
+      this.addTemplate('engine-params-contextual-component', '{{mount "componentParamEngine" model=(hash foo=(component "foo-component"))}}');
 
       return this.visit('/engine-params-contextual-component').then(() => {
         this.assertComponentElement(this.firstChild.firstChild, { content: 'foo-component rendered! - rendered app-bar-component from the app' });


### PR DESCRIPTION
After discussion during a recent core team meeting, the original implementation 
(and RFC) were determined to be a bit future hostile.

Specifically, with the implementation prior to this PR it would have been impossible to add any additional hash arguments that were targeting the `{{mount` syntax directly (e.g. namespacing for use with tree shaking) without breaking changes (since all hash arg names were allowed to be passed through before).

This change updates things a bit to limit the pass through to the `model` hash argument, which actually makes things a tad bit more teachable anyways. The ability to pass down arbitrary named values is absolutely still present through the usage of the `(hash` helper.