### PR TITLE
Docs: resetController - add a use for transition

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -453,7 +453,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
 
     export default Ember.Route.extend({
       resetController(controller, isExiting, transition) {
-        if (isExiting) {
+        if (isExiting && transition.targetName !== 'error') {
           controller.set('page', 1);
         }
       }


### PR DESCRIPTION
I was debating with some folks if the transition belongs in resetController, and for the docs to have a use of it would seem beneficial in understanding.