### PR TITLE
[CLEANUP] Refactor StringUtils tests.

### DIFF
--- a/packages/ember-runtime/tests/system/string/camelize_test.js
+++ b/packages/ember-runtime/tests/system/string/camelize_test.js
@@ -9,65 +9,21 @@ if (!ENV.EXTEND_PROTOTYPES.String) {
   });
 }
 
-QUnit.test('camelize normal string', function() {
-  deepEqual(camelize('my favorite items'), 'myFavoriteItems');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('my favorite items'.camelize(), 'myFavoriteItems');
-  }
-});
+function test(given, expected, description) {
+  QUnit.test(description, function() {
+    deepEqual(camelize(given), expected);
+    if (ENV.EXTEND_PROTOTYPES.String) {
+      deepEqual(given.camelize(), expected);
+    }
+  })
+}
 
-QUnit.test('camelize capitalized string', function() {
-  deepEqual(camelize('I Love Ramen'), 'iLoveRamen');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('I Love Ramen'.camelize(), 'iLoveRamen');
-  }
-});
-
-QUnit.test('camelize dasherized string', function() {
-  deepEqual(camelize('css-class-name'), 'cssClassName');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('css-class-name'.camelize(), 'cssClassName');
-  }
-});
-
-QUnit.test('camelize underscored string', function() {
-  deepEqual(camelize('action_name'), 'actionName');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('action_name'.camelize(), 'actionName');
-  }
-});
-
-QUnit.test('camelize dot notation string', function() {
-  deepEqual(camelize('action.name'), 'actionName');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('action.name'.camelize(), 'actionName');
-  }
-});
-
-QUnit.test('does nothing with camelcased string', function() {
-  deepEqual(camelize('innerHTML'), 'innerHTML');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('innerHTML'.camelize(), 'innerHTML');
-  }
-});
-
-QUnit.test('camelize namespaced classified string', function() {
-  deepEqual(camelize('PrivateDocs/OwnerInvoice'), 'privateDocs/ownerInvoice');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('PrivateDocs/OwnerInvoice'.camelize(), 'privateDocs/ownerInvoice');
-  }
-});
-
-QUnit.test('camelize namespaced underscored string', function() {
-  deepEqual(camelize('private_docs/owner_invoice'), 'privateDocs/ownerInvoice');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('private_docs/owner_invoice'.camelize(), 'privateDocs/ownerInvoice');
-  }
-});
-
-QUnit.test('camelize namespaced dasherized string', function() {
-  deepEqual(camelize('private-docs/owner-invoice'), 'privateDocs/ownerInvoice');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('private-docs/owner-invoice'.camelize(), 'privateDocs/ownerInvoice');
-  }
-});
+test('my favorite items',          'myFavoriteItems',          'camelize normal string');
+test('I Love Ramen',               'iLoveRamen',               'camelize capitalized string');
+test('css-class-name',             'cssClassName',             'camelize dasherized string');
+test('action_name',                'actionName',               'camelize underscored string');
+test('action.name',                'actionName',               'camelize dot notation string');
+test('innerHTML',                  'innerHTML',                'does nothing with camelcased string');
+test('PrivateDocs/OwnerInvoice',   'privateDocs/ownerInvoice', 'camelize namespaced classified string');
+test('private_docs/owner_invoice', 'privateDocs/ownerInvoice', 'camelize namespaced underscored string');
+test('private-docs/owner-invoice', 'privateDocs/ownerInvoice', 'camelize namespaced dasherized string');

--- a/packages/ember-runtime/tests/system/string/capitalize_test.js
+++ b/packages/ember-runtime/tests/system/string/capitalize_test.js
@@ -9,65 +9,21 @@ if (!ENV.EXTEND_PROTOTYPES.String) {
   });
 }
 
