### PR TITLE
[FEATURE ember-routing-router-service] isActive and Cleanup 

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -1045,7 +1045,7 @@ function commonSetupRegistry(registry) {
 
   if (EMBER_ROUTING_ROUTER_SERVICE) {
     registry.register('service:router', RouterService);
-    registry.injection('service:router', 'router', 'router:main');
+    registry.injection('service:router', '_router', 'router:main');
   }
 }
 

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -873,7 +873,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
         qp.serializedValue = svalue;
 
         let thisQueryParamHasDefaultValue = (qp.serializedDefaultValue === svalue);
-        if (!thisQueryParamHasDefaultValue) {
+        if (!thisQueryParamHasDefaultValue || transition._keepDefaultQueryParamValues) {
           finalParams.push({
             value: svalue,
             visible: true,

--- a/packages/ember-routing/lib/system/router_state.js
+++ b/packages/ember-routing/lib/system/router_state.js
@@ -8,6 +8,7 @@ export default EmberObject.extend({
   routerJsState: null,
 
   isActiveIntent(routeName, models, queryParams, queryParamsMustMatch) {
+    debugger;
     let state = this.routerJsState;
     if (!this.routerJs.isActiveIntent(routeName, models, null, state)) { return false; }
 

--- a/packages/ember-routing/lib/system/router_state.js
+++ b/packages/ember-routing/lib/system/router_state.js
@@ -8,7 +8,6 @@ export default EmberObject.extend({
   routerJsState: null,
 
   isActiveIntent(routeName, models, queryParams, queryParamsMustMatch) {
-    debugger;
     let state = this.routerJsState;
     if (!this.routerJs.isActiveIntent(routeName, models, null, state)) { return false; }
 

--- a/packages/ember/tests/routing/router_service_test/isActive_test.js
+++ b/packages/ember/tests/routing/router_service_test/isActive_test.js
@@ -1,0 +1,243 @@
+import {
+  Controller,
+  inject,
+  String
+} from 'ember-runtime';
+import { Component } from 'ember-glimmer';
+import { Route, NoneLocation } from 'ember-routing';
+import {
+  get,
+  set
+} from 'ember-metal';
+import {
+  RouterTestCase,
+  moduleFor
+} from 'internal-test-helpers';
+
+import { EMBER_ROUTING_ROUTER_SERVICE } from 'ember/features';
+
+if (EMBER_ROUTING_ROUTER_SERVICE) {
+  moduleFor('Router Service - isActive', class extends RouterTestCase {
+    ['@test RouterService#isActive returns true for simple route'](assert) {
+      assert.expect(1);
+
+      return this.visit('/')
+        .then(() => {
+          return this.routerService.transitionTo('parent.child');
+        })
+        .then(() => {
+          return this.routerService.transitionTo('parent.sister');
+        })
+        .then(() => {
+          assert.ok(this.routerService.isActive('parent.sister'));
+        });
+    }
+
+    ['@test RouterService#isActive returns true for simple route with dynamic segments'](assert) {
+      assert.expect(1);
+
+      let dynamicModel = { id: 1 };
+
+      return this.visit('/')
+        .then(() => {
+          return this.routerService.transitionTo('dynamic', dynamicModel);
+        })
+        .then(() => {
+          assert.ok(this.routerService.isActive('dynamic', dynamicModel));
+        });
+    }
+
+    ['@test RouterService#urlFor returns URL for simple route with basic query params'](assert) {
+      assert.expect(2);
+
+      let queryParams = this.buildQueryParams({ sort: 'ASC' });
+
+      this.registerController('parent.child', Controller.extend({
+          queryParams: ['sort'],
+          sort: 'ASC'
+        })
+      );
+      debugger;
+      return this.visit('/')
+        .then(() => {
+          return this.routerService.transitionTo('parent.child', queryParams);
+        })
+        .then(() => {
+          assert.ok(this.routerService.isActive('parent.child', queryParams));
+          assert.notOk(this.routerService.isActive('parent.child', this.buildQueryParams({ sort: 'DESC' })));
+        });
+    }
+
+    ['@test RouterService#urlFor returns URL for simple route with array as query params'](assert) {
+      assert.expect(1);
+
+      let queryParams = this.buildQueryParams({ sort: ['ascending'] });
+
+      return this.visit('/')
+        .then(() => {
+          return this.routerService.transitionTo('parent.child', queryParams);
+        })
+        .then(() => {
+          assert.ok(this.routerService.isActive('parent.child', this.buildQueryParams({ sort: 'descending' })));
+        });
+    }
+
+    // ['@test RouterService#urlFor returns URL for simple route with null query params'](assert) {
+    //   assert.expect(1);
+
+    //   let queryParams = buildQueryParams({ foo: null });
+
+    //   return this.visit('/').then(() => {
+    //     let expectedURL = this.routerService.urlFor('parent.child', queryParams);
+
+    //     assert.equal('/child', expectedURL);
+    //   });
+    // }
+
+    // ['@test RouterService#urlFor returns URL for simple route with undefined query params'](assert) {
+    //   assert.expect(1);
+
+    //   let queryParams = buildQueryParams({ foo: undefined });
+
+    //   return this.visit('/').then(() => {
+    //     let expectedURL = this.routerService.urlFor('parent.child', queryParams);
+
+    //     assert.equal('/child', expectedURL);
+    //   });
+    // }
+
+    // ['@test RouterService#urlFor returns URL for simple route with dynamic segments and basic query params'](assert) {
+    //   assert.expect(1);
+
+    //   let queryParams = buildQueryParams({ foo: 'bar' });
+
+    //   return this.visit('/').then(() => {
+    //     let expectedURL = this.routerService.urlFor('dynamic', { id: 1 }, queryParams);
+
+    //     assert.equal('/dynamic/1?foo=bar', expectedURL);
+    //   });
+    // }
+
+    // ['@test RouterService#urlFor returns URL for simple route with dynamic segments and array as query params'](assert) {
+    //   assert.expect(1);
+
+    //   let queryParams = buildQueryParams({ selectedItems: ['a', 'b', 'c'] });
+
+    //   return this.visit('/').then(() => {
+    //     let expectedURL = this.routerService.urlFor('dynamic', { id: 1 }, queryParams);
+
+    //     assert.equal('/dynamic/1?selectedItems[]=a&selectedItems[]=b&selectedItems[]=c', expectedURL);
+    //   });
+    // }
+
+    // ['@test RouterService#urlFor returns URL for simple route with dynamic segments and null query params'](assert) {
+    //   assert.expect(1);
+
+    //   let queryParams = buildQueryParams({ foo: null });
+
+    //   return this.visit('/').then(() => {
+    //     let expectedURL = this.routerService.urlFor('dynamic', { id: 1 }, queryParams);
+
+    //     assert.equal('/dynamic/1', expectedURL);
+    //   });
+    // }
+
+    // ['@test RouterService#urlFor returns URL for simple route with dynamic segments and undefined query params'](assert) {
+    //   assert.expect(1);
+
+    //   let queryParams = buildQueryParams({ foo: undefined });
+
+    //   return this.visit('/').then(() => {
+    //     let expectedURL = this.routerService.urlFor('dynamic', { id: 1 }, queryParams);
+
+    //     assert.equal('/dynamic/1', expectedURL);
+    //   });
+    // }
+
+    // ['@test RouterService#urlFor correctly transitions to route via generated path'](assert) {
+    //   assert.expect(1);
+
+    //   let expectedURL;
+
+    //   return this.visit('/')
+    //     .then(() => {
+    //       expectedURL = this.routerService.urlFor('parent.child');
+
+    //       return this.routerService.transitionTo(expectedURL);
+    //     })
+    //     .then(() => {
+    //       assert.equal(expectedURL, this.routerService.get('currentURL'));
+    //     });
+    // }
+
+    // ['@test RouterService#urlFor correctly transitions to route via generated path with dynamic segments'](assert) {
+    //   assert.expect(1);
+
+    //   let expectedURL;
+    //   let dynamicModel = { id: 1 };
+
+    //   this.registerRoute('dynamic', Route.extend({
+    //     model() {
+    //       return dynamicModel;
+    //     }
+    //   }));
+
+    //   return this.visit('/')
+    //     .then(() => {
+    //       expectedURL = this.routerService.urlFor('dynamic', dynamicModel);
+
+    //       return this.routerService.transitionTo(expectedURL);
+    //     })
+    //     .then(() => {
+    //       assert.equal(expectedURL, this.routerService.get('currentURL'));
+    //     });
+    // }
+
+    // ['@test RouterService#urlFor correctly transitions to route via generated path with query params'](assert) {
+    //   assert.expect(1);
+
+    //   let expectedURL;
+    //   let actualURL;
+    //   let queryParams = buildQueryParams({ foo: 'bar' });
+
+    //   return this.visit('/')
+    //     .then(() => {
+    //       expectedURL = this.routerService.urlFor('parent.child', queryParams);
+
+    //       return this.routerService.transitionTo(expectedURL);
+    //     })
+    //     .then(() => {
+    //       actualURL = `${this.routerService.get('currentURL')}?foo=bar`;
+
+    //       assert.equal(expectedURL, actualURL);
+    //     });
+    // }
+
+    // ['@test RouterService#urlFor correctly transitions to route via generated path with dynamic segments and query params'](assert) {
+    //   assert.expect(1);
+
+    //   let expectedURL;
+    //   let actualURL;
+    //   let queryParams = buildQueryParams({ foo: 'bar' });
+    //   let dynamicModel = { id: 1 };
+
+    //   this.registerRoute('dynamic', Route.extend({
+    //     model() {
+    //       return dynamicModel;
+    //     }
+    //   }));
+
+    //   return this.visit('/')
+    //     .then(() => {
+    //       expectedURL = this.routerService.urlFor('dynamic', dynamicModel, queryParams);
+
+    //       return this.routerService.transitionTo(expectedURL);
+    //     })
+    //     .then(() => {
+    //       actualURL = `${this.routerService.get('currentURL')}?foo=bar`;
+
+    //       assert.equal(expectedURL, actualURL);
+    //     });
+    // }
+  });
+}

--- a/packages/ember/tests/routing/router_service_test/isActive_test.js
+++ b/packages/ember/tests/routing/router_service_test/isActive_test.js
@@ -47,17 +47,41 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
         });
     }
 
-    ['@test RouterService#urlFor returns URL for simple route with basic query params'](assert) {
+    ['@test RouterService#isActive does not eagerly instantiate controller for query params'](assert) {
+      assert.expect(1);
+
+      let queryParams = this.buildQueryParams({ sort: 'ASC' });
+
+      this.add('controller:parent.sister', Controller.extend({
+        queryParams: ['sort'],
+        sort: 'ASC',
+
+        init() {
+          assert.ok(false, 'should never create');
+          this._super(...arguments);
+        }
+      }));
+
+      return this.visit('/')
+        .then(() => {
+          return this.routerService.transitionTo('parent.brother');
+        })
+        .then(() => {
+          assert.notOk(this.routerService.isActive('parent.sister', queryParams));
+        });
+    }
+
+    ['@test RouterService#isActive is correct for simple route with basic query params'](assert) {
       assert.expect(2);
 
       let queryParams = this.buildQueryParams({ sort: 'ASC' });
 
-      this.registerController('parent.child', Controller.extend({
-          queryParams: ['sort'],
-          sort: 'ASC'
-        })
-      );
-      debugger;
+      this.add('controller:parent.child', Controller.extend({
+        queryParams: ['sort'],
+        sort: 'ASC'
+      })
+              );
+
       return this.visit('/')
         .then(() => {
           return this.routerService.transitionTo('parent.child', queryParams);
@@ -68,7 +92,7 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
         });
     }
 
-    ['@test RouterService#urlFor returns URL for simple route with array as query params'](assert) {
+    ['@test RouterService#isActive for simple route with array as query params'](assert) {
       assert.expect(1);
 
       let queryParams = this.buildQueryParams({ sort: ['ascending'] });
@@ -78,166 +102,8 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
           return this.routerService.transitionTo('parent.child', queryParams);
         })
         .then(() => {
-          assert.ok(this.routerService.isActive('parent.child', this.buildQueryParams({ sort: 'descending' })));
+          assert.notOk(this.routerService.isActive('parent.child', this.buildQueryParams({ sort: 'descending' })));
         });
     }
-
-    // ['@test RouterService#urlFor returns URL for simple route with null query params'](assert) {
-    //   assert.expect(1);
-
-    //   let queryParams = buildQueryParams({ foo: null });
-
-    //   return this.visit('/').then(() => {
-    //     let expectedURL = this.routerService.urlFor('parent.child', queryParams);
-
-    //     assert.equal('/child', expectedURL);
-    //   });
-    // }
-
-    // ['@test RouterService#urlFor returns URL for simple route with undefined query params'](assert) {
-    //   assert.expect(1);
-
-    //   let queryParams = buildQueryParams({ foo: undefined });
-
-    //   return this.visit('/').then(() => {
-    //     let expectedURL = this.routerService.urlFor('parent.child', queryParams);
-
-    //     assert.equal('/child', expectedURL);
-    //   });
-    // }
-
-    // ['@test RouterService#urlFor returns URL for simple route with dynamic segments and basic query params'](assert) {
-    //   assert.expect(1);
-
-    //   let queryParams = buildQueryParams({ foo: 'bar' });
-
-    //   return this.visit('/').then(() => {
-    //     let expectedURL = this.routerService.urlFor('dynamic', { id: 1 }, queryParams);
-
-    //     assert.equal('/dynamic/1?foo=bar', expectedURL);
-    //   });
-    // }
-
-    // ['@test RouterService#urlFor returns URL for simple route with dynamic segments and array as query params'](assert) {
-    //   assert.expect(1);
-
-    //   let queryParams = buildQueryParams({ selectedItems: ['a', 'b', 'c'] });
-
-    //   return this.visit('/').then(() => {
-    //     let expectedURL = this.routerService.urlFor('dynamic', { id: 1 }, queryParams);
-
-    //     assert.equal('/dynamic/1?selectedItems[]=a&selectedItems[]=b&selectedItems[]=c', expectedURL);
-    //   });
-    // }
-
-    // ['@test RouterService#urlFor returns URL for simple route with dynamic segments and null query params'](assert) {
-    //   assert.expect(1);
-
-    //   let queryParams = buildQueryParams({ foo: null });
-
-    //   return this.visit('/').then(() => {
-    //     let expectedURL = this.routerService.urlFor('dynamic', { id: 1 }, queryParams);
-
-    //     assert.equal('/dynamic/1', expectedURL);
-    //   });
-    // }
-
-    // ['@test RouterService#urlFor returns URL for simple route with dynamic segments and undefined query params'](assert) {
-    //   assert.expect(1);
-
-    //   let queryParams = buildQueryParams({ foo: undefined });
-
-    //   return this.visit('/').then(() => {
-    //     let expectedURL = this.routerService.urlFor('dynamic', { id: 1 }, queryParams);
-
-    //     assert.equal('/dynamic/1', expectedURL);
-    //   });
-    // }
-
-    // ['@test RouterService#urlFor correctly transitions to route via generated path'](assert) {
-    //   assert.expect(1);
-
-    //   let expectedURL;
-
-    //   return this.visit('/')
-    //     .then(() => {
-    //       expectedURL = this.routerService.urlFor('parent.child');
-
-    //       return this.routerService.transitionTo(expectedURL);
-    //     })
-    //     .then(() => {
-    //       assert.equal(expectedURL, this.routerService.get('currentURL'));
-    //     });
-    // }
-
-    // ['@test RouterService#urlFor correctly transitions to route via generated path with dynamic segments'](assert) {
-    //   assert.expect(1);
-
-    //   let expectedURL;
-    //   let dynamicModel = { id: 1 };
-
-    //   this.registerRoute('dynamic', Route.extend({
-    //     model() {
-    //       return dynamicModel;
-    //     }
-    //   }));
-
-    //   return this.visit('/')
-    //     .then(() => {
-    //       expectedURL = this.routerService.urlFor('dynamic', dynamicModel);
-
-    //       return this.routerService.transitionTo(expectedURL);
-    //     })
-    //     .then(() => {
-    //       assert.equal(expectedURL, this.routerService.get('currentURL'));
-    //     });
-    // }
-
-    // ['@test RouterService#urlFor correctly transitions to route via generated path with query params'](assert) {
-    //   assert.expect(1);
-
-    //   let expectedURL;
-    //   let actualURL;
-    //   let queryParams = buildQueryParams({ foo: 'bar' });
-
-    //   return this.visit('/')
-    //     .then(() => {
-    //       expectedURL = this.routerService.urlFor('parent.child', queryParams);
-
-    //       return this.routerService.transitionTo(expectedURL);
-    //     })
-    //     .then(() => {
-    //       actualURL = `${this.routerService.get('currentURL')}?foo=bar`;
-
-    //       assert.equal(expectedURL, actualURL);
-    //     });
-    // }
-
-    // ['@test RouterService#urlFor correctly transitions to route via generated path with dynamic segments and query params'](assert) {
-    //   assert.expect(1);
-
-    //   let expectedURL;
-    //   let actualURL;
-    //   let queryParams = buildQueryParams({ foo: 'bar' });
-    //   let dynamicModel = { id: 1 };
-
-    //   this.registerRoute('dynamic', Route.extend({
-    //     model() {
-    //       return dynamicModel;
-    //     }
-    //   }));
-
-    //   return this.visit('/')
-    //     .then(() => {
-    //       expectedURL = this.routerService.urlFor('dynamic', dynamicModel, queryParams);
-
-    //       return this.routerService.transitionTo(expectedURL);
-    //     })
-    //     .then(() => {
-    //       actualURL = `${this.routerService.get('currentURL')}?foo=bar`;
-
-    //       assert.equal(expectedURL, actualURL);
-    //     });
-    // }
   });
 }

--- a/packages/ember/tests/routing/router_service_test/replaceWith_test.js
+++ b/packages/ember/tests/routing/router_service_test/replaceWith_test.js
@@ -4,6 +4,7 @@ import {
   moduleFor
 } from 'internal-test-helpers';
 import { Transition } from 'router';
+import { Controller } from 'ember-runtime';
 
 import { EMBER_ROUTING_ROUTER_SERVICE } from 'ember/features';
 
@@ -103,6 +104,31 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
         })
         .then(() => {
           assert.deepEqual(this.state, ['/', '/child', '/sister', '/sister']);
+        });
+    }
+
+    ['@test RouterService#replaceWith with basic query params does not remove query param defaults'](assert) {
+      assert.expect(1);
+
+      this.add('controller:parent.child', Controller.extend({
+        queryParams: ['sort'],
+        sort: 'ASC'
+      }));
+
+      let queryParams = this.buildQueryParams({ sort: 'ASC' });
+
+      return this.visit('/')
+        .then(() => {
+          return this.routerService.transitionTo('parent.brother');
+        })
+        .then(() => {
+          return this.routerService.replaceWith('parent.sister');
+        })
+        .then(() => {
+          return this.routerService.replaceWith('parent.child', queryParams);
+        })
+        .then(() => {
+          assert.deepEqual(this.state, ['/', '/child?sort=ASC']);
         });
     }
   });

