### PR TITLE
Update router_js to 2.0.0.

### DIFF
--- a/broccoli/packages.js
+++ b/broccoli/packages.js
@@ -16,24 +16,10 @@ const { stripIndent } = require('common-tags');
 const toES5 = require('./to-es5');
 
 module.exports.routerES = function _routerES() {
-  return new Rollup(findLib('router_js', 'lib'), {
+  return new Rollup(findLib('router_js'), {
     rollup: {
       external: ['route-recognizer', 'rsvp'],
-      entry: 'router.js',
-      plugins: [{
-        transform(code, id) {
-          if (/[^t][^e][^r]\/router\.js$/.test(id)) {
-            code += 'export { Transition } from \'./router/transition\';\n'
-          } else if (/\/router\/handler-info\/[^\/]+\.js$/.test(id)) {
-            code = code.replace(/\'router\//g, '\'../');
-          }
-          code = code.replace(/import\ Promise\ from \'rsvp\/promise\'/g, 'import { Promise } from \'rsvp\'')
-          return {
-            code: code,
-            map: { mappings: '' }
-          };
-        }
-      }],
+      entry: 'index.js',
       targets: [{
         dest: 'router.js',
         format: 'es'

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "qunit-phantomjs-runner": "^2.2.0",
     "qunitjs": "^1.22.0",
     "route-recognizer": "^0.3.3",
-    "router_js": "^1.2.8",
+    "router_js": "^2.0.0-beta.1",
     "semver": "^5.3.0",
     "serve-static": "^1.12.2",
     "simple-dom": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5322,9 +5322,9 @@ route-recognizer@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/route-recognizer/-/route-recognizer-0.3.3.tgz#1d365e27fa6995e091675f7dc940a8c00353bd29"
 
-router_js@^1.2.8:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/router_js/-/router_js-1.2.8.tgz#d2ea5d00726e1fd6494d20ae3ebeb99ce86cf0b3"
+router_js@^2.0.0-beta.1:
+  version "2.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/router_js/-/router_js-2.0.0-beta.1.tgz#6f267b5171bbe1e92729db3e8be447e6a9d63f5a"
 
 rsvp@3.0.14:
   version "3.0.14"


### PR DESCRIPTION
The diff of the changes is pretty noisey (due to lots of general cleanup work that was done), but for the most part the changes are:

* Drop support for non ES5 browsers (use `Array.isArray`,
  `Object.create`, etc directly)
* Refactor the dist output to emit `module` entry point.
* Update to use classes throughout the repo.
* Ensure `Route.prototype.serialize` is called bound to the route
  instance.