### PR TITLE
Add referrer capability to the test resolver

### DIFF
--- a/packages/container/tests/registry_test.js
+++ b/packages/container/tests/registry_test.js
@@ -1,5 +1,10 @@
 import { Registry, privatize } from '..';
-import { factory, moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import {
+  factory,
+  moduleFor,
+  AbstractTestCase,
+  ModuleBasedTestResolver
+} from 'internal-test-helpers';
 import { EMBER_MODULE_UNIFICATION } from 'ember/features';
 import { ENV } from 'ember-environment';
 
@@ -746,25 +751,25 @@ if (EMBER_MODULE_UNIFICATION) {
   moduleFor('Registry module unification', class extends AbstractTestCase {
     ['@test The registry can pass a source to the resolver'](assert) {
       let PrivateComponent = factory();
-      let lookup = 'component:my-input';
+      let type = 'component';
+      let name = 'my-input';
+      let specifier = `${type}:${name}`;
       let source = 'template:routes/application';
-      let resolveCount = 0;
-      let resolver = {
-        resolve(fullName, src) {
-          resolveCount++;
-          if (fullName === lookup && src === source) {
-            return PrivateComponent;
-          }
-        }
-      };
-      let registry = new Registry({ resolver });
-      registry.normalize = function(name) {
-        return name;
-      };
 
-      assert.strictEqual(registry.resolve(lookup, { source }), PrivateComponent, 'The correct factory was provided');
-      assert.strictEqual(registry.resolve(lookup, { source }), PrivateComponent, 'The correct factory was provided again');
-      assert.equal(resolveCount, 1, 'resolve called only once and a cached factory was returned the second time');
+      let resolver = new ModuleBasedTestResolver();
+      resolver.add({specifier, source}, PrivateComponent);
+      let registry = new Registry({ resolver });
+
+      assert.strictEqual(
+        registry.resolve(specifier, { source }),
+        PrivateComponent,
+        'The correct factory was provided'
+      );
+      assert.strictEqual(
+        registry.resolve(specifier, { source }),
+        PrivateComponent,
+        'The correct factory was provided again'
+      );
     }
   });
 }

--- a/packages/internal-test-helpers/lib/test-resolver.js
+++ b/packages/internal-test-helpers/lib/test-resolver.js
@@ -1,25 +1,43 @@
 import { compile } from 'ember-template-compiler';
 
+const DELIMITER = '\0';
+
+function serializeKey(specifier, source) {
+  return [specifier, source].join(DELIMITER);
+}
+
 class Resolver {
   constructor() {
     this._registered = {};
     this.constructor.lastInstance = this;
   }
-  resolve(specifier) {
-    return this._registered[specifier];
+  resolve(specifier, source) {
+    return this._registered[serializeKey(specifier, source)];
   }
-  add(specifier, factory) {
-    if (specifier.indexOf(':') === -1) {
-      throw new Error('Specifiers added to the resolver must be in the format of type:name');
+  add(lookup, factory) {
+    let key;
+    switch (typeof lookup) {
+      case 'string':
+        if (lookup.indexOf(':') === -1) {
+          throw new Error('Specifiers added to the resolver must be in the format of type:name');
+        }
+        key = serializeKey(lookup);
+        break;
+      case 'object':
+        key = serializeKey(lookup.specifier, lookup.source);
+        break;
+      default:
+        throw new Error('Specifier string has an unknown type');
     }
-    return this._registered[specifier] = factory;
+
+    return this._registered[key] = factory;
   }
   addTemplate(templateName, template) {
     let templateType = typeof template;
     if (templateType !== 'string') {
       throw new Error(`You called addTemplate for "${templateName}" with a template argument of type of '${templateType}'. addTemplate expects an argument of an uncompiled template as a string.`);
     }
-    return this._registered[`template:${templateName}`] = compile(template, {
+    return this._registered[serializeKey(`template:${templateName}`)] = compile(template, {
       moduleName: templateName
     });
   }


### PR DESCRIPTION
Extracted from https://github.com/emberjs/ember.js/pull/16158

This patch improves the the test-mode resolver used across the suite. It allows the addition of a resolution with a referrer. For example:

```js
  moduleFor('Registry module unification', class extends AbstractTestCase {
    ['@test The registry can pass a referrer to the resolver'](assert) {
      let PrivateComponent = factory();
      let type = 'component';
      let name = 'my-input';
      let specifier = `${type}:${name}`;
      let referrer = 'template:routes/application';

      let resolver = new ModuleBasedTestResolver();
      resolver.add({specifier, referrer}, PrivateComponent); // <- added with the fullName, and an expected referrer
      let registry = new Registry({ resolver });

      assert.strictEqual(
        registry.resolve(specifier, { referrer }),
        PrivateComponent,
        'The correct factory was provided'
      );
      assert.strictEqual(
        registry.resolve(specifier, { referrer }),
        PrivateComponent,
        'The correct factory was provided again'
      );
    }
  });
```