### PR TITLE
Publish metadata file to S3.

### DIFF
--- a/bin/build-for-publishing.js
+++ b/bin/build-for-publishing.js
@@ -4,6 +4,7 @@
 const fs = require('fs');
 const path = require('path');
 const execSync = require('child_process').execSync;
+const VERSION = require('../broccoli/version').VERSION;
 
 /*
   Updates the `package.json`'s `version` string to be the same value that
@@ -11,7 +12,6 @@ const execSync = require('child_process').execSync;
 */
 function updatePackageJSONVersion() {
   let packageJSONPath = path.join(__dirname, '..', 'package.json');
-  let VERSION = require('../broccoli/version').VERSION;
 
   let pkgContents = fs.readFileSync(packageJSONPath, { encoding: 'utf-8' });
   let pkg = JSON.parse(pkgContents);
@@ -31,7 +31,6 @@ function updatePackageJSONVersion() {
 */
 function updateDocumentationVersion() {
   let docsPath = path.join(__dirname, '..', 'docs', 'data.json');
-  let VERSION = require('../broccoli/version').VERSION;
 
   let contents = fs.readFileSync(docsPath, { encoding: 'utf-8' });
   let docs = JSON.parse(contents);
@@ -51,3 +50,12 @@ updateDocumentationVersion();
 // using npm pack here because `yarn pack` does not honor the `package.json`'s `files`
 // property properly, and therefore the tarball generated is quite large (~7MB).
 execSync('npm pack');
+
+// generate build-metadata.json
+const metadata = {
+  version: VERSION,
+  buildType: process.env.BUILD_TYPE,
+  SHA: process.env.TRAVIS_COMMIT,
+  assetPath: `/${process.env.BUILD_TYPE}/shas/${process.env.TRAVIS_COMMIT}.tgz`,
+};
+fs.writeFileSync('build-metadata.json', JSON.stringify(metadata, null, 2), { encoding: 'utf-8' });

--- a/config/s3ProjectConfig.js
+++ b/config/s3ProjectConfig.js
@@ -26,24 +26,37 @@ function fileMap(revision, tag, date) {
     contentType: 'application/x-gzip',
     destinations: {
       'alpha': [
-        `alpha.tgz`,
         `alpha/daily/${date}.tgz`,
         `alpha/shas/${revision}.tgz`,
       ],
       'canary': [
-        `canary.tgz`,
         `canary/daily/${date}.tgz`,
         `canary/shas/${revision}.tgz`,
       ],
       'beta': [
-        `beta.tgz`,
         `beta/daily/${date}.tgz`,
         `beta/shas/${revision}.tgz`,
       ],
       'release': [
-        `release.tgz`,
         `release/daily/${date}.tgz`,
         `release/shas/${revision}.tgz`,
+      ],
+    }
+  };
+  filesToPublish['../build-metadata.json'] = {
+    contentType: 'application/json',
+    destinations: {
+      'alpha': [
+        'alpha.json',
+      ],
+      'canary': [
+        'canary.json',
+      ],
+      'beta': [
+        'beta.json',
+      ],
+      'release': [
+        'release.json',
       ],
     }
   };


### PR DESCRIPTION
Remove publishing tarball to `/${channel}.tgz` due to npm and yarn caching issues.

Publishes a new `/${channel}.json` file (in a stable location) that can be used by tooling to determine the correct asset path for the current channel build SHA.