### PR TITLE
remove `bind` fallback

### DIFF
--- a/packages/ember-console/lib/index.js
+++ b/packages/ember-console/lib/index.js
@@ -16,13 +16,7 @@ function consoleMethod(name) {
     return;
   }
 
-  if (typeof method.bind === 'function') {
-    return method.bind(consoleObj);
-  }
-
-  return function() {
-    method.apply(consoleObj, arguments);
-  };
+  return method.bind(consoleObj);
 }
 
 function assertPolyfill(test, message) {


### PR DESCRIPTION
since `function.bind` supported from IE9