### PR TITLE
[BUGFIX release] Ignore --pod for -addon blueprints: helper, initializer, and instance-initializer

### DIFF
--- a/blueprints/-addon-import.js
+++ b/blueprints/-addon-import.js
@@ -10,15 +10,9 @@ module.exports = {
   fileMapTokens: function() {
     return {
       __name__: function(options) {
-        if (options.pod && options.hasPathToken) {
-          return options.locals.blueprintName;
-        }
         return options.dasherizedModuleName;
       },
       __path__: function(options) {
-        if (options.pod && options.hasPathToken) {
-          return path.join(options.podPath, options.dasherizedModuleName);
-        }
         return inflector.pluralize(options.locals.blueprintName);
       },
       __root__: function(options) {
@@ -40,10 +34,6 @@ module.exports = {
     if (blueprintName.match(/-addon/)) {
       blueprintName = blueprintName.substr(0, blueprintName.indexOf('-addon'));
       modulePathSegments = [addonName, inflector.pluralize(blueprintName), fileName];
-    }
-
-    if (options.pod) {
-      modulePathSegments = [addonName, fileName, blueprintName];
     }
 
     return {

--- a/node-tests/blueprints/helper-addon-test.js
+++ b/node-tests/blueprints/helper-addon-test.js
@@ -24,5 +24,12 @@ describe('Blueprint: helper-addon', function() {
           .to.equal(fixture('helper-addon.js'));
       });
     });
+
+    it('helper-addon foo/bar-baz --pod', function() {
+      return emberGenerateDestroy(['helper-addon', 'foo/bar-baz', '--pod'], _file => {
+        expect(_file('app/helpers/foo/bar-baz.js'))
+          .to.equal(fixture('helper-addon.js'));
+      });
+    });
   });
 });

--- a/node-tests/blueprints/initializer-addon-test.js
+++ b/node-tests/blueprints/initializer-addon-test.js
@@ -22,5 +22,12 @@ describe('Blueprint: initializer-addon', function() {
           .to.contain("export { default, initialize } from 'my-addon/initializers/foo';");
       });
     });
+
+    it('initializer-addon foo --pod', function() {
+      return emberGenerateDestroy(['initializer-addon', 'foo', '--pod'], _file => {
+        expect(_file('app/initializers/foo.js'))
+          .to.contain("export { default, initialize } from 'my-addon/initializers/foo';");
+      });
+    });
   });
 });

--- a/node-tests/blueprints/instance-initializer-addon-test.js
+++ b/node-tests/blueprints/instance-initializer-addon-test.js
@@ -22,5 +22,12 @@ describe('Blueprint: instance-initializer-addon', function() {
           .to.contain("export { default, initialize } from 'my-addon/instance-initializers/foo';");
       });
     });
+
+    it('instance-initializer-addon foo --pod', function() {
+      return emberGenerateDestroy(['instance-initializer-addon', 'foo', '--pod'], _file => {
+        expect(_file('app/instance-initializers/foo.js'))
+          .to.contain("export { default, initialize } from 'my-addon/instance-initializers/foo';");
+      });
+    });
   });
 });


### PR DESCRIPTION
In an addon, `helper`, `initializer`, and `instance-initializer` files are generated in the incorrect location under `app/` and attempt to import using an invalid module path when pod option is enabled.