### PR TITLE
Yield computed properties in link-to component

### DIFF
--- a/packages/ember-glimmer/lib/templates/link-to.hbs
+++ b/packages/ember-glimmer/lib/templates/link-to.hbs
@@ -1,1 +1,1 @@
-{{#if linkTitle}}{{linkTitle}}{{else}}{{yield}}{{/if}}
+{{#if linkTitle}}{{linkTitle}}{{else}}{{yield (hash href=href active=active loading=loading)}}{{/if}}


### PR DESCRIPTION
This would allow greater flexibility and support for some CSS frameworks and situations where the link-to needs more than one element. For example:

```hbs
{{#link-to "my-route" tagName="li" as |link|}}
  <a href={{link.href}} class="{{link.active}}">Link Title</a>
{{/link-to}}
```

Or even more complex ideas:

```hbs
{{#link-to "my-route" tagName="li" as |link|}}
  {{#if link.active}}
    <span class="red">Current Route</span>
  {{else}}
    <a href={{link.href}}>Link Title</a>
  {{/if}}
{{/link-to}}
```