### PR TITLE
blueprints/component-test: Add RFC232 variants

### DIFF
--- a/blueprints/component-test/qunit-rfc-232-files/tests/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/qunit-rfc-232-files/tests/__testType__/__path__/__test__.js
@@ -1,0 +1,36 @@
+<% if (testType === 'integration') { %>import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('<%= friendlyTestDescription %>', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{<%= componentPathName %>}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      {{#<%= componentPathName %>}}
+        template block text
+      {{/<%= componentPathName %>}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});<% } else if (testType === 'unit') { %>import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('<%= friendlyTestDescription %>', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let component = this.owner.factoryFor('component:<%= componentPathName %>').create();
+    assert.ok(component);
+  });
+});<% } %>

--- a/blueprints/test-framework-detector.js
+++ b/blueprints/test-framework-detector.js
@@ -11,14 +11,22 @@ module.exports = function(blueprint) {
     var type;
 
     var dependencies = this.project.dependencies();
-    if ('ember-qunit' in dependencies || 'ember-cli-qunit' in dependencies) {
-      type = 'qunit';
+    if ('ember-qunit' in dependencies) {
+      type = 'qunit-rfc-232';
+
+    } else if ('ember-cli-qunit' in dependencies) {
+      let checker = new VersionChecker(this.project);
+      if (fs.existsSync(this.path + '/qunit-rfc-232-files') && checker.for('ember-cli-qunit', 'npm').gte('4.1.1')) {
+        type = 'qunit-rfc-232';
+      } else {
+        type = 'qunit';
+      }
 
     } else if ('ember-mocha' in dependencies) {
       type = 'mocha-0.12';
 
     } else if ('ember-cli-mocha' in dependencies) {
-      var checker = new VersionChecker({ root: this.project.root });
+      let checker = new VersionChecker(this.project);
       if (fs.existsSync(this.path + '/mocha-0.12-files') && checker.for('ember-cli-mocha', 'npm').satisfies('>=0.12.0')) {
         type = 'mocha-0.12';
       } else {

--- a/node-tests/blueprints/component-test.js
+++ b/node-tests/blueprints/component-test.js
@@ -805,6 +805,28 @@ describe('Acceptance: ember generate component', function() {
       }));
   });
 
+  it('component-test x-foo for RFC232', function() {
+    var args = ['component-test', 'x-foo'];
+
+    return emberNew()
+      .then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.1'))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/integration/components/x-foo-test.js'))
+          .to.equal(fixture('component-test/rfc232.js'));
+      }));
+  });
+
+  it('component-test x-foo --unit for RFC232', function() {
+    var args = ['component-test', 'x-foo', '--unit'];
+
+    return emberNew()
+      .then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.1'))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/components/x-foo-test.js'))
+          .to.equal(fixture('component-test/rfc232-unit.js'));
+      }));
+  });
+
   it('component-test x-foo for mocha', function() {
     var args = ['component-test', 'x-foo'];
 

--- a/node-tests/blueprints/component-test.js
+++ b/node-tests/blueprints/component-test.js
@@ -13,6 +13,7 @@ var chai = require('ember-cli-blueprint-test-helpers/chai');
 var expect = chai.expect;
 
 var generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
+var fixture = require('../helpers/file');
 
 describe('Acceptance: ember generate component', function() {
   setupTestHooks(this);
@@ -719,12 +720,7 @@ describe('Acceptance: ember generate component', function() {
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/integration/components/x-foo-test.js'))
-          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
-          .to.contain("import hbs from 'htmlbars-inline-precompile';")
-          .to.contain("moduleForComponent('x-foo'")
-          .to.contain("integration: true")
-          .to.contain("{{x-foo}}")
-          .to.contain("{{#x-foo}}");
+          .to.equal(fixture('component-test/default.js'));
       }));
   });
 
@@ -757,9 +753,7 @@ describe('Acceptance: ember generate component', function() {
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/unit/components/x-foo-test.js'))
-          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
-          .to.contain("moduleForComponent('x-foo'")
-          .to.contain("unit: true");
+          .to.equal(fixture('component-test/unit.js'));
       }));
   });
 
@@ -822,12 +816,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => generateFakePackageManifest('ember-cli-mocha', '0.11.0'))
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/integration/components/x-foo-test.js'))
-          .to.contain("import { describeComponent, it } from 'ember-mocha';")
-          .to.contain("import hbs from 'htmlbars-inline-precompile';")
-          .to.contain("describeComponent('x-foo', 'Integration | Component | x foo'")
-          .to.contain("integration: true")
-          .to.contain("{{x-foo}}")
-          .to.contain("{{#x-foo}}");
+          .to.equal(fixture('component-test/mocha.js'));
       }));
   });
 
@@ -842,9 +831,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => generateFakePackageManifest('ember-cli-mocha', '0.11.0'))
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/unit/components/x-foo-test.js'))
-          .to.contain("import { describeComponent, it } from 'ember-mocha';")
-          .to.contain("describeComponent('x-foo', 'Unit | Component | x foo")
-          .to.contain("unit: true");
+          .to.equal(fixture('component-test/mocha-unit.js'));
       }));
   });
 
