### PR TITLE
[DOC release] Document the result of `hash` is an empty object.

### DIFF
--- a/packages/ember-glimmer/lib/helpers/hash.js
+++ b/packages/ember-glimmer/lib/helpers/hash.js
@@ -23,6 +23,17 @@
 
    Where the `title` is bound to updates of the `office` property.
 
+   Note that the hash is an empty object with no prototype chain, therefore
+   common methods like `toString` are not available in the resulting hash.
+   If you need to use such a method, you can use the `call` or `apply`
+   approach:
+
+   ```js
+   function toString(obj) {
+     return Object.prototype.toString.apply(obj);
+   }
+   ```
+
    @method hash
    @for Ember.Templates.helpers
    @param {Object} options


### PR DESCRIPTION
Fixes #14489