### PR TITLE
Remove run loop from abstract click helper.

### DIFF
--- a/packages/internal-test-helpers/lib/test-cases/abstract.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract.js
@@ -88,7 +88,7 @@ export default class AbstractTestCase {
   }
 
   click(selector) {
-    this.runTask(() => this.$(selector).click());
+    return this.$(selector).click();
   }
 
   textValue() {


### PR DESCRIPTION
In #15358, we discovered that not returning visit functions was
causing us to use unecessary run loops. A click event shouldn't
need to be scheduled in the run loop, and when that is something
else is going wrong.