### PR TITLE
Expose ability to detect serialization node.

### DIFF
--- a/packages/ember-application/tests/system/visit_test.js
+++ b/packages/ember-application/tests/system/visit_test.js
@@ -10,7 +10,7 @@ import Application from '../../system/application';
 import ApplicationInstance from '../../system/application-instance';
 import Engine from '../../system/engine';
 import { Route } from 'ember-routing';
-import { Component, helper } from 'ember-glimmer';
+import { Component, helper, isSerializationFirstNode } from 'ember-glimmer';
 import { compile } from 'ember-template-compiler';
 import { ENV } from 'ember-environment';
 
@@ -70,9 +70,8 @@ moduleFor('Application - visit()', class extends ApplicationTestCase {
 
     return this.visit('/', bootOptions)
       .then((instance) => {
-        assert.equal(
-          instance.rootElement.firstChild.nodeValue,
-          '%+b:0%',
+        assert.ok(
+          isSerializationFirstNode(instance.rootElement.firstChild),
           'glimmer-vm comment node was not found'
         );
       }).then(() =>{

--- a/packages/ember-glimmer/lib/index.ts
+++ b/packages/ember-glimmer/lib/index.ts
@@ -305,3 +305,4 @@ export { default as DebugStack } from './utils/debug-stack';
 export { default as OutletView } from './views/outlet';
 export { default as CustomComponentManager } from './component-managers/custom';
 export { COMPONENT_MANAGER, componentManager } from './utils/custom-component-manager';
+export { isSerializationFirstNode, SERIALIZATION_FIRST_NODE_STRING } from './utils/serialization-first-node-helpers';

--- a/packages/ember-glimmer/lib/index.ts
+++ b/packages/ember-glimmer/lib/index.ts
@@ -305,4 +305,4 @@ export { default as DebugStack } from './utils/debug-stack';
 export { default as OutletView } from './views/outlet';
 export { default as CustomComponentManager } from './component-managers/custom';
 export { COMPONENT_MANAGER, componentManager } from './utils/custom-component-manager';
-export { isSerializationFirstNode, SERIALIZATION_FIRST_NODE_STRING } from './utils/serialization-first-node-helpers';
+export { isSerializationFirstNode } from './utils/serialization-first-node-helpers';

--- a/packages/ember-glimmer/lib/utils/serialization-first-node-helpers.ts
+++ b/packages/ember-glimmer/lib/utils/serialization-first-node-helpers.ts
@@ -1,1 +1,1 @@
-export { isSerializationFirstNode, SERIALIZATION_FIRST_NODE_STRING } from '@glimmer/util';
+export { isSerializationFirstNode } from '@glimmer/util';

--- a/packages/ember-glimmer/lib/utils/serialization-first-node-helpers.ts
+++ b/packages/ember-glimmer/lib/utils/serialization-first-node-helpers.ts
@@ -1,0 +1,1 @@
+export { isSerializationFirstNode, SERIALIZATION_FIRST_NODE_STRING } from '@glimmer/util';

--- a/packages/ember/lib/index.js
+++ b/packages/ember/lib/index.js
@@ -429,7 +429,9 @@ import {
   setTemplates,
   template,
   TextField,
-  TextArea
+  TextArea,
+  isSerializationFirstNode,
+  SERIALIZATION_FIRST_NODE_STRING
 } from 'ember-glimmer';
 
 Ember.Component = Component;
@@ -507,7 +509,9 @@ Ember.ViewUtils = {
   getViewClientRects: views.getViewClientRects,
   getViewBoundingClientRect: views.getViewBoundingClientRect,
   getRootViews: views.getRootViews,
-  getChildViews: views.getChildViews
+  getChildViews: views.getChildViews,
+  isSerializationFirstNode: isSerializationFirstNode,
+  SERIALIZATION_FIRST_NODE_STRING: SERIALIZATION_FIRST_NODE_STRING
 };
 
 Ember.TextSupport = views.TextSupport;

--- a/packages/ember/lib/index.js
+++ b/packages/ember/lib/index.js
@@ -430,8 +430,7 @@ import {
   template,
   TextField,
   TextArea,
-  isSerializationFirstNode,
-  SERIALIZATION_FIRST_NODE_STRING
+  isSerializationFirstNode
 } from 'ember-glimmer';
 
 Ember.Component = Component;
@@ -510,8 +509,7 @@ Ember.ViewUtils = {
   getViewBoundingClientRect: views.getViewBoundingClientRect,
   getRootViews: views.getRootViews,
   getChildViews: views.getChildViews,
-  isSerializationFirstNode: isSerializationFirstNode,
-  SERIALIZATION_FIRST_NODE_STRING: SERIALIZATION_FIRST_NODE_STRING
+  isSerializationFirstNode: isSerializationFirstNode
 };
 
 Ember.TextSupport = views.TextSupport;

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -115,7 +115,6 @@ let allExports =[
   ['ViewUtils.getRootViews', 'ember-views', 'getRootViews'],
   ['ViewUtils.getChildViews', 'ember-views', 'getChildViews'],
   ['ViewUtils.isSerializationFirstNode', 'ember-glimmer', 'isSerializationFirstNode'],
-  ['ViewUtils.SERIALIZATION_FIRST_NODE_STRING', 'ember-glimmer', 'SERIALIZATION_FIRST_NODE_STRING'],
   ['TextSupport', 'ember-views'],
   ['ComponentLookup', 'ember-views'],
   ['EventDispatcher', 'ember-views'],

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -114,6 +114,8 @@ let allExports =[
   ['ViewUtils.getViewBoundingClientRect', 'ember-views', 'getViewBoundingClientRect'],
   ['ViewUtils.getRootViews', 'ember-views', 'getRootViews'],
   ['ViewUtils.getChildViews', 'ember-views', 'getChildViews'],
+  ['ViewUtils.isSerializationFirstNode', 'ember-glimmer', 'isSerializationFirstNode'],
+  ['ViewUtils.SERIALIZATION_FIRST_NODE_STRING', 'ember-glimmer', 'SERIALIZATION_FIRST_NODE_STRING'],
   ['TextSupport', 'ember-views'],
   ['ComponentLookup', 'ember-views'],
   ['EventDispatcher', 'ember-views'],


### PR DESCRIPTION
This is dependent on this glimmer-vm PR to actually work https://github.com/glimmerjs/glimmer-vm/pull/788. Which means we'll need to wait until it is merged/bumped and Ember itself updates to use the release with it in it before we can land this.

The idea here is to insulate things that depend on the magic string we use to determine whether or not the DOM node we pass was produced by the serialization element builder.

This needs to be exposed on the global to ensure we can use it in the ember-cli-fastboot vendor file so we can determine how to boot the app when it is loaded in the browser.

To see where it'd be used in ember-cli-fastboot please see this PR with the in progress work:

https://github.com/ember-fastboot/ember-cli-fastboot/pull/580