### PR TITLE
wrap `validationCache` and `.validateInjections` and  in DEBUG

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -32,10 +32,13 @@ export default function Container(registry, options = {}) {
   this.registry        = registry;
   this.owner           = options.owner || null;
   this.cache           = dictionary(options.cache || null);
-  this.validationCache = dictionary(options.validationCache || null);
   this.factoryManagerCache = dictionary(options.factoryManagerCache || null);
   this[CONTAINER_OVERRIDE] = undefined;
   this.isDestroyed = false;
+
+  if (DEBUG) {
+    this.validationCache = dictionary(options.validationCache || null);
+  }
 }
 
 Container.prototype = {
@@ -385,7 +388,6 @@ class FactoryManager {
   }
 
   create(options = {}) {
-
     let injections = this.injections;
     if (injections === undefined) {
       injections = injectionsFor(this.container, this.normalizedName);
@@ -394,7 +396,6 @@ class FactoryManager {
       }
     }
     let props = assign({}, injections, options);
-
 
     if (DEBUG) {
       let lazyInjections;

--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -1,6 +1,7 @@
 import { dictionary, assign, intern } from 'ember-utils';
 import { assert, deprecate } from 'ember-debug';
 import Container from './container';
+import { DEBUG } from 'ember-env-flags';
 
 const VALID_FULL_NAME_REGEXP = /^[^:]+:[^:]+$/;
 
@@ -572,18 +573,6 @@ Registry.prototype = {
     return VALID_FULL_NAME_REGEXP.test(fullName);
   },
 
-  validateInjections(injections) {
-    if (!injections) { return; }
-
-    let fullName;
-
-    for (let i = 0; i < injections.length; i++) {
-      fullName = injections[i].fullName;
-
-      assert(`Attempting to inject an unknown injection: '${fullName}'`, this.has(fullName));
-    }
-  },
-
   normalizeInjectionsHash(hash) {
     let injections = [];
 
@@ -625,6 +614,20 @@ function deprecateResolverFunction(registry) {
   registry.resolver = {
     resolve: registry.resolver
   };
+}
+
+if (DEBUG) {
+  Registry.prototype.validateInjections = function(injections) {
+    if (!injections) { return; }
+
+    let fullName;
+
+    for (let i = 0; i < injections.length; i++) {
+      fullName = injections[i].fullName;
+
+      assert(`Attempting to inject an unknown injection: '${fullName}'`, this.has(fullName));
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
since `registery.validateInjections` and `validationCache` is used only in DEBUG mode I think it is appropriate to wrap them in DEBUG