### PR TITLE
Fix - send event trace for keypress

### DIFF
--- a/packages/ember-glimmer/tests/integration/helpers/input-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/input-test.js
@@ -1,5 +1,5 @@
 import { assign } from 'ember-utils';
-import { set } from 'ember-metal';
+import { set, isPresent } from 'ember-metal';
 import { TextField, Checkbox, Component } from '../../utils/helpers';
 import { RenderingTest, moduleFor } from '../../utils/test-case';
 import { runDestroy } from 'internal-test-helpers';
@@ -313,14 +313,17 @@ moduleFor('Helpers test: {{input}}', class extends InputRenderingTest {
   }
 
   ['@test sends an action with `{{input key-press="foo"}}` is pressed'](assert) {
-    assert.expect(1);
+    assert.expect(4);
 
     this.render(`{{input value=value key-press='foo'}}`, {
       value: 'initial',
 
       actions: {
-        foo() {
+        foo(value, event) {
           assert.ok(true, 'action was triggered');
+          assert.ok(arguments.length === 2, 'action has two arguments; value and event');
+          assert.ok(value === 'initial', 'value was passesd in the first argument');
+          assert.ok(isPresent(event), 'event trace was passed in the second argument');
         }
       }
     });

--- a/packages/ember-views/lib/mixins/text_support.js
+++ b/packages/ember-views/lib/mixins/text_support.js
@@ -290,7 +290,7 @@ export default Mixin.create(TargetActionSupport, {
     @private
   */
   keyPress(event) {
-    sendAction('key-press', this, event);
+    this.sendAction('key-press', get(this, 'value'), event);
   },
 
   /**
@@ -333,22 +333,15 @@ export default Mixin.create(TargetActionSupport, {
 // In principle, this shouldn't be necessary, but the legacy
 // sendAction semantics for TextField are different from
 // the component semantics so this method normalizes them.
+
 function sendAction(eventName, view, event) {
   let action = get(view, `attrs.${eventName}`) || get(view, eventName);
-  let on = get(view, 'onEvent');
-  let value = get(view, 'value');
+  let { onEvent, value, bubbles } = view;
 
-  // back-compat support for keyPress as an event name even though
-  // it's also a method name that consumes the event (and therefore
-  // incompatible with sendAction semantics).
-  if (on === eventName || (on === 'keyPress' && eventName === 'key-press')) {
-    view.sendAction('action', value);
-  }
+  view.sendAction(eventName, value, event);
 
-  view.sendAction(eventName, value);
-
-  if (action || on === eventName) {
-    if (!get(view, 'bubbles')) {
+  if (action || onEvent === eventName) {
+    if (!bubbles) {
       event.stopPropagation();
     }
   }


### PR DESCRIPTION
1. Sends `jQuery Event info`  to the action as handled in other events.
2. Refactored sendAction method in `text_support`. It's long time, since we shift from 
``` handlebars
{{input on="key-press" action="doStuff"}}
````
to 
``` handlebars
{{input key-press="doStuff"}}
````