### PR TITLE
backport to BETA [BUGFIX release] [Fixes #15492] WorkAround WebKit/JSC JIT WorkARound

### DIFF
--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -513,10 +513,7 @@ if (HAS_NATIVE_WEAKMAP) {
       if (DEBUG) {
         counters.peekCalls++;
       }
-      // stop if we find a `null` value, since
-      // that means the meta was deleted
-      // any other truthy value is a "real" meta
-      if (meta === null || meta !== undefined) {
+      if (meta !== undefined) {
         return meta;
       }
 
@@ -528,14 +525,10 @@ if (HAS_NATIVE_WEAKMAP) {
   };
 } else {
   setMeta = function Fallback_setMeta(obj, meta) {
-    // if `null` already, just set it to the new value
-    // otherwise define property first
-    if (obj[META_FIELD] !== null) {
-      if (obj.__defineNonEnumerable) {
-        obj.__defineNonEnumerable(EMBER_META_PROPERTY);
-      } else {
-        Object.defineProperty(obj, META_FIELD, META_DESC);
-      }
+    if (obj.__defineNonEnumerable) {
+      obj.__defineNonEnumerable(EMBER_META_PROPERTY);
+    } else {
+      Object.defineProperty(obj, META_FIELD, META_DESC);
     }
 
     obj[META_FIELD] = meta;
@@ -584,7 +577,7 @@ export function meta(obj) {
   let parent;
 
   // remove this code, in-favor of explicit parent
-  if (maybeMeta !== undefined && maybeMeta !== null) {
+  if (maybeMeta !== undefined) {
     if (maybeMeta.source === obj) {
       return maybeMeta;
     }

--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -8,7 +8,6 @@
 //
 import { symbol } from 'ember-utils';
 
-import { peekMeta } from 'ember-metal';
 import Ember, { // ES6TODO: Ember.A
   get,
   computed,
@@ -24,7 +23,9 @@ import Ember, { // ES6TODO: Ember.A
   _addBeforeObserver,
   _removeBeforeObserver,
   addObserver,
-  removeObserver
+  removeObserver,
+  meta,
+  peekMeta
 } from 'ember-metal';
 import { deprecate, assert } from 'ember-debug';
 import Enumerable from './enumerable';
@@ -638,7 +639,7 @@ const ArrayMixin = Mixin.create(Enumerable, {
 function EachProxy(content) {
   this._content = content;
   this._keys = undefined;
-  this.__ember_meta__ = null;
+  meta(this);
 }
 
 EachProxy.prototype = {


### PR DESCRIPTION
Affected version: 10.1.1 (12603.2.4)
Unaffected version: Safari 11.0, WebKit 12604.1.29

Which suggests the issue has been addressed upstream.

---

The following commit https://github.com/emberjs/ember.js/commit/986710f9c57a9ff4520034b600e7fea93b56b955#diff-7e13eecefe753df1d82ce67b32bc4366R566 remove an implicit toBoolean conversion in WeakMap_peekParentMeta which apparently trips up Webkit…

Simply reversing the expression addressed the issue.

failed: `if (meta === null || meta !== undefined) { … }`
passed: `if (meta !== undefined || meta === null) { … }`

We also, confirmed that reverting the one line in question to `meta === null || !meta) {` fixed Safari.

This PR removes the need for the an unused feature which avoids the expression entirely.

@krisselden / @stefanpenner