### PR TITLE
[CLEANUP] Don't pass unused arguments to hooks

### DIFF
--- a/packages/ember-glimmer/lib/component-managers/curly.js
+++ b/packages/ember-glimmer/lib/component-managers/curly.js
@@ -25,10 +25,7 @@ import {
   _instrumentStart
 } from 'ember-metal';
 import { processComponentArgs } from '../utils/process-args';
-import {
-  dispatchLifeCycleHook,
-  setViewElement
-} from 'ember-views';
+import { setViewElement } from 'ember-views';
 import { privatize as P } from 'container';
 import AbstractManager from './abstract';
 import ComponentStateBucket from '../utils/curly-component-state-bucket';
@@ -324,8 +321,8 @@ export default class CurlyComponentManager extends AbstractManager {
       component.setProperties(props);
       component[IS_DISPATCHING_ATTRS] = false;
 
-      dispatchLifeCycleHook(component, 'didUpdateAttrs');
-      dispatchLifeCycleHook(component, 'didReceiveAttrs');
+      component.trigger('didUpdateAttrs');
+      component.trigger('didReceiveAttrs');
     }
 
     if (environment.isInteractive) {

--- a/packages/ember-views/lib/index.js
+++ b/packages/ember-views/lib/index.js
@@ -23,7 +23,7 @@ export { default as CoreView } from './views/core_view';
 export { default as ClassNamesSupport } from './mixins/class_names_support';
 export { default as ChildViewsSupport } from './mixins/child_views_support';
 export { default as ViewStateSupport } from './mixins/view_state_support';
-export { default as ViewMixin, dispatchLifeCycleHook } from './mixins/view_support';
+export { default as ViewMixin } from './mixins/view_support';
 export { default as ActionSupport } from './mixins/action_support';
 export {
   MUTABLE_CELL

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -9,10 +9,6 @@ import { DEBUG } from 'ember-env-flags';
 
 function K() { return this; }
 
-export function dispatchLifeCycleHook(component, hook) {
-  component.trigger(hook);
-}
-
 /**
  @class ViewMixin
  @namespace Ember
@@ -66,9 +62,10 @@ export default Mixin.create({
     @public
    */
   concatenatedProperties: ['attributeBindings'],
+
   [POST_INIT]() {
-    dispatchLifeCycleHook(this, 'didInitAttrs', undefined, this.attrs);
-    dispatchLifeCycleHook(this, 'didReceiveAttrs', undefined, this.attrs);
+    this.trigger('didInitAttrs');
+    this.trigger('didReceiveAttrs');
   },
 
   // ..........................................................


### PR DESCRIPTION
Also remove the `dispatchLifecycleHook` indirection since it doesn't do anything useful anymore.