### PR TITLE
Fixup test to ensure correct assertion is thrown.

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/target-action-test.js
+++ b/packages/ember-glimmer/tests/integration/components/target-action-test.js
@@ -600,13 +600,18 @@ moduleFor('Components test: send', class extends RenderingTest {
   }
 
   ['@test actions cannot be provided at create time'](assert) {
-    expectAssertion(() => Component.create({
-      actions: {
-        foo() {
-          assert.ok(true, 'foo');
+    this.registerComponent('foo-bar', Component.extend());
+    let ComponentFactory = this.owner.factoryFor('component:foo-bar');
+
+    expectAssertion(() => {
+      ComponentFactory.create({
+        actions: {
+          foo() {
+            assert.ok(true, 'foo');
+          }
         }
-      }
-    }));
+      });
+    }, /`actions` must be provided at extend time, not at create time/);
     // but should be OK on an object that doesn't mix in Ember.ActionHandler
     EmberObject.create({
       actions: ['foo']


### PR DESCRIPTION
This test previously allowed any old assertion to satisfy it, but now will properly validate that the one we expected was what was thrown.