### PR TITLE
[CLEANUP canary] remove `guid` from `backburner`

### DIFF
--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -1,4 +1,3 @@
-import { GUID_KEY } from 'ember-utils';
 import { assert, isTesting } from 'ember-debug';
 import {
   onErrorTarget
@@ -18,7 +17,6 @@ function onEnd(current, next) {
 }
 
 const backburner = new Backburner(['sync', 'actions', 'destroy'], {
-  GUID_KEY,
   sync: {
     before: beginPropertyChanges,
     after: endPropertyChanges
@@ -138,7 +136,7 @@ run.join = function() {
         setup: Ember.run.bind(this, this.setupEditor)
       });
     }),
-    
+
     didInsertElement() {
       tinymce.init({
         selector: '#' + this.$().prop('id'),


### PR DESCRIPTION
`backburner 2.0.0` no longer supports `GUID_KEY` and relies on native `Map`