### PR TITLE
Drop jQuery usage from the packages/ember/tests

### DIFF
--- a/packages/ember/tests/component_context_test.js
+++ b/packages/ember/tests/component_context_test.js
@@ -1,6 +1,6 @@
 import { Controller } from 'ember-runtime';
 import { Component } from 'ember-glimmer';
-import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
+import { moduleFor, ApplicationTestCase, getTextOf } from 'internal-test-helpers';
 
 moduleFor('Application Lifecycle - Component Context', class extends ApplicationTestCase {
   ['@test Components with a block should have the proper content when a template is provided'](assert) {
@@ -21,7 +21,7 @@ moduleFor('Application Lifecycle - Component Context', class extends Application
     });
 
     return this.visit('/').then(() => {
-      let text = this.$('#wrapper').text().trim();
+      let text = getTextOf(this.element.querySelector('#wrapper'));
       assert.equal(text, 'inner-outer', 'The component is composed correctly');
     });
   }
@@ -43,7 +43,7 @@ moduleFor('Application Lifecycle - Component Context', class extends Application
     });
 
     return this.visit('/').then(() => {
-      let text = this.$('#wrapper').text().trim();
+      let text = getTextOf(this.element.querySelector('#wrapper'));
       assert.equal(text, 'outer', 'The component is composed correctly');
     });
   }
@@ -63,7 +63,7 @@ moduleFor('Application Lifecycle - Component Context', class extends Application
     });
 
     return this.visit('/').then(() => {
-      let text = this.$('#wrapper').text().trim();
+      let text = getTextOf(this.element.querySelector('#wrapper'));
       assert.equal(text, 'inner', 'The component is composed correctly');
     });
   }
@@ -85,7 +85,7 @@ moduleFor('Application Lifecycle - Component Context', class extends Application
     });
 
     return this.visit('/').then(() => {
-      let text = this.$('#wrapper').text().trim();
+      let text = getTextOf(this.element.querySelector('#wrapper'));
       assert.equal(text, 'Some text inserted', 'The component is composed correctly');
     });
   }
@@ -108,7 +108,7 @@ moduleFor('Application Lifecycle - Component Context', class extends Application
     });
 
     return this.visit('/').then(() => {
-      let text = this.$('#wrapper').text().trim();
+      let text = getTextOf(this.element.querySelector('#wrapper'));
       assert.equal(text, 'Some text inserted', 'The component is composed correctly');
     });
   }
@@ -125,14 +125,13 @@ moduleFor('Application Lifecycle - Component Context', class extends Application
     this.addComponent('my-component', {
       ComponentClass: Component.extend({
         didInsertElement() {
-          // FIXME: I'm unsure if this is even the right way to access attrs
-          this.element.innerHTML = this.get('attrs.attrs').value;
+          this.element.innerHTML = this.get('attrs.attrs.value');
         }
       })
     });
 
     return this.visit('/').then(() => {
-      let text = this.$('#wrapper').text().trim();
+      let text = getTextOf(this.element.querySelector('#wrapper'));
       assert.equal(text, 'Some text inserted', 'The component is composed correctly');
     });
   }

--- a/packages/ember/tests/integration/multiple-app-test.js
+++ b/packages/ember/tests/integration/multiple-app-test.js
@@ -4,17 +4,16 @@ import {
 } from 'internal-test-helpers';
 import { Application } from 'ember-application';
 import { Component } from 'ember-glimmer';
