### PR TITLE
[BUGFIX beta] computed.sort should not sort if sortProperties is empty

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -837,7 +837,11 @@ function propertySort(itemsKey, sortPropertiesKey) {
     let items = itemsKeyIsAtThis ? this : get(this, itemsKey);
     if (!isArray(items)) { return emberA(); }
 
-    return sortByNormalizedSortProperties(items, normalizedSortProperties);
+    if (normalizedSortProperties.length === 0) {
+      return emberA(items.slice());
+    } else {
+      return sortByNormalizedSortProperties(items, normalizedSortProperties);
+    }
   }, { dependentKeys: [`${sortPropertiesKey}.[]`], readOnly: true });
 
   cp._activeObserverMap = undefined;

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -1116,6 +1116,20 @@ QUnit.test('updating an item\'s sort properties does not error when binary searc
   ], 'array is sorted correctly');
 });
 
+QUnit.test('array should not be sorted if sort properties array is empty', function(assert) {
+  var o = EmberObject.extend({
+    sortedItems: sort('items', 'itemSorting')
+  }).create({
+    itemSorting: emberA([]),
+    // This bug only manifests when array.sort(() => 0) is not equal to array.
+    // In order for this to happen, the browser must use an unstable sort and the
+    // array must be sufficient large. On Chrome, 12 items is currently sufficient.
+    items: emberA([6, 7, 8, 9, 10, 11, 0, 1, 2, 3, 4, 5])
+  });
+
+  assert.deepEqual(o.get('sortedItems'), [6, 7, 8, 9, 10, 11, 0, 1, 2, 3, 4, 5], 'array is not changed');
+});
+
 QUnit.test('array observers do not leak', function(assert) {
   let daria = { name: 'Daria' };
   let jane  = { name: 'Jane' };


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember.js/issues/13037.
Closes https://github.com/emberjs/ember.js/pull/13124.

This bug only manifests when `array.sort(() => 0)` is not equal to `array`. In order for this to happen, the browser must internally be using an unstable sort and the array must be sufficient large. On Chrome, 12 items is currently sufficient. (Safari and Firefox use stable sorts so it isn't an issue there).
