### PR TITLE
Allow visit to specify Rehydration/Serialization or default ClientBuilder

### DIFF
--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -340,7 +340,7 @@ class BootOptions {
       @type boolean
       @default auto-detected
       @private
-      */
+    */
     this.isInteractive = environment.hasDOM; // This default is overridable below
 
 

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -340,8 +340,17 @@ class BootOptions {
       @type boolean
       @default auto-detected
       @private
-    */
+      */
     this.isInteractive = environment.hasDOM; // This default is overridable below
+
+
+    /**
+      @property _renderMode
+      @type string
+      @default false
+      @private
+    */
+    this._renderMode = options._renderMode;
 
     /**
       Run in a full browser environment.
@@ -482,6 +491,7 @@ class BootOptions {
     // For compatibility with existing code
     env.hasDOM = this.isBrowser;
     env.isInteractive = this.isInteractive;
+    env._renderMode = this._renderMode;
     env.options = this;
     return env;
   }

--- a/packages/ember-application/tests/system/visit_test.js
+++ b/packages/ember-application/tests/system/visit_test.js
@@ -53,7 +53,7 @@ moduleFor('Application - visit()', class extends ApplicationTestCase {
     });
   }
 
-  [`@test renderMode: rehydrate`](assert) {
+  [`@test _renderMode: rehydrate`](assert) {
 
     let initialHTML = `<!--%+block:0%--><!--%+block:1%--><!--%+block:2%--><!--%+block:3%--><!--%+block:4%--><!--%+block:5%--><!--%+block:6%--><div class=\"foo\">Hi, Mom!</div><!--%-block:6%--><!--%-block:5%--><!--%-block:4%--><!--%-block:3%--><!--%-block:2%--><!--%-block:1%--><!--%-block:0%-->`;
 
@@ -64,7 +64,7 @@ moduleFor('Application - visit()', class extends ApplicationTestCase {
     let bootOptions = {
       isBrowser: false,
       rootElement,
-      renderMode: 'rehydrate'
+      _renderMode: 'rehydrate'
     };
 
     ENV._APPLICATION_TEMPLATE_WRAPPER = false;
@@ -75,14 +75,14 @@ moduleFor('Application - visit()', class extends ApplicationTestCase {
     });
   }
 
-  [`@test renderMode: serialize`](assert) {
+  [`@test _renderMode: serialize`](assert) {
     this.addTemplate('index', '<div class="foo">Hi, Mom!</div>');
     let rootElement = document.createElement('div');
 
     let bootOptions = {
       isBrowser: false,
       rootElement,
-      renderMode: 'serialize'
+      _renderMode: 'serialize'
     };
 
     ENV._APPLICATION_TEMPLATE_WRAPPER = false;

--- a/packages/ember-application/tests/system/visit_test.js
+++ b/packages/ember-application/tests/system/visit_test.js
@@ -86,6 +86,7 @@ moduleFor('Application - visit()', class extends ApplicationTestCase {
           rootElement,
           _renderMode: 'rehydrate'
         };
+
         this.application.visit('/', bootOptions).then(instance => {
           assert.equal(
             instance.rootElement.innerHTML,

--- a/packages/ember-application/tests/system/visit_test.js
+++ b/packages/ember-application/tests/system/visit_test.js
@@ -68,34 +68,32 @@ moduleFor('Application - visit()', class extends ApplicationTestCase {
 
     ENV._APPLICATION_TEMPLATE_WRAPPER = false;
 
-    return this.runTask(() => {
-      return this.visit('/', bootOptions)
-        .then((instance) => {
+    return this.visit('/', bootOptions)
+      .then((instance) => {
+        assert.equal(
+          instance.rootElement.firstChild.nodeValue,
+          '%+b:0%',
+          'glimmer-vm comment node was not found'
+        );
+      }).then(() =>{
+        return this.runTask(()=>{
+          this.applicationInstance.destroy();
+          this.applicationInstance = null;
+        });
+      }).then(() => {
+        bootOptions = {
+          isBrowser: false,
+          rootElement,
+          _renderMode: 'rehydrate'
+        };
+        this.application.visit('/', bootOptions).then(instance => {
           assert.equal(
-            instance.rootElement.firstChild.nodeValue,
-            '%+b:0%',
-            'glimmer-vm comment node was not found'
+            instance.rootElement.innerHTML,
+            indexTemplate,
+            'was not properly rehydrated'
           );
         });
-    }).then(() =>{
-      return this.runTask(()=>{
-        this.applicationInstance.destroy();
-        this.applicationInstance = null;
       });
-    }).then(() => {
-      bootOptions = {
-        isBrowser: false,
-        rootElement,
-        _renderMode: 'rehydrate'
-      };
-      this.application.visit('/', bootOptions).then(instance => {
-        assert.equal(
-          instance.rootElement.innerHTML,
-          indexTemplate,
-          'was not properly rehydrated'
-        );
-      });
-    });
   }
 
   // This tests whether the application is "autobooted" by registering an

--- a/packages/ember-application/tests/system/visit_test.js
+++ b/packages/ember-application/tests/system/visit_test.js
@@ -55,7 +55,7 @@ moduleFor('Application - visit()', class extends ApplicationTestCase {
 
   [`@test _renderMode: rehydrate`](assert) {
 
-    let initialHTML = `<!--%+block:0%--><!--%+block:1%--><!--%+block:2%--><!--%+block:3%--><!--%+block:4%--><!--%+block:5%--><!--%+block:6%--><div class=\"foo\">Hi, Mom!</div><!--%-block:6%--><!--%-block:5%--><!--%-block:4%--><!--%-block:3%--><!--%-block:2%--><!--%-block:1%--><!--%-block:0%-->`;
+    let initialHTML = `<!--%+b:0%--><!--%+b:1%--><!--%+b:2%--><!--%+b:3%--><!--%+b:4%--><!--%+b:5%--><!--%+b:6%--><div class=\"foo\">Hi, Mom!</div><!--%-b:6%--><!--%-b:5%--><!--%-b:4%--><!--%-b:3%--><!--%-b:2%--><!--%-b:1%--><!--%-b:0%-->`;
 
     this.addTemplate('index', '<div class="foo">Hi, Mom!</div>');
     let rootElement = document.createElement('div');
@@ -89,7 +89,7 @@ moduleFor('Application - visit()', class extends ApplicationTestCase {
     return this.visit('/', bootOptions).then(()=> {
       // The exact contents of this may change when the underlying
       // implementation changes in the glimmer vm
-      let expectedTemplate = `<!--%+block:0%--><!--%+block:1%--><!--%+block:2%--><!--%+block:3%--><!--%+block:4%--><!--%+block:5%--><!--%+block:6%--><div class=\"foo\">Hi, Mom!</div><!--%-block:6%--><!--%-block:5%--><!--%-block:4%--><!--%-block:3%--><!--%-block:2%--><!--%-block:1%--><!--%-block:0%-->`;
+      let expectedTemplate = `<!--%+b:0%--><!--%+b:1%--><!--%+b:2%--><!--%+b:3%--><!--%+b:4%--><!--%+b:5%--><!--%+b:6%--><div class=\"foo\">Hi, Mom!</div><!--%-b:6%--><!--%-b:5%--><!--%-b:4%--><!--%-b:3%--><!--%-b:2%--><!--%-b:1%--><!--%-b:0%-->`;
       assert.equal(rootElement.innerHTML, expectedTemplate, 'precond - without serialize flag renders as expected');
     });
   }

--- a/packages/ember-glimmer/lib/dom.ts
+++ b/packages/ember-glimmer/lib/dom.ts
@@ -1,3 +1,11 @@
 ///<reference path="./simple-dom.d.ts" />
-export { DOMChanges, DOMTreeConstruction } from '@glimmer/runtime';
-export { NodeDOMTreeConstruction } from '@glimmer/node';
+export {
+  DOMChanges,
+  DOMTreeConstruction,
+  clientBuilder,
+  rehydrationBuilder
+} from '@glimmer/runtime';
+export {
+  NodeDOMTreeConstruction,
+  serializeBuilder
+} from '@glimmer/node';

--- a/packages/ember-glimmer/lib/renderer.ts
+++ b/packages/ember-glimmer/lib/renderer.ts
@@ -105,7 +105,7 @@ class RootState {
         env,
         self,
         dynamicScope,
-        builder: builder(env, { element: parentElement, nextSibling: null}),
+        builder(env, { element: parentElement, nextSibling: null }),
         handle
       );
       let iteratorResult: IteratorResult<RenderResult>;

--- a/packages/ember-glimmer/lib/setup-registry.ts
+++ b/packages/ember-glimmer/lib/setup-registry.ts
@@ -6,9 +6,12 @@ import LinkToComponent from './components/link-to';
 import TextArea from './components/text_area';
 import TextField from './components/text_field';
 import {
+  clientBuilder,
   DOMChanges,
   DOMTreeConstruction,
   NodeDOMTreeConstruction,
+  rehydrationBuilder,
+  serializeBuilder,
 } from './dom';
 import Environment from './environment';
 import loc from './helpers/loc';
@@ -28,6 +31,20 @@ interface Registry {
 export function setupApplicationRegistry(registry: Registry) {
   registry.injection('service:-glimmer-environment', 'appendOperations', 'service:-dom-tree-construction');
   registry.injection('renderer', 'env', 'service:-glimmer-environment');
+
+  registry.register('service:-dom-builder', {
+    create({ bootOptions }: { bootOptions: { renderMode: string } }) {
+      let { renderMode } = bootOptions;
+
+      switch(renderMode) {
+        case 'serialize': return serializeBuilder;
+        case 'rehydrate': return rehydrationBuilder;
+        default: return clientBuilder;
+      }
+    }
+  });
+  registry.injection('service:-dom-builder', 'bootOptions', '-environment:main');
+  registry.injection('renderer', 'builder', 'service:-dom-builder');
 
   registry.register(P`template:-root`, RootTemplate);
   registry.injection('renderer', 'rootTemplate', P`template:-root`);

--- a/packages/ember-glimmer/lib/setup-registry.ts
+++ b/packages/ember-glimmer/lib/setup-registry.ts
@@ -33,10 +33,10 @@ export function setupApplicationRegistry(registry: Registry) {
   registry.injection('renderer', 'env', 'service:-glimmer-environment');
 
   registry.register('service:-dom-builder', {
-    create({ bootOptions }: { bootOptions: { renderMode: string } }) {
-      let { renderMode } = bootOptions;
+    create({ bootOptions }: { bootOptions: { _renderMode: string } }) {
+      let { _renderMode } = bootOptions;
 
-      switch(renderMode) {
+      switch(_renderMode) {
         case 'serialize': return serializeBuilder;
         case 'rehydrate': return rehydrationBuilder;
         default: return clientBuilder;


### PR DESCRIPTION
Expose as a configurable option the `renderMode` option.  This option
would be to specify the clientBuilder to be used when Glimmer does it's
append run.

The serialization mode, used by SSR applications, is used to specify
additional markings necessary to get enough fidelity to accurately
rehydrate the DOM.  For example, it would provide additional comment
nodes with codes to ensure text nodes are separated when they are rather
than merged.

The rehydration mode is specifically designed to read DOM that is
produced by the serialization mode and accurately reproduce it.

A great description of how Rehydration works can be found in this
commit:

https://github.com/glimmerjs/glimmer-vm/commit/316805b9175e01698120b9566ec51c88d075026a

This PR allows the appropriate ElementBuilder interface to be used via
the `visit` API.

---

**Current plan:**

This is part of an arching plan to introduce Glimmer's
rehydration/serializtion modes to Ember proper.

There are 4 PR's that are all interwoven, of which, this is one.

- [x] Glimmer.js: glimmerjs/glimmer-vm#783 (comment)
- [x] Ember.js: emberjs/ember.js#16227
- [x] Fastboot: ember-fastboot/fastboot#185
- [ ] EmberCLI Fastboot: ember-fastboot/ember-cli-fastboot#580

In order of need to land they are:

Glimmer.js:
glimmerjs/glimmer-vm#783 (comment)

This resolves a rather intimate API problem. Glimmer-vm expects a very
specific comment node to exist to know whether or not the rehydration
element builder can do it's job properly. If it is not found on the
first node from rootElement it throws.

In fastboot however we are certain that there will already be existant
elements in the way that will happen before rendered content.

This PR just iterates through the nodes until it finds the expected
comment node. And only throws if it never finds one.

Ember.js:
emberjs/ember.js#16227

This PR modifies the visit API to allow a private _renderMode to be
set to either serialize or rehydrate. In SSR environments the
assumption (as it is here in this fastboot PR) is that we'll set the
visit API to serialize mode which ensures glimmer-vm's serialize element
builder is used to build the API.

The serialize element builder ensures that we have the necessary fidelty
to rehydrate correctly and is mandatory input for rehydration.

Fastboot:
ember-fastboot/fastboot#185

This allows enviroment variable to set _renderMode to be used in Visit
API. Fastboot must send content to browser made with the serialization
element builder to ensure rehydration can be sucessful.

EmberCLI Fastboot:
ember-fastboot/ember-cli-fastboot#580

Finally this does the fun part of disabling the current
clear-double-render instance-initializer

We first check to ensure we are in a non-fastboot environment. Then we
ensure that we can find the expected comment node from glimmer-vm's
serialize element builder. This ensures that this change will only
effect peoeple who use ember-cli-fastboot with the serialized output
from the currently experimental fastboot setup

Then we ensure ApplicationInstance#_bootSync specifies the rehydrate
_renderMode.

This is done in _bootSync this way because visit is currently not used
to boot ember applications. And we must instead set bootOptions this
way instead.

We also remove the markings for fastboot-body-start and
fastboot-body-end to ensure clear-double render instance-initializer
is never called.
