### PR TITLE
[DOC release]Make it so Logger comes back to YUIDoc builds

### DIFF
--- a/yuidoc.json
+++ b/yuidoc.json
@@ -6,6 +6,7 @@
     "paths": [
       "packages/ember/lib",
       "packages/ember-utils/lib",
+      "packages/ember-console/lib",
       "packages/ember-debug/lib",
       "packages/ember-metal/lib",
       "packages/ember-runtime/lib",


### PR DESCRIPTION
Fixes #15866 

when ember-console was created and Logger added, it was not added to yuidoc.json