### PR TITLE
Remove Ember global usage when testing onError

### DIFF
--- a/packages/ember-testing/lib/index.js
+++ b/packages/ember-testing/lib/index.js
@@ -1,6 +1,5 @@
 export { default as Test } from './test';
 export { default as Adapter } from './adapters/adapter';
-export { setAdapter, getAdapter } from './test/adapter';
 export { default as setupForTesting } from './setup_for_testing';
 export { default as QUnitAdapter } from './adapters/qunit';
 

--- a/packages/ember-testing/lib/index.js
+++ b/packages/ember-testing/lib/index.js
@@ -1,5 +1,6 @@
 export { default as Test } from './test';
 export { default as Adapter } from './adapters/adapter';
+export { setAdapter, getAdapter } from './test/adapter';
 export { default as setupForTesting } from './setup_for_testing';
 export { default as QUnitAdapter } from './adapters/qunit';
 

--- a/packages/ember-testing/tests/adapters_test.js
+++ b/packages/ember-testing/tests/adapters_test.js
@@ -1,13 +1,26 @@
-import { run } from 'ember-metal';
+import { run, setOnerror } from 'ember-metal';
 import Test from '../test';
 import Adapter from '../adapters/adapter';
 import QUnitAdapter from '../adapters/qunit';
 import { Application as EmberApplication } from 'ember-application';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { RSVP } from 'ember-runtime';
 
 var App, originalAdapter, originalQUnit, originalWindowOnerror;
 
