### PR TITLE
[doc beta] Update docs for rfc176

### DIFF
--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -296,7 +296,7 @@ ApplicationInstance.reopenClass({
 
 /**
   A list of boot-time configuration options for customizing the behavior of
-  an `Ember.ApplicationInstance`.
+  an `ApplicationInstance`.
 
   This is an interface class that exists purely to document the available
   options; you do not need to construct it manually. Simply pass a regular
@@ -308,7 +308,7 @@ ApplicationInstance.reopenClass({
   ```
 
   Not all combinations of the supported options are valid. See the documentation
-  on `Ember.Application#visit` for the supported configurations.
+  on `Application#visit` for the supported configurations.
 
   Internal, experimental or otherwise unstable flags are marked as private.
 
@@ -437,7 +437,7 @@ function BootOptions(options = {}) {
     this options must be specified as a DOM `Element` object instead of
     a selector string.
 
-    See the documentation on `Ember.Applications`'s `rootElement` for
+    See the documentation on `Application`'s `rootElement` for
     details.
 
     @property rootElement

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -36,41 +36,45 @@ import { EMBER_ROUTING_ROUTER_SERVICE } from 'ember/features';
 let librariesRegistered = false;
 
 /**
-  An instance of `Ember.Application` is the starting point for every Ember
+  An instance of `Application` is the starting point for every Ember
   application. It helps to instantiate, initialize and coordinate the many
   objects that make up your app.
 
-  Each Ember app has one and only one `Ember.Application` object. In fact, the
+  Each Ember app has one and only one `Application` object. In fact, the
   very first thing you should do in your application is create the instance:
 
   ```javascript
-  window.App = Ember.Application.create();
+  import Application from '@ember/application';
+
+  window.App = Application.create();
   ```
 
   Typically, the application object is the only global variable. All other
-  classes in your app should be properties on the `Ember.Application` instance,
+  classes in your app should be properties on the `Application` instance,
   which highlights its first role: a global namespace.
 
   For example, if you define a view class, it might look like this:
 
   ```javascript
+  import Application from '@ember/application';
+
   App.MyView = Ember.View.extend();
   ```
 
-  By default, calling `Ember.Application.create()` will automatically initialize
-  your application by calling the `Ember.Application.initialize()` method. If
+  By default, calling `Application.create()` will automatically initialize
+  your application by calling the `Application.initialize()` method. If
   you need to delay initialization, you can call your app's `deferReadiness()`
   method. When you are ready for your app to be initialized, call its
   `advanceReadiness()` method.
 
-  You can define a `ready` method on the `Ember.Application` instance, which
+  You can define a `ready` method on the `Application` instance, which
   will be run by Ember when the application is initialized.
 
-  Because `Ember.Application` inherits from `Ember.Namespace`, any classes
+  Because `Application` inherits from `Ember.Namespace`, any classes
   you create will have useful string representations when calling `toString()`.
   See the `Ember.Namespace` documentation for more information.
 
-  While you can think of your `Ember.Application` as a container that holds the
+  While you can think of your `Application` as a container that holds the
   other classes in your application, there are several other responsibilities
   going on under-the-hood that you may want to understand.
 
@@ -86,7 +90,7 @@ let librariesRegistered = false;
   start walking up the DOM node tree, finding corresponding views and invoking
   their `mouseDown` method as it goes.
 
-  `Ember.Application` has a number of default events that it listens for, as
+  `Application` has a number of default events that it listens for, as
   well as a mapping from lowercase events to camel-cased view method names. For
   example, the `keypress` event causes the `keyPress` method on the view to be
   called, the `dblclick` event causes `doubleClick` to be called, and so on.
@@ -96,7 +100,9 @@ let librariesRegistered = false;
   names by setting the application's `customEvents` property:
 
   ```javascript
-  let App = Ember.Application.create({
+  import Application from '@ember/application';
+
+  let App = Application.create({
     customEvents: {
       // add support for the paste event
       paste: 'paste'
@@ -109,7 +115,9 @@ let librariesRegistered = false;
   property:
 
   ```javascript
-  let App = Ember.Application.create({
+  import Application from '@ember/application';
+
+  let App = Application.create({
     customEvents: {
       // prevent listeners for mouseenter/mouseleave events
       mouseenter: null,
@@ -127,7 +135,9 @@ let librariesRegistered = false;
   should be delegated, set your application's `rootElement` property:
 
   ```javascript
-  let App = Ember.Application.create({
+  import Application from '@ember/application';
+
+  let App = Application.create({
     rootElement: '#ember-app'
   });
   ```
@@ -138,19 +148,17 @@ let librariesRegistered = false;
   append views inside it!
 
   To learn more about the events Ember components use, see
-<<<<<<< HEAD
-  [components/handling-events](https://guides.emberjs.com/v2.6.0/components/handling-events/#toc_event-names).
-=======
 
   [components/handling-events](https://guides.emberjs.com/current/components/handling-events/#toc_event-names).
->>>>>>> 5d5d92478... [DOC beat] RFC176 api doc update
 
   ### Initializers
 
   Libraries on top of Ember can add initializers, like so:
 
   ```javascript
-  Ember.Application.initializer({
+  import Application from '@ember/application';
+
+  Application.initializer({
     name: 'api-adapter',
 
     initialize: function(application) {
@@ -167,14 +175,16 @@ let librariesRegistered = false;
 
   ### Routing
 
-  In addition to creating your application's router, `Ember.Application` is
+  In addition to creating your application's router, `Application` is
   also responsible for telling the router when to start routing. Transitions
   between routes can be logged with the `LOG_TRANSITIONS` flag, and more
   detailed intra-transition logging can be logged with
   the `LOG_TRANSITIONS_INTERNAL` flag:
 
   ```javascript
-  let App = Ember.Application.create({
+  import Application from '@ember/application';
+
+  let App = Application.create({
     LOG_TRANSITIONS: true, // basic logging of successful transitions
     LOG_TRANSITIONS_INTERNAL: true // detailed logging of all routing steps
   });
@@ -238,7 +248,7 @@ const Application = Engine.extend({
     instances.
 
     If you would like additional bubbling events to be delegated to your
-    views, set your `Ember.Application`'s `customEvents` property
+    views, set your `Application`'s `customEvents` property
     to a hash containing the DOM event name as the key and the
     corresponding view method name as the value. Setting an event to
     a value of `null` will prevent a default event listener from being
@@ -247,7 +257,9 @@ const Application = Engine.extend({
     To add new events to be listened to:
 
     ```javascript
-    let App = Ember.Application.create({
+    import Application from '@ember/application';
+
+    let App = Application.create({
       customEvents: {
         // add support for the paste event
         paste: 'paste'
@@ -258,7 +270,9 @@ const Application = Engine.extend({
     To prevent default events from being listened to:
 
     ```javascript
-    let App = Ember.Application.create({
+    import Application from '@ember/application';
+
+    let App = Application.create({
       customEvents: {
         // remove support for mouseenter / mouseleave events
         mouseenter: null,
@@ -293,7 +307,10 @@ const Application = Engine.extend({
     classes.
 
     ```javascript
-    let App = Ember.Application.create({
+    import Application from '@ember/application';
+    import Component from '@ember/component';
+
+    let App = Application.create({
       ...
     });
 
@@ -305,7 +322,7 @@ const Application = Engine.extend({
       ...
     });
 
-    App.MyComponent = Ember.Component.extend({
+    App.MyComponent = Component.extend({
       ...
     });
     ```
@@ -428,9 +445,9 @@ const Application = Engine.extend({
     @method _prepareForGlobalsMode
   */
   _prepareForGlobalsMode() {
-    // Create subclass of Ember.Router for this Application instance.
+    // Create subclass of Router for this Application instance.
     // This is to ensure that someone reopening `App.Router` does not
-    // tamper with the default `Ember.Router`.
+    // tamper with the default `Router`.
     this.Router = (this.Router || Router).extend();
 
     this._buildDeprecatedInstance();
@@ -533,12 +550,16 @@ const Application = Engine.extend({
     Example:
 
     ```javascript
-    let App = Ember.Application.create();
+    import Application from '@ember/application';
+
+    let App = Application.create();
 
     App.deferReadiness();
 
-    // Ember.$ is a reference to the jQuery object/function
-    Ember.$.getJSON('/auth-token', function(token) {
+    // $ is a reference to the jQuery object/function
+    import $ from 'jquery;
+
+    $.getJSON('/auth-token', function(token) {
       App.token = token;
       App.advanceReadiness();
     });
@@ -554,7 +575,7 @@ const Application = Engine.extend({
     @public
   */
   deferReadiness() {
-    assert('You must call deferReadiness on an instance of Ember.Application', this instanceof Application);
+    assert('You must call deferReadiness on an instance of Application', this instanceof Application);
     assert('You cannot defer readiness since the `ready()` hook has already been called.', this._readinessDeferrals > 0);
     this._readinessDeferrals++;
   },
@@ -569,7 +590,7 @@ const Application = Engine.extend({
     @public
   */
   advanceReadiness() {
-    assert('You must call advanceReadiness on an instance of Ember.Application', this instanceof Application);
+    assert('You must call advanceReadiness on an instance of Application', this instanceof Application);
     this._readinessDeferrals--;
 
     if (this._readinessDeferrals === 0) {
@@ -578,7 +599,7 @@ const Application = Engine.extend({
   },
 
   /**
-    Initialize the application and return a promise that resolves with the `Ember.Application`
+    Initialize the application and return a promise that resolves with the `Application`
     object when the boot process is complete.
 
     Run any application initializers and run the application load hook. These hooks may
@@ -655,10 +676,11 @@ const Application = Engine.extend({
     Typical Example:
 
     ```javascript
+    import Application from '@ember/application';
     let App;
 
     run(function() {
-      App = Ember.Application.create();
+      App = Application.create();
     });
 
     module('acceptance test', {
@@ -683,10 +705,11 @@ const Application = Engine.extend({
     to the app becoming ready.
 
     ```javascript
+    import Application from '@ember/application';
     let App;
 
     run(function() {
-      App = Ember.Application.create();
+      App = Application.create();
     });
 
     module('acceptance test', {
@@ -713,9 +736,9 @@ const Application = Engine.extend({
     @public
   */
   reset() {
-    assert(`Calling reset() on instances of \`Ember.Application\` is not
+    assert(`Calling reset() on instances of \`Application\` is not
             supported when globals mode is disabled; call \`visit()\` to
-            create new \`Ember.ApplicationInstance\`s and dispose them
+            create new \`ApplicationInstance\`s and dispose them
             via their \`destroy()\` method instead.`, this._globalsMode && this.autoboot);
 
     let instance = this.__deprecatedInstance__;
@@ -813,7 +836,7 @@ const Application = Engine.extend({
   },
 
   /**
-    Boot a new instance of `Ember.ApplicationInstance` for the current
+    Boot a new instance of `ApplicationInstance` for the current
     application and navigate it to the given `url`. Returns a `Promise` that
     resolves with the instance when the initial routing and rendering is
     complete, or rejects with any error that occurred during the boot process.
@@ -823,9 +846,9 @@ const Application = Engine.extend({
 
     This method also takes a hash of boot-time configuration options for
     customizing the instance's behavior. See the documentation on
-    `Ember.ApplicationInstance.BootOptions` for details.
+    `ApplicationInstance.BootOptions` for details.
 
-    `Ember.ApplicationInstance.BootOptions` is an interface class that exists
+    `ApplicationInstance.BootOptions` is an interface class that exists
     purely to document the available options; you do not need to construct it
     manually. Simply pass a regular JavaScript object containing of the
     desired options:
@@ -938,7 +961,7 @@ const Application = Engine.extend({
     (as opposed to a selector string like `"body"`).
 
     See the documentation on the `isBrowser`, `document` and `rootElement` properties
-    on `Ember.ApplicationInstance.BootOptions` for details.
+    on `ApplicationInstance.BootOptions` for details.
 
     #### Server-Side Resource Discovery
 

--- a/packages/ember-application/lib/system/engine-instance.js
+++ b/packages/ember-application/lib/system/engine-instance.js
@@ -28,7 +28,7 @@ const EngineInstance = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixi
   /**
     The base `Engine` for which this is an instance.
 
-    @property {Ember.Engine} engine
+    @property {Engine} engine
     @private
   */
   base: null,
@@ -58,7 +58,7 @@ const EngineInstance = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixi
   },
 
   /**
-    Initialize the `Ember.EngineInstance` and return a promise that resolves
+    Initialize the `EngineInstance` and return a promise that resolves
     with the instance itself when the boot process is complete.
 
     The primary task here is to run any registered instance initializers.
@@ -68,7 +68,7 @@ const EngineInstance = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixi
     @private
     @method boot
     @param options {Object}
-    @return {Promise<Ember.EngineInstance,Error>}
+    @return {Promise<EngineInstance,Error>}
   */
   boot(options) {
     if (this._bootPromise) { return this._bootPromise; }
@@ -128,7 +128,7 @@ const EngineInstance = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixi
   },
 
   /**
-    Build a new `Ember.EngineInstance` that's a child of this instance.
+    Build a new `EngineInstance` that's a child of this instance.
 
     Engines must be registered by name with their parent engine
     (or application).

--- a/packages/ember-application/lib/system/engine.js
+++ b/packages/ember-application/lib/system/engine.js
@@ -337,7 +337,7 @@ Engine.reopenClass({
     or after the one identified by the value. This value can be a single string
     or an array of strings, referencing the `name` of other initializers.
 
-    * See Ember.Application.initializer for discussion on the usage of before
+    * See Application.initializer for discussion on the usage of before
     and after.
 
     Example instanceInitializer to preload data into the store.
@@ -421,7 +421,7 @@ Engine.reopenClass({
   },
 
   /**
-    Set this to provide an alternate class to `Ember.DefaultResolver`
+    Set this to provide an alternate class to `DefaultResolver`
 
     @deprecated Use 'Resolver' instead
     @property resolver
@@ -430,7 +430,7 @@ Engine.reopenClass({
   resolver: null,
 
   /**
-    Set this to provide an alternate class to `Ember.DefaultResolver`
+    Set this to provide an alternate class to `DefaultResolver`
 
     @property resolver
     @public

--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -255,7 +255,7 @@ const DefaultResolver = EmberObject.extend({
 
   /**
     Given a parseName object (output from `parseName`), apply
-    the conventions expected by `Ember.Router`
+    the conventions expected by `Router`
 
     @param {Object} parsedName a parseName object with the parsed
       fullName lookup string

--- a/packages/ember-application/tests/system/application_instance_test.js
+++ b/packages/ember-application/tests/system/application_instance_test.js
@@ -13,7 +13,7 @@ import {
 
 let application, appInstance;
 
-moduleFor('Ember.ApplicationInstance', class extends TestCase {
+moduleFor('ApplicationInstance', class extends TestCase {
   constructor() {
     super();
 
@@ -172,7 +172,7 @@ moduleFor('Ember.ApplicationInstance', class extends TestCase {
       });
   }
 
-  ['can build a registry via Ember.ApplicationInstance.setupRegistry() -- simulates ember-test-helpers'](assert) {
+  ['can build a registry via ApplicationInstance.setupRegistry() -- simulates ember-test-helpers'](assert) {
     let namespace = EmberObject.create({
       Resolver: { create: function() { } }
     });

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -35,7 +35,7 @@ import {
 } from 'internal-test-helpers';
 import { run } from 'ember-metal';
 
-moduleFor('Ember.Application, autobooting multiple apps', class extends ApplicationTestCase {
+moduleFor('Application, autobooting multiple apps', class extends ApplicationTestCase {
   get fixture() {
     return `
       <div id="one">
@@ -106,7 +106,7 @@ moduleFor('Ember.Application, autobooting multiple apps', class extends Applicat
   }
 });
 
-moduleFor('Ember.Application', class extends ApplicationTestCase {
+moduleFor('Application', class extends ApplicationTestCase {
 
   [`@test builds a registry`](assert) {
     let {application} = this;
@@ -171,7 +171,7 @@ moduleFor('Ember.Application', class extends ApplicationTestCase {
 
 });
 
-moduleFor('Ember.Application, default resolver with autoboot', class extends DefaultResolverApplicationTestCase {
+moduleFor('Application, default resolver with autoboot', class extends DefaultResolverApplicationTestCase {
 
   constructor() {
     super();
@@ -221,7 +221,7 @@ moduleFor('Ember.Application, default resolver with autoboot', class extends Def
 
 });
 
-moduleFor('Ember.Application, autobooting', class extends AutobootApplicationTestCase {
+moduleFor('Application, autobooting', class extends AutobootApplicationTestCase {
 
   constructor() {
     super();
@@ -366,7 +366,7 @@ moduleFor('Ember.Application, autobooting', class extends AutobootApplicationTes
     assert.equal(_loaded.application, undefined);
   }
 
-  [`@test can build a registry via Ember.Application.buildRegistry() --- simulates ember-test-helpers`](assert) {
+  [`@test can build a registry via Application.buildRegistry() --- simulates ember-test-helpers`](assert) {
     let namespace = EmberObject.create({
       Resolver: { create: function() { } }
     });
@@ -378,9 +378,9 @@ moduleFor('Ember.Application, autobooting', class extends AutobootApplicationTes
 
 });
 
-moduleFor('Ember.Application#buildRegistry', class extends AbstractTestCase {
+moduleFor('Application#buildRegistry', class extends AbstractTestCase {
 
-  [`@test can build a registry via Ember.Application.buildRegistry() --- simulates ember-test-helpers`](assert) {
+  [`@test can build a registry via Application.buildRegistry() --- simulates ember-test-helpers`](assert) {
     let namespace = EmberObject.create({
       Resolver: { create() { } }
     });
@@ -392,7 +392,7 @@ moduleFor('Ember.Application#buildRegistry', class extends AbstractTestCase {
 
 });
 
-moduleFor('Ember.Application - instance tracking', class extends ApplicationTestCase {
+moduleFor('Application - instance tracking', class extends ApplicationTestCase {
 
   ['@test tracks built instance'](assert) {
     let instance = this.application.buildInstance();

--- a/packages/ember-application/tests/system/bootstrap-test.js
+++ b/packages/ember-application/tests/system/bootstrap-test.js
@@ -4,7 +4,7 @@ import {
   DefaultResolverApplicationTestCase
 } from 'internal-test-helpers';
 
-moduleFor('Ember.Application with default resolver and autoboot', class extends DefaultResolverApplicationTestCase {
+moduleFor('Application with default resolver and autoboot', class extends DefaultResolverApplicationTestCase {
   get fixture() {
     return `
       <div id="app"></div>

--- a/packages/ember-application/tests/system/dependency_injection/custom_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/custom_resolver_test.js
@@ -5,7 +5,7 @@ import {
   DefaultResolverApplicationTestCase
 } from 'internal-test-helpers';
 
-moduleFor('Ember.Application with extended default resolver and autoboot', class extends DefaultResolverApplicationTestCase {
+moduleFor('Application with extended default resolver and autoboot', class extends DefaultResolverApplicationTestCase {
 
   get applicationOptions() {
     let applicationTemplate = this.compile(`<h1>Fallback</h1>`);

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -19,7 +19,7 @@ import {
 } from 'ember-glimmer';
 import { getDebugFunction, setDebugFunction } from 'ember-debug';
 
-moduleFor('Ember.Application Dependency Injection - Integration - default resolver', class extends DefaultResolverApplicationTestCase {
+moduleFor('Application Dependency Injection - Integration - default resolver', class extends DefaultResolverApplicationTestCase {
 
   beforeEach() {
     this.runTask(() => this.createApplication());
@@ -187,7 +187,7 @@ moduleFor('Ember.Application Dependency Injection - Integration - default resolv
     }, /to resolve to an Ember.Route/, 'Should assert');
   }
 
-  [`@test no assertion for routes that extend from Ember.Route`](assert) {
+  [`@test no assertion for routes that extend from Route`](assert) {
     assert.expect(0);
     this.application.FooRoute = Route.extend();
     this.privateRegistry.resolve(`route:foo`);
@@ -197,10 +197,10 @@ moduleFor('Ember.Application Dependency Injection - Integration - default resolv
     expectAssertion(() =>{
       this.application.FooService = EmberObject.extend();
       this.privateRegistry.resolve('service:foo');
-    }, /Expected service:foo to resolve to an Ember.Service but instead it was \.FooService\./);
+    }, /Expected service:foo to resolve to an Service but instead it was \.FooService\./);
   }
 
-  [`@test no deprecation warning for service factories that extend from Ember.Service`](assert) {
+  [`@test no deprecation warning for service factories that extend from Service`](assert) {
     assert.expect(0);
     this.application.FooService = Service.extend();
     this.privateRegistry.resolve('service:foo');
@@ -213,7 +213,7 @@ moduleFor('Ember.Application Dependency Injection - Integration - default resolv
     }, /Expected component:foo to resolve to an Ember\.Component but instead it was \.FooComponent\./);
   }
 
-  [`@test no deprecation warning for component factories that extend from Ember.Component`]() {
+  [`@test no deprecation warning for component factories that extend from Component`]() {
     expectNoDeprecation();
     this.application.FooView = Component.extend();
     this.privateRegistry.resolve('component:foo');
@@ -241,7 +241,7 @@ moduleFor('Ember.Application Dependency Injection - Integration - default resolv
 
 });
 
-moduleFor('Ember.Application Dependency Injection - Integration - default resolver w/ other namespace', class extends DefaultResolverApplicationTestCase {
+moduleFor('Application Dependency Injection - Integration - default resolver w/ other namespace', class extends DefaultResolverApplicationTestCase {
 
   beforeEach() {
     this.UserInterface = context.lookup.UserInterface = Namespace.create();
@@ -271,7 +271,7 @@ moduleFor('Ember.Application Dependency Injection - Integration - default resolv
   }
 });
 
-moduleFor('Ember.Application Dependency Injection - Integration - default resolver', class extends DefaultResolverApplicationTestCase {
+moduleFor('Application Dependency Injection - Integration - default resolver', class extends DefaultResolverApplicationTestCase {
 
   constructor() {
     super();

--- a/packages/ember-application/tests/system/dependency_injection/normalization_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/normalization_test.js
@@ -8,7 +8,7 @@ import {
 
 let application, registry;
 
-moduleFor('Ember.Application Dependency Injection - normalize', class extends TestCase {
+moduleFor('Application Dependency Injection - normalize', class extends TestCase {
   constructor() {
     super();
 

--- a/packages/ember-application/tests/system/dependency_injection/to_string_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/to_string_test.js
@@ -7,7 +7,7 @@ import {
   DefaultResolverApplicationTestCase
 } from 'internal-test-helpers';
 
-moduleFor('Ember.Application Dependency Injection - DefaultResolver#toString', class extends DefaultResolverApplicationTestCase {
+moduleFor('Application Dependency Injection - DefaultResolver#toString', class extends DefaultResolverApplicationTestCase {
   constructor() {
     super();
     this.runTask(() => this.createApplication());
@@ -34,7 +34,7 @@ moduleFor('Ember.Application Dependency Injection - DefaultResolver#toString', c
   }
 });
 
-moduleFor('Ember.Application Dependency Injection - Resolver#toString', class extends ApplicationTestCase {
+moduleFor('Application Dependency Injection - Resolver#toString', class extends ApplicationTestCase {
 
   beforeEach() {
     return this.visit('/');

--- a/packages/ember-application/tests/system/dependency_injection_test.js
+++ b/packages/ember-application/tests/system/dependency_injection_test.js
@@ -13,7 +13,7 @@ let EmberApplication = Application;
 let originalLookup = context.lookup;
 let registry, locator, application;
 
-moduleFor('Ember.Application Dependency Injection', class extends TestCase {
+moduleFor('Application Dependency Injection', class extends TestCase {
   constructor() {
     super();
 

--- a/packages/ember-application/tests/system/engine_initializers_test.js
+++ b/packages/ember-application/tests/system/engine_initializers_test.js
@@ -7,7 +7,7 @@ import {
 
 let MyEngine, myEngine, myEngineInstance;
 
-moduleFor('Ember.Engine initializers', class extends TestCase {
+moduleFor('Engine initializers', class extends TestCase {
   teardown() {
     run(() => {
       if (myEngineInstance) {

--- a/packages/ember-application/tests/system/engine_instance_initializers_test.js
+++ b/packages/ember-application/tests/system/engine_instance_initializers_test.js
@@ -18,7 +18,7 @@ function buildEngineInstance(EngineClass) {
   return engineInstance;
 }
 
-moduleFor('Ember.Engine instance initializers', class extends TestCase {
+moduleFor('Engine instance initializers', class extends TestCase {
   teardown() {
     run(() => {
       if (myEngineInstance) {

--- a/packages/ember-application/tests/system/engine_instance_test.js
+++ b/packages/ember-application/tests/system/engine_instance_test.js
@@ -11,7 +11,7 @@ import {
 
 let engine, engineInstance;
 
-moduleFor('Ember.EngineInstance', class extends TestCase {
+moduleFor('EngineInstance', class extends TestCase {
   constructor() {
     super();
 

--- a/packages/ember-application/tests/system/engine_test.js
+++ b/packages/ember-application/tests/system/engine_test.js
@@ -17,7 +17,7 @@ let engine;
 let originalLookup = context.lookup;
 let lookup;
 
-moduleFor('Ember.Engine', class extends TestCase {
+moduleFor('Engine', class extends TestCase {
   constructor() {
     super();
 

--- a/packages/ember-application/tests/system/initializers_test.js
+++ b/packages/ember-application/tests/system/initializers_test.js
@@ -2,7 +2,7 @@ import { assign } from 'ember-utils';
 import { moduleFor, AutobootApplicationTestCase } from 'internal-test-helpers';
 import { Application } from 'ember-application';
 
-moduleFor('Ember.Application initializers', class extends AutobootApplicationTestCase {
+moduleFor('Application initializers', class extends AutobootApplicationTestCase {
   get fixture() {
     return `<div id="one">ONE</div>
       <div id="two">TWO</div>

--- a/packages/ember-application/tests/system/instance_initializers_test.js
+++ b/packages/ember-application/tests/system/instance_initializers_test.js
@@ -2,7 +2,7 @@ import { assign } from 'ember-utils';
 import { moduleFor, AutobootApplicationTestCase } from 'internal-test-helpers';
 import { Application, ApplicationInstance } from 'ember-application';
 
-moduleFor('Ember.Application instance initializers', class extends AutobootApplicationTestCase {
+moduleFor('Application instance initializers', class extends AutobootApplicationTestCase {
   get fixture() {
     return `<div id="one">ONE</div>
       <div id="two">TWO</div>

--- a/packages/ember-application/tests/system/logging_test.js
+++ b/packages/ember-application/tests/system/logging_test.js
@@ -37,7 +37,7 @@ class LoggingApplicationTestCase extends ApplicationTestCase {
   }
 }
 
-moduleFor('Ember.Application with LOG_ACTIVE_GENERATION=true', class extends LoggingApplicationTestCase {
+moduleFor('Application with LOG_ACTIVE_GENERATION=true', class extends LoggingApplicationTestCase {
 
   get applicationOptions() {
     return assign(super.applicationOptions, {
@@ -88,7 +88,7 @@ moduleFor('Ember.Application with LOG_ACTIVE_GENERATION=true', class extends Log
 
 });
 
-moduleFor('Ember.Application when LOG_ACTIVE_GENERATION=false', class extends LoggingApplicationTestCase {
+moduleFor('Application when LOG_ACTIVE_GENERATION=false', class extends LoggingApplicationTestCase {
 
   get applicationOptions() {
     return assign(super.applicationOptions, {
@@ -104,7 +104,7 @@ moduleFor('Ember.Application when LOG_ACTIVE_GENERATION=false', class extends Lo
 
 });
 
-moduleFor('Ember.Application with LOG_VIEW_LOOKUPS=true', class extends LoggingApplicationTestCase {
+moduleFor('Application with LOG_VIEW_LOOKUPS=true', class extends LoggingApplicationTestCase {
 
   get applicationOptions() {
     return assign(super.applicationOptions, {
@@ -131,7 +131,7 @@ moduleFor('Ember.Application with LOG_VIEW_LOOKUPS=true', class extends LoggingA
 
 });
 
-moduleFor('Ember.Application with LOG_VIEW_LOOKUPS=false', class extends LoggingApplicationTestCase {
+moduleFor('Application with LOG_VIEW_LOOKUPS=false', class extends LoggingApplicationTestCase {
 
   get applicationOptions() {
     return assign(super.applicationOptions, {

--- a/packages/ember-application/tests/system/readiness_test.js
+++ b/packages/ember-application/tests/system/readiness_test.js
@@ -61,7 +61,7 @@ moduleFor('Application readiness', class extends ApplicationTestCase {
   // synchronously during the application's initialization, we get the same behavior as if
   // it was triggered after initialization.
 
-  ['@test Ember.Application\'s ready event is called right away if jQuery is already ready'](assert) {
+  ['@test Application\'s ready event is called right away if jQuery is already ready'](assert) {
     jQuery.isReady = true;
 
     run(() => {
@@ -77,7 +77,7 @@ moduleFor('Application readiness', class extends ApplicationTestCase {
     assert.equal(readyWasCalled, 1, 'application\'s ready was not called again');
   }
 
-  ['@test Ember.Application\'s ready event is called after the document becomes ready'](assert) {
+  ['@test Application\'s ready event is called after the document becomes ready'](assert) {
     run(() => {
       application = Application.create({ router: false });
     });
@@ -89,7 +89,7 @@ moduleFor('Application readiness', class extends ApplicationTestCase {
     assert.equal(readyWasCalled, 1, 'ready was called now that DOM is ready');
   }
 
-  ['@test Ember.Application\'s ready event can be deferred by other components'](assert) {
+  ['@test Application\'s ready event can be deferred by other components'](assert) {
     run(() => {
       application = Application.create({ router: false });
       application.deferReadiness();
@@ -109,7 +109,7 @@ moduleFor('Application readiness', class extends ApplicationTestCase {
     assert.equal(readyWasCalled, 1, 'ready was called now all readiness deferrals are advanced');
   }
 
-  ['@test Ember.Application\'s ready event can be deferred by other components'](assert) {
+  ['@test Application\'s ready event can be deferred by other components'](assert) {
     jQuery.isReady = false;
 
     run(() => {

--- a/packages/ember-application/tests/system/reset_test.js
+++ b/packages/ember-application/tests/system/reset_test.js
@@ -3,7 +3,7 @@ import { Controller } from 'ember-runtime';
 import { Router } from 'ember-routing';
 import { moduleFor, AutobootApplicationTestCase } from 'internal-test-helpers';
 
-moduleFor('Ember.Application - resetting', class extends AutobootApplicationTestCase {
+moduleFor('Application - resetting', class extends AutobootApplicationTestCase {
 
   ['@test Brings its own run-loop if not provided'](assert) {
     assert.expect(0);

--- a/packages/ember-application/tests/system/visit_test.js
+++ b/packages/ember-application/tests/system/visit_test.js
@@ -17,7 +17,7 @@ function expectAsyncError() {
   RSVP.off('error');
 }
 
-moduleFor('Ember.Application - visit()', class extends ApplicationTestCase {
+moduleFor('Application - visit()', class extends ApplicationTestCase {
 
   teardown() {
     RSVP.on('error', onerrorDefault);


### PR DESCRIPTION
PR for #15723 for ember-application. I couldn't seem to find a replacement for `Ember.View`, assuming that just needs to go away but probably in a different pr.

Couldn't see any link related changes. 