### PR TITLE
Refactor base app test helper classes

### DIFF
--- a/packages/ember-application/tests/system/bootstrap-test.js
+++ b/packages/ember-application/tests/system/bootstrap-test.js
@@ -1,11 +1,11 @@
-import { Router } from 'ember-routing';
 import { assign } from 'ember-utils';
 import { jQuery } from 'ember-views';
-import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
-import { setTemplates } from 'ember-glimmer';
-import DefaultResolver from '../../system/resolver';
+import {
+  moduleFor,
+  DefaultResolverApplicationTestCase
+} from 'internal-test-helpers';
 
-moduleFor('Ember.Application with default resolver and autoboot', class extends ApplicationTestCase {
+moduleFor('Ember.Application with default resolver and autoboot', class extends DefaultResolverApplicationTestCase {
   constructor() {
     jQuery('#qunit-fixture').html(`
       <div id="app"></div>
@@ -16,22 +16,15 @@ moduleFor('Ember.Application with default resolver and autoboot', class extends 
     super();
   }
 
-  teardown() {
-    setTemplates({});
-  }
-
   get applicationOptions() {
     return assign(super.applicationOptions, {
       autoboot: true,
-      rootElement: '#app',
-      Resolver: DefaultResolver,
-      Router: Router.extend({
-        location: 'none'
-      })
+      rootElement: '#app'
     });
   }
 
   ['@test templates in script tags are extracted at application creation'](assert) {
-    assert.equal(jQuery('#app').text(), 'Hello World!');
+    this.runTask(() => this.createApplication());
+    assert.equal(this.$('#app').text(), 'Hello World!');
   }
 });

--- a/packages/ember-application/tests/system/dependency_injection/custom_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/custom_resolver_test.js
@@ -1,40 +1,34 @@
-import { jQuery } from 'ember-views';
-import { run } from 'ember-metal';
-import Application from '../../../system/application';
 import DefaultResolver from '../../../system/resolver';
-import { compile } from 'ember-template-compiler';
+import { assign } from 'ember-utils';
+import {
+  moduleFor,
+  DefaultResolverApplicationTestCase
+} from 'internal-test-helpers';
 
-let application;
+moduleFor('Ember.Application with extended default resolver and autoboot', class extends DefaultResolverApplicationTestCase {
 
-QUnit.module('Ember.Application Dependency Injection – customResolver', {
-  setup() {
-    let fallbackTemplate = compile('<h1>Fallback</h1>');
+  get applicationOptions() {
+    let applicationTemplate = this.compile(`<h1>Fallback</h1>`);
 
     let Resolver = DefaultResolver.extend({
       resolveTemplate(resolvable) {
-        let resolvedTemplate = this._super(resolvable);
-        if (resolvedTemplate) { return resolvedTemplate; }
         if (resolvable.fullNameWithoutType === 'application') {
-          return fallbackTemplate;
+          return applicationTemplate;
         } else {
-          return;
+          return this._super(resolvable);
         }
       }
     });
 
-    application = run(() => {
-      return Application.create({
-        Resolver: Resolver,
-        rootElement: '#qunit-fixture'
-      });
+    return assign(super.applicationOptions, {
+      Resolver,
+      autoboot: true
     });
-  },
-
-  teardown() {
-    run(application, 'destroy');
   }
-});
 
-QUnit.test('a resolver can be supplied to application', function() {
-  equal(jQuery('h1', application.rootElement).text(), 'Fallback');
+  [`@test a resolver can be supplied to application`](assert) {
+    this.runTask(() => this.createApplication());
+    assert.equal(this.$('h1').text(), 'Fallback');
+  }
+
 });

--- a/packages/internal-test-helpers/lib/index.js
+++ b/packages/internal-test-helpers/lib/index.js
@@ -29,6 +29,7 @@ export { default as AbstractRenderingTestCase } from './test-cases/abstract-rend
 export { default as RenderingTestCase } from './test-cases/rendering';
 export { default as RouterTestCase } from './test-cases/router';
 export { default as AutobootApplicationTestCase } from './test-cases/autoboot-application';
+export { default as DefaultResolverApplicationTestCase } from './test-cases/default-resolver-application';
 
 export {
   default as TestResolver,

--- a/packages/internal-test-helpers/lib/test-cases/abstract-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract-application.js
@@ -1,36 +1,23 @@
-import { run } from 'ember-metal';
-import { jQuery } from 'ember-views';
-import { Application } from 'ember-application';
-import { Router } from 'ember-routing';
 import { compile } from 'ember-template-compiler';
-
 import AbstractTestCase from './abstract';
-import { ModuleBasedResolver } from '../test-resolver';
+import { jQuery } from 'ember-views';
 import { runDestroy } from '../run';
 
 export default class AbstractApplicationTestCase extends AbstractTestCase {
+
   constructor() {
     super();
-
     this.element = jQuery('#qunit-fixture')[0];
+  }
 
-    let { applicationOptions } = this;
-    this.application = this.runTask(() => Application.create(applicationOptions));
-
-    this.resolver = applicationOptions.Resolver.lastInstance;
-
-    if (this.resolver) {
-      this.resolver.add('router:main', Router.extend(this.routerOptions));
-    }
-
-    this.applicationInstance = null;
+  teardown() {
+    runDestroy(this.application);
+    super.teardown();
   }
 
   get applicationOptions() {
     return {
-      rootElement: '#qunit-fixture',
-      autoboot: false,
-      Resolver: ModuleBasedResolver
+      rootElement: '#qunit-fixture'
     };
   }
 
@@ -44,57 +31,8 @@ export default class AbstractApplicationTestCase extends AbstractTestCase {
     return this.application.resolveRegistration('router:main');
   }
 
-  get appRouter() {
-    return this.applicationInstance.lookup('router:main');
-  }
-
-  teardown() {
-    runDestroy(this.applicationInstance);
-    runDestroy(this.application);
-  }
-
-  visit(url, options) {
-    let { applicationInstance } = this;
-
-    if (applicationInstance) {
-      return this.runTask(() => applicationInstance.visit(url, options));
-    } else {
-      return this.runTask(() => {
-        return this.application.visit(url, options).then(instance => {
-          this.applicationInstance = instance;
-        });
-      });
-    }
-  }
-
-  transitionTo() {
-    return run(this.appRouter, 'transitionTo', ...arguments);
-  }
-
   compile(string, options) {
     return compile(...arguments);
-  }
-
-  add(specifier, factory) {
-    this.resolver.add(specifier, factory);
-  }
-
-  addTemplate(templateName, templateString) {
-    this.resolver.add(`template:${templateName}`, this.compile(templateString, {
-      moduleName: templateName
-    }));
-  }
-
-  addComponent(name, { ComponentClass = null, template = null }) {
-    if (ComponentClass) {
-      this.resolver.add(`component:${name}`, ComponentClass);
-    }
-
-    if (typeof template === 'string') {
-      this.resolver.add(`template:components/${name}`, this.compile(template, {
-        moduleName: `components/${name}`
-      }));
-    }
   }
 
 }

--- a/packages/internal-test-helpers/lib/test-cases/autoboot-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/autoboot-application.js
@@ -1,52 +1,31 @@
-import AbstractTestCase from './abstract';
+import TestResolverApplicationTestCase from './test-resolver-application';
 import TestResolver from '../test-resolver';
 import { Application } from 'ember-application';
 import { assign } from 'ember-utils';
-import { runDestroy } from '../run';
-import { run } from 'ember-metal';
-import { compile } from 'ember-template-compiler';
+import { Router } from 'ember-routing';
 
-export default class AutobootApplicationTestCase extends AbstractTestCase {
-
-  teardown() {
-    runDestroy(this.application);
-    super.teardown();
-  }
+export default class AutobootApplicationTestCase extends TestResolverApplicationTestCase {
 
   createApplication(options, MyApplication=Application) {
-    let myOptions = assign({
-      rootElement: '#qunit-fixture',
-      Resolver: TestResolver
-    }, options);
+    let myOptions = assign(this.applicationOptions, options);
     let application = this.application = MyApplication.create(myOptions);
     this.resolver = myOptions.Resolver.lastInstance;
+
+    if (this.resolver) {
+      this.resolver.add('router:main', Router.extend(this.routerOptions));
+    }
+
     return application;
   }
 
-  add(specifier, factory) {
-    this.resolver.add(specifier, factory);
-  }
-
-  get router() {
-    return this.application.resolveRegistration('router:main');
-  }
-
   visit(url, options) {
-    return run(this.applicationInstance, 'visit', url, options);
+    return this.runTask(() => {
+      return this.applicationInstance.visit(url, options);
+    });
   }
 
   get applicationInstance() {
     return this.application.__deprecatedInstance__;
-  }
-
-  compile(string, options) {
-    return compile(...arguments);
-  }
-
-  addTemplate(templateName, templateString) {
-    this.resolver.add(`template:${templateName}`, this.compile(templateString, {
-      moduleName: templateName
-    }));
   }
 
 }

--- a/packages/internal-test-helpers/lib/test-cases/default-resolver-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/default-resolver-application.js
@@ -1,34 +1,30 @@
-import TestResolverApplicationTestCase from './test-resolver-application';
+import AbstractApplicationTestCase from './abstract-application';
+import { Resolver as DefaultResolver } from 'ember-application';
 import { Application } from 'ember-application';
-import { Router } from 'ember-routing';
+import {
+  setTemplates,
+  setTemplate
+} from 'ember-glimmer';
 import { assign } from 'ember-utils';
 import { runDestroy } from '../run';
 
-export default class ApplicationTestCase extends TestResolverApplicationTestCase {
-  constructor() {
-    super();
+export default class ApplicationTestCase extends AbstractApplicationTestCase {
 
-    let { applicationOptions } = this;
-    this.application = this.runTask(() => {
-      return Application.create(applicationOptions)
-    });
-
-    this.resolver = applicationOptions.Resolver.lastInstance;
-
-    if (this.resolver) {
-      this.resolver.add('router:main', Router.extend(this.routerOptions));
-    }
+  createApplication() {
+    return this.application = Application.create(this.applicationOptions);
   }
 
   get applicationOptions() {
     return assign(super.applicationOptions, {
-      autoboot: false
+      autoboot: false,
+      Resolver: DefaultResolver
     });
   }
 
   teardown() {
     runDestroy(this.applicationInstance);
     super.teardown();
+    setTemplates({});
   }
 
   visit(url, options) {
@@ -54,5 +50,12 @@ export default class ApplicationTestCase extends TestResolverApplicationTestCase
       return this.appRouter.transitionTo(...arguments);
     });
   }
+
+  addTemplate(name, templateString) {
+    let compiled = this.compile(templateString);
+    setTemplate(name, compiled);
+    return compiled;
+  }
+
 
 }

--- a/packages/internal-test-helpers/lib/test-cases/router.js
+++ b/packages/internal-test-helpers/lib/test-cases/router.js
@@ -1,4 +1,3 @@
-
 import ApplicationTestCase from './application';
 
 export default class RouterTestCase extends ApplicationTestCase {

--- a/packages/internal-test-helpers/lib/test-cases/test-resolver-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/test-resolver-application.js
@@ -1,0 +1,35 @@
+import AbstractApplicationTestCase from './abstract-application';
+import { ModuleBasedResolver } from '../test-resolver';
+import { assign } from 'ember-utils';
+
+export default class TestResolverApplicationTestCase extends AbstractApplicationTestCase {
+
+  get applicationOptions() {
+    return assign(super.applicationOptions, {
+      Resolver: ModuleBasedResolver
+    });
+  }
+
+  add(specifier, factory) {
+    this.resolver.add(specifier, factory);
+  }
+
+  addTemplate(templateName, templateString) {
+    this.resolver.add(`template:${templateName}`, this.compile(templateString, {
+      moduleName: templateName
+    }));
+  }
+
+  addComponent(name, { ComponentClass = null, template = null }) {
+    if (ComponentClass) {
+      this.resolver.add(`component:${name}`, ComponentClass);
+    }
+
+    if (typeof template === 'string') {
+      this.resolver.add(`template:components/${name}`, this.compile(template, {
+        moduleName: `components/${name}`
+      }));
+    }
+  }
+
+}


### PR DESCRIPTION
Refactor the test helpers to add an base class of `TestResolverApplicationTestCase` for `AutobootApplicationTestCase` and `ApplicationTestCase`, add a `DefaultResolverTestCase` that can be used for tests specifically targeting the default resolver.

Convert `custom_resolver_test`.

Refs: https://github.com/emberjs/ember.js/issues/15058