### PR TITLE
[BUGFIX release] empty path in `get` helper should not throw assertion

### DIFF
--- a/packages/ember-glimmer/lib/helpers/get.js
+++ b/packages/ember-glimmer/lib/helpers/get.js
@@ -94,7 +94,7 @@ class GetHelperReference extends CachedReference {
     let path = this.lastPath = this.pathReference.value();
 
     if (path !== lastPath) {
-      if (path !== undefined && path !== null) {
+      if (path !== undefined && path !== null && path !== '') {
         let pathType = typeof path;
 
         if (pathType === 'string') {


### PR DESCRIPTION
just noticed this in my app were `get` helper is throwing assertion for empty path which didn't before 