@@ -859,14 +846,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => generateFakePackageManifest('ember-cli-mocha', '0.12.0'))
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/integration/components/x-foo-test.js'))
-          .to.contain("import { describe, it } from 'mocha';")
-          .to.contain("import { setupComponentTest } from 'ember-mocha';")
-          .to.contain("import hbs from 'htmlbars-inline-precompile';")
-          .to.contain("describe('Integration | Component | x foo'")
-          .to.contain("setupComponentTest('x-foo',")
-          .to.contain("integration: true")
-          .to.contain("{{x-foo}}")
-          .to.contain("{{#x-foo}}");
+          .to.equal(fixture('component-test/mocha-0.12.js'));
       }));
   });
 
@@ -881,11 +861,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => generateFakePackageManifest('ember-cli-mocha', '0.12.0'))
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/unit/components/x-foo-test.js'))
-          .to.contain("import { describe, it } from 'mocha';")
-          .to.contain("import { setupComponentTest } from 'ember-mocha';")
-          .to.contain("describe('Unit | Component | x foo'")
-          .to.contain("setupComponentTest('x-foo',")
-          .to.contain("unit: true");
+          .to.equal(fixture('component-test/mocha-0.12-unit.js'));
       }));
   });
 });

--- a/node-tests/fixtures/component-test/default.js
+++ b/node-tests/fixtures/component-test/default.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('x-foo', 'Integration | Component | x foo', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{x-foo}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#x-foo}}
+      template block text
+    {{/x-foo}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/node-tests/fixtures/component-test/mocha-0.12-unit.js
+++ b/node-tests/fixtures/component-test/mocha-0.12-unit.js
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupComponentTest } from 'ember-mocha';
+
+describe('Unit | Component | x foo', function() {
+  setupComponentTest('x-foo', {
+    // Specify the other units that are required for this test
+    // needs: ['component:foo', 'helper:bar'],
+    unit: true
+  });
+
+  it('renders', function() {
+    // creates the component instance
+    let component = this.subject();
+    // renders the component on the page
+    this.render();
+    expect(component).to.be.ok;
+    expect(this.$()).to.have.length(1);
+  });
+});

--- a/node-tests/fixtures/component-test/mocha-0.12.js
+++ b/node-tests/fixtures/component-test/mocha-0.12.js
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupComponentTest } from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+describe('Integration | Component | x foo', function() {
+  setupComponentTest('x-foo', {
+    integration: true
+  });
+
+  it('renders', function() {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
+    // Template block usage:
+    // this.render(hbs`
+    //   {{#x-foo}}
+    //     template content
+    //   {{/x-foo}}
+    // `);
+
+    this.render(hbs`{{x-foo}}`);
+    expect(this.$()).to.have.length(1);
+  });
+});

--- a/node-tests/fixtures/component-test/mocha-unit.js
+++ b/node-tests/fixtures/component-test/mocha-unit.js
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+import { describeComponent, it } from 'ember-mocha';
+
+describeComponent('x-foo', 'Unit | Component | x foo',
+  {
+    // Specify the other units that are required for this test
+    // needs: ['component:foo', 'helper:bar'],
+    unit: true
+  },
+  function() {
+    it('renders', function() {
+      // creates the component instance
+      let component = this.subject();
+      // renders the component on the page
+      this.render();
+      expect(component).to.be.ok;
+      expect(this.$()).to.have.length(1);
+    });
+  }
+);

--- a/node-tests/fixtures/component-test/mocha.js
+++ b/node-tests/fixtures/component-test/mocha.js
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import { describeComponent, it } from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+describeComponent('x-foo', 'Integration | Component | x foo',
+  {
+    integration: true
+  },
+  function() {
+    it('renders', function() {
+      // Set any properties with this.set('myProperty', 'value');
+      // Handle any actions with this.on('myAction', function(val) { ... });
+      // Template block usage:
+      // this.render(hbs`
+      //   {{#x-foo}}
+      //     template content
+      //   {{/x-foo}}
+      // `);
+
+      this.render(hbs`{{x-foo}}`);
+      expect(this.$()).to.have.length(1);
+    });
+  }
+);

--- a/node-tests/fixtures/component-test/rfc232-unit.js
+++ b/node-tests/fixtures/component-test/rfc232-unit.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Component | x foo', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let component = this.owner.factoryFor('component:x-foo').create();
+    assert.ok(component);
+  });
+});

--- a/node-tests/fixtures/component-test/rfc232.js
+++ b/node-tests/fixtures/component-test/rfc232.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | x foo', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{x-foo}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      {{#x-foo}}
+        template block text
+      {{/x-foo}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});

--- a/node-tests/fixtures/component-test/unit.js
+++ b/node-tests/fixtures/component-test/unit.js
@@ -1,0 +1,16 @@
+import { moduleForComponent, test } from 'ember-qunit';
+
+moduleForComponent('x-foo', 'Unit | Component | x foo', {
+  // Specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar'],
+  unit: true
+});
+
+test('it renders', function(assert) {
+  
+  // Creates the component instance
+  /*let component =*/ this.subject();
+  // Renders the component to the page
+  this.render();
+  assert.equal(this.$().text().trim(), '');
+});


### PR DESCRIPTION
Addresses the `component-test` and test framework detector parts of https://github.com/emberjs/ember.js/issues/15933

/cc @rwjblue @alexander-alvarez 