### PR TITLE
[BACKPORT BETA] [BUGFIX beta] remove Error.captureStackTrace

### DIFF
--- a/packages/ember-debug/lib/error.js
+++ b/packages/ember-debug/lib/error.js
@@ -27,13 +27,7 @@ export default class EmberError extends ExtendBuiltin(Error) {
     }
 
     let error = Error.call(this, message);
-
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, EmberError);
-    } else {
-      this.stack = error.stack;
-    }
-
+    this.stack = error.stack;
     this.description = error.description;
     this.fileName = error.fileName;
     this.lineNumber = error.lineNumber;


### PR DESCRIPTION
We only do this for stack cosmetic reasons, it really just removes 1 or so frames, but apparently more recently at a hefty cost:

context: https://github.com/emberjs/ember.js/issues/15516 

cc @schuay