### PR TITLE
Move each proxy into a weak map

### DIFF
--- a/packages/ember-extension-support/lib/data_adapter.js
+++ b/packages/ember-extension-support/lib/data_adapter.js
@@ -1,13 +1,12 @@
 import { getOwner } from 'ember-utils';
-import { get, run } from 'ember-metal';
+import { get, run, objectAt } from 'ember-metal';
 import {
   String as StringUtils,
   Namespace,
   Object as EmberObject,
   A as emberA,
   addArrayObserver,
-  removeArrayObserver,
-  objectAt
+  removeArrayObserver
 } from 'ember-runtime';
 
 /**

--- a/packages/ember-glimmer/lib/utils/iterable.ts
+++ b/packages/ember-glimmer/lib/utils/iterable.ts
@@ -6,11 +6,16 @@ import {
   UpdatableTag,
 } from '@glimmer/reference';
 import { Opaque } from '@glimmer/util';
-import { get, isProxy, tagFor, tagForProperty } from 'ember-metal';
+import {
+  get,
+  isProxy,
+  objectAt,
+  tagFor,
+  tagForProperty
+} from 'ember-metal';
 import {
   _contentFor,
-  isEmberArray,
-  objectAt,
+  isEmberArray
 } from 'ember-runtime';
 import { guidFor } from 'ember-utils';
 import { isEachIn } from '../helpers/each-in';

--- a/packages/ember-metal/lib/array.js
+++ b/packages/ember-metal/lib/array.js
@@ -1,0 +1,7 @@
+export function objectAt(content, idx) {
+  if (typeof content.objectAt === 'function') {
+    return content.objectAt(idx);
+  } else {
+    return content[idx];
+  }
+}

--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -2,6 +2,7 @@ import { get } from './property_get';
 import { descriptorFor, meta as metaFor, peekMeta } from './meta';
 import { watchKey, unwatchKey } from './watch_key';
 import { cacheFor } from './computed';
+import { eachProxyFor } from './each_proxy';
 
 const FIRST_KEY = /^([^\.]+)/;
 
@@ -326,7 +327,9 @@ function lazyGet(obj, key) {
   }
 
   // Use `get` if the return value is an EachProxy or an uncacheable value.
-  if (isVolatile(obj, key, meta)) {
+  if (key === '@each') {
+    return eachProxyFor(obj);
+  } else if (isVolatile(obj, key, meta)) {
     return get(obj, key);
   // Otherwise attempt to get the cached value of the computed property
   } else {

--- a/packages/ember-metal/lib/each_proxy.js
+++ b/packages/ember-metal/lib/each_proxy.js
@@ -1,0 +1,131 @@
+import { assert } from 'ember-debug';
+import { get } from './property_get';
+import { notifyPropertyChange } from './property_events';
+import { addObserver, removeObserver } from './observer';
+import { meta, peekMeta } from './meta';
+import { objectAt } from './array';
+
+const EACH_PROXIES = new WeakMap();
+
+export function eachProxyFor(array) {
+  let eachProxy = EACH_PROXIES.get(array);
+  if (eachProxy === undefined) {
+    eachProxy = new EachProxy(array);
+    EACH_PROXIES.set(array, eachProxy);
+  }
+  return eachProxy;
+}
+
+export function eachProxyArrayWillChange(array, idx, removedCnt, addedCnt) {
+  let eachProxy = EACH_PROXIES.get(array);
+  if (eachProxy !== undefined) {
+    eachProxy.arrayWillChange(array, idx, removedCnt, addedCnt);
+  }
+}
+
+export function eachProxyArrayDidChange(array, idx, removedCnt, addedCnt) {
+  let eachProxy = EACH_PROXIES.get(array);
+  if (eachProxy !== undefined) {
+    eachProxy.arrayDidChange(array, idx, removedCnt, addedCnt);
+  }
+}
+
+class EachProxy {
+  constructor(content) {
+    this._content = content;
+    this._keys = undefined;
+    meta(this);
+  }
+
+  // ..........................................................
+  // ARRAY CHANGES
+  // Invokes whenever the content array itself changes.
+
+  arrayWillChange(content, idx, removedCnt, addedCnt) {   // eslint-disable-line no-unused-vars
+    let keys = this._keys;
+    let lim = removedCnt > 0 ? idx + removedCnt : -1;
+    for (let key in keys) {
+      if (lim > 0) {
+        removeObserverForContentKey(content, key, this, idx, lim);
+      }
+    }
+  }
+
+  arrayDidChange(content, idx, removedCnt, addedCnt) {
+    let keys = this._keys;
+    let lim = addedCnt > 0 ? idx + addedCnt : -1;
+    let meta = peekMeta(this);
+    for (let key in keys) {
+      if (lim > 0) {
+        addObserverForContentKey(content, key, this, idx, lim);
+      }
+      notifyPropertyChange(this, key, meta);
+    }
+  }
+
+  // ..........................................................
+  // LISTEN FOR NEW OBSERVERS AND OTHER EVENT LISTENERS
+  // Start monitoring keys based on who is listening...
+
+  willWatchProperty(property) {
+    this.beginObservingContentKey(property);
+  }
+
+  didUnwatchProperty(property) {
+    this.stopObservingContentKey(property);
+  }
+
+  // ..........................................................
+  // CONTENT KEY OBSERVING
+  // Actual watch keys on the source content.
+
+  beginObservingContentKey(keyName) {
+    let keys = this._keys;
+    if (!keys) {
+      keys = this._keys = Object.create(null);
+    }
+
+    if (!keys[keyName]) {
+      keys[keyName] = 1;
+      let content = this._content;
+      let len = get(content, 'length');
+
+      addObserverForContentKey(content, keyName, this, 0, len);
+    } else {
+      keys[keyName]++;
+    }
+  }
+
+  stopObservingContentKey(keyName) {
+    let keys = this._keys;
+    if (keys && (keys[keyName] > 0) && (--keys[keyName] <= 0)) {
+      let content = this._content;
+      let len     = get(content, 'length');
+
+      removeObserverForContentKey(content, keyName, this, 0, len);
+    }
+  }
+
+  contentKeyDidChange(obj, keyName) {
+    notifyPropertyChange(this, keyName);
+  }
+}
+
+function addObserverForContentKey(content, keyName, proxy, idx, loc) {
+  while (--loc >= idx) {
+    let item = objectAt(content, loc);
+    if (item) {
+      assert(`When using @each to observe the array \`${toString(content)}\`, the array must return an object`, typeof item === 'object');
+      addObserver(item, keyName, proxy, 'contentKeyDidChange');
+    }
+  }
+}
+
+function removeObserverForContentKey(content, keyName, proxy, idx, loc) {
+  while (--loc >= idx) {
+    let item = objectAt(content, loc);
+    if (item) {
+      removeObserver(item, keyName, proxy, 'contentKeyDidChange');
+    }
+  }
+}

--- a/packages/ember-metal/lib/index.d.ts
+++ b/packages/ember-metal/lib/index.d.ts
@@ -33,6 +33,8 @@ export function get(obj: any, keyName: string): any;
 
 export function set(obj: any, keyName: string, value: any, tolerant?: boolean): void;
 
+export function objectAt(arr: any, i: number): any;
+
 export function computed(...args: Array<any>): any;
 
 export function didRender(object: any, key: string, reference: any): boolean;

--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -39,6 +39,7 @@ export {
   set,
   trySet
 } from './property_set';
+export { objectAt } from './array';
 export {
   addListener,
   hasListeners,

--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -41,6 +41,11 @@ export {
 } from './property_set';
 export { objectAt } from './array';
 export {
+  eachProxyFor,
+  eachProxyArrayWillChange,
+  eachProxyArrayDidChange
+} from './each_proxy';
+export {
   addListener,
   hasListeners,
   on,

--- a/packages/ember-runtime/lib/index.d.ts
+++ b/packages/ember-runtime/lib/index.d.ts
@@ -18,8 +18,6 @@ export const String: {
   loc(s: string, ...args: string[]): string;
 };
 
-export function objectAt(arr: any, i: number): any;
-
 export function isEmberArray(arr: any): boolean;
 
 export function _contentFor(proxy: any): any;

--- a/packages/ember-runtime/lib/index.js
+++ b/packages/ember-runtime/lib/index.js
@@ -12,7 +12,6 @@ export { default as compare } from './compare';
 export { default as isEqual } from './is-equal';
 export {
   default as Array,
-  objectAt,
   isEmberArray,
   addArrayObserver,
   removeArrayObserver,

--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -6,6 +6,8 @@ import { symbol, toString } from 'ember-utils';
 import {
   get,
   set,
+  objectAt,
+  replace,
   computed,
   isNone,
   aliasMethod,
@@ -25,9 +27,6 @@ import {
 import { assert } from 'ember-debug';
 import Enumerable from './enumerable';
 import compare from '../compare';
-import {
-  replace
-} from 'ember-metal';
 import { ENV } from 'ember-environment';
 import Observable from '../mixins/observable';
 import Copyable from '../mixins/copyable';
@@ -56,10 +55,6 @@ export function addArrayObserver(array, target, opts) {
 
 export function removeArrayObserver(array, target, opts) {
   return arrayObserversHelper(array, target, opts, removeListener, true);
-}
-
-export function objectAt(content, idx) {
-  return typeof content.objectAt === 'function' ? content.objectAt(idx) : content[idx];
 }
 
 export function arrayContentWillChange(array, startIdx, removeAmt, addAmt) {

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -4,6 +4,7 @@
 
 import {
   get,
+  objectAt,
   computed,
   alias,
   PROPERTY_DID_CHANGE
@@ -15,8 +16,7 @@ import EmberObject from './object';
 import { MutableArray } from '../mixins/array';
 import {
   addArrayObserver,
-  removeArrayObserver,
-  objectAt
+  removeArrayObserver
 } from '../mixins/array';
 import { assert } from 'ember-debug';
 

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -101,7 +101,6 @@ function makeCtor() {
               property === 'willWatchProperty' ||
               property === 'didUnwatchProperty' ||
               property === 'didAddListener' ||
-              property === '__each' ||
               property in target
             ) {
               return Reflect.get(target, property, receiver);

--- a/packages/ember-runtime/tests/mixins/array_test.js
+++ b/packages/ember-runtime/tests/mixins/array_test.js
@@ -288,6 +288,14 @@ QUnit.test('adding an object should notify (@each.isDone)', function(assert) {
   assert.equal(called, 1, 'calls observer when object is pushed');
 });
 
+QUnit.test('getting @each is deprecated', function(assert) {
+  assert.expect(1);
+
+  expectDeprecation(() => {
+    get(ary, '@each');
+  }, /Getting the '@each' property on object .* is deprecated/);
+});
+
 QUnit.test('@each is readOnly', function(assert) {
   assert.expect(1);
 
@@ -328,8 +336,10 @@ QUnit.test('modifying the array should also indicate the isDone prop itself has 
   // important because it tests the case where we don't have an isDone
   // EachArray materialized but just want to know when the property has
   // changed.
-
-  let each = get(ary, '@each');
+  let each;
+  expectDeprecation(() => {
+    each = get(ary, '@each');
+  });
   let count = 0;
 
   addObserver(each, 'isDone', () => count++);

--- a/packages/ember-runtime/tests/mixins/array_test.js
+++ b/packages/ember-runtime/tests/mixins/array_test.js
@@ -1,6 +1,7 @@
 import {
   get,
   set,
+  objectAt,
   addObserver,
   observer as emberObserver,
   computed
@@ -12,8 +13,7 @@ import EmberArray, {
   addArrayObserver,
   removeArrayObserver,
   arrayContentDidChange,
-  arrayContentWillChange,
-  objectAt
+  arrayContentWillChange
 } from '../../mixins/array';
 import { A as emberA } from '../../mixins/array';
 

--- a/packages/ember-runtime/tests/suites/array/objectAt.js
+++ b/packages/ember-runtime/tests/suites/array/objectAt.js
@@ -1,5 +1,4 @@
 import { SuiteModuleBuilder } from '../suite';
-import { objectAt } from '../../../mixins/array';
 
 const suite = SuiteModuleBuilder.create();
 
@@ -11,7 +10,7 @@ suite.test('should return object at specified index', function(assert) {
   let len      = expected.length;
 
   for (let idx = 0; idx < len; idx++) {
-    assert.equal(objectAt(obj, idx), expected[idx], `obj.objectAt(${idx}) should match`);
+    assert.equal(obj.objectAt(idx), expected[idx], `obj.objectAt(${idx}) should match`);
   }
 });
 
@@ -19,10 +18,10 @@ suite.test('should return undefined when requesting objects beyond index', funct
   let obj;
 
   obj = this.newObject(this.newFixture(3));
-  assert.equal(objectAt(obj, 5), undefined, 'should return undefined for obj.objectAt(5) when len = 3');
+  assert.equal(obj.objectAt(obj, 5), undefined, 'should return undefined for obj.objectAt(5) when len = 3');
 
   obj = this.newObject([]);
-  assert.equal(objectAt(obj, 0), undefined, 'should return undefined for obj.objectAt(0) when len = 0');
+  assert.equal(obj.objectAt(obj, 0), undefined, 'should return undefined for obj.objectAt(0) when len = 0');
 });
 
 export default suite;

--- a/packages/ember-runtime/tests/system/array_proxy/arranged_content_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/arranged_content_test.js
@@ -1,7 +1,6 @@
-import { run, computed } from 'ember-metal';
+import { run, computed, objectAt } from 'ember-metal';
 import ArrayProxy from '../../../system/array_proxy';
 import { A as emberA } from '../../../mixins/array';
-import { objectAt } from '../../../mixins/array';
 
 let array;
 


### PR DESCRIPTION
- Move each proxy into meta so it doesn't have to be a computed property.
- Deprecate `get`ing `@each`. I am treating this as an intimate private API.
- This required moving `objectAt` into ember-metal to avoid ember-metal depending on ember-runtime.
- Fix a test that should have been testing `array.objectAt(i)` instead of `objectAt(array, i)`.

Remaining items:

- [x] [Deprecation guide](https://github.com/emberjs/website/pull/3179)