### PR TITLE
[BUGFIX LTS] ensure “pause on exception” pauses in the right place

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "babel-plugin-transform-proto-to-assign": "^6.23.0",
     "babel-template": "^6.24.1",
-    "backburner.js": "^1.2.0",
+    "backburner.js": "^1.2.1",
     "broccoli-babel-transpiler": "next",
     "broccoli-concat": "^3.2.2",
     "broccoli-file-creator": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "babel-plugin-transform-proto-to-assign": "^6.23.0",
     "babel-template": "^6.24.1",
-    "backburner.js": "^1.1.0",
+    "backburner.js": "^1.2.0",
     "broccoli-babel-transpiler": "next",
     "broccoli-concat": "^3.2.2",
     "broccoli-file-creator": "^1.1.1",

--- a/packages/ember-metal/lib/error_handler.js
+++ b/packages/ember-metal/lib/error_handler.js
@@ -14,6 +14,12 @@ let getStack = error => {
 };
 
 let onerror;
+export const onErrorTarget = {
+  get onerror() {
+    return dispatchOverride || onerror;
+  }
+};
+
 // Ember.onerror getter
 export function getOnerror() {
   return onerror;

--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -1,8 +1,7 @@
 import { GUID_KEY } from 'ember-utils';
 import { assert, isTesting } from 'ember-debug';
 import {
-  dispatchError,
-  setOnerror
+  onErrorTarget
 } from './error_handler';
 import {
   beginPropertyChanges,
@@ -18,25 +17,16 @@ function onEnd(current, next) {
   run.currentRunLoop = next;
 }
 
-const onErrorTarget = {
-  get onerror() {
-    return dispatchError;
-  },
-  set onerror(handler) {
-    return setOnerror(handler);
-  }
-};
-
 const backburner = new Backburner(['sync', 'actions', 'destroy'], {
-  GUID_KEY: GUID_KEY,
+  GUID_KEY,
   sync: {
     before: beginPropertyChanges,
     after: endPropertyChanges
   },
   defaultQueue: 'actions',
-  onBegin: onBegin,
-  onEnd: onEnd,
-  onErrorTarget: onErrorTarget,
+  onBegin,
+  onEnd,
+  onErrorTarget,
   onErrorMethod: 'onerror'
 });
 

--- a/packages/ember-metal/tests/run_loop/later_test.js
+++ b/packages/ember-metal/tests/run_loop/later_test.js
@@ -1,3 +1,4 @@
+import { assign } from 'ember-utils';
 import { run, isNone } from '../..';
 
 const originalSetTimeout = window.setTimeout;
@@ -198,7 +199,7 @@ asyncTest('setTimeout should never run with a negative wait', function() {
   // happens when an expired timer callback takes a while to run,
   // which is what we simulate here.
   let newSetTimeoutUsed;
-  run.backburner._platform = {
+  run.backburner._platform = assign({}, originalPlatform, {
     setTimeout() {
       let wait = arguments[arguments.length - 1];
       newSetTimeoutUsed = true;
@@ -206,7 +207,7 @@ asyncTest('setTimeout should never run with a negative wait', function() {
 
       return originalPlatform.setTimeout.apply(originalPlatform, arguments);
     }
-  };
+  });
 
   let count = 0;
   run(() => {

--- a/packages/ember-runtime/tests/system/object/create_test.js
+++ b/packages/ember-runtime/tests/system/object/create_test.js
@@ -115,9 +115,9 @@ QUnit.test('inherits properties from passed in EmberObject', function() {
 });
 
 QUnit.test('throws if you try to pass anything a string as a parameter', function() {
-  let expected = 'EmberObject.create only accepts an objects.';
+  let expected = 'Ember.Object.create only accepts objects.';
 
-  throws(() => EmberObject.create('some-string'), expected);
+  expectAssertion(() => EmberObject.create('some-string'), expected);
 });
 
 QUnit.test('EmberObject.create can take undefined as a parameter', function() {

--- a/packages/ember/tests/error_handler_test.js
+++ b/packages/ember/tests/error_handler_test.js
@@ -1,0 +1,93 @@
+import Ember from 'ember';
+import { run } from 'ember-metal';
+import { DEBUG } from 'ember-env-flags';
+
+const ONERROR = Ember.onerror;
+const ADAPTER = Ember.Test && Ember.Test.adapter;
+const TESTING = Ember.testing;
+
+QUnit.module('error_handler', {
+  teardown() {
+    Ember.onerror = ONERROR;
+    Ember.testing = TESTING;
+    if (Ember.Test) {
+      Ember.Test.adapter = ADAPTER;
+    }
+  }
+});
+
+function runThatThrows(message) {
+  return run(() => {
+    throw new Error(message);
+  });
+}
+
+test('by default there is no onerror', function(assert) {
+  Ember.onerror = undefined;
+  assert.throws(runThatThrows, Error);
+  assert.equal(Ember.onerror, undefined);
+});
+
+test('when Ember.onerror is registered', function(assert) {
+  assert.expect(2);
+  Ember.onerror = function(error) {
+    assert.ok(true, 'onerror called');
+    throw error;
+  };
+  assert.throws(runThatThrows, Error);
+  // Ember.onerror = ONERROR;
+});
+
+if (DEBUG) {
+  test('when Ember.Test.adapter is registered', function(assert) {
+    assert.expect(2);
+
+    Ember.Test.adapter = {
+      exception(error) {
+        assert.ok(true, 'adapter called');
+        throw error;
+      }
+    };
+
+    assert.throws(runThatThrows, Error);
+  });
+
+  test('when both Ember.onerror Ember.Test.adapter are registered', function(assert) {
+    assert.expect(2);
+
+    // takes precedence
+    Ember.Test.adapter = {
+      exception(error) {
+        assert.ok(true, 'adapter called');
+        throw error;
+      }
+    };
+
+    Ember.onerror = function(error) {
+      assert.ok(false, 'onerror was NEVER called');
+      throw error;
+    };
+
+    assert.throws(runThatThrows, Error);
+  });
+}
+
+QUnit.test('Ember.run does not swallow exceptions by default (Ember.testing = true)', function() {
+  Ember.testing = true;
+  let error = new Error('the error');
+  throws(() => {
+    Ember.run(() => {
+      throw error;
+    });
+  }, error);
+});
+
+QUnit.test('Ember.run does not swallow exceptions by default (Ember.testing = false)', function() {
+  Ember.testing = false;
+  let error = new Error('the error');
+  throws(() => {
+    Ember.run(() => {
+      throw error;
+    });
+  }, error);
+});

--- a/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
+++ b/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
@@ -564,7 +564,7 @@ moduleFor('The {{link-to}} helper + query params - globals mode app', class exte
   [`@test the {{link-to}} helper throws a useful error if you invoke it wrong`](assert) {
     assert.expect(1);
 
-    assert.throws(() => {
+    expectAssertion(() => {
       this.runTask(() => {
         this.createApplication();
 
@@ -574,6 +574,6 @@ moduleFor('The {{link-to}} helper + query params - globals mode app', class exte
 
         this.addTemplate('application', `{{#link-to id='the-link'}}Index{{/link-to}}`);
       });
-    }, /(You must provide one or more parameters to the link-to component.|undefined is not an object)/);
+    }, /You must provide one or more parameters to the link-to component/);
   }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -870,9 +870,9 @@ backbone@^1.1.2:
   dependencies:
     underscore ">=1.8.3"
 
-backburner.js@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-1.1.0.tgz#16ef021891bc330a2d021c63d8d68cb8611eb3e4"
+backburner.js@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-1.2.0.tgz#a8b0cf0f45b3c3b14bb330def23d9e3ee74d26dd"
 
 backo2@1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -870,9 +870,9 @@ backbone@^1.1.2:
   dependencies:
     underscore ">=1.8.3"
 
-backburner.js@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-1.2.0.tgz#a8b0cf0f45b3c3b14bb330def23d9e3ee74d26dd"
+backburner.js@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-1.2.1.tgz#26adfcd4d06adc80f78be010b3ff90bf44fc7790"
 
 backo2@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
It is quite common (like in ember-data’s tests) to not have a global onError handler in tests.
But because of the previous state of code, we would still end up paused in the default dispatchError rather then where the actual error was thrown.

This addresses the issue, but ensuring onErrorTarget.onerror returns undefined if no onError has been set

before:

<img width="946" alt="screen shot 2017-08-25 at 6 15 44 am" src="https://user-images.githubusercontent.com/1377/29716219-6885d146-895f-11e7-838d-f45f4e3b3f21.png">

After: 

<img width="943" alt="screen shot 2017-08-25 at 6 16 01 am" src="https://user-images.githubusercontent.com/1377/29716228-6d5b9c8c-895f-11e7-86b9-213e97cd5e57.png">

