### PR TITLE
[BUGFIX beta] Revert "Update to backburner.js@2.2.0."

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "babel-plugin-transform-proto-to-assign": "^6.26.0",
     "babel-template": "^6.26.0",
-    "backburner.js": "^2.2.0",
+    "backburner.js": "^2.1.0",
     "broccoli-babel-transpiler": "^6.1.2",
     "broccoli-concat": "^3.2.2",
     "broccoli-debug": "^0.6.4",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "babel-plugin-transform-proto-to-assign": "^6.26.0",
     "babel-template": "^6.26.0",
-    "backburner.js": "^2.1.0",
+    "backburner.js": "2.1.0",
     "broccoli-babel-transpiler": "^6.1.2",
     "broccoli-concat": "^3.2.2",
     "broccoli-debug": "^0.6.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -982,9 +982,9 @@ backbone@^1.1.2:
   dependencies:
     underscore ">=1.8.3"
 
-backburner.js@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-2.2.0.tgz#5b41f4ca262253b399b7e21ed781c0be303fabbb"
+backburner.js@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-2.1.0.tgz#2dd3b0f5043fc495b91407cf9f27d976e86159d5"
 
 backo2@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This reverts commit ecd93f9e28599ea5d5d665f6d18a2fba8d14a8a5.

Closes https://github.com/emberjs/ember.js/issues/16296