### PR TITLE
Decouple visit_test from default resolver

### DIFF
--- a/packages/ember-application/tests/system/dependency_injection/to_string_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/to_string_test.js
@@ -1,16 +1,22 @@
 import { guidFor, assign } from 'ember-utils';
 import { Object as EmberObject } from 'ember-runtime';
 import { Resolver as DefaultResolver } from 'ember-application';
-import { moduleFor, ApplicationTestCase, ModuleBasedTestResolver,
-  DefaultResolverApplicationTestCase } from 'internal-test-helpers';
+import {
+  moduleFor,
+  ApplicationTestCase,
+  ModuleBasedTestResolver,
+  DefaultResolverApplicationTestCase
+} from 'internal-test-helpers';
 
-moduleFor('Ember.Application Dependency Injection - DefaultResolver#toString', class extends
-  DefaultResolverApplicationTestCase {
+moduleFor('Ember.Application Dependency Injection - DefaultResolver#toString', class extends DefaultResolverApplicationTestCase {
   constructor() {
     super();
-    this.createApplication();
+    this.runTask(() => this.createApplication());
     this.application.Post = EmberObject.extend();
-    this.visit('/');
+  }
+
+  beforeEach() {
+    return this.visit('/');
   }
 
   ['@test factories'](assert) {
@@ -30,9 +36,9 @@ moduleFor('Ember.Application Dependency Injection - DefaultResolver#toString', c
 });
 
 moduleFor('Ember.Application Dependency Injection - Resolver#toString', class extends ApplicationTestCase {
-  constructor() {
-    super();
-    this.visit('/');
+
+  beforeEach() {
+    return this.visit('/');
   }
 
   get applicationOptions() {

--- a/packages/ember-application/tests/system/visit_test.js
+++ b/packages/ember-application/tests/system/visit_test.js
@@ -1,3 +1,4 @@
+import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
 import {
   Object as EmberObject,
   inject,
@@ -13,403 +14,367 @@ import { Component, helper } from 'ember-glimmer';
 import { compile } from 'ember-template-compiler';
 import { jQuery } from 'ember-views';
 
-let App = null;
-let instance = null;
-let instances = [];
-
-function createApplication(integration) {
-  App = Application.extend().create({
-    autoboot: false,
-    rootElement: '#qunit-fixture',
-    LOG_TRANSITIONS: true,
-    LOG_TRANSITIONS_INTERNAL: true,
-    LOG_ACTIVE_GENERATION: true
-  });
-
-  App.Router = Router.extend({
-    location: 'none'
-  });
-
-  if (integration) {
-    App.instanceInitializer({
-      name: 'auto-cleanup',
-      initialize(_instance) {
-        instances.push(_instance);
-      }
-    });
-  } else {
-    App.instanceInitializer({
-      name: 'auto-cleanup',
-      initialize(_instance) {
-        if (instance) {
-          run(instance, 'destroy');
-        }
-
-        instance = _instance;
-      }
-    });
-  }
-
-  return App;
-}
-
 function expectAsyncError() {
   RSVP.off('error');
 }
 
-QUnit.module('Ember.Application - visit()', {
+moduleFor('Ember.Application - visit()', class extends ApplicationTestCase {
+
   teardown() {
     RSVP.on('error', onerrorDefault);
-
-    if (instance) {
-      run(instance, 'destroy');
-      instance = null;
-    }
-
-    if (App) {
-      run(App, 'destroy');
-      App = null;
-    }
-  }
-});
-
-// This tests whether the application is "autobooted" by registering an
-// instance initializer and asserting it never gets run. Since this is
-// inherently testing that async behavior *doesn't* happen, we set a
-// 500ms timeout to verify that when autoboot is set to false, the
-// instance initializer that would normally get called on DOM ready
-// does not fire.
-QUnit.test('Applications with autoboot set to false do not autoboot', function(assert) {
-  function delay(time) {
-    return new RSVP.Promise(resolve => run.later(resolve, time));
+    super.teardown();
   }
 
-  let appBooted = 0;
-  let instanceBooted = 0;
+  createApplication(options) {
+    return super.createApplication(options, Application.extend());
+  }
 
-  run(() => {
-    createApplication();
+  // This tests whether the application is "autobooted" by registering an
+  // instance initializer and asserting it never gets run. Since this is
+  // inherently testing that async behavior *doesn't* happen, we set a
+  // 500ms timeout to verify that when autoboot is set to false, the
+  // instance initializer that would normally get called on DOM ready
+  // does not fire.
+  [`@test Applications with autoboot set to false do not autoboot`](assert) {
+    function delay(time) {
+      return new RSVP.Promise(resolve => run.later(resolve, time));
+    }
 
-    App.initializer({
+    let appBooted = 0;
+    let instanceBooted = 0;
+
+    this.application.initializer({
       name: 'assert-no-autoboot',
       initialize() {
         appBooted++;
       }
     });
 
-    App.instanceInitializer({
+    this.application.instanceInitializer({
       name: 'assert-no-autoboot',
       initialize() {
         instanceBooted++;
       }
     });
-  });
 
-  // Continue after 500ms
-  return delay(500).then(() => {
-    assert.ok(appBooted === 0, '500ms elapsed without app being booted');
-    assert.ok(instanceBooted === 0, '500ms elapsed without instances being booted');
+    assert.ok(!this.applicationInstance, 'precond - no instance');
+    assert.ok(appBooted === 0, 'precond - not booted');
+    assert.ok(instanceBooted === 0, 'precond - not booted');
 
-    return run(App, 'boot');
-  }).then(() => {
-    assert.ok(appBooted === 1, 'app should boot when manually calling `app.boot()`');
-    assert.ok(instanceBooted === 0, 'no instances should be booted automatically when manually calling `app.boot()');
-  });
-});
+    // Continue after 500ms
+    return delay(500).then(() => {
+      assert.ok(appBooted === 0, '500ms elapsed without app being booted');
+      assert.ok(instanceBooted === 0, '500ms elapsed without instances being booted');
 
-QUnit.test('calling visit() on an app without first calling boot() should boot the app', function(assert) {
-  let appBooted = 0;
-  let instanceBooted = 0;
+      return this.runTask(() => this.application.boot());
+    }).then(() => {
+      assert.ok(appBooted === 1, 'app should boot when manually calling `app.boot()`');
+      assert.ok(instanceBooted === 0, 'no instances should be booted automatically when manually calling `app.boot()');
+    });
+  }
 
-  run(() => {
-    createApplication();
+  [`@test calling visit() on an app without first calling boot() should boot the app`](assert) {
+    let appBooted = 0;
+    let instanceBooted = 0;
 
-    App.initializer({
+    this.application.initializer({
       name: 'assert-no-autoboot',
       initialize() {
         appBooted++;
       }
     });
 
-    App.instanceInitializer({
+    this.application.instanceInitializer({
       name: 'assert-no-autoboot',
       initialize() {
         instanceBooted++;
       }
     });
-  });
 
-  return run(App, 'visit', '/').then(() => {
-    assert.ok(appBooted === 1, 'the app should be booted`');
-    assert.ok(instanceBooted === 1, 'an instances should be booted');
-  });
-});
+    return this.visit('/').then(() => {
+      assert.ok(appBooted === 1, 'the app should be booted`');
+      assert.ok(instanceBooted === 1, 'an instances should be booted');
+    });
+  }
 
-QUnit.test('calling visit() on an already booted app should not boot it again', function(assert) {
-  let appBooted = 0;
-  let instanceBooted = 0;
+  [`@test calling visit() on an already booted app should not boot it again`](assert) {
+    let appBooted = 0;
+    let instanceBooted = 0;
 
-  run(() => {
-    createApplication();
-
-    App.initializer({
+    this.application.initializer({
       name: 'assert-no-autoboot',
       initialize() {
         appBooted++;
       }
     });
 
-    App.instanceInitializer({
+    this.application.instanceInitializer({
       name: 'assert-no-autoboot',
       initialize() {
         instanceBooted++;
       }
     });
-  });
 
-  return run(App, 'boot').then(() => {
-    assert.ok(appBooted === 1, 'the app should be booted');
-    assert.ok(instanceBooted === 0, 'no instances should be booted');
+    return this.runTask(() => this.application.boot()).then(() => {
+      assert.ok(appBooted === 1, 'the app should be booted');
+      assert.ok(instanceBooted === 0, 'no instances should be booted');
 
-    return run(App, 'visit', '/');
-  }).then(() => {
-    assert.ok(appBooted === 1, 'the app should not be booted again');
-    assert.ok(instanceBooted === 1, 'an instance should be booted');
+      return this.visit('/');
+    }).then(() => {
+      assert.ok(appBooted === 1, 'the app should not be booted again');
+      assert.ok(instanceBooted === 1, 'an instance should be booted');
 
-    return run(App, 'visit', '/');
-  }).then(() => {
-    assert.ok(appBooted === 1, 'the app should not be booted again');
-    assert.ok(instanceBooted === 2, 'another instance should be booted');
-  });
-});
+      /*
+       * Destroy the instance.
+       */
+      return this.runTask(() => {
+        this.applicationInstance.destroy()
+        this.applicationInstance = null;
+      });
+    }).then(() => {
+      /*
+       * Visit on the application a second time. The application should remain
+       * booted, but a new instance will be created.
+       */
+      return this.visit('/');
+    }).then(() => {
+      assert.ok(appBooted === 1, 'the app should not be booted again');
+      assert.ok(instanceBooted === 2, 'another instance should be booted');
+    });
+  }
 
-QUnit.test('visit() rejects on application boot failure', function(assert) {
-  run(() => {
-    createApplication();
-
-    App.initializer({
+  [`@test visit() rejects on application boot failure`](assert) {
+    this.application.initializer({
       name: 'error',
       initialize() {
         throw new Error('boot failure');
       }
     });
-  });
 
-  expectAsyncError();
+    expectAsyncError();
 
-  return run(App, 'visit', '/').then(() => {
-    assert.ok(false, 'It should not resolve the promise');
-  }, error => {
-    assert.ok(error instanceof Error, 'It should reject the promise with the boot error');
-    assert.equal(error.message, 'boot failure');
-  });
-});
+    return this.visit('/').then(() => {
+      assert.ok(false, 'It should not resolve the promise');
+    }, error => {
+      assert.ok(error instanceof Error, 'It should reject the promise with the boot error');
+      assert.equal(error.message, 'boot failure');
+    });
+  }
 
-QUnit.test('visit() rejects on instance boot failure', function(assert) {
-  run(() => {
-    createApplication();
-
-    App.instanceInitializer({
+  [`@test visit() rejects on instance boot failure`](assert) {
+    this.application.instanceInitializer({
       name: 'error',
       initialize() {
         throw new Error('boot failure');
       }
     });
-  });
 
-  expectAsyncError();
+    expectAsyncError();
 
-  return run(App, 'visit', '/').then(() => {
-    assert.ok(false, 'It should not resolve the promise');
-  }, error => {
-    assert.ok(error instanceof Error, 'It should reject the promise with the boot error');
-    assert.equal(error.message, 'boot failure');
-  });
-});
+    return this.visit('/').then(() => {
+      assert.ok(false, 'It should not resolve the promise');
+    }, error => {
+      assert.ok(error instanceof Error, 'It should reject the promise with the boot error');
+      assert.equal(error.message, 'boot failure');
+    });
+  }
 
-QUnit.test('visit() follows redirects', function(assert) {
-  run(() => {
-    createApplication();
-
-    App.Router.map(function() {
+  [`@test visit() follows redirects`](assert) {
+    this.router.map(function() {
       this.route('a');
       this.route('b', { path: '/b/:b' });
       this.route('c', { path: '/c/:c' });
     });
 
-    App.register('route:a', Route.extend({
+    this.add('route:a', Route.extend({
       afterModel() {
         this.replaceWith('b', 'zomg');
       }
     }));
 
-    App.register('route:b', Route.extend({
+    this.add('route:b', Route.extend({
       afterModel(params) {
         this.transitionTo('c', params.b);
       }
     }));
-  });
 
-  return run(App, 'visit', '/a').then(instance => {
-    assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
-    assert.equal(instance.getURL(), '/c/zomg', 'It should follow all redirects');
-  });
-});
+    /*
+     * First call to `visit` is `this.application.visit` and returns the
+     * applicationInstance.
+     */
+    return this.visit('/a').then(instance => {
+      assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+      assert.equal(instance.getURL(), '/c/zomg', 'It should follow all redirects');
+    });
+  }
 
-QUnit.test('visit() rejects if an error occurred during a transition', function(assert) {
-  run(() => {
-    createApplication();
-
-    App.Router.map(function() {
+  [`@test visit() rejects if an error occurred during a transition`](assert) {
+    this.router.map(function() {
       this.route('a');
       this.route('b', { path: '/b/:b' });
       this.route('c', { path: '/c/:c' });
     });
 
-    App.register('route:a', Route.extend({
+    this.add('route:a', Route.extend({
       afterModel() {
         this.replaceWith('b', 'zomg');
       }
     }));
 
-    App.register('route:b', Route.extend({
+    this.add('route:b', Route.extend({
       afterModel(params) {
         this.transitionTo('c', params.b);
       }
     }));
 
-    App.register('route:c', Route.extend({
+    this.add('route:c', Route.extend({
       afterModel(params) {
         throw new Error('transition failure');
       }
     }));
-  });
 
-  expectAsyncError();
+    expectAsyncError();
 
-  return run(App, 'visit', '/a').then(() => {
-    assert.ok(false, 'It should not resolve the promise');
-  }, error => {
-    assert.ok(error instanceof Error, 'It should reject the promise with the boot error');
-    assert.equal(error.message, 'transition failure');
-  });
-});
+    return this.visit('/a').then(() => {
+      assert.ok(false, 'It should not resolve the promise');
+    }, error => {
+      assert.ok(error instanceof Error, 'It should reject the promise with the boot error');
+      assert.equal(error.message, 'transition failure');
+    });
+  }
 
-QUnit.test('visit() chain', function(assert) {
-  run(() => {
-    createApplication();
-
-    App.Router.map(function() {
+  [`@test visit() chain`](assert) {
+    this.router.map(function() {
       this.route('a');
       this.route('b');
       this.route('c');
     });
-  });
 
-  return run(App, 'visit', '/').then(instance => {
-    assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
-    assert.equal(instance.getURL(), '/');
+    return this.visit('/').then(instance => {
+      assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+      assert.equal(instance.getURL(), '/');
 
-    return instance.visit('/a');
-  }).then(instance => {
-    assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
-    assert.equal(instance.getURL(), '/a');
+      return instance.visit('/a');
+    }).then(instance => {
+      assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+      assert.equal(instance.getURL(), '/a');
 
-    return instance.visit('/b');
-  }).then(instance => {
-    assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
-    assert.equal(instance.getURL(), '/b');
+      return instance.visit('/b');
+    }).then(instance => {
+      assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+      assert.equal(instance.getURL(), '/b');
 
-    return instance.visit('/c');
-  }).then(instance => {
-    assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
-    assert.equal(instance.getURL(), '/c');
-  });
-});
+      return instance.visit('/c');
+    }).then(instance => {
+      assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
+      assert.equal(instance.getURL(), '/c');
+    });
+  }
 
-QUnit.test('visit() returns a promise that resolves when the view has rendered', function(assert) {
-  run(() => {
-    createApplication();
+  [`@test visit() returns a promise that resolves when the view has rendered`](assert) {
+    this.addTemplate('application', `<h1>Hello world</h1>`);
 
-    App.register('template:application', compile('<h1>Hello world</h1>'));
-  });
+    assert.strictEqual(
+      this.$().children().length, 0,
+      'there are no elements in the fixture element'
+    );
 
-  assert.strictEqual(jQuery('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
+    return this.visit('/').then(instance => {
+      assert.ok(
+        instance instanceof ApplicationInstance,
+        'promise is resolved with an ApplicationInstance'
+      );
+      assert.equal(
+        this.$('.ember-view h1').text(), 'Hello world',
+        'the application was rendered once the promise resolves'
+      );
+    });
+  }
 
-  return run(App, 'visit', '/').then(instance => {
-    assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
-    assert.equal(jQuery('#qunit-fixture > .ember-view h1').text(), 'Hello world', 'the application was rendered once the promise resolves');
-  });
-});
+  [`@test visit() returns a promise that resolves without rendering when shouldRender is set to false`](assert) {
+    assert.expect(3);
 
-QUnit.test('visit() returns a promise that resolves without rendering when shouldRender is set to false', function(assert) {
-  assert.expect(3);
+    this.addTemplate('application', '<h1>Hello world</h1>');
 
-  run(() => {
-    createApplication();
+    assert.strictEqual(
+      this.$().children().length, 0,
+      'there are no elements in the fixture element'
+    );
 
-    App.register('template:application', compile('<h1>Hello world</h1>'));
-  });
+    return this.visit('/', { shouldRender: false }).then(instance => {
+      assert.ok(
+        instance instanceof ApplicationInstance,
+        'promise is resolved with an ApplicationInstance'
+      );
+      assert.strictEqual(
+        this.$().children().length, 0,
+        'there are still no elements in the fixture element after visit'
+      );
+    });
+  }
 
-  assert.strictEqual(jQuery('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
+  [`@test visit() renders a template when shouldRender is set to true`](assert) {
+    assert.expect(3);
 
-  return run(App, 'visit', '/', { shouldRender: false }).then(instance => {
-    assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
-    assert.strictEqual(jQuery('#qunit-fixture').children().length, 0, 'there are still no elements in the fixture element after visit');
-  });
-});
+    this.addTemplate('application', '<h1>Hello world</h1>');
 
-QUnit.test('visit() renders a template when shouldRender is set to true', function(assert) {
-  assert.expect(3);
+    assert.strictEqual(
+      this.$('#qunit-fixture').children().length, 0,
+      'there are no elements in the fixture element'
+    );
 
-  run(() => {
-    createApplication();
+    return this.visit('/', { shouldRender: true }).then(instance => {
+      assert.ok(
+        instance instanceof ApplicationInstance,
+        'promise is resolved with an ApplicationInstance'
+      );
+      assert.strictEqual(
+        this.$().children().length, 1,
+        'there is 1 element in the fixture element after visit'
+      );
+    });
+  }
 
-    App.register('template:application', compile('<h1>Hello world</h1>'));
-  });
+  [`@test visit() returns a promise that resolves without rendering when shouldRender is set to false with Engines`](assert) {
+    assert.expect(3);
 
-  assert.strictEqual(jQuery('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
+    this.router.map(function() {
+      this.mount('blog');
+    });
 
-  return run(App, 'visit', '/', { shouldRender: true }).then(instance => {
-    assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
-    assert.strictEqual(jQuery('#qunit-fixture').children().length, 1, 'there is 1 element in the fixture element after visit');
-  });
-});
-
-QUnit.test('visit() returns a promise that resolves without rendering when shouldRender is set to false with Engines', function(assert) {
-  assert.expect(3);
-
-  run(() => {
-    createApplication();
-
-    App.register('template:application', compile('<h1>Hello world</h1>'));
+    this.addTemplate('application', '<h1>Hello world</h1>');
 
     // Register engine
     let BlogEngine = Engine.extend();
-    App.register('engine:blog', BlogEngine);
+    this.add('engine:blog', BlogEngine);
 
     // Register engine route map
     let BlogMap = function() {};
-    App.register('route-map:blog', BlogMap);
+    this.add('route-map:blog', BlogMap);
 
-    App.Router.map(function() {
+    assert.strictEqual(
+      this.$('#qunit-fixture').children().length, 0,
+      'there are no elements in the fixture element'
+    );
+
+    return this.visit('/blog', { shouldRender: false }).then(instance => {
+      assert.ok(
+        instance instanceof ApplicationInstance,
+        'promise is resolved with an ApplicationInstance'
+      );
+      assert.strictEqual(
+        this.$().children().length, 0,
+        'there are still no elements in the fixture element after visit'
+      );
+    });
+  }
+
+  [`@test visit() on engine resolves engine component`](assert) {
+    assert.expect(2);
+
+    this.router.map(function() {
       this.mount('blog');
     });
-  });
-
-  assert.strictEqual(jQuery('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
-
-  return run(App, 'visit', '/blog', { shouldRender: false }).then(instance => {
-    assert.ok(instance instanceof ApplicationInstance, 'promise is resolved with an ApplicationInstance');
-    assert.strictEqual(jQuery('#qunit-fixture').children().length, 0, 'there are still no elements in the fixture element after visit');
-  });
-});
-
-QUnit.test('visit() on engine resolves engine component', function(assert) {
-  assert.expect(2);
-
-  run(() => {
-    createApplication();
 
     // Register engine
     let BlogEngine = Engine.extend({
@@ -422,29 +387,31 @@ QUnit.test('visit() on engine resolves engine component', function(assert) {
         this.register('component:cache-money', Component.extend({}));
       }
     });
-    App.register('engine:blog', BlogEngine);
+    this.add('engine:blog', BlogEngine);
 
     // Register engine route map
     let BlogMap = function() {};
-    App.register('route-map:blog', BlogMap);
+    this.add('route-map:blog', BlogMap);
 
-    App.Router.map(function() {
+    assert.strictEqual(
+      this.$().children().length, 0,
+      'there are no elements in the fixture element'
+    );
+
+    return this.visit('/blog', { shouldRender: true }).then(instance => {
+      assert.strictEqual(
+        this.$().find('p').text(), 'Dis cache money',
+        'Engine component is resolved'
+      );
+    });
+  }
+
+  [`@test visit() on engine resolves engine helper`](assert) {
+    assert.expect(2);
+
+    this.router.map(function() {
       this.mount('blog');
     });
-  });
-
-  assert.strictEqual(jQuery('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
-
-  return run(App, 'visit', '/blog', { shouldRender: true }).then(instance => {
-    assert.strictEqual(jQuery('#qunit-fixture').find('p').text(), 'Dis cache money', 'Engine component is resolved');
-  });
-});
-
-QUnit.test('visit() on engine resolves engine helper', function(assert) {
-  assert.expect(2);
-
-  run(() => {
-    createApplication();
 
     // Register engine
     let BlogEngine = Engine.extend({
@@ -456,53 +423,37 @@ QUnit.test('visit() on engine resolves engine helper', function(assert) {
         }));
       }
     });
-    App.register('engine:blog', BlogEngine);
+    this.add('engine:blog', BlogEngine);
 
     // Register engine route map
     let BlogMap = function() {};
-    App.register('route-map:blog', BlogMap);
+    this.add('route-map:blog', BlogMap);
 
-    App.Router.map(function() {
-      this.mount('blog');
+    assert.strictEqual(
+      this.$().children().length, 0,
+      'there are no elements in the fixture element'
+    );
+
+    return this.visit('/blog', { shouldRender: true }).then(() => {
+      assert.strictEqual(
+        this.$().text(), 'turnt up',
+        'Engine component is resolved'
+      );
     });
-  });
-
-  assert.strictEqual(jQuery('#qunit-fixture').children().length, 0, 'there are no elements in the fixture element');
-
-  return run(App, 'visit', '/blog', { shouldRender: true }).then(instance => {
-    assert.strictEqual(jQuery('#qunit-fixture').text(), 'turnt up', 'Engine component is resolved');
-  });
-});
-
-QUnit.module('Ember.Application - visit() Integration Tests', {
-  teardown() {
-    if (instances) {
-      run(instances, 'forEach', (i) => i.destroy());
-      instances = [];
-    }
-
-    if (App) {
-      run(App, 'destroy');
-      App = null;
-    }
   }
-});
 
-QUnit.test('Ember Islands-style setup', function(assert) {
-  let xFooInitCalled = false;
-  let xFooDidInsertElementCalled = false;
+  [`@test Ember Islands-style setup`](assert) {
+    let xFooInitCalled = false;
+    let xFooDidInsertElementCalled = false;
 
-  let xBarInitCalled = false;
-  let xBarDidInsertElementCalled = false;
+    let xBarInitCalled = false;
+    let xBarDidInsertElementCalled = false;
 
-  run(() => {
-    createApplication(true);
-
-    App.Router.map(function() {
+    this.router.map(function() {
       this.route('show', { path: '/:component_name' });
     });
 
-    App.register('route:show', Route.extend({
+    this.add('route:show', Route.extend({
       queryParams: {
         data: { refreshModel: true }
       },
@@ -523,17 +474,18 @@ QUnit.test('Ember Islands-style setup', function(assert) {
       }
     });
 
-    App.register('service:isolated-counter', Counter);
-    App.register('service:shared-counter', Counter.create(), { instantiate: false });
+    this.add('service:isolatedCounter', Counter);
+    this.add('service:sharedCounter', Counter.create());
+    this.application.registerOptions('service:sharedCounter', {instantiate: false});
 
-    App.register('template:show', compile('{{component model.componentName model=model.componentData}}'));
+    this.addTemplate('show', '{{component model.componentName model=model.componentData}}');
 
-    App.register('template:components/x-foo', compile(`
+    this.addTemplate('components/x-foo', `
       <h1>X-Foo</h1>
       <p>Hello {{model.name}}, I have been clicked {{isolatedCounter.value}} times ({{sharedCounter.value}} times combined)!</p>
-    `));
+    `);
 
-    App.register('component:x-foo', Component.extend({
+    this.add('component:x-foo', Component.extend({
       tagName: 'x-foo',
 
       isolatedCounter: inject.service(),
@@ -554,13 +506,13 @@ QUnit.test('Ember Islands-style setup', function(assert) {
       }
     }));
 
-    App.register('template:components/x-bar', compile(`
+    this.addTemplate('components/x-bar', `
       <h1>X-Bar</h1>
       <button {{action "incrementCounter"}}>Join {{counter.value}} others in clicking me!</button>
-    `));
+    `);
 
-    App.register('component:x-bar', Component.extend({
-      counter: inject.service('shared-counter'),
+    this.add('component:x-bar', Component.extend({
+      counter: inject.service('sharedCounter'),
 
       actions: {
         incrementCounter() {
@@ -577,48 +529,59 @@ QUnit.test('Ember Islands-style setup', function(assert) {
         xBarDidInsertElementCalled = true;
       }
     }));
-  });
 
-  let $foo = jQuery('<div />').appendTo('#qunit-fixture');
-  let $bar = jQuery('<div />').appendTo('#qunit-fixture');
+    let $foo = jQuery('<div />').appendTo(this.$());
+    let $bar = jQuery('<div />').appendTo(this.$());
 
-  let data = encodeURIComponent(JSON.stringify({ name: 'Godfrey' }));
+    let data = encodeURIComponent(JSON.stringify({ name: 'Godfrey' }));
+    let instances = [];
 
-  return RSVP.all([
-    run(App, 'visit', `/x-foo?data=${data}`, { rootElement: $foo[0] }),
-    run(App, 'visit', '/x-bar', { rootElement: $bar[0] })
-  ]).then(() => {
-    assert.ok(xFooInitCalled);
-    assert.ok(xFooDidInsertElementCalled);
+    return RSVP.all([
+      this.runTask(() => {
+        return this.application.visit(`/x-foo?data=${data}`, { rootElement: $foo[0] });
+      }),
+      this.runTask(() => {
+        return this.application.visit('/x-bar', { rootElement: $bar[0] });
+      })
+    ]).then(_instances => {
+      instances = _instances;
 
-    assert.ok(xBarInitCalled);
-    assert.ok(xBarDidInsertElementCalled);
+      assert.ok(xFooInitCalled);
+      assert.ok(xFooDidInsertElementCalled);
 
-    assert.equal($foo.find('h1').text(), 'X-Foo');
-    assert.equal($foo.find('p').text(), 'Hello Godfrey, I have been clicked 0 times (0 times combined)!');
-    assert.ok($foo.text().indexOf('X-Bar') === -1);
+      assert.ok(xBarInitCalled);
+      assert.ok(xBarDidInsertElementCalled);
 
-    assert.equal($bar.find('h1').text(), 'X-Bar');
-    assert.equal($bar.find('button').text(), 'Join 0 others in clicking me!');
-    assert.ok($bar.text().indexOf('X-Foo') === -1);
+      assert.equal($foo.find('h1').text(), 'X-Foo');
+      assert.equal($foo.find('p').text(), 'Hello Godfrey, I have been clicked 0 times (0 times combined)!');
+      assert.ok($foo.text().indexOf('X-Bar') === -1);
 
-    run(() => $foo.find('x-foo').click());
+      assert.equal($bar.find('h1').text(), 'X-Bar');
+      assert.equal($bar.find('button').text(), 'Join 0 others in clicking me!');
+      assert.ok($bar.text().indexOf('X-Foo') === -1);
 
-    assert.equal($foo.find('p').text(), 'Hello Godfrey, I have been clicked 1 times (1 times combined)!');
-    assert.equal($bar.find('button').text(), 'Join 1 others in clicking me!');
+      this.runTask(() => {
+        $foo.find('x-foo').click();
+      });
 
-    run(() => {
-      $bar.find('button').click();
-      $bar.find('button').click();
+      assert.equal($foo.find('p').text(), 'Hello Godfrey, I have been clicked 1 times (1 times combined)!');
+      assert.equal($bar.find('button').text(), 'Join 1 others in clicking me!');
+
+      this.runTask(() => {
+        $bar.find('button').click();
+        $bar.find('button').click();
+      });
+
+      assert.equal($foo.find('p').text(), 'Hello Godfrey, I have been clicked 1 times (3 times combined)!');
+      assert.equal($bar.find('button').text(), 'Join 3 others in clicking me!');
+
+    }).finally(() => {
+      this.runTask(() => {
+        instances.forEach(instance => {
+          instance.destroy();
+        });
+      });
     });
+  }
 
-    assert.equal($foo.find('p').text(), 'Hello Godfrey, I have been clicked 1 times (3 times combined)!');
-    assert.equal($bar.find('button').text(), 'Join 3 others in clicking me!');
-  });
-});
-
-QUnit.skip('Test setup', function(assert) {
-});
-
-QUnit.skip('iframe setup', function(assert) {
 });

--- a/packages/internal-test-helpers/lib/test-cases/application.js
+++ b/packages/internal-test-helpers/lib/test-cases/application.js
@@ -9,15 +9,17 @@ export default class ApplicationTestCase extends TestResolverApplicationTestCase
     super();
 
     let { applicationOptions } = this;
-    this.application = this.runTask(() => {
-      return Application.create(applicationOptions)
-    });
+    this.application = this.runTask(() => this.createApplication(applicationOptions));
 
     this.resolver = applicationOptions.Resolver.lastInstance;
 
     if (this.resolver) {
       this.resolver.add('router:main', Router.extend(this.routerOptions));
     }
+  }
+
+  createApplication(myOptions={}, MyApplication=Application) {
+    return MyApplication.create(myOptions);
   }
 
   get applicationOptions() {
@@ -40,6 +42,7 @@ export default class ApplicationTestCase extends TestResolverApplicationTestCase
       return this.runTask(() => {
         return this.application.visit(url, options).then(instance => {
           this.applicationInstance = instance;
+          return instance;
         });
       });
     }

--- a/packages/internal-test-helpers/lib/test-cases/default-resolver-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/default-resolver-application.js
@@ -13,7 +13,7 @@ export default class ApplicationTestCase extends AbstractApplicationTestCase {
 
   createApplication() {
     let application = this.application = Application.create(this.applicationOptions);
-    application.Router = Router.extend({ location: 'none' });
+    application.Router = Router.extend(this.routerOptions);
     return application;
   }
 


### PR DESCRIPTION
This builds on https://github.com/emberjs/ember.js/pull/15434. Drop the default resolver from `visit_test.js`.

Refs: https://github.com/emberjs/ember.js/issues/15058

TODO:
* [x] Skipped call-visit-on-app-multiple-times test
* [x] Skipped Ember-Islands test