### PR TITLE
use `peekMeta` where appropriate

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -17,6 +17,7 @@ import {
 import {
   get,
   meta,
+  peekMeta,
   finishChains,
   sendEvent,
   detectBinding,
@@ -38,10 +39,10 @@ import { assert, Error as EmberError } from 'ember-debug';
 import { DEBUG } from 'ember-env-flags';
 import { MANDATORY_SETTER } from 'ember/features';
 
-let schedule = run.schedule;
-let applyMixin = Mixin._apply;
-let finishPartial = Mixin.finishPartial;
-let reopen = Mixin.prototype.reopen;
+const schedule = run.schedule;
+const applyMixin = Mixin._apply;
+const finishPartial = Mixin.finishPartial;
+const reopen = Mixin.prototype.reopen;
 
 export const POST_INIT = symbol('POST_INIT');
 
@@ -403,7 +404,7 @@ CoreObject.PrototypeMixin = Mixin.create({
   */
   isDestroyed: descriptor({
     get() {
-      return meta(this).isSourceDestroyed();
+      return peekMeta(this).isSourceDestroyed();
     },
 
     set(value) {
@@ -428,7 +429,7 @@ CoreObject.PrototypeMixin = Mixin.create({
   */
   isDestroying: descriptor({
     get() {
-      return meta(this).isSourceDestroying();
+      return peekMeta(this).isSourceDestroying();
     },
 
     set(value) {
@@ -456,7 +457,7 @@ CoreObject.PrototypeMixin = Mixin.create({
     @public
   */
   destroy() {
-    let m = meta(this);
+    let m = peekMeta(this);
     if (m.isSourceDestroying()) { return; }
 
     m.setSourceDestroying();
@@ -535,7 +536,7 @@ CoreObject.PrototypeMixin = Mixin.create({
     let hasToStringExtension = typeof this.toStringExtension === 'function';
     let extension = hasToStringExtension ? `:${this.toStringExtension()}` : '';
 
-    let ret = `<${this[NAME_KEY] || meta(this).factory || this.constructor.toString()}:${guidFor(this)}${extension}>`;
+    let ret = `<${this[NAME_KEY] || peekMeta(this).factory || this.constructor.toString()}:${guidFor(this)}${extension}>`;
 
     return ret;
   }

--- a/packages/ember-runtime/lib/system/object.js
+++ b/packages/ember-runtime/lib/system/object.js
@@ -3,7 +3,7 @@
 */
 
 import { symbol, NAME_KEY, OWNER } from 'ember-utils';
-import { on, descriptor, meta as metaFor } from 'ember-metal';
+import { on, descriptor, peekMeta } from 'ember-metal';
 import CoreObject from './core_object';
 import Observable from '../mixins/observable';
 import { assert } from 'ember-debug';
@@ -30,7 +30,7 @@ const EmberObject = CoreObject.extend(Observable, {
         return this[OVERRIDE_CONTAINER_KEY];
       }
 
-      let meta = metaFor(this);
+      let meta = peekMeta(this);
       let { factory } = meta;
 
       return factory && factory.fullName;
@@ -44,7 +44,7 @@ const EmberObject = CoreObject.extend(Observable, {
         return this[OVERRIDE_OWNER];
       }
 
-      let meta = metaFor(this);
+      let meta = peekMeta(this);
       let { factory } = meta;
 
       return factory && factory.owner;


### PR DESCRIPTION
since `CoreObject` constructor already inits `meta` https://github.com/emberjs/ember.js/blob/master/packages/ember-runtime/lib/system/core_object.js#L68