### PR TITLE
make consistent `destroyDestroyables` with `resetMember`

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -367,7 +367,7 @@ function destroyDestroyables(container) {
     let key = keys[i];
     let value = cache[key];
 
-    if (isInstantiatable(container, key) && value.destroy) {
+    if (value.destroy) {
       value.destroy();
     }
   }


### PR DESCRIPTION
when single `container object` destroyed there is no `isInstantiatable(container, key)` check 
but when all `container object`s destroyed there is, I think it is inconsistent 