### PR TITLE
[BUGFIX release] Query params refreshModel

### DIFF
--- a/packages/ember/tests/routing/router_service_test/transitionTo_test.js
+++ b/packages/ember/tests/routing/router_service_test/transitionTo_test.js
@@ -302,6 +302,44 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
         });
     }
 
+    ['@test RouterService#transitionTo with refreshModel on parent route'](assert) {
+      assert.expect(2);
+
+      this.add('controller:parent', Controller.extend({
+        queryParams: ['parentParam'],
+        parentParam: null
+      }));
+
+      let modelCalled = 0;
+
+      this.add('route:parent', Route.extend({
+        queryParams: {
+          parentParam: {
+            refreshModel: true
+          }
+        },
+
+        model() {
+          modelCalled++;
+        }
+      }));
+
+      this.add('controller:parent.child', Controller.extend({
+        queryParams: ['childParam']
+      }));
+
+      let queryParams = this.buildQueryParams({ childParam: 'other' })
+
+      return this.visit('/child')
+        .then(() => {
+          assert.equal(modelCalled, 1, "Model called from first load");
+          return this.routerService.transitionTo(queryParams);
+        })
+        .then(() => {
+          assert.equal(modelCalled, 1, "Model should not be called again");
+        });
+    }
+
     ['@test RouterService#transitionTo with aliased query params uses the original provided key'](assert) {
       assert.expect(1);
 


### PR DESCRIPTION
This reproduces the https://github.com/emberjs/ember.js/issues/15801 in a test case. The problem actually lies in the query param change detection and I'm more than willing to include that. This does demonstrate the most user facing part of this issue.

Any pointers on the best approach to fix this are more than welcome.

While writing this I also noticed that transitioning from the parent route to the child route through the router service, actually triggered a transition abort. I'm convinced this is caused by the same underlying issue, but would be more than willing to include another failing test case to demonstrate that.