### PR TITLE
[BUGFIX release] ensure “pause on exception” pauses in the right place

### DIFF
--- a/packages/ember-metal/lib/error_handler.js
+++ b/packages/ember-metal/lib/error_handler.js
@@ -13,6 +13,12 @@ let getStack = error => {
   return stack;
 };
 
+export const onErrorTarget = {
+  get onerror() {
+    return dispatchOverride || getOnerror();
+  }
+};
+
 let onerror;
 // Ember.onerror getter
 export function getOnerror() {

--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -1,8 +1,7 @@
 import { GUID_KEY } from 'ember-utils';
 import { assert, isTesting } from 'ember-debug';
 import {
-  dispatchError,
-  setOnerror
+  onErrorTarget
 } from './error_handler';
 import {
   beginPropertyChanges,
@@ -18,25 +17,16 @@ function onEnd(current, next) {
   run.currentRunLoop = next;
 }
 
-const onErrorTarget = {
-  get onerror() {
-    return dispatchError;
-  },
-  set onerror(handler) {
-    return setOnerror(handler);
-  }
-};
-
 const backburner = new Backburner(['sync', 'actions', 'destroy'], {
-  GUID_KEY: GUID_KEY,
+  GUID_KEY,
   sync: {
     before: beginPropertyChanges,
     after: endPropertyChanges
   },
   defaultQueue: 'actions',
-  onBegin: onBegin,
-  onEnd: onEnd,
-  onErrorTarget: onErrorTarget,
+  onBegin,
+  onEnd,
+  onErrorTarget,
   onErrorMethod: 'onerror'
 });
 

--- a/packages/ember-metal/tests/error_handler_test.js
+++ b/packages/ember-metal/tests/error_handler_test.js
@@ -1,0 +1,56 @@
+import Ember from 'ember';
+import { run } from 'ember-metal';
+
+const ONERROR = Ember.onerror;
+const ADAPTER = Ember.Test.adapter;
+
+QUnit.module('error_handler', {
+  afterEach() {
+    Ember.onerror = ONERROR;
+    Ember.Test.adapter = ADAPTER;
+  }
+});
+
+function runThatThrows(message) {
+  return run(() => {
+    throw new Error(message);
+  });
+}
+
+test('by default there is no onerror', function(assert) {
+  Ember.onerror = undefined;
+  assert.throws(runThatThrows, Error);
+  assert.equal(Ember.onerror, undefined);
+});
+
+test('when Ember.onerror is registered', function(assert) {
+  assert.expect(1);
+  Ember.error = function() {
+    assert.ok(true, 'onerror called');
+  };
+  assert.throws(runThatThrows, Error);
+});
+
+test('when Ember.Test.adapter is registered', function(assert) {
+  assert.expect(1);
+
+  Ember.Test.adapter = function() {
+    assert.ok(true, 'adapter called');
+  };
+  assert.throws(runThatThrows, Error);
+});
+
+test('when both Ember.onerror Ember.Test.adapter is registered', function(assert) {
+  assert.expect(1);
+
+  Ember.Test.adapter = function() {
+    assert.ok(true, 'adapter called');
+  };
+
+  Ember.error = function() {
+    assert.ok(false, 'onerror was NEVER called');
+  };
+
+  assert.throws(runThatThrows, Error);
+});
+


### PR DESCRIPTION
It is quite common (like in ember-data’s tests) to not have a global onError handler in tests.
But because of the previous state of code, we would still end up paused in the default dispatchError rather then where the actual error was thrown.

This addresses the issue, but ensuring onErrorTarget.onerror returns undefined if no onError has been set

before:

<img width="946" alt="screen shot 2017-08-25 at 6 15 44 am" src="https://user-images.githubusercontent.com/1377/29716219-6885d146-895f-11e7-838d-f45f4e3b3f21.png">

After: 

<img width="943" alt="screen shot 2017-08-25 at 6 16 01 am" src="https://user-images.githubusercontent.com/1377/29716228-6d5b9c8c-895f-11e7-86b9-213e97cd5e57.png">

