### PR TITLE
Es5 getters return raw descriptors

### DIFF
--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -2,7 +2,7 @@
 @module @ember/object
 */
 
-import { assert } from 'ember-debug';
+import { assert, deprecate } from 'ember-debug';
 import { HAS_NATIVE_PROXY, symbol } from 'ember-utils';
 import { DESCRIPTOR_TRAP, EMBER_METAL_ES5_GETTERS, MANDATORY_GETTER } from 'ember/features';
 import { isPath } from './path_cache';
@@ -96,6 +96,15 @@ export function get(obj, keyName) {
       if (DESCRIPTOR_TRAP && isDescriptorTrap(value)) {
         descriptor = value[DESCRIPTOR];
       } else if (isDescriptor(value)) {
+        deprecate(
+          `[DEPRECATED] computed property '${keyName}' was not set on object '${obj && obj.toString && obj.toString()}' via 'defineProperty'`,
+          !EMBER_METAL_ES5_GETTERS,
+          {
+            id: 'ember-meta.descriptor-on-object',
+            until: '3.5.0',
+            url: 'https://emberjs.com/deprecations/v3.x#toc_use-defineProperty-to-define-computed-properties'
+          }
+        );
         descriptor = value;
       }
     }

--- a/packages/ember-metal/tests/accessors/get_test.js
+++ b/packages/ember-metal/tests/accessors/get_test.js
@@ -4,6 +4,7 @@ import {
   getWithDefault,
   Mixin,
   observer,
+  computed,
 } from '../..';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
@@ -25,6 +26,22 @@ moduleFor('get', class extends AbstractTestCase {
       }
       assert.equal(get(obj, key), obj[key], key);
     }
+  }
+
+  ['@test implicitly computing the values of descriptors on properties is deprecated'](assert) {
+    let cp = computed(() => 'value');
+    let obj = {
+      cp,
+      toString() { return 'myobject'; }
+    };
+
+    let result;
+
+    expectDeprecation(() => {
+      result = get(obj, 'cp');
+    }, /\[DEPRECATED\] computed property 'cp' was not set on object 'myobject' via 'defineProperty'/);
+
+    assert.equal(result, 'value', 'descriptor');
   }
 
   ['@test should retrieve a number key on an object'](assert) {


### PR DESCRIPTION
With EMBER_METAL_ES5_GETTERS enabled, deprecate `Ember.get` implicitly calling `get` on a property that happens to be a descriptor, but which wasn't found via `descriptorFor`.

With EMBER_METAL_ES5_GETTERS disabled, and in prior versions of Ember,  descriptors on the instance are treated as special properties.  In fact, in earlier versions of Ember, all computed properties were stored this way.


paired with @rwjblue 

PR for the website deprecation: https://github.com/emberjs/website/pull/3209