### PR TITLE
Add codeclimate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,33 @@
+version: "2"
+checks:
+  argument-count:
+    config:
+      threshold: 4
+  complex-logic:
+    config:
+      threshold: 4
+  file-lines:
+    enabled: false
+  method-complexity:
+    config:
+      threshold: 5
+  method-count:
+    enabled: false
+  method-lines:
+    config:
+      threshold: 25
+  nested-control-flow:
+    config:
+      threshold: 4
+  return-statements:
+    config:
+      threshold: 4
+  similar-code:
+    enabled: true
+  identical-code:
+    config:
+      threshold: # language-specific defaults. an override will affect all languages.
+exclude_patterns:
+  - "blueprints/**"
+  - "**/tests/**"
+  - "**/node-tests/**"


### PR DESCRIPTION
- Exclude tests (default codeclimate config excludes tests for other types of projects)
- Disable file-lines (# of lines in file complaints)
- Exclude blueprints (codeclimate errors on the templating)