### PR TITLE
fix factory injection deprecation link

### DIFF
--- a/packages/ember/lib/index.js
+++ b/packages/ember/lib/index.js
@@ -185,7 +185,7 @@ if (DEBUG) {
         {
           id: 'ember-metal.model_factory_injections',
           until: '2.17.0',
-          url: 'https://emberjs.com/deprecations/v2.x#toc_code-ember-model-factory-injections'
+          url: 'https://emberjs.com/deprecations/v2.x/#toc_ember-model-em-factory-em-injections-removed'
         }
       );
     },


### PR DESCRIPTION
The fact that this deprecation's id has underscores in it is causing some unexpected behavior when it is pulled in to the [docs](https://emberjs.com/deprecations/v2.x) in that it cause the word `factory` to be italicized and the anchor url to have unexpected characters around the word factory as well.  This PR at least fixes the link so that it takes you to the correct section of the deprecation guide.  Ideally we could change the deprecation id to be dasherized, but I'm not sure if it would be too late to do that?

Fixes https://github.com/emberjs/website/issues/2912