### PR TITLE
[BUGFIX lts] Ensure event dispatcher is a singleton

### DIFF
--- a/packages/ember-application/lib/system/engine-instance.js
+++ b/packages/ember-application/lib/system/engine-instance.js
@@ -166,7 +166,6 @@ const EngineInstance = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixi
 
     let registrations = [
       'route:basic',
-      'event_dispatcher:main',
       'service:-routing',
       'service:-glimmer-environment'
     ];
@@ -181,7 +180,8 @@ const EngineInstance = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixi
       P`-bucket-cache:main`,
       '-view-registry:main',
       `renderer:-${env.isInteractive ? 'dom' : 'inert'}`,
-      'service:-document'
+      'service:-document',
+      'event_dispatcher:main'
     ];
 
     singletons.forEach(key => this.register(key, parent.lookup(key), { instantiate: false }));

--- a/packages/ember-application/tests/system/application_instance_test.js
+++ b/packages/ember-application/tests/system/application_instance_test.js
@@ -156,7 +156,6 @@ QUnit.test('can build and boot a registered engine', function(assert) {
 
       let registrations = [
         'route:basic',
-        'event_dispatcher:main',
         'service:-routing',
         'service:-glimmer-environment'
       ];
@@ -173,7 +172,8 @@ QUnit.test('can build and boot a registered engine', function(assert) {
         P`-bucket-cache:main`,
         '-view-registry:main',
         '-environment:main',
-        'service:-document'
+        'service:-document',
+        'event_dispatcher:main'
       ];
 
       let env = appInstance.lookup('-environment:main');

--- a/packages/ember-glimmer/tests/integration/mount-test.js
+++ b/packages/ember-glimmer/tests/integration/mount-test.js
@@ -188,6 +188,48 @@ moduleFor('{{mount}} test', class extends ApplicationTest {
     });
   }
 
+  ['@test it declares the event dispatcher as a singleton']() {
+    this.router.map(function() {
+      this.route('engine-event-dispatcher-singleton');
+    });
+
+    let controller;
+    let component;
+
+    this.add('controller:engine-event-dispatcher-singleton', Controller.extend({
+      init() {
+        this._super(...arguments);
+        controller = this;
+      }
+    }));
+    this.addTemplate('engine-event-dispatcher-singleton', '{{mount "foo"}}');
+
+    this.add('engine:foo', Engine.extend({
+      router: null,
+      init() {
+        this._super(...arguments);
+        this.register('template:application', compile('<h2>Foo Engine: {{tagless-component}}</h2>', { moduleName: 'application' }));
+        this.register('component:tagless-component', Component.extend({
+          tagName: "",
+          init() {
+            this._super(...arguments);
+            component = this;
+          }
+        }));
+        this.register('template:components/tagless-component', compile('Tagless Component', { moduleName: 'components/tagless-component' }));
+      }
+    }));
+
+    return this.visit('/engine-event-dispatcher-singleton').then(() => {
+      this.assertComponentElement(this.firstChild, { content: '<h2>Foo Engine: Tagless Component</h2>' });
+
+      let controllerOwnerEventDispatcher = getOwner(controller).lookup('event_dispatcher:main');
+      let taglessComponentOwnerEventDispatcher = getOwner(component).lookup('event_dispatcher:main');
+
+      this.assert.strictEqual(controllerOwnerEventDispatcher, taglessComponentOwnerEventDispatcher);
+    });
+  }
+
 });
 
 if (EMBER_ENGINES_MOUNT_PARAMS) {


### PR DESCRIPTION
This PR fixes https://github.com/ember-engines/ember-engines/issues/440

I have added a test that follows the reproduction steps in the issue above, though the test isn't failing without the change, so I'm not sure if either I'm doing something wrong, or if there is something about the test environment which is masking the issue.

FWIW I have verified that this fix is working in the reproduction app via `yarn link`.

cc/ @rwjblue 