### PR TITLE
[BUGFIX beta] add window to list of descriptor exceptions

### DIFF
--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -115,7 +115,8 @@ if (EMBER_METAL_ES5_GETTERS) {
           } else if (
             property === 'prototype' ||
             property === 'constructor' ||
-            property === 'nodeType'
+            property === 'nodeType' ||
+            property === 'window'
           ) {
             return undefined;
           } else if (


### PR DESCRIPTION
@rwjblue this is a follow-on from https://github.com/emberjs/ember.js/pull/16050 since jQuery has an `isWindow` function that does something like this which trips this error as well:

> return obj != null && obj === obj.window;

> You attempted to access the `firstObject.window` property (of [object Object]