### PR TITLE
run Travis on tagged builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,14 @@ install:
 after_success:
   - "./bin/publish_builds"
 
+branches:
+  only:
+    - master
+    - beta
+    - stable
+    # npm version tags
+    - /^v\d+\.\d+\.\d+$/
+
 env:
   global:
     - SAUCE_USERNAME=ember-ci


### PR DESCRIPTION
This reverts https://github.com/emberjs/ember.js/commit/a3712c52692481dfdb368c48ec43b142d7488c18 and adds a tag regex. Tested [here](https://travis-ci.org/kellyselden/ember-awesome-macros/jobs/273034825) and is working as expected.

cc @rwjblue 