### PR TITLE
avoid extra checks for `lookupDescriptor` return value

### DIFF
--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -480,9 +480,7 @@ if (MANDATORY_SETTER) {
 
   Meta.prototype.writeValue = function(obj, key, value) {
     let descriptor = lookupDescriptor(obj, key);
-    let isMandatorySetter = descriptor !== undefined &&
-                            descriptor !== null &&
-                            descriptor.set && descriptor.set.isMandatorySetter;
+    let isMandatorySetter = descriptor !== null && descriptor.set && descriptor.set.isMandatorySetter;
 
     if (isMandatorySetter) {
       this.writeValues(key, value);

--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -56,7 +56,6 @@ export function set(obj, keyName, value, tolerant) {
     assert('setUnknownProperty must be a function', typeof obj.setUnknownProperty === 'function');
     obj.setUnknownProperty(keyName, value);
   } else if (currentValue === value) { /* no change */
-    return value;
   } else {
     let meta = peekMeta(obj);
     propertyWillChange(obj, keyName, meta);

--- a/packages/ember-metal/lib/watch_key.js
+++ b/packages/ember-metal/lib/watch_key.js
@@ -50,10 +50,11 @@ if (MANDATORY_SETTER) {
   // ember strip this entire block out
   handleMandatorySetter = function handleMandatorySetter(m, obj, keyName) {
     let descriptor = lookupDescriptor(obj, keyName);
-    let configurable = descriptor ? descriptor.configurable : true;
-    let isWritable = descriptor ? descriptor.writable : true;
-    let hasValue = descriptor ? 'value' in descriptor : true;
-    let possibleDesc = descriptor && descriptor.value;
+    let hasDescriptor = descriptor !== null;
+    let configurable = hasDescriptor ? descriptor.configurable : true;
+    let isWritable = hasDescriptor ? descriptor.writable : true;
+    let hasValue = hasDescriptor ? 'value' in descriptor : true;
+    let possibleDesc = hasDescriptor && descriptor.value;
     let isDescriptor = possibleDesc !== null &&
                        typeof possibleDesc === 'object' &&
                        possibleDesc.isDescriptor;


### PR DESCRIPTION
`lookupDescriptor` returns either `null` or `hash` so no need for `undefined` check