### PR TITLE
refactor set/get path

### DIFF
--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -55,7 +55,7 @@ export function get(obj, keyName) {
   assert(`'this' in paths is not supported`, keyName.lastIndexOf('this.', 0) !== 0);
   assert('Cannot call `Ember.get` with an empty string', keyName !== '');
 
-  return isPath(keyName) ? _getPath(obj, keyName) : _get(obj, keyName);
+  return isPath(keyName) ? _getPath(obj, keyName.split('.')) : _get(obj, keyName);
 }
 
 function _get(obj, keyName) {
@@ -72,16 +72,15 @@ function _get(obj, keyName) {
   }
 }
 
-export function _getPath(root, path) {
+export function _getPath(root, pathParts) {
   let obj = root;
-  let parts = path.split('.');
 
-  for (let i = 0; i < parts.length; i++) {
+  for (let i = 0; i < pathParts.length; i++) {
     if (!isGettable(obj)) {
       return undefined;
     }
 
-    obj = _get(obj, parts[i]);
+    obj = _get(obj, pathParts[i]);
 
     if (obj && obj.isDestroyed) {
       return undefined;

--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -55,10 +55,10 @@ export function get(obj, keyName) {
   assert(`'this' in paths is not supported`, keyName.lastIndexOf('this.', 0) !== 0);
   assert('Cannot call `Ember.get` with an empty string', keyName !== '');
 
-  if (isPath(keyName)) {
-    return _getPath(obj, keyName);
-  }
+  return isPath(keyName) ? _getPath(obj, keyName) : _get(obj, keyName);
+}
 
+function _get(obj, keyName) {
   let value = obj[keyName];
   let isDescriptor = value !== null && typeof value === 'object' && value.isDescriptor;
 
@@ -81,7 +81,7 @@ export function _getPath(root, path) {
       return undefined;
     }
 
-    obj = get(obj, parts[i]);
+    obj = _get(obj, parts[i]);
 
     if (obj && obj.isDestroyed) {
       return undefined;

--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -3,7 +3,6 @@
 */
 
 import { assert } from 'ember-debug';
-import { isPath } from './path_cache';
 
 const ALLOWABLE_TYPES = {
   object: true,
@@ -55,7 +54,8 @@ export function get(obj, keyName) {
   assert(`'this' in paths is not supported`, keyName.lastIndexOf('this.', 0) !== 0);
   assert('Cannot call `Ember.get` with an empty string', keyName !== '');
 
-  return isPath(keyName) ? _getPath(obj, keyName.split('.')) : _get(obj, keyName);
+  let keys = keyName.split('.');
+  return keys.length === 1 ? _get(obj, keyName) : _getPath(obj, keys);
 }
 
 function _get(obj, keyName) {

--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -55,13 +55,15 @@ export function get(obj, keyName) {
   assert(`'this' in paths is not supported`, keyName.lastIndexOf('this.', 0) !== 0);
   assert('Cannot call `Ember.get` with an empty string', keyName !== '');
 
+  if (isPath(keyName)) {
+    return _getPath(obj, keyName);
+  }
+
   let value = obj[keyName];
   let isDescriptor = value !== null && typeof value === 'object' && value.isDescriptor;
 
   if (isDescriptor) {
     return value.get(obj, keyName);
-  } else if (isPath(keyName)) {
-    return _getPath(obj, keyName);
   } else if (value === undefined && 'object' === typeof obj && !(keyName in obj) &&
     typeof obj.unknownProperty === 'function') {
     return obj.unknownProperty(keyName);


### PR DESCRIPTION
* checks `isPath` before accessing property in `get`
* uses spliced path for `setPath/getPath` to avoid extra join/splits
* avoids checking `isPath` when setting through `setPath/getPath`
* avoids using `isPath` (since indexOf and split seem to perform equally https://jsperf.com/string-match-vs-string-split so better just split)