### PR TITLE
[CLEANUP] Move computed and controllers tests to new testing style

### DIFF
--- a/packages/ember-runtime/tests/computed/computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/computed_macros_test.js
@@ -2,6 +2,8 @@ import {
   computed,
   alias,
   defineProperty,
+  get,
+  set
 } from 'ember-metal';
 import {
   empty,
@@ -20,485 +22,487 @@ import {
   and,
   or,
 } from '../../computed/computed_macros';
-import { testBoth } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 import EmberObject from '../../system/object';
 import { A as emberA } from '../../system/native_array';
 
-QUnit.module('CP macros');
-
-testBoth('Ember.computed.empty', function (get, set, assert) {
-  let obj = EmberObject.extend({
-    bestLannister: null,
-    lannisters: null,
-
-    bestLannisterUnspecified: empty('bestLannister'),
-    noLannistersKnown: empty('lannisters')
-  }).create({
-    lannisters: emberA()
-  });
-
-  assert.equal(get(obj, 'bestLannisterUnspecified'), true, 'bestLannister initially empty');
-  assert.equal(get(obj, 'noLannistersKnown'), true, 'lannisters initially empty');
-
-  get(obj, 'lannisters').pushObject('Tyrion');
-  set(obj, 'bestLannister', 'Tyrion');
-
-  assert.equal(get(obj, 'bestLannisterUnspecified'), false, 'empty respects strings');
-  assert.equal(get(obj, 'noLannistersKnown'), false, 'empty respects array mutations');
-});
-
-testBoth('Ember.computed.notEmpty', function(get, set, assert) {
-  let obj = EmberObject.extend({
-    bestLannister: null,
-    lannisters: null,
-
-    bestLannisterSpecified: notEmpty('bestLannister'),
-    LannistersKnown: notEmpty('lannisters')
-  }).create({
-    lannisters: emberA()
-  });
-
-  assert.equal(get(obj, 'bestLannisterSpecified'), false, 'bestLannister initially empty');
-  assert.equal(get(obj, 'LannistersKnown'), false, 'lannisters initially empty');
-
-  get(obj, 'lannisters').pushObject('Tyrion');
-  set(obj, 'bestLannister', 'Tyrion');
-
-  assert.equal(get(obj, 'bestLannisterSpecified'), true, 'empty respects strings');
-  assert.equal(get(obj, 'LannistersKnown'), true, 'empty respects array mutations');
-});
-
-testBoth('computed.not', function(get, set, assert) {
-  let obj = { foo: true };
-  defineProperty(obj, 'notFoo', not('foo'));
-  assert.equal(get(obj, 'notFoo'), false);
-
-  obj = { foo: { bar: true } };
-  defineProperty(obj, 'notFoo', not('foo.bar'));
-  assert.equal(get(obj, 'notFoo'), false);
-});
-
-testBoth('computed.empty', function(get, set, assert) {
-  let obj = { foo: [], bar: undefined, baz: null, quz: '' };
-  defineProperty(obj, 'fooEmpty', empty('foo'));
-  defineProperty(obj, 'barEmpty', empty('bar'));
-  defineProperty(obj, 'bazEmpty', empty('baz'));
-  defineProperty(obj, 'quzEmpty', empty('quz'));
-
-  assert.equal(get(obj, 'fooEmpty'), true);
-  set(obj, 'foo', [1]);
-  assert.equal(get(obj, 'fooEmpty'), false);
-  assert.equal(get(obj, 'barEmpty'), true);
-  assert.equal(get(obj, 'bazEmpty'), true);
-  assert.equal(get(obj, 'quzEmpty'), true);
-  set(obj, 'quz', 'asdf');
-  assert.equal(get(obj, 'quzEmpty'), false);
-});
-
-testBoth('computed.bool', function(get, set, assert) {
-  let obj = { foo() {}, bar: 'asdf', baz: null, quz: false };
-  defineProperty(obj, 'fooBool', bool('foo'));
-  defineProperty(obj, 'barBool', bool('bar'));
-  defineProperty(obj, 'bazBool', bool('baz'));
-  defineProperty(obj, 'quzBool', bool('quz'));
-  assert.equal(get(obj, 'fooBool'), true);
-  assert.equal(get(obj, 'barBool'), true);
-  assert.equal(get(obj, 'bazBool'), false);
-  assert.equal(get(obj, 'quzBool'), false);
-});
-
-testBoth('computed.alias', function(get, set, assert) {
-  let obj = { bar: 'asdf', baz: null, quz: false };
-  defineProperty(obj, 'bay', computed(function() {
-    return 'apple';
-  }));
-
-  defineProperty(obj, 'barAlias', alias('bar'));
-  defineProperty(obj, 'bazAlias', alias('baz'));
-  defineProperty(obj, 'quzAlias', alias('quz'));
-  defineProperty(obj, 'bayAlias', alias('bay'));
-
-  assert.equal(get(obj, 'barAlias'), 'asdf');
-  assert.equal(get(obj, 'bazAlias'), null);
-  assert.equal(get(obj, 'quzAlias'), false);
-  assert.equal(get(obj, 'bayAlias'), 'apple');
-
-  set(obj, 'barAlias', 'newBar');
-  set(obj, 'bazAlias', 'newBaz');
-  set(obj, 'quzAlias', null);
-
-  assert.equal(get(obj, 'barAlias'), 'newBar');
-  assert.equal(get(obj, 'bazAlias'), 'newBaz');
-  assert.equal(get(obj, 'quzAlias'), null);
-
-  assert.equal(get(obj, 'bar'), 'newBar');
-  assert.equal(get(obj, 'baz'), 'newBaz');
-  assert.equal(get(obj, 'quz'), null);
-});
-
-testBoth('computed.alias set', function(get, set, assert) {
-  let obj = {};
-  let constantValue = 'always `a`';
-
-  defineProperty(obj, 'original', computed({
-    get: function() { return constantValue; },
-    set: function() { return constantValue; }
-  }));
-  defineProperty(obj, 'aliased', alias('original'));
-
-  assert.equal(get(obj, 'original'), constantValue);
-  assert.equal(get(obj, 'aliased'), constantValue);
-
-  set(obj, 'aliased', 'should not set to this value');
-
-  assert.equal(get(obj, 'original'), constantValue);
-  assert.equal(get(obj, 'aliased'), constantValue);
-});
-
-testBoth('computed.match', function(get, set, assert) {
-  let obj = { name: 'Paul' };
-  defineProperty(obj, 'isPaul', match('name', /Paul/));
-
-  assert.equal(get(obj, 'isPaul'), true, 'is Paul');
-
-  set(obj, 'name', 'Pierre');
-
-  assert.equal(get(obj, 'isPaul'), false, 'is not Paul anymore');
-});
-
-testBoth('computed.notEmpty', function(get, set, assert) {
-  let obj = { items: [1] };
-  defineProperty(obj, 'hasItems', notEmpty('items'));
-
-  assert.equal(get(obj, 'hasItems'), true, 'is not empty');
-
-  set(obj, 'items', []);
-
-  assert.equal(get(obj, 'hasItems'), false, 'is empty');
-});
-
-testBoth('computed.equal', function(get, set, assert) {
-  let obj = { name: 'Paul' };
-  defineProperty(obj, 'isPaul', computedEqual('name', 'Paul'));
-
-  assert.equal(get(obj, 'isPaul'), true, 'is Paul');
-
-  set(obj, 'name', 'Pierre');
-
-  assert.equal(get(obj, 'isPaul'), false, 'is not Paul anymore');
-});
-
-testBoth('computed.gt', function(get, set, assert) {
-  let obj = { number: 2 };
-  defineProperty(obj, 'isGreaterThenOne', gt('number', 1));
-
-  assert.equal(get(obj, 'isGreaterThenOne'), true, 'is gt');
-
-  set(obj, 'number', 1);
-
-  assert.equal(get(obj, 'isGreaterThenOne'), false, 'is not gt');
-
-  set(obj, 'number', 0);
-
-  assert.equal(get(obj, 'isGreaterThenOne'), false, 'is not gt');
-});
-
-testBoth('computed.gte', function(get, set, assert) {
-  let obj = { number: 2 };
-  defineProperty(obj, 'isGreaterOrEqualThenOne', gte('number', 1));
-
-  assert.equal(get(obj, 'isGreaterOrEqualThenOne'), true, 'is gte');
-
-  set(obj, 'number', 1);
-
-  assert.equal(get(obj, 'isGreaterOrEqualThenOne'), true, 'is gte');
-
-  set(obj, 'number', 0);
-
-  assert.equal(get(obj, 'isGreaterOrEqualThenOne'), false, 'is not gte');
-});
-
-testBoth('computed.lt', function(get, set, assert) {
-  let obj = { number: 0 };
-  defineProperty(obj, 'isLesserThenOne', lt('number', 1));
-
-  assert.equal(get(obj, 'isLesserThenOne'), true, 'is lt');
-
-  set(obj, 'number', 1);
-
-  assert.equal(get(obj, 'isLesserThenOne'), false, 'is not lt');
-
-  set(obj, 'number', 2);
-
-  assert.equal(get(obj, 'isLesserThenOne'), false, 'is not lt');
-});
-
-testBoth('computed.lte', function(get, set, assert) {
-  let obj = { number: 0 };
-  defineProperty(obj, 'isLesserOrEqualThenOne', lte('number', 1));
-
-  assert.equal(get(obj, 'isLesserOrEqualThenOne'), true, 'is lte');
-
-  set(obj, 'number', 1);
-
-  assert.equal(get(obj, 'isLesserOrEqualThenOne'), true, 'is lte');
-
-  set(obj, 'number', 2);
-
-  assert.equal(get(obj, 'isLesserOrEqualThenOne'), false, 'is not lte');
-});
-
-testBoth('computed.and two properties', function(get, set, assert) {
-  let obj = { one: true, two: true };
-  defineProperty(obj, 'oneAndTwo', and('one', 'two'));
-
-  assert.equal(get(obj, 'oneAndTwo'), true, 'one and two');
-
-  set(obj, 'one', false);
-
-  assert.equal(get(obj, 'oneAndTwo'), false, 'one and not two');
-
-  set(obj, 'one', null);
-  set(obj, 'two', 'Yes');
-
-  assert.equal(get(obj, 'oneAndTwo'), null, 'returns falsy value as in &&');
-
-  set(obj, 'one', true);
-  set(obj, 'two', 2);
-
-  assert.equal(get(obj, 'oneAndTwo'), 2, 'returns truthy value as in &&');
-});
-
-testBoth('computed.and three properties', function(get, set, assert) {
-  let obj = { one: true, two: true, three: true };
-  defineProperty(obj, 'oneTwoThree', and('one', 'two', 'three'));
-
-  assert.equal(get(obj, 'oneTwoThree'), true, 'one and two and three');
-
-  set(obj, 'one', false);
-
-  assert.equal(get(obj, 'oneTwoThree'), false, 'one and not two and not three');
-
-  set(obj, 'one', true);
-  set(obj, 'two', 2);
-  set(obj, 'three', 3);
-
-  assert.equal(get(obj, 'oneTwoThree'), 3, 'returns truthy value as in &&');
-});
-
-testBoth('computed.and expand properties', function(get, set, assert) {
-  let obj = { one: true, two: true, three: true };
-  defineProperty(obj, 'oneTwoThree', and('{one,two,three}'));
-
-  assert.equal(get(obj, 'oneTwoThree'), true, 'one and two and three');
-
-  set(obj, 'one', false);
-
-  assert.equal(get(obj, 'oneTwoThree'), false, 'one and not two and not three');
-
-  set(obj, 'one', true);
-  set(obj, 'two', 2);
-  set(obj, 'three', 3);
-
-  assert.equal(get(obj, 'oneTwoThree'), 3, 'returns truthy value as in &&');
-});
-
-testBoth('computed.or two properties', function(get, set, assert) {
-  let obj = { one: true, two: true };
-  defineProperty(obj, 'oneOrTwo', or('one', 'two'));
-
-  assert.equal(get(obj, 'oneOrTwo'), true, 'one or two');
-
-  set(obj, 'one', false);
-
-  assert.equal(get(obj, 'oneOrTwo'), true, 'one or two');
-
-  set(obj, 'two', false);
-
-  assert.equal(get(obj, 'oneOrTwo'), false, 'nor one nor two');
-
-  set(obj, 'two', null);
-
-  assert.equal(get(obj, 'oneOrTwo'), null, 'returns last falsy value as in ||');
-
-  set(obj, 'two', true);
-
-  assert.equal(get(obj, 'oneOrTwo'), true, 'one or two');
-
-  set(obj, 'one', 1);
-
-  assert.equal(get(obj, 'oneOrTwo'), 1, 'returns truthy value as in ||');
-});
-
-testBoth('computed.or three properties', function(get, set, assert) {
-  let obj = { one: true, two: true, three: true };
-  defineProperty(obj, 'oneTwoThree', or('one', 'two', 'three'));
-
-  assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
-
-  set(obj, 'one', false);
-
-  assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
-
-  set(obj, 'two', false);
-
-  assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
-
-  set(obj, 'three', false);
-
-  assert.equal(get(obj, 'oneTwoThree'), false, 'one or two or three');
-
-  set(obj, 'three', null);
-
-  assert.equal(get(obj, 'oneTwoThree'), null, 'returns last falsy value as in ||');
-
-  set(obj, 'two', true);
-
-  assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
-
-  set(obj, 'one', 1);
-
-  assert.equal(get(obj, 'oneTwoThree'), 1, 'returns truthy value as in ||');
-});
-
-testBoth('computed.or expand properties', function(get, set, assert) {
-  let obj = { one: true, two: true, three: true };
-  defineProperty(obj, 'oneTwoThree', or('{one,two,three}'));
-
-  assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
-
-  set(obj, 'one', false);
-
-  assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
-
-  set(obj, 'two', false);
-
-  assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
-
-  set(obj, 'three', false);
-
-  assert.equal(get(obj, 'oneTwoThree'), false, 'one or two or three');
-
-  set(obj, 'three', null);
-
-  assert.equal(get(obj, 'oneTwoThree'), null, 'returns last falsy value as in ||');
-
-  set(obj, 'two', true);
-
-  assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
-
-  set(obj, 'one', 1);
-
-  assert.equal(get(obj, 'oneTwoThree'), 1, 'returns truthy value as in ||');
-});
-
-testBoth('computed.or and computed.and warn about dependent keys with spaces', function() {
-  let obj = { one: true, two: true };
-  expectAssertion(function() {
-    defineProperty(obj, 'oneOrTwo', or('one', 'two three'));
-  }, /Dependent keys passed to Ember\.computed\.or\(\) can't have spaces\./);
-
-  expectAssertion(function() {
-    defineProperty(obj, 'oneAndTwo', and('one', 'two three'));
-  }, /Dependent keys passed to Ember\.computed\.and\(\) can't have spaces\./);
-});
-
-testBoth('computed.oneWay', function(get, set, assert) {
-  let obj = {
-    firstName: 'Teddy',
-    lastName: 'Zeenny'
-  };
-
-  defineProperty(obj, 'nickName', oneWay('firstName'));
-
-  assert.equal(get(obj, 'firstName'), 'Teddy');
-  assert.equal(get(obj, 'lastName'), 'Zeenny');
-  assert.equal(get(obj, 'nickName'), 'Teddy');
-
-  set(obj, 'nickName', 'TeddyBear');
-
-  assert.equal(get(obj, 'firstName'), 'Teddy');
-  assert.equal(get(obj, 'lastName'), 'Zeenny');
-
-  assert.equal(get(obj, 'nickName'), 'TeddyBear');
-
-  set(obj, 'firstName', 'TEDDDDDDDDYYY');
-
-  assert.equal(get(obj, 'nickName'), 'TeddyBear');
-});
-
-testBoth('computed.readOnly', function(get, set, assert) {
-  let obj = {
-    firstName: 'Teddy',
-    lastName: 'Zeenny'
-  };
-
-  defineProperty(obj, 'nickName', readOnly('firstName'));
-
-  assert.equal(get(obj, 'firstName'), 'Teddy');
-  assert.equal(get(obj, 'lastName'), 'Zeenny');
-  assert.equal(get(obj, 'nickName'), 'Teddy');
-
-  assert.throws(function() {
-    set(obj, 'nickName', 'TeddyBear');
-  }, / /);
-
-  assert.equal(get(obj, 'firstName'), 'Teddy');
-  assert.equal(get(obj, 'lastName'), 'Zeenny');
-
-  assert.equal(get(obj, 'nickName'), 'Teddy');
-
-  set(obj, 'firstName', 'TEDDDDDDDDYYY');
-
-  assert.equal(get(obj, 'nickName'), 'TEDDDDDDDDYYY');
-});
-
-testBoth('computed.deprecatingAlias', function(get, set, assert) {
-  let obj = { bar: 'asdf', baz: null, quz: false };
-  defineProperty(obj, 'bay', computed(function() {
-    return 'apple';
-  }));
-
-  defineProperty(obj, 'barAlias', deprecatingAlias('bar'));
-  defineProperty(obj, 'bazAlias', deprecatingAlias('baz'));
-  defineProperty(obj, 'quzAlias', deprecatingAlias('quz'));
-  defineProperty(obj, 'bayAlias', deprecatingAlias('bay'));
-
-  expectDeprecation(function() {
+moduleFor('CP macros', class extends AbstractTestCase {
+
+  ['@test Ember.computed.empty'](assert) {
+    let obj = EmberObject.extend({
+      bestLannister: null,
+      lannisters: null,
+  
+      bestLannisterUnspecified: empty('bestLannister'),
+      noLannistersKnown: empty('lannisters')
+    }).create({
+      lannisters: emberA()
+    });
+  
+    assert.equal(get(obj, 'bestLannisterUnspecified'), true, 'bestLannister initially empty');
+    assert.equal(get(obj, 'noLannistersKnown'), true, 'lannisters initially empty');
+  
+    get(obj, 'lannisters').pushObject('Tyrion');
+    set(obj, 'bestLannister', 'Tyrion');
+  
+    assert.equal(get(obj, 'bestLannisterUnspecified'), false, 'empty respects strings');
+    assert.equal(get(obj, 'noLannistersKnown'), false, 'empty respects array mutations');
+  }
+  
+  ['@test Ember.computed.notEmpty'](assert) {
+    let obj = EmberObject.extend({
+      bestLannister: null,
+      lannisters: null,
+  
+      bestLannisterSpecified: notEmpty('bestLannister'),
+      LannistersKnown: notEmpty('lannisters')
+    }).create({
+      lannisters: emberA()
+    });
+  
+    assert.equal(get(obj, 'bestLannisterSpecified'), false, 'bestLannister initially empty');
+    assert.equal(get(obj, 'LannistersKnown'), false, 'lannisters initially empty');
+  
+    get(obj, 'lannisters').pushObject('Tyrion');
+    set(obj, 'bestLannister', 'Tyrion');
+  
+    assert.equal(get(obj, 'bestLannisterSpecified'), true, 'empty respects strings');
+    assert.equal(get(obj, 'LannistersKnown'), true, 'empty respects array mutations');
+  }
+  
+  ['@test computed.not'](assert) {
+    let obj = { foo: true };
+    defineProperty(obj, 'notFoo', not('foo'));
+    assert.equal(get(obj, 'notFoo'), false);
+  
+    obj = { foo: { bar: true } };
+    defineProperty(obj, 'notFoo', not('foo.bar'));
+    assert.equal(get(obj, 'notFoo'), false);
+  }
+  
+  ['@test computed.empty'](assert) {
+    let obj = { foo: [], bar: undefined, baz: null, quz: '' };
+    defineProperty(obj, 'fooEmpty', empty('foo'));
+    defineProperty(obj, 'barEmpty', empty('bar'));
+    defineProperty(obj, 'bazEmpty', empty('baz'));
+    defineProperty(obj, 'quzEmpty', empty('quz'));
+  
+    assert.equal(get(obj, 'fooEmpty'), true);
+    set(obj, 'foo', [1]);
+    assert.equal(get(obj, 'fooEmpty'), false);
+    assert.equal(get(obj, 'barEmpty'), true);
+    assert.equal(get(obj, 'bazEmpty'), true);
+    assert.equal(get(obj, 'quzEmpty'), true);
+    set(obj, 'quz', 'asdf');
+    assert.equal(get(obj, 'quzEmpty'), false);
+  }
+  
+  ['@test computed.bool'](assert) {
+    let obj = { foo() {}, bar: 'asdf', baz: null, quz: false };
+    defineProperty(obj, 'fooBool', bool('foo'));
+    defineProperty(obj, 'barBool', bool('bar'));
+    defineProperty(obj, 'bazBool', bool('baz'));
+    defineProperty(obj, 'quzBool', bool('quz'));
+    assert.equal(get(obj, 'fooBool'), true);
+    assert.equal(get(obj, 'barBool'), true);
+    assert.equal(get(obj, 'bazBool'), false);
+    assert.equal(get(obj, 'quzBool'), false);
+  }
+  
+  ['@test computed.alias'](assert) {
+    let obj = { bar: 'asdf', baz: null, quz: false };
+    defineProperty(obj, 'bay', computed(function() {
+      return 'apple';
+    }));
+  
+    defineProperty(obj, 'barAlias', alias('bar'));
+    defineProperty(obj, 'bazAlias', alias('baz'));
+    defineProperty(obj, 'quzAlias', alias('quz'));
+    defineProperty(obj, 'bayAlias', alias('bay'));
+  
     assert.equal(get(obj, 'barAlias'), 'asdf');
-  }, 'Usage of `barAlias` is deprecated, use `bar` instead.');
-
-  expectDeprecation(function() {
     assert.equal(get(obj, 'bazAlias'), null);
-  }, 'Usage of `bazAlias` is deprecated, use `baz` instead.');
-
-  expectDeprecation(function() {
     assert.equal(get(obj, 'quzAlias'), false);
-  }, 'Usage of `quzAlias` is deprecated, use `quz` instead.');
-
-  expectDeprecation(function() {
     assert.equal(get(obj, 'bayAlias'), 'apple');
-  }, 'Usage of `bayAlias` is deprecated, use `bay` instead.');
-
-  expectDeprecation(function() {
+  
     set(obj, 'barAlias', 'newBar');
-  }, 'Usage of `barAlias` is deprecated, use `bar` instead.');
-
-  expectDeprecation(function() {
     set(obj, 'bazAlias', 'newBaz');
-  }, 'Usage of `bazAlias` is deprecated, use `baz` instead.');
-
-  expectDeprecation(function() {
     set(obj, 'quzAlias', null);
-  }, 'Usage of `quzAlias` is deprecated, use `quz` instead.');
-
-
-  assert.equal(get(obj, 'barAlias'), 'newBar');
-  assert.equal(get(obj, 'bazAlias'), 'newBaz');
-  assert.equal(get(obj, 'quzAlias'), null);
-
-  assert.equal(get(obj, 'bar'), 'newBar');
-  assert.equal(get(obj, 'baz'), 'newBaz');
-  assert.equal(get(obj, 'quz'), null);
+  
+    assert.equal(get(obj, 'barAlias'), 'newBar');
+    assert.equal(get(obj, 'bazAlias'), 'newBaz');
+    assert.equal(get(obj, 'quzAlias'), null);
+  
+    assert.equal(get(obj, 'bar'), 'newBar');
+    assert.equal(get(obj, 'baz'), 'newBaz');
+    assert.equal(get(obj, 'quz'), null);
+  }
+  
+  ['@test computed.alias set'](assert) {
+    let obj = {};
+    let constantValue = 'always `a`';
+  
+    defineProperty(obj, 'original', computed({
+      get: function() { return constantValue; },
+      set: function() { return constantValue; }
+    }));
+    defineProperty(obj, 'aliased', alias('original'));
+  
+    assert.equal(get(obj, 'original'), constantValue);
+    assert.equal(get(obj, 'aliased'), constantValue);
+  
+    set(obj, 'aliased', 'should not set to this value');
+  
+    assert.equal(get(obj, 'original'), constantValue);
+    assert.equal(get(obj, 'aliased'), constantValue);
+  }
+  
+  ['@test computed.match'](assert) {
+    let obj = { name: 'Paul' };
+    defineProperty(obj, 'isPaul', match('name', /Paul/));
+  
+    assert.equal(get(obj, 'isPaul'), true, 'is Paul');
+  
+    set(obj, 'name', 'Pierre');
+  
+    assert.equal(get(obj, 'isPaul'), false, 'is not Paul anymore');
+  }
+  
+  ['@test computed.notEmpty'](assert) {
+    let obj = { items: [1] };
+    defineProperty(obj, 'hasItems', notEmpty('items'));
+  
+    assert.equal(get(obj, 'hasItems'), true, 'is not empty');
+  
+    set(obj, 'items', []);
+  
+    assert.equal(get(obj, 'hasItems'), false, 'is empty');
+  }
+  
+  ['@test computed.equal'](assert) {
+    let obj = { name: 'Paul' };
+    defineProperty(obj, 'isPaul', computedEqual('name', 'Paul'));
+  
+    assert.equal(get(obj, 'isPaul'), true, 'is Paul');
+  
+    set(obj, 'name', 'Pierre');
+  
+    assert.equal(get(obj, 'isPaul'), false, 'is not Paul anymore');
+  }
+  
+  ['@test computed.gt'](assert) {
+    let obj = { number: 2 };
+    defineProperty(obj, 'isGreaterThenOne', gt('number', 1));
+  
+    assert.equal(get(obj, 'isGreaterThenOne'), true, 'is gt');
+  
+    set(obj, 'number', 1);
+  
+    assert.equal(get(obj, 'isGreaterThenOne'), false, 'is not gt');
+  
+    set(obj, 'number', 0);
+  
+    assert.equal(get(obj, 'isGreaterThenOne'), false, 'is not gt');
+  }
+  
+  ['@test computed.gte'](assert) {
+    let obj = { number: 2 };
+    defineProperty(obj, 'isGreaterOrEqualThenOne', gte('number', 1));
+  
+    assert.equal(get(obj, 'isGreaterOrEqualThenOne'), true, 'is gte');
+  
+    set(obj, 'number', 1);
+  
+    assert.equal(get(obj, 'isGreaterOrEqualThenOne'), true, 'is gte');
+  
+    set(obj, 'number', 0);
+  
+    assert.equal(get(obj, 'isGreaterOrEqualThenOne'), false, 'is not gte');
+  }
+  
+  ['@test computed.lt'](assert) {
+    let obj = { number: 0 };
+    defineProperty(obj, 'isLesserThenOne', lt('number', 1));
+  
+    assert.equal(get(obj, 'isLesserThenOne'), true, 'is lt');
+  
+    set(obj, 'number', 1);
+  
+    assert.equal(get(obj, 'isLesserThenOne'), false, 'is not lt');
+  
+    set(obj, 'number', 2);
+  
+    assert.equal(get(obj, 'isLesserThenOne'), false, 'is not lt');
+  }
+  
+  ['@test computed.lte'](assert) {
+    let obj = { number: 0 };
+    defineProperty(obj, 'isLesserOrEqualThenOne', lte('number', 1));
+  
+    assert.equal(get(obj, 'isLesserOrEqualThenOne'), true, 'is lte');
+  
+    set(obj, 'number', 1);
+  
+    assert.equal(get(obj, 'isLesserOrEqualThenOne'), true, 'is lte');
+  
+    set(obj, 'number', 2);
+  
+    assert.equal(get(obj, 'isLesserOrEqualThenOne'), false, 'is not lte');
+  }
+  
+  ['@test computed.and two properties'](assert) {
+    let obj = { one: true, two: true };
+    defineProperty(obj, 'oneAndTwo', and('one', 'two'));
+  
+    assert.equal(get(obj, 'oneAndTwo'), true, 'one and two');
+  
+    set(obj, 'one', false);
+  
+    assert.equal(get(obj, 'oneAndTwo'), false, 'one and not two');
+  
+    set(obj, 'one', null);
+    set(obj, 'two', 'Yes');
+  
+    assert.equal(get(obj, 'oneAndTwo'), null, 'returns falsy value as in &&');
+  
+    set(obj, 'one', true);
+    set(obj, 'two', 2);
+  
+    assert.equal(get(obj, 'oneAndTwo'), 2, 'returns truthy value as in &&');
+  }
+  
+  ['@test computed.and three properties'](assert) {
+    let obj = { one: true, two: true, three: true };
+    defineProperty(obj, 'oneTwoThree', and('one', 'two', 'three'));
+  
+    assert.equal(get(obj, 'oneTwoThree'), true, 'one and two and three');
+  
+    set(obj, 'one', false);
+  
+    assert.equal(get(obj, 'oneTwoThree'), false, 'one and not two and not three');
+  
+    set(obj, 'one', true);
+    set(obj, 'two', 2);
+    set(obj, 'three', 3);
+  
+    assert.equal(get(obj, 'oneTwoThree'), 3, 'returns truthy value as in &&');
+  }
+  
+  ['@test computed.and expand properties'](assert) {
+    let obj = { one: true, two: true, three: true };
+    defineProperty(obj, 'oneTwoThree', and('{one,two,three}'));
+  
+    assert.equal(get(obj, 'oneTwoThree'), true, 'one and two and three');
+  
+    set(obj, 'one', false);
+  
+    assert.equal(get(obj, 'oneTwoThree'), false, 'one and not two and not three');
+  
+    set(obj, 'one', true);
+    set(obj, 'two', 2);
+    set(obj, 'three', 3);
+  
+    assert.equal(get(obj, 'oneTwoThree'), 3, 'returns truthy value as in &&');
+  }
+  
+  ['@test computed.or two properties'](assert) {
+    let obj = { one: true, two: true };
+    defineProperty(obj, 'oneOrTwo', or('one', 'two'));
+  
+    assert.equal(get(obj, 'oneOrTwo'), true, 'one or two');
+  
+    set(obj, 'one', false);
+  
+    assert.equal(get(obj, 'oneOrTwo'), true, 'one or two');
+  
+    set(obj, 'two', false);
+  
+    assert.equal(get(obj, 'oneOrTwo'), false, 'nor one nor two');
+  
+    set(obj, 'two', null);
+  
+    assert.equal(get(obj, 'oneOrTwo'), null, 'returns last falsy value as in ||');
+  
+    set(obj, 'two', true);
+  
+    assert.equal(get(obj, 'oneOrTwo'), true, 'one or two');
+  
+    set(obj, 'one', 1);
+  
+    assert.equal(get(obj, 'oneOrTwo'), 1, 'returns truthy value as in ||');
+  }
+  
+  ['@test computed.or three properties'](assert) {
+    let obj = { one: true, two: true, three: true };
+    defineProperty(obj, 'oneTwoThree', or('one', 'two', 'three'));
+  
+    assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+  
+    set(obj, 'one', false);
+  
+    assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+  
+    set(obj, 'two', false);
+  
+    assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+  
+    set(obj, 'three', false);
+  
+    assert.equal(get(obj, 'oneTwoThree'), false, 'one or two or three');
+  
+    set(obj, 'three', null);
+  
+    assert.equal(get(obj, 'oneTwoThree'), null, 'returns last falsy value as in ||');
+  
+    set(obj, 'two', true);
+  
+    assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+  
+    set(obj, 'one', 1);
+  
+    assert.equal(get(obj, 'oneTwoThree'), 1, 'returns truthy value as in ||');
+  }
+  
+  ['@test computed.or expand properties'](assert) {
+    let obj = { one: true, two: true, three: true };
+    defineProperty(obj, 'oneTwoThree', or('{one,two,three}'));
+  
+    assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+  
+    set(obj, 'one', false);
+  
+    assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+  
+    set(obj, 'two', false);
+  
+    assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+  
+    set(obj, 'three', false);
+  
+    assert.equal(get(obj, 'oneTwoThree'), false, 'one or two or three');
+  
+    set(obj, 'three', null);
+  
+    assert.equal(get(obj, 'oneTwoThree'), null, 'returns last falsy value as in ||');
+  
+    set(obj, 'two', true);
+  
+    assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+  
+    set(obj, 'one', 1);
+  
+    assert.equal(get(obj, 'oneTwoThree'), 1, 'returns truthy value as in ||');
+  }
+  
+  ['@test computed.or and computed.and warn about dependent keys with spaces']() {
+    let obj = { one: true, two: true };
+    expectAssertion(function() {
+      defineProperty(obj, 'oneOrTwo', or('one', 'two three'));
+    }, /Dependent keys passed to Ember\.computed\.or\(\) can't have spaces\./);
+  
+    expectAssertion(function() {
+      defineProperty(obj, 'oneAndTwo', and('one', 'two three'));
+    }, /Dependent keys passed to Ember\.computed\.and\(\) can't have spaces\./);
+  }
+  
+  ['@test computed.oneWay'](assert) {
+    let obj = {
+      firstName: 'Teddy',
+      lastName: 'Zeenny'
+    };
+  
+    defineProperty(obj, 'nickName', oneWay('firstName'));
+  
+    assert.equal(get(obj, 'firstName'), 'Teddy');
+    assert.equal(get(obj, 'lastName'), 'Zeenny');
+    assert.equal(get(obj, 'nickName'), 'Teddy');
+  
+    set(obj, 'nickName', 'TeddyBear');
+  
+    assert.equal(get(obj, 'firstName'), 'Teddy');
+    assert.equal(get(obj, 'lastName'), 'Zeenny');
+  
+    assert.equal(get(obj, 'nickName'), 'TeddyBear');
+  
+    set(obj, 'firstName', 'TEDDDDDDDDYYY');
+  
+    assert.equal(get(obj, 'nickName'), 'TeddyBear');
+  }
+  
+  ['@test computed.readOnly'](assert) {
+    let obj = {
+      firstName: 'Teddy',
+      lastName: 'Zeenny'
+    };
+  
+    defineProperty(obj, 'nickName', readOnly('firstName'));
+  
+    assert.equal(get(obj, 'firstName'), 'Teddy');
+    assert.equal(get(obj, 'lastName'), 'Zeenny');
+    assert.equal(get(obj, 'nickName'), 'Teddy');
+  
+    assert.throws(function() {
+      set(obj, 'nickName', 'TeddyBear');
+    }, / /);
+  
+    assert.equal(get(obj, 'firstName'), 'Teddy');
+    assert.equal(get(obj, 'lastName'), 'Zeenny');
+  
+    assert.equal(get(obj, 'nickName'), 'Teddy');
+  
+    set(obj, 'firstName', 'TEDDDDDDDDYYY');
+  
+    assert.equal(get(obj, 'nickName'), 'TEDDDDDDDDYYY');
+  }
+  
+  ['@test computed.deprecatingAlias'](assert) {
+    let obj = { bar: 'asdf', baz: null, quz: false };
+    defineProperty(obj, 'bay', computed(function() {
+      return 'apple';
+    }));
+  
+    defineProperty(obj, 'barAlias', deprecatingAlias('bar'));
+    defineProperty(obj, 'bazAlias', deprecatingAlias('baz'));
+    defineProperty(obj, 'quzAlias', deprecatingAlias('quz'));
+    defineProperty(obj, 'bayAlias', deprecatingAlias('bay'));
+  
+    expectDeprecation(function() {
+      assert.equal(get(obj, 'barAlias'), 'asdf');
+    }, 'Usage of `barAlias` is deprecated, use `bar` instead.');
+  
+    expectDeprecation(function() {
+      assert.equal(get(obj, 'bazAlias'), null);
+    }, 'Usage of `bazAlias` is deprecated, use `baz` instead.');
+  
+    expectDeprecation(function() {
+      assert.equal(get(obj, 'quzAlias'), false);
+    }, 'Usage of `quzAlias` is deprecated, use `quz` instead.');
+  
+    expectDeprecation(function() {
+      assert.equal(get(obj, 'bayAlias'), 'apple');
+    }, 'Usage of `bayAlias` is deprecated, use `bay` instead.');
+  
+    expectDeprecation(function() {
+      set(obj, 'barAlias', 'newBar');
+    }, 'Usage of `barAlias` is deprecated, use `bar` instead.');
+  
+    expectDeprecation(function() {
+      set(obj, 'bazAlias', 'newBaz');
+    }, 'Usage of `bazAlias` is deprecated, use `baz` instead.');
+  
+    expectDeprecation(function() {
+      set(obj, 'quzAlias', null);
+    }, 'Usage of `quzAlias` is deprecated, use `quz` instead.');
+  
+  
+    assert.equal(get(obj, 'barAlias'), 'newBar');
+    assert.equal(get(obj, 'bazAlias'), 'newBaz');
+    assert.equal(get(obj, 'quzAlias'), null);
+  
+    assert.equal(get(obj, 'bar'), 'newBar');
+    assert.equal(get(obj, 'baz'), 'newBaz');
+    assert.equal(get(obj, 'quz'), null);
+  }
 });
+

--- a/packages/ember-runtime/tests/controllers/controller_test.js
+++ b/packages/ember-runtime/tests/controllers/controller_test.js
@@ -6,180 +6,185 @@ import { Mixin, get } from 'ember-metal';
 import EmberObject from '../../system/object';
 import inject from '../../inject';
 import { buildOwner } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
-QUnit.module('Controller event handling');
-
-QUnit.test('Action can be handled by a function on actions object', function(assert) {
-  assert.expect(1);
-  let TestController = Controller.extend({
-    actions: {
-      poke() {
-        assert.ok(true, 'poked');
-      }
-    }
-  });
-  let controller = TestController.create();
-  controller.send('poke');
-});
-
-QUnit.test('A handled action can be bubbled to the target for continued processing', function(assert) {
-  assert.expect(2);
-  let TestController = Controller.extend({
-    actions: {
-      poke() {
-        assert.ok(true, 'poked 1');
-        return true;
-      }
-    }
-  });
-
-  let controller = TestController.create({
-    target: Controller.extend({
+moduleFor('Controller event handling', class extends AbstractTestCase {
+  
+  ['@test Action can be handled by a function on actions object'](assert) {
+    assert.expect(1);
+    let TestController = Controller.extend({
       actions: {
         poke() {
-          assert.ok(true, 'poked 2');
+          assert.ok(true, 'poked');
         }
       }
-    }).create()
-  });
-  controller.send('poke');
+    });
+    let controller = TestController.create();
+    controller.send('poke');
+  }
+
+  ['@test A handled action can be bubbled to the target for continued processing'](assert) {
+    assert.expect(2);
+    let TestController = Controller.extend({
+      actions: {
+        poke() {
+          assert.ok(true, 'poked 1');
+          return true;
+        }
+      }
+    });
+
+    let controller = TestController.create({
+      target: Controller.extend({
+        actions: {
+          poke() {
+            assert.ok(true, 'poked 2');
+          }
+        }
+      }).create()
+    });
+    controller.send('poke');
+  }
+
+  ['@test Action can be handled by a superclass\' actions object'](assert) {
+    assert.expect(4);
+
+    let SuperController = Controller.extend({
+      actions: {
+        foo() {
+          assert.ok(true, 'foo');
+        },
+        bar(msg) {
+          assert.equal(msg, 'HELLO');
+        }
+      }
+    });
+
+    let BarControllerMixin = Mixin.create({
+      actions: {
+        bar(msg) {
+          assert.equal(msg, 'HELLO');
+          this._super(msg);
+        }
+      }
+    });
+
+    let IndexController = SuperController.extend(BarControllerMixin, {
+      actions: {
+        baz() {
+          assert.ok(true, 'baz');
+        }
+      }
+    });
+
+    let controller = IndexController.create({});
+    controller.send('foo');
+    controller.send('bar', 'HELLO');
+    controller.send('baz');
+  }
 });
 
-QUnit.test('Action can be handled by a superclass\' actions object', function(assert) {
-  assert.expect(4);
-
-  let SuperController = Controller.extend({
-    actions: {
-      foo() {
-        assert.ok(true, 'foo');
-      },
-      bar(msg) {
-        assert.equal(msg, 'HELLO');
-      }
-    }
-  });
-
-  let BarControllerMixin = Mixin.create({
-    actions: {
-      bar(msg) {
-        assert.equal(msg, 'HELLO');
-        this._super(msg);
-      }
-    }
-  });
-
-  let IndexController = SuperController.extend(BarControllerMixin, {
-    actions: {
-      baz() {
-        assert.ok(true, 'baz');
-      }
-    }
-  });
-
-  let controller = IndexController.create({});
-  controller.send('foo');
-  controller.send('bar', 'HELLO');
-  controller.send('baz');
-});
-
-QUnit.module('Controller deprecations');
-
-QUnit.module('Controller Content -> Model Alias');
-
-QUnit.test('`content` is a deprecated alias of `model`', function(assert) {
-  assert.expect(2);
-  let controller = Controller.extend({
-    model: 'foo-bar'
-  }).create();
-
-  expectDeprecation(function () {
-    assert.equal(controller.get('content'), 'foo-bar', 'content is an alias of model');
-  });
-});
-
-QUnit.test('`content` is not moved to `model` when `model` is unset', function(assert) {
-  assert.expect(2);
-  let controller;
-
-  ignoreDeprecation(function() {
-    controller = Controller.extend({
+moduleFor('Controller Content -> Model Alias', class extends AbstractTestCase {
+  ['@test `content` is a deprecated alias of `model`'](assert) {
+    assert.expect(2);
+    let controller = Controller.extend({
+      model: 'foo-bar'
+    }).create();
+  
+    expectDeprecation(function () {
+      assert.equal(controller.get('content'), 'foo-bar', 'content is an alias of model');
+    });
+  }
+  
+  ['@test `content` is not moved to `model` when `model` is unset'](assert) {
+    assert.expect(2);
+    let controller;
+  
+    ignoreDeprecation(function() {
+      controller = Controller.extend({
+        content: 'foo-bar'
+      }).create();
+    });
+  
+    assert.notEqual(controller.get('model'), 'foo-bar', 'model is set properly');
+    assert.equal(controller.get('content'), 'foo-bar', 'content is not set properly');
+  }
+  
+  ['@test specifying `content` (without `model` specified) does not result in deprecation'](assert) {
+    assert.expect(2);
+    expectNoDeprecation();
+  
+    let controller = Controller.extend({
       content: 'foo-bar'
     }).create();
-  });
-
-  assert.notEqual(controller.get('model'), 'foo-bar', 'model is set properly');
-  assert.equal(controller.get('content'), 'foo-bar', 'content is not set properly');
+  
+    assert.equal(get(controller, 'content'), 'foo-bar');
+  }
+  
+  ['@test specifying `content` (with `model` specified) does not result in deprecation'](assert) {
+    assert.expect(3);
+    expectNoDeprecation();
+  
+    let controller = Controller.extend({
+      content: 'foo-bar',
+      model: 'blammo'
+    }).create();
+  
+    assert.equal(get(controller, 'content'), 'foo-bar');
+    assert.equal(get(controller, 'model'), 'blammo');
+  }
 });
 
-QUnit.test('specifying `content` (without `model` specified) does not result in deprecation', function(assert) {
-  assert.expect(2);
-  expectNoDeprecation();
-
-  let controller = Controller.extend({
-    content: 'foo-bar'
-  }).create();
-
-  assert.equal(get(controller, 'content'), 'foo-bar');
+moduleFor('Controller injected properties', class extends AbstractTestCase {
+ 
+    ['@test defining a controller on a non-controller should fail assertion'](assert) {
+      if (!EmberDev.runningProdBuild) {
+        expectAssertion(function() {
+          let owner = buildOwner();
+    
+          let AnObject = EmberObject.extend({
+            foo: inject.controller('bar')
+          });
+    
+          owner.register('controller:bar', EmberObject.extend());
+          owner.register('foo:main', AnObject);
+    
+          owner.lookup('foo:main');
+        }, /Defining an injected controller property on a non-controller is not allowed./);
+      } else {
+        assert.ok('Not running prod build');
+      }
+  }
+  
+  ['@test controllers can be injected into controllers'](assert) {
+    let owner = buildOwner();
+  
+    owner.register('controller:post', Controller.extend({
+      postsController: inject.controller('posts')
+    }));
+  
+    owner.register('controller:posts', Controller.extend());
+  
+    let postController = owner.lookup('controller:post');
+    let postsController = owner.lookup('controller:posts');
+  
+    assert.equal(postsController, postController.get('postsController'), 'controller.posts is injected');
+  }
+  
+  ['@test services can be injected into controllers'](assert) {
+    let owner = buildOwner();
+  
+    owner.register('controller:application', Controller.extend({
+      authService: inject.service('auth')
+    }));
+  
+    owner.register('service:auth', Service.extend());
+  
+    let appController = owner.lookup('controller:application');
+    let authService = owner.lookup('service:auth');
+  
+    assert.equal(authService, appController.get('authService'), 'service.auth is injected');
+  }
 });
 
-QUnit.test('specifying `content` (with `model` specified) does not result in deprecation', function(assert) {
-  assert.expect(3);
-  expectNoDeprecation();
 
-  let controller = Controller.extend({
-    content: 'foo-bar',
-    model: 'blammo'
-  }).create();
-
-  assert.equal(get(controller, 'content'), 'foo-bar');
-  assert.equal(get(controller, 'model'), 'blammo');
-});
-
-QUnit.module('Controller injected properties');
-
-if (!EmberDev.runningProdBuild) {
-  QUnit.test('defining a controller on a non-controller should fail assertion', function() {
-    expectAssertion(function() {
-      let owner = buildOwner();
-
-      let AnObject = EmberObject.extend({
-        foo: inject.controller('bar')
-      });
-
-      owner.register('controller:bar', EmberObject.extend());
-      owner.register('foo:main', AnObject);
-
-      owner.lookup('foo:main');
-    }, /Defining an injected controller property on a non-controller is not allowed./);
-  });
-}
-
-QUnit.test('controllers can be injected into controllers', function(assert) {
-  let owner = buildOwner();
-
-  owner.register('controller:post', Controller.extend({
-    postsController: inject.controller('posts')
-  }));
-
-  owner.register('controller:posts', Controller.extend());
-
-  let postController = owner.lookup('controller:post');
-  let postsController = owner.lookup('controller:posts');
-
-  assert.equal(postsController, postController.get('postsController'), 'controller.posts is injected');
-});
-
-QUnit.test('services can be injected into controllers', function(assert) {
-  let owner = buildOwner();
-
-  owner.register('controller:application', Controller.extend({
-    authService: inject.service('auth')
-  }));
-
-  owner.register('service:auth', Service.extend());
-
-  let appController = owner.lookup('controller:application');
-  let authService = owner.lookup('service:auth');
-
-  assert.equal(authService, appController.get('authService'), 'service.auth is injected');
-});


### PR DESCRIPTION
Part of #15988 

I had a couple of questions on this one:

Im not sure what the right approach is for this situation with nested moduleFors: 
https://github.com/emberjs/ember.js/compare/master...mikerhyssmith:ember-runtime-unify-computed-controllers?expand=1#diff-cf61b28086fbaee1f14d6212760e1c9dL85

I also wasn't sure the best way of moving the commonSortTests to the new style ?  Does it potentially need its own testCase class ?
https://github.com/emberjs/ember.js/compare/master...mikerhyssmith:ember-runtime-unify-computed-controllers?expand=1#diff-bf8afcf2ee2cba77bd823d03fd48ba7eR719