### PR TITLE
Upgrade to backburner@1.3.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "babel-plugin-transform-proto-to-assign": "^6.23.0",
     "babel-template": "^6.24.1",
-    "backburner.js": "^1.3.0",
+    "backburner.js": "^1.3.1",
     "broccoli-babel-transpiler": "^6.1.1",
     "broccoli-concat": "^3.2.2",
     "broccoli-debug": "^0.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -877,9 +877,9 @@ backbone@^1.1.2:
   dependencies:
     underscore ">=1.8.3"
 
-backburner.js@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-1.3.0.tgz#fbd51f7ddcdbf09cf80eab68f209247b6f62e28b"
+backburner.js@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-1.3.1.tgz#f89ebd433063693f2ab13b6f8a3427fefc31cdcf"
 
 backo2@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Includes a nice refactor to use a shared method for parsing the arguments of `run`, `run.join`, `run.schedule`, etc.

Should make stepping through Backburner code a bit easier...