### PR TITLE
allow `readOnly` to passed as option in `ComputedProperty`

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -129,7 +129,8 @@ const DEEP_EACH_REGEX = /\.@each\.[^.]+\./;
 */
 function ComputedProperty(config, opts) {
   this.isDescriptor = true;
-  if (typeof config === 'function') {
+  let hasGetterOnly = typeof config === 'function';
+  if (hasGetterOnly) {
     this._getter = config;
   } else {
     assert('Ember.computed expects a function or an object as last argument.', typeof config === 'object' && !Array.isArray(config));
@@ -141,8 +142,9 @@ function ComputedProperty(config, opts) {
   this._suspended = undefined;
   this._meta = undefined;
   this._volatile = false;
+
   this._dependentKeys = opts && opts.dependentKeys;
-  this._readOnly =  false;
+  this._readOnly = opts && hasGetterOnly && opts.readOnly === true;
 }
 
 ComputedProperty.prototype = new Descriptor();

--- a/packages/ember-runtime/lib/computed/computed_macros.js
+++ b/packages/ember-runtime/lib/computed/computed_macros.js
@@ -462,7 +462,7 @@ export function lte(dependentKey, value) {
   a logical `and` on the values of all the original values for properties.
   @public
 */
-export let and = generateComputedWithPredicate('and', value => value);
+export const and = generateComputedWithPredicate('and', value => value);
 
 /**
   A computed property which performs a logical `or` on the
@@ -499,7 +499,7 @@ export let and = generateComputedWithPredicate('and', value => value);
   a logical `or` on the values of all the original values for properties.
   @public
 */
-export let or = generateComputedWithPredicate('or', value => !value);
+export const or = generateComputedWithPredicate('or', value => !value);
 
 /**
   Creates a new property that is an alias for another property


### PR DESCRIPTION
looked odd to use `.readOnly()` with  `new ComputedProperty`