### PR TITLE
[DOC canary] Fix deprecation guide urls for propertyWillChange

### DIFF
--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -42,7 +42,7 @@ function propertyWillChange() {
     {
       id: 'ember-metal.deprecate-propertyWillChange',
       until: '3.5.0',
-      url: 'https://emberjs.com/deprecations/v3.x/#toc_ember-metal-deprecate-propertyWillChange-and-propertyDidChange'
+      url: 'https://emberjs.com/deprecations/v3.x/#toc_use-notifypropertychange-instead-of-propertywillchange-and-propertydidchange'
     }
   );
 }
@@ -59,7 +59,7 @@ function propertyDidChange(obj, keyName, _meta) {
     {
       id: 'ember-metal.deprecate-propertyDidChange',
       until: '3.5.0',
-      url: 'https://emberjs.com/deprecations/v3.x/#toc_ember-metal-deprecate-propertyWillChange-and-propertyDidChange'
+      url: 'https://emberjs.com/deprecations/v3.x/#toc_use-notifypropertychange-instead-of-propertywillchange-and-propertydidchange'
     }
   );
 


### PR DESCRIPTION
... and propertyDidChange:

https://emberjs.com/deprecations/v3.x/#toc_use-notifypropertychange-instead-of-propertywillchange-and-propertydidchange