### PR TITLE
[BUGFIX] Ensure findBy works for key with dot notation.

### DIFF
--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -60,7 +60,7 @@ export function get(obj, keyName) {
 
   if (isDescriptor) {
     return value.get(obj, keyName);
-  } else if (isPath(keyName)) {
+  } else if (isPath(keyName) && !(keyName in obj)) {
     return _getPath(obj, keyName);
   } else if (value === undefined && 'object' === typeof obj && !(keyName in obj) &&
     typeof obj.unknownProperty === 'function') {

--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -47,10 +47,12 @@ function pushCtx(ctx) {
 
 function iter(key, value) {
   let valueProvided = arguments.length === 2;
-
-  return valueProvided ?
-    (item)=> value === get(item, key) :
-    (item)=> !!get(item, key);
+  let i = (item => {
+    let itemVal = item[key];
+    let cur = itemVal === undefined ? get(item, key) : itemVal;
+    return valueProvided ? value === cur : !!cur;
+  });
+  return i;
 }
 
 /**

--- a/packages/ember-runtime/tests/suites/enumerable/find.js
+++ b/packages/ember-runtime/tests/suites/enumerable/find.js
@@ -102,4 +102,33 @@ suite.test('should return first undefined property match', function() {
   equal(obj.findBy('bar', undefined), ary[1], 'findBy(\'bar\', undefined)');
 });
 
+suite.test('findBy keyName with dot and as path', function() {
+  let obj = {};
+  let arrWithPath = [
+    { id: 1, foo: { bar: true } },
+    { id: 2, foo: { bar: false } }
+  ];
+  let arrWithDotKey = [
+      { id: 1, foo: { bar: true } },
+      { id: 2, foo: { bar: false }, 'bar.baz': true }
+  ];
+  let arrWithDotKeyAndPath = [
+      { id: 1, foo: { bar: true } },
+      { id: 2, foo: { bar: true } },
+      { id: 3, foo: { bar: false }, 'foo.bar': 'baz' }
+  ];
+
+  obj = this.newObject(arrWithPath);
+  let fooBarAsPath = obj.findBy('foo.bar');
+  equal(fooBarAsPath, arrWithPath[0], 'works for keyName as path');
+
+  obj = this.newObject(arrWithDotKey);
+  let fooBarWithDotKey = obj.findBy('bar.baz');
+  equal(fooBarWithDotKey, arrWithDotKey[1], 'works for keyName with dot');
+
+  obj = this.newObject(arrWithDotKeyAndPath);
+  let fooBarWithDotAndPath = obj.findBy('foo.bar', 'baz');
+  equal(fooBarWithDotAndPath, arrWithDotKeyAndPath[2], 'works for keyName as path also with dot');
+});
+
 export default suite;


### PR DESCRIPTION
Ensure `Ember.findBy()` works for keys with dot. 

``` javascript
let arr = [
 { canada: [....] },
 { 'u.s.a.': [....] }
];
Ember.get(arr, 'u.s.a'); // returns `undefined`
```
Ember get() assumes this as a path, since the key has dot.

To solve this, we have two options, 
1. Revert the  `get(obj, key)` usage here.
2. Add additional validations to get method.

The second option is little complicated and it disturbs the default behavior of get method for path lookup. 