### PR TITLE
[BUGFIX] missing modules docs for tryInvoke, compare, isEqual #16079

### DIFF
--- a/packages/ember-runtime/lib/compare.js
+++ b/packages/ember-runtime/lib/compare.js
@@ -38,6 +38,10 @@ function spaceship(a, b) {
 }
 
 /**
+ @module @ember/utils
+*/
+
+/**
  Compares two javascript values and returns:
 
   - -1 if the first is smaller than the second,
@@ -72,7 +76,8 @@ function spaceship(a, b) {
   ```
 
  @method compare
- @for Ember
+ @for @ember/utils
+ @static
  @param {Object} v First value to compare
  @param {Object} w Second value to compare
  @return {Number} -1 if v < w, 0 if v = w and 1 if v > w.

--- a/packages/ember-runtime/lib/is-equal.js
+++ b/packages/ember-runtime/lib/is-equal.js
@@ -1,4 +1,7 @@
 /**
+ @module @ember/utils
+*/
+/**
   Compares two objects, returning true if they are equal.
 
   ```javascript
@@ -30,7 +33,8 @@
   ```
 
   @method isEqual
-  @for Ember
+  @for @ember/utils
+  @static
   @param {Object} a first object to compare
   @param {Object} b second object to compare
   @return {Boolean}

--- a/packages/ember-utils/lib/invoke.js
+++ b/packages/ember-utils/lib/invoke.js
@@ -23,6 +23,10 @@ export function canInvoke(obj, methodName) {
 }
 
 /**
+  @module @ember/utils
+*/
+
+/**
   Checks to see if the `methodName` exists on the `obj`,
   and if it does, invokes it with the arguments passed.
 
@@ -35,7 +39,8 @@ export function canInvoke(obj, methodName) {
   ```
 
   @method tryInvoke
-  @for Ember
+  @for @ember/utils
+  @static
   @param {Object} obj The object to check for the method
   @param {String} methodName The method name to check for
   @param {Array} [args] The arguments to pass to the method


### PR DESCRIPTION
See https://github.com/emberjs/ember.js/issues/16079. This should target at least 2.18 LTS candidate and 3.0-beta. 2.16 LTS would be good too. I have no idea how any of that is done so let me know if I need to open more PRs against other branches.

Needs a good look by @toddjordan 

Thank you to sukima for reporting!