-QUnit.test('capitalize normal string', function() {
-  deepEqual(capitalize('my favorite items'), 'My favorite items');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('my favorite items'.capitalize(), 'My favorite items');
-  }
-});
+function test(given, expected, description) {
+  QUnit.test(description, function () {
+    deepEqual(capitalize(given), expected);
+    if (ENV.EXTEND_PROTOTYPES.String) {
+      deepEqual(given.capitalize(), expected);
+    }
+  });
+}
 
-QUnit.test('capitalize dasherized string', function() {
-  deepEqual(capitalize('css-class-name'), 'Css-class-name');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('css-class-name'.capitalize(), 'Css-class-name');
-  }
-});
-
-QUnit.test('capitalize underscored string', function() {
-  deepEqual(capitalize('action_name'), 'Action_name');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('action_name'.capitalize(), 'Action_name');
-  }
-});
-
-QUnit.test('capitalize camelcased string', function() {
-  deepEqual(capitalize('innerHTML'), 'InnerHTML');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('innerHTML'.capitalize(), 'InnerHTML');
-  }
-});
-
-QUnit.test('does nothing with capitalized string', function() {
-  deepEqual(capitalize('Capitalized string'), 'Capitalized string');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('Capitalized string'.capitalize(), 'Capitalized string');
-  }
-});
-
-QUnit.test('capitalize namespaced camelized string', function() {
-  deepEqual(capitalize('privateDocs/ownerInvoice'), 'PrivateDocs/OwnerInvoice');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('privateDocs/ownerInvoice'.capitalize(), 'PrivateDocs/OwnerInvoice');
-  }
-});
-
-QUnit.test('capitalize namespaced underscored string', function() {
-  deepEqual(capitalize('private_docs/owner_invoice'), 'Private_docs/Owner_invoice');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('private_docs/owner_invoice'.capitalize(), 'Private_docs/Owner_invoice');
-  }
-});
-
-QUnit.test('capitalize namespaced dasherized string', function() {
-  deepEqual(capitalize('private-docs/owner-invoice'), 'Private-docs/Owner-invoice');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('private-docs/owner-invoice'.capitalize(), 'Private-docs/Owner-invoice');
-  }
-});
-
-QUnit.test('capitalize string with accent character', function() {
-  deepEqual(capitalize('šabc'), 'Šabc');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('šabc'.capitalize(), 'Šabc');
-  }
-});
+test('my favorite items',          'My favorite items',          'capitalize normal string');
+test('css-class-name',             'Css-class-name',             'capitalize dasherized string');
+test('action_name',                'Action_name',                'capitalize underscored string');
+test('innerHTML',                  'InnerHTML',                  'capitalize camelcased string');
+test('Capitalized string',         'Capitalized string',         'does nothing with capitalized string');
+test('privateDocs/ownerInvoice',   'PrivateDocs/OwnerInvoice',   'capitalize namespaced camelized string');
+test('private_docs/owner_invoice', 'Private_docs/Owner_invoice', 'capitalize namespaced underscored string');
+test('private-docs/owner-invoice', 'Private-docs/Owner-invoice', 'capitalize namespaced dasherized string');
+test('šabc',                       'Šabc',                       'capitalize string with accent character');

--- a/packages/ember-runtime/tests/system/string/dasherize_test.js
+++ b/packages/ember-runtime/tests/system/string/dasherize_test.js
@@ -9,58 +9,20 @@ if (!ENV.EXTEND_PROTOTYPES.String) {
   });
 }
 
-QUnit.test('dasherize normal string', function() {
-  deepEqual(dasherize('my favorite items'), 'my-favorite-items');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('my favorite items'.dasherize(), 'my-favorite-items');
-  }
-});
+function test(given, expected, description) {
+  QUnit.test(description, function () {
+    deepEqual(dasherize(given), expected);
+    if (ENV.EXTEND_PROTOTYPES.String) {
+      deepEqual(given.dasherize(), expected);
+    }
+  });
+}
 
