### PR TITLE
[docs release] Document run as a function, so that it shows in @ember/runloop

### DIFF
--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -50,10 +50,9 @@ const backburner = new Backburner(['sync', 'actions', 'destroy'], {
     // code to be executed within a RunLoop
   });
   ```
-
-  @class @ember/runloop
+  @method run
+  @for @ember/runloop
   @static
-  @constructor
   @param {Object} [target] target of method to call
   @param {Function|String} method Method to invoke.
     May be a function or a string. If you pass a string


### PR DESCRIPTION
Addresses https://github.com/ember-learn/ember-api-docs/issues/406

makes run a function under @ember/runloop as described in https://github.com/ember-cli/ember-rfc176-data/blob/master/mappings.json

![image](https://user-images.githubusercontent.com/3609063/33980769-e6fe0c0c-e06f-11e7-9e61-550707cc0edd.png)
