### PR TITLE
[BUGFIX beta] Fix issues with `run.debounce` with only method and wait.

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "babel-plugin-transform-proto-to-assign": "^6.23.0",
     "babel-template": "^6.24.1",
-    "backburner.js": "^2.0.0",
+    "backburner.js": "^2.0.2",
     "broccoli-babel-transpiler": "^6.1.1",
     "broccoli-concat": "^3.2.2",
     "broccoli-debug": "^0.6.3",

--- a/packages/ember-metal/tests/run_loop/debounce_test.js
+++ b/packages/ember-metal/tests/run_loop/debounce_test.js
@@ -1,22 +1,80 @@
 import { run } from '../..';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
-const originalDebounce = run.backburner.debounce;
-let wasCalled = false;
-
 moduleFor('Ember.run.debounce', class extends AbstractTestCase {
-  constructor() {
-    super();
+  ['@test Ember.run.debounce - with target, with method, without args'](assert) {
+    let done = assert.async();
 
-    run.backburner.debounce = function() { wasCalled = true; };
+    let calledWith = [];
+    let target = {
+      someFunc(...args) {
+        calledWith.push(args);
+      }
+    };
+
+    run.debounce(target, target.someFunc, 10);
+    run.debounce(target, target.someFunc, 10);
+    run.debounce(target, target.someFunc, 10);
+
+    setTimeout(() => {
+      assert.deepEqual(calledWith, [ [] ], 'someFunc called once with correct arguments');
+      done();
+    }, 20);
   }
 
-  teardown() {
-    run.backburner.debounce = originalDebounce;
+  ['@test Ember.run.debounce - with target, with method name, without args'](assert) {
+    let done = assert.async();
+
+    let calledWith = [];
+    let target = {
+      someFunc(...args) {
+        calledWith.push(args);
+      }
+    };
+
+    run.debounce(target, 'someFunc', 10);
+    run.debounce(target, 'someFunc', 10);
+    run.debounce(target, 'someFunc', 10);
+
+    setTimeout(() => {
+      assert.deepEqual(calledWith, [ [] ], 'someFunc called once with correct arguments');
+      done();
+    }, 20);
   }
 
-  ['@test Ember.run.debounce uses Backburner.debounce'](assert) {
-    run.debounce(() => {});
-    assert.ok(wasCalled, 'Ember.run.debounce used');
+  ['@test Ember.run.debounce - without target, without args'](assert) {
+    let done = assert.async();
+
+    let calledWith = [];
+    function someFunc(...args) {
+      calledWith.push(args);
+    }
+
+    run.debounce(someFunc, 10);
+    run.debounce(someFunc, 10);
+    run.debounce(someFunc, 10);
+
+    setTimeout(() => {
+      assert.deepEqual(calledWith, [ [] ], 'someFunc called once with correct arguments');
+      done();
+    }, 20);
+  }
+
+  ['@test Ember.run.debounce - without target, with args'](assert) {
+    let done = assert.async();
+
+    let calledWith = [];
+    function someFunc(...args) {
+      calledWith.push(args);
+    }
+
+    run.debounce(someFunc, { isFoo: true }, 10);
+    run.debounce(someFunc, { isBar: true }, 10);
+    run.debounce(someFunc, { isBaz: true }, 10);
+
+    setTimeout(() => {
+      assert.deepEqual(calledWith, [ [ { isBaz: true } ] ], 'someFunc called once with correct arguments');
+      done();
+    }, 20);
   }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1141,9 +1141,9 @@ backbone@^1.1.2:
   dependencies:
     underscore ">=1.8.3"
 
-backburner.js@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-2.0.0.tgz#ca78f7357776e24885f4dd4a887249b35fdd9c6c"
+backburner.js@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-2.0.2.tgz#d0049c0c6fd023084b66afeb82849f704ac6315e"
 
 backo2@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Update to backburner.js@2.0.2.

Fixes issues with calling `Ember.run.debounce(someFunction, timeDelay)`.  In Ember 2.18 and 3.0.0-beta.1 that would throw an error.