### PR TITLE
blueprints: Extend test framework detection to `ember-qunit` and `ember-mocha`

### DIFF
--- a/blueprints/test-framework-detector.js
+++ b/blueprints/test-framework-detector.js
@@ -11,8 +11,12 @@ module.exports = function(blueprint) {
     var type;
 
     var dependencies = this.project.dependencies();
-    if ('ember-cli-qunit' in dependencies) {
+    if ('ember-qunit' in dependencies || 'ember-cli-qunit' in dependencies) {
       type = 'qunit';
+
+    } else if ('ember-mocha' in dependencies) {
+      type = 'mocha-0.12';
+
     } else if ('ember-cli-mocha' in dependencies) {
       var checker = new VersionChecker({ root: this.project.root });
       if (fs.existsSync(this.path + '/mocha-0.12-files') && checker.for('ember-cli-mocha', 'npm').satisfies('>=0.12.0')) {
@@ -20,6 +24,7 @@ module.exports = function(blueprint) {
       } else {
         type = 'mocha';
       }
+
     } else {
       this.ui.writeLine('Couldn\'t determine test style - using QUnit');
       type = 'qunit';


### PR DESCRIPTION
because emberjs/ember-qunit#282 and emberjs/ember-mocha#173

@rwjblue should this be backported?