### PR TITLE
Remove Ember global in NameSpace

### DIFF
--- a/packages/ember-extension-support/lib/container_debug_adapter.js
+++ b/packages/ember-extension-support/lib/container_debug_adapter.js
@@ -1,4 +1,3 @@
-import Ember from 'ember-metal'; // Ember as namespace
 import {
   A as emberA,
   typeOf,
@@ -88,7 +87,7 @@ export default EmberObject.extend({
     let typeSuffixRegex = new RegExp(`${StringUtils.classify(type)}$`);
 
     namespaces.forEach(namespace => {
-      if (namespace !== Ember) {
+      if (namespace.toString() !== 'Ember') {
         for (let key in namespace) {
           if (!namespace.hasOwnProperty(key)) { continue; }
           if (typeSuffixRegex.test(key)) {

--- a/packages/ember-extension-support/lib/container_debug_adapter.js
+++ b/packages/ember-extension-support/lib/container_debug_adapter.js
@@ -87,14 +87,12 @@ export default EmberObject.extend({
     let typeSuffixRegex = new RegExp(`${StringUtils.classify(type)}$`);
 
     namespaces.forEach(namespace => {
-      if (namespace.toString() !== 'Ember') {
-        for (let key in namespace) {
-          if (!namespace.hasOwnProperty(key)) { continue; }
-          if (typeSuffixRegex.test(key)) {
-            let klass = namespace[key];
-            if (typeOf(klass) === 'class') {
-              types.push(StringUtils.dasherize(key.replace(typeSuffixRegex, '')));
-            }
+      for (let key in namespace) {
+        if (!namespace.hasOwnProperty(key)) { continue; }
+        if (typeSuffixRegex.test(key)) {
+          let klass = namespace[key];
+          if (typeOf(klass) === 'class') {
+            types.push(StringUtils.dasherize(key.replace(typeSuffixRegex, '')));
           }
         }
       }

--- a/packages/ember-runtime/lib/system/namespace.js
+++ b/packages/ember-runtime/lib/system/namespace.js
@@ -2,7 +2,7 @@
 @module ember
 */
 import { guidFor } from 'ember-utils';
-import Ember, {
+import {
   get,
   Mixin,
   hasUnprocessedMixins,
@@ -74,10 +74,8 @@ const Namespace = EmberObject.extend({
 });
 
 Namespace.reopenClass({
-  NAMESPACES: [Ember],
-  NAMESPACES_BY_ID: {
-    Ember
-  },
+  NAMESPACES: [],
+  NAMESPACES_BY_ID: {},
   PROCESSED: false,
   processAll: processAllNamespaces,
   byName(name) {


### PR DESCRIPTION
This removes the Ember Global from NameSpace. NameSpace as a concept can likely go away but does require a deprecation guide.