--- a/packages/ember/tests/routing/router_service_test/transitionTo_test.js
+++ b/packages/ember/tests/routing/router_service_test/transitionTo_test.js
@@ -1,6 +1,7 @@
 import { inject } from 'ember-runtime';
 import { Component } from 'ember-glimmer';
 import { Route, NoneLocation } from 'ember-routing';
+import { Controller } from 'ember-runtime';
 import {
   run,
   get,
@@ -234,6 +235,63 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
         assert.equal(this.routerService.get('currentRouteName'), 'dynamic');
         assert.equal(this.routerService.get('currentURL'), '/dynamic/1');
         this.assertText('much dynamicism');
+      });
+    }
+
+    ['@test RouterService#transitionTo with basic query params does not remove query param defaults'](assert) {
+      assert.expect(1);
+
+      this.add('controller:parent.child', Controller.extend({
+        queryParams: ['sort'],
+        sort: 'ASC'
+      }));
+
+      let queryParams = this.buildQueryParams({ sort: 'ASC' });
+
+      return this.visit('/').then(() => {
+        return this.routerService.transitionTo('parent.child', queryParams);
+      })
+        .then(() => {
+          assert.equal(this.routerService.get('currentURL'), '/child?sort=ASC');
+        });
+    }
+
+    ['@test RouterService#transitionTo with aliased query params uses the original provided key'](assert) {
+      assert.expect(1);
+
+      this.add('controller:parent.child', Controller.extend({
+        queryParams: {
+          'cont_sort': 'url_sort'
+        },
+        cont_sort: 'ASC'
+      }));
+
+      let queryParams = this.buildQueryParams({ url_sort: 'ASC' });
+
+      return this.visit('/').then(() => {
+        return this.routerService.transitionTo('parent.child', queryParams);
+      })
+        .then(() => {
+          assert.equal(this.routerService.get('currentURL'), '/child?url_sort=ASC');
+        });
+    }
+
+    ['@test RouterService#transitionTo with aliased query params uses the original provided key when controller property name'](assert) {
+      assert.expect(1);
+
+      this.add('controller:parent.child', Controller.extend({
+        queryParams: {
+          'cont_sort': 'url_sort'
+        },
+        cont_sort: 'ASC'
+      }));
+
+      let queryParams = this.buildQueryParams({ cont_sort: 'ASC' });
+
+      return this.visit('/').then(() => {
+        expectAssertion(() => {
+          return this.routerService.transitionTo('parent.child', queryParams);
+        }, 'You passed the `cont_sort` query parameter during a transition into parent.child, please update to url_sort');
       });
     }
   });

