### PR TITLE
added assertion to `Ember.on` for invalid arguments

### DIFF
--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -301,6 +301,10 @@ export function listenersFor(obj, eventName) {
 export function on(...args) {
   let func = args.pop();
   let events = args;
+
+  assert('Ember.on expects function as last argument', typeof func === 'function');
+  assert('Ember.on called without valid event names', events.length > 0 && events.every((p)=> typeof p === 'string' && p.length));
+
   func.__ember_listens__ = events;
   return func;
 }

--- a/packages/ember-metal/tests/events_test.js
+++ b/packages/ember-metal/tests/events_test.js
@@ -236,6 +236,20 @@ QUnit.test('a listener can be added as part of a mixin', function() {
   equal(triggered, 2, 'should invoke listeners');
 });
 
+QUnit.test('Ember.on asserts for invalid arguments', function() {
+  expectAssertion(()=> {
+    Mixin.create({
+      foo1: on('bar'),
+    });
+  }, 'Ember.on expects function as last argument');
+
+  expectAssertion(()=> {
+    Mixin.create({
+      foo1: on(function(){}),
+    });
+  }, 'Ember.on called without valid event names');
+});
+
 QUnit.test('a listener added as part of a mixin may be overridden', function() {
   let triggered = 0;
   let FirstMixin = Mixin.create({


### PR DESCRIPTION
to be consistent with `Ember.observer` and `Ember.computed` that asserts for invalid arguments