### PR TITLE
Reduce flakiness with IE11 test runs.

### DIFF
--- a/packages/ember-glimmer/tests/integration/helpers/input-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/input-test.js
@@ -318,17 +318,19 @@ moduleFor('Helpers test: {{input}}', class extends InputRenderingTest {
   }
 
   ['@test triggers `focus-in` when focused'](assert) {
-    assert.expect(1);
+    let wasFocused = false;
 
     this.render(`{{input focus-in='foo'}}`, {
       actions: {
         foo() {
-          assert.ok(true, 'action was triggered');
+          wasFocused = true;
         }
       }
     });
 
     this.runTask(() => { this.$input().focus(); });
+
+    assert.ok(wasFocused, 'action was triggered');
   }
 
   ['@test sends `insert-newline` when <enter> is pressed'](assert) {

--- a/packages/internal-test-helpers/lib/browser-detect.js
+++ b/packages/internal-test-helpers/lib/browser-detect.js
@@ -1,0 +1,4 @@
+// `window.ActiveXObject` is "falsey" in IE11 (but not `undefined` or `false`)
+// `"ActiveXObject" in window` returns `true` in all IE versions
+// only IE11 will pass _both_ of these conditions
+export const isIE11 = !window.ActiveXObject && 'ActiveXObject' in window;

--- a/packages/internal-test-helpers/lib/index.js
+++ b/packages/internal-test-helpers/lib/index.js
@@ -35,3 +35,5 @@ export {
   default as TestResolver,
   ModuleBasedResolver as ModuleBasedTestResolver
 } from './test-resolver';
+
+export { isIE11 } from './browser-detect';


### PR DESCRIPTION
Under some circumstances (e.g. under heavy load) IE11 triggers the `focusin` event twice. The only way I was able to reproduce this was by severely restricting the resources available to my local VM when testing.

The changes here are not ideal (I would much prefer to expect _exact_ event ordering and counts like these tests originally had), but the main intent of the tests is still satisified in all cases.

🤞