--- a/packages/ember/tests/routing/router_service_test/urlFor_test.js
+++ b/packages/ember/tests/routing/router_service_test/urlFor_test.js
@@ -63,6 +63,44 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
       });
     }
 
+    ['@test RouterService#urlFor returns URL for simple route with basic query params and default value'](assert) {
+      assert.expect(1);
+
+      this.add('controller:parent.child', Controller.extend({
+        queryParams: ['sort'],
+        sort: 'ASC'
+      }));
+
+      let queryParams = this.buildQueryParams({ sort: 'ASC' });
+
+      return this.visit('/').then(() => {
+        let expectedURL = this.routerService.urlFor('parent.child', queryParams);
+
+        assert.equal('/child?sort=ASC', expectedURL);
+      });
+    }
+
+    ['@test RouterService#urlFor returns URL for simple route with basic query params and default value with stickyness'](assert) {
+      assert.expect(2);
+
+      this.add('controller:parent.child', Controller.extend({
+        queryParams: ['sort', 'foo'],
+        sort: 'ASC'
+      }));
+
+      let queryParams = this.buildQueryParams({ sort: 'DESC' });
+
+      return this.visit('/child/?sort=DESC').then(() => {
+        let controller = this.applicationInstance.lookup('controller:parent.child');
+        assert.equal(get(controller, 'sort'), 'DESC', 'sticky is set');
+
+        let queryParams = this.buildQueryParams({ foo: 'derp' });
+        let actual = this.routerService.urlFor('parent.child', queryParams);
+
+        assert.equal(actual, '/child?foo=derp', 'does not use "stickiness"');
+      });
+    }
+
     ['@test RouterService#urlFor returns URL for simple route with array as query params'](assert) {
       assert.expect(1);
 

--- a/packages/ember/tests/routing/router_service_test/urlFor_test.js
+++ b/packages/ember/tests/routing/router_service_test/urlFor_test.js
@@ -3,7 +3,6 @@ import {
   inject,
   String
 } from 'ember-runtime';
-import { Component } from 'ember-glimmer';
 import { Route, NoneLocation } from 'ember-routing';
 import {
   get,
@@ -24,12 +23,6 @@ function setupController(app, name) {
       throw new Error(`Generating a URL should not require instantiation of a ${controllerName}.`);
     }
   });
