### PR TITLE
remove leftovers from leveraging native `WeakMap`s

### DIFF
--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -23,7 +23,6 @@ export {
   getDispatchOverride
 } from './error_handler';
 export {
-  META_DESC,
   meta,
   peekMeta,
   deleteMeta

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -411,18 +411,6 @@ for (let name in listenerMethods) {
   Meta.prototype[name] = listenerMethods[name];
 }
 
-export const META_DESC = {
-  writable: true,
-  configurable: true,
-  enumerable: false,
-  value: null
-};
-
-const EMBER_META_PROPERTY = {
-  name: META_FIELD,
-  descriptor: META_DESC
-};
-
 if (MANDATORY_SETTER) {
   Meta.prototype.readInheritedValue = function(key, subkey) {
     let internalKey = `_${key}`;
@@ -455,9 +443,8 @@ if (MANDATORY_SETTER) {
   };
 }
 
-
-let getPrototypeOf = Object.getPrototypeOf;
-let metaStore = new WeakMap();
+const getPrototypeOf = Object.getPrototypeOf;
+const metaStore = new WeakMap();
 
 export function setMeta(obj, meta) {
   if (DEBUG) {

--- a/packages/ember/lib/index.js
+++ b/packages/ember/lib/index.js
@@ -68,7 +68,6 @@ Ember.Instrumentation = {
 };
 
 Ember.Error = EmberDebug.Error;
-Ember.META_DESC = metal.META_DESC;
 Ember.meta = metal.meta;
 Ember.get = metal.get;
 Ember.getWithDefault = metal.getWithDefault;

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -53,7 +53,6 @@ QUnit.module('ember reexports');
   ['FEATURES', 'ember/features'],
   ['FEATURES.isEnabled', 'ember-debug', 'isFeatureEnabled'],
   ['Error', 'ember-debug'],
-  ['META_DESC', 'ember-metal'],
   ['meta', 'ember-metal'],
   ['get', 'ember-metal'],
   ['set', 'ember-metal'],


### PR DESCRIPTION
after merging #15878 `EMBER_META_PROPERTY` and `META_DESC` looks obsolete  