### PR TITLE
[BUGFIX beta] Use `run.join` in `{{action` modifier.

### DIFF
--- a/packages/ember-glimmer/lib/modifiers/action.ts
+++ b/packages/ember-glimmer/lib/modifiers/action.ts
@@ -130,7 +130,7 @@ export class ActionState {
       event.stopPropagation();
     }
 
-    run(() => {
+    run.join(() => {
       let args = this.getActionArgs();
       let payload = {
         args,


### PR DESCRIPTION
Using `Ember.run(() => {})` directly here may cause us to create a nested runloop needlessly, which is not ideal.