### PR TITLE
[BUGFIX] Fix computed sort regression when array prop initially null

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -740,10 +740,6 @@ function propertySort(itemsKey, sortPropertiesKey) {
       activeObservers.forEach(args => removeObserver(...args));
     }
 
-    let itemsKeyIsAtThis = (itemsKey === '@this');
-    let items = itemsKeyIsAtThis ? this : get(this, itemsKey);
-    if (!isArray(items)) { return emberA(); }
-
     function sortPropertyDidChange() {
       this.notifyPropertyChange(key);
     }
@@ -756,6 +752,10 @@ function propertySort(itemsKey, sortPropertiesKey) {
     });
 
     activeObserversMap.set(this, activeObservers);
+
+    let itemsKeyIsAtThis = (itemsKey === '@this');
+    let items = itemsKeyIsAtThis ? this : get(this, itemsKey);
+    if (!isArray(items)) { return emberA(); }
 
     return sortByNormalizedSortProperties(items, normalizedSortProperties);
   }, { dependentKeys: [`${sortPropertiesKey}.[]`], readOnly: true });

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -918,6 +918,13 @@ QUnit.test('updating sort properties detaches observers for old sort properties'
   ], 'after changing removed item array is not updated');
 });
 
+QUnit.test('sort works if array property is null (non array value) on first evaluation of computed prop', function() {
+  obj.set('items', null);
+  deepEqual(obj.get('sortedItems'), []);
+  obj.set('items', emberA([{fname: 'Cersei', lname: 'Lanister'}]));
+  deepEqual(obj.get('sortedItems'), [{fname: 'Cersei', lname: 'Lanister'}]);
+});
+
 QUnit.test('updating sort properties updates the sorted array', function() {
   deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Cersei',


### PR DESCRIPTION
There was a regression introduced ([commit](https://github.com/emberjs/ember.js/commit/ea1c8db2a31afedd2ea76215835f384cdbb0c088#diff-be5c035bb6df695f80dbf5d940188c68)) in a sort computed macro.

If an array property (that is being sorted) is initially null or other non-array value - when computed property is first evaluated observers wouldn't be set and computed property would never work again. Provided test pretty much says it all.