### PR TITLE
Decouple acceptance_test, helpers_test frm globals

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -1028,7 +1028,7 @@ Application.reopenClass({
 });
 
 function commonSetupRegistry(registry) {
-  registry.register('router:main', Router);
+  registry.register('router:main', Router.extend());
   registry.register('-view-registry:main', { create() { return dictionary(null); } });
 
   registry.register('route:basic', Route);

--- a/packages/ember-testing/lib/ext/application.js
+++ b/packages/ember-testing/lib/ext/application.js
@@ -60,7 +60,8 @@ EmberApplication.reopen({
     the app when your tests are ready to run. It also sets the router's
     location to 'none', so that the window's location will not be modified
     (preventing both accidental leaking of state between tests and interference
-    with your testing framework).
+    with your testing framework). `setupForTesting` should only be called after
+    setting a custom `router` class (for example `App.Router = Router.extend(`).
 
     Example:
 
@@ -76,7 +77,7 @@ EmberApplication.reopen({
 
     this.testing = true;
 
-    this.Router.reopen({
+    this.resolveRegistration('router:main').reopen({
       location: 'none'
     });
   },

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -1,33 +1,22 @@
+import {
+  moduleFor,
+  AutobootApplicationTestCase
+} from 'internal-test-helpers';
+
 import { run } from 'ember-metal';
-import { jQuery } from 'ember-views';
 import Test from '../test';
 import QUnitAdapter from '../adapters/qunit';
-import '../initializers'; // ensure the initializer is setup
-import { Application as EmberApplication } from 'ember-application';
-import { Route as EmberRoute } from 'ember-routing';
-import { compile } from 'ember-template-compiler';
+import { Route } from 'ember-routing';
 import { RSVP } from 'ember-runtime';
-import { setTemplates, setTemplate } from 'ember-glimmer';
 
-//ES6TODO: we need {{link-to}}  and {{outlet}} to exist here
+moduleFor('ember-testing Acceptance', class extends AutobootApplicationTestCase {
+  constructor() {
+    super();
+    this._originalAdapter = Test.adapter;
 
-var App, find, click, fillIn, currentRoute, currentURL, visit, originalAdapter, andThen, indexHitCount;
-
-QUnit.module('ember-testing Acceptance', {
-  setup() {
-    jQuery('<style>#ember-testing-container { position: absolute; background: white; bottom: 0; right: 0; width: 640px; height: 384px; overflow: auto; z-index: 9999; border: 1px solid #ccc; } #ember-testing { zoom: 50%; }</style>').appendTo('head');
-    jQuery('<div id="ember-testing-container"><div id="ember-testing"></div></div>').appendTo('body');
-
-    originalAdapter = Test.adapter;
-
-    run(function() {
-      indexHitCount = 0;
-
-      App = EmberApplication.create({
-        rootElement: '#ember-testing'
-      });
-
-      App.Router.map(function() {
+    this.runTask(() => {
+      this.createApplication();
+      this.router.map(function() {
         this.route('posts');
         this.route('comments');
 
@@ -36,376 +25,365 @@ QUnit.module('ember-testing Acceptance', {
         this.route('redirect');
       });
 
-      App.IndexRoute = EmberRoute.extend({
+      this.indexHitCount = 0;
+      this.currentRoute = 'index';
+      let testContext = this;
+
+      this.add('route:index', Route.extend({
         model() {
-          indexHitCount += 1;
+          testContext.indexHitCount += 1;
         }
-      });
+      }));
 
-      App.PostsRoute = EmberRoute.extend({
+      this.add('route:posts', Route.extend({
         renderTemplate() {
-          currentRoute = 'posts';
+          testContext.currentRoute = 'posts';
           this._super(...arguments);
         }
-      });
+      }));
 
-      setTemplate('posts', compile('<div class="posts-view"><a class="dummy-link"></a><div id="comments-link">{{#link-to \'comments\'}}Comments{{/link-to}}</div></div>'));
+      this.addTemplate('posts', `
+        <div class="posts-view">
+          <a class="dummy-link"></a>
+          <div id="comments-link">
+            {{#link-to \'comments\'}}Comments{{/link-to}}
+          </div>
+        </div>
+      `);
 
-      App.CommentsRoute = EmberRoute.extend({
+      this.add('route:comments', Route.extend({
         renderTemplate() {
-          currentRoute = 'comments';
+          testContext.currentRoute = 'comments';
           this._super(...arguments);
         }
-      });
+      }));
 
-      setTemplate('comments', compile('<div>{{input type="text"}}</div>'));
+      this.addTemplate('comments', `<div>{{input type="text"}}</div>`);
 
-      App.AbortTransitionRoute = EmberRoute.extend({
+      this.add('route:abort_transition', Route.extend({
         beforeModel(transition) {
           transition.abort();
         }
-      });
+      }));
 
-      App.RedirectRoute = EmberRoute.extend({
+      this.add('route:redirect', Route.extend({
         beforeModel() {
           this.transitionTo('comments');
         }
+      }));
+
+      this.application.setupForTesting();
+
+      Test.registerAsyncHelper('slowHelper', () => {
+        return new RSVP.Promise(resolve => run.later(resolve, 10));
       });
 
-      App.setupForTesting();
+      this.application.injectTestHelpers();
     });
-
-    Test.registerAsyncHelper('slowHelper', function() {
-      return new RSVP.Promise(function(resolve) {
-        setTimeout(resolve, 10);
-      });
-    });
-
-    App.injectTestHelpers();
-
-    find = window.find;
-    click = window.click;
-    fillIn = window.fillIn;
-    visit = window.visit;
-    andThen = window.andThen;
-    currentURL = window.currentURL;
-  },
+  }
 
   teardown() {
-    Test.unregisterHelper('slowHelper');
-    setTemplates({});
-    jQuery('#ember-testing-container, #ember-testing').remove();
-    run(App, App.destroy);
-    App = null;
-    Test.adapter = originalAdapter;
-    indexHitCount = 0;
+    Test.adapter = this._originalAdapter;
+    super.teardown();
   }
-});
 
-QUnit.test('helpers can be chained with then', function() {
-  expect(6);
+  [`@test helpers can be chained with then`](assert) {
+    assert.expect(6);
 
-  currentRoute = 'index';
-
-  visit('/posts').then(function() {
-    equal(currentRoute, 'posts', 'Successfully visited posts route');
-    equal(currentURL(), '/posts', 'posts URL is correct');
-    return click('a:contains("Comments")');
-  }).then(function() {
-    equal(currentRoute, 'comments', 'visit chained with click');
-    return fillIn('.ember-text-field', 'yeah');
-  }).then(function() {
-    equal(jQuery('.ember-text-field').val(), 'yeah', 'chained with fillIn');
-    return fillIn('.ember-text-field', '#ember-testing-container', 'context working');
-  }).then(function() {
-    equal(jQuery('.ember-text-field').val(), 'context working', 'chained with fillIn');
-    return click('.does-not-exist');
-  }).then(null, function(e) {
-    equal(e.message, 'Element .does-not-exist not found.', 'Non-existent click exception caught');
-  });
-});
-
-
-
-// Keep this for backwards compatibility
-
-QUnit.test('helpers can be chained to each other', function() {
-  expect(7);
-
-  currentRoute = 'index';
-
-  visit('/posts')
-  .click('a:first', '#comments-link')
-  .fillIn('.ember-text-field', 'hello')
-  .then(function() {
-    equal(currentRoute, 'comments', 'Successfully visited comments route');
-    equal(currentURL(), '/comments', 'Comments URL is correct');
-    equal(jQuery('.ember-text-field').val(), 'hello', 'Fillin successfully works');
-    find('.ember-text-field').one('keypress', function(e) {
-      equal(e.keyCode, 13, 'keyevent chained with correct keyCode.');
-      equal(e.which, 13, 'keyevent chained with correct which.');
-    });
-  })
-  .keyEvent('.ember-text-field', 'keypress', 13)
-  .visit('/posts')
-  .then(function() {
-    equal(currentRoute, 'posts', 'Thens can also be chained to helpers');
-    equal(currentURL(), '/posts', 'URL is set correct on chained helpers');
-  });
-});
-
-QUnit.test('helpers don\'t need to be chained', function() {
-  expect(5);
-
-  currentRoute = 'index';
-
-  visit('/posts');
-
-  click('a:first', '#comments-link');
-
-  fillIn('.ember-text-field', 'hello');
-
-  andThen(function() {
-    equal(currentRoute, 'comments', 'Successfully visited comments route');
-    equal(currentURL(), '/comments', 'Comments URL is correct');
-    equal(find('.ember-text-field').val(), 'hello', 'Fillin successfully works');
-  });
-
-  visit('/posts');
-
-  andThen(function() {
-    equal(currentRoute, 'posts');
-    equal(currentURL(), '/posts');
-  });
-});
-
-QUnit.test('Nested async helpers', function() {
-  expect(5);
-
-  currentRoute = 'index';
-
-  visit('/posts');
-
-  andThen(function() {
-    click('a:first', '#comments-link');
-
-    fillIn('.ember-text-field', 'hello');
-  });
-
-  andThen(function() {
-    equal(currentRoute, 'comments', 'Successfully visited comments route');
-    equal(currentURL(), '/comments', 'Comments URL is correct');
-    equal(find('.ember-text-field').val(), 'hello', 'Fillin successfully works');
-  });
-
-  visit('/posts');
-
-  andThen(function() {
-    equal(currentRoute, 'posts');
-    equal(currentURL(), '/posts');
-  });
-});
-
-QUnit.test('Multiple nested async helpers', function() {
-  expect(3);
-
-  visit('/posts');
-
-  andThen(function() {
-    click('a:first', '#comments-link');
-
-    fillIn('.ember-text-field', 'hello');
-    fillIn('.ember-text-field', 'goodbye');
-  });
-
-  andThen(function() {
-    equal(find('.ember-text-field').val(), 'goodbye', 'Fillin successfully works');
-    equal(currentRoute, 'comments', 'Successfully visited comments route');
-    equal(currentURL(), '/comments', 'Comments URL is correct');
-  });
-});
-
-QUnit.test('Helpers nested in thens', function() {
-  expect(5);
-
-  currentRoute = 'index';
-
-  visit('/posts').then(function() {
-    click('a:first', '#comments-link');
-  });
-
-  andThen(function() {
-    fillIn('.ember-text-field', 'hello');
-  });
-
-  andThen(function() {
-    equal(currentRoute, 'comments', 'Successfully visited comments route');
-    equal(currentURL(), '/comments', 'Comments URL is correct');
-    equal(find('.ember-text-field').val(), 'hello', 'Fillin successfully works');
-  });
-
-  visit('/posts');
-
-  andThen(function() {
-    equal(currentRoute, 'posts');
-    equal(currentURL(), '/posts', 'Posts URL is correct');
-  });
-});
-
-QUnit.test('Aborted transitions are not logged via Ember.Test.adapter#exception', function () {
-  expect(0);
-
-  Test.adapter = QUnitAdapter.create({
-    exception(error) {
-      ok(false, 'aborted transitions are not logged');
-    }
-  });
-
-  visit('/abort_transition');
-});
-
-QUnit.test('Unhandled exceptions are logged via Ember.Test.adapter#exception', function () {
-  expect(2);
-
-  var asyncHandled;
-  Test.adapter = QUnitAdapter.create({
-    exception(error) {
-      equal(error.message, 'Element .does-not-exist not found.', 'Exception successfully caught and passed to Ember.Test.adapter.exception');
-      asyncHandled['catch'](function() { }); // handle the rejection so it doesn't leak later.
-    }
-  });
-
-  visit('/posts');
-
-  click('.invalid-element').then(null, function(error) {
-    equal(error.message, 'Element .invalid-element not found.', 'Exception successfully handled in the rejection handler');
-  });
-
-  asyncHandled = click('.does-not-exist');
-});
-
-QUnit.test('Unhandled exceptions in `andThen` are logged via Ember.Test.adapter#exception', function () {
-  expect(1);
-
-  Test.adapter = QUnitAdapter.create({
-    exception(error) {
-      equal(error.message, 'Catch me', 'Exception successfully caught and passed to Ember.Test.adapter.exception');
-    }
-  });
-
-  visit('/posts');
-
-  andThen(function() {
-    throw new Error('Catch me');
-  });
-});
-
-QUnit.test('should not start routing on the root URL when visiting another', function() {
-  expect(4);
-
-  visit('/posts');
-
-  andThen(function() {
-    ok(find('#comments-link'), 'found comments-link');
-    equal(currentRoute, 'posts', 'Successfully visited posts route');
-    equal(currentURL(), '/posts', 'Posts URL is correct');
-    equal(indexHitCount, 0, 'should not hit index route when visiting another route');
-  });
-});
-
-QUnit.test('only enters the index route once when visiting /', function() {
-  expect(1);
-
-  visit('/');
-
-  andThen(function() {
-    equal(indexHitCount, 1, 'should hit index once when visiting /');
-  });
-});
-
-QUnit.test('test must not finish while asyncHelpers are pending', function () {
-  expect(2);
-
-  var async = 0;
-  var innerRan = false;
-
-  Test.adapter = QUnitAdapter.extend({
-    asyncStart() {
-      async++;
-      this._super();
-    },
-    asyncEnd() {
-      async--;
-      this._super();
-    }
-  }).create();
-
-  App.testHelpers.slowHelper();
-  andThen(function() {
-    innerRan = true;
-  });
-
-
-  equal(innerRan, false, 'should not have run yet');
-  ok(async > 0, 'should have told the adapter to pause');
-
-  if (async === 0) {
-    // If we failed the test, prevent zalgo from escaping and breaking
-    // our other tests.
-    Test.adapter.asyncStart();
-    Test.resolve().then(function() {
-      Test.adapter.asyncEnd();
+    window.visit('/posts').then(() => {
+      assert.equal(this.currentRoute, 'posts', 'Successfully visited posts route');
+      assert.equal(window.currentURL(), '/posts', 'posts URL is correct');
+      return window.click('a:contains("Comments")');
+    }).then(() => {
+      assert.equal(this.currentRoute, 'comments', 'visit chained with click');
+      return window.fillIn('.ember-text-field', 'yeah');
+    }).then(() => {
+      assert.equal(this.$('.ember-text-field').val(), 'yeah', 'chained with fillIn');
+      return window.fillIn('.ember-text-field', '#qunit-fixture', 'context working');
+    }).then(() => {
+      assert.equal(this.$('.ember-text-field').val(), 'context working', 'chained with fillIn');
+      return window.click('.does-not-exist');
+    }).catch(e => {
+      assert.equal(e.message, 'Element .does-not-exist not found.', 'Non-existent click exception caught');
     });
   }
-});
 
-QUnit.test('visiting a URL that causes another transition should yield the correct URL', function () {
-  expect(1);
+  [`@test helpers can be chained to each other (legacy)`](assert) {
+    assert.expect(7);
 
-  visit('/redirect');
+    window.visit('/posts')
+      .click('a:first', '#comments-link')
+      .fillIn('.ember-text-field', 'hello')
+      .then(() => {
+        assert.equal(this.currentRoute, 'comments', 'Successfully visited comments route');
+        assert.equal(window.currentURL(), '/comments', 'Comments URL is correct');
+        assert.equal(this.$('.ember-text-field').val(), 'hello', 'Fillin successfully works');
+        window.find('.ember-text-field').one('keypress', e => {
+          assert.equal(e.keyCode, 13, 'keyevent chained with correct keyCode.');
+          assert.equal(e.which, 13, 'keyevent chained with correct which.');
+        });
+      })
+      .keyEvent('.ember-text-field', 'keypress', 13)
+      .visit('/posts')
+      .then(() => {
+        assert.equal(this.currentRoute, 'posts', 'Thens can also be chained to helpers');
+        assert.equal(window.currentURL(), '/posts', 'URL is set correct on chained helpers');
+      });
+  }
 
-  andThen(function () {
-    equal(currentURL(), '/comments', 'Redirected to Comments URL');
-  });
-});
+  [`@test helpers don't need to be chained`](assert) {
+    assert.expect(5);
 
-QUnit.test('visiting a URL and then visiting a second URL with a transition should yield the correct URL', function () {
-  expect(2);
+    window.visit('/posts');
 
-  visit('/posts');
+    window.click('a:first', '#comments-link');
 
-  andThen(function () {
-    equal(currentURL(), '/posts', 'First visited URL is correct');
-  });
+    window.fillIn('.ember-text-field', 'hello');
 
-  visit('/redirect');
-
-  andThen(function () {
-    equal(currentURL(), '/comments', 'Redirected to Comments URL');
-  });
-});
-
-QUnit.module('ember-testing Acceptance – teardown');
-
-QUnit.test('that the setup/teardown happens correct', function() {
-  expect(2);
-
-  jQuery('<style>#ember-testing-container { position: absolute; background: white; bottom: 0; right: 0; width: 640px; height: 384px; overflow: auto; z-index: 9999; border: 1px solid #ccc; } #ember-testing { zoom: 50%; }</style>').appendTo('head');
-  jQuery('<div id="ember-testing-container"><div id="ember-testing"></div></div>').appendTo('body');
-
-  run(function() {
-    indexHitCount = 0;
-    App = EmberApplication.create({
-      rootElement: '#ember-testing'
+    window.andThen(() => {
+      assert.equal(this.currentRoute, 'comments', 'Successfully visited comments route');
+      assert.equal(window.currentURL(), '/comments', 'Comments URL is correct');
+      assert.equal(window.find('.ember-text-field').val(), 'hello', 'Fillin successfully works');
     });
-  });
-  App.injectTestHelpers();
 
-  jQuery('#ember-testing-container, #ember-testing').remove();
-  ok(typeof Test.Promise.prototype.click === 'function');
-  run(App, App.destroy);
-  equal(Test.Promise.prototype.click, undefined);
-  App = null;
-  Test.adapter = originalAdapter;
-  indexHitCount = 0;
+    window.visit('/posts');
+
+    window.andThen(() => {
+      assert.equal(this.currentRoute, 'posts');
+      assert.equal(window.currentURL(), '/posts');
+    });
+  }
+
+  [`@test Nested async helpers`](assert) {
+    assert.expect(5);
+
+    window.visit('/posts');
+
+    window.andThen(() => {
+      window.click('a:first', '#comments-link');
+      window.fillIn('.ember-text-field', 'hello');
+    });
+
+    window.andThen(() => {
+      assert.equal(this.currentRoute, 'comments', 'Successfully visited comments route');
+      assert.equal(window.currentURL(), '/comments', 'Comments URL is correct');
+      assert.equal(window.find('.ember-text-field').val(), 'hello', 'Fillin successfully works');
+    });
+
+    window.visit('/posts');
+
+    window.andThen(() => {
+      assert.equal(this.currentRoute, 'posts');
+      assert.equal(window.currentURL(), '/posts');
+    });
+  }
+
+  [`@test Multiple nested async helpers`](assert) {
+    assert.expect(3);
+
+    window.visit('/posts');
+
+    window.andThen(() => {
+      window.click('a:first', '#comments-link');
+
+      window.fillIn('.ember-text-field', 'hello');
+      window.fillIn('.ember-text-field', 'goodbye');
+    });
+
+    window.andThen(() => {
+      assert.equal(window.find('.ember-text-field').val(), 'goodbye', 'Fillin successfully works');
+      assert.equal(this.currentRoute, 'comments', 'Successfully visited comments route');
+      assert.equal(window.currentURL(), '/comments', 'Comments URL is correct');
+    });
+  }
+
+  [`@test Helpers nested in thens`](assert) {
+    assert.expect(5);
+
+    window.visit('/posts').then(() => {
+      window.click('a:first', '#comments-link');
+    });
+
+    window.andThen(() => {
+      window.fillIn('.ember-text-field', 'hello');
+    });
+
+    window.andThen(() => {
+      assert.equal(this.currentRoute, 'comments', 'Successfully visited comments route');
+      assert.equal(window.currentURL(), '/comments', 'Comments URL is correct');
+      assert.equal(window.find('.ember-text-field').val(), 'hello', 'Fillin successfully works');
+    });
+
+    window.visit('/posts');
+
+    window.andThen(() => {
+      assert.equal(this.currentRoute, 'posts');
+      assert.equal(window.currentURL(), '/posts', 'Posts URL is correct');
+    });
+  }
+
+  [`@test Aborted transitions are not logged via Ember.Test.adapter#exception`](assert) {
+    assert.expect(0);
+
+    Test.adapter = QUnitAdapter.create({
+      exception(error) {
+        assert.ok(false, 'aborted transitions are not logged');
+      }
+    });
+
+    window.visit('/abort_transition');
+  }
+
+  [`@test Unhandled exceptions are logged via Ember.Test.adapter#exception`](assert) {
+    assert.expect(2);
+
+    let asyncHandled;
+    Test.adapter = QUnitAdapter.create({
+      exception(error) {
+        assert.equal(
+          error.message, 'Element .does-not-exist not found.',
+          'Exception successfully caught and passed to Ember.Test.adapter.exception'
+        );
+        // handle the rejection so it doesn't leak later.
+        asyncHandled.catch(() => { });
+      }
+    });
+
+    window.visit('/posts');
+
+    window.click('.invalid-element').catch(error => {
+      assert.equal(
+        error.message, 'Element .invalid-element not found.',
+        'Exception successfully handled in the rejection handler'
+      );
+    });
+
+    asyncHandled = window.click('.does-not-exist');
+  }
+
+  [`@test Unhandled exceptions in 'andThen' are logged via Ember.Test.adapter#exception`](assert) {
+    assert.expect(1);
+
+    Test.adapter = QUnitAdapter.create({
+      exception(error) {
+        assert.equal(
+          error.message, 'Catch me',
+          'Exception successfully caught and passed to Ember.Test.adapter.exception'
+        );
+      }
+    });
+
+    window.visit('/posts');
+
+    window.andThen(() => {
+      throw new Error('Catch me');
+    });
+  }
+
+  [`@test should not start routing on the root URL when visiting another`](assert) {
+    assert.expect(4);
+
+    window.visit('/posts');
+
+    window.andThen(() => {
+      assert.ok(window.find('#comments-link'), 'found comments-link');
+      assert.equal(this.currentRoute, 'posts', 'Successfully visited posts route');
+      assert.equal(window.currentURL(), '/posts', 'Posts URL is correct');
+      assert.equal(this.indexHitCount, 0, 'should not hit index route when visiting another route');
+    });
+  }
+
+  [`@test only enters the index route once when visiting `](assert) {
+    assert.expect(1);
+
+    window.visit('/');
+
+    window.andThen(() => {
+      assert.equal(this.indexHitCount, 1, 'should hit index once when visiting /');
+    });
+  }
+
+  [`@test test must not finish while asyncHelpers are pending`](assert) {
+    assert.expect(2);
+
+    let async = 0;
+    let innerRan = false;
+
+    Test.adapter = QUnitAdapter.extend({
+      asyncStart() {
+        async++;
+        this._super();
+      },
+      asyncEnd() {
+        async--;
+        this._super();
+      }
+    }).create();
+
+    this.application.testHelpers.slowHelper();
+
+    window.andThen(() => {
+      innerRan = true;
+    });
+
+    assert.equal(innerRan, false, 'should not have run yet');
+    assert.ok(async > 0, 'should have told the adapter to pause');
+
+    if (async === 0) {
+      // If we failed the test, prevent zalgo from escaping and breaking
+      // our other tests.
+      Test.adapter.asyncStart();
+      Test.resolve().then(() => {
+        Test.adapter.asyncEnd();
+      });
+    }
+  }
+
+  [`@test visiting a URL that causes another transition should yield the correct URL`](assert) {
+    assert.expect(1);
+
+    window.visit('/redirect');
+
+    window.andThen(() => {
+      assert.equal(window.currentURL(), '/comments', 'Redirected to Comments URL');
+    });
+  }
+
+  [`@test visiting a URL and then visiting a second URL with a transition should yield the correct URL`](assert) {
+    assert.expect(2);
+
+    window.visit('/posts');
+
+    window.andThen(function () {
+      assert.equal(window.currentURL(), '/posts', 'First visited URL is correct');
+    });
+
+    window.visit('/redirect');
+
+    window.andThen(() => {
+      assert.equal(window.currentURL(), '/comments', 'Redirected to Comments URL');
+    });
+  }
+
+});
+
+moduleFor('ember-testing Acceptance - teardown', class extends AutobootApplicationTestCase {
+
+  [`@test that the setup/teardown happens correctly`](assert) {
+    assert.expect(2);
+
+    this.runTask(() => {
+      this.createApplication();
+    });
+    this.application.injectTestHelpers();
+
+    assert.ok(typeof Test.Promise.prototype.click === 'function');
+
+    this.runTask(() => {
+      this.application.destroy();
+    });
+
+    assert.equal(Test.Promise.prototype.click, undefined);
+  }
+
 });

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -830,7 +830,6 @@ QUnit.module('ember-testing routing helpers', {
   setup() {
     run(function() {
       App = EmberApplication.create();
-      App.setupForTesting();
 
       App.injectTestHelpers();
 
@@ -843,6 +842,8 @@ QUnit.module('ember-testing routing helpers', {
           this.route('new');
         });
       });
+
+      App.setupForTesting();
     });
 
     run(App, 'advanceReadiness');

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -1,23 +1,21 @@
-import { Route, Router } from 'ember-routing';
+import {
+  moduleFor,
+  AutobootApplicationTestCase
+} from 'internal-test-helpers';
+
+import { Route } from 'ember-routing';
 import {
   Controller,
-  Object as EmberObject,
   RSVP
 } from 'ember-runtime';
 import { run } from 'ember-metal';
 import { jQuery } from 'ember-views';
 import {
   Component,
-  setTemplates,
-  setTemplate
 } from 'ember-glimmer';
 
 import Test from '../test';
-import '../helpers';  // ensure that the helpers are loaded
-import '../initializers'; // ensure the initializer is setup
 import setupForTesting from '../setup_for_testing';
-import { Application as EmberApplication } from 'ember-application';
-import { compile } from 'ember-template-compiler';
 
 import {
   pendingRequests,
@@ -33,32 +31,11 @@ import {
   unregisterWaiter
 } from '../test/waiters';
 
-var App;
-var originalAdapter = getAdapter();
-
-function cleanup() {
-  // Teardown setupForTesting
-
-  setAdapter(originalAdapter);
-  run(function() {
-    jQuery(document).off('ajaxSend');
-    jQuery(document).off('ajaxComplete');
-  });
-  clearPendingRequests();
-  // Test.waiters = null;
-
-  // Other cleanup
-
-  if (App) {
-    run(App, App.destroy);
-    App.removeTestHelpers();
-    App = null;
-  }
-
-  setTemplates({});
+function registerHelper() {
+  Test.registerHelper('LeakyMcLeakLeak', () => {});
 }
 
-function assertHelpers(application, helperContainer, expected) {
+function assertHelpers(assert, application, helperContainer, expected) {
   if (!helperContainer) { helperContainer = window; }
   if (expected === undefined) { expected = true; }
 
@@ -66,8 +43,14 @@ function assertHelpers(application, helperContainer, expected) {
     var presentInHelperContainer = !!helperContainer[helper];
     var presentInTestHelpers = !!application.testHelpers[helper];
 
-    ok(presentInHelperContainer === expected, 'Expected \'' + helper + '\' to be present in the helper container (defaults to window).');
-    ok(presentInTestHelpers === expected, 'Expected \'' + helper + '\' to be present in App.testHelpers.');
+    assert.ok(
+      presentInHelperContainer === expected,
+      'Expected \'' + helper + '\' to be present in the helper container (defaults to window).'
+    );
+    assert.ok(
+      presentInTestHelpers === expected,
+      'Expected \'' + helper + '\' to be present in App.testHelpers.'
+    );
   }
 
   checkHelperPresent('visit', expected);
@@ -78,994 +61,1182 @@ function assertHelpers(application, helperContainer, expected) {
   checkHelperPresent('triggerEvent', expected);
 }
 
-function assertNoHelpers(application, helperContainer) {
-  assertHelpers(application, helperContainer, false);
+function assertNoHelpers(assert, application, helperContainer) {
+  assertHelpers(assert, application, helperContainer, false);
 }
 
-function currentRouteName(app) {
-  return app.testHelpers.currentRouteName();
-}
+class HelpersTestCase extends AutobootApplicationTestCase {
 
-function currentPath(app) {
-  return app.testHelpers.currentPath();
-}
-
-function currentURL(app) {
-  return app.testHelpers.currentURL();
-}
-
-function setupApp() {
-  run(function() {
-    App = EmberApplication.create();
-    App.setupForTesting();
-
-    App.injectTestHelpers();
-  });
-}
-
-QUnit.module('ember-testing: Helper setup', {
-  setup() { cleanup(); },
-  teardown() { cleanup(); }
-});
-
-function registerHelper() {
-  Test.registerHelper('LeakyMcLeakLeak', function(app) {
-  });
-}
-
-QUnit.test('Ember.Application#injectTestHelpers/#removeTestHelpers', function() {
-  App = run(EmberApplication, EmberApplication.create);
-  assertNoHelpers(App);
-
-  registerHelper();
-
-  App.injectTestHelpers();
-  assertHelpers(App);
-  ok(Test.Promise.prototype.LeakyMcLeakLeak, 'helper in question SHOULD be present');
-
-  App.removeTestHelpers();
-  assertNoHelpers(App);
-
-  equal(Test.Promise.prototype.LeakyMcLeakLeak, undefined, 'should NOT leak test promise extensions');
-});
-
-
-QUnit.test('Ember.Application#setupForTesting', function() {
-  run(function() {
-    App = EmberApplication.create();
-    App.setupForTesting();
-  });
-
-  equal(App.__container__.lookup('router:main').location, 'none');
-});
-
-QUnit.test('Ember.Application.setupForTesting sets the application to `testing`.', function() {
-  run(function() {
-    App = EmberApplication.create();
-    App.setupForTesting();
-  });
-
-  equal(App.testing, true, 'Application instance is set to testing.');
-});
-
-QUnit.test('Ember.Application.setupForTesting leaves the system in a deferred state.', function() {
-  run(function() {
-    App = EmberApplication.create();
-    App.setupForTesting();
-  });
-
-  equal(App._readinessDeferrals, 1, 'App is in deferred state after setupForTesting.');
-});
-
-QUnit.test('App.reset() after Application.setupForTesting leaves the system in a deferred state.', function() {
-  run(function() {
-    App = EmberApplication.create();
-    App.setupForTesting();
-  });
-
-  equal(App._readinessDeferrals, 1, 'App is in deferred state after setupForTesting.');
-
-  App.reset();
-  equal(App._readinessDeferrals, 1, 'App is in deferred state after setupForTesting.');
-});
-
-QUnit.test('Ember.Application#setupForTesting attaches ajax listeners', function() {
-  var documentEvents;
-
-  documentEvents = jQuery._data(document, 'events');
-
-  if (!documentEvents) {
-    documentEvents = {};
+  constructor() {
+    super();
+    this._originalAdapter = getAdapter();
   }
 
-  ok(documentEvents['ajaxSend'] === undefined, 'there are no ajaxSend listers setup prior to calling injectTestHelpers');
-  ok(documentEvents['ajaxComplete'] === undefined, 'there are no ajaxComplete listers setup prior to calling injectTestHelpers');
-
-  run(function() {
-    setupForTesting();
-  });
-
-  documentEvents = jQuery._data(document, 'events');
-
-  equal(documentEvents['ajaxSend'].length, 1, 'calling injectTestHelpers registers an ajaxSend handler');
-  equal(documentEvents['ajaxComplete'].length, 1, 'calling injectTestHelpers registers an ajaxComplete handler');
-});
-
-QUnit.test('Ember.Application#setupForTesting attaches ajax listeners only once', function() {
-  var documentEvents;
-
-  documentEvents = jQuery._data(document, 'events');
-
-  if (!documentEvents) {
-    documentEvents = {};
-  }
-
-  ok(documentEvents['ajaxSend'] === undefined, 'there are no ajaxSend listeners setup prior to calling injectTestHelpers');
-  ok(documentEvents['ajaxComplete'] === undefined, 'there are no ajaxComplete listeners setup prior to calling injectTestHelpers');
-
-  run(function() {
-    setupForTesting();
-  });
-  run(function() {
-    setupForTesting();
-  });
-
-  documentEvents = jQuery._data(document, 'events');
-
-  equal(documentEvents['ajaxSend'].length, 1, 'calling injectTestHelpers registers an ajaxSend handler');
-  equal(documentEvents['ajaxComplete'].length, 1, 'calling injectTestHelpers registers an ajaxComplete handler');
-});
-
-QUnit.test('Ember.Application#injectTestHelpers calls callbacks registered with onInjectHelpers', function() {
-  var injected = 0;
-
-  Test.onInjectHelpers(function() {
-    injected++;
-  });
-
-  run(function() {
-    App = EmberApplication.create();
-    App.setupForTesting();
-  });
-
-  equal(injected, 0, 'onInjectHelpers are not called before injectTestHelpers');
-
-  App.injectTestHelpers();
-
-  equal(injected, 1, 'onInjectHelpers are called after injectTestHelpers');
-});
-
-QUnit.test('Ember.Application#injectTestHelpers adds helpers to provided object.', function() {
-  var helpers = {};
-
-  run(function() {
-    App = EmberApplication.create();
-    App.setupForTesting();
-  });
-
-  App.injectTestHelpers(helpers);
-  assertHelpers(App, helpers);
-
-  App.removeTestHelpers();
-  assertNoHelpers(App, helpers);
-});
-
-QUnit.test('Ember.Application#removeTestHelpers resets the helperContainer\'s original values', function() {
-  var helpers = { visit: 'snazzleflabber' };
-
-  run(function() {
-    App = EmberApplication.create();
-    App.setupForTesting();
-  });
-
-  App.injectTestHelpers(helpers);
-
-  ok(helpers.visit !== 'snazzleflabber', 'helper added to container');
-  App.removeTestHelpers();
-
-  ok(helpers.visit === 'snazzleflabber', 'original value added back to container');
-});
-
-QUnit.module('ember-testing: Helper methods', {
-  setup() {
-    setupApp();
-  },
   teardown() {
-    cleanup();
+    setAdapter(this._originalAdapter);
+    jQuery(document).off('ajaxSend');
+    jQuery(document).off('ajaxComplete');
+    clearPendingRequests();
+    if (this.application) {
+      this.application.removeTestHelpers();
+    }
+    super.teardown();
   }
+
+}
+
+class HelpersApplicationTestCase extends HelpersTestCase {
+  constructor() {
+    super();
+    this.runTask(() => {
+      this.createApplication();
+      this.application.setupForTesting();
+      this.application.injectTestHelpers();
+    });
+  }
+}
+
+moduleFor('ember-testing: Helper setup', class extends HelpersTestCase {
+
+  [`@test Ember.Application#injectTestHelpers/#removeTestHelper`](assert) {
+    this.runTask(() => {
+      this.createApplication();
+    });
+
+    assertNoHelpers(assert, this.application);
+
+    registerHelper();
+
+    this.application.injectTestHelpers();
+
+    assertHelpers(assert, this.application);
+
+    assert.ok(
+      Test.Promise.prototype.LeakyMcLeakLeak,
+      'helper in question SHOULD be present'
+    );
+
+    this.application.removeTestHelpers();
+
+    assertNoHelpers(assert, this.application);
+
+    assert.equal(
+      Test.Promise.prototype.LeakyMcLeakLeak, undefined,
+      'should NOT leak test promise extensions'
+    );
+  }
+
+  [`@test Ember.Application#setupForTesting`](assert) {
+    this.runTask(() => {
+      this.createApplication();
+      this.application.setupForTesting();
+    });
+
+    let routerInstance = this.applicationInstance.lookup('router:main');
+    assert.equal(routerInstance.location, 'none');
+  }
+
+  [`@test Ember.Application.setupForTesting sets the application to 'testing'`](assert) {
+    this.runTask(() => {
+      this.createApplication();
+      this.application.setupForTesting();
+    });
+
+    assert.equal(
+      this.application.testing, true,
+      'Application instance is set to testing.'
+    );
+  }
+
+  [`@test Ember.Application.setupForTesting leaves the system in a deferred state.`](assert) {
+    this.runTask(() => {
+      this.createApplication();
+      this.application.setupForTesting();
+    });
+
+    assert.equal(
+      this.application._readinessDeferrals, 1,
+      'App is in deferred state after setupForTesting.'
+    );
+  }
+
+  [`@test App.reset() after Application.setupForTesting leaves the system in a deferred state.`](assert) {
+    this.runTask(() => {
+      this.createApplication();
+      this.application.setupForTesting();
+    });
+
+    assert.equal(
+      this.application._readinessDeferrals, 1,
+      'App is in deferred state after setupForTesting.'
+    );
+
+    this.application.reset();
+
+    assert.equal(
+      this.application._readinessDeferrals, 1,
+      'App is in deferred state after setupForTesting.'
+    );
+  }
+
+  [`@test #setupForTesting attaches ajax listeners`](assert) {
+    let documentEvents = jQuery._data(document, 'events') || {};
+
+    assert.ok(
+      documentEvents['ajaxSend'] === undefined,
+      'there are no ajaxSend listers setup prior to calling injectTestHelpers'
+    );
+    assert.ok(
+      documentEvents['ajaxComplete'] === undefined,
+      'there are no ajaxComplete listers setup prior to calling injectTestHelpers'
+    );
+
+    setupForTesting();
+
+    documentEvents = jQuery._data(document, 'events');
+
+    assert.equal(
+      documentEvents['ajaxSend'].length, 1,
+      'calling injectTestHelpers registers an ajaxSend handler'
+    );
+    assert.equal(
+      documentEvents['ajaxComplete'].length, 1,
+      'calling injectTestHelpers registers an ajaxComplete handler'
+    );
+  }
+
+  [`@test #setupForTesting attaches ajax listeners only once`](assert) {
+    let documentEvents = jQuery._data(document, 'events') || {};
+
+    assert.ok(
+      documentEvents['ajaxSend'] === undefined,
+      'there are no ajaxSend listeners setup prior to calling injectTestHelpers'
+    );
+    assert.ok(
+      documentEvents['ajaxComplete'] === undefined,
+      'there are no ajaxComplete listeners setup prior to calling injectTestHelpers'
+    );
+
+    setupForTesting();
+    setupForTesting();
+
+    documentEvents = jQuery._data(document, 'events');
+
+    assert.equal(
+      documentEvents['ajaxSend'].length, 1,
+      'calling injectTestHelpers registers an ajaxSend handler'
+    );
+    assert.equal(
+      documentEvents['ajaxComplete'].length, 1,
+      'calling injectTestHelpers registers an ajaxComplete handler'
+    );
+  }
+
+  [`@test Ember.Application#injectTestHelpers calls callbacks registered with onInjectHelpers`](assert) {
+    let injected = 0;
+
+    Test.onInjectHelpers(() => {
+      injected++;
+    });
+
+    this.runTask(() => {
+      this.createApplication();
+      this.application.setupForTesting();
+    });
+
+    assert.equal(
+      injected, 0,
+      'onInjectHelpers are not called before injectTestHelpers'
+    );
+
+    this.application.injectTestHelpers();
+
+    assert.equal(
+      injected, 1,
+      'onInjectHelpers are called after injectTestHelpers'
+    );
+  }
+
+  [`@test Ember.Application#injectTestHelpers adds helpers to provided object.`](assert) {
+    let helpers = {};
+
+    this.runTask(() => {
+      this.createApplication();
+      this.application.setupForTesting();
+    });
+
+    this.application.injectTestHelpers(helpers);
+
+    assertHelpers(assert, this.application, helpers);
+
+    this.application.removeTestHelpers();
+
+    assertNoHelpers(assert, this.application, helpers);
+  }
+
+  [`@test Ember.Application#removeTestHelpers resets the helperContainer\'s original values`](assert) {
+    let helpers = { visit: 'snazzleflabber' };
+
+    this.runTask(() => {
+      this.createApplication();
+      this.application.setupForTesting();
+    });
+
+    this.application.injectTestHelpers(helpers);
+
+    assert.notEqual(
+      helpers.visit, 'snazzleflabber',
+      'helper added to container'
+    );
+    this.application.removeTestHelpers();
+
+    assert.equal(
+      helpers.visit, 'snazzleflabber',
+      'original value added back to container'
+    );
+  }
+
 });
 
-QUnit.test('`wait` respects registerWaiters', function(assert) {
-  assert.expect(3);
+moduleFor('ember-testing: Helper methods', class extends HelpersApplicationTestCase {
 
-  let done = assert.async();
+  [`@test 'wait' respects registerWaiters`](assert) {
+    assert.expect(3);
 
-  let counter = 0;
-  function waiter() {
-    return ++counter > 2;
-  }
+    let counter = 0;
+    function waiter() {
+      return ++counter > 2;
+    }
 
-  let other = 0;
-  function otherWaiter() {
-    return ++other > 2;
-  }
+    let other = 0;
+    function otherWaiter() {
+      return ++other > 2;
+    }
 
-  run(App, App.advanceReadiness);
-  registerWaiter(waiter);
-  registerWaiter(otherWaiter);
+    this.runTask(() => {
+      this.application.advanceReadiness();
+    });
 
-  App.testHelpers.wait()
-    .then(function() {
-      equal(waiter(), true, 'should not resolve until our waiter is ready');
+    registerWaiter(waiter);
+    registerWaiter(otherWaiter);
+
+    let {application: {testHelpers}} = this;
+    return testHelpers.wait().then(() => {
+      assert.equal(
+        waiter(), true,
+        'should not resolve until our waiter is ready'
+      );
       unregisterWaiter(waiter);
       counter = 0;
-      return App.testHelpers.wait();
-    })
-    .then(function() {
-      equal(counter, 0, 'unregistered waiter was not checked');
-      equal(otherWaiter(), true, 'other waiter is still registered');
-    })
-    .finally(() => {
+      return testHelpers.wait();
+    }).then(() => {
+      assert.equal(
+        counter, 0,
+        'unregistered waiter was not checked'
+      );
+      assert.equal(
+        otherWaiter(), true,
+        'other waiter is still registered'
+      );
+    }).finally(() => {
       unregisterWaiter(otherWaiter);
-      done();
     });
-});
-
-QUnit.test('`visit` advances readiness.', function() {
-  expect(2);
-
-  equal(App._readinessDeferrals, 1, 'App is in deferred state after setupForTesting.');
-
-  return App.testHelpers.visit('/').then(function() {
-    equal(App._readinessDeferrals, 0, 'App\'s readiness was advanced by visit.');
-  });
-});
-
-QUnit.test('`wait` helper can be passed a resolution value', function() {
-  expect(4);
-
-  var promise, wait;
-
-  promise = new RSVP.Promise(function(resolve) {
-    run(null, resolve, 'promise');
-  });
-
-  run(App, App.advanceReadiness);
-
-  wait = App.testHelpers.wait;
-
-  return wait('text').then(function(val) {
-    equal(val, 'text', 'can resolve to a string');
-    return wait(1);
-  }).then(function(val) {
-    equal(val, 1, 'can resolve to an integer');
-    return wait({ age: 10 });
-  }).then(function(val) {
-    deepEqual(val, { age: 10 }, 'can resolve to an object');
-    return wait(promise);
-  }).then(function(val) {
-    equal(val, 'promise', 'can resolve to a promise resolution value');
-  });
-});
-
-QUnit.test('`click` triggers appropriate events in order', function() {
-  expect(5);
-
-  var click, wait, events;
-
-  App.IndexWrapperComponent = Component.extend({
-    classNames: 'index-wrapper',
-
-    didInsertElement() {
-      this.$().on('mousedown focusin mouseup click', function(e) {
-        events.push(e.type);
-      });
-    }
-  });
-
-  App.XCheckboxComponent = Component.extend({
-    tagName: 'input',
-    attributeBindings: ['type'],
-    type: 'checkbox',
-    click() {
-      events.push('click:' + this.get('checked'));
-    },
-    change() {
-      events.push('change:' + this.get('checked'));
-    }
-  });
-
-  setTemplate('index', compile('{{#index-wrapper}}{{input type="text"}} {{x-checkbox type="checkbox"}} {{textarea}} <div contenteditable="true"> </div>{{/index-wrapper}}'));
-
-  run(App, App.advanceReadiness);
-
-  click = App.testHelpers.click;
-  wait  = App.testHelpers.wait;
-
-  return wait().then(function() {
-    events = [];
-    return click('.index-wrapper');
-  }).then(function() {
-    deepEqual(events,
-      ['mousedown', 'mouseup', 'click'],
-      'fires events in order');
-  }).then(function() {
-    events = [];
-    return click('.index-wrapper input[type=text]');
-  }).then(function() {
-    deepEqual(events,
-      ['mousedown', 'focusin', 'mouseup', 'click'],
-      'fires focus events on inputs');
-  }).then(function() {
-    events = [];
-    return click('.index-wrapper textarea');
-  }).then(function() {
-    deepEqual(events,
-      ['mousedown', 'focusin', 'mouseup', 'click'],
-      'fires focus events on textareas');
-  }).then(function() {
-    events = [];
-    return click('.index-wrapper div');
-  }).then(function() {
-    deepEqual(events,
-      ['mousedown', 'focusin', 'mouseup', 'click'],
-      'fires focus events on contenteditable');
-  }).then(function() {
-    events = [];
-    return click('.index-wrapper input[type=checkbox]');
-  }).then(function() {
-    // i.e. mousedown, mouseup, change:true, click, click:true
-    // Firefox differs so we can't assert the exact ordering here.
-    // See https://bugzilla.mozilla.org/show_bug.cgi?id=843554.
-    equal(events.length, 5, 'fires click and change on checkboxes');
-  });
-});
-
-QUnit.test('`click` triggers native events with simulated X/Y coordinates', function() {
-  expect(15);
-
-  var click, wait, events;
-
-  App.IndexWrapperComponent = Component.extend({
-    classNames: 'index-wrapper',
-
-    didInsertElement() {
-      let pushEvent  = e => events.push(e);
-      this.element.addEventListener('mousedown', pushEvent);
-      this.element.addEventListener('mouseup', pushEvent);
-      this.element.addEventListener('click', pushEvent);
-    }
-  });
-
-
-  setTemplate('index', compile('{{#index-wrapper}}some text{{/index-wrapper}}'));
-
-  run(App, App.advanceReadiness);
-
-  click = App.testHelpers.click;
-  wait  = App.testHelpers.wait;
-
-  return wait().then(function() {
-    events = [];
-    return click('.index-wrapper');
-  }).then(function() {
-    events.forEach(e => {
-      ok(e instanceof window.Event, 'The event is an instance of MouseEvent');
-      ok(typeof e.screenX === 'number' && e.screenX > 0, 'screenX is correct');
-      ok(typeof e.screenY === 'number' && e.screenY > 0, 'screenY is correct');
-      ok(typeof e.clientX === 'number' && e.clientX > 0, 'clientX is correct');
-      ok(typeof e.clientY === 'number' && e.clientY > 0, 'clientY is correct');
-    });
-  });
-});
-
-QUnit.test('`triggerEvent` with mouseenter triggers native events with simulated X/Y coordinates', function() {
-  expect(5);
-
-  var triggerEvent, wait, evt;
-
-  App.IndexWrapperComponent = Component.extend({
-    classNames: 'index-wrapper',
-
-    didInsertElement() {
-      this.element.addEventListener('mouseenter', e => evt = e);
-    }
-  });
-
-
-  setTemplate('index', compile('{{#index-wrapper}}some text{{/index-wrapper}}'));
-
-  run(App, App.advanceReadiness);
-
-  triggerEvent = App.testHelpers.triggerEvent;
-  wait  = App.testHelpers.wait;
-
-  return wait().then(function() {
-    return triggerEvent('.index-wrapper', 'mouseenter');
-  }).then(function() {
-    ok(evt instanceof window.Event, 'The event is an instance of MouseEvent');
-    ok(typeof evt.screenX === 'number' && evt.screenX > 0, 'screenX is correct');
-    ok(typeof evt.screenY === 'number' && evt.screenY > 0, 'screenY is correct');
-    ok(typeof evt.clientX === 'number' && evt.clientX > 0, 'clientX is correct');
-    ok(typeof evt.clientY === 'number' && evt.clientY > 0, 'clientY is correct');
-  });
-});
-
-QUnit.test('`wait` waits for outstanding timers', function() {
-  expect(1);
-
-  var wait_done = false;
-
-  run(App, App.advanceReadiness);
-
-  run.later(this, function() {
-    wait_done = true;
-  }, 500);
-
-  return App.testHelpers.wait().then(function() {
-    equal(wait_done, true, 'should wait for the timer to be fired.');
-  });
-});
-
-QUnit.test('`wait` respects registerWaiters with optional context', function() {
-  expect(3);
-
-  let obj = {
-    counter: 0,
-    ready() {
-      return ++this.counter > 2;
-    }
-  };
-
-  let other = 0;
-  function otherWaiter() {
-    return ++other > 2;
   }
 
-  run(App, App.advanceReadiness);
-  registerWaiter(obj, obj.ready);
-  registerWaiter(otherWaiter);
+  [`@test 'visit' advances readiness.`](assert) {
+    assert.expect(2);
 
-  return App.testHelpers.wait().then(function() {
-    equal(obj.ready(), true, 'should not resolve until our waiter is ready');
-    unregisterWaiter(obj, obj.ready);
-    obj.counter = 0;
-    return App.testHelpers.wait();
-  }).then(function() {
-    equal(obj.counter, 0, 'the unregistered waiter should still be at 0');
-    equal(otherWaiter(), true, 'other waiter should still be registered');
-  })
-    .finally(() => {
-      unregisterWaiter(otherWaiter);
+    assert.equal(
+      this.application._readinessDeferrals, 1,
+      'App is in deferred state after setupForTesting.'
+    );
+
+    return this.application.testHelpers.visit('/').then(() => {
+      assert.equal(
+        this.application._readinessDeferrals, 0,
+        `App's readiness was advanced by visit.`
+      );
     });
-});
+  }
 
-QUnit.test('`wait` does not error if routing has not begun', function() {
-  expect(1);
+  [`@test 'wait' helper can be passed a resolution value`](assert) {
+    assert.expect(4);
 
-  return App.testHelpers.wait().then(function() {
-    ok(true, 'should not error without `visit`');
-  });
-});
+    this.runTask(() => {
+      this.application.advanceReadiness();
+    });
 
-QUnit.test('`triggerEvent accepts an optional options hash without context', function() {
-  expect(3);
+    let promiseObjectValue = {};
+    let objectValue = {};
+    let {application: {testHelpers}} = this;
+    return testHelpers.wait('text').then(val => {
+      assert.equal(
+        val, 'text',
+        'can resolve to a string'
+      );
+      return testHelpers.wait(1);
+    }).then(val => {
+      assert.equal(
+        val, 1,
+        'can resolve to an integer'
+      );
+      return testHelpers.wait(objectValue);
+    }).then(val => {
+      assert.equal(
+        val, objectValue,
+        'can resolve to an object'
+      );
+      return testHelpers.wait(RSVP.resolve(promiseObjectValue));
+    }).then(val => {
+      assert.equal(
+        val, promiseObjectValue,
+        'can resolve to a promise resolution value'
+      );
+    });
+  }
 
-  var triggerEvent, wait, event;
+  [`@test 'click' triggers appropriate events in order`](assert) {
+    assert.expect(5);
 
-  App.IndexWrapperComponent = Component.extend({
-    didInsertElement() {
-      this.$('.input').on('keydown change', function(e) {
-        event = e;
-      });
-    }
-  });
+    this.add('component:index-wrapper', Component.extend({
+      classNames: 'index-wrapper',
 
-  setTemplate('index', compile('{{index-wrapper}}'));
-  setTemplate('components/index-wrapper', compile('{{input type="text" id="scope" class="input"}}'));
-
-  run(App, App.advanceReadiness);
-
-  triggerEvent = App.testHelpers.triggerEvent;
-  wait         = App.testHelpers.wait;
-
-  return wait().then(function() {
-    return triggerEvent('.input', 'keydown', { keyCode: 13 });
-  }).then(function() {
-    equal(event.keyCode, 13, 'options were passed');
-    equal(event.type, 'keydown', 'correct event was triggered');
-    equal(event.target.getAttribute('id'), 'scope', 'triggered on the correct element');
-  });
-});
-
-QUnit.test('`triggerEvent can limit searching for a selector to a scope', function() {
-  expect(2);
-
-  var triggerEvent, wait, event;
-
-  App.IndexWrapperComponent = Component.extend({
-
-    didInsertElement() {
-      this.$('.input').on('blur change', function(e) {
-        event = e;
-      });
-    }
-  });
-
-  setTemplate('components/index-wrapper', compile('{{input type="text" id="outside-scope" class="input"}}<div id="limited">{{input type="text" id="inside-scope" class="input"}}</div>'));
-  setTemplate('index', compile('{{index-wrapper}}'));
-
-  run(App, App.advanceReadiness);
-
-  triggerEvent = App.testHelpers.triggerEvent;
-  wait         = App.testHelpers.wait;
-
-  return wait().then(function() {
-    return triggerEvent('.input', '#limited', 'blur');
-  }).then(function() {
-    equal(event.type, 'blur', 'correct event was triggered');
-    equal(event.target.getAttribute('id'), 'inside-scope', 'triggered on the correct element');
-  });
-});
-
-QUnit.test('`triggerEvent` can be used to trigger arbitrary events', function() {
-  expect(2);
-
-  var triggerEvent, wait, event;
-
-  App.IndexWrapperComponent = Component.extend({
-    didInsertElement() {
-      this.$('#foo').on('blur change', function(e) {
-        event = e;
-      });
-    }
-  });
-
-  setTemplate('components/index-wrapper',  compile('{{input type="text" id="foo"}}'));
-  setTemplate('index', compile('{{index-wrapper}}'));
-
-  run(App, App.advanceReadiness);
-
-  triggerEvent = App.testHelpers.triggerEvent;
-  wait         = App.testHelpers.wait;
-
-  return wait().then(function() {
-    return triggerEvent('#foo', 'blur');
-  }).then(function() {
-    equal(event.type, 'blur', 'correct event was triggered');
-    equal(event.target.getAttribute('id'), 'foo', 'triggered on the correct element');
-  });
-});
-
-QUnit.test('`fillIn` takes context into consideration', function() {
-  expect(2);
-  var fillIn, find, visit, andThen;
-
-  setTemplate('index', compile('<div id="parent">{{input type="text" id="first" class="current"}}</div>{{input type="text" id="second" class="current"}}'));
-
-  run(App, App.advanceReadiness);
-
-  fillIn = App.testHelpers.fillIn;
-  find = App.testHelpers.find;
-  visit = App.testHelpers.visit;
-  andThen = App.testHelpers.andThen;
-
-  visit('/');
-  fillIn('.current', '#parent', 'current value');
-
-  return andThen(function() {
-    equal(find('#first').val(), 'current value');
-    equal(find('#second').val(), '');
-  });
-});
-
-QUnit.test('`fillIn` focuses on the element', function() {
-  expect(2);
-  var fillIn, find, visit, andThen, wait;
-
-  App.ApplicationRoute = Route.extend({
-    actions: {
-      wasFocused() {
-        ok(true, 'focusIn event was triggered');
+      didInsertElement() {
+        this.$().on('mousedown focusin mouseup click', e => {
+          events.push(e.type);
+        });
       }
-    }
-  });
+    }));
 
-  setTemplate('index', compile('<div id="parent">{{input type="text" id="first" focus-in="wasFocused"}}</div>'));
-
-  run(App, App.advanceReadiness);
-
-  fillIn = App.testHelpers.fillIn;
-  find = App.testHelpers.find;
-  visit = App.testHelpers.visit;
-  andThen = App.testHelpers.andThen;
-  wait = App.testHelpers.wait;
-
-  visit('/');
-  fillIn('#first', 'current value');
-  andThen(function() {
-    equal(find('#first').val(), 'current value');
-  });
-
-  return wait();
-});
-
-QUnit.test('`fillIn` fires `input` and `change` events in the proper order', function() {
-  expect(1);
-
-  var fillIn, visit, andThen, wait;
-  var events = [];
-  App.IndexController = Controller.extend({
-    actions: {
-      oninputHandler(e) {
-        events.push(e.type);
+    this.add('component:x-checkbox', Component.extend({
+      tagName: 'input',
+      attributeBindings: ['type'],
+      type: 'checkbox',
+      click() {
+        events.push('click:' + this.get('checked'));
       },
-      onchangeHandler(e) {
-        events.push(e.type);
+      change() {
+        events.push('change:' + this.get('checked'));
       }
-    }
-  });
+    }));
 
-  setTemplate('index', compile('<input type="text" id="first" oninput={{action "oninputHandler"}} onchange={{action "onchangeHandler"}}>'));
+    this.addTemplate('index', `
+      {{#index-wrapper}}
+        {{input type="text"}}
+        {{x-checkbox type="checkbox"}}
+        {{textarea}}
+        <div contenteditable="true"> </div>
+      {{/index-wrapper}}'));
+    `);
 
-  run(App, App.advanceReadiness);
+    this.runTask(() => {
+      this.application.advanceReadiness();
+    });
 
-  fillIn = App.testHelpers.fillIn;
-  visit = App.testHelpers.visit;
-  andThen = App.testHelpers.andThen;
-  wait = App.testHelpers.wait;
+    let events;
+    let {application: {testHelpers}} = this;
+    return testHelpers.wait().then(() => {
+      events = [];
+      return testHelpers.click('.index-wrapper');
+    }).then(() => {
+      assert.deepEqual(
+        events, ['mousedown', 'mouseup', 'click'],
+        'fires events in order'
+      );
+    }).then(() => {
+      events = [];
+      return testHelpers.click('.index-wrapper input[type=text]');
+    }).then(() => {
+      assert.deepEqual(
+        events, ['mousedown', 'focusin', 'mouseup', 'click'],
+        'fires focus events on inputs'
+      );
+    }).then(() => {
+      events = [];
+      return testHelpers.click('.index-wrapper textarea');
+    }).then(() => {
+      assert.deepEqual(
+        events, ['mousedown', 'focusin', 'mouseup', 'click'],
+        'fires focus events on textareas'
+      );
+    }).then(() => {
+      events = [];
+      return testHelpers.click('.index-wrapper div');
+    }).then(() => {
+      assert.deepEqual(
+        events, ['mousedown', 'focusin', 'mouseup', 'click'],
+        'fires focus events on contenteditable'
+      );
+    }).then(() => {
+      events = [];
+      return testHelpers.click('.index-wrapper input[type=checkbox]');
+    }).then(() => {
+      // i.e. mousedown, mouseup, change:true, click, click:true
+      // Firefox differs so we can't assert the exact ordering here.
+      // See https://bugzilla.mozilla.org/show_bug.cgi?id=843554.
+      assert.equal(
+        events.length, 5,
+        'fires click and change on checkboxes'
+      );
+    });
+  }
 
-  visit('/');
-  fillIn('#first', 'current value');
-  andThen(function() {
-    deepEqual(events, ['input', 'change'], '`input` and `change` events are fired in the proper order');
-  });
+  [`@test 'click' triggers native events with simulated X/Y coordinates`](assert) {
+    assert.expect(15);
 
-  return wait();
-});
+    this.add('component:index-wrapper', Component.extend({
+      classNames: 'index-wrapper',
 
-QUnit.test('`fillIn` only sets the value in the first matched element', function() {
-  let fillIn, find, visit, andThen, wait;
+      didInsertElement() {
+        let pushEvent  = e => events.push(e);
+        this.element.addEventListener('mousedown', pushEvent);
+        this.element.addEventListener('mouseup', pushEvent);
+        this.element.addEventListener('click', pushEvent);
+      }
+    }));
 
-  setTemplate('index', compile('<input type="text" id="first" class="in-test"><input type="text" id="second" class="in-test">'));
-  run(App, App.advanceReadiness);
+    this.addTemplate('index', `
+      {{#index-wrapper}}some text{{/index-wrapper}}
+    `);
 
-  fillIn = App.testHelpers.fillIn;
-  find = App.testHelpers.find;
-  visit = App.testHelpers.visit;
-  andThen = App.testHelpers.andThen;
-  wait = App.testHelpers.wait;
+    this.runTask(() => {
+      this.application.advanceReadiness();
+    });
 
-  visit('/');
-  fillIn('input.in-test', 'new value');
-  andThen(function() {
-    equal(find('#first').val(), 'new value');
-    equal(find('#second').val(), '');
-  });
-
-  return wait();
-});
-
-QUnit.test('`triggerEvent accepts an optional options hash and context', function() {
-  expect(3);
-
-  var triggerEvent, wait, event;
-
-  App.IndexWrapperComponent = Component.extend({
-    didInsertElement() {
-      this.$('.input').on('keydown change', function(e) {
-        event = e;
+    let events;
+    let {application: {testHelpers: {wait, click}}} = this;
+    return wait().then(() => {
+      events = [];
+      return click('.index-wrapper');
+    }).then(() => {
+      events.forEach(e => {
+        assert.ok(
+          e instanceof window.Event,
+          'The event is an instance of MouseEvent'
+        );
+        assert.ok(
+          typeof e.screenX === 'number',
+          'screenX is correct'
+        );
+        assert.ok(
+          typeof e.screenY === 'number',
+          'screenY is correct'
+        );
+        assert.ok(
+          typeof e.clientX === 'number',
+          'clientX is correct'
+        );
+        assert.ok(
+          typeof e.clientY === 'number',
+          'clientY is correct'
+        );
       });
+    });
+  }
+
+  [`@test 'triggerEvent' with mouseenter triggers native events with simulated X/Y coordinates`](assert) {
+    assert.expect(5);
+
+    let evt;
+    this.add('component:index-wrapper', Component.extend({
+      classNames: 'index-wrapper',
+      didInsertElement() {
+        this.element.addEventListener('mouseenter', e => evt = e);
+      }
+    }));
+
+    this.addTemplate('index', `{{#index-wrapper}}some text{{/index-wrapper}}`);
+
+    this.runTask(() => {
+      this.application.advanceReadiness();
+    });
+
+    let {application: {testHelpers: {wait, triggerEvent}}} = this;
+    return wait().then(() => {
+      return triggerEvent('.index-wrapper', 'mouseenter');
+    }).then(() => {
+      assert.ok(
+        evt instanceof window.Event,
+        'The event is an instance of MouseEvent'
+      );
+      assert.ok(
+        typeof evt.screenX === 'number',
+        'screenX is correct'
+      );
+      assert.ok(
+        typeof evt.screenY === 'number',
+        'screenY is correct'
+      );
+      assert.ok(
+        typeof evt.clientX === 'number',
+        'clientX is correct'
+      );
+      assert.ok(
+        typeof evt.clientY === 'number',
+        'clientY is correct'
+      );
+    });
+  }
+
+  [`@test 'wait' waits for outstanding timers`](assert) {
+    assert.expect(1);
+
+    this.runTask(() => {
+      this.application.advanceReadiness();
+    });
+
+    let waitDone = false;
+    run.later(() => {
+      waitDone = true;
+    }, 20);
+
+    return this.application.testHelpers.wait().then(() => {
+      assert.equal(waitDone, true, 'should wait for the timer to be fired.');
+    });
+  }
+
+  [`@test 'wait' respects registerWaiters with optional context`](assert) {
+    assert.expect(3);
+
+    let obj = {
+      counter: 0,
+      ready() {
+        return ++this.counter > 2;
+      }
+    };
+
+    let other = 0;
+    function otherWaiter() {
+      return ++other > 2;
     }
-  });
 
-  setTemplate('components/index-wrapper', compile('{{input type="text" id="outside-scope" class="input"}}<div id="limited">{{input type="text" id="inside-scope" class="input"}}</div>'));
-  setTemplate('index', compile('{{index-wrapper}}'));
+    this.runTask(() => {
+      this.application.advanceReadiness();
+    });
 
-  run(App, App.advanceReadiness);
+    registerWaiter(obj, obj.ready);
+    registerWaiter(otherWaiter);
 
-  triggerEvent = App.testHelpers.triggerEvent;
-  wait         = App.testHelpers.wait;
+    let {application: {testHelpers: {wait}}} = this;
+    return wait().then(() => {
+      assert.equal(
+        obj.ready(), true,
+        'should not resolve until our waiter is ready'
+      );
+      unregisterWaiter(obj, obj.ready);
+      obj.counter = 0;
+      return wait();
+    }).then(() => {
+      assert.equal(
+        obj.counter, 0,
+        'the unregistered waiter should still be at 0'
+      );
+      assert.equal(
+        otherWaiter(), true,
+        'other waiter should still be registered'
+      );
+    }).finally(() => {
+      unregisterWaiter(otherWaiter);
+    });
+  }
 
-  return wait()
-    .then(function() {
+  [`@test 'wait' does not error if routing has not begun`](assert) {
+    assert.expect(1);
+
+    return this.application.testHelpers.wait().then(() => {
+      ok(true, 'should not error without `visit`');
+    });
+  }
+
+  [`@test 'triggerEvent' accepts an optional options hash without context`](assert) {
+    assert.expect(3);
+
+    let event;
+    this.add('component:index-wrapper', Component.extend({
+      didInsertElement() {
+        this.$('.input').on('keydown change', e => event = e);
+      }
+    }));
+
+    this.addTemplate('index', `{{index-wrapper}}`);
+    this.addTemplate('components/index-wrapper', `
+      {{input type="text" id="scope" class="input"}}
+    `);
+
+    this.runTask(() => {
+      this.application.advanceReadiness();
+    });
+
+    let {application: {testHelpers: {wait, triggerEvent}}} = this;
+    return wait().then(() => {
+      return triggerEvent('.input', 'keydown', { keyCode: 13 });
+    }).then(() => {
+      assert.equal(event.keyCode, 13, 'options were passed');
+      assert.equal(event.type, 'keydown', 'correct event was triggered');
+      assert.equal(event.target.getAttribute('id'), 'scope', 'triggered on the correct element');
+    });
+  }
+
+  [`@test 'triggerEvent' can limit searching for a selector to a scope`](assert) {
+    assert.expect(2);
+
+    let event;
+    this.add('component:index-wrapper', Component.extend({
+      didInsertElement() {
+        this.$('.input').on('blur change', e => event = e);
+      }
+    }));
+
+    this.addTemplate('components/index-wrapper', `
+      {{input type="text" id="outside-scope" class="input"}}
+      <div id="limited">
+        {{input type="text" id="inside-scope" class="input"}}
+      </div>
+    `);
+    this.addTemplate('index', `{{index-wrapper}}`);
+
+    this.runTask(() => {
+      this.application.advanceReadiness();
+    });
+
+    let {application: {testHelpers: {wait, triggerEvent}}} = this;
+    return wait().then(() => {
+      return triggerEvent('.input', '#limited', 'blur');
+    }).then(() => {
+      assert.equal(
+        event.type, 'blur',
+        'correct event was triggered'
+      );
+      assert.equal(
+        event.target.getAttribute('id'), 'inside-scope',
+        'triggered on the correct element'
+      );
+    });
+  }
+
+  [`@test 'triggerEvent' can be used to trigger arbitrary events`](assert) {
+    assert.expect(2);
+
+    let event;
+    this.add('component:index-wrapper', Component.extend({
+      didInsertElement() {
+        this.$('#foo').on('blur change', e => event = e);
+      }
+    }));
+
+    this.addTemplate('components/index-wrapper', `
+      {{input type="text" id="foo"}}
+    `);
+    this.addTemplate('index', `{{index-wrapper}}`);
+
+    this.runTask(() => {
+      this.application.advanceReadiness();
+    });
+
+    let {application: {testHelpers: {wait, triggerEvent}}} = this;
+    return wait().then(() => {
+      return triggerEvent('#foo', 'blur');
+    }).then(() => {
+      assert.equal(
+        event.type, 'blur',
+        'correct event was triggered'
+      );
+      assert.equal(
+        event.target.getAttribute('id'), 'foo',
+        'triggered on the correct element'
+      );
+    });
+  }
+
+  [`@test 'fillIn' takes context into consideration`](assert) {
+    assert.expect(2);
+
+    this.addTemplate('index', `
+      <div id="parent">
+        {{input type="text" id="first" class="current"}}
+      </div>
+      {{input type="text" id="second" class="current"}}
+    `);
+
+    this.runTask(() => {
+      this.application.advanceReadiness();
+    });
+
+    let {application: {testHelpers: {visit, fillIn, andThen, find}}} = this;
+    visit('/');
+    fillIn('.current', '#parent', 'current value');
+
+    return andThen(() => {
+      assert.equal(find('#first').val(), 'current value');
+      assert.equal(find('#second').val(), '');
+    });
+  }
+
+  [`@test 'fillIn' focuses on the element`](assert) {
+    assert.expect(2);
+
+    this.add('route:application', Route.extend({
+      actions: {
+        wasFocused() {
+          assert.ok(true, 'focusIn event was triggered');
+        }
+      }
+    }));
+
+    this.addTemplate('index', `
+      <div id="parent">
+        {{input type="text" id="first" focus-in="wasFocused"}}
+      </div>'
+    `);
+
+    this.runTask(() => {
+      this.application.advanceReadiness();
+    });
+
+    let {application: {testHelpers: {visit, fillIn, andThen, find, wait}}} = this;
+    visit('/');
+    fillIn('#first', 'current value');
+    andThen(() => {
+      assert.equal(
+        find('#first').val(),'current value'
+      );
+    });
+
+    return wait();
+  }
+
+  [`@test 'fillIn' fires 'input' and 'change' events in the proper order`](assert) {
+    assert.expect(1);
+
+    let events = [];
+    this.add('controller:index', Controller.extend({
+      actions: {
+        oninputHandler(e) {
+          events.push(e.type);
+        },
+        onchangeHandler(e) {
+          events.push(e.type);
+        }
+      }
+    }));
+
+    this.addTemplate('index', `
+      <input type="text" id="first"
+          oninput={{action "oninputHandler"}}
+          onchange={{action "onchangeHandler"}}>
+    `);
+
+    this.runTask(() => {
+      this.application.advanceReadiness();
+    });
+
+    let {application: {testHelpers: {visit, fillIn, andThen, wait}}} = this;
+
+    visit('/');
+    fillIn('#first', 'current value');
+    andThen(() => {
+      assert.deepEqual(events, ['input', 'change'], '`input` and `change` events are fired in the proper order');
+    });
+
+    return wait();
+  }
+
+  [`@test 'fillIn' only sets the value in the first matched element`](assert) {
+    this.addTemplate('index', `
+      <input type="text" id="first" class="in-test">
+      <input type="text" id="second" class="in-test">
+    `);
+
+    this.runTask(() => {
+      this.application.advanceReadiness();
+    });
+
+    let {application: {testHelpers: {visit, fillIn, find, andThen, wait}}} = this;
+
+    visit('/');
+    fillIn('input.in-test', 'new value');
+    andThen(() => {
+      assert.equal(
+        find('#first').val(), 'new value'
+      );
+      assert.equal(
+        find('#second').val(), ''
+      );
+    });
+
+    return wait();
+  }
+
+  [`@test 'triggerEvent' accepts an optional options hash and context`](assert) {
+    assert.expect(3);
+
+    let event;
+    this.add('component:index-wrapper', Component.extend({
+      didInsertElement() {
+        this.$('.input').on('keydown change', e => event = e);
+      }
+    }));
+
+    this.addTemplate('components/index-wrapper', `
+      {{input type="text" id="outside-scope" class="input"}}
+      <div id="limited">
+        {{input type="text" id="inside-scope" class="input"}}
+      </div>
+    `);
+    this.addTemplate('index', `{{index-wrapper}}`);
+
+    this.runTask(() => {
+      this.application.advanceReadiness();
+    });
+
+    let {application: {testHelpers: {wait, triggerEvent}}} = this;
+    return wait().then(() => {
       return triggerEvent('.input', '#limited', 'keydown', { keyCode: 13 });
-    })
-    .then(function() {
-      equal(event.keyCode, 13, 'options were passed');
-      equal(event.type, 'keydown', 'correct event was triggered');
-      equal(event.target.getAttribute('id'), 'inside-scope', 'triggered on the correct element');
+    }).then(() => {
+      assert.equal(event.keyCode, 13, 'options were passed');
+      assert.equal(event.type, 'keydown', 'correct event was triggered');
+      assert.equal(event.target.getAttribute('id'), 'inside-scope', 'triggered on the correct element');
     });
-});
-
-
-QUnit.module('ember-testing debugging helpers', {
-  setup() {
-    setupApp();
-
-    run(function() {
-      App.Router = Router.extend({
-        location: 'none'
-      });
-    });
-
-    run(App, 'advanceReadiness');
-  },
-
-  teardown() {
-    cleanup();
-  }
-});
-
-QUnit.test('pauseTest pauses', function() {
-  expect(1);
-
-  function fakeAdapterAsyncStart() {
-    ok(true, 'Async start should be called after waiting for other helpers');
   }
 
-  App.testHelpers.andThen(() => {
-    Test.adapter.asyncStart = fakeAdapterAsyncStart;
-  });
-
-  App.testHelpers.pauseTest();
 });
 
-QUnit.test('resumeTest resumes paused tests', function() {
-  expect(1);
+moduleFor('ember-testing: debugging helpers', class extends HelpersApplicationTestCase {
 
-  let pausePromise = App.testHelpers.pauseTest();
-  setTimeout(() => App.testHelpers.resumeTest(), 0);
+  constructor() {
+    super();
+    this.runTask(() => {
+      this.application.advanceReadiness();
+    });
+  }
 
-  return pausePromise.then(() => ok(true, 'pauseTest promise was resolved'));
+  [`@test pauseTest pauses`](assert) {
+    assert.expect(1);
+
+    let {application: {testHelpers: {andThen, pauseTest}}} = this;
+    andThen(() => {
+      Test.adapter.asyncStart = () => {
+        assert.ok(
+          true,
+          'Async start should be called after waiting for other helpers'
+        );
+      };
+    });
+
+    pauseTest();
+  }
+
+  [`@test resumeTest resumes paused tests`](assert) {
+    assert.expect(1);
+
+    let {application: {testHelpers: {pauseTest, resumeTest}}} = this;
+
+    run.later(() => resumeTest(), 20);
+    return pauseTest().then(() => {
+      assert.ok(true, 'pauseTest promise was resolved');
+    });
+  }
+
+  [`@test resumeTest throws if nothing to resume`](assert) {
+    assert.expect(1);
+
+    assert.throws(() => {
+      this.application.testHelpers.resumeTest();
+    }, /Testing has not been paused. There is nothing to resume./);
+  }
+
 });
 
-QUnit.test('resumeTest throws if nothing to resume', function() {
-  expect(1);
+moduleFor('ember-testing: routing helpers', class extends HelpersTestCase {
 
-  throws(() => App.testHelpers.resumeTest(), /Testing has not been paused. There is nothing to resume./);
-});
-
-QUnit.module('ember-testing routing helpers', {
-  setup() {
-    run(function() {
-      App = EmberApplication.create();
-
-      App.injectTestHelpers();
-
-      App.Router = Router.extend({
-        location: 'none'
-      });
-
-      App.Router.map(function() {
-        this.route('posts', { resetNamespace: true }, function() {
+  constructor() {
+    super();
+    this.runTask(() => {
+      this.createApplication();
+      this.application.setupForTesting();
+      this.application.injectTestHelpers();
+      this.router.map(function() {
+        this.route('posts', {resetNamespace: true}, function() {
           this.route('new');
         });
       });
-
-      App.setupForTesting();
     });
-
-    run(App, 'advanceReadiness');
-  },
-
-  teardown() {
-    cleanup();
+    this.runTask(() => {
+      this.application.advanceReadiness();
+    });
   }
-});
 
-QUnit.test('currentRouteName for \'/\'', function() {
-  expect(3);
+  [`@test currentRouteName for '/'`](assert) {
+    assert.expect(3);
 
-  return App.testHelpers.visit('/').then(function() {
-    equal(App.testHelpers.currentRouteName(), 'index', 'should equal \'index\'.');
-    equal(App.testHelpers.currentPath(), 'index', 'should equal \'index\'.');
-    equal(App.testHelpers.currentURL(), '/', 'should equal \'/\'.');
-  });
-});
-
-
-QUnit.test('currentRouteName for \'/posts\'', function() {
-  expect(3);
-
-  return App.testHelpers.visit('/posts').then(function() {
-    equal(App.testHelpers.currentRouteName(), 'posts.index', 'should equal \'posts.index\'.');
-    equal(App.testHelpers.currentPath(), 'posts.index', 'should equal \'posts.index\'.');
-    equal(App.testHelpers.currentURL(), '/posts', 'should equal \'/posts\'.');
-  });
-});
-
-QUnit.test('currentRouteName for \'/posts/new\'', function() {
-  expect(3);
-
-  return App.testHelpers.visit('/posts/new').then(function() {
-    equal(App.testHelpers.currentRouteName(), 'posts.new', 'should equal \'posts.new\'.');
-    equal(App.testHelpers.currentPath(), 'posts.new', 'should equal \'posts.new\'.');
-    equal(App.testHelpers.currentURL(), '/posts/new', 'should equal \'/posts/new\'.');
-  });
-});
-
-QUnit.module('ember-testing pendingRequests', {
-  setup() {
-    setupApp();
-  },
-
-  teardown() {
-    cleanup();
+    let {application: {testHelpers}} = this;
+    return testHelpers.visit('/').then(() => {
+      assert.equal(
+        testHelpers.currentRouteName(), 'index',
+        `should equal 'index'.`
+      );
+      assert.equal(
+        testHelpers.currentPath(), 'index',
+        `should equal 'index'.`
+      );
+      assert.equal(
+        testHelpers.currentURL(), '/',
+        `should equal '/'.`
+      );
+    });
   }
+
+  [`@test currentRouteName for '/posts'`](assert) {
+    assert.expect(3);
+
+    let {application: {testHelpers}} = this;
+    return testHelpers.visit('/posts').then(() => {
+      assert.equal(
+        testHelpers.currentRouteName(), 'posts.index',
+        `should equal 'posts.index'.`
+      );
+      assert.equal(
+        testHelpers.currentPath(), 'posts.index',
+        `should equal 'posts.index'.`
+      );
+      assert.equal(
+        testHelpers.currentURL(), '/posts',
+        `should equal '/posts'.`
+      );
+    });
+  }
+
+  [`@test currentRouteName for '/posts/new'`](assert) {
+    assert.expect(3);
+
+    let {application: {testHelpers}} = this;
+    return testHelpers.visit('/posts/new').then(() => {
+      assert.equal(
+        testHelpers.currentRouteName(), 'posts.new',
+        `should equal 'posts.new'.`
+      );
+      assert.equal(
+        testHelpers.currentPath(), 'posts.new',
+        `should equal 'posts.new'.`
+      );
+      assert.equal(
+        testHelpers.currentURL(), '/posts/new',
+        `should equal '/posts/new'.`
+      );
+    });
+  }
+
 });
 
-QUnit.test('pendingRequests is maintained for ajaxSend and ajaxComplete events', function() {
-  equal(pendingRequests(), 0);
-  var xhr = { some: 'xhr' };
-  jQuery(document).trigger('ajaxSend', xhr);
-  equal(pendingRequests(), 1, 'Ember.Test.pendingRequests was incremented');
-  jQuery(document).trigger('ajaxComplete', xhr);
-  equal(pendingRequests(), 0, 'Ember.Test.pendingRequests was decremented');
-});
+moduleFor('ember-testing: pendingRequests', class extends HelpersApplicationTestCase {
 
-QUnit.test('pendingRequests is ignores ajaxComplete events from past setupForTesting calls', function() {
-  equal(pendingRequests(), 0);
-  var xhr = { some: 'xhr' };
-  jQuery(document).trigger('ajaxSend', xhr);
-  equal(pendingRequests(), 1, 'Ember.Test.pendingRequests was incremented');
+  [`@test pendingRequests is maintained for ajaxSend and ajaxComplete events`](assert) {
+    assert.equal(
+      pendingRequests(), 0
+    );
 
-  run(function() {
+    let xhr = { some: 'xhr' };
+
+    jQuery(document).trigger('ajaxSend', xhr);
+    assert.equal(
+      pendingRequests(), 1,
+      'Ember.Test.pendingRequests was incremented'
+    );
+
+    jQuery(document).trigger('ajaxComplete', xhr);
+    assert.equal(
+      pendingRequests(), 0,
+      'Ember.Test.pendingRequests was decremented'
+    );
+  }
+
+  [`@test pendingRequests is ignores ajaxComplete events from past setupForTesting calls`](assert) {
+    assert.equal(
+      pendingRequests(), 0
+    );
+
+    let xhr = { some: 'xhr' };
+
+    jQuery(document).trigger('ajaxSend', xhr);
+    assert.equal(
+      pendingRequests(), 1,
+      'Ember.Test.pendingRequests was incremented'
+    );
+
     setupForTesting();
-  });
-  equal(pendingRequests(), 0, 'Ember.Test.pendingRequests was reset');
 
-  var altXhr = { some: 'more xhr' };
-  jQuery(document).trigger('ajaxSend', altXhr);
-  equal(pendingRequests(), 1, 'Ember.Test.pendingRequests was incremented');
-  jQuery(document).trigger('ajaxComplete', xhr);
-  equal(pendingRequests(), 1, 'Ember.Test.pendingRequests is not impressed with your unexpected complete');
-});
+    assert.equal(
+      pendingRequests(), 0,
+      'Ember.Test.pendingRequests was reset'
+    );
 
-QUnit.test('pendingRequests is reset by setupForTesting', function() {
-  incrementPendingRequests();
-  run(function() {
+    let altXhr = { some: 'more xhr' };
+
+    jQuery(document).trigger('ajaxSend', altXhr);
+    assert.equal(
+      pendingRequests(), 1,
+      'Ember.Test.pendingRequests was incremented'
+    );
+
+    jQuery(document).trigger('ajaxComplete', xhr);
+    assert.equal(
+      pendingRequests(), 1,
+      'Ember.Test.pendingRequests is not impressed with your unexpected complete'
+    );
+  }
+
+  [`@test pendingRequests is reset by setupForTesting`](assert) {
+    incrementPendingRequests();
+
     setupForTesting();
-  });
-  equal(pendingRequests(), 0, 'pendingRequests is reset');
+
+    assert.equal(
+      pendingRequests(), 0,
+      'pendingRequests is reset'
+    );
+  }
+
 });
 
-QUnit.module('ember-testing async router', {
-  setup() {
-    cleanup();
+moduleFor('ember-testing: async router', class extends HelpersTestCase {
+  constructor() {
+    super();
 
-    run(function() {
-      App = EmberApplication.create();
-      App.Router = Router.extend({
-        location: 'none'
-      });
+    this.runTask(() => {
+      this.createApplication();
 
-      App.Router.map(function() {
+      this.router.map(function() {
         this.route('user', { resetNamespace: true }, function() {
           this.route('profile');
           this.route('edit');
         });
       });
 
-      App.UserRoute = Route.extend({
+      // Emulate a long-running unscheduled async operation.
+      let resolveLater = () => new RSVP.Promise(resolve => {
+        /*
+         * The wait() helper has a 10ms tick. We should resolve() after
+         * at least one tick to test whether wait() held off while the
+         * async router was still loading. 20ms should be enough.
+         */
+        run.later(resolve, {firstName: 'Tom'}, 20);
+      });
+
+      this.add('route:user', Route.extend({
         model() {
           return resolveLater();
         }
-      });
+      }));
 
-      App.UserProfileRoute = Route.extend({
+      this.add('route:user.profile', Route.extend({
         beforeModel() {
-          var self = this;
-          return resolveLater().then(function() {
-            self.transitionTo('user.edit');
-          });
+          return resolveLater().then(() => this.transitionTo('user.edit'));
         }
-      });
+      }));
 
-      // Emulates a long-running unscheduled async operation.
-      function resolveLater() {
-        var promise;
-
-        run(function() {
-          promise = new RSVP.Promise(function(resolve) {
-            // The wait() helper has a 10ms tick. We should resolve() after at least one tick
-            // to test whether wait() held off while the async router was still loading. 20ms
-            // should be enough.
-            setTimeout(function() {
-              run(function() {
-                resolve(EmberObject.create({ firstName: 'Tom' }));
-              });
-            }, 20);
-          });
-        });
-
-        return promise;
-      }
-
-      App.setupForTesting();
+      this.application.setupForTesting();
     });
 
-    App.injectTestHelpers();
-    run(App, 'advanceReadiness');
-  },
-
-  teardown() {
-    cleanup();
-  }
-});
-
-QUnit.test('currentRouteName for \'/user\'', function() {
-  expect(4);
-
-  return App.testHelpers.visit('/user').then(function() {
-    equal(currentRouteName(App), 'user.index', 'should equal \'user.index\'.');
-    equal(currentPath(App), 'user.index', 'should equal \'user.index\'.');
-    equal(currentURL(App), '/user', 'should equal \'/user\'.');
-    equal(App.__container__.lookup('route:user').get('controller.model.firstName'), 'Tom', 'should equal \'Tom\'.');
-  });
-});
-
-QUnit.test('currentRouteName for \'/user/profile\'', function() {
-  expect(4);
-
-  return App.testHelpers.visit('/user/profile').then(function() {
-    equal(currentRouteName(App), 'user.edit', 'should equal \'user.edit\'.');
-    equal(currentPath(App), 'user.edit', 'should equal \'user.edit\'.');
-    equal(currentURL(App), '/user/edit', 'should equal \'/user/edit\'.');
-    equal(App.__container__.lookup('route:user').get('controller.model.firstName'), 'Tom', 'should equal \'Tom\'.');
-  });
-});
-
-var originalVisitHelper, originalFindHelper, originalWaitHelper;
-
-QUnit.module('can override built-in helpers', {
-  setup() {
-    originalVisitHelper = Test._helpers.visit;
-    originalFindHelper  = Test._helpers.find;
-    originalWaitHelper  = Test._helpers.wait;
-
-    jQuery('<style>#ember-testing-container { position: absolute; background: white; bottom: 0; right: 0; width: 640px; height: 384px; overflow: auto; z-index: 9999; border: 1px solid #ccc; } #ember-testing { zoom: 50%; }</style>').appendTo('head');
-    jQuery('<div id="ember-testing-container"><div id="ember-testing"></div></div>').appendTo('body');
-    run(function() {
-      App = EmberApplication.create({
-        rootElement: '#ember-testing'
-      });
-
-      App.setupForTesting();
+    this.application.injectTestHelpers();
+    this.runTask(() => {
+      this.application.advanceReadiness();
     });
-  },
+  }
+
+  [`@test currentRouteName for '/user'`](assert) {
+    assert.expect(4);
+
+    let {application: {testHelpers}} = this;
+    return testHelpers.visit('/user').then(() => {
+      assert.equal(
+        testHelpers.currentRouteName(), 'user.index',
+        `should equal 'user.index'.`
+      );
+      assert.equal(
+        testHelpers.currentPath(), 'user.index',
+        `should equal 'user.index'.`
+      );
+      assert.equal(
+        testHelpers.currentURL(), '/user',
+        `should equal '/user'.`
+      );
+      let userRoute = this.applicationInstance.lookup('route:user');
+      assert.equal(
+        userRoute.get('controller.model.firstName'), 'Tom',
+        `should equal 'Tom'.`
+      );
+    });
+  }
+
+  [`@test currentRouteName for '/user/profile'`](assert) {
+    assert.expect(4);
+
+    let {application: {testHelpers}} = this;
+    return testHelpers.visit('/user/profile').then(() => {
+      assert.equal(
+        testHelpers.currentRouteName(), 'user.edit',
+        `should equal 'user.edit'.`
+      );
+      assert.equal(
+        testHelpers.currentPath(), 'user.edit',
+        `should equal 'user.edit'.`
+      );
+      assert.equal(
+        testHelpers.currentURL(), '/user/edit',
+        `should equal '/user/edit'.`
+      );
+      let userRoute = this.applicationInstance.lookup('route:user');
+      assert.equal(
+        userRoute.get('controller.model.firstName'), 'Tom',
+        `should equal 'Tom'.`
+      );
+    });
+  }
+
+});
+
+moduleFor('ember-testing: can override built-in helpers', class extends HelpersTestCase {
+
+  constructor() {
+    super();
+    this.runTask(() => {
+      this.createApplication();
+      this.application.setupForTesting();
+    });
+    this._originalVisitHelper = Test._helpers.visit;
+    this._originalFindHelper  = Test._helpers.find;
+  }
 
   teardown() {
-    cleanup();
-
-    Test._helpers.visit = originalVisitHelper;
-    Test._helpers.find  = originalFindHelper;
-    Test._helpers.wait  = originalWaitHelper;
+    Test._helpers.visit = this._originalVisitHelper;
+    Test._helpers.find  = this._originalFindHelper;
+    super.teardown();
   }
-});
 
-QUnit.test('can override visit helper', function() {
-  expect(1);
+  [`@test can override visit helper`](assert) {
+    assert.expect(1);
 
-  Test.registerHelper('visit', function() {
-    ok(true, 'custom visit helper was called');
-  });
+    Test.registerHelper('visit', () => {
+      assert.ok(true, 'custom visit helper was called');
+    });
 
-  App.injectTestHelpers();
+    this.application.injectTestHelpers();
 
-  return App.testHelpers.visit();
-});
+    return this.application.testHelpers.visit();
+  }
 
-QUnit.test('can override find helper', function() {
-  expect(1);
+  [`@test can override find helper`](assert) {
+    assert.expect(1);
 
-  Test.registerHelper('find', function() {
-    ok(true, 'custom find helper was called');
+    Test.registerHelper('find', () => {
+      assert.ok(true, 'custom find helper was called');
 
-    return ['not empty array'];
-  });
+      return ['not empty array'];
+    });
 
-  App.injectTestHelpers();
+    this.application.injectTestHelpers();
 
-  return App.testHelpers.findWithAssert('.who-cares');
+    return this.application.testHelpers.findWithAssert('.who-cares');
+  }
+
 });


### PR DESCRIPTION
1) Decouple the `acceptance_test` and `helpers_test` files from the globals
resolver per #15058.
2) Update `setupForTesting` to reference the router factory in the registry
instead of the globally resolved one on the application instance.
3) Extend the Router during application registry setup to isolate
`reopen` calls.