### PR TITLE
make consistent how `concatenatedProperties` merged

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -180,11 +180,7 @@ function makeCtor(base) {
               let baseValue = self[keyName];
 
               if (hasConcatenatedProps && concatenatedProperties.indexOf(keyName) > -1) {
-                if (baseValue) {
-                  value = makeArray(baseValue).concat(value);
-                } else {
-                  value = makeArray(value);
-                }
+                value = makeArray(baseValue).concat(makeArray(value));
               }
 
               if (hasMergedProps && mergedProperties.indexOf(keyName) > -1) {

--- a/packages/ember-runtime/tests/legacy_1x/system/object/concatenated_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/object/concatenated_test.js
@@ -127,5 +127,26 @@ moduleFor(
         `should concatenate functions property (expected: ${expected}, got: ${values})`
       );
     }
-  }
-);
+
+    ['@test concatenates instances with null/undefined properties'](assert) {
+      let objA = EmberObject.extend({
+        concatenatedProperties: ['values'],
+        values: null
+      })
+      .create({
+        values: ['a']
+      });
+
+      assert.deepEqual(objA.get('values'), ['a']);
+
+      let objB = EmberObject.extend({
+        concatenatedProperties: ['values'],
+        values: ['a']
+      })
+      .create({
+        values: null
+      });
+
+      assert.deepEqual(objB.get('values'), ['a']);
+    }
+});


### PR DESCRIPTION
`CoreObject` would concat `instance` and `class` properties inconsistently.
When `class property` is `null or undefined` then `instance property` would be concatenated without `null or undefined` values, while other way around, when `instance property` was `null or undefined` and `class property` had some value it would concat with `null or undefined`