### PR TITLE
Tell eslint to ignore Typescript files.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 blueprints/*/*files/**/*.js
 dist/
 tmp/
+**/*.ts


### PR DESCRIPTION
Prior to this in-editor `eslint`ing will trigger annoying warnings/errors about "invalid eslint config" for typescript files.  Since we are using tslint for these files anyways, this just makes eslint properly ignore them...