### PR TITLE
[TESTS es-classes] Adds a failing test for didReceiveAttrs

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -3119,6 +3119,24 @@ moduleFor('Components test: curly components', class extends RenderingTest {
 
     this.assertText('3');
   }
+
+  ['@test has attrs by didReceiveAttrs with native classes'](assert) {
+    class FooBarComponent extends Component {
+      constructor() {
+        super();
+        // analagous to class field defaults
+        this.foo = 'bar';
+      }
+
+      didReceiveAttrs() {
+        assert.equal(this.foo, 'bar', 'received default attrs correctly');
+      }
+    }
+
+    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent });
+
+    this.render('{{foo-bar}}');
+  }
 });
 
 if (jQueryDisabled) {


### PR DESCRIPTION
Adds a failing test for didReceiveAttrs in native classes. Class fields
will likely be the prefered way to initialize default values on class instances,
but because didReceiveAttrs is called in the base class constructor it is
initially called before class fields have had an opportunity to be setup.

cc @wycats 