### PR TITLE
[BUGFIX] Ensure findBy works for key with dot.

### DIFF
--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -49,8 +49,8 @@ function iter(key, value) {
   let valueProvided = arguments.length === 2;
 
   return valueProvided ?
-    (item)=> value === get(item, key) :
-    (item)=> !!get(item, key);
+    (item)=> value === item[key] :
+    (item)=> !!item[key];
 }
 
 /**


### PR DESCRIPTION
Ensure `Ember.findBy()` works for keys with dot. 

``` javascript
let arr = [
 { canada: [....] },
 { 'u.s.a.': [....] }
];
Ember.get(arr, 'u.s.a'); // returns `undefined`
```
Ember get() assumes this as a path, since the key has dot.

To solve this, we have two options, 
1. Revert the  `get(obj, key)` usage here.
2. Add additional validations to get method.

The second option is little complicated and it disturbs the default behavior of get method for path lookup. 