### PR TITLE
Work towards using QUnit 2 APIs.

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/life-cycle-test.js
+++ b/packages/ember-glimmer/tests/integration/components/life-cycle-test.js
@@ -17,8 +17,8 @@ class LifeCycleHooksTest extends RenderingTest {
     this.teardownAssertions = [];
   }
 
-  teardown() {
-    super.teardown();
+  afterEach() {
+    super.afterEach();
 
     for (let i = 0; i < this.teardownAssertions.length; i++) {
       this.teardownAssertions[i]();

--- a/packages/ember-metal/tests/accessors/get_test.js
+++ b/packages/ember-metal/tests/accessors/get_test.js
@@ -118,7 +118,7 @@ moduleFor('Ember.get', class extends AbstractTestCase {
   // BUGS
   //
 
-  ['@test (regression) watched properties on unmodified inherited objects should still return their original value']() {
+  ['@test (regression) watched properties on unmodified inherited objects should still return their original value'](assert) {
     let MyMixin = Mixin.create({
       someProperty: 'foo',
       propertyDidChange: observer('someProperty', () => {})
@@ -127,7 +127,7 @@ moduleFor('Ember.get', class extends AbstractTestCase {
     let baseObject = MyMixin.apply({});
     let theRealObject = Object.create(baseObject);
 
-    equal(get(theRealObject, 'someProperty'), 'foo', 'should return the set value, not false');
+    assert.equal(get(theRealObject, 'someProperty'), 'foo', 'should return the set value, not false');
   }
 });
 
@@ -160,7 +160,7 @@ moduleFor('Ember.getWithDefault', class extends AbstractTestCase {
     let obj = {
       count: 0,
       unknownProperty(key) {
-        equal(key, 'foo', 'should pass key');
+        assert.equal(key, 'foo', 'should pass key');
         this.count++;
         return 'FOO';
       }
@@ -174,7 +174,7 @@ moduleFor('Ember.getWithDefault', class extends AbstractTestCase {
     let obj = {
       unknownProperty(key) {
         if (key === 'foo') {
-          equal(key, 'foo', 'should pass key');
+          assert.equal(key, 'foo', 'should pass key');
           return 'FOO';
         }
       }

--- a/packages/ember-metal/tests/accessors/mandatory_setters_test.js
+++ b/packages/ember-metal/tests/accessors/mandatory_setters_test.js
@@ -35,7 +35,7 @@ if (MANDATORY_SETTER) {
     }
 
     ['@test should not setup mandatory-setter if property is not writable'](assert) {
-      expect(6);
+      assert.expect(6);
 
       let obj = { };
 
@@ -62,7 +62,7 @@ if (MANDATORY_SETTER) {
     }
 
     ['@test should not teardown non mandatory-setter descriptor'](assert) {
-      expect(1);
+      assert.expect(1);
 
       let obj = { get a() { return 'hi'; } };
 
@@ -73,7 +73,7 @@ if (MANDATORY_SETTER) {
     }
 
     ['@test should not confuse non descriptor watched gets'](assert) {
-      expect(2);
+      assert.expect(2);
 
       let obj = { get a() { return 'hi'; } };
 
@@ -83,7 +83,7 @@ if (MANDATORY_SETTER) {
     }
 
     ['@test should not setup mandatory-setter if setter is already setup on property'](assert) {
-      expect(2);
+      assert.expect(2);
 
       let obj = { someProp: null };
 
@@ -119,7 +119,7 @@ if (MANDATORY_SETTER) {
     }
 
     ['@test should not setup mandatory-setter if setter is already setup on property in parent prototype'](assert) {
-      expect(2);
+      assert.expect(2);
 
       function Foo() { }
 
@@ -142,7 +142,7 @@ if (MANDATORY_SETTER) {
     }
 
     ['@test should not setup mandatory-setter if setter is already setup on property in grandparent prototype'](assert) {
-      expect(2);
+      assert.expect(2);
 
       function Foo() { }
 
@@ -169,7 +169,7 @@ if (MANDATORY_SETTER) {
     }
 
     ['@test should not setup mandatory-setter if setter is already setup on property in great grandparent prototype'](assert) {
-      expect(2);
+      assert.expect(2);
 
       function Foo() { }
 
@@ -350,7 +350,7 @@ if (MANDATORY_SETTER) {
     }
 
     ['@test sets up mandatory-setter if property comes from prototype'](assert) {
-      expect(2);
+      assert.expect(2);
 
       let obj = {
         someProp: null,

--- a/packages/ember-metal/tests/alias_test.js
+++ b/packages/ember-metal/tests/alias_test.js
@@ -13,11 +13,11 @@ import {
 let obj, count;
 
 QUnit.module('ember-metal/alias', {
-  setup() {
+  beforeEach() {
     obj = { foo: { faz: 'FOO' } };
     count = 0;
   },
-  teardown() {
+  afterEach() {
     obj = null;
   }
 });
@@ -26,18 +26,18 @@ function incrementCount() {
   count++;
 }
 
-QUnit.test('should proxy get to alt key', function() {
+QUnit.test('should proxy get to alt key', function(assert) {
   defineProperty(obj, 'bar', alias('foo.faz'));
-  equal(get(obj, 'bar'), 'FOO');
+  assert.equal(get(obj, 'bar'), 'FOO');
 });
 
-QUnit.test('should proxy set to alt key', function() {
+QUnit.test('should proxy set to alt key', function(assert) {
   defineProperty(obj, 'bar', alias('foo.faz'));
   set(obj, 'bar', 'BAR');
-  equal(get(obj, 'foo.faz'), 'BAR');
+  assert.equal(get(obj, 'foo.faz'), 'BAR');
 });
 
-QUnit.test('old dependent keys should not trigger property changes', function() {
+QUnit.test('old dependent keys should not trigger property changes', function(assert) {
   let obj1 = Object.create(null);
   defineProperty(obj1, 'foo', null, null);
   defineProperty(obj1, 'bar', alias('foo'));
@@ -46,17 +46,17 @@ QUnit.test('old dependent keys should not trigger property changes', function() 
   addObserver(obj1, 'baz', incrementCount);
 
   set(obj1, 'foo', 'FOO');
-  equal(count, 1);
+  assert.equal(count, 1);
 
   removeObserver(obj1, 'baz', incrementCount);
 
   set(obj1, 'foo', 'OOF');
-  equal(count, 1);
+  assert.equal(count, 1);
 });
 
 QUnit.test(`inheriting an observer of the alias from the prototype then
             redefining the alias on the instance to another property dependent on same key
-            does not call the observer twice`, function() {
+            does not call the observer twice`, function(assert) {
   let obj1 = Object.create(null);
 
   meta(obj1).proto = obj1;
@@ -70,43 +70,41 @@ QUnit.test(`inheriting an observer of the alias from the prototype then
   defineProperty(obj2, 'baz', alias('bar')); // override baz
 
   set(obj2, 'foo', 'FOO');
-  equal(count, 1);
+  assert.equal(count, 1);
 
   removeObserver(obj2, 'baz', incrementCount);
 
   set(obj2, 'foo', 'OOF');
-  equal(count, 1);
+  assert.equal(count, 1);
 });
 
-QUnit.test('an observer of the alias works if added after defining the alias', function() {
+QUnit.test('an observer of the alias works if added after defining the alias', function(assert) {
   defineProperty(obj, 'bar', alias('foo.faz'));
   addObserver(obj, 'bar', incrementCount);
-  ok(isWatching(obj, 'foo.faz'));
+  assert.ok(isWatching(obj, 'foo.faz'));
   set(obj, 'foo.faz', 'BAR');
-  equal(count, 1);
+  assert.equal(count, 1);
 });
 
-QUnit.test('an observer of the alias works if added before defining the alias', function() {
+QUnit.test('an observer of the alias works if added before defining the alias', function(assert) {
   addObserver(obj, 'bar', incrementCount);
   defineProperty(obj, 'bar', alias('foo.faz'));
-  ok(isWatching(obj, 'foo.faz'));
+  assert.ok(isWatching(obj, 'foo.faz'));
   set(obj, 'foo.faz', 'BAR');
-  equal(count, 1);
+  assert.equal(count, 1);
 });
 
-QUnit.test('object with alias is dirtied if interior object of alias is set after consumption', function () {
+QUnit.test('object with alias is dirtied if interior object of alias is set after consumption', function(assert) {
   defineProperty(obj, 'bar', alias('foo.faz'));
   get(obj, 'bar');
-  assertDirty(obj, () => set(obj, 'foo.faz', 'BAR'), 'setting the aliased key should dirty the object');
+
+  let tag = tagFor(obj);
+  let tagValue = tag.value();
+  set(obj, 'foo.faz', 'BAR');
+
+  assert.ok(!tag.validate(tagValue), 'setting the aliased key should dirty the object');
 });
 
 QUnit.test('setting alias on self should fail assertion', function() {
   expectAssertion(() => defineProperty(obj, 'bar', alias('bar')), 'Setting alias \'bar\' on self');
 });
-
-function assertDirty(obj, callback, label) {
-  let tag = tagFor(obj);
-  let tagValue = tag.value();
-  callback();
-  ok(!tag.validate(tagValue), label);
-}

--- a/packages/ember-metal/tests/binding/connect_test.js
+++ b/packages/ember-metal/tests/binding/connect_test.js
@@ -13,32 +13,34 @@ function performTest(binding, a, b, get, set, connect) {
     connect = () => binding.connect(a);
   }
 
-  ok(!run.currentRunLoop, 'performTest should not have a currentRunLoop');
+  let { assert } = QUnit.config.current;
 
-  equal(get(a, 'foo'), 'FOO', 'a should not have changed');
-  equal(get(b, 'bar'), 'BAR', 'b should not have changed');
+  assert.ok(!run.currentRunLoop, 'performTest should not have a currentRunLoop');
+
+  assert.equal(get(a, 'foo'), 'FOO', 'a should not have changed');
+  assert.equal(get(b, 'bar'), 'BAR', 'b should not have changed');
 
   connect();
 
-  equal(get(a, 'foo'), 'BAR', 'a should have changed');
-  equal(get(b, 'bar'), 'BAR', 'b should have changed');
+  assert.equal(get(a, 'foo'), 'BAR', 'a should have changed');
+  assert.equal(get(b, 'bar'), 'BAR', 'b should have changed');
   //
   // make sure changes sync both ways
   run(() => set(b, 'bar', 'BAZZ'));
-  equal(get(a, 'foo'), 'BAZZ', 'a should have changed');
+  assert.equal(get(a, 'foo'), 'BAZZ', 'a should have changed');
 
   run(() => set(a, 'foo', 'BARF'));
-  equal(get(b, 'bar'), 'BARF', 'a should have changed');
+  assert.equal(get(b, 'bar'), 'BARF', 'a should have changed');
 }
 
 let originalLookup, lookup, GlobalB;
 
 QUnit.module('Ember.Binding', {
-  setup() {
+  beforeEach() {
     originalLookup = context.lookup;
     context.lookup = lookup = {};
   },
-  teardown() {
+  afterEach() {
     lookup = null;
     context.lookup = originalLookup;
   }
@@ -76,7 +78,7 @@ testBoth('Connecting a binding between two objects', function(get, set) {
   }, /`Ember\.Binding` is deprecated./);
 });
 
-testBoth('Connecting a binding to path', function(get, set) {
+testBoth('Connecting a binding to path', function(get, set, assert) {
   let a = { foo: 'FOO' };
   lookup['GlobalB'] = GlobalB = {
     b: { bar: 'BAR' }
@@ -96,7 +98,7 @@ testBoth('Connecting a binding to path', function(get, set) {
 
   run(() => set(GlobalB, 'b', b));
 
-  equal(get(a, 'foo'), 'BIFF', 'a should have changed');
+  assert.equal(get(a, 'foo'), 'BIFF', 'a should have changed');
 });
 
 testBoth('Calling connect more than once', function(get, set) {
@@ -114,7 +116,7 @@ testBoth('Calling connect more than once', function(get, set) {
   }, /`Ember\.Binding` is deprecated./);
 });
 
-QUnit.test('inherited bindings should sync on create', function() {
+QUnit.test('inherited bindings should sync on create', function(assert) {
   let a;
   run(() => {
     function A() {
@@ -126,5 +128,5 @@ QUnit.test('inherited bindings should sync on create', function() {
     set(a, 'bar', { baz: 'BAZ' });
   });
 
-  equal(get(a, 'foo'), 'BAZ', 'should have synced binding on new obj');
+  assert.equal(get(a, 'foo'), 'BAZ', 'should have synced binding on new obj');
 });

--- a/packages/ember-metal/tests/binding/sync_test.js
+++ b/packages/ember-metal/tests/binding/sync_test.js
@@ -11,7 +11,7 @@ import {
 
 QUnit.module('system/binding/sync_test.js');
 
-testBoth('bindings should not sync twice in a single run loop', function(get, set) {
+testBoth('bindings should not sync twice in a single run loop', function(get, set, assert) {
   let a, b, setValue;
   let setCalled = 0;
   let getCalled = 0;
@@ -47,12 +47,12 @@ testBoth('bindings should not sync twice in a single run loop', function(get, se
     set(a, 'foo', 'trollface');
   });
 
-  equal(get(b, 'foo'), 'trollface', 'the binding should sync');
-  equal(setCalled, 1, 'Set should only be called once');
-  equal(getCalled, 1, 'Get should only be called once');
+  assert.equal(get(b, 'foo'), 'trollface', 'the binding should sync');
+  assert.equal(setCalled, 1, 'Set should only be called once');
+  assert.equal(getCalled, 1, 'Get should only be called once');
 });
 
-testBoth('bindings should not infinite loop if computed properties return objects', function(get) {
+testBoth('bindings should not infinite loop if computed properties return objects', function(get, set, assert) {
   let a, b;
   let getCalled = 0;
 
@@ -74,11 +74,11 @@ testBoth('bindings should not infinite loop if computed properties return object
     expectDeprecation(() => bind(b, 'foo', 'a.foo'), /`Ember.Binding` is deprecated/);
   });
 
-  deepEqual(get(b, 'foo'), ['foo', 'bar'], 'the binding should sync');
-  equal(getCalled, 1, 'Get should only be called once');
+  assert.deepEqual(get(b, 'foo'), ['foo', 'bar'], 'the binding should sync');
+  assert.equal(getCalled, 1, 'Get should only be called once');
 });
 
-testBoth('bindings should do the right thing when observers trigger bindings in the opposite direction', function(get, set) {
+testBoth('bindings should do the right thing when observers trigger bindings in the opposite direction', function(get, set, assert) {
   let a, b, c;
 
   run(() => {
@@ -107,10 +107,10 @@ testBoth('bindings should do the right thing when observers trigger bindings in 
 
   run(() => set(a, 'foo', 'trollface'));
 
-  equal(get(a, 'foo'), 'what is going on');
+  assert.equal(get(a, 'foo'), 'what is going on');
 });
 
-testBoth('bindings should not try to sync destroyed objects', function(get, set) {
+testBoth('bindings should not try to sync destroyed objects', function(get, set, assert) {
   let a, b;
 
   run(() => {
@@ -130,7 +130,7 @@ testBoth('bindings should not try to sync destroyed objects', function(get, set)
   run(() => {
     set(a, 'foo', 'trollface');
     set(b, 'isDestroyed', true);
-    ok(true, 'should not raise');
+    assert.ok(true, 'should not raise');
   });
 
   run(() => {
@@ -150,6 +150,6 @@ testBoth('bindings should not try to sync destroyed objects', function(get, set)
   run(() => {
     set(b, 'foo', 'trollface');
     set(a, 'isDestroyed', true);
-    ok(true, 'should not raise');
+    assert.ok(true, 'should not raise');
   });
 });

--- a/packages/ember-metal/tests/cache_test.js
+++ b/packages/ember-metal/tests/cache_test.js
@@ -2,47 +2,47 @@ import { Cache } from '..';
 
 QUnit.module('Cache');
 
-QUnit.test('basic', function() {
+QUnit.test('basic', function(assert) {
   let cache = new Cache(100, key => key.toUpperCase());
 
-  equal(cache.get('foo'), 'FOO');
-  equal(cache.get('bar'), 'BAR');
-  equal(cache.get('foo'), 'FOO');
+  assert.equal(cache.get('foo'), 'FOO');
+  assert.equal(cache.get('bar'), 'BAR');
+  assert.equal(cache.get('foo'), 'FOO');
 });
 
-QUnit.test('explicit sets', function() {
+QUnit.test('explicit sets', function(assert) {
   let cache = new Cache(100, key => key.toUpperCase());
 
-  equal(cache.get('foo'), 'FOO');
+  assert.equal(cache.get('foo'), 'FOO');
 
-  equal(cache.set('foo', 'FOO!!!'), 'FOO!!!');
+  assert.equal(cache.set('foo', 'FOO!!!'), 'FOO!!!');
 
-  equal(cache.get('foo'), 'FOO!!!');
+  assert.equal(cache.get('foo'), 'FOO!!!');
 
-  strictEqual(cache.set('foo', undefined), undefined);
+  assert.strictEqual(cache.set('foo', undefined), undefined);
 
-  strictEqual(cache.get('foo'), undefined);
+  assert.strictEqual(cache.get('foo'), undefined);
 });
 
-QUnit.test('caches computation correctly', function() {
+QUnit.test('caches computation correctly', function(assert) {
   let count = 0;
   let cache = new Cache(100, key => {
     count++;
     return key.toUpperCase();
   });
 
-  equal(count, 0);
+  assert.equal(count, 0);
   cache.get('foo');
-  equal(count, 1);
+  assert.equal(count, 1);
   cache.get('bar');
-  equal(count, 2);
+  assert.equal(count, 2);
   cache.get('bar');
-  equal(count, 2);
+  assert.equal(count, 2);
   cache.get('foo');
-  equal(count, 2);
+  assert.equal(count, 2);
 });
 
-QUnit.test('caches computation correctly with custom cache keys', function() {
+QUnit.test('caches computation correctly with custom cache keys', function(assert) {
   let count = 0;
   let cache = new Cache(
     100,
@@ -53,41 +53,41 @@ QUnit.test('caches computation correctly with custom cache keys', function() {
     obj => obj.key
   );
 
-  equal(count, 0);
+  assert.equal(count, 0);
   cache.get({ key: 'foo', value: 'foo' });
-  equal(count, 1);
+  assert.equal(count, 1);
   cache.get({ key: 'bar', value: 'bar' });
-  equal(count, 2);
+  assert.equal(count, 2);
   cache.get({ key: 'bar', value: 'bar' });
-  equal(count, 2);
+  assert.equal(count, 2);
   cache.get({ key: 'foo', value: 'foo' });
-  equal(count, 2);
+  assert.equal(count, 2);
 });
 
-QUnit.test('handles undefined value correctly', function() {
+QUnit.test('handles undefined value correctly', function(assert) {
   let count = 0;
   let cache = new Cache(100, () => { count++; });
 
-  equal(count, 0);
-  strictEqual(cache.get('foo'), undefined);
-  equal(count, 1);
-  strictEqual(cache.get('bar'), undefined);
-  equal(count, 2);
-  strictEqual(cache.get('bar'), undefined);
-  equal(count, 2);
-  strictEqual(cache.get('foo'), undefined);
-  equal(count, 2);
+  assert.equal(count, 0);
+  assert.strictEqual(cache.get('foo'), undefined);
+  assert.equal(count, 1);
+  assert.strictEqual(cache.get('bar'), undefined);
+  assert.equal(count, 2);
+  assert.strictEqual(cache.get('bar'), undefined);
+  assert.equal(count, 2);
+  assert.strictEqual(cache.get('foo'), undefined);
+  assert.equal(count, 2);
 });
 
-QUnit.test('continues working after reaching cache limit', function() {
+QUnit.test('continues working after reaching cache limit', function(assert) {
   let cache = new Cache(3, key => key.toUpperCase());
 
   cache.get('a');
   cache.get('b');
   cache.get('c');
 
-  equal(cache.get('d'), 'D');
-  equal(cache.get('a'), 'A');
-  equal(cache.get('b'), 'B');
-  equal(cache.get('c'), 'C');
+  assert.equal(cache.get('d'), 'D');
+  assert.equal(cache.get('a'), 'A');
+  assert.equal(cache.get('b'), 'B');
+  assert.equal(cache.get('c'), 'C');
 });

--- a/packages/ember-metal/tests/chains_test.js
+++ b/packages/ember-metal/tests/chains_test.js
@@ -12,7 +12,7 @@ import {
 
 QUnit.module('Chains');
 
-QUnit.test('finishChains should properly copy chains from prototypes to instances', function() {
+QUnit.test('finishChains should properly copy chains from prototypes to instances', function(assert) {
   function didChange() {}
 
   let obj = {};
@@ -25,7 +25,7 @@ QUnit.test('finishChains should properly copy chains from prototypes to instance
 
   finishChains(childMeta);
 
-  ok(parentMeta.readableChains() !== childMeta.readableChains(), 'The chains object is copied');
+  assert.ok(parentMeta.readableChains() !== childMeta.readableChains(), 'The chains object is copied');
 });
 
 QUnit.test('does not observe primitive values', function(assert) {
@@ -39,7 +39,7 @@ QUnit.test('does not observe primitive values', function(assert) {
 });
 
 
-QUnit.test('observer and CP chains', function() {
+QUnit.test('observer and CP chains', function(assert) {
   let obj = { };
 
   defineProperty(obj, 'foo', computed('qux.[]', function() { }));
@@ -83,7 +83,7 @@ QUnit.test('observer and CP chains', function() {
   */
 
   get(obj, 'qux'); // CP chain re-recreated
-  ok(true, 'no crash');
+  assert.ok(true, 'no crash');
 });
 
 QUnit.test('checks cache correctly', function(assert) {

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -19,8 +19,8 @@ let obj, count;
 
 QUnit.module('computed');
 
-QUnit.test('computed property should be an instance of descriptor', function() {
-  ok(computed(function() {}) instanceof Descriptor);
+QUnit.test('computed property should be an instance of descriptor', function(assert) {
+  assert.ok(computed(function() {}) instanceof Descriptor);
 });
 
 QUnit.test('computed properties assert the presence of a getter or setter function', function() {
@@ -72,7 +72,7 @@ if (EMBER_METAL_ES5_GETTERS) {
   });
 }
 
-QUnit.test('defining computed property should invoke property on get', function() {
+QUnit.test('defining computed property should invoke property on get', function(assert) {
   let obj = {};
   let count = 0;
   defineProperty(obj, 'foo', computed(function(key) {
@@ -80,11 +80,11 @@ QUnit.test('defining computed property should invoke property on get', function(
     return 'computed ' + key;
   }));
 
-  equal(get(obj, 'foo'), 'computed foo', 'should return value');
-  equal(count, 1, 'should have invoked computed property');
+  assert.equal(get(obj, 'foo'), 'computed foo', 'should return value');
+  assert.equal(count, 1, 'should have invoked computed property');
 });
 
-QUnit.test('defining computed property should invoke property on set', function() {
+QUnit.test('defining computed property should invoke property on set', function(assert) {
   let obj = {};
   let count = 0;
   defineProperty(obj, 'foo', computed({
@@ -96,19 +96,19 @@ QUnit.test('defining computed property should invoke property on set', function(
     }
   }));
 
-  equal(set(obj, 'foo', 'bar'), 'bar', 'should return set value');
-  equal(count, 1, 'should have invoked computed property');
-  equal(get(obj, 'foo'), 'computed bar', 'should return new value');
+  assert.equal(set(obj, 'foo', 'bar'), 'bar', 'should return set value');
+  assert.equal(count, 1, 'should have invoked computed property');
+  assert.equal(get(obj, 'foo'), 'computed bar', 'should return new value');
 });
 
-QUnit.test('defining a computed property with a dependent key ending with @each is expanded to []', function() {
+QUnit.test('defining a computed property with a dependent key ending with @each is expanded to []', function(assert) {
   let cp = computed('blazo.@each', function() { });
 
-  deepEqual(cp._dependentKeys, ['blazo.[]']);
+  assert.deepEqual(cp._dependentKeys, ['blazo.[]']);
 
   cp = computed('qux', 'zoopa.@each', function() { });
 
-  deepEqual(cp._dependentKeys, ['qux', 'zoopa.[]']);
+  assert.deepEqual(cp._dependentKeys, ['qux', 'zoopa.[]']);
 });
 
 QUnit.test('defining a computed property with a dependent key more than one level deep beyond @each is not supported', function() {
@@ -131,7 +131,7 @@ QUnit.test('defining a computed property with a dependent key more than one leve
 
 let objA, objB;
 QUnit.module('computed should inherit through prototype', {
-  setup() {
+  beforeEach() {
     objA = { __foo: 'FOO' };
     defineProperty(objA, 'foo', computed({
       get(key) {
@@ -147,30 +147,30 @@ QUnit.module('computed should inherit through prototype', {
     objB.__foo = 'FOO'; // make a copy;
   },
 
-  teardown() {
+  afterEach() {
     objA = objB = null;
   }
 });
 
-testBoth('using get() and set()', function(get, set) {
-  equal(get(objA, 'foo'), 'FOO', 'should get FOO from A');
-  equal(get(objB, 'foo'), 'FOO', 'should get FOO from B');
+testBoth('using get() and set()', function(get, set, assert) {
+  assert.equal(get(objA, 'foo'), 'FOO', 'should get FOO from A');
+  assert.equal(get(objB, 'foo'), 'FOO', 'should get FOO from B');
 
   set(objA, 'foo', 'BIFF');
-  equal(get(objA, 'foo'), 'computed BIFF', 'should change A');
-  equal(get(objB, 'foo'), 'FOO', 'should NOT change B');
+  assert.equal(get(objA, 'foo'), 'computed BIFF', 'should change A');
+  assert.equal(get(objB, 'foo'), 'FOO', 'should NOT change B');
 
   set(objB, 'foo', 'bar');
-  equal(get(objB, 'foo'), 'computed bar', 'should change B');
-  equal(get(objA, 'foo'), 'computed BIFF', 'should NOT change A');
+  assert.equal(get(objB, 'foo'), 'computed bar', 'should change B');
+  assert.equal(get(objA, 'foo'), 'computed BIFF', 'should NOT change A');
 
   set(objA, 'foo', 'BAZ');
-  equal(get(objA, 'foo'), 'computed BAZ', 'should change A');
-  equal(get(objB, 'foo'), 'computed bar', 'should NOT change B');
+  assert.equal(get(objA, 'foo'), 'computed BAZ', 'should change A');
+  assert.equal(get(objB, 'foo'), 'computed bar', 'should NOT change B');
 });
 
 QUnit.module('redefining computed property to normal', {
-  setup() {
+  beforeEach() {
     objA = { __foo: 'FOO' };
     defineProperty(objA, 'foo', computed({
       get(key) {
@@ -186,30 +186,30 @@ QUnit.module('redefining computed property to normal', {
     defineProperty(objB, 'foo'); // make this just a normal property.
   },
 
-  teardown() {
+  afterEach() {
     objA = objB = null;
   }
 });
 
-testBoth('using get() and set()', function(get, set) {
-  equal(get(objA, 'foo'), 'FOO', 'should get FOO from A');
-  equal(get(objB, 'foo'), undefined, 'should get undefined from B');
+testBoth('using get() and set()', function(get, set, assert) {
+  assert.equal(get(objA, 'foo'), 'FOO', 'should get FOO from A');
+  assert.equal(get(objB, 'foo'), undefined, 'should get undefined from B');
 
   set(objA, 'foo', 'BIFF');
-  equal(get(objA, 'foo'), 'computed BIFF', 'should change A');
-  equal(get(objB, 'foo'), undefined, 'should NOT change B');
+  assert.equal(get(objA, 'foo'), 'computed BIFF', 'should change A');
+  assert.equal(get(objB, 'foo'), undefined, 'should NOT change B');
 
   set(objB, 'foo', 'bar');
-  equal(get(objB, 'foo'), 'bar', 'should change B');
-  equal(get(objA, 'foo'), 'computed BIFF', 'should NOT change A');
+  assert.equal(get(objB, 'foo'), 'bar', 'should change B');
+  assert.equal(get(objA, 'foo'), 'computed BIFF', 'should NOT change A');
 
   set(objA, 'foo', 'BAZ');
-  equal(get(objA, 'foo'), 'computed BAZ', 'should change A');
-  equal(get(objB, 'foo'), 'bar', 'should NOT change B');
+  assert.equal(get(objA, 'foo'), 'computed BAZ', 'should change A');
+  assert.equal(get(objB, 'foo'), 'bar', 'should NOT change B');
 });
 
 QUnit.module('redefining computed property to another property', {
-  setup() {
+  beforeEach() {
     objA = { __foo: 'FOO' };
     defineProperty(objA, 'foo', computed({
       get(key) {
@@ -232,40 +232,40 @@ QUnit.module('redefining computed property to another property', {
     }));
   },
 
-  teardown() {
+  afterEach() {
     objA = objB = null;
   }
 });
 
-testBoth('using get() and set()', function(get, set) {
-  equal(get(objA, 'foo'), 'FOO', 'should get FOO from A');
-  equal(get(objB, 'foo'), 'FOO', 'should get FOO from B');
+testBoth('using get() and set()', function(get, set, assert) {
+  assert.equal(get(objA, 'foo'), 'FOO', 'should get FOO from A');
+  assert.equal(get(objB, 'foo'), 'FOO', 'should get FOO from B');
 
   set(objA, 'foo', 'BIFF');
-  equal(get(objA, 'foo'), 'A BIFF', 'should change A');
-  equal(get(objB, 'foo'), 'FOO', 'should NOT change B');
+  assert.equal(get(objA, 'foo'), 'A BIFF', 'should change A');
+  assert.equal(get(objB, 'foo'), 'FOO', 'should NOT change B');
 
   set(objB, 'foo', 'bar');
-  equal(get(objB, 'foo'), 'B bar', 'should change B');
-  equal(get(objA, 'foo'), 'A BIFF', 'should NOT change A');
+  assert.equal(get(objB, 'foo'), 'B bar', 'should change B');
+  assert.equal(get(objA, 'foo'), 'A BIFF', 'should NOT change A');
 
   set(objA, 'foo', 'BAZ');
-  equal(get(objA, 'foo'), 'A BAZ', 'should change A');
-  equal(get(objB, 'foo'), 'B bar', 'should NOT change B');
+  assert.equal(get(objA, 'foo'), 'A BAZ', 'should change A');
+  assert.equal(get(objB, 'foo'), 'B bar', 'should NOT change B');
 });
 
 QUnit.module('computed - metadata');
 
-QUnit.test('can set metadata on a computed property', function() {
+QUnit.test('can set metadata on a computed property', function(assert) {
   let computedProperty = computed(function() { });
   computedProperty.meta({ key: 'keyValue' });
 
-  equal(computedProperty.meta().key, 'keyValue', 'saves passed meta hash to the _meta property');
+  assert.equal(computedProperty.meta().key, 'keyValue', 'saves passed meta hash to the _meta property');
 });
 
-QUnit.test('meta should return an empty hash if no meta is set', function() {
+QUnit.test('meta should return an empty hash if no meta is set', function(assert) {
   let computedProperty = computed(function() { });
-  deepEqual(computedProperty.meta(), {}, 'returned value is an empty hash');
+  assert.deepEqual(computedProperty.meta(), {}, 'returned value is an empty hash');
 });
 
 // ..........................................................
@@ -273,7 +273,7 @@ QUnit.test('meta should return an empty hash if no meta is set', function() {
 //
 
 QUnit.module('computed - cacheable', {
-  setup() {
+  beforeEach() {
     obj = {};
     count = 0;
     let func = function() {
@@ -283,61 +283,61 @@ QUnit.module('computed - cacheable', {
     defineProperty(obj, 'foo', computed({ get: func, set: func }));
   },
 
-  teardown() {
+  afterEach() {
     obj = count = null;
   }
 });
 
-testBoth('cacheable should cache', function(get) {
-  equal(get(obj, 'foo'), 'bar 1', 'first get');
-  equal(get(obj, 'foo'), 'bar 1', 'second get');
-  equal(count, 1, 'should only invoke once');
+testBoth('cacheable should cache', function(get, set, assert) {
+  assert.equal(get(obj, 'foo'), 'bar 1', 'first get');
+  assert.equal(get(obj, 'foo'), 'bar 1', 'second get');
+  assert.equal(count, 1, 'should only invoke once');
 });
 
-testBoth('modifying a cacheable property should update cache', function(get, set) {
-  equal(get(obj, 'foo'), 'bar 1', 'first get');
-  equal(get(obj, 'foo'), 'bar 1', 'second get');
+testBoth('modifying a cacheable property should update cache', function(get, set, assert) {
+  assert.equal(get(obj, 'foo'), 'bar 1', 'first get');
+  assert.equal(get(obj, 'foo'), 'bar 1', 'second get');
 
-  equal(set(obj, 'foo', 'baz'), 'baz', 'setting');
-  equal(get(obj, 'foo'), 'bar 2', 'third get');
-  equal(count, 2, 'should not invoke again');
+  assert.equal(set(obj, 'foo', 'baz'), 'baz', 'setting');
+  assert.equal(get(obj, 'foo'), 'bar 2', 'third get');
+  assert.equal(count, 2, 'should not invoke again');
 });
 
-testBoth('inherited property should not pick up cache', function(get, set) {
+testBoth('inherited property should not pick up cache', function(get, set, assert) {
   let objB = Object.create(obj);
 
-  equal(get(obj, 'foo'), 'bar 1', 'obj first get');
-  equal(get(objB, 'foo'), 'bar 2', 'objB first get');
+  assert.equal(get(obj, 'foo'), 'bar 1', 'obj first get');
+  assert.equal(get(objB, 'foo'), 'bar 2', 'objB first get');
 
-  equal(get(obj, 'foo'), 'bar 1', 'obj second get');
-  equal(get(objB, 'foo'), 'bar 2', 'objB second get');
+  assert.equal(get(obj, 'foo'), 'bar 1', 'obj second get');
+  assert.equal(get(objB, 'foo'), 'bar 2', 'objB second get');
 
   set(obj, 'foo', 'baz'); // modify A
-  equal(get(obj, 'foo'), 'bar 3', 'obj third get');
-  equal(get(objB, 'foo'), 'bar 2', 'objB third get');
+  assert.equal(get(obj, 'foo'), 'bar 3', 'obj third get');
+  assert.equal(get(objB, 'foo'), 'bar 2', 'objB third get');
 });
 
-testBoth('cacheFor should return the cached value', function(get) {
-  equal(cacheFor(obj, 'foo'), undefined, 'should not yet be a cached value');
+testBoth('cacheFor should return the cached value', function(get, set, assert) {
+  assert.equal(cacheFor(obj, 'foo'), undefined, 'should not yet be a cached value');
 
   get(obj, 'foo');
 
-  equal(cacheFor(obj, 'foo'), 'bar 1', 'should retrieve cached value');
+  assert.equal(cacheFor(obj, 'foo'), 'bar 1', 'should retrieve cached value');
 });
 
-testBoth('cacheFor should return falsy cached values', function(get) {
+testBoth('cacheFor should return falsy cached values', function(get, set, assert) {
   defineProperty(obj, 'falsy', computed(function() {
     return false;
   }));
 
-  equal(cacheFor(obj, 'falsy'), undefined, 'should not yet be a cached value');
+  assert.equal(cacheFor(obj, 'falsy'), undefined, 'should not yet be a cached value');
 
   get(obj, 'falsy');
 
-  equal(cacheFor(obj, 'falsy'), false, 'should retrieve cached value');
+  assert.equal(cacheFor(obj, 'falsy'), false, 'should retrieve cached value');
 });
 
-testBoth('setting a cached computed property passes the old value as the third argument', function(get, set) {
+testBoth('setting a cached computed property passes the old value as the third argument', function(get, set, assert) {
   let obj = {
     foo: 0
   };
@@ -353,13 +353,13 @@ testBoth('setting a cached computed property passes the old value as the third a
   );
 
   set(obj, 'plusOne', 1);
-  strictEqual(receivedOldValue, undefined, 'oldValue should be undefined');
+  assert.strictEqual(receivedOldValue, undefined, 'oldValue should be undefined');
 
   set(obj, 'plusOne', 2);
-  strictEqual(receivedOldValue, 1, 'oldValue should be 1');
+  assert.strictEqual(receivedOldValue, 1, 'oldValue should be 1');
 
   set(obj, 'plusOne', 3);
-  strictEqual(receivedOldValue, 2, 'oldValue should be 2');
+  assert.strictEqual(receivedOldValue, 2, 'oldValue should be 2');
 });
 
 // ..........................................................
@@ -367,7 +367,7 @@ testBoth('setting a cached computed property passes the old value as the third a
 //
 
 QUnit.module('computed - dependentkey', {
-  setup() {
+  beforeEach() {
     obj = { bar: 'baz' };
     count = 0;
     let getterAndSetter = function() {
@@ -381,36 +381,36 @@ QUnit.module('computed - dependentkey', {
     }).property('bar'));
   },
 
-  teardown() {
+  afterEach() {
     obj = count = null;
   }
 });
 
-testBoth('should lazily watch dependent keys on set', function (get, set) {
-  equal(isWatching(obj, 'bar'), false, 'precond not watching dependent key');
+testBoth('should lazily watch dependent keys on set', function (get, set, assert) {
+  assert.equal(isWatching(obj, 'bar'), false, 'precond not watching dependent key');
   set(obj, 'foo', 'bar');
-  equal(isWatching(obj, 'bar'), true, 'lazily watching dependent key');
+  assert.equal(isWatching(obj, 'bar'), true, 'lazily watching dependent key');
 });
 
-testBoth('should lazily watch dependent keys on get', function (get) {
-  equal(isWatching(obj, 'bar'), false, 'precond not watching dependent key');
+testBoth('should lazily watch dependent keys on get', function(get, set, assert) {
+  assert.equal(isWatching(obj, 'bar'), false, 'precond not watching dependent key');
   get(obj, 'foo');
-  equal(isWatching(obj, 'bar'), true, 'lazily watching dependent key');
+  assert.equal(isWatching(obj, 'bar'), true, 'lazily watching dependent key');
 });
 
-testBoth('local dependent key should invalidate cache', function(get, set) {
-  equal(isWatching(obj, 'bar'), false, 'precond not watching dependent key');
-  equal(get(obj, 'foo'), 'bar 1', 'get once');
-  equal(isWatching(obj, 'bar'), true, 'lazily setup watching dependent key');
-  equal(get(obj, 'foo'), 'bar 1', 'cached retrieve');
+testBoth('local dependent key should invalidate cache', function(get, set, assert) {
+  assert.equal(isWatching(obj, 'bar'), false, 'precond not watching dependent key');
+  assert.equal(get(obj, 'foo'), 'bar 1', 'get once');
+  assert.equal(isWatching(obj, 'bar'), true, 'lazily setup watching dependent key');
+  assert.equal(get(obj, 'foo'), 'bar 1', 'cached retrieve');
 
   set(obj, 'bar', 'BIFF'); // should invalidate foo
 
-  equal(get(obj, 'foo'), 'bar 2', 'should recache');
-  equal(get(obj, 'foo'), 'bar 2', 'cached retrieve');
+  assert.equal(get(obj, 'foo'), 'bar 2', 'should recache');
+  assert.equal(get(obj, 'foo'), 'bar 2', 'cached retrieve');
 });
 
-testBoth('should invalidate multiple nested dependent keys', function(get, set) {
+testBoth('should invalidate multiple nested dependent keys', function(get, set, assert) {
   let count = 0;
   defineProperty(obj, 'bar', computed(function() {
     count++;
@@ -418,24 +418,24 @@ testBoth('should invalidate multiple nested dependent keys', function(get, set) 
     return 'baz ' + count;
   }).property('baz'));
 
-  equal(isWatching(obj, 'bar'), false, 'precond not watching dependent key');
-  equal(isWatching(obj, 'baz'), false, 'precond not watching dependent key');
-  equal(get(obj, 'foo'), 'bar 1', 'get once');
-  equal(isWatching(obj, 'bar'), true, 'lazily setup watching dependent key');
-  equal(isWatching(obj, 'baz'), true, 'lazily setup watching dependent key');
-  equal(get(obj, 'foo'), 'bar 1', 'cached retrieve');
+  assert.equal(isWatching(obj, 'bar'), false, 'precond not watching dependent key');
+  assert.equal(isWatching(obj, 'baz'), false, 'precond not watching dependent key');
+  assert.equal(get(obj, 'foo'), 'bar 1', 'get once');
+  assert.equal(isWatching(obj, 'bar'), true, 'lazily setup watching dependent key');
+  assert.equal(isWatching(obj, 'baz'), true, 'lazily setup watching dependent key');
+  assert.equal(get(obj, 'foo'), 'bar 1', 'cached retrieve');
 
   set(obj, 'baz', 'BIFF'); // should invalidate bar -> foo
-  equal(isWatching(obj, 'bar'), false, 'should not be watching dependent key after cache cleared');
-  equal(isWatching(obj, 'baz'), false, 'should not be watching dependent key after cache cleared');
+  assert.equal(isWatching(obj, 'bar'), false, 'should not be watching dependent key after cache cleared');
+  assert.equal(isWatching(obj, 'baz'), false, 'should not be watching dependent key after cache cleared');
 
-  equal(get(obj, 'foo'), 'bar 2', 'should recache');
-  equal(get(obj, 'foo'), 'bar 2', 'cached retrieve');
-  equal(isWatching(obj, 'bar'), true, 'lazily setup watching dependent key');
-  equal(isWatching(obj, 'baz'), true, 'lazily setup watching dependent key');
+  assert.equal(get(obj, 'foo'), 'bar 2', 'should recache');
+  assert.equal(get(obj, 'foo'), 'bar 2', 'cached retrieve');
+  assert.equal(isWatching(obj, 'bar'), true, 'lazily setup watching dependent key');
+  assert.equal(isWatching(obj, 'baz'), true, 'lazily setup watching dependent key');
 });
 
-testBoth('circular keys should not blow up', function(get, set) {
+testBoth('circular keys should not blow up', function(get, set, assert) {
   let func = function() {
     count++;
     return 'bar ' + count;
@@ -447,57 +447,57 @@ testBoth('circular keys should not blow up', function(get, set) {
     return 'foo ' + count;
   }).property('bar'));
 
-  equal(get(obj, 'foo'), 'foo 1', 'get once');
-  equal(get(obj, 'foo'), 'foo 1', 'cached retrieve');
+  assert.equal(get(obj, 'foo'), 'foo 1', 'get once');
+  assert.equal(get(obj, 'foo'), 'foo 1', 'cached retrieve');
 
   set(obj, 'bar', 'BIFF'); // should invalidate bar -> foo -> bar
 
-  equal(get(obj, 'foo'), 'foo 3', 'should recache');
-  equal(get(obj, 'foo'), 'foo 3', 'cached retrieve');
+  assert.equal(get(obj, 'foo'), 'foo 3', 'should recache');
+  assert.equal(get(obj, 'foo'), 'foo 3', 'cached retrieve');
 });
 
-testBoth('redefining a property should undo old dependent keys', function(get, set) {
-  equal(isWatching(obj, 'bar'), false, 'precond not watching dependent key');
-  equal(get(obj, 'foo'), 'bar 1');
-  equal(isWatching(obj, 'bar'), true, 'lazily watching dependent key');
+testBoth('redefining a property should undo old dependent keys', function(get, set, assert) {
+  assert.equal(isWatching(obj, 'bar'), false, 'precond not watching dependent key');
+  assert.equal(get(obj, 'foo'), 'bar 1');
+  assert.equal(isWatching(obj, 'bar'), true, 'lazily watching dependent key');
 
   defineProperty(obj, 'foo', computed(function() {
     count++;
     return 'baz ' + count;
   }).property('baz'));
 
-  equal(isWatching(obj, 'bar'), false, 'after redefining should not be watching dependent key');
+  assert.equal(isWatching(obj, 'bar'), false, 'after redefining should not be watching dependent key');
 
-  equal(get(obj, 'foo'), 'baz 2');
+  assert.equal(get(obj, 'foo'), 'baz 2');
 
   set(obj, 'bar', 'BIFF'); // should not kill cache
-  equal(get(obj, 'foo'), 'baz 2');
+  assert.equal(get(obj, 'foo'), 'baz 2');
 
   set(obj, 'baz', 'BOP');
-  equal(get(obj, 'foo'), 'baz 3');
+  assert.equal(get(obj, 'foo'), 'baz 3');
 });
 
-testBoth('can watch multiple dependent keys specified declaratively via brace expansion', function (get, set) {
+testBoth('can watch multiple dependent keys specified declaratively via brace expansion', function(get, set, assert) {
   defineProperty(obj, 'foo', computed(function() {
     count++;
     return 'foo ' + count;
   }).property('qux.{bar,baz}'));
 
-  equal(get(obj, 'foo'), 'foo 1', 'get once');
-  equal(get(obj, 'foo'), 'foo 1', 'cached retrieve');
+  assert.equal(get(obj, 'foo'), 'foo 1', 'get once');
+  assert.equal(get(obj, 'foo'), 'foo 1', 'cached retrieve');
 
   set(obj, 'qux', {});
   set(obj, 'qux.bar', 'bar'); // invalidate foo
 
-  equal(get(obj, 'foo'), 'foo 2', 'foo invalidated from bar');
+  assert.equal(get(obj, 'foo'), 'foo 2', 'foo invalidated from bar');
 
   set(obj, 'qux.baz', 'baz'); // invalidate foo
 
-  equal(get(obj, 'foo'), 'foo 3', 'foo invalidated from baz');
+  assert.equal(get(obj, 'foo'), 'foo 3', 'foo invalidated from baz');
 
   set(obj, 'qux.quux', 'quux'); // do not invalidate foo
 
-  equal(get(obj, 'foo'), 'foo 3', 'foo not invalidated by quux');
+  assert.equal(get(obj, 'foo'), 'foo 3', 'foo not invalidated by quux');
 });
 
 testBoth('throws assertion if brace expansion notation has spaces', function () {
@@ -509,8 +509,8 @@ testBoth('throws assertion if brace expansion notation has spaces', function () 
   }, /cannot contain spaces/);
 });
 
-testBoth('throws an assertion if an uncached `get` is called after object is destroyed', function(get) {
-  equal(isWatching(obj, 'bar'), false, 'precond not watching dependent key');
+testBoth('throws an assertion if an uncached `get` is called after object is destroyed', function(get, set, assert) {
+  assert.equal(isWatching(obj, 'bar'), false, 'precond not watching dependent key');
 
   let meta = metaFor(obj);
   meta.destroy();
@@ -521,7 +521,7 @@ testBoth('throws an assertion if an uncached `get` is called after object is des
     get(obj, 'foo', 'bar');
   }, 'Cannot modify dependent keys for `foo` on `<custom-obj:here>` after it has been destroyed.');
 
-  equal(isWatching(obj, 'bar'), false, 'deps were not updated');
+  assert.equal(isWatching(obj, 'bar'), false, 'deps were not updated');
 });
 
 // ..........................................................
@@ -556,54 +556,54 @@ let moduleOpts = {
 
 QUnit.module('computed - dependentkey with chained properties', moduleOpts);
 
-testBoth('depending on simple chain', function(get, set) {
+testBoth('depending on simple chain', function(get, set, assert) {
   // assign computed property
   defineProperty(obj, 'prop',
     computed(func).property('foo.bar.baz.biff'));
 
-  equal(get(obj, 'prop'), 'BIFF 1');
+  assert.equal(get(obj, 'prop'), 'BIFF 1');
 
   set(get(obj, 'foo.bar.baz'), 'biff', 'BUZZ');
-  equal(get(obj, 'prop'), 'BUZZ 2');
-  equal(get(obj, 'prop'), 'BUZZ 2');
+  assert.equal(get(obj, 'prop'), 'BUZZ 2');
+  assert.equal(get(obj, 'prop'), 'BUZZ 2');
 
   set(get(obj, 'foo.bar'), 'baz', { biff: 'BLOB' });
-  equal(get(obj, 'prop'), 'BLOB 3');
-  equal(get(obj, 'prop'), 'BLOB 3');
+  assert.equal(get(obj, 'prop'), 'BLOB 3');
+  assert.equal(get(obj, 'prop'), 'BLOB 3');
 
   set(get(obj, 'foo.bar.baz'), 'biff', 'BUZZ');
-  equal(get(obj, 'prop'), 'BUZZ 4');
-  equal(get(obj, 'prop'), 'BUZZ 4');
+  assert.equal(get(obj, 'prop'), 'BUZZ 4');
+  assert.equal(get(obj, 'prop'), 'BUZZ 4');
 
   set(get(obj, 'foo'), 'bar', { baz: { biff: 'BOOM' } });
-  equal(get(obj, 'prop'), 'BOOM 5');
-  equal(get(obj, 'prop'), 'BOOM 5');
+  assert.equal(get(obj, 'prop'), 'BOOM 5');
+  assert.equal(get(obj, 'prop'), 'BOOM 5');
 
   set(get(obj, 'foo.bar.baz'), 'biff', 'BUZZ');
-  equal(get(obj, 'prop'), 'BUZZ 6');
-  equal(get(obj, 'prop'), 'BUZZ 6');
+  assert.equal(get(obj, 'prop'), 'BUZZ 6');
+  assert.equal(get(obj, 'prop'), 'BUZZ 6');
 
   set(obj, 'foo', { bar: { baz: { biff: 'BLARG' } } });
-  equal(get(obj, 'prop'), 'BLARG 7');
-  equal(get(obj, 'prop'), 'BLARG 7');
+  assert.equal(get(obj, 'prop'), 'BLARG 7');
+  assert.equal(get(obj, 'prop'), 'BLARG 7');
 
   set(get(obj, 'foo.bar.baz'), 'biff', 'BUZZ');
-  equal(get(obj, 'prop'), 'BUZZ 8');
-  equal(get(obj, 'prop'), 'BUZZ 8');
+  assert.equal(get(obj, 'prop'), 'BUZZ 8');
+  assert.equal(get(obj, 'prop'), 'BUZZ 8');
 
   defineProperty(obj, 'prop');
   set(obj, 'prop', 'NONE');
-  equal(get(obj, 'prop'), 'NONE');
+  assert.equal(get(obj, 'prop'), 'NONE');
 
   set(obj, 'foo', { bar: { baz: { biff: 'BLARG' } } });
-  equal(get(obj, 'prop'), 'NONE'); // should do nothing
-  equal(count, 8, 'should be not have invoked computed again');
+  assert.equal(get(obj, 'prop'), 'NONE'); // should do nothing
+  assert.equal(count, 8, 'should be not have invoked computed again');
 });
 
-testBoth('chained dependent keys should evaluate computed properties lazily', function() {
+testBoth('chained dependent keys should evaluate computed properties lazily', function(get, set, assert) {
   defineProperty(obj.foo.bar, 'b', computed(func));
   defineProperty(obj.foo, 'c', computed(function() {}).property('bar.b'));
-  equal(count, 0, 'b should not run');
+  assert.equal(count, 0, 'b should not run');
 });
 
 // ..........................................................
@@ -612,55 +612,55 @@ testBoth('chained dependent keys should evaluate computed properties lazily', fu
 
 QUnit.module('computed - improved cp syntax');
 
-QUnit.test('setter and getters are passed using an object', function() {
+QUnit.test('setter and getters are passed using an object', function(assert) {
   let testObj = EmberObject.extend({
     a: '1',
     b: '2',
     aInt: computed('a', {
       get(keyName) {
-        equal(keyName, 'aInt', 'getter receives the keyName');
+        assert.equal(keyName, 'aInt', 'getter receives the keyName');
         return parseInt(this.get('a'));
       },
       set(keyName, value, oldValue) {
-        equal(keyName, 'aInt', 'setter receives the keyName');
-        equal(value, 123, 'setter receives the new value');
-        equal(oldValue, 1, 'setter receives the old value');
+        assert.equal(keyName, 'aInt', 'setter receives the keyName');
+        assert.equal(value, 123, 'setter receives the new value');
+        assert.equal(oldValue, 1, 'setter receives the old value');
         this.set('a', '' + value); // side effect
         return parseInt(this.get('a'));
       }
     })
   }).create();
 
-  ok(testObj.get('aInt') === 1, 'getter works');
+  assert.ok(testObj.get('aInt') === 1, 'getter works');
   testObj.set('aInt', 123);
-  ok(testObj.get('a') === '123', 'setter works');
-  ok(testObj.get('aInt') === 123, 'cp has been updated too');
+  assert.ok(testObj.get('a') === '123', 'setter works');
+  assert.ok(testObj.get('aInt') === 123, 'cp has been updated too');
 });
 
-QUnit.test('setter can be omited', function() {
+QUnit.test('setter can be omited', function(assert) {
   let testObj = EmberObject.extend({
     a: '1',
     b: '2',
     aInt: computed('a', {
       get(keyName) {
-        equal(keyName, 'aInt', 'getter receives the keyName');
+        assert.equal(keyName, 'aInt', 'getter receives the keyName');
         return parseInt(this.get('a'));
       }
     })
   }).create();
 
-  ok(testObj.get('aInt') === 1, 'getter works');
-  ok(testObj.get('a') === '1');
+  assert.ok(testObj.get('aInt') === 1, 'getter works');
+  assert.ok(testObj.get('a') === '1');
   testObj.set('aInt', '123');
-  ok(testObj.get('aInt') === '123', 'cp has been updated too');
+  assert.ok(testObj.get('aInt') === '123', 'cp has been updated too');
 });
 
-QUnit.test('the return value of the setter gets cached', function() {
+QUnit.test('the return value of the setter gets cached', function(assert) {
   let testObj = EmberObject.extend({
     a: '1',
     sampleCP: computed('a', {
       get() {
-        ok(false, 'The getter should not be invoked');
+        assert.ok(false, 'The getter should not be invoked');
         return 'get-value';
       },
       set() {
@@ -670,7 +670,7 @@ QUnit.test('the return value of the setter gets cached', function() {
   }).create();
 
   testObj.set('sampleCP', 'abcd');
-  ok(testObj.get('sampleCP') === 'set-value', 'The return value of the CP was cached');
+  assert.ok(testObj.get('sampleCP') === 'set-value', 'The return value of the CP was cached');
 });
 
 // ..........................................................
@@ -679,7 +679,7 @@ QUnit.test('the return value of the setter gets cached', function() {
 
 QUnit.module('computed edge cases');
 
-QUnit.test('adding a computed property should show up in key iteration', function() {
+QUnit.test('adding a computed property should show up in key iteration', function(assert) {
   let obj = {};
   defineProperty(obj, 'foo', computed(function() {}));
 
@@ -687,11 +687,11 @@ QUnit.test('adding a computed property should show up in key iteration', functio
   for (let key in obj) {
     found.push(key);
   }
-  ok(found.indexOf('foo') >= 0, 'should find computed property in iteration found=' + found);
-  ok('foo' in obj, 'foo in obj should pass');
+  assert.ok(found.indexOf('foo') >= 0, 'should find computed property in iteration found=' + found);
+  assert.ok('foo' in obj, 'foo in obj should pass');
 });
 
-testBoth('when setting a value after it had been retrieved empty don\'t pass function UNDEFINED as oldValue', function(get, set) {
+testBoth('when setting a value after it had been retrieved empty don\'t pass function UNDEFINED as oldValue', function(get, set, assert) {
   let obj = {};
   let oldValueIsNoFunction = true;
 
@@ -708,12 +708,12 @@ testBoth('when setting a value after it had been retrieved empty don\'t pass fun
   get(obj, 'foo');
   set(obj, 'foo', undefined);
 
-  ok(oldValueIsNoFunction);
+  assert.ok(oldValueIsNoFunction);
 });
 
 QUnit.module('computed - setter');
 
-testBoth('setting a watched computed property', function(get, set) {
+testBoth('setting a watched computed property', function(get, set, assert) {
   let obj = {
     firstName: 'Yehuda',
     lastName: 'Katz'
@@ -754,25 +754,25 @@ testBoth('setting a watched computed property', function(get, set) {
     lastNameDidChange++;
   });
 
-  equal(get(obj, 'fullName'), 'Yehuda Katz');
+  assert.equal(get(obj, 'fullName'), 'Yehuda Katz');
 
   set(obj, 'fullName', 'Yehuda Katz');
 
   set(obj, 'fullName', 'Kris Selden');
 
-  equal(get(obj, 'fullName'), 'Kris Selden');
-  equal(get(obj, 'firstName'), 'Kris');
-  equal(get(obj, 'lastName'), 'Selden');
+  assert.equal(get(obj, 'fullName'), 'Kris Selden');
+  assert.equal(get(obj, 'firstName'), 'Kris');
+  assert.equal(get(obj, 'lastName'), 'Selden');
 
-  equal(fullNameWillChange, 1);
-  equal(fullNameDidChange, 1);
-  equal(firstNameWillChange, 1);
-  equal(firstNameDidChange, 1);
-  equal(lastNameWillChange, 1);
-  equal(lastNameDidChange, 1);
+  assert.equal(fullNameWillChange, 1);
+  assert.equal(fullNameDidChange, 1);
+  assert.equal(firstNameWillChange, 1);
+  assert.equal(firstNameDidChange, 1);
+  assert.equal(lastNameWillChange, 1);
+  assert.equal(lastNameDidChange, 1);
 });
 
-testBoth('setting a cached computed property that modifies the value you give it', function(get, set) {
+testBoth('setting a cached computed property that modifies the value you give it', function(get, set, assert) {
   let obj = {
     foo: 0
   };
@@ -794,25 +794,25 @@ testBoth('setting a cached computed property that modifies the value you give it
     plusOneDidChange++;
   });
 
-  equal(get(obj, 'plusOne'), 1);
+  assert.equal(get(obj, 'plusOne'), 1);
   set(obj, 'plusOne', 1);
-  equal(get(obj, 'plusOne'), 2);
+  assert.equal(get(obj, 'plusOne'), 2);
   set(obj, 'plusOne', 1);
-  equal(get(obj, 'plusOne'), 2);
+  assert.equal(get(obj, 'plusOne'), 2);
 
-  equal(plusOneWillChange, 1);
-  equal(plusOneDidChange, 1);
+  assert.equal(plusOneWillChange, 1);
+  assert.equal(plusOneDidChange, 1);
 
   set(obj, 'foo', 5);
-  equal(get(obj, 'plusOne'), 6);
+  assert.equal(get(obj, 'plusOne'), 6);
 
-  equal(plusOneWillChange, 2);
-  equal(plusOneDidChange, 2);
+  assert.equal(plusOneWillChange, 2);
+  assert.equal(plusOneDidChange, 2);
 });
 
 QUnit.module('computed - default setter');
 
-testBoth('when setting a value on a computed property that doesn\'t handle sets', function(get, set) {
+testBoth('when setting a value on a computed property that doesn\'t handle sets', function(get, set, assert) {
   let obj = {};
   let observerFired = false;
 
@@ -824,18 +824,18 @@ testBoth('when setting a value on a computed property that doesn\'t handle sets'
 
   set(obj, 'foo', 'bar');
 
-  equal(get(obj, 'foo'), 'bar', 'The set value is properly returned');
-  ok(typeof obj.foo === 'string', 'The computed property was removed');
-  ok(observerFired, 'The observer was still notified');
+  assert.equal(get(obj, 'foo'), 'bar', 'The set value is properly returned');
+  assert.ok(typeof obj.foo === 'string', 'The computed property was removed');
+  assert.ok(observerFired, 'The observer was still notified');
 });
 
 QUnit.module('computed - readOnly');
 
-QUnit.test('is chainable', function() {
+QUnit.test('is chainable', function(assert) {
   let cp = computed(function() {}).readOnly();
 
-  ok(cp instanceof Descriptor);
-  ok(cp instanceof ComputedProperty);
+  assert.ok(cp instanceof Descriptor);
+  assert.ok(cp instanceof ComputedProperty);
 });
 
 QUnit.test('throws assertion if called over a CP with a setter defined with the new syntax', function() {
@@ -847,18 +847,18 @@ QUnit.test('throws assertion if called over a CP with a setter defined with the 
   }, /Computed properties that define a setter using the new syntax cannot be read-only/);
 });
 
-testBoth('protects against setting', function(get, set) {
+testBoth('protects against setting', function(get, set, assert) {
   let obj = {  };
 
   defineProperty(obj, 'bar', computed(function() {
     return 'barValue';
   }).readOnly());
 
-  equal(get(obj, 'bar'), 'barValue');
+  assert.equal(get(obj, 'bar'), 'barValue');
 
-  throws(() => {
+  assert.throws(() => {
     set(obj, 'bar', 'newBar');
   }, /Cannot set read\-only property "bar" on object:/);
 
-  equal(get(obj, 'bar'), 'barValue');
+  assert.equal(get(obj, 'bar'), 'barValue');
 });

--- a/packages/ember-metal/tests/events_test.js
+++ b/packages/ember-metal/tests/events_test.js
@@ -12,26 +12,26 @@ import {
 
 QUnit.module('system/props/events_test');
 
-QUnit.test('listener should receive event - removing should remove', function() {
+QUnit.test('listener should receive event - removing should remove', function(assert) {
   let obj = {};
   let count = 0;
 
   function F() { count++; }
 
   addListener(obj, 'event!', F);
-  equal(count, 0, 'nothing yet');
+  assert.equal(count, 0, 'nothing yet');
 
   sendEvent(obj, 'event!');
-  equal(count, 1, 'received event');
+  assert.equal(count, 1, 'received event');
 
   removeListener(obj, 'event!', F);
 
   count = 0;
   sendEvent(obj, 'event!');
-  equal(count, 0, 'received event');
+  assert.equal(count, 0, 'received event');
 });
 
-QUnit.test('listeners should be inherited', function() {
+QUnit.test('listeners should be inherited', function(assert) {
   let obj = {};
   let count = 0;
   let F = function() { count++; };
@@ -40,23 +40,23 @@ QUnit.test('listeners should be inherited', function() {
 
   let obj2 = Object.create(obj);
 
-  equal(count, 0, 'nothing yet');
+  assert.equal(count, 0, 'nothing yet');
 
   sendEvent(obj2, 'event!');
-  equal(count, 1, 'received event');
+  assert.equal(count, 1, 'received event');
 
   removeListener(obj2, 'event!', F);
 
   count = 0;
   sendEvent(obj2, 'event!');
-  equal(count, 0, 'did not receive event');
+  assert.equal(count, 0, 'did not receive event');
 
   sendEvent(obj, 'event!');
-  equal(count, 1, 'should still invoke on parent');
+  assert.equal(count, 1, 'should still invoke on parent');
 });
 
 
-QUnit.test('adding a listener more than once should only invoke once', function() {
+QUnit.test('adding a listener more than once should only invoke once', function(assert) {
   let obj = {};
   let count = 0;
   function F() { count++; }
@@ -64,10 +64,10 @@ QUnit.test('adding a listener more than once should only invoke once', function(
   addListener(obj, 'event!', F);
 
   sendEvent(obj, 'event!');
-  equal(count, 1, 'should only invoke once');
+  assert.equal(count, 1, 'should only invoke once');
 });
 
-QUnit.test('adding a listener with a target should invoke with target', function() {
+QUnit.test('adding a listener with a target should invoke with target', function(assert) {
   let obj = {};
   let target;
 
@@ -78,10 +78,10 @@ QUnit.test('adding a listener with a target should invoke with target', function
 
   addListener(obj, 'event!', target, target.method);
   sendEvent(obj, 'event!');
-  equal(target.count, 1, 'should invoke');
+  assert.equal(target.count, 1, 'should invoke');
 });
 
-QUnit.test('suspending a listener should not invoke during callback', function() {
+QUnit.test('suspending a listener should not invoke during callback', function(assert) {
   let obj = {};
   let target, otherTarget;
 
@@ -100,7 +100,7 @@ QUnit.test('suspending a listener should not invoke during callback', function()
 
   function callback() {
     /*jshint validthis:true */
-    equal(this, target);
+    assert.equal(this, target);
 
     sendEvent(obj, 'event!');
 
@@ -109,15 +109,15 @@ QUnit.test('suspending a listener should not invoke during callback', function()
 
   sendEvent(obj, 'event!');
 
-  equal(suspendListener(obj, 'event!', target, target.method, callback), 'result');
+  assert.equal(suspendListener(obj, 'event!', target, target.method, callback), 'result');
 
   sendEvent(obj, 'event!');
 
-  equal(target.count, 2, 'should invoke');
-  equal(otherTarget.count, 3, 'should invoke');
+  assert.equal(target.count, 2, 'should invoke');
+  assert.equal(otherTarget.count, 3, 'should invoke');
 });
 
-QUnit.test('adding a listener with string method should lookup method on event delivery', function() {
+QUnit.test('adding a listener with string method should lookup method on event delivery', function(assert) {
   let obj = {};
   let target;
 
@@ -128,14 +128,14 @@ QUnit.test('adding a listener with string method should lookup method on event d
 
   addListener(obj, 'event!', target, 'method');
   sendEvent(obj, 'event!');
-  equal(target.count, 0, 'should invoke but do nothing');
+  assert.equal(target.count, 0, 'should invoke but do nothing');
 
   target.method = function() { this.count++; };
   sendEvent(obj, 'event!');
-  equal(target.count, 1, 'should invoke now');
+  assert.equal(target.count, 1, 'should invoke now');
 });
 
-QUnit.test('calling sendEvent with extra params should be passed to listeners', function() {
+QUnit.test('calling sendEvent with extra params should be passed to listeners', function(assert) {
   let obj = {};
   let params = null;
   addListener(obj, 'event!', function() {
@@ -143,49 +143,49 @@ QUnit.test('calling sendEvent with extra params should be passed to listeners', 
   });
 
   sendEvent(obj, 'event!', ['foo', 'bar']);
-  deepEqual(params, ['foo', 'bar'], 'params should be saved');
+  assert.deepEqual(params, ['foo', 'bar'], 'params should be saved');
 });
 
-QUnit.test('hasListeners tells you if there are listeners for a given event', function() {
+QUnit.test('hasListeners tells you if there are listeners for a given event', function(assert) {
   let obj = {};
 
   function F() {}
   function F2() {}
 
-  equal(hasListeners(obj, 'event!'), false, 'no listeners at first');
+  assert.equal(hasListeners(obj, 'event!'), false, 'no listeners at first');
 
   addListener(obj, 'event!', F);
   addListener(obj, 'event!', F2);
 
-  equal(hasListeners(obj, 'event!'), true, 'has listeners');
+  assert.equal(hasListeners(obj, 'event!'), true, 'has listeners');
 
   removeListener(obj, 'event!', F);
-  equal(hasListeners(obj, 'event!'), true, 'has listeners');
+  assert.equal(hasListeners(obj, 'event!'), true, 'has listeners');
 
   removeListener(obj, 'event!', F2);
-  equal(hasListeners(obj, 'event!'), false, 'has no more listeners');
+  assert.equal(hasListeners(obj, 'event!'), false, 'has no more listeners');
 
   addListener(obj, 'event!', F);
-  equal(hasListeners(obj, 'event!'), true, 'has listeners');
+  assert.equal(hasListeners(obj, 'event!'), true, 'has listeners');
 });
 
-QUnit.test('calling removeListener without method should remove all listeners', function() {
+QUnit.test('calling removeListener without method should remove all listeners', function(assert) {
   let obj = {};
   function F() {}
   function F2() {}
 
-  equal(hasListeners(obj, 'event!'), false, 'no listeners at first');
+  assert.equal(hasListeners(obj, 'event!'), false, 'no listeners at first');
 
   addListener(obj, 'event!', F);
   addListener(obj, 'event!', F2);
 
-  equal(hasListeners(obj, 'event!'), true, 'has listeners');
+  assert.equal(hasListeners(obj, 'event!'), true, 'has listeners');
   removeListener(obj, 'event!');
 
-  equal(hasListeners(obj, 'event!'), false, 'has no more listeners');
+  assert.equal(hasListeners(obj, 'event!'), false, 'has no more listeners');
 });
 
-QUnit.test('while suspended, it should not be possible to add a duplicate listener', function() {
+QUnit.test('while suspended, it should not be possible to add a duplicate listener', function(assert) {
   let obj = {};
   let target;
 
@@ -204,8 +204,8 @@ QUnit.test('while suspended, it should not be possible to add a duplicate listen
 
   suspendListener(obj, 'event!', target, target.method, callback);
 
-  equal(target.count, 1, 'should invoke');
-  equal(meta(obj).matchingListeners('event!').length, 3, 'a duplicate listener wasn\'t added');
+  assert.equal(target.count, 1, 'should invoke');
+  assert.equal(meta(obj).matchingListeners('event!').length, 3, 'a duplicate listener wasn\'t added');
 
   // now test suspendListeners...
 
@@ -213,11 +213,11 @@ QUnit.test('while suspended, it should not be possible to add a duplicate listen
 
   suspendListeners(obj, ['event!'], target, target.method, callback);
 
-  equal(target.count, 2, 'should have invoked again');
-  equal(meta(obj).matchingListeners('event!').length, 3, 'a duplicate listener wasn\'t added');
+  assert.equal(target.count, 2, 'should have invoked again');
+  assert.equal(meta(obj).matchingListeners('event!').length, 3, 'a duplicate listener wasn\'t added');
 });
 
-QUnit.test('a listener can be added as part of a mixin', function() {
+QUnit.test('a listener can be added as part of a mixin', function(assert) {
   let triggered = 0;
   let MyMixin = Mixin.create({
     foo1: on('bar', function() {
@@ -233,7 +233,7 @@ QUnit.test('a listener can be added as part of a mixin', function() {
   MyMixin.apply(obj);
 
   sendEvent(obj, 'bar');
-  equal(triggered, 2, 'should invoke listeners');
+  assert.equal(triggered, 2, 'should invoke listeners');
 });
 
 QUnit.test('Ember.on asserts for invalid arguments', function() {
@@ -250,7 +250,7 @@ QUnit.test('Ember.on asserts for invalid arguments', function() {
   }, 'on called without valid event names');
 });
 
-QUnit.test('a listener added as part of a mixin may be overridden', function() {
+QUnit.test('a listener added as part of a mixin may be overridden', function(assert) {
   let triggered = 0;
   let FirstMixin = Mixin.create({
     foo: on('bar', function() {
@@ -268,8 +268,8 @@ QUnit.test('a listener added as part of a mixin may be overridden', function() {
   SecondMixin.apply(obj);
 
   sendEvent(obj, 'bar');
-  equal(triggered, 0, 'should not invoke from overridden property');
+  assert.equal(triggered, 0, 'should not invoke from overridden property');
 
   sendEvent(obj, 'baz');
-  equal(triggered, 1, 'should invoke from subclass property');
+  assert.equal(triggered, 1, 'should invoke from subclass property');
 });

--- a/packages/ember-metal/tests/expand_properties_test.js
+++ b/packages/ember-metal/tests/expand_properties_test.js
@@ -7,72 +7,72 @@ function addProperty(property) {
 }
 
 QUnit.module('Property Brace Expansion Test', {
-  setup() {
+  beforeEach() {
     foundProperties = [];
   }
 });
 
-QUnit.test('Properties without expansions are unaffected', function() {
-  expect(1);
+QUnit.test('Properties without expansions are unaffected', function(assert) {
+  assert.expect(1);
 
   expandProperties('a', addProperty);
   expandProperties('a.b', addProperty);
   expandProperties('a.b.[]', addProperty);
   expandProperties('a.b.@each.c', addProperty);
 
-  deepEqual(['a', 'a.b', 'a.b.[]', 'a.b.@each.c'].sort(), foundProperties.sort());
+  assert.deepEqual(['a', 'a.b', 'a.b.[]', 'a.b.@each.c'].sort(), foundProperties.sort());
 });
 
-QUnit.test('A single expansion at the end expands properly', function() {
-  expect(1);
+QUnit.test('A single expansion at the end expands properly', function(assert) {
+  assert.expect(1);
 
   expandProperties('a.b.{c,d}', addProperty);
 
-  deepEqual(['a.b.c', 'a.b.d'].sort(), foundProperties.sort());
+  assert.deepEqual(['a.b.c', 'a.b.d'].sort(), foundProperties.sort());
 });
 
-QUnit.test('A property with only a brace expansion expands correctly', function() {
-  expect(1);
+QUnit.test('A property with only a brace expansion expands correctly', function(assert) {
+  assert.expect(1);
 
   expandProperties('{a,b,c}', addProperty);
 
   let expected = ['a', 'b', 'c'];
-  deepEqual(expected.sort(), foundProperties.sort());
+  assert.deepEqual(expected.sort(), foundProperties.sort());
 });
 
-QUnit.test('Expansions with single properties only expand once', function() {
-  expect(1);
+QUnit.test('Expansions with single properties only expand once', function(assert) {
+  assert.expect(1);
 
   expandProperties('a.b.{c}.d.{e}', addProperty);
 
-  deepEqual(['a.b.c.d.e'], foundProperties);
+  assert.deepEqual(['a.b.c.d.e'], foundProperties);
 });
 
-QUnit.test('A single brace expansion expands correctly', function() {
-  expect(1);
+QUnit.test('A single brace expansion expands correctly', function(assert) {
+  assert.expect(1);
 
   expandProperties('a.{b,c,d}.e', addProperty);
 
   let expected = ['a.b.e', 'a.c.e', 'a.d.e'];
-  deepEqual(expected.sort(), foundProperties.sort());
+  assert.deepEqual(expected.sort(), foundProperties.sort());
 });
 
-QUnit.test('Multiple brace expansions work correctly', function() {
-  expect(1);
+QUnit.test('Multiple brace expansions work correctly', function(assert) {
+  assert.expect(1);
 
   expandProperties('{a,b,c}.d.{e,f}.g', addProperty);
 
   let expected = ['a.d.e.g', 'a.d.f.g', 'b.d.e.g', 'b.d.f.g', 'c.d.e.g', 'c.d.f.g'];
-  deepEqual(expected.sort(), foundProperties.sort());
+  assert.deepEqual(expected.sort(), foundProperties.sort());
 });
 
-QUnit.test('A property with only brace expansions expands correctly', function() {
-  expect(1);
+QUnit.test('A property with only brace expansions expands correctly', function(assert) {
+  assert.expect(1);
 
   expandProperties('{a,b,c}.{d}.{e,f}', addProperty);
 
   let expected = ['a.d.e', 'a.d.f', 'b.d.e', 'b.d.f', 'c.d.e', 'c.d.f'];
-  deepEqual(expected.sort(), foundProperties.sort());
+  assert.deepEqual(expected.sort(), foundProperties.sort());
 });
 
 QUnit.test('Nested brace expansions are not allowed', function() {
@@ -90,24 +90,24 @@ QUnit.test('Nested brace expansions are not allowed', function() {
   }, /Brace expanded properties have to be balanced and cannot be nested/);
 });
 
-QUnit.test('A property with no braces does not expand', function() {
-  expect(1);
+QUnit.test('A property with no braces does not expand', function(assert) {
+  assert.expect(1);
 
   expandProperties('a,b,c.d.e,f', addProperty);
 
-  deepEqual(foundProperties, ['a,b,c.d.e,f']);
+  assert.deepEqual(foundProperties, ['a,b,c.d.e,f']);
 });
 
-QUnit.test('A pattern must be a string', function() {
-  expect(1);
+QUnit.test('A pattern must be a string', function(assert) {
+  assert.expect(1);
 
   expectAssertion(() => {
     expandProperties([1, 2], addProperty);
   }, /A computed property key must be a string/);
 });
 
-QUnit.test('A pattern must not contain a space', function() {
-  expect(1);
+QUnit.test('A pattern must not contain a space', function(assert) {
+  assert.expect(1);
 
   expectAssertion(function() {
     expandProperties('{a, b}', addProperty);

--- a/packages/ember-metal/tests/injected_property_test.js
+++ b/packages/ember-metal/tests/injected_property_test.js
@@ -9,17 +9,17 @@ import {
 
 QUnit.module('InjectedProperty');
 
-QUnit.test('injected properties should be descriptors', function() {
-  ok(new InjectedProperty() instanceof Descriptor);
+QUnit.test('injected properties should be descriptors', function(assert) {
+  assert.ok(new InjectedProperty() instanceof Descriptor);
 });
 
-QUnit.test('injected properties should be overridable', function() {
+QUnit.test('injected properties should be overridable', function(assert) {
   let obj = {};
   defineProperty(obj, 'foo', new InjectedProperty());
 
   set(obj, 'foo', 'bar');
 
-  equal(get(obj, 'foo'), 'bar', 'should return the overridden value');
+  assert.equal(get(obj, 'foo'), 'bar', 'should return the overridden value');
 });
 
 QUnit.test('getting on an object without an owner or container should fail assertion', function() {
@@ -31,11 +31,11 @@ QUnit.test('getting on an object without an owner or container should fail asser
   }, /Attempting to lookup an injected property on an object without a container, ensure that the object was instantiated via a container./);
 });
 
-QUnit.test('getting on an object without an owner but with a container should not fail', function() {
+QUnit.test('getting on an object without an owner but with a container should not fail', function(assert) {
   let obj = {
     container: {
       lookup(key) {
-        ok(true, 'should call container.lookup');
+        assert.ok(true, 'should call container.lookup');
         return key;
       }
     }
@@ -43,27 +43,27 @@ QUnit.test('getting on an object without an owner but with a container should no
 
   defineProperty(obj, 'foo', new InjectedProperty('type', 'name'));
 
-  equal(get(obj, 'foo'), 'type:name', 'should return the value of container.lookup');
+  assert.equal(get(obj, 'foo'), 'type:name', 'should return the value of container.lookup');
 });
 
-QUnit.test('getting should return a lookup on the container', function() {
-  expect(2);
+QUnit.test('getting should return a lookup on the container', function(assert) {
+  assert.expect(2);
 
   let obj = {};
 
   setOwner(obj, {
     lookup(key) {
-      ok(true, 'should call container.lookup');
+      assert.ok(true, 'should call container.lookup');
       return key;
     }
   });
 
   defineProperty(obj, 'foo', new InjectedProperty('type', 'name'));
 
-  equal(get(obj, 'foo'), 'type:name', 'should return the value of container.lookup');
+  assert.equal(get(obj, 'foo'), 'type:name', 'should return the value of container.lookup');
 });
 
-QUnit.test('omitting the lookup name should default to the property name', function() {
+QUnit.test('omitting the lookup name should default to the property name', function(assert) {
   let obj = {};
 
   setOwner(obj, {
@@ -74,5 +74,5 @@ QUnit.test('omitting the lookup name should default to the property name', funct
 
   defineProperty(obj, 'foo', new InjectedProperty('type'));
 
-  equal(get(obj, 'foo'), 'type:foo', 'should lookup the type using the property name');
+  assert.equal(get(obj, 'foo'), 'type:foo', 'should lookup the type using the property name');
 });

--- a/packages/ember-metal/tests/instrumentation_test.js
+++ b/packages/ember-metal/tests/instrumentation_test.js
@@ -6,20 +6,20 @@ import {
 } from '..';
 
 QUnit.module('Ember Instrumentation', {
-  teardown() {
+  afterEach() {
     reset();
   }
 });
 
-QUnit.test('execute block even if no listeners', function() {
+QUnit.test('execute block even if no listeners', function(assert) {
   let result = instrument('render', {}, function() {
     return 'hello';
   });
-  equal(result, 'hello', 'called block');
+  assert.equal(result, 'hello', 'called block');
 });
 
-QUnit.test('subscribing to a simple path receives the listener', function() {
-  expect(12);
+QUnit.test('subscribing to a simple path receives the listener', function(assert) {
+  assert.expect(12);
 
   let sentPayload = {};
   let count = 0;
@@ -27,24 +27,24 @@ QUnit.test('subscribing to a simple path receives the listener', function() {
   subscribe('render', {
     before(name, timestamp, payload) {
       if (count === 0) {
-        strictEqual(name, 'render');
+        assert.strictEqual(name, 'render');
       } else {
-        strictEqual(name, 'render.handlebars');
+        assert.strictEqual(name, 'render.handlebars');
       }
 
-      ok(typeof timestamp === 'number');
-      strictEqual(payload, sentPayload);
+      assert.ok(typeof timestamp === 'number');
+      assert.strictEqual(payload, sentPayload);
     },
 
     after(name, timestamp, payload) {
       if (count === 0) {
-        strictEqual(name, 'render');
+        assert.strictEqual(name, 'render');
       } else {
-        strictEqual(name, 'render.handlebars');
+        assert.strictEqual(name, 'render.handlebars');
       }
 
-      ok(typeof timestamp === 'number');
-      strictEqual(payload, sentPayload);
+      assert.ok(typeof timestamp === 'number');
+      assert.strictEqual(payload, sentPayload);
 
       count++;
     }
@@ -55,8 +55,8 @@ QUnit.test('subscribing to a simple path receives the listener', function() {
   instrument('render.handlebars', sentPayload, function() {});
 });
 
-QUnit.test('returning a value from the before callback passes it to the after callback', function() {
-  expect(2);
+QUnit.test('returning a value from the before callback passes it to the after callback', function(assert) {
+  assert.expect(2);
 
   let passthru1 = {};
   let passthru2 = {};
@@ -66,7 +66,7 @@ QUnit.test('returning a value from the before callback passes it to the after ca
       return passthru1;
     },
     after(name, timestamp, payload, beforeValue) {
-      strictEqual(beforeValue, passthru1);
+      assert.strictEqual(beforeValue, passthru1);
     }
   });
 
@@ -75,19 +75,19 @@ QUnit.test('returning a value from the before callback passes it to the after ca
       return passthru2;
     },
     after(name, timestamp, payload, beforeValue) {
-      strictEqual(beforeValue, passthru2);
+      assert.strictEqual(beforeValue, passthru2);
     }
   });
 
   instrument('render', null, function() {});
 });
 
-QUnit.test('instrument with 2 args (name, callback) no payload', function() {
-  expect(1);
+QUnit.test('instrument with 2 args (name, callback) no payload', function(assert) {
+  assert.expect(1);
 
   subscribe('render', {
     before(name, timestamp, payload) {
-      deepEqual(payload, {});
+      assert.deepEqual(payload, {});
     },
     after() {}
   });
@@ -95,30 +95,30 @@ QUnit.test('instrument with 2 args (name, callback) no payload', function() {
   instrument('render', function() {});
 });
 
-QUnit.test('instrument with 3 args (name, callback, binding) no payload', function() {
-  expect(2);
+QUnit.test('instrument with 3 args (name, callback, binding) no payload', function(assert) {
+  assert.expect(2);
 
   let binding = {};
   subscribe('render', {
     before(name, timestamp, payload) {
-      deepEqual(payload, {});
+      assert.deepEqual(payload, {});
     },
     after() {}
   });
 
   instrument('render', function() {
-    deepEqual(this, binding);
+    assert.deepEqual(this, binding);
   }, binding);
 });
 
 
-QUnit.test('instrument with 3 args (name, payload, callback) with payload', function() {
-  expect(1);
+QUnit.test('instrument with 3 args (name, payload, callback) with payload', function(assert) {
+  assert.expect(1);
 
   let expectedPayload = { hi: 1 };
   subscribe('render', {
     before(name, timestamp, payload) {
-      deepEqual(payload, expectedPayload);
+      assert.deepEqual(payload, expectedPayload);
     },
     after() {}
   });
@@ -126,40 +126,40 @@ QUnit.test('instrument with 3 args (name, payload, callback) with payload', func
   instrument('render', expectedPayload, function() {});
 });
 
-QUnit.test('instrument with 4 args (name, payload, callback, binding) with payload', function() {
-  expect(2);
+QUnit.test('instrument with 4 args (name, payload, callback, binding) with payload', function(assert) {
+  assert.expect(2);
 
   let expectedPayload = { hi: 1 };
   let binding = {};
   subscribe('render', {
     before(name, timestamp, payload) {
-      deepEqual(payload, expectedPayload);
+      assert.deepEqual(payload, expectedPayload);
     },
     after() {}
   });
 
   instrument('render', expectedPayload, function() {
-    deepEqual(this, binding);
+    assert.deepEqual(this, binding);
   }, binding);
 });
 
 
-QUnit.test('raising an exception in the instrumentation attaches it to the payload', function() {
-  expect(2);
+QUnit.test('raising an exception in the instrumentation attaches it to the payload', function(assert) {
+  assert.expect(2);
 
   let error = new Error('Instrumentation');
 
   subscribe('render', {
     before() {},
     after(name, timestamp, payload) {
-      strictEqual(payload.exception, error);
+      assert.strictEqual(payload.exception, error);
     }
   });
 
   subscribe('render', {
     before() {},
     after(name, timestamp, payload) {
-      strictEqual(payload.exception, error);
+      assert.strictEqual(payload.exception, error);
     }
   });
 
@@ -168,34 +168,34 @@ QUnit.test('raising an exception in the instrumentation attaches it to the paylo
   });
 });
 
-QUnit.test('it is possible to add a new subscriber after the first instrument', function() {
+QUnit.test('it is possible to add a new subscriber after the first instrument', function(assert) {
   instrument('render.handlebars', null, function() {});
 
   subscribe('render', {
     before() {
-      ok(true, 'Before callback was called');
+      assert.ok(true, 'Before callback was called');
     },
     after() {
-      ok(true, 'After callback was called');
+      assert.ok(true, 'After callback was called');
     }
   });
 
   instrument('render.handlebars', null, function() {});
 });
 
-QUnit.test('it is possible to remove a subscriber', function() {
-  expect(4);
+QUnit.test('it is possible to remove a subscriber', function(assert) {
+  assert.expect(4);
 
   let count = 0;
 
   let subscriber = subscribe('render', {
     before() {
-      equal(count, 0);
-      ok(true, 'Before callback was called');
+      assert.equal(count, 0);
+      assert.ok(true, 'Before callback was called');
     },
     after() {
-      equal(count, 0);
-      ok(true, 'After callback was called');
+      assert.equal(count, 0);
+      assert.ok(true, 'After callback was called');
       count++;
     }
   });

--- a/packages/ember-metal/tests/is_blank_test.js
+++ b/packages/ember-metal/tests/is_blank_test.js
@@ -2,24 +2,24 @@ import { isBlank } from '..';
 
 QUnit.module('Ember.isBlank');
 
-QUnit.test('Ember.isBlank', function() {
+QUnit.test('Ember.isBlank', function(assert) {
   let string = 'string';
   let fn = function() {};
   let object = { length: 0 };
 
-  equal(true, isBlank(null), 'for null');
-  equal(true, isBlank(undefined), 'for undefined');
-  equal(true, isBlank(''), 'for an empty String');
-  equal(true, isBlank('  '), 'for a whitespace String');
-  equal(true, isBlank('\n\t'), 'for another whitespace String');
-  equal(false, isBlank('\n\t Hi'), 'for a String with whitespaces');
-  equal(false, isBlank(true), 'for true');
-  equal(false, isBlank(false), 'for false');
-  equal(false, isBlank(string), 'for a String');
-  equal(false, isBlank(fn), 'for a Function');
-  equal(false, isBlank(0), 'for 0');
-  equal(true, isBlank([]), 'for an empty Array');
-  equal(false, isBlank({}), 'for an empty Object');
-  equal(true, isBlank(object), 'for an Object that has zero \'length\'');
-  equal(false, isBlank([1, 2, 3]), 'for a non-empty array');
+  assert.equal(true, isBlank(null), 'for null');
+  assert.equal(true, isBlank(undefined), 'for undefined');
+  assert.equal(true, isBlank(''), 'for an empty String');
+  assert.equal(true, isBlank('  '), 'for a whitespace String');
+  assert.equal(true, isBlank('\n\t'), 'for another whitespace String');
+  assert.equal(false, isBlank('\n\t Hi'), 'for a String with whitespaces');
+  assert.equal(false, isBlank(true), 'for true');
+  assert.equal(false, isBlank(false), 'for false');
+  assert.equal(false, isBlank(string), 'for a String');
+  assert.equal(false, isBlank(fn), 'for a Function');
+  assert.equal(false, isBlank(0), 'for 0');
+  assert.equal(true, isBlank([]), 'for an empty Array');
+  assert.equal(false, isBlank({}), 'for an empty Object');
+  assert.equal(true, isBlank(object), 'for an Object that has zero \'length\'');
+  assert.equal(false, isBlank([1, 2, 3]), 'for a non-empty array');
 });

--- a/packages/ember-metal/tests/is_empty_test.js
+++ b/packages/ember-metal/tests/is_empty_test.js
@@ -6,36 +6,36 @@ import {
 
 QUnit.module('Ember.isEmpty');
 
-QUnit.test('Ember.isEmpty', function() {
+QUnit.test('Ember.isEmpty', function(assert) {
   let string = 'string';
   let fn = function() {};
   let object = { length: 0 };
 
-  equal(true, isEmpty(null), 'for null');
-  equal(true, isEmpty(undefined), 'for undefined');
-  equal(true, isEmpty(''), 'for an empty String');
-  equal(false, isEmpty('  '), 'for a whitespace String');
-  equal(false, isEmpty('\n\t'), 'for another whitespace String');
-  equal(false, isEmpty(true), 'for true');
-  equal(false, isEmpty(false), 'for false');
-  equal(false, isEmpty(string), 'for a String');
-  equal(false, isEmpty(fn), 'for a Function');
-  equal(false, isEmpty(0), 'for 0');
-  equal(true, isEmpty([]), 'for an empty Array');
-  equal(false, isEmpty({}), 'for an empty Object');
-  equal(true, isEmpty(object), 'for an Object that has zero \'length\'');
+  assert.equal(true, isEmpty(null), 'for null');
+  assert.equal(true, isEmpty(undefined), 'for undefined');
+  assert.equal(true, isEmpty(''), 'for an empty String');
+  assert.equal(false, isEmpty('  '), 'for a whitespace String');
+  assert.equal(false, isEmpty('\n\t'), 'for another whitespace String');
+  assert.equal(false, isEmpty(true), 'for true');
+  assert.equal(false, isEmpty(false), 'for false');
+  assert.equal(false, isEmpty(string), 'for a String');
+  assert.equal(false, isEmpty(fn), 'for a Function');
+  assert.equal(false, isEmpty(0), 'for 0');
+  assert.equal(true, isEmpty([]), 'for an empty Array');
+  assert.equal(false, isEmpty({}), 'for an empty Object');
+  assert.equal(true, isEmpty(object), 'for an Object that has zero \'length\'');
 });
 
-QUnit.test('Ember.isEmpty Ember.Map', function() {
+QUnit.test('Ember.isEmpty Ember.Map', function(assert) {
   let map = new Map();
-  equal(true, isEmpty(map), 'Empty map is empty');
+  assert.equal(true, isEmpty(map), 'Empty map is empty');
   map.set('foo', 'bar');
-  equal(false, isEmpty(map), 'Map is not empty');
+  assert.equal(false, isEmpty(map), 'Map is not empty');
 });
 
-QUnit.test('Ember.isEmpty Ember.OrderedSet', function() {
+QUnit.test('Ember.isEmpty Ember.OrderedSet', function(assert) {
   let orderedSet = new OrderedSet();
-  equal(true, isEmpty(orderedSet), 'Empty ordered set is empty');
+  assert.equal(true, isEmpty(orderedSet), 'Empty ordered set is empty');
   orderedSet.add('foo');
-  equal(false, isEmpty(orderedSet), 'Ordered set is not empty');
+  assert.equal(false, isEmpty(orderedSet), 'Ordered set is not empty');
 });

--- a/packages/ember-metal/tests/is_none_test.js
+++ b/packages/ember-metal/tests/is_none_test.js
@@ -2,18 +2,18 @@ import { isNone } from '..';
 
 QUnit.module('Ember.isNone');
 
-QUnit.test('Ember.isNone', function() {
+QUnit.test('Ember.isNone', function(assert) {
   let string = 'string';
   let fn = function() {};
 
-  equal(true, isNone(null), 'for null');
-  equal(true, isNone(undefined), 'for undefined');
-  equal(false, isNone(''), 'for an empty String');
-  equal(false, isNone(true), 'for true');
-  equal(false, isNone(false), 'for false');
-  equal(false, isNone(string), 'for a String');
-  equal(false, isNone(fn), 'for a Function');
-  equal(false, isNone(0), 'for 0');
-  equal(false, isNone([]), 'for an empty Array');
-  equal(false, isNone({}), 'for an empty Object');
+  assert.equal(true, isNone(null), 'for null');
+  assert.equal(true, isNone(undefined), 'for undefined');
+  assert.equal(false, isNone(''), 'for an empty String');
+  assert.equal(false, isNone(true), 'for true');
+  assert.equal(false, isNone(false), 'for false');
+  assert.equal(false, isNone(string), 'for a String');
+  assert.equal(false, isNone(fn), 'for a Function');
+  assert.equal(false, isNone(0), 'for 0');
+  assert.equal(false, isNone([]), 'for an empty Array');
+  assert.equal(false, isNone({}), 'for an empty Object');
 });

--- a/packages/ember-metal/tests/is_present_test.js
+++ b/packages/ember-metal/tests/is_present_test.js
@@ -2,25 +2,25 @@ import { isPresent } from '..';
 
 QUnit.module('Ember.isPresent');
 
-QUnit.test('Ember.isPresent', function() {
+QUnit.test('Ember.isPresent', function(assert) {
   let string = 'string';
   let fn = function() {};
   let object = { length: 0 };
 
-  equal(false, isPresent(), 'for no params');
-  equal(false, isPresent(null), 'for null');
-  equal(false, isPresent(undefined), 'for undefined');
-  equal(false, isPresent(''), 'for an empty String');
-  equal(false, isPresent('  '), 'for a whitespace String');
-  equal(false, isPresent('\n\t'), 'for another whitespace String');
-  equal(true, isPresent('\n\t Hi'), 'for a String with whitespaces');
-  equal(true, isPresent(true), 'for true');
-  equal(true, isPresent(false), 'for false');
-  equal(true, isPresent(string), 'for a String');
-  equal(true, isPresent(fn), 'for a Function');
-  equal(true, isPresent(0), 'for 0');
-  equal(false, isPresent([]), 'for an empty Array');
-  equal(true, isPresent({}), 'for an empty Object');
-  equal(false, isPresent(object), 'for an Object that has zero \'length\'');
-  equal(true, isPresent([1, 2, 3]), 'for a non-empty array');
+  assert.equal(false, isPresent(), 'for no params');
+  assert.equal(false, isPresent(null), 'for null');
+  assert.equal(false, isPresent(undefined), 'for undefined');
+  assert.equal(false, isPresent(''), 'for an empty String');
+  assert.equal(false, isPresent('  '), 'for a whitespace String');
+  assert.equal(false, isPresent('\n\t'), 'for another whitespace String');
+  assert.equal(true, isPresent('\n\t Hi'), 'for a String with whitespaces');
+  assert.equal(true, isPresent(true), 'for true');
+  assert.equal(true, isPresent(false), 'for false');
+  assert.equal(true, isPresent(string), 'for a String');
+  assert.equal(true, isPresent(fn), 'for a Function');
+  assert.equal(true, isPresent(0), 'for 0');
+  assert.equal(false, isPresent([]), 'for an empty Array');
+  assert.equal(true, isPresent({}), 'for an empty Object');
+  assert.equal(false, isPresent(object), 'for an Object that has zero \'length\'');
+  assert.equal(true, isPresent([1, 2, 3]), 'for a non-empty array');
 });

--- a/packages/ember-metal/tests/libraries_test.js
+++ b/packages/ember-metal/tests/libraries_test.js
@@ -7,12 +7,12 @@ let libs, registry;
 let originalWarn = getDebugFunction('warn');
 
 QUnit.module('Libraries registry', {
-  setup() {
+  beforeEach() {
     libs = new Libraries();
     registry = libs._registry;
   },
 
-  teardown() {
+  afterEach() {
     libs = null;
     registry = null;
 
@@ -20,55 +20,55 @@ QUnit.module('Libraries registry', {
   }
 });
 
-QUnit.test('core libraries come before other libraries', function() {
-  expect(2);
+QUnit.test('core libraries come before other libraries', function(assert) {
+  assert.expect(2);
 
   libs.register('my-lib', '2.0.0a');
   libs.registerCoreLibrary('DS', '1.0.0-beta.2');
 
-  equal(registry[0].name, 'DS');
-  equal(registry[1].name, 'my-lib');
+  assert.equal(registry[0].name, 'DS');
+  assert.equal(registry[1].name, 'my-lib');
 });
 
-QUnit.test('only the first registration of a library is stored', function() {
-  expect(3);
+QUnit.test('only the first registration of a library is stored', function(assert) {
+  assert.expect(3);
 
   libs.register('magic', 1.23);
   libs.register('magic', 2.23);
 
-  equal(registry[0].name, 'magic');
-  equal(registry[0].version, 1.23);
-  equal(registry.length, 1);
+  assert.equal(registry[0].name, 'magic');
+  assert.equal(registry[0].version, 1.23);
+  assert.equal(registry.length, 1);
 });
 
 if (EMBER_LIBRARIES_ISREGISTERED) {
-  QUnit.test('isRegistered returns correct value', function() {
-    expect(3);
+  QUnit.test('isRegistered returns correct value', function(assert) {
+    assert.expect(3);
 
-    equal(libs.isRegistered('magic'), false);
+    assert.equal(libs.isRegistered('magic'), false);
 
     libs.register('magic', 1.23);
-    equal(libs.isRegistered('magic'), true);
+    assert.equal(libs.isRegistered('magic'), true);
 
     libs.deRegister('magic');
-    equal(libs.isRegistered('magic'), false);
+    assert.equal(libs.isRegistered('magic'), false);
   });
 }
 
-QUnit.test('attempting to register a library that is already registered warns you', function() {
+QUnit.test('attempting to register a library that is already registered warns you', function(assert) {
   if (EmberDev && EmberDev.runningProdBuild) {
-    ok(true, 'Logging does not occur in production builds');
+    assert.ok(true, 'Logging does not occur in production builds');
     return;
   }
 
-  expect(1);
+  assert.expect(1);
 
 
   libs.register('magic', 1.23);
 
   setDebugFunction('warn', function(msg, test) {
     if (!test) {
-      equal(msg, 'Library "magic" is already registered with Ember.');
+      assert.equal(msg, 'Library "magic" is already registered with Ember.');
     }
   });
 
@@ -76,8 +76,8 @@ QUnit.test('attempting to register a library that is already registered warns yo
   libs.register('magic', 2.23);
 });
 
-QUnit.test('libraries can be de-registered', function() {
-  expect(2);
+QUnit.test('libraries can be de-registered', function(assert) {
+  assert.expect(2);
 
   libs.register('lib1', '1.0.0b');
   libs.register('lib2', '1.0.0b');
@@ -86,6 +86,6 @@ QUnit.test('libraries can be de-registered', function() {
   libs.deRegister('lib1');
   libs.deRegister('lib3');
 
-  equal(registry[0].name, 'lib2');
-  equal(registry.length, 1);
+  assert.equal(registry[0].name, 'lib2');
+  assert.equal(registry.length, 1);
 });

--- a/packages/ember-metal/tests/main_test.js
+++ b/packages/ember-metal/tests/main_test.js
@@ -5,20 +5,20 @@ const SEMVER_REGEX = /^\bv?(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]
 
 QUnit.module('ember-metal/core/main');
 
-QUnit.test('Ember registers itself', function() {
+QUnit.test('Ember registers itself', function(assert) {
   let lib = Ember.libraries._registry[0];
 
-  equal(lib.name, 'Ember');
-  equal(lib.version, Ember.VERSION);
+  assert.equal(lib.name, 'Ember');
+  assert.equal(lib.version, Ember.VERSION);
 });
 
-QUnit.test('Ember.VERSION is in alignment with SemVer v2.0.0', function () {
-  ok(SEMVER_REGEX.test(Ember.VERSION), `Ember.VERSION (${Ember.VERSION})is valid SemVer v2.0.0`);
+QUnit.test('Ember.VERSION is in alignment with SemVer v2.0.0', function(assert) {
+  assert.ok(SEMVER_REGEX.test(Ember.VERSION), `Ember.VERSION (${Ember.VERSION})is valid SemVer v2.0.0`);
 });
 
-QUnit.test('SEMVER_REGEX properly validates and invalidates version numbers', function () {
+QUnit.test('SEMVER_REGEX properly validates and invalidates version numbers', function(assert) {
   function validateVersionString(versionString, expectedResult) {
-    equal(SEMVER_REGEX.test(versionString), expectedResult);
+    assert.equal(SEMVER_REGEX.test(versionString), expectedResult);
   }
 
   // Positive test cases

--- a/packages/ember-metal/tests/map_test.js
+++ b/packages/ember-metal/tests/map_test.js
@@ -11,7 +11,7 @@ function testMap(nameAndFunc) {
   variety = nameAndFunc[0];
 
   QUnit.module('Ember.' + variety + ' (forEach and get are implicitly tested)', {
-    setup() {
+    beforeEach() {
       object = {};
       number = 42;
       string = 'foo';
@@ -20,7 +20,7 @@ function testMap(nameAndFunc) {
     }
   });
 
-  let mapHasLength = function(expected, theMap) {
+  let mapHasLength = function(assert, expected, theMap) {
     theMap = theMap || map;
 
     let length = 0;
@@ -28,18 +28,18 @@ function testMap(nameAndFunc) {
       length++;
     });
 
-    equal(length, expected, 'map should contain ' + expected + ' items');
+    assert.equal(length, expected, 'map should contain ' + expected + ' items');
   };
 
-  let mapHasEntries = function(entries, theMap) {
+  let mapHasEntries = function(assert, entries, theMap) {
     theMap = theMap || map;
 
     for (let i = 0; i < entries.length; i++) {
-      equal(theMap.get(entries[i][0]), entries[i][1]);
-      equal(theMap.has(entries[i][0]), true);
+      assert.equal(theMap.get(entries[i][0]), entries[i][1]);
+      assert.equal(theMap.has(entries[i][0]), true);
     }
 
-    mapHasLength(entries.length, theMap);
+    mapHasLength(assert, entries.length, theMap);
   };
 
   let unboundThis;
@@ -48,12 +48,12 @@ function testMap(nameAndFunc) {
     unboundThis = this;
   }());
 
-  QUnit.test('set', function() {
+  QUnit.test('set', function(assert) {
     map.set(object, 'winning');
     map.set(number, 'winning');
     map.set(string, 'winning');
 
-    mapHasEntries([
+    mapHasEntries(assert, [
       [object, 'winning'],
       [number, 'winning'],
       [string, 'winning']
@@ -63,22 +63,22 @@ function testMap(nameAndFunc) {
     map.set(number, 'losing');
     map.set(string, 'losing');
 
-    mapHasEntries([
+    mapHasEntries(assert, [
       [object, 'losing'],
       [number, 'losing'],
       [string, 'losing']
     ]);
 
-    equal(map.has('nope'), false, 'expected the key `nope` to not be present');
-    equal(map.has({}), false, 'expected they key `{}` to not be present');
+    assert.equal(map.has('nope'), false, 'expected the key `nope` to not be present');
+    assert.equal(map.has({}), false, 'expected they key `{}` to not be present');
   });
 
-  QUnit.test('set chaining', function() {
+  QUnit.test('set chaining', function(assert) {
     map.set(object, 'winning').
         set(number, 'winning').
         set(string, 'winning');
 
-    mapHasEntries([
+    mapHasEntries(assert, [
       [object, 'winning'],
       [number, 'winning'],
       [string, 'winning']
@@ -88,43 +88,43 @@ function testMap(nameAndFunc) {
         set(number, 'losing').
         set(string, 'losing');
 
-    mapHasEntries([
+    mapHasEntries(assert, [
       [object, 'losing'],
       [number, 'losing'],
       [string, 'losing']
     ]);
 
-    equal(map.has('nope'), false, 'expected the key `nope` to not be present');
-    equal(map.has({}), false, 'expected they key `{}` to not be present');
+    assert.equal(map.has('nope'), false, 'expected the key `nope` to not be present');
+    assert.equal(map.has({}), false, 'expected they key `{}` to not be present');
   });
 
-  QUnit.test('with key with undefined value', function() {
+  QUnit.test('with key with undefined value', function(assert) {
     map.set('foo', undefined);
 
     map.forEach(function(value, key) {
-      equal(value, undefined);
-      equal(key, 'foo');
+      assert.equal(value, undefined);
+      assert.equal(key, 'foo');
     });
 
-    ok(map.has('foo'), 'has key foo, even with undefined value');
+    assert.ok(map.has('foo'), 'has key foo, even with undefined value');
 
-    equal(map.size, 1);
+    assert.equal(map.size, 1);
   });
 
-  QUnit.test('arity of forEach is 1 – es6 23.1.3.5', function() {
-    equal(map.forEach.length, 1, 'expected arity for map.forEach is 1');
+  QUnit.test('arity of forEach is 1 – es6 23.1.3.5', function(assert) {
+    assert.equal(map.forEach.length, 1, 'expected arity for map.forEach is 1');
   });
 
-  QUnit.test('forEach throws without a callback as the first argument', function() {
-    equal(map.forEach.length, 1, 'expected arity for map.forEach is 1');
+  QUnit.test('forEach throws without a callback as the first argument', function(assert) {
+    assert.equal(map.forEach.length, 1, 'expected arity for map.forEach is 1');
   });
 
-  QUnit.test('has empty collection', function() {
-    equal(map.has('foo'), false);
-    equal(map.has(), false);
+  QUnit.test('has empty collection', function(assert) {
+    assert.equal(map.has('foo'), false);
+    assert.equal(map.has(), false);
   });
 
-  QUnit.test('delete', function() {
+  QUnit.test('delete', function(assert) {
     expectNoDeprecation();
 
     map.set(object, 'winning');
@@ -138,10 +138,10 @@ function testMap(nameAndFunc) {
     // doesn't explode
     map.delete({});
 
-    mapHasEntries([]);
+    mapHasEntries(assert, []);
   });
 
-  QUnit.test('copy and then update', function() {
+  QUnit.test('copy and then update', function(assert) {
     map.set(object, 'winning');
     map.set(number, 'winning');
     map.set(string, 'winning');
@@ -152,20 +152,20 @@ function testMap(nameAndFunc) {
     map2.set(number, 'losing');
     map2.set(string, 'losing');
 
-    mapHasEntries([
+    mapHasEntries(assert, [
       [object, 'winning'],
       [number, 'winning'],
       [string, 'winning']
     ]);
 
-    mapHasEntries([
+    mapHasEntries(assert, [
       [object, 'losing'],
       [number, 'losing'],
       [string, 'losing']
     ], map2);
   });
 
-  QUnit.test('copy and then delete', function() {
+  QUnit.test('copy and then delete', function(assert) {
     map.set(object, 'winning');
     map.set(number, 'winning');
     map.set(string, 'winning');
@@ -176,49 +176,49 @@ function testMap(nameAndFunc) {
     map2.delete(number);
     map2.delete(string);
 
-    mapHasEntries([
+    mapHasEntries(assert, [
       [object, 'winning'],
       [number, 'winning'],
       [string, 'winning']
     ]);
 
-    mapHasEntries([], map2);
+    mapHasEntries(assert, [], map2);
   });
 
-  QUnit.test('size', function() {
+  QUnit.test('size', function(assert) {
     //Add a key twice
-    equal(map.size, 0);
+    assert.equal(map.size, 0);
     map.set(string, 'a string');
-    equal(map.size, 1);
+    assert.equal(map.size, 1);
     map.set(string, 'the same string');
-    equal(map.size, 1);
+    assert.equal(map.size, 1);
 
     //Add another
     map.set(number, 'a number');
-    equal(map.size, 2);
+    assert.equal(map.size, 2);
 
     //Remove one that doesn't exist
     map.delete('does not exist');
-    equal(map.size, 2);
+    assert.equal(map.size, 2);
 
     //Check copy
     let copy = map.copy();
-    equal(copy.size, 2);
+    assert.equal(copy.size, 2);
 
     //Remove a key twice
     map.delete(number);
-    equal(map.size, 1);
+    assert.equal(map.size, 1);
     map.delete(number);
-    equal(map.size, 1);
+    assert.equal(map.size, 1);
 
     //Remove the last key
     map.delete(string);
-    equal(map.size, 0);
+    assert.equal(map.size, 0);
     map.delete(string);
-    equal(map.size, 0);
+    assert.equal(map.size, 0);
   });
 
-  QUnit.test('forEach without proper callback', function() {
+  QUnit.test('forEach without proper callback', function(assert) {
     expectAssertion(function() {
       map.forEach();
     }, '[object Undefined] is not a function');
@@ -239,13 +239,13 @@ function testMap(nameAndFunc) {
       map.delete(key);
     });
     // ensure the error happens even if no data is present
-    equal(map.size, 0);
+    assert.equal(map.size, 0);
     expectAssertion(function() {
       map.forEach({});
     }, '[object Object] is not a function');
   });
 
-  QUnit.test('forEach basic', function() {
+  QUnit.test('forEach basic', function(assert) {
     map.set('a', 1);
     map.set('b', 2);
     map.set('c', 3);
@@ -261,18 +261,18 @@ function testMap(nameAndFunc) {
     map.forEach(function(value, key, theMap) {
       let expectation = expectations[iteration];
 
-      equal(value, expectation.value, 'value should be correct');
-      equal(key, expectation.key, 'key should be correct');
-      equal(this, expectation.context, 'context should be as if it was unbound');
-      equal(map, theMap, 'map being iterated over should be passed in');
+      assert.equal(value, expectation.value, 'value should be correct');
+      assert.equal(key, expectation.key, 'key should be correct');
+      assert.equal(this, expectation.context, 'context should be as if it was unbound');
+      assert.equal(map, theMap, 'map being iterated over should be passed in');
 
       iteration++;
     });
 
-    equal(iteration, 3, 'expected 3 iterations');
+    assert.equal(iteration, 3, 'expected 3 iterations');
   });
 
-  QUnit.test('forEach basic /w context', function() {
+  QUnit.test('forEach basic /w context', function(assert) {
     map.set('a', 1);
     map.set('b', 2);
     map.set('c', 3);
@@ -288,18 +288,18 @@ function testMap(nameAndFunc) {
     map.forEach(function(value, key, theMap) {
       let expectation = expectations[iteration];
 
-      equal(value, expectation.value, 'value should be correct');
-      equal(key, expectation.key, 'key should be correct');
-      equal(this, expectation.context, 'context should be as if it was unbound');
-      equal(map, theMap, 'map being iterated over should be passed in');
+      assert.equal(value, expectation.value, 'value should be correct');
+      assert.equal(key, expectation.key, 'key should be correct');
+      assert.equal(this, expectation.context, 'context should be as if it was unbound');
+      assert.equal(map, theMap, 'map being iterated over should be passed in');
 
       iteration++;
     }, context);
 
-    equal(iteration, 3, 'expected 3 iterations');
+    assert.equal(iteration, 3, 'expected 3 iterations');
   });
 
-  QUnit.test('forEach basic /w deletion while enumerating', function() {
+  QUnit.test('forEach basic /w deletion while enumerating', function(assert) {
     map.set('a', 1);
     map.set('b', 2);
     map.set('c', 3);
@@ -318,18 +318,18 @@ function testMap(nameAndFunc) {
 
       let expectation = expectations[iteration];
 
-      equal(value, expectation.value, 'value should be correct');
-      equal(key, expectation.key, 'key should be correct');
-      equal(this, expectation.context, 'context should be as if it was unbound');
-      equal(map, theMap, 'map being iterated over should be passed in');
+      assert.equal(value, expectation.value, 'value should be correct');
+      assert.equal(key, expectation.key, 'key should be correct');
+      assert.equal(this, expectation.context, 'context should be as if it was unbound');
+      assert.equal(map, theMap, 'map being iterated over should be passed in');
 
       iteration++;
     });
 
-    equal(iteration, 2, 'expected 3 iterations');
+    assert.equal(iteration, 2, 'expected 3 iterations');
   });
 
-  QUnit.test('forEach basic /w addition while enumerating', function() {
+  QUnit.test('forEach basic /w addition while enumerating', function(assert) {
     map.set('a', 1);
     map.set('b', 2);
     map.set('c', 3);
@@ -350,18 +350,18 @@ function testMap(nameAndFunc) {
 
       let expectation = expectations[iteration];
 
-      equal(value, expectation.value, 'value should be correct');
-      equal(key, expectation.key, 'key should be correct');
-      equal(this, expectation.context, 'context should be as if it was unbound');
-      equal(map, theMap, 'map being iterated over should be passed in');
+      assert.equal(value, expectation.value, 'value should be correct');
+      assert.equal(key, expectation.key, 'key should be correct');
+      assert.equal(this, expectation.context, 'context should be as if it was unbound');
+      assert.equal(map, theMap, 'map being iterated over should be passed in');
 
       iteration++;
     });
 
-    equal(iteration, 4, 'expected 3 iterations');
+    assert.equal(iteration, 4, 'expected 3 iterations');
   });
 
-  QUnit.test('clear', function() {
+  QUnit.test('clear', function(assert) {
     let iterations = 0;
 
     map.set('a', 1);
@@ -369,78 +369,78 @@ function testMap(nameAndFunc) {
     map.set('c', 3);
     map.set('d', 4);
 
-    equal(map.size, 4);
+    assert.equal(map.size, 4);
 
     map.forEach(function() {
       iterations++;
     });
-    equal(iterations, 4);
+    assert.equal(iterations, 4);
 
     map.clear();
-    equal(map.size, 0);
+    assert.equal(map.size, 0);
     iterations = 0;
     map.forEach(function() {
       iterations++;
     });
-    equal(iterations, 0);
+    assert.equal(iterations, 0);
   });
 
-  QUnit.test('-0', function() {
-    equal(map.has(-0), false);
-    equal(map.has(0), false);
+  QUnit.test('-0', function(assert) {
+    assert.equal(map.has(-0), false);
+    assert.equal(map.has(0), false);
 
     map.set(-0, 'zero');
 
-    equal(map.has(-0), true);
-    equal(map.has(0), true);
+    assert.equal(map.has(-0), true);
+    assert.equal(map.has(0), true);
 
-    equal(map.get(0), 'zero');
-    equal(map.get(-0), 'zero');
+    assert.equal(map.get(0), 'zero');
+    assert.equal(map.get(-0), 'zero');
 
     map.forEach(function(value, key) {
-      equal(1 / key, Infinity, 'spec says key should be positive zero');
+      assert.equal(1 / key, Infinity, 'spec says key should be positive zero');
     });
   });
 
-  QUnit.test('NaN', function() {
-    equal(map.has(NaN), false);
+  QUnit.test('NaN', function(assert) {
+    assert.equal(map.has(NaN), false);
 
     map.set(NaN, 'not-a-number');
 
-    equal(map.has(NaN), true);
+    assert.equal(map.has(NaN), true);
 
-    equal(map.get(NaN), 'not-a-number');
+    assert.equal(map.get(NaN), 'not-a-number');
   });
 
-  QUnit.test('NaN Boxed', function() {
+  QUnit.test('NaN Boxed', function(assert) {
     //jshint -W053
     let boxed = new Number(NaN);
-    equal(map.has(boxed), false);
+    assert.equal(map.has(boxed), false);
 
     map.set(boxed, 'not-a-number');
 
-    equal(map.has(boxed), true);
-    equal(map.has(NaN), false);
+    assert.equal(map.has(boxed), true);
+    assert.equal(map.has(NaN), false);
 
-    equal(map.get(NaN), undefined);
-    equal(map.get(boxed), 'not-a-number');
+    assert.equal(map.get(NaN), undefined);
+    assert.equal(map.get(boxed), 'not-a-number');
   });
 
-  QUnit.test('0 value', function() {
+  QUnit.test('0 value', function(assert) {
     let obj = {};
-    equal(map.has(obj), false);
+    assert.equal(map.has(obj), false);
 
-    equal(map.size, 0);
+    assert.equal(map.size, 0);
     map.set(obj, 0);
-    equal(map.size, 1);
+    assert.equal(map.size, 1);
 
-    equal(map.has(obj), true);
-    equal(map.get(obj), 0);
+    assert.equal(map.has(obj), true);
+    assert.equal(map.get(obj), 0);
 
     map.delete(obj);
-    equal(map.has(obj), false);
-    equal(map.get(obj), undefined);
-    equal(map.size, 0);
+    assert.equal(map.has(obj), false);
+    assert.equal(map.get(obj), undefined);
+    assert.equal(map.size, 0);
   });
 }
 
@@ -450,7 +450,7 @@ for (let i = 0;  i < varieties.length;  i++) {
 
 QUnit.module('MapWithDefault - default values');
 
-QUnit.test('Retrieving a value that has not been set returns and sets a default value', function() {
+QUnit.test('Retrieving a value that has not been set returns and sets a default value', function(assert) {
   let map = MapWithDefault.create({
     defaultValue(key) {
       return [key];
@@ -458,24 +458,24 @@ QUnit.test('Retrieving a value that has not been set returns and sets a default 
   });
 
   let value = map.get('ohai');
-  deepEqual(value, ['ohai']);
+  assert.deepEqual(value, ['ohai']);
 
-  strictEqual(value, map.get('ohai'));
+  assert.strictEqual(value, map.get('ohai'));
 });
 
-QUnit.test('Map.prototype.constructor', function() {
+QUnit.test('Map.prototype.constructor', function(assert) {
   let map = new Map();
-  equal(map.constructor, Map);
+  assert.equal(map.constructor, Map);
 });
 
-QUnit.test('MapWithDefault.prototype.constructor', function() {
+QUnit.test('MapWithDefault.prototype.constructor', function(assert) {
   let map = new MapWithDefault({
     defaultValue(key) { return key; }
   });
-  equal(map.constructor, MapWithDefault);
+  assert.equal(map.constructor, MapWithDefault);
 });
 
-QUnit.test('Copying a MapWithDefault copies the default value', function() {
+QUnit.test('Copying a MapWithDefault copies the default value', function(assert) {
   let map = MapWithDefault.create({
     defaultValue(key) {
       return [key];
@@ -487,23 +487,23 @@ QUnit.test('Copying a MapWithDefault copies the default value', function() {
 
   let map2 = map.copy();
 
-  equal(map2.get('ohai'), 1);
-  deepEqual(map2.get('bai'), ['bai']);
+  assert.equal(map2.get('ohai'), 1);
+  assert.deepEqual(map2.get('bai'), ['bai']);
 
   map2.set('kthx', 3);
 
-  deepEqual(map.get('kthx'), ['kthx']);
-  equal(map2.get('kthx'), 3);
+  assert.deepEqual(map.get('kthx'), ['kthx']);
+  assert.equal(map2.get('kthx'), 3);
 
-  deepEqual(map2.get('default'), ['default']);
+  assert.deepEqual(map2.get('default'), ['default']);
 
   map2.defaultValue = key => ['tom is on', key];
 
-  deepEqual(map2.get('drugs'), ['tom is on', 'drugs']);
+  assert.deepEqual(map2.get('drugs'), ['tom is on', 'drugs']);
 });
 
 QUnit.module('OrderedSet', {
-  setup() {
+  beforeEach() {
     object = {};
     number = 42;
     string = 'foo';
@@ -512,8 +512,8 @@ QUnit.module('OrderedSet', {
   }
 });
 
-QUnit.test('add returns the set', function() {
+QUnit.test('add returns the set', function(assert) {
   let obj = {};
-  equal(map.add(obj), map);
-  equal(map.add(obj), map, 'when it is already in the set');
+  assert.equal(map.add(obj), map);
+  assert.equal(map.add(obj), map, 'when it is already in the set');
 });

--- a/packages/ember-metal/tests/mixin/alias_method_test.js
+++ b/packages/ember-metal/tests/mixin/alias_method_test.js
@@ -7,22 +7,22 @@ import {
 
 QUnit.module('aliasMethod');
 
-function validateAliasMethod(obj) {
-  equal(obj.fooMethod(), 'FOO', 'obj.fooMethod()');
-  equal(obj.barMethod(), 'FOO', 'obj.barMethod should be a copy of foo');
+function validateAliasMethod(assert, obj) {
+  assert.equal(obj.fooMethod(), 'FOO', 'obj.fooMethod()');
+  assert.equal(obj.barMethod(), 'FOO', 'obj.barMethod should be a copy of foo');
 }
 
-QUnit.test('methods of another name are aliased when the mixin is applied', function() {
+QUnit.test('methods of another name are aliased when the mixin is applied', function(assert) {
   let MyMixin = Mixin.create({
     fooMethod() { return 'FOO'; },
     barMethod: aliasMethod('fooMethod')
   });
 
   let obj = MyMixin.apply({});
-  validateAliasMethod(obj);
+  validateAliasMethod(assert, obj);
 });
 
-QUnit.test('should follow aliasMethods all the way down', function() {
+QUnit.test('should follow aliasMethods all the way down', function(assert) {
   let MyMixin = Mixin.create({
     bar: aliasMethod('foo'), // put first to break ordered iteration
     baz() { return 'baz'; },
@@ -30,10 +30,10 @@ QUnit.test('should follow aliasMethods all the way down', function() {
   });
 
   let obj = MyMixin.apply({});
-  equal(get(obj, 'bar')(), 'baz', 'should have followed aliasMethods');
+  assert.equal(get(obj, 'bar')(), 'baz', 'should have followed aliasMethods');
 });
 
-QUnit.test('should alias methods from other dependent mixins', function() {
+QUnit.test('should alias methods from other dependent mixins', function(assert) {
   let BaseMixin = Mixin.create({
     fooMethod() { return 'FOO'; }
   });
@@ -43,10 +43,10 @@ QUnit.test('should alias methods from other dependent mixins', function() {
   });
 
   let obj = MyMixin.apply({});
-  validateAliasMethod(obj);
+  validateAliasMethod(assert, obj);
 });
 
-QUnit.test('should alias methods from other mixins applied at same time', function() {
+QUnit.test('should alias methods from other mixins applied at same time', function(assert) {
   let BaseMixin = Mixin.create({
     fooMethod() { return 'FOO'; }
   });
@@ -56,10 +56,10 @@ QUnit.test('should alias methods from other mixins applied at same time', functi
   });
 
   let obj = mixin({}, BaseMixin, MyMixin);
-  validateAliasMethod(obj);
+  validateAliasMethod(assert, obj);
 });
 
-QUnit.test('should alias methods from mixins already applied on object', function() {
+QUnit.test('should alias methods from mixins already applied on object', function(assert) {
   let BaseMixin = Mixin.create({
     quxMethod() { return 'qux'; }
   });
@@ -76,5 +76,5 @@ QUnit.test('should alias methods from mixins already applied on object', functio
   BaseMixin.apply(obj);
   MyMixin.apply(obj);
 
-  validateAliasMethod(obj);
+  validateAliasMethod(assert, obj);
 });

--- a/packages/ember-metal/tests/mixin/apply_test.js
+++ b/packages/ember-metal/tests/mixin/apply_test.js
@@ -8,33 +8,33 @@ QUnit.module('Ember.Mixin.apply');
 
 function K() {}
 
-QUnit.test('using apply() should apply properties', function() {
+QUnit.test('using apply() should apply properties', function(assert) {
   let MixinA = Mixin.create({ foo: 'FOO', baz: K });
   let obj = {};
   mixin(obj, MixinA);
 
-  equal(get(obj, 'foo'), 'FOO', 'should apply foo');
-  equal(get(obj, 'baz'), K, 'should apply foo');
+  assert.equal(get(obj, 'foo'), 'FOO', 'should apply foo');
+  assert.equal(get(obj, 'baz'), K, 'should apply foo');
 });
 
-QUnit.test('applying anonymous properties', function() {
+QUnit.test('applying anonymous properties', function(assert) {
   let obj = {};
   mixin(obj, {
     foo: 'FOO',
     baz: K
   });
 
-  equal(get(obj, 'foo'), 'FOO', 'should apply foo');
-  equal(get(obj, 'baz'), K, 'should apply foo');
+  assert.equal(get(obj, 'foo'), 'FOO', 'should apply foo');
+  assert.equal(get(obj, 'baz'), K, 'should apply foo');
 });
 
 QUnit.test('applying null values', function() {
   expectAssertion(() => mixin({}, null));
 });
 
-QUnit.test('applying a property with an undefined value', function() {
+QUnit.test('applying a property with an undefined value', function(assert) {
   let obj = { tagName: '' };
   mixin(obj, { tagName: undefined });
 
-  strictEqual(get(obj, 'tagName'), '');
+  assert.strictEqual(get(obj, 'tagName'), '');
 });

--- a/packages/ember-metal/tests/mixin/computed_test.js
+++ b/packages/ember-metal/tests/mixin/computed_test.js
@@ -10,7 +10,7 @@ function K() { return this; }
 
 QUnit.module('Mixin Computed Properties');
 
-QUnit.test('overriding computed properties', function() {
+QUnit.test('overriding computed properties', function(assert) {
   let MixinA, MixinB, MixinC, MixinD;
   let obj;
 
@@ -40,27 +40,27 @@ QUnit.test('overriding computed properties', function() {
 
   obj = {};
   MixinB.apply(obj);
-  equal(get(obj, 'aProp'), 'AB', 'should expose super for B');
+  assert.equal(get(obj, 'aProp'), 'AB', 'should expose super for B');
 
   obj = {};
   MixinC.apply(obj);
-  equal(get(obj, 'aProp'), 'AC', 'should expose super for C');
+  assert.equal(get(obj, 'aProp'), 'AC', 'should expose super for C');
 
   obj = {};
 
   MixinA.apply(obj);
   MixinD.apply(obj);
-  equal(get(obj, 'aProp'), 'AD', 'should define super for D');
+  assert.equal(get(obj, 'aProp'), 'AD', 'should define super for D');
 
   obj = { };
   defineProperty(obj, 'aProp', computed(function() {
     return 'obj';
   }));
   MixinD.apply(obj);
-  equal(get(obj, 'aProp'), 'objD', 'should preserve original computed property');
+  assert.equal(get(obj, 'aProp'), 'objD', 'should preserve original computed property');
 });
 
-QUnit.test('calling set on overridden computed properties', function() {
+QUnit.test('calling set on overridden computed properties', function(assert) {
   let SuperMixin, SubMixin;
   let obj;
 
@@ -85,7 +85,7 @@ QUnit.test('calling set on overridden computed properties', function() {
   SubMixin.apply(obj);
 
   set(obj, 'aProp', 'set thyself');
-  ok(superSetOccurred, 'should pass set to _super');
+  assert.ok(superSetOccurred, 'should pass set to _super');
 
   superSetOccurred = false; // reset the set assertion
 
@@ -93,13 +93,13 @@ QUnit.test('calling set on overridden computed properties', function() {
   SubMixin.apply(obj);
 
   get(obj, 'aProp');
-  ok(superGetOccurred, 'should pass get to _super');
+  assert.ok(superGetOccurred, 'should pass get to _super');
 
   set(obj, 'aProp', 'set thyself');
-  ok(superSetOccurred, 'should pass set to _super after getting');
+  assert.ok(superSetOccurred, 'should pass set to _super after getting');
 });
 
-QUnit.test('setter behavior works properly when overriding computed properties', function() {
+QUnit.test('setter behavior works properly when overriding computed properties', function(assert) {
   let obj = {};
 
   let MixinA = Mixin.create({
@@ -130,14 +130,14 @@ QUnit.test('setter behavior works properly when overriding computed properties',
   MixinB.apply(obj);
 
   set(obj, 'cpWithSetter2', 'test');
-  ok(cpWasCalled, 'The computed property setter was called when defined with two args');
+  assert.ok(cpWasCalled, 'The computed property setter was called when defined with two args');
   cpWasCalled = false;
 
   set(obj, 'cpWithSetter3', 'test');
-  ok(cpWasCalled, 'The computed property setter was called when defined with three args');
+  assert.ok(cpWasCalled, 'The computed property setter was called when defined with three args');
   cpWasCalled = false;
 
   set(obj, 'cpWithoutSetter', 'test');
-  equal(get(obj, 'cpWithoutSetter'), 'test', 'The default setter was called, the value is correct');
-  ok(!cpWasCalled, 'The default setter was called, not the CP itself');
+  assert.equal(get(obj, 'cpWithoutSetter'), 'test', 'The default setter was called, the value is correct');
+  assert.ok(!cpWasCalled, 'The default setter was called, not the CP itself');
 });

--- a/packages/ember-metal/tests/mixin/concatenated_properties_test.js
+++ b/packages/ember-metal/tests/mixin/concatenated_properties_test.js
@@ -6,7 +6,7 @@ import {
 
 QUnit.module('Mixin concatenatedProperties');
 
-QUnit.test('defining concatenated properties should concat future version', function() {
+QUnit.test('defining concatenated properties should concat future version', function(assert) {
   let MixinA = Mixin.create({
     concatenatedProperties: ['foo'],
     foo: ['a', 'b', 'c']
@@ -17,10 +17,10 @@ QUnit.test('defining concatenated properties should concat future version', func
   });
 
   let obj = mixin({}, MixinA, MixinB);
-  deepEqual(get(obj, 'foo'), ['a', 'b', 'c', 'd', 'e', 'f']);
+  assert.deepEqual(get(obj, 'foo'), ['a', 'b', 'c', 'd', 'e', 'f']);
 });
 
-QUnit.test('defining concatenated properties should concat future version', function() {
+QUnit.test('defining concatenated properties should concat future version', function(assert) {
   let MixinA = Mixin.create({
     concatenatedProperties: null
   });
@@ -31,11 +31,11 @@ QUnit.test('defining concatenated properties should concat future version', func
 
   let obj = mixin({}, MixinA, MixinB);
 
-  deepEqual(obj.concatenatedProperties, []);
+  assert.deepEqual(obj.concatenatedProperties, []);
 });
 
 
-QUnit.test('concatenatedProperties should be concatenated', function() {
+QUnit.test('concatenatedProperties should be concatenated', function(assert) {
   let MixinA = Mixin.create({
     concatenatedProperties: ['foo'],
     foo: ['a', 'b', 'c']
@@ -52,12 +52,12 @@ QUnit.test('concatenatedProperties should be concatenated', function() {
   });
 
   let obj = mixin({}, MixinA, MixinB, MixinC);
-  deepEqual(get(obj, 'concatenatedProperties'), ['foo', 'bar'], 'get concatenatedProperties');
-  deepEqual(get(obj, 'foo'), ['a', 'b', 'c', 'd', 'e', 'f'], 'get foo');
-  deepEqual(get(obj, 'bar'), [1, 2, 3, 4, 5, 6], 'get bar');
+  assert.deepEqual(get(obj, 'concatenatedProperties'), ['foo', 'bar'], 'get concatenatedProperties');
+  assert.deepEqual(get(obj, 'foo'), ['a', 'b', 'c', 'd', 'e', 'f'], 'get foo');
+  assert.deepEqual(get(obj, 'bar'), [1, 2, 3, 4, 5, 6], 'get bar');
 });
 
-QUnit.test('adding a prop that is not an array should make array', function() {
+QUnit.test('adding a prop that is not an array should make array', function(assert) {
   let MixinA = Mixin.create({
     concatenatedProperties: ['foo'],
     foo: [1, 2, 3]
@@ -68,20 +68,20 @@ QUnit.test('adding a prop that is not an array should make array', function() {
   });
 
   let obj = mixin({}, MixinA, MixinB);
-  deepEqual(get(obj, 'foo'), [1, 2, 3, 4]);
+  assert.deepEqual(get(obj, 'foo'), [1, 2, 3, 4]);
 });
 
-QUnit.test('adding a prop that is not an array should make array', function() {
+QUnit.test('adding a prop that is not an array should make array', function(assert) {
   let MixinA = Mixin.create({
     concatenatedProperties: ['foo'],
     foo: 'bar'
   });
 
   let obj = mixin({}, MixinA);
-  deepEqual(get(obj, 'foo'), ['bar']);
+  assert.deepEqual(get(obj, 'foo'), ['bar']);
 });
 
-QUnit.test('adding a non-concatenable property that already has a defined value should result in an array with both values', function() {
+QUnit.test('adding a non-concatenable property that already has a defined value should result in an array with both values', function(assert) {
   let mixinA = Mixin.create({
     foo: 1
   });
@@ -92,10 +92,10 @@ QUnit.test('adding a non-concatenable property that already has a defined value 
   });
 
   let obj = mixin({}, mixinA, mixinB);
-  deepEqual(get(obj, 'foo'), [1, 2]);
+  assert.deepEqual(get(obj, 'foo'), [1, 2]);
 });
 
-QUnit.test('adding a concatenable property that already has a defined value should result in a concatenated value', function() {
+QUnit.test('adding a concatenable property that already has a defined value should result in a concatenated value', function(assert) {
   let mixinA = Mixin.create({
     foobar: 'foo'
   });
@@ -106,5 +106,5 @@ QUnit.test('adding a concatenable property that already has a defined value shou
   });
 
   let obj = mixin({}, mixinA, mixinB);
-  deepEqual(get(obj, 'foobar'), ['foo', 'bar']);
+  assert.deepEqual(get(obj, 'foobar'), ['foo', 'bar']);
 });

--- a/packages/ember-metal/tests/mixin/detect_test.js
+++ b/packages/ember-metal/tests/mixin/detect_test.js
@@ -2,35 +2,35 @@ import { Mixin } from '../..';
 
 QUnit.module('Mixin.detect');
 
-QUnit.test('detect() finds a directly applied mixin', function() {
+QUnit.test('detect() finds a directly applied mixin', function(assert) {
   let MixinA = Mixin.create();
   let obj = {};
 
-  equal(MixinA.detect(obj), false, 'MixinA.detect(obj) before apply()');
+  assert.equal(MixinA.detect(obj), false, 'MixinA.detect(obj) before apply()');
 
   MixinA.apply(obj);
-  equal(MixinA.detect(obj), true, 'MixinA.detect(obj) after apply()');
+  assert.equal(MixinA.detect(obj), true, 'MixinA.detect(obj) after apply()');
 });
 
-QUnit.test('detect() finds nested mixins', function() {
+QUnit.test('detect() finds nested mixins', function(assert) {
   let MixinA = Mixin.create({});
   let MixinB = Mixin.create(MixinA);
   let obj = {};
 
-  equal(MixinA.detect(obj), false, 'MixinA.detect(obj) before apply()');
+  assert.equal(MixinA.detect(obj), false, 'MixinA.detect(obj) before apply()');
 
   MixinB.apply(obj);
-  equal(MixinA.detect(obj), true, 'MixinA.detect(obj) after apply()');
+  assert.equal(MixinA.detect(obj), true, 'MixinA.detect(obj) after apply()');
 });
 
-QUnit.test('detect() finds mixins on other mixins', function() {
+QUnit.test('detect() finds mixins on other mixins', function(assert) {
   let MixinA = Mixin.create({});
   let MixinB = Mixin.create(MixinA);
-  equal(MixinA.detect(MixinB), true, 'MixinA is part of MixinB');
-  equal(MixinB.detect(MixinA), false, 'MixinB is not part of MixinA');
+  assert.equal(MixinA.detect(MixinB), true, 'MixinA is part of MixinB');
+  assert.equal(MixinB.detect(MixinA), false, 'MixinB is not part of MixinA');
 });
 
-QUnit.test('detect handles null values', function() {
+QUnit.test('detect handles null values', function(assert) {
   let MixinA = Mixin.create();
-  equal(MixinA.detect(null), false);
+  assert.equal(MixinA.detect(null), false);
 });

--- a/packages/ember-metal/tests/mixin/introspection_test.js
+++ b/packages/ember-metal/tests/mixin/introspection_test.js
@@ -34,16 +34,16 @@ const Combined = Mixin.create(BarProperties, BarMethods);
 let obj;
 
 QUnit.module('Basic introspection', {
-  setup() {
+  beforeEach() {
     obj = {};
     mixin(obj, PrivateProperty, PublicProperty, PrivateMethod, PublicMethod, Combined);
   }
 });
 
-QUnit.test('Ember.mixins()', function() {
+QUnit.test('Ember.mixins()', function(assert) {
   function mapGuids(ary) {
     return ary.map(x => guidFor(x));
   }
 
-  deepEqual(mapGuids(Mixin.mixins(obj)), mapGuids([PrivateProperty, PublicProperty, PrivateMethod, PublicMethod, Combined, BarProperties, BarMethods]), 'should return included mixins');
+  assert.deepEqual(mapGuids(Mixin.mixins(obj)), mapGuids([PrivateProperty, PublicProperty, PrivateMethod, PublicMethod, Combined, BarProperties, BarMethods]), 'should return included mixins');
 });

--- a/packages/ember-metal/tests/mixin/merged_properties_test.js
+++ b/packages/ember-metal/tests/mixin/merged_properties_test.js
@@ -7,7 +7,7 @@ import {
 
 QUnit.module('Mixin mergedProperties');
 
-QUnit.test('defining mergedProperties should merge future version', function() {
+QUnit.test('defining mergedProperties should merge future version', function(assert) {
   let MixinA = Mixin.create({
     mergedProperties: ['foo'],
     foo: { a: true, b: true, c: true }
@@ -18,11 +18,11 @@ QUnit.test('defining mergedProperties should merge future version', function() {
   });
 
   let obj = mixin({}, MixinA, MixinB);
-  deepEqual(get(obj, 'foo'),
+  assert.deepEqual(get(obj, 'foo'),
     { a: true, b: true, c: true, d: true, e: true, f: true });
 });
 
-QUnit.test('defining mergedProperties on future mixin should merged into past', function() {
+QUnit.test('defining mergedProperties on future mixin should merged into past', function(assert) {
   let MixinA = Mixin.create({
     foo: { a: true, b: true, c: true }
   });
@@ -33,11 +33,11 @@ QUnit.test('defining mergedProperties on future mixin should merged into past', 
   });
 
   let obj = mixin({}, MixinA, MixinB);
-  deepEqual(get(obj, 'foo'),
+  assert.deepEqual(get(obj, 'foo'),
     { a: true, b: true, c: true, d: true, e: true, f: true });
 });
 
-QUnit.test('defining mergedProperties with null properties should keep properties null', function() {
+QUnit.test('defining mergedProperties with null properties should keep properties null', function(assert) {
   let MixinA = Mixin.create({
     mergedProperties: ['foo'],
     foo: null
@@ -48,10 +48,10 @@ QUnit.test('defining mergedProperties with null properties should keep propertie
   });
 
   let obj = mixin({}, MixinA, MixinB);
-  equal(get(obj, 'foo'), null);
+  assert.equal(get(obj, 'foo'), null);
 });
 
-QUnit.test('mergedProperties\' properties can get overwritten', function() {
+QUnit.test('mergedProperties\' properties can get overwritten', function(assert) {
   let MixinA = Mixin.create({
     mergedProperties: ['foo'],
     foo: { a: 1 }
@@ -62,10 +62,10 @@ QUnit.test('mergedProperties\' properties can get overwritten', function() {
   });
 
   let obj = mixin({}, MixinA, MixinB);
-  deepEqual(get(obj, 'foo'), { a: 2 });
+  assert.deepEqual(get(obj, 'foo'), { a: 2 });
 });
 
-QUnit.test('mergedProperties should be concatenated', function() {
+QUnit.test('mergedProperties should be concatenated', function(assert) {
   let MixinA = Mixin.create({
     mergedProperties: ['foo'],
     foo: { a: true, b: true, c: true }
@@ -82,12 +82,12 @@ QUnit.test('mergedProperties should be concatenated', function() {
   });
 
   let obj = mixin({}, MixinA, MixinB, MixinC);
-  deepEqual(get(obj, 'mergedProperties'), ['foo', 'bar'], 'get mergedProperties');
-  deepEqual(get(obj, 'foo'), { a: true, b: true, c: true, d: true, e: true, f: true }, 'get foo');
-  deepEqual(get(obj, 'bar'), { a: true, l: true, e: true, x: true }, 'get bar');
+  assert.deepEqual(get(obj, 'mergedProperties'), ['foo', 'bar'], 'get mergedProperties');
+  assert.deepEqual(get(obj, 'foo'), { a: true, b: true, c: true, d: true, e: true, f: true }, 'get foo');
+  assert.deepEqual(get(obj, 'bar'), { a: true, l: true, e: true, x: true }, 'get bar');
 });
 
-QUnit.test('mergedProperties should exist even if not explicitly set on create', function() {
+QUnit.test('mergedProperties should exist even if not explicitly set on create', function(assert) {
   let AnObj = EmberObject.extend({
     mergedProperties: ['options'],
     options: {
@@ -104,11 +104,11 @@ QUnit.test('mergedProperties should exist even if not explicitly set on create',
     }
   });
 
-  equal(get(obj, 'options').a, 'A');
-  equal(get(obj, 'options').b.c, 'ccc');
+  assert.equal(get(obj, 'options').a, 'A');
+  assert.equal(get(obj, 'options').b.c, 'ccc');
 });
 
-QUnit.test('defining mergedProperties at create time should not modify the prototype', function() {
+QUnit.test('defining mergedProperties at create time should not modify the prototype', function(assert) {
   let AnObj = EmberObject.extend({
     mergedProperties: ['options'],
     options: {
@@ -127,18 +127,18 @@ QUnit.test('defining mergedProperties at create time should not modify the proto
     }
   });
 
-  equal(get(objA, 'options').a, 2);
-  equal(get(objB, 'options').a, 3);
+  assert.equal(get(objA, 'options').a, 2);
+  assert.equal(get(objB, 'options').a, 3);
 });
 
-QUnit.test('mergedProperties\' overwriting methods can call _super', function() {
-  expect(4);
+QUnit.test('mergedProperties\' overwriting methods can call _super', function(assert) {
+  assert.expect(4);
 
   let MixinA = Mixin.create({
     mergedProperties: ['foo'],
     foo: {
       meth(a) {
-        equal(a, 'WOOT', '_super successfully called MixinA\'s `foo.meth` method');
+        assert.equal(a, 'WOOT', '_super successfully called MixinA\'s `foo.meth` method');
         return 'WAT';
       }
     }
@@ -147,7 +147,7 @@ QUnit.test('mergedProperties\' overwriting methods can call _super', function() 
   let MixinB = Mixin.create({
     foo: {
       meth() {
-        ok(true, 'MixinB\'s `foo.meth` method called');
+        assert.ok(true, 'MixinB\'s `foo.meth` method called');
         return this._super(...arguments);
       }
     }
@@ -156,18 +156,18 @@ QUnit.test('mergedProperties\' overwriting methods can call _super', function() 
   let MixinC = Mixin.create({
     foo: {
       meth(a) {
-        ok(true, 'MixinC\'s `foo.meth` method called');
+        assert.ok(true, 'MixinC\'s `foo.meth` method called');
         return this._super(a);
       }
     }
   });
 
   let obj = mixin({}, MixinA, MixinB, MixinC);
-  equal(obj.foo.meth('WOOT'), 'WAT');
+  assert.equal(obj.foo.meth('WOOT'), 'WAT');
 });
 
-QUnit.test('Merging an Array should raise an error', function() {
-  expect(1);
+QUnit.test('Merging an Array should raise an error', function(assert) {
+  assert.expect(1);
 
   let MixinA = Mixin.create({
     mergedProperties: ['foo'],

--- a/packages/ember-metal/tests/mixin/method_test.js
+++ b/packages/ember-metal/tests/mixin/method_test.js
@@ -5,7 +5,7 @@ import {
 
 QUnit.module('Mixin Methods');
 
-QUnit.test('defining simple methods', function() {
+QUnit.test('defining simple methods', function(assert) {
   let MixinA, obj, props;
 
   props = {
@@ -18,11 +18,11 @@ QUnit.test('defining simple methods', function() {
   MixinA.apply(obj);
 
   // but should be defined
-  equal(props.publicMethod(), 'publicMethod', 'publicMethod is func');
-  equal(props._privateMethod(), 'privateMethod', 'privateMethod is func');
+  assert.equal(props.publicMethod(), 'publicMethod', 'publicMethod is func');
+  assert.equal(props._privateMethod(), 'privateMethod', 'privateMethod is func');
 });
 
-QUnit.test('overriding public methods', function() {
+QUnit.test('overriding public methods', function(assert) {
   let MixinA, MixinB, MixinD, MixinF, obj;
 
   MixinA = Mixin.create({
@@ -43,24 +43,24 @@ QUnit.test('overriding public methods', function() {
 
   obj = {};
   MixinB.apply(obj);
-  equal(obj.publicMethod(), 'AB', 'should define super for A and B');
+  assert.equal(obj.publicMethod(), 'AB', 'should define super for A and B');
 
   obj = {};
   MixinD.apply(obj);
-  equal(obj.publicMethod(), 'AD', 'should define super for A and B');
+  assert.equal(obj.publicMethod(), 'AD', 'should define super for A and B');
 
   obj = {};
   MixinA.apply(obj);
   MixinF.apply(obj);
-  equal(obj.publicMethod(), 'AF', 'should define super for A and F');
+  assert.equal(obj.publicMethod(), 'AF', 'should define super for A and F');
 
   obj = { publicMethod() { return 'obj'; } };
   MixinF.apply(obj);
-  equal(obj.publicMethod(), 'objF', 'should define super for F');
+  assert.equal(obj.publicMethod(), 'objF', 'should define super for F');
 });
 
 
-QUnit.test('overriding inherited objects', function() {
+QUnit.test('overriding inherited objects', function(assert) {
   let cnt = 0;
   let MixinA = Mixin.create({
     foo() { cnt++; }
@@ -81,14 +81,14 @@ QUnit.test('overriding inherited objects', function() {
 
   cnt = 0;
   objB.foo();
-  equal(cnt, 2, 'should invoke both methods');
+  assert.equal(cnt, 2, 'should invoke both methods');
 
   cnt = 0;
   objA.foo();
-  equal(cnt, 1, 'should not screw w/ parent obj');
+  assert.equal(cnt, 1, 'should not screw w/ parent obj');
 });
 
-QUnit.test('Including the same mixin more than once will only run once', function() {
+QUnit.test('Including the same mixin more than once will only run once', function(assert) {
   let cnt = 0;
   let MixinA = Mixin.create({
     foo() { cnt++; }
@@ -113,10 +113,10 @@ QUnit.test('Including the same mixin more than once will only run once', functio
   cnt = 0;
   obj.foo();
 
-  equal(cnt, 1, 'should invoke MixinA.foo one time');
+  assert.equal(cnt, 1, 'should invoke MixinA.foo one time');
 });
 
-QUnit.test('_super from a single mixin with no superclass does not error', function() {
+QUnit.test('_super from a single mixin with no superclass does not error', function(assert) {
   let MixinA = Mixin.create({
     foo() {
       this._super(...arguments);
@@ -127,10 +127,10 @@ QUnit.test('_super from a single mixin with no superclass does not error', funct
   MixinA.apply(obj);
 
   obj.foo();
-  ok(true);
+  assert.ok(true);
 });
 
-QUnit.test('_super from a first-of-two mixins with no superclass function does not error', function() {
+QUnit.test('_super from a first-of-two mixins with no superclass function does not error', function(assert) {
   // _super was previously calling itself in the second assertion.
   // Use remaining count of calls to ensure it doesn't loop indefinitely.
   let remaining = 3;
@@ -151,7 +151,7 @@ QUnit.test('_super from a first-of-two mixins with no superclass function does n
   MixinB.apply(obj);
 
   obj.foo();
-  ok(true);
+  assert.ok(true);
 });
 
 // ..........................................................
@@ -161,18 +161,18 @@ QUnit.test('_super from a first-of-two mixins with no superclass function does n
 QUnit.module('Method Conflicts');
 
 
-QUnit.test('overriding toString', function() {
+QUnit.test('overriding toString', function(assert) {
   let MixinA = Mixin.create({
     toString() { return 'FOO'; }
   });
 
   let obj = {};
   MixinA.apply(obj);
-  equal(obj.toString(), 'FOO', 'should override toString w/o error');
+  assert.equal(obj.toString(), 'FOO', 'should override toString w/o error');
 
   obj = {};
   mixin(obj, { toString() { return 'FOO'; } });
-  equal(obj.toString(), 'FOO', 'should override toString w/o error');
+  assert.equal(obj.toString(), 'FOO', 'should override toString w/o error');
 });
 
 // ..........................................................
@@ -181,7 +181,7 @@ QUnit.test('overriding toString', function() {
 
 QUnit.module('system/mixin/method_test BUGS');
 
-QUnit.test('applying several mixins at once with sup already defined causes infinite loop', function() {
+QUnit.test('applying several mixins at once with sup already defined causes infinite loop', function(assert) {
   let cnt = 0;
   let MixinA = Mixin.create({
     foo() { cnt++; }
@@ -207,5 +207,5 @@ QUnit.test('applying several mixins at once with sup already defined causes infi
 
   cnt = 0;
   obj.foo();
-  equal(cnt, 3, 'should invoke all 3 methods');
+  assert.equal(cnt, 3, 'should invoke all 3 methods');
 });

--- a/packages/ember-metal/tests/mixin/observer_test.js
+++ b/packages/ember-metal/tests/mixin/observer_test.js
@@ -8,7 +8,7 @@ import {
 
 QUnit.module('Mixin observer');
 
-testBoth('global observer helper', function(get, set) {
+testBoth('global observer helper', function(get, set, assert) {
   let MyMixin = Mixin.create({
 
     count: 0,
@@ -20,13 +20,13 @@ testBoth('global observer helper', function(get, set) {
   });
 
   let obj = mixin({}, MyMixin);
-  equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+  assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
   set(obj, 'bar', 'BAZ');
-  equal(get(obj, 'count'), 1, 'should invoke observer after change');
+  assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
 });
 
-testBoth('global observer helper takes multiple params', function(get, set) {
+testBoth('global observer helper takes multiple params', function(get, set, assert) {
   let MyMixin = Mixin.create({
 
     count: 0,
@@ -38,14 +38,14 @@ testBoth('global observer helper takes multiple params', function(get, set) {
   });
 
   let obj = mixin({}, MyMixin);
-  equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+  assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
   set(obj, 'bar', 'BAZ');
   set(obj, 'baz', 'BAZ');
-  equal(get(obj, 'count'), 2, 'should invoke observer after change');
+  assert.equal(get(obj, 'count'), 2, 'should invoke observer after change');
 });
 
-testBoth('replacing observer should remove old observer', function(get, set) {
+testBoth('replacing observer should remove old observer', function(get, set, assert) {
   let MyMixin = Mixin.create({
 
     count: 0,
@@ -63,16 +63,16 @@ testBoth('replacing observer should remove old observer', function(get, set) {
   });
 
   let obj = mixin({}, MyMixin, Mixin2);
-  equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+  assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
   set(obj, 'bar', 'BAZ');
-  equal(get(obj, 'count'), 0, 'should not invoke observer after change');
+  assert.equal(get(obj, 'count'), 0, 'should not invoke observer after change');
 
   set(obj, 'baz', 'BAZ');
-  equal(get(obj, 'count'), 10, 'should invoke observer after change');
+  assert.equal(get(obj, 'count'), 10, 'should invoke observer after change');
 });
 
-testBoth('observing chain with property before', function(get, set) {
+testBoth('observing chain with property before', function(get, set, assert) {
   let obj2 = { baz: 'baz' };
 
   let MyMixin = Mixin.create({
@@ -84,13 +84,13 @@ testBoth('observing chain with property before', function(get, set) {
   });
 
   let obj = mixin({}, MyMixin);
-  equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+  assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
   set(obj2, 'baz', 'BAZ');
-  equal(get(obj, 'count'), 1, 'should invoke observer after change');
+  assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
 });
 
-testBoth('observing chain with property after', function(get, set) {
+testBoth('observing chain with property after', function(get, set, assert) {
   let obj2 = { baz: 'baz' };
 
   let MyMixin = Mixin.create({
@@ -102,13 +102,13 @@ testBoth('observing chain with property after', function(get, set) {
   });
 
   let obj = mixin({}, MyMixin);
-  equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+  assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
   set(obj2, 'baz', 'BAZ');
-  equal(get(obj, 'count'), 1, 'should invoke observer after change');
+  assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
 });
 
-testBoth('observing chain with property in mixin applied later', function(get, set) {
+testBoth('observing chain with property in mixin applied later', function(get, set, assert) {
   let obj2 = { baz: 'baz' };
 
   let MyMixin = Mixin.create({
@@ -122,16 +122,16 @@ testBoth('observing chain with property in mixin applied later', function(get, s
   let MyMixin2 = Mixin.create({ bar: obj2 });
 
   let obj = mixin({}, MyMixin);
-  equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+  assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
   MyMixin2.apply(obj);
-  equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+  assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
   set(obj2, 'baz', 'BAZ');
-  equal(get(obj, 'count'), 1, 'should invoke observer after change');
+  assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
 });
 
-testBoth('observing chain with existing property', function(get, set) {
+testBoth('observing chain with existing property', function(get, set, assert) {
   let obj2 = { baz: 'baz' };
 
   let MyMixin = Mixin.create({
@@ -142,13 +142,13 @@ testBoth('observing chain with existing property', function(get, set) {
   });
 
   let obj = mixin({ bar: obj2 }, MyMixin);
-  equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+  assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
   set(obj2, 'baz', 'BAZ');
-  equal(get(obj, 'count'), 1, 'should invoke observer after change');
+  assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
 });
 
-testBoth('observing chain with property in mixin before', function(get, set) {
+testBoth('observing chain with property in mixin before', function(get, set, assert) {
   let obj2 = { baz: 'baz' };
   let MyMixin2 = Mixin.create({ bar: obj2 });
 
@@ -160,13 +160,13 @@ testBoth('observing chain with property in mixin before', function(get, set) {
   });
 
   let obj = mixin({}, MyMixin2, MyMixin);
-  equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+  assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
   set(obj2, 'baz', 'BAZ');
-  equal(get(obj, 'count'), 1, 'should invoke observer after change');
+  assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
 });
 
-testBoth('observing chain with property in mixin after', function(get, set) {
+testBoth('observing chain with property in mixin after', function(get, set, assert) {
   let obj2 = { baz: 'baz' };
   let MyMixin2 = Mixin.create({ bar: obj2 });
 
@@ -178,13 +178,13 @@ testBoth('observing chain with property in mixin after', function(get, set) {
   });
 
   let obj = mixin({}, MyMixin, MyMixin2);
-  equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+  assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
   set(obj2, 'baz', 'BAZ');
-  equal(get(obj, 'count'), 1, 'should invoke observer after change');
+  assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
 });
 
-testBoth('observing chain with overridden property', function(get, set) {
+testBoth('observing chain with overridden property', function(get, set, assert) {
   let obj2 = { baz: 'baz' };
   let obj3 = { baz: 'foo' };
 
@@ -198,14 +198,14 @@ testBoth('observing chain with overridden property', function(get, set) {
   });
 
   let obj = mixin({ bar: obj2 }, MyMixin, MyMixin2);
-  equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+  assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
-  equal(isWatching(obj2, 'baz'), false, 'should not be watching baz');
-  equal(isWatching(obj3, 'baz'), true, 'should be watching baz');
+  assert.equal(isWatching(obj2, 'baz'), false, 'should not be watching baz');
+  assert.equal(isWatching(obj3, 'baz'), true, 'should be watching baz');
 
   set(obj2, 'baz', 'BAZ');
-  equal(get(obj, 'count'), 0, 'should not invoke observer after change');
+  assert.equal(get(obj, 'count'), 0, 'should not invoke observer after change');
 
   set(obj3, 'baz', 'BEAR');
-  equal(get(obj, 'count'), 1, 'should invoke observer after change');
+  assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
 });

--- a/packages/ember-metal/tests/mixin/reopen_test.js
+++ b/packages/ember-metal/tests/mixin/reopen_test.js
@@ -7,18 +7,18 @@ import {
 
 QUnit.module('Ember.Mixin#reopen');
 
-QUnit.test('using reopen() to add more properties to a simple', function() {
+QUnit.test('using reopen() to add more properties to a simple', function(assert) {
   let MixinA = Mixin.create({ foo: 'FOO', baz: 'BAZ' });
   MixinA.reopen({ bar: 'BAR', foo: 'FOO2' });
   let obj = {};
   MixinA.apply(obj);
 
-  equal(get(obj, 'foo'), 'FOO2', 'mixin() should override');
-  equal(get(obj, 'baz'), 'BAZ', 'preserve MixinA props');
-  equal(get(obj, 'bar'), 'BAR', 'include MixinB props');
+  assert.equal(get(obj, 'foo'), 'FOO2', 'mixin() should override');
+  assert.equal(get(obj, 'baz'), 'BAZ', 'preserve MixinA props');
+  assert.equal(get(obj, 'bar'), 'BAR', 'include MixinB props');
 });
 
-QUnit.test('using reopen() and calling _super where there is not a super function does not cause infinite recursion', function() {
+QUnit.test('using reopen() and calling _super where there is not a super function does not cause infinite recursion', function(assert) {
   let Taco = EmberObject.extend({
     createBreakfast() {
       // There is no original createBreakfast function.
@@ -46,6 +46,6 @@ QUnit.test('using reopen() and calling _super where there is not a super functio
     }
   });
 
-  equal(result, 'Breakfast!');
+  assert.equal(result, 'Breakfast!');
 });
 

--- a/packages/ember-metal/tests/mixin/required_test.js
+++ b/packages/ember-metal/tests/mixin/required_test.js
@@ -9,7 +9,7 @@ import { ENV } from 'ember-environment';
 let PartialMixin, FinalMixin, obj;
 let originalEnvVal;
 QUnit.module('Module.required', {
-  setup() {
+  beforeEach() {
     originalEnvVal = ENV._ENABLE_PROPERTY_REQUIRED_SUPPORT;
     ENV._ENABLE_PROPERTY_REQUIRED_SUPPORT = true;
     expectDeprecation(() => {
@@ -26,35 +26,35 @@ QUnit.module('Module.required', {
     obj = {};
   },
 
-  teardown() {
+  afterEach() {
     PartialMixin = FinalMixin = obj = null;
     ENV._ENABLE_PROPERTY_REQUIRED_SUPPORT = originalEnvVal;
   }
 });
 
-QUnit.test('applying a mixin to meet requirement', function() {
+QUnit.test('applying a mixin to meet requirement', function(assert) {
   FinalMixin.apply(obj);
   PartialMixin.apply(obj);
-  equal(get(obj, 'foo'), 'FOO', 'should now be defined');
+  assert.equal(get(obj, 'foo'), 'FOO', 'should now be defined');
 });
 
-QUnit.test('combined mixins to meet requirement', function() {
+QUnit.test('combined mixins to meet requirement', function(assert) {
   Mixin.create(PartialMixin, FinalMixin).apply(obj);
-  equal(get(obj, 'foo'), 'FOO', 'should now be defined');
+  assert.equal(get(obj, 'foo'), 'FOO', 'should now be defined');
 });
 
-QUnit.test('merged mixin', function() {
+QUnit.test('merged mixin', function(assert) {
   Mixin.create(PartialMixin, { foo: 'FOO' }).apply(obj);
-  equal(get(obj, 'foo'), 'FOO', 'should now be defined');
+  assert.equal(get(obj, 'foo'), 'FOO', 'should now be defined');
 });
 
-QUnit.test('define property on source object', function() {
+QUnit.test('define property on source object', function(assert) {
   obj.foo = 'FOO';
   PartialMixin.apply(obj);
-  equal(get(obj, 'foo'), 'FOO', 'should now be defined');
+  assert.equal(get(obj, 'foo'), 'FOO', 'should now be defined');
 });
 
-QUnit.test('using apply', function() {
+QUnit.test('using apply', function(assert) {
   mixin(obj, PartialMixin, { foo: 'FOO' });
-  equal(get(obj, 'foo'), 'FOO', 'should now be defined');
+  assert.equal(get(obj, 'foo'), 'FOO', 'should now be defined');
 });

--- a/packages/ember-metal/tests/mixin/without_test.js
+++ b/packages/ember-metal/tests/mixin/without_test.js
@@ -1,6 +1,6 @@
 import { Mixin } from '../..';
 
-QUnit.test('without should create a new mixin excluding named properties', function() {
+QUnit.test('without should create a new mixin excluding named properties', function(assert) {
   let MixinA = Mixin.create({
     foo: 'FOO',
     bar: 'BAR'
@@ -11,6 +11,6 @@ QUnit.test('without should create a new mixin excluding named properties', funct
   let obj = {};
   MixinB.apply(obj);
 
-  equal(obj.foo, 'FOO', 'should defined foo');
-  equal(obj.bar, undefined, 'should not define bar');
+  assert.equal(obj.foo, 'FOO', 'should defined foo');
+  assert.equal(obj.bar, undefined, 'should not define bar');
 });

--- a/packages/ember-metal/tests/observer_test.js
+++ b/packages/ember-metal/tests/observer_test.js
@@ -39,20 +39,20 @@ testBoth('observer should assert to invalid input', function() {
   }, 'observer called without a function');
 });
 
-testBoth('observer should fire when property is modified', function(get, set) {
+testBoth('observer should fire when property is modified', function(get, set, assert) {
   let obj = {};
   let count = 0;
 
   addObserver(obj, 'foo', function() {
-    equal(get(obj, 'foo'), 'bar', 'should invoke AFTER value changed');
+    assert.equal(get(obj, 'foo'), 'bar', 'should invoke AFTER value changed');
     count++;
   });
 
   set(obj, 'foo', 'bar');
-  equal(count, 1, 'should have invoked observer');
+  assert.equal(count, 1, 'should have invoked observer');
 });
 
-testBoth('observer should fire when dependent property is modified', function(get, set) {
+testBoth('observer should fire when dependent property is modified', function(get, set, assert) {
   let obj = { bar: 'bar' };
   defineProperty(obj, 'foo', computed(function() {
     return get(this, 'bar').toUpperCase();
@@ -62,15 +62,15 @@ testBoth('observer should fire when dependent property is modified', function(ge
 
   let count = 0;
   addObserver(obj, 'foo', function() {
-    equal(get(obj, 'foo'), 'BAZ', 'should have invoked after prop change');
+    assert.equal(get(obj, 'foo'), 'BAZ', 'should have invoked after prop change');
     count++;
   });
 
   set(obj, 'bar', 'baz');
-  equal(count, 1, 'should have invoked observer');
+  assert.equal(count, 1, 'should have invoked observer');
 });
 
-testBoth('observer should continue to fire after dependent properties are accessed', function(get) {
+testBoth('observer should continue to fire after dependent properties are accessed', function(get, set, assert) {
   let observerCount = 0;
   let obj = {};
 
@@ -86,11 +86,11 @@ testBoth('observer should continue to fire after dependent properties are access
     propertyDidChange(obj, 'prop');
   }
 
-  equal(observerCount, 10, 'should continue to fire indefinitely');
+  assert.equal(observerCount, 10, 'should continue to fire indefinitely');
 });
 
 if (ENV.EXTEND_PROTOTYPES.Function) {
-  testBoth('observer added declaratively via brace expansion should fire when property changes', function (get, set) {
+  testBoth('observer added declaratively via brace expansion should fire when property changes', function(get, set, assert) {
     let obj = { };
     let count = 0;
 
@@ -101,16 +101,16 @@ if (ENV.EXTEND_PROTOTYPES.Function) {
     });
 
     set(obj, 'foo', 'foo');
-    equal(count, 1, 'observer specified via brace expansion invoked on property change');
+    assert.equal(count, 1, 'observer specified via brace expansion invoked on property change');
 
     set(obj, 'bar', 'bar');
-    equal(count, 2, 'observer specified via brace expansion invoked on property change');
+    assert.equal(count, 2, 'observer specified via brace expansion invoked on property change');
 
     set(obj, 'baz', 'baz');
-    equal(count, 2, 'observer not invoked on unspecified property');
+    assert.equal(count, 2, 'observer not invoked on unspecified property');
   });
 
-  testBoth('observer specified declaratively via brace expansion should fire when dependent property changes', function (get, set) {
+  testBoth('observer specified declaratively via brace expansion should fire when dependent property changes', function(get, set, assert) {
     let obj = { baz: 'Initial' };
     let count = 0;
 
@@ -131,14 +131,14 @@ if (ENV.EXTEND_PROTOTYPES.Function) {
     get(obj, 'foo');
     set(obj, 'baz', 'Baz');
     // fire once for foo, once for bar
-    equal(count, 2, 'observer specified via brace expansion invoked on dependent property change');
+    assert.equal(count, 2, 'observer specified via brace expansion invoked on dependent property change');
 
     set(obj, 'quux', 'Quux');
-    equal(count, 2, 'observer not fired on unspecified property');
+    assert.equal(count, 2, 'observer not fired on unspecified property');
   });
 }
 
-testBoth('observers watching multiple properties via brace expansion should fire when the properties change', function (get, set) {
+testBoth('observers watching multiple properties via brace expansion should fire when the properties change', function(get, set, assert) {
   let obj = { };
   let count = 0;
 
@@ -149,16 +149,16 @@ testBoth('observers watching multiple properties via brace expansion should fire
   });
 
   set(obj, 'foo', 'foo');
-  equal(count, 1, 'observer specified via brace expansion invoked on property change');
+  assert.equal(count, 1, 'observer specified via brace expansion invoked on property change');
 
   set(obj, 'bar', 'bar');
-  equal(count, 2, 'observer specified via brace expansion invoked on property change');
+  assert.equal(count, 2, 'observer specified via brace expansion invoked on property change');
 
   set(obj, 'baz', 'baz');
-  equal(count, 2, 'observer not invoked on unspecified property');
+  assert.equal(count, 2, 'observer not invoked on unspecified property');
 });
 
-testBoth('observers watching multiple properties via brace expansion should fire when dependent properties change', function (get, set) {
+testBoth('observers watching multiple properties via brace expansion should fire when dependent properties change', function(get, set, assert) {
   let obj = { baz: 'Initial' };
   let count = 0;
 
@@ -179,13 +179,13 @@ testBoth('observers watching multiple properties via brace expansion should fire
   get(obj, 'foo');
   set(obj, 'baz', 'Baz');
   // fire once for foo, once for bar
-  equal(count, 2, 'observer specified via brace expansion invoked on dependent property change');
+  assert.equal(count, 2, 'observer specified via brace expansion invoked on dependent property change');
 
   set(obj, 'quux', 'Quux');
-  equal(count, 2, 'observer not fired on unspecified property');
+  assert.equal(count, 2, 'observer not fired on unspecified property');
 });
 
-testBoth('nested observers should fire in order', function(get, set) {
+testBoth('nested observers should fire in order', function(get, set, assert) {
   let obj = { foo: 'foo', bar: 'bar' };
   let fooCount = 0;
   let barCount = 0;
@@ -193,16 +193,16 @@ testBoth('nested observers should fire in order', function(get, set) {
   addObserver(obj, 'foo', function() { fooCount++; });
   addObserver(obj, 'bar', function() {
     set(obj, 'foo', 'BAZ');
-    equal(fooCount, 1, 'fooCount should have fired already');
+    assert.equal(fooCount, 1, 'fooCount should have fired already');
     barCount++;
   });
 
   set(obj, 'bar', 'BIFF');
-  equal(barCount, 1, 'barCount should have fired');
-  equal(fooCount, 1, 'foo should have fired');
+  assert.equal(barCount, 1, 'barCount should have fired');
+  assert.equal(fooCount, 1, 'foo should have fired');
 });
 
-testBoth('removing an chain observer on change should not fail', function(get, set) {
+testBoth('removing an chain observer on change should not fail', function(get, set, assert) {
   let foo = { bar: 'bar' };
   let obj1 = { foo: foo };
   let obj2 = { foo: foo };
@@ -230,13 +230,13 @@ testBoth('removing an chain observer on change should not fail', function(get, s
 
   set(foo, 'bar', 'baz');
 
-  equal(count1, 1, 'observer1 fired');
-  equal(count2, 1, 'observer2 fired');
-  equal(count3, 1, 'observer3 fired');
-  equal(count4, 0, 'observer4 did not fire');
+  assert.equal(count1, 1, 'observer1 fired');
+  assert.equal(count2, 1, 'observer2 fired');
+  assert.equal(count3, 1, 'observer3 fired');
+  assert.equal(count4, 0, 'observer4 did not fire');
 });
 
-testBoth('removing an chain before observer on change should not fail', function(get, set) {
+testBoth('removing an chain before observer on change should not fail', function(get, set, assert) {
   let foo = { bar: 'bar' };
   let obj1 = { foo: foo };
   let obj2 = { foo: foo };
@@ -264,13 +264,13 @@ testBoth('removing an chain before observer on change should not fail', function
 
   set(foo, 'bar', 'baz');
 
-  equal(count1, 1, 'observer1 fired');
-  equal(count2, 1, 'observer2 fired');
-  equal(count3, 1, 'observer3 fired');
-  equal(count4, 0, 'observer4 did not fire');
+  assert.equal(count1, 1, 'observer1 fired');
+  assert.equal(count2, 1, 'observer2 fired');
+  assert.equal(count3, 1, 'observer3 fired');
+  assert.equal(count4, 0, 'observer4 did not fire');
 });
 
-testBoth('suspending an observer should not fire during callback', function(get, set) {
+testBoth('suspending an observer should not fire during callback', function(get, set, assert) {
   let obj = {};
   let target, otherTarget;
 
@@ -289,7 +289,7 @@ testBoth('suspending an observer should not fire during callback', function(get,
 
   function callback() {
     /*jshint validthis:true */
-    equal(this, target);
+    assert.equal(this, target);
 
     set(obj, 'foo', '2');
 
@@ -298,16 +298,16 @@ testBoth('suspending an observer should not fire during callback', function(get,
 
   set(obj, 'foo', '1');
 
-  equal(_suspendObserver(obj, 'foo', target, target.method, callback), 'result');
+  assert.equal(_suspendObserver(obj, 'foo', target, target.method, callback), 'result');
 
   set(obj, 'foo', '3');
 
-  deepEqual(target.values, ['1', '3'], 'should invoke');
-  deepEqual(otherTarget.values, ['1', '2', '3'], 'should invoke');
+  assert.deepEqual(target.values, ['1', '3'], 'should invoke');
+  assert.deepEqual(otherTarget.values, ['1', '2', '3'], 'should invoke');
 });
 
 
-testBoth('suspending an observer should not defer change notifications during callback', function(get, set) {
+testBoth('suspending an observer should not defer change notifications during callback', function(get, set, assert) {
   let obj = {};
   let target, otherTarget;
 
@@ -326,82 +326,7 @@ testBoth('suspending an observer should not defer change notifications during ca
 
   function callback() {
     /*jshint validthis:true */
-    equal(this, target);
-
-    set(obj, 'foo', '2');
-
-    return 'result';
-  }
-
-  set(obj, 'foo', '1');
-
-  beginPropertyChanges();
-  equal(_suspendObserver(obj, 'foo', target, target.method, callback), 'result');
-  endPropertyChanges();
-
-  set(obj, 'foo', '3');
-
-  deepEqual(target.values, ['1', '3'], 'should invoke');
-  deepEqual(otherTarget.values, ['1', '2', '3'], 'should invoke');
-});
-
-testBoth('suspending observers should not fire during callback', function(get, set) {
-  let obj = {};
-  let target, otherTarget;
-
-  target = {
-    values: [],
-    method() { this.values.push(get(obj, 'foo')); }
-  };
-
-  otherTarget = {
-    values: [],
-    method() { this.values.push(get(obj, 'foo')); }
-  };
-
-  addObserver(obj, 'foo', target, target.method);
-  addObserver(obj, 'foo', otherTarget, otherTarget.method);
-
-  function callback() {
-    /*jshint validthis:true */
-    equal(this, target);
-
-    set(obj, 'foo', '2');
-
-    return 'result';
-  }
-
-  set(obj, 'foo', '1');
-
-  equal(_suspendObservers(obj, ['foo'], target, target.method, callback), 'result');
-
-  set(obj, 'foo', '3');
-
-  deepEqual(target.values, ['1', '3'], 'should invoke');
-  deepEqual(otherTarget.values, ['1', '2', '3'], 'should invoke');
-});
-
-
-testBoth('suspending observers should not defer change notifications during callback', function(get, set) {
-  let obj = {};
-  let target, otherTarget;
-
-  target = {
-    values: [],
-    method() { this.values.push(get(obj, 'foo')); }
-  };
-
-  otherTarget = {
-    values: [],
-    method() { this.values.push(get(obj, 'foo')); }
-  };
-
-  addObserver(obj, 'foo', target, target.method);
-  addObserver(obj, 'foo', otherTarget, otherTarget.method);
-
-  function callback() {
-    /*jshint validthis:true */
-    equal(this, target);
+    assert.equal(this, target);
 
     set(obj, 'foo', '2');
 
@@ -411,16 +336,91 @@ testBoth('suspending observers should not defer change notifications during call
   set(obj, 'foo', '1');
 
   beginPropertyChanges();
-  equal(_suspendObservers(obj, ['foo'], target, target.method, callback), 'result');
+  assert.equal(_suspendObserver(obj, 'foo', target, target.method, callback), 'result');
   endPropertyChanges();
 
   set(obj, 'foo', '3');
 
-  deepEqual(target.values, ['1', '3'], 'should invoke');
-  deepEqual(otherTarget.values, ['1', '2', '3'], 'should invoke');
+  assert.deepEqual(target.values, ['1', '3'], 'should invoke');
+  assert.deepEqual(otherTarget.values, ['1', '2', '3'], 'should invoke');
 });
 
-testBoth('deferring property change notifications', function(get, set) {
+testBoth('suspending observers should not fire during callback', function(get, set, assert) {
+  let obj = {};
+  let target, otherTarget;
+
+  target = {
+    values: [],
+    method() { this.values.push(get(obj, 'foo')); }
+  };
+
+  otherTarget = {
+    values: [],
+    method() { this.values.push(get(obj, 'foo')); }
+  };
+
+  addObserver(obj, 'foo', target, target.method);
+  addObserver(obj, 'foo', otherTarget, otherTarget.method);
+
+  function callback() {
+    /*jshint validthis:true */
+    assert.equal(this, target);
+
+    set(obj, 'foo', '2');
+
+    return 'result';
+  }
+
+  set(obj, 'foo', '1');
+
+  assert.equal(_suspendObservers(obj, ['foo'], target, target.method, callback), 'result');
+
+  set(obj, 'foo', '3');
+
+  assert.deepEqual(target.values, ['1', '3'], 'should invoke');
+  assert.deepEqual(otherTarget.values, ['1', '2', '3'], 'should invoke');
+});
+
+
+testBoth('suspending observers should not defer change notifications during callback', function(get, set, assert) {
+  let obj = {};
+  let target, otherTarget;
+
+  target = {
+    values: [],
+    method() { this.values.push(get(obj, 'foo')); }
+  };
+
+  otherTarget = {
+    values: [],
+    method() { this.values.push(get(obj, 'foo')); }
+  };
+
+  addObserver(obj, 'foo', target, target.method);
+  addObserver(obj, 'foo', otherTarget, otherTarget.method);
+
+  function callback() {
+    /*jshint validthis:true */
+    assert.equal(this, target);
+
+    set(obj, 'foo', '2');
+
+    return 'result';
+  }
+
+  set(obj, 'foo', '1');
+
+  beginPropertyChanges();
+  assert.equal(_suspendObservers(obj, ['foo'], target, target.method, callback), 'result');
+  endPropertyChanges();
+
+  set(obj, 'foo', '3');
+
+  assert.deepEqual(target.values, ['1', '3'], 'should invoke');
+  assert.deepEqual(otherTarget.values, ['1', '2', '3'], 'should invoke');
+});
+
+testBoth('deferring property change notifications', function(get, set, assert) {
   let obj = { foo: 'foo' };
   let fooCount = 0;
 
@@ -431,15 +431,15 @@ testBoth('deferring property change notifications', function(get, set) {
   set(obj, 'foo', 'BAZ');
   endPropertyChanges(obj);
 
-  equal(fooCount, 1, 'foo should have fired once');
+  assert.equal(fooCount, 1, 'foo should have fired once');
 });
 
-testBoth('deferring property change notifications safely despite exceptions', function(get, set) {
+testBoth('deferring property change notifications safely despite exceptions', function(get, set, assert) {
   let obj = { foo: 'foo' };
   let fooCount = 0;
   let exc = new Error('Something unexpected happened!');
 
-  expect(2);
+  assert.expect(2);
   addObserver(obj, 'foo', function() { fooCount++; });
 
   try {
@@ -454,17 +454,17 @@ testBoth('deferring property change notifications safely despite exceptions', fu
     }
   }
 
-  equal(fooCount, 1, 'foo should have fired once');
+  assert.equal(fooCount, 1, 'foo should have fired once');
 
   changeProperties(function() {
     set(obj, 'foo', 'BIFF2');
     set(obj, 'foo', 'BAZ2');
   });
 
-  equal(fooCount, 2, 'foo should have fired again once');
+  assert.equal(fooCount, 2, 'foo should have fired again once');
 });
 
-testBoth('deferring property change notifications will not defer before observers', function(get, set) {
+testBoth('deferring property change notifications will not defer before observers', function(get, set, assert) {
   let obj = { foo: 'foo' };
   let fooCount = 0;
 
@@ -472,14 +472,14 @@ testBoth('deferring property change notifications will not defer before observer
 
   beginPropertyChanges(obj);
   set(obj, 'foo', 'BIFF');
-  equal(fooCount, 1, 'should fire before observer immediately');
+  assert.equal(fooCount, 1, 'should fire before observer immediately');
   set(obj, 'foo', 'BAZ');
   endPropertyChanges(obj);
 
-  equal(fooCount, 1, 'should not fire before observer twice');
+  assert.equal(fooCount, 1, 'should not fire before observer twice');
 });
 
-testBoth('addObserver should propagate through prototype', function(get, set) {
+testBoth('addObserver should propagate through prototype', function(get, set, assert) {
   let obj = { foo: 'foo', count: 0 };
   let obj2;
 
@@ -488,16 +488,16 @@ testBoth('addObserver should propagate through prototype', function(get, set) {
 
   set(obj2, 'foo', 'bar');
 
-  equal(obj2.count, 1, 'should have invoked observer on inherited');
-  equal(obj.count, 0, 'should not have invoked observer on parent');
+  assert.equal(obj2.count, 1, 'should have invoked observer on inherited');
+  assert.equal(obj.count, 0, 'should not have invoked observer on parent');
 
   obj2.count = 0;
   set(obj, 'foo', 'baz');
-  equal(obj.count, 1, 'should have invoked observer on parent');
-  equal(obj2.count, 0, 'should not have invoked observer on inherited');
+  assert.equal(obj.count, 1, 'should have invoked observer on parent');
+  assert.equal(obj2.count, 0, 'should not have invoked observer on inherited');
 });
 
-testBoth('addObserver should respect targets with methods', function(get, set) {
+testBoth('addObserver should respect targets with methods', function(get, set, assert) {
   let observed = { foo: 'foo' };
 
   let target1 = {
@@ -505,10 +505,10 @@ testBoth('addObserver should respect targets with methods', function(get, set) {
 
     didChange(obj, keyName) {
       let value = get(obj, keyName);
-      equal(this, target1, 'should invoke with this');
-      equal(obj, observed, 'param1 should be observed object');
-      equal(keyName, 'foo', 'param2 should be keyName');
-      equal(value, 'BAZ', 'param3 should new value');
+      assert.equal(this, target1, 'should invoke with this');
+      assert.equal(obj, observed, 'param1 should be observed object');
+      assert.equal(keyName, 'foo', 'param2 should be keyName');
+      assert.equal(value, 'BAZ', 'param3 should new value');
       this.count++;
     }
   };
@@ -518,10 +518,10 @@ testBoth('addObserver should respect targets with methods', function(get, set) {
 
     didChange(obj, keyName) {
       let value = get(obj, keyName);
-      equal(this, target2, 'should invoke with this');
-      equal(obj, observed, 'param1 should be observed object');
-      equal(keyName, 'foo', 'param2 should be keyName');
-      equal(value, 'BAZ', 'param3 should new value');
+      assert.equal(this, target2, 'should invoke with this');
+      assert.equal(obj, observed, 'param1 should be observed object');
+      assert.equal(keyName, 'foo', 'param2 should be keyName');
+      assert.equal(value, 'BAZ', 'param3 should new value');
       this.count++;
     }
   };
@@ -530,11 +530,11 @@ testBoth('addObserver should respect targets with methods', function(get, set) {
   addObserver(observed, 'foo', target2, target2.didChange);
 
   set(observed, 'foo', 'BAZ');
-  equal(target1.count, 1, 'target1 observer should have fired');
-  equal(target2.count, 1, 'target2 observer should have fired');
+  assert.equal(target1.count, 1, 'target1 observer should have fired');
+  assert.equal(target2.count, 1, 'target2 observer should have fired');
 });
 
-testBoth('addObserver should allow multiple objects to observe a property', function(get, set) {
+testBoth('addObserver should allow multiple objects to observe a property', function(get, set, assert) {
   let observed = { foo: 'foo' };
 
   let target1 = {
@@ -557,8 +557,8 @@ testBoth('addObserver should allow multiple objects to observe a property', func
   addObserver(observed, 'foo', target2, 'didChange');
 
   set(observed, 'foo', 'BAZ');
-  equal(target1.count, 1, 'target1 observer should have fired');
-  equal(target2.count, 1, 'target2 observer should have fired');
+  assert.equal(target1.count, 1, 'target1 observer should have fired');
+  assert.equal(target2.count, 1, 'target2 observer should have fired');
 });
 
 // ..........................................................
@@ -567,22 +567,22 @@ testBoth('addObserver should allow multiple objects to observe a property', func
 
 QUnit.module('removeObserver');
 
-testBoth('removing observer should stop firing', function(get, set) {
+testBoth('removing observer should stop firing', function(get, set, assert) {
   let obj = {};
   let count = 0;
   function F() { count++; }
   addObserver(obj, 'foo', F);
 
   set(obj, 'foo', 'bar');
-  equal(count, 1, 'should have invoked observer');
+  assert.equal(count, 1, 'should have invoked observer');
 
   removeObserver(obj, 'foo', F);
 
   set(obj, 'foo', 'baz');
-  equal(count, 1, 'removed observer shouldn\'t fire');
+  assert.equal(count, 1, 'removed observer shouldn\'t fire');
 });
 
-testBoth('local observers can be removed', function(get, set) {
+testBoth('local observers can be removed', function(get, set, assert) {
   let barObserved = 0;
 
   let MyMixin = Mixin.create({
@@ -599,17 +599,17 @@ testBoth('local observers can be removed', function(get, set) {
   MyMixin.apply(obj);
 
   set(obj, 'bar', 'HI!');
-  equal(barObserved, 2, 'precond - observers should be fired');
+  assert.equal(barObserved, 2, 'precond - observers should be fired');
 
   removeObserver(obj, 'bar', null, 'foo1');
 
   barObserved = 0;
   set(obj, 'bar', 'HI AGAIN!');
 
-  equal(barObserved, 1, 'removed observers should not be called');
+  assert.equal(barObserved, 1, 'removed observers should not be called');
 });
 
-testBoth('removeObserver should respect targets with methods', function(get, set) {
+testBoth('removeObserver should respect targets with methods', function(get, set, assert) {
   let observed = { foo: 'foo' };
 
   let target1 = {
@@ -632,16 +632,16 @@ testBoth('removeObserver should respect targets with methods', function(get, set
   addObserver(observed, 'foo', target2, target2.didChange);
 
   set(observed, 'foo', 'BAZ');
-  equal(target1.count, 1, 'target1 observer should have fired');
-  equal(target2.count, 1, 'target2 observer should have fired');
+  assert.equal(target1.count, 1, 'target1 observer should have fired');
+  assert.equal(target2.count, 1, 'target2 observer should have fired');
 
   removeObserver(observed, 'foo', target1, 'didChange');
   removeObserver(observed, 'foo', target2, target2.didChange);
 
   target1.count = target2.count = 0;
   set(observed, 'foo', 'BAZ');
-  equal(target1.count, 0, 'target1 observer should not fire again');
-  equal(target2.count, 0, 'target2 observer should not fire again');
+  assert.equal(target1.count, 0, 'target1 observer should not fire again');
+  assert.equal(target2.count, 0, 'target2 observer should not fire again');
 });
 
 // ..........................................................
@@ -650,20 +650,20 @@ testBoth('removeObserver should respect targets with methods', function(get, set
 
 QUnit.module('_addBeforeObserver');
 
-testBoth('observer should fire before a property is modified', function(get, set) {
+testBoth('observer should fire before a property is modified', function(get, set, assert) {
   let obj = { foo: 'foo' };
   let count = 0;
 
   _addBeforeObserver(obj, 'foo', function() {
-    equal(get(obj, 'foo'), 'foo', 'should invoke before value changed');
+    assert.equal(get(obj, 'foo'), 'foo', 'should invoke before value changed');
     count++;
   });
 
   set(obj, 'foo', 'bar');
-  equal(count, 1, 'should have invoked observer');
+  assert.equal(count, 1, 'should have invoked observer');
 });
 
-testBoth('observer should fire before dependent property is modified', function(get, set) {
+testBoth('observer should fire before dependent property is modified', function(get, set, assert) {
   let obj = { bar: 'bar' };
   defineProperty(obj, 'foo', computed(function() {
     return get(this, 'bar').toUpperCase();
@@ -673,15 +673,15 @@ testBoth('observer should fire before dependent property is modified', function(
 
   let count = 0;
   _addBeforeObserver(obj, 'foo', function() {
-    equal(get(obj, 'foo'), 'BAR', 'should have invoked after prop change');
+    assert.equal(get(obj, 'foo'), 'BAR', 'should have invoked after prop change');
     count++;
   });
 
   set(obj, 'bar', 'baz');
-  equal(count, 1, 'should have invoked observer');
+  assert.equal(count, 1, 'should have invoked observer');
 });
 
-testBoth('before observer watching multiple properties via brace expansion should fire when properties change', function (get, set) {
+testBoth('before observer watching multiple properties via brace expansion should fire when properties change', function(get, set, assert) {
   let obj = {};
   let count = 0;
 
@@ -692,16 +692,16 @@ testBoth('before observer watching multiple properties via brace expansion shoul
   });
 
   set(obj, 'foo', 'foo');
-  equal(count, 1, 'observer specified via brace expansion invoked on property change');
+  assert.equal(count, 1, 'observer specified via brace expansion invoked on property change');
 
   set(obj, 'bar', 'bar');
-  equal(count, 2, 'observer specified via brace expansion invoked on property change');
+  assert.equal(count, 2, 'observer specified via brace expansion invoked on property change');
 
   set(obj, 'baz', 'baz');
-  equal(count, 2, 'observer not invoked on unspecified property');
+  assert.equal(count, 2, 'observer not invoked on unspecified property');
 });
 
-testBoth('before observer watching multiple properties via brace expansion should fire when dependent property changes', function (get, set) {
+testBoth('before observer watching multiple properties via brace expansion should fire when dependent property changes', function(get, set, assert) {
   let obj = { baz: 'Initial' };
   let count = 0;
 
@@ -722,13 +722,13 @@ testBoth('before observer watching multiple properties via brace expansion shoul
   get(obj, 'foo');
   set(obj, 'baz', 'Baz');
   // fire once for foo, once for bar
-  equal(count, 2, 'observer specified via brace expansion invoked on dependent property change');
+  assert.equal(count, 2, 'observer specified via brace expansion invoked on dependent property change');
 
   set(obj, 'quux', 'Quux');
-  equal(count, 2, 'observer not fired on unspecified property');
+  assert.equal(count, 2, 'observer not fired on unspecified property');
 });
 
-testBoth('_addBeforeObserver should propagate through prototype', function(get, set) {
+testBoth('_addBeforeObserver should propagate through prototype', function(get, set, assert) {
   let obj = { foo: 'foo', count: 0 };
   let obj2;
 
@@ -736,16 +736,16 @@ testBoth('_addBeforeObserver should propagate through prototype', function(get, 
   obj2 = Object.create(obj);
 
   set(obj2, 'foo', 'bar');
-  equal(obj2.count, 1, 'should have invoked observer on inherited');
-  equal(obj.count, 0, 'should not have invoked observer on parent');
+  assert.equal(obj2.count, 1, 'should have invoked observer on inherited');
+  assert.equal(obj.count, 0, 'should not have invoked observer on parent');
 
   obj2.count = 0;
   set(obj, 'foo', 'baz');
-  equal(obj.count, 1, 'should have invoked observer on parent');
-  equal(obj2.count, 0, 'should not have invoked observer on inherited');
+  assert.equal(obj.count, 1, 'should have invoked observer on parent');
+  assert.equal(obj2.count, 0, 'should not have invoked observer on inherited');
 });
 
-testBoth('_addBeforeObserver should respect targets with methods', function(get, set) {
+testBoth('_addBeforeObserver should respect targets with methods', function(get, set, assert) {
   let observed = { foo: 'foo' };
 
   let target1 = {
@@ -753,10 +753,10 @@ testBoth('_addBeforeObserver should respect targets with methods', function(get,
 
     willChange(obj, keyName) {
       let value = get(obj, keyName);
-      equal(this, target1, 'should invoke with this');
-      equal(obj, observed, 'param1 should be observed object');
-      equal(keyName, 'foo', 'param2 should be keyName');
-      equal(value, 'foo', 'param3 should old value');
+      assert.equal(this, target1, 'should invoke with this');
+      assert.equal(obj, observed, 'param1 should be observed object');
+      assert.equal(keyName, 'foo', 'param2 should be keyName');
+      assert.equal(value, 'foo', 'param3 should old value');
       this.count++;
     }
   };
@@ -766,10 +766,10 @@ testBoth('_addBeforeObserver should respect targets with methods', function(get,
 
     willChange(obj, keyName) {
       let value = get(obj, keyName);
-      equal(this, target2, 'should invoke with this');
-      equal(obj, observed, 'param1 should be observed object');
-      equal(keyName, 'foo', 'param2 should be keyName');
-      equal(value, 'foo', 'param3 should old value');
+      assert.equal(this, target2, 'should invoke with this');
+      assert.equal(obj, observed, 'param1 should be observed object');
+      assert.equal(keyName, 'foo', 'param2 should be keyName');
+      assert.equal(value, 'foo', 'param3 should old value');
       this.count++;
     }
   };
@@ -778,8 +778,8 @@ testBoth('_addBeforeObserver should respect targets with methods', function(get,
   _addBeforeObserver(observed, 'foo', target2, target2.willChange);
 
   set(observed, 'foo', 'BAZ');
-  equal(target1.count, 1, 'target1 observer should have fired');
-  equal(target2.count, 1, 'target2 observer should have fired');
+  assert.equal(target1.count, 1, 'target1 observer should have fired');
+  assert.equal(target2.count, 1, 'target2 observer should have fired');
 });
 
 // ..........................................................
@@ -789,7 +789,7 @@ testBoth('_addBeforeObserver should respect targets with methods', function(get,
 let obj, count;
 
 QUnit.module('addObserver - dependentkey with chained properties', {
-  setup() {
+  beforeEach() {
     obj = {
       foo: {
         bar: {
@@ -812,13 +812,13 @@ QUnit.module('addObserver - dependentkey with chained properties', {
     count = 0;
   },
 
-  teardown() {
+  afterEach() {
     obj = count = null;
   }
 });
 
 
-testBoth('depending on a chain with a computed property', function (get, set) {
+testBoth('depending on a chain with a computed property', function(get, set, assert) {
   defineProperty(obj, 'computed', computed(function () {
     return { foo: 'bar' };
   }));
@@ -828,14 +828,14 @@ testBoth('depending on a chain with a computed property', function (get, set) {
     changed++;
   });
 
-  equal(cacheFor(obj, 'computed'), undefined, 'addObserver should not compute CP');
+  assert.equal(cacheFor(obj, 'computed'), undefined, 'addObserver should not compute CP');
 
   set(obj, 'computed.foo', 'baz');
 
-  equal(changed, 1, 'should fire observer');
+  assert.equal(changed, 1, 'should fire observer');
 });
 
-testBoth('depending on a simple chain', function(get, set) {
+testBoth('depending on a simple chain', function(get, set, assert) {
   let val;
   addObserver(obj, 'foo.bar.baz.biff', function(target, key) {
     val = get(target, key);
@@ -843,36 +843,36 @@ testBoth('depending on a simple chain', function(get, set) {
   });
 
   set(get(obj, 'foo.bar.baz'), 'biff', 'BUZZ');
-  equal(val, 'BUZZ');
-  equal(count, 1);
+  assert.equal(val, 'BUZZ');
+  assert.equal(count, 1);
 
   set(get(obj, 'foo.bar'), 'baz', { biff: 'BLARG' });
-  equal(val, 'BLARG');
-  equal(count, 2);
+  assert.equal(val, 'BLARG');
+  assert.equal(count, 2);
 
   set(get(obj, 'foo'), 'bar', { baz: { biff: 'BOOM' } });
-  equal(val, 'BOOM');
-  equal(count, 3);
+  assert.equal(val, 'BOOM');
+  assert.equal(count, 3);
 
   set(obj, 'foo', { bar: { baz: { biff: 'BLARG' } } });
-  equal(val, 'BLARG');
-  equal(count, 4);
+  assert.equal(val, 'BLARG');
+  assert.equal(count, 4);
 
   set(get(obj, 'foo.bar.baz'), 'biff', 'BUZZ');
-  equal(val, 'BUZZ');
-  equal(count, 5);
+  assert.equal(val, 'BUZZ');
+  assert.equal(count, 5);
 
   let foo = get(obj, 'foo');
 
   set(obj, 'foo', 'BOO');
-  equal(val, undefined);
-  equal(count, 6);
+  assert.equal(val, undefined);
+  assert.equal(count, 6);
 
   set(foo.bar.baz, 'biff', 'BOOM');
-  equal(count, 6, 'should be not have invoked observer');
+  assert.equal(count, 6, 'should be not have invoked observer');
 });
 
-testBoth('depending on a chain with a capitalized first key', function(get, set) {
+testBoth('depending on a chain with a capitalized first key', function(get, set, assert) {
   let val;
 
   addObserver(obj, 'Capital.foo.bar.baz.biff', function(target, key) {
@@ -881,33 +881,33 @@ testBoth('depending on a chain with a capitalized first key', function(get, set)
   });
 
   set(get(obj, 'Capital.foo.bar.baz'), 'biff', 'BUZZ');
-  equal(val, 'BUZZ');
-  equal(count, 1);
+  assert.equal(val, 'BUZZ');
+  assert.equal(count, 1);
 
   set(get(obj, 'Capital.foo.bar'), 'baz', { biff: 'BLARG' });
-  equal(val, 'BLARG');
-  equal(count, 2);
+  assert.equal(val, 'BLARG');
+  assert.equal(count, 2);
 
   set(get(obj, 'Capital.foo'), 'bar', { baz: { biff: 'BOOM' } });
-  equal(val, 'BOOM');
-  equal(count, 3);
+  assert.equal(val, 'BOOM');
+  assert.equal(count, 3);
 
   set(obj, 'Capital.foo', { bar: { baz: { biff: 'BLARG' } } });
-  equal(val, 'BLARG');
-  equal(count, 4);
+  assert.equal(val, 'BLARG');
+  assert.equal(count, 4);
 
   set(get(obj, 'Capital.foo.bar.baz'), 'biff', 'BUZZ');
-  equal(val, 'BUZZ');
-  equal(count, 5);
+  assert.equal(val, 'BUZZ');
+  assert.equal(count, 5);
 
   let foo = get(obj, 'foo');
 
   set(obj, 'Capital.foo', 'BOO');
-  equal(val, undefined);
-  equal(count, 6);
+  assert.equal(val, undefined);
+  assert.equal(count, 6);
 
   set(foo.bar.baz, 'biff', 'BOOM');
-  equal(count, 6, 'should be not have invoked observer');
+  assert.equal(count, 6, 'should be not have invoked observer');
 });
 
 QUnit.module('_removeBeforeObserver');
@@ -918,26 +918,26 @@ QUnit.module('_removeBeforeObserver');
 
 QUnit.module('props/observer_test - setting identical values');
 
-testBoth('setting simple prop should not trigger', function(get, set) {
+testBoth('setting simple prop should not trigger', function(get, set, assert) {
   let obj = { foo: 'bar' };
   let count = 0;
 
   addObserver(obj, 'foo', function() { count++; });
 
   set(obj, 'foo', 'bar');
-  equal(count, 0, 'should not trigger observer');
+  assert.equal(count, 0, 'should not trigger observer');
 
   set(obj, 'foo', 'baz');
-  equal(count, 1, 'should trigger observer');
+  assert.equal(count, 1, 'should trigger observer');
 
   set(obj, 'foo', 'baz');
-  equal(count, 1, 'should not trigger observer again');
+  assert.equal(count, 1, 'should not trigger observer again');
 });
 
 // The issue here is when a computed property is directly set with a value, then has a
 // dependent key change (which triggers a cache expiration and recomputation), observers will
 // not be fired if the CP setter is called with the last set value.
-testBoth('setting a cached computed property whose value has changed should trigger', function(get, set) {
+testBoth('setting a cached computed property whose value has changed should trigger', function(get, set, assert) {
   let obj = {};
 
   defineProperty(obj, 'foo', computed({
@@ -950,22 +950,22 @@ testBoth('setting a cached computed property whose value has changed should trig
   addObserver(obj, 'foo', function() { count++; });
 
   set(obj, 'foo', 'bar');
-  equal(count, 1);
-  equal(get(obj, 'foo'), 'bar');
+  assert.equal(count, 1);
+  assert.equal(get(obj, 'foo'), 'bar');
 
   set(obj, 'baz', 'qux');
-  equal(count, 2);
-  equal(get(obj, 'foo'), 'qux');
+  assert.equal(count, 2);
+  assert.equal(get(obj, 'foo'), 'qux');
 
   get(obj, 'foo');
   set(obj, 'foo', 'bar');
-  equal(count, 3);
-  equal(get(obj, 'foo'), 'bar');
+  assert.equal(count, 3);
+  assert.equal(get(obj, 'foo'), 'bar');
 });
 
 QUnit.module('changeProperties');
 
-testBoth('observers added/removed during changeProperties should do the right thing.', function(get, set) {
+testBoth('observers added/removed during changeProperties should do the right thing.', function(get, set, assert) {
   let obj = {
     foo: 0
   };
@@ -1004,51 +1004,51 @@ testBoth('observers added/removed during changeProperties should do the right th
 
     set(obj, 'foo', 1);
 
-    equal(addedBeforeFirstChangeObserver.willChangeCount, 1, '_addBeforeObserver called before the first change invoked immediately');
-    equal(addedBeforeFirstChangeObserver.didChangeCount, 0, 'addObserver called before the first change is deferred');
+    assert.equal(addedBeforeFirstChangeObserver.willChangeCount, 1, '_addBeforeObserver called before the first change invoked immediately');
+    assert.equal(addedBeforeFirstChangeObserver.didChangeCount, 0, 'addObserver called before the first change is deferred');
 
     addedAfterFirstChangeObserver.add();
     removedBeforeLastChangeObserver.remove();
 
     set(obj, 'foo', 2);
 
-    equal(addedAfterFirstChangeObserver.willChangeCount, 1, '_addBeforeObserver called after the first change invoked immediately');
-    equal(addedAfterFirstChangeObserver.didChangeCount, 0, 'addObserver called after the first change is deferred');
+    assert.equal(addedAfterFirstChangeObserver.willChangeCount, 1, '_addBeforeObserver called after the first change invoked immediately');
+    assert.equal(addedAfterFirstChangeObserver.didChangeCount, 0, 'addObserver called after the first change is deferred');
 
     addedAfterLastChangeObserver.add();
     removedAfterLastChangeObserver.remove();
   });
 
-  equal(removedBeforeFirstChangeObserver.willChangeCount, 0, '_removeBeforeObserver called before the first change sees none');
-  equal(removedBeforeFirstChangeObserver.didChangeCount, 0, 'removeObserver called before the first change sees none');
-  equal(addedBeforeFirstChangeObserver.willChangeCount, 1, '_addBeforeObserver called before the first change sees only 1');
-  equal(addedBeforeFirstChangeObserver.didChangeCount, 1, 'addObserver called before the first change sees only 1');
-  equal(addedAfterFirstChangeObserver.willChangeCount, 1, '_addBeforeObserver called after the first change sees 1');
-  equal(addedAfterFirstChangeObserver.didChangeCount, 1, 'addObserver called after the first change sees 1');
-  equal(addedAfterLastChangeObserver.willChangeCount, 0, '_addBeforeObserver called after the last change sees none');
-  equal(addedAfterLastChangeObserver.didChangeCount, 0, 'addObserver called after the last change sees none');
-  equal(removedBeforeLastChangeObserver.willChangeCount, 1, '_removeBeforeObserver called before the last change still sees 1');
-  equal(removedBeforeLastChangeObserver.didChangeCount, 1, 'removeObserver called before the last change still sees 1');
-  equal(removedAfterLastChangeObserver.willChangeCount, 1, '_removeBeforeObserver called after the last change still sees 1');
-  equal(removedAfterLastChangeObserver.didChangeCount, 1, 'removeObserver called after the last change still sees 1');
+  assert.equal(removedBeforeFirstChangeObserver.willChangeCount, 0, '_removeBeforeObserver called before the first change sees none');
+  assert.equal(removedBeforeFirstChangeObserver.didChangeCount, 0, 'removeObserver called before the first change sees none');
+  assert.equal(addedBeforeFirstChangeObserver.willChangeCount, 1, '_addBeforeObserver called before the first change sees only 1');
+  assert.equal(addedBeforeFirstChangeObserver.didChangeCount, 1, 'addObserver called before the first change sees only 1');
+  assert.equal(addedAfterFirstChangeObserver.willChangeCount, 1, '_addBeforeObserver called after the first change sees 1');
+  assert.equal(addedAfterFirstChangeObserver.didChangeCount, 1, 'addObserver called after the first change sees 1');
+  assert.equal(addedAfterLastChangeObserver.willChangeCount, 0, '_addBeforeObserver called after the last change sees none');
+  assert.equal(addedAfterLastChangeObserver.didChangeCount, 0, 'addObserver called after the last change sees none');
+  assert.equal(removedBeforeLastChangeObserver.willChangeCount, 1, '_removeBeforeObserver called before the last change still sees 1');
+  assert.equal(removedBeforeLastChangeObserver.didChangeCount, 1, 'removeObserver called before the last change still sees 1');
+  assert.equal(removedAfterLastChangeObserver.willChangeCount, 1, '_removeBeforeObserver called after the last change still sees 1');
+  assert.equal(removedAfterLastChangeObserver.didChangeCount, 1, 'removeObserver called after the last change still sees 1');
 });
 
 
 QUnit.module('Keys behavior with observers');
 
 
-testBoth('should not leak properties on the prototype', function () {
+testBoth('should not leak properties on the prototype', function (get, set, assert) {
   function Beer() { }
   Beer.prototype.type = 'ipa';
 
   let beer = new Beer();
 
   addObserver(beer, 'type', K);
-  deepEqual(Object.keys(beer), []);
+  assert.deepEqual(Object.keys(beer), []);
   removeObserver(beer, 'type', K);
 });
 
-testBoth('observing a non existent property', function (get, set) {
+testBoth('observing a non existent property', function(get, set, assert) {
   function Beer() { }
   Beer.prototype.type = 'ipa';
 
@@ -1056,15 +1056,15 @@ testBoth('observing a non existent property', function (get, set) {
 
   addObserver(beer, 'brand', K);
 
-  deepEqual(Object.keys(beer), []);
+  assert.deepEqual(Object.keys(beer), []);
 
   set(beer, 'brand', 'Corona');
-  deepEqual(Object.keys(beer), ['brand']);
+  assert.deepEqual(Object.keys(beer), ['brand']);
 
   removeObserver(beer, 'brand', K);
 });
 
-testBoth('with observers switched on and off', function () {
+testBoth('with observers switched on and off', function (get, set, assert) {
   function Beer() { }
   Beer.prototype.type = 'ipa';
 
@@ -1073,10 +1073,10 @@ testBoth('with observers switched on and off', function () {
   addObserver(beer, 'type', K);
   removeObserver(beer, 'type', K);
 
-  deepEqual(Object.keys(beer), []);
+  assert.deepEqual(Object.keys(beer), []);
 });
 
-testBoth('observers switched on and off with setter in between', function (get, set) {
+testBoth('observers switched on and off with setter in between', function(get, set, assert) {
   function Beer() { }
   Beer.prototype.type = 'ipa';
 
@@ -1086,10 +1086,10 @@ testBoth('observers switched on and off with setter in between', function (get, 
   set(beer, 'type', 'ale');
   removeObserver(beer, 'type', K);
 
-  deepEqual(Object.keys(beer), ['type']);
+  assert.deepEqual(Object.keys(beer), ['type']);
 });
 
-testBoth('observer switched on and off and then setter', function (get, set) {
+testBoth('observer switched on and off and then setter', function(get, set, assert) {
   function Beer() { }
   Beer.prototype.type = 'ipa';
 
@@ -1099,54 +1099,54 @@ testBoth('observer switched on and off and then setter', function (get, set) {
   removeObserver(beer, 'type', K);
   set(beer, 'type', 'ale');
 
-  deepEqual(Object.keys(beer), ['type']);
+  assert.deepEqual(Object.keys(beer), ['type']);
 });
 
-testBoth('observers switched on and off with setter in between (observed property is not shadowing)', function (get, set) {
+testBoth('observers switched on and off with setter in between (observed property is not shadowing)', function(get, set, assert) {
   function Beer() { }
 
   let beer = new Beer();
   set(beer, 'type', 'ale');
-  deepEqual(Object.keys(beer), ['type'], 'only set');
+  assert.deepEqual(Object.keys(beer), ['type'], 'only set');
 
   let otherBeer = new Beer();
   addObserver(otherBeer, 'type', K);
   set(otherBeer, 'type', 'ale');
-  deepEqual(Object.keys(otherBeer), ['type'], 'addObserver -> set');
+  assert.deepEqual(Object.keys(otherBeer), ['type'], 'addObserver -> set');
 
   let yetAnotherBeer = new Beer();
   addObserver(yetAnotherBeer, 'type', K);
   set(yetAnotherBeer, 'type', 'ale');
   removeObserver(beer, 'type', K);
-  deepEqual(Object.keys(yetAnotherBeer), ['type'], 'addObserver -> set -> removeObserver');
+  assert.deepEqual(Object.keys(yetAnotherBeer), ['type'], 'addObserver -> set -> removeObserver');
 
   let itsMyLastBeer = new Beer();
   set(itsMyLastBeer, 'type', 'ale');
   removeObserver(beer, 'type', K);
-  deepEqual(Object.keys(itsMyLastBeer), ['type'], 'set -> removeObserver');
+  assert.deepEqual(Object.keys(itsMyLastBeer), ['type'], 'set -> removeObserver');
 });
 
-testBoth('observers switched on and off with setter in between (observed property is shadowing one on the prototype)', function (get, set) {
+testBoth('observers switched on and off with setter in between (observed property is shadowing one on the prototype)', function(get, set, assert) {
   function Beer() { }
   Beer.prototype.type = 'ipa';
 
   let beer = new Beer();
   set(beer, 'type', 'ale');
-  deepEqual(Object.keys(beer), ['type'], 'after set');
+  assert.deepEqual(Object.keys(beer), ['type'], 'after set');
 
   let otherBeer = new Beer();
   addObserver(otherBeer, 'type', K);
   set(otherBeer, 'type', 'ale');
-  deepEqual(Object.keys(otherBeer), ['type'], 'addObserver -> set');
+  assert.deepEqual(Object.keys(otherBeer), ['type'], 'addObserver -> set');
 
   let yetAnotherBeer = new Beer();
   addObserver(yetAnotherBeer, 'type', K);
   set(yetAnotherBeer, 'type', 'ale');
   removeObserver(beer, 'type', K);
-  deepEqual(Object.keys(yetAnotherBeer), ['type'], 'addObserver -> set -> removeObserver');
+  assert.deepEqual(Object.keys(yetAnotherBeer), ['type'], 'addObserver -> set -> removeObserver');
 
   let itsMyLastBeer = new Beer();
   set(itsMyLastBeer, 'type', 'ale');
   removeObserver(beer, 'type', K);
-  deepEqual(Object.keys(itsMyLastBeer), ['type'], 'set -> removeObserver');
+  assert.deepEqual(Object.keys(itsMyLastBeer), ['type'], 'set -> removeObserver');
 });

--- a/packages/ember-metal/tests/run_loop/run_bind_test.js
+++ b/packages/ember-metal/tests/run_loop/run_bind_test.js
@@ -8,7 +8,7 @@ moduleFor('system/run_loop/run_bind_test', class extends AbstractTestCase {
     let obj = {
       value: 0,
       increment(increment) {
-        ok(run.currentRunLoop, 'expected a run-loop');
+        assert.ok(run.currentRunLoop, 'expected a run-loop');
         return this.value += increment;
       }
     };

--- a/packages/ember-metal/tests/run_loop/unwind_test.js
+++ b/packages/ember-metal/tests/run_loop/unwind_test.js
@@ -6,7 +6,7 @@ moduleFor('system/run_loop/unwind_test', class extends AbstractTestCase {
   ['@test RunLoop unwinds despite unhandled exception'](assert) {
     let initialRunLoop = run.currentRunLoop;
 
-    throws(() => {
+    assert.throws(() => {
       run(() => {
         run.schedule('actions', function() { throw new EmberError('boom!'); });
       });

--- a/packages/ember-metal/tests/watching/is_watching_test.js
+++ b/packages/ember-metal/tests/watching/is_watching_test.js
@@ -11,48 +11,48 @@ import {
 
 QUnit.module('isWatching');
 
-function testObserver(setup, teardown, key = 'key') {
+function testObserver(assert, setup, teardown, key = 'key') {
   let obj = {};
   function fn() {}
 
-  equal(isWatching(obj, key), false, 'precond - isWatching is false by default');
+  assert.equal(isWatching(obj, key), false, 'precond - isWatching is false by default');
   setup(obj, key, fn);
-  equal(isWatching(obj, key), true, 'isWatching is true when observers are added');
+  assert.equal(isWatching(obj, key), true, 'isWatching is true when observers are added');
   teardown(obj, key, fn);
-  equal(isWatching(obj, key), false, 'isWatching is false after observers are removed');
+  assert.equal(isWatching(obj, key), false, 'isWatching is false after observers are removed');
 }
 
-QUnit.test('isWatching is true for regular local observers', function() {
-  testObserver((obj, key, fn) => {
+QUnit.test('isWatching is true for regular local observers', function(assert) {
+  testObserver(assert, (obj, key, fn) => {
     Mixin.create({
       didChange: observer(key, fn)
     }).apply(obj);
   }, (obj, key, fn) => removeObserver(obj, key, obj, fn));
 });
 
-QUnit.test('isWatching is true for nonlocal observers', function() {
-  testObserver((obj, key, fn) => {
+QUnit.test('isWatching is true for nonlocal observers', function(assert) {
+  testObserver(assert, (obj, key, fn) => {
     addObserver(obj, key, obj, fn);
   }, (obj, key, fn) => removeObserver(obj, key, obj, fn));
 });
 
-QUnit.test('isWatching is true for chained observers', function() {
-  testObserver(function(obj, key, fn) {
+QUnit.test('isWatching is true for chained observers', function(assert) {
+  testObserver(assert, function(obj, key, fn) {
     addObserver(obj, key + '.bar', obj, fn);
   }, function(obj, key, fn) {
     removeObserver(obj, key + '.bar', obj, fn);
   });
 });
 
-QUnit.test('isWatching is true for computed properties', function() {
-  testObserver((obj, key, fn) => {
+QUnit.test('isWatching is true for computed properties', function(assert) {
+  testObserver(assert, (obj, key, fn) => {
     defineProperty(obj, 'computed', computed(fn).property(key));
     get(obj, 'computed');
   }, obj => defineProperty(obj, 'computed', null));
 });
 
-QUnit.test('isWatching is true for chained computed properties', function() {
-  testObserver((obj, key, fn) => {
+QUnit.test('isWatching is true for chained computed properties', function(assert) {
+  testObserver(assert, (obj, key, fn) => {
     defineProperty(obj, 'computed', computed(fn).property(key + '.bar'));
     get(obj, 'computed');
   }, obj => defineProperty(obj, 'computed', null));
@@ -60,8 +60,8 @@ QUnit.test('isWatching is true for chained computed properties', function() {
 
 // can't watch length on Array - it is special...
 // But you should be able to watch a length property of an object
-QUnit.test('isWatching is true for \'length\' property on object', function() {
-  testObserver((obj, key, fn) => {
+QUnit.test('isWatching is true for \'length\' property on object', function(assert) {
+  testObserver(assert, (obj, key, fn) => {
     defineProperty(obj, 'length', null, '26.2 miles');
     addObserver(obj, 'length', obj, fn);
   }, (obj, key, fn) => removeObserver(obj, 'length', obj, fn), 'length');

--- a/packages/ember-metal/tests/watching/unwatch_test.js
+++ b/packages/ember-metal/tests/watching/unwatch_test.js
@@ -11,7 +11,7 @@ import {
 let willCount, didCount;
 
 QUnit.module('unwatch', {
-  setup() {
+  beforeEach() {
     willCount = didCount = 0;
   }
 });
@@ -21,7 +21,7 @@ function addListeners(obj, keyPath) {
   addListener(obj, keyPath + ':change', () => didCount++);
 }
 
-testBoth('unwatching a computed property - regular get/set', function(get, set) {
+testBoth('unwatching a computed property - regular get/set', function(get, set, assert) {
   let obj = {};
 
   defineProperty(obj, 'foo', computed({
@@ -37,80 +37,80 @@ testBoth('unwatching a computed property - regular get/set', function(get, set) 
 
   watch(obj, 'foo');
   set(obj, 'foo', 'bar');
-  equal(willCount, 1, 'should have invoked willCount');
-  equal(didCount, 1, 'should have invoked didCount');
+  assert.equal(willCount, 1, 'should have invoked willCount');
+  assert.equal(didCount, 1, 'should have invoked didCount');
 
   unwatch(obj, 'foo');
   willCount = didCount = 0;
   set(obj, 'foo', 'BAZ');
-  equal(willCount, 0, 'should NOT have invoked willCount');
-  equal(didCount, 0, 'should NOT have invoked didCount');
+  assert.equal(willCount, 0, 'should NOT have invoked willCount');
+  assert.equal(didCount, 0, 'should NOT have invoked didCount');
 });
 
 
-testBoth('unwatching a regular property - regular get/set', function(get, set) {
+testBoth('unwatching a regular property - regular get/set', function(get, set, assert) {
   let obj = { foo: 'BIFF' };
   addListeners(obj, 'foo');
 
   watch(obj, 'foo');
   set(obj, 'foo', 'bar');
-  equal(willCount, 1, 'should have invoked willCount');
-  equal(didCount, 1, 'should have invoked didCount');
+  assert.equal(willCount, 1, 'should have invoked willCount');
+  assert.equal(didCount, 1, 'should have invoked didCount');
 
   unwatch(obj, 'foo');
   willCount = didCount = 0;
   set(obj, 'foo', 'BAZ');
-  equal(willCount, 0, 'should NOT have invoked willCount');
-  equal(didCount, 0, 'should NOT have invoked didCount');
+  assert.equal(willCount, 0, 'should NOT have invoked willCount');
+  assert.equal(didCount, 0, 'should NOT have invoked didCount');
 });
 
-QUnit.test('unwatching should be nested', function() {
+QUnit.test('unwatching should be nested', function(assert) {
   let obj = { foo: 'BIFF' };
   addListeners(obj, 'foo');
 
   watch(obj, 'foo');
   watch(obj, 'foo');
   set(obj, 'foo', 'bar');
-  equal(willCount, 1, 'should have invoked willCount');
-  equal(didCount, 1, 'should have invoked didCount');
+  assert.equal(willCount, 1, 'should have invoked willCount');
+  assert.equal(didCount, 1, 'should have invoked didCount');
 
   unwatch(obj, 'foo');
   willCount = didCount = 0;
   set(obj, 'foo', 'BAZ');
-  equal(willCount, 1, 'should NOT have invoked willCount');
-  equal(didCount, 1, 'should NOT have invoked didCount');
+  assert.equal(willCount, 1, 'should NOT have invoked willCount');
+  assert.equal(didCount, 1, 'should NOT have invoked didCount');
 
   unwatch(obj, 'foo');
   willCount = didCount = 0;
   set(obj, 'foo', 'BAZ');
-  equal(willCount, 0, 'should NOT have invoked willCount');
-  equal(didCount, 0, 'should NOT have invoked didCount');
+  assert.equal(willCount, 0, 'should NOT have invoked willCount');
+  assert.equal(didCount, 0, 'should NOT have invoked didCount');
 });
 
-testBoth('unwatching "length" property on an object', function(get, set) {
+testBoth('unwatching "length" property on an object', function(get, set, assert) {
   let obj = { foo: 'RUN' };
   addListeners(obj, 'length');
 
   // Can watch length when it is undefined
   watch(obj, 'length');
   set(obj, 'length', '10k');
-  equal(willCount, 1, 'should have invoked willCount');
-  equal(didCount, 1, 'should have invoked didCount');
+  assert.equal(willCount, 1, 'should have invoked willCount');
+  assert.equal(didCount, 1, 'should have invoked didCount');
 
   // Should stop watching despite length now being defined (making object 'array-like')
   unwatch(obj, 'length');
   willCount = didCount = 0;
   set(obj, 'length', '5k');
-  equal(willCount, 0, 'should NOT have invoked willCount');
-  equal(didCount, 0, 'should NOT have invoked didCount');
+  assert.equal(willCount, 0, 'should NOT have invoked willCount');
+  assert.equal(didCount, 0, 'should NOT have invoked didCount');
 });
 
-testBoth('unwatching should not destroy non MANDATORY_SETTER descriptor', function() {
+testBoth('unwatching should not destroy non MANDATORY_SETTER descriptor', function(get, set, assert) {
   let obj = { get foo() { return 'RUN'; } };
 
-  equal(obj.foo, 'RUN', 'obj.foo');
+  assert.equal(obj.foo, 'RUN', 'obj.foo');
   watch(obj, 'foo');
-  equal(obj.foo, 'RUN', 'obj.foo after watch');
+  assert.equal(obj.foo, 'RUN', 'obj.foo after watch');
   unwatch(obj, 'foo');
-  equal(obj.foo, 'RUN', 'obj.foo after unwatch');
+  assert.equal(obj.foo, 'RUN', 'obj.foo after unwatch');
 });

--- a/packages/ember-metal/tests/watching/watch_test.js
+++ b/packages/ember-metal/tests/watching/watch_test.js
@@ -15,7 +15,7 @@ import { testBoth } from 'internal-test-helpers';
 let willCount, didCount, willKeys, didKeys, originalLookup;
 
 QUnit.module('watch', {
-  setup() {
+  beforeEach() {
     willCount = didCount = 0;
     willKeys = [];
     didKeys = [];
@@ -24,7 +24,7 @@ QUnit.module('watch', {
     context.lookup = {};
   },
 
-  teardown() {
+  afterEach() {
     context.lookup = originalLookup;
   }
 });
@@ -40,7 +40,7 @@ function addListeners(obj, keyPath) {
   });
 }
 
-testBoth('watching a computed property', function(get, set) {
+testBoth('watching a computed property', function(get, set, assert) {
   let obj = {};
   defineProperty(obj, 'foo', computed({
     get() {
@@ -57,57 +57,57 @@ testBoth('watching a computed property', function(get, set) {
 
   watch(obj, 'foo');
   set(obj, 'foo', 'bar');
-  equal(willCount, 1, 'should have invoked willCount');
-  equal(didCount, 1, 'should have invoked didCount');
+  assert.equal(willCount, 1, 'should have invoked willCount');
+  assert.equal(didCount, 1, 'should have invoked didCount');
 });
 
-testBoth('watching a regular defined property', function(get, set) {
+testBoth('watching a regular defined property', function(get, set, assert) {
   let obj = { foo: 'baz' };
   addListeners(obj, 'foo');
 
   watch(obj, 'foo');
-  equal(get(obj, 'foo'), 'baz', 'should have original prop');
+  assert.equal(get(obj, 'foo'), 'baz', 'should have original prop');
 
   set(obj, 'foo', 'bar');
-  equal(willCount, 1, 'should have invoked willCount');
-  equal(didCount, 1, 'should have invoked didCount');
+  assert.equal(willCount, 1, 'should have invoked willCount');
+  assert.equal(didCount, 1, 'should have invoked didCount');
 
-  equal(get(obj, 'foo'), 'bar', 'should get new value');
-  equal(obj.foo, 'bar', 'property should be accessible on obj');
+  assert.equal(get(obj, 'foo'), 'bar', 'should get new value');
+  assert.equal(obj.foo, 'bar', 'property should be accessible on obj');
 });
 
-testBoth('watching a regular undefined property', function(get, set) {
+testBoth('watching a regular undefined property', function(get, set, assert) {
   let obj = { };
   addListeners(obj, 'foo');
 
   watch(obj, 'foo');
 
-  equal('foo' in obj, false, 'precond undefined');
+  assert.equal('foo' in obj, false, 'precond undefined');
 
   set(obj, 'foo', 'bar');
 
-  equal(willCount, 1, 'should have invoked willCount');
-  equal(didCount, 1, 'should have invoked didCount');
+  assert.equal(willCount, 1, 'should have invoked willCount');
+  assert.equal(didCount, 1, 'should have invoked didCount');
 
-  equal(get(obj, 'foo'), 'bar', 'should get new value');
-  equal(obj.foo, 'bar', 'property should be accessible on obj');
+  assert.equal(get(obj, 'foo'), 'bar', 'should get new value');
+  assert.equal(obj.foo, 'bar', 'property should be accessible on obj');
 });
 
-testBoth('watches should inherit', function(get, set) {
+testBoth('watches should inherit', function(get, set, assert) {
   let obj = { foo: 'baz' };
   let objB = Object.create(obj);
 
   addListeners(obj, 'foo');
   watch(obj, 'foo');
-  equal(get(obj, 'foo'), 'baz', 'should have original prop');
+  assert.equal(get(obj, 'foo'), 'baz', 'should have original prop');
 
   set(obj, 'foo', 'bar');
   set(objB, 'foo', 'baz');
-  equal(willCount, 2, 'should have invoked willCount once only');
-  equal(didCount, 2, 'should have invoked didCount once only');
+  assert.equal(willCount, 2, 'should have invoked willCount once only');
+  assert.equal(didCount, 2, 'should have invoked didCount once only');
 });
 
-QUnit.test('watching an object THEN defining it should work also', function() {
+QUnit.test('watching an object THEN defining it should work also', function(assert) {
   let obj = {};
   addListeners(obj, 'foo');
 
@@ -116,12 +116,12 @@ QUnit.test('watching an object THEN defining it should work also', function() {
   defineProperty(obj, 'foo');
   set(obj, 'foo', 'bar');
 
-  equal(get(obj, 'foo'), 'bar', 'should have set');
-  equal(willCount, 1, 'should have invoked willChange once');
-  equal(didCount, 1, 'should have invoked didChange once');
+  assert.equal(get(obj, 'foo'), 'bar', 'should have set');
+  assert.equal(willCount, 1, 'should have invoked willChange once');
+  assert.equal(didCount, 1, 'should have invoked didChange once');
 });
 
-QUnit.test('watching a chain then defining the property', function () {
+QUnit.test('watching a chain then defining the property', function(assert) {
   let obj = {};
   let foo = { bar: 'bar' };
   addListeners(obj, 'foo.bar');
@@ -132,13 +132,13 @@ QUnit.test('watching a chain then defining the property', function () {
   defineProperty(obj, 'foo', undefined, foo);
   set(foo, 'bar', 'baz');
 
-  deepEqual(willKeys, ['foo.bar', 'bar'], 'should have invoked willChange with bar, foo.bar');
-  deepEqual(didKeys, ['foo.bar', 'bar'], 'should have invoked didChange with bar, foo.bar');
-  equal(willCount, 2, 'should have invoked willChange twice');
-  equal(didCount, 2, 'should have invoked didChange twice');
+  assert.deepEqual(willKeys, ['foo.bar', 'bar'], 'should have invoked willChange with bar, foo.bar');
+  assert.deepEqual(didKeys, ['foo.bar', 'bar'], 'should have invoked didChange with bar, foo.bar');
+  assert.equal(willCount, 2, 'should have invoked willChange twice');
+  assert.equal(didCount, 2, 'should have invoked didChange twice');
 });
 
-QUnit.test('watching a chain then defining the nested property', function () {
+QUnit.test('watching a chain then defining the nested property', function(assert) {
   let bar = {};
   let obj = { foo: bar };
   let baz = { baz: 'baz' };
@@ -150,26 +150,26 @@ QUnit.test('watching a chain then defining the nested property', function () {
   defineProperty(bar, 'bar', undefined, baz);
   set(baz, 'baz', 'BOO');
 
-  deepEqual(willKeys, ['foo.bar.baz', 'baz'], 'should have invoked willChange with bar, foo.bar');
-  deepEqual(didKeys, ['foo.bar.baz', 'baz'], 'should have invoked didChange with bar, foo.bar');
-  equal(willCount, 2, 'should have invoked willChange twice');
-  equal(didCount, 2, 'should have invoked didChange twice');
+  assert.deepEqual(willKeys, ['foo.bar.baz', 'baz'], 'should have invoked willChange with bar, foo.bar');
+  assert.deepEqual(didKeys, ['foo.bar.baz', 'baz'], 'should have invoked didChange with bar, foo.bar');
+  assert.equal(willCount, 2, 'should have invoked willChange twice');
+  assert.equal(didCount, 2, 'should have invoked didChange twice');
 });
 
-testBoth('watching an object value then unwatching should restore old value', function(get) {
+testBoth('watching an object value then unwatching should restore old value', function(get, set, assert) {
   let obj = { foo: { bar: { baz: { biff: 'BIFF' } } } };
   addListeners(obj, 'foo.bar.baz.biff');
 
   watch(obj, 'foo.bar.baz.biff');
 
   let foo = get(obj, 'foo');
-  equal(get(get(get(foo, 'bar'), 'baz'), 'biff'), 'BIFF', 'biff should exist');
+  assert.equal(get(get(get(foo, 'bar'), 'baz'), 'biff'), 'BIFF', 'biff should exist');
 
   unwatch(obj, 'foo.bar.baz.biff');
-  equal(get(get(get(foo, 'bar'), 'baz'), 'biff'), 'BIFF', 'biff should exist');
+  assert.equal(get(get(get(foo, 'bar'), 'baz'), 'biff'), 'BIFF', 'biff should exist');
 });
 
-QUnit.test('when watching another object, destroy should remove chain watchers from the other object', function() {
+QUnit.test('when watching another object, destroy should remove chain watchers from the other object', function(assert) {
   let objA = {};
   let objB = { foo: 'bar' };
   objA.b = objB;
@@ -180,48 +180,48 @@ QUnit.test('when watching another object, destroy should remove chain watchers f
   let meta_objB = meta(objB);
   let chainNode = meta(objA).readableChains()._chains.b._chains.foo;
 
-  equal(meta_objB.peekWatching('foo'), 1, 'should be watching foo');
-  equal(meta_objB.readableChainWatchers().has('foo', chainNode), true, 'should have chain watcher');
+  assert.equal(meta_objB.peekWatching('foo'), 1, 'should be watching foo');
+  assert.equal(meta_objB.readableChainWatchers().has('foo', chainNode), true, 'should have chain watcher');
 
   deleteMeta(objA);
 
-  equal(meta_objB.peekWatching('foo'), 0, 'should not be watching foo');
-  equal(meta_objB.readableChainWatchers().has('foo', chainNode), false, 'should not have chain watcher');
+  assert.equal(meta_objB.peekWatching('foo'), 0, 'should not be watching foo');
+  assert.equal(meta_objB.readableChainWatchers().has('foo', chainNode), false, 'should not have chain watcher');
 });
 
 // TESTS for length property
 
-testBoth('watching "length" property on an object', function(get, set) {
+testBoth('watching "length" property on an object', function(get, set, assert) {
   let obj = { length: '26.2 miles' };
   addListeners(obj, 'length');
 
   watch(obj, 'length');
-  equal(get(obj, 'length'), '26.2 miles', 'should have original prop');
+  assert.equal(get(obj, 'length'), '26.2 miles', 'should have original prop');
 
   set(obj, 'length', '10k');
-  equal(willCount, 1, 'should have invoked willCount');
-  equal(didCount, 1, 'should have invoked didCount');
+  assert.equal(willCount, 1, 'should have invoked willCount');
+  assert.equal(didCount, 1, 'should have invoked didCount');
 
-  equal(get(obj, 'length'), '10k', 'should get new value');
-  equal(obj.length, '10k', 'property should be accessible on obj');
+  assert.equal(get(obj, 'length'), '10k', 'should get new value');
+  assert.equal(obj.length, '10k', 'property should be accessible on obj');
 });
 
-testBoth('watching "length" property on an array', function(get, set) {
+testBoth('watching "length" property on an array', function(get, set, assert) {
   let arr = [];
   addListeners(arr, 'length');
 
   watch(arr, 'length');
-  equal(get(arr, 'length'), 0, 'should have original prop');
+  assert.equal(get(arr, 'length'), 0, 'should have original prop');
 
   set(arr, 'length', '10');
-  equal(willCount, 1, 'should NOT have invoked willCount');
-  equal(didCount, 1, 'should NOT have invoked didCount');
+  assert.equal(willCount, 1, 'should NOT have invoked willCount');
+  assert.equal(didCount, 1, 'should NOT have invoked didCount');
 
-  equal(get(arr, 'length'), 10, 'should get new value');
-  equal(arr.length, 10, 'property should be accessible on arr');
+  assert.equal(get(arr, 'length'), 10, 'should get new value');
+  assert.equal(arr.length, 10, 'property should be accessible on arr');
 });
 
-testBoth('watch + ES5 getter', function(get) {
+testBoth('watch + ES5 getter', function(get, set, assert) {
   let parent = { b: 1 };
   let child = {
     get b() {
@@ -229,27 +229,27 @@ testBoth('watch + ES5 getter', function(get) {
     }
   };
 
-  equal(parent.b,  1, 'parent.b should be 1');
-  equal(child.b, 1, 'child.b should be 1');
-  equal(get(child, 'b'), 1, 'Ember.get(child, "b") should be 1');
+  assert.equal(parent.b,  1, 'parent.b should be 1');
+  assert.equal(child.b, 1, 'child.b should be 1');
+  assert.equal(get(child, 'b'), 1, 'Ember.get(child, "b") should be 1');
 
   watch(child, 'b');
 
-  equal(parent.b,  1, 'parent.b should be 1 (after watch)');
-  equal(child.b, 1, 'child.b should be 1  (after watch)');
+  assert.equal(parent.b,  1, 'parent.b should be 1 (after watch)');
+  assert.equal(child.b, 1, 'child.b should be 1  (after watch)');
 
-  equal(get(child, 'b'), 1, 'Ember.get(child, "b") should be 1 (after watch)');
+  assert.equal(get(child, 'b'), 1, 'Ember.get(child, "b") should be 1 (after watch)');
 });
 
-testBoth('watch + Ember.set + no-descriptor', function(get, set) {
+testBoth('watch + Ember.set + no-descriptor', function(get, set, assert) {
   let child = { };
 
-  equal(child.b, undefined, 'child.b ');
-  equal(get(child, 'b'), undefined, 'Ember.get(child, "b")');
+  assert.equal(child.b, undefined, 'child.b ');
+  assert.equal(get(child, 'b'), undefined, 'Ember.get(child, "b")');
 
   watch(child, 'b');
   set(child, 'b', 1);
 
-  equal(child.b, 1, 'child.b (after watch)');
-  equal(get(child, 'b'), 1, 'Ember.get(child, "b") (after watch)');
+  assert.equal(child.b, 1, 'child.b (after watch)');
+  assert.equal(get(child, 'b'), 1, 'Ember.get(child, "b") (after watch)');
 });

--- a/packages/ember-runtime/tests/computed/computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/computed_macros_test.js
@@ -27,7 +27,7 @@ import { A as emberA } from '../../system/native_array';
 
 QUnit.module('CP macros');
 
-testBoth('Ember.computed.empty', function (get, set) {
+testBoth('Ember.computed.empty', function (get, set, assert) {
   let obj = EmberObject.extend({
     bestLannister: null,
     lannisters: null,
@@ -48,7 +48,7 @@ testBoth('Ember.computed.empty', function (get, set) {
   assert.equal(get(obj, 'noLannistersKnown'), false, 'empty respects array mutations');
 });
 
-testBoth('Ember.computed.notEmpty', function(get, set) {
+testBoth('Ember.computed.notEmpty', function(get, set, assert) {
   let obj = EmberObject.extend({
     bestLannister: null,
     lannisters: null,
@@ -69,7 +69,7 @@ testBoth('Ember.computed.notEmpty', function(get, set) {
   assert.equal(get(obj, 'LannistersKnown'), true, 'empty respects array mutations');
 });
 
-testBoth('computed.not', function(get) {
+testBoth('computed.not', function(get, set, assert) {
   let obj = { foo: true };
   defineProperty(obj, 'notFoo', not('foo'));
   assert.equal(get(obj, 'notFoo'), false);
@@ -79,7 +79,7 @@ testBoth('computed.not', function(get) {
   assert.equal(get(obj, 'notFoo'), false);
 });
 
-testBoth('computed.empty', function(get, set) {
+testBoth('computed.empty', function(get, set, assert) {
   let obj = { foo: [], bar: undefined, baz: null, quz: '' };
   defineProperty(obj, 'fooEmpty', empty('foo'));
   defineProperty(obj, 'barEmpty', empty('bar'));
@@ -96,7 +96,7 @@ testBoth('computed.empty', function(get, set) {
   assert.equal(get(obj, 'quzEmpty'), false);
 });
 
-testBoth('computed.bool', function(get) {
+testBoth('computed.bool', function(get, set, assert) {
   let obj = { foo() {}, bar: 'asdf', baz: null, quz: false };
   defineProperty(obj, 'fooBool', bool('foo'));
   defineProperty(obj, 'barBool', bool('bar'));
@@ -108,7 +108,7 @@ testBoth('computed.bool', function(get) {
   assert.equal(get(obj, 'quzBool'), false);
 });
 
-testBoth('computed.alias', function(get, set) {
+testBoth('computed.alias', function(get, set, assert) {
   let obj = { bar: 'asdf', baz: null, quz: false };
   defineProperty(obj, 'bay', computed(function() {
     return 'apple';
@@ -137,7 +137,7 @@ testBoth('computed.alias', function(get, set) {
   assert.equal(get(obj, 'quz'), null);
 });
 
-testBoth('computed.alias set', function(get, set) {
+testBoth('computed.alias set', function(get, set, assert) {
   let obj = {};
   let constantValue = 'always `a`';
 
@@ -156,7 +156,7 @@ testBoth('computed.alias set', function(get, set) {
   assert.equal(get(obj, 'aliased'), constantValue);
 });
 
-testBoth('computed.match', function(get, set) {
+testBoth('computed.match', function(get, set, assert) {
   let obj = { name: 'Paul' };
   defineProperty(obj, 'isPaul', match('name', /Paul/));
 
@@ -167,7 +167,7 @@ testBoth('computed.match', function(get, set) {
   assert.equal(get(obj, 'isPaul'), false, 'is not Paul anymore');
 });
 
-testBoth('computed.notEmpty', function(get, set) {
+testBoth('computed.notEmpty', function(get, set, assert) {
   let obj = { items: [1] };
   defineProperty(obj, 'hasItems', notEmpty('items'));
 
@@ -178,7 +178,7 @@ testBoth('computed.notEmpty', function(get, set) {
   assert.equal(get(obj, 'hasItems'), false, 'is empty');
 });
 
-testBoth('computed.equal', function(get, set) {
+testBoth('computed.equal', function(get, set, assert) {
   let obj = { name: 'Paul' };
   defineProperty(obj, 'isPaul', computedEqual('name', 'Paul'));
 
@@ -189,7 +189,7 @@ testBoth('computed.equal', function(get, set) {
   assert.equal(get(obj, 'isPaul'), false, 'is not Paul anymore');
 });
 
-testBoth('computed.gt', function(get, set) {
+testBoth('computed.gt', function(get, set, assert) {
   let obj = { number: 2 };
   defineProperty(obj, 'isGreaterThenOne', gt('number', 1));
 
@@ -204,7 +204,7 @@ testBoth('computed.gt', function(get, set) {
   assert.equal(get(obj, 'isGreaterThenOne'), false, 'is not gt');
 });
 
-testBoth('computed.gte', function(get, set) {
+testBoth('computed.gte', function(get, set, assert) {
   let obj = { number: 2 };
   defineProperty(obj, 'isGreaterOrEqualThenOne', gte('number', 1));
 
@@ -219,7 +219,7 @@ testBoth('computed.gte', function(get, set) {
   assert.equal(get(obj, 'isGreaterOrEqualThenOne'), false, 'is not gte');
 });
 
-testBoth('computed.lt', function(get, set) {
+testBoth('computed.lt', function(get, set, assert) {
   let obj = { number: 0 };
   defineProperty(obj, 'isLesserThenOne', lt('number', 1));
 
@@ -234,7 +234,7 @@ testBoth('computed.lt', function(get, set) {
   assert.equal(get(obj, 'isLesserThenOne'), false, 'is not lt');
 });
 
-testBoth('computed.lte', function(get, set) {
+testBoth('computed.lte', function(get, set, assert) {
   let obj = { number: 0 };
   defineProperty(obj, 'isLesserOrEqualThenOne', lte('number', 1));
 
@@ -249,7 +249,7 @@ testBoth('computed.lte', function(get, set) {
   assert.equal(get(obj, 'isLesserOrEqualThenOne'), false, 'is not lte');
 });
 
-testBoth('computed.and two properties', function(get, set) {
+testBoth('computed.and two properties', function(get, set, assert) {
   let obj = { one: true, two: true };
   defineProperty(obj, 'oneAndTwo', and('one', 'two'));
 
@@ -270,7 +270,7 @@ testBoth('computed.and two properties', function(get, set) {
   assert.equal(get(obj, 'oneAndTwo'), 2, 'returns truthy value as in &&');
 });
 
-testBoth('computed.and three properties', function(get, set) {
+testBoth('computed.and three properties', function(get, set, assert) {
   let obj = { one: true, two: true, three: true };
   defineProperty(obj, 'oneTwoThree', and('one', 'two', 'three'));
 
@@ -287,7 +287,7 @@ testBoth('computed.and three properties', function(get, set) {
   assert.equal(get(obj, 'oneTwoThree'), 3, 'returns truthy value as in &&');
 });
 
-testBoth('computed.and expand properties', function(get, set) {
+testBoth('computed.and expand properties', function(get, set, assert) {
   let obj = { one: true, two: true, three: true };
   defineProperty(obj, 'oneTwoThree', and('{one,two,three}'));
 
@@ -304,7 +304,7 @@ testBoth('computed.and expand properties', function(get, set) {
   assert.equal(get(obj, 'oneTwoThree'), 3, 'returns truthy value as in &&');
 });
 
-testBoth('computed.or two properties', function(get, set) {
+testBoth('computed.or two properties', function(get, set, assert) {
   let obj = { one: true, two: true };
   defineProperty(obj, 'oneOrTwo', or('one', 'two'));
 
@@ -331,7 +331,7 @@ testBoth('computed.or two properties', function(get, set) {
   assert.equal(get(obj, 'oneOrTwo'), 1, 'returns truthy value as in ||');
 });
 
-testBoth('computed.or three properties', function(get, set) {
+testBoth('computed.or three properties', function(get, set, assert) {
   let obj = { one: true, two: true, three: true };
   defineProperty(obj, 'oneTwoThree', or('one', 'two', 'three'));
 
@@ -362,7 +362,7 @@ testBoth('computed.or three properties', function(get, set) {
   assert.equal(get(obj, 'oneTwoThree'), 1, 'returns truthy value as in ||');
 });
 
-testBoth('computed.or expand properties', function(get, set) {
+testBoth('computed.or expand properties', function(get, set, assert) {
   let obj = { one: true, two: true, three: true };
   defineProperty(obj, 'oneTwoThree', or('{one,two,three}'));
 
@@ -404,7 +404,7 @@ testBoth('computed.or and computed.and warn about dependent keys with spaces', f
   }, /Dependent keys passed to Ember\.computed\.and\(\) can't have spaces\./);
 });
 
-testBoth('computed.oneWay', function(get, set) {
+testBoth('computed.oneWay', function(get, set, assert) {
   let obj = {
     firstName: 'Teddy',
     lastName: 'Zeenny'
@@ -428,7 +428,7 @@ testBoth('computed.oneWay', function(get, set) {
   assert.equal(get(obj, 'nickName'), 'TeddyBear');
 });
 
-testBoth('computed.readOnly', function(get, set) {
+testBoth('computed.readOnly', function(get, set, assert) {
   let obj = {
     firstName: 'Teddy',
     lastName: 'Zeenny'
@@ -454,7 +454,7 @@ testBoth('computed.readOnly', function(get, set) {
   assert.equal(get(obj, 'nickName'), 'TEDDDDDDDDYYY');
 });
 
-testBoth('computed.deprecatingAlias', function(get, set) {
+testBoth('computed.deprecatingAlias', function(get, set, assert) {
   let obj = { bar: 'asdf', baz: null, quz: false };
   defineProperty(obj, 'bay', computed(function() {
     return 'apple';

--- a/packages/ember-runtime/tests/computed/computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/computed_macros_test.js
@@ -38,14 +38,14 @@ testBoth('Ember.computed.empty', function (get, set) {
     lannisters: emberA()
   });
 
-  equal(get(obj, 'bestLannisterUnspecified'), true, 'bestLannister initially empty');
-  equal(get(obj, 'noLannistersKnown'), true, 'lannisters initially empty');
+  assert.equal(get(obj, 'bestLannisterUnspecified'), true, 'bestLannister initially empty');
+  assert.equal(get(obj, 'noLannistersKnown'), true, 'lannisters initially empty');
 
   get(obj, 'lannisters').pushObject('Tyrion');
   set(obj, 'bestLannister', 'Tyrion');
 
-  equal(get(obj, 'bestLannisterUnspecified'), false, 'empty respects strings');
-  equal(get(obj, 'noLannistersKnown'), false, 'empty respects array mutations');
+  assert.equal(get(obj, 'bestLannisterUnspecified'), false, 'empty respects strings');
+  assert.equal(get(obj, 'noLannistersKnown'), false, 'empty respects array mutations');
 });
 
 testBoth('Ember.computed.notEmpty', function(get, set) {
@@ -59,24 +59,24 @@ testBoth('Ember.computed.notEmpty', function(get, set) {
     lannisters: emberA()
   });
 
-  equal(get(obj, 'bestLannisterSpecified'), false, 'bestLannister initially empty');
-  equal(get(obj, 'LannistersKnown'), false, 'lannisters initially empty');
+  assert.equal(get(obj, 'bestLannisterSpecified'), false, 'bestLannister initially empty');
+  assert.equal(get(obj, 'LannistersKnown'), false, 'lannisters initially empty');
 
   get(obj, 'lannisters').pushObject('Tyrion');
   set(obj, 'bestLannister', 'Tyrion');
 
-  equal(get(obj, 'bestLannisterSpecified'), true, 'empty respects strings');
-  equal(get(obj, 'LannistersKnown'), true, 'empty respects array mutations');
+  assert.equal(get(obj, 'bestLannisterSpecified'), true, 'empty respects strings');
+  assert.equal(get(obj, 'LannistersKnown'), true, 'empty respects array mutations');
 });
 
 testBoth('computed.not', function(get) {
   let obj = { foo: true };
   defineProperty(obj, 'notFoo', not('foo'));
-  equal(get(obj, 'notFoo'), false);
+  assert.equal(get(obj, 'notFoo'), false);
 
   obj = { foo: { bar: true } };
   defineProperty(obj, 'notFoo', not('foo.bar'));
-  equal(get(obj, 'notFoo'), false);
+  assert.equal(get(obj, 'notFoo'), false);
 });
 
 testBoth('computed.empty', function(get, set) {
@@ -86,14 +86,14 @@ testBoth('computed.empty', function(get, set) {
   defineProperty(obj, 'bazEmpty', empty('baz'));
   defineProperty(obj, 'quzEmpty', empty('quz'));
 
-  equal(get(obj, 'fooEmpty'), true);
+  assert.equal(get(obj, 'fooEmpty'), true);
   set(obj, 'foo', [1]);
-  equal(get(obj, 'fooEmpty'), false);
-  equal(get(obj, 'barEmpty'), true);
-  equal(get(obj, 'bazEmpty'), true);
-  equal(get(obj, 'quzEmpty'), true);
+  assert.equal(get(obj, 'fooEmpty'), false);
+  assert.equal(get(obj, 'barEmpty'), true);
+  assert.equal(get(obj, 'bazEmpty'), true);
+  assert.equal(get(obj, 'quzEmpty'), true);
   set(obj, 'quz', 'asdf');
-  equal(get(obj, 'quzEmpty'), false);
+  assert.equal(get(obj, 'quzEmpty'), false);
 });
 
 testBoth('computed.bool', function(get) {
@@ -102,10 +102,10 @@ testBoth('computed.bool', function(get) {
   defineProperty(obj, 'barBool', bool('bar'));
   defineProperty(obj, 'bazBool', bool('baz'));
   defineProperty(obj, 'quzBool', bool('quz'));
-  equal(get(obj, 'fooBool'), true);
-  equal(get(obj, 'barBool'), true);
-  equal(get(obj, 'bazBool'), false);
-  equal(get(obj, 'quzBool'), false);
+  assert.equal(get(obj, 'fooBool'), true);
+  assert.equal(get(obj, 'barBool'), true);
+  assert.equal(get(obj, 'bazBool'), false);
+  assert.equal(get(obj, 'quzBool'), false);
 });
 
 testBoth('computed.alias', function(get, set) {
@@ -119,22 +119,22 @@ testBoth('computed.alias', function(get, set) {
   defineProperty(obj, 'quzAlias', alias('quz'));
   defineProperty(obj, 'bayAlias', alias('bay'));
 
-  equal(get(obj, 'barAlias'), 'asdf');
-  equal(get(obj, 'bazAlias'), null);
-  equal(get(obj, 'quzAlias'), false);
-  equal(get(obj, 'bayAlias'), 'apple');
+  assert.equal(get(obj, 'barAlias'), 'asdf');
+  assert.equal(get(obj, 'bazAlias'), null);
+  assert.equal(get(obj, 'quzAlias'), false);
+  assert.equal(get(obj, 'bayAlias'), 'apple');
 
   set(obj, 'barAlias', 'newBar');
   set(obj, 'bazAlias', 'newBaz');
   set(obj, 'quzAlias', null);
 
-  equal(get(obj, 'barAlias'), 'newBar');
-  equal(get(obj, 'bazAlias'), 'newBaz');
-  equal(get(obj, 'quzAlias'), null);
+  assert.equal(get(obj, 'barAlias'), 'newBar');
+  assert.equal(get(obj, 'bazAlias'), 'newBaz');
+  assert.equal(get(obj, 'quzAlias'), null);
 
-  equal(get(obj, 'bar'), 'newBar');
-  equal(get(obj, 'baz'), 'newBaz');
-  equal(get(obj, 'quz'), null);
+  assert.equal(get(obj, 'bar'), 'newBar');
+  assert.equal(get(obj, 'baz'), 'newBaz');
+  assert.equal(get(obj, 'quz'), null);
 });
 
 testBoth('computed.alias set', function(get, set) {
@@ -147,250 +147,250 @@ testBoth('computed.alias set', function(get, set) {
   }));
   defineProperty(obj, 'aliased', alias('original'));
 
-  equal(get(obj, 'original'), constantValue);
-  equal(get(obj, 'aliased'), constantValue);
+  assert.equal(get(obj, 'original'), constantValue);
+  assert.equal(get(obj, 'aliased'), constantValue);
 
   set(obj, 'aliased', 'should not set to this value');
 
-  equal(get(obj, 'original'), constantValue);
-  equal(get(obj, 'aliased'), constantValue);
+  assert.equal(get(obj, 'original'), constantValue);
+  assert.equal(get(obj, 'aliased'), constantValue);
 });
 
 testBoth('computed.match', function(get, set) {
   let obj = { name: 'Paul' };
   defineProperty(obj, 'isPaul', match('name', /Paul/));
 
-  equal(get(obj, 'isPaul'), true, 'is Paul');
+  assert.equal(get(obj, 'isPaul'), true, 'is Paul');
 
   set(obj, 'name', 'Pierre');
 
-  equal(get(obj, 'isPaul'), false, 'is not Paul anymore');
+  assert.equal(get(obj, 'isPaul'), false, 'is not Paul anymore');
 });
 
 testBoth('computed.notEmpty', function(get, set) {
   let obj = { items: [1] };
   defineProperty(obj, 'hasItems', notEmpty('items'));
 
-  equal(get(obj, 'hasItems'), true, 'is not empty');
+  assert.equal(get(obj, 'hasItems'), true, 'is not empty');
 
   set(obj, 'items', []);
 
-  equal(get(obj, 'hasItems'), false, 'is empty');
+  assert.equal(get(obj, 'hasItems'), false, 'is empty');
 });
 
 testBoth('computed.equal', function(get, set) {
   let obj = { name: 'Paul' };
   defineProperty(obj, 'isPaul', computedEqual('name', 'Paul'));
 
-  equal(get(obj, 'isPaul'), true, 'is Paul');
+  assert.equal(get(obj, 'isPaul'), true, 'is Paul');
 
   set(obj, 'name', 'Pierre');
 
-  equal(get(obj, 'isPaul'), false, 'is not Paul anymore');
+  assert.equal(get(obj, 'isPaul'), false, 'is not Paul anymore');
 });
 
 testBoth('computed.gt', function(get, set) {
   let obj = { number: 2 };
   defineProperty(obj, 'isGreaterThenOne', gt('number', 1));
 
-  equal(get(obj, 'isGreaterThenOne'), true, 'is gt');
+  assert.equal(get(obj, 'isGreaterThenOne'), true, 'is gt');
 
   set(obj, 'number', 1);
 
-  equal(get(obj, 'isGreaterThenOne'), false, 'is not gt');
+  assert.equal(get(obj, 'isGreaterThenOne'), false, 'is not gt');
 
   set(obj, 'number', 0);
 
-  equal(get(obj, 'isGreaterThenOne'), false, 'is not gt');
+  assert.equal(get(obj, 'isGreaterThenOne'), false, 'is not gt');
 });
 
 testBoth('computed.gte', function(get, set) {
   let obj = { number: 2 };
   defineProperty(obj, 'isGreaterOrEqualThenOne', gte('number', 1));
 
-  equal(get(obj, 'isGreaterOrEqualThenOne'), true, 'is gte');
+  assert.equal(get(obj, 'isGreaterOrEqualThenOne'), true, 'is gte');
 
   set(obj, 'number', 1);
 
-  equal(get(obj, 'isGreaterOrEqualThenOne'), true, 'is gte');
+  assert.equal(get(obj, 'isGreaterOrEqualThenOne'), true, 'is gte');
 
   set(obj, 'number', 0);
 
-  equal(get(obj, 'isGreaterOrEqualThenOne'), false, 'is not gte');
+  assert.equal(get(obj, 'isGreaterOrEqualThenOne'), false, 'is not gte');
 });
 
 testBoth('computed.lt', function(get, set) {
   let obj = { number: 0 };
   defineProperty(obj, 'isLesserThenOne', lt('number', 1));
 
-  equal(get(obj, 'isLesserThenOne'), true, 'is lt');
+  assert.equal(get(obj, 'isLesserThenOne'), true, 'is lt');
 
   set(obj, 'number', 1);
 
-  equal(get(obj, 'isLesserThenOne'), false, 'is not lt');
+  assert.equal(get(obj, 'isLesserThenOne'), false, 'is not lt');
 
   set(obj, 'number', 2);
 
-  equal(get(obj, 'isLesserThenOne'), false, 'is not lt');
+  assert.equal(get(obj, 'isLesserThenOne'), false, 'is not lt');
 });
 
 testBoth('computed.lte', function(get, set) {
   let obj = { number: 0 };
   defineProperty(obj, 'isLesserOrEqualThenOne', lte('number', 1));
 
-  equal(get(obj, 'isLesserOrEqualThenOne'), true, 'is lte');
+  assert.equal(get(obj, 'isLesserOrEqualThenOne'), true, 'is lte');
 
   set(obj, 'number', 1);
 
-  equal(get(obj, 'isLesserOrEqualThenOne'), true, 'is lte');
+  assert.equal(get(obj, 'isLesserOrEqualThenOne'), true, 'is lte');
 
   set(obj, 'number', 2);
 
-  equal(get(obj, 'isLesserOrEqualThenOne'), false, 'is not lte');
+  assert.equal(get(obj, 'isLesserOrEqualThenOne'), false, 'is not lte');
 });
 
 testBoth('computed.and two properties', function(get, set) {
   let obj = { one: true, two: true };
   defineProperty(obj, 'oneAndTwo', and('one', 'two'));
 
-  equal(get(obj, 'oneAndTwo'), true, 'one and two');
+  assert.equal(get(obj, 'oneAndTwo'), true, 'one and two');
 
   set(obj, 'one', false);
 
-  equal(get(obj, 'oneAndTwo'), false, 'one and not two');
+  assert.equal(get(obj, 'oneAndTwo'), false, 'one and not two');
 
   set(obj, 'one', null);
   set(obj, 'two', 'Yes');
 
-  equal(get(obj, 'oneAndTwo'), null, 'returns falsy value as in &&');
+  assert.equal(get(obj, 'oneAndTwo'), null, 'returns falsy value as in &&');
 
   set(obj, 'one', true);
   set(obj, 'two', 2);
 
-  equal(get(obj, 'oneAndTwo'), 2, 'returns truthy value as in &&');
+  assert.equal(get(obj, 'oneAndTwo'), 2, 'returns truthy value as in &&');
 });
 
 testBoth('computed.and three properties', function(get, set) {
   let obj = { one: true, two: true, three: true };
   defineProperty(obj, 'oneTwoThree', and('one', 'two', 'three'));
 
-  equal(get(obj, 'oneTwoThree'), true, 'one and two and three');
+  assert.equal(get(obj, 'oneTwoThree'), true, 'one and two and three');
 
   set(obj, 'one', false);
 
-  equal(get(obj, 'oneTwoThree'), false, 'one and not two and not three');
+  assert.equal(get(obj, 'oneTwoThree'), false, 'one and not two and not three');
 
   set(obj, 'one', true);
   set(obj, 'two', 2);
   set(obj, 'three', 3);
 
-  equal(get(obj, 'oneTwoThree'), 3, 'returns truthy value as in &&');
+  assert.equal(get(obj, 'oneTwoThree'), 3, 'returns truthy value as in &&');
 });
 
 testBoth('computed.and expand properties', function(get, set) {
   let obj = { one: true, two: true, three: true };
   defineProperty(obj, 'oneTwoThree', and('{one,two,three}'));
 
-  equal(get(obj, 'oneTwoThree'), true, 'one and two and three');
+  assert.equal(get(obj, 'oneTwoThree'), true, 'one and two and three');
 
   set(obj, 'one', false);
 
-  equal(get(obj, 'oneTwoThree'), false, 'one and not two and not three');
+  assert.equal(get(obj, 'oneTwoThree'), false, 'one and not two and not three');
 
   set(obj, 'one', true);
   set(obj, 'two', 2);
   set(obj, 'three', 3);
 
-  equal(get(obj, 'oneTwoThree'), 3, 'returns truthy value as in &&');
+  assert.equal(get(obj, 'oneTwoThree'), 3, 'returns truthy value as in &&');
 });
 
 testBoth('computed.or two properties', function(get, set) {
   let obj = { one: true, two: true };
   defineProperty(obj, 'oneOrTwo', or('one', 'two'));
 
-  equal(get(obj, 'oneOrTwo'), true, 'one or two');
+  assert.equal(get(obj, 'oneOrTwo'), true, 'one or two');
 
   set(obj, 'one', false);
 
-  equal(get(obj, 'oneOrTwo'), true, 'one or two');
+  assert.equal(get(obj, 'oneOrTwo'), true, 'one or two');
 
   set(obj, 'two', false);
 
-  equal(get(obj, 'oneOrTwo'), false, 'nor one nor two');
+  assert.equal(get(obj, 'oneOrTwo'), false, 'nor one nor two');
 
   set(obj, 'two', null);
 
-  equal(get(obj, 'oneOrTwo'), null, 'returns last falsy value as in ||');
+  assert.equal(get(obj, 'oneOrTwo'), null, 'returns last falsy value as in ||');
 
   set(obj, 'two', true);
 
-  equal(get(obj, 'oneOrTwo'), true, 'one or two');
+  assert.equal(get(obj, 'oneOrTwo'), true, 'one or two');
 
   set(obj, 'one', 1);
 
-  equal(get(obj, 'oneOrTwo'), 1, 'returns truthy value as in ||');
+  assert.equal(get(obj, 'oneOrTwo'), 1, 'returns truthy value as in ||');
 });
 
 testBoth('computed.or three properties', function(get, set) {
   let obj = { one: true, two: true, three: true };
   defineProperty(obj, 'oneTwoThree', or('one', 'two', 'three'));
 
-  equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+  assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
 
   set(obj, 'one', false);
 
-  equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+  assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
 
   set(obj, 'two', false);
 
-  equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+  assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
 
   set(obj, 'three', false);
 
-  equal(get(obj, 'oneTwoThree'), false, 'one or two or three');
+  assert.equal(get(obj, 'oneTwoThree'), false, 'one or two or three');
 
   set(obj, 'three', null);
 
-  equal(get(obj, 'oneTwoThree'), null, 'returns last falsy value as in ||');
+  assert.equal(get(obj, 'oneTwoThree'), null, 'returns last falsy value as in ||');
 
   set(obj, 'two', true);
 
-  equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+  assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
 
   set(obj, 'one', 1);
 
-  equal(get(obj, 'oneTwoThree'), 1, 'returns truthy value as in ||');
+  assert.equal(get(obj, 'oneTwoThree'), 1, 'returns truthy value as in ||');
 });
 
 testBoth('computed.or expand properties', function(get, set) {
   let obj = { one: true, two: true, three: true };
   defineProperty(obj, 'oneTwoThree', or('{one,two,three}'));
 
-  equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+  assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
 
   set(obj, 'one', false);
 
-  equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+  assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
 
   set(obj, 'two', false);
 
-  equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+  assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
 
   set(obj, 'three', false);
 
-  equal(get(obj, 'oneTwoThree'), false, 'one or two or three');
+  assert.equal(get(obj, 'oneTwoThree'), false, 'one or two or three');
 
   set(obj, 'three', null);
 
-  equal(get(obj, 'oneTwoThree'), null, 'returns last falsy value as in ||');
+  assert.equal(get(obj, 'oneTwoThree'), null, 'returns last falsy value as in ||');
 
   set(obj, 'two', true);
 
-  equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+  assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
 
   set(obj, 'one', 1);
 
-  equal(get(obj, 'oneTwoThree'), 1, 'returns truthy value as in ||');
+  assert.equal(get(obj, 'oneTwoThree'), 1, 'returns truthy value as in ||');
 });
 
 testBoth('computed.or and computed.and warn about dependent keys with spaces', function() {
@@ -412,20 +412,20 @@ testBoth('computed.oneWay', function(get, set) {
 
   defineProperty(obj, 'nickName', oneWay('firstName'));
 
-  equal(get(obj, 'firstName'), 'Teddy');
-  equal(get(obj, 'lastName'), 'Zeenny');
-  equal(get(obj, 'nickName'), 'Teddy');
+  assert.equal(get(obj, 'firstName'), 'Teddy');
+  assert.equal(get(obj, 'lastName'), 'Zeenny');
+  assert.equal(get(obj, 'nickName'), 'Teddy');
 
   set(obj, 'nickName', 'TeddyBear');
 
-  equal(get(obj, 'firstName'), 'Teddy');
-  equal(get(obj, 'lastName'), 'Zeenny');
+  assert.equal(get(obj, 'firstName'), 'Teddy');
+  assert.equal(get(obj, 'lastName'), 'Zeenny');
 
-  equal(get(obj, 'nickName'), 'TeddyBear');
+  assert.equal(get(obj, 'nickName'), 'TeddyBear');
 
   set(obj, 'firstName', 'TEDDDDDDDDYYY');
 
-  equal(get(obj, 'nickName'), 'TeddyBear');
+  assert.equal(get(obj, 'nickName'), 'TeddyBear');
 });
 
 testBoth('computed.readOnly', function(get, set) {
@@ -436,22 +436,22 @@ testBoth('computed.readOnly', function(get, set) {
 
   defineProperty(obj, 'nickName', readOnly('firstName'));
 
-  equal(get(obj, 'firstName'), 'Teddy');
-  equal(get(obj, 'lastName'), 'Zeenny');
-  equal(get(obj, 'nickName'), 'Teddy');
+  assert.equal(get(obj, 'firstName'), 'Teddy');
+  assert.equal(get(obj, 'lastName'), 'Zeenny');
+  assert.equal(get(obj, 'nickName'), 'Teddy');
 
-  throws(function() {
+  assert.throws(function() {
     set(obj, 'nickName', 'TeddyBear');
   }, / /);
 
-  equal(get(obj, 'firstName'), 'Teddy');
-  equal(get(obj, 'lastName'), 'Zeenny');
+  assert.equal(get(obj, 'firstName'), 'Teddy');
+  assert.equal(get(obj, 'lastName'), 'Zeenny');
 
-  equal(get(obj, 'nickName'), 'Teddy');
+  assert.equal(get(obj, 'nickName'), 'Teddy');
 
   set(obj, 'firstName', 'TEDDDDDDDDYYY');
 
-  equal(get(obj, 'nickName'), 'TEDDDDDDDDYYY');
+  assert.equal(get(obj, 'nickName'), 'TEDDDDDDDDYYY');
 });
 
 testBoth('computed.deprecatingAlias', function(get, set) {
@@ -466,19 +466,19 @@ testBoth('computed.deprecatingAlias', function(get, set) {
   defineProperty(obj, 'bayAlias', deprecatingAlias('bay'));
 
   expectDeprecation(function() {
-    equal(get(obj, 'barAlias'), 'asdf');
+    assert.equal(get(obj, 'barAlias'), 'asdf');
   }, 'Usage of `barAlias` is deprecated, use `bar` instead.');
 
   expectDeprecation(function() {
-    equal(get(obj, 'bazAlias'), null);
+    assert.equal(get(obj, 'bazAlias'), null);
   }, 'Usage of `bazAlias` is deprecated, use `baz` instead.');
 
   expectDeprecation(function() {
-    equal(get(obj, 'quzAlias'), false);
+    assert.equal(get(obj, 'quzAlias'), false);
   }, 'Usage of `quzAlias` is deprecated, use `quz` instead.');
 
   expectDeprecation(function() {
-    equal(get(obj, 'bayAlias'), 'apple');
+    assert.equal(get(obj, 'bayAlias'), 'apple');
   }, 'Usage of `bayAlias` is deprecated, use `bay` instead.');
 
   expectDeprecation(function() {
@@ -494,11 +494,11 @@ testBoth('computed.deprecatingAlias', function(get, set) {
   }, 'Usage of `quzAlias` is deprecated, use `quz` instead.');
 
 
-  equal(get(obj, 'barAlias'), 'newBar');
-  equal(get(obj, 'bazAlias'), 'newBaz');
-  equal(get(obj, 'quzAlias'), null);
+  assert.equal(get(obj, 'barAlias'), 'newBar');
+  assert.equal(get(obj, 'bazAlias'), 'newBaz');
+  assert.equal(get(obj, 'quzAlias'), null);
 
-  equal(get(obj, 'bar'), 'newBar');
-  equal(get(obj, 'baz'), 'newBaz');
-  equal(get(obj, 'quz'), null);
+  assert.equal(get(obj, 'bar'), 'newBar');
+  assert.equal(get(obj, 'baz'), 'newBaz');
+  assert.equal(get(obj, 'quz'), null);
 });

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -33,7 +33,7 @@ import { removeAt } from '../../mixins/mutable_array';
 
 let obj;
 QUnit.module('map', {
-  setup() {
+  beforeEach() {
     obj = EmberObject.extend({
       mapped: map('array.@each.v', (item) => item.v),
       mappedObjects: map('arrayObjects.@each.v',  (item) => ({ name: item.v.name }))
@@ -52,30 +52,30 @@ QUnit.module('map', {
     });
   },
 
-  teardown() {
+  afterEach() {
     run(obj, 'destroy');
   }
 });
 
-QUnit.test('map is readOnly', function() {
+QUnit.test('map is readOnly', function(assert) {
   QUnit.throws(function() {
     obj.set('mapped', 1);
   }, /Cannot set read-only property "mapped" on object:/);
 });
 
-QUnit.test('it maps simple properties', function() {
-  deepEqual(obj.get('mapped'), [1, 3, 2, 1]);
+QUnit.test('it maps simple properties', function(assert) {
+  assert.deepEqual(obj.get('mapped'), [1, 3, 2, 1]);
 
   obj.get('array').pushObject({ v: 5 });
 
-  deepEqual(obj.get('mapped'), [1, 3, 2, 1, 5]);
+  assert.deepEqual(obj.get('mapped'), [1, 3, 2, 1, 5]);
 
   removeAt(obj.get('array'), 3);
 
-  deepEqual(obj.get('mapped'), [1, 3, 2, 5]);
+  assert.deepEqual(obj.get('mapped'), [1, 3, 2, 5]);
 });
 
-QUnit.test('it maps simple unshifted properties', function() {
+QUnit.test('it maps simple unshifted properties', function(assert) {
   let array = emberA();
 
   obj = EmberObject.extend({
@@ -90,13 +90,13 @@ QUnit.test('it maps simple unshifted properties', function() {
 
   array.popObject();
 
-  deepEqual(obj.get('mapped'), ['A', 'B'], 'properties unshifted in sequence are mapped correctly');
+  assert.deepEqual(obj.get('mapped'), ['A', 'B'], 'properties unshifted in sequence are mapped correctly');
 });
 
-QUnit.test('it has the correct `this`', function() {
+QUnit.test('it has the correct `this`', function(assert) {
   obj = EmberObject.extend({
     mapped: map('array', function(item)  {
-      equal(this, obj, 'should have correct context');
+      assert.equal(this, obj, 'should have correct context');
       return this.upperCase(item);
     }),
     upperCase(string) {
@@ -106,10 +106,10 @@ QUnit.test('it has the correct `this`', function() {
     array: ['a', 'b', 'c']
   });
 
-  deepEqual(obj.get('mapped'), ['A', 'B', 'C'], 'properties unshifted in sequence are mapped correctly');
+  assert.deepEqual(obj.get('mapped'), ['A', 'B', 'C'], 'properties unshifted in sequence are mapped correctly');
 });
 
-QUnit.test('it passes the index to the callback', function() {
+QUnit.test('it passes the index to the callback', function(assert) {
   let array = ['a', 'b', 'c'];
 
   obj = EmberObject.extend({
@@ -118,11 +118,11 @@ QUnit.test('it passes the index to the callback', function() {
     array
   });
 
-  deepEqual(obj.get('mapped'), [0, 1, 2], 'index is passed to callback correctly');
+  assert.deepEqual(obj.get('mapped'), [0, 1, 2], 'index is passed to callback correctly');
 });
 
-QUnit.test('it maps objects', function() {
-  deepEqual(obj.get('mappedObjects'), [
+QUnit.test('it maps objects', function(assert) {
+  assert.deepEqual(obj.get('mappedObjects'), [
     { name: 'Robert' },
     { name: 'Leanna' }
   ]);
@@ -131,7 +131,7 @@ QUnit.test('it maps objects', function() {
     v: { name: 'Eddard' }
   });
 
-  deepEqual(obj.get('mappedObjects'), [
+  assert.deepEqual(obj.get('mappedObjects'), [
     { name: 'Robert' },
     { name: 'Leanna' },
     { name: 'Eddard' }
@@ -139,20 +139,20 @@ QUnit.test('it maps objects', function() {
 
   removeAt(obj.get('arrayObjects'), 1);
 
-  deepEqual(obj.get('mappedObjects'), [
+  assert.deepEqual(obj.get('mappedObjects'), [
     { name: 'Robert' },
     { name: 'Eddard' }
   ]);
 
   set(obj.get('arrayObjects')[0], 'v', { name: 'Stannis' });
 
-  deepEqual(obj.get('mappedObjects'), [
+  assert.deepEqual(obj.get('mappedObjects'), [
     { name: 'Stannis' },
     { name: 'Eddard' }
   ]);
 });
 
-QUnit.test('it maps unshifted objects with property observers', function() {
+QUnit.test('it maps unshifted objects with property observers', function(assert) {
   let array = emberA();
   let cObj = { v: 'c' };
 
@@ -168,12 +168,12 @@ QUnit.test('it maps unshifted objects with property observers', function() {
 
   set(cObj, 'v', 'd');
 
-  deepEqual(array.mapBy('v'), ['a', 'b', 'd'], 'precond - unmapped array is correct');
-  deepEqual(obj.get('mapped'), ['A', 'B', 'D'], 'properties unshifted in sequence are mapped correctly');
+  assert.deepEqual(array.mapBy('v'), ['a', 'b', 'd'], 'precond - unmapped array is correct');
+  assert.deepEqual(obj.get('mapped'), ['A', 'B', 'D'], 'properties unshifted in sequence are mapped correctly');
 });
 
 QUnit.module('mapBy', {
-  setup() {
+  beforeEach() {
     obj = EmberObject.extend({
       mapped: mapBy('array', 'v')
     }).create({
@@ -185,78 +185,78 @@ QUnit.module('mapBy', {
       ])
     });
   },
-  teardown() {
+  afterEach() {
     run(obj, 'destroy');
   }
 });
 
-QUnit.test('mapBy is readOnly', function() {
+QUnit.test('mapBy is readOnly', function(assert) {
   QUnit.throws(function() {
     obj.set('mapped', 1);
   }, /Cannot set read-only property "mapped" on object:/);
 });
 
-QUnit.test('it maps properties', function() {
-  deepEqual(obj.get('mapped'), [1, 3, 2, 1]);
+QUnit.test('it maps properties', function(assert) {
+  assert.deepEqual(obj.get('mapped'), [1, 3, 2, 1]);
 
   obj.get('array').pushObject({ v: 5 });
 
-  deepEqual(obj.get('mapped'), [1, 3, 2, 1, 5]);
+  assert.deepEqual(obj.get('mapped'), [1, 3, 2, 1, 5]);
 
   removeAt(obj.get('array'), 3);
 
-  deepEqual(obj.get('mapped'), [1, 3, 2, 5]);
+  assert.deepEqual(obj.get('mapped'), [1, 3, 2, 5]);
 });
 
-QUnit.test('it is observable', function() {
+QUnit.test('it is observable', function(assert) {
   let calls = 0;
 
-  deepEqual(obj.get('mapped'), [1, 3, 2, 1]);
+  assert.deepEqual(obj.get('mapped'), [1, 3, 2, 1]);
 
   addObserver(obj, 'mapped.@each', () => calls++);
 
   obj.get('array').pushObject({ v: 5 });
 
-  equal(calls, 1, 'mapBy is observable');
+  assert.equal(calls, 1, 'mapBy is observable');
 });
 
 QUnit.module('filter', {
-  setup() {
+  beforeEach() {
     obj = EmberObject.extend({
       filtered: filter('array', (item) => item % 2 === 0)
     }).create({
       array: emberA([1, 2, 3, 4, 5, 6, 7, 8])
     });
   },
-  teardown() {
+  afterEach() {
     run(obj, 'destroy');
   }
 });
 
-QUnit.test('filter is readOnly', function() {
+QUnit.test('filter is readOnly', function(assert) {
   QUnit.throws(function() {
     obj.set('filtered', 1);
   }, /Cannot set read-only property "filtered" on object:/);
 });
 
-QUnit.test('it filters according to the specified filter function', function() {
-  deepEqual(obj.get('filtered'), [2, 4, 6, 8], 'filter filters by the specified function');
+QUnit.test('it filters according to the specified filter function', function(assert) {
+  assert.deepEqual(obj.get('filtered'), [2, 4, 6, 8], 'filter filters by the specified function');
 });
 
-QUnit.test('it passes the index to the callback', function() {
+QUnit.test('it passes the index to the callback', function(assert) {
   obj = EmberObject.extend({
     filtered: filter('array', (item, index) => index === 1)
   }).create({
     array: ['a', 'b', 'c']
   });
 
-  deepEqual(get(obj, 'filtered'), ['b'], 'index is passed to callback correctly');
+  assert.deepEqual(get(obj, 'filtered'), ['b'], 'index is passed to callback correctly');
 });
 
-QUnit.test('it has the correct `this`', function() {
+QUnit.test('it has the correct `this`', function(assert) {
   obj = EmberObject.extend({
     filtered: filter('array', function(item, index) {
-      equal(this, obj);
+      assert.equal(this, obj);
       return this.isOne(index);
     }),
     isOne(value) {
@@ -266,54 +266,54 @@ QUnit.test('it has the correct `this`', function() {
     array: ['a', 'b', 'c']
   });
 
-  deepEqual(get(obj, 'filtered'), ['b'], 'index is passed to callback correctly');
+  assert.deepEqual(get(obj, 'filtered'), ['b'], 'index is passed to callback correctly');
 });
 
-QUnit.test('it passes the array to the callback', function() {
+QUnit.test('it passes the array to the callback', function(assert) {
   obj = EmberObject.extend({
     filtered: filter('array',  (item, index, array) => index === get(array, 'length') - 2)
   }).create({
     array: emberA(['a', 'b', 'c'])
   });
 
-  deepEqual(obj.get('filtered'), ['b'], 'array is passed to callback correctly');
+  assert.deepEqual(obj.get('filtered'), ['b'], 'array is passed to callback correctly');
 });
 
-QUnit.test('it caches properly', function() {
+QUnit.test('it caches properly', function(assert) {
   let array = obj.get('array');
 
   let filtered = obj.get('filtered');
-  ok(filtered === obj.get('filtered'));
+  assert.ok(filtered === obj.get('filtered'));
 
   array.addObject(11);
   let newFiltered = obj.get('filtered');
 
-  ok(filtered !== newFiltered);
+  assert.ok(filtered !== newFiltered);
 
-  ok(obj.get('filtered') === newFiltered);
+  assert.ok(obj.get('filtered') === newFiltered);
 });
 
-QUnit.test('it updates as the array is modified', function() {
+QUnit.test('it updates as the array is modified', function(assert) {
   let array = obj.get('array');
 
-  deepEqual(obj.get('filtered'), [2, 4, 6, 8], 'precond - filtered array is initially correct');
+  assert.deepEqual(obj.get('filtered'), [2, 4, 6, 8], 'precond - filtered array is initially correct');
 
   array.addObject(11);
-  deepEqual(obj.get('filtered'), [2, 4, 6, 8], 'objects not passing the filter are not added');
+  assert.deepEqual(obj.get('filtered'), [2, 4, 6, 8], 'objects not passing the filter are not added');
 
   array.addObject(12);
-  deepEqual(obj.get('filtered'), [2, 4, 6, 8, 12], 'objects passing the filter are added');
+  assert.deepEqual(obj.get('filtered'), [2, 4, 6, 8, 12], 'objects passing the filter are added');
 
   array.removeObject(3);
   array.removeObject(4);
 
-  deepEqual(obj.get('filtered'), [2, 6, 8, 12], 'objects removed from the dependent array are removed from the computed array');
+  assert.deepEqual(obj.get('filtered'), [2, 6, 8, 12], 'objects removed from the dependent array are removed from the computed array');
 });
 
-QUnit.test('the dependent array can be cleared one at a time', function() {
+QUnit.test('the dependent array can be cleared one at a time', function(assert) {
   let array = get(obj, 'array');
 
-  deepEqual(obj.get('filtered'), [2, 4, 6, 8], 'precond - filtered array is initially correct');
+  assert.deepEqual(obj.get('filtered'), [2, 4, 6, 8], 'precond - filtered array is initially correct');
 
   // clear 1-8 but in a random order
   array.removeObject(3);
@@ -325,26 +325,26 @@ QUnit.test('the dependent array can be cleared one at a time', function() {
   array.removeObject(5);
   array.removeObject(7);
 
-  deepEqual(obj.get('filtered'), [], 'filtered array cleared correctly');
+  assert.deepEqual(obj.get('filtered'), [], 'filtered array cleared correctly');
 });
 
-QUnit.test('the dependent array can be `clear`ed directly (#3272)', function() {
-  deepEqual(obj.get('filtered'), [2, 4, 6, 8], 'precond - filtered array is initially correct');
+QUnit.test('the dependent array can be `clear`ed directly (#3272)', function(assert) {
+  assert.deepEqual(obj.get('filtered'), [2, 4, 6, 8], 'precond - filtered array is initially correct');
 
   obj.get('array').clear();
 
-  deepEqual(obj.get('filtered'), [], 'filtered array cleared correctly');
+  assert.deepEqual(obj.get('filtered'), [], 'filtered array cleared correctly');
 });
 
-QUnit.test('it updates as the array is replaced', function() {
-  deepEqual(obj.get('filtered'), [2, 4, 6, 8], 'precond - filtered array is initially correct');
+QUnit.test('it updates as the array is replaced', function(assert) {
+  assert.deepEqual(obj.get('filtered'), [2, 4, 6, 8], 'precond - filtered array is initially correct');
 
   obj.set('array', [20, 21, 22, 23, 24]);
 
-  deepEqual(obj.get('filtered'), [20, 22, 24], 'computed array is updated when array is changed');
+  assert.deepEqual(obj.get('filtered'), [20, 22, 24], 'computed array is updated when array is changed');
 });
 
-QUnit.test('it updates properly on @each with {} dependencies', function() {
+QUnit.test('it updates properly on @each with {} dependencies', function(assert) {
   let item = EmberObject.create({prop: true});
 
   obj = EmberObject.extend({
@@ -355,15 +355,15 @@ QUnit.test('it updates properly on @each with {} dependencies', function() {
     items: emberA([item])
   });
 
-  deepEqual(obj.get('filtered'), [item]);
+  assert.deepEqual(obj.get('filtered'), [item]);
 
   item.set('prop', false);
 
-  deepEqual(obj.get('filtered'), []);
+  assert.deepEqual(obj.get('filtered'), []);
 });
 
 QUnit.module('filterBy', {
-  setup() {
+  beforeEach() {
     obj = EmberObject.extend({
       a1s: filterBy('array', 'a', 1),
       as: filterBy('array', 'a'),
@@ -377,20 +377,20 @@ QUnit.module('filterBy', {
       ])
     });
   },
-  teardown() {
+  afterEach() {
     run(obj, 'destroy');
   }
 });
 
-QUnit.test('filterBy is readOnly', function() {
+QUnit.test('filterBy is readOnly', function(assert) {
   QUnit.throws(function() {
     obj.set('as', 1);
   }, /Cannot set read-only property "as" on object:/);
 });
 
-QUnit.test('properties can be filtered by truthiness', function() {
-  deepEqual(obj.get('as').mapBy('name'), ['one', 'two', 'three'], 'properties can be filtered by existence');
-  deepEqual(obj.get('bs').mapBy('name'), ['three', 'four'], 'booleans can be filtered');
+QUnit.test('properties can be filtered by truthiness', function(assert) {
+  assert.deepEqual(obj.get('as').mapBy('name'), ['one', 'two', 'three'], 'properties can be filtered by existence');
+  assert.deepEqual(obj.get('bs').mapBy('name'), ['three', 'four'], 'booleans can be filtered');
 
   set(obj.get('array')[0], 'a', undefined);
   set(obj.get('array')[3], 'a', true);
@@ -398,45 +398,45 @@ QUnit.test('properties can be filtered by truthiness', function() {
   set(obj.get('array')[0], 'b', true);
   set(obj.get('array')[3], 'b', false);
 
-  deepEqual(obj.get('as').mapBy('name'), ['two', 'three', 'four'], 'arrays computed by filter property respond to property changes');
-  deepEqual(obj.get('bs').mapBy('name'), ['one', 'three'], 'arrays computed by filtered property respond to property changes');
+  assert.deepEqual(obj.get('as').mapBy('name'), ['two', 'three', 'four'], 'arrays computed by filter property respond to property changes');
+  assert.deepEqual(obj.get('bs').mapBy('name'), ['one', 'three'], 'arrays computed by filtered property respond to property changes');
 
   obj.get('array').pushObject({ name: 'five', a: 6, b: true });
 
-  deepEqual(obj.get('as').mapBy('name'), ['two', 'three', 'four', 'five'], 'arrays computed by filter property respond to added objects');
-  deepEqual(obj.get('bs').mapBy('name'), ['one', 'three', 'five'], 'arrays computed by filtered property respond to added objects');
+  assert.deepEqual(obj.get('as').mapBy('name'), ['two', 'three', 'four', 'five'], 'arrays computed by filter property respond to added objects');
+  assert.deepEqual(obj.get('bs').mapBy('name'), ['one', 'three', 'five'], 'arrays computed by filtered property respond to added objects');
 
   obj.get('array').popObject();
 
-  deepEqual(obj.get('as').mapBy('name'), ['two', 'three', 'four'], 'arrays computed by filter property respond to removed objects');
-  deepEqual(obj.get('bs').mapBy('name'), ['one', 'three'], 'arrays computed by filtered property respond to removed objects');
+  assert.deepEqual(obj.get('as').mapBy('name'), ['two', 'three', 'four'], 'arrays computed by filter property respond to removed objects');
+  assert.deepEqual(obj.get('bs').mapBy('name'), ['one', 'three'], 'arrays computed by filtered property respond to removed objects');
 
   obj.set('array', [
     { name: 'six', a: 12, b: true }
   ]);
 
-  deepEqual(obj.get('as').mapBy('name'), ['six'], 'arrays computed by filter property respond to array changes');
-  deepEqual(obj.get('bs').mapBy('name'), ['six'], 'arrays computed by filtered property respond to array changes');
+  assert.deepEqual(obj.get('as').mapBy('name'), ['six'], 'arrays computed by filter property respond to array changes');
+  assert.deepEqual(obj.get('bs').mapBy('name'), ['six'], 'arrays computed by filtered property respond to array changes');
 });
 
-QUnit.test('properties can be filtered by values', function() {
-  deepEqual(obj.get('a1s').mapBy('name'), ['one', 'three'], 'properties can be filtered by matching value');
+QUnit.test('properties can be filtered by values', function(assert) {
+  assert.deepEqual(obj.get('a1s').mapBy('name'), ['one', 'three'], 'properties can be filtered by matching value');
 
   obj.get('array').pushObject({ name: 'five', a: 1 });
 
-  deepEqual(obj.get('a1s').mapBy('name'), ['one', 'three', 'five'], 'arrays computed by matching value respond to added objects');
+  assert.deepEqual(obj.get('a1s').mapBy('name'), ['one', 'three', 'five'], 'arrays computed by matching value respond to added objects');
 
   obj.get('array').popObject();
 
-  deepEqual(obj.get('a1s').mapBy('name'), ['one', 'three'], 'arrays computed by matching value respond to removed objects');
+  assert.deepEqual(obj.get('a1s').mapBy('name'), ['one', 'three'], 'arrays computed by matching value respond to removed objects');
 
   set(obj.get('array')[1], 'a', 1);
   set(obj.get('array')[2], 'a', 2);
 
-  deepEqual(obj.get('a1s').mapBy('name'), ['one', 'two'], 'arrays computed by matching value respond to modified properties');
+  assert.deepEqual(obj.get('a1s').mapBy('name'), ['one', 'two'], 'arrays computed by matching value respond to modified properties');
 });
 
-QUnit.test('properties values can be replaced', function() {
+QUnit.test('properties values can be replaced', function(assert) {
   obj = EmberObject.extend({
     a1s: filterBy('array', 'a', 1),
     a1bs: filterBy('a1s', 'b')
@@ -444,13 +444,13 @@ QUnit.test('properties values can be replaced', function() {
     array: []
   });
 
-  deepEqual(obj.get('a1bs').mapBy('name'), [], 'properties can be filtered by matching value');
+  assert.deepEqual(obj.get('a1bs').mapBy('name'), [], 'properties can be filtered by matching value');
 
   set(obj, 'array', [
     { name: 'item1', a: 1, b: true }
   ]);
 
-  deepEqual(obj.get('a1bs').mapBy('name'), ['item1'], 'properties can be filtered by matching value');
+  assert.deepEqual(obj.get('a1bs').mapBy('name'), ['item1'], 'properties can be filtered by matching value');
 });
 
 [
@@ -460,7 +460,7 @@ QUnit.test('properties values can be replaced', function() {
   let [name, macro] = tuple;
 
   QUnit.module(`computed.${name}`, {
-    setup() {
+    beforeEach() {
       obj = EmberObject.extend({
         union: macro('array', 'array2', 'array3')
       }).create({
@@ -469,57 +469,57 @@ QUnit.test('properties values can be replaced', function() {
         array3: emberA([1, 8, 10])
       });
     },
-    teardown() {
+    afterEach() {
       run(obj, 'destroy');
     }
   });
 
-  QUnit.test(`${name} is readOnly`, function() {
+  QUnit.test(`${name} is readOnly`, function(assert) {
     QUnit.throws(function() {
       obj.set('union', 1);
     }, /Cannot set read-only property "union" on object:/);
   });
 
-  QUnit.test('does not include duplicates', function() {
+  QUnit.test('does not include duplicates', function(assert) {
     let array = obj.get('array');
     let array2 = obj.get('array2');
 
-    deepEqual(obj.get('union').sort((x, y) => x - y), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], name + ' does not include duplicates');
+    assert.deepEqual(obj.get('union').sort((x, y) => x - y), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], name + ' does not include duplicates');
 
     array.pushObject(8);
 
-    deepEqual(obj.get('union').sort((x, y) => x - y), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], name + ' does not add existing items');
+    assert.deepEqual(obj.get('union').sort((x, y) => x - y), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], name + ' does not add existing items');
 
     array.pushObject(11);
 
-    deepEqual(obj.get('union').sort((x, y) => x - y), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], name + ' adds new items');
+    assert.deepEqual(obj.get('union').sort((x, y) => x - y), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], name + ' adds new items');
 
     removeAt(array2, 6); // remove 7
 
-    deepEqual(obj.get('union').sort((x, y) => x - y), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], name + ' does not remove items that are still in the dependent array');
+    assert.deepEqual(obj.get('union').sort((x, y) => x - y), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], name + ' does not remove items that are still in the dependent array');
 
     array2.removeObject(7);
 
-    deepEqual(obj.get('union').sort((x, y) => x - y), [1, 2, 3, 4, 5, 6, 8, 9, 10, 11], name + ' removes items when their last instance is gone');
+    assert.deepEqual(obj.get('union').sort((x, y) => x - y), [1, 2, 3, 4, 5, 6, 8, 9, 10, 11], name + ' removes items when their last instance is gone');
   });
 
-  QUnit.test('has set-union semantics', function() {
+  QUnit.test('has set-union semantics', function(assert) {
     let array = obj.get('array');
 
-    deepEqual(obj.get('union').sort((x, y) => x - y), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], name + ' is initially correct');
+    assert.deepEqual(obj.get('union').sort((x, y) => x - y), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], name + ' is initially correct');
 
     array.removeObject(6);
 
-    deepEqual(obj.get('union').sort((x, y) => x - y), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 'objects are not removed if they exist in other dependent arrays');
+    assert.deepEqual(obj.get('union').sort((x, y) => x - y), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 'objects are not removed if they exist in other dependent arrays');
 
     array.clear();
 
-    deepEqual(obj.get('union').sort((x, y) => x - y), [1, 4, 5, 6, 7, 8, 9, 10], 'objects are removed when they are no longer in any dependent array');
+    assert.deepEqual(obj.get('union').sort((x, y) => x - y), [1, 4, 5, 6, 7, 8, 9, 10], 'objects are removed when they are no longer in any dependent array');
   });
 });
 
 QUnit.module('computed.uniqBy', {
-  setup() {
+  beforeEach() {
     obj = EmberObject.extend({
       list: null,
       uniqueById: uniqBy('list', 'id')
@@ -531,24 +531,24 @@ QUnit.module('computed.uniqBy', {
       ])
     });
   },
-  teardown() {
+  afterEach() {
     run(obj, 'destroy');
   }
 });
 
-QUnit.test('uniqBy is readOnly', function() {
+QUnit.test('uniqBy is readOnly', function(assert) {
   QUnit.throws(function() {
     obj.set('uniqueById', 1);
   }, /Cannot set read-only property "uniqueById" on object:/);
 });
-QUnit.test('does not include duplicates', function() {
-  deepEqual(obj.get('uniqueById'), [
+QUnit.test('does not include duplicates', function(assert) {
+  assert.deepEqual(obj.get('uniqueById'), [
     { id: 1, value: 'one' },
     { id: 2, value: 'two' }
   ]);
 });
 
-QUnit.test('it does not share state among instances', function() {
+QUnit.test('it does not share state among instances', function(assert) {
   let MyObject = EmberObject.extend({
     list: [],
     uniqueByName: uniqBy('list', 'name')
@@ -556,15 +556,15 @@ QUnit.test('it does not share state among instances', function() {
   let a = MyObject.create({ list: [{ name: 'bob' }, { name: 'mitch' }, { name: 'mitch' }] });
   let b = MyObject.create({ list: [{ name: 'warren' }, { name: 'mitch' }] });
 
-  deepEqual(a.get('uniqueByName'), [{ name: 'bob' }, { name: 'mitch' }]);
+  assert.deepEqual(a.get('uniqueByName'), [{ name: 'bob' }, { name: 'mitch' }]);
   // Making sure that 'mitch' appears
-  deepEqual(b.get('uniqueByName'), [{ name: 'warren' }, { name: 'mitch' }]);
+  assert.deepEqual(b.get('uniqueByName'), [{ name: 'warren' }, { name: 'mitch' }]);
 });
 
-QUnit.test('it handles changes to the dependent array', function() {
+QUnit.test('it handles changes to the dependent array', function(assert) {
   obj.get('list').pushObject({ id: 3, value: 'three' });
 
-  deepEqual(obj.get('uniqueById'), [
+  assert.deepEqual(obj.get('uniqueById'), [
     { id: 1, value: 'one' },
     { id: 2, value: 'two' },
     { id: 3, value: 'three' }
@@ -572,25 +572,25 @@ QUnit.test('it handles changes to the dependent array', function() {
 
   obj.get('list').pushObject({ id: 3, value: 'three' });
 
-  deepEqual(obj.get('uniqueById'), [
+  assert.deepEqual(obj.get('uniqueById'), [
     { id: 1, value: 'one' },
     { id: 2, value: 'two' },
     { id: 3, value: 'three' }
   ], 'The list does not include a duplicate three');
 });
 
-QUnit.test('it returns an empty array when computed on a non-array', function() {
+QUnit.test('it returns an empty array when computed on a non-array', function(assert) {
   let MyObject = EmberObject.extend({
     list: null,
     uniq: uniqBy('list', 'name')
   });
   let a = MyObject.create({ list: 'not an array' });
 
-  deepEqual(a.get('uniq'), []);
+  assert.deepEqual(a.get('uniq'), []);
 });
 
 QUnit.module('computed.intersect', {
-  setup() {
+  beforeEach() {
     obj = EmberObject.extend({
       intersection: intersect('array', 'array2', 'array3')
     }).create({
@@ -599,46 +599,46 @@ QUnit.module('computed.intersect', {
       array3: emberA([3, 5, 6, 7, 8])
     });
   },
-  teardown() {
+  afterEach() {
     run(obj, 'destroy');
   }
 });
 
-QUnit.test('intersect is readOnly', function() {
+QUnit.test('intersect is readOnly', function(assert) {
   QUnit.throws(function() {
     obj.set('intersection', 1);
   }, /Cannot set read-only property "intersection" on object:/);
 });
 
-QUnit.test('it has set-intersection semantics', function() {
+QUnit.test('it has set-intersection semantics', function(assert) {
   let array2 = obj.get('array2');
   let array3 = obj.get('array3');
 
-  deepEqual(obj.get('intersection').sort((x, y) => x - y), [3, 5], 'intersection is initially correct');
+  assert.deepEqual(obj.get('intersection').sort((x, y) => x - y), [3, 5], 'intersection is initially correct');
 
   array2.shiftObject();
 
-  deepEqual(obj.get('intersection').sort((x, y) => x - y), [3, 5], 'objects are not removed when they are still in all dependent arrays');
+  assert.deepEqual(obj.get('intersection').sort((x, y) => x - y), [3, 5], 'objects are not removed when they are still in all dependent arrays');
 
   array2.shiftObject();
 
-  deepEqual(obj.get('intersection').sort((x, y) => x - y), [3, 5], 'objects are not removed when they are still in all dependent arrays');
+  assert.deepEqual(obj.get('intersection').sort((x, y) => x - y), [3, 5], 'objects are not removed when they are still in all dependent arrays');
 
   array2.shiftObject();
 
-  deepEqual(obj.get('intersection'), [5], 'objects are removed once they are gone from all dependent arrays');
+  assert.deepEqual(obj.get('intersection'), [5], 'objects are removed once they are gone from all dependent arrays');
 
   array2.pushObject(1);
 
-  deepEqual(obj.get('intersection'), [5], 'objects are not added as long as they are missing from any dependent array');
+  assert.deepEqual(obj.get('intersection'), [5], 'objects are not added as long as they are missing from any dependent array');
 
   array3.pushObject(1);
 
-  deepEqual(obj.get('intersection').sort((x, y) => x - y), [1, 5], 'objects added once they belong to all dependent arrays');
+  assert.deepEqual(obj.get('intersection').sort((x, y) => x - y), [1, 5], 'objects added once they belong to all dependent arrays');
 });
 
 QUnit.module('setDiff', {
-  setup() {
+  beforeEach() {
     obj = EmberObject.extend({
       diff: setDiff('array', 'array2')
     }).create({
@@ -646,18 +646,18 @@ QUnit.module('setDiff', {
       array2: emberA([3, 4, 5, 10])
     });
   },
-  teardown() {
+  afterEach() {
     run(obj, 'destroy');
   }
 });
 
-QUnit.test('setDiff is readOnly', function() {
+QUnit.test('setDiff is readOnly', function(assert) {
   QUnit.throws(function() {
     obj.set('diff', 1);
   }, /Cannot set read-only property "diff" on object:/);
 });
 
-QUnit.test('it asserts if given fewer or more than two dependent properties', function() {
+QUnit.test('it asserts if given fewer or more than two dependent properties', function(assert) {
   expectAssertion(function () {
     EmberObject.extend({
       diff: setDiff('array')
@@ -679,37 +679,37 @@ QUnit.test('it asserts if given fewer or more than two dependent properties', fu
 });
 
 
-QUnit.test('it has set-diff semantics', function() {
+QUnit.test('it has set-diff semantics', function(assert) {
   let array1 = obj.get('array');
   let array2 = obj.get('array2');
 
-  deepEqual(obj.get('diff').sort((x, y) => x - y), [1, 2, 6, 7], 'set-diff is initially correct');
+  assert.deepEqual(obj.get('diff').sort((x, y) => x - y), [1, 2, 6, 7], 'set-diff is initially correct');
 
   array2.popObject();
 
-  deepEqual(obj.get('diff').sort((x, y) => x - y), [1, 2, 6, 7], 'removing objects from the remove set has no effect if the object is not in the keep set');
+  assert.deepEqual(obj.get('diff').sort((x, y) => x - y), [1, 2, 6, 7], 'removing objects from the remove set has no effect if the object is not in the keep set');
 
   array2.shiftObject();
 
-  deepEqual(obj.get('diff').sort((x, y) => x - y), [1, 2, 3, 6, 7], 'removing objects from the remove set adds them if they\'re in the keep set');
+  assert.deepEqual(obj.get('diff').sort((x, y) => x - y), [1, 2, 3, 6, 7], 'removing objects from the remove set adds them if they\'re in the keep set');
 
   array1.removeObject(3);
 
-  deepEqual(obj.get('diff').sort((x, y) => x - y), [1, 2, 6, 7], 'removing objects from the keep array removes them from the computed array');
+  assert.deepEqual(obj.get('diff').sort((x, y) => x - y), [1, 2, 6, 7], 'removing objects from the keep array removes them from the computed array');
 
   array1.pushObject(5);
 
-  deepEqual(obj.get('diff').sort((x, y) => x - y), [1, 2, 6, 7], 'objects added to the keep array that are in the remove array are not added to the computed array');
+  assert.deepEqual(obj.get('diff').sort((x, y) => x - y), [1, 2, 6, 7], 'objects added to the keep array that are in the remove array are not added to the computed array');
 
   array1.pushObject(22);
 
-  deepEqual(obj.get('diff').sort((x, y) => x - y), [1, 2, 6, 7, 22], 'objects added to the keep array not in the remove array are added to the computed array');
+  assert.deepEqual(obj.get('diff').sort((x, y) => x - y), [1, 2, 6, 7, 22], 'objects added to the keep array not in the remove array are added to the computed array');
 });
 
 
 function commonSortTests() {
-  QUnit.test('arrays are initially sorted', function() {
-    deepEqual(obj.get('sortedItems').mapBy('fname'), [
+  QUnit.test('arrays are initially sorted', function(assert) {
+    assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
       'Cersei',
       'Jaime',
       'Bran',
@@ -717,8 +717,8 @@ function commonSortTests() {
     ], 'array is initially sorted');
   });
 
-  QUnit.test('default sort order is correct', function() {
-    deepEqual(obj.get('sortedItems').mapBy('fname'), [
+  QUnit.test('default sort order is correct', function(assert) {
+    assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
       'Cersei',
       'Jaime',
       'Bran',
@@ -726,8 +726,8 @@ function commonSortTests() {
     ], 'array is initially sorted');
   });
 
-  QUnit.test('changing the dependent array updates the sorted array', function() {
-    deepEqual(obj.get('sortedItems').mapBy('fname'), [
+  QUnit.test('changing the dependent array updates the sorted array', function(assert) {
+    assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
       'Cersei',
       'Jaime',
       'Bran',
@@ -741,7 +741,7 @@ function commonSortTests() {
       { fname: 'Stannis', lname: 'Baratheon' }
     ]);
 
-    deepEqual(obj.get('sortedItems').mapBy('fname'), [
+    assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
       'Stannis',
       'Ramsey',
       'Roose',
@@ -749,10 +749,10 @@ function commonSortTests() {
     ], 'changing dependent array updates sorted array');
   });
 
-  QUnit.test('adding to the dependent array updates the sorted array', function() {
+  QUnit.test('adding to the dependent array updates the sorted array', function(assert) {
     let items = obj.get('items');
 
-    deepEqual(obj.get('sortedItems').mapBy('fname'), [
+    assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
       'Cersei',
       'Jaime',
       'Bran',
@@ -764,7 +764,7 @@ function commonSortTests() {
       lname: 'Lannister'
     });
 
-    deepEqual(obj.get('sortedItems').mapBy('fname'), [
+    assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
       'Cersei',
       'Jaime',
       'Tyrion',
@@ -773,8 +773,8 @@ function commonSortTests() {
     ], 'Adding to the dependent array updates the sorted array');
   });
 
-  QUnit.test('removing from the dependent array updates the sorted array', function() {
-    deepEqual(obj.get('sortedItems').mapBy('fname'), [
+  QUnit.test('removing from the dependent array updates the sorted array', function(assert) {
+    assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
       'Cersei',
       'Jaime',
       'Bran',
@@ -783,14 +783,14 @@ function commonSortTests() {
 
     obj.get('items').popObject();
 
-    deepEqual(obj.get('sortedItems').mapBy('fname'), [
+    assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
       'Cersei',
       'Jaime',
       'Robb'
     ], 'Removing from the dependent array updates the sorted array');
   });
 
-  QUnit.test('distinct items may be sort-equal, although their relative order will not be guaranteed', function() {
+  QUnit.test('distinct items may be sort-equal, although their relative order will not be guaranteed', function(assert) {
     // We recreate jaime and "Cersei" here only for test stability: we want
     // their guid-ordering to be deterministic
     let jaimeInDisguise = {
@@ -810,7 +810,7 @@ function commonSortTests() {
     items.replace(0, 1, [jaime]);
     items.replace(1, 1, [jaimeInDisguise]);
 
-    deepEqual(obj.get('sortedItems').mapBy('fname'), [
+    assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
       'Cersei',
       'Jaime',
       'Bran',
@@ -819,7 +819,7 @@ function commonSortTests() {
 
     set(jaimeInDisguise, 'fname', 'Jaime');
 
-    deepEqual(obj.get('sortedItems').mapBy('fname'), [
+    assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
       'Jaime',
       'Jaime',
       'Bran',
@@ -828,7 +828,7 @@ function commonSortTests() {
 
     set(jaimeInDisguise, 'fname', 'Cersei');
 
-    deepEqual(obj.get('sortedItems').mapBy('fname'), [
+    assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
       'Cersei',
       'Jaime',
       'Bran',
@@ -836,7 +836,7 @@ function commonSortTests() {
     ], 'sorted array is updated');
   });
 
-  QUnit.test('guid sort-order fallback with a search proxy is not confused by non-search ObjectProxys', function() {
+  QUnit.test('guid sort-order fallback with a search proxy is not confused by non-search ObjectProxys', function(assert) {
     let tyrion = {
       fname: 'Tyrion',
       lname: 'Lannister'
@@ -852,7 +852,7 @@ function commonSortTests() {
 
     items.pushObject(tyrion);
 
-    deepEqual(obj.get('sortedItems').mapBy('fname'), [
+    assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
       'Cersei',
       'Jaime',
       'Tyrion',
@@ -862,7 +862,7 @@ function commonSortTests() {
 
     items.pushObject(tyrionInDisguise);
 
-    deepEqual(obj.get('sortedItems').mapBy('fname'), [
+    assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
       'Yollo',
       'Cersei',
       'Jaime',
@@ -874,7 +874,7 @@ function commonSortTests() {
 }
 
 QUnit.module('sort - sortProperties', {
-  setup() {
+  beforeEach() {
     obj = EmberObject.extend({
       sortedItems: sort('items', 'itemSorting')
     }).create({
@@ -887,12 +887,12 @@ QUnit.module('sort - sortProperties', {
       ])
     });
   },
-  teardown() {
+  afterEach() {
     run(obj, 'destroy');
   }
 });
 
-QUnit.test('sort is readOnly', function() {
+QUnit.test('sort is readOnly', function(assert) {
   QUnit.throws(function() {
     obj.set('sortedItems', 1);
   }, /Cannot set read-only property "sortedItems" on object:/);
@@ -900,10 +900,10 @@ QUnit.test('sort is readOnly', function() {
 
 commonSortTests();
 
-QUnit.test('updating sort properties detaches observers for old sort properties', function() {
+QUnit.test('updating sort properties detaches observers for old sort properties', function(assert) {
   let objectToRemove = obj.get('items')[3];
 
-  deepEqual(obj.get('sortedItems').mapBy('fname'), [
+  assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Cersei',
     'Jaime',
     'Bran',
@@ -912,7 +912,7 @@ QUnit.test('updating sort properties detaches observers for old sort properties'
 
   obj.set('itemSorting', emberA(['fname:desc']));
 
-  deepEqual(obj.get('sortedItems').mapBy('fname'), [
+  assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Robb',
     'Jaime',
     'Cersei',
@@ -921,7 +921,7 @@ QUnit.test('updating sort properties detaches observers for old sort properties'
 
   obj.get('items').removeObject(objectToRemove);
 
-  deepEqual(obj.get('sortedItems').mapBy('fname'), [
+  assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Robb',
     'Jaime',
     'Cersei'
@@ -929,22 +929,22 @@ QUnit.test('updating sort properties detaches observers for old sort properties'
 
   set(objectToRemove, 'lname', 'Updated-Stark');
 
-  deepEqual(obj.get('sortedItems').mapBy('fname'), [
+  assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Robb',
     'Jaime',
     'Cersei'
   ], 'after changing removed item array is not updated');
 });
 
-QUnit.test('sort works if array property is null (non array value) on first evaluation of computed prop', function() {
+QUnit.test('sort works if array property is null (non array value) on first evaluation of computed prop', function(assert) {
   obj.set('items', null);
-  deepEqual(obj.get('sortedItems'), []);
+  assert.deepEqual(obj.get('sortedItems'), []);
   obj.set('items', emberA([{fname: 'Cersei', lname: 'Lanister'}]));
-  deepEqual(obj.get('sortedItems'), [{fname: 'Cersei', lname: 'Lanister'}]);
+  assert.deepEqual(obj.get('sortedItems'), [{fname: 'Cersei', lname: 'Lanister'}]);
 });
 
-QUnit.test('updating sort properties updates the sorted array', function() {
-  deepEqual(obj.get('sortedItems').mapBy('fname'), [
+QUnit.test('updating sort properties updates the sorted array', function(assert) {
+  assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Cersei',
     'Jaime',
     'Bran',
@@ -953,7 +953,7 @@ QUnit.test('updating sort properties updates the sorted array', function() {
 
   obj.set('itemSorting', emberA(['fname:desc']));
 
-  deepEqual(obj.get('sortedItems').mapBy('fname'), [
+  assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Robb',
     'Jaime',
     'Cersei',
@@ -961,10 +961,10 @@ QUnit.test('updating sort properties updates the sorted array', function() {
   ], 'after updating sort properties array is updated');
 });
 
-QUnit.test('updating sort properties invalidates the sorted array', function() {
+QUnit.test('updating sort properties invalidates the sorted array', function(assert) {
   let sortProps = obj.get('itemSorting');
 
-  deepEqual(obj.get('sortedItems').mapBy('fname'), [
+  assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Cersei',
     'Jaime',
     'Bran',
@@ -974,7 +974,7 @@ QUnit.test('updating sort properties invalidates the sorted array', function() {
   sortProps.clear();
   sortProps.pushObject('fname');
 
-  deepEqual(obj.get('sortedItems').mapBy('fname'), [
+  assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Bran',
     'Cersei',
     'Jaime',
@@ -982,8 +982,8 @@ QUnit.test('updating sort properties invalidates the sorted array', function() {
   ], 'after updating sort properties array is updated');
 });
 
-QUnit.test('updating new sort properties invalidates the sorted array', function() {
-  deepEqual(obj.get('sortedItems').mapBy('fname'), [
+QUnit.test('updating new sort properties invalidates the sorted array', function(assert) {
+  assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Cersei',
     'Jaime',
     'Bran',
@@ -992,7 +992,7 @@ QUnit.test('updating new sort properties invalidates the sorted array', function
 
   obj.set('itemSorting', emberA(['age:desc', 'fname:asc']));
 
-  deepEqual(obj.get('sortedItems').mapBy('fname'), [
+  assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Cersei',
     'Jaime',
     'Robb',
@@ -1001,7 +1001,7 @@ QUnit.test('updating new sort properties invalidates the sorted array', function
 
   set(obj.get('items')[1], 'age', 29);
 
-  deepEqual(obj.get('sortedItems').mapBy('fname'), [
+  assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Jaime',
     'Cersei',
     'Robb',
@@ -1009,8 +1009,8 @@ QUnit.test('updating new sort properties invalidates the sorted array', function
   ], 'after updating sort properties array is updated');
 });
 
-QUnit.test('sort direction defaults to ascending', function() {
-  deepEqual(obj.get('sortedItems').mapBy('fname'), [
+QUnit.test('sort direction defaults to ascending', function(assert) {
+  assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Cersei',
     'Jaime',
     'Bran',
@@ -1018,8 +1018,8 @@ QUnit.test('sort direction defaults to ascending', function() {
   ]);
 });
 
-QUnit.test('sort direction defaults to ascending (with sort property change)', function() {
-  deepEqual(obj.get('sortedItems').mapBy('fname'), [
+QUnit.test('sort direction defaults to ascending (with sort property change)', function(assert) {
+  assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Cersei',
     'Jaime',
     'Bran',
@@ -1028,7 +1028,7 @@ QUnit.test('sort direction defaults to ascending (with sort property change)', f
 
   obj.set('itemSorting', emberA(['fname']));
 
-  deepEqual(obj.get('sortedItems').mapBy('fname'), [
+  assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Bran',
     'Cersei',
     'Jaime',
@@ -1036,10 +1036,10 @@ QUnit.test('sort direction defaults to ascending (with sort property change)', f
   ], 'sort direction defaults to ascending');
 });
 
-QUnit.test('updating an item\'s sort properties updates the sorted array', function() {
+QUnit.test('updating an item\'s sort properties updates the sorted array', function(assert) {
   let tyrionInDisguise = obj.get('items')[1];
 
-  deepEqual(obj.get('sortedItems').mapBy('fname'), [
+  assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Cersei',
     'Jaime',
     'Bran',
@@ -1048,7 +1048,7 @@ QUnit.test('updating an item\'s sort properties updates the sorted array', funct
 
   set(tyrionInDisguise, 'fname', 'Tyrion');
 
-  deepEqual(obj.get('sortedItems').mapBy('fname'), [
+  assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Jaime',
     'Tyrion',
     'Bran',
@@ -1056,10 +1056,10 @@ QUnit.test('updating an item\'s sort properties updates the sorted array', funct
   ], 'updating an item\'s sort properties updates the sorted array');
 });
 
-QUnit.test('updating several of an item\'s sort properties updated the sorted array', function() {
+QUnit.test('updating several of an item\'s sort properties updated the sorted array', function(assert) {
   let sansaInDisguise = obj.get('items')[1];
 
-  deepEqual(obj.get('sortedItems').mapBy('fname'), [
+  assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Cersei',
     'Jaime',
     'Bran',
@@ -1071,7 +1071,7 @@ QUnit.test('updating several of an item\'s sort properties updated the sorted ar
     lname: 'Stark'
   });
 
-  deepEqual(obj.get('sortedItems').mapBy('fname'), [
+  assert.deepEqual(obj.get('sortedItems').mapBy('fname'), [
     'Jaime',
     'Bran',
     'Robb',
@@ -1079,7 +1079,7 @@ QUnit.test('updating several of an item\'s sort properties updated the sorted ar
   ], 'updating an item\'s sort properties updates the sorted array');
 });
 
-QUnit.test('updating an item\'s sort properties does not error when binary search does a self compare (#3273)', function() {
+QUnit.test('updating an item\'s sort properties does not error when binary search does a self compare (#3273)', function(assert) {
   let jaime = {
     name: 'Jaime',
     status: 1
@@ -1097,27 +1097,27 @@ QUnit.test('updating an item\'s sort properties does not error when binary searc
     people: [jaime, cersei]
   });
 
-  deepEqual(obj.get('sortedPeople'), [
+  assert.deepEqual(obj.get('sortedPeople'), [
     jaime,
     cersei
   ], 'precond - array is initially sorted');
 
   set(cersei, 'status', 3);
 
-  deepEqual(obj.get('sortedPeople'), [
+  assert.deepEqual(obj.get('sortedPeople'), [
     jaime,
     cersei
   ], 'array is sorted correctly');
 
   set(cersei, 'status', 2);
 
-  deepEqual(obj.get('sortedPeople'), [
+  assert.deepEqual(obj.get('sortedPeople'), [
     jaime,
     cersei
   ], 'array is sorted correctly');
 });
 
-QUnit.test('array observers do not leak', function() {
+QUnit.test('array observers do not leak', function(assert) {
   let daria = { name: 'Daria' };
   let jane  = { name: 'Jane' };
 
@@ -1138,13 +1138,13 @@ QUnit.test('array observers do not leak', function() {
     sortProps.pushObject({
       name: 'Anna'
     });
-    ok(true);
+    assert.ok(true);
   } catch (e) {
-    ok(false, e);
+    assert.ok(false, e);
   }
 });
 
-QUnit.test('property paths in sort properties update the sorted array', function () {
+QUnit.test('property paths in sort properties update the sorted array', function(assert) {
   let jaime = {
     relatedObj: { status: 1, firstName: 'Jaime', lastName: 'Lannister' }
   };
@@ -1164,7 +1164,7 @@ QUnit.test('property paths in sort properties update the sorted array', function
     people: [jaime, cersei, sansa]
   });
 
-  deepEqual(obj.get('sortedPeople'), [
+  assert.deepEqual(obj.get('sortedPeople'), [
     jaime,
     cersei,
     sansa
@@ -1172,7 +1172,7 @@ QUnit.test('property paths in sort properties update the sorted array', function
 
   set(cersei, 'status', 3);
 
-  deepEqual(obj.get('sortedPeople'), [
+  assert.deepEqual(obj.get('sortedPeople'), [
     jaime,
     cersei,
     sansa
@@ -1180,7 +1180,7 @@ QUnit.test('property paths in sort properties update the sorted array', function
 
   set(cersei, 'status', 1);
 
-  deepEqual(obj.get('sortedPeople'), [
+  assert.deepEqual(obj.get('sortedPeople'), [
     jaime,
     cersei,
     sansa
@@ -1188,22 +1188,22 @@ QUnit.test('property paths in sort properties update the sorted array', function
 
   sansa.set('status', 1);
 
-  deepEqual(obj.get('sortedPeople'), [jaime, cersei, sansa], 'array is sorted correctly');
+  assert.deepEqual(obj.get('sortedPeople'), [jaime, cersei, sansa], 'array is sorted correctly');
 
   obj.set('sortProps', ['relatedObj.firstName']);
 
-  deepEqual(obj.get('sortedPeople'), [cersei, jaime, sansa], 'array is sorted correctly');
+  assert.deepEqual(obj.get('sortedPeople'), [cersei, jaime, sansa], 'array is sorted correctly');
 });
 
-QUnit.test('if the dependentKey is neither an array nor object, it will return an empty array', () => {
+QUnit.test('if the dependentKey is neither an array nor object, it will return an empty array', assert => {
   set(obj, 'items', null);
-  ok(isArray(obj.get('sortedItems')), 'returns an empty arrays');
+  assert.ok(isArray(obj.get('sortedItems')), 'returns an empty arrays');
 
   set(obj, 'array', undefined);
-  ok(isArray(obj.get('sortedItems')), 'returns an empty arrays');
+  assert.ok(isArray(obj.get('sortedItems')), 'returns an empty arrays');
 
   set(obj, 'array', 'not an array');
-  ok(isArray(obj.get('sortedItems')), 'returns an empty arrays');
+  assert.ok(isArray(obj.get('sortedItems')), 'returns an empty arrays');
 });
 
 function sortByLnameFname(a, b) {
@@ -1228,7 +1228,7 @@ function sortByFnameAsc(a, b) {
 }
 
 QUnit.module('sort - sort function', {
-  setup() {
+  beforeEach() {
     obj = EmberObject.extend({
       sortedItems: sort('items.@each.fname', sortByLnameFname)
     }).create({
@@ -1240,15 +1240,15 @@ QUnit.module('sort - sort function', {
       ])
     });
   },
-  teardown() {
+  afterEach() {
     run(obj, 'destroy');
   }
 });
 
-QUnit.test('sort has correct `this`', function() {
+QUnit.test('sort has correct `this`', function(assert) {
   let obj = EmberObject.extend({
     sortedItems: sort('items.@each.fname', function(a, b) {
-      equal(this, obj, 'expected the object to be `this`');
+      assert.equal(this, obj, 'expected the object to be `this`');
       return this.sortByLastName(a, b);
     }),
     sortByLastName(a, b) {
@@ -1266,7 +1266,7 @@ QUnit.test('sort has correct `this`', function() {
   obj.get('sortedItems');
 });
 
-QUnit.test('sort (with function) is readOnly', function() {
+QUnit.test('sort (with function) is readOnly', function(assert) {
   QUnit.throws(function() {
     obj.set('sortedItems', 1);
   }, /Cannot set read-only property "sortedItems" on object:/);
@@ -1274,34 +1274,34 @@ QUnit.test('sort (with function) is readOnly', function() {
 
 commonSortTests();
 
-QUnit.test('changing item properties specified via @each triggers a resort of the modified item', function() {
+QUnit.test('changing item properties specified via @each triggers a resort of the modified item', function(assert) {
   let items = get(obj, 'items');
 
   let tyrionInDisguise = items[1];
 
-  deepEqual(obj.get('sortedItems').mapBy('fname'), ['Cersei', 'Jaime', 'Bran', 'Robb'], 'precond - array is initially sorted');
+  assert.deepEqual(obj.get('sortedItems').mapBy('fname'), ['Cersei', 'Jaime', 'Bran', 'Robb'], 'precond - array is initially sorted');
 
   set(tyrionInDisguise, 'fname', 'Tyrion');
 
-  deepEqual(obj.get('sortedItems').mapBy('fname'), ['Jaime', 'Tyrion', 'Bran', 'Robb'], 'updating a specified property on an item resorts it');
+  assert.deepEqual(obj.get('sortedItems').mapBy('fname'), ['Jaime', 'Tyrion', 'Bran', 'Robb'], 'updating a specified property on an item resorts it');
 });
 
-QUnit.test('changing item properties not specified via @each does not trigger a resort', function() {
+QUnit.test('changing item properties not specified via @each does not trigger a resort', function(assert) {
   let items = obj.get('items');
   let cersei = items[1];
 
-  deepEqual(obj.get('sortedItems').mapBy('fname'), ['Cersei', 'Jaime', 'Bran', 'Robb'], 'precond - array is initially sorted');
+  assert.deepEqual(obj.get('sortedItems').mapBy('fname'), ['Cersei', 'Jaime', 'Bran', 'Robb'], 'precond - array is initially sorted');
 
   set(cersei, 'lname', 'Stark'); // plot twist! (possibly not canon)
 
   // The array has become unsorted.  If your sort function is sensitive to
   // properties, they *must* be specified as dependent item property keys or
   // we'll be doing binary searches on unsorted arrays.
-  deepEqual(obj.get('sortedItems').mapBy('fname'), ['Cersei', 'Jaime', 'Bran', 'Robb'], 'updating an unspecified property on an item does not resort it');
+  assert.deepEqual(obj.get('sortedItems').mapBy('fname'), ['Cersei', 'Jaime', 'Bran', 'Robb'], 'updating an unspecified property on an item does not resort it');
 });
 
 QUnit.module('sort - stability', {
-  setup() {
+  beforeEach() {
     obj = EmberObject.extend({
       sortProps: ['count', 'name'],
       sortedItems: sort('items', 'sortProps')
@@ -1314,22 +1314,22 @@ QUnit.module('sort - stability', {
       ]
     });
   },
-  teardown() {
+  afterEach() {
     run(obj, 'destroy');
   }
 });
 
-QUnit.test('sorts correctly as only one property changes', function() {
-  deepEqual(obj.get('sortedItems').mapBy('name'), ['A', 'B', 'C', 'D'], 'initial');
+QUnit.test('sorts correctly as only one property changes', function(assert) {
+  assert.deepEqual(obj.get('sortedItems').mapBy('name'), ['A', 'B', 'C', 'D'], 'initial');
 
   set(obj.get('items')[3], 'count', 2);
 
-  deepEqual(obj.get('sortedItems').mapBy('name'), ['A', 'B', 'C', 'D'], 'final');
+  assert.deepEqual(obj.get('sortedItems').mapBy('name'), ['A', 'B', 'C', 'D'], 'final');
 });
 
 let klass;
 QUnit.module('sort - concurrency', {
-  setup() {
+  beforeEach() {
     klass = EmberObject.extend({
       sortProps: ['count'],
       sortedItems: sort('items', 'sortProps'),
@@ -1345,33 +1345,33 @@ QUnit.module('sort - concurrency', {
     });
   },
 
-  teardown() {
+  afterEach() {
     run(obj, 'destroy');
   }
 });
 
-QUnit.test('sorts correctly after mutation to the sort properties', function() {
+QUnit.test('sorts correctly after mutation to the sort properties', function(assert) {
   let sorted = obj.get('sortedItems');
-  deepEqual(sorted.mapBy('name'), ['A', 'B', 'C', 'D'], 'initial');
+  assert.deepEqual(sorted.mapBy('name'), ['A', 'B', 'C', 'D'], 'initial');
 
   set(obj.get('items')[1], 'count', 5);
   set(obj.get('items')[2], 'count', 6);
 
-  deepEqual(obj.get('sortedItems').mapBy('name'), ['A', 'D', 'B', 'C'], 'final');
+  assert.deepEqual(obj.get('sortedItems').mapBy('name'), ['A', 'D', 'B', 'C'], 'final');
 });
 
-QUnit.test('sort correctly after mutation to the sort', function() {
-  deepEqual(obj.get('customSortedItems').mapBy('name'), ['A', 'B', 'C', 'D'], 'initial');
+QUnit.test('sort correctly after mutation to the sort', function(assert) {
+  assert.deepEqual(obj.get('customSortedItems').mapBy('name'), ['A', 'B', 'C', 'D'], 'initial');
 
   set(obj.get('items')[1], 'count', 5);
   set(obj.get('items')[2], 'count', 6);
 
-  deepEqual(obj.get('customSortedItems').mapBy('name'), ['A', 'D', 'B', 'C'], 'final');
+  assert.deepEqual(obj.get('customSortedItems').mapBy('name'), ['A', 'D', 'B', 'C'], 'final');
 
-  deepEqual(obj.get('sortedItems').mapBy('name'), ['A', 'D', 'B', 'C'], 'final');
+  assert.deepEqual(obj.get('sortedItems').mapBy('name'), ['A', 'D', 'B', 'C'], 'final');
 });
 
-QUnit.test('sort correctly on multiple instances of the same class', function() {
+QUnit.test('sort correctly on multiple instances of the same class', function(assert) {
   let obj2 = klass.create({
     items: emberA([
       { name: 'W', count: 23, thing: 4 },
@@ -1381,31 +1381,31 @@ QUnit.test('sort correctly on multiple instances of the same class', function() 
     ])
   });
 
-  deepEqual(obj2.get('sortedItems').mapBy('name'), ['W', 'X', 'Y', 'Z'], 'initial');
-  deepEqual(obj.get('sortedItems').mapBy('name'), ['A', 'B', 'C', 'D'], 'initial');
+  assert.deepEqual(obj2.get('sortedItems').mapBy('name'), ['W', 'X', 'Y', 'Z'], 'initial');
+  assert.deepEqual(obj.get('sortedItems').mapBy('name'), ['A', 'B', 'C', 'D'], 'initial');
 
   set(obj.get('items')[1], 'count', 5);
   set(obj.get('items')[2], 'count', 6);
   set(obj2.get('items')[1], 'count', 27);
   set(obj2.get('items')[2], 'count', 28);
 
-  deepEqual(obj.get('sortedItems').mapBy('name'), ['A', 'D', 'B', 'C'], 'final');
-  deepEqual(obj2.get('sortedItems').mapBy('name'), ['W', 'Z', 'X', 'Y'], 'final');
+  assert.deepEqual(obj.get('sortedItems').mapBy('name'), ['A', 'D', 'B', 'C'], 'final');
+  assert.deepEqual(obj2.get('sortedItems').mapBy('name'), ['W', 'Z', 'X', 'Y'], 'final');
 
   obj.set('sortProps', ['thing']);
 
-  deepEqual(obj.get('sortedItems').mapBy('name'), ['D', 'C', 'B', 'A'], 'final');
+  assert.deepEqual(obj.get('sortedItems').mapBy('name'), ['D', 'C', 'B', 'A'], 'final');
 
   obj2.notifyPropertyChange('sortedItems'); // invalidate to flush, to get DK refreshed
   obj2.get('sortedItems'); // flush to get updated DK
 
   obj2.set('items.firstObject.count', 9999);
 
-  deepEqual(obj2.get('sortedItems').mapBy('name'), ['Z', 'X', 'Y', 'W'], 'final');
+  assert.deepEqual(obj2.get('sortedItems').mapBy('name'), ['Z', 'X', 'Y', 'W'], 'final');
 });
 
 
-QUnit.test('sort correctly when multiple sorts are chained on the same instance of a class', function() {
+QUnit.test('sort correctly when multiple sorts are chained on the same instance of a class', function(assert) {
   let obj2 = klass.extend({
     items: computed('sibling.sortedItems.[]', function() {
       return this.get('sibling.sortedItems');
@@ -1433,114 +1433,114 @@ QUnit.test('sort correctly when multiple sorts are chained on the same instance 
 └───────────┘                            ┗━━━━━━━━━━━┛                              ┗━━━━━━━━━━━━┛
    */
 
-  deepEqual(obj.get('sortedItems').mapBy('name'), ['A', 'B', 'C', 'D'], 'obj.sortedItems.name should be sorted alpha');
-  deepEqual(obj2.get('sortedItems').mapBy('name'), ['A', 'B', 'C', 'D'], 'obj2.sortedItems.name should be sorted alpha');
+  assert.deepEqual(obj.get('sortedItems').mapBy('name'), ['A', 'B', 'C', 'D'], 'obj.sortedItems.name should be sorted alpha');
+  assert.deepEqual(obj2.get('sortedItems').mapBy('name'), ['A', 'B', 'C', 'D'], 'obj2.sortedItems.name should be sorted alpha');
 
   set(obj.get('items')[1], 'count', 5);
   set(obj.get('items')[2], 'count', 6);
 
-  deepEqual(obj.get('sortedItems').mapBy('name'), ['A', 'D', 'B', 'C'], 'obj.sortedItems.name should now have changed');
-  deepEqual(obj2.get('sortedItems').mapBy('name'), ['A', 'D', 'B', 'C'], 'obj2.sortedItems.name should still mirror sortedItems2');
+  assert.deepEqual(obj.get('sortedItems').mapBy('name'), ['A', 'D', 'B', 'C'], 'obj.sortedItems.name should now have changed');
+  assert.deepEqual(obj2.get('sortedItems').mapBy('name'), ['A', 'D', 'B', 'C'], 'obj2.sortedItems.name should still mirror sortedItems2');
 
   obj.set('sortProps', ['thing']);
   obj2.set('sortProps', ['id']);
 
-  deepEqual(obj2.get('sortedItems').mapBy('name'), ['A', 'B', 'C', 'D'], 'we now sort obj2 by id, so we expect a b c d');
-  deepEqual(obj.get('sortedItems').mapBy('name'), ['D', 'C', 'B', 'A'], 'we now sort obj by thing');
+  assert.deepEqual(obj2.get('sortedItems').mapBy('name'), ['A', 'B', 'C', 'D'], 'we now sort obj2 by id, so we expect a b c d');
+  assert.deepEqual(obj.get('sortedItems').mapBy('name'), ['D', 'C', 'B', 'A'], 'we now sort obj by thing');
 });
 
 QUnit.module('max', {
-  setup() {
+  beforeEach() {
     obj = EmberObject.extend({
       max: max('items')
     }).create({
       items: emberA([1, 2, 3])
     });
   },
-  teardown() {
+  afterEach() {
     run(obj, 'destroy');
   }
 });
 
-QUnit.test('max is readOnly', function() {
+QUnit.test('max is readOnly', function(assert) {
   QUnit.throws(function() {
     obj.set('max', 1);
   }, /Cannot set read-only property "max" on object:/);
 });
 
-QUnit.test('max tracks the max number as objects are added', function() {
-  equal(obj.get('max'), 3, 'precond - max is initially correct');
+QUnit.test('max tracks the max number as objects are added', function(assert) {
+  assert.equal(obj.get('max'), 3, 'precond - max is initially correct');
 
   let items = obj.get('items');
 
   items.pushObject(5);
 
-  equal(obj.get('max'), 5, 'max updates when a larger number is added');
+  assert.equal(obj.get('max'), 5, 'max updates when a larger number is added');
 
   items.pushObject(2);
 
-  equal(obj.get('max'), 5, 'max does not update when a smaller number is added');
+  assert.equal(obj.get('max'), 5, 'max does not update when a smaller number is added');
 });
 
-QUnit.test('max recomputes when the current max is removed', function() {
-  equal(obj.get('max'), 3, 'precond - max is initially correct');
+QUnit.test('max recomputes when the current max is removed', function(assert) {
+  assert.equal(obj.get('max'), 3, 'precond - max is initially correct');
 
   obj.get('items').removeObject(2);
 
-  equal(obj.get('max'), 3, 'max is unchanged when a non-max item is removed');
+  assert.equal(obj.get('max'), 3, 'max is unchanged when a non-max item is removed');
 
   obj.get('items').removeObject(3);
 
-  equal(obj.get('max'), 1, 'max is recomputed when the current max is removed');
+  assert.equal(obj.get('max'), 1, 'max is recomputed when the current max is removed');
 });
 
 QUnit.module('min', {
-  setup() {
+  beforeEach() {
     obj = EmberObject.extend({
       min: min('items')
     }).create({
       items: emberA([1, 2, 3])
     });
   },
-  teardown() {
+  afterEach() {
     run(obj, 'destroy');
   }
 });
 
-QUnit.test('min is readOnly', function() {
+QUnit.test('min is readOnly', function(assert) {
   QUnit.throws(function() {
     obj.set('min', 1);
   }, /Cannot set read-only property "min" on object:/);
 });
 
-QUnit.test('min tracks the min number as objects are added', function() {
-  equal(obj.get('min'), 1, 'precond - min is initially correct');
+QUnit.test('min tracks the min number as objects are added', function(assert) {
+  assert.equal(obj.get('min'), 1, 'precond - min is initially correct');
 
   obj.get('items').pushObject(-2);
 
-  equal(obj.get('min'), -2, 'min updates when a smaller number is added');
+  assert.equal(obj.get('min'), -2, 'min updates when a smaller number is added');
 
   obj.get('items').pushObject(2);
 
-  equal(obj.get('min'), -2, 'min does not update when a larger number is added');
+  assert.equal(obj.get('min'), -2, 'min does not update when a larger number is added');
 });
 
-QUnit.test('min recomputes when the current min is removed', function() {
+QUnit.test('min recomputes when the current min is removed', function(assert) {
   let items = obj.get('items');
 
-  equal(obj.get('min'), 1, 'precond - min is initially correct');
+  assert.equal(obj.get('min'), 1, 'precond - min is initially correct');
 
   items.removeObject(2);
 
-  equal(obj.get('min'), 1, 'min is unchanged when a non-min item is removed');
+  assert.equal(obj.get('min'), 1, 'min is unchanged when a non-min item is removed');
 
   items.removeObject(1);
 
-  equal(obj.get('min'), 3, 'min is recomputed when the current min is removed');
+  assert.equal(obj.get('min'), 3, 'min is recomputed when the current min is removed');
 });
 
 QUnit.module('Ember.arrayComputed - mixed sugar', {
-  setup() {
+  beforeEach() {
     obj = EmberObject.extend({
       lannisters: filterBy('items', 'lname', 'Lannister'),
       lannisterSorting: emberA(['fname']),
@@ -1558,35 +1558,35 @@ QUnit.module('Ember.arrayComputed - mixed sugar', {
       ])
     });
   },
-  teardown() {
+  afterEach() {
     run(obj, 'destroy');
   }
 });
 
-QUnit.test('filtering and sorting can be combined', function() {
+QUnit.test('filtering and sorting can be combined', function(assert) {
   let items = obj.get('items');
 
-  deepEqual(obj.get('sortedLannisters').mapBy('fname'), ['Cersei', 'Jaime'], 'precond - array is initially filtered and sorted');
+  assert.deepEqual(obj.get('sortedLannisters').mapBy('fname'), ['Cersei', 'Jaime'], 'precond - array is initially filtered and sorted');
 
   items.pushObject({ fname: 'Tywin',   lname: 'Lannister' });
   items.pushObject({ fname: 'Lyanna',  lname: 'Stark' });
   items.pushObject({ fname: 'Gerion',  lname: 'Lannister' });
 
-  deepEqual(obj.get('sortedLannisters').mapBy('fname'), ['Cersei', 'Gerion', 'Jaime', 'Tywin'], 'updates propagate to array');
+  assert.deepEqual(obj.get('sortedLannisters').mapBy('fname'), ['Cersei', 'Gerion', 'Jaime', 'Tywin'], 'updates propagate to array');
 });
 
-QUnit.test('filtering, sorting and reduce (max) can be combined', function() {
+QUnit.test('filtering, sorting and reduce (max) can be combined', function(assert) {
   let items = obj.get('items');
 
-  equal(16, obj.get('oldestStarkAge'), 'precond - end of chain is initially correct');
+  assert.equal(16, obj.get('oldestStarkAge'), 'precond - end of chain is initially correct');
 
   items.pushObject({ fname: 'Rickon', lname: 'Stark', age: 5 });
 
-  equal(16, obj.get('oldestStarkAge'), 'chain is updated correctly');
+  assert.equal(16, obj.get('oldestStarkAge'), 'chain is updated correctly');
 
   items.pushObject({ fname: 'Eddard', lname: 'Stark', age: 35 });
 
-  equal(35, obj.get('oldestStarkAge'), 'chain is updated correctly');
+  assert.equal(35, obj.get('oldestStarkAge'), 'chain is updated correctly');
 });
 
 function todo(name, priority) {
@@ -1607,7 +1607,7 @@ function evenPriorities(todo) {
 }
 
 QUnit.module('Ember.arrayComputed - chains', {
-  setup() {
+  beforeEach() {
     obj = EmberObject.extend({
       sorted: sort('todos.@each.priority', priorityComparator),
       filtered: filter('sorted.@each.priority', evenPriorities)
@@ -1621,26 +1621,26 @@ QUnit.module('Ember.arrayComputed - chains', {
       ])
     });
   },
-  teardown() {
+  afterEach() {
     run(obj, 'destroy');
   }
 });
 
-QUnit.test('it can filter and sort when both depend on the same item property', function() {
-  deepEqual(obj.get('todos').mapBy('name'), ['E', 'D', 'C', 'B', 'A'], 'precond - todos initially correct');
-  deepEqual(obj.get('sorted').mapBy('name'), ['A', 'B', 'C', 'D', 'E'], 'precond - sorted initially correct');
-  deepEqual(obj.get('filtered').mapBy('name'), ['A', 'C', 'E'], 'precond - filtered initially correct');
+QUnit.test('it can filter and sort when both depend on the same item property', function(assert) {
+  assert.deepEqual(obj.get('todos').mapBy('name'), ['E', 'D', 'C', 'B', 'A'], 'precond - todos initially correct');
+  assert.deepEqual(obj.get('sorted').mapBy('name'), ['A', 'B', 'C', 'D', 'E'], 'precond - sorted initially correct');
+  assert.deepEqual(obj.get('filtered').mapBy('name'), ['A', 'C', 'E'], 'precond - filtered initially correct');
 
   set(obj.get('todos')[1], 'priority', 6);
 
-  deepEqual(obj.get('todos').mapBy('name'), ['E', 'D', 'C', 'B', 'A'], 'precond - todos remain correct');
-  deepEqual(obj.get('sorted').mapBy('name'), ['A', 'B', 'C', 'E', 'D'], 'precond - sorted updated correctly');
-  deepEqual(obj.get('filtered').mapBy('name'), ['A', 'C', 'E', 'D'], 'filtered updated correctly');
+  assert.deepEqual(obj.get('todos').mapBy('name'), ['E', 'D', 'C', 'B', 'A'], 'precond - todos remain correct');
+  assert.deepEqual(obj.get('sorted').mapBy('name'), ['A', 'B', 'C', 'E', 'D'], 'precond - sorted updated correctly');
+  assert.deepEqual(obj.get('filtered').mapBy('name'), ['A', 'C', 'E', 'D'], 'filtered updated correctly');
 });
 
 let userFnCalls;
 QUnit.module('Chaining array and reduced CPs', {
-  setup() {
+  beforeEach() {
     userFnCalls = 0;
     obj = EmberObject.extend({
       mapped: mapBy('array', 'v'),
@@ -1655,13 +1655,13 @@ QUnit.module('Chaining array and reduced CPs', {
       ])
     });
   },
-  teardown() {
+  afterEach() {
     run(obj, 'destroy');
   }
 });
 
-QUnit.test('it computes interdependent array computed properties', function() {
-  equal(obj.get('max'), 3, 'sanity - it properly computes the maximum value');
+QUnit.test('it computes interdependent array computed properties', function(assert) {
+  assert.equal(obj.get('max'), 3, 'sanity - it properly computes the maximum value');
 
   let calls = 0;
 
@@ -1669,13 +1669,13 @@ QUnit.test('it computes interdependent array computed properties', function() {
 
   obj.get('array').pushObject({ v: 5 });
 
-  equal(obj.get('max'), 5, 'maximum value is updated correctly');
-  equal(userFnCalls, 1, 'object defined observers fire');
-  equal(calls, 1, 'runtime created observers fire');
+  assert.equal(obj.get('max'), 5, 'maximum value is updated correctly');
+  assert.equal(userFnCalls, 1, 'object defined observers fire');
+  assert.equal(calls, 1, 'runtime created observers fire');
 });
 
 QUnit.module('sum', {
-  setup() {
+  beforeEach() {
     obj = EmberObject.extend({
       total: sum('array')
     }).create({
@@ -1683,39 +1683,39 @@ QUnit.module('sum', {
     });
   },
 
-  teardown() {
+  afterEach() {
     run(obj, 'destroy');
   }
 });
 
-QUnit.test('sum is readOnly', function() {
+QUnit.test('sum is readOnly', function(assert) {
   QUnit.throws(function() {
     obj.set('total', 1);
   }, /Cannot set read-only property "total" on object:/);
 });
-QUnit.test('sums the values in the dependentKey', function() {
-  equal(obj.get('total'), 6, 'sums the values');
+QUnit.test('sums the values in the dependentKey', function(assert) {
+  assert.equal(obj.get('total'), 6, 'sums the values');
 });
 
-QUnit.test('if the dependentKey is neither an array nor object, it will return `0`', () => {
+QUnit.test('if the dependentKey is neither an array nor object, it will return `0`', assert => {
   set(obj, 'array', null);
-  equal(get(obj, 'total'), 0, 'returns 0');
+  assert.equal(get(obj, 'total'), 0, 'returns 0');
 
   set(obj, 'array', undefined);
-  equal(get(obj, 'total'), 0, 'returns 0');
+  assert.equal(get(obj, 'total'), 0, 'returns 0');
 
   set(obj, 'array', 'not an array');
-  equal(get(obj, 'total'), 0, 'returns 0');
+  assert.equal(get(obj, 'total'), 0, 'returns 0');
 });
 
-QUnit.test('updates when array is modified', function() {
+QUnit.test('updates when array is modified', function(assert) {
   obj.get('array').pushObject(1);
 
-  equal(obj.get('total'), 7, 'recomputed when elements are added');
+  assert.equal(obj.get('total'), 7, 'recomputed when elements are added');
 
   obj.get('array').popObject();
 
-  equal(obj.get('total'), 6, 'recomputes when elements are removed');
+  assert.equal(obj.get('total'), 6, 'recomputes when elements are removed');
 });
 
 QUnit.module('collect');
@@ -1724,15 +1724,15 @@ testBoth('works', function(get, set) {
   let obj = { one: 'foo', two: 'bar', three: null };
   defineProperty(obj, 'all', collect('one', 'two', 'three', 'four'));
 
-  deepEqual(get(obj, 'all'), ['foo', 'bar', null, null], 'have all of them');
+  assert.deepEqual(get(obj, 'all'), ['foo', 'bar', null, null], 'have all of them');
 
   set(obj, 'four', true);
 
-  deepEqual(get(obj, 'all'), ['foo', 'bar', null, true], 'have all of them');
+  assert.deepEqual(get(obj, 'all'), ['foo', 'bar', null, true], 'have all of them');
 
   let a = [];
   set(obj, 'one', 0);
   set(obj, 'three', a);
 
-  deepEqual(get(obj, 'all'), [0, 'bar', a, true], 'have all of them');
+  assert.deepEqual(get(obj, 'all'), [0, 'bar', a, true], 'have all of them');
 });

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -58,7 +58,7 @@ QUnit.module('map', {
 });
 
 QUnit.test('map is readOnly', function(assert) {
-  QUnit.throws(function() {
+  assert.throws(function() {
     obj.set('mapped', 1);
   }, /Cannot set read-only property "mapped" on object:/);
 });
@@ -191,7 +191,7 @@ QUnit.module('mapBy', {
 });
 
 QUnit.test('mapBy is readOnly', function(assert) {
-  QUnit.throws(function() {
+  assert.throws(function() {
     obj.set('mapped', 1);
   }, /Cannot set read-only property "mapped" on object:/);
 });
@@ -234,7 +234,7 @@ QUnit.module('filter', {
 });
 
 QUnit.test('filter is readOnly', function(assert) {
-  QUnit.throws(function() {
+  assert.throws(function() {
     obj.set('filtered', 1);
   }, /Cannot set read-only property "filtered" on object:/);
 });
@@ -383,7 +383,7 @@ QUnit.module('filterBy', {
 });
 
 QUnit.test('filterBy is readOnly', function(assert) {
-  QUnit.throws(function() {
+  assert.throws(function() {
     obj.set('as', 1);
   }, /Cannot set read-only property "as" on object:/);
 });
@@ -475,7 +475,7 @@ QUnit.test('properties values can be replaced', function(assert) {
   });
 
   QUnit.test(`${name} is readOnly`, function(assert) {
-    QUnit.throws(function() {
+    assert.throws(function() {
       obj.set('union', 1);
     }, /Cannot set read-only property "union" on object:/);
   });
@@ -537,7 +537,7 @@ QUnit.module('computed.uniqBy', {
 });
 
 QUnit.test('uniqBy is readOnly', function(assert) {
-  QUnit.throws(function() {
+  assert.throws(function() {
     obj.set('uniqueById', 1);
   }, /Cannot set read-only property "uniqueById" on object:/);
 });
@@ -605,7 +605,7 @@ QUnit.module('computed.intersect', {
 });
 
 QUnit.test('intersect is readOnly', function(assert) {
-  QUnit.throws(function() {
+  assert.throws(function() {
     obj.set('intersection', 1);
   }, /Cannot set read-only property "intersection" on object:/);
 });
@@ -652,12 +652,12 @@ QUnit.module('setDiff', {
 });
 
 QUnit.test('setDiff is readOnly', function(assert) {
-  QUnit.throws(function() {
+  assert.throws(function() {
     obj.set('diff', 1);
   }, /Cannot set read-only property "diff" on object:/);
 });
 
-QUnit.test('it asserts if given fewer or more than two dependent properties', function(assert) {
+QUnit.test('it asserts if given fewer or more than two dependent properties', function() {
   expectAssertion(function () {
     EmberObject.extend({
       diff: setDiff('array')
@@ -893,7 +893,7 @@ QUnit.module('sort - sortProperties', {
 });
 
 QUnit.test('sort is readOnly', function(assert) {
-  QUnit.throws(function() {
+  assert.throws(function() {
     obj.set('sortedItems', 1);
   }, /Cannot set read-only property "sortedItems" on object:/);
 });
@@ -1267,7 +1267,7 @@ QUnit.test('sort has correct `this`', function(assert) {
 });
 
 QUnit.test('sort (with function) is readOnly', function(assert) {
-  QUnit.throws(function() {
+  assert.throws(function() {
     obj.set('sortedItems', 1);
   }, /Cannot set read-only property "sortedItems" on object:/);
 });
@@ -1463,7 +1463,7 @@ QUnit.module('max', {
 });
 
 QUnit.test('max is readOnly', function(assert) {
-  QUnit.throws(function() {
+  assert.throws(function() {
     obj.set('max', 1);
   }, /Cannot set read-only property "max" on object:/);
 });
@@ -1508,7 +1508,7 @@ QUnit.module('min', {
 });
 
 QUnit.test('min is readOnly', function(assert) {
-  QUnit.throws(function() {
+  assert.throws(function() {
     obj.set('min', 1);
   }, /Cannot set read-only property "min" on object:/);
 });
@@ -1689,7 +1689,7 @@ QUnit.module('sum', {
 });
 
 QUnit.test('sum is readOnly', function(assert) {
-  QUnit.throws(function() {
+  assert.throws(function() {
     obj.set('total', 1);
   }, /Cannot set read-only property "total" on object:/);
 });
@@ -1720,7 +1720,7 @@ QUnit.test('updates when array is modified', function(assert) {
 
 QUnit.module('collect');
 
-testBoth('works', function(get, set) {
+testBoth('works', function(get, set, assert) {
   let obj = { one: 'foo', two: 'bar', three: null };
   defineProperty(obj, 'all', collect('one', 'two', 'three', 'four'));
 

--- a/packages/ember-runtime/tests/controllers/controller_test.js
+++ b/packages/ember-runtime/tests/controllers/controller_test.js
@@ -138,7 +138,7 @@ QUnit.test('specifying `content` (with `model` specified) does not result in dep
 QUnit.module('Controller injected properties');
 
 if (!EmberDev.runningProdBuild) {
-  QUnit.test('defining a controller on a non-controller should fail assertion', function(assert) {
+  QUnit.test('defining a controller on a non-controller should fail assertion', function() {
     expectAssertion(function() {
       let owner = buildOwner();
 

--- a/packages/ember-runtime/tests/controllers/controller_test.js
+++ b/packages/ember-runtime/tests/controllers/controller_test.js
@@ -9,12 +9,12 @@ import { buildOwner } from 'internal-test-helpers';
 
 QUnit.module('Controller event handling');
 
-QUnit.test('Action can be handled by a function on actions object', function() {
-  expect(1);
+QUnit.test('Action can be handled by a function on actions object', function(assert) {
+  assert.expect(1);
   let TestController = Controller.extend({
     actions: {
       poke() {
-        ok(true, 'poked');
+        assert.ok(true, 'poked');
       }
     }
   });
@@ -22,12 +22,12 @@ QUnit.test('Action can be handled by a function on actions object', function() {
   controller.send('poke');
 });
 
-QUnit.test('A handled action can be bubbled to the target for continued processing', function() {
-  expect(2);
+QUnit.test('A handled action can be bubbled to the target for continued processing', function(assert) {
+  assert.expect(2);
   let TestController = Controller.extend({
     actions: {
       poke() {
-        ok(true, 'poked 1');
+        assert.ok(true, 'poked 1');
         return true;
       }
     }
@@ -37,7 +37,7 @@ QUnit.test('A handled action can be bubbled to the target for continued processi
     target: Controller.extend({
       actions: {
         poke() {
-          ok(true, 'poked 2');
+          assert.ok(true, 'poked 2');
         }
       }
     }).create()
@@ -45,16 +45,16 @@ QUnit.test('A handled action can be bubbled to the target for continued processi
   controller.send('poke');
 });
 
-QUnit.test('Action can be handled by a superclass\' actions object', function() {
-  expect(4);
+QUnit.test('Action can be handled by a superclass\' actions object', function(assert) {
+  assert.expect(4);
 
   let SuperController = Controller.extend({
     actions: {
       foo() {
-        ok(true, 'foo');
+        assert.ok(true, 'foo');
       },
       bar(msg) {
-        equal(msg, 'HELLO');
+        assert.equal(msg, 'HELLO');
       }
     }
   });
@@ -62,7 +62,7 @@ QUnit.test('Action can be handled by a superclass\' actions object', function() 
   let BarControllerMixin = Mixin.create({
     actions: {
       bar(msg) {
-        equal(msg, 'HELLO');
+        assert.equal(msg, 'HELLO');
         this._super(msg);
       }
     }
@@ -71,7 +71,7 @@ QUnit.test('Action can be handled by a superclass\' actions object', function() 
   let IndexController = SuperController.extend(BarControllerMixin, {
     actions: {
       baz() {
-        ok(true, 'baz');
+        assert.ok(true, 'baz');
       }
     }
   });
@@ -86,19 +86,19 @@ QUnit.module('Controller deprecations');
 
 QUnit.module('Controller Content -> Model Alias');
 
-QUnit.test('`content` is a deprecated alias of `model`', function() {
-  expect(2);
+QUnit.test('`content` is a deprecated alias of `model`', function(assert) {
+  assert.expect(2);
   let controller = Controller.extend({
     model: 'foo-bar'
   }).create();
 
   expectDeprecation(function () {
-    equal(controller.get('content'), 'foo-bar', 'content is an alias of model');
+    assert.equal(controller.get('content'), 'foo-bar', 'content is an alias of model');
   });
 });
 
-QUnit.test('`content` is not moved to `model` when `model` is unset', function() {
-  expect(2);
+QUnit.test('`content` is not moved to `model` when `model` is unset', function(assert) {
+  assert.expect(2);
   let controller;
 
   ignoreDeprecation(function() {
@@ -107,23 +107,23 @@ QUnit.test('`content` is not moved to `model` when `model` is unset', function()
     }).create();
   });
 
-  notEqual(controller.get('model'), 'foo-bar', 'model is set properly');
-  equal(controller.get('content'), 'foo-bar', 'content is not set properly');
+  assert.notEqual(controller.get('model'), 'foo-bar', 'model is set properly');
+  assert.equal(controller.get('content'), 'foo-bar', 'content is not set properly');
 });
 
-QUnit.test('specifying `content` (without `model` specified) does not result in deprecation', function() {
-  expect(2);
+QUnit.test('specifying `content` (without `model` specified) does not result in deprecation', function(assert) {
+  assert.expect(2);
   expectNoDeprecation();
 
   let controller = Controller.extend({
     content: 'foo-bar'
   }).create();
 
-  equal(get(controller, 'content'), 'foo-bar');
+  assert.equal(get(controller, 'content'), 'foo-bar');
 });
 
-QUnit.test('specifying `content` (with `model` specified) does not result in deprecation', function() {
-  expect(3);
+QUnit.test('specifying `content` (with `model` specified) does not result in deprecation', function(assert) {
+  assert.expect(3);
   expectNoDeprecation();
 
   let controller = Controller.extend({
@@ -131,14 +131,14 @@ QUnit.test('specifying `content` (with `model` specified) does not result in dep
     model: 'blammo'
   }).create();
 
-  equal(get(controller, 'content'), 'foo-bar');
-  equal(get(controller, 'model'), 'blammo');
+  assert.equal(get(controller, 'content'), 'foo-bar');
+  assert.equal(get(controller, 'model'), 'blammo');
 });
 
 QUnit.module('Controller injected properties');
 
 if (!EmberDev.runningProdBuild) {
-  QUnit.test('defining a controller on a non-controller should fail assertion', function() {
+  QUnit.test('defining a controller on a non-controller should fail assertion', function(assert) {
     expectAssertion(function() {
       let owner = buildOwner();
 
@@ -154,7 +154,7 @@ if (!EmberDev.runningProdBuild) {
   });
 }
 
-QUnit.test('controllers can be injected into controllers', function() {
+QUnit.test('controllers can be injected into controllers', function(assert) {
   let owner = buildOwner();
 
   owner.register('controller:post', Controller.extend({
@@ -166,10 +166,10 @@ QUnit.test('controllers can be injected into controllers', function() {
   let postController = owner.lookup('controller:post');
   let postsController = owner.lookup('controller:posts');
 
-  equal(postsController, postController.get('postsController'), 'controller.posts is injected');
+  assert.equal(postsController, postController.get('postsController'), 'controller.posts is injected');
 });
 
-QUnit.test('services can be injected into controllers', function() {
+QUnit.test('services can be injected into controllers', function(assert) {
   let owner = buildOwner();
 
   owner.register('controller:application', Controller.extend({
@@ -181,5 +181,5 @@ QUnit.test('services can be injected into controllers', function() {
   let appController = owner.lookup('controller:application');
   let authService = owner.lookup('service:auth');
 
-  equal(authService, appController.get('authService'), 'service.auth is injected');
+  assert.equal(authService, appController.get('authService'), 'service.auth is injected');
 });

--- a/packages/ember-runtime/tests/core/compare_test.js
+++ b/packages/ember-runtime/tests/core/compare_test.js
@@ -13,7 +13,7 @@ Comp.reopenClass({
 });
 
 QUnit.module('Ember.compare()', {
-  setup() {
+  beforeEach() {
     data[0]  = null;
     data[1]  = false;
     data[2]  = true;
@@ -33,13 +33,13 @@ QUnit.module('Ember.compare()', {
   }
 });
 
-QUnit.test('ordering should work', function() {
+QUnit.test('ordering should work', function(assert) {
   let suspect, comparable, failureMessage, suspectIndex, comparableIndex;
 
   for (suspectIndex = 0; suspectIndex < data.length; suspectIndex++) {
     suspect = data[suspectIndex];
 
-    equal(compare(suspect, suspect), 0, suspectIndex + ' should equal itself');
+    assert.equal(compare(suspect, suspect), 0, suspectIndex + ' should equal itself');
 
     for (comparableIndex = suspectIndex + 1; comparableIndex < data.length; comparableIndex++) {
       comparable = data[comparableIndex];
@@ -48,12 +48,12 @@ QUnit.test('ordering should work', function() {
         ') should be smaller than data[' + comparableIndex + '] (' +
         typeOf(comparable) + ')';
 
-      equal(compare(suspect, comparable), -1, failureMessage);
+      assert.equal(compare(suspect, comparable), -1, failureMessage);
     }
   }
 });
 
-QUnit.test('comparables should return values in the range of -1, 0, 1', function() {
+QUnit.test('comparables should return values in the range of -1, 0, 1', function(assert) {
   let negOne = Comp.create({
     val: -1
   });
@@ -66,11 +66,11 @@ QUnit.test('comparables should return values in the range of -1, 0, 1', function
     val: 1
   });
 
-  equal(compare(negOne, 'a'), -1, 'First item comparable - returns -1 (not negated)');
-  equal(compare(zero, 'b'), 0, 'First item comparable - returns  0 (not negated)');
-  equal(compare(one, 'c'), 1, 'First item comparable - returns  1 (not negated)');
+  assert.equal(compare(negOne, 'a'), -1, 'First item comparable - returns -1 (not negated)');
+  assert.equal(compare(zero, 'b'), 0, 'First item comparable - returns  0 (not negated)');
+  assert.equal(compare(one, 'c'), 1, 'First item comparable - returns  1 (not negated)');
 
-  equal(compare('a', negOne), 1, 'Second item comparable - returns -1 (negated)');
-  equal(compare('b', zero), 0, 'Second item comparable - returns  0 (negated)');
-  equal(compare('c', one), -1, 'Second item comparable - returns  1 (negated)');
+  assert.equal(compare('a', negOne), 1, 'Second item comparable - returns -1 (negated)');
+  assert.equal(compare('b', zero), 0, 'Second item comparable - returns  0 (negated)');
+  assert.equal(compare('c', one), -1, 'Second item comparable - returns  1 (negated)');
 });

--- a/packages/ember-runtime/tests/core/copy_test.js
+++ b/packages/ember-runtime/tests/core/copy_test.js
@@ -2,30 +2,30 @@ import copy from '../../copy';
 
 QUnit.module('Ember Copy Method');
 
-QUnit.test('Ember.copy null', function() {
+QUnit.test('Ember.copy null', function(assert) {
   let obj = { field: null };
 
-  equal(copy(obj, true).field, null, 'null should still be null');
+  assert.equal(copy(obj, true).field, null, 'null should still be null');
 });
 
-QUnit.test('Ember.copy date', function() {
+QUnit.test('Ember.copy date', function(assert) {
   let date = new Date(2014, 7, 22);
   let dateCopy = copy(date);
 
-  equal(date.getTime(), dateCopy.getTime(), 'dates should be equivalent');
+  assert.equal(date.getTime(), dateCopy.getTime(), 'dates should be equivalent');
 });
 
-QUnit.test('Ember.copy null prototype object', function() {
+QUnit.test('Ember.copy null prototype object', function(assert) {
   let obj = Object.create(null);
 
   obj.foo = 'bar';
 
-  equal(copy(obj).foo, 'bar', 'bar should still be bar');
+  assert.equal(copy(obj).foo, 'bar', 'bar should still be bar');
 });
 
-QUnit.test('Ember.copy Array', function() {
+QUnit.test('Ember.copy Array', function(assert) {
   let array = [1, null, new Date(2015, 9, 9), 'four'];
   let arrayCopy = copy(array);
 
-  deepEqual(array, arrayCopy, 'array content cloned successfully in new array');
+  assert.deepEqual(array, arrayCopy, 'array content cloned successfully in new array');
 });

--- a/packages/ember-runtime/tests/core/isEqual_test.js
+++ b/packages/ember-runtime/tests/core/isEqual_test.js
@@ -2,37 +2,37 @@ import isEqual from '../../is-equal';
 
 QUnit.module('isEqual');
 
-QUnit.test('undefined and null', function() {
-  ok(isEqual(undefined, undefined), 'undefined is equal to undefined');
-  ok(!isEqual(undefined, null), 'undefined is not equal to null');
-  ok(isEqual(null, null), 'null is equal to null');
-  ok(!isEqual(null, undefined), 'null is not equal to undefined');
+QUnit.test('undefined and null', function(assert) {
+  assert.ok(isEqual(undefined, undefined), 'undefined is equal to undefined');
+  assert.ok(!isEqual(undefined, null), 'undefined is not equal to null');
+  assert.ok(isEqual(null, null), 'null is equal to null');
+  assert.ok(!isEqual(null, undefined), 'null is not equal to undefined');
 });
 
-QUnit.test('strings should be equal', function() {
-  ok(!isEqual('Hello', 'Hi'), 'different Strings are unequal');
-  ok(isEqual('Hello', 'Hello'), 'same Strings are equal');
+QUnit.test('strings should be equal', function(assert) {
+  assert.ok(!isEqual('Hello', 'Hi'), 'different Strings are unequal');
+  assert.ok(isEqual('Hello', 'Hello'), 'same Strings are equal');
 });
 
-QUnit.test('numericals should be equal', function() {
-  ok(isEqual(24, 24), 'same numbers are equal');
-  ok(!isEqual(24, 21), 'different numbers are inequal');
+QUnit.test('numericals should be equal', function(assert) {
+  assert.ok(isEqual(24, 24), 'same numbers are equal');
+  assert.ok(!isEqual(24, 21), 'different numbers are inequal');
 });
 
-QUnit.test('dates should be equal', function() {
-  ok(isEqual(new Date(1985, 7, 22), new Date(1985, 7, 22)), 'same dates are equal');
-  ok(!isEqual(new Date(2014, 7, 22), new Date(1985, 7, 22)), 'different dates are not equal');
+QUnit.test('dates should be equal', function(assert) {
+  assert.ok(isEqual(new Date(1985, 7, 22), new Date(1985, 7, 22)), 'same dates are equal');
+  assert.ok(!isEqual(new Date(2014, 7, 22), new Date(1985, 7, 22)), 'different dates are not equal');
 });
 
-QUnit.test('array should be equal', function() {
+QUnit.test('array should be equal', function(assert) {
   // NOTE: We don't test for array contents -- that would be too expensive.
-  ok(!isEqual([1, 2], [1, 2]), 'two array instances with the same values should not be equal');
-  ok(!isEqual([1, 2], [1]), 'two array instances with different values should not be equal');
+  assert.ok(!isEqual([1, 2], [1, 2]), 'two array instances with the same values should not be equal');
+  assert.ok(!isEqual([1, 2], [1]), 'two array instances with different values should not be equal');
 });
 
-QUnit.test('first object implements isEqual should use it', function() {
-  ok(isEqual({ isEqual() { return true; } }, null), 'should return true always');
+QUnit.test('first object implements isEqual should use it', function(assert) {
+  assert.ok(isEqual({ isEqual() { return true; } }, null), 'should return true always');
 
   let obj = { isEqual() { return false; } };
-  equal(isEqual(obj, obj), false, 'should return false because isEqual returns false');
+  assert.equal(isEqual(obj, obj), false, 'should return false because isEqual returns false');
 });

--- a/packages/ember-runtime/tests/core/is_array_test.js
+++ b/packages/ember-runtime/tests/core/is_array_test.js
@@ -7,7 +7,7 @@ QUnit.module('Ember Type Checking');
 
 const global = this;
 
-QUnit.test('Ember.isArray', function() {
+QUnit.test('Ember.isArray', function(assert) {
   let numarray      = [1, 2, 3];
   let number        = 23;
   let strarray      = ['Hello', 'Hi'];
@@ -18,23 +18,23 @@ QUnit.test('Ember.isArray', function() {
   let fn            = function() {};
   let arrayProxy = ArrayProxy.create({ content: emberA() });
 
-  equal(isArray(numarray), true, '[1,2,3]');
-  equal(isArray(number), false, '23');
-  equal(isArray(strarray), true, '["Hello", "Hi"]');
-  equal(isArray(string), false, '"Hello"');
-  equal(isArray(object), false, '{}');
-  equal(isArray(length), true, '{ length: 12 }');
-  equal(isArray(strangeLength), false, '{ length: "yes" }');
-  equal(isArray(global), false, 'global');
-  equal(isArray(fn), false, 'function() {}');
-  equal(isArray(arrayProxy), true, '[]');
+  assert.equal(isArray(numarray), true, '[1,2,3]');
+  assert.equal(isArray(number), false, '23');
+  assert.equal(isArray(strarray), true, '["Hello", "Hi"]');
+  assert.equal(isArray(string), false, '"Hello"');
+  assert.equal(isArray(object), false, '{}');
+  assert.equal(isArray(length), true, '{ length: 12 }');
+  assert.equal(isArray(strangeLength), false, '{ length: "yes" }');
+  assert.equal(isArray(global), false, 'global');
+  assert.equal(isArray(fn), false, 'function() {}');
+  assert.equal(isArray(arrayProxy), true, '[]');
 });
 
 if (environment.window && typeof environment.window.FileList === 'function') {
-  QUnit.test('Ember.isArray(fileList)', function() {
+  QUnit.test('Ember.isArray(fileList)', function(assert) {
     let fileListElement = document.createElement('input');
     fileListElement.type = 'file';
     let fileList = fileListElement.files;
-    equal(isArray(fileList), false, 'fileList');
+    assert.equal(isArray(fileList), false, 'fileList');
   });
 }

--- a/packages/ember-runtime/tests/core/is_empty_test.js
+++ b/packages/ember-runtime/tests/core/is_empty_test.js
@@ -4,8 +4,8 @@ import { A as emberA } from '../../system/native_array';
 
 QUnit.module('Ember.isEmpty');
 
-QUnit.test('Ember.isEmpty', function() {
+QUnit.test('Ember.isEmpty', function(assert) {
   let arrayProxy = ArrayProxy.create({ content: emberA() });
 
-  equal(true, isEmpty(arrayProxy), 'for an ArrayProxy that has empty content');
+  assert.equal(true, isEmpty(arrayProxy), 'for an ArrayProxy that has empty content');
 });

--- a/packages/ember-runtime/tests/core/type_of_test.js
+++ b/packages/ember-runtime/tests/core/type_of_test.js
@@ -4,7 +4,7 @@ import { environment } from 'ember-environment';
 
 QUnit.module('Ember Type Checking');
 
-QUnit.test('Ember.typeOf', function() {
+QUnit.test('Ember.typeOf', function(assert) {
   let MockedDate = function() { };
   MockedDate.prototype = new Date();
 
@@ -17,32 +17,32 @@ QUnit.test('Ember.typeOf', function() {
   let obj = {};
   let instance = EmberObject.create({ method() {} });
 
-  equal(typeOf(), 'undefined', 'undefined');
-  equal(typeOf(null), 'null', 'null');
-  equal(typeOf('Cyril'), 'string', 'Cyril');
-  equal(typeOf(101), 'number', '101');
-  equal(typeOf(true), 'boolean', 'true');
-  equal(typeOf([1, 2, 90]), 'array', '[1,2,90]');
-  equal(typeOf(/abc/), 'regexp', '/abc/');
-  equal(typeOf(date), 'date', 'new Date()');
-  equal(typeOf(mockedDate), 'date', 'mocked date');
-  equal(typeOf(error), 'error', 'error');
-  equal(typeOf(object), 'object', 'object');
-  equal(typeOf(undefined), 'undefined', 'item of type undefined');
-  equal(typeOf(a), 'null', 'item of type null');
-  equal(typeOf(arr), 'array', 'item of type array');
-  equal(typeOf(obj), 'object', 'item of type object');
-  equal(typeOf(instance), 'instance', 'item of type instance');
-  equal(typeOf(instance.method), 'function', 'item of type function');
-  equal(typeOf(EmberObject.extend()), 'class', 'item of type class');
-  equal(typeOf(new Error()), 'error', 'item of type error');
+  assert.equal(typeOf(), 'undefined', 'undefined');
+  assert.equal(typeOf(null), 'null', 'null');
+  assert.equal(typeOf('Cyril'), 'string', 'Cyril');
+  assert.equal(typeOf(101), 'number', '101');
+  assert.equal(typeOf(true), 'boolean', 'true');
+  assert.equal(typeOf([1, 2, 90]), 'array', '[1,2,90]');
+  assert.equal(typeOf(/abc/), 'regexp', '/abc/');
+  assert.equal(typeOf(date), 'date', 'new Date()');
+  assert.equal(typeOf(mockedDate), 'date', 'mocked date');
+  assert.equal(typeOf(error), 'error', 'error');
+  assert.equal(typeOf(object), 'object', 'object');
+  assert.equal(typeOf(undefined), 'undefined', 'item of type undefined');
+  assert.equal(typeOf(a), 'null', 'item of type null');
+  assert.equal(typeOf(arr), 'array', 'item of type array');
+  assert.equal(typeOf(obj), 'object', 'item of type object');
+  assert.equal(typeOf(instance), 'instance', 'item of type instance');
+  assert.equal(typeOf(instance.method), 'function', 'item of type function');
+  assert.equal(typeOf(EmberObject.extend()), 'class', 'item of type class');
+  assert.equal(typeOf(new Error()), 'error', 'item of type error');
 });
 
 if (environment.window && typeof environment.window.FileList === 'function') {
-  QUnit.test('Ember.typeOf(fileList)', function() {
+  QUnit.test('Ember.typeOf(fileList)', function(assert) {
     let fileListElement = document.createElement('input');
     fileListElement.type = 'file';
     let fileList = fileListElement.files;
-    equal(typeOf(fileList), 'filelist', 'item of type filelist');
+    assert.equal(typeOf(fileList), 'filelist', 'item of type filelist');
   });
 }

--- a/packages/ember-runtime/tests/ext/function_test.js
+++ b/packages/ember-runtime/tests/ext/function_test.js
@@ -6,9 +6,9 @@ import Evented from '../../mixins/evented';
 
 QUnit.module('Function.prototype.observes() helper');
 
-testBoth('global observer helper takes multiple params', function(get, set) {
+testBoth('global observer helper takes multiple params', function(get, set, assert) {
   if (!ENV.EXTEND_PROTOTYPES.Function) {
-    ok('undefined' === typeof Function.prototype.observes, 'Function.prototype helper disabled');
+    assert.ok('undefined' === typeof Function.prototype.observes, 'Function.prototype helper disabled');
     return;
   }
 
@@ -23,18 +23,18 @@ testBoth('global observer helper takes multiple params', function(get, set) {
   });
 
   let obj = mixin({}, MyMixin);
-  equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+  assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
   set(obj, 'bar', 'BAZ');
   set(obj, 'baz', 'BAZ');
-  equal(get(obj, 'count'), 2, 'should invoke observer after change');
+  assert.equal(get(obj, 'count'), 2, 'should invoke observer after change');
 });
 
 QUnit.module('Function.prototype.on() helper');
 
-testBoth('sets up an event listener, and can trigger the function on multiple events', function(get, set) {
+testBoth('sets up an event listener, and can trigger the function on multiple events', function(get, set, assert) {
   if (!ENV.EXTEND_PROTOTYPES.Function) {
-    ok('undefined' === typeof Function.prototype.on, 'Function.prototype helper disabled');
+    assert.ok('undefined' === typeof Function.prototype.on, 'Function.prototype helper disabled');
     return;
   }
 
@@ -49,16 +49,16 @@ testBoth('sets up an event listener, and can trigger the function on multiple ev
   });
 
   let obj = mixin({}, Evented, MyMixin);
-  equal(get(obj, 'count'), 0, 'should not invoke listener immediately');
+  assert.equal(get(obj, 'count'), 0, 'should not invoke listener immediately');
 
   obj.trigger('bar');
   obj.trigger('baz');
-  equal(get(obj, 'count'), 2, 'should invoke listeners when events trigger');
+  assert.equal(get(obj, 'count'), 2, 'should invoke listeners when events trigger');
 });
 
-testBoth('can be chained with observes', function(get, set) {
+testBoth('can be chained with observes', function(get, set, assert) {
   if (!ENV.EXTEND_PROTOTYPES.Function) {
-    ok('Function.prototype helper disabled');
+    assert.ok('Function.prototype helper disabled');
     return;
   }
 
@@ -72,18 +72,18 @@ testBoth('can be chained with observes', function(get, set) {
   });
 
   let obj = mixin({}, Evented, MyMixin);
-  equal(get(obj, 'count'), 0, 'should not invoke listener immediately');
+  assert.equal(get(obj, 'count'), 0, 'should not invoke listener immediately');
 
   set(obj, 'bay', 'BAY');
   obj.trigger('bar');
-  equal(get(obj, 'count'), 2, 'should invoke observer and listener');
+  assert.equal(get(obj, 'count'), 2, 'should invoke observer and listener');
 });
 
 QUnit.module('Function.prototype.property() helper');
 
-testBoth('sets up a ComputedProperty', function(get, set) {
+testBoth('sets up a ComputedProperty', function(get, set, assert) {
   if (!ENV.EXTEND_PROTOTYPES.Function) {
-    ok('undefined' === typeof Function.prototype.property, 'Function.prototype helper disabled');
+    assert.ok('undefined' === typeof Function.prototype.property, 'Function.prototype helper disabled');
     return;
   }
 
@@ -96,11 +96,11 @@ testBoth('sets up a ComputedProperty', function(get, set) {
   });
 
   let obj = MyClass.create({ firstName: 'Fred', lastName: 'Flinstone' });
-  equal(get(obj, 'fullName'), 'Fred Flinstone', 'should return the computed value');
+  assert.equal(get(obj, 'fullName'), 'Fred Flinstone', 'should return the computed value');
 
   set(obj, 'firstName', 'Wilma');
-  equal(get(obj, 'fullName'), 'Wilma Flinstone', 'should return the new computed value');
+  assert.equal(get(obj, 'fullName'), 'Wilma Flinstone', 'should return the new computed value');
 
   set(obj, 'lastName', '');
-  equal(get(obj, 'fullName'), 'Wilma ', 'should return the new computed value');
+  assert.equal(get(obj, 'fullName'), 'Wilma ', 'should return the new computed value');
 });

--- a/packages/ember-runtime/tests/ext/mixin_test.js
+++ b/packages/ember-runtime/tests/ext/mixin_test.js
@@ -2,7 +2,7 @@ import { set, get, Mixin, Binding, run } from 'ember-metal';
 
 QUnit.module('system/mixin/binding_test');
 
-QUnit.test('Defining a property ending in Binding should setup binding when applied', function() {
+QUnit.test('Defining a property ending in Binding should setup binding when applied', function(assert) {
   let MyMixin = Mixin.create({
     fooBinding: 'bar.baz'
   });
@@ -17,11 +17,11 @@ QUnit.test('Defining a property ending in Binding should setup binding when appl
     }, deprecationMessage);
   });
 
-  ok(get(obj, 'fooBinding') instanceof Binding, 'should be a binding object');
-  equal(get(obj, 'foo'), 'BIFF', 'binding should be created and synced');
+  assert.ok(get(obj, 'fooBinding') instanceof Binding, 'should be a binding object');
+  assert.equal(get(obj, 'foo'), 'BIFF', 'binding should be created and synced');
 });
 
-QUnit.test('Defining a property ending in Binding should apply to prototype children', function() {
+QUnit.test('Defining a property ending in Binding should apply to prototype children', function(assert) {
   let MyMixin = run(()  => {
     return Mixin.create({
       fooBinding: 'bar.baz'
@@ -42,6 +42,6 @@ QUnit.test('Defining a property ending in Binding should apply to prototype chil
   let obj2 = Object.create(obj);
   run(() => set(get(obj2, 'bar'), 'baz', 'BARG'));
 
-  ok(get(obj2, 'fooBinding') instanceof Binding, 'should be a binding object');
-  equal(get(obj2, 'foo'), 'BARG', 'binding should be created and synced');
+  assert.ok(get(obj2, 'fooBinding') instanceof Binding, 'should be a binding object');
+  assert.equal(get(obj2, 'foo'), 'BARG', 'binding should be created and synced');
 });

--- a/packages/ember-runtime/tests/ext/rsvp_test.js
+++ b/packages/ember-runtime/tests/ext/rsvp_test.js
@@ -9,12 +9,12 @@ import { isTesting, setTesting } from 'ember-debug';
 const ORIGINAL_ONERROR = getOnerror();
 
 QUnit.module('Ember.RSVP', {
-  teardown() {
+  afterEach() {
     setOnerror(ORIGINAL_ONERROR);
   }
 });
 
-QUnit.test('Ensure that errors thrown from within a promise are sent to the console', function() {
+QUnit.test('Ensure that errors thrown from within a promise are sent to the console', function(assert) {
   let error = new Error('Error thrown in a promise for testing purposes.');
 
   try {
@@ -23,53 +23,53 @@ QUnit.test('Ensure that errors thrown from within a promise are sent to the cons
         throw error;
       });
     });
-    ok(false, 'expected assertion to be thrown');
+    assert.ok(false, 'expected assertion to be thrown');
   } catch (e) {
-    equal(e, error, 'error was re-thrown');
+    assert.equal(e, error, 'error was re-thrown');
   }
 });
 
-QUnit.test('TransitionAborted errors are not re-thrown', function() {
-  expect(1);
+QUnit.test('TransitionAborted errors are not re-thrown', function(assert) {
+  assert.expect(1);
   let fakeTransitionAbort = { name: 'TransitionAborted' };
 
   run(RSVP, 'reject', fakeTransitionAbort);
 
-  ok(true, 'did not throw an error when dealing with TransitionAborted');
+  assert.ok(true, 'did not throw an error when dealing with TransitionAborted');
 });
 
-QUnit.test('Can reject with non-Error object', function() {
+QUnit.test('Can reject with non-Error object', function(assert) {
   let wasEmberTesting = isTesting();
   setTesting(false);
-  expect(1);
+  assert.expect(1);
 
   try {
     run(RSVP, 'reject', 'foo');
   } catch (e) {
-    equal(e, 'foo', 'should throw with rejection message');
+    assert.equal(e, 'foo', 'should throw with rejection message');
   } finally {
     setTesting(wasEmberTesting);
   }
 });
 
-QUnit.test('Can reject with no arguments', function() {
+QUnit.test('Can reject with no arguments', function(assert) {
   let wasEmberTesting = isTesting();
   setTesting(false);
-  expect(1);
+  assert.expect(1);
 
   try {
     run(RSVP, 'reject');
   } catch (e) {
-    ok(false, 'should not throw');
+    assert.ok(false, 'should not throw');
   } finally {
     setTesting(wasEmberTesting);
   }
 
-  ok(true);
+  assert.ok(true);
 });
 
-QUnit.test('rejections like jqXHR which have errorThrown property work', function() {
-  expect(2);
+QUnit.test('rejections like jqXHR which have errorThrown property work', function(assert) {
+  assert.expect(2);
 
   let wasEmberTesting = isTesting();
   let wasOnError      = getOnerror();
@@ -77,8 +77,8 @@ QUnit.test('rejections like jqXHR which have errorThrown property work', functio
   try {
     setTesting(false);
     setOnerror(error => {
-      equal(error, actualError, 'expected the real error on the jqXHR');
-      equal(error.__reason_with_error_thrown__, jqXHR, 'also retains a helpful reference to the rejection reason');
+      assert.equal(error, actualError, 'expected the real error on the jqXHR');
+      assert.equal(error.__reason_with_error_thrown__, jqXHR, 'also retains a helpful reference to the rejection reason');
     });
 
     let actualError = new Error('OMG what really happened');
@@ -93,8 +93,8 @@ QUnit.test('rejections like jqXHR which have errorThrown property work', functio
   }
 });
 
-QUnit.test('rejections where the errorThrown is a string should wrap the sting in an error object', function() {
-  expect(2);
+QUnit.test('rejections where the errorThrown is a string should wrap the sting in an error object', function(assert) {
+  assert.expect(2);
 
   let wasEmberTesting = isTesting();
   let wasOnError      = getOnerror();
@@ -102,8 +102,8 @@ QUnit.test('rejections where the errorThrown is a string should wrap the sting i
   try {
     setTesting(false);
     setOnerror(error => {
-      equal(error.message, actualError, 'expected the real error on the jqXHR');
-      equal(error.__reason_with_error_thrown__, jqXHR, 'also retains a helpful reference to the rejection reason');
+      assert.equal(error.message, actualError, 'expected the real error on the jqXHR');
+      assert.equal(error.__reason_with_error_thrown__, jqXHR, 'also retains a helpful reference to the rejection reason');
     });
 
     let actualError = 'OMG what really happened';
@@ -119,7 +119,7 @@ QUnit.test('rejections where the errorThrown is a string should wrap the sting i
 });
 
 QUnit.test('rejections can be serialized to JSON', function (assert) {
-  expect(2);
+  assert.expect(2);
 
   let wasEmberTesting = isTesting();
   let wasOnError      = getOnerror();
@@ -155,41 +155,41 @@ function ajax() {
   });
 }
 
-QUnit.test('unambigiously unhandled rejection', function() {
-  QUnit.throws(function() {
+QUnit.test('unambigiously unhandled rejection', function(assert) {
+  assert.throws(function() {
     run(function() {
       RSVP.Promise.reject(reason);
     }); // something is funky, we should likely assert
   }, reason);
 });
 
-QUnit.test('sync handled', function() {
+QUnit.test('sync handled', function(assert) {
   run(function() {
     RSVP.Promise.reject(reason).catch(function() { });
   }); // handled, we shouldn't need to assert.
-  ok(true, 'reached end of test');
+  assert.ok(true, 'reached end of test');
 });
 
-QUnit.test('handled within the same micro-task (via Ember.RVP.Promise)', function() {
+QUnit.test('handled within the same micro-task (via Ember.RVP.Promise)', function(assert) {
   run(function() {
     let rejection = RSVP.Promise.reject(reason);
     RSVP.Promise.resolve(1).then(() => rejection.catch(function() { }));
   }); // handled, we shouldn't need to assert.
-  ok(true, 'reached end of test');
+  assert.ok(true, 'reached end of test');
 });
 
-QUnit.test('handled within the same micro-task (via direct run-loop)', function() {
+QUnit.test('handled within the same micro-task (via direct run-loop)', function(assert) {
   run(function() {
     let rejection = RSVP.Promise.reject(reason);
     run.schedule('afterRender', () => rejection.catch(function() { }));
   }); // handled, we shouldn't need to assert.
-  ok(true, 'reached end of test');
+  assert.ok(true, 'reached end of test');
 });
 
-QUnit.test('handled in the next microTask queue flush (run.next)', function() {
-  expect(2);
+QUnit.test('handled in the next microTask queue flush (run.next)', function(assert) {
+  assert.expect(2);
 
-  QUnit.throws(function() {
+  assert.throws(function() {
     run(function() {
       let rejection = RSVP.Promise.reject(reason);
 
@@ -197,7 +197,7 @@ QUnit.test('handled in the next microTask queue flush (run.next)', function() {
       run.next(() => {
         QUnit.start();
         rejection.catch(function() { });
-        ok(true, 'reached end of test');
+        assert.ok(true, 'reached end of test');
       });
     });
   }, reason);
@@ -206,7 +206,7 @@ QUnit.test('handled in the next microTask queue flush (run.next)', function() {
   // this is very likely an issue.
 });
 
-QUnit.test('handled in the same microTask Queue flush do to data locality', function() {
+QUnit.test('handled in the same microTask Queue flush do to data locality', function(assert) {
   // an ambiguous scenario, this may or may not assert
   // it depends on the locality of `user#1`
   let store = {
@@ -219,10 +219,10 @@ QUnit.test('handled in the same microTask Queue flush do to data locality', func
     store.find('user', 1).then(() => rejection.catch(function() { }));
   });
 
-  ok(true, 'reached end of test');
+  assert.ok(true, 'reached end of test');
 });
 
-QUnit.test('handled in a different microTask Queue flush do to data locality', function() {
+QUnit.test('handled in a different microTask Queue flush do to data locality', function(assert) {
   // an ambiguous scenario, this may or may not assert
   // it depends on the locality of `user#1`
   let store = {
@@ -230,24 +230,24 @@ QUnit.test('handled in a different microTask Queue flush do to data locality', f
       return ajax();
     }
   };
-  QUnit.throws(function() {
+  assert.throws(function() {
     run(function() {
       let rejection = RSVP.Promise.reject(reason);
       store.find('user', 1).then(() => {
         rejection.catch(function() { });
-        ok(true, 'reached end of test');
+        assert.ok(true, 'reached end of test');
       });
     });
   }, reason);
 });
 
-QUnit.test('handled in the next microTask queue flush (ajax example)', function() {
-  QUnit.throws(function() {
+QUnit.test('handled in the next microTask queue flush (ajax example)', function(assert) {
+  assert.throws(function() {
     run(function() {
       let rejection = RSVP.Promise.reject(reason);
       ajax('/something/').then(() => {
         rejection.catch(function() {});
-        ok(true, 'reached end of test');
+        assert.ok(true, 'reached end of test');
       });
     });
   }, reason);

--- a/packages/ember-runtime/tests/inject_test.js
+++ b/packages/ember-runtime/tests/inject_test.js
@@ -20,9 +20,9 @@ QUnit.test('calling `inject` directly should error', function() {
 if (!EmberDev.runningProdBuild) {
   // this check is done via an assertion which is stripped from
   // production builds
-  QUnit.test('injection type validation is run when first looked up', function() {
+  QUnit.test('injection type validation is run when first looked up', function(assert) {
     createInjectionHelper('foo', function() {
-      ok(true, 'should call validation method');
+      assert.ok(true, 'should call validation method');
     });
 
     let owner = buildOwner();
@@ -36,11 +36,11 @@ if (!EmberDev.runningProdBuild) {
     owner.register('foo:bar', EmberObject.extend());
     owner.register('foo:baz', EmberObject.extend());
 
-    expect(1);
+    assert.expect(1);
     owner.lookup('foo:main');
   });
 
-  QUnit.test('attempting to inject a nonexistent container key should error', function() {
+  QUnit.test('attempting to inject a nonexistent container key should error', function(assert) {
     let owner = buildOwner();
     let AnObject = EmberObject.extend({
       foo: new InjectedProperty('bar', 'baz')
@@ -48,19 +48,19 @@ if (!EmberDev.runningProdBuild) {
 
     owner.register('foo:main', AnObject);
 
-    throws(() => {
+    assert.throws(() => {
       owner.lookup('foo:main');
     }, /Attempting to inject an unknown injection: 'bar:baz'/);
   });
 }
 
 if (DEBUG) {
-  QUnit.test('factories should return a list of lazy injection full names', function() {
+  QUnit.test('factories should return a list of lazy injection full names', function(assert) {
     let AnObject = EmberObject.extend({
       foo: new InjectedProperty('foo', 'bar'),
       bar: new InjectedProperty('quux')
     });
 
-    deepEqual(AnObject._lazyInjections(), { 'foo': 'foo:bar', 'bar': 'quux:bar' }, 'should return injected container keys');
+    assert.deepEqual(AnObject._lazyInjections(), { 'foo': 'foo:bar', 'bar': 'quux:bar' }, 'should return injected container keys');
   });
 }

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/chained_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/chained_test.js
@@ -15,7 +15,7 @@ import { A as emberA } from '../../../../system/native_array';
 
 QUnit.module('Ember.Observable - Observing with @each');
 
-QUnit.test('chained observers on enumerable properties are triggered when the observed property of any item changes', function() {
+QUnit.test('chained observers on enumerable properties are triggered when the observed property of any item changes', function(assert) {
   let family = EmberObject.create({ momma: null });
   let momma = EmberObject.create({ children: [] });
 
@@ -34,20 +34,20 @@ QUnit.test('chained observers on enumerable properties are triggered when the ob
 
   observerFiredCount = 0;
   run(() => get(momma, 'children').setEach('name', 'Juan'));
-  equal(observerFiredCount, 3, 'observer fired after changing child names');
+  assert.equal(observerFiredCount, 3, 'observer fired after changing child names');
 
   observerFiredCount = 0;
   run(() => get(momma, 'children').pushObject(child4));
-  equal(observerFiredCount, 1, 'observer fired after adding a new item');
+  assert.equal(observerFiredCount, 1, 'observer fired after adding a new item');
 
   observerFiredCount = 0;
   run(() => set(child4, 'name', 'Herbert'));
-  equal(observerFiredCount, 1, 'observer fired after changing property on new object');
+  assert.equal(observerFiredCount, 1, 'observer fired after changing property on new object');
 
   set(momma, 'children', []);
 
   observerFiredCount = 0;
   run(() => set(child1, 'name', 'Hanna'));
-  equal(observerFiredCount, 0, 'observer did not fire after removing changing property on a removed object');
+  assert.equal(observerFiredCount, 0, 'observer did not fire after removing changing property on a removed object');
 });
 

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -42,7 +42,7 @@ var originalLookup = context.lookup;
 
 QUnit.module('object.get()', {
 
-  setup() {
+  beforeEach() {
     object = ObservableObject.extend(Observable, {
       computed: computed(function() { return 'value'; }).volatile(),
       method() { return 'value'; },
@@ -60,33 +60,33 @@ QUnit.module('object.get()', {
 
 });
 
-QUnit.test('should get normal properties', function() {
-  equal(object.get('normal'), 'value');
+QUnit.test('should get normal properties', function(assert) {
+  assert.equal(object.get('normal'), 'value');
 });
 
-QUnit.test('should call computed properties and return their result', function() {
-  equal(object.get('computed'), 'value');
+QUnit.test('should call computed properties and return their result', function(assert) {
+  assert.equal(object.get('computed'), 'value');
 });
 
-QUnit.test('should return the function for a non-computed property', function() {
+QUnit.test('should return the function for a non-computed property', function(assert) {
   var value = object.get('method');
-  equal(typeof value, 'function');
+  assert.equal(typeof value, 'function');
 });
 
-QUnit.test('should return null when property value is null', function() {
-  equal(object.get('nullProperty'), null);
+QUnit.test('should return null when property value is null', function(assert) {
+  assert.equal(object.get('nullProperty'), null);
 });
 
-QUnit.test('should call unknownProperty when value is undefined', function() {
-  equal(object.get('unknown'), 'unknown');
-  equal(object.lastUnknownProperty, 'unknown');
+QUnit.test('should call unknownProperty when value is undefined', function(assert) {
+  assert.equal(object.get('unknown'), 'unknown');
+  assert.equal(object.lastUnknownProperty, 'unknown');
 });
 
 // ..........................................................
 // Ember.GET()
 //
 QUnit.module('Ember.get()', {
-  setup() {
+  beforeEach() {
     objectA = ObservableObject.extend({
       computed: computed(function() { return 'value'; }).volatile(),
       method() { return 'value'; },
@@ -108,34 +108,34 @@ QUnit.module('Ember.get()', {
   }
 });
 
-QUnit.test('should get normal properties on Ember.Observable', function() {
-  equal(get(objectA, 'normal'), 'value');
+QUnit.test('should get normal properties on Ember.Observable', function(assert) {
+  assert.equal(get(objectA, 'normal'), 'value');
 });
 
-QUnit.test('should call computed properties on Ember.Observable and return their result', function() {
-  equal(get(objectA, 'computed'), 'value');
+QUnit.test('should call computed properties on Ember.Observable and return their result', function(assert) {
+  assert.equal(get(objectA, 'computed'), 'value');
 });
 
-QUnit.test('should return the function for a non-computed property on Ember.Observable', function() {
+QUnit.test('should return the function for a non-computed property on Ember.Observable', function(assert) {
   var value = get(objectA, 'method');
-  equal(typeof value, 'function');
+  assert.equal(typeof value, 'function');
 });
 
-QUnit.test('should return null when property value is null on Ember.Observable', function() {
-  equal(get(objectA, 'nullProperty'), null);
+QUnit.test('should return null when property value is null on Ember.Observable', function(assert) {
+  assert.equal(get(objectA, 'nullProperty'), null);
 });
 
-QUnit.test('should call unknownProperty when value is undefined on Ember.Observable', function() {
-  equal(get(objectA, 'unknown'), 'unknown');
-  equal(objectA.lastUnknownProperty, 'unknown');
+QUnit.test('should call unknownProperty when value is undefined on Ember.Observable', function(assert) {
+  assert.equal(get(objectA, 'unknown'), 'unknown');
+  assert.equal(objectA.lastUnknownProperty, 'unknown');
 });
 
-QUnit.test('should get normal properties on standard objects', function() {
-  equal(get(objectB, 'normal'), 'value');
+QUnit.test('should get normal properties on standard objects', function(assert) {
+  assert.equal(get(objectB, 'normal'), 'value');
 });
 
-QUnit.test('should return null when property is null on standard objects', function() {
-  equal(get(objectB, 'nullProperty'), null);
+QUnit.test('should return null when property is null on standard objects', function(assert) {
+  assert.equal(get(objectB, 'nullProperty'), null);
 });
 
 /*
@@ -154,24 +154,24 @@ QUnit.test('raise if the provided object is undefined', function() {
 
 QUnit.module('Ember.get() with paths');
 
-QUnit.test('should return a property at a given path relative to the passed object', function() {
+QUnit.test('should return a property at a given path relative to the passed object', function(assert) {
   var foo = ObservableObject.create({
     bar: ObservableObject.extend({
       baz: computed(function() { return 'blargh'; }).volatile()
     }).create()
   });
 
-  equal(get(foo, 'bar.baz'), 'blargh');
+  assert.equal(get(foo, 'bar.baz'), 'blargh');
 });
 
-QUnit.test('should return a property at a given path relative to the passed object - JavaScript hash', function() {
+QUnit.test('should return a property at a given path relative to the passed object - JavaScript hash', function(assert) {
   var foo = {
     bar: {
       baz: 'blargh'
     }
   };
 
-  equal(get(foo, 'bar.baz'), 'blargh');
+  assert.equal(get(foo, 'bar.baz'), 'blargh');
 });
 
 // ..........................................................
@@ -180,7 +180,7 @@ QUnit.test('should return a property at a given path relative to the passed obje
 
 QUnit.module('object.set()', {
 
-  setup() {
+  beforeEach() {
     object = ObservableObject.extend({
       computed: computed({
         get() {
@@ -225,41 +225,41 @@ QUnit.module('object.set()', {
 
 });
 
-QUnit.test('should change normal properties and return the value', function() {
+QUnit.test('should change normal properties and return the value', function(assert) {
   var ret = object.set('normal', 'changed');
-  equal(object.get('normal'), 'changed');
-  equal(ret, 'changed');
+  assert.equal(object.get('normal'), 'changed');
+  assert.equal(ret, 'changed');
 });
 
-QUnit.test('should call computed properties passing value and return the value', function() {
+QUnit.test('should call computed properties passing value and return the value', function(assert) {
   var ret = object.set('computed', 'changed');
-  equal(object.get('_computed'), 'changed');
-  equal(ret, 'changed');
+  assert.equal(object.get('_computed'), 'changed');
+  assert.equal(ret, 'changed');
 });
 
-QUnit.test('should change normal properties when passing undefined', function() {
+QUnit.test('should change normal properties when passing undefined', function(assert) {
   var ret = object.set('normal', undefined);
-  equal(object.get('normal'), undefined);
-  equal(ret, undefined);
+  assert.equal(object.get('normal'), undefined);
+  assert.equal(ret, undefined);
 });
 
-QUnit.test('should replace the function for a non-computed property and return the value', function() {
+QUnit.test('should replace the function for a non-computed property and return the value', function(assert) {
   var ret = object.set('method', 'changed');
-  equal(object.get('_method'), 'method'); // make sure this was NOT run
-  ok(typeof object.get('method') !== 'function');
-  equal(ret, 'changed');
+  assert.equal(object.get('_method'), 'method'); // make sure this was NOT run
+  assert.ok(typeof object.get('method') !== 'function');
+  assert.equal(ret, 'changed');
 });
 
-QUnit.test('should replace prover when property value is null', function() {
+QUnit.test('should replace prover when property value is null', function(assert) {
   var ret = object.set('nullProperty', 'changed');
-  equal(object.get('nullProperty'), 'changed');
-  equal(ret, 'changed');
+  assert.equal(object.get('nullProperty'), 'changed');
+  assert.equal(ret, 'changed');
 });
 
-QUnit.test('should call unknownProperty with value when property is undefined', function() {
+QUnit.test('should call unknownProperty with value when property is undefined', function(assert) {
   var ret = object.set('unknown', 'changed');
-  equal(object.get('_unknown'), 'changed');
-  equal(ret, 'changed');
+  assert.equal(object.get('_unknown'), 'changed');
+  assert.equal(ret, 'changed');
 });
 
 // ..........................................................
@@ -267,7 +267,7 @@ QUnit.test('should call unknownProperty with value when property is undefined', 
 //
 
 QUnit.module('Computed properties', {
-  setup() {
+  beforeEach() {
     lookup = context.lookup = {};
 
     object = ObservableObject.extend({
@@ -360,41 +360,41 @@ QUnit.module('Computed properties', {
       state: 'on'
     });
   },
-  teardown() {
+  afterEach() {
     context.lookup = originalLookup;
   }
 });
 
-QUnit.test('getting values should call function return value', function() {
+QUnit.test('getting values should call function return value', function(assert) {
   // get each property twice. Verify return.
   var keys = w('computed computedCached dependent dependentFront dependentCached');
 
   keys.forEach(function(key) {
-    equal(object.get(key), key, `Try #1: object.get(${key}) should run function`);
-    equal(object.get(key), key, `Try #2: object.get(${key}) should run function`);
+    assert.equal(object.get(key), key, `Try #1: object.get(${key}) should run function`);
+    assert.equal(object.get(key), key, `Try #2: object.get(${key}) should run function`);
   });
 
   // verify each call count.  cached should only be called once
   w('computedCalls dependentFrontCalls dependentCalls').forEach((key) => {
-    equal(object[key].length, 2, `non-cached property ${key} should be called 2x`);
+    assert.equal(object[key].length, 2, `non-cached property ${key} should be called 2x`);
   });
 
   w('computedCachedCalls dependentCachedCalls').forEach((key) => {
-    equal(object[key].length, 1, `non-cached property ${key} should be called 1x`);
+    assert.equal(object[key].length, 1, `non-cached property ${key} should be called 1x`);
   });
 });
 
-QUnit.test('setting values should call function return value', function() {
+QUnit.test('setting values should call function return value', function(assert) {
   // get each property twice. Verify return.
   var keys = w('computed dependent dependentFront computedCached dependentCached');
   var values = w('value1 value2');
 
   keys.forEach((key) => {
-    equal(object.set(key, values[0]), values[0], `Try #1: object.set(${key}, ${values[0]}) should run function`);
+    assert.equal(object.set(key, values[0]), values[0], `Try #1: object.set(${key}, ${values[0]}) should run function`);
 
-    equal(object.set(key, values[1]), values[1], `Try #2: object.set(${key}, ${values[1]}) should run function`);
+    assert.equal(object.set(key, values[1]), values[1], `Try #2: object.set(${key}, ${values[1]}) should run function`);
 
-    equal(object.set(key, values[1]), values[1], `Try #3: object.set(${key}, ${values[1]}) should not run function since it is setting same value as before`);
+    assert.equal(object.set(key, values[1]), values[1], `Try #3: object.set(${key}, ${values[1]}) should not run function since it is setting same value as before`);
   });
 
   // verify each call count.  cached should only be called once
@@ -405,14 +405,14 @@ QUnit.test('setting values should call function return value', function() {
     // Cached properties first check their cached value before setting the
     // property. Other properties blindly call set.
     expectedLength = 3;
-    equal(calls.length, expectedLength, `set(${key}) should be called the right amount of times`);
+    assert.equal(calls.length, expectedLength, `set(${key}) should be called the right amount of times`);
     for (idx = 0; idx < 2; idx++) {
-      equal(calls[idx], values[idx], `call #${idx + 1} to set(${key}) should have passed value ${values[idx]}`);
+      assert.equal(calls[idx], values[idx], `call #${idx + 1} to set(${key}) should have passed value ${values[idx]}`);
     }
   });
 });
 
-QUnit.test('notify change should clear cache', function() {
+QUnit.test('notify change should clear cache', function(assert) {
   // call get several times to collect call count
   object.get('computedCached'); // should run func
   object.get('computedCached'); // should not run func
@@ -421,78 +421,78 @@ QUnit.test('notify change should clear cache', function() {
     .propertyDidChange('computedCached');
 
   object.get('computedCached'); // should run again
-  equal(object.computedCachedCalls.length, 2, 'should have invoked method 2x');
+  assert.equal(object.computedCachedCalls.length, 2, 'should have invoked method 2x');
 });
 
-QUnit.test('change dependent should clear cache', function() {
+QUnit.test('change dependent should clear cache', function(assert) {
   // call get several times to collect call count
   var ret1 = object.get('inc'); // should run func
-  equal(object.get('inc'), ret1, 'multiple calls should not run cached prop');
+  assert.equal(object.get('inc'), ret1, 'multiple calls should not run cached prop');
 
   object.set('changer', 'bar');
 
-  equal(object.get('inc'), ret1 + 1, 'should increment after dependent key changes'); // should run again
+  assert.equal(object.get('inc'), ret1 + 1, 'should increment after dependent key changes'); // should run again
 });
 
-QUnit.test('just notifying change of dependent should clear cache', function() {
+QUnit.test('just notifying change of dependent should clear cache', function(assert) {
   // call get several times to collect call count
   var ret1 = object.get('inc'); // should run func
-  equal(object.get('inc'), ret1, 'multiple calls should not run cached prop');
+  assert.equal(object.get('inc'), ret1, 'multiple calls should not run cached prop');
 
   object.notifyPropertyChange('changer');
 
-  equal(object.get('inc'), ret1 + 1, 'should increment after dependent key changes'); // should run again
+  assert.equal(object.get('inc'), ret1 + 1, 'should increment after dependent key changes'); // should run again
 });
 
-QUnit.test('changing dependent should clear nested cache', function() {
+QUnit.test('changing dependent should clear nested cache', function(assert) {
   // call get several times to collect call count
   var ret1 = object.get('nestedInc'); // should run func
-  equal(object.get('nestedInc'), ret1, 'multiple calls should not run cached prop');
+  assert.equal(object.get('nestedInc'), ret1, 'multiple calls should not run cached prop');
 
   object.set('changer', 'bar');
 
-  equal(object.get('nestedInc'), ret1 + 1, 'should increment after dependent key changes'); // should run again
+  assert.equal(object.get('nestedInc'), ret1 + 1, 'should increment after dependent key changes'); // should run again
 });
 
-QUnit.test('just notifying change of dependent should clear nested cache', function() {
+QUnit.test('just notifying change of dependent should clear nested cache', function(assert) {
   // call get several times to collect call count
   var ret1 = object.get('nestedInc'); // should run func
-  equal(object.get('nestedInc'), ret1, 'multiple calls should not run cached prop');
+  assert.equal(object.get('nestedInc'), ret1, 'multiple calls should not run cached prop');
 
   object.notifyPropertyChange('changer');
 
-  equal(object.get('nestedInc'), ret1 + 1, 'should increment after dependent key changes'); // should run again
+  assert.equal(object.get('nestedInc'), ret1 + 1, 'should increment after dependent key changes'); // should run again
 });
 
 
 // This verifies a specific bug encountered where observers for computed
 // properties would fire before their prop caches were cleared.
-QUnit.test('change dependent should clear cache when observers of dependent are called', function() {
+QUnit.test('change dependent should clear cache when observers of dependent are called', function(assert) {
   // call get several times to collect call count
   var ret1 = object.get('inc'); // should run func
-  equal(object.get('inc'), ret1, 'multiple calls should not run cached prop');
+  assert.equal(object.get('inc'), ret1, 'multiple calls should not run cached prop');
 
   // add observer to verify change...
   object.addObserver('inc', this, function() {
-    equal(object.get('inc'), ret1 + 1, 'should increment after dependent key changes'); // should run again
+    assert.equal(object.get('inc'), ret1 + 1, 'should increment after dependent key changes'); // should run again
   });
 
   // now run
   object.set('changer', 'bar');
 });
 
-QUnit.test('setting one of two computed properties that depend on a third property should clear the kvo cache', function() {
+QUnit.test('setting one of two computed properties that depend on a third property should clear the kvo cache', function(assert) {
   // we have to call set twice to fill up the cache
   object.set('isOff', true);
   object.set('isOn', true);
 
   // setting isOff to true should clear the kvo cache
   object.set('isOff', true);
-  equal(object.get('isOff'), true, 'object.isOff should be true');
-  equal(object.get('isOn'), false, 'object.isOn should be false');
+  assert.equal(object.get('isOff'), true, 'object.isOff should be true');
+  assert.equal(object.get('isOn'), false, 'object.isOn should be false');
 });
 
-QUnit.test('dependent keys should be able to be specified as property paths', function() {
+QUnit.test('dependent keys should be able to be specified as property paths', function(assert) {
   var depObj = ObservableObject.extend({
     menuPrice: computed(function() {
       return this.get('menu.price');
@@ -503,14 +503,14 @@ QUnit.test('dependent keys should be able to be specified as property paths', fu
     })
   });
 
-  equal(depObj.get('menuPrice'), 5, 'precond - initial value returns 5');
+  assert.equal(depObj.get('menuPrice'), 5, 'precond - initial value returns 5');
 
   depObj.set('menu.price', 6);
 
-  equal(depObj.get('menuPrice'), 6, 'cache is properly invalidated after nested property changes');
+  assert.equal(depObj.get('menuPrice'), 6, 'cache is properly invalidated after nested property changes');
 });
 
-QUnit.test('nested dependent keys should propagate after they update', function() {
+QUnit.test('nested dependent keys should propagate after they update', function(assert) {
   var bindObj;
   run(function () {
     lookup.DepObj = ObservableObject.extend({
@@ -532,13 +532,13 @@ QUnit.test('nested dependent keys should propagate after they update', function(
     }, /`Ember.Binding` is deprecated/);
   });
 
-  equal(bindObj.get('price'), 5, 'precond - binding propagates');
+  assert.equal(bindObj.get('price'), 5, 'precond - binding propagates');
 
   run(function () {
     lookup.DepObj.set('restaurant.menu.price', 10);
   });
 
-  equal(bindObj.get('price'), 10, 'binding propagates after a nested dependent keys updates');
+  assert.equal(bindObj.get('price'), 10, 'binding propagates after a nested dependent keys updates');
 
   run(function () {
     lookup.DepObj.set('restaurant.menu', ObservableObject.create({
@@ -546,11 +546,11 @@ QUnit.test('nested dependent keys should propagate after they update', function(
     }));
   });
 
-  equal(bindObj.get('price'), 15, 'binding propagates after a middle dependent keys updates');
+  assert.equal(bindObj.get('price'), 15, 'binding propagates after a middle dependent keys updates');
 });
 
-QUnit.test('cacheable nested dependent keys should clear after their dependencies update', function() {
-  ok(true);
+QUnit.test('cacheable nested dependent keys should clear after their dependencies update', function(assert) {
+  assert.ok(true);
 
   var DepObj;
 
@@ -568,18 +568,18 @@ QUnit.test('cacheable nested dependent keys should clear after their dependencie
     });
   });
 
-  equal(DepObj.get('price'), 5, 'precond - computed property is correct');
+  assert.equal(DepObj.get('price'), 5, 'precond - computed property is correct');
 
   run(function() {
     DepObj.set('restaurant.menu.price', 10);
   });
-  equal(DepObj.get('price'), 10, 'cacheable computed properties are invalidated even if no run loop occurred');
+  assert.equal(DepObj.get('price'), 10, 'cacheable computed properties are invalidated even if no run loop occurred');
 
   run(function() {
     DepObj.set('restaurant.menu.price', 20);
   });
-  equal(DepObj.get('price'), 20, 'cacheable computed properties are invalidated after a second get before a run loop');
-  equal(DepObj.get('price'), 20, 'precond - computed properties remain correct after a run loop');
+  assert.equal(DepObj.get('price'), 20, 'cacheable computed properties are invalidated after a second get before a run loop');
+  assert.equal(DepObj.get('price'), 20, 'precond - computed properties remain correct after a run loop');
 
   run(function() {
     DepObj.set('restaurant.menu', ObservableObject.create({
@@ -588,7 +588,7 @@ QUnit.test('cacheable nested dependent keys should clear after their dependencie
   });
 
 
-  equal(DepObj.get('price'), 15, 'cacheable computed properties are invalidated after a middle property changes');
+  assert.equal(DepObj.get('price'), 15, 'cacheable computed properties are invalidated after a middle property changes');
 
   run(function() {
     DepObj.set('restaurant.menu', ObservableObject.create({
@@ -596,7 +596,7 @@ QUnit.test('cacheable nested dependent keys should clear after their dependencie
     }));
   });
 
-  equal(DepObj.get('price'), 25, 'cacheable computed properties are invalidated after a middle property changes again, before a run loop');
+  assert.equal(DepObj.get('price'), 25, 'cacheable computed properties are invalidated after a middle property changes again, before a run loop');
 });
 
 
@@ -606,7 +606,7 @@ QUnit.test('cacheable nested dependent keys should clear after their dependencie
 //
 
 QUnit.module('Observable objects & object properties ', {
-  setup() {
+  beforeEach() {
     object = ObservableObject.extend({
       getEach() {
         var keys = ['normal', 'abnormal'];
@@ -640,22 +640,22 @@ QUnit.module('Observable objects & object properties ', {
   }
 });
 
-QUnit.test('incrementProperty and decrementProperty', function() {
+QUnit.test('incrementProperty and decrementProperty', function(assert) {
   var newValue = object.incrementProperty('numberVal');
 
-  equal(25, newValue, 'numerical value incremented');
+  assert.equal(25, newValue, 'numerical value incremented');
   object.numberVal = 24;
   newValue = object.decrementProperty('numberVal');
-  equal(23, newValue, 'numerical value decremented');
+  assert.equal(23, newValue, 'numerical value decremented');
   object.numberVal = 25;
   newValue = object.incrementProperty('numberVal', 5);
-  equal(30, newValue, 'numerical value incremented by specified increment');
+  assert.equal(30, newValue, 'numerical value incremented by specified increment');
   object.numberVal = 25;
   newValue = object.incrementProperty('numberVal', -5);
-  equal(20, newValue, 'minus numerical value incremented by specified increment');
+  assert.equal(20, newValue, 'minus numerical value incremented by specified increment');
   object.numberVal = 25;
   newValue = object.incrementProperty('numberVal', 0);
-  equal(25, newValue, 'zero numerical value incremented by specified increment');
+  assert.equal(25, newValue, 'zero numerical value incremented by specified increment');
 
   expectAssertion(function() {
     newValue = object.incrementProperty('numberVal', (0 - void(0))); // Increment by NaN
@@ -669,17 +669,17 @@ QUnit.test('incrementProperty and decrementProperty', function() {
     newValue = object.incrementProperty('numberVal', 1 / 0); // Increment by Infinity
   }, /Must pass a numeric value to incrementProperty/i);
 
-  equal(25, newValue, 'Attempting to increment by non-numeric values should not increment value');
+  assert.equal(25, newValue, 'Attempting to increment by non-numeric values should not increment value');
 
   object.numberVal = 25;
   newValue = object.decrementProperty('numberVal', 5);
-  equal(20, newValue, 'numerical value decremented by specified increment');
+  assert.equal(20, newValue, 'numerical value decremented by specified increment');
   object.numberVal = 25;
   newValue = object.decrementProperty('numberVal', -5);
-  equal(30, newValue, 'minus numerical value decremented by specified increment');
+  assert.equal(30, newValue, 'minus numerical value decremented by specified increment');
   object.numberVal = 25;
   newValue = object.decrementProperty('numberVal', 0);
-  equal(25, newValue, 'zero numerical value decremented by specified increment');
+  assert.equal(25, newValue, 'zero numerical value decremented by specified increment');
 
   expectAssertion(function() {
     newValue = object.decrementProperty('numberVal', (0 - void(0))); // Decrement by NaN
@@ -693,22 +693,22 @@ QUnit.test('incrementProperty and decrementProperty', function() {
     newValue = object.decrementProperty('numberVal', 1 / 0); // Decrement by Infinity
   }, /Must pass a numeric value to decrementProperty/i);
 
-  equal(25, newValue, 'Attempting to decrement by non-numeric values should not decrement value');
+  assert.equal(25, newValue, 'Attempting to decrement by non-numeric values should not decrement value');
 });
 
-QUnit.test('toggle function, should be boolean', function() {
-  equal(object.toggleProperty('toggleVal', true, false), object.get('toggleVal'));
-  equal(object.toggleProperty('toggleVal', true, false), object.get('toggleVal'));
-  equal(object.toggleProperty('toggleVal', undefined, undefined), object.get('toggleVal'));
+QUnit.test('toggle function, should be boolean', function(assert) {
+  assert.equal(object.toggleProperty('toggleVal', true, false), object.get('toggleVal'));
+  assert.equal(object.toggleProperty('toggleVal', true, false), object.get('toggleVal'));
+  assert.equal(object.toggleProperty('toggleVal', undefined, undefined), object.get('toggleVal'));
 });
 
-QUnit.test('should notify array observer when array changes', function() {
+QUnit.test('should notify array observer when array changes', function(assert) {
   get(object, 'normalArray').replace(0, 0, [6]);
-  equal(object.abnormal, 'notifiedObserver', 'observer should be notified');
+  assert.equal(object.abnormal, 'notifiedObserver', 'observer should be notified');
 });
 
 QUnit.module('object.addObserver()', {
-  setup() {
+  beforeEach() {
     ObjectC = ObservableObject.create({
       objectE: ObservableObject.create({
         propertyVal: 'chainedProperty'
@@ -734,23 +734,23 @@ QUnit.module('object.addObserver()', {
   }
 });
 
-QUnit.test('should register an observer for a property', function() {
+QUnit.test('should register an observer for a property', function(assert) {
   ObjectC.addObserver('normal', ObjectC, 'action');
   ObjectC.set('normal', 'newValue');
-  equal(ObjectC.normal1, 'newZeroValue');
+  assert.equal(ObjectC.normal1, 'newZeroValue');
 });
 
-QUnit.test('should register an observer for a property - Special case of chained property', function() {
+QUnit.test('should register an observer for a property - Special case of chained property', function(assert) {
   ObjectC.addObserver('objectE.propertyVal', ObjectC, 'chainedObserver');
   ObjectC.objectE.set('propertyVal', 'chainedPropertyValue');
-  equal('chainedPropertyObserved', ObjectC.normal2);
+  assert.equal('chainedPropertyObserved', ObjectC.normal2);
   ObjectC.normal2 = 'dependentValue';
   ObjectC.set('objectE', '');
-  equal('chainedPropertyObserved', ObjectC.normal2);
+  assert.equal('chainedPropertyObserved', ObjectC.normal2);
 });
 
 QUnit.module('object.removeObserver()', {
-  setup() {
+  beforeEach() {
     ObjectD = ObservableObject.create({
       objectF: ObservableObject.create({
         propertyVal: 'chainedProperty'
@@ -789,32 +789,32 @@ QUnit.module('object.removeObserver()', {
   }
 });
 
-QUnit.test('should unregister an observer for a property', function() {
+QUnit.test('should unregister an observer for a property', function(assert) {
   ObjectD.addObserver('normal', ObjectD, 'addAction');
   ObjectD.set('normal', 'newValue');
-  equal(ObjectD.normal1, 'newZeroValue');
+  assert.equal(ObjectD.normal1, 'newZeroValue');
 
   ObjectD.set('normal1', 'zeroValue');
 
   ObjectD.removeObserver('normal', ObjectD, 'addAction');
   ObjectD.set('normal', 'newValue');
-  equal(ObjectD.normal1, 'zeroValue');
+  assert.equal(ObjectD.normal1, 'zeroValue');
 });
 
 
-QUnit.test('should unregister an observer for a property - special case when key has a \'.\' in it.', function() {
+QUnit.test('should unregister an observer for a property - special case when key has a \'.\' in it.', function(assert) {
   ObjectD.addObserver('objectF.propertyVal', ObjectD, 'removeChainedObserver');
   ObjectD.objectF.set('propertyVal', 'chainedPropertyValue');
   ObjectD.removeObserver('objectF.propertyVal', ObjectD, 'removeChainedObserver');
   ObjectD.normal2 = 'dependentValue';
   ObjectD.objectF.set('propertyVal', 'removedPropertyValue');
-  equal('dependentValue', ObjectD.normal2);
+  assert.equal('dependentValue', ObjectD.normal2);
   ObjectD.set('objectF', '');
-  equal('dependentValue', ObjectD.normal2);
+  assert.equal('dependentValue', ObjectD.normal2);
 });
 
 
-QUnit.test('removing an observer inside of an observer shouldn’t cause any problems', function() {
+QUnit.test('removing an observer inside of an observer shouldn’t cause any problems', function(assert) {
   // The observable system should be protected against clients removing
   // observers in the middle of observer notification.
   var encounteredError = false;
@@ -828,13 +828,13 @@ QUnit.test('removing an observer inside of an observer shouldn’t cause any pro
   } catch (e) {
     encounteredError = true;
   }
-  equal(encounteredError, false);
+  assert.equal(encounteredError, false);
 });
 
 
 
 QUnit.module('Bind function', {
-  setup() {
+  beforeEach() {
     objectA = ObservableObject.create({
       name: 'Sproutcore',
       location: 'Timbaktu'
@@ -855,12 +855,12 @@ QUnit.module('Bind function', {
     };
   },
 
-  teardown() {
+  afterEach() {
     context.lookup = originalLookup;
   }
 });
 
-QUnit.test('should bind property with method parameter as undefined', function() {
+QUnit.test('should bind property with method parameter as undefined', function(assert) {
   // creating binding
   run(function() {
     expectDeprecation(() => {
@@ -874,14 +874,14 @@ QUnit.test('should bind property with method parameter as undefined', function()
   });
 
   // support new-style bindings if available
-  equal('changedValue', objectA.get('name'), 'objectA.name is bound');
+  assert.equal('changedValue', objectA.get('name'), 'objectA.name is bound');
 });
 
 // ..........................................................
 // SPECIAL CASES
 //
 
-QUnit.test('changing chained observer object to null should not raise exception', function() {
+QUnit.test('changing chained observer object to null should not raise exception', function(assert) {
   var obj = ObservableObject.create({
     foo: ObservableObject.create({
       bar: ObservableObject.create({ bat: 'BAT' })
@@ -897,6 +897,6 @@ QUnit.test('changing chained observer object to null should not raise exception'
     obj.foo.set('bar', null);
   });
 
-  equal(callCount, 1, 'changing bar should trigger observer');
-  expect(1);
+  assert.equal(callCount, 1, 'changing bar should trigger observer');
+  assert.expect(1);
 });

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observersForKey_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observersForKey_test.js
@@ -24,20 +24,20 @@ var ObservableObject = EmberObject.extend(Observable);
 
 QUnit.module('object.observesForKey()');
 
-QUnit.test('should get observers', function() {
+QUnit.test('should get observers', function(assert) {
   var o1 = ObservableObject.create({ foo: 100 });
   var o2 = ObservableObject.create({ func() {} });
   var o3 = ObservableObject.create({ func() {} });
   var observers = null;
 
-  equal(get(o1.observersForKey('foo'), 'length'), 0, 'o1.observersForKey should return empty array');
+  assert.equal(get(o1.observersForKey('foo'), 'length'), 0, 'o1.observersForKey should return empty array');
 
   o1.addObserver('foo', o2, o2.func);
   o1.addObserver('foo', o3, o3.func);
 
   observers = o1.observersForKey('foo');
 
-  equal(get(observers, 'length'), 2, 'o2.observersForKey should return an array with length 2');
-  equal(observers[0][0], o2, 'first item in observers array should be o2');
-  equal(observers[1][0], o3, 'second item in observers array should be o3');
+  assert.equal(get(observers, 'length'), 2, 'o2.observersForKey should return an array with length 2');
+  assert.equal(observers[0][0], o2, 'first item in observers array should be o2');
+  assert.equal(observers[1][0], o3, 'second item in observers array should be o3');
 });

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
@@ -26,7 +26,7 @@ const ObservableObject = EmberObject.extend(Observable);
 let ObjectA;
 
 QUnit.module('object.propertyChanges', {
-  setup() {
+  beforeEach() {
     ObjectA = ObservableObject.extend({
       action: observer('foo', function() {
         this.set('prop', 'changedPropValue');
@@ -54,7 +54,7 @@ QUnit.module('object.propertyChanges', {
   }
 });
 
-QUnit.test('should observe the changes within the nested begin / end property changes', function() {
+QUnit.test('should observe the changes within the nested begin / end property changes', function(assert) {
   //start the outer nest
   ObjectA.beginPropertyChanges();
 
@@ -62,36 +62,36 @@ QUnit.test('should observe the changes within the nested begin / end property ch
   ObjectA.beginPropertyChanges();
   ObjectA.set('foo', 'changeFooValue');
 
-  equal(ObjectA.prop, 'propValue');
+  assert.equal(ObjectA.prop, 'propValue');
   ObjectA.endPropertyChanges();
 
   //end inner nest
   ObjectA.set('prop', 'changePropValue');
-  equal(ObjectA.newFoo, 'newFooValue');
+  assert.equal(ObjectA.newFoo, 'newFooValue');
 
   //close the outer nest
   ObjectA.endPropertyChanges();
 
-  equal(ObjectA.prop, 'changedPropValue');
-  equal(ObjectA.newFoo, 'changedNewFooValue');
+  assert.equal(ObjectA.prop, 'changedPropValue');
+  assert.equal(ObjectA.newFoo, 'changedNewFooValue');
 });
 
-QUnit.test('should observe the changes within the begin and end property changes', function() {
+QUnit.test('should observe the changes within the begin and end property changes', function(assert) {
   ObjectA.beginPropertyChanges();
   ObjectA.set('foo', 'changeFooValue');
 
-  equal(ObjectA.prop, 'propValue');
+  assert.equal(ObjectA.prop, 'propValue');
   ObjectA.endPropertyChanges();
 
-  equal(ObjectA.prop, 'changedPropValue');
+  assert.equal(ObjectA.prop, 'changedPropValue');
 });
 
-QUnit.test('should indicate that the property of an object has just changed', function() {
+QUnit.test('should indicate that the property of an object has just changed', function(assert) {
   // indicate that property of foo will change to its subscribers
   ObjectA.propertyWillChange('foo');
 
   //Value of the prop is unchanged yet as this will be changed when foo changes
-  equal(ObjectA.prop, 'propValue');
+  assert.equal(ObjectA.prop, 'propValue');
 
   //change the value of foo.
   ObjectA.set('foo', 'changeFooValue');
@@ -100,20 +100,20 @@ QUnit.test('should indicate that the property of an object has just changed', fu
   ObjectA.propertyDidChange('foo', null);
 
   // Values of prop has just changed
-  equal(ObjectA.prop, 'changedPropValue');
+  assert.equal(ObjectA.prop, 'changedPropValue');
 });
 
-QUnit.test('should notify that the property of an object has changed', function() {
+QUnit.test('should notify that the property of an object has changed', function(assert) {
   // Notify to its subscriber that the values of 'newFoo' will be changed. In this
   // case the observer is "newProp". Therefore this will call the notifyAction function
   // and value of "newProp" will be changed.
   ObjectA.notifyPropertyChange('newFoo', 'fooValue');
 
   //value of newProp changed.
-  equal(ObjectA.newProp, 'changedNewPropValue');
+  assert.equal(ObjectA.newProp, 'changedNewPropValue');
 });
 
-QUnit.test('should invalidate function property cache when notifyPropertyChange is called', function() {
+QUnit.test('should invalidate function property cache when notifyPropertyChange is called', function(assert) {
   let a = ObservableObject.extend({
     b: computed({
       get() { return this._b; },
@@ -127,10 +127,10 @@ QUnit.test('should invalidate function property cache when notifyPropertyChange 
   });
 
   a.set('b', 'foo');
-  equal(a.get('b'), 'foo', 'should have set the correct value for property b');
+  assert.equal(a.get('b'), 'foo', 'should have set the correct value for property b');
 
   a._b = 'bar';
   a.notifyPropertyChange('b');
   a.set('b', 'foo');
-  equal(a.get('b'), 'foo', 'should have invalidated the cache so that the newly set value is actually set');
+  assert.equal(a.get('b'), 'foo', 'should have invalidated the cache so that the newly set value is actually set');
 });

--- a/packages/ember-runtime/tests/legacy_1x/system/binding_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/binding_test.js
@@ -52,7 +52,7 @@ const originalLookup = context.lookup;
 let lookup;
 
 QUnit.module('basic object binding', {
-  setup() {
+  beforeEach() {
     fromObject = EmberObject.create({ value: 'start' });
     toObject = EmberObject.create({ value: 'end' });
     root = { fromObject: fromObject, toObject: toObject };
@@ -64,27 +64,27 @@ QUnit.module('basic object binding', {
   }
 });
 
-QUnit.test('binding should have synced on connect', function() {
-  equal(get(toObject, 'value'), 'start', 'toObject.value should match fromObject.value');
+QUnit.test('binding should have synced on connect', function(assert) {
+  assert.equal(get(toObject, 'value'), 'start', 'toObject.value should match fromObject.value');
 });
 
-QUnit.test('fromObject change should propagate to toObject only after flush', function() {
+QUnit.test('fromObject change should propagate to toObject only after flush', function(assert) {
   run(() => {
     set(fromObject, 'value', 'change');
-    equal(get(toObject, 'value'), 'start');
+    assert.equal(get(toObject, 'value'), 'start');
   });
-  equal(get(toObject, 'value'), 'change');
+  assert.equal(get(toObject, 'value'), 'change');
 });
 
-QUnit.test('toObject change should propagate to fromObject only after flush', function() {
+QUnit.test('toObject change should propagate to fromObject only after flush', function(assert) {
   run(() => {
     set(toObject, 'value', 'change');
-    equal(get(fromObject, 'value'), 'start');
+    assert.equal(get(fromObject, 'value'), 'start');
   });
-  equal(get(fromObject, 'value'), 'change');
+  assert.equal(get(fromObject, 'value'), 'change');
 });
 
-QUnit.test('deferred observing during bindings', function() {
+QUnit.test('deferred observing during bindings', function(assert) {
   // setup special binding
   fromObject = EmberObject.create({
     value1: 'value1',
@@ -93,8 +93,8 @@ QUnit.test('deferred observing during bindings', function() {
 
   toObject = EmberObject.extend({
     observer: emberObserver('value1', 'value2', function() {
-      equal(get(this, 'value1'), 'CHANGED', 'value1 when observer fires');
-      equal(get(this, 'value2'), 'CHANGED', 'value2 when observer fires');
+      assert.equal(get(this, 'value1'), 'CHANGED', 'value1 when observer fires');
+      assert.equal(get(this, 'value2'), 'CHANGED', 'value2 when observer fires');
       this.callCount++;
     })
   }).create({
@@ -120,15 +120,15 @@ QUnit.test('deferred observing during bindings', function() {
     set(fromObject, 'value2', 'CHANGED');
   });
 
-  equal(toObject.callCount, 2, 'should call observer twice');
+  assert.equal(toObject.callCount, 2, 'should call observer twice');
 });
 
-QUnit.test('binding disconnection actually works', function() {
+QUnit.test('binding disconnection actually works', function(assert) {
   binding.disconnect(root);
   run(function () {
     set(fromObject, 'value', 'change');
   });
-  equal(get(toObject, 'value'), 'start');
+  assert.equal(get(toObject, 'value'), 'start');
 });
 
 let first, second, third; // global variables
@@ -139,7 +139,7 @@ let first, second, third; // global variables
 
 QUnit.module('chained binding', {
 
-  setup() {
+  beforeEach() {
     run(function() {
       first = EmberObject.create({ output: 'first' });
 
@@ -165,22 +165,22 @@ QUnit.module('chained binding', {
       }, /`Ember\.Binding` is deprecated./);
     });
   },
-  teardown() {
+  afterEach() {
     run.cancelTimers();
   }
 });
 
-QUnit.test('changing first output should propagate to third after flush', function() {
+QUnit.test('changing first output should propagate to third after flush', function(assert) {
   run(function() {
     set(first, 'output', 'change');
-    equal('change', get(first, 'output'), 'first.output');
-    ok('change' !== get(third, 'input'), 'third.input');
+    assert.equal('change', get(first, 'output'), 'first.output');
+    assert.ok('change' !== get(third, 'input'), 'third.input');
   });
 
-  equal('change', get(first, 'output'), 'first.output');
-  equal('change', get(second, 'input'), 'second.input');
-  equal('change', get(second, 'output'), 'second.output');
-  equal('change', get(third, 'input'), 'third.input');
+  assert.equal('change', get(first, 'output'), 'first.output');
+  assert.equal('change', get(second, 'input'), 'second.input');
+  assert.equal('change', get(second, 'output'), 'second.output');
+  assert.equal('change', get(third, 'input'), 'third.input');
 });
 
 // ..........................................................
@@ -188,7 +188,7 @@ QUnit.test('changing first output should propagate to third after flush', functi
 //
 
 QUnit.module('Custom Binding', {
-  setup() {
+  beforeEach() {
     context.lookup = lookup = {};
 
     Bon1 = EmberObject.extend({
@@ -208,14 +208,14 @@ QUnit.module('Custom Binding', {
       Bon1: Bon1
     };
   },
-  teardown() {
+  afterEach() {
     context.lookup = originalLookup;
     Bon1 = bon2 = TestNamespace  = null;
     run.cancelTimers();
   }
 });
 
-QUnit.test('two bindings to the same value should sync in the order they are initialized', function() {
+QUnit.test('two bindings to the same value should sync in the order they are initialized', function(assert) {
   run.begin();
 
   let a = EmberObject.create({
@@ -244,9 +244,9 @@ QUnit.test('two bindings to the same value should sync in the order they are ini
 
   run.end();
 
-  equal(get(a, 'foo'), 'bar', 'a.foo should not change');
-  equal(get(b, 'foo'), 'bar', 'a.foo should propagate up to b.foo');
-  equal(get(b.c, 'foo'), 'bar', 'a.foo should propagate up to b.c.foo');
+  assert.equal(get(a, 'foo'), 'bar', 'a.foo should not change');
+  assert.equal(get(b, 'foo'), 'bar', 'a.foo should propagate up to b.foo');
+  assert.equal(get(b.c, 'foo'), 'bar', 'a.foo should propagate up to b.c.foo');
 });
 
 // ..........................................................
@@ -254,7 +254,7 @@ QUnit.test('two bindings to the same value should sync in the order they are ini
 //
 
 QUnit.module('propertyNameBinding with longhand', {
-  setup() {
+  beforeEach() {
     context.lookup = lookup = {};
 
     lookup['TestNamespace'] = TestNamespace = {};
@@ -273,28 +273,28 @@ QUnit.module('propertyNameBinding with longhand', {
       }, /`Ember\.Binding` is deprecated./);
     });
   },
-  teardown() {
+  afterEach() {
     TestNamespace = undefined;
     context.lookup = originalLookup;
   }
 });
 
-QUnit.test('works with full path', function() {
+QUnit.test('works with full path', function(assert) {
   run(() => set(TestNamespace.fromObject, 'value', 'updatedValue'));
 
-  equal(get(TestNamespace.toObject, 'value'), 'updatedValue');
+  assert.equal(get(TestNamespace.toObject, 'value'), 'updatedValue');
 
   run(() => set(TestNamespace.fromObject, 'value', 'newerValue'));
 
-  equal(get(TestNamespace.toObject, 'value'), 'newerValue');
+  assert.equal(get(TestNamespace.toObject, 'value'), 'newerValue');
 });
 
-QUnit.test('works with local path', function() {
+QUnit.test('works with local path', function(assert) {
   run(() => set(TestNamespace.toObject, 'localValue', 'updatedValue'));
 
-  equal(get(TestNamespace.toObject, 'relative'), 'updatedValue');
+  assert.equal(get(TestNamespace.toObject, 'relative'), 'updatedValue');
 
   run(() => set(TestNamespace.toObject, 'localValue', 'newerValue'));
 
-  equal(get(TestNamespace.toObject, 'relative'), 'newerValue');
+  assert.equal(get(TestNamespace.toObject, 'relative'), 'newerValue');
 });

--- a/packages/ember-runtime/tests/legacy_1x/system/object/base_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/object/base_test.js
@@ -27,7 +27,7 @@ let obj, obj1; // global variables
 
 QUnit.module('A new EmberObject instance', {
 
-  setup() {
+  beforeEach() {
     obj = EmberObject.create({
       foo: 'bar',
       total: 12345,
@@ -38,30 +38,30 @@ QUnit.module('A new EmberObject instance', {
     });
   },
 
-  teardown() {
+  afterEach() {
     obj = undefined;
   }
 
 });
 
-QUnit.test('Should return its properties when requested using EmberObject#get', function() {
-  equal(get(obj, 'foo'), 'bar');
-  equal(get(obj, 'total'), 12345);
+QUnit.test('Should return its properties when requested using EmberObject#get', function(assert) {
+  assert.equal(get(obj, 'foo'), 'bar');
+  assert.equal(get(obj, 'total'), 12345);
 });
 
-QUnit.test('Should allow changing of those properties by calling EmberObject#set', function() {
-  equal(get(obj, 'foo'), 'bar');
-  equal(get(obj, 'total'), 12345);
+QUnit.test('Should allow changing of those properties by calling EmberObject#set', function(assert) {
+  assert.equal(get(obj, 'foo'), 'bar');
+  assert.equal(get(obj, 'total'), 12345);
 
   set(obj, 'foo', 'Chunky Bacon');
   set(obj, 'total', 12);
 
-  equal(get(obj, 'foo'), 'Chunky Bacon');
-  equal(get(obj, 'total'), 12);
+  assert.equal(get(obj, 'foo'), 'Chunky Bacon');
+  assert.equal(get(obj, 'total'), 12);
 });
 
 QUnit.module('EmberObject superclass and subclasses', {
-  setup() {
+  beforeEach() {
     obj = EmberObject.extend({
       method1() {
         return 'hello';
@@ -70,18 +70,18 @@ QUnit.module('EmberObject superclass and subclasses', {
     obj1 = obj.extend();
   },
 
-  teardown() {
+  afterEach() {
     obj = undefined;
     obj1 = undefined;
   }
 });
 
-QUnit.test('Checking the detect() function on an object and its subclass', function() {
-  equal(obj.detect(obj1), true);
-  equal(obj1.detect(obj), false);
+QUnit.test('Checking the detect() function on an object and its subclass', function(assert) {
+  assert.equal(obj.detect(obj1), true);
+  assert.equal(obj1.detect(obj), false);
 });
 
-QUnit.test('Checking the detectInstance() function on an object and its subclass', function() {
-  ok(EmberObject.detectInstance(obj.create()));
-  ok(obj.detectInstance(obj.create()));
+QUnit.test('Checking the detectInstance() function on an object and its subclass', function(assert) {
+  assert.ok(EmberObject.detectInstance(obj.create()));
+  assert.ok(obj.detectInstance(obj.create()));
 });

--- a/packages/ember-runtime/tests/legacy_1x/system/object/bindings_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/object/bindings_test.js
@@ -24,7 +24,7 @@ let testObject, fromObject, TestObject;
 let TestNamespace, lookup;
 
 QUnit.module('bind() method', {
-  setup() {
+  beforeEach() {
     context.lookup = lookup = {};
 
     testObject = EmberObject.create({
@@ -44,13 +44,13 @@ QUnit.module('bind() method', {
     };
   },
 
-  teardown() {
+  afterEach() {
     testObject = fromObject = null;
     context.lookup = originalLookup;
   }
 });
 
-QUnit.test('bind(TestNamespace.fromObject.bar) should follow absolute path', function() {
+QUnit.test('bind(TestNamespace.fromObject.bar) should follow absolute path', function(assert) {
   run(() => {
     expectDeprecation(() => {
       // create binding
@@ -61,10 +61,10 @@ QUnit.test('bind(TestNamespace.fromObject.bar) should follow absolute path', fun
     set(fromObject, 'bar', 'changedValue');
   });
 
-  equal('changedValue', get(testObject, 'foo'), 'testObject.foo');
+  assert.equal('changedValue', get(testObject, 'foo'), 'testObject.foo');
 });
 
-QUnit.test('bind(.bar) should bind to relative path', function() {
+QUnit.test('bind(.bar) should bind to relative path', function(assert) {
   run(() => {
     expectDeprecation(() => {
       // create binding
@@ -75,11 +75,11 @@ QUnit.test('bind(.bar) should bind to relative path', function() {
     set(testObject, 'bar', 'changedValue');
   });
 
-  equal('changedValue', get(testObject, 'foo'), 'testObject.foo');
+  assert.equal('changedValue', get(testObject, 'foo'), 'testObject.foo');
 });
 
 QUnit.module('fooBinding method', {
-  setup() {
+  beforeEach() {
     context.lookup = lookup = {};
 
     TestObject = EmberObject.extend({
@@ -99,7 +99,7 @@ QUnit.module('fooBinding method', {
     };
   },
 
-  teardown() {
+  afterEach() {
     context.lookup = originalLookup;
     TestObject = fromObject = null;
     //  delete TestNamespace;
@@ -108,7 +108,7 @@ QUnit.module('fooBinding method', {
 
 let deprecationMessage = /`Ember.Binding` is deprecated/;
 
-QUnit.test('fooBinding: TestNamespace.fromObject.bar should follow absolute path', function() {
+QUnit.test('fooBinding: TestNamespace.fromObject.bar should follow absolute path', function(assert) {
   run(() => {
     expectDeprecation(() => {
       // create binding
@@ -121,10 +121,10 @@ QUnit.test('fooBinding: TestNamespace.fromObject.bar should follow absolute path
     set(fromObject, 'bar', 'changedValue');
   });
 
-  equal('changedValue', get(testObject, 'foo'), 'testObject.foo');
+  assert.equal('changedValue', get(testObject, 'foo'), 'testObject.foo');
 });
 
-QUnit.test('fooBinding: .bar should bind to relative path', function() {
+QUnit.test('fooBinding: .bar should bind to relative path', function(assert) {
   run(() => {
     expectDeprecation(() => {
       // create binding
@@ -137,10 +137,10 @@ QUnit.test('fooBinding: .bar should bind to relative path', function() {
     set(testObject, 'bar', 'changedValue');
   });
 
-  equal('changedValue', get(testObject, 'foo'), 'testObject.foo');
+  assert.equal('changedValue', get(testObject, 'foo'), 'testObject.foo');
 });
 
-QUnit.test('fooBinding: should disconnect bindings when destroyed', function () {
+QUnit.test('fooBinding: should disconnect bindings when destroyed', function(assert) {
   run(() => {
     expectDeprecation(() => {
       // create binding
@@ -152,11 +152,11 @@ QUnit.test('fooBinding: should disconnect bindings when destroyed', function () 
     set(TestNamespace.fromObject, 'bar', 'BAZ');
   });
 
-  equal(get(testObject, 'foo'), 'BAZ', 'binding should have synced');
+  assert.equal(get(testObject, 'foo'), 'BAZ', 'binding should have synced');
 
   run(() => testObject.destroy());
 
   run(() => set(TestNamespace.fromObject, 'bar', 'BIFF'));
 
-  ok(get(testObject, 'foo') !== 'bar', 'binding should not have synced');
+  assert.ok(get(testObject, 'foo') !== 'bar', 'binding should not have synced');
 });

--- a/packages/ember-runtime/tests/legacy_1x/system/object/concatenated_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/object/concatenated_test.js
@@ -18,7 +18,7 @@ function K() { return this; }
 let klass;
 
 QUnit.module('EmberObject Concatenated Properties', {
-  setup() {
+  beforeEach() {
     klass = EmberObject.extend({
       concatenatedProperties: ['values', 'functions'],
       values: ['a', 'b', 'c'],
@@ -27,7 +27,7 @@ QUnit.module('EmberObject Concatenated Properties', {
   }
 });
 
-QUnit.test('concatenates instances', function() {
+QUnit.test('concatenates instances', function(assert) {
   let obj = klass.create({
     values: ['d', 'e', 'f']
   });
@@ -35,10 +35,10 @@ QUnit.test('concatenates instances', function() {
   let values = get(obj, 'values');
   let expected = ['a', 'b', 'c', 'd', 'e', 'f'];
 
-  deepEqual(values, expected, `should concatenate values property (expected: ${expected}, got: ${values})`);
+  assert.deepEqual(values, expected, `should concatenate values property (expected: ${expected}, got: ${values})`);
 });
 
-QUnit.test('concatenates subclasses', function() {
+QUnit.test('concatenates subclasses', function(assert) {
   let subKlass = klass.extend({
     values: ['d', 'e', 'f']
   });
@@ -47,10 +47,10 @@ QUnit.test('concatenates subclasses', function() {
   let values = get(obj, 'values');
   let expected = ['a', 'b', 'c', 'd', 'e', 'f'];
 
-  deepEqual(values, expected, `should concatenate values property (expected: ${expected}, got: ${values})`);
+  assert.deepEqual(values, expected, `should concatenate values property (expected: ${expected}, got: ${values})`);
 });
 
-QUnit.test('concatenates reopen', function() {
+QUnit.test('concatenates reopen', function(assert) {
   klass.reopen({
     values: ['d', 'e', 'f']
   });
@@ -59,10 +59,10 @@ QUnit.test('concatenates reopen', function() {
   let values = get(obj, 'values');
   let expected = ['a', 'b', 'c', 'd', 'e', 'f'];
 
-  deepEqual(values, expected, `should concatenate values property (expected: ${expected}, got: ${values})`);
+  assert.deepEqual(values, expected, `should concatenate values property (expected: ${expected}, got: ${values})`);
 });
 
-QUnit.test('concatenates mixin', function() {
+QUnit.test('concatenates mixin', function(assert) {
   let mixin = {
     values: ['d', 'e']
   };
@@ -74,10 +74,10 @@ QUnit.test('concatenates mixin', function() {
   let values = get(obj, 'values');
   let expected = ['a', 'b', 'c', 'd', 'e', 'f'];
 
-  deepEqual(values, expected, `should concatenate values property (expected: ${expected}, got: ${values})`);
+  assert.deepEqual(values, expected, `should concatenate values property (expected: ${expected}, got: ${values})`);
 });
 
-QUnit.test('concatenates reopen, subclass, and instance', function() {
+QUnit.test('concatenates reopen, subclass, and instance', function(assert) {
   klass.reopen({ values: ['d'] });
   let subKlass = klass.extend({ values: ['e'] });
   let obj = subKlass.create({ values: ['f'] });
@@ -85,10 +85,10 @@ QUnit.test('concatenates reopen, subclass, and instance', function() {
   let values = get(obj, 'values');
   let expected = ['a', 'b', 'c', 'd', 'e', 'f'];
 
-  deepEqual(values, expected, `should concatenate values property (expected: ${expected}, got: ${values})`);
+  assert.deepEqual(values, expected, `should concatenate values property (expected: ${expected}, got: ${values})`);
 });
 
-QUnit.test('concatenates subclasses when the values are functions', function() {
+QUnit.test('concatenates subclasses when the values are functions', function(assert) {
   let subKlass = klass.extend({
     functions: K
   });
@@ -97,5 +97,5 @@ QUnit.test('concatenates subclasses when the values are functions', function() {
   let values = get(obj, 'functions');
   let expected = [K, K];
 
-  deepEqual(values, expected, `should concatenate functions property (expected: ${expected}, got: ${values})`);
+  assert.deepEqual(values, expected, `should concatenate functions property (expected: ${expected}, got: ${values})`);
 });

--- a/packages/ember-runtime/tests/legacy_1x/system/run_loop_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/run_loop_test.js
@@ -23,7 +23,7 @@ import EmberObject from '../../../system/object';
 let MyApp;
 
 QUnit.module('System:run_loop() - chained binding', {
-  setup() {
+  beforeEach() {
     MyApp = {};
     MyApp.first = EmberObject.extend(Observable).create({
       output: 'MyApp.first'
@@ -46,7 +46,7 @@ QUnit.module('System:run_loop() - chained binding', {
 
 let deprecationMessage = /`Ember.Binding` is deprecated/;
 
-QUnit.test('Should propagate bindings after the RunLoop completes (using Ember.RunLoop)', function() {
+QUnit.test('Should propagate bindings after the RunLoop completes (using Ember.RunLoop)', function(assert) {
   run(() => {
     //Binding of output of MyApp.first object to input of MyApp.second object
     expectDeprecation(() => {
@@ -68,20 +68,20 @@ QUnit.test('Should propagate bindings after the RunLoop completes (using Ember.R
     MyApp.first.set('output', 'change');
 
     //Changes the output of the MyApp.first object
-    equal(MyApp.first.get('output'), 'change');
+    assert.equal(MyApp.first.get('output'), 'change');
 
     //since binding has not taken into effect the value still remains as change.
-    equal(MyApp.second.get('output'), 'MyApp.first');
+    assert.equal(MyApp.second.get('output'), 'MyApp.first');
   }); // allows bindings to trigger...
 
   //Value of the output variable changed to 'change'
-  equal(MyApp.first.get('output'), 'change');
+  assert.equal(MyApp.first.get('output'), 'change');
 
   //Since binding triggered after the end loop the value changed to 'change'.
-  equal(MyApp.second.get('output'), 'change');
+  assert.equal(MyApp.second.get('output'), 'change');
 });
 
-QUnit.test('Should propagate bindings after the RunLoop completes', function() {
+QUnit.test('Should propagate bindings after the RunLoop completes', function(assert) {
   run(() => {
     //Binding of output of MyApp.first object to input of MyApp.second object
     expectDeprecation(() => {
@@ -102,15 +102,15 @@ QUnit.test('Should propagate bindings after the RunLoop completes', function() {
     MyApp.first.set('output', 'change');
 
     //Changes the output of the MyApp.first object
-    equal(MyApp.first.get('output'), 'change');
+    assert.equal(MyApp.first.get('output'), 'change');
 
     //since binding has not taken into effect the value still remains as change.
-    equal(MyApp.second.get('output'), 'MyApp.first');
+    assert.equal(MyApp.second.get('output'), 'MyApp.first');
   });
 
   //Value of the output variable changed to 'change'
-  equal(MyApp.first.get('output'), 'change');
+  assert.equal(MyApp.first.get('output'), 'change');
 
   //Since binding triggered after the end loop the value changed to 'change'.
-  equal(MyApp.second.get('output'), 'change');
+  assert.equal(MyApp.second.get('output'), 'change');
 });

--- a/packages/ember-runtime/tests/main_test.js
+++ b/packages/ember-runtime/tests/main_test.js
@@ -5,7 +5,7 @@ import {
 
 QUnit.module('ember-runtime/main');
 
-QUnit.test('Ember.computed.collect', function() {
+QUnit.test('Ember.computed.collect', function(assert) {
   let MyObj = EmberObject.extend({
     props: collect('foo', 'bar', 'baz')
   });
@@ -18,5 +18,5 @@ QUnit.test('Ember.computed.collect', function() {
 
   let propsValue = myObj.get('props');
 
-  deepEqual(propsValue, [3, 5, 'asdf']);
+  assert.deepEqual(propsValue, [3, 5, 'asdf']);
 });

--- a/packages/ember-runtime/tests/mixins/array_test.js
+++ b/packages/ember-runtime/tests/mixins/array_test.js
@@ -74,29 +74,29 @@ ArrayTests.extend({
 
 }).run();
 
-QUnit.test('the return value of slice has Ember.Array applied', function() {
+QUnit.test('the return value of slice has Ember.Array applied', function(assert) {
   let x = EmberObject.extend(EmberArray).create({
     length: 0
   });
   let y = x.slice(1);
-  equal(EmberArray.detect(y), true, 'mixin should be applied');
+  assert.equal(EmberArray.detect(y), true, 'mixin should be applied');
 });
 
-QUnit.test('slice supports negative index arguments', function() {
+QUnit.test('slice supports negative index arguments', function(assert) {
   let testArray = new TestArray([1, 2, 3, 4]);
 
-  deepEqual(testArray.slice(-2), [3, 4], 'slice(-2)');
-  deepEqual(testArray.slice(-2, -1), [3], 'slice(-2, -1');
-  deepEqual(testArray.slice(-2, -2), [], 'slice(-2, -2)');
-  deepEqual(testArray.slice(-1, -2), [], 'slice(-1, -2)');
+  assert.deepEqual(testArray.slice(-2), [3, 4], 'slice(-2)');
+  assert.deepEqual(testArray.slice(-2, -1), [3], 'slice(-2, -1');
+  assert.deepEqual(testArray.slice(-2, -2), [], 'slice(-2, -2)');
+  assert.deepEqual(testArray.slice(-1, -2), [], 'slice(-1, -2)');
 
-  deepEqual(testArray.slice(-4, 1), [1], 'slice(-4, 1)');
-  deepEqual(testArray.slice(-4, 5), [1, 2, 3, 4], 'slice(-4, 5)');
-  deepEqual(testArray.slice(-4), [1, 2, 3, 4], 'slice(-4)');
+  assert.deepEqual(testArray.slice(-4, 1), [1], 'slice(-4, 1)');
+  assert.deepEqual(testArray.slice(-4, 5), [1, 2, 3, 4], 'slice(-4, 5)');
+  assert.deepEqual(testArray.slice(-4), [1, 2, 3, 4], 'slice(-4)');
 
-  deepEqual(testArray.slice(0, -1), [1, 2, 3], 'slice(0, -1)');
-  deepEqual(testArray.slice(0, -4), [], 'slice(0, -4)');
-  deepEqual(testArray.slice(0, -3), [1], 'slice(0, -3)');
+  assert.deepEqual(testArray.slice(0, -1), [1, 2, 3], 'slice(0, -1)');
+  assert.deepEqual(testArray.slice(0, -4), [], 'slice(0, -4)');
+  assert.deepEqual(testArray.slice(0, -3), [1], 'slice(0, -3)');
 });
 
 // ..........................................................
@@ -117,7 +117,7 @@ let obj, observer;
 
 QUnit.module('mixins/array/arrayContent[Will|Did]Change');
 
-QUnit.test('should notify observers of []', function() {
+QUnit.test('should notify observers of []', function(assert) {
   obj = DummyArray.extend({
     enumerablePropertyDidChange: emberObserver('[]', function() {
       this._count++;
@@ -126,12 +126,12 @@ QUnit.test('should notify observers of []', function() {
     _count: 0
   });
 
-  equal(obj._count, 0, 'should not have invoked yet');
+  assert.equal(obj._count, 0, 'should not have invoked yet');
 
   arrayContentWillChange(obj, 0, 1, 1);
   arrayContentDidChange(obj, 0, 1, 1);
 
-  equal(obj._count, 1, 'should have invoked');
+  assert.equal(obj._count, 1, 'should have invoked');
 });
 
 // ..........................................................
@@ -139,7 +139,7 @@ QUnit.test('should notify observers of []', function() {
 //
 
 QUnit.module('notify observers of length', {
-  setup() {
+  beforeEach(assert) {
     obj = DummyArray.extend({
       lengthDidChange: emberObserver('length', function() {
         this._after++;
@@ -148,37 +148,37 @@ QUnit.module('notify observers of length', {
       _after: 0
     });
 
-    equal(obj._after, 0, 'should not have fired yet');
+    assert.equal(obj._after, 0, 'should not have fired yet');
   },
 
-  teardown() {
+  afterEach() {
     obj = null;
   }
 });
 
-QUnit.test('should notify observers when call with no params', function() {
+QUnit.test('should notify observers when call with no params', function(assert) {
   arrayContentWillChange(obj);
-  equal(obj._after, 0);
+  assert.equal(obj._after, 0);
 
   arrayContentDidChange(obj);
-  equal(obj._after, 1);
+  assert.equal(obj._after, 1);
 });
 
 // API variation that included items only
-QUnit.test('should not notify when passed lengths are same', function() {
+QUnit.test('should not notify when passed lengths are same', function(assert) {
   arrayContentWillChange(obj, 0, 1, 1);
-  equal(obj._after, 0);
+  assert.equal(obj._after, 0);
 
   arrayContentDidChange(obj, 0, 1, 1);
-  equal(obj._after, 0);
+  assert.equal(obj._after, 0);
 });
 
-QUnit.test('should notify when passed lengths are different', function() {
+QUnit.test('should notify when passed lengths are different', function(assert) {
   arrayContentWillChange(obj, 0, 1, 2);
-  equal(obj._after, 0);
+  assert.equal(obj._after, 0);
 
   arrayContentDidChange(obj, 0, 1, 2);
-  equal(obj._after, 1);
+  assert.equal(obj._after, 1);
 });
 
 
@@ -187,17 +187,17 @@ QUnit.test('should notify when passed lengths are different', function() {
 //
 
 QUnit.module('notify array observers', {
-  setup() {
+  beforeEach(assert) {
     obj = DummyArray.create();
 
     observer = EmberObject.extend({
       arrayWillChange() {
-        equal(this._before, null); // should only call once
+        assert.equal(this._before, null); // should only call once
         this._before = Array.prototype.slice.call(arguments);
       },
 
       arrayDidChange() {
-        equal(this._after, null); // should only call once
+        assert.equal(this._after, null); // should only call once
         this._after = Array.prototype.slice.call(arguments);
       }
     }).create({
@@ -208,43 +208,43 @@ QUnit.module('notify array observers', {
     addArrayObserver(obj, observer);
   },
 
-  teardown() {
+  afterEach() {
     obj = observer = null;
   }
 });
 
-QUnit.test('should notify enumerable observers when called with no params', function() {
+QUnit.test('should notify enumerable observers when called with no params', function(assert) {
   arrayContentWillChange(obj);
-  deepEqual(observer._before, [obj, 0, -1, -1]);
+  assert.deepEqual(observer._before, [obj, 0, -1, -1]);
 
   arrayContentDidChange(obj);
-  deepEqual(observer._after, [obj, 0, -1, -1]);
+  assert.deepEqual(observer._after, [obj, 0, -1, -1]);
 });
 
 // API variation that included items only
-QUnit.test('should notify when called with same length items', function() {
+QUnit.test('should notify when called with same length items', function(assert) {
   arrayContentWillChange(obj, 0, 1, 1);
-  deepEqual(observer._before, [obj, 0, 1, 1]);
+  assert.deepEqual(observer._before, [obj, 0, 1, 1]);
 
   arrayContentDidChange(obj, 0, 1, 1);
-  deepEqual(observer._after, [obj, 0, 1, 1]);
+  assert.deepEqual(observer._after, [obj, 0, 1, 1]);
 });
 
-QUnit.test('should notify when called with diff length items', function() {
+QUnit.test('should notify when called with diff length items', function(assert) {
   arrayContentWillChange(obj, 0, 2, 1);
-  deepEqual(observer._before, [obj, 0, 2, 1]);
+  assert.deepEqual(observer._before, [obj, 0, 2, 1]);
 
   arrayContentDidChange(obj, 0, 2, 1);
-  deepEqual(observer._after, [obj, 0, 2, 1]);
+  assert.deepEqual(observer._after, [obj, 0, 2, 1]);
 });
 
-QUnit.test('removing enumerable observer should disable', function() {
+QUnit.test('removing enumerable observer should disable', function(assert) {
   removeArrayObserver(obj, observer);
   arrayContentWillChange(obj);
-  deepEqual(observer._before, null);
+  assert.deepEqual(observer._before, null);
 
   arrayContentDidChange(obj);
-  deepEqual(observer._after, null);
+  assert.deepEqual(observer._after, null);
 });
 
 // ..........................................................
@@ -252,17 +252,17 @@ QUnit.test('removing enumerable observer should disable', function() {
 //
 
 QUnit.module('notify enumerable observers as well', {
-  setup() {
+  beforeEach(assert) {
     obj = DummyArray.create();
 
     observer = EmberObject.extend({
       enumerableWillChange() {
-        equal(this._before, null); // should only call once
+        assert.equal(this._before, null); // should only call once
         this._before = Array.prototype.slice.call(arguments);
       },
 
       enumerableDidChange() {
-        equal(this._after, null); // should only call once
+        assert.equal(this._after, null); // should only call once
         this._after = Array.prototype.slice.call(arguments);
       }
     }).create({
@@ -273,43 +273,43 @@ QUnit.module('notify enumerable observers as well', {
     obj.addEnumerableObserver(observer);
   },
 
-  teardown() {
+  afterEach() {
     obj = observer = null;
   }
 });
 
-QUnit.test('should notify enumerable observers when called with no params', function() {
+QUnit.test('should notify enumerable observers when called with no params', function(assert) {
   arrayContentWillChange(obj);
-  deepEqual(observer._before, [obj, null, null], 'before');
+  assert.deepEqual(observer._before, [obj, null, null], 'before');
 
   arrayContentDidChange(obj);
-  deepEqual(observer._after, [obj, null, null], 'after');
+  assert.deepEqual(observer._after, [obj, null, null], 'after');
 });
 
 // API variation that included items only
-QUnit.test('should notify when called with same length items', function() {
+QUnit.test('should notify when called with same length items', function(assert) {
   arrayContentWillChange(obj, 0, 1, 1);
-  deepEqual(observer._before, [obj, ['ITEM-0'], 1], 'before');
+  assert.deepEqual(observer._before, [obj, ['ITEM-0'], 1], 'before');
 
   arrayContentDidChange(obj, 0, 1, 1);
-  deepEqual(observer._after, [obj, 1, ['ITEM-0']], 'after');
+  assert.deepEqual(observer._after, [obj, 1, ['ITEM-0']], 'after');
 });
 
-QUnit.test('should notify when called with diff length items', function() {
+QUnit.test('should notify when called with diff length items', function(assert) {
   arrayContentWillChange(obj, 0, 2, 1);
-  deepEqual(observer._before, [obj, ['ITEM-0', 'ITEM-1'], 1], 'before');
+  assert.deepEqual(observer._before, [obj, ['ITEM-0', 'ITEM-1'], 1], 'before');
 
   arrayContentDidChange(obj, 0, 2, 1);
-  deepEqual(observer._after, [obj, 2, ['ITEM-0']], 'after');
+  assert.deepEqual(observer._after, [obj, 2, ['ITEM-0']], 'after');
 });
 
-QUnit.test('removing enumerable observer should disable', function() {
+QUnit.test('removing enumerable observer should disable', function(assert) {
   obj.removeEnumerableObserver(observer);
   arrayContentWillChange(obj);
-  deepEqual(observer._before, null, 'before');
+  assert.deepEqual(observer._before, null, 'before');
 
   arrayContentDidChange(obj);
-  deepEqual(observer._after, null, 'after');
+  assert.deepEqual(observer._after, null, 'after');
 });
 
 // ..........................................................
@@ -319,7 +319,7 @@ QUnit.test('removing enumerable observer should disable', function() {
 let ary;
 
 QUnit.module('EmberArray.@each support', {
-  setup() {
+  beforeEach() {
     ary = new TestArray([
       { isDone: true, desc: 'Todo 1' },
       { isDone: false, desc: 'Todo 2' },
@@ -328,12 +328,12 @@ QUnit.module('EmberArray.@each support', {
     ]);
   },
 
-  teardown() {
+  afterEach() {
     ary = null;
   }
 });
 
-QUnit.test('adding an object should notify (@each.isDone)', function() {
+QUnit.test('adding an object should notify (@each.isDone)', function(assert) {
   let called = 0;
 
   let observerObject = EmberObject.create({
@@ -349,18 +349,18 @@ QUnit.test('adding an object should notify (@each.isDone)', function() {
     isDone: false
   }));
 
-  equal(called, 1, 'calls observer when object is pushed');
+  assert.equal(called, 1, 'calls observer when object is pushed');
 });
 
-QUnit.test('@each is readOnly', function() {
-  expect(1);
+QUnit.test('@each is readOnly', function(assert) {
+  assert.expect(1);
 
-  throws(function() {
+  assert.throws(function() {
     set(ary, '@each', 'foo');
   }, /Cannot set read-only property "@each"/);
 });
 
-QUnit.test('using @each to observe arrays that does not return objects raise error', function() {
+QUnit.test('using @each to observe arrays that does not return objects raise error', function(assert) {
   let called = 0;
 
   let observerObject = EmberObject.create({
@@ -384,10 +384,10 @@ QUnit.test('using @each to observe arrays that does not return objects raise err
     }));
   }, /When using @each to observe the array/);
 
-  equal(called, 0, 'not calls observer when object is pushed');
+  assert.equal(called, 0, 'not calls observer when object is pushed');
 });
 
-QUnit.test('modifying the array should also indicate the isDone prop itself has changed', function() {
+QUnit.test('modifying the array should also indicate the isDone prop itself has changed', function(assert) {
   // NOTE: we never actually get the '@each.isDone' property here.  This is
   // important because it tests the case where we don't have an isDone
   // EachArray materialized but just want to know when the property has
@@ -401,16 +401,16 @@ QUnit.test('modifying the array should also indicate the isDone prop itself has 
   count = 0;
   let item = objectAt(ary, 2);
   set(item, 'isDone', !get(item, 'isDone'));
-  equal(count, 1, '@each.isDone should have notified');
+  assert.equal(count, 1, '@each.isDone should have notified');
 });
 
-QUnit.test('`objectAt` returns correct object', function() {
+QUnit.test('`objectAt` returns correct object', function(assert) {
   let arr = ['first', 'second', 'third', 'fourth'];
-  equal(objectAt(arr, 2), 'third');
-  equal(objectAt(arr, 4), undefined);
+  assert.equal(objectAt(arr, 2), 'third');
+  assert.equal(objectAt(arr, 4), undefined);
 });
 
-testBoth('should be clear caches for computed properties that have dependent keys on arrays that are changed after object initialization', function(get, set) {
+testBoth('should be clear caches for computed properties that have dependent keys on arrays that are changed after object initialization', function(get, set, assert) {
   let obj = EmberObject.extend({
     init() {
       this._super(...arguments);
@@ -423,13 +423,13 @@ testBoth('should be clear caches for computed properties that have dependent key
   }).create();
 
   get(obj, 'resources').pushObject(EmberObject.create({ common: 'HI!' }));
-  equal('HI!', get(obj, 'common'));
+  assert.equal('HI!', get(obj, 'common'));
 
   set(objectAt(get(obj, 'resources'), 0), 'common', 'BYE!');
-  equal('BYE!', get(obj, 'common'));
+  assert.equal('BYE!', get(obj, 'common'));
 });
 
-testBoth('observers that contain @each in the path should fire only once the first time they are accessed', function(get, set) {
+testBoth('observers that contain @each in the path should fire only once the first time they are accessed', function(get, set, assert) {
   let count = 0;
 
   let obj = EmberObject.extend({
@@ -447,5 +447,5 @@ testBoth('observers that contain @each in the path should fire only once the fir
   // Observer fires third time when property on an object is changed
   set(objectAt(get(obj, 'resources'), 0), 'common', 'BYE!');
 
-  equal(count, 2, 'observers should only be called once');
+  assert.equal(count, 2, 'observers should only be called once');
 });

--- a/packages/ember-runtime/tests/mixins/comparable_test.js
+++ b/packages/ember-runtime/tests/mixins/comparable_test.js
@@ -20,15 +20,15 @@ const Rectangle = EmberObject.extend(Comparable, {
 let r1, r2;
 
 QUnit.module('Comparable', {
-  setup() {
+  beforeEach() {
     r1 = Rectangle.create({ length: 6, width: 12 });
     r2 = Rectangle.create({ length: 6, width: 13 });
   }
 });
 
-QUnit.test('should be comparable and return the correct result', function() {
-  equal(Comparable.detect(r1), true);
-  equal(compare(r1, r1), 0);
-  equal(compare(r1, r2), -1);
-  equal(compare(r2, r1), 1);
+QUnit.test('should be comparable and return the correct result', function(assert) {
+  assert.equal(Comparable.detect(r1), true);
+  assert.equal(compare(r1, r1), 0);
+  assert.equal(compare(r1, r2), -1);
+  assert.equal(compare(r2, r1), 1);
 });

--- a/packages/ember-runtime/tests/mixins/container_proxy_test.js
+++ b/packages/ember-runtime/tests/mixins/container_proxy_test.js
@@ -4,7 +4,7 @@ import ContainerProxy from '../../mixins/container_proxy';
 import EmberObject from '../../system/object';
 
 QUnit.module('ember-runtime/mixins/container_proxy', {
-  setup() {
+  beforeEach() {
     this.Owner = EmberObject.extend(ContainerProxy);
     this.instance = this.Owner.create();
 

--- a/packages/ember-runtime/tests/mixins/enumerable_test.js
+++ b/packages/ember-runtime/tests/mixins/enumerable_test.js
@@ -67,31 +67,31 @@ EnumerableTests.extend({
 
 QUnit.module('Ember.Enumerable');
 
-QUnit.test('should apply Ember.Array to return value of map', function() {
+QUnit.test('should apply Ember.Array to return value of map', function(assert) {
   let x = EmberObject.extend(Enumerable).create();
   let y = x.map(K);
-  equal(EmberArray.detect(y), true, 'should have mixin applied');
+  assert.equal(EmberArray.detect(y), true, 'should have mixin applied');
 });
 
-QUnit.test('should apply Ember.Array to return value of filter', function() {
+QUnit.test('should apply Ember.Array to return value of filter', function(assert) {
   let x = EmberObject.extend(Enumerable).create();
   let y = x.filter(K);
-  equal(EmberArray.detect(y), true, 'should have mixin applied');
+  assert.equal(EmberArray.detect(y), true, 'should have mixin applied');
 });
 
-QUnit.test('should apply Ember.Array to return value of invoke', function() {
+QUnit.test('should apply Ember.Array to return value of invoke', function(assert) {
   let x = EmberObject.extend(Enumerable).create();
   let y = x.invoke(K);
-  equal(EmberArray.detect(y), true, 'should have mixin applied');
+  assert.equal(EmberArray.detect(y), true, 'should have mixin applied');
 });
 
-QUnit.test('should apply Ember.Array to return value of toArray', function() {
+QUnit.test('should apply Ember.Array to return value of toArray', function(assert) {
   let x = EmberObject.extend(Enumerable).create();
   let y = x.toArray(K);
-  equal(EmberArray.detect(y), true, 'should have mixin applied');
+  assert.equal(EmberArray.detect(y), true, 'should have mixin applied');
 });
 
-QUnit.test('should apply Ember.Array to return value of without', function() {
+QUnit.test('should apply Ember.Array to return value of without', function(assert) {
   let X = EmberObject.extend(Enumerable, {
     contains() {
       return true;
@@ -103,16 +103,16 @@ QUnit.test('should apply Ember.Array to return value of without', function() {
 
   let x = X.create();
   let y = x.without(K);
-  equal(EmberArray.detect(y), true, 'should have mixin applied');
+  assert.equal(EmberArray.detect(y), true, 'should have mixin applied');
 });
 
-QUnit.test('should apply Ember.Array to return value of uniq', function() {
+QUnit.test('should apply Ember.Array to return value of uniq', function(assert) {
   let x = EmberObject.extend(Enumerable).create();
   let y = x.uniq(K);
-  equal(EmberArray.detect(y), true, 'should have mixin applied');
+  assert.equal(EmberArray.detect(y), true, 'should have mixin applied');
 });
 
-QUnit.test('any', function() {
+QUnit.test('any', function(assert) {
   let kittens = emberA([{
     color: 'white'
   }, {
@@ -123,19 +123,19 @@ QUnit.test('any', function() {
   let foundWhite = kittens.any(kitten => kitten.color === 'white');
   let foundWhite2 = kittens.isAny('color', 'white');
 
-  equal(foundWhite, true);
-  equal(foundWhite2, true);
+  assert.equal(foundWhite, true);
+  assert.equal(foundWhite2, true);
 });
 
-QUnit.test('any with NaN', function() {
+QUnit.test('any with NaN', function(assert) {
   let numbers = emberA([1, 2, NaN, 4]);
 
   let hasNaN = numbers.any(n => isNaN(n));
 
-  equal(hasNaN, true, 'works when matching NaN');
+  assert.equal(hasNaN, true, 'works when matching NaN');
 });
 
-QUnit.test('every', function() {
+QUnit.test('every', function(assert) {
   let allColorsKittens = emberA([{
     color: 'white'
   }, {
@@ -154,22 +154,22 @@ QUnit.test('every', function() {
   let whiteKittenPredicate = function(kitten) { return kitten.color === 'white'; };
 
   allWhite = allColorsKittens.every(whiteKittenPredicate);
-  equal(allWhite, false);
+  assert.equal(allWhite, false);
 
   allWhite = allWhiteKittens.every(whiteKittenPredicate);
-  equal(allWhite, true);
+  assert.equal(allWhite, true);
 
   allWhite = allColorsKittens.isEvery('color', 'white');
-  equal(allWhite, false);
+  assert.equal(allWhite, false);
 
   allWhite = allWhiteKittens.isEvery('color', 'white');
-  equal(allWhite, true);
+  assert.equal(allWhite, true);
 });
 
-QUnit.test('should throw an error passing a second argument to includes', function() {
+QUnit.test('should throw an error passing a second argument to includes', function(assert) {
   let x = EmberObject.extend(Enumerable).create();
 
-  equal(x.includes('any'), false);
+  assert.equal(x.includes('any'), false);
   expectAssertion(() => {
     x.includes('any', 1);
   }, /Enumerable#includes cannot accept a second argument "startAt" as enumerable items are unordered./);
@@ -192,7 +192,7 @@ let obj, observer;
 
 QUnit.module('mixins/enumerable/enumerableContentDidChange');
 
-QUnit.test('should notify observers of []', function() {
+QUnit.test('should notify observers of []', function(assert) {
   let obj = EmberObject.extend(Enumerable, {
     nextObject() {}, // avoid exceptions
 
@@ -203,10 +203,10 @@ QUnit.test('should notify observers of []', function() {
     _count: 0
   });
 
-  equal(obj._count, 0, 'should not have invoked yet');
+  assert.equal(obj._count, 0, 'should not have invoked yet');
   obj.enumerableContentWillChange();
   obj.enumerableContentDidChange();
-  equal(obj._count, 1, 'should have invoked');
+  assert.equal(obj._count, 1, 'should have invoked');
 });
 
 // ..........................................................
@@ -214,7 +214,7 @@ QUnit.test('should notify observers of []', function() {
 //
 
 QUnit.module('notify observers of length', {
-  setup() {
+  beforeEach(assert) {
     obj = DummyEnum.extend({
       lengthDidChange: emberObserver('length', function() {
         this._after++;
@@ -223,60 +223,60 @@ QUnit.module('notify observers of length', {
       _after: 0
     });
 
-    equal(obj._after, 0, 'should not have fired yet');
+    assert.equal(obj._after, 0, 'should not have fired yet');
   },
 
-  teardown() {
+  afterEach() {
     obj = null;
   }
 });
 
-QUnit.test('should notify observers when call with no params', function() {
+QUnit.test('should notify observers when call with no params', function(assert) {
   obj.enumerableContentWillChange();
-  equal(obj._after, 0);
+  assert.equal(obj._after, 0);
 
   obj.enumerableContentDidChange();
-  equal(obj._after, 1);
+  assert.equal(obj._after, 1);
 });
 
 // API variation that included items only
-QUnit.test('should not notify when passed arrays of same length', function() {
+QUnit.test('should not notify when passed arrays of same length', function(assert) {
   let added = ['foo'];
   let removed = ['bar'];
 
   obj.enumerableContentWillChange(removed, added);
-  equal(obj._after, 0);
+  assert.equal(obj._after, 0);
 
   obj.enumerableContentDidChange(removed, added);
-  equal(obj._after, 0);
+  assert.equal(obj._after, 0);
 });
 
-QUnit.test('should notify when passed arrays of different length', function() {
+QUnit.test('should notify when passed arrays of different length', function(assert) {
   let added = ['foo'];
   let removed = ['bar', 'baz'];
 
   obj.enumerableContentWillChange(removed, added);
-  equal(obj._after, 0);
+  assert.equal(obj._after, 0);
 
   obj.enumerableContentDidChange(removed, added);
-  equal(obj._after, 1);
+  assert.equal(obj._after, 1);
 });
 
 // API variation passes indexes only
-QUnit.test('should not notify when passed with indexes', function() {
+QUnit.test('should not notify when passed with indexes', function(assert) {
   obj.enumerableContentWillChange(1, 1);
-  equal(obj._after, 0);
+  assert.equal(obj._after, 0);
 
   obj.enumerableContentDidChange(1, 1);
-  equal(obj._after, 0);
+  assert.equal(obj._after, 0);
 });
 
-QUnit.test('should notify when passed old index API with delta', function() {
+QUnit.test('should notify when passed old index API with delta', function(assert) {
   obj.enumerableContentWillChange(1, 2);
-  equal(obj._after, 0);
+  assert.equal(obj._after, 0);
 
   obj.enumerableContentDidChange(1, 2);
-  equal(obj._after, 1);
+  assert.equal(obj._after, 1);
 });
 
 // ..........................................................
@@ -284,17 +284,17 @@ QUnit.test('should notify when passed old index API with delta', function() {
 //
 
 QUnit.module('notify enumerable observers', {
-  setup() {
+  beforeEach(assert) {
     obj = DummyEnum.create();
 
     observer = EmberObject.extend({
       enumerableWillChange() {
-        equal(this._before, null); // should only call once
+        assert.equal(this._before, null); // should only call once
         this._before = Array.prototype.slice.call(arguments);
       },
 
       enumerableDidChange() {
-        equal(this._after, null); // should only call once
+        assert.equal(this._after, null); // should only call once
         this._after = Array.prototype.slice.call(arguments);
       }
     }).create({
@@ -305,55 +305,55 @@ QUnit.module('notify enumerable observers', {
     obj.addEnumerableObserver(observer);
   },
 
-  teardown() {
+  afterEach() {
     obj = observer = null;
   }
 });
 
-QUnit.test('should notify enumerable observers when called with no params', function() {
+QUnit.test('should notify enumerable observers when called with no params', function(assert) {
   obj.enumerableContentWillChange();
-  deepEqual(observer._before, [obj, null, null]);
+  assert.deepEqual(observer._before, [obj, null, null]);
 
   obj.enumerableContentDidChange();
-  deepEqual(observer._after, [obj, null, null]);
+  assert.deepEqual(observer._after, [obj, null, null]);
 });
 
 // API variation that included items only
-QUnit.test('should notify when called with same length items', function() {
+QUnit.test('should notify when called with same length items', function(assert) {
   let added = ['foo'];
   let removed = ['bar'];
 
   obj.enumerableContentWillChange(removed, added);
-  deepEqual(observer._before, [obj, removed, added]);
+  assert.deepEqual(observer._before, [obj, removed, added]);
 
   obj.enumerableContentDidChange(removed, added);
-  deepEqual(observer._after, [obj, removed, added]);
+  assert.deepEqual(observer._after, [obj, removed, added]);
 });
 
-QUnit.test('should notify when called with diff length items', function() {
+QUnit.test('should notify when called with diff length items', function(assert) {
   let added = ['foo', 'baz'];
   let removed = ['bar'];
 
   obj.enumerableContentWillChange(removed, added);
-  deepEqual(observer._before, [obj, removed, added]);
+  assert.deepEqual(observer._before, [obj, removed, added]);
 
   obj.enumerableContentDidChange(removed, added);
-  deepEqual(observer._after, [obj, removed, added]);
+  assert.deepEqual(observer._after, [obj, removed, added]);
 });
 
-QUnit.test('should not notify when passed with indexes only', function() {
+QUnit.test('should not notify when passed with indexes only', function(assert) {
   obj.enumerableContentWillChange(1, 2);
-  deepEqual(observer._before, [obj, 1, 2]);
+  assert.deepEqual(observer._before, [obj, 1, 2]);
 
   obj.enumerableContentDidChange(1, 2);
-  deepEqual(observer._after, [obj, 1, 2]);
+  assert.deepEqual(observer._after, [obj, 1, 2]);
 });
 
-QUnit.test('removing enumerable observer should disable', function() {
+QUnit.test('removing enumerable observer should disable', function(assert) {
   obj.removeEnumerableObserver(observer);
   obj.enumerableContentWillChange();
-  deepEqual(observer._before, null);
+  assert.deepEqual(observer._before, null);
 
   obj.enumerableContentDidChange();
-  deepEqual(observer._after, null);
+  assert.deepEqual(observer._after, null);
 });

--- a/packages/ember-runtime/tests/mixins/observable_test.js
+++ b/packages/ember-runtime/tests/mixins/observable_test.js
@@ -4,7 +4,7 @@ import EmberObject from '../../system/object';
 
 QUnit.module('mixins/observable');
 
-QUnit.test('should be able to use getProperties to get a POJO of provided keys', function() {
+QUnit.test('should be able to use getProperties to get a POJO of provided keys', function(assert) {
   let obj = EmberObject.create({
     firstName: 'Steve',
     lastName: 'Jobs',
@@ -12,11 +12,11 @@ QUnit.test('should be able to use getProperties to get a POJO of provided keys',
   });
 
   let pojo = obj.getProperties('firstName', 'lastName');
-  equal('Steve', pojo.firstName);
-  equal('Jobs', pojo.lastName);
+  assert.equal('Steve', pojo.firstName);
+  assert.equal('Jobs', pojo.lastName);
 });
 
-QUnit.test('should be able to use getProperties with array parameter to get a POJO of provided keys', function() {
+QUnit.test('should be able to use getProperties with array parameter to get a POJO of provided keys', function(assert) {
   let obj = EmberObject.create({
     firstName: 'Steve',
     lastName: 'Jobs',
@@ -24,11 +24,11 @@ QUnit.test('should be able to use getProperties with array parameter to get a PO
   });
 
   let pojo = obj.getProperties(['firstName', 'lastName']);
-  equal('Steve', pojo.firstName);
-  equal('Jobs', pojo.lastName);
+  assert.equal('Steve', pojo.firstName);
+  assert.equal('Jobs', pojo.lastName);
 });
 
-QUnit.test('should be able to use setProperties to set multiple properties at once', function() {
+QUnit.test('should be able to use setProperties to set multiple properties at once', function(assert) {
   let obj = EmberObject.create({
     firstName: 'Steve',
     lastName: 'Jobs',
@@ -36,11 +36,11 @@ QUnit.test('should be able to use setProperties to set multiple properties at on
   });
 
   obj.setProperties({ firstName: 'Tim', lastName: 'Cook' });
-  equal('Tim', obj.get('firstName'));
-  equal('Cook', obj.get('lastName'));
+  assert.equal('Tim', obj.get('firstName'));
+  assert.equal('Cook', obj.get('lastName'));
 });
 
-testBoth('calling setProperties completes safely despite exceptions', function() {
+testBoth('calling setProperties completes safely despite exceptions', function(get, set, assert) {
   let exc = new Error('Something unexpected happened!');
   let obj = EmberObject.extend({
     companyName: computed({
@@ -68,10 +68,10 @@ testBoth('calling setProperties completes safely despite exceptions', function()
     }
   }
 
-  equal(firstNameChangedCount, 1, 'firstName should have fired once');
+  assert.equal(firstNameChangedCount, 1, 'firstName should have fired once');
 });
 
-testBoth('should be able to retrieve cached values of computed properties without invoking the computed property', function(get) {
+testBoth('should be able to retrieve cached values of computed properties without invoking the computed property', function(get, set, assert) {
   let obj = EmberObject.extend({
     foo: computed(function() {
       return 'foo';
@@ -80,19 +80,19 @@ testBoth('should be able to retrieve cached values of computed properties withou
     bar: 'bar'
   });
 
-  equal(obj.cacheFor('foo'), undefined, 'should return undefined if no value has been cached');
+  assert.equal(obj.cacheFor('foo'), undefined, 'should return undefined if no value has been cached');
   get(obj, 'foo');
 
-  equal(get(obj, 'foo'), 'foo', 'precond - should cache the value');
-  equal(obj.cacheFor('foo'), 'foo', 'should return the cached value after it is invoked');
+  assert.equal(get(obj, 'foo'), 'foo', 'precond - should cache the value');
+  assert.equal(obj.cacheFor('foo'), 'foo', 'should return the cached value after it is invoked');
 
-  equal(obj.cacheFor('bar'), undefined, 'returns undefined if the value is not a computed property');
+  assert.equal(obj.cacheFor('bar'), undefined, 'returns undefined if the value is not a computed property');
 });
 
-QUnit.test('incrementProperty should work even if value is number in string', function() {
+QUnit.test('incrementProperty should work even if value is number in string', function(assert) {
   let obj = EmberObject.create({
     age: '24'
   });
   obj.incrementProperty('age');
-  equal(25, obj.get('age'));
+  assert.equal(25, obj.get('age'));
 });

--- a/packages/ember-runtime/tests/mixins/promise_proxy_test.js
+++ b/packages/ember-runtime/tests/mixins/promise_proxy_test.js
@@ -9,29 +9,29 @@ import * as RSVP from 'rsvp';
 
 let ObjectPromiseProxy;
 
-QUnit.test('present on ember namespace', function() {
-  ok(PromiseProxyMixin, 'expected PromiseProxyMixin to exist');
+QUnit.test('present on ember namespace', function(assert) {
+  assert.ok(PromiseProxyMixin, 'expected PromiseProxyMixin to exist');
 });
 
 QUnit.module('Ember.PromiseProxy - ObjectProxy', {
-  setup() {
+  beforeEach() {
     ObjectPromiseProxy = ObjectProxy.extend(PromiseProxyMixin);
   },
 
-  teardown() {
+  afterEach() {
     RSVP.on('error', onerrorDefault);
   }
 });
 
-QUnit.test('no promise, invoking then should raise', function() {
+QUnit.test('no promise, invoking then should raise', function(assert) {
   let proxy = ObjectPromiseProxy.create();
 
-  throws(function() {
+  assert.throws(function() {
     proxy.then(function() { return this; }, function() { return this; });
   }, new RegExp('PromiseProxy\'s promise must be set'));
 });
 
-QUnit.test('fulfillment', function() {
+QUnit.test('fulfillment', function(assert) {
   let value = {
     firstName: 'stef',
     lastName: 'penner'
@@ -49,49 +49,49 @@ QUnit.test('fulfillment', function() {
   proxy.then(() => didFulfillCount++,
              () => didRejectCount++);
 
-  equal(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
-  equal(get(proxy, 'reason'), undefined, 'expects the proxy to have no reason');
-  equal(get(proxy, 'isPending'), true, 'expects the proxy to indicate that it is loading');
-  equal(get(proxy, 'isSettled'), false, 'expects the proxy to indicate that it is not settled');
-  equal(get(proxy, 'isRejected'), false, 'expects the proxy to indicate that it is not rejected');
-  equal(get(proxy, 'isFulfilled'), false, 'expects the proxy to indicate that it is not fulfilled');
+  assert.equal(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
+  assert.equal(get(proxy, 'reason'), undefined, 'expects the proxy to have no reason');
+  assert.equal(get(proxy, 'isPending'), true, 'expects the proxy to indicate that it is loading');
+  assert.equal(get(proxy, 'isSettled'), false, 'expects the proxy to indicate that it is not settled');
+  assert.equal(get(proxy, 'isRejected'), false, 'expects the proxy to indicate that it is not rejected');
+  assert.equal(get(proxy, 'isFulfilled'), false, 'expects the proxy to indicate that it is not fulfilled');
 
-  equal(didFulfillCount, 0, 'should not yet have been fulfilled');
-  equal(didRejectCount, 0, 'should not yet have been rejected');
-
-  run(deferred, 'resolve', value);
-
-  equal(didFulfillCount, 1, 'should have been fulfilled');
-  equal(didRejectCount, 0, 'should not have been rejected');
-
-  equal(get(proxy, 'content'), value, 'expects the proxy to have content');
-  equal(get(proxy, 'reason'), undefined, 'expects the proxy to still have no reason');
-  equal(get(proxy, 'isPending'), false, 'expects the proxy to indicate that it is no longer loading');
-  equal(get(proxy, 'isSettled'), true, 'expects the proxy to indicate that it is settled');
-  equal(get(proxy, 'isRejected'), false, 'expects the proxy to indicate that it is not rejected');
-  equal(get(proxy, 'isFulfilled'), true, 'expects the proxy to indicate that it is fulfilled');
+  assert.equal(didFulfillCount, 0, 'should not yet have been fulfilled');
+  assert.equal(didRejectCount, 0, 'should not yet have been rejected');
 
   run(deferred, 'resolve', value);
 
-  equal(didFulfillCount, 1, 'should still have been only fulfilled once');
-  equal(didRejectCount, 0, 'should still not have been rejected');
+  assert.equal(didFulfillCount, 1, 'should have been fulfilled');
+  assert.equal(didRejectCount, 0, 'should not have been rejected');
+
+  assert.equal(get(proxy, 'content'), value, 'expects the proxy to have content');
+  assert.equal(get(proxy, 'reason'), undefined, 'expects the proxy to still have no reason');
+  assert.equal(get(proxy, 'isPending'), false, 'expects the proxy to indicate that it is no longer loading');
+  assert.equal(get(proxy, 'isSettled'), true, 'expects the proxy to indicate that it is settled');
+  assert.equal(get(proxy, 'isRejected'), false, 'expects the proxy to indicate that it is not rejected');
+  assert.equal(get(proxy, 'isFulfilled'), true, 'expects the proxy to indicate that it is fulfilled');
+
+  run(deferred, 'resolve', value);
+
+  assert.equal(didFulfillCount, 1, 'should still have been only fulfilled once');
+  assert.equal(didRejectCount, 0, 'should still not have been rejected');
 
   run(deferred, 'reject', value);
 
-  equal(didFulfillCount, 1, 'should still have been only fulfilled once');
-  equal(didRejectCount, 0, 'should still not have been rejected');
+  assert.equal(didFulfillCount, 1, 'should still have been only fulfilled once');
+  assert.equal(didRejectCount, 0, 'should still not have been rejected');
 
-  equal(get(proxy, 'content'), value, 'expects the proxy to have still have same content');
-  equal(get(proxy, 'reason'), undefined, 'expects the proxy still to have no reason');
-  equal(get(proxy, 'isPending'), false, 'expects the proxy to indicate that it is no longer loading');
-  equal(get(proxy, 'isSettled'), true, 'expects the proxy to indicate that it is settled');
-  equal(get(proxy, 'isRejected'), false, 'expects the proxy to indicate that it is not rejected');
-  equal(get(proxy, 'isFulfilled'), true, 'expects the proxy to indicate that it is fulfilled');
+  assert.equal(get(proxy, 'content'), value, 'expects the proxy to have still have same content');
+  assert.equal(get(proxy, 'reason'), undefined, 'expects the proxy still to have no reason');
+  assert.equal(get(proxy, 'isPending'), false, 'expects the proxy to indicate that it is no longer loading');
+  assert.equal(get(proxy, 'isSettled'), true, 'expects the proxy to indicate that it is settled');
+  assert.equal(get(proxy, 'isRejected'), false, 'expects the proxy to indicate that it is not rejected');
+  assert.equal(get(proxy, 'isFulfilled'), true, 'expects the proxy to indicate that it is fulfilled');
 
   // rest of the promise semantics are tested in directly in RSVP
 });
 
-QUnit.test('rejection', function() {
+QUnit.test('rejection', function(assert) {
   let reason = new Error('failure');
   let deferred = RSVP.defer();
   let proxy = ObjectPromiseProxy.create({
@@ -104,48 +104,48 @@ QUnit.test('rejection', function() {
   proxy.then(() => didFulfillCount++,
              () => didRejectCount++);
 
-  equal(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
-  equal(get(proxy, 'reason'), undefined, 'expects the proxy to have no reason');
-  equal(get(proxy, 'isPending'), true, 'expects the proxy to indicate that it is loading');
-  equal(get(proxy, 'isSettled'), false, 'expects the proxy to indicate that it is not settled');
-  equal(get(proxy, 'isRejected'), false, 'expects the proxy to indicate that it is not rejected');
-  equal(get(proxy, 'isFulfilled'), false, 'expects the proxy to indicate that it is not fulfilled');
+  assert.equal(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
+  assert.equal(get(proxy, 'reason'), undefined, 'expects the proxy to have no reason');
+  assert.equal(get(proxy, 'isPending'), true, 'expects the proxy to indicate that it is loading');
+  assert.equal(get(proxy, 'isSettled'), false, 'expects the proxy to indicate that it is not settled');
+  assert.equal(get(proxy, 'isRejected'), false, 'expects the proxy to indicate that it is not rejected');
+  assert.equal(get(proxy, 'isFulfilled'), false, 'expects the proxy to indicate that it is not fulfilled');
 
-  equal(didFulfillCount, 0, 'should not yet have been fulfilled');
-  equal(didRejectCount, 0, 'should not yet have been rejected');
-
-  run(deferred, 'reject', reason);
-
-  equal(didFulfillCount, 0, 'should not yet have been fulfilled');
-  equal(didRejectCount, 1, 'should have been rejected');
-
-  equal(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
-  equal(get(proxy, 'reason'), reason, 'expects the proxy to have a reason');
-  equal(get(proxy, 'isPending'), false, 'expects the proxy to indicate that it is not longer loading');
-  equal(get(proxy, 'isSettled'), true, 'expects the proxy to indicate that it is settled');
-  equal(get(proxy, 'isRejected'), true, 'expects the proxy to indicate that it is  rejected');
-  equal(get(proxy, 'isFulfilled'), false, 'expects the proxy to indicate that it is not fulfilled');
+  assert.equal(didFulfillCount, 0, 'should not yet have been fulfilled');
+  assert.equal(didRejectCount, 0, 'should not yet have been rejected');
 
   run(deferred, 'reject', reason);
 
-  equal(didFulfillCount, 0, 'should stll not yet have been fulfilled');
-  equal(didRejectCount, 1, 'should still remain rejected');
+  assert.equal(didFulfillCount, 0, 'should not yet have been fulfilled');
+  assert.equal(didRejectCount, 1, 'should have been rejected');
+
+  assert.equal(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
+  assert.equal(get(proxy, 'reason'), reason, 'expects the proxy to have a reason');
+  assert.equal(get(proxy, 'isPending'), false, 'expects the proxy to indicate that it is not longer loading');
+  assert.equal(get(proxy, 'isSettled'), true, 'expects the proxy to indicate that it is settled');
+  assert.equal(get(proxy, 'isRejected'), true, 'expects the proxy to indicate that it is  rejected');
+  assert.equal(get(proxy, 'isFulfilled'), false, 'expects the proxy to indicate that it is not fulfilled');
+
+  run(deferred, 'reject', reason);
+
+  assert.equal(didFulfillCount, 0, 'should stll not yet have been fulfilled');
+  assert.equal(didRejectCount, 1, 'should still remain rejected');
 
   run(deferred, 'resolve', 1);
 
-  equal(didFulfillCount, 0, 'should stll not yet have been fulfilled');
-  equal(didRejectCount, 1, 'should still remain rejected');
+  assert.equal(didFulfillCount, 0, 'should stll not yet have been fulfilled');
+  assert.equal(didRejectCount, 1, 'should still remain rejected');
 
-  equal(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
-  equal(get(proxy, 'reason'), reason, 'expects the proxy to have a reason');
-  equal(get(proxy, 'isPending'), false, 'expects the proxy to indicate that it is not longer loading');
-  equal(get(proxy, 'isSettled'), true, 'expects the proxy to indicate that it is settled');
-  equal(get(proxy, 'isRejected'), true, 'expects the proxy to indicate that it is  rejected');
-  equal(get(proxy, 'isFulfilled'), false, 'expects the proxy to indicate that it is not fulfilled');
+  assert.equal(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
+  assert.equal(get(proxy, 'reason'), reason, 'expects the proxy to have a reason');
+  assert.equal(get(proxy, 'isPending'), false, 'expects the proxy to indicate that it is not longer loading');
+  assert.equal(get(proxy, 'isSettled'), true, 'expects the proxy to indicate that it is settled');
+  assert.equal(get(proxy, 'isRejected'), true, 'expects the proxy to indicate that it is  rejected');
+  assert.equal(get(proxy, 'isFulfilled'), false, 'expects the proxy to indicate that it is not fulfilled');
 });
 
 // https://github.com/emberjs/ember.js/issues/15694
-QUnit.test('rejection without specifying reason', function() {
+QUnit.test('rejection without specifying reason', function(assert) {
   let deferred = RSVP.defer();
   let proxy = ObjectPromiseProxy.create({
     promise: deferred.promise
@@ -157,31 +157,31 @@ QUnit.test('rejection without specifying reason', function() {
   proxy.then(() => didFulfillCount++,
              () => didRejectCount++);
 
-  equal(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
-  equal(get(proxy, 'reason'), undefined, 'expects the proxy to have no reason');
-  equal(get(proxy, 'isPending'), true, 'expects the proxy to indicate that it is loading');
-  equal(get(proxy, 'isSettled'), false, 'expects the proxy to indicate that it is not settled');
-  equal(get(proxy, 'isRejected'), false, 'expects the proxy to indicate that it is not rejected');
-  equal(get(proxy, 'isFulfilled'), false, 'expects the proxy to indicate that it is not fulfilled');
+  assert.equal(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
+  assert.equal(get(proxy, 'reason'), undefined, 'expects the proxy to have no reason');
+  assert.equal(get(proxy, 'isPending'), true, 'expects the proxy to indicate that it is loading');
+  assert.equal(get(proxy, 'isSettled'), false, 'expects the proxy to indicate that it is not settled');
+  assert.equal(get(proxy, 'isRejected'), false, 'expects the proxy to indicate that it is not rejected');
+  assert.equal(get(proxy, 'isFulfilled'), false, 'expects the proxy to indicate that it is not fulfilled');
 
-  equal(didFulfillCount, 0, 'should not yet have been fulfilled');
-  equal(didRejectCount, 0, 'should not yet have been rejected');
+  assert.equal(didFulfillCount, 0, 'should not yet have been fulfilled');
+  assert.equal(didRejectCount, 0, 'should not yet have been rejected');
 
   run(deferred, 'reject');
 
-  equal(didFulfillCount, 0, 'should not yet have been fulfilled');
-  equal(didRejectCount, 1, 'should have been rejected');
+  assert.equal(didFulfillCount, 0, 'should not yet have been fulfilled');
+  assert.equal(didRejectCount, 1, 'should have been rejected');
 
-  equal(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
-  equal(get(proxy, 'reason'), undefined, 'expects the proxy to have a reason');
-  equal(get(proxy, 'isPending'), false, 'expects the proxy to indicate that it is not longer loading');
-  equal(get(proxy, 'isSettled'), true, 'expects the proxy to indicate that it is settled');
-  equal(get(proxy, 'isRejected'), true, 'expects the proxy to indicate that it is  rejected');
-  equal(get(proxy, 'isFulfilled'), false, 'expects the proxy to indicate that it is not fulfilled');
+  assert.equal(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
+  assert.equal(get(proxy, 'reason'), undefined, 'expects the proxy to have a reason');
+  assert.equal(get(proxy, 'isPending'), false, 'expects the proxy to indicate that it is not longer loading');
+  assert.equal(get(proxy, 'isSettled'), true, 'expects the proxy to indicate that it is settled');
+  assert.equal(get(proxy, 'isRejected'), true, 'expects the proxy to indicate that it is  rejected');
+  assert.equal(get(proxy, 'isFulfilled'), false, 'expects the proxy to indicate that it is not fulfilled');
 });
 
-QUnit.test('unhandled rejects still propagate to RSVP.on(\'error\', ...) ', function() {
-  expect(1);
+QUnit.test('unhandled rejects still propagate to RSVP.on(\'error\', ...) ', function(assert) {
+  assert.expect(1);
 
   RSVP.on('error', onerror);
   RSVP.off('error', onerrorDefault);
@@ -196,7 +196,7 @@ QUnit.test('unhandled rejects still propagate to RSVP.on(\'error\', ...) ', func
   proxy.get('promise');
 
   function onerror(reason) {
-    equal(reason, expectedReason, 'expected reason');
+    assert.equal(reason, expectedReason, 'expected reason');
   }
 
   RSVP.on('error', onerror);
@@ -213,7 +213,7 @@ QUnit.test('unhandled rejects still propagate to RSVP.on(\'error\', ...) ', func
   RSVP.off('error', onerror);
 });
 
-QUnit.test('should work with promise inheritance', function() {
+QUnit.test('should work with promise inheritance', function(assert) {
   function PromiseSubclass() {
     RSVP.Promise.apply(this, arguments);
   }
@@ -225,42 +225,42 @@ QUnit.test('should work with promise inheritance', function() {
     promise: new PromiseSubclass(() => { })
   });
 
-  ok(proxy.then() instanceof PromiseSubclass, 'promise proxy respected inheritance');
+  assert.ok(proxy.then() instanceof PromiseSubclass, 'promise proxy respected inheritance');
 });
 
-QUnit.test('should reset isFulfilled and isRejected when promise is reset', function() {
+QUnit.test('should reset isFulfilled and isRejected when promise is reset', function(assert) {
   let deferred = EmberRSVP.defer();
 
   let proxy = ObjectPromiseProxy.create({
     promise: deferred.promise
   });
 
-  equal(get(proxy, 'isPending'), true, 'expects the proxy to indicate that it is loading');
-  equal(get(proxy, 'isSettled'), false, 'expects the proxy to indicate that it is not settled');
-  equal(get(proxy, 'isRejected'), false, 'expects the proxy to indicate that it is not rejected');
-  equal(get(proxy, 'isFulfilled'), false, 'expects the proxy to indicate that it is not fulfilled');
+  assert.equal(get(proxy, 'isPending'), true, 'expects the proxy to indicate that it is loading');
+  assert.equal(get(proxy, 'isSettled'), false, 'expects the proxy to indicate that it is not settled');
+  assert.equal(get(proxy, 'isRejected'), false, 'expects the proxy to indicate that it is not rejected');
+  assert.equal(get(proxy, 'isFulfilled'), false, 'expects the proxy to indicate that it is not fulfilled');
 
   run(deferred, 'resolve');
 
-  equal(get(proxy, 'isPending'), false, 'expects the proxy to indicate that it is no longer loading');
-  equal(get(proxy, 'isSettled'), true, 'expects the proxy to indicate that it is settled');
-  equal(get(proxy, 'isRejected'), false, 'expects the proxy to indicate that it is not rejected');
-  equal(get(proxy, 'isFulfilled'), true, 'expects the proxy to indicate that it is fulfilled');
+  assert.equal(get(proxy, 'isPending'), false, 'expects the proxy to indicate that it is no longer loading');
+  assert.equal(get(proxy, 'isSettled'), true, 'expects the proxy to indicate that it is settled');
+  assert.equal(get(proxy, 'isRejected'), false, 'expects the proxy to indicate that it is not rejected');
+  assert.equal(get(proxy, 'isFulfilled'), true, 'expects the proxy to indicate that it is fulfilled');
 
   let anotherDeferred = EmberRSVP.defer();
   proxy.set('promise', anotherDeferred.promise);
 
-  equal(get(proxy, 'isPending'), true, 'expects the proxy to indicate that it is loading');
-  equal(get(proxy, 'isSettled'), false, 'expects the proxy to indicate that it is not settled');
-  equal(get(proxy, 'isRejected'), false, 'expects the proxy to indicate that it is not rejected');
-  equal(get(proxy, 'isFulfilled'), false, 'expects the proxy to indicate that it is not fulfilled');
+  assert.equal(get(proxy, 'isPending'), true, 'expects the proxy to indicate that it is loading');
+  assert.equal(get(proxy, 'isSettled'), false, 'expects the proxy to indicate that it is not settled');
+  assert.equal(get(proxy, 'isRejected'), false, 'expects the proxy to indicate that it is not rejected');
+  assert.equal(get(proxy, 'isFulfilled'), false, 'expects the proxy to indicate that it is not fulfilled');
 
   run(anotherDeferred, 'reject');
 
-  equal(get(proxy, 'isPending'), false, 'expects the proxy to indicate that it is not longer loading');
-  equal(get(proxy, 'isSettled'), true, 'expects the proxy to indicate that it is settled');
-  equal(get(proxy, 'isRejected'), true, 'expects the proxy to indicate that it is  rejected');
-  equal(get(proxy, 'isFulfilled'), false, 'expects the proxy to indicate that it is not fulfilled');
+  assert.equal(get(proxy, 'isPending'), false, 'expects the proxy to indicate that it is not longer loading');
+  assert.equal(get(proxy, 'isSettled'), true, 'expects the proxy to indicate that it is settled');
+  assert.equal(get(proxy, 'isRejected'), true, 'expects the proxy to indicate that it is  rejected');
+  assert.equal(get(proxy, 'isFulfilled'), false, 'expects the proxy to indicate that it is not fulfilled');
 });
 
 QUnit.test('should have content when isFulfilled is set', function() {
@@ -275,7 +275,7 @@ QUnit.test('should have content when isFulfilled is set', function() {
   run(deferred, 'resolve', true);
 });
 
-QUnit.test('should have reason when isRejected is set', function() {
+QUnit.test('should have reason when isRejected is set', function(assert) {
   let error = new Error('Y U REJECT?!?');
   let deferred = EmberRSVP.defer();
 
@@ -288,11 +288,11 @@ QUnit.test('should have reason when isRejected is set', function() {
   try {
     run(deferred, 'reject', error);
   } catch (e) {
-    equal(e, error);
+    assert.equal(e, error);
   }
 });
 
-QUnit.test('should not error if promise is resolved after proxy has been destroyed', function() {
+QUnit.test('should not error if promise is resolved after proxy has been destroyed', function(assert) {
   let deferred = EmberRSVP.defer();
 
   let proxy = ObjectPromiseProxy.create({
@@ -305,10 +305,10 @@ QUnit.test('should not error if promise is resolved after proxy has been destroy
 
   run(deferred, 'resolve', true);
 
-  ok(true, 'resolving the promise after the proxy has been destroyed does not raise an error');
+  assert.ok(true, 'resolving the promise after the proxy has been destroyed does not raise an error');
 });
 
-QUnit.test('should not error if promise is rejected after proxy has been destroyed', function() {
+QUnit.test('should not error if promise is rejected after proxy has been destroyed', function(assert) {
   let deferred = EmberRSVP.defer();
 
   let proxy = ObjectPromiseProxy.create({
@@ -321,10 +321,10 @@ QUnit.test('should not error if promise is rejected after proxy has been destroy
 
   run(deferred, 'reject', 'some reason');
 
-  ok(true, 'rejecting the promise after the proxy has been destroyed does not raise an error');
+  assert.ok(true, 'rejecting the promise after the proxy has been destroyed does not raise an error');
 });
 
-QUnit.test('promise chain is not broken if promised is resolved after proxy has been destroyed', function() {
+QUnit.test('promise chain is not broken if promised is resolved after proxy has been destroyed', function(assert) {
   let deferred = EmberRSVP.defer();
   let expectedValue = {};
   let receivedValue;
@@ -343,11 +343,11 @@ QUnit.test('promise chain is not broken if promised is resolved after proxy has 
 
   run(deferred, 'resolve', expectedValue);
 
-  equal(didResolveCount, 1, 'callback called');
-  equal(receivedValue, expectedValue, 'passed value is the value the promise was resolved with');
+  assert.equal(didResolveCount, 1, 'callback called');
+  assert.equal(receivedValue, expectedValue, 'passed value is the value the promise was resolved with');
 });
 
-QUnit.test('promise chain is not broken if promised is rejected after proxy has been destroyed', function() {
+QUnit.test('promise chain is not broken if promised is rejected after proxy has been destroyed', function(assert) {
   let deferred = EmberRSVP.defer();
   let expectedReason = 'some reason';
   let receivedReason;
@@ -368,6 +368,6 @@ QUnit.test('promise chain is not broken if promised is rejected after proxy has 
 
   run(deferred, 'reject', expectedReason);
 
-  equal(didRejectCount, 1, 'callback called');
-  equal(receivedReason, expectedReason, 'passed reason is the reason the promise was rejected for');
+  assert.equal(didRejectCount, 1, 'callback called');
+  assert.equal(receivedReason, expectedReason, 'passed reason is the reason the promise was rejected for');
 });

--- a/packages/ember-runtime/tests/mixins/target_action_support_test.js
+++ b/packages/ember-runtime/tests/mixins/target_action_support_test.js
@@ -6,64 +6,64 @@ let originalLookup = context.lookup;
 let lookup;
 
 QUnit.module('TargetActionSupport', {
-  setup() {
+  beforeEach() {
     context.lookup = lookup = {};
   },
-  teardown() {
+  afterEach() {
     context.lookup = originalLookup;
   }
 });
 
-QUnit.test('it should return false if no target or action are specified', function() {
-  expect(1);
+QUnit.test('it should return false if no target or action are specified', function(assert) {
+  assert.expect(1);
 
   let obj = EmberObject.extend(TargetActionSupport).create();
 
-  ok(false === obj.triggerAction(), 'no target or action was specified');
+  assert.ok(false === obj.triggerAction(), 'no target or action was specified');
 });
 
-QUnit.test('it should support actions specified as strings', function() {
-  expect(2);
+QUnit.test('it should support actions specified as strings', function(assert) {
+  assert.expect(2);
 
   let obj = EmberObject.extend(TargetActionSupport).create({
     target: EmberObject.create({
       anEvent() {
-        ok(true, 'anEvent method was called');
+        assert.ok(true, 'anEvent method was called');
       }
     }),
 
     action: 'anEvent'
   });
 
-  ok(true === obj.triggerAction(), 'a valid target and action were specified');
+  assert.ok(true === obj.triggerAction(), 'a valid target and action were specified');
 });
 
-QUnit.test('it should invoke the send() method on objects that implement it', function() {
-  expect(3);
+QUnit.test('it should invoke the send() method on objects that implement it', function(assert) {
+  assert.expect(3);
 
   let obj = EmberObject.extend(TargetActionSupport).create({
     target: EmberObject.create({
       send(evt, context) {
-        equal(evt, 'anEvent', 'send() method was invoked with correct event name');
-        equal(context, obj, 'send() method was invoked with correct context');
+        assert.equal(evt, 'anEvent', 'send() method was invoked with correct event name');
+        assert.equal(context, obj, 'send() method was invoked with correct context');
       }
     }),
 
     action: 'anEvent'
   });
 
-  ok(true === obj.triggerAction(), 'a valid target and action were specified');
+  assert.ok(true === obj.triggerAction(), 'a valid target and action were specified');
 });
 
-QUnit.test('it should find targets specified using a property path', function() {
-  expect(2);
+QUnit.test('it should find targets specified using a property path', function(assert) {
+  assert.expect(2);
 
   let Test = {};
   lookup.Test = Test;
 
   Test.targetObj = EmberObject.create({
     anEvent() {
-      ok(true, 'anEvent method was called on global object');
+      assert.ok(true, 'anEvent method was called on global object');
     }
   });
 
@@ -72,26 +72,26 @@ QUnit.test('it should find targets specified using a property path', function() 
     action: 'anEvent'
   });
 
-  ok(true === myObj.triggerAction(), 'a valid target and action were specified');
+  assert.ok(true === myObj.triggerAction(), 'a valid target and action were specified');
 });
 
-QUnit.test('it should use an actionContext object specified as a property on the object', function() {
-  expect(2);
+QUnit.test('it should use an actionContext object specified as a property on the object', function(assert) {
+  assert.expect(2);
   let obj = EmberObject.extend(TargetActionSupport).create({
     action: 'anEvent',
     actionContext: {},
     target: EmberObject.create({
       anEvent(ctx) {
-        ok(obj.actionContext === ctx, 'anEvent method was called with the expected context');
+        assert.ok(obj.actionContext === ctx, 'anEvent method was called with the expected context');
       }
     })
   });
-  ok(true === obj.triggerAction(), 'a valid target and action were specified');
+  assert.ok(true === obj.triggerAction(), 'a valid target and action were specified');
 });
 
 
-QUnit.test('it should raise a deprecation warning when targetObject is specified and used', function() {
-  expect(4);
+QUnit.test('it should raise a deprecation warning when targetObject is specified and used', function(assert) {
+  assert.expect(4);
   let obj;
   expectDeprecation(() => {
     obj = EmberObject.extend(TargetActionSupport).create({
@@ -99,18 +99,18 @@ QUnit.test('it should raise a deprecation warning when targetObject is specified
       actionContext: {},
       targetObject: EmberObject.create({
         anEvent(ctx) {
-          ok(obj.actionContext === ctx, 'anEvent method was called with the expected context');
+          assert.ok(obj.actionContext === ctx, 'anEvent method was called with the expected context');
         }
       })
     });
   }, /Usage of `targetObject` is deprecated. Please use `target` instead./);
-  ok(true === obj.triggerAction(), 'a valid targetObject and action were specified');
+  assert.ok(true === obj.triggerAction(), 'a valid targetObject and action were specified');
   expectDeprecation(() => obj.get('targetObject'),
     /Usage of `targetObject` is deprecated. Please use `target` instead./);
 });
 
-QUnit.test('it should find an actionContext specified as a property path', function() {
-  expect(2);
+QUnit.test('it should find an actionContext specified as a property path', function(assert) {
+  assert.expect(2);
 
   let Test = {};
   lookup.Test = Test;
@@ -121,82 +121,82 @@ QUnit.test('it should find an actionContext specified as a property path', funct
     actionContext: 'Test.aContext',
     target: EmberObject.create({
       anEvent(ctx) {
-        ok(Test.aContext === ctx, 'anEvent method was called with the expected context');
+        assert.ok(Test.aContext === ctx, 'anEvent method was called with the expected context');
       }
     })
   });
 
-  ok(true === obj.triggerAction(), 'a valid target and action were specified');
+  assert.ok(true === obj.triggerAction(), 'a valid target and action were specified');
 });
 
-QUnit.test('it should use the target specified in the argument', function() {
-  expect(2);
+QUnit.test('it should use the target specified in the argument', function(assert) {
+  assert.expect(2);
   let targetObj = EmberObject.create({
     anEvent() {
-      ok(true, 'anEvent method was called');
+      assert.ok(true, 'anEvent method was called');
     }
   });
   let obj = EmberObject.extend(TargetActionSupport).create({
     action: 'anEvent'
   });
 
-  ok(true === obj.triggerAction({ target: targetObj }), 'a valid target and action were specified');
+  assert.ok(true === obj.triggerAction({ target: targetObj }), 'a valid target and action were specified');
 });
 
-QUnit.test('it should use the action specified in the argument', function() {
-  expect(2);
+QUnit.test('it should use the action specified in the argument', function(assert) {
+  assert.expect(2);
 
   let obj = EmberObject.extend(TargetActionSupport).create({
     target: EmberObject.create({
       anEvent() {
-        ok(true, 'anEvent method was called');
+        assert.ok(true, 'anEvent method was called');
       }
     })
   });
-  ok(true === obj.triggerAction({ action: 'anEvent' }), 'a valid target and action were specified');
+  assert.ok(true === obj.triggerAction({ action: 'anEvent' }), 'a valid target and action were specified');
 });
 
-QUnit.test('it should use the actionContext specified in the argument', function() {
-  expect(2);
+QUnit.test('it should use the actionContext specified in the argument', function(assert) {
+  assert.expect(2);
   let context = {};
   let obj = EmberObject.extend(TargetActionSupport).create({
     target: EmberObject.create({
       anEvent(ctx) {
-        ok(context === ctx, 'anEvent method was called with the expected context');
+        assert.ok(context === ctx, 'anEvent method was called with the expected context');
       }
     }),
     action: 'anEvent'
   });
 
-  ok(true === obj.triggerAction({ actionContext: context }), 'a valid target and action were specified');
+  assert.ok(true === obj.triggerAction({ actionContext: context }), 'a valid target and action were specified');
 });
 
-QUnit.test('it should allow multiple arguments from actionContext', function() {
-  expect(3);
+QUnit.test('it should allow multiple arguments from actionContext', function(assert) {
+  assert.expect(3);
   let param1 = 'someParam';
   let param2 = 'someOtherParam';
   let obj = EmberObject.extend(TargetActionSupport).create({
     target: EmberObject.create({
       anEvent(first, second) {
-        ok(first === param1, 'anEvent method was called with the expected first argument');
-        ok(second === param2, 'anEvent method was called with the expected second argument');
+        assert.ok(first === param1, 'anEvent method was called with the expected first argument');
+        assert.ok(second === param2, 'anEvent method was called with the expected second argument');
       }
     }),
     action: 'anEvent'
   });
 
-  ok(true === obj.triggerAction({ actionContext: [param1, param2] }), 'a valid target and action were specified');
+  assert.ok(true === obj.triggerAction({ actionContext: [param1, param2] }), 'a valid target and action were specified');
 });
 
-QUnit.test('it should use a null value specified in the actionContext argument', function() {
-  expect(2);
+QUnit.test('it should use a null value specified in the actionContext argument', function(assert) {
+  assert.expect(2);
   let obj = EmberObject.extend(TargetActionSupport).create({
     target: EmberObject.create({
       anEvent(ctx) {
-        ok(null === ctx, 'anEvent method was called with the expected context (null)');
+        assert.ok(null === ctx, 'anEvent method was called with the expected context (null)');
       }
     }),
     action: 'anEvent'
   });
-  ok(true === obj.triggerAction({ actionContext: null }), 'a valid target and action were specified');
+  assert.ok(true === obj.triggerAction({ actionContext: null }), 'a valid target and action were specified');
 });

--- a/packages/ember-runtime/tests/system/application/base_test.js
+++ b/packages/ember-runtime/tests/system/application/base_test.js
@@ -3,6 +3,6 @@ import Application from '../../../system/application';
 
 QUnit.module('Ember.Application');
 
-QUnit.test('Ember.Application should be a subclass of Ember.Namespace', function() {
-  ok(Namespace.detect(Application), 'Ember.Application subclass of Ember.Namespace');
+QUnit.test('Ember.Application should be a subclass of Ember.Namespace', function(assert) {
+  assert.ok(Namespace.detect(Application), 'Ember.Application subclass of Ember.Namespace');
 });

--- a/packages/ember-runtime/tests/system/array_proxy/arranged_content_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/arranged_content_test.js
@@ -6,7 +6,7 @@ import { objectAt } from '../../../mixins/array';
 let array;
 
 QUnit.module('ArrayProxy - arrangedContent', {
-  setup() {
+  beforeEach() {
     run(() => {
       array = ArrayProxy.extend({
         arrangedContent: computed('content.[]', function() {
@@ -22,186 +22,186 @@ QUnit.module('ArrayProxy - arrangedContent', {
       });
     });
   },
-  teardown() {
+  afterEach() {
     run(() => array.destroy());
   }
 });
 
-QUnit.test('addObject - adds to end of \'content\' if not present', function() {
+QUnit.test('addObject - adds to end of \'content\' if not present', function(assert) {
   run(() => array.addObject(3));
 
-  deepEqual(array.get('content'), [1, 2, 4, 5, 3], 'adds to end of content');
-  deepEqual(array.get('arrangedContent'), [5, 4, 3, 2, 1], 'arrangedContent stays sorted');
+  assert.deepEqual(array.get('content'), [1, 2, 4, 5, 3], 'adds to end of content');
+  assert.deepEqual(array.get('arrangedContent'), [5, 4, 3, 2, 1], 'arrangedContent stays sorted');
 
   run(() => array.addObject(1));
 
-  deepEqual(array.get('content'), [1, 2, 4, 5, 3], 'does not add existing number to content');
+  assert.deepEqual(array.get('content'), [1, 2, 4, 5, 3], 'does not add existing number to content');
 });
 
-QUnit.test('addObjects - adds to end of \'content\' if not present', function() {
+QUnit.test('addObjects - adds to end of \'content\' if not present', function(assert) {
   run(() => array.addObjects([1, 3, 6]));
 
-  deepEqual(array.get('content'), [1, 2, 4, 5, 3, 6], 'adds to end of content');
-  deepEqual(array.get('arrangedContent'), [6, 5, 4, 3, 2, 1], 'arrangedContent stays sorted');
+  assert.deepEqual(array.get('content'), [1, 2, 4, 5, 3, 6], 'adds to end of content');
+  assert.deepEqual(array.get('arrangedContent'), [6, 5, 4, 3, 2, 1], 'arrangedContent stays sorted');
 });
 
-QUnit.test('compact - returns arrangedContent without nulls and undefined', function() {
+QUnit.test('compact - returns arrangedContent without nulls and undefined', function(assert) {
   run(() => array.set('content', emberA([1, 3, null, 2, undefined])));
 
-  deepEqual(array.compact(), [3, 2, 1]);
+  assert.deepEqual(array.compact(), [3, 2, 1]);
 });
 
-QUnit.test('indexOf - returns index of object in arrangedContent', function() {
-  equal(array.indexOf(4), 1, 'returns arranged index');
+QUnit.test('indexOf - returns index of object in arrangedContent', function(assert) {
+  assert.equal(array.indexOf(4), 1, 'returns arranged index');
 });
 
-QUnit.test('insertAt - raises, indeterminate behavior', function() {
-  throws(() => run(() =>  array.insertAt(2, 3)));
+QUnit.test('insertAt - raises, indeterminate behavior', function(assert) {
+  assert.throws(() => run(() =>  array.insertAt(2, 3)));
 });
 
-QUnit.test('lastIndexOf - returns last index of object in arrangedContent', function() {
+QUnit.test('lastIndexOf - returns last index of object in arrangedContent', function(assert) {
   run(() => array.pushObject(4));
 
-  equal(array.lastIndexOf(4), 2, 'returns last arranged index');
+  assert.equal(array.lastIndexOf(4), 2, 'returns last arranged index');
 });
 
-QUnit.test('nextObject - returns object at index in arrangedContent', function() {
-  equal(array.nextObject(1), 4, 'returns object at index');
+QUnit.test('nextObject - returns object at index in arrangedContent', function(assert) {
+  assert.equal(array.nextObject(1), 4, 'returns object at index');
 });
 
-QUnit.test('objectAt - returns object at index in arrangedContent', function() {
-  equal(objectAt(array, 1), 4, 'returns object at index');
+QUnit.test('objectAt - returns object at index in arrangedContent', function(assert) {
+  assert.equal(objectAt(array, 1), 4, 'returns object at index');
 });
 
 // Not sure if we need a specific test for it, since it's internal
-QUnit.test('objectAtContent - returns object at index in arrangedContent', function() {
-  equal(array.objectAtContent(1), 4, 'returns object at index');
+QUnit.test('objectAtContent - returns object at index in arrangedContent', function(assert) {
+  assert.equal(array.objectAtContent(1), 4, 'returns object at index');
 });
 
-QUnit.test('objectsAt - returns objects at indices in arrangedContent', function() {
-  deepEqual(array.objectsAt([0, 2, 4]), [5, 2, undefined], 'returns objects at indices');
+QUnit.test('objectsAt - returns objects at indices in arrangedContent', function(assert) {
+  assert.deepEqual(array.objectsAt([0, 2, 4]), [5, 2, undefined], 'returns objects at indices');
 });
 
-QUnit.test('popObject - removes last object in arrangedContent', function() {
+QUnit.test('popObject - removes last object in arrangedContent', function(assert) {
   let popped;
   run(() => popped = array.popObject());
-  equal(popped, 1, 'returns last object');
-  deepEqual(array.get('content'), [2, 4, 5], 'removes from content');
+  assert.equal(popped, 1, 'returns last object');
+  assert.deepEqual(array.get('content'), [2, 4, 5], 'removes from content');
 });
 
-QUnit.test('pushObject - adds to end of content even if it already exists', function() {
+QUnit.test('pushObject - adds to end of content even if it already exists', function(assert) {
   run(() => array.pushObject(1));
-  deepEqual(array.get('content'), [1, 2, 4, 5, 1], 'adds to end of content');
+  assert.deepEqual(array.get('content'), [1, 2, 4, 5, 1], 'adds to end of content');
 });
 
-QUnit.test('pushObjects - adds multiple to end of content even if it already exists', function() {
+QUnit.test('pushObjects - adds multiple to end of content even if it already exists', function(assert) {
   run(() => array.pushObjects([1, 2, 4]));
-  deepEqual(array.get('content'), [1, 2, 4, 5, 1, 2, 4], 'adds to end of content');
+  assert.deepEqual(array.get('content'), [1, 2, 4, 5, 1, 2, 4], 'adds to end of content');
 });
 
-QUnit.test('removeAt - removes from index in arrangedContent', function() {
+QUnit.test('removeAt - removes from index in arrangedContent', function(assert) {
   run(() => array.removeAt(1, 2));
-  deepEqual(array.get('content'), [1, 5]);
+  assert.deepEqual(array.get('content'), [1, 5]);
 });
 
-QUnit.test('removeObject - removes object from content', function() {
+QUnit.test('removeObject - removes object from content', function(assert) {
   run(() => array.removeObject(2));
-  deepEqual(array.get('content'), [1, 4, 5]);
+  assert.deepEqual(array.get('content'), [1, 4, 5]);
 });
 
-QUnit.test('removeObjects - removes objects from content', function() {
+QUnit.test('removeObjects - removes objects from content', function(assert) {
   run(() => array.removeObjects([2, 4, 6]));
-  deepEqual(array.get('content'), [1, 5]);
+  assert.deepEqual(array.get('content'), [1, 5]);
 });
 
-QUnit.test('replace - raises, indeterminate behavior', function() {
-  throws(() => run(() => array.replace(1, 2, [3])));
+QUnit.test('replace - raises, indeterminate behavior', function(assert) {
+  assert.throws(() => run(() => array.replace(1, 2, [3])));
 });
 
-QUnit.test('replaceContent - does a standard array replace on content', function() {
+QUnit.test('replaceContent - does a standard array replace on content', function(assert) {
   run(() => array.replaceContent(1, 2, [3]));
-  deepEqual(array.get('content'), [1, 3, 5]);
+  assert.deepEqual(array.get('content'), [1, 3, 5]);
 });
 
-QUnit.test('reverseObjects - raises, use Sortable#sortAscending', function() {
-  throws(() => run(() => array.reverseObjects()));
+QUnit.test('reverseObjects - raises, use Sortable#sortAscending', function(assert) {
+  assert.throws(() => run(() => array.reverseObjects()));
 });
 
-QUnit.test('setObjects - replaces entire content', function() {
+QUnit.test('setObjects - replaces entire content', function(assert) {
   run(() => array.setObjects([6, 7, 8]));
-  deepEqual(array.get('content'), [6, 7, 8], 'replaces content');
+  assert.deepEqual(array.get('content'), [6, 7, 8], 'replaces content');
 });
 
-QUnit.test('shiftObject - removes from start of arrangedContent', function() {
+QUnit.test('shiftObject - removes from start of arrangedContent', function(assert) {
   let shifted = run(() => array.shiftObject());
 
-  equal(shifted, 5, 'returns first object');
-  deepEqual(array.get('content'), [1, 2, 4], 'removes object from content');
+  assert.equal(shifted, 5, 'returns first object');
+  assert.deepEqual(array.get('content'), [1, 2, 4], 'removes object from content');
 });
 
-QUnit.test('slice - returns a slice of the arrangedContent', function() {
-  deepEqual(array.slice(1, 3), [4, 2], 'returns sliced arrangedContent');
+QUnit.test('slice - returns a slice of the arrangedContent', function(assert) {
+  assert.deepEqual(array.slice(1, 3), [4, 2], 'returns sliced arrangedContent');
 });
 
-QUnit.test('toArray - returns copy of arrangedContent', function() {
-  deepEqual(array.toArray(), [5, 4, 2, 1]);
+QUnit.test('toArray - returns copy of arrangedContent', function(assert) {
+  assert.deepEqual(array.toArray(), [5, 4, 2, 1]);
 });
 
-QUnit.test('unshiftObject - adds to start of content', function() {
+QUnit.test('unshiftObject - adds to start of content', function(assert) {
   run(() => array.unshiftObject(6));
-  deepEqual(array.get('content'), [6, 1, 2, 4, 5], 'adds to start of content');
+  assert.deepEqual(array.get('content'), [6, 1, 2, 4, 5], 'adds to start of content');
 });
 
-QUnit.test('unshiftObjects - adds to start of content', function() {
+QUnit.test('unshiftObjects - adds to start of content', function(assert) {
   run(function() { array.unshiftObjects([6, 7]); });
-  deepEqual(array.get('content'), [6, 7, 1, 2, 4, 5], 'adds to start of content');
+  assert.deepEqual(array.get('content'), [6, 7, 1, 2, 4, 5], 'adds to start of content');
 });
 
-QUnit.test('without - returns arrangedContent without object', function() {
-  deepEqual(array.without(2), [5, 4, 1], 'returns arranged without object');
+QUnit.test('without - returns arrangedContent without object', function(assert) {
+  assert.deepEqual(array.without(2), [5, 4, 1], 'returns arranged without object');
 });
 
-QUnit.test('lastObject - returns last arranged object', function() {
-  equal(array.get('lastObject'), 1, 'returns last arranged object');
+QUnit.test('lastObject - returns last arranged object', function(assert) {
+  assert.equal(array.get('lastObject'), 1, 'returns last arranged object');
 });
 
-QUnit.test('firstObject - returns first arranged object', function() {
-  equal(array.get('firstObject'), 5, 'returns first arranged object');
+QUnit.test('firstObject - returns first arranged object', function(assert) {
+  assert.equal(array.get('firstObject'), 5, 'returns first arranged object');
 });
 
 
 QUnit.module('ArrayProxy - arrangedContent matching content', {
-  setup() {
+  beforeEach() {
     run(function() {
       array = ArrayProxy.create({
         content: emberA([1, 2, 4, 5])
       });
     });
   },
-  teardown() {
+  afterEach() {
     run(function() {
       array.destroy();
     });
   }
 });
 
-QUnit.test('insertAt - inserts object at specified index', function() {
+QUnit.test('insertAt - inserts object at specified index', function(assert) {
   run(function() { array.insertAt(2, 3); });
-  deepEqual(array.get('content'), [1, 2, 3, 4, 5]);
+  assert.deepEqual(array.get('content'), [1, 2, 3, 4, 5]);
 });
 
-QUnit.test('replace - does a standard array replace', function() {
+QUnit.test('replace - does a standard array replace', function(assert) {
   run(function() { array.replace(1, 2, [3]); });
-  deepEqual(array.get('content'), [1, 3, 5]);
+  assert.deepEqual(array.get('content'), [1, 3, 5]);
 });
 
-QUnit.test('reverseObjects - reverses content', function() {
+QUnit.test('reverseObjects - reverses content', function(assert) {
   run(function() { array.reverseObjects(); });
-  deepEqual(array.get('content'), [5, 4, 2, 1]);
+  assert.deepEqual(array.get('content'), [5, 4, 2, 1]);
 });
 
 QUnit.module('ArrayProxy - arrangedContent with transforms', {
-  setup() {
+  beforeEach() {
     run(function() {
       array = ArrayProxy.extend({
         arrangedContent: computed(function() {
@@ -222,84 +222,84 @@ QUnit.module('ArrayProxy - arrangedContent with transforms', {
       });
     });
   },
-  teardown() {
+  afterEach() {
     run(function() {
       array.destroy();
     });
   }
 });
 
-QUnit.test('indexOf - returns index of object in arrangedContent', function() {
-  equal(array.indexOf('4'), 1, 'returns arranged index');
+QUnit.test('indexOf - returns index of object in arrangedContent', function(assert) {
+  assert.equal(array.indexOf('4'), 1, 'returns arranged index');
 });
 
-QUnit.test('lastIndexOf - returns last index of object in arrangedContent', function() {
+QUnit.test('lastIndexOf - returns last index of object in arrangedContent', function(assert) {
   run(function() { array.pushObject(4); });
-  equal(array.lastIndexOf('4'), 2, 'returns last arranged index');
+  assert.equal(array.lastIndexOf('4'), 2, 'returns last arranged index');
 });
 
-QUnit.test('nextObject - returns object at index in arrangedContent', function() {
-  equal(array.nextObject(1), '4', 'returns object at index');
+QUnit.test('nextObject - returns object at index in arrangedContent', function(assert) {
+  assert.equal(array.nextObject(1), '4', 'returns object at index');
 });
 
-QUnit.test('objectAt - returns object at index in arrangedContent', function() {
-  equal(objectAt(array, 1), '4', 'returns object at index');
+QUnit.test('objectAt - returns object at index in arrangedContent', function(assert) {
+  assert.equal(objectAt(array, 1), '4', 'returns object at index');
 });
 
 // Not sure if we need a specific test for it, since it's internal
-QUnit.test('objectAtContent - returns object at index in arrangedContent', function() {
-  equal(array.objectAtContent(1), '4', 'returns object at index');
+QUnit.test('objectAtContent - returns object at index in arrangedContent', function(assert) {
+  assert.equal(array.objectAtContent(1), '4', 'returns object at index');
 });
 
-QUnit.test('objectsAt - returns objects at indices in arrangedContent', function() {
-  deepEqual(array.objectsAt([0, 2, 4]), ['5', '2', undefined], 'returns objects at indices');
+QUnit.test('objectsAt - returns objects at indices in arrangedContent', function(assert) {
+  assert.deepEqual(array.objectsAt([0, 2, 4]), ['5', '2', undefined], 'returns objects at indices');
 });
 
-QUnit.test('popObject - removes last object in arrangedContent', function() {
+QUnit.test('popObject - removes last object in arrangedContent', function(assert) {
   let popped;
   run(function() { popped = array.popObject(); });
-  equal(popped, '1', 'returns last object');
-  deepEqual(array.get('content'), [2, 4, 5], 'removes from content');
+  assert.equal(popped, '1', 'returns last object');
+  assert.deepEqual(array.get('content'), [2, 4, 5], 'removes from content');
 });
 
-QUnit.test('removeObject - removes object from content', function() {
+QUnit.test('removeObject - removes object from content', function(assert) {
   run(function() { array.removeObject('2'); });
-  deepEqual(array.get('content'), [1, 4, 5]);
+  assert.deepEqual(array.get('content'), [1, 4, 5]);
 });
 
-QUnit.test('removeObjects - removes objects from content', function() {
+QUnit.test('removeObjects - removes objects from content', function(assert) {
   run(function() { array.removeObjects(['2', '4', '6']); });
-  deepEqual(array.get('content'), [1, 5]);
+  assert.deepEqual(array.get('content'), [1, 5]);
 });
 
-QUnit.test('shiftObject - removes from start of arrangedContent', function() {
+QUnit.test('shiftObject - removes from start of arrangedContent', function(assert) {
   let shifted;
   run(function() { shifted = array.shiftObject(); });
-  equal(shifted, '5', 'returns first object');
-  deepEqual(array.get('content'), [1, 2, 4], 'removes object from content');
+  assert.equal(shifted, '5', 'returns first object');
+  assert.deepEqual(array.get('content'), [1, 2, 4], 'removes object from content');
 });
 
-QUnit.test('slice - returns a slice of the arrangedContent', function() {
-  deepEqual(array.slice(1, 3), ['4', '2'], 'returns sliced arrangedContent');
+QUnit.test('slice - returns a slice of the arrangedContent', function(assert) {
+  assert.deepEqual(array.slice(1, 3), ['4', '2'], 'returns sliced arrangedContent');
 });
 
-QUnit.test('toArray - returns copy of arrangedContent', function() {
-  deepEqual(array.toArray(), ['5', '4', '2', '1']);
+QUnit.test('toArray - returns copy of arrangedContent', function(assert) {
+  assert.deepEqual(array.toArray(), ['5', '4', '2', '1']);
 });
 
-QUnit.test('without - returns arrangedContent without object', function() {
-  deepEqual(array.without('2'), ['5', '4', '1'], 'returns arranged without object');
+QUnit.test('without - returns arrangedContent without object', function(assert) {
+  assert.deepEqual(array.without('2'), ['5', '4', '1'], 'returns arranged without object');
 });
 
-QUnit.test('lastObject - returns last arranged object', function() {
-  equal(array.get('lastObject'), '1', 'returns last arranged object');
+QUnit.test('lastObject - returns last arranged object', function(assert) {
+  assert.equal(array.get('lastObject'), '1', 'returns last arranged object');
 });
 
-QUnit.test('firstObject - returns first arranged object', function() {
-  equal(array.get('firstObject'), '5', 'returns first arranged object');
+QUnit.test('firstObject - returns first arranged object', function(assert) {
+  assert.equal(array.get('firstObject'), '5', 'returns first arranged object');
 });
 
-QUnit.test('arrangedContentArray{Will,Did}Change are called when the arranged content changes', function() {
+QUnit.test('arrangedContentArray{Will,Did}Change are called when the arranged content changes', function(assert) {
   // The behavior covered by this test may change in the future if we decide
   // that built-in array methods are not overridable.
 
@@ -318,12 +318,12 @@ QUnit.test('arrangedContentArray{Will,Did}Change are called when the arranged co
     }
   }).create({ content });
 
-  equal(willChangeCallCount, 0);
-  equal(didChangeCallCount, 0);
+  assert.equal(willChangeCallCount, 0);
+  assert.equal(didChangeCallCount, 0);
 
   content.pushObject(4);
   content.pushObject(5);
 
-  equal(willChangeCallCount, 2);
-  equal(didChangeCallCount, 2);
+  assert.equal(willChangeCallCount, 2);
+  assert.equal(didChangeCallCount, 2);
 });

--- a/packages/ember-runtime/tests/system/array_proxy/content_change_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/content_change_test.js
@@ -5,26 +5,26 @@ import { A as emberA } from '../../../system/native_array';
 
 QUnit.module('ArrayProxy - content change');
 
-QUnit.test('should update length for null content', function() {
+QUnit.test('should update length for null content', function(assert) {
   let proxy = ArrayProxy.create({
     content: emberA([1, 2, 3])
   });
 
-  equal(proxy.get('length'), 3, 'precond - length is 3');
+  assert.equal(proxy.get('length'), 3, 'precond - length is 3');
 
   proxy.set('content', null);
 
-  equal(proxy.get('length'), 0, 'length updates');
+  assert.equal(proxy.get('length'), 0, 'length updates');
 });
 
-QUnit.test('should update length for null content when there is a computed property watching length', function() {
+QUnit.test('should update length for null content when there is a computed property watching length', function(assert) {
   let proxy = ArrayProxy.extend({
     isEmpty: not('length')
   }).create({
     content: emberA([1, 2, 3])
   });
 
-  equal(proxy.get('length'), 3, 'precond - length is 3');
+  assert.equal(proxy.get('length'), 3, 'precond - length is 3');
 
   // Consume computed property that depends on length
   proxy.get('isEmpty');
@@ -32,58 +32,58 @@ QUnit.test('should update length for null content when there is a computed prope
   // update content
   proxy.set('content', null);
 
-  equal(proxy.get('length'), 0, 'length updates');
+  assert.equal(proxy.get('length'), 0, 'length updates');
 });
 
-QUnit.test('The `arrangedContentWillChange` method is invoked before `content` is changed.', function() {
+QUnit.test('The `arrangedContentWillChange` method is invoked before `content` is changed.', function(assert) {
   let callCount = 0;
   let expectedLength;
 
   let proxy = ArrayProxy.extend({
     arrangedContentWillChange() {
-      equal(this.get('arrangedContent.length'), expectedLength, 'hook should be invoked before array has changed');
+      assert.equal(this.get('arrangedContent.length'), expectedLength, 'hook should be invoked before array has changed');
       callCount++;
     }
   }).create({ content: emberA([1, 2, 3]) });
 
   proxy.pushObject(4);
-  equal(callCount, 0, 'pushing content onto the array doesn\'t trigger it');
+  assert.equal(callCount, 0, 'pushing content onto the array doesn\'t trigger it');
 
   proxy.get('content').pushObject(5);
-  equal(callCount, 0, 'pushing content onto the content array doesn\'t trigger it');
+  assert.equal(callCount, 0, 'pushing content onto the content array doesn\'t trigger it');
 
   expectedLength = 5;
   proxy.set('content', emberA(['a', 'b']));
-  equal(callCount, 1, 'replacing the content array triggers the hook');
+  assert.equal(callCount, 1, 'replacing the content array triggers the hook');
 });
 
-QUnit.test('The `arrangedContentDidChange` method is invoked after `content` is changed.', function() {
+QUnit.test('The `arrangedContentDidChange` method is invoked after `content` is changed.', function(assert) {
   let callCount = 0;
   let expectedLength;
 
   let proxy = ArrayProxy.extend({
     arrangedContentDidChange() {
-      equal(this.get('arrangedContent.length'), expectedLength, 'hook should be invoked after array has changed');
+      assert.equal(this.get('arrangedContent.length'), expectedLength, 'hook should be invoked after array has changed');
       callCount++;
     }
   }).create({
     content: emberA([1, 2, 3])
   });
 
-  equal(callCount, 0, 'hook is not called after creating the object');
+  assert.equal(callCount, 0, 'hook is not called after creating the object');
 
   proxy.pushObject(4);
-  equal(callCount, 0, 'pushing content onto the array doesn\'t trigger it');
+  assert.equal(callCount, 0, 'pushing content onto the array doesn\'t trigger it');
 
   proxy.get('content').pushObject(5);
-  equal(callCount, 0, 'pushing content onto the content array doesn\'t trigger it');
+  assert.equal(callCount, 0, 'pushing content onto the content array doesn\'t trigger it');
 
   expectedLength = 2;
   proxy.set('content', emberA(['a', 'b']));
-  equal(callCount, 1, 'replacing the content array triggers the hook');
+  assert.equal(callCount, 1, 'replacing the content array triggers the hook');
 });
 
-QUnit.test('The ArrayProxy doesn\'t explode when assigned a destroyed object', function() {
+QUnit.test('The ArrayProxy doesn\'t explode when assigned a destroyed object', function(assert) {
   let proxy1 = ArrayProxy.create();
   let proxy2 = ArrayProxy.create();
 
@@ -91,10 +91,10 @@ QUnit.test('The ArrayProxy doesn\'t explode when assigned a destroyed object', f
 
   set(proxy2, 'content', proxy1);
 
-  ok(true, 'No exception was raised');
+  assert.ok(true, 'No exception was raised');
 });
 
-QUnit.test('arrayContent{Will,Did}Change are called when the content changes', function() {
+QUnit.test('arrayContent{Will,Did}Change are called when the content changes', function(assert) {
   // The behavior covered by this test may change in the future if we decide
   // that built-in array methods are not overridable.
 
@@ -113,12 +113,12 @@ QUnit.test('arrayContent{Will,Did}Change are called when the content changes', f
     }
   }).create({ content });
 
-  equal(willChangeCallCount, 0);
-  equal(didChangeCallCount, 0);
+  assert.equal(willChangeCallCount, 0);
+  assert.equal(didChangeCallCount, 0);
 
   content.pushObject(4);
   content.pushObject(5);
 
-  equal(willChangeCallCount, 2);
-  equal(didChangeCallCount, 2);
+  assert.equal(willChangeCallCount, 2);
+  assert.equal(didChangeCallCount, 2);
 });

--- a/packages/ember-runtime/tests/system/array_proxy/content_update_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/content_update_test.js
@@ -4,7 +4,7 @@ import { A as emberA } from '../../../system/native_array';
 
 QUnit.module('Ember.ArrayProxy - content update');
 
-QUnit.test('The `contentArrayDidChange` method is invoked after `content` is updated.', function() {
+QUnit.test('The `contentArrayDidChange` method is invoked after `content` is updated.', function(assert) {
   let observerCalled = false;
   let proxy = ArrayProxy.extend({
     arrangedContent: computed('content', function() {
@@ -21,5 +21,5 @@ QUnit.test('The `contentArrayDidChange` method is invoked after `content` is upd
 
   proxy.pushObject(1);
 
-  ok(observerCalled, 'contentArrayDidChange is invoked');
+  assert.ok(observerCalled, 'contentArrayDidChange is invoked');
 });

--- a/packages/ember-runtime/tests/system/array_proxy/length_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/length_test.js
@@ -5,7 +5,7 @@ import { A as a } from '../../../system/native_array';
 
 QUnit.module('Ember.ArrayProxy - content change (length)');
 
-QUnit.test('array proxy + aliasedProperty complex test', function() {
+QUnit.test('array proxy + aliasedProperty complex test', function(assert) {
   let aCalled, bCalled, cCalled, dCalled, eCalled;
 
   aCalled = bCalled = cCalled = dCalled = eCalled = 0;
@@ -30,28 +30,28 @@ QUnit.test('array proxy + aliasedProperty complex test', function() {
   })
   );
 
-  equal(obj.get('colors.content.length'), 3);
-  equal(obj.get('colors.length'), 3);
-  equal(obj.get('length'), 3);
+  assert.equal(obj.get('colors.content.length'), 3);
+  assert.equal(obj.get('colors.length'), 3);
+  assert.equal(obj.get('length'), 3);
 
-  equal(aCalled, 1, 'expected observer `length` to be called ONCE');
-  equal(bCalled, 1, 'expected observer `colors.length` to be called ONCE');
-  equal(cCalled, 1, 'expected observer `colors.content.length` to be called ONCE');
-  equal(dCalled, 1, 'expected observer `colors.[]` to be called ONCE');
-  equal(eCalled, 1, 'expected observer `colors.content.[]` to be called ONCE');
+  assert.equal(aCalled, 1, 'expected observer `length` to be called ONCE');
+  assert.equal(bCalled, 1, 'expected observer `colors.length` to be called ONCE');
+  assert.equal(cCalled, 1, 'expected observer `colors.content.length` to be called ONCE');
+  assert.equal(dCalled, 1, 'expected observer `colors.[]` to be called ONCE');
+  assert.equal(eCalled, 1, 'expected observer `colors.content.[]` to be called ONCE');
 
   obj.get('colors').pushObjects([
     'green',
     'red'
   ]);
 
-  equal(obj.get('colors.content.length'), 5);
-  equal(obj.get('colors.length'), 5);
-  equal(obj.get('length'), 5);
+  assert.equal(obj.get('colors.content.length'), 5);
+  assert.equal(obj.get('colors.length'), 5);
+  assert.equal(obj.get('length'), 5);
 
-  equal(aCalled, 2, 'expected observer `length` to be called TWICE');
-  equal(bCalled, 2, 'expected observer `colors.length` to be called TWICE');
-  equal(cCalled, 2, 'expected observer `colors.content.length` to be called TWICE');
-  equal(dCalled, 2, 'expected observer `colors.[]` to be called TWICE');
-  equal(eCalled, 2, 'expected observer `colors.content.[]` to be called TWICE');
+  assert.equal(aCalled, 2, 'expected observer `length` to be called TWICE');
+  assert.equal(bCalled, 2, 'expected observer `colors.length` to be called TWICE');
+  assert.equal(cCalled, 2, 'expected observer `colors.content.length` to be called TWICE');
+  assert.equal(dCalled, 2, 'expected observer `colors.[]` to be called TWICE');
+  assert.equal(eCalled, 2, 'expected observer `colors.content.[]` to be called TWICE');
 });

--- a/packages/ember-runtime/tests/system/array_proxy/watching_and_listening_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/watching_and_listening_test.js
@@ -17,54 +17,54 @@ function sortedListenersFor(obj, eventName) {
 
 QUnit.module('ArrayProxy - watching and listening');
 
-QUnit.test(`setting 'content' adds listeners correctly`, function() {
+QUnit.test(`setting 'content' adds listeners correctly`, function(assert) {
   let content = A();
   let proxy = ArrayProxy.create();
 
-  deepEqual(sortedListenersFor(content, '@array:before'), []);
-  deepEqual(sortedListenersFor(content, '@array:change'), []);
+  assert.deepEqual(sortedListenersFor(content, '@array:before'), []);
+  assert.deepEqual(sortedListenersFor(content, '@array:change'), []);
 
   proxy.set('content', content);
 
-  deepEqual(
+  assert.deepEqual(
     sortedListenersFor(content, '@array:before'),
     [[proxy, 'contentArrayWillChange'], [proxy, 'arrangedContentArrayWillChange']]
   );
-  deepEqual(
+  assert.deepEqual(
     sortedListenersFor(content, '@array:change'),
     [[proxy, 'contentArrayDidChange'], [proxy, 'arrangedContentArrayDidChange']]
   );
 });
 
-QUnit.test(`changing 'content' adds and removes listeners correctly`, function() {
+QUnit.test(`changing 'content' adds and removes listeners correctly`, function(assert) {
   let content1 = A();
   let content2 = A();
   let proxy = ArrayProxy.create({ content: content1 });
 
-  deepEqual(
+  assert.deepEqual(
     sortedListenersFor(content1, '@array:before'),
     [[proxy, 'contentArrayWillChange'], [proxy, 'arrangedContentArrayWillChange']]
   );
-  deepEqual(
+  assert.deepEqual(
     sortedListenersFor(content1, '@array:change'),
     [[proxy, 'contentArrayDidChange'], [proxy, 'arrangedContentArrayDidChange']]
   );
 
   proxy.set('content', content2);
 
-  deepEqual(sortedListenersFor(content1, '@array:before'), []);
-  deepEqual(sortedListenersFor(content1, '@array:change'), []);
-  deepEqual(
+  assert.deepEqual(sortedListenersFor(content1, '@array:before'), []);
+  assert.deepEqual(sortedListenersFor(content1, '@array:change'), []);
+  assert.deepEqual(
     sortedListenersFor(content2, '@array:before'),
     [[proxy, 'contentArrayWillChange'], [proxy, 'arrangedContentArrayWillChange']]
   );
-  deepEqual(
+  assert.deepEqual(
     sortedListenersFor(content2, '@array:change'),
     [[proxy, 'contentArrayDidChange'], [proxy, 'arrangedContentArrayDidChange']]
   );
 });
 
-QUnit.test(`regression test for https://github.com/emberjs/ember.js/issues/12475`, function() {
+QUnit.test(`regression test for https://github.com/emberjs/ember.js/issues/12475`, function(assert) {
   let item1a = { id: 1 };
   let item1b = { id: 2 };
   let item1c = { id: 3 };
@@ -89,34 +89,34 @@ QUnit.test(`regression test for https://github.com/emberjs/ember.js/issues/12475
 
   // The EachProxy has not yet been consumed. Only the manually added
   // observers are watching.
-  equal(watcherCount(item1a, 'id'), 1);
-  equal(watcherCount(item1b, 'id'), 1);
-  equal(watcherCount(item1c, 'id'), 1);
+  assert.equal(watcherCount(item1a, 'id'), 1);
+  assert.equal(watcherCount(item1b, 'id'), 1);
+  assert.equal(watcherCount(item1c, 'id'), 1);
 
   // Consume the each proxy. This causes the EachProxy to add two observers
   // per item: one for "before" events and one for "after" events.
-  deepEqual(get(obj, 'ids'), [1, 2, 3]);
+  assert.deepEqual(get(obj, 'ids'), [1, 2, 3]);
 
   // For each item, the two each proxy observers and one manual added observer
   // are watching.
-  equal(watcherCount(item1a, 'id'), 3);
-  equal(watcherCount(item1b, 'id'), 3);
-  equal(watcherCount(item1c, 'id'), 3);
+  assert.equal(watcherCount(item1a, 'id'), 3);
+  assert.equal(watcherCount(item1b, 'id'), 3);
+  assert.equal(watcherCount(item1c, 'id'), 3);
 
   // This should be a no-op because observers do not fire if the value
   // 1. is an object and 2. is the same as the old value.
   proxy.set('content', content1);
 
-  equal(watcherCount(item1a, 'id'), 3);
-  equal(watcherCount(item1b, 'id'), 3);
-  equal(watcherCount(item1c, 'id'), 3);
+  assert.equal(watcherCount(item1a, 'id'), 3);
+  assert.equal(watcherCount(item1b, 'id'), 3);
+  assert.equal(watcherCount(item1c, 'id'), 3);
 
   // This is repeated to catch the regression. It should still be a no-op.
   proxy.set('content', content1);
 
-  equal(watcherCount(item1a, 'id'), 3);
-  equal(watcherCount(item1b, 'id'), 3);
-  equal(watcherCount(item1c, 'id'), 3);
+  assert.equal(watcherCount(item1a, 'id'), 3);
+  assert.equal(watcherCount(item1b, 'id'), 3);
+  assert.equal(watcherCount(item1c, 'id'), 3);
 
   // Set the content to a new array with completely different items and
   // repeat the process.
@@ -131,27 +131,27 @@ QUnit.test(`regression test for https://github.com/emberjs/ember.js/issues/12475
 
   proxy.set('content', content2);
 
-  deepEqual(get(obj, 'ids'), [4, 5, 6]);
+  assert.deepEqual(get(obj, 'ids'), [4, 5, 6]);
 
-  equal(watcherCount(item2a, 'id'), 3);
-  equal(watcherCount(item2b, 'id'), 3);
-  equal(watcherCount(item2c, 'id'), 3);
+  assert.equal(watcherCount(item2a, 'id'), 3);
+  assert.equal(watcherCount(item2b, 'id'), 3);
+  assert.equal(watcherCount(item2c, 'id'), 3);
 
   // Ensure that the observers added by the EachProxy on all items in the
   // first content array have been torn down.
-  equal(watcherCount(item1a, 'id'), 1);
-  equal(watcherCount(item1b, 'id'), 1);
-  equal(watcherCount(item1c, 'id'), 1);
+  assert.equal(watcherCount(item1a, 'id'), 1);
+  assert.equal(watcherCount(item1b, 'id'), 1);
+  assert.equal(watcherCount(item1c, 'id'), 1);
 
   proxy.set('content', content2);
 
-  equal(watcherCount(item2a, 'id'), 3);
-  equal(watcherCount(item2b, 'id'), 3);
-  equal(watcherCount(item2c, 'id'), 3);
+  assert.equal(watcherCount(item2a, 'id'), 3);
+  assert.equal(watcherCount(item2b, 'id'), 3);
+  assert.equal(watcherCount(item2c, 'id'), 3);
 
   proxy.set('content', content2);
 
-  equal(watcherCount(item2a, 'id'), 3);
-  equal(watcherCount(item2b, 'id'), 3);
-  equal(watcherCount(item2c, 'id'), 3);
+  assert.equal(watcherCount(item2a, 'id'), 3);
+  assert.equal(watcherCount(item2b, 'id'), 3);
+  assert.equal(watcherCount(item2c, 'id'), 3);
 });

--- a/packages/ember-runtime/tests/system/core_object_test.js
+++ b/packages/ember-runtime/tests/system/core_object_test.js
@@ -3,17 +3,17 @@ import { set, observer } from 'ember-metal';
 
 QUnit.module('Ember.CoreObject');
 
-QUnit.test('works with new (one arg)', function() {
+QUnit.test('works with new (one arg)', function(assert) {
   let obj = new CoreObject({
     firstName: 'Stef',
     lastName: 'Penner'
   });
 
-  equal(obj.firstName, 'Stef');
-  equal(obj.lastName, 'Penner');
+  assert.equal(obj.firstName, 'Stef');
+  assert.equal(obj.lastName, 'Penner');
 });
 
-QUnit.test('works with new (> 1 arg)', function() {
+QUnit.test('works with new (> 1 arg)', function(assert) {
   let obj = new CoreObject({
     firstName: 'Stef',
     lastName: 'Penner'
@@ -21,13 +21,13 @@ QUnit.test('works with new (> 1 arg)', function() {
     other: 'name'
   });
 
-  equal(obj.firstName, 'Stef');
-  equal(obj.lastName, 'Penner');
+  assert.equal(obj.firstName, 'Stef');
+  assert.equal(obj.lastName, 'Penner');
 
-  equal(obj.other, undefined); // doesn't support multiple pojo' to the constructor
+  assert.equal(obj.other, undefined); // doesn't support multiple pojo' to the constructor
 });
 
-QUnit.test('toString should be not be added as a property when calling toString()', function() {
+QUnit.test('toString should be not be added as a property when calling toString()', function(assert) {
   let obj = new CoreObject({
     firstName: 'Foo',
     lastName: 'Bar'
@@ -35,10 +35,10 @@ QUnit.test('toString should be not be added as a property when calling toString(
 
   obj.toString();
 
-  notOk(obj.hasOwnProperty('toString'), 'Calling toString() should not create a toString class property');
+  assert.notOk(obj.hasOwnProperty('toString'), 'Calling toString() should not create a toString class property');
 });
 
-QUnit.test('[POST_INIT] invoked during construction', function() {
+QUnit.test('[POST_INIT] invoked during construction', function(assert) {
   let callCount = 0;
   let Obj = CoreObject.extend({
     [POST_INIT]() {
@@ -46,14 +46,14 @@ QUnit.test('[POST_INIT] invoked during construction', function() {
     }
   });
 
-  equal(callCount, 0);
+  assert.equal(callCount, 0);
 
   Obj.create();
 
-  equal(callCount, 1);
+  assert.equal(callCount, 1);
 });
 
-QUnit.test('[POST_INIT] invoked before finishChains', function() {
+QUnit.test('[POST_INIT] invoked before finishChains', function(assert) {
   let callCount = 0;
 
   let Obj = CoreObject.extend({
@@ -66,13 +66,13 @@ QUnit.test('[POST_INIT] invoked before finishChains', function() {
     })
   });
 
-  equal(callCount, 0);
+  assert.equal(callCount, 0);
 
   let obj = Obj.create();
 
-  equal(callCount, 0);
+  assert.equal(callCount, 0);
 
   set(obj, 'hi', 2);
 
-  equal(callCount, 1);
+  assert.equal(callCount, 1);
 });

--- a/packages/ember-runtime/tests/system/lazy_load_test.js
+++ b/packages/ember-runtime/tests/system/lazy_load_test.js
@@ -2,7 +2,7 @@ import { run } from 'ember-metal';
 import { onLoad, runLoadHooks, _loaded } from '../../system/lazy_load';
 
 QUnit.module('Lazy Loading', {
-  teardown() {
+  afterEach() {
     let keys = Object.keys(_loaded);
     for (let i = 0; i < keys.length; i++) {
       delete _loaded[keys[i]];
@@ -10,7 +10,7 @@ QUnit.module('Lazy Loading', {
   }
 });
 
-QUnit.test('if a load hook is registered, it is executed when runLoadHooks are exected', function() {
+QUnit.test('if a load hook is registered, it is executed when runLoadHooks are exected', function(assert) {
   let count = 0;
 
   run(function() {
@@ -23,10 +23,10 @@ QUnit.test('if a load hook is registered, it is executed when runLoadHooks are e
     runLoadHooks('__test_hook__', 1);
   });
 
-  equal(count, 1, 'the object was passed into the load hook');
+  assert.equal(count, 1, 'the object was passed into the load hook');
 });
 
-QUnit.test('if runLoadHooks was already run, it executes newly added hooks immediately', function() {
+QUnit.test('if runLoadHooks was already run, it executes newly added hooks immediately', function(assert) {
   let count = 0;
   run(() => {
     onLoad('__test_hook__', object => count += object);
@@ -39,10 +39,10 @@ QUnit.test('if runLoadHooks was already run, it executes newly added hooks immed
     onLoad('__test_hook__', object => count += object);
   });
 
-  equal(count, 1, 'the original object was passed into the load hook');
+  assert.equal(count, 1, 'the original object was passed into the load hook');
 });
 
-QUnit.test('hooks in ENV.EMBER_LOAD_HOOKS[\'hookName\'] get executed', function() {
+QUnit.test('hooks in ENV.EMBER_LOAD_HOOKS[\'hookName\'] get executed', function(assert) {
   // Note that the necessary code to perform this test is run before
   // the Ember lib is loaded in tests/index.html
 
@@ -50,16 +50,16 @@ QUnit.test('hooks in ENV.EMBER_LOAD_HOOKS[\'hookName\'] get executed', function(
     runLoadHooks('__before_ember_test_hook__', 1);
   });
 
-  equal(window.ENV.__test_hook_count__, 1, 'the object was passed into the load hook');
+  assert.equal(window.ENV.__test_hook_count__, 1, 'the object was passed into the load hook');
 });
 
 if (typeof window === 'object' && typeof window.dispatchEvent === 'function' && typeof CustomEvent === 'function') {
-  QUnit.test('load hooks trigger a custom event', function() {
+  QUnit.test('load hooks trigger a custom event', function(assert) {
     let eventObject = 'super duper awesome events';
 
     window.addEventListener('__test_hook_for_events__', function(e) {
-      ok(true, 'custom event was fired');
-      equal(e.detail, eventObject, 'event details are provided properly');
+      assert.ok(true, 'custom event was fired');
+      assert.equal(e.detail, eventObject, 'event details are provided properly');
     });
 
     run(() => {

--- a/packages/ember-runtime/tests/system/namespace/base_test.js
+++ b/packages/ember-runtime/tests/system/namespace/base_test.js
@@ -9,12 +9,12 @@ const originalLookup = context.lookup;
 let lookup;
 
 QUnit.module('Namespace', {
-  setup() {
+  beforeEach() {
     setNamespaceSearchDisabled(false);
 
     lookup = context.lookup = {};
   },
-  teardown() {
+  afterEach() {
     setNamespaceSearchDisabled(false);
 
     for (let prop in lookup) {
@@ -25,33 +25,33 @@ QUnit.module('Namespace', {
   }
 });
 
-QUnit.test('Namespace should be a subclass of EmberObject', function() {
-  ok(EmberObject.detect(Namespace));
+QUnit.test('Namespace should be a subclass of EmberObject', function(assert) {
+  assert.ok(EmberObject.detect(Namespace));
 });
 
-QUnit.test('Namespace should be duck typed', function() {
-  ok(get(Namespace.create(), 'isNamespace'), 'isNamespace property is true');
+QUnit.test('Namespace should be duck typed', function(assert) {
+  assert.ok(get(Namespace.create(), 'isNamespace'), 'isNamespace property is true');
 });
 
-QUnit.test('Namespace is found and named', function() {
+QUnit.test('Namespace is found and named', function(assert) {
   let nsA = lookup.NamespaceA = Namespace.create();
-  equal(nsA.toString(), 'NamespaceA', 'namespaces should have a name if they are on lookup');
+  assert.equal(nsA.toString(), 'NamespaceA', 'namespaces should have a name if they are on lookup');
 
   let nsB = lookup.NamespaceB = Namespace.create();
-  equal(nsB.toString(), 'NamespaceB', 'namespaces work if created after the first namespace processing pass');
+  assert.equal(nsB.toString(), 'NamespaceB', 'namespaces work if created after the first namespace processing pass');
 });
 
-QUnit.test('Classes under an Namespace are properly named', function() {
+QUnit.test('Classes under an Namespace are properly named', function(assert) {
   let nsA = lookup.NamespaceA = Namespace.create();
   nsA.Foo = EmberObject.extend();
-  equal(nsA.Foo.toString(), 'NamespaceA.Foo', 'Classes pick up their parent namespace');
+  assert.equal(nsA.Foo.toString(), 'NamespaceA.Foo', 'Classes pick up their parent namespace');
 
   nsA.Bar = EmberObject.extend();
-  equal(nsA.Bar.toString(), 'NamespaceA.Bar', 'New Classes get the naming treatment too');
+  assert.equal(nsA.Bar.toString(), 'NamespaceA.Bar', 'New Classes get the naming treatment too');
 
   let nsB = lookup.NamespaceB = Namespace.create();
   nsB.Foo = EmberObject.extend();
-  equal(nsB.Foo.toString(), 'NamespaceB.Foo', 'Classes in new namespaces get the naming treatment');
+  assert.equal(nsB.Foo.toString(), 'NamespaceB.Foo', 'Classes in new namespaces get the naming treatment');
 });
 
 //test("Classes under Ember are properly named", function() {
@@ -60,12 +60,12 @@ QUnit.test('Classes under an Namespace are properly named', function() {
 //  equal(Ember.TestObject.toString(), "Ember.TestObject", "class under Ember is given a string representation");
 //});
 
-QUnit.test('Lowercase namespaces are no longer supported', function() {
+QUnit.test('Lowercase namespaces are no longer supported', function(assert) {
   let nsC = lookup.namespaceC = Namespace.create();
-  equal(nsC.toString(), undefined);
+  assert.equal(nsC.toString(), undefined);
 });
 
-QUnit.test('A namespace can be assigned a custom name', function() {
+QUnit.test('A namespace can be assigned a custom name', function(assert) {
   let nsA = Namespace.create({
     name: 'NamespaceA'
   });
@@ -77,11 +77,11 @@ QUnit.test('A namespace can be assigned a custom name', function() {
   nsA.Foo = EmberObject.extend();
   nsB.Foo = EmberObject.extend();
 
-  equal(nsA.Foo.toString(), 'NamespaceA.Foo', 'The namespace\'s name is used when the namespace is not in the lookup object');
-  equal(nsB.Foo.toString(), 'CustomNamespaceB.Foo', 'The namespace\'s name is used when the namespace is in the lookup object');
+  assert.equal(nsA.Foo.toString(), 'NamespaceA.Foo', 'The namespace\'s name is used when the namespace is not in the lookup object');
+  assert.equal(nsB.Foo.toString(), 'CustomNamespaceB.Foo', 'The namespace\'s name is used when the namespace is in the lookup object');
 });
 
-QUnit.test('Calling namespace.nameClasses() eagerly names all classes', function() {
+QUnit.test('Calling namespace.nameClasses() eagerly names all classes', function(assert) {
   setNamespaceSearchDisabled(true);
 
   let namespace = lookup.NS = Namespace.create();
@@ -91,39 +91,39 @@ QUnit.test('Calling namespace.nameClasses() eagerly names all classes', function
 
   Namespace.processAll();
 
-  equal(namespace.ClassA.toString(), 'NS.ClassA');
-  equal(namespace.ClassB.toString(), 'NS.ClassB');
+  assert.equal(namespace.ClassA.toString(), 'NS.ClassA');
+  assert.equal(namespace.ClassB.toString(), 'NS.ClassB');
 });
 
-QUnit.test('A namespace can be looked up by its name', function() {
+QUnit.test('A namespace can be looked up by its name', function(assert) {
   let NS = lookup.NS = Namespace.create();
   let UI = lookup.UI = Namespace.create();
   let CF = lookup.CF = Namespace.create();
 
-  equal(Namespace.byName('NS'), NS);
-  equal(Namespace.byName('UI'), UI);
-  equal(Namespace.byName('CF'), CF);
+  assert.equal(Namespace.byName('NS'), NS);
+  assert.equal(Namespace.byName('UI'), UI);
+  assert.equal(Namespace.byName('CF'), CF);
 });
 
-QUnit.test('A nested namespace can be looked up by its name', function() {
+QUnit.test('A nested namespace can be looked up by its name', function(assert) {
   let UI = lookup.UI = Namespace.create();
   UI.Nav = Namespace.create();
 
-  equal(Namespace.byName('UI.Nav'), UI.Nav);
+  assert.equal(Namespace.byName('UI.Nav'), UI.Nav);
 });
 
-QUnit.test('Destroying a namespace before caching lookup removes it from the list of namespaces', function() {
+QUnit.test('Destroying a namespace before caching lookup removes it from the list of namespaces', function(assert) {
   let CF = lookup.CF = Namespace.create();
 
   run(CF, 'destroy');
-  equal(Namespace.byName('CF'), undefined, 'namespace can not be found after destroyed');
+  assert.equal(Namespace.byName('CF'), undefined, 'namespace can not be found after destroyed');
 });
 
-QUnit.test('Destroying a namespace after looking up removes it from the list of namespaces', function() {
+QUnit.test('Destroying a namespace after looking up removes it from the list of namespaces', function(assert) {
   let CF = lookup.CF = Namespace.create();
 
-  equal(Namespace.byName('CF'), CF, 'precondition - namespace can be looked up by name');
+  assert.equal(Namespace.byName('CF'), CF, 'precondition - namespace can be looked up by name');
 
   run(CF, 'destroy');
-  equal(Namespace.byName('CF'), undefined, 'namespace can not be found after destroyed');
+  assert.equal(Namespace.byName('CF'), undefined, 'namespace can not be found after destroyed');
 });

--- a/packages/ember-runtime/tests/system/native_array/a_test.js
+++ b/packages/ember-runtime/tests/system/native_array/a_test.js
@@ -3,10 +3,10 @@ import { A } from '../../../system/native_array';
 
 QUnit.module('Ember.A');
 
-QUnit.test('Ember.A', function() {
-  deepEqual(A([1, 2]), [1, 2], 'array values were not be modified');
-  deepEqual(A(), [], 'returned an array with no arguments');
-  deepEqual(A(null), [], 'returned an array with a null argument');
-  ok(EmberArray.detect(A()), 'returned an ember array');
-  ok(EmberArray.detect(A([1, 2])), 'returned an ember array');
+QUnit.test('Ember.A', function(assert) {
+  assert.deepEqual(A([1, 2]), [1, 2], 'array values were not be modified');
+  assert.deepEqual(A(), [], 'returned an array with no arguments');
+  assert.deepEqual(A(null), [], 'returned an array with a null argument');
+  assert.ok(EmberArray.detect(A()), 'returned an ember array');
+  assert.ok(EmberArray.detect(A([1, 2])), 'returned an ember array');
 });

--- a/packages/ember-runtime/tests/system/native_array/copyable_suite_test.js
+++ b/packages/ember-runtime/tests/system/native_array/copyable_suite_test.js
@@ -29,11 +29,11 @@ CopyableTests.extend({
 
 QUnit.module('NativeArray Copyable');
 
-QUnit.test('deep copy is respected', function() {
+QUnit.test('deep copy is respected', function(assert) {
   let array = emberA([{ id: 1 }, { id: 2 }, { id: 3 }]);
 
   let copiedArray = array.copy(true);
 
-  deepEqual(copiedArray, array, 'copied array is equivalent');
-  ok(copiedArray[0] !== array[0], 'objects inside should be unique');
+  assert.deepEqual(copiedArray, array, 'copied array is equivalent');
+  assert.ok(copiedArray[0] !== array[0], 'objects inside should be unique');
 });

--- a/packages/ember-runtime/tests/system/native_array/replace_test.js
+++ b/packages/ember-runtime/tests/system/native_array/replace_test.js
@@ -8,6 +8,6 @@ QUnit.test('raises assertion if third argument is not an array', function() {
   }, 'The third argument to replace needs to be an array.');
 });
 
-QUnit.test('it does not raise an assertion if third parameter is not passed', function() {
-  deepEqual(A([1, 2, 3]).replace(1, 2), A([1]), 'no assertion raised');
+QUnit.test('it does not raise an assertion if third parameter is not passed', function(assert) {
+  assert.deepEqual(A([1, 2, 3]).replace(1, 2), A([1]), 'no assertion raised');
 });

--- a/packages/ember-runtime/tests/system/object/computed_test.js
+++ b/packages/ember-runtime/tests/system/object/computed_test.js
@@ -11,16 +11,16 @@ function K() { return this; }
 
 QUnit.module('EmberObject computed property');
 
-testWithDefault('computed property on instance', function(get) {
+testWithDefault('computed property on instance', function(get, set, assert) {
   let MyClass = EmberObject.extend({
     foo: computed(function() { return 'FOO'; })
   });
 
-  equal(get(new MyClass(), 'foo'), 'FOO');
+  assert.equal(get(new MyClass(), 'foo'), 'FOO');
 });
 
 
-testWithDefault('computed property on subclass', function(get) {
+testWithDefault('computed property on subclass', function(get, set, assert) {
   let MyClass = EmberObject.extend({
     foo: computed(function() { return 'FOO'; })
   });
@@ -29,11 +29,11 @@ testWithDefault('computed property on subclass', function(get) {
     foo: computed(function() { return 'BAR'; })
   });
 
-  equal(get(new Subclass(), 'foo'), 'BAR');
+  assert.equal(get(new Subclass(), 'foo'), 'BAR');
 });
 
 
-testWithDefault('replacing computed property with regular val', function(get) {
+testWithDefault('replacing computed property with regular val', function(get, set, assert) {
   let MyClass = EmberObject.extend({
     foo: computed(function() { return 'FOO'; })
   });
@@ -42,10 +42,10 @@ testWithDefault('replacing computed property with regular val', function(get) {
     foo: 'BAR'
   });
 
-  equal(get(new Subclass(), 'foo'), 'BAR');
+  assert.equal(get(new Subclass(), 'foo'), 'BAR');
 });
 
-testWithDefault('complex depndent keys', function(get, set) {
+testWithDefault('complex depndent keys', function(get, set, assert) {
   let MyClass = EmberObject.extend({
 
     init() {
@@ -69,21 +69,21 @@ testWithDefault('complex depndent keys', function(get, set) {
   let obj1 = new MyClass();
   let obj2 = new Subclass();
 
-  equal(get(obj1, 'foo'), 'BIFF 1');
-  equal(get(obj2, 'foo'), 'BIFF 21');
+  assert.equal(get(obj1, 'foo'), 'BIFF 1');
+  assert.equal(get(obj2, 'foo'), 'BIFF 21');
 
   set(get(obj1, 'bar'), 'baz', 'BLARG');
 
-  equal(get(obj1, 'foo'), 'BLARG 2');
-  equal(get(obj2, 'foo'), 'BIFF 21');
+  assert.equal(get(obj1, 'foo'), 'BLARG 2');
+  assert.equal(get(obj2, 'foo'), 'BIFF 21');
 
   set(get(obj2, 'bar'), 'baz', 'BOOM');
 
-  equal(get(obj1, 'foo'), 'BLARG 2');
-  equal(get(obj2, 'foo'), 'BOOM 22');
+  assert.equal(get(obj1, 'foo'), 'BLARG 2');
+  assert.equal(get(obj2, 'foo'), 'BOOM 22');
 });
 
-testWithDefault('complex dependent keys changing complex dependent keys', function(get, set) {
+testWithDefault('complex dependent keys changing complex dependent keys', function(get, set, assert) {
   let MyClass = EmberObject.extend({
     init() {
       this._super(...arguments);
@@ -114,22 +114,22 @@ testWithDefault('complex dependent keys changing complex dependent keys', functi
 
   let obj2 = new Subclass();
 
-  equal(get(obj2, 'foo'), 'BIFF2 1');
+  assert.equal(get(obj2, 'foo'), 'BIFF2 1');
 
   set(get(obj2, 'bar'), 'baz', 'BLARG');
-  equal(get(obj2, 'foo'), 'BIFF2 1', 'should not invalidate property');
+  assert.equal(get(obj2, 'foo'), 'BIFF2 1', 'should not invalidate property');
 
   set(get(obj2, 'bar2'), 'baz', 'BLARG');
-  equal(get(obj2, 'foo'), 'BLARG 2', 'should invalidate property');
+  assert.equal(get(obj2, 'foo'), 'BLARG 2', 'should invalidate property');
 });
 
-QUnit.test('can retrieve metadata for a computed property', function() {
+QUnit.test('can retrieve metadata for a computed property', function(assert) {
   let MyClass = EmberObject.extend({
     computedProperty: computed(function() {
     }).meta({ key: 'keyValue' })
   });
 
-  equal(emberGet(MyClass.metaForProperty('computedProperty'), 'key'), 'keyValue', 'metadata saved on the computed property can be retrieved');
+  assert.equal(emberGet(MyClass.metaForProperty('computedProperty'), 'key'), 'keyValue', 'metadata saved on the computed property can be retrieved');
 
   let ClassWithNoMetadata = EmberObject.extend({
     computedProperty: computed(function() {
@@ -138,7 +138,7 @@ QUnit.test('can retrieve metadata for a computed property', function() {
     staticProperty: 12
   });
 
-  equal(typeof ClassWithNoMetadata.metaForProperty('computedProperty'), 'object', 'returns empty hash if no metadata has been saved');
+  assert.equal(typeof ClassWithNoMetadata.metaForProperty('computedProperty'), 'object', 'returns empty hash if no metadata has been saved');
 
   expectAssertion(function() {
     ClassWithNoMetadata.metaForProperty('nonexistentProperty');
@@ -149,7 +149,7 @@ QUnit.test('can retrieve metadata for a computed property', function() {
   }, 'metaForProperty() could not find a computed property with key \'staticProperty\'.');
 });
 
-QUnit.test('can iterate over a list of computed properties for a class', function() {
+QUnit.test('can iterate over a list of computed properties for a class', function(assert) {
   let MyClass = EmberObject.extend({
     foo: computed(function() {}),
 
@@ -174,7 +174,7 @@ QUnit.test('can iterate over a list of computed properties for a class', functio
     list.push(name);
   });
 
-  deepEqual(list.sort(), ['bar', 'foo', 'qux'], 'watched and unwatched computed properties are iterated');
+  assert.deepEqual(list.sort(), ['bar', 'foo', 'qux'], 'watched and unwatched computed properties are iterated');
 
   list = [];
 
@@ -182,16 +182,16 @@ QUnit.test('can iterate over a list of computed properties for a class', functio
     list.push(name);
 
     if (name === 'bat') {
-      deepEqual(meta, { iAmBat: true });
+      assert.deepEqual(meta, { iAmBat: true });
     } else {
-      deepEqual(meta, {});
+      assert.deepEqual(meta, {});
     }
   });
 
-  deepEqual(list.sort(), ['bar', 'bat', 'baz', 'foo', 'qux'], 'all inherited properties are included');
+  assert.deepEqual(list.sort(), ['bar', 'bat', 'baz', 'foo', 'qux'], 'all inherited properties are included');
 });
 
-QUnit.test('list of properties updates when an additional property is added (such cache busting)', function() {
+QUnit.test('list of properties updates when an additional property is added (such cache busting)', function(assert) {
   let MyClass = EmberObject.extend({
     foo: computed(K),
 
@@ -206,7 +206,7 @@ QUnit.test('list of properties updates when an additional property is added (suc
     list.push(name);
   });
 
-  deepEqual(list.sort(), ['bar', 'foo'].sort(), 'expected two computed properties');
+  assert.deepEqual(list.sort(), ['bar', 'foo'].sort(), 'expected two computed properties');
 
   MyClass.reopen({
     baz: computed(K)
@@ -220,10 +220,10 @@ QUnit.test('list of properties updates when an additional property is added (suc
     list.push(name);
   });
 
-  deepEqual(list.sort(), ['bar', 'foo', 'baz'].sort(), 'expected three computed properties');
+  assert.deepEqual(list.sort(), ['bar', 'foo', 'baz'].sort(), 'expected three computed properties');
 });
 
-QUnit.test('Calling _super in call outside the immediate function of a CP getter works', function() {
+QUnit.test('Calling _super in call outside the immediate function of a CP getter works', function(assert) {
   function macro(callback) {
     return computed(function() {
       return callback.call(this);
@@ -242,10 +242,10 @@ QUnit.test('Calling _super in call outside the immediate function of a CP getter
     })
   });
 
-  ok(emberGet(SubClass.create(), 'foo'), 'FOO', 'super value is fetched');
+  assert.ok(emberGet(SubClass.create(), 'foo'), 'FOO', 'super value is fetched');
 });
 
-QUnit.test('Calling _super in apply outside the immediate function of a CP getter works', function() {
+QUnit.test('Calling _super in apply outside the immediate function of a CP getter works', function(assert) {
   function macro(callback) {
     return computed(function() {
       return callback.apply(this);
@@ -264,10 +264,10 @@ QUnit.test('Calling _super in apply outside the immediate function of a CP gette
     })
   });
 
-  ok(emberGet(SubClass.create(), 'foo'), 'FOO', 'super value is fetched');
+  assert.ok(emberGet(SubClass.create(), 'foo'), 'FOO', 'super value is fetched');
 });
 
-QUnit.test('observing computed.reads prop and overriding it in create() works', function() {
+QUnit.test('observing computed.reads prop and overriding it in create() works', function(assert) {
   let Obj = EmberObject.extend({
     name: computed.reads('model.name'),
     nameDidChange: observer('name', function() {})
@@ -276,6 +276,6 @@ QUnit.test('observing computed.reads prop and overriding it in create() works', 
   let obj1 = Obj.create({name: '1'});
   let obj2 = Obj.create({name: '2'});
 
-  equal(obj1.get('name'), '1');
-  equal(obj2.get('name'), '2');
+  assert.equal(obj1.get('name'), '1');
+  assert.equal(obj2.get('name'), '2');
 });

--- a/packages/ember-runtime/tests/system/object/create_test.js
+++ b/packages/ember-runtime/tests/system/object/create_test.js
@@ -9,12 +9,12 @@ import EmberObject from '../../../system/object';
 
 QUnit.module('EmberObject.create', {});
 
-QUnit.test('simple properties are set', function() {
+QUnit.test('simple properties are set', function(assert) {
   let o = EmberObject.create({ ohai: 'there' });
-  equal(o.get('ohai'), 'there');
+  assert.equal(o.get('ohai'), 'there');
 });
 
-QUnit.test('calls computed property setters', function() {
+QUnit.test('calls computed property setters', function(assert) {
   let MyClass = EmberObject.extend({
     foo: computed({
       get() {
@@ -27,11 +27,11 @@ QUnit.test('calls computed property setters', function() {
   });
 
   let o = MyClass.create({ foo: 'bar' });
-  equal(o.get('foo'), 'bar');
+  assert.equal(o.get('foo'), 'bar');
 });
 
 if (MANDATORY_SETTER) {
-  QUnit.test('sets up mandatory setters for watched simple properties', function() {
+  QUnit.test('sets up mandatory setters for watched simple properties', function(assert) {
     let MyClass = EmberObject.extend({
       foo: null,
       bar: null,
@@ -39,17 +39,17 @@ if (MANDATORY_SETTER) {
     });
 
     let o = MyClass.create({ foo: 'bar', bar: 'baz' });
-    equal(o.get('foo'), 'bar');
+    assert.equal(o.get('foo'), 'bar');
 
     let descriptor = Object.getOwnPropertyDescriptor(o, 'foo');
-    ok(descriptor.set, 'Mandatory setter was setup');
+    assert.ok(descriptor.set, 'Mandatory setter was setup');
 
     descriptor = Object.getOwnPropertyDescriptor(o, 'bar');
-    ok(!descriptor.set, 'Mandatory setter was not setup');
+    assert.ok(!descriptor.set, 'Mandatory setter was not setup');
   });
 }
 
-QUnit.test('allows bindings to be defined', function() {
+QUnit.test('allows bindings to be defined', function(assert) {
   let obj;
 
   let deprecationMessage = /`Ember.Binding` is deprecated/;
@@ -61,10 +61,10 @@ QUnit.test('allows bindings to be defined', function() {
     });
   }, deprecationMessage);
 
-  equal(obj.get('bar'), 'foo', 'The binding value is correct');
+  assert.equal(obj.get('bar'), 'foo', 'The binding value is correct');
 });
 
-QUnit.test('calls setUnknownProperty if defined', function() {
+QUnit.test('calls setUnknownProperty if defined', function(assert) {
   let setUnknownPropertyCalled = false;
 
   let MyClass = EmberObject.extend({
@@ -74,7 +74,7 @@ QUnit.test('calls setUnknownProperty if defined', function() {
   });
 
   MyClass.create({ foo: 'bar' });
-  ok(setUnknownPropertyCalled, 'setUnknownProperty was called');
+  assert.ok(setUnknownPropertyCalled, 'setUnknownProperty was called');
 });
 
 QUnit.test('throws if you try to define a computed property', function() {
@@ -107,11 +107,11 @@ QUnit.test('throws if you try to \'mixin\' a definition', function() {
   }, 'Ember.Object.create no longer supports mixing in other definitions, use .extend & .create separately instead.');
 });
 
-QUnit.test('inherits properties from passed in EmberObject', function() {
+QUnit.test('inherits properties from passed in EmberObject', function(assert) {
   let baseObj = EmberObject.create({ foo: 'bar' });
   let secondaryObj = EmberObject.create(baseObj);
 
-  equal(secondaryObj.foo, baseObj.foo, 'Em.O.create inherits properties from EmberObject parameter');
+  assert.equal(secondaryObj.foo, baseObj.foo, 'Em.O.create inherits properties from EmberObject parameter');
 });
 
 QUnit.test('throws if you try to pass anything a string as a parameter', function() {
@@ -120,18 +120,18 @@ QUnit.test('throws if you try to pass anything a string as a parameter', functio
   expectAssertion(() => EmberObject.create('some-string'), expected);
 });
 
-QUnit.test('EmberObject.create can take undefined as a parameter', function() {
+QUnit.test('EmberObject.create can take undefined as a parameter', function(assert) {
   let o = EmberObject.create(undefined);
-  deepEqual(EmberObject.create(), o);
+  assert.deepEqual(EmberObject.create(), o);
 });
 
-QUnit.test('EmberObject.create can take null as a parameter', function() {
+QUnit.test('EmberObject.create can take null as a parameter', function(assert) {
   let o = EmberObject.create(null);
-  deepEqual(EmberObject.create(), o);
+  assert.deepEqual(EmberObject.create(), o);
 });
 
-QUnit.test('EmberObject.create avoids allocating a binding map when not necessary', function() {
+QUnit.test('EmberObject.create avoids allocating a binding map when not necessary', function(assert) {
   let o = EmberObject.create();
   let m = meta(o);
-  ok(!m.peekBindings(), 'A binding map is not allocated');
+  assert.ok(!m.peekBindings(), 'A binding map is not allocated');
 });

--- a/packages/ember-runtime/tests/system/object/destroy_test.js
+++ b/packages/ember-runtime/tests/system/object/destroy_test.js
@@ -13,27 +13,27 @@ import { MANDATORY_SETTER } from 'ember/features';
 
 QUnit.module('ember-runtime/system/object/destroy_test');
 
-testBoth('should schedule objects to be destroyed at the end of the run loop', function(get /*, set */) {
+testBoth('should schedule objects to be destroyed at the end of the run loop', function(get , set, assert) {
   let obj = EmberObject.create();
   let meta;
 
   run(() => {
     obj.destroy();
     meta = peekMeta(obj);
-    ok(meta, 'meta is not destroyed immediately');
-    ok(get(obj, 'isDestroying'), 'object is marked as destroying immediately');
-    ok(!get(obj, 'isDestroyed'), 'object is not destroyed immediately');
+    assert.ok(meta, 'meta is not destroyed immediately');
+    assert.ok(get(obj, 'isDestroying'), 'object is marked as destroying immediately');
+    assert.ok(!get(obj, 'isDestroyed'), 'object is not destroyed immediately');
   });
 
   meta = peekMeta(obj);
-  ok(get(obj, 'isDestroyed'), 'object is destroyed after run loop finishes');
+  assert.ok(get(obj, 'isDestroyed'), 'object is destroyed after run loop finishes');
 });
 
 if (MANDATORY_SETTER) {
   // MANDATORY_SETTER moves value to meta.values
   // a destroyed object removes meta but leaves the accessor
   // that looks it up
-  QUnit.test('should raise an exception when modifying watched properties on a destroyed object', function() {
+  QUnit.test('should raise an exception when modifying watched properties on a destroyed object', function(assert) {
     let obj = EmberObject.extend({
       fooDidChange: observer('foo', function() { })
     }).create({
@@ -42,11 +42,11 @@ if (MANDATORY_SETTER) {
 
     run(() => obj.destroy());
 
-    throws(() => set(obj, 'foo', 'baz'), Error, 'raises an exception');
+    assert.throws(() => set(obj, 'foo', 'baz'), Error, 'raises an exception');
   });
 }
 
-QUnit.test('observers should not fire after an object has been destroyed', function() {
+QUnit.test('observers should not fire after an object has been destroyed', function(assert) {
   let count = 0;
   let obj = EmberObject.extend({
     fooDidChange: observer('foo', function() {
@@ -56,7 +56,7 @@ QUnit.test('observers should not fire after an object has been destroyed', funct
 
   obj.set('foo', 'bar');
 
-  equal(count, 1, 'observer was fired once');
+  assert.equal(count, 1, 'observer was fired once');
 
   run(() => {
     beginPropertyChanges();
@@ -65,10 +65,10 @@ QUnit.test('observers should not fire after an object has been destroyed', funct
     endPropertyChanges();
   });
 
-  equal(count, 1, 'observer was not called after object was destroyed');
+  assert.equal(count, 1, 'observer was not called after object was destroyed');
 });
 
-QUnit.test('destroyed objects should not see each others changes during teardown but a long lived object should', function () {
+QUnit.test('destroyed objects should not see each others changes during teardown but a long lived object should', function(assert) {
   let shouldChange = 0;
   let shouldNotChange = 0;
 
@@ -138,11 +138,11 @@ QUnit.test('destroyed objects should not see each others changes during teardown
     }
   });
 
-  equal(shouldNotChange, 0, 'destroyed graph objs should not see change in willDestroy');
-  equal(shouldChange, 1, 'long lived should see change in willDestroy');
+  assert.equal(shouldNotChange, 0, 'destroyed graph objs should not see change in willDestroy');
+  assert.equal(shouldChange, 1, 'long lived should see change in willDestroy');
 });
 
-QUnit.test('bindings should be synced when are updated in the willDestroy hook', function() {
+QUnit.test('bindings should be synced when are updated in the willDestroy hook', function(assert) {
   let bar = EmberObject.create({
     value: false,
     willDestroy() {
@@ -163,9 +163,9 @@ QUnit.test('bindings should be synced when are updated in the willDestroy hook',
     }, deprecationMessage);
   });
 
-  ok(bar.get('value') === false, 'the initial value has been bound');
+  assert.ok(bar.get('value') === false, 'the initial value has been bound');
 
   run(() => bar.destroy());
 
-  ok(foo.get('value'), 'foo is synced when the binding is updated in the willDestroy hook');
+  assert.ok(foo.get('value'), 'foo is synced when the binding is updated in the willDestroy hook');
 });

--- a/packages/ember-runtime/tests/system/object/detectInstance_test.js
+++ b/packages/ember-runtime/tests/system/object/detectInstance_test.js
@@ -2,7 +2,7 @@ import EmberObject from '../../../system/object';
 
 QUnit.module('system/object/detectInstance');
 
-QUnit.test('detectInstance detects instances correctly', function() {
+QUnit.test('detectInstance detects instances correctly', function(assert) {
   let A = EmberObject.extend();
   let B = A.extend();
   let C = A.extend();
@@ -12,23 +12,23 @@ QUnit.test('detectInstance detects instances correctly', function() {
   let b = B.create();
   let c = C.create();
 
-  ok(EmberObject.detectInstance(o), 'o is an instance of EmberObject');
-  ok(EmberObject.detectInstance(a), 'a is an instance of EmberObject');
-  ok(EmberObject.detectInstance(b), 'b is an instance of EmberObject');
-  ok(EmberObject.detectInstance(c), 'c is an instance of EmberObject');
+  assert.ok(EmberObject.detectInstance(o), 'o is an instance of EmberObject');
+  assert.ok(EmberObject.detectInstance(a), 'a is an instance of EmberObject');
+  assert.ok(EmberObject.detectInstance(b), 'b is an instance of EmberObject');
+  assert.ok(EmberObject.detectInstance(c), 'c is an instance of EmberObject');
 
-  ok(!A.detectInstance(o), 'o is not an instance of A');
-  ok(A.detectInstance(a), 'a is an instance of A');
-  ok(A.detectInstance(b), 'b is an instance of A');
-  ok(A.detectInstance(c), 'c is an instance of A');
+  assert.ok(!A.detectInstance(o), 'o is not an instance of A');
+  assert.ok(A.detectInstance(a), 'a is an instance of A');
+  assert.ok(A.detectInstance(b), 'b is an instance of A');
+  assert.ok(A.detectInstance(c), 'c is an instance of A');
 
-  ok(!B.detectInstance(o), 'o is not an instance of B');
-  ok(!B.detectInstance(a), 'a is not an instance of B');
-  ok(B.detectInstance(b), 'b is an instance of B');
-  ok(!B.detectInstance(c), 'c is not an instance of B');
+  assert.ok(!B.detectInstance(o), 'o is not an instance of B');
+  assert.ok(!B.detectInstance(a), 'a is not an instance of B');
+  assert.ok(B.detectInstance(b), 'b is an instance of B');
+  assert.ok(!B.detectInstance(c), 'c is not an instance of B');
 
-  ok(!C.detectInstance(o), 'o is not an instance of C');
-  ok(!C.detectInstance(a), 'a is not an instance of C');
-  ok(!C.detectInstance(b), 'b is not an instance of C');
-  ok(C.detectInstance(c), 'c is an instance of C');
+  assert.ok(!C.detectInstance(o), 'o is not an instance of C');
+  assert.ok(!C.detectInstance(a), 'a is not an instance of C');
+  assert.ok(!C.detectInstance(b), 'b is not an instance of C');
+  assert.ok(C.detectInstance(c), 'c is an instance of C');
 });

--- a/packages/ember-runtime/tests/system/object/detect_test.js
+++ b/packages/ember-runtime/tests/system/object/detect_test.js
@@ -2,28 +2,28 @@ import EmberObject from '../../../system/object';
 
 QUnit.module('system/object/detect');
 
-QUnit.test('detect detects classes correctly', function() {
+QUnit.test('detect detects classes correctly', function(assert) {
   let A = EmberObject.extend();
   let B = A.extend();
   let C = A.extend();
 
-  ok(EmberObject.detect(EmberObject), 'EmberObject is an EmberObject class');
-  ok(EmberObject.detect(A), 'A is an EmberObject class');
-  ok(EmberObject.detect(B), 'B is an EmberObject class');
-  ok(EmberObject.detect(C), 'C is an EmberObject class');
+  assert.ok(EmberObject.detect(EmberObject), 'EmberObject is an EmberObject class');
+  assert.ok(EmberObject.detect(A), 'A is an EmberObject class');
+  assert.ok(EmberObject.detect(B), 'B is an EmberObject class');
+  assert.ok(EmberObject.detect(C), 'C is an EmberObject class');
 
-  ok(!A.detect(EmberObject), 'EmberObject is not an A class');
-  ok(A.detect(A), 'A is an A class');
-  ok(A.detect(B), 'B is an A class');
-  ok(A.detect(C), 'C is an A class');
+  assert.ok(!A.detect(EmberObject), 'EmberObject is not an A class');
+  assert.ok(A.detect(A), 'A is an A class');
+  assert.ok(A.detect(B), 'B is an A class');
+  assert.ok(A.detect(C), 'C is an A class');
 
-  ok(!B.detect(EmberObject), 'EmberObject is not a B class');
-  ok(!B.detect(A), 'A is not a B class');
-  ok(B.detect(B), 'B is a B class');
-  ok(!B.detect(C), 'C is not a B class');
+  assert.ok(!B.detect(EmberObject), 'EmberObject is not a B class');
+  assert.ok(!B.detect(A), 'A is not a B class');
+  assert.ok(B.detect(B), 'B is a B class');
+  assert.ok(!B.detect(C), 'C is not a B class');
 
-  ok(!C.detect(EmberObject), 'EmberObject is not a C class');
-  ok(!C.detect(A), 'A is not a C class');
-  ok(!C.detect(B), 'B is not a C class');
-  ok(C.detect(C), 'C is a C class');
+  assert.ok(!C.detect(EmberObject), 'EmberObject is not a C class');
+  assert.ok(!C.detect(A), 'A is not a C class');
+  assert.ok(!C.detect(B), 'B is not a C class');
+  assert.ok(C.detect(C), 'C is a C class');
 });

--- a/packages/ember-runtime/tests/system/object/events_test.js
+++ b/packages/ember-runtime/tests/system/object/events_test.js
@@ -3,7 +3,7 @@ import Evented from '../../../mixins/evented';
 
 QUnit.module('Object events');
 
-QUnit.test('a listener can be added to an object', function() {
+QUnit.test('a listener can be added to an object', function(assert) {
   let count = 0;
   let F = function() { count++; };
 
@@ -12,14 +12,14 @@ QUnit.test('a listener can be added to an object', function() {
   obj.on('event!', F);
   obj.trigger('event!');
 
-  equal(count, 1, 'the event was triggered');
+  assert.equal(count, 1, 'the event was triggered');
 
   obj.trigger('event!');
 
-  equal(count, 2, 'the event was triggered');
+  assert.equal(count, 2, 'the event was triggered');
 });
 
-QUnit.test('a listener can be added and removed automatically the first time it is triggered', function() {
+QUnit.test('a listener can be added and removed automatically the first time it is triggered', function(assert) {
   let count = 0;
   let F = function() { count++; };
 
@@ -28,14 +28,14 @@ QUnit.test('a listener can be added and removed automatically the first time it 
   obj.one('event!', F);
   obj.trigger('event!');
 
-  equal(count, 1, 'the event was triggered');
+  assert.equal(count, 1, 'the event was triggered');
 
   obj.trigger('event!');
 
-  equal(count, 1, 'the event was not triggered again');
+  assert.equal(count, 1, 'the event was not triggered again');
 });
 
-QUnit.test('triggering an event can have arguments', function() {
+QUnit.test('triggering an event can have arguments', function(assert) {
   let self, args;
 
   let obj = EmberObject.extend(Evented).create();
@@ -47,11 +47,11 @@ QUnit.test('triggering an event can have arguments', function() {
 
   obj.trigger('event!', 'foo', 'bar');
 
-  deepEqual(args, ['foo', 'bar']);
-  equal(self, obj);
+  assert.deepEqual(args, ['foo', 'bar']);
+  assert.equal(self, obj);
 });
 
-QUnit.test('a listener can be added and removed automatically and have arguments', function() {
+QUnit.test('a listener can be added and removed automatically and have arguments', function(assert) {
   let self, args;
   let count = 0;
 
@@ -65,18 +65,18 @@ QUnit.test('a listener can be added and removed automatically and have arguments
 
   obj.trigger('event!', 'foo', 'bar');
 
-  deepEqual(args, ['foo', 'bar']);
-  equal(self, obj);
-  equal(count, 1, 'the event is triggered once');
+  assert.deepEqual(args, ['foo', 'bar']);
+  assert.equal(self, obj);
+  assert.equal(count, 1, 'the event is triggered once');
 
   obj.trigger('event!', 'baz', 'bat');
 
-  deepEqual(args, ['foo', 'bar']);
-  equal(count, 1, 'the event was not triggered again');
-  equal(self, obj);
+  assert.deepEqual(args, ['foo', 'bar']);
+  assert.equal(count, 1, 'the event was not triggered again');
+  assert.equal(self, obj);
 });
 
-QUnit.test('binding an event can specify a different target', function() {
+QUnit.test('binding an event can specify a different target', function(assert) {
   let self, args;
 
   let obj = EmberObject.extend(Evented).create();
@@ -89,11 +89,11 @@ QUnit.test('binding an event can specify a different target', function() {
 
   obj.trigger('event!', 'foo', 'bar');
 
-  deepEqual(args, ['foo', 'bar']);
-  equal(self, target);
+  assert.deepEqual(args, ['foo', 'bar']);
+  assert.equal(self, target);
 });
 
-QUnit.test('a listener registered with one can take method as string and can be added with different target', function() {
+QUnit.test('a listener registered with one can take method as string and can be added with different target', function(assert) {
   let count = 0;
   let target = {};
   target.fn = function() { count++; };
@@ -103,14 +103,14 @@ QUnit.test('a listener registered with one can take method as string and can be 
   obj.one('event!', target, 'fn');
   obj.trigger('event!');
 
-  equal(count, 1, 'the event was triggered');
+  assert.equal(count, 1, 'the event was triggered');
 
   obj.trigger('event!');
 
-  equal(count, 1, 'the event was not triggered again');
+  assert.equal(count, 1, 'the event was not triggered again');
 });
 
-QUnit.test('a listener registered with one can be removed with off', function() {
+QUnit.test('a listener registered with one can be removed with off', function(assert) {
   let obj = EmberObject.extend(Evented, {
     F() {}
   }).create();
@@ -119,24 +119,24 @@ QUnit.test('a listener registered with one can be removed with off', function() 
   obj.one('event!', F);
   obj.one('event!', obj, 'F');
 
-  equal(obj.has('event!'), true, 'has events');
+  assert.equal(obj.has('event!'), true, 'has events');
 
   obj.off('event!', F);
   obj.off('event!', obj, 'F');
 
-  equal(obj.has('event!'), false, 'has no more events');
+  assert.equal(obj.has('event!'), false, 'has no more events');
 });
 
-QUnit.test('adding and removing listeners should be chainable', function() {
+QUnit.test('adding and removing listeners should be chainable', function(assert) {
   let obj = EmberObject.extend(Evented).create();
   let F = function() {};
 
   let ret = obj.on('event!', F);
-  equal(ret, obj, '#on returns self');
+  assert.equal(ret, obj, '#on returns self');
 
   ret = obj.off('event!', F);
-  equal(ret, obj, '#off returns self');
+  assert.equal(ret, obj, '#off returns self');
 
   ret = obj.one('event!', F);
-  equal(ret, obj, '#one returns self');
+  assert.equal(ret, obj, '#one returns self');
 });

--- a/packages/ember-runtime/tests/system/object/extend_test.js
+++ b/packages/ember-runtime/tests/system/object/extend_test.js
@@ -3,22 +3,22 @@ import EmberObject from '../../../system/object';
 
 QUnit.module('EmberObject.extend');
 
-QUnit.test('Basic extend', function() {
+QUnit.test('Basic extend', function(assert) {
   let SomeClass = EmberObject.extend({ foo: 'BAR' });
-  ok(SomeClass.isClass, 'A class has isClass of true');
+  assert.ok(SomeClass.isClass, 'A class has isClass of true');
   let obj = new SomeClass();
-  equal(obj.foo, 'BAR');
+  assert.equal(obj.foo, 'BAR');
 });
 
-QUnit.test('Sub-subclass', function() {
+QUnit.test('Sub-subclass', function(assert) {
   let SomeClass = EmberObject.extend({ foo: 'BAR' });
   let AnotherClass = SomeClass.extend({ bar: 'FOO' });
   let obj = new AnotherClass();
-  equal(obj.foo, 'BAR');
-  equal(obj.bar, 'FOO');
+  assert.equal(obj.foo, 'BAR');
+  assert.equal(obj.bar, 'FOO');
 });
 
-QUnit.test('Overriding a method several layers deep', function() {
+QUnit.test('Overriding a method several layers deep', function(assert) {
   let SomeClass = EmberObject.extend({
     fooCnt: 0,
     foo() { this.fooCnt++; },
@@ -46,8 +46,8 @@ QUnit.test('Overriding a method several layers deep', function() {
   let obj = new FinalClass();
   obj.foo();
   obj.bar();
-  equal(obj.fooCnt, 2, 'should invoke both');
-  equal(obj.barCnt, 2, 'should invoke both');
+  assert.equal(obj.fooCnt, 2, 'should invoke both');
+  assert.equal(obj.barCnt, 2, 'should invoke both');
 
   // Try overriding on create also
   obj = FinalClass.extend({
@@ -59,23 +59,23 @@ QUnit.test('Overriding a method several layers deep', function() {
 
   obj.foo();
   obj.bar();
-  equal(obj.fooCnt, 3, 'should invoke final as well');
-  equal(obj.barCnt, 2, 'should invoke both');
+  assert.equal(obj.fooCnt, 3, 'should invoke final as well');
+  assert.equal(obj.barCnt, 2, 'should invoke both');
 });
 
-QUnit.test('With concatenatedProperties', function() {
+QUnit.test('With concatenatedProperties', function(assert) {
   let SomeClass = EmberObject.extend({ things: 'foo', concatenatedProperties: ['things'] });
   let AnotherClass = SomeClass.extend({ things: 'bar' });
   let YetAnotherClass = SomeClass.extend({ things: 'baz' });
   let some = new SomeClass();
   let another = new AnotherClass();
   let yetAnother = new YetAnotherClass();
-  deepEqual(some.get('things'), ['foo'], 'base class should have just its value');
-  deepEqual(another.get('things'), ['foo', 'bar'], 'subclass should have base class\' and its own');
-  deepEqual(yetAnother.get('things'), ['foo', 'baz'], 'subclass should have base class\' and its own');
+  assert.deepEqual(some.get('things'), ['foo'], 'base class should have just its value');
+  assert.deepEqual(another.get('things'), ['foo', 'bar'], 'subclass should have base class\' and its own');
+  assert.deepEqual(yetAnother.get('things'), ['foo', 'baz'], 'subclass should have base class\' and its own');
 });
 
-QUnit.test('With concatenatedProperties class properties', function() {
+QUnit.test('With concatenatedProperties class properties', function(assert) {
   let SomeClass = EmberObject.extend();
   SomeClass.reopenClass({
     concatenatedProperties: ['things'],
@@ -88,9 +88,9 @@ QUnit.test('With concatenatedProperties class properties', function() {
   let some = new SomeClass();
   let another = new AnotherClass();
   let yetAnother = new YetAnotherClass();
-  deepEqual(get(some.constructor, 'things'), ['foo'], 'base class should have just its value');
-  deepEqual(get(another.constructor, 'things'), ['foo', 'bar'], 'subclass should have base class\' and its own');
-  deepEqual(get(yetAnother.constructor, 'things'), ['foo', 'baz'], 'subclass should have base class\' and its own');
+  assert.deepEqual(get(some.constructor, 'things'), ['foo'], 'base class should have just its value');
+  assert.deepEqual(get(another.constructor, 'things'), ['foo', 'bar'], 'subclass should have base class\' and its own');
+  assert.deepEqual(get(yetAnother.constructor, 'things'), ['foo', 'baz'], 'subclass should have base class\' and its own');
 });
 
 QUnit.test('Overriding a computed property with an observer', assert => {

--- a/packages/ember-runtime/tests/system/object/observer_test.js
+++ b/packages/ember-runtime/tests/system/object/observer_test.js
@@ -4,7 +4,7 @@ import EmberObject from '../../../system/object';
 
 QUnit.module('EmberObject observer');
 
-testBoth('observer on class', function(get, set) {
+testBoth('observer on class', function(get, set, assert) {
   let MyClass = EmberObject.extend({
     count: 0,
 
@@ -14,13 +14,13 @@ testBoth('observer on class', function(get, set) {
   });
 
   let obj = new MyClass();
-  equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+  assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
   set(obj, 'bar', 'BAZ');
-  equal(get(obj, 'count'), 1, 'should invoke observer after change');
+  assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
 });
 
-testBoth('observer on subclass', function(get, set) {
+testBoth('observer on subclass', function(get, set, assert) {
   let MyClass = EmberObject.extend({
     count: 0,
 
@@ -36,16 +36,16 @@ testBoth('observer on subclass', function(get, set) {
   });
 
   let obj = new Subclass();
-  equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+  assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
   set(obj, 'bar', 'BAZ');
-  equal(get(obj, 'count'), 0, 'should not invoke observer after change');
+  assert.equal(get(obj, 'count'), 0, 'should not invoke observer after change');
 
   set(obj, 'baz', 'BAZ');
-  equal(get(obj, 'count'), 1, 'should invoke observer after change');
+  assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
 });
 
-testBoth('observer on instance', function(get, set) {
+testBoth('observer on instance', function(get, set, assert) {
   let obj = EmberObject.extend({
     foo: observer('bar', function() {
       set(this, 'count', get(this, 'count') + 1);
@@ -54,13 +54,13 @@ testBoth('observer on instance', function(get, set) {
     count: 0
   });
 
-  equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+  assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
   set(obj, 'bar', 'BAZ');
-  equal(get(obj, 'count'), 1, 'should invoke observer after change');
+  assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
 });
 
-testBoth('observer on instance overriding class', function(get, set) {
+testBoth('observer on instance overriding class', function(get, set, assert) {
   let MyClass = EmberObject.extend({
     count: 0,
 
@@ -75,16 +75,16 @@ testBoth('observer on instance overriding class', function(get, set) {
     })
   }).create();
 
-  equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+  assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
   set(obj, 'bar', 'BAZ');
-  equal(get(obj, 'count'), 0, 'should not invoke observer after change');
+  assert.equal(get(obj, 'count'), 0, 'should not invoke observer after change');
 
   set(obj, 'baz', 'BAZ');
-  equal(get(obj, 'count'), 1, 'should invoke observer after change');
+  assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
 });
 
-testBoth('observer should not fire after being destroyed', function(get, set) {
+testBoth('observer should not fire after being destroyed', function(get, set, assert) {
   let obj = EmberObject.extend({
     count: 0,
     foo: observer('bar', function() {
@@ -92,7 +92,7 @@ testBoth('observer should not fire after being destroyed', function(get, set) {
     })
   }).create();
 
-  equal(get(obj, 'count'), 0, 'precond - should not invoke observer immediately');
+  assert.equal(get(obj, 'count'), 0, 'precond - should not invoke observer immediately');
 
   run(() => obj.destroy());
 
@@ -100,14 +100,14 @@ testBoth('observer should not fire after being destroyed', function(get, set) {
     set(obj, 'bar', 'BAZ');
   }, `calling set on destroyed object: ${obj}.bar = BAZ`);
 
-  equal(get(obj, 'count'), 0, 'should not invoke observer after change');
+  assert.equal(get(obj, 'count'), 0, 'should not invoke observer after change');
 });
 // ..........................................................
 // COMPLEX PROPERTIES
 //
 
 
-testBoth('chain observer on class', function(get, set) {
+testBoth('chain observer on class', function(get, set, assert) {
   let MyClass = EmberObject.extend({
     count: 0,
 
@@ -124,20 +124,20 @@ testBoth('chain observer on class', function(get, set) {
     bar: { baz: 'biff2' }
   });
 
-  equal(get(obj1, 'count'), 0, 'should not invoke yet');
-  equal(get(obj2, 'count'), 0, 'should not invoke yet');
+  assert.equal(get(obj1, 'count'), 0, 'should not invoke yet');
+  assert.equal(get(obj2, 'count'), 0, 'should not invoke yet');
 
   set(get(obj1, 'bar'), 'baz', 'BIFF1');
-  equal(get(obj1, 'count'), 1, 'should invoke observer on obj1');
-  equal(get(obj2, 'count'), 0, 'should not invoke yet');
+  assert.equal(get(obj1, 'count'), 1, 'should invoke observer on obj1');
+  assert.equal(get(obj2, 'count'), 0, 'should not invoke yet');
 
   set(get(obj2, 'bar'), 'baz', 'BIFF2');
-  equal(get(obj1, 'count'), 1, 'should not invoke again');
-  equal(get(obj2, 'count'), 1, 'should invoke observer on obj2');
+  assert.equal(get(obj1, 'count'), 1, 'should not invoke again');
+  assert.equal(get(obj2, 'count'), 1, 'should invoke observer on obj2');
 });
 
 
-testBoth('chain observer on class', function(get, set) {
+testBoth('chain observer on class', function(get, set, assert) {
   let MyClass = EmberObject.extend({
     count: 0,
 
@@ -159,23 +159,23 @@ testBoth('chain observer on class', function(get, set) {
     bar2: { baz: 'biff3' }
   });
 
-  equal(get(obj1, 'count'), 0, 'should not invoke yet');
-  equal(get(obj2, 'count'), 0, 'should not invoke yet');
+  assert.equal(get(obj1, 'count'), 0, 'should not invoke yet');
+  assert.equal(get(obj2, 'count'), 0, 'should not invoke yet');
 
   set(get(obj1, 'bar'), 'baz', 'BIFF1');
-  equal(get(obj1, 'count'), 1, 'should invoke observer on obj1');
-  equal(get(obj2, 'count'), 0, 'should not invoke yet');
+  assert.equal(get(obj1, 'count'), 1, 'should invoke observer on obj1');
+  assert.equal(get(obj2, 'count'), 0, 'should not invoke yet');
 
   set(get(obj2, 'bar'), 'baz', 'BIFF2');
-  equal(get(obj1, 'count'), 1, 'should not invoke again');
-  equal(get(obj2, 'count'), 0, 'should not invoke yet');
+  assert.equal(get(obj1, 'count'), 1, 'should not invoke again');
+  assert.equal(get(obj2, 'count'), 0, 'should not invoke yet');
 
   set(get(obj2, 'bar2'), 'baz', 'BIFF3');
-  equal(get(obj1, 'count'), 1, 'should not invoke again');
-  equal(get(obj2, 'count'), 1, 'should invoke observer on obj2');
+  assert.equal(get(obj1, 'count'), 1, 'should not invoke again');
+  assert.equal(get(obj2, 'count'), 1, 'should invoke observer on obj2');
 });
 
-testBoth('chain observer on class that has a reference to an uninitialized object will finish chains that reference it', function(get, set) {
+testBoth('chain observer on class that has a reference to an uninitialized object will finish chains that reference it', function(get, set, assert) {
   let changed = false;
 
   let ChildClass = EmberObject.extend({
@@ -198,13 +198,13 @@ testBoth('chain observer on class that has a reference to an uninitialized objec
 
   let parent = new ParentClass();
 
-  equal(changed, false, 'precond');
+  assert.equal(changed, false, 'precond');
 
   set(parent, 'one.two', 'new');
 
-  equal(changed, true, 'child should have been notified of change to path');
+  assert.equal(changed, true, 'child should have been notified of change to path');
 
   set(parent, 'one', { two: 'newer' });
 
-  equal(changed, true, 'child should have been notified of change to path');
+  assert.equal(changed, true, 'child should have been notified of change to path');
 });

--- a/packages/ember-runtime/tests/system/object/reopenClass_test.js
+++ b/packages/ember-runtime/tests/system/object/reopenClass_test.js
@@ -3,18 +3,18 @@ import EmberObject from '../../../system/object';
 
 QUnit.module('system/object/reopenClass');
 
-QUnit.test('adds new properties to subclass', function() {
+QUnit.test('adds new properties to subclass', function(assert) {
   let Subclass = EmberObject.extend();
   Subclass.reopenClass({
     foo() { return 'FOO'; },
     bar: 'BAR'
   });
 
-  equal(Subclass.foo(), 'FOO', 'Adds method');
-  equal(get(Subclass, 'bar'), 'BAR', 'Adds property');
+  assert.equal(Subclass.foo(), 'FOO', 'Adds method');
+  assert.equal(get(Subclass, 'bar'), 'BAR', 'Adds property');
 });
 
-QUnit.test('class properties inherited by subclasses', function() {
+QUnit.test('class properties inherited by subclasses', function(assert) {
   let Subclass = EmberObject.extend();
   Subclass.reopenClass({
     foo() { return 'FOO'; },
@@ -23,7 +23,7 @@ QUnit.test('class properties inherited by subclasses', function() {
 
   let SubSub = Subclass.extend();
 
-  equal(SubSub.foo(), 'FOO', 'Adds method');
-  equal(get(SubSub, 'bar'), 'BAR', 'Adds property');
+  assert.equal(SubSub.foo(), 'FOO', 'Adds method');
+  assert.equal(get(SubSub, 'bar'), 'BAR', 'Adds property');
 });
 

--- a/packages/ember-runtime/tests/system/object/reopen_test.js
+++ b/packages/ember-runtime/tests/system/object/reopen_test.js
@@ -3,18 +3,18 @@ import EmberObject from '../../../system/object';
 
 QUnit.module('system/core_object/reopen');
 
-QUnit.test('adds new properties to subclass instance', function() {
+QUnit.test('adds new properties to subclass instance', function(assert) {
   let Subclass = EmberObject.extend();
   Subclass.reopen({
     foo() { return 'FOO'; },
     bar: 'BAR'
   });
 
-  equal(new Subclass().foo(), 'FOO', 'Adds method');
-  equal(get(new Subclass(), 'bar'), 'BAR', 'Adds property');
+  assert.equal(new Subclass().foo(), 'FOO', 'Adds method');
+  assert.equal(get(new Subclass(), 'bar'), 'BAR', 'Adds property');
 });
 
-QUnit.test('reopened properties inherited by subclasses', function() {
+QUnit.test('reopened properties inherited by subclasses', function(assert) {
   let Subclass = EmberObject.extend();
   let SubSub = Subclass.extend();
 
@@ -23,11 +23,11 @@ QUnit.test('reopened properties inherited by subclasses', function() {
     bar: 'BAR'
   });
 
-  equal(new SubSub().foo(), 'FOO', 'Adds method');
-  equal(get(new SubSub(), 'bar'), 'BAR', 'Adds property');
+  assert.equal(new SubSub().foo(), 'FOO', 'Adds method');
+  assert.equal(get(new SubSub(), 'bar'), 'BAR', 'Adds property');
 });
 
-QUnit.test('allows reopening already instantiated classes', function() {
+QUnit.test('allows reopening already instantiated classes', function(assert) {
   let Subclass = EmberObject.extend();
 
   Subclass.create();
@@ -36,5 +36,5 @@ QUnit.test('allows reopening already instantiated classes', function() {
     trololol: true
   });
 
-  equal(Subclass.create().get('trololol'), true, 'reopen works');
+  assert.equal(Subclass.create().get('trololol'), true, 'reopen works');
 });

--- a/packages/ember-runtime/tests/system/object/strict-mode-test.js
+++ b/packages/ember-runtime/tests/system/object/strict-mode-test.js
@@ -2,7 +2,7 @@ import EmberObject from '../../../system/object';
 
 QUnit.module('strict mode tests');
 
-QUnit.test('__superWrapper does not throw errors in strict mode', function() {
+QUnit.test('__superWrapper does not throw errors in strict mode', function(assert) {
   let Foo = EmberObject.extend({
     blah() {
       return 'foo';
@@ -23,5 +23,5 @@ QUnit.test('__superWrapper does not throw errors in strict mode', function() {
 
   let bar = Bar.create();
 
-  equal(bar.callBlah(), 'bar', 'can call local function without call/apply');
+  assert.equal(bar.callBlah(), 'bar', 'can call local function without call/apply');
 });

--- a/packages/ember-runtime/tests/system/object/subclasses_test.js
+++ b/packages/ember-runtime/tests/system/object/subclasses_test.js
@@ -3,7 +3,7 @@ import EmberObject from '../../../system/object';
 
 QUnit.module('system/object/subclasses');
 
-QUnit.test('chains should copy forward to subclasses when prototype created', function () {
+QUnit.test('chains should copy forward to subclasses when prototype created', function(assert) {
   let ObjectWithChains, objWithChains, SubWithChains, SubSub, subSub;
   run(() => {
     ObjectWithChains = EmberObject.extend({
@@ -38,7 +38,7 @@ QUnit.test('chains should copy forward to subclasses when prototype created', fu
       subSub = SubSub.create();
     }, deprecationMessage);
   });
-  equal(subSub.get('greeting'), 'hi world');
+  assert.equal(subSub.get('greeting'), 'hi world');
   run(() => objWithChains.set('obj.hi', 'hello'));
-  equal(subSub.get('greeting'), 'hello world');
+  assert.equal(subSub.get('greeting'), 'hello world');
 });

--- a/packages/ember-runtime/tests/system/object/toString_test.js
+++ b/packages/ember-runtime/tests/system/object/toString_test.js
@@ -7,82 +7,82 @@ let originalLookup = context.lookup;
 let lookup;
 
 QUnit.module('system/object/toString', {
-  setup() {
+  beforeEach() {
     context.lookup = lookup = {};
   },
-  teardown() {
+  afterEach() {
     context.lookup = originalLookup;
   }
 });
 
-QUnit.test('NAME_KEY slot is present on Class', function() {
-  ok(EmberObject.extend().hasOwnProperty(NAME_KEY), 'Ember Class\'s have a NAME_KEY slot');
+QUnit.test('NAME_KEY slot is present on Class', function(assert) {
+  assert.ok(EmberObject.extend().hasOwnProperty(NAME_KEY), 'Ember Class\'s have a NAME_KEY slot');
 });
 
-QUnit.test('toString() returns the same value if called twice', function() {
+QUnit.test('toString() returns the same value if called twice', function(assert) {
   let Foo = Namespace.create();
   Foo.toString = function() { return 'Foo'; };
 
   Foo.Bar = EmberObject.extend();
 
-  equal(Foo.Bar.toString(), 'Foo.Bar');
-  equal(Foo.Bar.toString(), 'Foo.Bar');
+  assert.equal(Foo.Bar.toString(), 'Foo.Bar');
+  assert.equal(Foo.Bar.toString(), 'Foo.Bar');
 
   let obj = Foo.Bar.create();
 
-  equal(obj.toString(), '<Foo.Bar:' + guidFor(obj) + '>');
-  equal(obj.toString(), '<Foo.Bar:' + guidFor(obj) + '>');
+  assert.equal(obj.toString(), '<Foo.Bar:' + guidFor(obj) + '>');
+  assert.equal(obj.toString(), '<Foo.Bar:' + guidFor(obj) + '>');
 
-  equal(Foo.Bar.toString(), 'Foo.Bar');
+  assert.equal(Foo.Bar.toString(), 'Foo.Bar');
 });
 
-QUnit.test('toString on a class returns a useful value when nested in a namespace', function() {
+QUnit.test('toString on a class returns a useful value when nested in a namespace', function(assert) {
   let obj;
 
   let Foo = Namespace.create();
   Foo.toString = function() { return 'Foo'; };
 
   Foo.Bar = EmberObject.extend();
-  equal(Foo.Bar.toString(), 'Foo.Bar');
+  assert.equal(Foo.Bar.toString(), 'Foo.Bar');
 
   obj = Foo.Bar.create();
-  equal(obj.toString(), '<Foo.Bar:' + guidFor(obj) + '>');
+  assert.equal(obj.toString(), '<Foo.Bar:' + guidFor(obj) + '>');
 
   Foo.Baz = Foo.Bar.extend();
-  equal(Foo.Baz.toString(), 'Foo.Baz');
+  assert.equal(Foo.Baz.toString(), 'Foo.Baz');
 
   obj = Foo.Baz.create();
-  equal(obj.toString(), '<Foo.Baz:' + guidFor(obj) + '>');
+  assert.equal(obj.toString(), '<Foo.Baz:' + guidFor(obj) + '>');
 
   obj = Foo.Bar.create();
-  equal(obj.toString(), '<Foo.Bar:' + guidFor(obj) + '>');
+  assert.equal(obj.toString(), '<Foo.Bar:' + guidFor(obj) + '>');
 });
 
-QUnit.test('toString on a namespace finds the namespace in lookup', function() {
+QUnit.test('toString on a namespace finds the namespace in lookup', function(assert) {
   let Foo = lookup.Foo = Namespace.create();
 
-  equal(Foo.toString(), 'Foo');
+  assert.equal(Foo.toString(), 'Foo');
 });
 
-QUnit.test('toString on a namespace finds the namespace in lookup', function() {
+QUnit.test('toString on a namespace finds the namespace in lookup', function(assert) {
   let Foo = lookup.Foo = Namespace.create();
   let obj;
 
   Foo.Bar = EmberObject.extend();
 
-  equal(Foo.Bar.toString(), 'Foo.Bar');
+  assert.equal(Foo.Bar.toString(), 'Foo.Bar');
 
   obj = Foo.Bar.create();
-  equal(obj.toString(), '<Foo.Bar:' + guidFor(obj) + '>');
+  assert.equal(obj.toString(), '<Foo.Bar:' + guidFor(obj) + '>');
 });
 
-QUnit.test('toString on a namespace falls back to modulePrefix, if defined', function() {
+QUnit.test('toString on a namespace falls back to modulePrefix, if defined', function(assert) {
   let Foo = Namespace.create({ modulePrefix: 'foo' });
 
-  equal(Foo.toString(), 'foo');
+  assert.equal(Foo.toString(), 'foo');
 });
 
-QUnit.test('toString includes toStringExtension if defined', function() {
+QUnit.test('toString includes toStringExtension if defined', function(assert) {
   let Foo = EmberObject.extend({
     toStringExtension() {
       return 'fooey';
@@ -96,6 +96,6 @@ QUnit.test('toString includes toStringExtension if defined', function() {
   Foo[NAME_KEY] = 'Foo';
   Bar[NAME_KEY] = 'Bar';
 
-  equal(bar.toString(), '<Bar:' + guidFor(bar) + '>', 'does not include toStringExtension part');
-  equal(foo.toString(), '<Foo:' + guidFor(foo) + ':fooey>', 'Includes toStringExtension result');
+  assert.equal(bar.toString(), '<Bar:' + guidFor(bar) + '>', 'does not include toStringExtension part');
+  assert.equal(foo.toString(), '<Foo:' + guidFor(foo) + ':fooey>', 'Includes toStringExtension result');
 });

--- a/packages/ember-runtime/tests/system/object_proxy_test.js
+++ b/packages/ember-runtime/tests/system/object_proxy_test.js
@@ -9,7 +9,7 @@ import ObjectProxy from '../../system/object_proxy';
 
 QUnit.module('ObjectProxy');
 
-testBoth('should not proxy properties passed to create', function (get) {
+testBoth('should not proxy properties passed to create', function(get, set, assert) {
   let Proxy = ObjectProxy.extend({
     cp: computed({
       get() { return this._cp; },
@@ -24,11 +24,11 @@ testBoth('should not proxy properties passed to create', function (get) {
     cp: 'Bar'
   });
 
-  equal(get(proxy, 'prop'), 'Foo', 'should not have tried to proxy set');
-  equal(proxy._cp, 'Bar', 'should use CP setter');
+  assert.equal(get(proxy, 'prop'), 'Foo', 'should not have tried to proxy set');
+  assert.equal(proxy._cp, 'Bar', 'should use CP setter');
 });
 
-testBoth('should proxy properties to content', function(get, set) {
+testBoth('should proxy properties to content', function(get, set, assert) {
   let content = {
     firstName: 'Tom',
     lastName: 'Dale',
@@ -36,29 +36,29 @@ testBoth('should proxy properties to content', function(get, set) {
   };
   let proxy = ObjectProxy.create();
 
-  equal(get(proxy, 'firstName'), undefined, 'get on proxy without content should return undefined');
+  assert.equal(get(proxy, 'firstName'), undefined, 'get on proxy without content should return undefined');
   expectAssertion(() => {
     set(proxy, 'firstName', 'Foo');
   }, /Cannot delegate set\('firstName', Foo\) to the 'content'/i);
 
   set(proxy, 'content', content);
 
-  equal(get(proxy, 'firstName'), 'Tom', 'get on proxy with content should forward to content');
-  equal(get(proxy, 'lastName'), 'Dale', 'get on proxy with content should forward to content');
-  equal(get(proxy, 'foo'), 'foo unknown', 'get on proxy with content should forward to content');
+  assert.equal(get(proxy, 'firstName'), 'Tom', 'get on proxy with content should forward to content');
+  assert.equal(get(proxy, 'lastName'), 'Dale', 'get on proxy with content should forward to content');
+  assert.equal(get(proxy, 'foo'), 'foo unknown', 'get on proxy with content should forward to content');
 
   set(proxy, 'lastName', 'Huda');
 
-  equal(get(content, 'lastName'), 'Huda', 'content should have new value from set on proxy');
-  equal(get(proxy, 'lastName'), 'Huda', 'proxy should have new value from set on proxy');
+  assert.equal(get(content, 'lastName'), 'Huda', 'content should have new value from set on proxy');
+  assert.equal(get(proxy, 'lastName'), 'Huda', 'proxy should have new value from set on proxy');
 
   set(proxy, 'content', { firstName: 'Yehuda', lastName: 'Katz' });
 
-  equal(get(proxy, 'firstName'), 'Yehuda', 'proxy should reflect updated content');
-  equal(get(proxy, 'lastName'), 'Katz', 'proxy should reflect updated content');
+  assert.equal(get(proxy, 'firstName'), 'Yehuda', 'proxy should reflect updated content');
+  assert.equal(get(proxy, 'lastName'), 'Katz', 'proxy should reflect updated content');
 });
 
-testBoth('should work with watched properties', function(get, set) {
+testBoth('should work with watched properties', function(get, set, assert) {
   let content1 = { firstName: 'Tom', lastName: 'Dale' };
   let content2 = { firstName: 'Yehuda', lastName: 'Katz' };
   let count = 0;
@@ -84,49 +84,49 @@ testBoth('should work with watched properties', function(get, set) {
   });
 
   // proxy without content returns undefined
-  equal(get(proxy, 'fullName'), undefined);
+  assert.equal(get(proxy, 'fullName'), undefined);
 
   // setting content causes all watched properties to change
   set(proxy, 'content', content1);
   // both dependent keys changed
-  equal(count, 2);
-  equal(last, 'Tom Dale');
+  assert.equal(count, 2);
+  assert.equal(last, 'Tom Dale');
 
   // setting property in content causes proxy property to change
   set(content1, 'lastName', 'Huda');
-  equal(count, 3);
-  equal(last, 'Tom Huda');
+  assert.equal(count, 3);
+  assert.equal(last, 'Tom Huda');
 
   // replacing content causes all watched properties to change
   set(proxy, 'content', content2);
   // both dependent keys changed
-  equal(count, 5);
-  equal(last, 'Yehuda Katz');
+  assert.equal(count, 5);
+  assert.equal(last, 'Yehuda Katz');
   // content1 is no longer watched
-  ok(!isWatching(content1, 'firstName'), 'not watching firstName');
-  ok(!isWatching(content1, 'lastName'), 'not watching lastName');
+  assert.ok(!isWatching(content1, 'firstName'), 'not watching firstName');
+  assert.ok(!isWatching(content1, 'lastName'), 'not watching lastName');
 
   // setting property in new content
   set(content2, 'firstName', 'Tomhuda');
-  equal(last, 'Tomhuda Katz');
-  equal(count, 6);
+  assert.equal(last, 'Tomhuda Katz');
+  assert.equal(count, 6);
 
   // setting property in proxy syncs with new content
   set(proxy, 'lastName', 'Katzdale');
-  equal(count, 7);
-  equal(last, 'Tomhuda Katzdale');
-  equal(get(content2, 'firstName'), 'Tomhuda');
-  equal(get(content2, 'lastName'), 'Katzdale');
+  assert.equal(count, 7);
+  assert.equal(last, 'Tomhuda Katzdale');
+  assert.equal(get(content2, 'firstName'), 'Tomhuda');
+  assert.equal(get(content2, 'lastName'), 'Katzdale');
 });
 
-QUnit.test('set and get should work with paths', function () {
+QUnit.test('set and get should work with paths', function(assert) {
   let content = { foo: { bar: 'baz' } };
   let proxy = ObjectProxy.create({ content });
   let count = 0;
 
   proxy.set('foo.bar', 'hello');
-  equal(proxy.get('foo.bar'), 'hello');
-  equal(proxy.get('content.foo.bar'), 'hello');
+  assert.equal(proxy.get('foo.bar'), 'hello');
+  assert.equal(proxy.get('content.foo.bar'), 'hello');
 
   proxy.addObserver('foo.bar', function () {
     count++;
@@ -134,12 +134,12 @@ QUnit.test('set and get should work with paths', function () {
 
   proxy.set('foo.bar', 'bye');
 
-  equal(count, 1);
-  equal(proxy.get('foo.bar'), 'bye');
-  equal(proxy.get('content.foo.bar'), 'bye');
+  assert.equal(count, 1);
+  assert.equal(proxy.get('foo.bar'), 'bye');
+  assert.equal(proxy.get('content.foo.bar'), 'bye');
 });
 
-testBoth('should transition between watched and unwatched strategies', function(get, set) {
+testBoth('should transition between watched and unwatched strategies', function(get, set, assert) {
   let content = { foo: 'foo' };
   let proxy = ObjectProxy.create({ content: content });
   let count = 0;
@@ -148,51 +148,51 @@ testBoth('should transition between watched and unwatched strategies', function(
     count++;
   }
 
-  equal(get(proxy, 'foo'), 'foo');
+  assert.equal(get(proxy, 'foo'), 'foo');
 
   set(content, 'foo', 'bar');
 
-  equal(get(proxy, 'foo'), 'bar');
+  assert.equal(get(proxy, 'foo'), 'bar');
 
   set(proxy, 'foo', 'foo');
 
-  equal(get(content, 'foo'), 'foo');
-  equal(get(proxy, 'foo'), 'foo');
+  assert.equal(get(content, 'foo'), 'foo');
+  assert.equal(get(proxy, 'foo'), 'foo');
 
   addObserver(proxy, 'foo', observer);
 
-  equal(count, 0);
-  equal(get(proxy, 'foo'), 'foo');
+  assert.equal(count, 0);
+  assert.equal(get(proxy, 'foo'), 'foo');
 
   set(content, 'foo', 'bar');
 
-  equal(count, 1);
-  equal(get(proxy, 'foo'), 'bar');
+  assert.equal(count, 1);
+  assert.equal(get(proxy, 'foo'), 'bar');
 
   set(proxy, 'foo', 'foo');
 
-  equal(count, 2);
-  equal(get(content, 'foo'), 'foo');
-  equal(get(proxy, 'foo'), 'foo');
+  assert.equal(count, 2);
+  assert.equal(get(content, 'foo'), 'foo');
+  assert.equal(get(proxy, 'foo'), 'foo');
 
   removeObserver(proxy, 'foo', observer);
 
   set(content, 'foo', 'bar');
 
-  equal(get(proxy, 'foo'), 'bar');
+  assert.equal(get(proxy, 'foo'), 'bar');
 
   set(proxy, 'foo', 'foo');
 
-  equal(get(content, 'foo'), 'foo');
-  equal(get(proxy, 'foo'), 'foo');
+  assert.equal(get(content, 'foo'), 'foo');
+  assert.equal(get(proxy, 'foo'), 'foo');
 });
 
-testBoth('setting `undefined` to a proxied content property should override its existing value', function(get, set) {
+testBoth('setting `undefined` to a proxied content property should override its existing value', function(get, set, assert) {
   let proxyObject = ObjectProxy.create({
     content: {
       prop: 'emberjs'
     }
   });
   set(proxyObject, 'prop', undefined);
-  equal(get(proxyObject, 'prop'), undefined, 'sets the `undefined` value to the proxied content');
+  assert.equal(get(proxyObject, 'prop'), undefined, 'sets the `undefined` value to the proxied content');
 });

--- a/packages/ember-runtime/tests/system/string/camelize_test.js
+++ b/packages/ember-runtime/tests/system/string/camelize_test.js
@@ -4,16 +4,16 @@ import { camelize } from '../../../system/string';
 QUnit.module('EmberStringUtils.camelize');
 
 if (!ENV.EXTEND_PROTOTYPES.String) {
-  QUnit.test('String.prototype.camelize is not modified without EXTEND_PROTOTYPES', function() {
-    ok('undefined' === typeof String.prototype.camelize, 'String.prototype helper disabled');
+  QUnit.test('String.prototype.camelize is not modified without EXTEND_PROTOTYPES', function(assert) {
+    assert.ok('undefined' === typeof String.prototype.camelize, 'String.prototype helper disabled');
   });
 }
 
 function test(given, expected, description) {
-  QUnit.test(description, function() {
-    deepEqual(camelize(given), expected);
+  QUnit.test(description, function(assert) {
+    assert.deepEqual(camelize(given), expected);
     if (ENV.EXTEND_PROTOTYPES.String) {
-      deepEqual(given.camelize(), expected);
+      assert.deepEqual(given.camelize(), expected);
     }
   });
 }

--- a/packages/ember-runtime/tests/system/string/capitalize_test.js
+++ b/packages/ember-runtime/tests/system/string/capitalize_test.js
@@ -4,16 +4,16 @@ import { capitalize } from '../../../system/string';
 QUnit.module('EmberStringUtils.capitalize');
 
 if (!ENV.EXTEND_PROTOTYPES.String) {
-  QUnit.test('String.prototype.capitalize is not modified without EXTEND_PROTOTYPES', function() {
-    ok('undefined' === typeof String.prototype.capitalize, 'String.prototype helper disabled');
+  QUnit.test('String.prototype.capitalize is not modified without EXTEND_PROTOTYPES', function(assert) {
+    assert.ok('undefined' === typeof String.prototype.capitalize, 'String.prototype helper disabled');
   });
 }
 
 function test(given, expected, description) {
-  QUnit.test(description, function () {
-    deepEqual(capitalize(given), expected);
+  QUnit.test(description, function(assert) {
+    assert.deepEqual(capitalize(given), expected);
     if (ENV.EXTEND_PROTOTYPES.String) {
-      deepEqual(given.capitalize(), expected);
+      assert.deepEqual(given.capitalize(), expected);
     }
   });
 }

--- a/packages/ember-runtime/tests/system/string/classify_test.js
+++ b/packages/ember-runtime/tests/system/string/classify_test.js
@@ -4,16 +4,16 @@ import { classify } from '../../../system/string';
 QUnit.module('EmberStringUtils.classify');
 
 if (!ENV.EXTEND_PROTOTYPES.String) {
-  QUnit.test('String.prototype.classify is not modified without EXTEND_PROTOTYPES', function() {
-    ok('undefined' === typeof String.prototype.classify, 'String.prototype helper disabled');
+  QUnit.test('String.prototype.classify is not modified without EXTEND_PROTOTYPES', function(assert) {
+    assert.ok('undefined' === typeof String.prototype.classify, 'String.prototype helper disabled');
   });
 }
 
 function test(given, expected, description) {
-  QUnit.test(description, function() {
-    deepEqual(classify(given), expected);
+  QUnit.test(description, function(assert) {
+    assert.deepEqual(classify(given), expected);
     if (ENV.EXTEND_PROTOTYPES.String) {
-      deepEqual(given.classify(), expected);
+      assert.deepEqual(given.classify(), expected);
     }
   });
 }

--- a/packages/ember-runtime/tests/system/string/dasherize_test.js
+++ b/packages/ember-runtime/tests/system/string/dasherize_test.js
@@ -4,16 +4,16 @@ import { dasherize } from '../../../system/string';
 QUnit.module('EmberStringUtils.dasherize');
 
 if (!ENV.EXTEND_PROTOTYPES.String) {
-  QUnit.test('String.prototype.dasherize is not modified without EXTEND_PROTOTYPES', function() {
-    ok('undefined' === typeof String.prototype.dasherize, 'String.prototype helper disabled');
+  QUnit.test('String.prototype.dasherize is not modified without EXTEND_PROTOTYPES', function(assert) {
+    assert.ok('undefined' === typeof String.prototype.dasherize, 'String.prototype helper disabled');
   });
 }
 
 function test(given, expected, description) {
-  QUnit.test(description, function () {
-    deepEqual(dasherize(given), expected);
+  QUnit.test(description, function(assert) {
+    assert.deepEqual(dasherize(given), expected);
     if (ENV.EXTEND_PROTOTYPES.String) {
-      deepEqual(given.dasherize(), expected);
+      assert.deepEqual(given.dasherize(), expected);
     }
   });
 }

--- a/packages/ember-runtime/tests/system/string/decamelize_test.js
+++ b/packages/ember-runtime/tests/system/string/decamelize_test.js
@@ -4,16 +4,16 @@ import { decamelize } from '../../../system/string';
 QUnit.module('EmberStringUtils.decamelize');
 
 if (!ENV.EXTEND_PROTOTYPES.String) {
-  QUnit.test('String.prototype.decamelize is not modified without EXTEND_PROTOTYPES', function() {
-    ok('undefined' === typeof String.prototype.decamelize, 'String.prototype helper disabled');
+  QUnit.test('String.prototype.decamelize is not modified without EXTEND_PROTOTYPES', function(assert) {
+    assert.ok('undefined' === typeof String.prototype.decamelize, 'String.prototype helper disabled');
   });
 }
 
 function test(given, expected, description) {
-  QUnit.test(description, function() {
-    deepEqual(decamelize(given), expected);
+  QUnit.test(description, function(assert) {
+    assert.deepEqual(decamelize(given), expected);
     if (ENV.EXTEND_PROTOTYPES.String) {
-      deepEqual(given.decamelize(), expected);
+      assert.deepEqual(given.decamelize(), expected);
     }
   });
 }

--- a/packages/ember-runtime/tests/system/string/loc_test.js
+++ b/packages/ember-runtime/tests/system/string/loc_test.js
@@ -5,7 +5,7 @@ import { loc } from '../../../system/string';
 let oldString;
 
 QUnit.module('EmberStringUtils.loc', {
-  setup() {
+  beforeEach() {
     oldString = Ember.STRINGS;
     Ember.STRINGS = {
       '_Hello World': 'Bonjour le monde',
@@ -15,22 +15,22 @@ QUnit.module('EmberStringUtils.loc', {
     };
   },
 
-  teardown() {
+  afterEach() {
     Ember.STRINGS = oldString;
   }
 });
 
 if (!ENV.EXTEND_PROTOTYPES.String) {
-  QUnit.test('String.prototype.loc is not available without EXTEND_PROTOTYPES', function() {
-    ok('undefined' === typeof String.prototype.loc, 'String.prototype helper disabled');
+  QUnit.test('String.prototype.loc is not available without EXTEND_PROTOTYPES', function(assert) {
+    assert.ok('undefined' === typeof String.prototype.loc, 'String.prototype helper disabled');
   });
 }
 
 function test(given, args, expected, description) {
-  QUnit.test(description, function() {
-    equal(loc(given, args), expected);
+  QUnit.test(description, function(assert) {
+    assert.equal(loc(given, args), expected);
     if (ENV.EXTEND_PROTOTYPES.String) {
-      equal(given.loc(...args), expected);
+      assert.equal(given.loc(...args), expected);
     }
   });
 }
@@ -40,7 +40,7 @@ test('_Hello %@ %@',    ['John', 'Doe'], 'Bonjour John Doe', `loc('_Hello %@ %@'
 test('_Hello %@# %@#',  ['John', 'Doe'], 'Bonjour Doe John', `loc('_Hello %@# %@#', ['John', 'Doe']) => 'Bonjour Doe John'`);
 test('_Not In Strings', [],              '_Not In Strings',  `loc('_Not In Strings') => '_Not In Strings'`);
 
-QUnit.test('works with argument form', function() {
-  equal(loc('_Hello %@', 'John'), 'Bonjour John');
-  equal(loc('_Hello %@ %@', ['John'], 'Doe'), 'Bonjour [John] Doe');
+QUnit.test('works with argument form', function(assert) {
+  assert.equal(loc('_Hello %@', 'John'), 'Bonjour John');
+  assert.equal(loc('_Hello %@ %@', ['John'], 'Doe'), 'Bonjour [John] Doe');
 });

--- a/packages/ember-runtime/tests/system/string/underscore_test.js
+++ b/packages/ember-runtime/tests/system/string/underscore_test.js
@@ -4,16 +4,16 @@ import { underscore } from '../../../system/string';
 QUnit.module('EmberStringUtils.underscore');
 
 if (!ENV.EXTEND_PROTOTYPES.String) {
-  QUnit.test('String.prototype.underscore is not available without EXTEND_PROTOTYPES', function() {
-    ok('undefined' === typeof String.prototype.underscore, 'String.prototype helper disabled');
+  QUnit.test('String.prototype.underscore is not available without EXTEND_PROTOTYPES', function(assert) {
+    assert.ok('undefined' === typeof String.prototype.underscore, 'String.prototype helper disabled');
   });
 }
 
 function test(given, expected, description) {
-  QUnit.test(description, function() {
-    deepEqual(underscore(given), expected);
+  QUnit.test(description, function(assert) {
+    assert.deepEqual(underscore(given), expected);
     if (ENV.EXTEND_PROTOTYPES.String) {
-      deepEqual(given.underscore(), expected);
+      assert.deepEqual(given.underscore(), expected);
     }
   });
 }

--- a/packages/ember-runtime/tests/system/string/w_test.js
+++ b/packages/ember-runtime/tests/system/string/w_test.js
@@ -4,16 +4,16 @@ import { w } from '../../../system/string';
 QUnit.module('EmberStringUtils.w');
 
 if (!ENV.EXTEND_PROTOTYPES.String) {
-  QUnit.test('String.prototype.w is not available without EXTEND_PROTOTYPES', function() {
-    ok('undefined' === typeof String.prototype.w, 'String.prototype helper disabled');
+  QUnit.test('String.prototype.w is not available without EXTEND_PROTOTYPES', function(assert) {
+    assert.ok('undefined' === typeof String.prototype.w, 'String.prototype helper disabled');
   });
 }
 
 function test(given, expected, description) {
-  QUnit.test(description, function() {
-    deepEqual(w(given), expected);
+  QUnit.test(description, function(assert) {
+    assert.deepEqual(w(given), expected);
     if (ENV.EXTEND_PROTOTYPES.String) {
-      deepEqual(given.w(), expected);
+      assert.deepEqual(given.w(), expected);
     }
   });
 }

--- a/packages/internal-test-helpers/lib/ember-dev/setup-qunit.js
+++ b/packages/internal-test-helpers/lib/ember-dev/setup-qunit.js
@@ -11,17 +11,20 @@ export default function setupQUnit(assertion, _qunitGlobal) {
 
   qunitGlobal.module = function(name, _options) {
     var options = _options || {};
-    var originalSetup = options.setup || function() { };
-    var originalTeardown = options.teardown || function() { };
+    var originalSetup = options.setup || options.beforeEach || function() { };
+    var originalTeardown = options.teardown || options.afterEach || function() { };
 
-    options.setup = function() {
+    delete options.setup;
+    delete options.teardown;
+
+    options.beforeEach = function() {
       assertion.reset();
       assertion.inject();
 
       return originalSetup.apply(this, arguments);
     };
 
-    options.teardown = function() {
+    options.afterEach = function() {
       let result = originalTeardown.apply(this, arguments);
 
       assertion.assert();

--- a/packages/internal-test-helpers/lib/module-for.js
+++ b/packages/internal-test-helpers/lib/module-for.js
@@ -1,19 +1,28 @@
 import { isFeatureEnabled } from 'ember-debug';
 import applyMixins from './apply-mixins';
+import { all } from 'rsvp';
 
 export default function moduleFor(description, TestClass, ...mixins) {
   let context;
 
   QUnit.module(description, {
-    setup() {
+    beforeEach() {
       context = new TestClass();
       if (context.beforeEach) {
         return context.beforeEach();
       }
     },
 
-    teardown() {
-      return context.teardown();
+    afterEach() {
+      let promises = [];
+      if (context.teardown) {
+        promises.push(context.teardown());
+      }
+      if (context.afterEach) {
+        promises.push(context.afterEach());
+      }
+
+      return all(promises);
     }
   });
 

--- a/packages/internal-test-helpers/lib/module-for.js
+++ b/packages/internal-test-helpers/lib/module-for.js
@@ -22,7 +22,19 @@ export default function moduleFor(description, TestClass, ...mixins) {
         promises.push(context.afterEach());
       }
 
-      return all(promises);
+      // this seems odd, but actually saves significant time
+      // in the test suite
+      //
+      // returning a promise from a QUnit test always adds a 13ms
+      // delay to the test, this filtering prevents returning a
+      // promise when it is not needed
+      //
+      // Remove after we can update to QUnit that includes
+      // https://github.com/qunitjs/qunit/pull/1246
+      let filteredPromises = promises.filter(Boolean);
+      if (filteredPromises.length > 0) {
+        return all(filteredPromises);
+      }
     }
   });
 

--- a/packages/internal-test-helpers/lib/test-cases/abstract-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract-application.js
@@ -41,7 +41,7 @@ export default class AbstractApplicationTestCase extends AbstractTestCase {
     this._element = element;
   }
 
-  teardown() {
+  afterEach() {
     runDestroy(this.applicationInstance);
     runDestroy(this.application);
 

--- a/packages/internal-test-helpers/lib/test-cases/abstract-rendering.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract-rendering.js
@@ -43,7 +43,7 @@ export default class AbstractRenderingTestCase extends AbstractTestCase {
   getBootOptions() { }
   getResolver() { }
 
-  teardown() {
+  afterEach() {
     try {
       if (this.component) {
         runDestroy(this.component);

--- a/packages/internal-test-helpers/lib/test-cases/abstract.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract.js
@@ -39,6 +39,7 @@ export default class AbstractTestCase {
   }
 
   teardown() {}
+  afterEach() {}
 
   runTask(callback) {
     return run(callback);

--- a/packages/internal-test-helpers/lib/test-cases/default-resolver-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/default-resolver-application.js
@@ -23,9 +23,9 @@ export default class ApplicationTestCase extends AbstractApplicationTestCase {
     });
   }
 
-  teardown() {
-    super.teardown();
+  afterEach() {
     setTemplates({});
+    return super.afterEach();
   }
 
   get appRouter() {

--- a/packages/internal-test-helpers/lib/test-groups.js
+++ b/packages/internal-test-helpers/lib/test-groups.js
@@ -12,13 +12,13 @@ export function testBoth(testname, callback) {
   function aget(x, y) { return x[y]; }
   function aset(x, y, z) { return (x[y] = z); }
 
-  QUnit.test(`${testname} using getFromEmberMetal()/Ember.set()`, function() {
-    callback(emberget, emberset);
+  QUnit.test(`${testname} using getFromEmberMetal()/Ember.set()`, function(assert) {
+    callback(emberget, emberset, assert);
   });
 
-  QUnit.test(`${testname} using accessors`, function() {
+  QUnit.test(`${testname} using accessors`, function(assert) {
     if (ENV.USES_ACCESSORS) {
-      callback(aget, aset);
+      callback(aget, aset, assert);
     } else {
       ok('SKIPPING ACCESSORS');
     }
@@ -33,25 +33,25 @@ export function testWithDefault(testname, callback) {
   function aget(x, y) { return x[y]; }
   function aset(x, y, z) { return (x[y] = z); }
 
-  QUnit.test(`${testname} using obj.get()`, function() {
-    callback(emberget, emberset);
+  QUnit.test(`${testname} using obj.get()`, function(assert) {
+    callback(emberget, emberset, assert);
   });
 
-  QUnit.test(`${testname} using obj.getWithDefault()`, function() {
-    callback(getwithdefault, emberset);
+  QUnit.test(`${testname} using obj.getWithDefault()`, function(assert) {
+    callback(getwithdefault, emberset, assert);
   });
 
-  QUnit.test(`${testname} using getFromEmberMetal()`, function() {
-    callback(emberget, emberset);
+  QUnit.test(`${testname} using getFromEmberMetal()`, function(assert) {
+    callback(emberget, emberset, assert);
   });
 
-  QUnit.test(`${testname} using Ember.getWithDefault()`, function() {
-    callback(embergetwithdefault, emberset);
+  QUnit.test(`${testname} using Ember.getWithDefault()`, function(assert) {
+    callback(embergetwithdefault, emberset, assert);
   });
 
-  QUnit.test(`${testname} using accessors`, function() {
+  QUnit.test(`${testname} using accessors`, function(assert) {
     if (ENV.USES_ACCESSORS) {
-      callback(aget, aset);
+      callback(aget, aset, assert);
     } else {
       ok('SKIPPING ACCESSORS');
     }


### PR DESCRIPTION
Migrates ember-runtime and ember-metal to using QUnit 2 APIs (avoiding global assertions, using beforeEach/afterEach instead of setup/teardown, etc).

It also updates the test harness for `moduleFor` and the older `ember-dev` system to honor both `setup`/`teardown` and `beforeEach`/`afterEach`.