### PR TITLE
remove destructuring in MU component blueprint

### DIFF
--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -6,7 +6,7 @@ const isPackageMissing = require('ember-cli-is-package-missing');
 const getPathOption = require('ember-cli-get-component-path-option');
 
 const useTestFrameworkDetector = require('../test-framework-detector');
-const { isModuleUnificationProject } = require('../module-unification');
+const isModuleUnificationProject = require('../module-unification').isModuleUnificationProject;
 
 module.exports = useTestFrameworkDetector({
   description: 'Generates a component integration or unit test.',

--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -6,7 +6,7 @@ const pathUtil = require('ember-cli-path-utils');
 const validComponentName = require('ember-cli-valid-component-name');
 const getPathOption = require('ember-cli-get-component-path-option');
 const normalizeEntityName = require('ember-cli-normalize-entity-name');
-const { isModuleUnificationProject } = require('../module-unification');
+const isModuleUnificationProject = require('../module-unification').isModuleUnificationProject;
 
 module.exports = {
   description: 'Generates a component. Name must contain a hyphen.',


### PR DESCRIPTION
As [@ro0gr pointed out](https://github.com/emberjs/ember.js/pull/16043/files#diff-22511a29d6be2c46005d679096478f8a), Node 4 doesn't support destructuring.

