### PR TITLE
[BUGFIX beta] Ensure Mixin.prototype.toString does not return constructor code

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -589,7 +589,9 @@ if (ENV._ENABLE_BINDING_SUPPORT) {
 }
 
 let MixinPrototype = Mixin.prototype;
-MixinPrototype.toString = Object.toString;
+MixinPrototype.toString = function Mixin_toString() {
+  return '(unknown mixin)';
+};
 
 if (DEBUG) {
   Object.seal(MixinPrototype);


### PR DESCRIPTION
Addresses issue #15586. As mentioned in PR #12636 this particular definition of Mixin.prototype.toString is only used when ember-template-compiler.js is loaded before the rest of Ember (or at least that was the case in late 2015). I'm not sure how to write a test for that.