### PR TITLE
[BUGFIX beta] Add assertion in NativeArray.replace

### DIFF
--- a/packages/ember-glimmer/tests/integration/syntax/each-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/each-test.js
@@ -298,7 +298,7 @@ class SingleEachTest extends AbstractEachTest {
 
     this.assertText('Hello Planet EarthGlobe World');
 
-    this.runTask(() => this.replace(2, 4, { text: 'my' }));
+    this.runTask(() => this.replace(2, 4, [{ text: 'my' }]));
 
     this.assertText('Hello my World');
 
@@ -864,7 +864,7 @@ moduleFor('Syntax test: Multiple {{#each as}} helpers', class extends RenderingT
 
     this.runTask(() => {
       get(this.context, 'first').pushObject('I');
-      get(this.context, 'ninth').replace(0, 1, 'K');
+      get(this.context, 'ninth').replace(0, 1, ['K']);
     });
 
     this.assertText('O-Limbo-D-K-D-Wrath-K-Wrath-Limbo-I-D-K-D-Wrath-K-Wrath-I-O');
@@ -892,7 +892,7 @@ moduleFor('Syntax test: Multiple {{#each as}} helpers', class extends RenderingT
 
     this.runTask(() => {
       let name = get(this.context, 'name');
-      name.objectAt(0).replace(0, 1, 'lady');
+      name.objectAt(0).replace(0, 1, ['lady']);
       name.pushObject(['bird']);
     });
 

--- a/packages/ember-glimmer/tests/integration/syntax/with-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/with-test.js
@@ -195,7 +195,7 @@ moduleFor('Syntax test: {{#with as}}', class extends IfUnlessWithSyntaxTest {
 
     this.runTask(() => {
       let array = get(this.context, 'arrayThing');
-      array.replace(0, 1, 'Goodbye');
+      array.replace(0, 1, ['Goodbye']);
       removeAt(array, 1);
       array.insertAt(1, ', ');
       array.pushObject('!');

--- a/packages/ember-runtime/lib/system/native_array.js
+++ b/packages/ember-runtime/lib/system/native_array.js
@@ -54,6 +54,7 @@ let NativeArray = Mixin.create(MutableArray, Observable, Copyable, {
   // primitive for array support.
   replace(idx, amt, objects) {
     assert(FROZEN_ERROR, !this.isFrozen);
+    assert('The third argument to replace needs to be an array.', objects === null || objects === undefined || Array.isArray(objects))
 
     // if we replaced exactly the same number of items, then pass only the
     // replaced range. Otherwise, pass the full remaining array length

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -789,8 +789,8 @@ function commonSortTests() {
 
     let items = obj.get('items');
 
-    items.replace(0, 1, jaime);
-    items.replace(1, 1, jaimeInDisguise);
+    items.replace(0, 1, [jaime]);
+    items.replace(1, 1, [jaimeInDisguise]);
 
     deepEqual(obj.get('sortedItems').mapBy('fname'), [
       'Cersei',

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -703,7 +703,7 @@ QUnit.test('toggle function, should be boolean', function() {
 });
 
 QUnit.test('should notify array observer when array changes', function() {
-  get(object, 'normalArray').replace(0, 0, 6);
+  get(object, 'normalArray').replace(0, 0, [6]);
   equal(object.abnormal, 'notifiedObserver', 'observer should be notified');
 });
 

--- a/packages/ember-runtime/tests/system/native_array/replace_test.js
+++ b/packages/ember-runtime/tests/system/native_array/replace_test.js
@@ -1,0 +1,13 @@
+import { A } from '../../../system/native_array';
+
+QUnit.module('NativeArray.replace');
+
+QUnit.test('raises assertion if third argument is not an array', function() {
+  expectAssertion(function() {
+    A([1, 2, 3]).replace(1, 1, '');
+  }, 'The third argument to replace needs to be an array.');
+});
+
+QUnit.test('it does not raise an assertion if third parameter is not passed', function() {
+  deepEqual(A([1, 2, 3]).replace(1, 2), A([1]), 'no assertion raised');
+});


### PR DESCRIPTION
NativeArray.replace requires an array of items as third argument.
Before, it only check for the length property. The way it was
implemented made that the following two calls behave differently:

```js
arr.replace(0, 1, 'hola');
arr.replace(0, 1, '');
```

The first one would replace the first item with `'hola'`, but the second
would act as an splice and just remove the first element.

This PR adds an assertion and fixes some calls in tests.

Closes #15812