### PR TITLE
[BUGFIX beta] Ensure all "internal symbols" avoid the proxy assertion.

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -13,7 +13,8 @@ import {
   GUID_KEY_PROPERTY,
   NAME_KEY,
   GUID_KEY,
-  HAS_NATIVE_PROXY
+  HAS_NATIVE_PROXY,
+  isInternalSymbol,
 } from 'ember-utils';
 import {
   PROXY_CONTENT,
@@ -86,7 +87,7 @@ function makeCtor() {
             } else if (
               beforeInitCalled ||
               typeof property === 'symbol' ||
-              property === NAME_KEY ||
+              isInternalSymbol(property) ||
               property === GUID_KEY_PROPERTY ||
               property === 'toJSON' ||
               property === 'toString' ||

--- a/packages/ember-runtime/tests/system/core_object_test.js
+++ b/packages/ember-runtime/tests/system/core_object_test.js
@@ -1,3 +1,4 @@
+import { getOwner } from 'ember-utils';
 import { get } from 'ember-metal';
 import CoreObject from '../../system/core_object';
 
@@ -51,4 +52,17 @@ QUnit.test('should not trigger proxy assertion when retrieving a proxy with (GH#
 
   let proxy = get(obj, 'someProxyishThing');
   assert.equal(get(proxy, 'lolol'), true, 'should be able to get data from a proxy');
+});
+
+QUnit.test('should not trigger proxy assertion when probing for a "symbol"', function(assert) {
+  let proxy = CoreObject.extend({
+    unknownProperty() {
+      return true;
+    }
+  }).create();
+
+  assert.equal(get(proxy, 'lolol'), true, 'should be able to get data from a proxy');
+
+  // should not trigger an assertion
+  getOwner(proxy);
 });

--- a/packages/ember-utils/lib/index.js
+++ b/packages/ember-utils/lib/index.js
@@ -8,7 +8,7 @@
  Utility methods that are needed in < 80% of cases should be placed
  elsewhere (so they can be lazily evaluated / parsed).
 */
-export { default as symbol } from './symbol';
+export { default as symbol, isInternalSymbol } from './symbol';
 export { getOwner, setOwner, OWNER } from './owner';
 
 // Export `assignPolyfill` for testing

--- a/packages/ember-utils/lib/symbol.js
+++ b/packages/ember-utils/lib/symbol.js
@@ -1,10 +1,18 @@
 import { GUID_KEY } from './guid';
 import intern from './intern';
 
+const GENERATED_SYMBOLS = [];
+
+export function isInternalSymbol(possibleSymbol) {
+  return GENERATED_SYMBOLS.indexOf(possibleSymbol) > -1;
+}
+
 export default function symbol(debugName) {
   // TODO: Investigate using platform symbols, but we do not
   // want to require non-enumerability for this API, which
   // would introduce a large cost.
   let id = GUID_KEY + Math.floor(Math.random() * new Date());
-  return intern(`__${debugName}${id}__`);
+  let symbol = intern(`__${debugName}${id}__`);
+  GENERATED_SYMBOLS.push(symbol);
+  return symbol;
 }


### PR DESCRIPTION
The "symbols" we generate and use internally in Ember are not really `Symbol`s (yet) so they do not get automatically "whitelisted" by the pre-existing `typeof property === 'symbol'` check.

This change ensures that any of our "internal symbols" are allowed to be looked for without `.get`.