### PR TITLE
[BUGFIX beta] assert that `classNameBinding` items are non-empty strings

### DIFF
--- a/packages/ember-glimmer/lib/component-managers/curly.ts
+++ b/packages/ember-glimmer/lib/component-managers/curly.ts
@@ -412,12 +412,12 @@ export function validatePositionalParameters(named: NamedArguments, positional: 
 }
 
 export function processComponentInitializationAssertions(component: Component, props: any) {
-  assert(`classNameBindings must be strings: ${component}`, (() => {
+  assert(`classNameBindings must be non-empty strings: ${component}`, (() => {
     let { classNameBindings } = component;
     for (let i = 0; i < classNameBindings.length; i++) {
       let binding = classNameBindings[i];
 
-      if (typeof binding !== 'string') {
+      if (typeof binding !== 'string' || binding.length === 0) {
         return false;
       }
     }

--- a/packages/ember-glimmer/tests/integration/components/class-bindings-test.js
+++ b/packages/ember-glimmer/tests/integration/components/class-bindings-test.js
@@ -297,14 +297,28 @@ moduleFor('ClassNameBindings integration', class extends RenderingTest {
     let FooBarComponent = Component.extend({
       foo: 'foo',
       bar: 'bar',
-      classNameBindings: ['foo', ,'bar'] // eslint-disable-line no-sparse-arrays
+      classNameBindings: ['foo', , 'bar'] // eslint-disable-line no-sparse-arrays
     });
 
     this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: 'hello' });
 
     expectAssertion(() => {
       this.render('{{foo-bar}}');
-    }, /classNameBindings must be strings/);
+    }, /classNameBindings must be non-empty strings/);
+  }
+
+  ['@test it asserts that items must be non-empty strings']() {
+    let FooBarComponent = Component.extend({
+      foo: 'foo',
+      bar: 'bar',
+      classNameBindings: ['foo', '', 'bar']
+    });
+
+    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: 'hello' });
+
+    expectAssertion(() => {
+      this.render('{{foo-bar}}');
+    }, /classNameBindings must be non-empty strings/);
   }
 
   ['@test it can set class name bindings in the constructor']() {


### PR DESCRIPTION
This is a follow-up to a PR by @GavinJoyce (https://github.com/emberjs/ember.js/pull/15924)

`classNameBinding` items are now asserted to be strings, but can still be empty strings.

This PR fixes that, and asserts that empty strings are caught.