### PR TITLE
[CLEANUP] Remove _actions functionality

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -2447,33 +2447,6 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     }, 'Attempting to inject an unknown injection: \'service:missingService\'');
   }
 
-  ['@test can access `actions` hash via `_actions` [DEPRECATED]']() {
-    let component;
-
-    function derp() { }
-
-    this.registerComponent('foo-bar', {
-      ComponentClass: Component.extend({
-        init() {
-          this._super(...arguments);
-          component = this;
-        },
-
-        actions: {
-          derp
-        }
-      })
-    });
-
-    this.render('{{foo-bar}}');
-
-    this.assert.strictEqual(component.actions.derp, derp);
-
-    expectDeprecation(() => {
-      this.assert.strictEqual(component._actions.derp, derp);
-    }, 'Usage of `_actions` is deprecated, use `actions` instead.');
-  }
-
   ['@test throws if `this._super` is not called from `init`']() {
     this.registerComponent('foo-bar', {
       ComponentClass: Component.extend({

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -237,6 +237,7 @@ function mergeMixins(mixins, meta, descs, values, base, keys) {
     if (props === CONTINUE) { continue; }
 
     if (props) {
+      // remove willMergeMixin after 3.4 as it was used for _actions
       if (base.willMergeMixin) { base.willMergeMixin(props); }
       concats = concatenatedMixinProperties('concatenatedProperties', props, values, base);
       mergings = concatenatedMixinProperties('mergedProperties', props, values, base);

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -18,8 +18,7 @@ import {
   Object as EmberObject,
   A as emberA,
   Evented,
-  ActionHandler,
-  deprecateUnderscoreActions
+  ActionHandler
 } from 'ember-runtime';
 import generateController from './generate_controller';
 import {
@@ -2199,8 +2198,6 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     }
   }
 });
-
-deprecateUnderscoreActions(Route);
 
 Route.reopenClass({
   isRouteFactory: true

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -203,55 +203,6 @@ QUnit.test('.send just calls an action if the routers internal router property i
   equal(undefined, route.send('nonexistent', 1, 2, 3));
 });
 
-QUnit.test('can access `actions` hash via `_actions` [DEPRECATED]', function() {
-  expect(2);
-
-  let route = EmberRoute.extend({
-    actions: {
-      foo: function() {
-        ok(true, 'called foo action');
-      }
-    }
-  }).create();
-
-  expectDeprecation(function() {
-    route._actions.foo();
-  }, 'Usage of `_actions` is deprecated, use `actions` instead.');
-});
-
-QUnit.test('actions in both `_actions` and `actions` results in an assertion', function() {
-  expectAssertion(function() {
-    EmberRoute.extend({
-      _actions: { },
-      actions: { }
-    }).create();
-  }, 'Specifying `_actions` and `actions` in the same mixin is not supported.');
-});
-
-QUnit.test('actions added via `_actions` can be used [DEPRECATED]', function() {
-  expect(3);
-
-  let route;
-  expectDeprecation(function() {
-    route = EmberRoute.extend({
-      _actions: {
-        bar: function() {
-          ok(true, 'called bar action');
-        }
-      }
-    }, {
-      actions: {
-        foo: function() {
-          ok(true, 'called foo action');
-        }
-      }
-    }).create();
-  }, 'Specifying actions in `_actions` is deprecated, please use `actions` instead.');
-
-  route.send('foo');
-  route.send('bar');
-});
-
 QUnit.module('Ember.Route serialize', {
   setup: setup,
   teardown: teardown

--- a/packages/ember-runtime/lib/controllers/controller.js
+++ b/packages/ember-runtime/lib/controllers/controller.js
@@ -2,7 +2,6 @@ import { assert } from 'ember-debug';
 import EmberObject from '../system/object';
 import Mixin from '../mixins/controller';
 import { createInjectionHelper } from '../inject';
-import { deprecateUnderscoreActions } from '../mixins/action_handler';
 
 /**
 @module @ember/controller
@@ -15,8 +14,6 @@ import { deprecateUnderscoreActions } from '../mixins/action_handler';
   @public
 */
 const Controller = EmberObject.extend(Mixin);
-
-deprecateUnderscoreActions(Controller);
 
 function controllerInjectionHelper(factory) {
   assert(

--- a/packages/ember-runtime/lib/index.js
+++ b/packages/ember-runtime/lib/index.js
@@ -29,8 +29,7 @@ export { default as ObjectProxy } from './system/object_proxy';
 export { default as CoreObject } from './system/core_object';
 export { default as NativeArray, A } from './system/native_array';
 export {
-  default as ActionHandler,
-  deprecateUnderscoreActions
+  default as ActionHandler
 } from './mixins/action_handler';
 export { default as Copyable } from './mixins/copyable';
 export { default as Enumerable } from './mixins/enumerable';

--- a/packages/ember-runtime/lib/mixins/action_handler.js
+++ b/packages/ember-runtime/lib/mixins/action_handler.js
@@ -210,9 +210,7 @@ const ActionHandler = Mixin.create({
       );
       target.send(...arguments);
     }
-  },
-
-  willMergeMixin() {}
+  }
 });
 
 export default ActionHandler;

--- a/packages/ember-runtime/lib/mixins/action_handler.js
+++ b/packages/ember-runtime/lib/mixins/action_handler.js
@@ -212,38 +212,7 @@ const ActionHandler = Mixin.create({
     }
   },
 
-  willMergeMixin(props) {
-    assert('Specifying `_actions` and `actions` in the same mixin is not supported.', !props.actions || !props._actions);
-
-    if (props._actions) {
-      deprecate(
-        'Specifying actions in `_actions` is deprecated, please use `actions` instead.',
-        false,
-        { id: 'ember-runtime.action-handler-_actions', until: '3.0.0' }
-      );
-
-      props.actions = props._actions;
-      delete props._actions;
-    }
-  }
+  willMergeMixin() {}
 });
 
 export default ActionHandler;
-
-export function deprecateUnderscoreActions(factory) {
-  Object.defineProperty(factory.prototype, '_actions', {
-    configurable: true,
-    enumerable: false,
-    set(value) {
-      assert(`You cannot set \`_actions\` on ${this}, please use \`actions\` instead.`);
-    },
-    get() {
-      deprecate(
-        `Usage of \`_actions\` is deprecated, use \`actions\` instead.`,
-        false,
-        { id: 'ember-runtime.action-handler-_actions', until: '3.0.0' }
-      );
-      return get(this, 'actions');
-    }
-  });
-}

--- a/packages/ember-runtime/tests/controllers/controller_test.js
+++ b/packages/ember-runtime/tests/controllers/controller_test.js
@@ -9,22 +9,6 @@ import { buildOwner } from 'internal-test-helpers';
 
 QUnit.module('Controller event handling');
 
-QUnit.test('can access `actions` hash via `_actions` [DEPRECATED]', function() {
-  expect(2);
-
-  let controller = Controller.extend({
-    actions: {
-      foo: function() {
-        ok(true, 'called foo action');
-      }
-    }
-  }).create();
-
-  expectDeprecation(function() {
-    controller._actions.foo();
-  }, 'Usage of `_actions` is deprecated, use `actions` instead.');
-});
-
 QUnit.test('Action can be handled by a function on actions object', function() {
   expect(1);
   let TestController = Controller.extend({

--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -1,8 +1,7 @@
 import {
   ActionHandler,
   Evented,
-  FrameworkObject,
-  deprecateUnderscoreActions
+  FrameworkObject
 } from 'ember-runtime';
 import { initViewElement } from '../system/utils';
 import { cloneStates, states } from './states';
@@ -78,8 +77,6 @@ const CoreView = FrameworkObject.extend(Evented, ActionHandler, {
     return typeof this[name] === 'function' || this._super(name);
   }
 });
-
-deprecateUnderscoreActions(CoreView);
 
 CoreView.reopenClass({
   isViewFactory: true


### PR DESCRIPTION
Along with related deprecations, asserts, and tests.

Related: [ember-2-legacy PR](https://github.com/emberjs/ember-2-legacy/pull/17)

Apart of: #15876 