### PR TITLE
[DOC release] Remove Extra Space in Computed Macros

### DIFF
--- a/packages/ember-runtime/lib/computed/computed_macros.js
+++ b/packages/ember-runtime/lib/computed/computed_macros.js
@@ -549,7 +549,7 @@ export const or = generateComputedWithPredicate('or', value => !value);
 
   let teddy = User.create({
     firstName: 'Teddy',
-    lastName:  'Zeenny'
+    lastName: 'Zeenny'
   });
 
   teddy.get('nickName');              // 'Teddy'


### PR DESCRIPTION
Removes an extra space in computed macros documentation to fix misalignment. [Documentation](https://github.com/emberjs/ember.js/blob/v2.15.0/packages/ember-runtime/lib/computed/computed_macros.js#L550) was vertically aligned in the code, but misaligned when viewing [the API](https://emberjs.com/api/ember/2.15/namespaces/Ember.computed/methods/notEmpty?anchor=oneWay).

<img width="720" alt="screenshot 2017-10-25 15 09 17" src="https://user-images.githubusercontent.com/22661110/32018013-7f47d89a-b996-11e7-94c4-2020494ff851.png">