### PR TITLE
[BUGFIX] Passing query params via router service

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -972,7 +972,7 @@ const EmberRouter = EmberObject.extend(Evented, {
               return true;
             }
 
-            if (_fromRouterService) {
+            if (_fromRouterService && presentProp !== false) {
               return false;
             }
 

--- a/packages/ember/tests/routing/router_service_test/transitionTo_test.js
+++ b/packages/ember/tests/routing/router_service_test/transitionTo_test.js
@@ -256,6 +256,27 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
         });
     }
 
+    ['@test RouterService#transitionTo with unspecified query params'](assert) {
+      assert.expect(1);
+
+      this.add('controller:parent.child', Controller.extend({
+        queryParams: ['sort', 'string', 'page', 'category', 'extra'],
+        sort: 'ASC',
+        string: '',
+        page: null,
+        category: undefined
+      }));
+
+      let queryParams = this.buildQueryParams({ sort: 'ASC' });
+
+      return this.visit('/').then(() => {
+        return this.routerService.transitionTo('parent.child', queryParams);
+      })
+        .then(() => {
+          assert.equal(this.routerService.get('currentURL'), '/child?category=undefined&extra=undefined&page=null&sort=ASC&string=');
+        });
+    }
+
     ['@test RouterService#transitionTo with aliased query params uses the original provided key'](assert) {
       assert.expect(1);
 


### PR DESCRIPTION
Continued from PR #15613. (Closes #15725)

Fixes an error that happens when passing fewer than all query params of a given route via router service (a bug introduced in #15414).