### PR TITLE
[FEATURE ember-routing-router-service] Enable by default.

### DIFF
--- a/features.json
+++ b/features.json
@@ -5,7 +5,7 @@
     "ember-improved-instrumentation": null,
     "ember-metal-weakmap": null,
     "ember-glimmer-allow-backtracking-rerender": null,
-    "ember-routing-router-service": null,
+    "ember-routing-router-service": true,
     "ember-engines-mount-params": true,
     "glimmer-custom-component-manager": null
   },


### PR DESCRIPTION
Enables the first phase of the routing service by default. 

The service implements all proposed API's (with the proposed semantics) that are not returning RouteInfo objects (that will come in a later stage).