### PR TITLE
remove `__defineNonEnumerable`

### DIFF
--- a/packages/ember-glimmer/lib/component.ts
+++ b/packages/ember-glimmer/lib/component.ts
@@ -597,13 +597,6 @@ const Component = CoreView.extend(
       this._super();
     },
 
-    __defineNonEnumerable(property: {
-      name: string;
-      descriptor: { value: any }
-    }) {
-      this[property.name] = property.descriptor.value;
-    },
-
     [PROPERTY_DID_CHANGE](key: string) {
       if (this[IS_DISPATCHING_ATTRS]) { return; }
 

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -110,7 +110,8 @@ function makeCtor() {
         });
       }
 
-      self.__defineNonEnumerable(GUID_KEY_PROPERTY);
+      Object.defineProperty(this, GUID_KEY_PROPERTY.name, GUID_KEY_PROPERTY.descriptor);
+
       let m = meta(self);
       let proto = m.proto;
       m.proto = self;
@@ -311,11 +312,6 @@ CoreObject.PrototypeMixin = Mixin.create({
     @public
   */
   init() {},
-
-  __defineNonEnumerable(property) {
-    Object.defineProperty(this, property.name, property.descriptor);
-    //this[property.name] = property.descriptor.value;
-  },
 
   /**
     Defines the properties that will be concatenated from the superclass

--- a/packages/ember-utils/lib/guid.js
+++ b/packages/ember-utils/lib/guid.js
@@ -98,11 +98,7 @@ export function generateGuid(obj, prefix = GUID_PREFIX) {
       obj[GUID_KEY] = ret;
     } else {
       GUID_DESC.value = ret;
-      if (obj.__defineNonEnumerable) {
-        obj.__defineNonEnumerable(GUID_KEY_PROPERTY);
-      } else {
-        Object.defineProperty(obj, GUID_KEY, GUID_DESC);
-      }
+      Object.defineProperty(obj, GUID_KEY, GUID_DESC);
     }
   }
   return ret;

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -428,10 +428,6 @@ export default Mixin.create({
     );
   },
 
-  __defineNonEnumerable(property) {
-    this[property.name] = property.descriptor.value;
-  },
-
   // .......................................................
   // EVENT HANDLING
   //


### PR DESCRIPTION
looks odd to have `__defineNonEnumerable` when you can use `Object.defineProperty `