### PR TITLE
[DOC release] ObjectProxy and PromiseProxyMixin examples

### DIFF
--- a/packages/ember-runtime/lib/mixins/promise_proxy.js
+++ b/packages/ember-runtime/lib/mixins/promise_proxy.js
@@ -40,7 +40,10 @@ function tap(proxy, promise) {
   A low level mixin making ObjectProxy promise-aware.
 
   ```javascript
-  let ObjectPromiseProxy = Ember.ObjectProxy.extend(Ember.PromiseProxyMixin);
+  import ObjectProxy from '@ember/object/proxy';
+  import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
+
+  const ObjectPromiseProxy = ObjectProxy.extend(PromiseProxyMixin);
 
   let proxy = ObjectPromiseProxy.create({
     promise: Ember.RSVP.resolve($.getJSON('/some/remote/data.json'))
@@ -150,7 +153,7 @@ export default Mixin.create({
     Example:
 
     ```javascript
-    Ember.ObjectProxy.extend(Ember.PromiseProxyMixin).create({
+    ObjectProxy.extend(PromiseProxyMixin).create({
       promise: <thenable>
     });
     ```

--- a/packages/ember-runtime/lib/system/object_proxy.js
+++ b/packages/ember-runtime/lib/system/object_proxy.js
@@ -6,11 +6,14 @@ import _ProxyMixin from '../mixins/-proxy';
   to a proxied `content` object.
 
   ```javascript
-  object = Ember.Object.create({
+  import EmberObject, {computed} from '@ember/object';
+  import ObjectProxy from '@ember/object/proxy';
+
+  object = EmberObject.create({
     name: 'Foo'
   });
 
-  proxy = Ember.ObjectProxy.create({
+  proxy = ObjectProxy.create({
     content: object
   });
 
@@ -28,7 +31,7 @@ import _ProxyMixin from '../mixins/-proxy';
   Error.
 
   ```javascript
-  proxy = Ember.ObjectProxy.create({
+  proxy = ObjectProxy.create({
     content: null,
     flag: null
   });
@@ -43,8 +46,8 @@ import _ProxyMixin from '../mixins/-proxy';
   Computed properties on the proxy itself can depend on delegated properties.
 
   ```javascript
-  ProxyWithComputedProperty = Ember.ObjectProxy.extend({
-    fullName: Ember.computed('firstName', 'lastName', function() {
+  ProxyWithComputedProperty = ObjectProxy.extend({
+    fullName: computed('firstName', 'lastName', function() {
       var firstName = this.get('firstName'),
           lastName = this.get('lastName');
       if (firstName && lastName) {


### PR DESCRIPTION
Context:
=======
I was confused for quite some time as to what the actual import was for ObjectProxy and PromiseProxyMixin. It doesn't look like the JSDocs for these components have been updated since 2.15.

Objective:
---------------
Update examples in JSDoc for `ObjectProxy` and `PromiseProxyMixin`.

Misc:
-------
I originally filed an issue about this: https://github.com/emberjs/website/issues/3073
I was not able to get the ember-api-docs site to run locally. I looked at https://github.com/ember-learn/ember-api-docs/issues/360, but I wouldn't even know where to start.