-QUnit.test('does nothing with dasherized string', function() {
-  deepEqual(dasherize('css-class-name'), 'css-class-name');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('css-class-name'.dasherize(), 'css-class-name');
-  }
-});
-
-QUnit.test('dasherize underscored string', function() {
-  deepEqual(dasherize('action_name'), 'action-name');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('action_name'.dasherize(), 'action-name');
-  }
-});
-
-QUnit.test('dasherize camelcased string', function() {
-  deepEqual(dasherize('innerHTML'), 'inner-html');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('innerHTML'.dasherize(), 'inner-html');
-  }
-});
-
-QUnit.test('dasherize string that is the property name of Object.prototype', function() {
-  deepEqual(dasherize('toString'), 'to-string');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('toString'.dasherize(), 'to-string');
-  }
-});
-
-QUnit.test('dasherize namespaced classified string', function() {
-  deepEqual(dasherize('PrivateDocs/OwnerInvoice'), 'private-docs/owner-invoice');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('PrivateDocs/OwnerInvoice'.dasherize(), 'private-docs/owner-invoice');
-  }
-});
-
-QUnit.test('dasherize namespaced camelized string', function() {
-  deepEqual(dasherize('privateDocs/ownerInvoice'), 'private-docs/owner-invoice');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('privateDocs/ownerInvoice'.dasherize(), 'private-docs/owner-invoice');
-  }
-});
-
-QUnit.test('dasherize namespaced underscored string', function() {
-  deepEqual(dasherize('private_docs/owner_invoice'), 'private-docs/owner-invoice');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('private_docs/owner_invoice'.dasherize(), 'private-docs/owner-invoice');
-  }
-});
+test('my favorite items',           'my-favorite-items',            'dasherize normal string');
+test('css-class-name',              'css-class-name',               'does nothing with dasherized string');
+test('action_name',                 'action-name',                  'dasherize underscored string');
+test('innerHTML',                   'inner-html',                   'dasherize camelcased string');
+test('toString',                    'to-string',                    'dasherize string that is the property name of Object.prototype');
+test('PrivateDocs/OwnerInvoice',    'private-docs/owner-invoice',   'dasherize namespaced classified string');
+test('privateDocs/ownerInvoice',    'private-docs/owner-invoice',   'dasherize namespaced camelized string');
+test('private_docs/owner_invoice',  'private-docs/owner-invoice',   'dasherize namespaced underscored string');

--- a/packages/ember-runtime/tests/system/string/decamelize_test.js
+++ b/packages/ember-runtime/tests/system/string/decamelize_test.js
@@ -9,51 +9,19 @@ if (!ENV.EXTEND_PROTOTYPES.String) {
   });
 }
 
-QUnit.test('does nothing with normal string', function() {
-  deepEqual(decamelize('my favorite items'), 'my favorite items');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('my favorite items'.decamelize(), 'my favorite items');
-  }
-});
+function test(given, expected, description) {
+  QUnit.test(description, function() {
+    deepEqual(decamelize(given), expected);
+    if (ENV.EXTEND_PROTOTYPES.String) {
+      deepEqual(given.decamelize(), expected);
+    }
+  });
+}
 
-QUnit.test('does nothing with dasherized string', function() {
-  deepEqual(decamelize('css-class-name'), 'css-class-name');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('css-class-name'.decamelize(), 'css-class-name');
-  }
-});
-
-QUnit.test('does nothing with underscored string', function() {
-  deepEqual(decamelize('action_name'), 'action_name');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('action_name'.decamelize(), 'action_name');
-  }
-});
-
-QUnit.test('converts a camelized string into all lower case separated by underscores.', function() {
-  deepEqual(decamelize('innerHTML'), 'inner_html');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('innerHTML'.decamelize(), 'inner_html');
-  }
-});
-
-QUnit.test('decamelizes strings with numbers', function() {
-  deepEqual(decamelize('size160Url'), 'size160_url');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('size160Url'.decamelize(), 'size160_url');
-  }
-});
-
-QUnit.test('decamelize namespaced classified string', function() {
-  deepEqual(decamelize('PrivateDocs/OwnerInvoice'), 'private_docs/owner_invoice');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('PrivateDocs/OwnerInvoice'.decamelize(), 'private_docs/owner_invoice');
-  }
-});
-
-QUnit.test('decamelize namespaced camelized string', function() {
-  deepEqual(decamelize('privateDocs/ownerInvoice'), 'private_docs/owner_invoice');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('privateDocs/ownerInvoice'.decamelize(), 'private_docs/owner_invoice');
-  }
-});
+test('my favorite items',         'my favorite items',          'does nothing with normal string');
+test('css-class-name',            'css-class-name',             'does nothing with dasherized string');
+test('action_name',               'action_name',                'does nothing with underscored string');
+test('innerHTML',                 'inner_html',                 'converts a camelized string into all lower case separated by underscores.');
+test('size160Url',                'size160_url',                'decamelizes strings with numbers');
+test('PrivateDocs/OwnerInvoice',  'private_docs/owner_invoice', 'decamelize namespaced classified string');
+test('privateDocs/ownerInvoice',  'private_docs/owner_invoice', 'decamelize namespaced camelized string');

