### PR TITLE
[doc beta] Update ember-routing docs for RFC176

### DIFF
--- a/packages/ember-routing/lib/ext/controller.js
+++ b/packages/ember-routing/lib/ext/controller.js
@@ -32,18 +32,18 @@ ControllerMixin.reopen({
   /**
    This property is updated to various different callback functions depending on
    the current "state" of the backing route. It is used by
-   `Ember.Controller.prototype._qpChanged`.
+   `Controller.prototype._qpChanged`.
 
-   The methods backing each state can be found in the `Ember.Route.prototype._qp` computed
+   The methods backing each state can be found in the `Route.prototype._qp` computed
    property return value (the `.states` property). The current values are listed here for
    the sanity of future travelers:
 
    * `inactive` - This state is used when this controller instance is not part of the active
-     route hierarchy. Set in `Ember.Route.prototype._reset` (a `router.js` microlib hook) and
-     `Ember.Route.prototype.actions.finalizeQueryParamChange`.
+     route hierarchy. Set in `Route.prototype._reset` (a `router.js` microlib hook) and
+     `Route.prototype.actions.finalizeQueryParamChange`.
    * `active` - This state is used when this controller instance is part of the active
-     route hierarchy. Set in `Ember.Route.prototype.actions.finalizeQueryParamChange`.
-   * `allowOverrides` - This state is used in `Ember.Route.prototype.setup` (`route.js` microlib hook).
+     route hierarchy. Set in `Route.prototype.actions.finalizeQueryParamChange`.
+   * `allowOverrides` - This state is used in `Route.prototype.setup` (`route.js` microlib hook).
 
     @method _qpDelegate
     @private
@@ -51,13 +51,13 @@ ControllerMixin.reopen({
   _qpDelegate: null, // set by route
 
   /**
-   During `Ember.Route#setup` observers are created to invoke this method
-   when any of the query params declared in `Ember.Controller#queryParams` property
+   During `Route#setup` observers are created to invoke this method
+   when any of the query params declared in `Controller#queryParams` property
    are changed.
 
 
    When invoked this method uses the currently active query param update delegate
-   (see `Ember.Controller.prototype._qpDelegate` for details) and invokes it with
+   (see `Controller.prototype._qpDelegate` for details) and invokes it with
    the QP key/value being changed.
 
     @method _qpChanged
@@ -134,14 +134,14 @@ ControllerMixin.reopen({
     aController.transitionToRoute({ queryParams: { sort: 'date' } });
     ```
 
-    See also [replaceRoute](/api/classes/Ember.ControllerMixin.html#method_replaceRoute).
+    See also [replaceRoute](/api/ember/release/classes/Ember.ControllerMixin/methods/replaceRoute?anchor=replaceRoute).
 
     @param {String} name the name of the route or a URL
     @param {...Object} models the model(s) or identifier(s) to be used
       while transitioning to the route.
     @param {Object} [options] optional hash with a queryParams property
       containing a mapping of query parameters
-    @for Ember.ControllerMixin
+    @for ControllerMixin
     @method transitionToRoute
     @public
   */
@@ -206,7 +206,7 @@ ControllerMixin.reopen({
     @param {String} name the name of the route or a URL
     @param {...Object} models the model(s) or identifier(s) to be used
     while transitioning to the route.
-    @for Ember.ControllerMixin
+    @for ControllerMixin
     @method replaceRoute
     @public
   */

--- a/packages/ember-routing/lib/location/api.js
+++ b/packages/ember-routing/lib/location/api.js
@@ -7,7 +7,7 @@ import { getHash } from './util';
 */
 
 /**
-  Ember.Location returns an instance of the correct implementation of
+  Location returns an instance of the correct implementation of
   the `location` API.
 
   ## Implementations
@@ -15,10 +15,10 @@ import { getHash } from './util';
   You can pass an implementation name (`hash`, `history`, `none`, `auto`) to force a
   particular implementation to be used in your application.
 
-  See [Ember.Location.HashLocation](/api/classes/Ember.Location.HashLocation).
-  See [Ember.Location.HistoryLocation](/api/classes/Ember.Location.HistoryLocation).
-  See [Ember.Location.NoneLocation](/api/classes/Ember.Location.NoneLocation).
-  See [Ember.Location.AutoLocation](/api/classes/Ember.Location.AutoLocation).
+  See [HashLocation](/api/ember/release/classes/HashLocation).
+  See [HistoryLocation](/api/ember/release/classes/HistoryLocation).
+  See [NoneLocation](/api/ember/release/classes/NoneLocation).
+  See [AutoLocation](/api/ember/release/classes/AutoLocation).
 
 
   ## Location API
@@ -45,9 +45,7 @@ import { getHash } from './util';
   Example:
 
   ```javascript
-  import Ember from 'ember';
-
-  const { HistoryLocation } = Ember;
+  import HistoryLocation from '@ember/routing/history-location';
 
   export default class MyHistory {
     implementation: 'my-custom-history',
@@ -90,10 +88,10 @@ export default {
   */
   create(options) {
     let implementation = options && options.implementation;
-    assert('Ember.Location.create: you must specify a \'implementation\' option', !!implementation);
+    assert('Location.create: you must specify a \'implementation\' option', !!implementation);
 
     let implementationClass = this.implementations[implementation];
-    assert(`Ember.Location.create: ${implementation} is not a valid implementation`, !!implementationClass);
+    assert(`Location.create: ${implementation} is not a valid implementation`, !!implementationClass);
 
     return implementationClass.create(...arguments);
   },

--- a/packages/ember-routing/lib/location/auto_location.js
+++ b/packages/ember-routing/lib/location/auto_location.js
@@ -20,7 +20,7 @@ import {
 
 
 /**
-  Ember.AutoLocation will select the best location option based off browser
+  AutoLocation will select the best location option based off browser
   support with the priority order: history, hash, none.
 
   Clean pushState paths accessed by hashchange-only browsers will be redirected

--- a/packages/ember-routing/lib/location/hash_location.js
+++ b/packages/ember-routing/lib/location/hash_location.js
@@ -12,7 +12,7 @@ import EmberLocation from './api';
 */
 
 /**
-  `Ember.HashLocation` implements the location API using the browser's
+  `HashLocation` implements the location API using the browser's
   hash. At present, it relies on a `hashchange` event existing in the
   browser.
 

--- a/packages/ember-routing/lib/location/history_location.js
+++ b/packages/ember-routing/lib/location/history_location.js
@@ -23,7 +23,7 @@ function _uuid() {
 
 
 /**
-  Ember.HistoryLocation implements the location API using the browser's
+  HistoryLocation implements the location API using the browser's
   history.pushState API.
 
   Using `HistoryLocation` results in URLs that are indistinguishable from a

--- a/packages/ember-routing/lib/location/none_location.js
+++ b/packages/ember-routing/lib/location/none_location.js
@@ -10,7 +10,7 @@ import { Object as EmberObject } from 'ember-runtime';
 */
 
 /**
-  Ember.NoneLocation does not interact with the browser. It is useful for
+  NoneLocation does not interact with the browser. It is useful for
   testing, or when you need to manage state with your Router, but temporarily
   don't want it to muck with the URL (for example when you embed your
   application in a larger page).

--- a/packages/ember-routing/lib/services/router.js
+++ b/packages/ember-routing/lib/services/router.js
@@ -90,7 +90,7 @@ const RouterService = Service.extend({
 
     @property location
     @default 'hash'
-    @see {Ember.Location}
+    @see {Location}
     @public
   */
   location: readOnly('_router.location'),
@@ -129,7 +129,7 @@ const RouterService = Service.extend({
      Transition the application into another route. The route may
      be either a single route or route path:
 
-     See [Route.transitionTo](https://emberjs.com/api/classes/Ember.Route.html#method_transitionTo) for more info.
+     See [transitionTo](/api/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo) for more info.
 
      @method transitionTo
      @category ember-routing-router-service
@@ -159,7 +159,7 @@ const RouterService = Service.extend({
      Transition into another route while replacing the current URL, if possible.
      The route may be either a single route or route path:
 
-     See [Route.replaceWith](https://emberjs.com/api/classes/Ember.Route.html#method_replaceWith) for more info.
+     See [replaceWith](/api/ember/release/classes/Route/methods/replaceWith?anchor=replaceWith) for more info.
 
      @method replaceWith
      @category ember-routing-router-service

--- a/packages/ember-routing/lib/system/generate_controller.js
+++ b/packages/ember-routing/lib/system/generate_controller.js
@@ -31,7 +31,7 @@ export function generateControllerFactory(owner, controllerName) {
 
 /**
   Generates and instantiates a controller extending from `controller:basic`
-  if present, or `Ember.Controller` if not.
+  if present, or `Controller` if not.
 
   @for Ember
   @method generateController

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -61,12 +61,12 @@ export function hasDefaultSerialize(route) {
 */
 
 /**
-  The `Ember.Route` class is used to define individual routes. Refer to
+  The `Route` class is used to define individual routes. Refer to
   the [routing guide](https://emberjs.com/guides/routing/) for documentation.
 
   @class Route
   @extends EmberObject
-  @uses Ember.ActionHandler
+  @uses ActionHandler
   @uses Evented
   @since 1.0.0
   @public
@@ -670,11 +670,12 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     as well as any unhandled errors from child routes:
 
     ```app/routes/admin.js
+    import { reject } from 'rsvp';
     import Route from '@ember/routing/route';
 
     export default Route.extend({
       beforeModel() {
-        return Ember.RSVP.reject('bad things!');
+        return reject('bad things!');
       },
 
       actions: {
@@ -723,10 +724,11 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     not executed when the model for the route changes.
 
     ```app/routes/application.js
+    import { on } from '@ember/object/evented';
     import Route from '@ember/routing/route';
 
     export default Route.extend({
-      collectAnalytics: Ember.on('activate', function(){
+      collectAnalytics: on('activate', function(){
         collectAnalytics();
       })
     });
@@ -742,10 +744,11 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     route. It is not executed when the model for the route changes.
 
     ```app/routes/index.js
+    import { on } from '@ember/object/evented';
     import Route from '@ember/routing/route';
 
     export default Route.extend({
-      trackPageLeaveAnalytics: Ember.on('deactivate', function(){
+      trackPageLeaveAnalytics: on('deactivate', function(){
         trackPageLeaveAnalytics();
       })
     });
@@ -1005,9 +1008,9 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     ```
 
     ```app/routes/index.js
-    import Ember from 'ember':
+    import Route from '@ember/routing/route';
 
-    export Ember.Route.extend({
+    export Route.extend({
       actions: {
         moveToSecret(context) {
           if (authorized()) {
@@ -1509,7 +1512,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     This hook follows the asynchronous/promise semantics
     described in the documentation for `beforeModel`. In particular,
     if a promise returned from `model` fails, the error will be
-    handled by the `error` hook on `Ember.Route`.
+    handled by the `error` hook on `Route`.
 
     Example
 
@@ -1639,12 +1642,13 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     ```
 
     ```app/routes/post.js
+    import $ from 'jquery';
     import Route from '@ember/routing/route';
 
     export default Route.extend({
       model(params) {
         // the server returns `{ id: 12 }`
-        return Ember.$.getJSON('/posts/' + params.post_id);
+        return $.getJSON('/posts/' + params.post_id);
       },
 
       serialize(model) {
@@ -1657,7 +1661,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     The default `serialize` method will insert the model's `id` into the
     route's dynamic segment (in this case, `:post_id`) if the segment contains '_id'.
     If the route has multiple dynamic segments or does not contain '_id', `serialize`
-    will return `Ember.getProperties(model, params)`
+    will return `getProperties(model, params)`
 
     This method is called when `transitionTo` is called with a context
     in order to populate the URL.
@@ -1721,7 +1725,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     ```
 
     For the `post` route, a controller named `App.PostController` would
-    be used if it is defined. If it is not defined, a basic `Ember.Controller`
+    be used if it is defined. If it is not defined, a basic `Controller`
     instance would be used.
 
     Example
@@ -1989,7 +1993,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
 
     The string values provided for the template name, and controller
     will eventually pass through to the resolver for lookup. See
-    Ember.Resolver for how these are mapped to JavaScript objects in your
+    Resolver for how these are mapped to JavaScript objects in your
     application. The template to render into needs to be related to  either the
     current route or one of its ancestors.
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -228,7 +228,10 @@ const EmberRouter = EmberObject.extend(Evented, {
     you could use this hook.  (Note: requires also including GA scripts, etc.)
 
     ```javascript
-    let Router = Ember.Router.extend({
+    import config from './config/environment';
+    import EmberRouter from '@ember/routing/router';
+
+    let Router = EmberRouter.extend({
       location: config.locationType,
 
       didTransition: function() {
@@ -266,7 +269,7 @@ const EmberRouter = EmberObject.extend(Evented, {
   },
 
   _setOutlets() {
-    // This is triggered async during Ember.Route#willDestroy.
+    // This is triggered async during Route#willDestroy.
     // If the router is also being destroyed we do not want to
     // to create another this._toplevelView (and leak the renderer)
     if (this.isDestroying || this.isDestroyed) { return; }
@@ -355,7 +358,7 @@ const EmberRouter = EmberObject.extend(Evented, {
     Transition the application into another route. The route may
     be either a single route or route path:
 
-    See [Route.transitionTo](https://emberjs.com/api/classes/Ember.Route.html#method_transitionTo) for more info.
+    See [transitionTo](/api/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo) for more info.
 
     @method transitionTo
     @param {String} name the name of the route or a URL

--- a/packages/ember-routing/tests/location/auto_location_test.js
+++ b/packages/ember-routing/tests/location/auto_location_test.js
@@ -53,7 +53,7 @@ function createLocation(location, history) {
 
 let location;
 
-moduleFor('Ember.AutoLocation', class extends AbstractTestCase {
+moduleFor('AutoLocation', class extends AbstractTestCase {
   teardown() {
     if (location) {
       run(location, 'destroy');

--- a/packages/ember-routing/tests/location/hash_location_test.js
+++ b/packages/ember-routing/tests/location/hash_location_test.js
@@ -48,7 +48,7 @@ function triggerHashchange() {
   window.dispatchEvent(event);
 }
 
-moduleFor('Ember.HashLocation', class extends AbstractTestCase {
+moduleFor('HashLocation', class extends AbstractTestCase {
   teardown() {
     run(function() {
       if (location) { location.destroy(); }

--- a/packages/ember-routing/tests/location/history_location_test.js
+++ b/packages/ember-routing/tests/location/history_location_test.js
@@ -33,7 +33,7 @@ function mockBrowserLocation(path) {
   };
 }
 
-moduleFor('Ember.HistoryLocation', class extends AbstractTestCase {
+moduleFor('HistoryLocation', class extends AbstractTestCase {
   constructor() {
     super();
 

--- a/packages/ember-routing/tests/location/none_location_test.js
+++ b/packages/ember-routing/tests/location/none_location_test.js
@@ -9,7 +9,7 @@ function createLocation(options) {
   location = NoneTestLocation.create(options);
 }
 
-moduleFor('Ember.NoneLocation', class extends AbstractTestCase {
+moduleFor('NoneLocation', class extends AbstractTestCase {
   constructor() {
     super();
     NoneTestLocation = NoneLocation.extend({});

--- a/packages/ember-routing/tests/system/controller_for_test.js
+++ b/packages/ember-routing/tests/system/controller_for_test.js
@@ -5,7 +5,7 @@ import controllerFor from '../../system/controller_for';
 import generateController from '../../system/generate_controller';
 import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
 
-moduleFor('Ember.controllerFor', class extends ApplicationTestCase {
+moduleFor('controllerFor', class extends ApplicationTestCase {
   ['@test controllerFor should lookup for registered controllers'](assert) {
     this.add('controller:app', Controller.extend());
 
@@ -18,8 +18,8 @@ moduleFor('Ember.controllerFor', class extends ApplicationTestCase {
   }
 });
 
-moduleFor('Ember.generateController', class extends ApplicationTestCase {
-  ['@test generateController should return Ember.Controller'](assert) {
+moduleFor('generateController', class extends ApplicationTestCase {
+  ['@test generateController should return Controller'](assert) {
     return this.visit('/').then(() => {
       let controller = generateController(this.applicationInstance, 'home');
       assert.ok(controller instanceof Controller, 'should return controller');

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -9,7 +9,7 @@ import EmberRoute from '../../system/route';
 
 let route, routeOne, routeTwo, lookupHash;
 
-moduleFor('Ember.Route', class extends AbstractTestCase {
+moduleFor('Route', class extends AbstractTestCase {
   constructor() {
     super();
     route = EmberRoute.create();
@@ -195,7 +195,7 @@ moduleFor('Ember.Route', class extends AbstractTestCase {
   }
 });
 
-moduleFor('Ember.Route serialize', class extends AbstractTestCase {
+moduleFor('Route serialize', class extends AbstractTestCase {
   constructor() {
     super();
     route = EmberRoute.create();
@@ -228,7 +228,7 @@ moduleFor('Ember.Route serialize', class extends AbstractTestCase {
   }
 });
 
-moduleFor('Ember.Route interaction', class extends AbstractTestCase {
+moduleFor('Route interaction', class extends AbstractTestCase {
   constructor() {
     super();
 
@@ -293,7 +293,7 @@ moduleFor('Route injected properties', class extends AbstractTestCase {
   }
 });
 
-moduleFor('Ember.Route with engines', class extends AbstractTestCase {
+moduleFor('Route with engines', class extends AbstractTestCase {
 
   ['@test paramsFor considers an engine\'s mountPoint'](assert) {
     let router = {

--- a/packages/ember-routing/tests/system/router_test.js
+++ b/packages/ember-routing/tests/system/router_test.js
@@ -112,7 +112,7 @@ moduleFor('Ember Router', class extends AbstractTestCase {
     });
   }
 
-  ['@test Ember.Router._routePath should consume identical prefixes'](assert) {
+  ['@test Router._routePath should consume identical prefixes'](assert) {
     createRouter();
 
   function routePath() {

--- a/packages/internal-test-helpers/lib/test-groups.js
+++ b/packages/internal-test-helpers/lib/test-groups.js
@@ -12,7 +12,7 @@ export function testBoth(testname, callback) {
   function aget(x, y) { return x[y]; }
   function aset(x, y, z) { return (x[y] = z); }
 
-  QUnit.test(`${testname} using getFromEmberMetal()/Ember.set()`, function(assert) {
+  QUnit.test(`${testname} using getFromEmberMetal()/set()`, function(assert) {
     callback(emberget, emberset, assert);
   });
 
@@ -45,7 +45,7 @@ export function testWithDefault(testname, callback) {
     callback(emberget, emberset, assert);
   });
 
-  QUnit.test(`${testname} using Ember.getWithDefault()`, function(assert) {
+  QUnit.test(`${testname} using getWithDefault()`, function(assert) {
     callback(embergetwithdefault, emberset, assert);
   });
 


### PR DESCRIPTION
RE: https://github.com/emberjs/ember.js/issues/15723

Updated `ember-routing` to new RFC176 and /release/ urls.

Could not find any updates required for `ember-console`.

I only updated a few small spots in `internal-test-helpers`.  I wasn't sure if updating lines like [this](https://github.com/emberjs/ember.js/blob/master/packages/internal-test-helpers/lib/confirm-export.js#L23) to remove `Ember.` was part of this scope. Happy to update those in a separate PR if this is something we should do.