### PR TITLE
[CLEANUP beta] Fix ember-2-legacy support for Ember.Binding.

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -338,14 +338,14 @@ function applyMixin(obj, mixins, partial) {
       replaceObserversAndListeners(obj, key, obj[key], value);
     }
 
-    if (ENV._ENABLE_BINDING_SUPPORT && Mixin.detectBinding(key)) {
+    if (ENV._ENABLE_BINDING_SUPPORT && typeof Mixin.detectBinding === 'function' && Mixin.detectBinding(key)) {
       meta.writeBindings(key, value);
     }
 
     defineProperty(obj, key, desc, value, meta);
   }
 
-  if (ENV._ENABLE_BINDING_SUPPORT && !partial) { // don't apply to prototype
+  if (ENV._ENABLE_BINDING_SUPPORT && !partial && typeof Mixin.finishProtype === 'function') {
     Mixin.finishPartial(obj, meta);
   }
 

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -24,7 +24,6 @@ import {
   Mixin,
   REQUIRED,
   defineProperty,
-  Binding,
   ComputedProperty,
   computed,
   InjectedProperty,
@@ -493,12 +492,6 @@ CoreObject.PrototypeMixin = Mixin.create({
     if (m.isSourceDestroyed()) { return; }
     deleteMeta(this);
     m.setSourceDestroyed();
-  },
-
-  bind(to, from) {
-    if (!(from instanceof Binding)) { from = Binding.from(from); }
-    from.to(to).connect(this);
-    return from;
   },
 
   /**


### PR DESCRIPTION
The primary change here is to allow `Ember.Mixin.finishPartial` and `Ember.Mixin.detectBinding` to be undefined/null. The reason for this is that there is an annoying ordering issue. Basically, the environment flags are present from when Ember itself boots, but the monkey patches added by ember-2-legacy (`detectBinding` and `finishPartial`) are not done until _after_ the main `ember.debug.js` / `ember.prod.js` files have been processed. _Within_ the evaluation of the main `ember.*.js` file, the environment variable has been set but these functions are still missing. This means that _Ember itself_ (during evaluation of `Ember.CoreObject`) causes an issue when it attempts to call `Mixin.finishPartials`.