### PR TITLE
[BUGFIX beta] Don't throw an error, when not all query params are passed to routerService.transitionTo

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -848,7 +848,10 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
         } else {
           if (presentKey) {
             svalue = params[presentKey];
-            value = route.deserializeQueryParam(svalue, qp.urlKey, qp.type);
+
+            if (svalue !== undefined) {
+              value = route.deserializeQueryParam(svalue, qp.urlKey, qp.type);
+            }
           } else {
             // No QP provided; use default value.
             svalue = qp.serializedDefaultValue;
@@ -2127,7 +2130,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
       }
     });
 	```
-	
+
     @method disconnectOutlet
     @param {Object|String} options the options hash or outlet name
     @since 1.0.0

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -701,7 +701,9 @@ const EmberRouter = EmberObject.extend(Evented, {
     @param {String} type
   */
   _serializeQueryParam(value, type) {
-    if (type === 'array') {
+    if (value === null || value === undefined) {
+      return null;
+    } else if (type === 'array') {
       return JSON.stringify(value);
     }
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -702,7 +702,7 @@ const EmberRouter = EmberObject.extend(Evented, {
   */
   _serializeQueryParam(value, type) {
     if (value === null || value === undefined) {
-      return null;
+      return value;
     } else if (type === 'array') {
       return JSON.stringify(value);
     }
@@ -739,7 +739,9 @@ const EmberRouter = EmberObject.extend(Evented, {
     @param {String} defaultType
   */
   _deserializeQueryParam(value, defaultType) {
-    if (defaultType === 'boolean') {
+    if (value === null || value === undefined) {
+      return value;
+    } else if (defaultType === 'boolean') {
       return value === 'true';
     } else if (defaultType === 'number') {
       return (Number(value)).valueOf();

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -976,7 +976,7 @@ const EmberRouter = EmberObject.extend(Evented, {
               return true;
             }
 
-            if (_fromRouterService) {
+            if (_fromRouterService && presentProp !== false) {
               return false;
             }
 

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -1153,6 +1153,63 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
     });
   }
 
+  test("Setting bound query pram property to null or undefined do not seralize to url", function() {
+    Router.map(function() {
+      this.route("home", { path: '/home' });
+    });
+
+    App.HomeController = Ember.Controller.extend({
+      queryParams: ['foo'],
+      foo: [1, 2]
+    });
+
+    startingURL = '/home';
+    bootApplication();
+
+    var controller = container.lookup('controller:home');
+
+    deepEqual(controller.get('foo'), [1,2]);
+    equal(router.get('location.path'), "/home");
+
+    Ember.run(controller, 'set', 'foo', [1,3]);
+    equal(router.get('location.path'), "/home?foo=%5B1%2C3%5D");
+
+    Ember.run(router, 'transitionTo', '/home');
+    deepEqual(controller.get('foo'), [1,2]);
+
+    Ember.run(controller, 'set', 'foo', null);
+    equal(router.get('location.path'), "/home", "Setting property to null");
+
+    Ember.run(controller, 'set', 'foo', [1,3]);
+    equal(router.get('location.path'), "/home?foo=%5B1%2C3%5D");
+
+    Ember.run(controller, 'set', 'foo', undefined);
+    equal(router.get('location.path'), "/home", "Setting property to undefined");
+  });
+
+  test("{{link-to}} with null or undefined qps do not get serialized into url", function() {
+    Ember.TEMPLATES.home = Ember.Handlebars.compile(
+      "{{link-to 'Home' 'home' (query-params foo=nullValue) id='null-link'}}" +
+      "{{link-to 'Home' 'home' (query-params foo=undefinedValue) id='undefined-link'}}");
+    Router.map(function() {
+      this.route("home", { path: '/home' });
+    });
+
+    App.HomeController = Ember.Controller.extend({
+      queryParams: ['foo'],
+      foo: [],
+      nullValue: null,
+      undefinedValue: undefined
+    });
+
+    startingURL = '/home';
+    bootApplication();
+
+    var controller = container.lookup('controller:home');
+    equal(Ember.$('#null-link').attr('href'), "/home");
+    equal(Ember.$('#undefined-link').attr('href'), "/home");
+  });
+
   ['@test A child of a resource route still defaults to parent route\'s model even if the child route has a query param'](assert) {
     assert.expect(2);
 

--- a/packages/ember/tests/routing/router_service_test/transitionTo_test.js
+++ b/packages/ember/tests/routing/router_service_test/transitionTo_test.js
@@ -256,6 +256,26 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
         });
     }
 
+    ['@test RouterService#transitionTo with unspecified query params'](assert) {
+      assert.expect(1);
+
+      this.add('controller:parent.child', Controller.extend({
+        queryParams: ['sort', 'page', 'category', 'extra'],
+        sort: 'ASC',
+        page: null,
+        category: undefined
+      }));
+
+      let queryParams = this.buildQueryParams({ sort: 'ASC' });
+
+      return this.visit('/').then(() => {
+        return this.routerService.transitionTo('parent.child', queryParams);
+      })
+        .then(() => {
+          assert.equal(this.routerService.get('currentURL'), '/child?sort=ASC');
+        });
+    }
+
     ['@test RouterService#transitionTo with aliased query params uses the original provided key'](assert) {
       assert.expect(1);
 


### PR DESCRIPTION
This PR attempts to fix two issues:

1. A bug introduced in #15414.
  Using `transitionTo` via router service fail with an error, unless all query parameters of the target route are passed into the method. Here's the failing test: https://github.com/CvX/ember.js/blob/1c8c6ecad42228e94deffb7672fc6de905fca007/packages/ember/tests/routing/router_service_test/transitionTo_test.js#L259-L277.
  And for googling folks, the error message was ```Error: Assertion Failed: You passed the `false` query parameter during a transition into [route-name-here]}, please update to [query-param-here]```.
2. A problem reported in #4570 (and attempted to be fixed in #4571). This fix (originally by  @raytiley) is required to make the above use case work. Without it, transitioning to a route that has multiple query params ends up with all of them in the url with the value `null`, i.e.
  ```
    Ember.Controller.extend({
      queryParams: ['q', 'other', 'stuff']
    });

    // in some component
    this.get('router').transitionTo('articles', {
      queryParams: { q: 'test' },
    });

    // We end up at: /articles?q=test&other=null&stuff=null
    // Instead of (after the fix): /articles?q=test
  ```

cc: @rwjblue