### PR TITLE
refactor(core-object): Passes initProperties directly to the constructor

### DIFF
--- a/packages/ember-routing/tests/system/router_test.js
+++ b/packages/ember-routing/tests/system/router_test.js
@@ -41,7 +41,7 @@ moduleFor('Ember Router', class extends AbstractTestCase {
   }
 
   ['@test can create a router without an owner'](assert) {
-    createRouter(null, { disableSetup: true, skipOwner: true });
+    createRouter(undefined, { disableSetup: true, skipOwner: true });
 
     assert.ok(true, 'no errors were thrown when creating without a container');
   }
@@ -54,13 +54,13 @@ moduleFor('Ember Router', class extends AbstractTestCase {
   }
 
   ['@test should not create a router.js instance upon init'](assert) {
-    let router = createRouter(null, { disableSetup: true });
+    let router = createRouter(undefined, { disableSetup: true });
 
     assert.ok(!router._routerMicrolib);
   }
 
   ['@test should not reify location until setupRouter is called'](assert) {
-    let router = createRouter(null, { disableSetup: true });
+    let router = createRouter(undefined, { disableSetup: true });
     assert.equal(typeof router.location, 'string', 'location is specified as a string');
 
     router.setupRouter();

--- a/packages/ember-runtime/tests/mixins/array_test.js
+++ b/packages/ember-runtime/tests/mixins/array_test.js
@@ -24,8 +24,8 @@ import { A as emberA } from '../../mixins/array';
 const TestArray = EmberObject.extend(EmberArray, {
   _content: null,
 
-  init(ary = []) {
-    this._content = ary;
+  init() {
+    this._content = this._content || [];
   },
 
   // some methods to modify the array so we can test changes.  Note that
@@ -60,7 +60,7 @@ ArrayTests.extend({
 
   newObject(ary) {
     ary = ary ? ary.slice() : this.newFixture(3);
-    return new TestArray(ary);
+    return new TestArray({ _content: ary });
   },
 
   // allows for testing of the basic enumerable after an internal mutation
@@ -83,7 +83,7 @@ QUnit.test('the return value of slice has Ember.Array applied', function(assert)
 });
 
 QUnit.test('slice supports negative index arguments', function(assert) {
-  let testArray = new TestArray([1, 2, 3, 4]);
+  let testArray = new TestArray({ _content: [1, 2, 3, 4] });
 
   assert.deepEqual(testArray.slice(-2), [3, 4], 'slice(-2)');
   assert.deepEqual(testArray.slice(-2, -1), [3], 'slice(-2, -1');
@@ -254,12 +254,14 @@ let ary;
 
 QUnit.module('EmberArray.@each support', {
   beforeEach() {
-    ary = new TestArray([
-      { isDone: true, desc: 'Todo 1' },
-      { isDone: false, desc: 'Todo 2' },
-      { isDone: true, desc: 'Todo 3' },
-      { isDone: false, desc: 'Todo 4' }
-    ]);
+    ary = new TestArray({
+      _content: [
+        { isDone: true, desc: 'Todo 1' },
+        { isDone: false, desc: 'Todo 2' },
+        { isDone: true, desc: 'Todo 3' },
+        { isDone: false, desc: 'Todo 4' }
+      ]
+    });
   },
 
   afterEach() {

--- a/packages/ember-runtime/tests/system/object/create_test.js
+++ b/packages/ember-runtime/tests/system/object/create_test.js
@@ -108,8 +108,3 @@ QUnit.test('EmberObject.create can take undefined as a parameter', function(asse
   let o = EmberObject.create(undefined);
   assert.deepEqual(EmberObject.create(), o);
 });
-
-QUnit.test('EmberObject.create can take null as a parameter', function(assert) {
-  let o = EmberObject.create(null);
-  assert.deepEqual(EmberObject.create(), o);
-});


### PR DESCRIPTION
Passes initProperties directly to the constructor, and does property collapsing in the `create` function instead of in the constructor for when multiple objects are passed in. This is part of the initial work to get the proposed APIs in the ES Class RFC solidified (constructor API mainly). 

This PR is mostly a rebase of the work done in #14349, though it goes the extra step of completely removing the `initProperties` closure variable and modernizes some of the syntax.

The last PR was held up by performance testing, I haven't run those before but am up to doing it if someone can point me in the right direction!

cc @rwjblue @krisselden @locks 