### PR TITLE
[docs beta]Fix inheritance link for core view

### DIFF
--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -16,9 +16,9 @@ import { cloneStates, states } from './states';
 
   @class CoreView
   @namespace Ember
-  @extends Ember.Object
-  @deprecated Use `Ember.Component` instead.
-  @uses Ember.Evented
+  @extends EmberObject
+  @deprecated Use `Component` instead.
+  @uses Evented
   @uses Ember.ActionHandler
   @private
 */

--- a/yuidoc.json
+++ b/yuidoc.json
@@ -3,6 +3,7 @@
   "description": "The Ember API: a framework for building ambitious web applications",
   "url": "https://emberjs.com/",
   "options": {
+    "extension": ".js,.ts",
     "paths": [
       "packages/ember/lib",
       "packages/ember-utils/lib",


### PR DESCRIPTION
Fixes https://github.com/ember-learn/ember-api-docs/issues/404
as well as tells  yuidoc to compile ts files, which is necessary to get in for beta (as files are being converted over)