### PR TITLE
Begin publishing npm tarballs to S3.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ bower_components/
 npm-debug.log
 .ember-cli
 DEBUG/
+*.tgz
+*.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ env:
     - secure: e0yxVfwVW61d3Mi/QBOsY6Rfd1mZd3VXUd9xNRoz/fkvQJRuVwDe7oG3NOuJ4LZzvMw7BJ+zpDV9D8nKhAyPEEOgpkkMHUB7Ds83pHG4qSMzm4EAwBCadDLXCQirldz8dzN5FAqgGucXoj5fj/p2SKOkO6qWIZveGr8pdBJEG1E=
   matrix:
     - TEST_SUITE=sauce
-    - TEST_SUITE=each-package-tests PUBLISH=true
+    - TEST_SUITE=each-package-tests BUILD_TYPE=canary PUBLISH=true
     - TEST_SUITE=built-tests EMBER_ENV=production DISABLE_JSCS=true DISABLE_JSHINT=true
     - TEST_SUITE=old-jquery-and-extend-prototypes DISABLE_JSCS=true DISABLE_JSHINT=true
     - TEST_SUITE=node DISABLE_JSCS=true DISABLE_JSHINT=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ before_install:
     sudo apt-get install -y -qq yarn
     yarn --version
 
+    # install the most recent `npm version`
+    # used when publishing to build a properly packed tarball
+    npm i -g npm
+
 install:
 - |
     yarn install

--- a/bin/build-for-publishing.js
+++ b/bin/build-for-publishing.js
@@ -21,11 +21,32 @@ function updatePackageJSONVersion() {
   fs.writeFileSync(packageJSONPath, JSON.stringify(pkg, null, 2), { encoding: 'utf-8' });
 }
 
+/*
+  Updates the version number listed within the docs/data.json file to match
+  `Ember.VERSION` and `package.json` version.
+
+  This is needed because ember-cli-yuidoc automatically sets the version string
+  property in the generated `docs/data.json` to
+`${packageJsonVersion}.${gitSha}`.
+*/
+function updateDocumentationVersion() {
+  let docsPath = path.join(__dirname, '..', 'docs', 'data.json');
+  let VERSION = require('../broccoli/version').VERSION;
+
+  let contents = fs.readFileSync(docsPath, { encoding: 'utf-8' });
+  let docs = JSON.parse(contents);
+  docs.project.version = VERSION;
+  fs.writeFileSync(docsPath, JSON.stringify(docs, null, 2), { encoding: 'utf-8' });
+}
 
 updatePackageJSONVersion();
 
 // do a production build
 execSync('yarn build');
+
+// generate docs
+execSync('yarn docs');
+updateDocumentationVersion();
 
 // using npm pack here because `yarn pack` does not honor the `package.json`'s `files`
 // property properly, and therefore the tarball generated is quite large (~7MB).

--- a/bin/build-for-publishing.js
+++ b/bin/build-for-publishing.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const execSync = require('child_process').execSync;
+
+/*
+  Updates the `package.json`'s `version` string to be the same value that
+  the built assets will have as `Ember.VERSION`.
+*/
+function updatePackageJSONVersion() {
+  let packageJSONPath = path.join(__dirname, '..', 'package.json');
+  let VERSION = require('../broccoli/version').VERSION;
+
+  let pkgContents = fs.readFileSync(packageJSONPath, { encoding: 'utf-8' });
+  let pkg = JSON.parse(pkgContents);
+  pkg._versionPreviouslyCalculated = true;
+  pkg._originalVersion = pkg.version;
+  pkg.version = VERSION;
+  fs.writeFileSync(packageJSONPath, JSON.stringify(pkg, null, 2), { encoding: 'utf-8' });
+}
+
+
+updatePackageJSONVersion();
+
+// using npm pack here because `yarn pack` does not honor the `package.json`'s `files`
+// property properly, and therefore the tarball generated is quite large (~7MB).
+execSync('npm pack');

