### PR TITLE
[BUGFIX lts] Mark error as handled before transition for error routes and substates

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "pretest": "ember build",
     "test": "node bin/run-tests.js",
     "test:blueprints": "node node-tests/nodetest-runner.js",
+    "test:node": "node bin/run-node-tests.js",
     "test:sauce": "node bin/run-sauce-tests.js",
     "test:testem": "testem -f testem.dist.json",
     "link:glimmer": "node bin/yarn-link-glimmer.js"

--- a/packages/ember-glimmer/tests/integration/application/engine-test.js
+++ b/packages/ember-glimmer/tests/integration/application/engine-test.js
@@ -426,7 +426,7 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
     return this.visit('/').then(() => {
       this.assertText('Application');
       return this.transitionTo('blog.post');
-    }).catch(() => {
+    }).then(() => {
       return errorEntered.promise;
     }).then(() => {
       this.assertText('ApplicationError! Oh, noes!');
@@ -456,7 +456,7 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
     return this.visit('/').then(() => {
       this.assertText('Application');
       return this.transitionTo('blog.post');
-    }).catch(() => {
+    }).then(() => {
       return errorEntered.promise;
     }).then(() => {
       this.assertText('ApplicationEngineError! Oh, noes!');
@@ -486,7 +486,7 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
     return this.visit('/').then(() => {
       this.assertText('Application');
       return this.transitionTo('blog.post');
-    }).catch(() => {
+    }).then(() => {
       return errorEntered.promise;
     }).then(() => {
       this.assertText('ApplicationEngineError! Oh, noes!');
@@ -516,7 +516,7 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
     return this.visit('/').then(() => {
       this.assertText('Application');
       return this.transitionTo('blog.post.comments');
-    }).catch(() => {
+    }).then(() => {
       return errorEntered.promise;
     }).then(() => {
       this.assertText('ApplicationEngineError! Oh, noes!');

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -1126,6 +1126,8 @@ let defaultActionHandlers = {
         // Check for the existence of an 'error' route.
         let errorRouteName = findRouteStateName(route, 'error');
         if (errorRouteName) {
+          let errorId = guidFor(error);
+          router._markErrorAsHandled(errorId);
           router.intermediateTransitionTo(errorRouteName, error);
           return false;
         }
@@ -1134,6 +1136,8 @@ let defaultActionHandlers = {
       // Check for an 'error' substate route
       let errorSubstateName = findRouteSubstateName(route, 'error');
       if (errorSubstateName) {
+        var errorId = guidFor(error);
+        router._markErrorAsHandled(errorId);
         router.intermediateTransitionTo(errorSubstateName, error);
         return false;
       }

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -2714,7 +2714,7 @@ QUnit.test('Errors in transition show error template if available', function() {
     }
   });
 
-  throws(() => bootApplication(), /More context objects were passed/);
+  bootApplication();
 
   equal(jQuery('#error').length, 1, 'Error template was rendered.');
 });

--- a/tests/node/visit-test.js
+++ b/tests/node/visit-test.js
@@ -170,24 +170,50 @@ QUnit.test('FastBoot: route error', function(assert) {
   var App = this.createApplication();
 
   return RSVP.all([
-    fastbootVisit(App, '/a').then(
-      function(instance) {
-        assert.ok(false, 'It should not render');
-        instance.destroy();
-      },
-      function(error) {
-        assert.equal(error.message, 'Error from A');
-      }
-    ),
-    fastbootVisit(App, '/b').then(
-      function(instance) {
-        assert.ok(false, 'It should not render');
-        instance.destroy();
-      },
-      function(error) {
-        assert.equal(error.message, 'Error from B');
-      }
-    )
+    fastbootVisit(App, '/a')
+      .then(
+        function(instance) {
+          assert.ok(false, 'It should not render');
+          instance.destroy();
+        },
+        function(error) {
+          assert.equal(error.message, 'Error from A');
+        }
+      ),
+      fastbootVisit(App, '/b').then(
+        function(instance) {
+          assert.ok(false, 'It should not render');
+          instance.destroy();
+        },
+        function(error) {
+          assert.equal(error.message, 'Error from B');
+        }
+      )
+  ]);
+});
+
+QUnit.test('FastBoot: route error template', function(assert) {
+  this.routes(function() {
+    this.route('a');
+  });
+
+  this.template('error', '<p>Error template rendered!</p>');
+  this.template('a', '<h1>Hello from A</h1>');
+
+  this.route('a', {
+    model: function() {
+      throw new Error('Error from A');
+    }
+  });
+
+  var App = this.createApplication();
+
+  return RSVP.all([
+    fastbootVisit(App, '/a')
+      .then(
+        assertFastbootResult(assert, { url: '/a', body: '<p>Error template rendered!</p>' }),
+        handleError(assert)
+      ),
   ]);
 });
 


### PR DESCRIPTION
We currently were not marking the error as "handled" before transitioning to the error route (even though we were handling the error by transitioning to the error route/substate). Due to this, the error was being bubbled up and thrown. In the browser this is fine, but in fastboot this causes the `visit` promise to be rejected and the error template to not be serialized.

Super thank you and shout out to @rwjblue for helping figure out the fix!

cc: @rwjblue 