### PR TITLE
Drop unimplemented application.option API

### DIFF
--- a/packages/ember-runtime/lib/mixins/registry_proxy.js
+++ b/packages/ember-runtime/lib/mixins/registry_proxy.js
@@ -120,17 +120,6 @@ export default Mixin.create({
   hasRegistration: registryAlias('has'),
 
   /**
-   Register an option for a particular factory.
-
-   @public
-   @method registerOption
-   @param {String} fullName
-   @param {String} optionName
-   @param {Object} options
-   */
-  registerOption: registryAlias('option'),
-
-  /**
    Return a specific registered option for a particular factory.
 
    @public


### PR DESCRIPTION
Although [Registry#options](https://github.com/emberjs/ember.js/blob/master/packages/container/lib/registry.js#L383) is implemented, the `Registry#option` API this alias depends on is not. Since it never worked, I suggest removing it. Currently it throws an error in the alias code resulting from a failed property lookup.

/cc @dgeb 