### PR TITLE
Fix types and enforce typechecker in CI

### DIFF
--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -243,11 +243,10 @@ function runChecker(bin, args) {
 
 function codeQualityChecks() {
   var checkers = [
-    // TODO: Uncomment this to enable TS checker too
-    // runChecker('node', [
-    //   require.resolve('typescript/bin/tsc'),
-    //   '--noEmit'
-    // ]),
+    runChecker('node', [
+      require.resolve('typescript/bin/tsc'),
+      '--noEmit'
+    ]),
     runChecker('node', [
       require.resolve('tslint/bin/tslint'),
       '-p',

--- a/packages/ember-environment/lib/index.d.ts
+++ b/packages/ember-environment/lib/index.d.ts
@@ -6,4 +6,8 @@ export const environment: {
   history: History | null;
   userAgent: string;
   window: Window | null;
+}
+
+export const ENV: {
+  _ENABLE_RENDER_SUPPORT: boolean;
 };

--- a/packages/ember-glimmer/lib/component-managers/curly.ts
+++ b/packages/ember-glimmer/lib/component-managers/curly.ts
@@ -12,8 +12,6 @@ import {
   ComponentDefinition,
   ComponentManager,
   ElementOperations,
-  NamedArguments,
-  PositionalArguments,
   PreparedArguments,
   PrimitiveReference,
   Simple,
@@ -383,7 +381,7 @@ export default class CurlyComponentManager extends AbstractManager<ComponentStat
   }
 }
 
-export function validatePositionalParameters(named: NamedArguments, positional: PositionalArguments, positionalParamsDefinition: any) {
+export function validatePositionalParameters(named: { has(name: string): boolean }, positional: { length: number }, positionalParamsDefinition: any) {
   if (DEBUG) {
     if (!named || !positional || !positional.length) {
       return;
@@ -456,12 +454,20 @@ export function rerenderInstrumentDetails(component: any): any {
 
 const MANAGER = new CurlyComponentManager();
 
+// This is not any of glimmer-vm's proper Argument types because we
+// don't have sufficient public constructors to conveniently
+// reassemble one after we mangle the various arguments.
+interface CurriedArgs {
+  positional: any[];
+  named: any;
+}
+
 export class CurlyComponentDefinition extends ComponentDefinition<ComponentStateBucket> {
   public template: OwnedTemplate;
-  public args: Arguments | undefined;
+  public args: CurriedArgs | undefined;
 
   // tslint:disable-next-line:no-shadowed-variable
-  constructor(name: string, ComponentClass: ComponentClass, template: OwnedTemplate, args: Arguments | undefined, customManager?: ComponentManager<ComponentStateBucket>) {
+  constructor(name: string, ComponentClass: ComponentClass, template: OwnedTemplate, args: CurriedArgs | undefined, customManager?: ComponentManager<ComponentStateBucket>) {
     super(name, customManager || MANAGER, ComponentClass);
     this.template = template;
     this.args = args;

--- a/packages/ember-glimmer/lib/component.ts
+++ b/packages/ember-glimmer/lib/component.ts
@@ -1,8 +1,7 @@
 import { DirtyableTag } from '@glimmer/reference';
 import { readDOMAttr } from '@glimmer/runtime';
 import {
-  assert,
-  deprecate,
+  assert
 } from 'ember-debug';
 import {
   get,

--- a/packages/ember-glimmer/lib/components/link-to.ts
+++ b/packages/ember-glimmer/lib/components/link-to.ts
@@ -312,15 +312,13 @@
 */
 
 import { DEBUG } from 'ember-env-flags';
-import { assert, deprecate, warn } from 'ember-debug';
+import { assert, warn } from 'ember-debug';
 import {
   computed,
   flaggedInstrument,
   get,
 } from 'ember-metal';
 import {
-  ControllerMixin,
-  deprecatingAlias,
   inject,
 } from 'ember-runtime';
 import { isSimpleClick } from 'ember-views';

--- a/packages/ember-glimmer/lib/dom.ts
+++ b/packages/ember-glimmer/lib/dom.ts
@@ -1,2 +1,3 @@
+///<reference path="./simple-dom.d.ts" />
 export { DOMChanges, DOMTreeConstruction } from '@glimmer/runtime';
 export { NodeDOMTreeConstruction } from '@glimmer/node';

--- a/packages/ember-glimmer/lib/helpers/component.ts
+++ b/packages/ember-glimmer/lib/helpers/component.ts
@@ -3,6 +3,7 @@
 */
 import {
   Arguments,
+  CapturedArguments,
   Environment,
   isComponentDefinition,
   VM
@@ -147,19 +148,19 @@ import { CachedReference } from '../utils/references';
   @public
 */
 export class ClosureComponentReference extends CachedReference {
-  static create(args: Arguments, meta: any, env: Environment) {
+  static create(args: CapturedArguments, meta: any, env: Environment) {
     return new ClosureComponentReference(args, meta, env);
   }
 
   public defRef: any;
   public tag: any;
-  public args: Arguments;
+  public args: CapturedArguments;
   public meta: any;
   public env: Environment;
   public lastDefinition: any;
   public lastName: string | undefined;
 
-  constructor(args: Arguments, meta: any, env: Environment) {
+  constructor(args: CapturedArguments, meta: any, env: Environment) {
     super();
 
     let firstArg = args.positional.at(0);
@@ -212,7 +213,7 @@ export class ClosureComponentReference extends CachedReference {
   }
 }
 
-function createCurriedDefinition(definition: CurlyComponentDefinition, args: Arguments) {
+function createCurriedDefinition(definition: CurlyComponentDefinition, args: CapturedArguments) {
   let curriedArgs = curryArgs(definition, args);
 
   return new CurlyComponentDefinition(
@@ -223,7 +224,7 @@ function createCurriedDefinition(definition: CurlyComponentDefinition, args: Arg
   );
 }
 
-function curryArgs(definition: CurlyComponentDefinition, newArgs: Arguments): Arguments {
+function curryArgs(definition: CurlyComponentDefinition, newArgs: CapturedArguments): any {
   let { args, ComponentClass } = definition;
   let positionalParams = ComponentClass.class.positionalParams;
 

--- a/packages/ember-glimmer/lib/simple-dom.d.ts
+++ b/packages/ember-glimmer/lib/simple-dom.d.ts
@@ -1,0 +1,4 @@
+declare module "simple-dom" {
+  import { Simple } from "@glimmer/runtime";
+  export interface Document extends Simple.Document {}
+}

--- a/packages/ember-glimmer/lib/utils/bindings.ts
+++ b/packages/ember-glimmer/lib/utils/bindings.ts
@@ -133,7 +133,12 @@ class StyleBindingReference extends CachedReference<string | SafeString> {
 
 export const IsVisibleBinding = {
   install(element: Simple.Element, component: Component, operations: ElementOperations) {
-    operations.addDynamicAttribute(element, 'style', map(referenceForKey(component, 'isVisible'), this.mapStyleValue), false);
+    let ref = map(referenceForKey(component, 'isVisible'), this.mapStyleValue);
+
+    // the upstream type for addDynamicAttribute's `value` argument
+    // appears to be incorrect. It is currently a Reference<string>, I
+    // think it should be a Reference<string|null>.
+    operations.addDynamicAttribute(element, 'style', ref as any as Reference<string>, false);
   },
 
   mapStyleValue(isVisible: boolean) {
@@ -160,7 +165,10 @@ export const ClassNameBinding = {
         ref = new ColonClassNameBindingReference(value, truthy, falsy);
       }
 
-      operations.addDynamicAttribute(element, 'class', ref, false);
+      // the upstream type for addDynamicAttribute's `value` argument
+      // appears to be incorrect. It is currently a Reference<string>, I
+      // think it should be a Reference<string|null>.
+      operations.addDynamicAttribute(element, 'class', ref as any as Reference<string>, false);
     }
   },
 };

--- a/packages/ember-glimmer/lib/utils/string.ts
+++ b/packages/ember-glimmer/lib/utils/string.ts
@@ -2,8 +2,6 @@
 @module @ember/string
 */
 
-import { deprecate } from 'ember-debug';
-
 export class SafeString {
   public string: string;
 


### PR DESCRIPTION
This is based off #16000. It may be easier to review [these changes alone](https://github.com/emberjs/ember.js/compare/code-quality...fix-ts2).

I know we will soon integrate a newer version of glimmer-vm, so I didn't go deep into trying to model things that seemed to need upstream glimmer-vm changes. But these changes seem reasonable and they give us a consistent base to start from when integrating, with CI coverage to ensure we don't let more errors creep back in.