### PR TITLE
[BUGFIX lts] Enable _some_ recovery of errors thrown during render.

### DIFF
--- a/packages/ember-glimmer/lib/renderer.ts
+++ b/packages/ember-glimmer/lib/renderer.ts
@@ -450,6 +450,9 @@ export abstract class Renderer {
     } finally {
       if (!completedWithoutError) {
         this._lastRevision = CURRENT_TAG.value();
+        if (this._env.inTransaction === true) {
+          this._env.commit();
+        }
       }
       this._isRenderingRoots = false;
     }

--- a/packages/ember-glimmer/tests/integration/components/error-handling-test.js
+++ b/packages/ember-glimmer/tests/integration/components/error-handling-test.js
@@ -1,0 +1,72 @@
+import { set } from 'ember-metal';
+import { Component } from '../../utils/helpers';
+import { moduleFor, RenderingTest } from '../../utils/test-case';
+
+moduleFor('Errors thrown during render', class extends RenderingTest {
+  ['@test it can recover resets the transaction when an error is thrown during initial render'](assert) {
+    let shouldThrow = true;
+    let FooBarComponent = Component.extend({
+      init() {
+        this._super(...arguments);
+        if (shouldThrow) {
+          throw new Error('silly mistake in init!');
+        }
+      }
+    });
+
+    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: 'hello' });
+
+    assert.throws(() => {
+      this.render('{{#if switch}}{{#foo-bar}}{{foo-bar}}{{/foo-bar}}{{/if}}', { switch: true });
+    }, /silly mistake in init/);
+
+    assert.equal(this.env.inTransaction, false, 'should not be in a transaction even though an error was thrown');
+
+    this.assertText('');
+
+    this.runTask(() => set(this.context, 'switch', false));
+
+    shouldThrow = false;
+
+    this.runTask(() => set(this.context, 'switch', true));
+
+    this.assertText('hello');
+  }
+
+  ['@test it can recover resets the transaction when an error is thrown during rerender'](assert) {
+    let shouldThrow = false;
+    let FooBarComponent = Component.extend({
+      init() {
+        this._super(...arguments);
+        if (shouldThrow) {
+          throw new Error('silly mistake in init!');
+        }
+      }
+    });
+
+    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: 'hello' });
+
+    this.render('{{#if switch}}{{#foo-bar}}{{foo-bar}}{{/foo-bar}}{{/if}}', { switch: true });
+
+    this.assertText('hello');
+
+    this.runTask(() => set(this.context, 'switch', false));
+
+    shouldThrow = true;
+
+    assert.throws(() => {
+      this.runTask(() => set(this.context, 'switch', true));
+    }, /silly mistake in init/);
+
+    assert.equal(this.env.inTransaction, false, 'should not be in a transaction even though an error was thrown');
+
+    this.assertText('');
+
+    this.runTask(() => set(this.context, 'switch', false));
+    shouldThrow = false;
+
+    this.runTask(() => set(this.context, 'switch', true));
+
+    this.assertText('hello');
+  }
+});


### PR DESCRIPTION
If `env.commit()` is not called after it has started, and another `env.begin()` starts Glimmer throws an error:

```
Error: a glimmer transaction was begun, but one already exists. You may have a nested transaction
```

This commit works around the issue by ensuring that if a transaction had been started, it is cleaned up even if an error was thrown during render.

Fixes https://github.com/glimmerjs/glimmer-vm/issues/484