### PR TITLE
[BUGFIX beta] Allow symbol usage throughout internals.

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/utils/references.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/references.ts
@@ -520,7 +520,8 @@ function ensurePrimitive(value: unknown) {
         value === null ||
         typeof value === 'boolean' ||
         typeof value === 'number' ||
-        typeof value === 'string'
+        typeof value === 'string' ||
+        typeof value === 'symbol'
     );
   }
 }

--- a/packages/@ember/-internals/glimmer/lib/utils/references.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/references.ts
@@ -182,10 +182,14 @@ export class RootPropertyReference extends PropertyReference
 
 if (DEBUG) {
   RootPropertyReference.prototype['debug'] = function debug(subPath?: string): string {
-    let path = `this.${this['propertyKey']}`;
+    let propertyKey = this['propertyKey'];
+
+    let path = `this${
+      typeof propertyKey === 'string' ? `.${propertyKey}` : `[${String(propertyKey)}]`
+    }`;
 
     if (subPath) {
-      path += `.${subPath}`;
+      path += typeof subPath === 'string' ? `.${subPath}` : `[${String(subPath)}]`;
     }
 
     return `${this['debugStackLog']}${path}`;

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/get-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/get-test.js
@@ -141,6 +141,42 @@ moduleFor(
       this.assertText('[3][2][1]');
     }
 
+    ['@test should be able to get an object value with a path evaluating to a symbol'](assert) {
+      if (typeof Symbol === 'undefined') {
+        assert.expect(0);
+        return;
+      }
+
+      let first = Symbol();
+      let second = Symbol();
+      let third = Symbol();
+
+      this.render(`{{#each indexes as |index|}}[{{get items index}}]{{/each}}`, {
+        indexes: [first, second, third],
+        items: {
+          [first]: 'First',
+          [second]: 'Second',
+          [third]: 'Third',
+        },
+      });
+
+      this.assertText('[First][Second][Third]');
+
+      runTask(() => this.rerender());
+
+      this.assertText('[First][Second][Third]');
+
+      runTask(() => set(this.context.items, first, 'Qux'));
+
+      this.assertText('[Qux][Second][Third]');
+
+      runTask(() =>
+        set(this.context, 'items', { [first]: 'First', [second]: 'Second', [third]: 'Third' })
+      );
+
+      this.assertText('[First][Second][Third]');
+    }
+
     ['@test should be able to get an object value with a bound/dynamic key']() {
       this.render(`[{{get colors key}}] [{{if true (get colors key)}}]`, {
         colors: { apple: 'red', banana: 'yellow' },

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/each-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/each-test.js
@@ -495,6 +495,34 @@ class EachTest extends AbstractEachTest {
     this.assertText('123');
   }
 
+  ['@test it can iterate over symbols'](assert) {
+    if (typeof Symbol === 'undefined') {
+      assert.expect(0);
+      return;
+    }
+
+    let one = Symbol('one');
+    let two = Symbol('two');
+    let three = Symbol('three');
+    let four = Symbol('four');
+
+    this.makeList([one, two, three]);
+
+    this.render(`{{#each list as |item|}}{{item}}{{/each}}`);
+
+    this.assertText(`${one.toString()}${two.toString()}${three.toString()}`);
+
+    this.assertStableRerender();
+
+    runTask(() => this.pushObject(four));
+
+    this.assertText(`${one.toString()}${two.toString()}${three.toString()}${four.toString()}`);
+
+    this.replaceList([one, two, three]);
+
+    this.assertText(`${one.toString()}${two.toString()}${three.toString()}`);
+  }
+
   ['@test it can render duplicate primitive items']() {
     this.makeList(['a', 'a', 'a']);
 

--- a/packages/@ember/-internals/meta/lib/meta.ts
+++ b/packages/@ember/-internals/meta/lib/meta.ts
@@ -94,7 +94,7 @@ type Listener = StringListener | FunctionListener;
 let currentListenerVersion = 1;
 
 export class Meta {
-  _descriptors: Map<string, any> | undefined;
+  _descriptors: Map<string | number | symbol, any> | undefined;
   _watching: any | undefined;
   _mixins: any | undefined;
   _deps: any | undefined;
@@ -258,10 +258,10 @@ export class Meta {
     }
   }
 
-  _findInheritedMap(key: string, subkey: string): any | undefined {
+  _findInheritedMap(key: string, subkey: string | number | symbol): any | undefined {
     let pointer: Meta | null = this;
     while (pointer !== null) {
-      let map: Map<string, any> = pointer[key];
+      let map: Map<string | number | symbol, any> = pointer[key];
       if (map !== undefined) {
         let value = map.get(subkey);
         if (value !== undefined) {
@@ -376,7 +376,7 @@ export class Meta {
     return lazyChains[key];
   }
 
-  readableLazyChainsFor(key: string) {
+  readableLazyChainsFor(key: string | number | symbol) {
     if (DEBUG) {
       counters!.readableLazyChainsCalls++;
     }
@@ -384,7 +384,9 @@ export class Meta {
     let lazyChains = this._lazyChains;
 
     if (lazyChains !== undefined) {
-      return lazyChains[key];
+      // casting to any here due to lack of TS support for indexing with symbols
+      // https://github.com/microsoft/TypeScript/issues/1863
+      return lazyChains[key as any];
     }
 
     return undefined;
@@ -488,10 +490,10 @@ export class Meta {
     }
   }
 
-  writeDescriptors(subkey: string, value: any) {
+  writeDescriptors(subkey: string | number | symbol, value: any) {
     assert(
       this.isMetaDestroyed()
-        ? `Cannot update descriptors for \`${subkey}\` on \`${toString(
+        ? `Cannot update descriptors for \`${String(subkey)}\` on \`${toString(
             this.source
           )}\` after it has been destroyed.`
         : '',
@@ -501,7 +503,7 @@ export class Meta {
     map.set(subkey, value);
   }
 
-  peekDescriptors(subkey: string) {
+  peekDescriptors(subkey: string | number | symbol) {
     let possibleDesc = this._findInheritedMap('_descriptors', subkey);
     return possibleDesc === UNDEFINED ? undefined : possibleDesc;
   }

--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -459,9 +459,9 @@ export class ComputedProperty extends ComputedDescriptor {
     function addArg(property: string): void {
       warn(
         `Dependent keys containing @each only work one level deep. ` +
-          `You used the key "${property}" which is invalid. ` +
+          `You used the key "${String(property)}" which is invalid. ` +
           `Please create an intermediary computed property.`,
-        DEEP_EACH_REGEX.test(property) === false,
+        typeof property !== 'string' || DEEP_EACH_REGEX.test(property) === false,
         { id: 'ember-metal.computed-deep-each' }
       );
       args.push(property);

--- a/packages/@ember/-internals/metal/lib/computed_cache.ts
+++ b/packages/@ember/-internals/metal/lib/computed_cache.ts
@@ -1,10 +1,10 @@
 import { EMBER_METAL_TRACKED_PROPERTIES } from '@ember/canary-features';
-const COMPUTED_PROPERTY_CACHED_VALUES = new WeakMap<object, Map<string, any | null | undefined>>();
+const COMPUTED_PROPERTY_CACHED_VALUES = new WeakMap<object, Map<string | number | symbol, any | null | undefined>>();
 const COMPUTED_PROPERTY_LAST_REVISION = EMBER_METAL_TRACKED_PROPERTIES
-  ? new WeakMap<object, Map<string, number>>()
+  ? new WeakMap<object, Map<string | number | symbol, number>>()
   : undefined;
 
-export function getCacheFor(obj: object): Map<string, any> {
+export function getCacheFor(obj: object): Map<string | number | symbol, any> {
   let cache = COMPUTED_PROPERTY_CACHED_VALUES.get(obj);
   if (cache === undefined) {
     cache = new Map<string, any>();
@@ -29,15 +29,19 @@ export function getCacheFor(obj: object): Map<string, any> {
   @return {Object} the cached value
   @public
 */
-export function getCachedValueFor(obj: object, key: string): any {
+export function getCachedValueFor(obj: object, key: string | number | symbol): any {
   let cache = COMPUTED_PROPERTY_CACHED_VALUES.get(obj);
   if (cache !== undefined) {
     return cache.get(key);
   }
 }
 
-export let setLastRevisionFor: (obj: object, key: string, revision: number) => void;
-export let getLastRevisionFor: (obj: object, key: string) => number;
+export let setLastRevisionFor: (
+  obj: object,
+  key: string | number | symbol,
+  revision: number
+) => void;
+export let getLastRevisionFor: (obj: object, key: string | number | symbol) => number;
 
 if (EMBER_METAL_TRACKED_PROPERTIES) {
   setLastRevisionFor = (obj, key, revision) => {

--- a/packages/@ember/-internals/metal/lib/descriptor_map.ts
+++ b/packages/@ember/-internals/metal/lib/descriptor_map.ts
@@ -15,7 +15,11 @@ const DECORATOR_DESCRIPTOR_MAP: WeakMap<
   @return {Descriptor}
   @private
 */
-export function descriptorForProperty(obj: object, keyName: string, _meta?: Meta | null) {
+export function descriptorForProperty(
+  obj: object,
+  keyName: string | number | symbol,
+  _meta?: Meta | null
+) {
   assert('Cannot call `descriptorForProperty` on null', obj !== null);
   assert('Cannot call `descriptorForProperty` on undefined', obj !== undefined);
   assert(

--- a/packages/@ember/-internals/metal/lib/expand_properties.ts
+++ b/packages/@ember/-internals/metal/lib/expand_properties.ts
@@ -40,25 +40,31 @@ export default function expandProperties(
   pattern: string,
   callback: (expansion: string) => void
 ): void {
+  let patternType = typeof pattern;
   assert(
-    `A computed property key must be a string, you passed ${typeof pattern} ${pattern}`,
-    typeof pattern === 'string'
+    `A computed property key must be a string, number, or symbol; you passed ${patternType} ${pattern}`,
+    patternType === 'string' || patternType === 'number' || patternType === 'symbol'
   );
   assert(
     'Brace expanded properties cannot contain spaces, e.g. "user.{firstName, lastName}" should be "user.{firstName,lastName}"',
-    pattern.indexOf(' ') === -1
+    patternType !== 'string' || pattern.indexOf(' ') === -1
   );
   // regex to look for double open, double close, or unclosed braces
   assert(
     `Brace expanded properties have to be balanced and cannot be nested, pattern: ${pattern}`,
-    pattern.match(/\{[^}{]*\{|\}[^}{]*\}|\{[^}]*$/g) === null
+    patternType !== 'string' || pattern.match(/\{[^}{]*\{|\}[^}{]*\}|\{[^}]*$/g) === null
   );
 
-  let start = pattern.indexOf('{');
-  if (start < 0) {
-    callback(pattern.replace(END_WITH_EACH_REGEX, '.[]'));
+  // support numbers or symbols
+  if (patternType !== 'string') {
+    callback(pattern);
   } else {
-    dive('', pattern, start, callback);
+    let start = pattern.indexOf('{');
+    if (start < 0) {
+      callback(pattern.replace(END_WITH_EACH_REGEX, '.[]'));
+    } else {
+      dive('', pattern, start, callback);
+    }
   }
 }
 

--- a/packages/@ember/-internals/metal/lib/property_get.ts
+++ b/packages/@ember/-internals/metal/lib/property_get.ts
@@ -82,8 +82,10 @@ export function get(obj: object, keyName: string): any {
     obj !== undefined && obj !== null
   );
   assert(
-    `The key provided to get must be a string or number, you passed ${keyName}`,
-    typeof keyName === 'string' || (typeof keyName === 'number' && !isNaN(keyName))
+    `The key provided to get must be a string, number, or symbol; you passed ${String(keyName)}`,
+    typeof keyName === 'string' ||
+      typeof keyName === 'symbol' ||
+      (typeof keyName === 'number' && !isNaN(keyName))
   );
   assert(
     `'this' in paths is not supported`,

--- a/packages/@ember/-internals/metal/lib/property_set.ts
+++ b/packages/@ember/-internals/metal/lib/property_set.ts
@@ -61,12 +61,14 @@ export function set(obj: object, keyName: string, value: any, tolerant?: boolean
     arguments.length === 3 || arguments.length === 4
   );
   assert(
-    `Cannot call set with '${keyName}' on an undefined object.`,
+    `Cannot call set with '${String(keyName)}' on an undefined object.`,
     (obj && typeof obj === 'object') || typeof obj === 'function'
   );
   assert(
-    `The key provided to set must be a string or number, you passed ${keyName}`,
-    typeof keyName === 'string' || (typeof keyName === 'number' && !isNaN(keyName))
+    `The key provided to set must be a string, number, or symbol; you passed ${String(keyName)}`,
+    typeof keyName === 'string' ||
+      typeof keyName === 'symbol' ||
+      (typeof keyName === 'number' && !isNaN(keyName))
   );
   assert(
     `'this' in paths is not supported`,
@@ -75,7 +77,9 @@ export function set(obj: object, keyName: string, value: any, tolerant?: boolean
 
   if ((obj as ExtendedObject).isDestroyed) {
     assert(
-      `calling set on destroyed object: ${toString(obj)}.${keyName} = ${toString(value)}`,
+      `calling set on destroyed object: ${toString(obj)}['${toString(keyName)}'] = ${toString(
+        value
+      )}`,
       tolerant
     );
     return;

--- a/packages/@ember/-internals/metal/lib/tags.ts
+++ b/packages/@ember/-internals/metal/lib/tags.ts
@@ -8,7 +8,7 @@ import { assertTagNotConsumed } from './tracked';
 
 export const UNKNOWN_PROPERTY_TAG = symbol('UNKNOWN_PROPERTY_TAG');
 
-export function tagForProperty(object: any, propertyKey: string | symbol, _meta?: Meta): Tag {
+export function tagForProperty(object: any, propertyKey: string | number | symbol, _meta?: Meta): Tag {
   let objectType = typeof object;
   if (objectType !== 'function' && (objectType !== 'object' || object === null)) {
     return CONSTANT_TAG;

--- a/packages/@ember/-internals/metal/tests/accessors/get_test.js
+++ b/packages/@ember/-internals/metal/tests/accessors/get_test.js
@@ -34,6 +34,20 @@ moduleFor(
       assert.equal(get(obj, 1), 'first');
     }
 
+    ['@test should retrieve a symbol from an object'](assert) {
+      if (typeof Symbol === 'undefined') {
+        assert.expect(0);
+        return;
+      }
+
+      let symbol = Symbol();
+      let obj = {
+        [symbol]: 'wheeeee',
+      };
+
+      assert.equal(get(obj, symbol), 'wheeeee');
+    }
+
     ['@test should retrieve an array index'](assert) {
       let arr = ['first', 'second'];
 
@@ -159,19 +173,19 @@ moduleFor(
       let obj = {};
       expectAssertion(
         () => get(obj, null),
-        /The key provided to get must be a string or number, you passed null/
+        /The key provided to get must be a string, number, or symbol; you passed null/
       );
       expectAssertion(
         () => get(obj, NaN),
-        /The key provided to get must be a string or number, you passed NaN/
+        /The key provided to get must be a string, number, or symbol; you passed NaN/
       );
       expectAssertion(
         () => get(obj, undefined),
-        /The key provided to get must be a string or number, you passed undefined/
+        /The key provided to get must be a string, number, or symbol; you passed undefined/
       );
       expectAssertion(
         () => get(obj, false),
-        /The key provided to get must be a string or number, you passed false/
+        /The key provided to get must be a string, number, or symbol; you passed false/
       );
     }
 

--- a/packages/@ember/-internals/metal/tests/accessors/set_test.js
+++ b/packages/@ember/-internals/metal/tests/accessors/set_test.js
@@ -36,6 +36,19 @@ moduleFor(
       assert.equal(obj[1], 'first');
     }
 
+    ['@test should set a symbol key on an object'](assert) {
+      if (typeof Symbol === 'undefined') {
+        assert.expect(0);
+        return;
+      }
+
+      let symbol = Symbol();
+      let obj = {};
+
+      set(obj, symbol, 'first');
+      assert.equal(obj[symbol], 'first');
+    }
+
     ['@test should set an array index'](assert) {
       let arr = ['first', 'second'];
 
@@ -81,19 +94,19 @@ moduleFor(
       let obj = {};
       expectAssertion(
         () => set(obj, null, 42),
-        /The key provided to set must be a string or number, you passed null/
+        /The key provided to set must be a string, number, or symbol; you passed null/
       );
       expectAssertion(
         () => set(obj, NaN, 42),
-        /The key provided to set must be a string or number, you passed NaN/
+        /The key provided to set must be a string, number, or symbol; you passed NaN/
       );
       expectAssertion(
         () => set(obj, undefined, 42),
-        /The key provided to set must be a string or number, you passed undefined/
+        /The key provided to set must be a string, number, or symbol; you passed undefined/
       );
       expectAssertion(
         () => set(obj, false, 42),
-        /The key provided to set must be a string or number, you passed false/
+        /The key provided to set must be a string, number, or symbol; you passed false/
       );
     }
 
@@ -102,7 +115,7 @@ moduleFor(
 
       expectAssertion(
         () => set(obj, 'favoriteFood', 'hot dogs'),
-        'calling set on destroyed object: [object Object].favoriteFood = hot dogs'
+        "calling set on destroyed object: [object Object]['favoriteFood'] = hot dogs"
       );
     }
 

--- a/packages/@ember/-internals/metal/tests/observer_test.js
+++ b/packages/@ember/-internals/metal/tests/observer_test.js
@@ -539,6 +539,37 @@ moduleFor(
       assert.equal(target1.count, 1, 'target1 observer should have fired');
       assert.equal(target2.count, 1, 'target2 observer should have fired');
     }
+
+    async '@test observer should fire when depending on number property that is modified'(assert) {
+      let obj = {};
+      let count = 0;
+
+      addObserver(obj, 42, function() {
+        assert.equal(get(obj, 42), 'bar', 'should invoke AFTER value changed');
+        count++;
+      });
+
+      set(obj, 42, 'bar');
+      await runLoopSettled();
+
+      assert.equal(count, 1, 'should have invoked observer');
+    }
+
+    async '@test observer should fire when depending on symbol property that is modified'(assert) {
+      let obj = {};
+      let count = 0;
+      let foo = Symbol('foo');
+
+      addObserver(obj, foo, function() {
+        assert.equal(get(obj, foo), 'bar', 'should invoke AFTER value changed');
+        count++;
+      });
+
+      set(obj, foo, 'bar');
+      await runLoopSettled();
+
+      assert.equal(count, 1, 'should have invoked observer');
+    }
   }
 );
 
@@ -565,6 +596,54 @@ moduleFor(
       removeObserver(obj, 'foo', F);
 
       set(obj, 'foo', 'baz');
+      await runLoopSettled();
+
+      assert.equal(count, 1, "removed observer shouldn't fire");
+    }
+
+    async '@test removing observer watching number property should stop firing'(assert) {
+      let obj = {};
+      let count = 0;
+      function F() {
+        count++;
+      }
+      addObserver(obj, 42, F);
+
+      set(obj, 42, 'bar');
+      await runLoopSettled();
+
+      assert.equal(count, 1, 'should have invoked observer');
+
+      removeObserver(obj, 42, F);
+
+      set(obj, 42, 'baz');
+      await runLoopSettled();
+
+      assert.equal(count, 1, "removed observer shouldn't fire");
+    }
+
+    async '@test removing observer watching symbol property should stop firing'(assert) {
+      if (typeof Symbol === 'undefined') {
+        assert.expect(0);
+        return;
+      }
+
+      let obj = {};
+      let foo = Symbol('foo');
+      let count = 0;
+      function F() {
+        count++;
+      }
+      addObserver(obj, foo, F);
+
+      set(obj, foo, 'bar');
+      await runLoopSettled();
+
+      assert.equal(count, 1, 'should have invoked observer');
+
+      removeObserver(obj, foo, F);
+
+      set(obj, foo, 'baz');
       await runLoopSettled();
 
       assert.equal(count, 1, "removed observer shouldn't fire");

--- a/packages/@ember/-internals/runtime/tests/system/object/observer_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/observer_test.js
@@ -138,7 +138,7 @@ moduleFor(
 
       expectAssertion(function() {
         set(obj, 'bar', 'BAZ');
-      }, `calling set on destroyed object: ${obj}.bar = BAZ`);
+      }, `calling set on destroyed object: ${obj}['bar'] = BAZ`);
 
       assert.equal(get(obj, 'count'), 0, 'should not invoke observer after change');
     }

--- a/packages/@ember/-internals/utils/lib/lookup-descriptor.ts
+++ b/packages/@ember/-internals/utils/lib/lookup-descriptor.ts
@@ -1,4 +1,4 @@
-export default function lookupDescriptor(obj: object, keyName: string | symbol) {
+export default function lookupDescriptor(obj: object, keyName: string | number | symbol) {
   let current: object | null = obj;
   do {
     let descriptor = Object.getOwnPropertyDescriptor(current, keyName);

--- a/packages/@ember/-internals/utils/lib/mandatory-setter.ts
+++ b/packages/@ember/-internals/utils/lib/mandatory-setter.ts
@@ -3,8 +3,12 @@ import { assert } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 import lookupDescriptor from './lookup-descriptor';
 
-export let setupMandatorySetter: ((obj: object, keyName: string | symbol) => void) | undefined;
-export let teardownMandatorySetter: ((obj: object, keyName: string | symbol) => void) | undefined;
+export let setupMandatorySetter:
+  | ((obj: object, keyName: string | number | symbol) => void)
+  | undefined;
+export let teardownMandatorySetter:
+  | ((obj: object, keyName: string | number | symbol) => void)
+  | undefined;
 export let setWithMandatorySetter:
   | ((obj: object, keyName: string | symbol, value: any) => void)
   | undefined;
@@ -18,11 +22,11 @@ if (DEBUG && EMBER_METAL_TRACKED_PROPERTIES) {
     { [key: string | symbol]: PropertyDescriptorWithMeta }
   > = new WeakMap();
 
-  let propertyIsEnumerable = function(obj: object, key: string | symbol) {
+  let propertyIsEnumerable = function(obj: object, key: string | number | symbol) {
     return Object.prototype.propertyIsEnumerable.call(obj, key);
   };
 
-  setupMandatorySetter = function(obj: object, keyName: string | symbol) {
+  setupMandatorySetter = function(obj: object, keyName: string | number | symbol) {
     let desc = (lookupDescriptor(obj, keyName) as PropertyDescriptorWithMeta) || {};
 
     if (desc.get || desc.set) {
@@ -71,7 +75,7 @@ if (DEBUG && EMBER_METAL_TRACKED_PROPERTIES) {
     });
   };
 
-  teardownMandatorySetter = function(obj: object, keyName: string | symbol) {
+  teardownMandatorySetter = function(obj: object, keyName: string | number | symbol) {
     let setters = MANDATORY_SETTERS.get(obj);
 
     if (setters !== undefined && setters[keyName] !== undefined) {
@@ -81,7 +85,7 @@ if (DEBUG && EMBER_METAL_TRACKED_PROPERTIES) {
     }
   };
 
-  setWithMandatorySetter = function(obj: object, keyName: string | symbol, value: any) {
+  setWithMandatorySetter = function(obj: object, keyName: string | number | symbol, value: any) {
     let setters = MANDATORY_SETTERS.get(obj);
 
     if (setters !== undefined && setters[keyName] !== undefined) {


### PR DESCRIPTION
Previously, this would result in an exception (both `Ember.get` and `Ember.set` expected a string for the key name argument).