### PR TITLE
[FEATURE ember-glimmer-named-arguments] update reserve names

### DIFF
--- a/packages/ember-template-compiler/lib/plugins/assert-reserved-named-arguments.js
+++ b/packages/ember-template-compiler/lib/plugins/assert-reserved-named-arguments.js
@@ -2,7 +2,7 @@ import { assert } from 'ember-debug';
 import { EMBER_GLIMMER_NAMED_ARGUMENTS } from 'ember/features';
 import calculateLocationDisplay from '../system/calculate-location-display';
 
-const RESERVED = ['@arguments', '@args'];
+const RESERVED = ['@arguments', '@args', '@block', '@else'];
 
 let isReserved, assertMessage;
 

--- a/packages/ember-template-compiler/tests/plugins/assert-reserved-named-arguments-test.js
+++ b/packages/ember-template-compiler/tests/plugins/assert-reserved-named-arguments-test.js
@@ -44,6 +44,46 @@ if (EMBER_GLIMMER_NAMED_ARGUMENTS) {
       }, `'@args' is reserved. ('baz/foo-bar' @ L1:C17) `);
     }
 
+    [`@test '@block' is reserved`]() {
+      expectAssertion(() => {
+        compile(`{{@block}}`, {
+          moduleName: 'baz/foo-bar'
+        });
+      }, `'@block' is reserved. ('baz/foo-bar' @ L1:C2) `);
+
+      expectAssertion(() => {
+        compile(`{{#if @block}}Yup{{/if}}`, {
+          moduleName: 'baz/foo-bar'
+        });
+      }, `'@block' is reserved. ('baz/foo-bar' @ L1:C6) `);
+
+      expectAssertion(() => {
+        compile(`{{input type=(if @block "bar" "baz")}}`, {
+          moduleName: 'baz/foo-bar'
+        });
+      }, `'@block' is reserved. ('baz/foo-bar' @ L1:C17) `);
+    }
+
+    [`@test '@else' is reserved`]() {
+      expectAssertion(() => {
+        compile(`{{@else}}`, {
+          moduleName: 'baz/foo-bar'
+        });
+      }, `'@else' is reserved. ('baz/foo-bar' @ L1:C2) `);
+
+      expectAssertion(() => {
+        compile(`{{#if @else}}Yup{{/if}}`, {
+          moduleName: 'baz/foo-bar'
+        });
+      }, `'@else' is reserved. ('baz/foo-bar' @ L1:C6) `);
+
+      expectAssertion(() => {
+        compile(`{{input type=(if @else "bar" "baz")}}`, {
+          moduleName: 'baz/foo-bar'
+        });
+      }, `'@else' is reserved. ('baz/foo-bar' @ L1:C17) `);
+    }
+
     // anything else that doesn't start with a lower case letter
     [`@test '@Arguments' is reserved`]() {
       expectAssertion(() => {


### PR DESCRIPTION
Reserve some more names used in the named blocks RFC

I would like to avoid reserving `@main` if we could, but I am not sure if we have enough consensus on that (the proposal is to replace `@main` with `@block`).