### PR TITLE
[DEPRECATION canary] Deprecate Ember.String and prototype extension

### DIFF
--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -5,7 +5,7 @@
 import { dictionary } from 'ember-utils';
 import { get, findNamespace } from 'ember-metal';
 import { assert, info } from 'ember-debug';
-import { String as StringUtils, Object as EmberObject } from 'ember-runtime';
+import { StringUtils, Object as EmberObject } from 'ember-runtime';
 import validateType from '../utils/validate-type';
 import { getTemplate } from 'ember-glimmer';
 import { DEBUG } from 'ember-env-flags';

--- a/packages/ember-extension-support/lib/container_debug_adapter.js
+++ b/packages/ember-extension-support/lib/container_debug_adapter.js
@@ -1,10 +1,4 @@
-import {
-  A as emberA,
-  typeOf,
-  String as StringUtils,
-  Namespace,
-  Object as EmberObject,
-} from 'ember-runtime';
+import { A as emberA, typeOf, StringUtils, Namespace, Object as EmberObject } from 'ember-runtime';
 
 /**
 @module @ember/debug

--- a/packages/ember-glimmer/index.ts
+++ b/packages/ember-glimmer/index.ts
@@ -268,7 +268,14 @@ export { default as LinkComponent } from './lib/components/link-to';
 export { default as Component, ROOT_REF } from './lib/component';
 export { default as Helper, helper } from './lib/helper';
 export { default as Environment } from './lib/environment';
-export { SafeString, escapeExpression, htmlSafe, isHTMLSafe } from './lib/utils/string';
+export {
+  SafeString,
+  deprecatedHTMLSafe,
+  deprecatedIsHTMLSafe,
+  escapeExpression,
+  htmlSafe,
+  isHTMLSafe,
+} from './lib/utils/string';
 export {
   Renderer,
   InertRenderer,

--- a/packages/ember-glimmer/lib/component-managers/curly.ts
+++ b/packages/ember-glimmer/lib/component-managers/curly.ts
@@ -25,7 +25,7 @@ import { assert, deprecate } from 'ember-debug';
 import { DEBUG } from 'ember-env-flags';
 import { ENV } from 'ember-environment';
 import { _instrumentStart, get } from 'ember-metal';
-import { String as StringUtils } from 'ember-runtime';
+import { StringUtils } from 'ember-runtime';
 import { assign, getOwner, guidFor } from 'ember-utils';
 import { addChildView, OwnedTemplateMeta, setViewElement } from 'ember-views';
 import { BOUNDS, DIRTY_TAG, HAS_BLOCK, IS_DISPATCHING_ATTRS, ROOT_REF } from '../component';

--- a/packages/ember-glimmer/lib/helpers/-class.ts
+++ b/packages/ember-glimmer/lib/helpers/-class.ts
@@ -1,5 +1,5 @@
 import { Arguments, VM } from '@glimmer/runtime';
-import { String as StringUtils } from 'ember-runtime';
+import { StringUtils } from 'ember-runtime';
 import { InternalHelperReference } from '../utils/references';
 
 function classHelper({ positional }: any) {

--- a/packages/ember-glimmer/lib/helpers/-normalize-class.ts
+++ b/packages/ember-glimmer/lib/helpers/-normalize-class.ts
@@ -1,5 +1,5 @@
 import { Arguments, VM } from '@glimmer/runtime';
-import { String as StringUtils } from 'ember-runtime';
+import { StringUtils } from 'ember-runtime';
 import { InternalHelperReference } from '../utils/references';
 
 function normalizeClass({ positional }: any) {

--- a/packages/ember-glimmer/lib/helpers/loc.ts
+++ b/packages/ember-glimmer/lib/helpers/loc.ts
@@ -2,7 +2,7 @@
 @module ember
 */
 
