### PR TITLE
use `assign` internally for merge

### DIFF
--- a/packages/ember-metal/lib/merge.js
+++ b/packages/ember-metal/lib/merge.js
@@ -1,3 +1,4 @@
+import { assign } from 'ember-utils';
 /**
  @module @ember/polyfills
 */
@@ -26,13 +27,5 @@ export default function merge(original, updates) {
     return original;
   }
 
-  let props = Object.keys(updates);
-  let prop;
-
-  for (let i = 0; i < props.length; i++) {
-    prop = props[i];
-    original[prop] = updates[prop];
-  }
-
-  return original;
+  return assign(original, updates);
 }

--- a/packages/ember-utils/lib/assign.js
+++ b/packages/ember-utils/lib/assign.js
@@ -22,7 +22,7 @@
 export function assign(original) {
   for (let i = 1; i < arguments.length; i++) {
     let arg = arguments[i];
-    if (!arg) { continue; }
+    if (arg === undefined || arg === null) { continue; }
 
     let updates = Object.keys(arg);
 


### PR DESCRIPTION
until `merge` is deprecated it is good idea to use `assign` which fallbacks to native `Object.assign`