### PR TITLE
Expose meta counters (privately).

### DIFF
--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -563,6 +563,10 @@ export function meta(obj) {
   return newMeta;
 }
 
+if (DEBUG) {
+  meta._counters = counters;
+}
+
 // Using `symbol()` here causes some node test to fail, presumably
 // because we define the CP with one copy of Ember and boot the app
 // with a different copy, so the random key we generate do not line


### PR DESCRIPTION
Various counters are being tracked around meta usage (how many instantiated, how many prototype walks, etc) but this data is not exposed (even privately) at the moment.

This PR updates `Ember.meta` to tack on `Ember.meta._counters` which exposes the counters object in debug builds only...