### PR TITLE
Run tests with Chrome headless.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ cache:
 
 before_install:
 - |
-    phantomjs --version
     export DISPLAY=:99.0
     sh -e /etc/init.d/xvfb start
 

--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -40,20 +40,10 @@ function runInBrowser(url, retries, resolve, reject) {
 
   puppeteer.launch().then(function(browser) {
     browser.newPage().then(function(page) {
-      page.on('console', function() {
+      page.on('console', function(msg) {
+        console.log(msg.text);
 
-        var string = Array.prototype.slice.call(arguments).join('');
-        var lines = string.split('\n');
-
-        lines.forEach(function(line) {
-          if (line.indexOf('0 failed.') > -1) {
-            console.log(chalk.green(line));
-          } else {
-            console.log(line);
-          }
-        });
-
-        result.output.push(string);
+        result.output.push(msg.text);
       });
 
       page.on('error', function(err) {

--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -28,7 +28,6 @@ function run(queryString) {
   return new RSVP.Promise(function(resolve, reject) {
     var url = 'http://localhost:' + PORT + '/tests/?' + queryString;
     runInBrowser(url, 3, resolve, reject);
-    //runInPhantom(url, 3, resolve, reject);
   });
 }
 
@@ -169,62 +168,6 @@ function runInBrowser(url, retries, resolve, reject) {
       page.goto(url, { timeout: 900 });
     });
   })
-}
-
-function runInPhantom(url, retries, resolve, reject) {
-  var args = [require.resolve('qunit-phantomjs-runner'), url, '900'];
-
-  console.log('Running: phantomjs ' + args.join(' '));
-
-  var crashed = false;
-  var child = spawn('phantomjs', args);
-  var result = {output: [], errors: [], code: null};
-
-  child.stdout.on('data', function (data) {
-    var string = data.toString();
-    var lines = string.split('\n');
-
-    lines.forEach(function(line) {
-      if (line.indexOf('0 failed.') > -1) {
-        console.log(chalk.green(line));
-      } else {
-        console.log(line);
-      }
-    });
-    result.output.push(string);
-  });
-
-  child.stderr.on('data', function (data) {
-    var string = data.toString();
-
-    if (string.indexOf('PhantomJS has crashed.') > -1) {
-      crashed = true;
-    }
-
-    result.errors.push(string);
-    console.error(chalk.red(string));
-  });
-
-  child.on('close', function (code) {
-    result.code = code;
-
-    if (!crashed && code === 0) {
-      resolve(result);
-    } else if (crashed) {
-      console.log(chalk.red('Phantom crashed with exit code ' + code));
-
-      if (retries > 1) {
-        console.log(chalk.yellow('Retrying... ¯\_(ツ)_/¯'));
-        runInPhantom(url, retries - 1, resolve, reject);
-      } else {
-        console.log(chalk.red('Giving up! (╯°□°)╯︵ ┻━┻'));
-        console.log(chalk.yellow('This might be a known issue with PhantomJS 1.9.8, skipping for now'));
-        resolve(result);
-      }
-    } else {
-      reject(result);
-    }
-  });
 }
 
 var testFunctions = [];

--- a/bin/run-travis-browser-tests.js
+++ b/bin/run-travis-browser-tests.js
@@ -35,23 +35,7 @@ function run(command, _args) {
 }
 
 
-function setupChrome() {
-  return RSVP.resolve()
-    .then(function() {
-      return run('sudo', ['apt-get', 'install', '-y', 'google-chrome-stable']);
-    })
-    .then(function() {
-      return run('/usr/bin/google-chrome', ['--version']);
-    });
-}
-
 RSVP.resolve()
-  .then(function() {
-    return run('sudo', ['apt-get', 'update']);
-  })
-  .then(function() {
-    return setupChrome();
-  })
   .then(function() {
     return run('./node_modules/.bin/testem', ['launchers']);
   })

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "html-differ": "^1.3.4",
     "lodash.uniq": "^4.5.0",
     "mocha": "^2.4.5",
-    "puppeteer": "^0.10.1",
+    "puppeteer": "^0.13.0",
     "qunit-extras": "^1.5.0",
     "qunit-phantomjs-runner": "^2.2.0",
     "qunitjs": "^1.22.0",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "html-differ": "^1.3.4",
     "lodash.uniq": "^4.5.0",
     "mocha": "^2.4.5",
+    "puppeteer": "^0.9.0",
     "qunit-extras": "^1.5.0",
     "qunit-phantomjs-runner": "^2.2.0",
     "qunitjs": "^1.22.0",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "mocha": "^2.4.5",
     "puppeteer": "^0.13.0",
     "qunit-extras": "^1.5.0",
-    "qunit-phantomjs-runner": "^2.2.0",
     "qunitjs": "^1.22.0",
     "route-recognizer": "^0.3.3",
     "router_js": "^2.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "html-differ": "^1.3.4",
     "lodash.uniq": "^4.5.0",
     "mocha": "^2.4.5",
-    "puppeteer": "^0.9.0",
+    "puppeteer": "^0.10.1",
     "qunit-extras": "^1.5.0",
     "qunit-phantomjs-runner": "^2.2.0",
     "qunitjs": "^1.22.0",

--- a/testem.dist.json
+++ b/testem.dist.json
@@ -38,7 +38,7 @@
       "protocol": "tap"
     }
   },
-  "launch_in_dev": ["PhantomJS"],
+  "launch_in_dev": [],
   "launch_in_ci": [
     "SL_Safari_Current",
     "SL_MS_Edge",

--- a/testem.json
+++ b/testem.json
@@ -4,5 +4,5 @@
   "timeout": 540,
   "parallel": 4,
   "disable_watching": true,
-  "launch_in_dev": ["PhantomJS"]
+  "launch_in_dev": []
 }

--- a/testem.travis-browsers.js
+++ b/testem.travis-browsers.js
@@ -29,11 +29,9 @@ module.exports = {
   disable_watching: true,
   launch_in_dev: [
     'Firefox',
-    'Chrome'
   ],
   launch_in_ci: [
     'Firefox',
-    'Chrome'
   ],
   reporter: new FailureOnlyReporter()
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4993,9 +4993,9 @@ punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-puppeteer@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-0.10.1.tgz#a26f7012ff0fcc9f21c70ff9e2a8c60cba568a83"
+puppeteer@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-0.13.0.tgz#2e6956205f2c640964c2107f620ae1eef8bde8fd"
   dependencies:
     debug "^2.6.8"
     extract-zip "^1.6.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5046,16 +5046,6 @@ qunit-extras@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/qunit-extras/-/qunit-extras-1.5.0.tgz#a64d1c5088ab20c01c0e1b04c72132c397b3964c"
 
-qunit-phantomjs-runner@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/qunit-phantomjs-runner/-/qunit-phantomjs-runner-2.3.0.tgz#270acb197c0f2fcaaf06676ab0a48fd5aca66a99"
-  dependencies:
-    qunit-reporter-junit "^1.0.2"
-
-qunit-reporter-junit@^1.0.2:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/qunit-reporter-junit/-/qunit-reporter-junit-1.1.1.tgz#eeb6226457896993e795a11940f18af6afa579b4"
-
 qunitjs@^1.22.0:
   version "1.23.1"
   resolved "https://registry.yarnpkg.com/qunitjs/-/qunitjs-1.23.1.tgz#1971cf97ac9be01a64d2315508d2e48e6fd4e719"

--- a/yarn.lock
+++ b/yarn.lock
@@ -123,6 +123,12 @@ agent-base@2:
     extend "~3.0.0"
     semver "~5.0.1"
 
+agent-base@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.1.1.tgz#92d8a4fc2524a3b09b3666a33b6c97960f23d6a4"
+  dependencies:
+    es6-promisify "^5.0.0"
+
 ajv-keywords@^1.0.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
@@ -1919,7 +1925,7 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-debug@2, debug@2.6.8, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.4.0, debug@^2.6.8, debug@~2.6.7:
+debug@2, debug@2.6.8, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.4.0, debug@^2.4.1, debug@^2.6.8, debug@~2.6.7:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
@@ -2507,6 +2513,16 @@ es6-map@^0.1.3, es6-map@^0.1.4:
     es6-set "~0.1.5"
     es6-symbol "~3.1.1"
     event-emitter "~0.3.5"
+
+es6-promise@^4.0.3:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.1.1.tgz#8811e90915d9a0dba36274f0b242dbda78f9c92a"
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  dependencies:
+    es6-promise "^4.0.3"
 
 es6-set@~0.1.5:
   version "0.1.5"
@@ -3466,6 +3482,13 @@ http-signature@~1.1.0:
     assert-plus "^0.2.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
+
+https-proxy-agent@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.1.0.tgz#1391bee7fd66aeabc0df2a1fa90f58954f43e443"
+  dependencies:
+    agent-base "^4.1.0"
+    debug "^2.4.1"
 
 https-proxy-agent@~1.0.0:
   version "1.0.0"
@@ -4954,6 +4977,10 @@ proxy-addr@~1.1.4:
     forwarded "~0.1.0"
     ipaddr.js "1.3.0"
 
+proxy-from-env@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -4966,14 +4993,16 @@ punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-puppeteer@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-0.9.0.tgz#d65997ff83e24eb569e5577d2f75695dcbe5be4a"
+puppeteer@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-0.10.1.tgz#a26f7012ff0fcc9f21c70ff9e2a8c60cba568a83"
   dependencies:
     debug "^2.6.8"
     extract-zip "^1.6.5"
+    https-proxy-agent "^2.1.0"
     mime "^1.3.4"
     progress "^2.0.0"
+    proxy-from-env "^1.0.0"
     rimraf "^2.6.1"
     ws "^3.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,7 +1775,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.7, concat-stream@^1.5.2:
+concat-stream@1.6.0, concat-stream@^1.4.7, concat-stream@^1.5.2:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -1919,9 +1919,9 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-debug@2, debug@2.6.9, debug@^2.1.3, debug@~2.6.7:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+debug@2, debug@2.6.8, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.4.0, debug@^2.6.8, debug@~2.6.7:
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
     ms "2.0.0"
 
@@ -1943,9 +1943,9 @@ debug@2.6.7:
   dependencies:
     ms "2.0.0"
 
-debug@2.6.8, debug@^2.1.0, debug@^2.1.1, debug@^2.2.0, debug@^2.4.0:
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
+debug@2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
@@ -2764,6 +2764,15 @@ extglob@^0.3.1:
   dependencies:
     is-extglob "^1.0.0"
 
+extract-zip@^1.6.5:
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.5.tgz#99a06735b6ea20ea9b705d779acffcc87cff0440"
+  dependencies:
+    concat-stream "1.6.0"
+    debug "2.2.0"
+    mkdirp "0.5.0"
+    yauzl "2.4.1"
+
 extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
@@ -2802,6 +2811,12 @@ fb-watchman@^2.0.0:
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58"
   dependencies:
     bser "^2.0.0"
+
+fd-slicer@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
+  dependencies:
+    pend "~1.2.0"
 
 figures@^1.3.5:
   version "1.7.0"
@@ -4320,7 +4335,7 @@ mime@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
 
-mime@^1.2.11:
+mime@^1.2.11, mime@^1.3.4:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.6.tgz#591d84d3653a6b0b4a3b9df8de5aa8108e72e5e0"
 
@@ -4365,6 +4380,12 @@ minimist@^1.1.0, minimist@^1.1.1:
 mkdirp@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
+
+mkdirp@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.0.tgz#1d73076a6df986cd9344e15e71fcc05a4c9abf12"
+  dependencies:
+    minimist "0.0.8"
 
 mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
@@ -4842,6 +4863,10 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
@@ -4902,6 +4927,10 @@ progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
+progress@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
+
 promise-map-series@^0.2.1:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/promise-map-series/-/promise-map-series-0.2.3.tgz#c2d377afc93253f6bd03dbb77755eb88ab20a847"
@@ -4936,6 +4965,17 @@ punycode@1.3.2:
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+
+puppeteer@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-0.9.0.tgz#d65997ff83e24eb569e5577d2f75695dcbe5be4a"
+  dependencies:
+    debug "^2.6.8"
+    extract-zip "^1.6.5"
+    mime "^1.3.4"
+    progress "^2.0.0"
+    rimraf "^2.6.1"
+    ws "^3.0.0"
 
 q@1.4.1, q@^1.1.2:
   version "1.4.1"
@@ -6146,6 +6186,10 @@ ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
 
+ultron@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.0.tgz#b07a2e6a541a815fc6a34ccd4533baec307ca864"
+
 umask@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
@@ -6409,6 +6453,13 @@ ws@1.1.1:
     options ">=0.0.5"
     ultron "1.0.x"
 
+ws@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-3.1.0.tgz#8afafecdeab46d572e5397ee880739367aa2f41c"
+  dependencies:
+    safe-buffer "~5.1.0"
+    ultron "~1.1.0"
+
 wtf-8@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wtf-8/-/wtf-8-1.0.0.tgz#392d8ba2d0f1c34d1ee2d630f15d0efb68e1048a"
@@ -6478,6 +6529,12 @@ yargs@~3.27.0:
     os-locale "^1.4.0"
     window-size "^0.1.2"
     y18n "^3.2.0"
+
+yauzl@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
+  dependencies:
+    fd-slicer "~1.0.1"
 
 yeast@0.1.2:
   version "0.1.2"


### PR DESCRIPTION
Rebased and tweaked version of https://github.com/emberjs/ember.js/pull/15588 (thanks to @maclover7 for all of the _actual_ hard work here).

Also, added a few commits on top of those changes for:

* Drop phantomjs testing infrastructure
* Remove extra running of `Chrome` in `TEST_SUITE=travis-browsers`
* Update puppeteer to 0.13.0 (~ Chromium 64)

Addresses part of https://github.com/emberjs/ember.js/issues/15876.