### PR TITLE
[DOC release] Mark MutableEnumerable as private

### DIFF
--- a/packages/ember-runtime/lib/mixins/mutable_enumerable.js
+++ b/packages/ember-runtime/lib/mixins/mutable_enumerable.js
@@ -47,7 +47,7 @@ import {
   @class MutableEnumerable
   @namespace Ember
   @uses Ember.Enumerable
-  @public
+  @private
 */
 export default Mixin.create(Enumerable, {
 


### PR DESCRIPTION
This model is mistakenly marked public. It should be marked private like its sibling `Enumerable`.