### PR TITLE
[BUGFIX release] Remove sourceMappingURL for dag-map.

### DIFF
--- a/broccoli/packages.js
+++ b/broccoli/packages.js
@@ -121,9 +121,18 @@ module.exports.backburnerES = function _backburnerES() {
 }
 
 module.exports.dagES = function _dagES() {
-  return funnelLib('dag-map', {
+  let lib = funnelLib('dag-map', {
     files: ['dag-map.js'],
     annotation: 'dag-map es'
+  });
+
+  return new StringReplace(lib, {
+    files: ['dag-map.js'],
+    patterns: [{
+      match: /\/\/# sourceMappingURL=dag-map.js.map/g,
+      replacement: ''
+    }],
+    annotation: 'remove sourcemap annotation (dag-map)'
   });
 }
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,11 +1,6 @@
 'use strict';
 /* eslint-env node */
 
-// To create fast production builds (without ES3 support, minification, derequire, or JSHint)
-// run the following:
-//
-// DISABLE_ES3=true DISABLE_JSCS=true DISABLE_JSHINT=true DISABLE_MIN=true DISABLE_DEREQUIRE=true ember serve --environment=production
-
 const MergeTrees = require('broccoli-merge-trees');
 const Funnel = require('broccoli-funnel');
 const babelHelpers = require('./broccoli/babel-helpers');


### PR DESCRIPTION
Babel is not properly ingesting the sourcemaps (even when the upstream funnel brings the mapping file in with it), this commit strips it out to avoid errors during uglification.

Fixes ember-cli/ember-cli-uglify#29