### PR TITLE
[Module Unification] Introduce source to injections

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -43,9 +43,8 @@ for a detailed explanation.
   ([RFC](https://github.com/dgeb/rfcs/blob/module-unification/text/0000-module-unification.md))
   to Ember. This includes:
 
-  - Passing the `source` of a `lookup`/`factoryFor` call as the second argument
-    to an Ember resolver's `resolve` method (as a positional arg we will call
-    `referrer`).
+  - Passing the `source` of a `lookup`/`factoryFor` call as an argument to
+    `expandLocalLookup` on the resolver.
   - Making `lookupComponentPair` friendly to local/private resolutions. The
     new code ensures a local resolution is not paired with a global resolution.
 

--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -130,10 +130,6 @@ export default class Container {
     return { [OWNER]: this.owner };
   }
 
-  _resolverCacheKey(name) {
-    return this.registry.resolverCacheKey(name);
-  }
-
   /**
    Given a fullName, return the corresponding factory. The consumer of the factory
    is responsible for the destruction of any factory instances, as there is no
@@ -230,8 +226,7 @@ function lookup(container, fullName, options = {}) {
   }
 
   if (options.singleton !== false) {
-    let cacheKey = container._resolverCacheKey(normalizedName);
-    let cached = container.cache[cacheKey];
+    let cached = container.cache[normalizedName];
     if (cached !== undefined) {
       return cached;
     }
@@ -242,8 +237,7 @@ function lookup(container, fullName, options = {}) {
 
 
 function factoryFor(container, normalizedName, fullName) {
-  let cacheKey = container._resolverCacheKey(normalizedName);
-  let cached = container.factoryManagerCache[cacheKey];
+  let cached = container.factoryManagerCache[normalizedName];
 
   if (cached !== undefined) { return cached; }
 
@@ -263,7 +257,7 @@ function factoryFor(container, normalizedName, fullName) {
     manager = wrapManagerInDeprecationProxy(manager);
   }
 
-  container.factoryManagerCache[cacheKey] = manager;
+  container.factoryManagerCache[normalizedName] = manager;
   return manager;
 }
 
@@ -293,8 +287,7 @@ function instantiateFactory(container, normalizedName, fullName, options) {
   // SomeClass { singleton: true, instantiate: true } | { singleton: true } | { instantiate: true } | {}
   // By default majority of objects fall into this case
   if (isSingletonInstance(container, fullName, options)) {
-    let cacheKey = container._resolverCacheKey(normalizedName);
-    return container.cache[cacheKey] = factoryManager.create();
+    return container.cache[normalizedName] = factoryManager.create();
   }
 
   // SomeClass { singleton: false, instantiate: true }
@@ -364,13 +357,12 @@ function resetCache(container) {
 }
 
 function resetMember(container, fullName) {
-  let cacheKey = container._resolverCacheKey(fullName);
-  let member = container.cache[cacheKey];
+  let member = container.cache[fullName];
 
-  delete container.factoryManagerCache[cacheKey];
+  delete container.factoryManagerCache[fullName];
 
   if (member) {
-    delete container.cache[cacheKey];
+    delete container.cache[fullName];
 
     if (member.destroy) {
       member.destroy();

--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -151,10 +151,9 @@ export default class Registry {
     assert(`Attempting to register an unknown factory: '${fullName}'`, factory !== undefined);
 
     let normalizedName = this.normalize(fullName);
-    let cacheKey = this.resolverCacheKey(normalizedName);
-    assert(`Cannot re-register: '${fullName}', as it has already been resolved.`, !this._resolveCache[cacheKey]);
+    assert(`Cannot re-register: '${fullName}', as it has already been resolved.`, !this._resolveCache[normalizedName]);
 
-    this._failSet.delete(cacheKey);
+    this._failSet.delete(normalizedName);
     this.registrations[normalizedName] = factory;
     this._options[normalizedName] = options;
   }
@@ -180,14 +179,13 @@ export default class Registry {
     assert('fullName must be a proper full name', this.isValidFullName(fullName));
 
     let normalizedName = this.normalize(fullName);
-    let cacheKey = this.resolverCacheKey(normalizedName);
 
     this._localLookupCache = Object.create(null);
 
     delete this.registrations[normalizedName];
-    delete this._resolveCache[cacheKey];
+    delete this._resolveCache[normalizedName];
     delete this._options[normalizedName];
-    this._failSet.delete(cacheKey);
+    this._failSet.delete(normalizedName);
   }
 
   /**
@@ -567,10 +565,6 @@ export default class Registry {
     return injections;
   }
 
-  resolverCacheKey(name) {
-    return name;
-  }
-
   /**
    Given a fullName and a source fullName returns the fully resolved
    fullName. Used to allow for local lookup.
@@ -685,10 +679,9 @@ function resolve(registry, normalizedName, options) {
     }
   }
 
-  let cacheKey = registry.resolverCacheKey(normalizedName);
-  let cached = registry._resolveCache[cacheKey];
+  let cached = registry._resolveCache[normalizedName];
   if (cached !== undefined) { return cached; }
-  if (registry._failSet.has(cacheKey)) { return; }
+  if (registry._failSet.has(normalizedName)) { return; }
 
   let resolved;
 
@@ -701,9 +694,9 @@ function resolve(registry, normalizedName, options) {
   }
 
   if (resolved === undefined) {
-    registry._failSet.add(cacheKey);
+    registry._failSet.add(normalizedName);
   } else {
-    registry._resolveCache[cacheKey] = resolved;
+    registry._resolveCache[normalizedName] = resolved;
   }
 
   return resolved;

--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -151,9 +151,10 @@ export default class Registry {
     assert(`Attempting to register an unknown factory: '${fullName}'`, factory !== undefined);
 
     let normalizedName = this.normalize(fullName);
-    assert(`Cannot re-register: '${fullName}', as it has already been resolved.`, !this._resolveCache[normalizedName]);
+    let cacheKey = this.resolverCacheKey(normalizedName);
+    assert(`Cannot re-register: '${fullName}', as it has already been resolved.`, !this._resolveCache[cacheKey]);
 
-    this._failSet.delete(normalizedName);
+    this._failSet.delete(cacheKey);
     this.registrations[normalizedName] = factory;
     this._options[normalizedName] = options;
   }
@@ -179,13 +180,14 @@ export default class Registry {
     assert('fullName must be a proper full name', this.isValidFullName(fullName));
 
     let normalizedName = this.normalize(fullName);
+    let cacheKey = this.resolverCacheKey(normalizedName);
 
     this._localLookupCache = Object.create(null);
 
     delete this.registrations[normalizedName];
-    delete this._resolveCache[normalizedName];
+    delete this._resolveCache[cacheKey];
     delete this._options[normalizedName];
-    this._failSet.delete(normalizedName);
+    this._failSet.delete(cacheKey);
   }
 
   /**
@@ -224,7 +226,6 @@ export default class Registry {
    @return {Function} fullName's factory
    */
   resolve(fullName, options) {
-    assert('fullName must be a proper full name', this.isValidFullName(fullName));
     let factory = resolve(this, this.normalize(fullName), options);
     if (factory === undefined && this.fallback !== null) {
       factory = this.fallback.resolve(...arguments);
@@ -450,7 +451,7 @@ export default class Registry {
     let injections = this._typeInjections[type] ||
                      (this._typeInjections[type] = []);
 
-    injections.push({ property, fullName });
+    injections.push({ property, specifier: fullName });
   }
 
   /**
@@ -514,7 +515,7 @@ export default class Registry {
     let injections = this._injections[normalizedName] ||
                      (this._injections[normalizedName] = []);
 
-    injections.push({ property, fullName: normalizedInjectionName });
+    injections.push({ property, specifier: normalizedInjectionName });
   }
 
   /**
@@ -566,12 +567,8 @@ export default class Registry {
     return injections;
   }
 
-  resolverCacheKey(name, options) {
-    if (!EMBER_MODULE_UNIFICATION) {
-      return name;
-    }
-
-    return (options && options.source) ? `${options.source}:${name}` : name;
+  resolverCacheKey(name) {
+    return name;
   }
 
   /**
@@ -625,11 +622,13 @@ if (DEBUG) {
 
     for (let key in hash) {
       if (hash.hasOwnProperty(key)) {
-        assert(`Expected a proper full name, given '${hash[key]}'`, this.isValidFullName(hash[key]));
+        let { specifier, source } = hash[key];
+        assert(`Expected a proper full name, given '${specifier}'`, this.isValidFullName(specifier));
 
         injections.push({
           property: key,
-          fullName: hash[key]
+          specifier,
+          source
         });
       }
     }
@@ -640,12 +639,10 @@ if (DEBUG) {
   Registry.prototype.validateInjections = function(injections) {
     if (!injections) { return; }
 
-    let fullName;
-
     for (let i = 0; i < injections.length; i++) {
-      fullName = injections[i].fullName;
+      let {specifier, source} = injections[i];
 
-      assert(`Attempting to inject an unknown injection: '${fullName}'`, this.has(fullName));
+      assert(`Attempting to inject an unknown injection: '${specifier}'`, this.has(specifier, {source}));
     }
   };
 }
@@ -688,7 +685,7 @@ function resolve(registry, normalizedName, options) {
     }
   }
 
-  let cacheKey = registry.resolverCacheKey(normalizedName, options);
+  let cacheKey = registry.resolverCacheKey(normalizedName);
   let cached = registry._resolveCache[cacheKey];
   if (cached !== undefined) { return cached; }
   if (registry._failSet.has(cacheKey)) { return; }
@@ -696,7 +693,7 @@ function resolve(registry, normalizedName, options) {
   let resolved;
 
   if (registry.resolver) {
-    resolved = registry.resolver.resolve(normalizedName, options && options.source);
+    resolved = registry.resolver.resolve(normalizedName);
   }
 
   if (resolved === undefined) {

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -388,7 +388,7 @@ moduleFor('Container', class extends AbstractTestCase {
     assert.deepEqual(resolveWasCalled, ['foo:post']);
   }
 
-  ['@test A factory\'s lazy injections are validated when first instantiated'](assert) {
+  [`@test A factory's lazy injections are validated when first instantiated`](assert) {
     let registry = new Registry();
     let container = registry.container();
     let Apple = factory();
@@ -396,7 +396,10 @@ moduleFor('Container', class extends AbstractTestCase {
 
     Apple.reopenClass({
       _lazyInjections() {
-        return ['orange:main', 'banana:main'];
+        return [
+          {specifier: 'orange:main'},
+          {specifier: 'banana:main'}
+        ];
       }
     });
 
@@ -419,7 +422,9 @@ moduleFor('Container', class extends AbstractTestCase {
     Apple.reopenClass({
       _lazyInjections: () => {
         assert.ok(true, 'should call lazy injection method');
-        return ['orange:main'];
+        return [
+          {specifier: 'orange:main'}
+        ];
       }
     });
 
@@ -637,18 +642,20 @@ moduleFor('Container', class extends AbstractTestCase {
 });
 
 if (EMBER_MODULE_UNIFICATION) {
-  QUnit.module('Container module unification');
-
   moduleFor('Container module unification', class extends AbstractTestCase {
-    ['@test The container can pass a source to factoryFor'](assert) {
+    ['@test The container can expand and resolve a source to factoryFor'](assert) {
       let PrivateComponent = factory();
       let lookup = 'component:my-input';
       let expectedSource = 'template:routes/application';
       let registry = new Registry();
       let resolveCount = 0;
-      registry.resolve = function(fullName, { source }) {
+      let expandedKey = 'boom, special expanded key';
+      registry.expandLocalLookup = function() {
+        return expandedKey;
+      };
+      registry.resolve = function(fullName) {
         resolveCount++;
-        if (fullName === lookup && source === expectedSource) {
+        if (fullName === expandedKey) {
           return PrivateComponent;
         }
       };
@@ -660,13 +667,17 @@ if (EMBER_MODULE_UNIFICATION) {
       assert.equal(resolveCount, 1, 'resolve called only once and a cached factory was returned the second time');
     }
 
-    ['@test The container can pass a source to lookup']() {
+    ['@test The container can expand and resolve a source to lookup']() {
       let PrivateComponent = factory();
       let lookup = 'component:my-input';
       let expectedSource = 'template:routes/application';
       let registry = new Registry();
-      registry.resolve = function(fullName, { source }) {
-        if (fullName === lookup && source === expectedSource) {
+      let expandedKey = 'boom, special expanded key';
+      registry.expandLocalLookup = function() {
+        return expandedKey;
+      };
+      registry.resolve = function(fullName) {
+        if (fullName === expandedKey) {
           return PrivateComponent;
         }
       };
@@ -676,7 +687,7 @@ if (EMBER_MODULE_UNIFICATION) {
       let result = container.lookup(lookup, { source: expectedSource });
       this.assert.ok(result instanceof PrivateComponent, 'The correct factory was provided');
 
-      this.assert.ok(container.cache[`template:routes/application:component:my-input`] instanceof PrivateComponent,
+      this.assert.ok(container.cache[expandedKey] instanceof PrivateComponent,
         'The correct factory was stored in the cache with the correct key which includes the source.');
     }
   });

--- a/packages/ember-application/tests/system/application_instance_test.js
+++ b/packages/ember-application/tests/system/application_instance_test.js
@@ -121,6 +121,29 @@ moduleFor('ApplicationInstance', class extends TestCase {
     assert.notStrictEqual(postController1, postController2, 'lookup creates a brand new instance, because the previous one was reset');
   }
 
+  ['@skip unregistering a factory clears caches with source of that factory'](assert) {
+    assert.expect(1);
+
+    appInstance = run(() => ApplicationInstance.create({ application }));
+
+    let PostController1 = factory();
+    let PostController2 = factory();
+
+    appInstance.register('controller:post', PostController1);
+
+    appInstance.lookup('controller:post');
+    let postControllerLookupWithSource = appInstance.lookup('controller:post', {source: 'doesnt-even-matter'});
+
+    appInstance.unregister('controller:post');
+    appInstance.register('controller:post', PostController2);
+
+    // The cache that is source-specific is not cleared
+    assert.ok(
+      postControllerLookupWithSource !== appInstance.lookup('controller:post', {source: 'doesnt-even-matter'}),
+      'lookup with source creates a new instance'
+    );
+  }
+
   ['@test can build and boot a registered engine'](assert) {
     assert.expect(11);
 

--- a/packages/ember-application/tests/test-helpers/registry-check.js
+++ b/packages/ember-application/tests/test-helpers/registry-check.js
@@ -18,7 +18,7 @@ export function verifyInjection(assert, owner, fullName, property, injectionName
 
   for (let i = 0, l = injections.length; i < l; i++) {
     injection = injections[i];
-    if (injection.property === property && injection.fullName === normalizedName) {
+    if (injection.property === property && injection.specifier === normalizedName) {
       hasInjection = true;
       break;
     }

--- a/packages/ember-glimmer/tests/integration/application/rendering-test.js
+++ b/packages/ember-glimmer/tests/integration/application/rendering-test.js
@@ -407,7 +407,7 @@ moduleFor('Application test: rendering', class extends ApplicationTest {
       template: 'Hi {{person.name}} from component'
     });
 
-    let expectedBacktrackingMessage = /modified "model\.name" twice on \[object Object\] in a single render\. It was rendered in "template:routeWithError" and modified in "component:x-foo"/;
+    let expectedBacktrackingMessage = /modified "model\.name" twice on \[object Object\] in a single render\. It was rendered in "template:my-app\/templates\/routeWithError.hbs" and modified in "component:x-foo"/;
 
     return this.visit('/').then(() => {
       expectAssertion(() => {

--- a/packages/ember-glimmer/tests/integration/components/local-lookup-test.js
+++ b/packages/ember-glimmer/tests/integration/components/local-lookup-test.js
@@ -202,14 +202,20 @@ function buildResolver() {
       let [sourceType, sourceName ] = sourceFullName.split(':');
       let [type, name ] = fullName.split(':');
 
-      if (type !== 'template' && sourceType === 'template' && sourceName.slice(0, 11) === 'components/') {
-        sourceName = sourceName.slice(11);
+      sourceName = sourceName.replace('my-app/', '');
+
+      if (sourceType === 'template' && sourceName.slice(0, 21) === 'templates/components/') {
+        sourceName = sourceName.slice(21);
       }
 
-      if (type === 'template' && sourceType === 'template' && name.slice(0, 11) === 'components/') {
+      name = name.replace('my-app/', '');
+
+      if (type === 'template' && name.slice(0, 11) === 'components/') {
         name = name.slice(11);
+        sourceName = `components/${sourceName}`;
       }
 
+      sourceName = sourceName.replace('.hbs', '');
 
       let result = `${type}:${sourceName}/${name}`;
 
@@ -229,13 +235,15 @@ moduleFor('Components test: local lookup with expandLocalLookup feature', class 
 if (EMBER_MODULE_UNIFICATION) {
   class LocalLookupTestResolver extends ModuleBasedTestResolver {
     resolve(specifier, referrer) {
+      let [type, name ] = specifier.split(':');
       let fullSpecifier = specifier;
 
       if (referrer) {
-        let namespace = referrer.split('template:components/')[1];
+        let namespace = referrer.split('components/')[1] || '';
+        namespace = namespace.replace('.hbs', '');
         if (specifier.indexOf('template:components/') !== -1) {
-            let name = specifier.split('template:components/')[1];
-            fullSpecifier = `template:components/${namespace}/${name}`;
+          name = name.replace('components/', '');
+          fullSpecifier = `${type}:components/${namespace}/${name}`;
         } else if (specifier.indexOf(':') !== -1) {
           let [type, name] = specifier.split(':');
           fullSpecifier = `${type}:${namespace}/${name}`;
@@ -272,7 +280,7 @@ if (EMBER_MODULE_UNIFICATION) {
 
       if (typeof template === 'string') {
         resolver.add(`template:components/${name}`, this.compile(template, {
-          moduleName: `components/${name}`
+          moduleName: `my-name/templates/components/${name}.hbs`
         }));
       }
     }
@@ -281,7 +289,7 @@ if (EMBER_MODULE_UNIFICATION) {
       let { resolver } = this;
       if (typeof template === 'string') {
         resolver.add(`template:${name}`, this.compile(template, {
-          moduleName: name
+          moduleName: `my-name/templates/${name}.hbs`
         }));
       } else {
         throw new Error(`Registered template "${name}" must be a string`);

--- a/packages/ember-glimmer/tests/integration/mount-test.js
+++ b/packages/ember-glimmer/tests/integration/mount-test.js
@@ -64,7 +64,7 @@ moduleFor('{{mount}} test', class extends ApplicationTest {
   }
 
   ['@test it boots an engine, instantiates its application controller, and renders its application template'](assert) {
-    this.engineRegistrations['template:application'] = compile('<h2>Chat here, {{username}}</h2>', { moduleName: 'application' });
+    this.engineRegistrations['template:application'] = compile('<h2>Chat here, {{username}}</h2>', { moduleName: 'my-app/templates/application.hbs' });
 
     let controller;
 
@@ -103,12 +103,12 @@ moduleFor('{{mount}} test', class extends ApplicationTest {
     this.addTemplate('index', '');
     this.addTemplate('route-with-mount', '{{mount "chat"}}');
 
-    this.engineRegistrations['template:application'] = compile('hi {{person.name}} [{{component-with-backtracking-set person=person}}]', { moduleName: 'application' });
+    this.engineRegistrations['template:application'] = compile('hi {{person.name}} [{{component-with-backtracking-set person=person}}]', { moduleName: 'my-app/templates/application.hbs' });
     this.engineRegistrations['controller:application'] = Controller.extend({
       person: { name: 'Alex' }
     });
 
-    this.engineRegistrations['template:components/component-with-backtracking-set'] = compile('[component {{person.name}}]', { moduleName: 'components/component-with-backtracking-set' });
+    this.engineRegistrations['template:components/component-with-backtracking-set'] = compile('[component {{person.name}}]', { moduleName: 'my-app/templates/components/component-with-backtracking-set.hbs' });
     this.engineRegistrations['component:component-with-backtracking-set'] = Component.extend({
       init() {
         this._super(...arguments);
@@ -116,7 +116,7 @@ moduleFor('{{mount}} test', class extends ApplicationTest {
       }
     });
 
-    let expectedBacktrackingMessage = /modified "person\.name" twice on \[object Object\] in a single render\. It was rendered in "template:route-with-mount" \(in "engine:chat"\) and modified in "component:component-with-backtracking-set" \(in "engine:chat"\)/;
+    let expectedBacktrackingMessage = /modified "person\.name" twice on \[object Object\] in a single render\. It was rendered in "template:my-app\/templates\/route-with-mount.hbs" \(in "engine:chat"\) and modified in "component:component-with-backtracking-set" \(in "engine:chat"\)/;
 
     return this.visit('/').then(() => {
       expectAssertion(() => {
@@ -143,14 +143,14 @@ moduleFor('{{mount}} test', class extends ApplicationTest {
       router: null,
       init() {
         this._super(...arguments);
-        this.register('template:application', compile('<h2>Foo Engine</h2>', { moduleName: 'application' }));
+        this.register('template:application', compile('<h2>Foo Engine</h2>', { moduleName: 'my-app/templates/application.hbs' }));
       }
     }));
     this.add('engine:bar', Engine.extend({
       router: null,
       init() {
         this._super(...arguments);
-        this.register('template:application', compile('<h2>Bar Engine</h2>', { moduleName: 'application' }));
+        this.register('template:application', compile('<h2>Bar Engine</h2>', { moduleName: 'my-app/templates/application.hbs' }));
       }
     }));
 
@@ -203,7 +203,7 @@ moduleFor('{{mount}} test', class extends ApplicationTest {
       router: null,
       init() {
         this._super(...arguments);
-        this.register('template:application', compile('<h2>Foo Engine: {{tagless-component}}</h2>', { moduleName: 'application' }));
+        this.register('template:application', compile('<h2>Foo Engine: {{tagless-component}}</h2>', { moduleName: 'my-app/templates/application.hbs' }));
         this.register('component:tagless-component', Component.extend({
           tagName: "",
           init() {
@@ -211,7 +211,7 @@ moduleFor('{{mount}} test', class extends ApplicationTest {
             component = this;
           }
         }));
-        this.register('template:components/tagless-component', compile('Tagless Component', { moduleName: 'components/tagless-component' }));
+        this.register('template:components/tagless-component', compile('Tagless Component', { moduleName: 'my-app/templates/components/tagless-component.hbs' }));
       }
     }));
 
@@ -236,7 +236,7 @@ if (EMBER_ENGINES_MOUNT_PARAMS) {
         router: null,
         init() {
           this._super(...arguments);
-          this.register('template:application', compile('<h2>Param Engine: {{model.foo}}</h2>', { moduleName: 'application' }));
+          this.register('template:application', compile('<h2>Param Engine: {{model.foo}}</h2>', { moduleName: 'my-app/templates/application.hbs' }));
         }
       }));
     }
@@ -311,7 +311,7 @@ if (EMBER_ENGINES_MOUNT_PARAMS) {
         router: null,
         init() {
           this._super(...arguments);
-          this.register('template:application', compile('{{model.foo}}', { moduleName: 'application' }));
+          this.register('template:application', compile('{{model.foo}}', { moduleName: 'my-app/templates/application.hbs' }));
         }
       }));
       this.addTemplate('engine-params-contextual-component', '{{mount "componentParamEngine" model=(hash foo=(component "foo-component"))}}');

--- a/packages/ember-glimmer/tests/unit/template-factory-test.js
+++ b/packages/ember-glimmer/tests/unit/template-factory-test.js
@@ -9,7 +9,7 @@ moduleFor('Template factory test', class extends RenderingTest {
     let { runtimeResolver } = this;
 
     let templateStr = 'Hello {{name}}';
-    let options = { moduleName: 'some-module' };
+    let options = { moduleName: 'my-app/templates/some-module.hbs' };
 
     let spec = precompile(templateStr, options);
     let body = `exports.default = template(${spec});`;

--- a/packages/ember-metal/lib/injected_property.js
+++ b/packages/ember-metal/lib/injected_property.js
@@ -20,11 +20,12 @@ import { descriptorFor } from './meta';
   @private
 */
 export default class InjectedProperty extends ComputedProperty {
-  constructor(type, name) {
+  constructor(type, name, options) {
     super(injectedPropertyGet);
 
     this.type = type;
     this.name = name;
+    this.source = options ? options.source : undefined;
   }
 }
 
@@ -35,5 +36,6 @@ function injectedPropertyGet(keyName) {
   assert(`InjectedProperties should be defined with the inject computed property macros.`, desc && desc.type);
   assert(`Attempting to lookup an injected property on an object without a container, ensure that the object was instantiated via a container.`, owner);
 
-  return owner.lookup(`${desc.type}:${desc.name || keyName}`);
+  let specifier = `${desc.type}:${desc.name || keyName}`;
+  return owner.lookup(specifier, {source: desc.source});
 }

--- a/packages/ember-runtime/lib/inject.js
+++ b/packages/ember-runtime/lib/inject.js
@@ -1,5 +1,7 @@
 import { InjectedProperty, descriptorFor } from 'ember-metal';
 import { assert } from 'ember-debug';
+import { EMBER_MODULE_UNIFICATION } from 'ember/features';
+
 /**
 @module ember
 */
@@ -35,7 +37,11 @@ const typeValidators = {};
 export function createInjectionHelper(type, validator) {
   typeValidators[type] = validator;
 
-  inject[type] = name => new InjectedProperty(type, name);
+  if (EMBER_MODULE_UNIFICATION) {
+    inject[type] = (name, options) => new InjectedProperty(type, name, options);
+  } else {
+    inject[type] = name => new InjectedProperty(type, name);
+  }
 }
 
 /**

--- a/packages/ember-runtime/lib/mixins/registry_proxy.js
+++ b/packages/ember-runtime/lib/mixins/registry_proxy.js
@@ -2,6 +2,7 @@
 @module ember
 */
 
+import { assert } from 'ember-debug';
 import {
   Mixin
 } from 'ember-metal';
@@ -24,7 +25,10 @@ export default Mixin.create({
    @param {String} fullName
    @return {Function} fullName's factory
    */
-  resolveRegistration: registryAlias('resolve'),
+  resolveRegistration(fullName, options) {
+    assert('fullName must be a proper full name', this.__registry__.isValidFullName(fullName));
+    return this.__registry__.resolve(fullName, options);
+  },
 
   /**
     Registers a factory that can be used for dependency injection (with

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -1020,7 +1020,10 @@ if (DEBUG) {
     for (key in proto) {
       desc = descriptorFor(proto, key);
       if (desc instanceof InjectedProperty) {
-        injections[key] = `${desc.type}:${desc.name || key}`;
+        injections[key] = {
+          specifier: `${desc.type}:${desc.name || key}`,
+          source: desc.source
+        };
       }
     }
 

--- a/packages/ember-runtime/tests/inject_test.js
+++ b/packages/ember-runtime/tests/inject_test.js
@@ -61,6 +61,11 @@ if (DEBUG) {
       bar: new InjectedProperty('quux')
     });
 
-    assert.deepEqual(AnObject._lazyInjections(), { 'foo': 'foo:bar', 'bar': 'quux:bar' }, 'should return injected container keys');
+    assert.deepEqual(
+      AnObject._lazyInjections(),
+      {
+        'foo': { specifier: 'foo:bar', source: undefined },
+        'bar': { specifier: 'quux:bar', source: undefined }
+      }, 'should return injected container keys');
   });
 }

--- a/packages/ember/tests/integration/multiple-app-test.js
+++ b/packages/ember/tests/integration/multiple-app-test.js
@@ -61,7 +61,7 @@ moduleFor('View Integration', class extends ApplicationTestCase {
       this.compile(`
         <h1>Node 1</h1>{{special-button}}
       `, {
-        moduleName: 'index'
+        moduleName: 'my-app/templates/index.hbs'
       })
     );
     resolver.add(
@@ -69,7 +69,7 @@ moduleFor('View Integration', class extends ApplicationTestCase {
       this.compile(`
         <button class='do-stuff' {{action 'doStuff'}}>Button</button>
       `, {
-        moduleName: 'components/special-button'
+        moduleName: 'my-app/templates/components/special-button.hbs'
       })
     );
   }

--- a/packages/ember/tests/service_injection_test.js
+++ b/packages/ember/tests/service_injection_test.js
@@ -2,7 +2,7 @@ import { Controller } from 'ember-runtime';
 import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
 import { inject, Service } from 'ember-runtime';
 import { computed } from 'ember-metal';
-import { EMBER_METAL_ES5_GETTERS } from 'ember/features';
+import { EMBER_METAL_ES5_GETTERS, EMBER_MODULE_UNIFICATION } from 'ember/features';
 
 moduleFor('Service Injection', class extends ApplicationTestCase {
 
@@ -42,4 +42,132 @@ if (EMBER_METAL_ES5_GETTERS) {
       });
     }
   });
+}
+
+if (EMBER_MODULE_UNIFICATION) {
+  moduleFor('Service Injection (MU)', class extends ApplicationTestCase {
+    ['@test Service can be injected with source and is resolved'](assert) {
+      let source = 'controller:src/ui/routes/application/controller';
+      this.add('controller:application', Controller.extend({
+        myService: inject.service('my-service', { source })
+      }));
+      let MyService = Service.extend();
+      this.add({
+        specifier: 'service:my-service',
+        source
+      }, MyService);
+
+      return this.visit('/').then(() => {
+        let controller = this.applicationInstance.lookup('controller:application');
+
+        assert.ok(controller.get('myService') instanceof MyService);
+      });
+    }
+
+    ['@test Services can be injected with same name, different source, and resolve different instances'](assert) {
+      // This test implies that there is a file src/ui/routes/route-a/-services/my-service
+      let routeASource = 'controller:src/ui/routes/route-a/controller';
+      // This test implies that there is a file src/ui/routes/route-b/-services/my-service
+      let routeBSource = 'controller:src/ui/routes/route-b/controller';
+
+      this.add('controller:route-a', Controller.extend({
+        myService: inject.service('my-service', { source: routeASource })
+      }));
+
+      this.add('controller:route-b', Controller.extend({
+        myService: inject.service('my-service', { source: routeBSource })
+      }));
+
+      let LocalLookupService = Service.extend();
+      this.add({
+        specifier: 'service:my-service',
+        source: routeASource
+      }, LocalLookupService);
+
+      let MyService = Service.extend();
+      this.add({
+        specifier: 'service:my-service',
+        source: routeBSource
+      }, MyService);
+
+      return this.visit('/').then(() => {
+        let controllerA = this.applicationInstance.lookup('controller:route-a');
+        let serviceFromControllerA = controllerA.get('myService');
+        assert.ok(serviceFromControllerA instanceof LocalLookupService, 'local lookup service is returned');
+
+        let controllerB = this.applicationInstance.lookup('controller:route-b');
+        let serviceFromControllerB = controllerB.get('myService');
+        assert.ok(serviceFromControllerB instanceof MyService, 'global service is returned');
+
+        assert.notStrictEqual(serviceFromControllerA, serviceFromControllerB);
+      });
+    }
+
+    ['@test Services can be injected with same name, different source, but same resolution result, and share an instance'](assert) {
+      let routeASource = 'controller:src/ui/routes/route-a/controller';
+      let routeBSource = 'controller:src/ui/routes/route-b/controller';
+
+      this.add('controller:route-a', Controller.extend({
+        myService: inject.service('my-service', { source: routeASource })
+      }));
+
+      this.add('controller:route-b', Controller.extend({
+        myService: inject.service('my-service', { source: routeBSource })
+      }));
+
+      let MyService = Service.extend();
+      this.add({
+        specifier: 'service:my-service'
+      }, MyService);
+
+      return this.visit('/').then(() => {
+        let controllerA = this.applicationInstance.lookup('controller:route-a');
+        let serviceFromControllerA = controllerA.get('myService');
+        assert.ok(serviceFromControllerA instanceof MyService);
+
+        let controllerB = this.applicationInstance.lookup('controller:route-b');
+        assert.strictEqual(serviceFromControllerA, controllerB.get('myService'));
+      });
+    }
+
+    /*
+     * This test demonstrates a failure in the caching system of ember's
+     * container around singletons and and local lookup. The local lookup
+     * is cached and the global injection is then looked up incorrectly.
+     *
+     * The paractical rules of Ember's module unification config are such
+     * that services cannot be locally looked up, thus this case is really
+     * just a demonstration of what could go wrong if we permit arbitrary
+     * configuration (such as a singleton type that has local lookup).
+     */
+    ['@test Services can be injected with same name, one with source one without, and share an instance'](assert) {
+      let routeASource = 'controller:src/ui/routes/route-a/controller';
+      this.add('controller:route-a', Controller.extend({
+        myService: inject.service('my-service', { source: routeASource })
+      }));
+
+      this.add('controller:route-b', Controller.extend({
+        myService: inject.service('my-service')
+      }));
+
+      let MyService = Service.extend();
+      this.add({
+        specifier: 'service:my-service'
+      }, MyService);
+
+      return this.visit('/').then(() => {
+        let controllerA = this.applicationInstance.lookup('controller:route-a');
+        let serviceFromControllerA = controllerA.get('myService');
+        assert.ok(serviceFromControllerA instanceof MyService, 'global service is returned');
+
+        let controllerB = this.applicationInstance.lookup('controller:route-b');
+        let serviceFromControllerB = controllerB.get('myService');
+        assert.ok(serviceFromControllerB instanceof MyService, 'global service is returned');
+
+        assert.strictEqual(serviceFromControllerA, serviceFromControllerB);
+      });
+    }
+
+  });
+
 }

--- a/packages/internal-test-helpers/lib/test-cases/abstract-rendering.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract-rendering.js
@@ -98,8 +98,7 @@ export default class AbstractRenderingTestCase extends AbstractTestCase {
   registerPartial(name, template) {
     let owner = this.env.owner || this.owner;
     if (typeof template === 'string') {
-      let moduleName = `template:${name}`;
-      owner.register(moduleName, this.compile(template, { moduleName }));
+      owner.register(`template:${name}`, this.compile(template, { moduleName: `my-app/templates/-${name}.hbs` }));
     }
   }
 
@@ -112,7 +111,7 @@ export default class AbstractRenderingTestCase extends AbstractTestCase {
 
     if (typeof template === 'string') {
       owner.register(`template:components/${name}`, this.compile(template, {
-        moduleName: `components/${name}`
+        moduleName: `my-app/templates/components/${name}.hbs`
       }));
     }
   }
@@ -121,7 +120,7 @@ export default class AbstractRenderingTestCase extends AbstractTestCase {
     let { owner } = this;
     if (typeof template === 'string') {
       owner.register(`template:${name}`, this.compile(template, {
-        moduleName: name
+        moduleName: `my-app/templates/${name}.hbs`
       }));
     } else {
       throw new Error(`Registered template "${name}" must be a string`);

--- a/packages/internal-test-helpers/lib/test-cases/test-resolver-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/test-resolver-application.js
@@ -17,7 +17,7 @@ export default class TestResolverApplicationTestCase extends AbstractApplication
 
   addTemplate(templateName, templateString) {
     this.resolver.add(`template:${templateName}`, this.compile(templateString, {
-      moduleName: templateName
+      moduleName: `my-app/templates/${templateName}.hbs`
     }));
   }
 
@@ -28,7 +28,7 @@ export default class TestResolverApplicationTestCase extends AbstractApplication
 
     if (typeof template === 'string') {
       this.resolver.add(`template:components/${name}`, this.compile(template, {
-        moduleName: `components/${name}`
+        moduleName: `my-app/templates/components/${name}.hbs`
       }));
     }
   }

--- a/packages/internal-test-helpers/lib/test-resolver.js
+++ b/packages/internal-test-helpers/lib/test-resolver.js
@@ -1,6 +1,6 @@
 import { compile } from 'ember-template-compiler';
 
-const DELIMITER = '\0';
+const DELIMITER = '%';
 
 function serializeKey(specifier, source) {
   return [specifier, source].join(DELIMITER);
@@ -11,8 +11,19 @@ class Resolver {
     this._registered = {};
     this.constructor.lastInstance = this;
   }
-  resolve(specifier, source) {
-    return this._registered[serializeKey(specifier, source)];
+  resolve(specifier) {
+    return this._registered[specifier] || this._registered[serializeKey(specifier)];
+  }
+  expandLocalLookup(specifier, source) {
+    let key = serializeKey(specifier, source);
+    if (this._registered[key]) {
+      return key;
+    }
+
+    /*
+     * For a top-level resolution or no resolution, return null
+     */
+    return null;
   }
   add(lookup, factory) {
     let key;

--- a/packages/internal-test-helpers/lib/test-resolver.js
+++ b/packages/internal-test-helpers/lib/test-resolver.js
@@ -38,7 +38,7 @@ class Resolver {
       throw new Error(`You called addTemplate for "${templateName}" with a template argument of type of '${templateType}'. addTemplate expects an argument of an uncompiled template as a string.`);
     }
     return this._registered[serializeKey(`template:${templateName}`)] = compile(template, {
-      moduleName: templateName
+      moduleName: `my-app/templates/${templateName}.hbs`
     });
   }
   static create() {


### PR DESCRIPTION
Ember templates use a `source` argument to the container. This hints where to look for "local lookup", and also what namespace to look in for a partial specifier. For example a template in an addon's `src` tree can invoke components and helpers in that tree because it has a `source` argument passed to lookups.

This introduces the same functionality for service injections. A service can now accept a `source` argument and its lookup will apply to the namespace of that file.

Additionally:

* Use `expandLocalLookup` to for the resolution of local item instead of a new argument to `resolve` on resolvers.
* Get rid of `resolverCacheKey`, no longer needed.