### PR TITLE
Align TestAdapter and EmberRouter with rfc 176 mapping names

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -49,10 +49,10 @@ const { slice } = Array.prototype;
 
 
 /**
-  The `Ember.Router` class manages the application state and URLs. Refer to
+  The `EmberRouter` class manages the application state and URLs. Refer to
   the [routing guide](https://emberjs.com/guides/routing/) for documentation.
 
-  @class Router
+  @class EmberRouter
   @extends EmberObject
   @uses Evented
   @public

--- a/packages/ember-testing/lib/adapters/adapter.js
+++ b/packages/ember-testing/lib/adapters/adapter.js
@@ -10,7 +10,7 @@ function K() { return this; }
   The primary purpose of this class is to create hooks that can be implemented
   by an adapter for various test frameworks.
 
-  @class Adapter
+  @class TestAdapter
   @public
 */
 export default EmberObject.extend({


### PR DESCRIPTION
Addresses part of https://github.com/ember-learn/ember-api-docs/issues/423

Change names to align with `localName` in rfc 176 https://github.com/ember-cli/ember-rfc176-data/blob/master/mappings.json

API docs rely on a match to give import examples programmatically inline 