-}
-
-function buildQueryParams(queryParams) {
-  return {
-    queryParams
-  };
 }
 
 if (EMBER_ROUTING_ROUTER_SERVICE) {
@@ -61,7 +54,7 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
     ['@test RouterService#urlFor returns URL for simple route with basic query params'](assert) {
       assert.expect(1);
 
-      let queryParams = buildQueryParams({ foo: 'bar' });
+      let queryParams = this.buildQueryParams({ foo: 'bar' });
 
       return this.visit('/').then(() => {
         let expectedURL = this.routerService.urlFor('parent.child', queryParams);
@@ -73,7 +66,7 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
     ['@test RouterService#urlFor returns URL for simple route with array as query params'](assert) {
       assert.expect(1);
 
-      let queryParams = buildQueryParams({ selectedItems: ['a', 'b', 'c'] });
+      let queryParams = this.buildQueryParams({ selectedItems: ['a', 'b', 'c'] });
 
       return this.visit('/').then(() => {
         let expectedURL = this.routerService.urlFor('parent.child', queryParams);
@@ -85,7 +78,7 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
     ['@test RouterService#urlFor returns URL for simple route with null query params'](assert) {
       assert.expect(1);
 
-      let queryParams = buildQueryParams({ foo: null });
+      let queryParams = this.buildQueryParams({ foo: null });
 
       return this.visit('/').then(() => {
         let expectedURL = this.routerService.urlFor('parent.child', queryParams);
@@ -97,7 +90,7 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
     ['@test RouterService#urlFor returns URL for simple route with undefined query params'](assert) {
       assert.expect(1);
 
-      let queryParams = buildQueryParams({ foo: undefined });
+      let queryParams = this.buildQueryParams({ foo: undefined });
 
       return this.visit('/').then(() => {
         let expectedURL = this.routerService.urlFor('parent.child', queryParams);
@@ -109,7 +102,7 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
     ['@test RouterService#urlFor returns URL for simple route with dynamic segments and basic query params'](assert) {
       assert.expect(1);
 
-      let queryParams = buildQueryParams({ foo: 'bar' });
+      let queryParams = this.buildQueryParams({ foo: 'bar' });
 
       return this.visit('/').then(() => {
         let expectedURL = this.routerService.urlFor('dynamic', { id: 1 }, queryParams);
@@ -121,7 +114,7 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
     ['@test RouterService#urlFor returns URL for simple route with dynamic segments and array as query params'](assert) {
       assert.expect(1);
 
-      let queryParams = buildQueryParams({ selectedItems: ['a', 'b', 'c'] });
+      let queryParams = this.buildQueryParams({ selectedItems: ['a', 'b', 'c'] });
 
       return this.visit('/').then(() => {
         let expectedURL = this.routerService.urlFor('dynamic', { id: 1 }, queryParams);
@@ -133,7 +126,7 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
     ['@test RouterService#urlFor returns URL for simple route with dynamic segments and null query params'](assert) {
       assert.expect(1);
 
-      let queryParams = buildQueryParams({ foo: null });
+      let queryParams = this.buildQueryParams({ foo: null });
 
       return this.visit('/').then(() => {
         let expectedURL = this.routerService.urlFor('dynamic', { id: 1 }, queryParams);
@@ -145,7 +138,7 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
     ['@test RouterService#urlFor returns URL for simple route with dynamic segments and undefined query params'](assert) {
       assert.expect(1);
 
-      let queryParams = buildQueryParams({ foo: undefined });
+      let queryParams = this.buildQueryParams({ foo: undefined });
 
       return this.visit('/').then(() => {
         let expectedURL = this.routerService.urlFor('dynamic', { id: 1 }, queryParams);
@@ -198,7 +191,7 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
 
       let expectedURL;
       let actualURL;
-      let queryParams = buildQueryParams({ foo: 'bar' });
+      let queryParams = this.buildQueryParams({ foo: 'bar' });
 
       return this.visit('/')
         .then(() => {
@@ -218,7 +211,7 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
 
       let expectedURL;
       let actualURL;
-      let queryParams = buildQueryParams({ foo: 'bar' });
+      let queryParams = this.buildQueryParams({ foo: 'bar' });
       let dynamicModel = { id: 1 };
 
       this.add('route:dynamic', Route.extend({

--- a/packages/internal-test-helpers/lib/test-cases/router.js
+++ b/packages/internal-test-helpers/lib/test-cases/router.js
@@ -17,4 +17,10 @@ export default class RouterTestCase extends ApplicationTestCase {
   get routerService() {
     return this.applicationInstance.lookup('service:router');
   }
+
+  buildQueryParams(queryParams) {
+    return {
+      queryParams
+    };
+  }
 }


### PR DESCRIPTION
* Adding isActive.
* Ensure that `routerService.transitionTo` and `routerService.replaceWith`
  does not elide query params (even the are the default values).
* Update implementation of `routerService.isActive` to handle query params.
* Ensure that the `router:main` injection property into the routerService is
  at `_router`.
* Remove `routerService.currentState`
* Add tests around various query param edge cases with `transitionTo` / `replaceWith`

Most of the work here is @scalvert's (thank you!!). 

I paired with @ef4 at the F2F today to confirm the semantics match the router service RFC, and fix-up some edge cases around `isActive` / `transitionTo` / `replaceWith`.