### PR TITLE
[BUGFIX beta] Improve support for components defined as ES classes

### DIFF
--- a/packages/ember-glimmer/lib/component-managers/curly.ts
+++ b/packages/ember-glimmer/lib/component-managers/curly.ts
@@ -268,6 +268,10 @@ export default class CurlyComponentManager extends AbstractManager<ComponentStat
 
     // We usually do this in the `didCreateElement`, but that hook doesn't fire for tagless components
     if (component.tagName === '') {
+      if (component.elementId === guidFor(component)) {
+        component.elementId = '';
+      }
+
       if (environment.isInteractive) {
         component.trigger('willRender');
       }
@@ -476,8 +480,10 @@ export function processComponentInitializationAssertions(component: Component, p
     component.tagName !== '' || !component.classNameBindings || component.classNameBindings.length === 0);
 
   assert(`You cannot use \`elementId\` on a tag-less component: ${component}`,
-    component.tagName !== '' || props.id === component.elementId ||
-    (!component.elementId && component.elementId !== ''));
+    component.tagName !== '' || // component has a tagname
+    props.id === component.elementId || // elementId comes from cloning id
+    guidFor(component) === component.elementId || // elementId is set by default
+    !(component.elementId && component.elementId !== ''));
 
   assert(`You cannot use \`attributeBindings\` on a tag-less component: ${component}`,
     component.tagName !== '' || !component.attributeBindings || component.attributeBindings.length === 0);

--- a/packages/ember-glimmer/tests/integration/components/fragment-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/fragment-components-test.js
@@ -139,6 +139,57 @@ moduleFor('Components test: fragment components', class extends RenderingTest {
     this.assertText('baz');
   }
 
+  ['@test [GH#16177] does not throw an error if `tagName` is set to empty after calling super in an ES6 class']() {
+    let template = 'hola';
+    let FooBarComponent = class extends Component {
+      constructor() {
+        super(...arguments);
+        this.tagName = '';
+      }
+    };
+
+    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template });
+    this.render(`{{foo-bar}}`);
+    this.assertText('hola');
+  }
+
+  ['@test [GH#16177] tagName can be changed after calling `super` in ES6 classes']() {
+    let template = 'hola';
+    let tagName = 'span';
+    let FooBarComponent = class extends Component {
+      constructor() {
+        super(...arguments);
+        this.tagName = tagName;
+      }
+    };
+
+    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template });
+    this.render('{{foo-bar}}');
+    this.assertComponentElement(this.firstChild, {
+      tagName
+    });
+  }
+
+  ['@test [GH#16177] tagless components written with ES6 classes have a null elementId']() {
+    this.assert.expect(1);
+    let assert = this.assert;
+    let template = 'hola';
+    let FooBarComponent = class extends Component {
+      constructor() {
+        super(...arguments);
+        this.tagName = '';
+      }
+
+      didInsertElement() {
+        super.didInsertElement();
+        assert.equal(this.elementId, '');
+      }
+    };
+
+    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template });
+    this.render(`{{foo-bar}}`);
+  }
+
   ['@test does not throw an error if `tagName` is an empty string and `id` is specified via template']() {
     let template = `{{id}}`;
     let FooBarComponent = Component.extend({


### PR DESCRIPTION
If a component is defined as an ES class, tagName cannot be defined
before calling super. This PR adds support for tagless components
defined with an ES6 class.

```js
import Component from '@ember/component';

export default class extends Component {
  constructor() {
    super();
    this.tagName = '';
  }
}
```

Fixes #16177