### PR TITLE
[WIP]: Component Capabilities

### DIFF
--- a/packages/ember-glimmer/lib/component-managers/abstract.ts
+++ b/packages/ember-glimmer/lib/component-managers/abstract.ts
@@ -18,6 +18,7 @@ import {
 } from '@glimmer/util';
 import { DEBUG } from 'ember-env-flags';
 import DebugStack from '../utils/debug-stack';
+import { Component } from '../utils/curly-component-state-bucket';
 
 // implements the ComponentManager interface as defined in glimmer:
 // tslint:disable-next-line:max-line-length
@@ -53,7 +54,7 @@ export default abstract class AbstractManager<T> implements ComponentManager<T> 
     env: Environment): CompiledDynamicTemplate<ProgramSymbolTable>;
   abstract getSelf(component: T): VersionedPathReference<Opaque>;
   abstract templateFor(
-     component: T,
+     component: Component,
      env: Environment): CompiledDynamicTemplate<ProgramSymbolTable>;
 
   didCreateElement(_component: T, _element: Element, _operations: ElementOperations): void {

--- a/packages/ember-glimmer/lib/component-managers/abstract.ts
+++ b/packages/ember-glimmer/lib/component-managers/abstract.ts
@@ -14,7 +14,7 @@ import { IArguments } from '@glimmer/runtime/dist/types/lib/vm/arguments';
 import {
   Destroyable,
   Opaque,
-  Option 
+  Option
 } from '@glimmer/util';
 import { DEBUG } from 'ember-env-flags';
 import DebugStack from '../utils/debug-stack';
@@ -52,6 +52,9 @@ export default abstract class AbstractManager<T> implements ComponentManager<T> 
     component: T,
     env: Environment): CompiledDynamicTemplate<ProgramSymbolTable>;
   abstract getSelf(component: T): VersionedPathReference<Opaque>;
