### PR TITLE
[BUGFIX beta] Allow numeric keys for the `get` helper.

### DIFF
--- a/packages/ember-glimmer/lib/helpers/get.js
+++ b/packages/ember-glimmer/lib/helpers/get.js
@@ -96,7 +96,7 @@ class GetHelperReference extends CachedReference {
         if (pathType === 'string') {
           innerReference = this.innerReference = referenceFromParts(this.sourceReference, path.split('.'));
         } else if (pathType === 'number') {
-          innerReference = this.innerReference = this.sourceReference.get(path);
+          innerReference = this.innerReference = this.sourceReference.get('' + path);
         }
 
         innerTag.update(innerReference.tag);

--- a/packages/ember-glimmer/tests/integration/helpers/get-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/get-test.js
@@ -50,6 +50,31 @@ moduleFor('Helpers test: {{get}}', class extends RenderingTest {
     this.assertText('[red and yellow] [red and yellow]');
   }
 
+  ['@test should be able to get an object value with numeric keys']() {
+    this.render(`{{#each indexes as |index|}}[{{get items index}}]{{/each}}`, {
+      indexes: [1, 2, 3],
+      items: {
+        1: 'First',
+        2: 'Second',
+        3: 'Third'
+      }
+    });
+
+    this.assertText('[First][Second][Third]');
+
+    this.runTask(() => this.rerender());
+
+    this.assertText('[First][Second][Third]');
+
+    this.runTask(() => set(this.context, 'items.1', 'Qux'));
+
+    this.assertText('[Qux][Second][Third]');
+
+    this.runTask(() => set(this.context, 'items', { 1: 'First', 2: 'Second', 3: 'Third' }));
+
+    this.assertText('[First][Second][Third]');
+  }
+
   ['@test should be able to get an object value with a bound/dynamic key']() {
     this.render(`[{{get colors key}}] [{{if true (get colors key)}}]`, {
       colors: { apple: 'red', banana: 'yellow' },


### PR DESCRIPTION
Fixes #13296
Closes #13311 

/cc @duggiefresh

Note: This commit is straight out of a rebase of #13311. Normally I would just push to the branch, but that PR predates github's feature that allows maintainers to do this.
