### PR TITLE
[WIP es-classes] Fix extending from ES Classes

### DIFF
--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -35,6 +35,7 @@ export const UNDEFINED = symbol('undefined');
 const SOURCE_DESTROYING = 1 << 1;
 const SOURCE_DESTROYED = 1 << 2;
 const META_DESTROYED = 1 << 3;
+const WAS_APPLIED = 1 << 5;
 
 const NODE_STACK = [];
 
@@ -155,6 +156,22 @@ export class Meta {
 
   _hasFlag(flag) {
     return (this._flags & flag) === flag;
+  }
+
+  get wasApplied() {
+    assert('cannot access wasApplied for an instances meta', this.proto === this.source);
+
+    return this._hasFlag(WAS_APPLIED);
+  }
+
+  set wasApplied(value) {
+    assert('cannot set wasApplied for an instances meta', this.proto === this.source);
+
+    if (value === true) {
+      this._flags |= WAS_APPLIED;
+    } else {
+      this._flags &= ~WAS_APPLIED;
+    }
   }
 
   _getOrCreateOwnMap(key) {

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -50,10 +50,10 @@ function makeCtor() {
   class Class {
     constructor(properties) {
       let self = this;
-      let m = meta(self);
+      let m = meta(this);
 
       if (!m.parent.wasApplied) {
-        Class.proto(); // prepare prototype...
+        this.constructor.proto(); // prepare prototype...
       }
 
       let beforeInitCalled; // only used in debug builds to enable the proxy trap
@@ -103,6 +103,10 @@ function makeCtor() {
             assert(messageFor(receiver, property), value === undefined);
           }
         });
+
+        // We've changed "self" so meta will necessarily change as well, due to it being a different
+        // object. Reset meta in this case as well.
+        m = meta(self);
       }
 
       let proto = m.proto;
@@ -209,22 +213,33 @@ function makeCtor() {
     static willReopen() {
       let m = meta(this.prototype);
       if (m.wasApplied) {
-        Class.PrototypeMixin = Mixin.create(Class.PrototypeMixin);
+        this.PrototypeMixin = Mixin.create(this.PrototypeMixin);
       }
 
-      m.asApplied = false;
+      m.wasApplied = false;
     }
 
     static _initFactory(factory) { initFactory = factory; }
 
     static proto() {
-      let superclass = Class.superclass;
-      if (superclass) { superclass.proto(); }
+      // Native classes set the prototype of the constructor to the superclass,
+      // so first we check to see if it exists and contains `proto`. If not, we
+      // look for a manually assigned superclass.
+      let superclass = Object.getPrototypeOf(this);
+
+      if (typeof superclass.proto === 'function') {
+        superclass.proto();
+      } else if (this.superclass) {
+        this.superclass.proto();
+      }
 
       let m = meta(this.prototype);
+
+      // Setup proto incase it hasn't been setup, as in ES Class extend
+      m.proto = this.prototype;
       if (!m.wasApplied) {
         m.wasApplied = true;
-        Class.PrototypeMixin.applyPartial(Class.prototype);
+        this.PrototypeMixin.applyPartial(this.prototype);
       }
 
       return this.prototype;
@@ -683,10 +698,27 @@ let ClassMixinProps = {
     @public
   */
   extend() {
-    let Class = makeCtor();
-    let proto;
-    Class.ClassMixin = Mixin.create(this.ClassMixin);
-    Class.PrototypeMixin = Mixin.create(this.PrototypeMixin);
+    let Class, proto;
+
+    if (Object.getPrototypeOf(this) === Function.prototype) {
+      // The class we're extending is a base class, does not have anything
+      // else in the prototype chain, so continue as normal
+      Class = makeCtor();
+    } else {
+      // Create a simple wrapper class to defer to the rest of the prototype chain
+      // for native classes and classes that extend from native classes
+      Class = class extends this {};
+    }
+
+    if (this.hasOwnProperty('ClassMixin')) {
+      Class.ClassMixin = Mixin.create(this.ClassMixin);
+      Class.PrototypeMixin = Mixin.create(this.PrototypeMixin);
+    } else {
+      // Native classes do not have a ClassMixin or PrototypeMixin,
+      // create one using their constructor and prototype respectively
+      Class.ClassMixin = Mixin.create(this);
+      Class.PrototypeMixin = Mixin.create(this.prototype);
+    }
 
     Class.ClassMixin.ownerConstructor = Class;
     Class.PrototypeMixin.ownerConstructor = Class;
@@ -790,6 +822,7 @@ let ClassMixinProps = {
     @public
   */
   reopen() {
+    assert(`You cannot reopen ${this.name} because it was defined with native class syntax`, this.hasOwnProperty('PrototypeMixin'));
     this.willReopen();
     reopen.apply(this.PrototypeMixin, arguments);
     return this;
@@ -857,6 +890,7 @@ let ClassMixinProps = {
     @public
   */
   reopenClass() {
+    assert(`You cannot reopen ${this.name} because it was defined with native class syntax`, this.hasOwnProperty('ClassMixin'));
     reopen.apply(this.ClassMixin, arguments);
     applyMixin(this, arguments, false);
     return this;
@@ -1041,7 +1075,6 @@ CoreObject.ClassMixin = ClassMixin;
 
 // ensure CoreObject itself has a proper class meta
 let proto = CoreObject.prototype;
-generateGuid(proto);
 meta(proto).proto = proto;
 
 ClassMixin.apply(CoreObject);


### PR DESCRIPTION
This PR seeks to fix the behavior of ES classes, specifically when calling `.extend()` on a native class. Currently, a new base class constructor (`makeCtor`) is made each time we call `.extend()`. With ES classes, this no longer works as expected because the base class does not ever call it's super constructor, breaking both the constructor of the native class and (in the future) class fields, which are assigned in the constructor.

The changes here detect if the class being extended from is actually a `makeCtor`, and if not provide a simple anonymous class that extends from the superclass instead. This allows the constructor to follow the prototype chain upward instead to whatever the last real `makeCtor` was, which then does all of the work of assigning properties, running `proto`, etc. In order to do this, metadata such as `wasApplied` had to be moved to the meta object for the object (see #15580) and static methods such as `proto` had to remove direct references to the class in `makeCtor` itself so they could be reused for upstream classes.

TODO:

- [x] Make sure this is the right strategy for fixing cross-compatibility
- [x] Cleanup code (some quirky/hacky things made it in)
- [x] Throw an error when trying to reopen native classes
- [x] More tests
  - [x] Testing `reopen` and `reopenClass`, particularly when they retrigger a `proto`
  - [x] Testing `reopen` and `reopenClass` fail on native classes
- [x] Perf benchmarks