### PR TITLE
[BUGFIX beta] Include missing sourcemaps in vendorTree

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,11 +58,18 @@ module.exports = {
       'ember.debug.js',
       'ember.min.js',
       'ember.prod.js'
-    ].filter(function(file) {
-      var fullPath = path.join(__dirname, 'dist', file);
+    ]
+      .map(function(file) {
+        return [file, file.replace('.js', '.map')];
+      })
+      .reduce(function(flat, jsAndMap) {
+        return flat.concat(jsAndMap);
+      }, [])
+      .filter(function(file) {
+        var fullPath = path.join(__dirname, 'dist', file);
 
-      return fs.existsSync(fullPath);
-    });
+        return fs.existsSync(fullPath);
+      });
 
     var ember = new Funnel(__dirname + '/dist', {
       destDir: 'ember',


### PR DESCRIPTION
Fixes #15464 

This adds the missing sourcemap files to `vendorTree`, so the references in `.js` files (`//# sourceMappingURL=ember.debug.map`) are not pointing to non-existing files anymore.

There were no existing tests for the addon-output, so not sure if I should add some? (maybe separate PR?). Tested this in a real app, seems to work fine so far:
<img src="https://user-images.githubusercontent.com/1325249/29192215-e94687e8-7e20-11e7-8bb4-dd600416a98a.png" width="197" height="258">

Also not sure if this should rather be tagged for `release` rather than `beta`?

cc @rwjblue 
