### PR TITLE
Refactor test helpers `visit` implementation to be consistent.

### DIFF
--- a/packages/ember-application/tests/system/visit_test.js
+++ b/packages/ember-application/tests/system/visit_test.js
@@ -142,7 +142,9 @@ moduleFor('Ember.Application - visit()', class extends ApplicationTestCase {
        * Visit on the application a second time. The application should remain
        * booted, but a new instance will be created.
        */
-      return this.visit('/');
+      return this.application.visit('/').then(instance => {
+        this.applicationInstance = instance;
+      });
     }).then(() => {
       assert.ok(appBooted === 1, 'the app should not be booted again');
       assert.ok(instanceBooted === 2, 'another instance should be booted');

--- a/packages/internal-test-helpers/lib/test-cases/abstract-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract-application.js
@@ -5,6 +5,28 @@ import { runDestroy } from '../run';
 
 export default class AbstractApplicationTestCase extends AbstractTestCase {
 
+  _ensureInstance(bootOptions) {
+    if (this._applicationInstancePromise) {
+      return this._applicationInstancePromise;
+    }
+
+    return this._applicationInstancePromise = this.runTask(() => this.application.boot())
+      .then((app) => {
+        this.applicationInstance = app.buildInstance();
+
+        return this.applicationInstance.boot(bootOptions);
+      });
+  }
+
+  visit(url, options) {
+    // TODO: THIS IS HORRIBLE
+    // the promise returned by `ApplicationInstance.protoype.visit` does **not**
+    // currently guarantee rendering is completed
+    return this.runTask(() => {
+      return this._ensureInstance(options).then(instance => instance.visit(url));
+    });
+  }
+
   get element() {
     if (this._element) {
       return this._element;
@@ -20,7 +42,9 @@ export default class AbstractApplicationTestCase extends AbstractTestCase {
   }
 
   teardown() {
+    runDestroy(this.applicationInstance);
     runDestroy(this.application);
+
     super.teardown();
   }
 

--- a/packages/internal-test-helpers/lib/test-cases/application.js
+++ b/packages/internal-test-helpers/lib/test-cases/application.js
@@ -2,7 +2,6 @@ import TestResolverApplicationTestCase from './test-resolver-application';
 import { Application } from 'ember-application';
 import { Router } from 'ember-routing';
 import { assign } from 'ember-utils';
-import { runDestroy } from '../run';
 
 export default class ApplicationTestCase extends TestResolverApplicationTestCase {
   constructor() {
@@ -26,26 +25,6 @@ export default class ApplicationTestCase extends TestResolverApplicationTestCase
     return assign(super.applicationOptions, {
       autoboot: false
     });
-  }
-
-  teardown() {
-    runDestroy(this.applicationInstance);
-    super.teardown();
-  }
-
-  visit(url, options) {
-    let { applicationInstance } = this;
-
-    if (applicationInstance) {
-      return this.runTask(() => applicationInstance.visit(url, options));
-    } else {
-      return this.runTask(() => {
-        return this.application.visit(url, options).then(instance => {
-          this.applicationInstance = instance;
-          return instance;
-        });
-      });
-    }
   }
 
   get appRouter() {

--- a/packages/internal-test-helpers/lib/test-cases/autoboot-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/autoboot-application.js
@@ -24,7 +24,13 @@ export default class AutobootApplicationTestCase extends TestResolverApplication
   }
 
   get applicationInstance() {
-    return this.application.__deprecatedInstance__;
+    let { application } = this;
+
+    if (!application) {
+      return undefined;
+    }
+
+    return application.__deprecatedInstance__;
   }
 
 }

--- a/packages/internal-test-helpers/lib/test-cases/default-resolver-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/default-resolver-application.js
@@ -6,7 +6,6 @@ import {
   setTemplate
 } from 'ember-glimmer';
 import { assign } from 'ember-utils';
-import { runDestroy } from '../run';
 import { Router } from 'ember-routing';
 
 export default class ApplicationTestCase extends AbstractApplicationTestCase {
@@ -25,23 +24,8 @@ export default class ApplicationTestCase extends AbstractApplicationTestCase {
   }
 
   teardown() {
-    runDestroy(this.applicationInstance);
     super.teardown();
     setTemplates({});
-  }
-
-  visit(url, options) {
-    let { applicationInstance } = this;
-
-    if (applicationInstance) {
-      return this.runTask(() => applicationInstance.visit(url, options));
-    } else {
-      return this.runTask(() => {
-        return this.application.visit(url, options).then(instance => {
-          this.applicationInstance = instance;
-        });
-      });
-    }
   }
 
   get appRouter() {


### PR DESCRIPTION
Ensures that the `ApplicationInstance` instance is always gathered, regardless of if the `visit` itself fails, and also that it properly cleans up (even when the visit is rejected).

Requires #16054.