### PR TITLE
[BUGFIX beta] Fix version with many special chars.

### DIFF
--- a/broccoli/version.js
+++ b/broccoli/version.js
@@ -29,7 +29,7 @@ module.exports.VERSION = (() => {
   let sha = info.sha || '';
   let suffix = process.env.BUILD_TYPE || info.branch;
   // * remove illegal non-alphanumeric characters from branch name.
-  suffix = suffix && suffix.replace(/[^a-zA-Z\d\s-]/, '-');
+  suffix = suffix && suffix.replace(/[^a-zA-Z\d\s-]/g, '-');
   let metadata = sha.slice(0, 8);
 
   return `${packageVersion}${suffix ? '-' + suffix : ''}+${metadata}`;


### PR DESCRIPTION
The current sanitizer regexp works well when there is a single invalid character, but does not handle the case where multiple invalid chars are present (e.g. with a branch name of `__DESCRIPTOR__-something__something/special`).