--- a/packages/ember-runtime/tests/system/string/fmt_string_test.js
+++ b/packages/ember-runtime/tests/system/string/fmt_string_test.js
@@ -9,38 +9,25 @@ if (!ENV.EXTEND_PROTOTYPES.String) {
   });
 }
 
-QUnit.test('\'Hello %@ %@\'.fmt(\'John\', \'Doe\') => \'Hello John Doe\'', function() {
-  expectDeprecation('Ember.String.fmt is deprecated, use ES6 template strings instead.');
-  equal(fmt('Hello %@ %@', ['John', 'Doe']), 'Hello John Doe');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    equal('Hello %@ %@'.fmt('John', 'Doe'), 'Hello John Doe');
-  }
-});
+function test(given, args, expected, description) {
+  QUnit.test(description, function() {
+    expectDeprecation('Ember.String.fmt is deprecated, use ES6 template strings instead.');
+    equal(fmt(given, args), expected);
+    if (ENV.EXTEND_PROTOTYPES.String) {
+      equal(given.fmt(...args), expected);
+    }
+  });
+}
 
-QUnit.test('\'Hello %@2 %@1\'.fmt(\'John\', \'Doe\') => \'Hello Doe John\'', function() {
-  expectDeprecation('Ember.String.fmt is deprecated, use ES6 template strings instead.');
-  equal(fmt('Hello %@2 %@1', ['John', 'Doe']), 'Hello Doe John');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    equal('Hello %@2 %@1'.fmt('John', 'Doe'), 'Hello Doe John');
-  }
-});
-
-QUnit.test('\'%@08 %@07 %@06 %@05 %@04 %@03 %@02 %@01\'.fmt(\'One\', \'Two\', \'Three\', \'Four\', \'Five\', \'Six\', \'Seven\', \'Eight\') => \'Eight Seven Six Five Four Three Two One\'', function() {
-  expectDeprecation('Ember.String.fmt is deprecated, use ES6 template strings instead.');
-  equal(fmt('%@08 %@07 %@06 %@05 %@04 %@03 %@02 %@01', ['One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight']), 'Eight Seven Six Five Four Three Two One');
-
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    equal('%@08 %@07 %@06 %@05 %@04 %@03 %@02 %@01'.fmt('One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight'), 'Eight Seven Six Five Four Three Two One');
-  }
-});
-
-QUnit.test('\'data: %@\'.fmt({ id: 3 }) => \'data: {id: 3}\'', function() {
-  expectDeprecation('Ember.String.fmt is deprecated, use ES6 template strings instead.');
-  equal(fmt('data: %@', [{ id: 3 }]), 'data: {id: 3}');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    equal('data: %@'.fmt({ id: 3 }), 'data: {id: 3}');
-  }
-});
+test('Hello %@ %@',   ['John', 'Doe'],  'Hello John Doe', `fmt('Hello %@ %@', ['John', 'Doe']) => 'Hello John Doe'`);
+test('Hello %@2 %@1', ['John', 'Doe'],  'Hello Doe John', `fmt('Hello %@2 %@1', ['John', 'Doe']) => 'Hello Doe John'`);
+test(
+  '%@08 %@07 %@06 %@05 %@04 %@03 %@02 %@01',
+  ['One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight'],
+ 'Eight Seven Six Five Four Three Two One',
+  `fmt('%@08 %@07 %@06 %@05 %@04 %@03 %@02 %@01', ['One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight']) => 'Eight Seven Six Five Four Three Two One'`
+);
+test('data: %@', [{ id: 3 }],  'data: {id: 3}', `fmt('data: %@', [{ id: 3 }]) => 'data: {id: 3}'`);
 
 QUnit.test('works with argument form', function() {
   expectDeprecation('Ember.String.fmt is deprecated, use ES6 template strings instead.');

--- a/packages/ember-runtime/tests/system/string/loc_test.js
+++ b/packages/ember-runtime/tests/system/string/loc_test.js
@@ -26,33 +26,19 @@ if (!ENV.EXTEND_PROTOTYPES.String) {
   });
 }
 
