### PR TITLE
Support ES6 iterables on {{#each}} helper

### DIFF
--- a/packages/ember-glimmer/lib/utils/iterable.ts
+++ b/packages/ember-glimmer/lib/utils/iterable.ts
@@ -17,7 +17,7 @@ import {
   _contentFor,
   isEmberArray
 } from 'ember-runtime';
-import { guidFor } from 'ember-utils';
+import { guidFor, HAS_NATIVE_SYMBOL } from 'ember-utils';
 import { isEachIn } from '../helpers/each-in';
 import {
   UpdatablePrimitiveReference,
@@ -244,7 +244,6 @@ class EachInIterable {
     reference.update(item.value);
   }
 }
-
 class ArrayIterable {
   public ref: UpdatableReference;
   public keyFor: KeyFor;
@@ -279,6 +278,8 @@ class ArrayIterable {
       let array: any[] = [];
       iterable.forEach((item: any) => array.push(item));
       return ArrayIterator.from(array, keyFor);
+    } else if (HAS_NATIVE_SYMBOL && typeof iterable[Symbol.iterator] === 'function') {
+      return ArrayIterator.from(Array.from(iterable), keyFor);
     } else {
       return EMPTY_ITERATOR;
     }

--- a/packages/ember-utils/lib/index.js
+++ b/packages/ember-utils/lib/index.js
@@ -29,4 +29,5 @@ export { canInvoke, tryInvoke } from './invoke';
 export { default as makeArray } from './make-array';
 export { default as NAME_KEY } from './name';
 export { default as toString } from './to-string';
+export { HAS_NATIVE_SYMBOL } from './symbol-utils';
 export { HAS_NATIVE_PROXY } from './proxy-utils';

--- a/packages/ember-utils/lib/symbol-utils.js
+++ b/packages/ember-utils/lib/symbol-utils.js
@@ -1,0 +1,9 @@
+export const HAS_NATIVE_SYMBOL = (function() {
+  let hasSymbol = typeof Symbol === 'function';
+  if (hasSymbol === false) { return false; }
+
+  let instance = Symbol('test-symbol');
+  // use `Object`'s `.toString` directly to prevent us from detecting
+  // polyfills as native
+  return Object.prototype.toString.call(instance) === '[object Symbol]';
+})();


### PR DESCRIPTION
The requirement is that they support `Symbol.iterator`, only for browsers that have iterators. 
The only supported browser that doesn't support is Internet Explorer 11.

One caveat of this feature is that iterables are not observables, so each
cannot track updates to them, but the code is structured on a way that
this branch is a fallback, so all special cases where KVO is possible are
handled as they where before.