-moduleFor('ember-testing Adapters', class extends AbstractTestCase {
+function runThatThrowsSync(message = 'Error for testing error handling') {
+  return run(() => {
+    throw new Error(message);
+  });
+}
+
+function runThatThrowsAsync(message = 'Error for testing error handling') {
+  return run.next(() => {
+    throw new Error(message);
+  });
+}
+
+class AdapterSetupAndTearDown extends AbstractTestCase {
   constructor() {
     super();
     originalAdapter = Test.adapter;
@@ -25,8 +38,11 @@ moduleFor('ember-testing Adapters', class extends AbstractTestCase {
     Test.adapter = originalAdapter;
     window.QUnit = originalQUnit;
     window.onerror = originalWindowOnerror;
+    setOnerror(undefined);
   }
+}
 
+moduleFor('ember-testing Adapters', class extends AdapterSetupAndTearDown {
   ['@test Setting a test adapter manually'](assert) {
     assert.expect(1);
     var CustomAdapter;
@@ -94,4 +110,228 @@ moduleFor('ember-testing Adapters', class extends AbstractTestCase {
     assert.equal(caughtInAdapter, undefined, 'test adapter should never receive synchronous errors');
     assert.equal(caughtInCatch, thrown, 'a "normal" try/catch should catch errors in sync run');
   }
+
+  ['@test when both Ember.onerror (which rethrows) and TestAdapter are registered - sync run'](assert) {
+    assert.expect(2);
+
+    Test.adapter = {
+      exception() {
+        assert.notOk(true, 'adapter is not called for errors thrown in sync run loops');
+      }
+    };
+
+    setOnerror(function(error) {
+      assert.ok(true, 'onerror is called for sync errors even if TestAdapter is setup');
+      throw error;
+    });
+
+    assert.throws(runThatThrowsSync, Error, 'error is thrown');
+  }
+
+  ['@test when both Ember.onerror (which does not rethrow) and TestAdapter are registered - sync run'](assert) {
+    assert.expect(2);
+
+    Test.adapter = {
+      exception() {
+        assert.notOk(true, 'adapter is not called for errors thrown in sync run loops');
+      }
+    };
+
+    setOnerror(function() {
+      assert.ok(true, 'onerror is called for sync errors even if TestAdapter is setup');
+    });
+
+    runThatThrowsSync();
+    assert.ok(true, 'no error was thrown, Ember.onerror can intercept errors');
+  }
+
+  ['@test when TestAdapter is registered and error is thrown - async run'](assert) {
+    assert.expect(3);
+    let done = assert.async();
+
+    let caughtInAdapter, caughtInCatch, caughtByWindowOnerror;
+    Test.adapter = {
+      exception(error) {
+        caughtInAdapter = error;
+      }
+    };
+
+    window.onerror = function(message) {
+      caughtByWindowOnerror = message;
+      // prevent "bubbling" and therefore failing the test
+      return true;
+    };
+
+    try {
+      runThatThrowsAsync();
+    } catch(e) {
+      caughtInCatch = e;
+    }
+
+    setTimeout(() => {
+      assert.equal(caughtInAdapter, undefined, 'test adapter should never catch errors in run loops');
+      assert.equal(caughtInCatch, undefined, 'a "normal" try/catch should never catch errors in an async run');
+
+      assert.pushResult({
+        result: /Error for testing error handling/.test(caughtByWindowOnerror),
+        actual: caughtByWindowOnerror,
+        expected: 'to include `Error for testing error handling`',
+        message: 'error should bubble out to window.onerror, and therefore fail tests (due to QUnit implementing window.onerror)'
+      });
+
+      done();
+    }, 20);
+  }
+
+  ['@test when both Ember.onerror and TestAdapter are registered - async run'](assert) {
+    assert.expect(1);
+    let done = assert.async();
+
+    Test.adapter ={
+      exception() {
+        assert.notOk(true, 'Adapter.exception is not called for errors thrown in run.next');
+      }
+    };
+
+    setOnerror(function() {
+      assert.ok(true, 'onerror is invoked for errors thrown in run.next/run.later');
+    });
+
+    runThatThrowsAsync();
+    setTimeout(done, 10);
+  }
 });
+
+
+function testAdapter(message, generatePromise, timeout = 10) {
+  return class PromiseFailureTests extends AdapterSetupAndTearDown {
+    [`@test ${message} when TestAdapter without \`exception\` method is present - rsvp`](assert) {
+      assert.expect(1);
+
+      let thrown = new Error('the error');
+      Test.adapter = QUnitAdapter.create({
+        exception: undefined
+      });
+
+      window.onerror = function(message) {
+        assert.pushResult({
+          result: /the error/.test(message),
+          actual: message,
+          expected: 'to include `the error`',
+          message: 'error should bubble out to window.onerror, and therefore fail tests (due to QUnit implementing window.onerror)'
+        });
+
+        // prevent "bubbling" and therefore failing the test
+        return true;
+      };
+
+      generatePromise(thrown);
+
+      // RSVP.Promise's are configured to settle within the run loop, this
+      // ensures that run loop has completed
+      return new RSVP.Promise((resolve) => setTimeout(resolve, timeout));
+    }
+
+    [`@test ${message} when both Ember.onerror and TestAdapter without \`exception\` method are present - rsvp`](assert) {
+      assert.expect(1);
+
+      let thrown = new Error('the error');
+      Test.adapter = QUnitAdapter.create({
+        exception: undefined
+      });
+
+      setOnerror(function(error) {
+        assert.pushResult({
+          result: /the error/.test(error.message),
+          actual: error.message,
+          expected: 'to include `the error`',
+          message: 'error should bubble out to window.onerror, and therefore fail tests (due to QUnit implementing window.onerror)'
+        });
+      });
+
+      generatePromise(thrown);
+
+      // RSVP.Promise's are configured to settle within the run loop, this
+      // ensures that run loop has completed
+      return new RSVP.Promise((resolve) => setTimeout(resolve, timeout));
+    }
+
+    [`@test ${message} when TestAdapter is present - rsvp`](assert) {
+      assert.expect(1);
+
+      let thrown = new Error('the error');
+      Test.adapter = QUnitAdapter.create({
+        exception(error) {
+          assert.strictEqual(error, thrown, 'Adapter.exception is called for errors thrown in RSVP promises');
+        }
+      });
+
+      generatePromise(thrown);
+
+      // RSVP.Promise's are configured to settle within the run loop, this
+      // ensures that run loop has completed
+      return new RSVP.Promise((resolve) => setTimeout(resolve, timeout));
+    }
+
+    [`@test ${message} when both Ember.onerror and TestAdapter are present - rsvp`](assert) {
+      assert.expect(1);
+
+      let thrown = new Error('the error');
+      Test.adapter = QUnitAdapter.create({
+        exception(error) {
+          assert.strictEqual(error, thrown, 'Adapter.exception is called for errors thrown in RSVP promises');
+        }
+      });
+
+      setOnerror(function() {
+        assert.notOk(true, 'Ember.onerror is not called if Test.adapter does not rethrow');
+      });
+
+      generatePromise(thrown);
+
+      // RSVP.Promise's are configured to settle within the run loop, this
+      // ensures that run loop has completed
+      return new RSVP.Promise((resolve) => setTimeout(resolve, timeout));
+    }
+
+    [`@test ${message} when both Ember.onerror and TestAdapter are present - rsvp`](assert) {
+      assert.expect(2);
+
+      let thrown = new Error('the error');
+      Test.adapter = QUnitAdapter.create({
+        exception(error) {
+          assert.strictEqual(error, thrown, 'Adapter.exception is called for errors thrown in RSVP promises');
+          throw error;
+        }
+      });
+
+      setOnerror(function(error) {
+        assert.strictEqual(error, thrown, 'Ember.onerror is called for errors thrown in RSVP promises if Test.adapter rethrows');
+      });
+
+      generatePromise(thrown);
+
+      // RSVP.Promise's are configured to settle within the run loop, this
+      // ensures that run loop has completed
+      return new RSVP.Promise((resolve) => setTimeout(resolve, timeout));
+    }
+  };
+}
+
+moduleFor('Adapter Errors: .then callback', testAdapter('errors in promise constructor', (error) => {
+  new RSVP.Promise(() => {
+    throw error;
+  });
+}));
+
+moduleFor('Adapter Errors: Promise Contructor', testAdapter('errors in promise constructor', (error) => {
+  RSVP.resolve().then(() => {
+    throw error;
+  });
+}));
+
+moduleFor('Adapter Errors: Promise chain .then callback', testAdapter('errors in promise constructor', (error) => {
+  new RSVP.Promise((resolve) => setTimeout(resolve, 10)).then(() => {
+    throw error;
+  });
+}, 20));

--- a/packages/ember/tests/error_handler_test.js
+++ b/packages/ember/tests/error_handler_test.js
@@ -1,21 +1,12 @@
 import { isTesting, setTesting } from 'ember-debug';
 import { run, getOnerror, setOnerror } from 'ember-metal';
-import { DEBUG } from 'ember-env-flags';
 import RSVP from 'rsvp';
-import require, { has } from 'require';
 
 let WINDOW_ONERROR;
 
-let setAdapter;
-let QUnitAdapter;
 
 QUnit.module('error_handler', {
   beforeEach() {
-    if (has('ember-testing')) {
-      let testing = require('ember-testing');
-      setAdapter = testing.setAdapter;
-      QUnitAdapter = testing.QUnitAdapter;
-    }
     // capturing this outside of module scope to ensure we grab
     // the test frameworks own window.onerror to reset it
     WINDOW_ONERROR = window.onerror;
@@ -25,23 +16,12 @@ QUnit.module('error_handler', {
     setTesting(isTesting);
     window.onerror = WINDOW_ONERROR;
 
-    if (setAdapter) {
-      setAdapter();
-    }
-
     setOnerror(undefined);
-
   }
 });
 
 function runThatThrowsSync(message = 'Error for testing error handling') {
   return run(() => {
-    throw new Error(message);
-  });
-}
-
-function runThatThrowsAsync(message = 'Error for testing error handling') {
-  return run.next(() => {
     throw new Error(message);
   });
 }
@@ -68,110 +48,6 @@ QUnit.test('when Ember.onerror (which does not rethrow) is registered - sync run
   runThatThrowsSync();
   assert.ok(true, 'no error was thrown, Ember.onerror can intercept errors');
 });
-
-if (DEBUG) {
-  QUnit.test('when TestAdapter is registered and error is thrown - sync run', function(assert) {
-    assert.expect(1);
-
-    setAdapter({
-      exception() {
-        assert.notOk(true, 'adapter is not called for errors thrown in sync run loops');
-      }
-    });
-
-    assert.throws(runThatThrowsSync, Error);
-  });
-
-  QUnit.test('when both Ember.onerror (which rethrows) and TestAdapter are registered - sync run', function(assert) {
-    assert.expect(2);
-
-    setAdapter({
-      exception() {
-        assert.notOk(true, 'adapter is not called for errors thrown in sync run loops');
-      }
-    });
-
-    setOnerror(function(error) {
-      assert.ok(true, 'onerror is called for sync errors even if TestAdapter is setup');
-      throw error;
-    });
-
-    assert.throws(runThatThrowsSync, Error, 'error is thrown');
-  });
-
-  QUnit.test('when both Ember.onerror (which does not rethrow) and TestAdapter are registered - sync run', function(assert) {
-    assert.expect(2);
-
-    setAdapter({
-      exception() {
-        assert.notOk(true, 'adapter is not called for errors thrown in sync run loops');
-      }
-    });
-
-    setOnerror(function() {
-      assert.ok(true, 'onerror is called for sync errors even if TestAdapter is setup');
-    });
-
-    runThatThrowsSync();
-    assert.ok(true, 'no error was thrown, Ember.onerror can intercept errors');
-  });
-
-  QUnit.test('when TestAdapter is registered and error is thrown - async run', function(assert) {
-    assert.expect(3);
-    let done = assert.async();
-
-    let caughtInAdapter, caughtInCatch, caughtByWindowOnerror;
-    setAdapter({
-      exception(error) {
-        caughtInAdapter = error;
-      }
-    });
-
-    window.onerror = function(message) {
-      caughtByWindowOnerror = message;
-      // prevent "bubbling" and therefore failing the test
-      return true;
-    };
-
-    try {
-      runThatThrowsAsync();
-    } catch(e) {
-      caughtInCatch = e;
-    }
-
-    setTimeout(() => {
-      assert.equal(caughtInAdapter, undefined, 'test adapter should never catch errors in run loops');
-      assert.equal(caughtInCatch, undefined, 'a "normal" try/catch should never catch errors in an async run');
-
-      assert.pushResult({
-        result: /Error for testing error handling/.test(caughtByWindowOnerror),
-        actual: caughtByWindowOnerror,
-        expected: 'to include `Error for testing error handling`',
-        message: 'error should bubble out to window.onerror, and therefore fail tests (due to QUnit implementing window.onerror)'
-      });
-
-      done();
-    }, 20);
-  });
-
-  QUnit.test('when both Ember.onerror and TestAdapter are registered - async run', function(assert) {
-    assert.expect(1);
-    let done = assert.async();
-
-    setAdapter({
-      exception() {
-        assert.notOk(true, 'Adapter.exception is not called for errors thrown in run.next');
-      }
-    });
-
-    setOnerror(function() {
-      assert.ok(true, 'onerror is invoked for errors thrown in run.next/run.later');
-    });
-
-    runThatThrowsAsync();
-    setTimeout(done, 10);
-  });
-}
 
 QUnit.test('does not swallow exceptions by default (Ember.testing = true, no Ember.onerror) - sync run', function(assert) {
   setTesting(true);
@@ -397,119 +273,6 @@ function generateRSVPErrorHandlingTests(message, generatePromise, timeout = 10) 
     // ensures that run loop has completed
     return new RSVP.Promise((resolve) => setTimeout(resolve, timeout));
   });
-
-  if (DEBUG) {
-    QUnit.test(`${message} when TestAdapter without \`exception\` method is present - rsvp`, function(assert) {
-      assert.expect(1);
-
-      let thrown = new Error('the error');
-      setAdapter(QUnitAdapter.create({
-        exception: undefined
-      }));
-
-      window.onerror = function(message) {
-        assert.pushResult({
-          result: /the error/.test(message),
-          actual: message,
-          expected: 'to include `the error`',
-          message: 'error should bubble out to window.onerror, and therefore fail tests (due to QUnit implementing window.onerror)'
-        });
-
-        // prevent "bubbling" and therefore failing the test
-        return true;
-      };
-
-      generatePromise(thrown);
-
-      // RSVP.Promise's are configured to settle within the run loop, this
-      // ensures that run loop has completed
-      return new RSVP.Promise((resolve) => setTimeout(resolve, timeout));
-    });
-
-    QUnit.test(`${message} when both Ember.onerror and TestAdapter without \`exception\` method are present - rsvp`, function(assert) {
-      assert.expect(1);
-
-      let thrown = new Error('the error');
-      setAdapter(QUnitAdapter.create({
-        exception: undefined
-      }));
-
-      setOnerror(function(error) {
-        assert.pushResult({
-          result: /the error/.test(error.message),
-          actual: error.message,
-          expected: 'to include `the error`',
-          message: 'error should bubble out to window.onerror, and therefore fail tests (due to QUnit implementing window.onerror)'
-        });
-      });
-
-      generatePromise(thrown);
-
-      // RSVP.Promise's are configured to settle within the run loop, this
-      // ensures that run loop has completed
-      return new RSVP.Promise((resolve) => setTimeout(resolve, timeout));
-    });
-
-    QUnit.test(`${message} when TestAdapter is present - rsvp`, function(assert) {
-      assert.expect(1);
-
-      let thrown = new Error('the error');
-      setAdapter(QUnitAdapter.create({
-        exception(error) {
-          assert.strictEqual(error, thrown, 'Adapter.exception is called for errors thrown in RSVP promises');
-        }
-      }));
-
-      generatePromise(thrown);
-
-      // RSVP.Promise's are configured to settle within the run loop, this
-      // ensures that run loop has completed
-      return new RSVP.Promise((resolve) => setTimeout(resolve, timeout));
-    });
-
-    QUnit.test(`${message} when both Ember.onerror and TestAdapter are present - rsvp`, function(assert) {
-      assert.expect(1);
-
-      let thrown = new Error('the error');
-      setAdapter(QUnitAdapter.create({
-        exception(error) {
-          assert.strictEqual(error, thrown, 'Adapter.exception is called for errors thrown in RSVP promises');
-        }
-      }));
-
-      setOnerror(function() {
-        assert.notOk(true, 'Ember.onerror is not called if Test.adapter does not rethrow');
-      });
-
-      generatePromise(thrown);
-
-      // RSVP.Promise's are configured to settle within the run loop, this
-      // ensures that run loop has completed
-      return new RSVP.Promise((resolve) => setTimeout(resolve, timeout));
-    });
-
-    QUnit.test(`${message} when both Ember.onerror and TestAdapter are present - rsvp`, function(assert) {
-      assert.expect(2);
-
-      let thrown = new Error('the error');
-      setAdapter(QUnitAdapter.create({
-        exception(error) {
-          assert.strictEqual(error, thrown, 'Adapter.exception is called for errors thrown in RSVP promises');
-          throw error;
-        }
-      }));
-
-      setOnerror(function(error) {
-        assert.strictEqual(error, thrown, 'Ember.onerror is called for errors thrown in RSVP promises if Test.adapter rethrows');
-      });
-
-      generatePromise(thrown);
-
-      // RSVP.Promise's are configured to settle within the run loop, this
-      // ensures that run loop has completed
-      return new RSVP.Promise((resolve) => setTimeout(resolve, timeout));
-    });
-  }
 }
 
 generateRSVPErrorHandlingTests('errors in promise constructor', (error) => {


### PR DESCRIPTION
This removes the `Ember` global from the error handling tests. All the places where we are assigning on to the global and testing, are actually going through accessor functions exposed by a module. These functions are just called via a getter and/or setter on a property descriptor of the Ember global. 