### PR TITLE
Show the right ContainerProxyMixin Docs

### DIFF
--- a/packages/ember-runtime/lib/mixins/container_proxy.js
+++ b/packages/ember-runtime/lib/mixins/container_proxy.js
@@ -156,7 +156,6 @@ let containerProxyMixin = {
   ```
 
   @public
-  @class ContainerProxyMixin
   @method factoryFor
   @param {String} fullName
   @param {Object} options


### PR DESCRIPTION
Part of the fix for https://github.com/ember-learn/ember-api-docs/issues/423

ContainerProxy mixin had a bug in its documentation.  It had a `@class` annotation defined on one of its methods, making the Class public and documenting the method as a description to the class, when it is actually labelled private.

Before:
![image](https://user-images.githubusercontent.com/3609063/35662900-bd3605b0-06e8-11e8-8b3d-e7c7bbae8321.png)

After: 
![image](https://user-images.githubusercontent.com/3609063/35662929-e6179d04-06e8-11e8-85f7-564b812f0e48.png)
