### PR TITLE
[Cleanup] Convert container tests to new style

### DIFF
--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -1,686 +1,687 @@
 import { OWNER, assign } from 'ember-utils';
-import { get } from 'ember-metal';
 import { EMBER_MODULE_UNIFICATION } from 'ember/features';
 import { Registry } from '..';
-import { factory } from 'internal-test-helpers';
+import { factory, moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
-QUnit.module('Container');
+moduleFor('Container', class extends AbstractTestCase {
+  ['@test A registered factory returns the same instance each time'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+    let PostController = factory();
 
-QUnit.test('A registered factory returns the same instance each time', function() {
-  let registry = new Registry();
-  let container = registry.container();
-  let PostController = factory();
+    registry.register('controller:post', PostController);
 
-  registry.register('controller:post', PostController);
+    let postController = container.lookup('controller:post');
 
-  let postController = container.lookup('controller:post');
+    assert.ok(postController instanceof PostController, 'The lookup is an instance of the factory');
 
-  ok(postController instanceof PostController, 'The lookup is an instance of the factory');
+    assert.equal(postController, container.lookup('controller:post'));
+  }
 
-  equal(postController, container.lookup('controller:post'));
-});
+  ['@test uses create time injections if factory has no extend'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+    let AppleController = factory();
+    let PostController = factory();
 
-QUnit.test('uses create time injections if factory has no extend', function() {
-  let registry = new Registry();
-  let container = registry.container();
-  let AppleController = factory();
-  let PostController = factory();
+    PostController.extend = undefined; // remove extend
 
-  PostController.extend = undefined; // remove extend
+    registry.register('controller:apple', AppleController);
+    registry.register('controller:post', PostController);
+    registry.injection('controller:post', 'apple', 'controller:apple');
 
-  registry.register('controller:apple', AppleController);
-  registry.register('controller:post', PostController);
-  registry.injection('controller:post', 'apple', 'controller:apple');
+    let postController = container.lookup('controller:post');
 
-  let postController = container.lookup('controller:post');
+    assert.ok(postController.apple instanceof AppleController, 'instance receives an apple of instance AppleController');
+  }
 
-  ok(postController.apple instanceof AppleController, 'instance receives an apple of instance AppleController');
-});
+  ['@test A registered factory returns a fresh instance if singleton: false is passed as an option'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+    let PostController = factory();
 
-QUnit.test('A registered factory returns a fresh instance if singleton: false is passed as an option', function() {
-  let registry = new Registry();
-  let container = registry.container();
-  let PostController = factory();
+    registry.register('controller:post', PostController);
 
-  registry.register('controller:post', PostController);
+    let postController1 = container.lookup('controller:post');
+    let postController2 = container.lookup('controller:post', { singleton: false });
+    let postController3 = container.lookup('controller:post', { singleton: false });
+    let postController4 = container.lookup('controller:post');
 
-  let postController1 = container.lookup('controller:post');
-  let postController2 = container.lookup('controller:post', { singleton: false });
-  let postController3 = container.lookup('controller:post', { singleton: false });
-  let postController4 = container.lookup('controller:post');
+    assert.equal(postController1.toString(), postController4.toString(), 'Singleton factories looked up normally return the same value');
+    assert.notEqual(postController1.toString(), postController2.toString(), 'Singleton factories are not equal to factories looked up with singleton: false');
+    assert.notEqual(postController2.toString(), postController3.toString(), 'Two factories looked up with singleton: false are not equal');
+    assert.notEqual(postController3.toString(), postController4.toString(), 'A singleton factory looked up after a factory called with singleton: false is not equal');
 
-  equal(postController1.toString(), postController4.toString(), 'Singleton factories looked up normally return the same value');
-  notEqual(postController1.toString(), postController2.toString(), 'Singleton factories are not equal to factories looked up with singleton: false');
-  notEqual(postController2.toString(), postController3.toString(), 'Two factories looked up with singleton: false are not equal');
-  notEqual(postController3.toString(), postController4.toString(), 'A singleton factory looked up after a factory called with singleton: false is not equal');
+    assert.ok(postController1 instanceof PostController, 'All instances are instances of the registered factory');
+    assert.ok(postController2 instanceof PostController, 'All instances are instances of the registered factory');
+    assert.ok(postController3 instanceof PostController, 'All instances are instances of the registered factory');
+    assert.ok(postController4 instanceof PostController, 'All instances are instances of the registered factory');
+  }
 
-  ok(postController1 instanceof PostController, 'All instances are instances of the registered factory');
-  ok(postController2 instanceof PostController, 'All instances are instances of the registered factory');
-  ok(postController3 instanceof PostController, 'All instances are instances of the registered factory');
-  ok(postController4 instanceof PostController, 'All instances are instances of the registered factory');
-});
+  ['@test A factory type with a registered injection\'s instances receive that injection'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+    let PostController = factory();
+    let Store = factory();
 
-QUnit.test('A factory type with a registered injection\'s instances receive that injection', function() {
-  let registry = new Registry();
-  let container = registry.container();
-  let PostController = factory();
-  let Store = factory();
+    registry.register('controller:post', PostController);
+    registry.register('store:main', Store);
 
-  registry.register('controller:post', PostController);
-  registry.register('store:main', Store);
+    registry.typeInjection('controller', 'store', 'store:main');
 
-  registry.typeInjection('controller', 'store', 'store:main');
+    let postController = container.lookup('controller:post');
+    let store = container.lookup('store:main');
 
-  let postController = container.lookup('controller:post');
-  let store = container.lookup('store:main');
+    assert.equal(postController.store, store);
+  }
 
-  equal(postController.store, store);
-});
+  ['@test An individual factory with a registered injection receives the injection'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+    let PostController = factory();
+    let Store = factory();
 
-QUnit.test('An individual factory with a registered injection receives the injection', function() {
-  let registry = new Registry();
-  let container = registry.container();
-  let PostController = factory();
-  let Store = factory();
+    registry.register('controller:post', PostController);
+    registry.register('store:main', Store);
 
-  registry.register('controller:post', PostController);
-  registry.register('store:main', Store);
+    registry.injection('controller:post', 'store', 'store:main');
 
-  registry.injection('controller:post', 'store', 'store:main');
+    let postController = container.lookup('controller:post');
+    let store = container.lookup('store:main');
 
-  let postController = container.lookup('controller:post');
-  let store = container.lookup('store:main');
+    assert.equal(postController.store, store, 'has the correct store injected');
+  }
 
-  equal(postController.store, store, 'has the correct store injected');
-});
+  ['@test A factory with both type and individual injections'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+    let PostController = factory();
+    let Store = factory();
+    let Router = factory();
 
-QUnit.test('A factory with both type and individual injections', function() {
-  let registry = new Registry();
-  let container = registry.container();
-  let PostController = factory();
-  let Store = factory();
-  let Router = factory();
+    registry.register('controller:post', PostController);
+    registry.register('store:main', Store);
+    registry.register('router:main', Router);
 
-  registry.register('controller:post', PostController);
-  registry.register('store:main', Store);
-  registry.register('router:main', Router);
+    registry.injection('controller:post', 'store', 'store:main');
+    registry.typeInjection('controller', 'router', 'router:main');
 
-  registry.injection('controller:post', 'store', 'store:main');
-  registry.typeInjection('controller', 'router', 'router:main');
+    let postController = container.lookup('controller:post');
+    let store = container.lookup('store:main');
+    let router = container.lookup('router:main');
 
-  let postController = container.lookup('controller:post');
-  let store = container.lookup('store:main');
-  let router = container.lookup('router:main');
+    assert.equal(postController.store, store);
+    assert.equal(postController.router, router);
+  }
 
-  equal(postController.store, store);
-  equal(postController.router, router);
-});
+  ['@test A non-singleton instance is never cached'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+    let PostView = factory();
 
-QUnit.test('A non-singleton instance is never cached', function() {
-  let registry = new Registry();
-  let container = registry.container();
-  let PostView = factory();
+    registry.register('view:post', PostView, { singleton: false });
 
-  registry.register('view:post', PostView, { singleton: false });
+    let postView1 = container.lookup('view:post');
+    let postView2 = container.lookup('view:post');
 
-  let postView1 = container.lookup('view:post');
-  let postView2 = container.lookup('view:post');
+    assert.ok(postView1 !== postView2, 'Non-singletons are not cached');
+  }
 
-  ok(postView1 !== postView2, 'Non-singletons are not cached');
-});
+  ['@test A non-instantiated property is not instantiated'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
 
-QUnit.test('A non-instantiated property is not instantiated', function() {
-  let registry = new Registry();
-  let container = registry.container();
+    let template = function() {};
+    registry.register('template:foo', template, { instantiate: false });
+    assert.equal(container.lookup('template:foo'), template);
+  }
 
-  let template = function() {};
-  registry.register('template:foo', template, { instantiate: false });
-  equal(container.lookup('template:foo'), template);
-});
+  ['@test A failed lookup returns undefined']() {
+    let registry = new Registry();
+    let container = registry.container();
 
-QUnit.test('A failed lookup returns undefined', function() {
-  let registry = new Registry();
-  let container = registry.container();
+    equal(container.lookup('doesnot:exist'), undefined);
+  }
 
-  equal(container.lookup('doesnot:exist'), undefined);
-});
+  ['@test An invalid factory throws an error'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
 
-QUnit.test('An invalid factory throws an error', function() {
-  let registry = new Registry();
-  let container = registry.container();
+    registry.register('controller:foo', {});
 
-  registry.register('controller:foo', {});
+    assert.throws(() => {
+      container.lookup('controller:foo');
+    }, /Failed to create an instance of \'controller:foo\'/);
+  }
 
-  throws(() => {
-    container.lookup('controller:foo');
-  }, /Failed to create an instance of \'controller:foo\'/);
-});
+  ['@test Injecting a failed lookup raises an error'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
 
-QUnit.test('Injecting a failed lookup raises an error', function() {
-  let registry = new Registry();
-  let container = registry.container();
+    let fooInstance = {};
+    let fooFactory  = {};
 
-  let fooInstance = {};
-  let fooFactory  = {};
+    let Foo = {
+      create(args) { return fooInstance; },
+      extend(args) { return fooFactory;  }
+    };
 
-  let Foo = {
-    create(args) { return fooInstance; },
-    extend(args) { return fooFactory;  }
-  };
+    registry.register('model:foo', Foo);
+    registry.injection('model:foo', 'store', 'store:main');
 
-  registry.register('model:foo', Foo);
-  registry.injection('model:foo', 'store', 'store:main');
+    assert.throws(() => {
+      container.lookup('model:foo');
+    });
+  }
 
-  throws(() => {
-    container.lookup('model:foo');
-  });
-});
+  ['@test Injecting a falsy value does not raise an error'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+    let ApplicationController = factory();
 
-QUnit.test('Injecting a falsy value does not raise an error', function() {
-  let registry = new Registry();
-  let container = registry.container();
-  let ApplicationController = factory();
+    registry.register('controller:application', ApplicationController);
+    registry.register('user:current', null, { instantiate: false });
+    registry.injection('controller:application', 'currentUser', 'user:current');
 
-  registry.register('controller:application', ApplicationController);
-  registry.register('user:current', null, { instantiate: false });
-  registry.injection('controller:application', 'currentUser', 'user:current');
+    assert.strictEqual(container.lookup('controller:application').currentUser, null);
+  }
 
-  strictEqual(container.lookup('controller:application').currentUser, null);
-});
+  ['@test The container returns same value each time even if the value is falsy'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
 
-QUnit.test('The container returns same value each time even if the value is falsy', function() {
-  let registry = new Registry();
-  let container = registry.container();
+    registry.register('falsy:value', null, { instantiate: false });
 
-  registry.register('falsy:value', null, { instantiate: false });
+    assert.strictEqual(container.lookup('falsy:value'), container.lookup('falsy:value'));
+  }
 
-  strictEqual(container.lookup('falsy:value'), container.lookup('falsy:value'));
-});
+  ['@test Destroying the container destroys any cached singletons'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+    let PostController = factory();
+    let PostView = factory();
+    let template = function() {};
 
-QUnit.test('Destroying the container destroys any cached singletons', function() {
-  let registry = new Registry();
-  let container = registry.container();
-  let PostController = factory();
-  let PostView = factory();
-  let template = function() {};
+    registry.register('controller:post', PostController);
+    registry.register('view:post', PostView, { singleton: false });
+    registry.register('template:post', template, { instantiate: false });
 
-  registry.register('controller:post', PostController);
-  registry.register('view:post', PostView, { singleton: false });
-  registry.register('template:post', template, { instantiate: false });
+    registry.injection('controller:post', 'postView', 'view:post');
 
-  registry.injection('controller:post', 'postView', 'view:post');
+    let postController = container.lookup('controller:post');
+    let postView = postController.postView;
 
-  let postController = container.lookup('controller:post');
-  let postView = postController.postView;
+    assert.ok(postView instanceof PostView, 'The non-singleton was injected');
 
-  ok(postView instanceof PostView, 'The non-singleton was injected');
+    container.destroy();
 
-  container.destroy();
+    assert.ok(postController.isDestroyed, 'Singletons are destroyed');
+    assert.ok(!postView.isDestroyed, 'Non-singletons are not destroyed');
+  }
 
-  ok(postController.isDestroyed, 'Singletons are destroyed');
-  ok(!postView.isDestroyed, 'Non-singletons are not destroyed');
-});
+  ['@test The container can use a registry hook to resolve factories lazily'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+    let PostController = factory();
 
-QUnit.test('The container can use a registry hook to resolve factories lazily', function() {
-  let registry = new Registry();
-  let container = registry.container();
-  let PostController = factory();
-
-  registry.resolver = {
-    resolve(fullName) {
-      if (fullName === 'controller:post') {
-        return PostController;
+    registry.resolver = {
+      resolve(fullName) {
+        if (fullName === 'controller:post') {
+          return PostController;
+        }
       }
-    }
-  };
+    };
 
-  let postController = container.lookup('controller:post');
+    let postController = container.lookup('controller:post');
 
-  ok(postController instanceof PostController, 'The correct factory was provided');
-});
+    assert.ok(postController instanceof PostController, 'The correct factory was provided');
+  }
 
-QUnit.test('The container normalizes names before resolving', function() {
-  let registry = new Registry();
-  let container = registry.container();
-  let PostController = factory();
+  ['@test The container normalizes names before resolving'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+    let PostController = factory();
 
-  registry.normalizeFullName = function(fullName) {
-    return 'controller:post';
-  };
+    registry.normalizeFullName = function(fullName) {
+      return 'controller:post';
+    };
 
-  registry.register('controller:post', PostController);
-  let postController = container.lookup('controller:normalized');
+    registry.register('controller:post', PostController);
+    let postController = container.lookup('controller:normalized');
 
-  ok(postController instanceof PostController, 'Normalizes the name before resolving');
-});
+    assert.ok(postController instanceof PostController, 'Normalizes the name before resolving');
+  }
 
-QUnit.test('The container normalizes names when looking factory up', function() {
-  let registry = new Registry();
-  let container = registry.container();
-  let PostController = factory();
+  ['@test The container normalizes names when looking factory up'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+    let PostController = factory();
 
-  registry.normalizeFullName = function(fullName) {
-    return 'controller:post';
-  };
+    registry.normalizeFullName = function(fullName) {
+      return 'controller:post';
+    };
 
-  registry.register('controller:post', PostController);
-  let fact = container.factoryFor('controller:normalized');
+    registry.register('controller:post', PostController);
+    let fact = container.factoryFor('controller:normalized');
 
-  let factInstance = fact.create();
-  ok(factInstance instanceof PostController, 'Normalizes the name');
-});
+    let factInstance = fact.create();
+    assert.ok(factInstance instanceof PostController, 'Normalizes the name');
+  }
 
-QUnit.test('Options can be registered that should be applied to a given factory', function() {
-  let registry = new Registry();
-  let container = registry.container();
-  let PostView = factory();
+  ['@test Options can be registered that should be applied to a given factory'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+    let PostView = factory();
 
-  registry.resolver = {
-    resolve(fullName) {
-      if (fullName === 'view:post') {
-        return PostView;
+    registry.resolver = {
+      resolve(fullName) {
+        if (fullName === 'view:post') {
+          return PostView;
+        }
       }
-    }
-  };
+    };
 
-  registry.options('view:post', { instantiate: true, singleton: false });
+    registry.options('view:post', { instantiate: true, singleton: false });
 
-  let postView1 = container.lookup('view:post');
-  let postView2 = container.lookup('view:post');
+    let postView1 = container.lookup('view:post');
+    let postView2 = container.lookup('view:post');
 
-  ok(postView1 instanceof PostView, 'The correct factory was provided');
-  ok(postView2 instanceof PostView, 'The correct factory was provided');
+    assert.ok(postView1 instanceof PostView, 'The correct factory was provided');
+    assert.ok(postView2 instanceof PostView, 'The correct factory was provided');
 
-  ok(postView1 !== postView2, 'The two lookups are different');
-});
+    assert.ok(postView1 !== postView2, 'The two lookups are different');
+  }
 
-QUnit.test('Options can be registered that should be applied to all factories for a given type', function() {
-  let registry = new Registry();
-  let container = registry.container();
-  let PostView = factory();
+  ['@test Options can be registered that should be applied to all factories for a given type'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+    let PostView = factory();
 
-  registry.resolver = {
-    resolve(fullName) {
-      if (fullName === 'view:post') {
-        return PostView;
+    registry.resolver = {
+      resolve(fullName) {
+        if (fullName === 'view:post') {
+          return PostView;
+        }
       }
-    }
-  };
+    };
 
-  registry.optionsForType('view', { singleton: false });
+    registry.optionsForType('view', { singleton: false });
 
-  let postView1 = container.lookup('view:post');
-  let postView2 = container.lookup('view:post');
+    let postView1 = container.lookup('view:post');
+    let postView2 = container.lookup('view:post');
 
-  ok(postView1 instanceof PostView, 'The correct factory was provided');
-  ok(postView2 instanceof PostView, 'The correct factory was provided');
+    assert.ok(postView1 instanceof PostView, 'The correct factory was provided');
+    assert.ok(postView2 instanceof PostView, 'The correct factory was provided');
 
-  ok(postView1 !== postView2, 'The two lookups are different');
-});
+    assert.ok(postView1 !== postView2, 'The two lookups are different');
+  }
 
-QUnit.test('An injected non-singleton instance is never cached', function() {
-  let registry = new Registry();
-  let container = registry.container();
-  let PostView = factory();
-  let PostViewHelper = factory();
+  ['@test An injected non-singleton instance is never cached'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+    let PostView = factory();
+    let PostViewHelper = factory();
 
-  registry.register('view:post', PostView, { singleton: false });
-  registry.register('view_helper:post', PostViewHelper, { singleton: false });
-  registry.injection('view:post', 'viewHelper', 'view_helper:post');
+    registry.register('view:post', PostView, { singleton: false });
+    registry.register('view_helper:post', PostViewHelper, { singleton: false });
+    registry.injection('view:post', 'viewHelper', 'view_helper:post');
 
-  let postView1 = container.lookup('view:post');
-  let postView2 = container.lookup('view:post');
+    let postView1 = container.lookup('view:post');
+    let postView2 = container.lookup('view:post');
 
-  ok(postView1.viewHelper !== postView2.viewHelper, 'Injected non-singletons are not cached');
-});
+    assert.ok(postView1.viewHelper !== postView2.viewHelper, 'Injected non-singletons are not cached');
+  }
 
-QUnit.test('Factory resolves are cached', function() {
-  let registry = new Registry();
-  let container = registry.container();
-  let PostController = factory();
-  let resolveWasCalled = [];
-  registry.resolve = function(fullName) {
-    resolveWasCalled.push(fullName);
-    return PostController;
-  };
+  ['@test Factory resolves are cached'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+    let PostController = factory();
+    let resolveWasCalled = [];
+    registry.resolve = function(fullName) {
+      resolveWasCalled.push(fullName);
+      return PostController;
+    };
 
-  deepEqual(resolveWasCalled, []);
-  container.factoryFor('controller:post');
-  deepEqual(resolveWasCalled, ['controller:post']);
+    assert.deepEqual(resolveWasCalled, []);
+    container.factoryFor('controller:post');
+    assert.deepEqual(resolveWasCalled, ['controller:post']);
 
-  container.factoryFor('controller:post');
-  deepEqual(resolveWasCalled, ['controller:post']);
-});
+    container.factoryFor('controller:post');
+    assert.deepEqual(resolveWasCalled, ['controller:post']);
+  }
 
-QUnit.test('factory for non extendables (MODEL) resolves are cached', function() {
-  let registry = new Registry();
-  let container = registry.container();
-  let PostController = factory();
-  let resolveWasCalled = [];
-  registry.resolve = function(fullName) {
-    resolveWasCalled.push(fullName);
-    return PostController;
-  };
+  ['@test factory for non extendables (MODEL) resolves are cached'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+    let PostController = factory();
+    let resolveWasCalled = [];
+    registry.resolve = function(fullName) {
+      resolveWasCalled.push(fullName);
+      return PostController;
+    };
 
-  deepEqual(resolveWasCalled, []);
-  container.factoryFor('model:post');
-  deepEqual(resolveWasCalled, ['model:post']);
+    assert.deepEqual(resolveWasCalled, []);
+    container.factoryFor('model:post');
+    assert.deepEqual(resolveWasCalled, ['model:post']);
 
-  container.factoryFor('model:post');
-  deepEqual(resolveWasCalled, ['model:post']);
-});
+    container.factoryFor('model:post');
+    assert.deepEqual(resolveWasCalled, ['model:post']);
+  }
 
-QUnit.test('factory for non extendables resolves are cached', function() {
-  let registry = new Registry();
-  let container = registry.container();
-  let PostController = {};
-  let resolveWasCalled = [];
+  ['@test factory for non extendables resolves are cached'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+    let PostController = {};
+    let resolveWasCalled = [];
 
-  registry.resolve = function(fullName) {
-    resolveWasCalled.push(fullName);
-    return PostController;
-  };
+    registry.resolve = function(fullName) {
+      resolveWasCalled.push(fullName);
+      return PostController;
+    };
 
-  deepEqual(resolveWasCalled, []);
-  container.factoryFor('foo:post');
-  deepEqual(resolveWasCalled, ['foo:post']);
+    assert.deepEqual(resolveWasCalled, []);
+    container.factoryFor('foo:post');
+    assert.deepEqual(resolveWasCalled, ['foo:post']);
 
-  container.factoryFor('foo:post');
-  deepEqual(resolveWasCalled, ['foo:post']);
-});
+    container.factoryFor('foo:post');
+    assert.deepEqual(resolveWasCalled, ['foo:post']);
+  }
 
-QUnit.test('A factory\'s lazy injections are validated when first instantiated', function() {
-  let registry = new Registry();
-  let container = registry.container();
-  let Apple = factory();
-  let Orange = factory();
+  ['@test A factory\'s lazy injections are validated when first instantiated'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+    let Apple = factory();
+    let Orange = factory();
 
-  Apple.reopenClass({
-    _lazyInjections() {
-      return ['orange:main', 'banana:main'];
-    }
-  });
+    Apple.reopenClass({
+      _lazyInjections() {
+        return ['orange:main', 'banana:main'];
+      }
+    });
 
-  registry.register('apple:main', Apple);
-  registry.register('orange:main', Orange);
+    registry.register('apple:main', Apple);
+    registry.register('orange:main', Orange);
 
-  throws(() => {
+    assert.throws(() => {
+      container.lookup('apple:main');
+    }, /Attempting to inject an unknown injection: 'banana:main'/);
+  }
+
+  ['@test Lazy injection validations are cached'](assert) {
+    assert.expect(1);
+
+    let registry = new Registry();
+    let container = registry.container();
+    let Apple = factory();
+    let Orange = factory();
+
+    Apple.reopenClass({
+      _lazyInjections: () => {
+        assert.ok(true, 'should call lazy injection method');
+        return ['orange:main'];
+      }
+    });
+
+    registry.register('apple:main', Apple);
+    registry.register('orange:main', Orange);
+
     container.lookup('apple:main');
-  }, /Attempting to inject an unknown injection: 'banana:main'/);
-});
-
-QUnit.test('Lazy injection validations are cached', function() {
-  expect(1);
-
-  let registry = new Registry();
-  let container = registry.container();
-  let Apple = factory();
-  let Orange = factory();
-
-  Apple.reopenClass({
-    _lazyInjections() {
-      ok(true, 'should call lazy injection method');
-      return ['orange:main'];
-    }
-  });
-
-  registry.register('apple:main', Apple);
-  registry.register('orange:main', Orange);
-
-  container.lookup('apple:main');
-  container.lookup('apple:main');
-});
-
-QUnit.test('An object with its owner pre-set should be returned from ownerInjection', function() {
-  let owner = { };
-  let registry = new Registry();
-  let container = registry.container({ owner });
-
-  let result = container.ownerInjection();
-
-  equal(result[OWNER], owner, 'owner is properly included');
-});
-
-QUnit.test('lookup passes options through to expandlocallookup', function(assert) {
-  let registry = new Registry();
-  let container = registry.container();
-  let PostController = factory();
-
-  registry.register('controller:post', PostController);
-  registry.expandLocalLookup = function(fullName, options) {
-    assert.ok(true, 'expandLocalLookup was called');
-    assert.equal(fullName, 'foo:bar');
-    assert.deepEqual(options, { source: 'baz:qux' });
-
-    return 'controller:post';
-  };
-
-  let PostControllerLookupResult = container.lookup('foo:bar', { source: 'baz:qux' });
-
-  assert.ok(PostControllerLookupResult instanceof PostController);
-});
-
-QUnit.test('#factoryFor class is registered class', (assert) => {
-  let registry = new Registry();
-  let container = registry.container();
-
-  let Component = factory();
-  registry.register('component:foo-bar', Component);
-
-  let factoryManager = container.factoryFor('component:foo-bar');
-  assert.deepEqual(factoryManager.class, Component, 'No double extend');
-});
-
-QUnit.test('#factoryFor must supply a fullname', (assert) => {
-  let registry = new Registry();
-  let container = registry.container();
-  expectAssertion(() => {
-    container.factoryFor('chad-bar');
-  }, /fullName must be a proper full name/);
-});
-
-QUnit.test('#factoryFor returns a factory manager', (assert) => {
-  let registry = new Registry();
-  let container = registry.container();
-
-  let Component = factory();
-  registry.register('component:foo-bar', Component);
-
-  let factoryManager = container.factoryFor('component:foo-bar');
-  assert.ok(factoryManager.create);
-  assert.ok(factoryManager.class);
-});
-
-QUnit.test('#factoryFor returns a cached factory manager for the same type', (assert) => {
-  let registry = new Registry();
-  let container = registry.container();
-
-  let Component = factory();
-  registry.register('component:foo-bar', Component);
-  registry.register('component:baz-bar', Component);
-
-  let factoryManager1 = container.factoryFor('component:foo-bar');
-  let factoryManager2 = container.factoryFor('component:foo-bar');
-  let factoryManager3 = container.factoryFor('component:baz-bar');
-
-  assert.equal(factoryManager1, factoryManager2, 'cache hit');
-  assert.notEqual(factoryManager1, factoryManager3, 'cache miss');
-});
-
-QUnit.test('#factoryFor class returns the factory function', (assert) => {
-  let registry = new Registry();
-  let container = registry.container();
-
-  let Component = factory();
-  registry.register('component:foo-bar', Component);
-
-  let factoryManager = container.factoryFor('component:foo-bar');
-  assert.deepEqual(factoryManager.class, Component, 'No double extend');
-});
-
-QUnit.test('#factoryFor instance have a common parent', (assert) => {
-  let registry = new Registry();
-  let container = registry.container();
-
-  let Component = factory();
-  registry.register('component:foo-bar', Component);
-
-  let factoryManager1 = container.factoryFor('component:foo-bar');
-  let factoryManager2 = container.factoryFor('component:foo-bar');
-  let instance1 = factoryManager1.create({ foo: 'foo' });
-  let instance2 = factoryManager2.create({ bar: 'bar' });
-
-  assert.deepEqual(instance1.constructor, instance2.constructor);
-});
-
-QUnit.test('can properly reset cache', (assert) => {
-  let registry = new Registry();
-  let container = registry.container();
-
-  let Component = factory();
-  registry.register('component:foo-bar', Component);
-
-  let factory1 = container.factoryFor('component:foo-bar');
-  let factory2 = container.factoryFor('component:foo-bar');
-
-  let instance1 = container.lookup('component:foo-bar');
-  let instance2 = container.lookup('component:foo-bar');
-
-  assert.equal(instance1, instance2);
-  assert.equal(factory1, factory2);
-
-  container.reset();
-
-  let factory3 = container.factoryFor('component:foo-bar');
-  let instance3 = container.lookup('component:foo-bar');
-
-  assert.notEqual(instance1, instance3);
-  assert.notEqual(factory1, factory3);
-});
-
-QUnit.test('#factoryFor created instances come with instance injections', (assert) => {
-  let registry = new Registry();
-  let container = registry.container();
-
-  let Component = factory();
-  let Ajax = factory();
-  registry.register('component:foo-bar', Component);
-  registry.register('util:ajax', Ajax);
-  registry.injection('component:foo-bar', 'ajax', 'util:ajax');
-
-  let componentFactory = container.factoryFor('component:foo-bar');
-  let component = componentFactory.create();
-
-  assert.ok(component.ajax);
-  assert.ok(component.ajax instanceof Ajax);
-});
-
-QUnit.test('#factoryFor options passed to create clobber injections', (assert) => {
-  let registry = new Registry();
-  let container = registry.container();
-
-  let Component = factory();
-  let Ajax = factory();
-  registry.register('component:foo-bar', Component);
-  registry.register('util:ajax', Ajax);
-  registry.injection('component:foo-bar', 'ajax', 'util:ajax');
-
-  let componentFactory = container.factoryFor('component:foo-bar');
-
-  let instrance = componentFactory.create({ ajax: 'fetch' });
-
-  assert.equal(instrance.ajax, 'fetch');
-});
-
-QUnit.test('#factoryFor does not add properties to the object being instantiated when _initFactory is present', function(assert) {
-  let owner = {};
-  let registry = new Registry();
-  let container = registry.container();
-
-  let factory;
-  class Component {
-    static _initFactory(_factory) { factory = _factory; }
-    static create(options) {
-      let instance = new this();
-      assign(instance, options);
-      return instance;
-    }
+    container.lookup('apple:main');
   }
-  registry.register('component:foo-bar', Component);
 
-  let componentFactory = container.factoryFor('component:foo-bar');
-  let instance = componentFactory.create();
+  ['@test An object with its owner pre-set should be returned from ownerInjection'](assert) {
+    let owner = { };
+    let registry = new Registry();
+    let container = registry.container({ owner });
 
-  // note: _guid and isDestroyed are being set in the `factory` constructor
-  // not via registry/container shenanigans
-  assert.deepEqual(Object.keys(instance), []);
-});
+    let result = container.ownerInjection();
 
-// this is skipped until templates and the glimmer environment do not require `OWNER` to be
-// passed in as constructor args
-QUnit.skip('#factoryFor does not add properties to the object being instantiated', function(assert) {
-  let owner = {};
-  let registry = new Registry();
-  let container = registry.container();
-
-  let factory;
-  class Component {
-    static create(options) {
-      let instance = new this();
-      assign(instance, options);
-      return instance;
-    }
+    assert.equal(result[OWNER], owner, 'owner is properly included');
   }
-  registry.register('component:foo-bar', Component);
 
-  let componentFactory = container.factoryFor('component:foo-bar');
-  let instance = componentFactory.create();
+  ['@test lookup passes options through to expandlocallookup'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+    let PostController = factory();
 
-  // note: _guid and isDestroyed are being set in the `factory` constructor
-  // not via registry/container shenanigans
-  assert.deepEqual(Object.keys(instance), []);
+    registry.register('controller:post', PostController);
+    registry.expandLocalLookup = (fullName, options) => {
+      assert.ok(true, 'expandLocalLookup was called');
+      assert.equal(fullName, 'foo:bar');
+      assert.deepEqual(options, { source: 'baz:qux' });
+
+      return 'controller:post';
+    };
+
+    let PostControllerLookupResult = container.lookup('foo:bar', { source: 'baz:qux' });
+
+    assert.ok(PostControllerLookupResult instanceof PostController);
+  }
+
+  ['@test #factoryFor class is registered class'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+
+    let Component = factory();
+    registry.register('component:foo-bar', Component);
+
+    let factoryManager = container.factoryFor('component:foo-bar');
+    assert.deepEqual(factoryManager.class, Component, 'No double extend');
+  }
+
+  ['@test #factoryFor must supply a fullname']() {
+    let registry = new Registry();
+    let container = registry.container();
+    expectAssertion(() => {
+      container.factoryFor('chad-bar');
+    }, /fullName must be a proper full name/);
+  }
+
+  ['@test #factoryFor returns a factory manager'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+
+    let Component = factory();
+    registry.register('component:foo-bar', Component);
+
+    let factoryManager = container.factoryFor('component:foo-bar');
+    assert.ok(factoryManager.create);
+    assert.ok(factoryManager.class);
+  }
+
+  ['@test #factoryFor returns a cached factory manager for the same type'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+
+    let Component = factory();
+    registry.register('component:foo-bar', Component);
+    registry.register('component:baz-bar', Component);
+
+    let factoryManager1 = container.factoryFor('component:foo-bar');
+    let factoryManager2 = container.factoryFor('component:foo-bar');
+    let factoryManager3 = container.factoryFor('component:baz-bar');
+
+    assert.equal(factoryManager1, factoryManager2, 'cache hit');
+    assert.notEqual(factoryManager1, factoryManager3, 'cache miss');
+  }
+
+  ['@test #factoryFor class returns the factory function'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+
+    let Component = factory();
+    registry.register('component:foo-bar', Component);
+
+    let factoryManager = container.factoryFor('component:foo-bar');
+    assert.deepEqual(factoryManager.class, Component, 'No double extend');
+  }
+
+  ['@test #factoryFor instance have a common parent'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+
+    let Component = factory();
+    registry.register('component:foo-bar', Component);
+
+    let factoryManager1 = container.factoryFor('component:foo-bar');
+    let factoryManager2 = container.factoryFor('component:foo-bar');
+    let instance1 = factoryManager1.create({ foo: 'foo' });
+    let instance2 = factoryManager2.create({ bar: 'bar' });
+
+    assert.deepEqual(instance1.constructor, instance2.constructor);
+  }
+
+  ['@test can properly reset cache'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+
+    let Component = factory();
+    registry.register('component:foo-bar', Component);
+
+    let factory1 = container.factoryFor('component:foo-bar');
+    let factory2 = container.factoryFor('component:foo-bar');
+
+    let instance1 = container.lookup('component:foo-bar');
+    let instance2 = container.lookup('component:foo-bar');
+
+    assert.equal(instance1, instance2);
+    assert.equal(factory1, factory2);
+
+    container.reset();
+
+    let factory3 = container.factoryFor('component:foo-bar');
+    let instance3 = container.lookup('component:foo-bar');
+
+    assert.notEqual(instance1, instance3);
+    assert.notEqual(factory1, factory3);
+  }
+
+  ['@test #factoryFor created instances come with instance injections'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+
+    let Component = factory();
+    let Ajax = factory();
+    registry.register('component:foo-bar', Component);
+    registry.register('util:ajax', Ajax);
+    registry.injection('component:foo-bar', 'ajax', 'util:ajax');
+
+    let componentFactory = container.factoryFor('component:foo-bar');
+    let component = componentFactory.create();
+
+    assert.ok(component.ajax);
+    assert.ok(component.ajax instanceof Ajax);
+  }
+
+  ['@test #factoryFor options passed to create clobber injections'](assert) {
+    let registry = new Registry();
+    let container = registry.container();
+
+    let Component = factory();
+    let Ajax = factory();
+    registry.register('component:foo-bar', Component);
+    registry.register('util:ajax', Ajax);
+    registry.injection('component:foo-bar', 'ajax', 'util:ajax');
+
+    let componentFactory = container.factoryFor('component:foo-bar');
+
+    let instrance = componentFactory.create({ ajax: 'fetch' });
+
+    assert.equal(instrance.ajax, 'fetch');
+  }
+
+  ['@test #factoryFor does not add properties to the object being instantiated when _initFactory is present'](assert) {
+    let owner = {};
+    let registry = new Registry();
+    let container = registry.container();
+
+    let factory;
+    class Component {
+      static _initFactory(_factory) { factory = _factory; }
+      static create(options) {
+        let instance = new this();
+        assign(instance, options);
+        return instance;
+      }
+    }
+    registry.register('component:foo-bar', Component);
+
+    let componentFactory = container.factoryFor('component:foo-bar');
+    let instance = componentFactory.create();
+
+    // note: _guid and isDestroyed are being set in the `factory` constructor
+    // not via registry/container shenanigans
+    assert.deepEqual(Object.keys(instance), []);
+  }
+
+  // this is skipped until templates and the glimmer environment do not require `OWNER` to be
+  // passed in as constructor args
+  ['@skip #factoryFor does not add properties to the object being instantiated'](assert) {
+    let owner = {};
+    let registry = new Registry();
+    let container = registry.container();
+
+    let factory;
+    class Component {
+      static create(options) {
+        let instance = new this();
+        assign(instance, options);
+        return instance;
+      }
+    }
+    registry.register('component:foo-bar', Component);
+
+    let componentFactory = container.factoryFor('component:foo-bar');
+    let instance = componentFactory.create();
+
+    // note: _guid and isDestroyed are being set in the `factory` constructor
+    // not via registry/container shenanigans
+    assert.deepEqual(Object.keys(instance), []);
+  }
 });
 
 if (EMBER_MODULE_UNIFICATION) {
   QUnit.module('Container module unification');
 
-  QUnit.test('The container can pass a source to factoryFor', function(assert) {
-    let PrivateComponent = factory();
-    let lookup = 'component:my-input';
-    let expectedSource = 'template:routes/application';
-    let registry = new Registry();
-    let resolveCount = 0;
-    registry.resolve = function(fullName, { source }) {
-      resolveCount++;
-      if (fullName === lookup && source === expectedSource) {
-        return PrivateComponent;
-      }
-    };
+  moduleFor('Container module unification', class extends AbstractTestCase {
+    ['@test The container can pass a source to factoryFor'](assert) {
+      let PrivateComponent = factory();
+      let lookup = 'component:my-input';
+      let expectedSource = 'template:routes/application';
+      let registry = new Registry();
+      let resolveCount = 0;
+      registry.resolve = function(fullName, { source }) {
+        resolveCount++;
+        if (fullName === lookup && source === expectedSource) {
+          return PrivateComponent;
+        }
+      };
 
-    let container = registry.container();
+      let container = registry.container();
 
-    assert.strictEqual(container.factoryFor(lookup, { source: expectedSource }).class, PrivateComponent, 'The correct factory was provided');
-    assert.strictEqual(container.factoryFor(lookup, { source: expectedSource }).class, PrivateComponent, 'The correct factory was provided again');
-    assert.equal(resolveCount, 1, 'resolve called only once and a cached factory was returned the second time');
-  });
+      assert.strictEqual(container.factoryFor(lookup, { source: expectedSource }).class, PrivateComponent, 'The correct factory was provided');
+      assert.strictEqual(container.factoryFor(lookup, { source: expectedSource }).class, PrivateComponent, 'The correct factory was provided again');
+      assert.equal(resolveCount, 1, 'resolve called only once and a cached factory was returned the second time');
+    }
 
-  QUnit.test('The container can pass a source to lookup', function(assert) {
-    let PrivateComponent = factory();
-    let lookup = 'component:my-input';
-    let expectedSource = 'template:routes/application';
-    let registry = new Registry();
-    registry.resolve = function(fullName, { source }) {
-      if (fullName === lookup && source === expectedSource) {
-        return PrivateComponent;
-      }
-    };
+    ['@test The container can pass a source to lookup']() {
+      let PrivateComponent = factory();
+      let lookup = 'component:my-input';
+      let expectedSource = 'template:routes/application';
+      let registry = new Registry();
+      registry.resolve = function(fullName, { source }) {
+        if (fullName === lookup && source === expectedSource) {
+          return PrivateComponent;
+        }
+      };
 
-    let container = registry.container();
+      let container = registry.container();
 
-    let result = container.lookup(lookup, { source: expectedSource });
-    assert.ok(result instanceof PrivateComponent, 'The correct factory was provided');
+      let result = container.lookup(lookup, { source: expectedSource });
+      this.assert.ok(result instanceof PrivateComponent, 'The correct factory was provided');
 
-    assert.ok(container.cache[`template:routes/application:component:my-input`] instanceof PrivateComponent,
-       'The correct factory was stored in the cache with the correct key which includes the source.');
+      this.assert.ok(container.cache[`template:routes/application:component:my-input`] instanceof PrivateComponent,
+        'The correct factory was stored in the cache with the correct key which includes the source.');
+    }
   });
 }

--- a/packages/container/tests/owner_test.js
+++ b/packages/container/tests/owner_test.js
@@ -1,16 +1,17 @@
 import { getOwner, setOwner, OWNER } from 'ember-utils';
+import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
-QUnit.module('Owner', {});
+moduleFor('Owner', class extends AbstractTestCase {
+  ['@test An owner can be set with `setOwner` and retrieved with `getOwner`'](assert) {
+    let owner = {};
+    let obj = {};
 
-QUnit.test('An owner can be set with `setOwner` and retrieved with `getOwner`', function() {
-  let owner = {};
-  let obj = {};
+    assert.strictEqual(getOwner(obj), undefined, 'owner has not been set');
 
-  strictEqual(getOwner(obj), undefined, 'owner has not been set');
+    setOwner(obj, owner);
 
-  setOwner(obj, owner);
+    assert.strictEqual(getOwner(obj), owner, 'owner has been set');
 
-  strictEqual(getOwner(obj), owner, 'owner has been set');
-
-  strictEqual(obj[OWNER], owner, 'owner has been set to the OWNER symbol');
+    assert.strictEqual(obj[OWNER], owner, 'owner has been set to the OWNER symbol');
+  }
 });

--- a/packages/container/tests/registry_test.js
+++ b/packages/container/tests/registry_test.js
@@ -1,778 +1,772 @@
 import { Registry, privatize } from '..';
-import { factory } from 'internal-test-helpers';
+import { factory, moduleFor, AbstractTestCase } from 'internal-test-helpers';
 import { EMBER_MODULE_UNIFICATION } from 'ember/features';
 import { ENV } from 'ember-environment';
 
-let originalResolverFunctionSupport;
+moduleFor('Registry', class extends AbstractTestCase{
+  constructor() {
+    super();
 
-QUnit.module('Registry', {
-  setup() {
-    originalResolverFunctionSupport = ENV._ENABLE_RESOLVER_FUNCTION_SUPPORT;
+    this.originalResolverFunctionSupport = ENV._ENABLE_RESOLVER_FUNCTION_SUPPORT;
     ENV._ENABLE_RESOLVER_FUNCTION_SUPPORT = true;
-  },
+  }
 
   teardown() {
-    ENV._ENABLE_RESOLVER_FUNCTION_SUPPORT = originalResolverFunctionSupport;
+    ENV._ENABLE_RESOLVER_FUNCTION_SUPPORT = this.originalResolverFunctionSupport;
   }
-});
 
-QUnit.test('A registered factory is returned from resolve', function() {
-  let registry = new Registry();
-  let PostController = factory();
+  ['@test A registered factory is returned from resolve'](assert) {
+    let registry = new Registry();
+    let PostController = factory();
 
-  registry.register('controller:post', PostController);
+    registry.register('controller:post', PostController);
 
-  let PostControllerFactory = registry.resolve('controller:post');
+    let PostControllerFactory = registry.resolve('controller:post');
 
-  ok(PostControllerFactory, 'factory is returned');
-  ok(PostControllerFactory.create() instanceof  PostController, 'The return of factory.create is an instance of PostController');
-});
+    assert.ok(PostControllerFactory, 'factory is returned');
+    assert.ok(PostControllerFactory.create() instanceof  PostController, 'The return of factory.create is an instance of PostController');
+  }
 
-QUnit.test('The registered factory returned from resolve is the same factory each time', function() {
-  let registry = new Registry();
-  let PostController = factory();
+  ['@test The registered factory returned from resolve is the same factory each time'](assert) {
+    let registry = new Registry();
+    let PostController = factory();
 
-  registry.register('controller:post', PostController);
+    registry.register('controller:post', PostController);
 
-  deepEqual(registry.resolve('controller:post'), registry.resolve('controller:post'), 'The return of resolve is always the same');
-});
+    assert.deepEqual(registry.resolve('controller:post'), registry.resolve('controller:post'), 'The return of resolve is always the same');
+  }
 
-QUnit.test('The registered value returned from resolve is the same value each time even if the value is falsy', function() {
-  let registry = new Registry();
+  ['@test The registered value returned from resolve is the same value each time even if the value is falsy'](assert) {
+    let registry = new Registry();
 
-  registry.register('falsy:value', null, { instantiate: false });
+    registry.register('falsy:value', null, { instantiate: false });
 
-  strictEqual(registry.resolve('falsy:value'), registry.resolve('falsy:value'), 'The return of resolve is always the same');
-});
+    assert.strictEqual(registry.resolve('falsy:value'), registry.resolve('falsy:value'), 'The return of resolve is always the same');
+  }
 
-QUnit.test('The value returned from resolver is the same value as the original value even if the value is falsy', function() {
-  let resolver = {
-    resolve(fullName) {
-      if (fullName === 'falsy:value') {
-        return null;
-      }
-    }
-  };
-  let registry = new Registry({ resolver });
-
-  strictEqual(registry.resolve('falsy:value'), null);
-});
-
-QUnit.test('A registered factory returns true for `has` if an item is registered', function() {
-  let registry = new Registry();
-  let PostController = factory();
-
-  registry.register('controller:post', PostController);
-
-  equal(registry.has('controller:post'), true, 'The `has` method returned true for registered factories');
-  equal(registry.has('controller:posts'), false, 'The `has` method returned false for unregistered factories');
-});
-
-QUnit.test('Throw exception when trying to inject `type:thing` on all type(s)', function() {
-  let registry = new Registry();
-  let PostController = factory();
-
-  registry.register('controller:post', PostController);
-
-  expectAssertion(() => {
-    registry.typeInjection('controller', 'injected', 'controller:post');
-  }, /Cannot inject a 'controller:post' on other controller\(s\)\./);
-});
-
-QUnit.test('The registry can take a hook to resolve factories lazily', function() {
-  let PostController = factory();
-  let resolver = {
-    resolve(fullName) {
-      if (fullName === 'controller:post') {
-        return PostController;
-      }
-    }
-  };
-  let registry = new Registry({ resolver });
-
-  strictEqual(registry.resolve('controller:post'), PostController, 'The correct factory was provided');
-});
-
-QUnit.test('The registry respects the resolver hook for `has`', function() {
-  let PostController = factory();
-  let resolver = {
-    resolve(fullName) {
-      if (fullName === 'controller:post') {
-        return PostController;
-      }
-    }
-  };
-  let registry = new Registry({ resolver });
-
-  ok(registry.has('controller:post'), 'the `has` method uses the resolver hook');
-});
-
-QUnit.test('The registry normalizes names when resolving', function() {
-  let registry = new Registry();
-  let PostController = factory();
-
-  registry.normalizeFullName = function(fullName) {
-    return 'controller:post';
-  };
-
-  registry.register('controller:post', PostController);
-  let type = registry.resolve('controller:normalized');
-
-  strictEqual(type, PostController, 'Normalizes the name when resolving');
-});
-
-QUnit.test('The registry normalizes names when checking if the factory is registered', function() {
-  let registry = new Registry();
-  let PostController = factory();
-
-  registry.normalizeFullName = function(fullName) {
-    return fullName === 'controller:normalized' ? 'controller:post' : fullName;
-  };
-
-  registry.register('controller:post', PostController);
-  let isPresent = registry.has('controller:normalized');
-
-  equal(isPresent, true, 'Normalizes the name when checking if the factory or instance is present');
-});
-
-QUnit.test('The registry normalizes names when injecting', function() {
-  let registry = new Registry();
-  let PostController = factory();
-  let user = { name: 'Stef' };
-
-  registry.normalize = function(fullName) {
-    return 'controller:post';
-  };
-
-  registry.register('controller:post', PostController);
-  registry.register('user:post', user, { instantiate: false });
-  registry.injection('controller:post', 'user', 'controller:normalized');
-
-  deepEqual(registry.resolve('controller:post'), user, 'Normalizes the name when injecting');
-});
-
-QUnit.test('cannot register an `undefined` factory', function() {
-  let registry = new Registry();
-
-  throws(() => {
-    registry.register('controller:apple', undefined);
-  }, '');
-});
-
-QUnit.test('can re-register a factory', function() {
-  let registry = new Registry();
-  let FirstApple = factory('first');
-  let SecondApple = factory('second');
-
-  registry.register('controller:apple', FirstApple);
-  registry.register('controller:apple', SecondApple);
-
-  ok(registry.resolve('controller:apple').create() instanceof SecondApple);
-});
-
-QUnit.test('cannot re-register a factory if it has been resolved', function() {
-  let registry = new Registry();
-  let FirstApple = factory('first');
-  let SecondApple = factory('second');
-
-  registry.register('controller:apple', FirstApple);
-  strictEqual(registry.resolve('controller:apple'), FirstApple);
-
-  expectAssertion(function() {
-    registry.register('controller:apple', SecondApple);
-  }, /Cannot re-register: 'controller:apple', as it has already been resolved\./);
-
-  strictEqual(registry.resolve('controller:apple'), FirstApple);
-});
-
-QUnit.test('registry.has should not accidentally cause injections on that factory to be run. (Mitigate merely on observing)', function() {
-  expect(1);
-
-  let registry = new Registry();
-  let FirstApple = factory('first');
-  let SecondApple = factory('second');
-
-  SecondApple.extend = function(a, b, c) {
-    ok(false, 'should not extend or touch the injected model, merely to inspect existence of another');
-  };
-
-  registry.register('controller:apple', FirstApple);
-  registry.register('controller:second-apple', SecondApple);
-  registry.injection('controller:apple', 'badApple', 'controller:second-apple');
-
-  ok(registry.has('controller:apple'));
-});
-
-QUnit.test('registry.has should not error for invalid fullNames)', function() {
-  expect(1);
-
-  let registry = new Registry();
-
-  ok(!registry.has('foo:bar:baz'));
-});
-
-QUnit.test('once resolved, always return the same result', function() {
-  expect(1);
-
-  let registry = new Registry();
-
-  registry.resolver = {
-    resolve() {
-      return 'bar';
-    }
-  };
-
-  let Bar = registry.resolve('models:bar');
-
-  registry.resolver = {
-    resolve() {
-      return 'not bar';
-    }
-  };
-
-  equal(registry.resolve('models:bar'), Bar);
-});
-
-QUnit.test('factory resolves are cached', function() {
-  let registry = new Registry();
-  let PostController = factory();
-  let resolveWasCalled = [];
-
-  registry.resolver = {
-    resolve(fullName) {
-      resolveWasCalled.push(fullName);
-      return PostController;
-    }
-  };
-
-  deepEqual(resolveWasCalled, []);
-  registry.resolve('controller:post');
-  deepEqual(resolveWasCalled, ['controller:post']);
-
-  registry.resolve('controller:post');
-  deepEqual(resolveWasCalled, ['controller:post']);
-});
-
-QUnit.test('factory for non extendables (MODEL) resolves are cached', function() {
-  let registry = new Registry();
-  let PostController = factory();
-  let resolveWasCalled = [];
-
-  registry.resolver = {
-    resolve(fullName) {
-      resolveWasCalled.push(fullName);
-      return PostController;
-    }
-  };
-
-  deepEqual(resolveWasCalled, []);
-  registry.resolve('model:post');
-  deepEqual(resolveWasCalled, ['model:post']);
-
-  registry.resolve('model:post');
-  deepEqual(resolveWasCalled, ['model:post']);
-});
-
-QUnit.test('factory for non extendables resolves are cached', function() {
-  let registry = new Registry();
-  let PostController = {};
-  let resolveWasCalled = [];
-
-  registry.resolver = {
-    resolve(fullName) {
-      resolveWasCalled.push(fullName);
-      return PostController;
-    }
-  };
-
-  deepEqual(resolveWasCalled, []);
-  registry.resolve('foo:post');
-  deepEqual(resolveWasCalled, ['foo:post']);
-
-  registry.resolve('foo:post');
-  deepEqual(resolveWasCalled, ['foo:post']);
-});
-
-QUnit.test('registry.container creates a container', function() {
-  let registry = new Registry();
-  let PostController = factory();
-  registry.register('controller:post', PostController);
-
-  let container = registry.container();
-  let postController = container.lookup('controller:post');
-
-  ok(postController instanceof PostController, 'The lookup is an instance of the registered factory');
-});
-
-QUnit.test('`describe` will be handled by the resolver, then by the fallback registry, if available', function() {
-  let fallback = {
-    describe(fullName) {
-      return `${fullName}-fallback`;
-    }
-  };
-
-  let resolver = {
-    lookupDescription(fullName) {
-      return `${fullName}-resolver`;
-    }
-  };
-
-  let registry = new Registry({ fallback, resolver });
-
-  equal(registry.describe('controller:post'), 'controller:post-resolver', '`describe` handled by the resolver first.');
-
-  registry.resolver = null;
-
-  equal(registry.describe('controller:post'), 'controller:post-fallback', '`describe` handled by fallback registry next.');
-
-  registry.fallback = null;
-
-  equal(registry.describe('controller:post'), 'controller:post', '`describe` by default returns argument.');
-});
-
-QUnit.test('`normalizeFullName` will be handled by the resolver, then by the fallback registry, if available', function() {
-  let fallback = {
-    normalizeFullName(fullName) {
-      return `${fullName}-fallback`;
-    }
-  };
-
-  let resolver = {
-    normalize(fullName) {
-      return `${fullName}-resolver`;
-    }
-  };
-
-  let registry = new Registry({ fallback, resolver });
-
-  equal(registry.normalizeFullName('controller:post'), 'controller:post-resolver', '`normalizeFullName` handled by the resolver first.');
-
-  registry.resolver = null;
-
-  equal(registry.normalizeFullName('controller:post'), 'controller:post-fallback', '`normalizeFullName` handled by fallback registry next.');
-
-  registry.fallback = null;
-
-  equal(registry.normalizeFullName('controller:post'), 'controller:post', '`normalizeFullName` by default returns argument.');
-});
-
-QUnit.test('`makeToString` will be handled by the resolver, then by the fallback registry, if available', function() {
-  let fallback = {
-    makeToString(fullName) {
-      return `${fullName}-fallback`;
-    }
-  };
-
-  let resolver = {
-    makeToString(fullName) {
-      return `${fullName}-resolver`;
-    }
-  };
-
-  let registry = new Registry({ fallback, resolver });
-
-  equal(registry.makeToString('controller:post'), 'controller:post-resolver', '`makeToString` handled by the resolver first.');
-
-  registry.resolver = null;
-
-  equal(registry.makeToString('controller:post'), 'controller:post-fallback', '`makeToString` handled by fallback registry next.');
-
-  registry.fallback = null;
-
-  equal(registry.makeToString('controller:post'), 'controller:post', '`makeToString` by default returns argument.');
-});
-
-QUnit.test('`resolve` can be handled by a fallback registry', function() {
-  let fallback = new Registry();
-
-  let registry = new Registry({ fallback: fallback });
-  let PostController = factory();
-
-  fallback.register('controller:post', PostController);
-
-  let PostControllerFactory = registry.resolve('controller:post');
-
-  ok(PostControllerFactory, 'factory is returned');
-  ok(PostControllerFactory.create() instanceof  PostController, 'The return of factory.create is an instance of PostController');
-});
-
-QUnit.test('`has` can be handled by a fallback registry', function() {
-  let fallback = new Registry();
-
-  let registry = new Registry({ fallback: fallback });
-  let PostController = factory();
-
-  fallback.register('controller:post', PostController);
-
-  equal(registry.has('controller:post'), true, 'Fallback registry is checked for registration');
-});
-
-QUnit.test('`getInjections` includes injections from a fallback registry', function() {
-  let fallback = new Registry();
-  let registry = new Registry({ fallback: fallback });
-
-  equal(registry.getInjections('model:user').length, 0, 'No injections in the primary registry');
-
-  fallback.injection('model:user', 'post', 'model:post');
-
-  equal(registry.getInjections('model:user').length, 1, 'Injections from the fallback registry are merged');
-});
-
-QUnit.test('`getTypeInjections` includes type injections from a fallback registry', function() {
-  let fallback = new Registry();
-  let registry = new Registry({ fallback: fallback });
-
-  equal(registry.getTypeInjections('model').length, 0, 'No injections in the primary registry');
-
-  fallback.injection('model', 'source', 'source:main');
-
-  equal(registry.getTypeInjections('model').length, 1, 'Injections from the fallback registry are merged');
-});
-
-QUnit.test('`knownForType` contains keys for each item of a given type', function() {
-  let registry = new Registry();
-
-  registry.register('foo:bar-baz', 'baz');
-  registry.register('foo:qux-fez', 'fez');
-
-  let found = registry.knownForType('foo');
-
-  deepEqual(found, {
-    'foo:bar-baz': true,
-    'foo:qux-fez': true
-  });
-});
-
-QUnit.test('`knownForType` includes fallback registry results', function() {
-  let fallback = new Registry();
-  let registry = new Registry({ fallback: fallback });
-
-  registry.register('foo:bar-baz', 'baz');
-  registry.register('foo:qux-fez', 'fez');
-  fallback.register('foo:zurp-zorp', 'zorp');
-
-  let found = registry.knownForType('foo');
-
-  deepEqual(found, {
-    'foo:bar-baz': true,
-    'foo:qux-fez': true,
-    'foo:zurp-zorp': true
-  });
-});
-
-QUnit.test('`knownForType` is called on the resolver if present', function() {
-  expect(3);
-
-  let resolver = {
-    knownForType(type) {
-      ok(true, 'knownForType called on the resolver');
-      equal(type, 'foo', 'the type was passed through');
-
-      return { 'foo:yorp': true };
-    }
-  };
-
-  let registry = new Registry({
-    resolver
-  });
-  registry.register('foo:bar-baz', 'baz');
-
-  let found = registry.knownForType('foo');
-
-  deepEqual(found, {
-    'foo:yorp': true,
-    'foo:bar-baz': true
-  });
-});
-
-QUnit.test('A registry created with `resolver` function instead of an object throws deprecation', (assert) => {
-  assert.expect(2);
-
-  ENV._ENABLE_RESOLVER_FUNCTION_SUPPORT = true;
-
-  let registry;
-
-  expectDeprecation(() => {
-    registry = new Registry({
-      resolver(fullName) {
-        return `${fullName}-resolved`;
-      }
-    });
-  }, 'Passing a `resolver` function into a Registry is deprecated. Please pass in a Resolver object with a `resolve` method.');
-
-  assert.equal(registry.resolve('foo:bar'), 'foo:bar-resolved', '`resolve` still calls the deprecated function');
-});
-
-QUnit.test('A registry created with `resolver` function instead of an object throws assertion', (assert) => {
-  assert.expect(1);
-
-  ENV._ENABLE_RESOLVER_FUNCTION_SUPPORT = false;
-
-  let registry;
-
-  expectAssertion(() => {
-    registry = new Registry({
-      resolver(fullName) {
-        return `${fullName}-resolved`;
-      }
-    });
-  }, /Passing a \`resolver\` function into a Registry is deprecated\. Please pass in a Resolver object with a \`resolve\` method\./);
-});
-
-QUnit.test('resolver.expandLocalLookup is not required', function(assert) {
-  assert.expect(1);
-
-  let registry = new Registry({
-    resolver: { }
-  });
-
-  let result = registry.expandLocalLookup('foo:bar', {
-    source: 'baz:qux'
-  });
-
-  assert.equal(result, null);
-});
-
-QUnit.test('expandLocalLookup is called on the resolver if present', function(assert) {
-  assert.expect(4);
-
-  let resolver = {
-    expandLocalLookup(targetFullName, sourceFullName) {
-      assert.ok(true, 'expandLocalLookup is called on the resolver');
-      assert.equal(targetFullName, 'foo:bar', 'the targetFullName was passed through');
-      assert.equal(sourceFullName, 'baz:qux', 'the sourceFullName was passed through');
-
-      return 'foo:qux/bar';
-    }
-  };
-
-  let registry = new Registry({
-    resolver
-  });
-
-  let result = registry.expandLocalLookup('foo:bar', {
-    source: 'baz:qux'
-  });
-
-  assert.equal(result, 'foo:qux/bar');
-});
-
-QUnit.test('`expandLocalLookup` is handled by the resolver, then by the fallback registry, if available', function(assert) {
-  assert.expect(9);
-
-  let fallbackResolver = {
-    expandLocalLookup(targetFullName, sourceFullName) {
-      assert.ok(true, 'expandLocalLookup is called on the fallback resolver');
-      assert.equal(targetFullName, 'foo:bar', 'the targetFullName was passed through');
-      assert.equal(sourceFullName, 'baz:qux', 'the sourceFullName was passed through');
-
-      return 'foo:qux/bar-fallback';
-    }
-  };
-
-  let resolver = {
-    expandLocalLookup(targetFullName, sourceFullName) {
-      assert.ok(true, 'expandLocalLookup is called on the resolver');
-      assert.equal(targetFullName, 'foo:bar', 'the targetFullName was passed through');
-      assert.equal(sourceFullName, 'baz:qux', 'the sourceFullName was passed through');
-
-      return 'foo:qux/bar-resolver';
-    }
-  };
-
-  let fallbackRegistry = new Registry({
-    resolver: fallbackResolver
-  });
-
-  let registry = new Registry({
-    fallback: fallbackRegistry,
-    resolver
-  });
-
-  let result = registry.expandLocalLookup('foo:bar', {
-    source: 'baz:qux'
-  });
-
-  assert.equal(result, 'foo:qux/bar-resolver', 'handled by the resolver');
-
-  registry.resolver = null;
-
-  result = registry.expandLocalLookup('foo:bar', {
-    source: 'baz:qux'
-  });
-
-  assert.equal(result, 'foo:qux/bar-fallback', 'handled by the fallback registry');
-
-  registry.fallback = null;
-
-  result = registry.expandLocalLookup('foo:bar', {
-    source: 'baz:qux'
-  });
-
-  assert.equal(result, null, 'null is returned by default when no resolver or fallback registry is present');
-});
-
-QUnit.test('resolver.expandLocalLookup result is cached', function(assert) {
-  assert.expect(3);
-  let result;
-
-  let resolver = {
-    expandLocalLookup(targetFullName, sourceFullName) {
-      assert.ok(true, 'expandLocalLookup is called on the resolver');
-
-      return 'foo:qux/bar';
-    }
-  };
-
-  let registry = new Registry({
-    resolver
-  });
-
-  result = registry.expandLocalLookup('foo:bar', {
-    source: 'baz:qux'
-  });
-
-  assert.equal(result, 'foo:qux/bar');
-
-  result = registry.expandLocalLookup('foo:bar', {
-    source: 'baz:qux'
-  });
-
-  assert.equal(result, 'foo:qux/bar');
-});
-
-QUnit.test('resolver.expandLocalLookup cache is busted when any unregister is called', function(assert) {
-  assert.expect(4);
-  let result;
-
-  let resolver = {
-    expandLocalLookup(targetFullName, sourceFullName) {
-      assert.ok(true, 'expandLocalLookup is called on the resolver');
-
-      return 'foo:qux/bar';
-    }
-  };
-
-  let registry = new Registry({
-    resolver
-  });
-
-  result = registry.expandLocalLookup('foo:bar', {
-    source: 'baz:qux'
-  });
-
-  assert.equal(result, 'foo:qux/bar');
-
-  registry.unregister('foo:bar');
-
-  result = registry.expandLocalLookup('foo:bar', {
-    source: 'baz:qux'
-  });
-
-  assert.equal(result, 'foo:qux/bar');
-});
-
-QUnit.test('resolve calls expandLocallookup when it receives options.source', function(assert) {
-  assert.expect(3);
-
-  let resolver = {
-    resolve() { },
-    expandLocalLookup(targetFullName, sourceFullName) {
-      assert.ok(true, 'expandLocalLookup is called on the resolver');
-      assert.equal(targetFullName, 'foo:bar', 'the targetFullName was passed through');
-      assert.equal(sourceFullName, 'baz:qux', 'the sourceFullName was passed through');
-
-      return 'foo:qux/bar';
-    }
-  };
-
-  let registry = new Registry({
-    resolver
-  });
-
-  registry.resolve('foo:bar', {
-    source: 'baz:qux'
-  });
-});
-
-QUnit.test('has uses expandLocalLookup', function(assert) {
-  assert.expect(5);
-  let resolvedFullNames = [];
-  let result;
-
-  let resolver = {
-    resolve(name) {
-      if (EMBER_MODULE_UNIFICATION && name === 'foo:baz') { return; }
-      resolvedFullNames.push(name);
-
-      return 'yippie!';
-    },
-
-    expandLocalLookup(targetFullName, sourceFullName) {
-      assert.ok(true, 'expandLocalLookup is called on the resolver');
-
-      if (targetFullName === 'foo:bar') {
-        return 'foo:qux/bar';
-      } else {
-        return null;
-      }
-    }
-  };
-
-  let registry = new Registry({
-    resolver
-  });
-
-  result = registry.has('foo:bar', {
-    source: 'baz:qux'
-  });
-
-  assert.ok(result, 'found foo:bar/qux');
-
-  result = registry.has('foo:baz', {
-    source: 'baz:qux'
-  });
-
-  assert.ok(!result, 'foo:baz/qux not found');
-
-  assert.deepEqual(['foo:qux/bar'], resolvedFullNames);
-});
-
-QUnit.module('Registry privatize');
-
-QUnit.test('valid format', function(assert) {
-  let privatized = privatize(['secret:factory']);
-  let matched = privatized.match(/^([^:]+):([^:]+)-(\d+)$/);
-
-  assert.ok(matched, 'privatized format was recognized');
-  assert.equal(matched[1], 'secret');
-  assert.equal(matched[2], 'factory');
-  assert.ok(/^\d+$/.test(matched[3]));
-});
-
-if (EMBER_MODULE_UNIFICATION) {
-  QUnit.module('Registry module unification');
-
-  QUnit.test('The registry can pass a source to the resolver', function(assert) {
-    let PrivateComponent = factory();
-    let lookup = 'component:my-input';
-    let source = 'template:routes/application';
-    let resolveCount = 0;
+  ['@test The value returned from resolver is the same value as the original value even if the value is falsy'](assert) {
     let resolver = {
-      resolve(fullName, src) {
-        resolveCount++;
-        if (fullName === lookup && src === source) {
-          return PrivateComponent;
+      resolve(fullName) {
+        if (fullName === 'falsy:value') {
+          return null;
         }
       }
     };
     let registry = new Registry({ resolver });
-    registry.normalize = function(name) {
-      return name;
+
+    assert.strictEqual(registry.resolve('falsy:value'), null);
+  }
+
+  ['@test A registered factory returns true for `has` if an item is registered'](assert) {
+    let registry = new Registry();
+    let PostController = factory();
+
+    registry.register('controller:post', PostController);
+
+    assert.equal(registry.has('controller:post'), true, 'The `has` method returned true for registered factories');
+    assert.equal(registry.has('controller:posts'), false, 'The `has` method returned false for unregistered factories');
+  }
+
+  ['@test Throw exception when trying to inject `type:thing` on all type(s)']() {
+    let registry = new Registry();
+    let PostController = factory();
+
+    registry.register('controller:post', PostController);
+
+    expectAssertion(() => {
+      registry.typeInjection('controller', 'injected', 'controller:post');
+    }, /Cannot inject a 'controller:post' on other controller\(s\)\./);
+  }
+
+  ['@test The registry can take a hook to resolve factories lazily'](assert) {
+    let PostController = factory();
+    let resolver = {
+      resolve(fullName) {
+        if (fullName === 'controller:post') {
+          return PostController;
+        }
+      }
+    };
+    let registry = new Registry({ resolver });
+
+    assert.strictEqual(registry.resolve('controller:post'), PostController, 'The correct factory was provided');
+  }
+
+  ['@test The registry respects the resolver hook for `has`'](assert) {
+    let PostController = factory();
+    let resolver = {
+      resolve(fullName) {
+        if (fullName === 'controller:post') {
+          return PostController;
+        }
+      }
+    };
+    let registry = new Registry({ resolver });
+
+    assert.ok(registry.has('controller:post'), 'the `has` method uses the resolver hook');
+  }
+
+  ['@test The registry normalizes names when resolving'](assert) {
+    let registry = new Registry();
+    let PostController = factory();
+
+    registry.normalizeFullName = function(fullName) {
+      return 'controller:post';
     };
 
-    assert.strictEqual(registry.resolve(lookup, { source }), PrivateComponent, 'The correct factory was provided');
-    assert.strictEqual(registry.resolve(lookup, { source }), PrivateComponent, 'The correct factory was provided again');
-    assert.equal(resolveCount, 1, 'resolve called only once and a cached factory was returned the second time');
+    registry.register('controller:post', PostController);
+    let type = registry.resolve('controller:normalized');
+
+    assert.strictEqual(type, PostController, 'Normalizes the name when resolving');
+  }
+
+  ['@test The registry normalizes names when checking if the factory is registered'](assert) {
+    let registry = new Registry();
+    let PostController = factory();
+
+    registry.normalizeFullName = function(fullName) {
+      return fullName === 'controller:normalized' ? 'controller:post' : fullName;
+    };
+
+    registry.register('controller:post', PostController);
+    let isPresent = registry.has('controller:normalized');
+
+    assert.equal(isPresent, true, 'Normalizes the name when checking if the factory or instance is present');
+  }
+
+  ['@test The registry normalizes names when injecting'](assert) {
+    let registry = new Registry();
+    let PostController = factory();
+    let user = { name: 'Stef' };
+
+    registry.normalize = function(fullName) {
+      return 'controller:post';
+    };
+
+    registry.register('controller:post', PostController);
+    registry.register('user:post', user, { instantiate: false });
+    registry.injection('controller:post', 'user', 'controller:normalized');
+
+    assert.deepEqual(registry.resolve('controller:post'), user, 'Normalizes the name when injecting');
+  }
+
+  ['@test cannot register an `undefined` factory'](assert) {
+    let registry = new Registry();
+
+    assert.throws(() => {
+      registry.register('controller:apple', undefined);
+    }, '');
+  }
+
+  ['@test can re-register a factory'](assert) {
+    let registry = new Registry();
+    let FirstApple = factory('first');
+    let SecondApple = factory('second');
+
+    registry.register('controller:apple', FirstApple);
+    registry.register('controller:apple', SecondApple);
+
+    assert.ok(registry.resolve('controller:apple').create() instanceof SecondApple);
+  }
+
+  ['@test cannot re-register a factory if it has been resolved'](assert) {
+    let registry = new Registry();
+    let FirstApple = factory('first');
+    let SecondApple = factory('second');
+
+    registry.register('controller:apple', FirstApple);
+    assert.strictEqual(registry.resolve('controller:apple'), FirstApple);
+
+    expectAssertion(function() {
+      registry.register('controller:apple', SecondApple);
+    }, /Cannot re-register: 'controller:apple', as it has already been resolved\./);
+
+    assert.strictEqual(registry.resolve('controller:apple'), FirstApple);
+  }
+
+  ['@test registry.has should not accidentally cause injections on that factory to be run. (Mitigate merely on observing)'](assert) {
+    assert.expect(1);
+
+    let registry = new Registry();
+    let FirstApple = factory('first');
+    let SecondApple = factory('second');
+
+    SecondApple.extend = function(a, b, c) {
+      assert.ok(false, 'should not extend or touch the injected model, merely to inspect existence of another');
+    };
+
+    registry.register('controller:apple', FirstApple);
+    registry.register('controller:second-apple', SecondApple);
+    registry.injection('controller:apple', 'badApple', 'controller:second-apple');
+
+    assert.ok(registry.has('controller:apple'));
+  }
+
+  ['@test registry.has should not error for invalid fullNames'](assert) {
+    let registry = new Registry();
+
+    assert.ok(!registry.has('foo:bar:baz'));
+  }
+
+  ['@test once resolved, always return the same result'](assert) {
+    let registry = new Registry();
+
+    registry.resolver = {
+      resolve() {
+        return 'bar';
+      }
+    };
+
+    let Bar = registry.resolve('models:bar');
+
+    registry.resolver = {
+      resolve() {
+        return 'not bar';
+      }
+    };
+
+    assert.equal(registry.resolve('models:bar'), Bar);
+  }
+
+  ['@test factory resolves are cached'](assert) {
+    let registry = new Registry();
+    let PostController = factory();
+    let resolveWasCalled = [];
+
+    registry.resolver = {
+      resolve(fullName) {
+        resolveWasCalled.push(fullName);
+        return PostController;
+      }
+    };
+
+    assert.deepEqual(resolveWasCalled, []);
+    registry.resolve('controller:post');
+    assert.deepEqual(resolveWasCalled, ['controller:post']);
+
+    registry.resolve('controller:post');
+    assert.deepEqual(resolveWasCalled, ['controller:post']);
+  }
+
+  ['@test factory for non extendables (MODEL) resolves are cached'](assert) {
+    let registry = new Registry();
+    let PostController = factory();
+    let resolveWasCalled = [];
+
+    registry.resolver = {
+      resolve(fullName) {
+        resolveWasCalled.push(fullName);
+        return PostController;
+      }
+    };
+
+    assert.deepEqual(resolveWasCalled, []);
+    registry.resolve('model:post');
+    assert.deepEqual(resolveWasCalled, ['model:post']);
+
+    registry.resolve('model:post');
+    assert.deepEqual(resolveWasCalled, ['model:post']);
+  }
+
+  ['@test factory for non extendables resolves are cached'](assert) {
+    let registry = new Registry();
+    let PostController = {};
+    let resolveWasCalled = [];
+
+    registry.resolver = {
+      resolve(fullName) {
+        resolveWasCalled.push(fullName);
+        return PostController;
+      }
+    };
+
+    assert.deepEqual(resolveWasCalled, []);
+    registry.resolve('foo:post');
+    assert.deepEqual(resolveWasCalled, ['foo:post']);
+
+    registry.resolve('foo:post');
+    assert.deepEqual(resolveWasCalled, ['foo:post']);
+  }
+
+  ['@test registry.container creates a container'](assert) {
+    let registry = new Registry();
+    let PostController = factory();
+    registry.register('controller:post', PostController);
+
+    let container = registry.container();
+    let postController = container.lookup('controller:post');
+
+    assert.ok(postController instanceof PostController, 'The lookup is an instance of the registered factory');
+  }
+
+  ['@test `describe` will be handled by the resolver, then by the fallback registry, if available'](assert) {
+    let fallback = {
+      describe(fullName) {
+        return `${fullName}-fallback`;
+      }
+    };
+
+    let resolver = {
+      lookupDescription(fullName) {
+        return `${fullName}-resolver`;
+      }
+    };
+
+    let registry = new Registry({ fallback, resolver });
+
+    assert.equal(registry.describe('controller:post'), 'controller:post-resolver', '`describe` handled by the resolver first.');
+
+    registry.resolver = null;
+
+    assert.equal(registry.describe('controller:post'), 'controller:post-fallback', '`describe` handled by fallback registry next.');
+
+    registry.fallback = null;
+
+    assert.equal(registry.describe('controller:post'), 'controller:post', '`describe` by default returns argument.');
+  }
+
+  ['@test `normalizeFullName` will be handled by the resolver, then by the fallback registry, if available'](assert) {
+    let fallback = {
+      normalizeFullName(fullName) {
+        return `${fullName}-fallback`;
+      }
+    };
+
+    let resolver = {
+      normalize(fullName) {
+        return `${fullName}-resolver`;
+      }
+    };
+
+    let registry = new Registry({ fallback, resolver });
+
+    assert.equal(registry.normalizeFullName('controller:post'), 'controller:post-resolver', '`normalizeFullName` handled by the resolver first.');
+
+    registry.resolver = null;
+
+    assert.equal(registry.normalizeFullName('controller:post'), 'controller:post-fallback', '`normalizeFullName` handled by fallback registry next.');
+
+    registry.fallback = null;
+
+    assert.equal(registry.normalizeFullName('controller:post'), 'controller:post', '`normalizeFullName` by default returns argument.');
+  }
+
+  ['@test `makeToString` will be handled by the resolver, then by the fallback registry, if available'](assert) {
+    let fallback = {
+      makeToString(fullName) {
+        return `${fullName}-fallback`;
+      }
+    };
+
+    let resolver = {
+      makeToString(fullName) {
+        return `${fullName}-resolver`;
+      }
+    };
+
+    let registry = new Registry({ fallback, resolver });
+
+    assert.equal(registry.makeToString('controller:post'), 'controller:post-resolver', '`makeToString` handled by the resolver first.');
+
+    registry.resolver = null;
+
+    assert.equal(registry.makeToString('controller:post'), 'controller:post-fallback', '`makeToString` handled by fallback registry next.');
+
+    registry.fallback = null;
+
+    assert.equal(registry.makeToString('controller:post'), 'controller:post', '`makeToString` by default returns argument.');
+  }
+
+  ['@test `resolve` can be handled by a fallback registry'](assert) {
+    let fallback = new Registry();
+
+    let registry = new Registry({ fallback: fallback });
+    let PostController = factory();
+
+    fallback.register('controller:post', PostController);
+
+    let PostControllerFactory = registry.resolve('controller:post');
+
+    assert.ok(PostControllerFactory, 'factory is returned');
+    assert.ok(PostControllerFactory.create() instanceof  PostController, 'The return of factory.create is an instance of PostController');
+  }
+
+  ['@test `has` can be handled by a fallback registry'](assert) {
+    let fallback = new Registry();
+
+    let registry = new Registry({ fallback: fallback });
+    let PostController = factory();
+
+    fallback.register('controller:post', PostController);
+
+    assert.equal(registry.has('controller:post'), true, 'Fallback registry is checked for registration');
+  }
+
+  ['@test `getInjections` includes injections from a fallback registry'](assert) {
+    let fallback = new Registry();
+    let registry = new Registry({ fallback: fallback });
+
+    assert.equal(registry.getInjections('model:user').length, 0, 'No injections in the primary registry');
+
+    fallback.injection('model:user', 'post', 'model:post');
+
+    assert.equal(registry.getInjections('model:user').length, 1, 'Injections from the fallback registry are merged');
+  }
+
+  ['@test `getTypeInjections` includes type injections from a fallback registry'](assert) {
+    let fallback = new Registry();
+    let registry = new Registry({ fallback: fallback });
+
+    assert.equal(registry.getTypeInjections('model').length, 0, 'No injections in the primary registry');
+
+    fallback.injection('model', 'source', 'source:main');
+
+    assert.equal(registry.getTypeInjections('model').length, 1, 'Injections from the fallback registry are merged');
+  }
+
+  ['@test `knownForType` contains keys for each item of a given type'](assert) {
+    let registry = new Registry();
+
+    registry.register('foo:bar-baz', 'baz');
+    registry.register('foo:qux-fez', 'fez');
+
+    let found = registry.knownForType('foo');
+
+    assert.deepEqual(found, {
+      'foo:bar-baz': true,
+      'foo:qux-fez': true
+    });
+  }
+
+  ['@test `knownForType` includes fallback registry results'](assert) {
+    let fallback = new Registry();
+    let registry = new Registry({ fallback: fallback });
+
+    registry.register('foo:bar-baz', 'baz');
+    registry.register('foo:qux-fez', 'fez');
+    fallback.register('foo:zurp-zorp', 'zorp');
+
+    let found = registry.knownForType('foo');
+
+    assert.deepEqual(found, {
+      'foo:bar-baz': true,
+      'foo:qux-fez': true,
+      'foo:zurp-zorp': true
+    });
+  }
+
+  ['@test `knownForType` is called on the resolver if present'](assert) {
+    assert.expect(3);
+
+    let resolver = {
+      knownForType(type) {
+        ok(true, 'knownForType called on the resolver');
+        equal(type, 'foo', 'the type was passed through');
+
+        return { 'foo:yorp': true };
+      }
+    };
+
+    let registry = new Registry({
+      resolver
+    });
+    registry.register('foo:bar-baz', 'baz');
+
+    let found = registry.knownForType('foo');
+
+    assert.deepEqual(found, {
+      'foo:yorp': true,
+      'foo:bar-baz': true
+    });
+  }
+
+  ['@test A registry created with `resolver` function instead of an object throws deprecation'](assert) {
+    assert.expect(2);
+
+    ENV._ENABLE_RESOLVER_FUNCTION_SUPPORT = true;
+
+    let registry;
+
+    expectDeprecation(() => {
+      registry = new Registry({
+        resolver(fullName) {
+          return `${fullName}-resolved`;
+        }
+      });
+    }, 'Passing a `resolver` function into a Registry is deprecated. Please pass in a Resolver object with a `resolve` method.');
+
+    assert.equal(registry.resolve('foo:bar'), 'foo:bar-resolved', '`resolve` still calls the deprecated function');
+  }
+
+  ['@test A registry created with `resolver` function instead of an object throws assertion'](assert) {
+    assert.expect(1);
+
+    ENV._ENABLE_RESOLVER_FUNCTION_SUPPORT = false;
+
+    let registry;
+
+    expectAssertion(() => {
+      registry = new Registry({
+        resolver(fullName) {
+          return `${fullName}-resolved`;
+        }
+      });
+    }, /Passing a \`resolver\` function into a Registry is deprecated\. Please pass in a Resolver object with a \`resolve\` method\./);
+  }
+
+  ['@test resolver.expandLocalLookup is not required'](assert) {
+    let registry = new Registry({
+      resolver: { }
+    });
+
+    let result = registry.expandLocalLookup('foo:bar', {
+      source: 'baz:qux'
+    });
+
+    assert.equal(result, null);
+  }
+
+  ['@test expandLocalLookup is called on the resolver if present'](assert) {
+    assert.expect(4);
+
+    let resolver = {
+      expandLocalLookup: (targetFullName, sourceFullName) => {
+        assert.ok(true, 'expandLocalLookup is called on the resolver');
+        assert.equal(targetFullName, 'foo:bar', 'the targetFullName was passed through');
+        assert.equal(sourceFullName, 'baz:qux', 'the sourceFullName was passed through');
+
+        return 'foo:qux/bar';
+      }
+    };
+
+    let registry = new Registry({
+      resolver
+    });
+
+    let result = registry.expandLocalLookup('foo:bar', {
+      source: 'baz:qux'
+    });
+
+    assert.equal(result, 'foo:qux/bar');
+  }
+
+  ['@test `expandLocalLookup` is handled by the resolver, then by the fallback registry, if available'](assert) {
+    assert.expect(9);
+
+    let fallbackResolver = {
+      expandLocalLookup: (targetFullName, sourceFullName) => {
+        assert.ok(true, 'expandLocalLookup is called on the fallback resolver');
+        assert.equal(targetFullName, 'foo:bar', 'the targetFullName was passed through');
+        assert.equal(sourceFullName, 'baz:qux', 'the sourceFullName was passed through');
+
+        return 'foo:qux/bar-fallback';
+      }
+    };
+
+    let resolver = {
+      expandLocalLookup: (targetFullName, sourceFullName) => {
+        assert.ok(true, 'expandLocalLookup is called on the resolver');
+        assert.equal(targetFullName, 'foo:bar', 'the targetFullName was passed through');
+        assert.equal(sourceFullName, 'baz:qux', 'the sourceFullName was passed through');
+
+        return 'foo:qux/bar-resolver';
+      }
+    };
+
+    let fallbackRegistry = new Registry({
+      resolver: fallbackResolver
+    });
+
+    let registry = new Registry({
+      fallback: fallbackRegistry,
+      resolver
+    });
+
+    let result = registry.expandLocalLookup('foo:bar', {
+      source: 'baz:qux'
+    });
+
+    assert.equal(result, 'foo:qux/bar-resolver', 'handled by the resolver');
+
+    registry.resolver = null;
+
+    result = registry.expandLocalLookup('foo:bar', {
+      source: 'baz:qux'
+    });
+
+    assert.equal(result, 'foo:qux/bar-fallback', 'handled by the fallback registry');
+
+    registry.fallback = null;
+
+    result = registry.expandLocalLookup('foo:bar', {
+      source: 'baz:qux'
+    });
+
+    assert.equal(result, null, 'null is returned by default when no resolver or fallback registry is present');
+  }
+
+  ['@test resolver.expandLocalLookup result is cached'](assert) {
+    assert.expect(3);
+    let result;
+
+    let resolver = {
+      expandLocalLookup: (targetFullName, sourceFullName) => {
+        assert.ok(true, 'expandLocalLookup is called on the resolver');
+
+        return 'foo:qux/bar';
+      }
+    };
+
+    let registry = new Registry({
+      resolver
+    });
+
+    result = registry.expandLocalLookup('foo:bar', {
+      source: 'baz:qux'
+    });
+
+    assert.equal(result, 'foo:qux/bar');
+
+    result = registry.expandLocalLookup('foo:bar', {
+      source: 'baz:qux'
+    });
+
+    assert.equal(result, 'foo:qux/bar');
+  }
+
+  ['@test resolver.expandLocalLookup cache is busted when any unregister is called'](assert) {
+    assert.expect(4);
+    let result;
+
+    let resolver = {
+      expandLocalLookup: (targetFullName, sourceFullName) => {
+        assert.ok(true, 'expandLocalLookup is called on the resolver');
+
+        return 'foo:qux/bar';
+      }
+    };
+
+    let registry = new Registry({
+      resolver
+    });
+
+    result = registry.expandLocalLookup('foo:bar', {
+      source: 'baz:qux'
+    });
+
+    assert.equal(result, 'foo:qux/bar');
+
+    registry.unregister('foo:bar');
+
+    result = registry.expandLocalLookup('foo:bar', {
+      source: 'baz:qux'
+    });
+
+    assert.equal(result, 'foo:qux/bar');
+  }
+
+  ['@test resolve calls expandLocallookup when it receives options.source'](assert) {
+    assert.expect(3);
+
+    let resolver = {
+      resolve() { },
+      expandLocalLookup: (targetFullName, sourceFullName) => {
+        assert.ok(true, 'expandLocalLookup is called on the resolver');
+        assert.equal(targetFullName, 'foo:bar', 'the targetFullName was passed through');
+        assert.equal(sourceFullName, 'baz:qux', 'the sourceFullName was passed through');
+
+        return 'foo:qux/bar';
+      }
+    };
+
+    let registry = new Registry({
+      resolver
+    });
+
+    registry.resolve('foo:bar', {
+      source: 'baz:qux'
+    });
+  }
+
+  ['@test has uses expandLocalLookup'](assert) {
+    assert.expect(5);
+    let resolvedFullNames = [];
+    let result;
+
+    let resolver = {
+      resolve(name) {
+        if (EMBER_MODULE_UNIFICATION && name === 'foo:baz') { return; }
+        resolvedFullNames.push(name);
+
+        return 'yippie!';
+      },
+
+      expandLocalLookup: (targetFullName, sourceFullName) => {
+        assert.ok(true, 'expandLocalLookup is called on the resolver');
+
+        if (targetFullName === 'foo:bar') {
+          return 'foo:qux/bar';
+        } else {
+          return null;
+        }
+      }
+    };
+
+    let registry = new Registry({
+      resolver
+    });
+
+    result = registry.has('foo:bar', {
+      source: 'baz:qux'
+    });
+
+    assert.ok(result, 'found foo:bar/qux');
+
+    result = registry.has('foo:baz', {
+      source: 'baz:qux'
+    });
+
+    assert.ok(!result, 'foo:baz/qux not found');
+
+    assert.deepEqual(['foo:qux/bar'], resolvedFullNames);
+  }
+});
+
+moduleFor('Registry privatize', class extends AbstractTestCase {
+  ['@test valid format'](assert) {
+    let privatized = privatize(['secret:factory']);
+    let matched = privatized.match(/^([^:]+):([^:]+)-(\d+)$/);
+
+    assert.ok(matched, 'privatized format was recognized');
+    assert.equal(matched[1], 'secret');
+    assert.equal(matched[2], 'factory');
+    assert.ok(/^\d+$/.test(matched[3]));
+  }
+});
+
+if (EMBER_MODULE_UNIFICATION) {
+  moduleFor('Registry module unification', class extends AbstractTestCase {
+    ['@test The registry can pass a source to the resolver'](assert) {
+      let PrivateComponent = factory();
+      let lookup = 'component:my-input';
+      let source = 'template:routes/application';
+      let resolveCount = 0;
+      let resolver = {
+        resolve(fullName, src) {
+          resolveCount++;
+          if (fullName === lookup && src === source) {
+            return PrivateComponent;
+          }
+        }
+      };
+      let registry = new Registry({ resolver });
+      registry.normalize = function(name) {
+        return name;
+      };
+
+      assert.strictEqual(registry.resolve(lookup, { source }), PrivateComponent, 'The correct factory was provided');
+      assert.strictEqual(registry.resolve(lookup, { source }), PrivateComponent, 'The correct factory was provided again');
+      assert.equal(resolveCount, 1, 'resolve called only once and a cached factory was returned the second time');
+    }
   });
 }


### PR DESCRIPTION
See #15988 

Two things I observed while converting:

- `expectAssertion` and `expectDeprecation` are not available on `this.assert`. Is this intended? Is there a newer replacement for that?
- There are a couple of `assert.expect(1)` which is not needed as far as I know, correct?