### PR TITLE
Move `accumulateListeners` to the only place where it's used.

### DIFF
--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -25,42 +25,6 @@ import { ONCE, SUSPENDED } from './meta_listeners';
 
 */
 
-function indexOf(array, target, method) {
-  let index = -1;
-  // hashes are added to the end of the event array
-  // so it makes sense to start searching at the end
-  // of the array and search in reverse
-  for (let i = array.length - 3; i >= 0; i -= 3) {
-    if (target === array[i] && method === array[i + 1]) {
-      index = i;
-      break;
-    }
-  }
-  return index;
-}
-
-export function accumulateListeners(obj, eventName, otherActions) {
-  let meta = peekMeta(obj);
-  if (!meta) { return; }
-  let actions = meta.matchingListeners(eventName);
-  if (actions === undefined) { return; }
-  let newActions = [];
-
-  for (let i = actions.length - 3; i >= 0; i -= 3) {
-    let target = actions[i];
-    let method = actions[i + 1];
-    let flags = actions[i + 2];
-    let actionIndex = indexOf(otherActions, target, method);
-
-    if (actionIndex === -1) {
-      otherActions.push(target, method, flags);
-      newActions.push(target, method, flags);
-    }
-  }
-
-  return newActions;
-}
-
 /**
   Add an event listener
 

--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -44,7 +44,6 @@ export {
 } from './property_set';
 export { default as WeakMap } from './weak_map';
 export {
-  accumulateListeners,
   addListener,
   hasListeners,
   listenersFor,

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -3,8 +3,7 @@ import {
   peekMeta
 } from './meta';
 import {
-  sendEvent,
-  accumulateListeners
+  sendEvent
 } from './events';
 import {
   markObjectAsDirty
@@ -252,6 +251,41 @@ function changeProperties(callback, binding) {
   }
 }
 
+function indexOf(array, target, method) {
+  let index = -1;
+  // hashes are added to the end of the event array
+  // so it makes sense to start searching at the end
+  // of the array and search in reverse
+  for (let i = array.length - 3; i >= 0; i -= 3) {
+    if (target === array[i] && method === array[i + 1]) {
+      index = i;
+      break;
+    }
+  }
+  return index;
+}
+
+function accumulateListeners(obj, eventName, otherActions, meta) {
+  if (meta === null || meta === undefined) { return; }
+  let actions = meta.matchingListeners(eventName);
+  if (actions === undefined) { return; }
+  let newActions = [];
+
+  for (let i = actions.length - 3; i >= 0; i -= 3) {
+    let target = actions[i];
+    let method = actions[i + 1];
+    let flags = actions[i + 2];
+    let actionIndex = indexOf(otherActions, target, method);
+
+    if (actionIndex === -1) {
+      otherActions.push(target, method, flags);
+      newActions.push(target, method, flags);
+    }
+  }
+
+  return newActions;
+}
+
 function notifyBeforeObservers(obj, keyName, meta) {
   if (meta.isSourceDestroying()) { return; }
 
@@ -259,7 +293,7 @@ function notifyBeforeObservers(obj, keyName, meta) {
   let listeners, added;
   if (deferred) {
     listeners = beforeObserverSet.add(obj, keyName, eventName);
-    added = accumulateListeners(obj, eventName, listeners);
+    added = accumulateListeners(obj, eventName, listeners, meta);
     sendEvent(obj, eventName, [obj, keyName], added);
   } else {
     sendEvent(obj, eventName, [obj, keyName]);
@@ -273,7 +307,7 @@ function notifyObservers(obj, keyName, meta) {
   let listeners;
   if (deferred) {
     listeners = observerSet.add(obj, keyName, eventName);
-    accumulateListeners(obj, eventName, listeners);
+    accumulateListeners(obj, eventName, listeners, meta);
   } else {
     sendEvent(obj, eventName, [obj, keyName]);
   }

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -266,7 +266,6 @@ function indexOf(array, target, method) {
 }
 
 function accumulateListeners(obj, eventName, otherActions, meta) {
-  if (meta === null || meta === undefined) { return; }
   let actions = meta.matchingListeners(eventName);
   if (actions === undefined) { return; }
   let newActions = [];

--- a/packages/ember/lib/index.js
+++ b/packages/ember/lib/index.js
@@ -88,7 +88,6 @@ Ember.sendEvent = metal.sendEvent;
 Ember.hasListeners = metal.hasListeners;
 Ember.watchedEvents = metal.watchedEvents;
 Ember.listenersFor = metal.listenersFor;
-Ember.accumulateListeners = metal.accumulateListeners;
 Ember.isNone = metal.isNone;
 Ember.isEmpty = metal.isEmpty;
 Ember.isBlank = metal.isBlank;

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -71,7 +71,6 @@ QUnit.module('ember reexports');
   ['hasListeners', 'ember-metal'],
   ['watchedEvents', 'ember-metal'],
   ['listenersFor', 'ember-metal'],
-  ['accumulateListeners', 'ember-metal'],
   ['isNone', 'ember-metal'],
   ['isEmpty', 'ember-metal'],
   ['isBlank', 'ember-metal'],


### PR DESCRIPTION
I found that this private function was only used in one place within Ember and exactly 0 times in the wild, so I made it a local function in the file where it's used.

This avoids a few import/export for no reason. Also improved so we void peeking a
meta that we already have in the context.