### PR TITLE
Introduce namespaced component and service invocation

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -10,6 +10,7 @@ import {
   HAS_NATIVE_PROXY
 } from 'ember-utils';
 
+
 /**
  A container used to instantiate and cache objects.
 
@@ -223,8 +224,7 @@ function wrapManagerInDeprecationProxy(manager) {
 }
 
 function isSingleton(container, fullName, options) {
-  let res = container.registry.getOption(fullName, 'singleton', options) !== false;
-  return res;
+  return container.registry.getOption(fullName, 'singleton', options) !== false;
 }
 
 function isInstantiatable(container, fullName) {

--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -319,10 +319,10 @@ function buildInjections(container, injections) {
     let injection;
     for (let i = 0; i < injections.length; i++) {
       injection = injections[i];
-      let {name, rawString, type} = parseInjectionString(injection.fullName);
-      hash[injection.property] = lookupWithRawString(container, type, rawString || name);
+      let {name, namespace, type} = parseInjectionString(injection.fullName);
+      hash[injection.property] = lookupWithRawString(container, type, namespace || name);
       if (!isDynamic) {
-        isDynamic = !isSingleton(container, injection.fullName, {[RAW_STRING_OPTION_KEY]: rawString});
+        isDynamic = !isSingleton(container, injection.fullName, {[RAW_STRING_OPTION_KEY]: namespace});
       }
     }
   }
@@ -462,7 +462,7 @@ export function parseInjectionString(injectionString) {
     let fullName = type.indexOf(':') === -1 ? `${type}:${name}` : `${type}${name}`;
     return {
       fullName,
-      rawString: namespace,
+      namespace,
       type
     };
   }
@@ -485,7 +485,7 @@ export function factoryForWithRawString(container, type, rawString) {
     return container.factoryFor(`${type}:${rawString}`);
   } else {
     let [ namespace, name ] = rawString.split('::');
-    // type might already contain : eg. "template:components/"
+    // type might already contain ":" eg. "template:components/"
     let fullName = type.indexOf(':') === -1 ? `${type}:${name}` : `${type}${name}`;
     return container.factoryFor(fullName, {
       [RAW_STRING_OPTION_KEY]: namespace

--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -88,7 +88,7 @@ export default class Container {
    @return {any}
    */
   lookup(fullName, options) {
-    assert('fullName must be a proper full name', this.registry.isValidFullName(fullName, options));
+    assert('fullName must be a proper full name', this.registry.isValidFullName(fullName));
     return lookup(this, this.registry.normalize(fullName), options);
   }
 
