### PR TITLE
[FEATURE ember-module-unification] Initial implementation

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -26,3 +26,19 @@ for a detailed explanation.
 
   Adds an ability to for developers to integrate their own custom component managers
   into Ember Applications per [RFC](https://github.com/emberjs/rfcs/blob/custom-components/text/0000-custom-components.md).
+
+* `ember-module-unification`
+
+  Introduces support for Module Unification
+  ([RFC](https://github.com/dgeb/rfcs/blob/module-unification/text/0000-module-unification.md))
+  to Ember. This includes:
+
+  - Passing the `source` of a `lookup`/`factoryFor` call as the second argument
+    to an Ember resolver's `resolve` method (as a positional arg we will call
+    `referrer`).
+  - Making `lookupComponentPair` friendly to local/private resolutions. The
+    new code ensures a local resolution is not paired with a global resolution.
+
+  This feature is paired with the
+  [`EMBER_RESOLVER_MODULE_UNIFICATION`](https://github.com/ember-cli/ember-resolver#ember_resolver_module_unification)
+  flag on the ember-resolver package.

--- a/features.json
+++ b/features.json
@@ -7,6 +7,7 @@
     "ember-glimmer-allow-backtracking-rerender": null,
     "ember-routing-router-service": true,
     "ember-engines-mount-params": true,
+    "ember-module-unification": null,
     "glimmer-custom-component-manager": null
   },
   "deprecations": {

--- a/packages/container/tests/registry_test.js
+++ b/packages/container/tests/registry_test.js
@@ -1,5 +1,6 @@
 import { Registry, privatize } from '..';
 import { factory } from 'internal-test-helpers';
+import { EMBER_MODULE_UNIFICATION } from 'ember/features';
 
 QUnit.module('Registry');
 
@@ -691,6 +692,7 @@ QUnit.test('has uses expandLocalLookup', function(assert) {
 
   let resolver = {
     resolve(name) {
+      if (EMBER_MODULE_UNIFICATION && name === 'foo:baz') { return; }
       resolvedFullNames.push(name);
 
       return 'yippie!';
@@ -737,3 +739,30 @@ QUnit.test('valid format', function(assert) {
   assert.equal(matched[2], 'factory');
   assert.ok(/^\d+$/.test(matched[3]));
 });
+
+if (EMBER_MODULE_UNIFICATION) {
+  QUnit.module('Registry module unification');
+
+  QUnit.test('The registry can pass a source to the resolver', function(assert) {
+    let PrivateComponent = factory();
+    let lookup = 'component:my-input';
+    let source = 'template:routes/application';
+    let resolveCount = 0;
+    let resolver = {
+      resolve(fullName, src) {
+        resolveCount++;
+        if (fullName === lookup && src === source) {
+          return PrivateComponent;
+        }
+      }
+    };
+    let registry = new Registry({ resolver });
+    registry.normalize = function(name) {
+      return name;
+    };
+
+    assert.strictEqual(registry.resolve(lookup, { source }), PrivateComponent, 'The correct factory was provided');
+    assert.strictEqual(registry.resolve(lookup, { source }), PrivateComponent, 'The correct factory was provided again');
+    assert.equal(resolveCount, 1, 'resolve called only once and a cached factory was returned the second time');
+  });
+}

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -1,6 +1,7 @@
 import { guidFor, OWNER } from 'ember-utils';
 import { Cache, _instrumentStart } from 'ember-metal';
 import { assert, warn } from 'ember-debug';
+import { EMBER_MODULE_UNIFICATION } from 'ember/features';
 import { DEBUG } from 'ember-env-flags';
 import {
   lookupPartial,
@@ -91,7 +92,8 @@ export default class Environment extends GlimmerEnvironment {
         return new CurlyComponentDefinition(name, componentFactory, layout, undefined, customManager);
       }
     }, ({ name, source, owner }) => {
-      let expandedName = source && owner._resolveLocalLookupName(name, source) || name;
+      let expandedName = source && this._resolveLocalLookupName(name, source, owner) || name;
+
       let ownerGuid = guidFor(owner);
 
       return ownerGuid + '|' + expandedName;
@@ -145,6 +147,11 @@ export default class Environment extends GlimmerEnvironment {
     if (DEBUG) {
       this.debugStack = new DebugStack()
     }
+  }
+
+  _resolveLocalLookupName(name, source, owner) {
+    return EMBER_MODULE_UNIFICATION ? `${source}:${name}`
+      : owner._resolveLocalLookupName(name, source);
   }
 
   macros() {

--- a/packages/ember-glimmer/tests/integration/components/local-lookup-test.js
+++ b/packages/ember-glimmer/tests/integration/components/local-lookup-test.js
@@ -1,36 +1,10 @@
 import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { ModuleBasedTestResolver } from 'internal-test-helpers';
 import { Component } from '../../utils/helpers';
+import { EMBER_MODULE_UNIFICATION } from 'ember/features';
+import { helper, Helper } from 'ember-glimmer';
 
-function buildResolver() {
-  let resolver = {
-    resolve() { },
-    expandLocalLookup(fullName, sourceFullName) {
-      let [sourceType, sourceName ] = sourceFullName.split(':');
-      let [type, name ] = fullName.split(':');
-
-      if (type !== 'template' && sourceType === 'template' && sourceName.slice(0, 11) === 'components/') {
-        sourceName = sourceName.slice(11);
-      }
-
-      if (type === 'template' && sourceType === 'template' && name.slice(0, 11) === 'components/') {
-        name = name.slice(11);
-      }
-
-
-      let result = `${type}:${sourceName}/${name}`;
-
-      return result;
-    }
-  };
-
-  return resolver;
-}
-
-moduleFor('Components test: local lookup', class extends RenderingTest {
-  getResolver() {
-    return buildResolver();
-  }
-
+class LocalLookupTest extends RenderingTest {
   ['@test it can lookup a local template']() {
     this.registerComponent('x-outer/x-inner', { template: 'Nested template says: {{yield}}' });
     this.registerComponent('x-outer', { template: '{{#x-inner}}Hi!{{/x-inner}}' });
@@ -217,4 +191,114 @@ moduleFor('Components test: local lookup', class extends RenderingTest {
 
     this.assertText('Nested template says (from global): Hi! Nested template says (from local): Hi! Nested template says (from local): Hi!');
   }
+}
+
+// first run these tests with expandLocalLookup
+
+function buildResolver() {
+  let resolver = {
+    resolve() { },
+    expandLocalLookup(fullName, sourceFullName) {
+      let [sourceType, sourceName ] = sourceFullName.split(':');
+      let [type, name ] = fullName.split(':');
+
+      if (type !== 'template' && sourceType === 'template' && sourceName.slice(0, 11) === 'components/') {
+        sourceName = sourceName.slice(11);
+      }
+
+      if (type === 'template' && sourceType === 'template' && name.slice(0, 11) === 'components/') {
+        name = name.slice(11);
+      }
+
+
+      let result = `${type}:${sourceName}/${name}`;
+
+      return result;
+    }
+  };
+
+  return resolver;
+}
+
+moduleFor('Components test: local lookup with expandLocalLookup feature', class extends LocalLookupTest {
+  getResolver() {
+    return buildResolver();
+  }
 });
+
+if (EMBER_MODULE_UNIFICATION) {
+  class LocalLookupTestResolver extends ModuleBasedTestResolver {
+    resolve(specifier, referrer) {
+      let fullSpecifier = specifier;
+
+      if (referrer) {
+        let namespace = referrer.split('template:components/')[1];
+        if (specifier.indexOf('template:components/') !== -1) {
+            let name = specifier.split('template:components/')[1];
+            fullSpecifier = `template:components/${namespace}/${name}`;
+        } else if (specifier.indexOf(':') !== -1) {
+          let [type, name] = specifier.split(':');
+          fullSpecifier = `${type}:${namespace}/${name}`;
+        }
+      }
+
+      return super.resolve(fullSpecifier);
+    }
+  }
+
+  /*
+   * This sub-classing changes `registerXXX` methods to use the resolver.
+   * Required for testing the module unification-friendly `resolve` call
+   * with a `referrer` argument.
+   *
+   * In theory all these tests can be ported to use the resolver instead of
+   * the registry.
+   */
+  moduleFor('Components test: local lookup with resolution referrer', class extends LocalLookupTest {
+    get resolver() {
+      return this.owner.__registry__.fallback.resolver;
+    }
+
+    getResolver() {
+      return new LocalLookupTestResolver();
+    }
+
+    registerComponent(name, { ComponentClass = null, template = null }) {
+      let { resolver } = this;
+
+      if (ComponentClass) {
+        resolver.add(`component:${name}`, ComponentClass);
+      }
+
+      if (typeof template === 'string') {
+        resolver.add(`template:components/${name}`, this.compile(template, {
+          moduleName: `components/${name}`
+        }));
+      }
+    }
+
+    registerTemplate(name, template) {
+      let { resolver } = this;
+      if (typeof template === 'string') {
+        resolver.add(`template:${name}`, this.compile(template, {
+          moduleName: name
+        }));
+      } else {
+        throw new Error(`Registered template "${name}" must be a string`);
+      }
+    }
+
+    registerHelper(name, funcOrClassBody) {
+      let { resolver } = this;
+      let type = typeof funcOrClassBody;
+
+      if (type === 'function') {
+        resolver.add(`helper:${name}`, helper(funcOrClassBody));
+      } else if (type === 'object' && type !== null) {
+        resolver.add(`helper:${name}`, Helper.extend(funcOrClassBody));
+      } else {
+        throw new Error(`Cannot register ${funcOrClassBody} as a helper`);
+      }
+    }
+  });
+}

--- a/packages/ember-views/lib/utils/lookup-component.js
+++ b/packages/ember-views/lib/utils/lookup-component.js
@@ -1,6 +1,39 @@
 import { privatize as P } from 'container';
+import { EMBER_MODULE_UNIFICATION } from 'ember/features';
+
+function lookupModuleUnificationComponentPair(componentLookup, owner, name, options) {
+  let localComponent = componentLookup.componentFor(name, owner, options);
+  let localLayout = componentLookup.layoutFor(name, owner, options);
+
+  let globalComponent = componentLookup.componentFor(name, owner);
+  let globalLayout = componentLookup.layoutFor(name, owner);
+
+  let localAndUniqueComponent = !!localComponent && (!globalComponent || localComponent.class !== globalComponent.class);
+  let localAndUniqueLayout = !!localLayout && (!globalLayout || localLayout.meta.moduleName !== globalLayout.meta.moduleName);
+
+  if (localAndUniqueComponent && localAndUniqueLayout) {
+    return { layout: localLayout, component: localComponent };
+  }
+
+  if (localAndUniqueComponent && !localAndUniqueLayout) {
+    return { layout: null, component: localComponent };
+  }
+
+  let defaultComponentFactory = owner.factoryFor(P`component:-default`);
+
+  if (!localAndUniqueComponent && localAndUniqueLayout) {
+    return { layout: localLayout, component: defaultComponentFactory };
+  }
+
+  let component = globalComponent || (globalLayout && defaultComponentFactory);
+  return { layout: globalLayout, component };
+}
 
 function lookupComponentPair(componentLookup, owner, name, options) {
+  if (EMBER_MODULE_UNIFICATION) {
+    return lookupModuleUnificationComponentPair(componentLookup, owner, name, options);
+  }
+
   let component = componentLookup.componentFor(name, owner, options);
   let layout = componentLookup.layoutFor(name, owner, options);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -838,9 +838,9 @@ backbone@^1.1.2:
   dependencies:
     underscore ">=1.8.3"
 
-backburner.js@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-1.0.0.tgz#fffae139998f20a161ac2140d85639b152dfc226"
+backburner.js@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-1.1.0.tgz#16ef021891bc330a2d021c63d8d68cb8611eb3e4"
 
 backo2@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
To support module unification, we must modify the container and registry to pass the source as second parameter to the resolver. This PR introduces a new feature flag called `ember-module-unification` which does just that.

I'll follow up with some PRs in the `ember-resolver` and `glimmer-resolver` repos, and an end-to-end example of an Ember app using module unification and private components.

When the feature flag is on, this change breaks two tests related to `expandLocalLookup`. I'm looking at a way to support the new functionality and make those tests pass. While I'm doing that, I'd appreciate some feedback on the overall design here.

**EDIT**

Related PRs:
 - https://github.com/ember-cli/ember-resolver/pull/196
 - https://github.com/glimmerjs/glimmer-resolver/pull/16

@mixonic @rwjblue 