### PR TITLE
[BUGFIX beta] Make toString safe for arrays too.

### DIFF
--- a/packages/ember-utils/lib/to-string.js
+++ b/packages/ember-utils/lib/to-string.js
@@ -1,11 +1,36 @@
 const objectToString = Object.prototype.toString;
 
+function isNone(obj) {
+  return obj === null || obj === undefined;
+}
+
 /*
  A `toString` util function that supports objects without a `toString`
  method, e.g. an object created with `Object.create(null)`.
 */
 export default function toString(obj) {
-  if (obj && typeof obj.toString === 'function') {
+  let type = typeof obj;
+  if (type === "string") { return obj; }
+
+  if (Array.isArray(obj)) {
+    // Reimplement Array.prototype.join according to spec (22.1.3.13)
+    // Changing ToString(element) with this safe version of ToString.
+    let len = obj.length;
+    let sep = ',';
+    let r = '';
+
+    for (let k = 0; k < len; k++) {
+      if (k > 0) {
+        r += ',';
+      }
+
+      if (!isNone(obj[k])) {
+        r += toString(obj[k]);
+      }
+    }
+
+    return r;
+  } else if (obj != null && typeof obj.toString === 'function') {
     return obj.toString();
   } else {
     return objectToString.call(obj);

--- a/packages/ember-utils/tests/to-string-test.js
+++ b/packages/ember-utils/tests/to-string-test.js
@@ -17,3 +17,10 @@ QUnit.test('toString falls back to Object.prototype.toString', function() {
 
   strictEqual(toString(obj), {}.toString());
 });
+
+QUnit.test('toString does not fail when called on Arrays with objects without toString method', function() {
+  let obj = Object.create(null);
+  let arr = [obj, 2];
+
+  strictEqual(toString(arr), `${({}).toString()},2`);
+});


### PR DESCRIPTION
`ember-utils/to-string` is documented as a `toString` function that supports
objects without a `toString` method.

Arrays do have a string method that is based on their `join` method. This
method spec ([Array.prototype.join in exma262 2017
draft](https://tc39.github.io/ecma262/#sec-array.prototype.join)) is based on
calling `toString` on the objects that form the collection. If an object were
not to have such method, `Array.prototype.toString` would throw and error.

This PR recreates `Array.prototype.join` as closer to the spec as I could,
changing the `ToString` part with the safe version of `toString`.

Fixes #14738 and #15113.