### PR TITLE
Expose listenersFor from Evented

### DIFF
--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -255,11 +255,11 @@ export function hasListeners(obj, eventName) {
 }
 
 /**
-  @private
   @method listenersFor
   @for Ember
   @param obj
   @param {String} eventName
+  @public
 */
 export function listenersFor(obj, eventName) {
   let ret = [];

--- a/packages/ember-runtime/lib/mixins/evented.js
+++ b/packages/ember-runtime/lib/mixins/evented.js
@@ -3,6 +3,7 @@ import {
   addListener,
   removeListener,
   hasListeners,
+  listenersFor,
   sendEvent
 } from 'ember-metal';
 
@@ -149,5 +150,17 @@ export default Mixin.create({
    */
   has(name) {
     return hasListeners(this, name);
+  },
+
+  /**
+    Returns the list of listeners for a specific event.
+
+    @method listenersFor
+    @param {String} name The name of the event
+    @return {Array} array of [target, method] elements or the empty array
+    @public
+   */
+  listenersFor(name) {
+    return listenersFor(this, name);
   }
 });


### PR DESCRIPTION
## Reason
I had the need to remove listeners from an Evented-mixed class. There is already the nice `has()` method but I didn't find a way to loop through all the listeners and remove them. I noticed that the `ember-metal/events` object has the `listenersFor` method so I just exposed it through the Evented interface.

## Notes on test
- I was not able to `yarn install` ember@master because `"https://registry.yarnpkg.com/@glimmer/runtime/-/runtime-0.24.0-beta.4.tgz: Request failed "401 Unauthorized""`. Interestingly, `npm install` worked fine though
- I am not able to run tests even on the master branch: Broccoli explodes with `TypeError: container.js: path.inShadow is not a function` (I am using node 6.x on OSX 10.11)
- I didn't find any test for the Evented mixin

So, sorry about tests (I will try again from a newer laptop) but I wasn't able to try the PR itself, so take it as it is (or trash it)

Thanks!