### PR TITLE
Revert "[BUGFIX release] fix issue with unchaining ChainNodes"

### DIFF
--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -209,11 +209,8 @@ class ChainNode {
   remove(path) {
     let paths = this._paths;
     if (paths === undefined) { return; }
-
     if (paths[path] > 0) {
       paths[path]--;
-    } else {
-      return;
     }
 
     let key = firstKey(path);


### PR DESCRIPTION
This reverts commit 1396becfc2f19045ae88b33888f46b102b3faf2f.

From @krisselden

> This is a serious bug and this doesn't actually fix the issue,
> some refactoring to ember-metal has caused overriding watch to
> issue unbalanced watch/unwatch calls. It needs to be bisected.