### PR TITLE
[RFC 297] Deprecation of Ember.Logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "ember-cli-yuidoc": "^0.8.8",
     "ember-publisher": "0.0.7",
     "eslint": "^3.0.0",
-    "eslint-plugin-ember-internal": "^1.1.0",
+    "eslint-plugin-ember-internal": "^1.1.1",
     "execa": "^0.9.0",
     "express": "^4.16.2",
     "finalhandler": "^1.0.2",

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -345,7 +345,7 @@ moduleFor('Application Dependency Injection - Integration - default resolver', c
 
     this.applicationInstance.resolveRegistration('doo:scooby');
     this.applicationInstance.resolveRegistration('doo:scrappy');
-    assert.equal(infoCount, 0, 'Logger.info should not be called if LOG_RESOLVER is not set');
+    assert.equal(infoCount, 0, 'console.info should not be called if LOG_RESOLVER is not set');
   }
 
 });

--- a/packages/ember-application/tests/system/logging_test.js
+++ b/packages/ember-application/tests/system/logging_test.js
@@ -5,7 +5,6 @@ import {
   ApplicationTestCase
 } from 'internal-test-helpers';
 
-import Logger from 'ember-console';
 import { Controller } from 'ember-runtime';
 import { Route } from 'ember-routing';
 import { assign } from 'ember-utils';
