### PR TITLE
Update semver regex to support uppercase branches

### DIFF
--- a/packages/ember-metal/tests/main_test.js
+++ b/packages/ember-metal/tests/main_test.js
@@ -1,7 +1,7 @@
 import Ember from '..'; // testing reexports
 
-// From sindresourhus/semver-regex https://github.com/sindresorhus/semver-regex/blob/795b05628d96597ebcbe6d31ef4a432858365582/index.js#L3
-const SEMVER_REGEX = /^\bv?(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?:\+[\da-z\-]+(?:\.[\da-z\-]+)*)?\b$/;
+// From https://github.com/semver/semver.org/issues/59 & https://regex101.com/r/vW1jA8/6
+const SEMVER_REGEX = /^((?:0|(?:[1-9]\d*)))\.((?:0|(?:[1-9]\d*)))\.((?:0|(?:[1-9]\d*)))(?:-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$/;
 
 QUnit.module('ember-metal/core/main');
 
@@ -26,6 +26,7 @@ QUnit.test('SEMVER_REGEX properly validates and invalidates version numbers', fu
   validateVersionString('1.0.0-beta.16.1', true);
   validateVersionString('1.12.1+canary.aba1412', true);
   validateVersionString('2.0.0-beta.1+canary.bb344775', true);
+  validateVersionString('3.1.0-foobarBaz+30d70bd3', true);
 
   // Negative test cases
   validateVersionString('1.11.3.aba18a', false);


### PR DESCRIPTION
Having an uppercase character within your git branch name would cause the regex to fail. Ember.VERSION would become something like `3.1.0-foobarBaz+30d70bd3` and would fail. Updating the regex to support this use case.