### PR TITLE
[BUGFIX beta] Fix a few bugs in the caching ArrayProxy implementation

### DIFF
--- a/packages/ember-runtime/tests/system/array_proxy/array_observer_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/array_observer_test.js
@@ -1,4 +1,4 @@
-import { get, set } from 'ember-metal';
+import { set } from 'ember-metal';
 import ArrayProxy from '../../../system/array_proxy';
 import { A } from '../../../system/native_array';
 
@@ -21,7 +21,7 @@ QUnit.test('mutating content', assert => {
     }
   });
 
-  get(proxy, 'length');
+  proxy.toArray();
   content.replace(1, 1, ['a', 'b', 'c']);
 });
 
@@ -42,6 +42,6 @@ QUnit.test('assigning content', assert => {
     }
   });
 
-  get(proxy, 'length');
+  proxy.toArray();
   set(proxy, 'content', A(['a', 'b', 'c', 'd', 'e']));
 });

--- a/packages/ember-runtime/tests/system/array_proxy/content_change_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/content_change_test.js
@@ -1,4 +1,4 @@
-import { set, run } from 'ember-metal';
+import { get, set, run, changeProperties } from 'ember-metal';
 import { not } from '../../../computed/computed_macros';
 import ArrayProxy from '../../../system/array_proxy';
 import { A as emberA } from '../../../system/native_array';
@@ -44,4 +44,94 @@ QUnit.test('The ArrayProxy doesn\'t explode when assigned a destroyed object', f
   set(proxy2, 'content', proxy1);
 
   assert.ok(true, 'No exception was raised');
+});
+
+QUnit.test('should update if content changes while change events are deferred', function(assert) {
+  let proxy = ArrayProxy.create();
+
+  assert.deepEqual(proxy.toArray(), []);
+
+  changeProperties(() => {
+    proxy.set('content', emberA([1, 2, 3]));
+    assert.deepEqual(proxy.toArray(), [1, 2, 3]);
+  });
+});
+
+QUnit.test('objectAt recomputes the object cache correctly', function(assert) {
+  let indexes = [];
+
+  let proxy = ArrayProxy.extend({
+    objectAtContent(index) {
+      indexes.push(index);
+      return this.content[index];
+    }
+  }).create({
+    content: emberA([1, 2, 3, 4, 5])
+  });
+
+  assert.deepEqual(indexes, []);
+  assert.deepEqual(proxy.objectAt(0), 1);
+  assert.deepEqual(indexes, [0, 1, 2, 3, 4]);
+
+  indexes.length = 0;
+  proxy.set('content', emberA([1, 2, 3]));
+  assert.deepEqual(proxy.objectAt(0), 1);
+  assert.deepEqual(indexes, [0, 1, 2]);
+
+  indexes.length = 0;
+  proxy.content.replace(2, 0, [4, 5]);
+  assert.deepEqual(proxy.objectAt(0), 1);
+  assert.deepEqual(proxy.objectAt(1), 2);
+  assert.deepEqual(indexes, []);
+  assert.deepEqual(proxy.objectAt(2), 4);
+  assert.deepEqual(indexes, [2, 3, 4]);
+});
+
+QUnit.test('getting length does not recompute the object cache', function(assert) {
+  let indexes = [];
+
+  let proxy = ArrayProxy.extend({
+    objectAtContent(index) {
+      indexes.push(index);
+      return this.content[index];
+    }
+  }).create({
+    content: emberA([1, 2, 3, 4, 5])
+  });
+
+  assert.equal(get(proxy, 'length'), 5);
+  assert.deepEqual(indexes, []);
+
+  indexes.length = 0;
+  proxy.set('content', emberA([6, 7, 8]));
+  assert.equal(get(proxy, 'length'), 3);
+  assert.deepEqual(indexes, []);
+
+  indexes.length = 0;
+  proxy.content.replace(1, 0, [1, 2, 3]);
+  assert.equal(get(proxy, 'length'), 6);
+  assert.deepEqual(indexes, []);
+});
+
+QUnit.test('negative indexes are handled correctly', function(assert) {
+  let indexes = [];
+
+  let proxy = ArrayProxy.extend({
+    objectAtContent(index) {
+      indexes.push(index);
+      return this.content[index];
+    }
+  }).create({
+    content: emberA([1, 2, 3, 4, 5])
+  });
+
+  assert.deepEqual(proxy.toArray(), [1, 2, 3, 4, 5]);
+
+  indexes.length = 0;
+
+  proxy.content.replace(-1, 0, [7]);
+  proxy.content.replace(-2, 0, [6]);
+
+  assert.deepEqual(proxy.toArray(), [1, 2, 3, 4, 6, 7, 5]);
+  assert.deepEqual(indexes, [4, 5, 6]);
 });


### PR DESCRIPTION
- Fix handling of negative indexes: `arrayProxy.replace(-1, 0, [obj]);`
- Change `arrangedContent` observer to use private `PROPERTY_DID_CHANGE`. See the test "should update if content changes while change events are deferred" for an example of why this is needed. This was also causing the ember-data tests to fail.
- Optimize `arrayProxy.get('length')` so that it no longer triggers the objects cache to revalidate.
- Changed the `length` computed property to be volatile since we are handling the cache ourselves.
- Added a comment explaining what the `this._objectsDirtyIndex` field is doing.
  - Switch to using -1 as a sentinel instead of `undefined`.
  
I've confirmed locally that this fixes the failing test in ember-data.