### PR TITLE
[FEATURE ember-module-unification] Support name-spaced lookups

### DIFF
--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -6,6 +6,7 @@ import { DEBUG } from 'ember-env-flags';
 import { ENV } from 'ember-environment';
 
 const VALID_FULL_NAME_REGEXP = /^[^:]+:[^:]+$/;
+const MODULE_UNIFICATION_VALID_FULL_NAME_REGEXP = /^[^:]+:[^:]+(::[^:]+)?$/;
 const missingResolverFunctionsDeprecation = 'Passing a `resolver` function into a Registry is deprecated. Please pass in a Resolver object with a `resolve` method.';
 
 /**
@@ -547,7 +548,11 @@ export default class Registry {
   }
 
   isValidFullName(fullName) {
-    return VALID_FULL_NAME_REGEXP.test(fullName);
+    if(!EMBER_MODULE_UNIFICATION) {
+      return VALID_FULL_NAME_REGEXP.test(fullName);
+    }
+
+    return MODULE_UNIFICATION_VALID_FULL_NAME_REGEXP.test(fullName);
   }
 
   getInjections(fullName) {

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -680,4 +680,41 @@ if (EMBER_MODULE_UNIFICATION) {
         'The correct factory was stored in the cache with the correct key which includes the source.');
     }
   });
+
+  QUnit.test('The container can pass a namespaced path to factoryFor', function(assert) {
+    let PrivateComponent = factory();
+    let lookup = 'template:components/my-addon::my-input';
+    let registry = new Registry();
+    let resolveCount = 0;
+    registry.resolve = function(fullName) {
+      resolveCount++;
+      if (fullName === lookup) {
+        return PrivateComponent;
+      }
+    };
+
+    let container = registry.container();
+
+    assert.strictEqual(container.factoryFor(lookup).class, PrivateComponent, 'The correct factory was provided');
+    assert.strictEqual(container.factoryFor(lookup).class, PrivateComponent, 'The correct factory was provided again');
+    assert.equal(resolveCount, 1, 'resolve called only once and a cached factory was returned the second time');
+  });
+
+  QUnit.test('The container can pass a namespaced to lookup', function(assert) {
+    let PrivateComponent = factory();
+    let lookup = 'template:components/my-addon::my-input';
+    let registry = new Registry();
+    registry.resolve = function(fullName) {
+      if (fullName === lookup) {
+        return PrivateComponent;
+      }
+    };
+
+    let container = registry.container();
+
+    let result = container.lookup(lookup);
+    assert.ok(result instanceof PrivateComponent, 'The correct factory was provided');
+    assert.ok(container.cache[`template:components/my-addon::my-input`] instanceof PrivateComponent,
+       'The correct factory was stored in the cache with the correct key which includes the source.');
+  });
 }

--- a/packages/container/tests/registry_test.js
+++ b/packages/container/tests/registry_test.js
@@ -767,4 +767,26 @@ if (EMBER_MODULE_UNIFICATION) {
       assert.equal(resolveCount, 1, 'resolve called only once and a cached factory was returned the second time');
     }
   });
+
+  QUnit.test('The registry can pass a namespaced lookup to the resolver', function(assert) {
+    let PrivateComponent = factory();
+    let lookup = 'template:components/my-addon::my-input';
+    let resolveCount = 0;
+    let resolver = {
+      resolve(fullName) {
+        resolveCount++;
+        if (fullName === lookup) {
+          return PrivateComponent;
+        }
+      }
+    };
+    let registry = new Registry({ resolver });
+    registry.normalize = function(name) {
+      return name;
+    };
+
+    assert.strictEqual(registry.resolve(lookup), PrivateComponent, 'The correct factory was provided');
+    assert.strictEqual(registry.resolve(lookup), PrivateComponent, 'The correct factory was provided again');
+    assert.equal(resolveCount, 1, 'resolve called only once and a cached factory was returned the second time');
+  });
 }


### PR DESCRIPTION
To support module unification, Ember needs to be able to pass lookup strings that have an an addon namespace, for example, `"component::my-addon:my-input"`

Related PRs:
 * https://github.com/ember-cli/ember-resolver/pull/215
 * https://github.com/glimmerjs/glimmer-resolver/pull/20

Prior work: https://github.com/emberjs/ember.js/pull/15368

@mixonic 