### PR TITLE
Fix script that publishes to Rubygems

### DIFF
--- a/bin/publish_npm_and_bower
+++ b/bin/publish_npm_and_bower
@@ -88,7 +88,7 @@ if [[ "$TRAVIS_TAG" =~ ^v[0-9.]+ ]]; then
   chmod 0600 ~/.gem/credentials
 
   gem build ember-source.gemspec
-  gem push `echo *.gem`.strip
+  gem push `echo *.gem`
 fi
 
 #### BOWER PUBLISHING


### PR DESCRIPTION
Apparently a brilliant young man tacked a `.strip` to the end of a bash command in hopes that it would strip whitespace.
Of course, what ended up happening was that a gem with `.strip` tacked on to the end of the name would not be found in the filesystem by the publish command.