### PR TITLE
Fix error & loading (sub-)states with async handlers.

### DIFF
--- a/packages/ember-glimmer/tests/integration/application/engine-test.js
+++ b/packages/ember-glimmer/tests/integration/application/engine-test.js
@@ -719,4 +719,28 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
       assert.ok(this.stringsEndWith(href1337, suffix1337));
     });
   }
+
+  ['@test visit() routable engine which errors on init'](assert) {
+    assert.expect(1);
+
+    let hooks = [];
+
+    this.additionalEngineRegistrations(function() {
+      this.register('route:application', Route.extend({
+        init() {
+          throw new Error('Whoops! Something went wrong...');
+        }
+      }));
+    });
+
+    this.setupAppAndRoutableEngine(hooks);
+
+    return this.visit('/', { shouldRender: true })
+      .then(() => {
+        return this.visit('/blog');
+      })
+      .catch((error) => {
+        assert.equal(error.message, 'Whoops! Something went wrong...');
+      });
+  }
 });

--- a/packages/ember-glimmer/tests/integration/application/engine-test.js
+++ b/packages/ember-glimmer/tests/integration/application/engine-test.js
@@ -4,9 +4,50 @@ import { compile } from '../../utils/helpers';
 import { Controller, RSVP } from 'ember-runtime';
 import { Component } from 'ember-glimmer';
 import { Engine } from 'ember-application';
