### PR TITLE
[BUGFIX beta] Remove humanize() call from generated test descriptions

### DIFF
--- a/blueprints/acceptance-test/index.js
+++ b/blueprints/acceptance-test/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const path = require('path');
-const testInfo = require('ember-cli-test-info');
 const pathUtil = require('ember-cli-path-utils');
 const stringUtils = require('ember-cli-string-utils');
 const existsSync = require('exists-sync');
@@ -21,9 +20,11 @@ module.exports = useTestFrameworkDetector({
     let destroyAppExists =
       existsSync(path.join(this.project.root, '/tests/helpers/destroy-app.js'));
 
+    let friendlyTestName = ['Acceptance', stringUtils.dasherize(options.entity.name).replace(/[-]/g,' ')].join(' | ');
+
     return {
       testFolderRoot: testFolderRoot,
-      friendlyTestName: testInfo.name(options.entity.name, 'Acceptance', null),
+      friendlyTestName,
       destroyAppExists: destroyAppExists
     };
   }

--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const path = require('path');
-const testInfo = require('ember-cli-test-info');
 const stringUtil = require('ember-cli-string-utils');
 const isPackageMissing = require('ember-cli-is-package-missing');
 const getPathOption = require('ember-cli-get-component-path-option');
@@ -42,14 +41,15 @@ module.exports = useTestFrameworkDetector({
     let dasherizedModuleName = stringUtil.dasherize(options.entity.name);
     let componentPathName = dasherizedModuleName;
     let testType = options.testType || 'integration';
-    let friendlyTestDescription = testInfo.description(options.entity.name, 'Integration', 'Component');
+
+    let friendlyTestDescription = [
+      testType === 'unit' ? 'Unit' : 'Integration',
+      'Component',
+      dasherizedModuleName,
+    ].join(' | ');
 
     if (options.pod && options.path !== 'components' && options.path !== '') {
       componentPathName = [options.path, dasherizedModuleName].filter(Boolean).join('/');
-    }
-
-    if (options.testType === 'unit') {
-      friendlyTestDescription = testInfo.description(options.entity.name, 'Unit', 'Component');
     }
 
     return {

--- a/blueprints/controller-test/index.js
+++ b/blueprints/controller-test/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const stringUtil = require('ember-cli-string-utils');
-const testInfo = require('ember-cli-test-info');
 
 const useTestFrameworkDetector = require('../test-framework-detector');
 
@@ -12,7 +11,7 @@ module.exports = useTestFrameworkDetector({
     let controllerPathName = dasherizedModuleName;
     return {
       controllerPathName: controllerPathName,
-      friendlyTestDescription: testInfo.description(options.entity.name, 'Unit', 'Controller')
+      friendlyTestDescription: ['Unit', 'Controller', dasherizedModuleName].join(' | ')
     };
   }
 });

--- a/blueprints/helper-test/index.js
+++ b/blueprints/helper-test/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const testInfo = require('ember-cli-test-info');
 const stringUtils = require('ember-cli-string-utils');
 const isPackageMissing = require('ember-cli-is-package-missing');
 
@@ -34,7 +33,7 @@ module.exports = useTestFrameworkDetector({
   locals: function(options) {
     let testType = options.testType || 'integration';
     let testName = testType === 'integration' ? 'Integration' : 'Unit';
-    let friendlyTestName = testInfo.name(options.entity.name, testName, 'Helper');
+    let friendlyTestName = [testName, 'Helper', options.entity.name].join(' | ');
 
     return {
       friendlyTestName: friendlyTestName,

--- a/blueprints/initializer-test/index.js
+++ b/blueprints/initializer-test/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const testInfo = require('ember-cli-test-info');
 const stringUtils = require('ember-cli-string-utils');
 
 const useTestFrameworkDetector = require('../test-framework-detector');
@@ -9,7 +8,7 @@ module.exports = useTestFrameworkDetector({
   description: 'Generates an initializer unit test.',
   locals: function(options) {
     return {
-      friendlyTestName: testInfo.name(options.entity.name, 'Unit', 'Initializer'),
+      friendlyTestName: ['Unit', 'Initializer', options.entity.name].join(' | '),
       dasherizedModulePrefix: stringUtils.dasherize(options.project.config().modulePrefix)
     };
   }

--- a/blueprints/instance-initializer-test/index.js
+++ b/blueprints/instance-initializer-test/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const testInfo = require('ember-cli-test-info');
 const stringUtils = require('ember-cli-string-utils');
 
 const useTestFrameworkDetector = require('../test-framework-detector');
@@ -9,7 +8,7 @@ module.exports = useTestFrameworkDetector({
   description: 'Generates an instance initializer unit test.',
   locals: function(options) {
     return {
-      friendlyTestName: testInfo.name(options.entity.name, 'Unit', 'Instance Initializer'),
+      friendlyTestName: ['Unit', 'Instance Initializer', options.entity.name].join(' | '),
       dasherizedModulePrefix: stringUtils.dasherize(options.project.config().modulePrefix)
     };
   }

--- a/blueprints/mixin-test/index.js
+++ b/blueprints/mixin-test/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const testInfo = require('ember-cli-test-info');
 const useTestFrameworkDetector = require('../test-framework-detector');
 
 module.exports = useTestFrameworkDetector({
@@ -8,7 +7,7 @@ module.exports = useTestFrameworkDetector({
   locals: function(options) {
     return {
       projectName: options.inRepoAddon ? options.inRepoAddon : options.project.name(),
-      friendlyTestName: testInfo.name(options.entity.name, 'Unit', 'Mixin')
+      friendlyTestName: ['Unit', 'Mixin', options.entity.name].join(' | ')
     };
   }
 });

--- a/blueprints/route-test/index.js
+++ b/blueprints/route-test/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const testInfo = require('ember-cli-test-info');
 const path = require('path');
 const stringUtil = require('ember-cli-string-utils');
 const useTestFrameworkDetector = require('../test-framework-detector');
@@ -43,7 +42,7 @@ module.exports = useTestFrameworkDetector({
     }
 
     return {
-      friendlyTestDescription: testInfo.description(options.entity.name, 'Unit', 'Route'),
+      friendlyTestDescription: ['Unit', 'Route', options.entity.name].join(' | '),
       moduleName: stringUtil.dasherize(moduleName)
     };
   },

--- a/blueprints/service-test/index.js
+++ b/blueprints/service-test/index.js
@@ -1,14 +1,12 @@
 'use strict';
 
-const testInfo = require('ember-cli-test-info');
-
 const useTestFrameworkDetector = require('../test-framework-detector');
 
 module.exports = useTestFrameworkDetector({
   description: 'Generates a service unit test.',
   locals: function(options) {
     return {
-      friendlyTestDescription: testInfo.description(options.entity.name, 'Unit', 'Service')
+      friendlyTestDescription: ['Unit', 'Service', options.entity.name].join(' | ')
     };
   },
 });

--- a/blueprints/util-test/index.js
+++ b/blueprints/util-test/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const testInfo = require('ember-cli-test-info');
 const stringUtils = require('ember-cli-string-utils');
 
 const useTestFrameworkDetector = require('../test-framework-detector');
@@ -9,7 +8,7 @@ module.exports = useTestFrameworkDetector({
   description: 'Generates a util unit test.',
   locals: function(options) {
     return {
-      friendlyTestName: testInfo.name(options.entity.name, 'Unit', 'Utility'),
+      friendlyTestName: ['Unit', 'Utility', options.entity.name].join(' | '),
       dasherizedModulePrefix: stringUtils.dasherize(options.project.config().modulePrefix)
     };
   }

--- a/node-tests/fixtures/component-test/default.js
+++ b/node-tests/fixtures/component-test/default.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-moduleForComponent('x-foo', 'Integration | Component | x foo', {
+moduleForComponent('x-foo', 'Integration | Component | x-foo', {
   integration: true
 });
 

--- a/node-tests/fixtures/component-test/mocha-0.12-unit.js
+++ b/node-tests/fixtures/component-test/mocha-0.12-unit.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
 
-describe('Unit | Component | x foo', function() {
+describe('Unit | Component | x-foo', function() {
   setupComponentTest('x-foo', {
     // Specify the other units that are required for this test
     // needs: ['component:foo', 'helper:bar'],

--- a/node-tests/fixtures/component-test/mocha-0.12.js
+++ b/node-tests/fixtures/component-test/mocha-0.12.js
@@ -3,7 +3,7 @@ import { describe, it } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-describe('Integration | Component | x foo', function() {
+describe('Integration | Component | x-foo', function() {
   setupComponentTest('x-foo', {
     integration: true
   });

--- a/node-tests/fixtures/component-test/mocha-unit.js
+++ b/node-tests/fixtures/component-test/mocha-unit.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describeComponent, it } from 'ember-mocha';
 
-describeComponent('x-foo', 'Unit | Component | x foo',
+describeComponent('x-foo', 'Unit | Component | x-foo',
   {
     // Specify the other units that are required for this test
     // needs: ['component:foo', 'helper:bar'],

--- a/node-tests/fixtures/component-test/mocha.js
+++ b/node-tests/fixtures/component-test/mocha.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { describeComponent, it } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-describeComponent('x-foo', 'Integration | Component | x foo',
+describeComponent('x-foo', 'Integration | Component | x-foo',
   {
     integration: true
   },

--- a/node-tests/fixtures/component-test/rfc232-unit.js
+++ b/node-tests/fixtures/component-test/rfc232-unit.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Component | x foo', function(hooks) {
+module('Unit | Component | x-foo', function(hooks) {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/node-tests/fixtures/component-test/rfc232.js
+++ b/node-tests/fixtures/component-test/rfc232.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | x foo', function(hooks) {
+module('Integration | Component | x-foo', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {

--- a/node-tests/fixtures/component-test/unit.js
+++ b/node-tests/fixtures/component-test/unit.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 
-moduleForComponent('x-foo', 'Unit | Component | x foo', {
+moduleForComponent('x-foo', 'Unit | Component | x-foo', {
   // Specify the other units that are required for this test
   // needs: ['component:foo', 'helper:bar'],
   unit: true

--- a/node-tests/fixtures/helper-test/mocha-0.12-unit.js
+++ b/node-tests/fixtures/helper-test/mocha-0.12-unit.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';
 
-describe('Unit | Helper | foo/bar baz', function() {
+describe('Unit | Helper | foo/bar-baz', function() {
 
   // Replace this with your real tests.
   it('works', function() {

--- a/node-tests/fixtures/helper-test/mocha-0.12.js
+++ b/node-tests/fixtures/helper-test/mocha-0.12.js
@@ -3,7 +3,7 @@ import { describe, it } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-describe('Integration | Helper | foo/bar baz', function() {
+describe('Integration | Helper | foo/bar-baz', function() {
   setupComponentTest('foo/bar-baz', {
     integration: true
   });

--- a/node-tests/fixtures/helper-test/mocha-unit.js
+++ b/node-tests/fixtures/helper-test/mocha-unit.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';
 
-describe('Unit | Helper | foo/bar baz', function() {
+describe('Unit | Helper | foo/bar-baz', function() {
 
   // Replace this with your real tests.
   it('works', function() {

--- a/node-tests/fixtures/helper-test/rfc232-unit.js
+++ b/node-tests/fixtures/helper-test/rfc232-unit.js
@@ -2,7 +2,7 @@ import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Helper | foo/bar baz', function(hooks) {
+module('Unit | Helper | foo/bar-baz', function(hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.

--- a/node-tests/fixtures/helper-test/rfc232.js
+++ b/node-tests/fixtures/helper-test/rfc232.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Helper | foo/bar baz', function(hooks) {
+module('Integration | Helper | foo/bar-baz', function(hooks) {
   setupRenderingTest(hooks);
 
   // Replace this with your real tests.

--- a/node-tests/fixtures/helper-test/unit.js
+++ b/node-tests/fixtures/helper-test/unit.js
@@ -2,7 +2,7 @@
 import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';
 import { module, test } from 'qunit';
 
-module('Unit | Helper | foo/bar baz');
+module('Unit | Helper | foo/bar-baz');
 
 // Replace this with your real tests.
 test('it works', function(assert) {

--- a/node-tests/fixtures/util-test/default.js
+++ b/node-tests/fixtures/util-test/default.js
@@ -1,7 +1,7 @@
 import fooBar from 'my-app/utils/foo-bar';
 import { module, test } from 'qunit';
 
-module('Unit | Utility | foo bar');
+module('Unit | Utility | foo-bar');
 
 // Replace this with your real tests.
 test('it works', function(assert) {

--- a/node-tests/fixtures/util-test/dummy.js
+++ b/node-tests/fixtures/util-test/dummy.js
@@ -1,7 +1,7 @@
 import fooBar from 'dummy/utils/foo-bar';
 import { module, test } from 'qunit';
 
-module('Unit | Utility | foo bar');
+module('Unit | Utility | foo-bar');
 
 // Replace this with your real tests.
 test('it works', function(assert) {

--- a/node-tests/fixtures/util-test/mocha.js
+++ b/node-tests/fixtures/util-test/mocha.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import fooBar from 'my-app/utils/foo-bar';
 
-describe('Unit | Utility | foo bar', function() {
+describe('Unit | Utility | foo-bar', function() {
   // Replace this with your real tests.
   it('works', function() {
     let result = fooBar();

--- a/node-tests/fixtures/util-test/rfc232.js
+++ b/node-tests/fixtures/util-test/rfc232.js
@@ -1,7 +1,7 @@
 import fooBar from 'my-app/utils/foo-bar';
 import { module, test } from 'qunit';
 
-module('Unit | Utility | foo bar', function(hooks) {
+module('Unit | Utility | foo-bar', function(hooks) {
 
   // Replace this with your real tests.
   test('it works', function(assert) {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "ember-cli-normalize-entity-name": "^1.0.0",
     "ember-cli-path-utils": "^1.0.0",
     "ember-cli-string-utils": "^1.1.0",
-    "ember-cli-test-info": "^1.0.0",
     "ember-cli-valid-component-name": "^1.0.0",
     "ember-cli-version-checker": "^2.1.0",
     "ember-router-generator": "^1.2.3",


### PR DESCRIPTION
Resolves https://github.com/emberjs/ember.js/issues/14915 and implements https://github.com/emberjs/rfcs/pull/216

In the process the whole `ember-cli-test-info` dependency is dropped as it is no longer necessary.

/cc @GabrielCW @rwjblue @cibernox 