-import { String as StringUtils } from 'ember-runtime';
+import { StringUtils } from 'ember-runtime';
 import { helper } from '../helper';
 
 /**

--- a/packages/ember-glimmer/lib/utils/bindings.ts
+++ b/packages/ember-glimmer/lib/utils/bindings.ts
@@ -4,7 +4,7 @@ import { ElementOperations, PrimitiveReference } from '@glimmer/runtime';
 import { Core, Ops } from '@glimmer/wire-format';
 import { assert } from 'ember-debug';
 import { get } from 'ember-metal';
-import { String as StringUtils } from 'ember-runtime';
+import { StringUtils } from 'ember-runtime';
 import { ROOT_REF } from '../component';
 import { Component } from './curly-component-state-bucket';
 import { referenceFromParts } from './references';

--- a/packages/ember-glimmer/lib/utils/string.ts
+++ b/packages/ember-glimmer/lib/utils/string.ts
@@ -2,6 +2,8 @@
 @module @ember/string
 */
 
+import { deprecate } from 'ember-debug';
+
 export class SafeString {
   public string: string;
 
@@ -74,6 +76,7 @@ export function escapeExpression(string: any): string {
   @static
   @return {Handlebars.SafeString} A string that will not be HTML escaped by Handlebars.
   @public
+  @deprecated
 */
 export function htmlSafe(str: string) {
   if (str === null || str === undefined) {
@@ -82,6 +85,19 @@ export function htmlSafe(str: string) {
     str = '' + str;
   }
   return new SafeString(str);
+}
+
+export function deprecatedHTMLSafe(str: string) {
+  deprecate(
+    'Ember.String namespace is deprecated. Please, import `htmlSafe` from `@ember/template`.',
+    false,
+    {
+      id: 'ember-glimmer.ember-string-html-safe',
+      until: '3.5.0',
+      url: '',
+    }
+  );
+  return htmlSafe(str);
 }
 
 /**
@@ -102,7 +118,21 @@ export function htmlSafe(str: string) {
   @static
   @return {Boolean} `true` if the string was decorated with `htmlSafe`, `false` otherwise.
   @public
+  @deprecated
 */
 export function isHTMLSafe(str: any | null | undefined): str is SafeString {
   return str !== null && typeof str === 'object' && typeof str.toHTML === 'function';
+}
+
+export function deprecatedIsHTMLSafe(str: any | null | undefined): str is SafeString {
+  deprecate(
+    'Ember.String namespace is deprecated. Please, import `isHTMLSafe` from `@ember/template`.',
+    false,
+    {
+      id: 'ember-glimmer.ember-string-is-html-safe',
+      until: '3.5.0',
+      url: '',
+    }
+  );
+  return isHTMLSafe(str);
 }

--- a/packages/ember-glimmer/tests/utils/helpers.js
+++ b/packages/ember-glimmer/tests/utils/helpers.js
@@ -9,7 +9,9 @@ export {
   InteractiveRender,
   InertRenderer,
   htmlSafe,
+  deprecatedHTMLSafe,
   SafeString,
   DOMChanges,
   isHTMLSafe,
+  deprecatedIsHTMLSafe,
 } from 'ember-glimmer';

--- a/packages/ember-glimmer/tests/utils/string-test.js
+++ b/packages/ember-glimmer/tests/utils/string-test.js
@@ -1,10 +1,23 @@
-import { SafeString, htmlSafe, isHTMLSafe } from './helpers';
+import {
+  SafeString,
+  htmlSafe,
+  deprecatedHTMLSafe,
+  isHTMLSafe,
+  deprecatedIsHTMLSafe,
+} from './helpers';
 import { TestCase } from './abstract-test-case';
 import { moduleFor } from './test-case';
 
 moduleFor(
   'SafeString',
   class extends TestCase {
+    ['@test deprecated version is deprecated']() {
+      expectDeprecation(/ember\/template/);
+      let safeString = deprecatedHTMLSafe('Hello');
+
+      this.assert.ok(safeString instanceof SafeString, 'should be a SafeString');
+    }
+
     ['@test htmlSafe should return an instance of SafeString']() {
       let safeString = htmlSafe('you need to be more <b>bold</b>');
 
@@ -30,6 +43,10 @@ moduleFor(
 moduleFor(
   'SafeString isHTMLSafe',
   class extends TestCase {
+    ['@test deprecated version is deprecated']() {
+      expectDeprecation(/ember\/template/);
+      deprecatedIsHTMLSafe('Hello');
+    }
     ['@test isHTMLSafe should detect SafeString']() {
       let safeString = htmlSafe('<em>Emphasize</em> the important things.');
 

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -5,7 +5,7 @@ import { DEBUG } from 'ember-env-flags';
 import {
   typeOf,
   copy,
-  String as StringUtils,
+  StringUtils,
   Object as EmberObject,
   A as emberA,
   Evented,

--- a/packages/ember-runtime/index.d.ts
+++ b/packages/ember-runtime/index.d.ts
@@ -21,3 +21,15 @@ export const String: {
 export function isEmberArray(arr: any): boolean;
 
 export function _contentFor(proxy: any): any;
+
+export const StringUtils: {
+  fmt(s: string, ...args: any[]): string,
+  loc(s: string, ...args: any[]): string,
+  w(s: string): string[],
+  decamelize(s: string): string,
+  dasherize(s: string): string,
+  camelize(s: string): string,
+  classify(s: string): string,
+  underscore(s: string): string,
+  capitalize(s: string): string
+}

--- a/packages/ember-runtime/lib/ext/string.js
+++ b/packages/ember-runtime/lib/ext/string.js
@@ -3,6 +3,7 @@
 */
 
 import { ENV } from 'ember-environment';
+import { deprecate } from 'ember-debug';
 import {
   w,
   loc,
@@ -15,6 +16,23 @@ import {
 } from '../system/string';
 
 const StringPrototype = String.prototype;
+
+function deprecateEmberStringPrototypeExtension(name, fn, opts = {}) {
+  return function() {
+    deprecate(
+      opts.message ||
+        `String prototype extensions are deprecated. Please, us ${name} from '@ember/string' instead.`,
+      false,
+      opts.options || {
+        id: 'ember-string.prototype_extensions',
+        until: '3.5.0',
+        url: 'https://emberjs.com/deprecations/v2.x/#toc_ember-string-prototype-extensions',
+      }
+    );
+
+    return fn(this, ...arguments);
+  };
+}
 
 if (ENV.EXTEND_PROTOTYPES.String) {
   /**
@@ -29,9 +47,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
     configurable: true,
     enumerable: false,
     writeable: true,
-    value: function() {
-      return w(this);
-    },
+    value: deprecateEmberStringPrototypeExtension('w', w),
   });
 
   /**
@@ -46,9 +62,10 @@ if (ENV.EXTEND_PROTOTYPES.String) {
     configurable: true,
     enumerable: false,
     writeable: true,
-    value: function(...args) {
-      return loc(this, args);
-    },
+    value: deprecateEmberStringPrototypeExtension('loc', loc, {
+      message:
+        '`loc` is deprecated. Please, use an i18n addon instead. See https://emberobserver.com/categories/internationalization for a list of them.',
+    }),
   });
 
   /**
@@ -63,9 +80,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
     configurable: true,
     enumerable: false,
     writeable: true,
-    value: function() {
-      return camelize(this);
-    },
+    value: deprecateEmberStringPrototypeExtension('camelize', camelize),
   });
 
   /**
@@ -80,9 +95,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
     configurable: true,
     enumerable: false,
     writeable: true,
-    value: function() {
-      return decamelize(this);
-    },
+    value: deprecateEmberStringPrototypeExtension('decamelize', decamelize),
   });
 
   /**
@@ -97,9 +110,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
     configurable: true,
     enumerable: false,
     writeable: true,
-    value: function() {
-      return dasherize(this);
-    },
+    value: deprecateEmberStringPrototypeExtension('dasherize', dasherize),
   });
 
   /**
@@ -114,9 +125,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
     configurable: true,
     enumerable: false,
     writeable: true,
-    value: function() {
-      return underscore(this);
-    },
+    value: deprecateEmberStringPrototypeExtension('underscore', underscore),
   });
 
   /**
@@ -131,9 +140,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
     configurable: true,
     enumerable: false,
     writeable: true,
-    value: function() {
-      return classify(this);
-    },
+    value: deprecateEmberStringPrototypeExtension('classify', classify),
   });
 
   /**
@@ -148,8 +155,6 @@ if (ENV.EXTEND_PROTOTYPES.String) {
     configurable: true,
     enumerable: false,
     writeable: true,
-    value: function() {
-      return capitalize(this);
-    },
+    value: deprecateEmberStringPrototypeExtension('capitalize', capitalize),
   });
 }

--- a/packages/ember-runtime/lib/index.js
+++ b/packages/ember-runtime/lib/index.js
@@ -1,5 +1,5 @@
 export { default as Object, FrameworkObject } from './system/object';
-export { default as String } from './system/string';
+export { default as String, StringUtils } from './system/string';
 export { default as RegistryProxyMixin } from './mixins/registry_proxy';
 export { default as ContainerProxyMixin } from './mixins/container_proxy';
 export { default as copy } from './copy';

--- a/packages/ember-runtime/lib/system/string.js
+++ b/packages/ember-runtime/lib/system/string.js
@@ -1,6 +1,7 @@
 /**
 @module @ember/string
 */
+import { deprecate } from 'ember-debug';
 import { Cache } from 'ember-metal';
 import { inspect } from 'ember-utils';
 import { isArray } from '../utils';
@@ -82,6 +83,22 @@ function _fmt(str, formats) {
   });
 }
 
+export function deprecateEmberStringUtil(name, fn, opts = {}) {
+  return function() {
+    deprecate(
+      opts.message ||
+        `Ember.String namespace is deprecated. Please, use ${name} from '@ember/string' instead.`,
+      false,
+      opts.options || {
+        id: 'ember-string.namespace',
+        until: '3.5.0',
+        url: 'https://emberjs.com/deprecations/v2.x/#toc_ember-string-namespace',
+      }
+    );
+    return fn(...arguments);
+  };
+}
+
 function loc(str, formats) {
   if (!isArray(formats) || arguments.length > 2) {
     formats = Array.prototype.slice.call(arguments, 1);
@@ -153,8 +170,9 @@ export default {
     @param {Array} formats Optional array of parameters to interpolate into string.
     @return {String} formatted string
     @public
+    @deprecated Use @ember/string addon instead
   */
-  loc,
+  loc: deprecateEmberStringUtil('loc', loc),
 
   /**
     Splits a string into separate units separated by spaces, eliminating any
@@ -177,8 +195,9 @@ export default {
     @param {String} str The string to split
     @return {Array} array containing the split strings
     @public
+    @deprecated Use @ember/string addon instead
   */
-  w,
+  w: deprecateEmberStringUtil('w', w),
 
   /**
     Converts a camelized string into all lower case separated by underscores.
@@ -194,8 +213,9 @@ export default {
     @param {String} str The string to decamelize.
     @return {String} the decamelized string.
     @public
+    @deprecated Use @ember/string addon instead
   */
-  decamelize,
+  decamelize: deprecateEmberStringUtil('decamelize', decamelize),
 
   /**
     Replaces underscores, spaces, or camelCase with dashes.
@@ -212,8 +232,9 @@ export default {
     @param {String} str The string to dasherize.
     @return {String} the dasherized string.
     @public
+    @deprecated Use @ember/string addon instead
   */
-  dasherize,
+  dasherize: deprecateEmberStringUtil('dasherize', dasherize),
 
   /**
     Returns the lowerCamelCase form of a string.
@@ -231,8 +252,9 @@ export default {
     @param {String} str The string to camelize.
     @return {String} the camelized string.
     @public
+    @deprecated Use @ember/string addon instead
   */
-  camelize,
+  camelize: deprecateEmberStringUtil('camelize', camelize),
 
   /**
     Returns the UpperCamelCase form of a string.
@@ -249,8 +271,9 @@ export default {
     @param {String} str the string to classify
     @return {String} the classified string
     @public
+    @deprecated Use @ember/string addon instead
   */
-  classify,
+  classify: deprecateEmberStringUtil('classify', classify),
 
   /**
     More general than decamelize. Returns the lower\_case\_and\_underscored
@@ -268,8 +291,9 @@ export default {
     @param {String} str The string to underscore.
     @return {String} the underscored string.
     @public
+    @deprecated Use @ember/string addon instead
   */
-  underscore,
+  underscore: deprecateEmberStringUtil('underscore', underscore),
 
   /**
     Returns the Capitalized form of a string
@@ -286,8 +310,20 @@ export default {
     @param {String} str The string to capitalize.
     @return {String} The capitalized string.
     @public
+    @deprecated Use @ember/string addon instead
   */
-  capitalize,
+  capitalize: deprecateEmberStringUtil('capitalize', capitalize),
 };
 
 export { loc, w, decamelize, dasherize, camelize, classify, underscore, capitalize };
+
+export const StringUtils = {
+  loc,
+  w,
+  decamelize,
+  dasherize,
+  camelize,
+  classify,
+  underscore,
+  capitalize,
+};

--- a/packages/ember-runtime/tests/system/string/camelize_test.js
+++ b/packages/ember-runtime/tests/system/string/camelize_test.js
@@ -1,10 +1,11 @@
 import { ENV } from 'ember-environment';
-import { camelize } from '../../../system/string';
+import { camelize, default as EmberString } from '../../../system/string';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 function test(assert, given, expected, description) {
   assert.deepEqual(camelize(given), expected, description);
   if (ENV.EXTEND_PROTOTYPES.String) {
+    expectDeprecation(/@ember\/string/);
     assert.deepEqual(given.camelize(), expected, description);
   }
 }
@@ -12,6 +13,11 @@ function test(assert, given, expected, description) {
 moduleFor(
   'EmberStringUtils.camelize',
   class extends AbstractTestCase {
+    ['@test Ember.String.camelize is deprecated']() {
+      expectDeprecation(/Ember.String namespace is deprecated/);
+      EmberString.camelize('hello world');
+    }
+
     ['@test String.prototype.camelize is not modified without EXTEND_PROTOTYPES'](assert) {
       if (!ENV.EXTEND_PROTOTYPES.String) {
         assert.ok(

--- a/packages/ember-runtime/tests/system/string/capitalize_test.js
+++ b/packages/ember-runtime/tests/system/string/capitalize_test.js
@@ -1,10 +1,11 @@
 import { ENV } from 'ember-environment';
-import { capitalize } from '../../../system/string';
+import { capitalize, default as EmberString } from '../../../system/string';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 function test(assert, given, expected, description) {
   assert.deepEqual(capitalize(given), expected, description);
   if (ENV.EXTEND_PROTOTYPES.String) {
+    expectDeprecation(/@ember\/string/);
     assert.deepEqual(given.capitalize(), expected, description);
   }
 }
@@ -12,6 +13,11 @@ function test(assert, given, expected, description) {
 moduleFor(
   'EmberStringUtils.capitalize',
   class extends AbstractTestCase {
+    ['@test Ember.String.capitalize is deprecated']() {
+      expectDeprecation(/Ember.String namespace is deprecated/);
+      EmberString.capitalize('hello world');
+    }
+
     ['@test String.prototype.capitalize is not modified without EXTEND_PROTOTYPES'](assert) {
       if (!ENV.EXTEND_PROTOTYPES.String) {
         assert.ok(

--- a/packages/ember-runtime/tests/system/string/classify_test.js
+++ b/packages/ember-runtime/tests/system/string/classify_test.js
@@ -1,10 +1,11 @@
 import { ENV } from 'ember-environment';
-import { classify } from '../../../system/string';
+import { classify, default as EmberString } from '../../../system/string';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 function test(assert, given, expected, description) {
   assert.deepEqual(classify(given), expected, description);
   if (ENV.EXTEND_PROTOTYPES.String) {
+    expectDeprecation(/@ember\/string/);
     assert.deepEqual(given.classify(), expected, description);
   }
 }
@@ -12,6 +13,11 @@ function test(assert, given, expected, description) {
 moduleFor(
   'EmberStringUtils.classify',
   class extends AbstractTestCase {
+    ['@test Ember.String.classify is deprecated']() {
+      expectDeprecation(/Ember.String namespace is deprecated/);
+      EmberString.classify('hello world');
+    }
+
     ['@test String.prototype.classify is not modified without EXTEND_PROTOTYPES'](assert) {
       if (!ENV.EXTEND_PROTOTYPES.String) {
         assert.ok(

--- a/packages/ember-runtime/tests/system/string/dasherize_test.js
+++ b/packages/ember-runtime/tests/system/string/dasherize_test.js
@@ -1,10 +1,11 @@
 import { ENV } from 'ember-environment';
-import { dasherize } from '../../../system/string';
+import { dasherize, default as EmberString } from '../../../system/string';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 function test(assert, given, expected, description) {
   assert.deepEqual(dasherize(given), expected, description);
   if (ENV.EXTEND_PROTOTYPES.String) {
+    expectDeprecation(/@ember\/string/);
     assert.deepEqual(given.dasherize(), expected, description);
   }
 }
@@ -12,6 +13,11 @@ function test(assert, given, expected, description) {
 moduleFor(
   'EmberStringUtils.dasherize',
   class extends AbstractTestCase {
+    ['@test Ember.String.dasherize is deprecated']() {
+      expectDeprecation(/Ember.String namespace is deprecated/);
+      EmberString.dasherize('hello world');
+    }
+
     ['@test String.prototype.dasherize is not modified without EXTEND_PROTOTYPES'](assert) {
       if (!ENV.EXTEND_PROTOTYPES.String) {
         assert.ok(

--- a/packages/ember-runtime/tests/system/string/decamelize_test.js
+++ b/packages/ember-runtime/tests/system/string/decamelize_test.js
@@ -1,10 +1,11 @@
 import { ENV } from 'ember-environment';
-import { decamelize } from '../../../system/string';
+import { decamelize, default as EmberString } from '../../../system/string';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 function test(assert, given, expected, description) {
   assert.deepEqual(decamelize(given), expected, description);
   if (ENV.EXTEND_PROTOTYPES.String) {
+    expectDeprecation(/@ember\/string/);
     assert.deepEqual(given.decamelize(), expected, description);
   }
 }
@@ -12,6 +13,11 @@ function test(assert, given, expected, description) {
 moduleFor(
   'EmberStringUtils.decamelize',
   class extends AbstractTestCase {
+    ['@test Ember.String.decamelize is deprecated']() {
+      expectDeprecation(/Ember.String namespace is deprecated/);
+      EmberString.decamelize('hello world');
+    }
+
     ['@test String.prototype.decamelize is not modified without EXTEND_PROTOTYPES'](assert) {
       if (!ENV.EXTEND_PROTOTYPES.String) {
         assert.ok(

--- a/packages/ember-runtime/tests/system/string/loc_test.js
+++ b/packages/ember-runtime/tests/system/string/loc_test.js
@@ -1,5 +1,5 @@
 import { ENV } from 'ember-environment';
-import { loc } from '../../../system/string';
+import { default as EmberString, loc } from '../../../system/string';
 import { setStrings, getStrings } from '../../../string_registry';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
@@ -8,6 +8,7 @@ let oldString;
 function test(assert, given, args, expected, description) {
   assert.equal(loc(given, args), expected, description);
   if (ENV.EXTEND_PROTOTYPES.String) {
+    expectDeprecation(/`loc` is deprecated/);
     assert.deepEqual(given.loc(...args), expected, description);
   }
 }
@@ -27,6 +28,11 @@ moduleFor(
 
     afterEach() {
       setStrings(oldString);
+    }
+
+    ['@test Ember.String.loc is deprecated']() {
+      expectDeprecation(/Ember.String namespace is deprecated/);
+      EmberString.loc('_Hello Worl', []);
     }
 
     ['@test String.prototype.loc is not available without EXTEND_PROTOTYPES'](assert) {

--- a/packages/ember-runtime/tests/system/string/underscore_test.js
+++ b/packages/ember-runtime/tests/system/string/underscore_test.js
@@ -1,10 +1,11 @@
 import { ENV } from 'ember-environment';
-import { underscore } from '../../../system/string';
+import { underscore, default as EmberString } from '../../../system/string';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 function test(assert, given, expected, description) {
   assert.deepEqual(underscore(given), expected, description);
   if (ENV.EXTEND_PROTOTYPES.String) {
+    expectDeprecation(/@ember\/string/);
     assert.deepEqual(given.underscore(), expected, description);
   }
 }
@@ -12,6 +13,11 @@ function test(assert, given, expected, description) {
 moduleFor(
   'EmberStringUtils.underscore',
   class extends AbstractTestCase {
+    ['@test Ember.String.underscore is deprecated']() {
+      expectDeprecation(/Ember.String namespace is deprecated/);
+      EmberString.underscore('hello world');
+    }
+
     ['@test String.prototype.underscore is not available without EXTEND_PROTOTYPES'](assert) {
       if (!ENV.EXTEND_PROTOTYPES.String) {
         assert.ok(

--- a/packages/ember-runtime/tests/system/string/w_test.js
+++ b/packages/ember-runtime/tests/system/string/w_test.js
@@ -1,10 +1,11 @@
 import { ENV } from 'ember-environment';
-import { w } from '../../../system/string';
+import { w, default as EmberString } from '../../../system/string';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 function test(assert, given, expected, description) {
   assert.deepEqual(w(given), expected, description);
   if (ENV.EXTEND_PROTOTYPES.String) {
+    expectDeprecation(/@ember\/string/);
     assert.deepEqual(given.w(), expected, description);
   }
 }
@@ -12,6 +13,11 @@ function test(assert, given, expected, description) {
 moduleFor(
   'EmberStringUtils.w',
   class extends AbstractTestCase {
+    ['@test Ember.String.w is deprecated']() {
+      expectDeprecation(/Ember.String namespace is deprecated/);
+      EmberString.w('hello world');
+    }
+
     ['@test String.prototype.w is not available without EXTEND_PROTOTYPES'](assert) {
       if (!ENV.EXTEND_PROTOTYPES.String) {
         assert.ok('undefined' === typeof String.prototype.w, 'String.prototype helper disabled');

--- a/packages/ember/lib/index.js
+++ b/packages/ember/lib/index.js
@@ -85,6 +85,8 @@ import {
   Checkbox,
   Component,
   componentManager,
+  deprecatedHTMLSafe,
+  deprecatedIsHTMLSafe,
   escapeExpression,
   getTemplates,
   Helper,
@@ -424,11 +426,20 @@ Ember.HTMLBars = {
 
 if (ENV.EXTEND_PROTOTYPES.String) {
   String.prototype.htmlSafe = function() {
+    EmberDebug.deprecate(
+      `Extending String prototype is deprecated. Please, use htmlSafe from '@ember/template'.`,
+      false,
+      {
+        id: 'ember-runtime.string-prototype-extension',
+        until: '3.5.0',
+        url: '',
+      }
+    );
     return htmlSafe(this);
   };
 }
-EmberString.htmlSafe = htmlSafe;
-EmberString.isHTMLSafe = isHTMLSafe;
+EmberString.htmlSafe = deprecatedHTMLSafe;
+EmberString.isHTMLSafe = deprecatedIsHTMLSafe;
 
 /**
   Global hash of shared templates. This will automatically be populated
@@ -446,6 +457,19 @@ Object.defineProperty(Ember, 'TEMPLATES', {
   configurable: false,
   enumerable: false,
 });
+
+/**
+  Global for safe usage of methods coming from module '@ember/template'.
+
+  @property Template
+  @for Ember
+  @type Object
+  @private
+ */
+Ember._Template = {
+  htmlSafe,
+  isHTMLSafe,
+};
 
 /**
   The semantic version

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -19,7 +19,7 @@ moduleFor(
     }
 
     ['@test Ember.String.isHTMLSafe exports correctly'](assert) {
-      confirmExport(Ember, assert, 'String.isHTMLSafe', 'ember-glimmer', 'isHTMLSafe');
+      confirmExport(Ember, assert, 'String.isHTMLSafe', 'ember-glimmer', 'deprecatedIsHTMLSafe');
     }
   }
 );
@@ -172,7 +172,9 @@ let allExports = [
   ['Handlebars.template', 'ember-glimmer', 'template'],
   ['HTMLBars.template', 'ember-glimmer', 'template'],
   ['Handlebars.Utils.escapeExpression', 'ember-glimmer', 'escapeExpression'],
-  ['String.htmlSafe', 'ember-glimmer', 'htmlSafe'],
+  ['String.htmlSafe', 'ember-glimmer', 'deprecatedHTMLSafe'],
+  ['_Template.htmlSafe', 'ember-glimmer', 'htmlSafe'],
+  ['_Template.isHTMLSafe', 'ember-glimmer', 'isHTMLSafe'],
   ['_setComponentManager', 'ember-glimmer', 'componentManager'],
 
   // ember-runtime

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -1,10 +1,4 @@
-import {
-  Controller,
-  RSVP,
-  Object as EmberObject,
-  A as emberA,
-  String as StringUtils,
-} from 'ember-runtime';
+import { Controller, RSVP, Object as EmberObject, A as emberA, StringUtils } from 'ember-runtime';
 import { run, get, computed, peekMeta } from 'ember-metal';
 import { Route } from 'ember-routing';
 

--- a/packages/ember/tests/routing/router_service_test/urlFor_test.js
+++ b/packages/ember/tests/routing/router_service_test/urlFor_test.js
@@ -1,4 +1,4 @@
-import { Controller, String } from 'ember-runtime';
+import { Controller, StringUtils } from 'ember-runtime';
 import { Route } from 'ember-routing';
 import { get } from 'ember-metal';
 import { RouterTestCase, moduleFor } from 'internal-test-helpers';
@@ -6,7 +6,7 @@ import { RouterTestCase, moduleFor } from 'internal-test-helpers';
 import { EMBER_ROUTING_ROUTER_SERVICE } from 'ember/features';
 
 function setupController(app, name) {
-  let controllerName = `${String.capitalize(name)}Controller`;
+  let controllerName = `${StringUtils.capitalize(name)}Controller`;
 
   Object.defineProperty(app, controllerName, {
     get() {


### PR DESCRIPTION
This PR deprecates the use of String prototype extension and
Ember.String namespace.

Methods coming from ember-runtime
---

A new `StringUtils` object is added, to be used internally by Ember
instead of using the same object being exposed as `Ember.String`. This
simplifies testing and the changes required in the rest of the code.
Also, dropping the deprecated code will be much simpler.

Methods coming from ember-glimmer
---

Deprecated versions are being added and reexported as the same global
the non-deprecated versions were. Besides, the non-deprecated version is
being exported under the new global `Ember.Template`.

The `Ember.Template` is just a placeholder until the final global is chosen.