### PR TITLE
Bring back `sync` queue with deprecation (until: 3.5.0).

### DIFF
--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -2,6 +2,10 @@ import { assert, isTesting } from 'ember-debug';
 import {
   onErrorTarget
 } from './error_handler';
+import {
+  beginPropertyChanges,
+  endPropertyChanges
+} from './property_events';
 import Backburner from 'backburner';
 
 function onBegin(current) {
@@ -12,7 +16,11 @@ function onEnd(current, next) {
   run.currentRunLoop = next;
 }
 
-const backburner = new Backburner(['actions', 'destroy'], {
+const backburner = new Backburner(['sync', 'actions', 'destroy'], {
+  sync: {
+    before: beginPropertyChanges,
+    after: endPropertyChanges
+  },
   defaultQueue: 'actions',
   onBegin,
   onEnd,

--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -1,4 +1,4 @@
-import { assert, isTesting } from 'ember-debug';
+import { assert, deprecate, isTesting } from 'ember-debug';
 import {
   onErrorTarget
 } from './error_handler';
@@ -277,11 +277,16 @@ run.end = function() {
   @return {*} Timer information for use in canceling, see `run.cancel`.
   @public
 */
-run.schedule = function(/* queue, target, method */) {
+run.schedule = function(queue /*, target, method */) {
   assert(
     `You have turned on testing mode, which disabled the run-loop's autorun. ` +
     `You will need to wrap any code with asynchronous side-effects in a run`,
     run.currentRunLoop || !isTesting()
+  );
+  deprecate(
+   `Scheduling into the '${queue}' run loop queue is deprecated.`,
+   queue !== 'sync',
+   { id: 'ember-metal.run.sync', until: '3.5.0' }
   );
 
   return backburner.schedule(...arguments);
@@ -428,11 +433,16 @@ run.once = function(...args) {
   @return {Object} Timer information for use in canceling, see `run.cancel`.
   @public
 */
-run.scheduleOnce = function(/*queue, target, method*/) {
+run.scheduleOnce = function(queue /*, target, method*/) {
   assert(
     `You have turned on testing mode, which disabled the run-loop's autorun. ` +
     `You will need to wrap any code with asynchronous side-effects in a run`,
     run.currentRunLoop || !isTesting()
+  );
+  deprecate(
+   `Scheduling into the '${queue}' run loop queue is deprecated.`,
+   queue !== 'sync',
+   { id: 'ember-metal.run.sync', until: '3.5.0' }
   );
   return backburner.scheduleOnce(...arguments);
 };

--- a/packages/ember-metal/tests/run_loop/schedule_test.js
+++ b/packages/ember-metal/tests/run_loop/schedule_test.js
@@ -48,12 +48,22 @@ moduleFor('system/run_loop/schedule_test', class extends AbstractTestCase {
       let runLoop = run.currentRunLoop;
       assert.ok(runLoop, 'run loop present');
 
+      run.schedule('sync', () => {
+        order.push('sync');
+        assert.equal(runLoop, run.currentRunLoop, 'same run loop used');
+      });
+
       run.schedule('actions', () => {
         order.push('actions');
         assert.equal(runLoop, run.currentRunLoop, 'same run loop used');
 
         run.schedule('actions', () => {
           order.push('actions');
+          assert.equal(runLoop, run.currentRunLoop, 'same run loop used');
+        });
+
+        run.schedule('sync', () => {
+          order.push('sync');
           assert.equal(runLoop, run.currentRunLoop, 'same run loop used');
         });
       });
@@ -64,7 +74,7 @@ moduleFor('system/run_loop/schedule_test', class extends AbstractTestCase {
       });
     });
 
-    assert.deepEqual(order, ['actions', 'actions', 'destroy']);
+    assert.deepEqual(order, ['sync', 'actions', 'sync', 'actions', 'destroy']);
   }
 
   ['@test makes sure it does not trigger an autorun during testing']() {

--- a/packages/ember-metal/tests/run_loop/schedule_test.js
+++ b/packages/ember-metal/tests/run_loop/schedule_test.js
@@ -48,10 +48,12 @@ moduleFor('system/run_loop/schedule_test', class extends AbstractTestCase {
       let runLoop = run.currentRunLoop;
       assert.ok(runLoop, 'run loop present');
 
-      run.schedule('sync', () => {
-        order.push('sync');
-        assert.equal(runLoop, run.currentRunLoop, 'same run loop used');
-      });
+      expectDeprecation(() => {
+        run.schedule('sync', () => {
+          order.push('sync');
+          assert.equal(runLoop, run.currentRunLoop, 'same run loop used');
+        });
+      }, `Scheduling into the 'sync' run loop queue is deprecated.`);
 
       run.schedule('actions', () => {
         order.push('actions');
@@ -62,10 +64,12 @@ moduleFor('system/run_loop/schedule_test', class extends AbstractTestCase {
           assert.equal(runLoop, run.currentRunLoop, 'same run loop used');
         });
 
-        run.schedule('sync', () => {
-          order.push('sync');
-          assert.equal(runLoop, run.currentRunLoop, 'same run loop used');
-        });
+        expectDeprecation(() => {
+          run.schedule('sync', () => {
+            order.push('sync');
+            assert.equal(runLoop, run.currentRunLoop, 'same run loop used');
+          });
+        }, `Scheduling into the 'sync' run loop queue is deprecated.`);
       });
 
       run.schedule('destroy', () => {

--- a/packages/ember-metal/tests/run_loop/sync_test.js
+++ b/packages/ember-metal/tests/run_loop/sync_test.js
@@ -1,0 +1,26 @@
+import { run } from '../..';
+import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+
+moduleFor('system/run_loop/sync_test', class extends AbstractTestCase {
+  ['@test sync() will immediately flush the sync queue only'](assert) {
+    let cnt = 0;
+
+    run(() => {
+      function cntup() { cnt++; }
+
+      function syncfunc() {
+        if (++cnt < 5) {
+          run.schedule('sync', syncfunc);
+        }
+        run.schedule('actions', cntup);
+      }
+
+      syncfunc();
+
+      assert.equal(cnt, 1, 'should not run action yet');
+    });
+
+    assert.equal(cnt, 10, 'should flush actions now too');
+  }
+});
+

--- a/packages/ember-metal/tests/run_loop/sync_test.js
+++ b/packages/ember-metal/tests/run_loop/sync_test.js
@@ -10,7 +10,9 @@ moduleFor('system/run_loop/sync_test', class extends AbstractTestCase {
 
       function syncfunc() {
         if (++cnt < 5) {
-          run.schedule('sync', syncfunc);
+          expectDeprecation(() => {
+            run.schedule('sync', syncfunc);
+          }, `Scheduling into the 'sync' run loop queue is deprecated.`);
         }
         run.schedule('actions', cntup);
       }


### PR DESCRIPTION
Removing the `sync` queue was done in https://github.com/emberjs/ember.js/pull/16097 and https://github.com/emberjs/ember.js/pull/16110. Unfortunately, addon authors have reported this as a regression in the 3.0.0 beta cycle (due to it not having been previously deprecated).

This reverts the removal, and adds a private API deprecation scheduled for removal in 3.5.0.