### PR TITLE
[BUGFIX] Track applicationInstances created by Ember.Application for teardown

### DIFF
--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -69,6 +69,8 @@ const ApplicationInstance = EngineInstance.extend({
   init() {
     this._super(...arguments);
 
+    this.application._watchInstance(this);
+
     // Register this instance in the per-instance registry.
     //
     // Why do we need to register the instance in the first place?
@@ -271,6 +273,11 @@ const ApplicationInstance = EngineInstance.extend({
 
     // getURL returns the set url with the rootURL stripped off
     return router.handleURL(location.getURL()).then(handleTransitionResolve, handleTransitionReject);
+  },
+
+  willDestroy() {
+    this._super(...arguments);
+    this.application._unwatchInstance(this);
   }
 });
 

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -33,6 +33,7 @@ import {
   AutobootApplicationTestCase,
   DefaultResolverApplicationTestCase
 } from 'internal-test-helpers';
+import { run } from 'ember-metal';
 
 moduleFor('Ember.Application, autobooting multiple apps', class extends ApplicationTestCase {
   get fixture() {
@@ -387,4 +388,27 @@ moduleFor('Ember.Application#buildRegistry', class extends AbstractTestCase {
     assert.equal(registry.resolve('application:main'), namespace);
   }
 
+});
+
+moduleFor('Ember.Application - instance tracking', class extends ApplicationTestCase {
+
+  ['@test tracks built instance'](assert) {
+    let instance = this.application.buildInstance();
+    run(() => {
+      this.application.destroy();
+    });
+
+    assert.ok(instance.isDestroyed, 'instance was destroyed');
+  }
+
+  ['@test tracks built instances'](assert) {
+    let instanceA = this.application.buildInstance();
+    let instanceB = this.application.buildInstance();
+    run(() => {
+      this.application.destroy();
+    });
+
+    assert.ok(instanceA.isDestroyed, 'instanceA was destroyed');
+    assert.ok(instanceB.isDestroyed, 'instanceB was destroyed');
+  }
 });

--- a/packages/ember/tests/component_registration_test.js
+++ b/packages/ember/tests/component_registration_test.js
@@ -1,162 +1,178 @@
+import { Application } from 'ember-application';
 import { Controller } from 'ember-runtime';
 import { Component } from 'ember-glimmer';
-import { moduleFor, AutobootApplicationTestCase } from 'internal-test-helpers';
+import { compile } from 'ember-template-compiler';
+import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
 
-moduleFor('Application Lifecycle - Component Registration', class extends AutobootApplicationTestCase {
+moduleFor('Application Lifecycle - Component Registration', class extends ApplicationTestCase {
+
+  // This is necessary for this.application.instanceInitializer to not leak between tests
+  createApplication(options) {
+    return super.createApplication(options, Application.extend());
+  }
 
   ['@feature(!ember-glimmer-template-only-components) The helper becomes the body of the component']() {
-    this.runTask(() => {
-      this.createApplication();
+    this.addTemplate('components/expand-it', '<p>hello {{yield}}</p>');
+    this.addTemplate('application', 'Hello world {{#expand-it}}world{{/expand-it}}');
 
-      this.addTemplate('components/expand-it', '<p>hello {{yield}}</p>');
-      this.addTemplate('application', 'Hello world {{#expand-it}}world{{/expand-it}}');
+    return this.visit('/').then(() => {
+      this.assertText('Hello world hello world');
+      this.assertComponentElement(this.element.firstElementChild, { tagName: 'div', content: '<p>hello world</p>' });
     });
-
-    this.assertText('Hello world hello world');
-    this.assertComponentElement(this.element.firstElementChild, { tagName: 'div', content: '<p>hello world</p>' });
   }
 
   ['@feature(ember-glimmer-template-only-components) The helper becomes the body of the component']() {
-    this.runTask(() => {
-      this.createApplication();
+    this.addTemplate('components/expand-it', '<p>hello {{yield}}</p>');
+    this.addTemplate('application', 'Hello world {{#expand-it}}world{{/expand-it}}');
 
-      this.addTemplate('components/expand-it', '<p>hello {{yield}}</p>');
-      this.addTemplate('application', 'Hello world {{#expand-it}}world{{/expand-it}}');
+    return this.visit('/').then(() => {
+      this.assertInnerHTML('Hello world <p>hello world</p>');
     });
-
-    this.assertInnerHTML('Hello world <p>hello world</p>');
   }
 
   ['@test If a component is registered, it is used'](assert) {
-    this.runTask(() => {
-      this.createApplication();
+    this.addTemplate('components/expand-it', '<p>hello {{yield}}</p>');
+    this.addTemplate('application', `Hello world {{#expand-it}}world{{/expand-it}}`);
 
-      this.addTemplate('components/expand-it', '<p>hello {{yield}}</p>');
-      this.addTemplate('application', `Hello world {{#expand-it}}world{{/expand-it}}`);
-
-      this.applicationInstance.register('component:expand-it', Component.extend({
-        classNames: 'testing123'
-      }));
+    this.application.instanceInitializer({
+      name: 'expand-it-component',
+      initialize(applicationInstance) {
+        applicationInstance.register('component:expand-it', Component.extend({
+          classNames: 'testing123'
+        }));
+      }
     });
 
-    let text = this.$('div.testing123').text().trim();
-    assert.equal(text, 'hello world', 'The component is composed correctly');
+    return this.visit('/').then(() => {
+      let text = this.$('div.testing123').text().trim();
+      assert.equal(text, 'hello world', 'The component is composed correctly');
+    });
   }
 
   ['@test Late-registered components can be rendered with custom `layout` property'](assert) {
-    this.runTask(() => {
-      this.createApplication();
+    this.addTemplate('application', `<div id='wrapper'>there goes {{my-hero}}</div>`);
 
-      this.addTemplate('application', `<div id='wrapper'>there goes {{my-hero}}</div>`);
-
-      this.applicationInstance.register('component:my-hero', Component.extend({
-        classNames: 'testing123',
-        layout: this.compile('watch him as he GOES')
-      }));
+    this.application.instanceInitializer({
+      name: 'my-hero-component',
+      initialize(applicationInstance) {
+        applicationInstance.register('component:my-hero', Component.extend({
+          classNames: 'testing123',
+          layout: compile('watch him as he GOES')
+        }));
+      }
     });
 
-    let text = this.$('#wrapper').text().trim();
-    assert.equal(text, 'there goes watch him as he GOES', 'The component is composed correctly');
+    return this.visit('/').then(() => {
+      let text = this.$('#wrapper').text().trim();
+      assert.equal(text, 'there goes watch him as he GOES', 'The component is composed correctly');
+    });
   }
 
   ['@test Late-registered components can be rendered with template registered on the container'](assert) {
-    this.runTask(() => {
-      this.createApplication();
+    this.addTemplate('application', `<div id='wrapper'>hello world {{sally-rutherford}}-{{#sally-rutherford}}!!!{{/sally-rutherford}}</div>`);
 
-      this.addTemplate('application', `<div id='wrapper'>hello world {{sally-rutherford}}-{{#sally-rutherford}}!!!{{/sally-rutherford}}</div>`);
-
-      this.applicationInstance.register('template:components/sally-rutherford', this.compile('funkytowny{{yield}}'));
-      this.applicationInstance.register('component:sally-rutherford', Component);
+    this.application.instanceInitializer({
+      name: 'sally-rutherford-component-template',
+      initialize(applicationInstance) {
+        applicationInstance.register('template:components/sally-rutherford', compile('funkytowny{{yield}}'));
+      }
+    });
+    this.application.instanceInitializer({
+      name: 'sally-rutherford-component',
+      initialize(applicationInstance) {
+        applicationInstance.register('component:sally-rutherford', Component);
+      }
     });
 
-    let text = this.$('#wrapper').text().trim();
-    assert.equal(text, 'hello world funkytowny-funkytowny!!!', 'The component is composed correctly');
+    return this.visit('/').then(() => {
+      let text = this.$('#wrapper').text().trim();
+      assert.equal(text, 'hello world funkytowny-funkytowny!!!', 'The component is composed correctly');
+    });
   }
 
   ['@test Late-registered components can be rendered with ONLY the template registered on the container'](assert) {
-    this.runTask(() => {
-      this.createApplication();
+    this.addTemplate('application', `<div id='wrapper'>hello world {{borf-snorlax}}-{{#borf-snorlax}}!!!{{/borf-snorlax}}</div>`);
 
-      this.addTemplate('application', `<div id='wrapper'>hello world {{borf-snorlax}}-{{#borf-snorlax}}!!!{{/borf-snorlax}}</div>`);
-
-      this.applicationInstance.register('template:components/borf-snorlax', this.compile('goodfreakingTIMES{{yield}}'));
+    this.application.instanceInitializer({
+      name: 'borf-snorlax-component-template',
+      initialize(applicationInstance) {
+        applicationInstance.register('template:components/borf-snorlax', compile('goodfreakingTIMES{{yield}}'));
+      }
     });
 
-    let text = this.$('#wrapper').text().trim();
-    assert.equal(text, 'hello world goodfreakingTIMES-goodfreakingTIMES!!!', 'The component is composed correctly');
+    return this.visit('/').then(() => {
+      let text = this.$('#wrapper').text().trim();
+      assert.equal(text, 'hello world goodfreakingTIMES-goodfreakingTIMES!!!', 'The component is composed correctly');
+    });
   }
 
   ['@test Assigning layoutName to a component should setup the template as a layout'](assert) {
     assert.expect(1);
 
-    this.runTask(() => {
-      this.createApplication();
+    this.addTemplate('application', `<div id='wrapper'>{{#my-component}}{{text}}{{/my-component}}</div>`);
+    this.addTemplate('foo-bar-baz', '{{text}}-{{yield}}');
 
-      this.addTemplate('application', `<div id='wrapper'>{{#my-component}}{{text}}{{/my-component}}</div>`);
-      this.addTemplate('foo-bar-baz', '{{text}}-{{yield}}');
-
-      this.applicationInstance.register('controller:application', Controller.extend({
-        text: 'outer'
-      }));
-      this.applicationInstance.register('component:my-component', Component.extend({
-        text: 'inner',
-        layoutName: 'foo-bar-baz'
-      }));
+    this.application.instanceInitializer({
+      name: 'application-controller',
+      initialize(applicationInstance) {
+        applicationInstance.register('controller:application', Controller.extend({
+          text: 'outer'
+        }));
+      }
+    });
+    this.application.instanceInitializer({
+      name: 'my-component-component',
+      initialize(applicationInstance) {
+        applicationInstance.register('component:my-component', Component.extend({
+          text: 'inner',
+          layoutName: 'foo-bar-baz'
+        }));
+      }
     });
 
-    let text = this.$('#wrapper').text().trim();
-    assert.equal(text, 'inner-outer', 'The component is composed correctly');
+    return this.visit('/').then(() => {
+      let text = this.$('#wrapper').text().trim();
+      assert.equal(text, 'inner-outer', 'The component is composed correctly');
+    });
   }
 
   ['@test Assigning layoutName and layout to a component should use the `layout` value'](assert) {
     assert.expect(1);
 
-    this.runTask(() => {
-      this.createApplication();
+    this.addTemplate('application', `<div id='wrapper'>{{#my-component}}{{text}}{{/my-component}}</div>`);
+    this.addTemplate('foo-bar-baz', 'No way!');
 
-      this.addTemplate('application', `<div id='wrapper'>{{#my-component}}{{text}}{{/my-component}}</div>`);
-      this.addTemplate('foo-bar-baz', 'No way!');
-
-      this.applicationInstance.register('controller:application', Controller.extend({
-        text: 'outer'
-      }));
-      this.applicationInstance.register('component:my-component', Component.extend({
-        text: 'inner',
-        layoutName: 'foo-bar-baz',
-        layout: this.compile('{{text}}-{{yield}}')
-      }));
+    this.application.instanceInitializer({
+      name: 'application-controller-layout',
+      initialize(applicationInstance) {
+        applicationInstance.register('controller:application', Controller.extend({
+          text: 'outer'
+        }));
+      }
+    });
+    this.application.instanceInitializer({
+      name: 'my-component-component-layout',
+      initialize(applicationInstance) {
+        applicationInstance.register('component:my-component', Component.extend({
+          text: 'inner',
+          layoutName: 'foo-bar-baz',
+          layout: compile('{{text}}-{{yield}}')
+        }));
+      }
     });
 
-    let text = this.$('#wrapper').text().trim();
-    assert.equal(text, 'inner-outer', 'The component is composed correctly');
+    return this.visit('/').then(() => {
+      let text = this.$('#wrapper').text().trim();
+      assert.equal(text, 'inner-outer', 'The component is composed correctly');
+    });
   }
 
-  /*
-   * When an exception is thrown during the initial rendering phase, the
-   * `visit` promise is not resolved or rejected. This means the `applicationInstance`
-   * is never torn down and tests running after this one will fail.
-   *
-   * It is ugly, but since this test intentionally causes an initial render
-   * error, it requires globals mode to access the `applicationInstance`
-   * for teardown after test completion.
-   *
-   * Application "globals mode" is trigged by `autoboot: true`. It doesn't
-   * have anything to do with the resolver.
-   *
-   * We should be able to fix this by having the application eagerly stash a
-   * copy of each application instance it creates. When the application is
-   * destroyed, it can also destroy the instances (this is how the globals
-   * mode avoid the problem).
-   *
-   * See: https://github.com/emberjs/ember.js/issues/15327
-   */
   ['@test Using name of component that does not exist']() {
-    expectAssertion(() => {
-      this.runTask(() => {
-        this.createApplication();
+    this.addTemplate('application', `<div id='wrapper'>{{#no-good}} {{/no-good}}</div>`);
 
-        this.addTemplate('application', `<div id='wrapper'>{{#no-good}} {{/no-good}}</div>`);
-      });
+    // TODO: Use the async form of expectAssertion here when it is available
+    expectAssertion(() => {
+      this.visit('/');
     }, /.* named "no-good" .*/);
   }
 });

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1,7 +1,6 @@
 import {
   moduleFor,
-  ApplicationTestCase,
-  AutobootApplicationTestCase
+  ApplicationTestCase
 } from 'internal-test-helpers';
 
 import {
@@ -13,7 +12,7 @@ import {
   instrumentationSubscribe as subscribe,
   alias
 } from 'ember-metal';
-import { Router, Route, NoneLocation } from 'ember-routing';
+import { Route, NoneLocation } from 'ember-routing';
 import { jQuery } from 'ember-views';
 import { EMBER_IMPROVED_INSTRUMENTATION } from 'ember/features';
 
@@ -1210,6 +1209,20 @@ moduleFor('The {{link-to}} helper - nested routes and link-to arguments', class 
     assert.equal(this.$('b').length, 0);
   }
 
+  [`@test the {{link-to}} helper throws a useful error if you invoke it wrong`](assert) {
+    assert.expect(1);
+
+    this.router.map(function() {
+      this.route('post', { path: 'post/:post_id' });
+    });
+
+    this.addTemplate('application', `{{#link-to 'post'}}Post{{/link-to}}`);
+
+    assert.throws(() => {
+      this.visit('/');
+    }, /(You attempted to define a `\{\{link-to "post"\}\}` but did not pass the parameters required for generating its dynamic segments.|You must provide param `post_id` to `generate`)/);
+  }
+
   [`@test the {{link-to}} helper does not throw an error if its route has exited`](assert) {
     assert.expect(0);
 
@@ -1504,49 +1517,6 @@ moduleFor('The {{link-to}} helper - loading states and warnings', class extends 
 
     // Click the now-active link
     this.click(staticLink[0]);
-  }
-
-});
-
-moduleFor('The {{link-to}} helper - globals mode app', class extends AutobootApplicationTestCase {
-
-  /*
-   * When an exception is thrown during the initial rendering phase, the
-   * `visit` promise is not resolved or rejected. This means the `applicationInstance`
-   * is never torn down and tests running after this one will fail.
-   *
-   * It is ugly, but since this test intentionally causes an initial render
-   * error, it requires globals mode to access the `applicationInstance`
-   * for teardown after test completion.
-   *
-   * Application "globals mode" is trigged by `autoboot: true`. It doesn't
-   * have anything to do with the resolver.
-   *
-   * We should be able to fix this by having the application eagerly stash a
-   * copy of each application instance it creates. When the application is
-   * destroyed, it can also destroy the instances (this is how the globals
-   * mode avoid the problem).
-   *
-   * See: https://github.com/emberjs/ember.js/issues/15327
-   */
-  [`@test the {{link-to}} helper throws a useful error if you invoke it wrong`](assert) {
-    assert.expect(1);
-
-    assert.throws(() => {
-      this.runTask(() => {
-        this.createApplication();
-
-        this.add('router:main', Router.extend({
-          location: 'none'
-        }));
-
-        this.router.map(function() {
-          this.route('post', { path: 'post/:post_id' });
-        });
-
-        this.addTemplate('application', `{{#link-to 'post'}}Post{{/link-to}}`);
-      });
-    }, /(You attempted to define a `\{\{link-to "post"\}\}` but did not pass the parameters required for generating its dynamic segments.|You must provide param `post_id` to `generate`)/);
   }
 
 });

--- a/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
+++ b/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
@@ -1,6 +1,6 @@
 import { Controller, RSVP } from 'ember-runtime';
-import { Route, Router } from 'ember-routing';
-import { moduleFor, ApplicationTestCase, AutobootApplicationTestCase } from 'internal-test-helpers';
+import { Route } from 'ember-routing';
+import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
 
 moduleFor('The {{link-to}} helper: invoking with query params', class extends ApplicationTestCase {
   constructor() {
@@ -539,41 +539,14 @@ moduleFor('The {{link-to}} helper: invoking with query params', class extends Ap
       this.shouldBeActive(assert, '#foos-link');
     });
   }
-});
 
-moduleFor('The {{link-to}} helper + query params - globals mode app', class extends AutobootApplicationTestCase {
-  /*
-   * When an exception is thrown during the initial rendering phase, the
-   * `visit` promise is not resolved or rejected. This means the `applicationInstance`
-   * is never torn down and tests running after this one will fail.
-   *
-   * It is ugly, but since this test intentionally causes an initial render
-   * error, it requires globals mode to access the `applicationInstance`
-   * for teardown after test completion.
-   *
-   * Application "globals mode" is trigged by `autoboot: true`. It doesn't
-   * have anything to do with the resolver.
-   *
-   * We should be able to fix this by having the application eagerly stash a
-   * copy of each application instance it creates. When the application is
-   * destroyed, it can also destroy the instances (this is how the globals
-   * mode avoid the problem).
-   *
-   * See: https://github.com/emberjs/ember.js/issues/15327
-   */
   [`@test the {{link-to}} helper throws a useful error if you invoke it wrong`](assert) {
     assert.expect(1);
 
+    this.addTemplate('application', `{{#link-to id='the-link'}}Index{{/link-to}}`);
+
     expectAssertion(() => {
-      this.runTask(() => {
-        this.createApplication();
-
-        this.add('router:main', Router.extend({
-          location: 'none'
-        }));
-
-        this.addTemplate('application', `{{#link-to id='the-link'}}Index{{/link-to}}`);
-      });
+      this.visit('/');
     }, /You must provide one or more parameters to the link-to component/);
   }
 });


### PR DESCRIPTION
Resolves #15327 

The fixes here occur within `packages/ember-application/lib/system/application.js`:
- Add a private/internal `_applicationInstances` array property to `Ember.Application`
- Push each `applicationInstance` onto the `_applicationInstances` array each time one is created with `buildInstance()`
- Splice an `applicationInstance` out of the `_applicationInstances` array if it is destroyed so that we're not leaking instances after they have been destroyed
- During `willDestroy()`, check for the length of `_applicationInstances` and call `destroy()` on each one to make sure we are tearing down all `applicationInstances`

I have also refactored a couple of tests that were using Ember globals mode to work around the bug described in #15327. There are still a couple of tests that need to be refactored (noted below).

TODO:
- [x] Refactor [component_registration_test](https://github.com/emberjs/ember.js/blob/98cc07f7efeeabed7524511966a510e0470b1000/packages/ember/tests/component_registration_test.js#L170-L197) to not use globals mode workaround ~~_(note that this *entire* test file is using Ember's globals mode, so I'm unsure if the entire file needs refactored or if the note simply needs removed from this one test)_~~
- [x] Refactor [substates_test](https://github.com/emberjs/ember.js/blob/7dd709422e1961dffe65a967fc48b0e5940a0200/packages/ember/tests/routing/substates_test.js#L441-L502) to not use globals mode workaround
- [x] Add unit tests to `Ember.Application`:
  - [x] Test that each applicationInstance created by `buildInstance()` gets added to `_applicationInstances`
  - [x] Test that a destroyed applicationInstance gets spliced out of `_applicationInstances`
  - [x] Test that `willDestroy()` calls `destroy()` on each applicationInstance that has been added to `_applicationInstances`

cc: @mixonic 
  