### PR TITLE
[doc beta] add ember module to namespaced classes so "Ember" doesn't show

### DIFF
--- a/packages/ember-runtime/lib/inject.js
+++ b/packages/ember-runtime/lib/inject.js
@@ -1,6 +1,8 @@
 import { InjectedProperty, descriptorFor } from 'ember-metal';
 import { assert } from 'ember-debug';
-
+/**
+@module ember
+*/
 /**
   Namespace for injection helper methods.
 

--- a/packages/ember-testing/lib/setup_for_testing.js
+++ b/packages/ember-testing/lib/setup_for_testing.js
@@ -12,7 +12,9 @@ import {
 } from './test/pending_requests';
 import Adapter from './adapters/adapter';
 import QUnitAdapter from './adapters/qunit';
-
+/**
+@module ember
+*/
 /**
   Sets Ember up for testing. This is useful to perform
   basic setup steps in order to unit test.


### PR DESCRIPTION
Rest of the fix to https://github.com/ember-learn/ember-api-docs/issues/419

Removes the Ember reference from

* `@ember/object`
* `@ember/test`


