### PR TITLE
[BUGFIX release] Avoid creating event dispatcher in FastBoot with Engines

### DIFF
--- a/packages/ember-application/lib/system/engine-instance.js
+++ b/packages/ember-application/lib/system/engine-instance.js
@@ -181,8 +181,11 @@ const EngineInstance = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixi
       '-view-registry:main',
       `renderer:-${env.isInteractive ? 'dom' : 'inert'}`,
       'service:-document',
-      'event_dispatcher:main'
     ];
+
+    if (env.isInteractive) {
+      singletons.push('event_dispatcher:main');
+    }
 
     singletons.forEach(key => this.register(key, parent.lookup(key), { instantiate: false }));
 

--- a/packages/ember-application/tests/system/application_instance_test.js
+++ b/packages/ember-application/tests/system/application_instance_test.js
@@ -63,6 +63,7 @@ QUnit.test('customEvents added to the application before setupEventDispatcher', 
   assert.expect(1);
 
   appInstance = run(() => ApplicationInstance.create({ application }));
+  appInstance.setupRegistry();
 
   application.customEvents = {
     awesome: 'sauce'
@@ -80,6 +81,7 @@ QUnit.test('customEvents added to the application before setupEventDispatcher', 
   assert.expect(1);
 
   run(() => appInstance = ApplicationInstance.create({ application }));
+  appInstance.setupRegistry();
 
   application.customEvents = {
     awesome: 'sauce'
@@ -97,6 +99,7 @@ QUnit.test('customEvents added to the application instance before setupEventDisp
   assert.expect(1);
 
   appInstance = run(() => ApplicationInstance.create({ application }));
+  appInstance.setupRegistry();
 
   appInstance.customEvents = {
     awesome: 'sauce'

--- a/packages/ember-glimmer/tests/integration/event-dispatcher-test.js
+++ b/packages/ember-glimmer/tests/integration/event-dispatcher-test.js
@@ -209,15 +209,6 @@ moduleFor('EventDispatcher#setup', class extends RenderingTest {
     this.render(`{{x-foo}}`);
   }
 
-  ['@test canDispatchToEventManager is deprecated in EventDispatcher'](assert) {
-    let MyDispatcher = EventDispatcher.extend({
-      canDispatchToEventManager: null
-    });
-
-    expectDeprecation(/`canDispatchToEventManager` has been deprecated/);
-    MyDispatcher.create();
-  }
-
   ['@test a rootElement can be specified'](assert) {
     this.$().append('<div id="app"></div>');
     this.dispatcher.setup({ myevent: 'myEvent' }, '#app');
@@ -257,6 +248,27 @@ moduleFor('EventDispatcher#setup', class extends RenderingTest {
     assert.throws(() => {
       this.dispatcher.setup({ myevent: 'myEvent' }, '#app');
     });
+  }
+});
+
+moduleFor('custom EventDispatcher subclass with #setup', class extends RenderingTest {
+  constructor() {
+    super();
+
+    let dispatcher = this.owner.lookup('event_dispatcher:main');
+    run(dispatcher, 'destroy');
+    this.owner.__container__.reset('event_dispatcher:main');
+    this.owner.unregister('event_dispatcher:main');
+  }
+
+  ['@test canDispatchToEventManager is deprecated in EventDispatcher'](assert) {
+    let MyDispatcher = EventDispatcher.extend({
+      canDispatchToEventManager: null
+    });
+    this.owner.register('event_dispatcher:main', MyDispatcher);
+
+    expectDeprecation(/`canDispatchToEventManager` has been deprecated/);
+    this.owner.lookup('event_dispatcher:main');
   }
 });
 

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -10,7 +10,6 @@ import { deprecate } from 'ember-debug';
 import { Object as EmberObject } from 'ember-runtime';
 import jQuery from './jquery';
 import ActionManager from './action_manager';
-import { environment } from 'ember-environment';
 import fallbackViewRegistry from '../compat/fallback-view-registry';
 
 const ROOT_ELEMENT_CLASS = 'ember-application';
@@ -136,7 +135,13 @@ export default EmberObject.extend({
 
   init() {
     this._super();
-    assert('EventDispatcher should never be instantiated in fastboot mode. Please report this as an Ember bug.', environment.hasDOM);
+
+    assert('EventDispatcher should never be instantiated in fastboot mode. Please report this as an Ember bug.', (() => {
+      let owner = getOwner(this);
+      let environment = owner.lookup('-environment:main');
+
+      return environment.isInteractive;
+    })());
 
     deprecate(
       `\`canDispatchToEventManager\` has been deprecated in ${this}.`,

--- a/packages/internal-test-helpers/lib/test-cases/abstract-rendering.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract-rendering.js
@@ -12,10 +12,12 @@ const TextNode = window.Text;
 export default class AbstractRenderingTestCase extends AbstractTestCase {
   constructor() {
     super();
+    let bootOptions = this.getBootOptions();
+
     let owner = this.owner = buildOwner({
       ownerOptions: this.getOwnerOptions(),
-      bootOptions: this.getBootOptions(),
-      resolver: this.getResolver()
+      resolver: this.getResolver(),
+      bootOptions,
     });
 
     this.renderer = this.owner.lookup('renderer:-dom');
@@ -24,7 +26,9 @@ export default class AbstractRenderingTestCase extends AbstractTestCase {
 
     owner.register('event_dispatcher:main', EventDispatcher);
     owner.inject('event_dispatcher:main', '_viewRegistry', '-view-registry:main');
-    owner.lookup('event_dispatcher:main').setup(this.getCustomDispatcherEvents(), this.element);
+    if (!bootOptions || bootOptions.isInteractive !== false) {
+      owner.lookup('event_dispatcher:main').setup(this.getCustomDispatcherEvents(), this.element);
+    }
   }
 
   compile() {


### PR DESCRIPTION
Prior to this commit, the `event_dispatcher:main` was always being instantiated so that it can be injected eagerly into child engines. In general, this is good (we should only ever have a single event dispatcher going) but in the FastBoot case the event dispatcher should not have been created at all (since there is no DOM or interactivity booting the event dispatcher to listen to DOM events is wasteful and error prone).

This commit updates the EventDispatcher base class to properly look for the `isInteractive` flag (which is what it should have been doing all along) on the `-environment:main` that is injected from the `Application.visit` API. When `isInteractive` is falsey and the event dispatcher is instantiated we will issue an assertion.

We also avoid eagerly looking up (and therefore forcing to initialize) the EventDispatcher if `.visit` API is passed `isInteractive: false`.  This avoids the specifically reported issue of triggering an assertion in FastBoot mode.

Fixes #15615