### PR TITLE
[BUGFIX beta] getParentEngine was not being exported under Ember.

### DIFF
--- a/packages/ember/lib/index.js
+++ b/packages/ember/lib/index.js
@@ -580,6 +580,7 @@ Ember.ApplicationInstance = application.ApplicationInstance;
 Ember.Engine = application.Engine;
 Ember.EngineInstance = application.EngineInstance;
 Ember.DefaultResolver = Ember.Resolver = application.Resolver;
+Ember.getEngineParent = application.getEngineParent;
 
 runLoadHooks('Ember.Application', application.Application);
 

--- a/packages/ember/tests/global-api-test.js
+++ b/packages/ember/tests/global-api-test.js
@@ -1,5 +1,6 @@
 import { get } from 'ember-metal';
 import { isArray } from 'ember-runtime';
+import { getEngineParent } from 'ember-application';
 
 QUnit.module('Global API Tests');
 
@@ -18,3 +19,4 @@ confirmExport('Ember.generateController');
 confirmExport('Ember.Helper');
 confirmExport('Ember.Helper.helper');
 confirmExport('Ember.isArray', isArray);
+confirmExport('Ember.getEngineParent', getEngineParent);


### PR DESCRIPTION
As reported in #15630, these were marked as public but were not being
exported.

Fixes #15630