### PR TITLE
[BUGFIX beta] Fix nested ObserverSet flushes

### DIFF
--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -188,8 +188,7 @@ function beginPropertyChanges() {
 function endPropertyChanges() {
   deferred--;
   if (deferred <= 0) {
-    observerSet.forEach((object, key)=> sendEvent(object, key, [object, key]));
-    observerSet.clear();
+    observerSet.flush();
   }
 }
 

--- a/packages/ember-metal/tests/observer_test.js
+++ b/packages/ember-metal/tests/observer_test.js
@@ -673,6 +673,21 @@ testBoth('observers added/removed during changeProperties should do the right th
   assert.equal(removedAfterLastChangeObserver.didChangeCount, 0, 'removeObserver called after the last change sees none');
 });
 
+testBoth('calling changeProperties while executing deferred observers works correctly', function(get, set, assert) {
+  let obj = { foo: 0 };
+  let fooDidChange = 0;
+  
+  addObserver(obj, 'foo', () => {
+    fooDidChange++;
+    changeProperties(() => {});
+  });
+  
+  changeProperties(() => {
+    set(obj, 'foo', 1);
+  });
+  
+  assert.equal(fooDidChange, 1);
+});
 
 QUnit.module('Keys behavior with observers');
 


### PR DESCRIPTION
https://github.com/emberjs/ember.js/commit/7b723b21e2eb2561b93b9f12fc436d4bc7c785a7#diff-5024f8fa1f51ab072b1580a74851b2b8 introduced a bug causing infinite loops while flushing deferred observers in some cases.

This PR fixes the bug and adds a test.