### PR TITLE
[BUGFIX release] Update to backburner@1.3.5.

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "babel-plugin-transform-proto-to-assign": "^6.23.0",
     "babel-template": "^6.24.1",
-    "backburner.js": "^1.3.4",
+    "backburner.js": "^1.3.5",
     "broccoli-babel-transpiler": "^6.1.1",
     "broccoli-concat": "^3.2.2",
     "broccoli-debug": "^0.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -877,9 +877,9 @@ backbone@^1.1.2:
   dependencies:
     underscore ">=1.8.3"
 
-backburner.js@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-1.3.4.tgz#42749db763615b3a754a91a863201a5fb4464d10"
+backburner.js@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-1.3.5.tgz#89ebd637f0ea10828588641ad043003f840e0a90"
 
 backo2@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Fixes issues with `run.debounce(someFunc, 1000)` in 2.18.