### PR TITLE
Revert "[BUGFIX release] fix issue with unchaining ChainNodes"

### DIFF
--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -209,11 +209,8 @@ class ChainNode {
   remove(path) {
     let paths = this._paths;
     if (paths === undefined) { return; }
-
     if (paths[path] > 0) {
       paths[path]--;
-    } else {
-      return;
     }
 
     let key = firstKey(path);

--- a/packages/ember-runtime/tests/system/object/computed_test.js
+++ b/packages/ember-runtime/tests/system/object/computed_test.js
@@ -266,16 +266,3 @@ QUnit.test('Calling _super in apply outside the immediate function of a CP gette
 
   ok(emberGet(SubClass.create(), 'foo'), 'FOO', 'super value is fetched');
 });
-
-QUnit.test('observing computed.reads prop and overriding it in create() works', function() {
-  let Obj = EmberObject.extend({
-    name: computed.reads('model.name'),
-    nameDidChange: observer('name', function() {})
-  });
-
-  let obj1 = Obj.create({name: '1'});
-  let obj2 = Obj.create({name: '2'});
-
-  equal(obj1.get('name'), '1');
-  equal(obj2.get('name'), '2');
-});


### PR DESCRIPTION
Reverts emberjs/ember.js#15849

This is a serious bug and this doesn't actually fix the issue, some refactoring to ember-metal has caused overriding watch to issue unbalanced watch/unwatch calls.  It needs to be bisected.

I would like us to pause refactorings to ember-metal until this is properly root caused.