### PR TITLE
[BUGFIX beta] Fix ChainNode unchaining

### DIFF
--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -241,7 +241,7 @@ class ChainNode {
     let node = chains[key];
 
     // unchain rest of path first...
-    if (tails.length > 1) {
+    if (tails.length > 0) {
       node.unchain(tails.shift(), tails);
     }
 

--- a/packages/ember-metal/tests/chains_test.js
+++ b/packages/ember-metal/tests/chains_test.js
@@ -7,7 +7,10 @@ import {
   computed,
   notifyPropertyChange,
   peekMeta,
-  meta
+  meta,
+  watch,
+  unwatch,
+  watcherCount
 } from '..';
 
 QUnit.module('Chains');
@@ -95,4 +98,48 @@ QUnit.test('checks cache correctly', function(assert) {
   get(obj, 'foo');
 
   assert.strictEqual(chainNode.value(), undefined);
+});
+
+QUnit.test('chains are watched correctly', function(assert) {
+  let obj = { foo: { bar: { baz: 1 } } };
+
+  watch(obj, 'foo.bar.baz');
+
+  assert.equal(watcherCount(obj, 'foo'), 1);
+  assert.equal(watcherCount(obj, 'foo.bar'), 0);
+  assert.equal(watcherCount(obj, 'foo.bar.baz'), 1);
+  assert.equal(watcherCount(obj.foo, 'bar'), 1);
+  assert.equal(watcherCount(obj.foo, 'bar.baz'), 0);
+  assert.equal(watcherCount(obj.foo.bar, 'baz'), 1);
+
+  unwatch(obj, 'foo.bar.baz');
+
+  assert.equal(watcherCount(obj, 'foo'), 0);
+  assert.equal(watcherCount(obj, 'foo.bar'), 0);
+  assert.equal(watcherCount(obj, 'foo.bar.baz'), 0);
+  assert.equal(watcherCount(obj.foo, 'bar'), 0);
+  assert.equal(watcherCount(obj.foo, 'bar.baz'), 0);
+  assert.equal(watcherCount(obj.foo.bar, 'baz'), 0);
+});
+
+QUnit.test('chains with single character keys are watched correctly', function (assert) {
+  let obj = { a: { b: { c: 1 } } };
+
+  watch(obj, 'a.b.c');
+
+  assert.equal(watcherCount(obj, 'a'), 1);
+  assert.equal(watcherCount(obj, 'a.b'), 0);
+  assert.equal(watcherCount(obj, 'a.b.c'), 1);
+  assert.equal(watcherCount(obj.a, 'b'), 1);
+  assert.equal(watcherCount(obj.a, 'b.c'), 0);
+  assert.equal(watcherCount(obj.a.b, 'c'), 1);
+
+  unwatch(obj, 'a.b.c');
+
+  assert.equal(watcherCount(obj, 'a'), 0);
+  assert.equal(watcherCount(obj, 'a.b'), 0);
+  assert.equal(watcherCount(obj, 'a.b.c'), 0);
+  assert.equal(watcherCount(obj.a, 'b'), 0);
+  assert.equal(watcherCount(obj.a, 'b.c'), 0);
+  assert.equal(watcherCount(obj.a.b, 'c'), 0);
 });


### PR DESCRIPTION
A bug was introduced in #15850 where the last node in a chain was not being cleaned up correctly. This PR fixes this bug.

Relatedly, #15850 accidentally fixed a long standing bug with chains with single-character keys. This PR also includes a test for this second bug.

To assist with reviewing, here are a couple screenshots showing how the tests I've added fail on Ember 2.18 and on master before applying this fix.

Ember 2.18:

![screen shot 2018-02-22 at 8 08 36 pm](https://user-images.githubusercontent.com/1151810/36573393-ad853136-180e-11e8-9337-0f96830580a6.png)

master:

![screen shot 2018-02-22 at 8 18 38 pm](https://user-images.githubusercontent.com/1151810/36573396-b3f96be0-180e-11e8-887f-d47270cc1a16.png)