### PR TITLE
Decouple transitioning CSS classes tests from global resolver.

### DIFF
--- a/packages/ember/tests/helpers/link_to_test/link_to_transitioning_classes_test.js
+++ b/packages/ember/tests/helpers/link_to_test/link_to_transitioning_classes_test.js
@@ -1,200 +1,244 @@
 import { RSVP } from 'ember-runtime';
-import { Route, NoneLocation } from 'ember-routing';
-import { run, set } from 'ember-metal';
-import { compile } from 'ember-template-compiler';
-import { Application } from 'ember-application';
-import { jQuery } from 'ember-views';
-import { setTemplates, setTemplate } from 'ember-glimmer';
+import { Route } from 'ember-routing';
+import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
 
-let Router, App, registry, container;
+function assertHasClass(assert, selector, label) {
+  let testLabel = `${selector.attr('id')} should have class ${label}`;
 
-let aboutDefer, otherDefer;
-
-function bootApplication() {
-  container.lookup('router:main');
-  run(App, 'advanceReadiness');
+  assert.equal(selector.hasClass(label), true, testLabel);
 }
 
-function assertHasClass(className) {
-  let i = 1;
-  while (i < arguments.length) {
-    let $a = arguments[i];
-    let shouldHaveClass = arguments[i + 1];
-    equal($a.hasClass(className), shouldHaveClass, $a.attr('id') + ' should ' + (shouldHaveClass ? '' : 'not ') + 'have class ' + className);
-    i += 2;
-  }
+function assertHasNoClass(assert, selector, label) {
+  let testLabel = `${selector.attr('id')} should not have class ${label}`;
+
+  assert.equal(selector.hasClass(label), false, testLabel);
 }
 
-let updateCount, replaceCount;
+moduleFor('The {{link-to}} helper: .transitioning-in .transitioning-out CSS classes', class extends ApplicationTestCase {
+  constructor() {
+    super();
 
-function sharedSetup() {
-  App = Application.create({
-    name: 'App',
-    rootElement: '#qunit-fixture'
-  });
+    this.aboutDefer = RSVP.defer();
+    this.otherDefer = RSVP.defer();
+    let _this = this;
 
-  App.deferReadiness();
-
-  updateCount = replaceCount = 0;
-  App.Router.reopen({
-    location: NoneLocation.create({
-      setURL(path) {
-        updateCount++;
-        set(this, 'path', path);
-      },
-
-      replaceURL(path) {
-        replaceCount++;
-        set(this, 'path', path);
-      }
-    })
-  });
-
-  Router = App.Router;
-  registry = App.__registry__;
-  container = App.__container__;
-}
-
-function sharedTeardown() {
-  run(() => App.destroy());
-  setTemplates({});
-}
-
-
-QUnit.module('The {{link-to}} helper: .transitioning-in .transitioning-out CSS classes', {
-  setup() {
-    run(() => {
-      sharedSetup();
-
-      registry.unregister('router:main');
-      registry.register('router:main', Router);
-
-      Router.map(function() {
-        this.route('about');
-        this.route('other');
-      });
-
-      App.AboutRoute = Route.extend({
-        model() {
-          aboutDefer = RSVP.defer();
-          return aboutDefer.promise;
-        }
-      });
-
-      App.OtherRoute = Route.extend({
-        model() {
-          otherDefer = RSVP.defer();
-          return otherDefer.promise;
-        }
-      });
-
-      setTemplate('application', compile('{{outlet}}{{link-to \'Index\' \'index\' id=\'index-link\'}}{{link-to \'About\' \'about\' id=\'about-link\'}}{{link-to \'Other\' \'other\' id=\'other-link\'}}'));
-    });
-  },
-
-  teardown() {
-    sharedTeardown();
-    aboutDefer = null;
-  }
-});
-
-QUnit.test('while a transition is underway', function() {
-  expect(18);
-  bootApplication();
-
-  let $index = jQuery('#index-link');
-  let $about = jQuery('#about-link');
-  let $other = jQuery('#other-link');
-
-  run($about, 'click');
-
-  assertHasClass('active', $index, true, $about, false, $other, false);
-  assertHasClass('ember-transitioning-in', $index, false, $about, true, $other, false);
-  assertHasClass('ember-transitioning-out', $index, true, $about, false, $other, false);
-
-  run(aboutDefer, 'resolve');
-
-  assertHasClass('active', $index, false, $about, true, $other, false);
-  assertHasClass('ember-transitioning-in', $index, false, $about, false, $other, false);
-  assertHasClass('ember-transitioning-out', $index, false, $about, false, $other, false);
-});
-
-QUnit.test('while a transition is underway with nested link-to\'s', function() {
-  expect(54);
-
-  Router.map(function() {
-    this.route('parent-route', function() {
+    this.router.map(function() {
       this.route('about');
       this.route('other');
     });
-  });
 
-  App.ParentRouteAboutRoute = Route.extend({
-    model() {
-      aboutDefer = RSVP.defer();
-      return aboutDefer.promise;
-    }
-  });
+    this.add('route:about', Route.extend({
+      model() {
+        return _this.aboutDefer.promise;
+      }
+    }));
 
-  App.ParentRouteOtherRoute = Route.extend({
-    model() {
-      otherDefer = RSVP.defer();
-      return otherDefer.promise;
-    }
-  });
+    this.add('route:other', Route.extend({
+      model() {
+        return _this.otherDefer.promise;
+      }
+    }));
 
-  setTemplate('application', compile(`
-    {{outlet}}
-    {{#link-to 'index' tagName='li'}}
+    this.addTemplate('application',`
+      {{outlet}}
       {{link-to 'Index' 'index' id='index-link'}}
-    {{/link-to}}
-    {{#link-to 'parent-route.about' tagName='li'}}
-      {{link-to 'About' 'parent-route.about' id='about-link'}}
-    {{/link-to}}
-    {{#link-to 'parent-route.other' tagName='li'}}
-      {{link-to 'Other' 'parent-route.other' id='other-link'}}
-    {{/link-to}}
-  `));
+      {{link-to 'About' 'about' id='about-link'}}
+      {{link-to 'Other' 'other' id='other-link'}}
+    `);
 
-  bootApplication();
+    this.visit('/');
+  }
 
-  let $index = jQuery('#index-link');
-  let $about = jQuery('#about-link');
-  let $other = jQuery('#other-link');
+  teardown() {
+    super.teardown();
+    this.aboutDefer = null;
+    this.otherDefer = null;
+  }
 
-  run($about, 'click');
+  ['@test while a transition is underway'](assert) {
+    let $index = this.$('#index-link');
+    let $about = this.$('#about-link');
+    let $other = this.$('#other-link');
 
-  assertHasClass('active', $index, true, $about, false, $other, false);
-  assertHasClass('ember-transitioning-in', $index, false, $about, true, $other, false);
-  assertHasClass('ember-transitioning-out', $index, true, $about, false, $other, false);
+    $about.click();
 
-  run(aboutDefer, 'resolve');
+    assertHasClass(assert, $index, 'active');
+    assertHasNoClass(assert, $about, 'active');
+    assertHasNoClass(assert, $other, 'active');
 
-  assertHasClass('active', $index, false, $about, true, $other, false);
-  assertHasClass('ember-transitioning-in', $index, false, $about, false, $other, false);
-  assertHasClass('ember-transitioning-out', $index, false, $about, false, $other, false);
+    assertHasNoClass(assert, $index, 'ember-transitioning-in');
+    assertHasClass(assert, $about, 'ember-transitioning-in');
+    assertHasNoClass(assert, $other, 'ember-transitioning-in');
 
-  run($other, 'click');
+    assertHasClass(assert, $index, 'ember-transitioning-out');
+    assertHasNoClass(assert, $about, 'ember-transitioning-out');
+    assertHasNoClass(assert, $other, 'ember-transitioning-out');
 
-  assertHasClass('active', $index, false, $about, true, $other, false);
-  assertHasClass('ember-transitioning-in', $index, false, $about, false, $other, true);
-  assertHasClass('ember-transitioning-out', $index, false, $about, true, $other, false);
+    this.runTask(() => this.aboutDefer.resolve());
 
-  run(otherDefer, 'resolve');
+    assertHasNoClass(assert, $index, 'active');
+    assertHasClass(assert, $about, 'active');
+    assertHasNoClass(assert, $other, 'active');
 
-  assertHasClass('active', $index, false, $about, false, $other, true);
-  assertHasClass('ember-transitioning-in', $index, false, $about, false, $other, false);
-  assertHasClass('ember-transitioning-out', $index, false, $about, false, $other, false);
+    assertHasNoClass(assert, $index, 'ember-transitioning-in');
+    assertHasNoClass(assert, $about, 'ember-transitioning-in');
+    assertHasNoClass(assert, $other, 'ember-transitioning-in');
 
-  run($about, 'click');
+    assertHasNoClass(assert, $index, 'ember-transitioning-out');
+    assertHasNoClass(assert, $about, 'ember-transitioning-out');
+    assertHasNoClass(assert, $other, 'ember-transitioning-out');
+  }
+});
 
-  assertHasClass('active', $index, false, $about, false, $other, true);
-  assertHasClass('ember-transitioning-in', $index, false, $about, true, $other, false);
-  assertHasClass('ember-transitioning-out', $index, false, $about, false, $other, true);
+moduleFor(`The {{link-to}} helper: .transitioning-in .transitioning-out CSS classes - nested link-to's`, class extends ApplicationTestCase {
+  constructor() {
+    super();
+    this.aboutDefer = RSVP.defer();
+    this.otherDefer = RSVP.defer();
+    let _this = this;
 
-  run(aboutDefer, 'resolve');
+    this.router.map(function() {
+      this.route('parent-route', function() {
+        this.route('about');
+        this.route('other');
+      });
+    });
+    this.add('route:parent-route.about', Route.extend({
+      model() {
+        return _this.aboutDefer.promise;
+      }
+    }));
 
-  assertHasClass('active', $index, false, $about, true, $other, false);
-  assertHasClass('ember-transitioning-in', $index, false, $about, false, $other, false);
-  assertHasClass('ember-transitioning-out', $index, false, $about, false, $other, false);
+    this.add('route:parent-route.other', Route.extend({
+      model() {
+        return _this.otherDefer.promise;
+      }
+    }));
+
+    this.addTemplate('application', `
+      {{outlet}}
+      {{#link-to 'index' tagName='li'}}
+        {{link-to 'Index' 'index' id='index-link'}}
+      {{/link-to}}
+      {{#link-to 'parent-route.about' tagName='li'}}
+        {{link-to 'About' 'parent-route.about' id='about-link'}}
+      {{/link-to}}
+      {{#link-to 'parent-route.other' tagName='li'}}
+        {{link-to 'Other' 'parent-route.other' id='other-link'}}
+      {{/link-to}}
+    `);
+
+    this.visit('/');
+  }
+
+  resolveAbout() {
+    return this.runTask(() => {
+      this.aboutDefer.resolve();
+      this.aboutDefer = RSVP.defer();
+    });
+  }
+
+  resolveOther() {
+    return this.runTask(() => {
+      this.otherDefer.resolve();
+      this.otherDefer = RSVP.defer();
+    });
+  }
+
+  teardown() {
+    super.teardown();
+    this.aboutDefer = null;
+    this.otherDefer = null;
+  }
+
+  [`@test while a transition is underway with nested link-to's`](assert) {
+    let $index = this.$('#index-link');
+    let $about = this.$('#about-link');
+    let $other = this.$('#other-link');
+
+    $about.click();
+
+    assertHasClass(assert, $index, 'active');
+    assertHasNoClass(assert, $about, 'active');
+    assertHasNoClass(assert, $about, 'active');
+
+    assertHasNoClass(assert, $index, 'ember-transitioning-in');
+    assertHasClass(assert, $about, 'ember-transitioning-in');
+    assertHasNoClass(assert, $other, 'ember-transitioning-in');
+
+    assertHasClass(assert, $index, 'ember-transitioning-out');
+    assertHasNoClass(assert, $about, 'ember-transitioning-out');
+    assertHasNoClass(assert, $other, 'ember-transitioning-out');
+
+    this.resolveAbout();
+
+    assertHasNoClass(assert, $index, 'active');
+    assertHasClass(assert, $about, 'active');
+    assertHasNoClass(assert, $other, 'active');
+
+    assertHasNoClass(assert, $index, 'ember-transitioning-in');
+    assertHasNoClass(assert, $about, 'ember-transitioning-in');
+    assertHasNoClass(assert, $other, 'ember-transitioning-in');
+
+    assertHasNoClass(assert, $index, 'ember-transitioning-out');
+    assertHasNoClass(assert, $about, 'ember-transitioning-out');
+    assertHasNoClass(assert, $other, 'ember-transitioning-out');
+
+    $other.click();
+
+    assertHasNoClass(assert, $index, 'active');
+    assertHasClass(assert, $about, 'active');
+    assertHasNoClass(assert, $other, 'active');
+
+    assertHasNoClass(assert, $index, 'ember-transitioning-in');
+    assertHasNoClass(assert, $about, 'ember-transitioning-in');
+    assertHasClass(assert, $other, 'ember-transitioning-in');
+
+    assertHasNoClass(assert, $index, 'ember-transitioning-out');
+    assertHasClass(assert, $about, 'ember-transitioning-out');
+    assertHasNoClass(assert, $other, 'ember-transitioning-out');
+
+    this.resolveOther();
+
+    assertHasNoClass(assert, $index, 'active');
+    assertHasNoClass(assert, $about, 'active');
+    assertHasClass(assert, $other, 'active');
+
+    assertHasNoClass(assert, $index, 'ember-transitioning-in');
+    assertHasNoClass(assert, $about, 'ember-transitioning-in');
+    assertHasNoClass(assert, $other, 'ember-transitioning-in');
+
+    assertHasNoClass(assert, $index, 'ember-transitioning-out');
+    assertHasNoClass(assert, $about, 'ember-transitioning-out');
+    assertHasNoClass(assert, $other, 'ember-transitioning-out');
+
+    $about.click();
+
+
+    assertHasNoClass(assert, $index, 'active');
+    assertHasNoClass(assert, $about, 'active');
+    assertHasClass(assert, $other, 'active');
+
+    assertHasNoClass(assert, $index, 'ember-transitioning-in');
+    assertHasClass(assert, $about, 'ember-transitioning-in');
+    assertHasNoClass(assert, $other, 'ember-transitioning-in');
+
+    assertHasNoClass(assert, $index, 'ember-transitioning-out');
+    assertHasNoClass(assert, $about, 'ember-transitioning-out');
+    assertHasClass(assert, $other, 'ember-transitioning-out');
+
+    this.resolveAbout();
+
+    assertHasNoClass(assert, $index, 'active');
+    assertHasClass(assert, $about, 'active');
+    assertHasNoClass(assert, $other, 'active');
+
+    assertHasNoClass(assert, $index, 'ember-transitioning-in');
+    assertHasNoClass(assert, $about, 'ember-transitioning-in');
+    assertHasNoClass(assert, $other, 'ember-transitioning-in');
+
+    assertHasNoClass(assert, $index, 'ember-transitioning-out');
+    assertHasNoClass(assert, $about, 'ember-transitioning-out');
+    assertHasNoClass(assert, $other, 'ember-transitioning-out');
+  }
 });


### PR DESCRIPTION
I did a fair amount of other refactorings here:
* split the class assertions in a 1:1 per selector. I wasn't
particurarly fond of the assertion function that relied on argument
length and found having explicit assertions per selector to be helpful.
* split the two cases into two modules because the test case setup was
different enough to merit it (imo).

refs #15058 