### PR TITLE
Clarify documentation for `.any` return value

### DIFF
--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -603,7 +603,9 @@ const Enumerable = Mixin.create({
 
   /**
     Returns `true` if the passed function returns true for any item in the
-    enumeration. This corresponds with the `some()` method in JavaScript 1.6.
+    enumeration. This corresponds with the `some()` method in JavaScript 1.6
+    except that if the callback function returns a value other than `true` or
+    `false` then that value will be returned by this function as well.
 
     The callback method you provide should have the following signature (all
     parameters are optional):


### PR DESCRIPTION
The note about corresponding to the `.some` method is slightly misleading. Though the concept is the same the behavior is different in cases where the callback function does not return `true` or `false`. (Admittedly, the documentation regarding the callback functions specifies that they **should** return `true` or `false` but not that they **must** so people may lazily assume that a truthy or falsey result is good enough.) See the examples below:

```
var a = Ember.A();
a.pushObject(Ember.Object.create());
var anyResult = a.any(x => null)
var someResult = a.some(x => null)
console.log(`Results: some -> ${someResult}; any -> ${anyResult}`); // Results: some -> false; any -> null
```

```
var i = 0, j = 0;
var a = Ember.A();
a.pushObject(Ember.Object.create());
a.pushObject(Ember.Object.create());
var anyResult = a.any(x => i++)
var someResult = a.some(x => j++)
console.log(`Results: some -> ${someResult}; any -> ${anyResult}; i = ${j}; i = ${j}`);
// Results: some -> true; any -> 1; i = 2; i = 2
```