### PR TITLE
[CLEANUP beta] Removes unused imports

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -6,13 +6,10 @@ import {
   dictionary,
   symbol,
   setOwner,
-  getOwner,
   OWNER,
   assign,
-  NAME_KEY,
   HAS_NATIVE_PROXY
 } from 'ember-utils';
-import { ENV } from 'ember-environment';
 
 const CONTAINER_OVERRIDE = symbol('CONTAINER_OVERRIDE');
 

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -1,5 +1,4 @@
-import { getOwner, OWNER, assign } from 'ember-utils';
-import { ENV } from 'ember-environment';
+import { OWNER, assign } from 'ember-utils';
 import { get } from 'ember-metal';
 import { EMBER_MODULE_UNIFICATION } from 'ember/features';
 import { Registry } from '..';

--- a/packages/ember-application/tests/system/dependency_injection_test.js
+++ b/packages/ember-application/tests/system/dependency_injection_test.js
@@ -1,4 +1,4 @@
-import { ENV, context } from 'ember-environment';
+import { context } from 'ember-environment';
 import { run } from 'ember-metal';
 import { Object as EmberObject } from 'ember-runtime';
 import Application from '../../system/application';


### PR DESCRIPTION
When bulding ember.js and running `yarn start`, I received the following:

```
➜  ember.js git:(master) yarn start
yarn start v1.0.1
warning ../package.json: No license field
$ ember serve
Livereload server on http://localhost:49152
Serving on http://localhost:4200/
'getOwner' and 'NAME_KEY' are imported from external module 'ember-utils' but never used
'ENV' is imported from external module 'ember-environment' but never used
```

This PR is to help with removing those last two lines, which I assume are warnings.

## Changes

- Removes `getOwner` import where not used
- Removes `NAME_KEY` import where not used
- Removes `ENV` import where not used