### PR TITLE
[DOC beta] Improve run.scheduleOnce documentation

### DIFF
--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -389,9 +389,23 @@ run.once = function(...args) {
   });
   ```
 
-  Also note that passing an anonymous function to `run.scheduleOnce` will
-  not prevent additional calls with an identical anonymous function from
-  scheduling the items multiple times, e.g.:
+  Also note that for `run.scheduleOnce` to prevent additional calls, you need to
+  pass the same function instance. The following case works as expected:
+
+  ```javascript
+  function log() {
+    console.log('Logging only once');
+  }
+
+  function scheduleIt() {
+    run.scheduleOnce('actions', myContext, log);
+  }
+
+  scheduleIt();
+  scheduleIt();
+  ```
+
+  But this other case will schedule the function multiple times:
 
   ```javascript
   function scheduleIt() {
@@ -404,7 +418,7 @@ run.once = function(...args) {
   scheduleIt();
 
   // "Closure" will print twice, even though we're using `run.scheduleOnce`,
-  // because the function we pass to it is anonymous and won't match the
+  // because the function we pass to it won't match the
   // previously scheduled operation.
   ```
 


### PR DESCRIPTION
Improve the documentation about how scheduleOnce prevents a function
being called more than once.

Fixes #15620