### PR TITLE
Add work around for qunit-fixture attribute leakage.

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -167,6 +167,18 @@
           }
         });
 
+        // work around https://github.com/qunitjs/qunit/issues/1224
+        QUnit.testStart(function() {
+          var existingFixture = document.getElementById('qunit-fixture');
+
+          // create a new pristine fixture element
+          var newFixture = document.createElement('div');
+          newFixture.setAttribute('id', 'qunit-fixture');
+
+          // replace the old (possibly mutated fixture) with the new pristine one
+          existingFixture.parentNode.replaceChild(newFixture, existingFixture);
+        });
+
         QUnit.testDone(function(results) {
           testsTotal++;
 


### PR DESCRIPTION
Works around the issue described in https://github.com/qunitjs/qunit/issues/1224 (which will hopefully be fixed in https://github.com/qunitjs/qunit/pull/1250 soonish) where once _anything_ mutates the `qunit-fixture` element's attributes they are never reset/cleaned up. Which (in Ember's own test suite) results in **all following tests** failing... 😩 
