### PR TITLE
[Cleanup] Remove orphaned outlets

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -1488,12 +1488,11 @@ function appendLiveRoute(liveRoutes, defaultParentState, renderOptions) {
     set(target.outlets, renderOptions.outlet, myState);
   } else {
     if (renderOptions.into) {
-      let orphanedOutletsDeprecation = `Rendering into a {{render}} helper that resolves to an {{outlet}} is deprecated.`;
       if (ENV._ENABLE_ORPHANED_OUTLETS_SUPPORT !== true) {
-        assert(orphanedOutletsDeprecation);
+        assert(`Rendering into a {{render}} helper that resolves to an {{outlet}} is no longer supported.`);
       } else {
         deprecate(
-          orphanedOutletsDeprecation,
+          `Rendering into a {{render}} helper that resolves to an {{outlet}} is deprecated.`,
           false,
           {
             id: 'ember-routing.top-level-render-helper',

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -36,6 +36,7 @@ import {
 } from '../utils';
 import RouterState from './router_state';
 import { DEBUG } from 'ember-env-flags';
+import { ENV } from 'ember-environment';
 
 /**
 @module @ember/routing
@@ -1487,23 +1488,28 @@ function appendLiveRoute(liveRoutes, defaultParentState, renderOptions) {
     set(target.outlets, renderOptions.outlet, myState);
   } else {
     if (renderOptions.into) {
-      deprecate(
-        `Rendering into a {{render}} helper that resolves to an {{outlet}} is deprecated.`,
-        false,
-        {
-          id: 'ember-routing.top-level-render-helper',
-          until: '3.0.0',
-          url: 'https://emberjs.com/deprecations/v2.x/#toc_rendering-into-a-render-helper-that-resolves-to-an-outlet'
-        }
-      );
+      let orphanedOutletsDeprecation = `Rendering into a {{render}} helper that resolves to an {{outlet}} is deprecated.`;
+      if (ENV._ENABLE_ORPHANED_OUTLETS_SUPPORT !== true) {
+        assert(orphanedOutletsDeprecation);
+      } else {
+        deprecate(
+          orphanedOutletsDeprecation,
+          false,
+          {
+            id: 'ember-routing.top-level-render-helper',
+            until: '3.0.0',
+            url: 'https://emberjs.com/deprecations/v2.x/#toc_rendering-into-a-render-helper-that-resolves-to-an-outlet'
+          }
+        );
 
-      // Megahax time. Post-3.0-breaking-changes, we will just assert
-      // right here that the user tried to target a nonexistent
-      // thing. But for now we still need to support the `render`
-      // helper, and people are allowed to target templates rendered
-      // by the render helper. So instead we defer doing anyting with
-      // these orphan renders until afterRender.
-      appendOrphan(liveRoutes, renderOptions.into, myState);
+        // Megahax time. Post-3.0-breaking-changes, we will just assert
+        // right here that the user tried to target a nonexistent
+        // thing. But for now we still need to support the `render`
+        // helper, and people are allowed to target templates rendered
+        // by the render helper. So instead we defer doing anyting with
+        // these orphan renders until afterRender.
+        appendOrphan(liveRoutes, renderOptions.into, myState);
+      }
     } else {
       liveRoutes = myState;
     }

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1477,8 +1477,24 @@ QUnit.test('Route should tear down multiple outlets', function(assert) {
   assert.equal(jQuery('div.posts-footer:contains(postsFooter)', '#qunit-fixture').length, 0, 'The posts/footer template was removed');
 });
 
+QUnit.test('Route will assert if you try to explicitly render {into: ...} a {{render}} helper that resolves to an {{outlet}}', function() {
+
+  Router.map(function() {
+    this.route('home', { path: '/' });
+  });
+
+  App.HomeRoute = Route.extend({
+    renderTemplate() {
+      this.render({ into: 'nonexistent' });
+    }
+  });
+
+  expectAssertion(() => bootApplication(), 'Rendering into a {{render}} helper that resolves to an {{outlet}} is deprecated.');
+});
+
 
 QUnit.test('Route will assert if you try to explicitly render {into: ...} a missing template', function() {
+  ENV._ENABLE_ORPHANED_OUTLETS_SUPPORT = true;
   expectDeprecation(/Rendering into a {{render}} helper that resolves to an {{outlet}} is deprecated./);
 
   Router.map(function() {
@@ -2630,6 +2646,7 @@ QUnit.test('Allows any route to disconnectOutlet another route\'s templates', fu
 });
 
 QUnit.test('Can this.render({into:...}) the render helper', function(assert) {
+  ENV._ENABLE_ORPHANED_OUTLETS_SUPPORT = true;
   expectDeprecation(/Rendering into a {{render}} helper that resolves to an {{outlet}} is deprecated./);
 
   expectDeprecation(() => {
@@ -2662,6 +2679,7 @@ QUnit.test('Can this.render({into:...}) the render helper', function(assert) {
 });
 
 QUnit.test('Can disconnect from the render helper', function(assert) {
+  ENV._ENABLE_ORPHANED_OUTLETS_SUPPORT = true;
   expectDeprecation(/Rendering into a {{render}} helper that resolves to an {{outlet}} is deprecated./);
 
   expectDeprecation(() => {
@@ -2692,6 +2710,7 @@ QUnit.test('Can disconnect from the render helper', function(assert) {
 });
 
 QUnit.test('Can this.render({into:...}) the render helper\'s children', function(assert) {
+  ENV._ENABLE_ORPHANED_OUTLETS_SUPPORT = true;
   expectDeprecation(/Rendering into a {{render}} helper that resolves to an {{outlet}} is deprecated./);
 
   expectDeprecation(() => {
@@ -2726,6 +2745,7 @@ QUnit.test('Can this.render({into:...}) the render helper\'s children', function
 });
 
 QUnit.test('Can disconnect from the render helper\'s children', function(assert) {
+  ENV._ENABLE_ORPHANED_OUTLETS_SUPPORT = true;
   expectDeprecation(/Rendering into a {{render}} helper that resolves to an {{outlet}} is deprecated./);
 
   expectDeprecation(() => {
@@ -2758,6 +2778,7 @@ QUnit.test('Can disconnect from the render helper\'s children', function(assert)
 });
 
 QUnit.test('Can this.render({into:...}) nested render helpers', function(assert) {
+  ENV._ENABLE_ORPHANED_OUTLETS_SUPPORT = true;
   expectDeprecation(/Rendering into a {{render}} helper that resolves to an {{outlet}} is deprecated./);
 
   expectDeprecation(() => {
@@ -2794,6 +2815,7 @@ QUnit.test('Can this.render({into:...}) nested render helpers', function(assert)
 });
 
 QUnit.test('Can disconnect from nested render helpers', function(assert) {
+  ENV._ENABLE_ORPHANED_OUTLETS_SUPPORT = true;
   expectDeprecation(/Rendering into a {{render}} helper that resolves to an {{outlet}} is deprecated./);
 
   expectDeprecation(() => {

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -31,7 +31,7 @@ import { compile } from 'ember-template-compiler';
 import { Application, Engine } from 'ember-application';
 import { Transition } from 'router';
 
-let Router, App, router, registry, container, originalLoggerError, originalRenderSupport;
+let Router, App, router, registry, container, originalLoggerError, originalRenderSupport, originalEnabledOrphanedOutletSupport;
 
 function bootApplication() {
   router = container.lookup('router:main');
@@ -89,6 +89,7 @@ QUnit.module('Basic Routing', {
 
       originalLoggerError = Logger.error;
       originalRenderSupport = ENV._ENABLE_RENDER_SUPPORT;
+      originalEnabledOrphanedOutletSupport = ENV._ENABLE_ORPHANED_OUTLETS_SUPPORT;
 
       ENV._ENABLE_RENDER_SUPPORT = true;
     });
@@ -102,6 +103,7 @@ QUnit.module('Basic Routing', {
       setTemplates({});
       Logger.error = originalLoggerError;
       ENV._ENABLE_RENDER_SUPPORT = originalRenderSupport;
+      ENV._ENABLE_ORPHANED_OUTLETS_SUPPORT = originalEnabledOrphanedOutletSupport;
     });
   }
 });
@@ -1489,7 +1491,7 @@ QUnit.test('Route will assert if you try to explicitly render {into: ...} a {{re
     }
   });
 
-  expectAssertion(() => bootApplication(), 'Rendering into a {{render}} helper that resolves to an {{outlet}} is deprecated.');
+  expectAssertion(() => bootApplication(), 'Rendering into a {{render}} helper that resolves to an {{outlet}} is no longer supported.');
 });
 
 


### PR DESCRIPTION
Addresses https://github.com/emberjs/ember.js/pull/15916#issuecomment-349135327. Best reviewed [with whitespace off](https://github.com/emberjs/ember.js/pull/15925/files?w=1)

The ember-2-legacy plugin provides the environment variable `_ENABLE_ORPHANED_OUTLETS_SUPPORT ` with https://github.com/emberjs/ember-2-legacy/pull/24.

Later if/when we decide to remove the code associated with this deprecation we can use https://github.com/emberjs/ember.js/pull/15916 to get an idea of what's needed.