### PR TITLE
[BUGFIX release] fix regression with computed `filter/map/sort`

### DIFF
--- a/packages/ember-metal/lib/expand_properties.js
+++ b/packages/ember-metal/lib/expand_properties.js
@@ -4,7 +4,7 @@ import { assert } from 'ember-debug';
 @module @ember/object
 */
 
-var END_WITH_EACH_REGEX = /\.@each$/;
+const END_WITH_EACH_REGEX = /\.@each$/;
 
 /**
   Expands `pattern`, invoking `callback` for each expansion.

--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -17,7 +17,6 @@ import compare from '../compare';
 import { isArray } from '../utils';
 import { A as emberA } from '../system/native_array';
 
-
 function reduceMacro(dependentKey, callback, initialValue) {
   let cp = new ComputedProperty(function() {
     let arr = get(this, dependentKey);
@@ -45,7 +44,9 @@ function arrayMacro(dependentKey, callback) {
     } else {
       return emberA();
     }
-  }, { dependentKeys: [ dependentKey ], readOnly: true });
+  }, { readOnly: true });
+
+  cp.property(dependentKey); // this forces to expand properties GH #15855
 
   return cp;
 }

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -665,7 +665,7 @@ QUnit.test('it asserts if given fewer or more than two dependent properties', fu
       array: emberA([1, 2, 3, 4, 5, 6, 7]),
       array2: emberA([3, 4, 5])
     });
-  }, /Ember\.computed\.setDiff requires exactly two dependent arrays/, 'setDiff requires two dependent arrays');
+  }, /\`Ember\.computed\.setDiff\` requires exactly two dependent arrays/, 'setDiff requires two dependent arrays');
 
   expectAssertion(function () {
     EmberObject.extend({
@@ -675,7 +675,7 @@ QUnit.test('it asserts if given fewer or more than two dependent properties', fu
       array2: emberA([3, 4, 5]),
       array3: emberA([7])
     });
-  }, /Ember\.computed\.setDiff requires exactly two dependent arrays/, 'setDiff requires two dependent arrays');
+  }, /\`Ember\.computed\.setDiff\` requires exactly two dependent arrays/, 'setDiff requires two dependent arrays');
 });
 
 

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -352,7 +352,7 @@ QUnit.test('it updates properly on @each with {} dependencies', function() {
       return item.get('prop') === true;
     })
   }).create({
-    items: [item]
+    items: emberA([item])
   });
 
   deepEqual(obj.get('filtered'), [item]);

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -344,6 +344,24 @@ QUnit.test('it updates as the array is replaced', function() {
   deepEqual(obj.get('filtered'), [20, 22, 24], 'computed array is updated when array is changed');
 });
 
+QUnit.test('it updates properly on @each with {} dependencies', function() {
+  let item = EmberObject.create({prop: true});
+
+  obj = EmberObject.extend({
+    filtered: filter('items.@each.{prop}', function(item, index) {
+      return item.get('prop') === true;
+    })
+  }).create({
+    items: [item]
+  });
+
+  deepEqual(obj.get('filtered'), [item]);
+
+  item.set('prop', false);
+
+  deepEqual(obj.get('filtered'), []);
+});
+
 QUnit.module('filterBy', {
   setup() {
     obj = EmberObject.extend({


### PR DESCRIPTION
`filter/map/sort` would not expand `items.@each.{prop1,prop2}` therefore would not properly work 