### PR TITLE
[BUGFIX lts] blueprints: fix framework detection to work with prerelease versions of ember-cli-mocha

### DIFF
--- a/blueprints/test-framework-detector.js
+++ b/blueprints/test-framework-detector.js
@@ -27,7 +27,7 @@ module.exports = function(blueprint) {
 
     } else if ('ember-cli-mocha' in dependencies) {
       let checker = new VersionChecker(this.project);
-      if (fs.existsSync(this.path + '/mocha-0.12-files') && checker.for('ember-cli-mocha', 'npm').satisfies('>=0.12.0')) {
+      if (fs.existsSync(this.path + '/mocha-0.12-files') && checker.for('ember-cli-mocha', 'npm').gte('0.12.0')) {
         type = 'mocha-0.12';
       } else {
         type = 'mocha';


### PR DESCRIPTION
`semver.satisfies` does not cover prerelease versions like `*.*.*-beta` as required, so use `gte`

cc @Turbo87 