### PR TITLE
[DOC release] Mark `readonly` glimmer helper as public

### DIFF
--- a/packages/ember-glimmer/lib/helpers/readonly.js
+++ b/packages/ember-glimmer/lib/helpers/readonly.js
@@ -98,7 +98,7 @@ import { unMut } from './mut';
   @method readonly
   @param {Object} [attr] the read-only attribute.
   @for Ember.Templates.helpers
-  @private
+  @public
 */
 export default function(vm, args) {
   let ref = unMut(args.positional.at(0));


### PR DESCRIPTION
I found [this blog post](http://emberup.co/bindings-with-htmlbars-helpers/) from 2015 that described the `readonly` template helper—a very pleasant surprise. I wondered why I'd never heard of it ... turns out it doesn't appear in [the official documentation](https://emberjs.com/api/classes/Ember.Templates.helpers.html). Turns out we just need to mark the helper as `public`!