### PR TITLE
[spike] extract some shared reference types

### DIFF
--- a/packages/ember-glimmer/lib/helpers/if-unless.ts
+++ b/packages/ember-glimmer/lib/helpers/if-unless.ts
@@ -3,24 +3,22 @@
 */
 
 import {
-  combine,
-  CONSTANT_TAG,
   isConst,
-  TagWrapper,
-  UpdatableTag,
 } from '@glimmer/reference';
 import { assert } from 'ember-debug';
 import {
-  CachedReference,
   ConditionalReference,
+  PropertyReference
 } from '../utils/references';
 
-class ConditionalHelperReference extends CachedReference {
-  public branchTag: TagWrapper<UpdatableTag>;
-  public tag: any;
-  public cond: any;
-  public truthy: any;
-  public falsy: any;
+import {
+  ConditionalHelperReference as GlimmerConditionalHelperReference
+} from '../utils/glimmer-references';
+
+class ConditionalHelperReference extends GlimmerConditionalHelperReference<any> {
+  get(key?): any {
+    return PropertyReference.create(this, key);
+  }
 
   static create(_condRef, truthyRef, falsyRef) {
     let condRef = ConditionalReference.create(_condRef);
@@ -32,22 +30,7 @@ class ConditionalHelperReference extends CachedReference {
   }
 
   constructor(cond, truthy, falsy) {
-    super();
-
-    this.branchTag = UpdatableTag.create(CONSTANT_TAG);
-    this.tag = combine([cond.tag, this.branchTag]);
-
-    this.cond = cond;
-    this.truthy = truthy;
-    this.falsy = falsy;
-  }
-
-  compute() {
-    let branch = this.cond.value() ? this.truthy : this.falsy;
-
-    this.branchTag.inner.update(branch.tag);
-
-    return branch.value();
+    super(cond, truthy, falsy);
   }
 }
 

--- a/packages/ember-glimmer/lib/utils/glimmer-references.ts
+++ b/packages/ember-glimmer/lib/utils/glimmer-references.ts
@@ -1,0 +1,68 @@
+//mirroring some of the classes in https://github.com/glimmerjs/glimmer.js/blob/master/packages/@glimmer/component/src/references.ts
+//these would be extracted into somewhere shared between ember and glimmer
+
+import {
+  PathReference,
+  CONSTANT_TAG,
+  // ConstReference,
+  // DirtyableTag,
+  UpdatableTag,
+  combine,
+  // isConst,
+  Tag,
+  TagWrapper
+} from "@glimmer/reference";
+
+/**
+ * The base PathReference.
+ */
+export abstract class ComponentPathReference<T> implements PathReference<T> {
+  abstract value(): T;
+  abstract get tag(): Tag;
+  abstract get(key: string): PathReference<any>;
+}
+
+export abstract class CachedReference<T> extends ComponentPathReference<T> {
+  _lastRevision: number | null = null;
+  _lastValue: any = null;
+
+  abstract compute(): T;
+
+  value() {
+    let { tag, _lastRevision, _lastValue } = this;
+
+    if (!_lastRevision || !tag.validate(_lastRevision)) {
+      _lastValue = this._lastValue = this.compute();
+      this._lastRevision = tag.value();
+    }
+
+    return _lastValue;
+  }
+}
+
+export abstract class ConditionalHelperReference<T> extends CachedReference<T> {
+  public branchTag: TagWrapper<UpdatableTag>;
+  public tag: any;
+  public cond: any;
+  public truthy: any;
+  public falsy: any;
+
+  constructor(cond, truthy, falsy) {
+    super();
+
+    this.branchTag = UpdatableTag.create(CONSTANT_TAG);
+    this.tag = combine([cond.tag, this.branchTag]);
+
+    this.cond = cond;
+    this.truthy = truthy;
+    this.falsy = falsy;
+  }
+
+  compute() {
+    let branch = this.cond.value() ? this.truthy : this.falsy;
+
+    this.branchTag.inner.update(branch.tag);
+
+    return branch.value();
+  }
+}

--- a/packages/ember-glimmer/lib/utils/references.ts
+++ b/packages/ember-glimmer/lib/utils/references.ts
@@ -35,6 +35,11 @@ import emberToBool from './to-bool';
 
 export const UPDATE = symbol('UPDATE');
 
+import {
+  ComponentPathReference as GlimmerComponentPathReference,
+  CachedReference as GlimmerCachedReference
+} from './glimmer-references';
+
 let maybeFreeze;
 if (DEBUG) {
   // gaurding this in a DEBUG gaurd (as well as all invocations)
@@ -51,43 +56,18 @@ if (DEBUG) {
   };
 }
 
-// @abstract
-// @implements PathReference
-class EmberPathReference {
-  // @abstract get tag()
-  // @abstract value()
+abstract class EmberPathReference extends GlimmerComponentPathReference<any> {
+  get(key?): any {
+    return PropertyReference.create(this, key);
+  }
+};
+
+export abstract class CachedReference extends GlimmerCachedReference<any> {
+  public tag: any;
 
   get(key?): any {
     return PropertyReference.create(this, key);
   }
-}
-
-// @abstract
-export class CachedReference extends EmberPathReference {
-  private _lastRevision: any;
-  private _lastValue: any;
-  public tag: any;
-
-  constructor() {
-    super();
-    this._lastRevision = null;
-    this._lastValue = null;
-  }
-
-  compute() { /* NOOP */ }
-
-  value() {
-    let { tag, _lastRevision, _lastValue } = this;
-
-    if (!_lastRevision || !tag.validate(_lastRevision)) {
-      _lastValue = this._lastValue = this.compute();
-      this._lastRevision = tag.value();
-    }
-
-    return _lastValue;
-  }
-
-  // @abstract compute()
 }
 
 // @implements PathReference


### PR DESCRIPTION
just a spike to see if it's possible to extract some shared reference types used by ember and glimmer