### PR TITLE
remove redundant `this.isDescriptor`

### DIFF
--- a/packages/ember-metal/lib/alias.js
+++ b/packages/ember-metal/lib/alias.js
@@ -22,7 +22,6 @@ export default function alias(altKey) {
 export class AliasedProperty extends Descriptor {
   constructor(altKey) {
     super();
-    this.isDescriptor = true;
     this.altKey = altKey;
     this._dependentKeys = [altKey];
   }


### PR DESCRIPTION
it is being set here https://github.com/emberjs/ember.js/blob/master/packages/ember-metal/lib/properties.js#L24 already