### PR TITLE
[BUGFIX beta] Revert "[CLEANUP] Remove ':change' suffix on change events"

### DIFF
--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -15,7 +15,7 @@ import { meta as metaFor, peekMeta } from './meta';
       // Object's meta hash
       {
         listeners: {       // variable name: `listenerSet`
-          "foo": [ // variable name: `actions`
+          "foo:change": [ // variable name: `actions`
             target, method, once
           ]
         }

--- a/packages/ember-metal/lib/observer.js
+++ b/packages/ember-metal/lib/observer.js
@@ -10,6 +10,12 @@ import {
 @module @ember/object
 */
 
+const AFTER_OBSERVERS = ':change';
+
+export function changeEvent(keyName) {
+  return keyName + AFTER_OBSERVERS;
+}
+
 /**
   @method addObserver
   @static
@@ -21,7 +27,7 @@ import {
   @public
 */
 export function addObserver(obj, _path, target, method) {
-  addListener(obj, _path, target, method);
+  addListener(obj, changeEvent(_path), target, method);
   watch(obj, _path);
 }
 
@@ -37,5 +43,5 @@ export function addObserver(obj, _path, target, method) {
 */
 export function removeObserver(obj, path, target, method) {
   unwatch(obj, path);
-  removeListener(obj, path, target, method);
+  removeListener(obj, changeEvent(path), target, method);
 }

--- a/packages/ember-metal/lib/observer_set.js
+++ b/packages/ember-metal/lib/observer_set.js
@@ -21,7 +21,7 @@ export default class ObserverSet {
     this.queue = [];
   }
 
-  add(object, key) {
+  add(object, key, event) {
     let keys = this.added.get(object);
     if (keys === undefined) {
       keys = new Set();
@@ -29,7 +29,7 @@ export default class ObserverSet {
     }
 
     if (!keys.has(key)) {
-      this.queue.push([object, key]);
+      this.queue.push(object, key, event);
       keys.add(key);
     }
   }
@@ -40,16 +40,16 @@ export default class ObserverSet {
     this.added.clear();
     this.queue = [];
 
-    for (let i = 0; i < queue.length; i++) {
-      let pair = queue[i];
-      let object = pair[0];
-      let key = pair[1];
+    for (let i = 0; i < queue.length; i += 3) {
+      let object = queue[i];
+      let key = queue[i + 1];
+      let event = queue[i + 2];
 
       if (object.isDestroying || object.isDestroyed) {
         continue;
       }
 
-      sendEvent(object, key, pair);
+      sendEvent(object, event, [object, key]);
     }
   }
 }

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -15,6 +15,7 @@ import {
 } from 'ember/features';
 import { deprecate } from 'ember-debug';
 import { assertNotRendered } from './transaction';
+import { changeEvent } from './observer';
 
 /**
  @module ember
@@ -219,10 +220,11 @@ function changeProperties(callback) {
 function notifyObservers(obj, keyName, meta) {
   if (meta.isSourceDestroying()) { return; }
 
+  let eventName = changeEvent(keyName);
   if (deferred > 0) {
-    observerSet.add(obj, keyName);
+    observerSet.add(obj, keyName, eventName);
   } else {
-    sendEvent(obj, keyName, [obj, keyName]);
+    sendEvent(obj, eventName, [obj, keyName]);
   }
 }
 

--- a/packages/ember-metal/tests/watching/unwatch_test.js
+++ b/packages/ember-metal/tests/watching/unwatch_test.js
@@ -14,7 +14,7 @@ import {
 let didCount;
 
 function addListeners(obj, keyPath) {
-  addListener(obj, keyPath, () => didCount++);
+  addListener(obj, keyPath + ':change', () => didCount++);
 }
 
 moduleFor('unwatch', class extends AbstractTestCase {

--- a/packages/ember-metal/tests/watching/watch_test.js
+++ b/packages/ember-metal/tests/watching/watch_test.js
@@ -18,7 +18,7 @@ import {
 let didCount, didKeys, originalLookup;
 
 function addListeners(obj, keyPath) {
-  addListener(obj, keyPath, function() {
+  addListener(obj, keyPath + ':change', function() {
     didCount++;
     didKeys.push(keyPath);
   });

--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -386,7 +386,7 @@ export default Mixin.create({
     @private
   */
   hasObserverFor(key) {
-    return hasListeners(this, key);
+    return hasListeners(this, `${key}:change`);
   },
 
   /**


### PR DESCRIPTION
#This reverts commit b861ccc93ac8dee15c4e58c10ebada28bc85f503.

The problem here is that removing the suffix here makes it more likely (although still pretty unlikely...) to conflict with other events like `.trigger('click')`.