### PR TITLE
Stash test timeout on pauseTest

### DIFF
--- a/packages/ember-testing/lib/adapters/adapter.js
+++ b/packages/ember-testing/lib/adapters/adapter.js
@@ -36,6 +36,18 @@ export default EmberObject.extend({
   asyncEnd: K,
 
   /**
+    Removes test timeout for current test.
+
+    This allows `pauseTest` test helper to wait forever.
+    It should also store an original test timeout value in order to restore it on `resumeTest()`.
+
+    @public
+    @method stashTimeout
+    @return {function} Function that restores timeout
+  */
+  stashTimeout: () => K,
+
+  /**
     Override this method with your testing framework's false assertion.
     This function is called whenever an exception occurs causing the testing
     promise to fail.

--- a/packages/ember-testing/lib/helpers/pause_test.js
+++ b/packages/ember-testing/lib/helpers/pause_test.js
@@ -5,6 +5,7 @@
 import { RSVP } from 'ember-runtime';
 import Logger from 'ember-console';
 import { assert } from 'ember-debug';
+import Test from '../test';
 
 let resume;
 
@@ -39,7 +40,12 @@ export function resumeTest() {
 export function pauseTest() {
   Logger.info('Testing paused. Use `resumeTest()` to continue.');
 
+  let restoreTimeout = Test.adapter.stashTimeout();
   return new RSVP.Promise((resolve) => {
-    resume = resolve;
+    resume = () => {
+      restoreTimeout();
+      resolve();
+    };
   }, 'TestAdapter paused promise');
 }
+

--- a/packages/ember-testing/lib/test/adapter.js
+++ b/packages/ember-testing/lib/test/adapter.js
@@ -15,6 +15,12 @@ export function setAdapter(value) {
   }
 }
 
+export function stashTimeout() {
+  if (adapter) {
+    return adapter.stashTimeout();
+  }
+}
+
 export function asyncStart() {
   if (adapter) {
     adapter.asyncStart();

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -926,6 +926,50 @@ moduleFor('ember-testing: debugging helpers', class extends HelpersApplicationTe
     pauseTest();
   }
 
+  [`@test pauseTest stashes test timeout`](assert) {
+    assert.expect(1);
+
+    let {application: {testHelpers: {andThen, pauseTest, resumeTest}}} = this;
+    let origTimeout = 20,
+      testTimeout = origTimeout;
+
+    Test.adapter.stashTimeout = () => {
+      testTimeout = 0;
+      return () => {
+        testTimeout = origTimeout;
+      }
+    };
+
+    run.later(() => {
+      assert.equal(testTimeout, 0);
+      resumeTest();
+    }, 20);
+
+    pauseTest();
+  }
+
+  [`@test resumeTest restores test timeout`](assert) {
+    assert.expect(1);
+
+    let {application: {testHelpers: {andThen, pauseTest, resumeTest}}} = this;
+    let origTimeout = 20,
+      testTimeout = origTimeout;
+
+    Test.adapter.stashTimeout = () => {
+      testTimeout = 0;
+      return () => {
+        testTimeout = origTimeout;
+      };
+    };
+
+    run.later(() => {
+      resumeTest();
+      assert.equal(testTimeout, origTimeout);
+    }, 20);
+
+    pauseTest();
+  }
+
   [`@test resumeTest resumes paused tests`](assert) {
     assert.expect(1);
 


### PR DESCRIPTION
### Reason
Currently `pauseTest` do nothing special with `QUnit.config.testTimeout`. It leads to pure dev experience out of the box - [Demo](https://ember-twiddle.com/b9d380a0110f11ae1bebf2f0bdee93ad?openFiles=tests.acceptance.my-acceptance-test.js%2C)

The same issue is also valid for mocha - #15593 

### Changes
This pr extends `Test.Adapter` with a new [`stashTimeout()`](https://github.com/emberjs/ember.js/compare/master...ro0gr:resume-timeout?expand=1#diff-d30d6f515bf6770d40cb24e9bc3e7664R48) method. This potentially allows `pauseTest` to behave more correct.

---

Does the change of this kind require a RFC? 🙉 
The reason why I'm asking is that technically `Test.Adapter` is [public](https://emberjs.com/api/ember/2.15/classes/Ember.Test.Adapter). But in [fact](https://emberobserver.com/code-search?codeQuery=Test.Adapter) seems like it's used only by `ember-source`.
