### PR TITLE
[BUGFIX beta] Fix behaviour for set-only CP

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -143,6 +143,9 @@ function ComputedProperty(config, opts) {
     this._setter = config.set;
   }
   assert('Computed properties must receive a getter or a setter, you passed none.', !!this._getter || !!this._setter);
+  if (!this._getter) {
+    this._getter = () => undefined;
+  }
   this._suspended = undefined;
   this._meta = undefined;
   this._volatile = false;

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -101,6 +101,15 @@ QUnit.test('defining computed property should invoke property on set', function(
   assert.equal(get(obj, 'foo'), 'computed bar', 'should return new value');
 });
 
+QUnit.test('defining a computed property with only a set key returns undefined', function(assert) {
+  let obj = {};
+  defineProperty(obj, 'foo', computed({
+    set() {}
+  }));
+
+  assert.strictEqual(get(obj, 'foo'), undefined, 'returns undefined');
+});
+
 QUnit.test('defining a computed property with a dependent key ending with @each is expanded to []', function(assert) {
   let cp = computed('blazo.@each', function() { });
 


### PR DESCRIPTION
As explained in https://github.com/emberjs/ember.js/issues/15939,
_set-only_ properties raise an error when `get`ting them.

This PR makes this behaviour return undefined, as it would do
in the following vanilla-js case:

```js
class MyClass {
  set myProp(value) {
    console.log(value);
  }
}

let obj = new MyClass();
obj.myProp = 5; // outputs 5
console.log(obj.myProp); // outputs `undefined`
```

Fixes #15939