-import { jQuery } from 'ember-views';
 import { assign, getOwner } from 'ember-utils';
 import { resolve } from 'rsvp';
 
 moduleFor('View Integration', class extends ApplicationTestCase {
 
   constructor() {
-    jQuery('#qunit-fixture').html(`
+    document.getElementById('qunit-fixture').innerHTML = `
       <div id="one"></div>
       <div id="two"></div>
-    `);
+    `;
     super();
     this.runTask(() => {
       this.createSecondApplication();
@@ -85,8 +84,8 @@ moduleFor('View Integration', class extends ApplicationTestCase {
       .then(() => this.application.visit('/'))
       .then(() => this.secondApp.visit('/'))
       .then(() => {
-        jQuery('#two .do-stuff').click();
-        jQuery('#one .do-stuff').click();
+        document.querySelector('#two .do-stuff').click();
+        document.querySelector('#one .do-stuff').click();
 
         assert.deepEqual(actions, ['#two', '#one']);
       });

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -25,13 +25,13 @@ import {
   setTemplates,
   setTemplate
 } from 'ember-glimmer';
-import { jQuery } from 'ember-views';
 import { ENV } from 'ember-environment';
 import { compile } from 'ember-template-compiler';
 import { Application, Engine } from 'ember-application';
 import { Transition } from 'router';
+import { getTextOf } from 'internal-test-helpers';
 
-let Router, App, router, registry, container, originalLoggerError, originalRenderSupport;
+let Router, App, router, registry, container, originalLoggerError, originalRenderSupport, rootElement;
 
 function bootApplication() {
   router = container.lookup('router:main');
@@ -67,6 +67,8 @@ QUnit.module('Basic Routing', {
         name: 'App',
         rootElement: '#qunit-fixture'
       });
+
+      rootElement = document.getElementById('qunit-fixture');
 
       App.deferReadiness();
 
@@ -187,7 +189,7 @@ QUnit.test('Nested callbacks are not exited when moving to siblings', function(a
 
   registry.register('controller:special', Controller.extend());
 
-  assert.equal(jQuery('h3', '#qunit-fixture').text(), 'Home', 'The app is now in the initial state');
+  assert.equal(getTextOf(rootElement.querySelector('h3')), 'Home', 'The app is now in the initial state');
   assert.equal(rootSetup, 1, 'The root setup was triggered');
   assert.equal(rootRender, 1, 'The root render was triggered');
   assert.equal(rootSerialize, 0, 'The root serialize was not called');
@@ -255,7 +257,7 @@ QUnit.test('Events are triggered on the controller if a matching action name is 
 
   bootApplication();
 
-  jQuery('#qunit-fixture a').click();
+  rootElement.querySelector('a').click();
 });
 
 QUnit.test('Events are triggered on the current state when defined in `actions` object', function(assert) {
@@ -287,7 +289,7 @@ QUnit.test('Events are triggered on the current state when defined in `actions` 
 
   bootApplication();
 
-  jQuery('#qunit-fixture a').click();
+  rootElement.querySelector('a').click();
 });
 
 QUnit.test('Events defined in `actions` object are triggered on the current state when routes are nested', function(assert) {
@@ -324,7 +326,7 @@ QUnit.test('Events defined in `actions` object are triggered on the current stat
 
   bootApplication();
 
-  jQuery('#qunit-fixture a').click();
+  rootElement.querySelector('a').click();
 });
 
 QUnit.test('Events can be handled by inherited event handlers', function(assert) {
@@ -404,7 +406,7 @@ QUnit.test('Actions are not triggered on the controller if a matching action nam
 
   bootApplication();
 
-  jQuery('#qunit-fixture a').click();
+  rootElement.querySelector('a').click();
 });
 
 QUnit.test('actions can be triggered with multiple arguments', function(assert) {
@@ -441,7 +443,7 @@ QUnit.test('actions can be triggered with multiple arguments', function(assert) 
 
   bootApplication();
 
-  jQuery('#qunit-fixture a').click();
+  rootElement.querySelector('a').click();
 });
 
 QUnit.test('transitioning multiple times in a single run loop only sets the URL once', function(assert) {
@@ -737,7 +739,7 @@ QUnit.test('A redirection hook is provided', function(assert) {
   bootApplication();
 
   assert.equal(chooseFollowed, 0, 'The choose route wasn\'t entered since a transition occurred');
-  assert.equal(jQuery('h3.hours', '#qunit-fixture').length, 1, 'The home template was rendered');
+  assert.equal(rootElement.querySelectorAll('h3.hours').length, 1, 'The home template was rendered');
   assert.equal(getOwner(router).lookup('controller:application').get('currentPath'), 'home');
 });
 
@@ -930,7 +932,7 @@ QUnit.test('Generated names can be customized when providing routes with dot not
 
   handleURL(assert, '/top/middle/bottom');
 
-  assert.equal(jQuery('.main .middle .bottom p', '#qunit-fixture').text(), 'BarBazBottom!', 'The templates were rendered into their appropriate parents');
+  assert.equal(getTextOf(rootElement.querySelector('.main .middle .bottom p')), 'BarBazBottom!', 'The templates were rendered into their appropriate parents');
 });
 
 QUnit.test('Child routes render into their parent route\'s template by default', function(assert) {
@@ -952,7 +954,7 @@ QUnit.test('Child routes render into their parent route\'s template by default',
 
   handleURL(assert, '/top/middle/bottom');
 
-  assert.equal(jQuery('.main .middle .bottom p', '#qunit-fixture').text(), 'Bottom!', 'The templates were rendered into their appropriate parents');
+  assert.equal(getTextOf(rootElement.querySelector('.main .middle .bottom p')), 'Bottom!', 'The templates were rendered into their appropriate parents');
 });
 
 QUnit.test('Child routes render into specified template', function(assert) {
@@ -980,8 +982,8 @@ QUnit.test('Child routes render into specified template', function(assert) {
 
   handleURL(assert, '/top/middle/bottom');
 
-  assert.equal(jQuery('.main .middle .bottom p', '#qunit-fixture').length, 0, 'should not render into the middle template');
-  assert.equal(jQuery('.main .middle > p', '#qunit-fixture').text(), 'Bottom!', 'The template was rendered into the top template');
+  assert.equal(rootElement.querySelectorAll('.main .middle .bottom p').length, 0, 'should not render into the middle template');
+  assert.equal(getTextOf(rootElement.querySelector('.main .middle > p')), 'Bottom!', 'The template was rendered into the top template');
 });
 
 QUnit.test('Rendering into specified template with slash notation', function(assert) {
@@ -1001,7 +1003,7 @@ QUnit.test('Rendering into specified template with slash notation', function(ass
 
   bootApplication();
 
-  assert.equal(jQuery('#qunit-fixture:contains(profile details!)').length, 1, 'The templates were rendered');
+  assert.equal(rootElement.textContent.trim(), 'profile details!', 'The templates were rendered');
 });
 
 QUnit.test('Parent route context change', function(assert) {
@@ -1175,8 +1177,8 @@ QUnit.test('Only use route rendered into main outlet for default into property o
 
   handleURL(assert, '/posts');
 
-  assert.equal(jQuery('div.posts-menu:contains(postsMenu)', '#qunit-fixture').length, 1, 'The posts/menu template was rendered');
-  assert.equal(jQuery('p.posts-index:contains(postsIndex)', '#qunit-fixture').length, 1, 'The posts/index template was rendered');
+  assert.equal(getTextOf(rootElement.querySelector('div.posts-menu')), 'postsMenu', 'The posts/menu template was rendered');
+  assert.equal(getTextOf(rootElement.querySelector('p.posts-index')), 'postsIndex', 'The posts/index template was rendered');
 });
 
 QUnit.test('Generating a URL should not affect currentModel', function(assert) {
@@ -1259,7 +1261,7 @@ QUnit.test('Application template does not duplicate when re-rendered', function(
   // should cause application template to re-render
   handleURL(assert, '/posts');
 
-  assert.equal(jQuery('h3.render-once').text(), "I render once");
+  assert.equal(getTextOf(rootElement.querySelector('h3.render-once')), "I render once");
 });
 
 QUnit.test('Child routes should render inside the application template if the application template causes a redirect', function(assert) {
@@ -1279,7 +1281,7 @@ QUnit.test('Child routes should render inside the application template if the ap
 
   bootApplication();
 
-  assert.equal(jQuery('#qunit-fixture').text(), 'App posts');
+  assert.equal(rootElement.textContent.trim(), 'App posts');
 });
 
 QUnit.test('The template is not re-rendered when the route\'s context changes', function(assert) {
@@ -1308,17 +1310,17 @@ QUnit.test('The template is not re-rendered when the route\'s context changes', 
 
   handleURL(assert, '/page/first');
 
-  assert.equal(jQuery('p', '#qunit-fixture').text(), 'first');
+  assert.equal(getTextOf(rootElement.querySelector('p')), 'first');
   assert.equal(insertionCount, 1);
 
   handleURL(assert, '/page/second');
 
-  assert.equal(jQuery('p', '#qunit-fixture').text(), 'second');
+  assert.equal(getTextOf(rootElement.querySelector('p')), 'second');
   assert.equal(insertionCount, 1, 'view should have inserted only once');
 
   run(() => router.transitionTo('page', EmberObject.create({ name: 'third' })));
 
-  assert.equal(jQuery('p', '#qunit-fixture').text(), 'third');
+  assert.equal(getTextOf(rootElement.querySelector('p')), 'third');
   assert.equal(insertionCount, 1, 'view should still have inserted only once');
 });
 
@@ -1364,13 +1366,13 @@ QUnit.test('The template is not re-rendered when two routes present the exact sa
 
   handleURL(assert, '/first');
 
-  assert.equal(jQuery('p', '#qunit-fixture').text(), 'This is the first message');
+  assert.equal(getTextOf(rootElement.querySelector('p')), 'This is the first message');
   assert.equal(insertionCount, 1, 'expected one assertion');
 
   // Transition by URL
   handleURL(assert, '/second');
 
-  assert.equal(jQuery('p', '#qunit-fixture').text(), 'This is the second message');
+  assert.equal(getTextOf(rootElement.querySelector('p')), 'This is the second message');
   assert.equal(insertionCount, 1, 'expected one assertion');
 
   // Then transition directly by route name
@@ -1382,14 +1384,14 @@ QUnit.test('The template is not re-rendered when two routes present the exact sa
     });
   });
 
-  assert.equal(jQuery('p', '#qunit-fixture').text(), 'This is the third message');
+  assert.equal(getTextOf(rootElement.querySelector('p')), 'This is the third message');
   assert.equal(insertionCount, 1, 'expected one assertion');
 
   // Lastly transition to a different view, with the same controller and template
   handleURL(assert, '/fourth');
   assert.equal(insertionCount, 1, 'expected one assertion');
 
-  assert.equal(jQuery('p', '#qunit-fixture').text(), 'This is the fourth message');
+  assert.equal(getTextOf(rootElement.querySelector('p')), 'This is the fourth message');
 });
 
 QUnit.test('ApplicationRoute with model does not proxy the currentPath', function(assert) {
@@ -1428,9 +1430,9 @@ QUnit.test('Promises encountered on app load put app into loading state until re
 
   bootApplication();
 
-  assert.equal(jQuery('p', '#qunit-fixture').text(), 'LOADING', 'The loading state is displaying.');
+  assert.equal(getTextOf(rootElement.querySelector('p')), 'LOADING', 'The loading state is displaying.');
   run(deferred.resolve);
-  assert.equal(jQuery('p', '#qunit-fixture').text(), 'INDEX', 'The index route is display.');
+  assert.equal(getTextOf(rootElement.querySelector('p')), 'INDEX', 'The index route is display.');
 });
 
 QUnit.test('Route should tear down multiple outlets', function(assert) {
@@ -1466,15 +1468,15 @@ QUnit.test('Route should tear down multiple outlets', function(assert) {
 
   handleURL(assert, '/posts');
 
-  assert.equal(jQuery('div.posts-menu:contains(postsMenu)', '#qunit-fixture').length, 1, 'The posts/menu template was rendered');
-  assert.equal(jQuery('p.posts-index:contains(postsIndex)', '#qunit-fixture').length, 1, 'The posts/index template was rendered');
-  assert.equal(jQuery('div.posts-footer:contains(postsFooter)', '#qunit-fixture').length, 1, 'The posts/footer template was rendered');
+  assert.equal(getTextOf(rootElement.querySelector('div.posts-menu')), 'postsMenu', 'The posts/menu template was rendered');
+  assert.equal(getTextOf(rootElement.querySelector('p.posts-index')), 'postsIndex', 'The posts/index template was rendered');
+  assert.equal(getTextOf(rootElement.querySelector('div.posts-footer')), 'postsFooter', 'The posts/footer template was rendered');
 
   handleURL(assert, '/users');
 
-  assert.equal(jQuery('div.posts-menu:contains(postsMenu)', '#qunit-fixture').length, 0, 'The posts/menu template was removed');
-  assert.equal(jQuery('p.posts-index:contains(postsIndex)', '#qunit-fixture').length, 0, 'The posts/index template was removed');
-  assert.equal(jQuery('div.posts-footer:contains(postsFooter)', '#qunit-fixture').length, 0, 'The posts/footer template was removed');
+  assert.equal(rootElement.querySelector('div.posts-menu'), null, 'The posts/menu template was removed');
+  assert.equal(rootElement.querySelector('p.posts-index'), null, 'The posts/index template was removed');
+  assert.equal(rootElement.querySelector('div.posts-footer'), null, 'The posts/footer template was removed');
 });
 
 
@@ -1538,37 +1540,37 @@ QUnit.test('Route supports clearing outlet explicitly', function(assert) {
 
   handleURL(assert, '/posts');
 
-  assert.equal(jQuery('div.posts-index:contains(postsIndex)', '#qunit-fixture').length, 1, 'The posts/index template was rendered');
+  assert.equal(getTextOf(rootElement.querySelector('div.posts-index')), 'postsIndex', 'The posts/index template was rendered');
 
   run(() => router.send('showModal'));
 
-  assert.equal(jQuery('div.posts-modal:contains(postsModal)', '#qunit-fixture').length, 1, 'The posts/modal template was rendered');
+  assert.equal(getTextOf(rootElement.querySelector('div.posts-modal')), 'postsModal', 'The posts/modal template was rendered');
 
   run(() => router.send('showExtra'));
 
-  assert.equal(jQuery('div.posts-extra:contains(postsExtra)', '#qunit-fixture').length, 1, 'The posts/extra template was rendered');
+  assert.equal(getTextOf(rootElement.querySelector('div.posts-extra')), 'postsExtra', 'The posts/extra template was rendered');
 
   run(() => router.send('hideModal'));
 
-  assert.equal(jQuery('div.posts-modal:contains(postsModal)', '#qunit-fixture').length, 0, 'The posts/modal template was removed');
+  assert.equal(rootElement.querySelector('div.posts-modal'), null, 'The posts/modal template was removed');
 
   run(() => router.send('hideExtra'));
 
-  assert.equal(jQuery('div.posts-extra:contains(postsExtra)', '#qunit-fixture').length, 0, 'The posts/extra template was removed');
+  assert.equal(rootElement.querySelector('div.posts-extra'), null, 'The posts/extra template was removed');
   run(function() {
     router.send('showModal');
   });
-  assert.equal(jQuery('div.posts-modal:contains(postsModal)', '#qunit-fixture').length, 1, 'The posts/modal template was rendered');
+  assert.equal(getTextOf(rootElement.querySelector('div.posts-modal')), 'postsModal', 'The posts/modal template was rendered');
   run(function() {
     router.send('showExtra');
   });
-  assert.equal(jQuery('div.posts-extra:contains(postsExtra)', '#qunit-fixture').length, 1, 'The posts/extra template was rendered');
+  assert.equal(getTextOf(rootElement.querySelector('div.posts-extra')), 'postsExtra', 'The posts/extra template was rendered');
 
   handleURL(assert, '/users');
 
-  assert.equal(jQuery('div.posts-index:contains(postsIndex)', '#qunit-fixture').length, 0, 'The posts/index template was removed');
-  assert.equal(jQuery('div.posts-modal:contains(postsModal)', '#qunit-fixture').length, 0, 'The posts/modal template was removed');
-  assert.equal(jQuery('div.posts-extra:contains(postsExtra)', '#qunit-fixture').length, 0, 'The posts/extra template was removed');
+  assert.equal(rootElement.querySelector('div.posts-index'), null, 'The posts/index template was removed');
+  assert.equal(rootElement.querySelector('div.posts-modal'), null, 'The posts/modal template was removed');
+  assert.equal(rootElement.querySelector('div.posts-extra'), null, 'The posts/extra template was removed');
 });
 
 QUnit.test('Route supports clearing outlet using string parameter', function(assert) {
@@ -1601,20 +1603,20 @@ QUnit.test('Route supports clearing outlet using string parameter', function(ass
 
   handleURL(assert, '/posts');
 
-  assert.equal(jQuery('div.posts-index:contains(postsIndex)', '#qunit-fixture').length, 1, 'The posts/index template was rendered');
+  assert.equal(getTextOf(rootElement.querySelector('div.posts-index')), 'postsIndex', 'The posts/index template was rendered');
 
   run(() => router.send('showModal'));
 
-  assert.equal(jQuery('div.posts-modal:contains(postsModal)', '#qunit-fixture').length, 1, 'The posts/modal template was rendered');
+  assert.equal(getTextOf(rootElement.querySelector('div.posts-modal')), 'postsModal', 'The posts/modal template was rendered');
 
   run(() => router.send('hideModal'));
 
-  assert.equal(jQuery('div.posts-modal:contains(postsModal)', '#qunit-fixture').length, 0, 'The posts/modal template was removed');
+  assert.equal(rootElement.querySelector('div.posts-modal'), null, 'The posts/modal template was removed');
 
   handleURL(assert, '/users');
 
-  assert.equal(jQuery('div.posts-index:contains(postsIndex)', '#qunit-fixture').length, 0, 'The posts/index template was removed');
-  assert.equal(jQuery('div.posts-modal:contains(postsModal)', '#qunit-fixture').length, 0, 'The posts/modal template was removed');
+  assert.equal(rootElement.querySelector('div.posts-index'), null, 'The posts/index template was removed');
+  assert.equal(rootElement.querySelector('div.posts-modal'), null, 'The posts/modal template was removed');
 });
 
 QUnit.test('Route silently fails when cleaning an outlet from an inactive view', function(assert) {
@@ -2262,7 +2264,7 @@ QUnit.test('Errors in transition show error template if available', function(ass
 
   bootApplication();
 
-  assert.equal(jQuery('#error').length, 1, 'Error template was rendered.');
+  assert.equal(rootElement.querySelectorAll('#error').length, 1, 'Error template was rendered.');
 });
 
 QUnit.test('Route#resetController gets fired when changing models and exiting routes', function(assert) {
@@ -2386,15 +2388,15 @@ QUnit.test('{{outlet}} works when created after initial render', function(assert
 
   bootApplication();
 
-  assert.equal(jQuery('#qunit-fixture').text(), 'HiBye', 'initial render');
+  assert.equal(rootElement.textContent.trim(), 'HiBye', 'initial render');
 
   run(() => container.lookup('controller:sample').set('showTheThing', true));
 
-  assert.equal(jQuery('#qunit-fixture').text(), 'HiYayBye', 'second render');
+  assert.equal(rootElement.textContent.trim(), 'HiYayBye', 'second render');
 
   handleURL(assert, '/2');
 
-  assert.equal(jQuery('#qunit-fixture').text(), 'HiBooBye', 'third render');
+  assert.equal(rootElement.textContent.trim(), 'HiBooBye', 'third render');
 });
 
 QUnit.test('Can render into a named outlet at the top level', function(assert) {
@@ -2414,7 +2416,7 @@ QUnit.test('Can render into a named outlet at the top level', function(assert) {
 
   bootApplication();
 
-  assert.equal(jQuery('#qunit-fixture').text(), 'A-The index-B-Hello world-C', 'initial render');
+  assert.equal(rootElement.textContent.trim(), 'A-The index-B-Hello world-C', 'initial render');
 });
 
 QUnit.test('Can disconnect a named outlet at the top level', function(assert) {
@@ -2442,11 +2444,11 @@ QUnit.test('Can disconnect a named outlet at the top level', function(assert) {
 
   bootApplication();
 
-  assert.equal(jQuery('#qunit-fixture').text(), 'A-The index-B-Hello world-C', 'initial render');
+  assert.equal(rootElement.textContent.trim(), 'A-The index-B-Hello world-C', 'initial render');
 
   run(router, 'send', 'banish');
 
-  assert.equal(jQuery('#qunit-fixture').text(), 'A-The index-B--C', 'second render');
+  assert.equal(rootElement.textContent.trim(), 'A-The index-B--C', 'second render');
 });
 
 QUnit.test('Can render into a named outlet at the top level, with empty main outlet', function(assert) {
@@ -2469,7 +2471,7 @@ QUnit.test('Can render into a named outlet at the top level, with empty main out
 
   bootApplication();
 
-  assert.equal(jQuery('#qunit-fixture').text(), 'A--B-Hello world-C', 'initial render');
+  assert.equal(rootElement.textContent.trim(), 'A--B-Hello world-C', 'initial render');
 });
 
 
@@ -2491,11 +2493,11 @@ QUnit.test('Can render into a named outlet at the top level, later', function(as
 
   bootApplication();
 
-  assert.equal(jQuery('#qunit-fixture').text(), 'A-The index-B--C', 'initial render');
+  assert.equal(rootElement.textContent.trim(), 'A-The index-B--C', 'initial render');
 
   run(router, 'send', 'launch');
 
-  assert.equal(jQuery('#qunit-fixture').text(), 'A-The index-B-Hello world-C', 'second render');
+  assert.equal(rootElement.textContent.trim(), 'A-The index-B-Hello world-C', 'second render');
 });
 
 QUnit.test('Can render routes with no \'main\' outlet and their children', function(assert) {
@@ -2534,10 +2536,10 @@ QUnit.test('Can render routes with no \'main\' outlet and their children', funct
 
   bootApplication();
   handleURL(assert, '/app');
-  assert.equal(jQuery('#app-common #common').length, 1, 'Finds common while viewing /app');
+  assert.equal(rootElement.querySelectorAll('#app-common #common').length, 1, 'Finds common while viewing /app');
   handleURL(assert, '/app/sub');
-  assert.equal(jQuery('#app-common #common').length, 1, 'Finds common while viewing /app/sub');
-  assert.equal(jQuery('#app-sub #sub').length, 1, 'Finds sub while viewing /app/sub');
+  assert.equal(rootElement.querySelectorAll('#app-common #common').length, 1, 'Finds common while viewing /app/sub');
+  assert.equal(rootElement.querySelectorAll('#app-sub #sub').length, 1, 'Finds sub while viewing /app/sub');
 });
 
 QUnit.test('Tolerates stacked renders', function(assert) {
@@ -2561,13 +2563,13 @@ QUnit.test('Tolerates stacked renders', function(assert) {
     }
   });
   bootApplication();
-  assert.equal(jQuery('#qunit-fixture').text().trim(), 'hi');
+  assert.equal(rootElement.textContent.trim(), 'hi');
   run(router, 'send', 'openLayer');
-  assert.equal(jQuery('#qunit-fixture').text().trim(), 'hilayer');
+  assert.equal(rootElement.textContent.trim(), 'hilayer');
   run(router, 'send', 'openLayer');
-  assert.equal(jQuery('#qunit-fixture').text().trim(), 'hilayer');
+  assert.equal(rootElement.textContent.trim(), 'hilayer');
   run(router, 'send', 'close');
-  assert.equal(jQuery('#qunit-fixture').text().trim(), 'hi');
+  assert.equal(rootElement.textContent.trim(), 'hi');
 });
 
 QUnit.test('Renders child into parent with non-default template name', function(assert) {
@@ -2594,7 +2596,7 @@ QUnit.test('Renders child into parent with non-default template name', function(
 
   bootApplication();
   handleURL(assert, '/root');
-  assert.equal(jQuery('#qunit-fixture .a .b .c').length, 1);
+  assert.equal(rootElement.querySelectorAll('.a .b .c').length, 1);
 });
 
 QUnit.test('Allows any route to disconnectOutlet another route\'s templates', function(assert) {
@@ -2622,11 +2624,11 @@ QUnit.test('Allows any route to disconnectOutlet another route\'s templates', fu
     }
   });
   bootApplication();
-  assert.equal(jQuery('#qunit-fixture').text().trim(), 'hi');
+  assert.equal(rootElement.textContent.trim(), 'hi');
   run(router, 'send', 'openLayer');
-  assert.equal(jQuery('#qunit-fixture').text().trim(), 'hilayer');
+  assert.equal(rootElement.textContent.trim(), 'hilayer');
   run(router, 'send', 'close');
-  assert.equal(jQuery('#qunit-fixture').text().trim(), 'hi');
+  assert.equal(rootElement.textContent.trim(), 'hi');
 });
 
 QUnit.test('Can this.render({into:...}) the render helper', function(assert) {
@@ -2656,9 +2658,9 @@ QUnit.test('Can this.render({into:...}) the render helper', function(assert) {
   });
 
   bootApplication();
-  assert.equal(jQuery('#qunit-fixture .sidebar').text(), 'other');
+  assert.equal(getTextOf(rootElement.querySelector('.sidebar')), 'other');
   run(router, 'send', 'changeToBar');
-  assert.equal(jQuery('#qunit-fixture .sidebar').text(), 'bar');
+  assert.equal(getTextOf(rootElement.querySelector('.sidebar')), 'bar');
 });
 
 QUnit.test('Can disconnect from the render helper', function(assert) {
@@ -2686,9 +2688,9 @@ QUnit.test('Can disconnect from the render helper', function(assert) {
   });
 
   bootApplication();
-  assert.equal(jQuery('#qunit-fixture .sidebar').text(), 'other');
+  assert.equal(getTextOf(rootElement.querySelector('.sidebar')), 'other');
   run(router, 'send', 'disconnect');
-  assert.equal(jQuery('#qunit-fixture .sidebar').text(), '');
+  assert.equal(getTextOf(rootElement.querySelector('.sidebar')), '');
 });
 
 QUnit.test('Can this.render({into:...}) the render helper\'s children', function(assert) {
@@ -2720,9 +2722,9 @@ QUnit.test('Can this.render({into:...}) the render helper\'s children', function
   });
 
   bootApplication();
-  assert.equal(jQuery('#qunit-fixture .sidebar .index').text(), 'other');
+  assert.equal(getTextOf(rootElement.querySelector('.sidebar .index')), 'other');
   run(router, 'send', 'changeToBar');
-  assert.equal(jQuery('#qunit-fixture .sidebar .index').text(), 'bar');
+  assert.equal(getTextOf(rootElement.querySelector('.sidebar .index')), 'bar');
 });
 
 QUnit.test('Can disconnect from the render helper\'s children', function(assert) {
@@ -2752,9 +2754,9 @@ QUnit.test('Can disconnect from the render helper\'s children', function(assert)
   });
 
   bootApplication();
-  assert.equal(jQuery('#qunit-fixture .sidebar .index').text(), 'other');
+  assert.equal(getTextOf(rootElement.querySelector('.sidebar .index')), 'other');
   run(router, 'send', 'disconnect');
-  assert.equal(jQuery('#qunit-fixture .sidebar .index').text(), '');
+  assert.equal(getTextOf(rootElement.querySelector('.sidebar .index')), '');
 });
 
 QUnit.test('Can this.render({into:...}) nested render helpers', function(assert) {
@@ -2788,9 +2790,9 @@ QUnit.test('Can this.render({into:...}) nested render helpers', function(assert)
   });
 
   bootApplication();
-  assert.equal(jQuery('#qunit-fixture .cart').text(), 'other');
+  assert.equal(getTextOf(rootElement.querySelector('.cart')), 'other');
   run(router, 'send', 'changeToBaz');
-  assert.equal(jQuery('#qunit-fixture .cart').text(), 'baz');
+  assert.equal(getTextOf(rootElement.querySelector('.cart')), 'baz');
 });
 
 QUnit.test('Can disconnect from nested render helpers', function(assert) {
@@ -2822,9 +2824,9 @@ QUnit.test('Can disconnect from nested render helpers', function(assert) {
   });
 
   bootApplication();
-  assert.equal(jQuery('#qunit-fixture .cart').text(), 'other');
+  assert.equal(getTextOf(rootElement.querySelector('.cart')), 'other');
   run(router, 'send', 'disconnect');
-  assert.equal(jQuery('#qunit-fixture .cart').text(), '');
+  assert.equal(getTextOf(rootElement.querySelector('.cart')), '');
 });
 
 QUnit.test('Components inside an outlet have their didInsertElement hook invoked when the route is displayed', function(assert) {

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -12,9 +12,8 @@ import {
   peekMeta
 } from 'ember-metal';
 import { Route } from 'ember-routing';
-import { jQuery } from 'ember-views';
 
-import { QueryParamTestCase, moduleFor } from 'internal-test-helpers';
+import { QueryParamTestCase, moduleFor, getTextOf } from 'internal-test-helpers';
 
 moduleFor('Query Params - main', class extends QueryParamTestCase {
   refreshModelWhileLoadingTest(loadingReturn) {
@@ -592,14 +591,14 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
     }));
 
     return this.visitAndAssert('/').then(() => {
-      assert.equal(jQuery('#test-value').text().trim(), '1');
+      assert.equal(getTextOf(document.getElementById('test-value')), '1');
 
-      run(jQuery('#test-button'), 'click');
-      assert.equal(jQuery('#test-value').text().trim(), '2');
+      run(document.getElementById('test-button'), 'click');
+      assert.equal(getTextOf(document.getElementById('test-value')), '2');
       this.assertCurrentPath('/?foo=2');
 
-      run(jQuery('#test-button'), 'click');
-      assert.equal(jQuery('#test-value').text().trim(), '3');
+      run(document.getElementById('test-button'), 'click');
+      assert.equal(getTextOf(document.getElementById('test-value')), '3');
       this.assertCurrentPath('/?foo=3');
     });
   }
@@ -783,7 +782,7 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
     return this.visit('/parent/child?foo=lol').then(() => {
       assert.equal(parentModelCount, 1);
 
-      run(jQuery('#parent-link'), 'click');
+      run(document.getElementById('parent-link'), 'click');
       assert.equal(parentModelCount, 2);
     });
   }
@@ -892,13 +891,13 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
     this.setSingleQPController('abc.def.zoo', 'bar', 'haha');
 
     return this.visitAndAssert('/').then(() => {
-      assert.equal(jQuery('#one').attr('href'), '/abcdef?foo=123');
-      assert.equal(jQuery('#two').attr('href'), '/abcdef/zoo?bar=456&foo=123');
+      assert.equal(this.$('#one').attr('href'), '/abcdef?foo=123');
+      assert.equal(this.$('#two').attr('href'), '/abcdef/zoo?bar=456&foo=123');
 
-      run(jQuery('#one'), 'click');
+      run(this.$('#one'), 'click');
       this.assertCurrentPath('/abcdef?foo=123');
 
-      run(jQuery('#two'), 'click');
+      run(this.$('#two'), 'click');
       this.assertCurrentPath('/abcdef/zoo?bar=456&foo=123');
     });
   }
@@ -1253,19 +1252,19 @@ moduleFor('Query Params - main', class extends QueryParamTestCase {
       let controller = this.getController('bar');
 
       this.expectedPushURL = '/foo';
-      run(jQuery('#foo-link'), 'click');
+      run(document.getElementById('foo-link'), 'click');
 
       this.expectedPushURL = '/bar';
-      run(jQuery('#bar-no-qp-link'), 'click');
+      run(document.getElementById('bar-no-qp-link'), 'click');
 
       this.expectedReplaceURL = '/bar?raytiley=woot';
       this.setAndFlush(controller, 'raytiley', 'woot');
 
       this.expectedPushURL = '/foo';
-      run(jQuery('#foo-link'), 'click');
+      run(document.getElementById('foo-link'), 'click');
 
       this.expectedPushURL = '/bar?raytiley=isthebest';
-      run(jQuery('#bar-link'), 'click');
+      run(document.getElementById('bar-link'), 'click');
     });
   }
 

--- a/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
@@ -4,7 +4,6 @@ import {
 } from 'ember-runtime';
 import { Route } from 'ember-routing';
 import { run, computed } from 'ember-metal';
-import { jQuery } from 'ember-views';
 import { QueryParamTestCase, moduleFor } from 'internal-test-helpers';
 
 class ModelDependentQPTestCase extends QueryParamTestCase {
@@ -37,18 +36,18 @@ class ModelDependentQPTestCase extends QueryParamTestCase {
 
       this.setAndFlush(this.controller, 'q', 'lol');
 
-      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
-      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2`);
-      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
+      assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=lol`);
+      assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2`);
+      assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3`);
 
       run(this.$link2, 'click');
 
       assert.equal(this.controller.get('q'), 'wat');
       assert.equal(this.controller.get('z'), 0);
       assert.deepEqual(this.controller.get('model'), { id: 'a-2' });
-      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
-      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2`);
-      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
+      assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=lol`);
+      assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2`);
+      assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3`);
     });
   }
 
@@ -64,9 +63,9 @@ class ModelDependentQPTestCase extends QueryParamTestCase {
       assert.deepEqual(this.controller.get('model'), { id: 'a-1' });
       assert.equal(this.controller.get('q'), 'lol');
       assert.equal(this.controller.get('z'), 0);
-      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
-      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2`);
-      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
+      assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=lol`);
+      assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2`);
+      assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3`);
 
       this.expectedModelHookParams = { id: 'a-2', q: 'lol', z: 0 };
       this.transitionTo(`${urlPrefix}/a-2?q=lol`);
@@ -74,18 +73,18 @@ class ModelDependentQPTestCase extends QueryParamTestCase {
       assert.deepEqual(this.controller.get('model'), { id: 'a-2' }, 'controller\'s model changed to a-2');
       assert.equal(this.controller.get('q'), 'lol');
       assert.equal(this.controller.get('z'), 0);
-      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
-      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`);
-      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
+      assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=lol`);
+      assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=lol`);
+      assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3`);
 
       this.expectedModelHookParams = { id: 'a-3', q: 'lol', z: 123 };
       this.transitionTo(`${urlPrefix}/a-3?q=lol&z=123`);
 
       assert.equal(this.controller.get('q'), 'lol');
       assert.equal(this.controller.get('z'), 123);
-      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
-      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`);
-      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=lol&z=123`);
+      assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=lol`);
+      assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=lol`);
+      assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3?q=lol&z=123`);
     });
   }
 
@@ -103,9 +102,9 @@ class ModelDependentQPTestCase extends QueryParamTestCase {
       assert.deepEqual(this.controller.get('model'), { id: 'a-1' });
       assert.equal(this.controller.get('q'), 'wat');
       assert.equal(this.controller.get('z'), 0);
-      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1`);
-      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2`);
-      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
+      assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1`);
+      assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2`);
+      assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3`);
 
       this.expectedModelHookParams = { id: 'a-2', q: 'lol', z: 0 };
       this.transitionTo(articleLookup, 'a-2', { queryParams: { q: 'lol' } });
@@ -113,9 +112,9 @@ class ModelDependentQPTestCase extends QueryParamTestCase {
       assert.deepEqual(this.controller.get('model'), { id: 'a-2' });
       assert.equal(this.controller.get('q'), 'lol');
       assert.equal(this.controller.get('z'), 0);
-      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1`);
-      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`);
-      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
+      assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1`);
+      assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=lol`);
+      assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3`);
 
       this.expectedModelHookParams = { id: 'a-3', q: 'hay', z: 0 };
       this.transitionTo(articleLookup, 'a-3', { queryParams: { q: 'hay' } });
@@ -123,9 +122,9 @@ class ModelDependentQPTestCase extends QueryParamTestCase {
       assert.deepEqual(this.controller.get('model'), { id: 'a-3' });
       assert.equal(this.controller.get('q'), 'hay');
       assert.equal(this.controller.get('z'), 0);
-      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1`);
-      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`);
-      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=hay`);
+      assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1`);
+      assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=lol`);
+      assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3?q=hay`);
 
       this.expectedModelHookParams = { id: 'a-2', q: 'lol', z: 1 };
       this.transitionTo(articleLookup, 'a-2', { queryParams: { z: 1 } });
@@ -133,9 +132,9 @@ class ModelDependentQPTestCase extends QueryParamTestCase {
       assert.deepEqual(this.controller.get('model'), { id: 'a-2' });
       assert.equal(this.controller.get('q'), 'lol');
       assert.equal(this.controller.get('z'), 1);
-      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1`);
-      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol&z=1`);
-      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=hay`);
+      assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1`);
+      assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=lol&z=1`);
+      assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3?q=hay`);
     });
   }
 
@@ -156,9 +155,9 @@ class ModelDependentQPTestCase extends QueryParamTestCase {
 
       this.setAndFlush(this.controller, 'q', 'lol');
 
-      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
-      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`);
-      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=lol`);
+      assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=lol`);
+      assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=lol`);
+      assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3?q=lol`);
 
       run(this.$link2, 'click');
 
@@ -166,9 +165,9 @@ class ModelDependentQPTestCase extends QueryParamTestCase {
       assert.equal(this.controller.get('z'), 0);
       assert.deepEqual(this.controller.get('model'), { id: 'a-2' });
 
-      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
-      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`);
-      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=lol`);
+      assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=lol`);
+      assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=lol`);
+      assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3?q=lol`);
 
       this.expectedModelHookParams = { id: 'a-3', q: 'haha', z: 123 };
       this.transitionTo(`${urlPrefix}/a-3?q=haha&z=123`);
@@ -177,15 +176,15 @@ class ModelDependentQPTestCase extends QueryParamTestCase {
       assert.equal(this.controller.get('q'), 'haha');
       assert.equal(this.controller.get('z'), 123);
 
-      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=haha`);
-      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=haha`);
-      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=haha&z=123`);
+      assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=haha`);
+      assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=haha`);
+      assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3?q=haha&z=123`);
 
       this.setAndFlush(this.controller, 'q', 'woot');
 
-      assert.equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=woot`);
-      assert.equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=woot`);
-      assert.equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=woot&z=123`);
+      assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=woot`);
+      assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=woot`);
+      assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3?q=woot&z=123`);
     });
   }
 
@@ -255,8 +254,8 @@ class ModelDependentQPTestCase extends QueryParamTestCase {
       assert.equal(commentsCtrl.get('page'), 1);
 
       this.transitionTo('about');
-      assert.equal(jQuery('#one').attr('href'), `${urlPrefix}/a-1/comments?q=imdone`);
-      assert.equal(jQuery('#two').attr('href'), `${urlPrefix}/a-2/comments`);
+      assert.equal(document.getElementById('one').getAttribute('href'), `${urlPrefix}/a-1/comments?q=imdone`);
+      assert.equal(document.getElementById('two').getAttribute('href'), `${urlPrefix}/a-2/comments`);
     });
   }
 }
@@ -306,13 +305,13 @@ moduleFor('Query Params - model-dependent state', class extends ModelDependentQP
     return this.visit('/').then(() => {
       let assert = this.assert;
 
-      this.$link1 = jQuery('#a-1');
-      this.$link2 = jQuery('#a-2');
-      this.$link3 = jQuery('#a-3');
+      this.$link1 = document.getElementById('a-1');
+      this.$link2 = document.getElementById('a-2');
+      this.$link3 = document.getElementById('a-3');
 
-      assert.equal(this.$link1.attr('href'), '/a/a-1');
-      assert.equal(this.$link2.attr('href'), '/a/a-2');
-      assert.equal(this.$link3.attr('href'), '/a/a-3');
+      assert.equal(this.$link1.getAttribute('href'), '/a/a-1');
+      assert.equal(this.$link2.getAttribute('href'), '/a/a-2');
+      assert.equal(this.$link3.getAttribute('href'), '/a/a-3');
 
       this.controller = this.getController('article');
     });
@@ -390,13 +389,13 @@ moduleFor('Query Params - model-dependent state (nested)', class extends ModelDe
     return this.visit('/').then(() => {
       let assert = this.assert;
 
-      this.$link1 = jQuery('#a-1');
-      this.$link2 = jQuery('#a-2');
-      this.$link3 = jQuery('#a-3');
+      this.$link1 = document.getElementById('a-1');
+      this.$link2 = document.getElementById('a-2');
+      this.$link3 = document.getElementById('a-3');
 
-      assert.equal(this.$link1.attr('href'), '/site/a/a-1');
-      assert.equal(this.$link2.attr('href'), '/site/a/a-2');
-      assert.equal(this.$link3.attr('href'), '/site/a/a-3');
+      assert.equal(this.$link1.getAttribute('href'), '/site/a/a-1');
+      assert.equal(this.$link2.getAttribute('href'), '/site/a/a-2');
+      assert.equal(this.$link3.getAttribute('href'), '/site/a/a-3');
 
       this.controller = this.getController('site.article');
     });
@@ -504,25 +503,25 @@ moduleFor('Query Params - model-dependent state (nested & more than 1 dynamic se
       let assert = this.assert;
 
       this.links = {};
-      this.links['s-1-a-1'] = jQuery('#s-1-a-1');
-      this.links['s-1-a-2'] = jQuery('#s-1-a-2');
-      this.links['s-1-a-3'] = jQuery('#s-1-a-3');
-      this.links['s-2-a-1'] = jQuery('#s-2-a-1');
-      this.links['s-2-a-2'] = jQuery('#s-2-a-2');
-      this.links['s-2-a-3'] = jQuery('#s-2-a-3');
-      this.links['s-3-a-1'] = jQuery('#s-3-a-1');
-      this.links['s-3-a-2'] = jQuery('#s-3-a-2');
-      this.links['s-3-a-3'] = jQuery('#s-3-a-3');
+      this.links['s-1-a-1'] = document.getElementById('s-1-a-1');
+      this.links['s-1-a-2'] = document.getElementById('s-1-a-2');
+      this.links['s-1-a-3'] = document.getElementById('s-1-a-3');
+      this.links['s-2-a-1'] = document.getElementById('s-2-a-1');
+      this.links['s-2-a-2'] = document.getElementById('s-2-a-2');
+      this.links['s-2-a-3'] = document.getElementById('s-2-a-3');
+      this.links['s-3-a-1'] = document.getElementById('s-3-a-1');
+      this.links['s-3-a-2'] = document.getElementById('s-3-a-2');
+      this.links['s-3-a-3'] = document.getElementById('s-3-a-3');
 
-      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
-      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2');
-      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
-      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1');
-      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
-      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
-      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
-      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
-      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1');
+      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2');
+      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3');
+      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1');
+      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2');
+      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
+      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1');
+      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
+      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
 
       this.site_controller = this.getController('site');
       this.article_controller = this.getController('site.article');
@@ -540,27 +539,27 @@ moduleFor('Query Params - model-dependent state (nested & more than 1 dynamic se
 
       this.setAndFlush(this.article_controller, 'q', 'lol');
 
-      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
-      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2');
-      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
-      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?q=lol');
-      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
-      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
-      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
-      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
-      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=lol');
+      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2');
+      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3');
+      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?q=lol');
+      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2');
+      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
+      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
+      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
+      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
 
       this.setAndFlush(this.site_controller, 'country', 'us');
 
-      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?country=us&q=lol');
-      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?country=us');
-      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?country=us');
-      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?q=lol');
-      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
-      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
-      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
-      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
-      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?country=us&q=lol');
+      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?country=us');
+      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?country=us');
+      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?q=lol');
+      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2');
+      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
+      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
+      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
+      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
 
       run(this.links['s-1-a-2'], 'click');
 
@@ -569,15 +568,15 @@ moduleFor('Query Params - model-dependent state (nested & more than 1 dynamic se
       assert.equal(this.article_controller.get('z'), 0);
       assert.deepEqual(this.site_controller.get('model'), { id: 's-1' });
       assert.deepEqual(this.article_controller.get('model'), { id: 'a-2' });
-      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?country=us&q=lol');
-      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?country=us');
-      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?country=us');
-      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?q=lol');
-      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
-      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
-      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
-      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
-      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?country=us&q=lol');
+      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?country=us');
+      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?country=us');
+      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?q=lol');
+      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2');
+      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
+      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
+      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
+      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
 
       run(this.links['s-2-a-2'], 'click');
 
@@ -586,15 +585,15 @@ moduleFor('Query Params - model-dependent state (nested & more than 1 dynamic se
       assert.equal(this.article_controller.get('z'), 0);
       assert.deepEqual(this.site_controller.get('model'), { id: 's-2' });
       assert.deepEqual(this.article_controller.get('model'), { id: 'a-2' });
-      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?country=us&q=lol');
-      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?country=us');
-      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?country=us');
-      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?q=lol');
-      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
-      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
-      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
-      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
-      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?country=us&q=lol');
+      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?country=us');
+      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?country=us');
+      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?q=lol');
+      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2');
+      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
+      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
+      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
+      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
     });
   }
 
@@ -611,15 +610,15 @@ moduleFor('Query Params - model-dependent state (nested & more than 1 dynamic se
       assert.equal(this.site_controller.get('country'), 'au');
       assert.equal(this.article_controller.get('q'), 'lol');
       assert.equal(this.article_controller.get('z'), 0);
-      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
-      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2');
-      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
-      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?q=lol');
-      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
-      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
-      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
-      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
-      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=lol');
+      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2');
+      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3');
+      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?q=lol');
+      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2');
+      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
+      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
+      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
+      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
 
       this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
       this.expectedArticleModelHookParams = { article_id: 'a-1', q: 'lol', z: 0 };
@@ -630,15 +629,15 @@ moduleFor('Query Params - model-dependent state (nested & more than 1 dynamic se
       assert.equal(this.site_controller.get('country'), 'us');
       assert.equal(this.article_controller.get('q'), 'lol');
       assert.equal(this.article_controller.get('z'), 0);
-      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
-      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2');
-      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
-      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=lol');
-      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us');
-      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us');
-      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
-      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
-      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=lol');
+      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2');
+      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3');
+      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?country=us&q=lol');
+      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2?country=us');
+      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3?country=us');
+      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
+      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
+      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
 
       this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
       this.expectedArticleModelHookParams = { article_id: 'a-2', q: 'lol', z: 0 };
@@ -649,15 +648,15 @@ moduleFor('Query Params - model-dependent state (nested & more than 1 dynamic se
       assert.equal(this.site_controller.get('country'), 'us');
       assert.equal(this.article_controller.get('q'), 'lol');
       assert.equal(this.article_controller.get('z'), 0);
-      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
-      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol');
-      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
-      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=lol');
-      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol');
-      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us');
-      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
-      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol');
-      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=lol');
+      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol');
+      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3');
+      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?country=us&q=lol');
+      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2?country=us&q=lol');
+      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3?country=us');
+      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
+      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?q=lol');
+      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
 
       this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
       this.expectedArticleModelHookParams = { article_id: 'a-3', q: 'lol', z: 123 };
@@ -668,15 +667,15 @@ moduleFor('Query Params - model-dependent state (nested & more than 1 dynamic se
       assert.equal(this.site_controller.get('country'), 'us');
       assert.equal(this.article_controller.get('q'), 'lol');
       assert.equal(this.article_controller.get('z'), 123);
-      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
-      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol');
-      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=lol&z=123');
-      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=lol');
-      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol');
-      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us&q=lol&z=123');
-      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
-      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol');
-      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?q=lol&z=123');
+      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=lol');
+      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol');
+      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?q=lol&z=123');
+      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?country=us&q=lol');
+      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2?country=us&q=lol');
+      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3?country=us&q=lol&z=123');
+      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
+      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?q=lol');
+      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3?q=lol&z=123');
 
       this.expectedSiteModelHookParams = { site_id: 's-3', country: 'nz' };
       this.expectedArticleModelHookParams = { article_id: 'a-3', q: 'lol', z: 123 };
@@ -687,15 +686,15 @@ moduleFor('Query Params - model-dependent state (nested & more than 1 dynamic se
       assert.equal(this.site_controller.get('country'), 'nz');
       assert.equal(this.article_controller.get('q'), 'lol');
       assert.equal(this.article_controller.get('z'), 123);
-      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
-      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol');
-      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=lol&z=123');
-      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=lol');
-      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol');
-      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us&q=lol&z=123');
-      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?country=nz&q=lol');
-      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?country=nz&q=lol');
-      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?country=nz&q=lol&z=123');
+      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=lol');
+      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol');
+      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?q=lol&z=123');
+      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?country=us&q=lol');
+      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2?country=us&q=lol');
+      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3?country=us&q=lol&z=123');
+      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?country=nz&q=lol');
+      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?country=nz&q=lol');
+      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3?country=nz&q=lol&z=123');
     });
   }
 
@@ -712,15 +711,15 @@ moduleFor('Query Params - model-dependent state (nested & more than 1 dynamic se
       assert.equal(this.site_controller.get('country'), 'au');
       assert.equal(this.article_controller.get('q'), 'wat');
       assert.equal(this.article_controller.get('z'), 0);
-      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
-      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2');
-      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
-      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1');
-      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
-      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
-      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
-      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
-      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1');
+      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2');
+      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3');
+      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1');
+      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2');
+      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
+      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1');
+      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
+      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
 
       this.expectedSiteModelHookParams = { site_id: 's-1', country: 'au' };
       this.expectedArticleModelHookParams = { article_id: 'a-2', q: 'lol', z: 0 };
@@ -731,15 +730,15 @@ moduleFor('Query Params - model-dependent state (nested & more than 1 dynamic se
       assert.equal(this.site_controller.get('country'), 'au');
       assert.equal(this.article_controller.get('q'), 'lol');
       assert.equal(this.article_controller.get('z'), 0);
-      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
-      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol');
-      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
-      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1');
-      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?q=lol');
-      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
-      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
-      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol');
-      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1');
+      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol');
+      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3');
+      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1');
+      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2?q=lol');
+      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
+      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1');
+      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?q=lol');
+      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
 
       this.expectedSiteModelHookParams = { site_id: 's-1', country: 'au' };
       this.expectedArticleModelHookParams = { article_id: 'a-3', q: 'hay', z: 0 };
@@ -750,15 +749,15 @@ moduleFor('Query Params - model-dependent state (nested & more than 1 dynamic se
       assert.equal(this.site_controller.get('country'), 'au');
       assert.equal(this.article_controller.get('q'), 'hay');
       assert.equal(this.article_controller.get('z'), 0);
-      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
-      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol');
-      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=hay');
-      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1');
-      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?q=lol');
-      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?q=hay');
-      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
-      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol');
-      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?q=hay');
+      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1');
+      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol');
+      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?q=hay');
+      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1');
+      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2?q=lol');
+      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3?q=hay');
+      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1');
+      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?q=lol');
+      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3?q=hay');
 
       this.expectedSiteModelHookParams = { site_id: 's-1', country: 'au' };
       this.expectedArticleModelHookParams = { article_id: 'a-2', q: 'lol', z: 1 };
@@ -769,15 +768,15 @@ moduleFor('Query Params - model-dependent state (nested & more than 1 dynamic se
       assert.equal(this.site_controller.get('country'), 'au');
       assert.equal(this.article_controller.get('q'), 'lol');
       assert.equal(this.article_controller.get('z'), 1);
-      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
-      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol&z=1');
-      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=hay');
-      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1');
-      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?q=lol&z=1');
-      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?q=hay');
-      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
-      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol&z=1');
-      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?q=hay');
+      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1');
+      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol&z=1');
+      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?q=hay');
+      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1');
+      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2?q=lol&z=1');
+      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3?q=hay');
+      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1');
+      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?q=lol&z=1');
+      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3?q=hay');
 
       this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
       this.expectedArticleModelHookParams = { article_id: 'a-2', q: 'lol', z: 1 };
@@ -788,15 +787,15 @@ moduleFor('Query Params - model-dependent state (nested & more than 1 dynamic se
       assert.equal(this.site_controller.get('country'), 'us');
       assert.equal(this.article_controller.get('q'), 'lol');
       assert.equal(this.article_controller.get('z'), 1);
-      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
-      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol&z=1');
-      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=hay');
-      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us');
-      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol&z=1');
-      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us&q=hay');
-      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
-      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol&z=1');
-      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?q=hay');
+      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1');
+      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol&z=1');
+      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?q=hay');
+      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?country=us');
+      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2?country=us&q=lol&z=1');
+      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3?country=us&q=hay');
+      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1');
+      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?q=lol&z=1');
+      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3?q=hay');
 
       this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
       this.expectedArticleModelHookParams = { article_id: 'a-1', q: 'yeah', z: 0 };
@@ -807,15 +806,15 @@ moduleFor('Query Params - model-dependent state (nested & more than 1 dynamic se
       assert.equal(this.site_controller.get('country'), 'us');
       assert.equal(this.article_controller.get('q'), 'yeah');
       assert.equal(this.article_controller.get('z'), 0);
-      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=yeah');
-      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol&z=1');
-      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=hay');
-      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=yeah');
-      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol&z=1');
-      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us&q=hay');
-      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=yeah');
-      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol&z=1');
-      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?q=hay');
+      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=yeah');
+      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol&z=1');
+      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?q=hay');
+      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?country=us&q=yeah');
+      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2?country=us&q=lol&z=1');
+      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3?country=us&q=hay');
+      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=yeah');
+      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?q=lol&z=1');
+      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3?q=hay');
 
       this.expectedSiteModelHookParams = { site_id: 's-3', country: 'nz' };
       this.expectedArticleModelHookParams = { article_id: 'a-3', q: 'hay', z: 3 };
@@ -826,15 +825,15 @@ moduleFor('Query Params - model-dependent state (nested & more than 1 dynamic se
       assert.equal(this.site_controller.get('country'), 'nz');
       assert.equal(this.article_controller.get('q'), 'hay');
       assert.equal(this.article_controller.get('z'), 3);
-      assert.equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=yeah');
-      assert.equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol&z=1');
-      assert.equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=hay&z=3');
-      assert.equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=yeah');
-      assert.equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol&z=1');
-      assert.equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us&q=hay&z=3');
-      assert.equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?country=nz&q=yeah');
-      assert.equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?country=nz&q=lol&z=1');
-      assert.equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?country=nz&q=hay&z=3');
+      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=yeah');
+      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol&z=1');
+      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?q=hay&z=3');
+      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?country=us&q=yeah');
+      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2?country=us&q=lol&z=1');
+      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3?country=us&q=hay&z=3');
+      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?country=nz&q=yeah');
+      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?country=nz&q=lol&z=1');
+      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3?country=nz&q=hay&z=3');
     });
   }
 });

--- a/packages/ember/tests/routing/query_params_test/query_params_paramless_link_to_test.js
+++ b/packages/ember/tests/routing/query_params_test/query_params_paramless_link_to_test.js
@@ -1,5 +1,4 @@
 import { Controller } from 'ember-runtime';
-import { jQuery } from 'ember-views';
 import { QueryParamTestCase, moduleFor } from 'internal-test-helpers';
 
 moduleFor('Query Params - paramless link-to', class extends QueryParamTestCase {
@@ -14,7 +13,7 @@ moduleFor('Query Params - paramless link-to', class extends QueryParamTestCase {
     }));
 
     return this.visit('/?foo=YEAH').then(() => {
-      assert.equal(jQuery('#index-link').attr('href'), '/?foo=YEAH');
+      assert.equal(document.getElementById('index-link').getAttribute('href'), '/?foo=YEAH');
     });
   }
 

--- a/packages/ember/tests/routing/query_params_test/shared_state_test.js
+++ b/packages/ember/tests/routing/query_params_test/shared_state_test.js
@@ -4,7 +4,6 @@ import {
   inject
 } from 'ember-runtime';
 import { run } from 'ember-metal';
-import { jQuery } from 'ember-views';
 import { QueryParamTestCase, moduleFor } from 'internal-test-helpers';
 
 moduleFor('Query Params - shared service state', class extends QueryParamTestCase {
@@ -47,7 +46,7 @@ moduleFor('Query Params - shared service state', class extends QueryParamTestCas
     assert.expect(1);
 
     return this.boot().then(() => {
-      this.$input = jQuery('#filters-checkbox');
+      this.$input = document.getElementById('filters-checkbox');
 
       // click the checkbox once to set filters.shared to false
       run(this.$input, 'click');
@@ -62,7 +61,7 @@ moduleFor('Query Params - shared service state', class extends QueryParamTestCas
     assert.expect(1);
 
     return this.boot().then(() => {
-      this.$input = jQuery('#filters-checkbox');
+      this.$input = document.getElementById('filters-checkbox');
 
       // click the checkbox twice to set filters.shared to false and back to true
       run(this.$input, 'click');

--- a/packages/internal-test-helpers/lib/get-text-of.js
+++ b/packages/internal-test-helpers/lib/get-text-of.js
@@ -1,0 +1,3 @@
+export default function getTextOf(elem) {
+  return elem.textContent.trim();
+}

--- a/packages/internal-test-helpers/lib/index.js
+++ b/packages/internal-test-helpers/lib/index.js
@@ -6,6 +6,7 @@ export { default as equalTokens } from './equal-tokens';
 export { default as moduleFor } from './module-for';
 export { default as strip } from './strip';
 export { default as applyMixins } from './apply-mixins';
+export { default as getTextOf } from './get-text-of';
 export {
   equalsElement,
   classes,


### PR DESCRIPTION
Fixes all ember package tests, except:
 - [ ] `The {{link-to}} helper - nested routes and link-to arguments`: The {{link-to}} helper supports bubbles=false
 - [ ] `The {{link-to}} helper - nested routes and link-to arguments`: The {{link-to}} helper supports bubbles=boundFalseyThing
 - [ ] `ember reexports`: Ember.$ exports correctly

So the list currently looks like
 - [x] component_context_test.js - 3 failing
 - [ ] link_to_test.js - 2 failing
 - [x] multiple-app-test.js - 1 failing
 - [ ] reexports_test.js - 1 failing
 - [x] basic_test.js - 38 failing
 - [x] query_params_test.js - 23 failing

Ref #16058