### PR TITLE
[BUGFIX beta] Migrate to using execa and pipe to stdout for publishing.

### DIFF
--- a/bin/publish_builds
+++ b/bin/publish_builds
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# ensure the first failure, stops the script
+set -e
+
 echo -e "CURRENT_BRANCH: ${TRAVIS_BRANCH}\n"
 echo -e "PULL_REQUEST: ${TRAVIS_PULL_REQUEST}\n"
 


### PR DESCRIPTION
The prior `execSync` seemed to work properly, however it obscured the output which makes it very hard to debug when there is an issue.

The migration to `execa` also fixes a bug (likely the cause of the recent invalid publishing of a beta as latest). Previously we were using `execSync('auto-dist-tag -w')` which would _only_ work if `auto-dist-tag` were on $PATH, but unfortunately we installed it into `node_modules/.bin`. The console output of this was lost (due to not properly piping to STDOUT), so we will need to confirm with another beta...

Also, add `set -e` to prevent publish on prior errors...

Fixes https://github.com/emberjs/ember.js/issues/16128