### PR TITLE
[DOC release] document how to use pauseTest() with ember-mocha

### DIFF
--- a/packages/ember-testing/lib/helpers/pause_test.js
+++ b/packages/ember-testing/lib/helpers/pause_test.js
@@ -31,6 +31,28 @@ export function resumeTest() {
  return pauseTest();
  click('.btn');
  ```
+
+ You may want to turn off the timeout before pausing.
+
+ qunit (as of 2.4.0):
+
+ ```
+ visit('/');
+ assert.timeout(0);
+ return pauseTest();
+ click('.btn');
+ ```
+
+ mocha:
+
+ ```
+ visit('/');
+ this.timeout(0);
+ return pauseTest();
+ click('.btn');
+ ```
+
+
  @since 1.9.0
  @method pauseTest
  @return {Object} A promise that will never resolve


### PR DESCRIPTION
Anyone using `pauseTest()` probably needs to disable the timeout for the test in order for it to be useful. This PR documents that in exactly the place where it would help people discover this most easily.

I've tried quite a few approaches to reducing the timeout before coming across this one:
- Through an environment variable I used to toggle the mocha setup as described [here](https://github.com/emberjs/ember-mocha/issues/28).
- hoping the cli flag `--no-timeouts` would pass through to mocha (but it didn't).
- Finally, just doing it in the specific test (I didn't even realize this was an option right away!)

(for another PR/discussion:) It would be even more awesome if pauseTest() could set timeout to 0 for us, since that's what developers are likely to want/hope/expect when using pauseTest(). For discussion of that, see: https://github.com/emberjs/ember-mocha/issues/75