+  abstract templateFor(
+     component: T,
+     env: Environment): CompiledDynamicTemplate<ProgramSymbolTable>;
 
   didCreateElement(_component: T, _element: Element, _operations: ElementOperations): void {
     // noop

--- a/packages/ember-glimmer/lib/component-managers/capabilities.ts
+++ b/packages/ember-glimmer/lib/component-managers/capabilities.ts
@@ -1,0 +1,40 @@
+import { assert } from 'ember-debug';
+import { assign } from 'ember-utils';
+
+// because we're not yet compatible with latest Glimmer
+// we lack typings in Ember.js.
+// steal capabilities interface from http://bit.ly/2gMdhv5 for now
+export interface ComponentCapabilities {
+  dynamicLayout: boolean;
+  dynamicTag: boolean;
+  prepareArgs: boolean;
+  createArgs: boolean;
+  attributeHook: boolean;
+  elementHook: boolean;
+}
+
+// default capabilities values stolen from http://bit.ly/2y9gCvc
+export const DEFAULT_CAPABILITIES: ComponentCapabilities = {
+  dynamicLayout: true,
+  dynamicTag: true,
+  prepareArgs: true,
+  createArgs: true,
+  attributeHook: true,
+  elementHook: true
+};
+
+const SPECIFIER_HASH = {
+  '2.16': DEFAULT_CAPABILITIES
+};
+
+function getCapabilities(specifier: string): ComponentCapabilities {
+  assert(`No capabilities mask is defined for "${specifier}" specifier`, SPECIFIER_HASH[specifier] !== undefined);
+
+  return DEFAULT_CAPABILITIES;
+}
+
+export default function capabilities(specifier: string, features: Object): ComponentCapabilities {
+  assert('You must pass a specifier, e.g. `2.16`', specifier !== undefined);
+
+  return assign({}, getCapabilities(specifier), features);
+}

--- a/packages/ember-glimmer/lib/component-managers/curly.ts
+++ b/packages/ember-glimmer/lib/component-managers/curly.ts
@@ -104,7 +104,7 @@ function ariaRole(vm: VM) {
   return vm.getSelf().get('ariaRole');
 }
 
-class CurlyComponentLayoutCompiler {
+export class CurlyComponentLayoutCompiler {
   static id: string;
   public template: WrappedTemplateFactory;
 

--- a/packages/ember-glimmer/lib/component-managers/custom.ts
+++ b/packages/ember-glimmer/lib/component-managers/custom.ts
@@ -1,14 +1,38 @@
+import { get } from 'ember-metal';
+import { OWNER } from 'ember-utils';
+import { DEBUG } from 'ember-env-flags';
 import { assert } from 'ember-debug';
 import AbstractManager from './abstract';
 import {
   CurlyComponentLayoutCompiler
 } from './curly';
-import { ComponentManager } from '@glimmer/runtime';
-import ComponentStateBucket from '../utils/curly-component-state-bucket';
+import {
+  Arguments,
+  CompiledDynamicProgram,
+  ComponentDefinition,
+  ComponentManager,
+  DynamicScope,
+  ElementOperations
+} from '@glimmer/runtime';
+import ComponentStateBucket, { Component } from '../utils/curly-component-state-bucket';
+import { ComponentCapabilities } from './capabilities';
+import { Destroyable, Opaque } from '@glimmer/util';
+import { Option } from '@glimmer/interfaces';
+import Environment from '../environment';
+import { VersionedPathReference } from '@glimmer/reference';
+import { privatize as P } from 'container';
+import { OwnedTemplate } from '../template';
+
+const DEFAULT_LAYOUT = P`template:components/-default`;
+
+interface CustomComponentDefinition extends ComponentDefinition<ComponentStateBucket> {
+  template: OwnedTemplate;
+  args: Arguments | undefined;
+}
 
 /**
   Wrapper class for custom component managers as per
-  Custom Components RFC.
+  Custom Components RFC, http://bit.ly/2AlScAb.
 
   When defining a custom component manager, the following
   methods are required:
@@ -17,15 +41,17 @@ import ComponentStateBucket from '../utils/curly-component-state-bucket';
   - `getSelf`
   - `update`
 
-  `layoutFor` method is not required to be implemented and
-  mirrors the behaviour of curly components.
+  `layoutFor`/`templateFor` mirror the behaviour of curly components.
+  `didCreate`, `didUpdate`, `getDestructor` are optional methods which
+  could be overriden but by default are no-ops.
+
   @private
   @class CustomManager
 */
 export default class CustomManager extends AbstractManager<ComponentStateBucket> {
   private _manager: ComponentManager<ComponentStateBucket>;
 
-  constructor(manager) {
+  constructor(manager: ComponentManager<ComponentStateBucket>) {
     super();
 
     this._manager = manager;
@@ -35,48 +61,77 @@ export default class CustomManager extends AbstractManager<ComponentStateBucket>
     assert('You must implement `update` method.', this._manager.update !== undefined);
   }
 
-  create(environment, definition, args, dynamicScope, callerSelfRef, hasBlock) {
+  create(environment: Environment, definition: ComponentDefinition<ComponentStateBucket>, args: Arguments, dynamicScope: DynamicScope, callerSelfRef: VersionedPathReference<Opaque>, hasBlock: boolean) {
+    if (DEBUG) {
+      this._pushToDebugStack(`component:${definition.name}`, environment);
+    }
+
     return this._manager.create(environment, definition, args, dynamicScope, callerSelfRef, hasBlock);
   }
 
-  getSelf({ component }) {
-    return this._manager.getSelf(component);
+  getCapabilities(state: ComponentStateBucket): ComponentCapabilities {
+    return state.capabilities;
   }
 
-  update(bucket, dynamicScope) {
-    return this._manager.update(bucket, dynamicScope);
+  getSelf(state: ComponentStateBucket) {
+    return this._manager.getSelf(state);
   }
 
-  layoutFor(definition, bucket, env) {
+  update(state: ComponentStateBucket, dynamicScope: DynamicScope): void {
+    let { component, environment } = state;
+
+    if (DEBUG) {
+       this._pushToDebugStack(component._debugContainerKey, environment);
+    }
+
+    this._manager.update(state, dynamicScope);
+  }
+
+  layoutFor(definition: CustomComponentDefinition, state: ComponentStateBucket, env: Environment): CompiledDynamicProgram {
     if (this._manager.layoutFor) {
-      return this._manager.layoutFor(definition, bucket, env);
+      return this._manager.layoutFor(definition, state, env);
     }
 
     let template = definition.template;
     if (!template) {
-      let { component } = bucket;
-      template = this.templateFor(component, env);
+      template = this.templateFor(state.component, env);
     }
     return env.getCompiledBlock(CurlyComponentLayoutCompiler, template);
   }
 
-  didCreate(component) {
+  templateFor(component: Component, env: Environment): OwnedTemplate {
+    let Template = get(component, 'layout');
+    let owner = component[OWNER];
+    if (Template) {
+      return env.getTemplate(Template, owner);
+    }
+    let layoutName = get(component, 'layoutName');
+    if (layoutName) {
+      let template = owner.lookup('template:' + layoutName);
+      if (template) {
+        return template;
+      }
+    }
+    return owner.lookup(DEFAULT_LAYOUT);
+  }
+
+  didCreate(state: ComponentStateBucket): void {
     if (this._manager.didCreate !== undefined) {
-      this._manager.didCreate(component);
+      this._manager.didCreate(state);
     } else {
-      super.didCreate(component);
+      super.didCreate(state);
     }
   }
 
-  didCreateElement(component, element, operations) {
+  didCreateElement(state: ComponentStateBucket, element: Element, operations: ElementOperations): void {
     if (this._manager.didCreateElement !== undefined) {
-      this._manager.didCreateElement(component, element, operations);
+      this._manager.didCreateElement(state, element, operations);
     } else {
-      super.didCreateElement(component, element, operations);
+      super.didCreateElement(state, element, operations);
     }
   }
 
-  didUpdate(state) {
+  didUpdate(state: ComponentStateBucket): void {
     if (this._manager.didUpdate !== undefined) {
       this._manager.didUpdate(state);
     } else {
@@ -84,11 +139,19 @@ export default class CustomManager extends AbstractManager<ComponentStateBucket>
     }
   }
 
-  getDestructor(state) {
-    if (this._manager.getDestructor !== undefined) {
-      this._manager.getDestructor(state);
-    } else {
-      return state;
+  didUpdateLayout(state: ComponentStateBucket): void {
+    state.finalize();
+
+    if (DEBUG) {
+      this.debugStack.pop();
     }
+  }
+
+  getDestructor(state: ComponentStateBucket): Option<Destroyable> {
+    if (this._manager.getDestructor !== undefined) {
+      return this._manager.getDestructor(state);
+    }
+
+    return state;
   }
 }

--- a/packages/ember-glimmer/lib/component-managers/custom.ts
+++ b/packages/ember-glimmer/lib/component-managers/custom.ts
@@ -1,0 +1,94 @@
+import { assert } from 'ember-debug';
+import AbstractManager from './abstract';
+import {
+  CurlyComponentLayoutCompiler
+} from './curly';
+import { ComponentManager } from '@glimmer/runtime';
+import ComponentStateBucket from '../utils/curly-component-state-bucket';
+
+/**
+  Wrapper class for custom component managers as per
+  Custom Components RFC.
+
+  When defining a custom component manager, the following
+  methods are required:
+
+  - `create`
+  - `getSelf`
+  - `update`
+
+  `layoutFor` method is not required to be implemented and
+  mirrors the behaviour of curly components.
+  @private
+  @class CustomManager
+*/
+export default class CustomManager extends AbstractManager<ComponentStateBucket> {
+  private _manager: ComponentManager<ComponentStateBucket>;
+
+  constructor(manager) {
+    super();
+
+    this._manager = manager;
+
+    assert('You must implement `create` method.', this._manager.create !== undefined);
+    assert('You must implement `getSelf` method.', this._manager.getSelf !== undefined);
+    assert('You must implement `update` method.', this._manager.update !== undefined);
+  }
+
+  create(environment, definition, args, dynamicScope, callerSelfRef, hasBlock) {
+    return this._manager.create(environment, definition, args, dynamicScope, callerSelfRef, hasBlock);
+  }
+
+  getSelf({ component }) {
+    return this._manager.getSelf(component);
+  }
+
+  update(bucket, dynamicScope) {
+    return this._manager.update(bucket, dynamicScope);
+  }
+
+  layoutFor(definition, bucket, env) {
+    if (this._manager.layoutFor) {
+      return this._manager.layoutFor(definition, bucket, env);
+    }
+
+    let template = definition.template;
+    if (!template) {
+      let { component } = bucket;
+      template = this.templateFor(component, env);
+    }
+    return env.getCompiledBlock(CurlyComponentLayoutCompiler, template);
+  }
+
+  didCreate(component) {
+    if (this._manager.didCreate !== undefined) {
+      this._manager.didCreate(component);
+    } else {
+      super.didCreate(component);
+    }
+  }
+
+  didCreateElement(component, element, operations) {
+    if (this._manager.didCreateElement !== undefined) {
+      this._manager.didCreateElement(component, element, operations);
+    } else {
+      super.didCreateElement(component, element, operations);
+    }
+  }
+
+  didUpdate(state) {
+    if (this._manager.didUpdate !== undefined) {
+      this._manager.didUpdate(state);
+    } else {
+      super.didUpdate(state);
+    }
+  }
+
+  getDestructor(state) {
+    if (this._manager.getDestructor !== undefined) {
+      this._manager.getDestructor(state);
+    } else {
+      return state;
+    }
+  }
+}

--- a/packages/ember-glimmer/lib/environment.ts
+++ b/packages/ember-glimmer/lib/environment.ts
@@ -44,6 +44,7 @@ import {
   SimpleHelperReference,
   UpdatableReference,
 } from './utils/references';
+import CustomManager from './component-managers/custom';
 
 import { default as classHelper } from './helpers/-class';
 import { default as htmlSafeHelper } from './helpers/-html-safe';
@@ -133,7 +134,7 @@ export default class Environment extends GlimmerEnvironment {
           let managerId = layout && layout.meta.managerId;
 
           if (managerId) {
-            customManager = owner.factoryFor<any>(`component-manager:${managerId}`).class;
+            customManager = new CustomManager(owner.factoryFor<any>(`component-manager:${managerId}`).class);
           }
         }
         return new CurlyComponentDefinition(name, componentFactory, layout, undefined, customManager);

--- a/packages/ember-glimmer/lib/utils/curly-component-state-bucket.ts
+++ b/packages/ember-glimmer/lib/utils/curly-component-state-bucket.ts
@@ -2,6 +2,7 @@ import { Revision, VersionedReference } from '@glimmer/reference';
 import { CapturedNamedArguments } from '@glimmer/runtime';
 import { Opaque } from '@glimmer/util/dist/types';
 import Environment from '../environment';
+import { ComponentCapabilities } from '../component-managers/capabilities';
 
 export interface Component {
   _debugContainerKey: string;
@@ -36,6 +37,7 @@ function NOOP() {}
 export default class ComponentStateBucket {
   public classRef: VersionedReference<Opaque> | null = null;
   public argsRevision: Revision;
+  public capabilities: ComponentCapabilities;
 
   constructor(public environment: Environment, public component: Component, public args: CapturedNamedArguments, public finalizer: Finalizer) {
     this.classRef = null;

--- a/packages/ember-glimmer/tests/unit/component-managers/capabilities-test.js
+++ b/packages/ember-glimmer/tests/unit/component-managers/capabilities-test.js
@@ -1,0 +1,39 @@
+import { default as capabilities, DEFAULT_CAPABILITIES } from 'ember-glimmer/component-managers/capabilities';
+import { moduleFor, TestCase } from 'ember-glimmer/tests/utils/test-case';
+import { GLIMMER_CUSTOM_COMPONENT_MANAGER } from 'ember/features';
+
+if (GLIMMER_CUSTOM_COMPONENT_MANAGER) {
+  moduleFor('Component Definition Capabilities', class extends TestCase {
+    ['@test returns default capabilities if no features were passed in'](assert) {
+      assert.deepEqual(capabilities('2.16'), DEFAULT_CAPABILITIES, 'default capabilities were returned');
+    }
+
+    ['@test asserts if specifier is not passed in'](assert) {
+      expectAssertion(() => {
+        capabilities();
+      }, /You must pass a specifier, e.g. `2.16`/);
+    }
+
+    ['@test asserts if capabilities mask is not defined for a specifier'](assert) {
+      expectAssertion(() => {
+        capabilities('2.14');
+      }, /No capabilities mask is defined for "2.14" specifier/);
+    }
+
+    ['@test returns modified capabilities if features were passed in'](assert) {
+      let modifiedCapabilities = {
+        dynamicLayout: true,
+        dynamicTag: true,
+        prepareArgs: true,
+        createArgs: true,
+        attributeHook: true,
+        elementHook: true
+      };
+
+      assert.deepEqual(capabilities('2.16', {
+        attributeHook: true,
+        elementHook: true
+      }), modifiedCapabilities, 'default capabilities were returned');
+    }
+  });
+}

--- a/packages/ember-glimmer/tests/unit/component-managers/custom-test.js
+++ b/packages/ember-glimmer/tests/unit/component-managers/custom-test.js
@@ -1,91 +1,112 @@
 import CustomComponentManager from 'ember-glimmer/component-managers/custom';
 import { moduleFor, TestCase } from 'ember-glimmer/tests/utils/test-case';
+import { GLIMMER_CUSTOM_COMPONENT_MANAGER } from 'ember/features';
 
-moduleFor('Custom Component Manager', class extends TestCase {
-  ['@test throws an exception if custom component manager does not define `create` method'](assert) {
-    assert.throws(() => {
-      new CustomComponentManager({
+if (GLIMMER_CUSTOM_COMPONENT_MANAGER) {
+  moduleFor('Custom Component Manager', class extends TestCase {
+    ['@test `getCapabilities` returns component definition capabilities'](assert) {
+      let componentManager = new CustomComponentManager({
+        create() {},
         getSelf() {},
         update() {}
       });
-    }, /You must implement `create` method./);
-  }
+      let componentDefintion = {
+        capabilities: {
+          dynamicLayout: true,
+          dynamicTag: true
+        }
+      };
+      assert.deepEqual(componentManager.getCapabilities(componentDefintion), {
+        dynamicLayout: true,
+        dynamicTag: true
+      }, 'correct capabilities were returned');
+    }
 
-  ['@test throws an exception if custom component manager does not define `getSelf` method'](assert) {
-    assert.throws(() => {
-      new CustomComponentManager({
+    ['@test throws an exception if custom component manager does not define `create` method'](assert) {
+      assert.throws(() => {
+        new CustomComponentManager({
+          getSelf() {},
+          update() {}
+        });
+      }, /You must implement `create` method./);
+    }
+
+    ['@test throws an exception if custom component manager does not define `getSelf` method'](assert) {
+      assert.throws(() => {
+        new CustomComponentManager({
+          create() {},
+          update() {}
+        });
+      }, /You must implement `getSelf` method./);
+    }
+
+    ['@test throws an exception if custom component manager does not define `update` method'](assert) {
+      assert.throws(() => {
+        new CustomComponentManager({
+          create() {},
+          getSelf() {}
+        });
+      }, /You must implement `update` method./);
+    }
+
+    ['@test proxies `didCreateElement` method if defined'](assert) {
+      let didCreateElementCalled = false;
+      let componentManager = new CustomComponentManager({
         create() {},
-        update() {}
+        getSelf() {},
+        update() {},
+        didCreateElement() {
+          didCreateElementCalled = true;
+        }
       });
-    }, /You must implement `getSelf` method./);
-  }
 
-  ['@test throws an exception if custom component manager does not define `update` method'](assert) {
-    assert.throws(() => {
-      new CustomComponentManager({
+      componentManager.didCreateElement();
+      assert.ok(didCreateElementCalled, '`didCreateElement` was successfully called');
+    }
+
+    ['@test proxies `didCreate` method if defined'](assert) {
+      let didCreateCalled = false;
+      let componentManager = new CustomComponentManager({
         create() {},
-        getSelf() {}
+        getSelf() {},
+        update() {},
+        didCreate() {
+          didCreateCalled = true;
+        }
       });
-    }, /You must implement `update` method./);
-  }
 
-  ['@test proxies `didCreateElement` method if defined'](assert) {
-    let didCreateElementCalled = false;
-    let componentManager = new CustomComponentManager({
-      create() {},
-      getSelf() {},
-      update() {},
-      didCreateElement() {
-        didCreateElementCalled = true;
-      }
-    });
+      componentManager.didCreate();
+      assert.ok(didCreateCalled, '`didCreate` was successfully called');
+    }
 
-    componentManager.didCreateElement();
-    assert.ok(didCreateElementCalled, '`didCreateElement` was successfully called');
-  }
+    ['@test proxies `didUpdate` method if defined'](assert) {
+      let didUpdateCalled = false;
+      let componentManager = new CustomComponentManager({
+        create() {},
+        getSelf() {},
+        update() {},
+        didUpdate() {
+          didUpdateCalled = true;
+        }
+      });
 
-  ['@test proxies `didCreate` method if defined'](assert) {
-    let didCreateCalled = false;
-    let componentManager = new CustomComponentManager({
-      create() {},
-      getSelf() {},
-      update() {},
-      didCreate() {
-        didCreateCalled = true;
-      }
-    });
+      componentManager.didUpdate();
+      assert.ok(didUpdateCalled, '`didUpdate` was successfully called');
+    }
 
-    componentManager.didCreate();
-    assert.ok(didCreateCalled, '`didCreate` was successfully called');
-  }
+    ['@test proxies `getDestructor` method if defined'](assert) {
+      let getDestructorCalled = false;
+      let componentManager = new CustomComponentManager({
+        create() {},
+        getSelf() {},
+        update() {},
+        getDestructor() {
+          getDestructorCalled = true;
+        }
+      });
 
-  ['@test proxies `didUpdate` method if defined'](assert) {
-    let didUpdateCalled = false;
-    let componentManager = new CustomComponentManager({
-      create() {},
-      getSelf() {},
-      update() {},
-      didUpdate() {
-        didUpdateCalled = true;
-      }
-    });
-
-    componentManager.didUpdate();
-    assert.ok(didUpdateCalled, '`didUpdate` was successfully called');
-  }
-
-  ['@test proxies `getDestructor` method if defined'](assert) {
-    let getDestructorCalled = false;
-    let componentManager = new CustomComponentManager({
-      create() {},
-      getSelf() {},
-      update() {},
-      getDestructor() {
-        getDestructorCalled = true;
-      }
-    });
-
-    componentManager.getDestructor();
-    assert.ok(getDestructorCalled, '`getDestructor` was successfully called');
-  }
-});
+      componentManager.getDestructor();
+      assert.ok(getDestructorCalled, '`getDestructor` was successfully called');
+    }
+  });
+}

--- a/packages/ember-glimmer/tests/unit/component-managers/custom-test.js
+++ b/packages/ember-glimmer/tests/unit/component-managers/custom-test.js
@@ -1,0 +1,91 @@
+import CustomComponentManager from 'ember-glimmer/component-managers/custom';
+import { moduleFor, TestCase } from 'ember-glimmer/tests/utils/test-case';
+
+moduleFor('Custom Component Manager', class extends TestCase {
+  ['@test throws an exception if custom component manager does not define `create` method'](assert) {
+    assert.throws(() => {
+      new CustomComponentManager({
+        getSelf() {},
+        update() {}
+      });
+    }, /You must implement `create` method./);
+  }
+
+  ['@test throws an exception if custom component manager does not define `getSelf` method'](assert) {
+    assert.throws(() => {
+      new CustomComponentManager({
+        create() {},
+        update() {}
+      });
+    }, /You must implement `getSelf` method./);
+  }
+
+  ['@test throws an exception if custom component manager does not define `update` method'](assert) {
+    assert.throws(() => {
+      new CustomComponentManager({
+        create() {},
+        getSelf() {}
+      });
+    }, /You must implement `update` method./);
+  }
+
+  ['@test proxies `didCreateElement` method if defined'](assert) {
+    let didCreateElementCalled = false;
+    let componentManager = new CustomComponentManager({
+      create() {},
+      getSelf() {},
+      update() {},
+      didCreateElement() {
+        didCreateElementCalled = true;
+      }
+    });
+
+    componentManager.didCreateElement();
+    assert.ok(didCreateElementCalled, '`didCreateElement` was successfully called');
+  }
+
+  ['@test proxies `didCreate` method if defined'](assert) {
+    let didCreateCalled = false;
+    let componentManager = new CustomComponentManager({
+      create() {},
+      getSelf() {},
+      update() {},
+      didCreate() {
+        didCreateCalled = true;
+      }
+    });
+
+    componentManager.didCreate();
+    assert.ok(didCreateCalled, '`didCreate` was successfully called');
+  }
+
+  ['@test proxies `didUpdate` method if defined'](assert) {
+    let didUpdateCalled = false;
+    let componentManager = new CustomComponentManager({
+      create() {},
+      getSelf() {},
+      update() {},
+      didUpdate() {
+        didUpdateCalled = true;
+      }
+    });
+
+    componentManager.didUpdate();
+    assert.ok(didUpdateCalled, '`didUpdate` was successfully called');
+  }
+
+  ['@test proxies `getDestructor` method if defined'](assert) {
+    let getDestructorCalled = false;
+    let componentManager = new CustomComponentManager({
+      create() {},
+      getSelf() {},
+      update() {},
+      getDestructor() {
+        getDestructorCalled = true;
+      }
+    });
+
+    componentManager.getDestructor();
+    assert.ok(getDestructorCalled, '`getDestructor` was successfully called');
+  }
+});


### PR DESCRIPTION
Implementation of `capabilities` feature described in Custom Components
RFC.

This change depends on three things:

+ https://github.com/emberjs/ember.js/pull/15628
+ feature flag `GLIMMER_CUSTOM_COMPONENT_MANAGER`
+ version of `glimmer-vm` that has `capabilities` API implemented
(0.28.0+)

Relevant links:

+ https://github.com/emberjs/rfcs/blob/custom-components/text/0000-custom-components.md