### PR TITLE
Release root components after they are destroyed

### DIFF
--- a/packages/ember-glimmer/lib/renderer.js
+++ b/packages/ember-glimmer/lib/renderer.js
@@ -241,6 +241,7 @@ class Renderer {
       let root = roots[i];
       if (root.isFor(view)) {
         root.destroy();
+        roots.splice(i, 1);
       }
     }
   }

--- a/packages/ember-glimmer/tests/integration/components/append-test.js
+++ b/packages/ember-glimmer/tests/integration/components/append-test.js
@@ -317,11 +317,7 @@ class AbstractAppendTest extends RenderingTest {
 
     this.runTask(() => this.component.destroy());
 
-    if (this.isHTMLBars) {
-      // Bug in Glimmer – component should not have .element at this point
-      assert.ok(!this.component.element, 'It should not have an element');
-    }
-
+    assert.ok(!this.component.element, 'It should not have an element');
     assert.ok(!componentElement.parentElement, 'The component element should be detached');
 
     this.assert.equal(willDestroyCalled, 1);
@@ -411,11 +407,8 @@ class AbstractAppendTest extends RenderingTest {
       second.destroy();
     });
 
-    if (this.isHTMLBars) {
-      // Bug in Glimmer – component should not have .element at this point
-      assert.ok(!first.element, 'The first component should not have an element');
-      assert.ok(!second.element, 'The second component should not have an element');
-    }
+    assert.ok(!first.element, 'The first component should not have an element');
+    assert.ok(!second.element, 'The second component should not have an element');
 
     assert.ok(!componentElement1.parentElement, 'The first component element should be detached');
     assert.ok(!componentElement2.parentElement, 'The second component element should be detached');

--- a/packages/ember-glimmer/tests/integration/components/append-test.js
+++ b/packages/ember-glimmer/tests/integration/components/append-test.js
@@ -323,6 +323,23 @@ class AbstractAppendTest extends RenderingTest {
     this.assert.equal(willDestroyCalled, 1);
   }
 
+  ['@test releasing a root component after it has been destroy'](assert) {
+    let renderer = this.owner.lookup('renderer:-dom');
+
+    this.registerComponent('x-component', {
+      ComponentClass: Component.extend()
+    });
+
+    this.component = this.owner.factoryFor('component:x-component').create();
+    this.append(this.component);
+
+    assert.equal(renderer._roots.length, 1, 'added a root component');
+
+    this.runTask(() => this.component.destroy());
+
+    assert.equal(renderer._roots.length, 0, 'released the root component');
+  }
+
   ['@test appending, updating and destroying multiple components'](assert) {
     let willDestroyCalled = 0;
 


### PR DESCRIPTION
The first commit removes some guards around assertions that used to fail in Glimmer. They seem to be working now 🎉 

The second commit removes destroyed root components from `renderer._roots`. This was the behavior [before this commit](https://github.com/emberjs/ember.js/commit/779135f4f3573ef2c2198398b3337d099f1454e4#diff-81a6bd748241dc482155a442e12bc32e).

I'm submitting this PR because retaining the destroyed components is causing trouble for me when attempting to create [a new feature for ember-islands](https://github.com/mitchlloyd/ember-islands/issues/41). I'd like to destroy a component and have it released so that I don't leak memory. The issue manifests in tests:

1) Use `component.appendTo()` in an acceptance test.
2) Call `component.destroy()`.
3) On test teardown (`application.destroy()`) I get an error `Error: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.`

Glimmer throws this error because Ember attempts to clean up all the `_roots` from [`_clearAllRoots`](https://github.com/emberjs/ember.js/blob/58c0faa0cceaef1aa1e191042b39bcfc044dc924/packages/ember-glimmer/lib/renderer.js#L368destroy). However the component in `_roots` has already been destroyed.