--- a/bin/build-for-publishing.js
+++ b/bin/build-for-publishing.js
@@ -24,6 +24,9 @@ function updatePackageJSONVersion() {
 
 updatePackageJSONVersion();
 
+// do a production build
+execSync('yarn build');
+
 // using npm pack here because `yarn pack` does not honor the `package.json`'s `files`
 // property properly, and therefore the tarball generated is quite large (~7MB).
 execSync('npm pack');

--- a/bin/publish_builds
+++ b/bin/publish_builds
@@ -5,9 +5,7 @@ echo -e "PULL_REQUEST: ${TRAVIS_PULL_REQUEST}\n"
 
 if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$PUBLISH" == "true" ]; then
 
-  if [ "$EMBER_ENV" != "production" ]; then
-    DISABLE_JSCS=true DISABLE_JSHINT=true ember build --environment=production
-  fi
+  ./bin/build-for-publishing.js
 
   yarn run docs # Generate documentation to be published.
   ./bin/publish_to_s3.js

--- a/bin/publish_builds
+++ b/bin/publish_builds
@@ -7,7 +7,6 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$PUBLISH" == "true" ]; then
 
   ./bin/build-for-publishing.js
 
-  yarn run docs # Generate documentation to be published.
   ./bin/publish_to_s3.js
   ./bin/publish_npm_and_bower
 fi

--- a/bin/publish_to_s3.js
+++ b/bin/publish_to_s3.js
@@ -25,7 +25,6 @@ publisher.currentBranch = function() {
     beta: 'beta',
     release: 'release',
     'lts-2-4': 'lts-2-4',
-    'release-1-13': 'release-1-13'
   }[this.CURRENT_BRANCH];
 };
 

--- a/broccoli/version.js
+++ b/broccoli/version.js
@@ -11,7 +11,8 @@ module.exports.VERSION = (() => {
 
   let packageVersion  = require('../package.json').version;
   let sha = info.sha || '';
-  let prefix = `${packageVersion}-${(process.env.BUILD_TYPE || info.branch)}`;
+  let suffix = process.env.BUILD_TYPE || info.branch;
+  let metadata = sha.slice(0, 8);
 
-  return `${prefix}+${sha.slice(0, 8)}`;
+  return `${packageVersion}${suffix ? '-' + suffix : ''}+${metadata}`;
 })();

