### PR TITLE
Update Backburner.js to 2.0.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "babel-plugin-transform-proto-to-assign": "^6.23.0",
     "babel-template": "^6.24.1",
-    "backburner.js": "^1.3.1",
+    "backburner.js": "^2.0.0",
     "broccoli-babel-transpiler": "^6.1.1",
     "broccoli-concat": "^3.2.2",
     "broccoli-debug": "^0.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -908,9 +908,9 @@ backbone@^1.1.2:
   dependencies:
     underscore ">=1.8.3"
 
-backburner.js@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-1.3.1.tgz#f89ebd433063693f2ab13b6f8a3427fefc31cdcf"
+backburner.js@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-2.0.0.tgz#ca78f7357776e24885f4dd4a887249b35fdd9c6c"
 
 backo2@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Updates to require native Map (aka drops IE < 10 and phantomjs support).