### PR TITLE
Remove outdated {{with}} documentation

### DIFF
--- a/packages/ember-glimmer/lib/index.js
+++ b/packages/ember-glimmer/lib/index.js
@@ -95,9 +95,7 @@
     {{/each}}
   {{/with}}
   ```
-
-  Without the `as` operator, it would be impossible to reference `user.name` in the example above.
-
+  
   NOTE: The alias should not reuse a name from the bound property path.
 
   For example: `{{#with foo.bar as |foo|}}` is not supported because it attempts to alias using


### PR DESCRIPTION
`{{with}}` used to change the scope of `this`, so I expect this is what's meant by "Without the as operator, it would be impossible to reference user.name in the example above." but that's not the case now as far as I'm aware.

[Twiddle to demonstrate](https://ember-twiddle.com/77c748e8449e44c974f68c918910368d?openFiles=templates.application.hbs%2C).