-QUnit.test('\'_Hello World\'.loc() => \'Bonjour le monde\'', function() {
-  equal(loc('_Hello World'), 'Bonjour le monde');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    equal('_Hello World'.loc(), 'Bonjour le monde');
-  }
-});
+function test(given, args, expected, description) {
+  QUnit.test(description, function() {
+    equal(loc(given, args), expected);
+    if (ENV.EXTEND_PROTOTYPES.String) {
+      equal(given.loc(...args), expected);
+    }
+  });
+}
 
-QUnit.test('\'_Hello %@ %@\'.loc(\'John\', \'Doe\') => \'Bonjour John Doe\'', function() {
-  equal(loc('_Hello %@ %@', ['John', 'Doe']), 'Bonjour John Doe');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    equal('_Hello %@ %@'.loc('John', 'Doe'), 'Bonjour John Doe');
-  }
-});
-
-QUnit.test('\'_Hello %@# %@#\'.loc(\'John\', \'Doe\') => \'Bonjour Doe John\'', function() {
-  equal(loc('_Hello %@# %@#', ['John', 'Doe']), 'Bonjour Doe John');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    equal('_Hello %@# %@#'.loc('John', 'Doe'), 'Bonjour Doe John');
-  }
-});
-
-QUnit.test('\'_Not In Strings\'.loc() => \'_Not In Strings\'', function() {
-  equal(loc('_Not In Strings'), '_Not In Strings');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    equal('_Not In Strings'.loc(), '_Not In Strings');
-  }
-});
+test('_Hello World',    [],              'Bonjour le monde', `loc('_Hello World') => 'Bonjour le monde'`);
+test('_Hello %@ %@',    ['John', 'Doe'], 'Bonjour John Doe', `loc('_Hello %@ %@', ['John', 'Doe']) => 'Bonjour John Doe'`);
+test('_Hello %@# %@#',  ['John', 'Doe'], 'Bonjour Doe John', `loc('_Hello %@# %@#', ['John', 'Doe']) => 'Bonjour Doe John'`);
+test('_Not In Strings', [],              '_Not In Strings',  `loc('_Not In Strings') => '_Not In Strings'`);
 
 QUnit.test('works with argument form', function() {
   equal(loc('_Hello %@', 'John'), 'Bonjour John');

--- a/packages/ember-runtime/tests/system/string/underscore_test.js
+++ b/packages/ember-runtime/tests/system/string/underscore_test.js
@@ -9,51 +9,19 @@ if (!ENV.EXTEND_PROTOTYPES.String) {
   });
 }
 
-QUnit.test('with normal string', function() {
-  deepEqual(underscore('my favorite items'), 'my_favorite_items');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('my favorite items'.underscore(), 'my_favorite_items');
-  }
-});
+function test(given, expected, description) {
+  QUnit.test(description, function() {
+    deepEqual(underscore(given), expected);
+    if (ENV.EXTEND_PROTOTYPES.String) {
+      deepEqual(given.underscore(), expected);
+    }
+  });
+}
 
