### PR TITLE
Update ember-cli-version-checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "ember-cli-string-utils": "^1.1.0",
     "ember-cli-test-info": "^1.0.0",
     "ember-cli-valid-component-name": "^1.0.0",
-    "ember-cli-version-checker": "^1.3.1",
+    "ember-cli-version-checker": "^2.0.0",
     "ember-router-generator": "^1.2.3",
     "handlebars": "^4.0.6",
     "jquery": "^3.2.1",


### PR DESCRIPTION
The presence of ember-cli-version-checker prior to 2.0.0 anywhere in an app's dependencies makes it impossible to use dependencies that are hoisted above the ember app's root directory. Now that yarn has workspaces support, that's not an unreasonable thing to want to do.