### PR TITLE
Convert blueprints to using new module syntax

### DIFF
--- a/blueprints/acceptance-test/mocha-files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/mocha-files/tests/acceptance/__name__-test.js
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
 import startApp from '<%= dasherizedPackageName %>/tests/helpers/start-app';
-<% if (destroyAppExists) { %>import destroyApp from '<%= dasherizedPackageName %>/tests/helpers/destroy-app';<% } else { %>import Ember from 'ember';<% } %>
+<% if (destroyAppExists) { %>import destroyApp from '<%= dasherizedPackageName %>/tests/helpers/destroy-app';<% } else { %>import { run } from '@ember/runloop';<% } %>
 
 describe('<%= friendlyTestName %>', function() {
   let application;
@@ -11,7 +11,7 @@ describe('<%= friendlyTestName %>', function() {
   });
 
   afterEach(function() {
-    <% if (destroyAppExists) { %>destroyApp(application);<% } else { %>Ember.run(application, 'destroy');<% } %>
+    <% if (destroyAppExists) { %>destroyApp(application);<% } else { %>run(application, 'destroy');<% } %>
   });
 
   it('can visit /<%= dasherizedModuleName %>', function() {

--- a/blueprints/component/files/__root__/__path__/__name__.js
+++ b/blueprints/component/files/__root__/__path__/__name__.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 <%= importTemplate %>
-export default Ember.Component.extend({<%= contents %>
+export default Component.extend({<%= contents %>
 });

--- a/blueprints/controller/files/__root__/__path__/__name__.js
+++ b/blueprints/controller/files/__root__/__path__/__name__.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Controller from '@ember/controller';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
 });

--- a/blueprints/helper/files/__root__/helpers/__name__.js
+++ b/blueprints/helper/files/__root__/helpers/__name__.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import { helper } from '@ember/component/helper';
 
 export function <%= camelizedModuleName %>(params/*, hash*/) {
   return params;
 }
 
-export default Ember.Helper.helper(<%= camelizedModuleName %>);
+export default helper(<%= camelizedModuleName %>);

--- a/blueprints/initializer-test/mocha-files/tests/unit/initializers/__name__-test.js
+++ b/blueprints/initializer-test/mocha-files/tests/unit/initializers/__name__-test.js
@@ -1,15 +1,16 @@
+import Application from '@ember/application';
 import { expect } from 'chai';
 import { describe, it, beforeEach, afterEach } from 'mocha';
-import Ember from 'ember';
 import { initialize } from '<%= dasherizedModulePrefix %>/initializers/<%= dasherizedModuleName %>';
 import destroyApp from '../../helpers/destroy-app';
+import { run } from '@ember/runloop';
 
 describe('<%= friendlyTestName %>', function() {
   let application;
 
   beforeEach(function() {
-    Ember.run(function() {
-      application = Ember.Application.create();
+    run(function() {
+      application = Application.create();
       application.deferReadiness();
     });
   });

--- a/blueprints/initializer-test/qunit-files/tests/unit/initializers/__name__-test.js
+++ b/blueprints/initializer-test/qunit-files/tests/unit/initializers/__name__-test.js
@@ -1,12 +1,13 @@
-import Ember from 'ember';
+import Application from '@ember/application';
 import { initialize } from '<%= dasherizedModulePrefix %>/initializers/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 import destroyApp from '../../helpers/destroy-app';
+import { run } from '@ember/runloop';
 
 module('<%= friendlyTestName %>', {
   beforeEach() {
-    Ember.run(() => {
-      this.application = Ember.Application.create();
+    run(() => {
+      this.application = Application.create();
       this.application.deferReadiness();
     });
   },

--- a/blueprints/instance-initializer-test/mocha-files/tests/unit/instance-initializers/__name__-test.js
+++ b/blueprints/instance-initializer-test/mocha-files/tests/unit/instance-initializers/__name__-test.js
@@ -1,21 +1,22 @@
+import Application from '@ember/application';
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
-import Ember from 'ember';
 import { initialize } from '<%= dasherizedModulePrefix %>/instance-initializers/<%= dasherizedModuleName %>';
 import destroyApp from '../../helpers/destroy-app';
+import { run } from '@ember/runloop';
 
 describe('<%= friendlyTestName %>', function() {
   let application, appInstance;
 
   beforeEach(function() {
-    Ember.run(function() {
-      application = Ember.Application.create();
+    run(function() {
+      application = Application.create();
       appInstance = application.buildInstance();
     });
   });
 
   afterEach(function() {
-    Ember.run(appInstance, 'destroy');
+    run(appInstance, 'destroy');
     destroyApp(application);
   });
 

--- a/blueprints/instance-initializer-test/qunit-files/tests/unit/instance-initializers/__name__-test.js
+++ b/blueprints/instance-initializer-test/qunit-files/tests/unit/instance-initializers/__name__-test.js
@@ -1,17 +1,18 @@
-import Ember from 'ember';
+import Application from '@ember/application';
 import { initialize } from '<%= dasherizedModulePrefix %>/instance-initializers/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 import destroyApp from '../../helpers/destroy-app';
+import { run } from '@ember/runloop';
 
 module('<%= friendlyTestName %>', {
   beforeEach() {
-    Ember.run(() => {
-      this.application = Ember.Application.create();
+    run(() => {
+      this.application = Application.create();
       this.appInstance = this.application.buildInstance();
     });
   },
   afterEach() {
-    Ember.run(this.appInstance, 'destroy');
+    run(this.appInstance, 'destroy');
     destroyApp(this.application);
   }
 });

--- a/blueprints/mixin-test/mocha-files/tests/unit/mixins/__name__-test.js
+++ b/blueprints/mixin-test/mocha-files/tests/unit/mixins/__name__-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import Ember from 'ember';
+import EmberObject from '@ember/object';
 import <%= classifiedModuleName %>Mixin from '<%= dasherizedPackageName %>/mixins/<%= dasherizedModuleName %>';
 
 describe('<%= friendlyTestName %>', function() {
   // Replace this with your real tests.
   it('works', function() {
-    let <%= classifiedModuleName %>Object = Ember.Object.extend(<%= classifiedModuleName %>Mixin);
+    let <%= classifiedModuleName %>Object = EmberObject.extend(<%= classifiedModuleName %>Mixin);
     let subject = <%= classifiedModuleName %>Object.create();
     expect(subject).to.be.ok;
   });

--- a/blueprints/mixin-test/qunit-files/tests/unit/mixins/__name__-test.js
+++ b/blueprints/mixin-test/qunit-files/tests/unit/mixins/__name__-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import EmberObject from '@ember/object';
 import <%= classifiedModuleName %>Mixin from '<%= projectName %>/mixins/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 
@@ -6,7 +6,7 @@ module('<%= friendlyTestName %>');
 
 // Replace this with your real tests.
 test('it works', function(assert) {
-  let <%= classifiedModuleName %>Object = Ember.Object.extend(<%= classifiedModuleName %>Mixin);
+  let <%= classifiedModuleName %>Object = EmberObject.extend(<%= classifiedModuleName %>Mixin);
   let subject = <%= classifiedModuleName %>Object.create();
   assert.ok(subject);
 });

--- a/blueprints/mixin/files/__root__/mixins/__name__.js
+++ b/blueprints/mixin/files/__root__/mixins/__name__.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Mixin from '@ember/mixin';
 
-export default Ember.Mixin.create({
+export default Mixin.create({
 });

--- a/blueprints/route/files/__root__/__path__/__name__.js
+++ b/blueprints/route/files/__root__/__path__/__name__.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
 });

--- a/blueprints/service/files/__root__/__path__/__name__.js
+++ b/blueprints/service/files/__root__/__path__/__name__.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Service from '@ember/service';
 
-export default Ember.Service.extend({
+export default Service.extend({
 });

--- a/blueprints/test-helper/files/tests/helpers/__name__.js
+++ b/blueprints/test-helper/files/tests/helpers/__name__.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import { registerAsyncHelper } from '@ember/test';
 
-export default Ember.Test.registerAsyncHelper('<%= camelizedModuleName %>', function(app) {
+export default registerAsyncHelper('<%= camelizedModuleName %>', function(app) {
 
 });


### PR DESCRIPTION
This PR converts the blueprints over to using the new module syntax. I’m not sure if we want to throw in checks for ember-cli-babel version, and switch what they do based on that or not.

Additionally, I’m unsure if we want to merge these in before updating the rest of the codebase to use modules as well.

I just know I could really use some blueprints with the new syntax, so wanted to get the ball rolling :smiley: 