### PR TITLE
Adds type annotations for ember-glimmer macro implementations

### DIFF
--- a/packages/ember-glimmer/lib/syntax.ts
+++ b/packages/ember-glimmer/lib/syntax.ts
@@ -1,18 +1,22 @@
+import { InlineMacros, BlockMacros, OpcodeBuilderDSL, Block } from '@glimmer/runtime';
+import * as WireFormat from '@glimmer/wire-format';
 import { assert } from 'ember-debug';
 import { textAreaMacro } from './syntax/-text-area';
 import {
   blockComponentMacro,
   inlineComponentMacro,
 } from './syntax/dynamic-component';
+import Environment from './environment';
 import { inputMacro } from './syntax/input';
 import { mountMacro } from './syntax/mount';
 import { outletMacro } from './syntax/outlet';
 import { renderMacro } from './syntax/render';
 import { hashToArgs } from './syntax/utils';
 import { wrapComponentClassAttribute } from './utils/bindings';
+import { Option } from '@glimmer/util';
 
-function refineInlineSyntax(name: string, params: any[], hash: any, builder: any) {
-  assert(`You attempted to overwrite the built-in helper "${name}" which is not allowed. Please rename the helper.`, !(builder.env.builtInHelpers[name] && builder.env.owner.hasRegistration(`helper:${name}`)));
+function refineInlineSyntax(name: string, params: WireFormat.Core.Params, hash: WireFormat.Core.Hash, builder: OpcodeBuilderDSL) {
+  assert(`You attempted to overwrite the built-in helper "${name}" which is not allowed. Please rename the helper.`, !((builder.env as Environment).builtInHelpers[name] && (builder.env as Environment).owner.hasRegistration(`helper:${name}`)));
 
   let definition;
   if (name.indexOf('-') > -1) {
@@ -28,7 +32,7 @@ function refineInlineSyntax(name: string, params: any[], hash: any, builder: any
   return false;
 }
 
-function refineBlockSyntax(name: string, params: any[], hash: any, _default: any, inverse: any, builder: any) {
+function refineBlockSyntax(name: string, params: WireFormat.Core.Params, hash: WireFormat.Core.Hash, _default: Option<Block>, inverse: Option<Block>, builder: OpcodeBuilderDSL) {
   if (name.indexOf('-') === -1) {
     return false;
   }
@@ -53,16 +57,17 @@ function refineBlockSyntax(name: string, params: any[], hash: any, _default: any
   return false;
 }
 
-export const experimentalMacros: any[] = [];
+export type ExperimentalMacro = (blocks: BlockMacros, inlines: InlineMacros) => void;
+export const experimentalMacros: ExperimentalMacro[] = [];
 
 // This is a private API to allow for experimental macros
 // to be created in user space. Registering a macro should
 // should be done in an initializer.
-export function registerMacros(macro: any) {
+export function registerMacros(macro: ExperimentalMacro) {
   experimentalMacros.push(macro);
 }
 
-export function populateMacros(blocks: any, inlines: any) {
+export function populateMacros(blocks: BlockMacros, inlines: InlineMacros) {
   inlines.add('outlet', outletMacro);
   inlines.add('component', inlineComponentMacro);
   inlines.add('render', renderMacro);

--- a/packages/ember-glimmer/lib/syntax/-text-area.ts
+++ b/packages/ember-glimmer/lib/syntax/-text-area.ts
@@ -1,7 +1,9 @@
+import { OpcodeBuilderDSL } from '@glimmer/runtime';
+import * as WireFormat from '@glimmer/wire-format';
 import { wrapComponentClassAttribute } from '../utils/bindings';
 import { hashToArgs } from './utils';
 
-export function textAreaMacro(_name: string, params: any[], hash: any, builder: any) {
+export function textAreaMacro(_name: string, params: WireFormat.Core.Params, hash: WireFormat.Core.Hash, builder: OpcodeBuilderDSL) {
   let definition = builder.env.getComponentDefinition('-text-area', builder.meta.templateMeta);
   wrapComponentClassAttribute(hash);
   builder.component.static(definition, [params, hashToArgs(hash), null, null]);

--- a/packages/ember-glimmer/lib/syntax/input.ts
+++ b/packages/ember-glimmer/lib/syntax/input.ts
@@ -1,12 +1,15 @@
 /**
 @module ember
 */
+import * as WireFormat from '@glimmer/wire-format';
 import { assert } from 'ember-debug';
 import { wrapComponentClassAttribute } from '../utils/bindings';
 import { dynamicComponentMacro } from './dynamic-component';
 import { hashToArgs } from './utils';
+import { OpcodeBuilderDSL } from '@glimmer/runtime';
+import { unwrap } from '@glimmer/util';
 
-function buildSyntax(type: string, params: any[], hash: any, builder: any) {
+function buildSyntax(type: string, params: WireFormat.Core.Params, hash: WireFormat.Core.Hash, builder: OpcodeBuilderDSL) {
   let definition = builder.env.getComponentDefinition(type, builder.meta.templateMeta);
   builder.component.static(definition, [params, hashToArgs(hash), null, null]);
   return true;
@@ -148,7 +151,7 @@ function buildSyntax(type: string, params: any[], hash: any, builder: any) {
   @public
 */
 
-export function inputMacro(_name: string, params: any[], hash: any[], builder: any) {
+export function inputMacro(_name: string, params: WireFormat.Core.Params, hash: WireFormat.Core.Hash, builder: OpcodeBuilderDSL): boolean {
   let keys;
   let values;
   let typeIndex = -1;
@@ -164,7 +167,7 @@ export function inputMacro(_name: string, params: any[], hash: any[], builder: a
   if (!params) { params = []; }
 
   if (typeIndex > -1) {
-    let typeArg = values[typeIndex];
+    let typeArg = unwrap(values)[typeIndex];
     if (Array.isArray(typeArg)) {
       return dynamicComponentMacro(params, hash, null, null, builder);
     } else if (typeArg === 'checkbox') {
@@ -173,7 +176,7 @@ export function inputMacro(_name: string, params: any[], hash: any[], builder: a
           'you must use `checked=someBooleanValue` instead.',
         valueIndex === -1,
       );
-      wrapComponentClassAttribute(hash);
+      wrapComponentClassAttribute(unwrap(hash));
       return buildSyntax('-checkbox', params, hash, builder);
     }
   }

--- a/packages/ember-glimmer/lib/syntax/utils.ts
+++ b/packages/ember-glimmer/lib/syntax/utils.ts
@@ -1,4 +1,6 @@
-export function hashToArgs(hash: any[]) {
+import * as WireFormat from '@glimmer/wire-format';
+
+export function hashToArgs(hash: WireFormat.Core.Hash): WireFormat.Core.Hash {
   if (hash === null) { return null; }
   let names = hash[0].map((key: string) => `@${key}`);
   return [names, hash[1]];

--- a/packages/ember-glimmer/lib/views/outlet.ts
+++ b/packages/ember-glimmer/lib/views/outlet.ts
@@ -62,7 +62,7 @@ class OrphanedOutletStateReference extends RootOutletStateReference {
     let state = Object.create(null);
     state[matched.render.outlet] = matched;
     matched.wasUsed = true;
-    return { outlets: state, render: undefined };
+    return { outlets: state, render: null };
   }
 }
 
@@ -100,7 +100,7 @@ export interface OutletState {
   outlets: {
     [name: string]: OutletState | undefined;
   };
-  render: RenderState | undefined;
+  render: Option<RenderState>;
 }
 
 export interface BootEnvironment {


### PR DESCRIPTION
This PR adds annotations for the various Ember features implemented as Glimmer VM "macros" (i.e. they tap into the low-level opcode builder API). Previously these were mostly typed as `any`s. I skipped typing the `component` helper implementation due to time constraints, but it should be straightforward to derive its types from the others I've done here.