### PR TITLE
[BUGFIX beta] Update to backburner.js@2.1.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "babel-plugin-transform-proto-to-assign": "^6.23.0",
     "babel-template": "^6.24.1",
-    "backburner.js": "^2.0.2",
+    "backburner.js": "^2.1.0",
     "broccoli-babel-transpiler": "^6.1.1",
     "broccoli-concat": "^3.2.2",
     "broccoli-debug": "^0.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -958,9 +958,9 @@ backbone@^1.1.2:
   dependencies:
     underscore ">=1.8.3"
 
-backburner.js@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-2.0.2.tgz#d0049c0c6fd023084b66afeb82849f704ac6315e"
+backburner.js@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-2.1.0.tgz#2dd3b0f5043fc495b91407cf9f27d976e86159d5"
 
 backo2@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
* Adds debug stack tracking for `run.later` / `run.next` :tada:
* Fixes a number of issues with typings (though I don't think Ember uses them at this point).

[Full Diff Here](https://github.com/BackburnerJS/backburner.js/compare/v2.0.2...v2.1.0)

Fixes https://github.com/emberjs/ember.js/issues/15215