### PR TITLE
Fix link-to bubbling in no jquery tests

### DIFF
--- a/packages/ember-glimmer/lib/components/link-to.ts
+++ b/packages/ember-glimmer/lib/components/link-to.ts
@@ -622,7 +622,8 @@ const LinkComponent = EmberComponent.extend({
       }
     }
 
-    if (get(this, 'bubbles') === false) { event.stopPropagation(); }
+    let shouldBubble = get(this, 'bubbles') !== false;
+    if (!shouldBubble) { event.stopPropagation(); }
 
     if (this._isDisabled) { return false; }
 
@@ -648,7 +649,7 @@ const LinkComponent = EmberComponent.extend({
 
     // tslint:disable-next-line:max-line-length
     flaggedInstrument('interaction.link-to', payload, this._generateTransition(payload, qualifiedRouteName, models, queryParams, shouldReplace));
-    return false;
+    return shouldBubble;
   },
 
   _generateTransition(payload: any, qualifiedRouteName: string, models: any[], queryParams: any[], shouldReplace: boolean) {

--- a/packages/ember-glimmer/lib/components/link-to.ts
+++ b/packages/ember-glimmer/lib/components/link-to.ts
@@ -610,7 +610,7 @@ const LinkComponent = EmberComponent.extend({
     @param {Event} event
     @private
   */
-  _invoke(this: any, event: Event): boolean {
+  _invoke(this: any, event: Event): boolean|void {
     if (!isSimpleClick(event)) { return true; }
 
     let preventDefault = get(this, 'preventDefault');
@@ -625,16 +625,16 @@ const LinkComponent = EmberComponent.extend({
     let shouldBubble = get(this, 'bubbles') !== false;
     if (!shouldBubble) { event.stopPropagation(); }
 
-    if (this._isDisabled) { return false; }
+    if (this._isDisabled) { return; }
 
     if (get(this, 'loading')) {
       // tslint:disable-next-line:max-line-length
       warn('This link-to is in an inactive loading state because at least one of its parameters presently has a null/undefined value, or the provided route name is invalid.', false);
-      return false;
+      return;
     }
 
     if (targetAttribute && targetAttribute !== '_self') {
-      return false;
+      return;
     }
 
     let qualifiedRouteName = get(this, 'qualifiedRouteName');

--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -197,15 +197,23 @@ export function sendEvent(obj, eventName, params, actions, _meta) {
     if (!target) { target = obj; }
     if ('string' === typeof method) {
       if (params) {
-        applyStr(target, method, params);
+        if (applyStr(target, method, params) === false) {
+          return false;
+        }
       } else {
-        target[method]();
+        if (target[method]() === false) {
+          return false;
+        }
       }
     } else {
       if (params) {
-        method.apply(target, params);
+        if (method.apply(target, params) === false) {
+          return false;
+        }
       } else {
-        method.call(target);
+        if (method.call(target) === false) {
+          return false;
+        }
       }
     }
   }

--- a/packages/ember-runtime/lib/mixins/evented.js
+++ b/packages/ember-runtime/lib/mixins/evented.js
@@ -124,7 +124,7 @@ export default Mixin.create({
     @public
   */
   trigger(name, ...args) {
-    sendEvent(this, name, args);
+    return sendEvent(this, name, args);
   },
 
   /**

--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -66,11 +66,13 @@ const CoreView = FrameworkObject.extend(Evented, ActionHandler, {
     @private
   */
   trigger(name, ...args) {
-    this._super(...arguments);
+    let superResult = this._super(...arguments);
     let method = this[name];
     if (typeof method === 'function') {
       return method.apply(this, args);
     }
+
+    return superResult;
   },
 
   has(name) {


### PR DESCRIPTION
This is an attempt to make work link-to bubbling based on [this suggestion](https://github.com/emberjs/ember.js/pull/16130#issuecomment-358090659):
 - nested routes and link-to arguments: The {{link-to}} helper supports bubbles=false
 - nested routes and link-to arguments: The {{link-to}} helper supports bubbles=boundFalseyThing

Unfortunately it's [not enough](https://github.com/emberjs/ember.js/pull/16130#issuecomment-358105291) to make `LinkTo._invoke()` return a proper `bubbling` value. The only way(as I can see) to make it work is to allow `Evented.trigger` and `sendEvent` to [return a handler result](https://github.com/emberjs/ember.js/pull/16135/files#diff-cd9c6dab075b5ae3040558030f10d826R127) which definitely is a change of public API. 

@rwjblue feel free to close. I've created this pr mostly for demonstration purpose.