--- a/broccoli/version.js
+++ b/broccoli/version.js
@@ -5,11 +5,27 @@ const path = require('path');
 
 module.exports.VERSION = (() => {
   let info = getGitInfo(path.resolve(__dirname, '..'));
+  // if the current commit _is_ a tagged commit, use the tag as the version
+  // number
   if (info.tag) {
     return info.tag.replace(/^v/, '');
   }
 
-  let packageVersion  = require('../package.json').version;
+  let pkg = require('../package');
+  // if `_versionPreviouslyCalculated` is set the `package.json` version string
+  // _already_ includes the branch, sha, etc (from bin/build-for-publishing.js)
+  // so just use it directly
+  if (pkg._versionPreviouslyCalculated) {
+    return pkg.version;
+  }
+
+  // otherwise build the version number up of:
+  //
+  // * actual package.json version string
+  // * current "build type" or branch name (in CI this is generally not
+  //   present, but it is very useful for local / testing builds)
+  // * the sha for the commit
+  let packageVersion  = pkg.version;
   let sha = info.sha || '';
   let suffix = process.env.BUILD_TYPE || info.branch;
   let metadata = sha.slice(0, 8);

--- a/config/s3ProjectConfig.js
+++ b/config/s3ProjectConfig.js
@@ -38,11 +38,6 @@ function fileObject(baseName, extension, contentType, currentRevision, tag, date
         "release/daily/" + date + fullName,
         "release/shas/" + currentRevision + fullName
       ],
-      'release-1-13': [
-        "release-1-13" + fullName,
-        "release-1-13/daily/" + date + fullName,
-        "release-1-13/shas/" + currentRevision + fullName
-      ],
       beta: [
         "beta" + fullName,
         "beta/daily/" + date + fullName,

--- a/config/s3ProjectConfig.js
+++ b/config/s3ProjectConfig.js
@@ -1,5 +1,9 @@
+'use strict';
+
+const semver = require('semver');
+
 function fileMap(revision, tag, date) {
-  return {
+  let filesToPublish = {
     "ember.debug.js":             fileObject("ember.debug",             ".js",   "text/javascript",  revision, tag, date),
     "ember-testing.js":           fileObject("ember-testing",           ".js",   "text/javascript",  revision, tag, date),
     "ember-tests.js":             fileObject("ember-tests",             ".js",   "text/javascript",  revision, tag, date),
@@ -14,6 +18,37 @@ function fileMap(revision, tag, date) {
     "composer.json":              fileObject("composer",                ".json", "application/json", revision, tag, date),
     "package.json":               fileObject("package",                 ".json", "application/json", revision, tag, date),
   };
+
+  let version = require('../package').version;
+  // semver.parse(...).version drops the `+build-info-metadata` stuff
+  let sanitizedVersion = semver.parse(version).version;
+  filesToPublish[`../ember-source-${sanitizedVersion}.tgz`] = {
+    contentType: 'application/x-gzip',
+    destinations: {
+      'alpha': [
+        `alpha.tgz`,
+        `alpha/daily/${date}.tgz`,
+        `alpha/shas/${revision}.tgz`,
+      ],
+      'canary': [
+        `canary.tgz`,
+        `canary/daily/${date}.tgz`,
+        `canary/shas/${revision}.tgz`,
+      ],
+      'beta': [
+        `beta.tgz`,
+        `beta/daily/${date}.tgz`,
+        `beta/shas/${revision}.tgz`,
+      ],
+      'release': [
+        `release.tgz`,
+        `release/daily/${date}.tgz`,
+        `release/shas/${revision}.tgz`,
+      ],
+    }
+  };
+
+  return filesToPublish;
 }
 
 function fileObject(baseName, extension, contentType, currentRevision, tag, date) {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "link:glimmer": "node bin/yarn-link-glimmer.js",
     "sauce:launch": "ember sauce:launch",
     "start": "ember serve",
+    "pretest": "ember build",
     "lint": "tslint -p tsconfig.json && eslint node-tests",
     "test": "node bin/run-tests.js",
     "test:blueprints": "node node-tests/nodetest-runner.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-source",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0",
   "description": "A JavaScript framework for creating ambitious web applications",
   "keywords": [
     "ember-addon"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "!dist/qunit",
     "!dist/jquery",
     "!dist/tests",
+    "docs/data.json",
     "vendor/ember",
     "index.js"
   ],

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "link:glimmer": "node bin/yarn-link-glimmer.js",
     "sauce:launch": "ember sauce:launch",
     "start": "ember serve",
-    "prepare": "ember build -prod",
     "lint": "tslint -p tsconfig.json && eslint node-tests",
     "test": "node bin/run-tests.js",
     "test:blueprints": "node node-tests/nodetest-runner.js",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "build": "ember build --environment production",
     "docs": "ember ember-cli-yuidoc",
     "link:glimmer": "node bin/yarn-link-glimmer.js",
-    "release": "node scripts/release.js",
     "sauce:launch": "ember sauce:launch",
     "start": "ember serve",
     "prepare": "ember build -prod",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,13 @@
     "blueprints",
     "dist",
     "!dist/ember-tests.prod.js",
+    "!dist/ember-tests.prod.map",
     "!dist/ember-tests.js",
+    "!dist/ember-tests.map",
     "!dist/qunit",
     "!dist/jquery",
     "!dist/tests",
+    "!dist/node",
     "docs/data.json",
     "vendor/ember",
     "index.js"

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,4 +1,0 @@
-var execSync = require('child_process').execSync;
-
-execSync("ember build --environment production");
-execSync("npm publish");


### PR DESCRIPTION
This PR finally allows us to easily consume and test alpha, canary, beta, and release channels with `ember-source` as an `npm` dependency (previously to use these channel specific builds you **must** use them via `bower`).

For example, to use the canary channel from an app (or addon) after this lands you would have the following in your `package.json`:

```js
{
  // ...snip...
  devDependencies: {
    //...snip...
    "ember-source": "http://builds.emberjs.com/canary.tgz",
  }
}
```

The following assets are published for each channel (using `canary` for illustrative purposes, but the same paths are available for each):

```
http://builds.emberjs.com/canary.tgz
http://builds.emberjs.com/canary/daily/20180101.tgz
http://builds.emberjs.com/canary/shas/SOMESHAHERE.tgz
```

Once this lands, we can begin removing bower and globals build publishing infrastructure...