### PR TITLE
Migrate `meta.factory` to independent WeakMap.

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -216,7 +216,8 @@ function wrapManagerInDeprecationProxy(manager) {
       }
     };
 
-    return new Proxy(proxiedManager, validator);
+    let proxy = new Proxy(proxiedManager, validator);
+    FACTORY_FOR.set(proxy, manager);
   }
 
   return manager;
@@ -367,6 +368,7 @@ function resetMember(container, fullName) {
   }
 }
 
+export const FACTORY_FOR = new WeakMap();
 class FactoryManager {
   constructor(container, factory, fullName, normalizedName) {
     this.container = container;
@@ -376,6 +378,7 @@ class FactoryManager {
     this.normalizedName = normalizedName;
     this.madeToString = undefined;
     this.injections = undefined;
+    FACTORY_FOR.set(this, this);
   }
 
   toString() {
@@ -431,6 +434,9 @@ class FactoryManager {
       setOwner(props, this.owner);
     }
 
-    return this.class.create(props);
+    let instance = this.class.create(props);
+    FACTORY_FOR.set(instance, this);
+
+    return instance;
   }
 }

--- a/packages/container/lib/index.js
+++ b/packages/container/lib/index.js
@@ -7,5 +7,6 @@ The public API, specified on the application namespace should be considered the 
 
 export { default as Registry, privatize } from './registry';
 export {
-  default as Container
+  default as Container,
+  FACTORY_FOR,
 } from './container';

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -62,7 +62,6 @@ export class Meta {
     this._chains = undefined;
     this._tag = undefined;
     this._tags = undefined;
-    this._factory = undefined;
 
     // initial value for all flags right now is false
     // see FLAGS const for detailed list of flags used
@@ -266,14 +265,6 @@ export class Meta {
         fn(calls[i], calls[i + 1]);
       }
     }
-  }
-
-  set factory(factory) {
-    this._factory = factory;
-  }
-
-  get factory() {
-    return this._factory;
   }
 
   writableCache() { return this._getOrCreateOwnMap('_cache'); }

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -4,6 +4,7 @@
 
 // using ember-metal/lib/main here to ensure that ember-debug is setup
 // if present
+import { FACTORY_FOR } from 'container';
 import {
   assign,
   guidFor,
@@ -69,7 +70,7 @@ function makeCtor() {
       m.proto = this;
 
       if (initFactory) {
-        m.factory = initFactory;
+        FACTORY_FOR.set(this, initFactory);
         initFactory = null;
       }
       if (initProperties) {
@@ -543,7 +544,7 @@ CoreObject.PrototypeMixin = Mixin.create({
     let hasToStringExtension = typeof this.toStringExtension === 'function';
     let extension = hasToStringExtension ? `:${this.toStringExtension()}` : '';
 
-    let ret = `<${this[NAME_KEY] || peekMeta(this).factory || this.constructor.toString()}:${guidFor(this)}${extension}>`;
+    let ret = `<${this[NAME_KEY] || FACTORY_FOR.get(this) || this.constructor.toString()}:${guidFor(this)}${extension}>`;
 
     return ret;
   }

--- a/packages/ember-runtime/lib/system/object.js
+++ b/packages/ember-runtime/lib/system/object.js
@@ -2,8 +2,9 @@
 @module @ember/object
 */
 
+import { FACTORY_FOR } from 'container';
 import { symbol, OWNER } from 'ember-utils';
-import { on, descriptor, peekMeta } from 'ember-metal';
+import { on, descriptor } from 'ember-metal';
 import CoreObject from './core_object';
 import Observable from '../mixins/observable';
 import { assert } from 'ember-debug';
@@ -25,10 +26,9 @@ const EmberObject = CoreObject.extend(Observable, {
   _debugContainerKey: descriptor({
     enumerable: false,
     get() {
-      let meta = peekMeta(this);
-      let { factory } = meta;
+      let factory = FACTORY_FOR.get(this);
 
-      return factory && factory.fullName;
+      return factory !== undefined && factory.fullName;
     }
   }),
 
@@ -39,10 +39,9 @@ const EmberObject = CoreObject.extend(Observable, {
         return this[OVERRIDE_OWNER];
       }
 
-      let meta = peekMeta(this);
-      let { factory } = meta;
+      let factory = FACTORY_FOR.get(this);
 
-      return factory && factory.owner;
+      return factory !== undefined && factory.owner;
     },
 
     // we need a setter here largely to support


### PR DESCRIPTION
`Meta.prototype.factory` was only added because at the time we had special logic for associating `meta` with an instance (sometimes we would use WeakMap and othertimes a property on the object itself).

Now we can always assume that WeakMap is available (yippie!) so we no longer need to muddy the intentions of Meta with `.factory`.

The change here is a straight refactor to an independent WeakMap for associating the factory (internally in the code this is incorrectly labeled as `FactoryManager`) instead of using meta.