-import { Route } from 'ember-routing';
+import { Route, Router } from 'ember-routing';
+import { run } from 'ember-metal';
 
 moduleFor('Application test: engine rendering', class extends ApplicationTest {
+  get routerOptions() {
+    let { assert } = this;
+    return {
+      location: 'none',
+
+      // This creates a handler function similar to what is in use by ember-engines
+      // internally. Specifically, it returns a promise when transitioning _into_
+      // the first engine route, but returns the synchronously available handler
+      // _after_ the engine has been resolved.
+      _getHandlerFunction() {
+        let syncHandler = this._super(...arguments);
+        this._enginePromises = Object.create(null);
+        this._resolvedEngines = Object.create(null);
+
+        return name => {
+          let engineInfo = this._engineInfoByRoute[name];
+          if (!engineInfo) { return syncHandler(name); }
+
+          let engineName = engineInfo.name;
+          if (this._resolvedEngines[engineName]) { return syncHandler(name); }
+
+          let enginePromise = this._enginePromises[engineName];
+
+          if (!enginePromise) {
+            enginePromise = new RSVP.Promise(resolve => {
+              setTimeout(() => {
+                this._resolvedEngines[engineName] = true;
+
+                resolve();
+              }, 1);
+            });
+            this._enginePromises[engineName] = enginePromise;
+          }
+
+          return enginePromise.then(() => syncHandler(name));
+        };
+      }
+    };
+  }
+
   setupAppAndRoutableEngine(hooks = []) {
     let self = this;
 
@@ -365,8 +406,15 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
   ['@test error substate route works for the application route of an Engine'](assert) {
     assert.expect(2);
 
+    let errorEntered = RSVP.defer();
+
     this.setupAppAndRoutableEngine();
     this.additionalEngineRegistrations(function() {
+      this.register('route:application_error', Route.extend({
+        activate() {
+          run.next(errorEntered.resolve);
+        }
+      }));
       this.register('template:application_error', compile('Error! {{model.message}}'));
       this.register('route:post', Route.extend({
         model() {
@@ -379,6 +427,8 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
       this.assertText('Application');
       return this.transitionTo('blog.post');
     }).catch(() => {
+      return errorEntered.promise;
+    }).then(() => {
       this.assertText('ApplicationError! Oh, noes!');
     });
   }
@@ -386,8 +436,15 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
   ['@test error route works for the application route of an Engine'](assert) {
     assert.expect(2);
 
+    let errorEntered = RSVP.defer();
+
     this.setupAppAndRoutableEngine();
     this.additionalEngineRegistrations(function() {
+      this.register('route:error', Route.extend({
+        activate() {
+          run.next(errorEntered.resolve);
+        }
+      }));
       this.register('template:error', compile('Error! {{model.message}}'));
       this.register('route:post', Route.extend({
         model() {
@@ -400,6 +457,8 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
       this.assertText('Application');
       return this.transitionTo('blog.post');
     }).catch(() => {
+      return errorEntered.promise;
+    }).then(() => {
       this.assertText('ApplicationEngineError! Oh, noes!');
     });
   }
@@ -407,8 +466,15 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
   ['@test error substate route works for a child route of an Engine'](assert) {
     assert.expect(2);
 
+    let errorEntered = RSVP.defer();
+
     this.setupAppAndRoutableEngine();
     this.additionalEngineRegistrations(function() {
+      this.register('route:post_error', Route.extend({
+        activate() {
+          run.next(errorEntered.resolve);
+        }
+      }));
       this.register('template:post_error', compile('Error! {{model.message}}'));
       this.register('route:post', Route.extend({
         model() {
@@ -421,6 +487,8 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
       this.assertText('Application');
       return this.transitionTo('blog.post');
     }).catch(() => {
+      return errorEntered.promise;
+    }).then(() => {
       this.assertText('ApplicationEngineError! Oh, noes!');
     });
   }
@@ -428,8 +496,15 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
   ['@test error route works for a child route of an Engine'](assert) {
     assert.expect(2);
 
+    let errorEntered = RSVP.defer();
+
     this.setupAppAndRoutableEngine();
     this.additionalEngineRegistrations(function() {
+      this.register('route:post.error', Route.extend({
+        activate() {
+          run.next(errorEntered.resolve);
+        }
+      }));
       this.register('template:post.error', compile('Error! {{model.message}}'));
       this.register('route:post.comments', Route.extend({
         model() {
@@ -442,24 +517,31 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
       this.assertText('Application');
       return this.transitionTo('blog.post.comments');
     }).catch(() => {
+      return errorEntered.promise;
+    }).then(() => {
       this.assertText('ApplicationEngineError! Oh, noes!');
     });
   }
 
   ['@test loading substate route works for the application route of an Engine'](assert) {
     assert.expect(3);
+    let done = assert.async();
 
-    let resolveLoading;
+    let loadingEntered = RSVP.defer();
+    let resolveLoading = RSVP.defer();
 
     this.setupAppAndRoutableEngine();
     this.additionalEngineRegistrations(function() {
+      this.register('route:application_loading', Route.extend({
+        activate() {
+          run.next(loadingEntered.resolve);
+        }
+      }));
       this.register('template:application_loading', compile('Loading'));
       this.register('template:post', compile('Post'));
       this.register('route:post', Route.extend({
         model() {
-          return new RSVP.Promise((resolve) => {
-            resolveLoading = resolve;
-          });
+          return resolveLoading.promise;
         }
       }));
     });
@@ -468,31 +550,39 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
       this.assertText('Application');
       let transition = this.transitionTo('blog.post');
 
-      this.runTaskNext(() => {
+      loadingEntered.promise.then(() => {
         this.assertText('ApplicationLoading');
-        resolveLoading();
+        resolveLoading.resolve();
+
+        this.runTaskNext(() => {
+          this.assertText('ApplicationEnginePost');
+          done();
+        });
       });
 
-      return transition.then(() => {
-        this.runTaskNext(() => this.assertText('ApplicationEnginePost'));
-      });
+      return transition;
     });
   }
 
   ['@test loading route works for the application route of an Engine'](assert) {
     assert.expect(3);
+    let done = assert.async();
 
-    let resolveLoading;
+    let loadingEntered = RSVP.defer();
+    let resolveLoading = RSVP.defer();
 
     this.setupAppAndRoutableEngine();
     this.additionalEngineRegistrations(function() {
+      this.register('route:loading', Route.extend({
+        activate() {
+          run.next(loadingEntered.resolve);
+        }
+      }));
       this.register('template:loading', compile('Loading'));
       this.register('template:post', compile('Post'));
       this.register('route:post', Route.extend({
         model() {
-          return new RSVP.Promise((resolve) => {
-            resolveLoading = resolve;
-          });
+          return resolveLoading.promise;
         }
       }));
     });
@@ -501,14 +591,17 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
       this.assertText('Application');
       let transition = this.transitionTo('blog.post');
 
-      this.runTaskNext(() => {
+      loadingEntered.promise.then(() => {
         this.assertText('ApplicationEngineLoading');
-        resolveLoading();
+        resolveLoading.resolve();
+
+        this.runTaskNext(() => {
+          this.assertText('ApplicationEnginePost')
+          done();
+        });
       });
 
-      return transition.then(() => {
-        this.runTaskNext(() => this.assertText('ApplicationEnginePost'));
-      });
+      return transition
     });
   }
 
@@ -549,20 +642,25 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
 
   ['@test loading route works for a child route of an Engine'](assert) {
     assert.expect(3);
+    let done = assert.async();
 
-    let resolveLoading;
+    let loadingEntered = RSVP.defer();
+    let resolveLoading = RSVP.defer();
 
     this.setupAppAndRoutableEngine();
     this.additionalEngineRegistrations(function() {
       this.register('template:post', compile('{{outlet}}'));
       this.register('template:post.comments', compile('Comments'));
+      this.register('route:post.loading', Route.extend({
+        activate() {
+          run.next(loadingEntered.resolve);
+        }
+      }));
       this.register('template:post.loading', compile('Loading'));
       this.register('template:post.likes', compile('Likes'));
       this.register('route:post.likes', Route.extend({
         model() {
-          return new RSVP.Promise((resolve) => {
-            resolveLoading = resolve;
-          });
+          return resolveLoading.promise;
         }
       }));
     });
@@ -571,14 +669,17 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
       this.assertText('ApplicationEngineComments');
       let transition = this.transitionTo('blog.post.likes');
 
-      this.runTaskNext(() => {
+      loadingEntered.promise.then(() => {
         this.assertText('ApplicationEngineLoading');
-        resolveLoading();
+        resolveLoading.resolve();
+
+        this.runTaskNext(() => {
+          this.assertText('ApplicationEngineLikes')
+          done();
+        });
       });
 
-      return transition.then(() => {
-        this.runTaskNext(() => this.assertText('ApplicationEngineLikes'));
-      });
+      return transition;
     });
   }
 


### PR DESCRIPTION
When a given `HandlerInfo` has an `undefined` `.handler` property, it means that either the handler threw an error during its `init` or that we are traversing into an async resolved handler (e.g. engines).  When handlers are loaded sync, any errors during `init` are immediately surfaced however when they are loaded in an async manner these errors were previously being obfuscated by logic deep in the Ember routing internals that itself fails and throws other errors.  The refactoring in this commit, avoids the masking errors that were being thrown.