### PR TITLE
Improve eachComputedProperty implementation

### DIFF
--- a/packages/ember-metal/lib/descriptor.js
+++ b/packages/ember-metal/lib/descriptor.js
@@ -16,6 +16,7 @@ class Descriptor extends EmberDescriptor {
   constructor(desc) {
     super();
     this.desc = desc;
+    this.enumerable = desc.enumerable;
   }
 
   setup(obj, key) {

--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -72,8 +72,7 @@ export {
 } from './property_events';
 export {
   defineProperty,
-  Descriptor,
-  _hasCachedComputedProperties
+  Descriptor
 } from './properties';
 export {
   watchKey,

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -446,6 +446,27 @@ if (EMBER_METAL_ES5_GETTERS) {
   Meta.prototype.removeDescriptors = function(subkey) {
     this.writeDescriptors(subkey, UNDEFINED);
   };
+
+  Meta.prototype.forEachDescriptors = function(fn) {
+    let pointer = this;
+    let seen;
+    while (pointer !== undefined) {
+      let map = pointer._descriptors;
+      if (map !== undefined) {
+        for (let key in map) {
+          seen = seen === undefined ? new Set() : seen;
+          if (!seen.has(key)) {
+            seen.add(key);
+            let value = map[key];
+            if (value !== UNDEFINED) {
+              fn(key, value);
+            }
+          }
+        }
+      }
+      pointer = pointer.parent;
+    }
+  };
 }
 
 const getPrototypeOf = Object.getPrototypeOf;

--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -7,7 +7,6 @@ import { HAS_NATIVE_PROXY } from 'ember-utils';
 import { descriptorFor, meta as metaFor, peekMeta, DESCRIPTOR, UNDEFINED } from './meta';
 import { overrideChains } from './property_events';
 import { DESCRIPTOR_TRAP, EMBER_METAL_ES5_GETTERS, MANDATORY_SETTER } from 'ember/features';
-import { peekCacheFor } from './computed';
 // ..........................................................
 // DESCRIPTOR
 //
@@ -22,6 +21,7 @@ import { peekCacheFor } from './computed';
 export class Descriptor {
   constructor() {
     this.isDescriptor = true;
+    this.enumerable = true;
   }
 }
 
@@ -282,8 +282,6 @@ export function defineProperty(obj, keyName, desc, data, meta) {
       meta.writeDescriptors(keyName, value);
     }
 
-    didDefineComputedProperty(obj.constructor);
-
     if (typeof desc.setup === 'function') { desc.setup(obj, keyName); }
   } else if (desc === undefined || desc === null) {
     value = data;
@@ -332,18 +330,4 @@ export function defineProperty(obj, keyName, desc, data, meta) {
   if (typeof obj.didDefineProperty === 'function') { obj.didDefineProperty(obj, keyName, value); }
 
   return this;
-}
-
-let hasCachedComputedProperties = false;
-export function _hasCachedComputedProperties() {
-  hasCachedComputedProperties = true;
-}
-
-function didDefineComputedProperty(constructor) {
-  if (hasCachedComputedProperties === false) { return; }
-
-  let cache = peekCacheFor(constructor);
-  if (cache !== undefined) {
-    cache.delete('_computedProperties');
-  }
 }


### PR DESCRIPTION
Closes https://github.com/emberjs/ember.js/pull/13787.

A simpler implementation of `eachComputedProperty` that leverages how we now collect descriptors in meta and no longer need to iterate all keys on the prototype. I also copied a couple tests over from https://github.com/emberjs/ember.js/pull/13787.

Benchmarking emberaddons.com shows that this change is statistically insignificant.

[results.pdf](https://github.com/emberjs/ember.js/files/1753524/results.pdf)