### PR TITLE
[doc beta]Removes the @submodule reference to ember-glimmer

### DIFF
--- a/packages/ember-glimmer/lib/helpers/if-unless.ts
+++ b/packages/ember-glimmer/lib/helpers/if-unless.ts
@@ -1,6 +1,5 @@
 /**
 @module ember
-@submodule ember-glimmer
 */
 
 import {


### PR DESCRIPTION
Partial fix for https://github.com/ember-learn/ember-api-docs/issues/419

Removes the "ember-glimmer" reference from the api docs:
![image](https://user-images.githubusercontent.com/3609063/34752084-395bffcc-f57e-11e7-8955-6e35412a264b.png)