### PR TITLE
use updated address for model_factory_injections deprecation

### DIFF
--- a/packages/ember/lib/index.js
+++ b/packages/ember/lib/index.js
@@ -185,7 +185,7 @@ if (DEBUG) {
         {
           id: 'ember-metal.model_factory_injections',
           until: '2.17.0',
-          url: 'https://emberjs.com/deprecations/v2.x/#toc_ember-model-em-factory-em-injections-removed'
+          url: 'https://emberjs.com/deprecations/v2.x/#toc_id-ember-metal-model_factory_injections'
         }
       );
     },


### PR DESCRIPTION
@GavinJoyce fixed the problem I was working around in https://github.com/emberjs/ember.js/pull/15345 in a much betterway in https://github.com/emberjs/website/pull/2934 so this PR updates the ember code to point at the new deprecation link