### PR TITLE
[BUGFIX beta] Fix input macro params handling

### DIFF
--- a/packages/ember-glimmer/lib/syntax/input.ts
+++ b/packages/ember-glimmer/lib/syntax/input.ts
@@ -165,8 +165,8 @@ export function inputMacro(_name: string, params: Option<WireFormat.Core.Params>
       if (Array.isArray(typeArg)) {
         // there is an AST plugin that converts this to an expression
         // it really should just compile in the component call too.
-        let inputTypeExpr = params.shift() as WireFormat.Expression;
-        builder.dynamicComponent(inputTypeExpr, params, hash, true, null, null);
+        let inputTypeExpr = params[0] as WireFormat.Expression;
+        builder.dynamicComponent(inputTypeExpr, params.slice(1), hash, true, null, null);
         return true;
       }
       if (typeArg === 'checkbox') {

--- a/packages/ember-glimmer/tests/integration/helpers/input-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/input-test.js
@@ -446,6 +446,22 @@ moduleFor('Helpers test: {{input}} with dynamic type', class extends InputRender
 
     this.assertAttr('type', 'text');
   }
+
+  ['@test GH16256 input macro does not modify params in place']() {
+    this.registerComponent('my-input', {
+      template: `{{input type=inputType}}`
+    });
+
+    this.render(`{{my-input inputType=firstType}}{{my-input inputType=secondType}}`, {
+      firstType: 'password',
+      secondType: 'email'
+    });
+
+    let inputs = this.element.querySelectorAll('input');
+    this.assert.equal(inputs.length, 2, 'there are two inputs');
+    this.assert.equal(inputs[0].getAttribute('type'), 'password');
+    this.assert.equal(inputs[1].getAttribute('type'), 'email');
+  }
 });
 
 moduleFor(`Helpers test: {{input type='checkbox'}}`, class extends InputRenderingTest {


### PR DESCRIPTION
Before this PR, having a component with an `{{input}}` with bound type
would make that input only to work the first time it was rendered. This
was because the first param would be shifter from params, and that would
modify the params of the rest of the instances.

This is breaking in current beta.

Fixes #16256