### PR TITLE
Add null and undefined type coercion for query params

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -848,7 +848,10 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
         } else {
           if (presentKey) {
             svalue = params[presentKey];
-            value = route.deserializeQueryParam(svalue, qp.urlKey, qp.type);
+
+            if (svalue !== undefined) {
+              value = route.deserializeQueryParam(svalue, qp.urlKey, qp.type);
+            }
           } else {
             // No QP provided; use default value.
             svalue = qp.serializedDefaultValue;

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -701,7 +701,9 @@ const EmberRouter = EmberObject.extend(Evented, {
     @param {String} type
   */
   _serializeQueryParam(value, type) {
-    if (type === 'array') {
+    if (value === null || value === undefined) {
+      return null;
+    } else if (type === 'array') {
       return JSON.stringify(value);
     }
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -702,7 +702,7 @@ const EmberRouter = EmberObject.extend(Evented, {
   */
   _serializeQueryParam(value, type) {
     if (value === null || value === undefined) {
-      return null;
+      return value;
     } else if (type === 'array') {
       return JSON.stringify(value);
     }
@@ -739,7 +739,9 @@ const EmberRouter = EmberObject.extend(Evented, {
     @param {String} defaultType
   */
   _deserializeQueryParam(value, defaultType) {
-    if (defaultType === 'boolean') {
+    if (value === null || value === undefined) {
+      return value;
+    } else if (defaultType === 'boolean') {
       return value === 'true';
     } else if (defaultType === 'number') {
       return (Number(value)).valueOf();

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -1153,6 +1153,63 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
     });
   }
 
+  test("Setting bound query pram property to null or undefined do not seralize to url", function() {
+    Router.map(function() {
+      this.route("home", { path: '/home' });
+    });
+
+    App.HomeController = Ember.Controller.extend({
+      queryParams: ['foo'],
+      foo: [1, 2]
+    });
+
+    startingURL = '/home';
+    bootApplication();
+
+    var controller = container.lookup('controller:home');
+
+    deepEqual(controller.get('foo'), [1,2]);
+    equal(router.get('location.path'), "/home");
+
+    Ember.run(controller, 'set', 'foo', [1,3]);
+    equal(router.get('location.path'), "/home?foo=%5B1%2C3%5D");
+
+    Ember.run(router, 'transitionTo', '/home');
+    deepEqual(controller.get('foo'), [1,2]);
+
+    Ember.run(controller, 'set', 'foo', null);
+    equal(router.get('location.path'), "/home", "Setting property to null");
+
+    Ember.run(controller, 'set', 'foo', [1,3]);
+    equal(router.get('location.path'), "/home?foo=%5B1%2C3%5D");
+
+    Ember.run(controller, 'set', 'foo', undefined);
+    equal(router.get('location.path'), "/home", "Setting property to undefined");
+  });
+
+  test("{{link-to}} with null or undefined qps do not get serialized into url", function() {
+    Ember.TEMPLATES.home = Ember.Handlebars.compile(
+      "{{link-to 'Home' 'home' (query-params foo=nullValue) id='null-link'}}" +
+      "{{link-to 'Home' 'home' (query-params foo=undefinedValue) id='undefined-link'}}");
+    Router.map(function() {
+      this.route("home", { path: '/home' });
+    });
+
+    App.HomeController = Ember.Controller.extend({
+      queryParams: ['foo'],
+      foo: [],
+      nullValue: null,
+      undefinedValue: undefined
+    });
+
+    startingURL = '/home';
+    bootApplication();
+
+    var controller = container.lookup('controller:home');
+    equal(Ember.$('#null-link').attr('href'), "/home");
+    equal(Ember.$('#undefined-link').attr('href'), "/home");
+  });
+
   ['@test A child of a resource route still defaults to parent route\'s model even if the child route has a query param'](assert) {
     assert.expect(2);
 


### PR DESCRIPTION
Continued from PR #15613.

Fixes the problem reported in #4570 (and attempted to be fixed in #4571). This fix (originally by @raytiley) is required to make the above use case work. Without it, transitioning to a route that has multiple query params ends up with all of them in the url with the value null, i.e.

```
  Ember.Controller.extend({
    queryParams: ['q', 'other', 'stuff']
  });

  // in some component
  this.get('router').transitionTo('articles', {
    queryParams: { q: 'test' },
  });

  // We end up at: /articles?q=test&other=null&stuff=null
  // Instead of (after the fix): /articles?q=test
```