### PR TITLE
blueprints/mixin-test: Added RFC-232 variant

### DIFF
--- a/blueprints/mixin-test/qunit-rfc-232-files/tests/unit/mixins/__name__-test.js
+++ b/blueprints/mixin-test/qunit-rfc-232-files/tests/unit/mixins/__name__-test.js
@@ -1,0 +1,12 @@
+import EmberObject from '@ember/object';
+import <%= classifiedModuleName %>Mixin from '<%= projectName %>/mixins/<%= dasherizedModuleName %>';
+import { module, test } from 'qunit';
+
+module('<%= friendlyTestName %>', function() {
+  // Replace this with your real tests.
+  test('it works', function (assert) {
+    let <%= classifiedModuleName %>Object = EmberObject.extend(<%= classifiedModuleName %>Mixin);
+    let subject = <%= classifiedModuleName %>Object.create();
+    assert.ok(subject);
+  });
+});

--- a/node-tests/blueprints/mixin-test-test.js
+++ b/node-tests/blueprints/mixin-test-test.js
@@ -9,6 +9,7 @@ const modifyPackages = blueprintHelpers.modifyPackages;
 const chai = require('ember-cli-blueprint-test-helpers/chai');
 const expect = chai.expect;
 
+const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
 const fixture = require('../helpers/fixture');
 
 describe('Blueprint: mixin-test', function() {
@@ -38,6 +39,19 @@ describe('Blueprint: mixin-test', function() {
         return emberGenerateDestroy(['mixin-test', 'foo'], _file => {
           expect(_file('tests/unit/mixins/foo-test.js'))
             .to.equal(fixture('mixin-test/mocha.js'));
+        });
+      });
+    });
+
+    describe('with ember-cli-qunit@4.1.1', function() {
+      beforeEach(function() {
+        generateFakePackageManifest('ember-cli-qunit', '4.1.1');
+      });
+
+      it('mixin-test foo', function() {
+        return emberGenerateDestroy(['mixin-test', 'foo'], _file => {
+          expect(_file('tests/unit/mixins/foo-test.js'))
+            .to.equal(fixture('mixin-test/rfc232.js'));
         });
       });
     });

--- a/node-tests/fixtures/mixin-test/rfc232.js
+++ b/node-tests/fixtures/mixin-test/rfc232.js
@@ -1,0 +1,12 @@
+import EmberObject from '@ember/object';
+import FooMixin from 'my-app/mixins/foo';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | foo', function() {
+  // Replace this with your real tests.
+  test('it works', function (assert) {
+    let FooObject = EmberObject.extend(FooMixin);
+    let subject = FooObject.create();
+    assert.ok(subject);
+  });
+});


### PR DESCRIPTION
Progress for #15933 

A couple of things I am not sure about: 

- I wasn't sure whether the `setupTest` call is needed for mixing test (no setup was required before) and the codemod from https://github.com/rwjblue/ember-qunit-codemod didn't add it. I added it anyway, it looks logical after reading the RFC a couple of times. 

- and also there's an addon version of this blueprint. Should there also be an updated version for rfc232 for that as well ? 

P.S. Sorry If the questions are stupid. I am still learning how all this works under the hood.