@@ -148,7 +148,7 @@ export default class Container {
   factoryFor(fullName, options = {}) {
     let normalizedName = this.registry.normalize(fullName);
 
-    assert('fullName must be a proper full name', this.registry.isValidFullName(normalizedName, options));
+    assert('fullName must be a proper full name', this.registry.isValidFullName(normalizedName));
 
     if (options.source) {
       let expandedFullName = this.registry.expandLocalLookup(fullName, options);

--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -9,9 +9,6 @@ import {
   assign,
   HAS_NATIVE_PROXY
 } from 'ember-utils';
-import { symbol } from 'ember-utils';
-
-export const RAW_STRING_OPTION_KEY = symbol('RAW_STRING_OPTION_KEY');
 
 /**
  A container used to instantiate and cache objects.
@@ -322,7 +319,7 @@ function buildInjections(container, injections) {
       let {name, namespace, type} = parseInjectionString(injection.fullName);
       hash[injection.property] = lookupWithRawString(container, type, namespace || name);
       if (!isDynamic) {
-        isDynamic = !isSingleton(container, injection.fullName, {[RAW_STRING_OPTION_KEY]: namespace});
+        isDynamic = !isSingleton(container, injection.fullName, { namespace });
       }
     }
   }
@@ -474,9 +471,7 @@ export function lookupWithRawString(container, type, rawString) {
   } else {
     let [ namespace, name ] = rawString.split('::');
     let fullName = type.indexOf(':') === -1 ? `${type}:${name}` : `${type}${name}`;
-    return container.lookup(fullName, {
-      [RAW_STRING_OPTION_KEY]: namespace
-    });
+    return container.lookup(fullName, { namespace });
   }
 }
 
@@ -487,8 +482,6 @@ export function factoryForWithRawString(container, type, rawString) {
     let [ namespace, name ] = rawString.split('::');
     // type might already contain ":" eg. "template:components/"
     let fullName = type.indexOf(':') === -1 ? `${type}:${name}` : `${type}${name}`;
-    return container.factoryFor(fullName, {
-      [RAW_STRING_OPTION_KEY]: namespace
-    });
+    return container.factoryFor(fullName, { namespace });
   }
 }

--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -319,7 +319,7 @@ function buildInjections(container, injections) {
     let injection;
     for (let i = 0; i < injections.length; i++) {
       injection = injections[i];
-      let {fullName, name, rawString, type} = parseInjectionString(injection.fullName);
+      let {name, rawString, type} = parseInjectionString(injection.fullName);
       hash[injection.property] = lookupWithRawString(container, type, rawString || name);
       if (!isDynamic) {
         isDynamic = !isSingleton(container, injection.fullName, {[RAW_STRING_OPTION_KEY]: rawString});
@@ -458,9 +458,11 @@ export function parseInjectionString(injectionString) {
       type
     };
   } else {
+    let [ namespace, name ] = rawString.split('::');
+    let fullName = type.indexOf(':') === -1 ? `${type}:${name}` : `${type}${name}`;
     return {
-      fullName: type,
-      rawString,
+      fullName,
+      rawString: namespace,
       type
     };
   }
@@ -470,8 +472,10 @@ export function lookupWithRawString(container, type, rawString) {
   if (rawString.indexOf('::') === -1) {
     return container.lookup(`${type}:${rawString}`);
   } else {
-    return container.lookup(`${type}`, {
-      [RAW_STRING_OPTION_KEY]: rawString
+    let [ namespace, name ] = rawString.split('::');
+    let fullName = type.indexOf(':') === -1 ? `${type}:${name}` : `${type}${name}`;
+    return container.lookup(fullName, {
+      [RAW_STRING_OPTION_KEY]: namespace
     });
   }
 }
@@ -480,8 +484,11 @@ export function factoryForWithRawString(container, type, rawString) {
   if (rawString.indexOf('::') === -1) {
     return container.factoryFor(`${type}:${rawString}`);
   } else {
-    return container.factoryFor(`${type}`, {
-      [RAW_STRING_OPTION_KEY]: rawString
+    let [ namespace, name ] = rawString.split('::');
+    // type might already contain : eg. "template:components/"
+    let fullName = type.indexOf(':') === -1 ? `${type}:${name}` : `${type}${name}`;
+    return container.factoryFor(fullName, {
+      [RAW_STRING_OPTION_KEY]: namespace
     });
   }
 }

--- a/packages/container/lib/index.js
+++ b/packages/container/lib/index.js
@@ -9,4 +9,7 @@ export { default as Registry, privatize } from './registry';
 export {
   default as Container,
   FACTORY_FOR,
+  factoryForWithRawString,
+  lookupWithRawString,
+  RAW_STRING_OPTION_KEY as _RAW_STRING_OPTION_KEY
 } from './container';

--- a/packages/container/lib/index.js
+++ b/packages/container/lib/index.js
@@ -10,6 +10,5 @@ export {
   default as Container,
   FACTORY_FOR,
   factoryForWithRawString,
-  lookupWithRawString,
-  RAW_STRING_OPTION_KEY as _RAW_STRING_OPTION_KEY
+  lookupWithRawString
 } from './container';

--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -630,12 +630,15 @@ if (DEBUG) {
 
     for (let key in hash) {
       if (hash.hasOwnProperty(key)) {
-        let { fullName } = parseInjectionString(hash[key]);
+        let injection = hash[key];
+        let injectionString = (typeof injection === 'string') ? injection : injection.fullName;
+        let { fullName } = parseInjectionString(injectionString);
         assert(`Expected a proper full name, given '${fullName}'`, this.isValidFullName(fullName));
 
         injections.push({
           property: key,
-          fullName: hash[key]
+          fullName: hash[key].fullName,
+          namespace: hash[key].namespace
         });
       }
     }
@@ -647,10 +650,14 @@ if (DEBUG) {
     if (!injections) { return; }
 
     for (let i = 0; i < injections.length; i++) {
+      let injection = injections[i];
+      let injectionString = (typeof injection === 'string') ? injection : injection.fullName;
       let {
         fullName,
         namespace
-      } = parseInjectionString(injections[i].fullName);
+      } = parseInjectionString(injectionString);
+
+      namespace = namespace || injection.namespace;
 
       assert(`Attempting to inject an unknown injection: '${fullName}'`, this.has(fullName, {namespace}));
     }

--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -149,7 +149,7 @@ export default class Registry {
    @param {Object} options
    */
   register(fullName, factory, options = {}) {
-    assert('fullName must be a proper full name', this.isValidFullName(fullName, options));
+    assert('fullName must be a proper full name', this.isValidFullName(fullName));
     assert(`Attempting to register an unknown factory: '${fullName}'`, factory !== undefined);
 
     let normalizedName = this.normalize(fullName);
@@ -228,7 +228,7 @@ export default class Registry {
    @return {Function} fullName's factory
    */
   resolve(fullName, options) {
-    assert('fullName must be a proper full name', this.isValidFullName(fullName, options));
+    assert('fullName must be a proper full name', this.isValidFullName(fullName));
     let factory = resolve(this, this.normalize(fullName), options);
     if (factory === undefined && this.fallback !== null) {
       factory = this.fallback.resolve(...arguments);
@@ -321,7 +321,7 @@ export default class Registry {
    @return {Boolean}
    */
   has(fullName, options) {
-    if (!this.isValidFullName(fullName, options)) {
+    if (!this.isValidFullName(fullName)) {
       return false;
     }
 
@@ -504,8 +504,8 @@ export default class Registry {
    @param {String} property
    @param {String} injectionName
    */
-  injection(fullName, property, injectionName, options) {
-    assert(`Invalid injectionName, expected: 'type:name' got: ${injectionName}`, this.isValidFullName(injectionName, options));
+  injection(fullName, property, injectionName) {
+    assert(`Invalid injectionName, expected: 'type:name' got: ${injectionName}`, this.isValidFullName(injectionName));
 
     let normalizedInjectionName = this.normalize(injectionName);
 
@@ -630,11 +630,8 @@ if (DEBUG) {
 
     for (let key in hash) {
       if (hash.hasOwnProperty(key)) {
-        let {
-          fullName,
-          namespace
-        } = parseInjectionString(hash[key]);
-        assert(`Expected a proper full name, given '${fullName}'`, this.isValidFullName(fullName, { namespace }));
+        let { fullName } = parseInjectionString(hash[key]);
+        assert(`Expected a proper full name, given '${fullName}'`, this.isValidFullName(fullName));
 
         injections.push({
           property: key,

--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -2,8 +2,7 @@ import { dictionary, assign, intern } from 'ember-utils';
 import { assert, deprecate } from 'ember-debug';
 import { EMBER_MODULE_UNIFICATION } from 'ember/features';
 import Container, {
-  parseInjectionString,
-  RAW_STRING_OPTION_KEY
+  parseInjectionString
 } from './container';
 import { DEBUG } from 'ember-env-flags';
 import { ENV } from 'ember-environment';
@@ -327,7 +326,7 @@ export default class Registry {
     }
 
     let source = options && options.source && this.normalize(options.source);
-    let namespace = options && options[RAW_STRING_OPTION_KEY];
+    let namespace = options && options.namespace;
 
     return has(this, this.normalize(fullName), source, namespace);
   }
@@ -576,7 +575,7 @@ export default class Registry {
     return [
       name,
       options.source,
-      options[RAW_STRING_OPTION_KEY]
+      options.namespace
     ].join('\0');
   }
 
@@ -635,7 +634,7 @@ if (DEBUG) {
           fullName,
           namespace
         } = parseInjectionString(hash[key]);
-        assert(`Expected a proper full name, given '${fullName}'`, this.isValidFullName(fullName, {[RAW_STRING_OPTION_KEY]: namespace}));
+        assert(`Expected a proper full name, given '${fullName}'`, this.isValidFullName(fullName, { namespace }));
 
         injections.push({
           property: key,
@@ -656,7 +655,7 @@ if (DEBUG) {
         namespace
       } = parseInjectionString(injections[i].fullName);
 
-      assert(`Attempting to inject an unknown injection: '${fullName}'`, this.has(fullName, {[RAW_STRING_OPTION_KEY]: namespace}));
+      assert(`Attempting to inject an unknown injection: '${fullName}'`, this.has(fullName, {namespace}));
     }
   };
 }
@@ -707,7 +706,7 @@ function resolve(registry, normalizedName, options) {
   let resolved;
 
   if (registry.resolver) {
-    resolved = registry.resolver.resolve(normalizedName, options && options.source, options && options[RAW_STRING_OPTION_KEY]);
+    resolved = registry.resolver.resolve(normalizedName, options && options.source, options && options.namespace);
   }
 
   if (resolved === undefined) {
@@ -726,7 +725,7 @@ function resolve(registry, normalizedName, options) {
 function has(registry, fullName, source, namespace) {
   return registry.resolve(fullName, {
     source,
-    [RAW_STRING_OPTION_KEY]: namespace
+    namespace
   }) !== undefined;
 }
 

--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -9,8 +9,7 @@ import { DEBUG } from 'ember-env-flags';
 import { ENV } from 'ember-environment';
 
 const VALID_FULL_NAME_REGEXP = /^[^:]+:[^:]+$/;
-
-let missingResolverFunctionsDeprecation = 'Passing a `resolver` function into a Registry is deprecated. Please pass in a Resolver object with a `resolve` method.';
+const missingResolverFunctionsDeprecation = 'Passing a `resolver` function into a Registry is deprecated. Please pass in a Resolver object with a `resolve` method.';
 
 /**
  A registry used to store factory and option information keyed
@@ -188,7 +187,6 @@ export default class Registry {
 
     this._localLookupCache = Object.create(null);
 
-
     delete this.registrations[normalizedName];
     delete this._resolveCache[cacheKey];
     delete this._options[cacheKey];
@@ -329,9 +327,9 @@ export default class Registry {
     }
 
     let source = options && options.source && this.normalize(options.source);
-    let rawString = options && options[RAW_STRING_OPTION_KEY];
+    let namespace = options && options[RAW_STRING_OPTION_KEY];
 
-    return has(this, this.normalize(fullName), source, rawString);
+    return has(this, this.normalize(fullName), source, namespace);
   }
 
   /**
@@ -554,14 +552,7 @@ export default class Registry {
     return assign({}, fallbackKnown, localKnown, resolverKnown);
   }
 
-  isValidFullName(fullName, options) {
-    if(EMBER_MODULE_UNIFICATION) {
-      /* With a rawString, the fullName doesn't need to contain a : */
-      if (options && options[RAW_STRING_OPTION_KEY] && fullName) {
-        return true;
-      }
-    }
-
+  isValidFullName(fullName) {
     return VALID_FULL_NAME_REGEXP.test(fullName);
   }
 
@@ -642,9 +633,9 @@ if (DEBUG) {
       if (hash.hasOwnProperty(key)) {
         let {
           fullName,
-          rawString
+          namespace
         } = parseInjectionString(hash[key]);
-        assert(`Expected a proper full name, given '${fullName}'`, this.isValidFullName(fullName, {[RAW_STRING_OPTION_KEY]: rawString}));
+        assert(`Expected a proper full name, given '${fullName}'`, this.isValidFullName(fullName, {[RAW_STRING_OPTION_KEY]: namespace}));
 
         injections.push({
           property: key,
@@ -662,10 +653,10 @@ if (DEBUG) {
     for (let i = 0; i < injections.length; i++) {
       let {
         fullName,
-        rawString
+        namespace
       } = parseInjectionString(injections[i].fullName);
 
-      assert(`Attempting to inject an unknown injection: '${fullName}'`, this.has(fullName, {[RAW_STRING_OPTION_KEY]: rawString}));
+      assert(`Attempting to inject an unknown injection: '${fullName}'`, this.has(fullName, {[RAW_STRING_OPTION_KEY]: namespace}));
     }
   };
 }
@@ -732,10 +723,10 @@ function resolve(registry, normalizedName, options) {
   return resolved;
 }
 
-function has(registry, fullName, source, rawString) {
+function has(registry, fullName, source, namespace) {
   return registry.resolve(fullName, {
     source,
-    [RAW_STRING_OPTION_KEY]: rawString
+    [RAW_STRING_OPTION_KEY]: namespace
   }) !== undefined;
 }
 

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -400,7 +400,8 @@ moduleFor('Container', class extends AbstractTestCase {
 
     Apple.reopenClass({
       _lazyInjections() {
-        return ['orange:main', 'banana:main'];
+        return [{ fullName: 'orange:main' },
+                { fullName: 'banana:main' }];
       }
     });
 
@@ -423,7 +424,7 @@ moduleFor('Container', class extends AbstractTestCase {
     Apple.reopenClass({
       _lazyInjections: () => {
         assert.ok(true, 'should call lazy injection method');
-        return ['orange:main'];
+        return [{ fullName: 'orange:main' }];
       }
     });
 

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -5,7 +5,12 @@ import {
   lookupWithRawString,
   Registry
 } from '..';
-import { factory, moduleFor, AbstractTestCase, ModuleBasedTestResolver } from 'internal-test-helpers';
+import {
+  factory,
+  moduleFor,
+  AbstractTestCase,
+  ModuleBasedTestResolver
+} from 'internal-test-helpers';
 
 moduleFor('Container', class extends AbstractTestCase {
   ['@test A registered factory returns the same instance each time'](assert) {

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -689,15 +689,16 @@ if (EMBER_MODULE_UNIFICATION) {
     ['@test The container can pass a namespaced path to factoryFor']() {
       let PrivateComponent = factory();
       let type = 'component';
-      let namespace = 'my-addon';
+      let targetNamespace = 'my-addon';
       let name = 'my-component';
-      let rawString = `${namespace}::${name}`;
+      let rawString = `${targetNamespace}::${name}`;
+      let specifier = `${type}:${name}`;
       let resolver = new ModuleBasedTestResolver();
       let registry = new Registry({resolver});
 
       resolver.add({
-        specifier: type,
-        rawString: rawString
+        specifier,
+        targetNamespace
       }, PrivateComponent);
 
       let container = registry.container();
@@ -724,15 +725,16 @@ if (EMBER_MODULE_UNIFICATION) {
     ['@test The container can pass a namespace to lookup']() {
       let PrivateComponent = factory();
       let type = 'component';
-      let namespace = 'my-addon';
+      let targetNamespace = 'my-addon';
       let name = 'my-component';
-      let rawString = `${namespace}::${name}`;
+      let rawString = `${targetNamespace}::${name}`;
+      let specifier = `${type}:${name}`;
       let resolver = new ModuleBasedTestResolver();
       let registry = new Registry({resolver});
 
       resolver.add({
-        specifier: type,
-        rawString: rawString
+        specifier,
+        targetNamespace
       }, PrivateComponent);
 
       let container = registry.container();
@@ -748,7 +750,7 @@ if (EMBER_MODULE_UNIFICATION) {
       let result = lookupWithRawString(container, 'component', rawString);
       this.assert.ok(result instanceof PrivateComponent, 'The correct factory was provided');
       this.assert.ok(
-        container.cache[`${type}\0\0${rawString}`] instanceof PrivateComponent,
+        container.cache[`${specifier}\0\0${targetNamespace}`] instanceof PrivateComponent,
         'The correct factory was stored in the cache with the correct key which includes the raw string.'
       );
     }

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -689,29 +689,41 @@ if (EMBER_MODULE_UNIFICATION) {
     ['@test The container can pass a namespaced path to factoryFor']() {
       let PrivateComponent = factory();
       let type = 'component';
-      let targetNamespace = 'my-addon';
+      let namespace = 'my-addon';
       let name = 'my-component';
-      let rawString = `${targetNamespace}::${name}`;
+      let rawString = `${namespace}::${name}`;
       let specifier = `${type}:${name}`;
       let resolver = new ModuleBasedTestResolver();
       let registry = new Registry({resolver});
 
       resolver.add({
         specifier,
-        targetNamespace
+        namespace
       }, PrivateComponent);
 
       let container = registry.container();
 
       this.assert.equal(
-        container.factoryFor(`${type}:${name}`), undefined,
+        container.factoryFor(specifier), undefined,
         'Cannot find factoryFor by name'
       );
       expectAssertion(() => {
         container.factoryFor(`${type}:${rawString}`);
       }, /must be a proper full name/, 'Cannot find factoryFor by rawString');
 
+      // test internal API of factoryForWithRawString
       let result = factoryForWithRawString(container, 'component', rawString);
+      this.assert.strictEqual(
+        result.class, PrivateComponent,
+        'The correct factory was provided by internal method factoryForWithRawString'
+      );
+      this.assert.strictEqual(
+        result.class, PrivateComponent,
+        'The correct factory was provided again by internal method factoryForWithRawString'
+      );
+
+      // test public API of passing namespace to factoryFor
+      result = container.factoryFor(specifier, { namespace });
       this.assert.strictEqual(
         result.class, PrivateComponent,
         'The correct factory was provided'
@@ -722,35 +734,77 @@ if (EMBER_MODULE_UNIFICATION) {
       );
     }
 
-    ['@test The container can pass a namespace to lookup']() {
+    ['@test The container will not lookup a namespaced factory without namespace']() {
       let PrivateComponent = factory();
       let type = 'component';
-      let targetNamespace = 'my-addon';
+      let namespace = 'my-addon';
       let name = 'my-component';
-      let rawString = `${targetNamespace}::${name}`;
+      let rawString = `${namespace}::${name}`;
       let specifier = `${type}:${name}`;
       let resolver = new ModuleBasedTestResolver();
       let registry = new Registry({resolver});
 
       resolver.add({
         specifier,
-        targetNamespace
+        namespace
       }, PrivateComponent);
 
       let container = registry.container();
 
       this.assert.equal(
-        container.lookup(`${type}:${name}`), undefined,
+        container.lookup(specifier), undefined,
         'Cannot lookup by type:name'
       );
       expectAssertion(() => {
         container.lookup(`${type}:${rawString}`);
       }, /must be a proper full name/, 'Cannot lookup by type:rawString');
+    }
+
+    ['@test The container will lookup a namespaced factory with namespace via lookupWithRawString']() {
+      let PrivateComponent = factory();
+      let type = 'component';
+      let namespace = 'my-addon';
+      let name = 'my-component';
+      let rawString = `${namespace}::${name}`;
+      let specifier = `${type}:${name}`;
+      let resolver = new ModuleBasedTestResolver();
+      let registry = new Registry({resolver});
+
+      resolver.add({
+        specifier,
+        namespace
+      }, PrivateComponent);
+
+      let container = registry.container();
 
       let result = lookupWithRawString(container, 'component', rawString);
+      this.assert.ok(result instanceof PrivateComponent, 'The correct factory was provided by private API');
+      this.assert.ok(
+        container.cache[`${specifier}\0\0${namespace}`] instanceof PrivateComponent,
+        'The correct factory was stored in the cache with the correct key which includes the raw string.'
+      );
+    }
+
+    ['@test The container will lookup a namespaced factory with namespace via lookup']() {
+      let PrivateComponent = factory();
+      let type = 'component';
+      let namespace = 'my-addon';
+      let name = 'my-component';
+      let specifier = `${type}:${name}`;
+      let resolver = new ModuleBasedTestResolver();
+      let registry = new Registry({resolver});
+
+      resolver.add({
+        specifier,
+        namespace
+      }, PrivateComponent);
+
+      let container = registry.container();
+
+      let result = container.lookup(specifier, { namespace });
       this.assert.ok(result instanceof PrivateComponent, 'The correct factory was provided');
       this.assert.ok(
-        container.cache[`${specifier}\0\0${targetNamespace}`] instanceof PrivateComponent,
+        container.cache[`${specifier}\0\0${namespace}`] instanceof PrivateComponent,
         'The correct factory was stored in the cache with the correct key which includes the raw string.'
       );
     }

--- a/packages/container/tests/registry_test.js
+++ b/packages/container/tests/registry_test.js
@@ -773,7 +773,7 @@ if (EMBER_MODULE_UNIFICATION) {
 
       resolver.add({
         specifier,
-        targetNamespace: namespace
+        namespace
       }, PrivateComponent);
 
       assert.strictEqual(registry.resolve(specifier, { namespace }), PrivateComponent, 'The correct factory was provided');

--- a/packages/container/tests/registry_test.js
+++ b/packages/container/tests/registry_test.js
@@ -1,4 +1,4 @@
-import { Registry, privatize, _RAW_STRING_OPTION_KEY } from '..';
+import { Registry, privatize } from '..';
 import { factory, moduleFor, AbstractTestCase, ModuleBasedTestResolver } from 'internal-test-helpers';
 import { EMBER_MODULE_UNIFICATION } from 'ember/features';
 import { ENV } from 'ember-environment';
@@ -776,8 +776,8 @@ if (EMBER_MODULE_UNIFICATION) {
         targetNamespace: namespace
       }, PrivateComponent);
 
-      assert.strictEqual(registry.resolve(specifier, { [_RAW_STRING_OPTION_KEY]: namespace }), PrivateComponent, 'The correct factory was provided');
-      assert.strictEqual(registry.resolve(specifier, { [_RAW_STRING_OPTION_KEY]: namespace }), PrivateComponent, 'The correct factory was provided again');
+      assert.strictEqual(registry.resolve(specifier, { namespace }), PrivateComponent, 'The correct factory was provided');
+      assert.strictEqual(registry.resolve(specifier, { namespace }), PrivateComponent, 'The correct factory was provided again');
     }
   });
 

--- a/packages/container/tests/registry_test.js
+++ b/packages/container/tests/registry_test.js
@@ -1,5 +1,5 @@
-import { Registry, privatize } from '..';
-import { factory, moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { Registry, privatize, _RAW_STRING_OPTION_KEY } from '..';
+import { factory, moduleFor, AbstractTestCase, ModuleBasedTestResolver } from 'internal-test-helpers';
 import { EMBER_MODULE_UNIFICATION } from 'ember/features';
 import { ENV } from 'ember-environment';
 
@@ -746,25 +746,39 @@ if (EMBER_MODULE_UNIFICATION) {
   moduleFor('Registry module unification', class extends AbstractTestCase {
     ['@test The registry can pass a source to the resolver'](assert) {
       let PrivateComponent = factory();
-      let lookup = 'component:my-input';
+      let type = 'component';
+      let name = 'my-component';
+      let fullName = `${type}:${name}`;
       let source = 'template:routes/application';
-      let resolveCount = 0;
-      let resolver = {
-        resolve(fullName, src) {
-          resolveCount++;
-          if (fullName === lookup && src === source) {
-            return PrivateComponent;
-          }
-        }
-      };
+      let resolver = new ModuleBasedTestResolver();
       let registry = new Registry({ resolver });
-      registry.normalize = function(name) {
-        return name;
-      };
 
-      assert.strictEqual(registry.resolve(lookup, { source }), PrivateComponent, 'The correct factory was provided');
-      assert.strictEqual(registry.resolve(lookup, { source }), PrivateComponent, 'The correct factory was provided again');
-      assert.equal(resolveCount, 1, 'resolve called only once and a cached factory was returned the second time');
+      resolver.add({
+        specifier: fullName,
+        referrer: source
+      }, PrivateComponent);
+
+      assert.strictEqual(registry.resolve(fullName, { source }), PrivateComponent, 'The correct factory was provided');
+      assert.strictEqual(registry.resolve(fullName, { source }), PrivateComponent, 'The correct factory was provided again');
+    }
+
+    ['@test The registry can pass a namespaced lookup to the resolver'](assert) {
+      let PrivateComponent = factory();
+      let type = 'component';
+      let namespace = 'my-addon';
+      let name = 'my-component';
+      let rawString = `${namespace}::${name}`;
+      let resolver = new ModuleBasedTestResolver();
+      let registry = new Registry({ resolver });
+
+      resolver.add({
+        specifier: type,
+        rawString
+      }, PrivateComponent);
+
+      assert.strictEqual(registry.resolve(type, { [_RAW_STRING_OPTION_KEY]: rawString }), PrivateComponent, 'The correct factory was provided');
+      assert.strictEqual(registry.resolve(type, { [_RAW_STRING_OPTION_KEY]: rawString }), PrivateComponent, 'The correct factory was provided again');
     }
   });
+
 }

--- a/packages/container/tests/registry_test.js
+++ b/packages/container/tests/registry_test.js
@@ -767,17 +767,17 @@ if (EMBER_MODULE_UNIFICATION) {
       let type = 'component';
       let namespace = 'my-addon';
       let name = 'my-component';
-      let rawString = `${namespace}::${name}`;
+      let specifier = `${type}:${name}`;
       let resolver = new ModuleBasedTestResolver();
       let registry = new Registry({ resolver });
 
       resolver.add({
-        specifier: type,
-        rawString
+        specifier,
+        targetNamespace: namespace
       }, PrivateComponent);
 
-      assert.strictEqual(registry.resolve(type, { [_RAW_STRING_OPTION_KEY]: rawString }), PrivateComponent, 'The correct factory was provided');
-      assert.strictEqual(registry.resolve(type, { [_RAW_STRING_OPTION_KEY]: rawString }), PrivateComponent, 'The correct factory was provided again');
+      assert.strictEqual(registry.resolve(specifier, { [_RAW_STRING_OPTION_KEY]: namespace }), PrivateComponent, 'The correct factory was provided');
+      assert.strictEqual(registry.resolve(specifier, { [_RAW_STRING_OPTION_KEY]: namespace }), PrivateComponent, 'The correct factory was provided again');
     }
   });
 

--- a/packages/ember-glimmer/lib/resolver.ts
+++ b/packages/ember-glimmer/lib/resolver.ts
@@ -11,7 +11,7 @@ import {
   Helper,
   ModifierManager,
 } from '@glimmer/runtime';
-import { privatize as P } from 'container';
+import { privatize as P, factoryForWithRawString } from 'container';
 import { assert } from 'ember-debug';
 import { ENV } from 'ember-environment';
 import { _instrumentStart } from 'ember-metal';
@@ -218,7 +218,10 @@ export default class RuntimeResolver implements IRuntimeResolver<OwnedTemplateMe
 
     const options: LookupOptions | undefined = makeOptions(moduleName);
 
-    const factory = owner.factoryFor(`helper:${name}`, options) || owner.factoryFor(`helper:${name}`);
+    const specifier = `helper:${name}`;
+    const factory = name.indexOf('::') === -1 ?
+          (owner.factoryFor(specifier, options) || owner.factoryFor(specifier)) :
+          factoryForWithRawString(owner, 'helper', name);
 
     if (!isHelperFactory(factory)) {
       return null;

--- a/packages/ember-glimmer/tests/integration/components/namespaced-lookup-test.js
+++ b/packages/ember-glimmer/tests/integration/components/namespaced-lookup-test.js
@@ -1,6 +1,6 @@
 import { moduleFor, RenderingTest } from '../../utils/test-case';
 import { EMBER_MODULE_UNIFICATION } from 'ember/features';
-import { Component } from 'ember-glimmer';
+import { Component, helper } from 'ember-glimmer';
 
 if (EMBER_MODULE_UNIFICATION) {
 
@@ -97,5 +97,19 @@ if (EMBER_MODULE_UNIFICATION) {
       this.assertText('Nested namespaced component');
     }
 
+    ['@test it renders a namespaced helper']() {
+      this.add({
+        specifier: 'helper:my-helper',
+        namespace: 'my-namespace'
+      }, helper(() => 'my helper'));
+
+      this.render('{{my-namespace::my-helper}}');
+
+      this.assertText('my helper');
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('my helper');
+    }
   });
 }

--- a/packages/ember-glimmer/tests/integration/components/namespaced-lookup-test.js
+++ b/packages/ember-glimmer/tests/integration/components/namespaced-lookup-test.js
@@ -97,6 +97,34 @@ if (EMBER_MODULE_UNIFICATION) {
       this.assertText('Nested namespaced component');
     }
 
+    ['@test it does not render a main component when using a namespace']() {
+      this.addTemplate({
+        specifier: 'template:components/main',
+        namespace: 'my-addon'
+      }, 'namespaced template {{myProp}}');
+
+      this.add({
+        specifier: 'component:main',
+        namespace: 'my-addon'
+      }, Component.extend({
+        myProp: 'My property'
+      }));
+
+      this.add({
+        specifier: 'helper:my-addon',
+        namespace: 'empty-namespace'
+
+      }, helper(() => 'my helper'));
+
+      this.render('{{empty-namespace::my-addon}}');
+
+      this.assertText('my helper'); // component should be not found
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('my helper');
+    }
+
     ['@test it renders a namespaced helper']() {
       this.add({
         specifier: 'helper:my-helper',

--- a/packages/ember-glimmer/tests/integration/components/namespaced-lookup-test.js
+++ b/packages/ember-glimmer/tests/integration/components/namespaced-lookup-test.js
@@ -1,0 +1,101 @@
+import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { EMBER_MODULE_UNIFICATION } from 'ember/features';
+import { Component } from 'ember-glimmer';
+
+if (EMBER_MODULE_UNIFICATION) {
+
+  moduleFor('Namespaced lookup', class extends RenderingTest {
+    ['@test it can render a namespaced component']() {
+      this.addTemplate({
+        specifier: 'template:components/',
+        rawString: 'my-addon::my-component'
+      }, 'namespaced template {{myProp}}');
+
+      this.add({
+        specifier: 'component',
+        rawString: 'my-addon::my-component'
+      }, Component.extend({
+        myProp: 'My property'
+      }));
+
+      this.addComponent('x-outer', { template: '{{my-addon::my-component}}' });
+
+      this.render('{{x-outer}}');
+
+      this.assertText('namespaced template My property');
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('namespaced template My property');
+    }
+
+    ['@test it can render a nested namespaced component']() {
+      this.addTemplate({
+        specifier: 'template:components/',
+        rawString: 'second-addon::my-component'
+      }, 'second namespaced template');
+
+      this.addTemplate({
+        specifier: 'template:components/',
+        rawString: 'first-addon::my-component'
+      }, '{{second-addon::my-component}}');
+
+      this.addComponent('x-outer', { template: '{{first-addon::my-component}}' });
+
+      this.render('{{x-outer}}');
+
+      this.assertText('second namespaced template');
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('second namespaced template');
+    }
+
+    ['@test it can render a nested un-namespaced component']() {
+      this.addTemplate({
+        specifier: 'template:components/addon-component',
+        referrer: 'template:/first-addon/src/ui/components/my-component'
+      }, 'un-namespaced addon template');
+
+      this.addTemplate({
+        specifier: 'template:components/',
+        // TODO: moduleNames really should have type, be specifiers.
+        moduleName: '/first-addon/src/ui/components/my-component',
+        rawString: 'first-addon::my-component'
+      }, '{{addon-component}}');
+
+      this.addComponent('x-outer', { template: '{{first-addon::my-component}}' });
+
+      this.render('{{x-outer}}');
+
+      this.assertText('un-namespaced addon template');
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('un-namespaced addon template');
+    }
+
+    ['@test it can render a namespaced main component']() {
+      this.addTemplate({
+        specifier: 'template:components/addon-component',
+        referrer: 'template:/first-addon/src/ui/components/main'
+      }, 'Nested namespaced component');
+
+      this.addTemplate({
+        specifier: 'template:components/first-addon',
+        moduleName: '/first-addon/src/ui/components/main'
+      }, '{{addon-component}}');
+
+      this.addComponent('x-outer', { template: '{{first-addon}}' });
+
+      this.render('{{x-outer}}');
+
+      this.assertText('Nested namespaced component');
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('Nested namespaced component');
+    }
+
+  });
+}

--- a/packages/ember-glimmer/tests/integration/components/namespaced-lookup-test.js
+++ b/packages/ember-glimmer/tests/integration/components/namespaced-lookup-test.js
@@ -8,12 +8,12 @@ if (EMBER_MODULE_UNIFICATION) {
     ['@test it can render a namespaced component']() {
       this.addTemplate({
         specifier: 'template:components/my-component',
-        targetNamespace: 'my-addon'
+        namespace: 'my-addon'
       }, 'namespaced template {{myProp}}');
 
       this.add({
         specifier: 'component:my-component',
-        targetNamespace: 'my-addon'
+        namespace: 'my-addon'
       }, Component.extend({
         myProp: 'My property'
       }));
@@ -32,12 +32,12 @@ if (EMBER_MODULE_UNIFICATION) {
     ['@test it can render a nested namespaced component']() {
       this.addTemplate({
         specifier: 'template:components/my-component',
-        targetNamespace: 'second-addon'
+        namespace: 'second-addon'
       }, 'second namespaced template');
 
       this.addTemplate({
         specifier: 'template:components/my-component',
-        targetNamespace: 'first-addon'
+        namespace: 'first-addon'
       }, '{{second-addon::my-component}}');
 
       this.addComponent('x-outer', { template: '{{first-addon::my-component}}' });
@@ -61,7 +61,7 @@ if (EMBER_MODULE_UNIFICATION) {
         specifier: 'template:components/my-component',
         // TODO: moduleNames really should have type, be specifiers.
         moduleName: '/first-addon/src/ui/components/my-component',
-        targetNamespace: 'first-addon'
+        namespace: 'first-addon'
       }, '{{addon-component}}');
 
       this.addComponent('x-outer', { template: '{{first-addon::my-component}}' });

--- a/packages/ember-glimmer/tests/integration/components/namespaced-lookup-test.js
+++ b/packages/ember-glimmer/tests/integration/components/namespaced-lookup-test.js
@@ -7,13 +7,13 @@ if (EMBER_MODULE_UNIFICATION) {
   moduleFor('Namespaced lookup', class extends RenderingTest {
     ['@test it can render a namespaced component']() {
       this.addTemplate({
-        specifier: 'template:components/',
-        rawString: 'my-addon::my-component'
+        specifier: 'template:components/my-component',
+        targetNamespace: 'my-addon'
       }, 'namespaced template {{myProp}}');
 
       this.add({
-        specifier: 'component',
-        rawString: 'my-addon::my-component'
+        specifier: 'component:my-component',
+        targetNamespace: 'my-addon'
       }, Component.extend({
         myProp: 'My property'
       }));
@@ -31,13 +31,13 @@ if (EMBER_MODULE_UNIFICATION) {
 
     ['@test it can render a nested namespaced component']() {
       this.addTemplate({
-        specifier: 'template:components/',
-        rawString: 'second-addon::my-component'
+        specifier: 'template:components/my-component',
+        targetNamespace: 'second-addon'
       }, 'second namespaced template');
 
       this.addTemplate({
-        specifier: 'template:components/',
-        rawString: 'first-addon::my-component'
+        specifier: 'template:components/my-component',
+        targetNamespace: 'first-addon'
       }, '{{second-addon::my-component}}');
 
       this.addComponent('x-outer', { template: '{{first-addon::my-component}}' });
@@ -58,10 +58,10 @@ if (EMBER_MODULE_UNIFICATION) {
       }, 'un-namespaced addon template');
 
       this.addTemplate({
-        specifier: 'template:components/',
+        specifier: 'template:components/my-component',
         // TODO: moduleNames really should have type, be specifiers.
         moduleName: '/first-addon/src/ui/components/my-component',
-        rawString: 'first-addon::my-component'
+        targetNamespace: 'first-addon'
       }, '{{addon-component}}');
 
       this.addComponent('x-outer', { template: '{{first-addon::my-component}}' });

--- a/packages/ember-metal/lib/injected_property.js
+++ b/packages/ember-metal/lib/injected_property.js
@@ -4,6 +4,7 @@ import { ComputedProperty } from './computed';
 import { AliasedProperty } from './alias';
 import { Descriptor } from './properties';
 import { descriptorFor } from './meta';
+import { lookupWithRawString } from 'container';
 
 /**
  @module ember
@@ -36,7 +37,7 @@ function injectedPropertyGet(keyName) {
   assert(`InjectedProperties should be defined with the inject computed property macros.`, desc && desc.type);
   assert(`Attempting to lookup an injected property on an object without a container, ensure that the object was instantiated via a container.`, owner);
 
-  return owner.lookup(`${desc.type}:${desc.name || keyName}`);
+  return lookupWithRawString(owner, desc.type, desc.name || keyName);
 }
 
 InjectedProperty.prototype = Object.create(Descriptor.prototype);

--- a/packages/ember-metal/lib/injected_property.js
+++ b/packages/ember-metal/lib/injected_property.js
@@ -22,9 +22,10 @@ import { lookupWithRawString } from 'container';
          to the property's name
   @private
 */
-export default function InjectedProperty(type, name) {
+export default function InjectedProperty(type, name, options) {
   this.type = type;
   this.name = name;
+  this.options = options;
 
   this._super$Constructor(injectedPropertyGet);
   AliasedPropertyPrototype.oneWay.call(this);
@@ -37,6 +38,9 @@ function injectedPropertyGet(keyName) {
   assert(`InjectedProperties should be defined with the inject computed property macros.`, desc && desc.type);
   assert(`Attempting to lookup an injected property on an object without a container, ensure that the object was instantiated via a container.`, owner);
 
+  if (desc.options && desc.options.namespace) { // && (!desc.name || desc.name.indexOf('::') === -1)
+    return lookupWithRawString(owner, desc.type, `${desc.options.namespace}::${desc.name || keyName}`);
+  }
   return lookupWithRawString(owner, desc.type, desc.name || keyName);
 }
 

--- a/packages/ember-runtime/lib/inject.js
+++ b/packages/ember-runtime/lib/inject.js
@@ -35,7 +35,7 @@ const typeValidators = {};
 export function createInjectionHelper(type, validator) {
   typeValidators[type] = validator;
 
-  inject[type] = name => new InjectedProperty(type, name);
+  inject[type] = (name, options) => new InjectedProperty(type, name, options);
 }
 
 /**

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -1057,7 +1057,10 @@ if (DEBUG) {
     for (key in proto) {
       desc = descriptorFor(proto, key);
       if (desc instanceof InjectedProperty) {
-        injections[key] = `${desc.type}:${desc.name || key}`;
+        injections[key] = {
+          fullName: `${desc.type}:${desc.name || key}`,
+          namespace: desc.options && desc.options.namespace
+        };
       }
     }
 

--- a/packages/ember-runtime/tests/inject_test.js
+++ b/packages/ember-runtime/tests/inject_test.js
@@ -61,6 +61,9 @@ if (DEBUG) {
       bar: new InjectedProperty('quux')
     });
 
-    assert.deepEqual(AnObject._lazyInjections(), { 'foo': 'foo:bar', 'bar': 'quux:bar' }, 'should return injected container keys');
+    assert.deepEqual(AnObject._lazyInjections(), {
+      'foo': { fullName: 'foo:bar', namespace: undefined },
+      'bar': { fullName: 'quux:bar', namespace: undefined }
+    }, 'should return injected container keys');
   });
 }

--- a/packages/ember-views/lib/component_lookup.js
+++ b/packages/ember-views/lib/component_lookup.js
@@ -1,17 +1,29 @@
 import { assert } from 'ember-debug';
 import { Object as EmberObject } from 'ember-runtime';
+import {
+  factoryForWithRawString,
+  lookupWithRawString
+} from 'container';
 
 export default EmberObject.extend({
   componentFor(name, owner, options) {
     assert(`You cannot use '${name}' as a component name. Component names must contain a hyphen.`, ~name.indexOf('-'));
-    let fullName = `component:${name}`;
-    return owner.factoryFor(fullName, options);
+    if (name.indexOf('::') === -1) {
+      let fullName = `component:${name}`;
+      return owner.factoryFor(fullName, options);
+    } else {
+      return factoryForWithRawString(owner, 'component', name);
+    }
   },
 
   layoutFor(name, owner, options) {
     assert(`You cannot use '${name}' as a component name. Component names must contain a hyphen.`, ~name.indexOf('-'));
 
-    let templateFullName = `template:components/${name}`;
-    return owner.lookup(templateFullName, options);
+    if (name.indexOf('::') === -1) {
+      let templateFullName = `template:components/${name}`;
+      return owner.lookup(templateFullName, options);
+    } else {
+      return lookupWithRawString(owner, 'template:components/', name);
+    }
   }
 });

--- a/packages/ember/tests/service_injection_test.js
+++ b/packages/ember/tests/service_injection_test.js
@@ -2,7 +2,7 @@ import { Controller } from 'ember-runtime';
 import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
 import { inject, Service } from 'ember-runtime';
 import { computed } from 'ember-metal';
-import { EMBER_METAL_ES5_GETTERS } from 'ember/features';
+import { EMBER_METAL_ES5_GETTERS, EMBER_MODULE_UNIFICATION } from 'ember/features';
 
 moduleFor('Service Injection', class extends ApplicationTestCase {
 
@@ -39,6 +39,26 @@ if (EMBER_METAL_ES5_GETTERS) {
         let controller = this.applicationInstance.lookup('controller:application');
         assert.ok(controller.myService instanceof MyService);
         assert.equal(controller.myService.name, 'The service name', 'service property accessible');
+      });
+    }
+  });
+}
+
+if (EMBER_MODULE_UNIFICATION) {
+  moduleFor('Service Injection (MU)', class extends ApplicationTestCase {
+    ['@test Service with namespace can be injected and is resolved'](assert) {
+      this.add('controller:application', Controller.extend({
+        myService: inject.service('my-namespace::my-service')
+      }));
+      let MyService = Service.extend();
+      this.add({
+        specifier: 'service',
+        rawString: 'my-namespace::my-service'
+      }, MyService);
+
+      this.visit('/').then(() => {
+        let controller = this.applicationInstance.lookup('controller:application');
+        assert.ok(controller.get('myService') instanceof MyService);
       });
     }
   });

--- a/packages/ember/tests/service_injection_test.js
+++ b/packages/ember/tests/service_injection_test.js
@@ -61,5 +61,23 @@ if (EMBER_MODULE_UNIFICATION) {
         assert.ok(controller.get('myService') instanceof MyService);
       });
     }
+
+    ['@test Service with namespace can be injected with namespace and is resolved'](assert) {
+      let namespace = 'my-namespace';
+      this.add('controller:application', Controller.extend({
+        myService: inject.service('my-service', { namespace })
+      }));
+      let MyService = Service.extend();
+      this.add({
+        specifier: 'service:my-service',
+        namespace
+      }, MyService);
+
+      this.visit('/').then(() => {
+        let controller = this.applicationInstance.lookup('controller:application');
+
+        assert.ok(controller.get('myService') instanceof MyService);
+      });
+    }
   });
 }

--- a/packages/ember/tests/service_injection_test.js
+++ b/packages/ember/tests/service_injection_test.js
@@ -52,8 +52,8 @@ if (EMBER_MODULE_UNIFICATION) {
       }));
       let MyService = Service.extend();
       this.add({
-        specifier: 'service',
-        rawString: 'my-namespace::my-service'
+        specifier: 'service:my-service',
+        targetNamespace: 'my-namespace'
       }, MyService);
 
       this.visit('/').then(() => {

--- a/packages/ember/tests/service_injection_test.js
+++ b/packages/ember/tests/service_injection_test.js
@@ -53,7 +53,7 @@ if (EMBER_MODULE_UNIFICATION) {
       let MyService = Service.extend();
       this.add({
         specifier: 'service:my-service',
-        targetNamespace: 'my-namespace'
+        namespace: 'my-namespace'
       }, MyService);
 
       this.visit('/').then(() => {

--- a/packages/internal-test-helpers/lib/test-cases/abstract-rendering.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract-rendering.js
@@ -2,6 +2,7 @@ import { assign } from 'ember-utils';
 import { compile } from 'ember-template-compiler';
 import { EventDispatcher } from 'ember-views';
 import { helper, Helper, Component, _resetRenderers} from 'ember-glimmer';
+import { ModuleBasedResolver } from '../test-resolver';
 
 import AbstractTestCase from './abstract';
 import buildOwner from '../build-owner';
@@ -41,7 +42,42 @@ export default class AbstractRenderingTestCase extends AbstractTestCase {
 
   getOwnerOptions() { }
   getBootOptions() { }
-  getResolver() { }
+
+  get resolver() {
+    return this.owner.__registry__.fallback.resolver;
+  }
+
+  getResolver() {
+    return new ModuleBasedResolver();
+  }
+
+  add(specifier, factory) {
+    this.resolver.add(specifier, factory);
+  }
+
+  addTemplate(templateName, templateString) {
+    if (typeof templateName === 'string') {
+      this.resolver.add(`template:${templateName}`, this.compile(templateString, {
+        moduleName: templateName
+      }));
+    } else {
+      this.resolver.add(templateName, this.compile(templateString, {
+        moduleName: templateName.moduleName
+      }));
+    }
+  }
+
+  addComponent(name, { ComponentClass = null, template = null }) {
+    if (ComponentClass) {
+      this.resolver.add(`component:${name}`, ComponentClass);
+    }
+
+    if (typeof template === 'string') {
+      this.resolver.add(`template:components/${name}`, this.compile(template, {
+        moduleName: `components/${name}`
+      }));
+    }
+  }
 
   afterEach() {
     try {

--- a/packages/internal-test-helpers/lib/test-resolver.js
+++ b/packages/internal-test-helpers/lib/test-resolver.js
@@ -2,8 +2,8 @@ import { compile } from 'ember-template-compiler';
 
 const DELIMITER = '\0';
 
-function serializeKey(specifier, referrer, targetNamespace) {
-  return [specifier, referrer, targetNamespace].join(DELIMITER);
+function serializeKey(specifier, referrer, namespace) {
+  return [specifier, referrer, namespace].join(DELIMITER);
 }
 
 class Resolver {
@@ -11,8 +11,8 @@ class Resolver {
     this._registered = {};
     this.constructor.lastInstance = this;
   }
-  resolve(specifier, referrer, targetNamespace) {
-    return this._registered[serializeKey(specifier, referrer, targetNamespace)];
+  resolve(specifier, referrer, namespace) {
+    return this._registered[serializeKey(specifier, referrer, namespace)];
   }
   add(specifier, factory) {
     let key;
@@ -24,7 +24,7 @@ class Resolver {
         key = serializeKey(specifier);
         break;
       case 'object':
-        key = serializeKey(specifier.specifier, specifier.referrer, specifier.targetNamespace);
+        key = serializeKey(specifier.specifier, specifier.referrer, specifier.namespace);
         break;
       default:
         throw new Error('Specifier string has an unknown type');

--- a/packages/internal-test-helpers/lib/test-resolver.js
+++ b/packages/internal-test-helpers/lib/test-resolver.js
@@ -2,8 +2,8 @@ import { compile } from 'ember-template-compiler';
 
 const DELIMITER = '\0';
 
-function serializeKey(specifier, referrer, rawString) {
-  return [specifier, referrer, rawString].join(DELIMITER);
+function serializeKey(specifier, referrer, targetNamespace) {
+  return [specifier, referrer, targetNamespace].join(DELIMITER);
 }
 
 class Resolver {
@@ -11,8 +11,8 @@ class Resolver {
     this._registered = {};
     this.constructor.lastInstance = this;
   }
-  resolve(specifier, referrer, rawString) {
-    return this._registered[serializeKey(specifier, referrer, rawString)];
+  resolve(specifier, referrer, targetNamespace) {
+    return this._registered[serializeKey(specifier, referrer, targetNamespace)];
   }
   add(specifier, factory) {
     let key;
@@ -24,7 +24,7 @@ class Resolver {
         key = serializeKey(specifier);
         break;
       case 'object':
-        key = serializeKey(specifier.specifier, specifier.referrer, specifier.rawString);
+        key = serializeKey(specifier.specifier, specifier.referrer, specifier.targetNamespace);
         break;
       default:
         throw new Error('Specifier string has an unknown type');

--- a/packages/internal-test-helpers/lib/test-resolver.js
+++ b/packages/internal-test-helpers/lib/test-resolver.js
@@ -1,25 +1,43 @@
 import { compile } from 'ember-template-compiler';
 
+const DELIMITER = '\0';
+
+function serializeKey(specifier, referrer, rawString) {
+  return [specifier, referrer, rawString].join(DELIMITER);
+}
+
 class Resolver {
   constructor() {
     this._registered = {};
     this.constructor.lastInstance = this;
   }
-  resolve(specifier) {
-    return this._registered[specifier];
+  resolve(specifier, referrer, rawString) {
+    return this._registered[serializeKey(specifier, referrer, rawString)];
   }
   add(specifier, factory) {
-    if (specifier.indexOf(':') === -1) {
-      throw new Error('Specifiers added to the resolver must be in the format of type:name');
+    let key;
+    switch (typeof specifier) {
+      case 'string':
+        if (specifier.indexOf(':') === -1) {
+          throw new Error('Specifiers added to the resolver must be in the format of type:name');
+        }
+        key = serializeKey(specifier);
+        break;
+      case 'object':
+        key = serializeKey(specifier.specifier, specifier.referrer, specifier.rawString);
+        break;
+      default:
+        throw new Error('Specifier string has an unknown type');
     }
-    return this._registered[specifier] = factory;
+
+    return this._registered[key] = factory;
   }
   addTemplate(templateName, template) {
     let templateType = typeof template;
     if (templateType !== 'string') {
       throw new Error(`You called addTemplate for "${templateName}" with a template argument of type of '${templateType}'. addTemplate expects an argument of an uncompiled template as a string.`);
     }
-    return this._registered[`template:${templateName}`] = compile(template, {
+    return this._registered[serializeKey(`template:${templateName}`)] = compile(template, {
       moduleName: templateName
     });
   }


### PR DESCRIPTION
This commit adds support for invoking a component or injecting a service from a module unification namespace. It does so in a very targeted manner, and specifically *avoids* adding support for namespaces to lower-level APIs like lookup or factoryFor.

Ember itself doesn't perform any resolution steps for a lookup. Instead, it defers resolution to a resolver class provided to the application at runtime. For example this invocation:

```hbs
{{! app/templates/index.hbs }}
{{app-component}}
```

Causes a resolver invocation of:

```js
resolve(
  'template:components/app-component', // a "fullName" formatted type:name.
  'app/templates/index' // a referrer for this lookup
);
```

The resolver API has already been changed behind the module unification feature flag to pass the second argument of "referrer" when appropriate.

A component from another namespace is invoked by putting the namespace before a `::` delemiter. For example an invocation:

```hbs
{{! src/ui/components/app-component/template.hbs }}
{{my-addon::addon-component}}
```

In order to resolve this namespace the resolver must be passed `my-addon` is some form or another.

The current Ember container APIs are coupled heavily to the idea of a "fullName". This is a string formatted as `type:name`, and expected to resolve something. I'm hesitant to expand that syntax to something like `type:optional-namespace::name`, especially since we would like to replace the strings there with "specifiers" from the glimmer-di project as we adopt more of that project.

Additionally we want existing implementions of the resolver API to *not* be passed the namespace in the first argument. If they were, they may resolve certain lookups in ways that don't mesh our goals for the `::` syntax. For example a custom resolver in someone's app may be splitting on `:` an expecting a syntax in the string that matches `type:name`. It is ok to break those resolvers for namespaced lookups, and we would rather they fail in some way than resolve something that is wrong.

Instead, we've made an *additive* change to the resolver API. The "rawString", the string invoking the lookup, is passed in the third position:

```hbs
{{! src/ui/components/app-component/template.hbs }}
{{my-addon::addon-component}}
```

Resolves with:

```js
resolve(
  'template:components/',
  'src/ui/components/app-component/template',
  'my-addon::addon-component'
);
resolve(
  'component',
  'src/ui/components/app-component/template',
  'my-addon::addon-component'
);
```

Similarly service injections pass their "rawString":

```hbs
Ember.inject.service('my-addon::addon-service');
```

Resolves with:

```js
resolve(
  'service',
  undefined,
  'my-addon::addon-service'
);
```

The resolver is expected to parse the invocation string.

TODO:

* [ ] Complete a smoke test against ember-resolver master with the MU feature flag.
* [ ] Add a test for namespaced `main` lookups of services. `store: Ember.inject.service('ember-data')` and the addons `src/services/main.js` would be resolved.
* [ ] Rationalize what `moduleName` is on a template and what it should be.