### PR TITLE
Turn `loc` from a built-in helper into a regular helper

### DIFF
--- a/packages/ember-glimmer/lib/environment.ts
+++ b/packages/ember-glimmer/lib/environment.ts
@@ -62,7 +62,6 @@ import {
   inlineIf,
   inlineUnless,
 } from './helpers/if-unless';
-import { default as loc } from './helpers/loc';
 import { default as log } from './helpers/log';
 import { default as mut } from './helpers/mut';
 import { default as queryParams } from './helpers/query-param';
@@ -88,7 +87,7 @@ function isTemplateFactory(template: OwnedTemplate | WrappedTemplateFactory): te
 
 export interface CompilerFactory {
   id: string;
-  new (template: OwnedTemplate | undefined): CompilableLayout;
+  new(template: OwnedTemplate | undefined): CompilableLayout;
 }
 
 export default class Environment extends GlimmerEnvironment {
@@ -180,7 +179,6 @@ export default class Environment extends GlimmerEnvironment {
       concat,
       get,
       hash,
-      loc,
       log,
       mut,
       'query-params': queryParams,
@@ -261,7 +259,7 @@ export default class Environment extends GlimmerEnvironment {
     }
   }
 
-  hasHelper(name: string, { owner, moduleName }: {owner: Container, moduleName: string}): boolean {
+  hasHelper(name: string, { owner, moduleName }: { owner: Container, moduleName: string }): boolean {
     if (name === 'component' || this.builtInHelpers[name]) {
       return true;
     }
@@ -289,7 +287,7 @@ export default class Environment extends GlimmerEnvironment {
 
     // TODO: try to unify this into a consistent protocol to avoid wasteful closure allocations
     let HelperReference: {
-      create: (HelperFactory: any, vm: VM, args: CapturedArguments ) => PathReference<Opaque>;
+      create: (HelperFactory: any, vm: VM, args: CapturedArguments) => PathReference<Opaque>;
     };
     if (helperFactory.class.isSimpleHelperFactory) {
       HelperReference = SimpleHelperReference;
@@ -387,7 +385,7 @@ if (DEBUG) {
 
   let STYLE_ATTRIBUTE_MANANGER = new StyleAttributeManager('style');
 
-  Environment.prototype.attributeFor = function(element, attribute, isTrusting) {
+  Environment.prototype.attributeFor = function (element, attribute, isTrusting) {
     if (attribute === 'style' && !isTrusting) {
       return STYLE_ATTRIBUTE_MANANGER;
     }

--- a/packages/ember-glimmer/lib/helpers/loc.ts
+++ b/packages/ember-glimmer/lib/helpers/loc.ts
@@ -3,13 +3,8 @@
 @module ember
 */
 
-import {
-  Arguments,
-  CapturedArguments,
-  VM
-} from '@glimmer/runtime';
+import { helper } from '../helper';
 import { String as StringUtils } from 'ember-runtime';
-import { InternalHelperReference } from '../utils/references';
 
 /**
   Calls [loc](/api/classes/Ember.String.html#method_loc) with the
@@ -43,10 +38,7 @@ import { InternalHelperReference } from '../utils/references';
   @see {Ember.String#loc}
   @public
 */
-function locHelper({ positional }: CapturedArguments) {
-  return StringUtils.loc.apply(null, positional.value());
-}
+export default helper(function (params) {
+  return StringUtils.loc.apply(null, params);
+});
 
-export default function(_vm: VM, args: Arguments) {
-  return new InternalHelperReference(locHelper, args.capture());
-}

--- a/packages/ember-glimmer/lib/setup-registry.ts
+++ b/packages/ember-glimmer/lib/setup-registry.ts
@@ -16,6 +16,7 @@ import ComponentTemplate from './templates/component';
 import OutletTemplate from './templates/outlet';
 import RootTemplate from './templates/root';
 import OutletView from './views/outlet';
+import loc from './helpers/loc';
 
 interface Registry {
   injection(name: string, name2: string, name3: string): void;
@@ -65,6 +66,8 @@ export function setupEngineRegistry(registry: Registry) {
   registry.injection('template', 'env', 'service:-glimmer-environment');
 
   registry.optionsForType('helper', { instantiate: false });
+
+  registry.register('helper:loc', loc);
 
   registry.register('component:-text-field', TextField);
   registry.register('component:-text-area', TextArea);

--- a/packages/ember-glimmer/tests/integration/helpers/loc-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/loc-test.js
@@ -85,4 +85,12 @@ moduleFor('Helpers test: {{loc}}', class extends RenderingTest {
     this.assertText('Hallo Freund - Hallo, Mr. Pitkin',
                     'the bound value is correct after replacement');
   }
+
+  ['@test it can be overriden']() {
+    this.registerHelper('loc', () => 'Yup');
+    this.render(`{{loc greeting}}`, {
+      greeting: 'Hello Friend'
+    });
+    this.assertText('Yup', 'the localized string is correct');      
+  }
 });


### PR DESCRIPTION
This is necessary for the RFC 236 `loc` deprecation, so the `@ember/string` package can override it once it is deprecated.