### PR TITLE
[BUGFIX release] Update backburner.js to 1.2.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "babel-plugin-transform-proto-to-assign": "^6.23.0",
     "babel-template": "^6.24.1",
-    "backburner.js": "^1.1.0",
+    "backburner.js": "^1.2.1",
     "broccoli-babel-transpiler": "next",
     "broccoli-concat": "^3.2.2",
     "broccoli-file-creator": "^1.1.1",

--- a/packages/ember-metal/tests/run_loop/later_test.js
+++ b/packages/ember-metal/tests/run_loop/later_test.js
@@ -1,3 +1,4 @@
+import { assign } from 'ember-utils';
 import { run, isNone } from '../..';
 
 const originalSetTimeout = window.setTimeout;
@@ -198,7 +199,7 @@ asyncTest('setTimeout should never run with a negative wait', function() {
   // happens when an expired timer callback takes a while to run,
   // which is what we simulate here.
   let newSetTimeoutUsed;
-  run.backburner._platform = {
+  run.backburner._platform = Object.assign({}, originalPlatform, {
     setTimeout() {
       let wait = arguments[arguments.length - 1];
       newSetTimeoutUsed = true;
@@ -206,7 +207,7 @@ asyncTest('setTimeout should never run with a negative wait', function() {
 
       return originalPlatform.setTimeout.apply(originalPlatform, arguments);
     }
-  };
+  });
 
   let count = 0;
   run(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -870,9 +870,9 @@ backbone@^1.1.2:
   dependencies:
     underscore ">=1.8.3"
 
-backburner.js@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-1.1.0.tgz#16ef021891bc330a2d021c63d8d68cb8611eb3e4"
+backburner.js@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-1.2.1.tgz#26adfcd4d06adc80f78be010b3ff90bf44fc7790"
 
 backo2@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
The diff between [v1.1.0 and v1.2.0](https://github.com/BackburnerJS/backburner.js/compare/v1.1.0...v1.2.1) includes the following changes:

* Allow `onError` to be late bound (and recalculated for each flush).
* Make `now()` late bound (allowing for things like `sinon.useFakeTimers()`).