### PR TITLE
[CLEANUP canary] remove leftovers from `injected-container` depreciation removal 

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -4,14 +4,11 @@ import { EMBER_MODULE_UNIFICATION } from 'ember/features';
 import { DEBUG } from 'ember-env-flags';
 import {
   dictionary,
-  symbol,
   setOwner,
   OWNER,
   assign,
   HAS_NATIVE_PROXY
 } from 'ember-utils';
-
-const CONTAINER_OVERRIDE = symbol('CONTAINER_OVERRIDE');
 
 /**
  A container used to instantiate and cache objects.
@@ -32,7 +29,6 @@ export default class Container {
     this.owner           = options.owner || null;
     this.cache           = dictionary(options.cache || null);
     this.factoryManagerCache = dictionary(options.factoryManagerCache || null);
-    this[CONTAINER_OVERRIDE] = undefined;
     this.isDestroyed = false;
 
     if (DEBUG) {


### PR DESCRIPTION
looks like `ember-application.injected-container` depreciation removal left some code behind 