### PR TITLE
[BUGFIX canary] Update Backburner.js to v1.3.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "babel-plugin-transform-proto-to-assign": "^6.23.0",
     "babel-template": "^6.24.1",
-    "backburner.js": "^1.2.2",
+    "backburner.js": "^1.3.0",
     "broccoli-babel-transpiler": "^6.1.1",
     "broccoli-concat": "^3.2.2",
     "broccoli-debug": "^0.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -877,9 +877,9 @@ backbone@^1.1.2:
   dependencies:
     underscore ">=1.8.3"
 
-backburner.js@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-1.2.2.tgz#0350aae362cf0522e6618f24d4b0a44cda2ec81e"
+backburner.js@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-1.3.0.tgz#fbd51f7ddcdbf09cf80eab68f209247b6f62e28b"
 
 backo2@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
For a full list of changes [compare v1.2.2...v1.3.0](https://github.com/BackburnerJS/backburner.js/compare/v1.2.2...v1.3.0).

High level changes:

* Includes fixes for Ember.run.join swallowing errors when an `Ember.onerror` exists.
* Fix `run.throttle` argument usage to now invoke the throttled function
  with the _last_ arguments (previously was the first set of arguments).
* Various cleanup / refactors of the codebase.