### PR TITLE
Remove Ember.Logger from application module, Ember.Test from test

### DIFF
--- a/packages/ember-console/lib/index.js
+++ b/packages/ember-console/lib/index.js
@@ -1,4 +1,7 @@
 /**
+   @module ember
+*/
+/**
   Inside Ember-Metal, simply uses the methods from `imports.console`.
   Override this to provide more robust logging functionality.
 

--- a/packages/ember-metal/lib/map.js
+++ b/packages/ember-metal/lib/map.js
@@ -3,6 +3,7 @@ import { guidFor } from 'ember-utils';
 
 /**
 @module @ember/map
+@private
 */
 
 /*

--- a/packages/ember-testing/lib/adapters/qunit.js
+++ b/packages/ember-testing/lib/adapters/qunit.js
@@ -1,6 +1,8 @@
 import { inspect } from 'ember-utils';
 import Adapter from './adapter';
-
+/**
+   @module ember
+*/
 /**
   This class implements the methods defined by TestAdapter for the
   QUnit testing framework.


### PR DESCRIPTION
Part of https://github.com/ember-learn/ember-api-docs/issues/419

stuff removed from modules still documented in classes, they just aren't imported view those modules so didn't want to add confusion.

Still trying to figure out how to get rid of the odd Ember references that show up in them.

Removed some stuff from `@ember/application`
![image](https://user-images.githubusercontent.com/3609063/35655629-c65152da-06c0-11e8-9bc7-4e178ee50e21.png)

Removed some stuff from `@ember/testing`
![image](https://user-images.githubusercontent.com/3609063/35655643-d6d4e36a-06c0-11e8-8af2-3aec64a86d3f.png)

And the newly added private `@ember/map` package was showing up, so I made it private.