### PR TITLE
[FEATURE ember-engines-mount-params] Enable by default.

### DIFF
--- a/features.json
+++ b/features.json
@@ -6,7 +6,7 @@
     "ember-metal-weakmap": null,
     "ember-glimmer-allow-backtracking-rerender": null,
     "ember-routing-router-service": null,
-    "ember-engines-mount-params": null,
+    "ember-engines-mount-params": true,
     "glimmer-custom-component-manager": null
   },
   "deprecations": {


### PR DESCRIPTION
As discussed during the 2017-06-02 core team meeting, once the feature was restricted to the `model` named argument (as opposed to passing through all named args) this feature was good to go.

This enables the feature by default.