### PR TITLE
[BUGFIX release] Update Backburner.js to 1.2.3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "babel-plugin-transform-proto-to-assign": "^6.23.0",
     "babel-template": "^6.24.1",
-    "backburner.js": "^1.2.2",
+    "backburner.js": "1.2.3",
     "broccoli-babel-transpiler": "^6.1.1",
     "broccoli-concat": "^3.2.2",
     "broccoli-file-creator": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -876,9 +876,9 @@ backbone@^1.1.2:
   dependencies:
     underscore ">=1.8.3"
 
-backburner.js@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-1.2.2.tgz#0350aae362cf0522e6618f24d4b0a44cda2ec81e"
+backburner.js@1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-1.2.3.tgz#dbeee1869a09bc4888b2c419110ba85889a1fdf8"
 
 backo2@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Includes fixes for `Ember.run.join` swallowing errors when an `Ember.onerror` exists.

Fixes https://github.com/emberjs/ember.js/issues/15864
