### PR TITLE
[BUGFIX beta] Throw if Ember is in both `package.json` and `bower.json`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 var fs = require('fs');
 var path = require('path');
 var resolve = require('resolve');
+var SilentError = require('silent-error');
 
 var paths = {};
 var absolutePaths = {};
@@ -26,8 +27,7 @@ module.exports = {
   init: function() {
 		this._super.init && this._super.init.apply(this, arguments);
     if ('ember' in this.project.bowerDependencies()) {
-      // TODO: move this to a throw soon.
-      this.ui.writeWarnLine('Ember.js is now provided by node_module `ember-source`, please remove it from bower');
+      throw new SilentError('Ember.js is now provided by node_module `ember-source`, please remove it from your project\'s bower.json.');
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "jquery": "^3.2.1",
     "resolve": "^1.3.3",
     "rsvp": "^3.6.1",
+    "silent-error": "^1.1.0",
     "simple-dom": "^0.3.0",
     "simple-html-tokenizer": "^0.4.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5490,7 +5490,7 @@ signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-silent-error@^1.0.0, silent-error@^1.0.1:
+silent-error@^1.0.0, silent-error@^1.0.1, silent-error@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/silent-error/-/silent-error-1.1.0.tgz#2209706f1c850a9f1d10d0d840918b46f26e1bc9"
   dependencies:


### PR DESCRIPTION
This warning was non-obvious (which one "wins"?), and allows for misconfiguration in `config/ember-try.js` to _seem_ like you are testing many Ember versions but in reality you are just testing whatever `ember-source` version you have :sob:.

See https://github.com/emberjs/data/pull/5123 for the full sob story...