### PR TITLE
Add internal "TBD" deprecations feature

### DIFF
--- a/packages/ember-debug/lib/deprecate.js
+++ b/packages/ember-debug/lib/deprecate.js
@@ -159,50 +159,53 @@ if (DEBUG) {
     @public
     @since 1.0.0
   */
-  deprecate = function deprecate(message, test, options) {
-    if (ENV._ENABLE_DEPRECATION_OPTIONS_SUPPORT !== true) {
-      assert(missingOptionsDeprecation, options && (options.id || options.until));
-      assert(missingOptionsIdDeprecation, options.id);
-      assert(missingOptionsUntilDeprecation, options.until);
+  deprecate = function deprecate(message, test, { id, until } = {}) {
+    if (ENV._ENABLE_DEPRECATION_OPTIONS_SUPPORT === true) {
+      // ember-2-legacy
+      if (!id && !until) {
+        deprecate(
+          missingOptionsDeprecation,
+          false,
+          {
+            id: 'ember-debug.deprecate-options-missing',
+            until: '3.0.0',
+            url: 'https://emberjs.com/deprecations/v2.x/#toc_ember-debug-function-options'
+          }
+        );
+      } else if (!id) {
+        deprecate(
+          missingOptionsIdDeprecation,
+          false,
+          {
+            id: 'ember-debug.deprecate-id-missing',
+            until: '3.0.0',
+            url: 'https://emberjs.com/deprecations/v2.x/#toc_ember-debug-function-options'
+          }
+        );
+      } else if (!until) {
+        deprecate(
+          missingOptionsUntilDeprecation,
+          false,
+          {
+            id: 'ember-debug.deprecate-until-missing',
+            until: '3.0.0',
+            url: 'https://emberjs.com/deprecations/v2.x/#toc_ember-debug-function-options'
+          }
+        );
+      }
+    } else {
+      if (!id && !until) {
+        assert(missingOptionsDeprecation);
+      } else if (!id) {
+        assert(missingOptionsIdDeprecation);
+      } else if (!until) {
+        assert(missingOptionsUntilDeprecation);
+      }
     }
 
-    if ((!options || (!options.id && !options.until)) && ENV._ENABLE_DEPRECATION_OPTIONS_SUPPORT === true) {
-      deprecate(
-        missingOptionsDeprecation,
-        false,
-        {
-          id: 'ember-debug.deprecate-options-missing',
-          until: '3.0.0',
-          url: 'https://emberjs.com/deprecations/v2.x/#toc_ember-debug-function-options'
-        }
-      );
+    if (until !== 'TBD' || ENV._ENABLE_TBD_DEPRECATIONS === true) {
+      invoke('deprecate', ...arguments);
     }
-
-    if (options && !options.id && ENV._ENABLE_DEPRECATION_OPTIONS_SUPPORT === true) {
-      deprecate(
-        missingOptionsIdDeprecation,
-        false,
-        {
-          id: 'ember-debug.deprecate-id-missing',
-          until: '3.0.0',
-          url: 'https://emberjs.com/deprecations/v2.x/#toc_ember-debug-function-options'
-        }
-      );
-    }
-
-    if (options && !options.until && ENV._ENABLE_DEPRECATION_OPTIONS_SUPPORT === true) {
-      deprecate(
-        missingOptionsUntilDeprecation,
-        options && options.until,
-        {
-          id: 'ember-debug.deprecate-until-missing',
-          until: '3.0.0',
-          url: 'https://emberjs.com/deprecations/v2.x/#toc_ember-debug-function-options'
-        }
-      );
-    }
-
-    invoke('deprecate', ...arguments);
   };
 }
 

--- a/packages/ember-debug/tests/main_test.js
+++ b/packages/ember-debug/tests/main_test.js
@@ -24,6 +24,7 @@ let originalEnvValue;
 let originalDeprecateHandler;
 let originalWarnOptions;
 let originalDeprecationOptions;
+let originalTBD;
 
 QUnit.module('ember-debug', {
   setup() {
@@ -31,9 +32,12 @@ QUnit.module('ember-debug', {
     originalDeprecateHandler = HANDLERS.deprecate;
     originalWarnOptions = ENV._ENABLE_WARN_OPTIONS_SUPPORT;
     originalDeprecationOptions = ENV._ENABLE_DEPRECATION_OPTIONS_SUPPORT;
+    originalTBD = ENV._ENABLE_TBD_DEPRECATIONS;
 
     ENV.RAISE_ON_DEPRECATION = true;
-    ENV._ENABLE_DEPRECATION_OPTIONS_SUPPORT = true;
+    ENV._ENABLE_WARN_OPTIONS_SUPPORT = undefined;
+    ENV._ENABLE_DEPRECATION_OPTIONS_SUPPORT = undefined;
+    ENV._ENABLE_TBD_DEPRECATIONS = undefined;
   },
 
   teardown() {
@@ -42,6 +46,7 @@ QUnit.module('ember-debug', {
     ENV.RAISE_ON_DEPRECATION = originalEnvValue;
     ENV._ENABLE_WARN_OPTIONS_SUPPORT = originalWarnOptions;
     ENV._ENABLE_DEPRECATION_OPTIONS_SUPPORT = originalDeprecationOptions;
+    ENV._ENABLE_TBD_DEPRECATIONS = originalTBD;
   }
 });
 
@@ -209,6 +214,8 @@ QUnit.test('Ember.deprecate does not throw a deprecation at log and silence leve
 QUnit.test('Ember.deprecate without options triggers a deprecation', function(assert) {
   assert.expect(4);
 
+  ENV._ENABLE_DEPRECATION_OPTIONS_SUPPORT = true;
+
   registerHandler(function(message) {
     if (message === missingOptionsDeprecation) {
       assert.ok(true, 'proper deprecation is triggered when options is missing');
@@ -223,7 +230,6 @@ QUnit.test('Ember.deprecate without options triggers a deprecation', function(as
 
 QUnit.test('Ember.deprecate without options triggers an assertion', function(assert) {
   expect(2);
-  ENV._ENABLE_DEPRECATION_OPTIONS_SUPPORT = false;
 
   assert.throws(
     () => deprecate('foo'),
@@ -242,6 +248,8 @@ QUnit.test('Ember.deprecate without options triggers an assertion', function(ass
 QUnit.test('Ember.deprecate without options.id triggers a deprecation', function(assert) {
   assert.expect(2);
 
+  ENV._ENABLE_DEPRECATION_OPTIONS_SUPPORT = true;
+
   registerHandler(function(message) {
     if (message === missingOptionsIdDeprecation) {
       assert.ok(true, 'proper deprecation is triggered when options.id is missing');
@@ -255,7 +263,6 @@ QUnit.test('Ember.deprecate without options.id triggers a deprecation', function
 
 QUnit.test('Ember.deprecate without options.id triggers an assertion', function(assert) {
   expect(1);
-  ENV._ENABLE_DEPRECATION_OPTIONS_SUPPORT = false;
 
   assert.throws(
     () => deprecate('foo', false, { until: 'forever' }),
@@ -266,6 +273,8 @@ QUnit.test('Ember.deprecate without options.id triggers an assertion', function(
 
 QUnit.test('Ember.deprecate without options.until triggers a deprecation', function(assert) {
   assert.expect(2);
+
+  ENV._ENABLE_DEPRECATION_OPTIONS_SUPPORT = true;
 
   registerHandler(function(message) {
     if (message === missingOptionsUntilDeprecation) {
@@ -280,12 +289,28 @@ QUnit.test('Ember.deprecate without options.until triggers a deprecation', funct
 
 QUnit.test('Ember.deprecate without options.until triggers an assertion', function(assert) {
   expect(1);
-  ENV._ENABLE_DEPRECATION_OPTIONS_SUPPORT = false;
 
   assert.throws(
     () => deprecate('foo', false, { id: 'test' }),
     new RegExp(missingOptionsUntilDeprecation),
     'proper assertion is triggered when options.until is missing'
+  );
+});
+
+QUnit.test('Ember.deprecate with TBD is ignored', function(assert) {
+  expect(0);
+  deprecate('foo', false, { id: 'test', until: 'TBD' });
+});
+
+
+QUnit.test('Ember.deprecate with TBD can be enabled in tests', function(assert) {
+  expect(1);
+
+  ENV._ENABLE_TBD_DEPRECATIONS = true;
+
+  assert.throws(
+    () => deprecate('foo', false, { id: 'test', until: 'TBD' }),
+    'TBD assertions should be triggered when explictly enabled'
   );
 });
 

--- a/packages/ember-glimmer/tests/integration/application/engine-test.js
+++ b/packages/ember-glimmer/tests/integration/application/engine-test.js
@@ -6,6 +6,7 @@ import { Component } from 'ember-glimmer';
 import { Engine } from 'ember-application';
 import { Route, Router } from 'ember-routing';
 import { run } from 'ember-metal';
+import { EMBER_GLIMMER_NAMED_ARGUMENTS } from 'ember/features';
 
 moduleFor('Application test: engine rendering', class extends ApplicationTest {
   get routerOptions() {
@@ -182,7 +183,7 @@ moduleFor('Application test: engine rendering', class extends ApplicationTest {
       init() {
         this._super(...arguments);
         this.register('template:components/foo-bar', compile(`{{partial "troll"}}`));
-        this.register('template:troll', compile('{{attrs.wat}}'));
+        this.register('template:troll', EMBER_GLIMMER_NAMED_ARGUMENTS ? compile('{{@wat}}') : compile('{{attrs.wat}}'));
         this.register('controller:application', Controller.extend({
           contextType: 'Engine'
         }));

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -24,6 +24,7 @@ import {
   styles
 } from '../../utils/test-helpers';
 import {
+  EMBER_GLIMMER_NAMED_ARGUMENTS,
   MANDATORY_SETTER
 } from 'ember/features';
 
@@ -1066,6 +1067,10 @@ moduleFor('Components test: curly components', class extends RenderingTest {
   }
 
   ['@test non-block with properties on attrs']() {
+    if (EMBER_GLIMMER_NAMED_ARGUMENTS) {
+      expectDeprecation('Accessing `attrs.someProp` is deprecated, use `@someProp` instead.');
+    }
+
     this.registerComponent('non-block', {
       template: 'In layout - someProp: {{attrs.someProp}}'
     });
@@ -1259,6 +1264,8 @@ moduleFor('Components test: curly components', class extends RenderingTest {
   }
 
   ['@feature(ember-glimmer-named-arguments) this.attrs.foo === attrs.foo === @foo === foo']() {
+    expectDeprecation('Accessing `attrs.value` is deprecated, use `@value` instead.');
+
     this.registerComponent('foo-bar', {
       template: strip`
         Args: {{this.attrs.value}} | {{attrs.value}} | {{@value}} | {{value}}
@@ -1351,6 +1358,10 @@ moduleFor('Components test: curly components', class extends RenderingTest {
   }
 
   ['@test block with properties on attrs']() {
+    if (EMBER_GLIMMER_NAMED_ARGUMENTS) {
+      expectDeprecation('Accessing `attrs.someProp` is deprecated, use `@someProp` instead.');
+    }
+
     this.registerComponent('with-block', {
       template: 'In layout - someProp: {{attrs.someProp}} - {{yield}}'
     });
@@ -3070,6 +3081,11 @@ moduleFor('Components test: curly components', class extends RenderingTest {
   }
 
   ['@test using attrs for positional params'](assert) {
+    if (EMBER_GLIMMER_NAMED_ARGUMENTS) {
+      expectDeprecation('Accessing `attrs.myVar` is deprecated, use `@myVar` instead.');
+      expectDeprecation('Accessing `attrs.myVar2` is deprecated, use `@myVar2` instead.');
+    }
+
     let MyComponent = Component.extend();
 
     this.registerComponent('foo-bar', {

--- a/packages/ember-glimmer/tests/integration/components/dynamic-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/dynamic-components-test.js
@@ -446,9 +446,9 @@ moduleFor('Components test: dynamic components', class extends RenderingTest {
   }
 
   ['@test nested component helpers'](assert) {
-    this.registerComponent('foo-bar', { template: 'yippie! {{attrs.location}} {{yield}}' });
-    this.registerComponent('baz-qux', { template: 'yummy {{attrs.location}} {{yield}}' });
-    this.registerComponent('corge-grault', { template: 'delicious {{attrs.location}} {{yield}}' });
+    this.registerComponent('foo-bar', { template: 'yippie! {{location}} {{yield}}' });
+    this.registerComponent('baz-qux', { template: 'yummy {{location}} {{yield}}' });
+    this.registerComponent('corge-grault', { template: 'delicious {{location}} {{yield}}' });
 
     this.render('{{#component componentName1 location=location}}{{#component componentName2 location=location}}arepas!{{/component}}{{/component}}', {
       componentName1: 'foo-bar',

--- a/packages/ember-glimmer/tests/integration/helpers/closure-action-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/closure-action-test.js
@@ -5,7 +5,10 @@ import {
   instrumentationSubscribe,
   instrumentationUnsubscribe
 } from 'ember-metal';
-import { EMBER_IMPROVED_INSTRUMENTATION } from 'ember/features';
+import {
+  EMBER_GLIMMER_NAMED_ARGUMENTS,
+  EMBER_IMPROVED_INSTRUMENTATION
+} from 'ember/features';
 import { RenderingTest, moduleFor } from '../../utils/test-case';
 import { strip } from '../../utils/abstract-test-case';
 import { Component, INVOKE } from '../../utils/helpers';
@@ -232,6 +235,10 @@ moduleFor('Helpers test: closure {{action}}', class extends RenderingTest {
   }
 
   ['@test [#12718] a nice error is shown when a bound action function is undefined and it is passed as attrs.foo']() {
+    if (EMBER_GLIMMER_NAMED_ARGUMENTS) {
+      expectDeprecation('Accessing `attrs.external-action` is deprecated, use `@external-action` instead.');
+    }
+
     this.registerComponent('inner-component', {
       template: '<button id="inner-button" {{action (action attrs.external-action)}}>Click me</button>'
     });
@@ -905,6 +912,10 @@ moduleFor('Helpers test: closure {{action}}', class extends RenderingTest {
   }
 
   ['@test action closure does not get auto-mut wrapped'](assert) {
+    if (EMBER_GLIMMER_NAMED_ARGUMENTS) {
+      expectDeprecation('Accessing `attrs.submit` is deprecated, use `@submit` instead.');
+    }
+
     let first = 'raging robert';
     let second = 'mild machty';
     let returnValue = 'butch brian';
@@ -972,6 +983,7 @@ moduleFor('Helpers test: closure {{action}}', class extends RenderingTest {
 
   ['@test action should be called within a run loop']() {
     let innerComponent;
+
     let capturedRunLoop;
 
     let InnerComponent = Component.extend({

--- a/packages/ember-template-compiler/lib/plugins/transform-attrs-into-args.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-attrs-into-args.js
@@ -1,3 +1,7 @@
+import { deprecate } from 'ember-debug';
+import { EMBER_GLIMMER_NAMED_ARGUMENTS } from 'ember/features';
+import calculateLocationDisplay from '../system/calculate-location-display';
+
 /**
  @module ember
 */
@@ -43,6 +47,13 @@ export default function transformAttrsIntoArgs(env) {
 
       PathExpression(node) {
         if (isAttrs(node, stack[stack.length - 1])) {
+          if (EMBER_GLIMMER_NAMED_ARGUMENTS) {
+            deprecate(deprecationMessage(env.meta.moduleName, node), false, {
+              id: 'ember-template-compiler.deprecate-attrs',
+              until: 'TBD'
+            });
+          }
+
           let path = b.path(node.original.substr(6));
           path.original = `@${path.original}`;
           path.data = true;
@@ -70,4 +81,13 @@ function isAttrs(node, symbols) {
   }
 
   return false;
+}
+
+function deprecationMessage(moduleName, node) {
+  let sourceInformation = calculateLocationDisplay(moduleName, node.loc);
+  let name = node.original.substr(6);
+  let original = `attrs.${name}`;
+  let preferred = `@${name}`;
+
+  return `Accessing \`${original}\` is deprecated, use \`${preferred}\` instead.`;
 }

--- a/tests/index.html
+++ b/tests/index.html
@@ -74,6 +74,7 @@
         }
 
         ENV['RAISE_ON_DEPRECATION'] = true;
+        ENV['_ENABLE_TBD_DEPRECATIONS'] = true;
       })();
     </script>
 


### PR DESCRIPTION
* [x] Added a "TBD" deprecation feature that allows the code paths to be flagged without rolling the deprecations out to users immediately. This is an internal, undocumented feature that is not intended to be used by libraries and apps (yet, should go through an RFC at least), and the API/implementation are subject to change.
* [x] Flagged `{{attrs.*}}` for future deprecation