### PR TITLE
remove jquery from ember-testing

### DIFF
--- a/lib/packages.js
+++ b/lib/packages.js
@@ -9,7 +9,12 @@ module.exports = function() {
     'ember-runtime':              { trees: null,  vendorRequirements: ['rsvp'], requirements: ['container', 'ember-environment', 'ember-console', 'ember-metal'], requiresJQuery: false },
     'ember-views':                { trees: null,  requirements: ['ember-runtime'], skipTests: true },
     'ember-extension-support':    { trees: null,  requirements: ['ember-application'], requiresJQuery: false },
-    'ember-testing':              { trees: null,  requirements: ['ember-application', 'ember-routing'], testing: true },
+    'ember-testing':              { 
+      trees: null,  
+      requiresJQuery: false,
+      requirements: ['ember-application', 'ember-routing'], 
+      testing: true 
+    },
     'ember-template-compiler': {
       trees: null,
       templateCompilerOnly: true,

--- a/packages/ember-testing/lib/events.js
+++ b/packages/ember-testing/lib/events.js
@@ -1,5 +1,6 @@
-import { jQuery } from 'ember-views';
 import { run } from 'ember-metal';
+import { assign } from 'ember-utils';
+import isFormControl from './helpers/-is-form-control';
 
 const DEFAULT_EVENT_OPTIONS = { canBubble: true, cancelable: true };
 const KEYBOARD_EVENT_TYPES = ['keydown', 'keypress', 'keyup'];
@@ -7,19 +8,25 @@ const MOUSE_EVENT_TYPES = ['click', 'mousedown', 'mouseup', 'dblclick', 'mouseen
 
 export function focus(el) {
   if (!el) { return; }
-  let $el = jQuery(el);
-  if ($el.is(':input, [contenteditable=true]')) {
-    let type = $el.prop('type');
+  if (el.isContentEditable || isFormControl(el)) {
+    let type = el.getAttribute('type');
     if (type !== 'checkbox' && type !== 'radio' && type !== 'hidden') {
       run(null, function() {
-        // Firefox does not trigger the `focusin` event if the window
-        // does not have focus. If the document doesn't have focus just
-        // use trigger('focusin') instead.
+        let browserIsNotFocused = document.hasFocus && !document.hasFocus();
 
-        if (!document.hasFocus || document.hasFocus()) {
-          el.focus();
-        } else {
-          $el.trigger('focusin');
+        // makes `document.activeElement` be `element`. If the browser is focused, it also fires a focus event
+        el.focus();
+      
+        // Firefox does not trigger the `focusin` event if the window
+        // does not have focus. If the document does not have focus then
+        // fire `focusin` event as well.
+        if (browserIsNotFocused) {
+          // if the browser is not focused the previous `el.focus()` didn't fire an event, so we simulate it
+          fireEvent(el, 'focus', {
+            bubbles: false,
+          });
+      
+          fireEvent(el, 'focusin');
         }
       });
     }
@@ -43,7 +50,7 @@ export function fireEvent(element, type, options = {}) {
       clientX: x,
       clientY: y
     };
-    event = buildMouseEvent(type, jQuery.extend(simulatedCoordinates, options));
+    event = buildMouseEvent(type, assign(simulatedCoordinates, options));
   } else {
     event = buildBasicEvent(type, options);
   }
@@ -52,8 +59,16 @@ export function fireEvent(element, type, options = {}) {
 
 function buildBasicEvent(type, options = {}) {
   let event = document.createEvent('Events');
-  event.initEvent(type, true, true);
-  jQuery.extend(event, options);
+
+  // Event.bubbles is read only
+  let bubbles = options.bubbles !== undefined ? options.bubbles : true;
+  let cancelable = options.cancelable !== undefined ? options.cancelable : true;
+
+  delete options.bubbles;
+  delete options.cancelable;
+
+  event.initEvent(type, bubbles, cancelable);
+  assign(event, options);
   return event;
 }
 
@@ -61,7 +76,7 @@ function buildMouseEvent(type, options = {}) {
   let event;
   try {
     event = document.createEvent('MouseEvents');
-    let eventOpts = jQuery.extend({}, DEFAULT_EVENT_OPTIONS, options);
+    let eventOpts = assign({}, DEFAULT_EVENT_OPTIONS, options);
     event.initMouseEvent(
       type,
       eventOpts.canBubble,
@@ -88,7 +103,7 @@ function buildKeyboardEvent(type, options = {}) {
   let event;
   try {
     event = document.createEvent('KeyEvents');
-    let eventOpts = jQuery.extend({}, DEFAULT_EVENT_OPTIONS, options);
+    let eventOpts = assign({}, DEFAULT_EVENT_OPTIONS, options);
     event.initKeyEvent(
       type,
       eventOpts.canBubble,

--- a/packages/ember-testing/lib/helpers/-is-form-control.js
+++ b/packages/ember-testing/lib/helpers/-is-form-control.js
@@ -1,0 +1,16 @@
+const FORM_CONTROL_TAGS = ['INPUT', 'BUTTON', 'SELECT', 'TEXTAREA'];
+
+/**
+  @private
+  @param {Element} element the element to check
+  @returns {boolean} `true` when the element is a form control, `false` otherwise
+*/
+export default function isFormControl(element) {
+  let { tagName, type } = element;
+
+  if (type === 'hidden') {
+    return false;
+  }
+
+  return FORM_CONTROL_TAGS.indexOf(tagName) > -1;
+}

--- a/packages/ember-testing/lib/helpers/fill_in.js
+++ b/packages/ember-testing/lib/helpers/fill_in.js
@@ -2,6 +2,7 @@
 @module ember
 */
 import { focus, fireEvent } from '../events';
+import isFormControl from './-is-form-control';
 
 /**
   Fills in an input element with some text.
@@ -32,7 +33,12 @@ export default function fillIn(app, selector, contextOrText, text) {
   el = $el[0];
   focus(el);
 
-  $el.eq(0).val(text);
+  if (isFormControl(el)) {
+    el.value = text;
+  } else {
+    el.innerHTML = text;
+  }
+
   fireEvent(el, 'input');
   fireEvent(el, 'change');
 

--- a/packages/ember-testing/lib/helpers/find.js
+++ b/packages/ember-testing/lib/helpers/find.js
@@ -2,6 +2,8 @@
 @module ember
 */
 import { get } from 'ember-metal';
+import { assert } from 'ember-debug';
+import { jQueryDisabled } from 'ember-views';
 
 /**
   Finds an element in the context of the app's container element. A simple alias
@@ -20,13 +22,16 @@ import { get } from 'ember-metal';
   ```
 
   @method find
-  @param {String} selector jQuery string selector for element lookup
+  @param {String} selector jQuery selector for element lookup
   @param {String} [context] (optional) jQuery selector that will limit the selector
                             argument to find only within the context's children
-  @return {Object} jQuery object representing the results of the query
+  @return {Object} DOM element representing the results of the query
   @public
 */
 export default function find(app, selector, context) {
+  if (jQueryDisabled) {
+    assert('If jQuery is disabled, please import and use helpers from @ember/test-helpers [https://github.com/emberjs/ember-test-helpers]. Note: `find` is not an available helper.');
+  }
   let $el;
   context = context || get(app, 'rootElement');
   $el = app.$(selector, context);

--- a/packages/ember-testing/lib/helpers/find_with_assert.js
+++ b/packages/ember-testing/lib/helpers/find_with_assert.js
@@ -22,7 +22,7 @@
   @param {String} [context] (optional) jQuery selector that will limit the
   selector argument to find only within the context's children
   @return {Object} jQuery object representing the results of the query
-  @throws {Error} throws error if jQuery object returned has a length of 0
+  @throws {Error} throws error if object returned has a length of 0
   @public
 */
 export default function findWithAssert(app, selector, context) {

--- a/packages/ember-testing/lib/setup_for_testing.js
+++ b/packages/ember-testing/lib/setup_for_testing.js
@@ -1,7 +1,6 @@
 /* global self */
 
 import { setTesting } from 'ember-debug';
-import { jQuery } from 'ember-views';
 import {
   getAdapter,
   setAdapter
@@ -35,13 +34,11 @@ export default function setupForTesting() {
     setAdapter((typeof self.QUnit === 'undefined') ? new Adapter() : new QUnitAdapter());
   }
 
-  if (jQuery) {
-    jQuery(document).off('ajaxSend', incrementPendingRequests);
-    jQuery(document).off('ajaxComplete', decrementPendingRequests);
+  document.removeEventListener('ajaxSend', incrementPendingRequests);
+  document.removeEventListener('ajaxComplete', decrementPendingRequests);
 
-    clearPendingRequests();
+  clearPendingRequests();
 
-    jQuery(document).on('ajaxSend', incrementPendingRequests);
-    jQuery(document).on('ajaxComplete', decrementPendingRequests);
-  }
+  document.addEventListener('ajaxSend', incrementPendingRequests);
+  document.addEventListener('ajaxComplete', decrementPendingRequests);
 }

--- a/packages/ember-testing/lib/support.js
+++ b/packages/ember-testing/lib/support.js
@@ -43,7 +43,7 @@ if (environment.hasDOM && !jQueryDisabled) {
         $.event.special.click = {
           // For checkbox, fire native event so checked state will be right
           trigger() {
-            if ($.nodeName(this, 'input') && this.type === 'checkbox' && this.click) {
+            if (this.nodeName === 'INPUT' && this.type === 'checkbox' && this.click) {
               this.click();
               return false;
             }

--- a/packages/ember-testing/lib/test/pending_requests.js
+++ b/packages/ember-testing/lib/test/pending_requests.js
@@ -8,11 +8,13 @@ export function clearPendingRequests() {
   requests.length = 0;
 }
 
-export function incrementPendingRequests(_, xhr) {
+export function incrementPendingRequests({ detail } = { detail: { xhr: null }}) {
+  let xhr = detail.xhr;
   requests.push(xhr);
 }
 
-export function decrementPendingRequests(_, xhr) {
+export function decrementPendingRequests({ detail } = { detail: { xhr: null }}) {
+  let xhr = detail.xhr;
   for (let i = 0; i < requests.length; i++) {
     if (xhr === requests[i]) {
       requests.splice(i, 1);

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -8,382 +8,385 @@ import Test from '../test';
 import QUnitAdapter from '../adapters/qunit';
 import { Route } from 'ember-routing';
 import { RSVP } from 'ember-runtime';
+import { jQueryDisabled } from 'ember-views';
 
-moduleFor('ember-testing Acceptance', class extends AutobootApplicationTestCase {
-  constructor() {
-    super();
-    this._originalAdapter = Test.adapter;
+if (!jQueryDisabled) {
+  moduleFor('ember-testing Acceptance', class extends AutobootApplicationTestCase {
+    constructor() {
+      super();
+      this._originalAdapter = Test.adapter;
 
-    this.runTask(() => {
-      this.createApplication();
-      this.router.map(function() {
-        this.route('posts');
-        this.route('comments');
+      this.runTask(() => {
+        this.createApplication();
+        this.router.map(function() {
+          this.route('posts');
+          this.route('comments');
 
-        this.route('abort_transition');
+          this.route('abort_transition');
 
-        this.route('redirect');
-      });
-
-      this.indexHitCount = 0;
-      this.currentRoute = 'index';
-      let testContext = this;
-
-      this.add('route:index', Route.extend({
-        model() {
-          testContext.indexHitCount += 1;
-        }
-      }));
-
-      this.add('route:posts', Route.extend({
-        renderTemplate() {
-          testContext.currentRoute = 'posts';
-          this._super(...arguments);
-        }
-      }));
-
-      this.addTemplate('posts', `
-        <div class="posts-view">
-          <a class="dummy-link"></a>
-          <div id="comments-link">
-            {{#link-to \'comments\'}}Comments{{/link-to}}
-          </div>
-        </div>
-      `);
-
-      this.add('route:comments', Route.extend({
-        renderTemplate() {
-          testContext.currentRoute = 'comments';
-          this._super(...arguments);
-        }
-      }));
-
-      this.addTemplate('comments', `<div>{{input type="text"}}</div>`);
-
-      this.add('route:abort_transition', Route.extend({
-        beforeModel(transition) {
-          transition.abort();
-        }
-      }));
-
-      this.add('route:redirect', Route.extend({
-        beforeModel() {
-          this.transitionTo('comments');
-        }
-      }));
-
-      this.application.setupForTesting();
-
-      Test.registerAsyncHelper('slowHelper', () => {
-        return new RSVP.Promise(resolve => run.later(resolve, 10));
-      });
-
-      this.application.injectTestHelpers();
-    });
-  }
-
-  teardown() {
-    Test.adapter = this._originalAdapter;
-    super.teardown();
-  }
-
-  [`@test helpers can be chained with then`](assert) {
-    assert.expect(6);
-
-    window.visit('/posts').then(() => {
-      assert.equal(this.currentRoute, 'posts', 'Successfully visited posts route');
-      assert.equal(window.currentURL(), '/posts', 'posts URL is correct');
-      return window.click('a:contains("Comments")');
-    }).then(() => {
-      assert.equal(this.currentRoute, 'comments', 'visit chained with click');
-      return window.fillIn('.ember-text-field', 'yeah');
-    }).then(() => {
-      assert.equal(this.$('.ember-text-field').val(), 'yeah', 'chained with fillIn');
-      return window.fillIn('.ember-text-field', '#qunit-fixture', 'context working');
-    }).then(() => {
-      assert.equal(this.$('.ember-text-field').val(), 'context working', 'chained with fillIn');
-      return window.click('.does-not-exist');
-    }).catch(e => {
-      assert.equal(e.message, 'Element .does-not-exist not found.', 'Non-existent click exception caught');
-    });
-  }
-
-  [`@test helpers can be chained to each other (legacy)`](assert) {
-    assert.expect(7);
-
-    window.visit('/posts')
-      .click('a:first', '#comments-link')
-      .fillIn('.ember-text-field', 'hello')
-      .then(() => {
-        assert.equal(this.currentRoute, 'comments', 'Successfully visited comments route');
-        assert.equal(window.currentURL(), '/comments', 'Comments URL is correct');
-        assert.equal(this.$('.ember-text-field').val(), 'hello', 'Fillin successfully works');
-        window.find('.ember-text-field').one('keypress', e => {
-          assert.equal(e.keyCode, 13, 'keyevent chained with correct keyCode.');
-          assert.equal(e.which, 13, 'keyevent chained with correct which.');
+          this.route('redirect');
         });
-      })
-      .keyEvent('.ember-text-field', 'keypress', 13)
-      .visit('/posts')
-      .then(() => {
-        assert.equal(this.currentRoute, 'posts', 'Thens can also be chained to helpers');
-        assert.equal(window.currentURL(), '/posts', 'URL is set correct on chained helpers');
-      });
-  }
 
-  [`@test helpers don't need to be chained`](assert) {
-    assert.expect(5);
+        this.indexHitCount = 0;
+        this.currentRoute = 'index';
+        let testContext = this;
 
-    window.visit('/posts');
+        this.add('route:index', Route.extend({
+          model() {
+            testContext.indexHitCount += 1;
+          }
+        }));
 
-    window.click('a:first', '#comments-link');
+        this.add('route:posts', Route.extend({
+          renderTemplate() {
+            testContext.currentRoute = 'posts';
+            this._super(...arguments);
+          }
+        }));
 
-    window.fillIn('.ember-text-field', 'hello');
+        this.addTemplate('posts', `
+          <div class="posts-view">
+            <a class="dummy-link"></a>
+            <div id="comments-link">
+              {{#link-to \'comments\'}}Comments{{/link-to}}
+            </div>
+          </div>
+        `);
 
-    window.andThen(() => {
-      assert.equal(this.currentRoute, 'comments', 'Successfully visited comments route');
-      assert.equal(window.currentURL(), '/comments', 'Comments URL is correct');
-      assert.equal(window.find('.ember-text-field').val(), 'hello', 'Fillin successfully works');
-    });
+        this.add('route:comments', Route.extend({
+          renderTemplate() {
+            testContext.currentRoute = 'comments';
+            this._super(...arguments);
+          }
+        }));
 
-    window.visit('/posts');
+        this.addTemplate('comments', `<div>{{input type="text"}}</div>`);
 
-    window.andThen(() => {
-      assert.equal(this.currentRoute, 'posts');
-      assert.equal(window.currentURL(), '/posts');
-    });
-  }
+        this.add('route:abort_transition', Route.extend({
+          beforeModel(transition) {
+            transition.abort();
+          }
+        }));
 
-  [`@test Nested async helpers`](assert) {
-    assert.expect(5);
+        this.add('route:redirect', Route.extend({
+          beforeModel() {
+            this.transitionTo('comments');
+          }
+        }));
 
-    window.visit('/posts');
+        this.application.setupForTesting();
 
-    window.andThen(() => {
-      window.click('a:first', '#comments-link');
-      window.fillIn('.ember-text-field', 'hello');
-    });
+        Test.registerAsyncHelper('slowHelper', () => {
+          return new RSVP.Promise(resolve => run.later(resolve, 10));
+        });
 
-    window.andThen(() => {
-      assert.equal(this.currentRoute, 'comments', 'Successfully visited comments route');
-      assert.equal(window.currentURL(), '/comments', 'Comments URL is correct');
-      assert.equal(window.find('.ember-text-field').val(), 'hello', 'Fillin successfully works');
-    });
-
-    window.visit('/posts');
-
-    window.andThen(() => {
-      assert.equal(this.currentRoute, 'posts');
-      assert.equal(window.currentURL(), '/posts');
-    });
-  }
-
-  [`@test Multiple nested async helpers`](assert) {
-    assert.expect(3);
-
-    window.visit('/posts');
-
-    window.andThen(() => {
-      window.click('a:first', '#comments-link');
-
-      window.fillIn('.ember-text-field', 'hello');
-      window.fillIn('.ember-text-field', 'goodbye');
-    });
-
-    window.andThen(() => {
-      assert.equal(window.find('.ember-text-field').val(), 'goodbye', 'Fillin successfully works');
-      assert.equal(this.currentRoute, 'comments', 'Successfully visited comments route');
-      assert.equal(window.currentURL(), '/comments', 'Comments URL is correct');
-    });
-  }
-
-  [`@test Helpers nested in thens`](assert) {
-    assert.expect(5);
-
-    window.visit('/posts').then(() => {
-      window.click('a:first', '#comments-link');
-    });
-
-    window.andThen(() => {
-      window.fillIn('.ember-text-field', 'hello');
-    });
-
-    window.andThen(() => {
-      assert.equal(this.currentRoute, 'comments', 'Successfully visited comments route');
-      assert.equal(window.currentURL(), '/comments', 'Comments URL is correct');
-      assert.equal(window.find('.ember-text-field').val(), 'hello', 'Fillin successfully works');
-    });
-
-    window.visit('/posts');
-
-    window.andThen(() => {
-      assert.equal(this.currentRoute, 'posts');
-      assert.equal(window.currentURL(), '/posts', 'Posts URL is correct');
-    });
-  }
-
-  [`@test Aborted transitions are not logged via Ember.Test.adapter#exception`](assert) {
-    assert.expect(0);
-
-    Test.adapter = QUnitAdapter.create({
-      exception() {
-        assert.ok(false, 'aborted transitions are not logged');
-      }
-    });
-
-    window.visit('/abort_transition');
-  }
-
-  [`@test Unhandled exceptions are logged via Ember.Test.adapter#exception`](assert) {
-    assert.expect(2);
-
-    let asyncHandled;
-    Test.adapter = QUnitAdapter.create({
-      exception(error) {
-        assert.equal(
-          error.message, 'Element .does-not-exist not found.',
-          'Exception successfully caught and passed to Ember.Test.adapter.exception'
-        );
-        // handle the rejection so it doesn't leak later.
-        asyncHandled.catch(() => { });
-      }
-    });
-
-    window.visit('/posts');
-
-    window.click('.invalid-element').catch(error => {
-      assert.equal(
-        error.message, 'Element .invalid-element not found.',
-        'Exception successfully handled in the rejection handler'
-      );
-    });
-
-    asyncHandled = window.click('.does-not-exist');
-  }
-
-  [`@test Unhandled exceptions in 'andThen' are logged via Ember.Test.adapter#exception`](assert) {
-    assert.expect(1);
-
-    Test.adapter = QUnitAdapter.create({
-      exception(error) {
-        assert.equal(
-          error.message, 'Catch me',
-          'Exception successfully caught and passed to Ember.Test.adapter.exception'
-        );
-      }
-    });
-
-    window.visit('/posts');
-
-    window.andThen(() => {
-      throw new Error('Catch me');
-    });
-  }
-
-  [`@test should not start routing on the root URL when visiting another`](assert) {
-    assert.expect(4);
-
-    window.visit('/posts');
-
-    window.andThen(() => {
-      assert.ok(window.find('#comments-link'), 'found comments-link');
-      assert.equal(this.currentRoute, 'posts', 'Successfully visited posts route');
-      assert.equal(window.currentURL(), '/posts', 'Posts URL is correct');
-      assert.equal(this.indexHitCount, 0, 'should not hit index route when visiting another route');
-    });
-  }
-
-  [`@test only enters the index route once when visiting `](assert) {
-    assert.expect(1);
-
-    window.visit('/');
-
-    window.andThen(() => {
-      assert.equal(this.indexHitCount, 1, 'should hit index once when visiting /');
-    });
-  }
-
-  [`@test test must not finish while asyncHelpers are pending`](assert) {
-    assert.expect(2);
-
-    let async = 0;
-    let innerRan = false;
-
-    Test.adapter = QUnitAdapter.extend({
-      asyncStart() {
-        async++;
-        this._super();
-      },
-      asyncEnd() {
-        async--;
-        this._super();
-      }
-    }).create();
-
-    this.application.testHelpers.slowHelper();
-
-    window.andThen(() => {
-      innerRan = true;
-    });
-
-    assert.equal(innerRan, false, 'should not have run yet');
-    assert.ok(async > 0, 'should have told the adapter to pause');
-
-    if (async === 0) {
-      // If we failed the test, prevent zalgo from escaping and breaking
-      // our other tests.
-      Test.adapter.asyncStart();
-      Test.resolve().then(() => {
-        Test.adapter.asyncEnd();
+        this.application.injectTestHelpers();
       });
     }
-  }
 
-  [`@test visiting a URL that causes another transition should yield the correct URL`](assert) {
-    assert.expect(1);
+    teardown() {
+      Test.adapter = this._originalAdapter;
+      super.teardown();
+    }
 
-    window.visit('/redirect');
+    [`@test helpers can be chained with then`](assert) {
+      assert.expect(6);
 
-    window.andThen(() => {
-      assert.equal(window.currentURL(), '/comments', 'Redirected to Comments URL');
-    });
-  }
+      window.visit('/posts').then(() => {
+        assert.equal(this.currentRoute, 'posts', 'Successfully visited posts route');
+        assert.equal(window.currentURL(), '/posts', 'posts URL is correct');
+        return window.click('a:contains("Comments")');
+      }).then(() => {
+        assert.equal(this.currentRoute, 'comments', 'visit chained with click');
+        return window.fillIn('.ember-text-field', 'yeah');
+      }).then(() => {
+        assert.equal(document.querySelector('.ember-text-field').value, 'yeah', 'chained with fillIn');
+        return window.fillIn('.ember-text-field', '#qunit-fixture', 'context working');
+      }).then(() => {
+        assert.equal(document.querySelector('.ember-text-field').value, 'context working', 'chained with fillIn');
+        return window.click('.does-not-exist');
+      }).catch(e => {
+        assert.equal(e.message, 'Element .does-not-exist not found.', 'Non-existent click exception caught');
+      });
+    }
 
-  [`@test visiting a URL and then visiting a second URL with a transition should yield the correct URL`](assert) {
-    assert.expect(2);
+    [`@test helpers can be chained to each other (legacy)`](assert) {
+      assert.expect(7);
 
-    window.visit('/posts');
+      window.visit('/posts')
+        .click('a:first', '#comments-link')
+        .fillIn('.ember-text-field', 'hello')
+        .then(() => {
+          assert.equal(this.currentRoute, 'comments', 'Successfully visited comments route');
+          assert.equal(window.currentURL(), '/comments', 'Comments URL is correct');
+          assert.equal(document.querySelector('.ember-text-field').value, 'hello', 'Fillin successfully works');
+          window.find('.ember-text-field').one('keypress', e => {
+            assert.equal(e.keyCode, 13, 'keyevent chained with correct keyCode.');
+            assert.equal(e.which, 13, 'keyevent chained with correct which.');
+          });
+        })
+        .keyEvent('.ember-text-field', 'keypress', 13)
+        .visit('/posts')
+        .then(() => {
+          assert.equal(this.currentRoute, 'posts', 'Thens can also be chained to helpers');
+          assert.equal(window.currentURL(), '/posts', 'URL is set correct on chained helpers');
+        });
+    }
 
-    window.andThen(function () {
-      assert.equal(window.currentURL(), '/posts', 'First visited URL is correct');
-    });
+    [`@test helpers don't need to be chained`](assert) {
+      assert.expect(5);
 
-    window.visit('/redirect');
+      window.visit('/posts');
 
-    window.andThen(() => {
-      assert.equal(window.currentURL(), '/comments', 'Redirected to Comments URL');
-    });
-  }
+      window.click('a:first', '#comments-link');
 
-});
+      window.fillIn('.ember-text-field', 'hello');
 
-moduleFor('ember-testing Acceptance - teardown', class extends AutobootApplicationTestCase {
+      window.andThen(() => {
+        assert.equal(this.currentRoute, 'comments', 'Successfully visited comments route');
+        assert.equal(window.currentURL(), '/comments', 'Comments URL is correct');
+        assert.equal(window.find('.ember-text-field').val(), 'hello', 'Fillin successfully works');
+      });
 
-  [`@test that the setup/teardown happens correctly`](assert) {
-    assert.expect(2);
+      window.visit('/posts');
 
-    this.runTask(() => {
-      this.createApplication();
-    });
-    this.application.injectTestHelpers();
+      window.andThen(() => {
+        assert.equal(this.currentRoute, 'posts');
+        assert.equal(window.currentURL(), '/posts');
+      });
+    }
 
-    assert.ok(typeof Test.Promise.prototype.click === 'function');
+    [`@test Nested async helpers`](assert) {
+      assert.expect(5);
 
-    this.runTask(() => {
-      this.application.destroy();
-    });
+      window.visit('/posts');
 
-    assert.equal(Test.Promise.prototype.click, undefined);
-  }
+      window.andThen(() => {
+        window.click('a:first', '#comments-link');
+        window.fillIn('.ember-text-field', 'hello');
+      });
 
-});
+      window.andThen(() => {
+        assert.equal(this.currentRoute, 'comments', 'Successfully visited comments route');
+        assert.equal(window.currentURL(), '/comments', 'Comments URL is correct');
+        assert.equal(window.find('.ember-text-field').val(), 'hello', 'Fillin successfully works');
+      });
+
+      window.visit('/posts');
+
+      window.andThen(() => {
+        assert.equal(this.currentRoute, 'posts');
+        assert.equal(window.currentURL(), '/posts');
+      });
+    }
+
+    [`@test Multiple nested async helpers`](assert) {
+      assert.expect(3);
+
+      window.visit('/posts');
+
+      window.andThen(() => {
+        window.click('a:first', '#comments-link');
+
+        window.fillIn('.ember-text-field', 'hello');
+        window.fillIn('.ember-text-field', 'goodbye');
+      });
+
+      window.andThen(() => {
+        assert.equal(window.find('.ember-text-field').val(), 'goodbye', 'Fillin successfully works');
+        assert.equal(this.currentRoute, 'comments', 'Successfully visited comments route');
+        assert.equal(window.currentURL(), '/comments', 'Comments URL is correct');
+      });
+    }
+
+    [`@test Helpers nested in thens`](assert) {
+      assert.expect(5);
+
+      window.visit('/posts').then(() => {
+        window.click('a:first', '#comments-link');
+      });
+
+      window.andThen(() => {
+        window.fillIn('.ember-text-field', 'hello');
+      });
+
+      window.andThen(() => {
+        assert.equal(this.currentRoute, 'comments', 'Successfully visited comments route');
+        assert.equal(window.currentURL(), '/comments', 'Comments URL is correct');
+        assert.equal(window.find('.ember-text-field').val(), 'hello', 'Fillin successfully works');
+      });
+
+      window.visit('/posts');
+
+      window.andThen(() => {
+        assert.equal(this.currentRoute, 'posts');
+        assert.equal(window.currentURL(), '/posts', 'Posts URL is correct');
+      });
+    }
+
+    [`@test Aborted transitions are not logged via Ember.Test.adapter#exception`](assert) {
+      assert.expect(0);
+
+      Test.adapter = QUnitAdapter.create({
+        exception() {
+          assert.ok(false, 'aborted transitions are not logged');
+        }
+      });
+
+      window.visit('/abort_transition');
+    }
+
+    [`@test Unhandled exceptions are logged via Ember.Test.adapter#exception`](assert) {
+      assert.expect(2);
+
+      let asyncHandled;
+      Test.adapter = QUnitAdapter.create({
+        exception(error) {
+          assert.equal(
+            error.message, 'Element .does-not-exist not found.',
+            'Exception successfully caught and passed to Ember.Test.adapter.exception'
+          );
+          // handle the rejection so it doesn't leak later.
+          asyncHandled.catch(() => { });
+        }
+      });
+
+      window.visit('/posts');
+
+      window.click('.invalid-element').catch(error => {
+        assert.equal(
+          error.message, 'Element .invalid-element not found.',
+          'Exception successfully handled in the rejection handler'
+        );
+      });
+
+      asyncHandled = window.click('.does-not-exist');
+    }
+
+    [`@test Unhandled exceptions in 'andThen' are logged via Ember.Test.adapter#exception`](assert) {
+      assert.expect(1);
+
+      Test.adapter = QUnitAdapter.create({
+        exception(error) {
+          assert.equal(
+            error.message, 'Catch me',
+            'Exception successfully caught and passed to Ember.Test.adapter.exception'
+          );
+        }
+      });
+
+      window.visit('/posts');
+
+      window.andThen(() => {
+        throw new Error('Catch me');
+      });
+    }
+
+    [`@test should not start routing on the root URL when visiting another`](assert) {
+      assert.expect(4);
+
+      window.visit('/posts');
+
+      window.andThen(() => {
+        assert.ok(window.find('#comments-link'), 'found comments-link');
+        assert.equal(this.currentRoute, 'posts', 'Successfully visited posts route');
+        assert.equal(window.currentURL(), '/posts', 'Posts URL is correct');
+        assert.equal(this.indexHitCount, 0, 'should not hit index route when visiting another route');
+      });
+    }
+
+    [`@test only enters the index route once when visiting `](assert) {
+      assert.expect(1);
+
+      window.visit('/');
+
+      window.andThen(() => {
+        assert.equal(this.indexHitCount, 1, 'should hit index once when visiting /');
+      });
+    }
+
+    [`@test test must not finish while asyncHelpers are pending`](assert) {
+      assert.expect(2);
+
+      let async = 0;
+      let innerRan = false;
+
+      Test.adapter = QUnitAdapter.extend({
+        asyncStart() {
+          async++;
+          this._super();
+        },
+        asyncEnd() {
+          async--;
+          this._super();
+        }
+      }).create();
+
+      this.application.testHelpers.slowHelper();
+
+      window.andThen(() => {
+        innerRan = true;
+      });
+
+      assert.equal(innerRan, false, 'should not have run yet');
+      assert.ok(async > 0, 'should have told the adapter to pause');
+
+      if (async === 0) {
+        // If we failed the test, prevent zalgo from escaping and breaking
+        // our other tests.
+        Test.adapter.asyncStart();
+        Test.resolve().then(() => {
+          Test.adapter.asyncEnd();
+        });
+      }
+    }
+
+    [`@test visiting a URL that causes another transition should yield the correct URL`](assert) {
+      assert.expect(1);
+
+      window.visit('/redirect');
+
+      window.andThen(() => {
+        assert.equal(window.currentURL(), '/comments', 'Redirected to Comments URL');
+      });
+    }
+
+    [`@test visiting a URL and then visiting a second URL with a transition should yield the correct URL`](assert) {
+      assert.expect(2);
+
+      window.visit('/posts');
+
+      window.andThen(function () {
+        assert.equal(window.currentURL(), '/posts', 'First visited URL is correct');
+      });
+
+      window.visit('/redirect');
+
+      window.andThen(() => {
+        assert.equal(window.currentURL(), '/comments', 'Redirected to Comments URL');
+      });
+    }
+
+  });
+
+  moduleFor('ember-testing Acceptance - teardown', class extends AutobootApplicationTestCase {
+
+    [`@test that the setup/teardown happens correctly`](assert) {
+      assert.expect(2);
+
+      this.runTask(() => {
+        this.createApplication();
+      });
+      this.application.injectTestHelpers();
+
+      assert.ok(typeof Test.Promise.prototype.click === 'function');
+
+      this.runTask(() => {
+        this.application.destroy();
+      });
+
+      assert.equal(Test.Promise.prototype.click, undefined);
+    }
+
+  });
+}

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -9,10 +9,10 @@ import {
   RSVP
 } from 'ember-runtime';
 import { run } from 'ember-metal';
-import { jQuery } from 'ember-views';
 import {
   Component,
 } from 'ember-glimmer';
+import { jQueryDisabled } from 'ember-views';
 
 import Test from '../test';
 import setupForTesting from '../setup_for_testing';
@@ -20,7 +20,8 @@ import setupForTesting from '../setup_for_testing';
 import {
   pendingRequests,
   incrementPendingRequests,
-  clearPendingRequests
+  decrementPendingRequests,
+  clearPendingRequests,
 } from '../test/pending_requests';
 import {
   setAdapter,
@@ -33,6 +34,12 @@ import {
 
 function registerHelper() {
   Test.registerHelper('LeakyMcLeakLeak', () => {});
+}
+
+function customEvent(name, xhr) {
+  let event = document.createEvent('CustomEvent');
+  event.initCustomEvent(name, true, true, { xhr });
+  document.dispatchEvent(event);
 }
 
 function assertHelpers(assert, application, helperContainer, expected) {
@@ -74,8 +81,8 @@ class HelpersTestCase extends AutobootApplicationTestCase {
 
   teardown() {
     setAdapter(this._originalAdapter);
-    jQuery(document).off('ajaxSend');
-    jQuery(document).off('ajaxComplete');
+    document.removeEventListener('ajaxSend', incrementPendingRequests);
+    document.removeEventListener('ajaxComplete', decrementPendingRequests);
     clearPendingRequests();
     if (this.application) {
       this.application.removeTestHelpers();
@@ -96,1168 +103,1133 @@ class HelpersApplicationTestCase extends HelpersTestCase {
   }
 }
 
-moduleFor('ember-testing: Helper setup', class extends HelpersTestCase {
+if (!jQueryDisabled) {
+  moduleFor('ember-testing: Helper setup', class extends HelpersTestCase {
 
-  [`@test Ember.Application#injectTestHelpers/#removeTestHelper`](assert) {
-    this.runTask(() => {
-      this.createApplication();
-    });
+    [`@test Ember.Application#injectTestHelpers/#removeTestHelper`](assert) {
+      this.runTask(() => {
+        this.createApplication();
+      });
 
-    assertNoHelpers(assert, this.application);
+      assertNoHelpers(assert, this.application);
 
-    registerHelper();
+      registerHelper();
 
-    this.application.injectTestHelpers();
+      this.application.injectTestHelpers();
 
-    assertHelpers(assert, this.application);
+      assertHelpers(assert, this.application);
 
-    assert.ok(
-      Test.Promise.prototype.LeakyMcLeakLeak,
-      'helper in question SHOULD be present'
-    );
+      assert.ok(
+        Test.Promise.prototype.LeakyMcLeakLeak,
+        'helper in question SHOULD be present'
+      );
 
-    this.application.removeTestHelpers();
+      this.application.removeTestHelpers();
 
-    assertNoHelpers(assert, this.application);
+      assertNoHelpers(assert, this.application);
 
-    assert.equal(
-      Test.Promise.prototype.LeakyMcLeakLeak, undefined,
-      'should NOT leak test promise extensions'
-    );
-  }
-
-  [`@test Ember.Application#setupForTesting`](assert) {
-    this.runTask(() => {
-      this.createApplication();
-      this.application.setupForTesting();
-    });
-
-    let routerInstance = this.applicationInstance.lookup('router:main');
-    assert.equal(routerInstance.location, 'none');
-  }
-
-  [`@test Ember.Application.setupForTesting sets the application to 'testing'`](assert) {
-    this.runTask(() => {
-      this.createApplication();
-      this.application.setupForTesting();
-    });
-
-    assert.equal(
-      this.application.testing, true,
-      'Application instance is set to testing.'
-    );
-  }
-
-  [`@test Ember.Application.setupForTesting leaves the system in a deferred state.`](assert) {
-    this.runTask(() => {
-      this.createApplication();
-      this.application.setupForTesting();
-    });
-
-    assert.equal(
-      this.application._readinessDeferrals, 1,
-      'App is in deferred state after setupForTesting.'
-    );
-  }
-
-  [`@test App.reset() after Application.setupForTesting leaves the system in a deferred state.`](assert) {
-    this.runTask(() => {
-      this.createApplication();
-      this.application.setupForTesting();
-    });
-
-    assert.equal(
-      this.application._readinessDeferrals, 1,
-      'App is in deferred state after setupForTesting.'
-    );
-
-    this.application.reset();
-
-    assert.equal(
-      this.application._readinessDeferrals, 1,
-      'App is in deferred state after setupForTesting.'
-    );
-  }
-
-  [`@test #setupForTesting attaches ajax listeners`](assert) {
-    let documentEvents = jQuery._data(document, 'events') || {};
-
-    assert.ok(
-      documentEvents['ajaxSend'] === undefined,
-      'there are no ajaxSend listers setup prior to calling injectTestHelpers'
-    );
-    assert.ok(
-      documentEvents['ajaxComplete'] === undefined,
-      'there are no ajaxComplete listers setup prior to calling injectTestHelpers'
-    );
-
-    setupForTesting();
-
-    documentEvents = jQuery._data(document, 'events');
-
-    assert.equal(
-      documentEvents['ajaxSend'].length, 1,
-      'calling injectTestHelpers registers an ajaxSend handler'
-    );
-    assert.equal(
-      documentEvents['ajaxComplete'].length, 1,
-      'calling injectTestHelpers registers an ajaxComplete handler'
-    );
-  }
-
-  [`@test #setupForTesting attaches ajax listeners only once`](assert) {
-    let documentEvents = jQuery._data(document, 'events') || {};
-
-    assert.ok(
-      documentEvents['ajaxSend'] === undefined,
-      'there are no ajaxSend listeners setup prior to calling injectTestHelpers'
-    );
-    assert.ok(
-      documentEvents['ajaxComplete'] === undefined,
-      'there are no ajaxComplete listeners setup prior to calling injectTestHelpers'
-    );
-
-    setupForTesting();
-    setupForTesting();
-
-    documentEvents = jQuery._data(document, 'events');
-
-    assert.equal(
-      documentEvents['ajaxSend'].length, 1,
-      'calling injectTestHelpers registers an ajaxSend handler'
-    );
-    assert.equal(
-      documentEvents['ajaxComplete'].length, 1,
-      'calling injectTestHelpers registers an ajaxComplete handler'
-    );
-  }
-
-  [`@test Ember.Application#injectTestHelpers calls callbacks registered with onInjectHelpers`](assert) {
-    let injected = 0;
-
-    Test.onInjectHelpers(() => {
-      injected++;
-    });
-
-    this.runTask(() => {
-      this.createApplication();
-      this.application.setupForTesting();
-    });
-
-    assert.equal(
-      injected, 0,
-      'onInjectHelpers are not called before injectTestHelpers'
-    );
-
-    this.application.injectTestHelpers();
-
-    assert.equal(
-      injected, 1,
-      'onInjectHelpers are called after injectTestHelpers'
-    );
-  }
-
-  [`@test Ember.Application#injectTestHelpers adds helpers to provided object.`](assert) {
-    let helpers = {};
-
-    this.runTask(() => {
-      this.createApplication();
-      this.application.setupForTesting();
-    });
-
-    this.application.injectTestHelpers(helpers);
-
-    assertHelpers(assert, this.application, helpers);
-
-    this.application.removeTestHelpers();
-
-    assertNoHelpers(assert, this.application, helpers);
-  }
-
-  [`@test Ember.Application#removeTestHelpers resets the helperContainer\'s original values`](assert) {
-    let helpers = { visit: 'snazzleflabber' };
-
-    this.runTask(() => {
-      this.createApplication();
-      this.application.setupForTesting();
-    });
-
-    this.application.injectTestHelpers(helpers);
-
-    assert.notEqual(
-      helpers.visit, 'snazzleflabber',
-      'helper added to container'
-    );
-    this.application.removeTestHelpers();
-
-    assert.equal(
-      helpers.visit, 'snazzleflabber',
-      'original value added back to container'
-    );
-  }
-
-});
-
-moduleFor('ember-testing: Helper methods', class extends HelpersApplicationTestCase {
-
-  [`@test 'wait' respects registerWaiters`](assert) {
-    assert.expect(3);
-
-    let counter = 0;
-    function waiter() {
-      return ++counter > 2;
+      assert.equal(
+        Test.Promise.prototype.LeakyMcLeakLeak, undefined,
+        'should NOT leak test promise extensions'
+      );
     }
 
-    let other = 0;
-    function otherWaiter() {
-      return ++other > 2;
+    [`@test Ember.Application#setupForTesting`](assert) {
+      this.runTask(() => {
+        this.createApplication();
+        this.application.setupForTesting();
+      });
+
+      let routerInstance = this.applicationInstance.lookup('router:main');
+      assert.equal(routerInstance.location, 'none');
     }
 
-    this.runTask(() => {
-      this.application.advanceReadiness();
-    });
+    [`@test Ember.Application.setupForTesting sets the application to 'testing'`](assert) {
+      this.runTask(() => {
+        this.createApplication();
+        this.application.setupForTesting();
+      });
 
-    registerWaiter(waiter);
-    registerWaiter(otherWaiter);
-
-    let {application: {testHelpers}} = this;
-    return testHelpers.wait().then(() => {
       assert.equal(
-        waiter(), true,
-        'should not resolve until our waiter is ready'
+        this.application.testing, true,
+        'Application instance is set to testing.'
       );
-      unregisterWaiter(waiter);
-      counter = 0;
-      return testHelpers.wait();
-    }).then(() => {
+    }
+
+    [`@test Ember.Application.setupForTesting leaves the system in a deferred state.`](assert) {
+      this.runTask(() => {
+        this.createApplication();
+        this.application.setupForTesting();
+      });
+
       assert.equal(
-        counter, 0,
-        'unregistered waiter was not checked'
+        this.application._readinessDeferrals, 1,
+        'App is in deferred state after setupForTesting.'
       );
+    }
+
+    [`@test App.reset() after Application.setupForTesting leaves the system in a deferred state.`](assert) {
+      this.runTask(() => {
+        this.createApplication();
+        this.application.setupForTesting();
+      });
+
       assert.equal(
-        otherWaiter(), true,
-        'other waiter is still registered'
+        this.application._readinessDeferrals, 1,
+        'App is in deferred state after setupForTesting.'
       );
-    }).finally(() => {
-      unregisterWaiter(otherWaiter);
-    });
-  }
 
-  [`@test 'visit' advances readiness.`](assert) {
-    assert.expect(2);
+      this.application.reset();
 
-    assert.equal(
-      this.application._readinessDeferrals, 1,
-      'App is in deferred state after setupForTesting.'
-    );
-
-    return this.application.testHelpers.visit('/').then(() => {
       assert.equal(
-        this.application._readinessDeferrals, 0,
-        `App's readiness was advanced by visit.`
+        this.application._readinessDeferrals, 1,
+        'App is in deferred state after setupForTesting.'
       );
-    });
-  }
+    }
 
-  [`@test 'wait' helper can be passed a resolution value`](assert) {
-    assert.expect(4);
+    [`@test Ember.Application#injectTestHelpers calls callbacks registered with onInjectHelpers`](assert) {
+      let injected = 0;
 
-    this.runTask(() => {
-      this.application.advanceReadiness();
-    });
+      Test.onInjectHelpers(() => {
+        injected++;
+      });
 
-    let promiseObjectValue = {};
-    let objectValue = {};
-    let {application: {testHelpers}} = this;
-    return testHelpers.wait('text').then(val => {
+      this.runTask(() => {
+        this.createApplication();
+        this.application.setupForTesting();
+      });
+
       assert.equal(
-        val, 'text',
-        'can resolve to a string'
+        injected, 0,
+        'onInjectHelpers are not called before injectTestHelpers'
       );
-      return testHelpers.wait(1);
-    }).then(val => {
-      assert.equal(
-        val, 1,
-        'can resolve to an integer'
-      );
-      return testHelpers.wait(objectValue);
-    }).then(val => {
-      assert.equal(
-        val, objectValue,
-        'can resolve to an object'
-      );
-      return testHelpers.wait(RSVP.resolve(promiseObjectValue));
-    }).then(val => {
-      assert.equal(
-        val, promiseObjectValue,
-        'can resolve to a promise resolution value'
-      );
-    });
-  }
 
-  [`@test 'click' triggers appropriate events in order`](assert) {
-    assert.expect(5);
+      this.application.injectTestHelpers();
 
-    this.add('component:index-wrapper', Component.extend({
-      classNames: 'index-wrapper',
+      assert.equal(
+        injected, 1,
+        'onInjectHelpers are called after injectTestHelpers'
+      );
+    }
 
-      didInsertElement() {
-        this.$().on('mousedown focusin mouseup click', e => {
-          events.push(e.type);
+    [`@test Ember.Application#injectTestHelpers adds helpers to provided object.`](assert) {
+      let helpers = {};
+
+      this.runTask(() => {
+        this.createApplication();
+        this.application.setupForTesting();
+      });
+
+      this.application.injectTestHelpers(helpers);
+
+      assertHelpers(assert, this.application, helpers);
+
+      this.application.removeTestHelpers();
+
+      assertNoHelpers(assert, this.application, helpers);
+    }
+
+    [`@test Ember.Application#removeTestHelpers resets the helperContainer\'s original values`](assert) {
+      let helpers = { visit: 'snazzleflabber' };
+
+      this.runTask(() => {
+        this.createApplication();
+        this.application.setupForTesting();
+      });
+
+      this.application.injectTestHelpers(helpers);
+
+      assert.notEqual(
+        helpers.visit, 'snazzleflabber',
+        'helper added to container'
+      );
+      this.application.removeTestHelpers();
+
+      assert.equal(
+        helpers.visit, 'snazzleflabber',
+        'original value added back to container'
+      );
+    }
+
+  });
+
+  moduleFor('ember-testing: Helper methods', class extends HelpersApplicationTestCase {
+
+    [`@test 'wait' respects registerWaiters`](assert) {
+      assert.expect(3);
+
+      let counter = 0;
+      function waiter() {
+        return ++counter > 2;
+      }
+
+      let other = 0;
+      function otherWaiter() {
+        return ++other > 2;
+      }
+
+      this.runTask(() => {
+        this.application.advanceReadiness();
+      });
+
+      registerWaiter(waiter);
+      registerWaiter(otherWaiter);
+
+      let {application: {testHelpers}} = this;
+      return testHelpers.wait().then(() => {
+        assert.equal(
+          waiter(), true,
+          'should not resolve until our waiter is ready'
+        );
+        unregisterWaiter(waiter);
+        counter = 0;
+        return testHelpers.wait();
+      }).then(() => {
+        assert.equal(
+          counter, 0,
+          'unregistered waiter was not checked'
+        );
+        assert.equal(
+          otherWaiter(), true,
+          'other waiter is still registered'
+        );
+      }).finally(() => {
+        unregisterWaiter(otherWaiter);
+      });
+    }
+
+    [`@test 'visit' advances readiness.`](assert) {
+      assert.expect(2);
+
+      assert.equal(
+        this.application._readinessDeferrals, 1,
+        'App is in deferred state after setupForTesting.'
+      );
+
+      return this.application.testHelpers.visit('/').then(() => {
+        assert.equal(
+          this.application._readinessDeferrals, 0,
+          `App's readiness was advanced by visit.`
+        );
+      });
+    }
+
+    [`@test 'wait' helper can be passed a resolution value`](assert) {
+      assert.expect(4);
+
+      this.runTask(() => {
+        this.application.advanceReadiness();
+      });
+
+      let promiseObjectValue = {};
+      let objectValue = {};
+      let {application: {testHelpers}} = this;
+      return testHelpers.wait('text').then(val => {
+        assert.equal(
+          val, 'text',
+          'can resolve to a string'
+        );
+        return testHelpers.wait(1);
+      }).then(val => {
+        assert.equal(
+          val, 1,
+          'can resolve to an integer'
+        );
+        return testHelpers.wait(objectValue);
+      }).then(val => {
+        assert.equal(
+          val, objectValue,
+          'can resolve to an object'
+        );
+        return testHelpers.wait(RSVP.resolve(promiseObjectValue));
+      }).then(val => {
+        assert.equal(
+          val, promiseObjectValue,
+          'can resolve to a promise resolution value'
+        );
+      });
+    }
+
+    [`@test 'click' triggers appropriate events in order`](assert) {
+      assert.expect(5);
+
+      this.add('component:index-wrapper', Component.extend({
+        classNames: 'index-wrapper',
+
+        didInsertElement() {
+          let wrapper = document.querySelector('.index-wrapper');
+          wrapper.addEventListener('mousedown', e => events.push(e.type));
+          wrapper.addEventListener('mouseup', e => events.push(e.type));
+          wrapper.addEventListener('click', e => events.push(e.type));
+          wrapper.addEventListener('focusin', e => events.push(e.type));
+        }
+      }));
+
+      this.add('component:x-checkbox', Component.extend({
+        tagName: 'input',
+        attributeBindings: ['type'],
+        type: 'checkbox',
+        click() {
+          events.push('click:' + this.get('checked'));
+        },
+        change() {
+          events.push('change:' + this.get('checked'));
+        }
+      }));
+
+      this.addTemplate('index', `
+        {{#index-wrapper}}
+          {{input type="text"}}
+          {{x-checkbox type="checkbox"}}
+          {{textarea}}
+          <div contenteditable="true"> </div>
+        {{/index-wrapper}}'));
+      `);
+
+      this.runTask(() => {
+        this.application.advanceReadiness();
+      });
+
+      let events;
+      let {application: {testHelpers}} = this;
+      return testHelpers.wait().then(() => {
+        events = [];
+        return testHelpers.click('.index-wrapper');
+      }).then(() => {
+        assert.deepEqual(
+          events, ['mousedown', 'mouseup', 'click'],
+          'fires events in order'
+        );
+      }).then(() => {
+        events = [];
+        return testHelpers.click('.index-wrapper input[type=text]');
+      }).then(() => {
+        assert.deepEqual(
+          events, ['mousedown', 'focusin', 'mouseup', 'click'],
+          'fires focus events on inputs'
+        );
+      }).then(() => {
+        events = [];
+        return testHelpers.click('.index-wrapper textarea');
+      }).then(() => {
+        assert.deepEqual(
+          events, ['mousedown', 'focusin', 'mouseup', 'click'],
+          'fires focus events on textareas'
+        );
+      }).then(() => {
+        events = [];
+        return testHelpers.click('.index-wrapper div');
+      }).then(() => {
+        assert.deepEqual(
+          events, ['mousedown', 'focusin', 'mouseup', 'click'],
+          'fires focus events on contenteditable'
+        );
+      }).then(() => {
+        events = [];
+        return testHelpers.click('.index-wrapper input[type=checkbox]');
+      }).then(() => {
+        // i.e. mousedown, mouseup, change:true, click, click:true
+        // Firefox differs so we can't assert the exact ordering here.
+        // See https://bugzilla.mozilla.org/show_bug.cgi?id=843554.
+        assert.equal(
+          events.length, 5,
+          'fires click and change on checkboxes'
+        );
+      });
+    }
+
+    [`@test 'click' triggers native events with simulated X/Y coordinates`](assert) {
+      assert.expect(15);
+
+      this.add('component:index-wrapper', Component.extend({
+        classNames: 'index-wrapper',
+
+        didInsertElement() {
+          let pushEvent  = e => events.push(e);
+          this.element.addEventListener('mousedown', pushEvent);
+          this.element.addEventListener('mouseup', pushEvent);
+          this.element.addEventListener('click', pushEvent);
+        }
+      }));
+
+      this.addTemplate('index', `
+        {{#index-wrapper}}some text{{/index-wrapper}}
+      `);
+
+      this.runTask(() => {
+        this.application.advanceReadiness();
+      });
+
+      let events;
+      let {application: {testHelpers: {wait, click}}} = this;
+      return wait().then(() => {
+        events = [];
+        return click('.index-wrapper');
+      }).then(() => {
+        events.forEach(e => {
+          assert.ok(
+            e instanceof window.Event,
+            'The event is an instance of MouseEvent'
+          );
+          assert.ok(
+            typeof e.screenX === 'number',
+            'screenX is correct'
+          );
+          assert.ok(
+            typeof e.screenY === 'number',
+            'screenY is correct'
+          );
+          assert.ok(
+            typeof e.clientX === 'number',
+            'clientX is correct'
+          );
+          assert.ok(
+            typeof e.clientY === 'number',
+            'clientY is correct'
+          );
         });
-      }
-    }));
+      });
+    }
 
-    this.add('component:x-checkbox', Component.extend({
-      tagName: 'input',
-      attributeBindings: ['type'],
-      type: 'checkbox',
-      click() {
-        events.push('click:' + this.get('checked'));
-      },
-      change() {
-        events.push('change:' + this.get('checked'));
-      }
-    }));
+    [`@test 'triggerEvent' with mouseenter triggers native events with simulated X/Y coordinates`](assert) {
+      assert.expect(5);
 
-    this.addTemplate('index', `
-      {{#index-wrapper}}
-        {{input type="text"}}
-        {{x-checkbox type="checkbox"}}
-        {{textarea}}
-        <div contenteditable="true"> </div>
-      {{/index-wrapper}}'));
-    `);
+      let evt;
+      this.add('component:index-wrapper', Component.extend({
+        classNames: 'index-wrapper',
+        didInsertElement() {
+          this.element.addEventListener('mouseenter', e => evt = e);
+        }
+      }));
 
-    this.runTask(() => {
-      this.application.advanceReadiness();
-    });
+      this.addTemplate('index', `{{#index-wrapper}}some text{{/index-wrapper}}`);
 
-    let events;
-    let {application: {testHelpers}} = this;
-    return testHelpers.wait().then(() => {
-      events = [];
-      return testHelpers.click('.index-wrapper');
-    }).then(() => {
-      assert.deepEqual(
-        events, ['mousedown', 'mouseup', 'click'],
-        'fires events in order'
-      );
-    }).then(() => {
-      events = [];
-      return testHelpers.click('.index-wrapper input[type=text]');
-    }).then(() => {
-      assert.deepEqual(
-        events, ['mousedown', 'focusin', 'mouseup', 'click'],
-        'fires focus events on inputs'
-      );
-    }).then(() => {
-      events = [];
-      return testHelpers.click('.index-wrapper textarea');
-    }).then(() => {
-      assert.deepEqual(
-        events, ['mousedown', 'focusin', 'mouseup', 'click'],
-        'fires focus events on textareas'
-      );
-    }).then(() => {
-      events = [];
-      return testHelpers.click('.index-wrapper div');
-    }).then(() => {
-      assert.deepEqual(
-        events, ['mousedown', 'focusin', 'mouseup', 'click'],
-        'fires focus events on contenteditable'
-      );
-    }).then(() => {
-      events = [];
-      return testHelpers.click('.index-wrapper input[type=checkbox]');
-    }).then(() => {
-      // i.e. mousedown, mouseup, change:true, click, click:true
-      // Firefox differs so we can't assert the exact ordering here.
-      // See https://bugzilla.mozilla.org/show_bug.cgi?id=843554.
-      assert.equal(
-        events.length, 5,
-        'fires click and change on checkboxes'
-      );
-    });
-  }
+      this.runTask(() => {
+        this.application.advanceReadiness();
+      });
 
-  [`@test 'click' triggers native events with simulated X/Y coordinates`](assert) {
-    assert.expect(15);
-
-    this.add('component:index-wrapper', Component.extend({
-      classNames: 'index-wrapper',
-
-      didInsertElement() {
-        let pushEvent  = e => events.push(e);
-        this.element.addEventListener('mousedown', pushEvent);
-        this.element.addEventListener('mouseup', pushEvent);
-        this.element.addEventListener('click', pushEvent);
-      }
-    }));
-
-    this.addTemplate('index', `
-      {{#index-wrapper}}some text{{/index-wrapper}}
-    `);
-
-    this.runTask(() => {
-      this.application.advanceReadiness();
-    });
-
-    let events;
-    let {application: {testHelpers: {wait, click}}} = this;
-    return wait().then(() => {
-      events = [];
-      return click('.index-wrapper');
-    }).then(() => {
-      events.forEach(e => {
+      let {application: {testHelpers: {wait, triggerEvent}}} = this;
+      return wait().then(() => {
+        return triggerEvent('.index-wrapper', 'mouseenter');
+      }).then(() => {
         assert.ok(
-          e instanceof window.Event,
+          evt instanceof window.Event,
           'The event is an instance of MouseEvent'
         );
         assert.ok(
-          typeof e.screenX === 'number',
+          typeof evt.screenX === 'number',
           'screenX is correct'
         );
         assert.ok(
-          typeof e.screenY === 'number',
+          typeof evt.screenY === 'number',
           'screenY is correct'
         );
         assert.ok(
-          typeof e.clientX === 'number',
+          typeof evt.clientX === 'number',
           'clientX is correct'
         );
         assert.ok(
-          typeof e.clientY === 'number',
+          typeof evt.clientY === 'number',
           'clientY is correct'
         );
       });
-    });
-  }
-
-  [`@test 'triggerEvent' with mouseenter triggers native events with simulated X/Y coordinates`](assert) {
-    assert.expect(5);
-
-    let evt;
-    this.add('component:index-wrapper', Component.extend({
-      classNames: 'index-wrapper',
-      didInsertElement() {
-        this.element.addEventListener('mouseenter', e => evt = e);
-      }
-    }));
-
-    this.addTemplate('index', `{{#index-wrapper}}some text{{/index-wrapper}}`);
-
-    this.runTask(() => {
-      this.application.advanceReadiness();
-    });
-
-    let {application: {testHelpers: {wait, triggerEvent}}} = this;
-    return wait().then(() => {
-      return triggerEvent('.index-wrapper', 'mouseenter');
-    }).then(() => {
-      assert.ok(
-        evt instanceof window.Event,
-        'The event is an instance of MouseEvent'
-      );
-      assert.ok(
-        typeof evt.screenX === 'number',
-        'screenX is correct'
-      );
-      assert.ok(
-        typeof evt.screenY === 'number',
-        'screenY is correct'
-      );
-      assert.ok(
-        typeof evt.clientX === 'number',
-        'clientX is correct'
-      );
-      assert.ok(
-        typeof evt.clientY === 'number',
-        'clientY is correct'
-      );
-    });
-  }
-
-  [`@test 'wait' waits for outstanding timers`](assert) {
-    assert.expect(1);
-
-    this.runTask(() => {
-      this.application.advanceReadiness();
-    });
-
-    let waitDone = false;
-    run.later(() => {
-      waitDone = true;
-    }, 20);
-
-    return this.application.testHelpers.wait().then(() => {
-      assert.equal(waitDone, true, 'should wait for the timer to be fired.');
-    });
-  }
-
-  [`@test 'wait' respects registerWaiters with optional context`](assert) {
-    assert.expect(3);
-
-    let obj = {
-      counter: 0,
-      ready() {
-        return ++this.counter > 2;
-      }
-    };
-
-    let other = 0;
-    function otherWaiter() {
-      return ++other > 2;
     }
 
-    this.runTask(() => {
-      this.application.advanceReadiness();
-    });
+    [`@test 'wait' waits for outstanding timers`](assert) {
+      assert.expect(1);
 
-    registerWaiter(obj, obj.ready);
-    registerWaiter(otherWaiter);
+      this.runTask(() => {
+        this.application.advanceReadiness();
+      });
 
-    let {application: {testHelpers: {wait}}} = this;
-    return wait().then(() => {
-      assert.equal(
-        obj.ready(), true,
-        'should not resolve until our waiter is ready'
-      );
-      unregisterWaiter(obj, obj.ready);
-      obj.counter = 0;
-      return wait();
-    }).then(() => {
-      assert.equal(
-        obj.counter, 0,
-        'the unregistered waiter should still be at 0'
-      );
-      assert.equal(
-        otherWaiter(), true,
-        'other waiter should still be registered'
-      );
-    }).finally(() => {
-      unregisterWaiter(otherWaiter);
-    });
-  }
+      let waitDone = false;
+      run.later(() => {
+        waitDone = true;
+      }, 20);
 
-  [`@test 'wait' does not error if routing has not begun`](assert) {
-    assert.expect(1);
+      return this.application.testHelpers.wait().then(() => {
+        assert.equal(waitDone, true, 'should wait for the timer to be fired.');
+      });
+    }
 
-    return this.application.testHelpers.wait().then(() => {
-      assert.ok(true, 'should not error without `visit`');
-    });
-  }
+    [`@test 'wait' respects registerWaiters with optional context`](assert) {
+      assert.expect(3);
 
-  [`@test 'triggerEvent' accepts an optional options hash without context`](assert) {
-    assert.expect(3);
-
-    let event;
-    this.add('component:index-wrapper', Component.extend({
-      didInsertElement() {
-        this.$('.input').on('keydown change', e => event = e);
-      }
-    }));
-
-    this.addTemplate('index', `{{index-wrapper}}`);
-    this.addTemplate('components/index-wrapper', `
-      {{input type="text" id="scope" class="input"}}
-    `);
-
-    this.runTask(() => {
-      this.application.advanceReadiness();
-    });
-
-    let {application: {testHelpers: {wait, triggerEvent}}} = this;
-    return wait().then(() => {
-      return triggerEvent('.input', 'keydown', { keyCode: 13 });
-    }).then(() => {
-      assert.equal(event.keyCode, 13, 'options were passed');
-      assert.equal(event.type, 'keydown', 'correct event was triggered');
-      assert.equal(event.target.getAttribute('id'), 'scope', 'triggered on the correct element');
-    });
-  }
-
-  [`@test 'triggerEvent' can limit searching for a selector to a scope`](assert) {
-    assert.expect(2);
-
-    let event;
-    this.add('component:index-wrapper', Component.extend({
-      didInsertElement() {
-        this.$('.input').on('blur change', e => event = e);
-      }
-    }));
-
-    this.addTemplate('components/index-wrapper', `
-      {{input type="text" id="outside-scope" class="input"}}
-      <div id="limited">
-        {{input type="text" id="inside-scope" class="input"}}
-      </div>
-    `);
-    this.addTemplate('index', `{{index-wrapper}}`);
-
-    this.runTask(() => {
-      this.application.advanceReadiness();
-    });
-
-    let {application: {testHelpers: {wait, triggerEvent}}} = this;
-    return wait().then(() => {
-      return triggerEvent('.input', '#limited', 'blur');
-    }).then(() => {
-      assert.equal(
-        event.type, 'blur',
-        'correct event was triggered'
-      );
-      assert.equal(
-        event.target.getAttribute('id'), 'inside-scope',
-        'triggered on the correct element'
-      );
-    });
-  }
-
-  [`@test 'triggerEvent' can be used to trigger arbitrary events`](assert) {
-    assert.expect(2);
-
-    let event;
-    this.add('component:index-wrapper', Component.extend({
-      didInsertElement() {
-        this.$('#foo').on('blur change', e => event = e);
-      }
-    }));
-
-    this.addTemplate('components/index-wrapper', `
-      {{input type="text" id="foo"}}
-    `);
-    this.addTemplate('index', `{{index-wrapper}}`);
-
-    this.runTask(() => {
-      this.application.advanceReadiness();
-    });
-
-    let {application: {testHelpers: {wait, triggerEvent}}} = this;
-    return wait().then(() => {
-      return triggerEvent('#foo', 'blur');
-    }).then(() => {
-      assert.equal(
-        event.type, 'blur',
-        'correct event was triggered'
-      );
-      assert.equal(
-        event.target.getAttribute('id'), 'foo',
-        'triggered on the correct element'
-      );
-    });
-  }
-
-  [`@test 'fillIn' takes context into consideration`](assert) {
-    assert.expect(2);
-
-    this.addTemplate('index', `
-      <div id="parent">
-        {{input type="text" id="first" class="current"}}
-      </div>
-      {{input type="text" id="second" class="current"}}
-    `);
-
-    this.runTask(() => {
-      this.application.advanceReadiness();
-    });
-
-    let {application: {testHelpers: {visit, fillIn, andThen, find}}} = this;
-    visit('/');
-    fillIn('.current', '#parent', 'current value');
-
-    return andThen(() => {
-      assert.equal(find('#first').val(), 'current value');
-      assert.equal(find('#second').val(), '');
-    });
-  }
-
-  [`@test 'fillIn' focuses on the element`](assert) {
-    assert.expect(2);
-
-    this.add('route:application', Route.extend({
-      actions: {
-        wasFocused() {
-          assert.ok(true, 'focusIn event was triggered');
+      let obj = {
+        counter: 0,
+        ready() {
+          return ++this.counter > 2;
         }
-      }
-    }));
-
-    this.addTemplate('index', `
-      <div id="parent">
-        {{input type="text" id="first" focus-in="wasFocused"}}
-      </div>'
-    `);
-
-    this.runTask(() => {
-      this.application.advanceReadiness();
-    });
-
-    let {application: {testHelpers: {visit, fillIn, andThen, find, wait}}} = this;
-    visit('/');
-    fillIn('#first', 'current value');
-    andThen(() => {
-      assert.equal(
-        find('#first').val(),'current value'
-      );
-    });
-
-    return wait();
-  }
-
-  [`@test 'fillIn' fires 'input' and 'change' events in the proper order`](assert) {
-    assert.expect(1);
-
-    let events = [];
-    this.add('controller:index', Controller.extend({
-      actions: {
-        oninputHandler(e) {
-          events.push(e.type);
-        },
-        onchangeHandler(e) {
-          events.push(e.type);
-        }
-      }
-    }));
-
-    this.addTemplate('index', `
-      <input type="text" id="first"
-          oninput={{action "oninputHandler"}}
-          onchange={{action "onchangeHandler"}}>
-    `);
-
-    this.runTask(() => {
-      this.application.advanceReadiness();
-    });
-
-    let {application: {testHelpers: {visit, fillIn, andThen, wait}}} = this;
-
-    visit('/');
-    fillIn('#first', 'current value');
-    andThen(() => {
-      assert.deepEqual(events, ['input', 'change'], '`input` and `change` events are fired in the proper order');
-    });
-
-    return wait();
-  }
-
-  [`@test 'fillIn' only sets the value in the first matched element`](assert) {
-    this.addTemplate('index', `
-      <input type="text" id="first" class="in-test">
-      <input type="text" id="second" class="in-test">
-    `);
-
-    this.runTask(() => {
-      this.application.advanceReadiness();
-    });
-
-    let {application: {testHelpers: {visit, fillIn, find, andThen, wait}}} = this;
-
-    visit('/');
-    fillIn('input.in-test', 'new value');
-    andThen(() => {
-      assert.equal(
-        find('#first').val(), 'new value'
-      );
-      assert.equal(
-        find('#second').val(), ''
-      );
-    });
-
-    return wait();
-  }
-
-  [`@test 'triggerEvent' accepts an optional options hash and context`](assert) {
-    assert.expect(3);
-
-    let event;
-    this.add('component:index-wrapper', Component.extend({
-      didInsertElement() {
-        this.$('.input').on('keydown change', e => event = e);
-      }
-    }));
-
-    this.addTemplate('components/index-wrapper', `
-      {{input type="text" id="outside-scope" class="input"}}
-      <div id="limited">
-        {{input type="text" id="inside-scope" class="input"}}
-      </div>
-    `);
-    this.addTemplate('index', `{{index-wrapper}}`);
-
-    this.runTask(() => {
-      this.application.advanceReadiness();
-    });
-
-    let {application: {testHelpers: {wait, triggerEvent}}} = this;
-    return wait().then(() => {
-      return triggerEvent('.input', '#limited', 'keydown', { keyCode: 13 });
-    }).then(() => {
-      assert.equal(event.keyCode, 13, 'options were passed');
-      assert.equal(event.type, 'keydown', 'correct event was triggered');
-      assert.equal(event.target.getAttribute('id'), 'inside-scope', 'triggered on the correct element');
-    });
-  }
-
-});
-
-moduleFor('ember-testing: debugging helpers', class extends HelpersApplicationTestCase {
-
-  constructor() {
-    super();
-    this.runTask(() => {
-      this.application.advanceReadiness();
-    });
-  }
-
-  [`@test pauseTest pauses`](assert) {
-    assert.expect(1);
-
-    let {application: {testHelpers: {andThen, pauseTest}}} = this;
-    andThen(() => {
-      Test.adapter.asyncStart = () => {
-        assert.ok(
-          true,
-          'Async start should be called after waiting for other helpers'
-        );
       };
-    });
 
-    pauseTest();
-  }
+      let other = 0;
+      function otherWaiter() {
+        return ++other > 2;
+      }
 
-  [`@test resumeTest resumes paused tests`](assert) {
-    assert.expect(1);
+      this.runTask(() => {
+        this.application.advanceReadiness();
+      });
 
-    let {application: {testHelpers: {pauseTest, resumeTest}}} = this;
+      registerWaiter(obj, obj.ready);
+      registerWaiter(otherWaiter);
 
-    run.later(() => resumeTest(), 20);
-    return pauseTest().then(() => {
-      assert.ok(true, 'pauseTest promise was resolved');
-    });
-  }
+      let {application: {testHelpers: {wait}}} = this;
+      return wait().then(() => {
+        assert.equal(
+          obj.ready(), true,
+          'should not resolve until our waiter is ready'
+        );
+        unregisterWaiter(obj, obj.ready);
+        obj.counter = 0;
+        return wait();
+      }).then(() => {
+        assert.equal(
+          obj.counter, 0,
+          'the unregistered waiter should still be at 0'
+        );
+        assert.equal(
+          otherWaiter(), true,
+          'other waiter should still be registered'
+        );
+      }).finally(() => {
+        unregisterWaiter(otherWaiter);
+      });
+    }
 
-  [`@test resumeTest throws if nothing to resume`](assert) {
-    assert.expect(1);
+    [`@test 'wait' does not error if routing has not begun`](assert) {
+      assert.expect(1);
 
-    assert.throws(() => {
-      this.application.testHelpers.resumeTest();
-    }, /Testing has not been paused. There is nothing to resume./);
-  }
+      return this.application.testHelpers.wait().then(() => {
+        assert.ok(true, 'should not error without `visit`');
+      });
+    }
 
-});
+    [`@test 'triggerEvent' accepts an optional options hash without context`](assert) {
+      assert.expect(3);
 
-moduleFor('ember-testing: routing helpers', class extends HelpersTestCase {
+      let event;
+      this.add('component:index-wrapper', Component.extend({
+        didInsertElement() {
+          let domElem = document.querySelector('.input');
+          domElem.addEventListener('change', e => event = e);
+          domElem.addEventListener('keydown', e => event = e);
+        }
+      }));
 
-  constructor() {
-    super();
-    this.runTask(() => {
-      this.createApplication();
-      this.application.setupForTesting();
+      this.addTemplate('index', `{{index-wrapper}}`);
+      this.addTemplate('components/index-wrapper', `
+        {{input type="text" id="scope" class="input"}}
+      `);
+
+      this.runTask(() => {
+        this.application.advanceReadiness();
+      });
+
+      let {application: {testHelpers: {wait, triggerEvent}}} = this;
+      return wait().then(() => {
+        return triggerEvent('.input', 'keydown', { keyCode: 13 });
+      }).then(() => {
+        assert.equal(event.keyCode, 13, 'options were passed');
+        assert.equal(event.type, 'keydown', 'correct event was triggered');
+        assert.equal(event.target.getAttribute('id'), 'scope', 'triggered on the correct element');
+      });
+    }
+
+    [`@test 'triggerEvent' can limit searching for a selector to a scope`](assert) {
+      assert.expect(2);
+
+      let event;
+      this.add('component:index-wrapper', Component.extend({
+        didInsertElement() {
+          let firstInput = document.querySelector('.input');
+          firstInput.addEventListener('blur', e => event = e);
+          firstInput.addEventListener('change', e => event = e);
+          let secondInput = document.querySelector('#limited .input');
+          secondInput.addEventListener('blur', e => event = e);
+          secondInput.addEventListener('change', e => event = e);
+        }
+      }));
+
+      this.addTemplate('components/index-wrapper', `
+        {{input type="text" id="outside-scope" class="input"}}
+        <div id="limited">
+          {{input type="text" id="inside-scope" class="input"}}
+        </div>
+      `);
+      this.addTemplate('index', `{{index-wrapper}}`);
+
+      this.runTask(() => {
+        this.application.advanceReadiness();
+      });
+
+      let {application: {testHelpers: {wait, triggerEvent}}} = this;
+      return wait().then(() => {
+        return triggerEvent('.input', '#limited', 'blur');
+      }).then(() => {
+        assert.equal(
+          event.type, 'blur',
+          'correct event was triggered'
+        );
+        assert.equal(
+          event.target.getAttribute('id'), 'inside-scope',
+          'triggered on the correct element'
+        );
+      });
+    }
+
+    [`@test 'triggerEvent' can be used to trigger arbitrary events`](assert) {
+      assert.expect(2);
+
+      let event;
+      this.add('component:index-wrapper', Component.extend({
+        didInsertElement() {
+          let foo = document.getElementById('foo');
+          foo.addEventListener('blur', e => event = e);
+          foo.addEventListener('change', e => event = e);
+        }
+      }));
+
+      this.addTemplate('components/index-wrapper', `
+        {{input type="text" id="foo"}}
+      `);
+      this.addTemplate('index', `{{index-wrapper}}`);
+
+      this.runTask(() => {
+        this.application.advanceReadiness();
+      });
+
+      let {application: {testHelpers: {wait, triggerEvent}}} = this;
+      return wait().then(() => {
+        return triggerEvent('#foo', 'blur');
+      }).then(() => {
+        assert.equal(
+          event.type, 'blur',
+          'correct event was triggered'
+        );
+        assert.equal(
+          event.target.getAttribute('id'), 'foo',
+          'triggered on the correct element'
+        );
+      });
+    }
+
+    [`@test 'fillIn' takes context into consideration`](assert) {
+      assert.expect(2);
+
+      this.addTemplate('index', `
+        <div id="parent">
+          {{input type="text" id="first" class="current"}}
+        </div>
+        {{input type="text" id="second" class="current"}}
+      `);
+
+      this.runTask(() => {
+        this.application.advanceReadiness();
+      });
+
+      let {application: {testHelpers: {visit, fillIn, andThen, find}}} = this;
+      visit('/');
+      fillIn('.current', '#parent', 'current value');
+
+      return andThen(() => {
+        assert.equal(find('#first')[0].value, 'current value');
+        assert.equal(find('#second')[0].value, '');
+      });
+    }
+
+    [`@test 'fillIn' focuses on the element`](assert) {
+      assert.expect(2);
+
+      this.add('route:application', Route.extend({
+        actions: {
+          wasFocused() {
+            assert.ok(true, 'focusIn event was triggered');
+          }
+        }
+      }));
+
+      this.addTemplate('index', `
+        <div id="parent">
+          {{input type="text" id="first" focus-in="wasFocused"}}
+        </div>'
+      `);
+
+      this.runTask(() => {
+        this.application.advanceReadiness();
+      });
+
+      let {application: {testHelpers: {visit, fillIn, andThen, find, wait}}} = this;
+      visit('/');
+      fillIn('#first', 'current value');
+      andThen(() => {
+        assert.equal(
+          find('#first')[0].value,'current value'
+        );
+      });
+
+      return wait();
+    }
+
+    [`@test 'fillIn' fires 'input' and 'change' events in the proper order`](assert) {
+      assert.expect(1);
+
+      let events = [];
+      this.add('controller:index', Controller.extend({
+        actions: {
+          oninputHandler(e) {
+            events.push(e.type);
+          },
+          onchangeHandler(e) {
+            events.push(e.type);
+          }
+        }
+      }));
+
+      this.addTemplate('index', `
+        <input type="text" id="first"
+            oninput={{action "oninputHandler"}}
+            onchange={{action "onchangeHandler"}}>
+      `);
+
+      this.runTask(() => {
+        this.application.advanceReadiness();
+      });
+
+      let {application: {testHelpers: {visit, fillIn, andThen, wait}}} = this;
+
+      visit('/');
+      fillIn('#first', 'current value');
+      andThen(() => {
+        assert.deepEqual(events, ['input', 'change'], '`input` and `change` events are fired in the proper order');
+      });
+
+      return wait();
+    }
+
+    [`@test 'fillIn' only sets the value in the first matched element`](assert) {
+      this.addTemplate('index', `
+        <input type="text" id="first" class="in-test">
+        <input type="text" id="second" class="in-test">
+      `);
+
+      this.runTask(() => {
+        this.application.advanceReadiness();
+      });
+
+      let {application: {testHelpers: {visit, fillIn, find, andThen, wait}}} = this;
+
+      visit('/');
+      fillIn('input.in-test', 'new value');
+      andThen(() => {
+        assert.equal(
+          find('#first')[0].value, 'new value'
+        );
+        assert.equal(
+          find('#second')[0].value, ''
+        );
+      });
+
+      return wait();
+    }
+
+    [`@test 'triggerEvent' accepts an optional options hash and context`](assert) {
+      assert.expect(3);
+
+      let event;
+      this.add('component:index-wrapper', Component.extend({
+        didInsertElement() {
+          let firstInput = document.querySelector('.input');
+          firstInput.addEventListener('keydown', e => event = e, false);
+          firstInput.addEventListener('change', e => event = e, false);
+          let secondInput = document.querySelector('#limited .input');
+          secondInput.addEventListener('keydown', e => event = e, false);
+          secondInput.addEventListener('change', e => event = e, false);
+        }
+      }));
+
+      this.addTemplate('components/index-wrapper', `
+        {{input type="text" id="outside-scope" class="input"}}
+        <div id="limited">
+          {{input type="text" id="inside-scope" class="input"}}
+        </div>
+      `);
+      this.addTemplate('index', `{{index-wrapper}}`);
+
+      this.runTask(() => {
+        this.application.advanceReadiness();
+      });
+
+      let {application: {testHelpers: {wait, triggerEvent}}} = this;
+      return wait().then(() => {
+        return triggerEvent('.input', '#limited', 'keydown', { keyCode: 13 });
+      }).then(() => {
+        assert.equal(event.keyCode, 13, 'options were passed');
+        assert.equal(event.type, 'keydown', 'correct event was triggered');
+        assert.equal(event.target.getAttribute('id'), 'inside-scope', 'triggered on the correct element');
+      });
+    }
+
+  });
+
+  moduleFor('ember-testing: debugging helpers', class extends HelpersApplicationTestCase {
+
+    constructor() {
+      super();
+      this.runTask(() => {
+        this.application.advanceReadiness();
+      });
+    }
+
+    [`@test pauseTest pauses`](assert) {
+      assert.expect(1);
+
+      let {application: {testHelpers: {andThen, pauseTest}}} = this;
+      andThen(() => {
+        Test.adapter.asyncStart = () => {
+          assert.ok(
+            true,
+            'Async start should be called after waiting for other helpers'
+          );
+        };
+      });
+
+      pauseTest();
+    }
+
+    [`@test resumeTest resumes paused tests`](assert) {
+      assert.expect(1);
+
+      let {application: {testHelpers: {pauseTest, resumeTest}}} = this;
+
+      run.later(() => resumeTest(), 20);
+      return pauseTest().then(() => {
+        assert.ok(true, 'pauseTest promise was resolved');
+      });
+    }
+
+    [`@test resumeTest throws if nothing to resume`](assert) {
+      assert.expect(1);
+
+      assert.throws(() => {
+        this.application.testHelpers.resumeTest();
+      }, /Testing has not been paused. There is nothing to resume./);
+    }
+
+  });
+
+  moduleFor('ember-testing: routing helpers', class extends HelpersTestCase {
+
+    constructor() {
+      super();
+      this.runTask(() => {
+        this.createApplication();
+        this.application.setupForTesting();
+        this.application.injectTestHelpers();
+        this.router.map(function() {
+          this.route('posts', {resetNamespace: true}, function() {
+            this.route('new');
+            this.route('edit', { resetNamespace: true });
+          });
+        });
+      });
+      this.runTask(() => {
+        this.application.advanceReadiness();
+      });
+    }
+
+    [`@test currentRouteName for '/'`](assert) {
+      assert.expect(3);
+
+      let {application: {testHelpers}} = this;
+      return testHelpers.visit('/').then(() => {
+        assert.equal(
+          testHelpers.currentRouteName(), 'index',
+          `should equal 'index'.`
+        );
+        assert.equal(
+          testHelpers.currentPath(), 'index',
+          `should equal 'index'.`
+        );
+        assert.equal(
+          testHelpers.currentURL(), '/',
+          `should equal '/'.`
+        );
+      });
+    }
+
+    [`@test currentRouteName for '/posts'`](assert) {
+      assert.expect(3);
+
+      let {application: {testHelpers}} = this;
+      return testHelpers.visit('/posts').then(() => {
+        assert.equal(
+          testHelpers.currentRouteName(), 'posts.index',
+          `should equal 'posts.index'.`
+        );
+        assert.equal(
+          testHelpers.currentPath(), 'posts.index',
+          `should equal 'posts.index'.`
+        );
+        assert.equal(
+          testHelpers.currentURL(), '/posts',
+          `should equal '/posts'.`
+        );
+      });
+    }
+
+    [`@test currentRouteName for '/posts/new'`](assert) {
+      assert.expect(3);
+
+      let {application: {testHelpers}} = this;
+      return testHelpers.visit('/posts/new').then(() => {
+        assert.equal(
+          testHelpers.currentRouteName(), 'posts.new',
+          `should equal 'posts.new'.`
+        );
+        assert.equal(
+          testHelpers.currentPath(), 'posts.new',
+          `should equal 'posts.new'.`
+        );
+        assert.equal(
+          testHelpers.currentURL(), '/posts/new',
+          `should equal '/posts/new'.`
+        );
+      });
+    }
+
+    [`@test currentRouteName for '/posts/edit'`](assert) {
+      assert.expect(3);
+
+      let {application: {testHelpers}} = this;
+      return testHelpers.visit('/posts/edit').then(() => {
+        assert.equal(
+          testHelpers.currentRouteName(), 'edit',
+          `should equal 'edit'.`
+        );
+        assert.equal(
+          testHelpers.currentPath(), 'posts.edit',
+          `should equal 'posts.edit'.`
+        );
+        assert.equal(
+          testHelpers.currentURL(), '/posts/edit',
+          `should equal '/posts/edit'.`
+        );
+      });
+    }
+
+  });
+
+  moduleFor('ember-testing: pendingRequests', class extends HelpersApplicationTestCase {
+
+    [`@test pendingRequests is maintained for ajaxSend and ajaxComplete events`](assert) {
+      assert.equal(
+        pendingRequests(), 0
+      );
+
+      let xhr = { some: 'xhr' };
+
+      customEvent('ajaxSend', xhr);
+      assert.equal(
+        pendingRequests(), 1,
+        'Ember.Test.pendingRequests was incremented'
+      );
+
+      customEvent('ajaxComplete', xhr);
+      assert.equal(
+        pendingRequests(), 0,
+        'Ember.Test.pendingRequests was decremented'
+      );
+    }
+
+    [`@test pendingRequests is ignores ajaxComplete events from past setupForTesting calls`](assert) {
+      assert.equal(
+        pendingRequests(), 0
+      );
+
+      let xhr = { some: 'xhr' };
+
+      customEvent('ajaxSend', xhr);
+      assert.equal(
+        pendingRequests(), 1,
+        'Ember.Test.pendingRequests was incremented'
+      );
+
+      setupForTesting();
+
+      assert.equal(
+        pendingRequests(), 0,
+        'Ember.Test.pendingRequests was reset'
+      );
+
+      let altXhr = { some: 'more xhr' };
+
+      customEvent('ajaxSend', altXhr);
+      assert.equal(
+        pendingRequests(), 1,
+        'Ember.Test.pendingRequests was incremented'
+      );
+
+      customEvent('ajaxComplete', xhr);
+      assert.equal(
+        pendingRequests(), 1,
+        'Ember.Test.pendingRequests is not impressed with your unexpected complete'
+      );
+    }
+
+    [`@test pendingRequests is reset by setupForTesting`](assert) {
+      incrementPendingRequests();
+
+      setupForTesting();
+
+      assert.equal(
+        pendingRequests(), 0,
+        'pendingRequests is reset'
+      );
+    }
+
+  });
+
+  moduleFor('ember-testing: async router', class extends HelpersTestCase {
+    constructor() {
+      super();
+
+      this.runTask(() => {
+        this.createApplication();
+
+        this.router.map(function() {
+          this.route('user', { resetNamespace: true }, function() {
+            this.route('profile');
+            this.route('edit');
+          });
+        });
+
+        // Emulate a long-running unscheduled async operation.
+        let resolveLater = () => new RSVP.Promise(resolve => {
+          /*
+          * The wait() helper has a 10ms tick. We should resolve() after
+          * at least one tick to test whether wait() held off while the
+          * async router was still loading. 20ms should be enough.
+          */
+          run.later(resolve, {firstName: 'Tom'}, 20);
+        });
+
+        this.add('route:user', Route.extend({
+          model() {
+            return resolveLater();
+          }
+        }));
+
+        this.add('route:user.profile', Route.extend({
+          beforeModel() {
+            return resolveLater().then(() => this.transitionTo('user.edit'));
+          }
+        }));
+
+        this.application.setupForTesting();
+      });
+
       this.application.injectTestHelpers();
-      this.router.map(function() {
-        this.route('posts', {resetNamespace: true}, function() {
-          this.route('new');
-          this.route('edit', { resetNamespace: true });
-        });
+      this.runTask(() => {
+        this.application.advanceReadiness();
       });
-    });
-    this.runTask(() => {
-      this.application.advanceReadiness();
-    });
-  }
+    }
 
-  [`@test currentRouteName for '/'`](assert) {
-    assert.expect(3);
+    [`@test currentRouteName for '/user'`](assert) {
+      assert.expect(4);
 
-    let {application: {testHelpers}} = this;
-    return testHelpers.visit('/').then(() => {
-      assert.equal(
-        testHelpers.currentRouteName(), 'index',
-        `should equal 'index'.`
-      );
-      assert.equal(
-        testHelpers.currentPath(), 'index',
-        `should equal 'index'.`
-      );
-      assert.equal(
-        testHelpers.currentURL(), '/',
-        `should equal '/'.`
-      );
-    });
-  }
+      let {application: {testHelpers}} = this;
+      return testHelpers.visit('/user').then(() => {
+        assert.equal(
+          testHelpers.currentRouteName(), 'user.index',
+          `should equal 'user.index'.`
+        );
+        assert.equal(
+          testHelpers.currentPath(), 'user.index',
+          `should equal 'user.index'.`
+        );
+        assert.equal(
+          testHelpers.currentURL(), '/user',
+          `should equal '/user'.`
+        );
+        let userRoute = this.applicationInstance.lookup('route:user');
+        assert.equal(
+          userRoute.get('controller.model.firstName'), 'Tom',
+          `should equal 'Tom'.`
+        );
+      });
+    }
 
-  [`@test currentRouteName for '/posts'`](assert) {
-    assert.expect(3);
+    [`@test currentRouteName for '/user/profile'`](assert) {
+      assert.expect(4);
 
-    let {application: {testHelpers}} = this;
-    return testHelpers.visit('/posts').then(() => {
-      assert.equal(
-        testHelpers.currentRouteName(), 'posts.index',
-        `should equal 'posts.index'.`
-      );
-      assert.equal(
-        testHelpers.currentPath(), 'posts.index',
-        `should equal 'posts.index'.`
-      );
-      assert.equal(
-        testHelpers.currentURL(), '/posts',
-        `should equal '/posts'.`
-      );
-    });
-  }
+      let {application: {testHelpers}} = this;
+      return testHelpers.visit('/user/profile').then(() => {
+        assert.equal(
+          testHelpers.currentRouteName(), 'user.edit',
+          `should equal 'user.edit'.`
+        );
+        assert.equal(
+          testHelpers.currentPath(), 'user.edit',
+          `should equal 'user.edit'.`
+        );
+        assert.equal(
+          testHelpers.currentURL(), '/user/edit',
+          `should equal '/user/edit'.`
+        );
+        let userRoute = this.applicationInstance.lookup('route:user');
+        assert.equal(
+          userRoute.get('controller.model.firstName'), 'Tom',
+          `should equal 'Tom'.`
+        );
+      });
+    }
 
-  [`@test currentRouteName for '/posts/new'`](assert) {
-    assert.expect(3);
+  });
 
-    let {application: {testHelpers}} = this;
-    return testHelpers.visit('/posts/new').then(() => {
-      assert.equal(
-        testHelpers.currentRouteName(), 'posts.new',
-        `should equal 'posts.new'.`
-      );
-      assert.equal(
-        testHelpers.currentPath(), 'posts.new',
-        `should equal 'posts.new'.`
-      );
-      assert.equal(
-        testHelpers.currentURL(), '/posts/new',
-        `should equal '/posts/new'.`
-      );
-    });
-  }
+  moduleFor('ember-testing: can override built-in helpers', class extends HelpersTestCase {
 
-  [`@test currentRouteName for '/posts/edit'`](assert) {
-    assert.expect(3);
+    constructor() {
+      super();
+      this.runTask(() => {
+        this.createApplication();
+        this.application.setupForTesting();
+      });
+      this._originalVisitHelper = Test._helpers.visit;
+      this._originalFindHelper  = Test._helpers.find;
+    }
 
-    let {application: {testHelpers}} = this;
-    return testHelpers.visit('/posts/edit').then(() => {
-      assert.equal(
-        testHelpers.currentRouteName(), 'edit',
-        `should equal 'edit'.`
-      );
-      assert.equal(
-        testHelpers.currentPath(), 'posts.edit',
-        `should equal 'posts.edit'.`
-      );
-      assert.equal(
-        testHelpers.currentURL(), '/posts/edit',
-        `should equal '/posts/edit'.`
-      );
-    });
-  }
+    teardown() {
+      Test._helpers.visit = this._originalVisitHelper;
+      Test._helpers.find  = this._originalFindHelper;
+      super.teardown();
+    }
 
-});
+    [`@test can override visit helper`](assert) {
+      assert.expect(1);
 
-moduleFor('ember-testing: pendingRequests', class extends HelpersApplicationTestCase {
-
-  [`@test pendingRequests is maintained for ajaxSend and ajaxComplete events`](assert) {
-    assert.equal(
-      pendingRequests(), 0
-    );
-
-    let xhr = { some: 'xhr' };
-
-    jQuery(document).trigger('ajaxSend', xhr);
-    assert.equal(
-      pendingRequests(), 1,
-      'Ember.Test.pendingRequests was incremented'
-    );
-
-    jQuery(document).trigger('ajaxComplete', xhr);
-    assert.equal(
-      pendingRequests(), 0,
-      'Ember.Test.pendingRequests was decremented'
-    );
-  }
-
-  [`@test pendingRequests is ignores ajaxComplete events from past setupForTesting calls`](assert) {
-    assert.equal(
-      pendingRequests(), 0
-    );
-
-    let xhr = { some: 'xhr' };
-
-    jQuery(document).trigger('ajaxSend', xhr);
-    assert.equal(
-      pendingRequests(), 1,
-      'Ember.Test.pendingRequests was incremented'
-    );
-
-    setupForTesting();
-
-    assert.equal(
-      pendingRequests(), 0,
-      'Ember.Test.pendingRequests was reset'
-    );
-
-    let altXhr = { some: 'more xhr' };
-
-    jQuery(document).trigger('ajaxSend', altXhr);
-    assert.equal(
-      pendingRequests(), 1,
-      'Ember.Test.pendingRequests was incremented'
-    );
-
-    jQuery(document).trigger('ajaxComplete', xhr);
-    assert.equal(
-      pendingRequests(), 1,
-      'Ember.Test.pendingRequests is not impressed with your unexpected complete'
-    );
-  }
-
-  [`@test pendingRequests is reset by setupForTesting`](assert) {
-    incrementPendingRequests();
-
-    setupForTesting();
-
-    assert.equal(
-      pendingRequests(), 0,
-      'pendingRequests is reset'
-    );
-  }
-
-});
-
-moduleFor('ember-testing: async router', class extends HelpersTestCase {
-  constructor() {
-    super();
-
-    this.runTask(() => {
-      this.createApplication();
-
-      this.router.map(function() {
-        this.route('user', { resetNamespace: true }, function() {
-          this.route('profile');
-          this.route('edit');
-        });
+      Test.registerHelper('visit', () => {
+        assert.ok(true, 'custom visit helper was called');
       });
 
-      // Emulate a long-running unscheduled async operation.
-      let resolveLater = () => new RSVP.Promise(resolve => {
-        /*
-         * The wait() helper has a 10ms tick. We should resolve() after
-         * at least one tick to test whether wait() held off while the
-         * async router was still loading. 20ms should be enough.
-         */
-        run.later(resolve, {firstName: 'Tom'}, 20);
+      this.application.injectTestHelpers();
+
+      return this.application.testHelpers.visit();
+    }
+
+    [`@test can override find helper`](assert) {
+      assert.expect(1);
+
+      Test.registerHelper('find', () => {
+        assert.ok(true, 'custom find helper was called');
+
+        return ['not empty array'];
       });
 
-      this.add('route:user', Route.extend({
-        model() {
-          return resolveLater();
-        }
-      }));
+      this.application.injectTestHelpers();
 
-      this.add('route:user.profile', Route.extend({
-        beforeModel() {
-          return resolveLater().then(() => this.transitionTo('user.edit'));
-        }
-      }));
+      return this.application.testHelpers.findWithAssert('.who-cares');
+    }
 
-      this.application.setupForTesting();
-    });
-
-    this.application.injectTestHelpers();
-    this.runTask(() => {
-      this.application.advanceReadiness();
-    });
-  }
-
-  [`@test currentRouteName for '/user'`](assert) {
-    assert.expect(4);
-
-    let {application: {testHelpers}} = this;
-    return testHelpers.visit('/user').then(() => {
-      assert.equal(
-        testHelpers.currentRouteName(), 'user.index',
-        `should equal 'user.index'.`
-      );
-      assert.equal(
-        testHelpers.currentPath(), 'user.index',
-        `should equal 'user.index'.`
-      );
-      assert.equal(
-        testHelpers.currentURL(), '/user',
-        `should equal '/user'.`
-      );
-      let userRoute = this.applicationInstance.lookup('route:user');
-      assert.equal(
-        userRoute.get('controller.model.firstName'), 'Tom',
-        `should equal 'Tom'.`
-      );
-    });
-  }
-
-  [`@test currentRouteName for '/user/profile'`](assert) {
-    assert.expect(4);
-
-    let {application: {testHelpers}} = this;
-    return testHelpers.visit('/user/profile').then(() => {
-      assert.equal(
-        testHelpers.currentRouteName(), 'user.edit',
-        `should equal 'user.edit'.`
-      );
-      assert.equal(
-        testHelpers.currentPath(), 'user.edit',
-        `should equal 'user.edit'.`
-      );
-      assert.equal(
-        testHelpers.currentURL(), '/user/edit',
-        `should equal '/user/edit'.`
-      );
-      let userRoute = this.applicationInstance.lookup('route:user');
-      assert.equal(
-        userRoute.get('controller.model.firstName'), 'Tom',
-        `should equal 'Tom'.`
-      );
-    });
-  }
-
-});
-
-moduleFor('ember-testing: can override built-in helpers', class extends HelpersTestCase {
-
-  constructor() {
-    super();
-    this.runTask(() => {
-      this.createApplication();
-      this.application.setupForTesting();
-    });
-    this._originalVisitHelper = Test._helpers.visit;
-    this._originalFindHelper  = Test._helpers.find;
-  }
-
-  teardown() {
-    Test._helpers.visit = this._originalVisitHelper;
-    Test._helpers.find  = this._originalFindHelper;
-    super.teardown();
-  }
-
-  [`@test can override visit helper`](assert) {
-    assert.expect(1);
-
-    Test.registerHelper('visit', () => {
-      assert.ok(true, 'custom visit helper was called');
-    });
-
-    this.application.injectTestHelpers();
-
-    return this.application.testHelpers.visit();
-  }
-
-  [`@test can override find helper`](assert) {
-    assert.expect(1);
-
-    Test.registerHelper('find', () => {
-      assert.ok(true, 'custom find helper was called');
-
-      return ['not empty array'];
-    });
-
-    this.application.injectTestHelpers();
-
-    return this.application.testHelpers.findWithAssert('.who-cares');
-  }
-
-});
+  });
+}

--- a/packages/ember-testing/tests/integration_test.js
+++ b/packages/ember-testing/tests/integration_test.js
@@ -8,6 +8,7 @@ import {
   A as emberA
 } from 'ember-runtime';
 import { Route } from 'ember-routing';
+import { jQueryDisabled } from 'ember-views';
 
 moduleFor('ember-testing Integration tests of acceptance', class extends AutobootApplicationTestCase {
 
@@ -52,39 +53,56 @@ moduleFor('ember-testing Integration tests of acceptance', class extends Autoboo
   }
 
   [`@test template is bound to empty array of people`](assert) {
-    this.runTask(() => this.application.advanceReadiness());
-    window.visit('/').then(() => {
-      let rows = window.find('.name').length;
-      assert.equal(
-        rows, 0,
-        'successfully stubbed an empty array of people'
-      );
-    });
+    if (!jQueryDisabled) {
+      this.runTask(() => this.application.advanceReadiness());
+      window.visit('/').then(() => {
+        let rows = window.find('.name').length;
+        assert.equal(
+          rows, 0,
+          'successfully stubbed an empty array of people'
+        );
+      });
+    } else {
+      this.runTask(() => this.application.advanceReadiness());
+      window.visit('/').then(() => {
+        expectAssertion(() => window.find('.name'), 
+        'If jQuery is disabled, please import and use helpers from @ember/test-helpers [https://github.com/emberjs/ember-test-helpers]. Note: `find` is not an available helper.'
+        );
+      });
+    }
   }
 
   [`@test template is bound to array of 2 people`](assert) {
-    this.modelContent = emberA([]);
-    this.modelContent.pushObject({ firstName: 'x' });
-    this.modelContent.pushObject({ firstName: 'y' });
+    if (!jQueryDisabled) {
+      this.modelContent = emberA([]);
+      this.modelContent.pushObject({ firstName: 'x' });
+      this.modelContent.pushObject({ firstName: 'y' });
 
-    this.runTask(() => this.application.advanceReadiness());
-    window.visit('/').then(() => {
-      let rows = window.find('.name').length;
-      assert.equal(
-        rows, 2,
-        'successfully stubbed a non empty array of people'
-      );
-    });
+      this.runTask(() => this.application.advanceReadiness());
+      window.visit('/').then(() => {
+        let rows = window.find('.name').length;
+        assert.equal(
+          rows, 2,
+          'successfully stubbed a non empty array of people'
+        );
+      });
+    } else {
+      assert.expect(0);
+    }
   }
 
   [`@test 'visit' can be called without advanceReadiness.`](assert) {
-    window.visit('/').then(() => {
-      let rows = window.find('.name').length;
-      assert.equal(
-        rows, 0,
-        'stubbed an empty array of people without calling advanceReadiness.'
-      );
-    });
+    if (!jQueryDisabled) {
+      window.visit('/').then(() => {
+        let rows = window.find('.name').length;
+        assert.equal(
+          rows, 0,
+          'stubbed an empty array of people without calling advanceReadiness.'
+        );
+      });
+    } else {
+      assert.expect(0);
+    }
   }
 
 });


### PR DESCRIPTION
Edited: The path forward now is to warn the end user that if jQuery is disabled, they should use instead `@ember/test-helpers`. 

References  #16058 
  
  