### PR TITLE
[BUGFIX release] Refactor package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "babel-plugin-transform-proto-to-assign": "^6.23.0",
     "babel-template": "^6.24.1",
     "backburner.js": "^1.2.2",
-    "broccoli-babel-transpiler": "next",
+    "broccoli-babel-transpiler": "^6.1.1",
     "broccoli-concat": "^3.2.2",
     "broccoli-debug": "^0.6.3",
     "broccoli-file-creator": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -28,22 +28,19 @@
   "scripts": {
     "build": "ember build --environment production",
     "docs": "ember ember-cli-yuidoc",
+    "link:glimmer": "node bin/yarn-link-glimmer.js",
     "release": "node scripts/release.js",
     "sauce:launch": "ember sauce:launch",
     "start": "ember serve",
     "pretest": "ember build",
+    "prepare": "ember build -prod",
     "test": "node bin/run-tests.js",
     "test:blueprints": "node node-tests/nodetest-runner.js",
     "test:node": "node bin/run-node-tests.js",
     "test:sauce": "node bin/run-sauce-tests.js",
-    "test:testem": "testem -f testem.dist.json",
-    "link:glimmer": "node bin/yarn-link-glimmer.js"
+    "test:testem": "testem -f testem.dist.json"
   },
   "dependencies": {
-    "@glimmer/compiler": "^0.25.4",
-    "@glimmer/node": "^0.25.4",
-    "@glimmer/reference": "^0.25.4",
-    "@glimmer/runtime": "^0.25.4",
     "broccoli-funnel": "^1.2.0",
     "broccoli-merge-trees": "^2.0.0",
     "ember-cli-get-component-path-option": "^1.0.0",
@@ -58,13 +55,13 @@
     "fs-extra": "^4.0.1",
     "inflection": "^1.12.0",
     "jquery": "^3.2.1",
-    "resolve": "^1.3.3",
-    "rsvp": "^4.7.0",
-    "simple-dom": "^0.3.0",
-    "simple-html-tokenizer": "^0.4.1",
-    "tslint": "^5.8.0"
+    "resolve": "^1.3.3"
   },
   "devDependencies": {
+    "@glimmer/compiler": "^0.25.4",
+    "@glimmer/node": "^0.25.4",
+    "@glimmer/reference": "^0.25.4",
+    "@glimmer/runtime": "^0.25.4",
     "aws-sdk": "^2.46.0",
     "babel-plugin-check-es2015-constants": "^6.22.0",
     "babel-plugin-debug-macros": "^0.1.10",
@@ -120,10 +117,13 @@
     "qunitjs": "^1.22.0",
     "route-recognizer": "^0.3.3",
     "router_js": "^2.0.0-beta.1",
+    "rsvp": "^4.7.0",
     "semver": "^5.3.0",
     "serve-static": "^1.12.2",
     "simple-dom": "^0.3.0",
-    "testem": "1.15.0"
+    "simple-html-tokenizer": "^0.4.1",
+    "testem": "1.15.0",
+    "tslint": "^5.8.0"
   },
   "ember-addon": {
     "after": "ember-cli-legacy-blueprints"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1025,9 +1025,9 @@ broccoli-babel-transpiler@^5.4.5, broccoli-babel-transpiler@^5.6.2:
     rsvp "^3.5.0"
     workerpool "^2.2.1"
 
-broccoli-babel-transpiler@next:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.1.tgz#938f470e1ddb47047a77ef5e38f34c21de0e85a8"
+broccoli-babel-transpiler@^6.1.1:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.2.tgz#26019c045b5ea3e44cfef62821302f9bd483cabd"
   dependencies:
     babel-core "^6.14.0"
     broccoli-funnel "^1.0.0"


### PR DESCRIPTION
* Move build time deps to `devDependencies`.
* Sort `package.json` scripts.
* Add `prepare` script.

The effective result of this change is to allow users of `npm@5` and `yarn` to reference `"ember-source": "git:emberjs/ember.js",` in their `package.json`'s and have things "just work".

See https://docs.npmjs.com/cli/install (the `npm install <git remote url>` section) for the exact details.