### PR TITLE
assert for invalid path in `Ember.observer`

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -748,7 +748,7 @@ export function observer(...args) {
   }
 
   assert('Ember.observer called without a function', typeof func === 'function');
-  assert('Ember.observer called without valid path', _paths.length > 0 && _paths.every((p)=> p && p.length));
+  assert('Ember.observer called without valid path', _paths.length > 0 && _paths.every((p)=> typeof p === 'string' && p.length));
 
   let paths = [];
   let addWatchedProperty = path => paths.push(path);

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -735,30 +735,26 @@ export function aliasMethod(methodName) {
   @public
 */
 export function observer(...args) {
-  let func  = args[args.length - 1];
-  let paths;
-
-  let addWatchedProperty = path => {
-    paths.push(path);
-  };
-  let _paths = args.slice(0, -1);
-
-  if (typeof func !== 'function') {
+  let _paths, func;
+  if (typeof args[args.length - 1] !== 'function') {
     // revert to old, soft-deprecated argument ordering
     deprecate('Passing the dependentKeys after the callback function in Ember.observer is deprecated. Ensure the callback function is the last argument.', false, { id: 'ember-metal.observer-argument-order', until: '3.0.0' });
 
-    func  = args[0];
-    _paths = args.slice(1);
+    func = args.shift();
+    _paths = args;
+  } else {
+    func = args.pop();
+    _paths = args;
   }
 
-  paths = [];
+  assert('Ember.observer called without a function', typeof func === 'function');
+  assert('Ember.observer called without valid path', _paths.length > 0 && _paths.every((p)=> p && p.length));
+
+  let paths = [];
+  let addWatchedProperty = path => paths.push(path);
 
   for (let i = 0; i < _paths.length; ++i) {
     expandProperties(_paths[i], addWatchedProperty);
-  }
-
-  if (typeof func !== 'function') {
-    throw new EmberError('Ember.observer called without a function');
   }
 
   func.__ember_observes__ = paths;

--- a/packages/ember-metal/tests/observer_test.js
+++ b/packages/ember-metal/tests/observer_test.js
@@ -31,6 +31,18 @@ function K() {}
 
 QUnit.module('addObserver');
 
+testBoth('observer should assert to invalid input', function(get, set) {
+  expectAssertion(()=> {
+    observer(()=>{})
+  }, 'Ember.observer called without valid path');
+
+  expectDeprecation('Passing the dependentKeys after the callback function in Ember.observer is deprecated. Ensure the callback function is the last argument.')
+
+  expectAssertion(()=> {
+    observer(null)
+  }, 'Ember.observer called without a function');
+})
+
 testBoth('observer should fire when property is modified', function(get, set) {
   let obj = {};
   let count = 0;


### PR DESCRIPTION
why trying to solve # 15246  
* converted throw `function missing` error into assertion
* added assertion for missing path 
* cleaned up `Ember.observer`