### PR TITLE
[BUGFIX lts] add ember-cli-is-package-missing to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "broccoli-funnel": "^1.2.0",
     "broccoli-merge-trees": "^2.0.0",
     "ember-cli-get-component-path-option": "^1.0.0",
+    "ember-cli-is-package-missing": "^1.0.0",
     "ember-cli-normalize-entity-name": "^1.0.0",
     "ember-cli-path-utils": "^1.0.0",
     "ember-cli-string-utils": "^1.1.0",


### PR DESCRIPTION
This blueprint dependency is missing from package.json. Without this, on npm 2 and if you linked ember-cli, you get:

```
Cannot find module 'ember-cli-is-package-missing'
Error: Cannot find module 'ember-cli-is-package-missing'
    at Function.Module._resolveFilename (module.js:470:15)
    at Function.Module._load (module.js:418:25)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/kelly.selden/Sites/dustbunny/node_modules/ember-source/blueprints/component-test/index.js:6:24)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
```