### PR TITLE
[DOC release] Fix links in {{action}} helper documentation

### DIFF
--- a/packages/ember-glimmer/lib/helpers/action.js
+++ b/packages/ember-glimmer/lib/helpers/action.js
@@ -205,8 +205,8 @@ export const ACTION = symbol('ACTION');
 
   If you need the default handler to trigger you should either register your
   own event handler, or use event methods on your view class. See
-  ["Responding to Browser Events"](/api/classes/Ember.View.html#toc_responding-to-browser-events)
-  in the documentation for Ember.View for more information.
+  ["Responding to Browser Events"](/api/classes/Ember.Component#responding-to-browser-events)
+  in the documentation for Ember.Component for more information.
 
   ### Specifying DOM event type
 
@@ -220,7 +220,7 @@ export const ACTION = symbol('ACTION');
   </div>
   ```
 
-  See ["Event Names"](/api/classes/Ember.View.html#toc_event-names) for a list of
+  See ["Event Names"](/api/classes/Ember.Component#event-names) for a list of
   acceptable DOM event names.
 
   ### Specifying whitelisted modifier keys


### PR DESCRIPTION
Documentation in the `{{action}}` helper still referred to Ember.View
documentation.

Fixes #15571