### PR TITLE
[BUGFIX beta] add inspect and constructor to list of descriptor exceptions

### DIFF
--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -112,9 +112,19 @@ if (EMBER_METAL_ES5_GETTERS) {
         get(descriptor, property) {
           if (property === DESCRIPTOR) {
             return descriptor;
-          } else if (property === 'toString' || property == 'valueOf' ||
-            property == 'inspect' || property == 'constructor' ||
-            (Symbol && property === Symbol.toPrimitive)) {
+          } else if (
+            property === 'prototype' ||
+            property === 'constructor' ||
+            property === 'nodeType'
+          ) {
+            return undefined;
+          } else if (
+            property === 'toString' ||
+            property === 'valueOf' ||
+            property === 'inspect' ||
+            Symbol && property === Symbol.toPrimitive ||
+            Symbol && property === Symbol.toStringTag
+          ) {
             return () => '[COMPUTED PROPERTY]';
           }
 

--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -112,7 +112,9 @@ if (EMBER_METAL_ES5_GETTERS) {
         get(descriptor, property) {
           if (property === DESCRIPTOR) {
             return descriptor;
-          } else if (property === 'toString' || property == 'valueOf' || (Symbol && property === Symbol.toPrimitive)) {
+          } else if (property === 'toString' || property == 'valueOf' ||
+            property == 'inspect' || property == 'constructor' ||
+            (Symbol && property === Symbol.toPrimitive)) {
             return () => '[COMPUTED PROPERTY]';
           }
 

--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -82,10 +82,10 @@ if (EMBER_METAL_ES5_GETTERS) {
   // development to aid in development asertions. Production builds of
   // ember strip this entire branch out.
   let messageFor = function(obj, keyName, property, value) {
-    return `You attempted to access the \`${keyName}.${property}\` property ` +
+    return `You attempted to access the \`${keyName}.${String(property)}\` property ` +
       `(of ${obj}). Due to certain internal implementation details of Ember, ` +
       `the \`${keyName}\` property previously contained an internal "descriptor" ` +
-      `object (a private API), therefore \`${keyName}.${property}\` would have ` +
+      `object (a private API), therefore \`${keyName}.${String(property)}\` would have ` +
       `been \`${String(value).replace(/\n/g, ' ')}\`. This internal implementation ` +
       `detail was never intended to be a public (or even intimate) API.\n\n` +
       `This internal implementation detail has now changed and the (still private) ` +


### PR DESCRIPTION
In addition to `inspect` I ended up needing to add `constructor` as well to get things working (confirmed locally). Let me know if there is anything else I can do here.

Fixes https://github.com/emberjs/ember.js/issues/16049