### PR TITLE
Re-enable missing tests

### DIFF
--- a/packages/ember-application/tests/system/application_instance_test.js
+++ b/packages/ember-application/tests/system/application_instance_test.js
@@ -2,7 +2,6 @@ import Engine from '../../system/engine';
 import Application from '../../system/application';
 import ApplicationInstance from '../../system/application-instance';
 import { run } from 'ember-metal';
-import { jQuery } from 'ember-views';
 import { privatize as P } from 'container';
 import { factory } from 'internal-test-helpers';
 import { Object as EmberObject } from 'ember-runtime';
@@ -17,13 +16,13 @@ moduleFor('ApplicationInstance', class extends TestCase {
   constructor() {
     super();
 
-    jQuery('#qunit-fixture').html('<div id=\'one\'><div id=\'one-child\'>HI</div></div><div id=\'two\'>HI</div>');
+    document.getElementById('qunit-fixture').innerHTML = `
+      <div id='one'><div id='one-child'>HI</div></div><div id='two'>HI</div>
+    `;
     application = run(() => Application.create({ rootElement: '#one', router: null }));
   }
 
   teardown() {
-    jQuery('#qunit-fixture').empty();
-
     if (appInstance) {
       run(appInstance, 'destroy');
     }
@@ -31,16 +30,18 @@ moduleFor('ApplicationInstance', class extends TestCase {
     if (application) {
       run(application, 'destroy');
     }
+
+    document.getElementById('qunit-fixture').innerHTML = '';
   }
 
-  ['an application instance can be created based upon an application'](assert) {
-    appInstance = run(() => appInstance = ApplicationInstance.create({ application }));
+  ['@test an application instance can be created based upon an application'](assert) {
+    appInstance = run(() => ApplicationInstance.create({ application }));
 
     assert.ok(appInstance, 'instance should be created');
     assert.equal(appInstance.application, application, 'application should be set to parent');
   }
 
-  ['customEvents added to the application before setupEventDispatcher'](assert) {
+  ['@test customEvents added to the application before setupEventDispatcher'](assert) {
     assert.expect(1);
 
     appInstance = run(() => ApplicationInstance.create({ application }));
@@ -58,10 +59,10 @@ moduleFor('ApplicationInstance', class extends TestCase {
     appInstance.setupEventDispatcher();
   }
 
-  ['customEvents added to the application before setupEventDispatcher'](assert) {
+  ['@test customEvents added to the application before setupEventDispatcher'](assert) {
     assert.expect(1);
 
-    run(() => appInstance = ApplicationInstance.create({ application }));
+    appInstance = run(() => ApplicationInstance.create({ application }));
     appInstance.setupRegistry();
 
     application.customEvents = {
@@ -76,7 +77,7 @@ moduleFor('ApplicationInstance', class extends TestCase {
     appInstance.setupEventDispatcher();
   }
 
-  ['customEvents added to the application instance before setupEventDispatcher'](assert) {
+  ['@test customEvents added to the application instance before setupEventDispatcher'](assert) {
     assert.expect(1);
 
     appInstance = run(() => ApplicationInstance.create({ application }));
@@ -94,7 +95,7 @@ moduleFor('ApplicationInstance', class extends TestCase {
     appInstance.setupEventDispatcher();
   }
 
-  ['unregistering a factory clears all cached instances of that factory'](assert) {
+  ['@test unregistering a factory clears all cached instances of that factory'](assert) {
     assert.expect(5);
 
     appInstance = run(() => ApplicationInstance.create({ application }));
@@ -120,7 +121,7 @@ moduleFor('ApplicationInstance', class extends TestCase {
     assert.notStrictEqual(postController1, postController2, 'lookup creates a brand new instance, because the previous one was reset');
   }
 
-  ['can build and boot a registered engine'](assert) {
+  ['@test can build and boot a registered engine'](assert) {
     assert.expect(11);
 
     let ChatEngine = Engine.extend();
@@ -172,7 +173,7 @@ moduleFor('ApplicationInstance', class extends TestCase {
       });
   }
 
-  ['can build a registry via ApplicationInstance.setupRegistry() -- simulates ember-test-helpers'](assert) {
+  ['@test can build a registry via ApplicationInstance.setupRegistry() -- simulates ember-test-helpers'](assert) {
     let namespace = EmberObject.create({
       Resolver: { create: function() { } }
     });

--- a/packages/ember-application/tests/system/engine_initializers_test.js
+++ b/packages/ember-application/tests/system/engine_initializers_test.js
@@ -20,7 +20,7 @@ moduleFor('Engine initializers', class extends TestCase {
     });
   }
 
-  ['initializers require proper \'name\' and \'initialize\' properties']() {
+  ['@test initializers require proper \'name\' and \'initialize\' properties']() {
     MyEngine = Engine.extend();
 
     expectAssertion(() => {
@@ -36,7 +36,7 @@ moduleFor('Engine initializers', class extends TestCase {
     });
   }
 
-  ['initializers are passed an Engine'](assert) {
+  ['@test initializers are passed an Engine'](assert) {
     MyEngine = Engine.extend();
 
     MyEngine.initializer({
@@ -50,7 +50,7 @@ moduleFor('Engine initializers', class extends TestCase {
     myEngineInstance = myEngine.buildInstance();
   }
 
-  ['initializers can be registered in a specified order'](assert) {
+  ['@test initializers can be registered in a specified order'](assert) {
     let order = [];
 
     MyEngine = Engine.extend();
@@ -108,7 +108,7 @@ moduleFor('Engine initializers', class extends TestCase {
     assert.deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
   }
 
-  ['initializers can be registered in a specified order as an array'](assert) {
+  ['@test initializers can be registered in a specified order as an array'](assert) {
     let order = [];
 
     MyEngine = Engine.extend();
@@ -167,7 +167,7 @@ moduleFor('Engine initializers', class extends TestCase {
     assert.deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
   }
 
-  ['initializers can have multiple dependencies'](assert) {
+  ['@test initializers can have multiple dependencies'](assert) {
     let order = [];
 
     MyEngine = Engine.extend();
@@ -222,7 +222,7 @@ moduleFor('Engine initializers', class extends TestCase {
     assert.ok(order.indexOf(c.name) < order.indexOf(afterC.name), 'c < afterC');
   }
 
-  ['initializers set on Engine subclasses are not shared between engines'](assert) {
+  ['@test initializers set on Engine subclasses are not shared between engines'](assert) {
     let firstInitializerRunCount = 0;
     let secondInitializerRunCount = 0;
     let FirstEngine = Engine.extend();
@@ -264,7 +264,7 @@ moduleFor('Engine initializers', class extends TestCase {
     });
   }
 
-  ['initializers are concatenated'](assert) {
+  ['@test initializers are concatenated'](assert) {
     let firstInitializerRunCount = 0;
     let secondInitializerRunCount = 0;
     let FirstEngine = Engine.extend();
@@ -307,7 +307,7 @@ moduleFor('Engine initializers', class extends TestCase {
     });
   }
 
-  ['initializers are per-engine'](assert) {
+  ['@test initializers are per-engine'](assert) {
     assert.expect(2);
 
     let FirstEngine = Engine.extend();
@@ -333,7 +333,7 @@ moduleFor('Engine initializers', class extends TestCase {
     assert.ok(true, 'Two engines can have initializers named the same.');
   }
 
-  ['initializers are executed in their own context'](assert) {
+  ['@test initializers are executed in their own context'](assert) {
     assert.expect(1);
 
     MyEngine = Engine.extend();


### PR DESCRIPTION
We were not running these tests because they lacked `@test` at the start of their method names.