### PR TITLE
Refactor feature flag conditionals to appease babel-plugin-debug-macros.

### DIFF
--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -608,11 +608,11 @@ Registry.prototype = {
   },
 
   resolverCacheKey(name, options) {
-    if (!EMBER_MODULE_UNIFICATION) {
+    if (EMBER_MODULE_UNIFICATION) {
+      return (options && options.source) ? `${options.source}:${name}` : name;
+    } else {
       return name;
     }
-
-    return (options && options.source) ? `${options.source}:${name}` : name;
   }
 };
 
@@ -697,18 +697,20 @@ function resolve(registry, normalizedName, options) {
     // and source into the full normalizedName
     let expandedNormalizedName = registry.expandLocalLookup(normalizedName, options);
 
-    // if expandLocalLookup returns falsey, we do not support local lookup
-    if (!EMBER_MODULE_UNIFICATION) {
+    if (EMBER_MODULE_UNIFICATION) {
+      if (expandedNormalizedName) {
+        // with ember-module-unification, if expandLocalLookup returns something,
+        // pass it to the resolve without the source
+        normalizedName = expandedNormalizedName;
+        options = {};
+      }
+    } else {
+      // if expandLocalLookup returns falsey, we do not support local lookup
       if (!expandedNormalizedName) {
         return;
       }
 
       normalizedName = expandedNormalizedName;
-    } else if (expandedNormalizedName) {
-      // with ember-module-unification, if expandLocalLookup returns something,
-      // pass it to the resolve without the source
-      normalizedName = expandedNormalizedName;
-      options = {};
     }
   }
 

--- a/packages/ember-glimmer/lib/environment.js
+++ b/packages/ember-glimmer/lib/environment.js
@@ -150,8 +150,11 @@ export default class Environment extends GlimmerEnvironment {
   }
 
   _resolveLocalLookupName(name, source, owner) {
-    return EMBER_MODULE_UNIFICATION ? `${source}:${name}`
-      : owner._resolveLocalLookupName(name, source);
+    if (EMBER_MODULE_UNIFICATION) {
+      return `${source}:${name}`;
+    } else {
+      return owner._resolveLocalLookupName(name, source);
+    }
   }
 
   macros() {


### PR DESCRIPTION
Due to issues with babel-plugin-debug-macros, these conditionals had to be rewritten.  

The fundamental issue upstream is that we [only check for very specific types of statements](https://github.com/chadhietala/babel-plugin-debug-macros/blob/11b5d056071bc2bff9062b65ff9c8db13ce8156c/src/lib/utils/macros.js#L58-L63) to replace with `true` or `false`.  I will create an issue over there to track fixing this properly, but for now this PR unblocks the release of 2.15 beta.