### PR TITLE
[BUGFIX beta] assert that attributes passed to component don't have duplicate keys

### DIFF
--- a/packages/ember-glimmer/lib/utils/process-args.ts
+++ b/packages/ember-glimmer/lib/utils/process-args.ts
@@ -4,11 +4,17 @@ import { CapturedNamedArguments } from '@glimmer/runtime';
 import { ARGS } from '../component';
 import { ACTION } from '../helpers/action';
 import { UPDATE } from './references';
+import { DEBUG } from 'ember-env-flags';
+import { assert } from 'ember-debug';
 
 // ComponentArgs takes EvaluatedNamedArgs and converts them into the
 // inputs needed by CurlyComponents (attrs and props, with mutable
 // cells, etc).
 export function processComponentArgs(namedArgs: CapturedNamedArguments) {
+  if (DEBUG) {
+    processComponentArgsAssertions(namedArgs);
+  }
+
   let keys = namedArgs.names;
   let attrs = namedArgs.value();
   let props = Object.create(null);
@@ -34,6 +40,16 @@ export function processComponentArgs(namedArgs: CapturedNamedArguments) {
   props.attrs = attrs;
 
   return props;
+}
+
+export function processComponentArgsAssertions(namedArgs: CapturedNamedArguments) {
+  let keys = namedArgs.names;
+  let attrs = namedArgs.value();
+
+  if (keys.length !== Object.keys(attrs).length) {
+    let duplicateKey = keys.find((key, index) => keys.indexOf(key) !== index);
+    assert(`You are passing more than one attribute with key "${duplicateKey}"`);
+  }
 }
 
 const REF = symbol('REF');

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -195,6 +195,14 @@ moduleFor('Components test: curly components', class extends RenderingTest {
     }, /You cannot invoke a component with both 'id' and 'elementId' at the same time./);
   }
 
+  ['@test cannot pass attributes with duplicate keys'](assert) {
+    this.registerComponent('foo-bar', { template: '' });
+
+    expectAssertion(() => {
+      this.render('{{foo-bar foo="pizza" foo="burger" bar="pepperoni"}}');
+    }, /You are passing more than one attribute with key "foo"/);
+  }
+
   ['@test it can have a custom tagName']() {
     let FooBarComponent = Component.extend({
       tagName: 'foo-bar'


### PR DESCRIPTION
If we invoke a component as such:
```
{{foo-bar 
  foo="pizza"
  foo="burger
  bar="pepperoni"
}}
```
I think it'd be useful to raise an exception saying that some of the attributes passed have duplicate keys (`foo` in this case)