### PR TITLE
[BUGFIX beta] Stop publishing non-ember-source files to S3.

### DIFF
--- a/config/s3ProjectConfig.js
+++ b/config/s3ProjectConfig.js
@@ -4,15 +4,14 @@ const semver = require('semver');
 
 function fileMap(revision, tag, date) {
   let filesToPublish = {
-    "ember.debug.js":             fileObject("ember.debug",             ".js",   "text/javascript",  revision, tag, date),
-    "ember-testing.js":           fileObject("ember-testing",           ".js",   "text/javascript",  revision, tag, date),
-    "ember-tests.js":             fileObject("ember-tests",             ".js",   "text/javascript",  revision, tag, date),
-    "ember-runtime.js":           fileObject("ember-runtime",           ".js",   "text/javascript",  revision, tag, date),
-    "ember-template-compiler.js": fileObject("ember-template-compiler", ".js",   "text/javascript",  revision, tag, date),
-    "ember.min.js":               fileObject("ember.min",               ".js",   "text/javascript",  revision, tag, date),
-    "ember.prod.js":              fileObject("ember.prod",              ".js",   "text/javascript",  revision, tag, date),
-    "../docs/data.json":          fileObject("ember-docs",              ".json", "application/json", revision, tag, date),
-    "tests/index.html":           fileObject("ember-tests-index",       ".json", "application/json", revision, tag, date)
+    "../docs/data.json": fileObject(
+      "ember-docs",
+      ".json",
+      "application/json",
+      revision,
+      tag,
+      date
+    )
   };
 
   let version = require('../package').version;


### PR DESCRIPTION
Ember 3.0 will explicitly only support usage via ember-cli, as such we will no longer be publishing these prebuild assets on S3 (though we will continue to publish the `/${channel}/shas/${sha}.tgz` and `/${channel}/daily/${date}.tgz` files).