### PR TITLE
[FEATURE ...] Enable emberjs/rfcs#278, emberjs/rfcs#280

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -32,16 +32,6 @@ for a detailed explanation.
   Add `{{@foo}}` syntax to access named arguments in component templates per
   [RFC](https://github.com/emberjs/rfcs/pull/276).
 
-* `ember-glimmer-remove-application-template-wrapper`
-
-  Remove the `<div>` wrapper around the application template per
-  [RFC](https://github.com/emberjs/rfcs/pull/280).
-
-* `ember-glimmer-template-only-components`
-
-  Use Glimmer Components semantics for template-only components per
-  [RFC](https://github.com/emberjs/rfcs/pull/278).
-
 * `ember-metal-es5-getters`
 
   Define ES5 getters for computed properties, eliminating the need to access them

--- a/features.json
+++ b/features.json
@@ -4,8 +4,6 @@
     "ember-libraries-isregistered": null,
     "ember-improved-instrumentation": null,
     "ember-glimmer-named-arguments": true,
-    "ember-glimmer-remove-application-template-wrapper": null,
-    "ember-glimmer-template-only-components": null,
     "ember-metal-es5-getters": true,
     "ember-routing-router-service": true,
     "ember-engines-mount-params": true,

--- a/packages/ember-environment/lib/index.d.ts
+++ b/packages/ember-environment/lib/index.d.ts
@@ -9,5 +9,7 @@ export const environment: {
 }
 
 export const ENV: {
+  _APPLICATION_TEMPLATE_WRAPPER: boolean;
   _ENABLE_RENDER_SUPPORT: boolean;
+  _TEMPLATE_ONLY_GLIMMER_COMPONENTS: boolean;
 };

--- a/packages/ember-environment/lib/index.js
+++ b/packages/ember-environment/lib/index.js
@@ -78,8 +78,37 @@ ENV.LOG_VERSION = defaultTrue(ENV.LOG_VERSION);
 */
 ENV.LOG_BINDINGS = defaultFalse(ENV.LOG_BINDINGS);
 
-
 ENV.RAISE_ON_DEPRECATION = defaultFalse(ENV.RAISE_ON_DEPRECATION);
+
+/**
+  Whether to insert a `<div class="ember-view" />` wrapper around the
+  application template. See RFC #280.
+
+  This is not intended to be set directly, as the implementation may change in
+  the future. Use `@ember/optional-features` instead.
+
+  @property _APPLICATION_TEMPLATE_WRAPPER
+  @for EmberENV
+  @type Boolean
+  @default true
+  @private
+*/
+ENV._APPLICATION_TEMPLATE_WRAPPER = defaultTrue(ENV._APPLICATION_TEMPLATE_WRAPPER);
+
+/**
+  Whether to use Glimmer Component semantics (as opposed to the classic "Curly"
+  components semantics) for template-only components. See RFC #278.
+
+  This is not intended to be set directly, as the implementation may change in
+  the future. Use `@ember/optional-features` instead.
+
+  @property _TEMPLATE_ONLY_GLIMMER_COMPONENTS
+  @for EmberENV
+  @type Boolean
+  @default false
+  @private
+*/
+ENV._TEMPLATE_ONLY_GLIMMER_COMPONENTS = defaultFalse(ENV._TEMPLATE_ONLY_GLIMMER_COMPONENTS);
 
 // check if window exists and actually is the global
 const hasDOM = typeof window !== 'undefined' && window === global &&

--- a/packages/ember-glimmer/externs.d.ts
+++ b/packages/ember-glimmer/externs.d.ts
@@ -4,8 +4,6 @@ declare module 'ember/features' {
   export const GLIMMER_CUSTOM_COMPONENT_MANAGER: boolean | null;
   export const EMBER_ENGINES_MOUNT_PARAMS: boolean | null;
   export const EMBER_GLIMMER_DETECT_BACKTRACKING_RERENDER: boolean | null;
-  export const EMBER_GLIMMER_REMOVE_APPLICATION_TEMPLATE_WRAPPER: boolean | null;
-  export const EMBER_GLIMMER_TEMPLATE_ONLY_COMPONENTS: boolean | null;
   export const MANDATORY_SETTER: boolean | null;
 }
 

--- a/packages/ember-glimmer/lib/environment.ts
+++ b/packages/ember-glimmer/lib/environment.ts
@@ -23,6 +23,7 @@ import {
   Destroyable, Opaque,
 } from '@glimmer/util';
 import { warn } from 'ember-debug';
+import { ENV } from 'ember-environment';
 import { DEBUG } from 'ember-env-flags';
 import { _instrumentStart, Cache } from 'ember-metal';
 import { guidFor, OWNER } from 'ember-utils';
@@ -76,7 +77,6 @@ import installPlatformSpecificProtocolForURL from './protocol-for-url';
 
 import {
   EMBER_MODULE_UNIFICATION,
-  EMBER_GLIMMER_TEMPLATE_ONLY_COMPONENTS,
   GLIMMER_CUSTOM_COMPONENT_MANAGER,
 } from 'ember/features';
 import { Container, OwnedTemplate, WrappedTemplateFactory } from './template';
@@ -134,7 +134,7 @@ export default class Environment extends GlimmerEnvironment {
     this._definitionCache = new Cache(2000, ({ name, source, owner }) => {
       let { component: componentFactory, layout } = lookupComponent(owner, name, { source });
       let customManager: any;
-      if (EMBER_GLIMMER_TEMPLATE_ONLY_COMPONENTS && layout && !componentFactory) {
+      if (ENV._TEMPLATE_ONLY_GLIMMER_COMPONENTS && layout && !componentFactory) {
         return new TemplateOnlyComponentDefinition(name, layout);
       } else if (componentFactory || layout) {
         if (GLIMMER_CUSTOM_COMPONENT_MANAGER) {

--- a/packages/ember-glimmer/lib/setup-registry.ts
+++ b/packages/ember-glimmer/lib/setup-registry.ts
@@ -1,5 +1,5 @@
 import { privatize as P } from 'container';
-import { environment } from 'ember-environment';
+import { ENV, environment } from 'ember-environment';
 import Component from './component';
 import Checkbox from './components/checkbox';
 import LinkToComponent from './components/link-to';
@@ -17,7 +17,6 @@ import OutletTemplate from './templates/outlet';
 import RootTemplate from './templates/root';
 import OutletView from './views/outlet';
 import loc from './helpers/loc';
-import { EMBER_GLIMMER_TEMPLATE_ONLY_COMPONENTS } from 'ember/features';
 
 interface Registry {
   injection(name: string, name2: string, name3: string): void;
@@ -75,7 +74,7 @@ export function setupEngineRegistry(registry: Registry) {
   registry.register('component:-checkbox', Checkbox);
   registry.register('component:link-to', LinkToComponent);
 
-  if (!EMBER_GLIMMER_TEMPLATE_ONLY_COMPONENTS) {
+  if (!ENV._TEMPLATE_ONLY_GLIMMER_COMPONENTS) {
     registry.register(P`component:-default`, Component);
   }
 }

--- a/packages/ember-glimmer/tests/integration/application/rendering-test.js
+++ b/packages/ember-glimmer/tests/integration/application/rendering-test.js
@@ -1,3 +1,4 @@
+import { ENV } from 'ember-environment';
 import { Controller } from 'ember-runtime';
 import { moduleFor, ApplicationTest } from '../../utils/test-case';
 import { strip } from '../../utils/abstract-test-case';
@@ -5,8 +6,19 @@ import { Route } from 'ember-routing';
 import { Component } from 'ember-glimmer';
 
 moduleFor('Application test: rendering', class extends ApplicationTest {
+  constructor() {
+    super();
+    this._APPLICATION_TEMPLATE_WRAPPER = ENV._APPLICATION_TEMPLATE_WRAPPER;
+  }
 
-  ['@feature(!ember-glimmer-remove-application-template-wrapper) it can render the application template']() {
+  teardown() {
+    super.teardown();
+    ENV._APPLICATION_TEMPLATE_WRAPPER = this._APPLICATION_TEMPLATE_WRAPPER;
+  }
+
+  ['@test it can render the application template with a wrapper']() {
+    ENV._APPLICATION_TEMPLATE_WRAPPER = true;
+
     this.addTemplate('application', 'Hello world!');
 
     return this.visit('/').then(() => {
@@ -14,7 +26,9 @@ moduleFor('Application test: rendering', class extends ApplicationTest {
     });
   }
 
-  ['@feature(ember-glimmer-remove-application-template-wrapper) it can render the application template']() {
+  ['@test it can render the application template without a wrapper']() {
+    ENV._APPLICATION_TEMPLATE_WRAPPER = false;
+
     this.addTemplate('application', 'Hello world!');
 
     return this.visit('/').then(() => {

--- a/packages/ember-glimmer/tests/integration/components/template-only-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/template-only-components-test.js
@@ -1,6 +1,6 @@
 import { moduleFor, RenderingTest } from '../../utils/test-case';
 import { classes } from '../../utils/test-helpers';
-import { EMBER_GLIMMER_TEMPLATE_ONLY_COMPONENTS } from 'ember/features';
+import { ENV } from 'ember-environment';
 
 class TemplateOnlyComponentsTest extends RenderingTest {
   registerComponent(name, template) {
@@ -8,189 +8,209 @@ class TemplateOnlyComponentsTest extends RenderingTest {
   }
 }
 
-if (EMBER_GLIMMER_TEMPLATE_ONLY_COMPONENTS) {
-  moduleFor('Components test: template-only components (glimmer components)', class extends TemplateOnlyComponentsTest {
-    ['@test it can render a template-only component']() {
-      this.registerComponent('foo-bar', 'hello');
+moduleFor('Components test: template-only components (glimmer components)', class extends TemplateOnlyComponentsTest {
+  constructor() {
+    super();
+    this._TEMPLATE_ONLY_GLIMMER_COMPONENTS = ENV._TEMPLATE_ONLY_GLIMMER_COMPONENTS;
+    ENV._TEMPLATE_ONLY_GLIMMER_COMPONENTS = true;
+  }
 
-      this.render('{{foo-bar}}');
+  teardown() {
+    super.teardown();
+    ENV._TEMPLATE_ONLY_GLIMMER_COMPONENTS = this._TEMPLATE_ONLY_GLIMMER_COMPONENTS;
+  }
 
-      this.assertInnerHTML('hello');
+  ['@test it can render a template-only component']() {
+    this.registerComponent('foo-bar', 'hello');
 
-      this.assertStableRerender();
-    }
+    this.render('{{foo-bar}}');
 
-    ['@feature(ember-glimmer-named-arguments) it can render named arguments']() {
-      this.registerComponent('foo-bar', '|{{@foo}}|{{@bar}}|');
+    this.assertInnerHTML('hello');
 
-      this.render('{{foo-bar foo=foo bar=bar}}', {
-        foo: 'foo', bar: 'bar'
-      });
+    this.assertStableRerender();
+  }
 
-      this.assertInnerHTML('|foo|bar|');
+  ['@feature(ember-glimmer-named-arguments) it can render named arguments']() {
+    this.registerComponent('foo-bar', '|{{@foo}}|{{@bar}}|');
 
-      this.assertStableRerender();
+    this.render('{{foo-bar foo=foo bar=bar}}', {
+      foo: 'foo', bar: 'bar'
+    });
 
-      this.runTask(() => this.context.set('foo', 'FOO'));
+    this.assertInnerHTML('|foo|bar|');
 
-      this.assertInnerHTML('|FOO|bar|');
+    this.assertStableRerender();
 
-      this.runTask(() => this.context.set('bar', 'BAR'));
+    this.runTask(() => this.context.set('foo', 'FOO'));
 
-      this.assertInnerHTML('|FOO|BAR|');
+    this.assertInnerHTML('|FOO|bar|');
 
-      this.runTask(() => this.context.setProperties({ foo: 'foo', bar: 'bar' }));
+    this.runTask(() => this.context.set('bar', 'BAR'));
 
-      this.assertInnerHTML('|foo|bar|');
-    }
+    this.assertInnerHTML('|FOO|BAR|');
 
-    ['@test it does not reflected arguments as properties']() {
-      this.registerComponent('foo-bar', '|{{foo}}|{{this.bar}}|');
+    this.runTask(() => this.context.setProperties({ foo: 'foo', bar: 'bar' }));
 
-      this.render('{{foo-bar foo=foo bar=bar}}', {
-        foo: 'foo', bar: 'bar'
-      });
+    this.assertInnerHTML('|foo|bar|');
+  }
 
-      this.assertInnerHTML('|||');
+  ['@test it does not reflected arguments as properties']() {
+    this.registerComponent('foo-bar', '|{{foo}}|{{this.bar}}|');
 
-      this.assertStableRerender();
+    this.render('{{foo-bar foo=foo bar=bar}}', {
+      foo: 'foo', bar: 'bar'
+    });
 
-      this.runTask(() => this.context.set('foo', 'FOO'));
+    this.assertInnerHTML('|||');
 
-      this.assertInnerHTML('|||');
+    this.assertStableRerender();
 
-      this.runTask(() => this.context.set('bar', null));
+    this.runTask(() => this.context.set('foo', 'FOO'));
 
-      this.assertInnerHTML('|||');
+    this.assertInnerHTML('|||');
 
-      this.runTask(() => this.context.setProperties({ foo: 'foo', bar: 'bar' }));
+    this.runTask(() => this.context.set('bar', null));
 
-      this.assertInnerHTML('|||');
-    }
+    this.assertInnerHTML('|||');
 
-    ['@test it does not have curly component features']() {
-      this.registerComponent('foo-bar', 'hello');
+    this.runTask(() => this.context.setProperties({ foo: 'foo', bar: 'bar' }));
 
-      this.render('{{foo-bar tagName="p" class=class}}', {
-        class: 'foo bar'
-      });
+    this.assertInnerHTML('|||');
+  }
 
-      this.assertInnerHTML('hello');
+  ['@test it does not have curly component features']() {
+    this.registerComponent('foo-bar', 'hello');
 
+    this.render('{{foo-bar tagName="p" class=class}}', {
+      class: 'foo bar'
+    });
 
-      this.assertStableRerender();
+    this.assertInnerHTML('hello');
 
-      this.runTask(() => this.context.set('class', 'foo'));
 
-      this.assertInnerHTML('hello');
+    this.assertStableRerender();
 
-      this.runTask(() => this.context.set('class', null));
+    this.runTask(() => this.context.set('class', 'foo'));
 
-      this.assertInnerHTML('hello');
+    this.assertInnerHTML('hello');
 
-      this.runTask(() => this.context.set('class', 'foo bar'));
+    this.runTask(() => this.context.set('class', null));
 
-      this.assertInnerHTML('hello');
-    }
-  });
-} else {
-  moduleFor('Components test: template-only components (curly components)', class extends TemplateOnlyComponentsTest {
-    ['@test it can render a template-only component']() {
-      this.registerComponent('foo-bar', 'hello');
+    this.assertInnerHTML('hello');
 
-      this.render('{{foo-bar}}');
+    this.runTask(() => this.context.set('class', 'foo bar'));
 
-      this.assertComponentElement(this.firstChild, { content: 'hello' });
+    this.assertInnerHTML('hello');
+  }
+});
 
-      this.assertStableRerender();
-    }
+moduleFor('Components test: template-only components (curly components)', class extends TemplateOnlyComponentsTest {
+  constructor() {
+    super();
+    this._TEMPLATE_ONLY_GLIMMER_COMPONENTS = ENV._TEMPLATE_ONLY_GLIMMER_COMPONENTS;
+    ENV._TEMPLATE_ONLY_GLIMMER_COMPONENTS = false;
+  }
 
-    ['@feature(ember-glimmer-named-arguments) it can render named arguments']() {
-      this.registerComponent('foo-bar', '|{{@foo}}|{{@bar}}|');
+  teardown() {
+    super.teardown();
+    ENV._TEMPLATE_ONLY_GLIMMER_COMPONENTS = this._TEMPLATE_ONLY_GLIMMER_COMPONENTS;
+  }
 
-      this.render('{{foo-bar foo=foo bar=bar}}', {
-        foo: 'foo', bar: 'bar'
-      });
+  ['@test it can render a template-only component']() {
+    this.registerComponent('foo-bar', 'hello');
 
-      this.assertComponentElement(this.firstChild, { content: '|foo|bar|' });
+    this.render('{{foo-bar}}');
 
-      this.assertStableRerender();
+    this.assertComponentElement(this.firstChild, { content: 'hello' });
 
-      this.runTask(() => this.context.set('foo', 'FOO'));
+    this.assertStableRerender();
+  }
 
-      this.assertComponentElement(this.firstChild, { content: '|FOO|bar|' });
+  ['@feature(ember-glimmer-named-arguments) it can render named arguments']() {
+    this.registerComponent('foo-bar', '|{{@foo}}|{{@bar}}|');
 
-      this.runTask(() => this.context.set('bar', 'BAR'));
+    this.render('{{foo-bar foo=foo bar=bar}}', {
+      foo: 'foo', bar: 'bar'
+    });
 
-      this.assertComponentElement(this.firstChild, { content: '|FOO|BAR|' });
+    this.assertComponentElement(this.firstChild, { content: '|foo|bar|' });
 
-      this.runTask(() => this.context.setProperties({ foo: 'foo', bar: 'bar' }));
+    this.assertStableRerender();
 
-      this.assertComponentElement(this.firstChild, { content: '|foo|bar|' });
-    }
+    this.runTask(() => this.context.set('foo', 'FOO'));
 
-    ['@test it renders named arguments as reflected properties']() {
-      this.registerComponent('foo-bar', '|{{foo}}|{{this.bar}}|');
+    this.assertComponentElement(this.firstChild, { content: '|FOO|bar|' });
 
-      this.render('{{foo-bar foo=foo bar=bar}}', {
-        foo: 'foo', bar: 'bar'
-      });
+    this.runTask(() => this.context.set('bar', 'BAR'));
 
-      this.assertComponentElement(this.firstChild, { content: '|foo|bar|' });
+    this.assertComponentElement(this.firstChild, { content: '|FOO|BAR|' });
 
-      this.assertStableRerender();
+    this.runTask(() => this.context.setProperties({ foo: 'foo', bar: 'bar' }));
 
-      this.runTask(() => this.context.set('foo', 'FOO'));
+    this.assertComponentElement(this.firstChild, { content: '|foo|bar|' });
+  }
 
-      this.assertComponentElement(this.firstChild, { content: '|FOO|bar|' });
+  ['@test it renders named arguments as reflected properties']() {
+    this.registerComponent('foo-bar', '|{{foo}}|{{this.bar}}|');
 
-      this.runTask(() => this.context.set('bar', null));
+    this.render('{{foo-bar foo=foo bar=bar}}', {
+      foo: 'foo', bar: 'bar'
+    });
 
-      this.assertComponentElement(this.firstChild, { content: '|FOO||' });
+    this.assertComponentElement(this.firstChild, { content: '|foo|bar|' });
 
-      this.runTask(() => this.context.setProperties({ foo: 'foo', bar: 'bar' }));
+    this.assertStableRerender();
 
-      this.assertComponentElement(this.firstChild, { content: '|foo|bar|' });
-    }
+    this.runTask(() => this.context.set('foo', 'FOO'));
 
-    ['@test it has curly component features']() {
-      this.registerComponent('foo-bar', 'hello');
+    this.assertComponentElement(this.firstChild, { content: '|FOO|bar|' });
 
-      this.render('{{foo-bar tagName="p" class=class}}', {
-        class: 'foo bar'
-      });
+    this.runTask(() => this.context.set('bar', null));
 
-      this.assertComponentElement(this.firstChild, {
-        tagName: 'p',
-        attrs: { class: classes('foo bar ember-view') },
-        content: 'hello'
-      });
+    this.assertComponentElement(this.firstChild, { content: '|FOO||' });
 
-      this.assertStableRerender();
+    this.runTask(() => this.context.setProperties({ foo: 'foo', bar: 'bar' }));
 
-      this.runTask(() => this.context.set('class', 'foo'));
+    this.assertComponentElement(this.firstChild, { content: '|foo|bar|' });
+  }
 
-      this.assertComponentElement(this.firstChild, {
-        tagName: 'p',
-        attrs: { class: classes('foo ember-view') },
-        content: 'hello'
-      });
+  ['@test it has curly component features']() {
+    this.registerComponent('foo-bar', 'hello');
 
-      this.runTask(() => this.context.set('class', null));
+    this.render('{{foo-bar tagName="p" class=class}}', {
+      class: 'foo bar'
+    });
 
-      this.assertComponentElement(this.firstChild, {
-        tagName: 'p',
-        attrs: { class: classes('ember-view') },
-        content: 'hello'
-      });
+    this.assertComponentElement(this.firstChild, {
+      tagName: 'p',
+      attrs: { class: classes('foo bar ember-view') },
+      content: 'hello'
+    });
 
-      this.runTask(() => this.context.set('class', 'foo bar'));
+    this.assertStableRerender();
 
-      this.assertComponentElement(this.firstChild, {
-        tagName: 'p',
-        attrs: { class: classes('foo bar ember-view') },
-        content: 'hello'
-      });
-    }
-  });
-}
+    this.runTask(() => this.context.set('class', 'foo'));
+
+    this.assertComponentElement(this.firstChild, {
+      tagName: 'p',
+      attrs: { class: classes('foo ember-view') },
+      content: 'hello'
+    });
+
+    this.runTask(() => this.context.set('class', null));
+
+    this.assertComponentElement(this.firstChild, {
+      tagName: 'p',
+      attrs: { class: classes('ember-view') },
+      content: 'hello'
+    });
+
+    this.runTask(() => this.context.set('class', 'foo bar'));
+
+    this.assertComponentElement(this.firstChild, {
+      tagName: 'p',
+      attrs: { class: classes('foo bar ember-view') },
+      content: 'hello'
+    });
+  }
+});

--- a/packages/ember-views/lib/utils/lookup-component.js
+++ b/packages/ember-views/lib/utils/lookup-component.js
@@ -1,7 +1,7 @@
 import { privatize as P } from 'container';
+import { ENV } from 'ember-environment';
 import {
   EMBER_MODULE_UNIFICATION,
-  EMBER_GLIMMER_TEMPLATE_ONLY_COMPONENTS
 } from 'ember/features';
 
 function lookupModuleUnificationComponentPair(componentLookup, owner, name, options) {
@@ -24,7 +24,7 @@ function lookupModuleUnificationComponentPair(componentLookup, owner, name, opti
 
   let defaultComponentFactory = null;
 
-  if (!EMBER_GLIMMER_TEMPLATE_ONLY_COMPONENTS) {
+  if (!ENV._TEMPLATE_ONLY_GLIMMER_COMPONENTS) {
     defaultComponentFactory = owner.factoryFor(P`component:-default`);
   }
 
@@ -46,7 +46,7 @@ function lookupComponentPair(componentLookup, owner, name, options) {
 
   let result = { layout, component };
 
-  if (!EMBER_GLIMMER_TEMPLATE_ONLY_COMPONENTS && layout && !component) {
+  if (!ENV._TEMPLATE_ONLY_GLIMMER_COMPONENTS && layout && !component) {
     result.component = owner.factoryFor(P`component:-default`);
   }
 

--- a/packages/ember/tests/routing/toplevel_dom_test.js
+++ b/packages/ember/tests/routing/toplevel_dom_test.js
@@ -1,7 +1,20 @@
+import { ENV } from 'ember-environment';
 import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
 
 moduleFor('Top Level DOM Structure', class extends ApplicationTestCase {
-  ['@feature(!ember-glimmer-remove-application-template-wrapper) Topmost template always get an element']() {
+  constructor() {
+    super();
+    this._APPLICATION_TEMPLATE_WRAPPER = ENV._APPLICATION_TEMPLATE_WRAPPER;
+  }
+
+  teardown() {
+    super.teardown();
+    ENV._APPLICATION_TEMPLATE_WRAPPER = this._APPLICATION_TEMPLATE_WRAPPER;
+  }
+
+  ['@test topmost template with wrapper']() {
+    ENV._APPLICATION_TEMPLATE_WRAPPER = true;
+
     this.addTemplate('application', 'hello world');
 
     return this.visit('/').then(() => {
@@ -9,7 +22,9 @@ moduleFor('Top Level DOM Structure', class extends ApplicationTestCase {
     });
   }
 
-  ['@feature(ember-glimmer-remove-application-template-wrapper) Topmost template does not get an element']() {
+  ['@test topmost template without wrapper']() {
+    ENV._APPLICATION_TEMPLATE_WRAPPER = false;
+
     this.addTemplate('application', 'hello world');
 
     return this.visit('/').then(() => {

--- a/packages/internal-test-helpers/lib/test-cases/abstract-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract-application.js
@@ -1,5 +1,5 @@
 import { compile } from 'ember-template-compiler';
-import { EMBER_GLIMMER_REMOVE_APPLICATION_TEMPLATE_WRAPPER } from 'ember/features';
+import { ENV } from 'ember-environment';
 import AbstractTestCase from './abstract';
 import { runDestroy } from '../run';
 
@@ -30,10 +30,10 @@ export default class AbstractApplicationTestCase extends AbstractTestCase {
   get element() {
     if (this._element) {
       return this._element;
-    } else if (EMBER_GLIMMER_REMOVE_APPLICATION_TEMPLATE_WRAPPER) {
-      return this._element = document.querySelector('#qunit-fixture');
-    } else {
+    } else if (ENV._APPLICATION_TEMPLATE_WRAPPER) {
       return this._element = document.querySelector('#qunit-fixture > div.ember-view');
+    } else {
+      return this._element = document.querySelector('#qunit-fixture');
     }
   }
 


### PR DESCRIPTION
These features are enabled by turning them into a runtime flag. These flags are intended to be set by @emberjs/ember-optional-features. In the future, these runtime flags might be removed in favor of build-time flags once the infrastructure is in place.