### PR TITLE
[WIP] [BUGFIX beta] Enable pushObject as a generic array method

### DIFF
--- a/packages/ember-extension-support/tests/data_adapter_test.js
+++ b/packages/ember-extension-support/tests/data_adapter_test.js
@@ -5,7 +5,11 @@ import {
   addObserver,
   removeObserver
 } from 'ember-metal';
-import { Object as EmberObject, A as emberA } from 'ember-runtime';
+import { 
+  Object as EmberObject, 
+  A as emberA,
+  pushObject
+} from 'ember-runtime';
 import EmberDataAdapter from '../data_adapter';
 import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
 
@@ -127,7 +131,7 @@ moduleFor('Data Adapter', class extends ApplicationTestCase {
 
       function modelTypesAdded(types) {
         run(() => {
-          records.pushObject(4);
+          pushObject(records, 4);
         });
       }
 
@@ -175,7 +179,7 @@ moduleFor('Data Adapter', class extends ApplicationTestCase {
       adapter.watchRecords('post', recordsAdded);
       countAdded++;
       post = PostClass.create();
-      recordList.pushObject(post);
+      pushObject(recordList, post);
     });
   }
 

--- a/packages/ember-runtime/lib/index.js
+++ b/packages/ember-runtime/lib/index.js
@@ -19,6 +19,7 @@ export { default as isEqual } from './is-equal';
 export {
   default as Array,
   objectAt,
+  pushObject,
   isEmberArray,
   addArrayObserver,
   removeArrayObserver

--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -60,6 +60,10 @@ export function objectAt(content, idx) {
   return typeof content.objectAt === 'function' ? content.objectAt(idx) : content[idx];
 }
 
+export function pushObject(arr, obj) {
+  return typeof arr.pushObject === 'function' ? arr.pushObject(obj) : arr.push(obj);
+}
+
 export function arrayContentWillChange(array, startIdx, removeAmt, addAmt) {
   let removing, lim;
 


### PR DESCRIPTION
Tackles #15501 `pushObject` task.

## Changes

- Creates an exportable `pushObject` method in `packages/ember-runtime/lib/mixins/array.js`
- Updates the following files to use the new exported `pushObject`
  - `packages/ember-extension-support/tests/data_adapter_test.js`

