### PR TITLE
[WIP] Move CP descriptors into meta

### DIFF
--- a/packages/ember-glimmer/lib/component.ts
+++ b/packages/ember-glimmer/lib/component.ts
@@ -2,7 +2,6 @@ import { DirtyableTag } from '@glimmer/reference';
 import { readDOMAttr } from '@glimmer/runtime';
 import {
   assert,
-  deprecate,
 } from 'ember-debug';
 import {
   get,
@@ -590,9 +589,6 @@ const Component = CoreView.extend(
           return false;
         }
       )());
-
-      // tslint:disable-next-line:max-line-length
-      assert(`You cannot use a computed property for the component's \`tagName\` (${this}).`, !(this.tagName && this.tagName.isDescriptor));
     },
 
     rerender() {

--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -323,8 +323,10 @@ function lazyGet(obj, key) {
     return;
   }
 
+  let possibleDesc = meta !== undefined && meta.peekDescriptors(key);
+
   // Use `get` if the return value is an EachProxy or an uncacheable value.
-  if (isVolatile(obj[key])) {
+  if (isVolatile(possibleDesc)) {
     return get(obj, key);
   // Otherwise attempt to get the cached value of the computed property
   } else {

--- a/packages/ember-metal/lib/descriptor.js
+++ b/packages/ember-metal/lib/descriptor.js
@@ -1,4 +1,5 @@
-import { Descriptor as EmberDescriptor } from './properties';
+import { meta } from './meta';
+import { Descriptor as EmberDescriptor, defineProperty } from './properties';
 
 export default function descriptor(desc) {
   return new Descriptor(desc);
@@ -19,7 +20,17 @@ class Descriptor extends EmberDescriptor {
   }
 
   setup(obj, key) {
-    Object.defineProperty(obj, key, this.desc);
+    defineProperty(obj, key, this.desc);
+    // meta(obj).removeDescriptors(key);
+    // Object.defineProperty(obj, key, this.desc);
+  }
+
+  get(obj, key) {
+    return obj[key];
+  }
+
+  set(obj, key, value) {
+    return obj[key] = value;
   }
 
   teardown(obj, key) {

--- a/packages/ember-metal/lib/injected_property.js
+++ b/packages/ember-metal/lib/injected_property.js
@@ -1,5 +1,6 @@
 import { getOwner } from 'ember-utils';
 import { assert } from 'ember-debug';
+import { peekMeta } from './meta';
 import { ComputedProperty } from './computed';
 import { AliasedProperty } from './alias';
 import { Descriptor } from './properties';
@@ -28,7 +29,8 @@ export default function InjectedProperty(type, name) {
 }
 
 function injectedPropertyGet(keyName) {
-  let desc = this[keyName];
+  let meta = peekMeta(this);
+  let desc = meta !== undefined && meta.peekDescriptors(keyName);
   let owner = getOwner(this) || this.container; // fallback to `container` for backwards compat
 
   assert(`InjectedProperties should be defined with the inject computed property macros.`, desc && desc.isDescriptor && desc.type);

--- a/packages/ember-metal/lib/is_empty.js
+++ b/packages/ember-metal/lib/is_empty.js
@@ -49,15 +49,10 @@ export default function isEmpty(obj) {
     }
   }
 
-  if (typeof obj.length === 'number' && objectType !== 'function') {
-    return !obj.length;
-  }
+  let length = get(obj, 'length');
 
-  if (objectType === 'object') {
-    let length = get(obj, 'length');
-    if (typeof length === 'number') {
-      return !length;
-    }
+  if (typeof length === 'number' && objectType !== 'function') {
+    return !length;
   }
 
   return false;

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -46,6 +46,7 @@ export class Meta {
     }
 
     this._cache = undefined;
+    this._descriptors = undefined;
     this._watching = undefined;
     this._mixins = undefined;
     this._bindings = undefined;
@@ -319,6 +320,21 @@ export class Meta {
     return this._getInherited('_chains');
   }
 
+  writeDescriptors(subkey, value) {
+    assert(`Cannot update descriptors for \`${subkey}\` on \`${toString(this.source)}\` after it has been destroyed.`, !this.isMetaDestroyed());
+    let map = this._getOrCreateOwnMap('_descriptors');
+    map[subkey] = value;
+  }
+
+  peekDescriptors(subkey) {
+    let possibleDesc = this._findInherited('_descriptors', subkey);
+    return possibleDesc === UNDEFINED ? undefined : possibleDesc;
+  }
+
+  removeDescriptors(subkey) {
+    this.writeDescriptors(subkey, UNDEFINED);
+  }
+
   writeWatching(subkey, value) {
     assert(`Cannot update watchers for \`${subkey}\` on \`${toString(this.source)}\` after it has been destroyed.`, !this.isMetaDestroyed());
     let map = this._getOrCreateOwnMap('_watching');
@@ -326,7 +342,7 @@ export class Meta {
   }
 
   peekWatching(subkey) {
-   return this._findInherited('_watching', subkey);
+    return this._findInherited('_watching', subkey);
   }
 
   writeMixins(subkey, value) {

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -22,6 +22,7 @@ import {
   Descriptor,
   defineProperty
 } from './properties';
+import { get } from './property_get';
 import { ComputedProperty } from './computed';
 import { Binding } from './binding';
 import {
@@ -85,10 +86,7 @@ function giveDescriptorSuper(meta, key, property, values, descs, base) {
   // If we didn't find the original descriptor in a parent mixin, find
   // it on the original object.
   if (!superProperty) {
-    let possibleDesc = base[key];
-    let superDesc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
-
-    superProperty = superDesc;
+    superProperty = meta.peekDescriptors(key);
   }
 
   if (superProperty === undefined || !(superProperty instanceof ComputedProperty)) {
@@ -317,6 +315,13 @@ function updateObserversAndListeners(obj, key, paths, updateMethod) {
 }
 
 function replaceObserversAndListeners(obj, key, observerOrListener) {
+  let meta = peekMeta(obj);
+  let possibleDesc = meta && meta.peekDescriptors(key);
+
+  if (possibleDesc !== undefined) {
+    return;
+  }
+
   let prev = obj[key];
 
   if (typeof prev === 'function') {

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -51,10 +51,9 @@ function propertyWillChange(obj, keyName, _meta) {
   if (meta !== undefined && !meta.isInitialized(obj)) { return; }
 
   let watching = meta !== undefined && meta.peekWatching(keyName) > 0;
-  let possibleDesc = obj[keyName];
-  let isDescriptor = possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor;
+  let possibleDesc = meta !== undefined && meta.peekDescriptors(keyName);
 
-  if (isDescriptor && possibleDesc.willChange) {
+  if (possibleDesc !== undefined && possibleDesc.willChange) {
     possibleDesc.willChange(obj, keyName);
   }
 
@@ -88,11 +87,10 @@ function propertyDidChange(obj, keyName, _meta) {
 
   if (hasMeta && !meta.isInitialized(obj)) { return; }
 
-  let possibleDesc = obj[keyName];
-  let isDescriptor = possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor;
+  let possibleDesc = hasMeta && meta.peekDescriptors(keyName);
 
   // shouldn't this mean that we're watching this key?
-  if (isDescriptor && possibleDesc.didChange) {
+  if (possibleDesc !== undefined && possibleDesc.didChange) {
     possibleDesc.didChange(obj, keyName);
   }
 
@@ -169,10 +167,9 @@ function iterDeps(method, obj, depKey, seen, meta) {
   meta.forEachInDeps(depKey, (key, value) => {
     if (!value) { return; }
 
-    possibleDesc = obj[key];
-    isDescriptor = possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor;
+    possibleDesc = meta.peekDescriptors(key);
 
-    if (isDescriptor && possibleDesc._suspended === obj) {
+    if (possibleDesc !== undefined && possibleDesc._suspended === obj) {
       return;
     }
 

--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -49,12 +49,13 @@ export function set(obj, keyName, value, tolerant) {
     return setPath(obj, keyName, value, tolerant);
   }
 
-  let currentValue = obj[keyName];
-  let isDescriptor = currentValue !== null && typeof currentValue === 'object' && currentValue.isDescriptor;
+  let meta = peekMeta(obj);
+  let possibleDesc = meta && meta.peekDescriptors(keyName);
+  let currentValue;
 
-  if (isDescriptor) { /* computed property */
-    currentValue.set(obj, keyName, value);
-  } else if (currentValue === undefined && 'object' === typeof obj && !(keyName in obj) &&
+  if (possibleDesc !== undefined) { /* computed property */
+    possibleDesc.set(obj, keyName, value);
+  } else if ((currentValue = obj[keyName]) === undefined && 'object' === typeof obj && !(keyName in obj) &&
     typeof obj.setUnknownProperty === 'function') { /* unknown property */
     obj.setUnknownProperty(keyName, value);
   } else if (currentValue === value) { /* no change */

--- a/packages/ember-metal/lib/watch_key.js
+++ b/packages/ember-metal/lib/watch_key.js
@@ -21,10 +21,9 @@ export function watchKey(obj, keyName, _meta) {
   meta.writeWatching(keyName, count + 1);
 
   if (count === 0) { // activate watching first time
-    let possibleDesc = obj[keyName];
-    let isDescriptor = possibleDesc !== null &&
-      typeof possibleDesc === 'object' && possibleDesc.isDescriptor;
-    if (isDescriptor && possibleDesc.willWatch) { possibleDesc.willWatch(obj, keyName, meta); }
+    let possibleDesc = meta.peekDescriptors(keyName);
+
+    if (possibleDesc !== undefined && possibleDesc.willWatch) { possibleDesc.willWatch(obj, keyName, meta); }
 
     if (typeof obj.willWatchProperty === 'function') {
       obj.willWatchProperty(keyName);
@@ -92,9 +91,8 @@ export function unwatchKey(obj, keyName, _meta) {
   if (count === 1) {
     meta.writeWatching(keyName, 0);
 
-    let possibleDesc = obj[keyName];
-    let isDescriptor = possibleDesc !== null &&
-      typeof possibleDesc === 'object' && possibleDesc.isDescriptor;
+    let possibleDesc = meta.peekDescriptors(keyName);
+    let isDescriptor = possibleDesc !== undefined;
 
     if (isDescriptor && possibleDesc.didUnwatch) { possibleDesc.didUnwatch(obj, keyName, meta); }
 

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -44,6 +44,17 @@ QUnit.test('computed properties defined with an object only allow `get` and `set
   }, 'Config object passed to computed can only contain `get` or `set` keys.');
 });
 
+QUnit.test('accessing computed property without get is not allowed', assert => {
+  let obj = {};
+  let count = 0;
+  defineProperty(obj, 'foo', computed(function(key) {
+    count++;
+    return 'computed ' + key;
+  }));
+
+  expectAssertion(() => obj.foo, /You must use get\(\) to access the `foo` property/);
+  assert.strictEqual(count, 0, 'should not have invoked computed property');
+});
 
 QUnit.test('defining computed property should invoke property on get', function() {
   let obj = {};

--- a/packages/ember-runtime/lib/inject.js
+++ b/packages/ember-runtime/lib/inject.js
@@ -1,4 +1,4 @@
-import { InjectedProperty } from 'ember-metal';
+import { InjectedProperty, peekMeta } from 'ember-metal';
 import { assert } from 'ember-debug';
 
 /**
@@ -48,10 +48,16 @@ export function createInjectionHelper(type, validator) {
 */
 export function validatePropertyInjections(factory) {
   let proto = factory.proto();
+  let meta = peekMeta(proto);
+
+  if (meta === undefined) {
+    return true;
+  }
+
   let types = [];
 
   for (let key in proto) {
-    let desc = proto[key];
+    let desc = meta.peekDescriptors(key);
     if (desc instanceof InjectedProperty && types.indexOf(desc.type) === -1) {
       types.push(desc.type);
     }

--- a/packages/ember-utils/lib/inspect.js
+++ b/packages/ember-utils/lib/inspect.js
@@ -41,14 +41,18 @@ export default function inspect(obj) {
   let ret = [];
   for (let key in obj) {
     if (obj.hasOwnProperty(key)) {
-      v = obj[key];
-      if (v === 'toString') { continue; } // ignore useless items
-      if (typeof v === 'function') { v = 'function() { ... }'; }
+      try {
+        v = obj[key];
+        if (v === 'toString') { continue; } // ignore useless items
+        if (typeof v === 'function') { v = 'function() { ... }'; }
 
-      if (v && typeof v.toString !== 'function') {
-        ret.push(`${key}: ${objectToString.call(v)}`);
-      } else {
-        ret.push(`${key}: ${v}`);
+        if (v && typeof v.toString !== 'function') {
+          ret.push(`${key}: ${objectToString.call(v)}`);
+        } else {
+          ret.push(`${key}: ${v}`);
+        }
+      } catch(e) {
+        ret.push(`${key}: ${e}`);
       }
     }
   }

--- a/packages/ember-views/lib/mixins/class_names_support.js
+++ b/packages/ember-views/lib/mixins/class_names_support.js
@@ -2,7 +2,7 @@
 @module ember
 */
 
-import { Mixin } from 'ember-metal';
+import { Mixin, meta } from 'ember-metal';
 import { assert } from 'ember-debug';
 
 const EMPTY_ARRAY = Object.freeze([]);
@@ -18,8 +18,8 @@ export default Mixin.create({
   init() {
     this._super(...arguments);
 
-    assert(`Only arrays are allowed for 'classNameBindings'`, Array.isArray(this.classNameBindings));
-    assert(`Only arrays of static class strings are allowed for 'classNames'. For dynamic classes, use 'classNameBindings'.`, Array.isArray(this.classNames));
+    assert(`Only arrays are allowed for 'classNameBindings'`, meta(this).peekDescriptors('classNameBindings') === undefined && Array.isArray(this.classNameBindings));
+    assert(`Only arrays of static class strings are allowed for 'classNames'. For dynamic classes, use 'classNameBindings'.`, meta(this).peekDescriptors('classNames') === undefined && Array.isArray(this.classNames));
   },
 
   /**

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -1,5 +1,5 @@
 import { guidFor, getOwner } from 'ember-utils';
-import { descriptor, Mixin } from 'ember-metal';
+import { descriptor, meta, Mixin } from 'ember-metal';
 import { assert, deprecate } from 'ember-debug';
 import { environment, ENV } from 'ember-environment';
 import { matches } from '../system/utils';
@@ -405,6 +405,9 @@ export default Mixin.create({
   */
   init() {
     this._super(...arguments);
+
+    // tslint:disable-next-line:max-line-length
+    assert(`You cannot use a computed property for the component's \`tagName\` (${this}).`, meta(this).peekDescriptors('tagName') === undefined);
 
     if (!this.elementId && this.tagName !== '') {
       this.elementId = guidFor(this);


### PR DESCRIPTION
Opening this to run tests on CI (they are passing for me locally).

I don't plan to merge this as-is – I plan to do it a bit differently:

* [x] 1. ~~add an internal `descriptorFor` function that looks like this:~~ (#15989)
    ```js
    export function descriptorFor(obj, keyName, [optional] meta) {
      return obj[keyName];
    }
    ```
* [x] ~~2. change all the spot that assumes `possibleDesc = obj[keyName]` to use `descriptorFor`~~ (#15989)
* [ ] 3. move descriptors to meta and change the `descriptorFor` implementation
* [ ] 4. (in dev mode) leave a proxy in its place to assert 3rd-party usage of `obj[keyName].{get, isDescriptor, ...}`
* [ ] 5. add a flag to install a ES5 getter on the object