### PR TITLE
[Refactor]: Align component manager's methods with RFC

### DIFF
--- a/packages/ember-glimmer/lib/component-managers/abstract.ts
+++ b/packages/ember-glimmer/lib/component-managers/abstract.ts
@@ -47,6 +47,9 @@ export default abstract class AbstractManager<T> implements ComponentManager<T> 
     definition: ComponentDefinition<T>,
     component: T,
     env: Environment): CompiledDynamicTemplate<ProgramSymbolTable>;
+  abstract templateFor(
+     component: T,
+     env: Environment): CompiledDynamicTemplate<ProgramSymbolTable>;
   abstract getSelf(component: T): VersionedPathReference<void | {}>;
 
   didCreateElement(_component: T, _element: Element, _operations: ElementOperations): void {

--- a/packages/ember-glimmer/lib/component-managers/curly.ts
+++ b/packages/ember-glimmer/lib/component-managers/curly.ts
@@ -85,7 +85,7 @@ function ariaRole(vm) {
   return vm.getSelf().get('ariaRole');
 }
 
-class CurlyComponentLayoutCompiler {
+export class CurlyComponentLayoutCompiler {
   static id: string;
   public template: any;
 

--- a/packages/ember-glimmer/lib/component-managers/custom.ts
+++ b/packages/ember-glimmer/lib/component-managers/custom.ts
@@ -1,0 +1,94 @@
+import { assert } from 'ember-debug';
+import AbstractManager from './abstract';
+import {
+  CurlyComponentLayoutCompiler
+} from './curly';
+import { ComponentManager } from '@glimmer/runtime';
+import ComponentStateBucket from '../utils/curly-component-state-bucket';
+
+/**
+  Wrapper class for custom component managers as per
+  Custom Components RFC.
+
+  When defining a custom component manager, the following
+  methods are required:
+
+  - `create`
+  - `getSelf`
+  - `update`
+
+  `layoutFor` method is not required to be implemented and
+  mirrors the behaviour of curly components.
+  @private
+  @class CustomManager
+*/
+export default class CustomManager extends AbstractManager<ComponentStateBucket> {
+  private _manager: ComponentManager<ComponentStateBucket>;
+
+  constructor(manager) {
+    super();
+
+    this._manager = manager;
+
+    assert('You must implement `create` method.', this._manager.create !== undefined);
+    assert('You must implement `getSelf` method.', this._manager.getSelf !== undefined);
+    assert('You must implement `update` method.', this._manager.update !== undefined);
+  }
+
+  create(environment, definition, args, dynamicScope, callerSelfRef, hasBlock) {
+    return this._manager.create(environment, definition, args, dynamicScope, callerSelfRef, hasBlock);
+  }
+
+  getSelf({ component }) {
+    return this._manager.getSelf(component);
+  }
+
+  update(bucket, dynamicScope) {
+    return this._manager.update(bucket, dynamicScope);
+  }
+
+  layoutFor(definition, bucket, env) {
+    if (this._manager.layoutFor) {
+      return this._manager.layoutFor(definition, bucket, env);
+    }
+
+    let template = definition.template;
+    if (!template) {
+      let { component } = bucket;
+      template = this.templateFor(component, env);
+    }
+    return env.getCompiledBlock(CurlyComponentLayoutCompiler, template);
+  }
+
+  didCreate(component) {
+    if (this._manager.didCreate !== undefined) {
+      this._manager.didCreate(component);
+    } else {
+      super.didCreate(component);
+    }
+  }
+
+  didCreateElement(component, element, operations) {
+    if (this._manager.didCreateElement !== undefined) {
+      this._manager.didCreateElement(component, element, operations);
+    } else {
+      super.didCreateElement(component, element, operations);
+    }
+  }
+
+  didUpdate(state) {
+    if (this._manager.didUpdate !== undefined) {
+      this._manager.didUpdate(state);
+    } else {
+      super.didUpdate(state);
+    }
+  }
+
+  getDestructor(state) {
+    if (this._manager.getDestructor !== undefined) {
+      this._manager.getDestructor(state);
+    } else {
+      return state;
+    }
+  }
+}

--- a/packages/ember-glimmer/lib/environment.ts
+++ b/packages/ember-glimmer/lib/environment.ts
@@ -40,6 +40,7 @@ import {
   ConditionalReference,
   SimpleHelperReference,
 } from './utils/references';
+import CustomManager from './component-managers/custom';
 
 import { default as classHelper } from './helpers/-class';
 import { default as htmlSafeHelper } from './helpers/-html-safe';
@@ -129,7 +130,7 @@ export default class Environment extends GlimmerEnvironment {
           let managerId = layout && layout.meta.managerId;
 
           if (managerId) {
-            customManager = owner.factoryFor<any>(`component-manager:${managerId}`).class;
+            customManager = new CustomManager(owner.factoryFor<any>(`component-manager:${managerId}`).class);
           }
         }
         return new CurlyComponentDefinition(name, componentFactory, layout, undefined, customManager);

--- a/packages/ember-glimmer/tests/unit/component-managers/custom-test.js
+++ b/packages/ember-glimmer/tests/unit/component-managers/custom-test.js
@@ -1,0 +1,94 @@
+import CustomComponentManager from 'ember-glimmer/component-managers/custom';
+import { moduleFor, TestCase } from 'ember-glimmer/tests/utils/test-case';
+import { GLIMMER_CUSTOM_COMPONENT_MANAGER } from 'ember/features';
+
+if (GLIMMER_CUSTOM_COMPONENT_MANAGER) {
+  moduleFor('Custom Component Manager', class extends TestCase {
+    ['@test throws an exception if custom component manager does not define `create` method'](assert) {
+      assert.throws(() => {
+        new CustomComponentManager({
+          getSelf() {},
+          update() {}
+        });
+      }, /You must implement `create` method./);
+    }
+
+    ['@test throws an exception if custom component manager does not define `getSelf` method'](assert) {
+      assert.throws(() => {
+        new CustomComponentManager({
+          create() {},
+          update() {}
+        });
+      }, /You must implement `getSelf` method./);
+    }
+
+    ['@test throws an exception if custom component manager does not define `update` method'](assert) {
+      assert.throws(() => {
+        new CustomComponentManager({
+          create() {},
+          getSelf() {}
+        });
+      }, /You must implement `update` method./);
+    }
+
+    ['@test proxies `didCreateElement` method if defined'](assert) {
+      let didCreateElementCalled = false;
+      let componentManager = new CustomComponentManager({
+        create() {},
+        getSelf() {},
+        update() {},
+        didCreateElement() {
+          didCreateElementCalled = true;
+        }
+      });
+
+      componentManager.didCreateElement();
+      assert.ok(didCreateElementCalled, '`didCreateElement` was successfully called');
+    }
+
+    ['@test proxies `didCreate` method if defined'](assert) {
+      let didCreateCalled = false;
+      let componentManager = new CustomComponentManager({
+        create() {},
+        getSelf() {},
+        update() {},
+        didCreate() {
+          didCreateCalled = true;
+        }
+      });
+
+      componentManager.didCreate();
+      assert.ok(didCreateCalled, '`didCreate` was successfully called');
+    }
+
+    ['@test proxies `didUpdate` method if defined'](assert) {
+      let didUpdateCalled = false;
+      let componentManager = new CustomComponentManager({
+        create() {},
+        getSelf() {},
+        update() {},
+        didUpdate() {
+          didUpdateCalled = true;
+        }
+      });
+
+      componentManager.didUpdate();
+      assert.ok(didUpdateCalled, '`didUpdate` was successfully called');
+    }
+
+    ['@test proxies `getDestructor` method if defined'](assert) {
+      let getDestructorCalled = false;
+      let componentManager = new CustomComponentManager({
+        create() {},
+        getSelf() {},
+        update() {},
+        getDestructor() {
+          getDestructorCalled = true;
+        }
+      });
+
+      componentManager.getDestructor();
+      assert.ok(getDestructorCalled, '`getDestructor` was successfully called');
+    }
+  });
+}


### PR DESCRIPTION
Before this change, when defining a custom component manager, you'd have to define `layoutFor` (or extend from `AbstractComponentManager`)  for components to render properly. After this change, you'd have to define only 3 methods (as per [RFC](https://github.com/emberjs/rfcs/blob/custom-components/text/0000-custom-components.md)): `create`, `getSelf` (`getContext` in RFC) and `update`. This commit does not change existing behaviour.

Changes:
+ introduce a new "wrapper" class for custom component managers. `layoutFor` mimics the behaviour of curly components and `create`, `getSelf` and `update` are left for developers to define
+ tests

Relevant links:
+ [Custom Components RFC](https://github.com/emberjs/rfcs/blob/custom-components/text/0000-custom-components.md)