### PR TITLE
[BUGFIX] Recompute link-to active prop when attrs.params changes

### DIFF
--- a/packages/ember-glimmer/lib/components/link-to.ts
+++ b/packages/ember-glimmer/lib/components/link-to.ts
@@ -573,7 +573,7 @@ const LinkComponent = EmberComponent.extend({
     return this.get('_active') ? get(this, 'activeClass') : false;
   }),
 
-  _active: computed('_routing.currentState', function computeLinkToComponentActive(this: any) {
+  _active: computed('_routing.currentState', 'attrs.params', function computeLinkToComponentActive(this: any) {
     let currentState = get(this, '_routing.currentState');
     if (!currentState) { return false; }
     return this._isActive(currentState);


### PR DESCRIPTION
Prior to 2.18.0, the link-to component would recompute `active`/`_active` when `attrs.params` changed.  This restores prior functionality where a deeply nested async relationship that resolves after initial render of a link-to and meets the criteria `this._isActive` then the active class is applied to the link element.  Currently, that functionality is broken and the active class is never applied when the async relationship settles.


I'll update tests before this is merged once it's clear that this wasn't an intentional breaking change.
  
<= 2.17.0 behavior https://github.com/emberjs/ember.js/blob/v2.17.0/packages/ember-glimmer/lib/components/link-to.js#L593
  
  