### PR TITLE
Update docs for RFC 176 syntax and canonical URL

### DIFF
--- a/packages/ember-debug/lib/deprecate.js
+++ b/packages/ember-debug/lib/deprecate.js
@@ -14,12 +14,14 @@ import { registerHandler as genericRegisterHandler, invoke } from './handlers';
 */
 /**
   Allows for runtime registration of handler functions that override the default deprecation behavior.
-  Deprecations are invoked by calls to [Ember.deprecate](https://emberjs.com/api/classes/Ember.html#method_deprecate).
+  Deprecations are invoked by calls to [@ember/application/deprecations/deprecate](https://emberjs.com/api/ember/release/classes/@ember%2Fapplication%2Fdeprecations/methods/deprecate?anchor=deprecate).
   The following example demonstrates its usage by registering a handler that throws an error if the
   message contains the word "should", otherwise defers to the default handler.
 
   ```javascript
-  Ember.Debug.registerDeprecationHandler((message, options, next) => {
+  import { registerDeprecationHandler } from '@ember/debug';
+
+  registerDeprecationHandler((message, options, next) => {
     if (message.indexOf('should') !== -1) {
       throw new Error(`Deprecation message with should: ${message}`);
     } else {
@@ -126,11 +128,11 @@ if (DEBUG) {
     }
   });
 
-  missingOptionsDeprecation = 'When calling `Ember.deprecate` you ' +
+  missingOptionsDeprecation = 'When calling `deprecate` you ' +
     'must provide an `options` hash as the third parameter.  ' +
     '`options` should include `id` and `until` properties.';
-  missingOptionsIdDeprecation = 'When calling `Ember.deprecate` you must provide `id` in options.';
-  missingOptionsUntilDeprecation = 'When calling `Ember.deprecate` you must provide `until` in options.';
+  missingOptionsIdDeprecation = 'When calling `deprecate` you must provide `id` in options.';
+  missingOptionsUntilDeprecation = 'When calling `deprecate` you must provide `until` in options.';
   /**
    @module @ember/application
    @public

--- a/packages/ember-debug/lib/index.js
+++ b/packages/ember-debug/lib/index.js
@@ -147,14 +147,16 @@ if (DEBUG) {
     * In a production build, this method is defined as an empty function (NOP).
 
     ```javascript
-    Ember.oldMethod = Ember.deprecateFunc('Please use the new, updated method', Ember.newMethod);
+    import { deprecateFunc } from '@ember/application/deprecations';
+
+    Ember.oldMethod = deprecateFunc('Please use the new, updated method', options, Ember.newMethod);
     ```
 
     @method deprecateFunc
     @static
     @for @ember/application/deprecations
     @param {String} message A description of the deprecation.
-    @param {Object} [options] The options object for Ember.deprecate.
+    @param {Object} [options] The options object for `deprecate`.
     @param {Function} func The new function called to replace its deprecated counterpart.
     @return {Function} A new function that wraps the original function with a deprecation warning
     @private

--- a/packages/ember-debug/lib/warn.js
+++ b/packages/ember-debug/lib/warn.js
@@ -17,7 +17,7 @@ let missingOptionsDeprecation, missingOptionsIdDeprecation;
 if (DEBUG) {
   /**
     Allows for runtime registration of handler functions that override the default warning behavior.
-    Warnings are invoked by calls made to [warn](https://emberjs.com/api/classes/Ember.html#method_warn).
+    Warnings are invoked by calls made to [@ember/debug/warn](https://emberjs.com/api/ember/release/classes/@ember%2Fdebug/methods/warn?anchor=warn).
     The following example demonstrates its usage by registering a handler that does nothing overriding Ember's
     default warning behavior.
 

--- a/packages/ember-debug/tests/error_test.js
+++ b/packages/ember-debug/tests/error_test.js
@@ -5,7 +5,7 @@ import {
 } from 'internal-test-helpers';
 
 moduleFor('Ember Error Throwing', class extends TestCase {
-  ['@test new Ember.Error displays provided message'](assert) {
+  ['@test new EmberError displays provided message'](assert) {
     assert.throws(() => {
       throw new EmberError('A Message');
     }, e => e.message === 'A Message', 'the assigned message was displayed');

--- a/packages/ember-debug/tests/main_test.js
+++ b/packages/ember-debug/tests/main_test.js
@@ -55,27 +55,27 @@ moduleFor('ember-debug', class extends TestCase {
     ENV._ENABLE_DEPRECATION_OPTIONS_SUPPORT = originalDeprecationOptions;
   }
 
-  ['@test Ember.deprecate does not throw if RAISE_ON_DEPRECATION is false'](assert) {
+  ['@test deprecate does not throw if RAISE_ON_DEPRECATION is false'](assert) {
     assert.expect(1);
 
     ENV.RAISE_ON_DEPRECATION = false;
 
     try {
       deprecate('Should not throw', false, { id: 'test', until: 'forever' });
-      assert.ok(true, 'Ember.deprecate did not throw');
+      assert.ok(true, 'deprecate did not throw');
     } catch (e) {
       assert.ok(false, `Expected deprecate not to throw but it did: ${e.message}`);
     }
   }
 
-  ['@test Ember.deprecate resets deprecation level to RAISE if ENV.RAISE_ON_DEPRECATION is set'](assert) {
+  ['@test deprecate resets deprecation level to RAISE if ENV.RAISE_ON_DEPRECATION is set'](assert) {
     assert.expect(2);
 
     ENV.RAISE_ON_DEPRECATION = false;
 
     try {
       deprecate('Should not throw', false, { id: 'test', until: 'forever' });
-      assert.ok(true, 'Ember.deprecate did not throw');
+      assert.ok(true, 'deprecate did not throw');
     } catch (e) {
       assert.ok(false, `Expected deprecate not to throw but it did: ${e.message}`);
     }
@@ -113,7 +113,7 @@ moduleFor('ember-debug', class extends TestCase {
     }, /Should throw with non-matching id/);
   }
 
-  ['@test Ember.deprecate throws deprecation if second argument is falsy'](assert) {
+  ['@test deprecate throws deprecation if second argument is falsy'](assert) {
     assert.expect(3);
 
     assert.throws(() => deprecate('Deprecation is thrown', false, { id: 'test', until: 'forever' }));
@@ -121,7 +121,7 @@ moduleFor('ember-debug', class extends TestCase {
     assert.throws(() => deprecate('Deprecation is thrown', 0, { id: 'test', until: 'forever' }));
   }
 
-  ['@test Ember.deprecate does not invoke a function as the second argument'](assert) {
+  ['@test deprecate does not invoke a function as the second argument'](assert) {
     assert.expect(1);
 
     deprecate('Deprecation is thrown', function() {
@@ -131,7 +131,7 @@ moduleFor('ember-debug', class extends TestCase {
     assert.ok(true, 'deprecations were not thrown');
   }
 
-  ['@test Ember.deprecate does not throw deprecations if second argument is truthy'](assert) {
+  ['@test deprecate does not throw deprecations if second argument is truthy'](assert) {
     assert.expect(1);
 
     deprecate('Deprecation is thrown', true, { id: 'test', until: 'forever' });
@@ -141,7 +141,7 @@ moduleFor('ember-debug', class extends TestCase {
     assert.ok(true, 'deprecations were not thrown');
   }
 
-  ['@test Ember.assert throws if second argument is falsy'](assert) {
+  ['@test assert throws if second argument is falsy'](assert) {
     assert.expect(3);
 
     assert.throws(() => emberAssert('Assertion is thrown', false));
@@ -149,7 +149,7 @@ moduleFor('ember-debug', class extends TestCase {
     assert.throws(() => emberAssert('Assertion is thrown', 0));
   }
 
-  ['@test Ember.assert does not throw if second argument is a function'](assert) {
+  ['@test assert does not throw if second argument is a function'](assert) {
     assert.expect(1);
 
     emberAssert('Assertion is thrown', () => true);
@@ -157,7 +157,7 @@ moduleFor('ember-debug', class extends TestCase {
     assert.ok(true, 'assertions were not thrown');
   }
 
-  ['@test Ember.assert does not throw if second argument is falsy'](assert) {
+  ['@test assert does not throw if second argument is falsy'](assert) {
     assert.expect(1);
 
     emberAssert('Assertion is thrown', true);
@@ -167,7 +167,7 @@ moduleFor('ember-debug', class extends TestCase {
     assert.ok(true, 'assertions were not thrown');
   }
 
-  ['@test Ember.assert does not throw if second argument is an object'](assert) {
+  ['@test assert does not throw if second argument is an object'](assert) {
     assert.expect(1);
     let Igor = EmberObject.extend();
 
@@ -178,7 +178,7 @@ moduleFor('ember-debug', class extends TestCase {
   }
 
 
-  ['@test Ember.deprecate does not throw a deprecation at log and silence'](assert) {
+  ['@test deprecate does not throw a deprecation at log and silence'](assert) {
     assert.expect(4);
     let id = 'ABC';
     let until = 'forever';
@@ -217,7 +217,7 @@ moduleFor('ember-debug', class extends TestCase {
     });
   }
 
-  ['@test Ember.deprecate without options triggers a deprecation'](assert) {
+  ['@test deprecate without options triggers a deprecation'](assert) {
     assert.expect(4);
 
     registerHandler(function(message) {
@@ -232,7 +232,7 @@ moduleFor('ember-debug', class extends TestCase {
     deprecate('foo', false, { });
   }
 
-  ['@test Ember.deprecate without options triggers an assertion'](assert) {
+  ['@test deprecate without options triggers an assertion'](assert) {
     assert.expect(2);
     ENV._ENABLE_DEPRECATION_OPTIONS_SUPPORT = false;
 
@@ -250,7 +250,7 @@ moduleFor('ember-debug', class extends TestCase {
   }
 
 
-  ['@test Ember.deprecate without options.id triggers a deprecation'](assert) {
+  ['@test deprecate without options.id triggers a deprecation'](assert) {
     assert.expect(2);
 
     registerHandler(function(message) {
@@ -264,7 +264,7 @@ moduleFor('ember-debug', class extends TestCase {
     deprecate('foo', false, { until: 'forever' });
   }
 
-  ['@test Ember.deprecate without options.id triggers an assertion'](assert) {
+  ['@test deprecate without options.id triggers an assertion'](assert) {
     assert.expect(1);
     ENV._ENABLE_DEPRECATION_OPTIONS_SUPPORT = false;
 
@@ -275,7 +275,7 @@ moduleFor('ember-debug', class extends TestCase {
     );
   }
 
-  ['@test Ember.deprecate without options.until triggers a deprecation'](assert) {
+  ['@test deprecate without options.until triggers a deprecation'](assert) {
     assert.expect(2);
 
     registerHandler(function(message) {
@@ -289,7 +289,7 @@ moduleFor('ember-debug', class extends TestCase {
     deprecate('foo', false, { id: 'test' });
   }
 
-  ['@test Ember.deprecate without options.until triggers an assertion'](assert) {
+  ['@test deprecate without options.until triggers an assertion'](assert) {
     assert.expect(1);
     ENV._ENABLE_DEPRECATION_OPTIONS_SUPPORT = false;
 


### PR DESCRIPTION
#15723 Update `ember-debug` package to use rfc176 imports/naming conventions and update doc URLs to use `../release/..` for canonical path