### PR TITLE
updating ember-cli-version-checker

### DIFF
--- a/blueprints/test-framework-detector.js
+++ b/blueprints/test-framework-detector.js
@@ -14,7 +14,7 @@ module.exports = function(blueprint) {
     if ('ember-cli-qunit' in dependencies) {
       type = 'qunit';
     } else if ('ember-cli-mocha' in dependencies) {
-      var checker = new VersionChecker({ project: this.project });
+      var checker = new VersionChecker({ root: this.project.root });
       if (fs.existsSync(this.path + '/mocha-0.12-files') && checker.for('ember-cli-mocha', 'npm').satisfies('>=0.12.0')) {
         type = 'mocha-0.12';
       } else {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "ember-cli-string-utils": "^1.1.0",
     "ember-cli-test-info": "^1.0.0",
     "ember-cli-valid-component-name": "^1.0.0",
-    "ember-cli-version-checker": "^1.3.1",
+    "ember-cli-version-checker": "^2.1.0",
     "ember-router-generator": "^1.2.3",
     "inflection": "^1.12.0",
     "jquery": "^3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2259,10 +2259,17 @@ ember-cli-valid-component-name@^1.0.0:
   dependencies:
     silent-error "^1.0.0"
 
-ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.6, ember-cli-version-checker@^1.1.7, ember-cli-version-checker@^1.3.1:
+ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.6, ember-cli-version-checker@^1.1.7:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz#0bc2d134c830142da64bf9627a0eded10b61ae72"
   dependencies:
+    semver "^5.3.0"
+
+ember-cli-version-checker@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz#fc79a56032f3717cf844ada7cbdec1a06fedb604"
+  dependencies:
+    resolve "^1.3.3"
     semver "^5.3.0"
 
 ember-cli-yuidoc@^0.8.8:


### PR DESCRIPTION
Updating this everywhere is a prerequisite for getting ember-cli to work with yarn workspaces.