### PR TITLE
[BUGFIX release] Update to router_js@2.0.0-beta.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "puppeteer": "^0.13.0",
     "qunit": "^2.5.0",
     "route-recognizer": "^0.3.3",
-    "router_js": "^2.0.0-beta.1",
+    "router_js": "^2.0.0-beta.2",
     "rsvp": "^4.8.0",
     "semver": "^5.5.0",
     "serve-static": "^1.12.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6009,9 +6009,9 @@ route-recognizer@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/route-recognizer/-/route-recognizer-0.3.3.tgz#1d365e27fa6995e091675f7dc940a8c00353bd29"
 
-router_js@^2.0.0-beta.1:
-  version "2.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/router_js/-/router_js-2.0.0-beta.1.tgz#6f267b5171bbe1e92729db3e8be447e6a9d63f5a"
+router_js@^2.0.0-beta.2:
+  version "2.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/router_js/-/router_js-2.0.0-beta.2.tgz#75dd75d4ec0170700b754c3f9d475f993958b2c5"
 
 rsvp@3.0.14:
   version "3.0.14"


### PR DESCRIPTION
Main changes:

* ES6ify a few classes.
* Fix issue when calling `.replaceWith` when the current transition is also a `.replaceWith` (previously this would surprisingly result in a `.transitionTo` _not_ a replace).

[Full changelog](https://github.com/tildeio/router.js/compare/v2.0.0-beta.1...v2.0.0-beta.2)