-QUnit.test('with dasherized string', function() {
-  deepEqual(underscore('css-class-name'), 'css_class_name');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('css-class-name'.underscore(), 'css_class_name');
-  }
-});
-
-QUnit.test('does nothing with underscored string', function() {
-  deepEqual(underscore('action_name'), 'action_name');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('action_name'.underscore(), 'action_name');
-  }
-});
-
-QUnit.test('with camelcased string', function() {
-  deepEqual(underscore('innerHTML'), 'inner_html');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('innerHTML'.underscore(), 'inner_html');
-  }
-});
-
-QUnit.test('underscore namespaced classified string', function() {
-  deepEqual(underscore('PrivateDocs/OwnerInvoice'), 'private_docs/owner_invoice');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('PrivateDocs/OwnerInvoice'.underscore(), 'private_docs/owner_invoice');
-  }
-});
-
-QUnit.test('underscore namespaced camelized string', function() {
-  deepEqual(underscore('privateDocs/ownerInvoice'), 'private_docs/owner_invoice');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('privateDocs/ownerInvoice'.underscore(), 'private_docs/owner_invoice');
-  }
-});
-
-QUnit.test('underscore namespaced dasherized string', function() {
-  deepEqual(underscore('private-docs/owner-invoice'), 'private_docs/owner_invoice');
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('private-docs/owner-invoice'.underscore(), 'private_docs/owner_invoice');
-  }
-});
+test('my favorite items',          'my_favorite_items',          'with normal string');
+test('css-class-name',             'css_class_name',             'with dasherized string');
+test('action_name',                'action_name',                'does nothing with underscored string');
+test('innerHTML',                  'inner_html',                 'with camelcased string');
+test('PrivateDocs/OwnerInvoice',   'private_docs/owner_invoice', 'underscore namespaced classified string');
+test('privateDocs/ownerInvoice',   'private_docs/owner_invoice', 'underscore namespaced camelized string');
+test('private-docs/owner-invoice', 'private_docs/owner_invoice', 'underscore namespaced dasherized string');

--- a/packages/ember-runtime/tests/system/string/w_test.js
+++ b/packages/ember-runtime/tests/system/string/w_test.js
@@ -9,23 +9,15 @@ if (!ENV.EXTEND_PROTOTYPES.String) {
   });
 }
 
-QUnit.test('\'one two three\'.w() => [\'one\',\'two\',\'three\']', function() {
-  deepEqual(w('one two three'), ['one', 'two', 'three']);
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('one two three'.w(), ['one', 'two', 'three']);
-  }
-});
+function test(given, expected, description) {
+  QUnit.test(description, function() {
+    deepEqual(w(given), expected);
+    if (ENV.EXTEND_PROTOTYPES.String) {
+      deepEqual(given.w(), expected);
+    }
+  });
+}
 
-QUnit.test('\'one    two    three\'.w() with extra spaces between words => [\'one\',\'two\',\'three\']', function() {
-  deepEqual(w('one   two  three'), ['one', 'two', 'three']);
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('one   two  three'.w(), ['one', 'two', 'three']);
-  }
-});
-
-QUnit.test('\'one two three\'.w() with tabs', function() {
-  deepEqual(w('one\ttwo  three'), ['one', 'two', 'three']);
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    deepEqual('one\ttwo  three'.w(), ['one', 'two', 'three']);
-  }
-});
+test('one two three',    ['one', 'two', 'three'], `w('one two three') => ['one','two','three']`);
+test('one   two  three', ['one', 'two', 'three'], `w('one    two    three') with extra spaces between words => ['one','two','three']`);
+test('one\ttwo  three',  ['one', 'two', 'three'], `w('one two three') with tabs`);


### PR DESCRIPTION
This normalizes tests in `ember-runtime/tests/system/string/*` to look
like the `classify` tests.

This will make adding the deprecation in #15625 much easier (I'm on it).