### PR TITLE
fix(link-to): add id to "inactive loading state" warning

### DIFF
--- a/packages/ember-glimmer/lib/components/link-to.ts
+++ b/packages/ember-glimmer/lib/components/link-to.ts
@@ -628,7 +628,9 @@ const LinkComponent = EmberComponent.extend({
 
     if (get(this, 'loading')) {
       // tslint:disable-next-line:max-line-length
-      warn('This link-to is in an inactive loading state because at least one of its parameters presently has a null/undefined value, or the provided route name is invalid.', false);
+      warn('This link-to is in an inactive loading state because at least one of its parameters presently has a null/undefined value, or the provided route name is invalid.', false, {
+        id: 'ember-glimmer.link-to.inactive-loading-state'
+      });
       return false;
     }
 


### PR DESCRIPTION
Without an ID, this triggers an assertion with the message "When calling warn you must provide an options hash as the third parameter. options should include an id property."