### PR TITLE
remove binding param in `changeProperties`

### DIFF
--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -235,13 +235,12 @@ function endPropertyChanges() {
 
   @method changeProperties
   @param {Function} callback
-  @param [binding]
   @private
 */
-function changeProperties(callback, binding) {
+function changeProperties(callback) {
   beginPropertyChanges();
   try {
-    callback.call(binding);
+    callback();
   } finally {
     endPropertyChanges();
   }


### PR DESCRIPTION
just throwing this for discussion, with availability of `arrow functions` and `Function.prototype.bind` I think `binding` param could be removed from `changeProperties` which will improve common case usage were `binding` is not supplied