### PR TITLE
[DOC release] Update description of value returned by Ember.computed.empty

### DIFF
--- a/packages/ember-runtime/lib/computed/computed_macros.js
+++ b/packages/ember-runtime/lib/computed/computed_macros.js
@@ -80,8 +80,10 @@ function generateComputedWithPredicate(name, predicate) {
   @method empty
   @for Ember.computed
   @param {String} dependentKey
-  @return {Ember.ComputedProperty} computed property which negate
-  the original value for property
+  @return {Ember.ComputedProperty} computed property which returns true if
+  the value of the dependent property is null, an empty string, empty array,
+  or empty function and false if the underlying value is not empty.
+
   @public
 */
 export function empty(dependentKey) {


### PR DESCRIPTION
The description modified in this PR has been present since the addition of `Ember.computed.empty` in https://github.com/emberjs/ember.js/pull/2219. At the time this was also the description for [`Ember.computed.not`'s return value](https://github.com/emberjs/ember.js/pull/2219/files#diff-845b71768b2891302a6a3adf45cd55f0L450) and it seems like it was unintentionally copied and left unchanged when `empty` was added.