### PR TITLE
Introduce `descriptorFor`

### DIFF
--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -23,6 +23,7 @@ export {
   getDispatchOverride
 } from './error_handler';
 export {
+  descriptorFor,
   meta,
   peekMeta,
   deleteMeta

--- a/packages/ember-metal/lib/injected_property.js
+++ b/packages/ember-metal/lib/injected_property.js
@@ -3,6 +3,8 @@ import { assert } from 'ember-debug';
 import { ComputedProperty } from './computed';
 import { AliasedProperty } from './alias';
 import { Descriptor } from './properties';
+import { descriptorFor } from './meta';
+
 /**
  @module ember
  @private
@@ -28,10 +30,10 @@ export default function InjectedProperty(type, name) {
 }
 
 function injectedPropertyGet(keyName) {
-  let desc = this[keyName];
+  let desc = descriptorFor(this, keyName);
   let owner = getOwner(this) || this.container; // fallback to `container` for backwards compat
 
-  assert(`InjectedProperties should be defined with the inject computed property macros.`, desc && desc.isDescriptor && desc.type);
+  assert(`InjectedProperties should be defined with the inject computed property macros.`, desc && desc.type);
   assert(`Attempting to lookup an injected property on an object without a container, ensure that the object was instantiated via a container.`, owner);
 
   return owner.lookup(`${desc.type}:${desc.name || keyName}`);

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -533,4 +533,31 @@ export function meta(obj) {
   return newMeta;
 }
 
+/**
+  Returns the CP descriptor assocaited with `obj` and `keyName`, if any.
+
+  @method descriptorFor
+  @param {Object} obj the object to check
+  @param {String} keyName the key to check
+  @param {Object} [meta] the meta hash for the object (optional)
+  @return {Descriptor}
+  @private
+*/
+export function descriptorFor(obj, keyName, meta) {
+  let possibleDesc = obj[keyName];
+  return isDescriptor(possibleDesc) ? possibleDesc : undefined;
+}
+
+/**
+  Check whether a value is a CP descriptor.
+
+  @method descriptorFor
+  @param {any} possibleDesc the value to check
+  @return {boolean}
+  @private
+*/
+export function isDescriptor(possibleDesc) {
+  return possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor;
+}
+
 export { counters };

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -16,7 +16,7 @@ import {
   deprecate
 } from 'ember-debug';
 import { DEBUG } from 'ember-env-flags';
-import { meta as metaFor, peekMeta } from './meta';
+import { descriptorFor, meta as metaFor, peekMeta } from './meta';
 import expandProperties from './expand_properties';
 import {
   Descriptor,
@@ -85,10 +85,7 @@ function giveDescriptorSuper(meta, key, property, values, descs, base) {
   // If we didn't find the original descriptor in a parent mixin, find
   // it on the original object.
   if (!superProperty) {
-    let possibleDesc = base[key];
-    let superDesc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
-
-    superProperty = superDesc;
+    superProperty = descriptorFor(base, key, meta);
   }
 
   if (superProperty === undefined || !(superProperty instanceof ComputedProperty)) {

--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -3,7 +3,7 @@
 */
 
 import { assert } from 'ember-debug';
-import { meta as metaFor, peekMeta, UNDEFINED } from './meta';
+import { descriptorFor, meta as metaFor, peekMeta, UNDEFINED } from './meta';
 import { overrideChains } from './property_events';
 import { MANDATORY_SETTER } from 'ember/features';
 // ..........................................................
@@ -120,11 +120,10 @@ export function defineProperty(obj, keyName, desc, data, meta) {
 
   let watchEntry = meta.peekWatching(keyName);
   let watching = watchEntry !== undefined && watchEntry > 0;
-  let possibleDesc = obj[keyName];
-  let isDescriptor = possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor;
+  let previousDesc = descriptorFor(obj, keyName, meta);
 
-  if (isDescriptor) {
-    possibleDesc.teardown(obj, keyName, meta);
+  if (previousDesc) {
+    previousDesc.teardown(obj, keyName, meta);
   }
 
   let value;

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -1,5 +1,6 @@
 import { guidFor, symbol } from 'ember-utils';
 import {
+  descriptorFor,
   peekMeta
 } from './meta';
 import {
@@ -51,10 +52,9 @@ function propertyWillChange(obj, keyName, _meta) {
   if (meta !== undefined && !meta.isInitialized(obj)) { return; }
 
   let watching = meta !== undefined && meta.peekWatching(keyName) > 0;
-  let possibleDesc = obj[keyName];
-  let isDescriptor = possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor;
+  let possibleDesc = descriptorFor(obj, keyName, meta);
 
-  if (isDescriptor && possibleDesc.willChange) {
+  if (possibleDesc !== undefined && possibleDesc.willChange) {
     possibleDesc.willChange(obj, keyName);
   }
 
@@ -88,11 +88,10 @@ function propertyDidChange(obj, keyName, _meta) {
 
   if (hasMeta && !meta.isInitialized(obj)) { return; }
 
-  let possibleDesc = obj[keyName];
-  let isDescriptor = possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor;
+  let possibleDesc = descriptorFor(obj, keyName, meta);
 
   // shouldn't this mean that we're watching this key?
-  if (isDescriptor && possibleDesc.didChange) {
+  if (possibleDesc !== undefined && possibleDesc.didChange) {
     possibleDesc.didChange(obj, keyName);
   }
 
@@ -169,10 +168,9 @@ function iterDeps(method, obj, depKey, seen, meta) {
   meta.forEachInDeps(depKey, (key, value) => {
     if (!value) { return; }
 
-    possibleDesc = obj[key];
-    isDescriptor = possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor;
+    possibleDesc = descriptorFor(obj, key, meta);
 
-    if (isDescriptor && possibleDesc._suspended === obj) {
+    if (possibleDesc !== undefined && possibleDesc._suspended === obj) {
       return;
     }
 

--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -4,6 +4,7 @@
 
 import { assert } from 'ember-debug';
 import { isPath } from './path_cache';
+import { isDescriptor } from './meta';
 
 const ALLOWABLE_TYPES = {
   object: true,
@@ -55,10 +56,11 @@ export function get(obj, keyName) {
   assert(`'this' in paths is not supported`, keyName.lastIndexOf('this.', 0) !== 0);
   assert('Cannot call `Ember.get` with an empty string', keyName !== '');
 
+  // we can't use `descriptorFor` here because we don't want to access the property
+  // more than once (e.g. side-effectful ES5 getters, etc)
   let value = obj[keyName];
-  let isDescriptor = value !== null && typeof value === 'object' && value.isDescriptor;
 
-  if (isDescriptor) {
+  if (isDescriptor(value)) {
     return value.get(obj, keyName);
   } else if (isPath(keyName)) {
     return _getPath(obj, keyName);

--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -10,6 +10,7 @@ import {
   isPath
 } from './path_cache';
 import {
+  isDescriptor,
   peekMeta
 } from './meta';
 import { MANDATORY_SETTER } from 'ember/features';
@@ -49,10 +50,11 @@ export function set(obj, keyName, value, tolerant) {
     return setPath(obj, keyName, value, tolerant);
   }
 
+  // we can't use `descriptorFor` here because we don't want to access the property
+  // more than once (e.g. side-effectful ES5 getters, etc)
   let currentValue = obj[keyName];
-  let isDescriptor = currentValue !== null && typeof currentValue === 'object' && currentValue.isDescriptor;
 
-  if (isDescriptor) { /* computed property */
+  if (isDescriptor(currentValue)) { /* computed property */
     currentValue.set(obj, keyName, value);
   } else if (currentValue === undefined && 'object' === typeof obj && !(keyName in obj) &&
     typeof obj.setUnknownProperty === 'function') { /* unknown property */

--- a/packages/ember-metal/lib/watch_key.js
+++ b/packages/ember-metal/lib/watch_key.js
@@ -1,6 +1,7 @@
 import { lookupDescriptor } from 'ember-utils';
 import { MANDATORY_SETTER } from 'ember/features';
 import {
+  descriptorFor,
   meta as metaFor,
   peekMeta,
   UNDEFINED
@@ -21,10 +22,11 @@ export function watchKey(obj, keyName, _meta) {
   meta.writeWatching(keyName, count + 1);
 
   if (count === 0) { // activate watching first time
-    let possibleDesc = obj[keyName];
-    let isDescriptor = possibleDesc !== null &&
-      typeof possibleDesc === 'object' && possibleDesc.isDescriptor;
-    if (isDescriptor && possibleDesc.willWatch) { possibleDesc.willWatch(obj, keyName, meta); }
+    let possibleDesc = descriptorFor(obj, keyName, meta);
+
+    if (possibleDesc !== undefined && possibleDesc.willWatch) {
+      possibleDesc.willWatch(obj, keyName, meta);
+    }
 
     if (typeof obj.willWatchProperty === 'function') {
       obj.willWatchProperty(keyName);

--- a/packages/ember-runtime/lib/inject.js
+++ b/packages/ember-runtime/lib/inject.js
@@ -1,4 +1,4 @@
-import { InjectedProperty } from 'ember-metal';
+import { InjectedProperty, descriptorFor } from 'ember-metal';
 import { assert } from 'ember-debug';
 
 /**
@@ -51,7 +51,7 @@ export function validatePropertyInjections(factory) {
   let types = [];
 
   for (let key in proto) {
-    let desc = proto[key];
+    let desc = descriptorFor(proto, key);
     if (desc instanceof InjectedProperty && types.indexOf(desc.type) === -1) {
       types.push(desc.type);
     }


### PR DESCRIPTION
This abstracts away the fact that CP descriptors are stored on the prototypes currently, which should make it easier to move them into the meta.

Step 1 of #15984