### PR TITLE
[BUGFIX beta] Ensure accessing a "proxy" itself does not error.

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -98,6 +98,8 @@ function makeCtor() {
               property === 'willWatchProperty' ||
               property === 'didUnwatchProperty' ||
               property === 'didAddListener' ||
+              property === '__DESCRIPTOR__' ||
+              property === 'isDescriptor' ||
               property in target
             ) {
               return Reflect.get(target, property, receiver);

--- a/packages/ember-runtime/tests/system/core_object_test.js
+++ b/packages/ember-runtime/tests/system/core_object_test.js
@@ -1,3 +1,4 @@
+import { get } from 'ember-metal';
 import CoreObject from '../../system/core_object';
 
 QUnit.module('Ember.CoreObject');
@@ -35,4 +36,19 @@ QUnit.test('toString should be not be added as a property when calling toString(
   obj.toString();
 
   assert.notOk(obj.hasOwnProperty('toString'), 'Calling toString() should not create a toString class property');
+});
+
+QUnit.test('should not trigger proxy assertion when retrieving a proxy with (GH#16263)', function(assert) {
+  let someProxyishThing = CoreObject.extend({
+    unknownProperty() {
+      return true;
+    }
+  }).create();
+
+  let obj = new CoreObject({
+    someProxyishThing
+  });
+
+  let proxy = get(obj, 'someProxyishThing');
+  assert.equal(get(proxy, 'lolol'), true, 'should be able to get data from a proxy');
 });


### PR DESCRIPTION
Prior to this change, if `Ember.get` (or `this.get`) is used to access a property that is an Ember.Object with an `unknownProperty` that always returns a non-`undefined` value, the internals of `Ember.get` would check if that property is a "descriptor" and (due to the `unknownProperty` never returning `undefined`) the dev time assertion for accessing a proxy's content without using `Ember.get` would be triggered.

Fixes #16263