### PR TITLE
[BUGFIX beta] Assert {{input}} helper is not used in block form.

### DIFF
--- a/packages/ember-template-compiler/lib/plugins/assert-input-helper-without-block.js
+++ b/packages/ember-template-compiler/lib/plugins/assert-input-helper-without-block.js
@@ -1,0 +1,24 @@
+import { assert } from 'ember-debug';
+import calculateLocationDisplay from '../system/calculate-location-display';
+
+export default function errorOnInputWithContent(env) {
+  let { moduleName } = env.meta;
+
+  return {
+    name: 'assert-input-helper-without-block',
+
+    visitors: {
+      BlockStatement(node) {
+        if (node.path.original !== 'input') { return; }
+
+        assert(assertMessage(moduleName, node));
+      }
+    }
+  };
+}
+
+function assertMessage(moduleName, node) {
+  let sourceInformation = calculateLocationDisplay(moduleName, node.loc);
+
+  return `The {{input}} helper cannot be used in block form. ${sourceInformation}`;
+}

--- a/packages/ember-template-compiler/lib/plugins/index.js
+++ b/packages/ember-template-compiler/lib/plugins/index.js
@@ -15,6 +15,7 @@ import TransformEachInIntoEach from './transform-each-in-into-each';
 import TransformHasBlockSyntax from './transform-has-block-syntax';
 import TransformDotComponentInvocation from './transform-dot-component-invocation';
 import ExtractPragmaTag from './extract-pragma-tag';
+import AssertInputHelperWithoutBlock from './assert-input-helper-without-block';
 import {
   GLIMMER_CUSTOM_COMPONENT_MANAGER
 } from 'ember/features';
@@ -35,7 +36,8 @@ const transforms = [
   TransformInputTypeSyntax,
   TransformAttrsIntoArgs,
   TransformEachInIntoEach,
-  TransformHasBlockSyntax
+  TransformHasBlockSyntax,
+  AssertInputHelperWithoutBlock
 ];
 
 if (GLIMMER_CUSTOM_COMPONENT_MANAGER) {

--- a/packages/ember-template-compiler/tests/plugins/assert-input-helper-without-block-test.js
+++ b/packages/ember-template-compiler/tests/plugins/assert-input-helper-without-block-test.js
@@ -1,0 +1,16 @@
+import { compile } from '../../index';
+
+QUnit.module('ember-template-compiler: assert-input-helper-without-block');
+
+QUnit.test('Using {{#input}}{{/input}} is not valid', function() {
+  expect(1);
+
+  let expectedMessage =
+    `The {{input}} helper cannot be used in block form. ('baz/foo-bar' @ L1:C0) `;
+
+  expectAssertion(() => {
+    compile('{{#input value="123"}}Completely invalid{{/input}}', {
+      moduleName: 'baz/foo-bar'
+    });
+  }, expectedMessage);
+});


### PR DESCRIPTION
`input`'s content model is empty. That means it cannot have anything
inside. Previously, calling the `{{input}}` helper with a block was
allowed, but now it fails.

This PR improves the message and fails earlier than during execution.

Fixes #15361