@@ -17,14 +16,16 @@ class LoggingApplicationTestCase extends ApplicationTestCase {
 
     this.logs = {};
 
-    this._originalLogger = Logger.info;
+    /* eslint-disable no-console */
+    this._originalLogger = console.info;
 
-    Logger.info = (_, {fullName}) => {
+    console.info = (_, {fullName}) => {
       if (!this.logs.hasOwnProperty(fullName)) {
         this.logs[fullName] = 0;
       }
-      this.logs[fullName]++;
-    };
+    /* eslint-ensable no-console */
+    this.logs[fullName]++;
+  };
 
     this.router.map(function() {
       this.route('posts', { resetNamespace: true });
@@ -32,7 +33,9 @@ class LoggingApplicationTestCase extends ApplicationTestCase {
   }
 
   teardown() {
-    Logger.info = this._originalLogger;
+    /* eslint-disable no-console */
+    console.info = this._originalLogger;
+    /* eslint-enable no-console */
     super.teardown();
   }
 }

--- a/packages/ember-console/lib/index.js
+++ b/packages/ember-console/lib/index.js
@@ -1,3 +1,10 @@
+import { deprecate } from 'ember-debug';
+
+// Deliver message that the function is deprecated
+
+const DEPRECATION_MESSAGE = 'Use of Ember.Logger is deprecated. Please use `console` for logging.';
+const DEPRECATION_ID = 'ember-console.deprecate-logger';
+const DEPRECATION_URL = 'https://emberjs.com/deprecations/v3.x#toc_use-console-rather-than-ember-logger';
 /**
    @module ember
 */
@@ -6,6 +13,8 @@
   Override this to provide more robust logging functionality.
 
   @class Logger
+  @deprecated Use 'console' instead
+
   @namespace Ember
   @public
 */
@@ -25,7 +34,10 @@ export default {
    @param {*} arguments
    @public
   */
-  log() { return console.log(...arguments);}, // eslint-disable-line no-console
+  log() { 
+    deprecate( DEPRECATION_MESSAGE, false, { id: DEPRECATION_ID, until: '4.0.0', url: DEPRECATION_URL } );
+    return console.log(...arguments); // eslint-disable-line no-console
+  },
 
   /**
    Prints the arguments to the console with a warning icon.
@@ -41,7 +53,10 @@ export default {
    @param {*} arguments
    @public
   */
-  warn() { return console.warn(...arguments);}, // eslint-disable-line no-console
+  warn() { 
+    deprecate( DEPRECATION_MESSAGE, false, { id: DEPRECATION_ID, until: '4.0.0', url: DEPRECATION_URL } );
+    return console.warn(...arguments); // eslint-disable-line no-console
+  },
 
   /**
    Prints the arguments to the console with an error icon, red text and a stack trace.
@@ -57,7 +72,10 @@ export default {
    @param {*} arguments
    @public
   */
-  error() { return console.error(...arguments);}, // eslint-disable-line no-console
+  error() { 
+    deprecate( DEPRECATION_MESSAGE, false, { id: DEPRECATION_ID, until: '4.0.0', url: DEPRECATION_URL } );
+    return console.error(...arguments); // eslint-disable-line no-console
+  },
 
   /**
    Logs the arguments to the console.
@@ -74,7 +92,10 @@ export default {
    @param {*} arguments
    @public
   */
-  info() { return console.info(...arguments);}, // eslint-disable-line no-console
+  info() { 
+    deprecate( DEPRECATION_MESSAGE, false, { id: DEPRECATION_ID, until: '4.0.0', url: DEPRECATION_URL } );
+    return console.info(...arguments); // eslint-disable-line no-console
+  },
 
   /**
    Logs the arguments to the console in blue text.
@@ -92,11 +113,11 @@ export default {
    @public
   */
   debug() {
+    deprecate( DEPRECATION_MESSAGE, false, { id: DEPRECATION_ID, until: '4.0.0', url: DEPRECATION_URL } );
     /* eslint-disable no-console */
     if (console.debug) {
       return console.debug(...arguments);
     }
-
     return console.info(...arguments);
     /* eslint-enable no-console */
   },
@@ -116,5 +137,8 @@ export default {
    @param {String} message Assertion message on failed
    @public
   */
-  assert() { return console.assert(...arguments);} // eslint-disable-line no-console
+  assert() { 
+    deprecate( DEPRECATION_MESSAGE, false, { id: DEPRECATION_ID, until: '4.0.0', url: DEPRECATION_URL } );
+    return console.assert(...arguments); // eslint-disable-line no-console
+  }
 };

--- a/packages/ember-debug/lib/deprecate.js
+++ b/packages/ember-debug/lib/deprecate.js
@@ -2,7 +2,6 @@
 import { DEBUG } from 'ember-env-flags';
 
 import EmberError from './error';
-import Logger from 'ember-console';
 
 import { ENV } from 'ember-environment';
 
@@ -74,8 +73,7 @@ if (DEBUG) {
 
   registerHandler(function logDeprecationToConsole(message, options) {
     let updatedMessage = formatMessage(message, options);
-
-    Logger.warn(`DEPRECATION: ${updatedMessage}`);
+    console.warn(`DEPRECATION: ${updatedMessage}`); // eslint-disable-line no-console
   });
 
   let captureErrorForStack;
@@ -112,8 +110,8 @@ if (DEBUG) {
 
       let updatedMessage = formatMessage(message, options);
 
-      Logger.warn(`DEPRECATION: ${updatedMessage}${stackStr}`);
-    } else {
+    console.warn(`DEPRECATION: ${updatedMessage}${stackStr}`); // eslint-disable-line no-console 
+  } else {
       next(...arguments);
     }
   });

--- a/packages/ember-debug/lib/index.js
+++ b/packages/ember-debug/lib/index.js
@@ -1,6 +1,5 @@
 import { DEBUG } from 'ember-env-flags';
 import { ENV, environment } from 'ember-environment';
-import Logger from 'ember-console';
 import { isTesting } from './testing';
 import EmberError from './error';
 import { default as isFeatureEnabled } from './features';
@@ -117,8 +116,15 @@ if (DEBUG) {
     @public
   */
   setDebugFunction('debug', function debug(message) {
-    Logger.debug(`DEBUG: ${message}`);
+    /* eslint-disable no-console */
+    if (console.debug) {
+      console.debug(`DEBUG: ${message}`);
+    } else {
+      console.log(`DEBUG: ${message}`);
+    }
+    /* eslint-ensable no-console */  
   });
+
 
   /**
     Display an info notice.
@@ -129,8 +135,8 @@ if (DEBUG) {
     @method info
     @private
   */
-  setDebugFunction('info', function info() {
-    Logger.info.apply(undefined, arguments);
+  setDebugFunction('info', function info() {    
+    console.info(...arguments); /* eslint-disable-line no-console */
   });
 
   /**

--- a/packages/ember-debug/lib/warn.js
+++ b/packages/ember-debug/lib/warn.js
@@ -1,7 +1,6 @@
 import { DEBUG } from 'ember-env-flags';
 import { ENV } from 'ember-environment';
 
-import Logger from 'ember-console';
 import deprecate from './deprecate';
 import { assert } from './index';
 import { registerHandler as genericRegisterHandler, invoke } from './handlers';
@@ -51,10 +50,12 @@ if (DEBUG) {
   };
 
   registerHandler(function logWarning(message) {
-    Logger.warn(`WARNING: ${message}`);
-    if ('trace' in Logger) {
-      Logger.trace();
-    }
+    /* eslint-disable no-console */
+    console.warn(`WARNING: ${message}`); 
+    if (console.trace) {
+      console.trace();
+    } 
+    /* eslint-enable no-console */
   });
 
   missingOptionsDeprecation = 'When calling `warn` you ' +

--- a/packages/ember-glimmer/lib/helpers/log.ts
+++ b/packages/ember-glimmer/lib/helpers/log.ts
@@ -8,8 +8,6 @@ import { InternalHelperReference } from '../utils/references';
 @module ember
 */
 
-import Logger from 'ember-console';
-
 /**
   `log` allows you to output the value of variables in the current rendering
   context. `log` also accepts primitive types such as strings or numbers.
@@ -24,8 +22,10 @@ import Logger from 'ember-console';
   @public
 */
 function log({ positional }: CapturedArguments) {
-  Logger.log.apply(null, positional.value());
-}
+    /* eslint-disable no-console */
+    console.log(...positional.value());
+    /* eslint-enable no-console */
+  }
 
 export default function(_vm: VM, args: Arguments) {
   return new InternalHelperReference(log, args.capture());

--- a/packages/ember-glimmer/tests/integration/helpers/log-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/log-test.js
@@ -1,22 +1,24 @@
 import { RenderingTest, moduleFor } from '../../utils/test-case';
-import Logger from 'ember-console';
 
 
 moduleFor('Helpers test: {{log}}', class extends RenderingTest {
 
   constructor() {
     super();
-
-    this.originalLog = Logger.log;
+    /* eslint-disable no-console */
+    this.originalLog = console.log;
     this.logCalls = [];
-    Logger.log = (...args) => {
+    console.log = (...args) => {
       this.logCalls.push(...args);
-    };
+    /* eslint-enable no-console */
+  };
   }
 
   teardown() {
     super.teardown();
-    Logger.log = this.originalLog;
+    /* eslint-disable no-console */
+    console.log = this.originalLog;
+    /* eslint-enable no-console */
   }
 
   assertLog(values) {

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -2,7 +2,6 @@ import {
   assign,
   getOwner
 } from 'ember-utils';
-import Logger from 'ember-console';
 import {
   get,
   set,
@@ -106,7 +105,7 @@ const EmberRouter = EmberObject.extend(Evented, {
 
     if (DEBUG) {
       if (get(this, 'namespace.LOG_TRANSITIONS_INTERNAL')) {
-        routerMicrolib.log = Logger.debug;
+        routerMicrolib.log = console.log.bind(console); // eslint-disable-line no-console
       }
     }
 
@@ -263,7 +262,8 @@ const EmberRouter = EmberObject.extend(Evented, {
 
     if (DEBUG) {
       if (get(this, 'namespace').LOG_TRANSITIONS) {
-        Logger.log(`Transitioned into '${EmberRouter._routePath(infos)}'`);
+        // eslint-disable-next-line no-console 
+        console.log(`Transitioned into '${EmberRouter._routePath(infos)}'`);
       }
     }
   },
@@ -336,7 +336,8 @@ const EmberRouter = EmberObject.extend(Evented, {
 
     if (DEBUG) {
       if (get(this, 'namespace').LOG_TRANSITIONS) {
-        Logger.log(`Preparing to transition from '${EmberRouter._routePath(oldInfos)}' to '${EmberRouter._routePath(newInfos)}'`);
+        // eslint-disable-next-line no-console 
+        console.log(`Preparing to transition from '${EmberRouter._routePath(oldInfos)}' to '${EmberRouter._routePath(newInfos)}'`);
       }
     }
   },
@@ -386,7 +387,8 @@ const EmberRouter = EmberObject.extend(Evented, {
     if (DEBUG) {
       let infos = this._routerMicrolib.currentHandlerInfos;
       if (get(this, 'namespace').LOG_TRANSITIONS) {
-        Logger.log(`Intermediate-transitioned into '${EmberRouter._routePath(infos)}'`);
+        // eslint-disable-next-line no-console 
+        console.log(`Intermediate-transitioned into '${EmberRouter._routePath(infos)}'`);
       }
     }
   },
@@ -1180,7 +1182,7 @@ function logError(_error, initialMessage) {
     if (typeof error === 'string') { errorArgs.push(error); }
   }
 
-  Logger.error.apply(this, errorArgs);
+  console.error(...errorArgs); //eslint-disable-line no-console
 }
 
 /**

--- a/packages/ember-testing/lib/helpers/pause_test.js
+++ b/packages/ember-testing/lib/helpers/pause_test.js
@@ -2,7 +2,6 @@
 @module ember
 */
 import { RSVP } from 'ember-runtime';
-import Logger from 'ember-console';
 import { assert } from 'ember-debug';
 
 let resume;
@@ -58,7 +57,8 @@ export function resumeTest() {
  @public
 */
 export function pauseTest() {
-  Logger.info('Testing paused. Use `resumeTest()` to continue.');
+  // eslint-disable-next-line no-console
+  console.info('Testing paused. Use `resumeTest()` to continue.');
 
   return new RSVP.Promise((resolve) => {
     resume = resolve;

--- a/packages/ember-testing/lib/test/adapter.js
+++ b/packages/ember-testing/lib/test/adapter.js
@@ -1,4 +1,3 @@
-import Logger from 'ember-console';
 import { setDispatchOverride } from 'ember-metal';
 
 let adapter;
@@ -29,5 +28,6 @@ export function asyncEnd() {
 
 function adapterDispatch(error) {
   adapter.exception(error);
-  Logger.error(error.stack);
+  
+  console.error(error.stack);// eslint-disable-line no-console 
 }

--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -1,6 +1,6 @@
+/* eslint-disable no-console */
 import { getOwner } from 'ember-utils';
 import RSVP from 'rsvp';
-import Logger from 'ember-console';
 import { compile } from 'ember-template-compiler';
 import { ENV } from 'ember-environment';
 import {
@@ -29,6 +29,7 @@ import { Engine } from 'ember-application';
 import { Transition } from 'router';
 
 let originalRenderSupport;
+let originalConsoleError;
 
 moduleFor('Basic Routing - Decoupled from global resolver', class extends ApplicationTestCase {
   constructor() {
@@ -42,11 +43,13 @@ moduleFor('Basic Routing - Decoupled from global resolver', class extends Applic
     });
     originalRenderSupport = ENV._ENABLE_RENDER_SUPPORT;
     ENV._ENABLE_RENDER_SUPPORT = true;
+    originalConsoleError = console.error;
   }
 
   teardown() {
     super.teardown();
     ENV._ENABLE_RENDER_SUPPORT = originalRenderSupport;
+    console.error = originalConsoleError;
   }
 
   getController(name) {
@@ -2696,7 +2699,7 @@ moduleFor('Basic Routing - Decoupled from global resolver', class extends Applic
       this.route('yippie', { path: '/' });
     });
 
-    Logger.error = function (initialMessage, errorMessage, errorStack) {
+    console.error = function (initialMessage, errorMessage, errorStack) {
       assert.equal(initialMessage, 'Error while processing route: yippie', 'a message with the current route name is printed');
       assert.equal(errorMessage, rejectedMessage, 'the rejected reason\'s message property is logged');
       assert.equal(errorStack, rejectedStack, 'the rejected reason\'s stack property is logged');
@@ -2725,7 +2728,7 @@ moduleFor('Basic Routing - Decoupled from global resolver', class extends Applic
       this.route('yippie', { path: '/' });
     });
 
-    Logger.error = function (initialMessage, errorMessage, errorStack) {
+    console.error = function (initialMessage, errorMessage, errorStack) {
       assert.equal(initialMessage, 'Error while processing route: yippie', 'a message with the current route name is printed');
       assert.equal(errorMessage, rejectedMessage, 'the rejected reason\'s message property is logged');
       assert.equal(errorStack, rejectedStack, 'the rejected reason\'s stack property is logged');
@@ -2751,7 +2754,7 @@ moduleFor('Basic Routing - Decoupled from global resolver', class extends Applic
       this.route('wowzers', { path: '/' });
     });
 
-    Logger.error = function(initialMessage) {
+    console.error = function(initialMessage) {
       assert.equal(initialMessage, 'Error while processing route: wowzers', 'a message with the current route name is printed');
     };
 
@@ -2766,14 +2769,13 @@ moduleFor('Basic Routing - Decoupled from global resolver', class extends Applic
 
   ['@test rejecting the model hooks promise with a string shows a good error'](assert) {
     assert.expect(3);
-    let originalLoggerError = Logger.error;
     let rejectedMessage = 'Supercalifragilisticexpialidocious';
 
     this.router.map(function() {
       this.route('yondo', { path: '/' });
     });
 
-    Logger.error = function(initialMessage, errorMessage) {
+    console.error = function(initialMessage, errorMessage) {
       assert.equal(initialMessage, 'Error while processing route: yondo', 'a message with the current route name is printed');
       assert.equal(errorMessage, rejectedMessage, 'the rejected reason\'s message property is logged');
     };
@@ -2785,8 +2787,6 @@ moduleFor('Basic Routing - Decoupled from global resolver', class extends Applic
     }));
 
     assert.throws(() => this.visit('/'), new RegExp(rejectedMessage), 'expected an exception');
-
-    Logger.error = originalLoggerError;
   }
 
   ['@test willLeave, willChangeContext, willChangeModel actions don\'t fire unless feature flag enabled'](assert) {
@@ -2832,7 +2832,7 @@ moduleFor('Basic Routing - Decoupled from global resolver', class extends Applic
       }
     }));
 
-    Logger.error = function() {
+    console.error = function() {
       // push the arguments onto an array so we can detect if the error gets logged twice
       actual.push(arguments);
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2745,9 +2745,9 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-plugin-ember-internal@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-ember-internal/-/eslint-plugin-ember-internal-1.1.0.tgz#4bf01f696ca607cb256c9291aaad7447c9ec18bd"
+eslint-plugin-ember-internal@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ember-internal/-/eslint-plugin-ember-internal-1.1.1.tgz#5327f709799eac010bfcf0dd1be8d0acbc917d34"
   dependencies:
     line-column "^1.0.2"
     requireindex "~1.1.0"


### PR DESCRIPTION
I've implemented the changes to the project. Since Ember itself no longer uses Ember.Logger, this PR could perhaps use one more test that deliberately calls the methods to verify that the console is reporting deprecation. Otherwise, this should be set to go.