### PR TITLE
Allow to define only setter in computed property

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -21,6 +21,8 @@ import {
 
 const DEEP_EACH_REGEX = /\.@each\.[^.]+\./;
 
+function noop() {}
+
 /**
   A computed property transforms an object literal with object's accessor function(s) into a property.
 
@@ -138,11 +140,12 @@ class ComputedProperty extends Descriptor {
       this._getter = config;
     } else {
       assert('computed expects a function or an object as last argument.', typeof config === 'object' && !Array.isArray(config));
-      assert('Config object passed to computed can only contain `get` or `set` keys.', Object.keys(config).every((key)=> key === 'get' || key === 'set'));
-      this._getter = config.get;
+      assert('Config object passed to computed can only contain `get` and `set` keys.', Object.keys(config).every((key)=> key === 'get' || key === 'set'));
+      assert('Computed properties must receive a getter or a setter, you passed none.', !!config.get || !!config.set);
+      this._getter = config.get || noop;
       this._setter = config.set;
     }
-    assert('Computed properties must receive a getter or a setter, you passed none.', !!this._getter || !!this._setter);
+
     this._suspended = undefined;
     this._meta = undefined;
     this._volatile = false;

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -41,7 +41,7 @@ QUnit.test('computed properties defined with an object only allow `get` and `set
       set() {},
       other() {}
     });
-  }, 'Config object passed to computed can only contain `get` or `set` keys.');
+  }, 'Config object passed to computed can only contain `get` and `set` keys.');
 });
 
 if (EMBER_METAL_ES5_GETTERS) {
@@ -652,6 +652,20 @@ QUnit.test('setter can be omited', function(assert) {
   assert.ok(testObj.get('a') === '1');
   testObj.set('aInt', '123');
   assert.ok(testObj.get('aInt') === '123', 'cp has been updated too');
+});
+
+QUnit.test('getter can be omited', function(assert) {
+  let testObj = EmberObject.extend({
+    com: computed({
+      set(key, value) {
+        return value;
+      }
+    })
+  }).create();
+
+  assert.ok(testObj.get('com') === undefined);
+  testObj.set('com', '123');
+  assert.ok(testObj.get('com') === '123', 'cp has been updated');
 });
 
 QUnit.test('the return value of the setter gets cached', function(assert) {


### PR DESCRIPTION
This PR will fix issue: #15939 

Before when we tried to access undefined getter we got into this problem:
<img width="890" alt="screen shot 2017-12-09 at 11 32 24" src="https://user-images.githubusercontent.com/1469375/33794911-5ea31e80-dcd5-11e7-949c-549afc980a0b.png">
