### PR TITLE
Clean up `Meta`.

### DIFF
--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -15,7 +15,6 @@ import {
 import {
   removeChainWatcher
 } from './chains';
-import { has } from 'require';
 
 let counters;
 if (DEBUG) {

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -283,36 +283,6 @@ export class Meta {
     }
   }
 
-  readInheritedValue(key, subkey) {
-    let internalKey = `_${key}`;
-
-    let pointer = this;
-
-    while (pointer !== undefined) {
-      let map = pointer[internalKey];
-      if (map !== undefined) {
-        let value = map[subkey];
-        if (value !== undefined || subkey in map) {
-          return value;
-        }
-      }
-      pointer = pointer.parent;
-    }
-
-    return UNDEFINED;
-  }
-
-  writeValue(obj, key, value) {
-    let descriptor = lookupDescriptor(obj, key);
-    let isMandatorySetter = descriptor !== undefined && descriptor.set && descriptor.set.isMandatorySetter;
-
-    if (isMandatorySetter) {
-      this.writeValues(key, value);
-    } else {
-      obj[key] = value;
-    }
-  }
-
   set factory(factory) {
     this._factory = factory;
   }

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -353,38 +353,6 @@ export class Meta {
    return this._findInherited('_watching', subkey);
   }
 
-  forEachWatching(fn) {
-    let pointer = this;
-    let seen;
-    while (pointer !== undefined) {
-      let map = pointer._watching;
-      if (map !== undefined) {
-        for (let key in map) {
-          seen = seen || Object.create(null);
-          if (seen[key] === undefined) {
-            seen[key] = true;
-            fn(key, map[key]);
-          }
-       }
-    }
-    pointer = pointer.parent;
-    }
-  }
-
-  clearWatching() {
-   assert(`Cannot clear watchers on \`${toString(this.source)}\` after it has been destroyed.`, !this.isMetaDestroyed());
-
-   this._watching = undefined;
-  }
-
-  deleteFromWatching(subkey) {
-    delete this._getOrCreateOwnMap('_watching')[subkey];
-  }
-
-  hasInWatching(subkey) {
-    return this._findInherited('_watching', subkey) !== undefined;
-  }
-
   writeMixins(subkey, value) {
     assert(`Cannot add mixins for \`${subkey}\` on \`${toString(this.source)}\` call writeMixins after it has been destroyed.`, !this.isMetaDestroyed());
     let map = this._getOrCreateOwnMap('_mixins');
@@ -411,20 +379,6 @@ export class Meta {
       }
       pointer = pointer.parent;
     }
-  }
-
-  clearMixins() {
-    assert(`Cannot clear mixins on \`${toString(this.source)}\` after it has been destroyed.`, !this.isMetaDestroyed());
-
-    this._mixins = undefined;
-  }
-
-  deleteFromMixins(subkey) {
-    delete this._getOrCreateOwnMap('_mixins')[subkey];
-  }
-
-  hasInMixins(subkey) {
-    return this._findInherited('_mixins', subkey) !== undefined;
   }
 
   writeBindings(subkey, value) {
@@ -461,14 +415,6 @@ export class Meta {
     this._bindings = undefined;
   }
 
-  deleteFromBindings(subkey) {
-    delete this._getOrCreateOwnMap('_bindings')[subkey];
-  }
-
-  hasInBindings(subkey) {
-    return this._findInherited('_bindings', subkey) !== undefined;
-  }
-
   writeValues(subkey, value) {
     assert(`Cannot set the value of \`${subkey}\` on \`${toString(this.source)}\` after it has been destroyed.`, !this.isMetaDestroyed());
 
@@ -480,38 +426,9 @@ export class Meta {
     return this._findInherited('_values', subkey);
   }
 
-  forEachValues(fn) {
-    let pointer = this;
-    let seen;
-    while (pointer !== undefined) {
-      let map = pointer._values;
-      if (map !== undefined) {
-        for (let key in map) {
-          seen = seen || Object.create(null);
-          if (seen[key] === undefined) {
-            seen[key] = true;
-            fn(key, map[key]);
-          }
-        }
-      }
-      pointer = pointer.parent;
-    }
-  }
-
-  clearValues() {
-    assert(`Cannot call clearValues after the object is destroyed.`, !this.isMetaDestroyed());
-
-    this._values = undefined;
-  }
-
   deleteFromValues(subkey) {
     delete this._getOrCreateOwnMap('_values')[subkey];
   }
-
-  hasInValues(subkey) {
-    return this._findInherited('_values', subkey) !== undefined;
-  }
-
 }
 
 if (EMBER_GLIMMER_DETECT_BACKTRACKING_RERENDER || EMBER_GLIMMER_ALLOW_BACKTRACKING_RERENDER) {

--- a/packages/ember-metal/tests/accessors/mandatory_setters_test.js
+++ b/packages/ember-metal/tests/accessors/mandatory_setters_test.js
@@ -18,7 +18,7 @@ function hasMandatorySetter(object, property) {
 }
 
 function hasMetaValue(object, property) {
-  return metaFor(object).hasInValues(property);
+  return metaFor(object).peekValues(property) !== undefined;
 }
 
 if (MANDATORY_SETTER) {

--- a/packages/ember-metal/tests/meta_test.js
+++ b/packages/ember-metal/tests/meta_test.js
@@ -89,18 +89,6 @@ QUnit.test('meta.writeWatching issues useful error after destroy', function(asse
   }, 'Cannot update watchers for `hello` on `<special-sauce:123>` after it has been destroyed.');
 });
 
-QUnit.test('meta.clearWatching issues useful error after destroy', function(assert) {
-  let target = {
-    toString() { return '<special-sauce:123>'; }
-  };
-  let targetMeta = meta(target);
-
-  targetMeta.destroy();
-
-  expectAssertion(() => {
-    targetMeta.clearWatching();
-  }, 'Cannot clear watchers on `<special-sauce:123>` after it has been destroyed.');
-});
 QUnit.test('meta.writableTag issues useful error after destroy', function(assert) {
   let target = {
     toString() { return '<special-sauce:123>'; }


### PR DESCRIPTION
* Remove unused `has` import.
* Move `readInheritedValue` and `writeValue` into guarded `MANDATORY_SETTER` section.
* Remove unused methods (not used in Ember, and no relavent results in emberobserver.com)
  * `forEachWatching` - [emberobserver.com code search](https://emberobserver.com/code-search?codeQuery=forEachWatching) 
  * `clearWatching` - [emberobserver.com code search](https://emberobserver.com/code-search?codeQuery=clearWatching) 
  * `deleteFromWatching` - [emberobserver.com code search](https://emberobserver.com/code-search?codeQuery=deleteFromWatching) 
  * `hasInWatching` - [emberobserver.com code search](https://emberobserver.com/code-search?codeQuery=hasInWatching) 
  * `clearMixins` - [emberobserver.com code search](https://emberobserver.com/code-search?codeQuery=clearMixins) 
  * `deleteFromMixins` - [emberobserver.com code search](https://emberobserver.com/code-search?codeQuery=deleteFromMixins) 
  * `hasInMixins` - [emberobserver.com code search](https://emberobserver.com/code-search?codeQuery=hasInMixins) 
  * `deleteFromBindings` - [emberobserver.com code search](https://emberobserver.com/code-search?codeQuery=deleteFromBindings) 
  * `hasInBindings` - [emberobserver.com code search](https://emberobserver.com/code-search?codeQuery=hasInBindings) 
  * `forEachValues` - [emberobserver.com code search](https://emberobserver.com/code-search?codeQuery=forEachValues) 
  * `clearValues` - [emberobserver.com code search](https://emberobserver.com/code-search?codeQuery=clearValues) 
  * `hasInValue` - [emberobserver.com code search](https://emberobserver.com/code-search?codeQuery=hasInValues)