### PR TITLE
Decouple default_resolver_test from defaults

### DIFF
--- a/packages/internal-test-helpers/lib/module-for.js
+++ b/packages/internal-test-helpers/lib/module-for.js
@@ -1,3 +1,4 @@
+import { RSVP } from 'ember-runtime';
 import applyMixins from './apply-mixins';
 
 export default function moduleFor(description, TestClass, ...mixins) {
@@ -6,6 +7,9 @@ export default function moduleFor(description, TestClass, ...mixins) {
   QUnit.module(description, {
     setup() {
       context = new TestClass();
+      if (context.beforeEach) {
+        return context.beforeEach();
+      }
     },
 
     teardown() {

--- a/packages/internal-test-helpers/lib/test-cases/default-resolver-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/default-resolver-application.js
@@ -7,11 +7,14 @@ import {
 } from 'ember-glimmer';
 import { assign } from 'ember-utils';
 import { runDestroy } from '../run';
+import { Router } from 'ember-routing';
 
 export default class ApplicationTestCase extends AbstractApplicationTestCase {
 
   createApplication() {
-    return this.application = Application.create(this.applicationOptions);
+    let application = this.application = Application.create(this.applicationOptions);
+    application.Router = Router.extend({ location: 'none' });
+    return application;
   }
 
   get applicationOptions() {


### PR DESCRIPTION
The `default_resolver_test.js` was written under the assumption that the Ember `DefaultResolver` globals resolver would be an application default. This decouples away from that.

Refs: https://github.com/emberjs/ember.js/issues/15058