### PR TITLE
[DEPRECATION] update dispatch to event manager deprecation until version 2.17.0

### DIFF
--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -412,7 +412,7 @@ export default Mixin.create({
         false,
         {
           id: 'ember-views.event-dispatcher.canDispatchToEventManager',
-          until: '2.16.0'
+          until: '2.17.0'
         }
       );
 

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -143,7 +143,7 @@ export default EmberObject.extend({
       !('canDispatchToEventManager' in this),
       {
         id: 'ember-views.event-dispatcher.canDispatchToEventManager',
-        until: '2.16.0'
+        until: '2.17.0'
       }
     );
   },


### PR DESCRIPTION
part of https://github.com/emberjs/website/pull/2914#issuecomment-311255869

<img width="840" alt="screen shot 2017-06-27 at 09 24 35" src="https://user-images.githubusercontent.com/2526/27577964-759ff92e-5b1a-11e7-85a0-b1064eabc0e4.png">

