### PR TITLE
[BUGFIX beta] Fix dot-component invocation predicate

### DIFF
--- a/packages/ember-template-compiler/lib/plugins/transform-dot-component-invocation.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-dot-component-invocation.js
@@ -74,7 +74,7 @@ export default function transformDotComponentInvocation(env) {
 }
 
 function isMultipartPath(path)  {
-  return path.parts.length > 1;
+  return path.parts && path.parts.length > 1;
 }
 
 function isInlineInvocation(path, params, hash) {

--- a/packages/ember-template-compiler/tests/plugins/transform-dot-component-invocation-test.js
+++ b/packages/ember-template-compiler/tests/plugins/transform-dot-component-invocation-test.js
@@ -14,7 +14,9 @@ QUnit.test('Does not throw a compiler error for path components', function(asser
     '{{#c.modal}}Woot{{/c.modal}}',
     '{{#my-component as |c|}}{{c.a name="Chad"}}{{/my-component}}',
     '{{#my-component as |c|}}{{c.a "Chad"}}{{/my-component}}',
-    '{{#my-component as |c|}}{{#c.a}}{{/c.a}}{{/my-component}}'
+    '{{#my-component as |c|}}{{#c.a}}{{/c.a}}{{/my-component}}',
+    '<input disabled={{true}}>', // GH#15740
+    '<td colspan={{3}}></td>' // GH#15217
   ].forEach((layout, i) => {
     compile(layout, { moduleName: `example-${i}` });
   });


### PR DESCRIPTION
A BooleanLiteral has no parts, so the following template was raising
an issue: `<input disabled={{true}} />`.

Also happens with integers and other literals.

Closes #15217
Closes #15740 