### PR TITLE
[DOC release] Update Evented example code for RFC 176

### DIFF
--- a/packages/ember-runtime/lib/mixins/evented.js
+++ b/packages/ember-runtime/lib/mixins/evented.js
@@ -18,7 +18,7 @@ import {
   import EmberObject from '@ember/object';
   import Evented from '@ember/object/evented';
   
-  export default EmberObject.extend(Ember.Evented, {
+  export default EmberObject.extend(Evented, {
     greet() {
       // ...
       this.trigger('greet');


### PR DESCRIPTION
The example code still mixed in `Ember.Evented`, but the import was updated to just `Evented`