### PR TITLE
Consider defaulting RouterDSL parent name to 'application'

### DIFF
--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -9,7 +9,7 @@ import { assert, deprecate } from 'ember-debug';
 let uuid = 0;
 
 class DSL {
-  constructor(name, options) {
+  constructor(name = 'application', options) {
     this.parent = name;
     this.enableLoadingSubstates = options && options.enableLoadingSubstates;
     this.matches = [];


### PR DESCRIPTION
Default `name` to _"application"_ for the RouterDSL constructor in dsl.js
https://github.com/emberjs/ember.js/blob/6d9a9735eeb04182589ff9bd98569288667cb8d8/packages/ember-routing/lib/system/dsl.js#L12

The reasoning behind this is that it is possible for a user to pass in _null_ to the constructor. Because of that, the generated route names from the `getFullName` function might be, for example: _"null.index"_ instead of _"index"_
https://github.com/emberjs/ember.js/blob/6d9a9735eeb04182589ff9bd98569288667cb8d8/packages/ember-routing/lib/system/dsl.js#L178

If the default name was _"application"_, then `getFullName` will return simply _"index"_ without the _null_ prefix (this happens because of the in the `canNest` function.)

This issue was introduced in v2.15.x - previously, supplying _null_ would return _"index"_

For more information please review https://github.com/nathanhammond/ember-route-alias/pull/22#discussion_r145839398