### PR TITLE
[CLEANUP] Convert ember-router tests to new style

### DIFF
--- a/packages/ember-routing/tests/ext/controller_test.js
+++ b/packages/ember-routing/tests/ext/controller_test.js
@@ -1,59 +1,55 @@
 import { setOwner } from 'ember-utils';
-import { buildOwner } from 'internal-test-helpers';
 import { Controller } from 'ember-runtime';
+import { buildOwner, moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
-QUnit.module('ember-routing/ext/controller');
+moduleFor('ember-routing/ext/controller', class extends AbstractTestCase {
+  ['@test transitionToRoute considers an engine\'s mountPoint'](assert) {
+    let router = {
+      transitionTo(route) {
+        return route;
+      }
+    };
 
-QUnit.test('transitionToRoute considers an engine\'s mountPoint', function() {
-  expect(4);
+    let engineInstance = buildOwner({
+      ownerOptions: {
+        routable: true,
+        mountPoint: 'foo.bar'
+      }
+    });
 
-  let router = {
-    transitionTo(route) {
-      return route;
-    }
-  };
+    let controller = Controller.create({ target: router });
+    setOwner(controller, engineInstance);
 
-  let engineInstance = buildOwner({
-    ownerOptions: {
-      routable: true,
-      mountPoint: 'foo.bar'
-    }
-  });
+    assert.strictEqual(controller.transitionToRoute('application'), 'foo.bar.application', 'properly prefixes application route');
+    assert.strictEqual(controller.transitionToRoute('posts'), 'foo.bar.posts', 'properly prefixes child routes');
+    assert.throws(() => controller.transitionToRoute('/posts'), 'throws when trying to use a url');
 
-  let controller = Controller.create({ target: router });
-  setOwner(controller, engineInstance);
+    let queryParams = {};
+    assert.strictEqual(controller.transitionToRoute(queryParams), queryParams, 'passes query param only transitions through');
+  }
 
-  strictEqual(controller.transitionToRoute('application'), 'foo.bar.application', 'properly prefixes application route');
-  strictEqual(controller.transitionToRoute('posts'), 'foo.bar.posts', 'properly prefixes child routes');
-  throws(() => controller.transitionToRoute('/posts'), 'throws when trying to use a url');
+  ['@test replaceRoute considers an engine\'s mountPoint'](assert) {
+    let router = {
+      replaceWith(route) {
+        return route;
+      }
+    };
 
-  let queryParams = {};
-  strictEqual(controller.transitionToRoute(queryParams), queryParams, 'passes query param only transitions through');
-});
+    let engineInstance = buildOwner({
+      ownerOptions: {
+        routable: true,
+        mountPoint: 'foo.bar'
+      }
+    });
 
-QUnit.test('replaceRoute considers an engine\'s mountPoint', function() {
-  expect(4);
+    let controller = Controller.create({ target: router });
+    setOwner(controller, engineInstance);
 
-  let router = {
-    replaceWith(route) {
-      return route;
-    }
-  };
+    assert.strictEqual(controller.replaceRoute('application'), 'foo.bar.application', 'properly prefixes application route');
+    assert.strictEqual(controller.replaceRoute('posts'), 'foo.bar.posts', 'properly prefixes child routes');
+    assert.throws(() => controller.replaceRoute('/posts'), 'throws when trying to use a url');
 
-  let engineInstance = buildOwner({
-    ownerOptions: {
-      routable: true,
-      mountPoint: 'foo.bar'
-    }
-  });
-
-  let controller = Controller.create({ target: router });
-  setOwner(controller, engineInstance);
-
-  strictEqual(controller.replaceRoute('application'), 'foo.bar.application', 'properly prefixes application route');
-  strictEqual(controller.replaceRoute('posts'), 'foo.bar.posts', 'properly prefixes child routes');
-  throws(() => controller.replaceRoute('/posts'), 'throws when trying to use a url');
-
-  let queryParams = {};
-  strictEqual(controller.replaceRoute(queryParams), queryParams, 'passes query param only transitions through');
+    let queryParams = {};
+    assert.strictEqual(controller.replaceRoute(queryParams), queryParams, 'passes query param only transitions through');
+  }
 });

--- a/packages/ember-routing/tests/location/auto_location_test.js
+++ b/packages/ember-routing/tests/location/auto_location_test.js
@@ -9,27 +9,27 @@ import {
 import HistoryLocation from '../../location/history_location';
 import HashLocation from '../../location/hash_location';
 import NoneLocation from '../../location/none_location';
-import { buildOwner } from 'internal-test-helpers';
+import { buildOwner, moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
-function mockBrowserLocation(overrides) {
+function mockBrowserLocation(overrides, assert) {
   return assign({
     href: 'http://test.com/',
     pathname: '/',
     hash: '',
     search: '',
     replace() {
-      ok(false, 'location.replace should not be called during testing');
+      assert.ok(false, 'location.replace should not be called during testing');
     }
   }, overrides);
 }
 
-function mockBrowserHistory(overrides) {
+function mockBrowserHistory(overrides, assert) {
   return assign({
     pushState() {
-      ok(false, 'history.pushState should not be called during testing');
+      assert.ok(false, 'history.pushState should not be called during testing');
     },
     replaceState() {
-      ok(false, 'history.replaceState should not be called during testing');
+      assert.ok(false, 'history.replaceState should not be called during testing');
     }
   }, overrides);
 }
@@ -53,246 +53,228 @@ function createLocation(location, history) {
 
 let location;
 
-QUnit.module('Ember.AutoLocation', {
+moduleFor('Ember.AutoLocation', class extends AbstractTestCase {
   teardown() {
     if (location) {
       run(location, 'destroy');
     }
   }
-});
 
-QUnit.test('AutoLocation should have the `global`', function(assert) {
-  let location = AutoLocation.create();
+  ['@test AutoLocation should have the `global`'](assert) {
+    let location = AutoLocation.create();
 
-  assert.ok(location.global, 'has a global defined');
-  assert.strictEqual(location.global, environment.window, 'has the environments window global');
-});
+    assert.ok(location.global, 'has a global defined');
+    assert.strictEqual(location.global, environment.window, 'has the environments window global');
+  }
 
-QUnit.test('AutoLocation should return concrete implementation\'s value for `getURL`', function() {
-  expect(1);
+  ['@test AutoLocation should return concrete implementation\'s value for `getURL`'](assert) {
+    let browserLocation = mockBrowserLocation({}, assert);
+    let browserHistory = mockBrowserHistory({}, assert);
 
-  let browserLocation = mockBrowserLocation();
-  let browserHistory = mockBrowserHistory();
-
-  location = createLocation(browserLocation, browserHistory);
-  location.detect();
-
-  let concreteImplementation = get(location, 'concreteImplementation');
-
-  concreteImplementation.getURL = function() {
-    return '/lincoln/park';
-  };
-
-  equal(location.getURL(), '/lincoln/park');
-});
-
-QUnit.test('AutoLocation should use a HistoryLocation instance when pushStates is supported', function() {
-  expect(1);
-
-  let browserLocation = mockBrowserLocation();
-  let browserHistory = mockBrowserHistory();
-
-  location = createLocation(browserLocation, browserHistory);
-  location.detect();
-
-  ok(get(location, 'concreteImplementation') instanceof HistoryLocation);
-});
-
-QUnit.test('AutoLocation should use a HashLocation instance when pushStates are not supported, but hashchange events are and the URL is already in the HashLocation format', function() {
-  expect(1);
-
-  let browserLocation = mockBrowserLocation({
-    hash: '#/testd'
-  });
-
-  location = createLocation(browserLocation);
-  location.global = {
-    onhashchange() { }
-  };
-
-  location.detect();
-  ok(get(location, 'concreteImplementation') instanceof HashLocation);
-});
-
-QUnit.test('AutoLocation should use a NoneLocation instance when neither history nor hashchange are supported.', function() {
-  expect(1);
-
-  location = createLocation(mockBrowserLocation());
-  location.detect();
-
-  ok(get(location, 'concreteImplementation') instanceof NoneLocation);
-});
-
-QUnit.test('AutoLocation should use an index path (i.e. \'/\') without any location.hash as OK for HashLocation', function() {
-  expect(1);
-
-  let browserLocation = mockBrowserLocation({
-    href: 'http://test.com/',
-    pathname: '/',
-    hash: '',
-    search: '',
-    replace() {
-      ok(false, 'location.replace should not be called');
-    }
-  });
-
-  location = createLocation(browserLocation);
-  location.global = {
-    onhashchange() { }
-  };
-
-  location.detect();
-
-  ok(get(location, 'concreteImplementation') instanceof HashLocation, 'uses a HashLocation');
-});
-
-QUnit.test('AutoLocation should transform the URL for hashchange-only browsers viewing a HistoryLocation-formatted path', function() {
-  expect(3);
-
-  let browserLocation = mockBrowserLocation({
-    hash: '',
-    hostname: 'test.com',
-    href: 'http://test.com/test',
-    pathname: '/test',
-    protocol: 'http:',
-    port: '',
-    search: '',
-
-    replace(path) {
-      equal(path, 'http://test.com/#/test', 'location.replace should be called with normalized HashLocation path');
-    }
-  });
-
-  let location = createLocation(browserLocation);
-  location.global = {
-    onhashchange() { }
-  };
-
-  location.detect();
-
-  ok(get(location, 'concreteImplementation') instanceof NoneLocation, 'NoneLocation should be used while we attempt to location.replace()');
-  equal(get(location, 'cancelRouterSetup'), true, 'cancelRouterSetup should be set so the router knows.');
-});
-
-QUnit.test('AutoLocation should replace the URL for pushState-supported browsers viewing a HashLocation-formatted url', function() {
-  expect(2);
-
-  let browserLocation = mockBrowserLocation({
-    hash: '#/test',
-    hostname: 'test.com',
-    href: 'http://test.com/#/test',
-    pathname: '/',
-    protocol: 'http:',
-    port: '',
-    search: ''
-  });
-
-  let browserHistory = mockBrowserHistory({
-    replaceState(state, title, path) {
-      equal(path, '/test', 'history.replaceState should be called with normalized HistoryLocation url');
-    }
-  });
-
-  let location = createLocation(browserLocation, browserHistory);
-  location.detect();
-
-  ok(get(location, 'concreteImplementation'), HistoryLocation);
-});
-
-QUnit.test('AutoLocation requires any rootURL given to end in a trailing forward slash', function() {
-  expect(3);
-  let browserLocation = mockBrowserLocation();
-  let expectedMsg = /rootURL must end with a trailing forward slash e.g. "\/app\/"/;
-
-  location = createLocation(browserLocation);
-  location.rootURL = 'app';
-
-  expectAssertion(function() {
+    location = createLocation(browserLocation, browserHistory);
     location.detect();
-  }, expectedMsg);
 
-  location.rootURL = '/app';
-  expectAssertion(function() {
+    let concreteImplementation = get(location, 'concreteImplementation');
+
+    concreteImplementation.getURL = function() {
+      return '/lincoln/park';
+    };
+
+    assert.equal(location.getURL(), '/lincoln/park');
+  }
+
+  ['@test AutoLocation should use a HistoryLocation instance when pushStates is supported'](assert) {
+    let browserLocation = mockBrowserLocation({}, assert);
+    let browserHistory = mockBrowserHistory({}, assert);
+
+    location = createLocation(browserLocation, browserHistory);
     location.detect();
-  }, expectedMsg);
 
-  // Note the trailing whitespace
-  location.rootURL = '/app/ ';
-  expectAssertion(function() {
+    assert.ok(get(location, 'concreteImplementation') instanceof HistoryLocation);
+  }
+
+  ['@test AutoLocation should use a HashLocation instance when pushStates are not supported, but hashchange events are and the URL is already in the HashLocation format'](assert) {
+    let browserLocation = mockBrowserLocation({
+      hash: '#/testd'
+    }, assert);
+
+    location = createLocation(browserLocation);
+    location.global = {
+      onhashchange() { }
+    };
+
     location.detect();
-  }, expectedMsg);
-});
+    assert.ok(get(location, 'concreteImplementation') instanceof HashLocation);
+  }
 
-QUnit.test('AutoLocation provides its rootURL to the concreteImplementation', function() {
-  expect(1);
-  let browserLocation = mockBrowserLocation({
-    pathname: '/some/subdir/derp'
-  });
-  let browserHistory = mockBrowserHistory();
+  ['@test AutoLocation should use a NoneLocation instance when neither history nor hashchange are supported.'](assert) {
+    location = createLocation(mockBrowserLocation({}, assert));
+    location.detect();
 
-  location = createLocation(browserLocation, browserHistory);
-  location.rootURL = '/some/subdir/';
+    assert.ok(get(location, 'concreteImplementation') instanceof NoneLocation);
+  }
 
-  location.detect();
+  ['@test AutoLocation should use an index path (i.e. \'/\') without any location.hash as OK for HashLocation'](assert) {
+    let browserLocation = mockBrowserLocation({
+      href: 'http://test.com/',
+      pathname: '/',
+      hash: '',
+      search: '',
+      replace() {
+        assert.ok(false, 'location.replace should not be called');
+      }
+    }, assert);
 
-  let concreteLocation = get(location, 'concreteImplementation');
-  equal(location.rootURL, concreteLocation.rootURL);
-});
+    location = createLocation(browserLocation);
+    location.global = {
+      onhashchange() { }
+    };
 
-QUnit.test('getHistoryPath() should return a normalized, HistoryLocation-supported path', function() {
-  expect(3);
+    location.detect();
 
-  let browserLocation = mockBrowserLocation({
-    href: 'http://test.com/app/about?foo=bar#foo',
-    pathname: '/app/about',
-    search: '?foo=bar',
-    hash: '#foo'
-  });
+    assert.ok(get(location, 'concreteImplementation') instanceof HashLocation, 'uses a HashLocation');
+  }
 
-  equal(getHistoryPath('/app/', browserLocation), '/app/about?foo=bar#foo', 'URLs already in HistoryLocation form should come out the same');
+  ['@test AutoLocation should transform the URL for hashchange-only browsers viewing a HistoryLocation-formatted path'](assert) {
+    assert.expect(3);
 
-  browserLocation = mockBrowserLocation({
-    href: 'http://test.com/app/#/about?foo=bar#foo',
-    pathname: '/app/',
-    search: '',
-    hash: '#/about?foo=bar#foo'
-  });
-  equal(getHistoryPath('/app/', browserLocation), '/app/about?foo=bar#foo', 'HashLocation formed URLs should be normalized');
+    let browserLocation = mockBrowserLocation({
+      hash: '',
+      hostname: 'test.com',
+      href: 'http://test.com/test',
+      pathname: '/test',
+      protocol: 'http:',
+      port: '',
+      search: '',
+      replace(path) {
+        assert.equal(path, 'http://test.com/#/test', 'location.replace should be called with normalized HashLocation path');
+      }
+    }, assert);
 
-  browserLocation = mockBrowserLocation({
-    href: 'http://test.com/app/#about?foo=bar#foo',
-    pathname: '/app/',
-    search: '',
-    hash: '#about?foo=bar#foo'
-  });
-  equal(getHistoryPath('/app', browserLocation), '/app/#about?foo=bar#foo', 'URLs with a hash not following #/ convention shouldn\'t be normalized as a route');
-});
+    let location = createLocation(browserLocation);
+    location.global = {
+      onhashchange() { }
+    };
 
-QUnit.test('getHashPath() should return a normalized, HashLocation-supported path', function() {
-  expect(3);
+    location.detect();
 
-  let browserLocation = mockBrowserLocation({
-    href: 'http://test.com/app/#/about?foo=bar#foo',
-    pathname: '/app/',
-    search: '',
-    hash: '#/about?foo=bar#foo'
-  });
-  equal(getHashPath('/app/', browserLocation), '/app/#/about?foo=bar#foo', 'URLs already in HistoryLocation form should come out the same');
+    assert.ok(get(location, 'concreteImplementation') instanceof NoneLocation, 'NoneLocation should be used while we attempt to location.replace()');
+    assert.equal(get(location, 'cancelRouterSetup'), true, 'cancelRouterSetup should be set so the router knows.');
+  }
 
-  browserLocation = mockBrowserLocation({
-    href: 'http://test.com/app/about?foo=bar#foo',
-    pathname: '/app/about',
-    search: '?foo=bar',
-    hash: '#foo'
-  });
-  equal(getHashPath('/app/', browserLocation), '/app/#/about?foo=bar#foo', 'HistoryLocation formed URLs should be normalized');
+  ['@test AutoLocation should replace the URL for pushState-supported browsers viewing a HashLocation-formatted url'](assert) {
+    assert.expect(2);
+    let browserLocation = mockBrowserLocation({
+      hash: '#/test',
+      hostname: 'test.com',
+      href: 'http://test.com/#/test',
+      pathname: '/',
+      protocol: 'http:',
+      port: '',
+      search: ''
+    }, assert);
 
-  browserLocation = mockBrowserLocation({
-    href: 'http://test.com/app/#about?foo=bar#foo',
-    pathname: '/app/',
-    search: '',
-    hash: '#about?foo=bar#foo'
-  });
+    let browserHistory = mockBrowserHistory({
+      replaceState(state, title, path) {
+        assert.equal(path, '/test', 'history.replaceState should be called with normalized HistoryLocation url');
+      }
+    }, assert);
 
-  equal(getHashPath('/app/', browserLocation), '/app/#/#about?foo=bar#foo', 'URLs with a hash not following #/ convention shouldn\'t be normalized as a route');
+    let location = createLocation(browserLocation, browserHistory);
+    location.detect();
+
+    assert.ok(get(location, 'concreteImplementation'), HistoryLocation);
+  }
+
+  ['@test AutoLocation requires any rootURL given to end in a trailing forward slash'](assert) {
+    let browserLocation = mockBrowserLocation({}, assert);
+    let expectedMsg = /rootURL must end with a trailing forward slash e.g. "\/app\/"/;
+
+    location = createLocation(browserLocation);
+    location.rootURL = 'app';
+
+    expectAssertion(function() {
+      location.detect();
+    }, expectedMsg);
+
+    location.rootURL = '/app';
+    expectAssertion(function() {
+      location.detect();
+    }, expectedMsg);
+
+    // Note the trailing whitespace
+    location.rootURL = '/app/ ';
+    expectAssertion(function() {
+      location.detect();
+    }, expectedMsg);
+  }
+
+  ['@test AutoLocation provides its rootURL to the concreteImplementation'](assert) {
+    let browserLocation = mockBrowserLocation({
+      pathname: '/some/subdir/derp'
+    }, assert);
+    let browserHistory = mockBrowserHistory({}, assert);
+
+    location = createLocation(browserLocation, browserHistory);
+    location.rootURL = '/some/subdir/';
+
+    location.detect();
+
+    let concreteLocation = get(location, 'concreteImplementation');
+    assert.equal(location.rootURL, concreteLocation.rootURL);
+  }
+
+  ['@test getHistoryPath() should return a normalized, HistoryLocation-supported path'](assert) {
+    let browserLocation = mockBrowserLocation({
+      href: 'http://test.com/app/about?foo=bar#foo',
+      pathname: '/app/about',
+      search: '?foo=bar',
+      hash: '#foo'
+    }, assert);
+
+    assert.equal(getHistoryPath('/app/', browserLocation), '/app/about?foo=bar#foo', 'URLs already in HistoryLocation form should come out the same');
+
+    browserLocation = mockBrowserLocation({
+      href: 'http://test.com/app/#/about?foo=bar#foo',
+      pathname: '/app/',
+      search: '',
+      hash: '#/about?foo=bar#foo'
+    }, assert);
+    assert.equal(getHistoryPath('/app/', browserLocation), '/app/about?foo=bar#foo', 'HashLocation formed URLs should be normalized');
+
+    browserLocation = mockBrowserLocation({
+      href: 'http://test.com/app/#about?foo=bar#foo',
+      pathname: '/app/',
+      search: '',
+      hash: '#about?foo=bar#foo'
+    }, assert);
+    assert.equal(getHistoryPath('/app', browserLocation), '/app/#about?foo=bar#foo', 'URLs with a hash not following #/ convention shouldn\'t be normalized as a route');
+  }
+
+  ['@test getHashPath() should return a normalized, HashLocation-supported path'](assert) {
+    let browserLocation = mockBrowserLocation({
+      href: 'http://test.com/app/#/about?foo=bar#foo',
+      pathname: '/app/',
+      search: '',
+      hash: '#/about?foo=bar#foo'
+    }, assert);
+    assert.equal(getHashPath('/app/', browserLocation), '/app/#/about?foo=bar#foo', 'URLs already in HistoryLocation form should come out the same');
+
+    browserLocation = mockBrowserLocation({
+      href: 'http://test.com/app/about?foo=bar#foo',
+      pathname: '/app/about',
+      search: '?foo=bar',
+      hash: '#foo'
+    }, assert);
+    assert.equal(getHashPath('/app/', browserLocation), '/app/#/about?foo=bar#foo', 'HistoryLocation formed URLs should be normalized');
+
+    browserLocation = mockBrowserLocation({
+      href: 'http://test.com/app/#about?foo=bar#foo',
+      pathname: '/app/',
+      search: '',
+      hash: '#about?foo=bar#foo'
+    }, assert);
+
+    assert.equal(getHashPath('/app/', browserLocation), '/app/#/#about?foo=bar#foo', 'URLs with a hash not following #/ convention shouldn\'t be normalized as a route');
+  }
 });

--- a/packages/ember-routing/tests/utils_test.js
+++ b/packages/ember-routing/tests/utils_test.js
@@ -1,36 +1,34 @@
-import {
-  normalizeControllerQueryParams
-} from '../utils';
+import { normalizeControllerQueryParams } from '../utils';
+import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
+moduleFor('Routing query parameter utils - normalizeControllerQueryParams', class extends AbstractTestCase {
+  ['@test converts array style into verbose object style'](assert) {
+    let paramName = 'foo';
+    let params = [paramName];
+    let normalized = normalizeControllerQueryParams(params);
 
-QUnit.module('Routing query parameter utils - normalizeControllerQueryParams');
+    assert.ok(normalized[paramName], 'turns the query param name into key');
+    assert.equal(normalized[paramName].as, null, 'includes a blank alias in \'as\' key');
+    assert.equal(normalized[paramName].scope, 'model', 'defaults scope to model');
+  }
 
-QUnit.test('converts array style into verbose object style', function() {
-  let paramName = 'foo';
-  let params = [paramName];
-  let normalized = normalizeControllerQueryParams(params);
+  ['@test converts object style [{foo: \'an_alias\'}]'](assert) {
+    let paramName = 'foo';
+    let params = [{ 'foo': 'an_alias' }];
+    let normalized = normalizeControllerQueryParams(params);
 
-  ok(normalized[paramName], 'turns the query param name into key');
-  equal(normalized[paramName].as, null, 'includes a blank alias in \'as\' key');
-  equal(normalized[paramName].scope, 'model', 'defaults scope to model');
-});
+    assert.ok(normalized[paramName], 'retains the query param name as key');
+    assert.equal(normalized[paramName].as, 'an_alias', 'includes the provided alias in \'as\' key');
+    assert.equal(normalized[paramName].scope, 'model', 'defaults scope to model');
+  }
 
-QUnit.test('converts object style [{foo: \'an_alias\'}]', function() {
-  let paramName = 'foo';
-  let params = [{ 'foo': 'an_alias' }];
-  let normalized = normalizeControllerQueryParams(params);
+  ['@test retains maximally verbose object style [{foo: {as: \'foo\'}}]'](assert) {
+    let paramName = 'foo';
+    let params = [{ 'foo': { as: 'an_alias' } }];
+    let normalized = normalizeControllerQueryParams(params);
 
-  ok(normalized[paramName], 'retains the query param name as key');
-  equal(normalized[paramName].as, 'an_alias', 'includes the provided alias in \'as\' key');
-  equal(normalized[paramName].scope, 'model', 'defaults scope to model');
-});
-
-QUnit.test('retains maximally verbose object style [{foo: {as: \'foo\'}}]', function() {
-  let paramName = 'foo';
-  let params = [{ 'foo': { as: 'an_alias' } }];
-  let normalized = normalizeControllerQueryParams(params);
-
-  ok(normalized[paramName], 'retains the query param name as key');
-  equal(normalized[paramName].as, 'an_alias', 'includes the provided alias in \'as\' key');
-  equal(normalized[paramName].scope, 'model', 'defaults scope to model');
+    assert.ok(normalized[paramName], 'retains the query param name as key');
+    assert.equal(normalized[paramName].as, 'an_alias', 'includes the provided alias in \'as\' key');
+    assert.equal(normalized[paramName].scope, 'model', 'defaults scope to model');
+  }
 });


### PR DESCRIPTION
Apart of #15988 

During this I created a subtask on the Quest issue for us to move `expectAssertion` and `expectDeprecation` onto assert. This is just a subpart for the ember-router package so that these PRs arn't too big. 