### PR TITLE
Move computed property caches into a weak map

### DIFF
--- a/packages/ember-metal/lib/alias.js
+++ b/packages/ember-metal/lib/alias.js
@@ -6,7 +6,7 @@ import {
   Descriptor,
   defineProperty
 } from './properties';
-import { ComputedProperty } from './computed';
+import { ComputedProperty, getCacheFor } from './computed';
 import { meta as metaFor } from './meta';
 import {
   addDependentKeys,
@@ -52,9 +52,9 @@ export class AliasedProperty extends Descriptor {
   get(obj, keyName) {
     let ret = get(obj, this.altKey);
     let meta = metaFor(obj);
-    let cache = meta.writableCache();
-    if (cache[keyName] !== CONSUMED) {
-      cache[keyName] = CONSUMED;
+    let cache = getCacheFor(obj);
+    if (cache.get(keyName) !== CONSUMED) {
+      cache.set(keyName, CONSUMED);
       addDependentKeys(this, obj, keyName, meta);
     }
     return ret;

--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -1,7 +1,7 @@
 import { get } from './property_get';
 import { descriptorFor, meta as metaFor, peekMeta } from './meta';
 import { watchKey, unwatchKey } from './watch_key';
-import { cacheFor } from './computed';
+import { getCachedValueFor } from './computed';
 import { eachProxyFor } from './each_proxy';
 
 const FIRST_KEY = /^([^\.]+)/;
@@ -333,10 +333,7 @@ function lazyGet(obj, key) {
     return get(obj, key);
   // Otherwise attempt to get the cached value of the computed property
   } else {
-    let cache = meta.readableCache();
-    if (cache !== undefined) {
-      return cacheFor.get(cache, key);
-    }
+    return getCachedValueFor(obj, key);
   }
 }
 

--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -2,7 +2,9 @@
 export { default } from './core'; // reexports
 export {
   default as computed,
-  cacheFor,
+  getCacheFor,
+  getCachedValueFor,
+  peekCacheFor,
   ComputedProperty
 } from './computed';
 export { default as alias } from './alias';

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -45,8 +45,6 @@ export class Meta {
       counters.metaInstantiated++;
     }
 
-    this._cache = undefined;
-
     if (EMBER_METAL_ES5_GETTERS) {
       this._descriptors = undefined;
     }
@@ -265,9 +263,6 @@ export class Meta {
       }
     }
   }
-
-  writableCache() { return this._getOrCreateOwnMap('_cache'); }
-  readableCache() { return this._cache; }
 
   writableTags() { return this._getOrCreateOwnMap('_tags'); }
   readableTags() { return this._tags; }

--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -7,6 +7,7 @@ import { HAS_NATIVE_PROXY } from 'ember-utils';
 import { descriptorFor, meta as metaFor, peekMeta, DESCRIPTOR, UNDEFINED } from './meta';
 import { overrideChains } from './property_events';
 import { DESCRIPTOR_TRAP, EMBER_METAL_ES5_GETTERS, MANDATORY_SETTER } from 'ember/features';
+import { peekCacheFor } from './computed';
 // ..........................................................
 // DESCRIPTOR
 //
@@ -338,9 +339,9 @@ export function _hasCachedComputedProperties() {
 
 function didDefineComputedProperty(constructor) {
   if (hasCachedComputedProperties === false) { return; }
-  let cache = metaFor(constructor).readableCache();
 
-  if (cache && cache._computedProperties !== undefined) {
-    cache._computedProperties = undefined;
+  let cache = peekCacheFor(constructor);
+  if (cache !== undefined) {
+    cache.delete('_computedProperties');
   }
 }

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -4,7 +4,7 @@ import { testBoth } from 'internal-test-helpers';
 import {
   ComputedProperty,
   computed,
-  cacheFor,
+  getCachedValueFor,
   Descriptor,
   defineProperty,
   get,
@@ -316,24 +316,24 @@ testBoth('inherited property should not pick up cache', function(get, set, asser
   assert.equal(get(objB, 'foo'), 'bar 2', 'objB third get');
 });
 
-testBoth('cacheFor should return the cached value', function(get, set, assert) {
-  assert.equal(cacheFor(obj, 'foo'), undefined, 'should not yet be a cached value');
+testBoth('getCachedValueFor should return the cached value', function(get, set, assert) {
+  assert.equal(getCachedValueFor(obj, 'foo'), undefined, 'should not yet be a cached value');
 
   get(obj, 'foo');
 
-  assert.equal(cacheFor(obj, 'foo'), 'bar 1', 'should retrieve cached value');
+  assert.equal(getCachedValueFor(obj, 'foo'), 'bar 1', 'should retrieve cached value');
 });
 
-testBoth('cacheFor should return falsy cached values', function(get, set, assert) {
+testBoth('getCachedValueFor should return falsy cached values', function(get, set, assert) {
   defineProperty(obj, 'falsy', computed(function() {
     return false;
   }));
 
-  assert.equal(cacheFor(obj, 'falsy'), undefined, 'should not yet be a cached value');
+  assert.equal(getCachedValueFor(obj, 'falsy'), undefined, 'should not yet be a cached value');
 
   get(obj, 'falsy');
 
-  assert.equal(cacheFor(obj, 'falsy'), false, 'should retrieve cached value');
+  assert.equal(getCachedValueFor(obj, 'falsy'), false, 'should retrieve cached value');
 });
 
 testBoth('setting a cached computed property passes the old value as the third argument', function(get, set, assert) {

--- a/packages/ember-metal/tests/observer_test.js
+++ b/packages/ember-metal/tests/observer_test.js
@@ -6,7 +6,7 @@ import {
   notifyPropertyChange,
   defineProperty,
   computed,
-  cacheFor,
+  getCachedValueFor,
   Mixin,
   mixin,
   observer,
@@ -484,7 +484,7 @@ testBoth('depending on a chain with a computed property', function(get, set, ass
     changed++;
   });
 
-  assert.equal(cacheFor(obj, 'computed'), undefined, 'addObserver should not compute CP');
+  assert.equal(getCachedValueFor(obj, 'computed'), undefined, 'addObserver should not compute CP');
 
   set(obj, 'computed.foo', 'baz');
 

--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -22,7 +22,8 @@ import {
   eachProxyArrayWillChange,
   eachProxyArrayDidChange,
   beginPropertyChanges,
-  endPropertyChanges
+  endPropertyChanges,
+  peekCacheFor
 } from 'ember-metal';
 import { assert, deprecate } from 'ember-debug';
 import Enumerable from './enumerable';
@@ -105,7 +106,7 @@ export function arrayContentDidChange(array, startIdx, removeAmt, addAmt) {
   sendEvent(array, '@array:change', [array, startIdx, removeAmt, addAmt]);
 
   let meta = peekMeta(array);
-  let cache = meta !== undefined ? meta.readableCache() : undefined;
+  let cache = peekCacheFor(array);
   if (cache !== undefined) {
     let length = get(array, 'length');
     let addedAmount = (addAmt === -1 ? 0 : addAmt);
@@ -114,17 +115,17 @@ export function arrayContentDidChange(array, startIdx, removeAmt, addAmt) {
     let previousLength = length - delta;
 
     let normalStartIdx = startIdx < 0 ? previousLength + startIdx : startIdx;
-    if (cache.firstObject !== undefined && normalStartIdx === 0) {
+    if (cache.has('firstObject') && normalStartIdx === 0) {
       notifyPropertyChange(array, 'firstObject', meta);
     }
 
-    if (cache.lastObject !== undefined) {
+    if (cache.has('lastObject')) {
       let previousLastIndex = previousLength - 1;
       let lastAffectedIndex = normalStartIdx + removedAmount;
       if (previousLastIndex < lastAffectedIndex) {
         notifyPropertyChange(array, 'lastObject', meta);
       }
-   }
+    }
   }
 
   return array;

--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -17,7 +17,7 @@ import {
   endPropertyChanges,
   addObserver,
   removeObserver,
-  cacheFor,
+  getCachedValueFor,
   isNone
 } from 'ember-metal';
 import { assert } from 'ember-debug';
@@ -476,6 +476,6 @@ export default Mixin.create({
     @public
   */
   cacheFor(keyName) {
-    return cacheFor(this, keyName);
+    return getCachedValueFor(this, keyName);
   },
 });

--- a/packages/ember/lib/index.js
+++ b/packages/ember/lib/index.js
@@ -40,7 +40,7 @@ const computed = metal.computed;
 computed.alias = metal.alias;
 Ember.computed = computed;
 Ember.ComputedProperty = metal.ComputedProperty;
-Ember.cacheFor = metal.cacheFor;
+Ember.cacheFor = metal.getCachedValueFor;
 
 Ember.assert = EmberDebug.assert;
 Ember.warn = EmberDebug.warn;

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -40,7 +40,7 @@ let allExports =[
   ['computed', 'ember-metal'],
   ['computed.alias', 'ember-metal', 'alias'],
   ['ComputedProperty', 'ember-metal'],
-  ['cacheFor', 'ember-metal'],
+  ['cacheFor', 'ember-metal', 'getCachedValueFor'],
   ['merge', 'ember-metal'],
   ['instrument', 'ember-metal'],
   ['Instrumentation.instrument', 'ember-metal', 'instrument'],


### PR DESCRIPTION
Continuing our effort to make meta smaller...

FYI, the `cacheFor.{get,set,remove}` have never been used in a public add-on so I'm remove them. We weren't even using them internally :)