### PR TITLE
Fix formatting issues for a couple YUI docs

### DIFF
--- a/packages/ember-glimmer/lib/syntax/let.ts
+++ b/packages/ember-glimmer/lib/syntax/let.ts
@@ -1,37 +1,37 @@
-import { compileList } from "@glimmer/runtime";
-
 /**
 @module ember
+*/
 
-/**
-  The `let` helper receives one or more positional arguments and yields
-  them out as block params.
+import { compileList } from "@glimmer/runtime";
+  /**
+    The `let` helper receives one or more positional arguments and yields
+    them out as block params.
 
-  This allows the developer to introduce shorter names for certain computations
-  in the template.
+    This allows the developer to introduce shorter names for certain computations
+    in the template.
 
-  This is especially useful if you are passing properties to a component
-  that receives a lot of options and you want to clean up the invocation.
+    This is especially useful if you are passing properties to a component
+    that receives a lot of options and you want to clean up the invocation.
 
-  For the following example, the template receives a `post` object with
-  `content` and `title` properties.
+    For the following example, the template receives a `post` object with
+    `content` and `title` properties.
 
-  We are going to call the `my-post` component, passing a title which is
-  the title of the post suffixed with the name of the blog, the content
-  of the post, and a series of options defined in-place.
+    We are going to call the `my-post` component, passing a title which is
+    the title of the post suffixed with the name of the blog, the content
+    of the post, and a series of options defined in-place.
 
-  ```handlebars
-  {{#let
-      (concat post.title ' | The Ember.js Blog')
-      post.content
-      (hash
-        theme="high-contrast"
-        enableComments=true
-      )
-      as |title content options|
-  }}
-    {{my-post title=title content=content options=options}}
-  {{/let}}
+    ```handlebars
+    {{#let
+        (concat post.title ' | The Ember.js Blog')
+        post.content
+        (hash
+          theme="high-contrast"
+          enableComments=true
+        )
+        as |title content options|
+    }}
+      {{my-post title=title content=content options=options}}
+    {{/let}}
   ```
 
   @method let

--- a/packages/ember-glimmer/lib/syntax/render.ts
+++ b/packages/ember-glimmer/lib/syntax/render.ts
@@ -1,7 +1,8 @@
 /**
-@module ember
-
-Remove after 3.4 once _ENABLE_RENDER_SUPPORT flag is no longer needed.
+ @module ember
+*/
+/*
+ Remove after 3.4 once _ENABLE_RENDER_SUPPORT flag is no longer needed.
 */
 
 import { ConstReference, isConst } from '@glimmer/reference';


### PR DESCRIPTION
I was building the docs locally for the latest `ember.js` and noticed some funky formatting (see screenshot).

It looks like there was a missing `*/` for `let.ts` and `render.ts`. I'm not up to speed on best practices for YUIdoc formatting, but looking at some other files in the repo, I _think_ these updates are appropriate.

<img width="483" alt="screen shot 2018-01-11 at 11 32 06 am" src="https://user-images.githubusercontent.com/1851748/34838263-12a436ba-f6c3-11e7-8f4c-7d992036d1e0.png">

If I run the following off master...

```
git clone https://github.com/emberjs/ember.js && \
  cd ember.js && \
  yarn && \
  npm run docs && \
  grep -irn 'this allows the developer to introduce' .
```

I get a lot of **ton** of hits like this...

```
./docs/modules/@ember_utils.html:204:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_engine.html:173:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_engine.html:204:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_polyfills.html:173:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_polyfills.html:204:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/jquery.html:173:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/jquery.html:204:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_component.html:173:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_component.html:204:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/ember

Remove after 3.4 once _ENABLE_RENDER_SUPPORT flag is no longer needed..html:175:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/ember

Remove after 3.4 once _ENABLE_RENDER_SUPPORT flag is no longer needed..html:206:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_application.html:173:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_application.html:204:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_instrumentation.html:173:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_instrumentation.html:204:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_error.html:173:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_error.html:204:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_routing.html:173:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_routing.html:204:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_test.html:173:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_test.html:204:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_controller.html:173:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_controller.html:204:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_object.html:173:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_object.html:204:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_string.html:173:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_string.html:204:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/ember-glimmer.html:173:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/ember-glimmer.html:204:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_runloop.html:173:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_runloop.html:204:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_array.html:173:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_array.html:204:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_debug.html:173:                  This allows the developer to introduce shorter names for certain computations
./docs/modules/@ember_debug.html:204:                  This allows the developer to introduce shorter names for certain computations
./packages/ember-glimmer/lib/syntax/let.ts:10:  This allows the developer to introduce shorter names for certain computations
```

These updates seem to fix that.