### PR TITLE
[WIP] Move `wasApplied` into Meta.

### DIFF
--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -40,6 +40,7 @@ const SOURCE_DESTROYING = 1 << 1;
 const SOURCE_DESTROYED = 1 << 2;
 const META_DESTROYED = 1 << 3;
 const IS_PROXY = 1 << 4;
+const WAS_APPLIED = 1 << 5;
 
 const META_FIELD = '__ember_meta__';
 const NODE_STACK = [];
@@ -169,6 +170,22 @@ export class Meta {
 
   setProxy() {
     this._flags |= IS_PROXY;
+  }
+
+  get wasApplied() {
+    assert('cannot access wasApplied for an instances meta', this.proto === this.source);
+
+    return (this._flags & WAS_APPLIED) !== 0;
+  }
+
+  set wasApplied(value) {
+    assert('cannot set wasApplied for an instances meta', this.proto === this.source);
+
+    if (value === true) {
+      this._flags |= WAS_APPLIED;
+    } else {
+      this._flags &= ~WAS_APPLIED;
+    }
   }
 
   _getOrCreateOwnMap(key) {

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -50,13 +50,12 @@ function makeCtor() {
   // Note: avoid accessing any properties on the object since it makes the
   // method a lot faster. This is glue code so we want it to be as fast as
   // possible.
-
-  let wasApplied = false;
   let initProperties, initFactory;
 
   class Class {
     constructor() {
-      if (!wasApplied) {
+      let m = meta(this);
+      if (!m.parent.wasApplied) {
         Class.proto(); // prepare prototype...
       }
 
@@ -65,7 +64,6 @@ function makeCtor() {
       }
 
       this.__defineNonEnumerable(GUID_KEY_PROPERTY);
-      let m = meta(this);
       let proto = m.proto;
       m.proto = this;
 
@@ -167,11 +165,12 @@ function makeCtor() {
     }
 
     static willReopen() {
-      if (wasApplied) {
+      let m = meta(this.prototype);
+      if (m.wasApplied) {
         Class.PrototypeMixin = Mixin.create(Class.PrototypeMixin);
       }
 
-      wasApplied = false;
+      m.wasApplied = false;
     }
 
     static _initProperties(args) { initProperties = args; }
@@ -181,8 +180,9 @@ function makeCtor() {
       let superclass = Class.superclass;
       if (superclass) { superclass.proto(); }
 
-      if (!wasApplied) {
-        wasApplied = true;
+      let m = meta(this.prototype);
+      if (!m.wasApplied) {
+        m.wasApplied = true;
         Class.PrototypeMixin.applyPartial(Class.prototype);
       }
 
@@ -947,6 +947,11 @@ let ClassMixin = Mixin.create(ClassMixinProps);
 ClassMixin.ownerConstructor = CoreObject;
 
 CoreObject.ClassMixin = ClassMixin;
+
+// ensure CoreObject itself has a proper class meta
+let proto = CoreObject.prototype;
+generateGuid(proto);
+meta(proto).proto = proto;
 
 ClassMixin.apply(CoreObject);
 export default CoreObject;


### PR DESCRIPTION
This removes the closure scoped variable used to track if a given `PrototypeMixin` has been applied for the current class by moving it into the `Meta`'s `this._flags`.

This is the first baby step towards correcting some issues with native ES class interop.

TODO: 

- [ ] Ensure that `.proto` is not being called more than once (I believe this is already undertest but want to confirm).
- [ ] Run benchmarks to confirm this isn't a performance regression.