### PR TITLE
Remove `IE9` and `IE10` from CI.

### DIFF
--- a/testem.dist.json
+++ b/testem.dist.json
@@ -28,22 +28,12 @@
     "SL_IE_11": {
       "command": "npm run sauce:launch -- -b 'internet explorer' -v 11 --no-connect -u '<url>'",
       "protocol": "tap"
-    },
-    "SL_IE_10": {
-      "command": "npm run sauce:launch -- -b 'internet explorer' -v 10 --no-connect -u '<url>'",
-      "protocol": "tap"
-    },
-    "SL_IE_9": {
-      "command": "npm run sauce:launch  -- -b 'internet explorer' -v 9 --no-connect -u '<url>'",
-      "protocol": "tap"
     }
   },
   "launch_in_dev": [],
   "launch_in_ci": [
     "SL_Safari_Current",
     "SL_MS_Edge",
-    "SL_IE_11",
-    "SL_IE_10",
-    "SL_IE_9"
+    "SL_IE_11"
   ]
 }


### PR DESCRIPTION
Addresses parts of https://github.com/emberjs/ember.js/issues/15876