### PR TITLE
assert for non-array values in `concatenatedProperties` and `mergedProperties`

### DIFF
--- a/packages/ember-metal/tests/mixin/concatenated_properties_test.js
+++ b/packages/ember-metal/tests/mixin/concatenated_properties_test.js
@@ -18,20 +18,6 @@ moduleFor(
       assert.deepEqual(get(obj, 'foo'), ['a', 'b', 'c', 'd', 'e', 'f']);
     }
 
-    ['@test defining concatenated properties should concat future version'](assert) {
-      let MixinA = Mixin.create({
-        concatenatedProperties: null,
-      });
-
-      let MixinB = Mixin.create({
-        concatenatedProperties: null,
-      });
-
-      let obj = mixin({}, MixinA, MixinB);
-
-      assert.deepEqual(obj.concatenatedProperties, []);
-    }
-
     ['@test concatenatedProperties should be concatenated'](assert) {
       let MixinA = Mixin.create({
         concatenatedProperties: ['foo'],
@@ -39,7 +25,7 @@ moduleFor(
       });
 
       let MixinB = Mixin.create({
-        concatenatedProperties: 'bar',
+        concatenatedProperties: ['bar'],
         foo: ['d', 'e', 'f'],
         bar: [1, 2, 3],
       });
@@ -112,6 +98,32 @@ moduleFor(
 
       let obj = mixin({}, mixinA, mixinB);
       assert.deepEqual(get(obj, 'foobar'), ['foo', 'bar']);
+    }
+
+    ['@test should assert for non-array value in concatenatedProperties']() {
+      let mixinA = Mixin.create({
+        concatenatedProperties: ['a', 'b', 'c'],
+      });
+
+      let mixinB = Mixin.create({
+        concatenatedProperties: null,
+      });
+
+      let mixinC = Mixin.create({
+        concatenatedProperties: 'bar',
+      });
+
+      expectAssertion(()=> {
+        mixin({}, mixinA, mixinB);
+      }, 'You passed in `null` as the value for `concatenatedProperties` but `concatenatedProperties` should be an Array');
+
+      expectAssertion(()=> {
+        mixin({}, mixinA, mixinC);
+      }, 'You passed in `"bar"` as the value for `concatenatedProperties` but `concatenatedProperties` should be an Array');
+
+      expectAssertion(()=> {
+        mixin({}, mixinB, mixinA);
+      }, 'You passed in `null` as the value for `concatenatedProperties` but `concatenatedProperties` should be an Array');
     }
   }
 );

--- a/packages/ember-metal/tests/mixin/merged_properties_test.js
+++ b/packages/ember-metal/tests/mixin/merged_properties_test.js
@@ -82,7 +82,7 @@ moduleFor(
       });
 
       let MixinB = Mixin.create({
-        mergedProperties: 'bar',
+        mergedProperties: ['bar'],
         foo: { d: true, e: true, f: true },
         bar: { a: true, l: true },
       });
@@ -195,6 +195,32 @@ moduleFor(
       expectAssertion(() => {
         mixin({}, MixinA, MixinB);
       }, 'You passed in `["a"]` as the value for `foo` but `foo` cannot be an Array');
+    }
+
+    ['@test should assert for non-array value in mergedProperties']() {
+      let mixinA = Mixin.create({
+        mergedProperties: ['a', 'b', 'c'],
+      });
+
+      let mixinB = Mixin.create({
+        mergedProperties: null,
+      });
+
+      let mixinC = Mixin.create({
+        mergedProperties: 'bar',
+      });
+
+      expectAssertion(()=> {
+        mixin({}, mixinA, mixinB);
+      }, 'You passed in `null` as the value for `mergedProperties` but `mergedProperties` should be an Array');
+
+      expectAssertion(()=> {
+        mixin({}, mixinA, mixinC);
+      }, 'You passed in `"bar"` as the value for `mergedProperties` but `mergedProperties` should be an Array');
+
+      expectAssertion(()=> {
+        mixin({}, mixinB, mixinA);
+      }, 'You passed in `null` as the value for `mergedProperties` but `mergedProperties` should be an Array');
     }
   }
 );

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -412,7 +412,7 @@ CoreObject.PrototypeMixin = Mixin.create({
     @default null
     @public
   */
-  concatenatedProperties: null,
+  // concatenatedProperties: null,
 
   /**
     Defines the properties that will be merged from the superclass
@@ -488,7 +488,7 @@ CoreObject.PrototypeMixin = Mixin.create({
     @default null
     @public
   */
-  mergedProperties: null,
+  // mergedProperties: null,
 
   /**
     Destroyed object property flag.


### PR DESCRIPTION
possible fix for #16014 