### PR TITLE
[BUGFIX beta] Fix link-to throwing in integration tests

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/link-to-test.js
+++ b/packages/ember-glimmer/tests/integration/components/link-to-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, ApplicationTest } from '../../utils/test-case';
+import { moduleFor, ApplicationTest, RenderingTest } from '../../utils/test-case';
 import { Controller } from 'ember-runtime';
 import { set } from 'ember-metal';
 import { LinkComponent } from '../../utils/helpers';
@@ -174,5 +174,19 @@ moduleFor('Link-to component with query-params', class extends ApplicationTest {
         content: 'Index'
       });
     });
+  }
+});
+
+moduleFor('Link-to component', class extends RenderingTest {
+  ['@test should be able to be inserted in DOM when the router is not present - block']() {
+    this.render(`{{#link-to 'index'}}Go to Index{{/link-to}}`);
+
+    this.assertText('Go to Index');
+  }
+
+  ['@test should be able to be inserted in DOM when the router is not present - inline']() {
+    this.render(`{{link-to 'Go to Index' 'index'}}`);
+
+    this.assertText('Go to Index');
   }
 });

--- a/packages/ember-routing/lib/services/routing.js
+++ b/packages/ember-routing/lib/services/routing.js
@@ -48,13 +48,17 @@ export default Service.extend({
   },
 
   generateURL(routeName, models, queryParams) {
+    let router = get(this, 'router');
+    // return early when the router microlib is not present, which is the case for {{link-to}} in integration tests
+    if (!router._routerMicrolib) { return; }
+
     let visibleQueryParams = {};
     if (queryParams) {
       assign(visibleQueryParams, queryParams);
       this.normalizeQueryParams(routeName, models, visibleQueryParams);
     }
 
-    return get(this, 'router').generate(routeName, ...models, { queryParams: visibleQueryParams });
+    return router.generate(routeName, ...models, { queryParams: visibleQueryParams });
   },
 
   isActiveForRoute(contexts, queryParams, routeName, routerState, isCurrentWhenSpecified) {


### PR DESCRIPTION
Fixes #15831

Fixes a regression introduced by #15788 by returning early again from `routing.generateURL()` when `router._routerMicrolib` is not present. [This is the line](https://github.com/emberjs/ember.js/pull/15788/files#diff-f0eec040f8686d2b0ddec02e3eeab6e4L55) that got lost during the refactoring.

Was not able to write a regression test for this, as e.g. in [this test](https://github.com/emberjs/ember.js/blob/master/packages/ember-glimmer/tests/integration/components/link-to-test.js#L18-L24) `_routerMicrolib` is correctly setup, so was not able to write a failing test. If there is a way to setup the router in the same state as in integration tests (i.e. without `_routerMicrolib`), then I would be happy for any hint! 😉

Would be nice to get this into a minor beta release, as this is causing failing tests in ember-try scenarios for ember-beta now (was already failing for canary, but these were "allowed" failures. Now that canary has been promoted to beta, this is causing failed builds).

cc @rwjblue @bekzod  