### PR TITLE
remove function export from helper blueprint

### DIFF
--- a/blueprints/helper/files/__root__/__collection__/__name__.js
+++ b/blueprints/helper/files/__root__/__collection__/__name__.js
@@ -1,7 +1,5 @@
 import { helper } from '@ember/component/helper';
 
-export function <%= camelizedModuleName %>(params/*, hash*/) {
+export default helper(function <%= camelizedModuleName %>(params/*, hash*/) {
   return params;
-}
-
-export default helper(<%= camelizedModuleName %>);
+});

--- a/node-tests/fixtures/helper/helper.js
+++ b/node-tests/fixtures/helper/helper.js
@@ -1,7 +1,5 @@
 import { helper } from '@ember/component/helper';
 
-export function fooBarBaz(params/*, hash*/) {
+export default helper(function fooBarBaz(params/*, hash*/) {
   return params;
-}
-
-export default helper(fooBarBaz);
+});


### PR DESCRIPTION
I find myself removing this export from every helper I create. Calling this function from component JS is cumbersome as you have to conform with its strict helper argument style. If I ever need to call a helper in JS, I move the code to a util and have the helper also use it.