### PR TITLE
[BUGFIX beta] Ensure proper .toString() of default components.

### DIFF
--- a/packages/ember-glimmer/lib/component.ts
+++ b/packages/ember-glimmer/lib/component.ts
@@ -9,7 +9,7 @@ import {
   PROPERTY_DID_CHANGE,
 } from 'ember-metal';
 import { TargetActionSupport } from 'ember-runtime';
-import { getOwner, NAME_KEY, symbol } from 'ember-utils';
+import { getOwner, symbol } from 'ember-utils';
 import {
   ActionSupport,
   ChildViewsSupport,
@@ -907,7 +907,7 @@ const Component = CoreView.extend(
   },
 );
 
-Component[NAME_KEY] = 'Ember.Component';
+Component.toString = () => '@ember/component';
 
 Component.reopenClass({
   isComponentFactory: true,

--- a/packages/ember-glimmer/lib/components/checkbox.ts
+++ b/packages/ember-glimmer/lib/components/checkbox.ts
@@ -29,7 +29,7 @@ import layout from '../templates/empty';
   @extends Component
   @public
 */
-export default EmberComponent.extend({
+const Checkbox = EmberComponent.extend({
   layout,
   classNames: ['ember-checkbox'],
 
@@ -60,3 +60,7 @@ export default EmberComponent.extend({
    set(this, 'checked', this.element.checked);
   },
 });
+
+Checkbox.toString = () => '@ember/component/checkbox';
+
+export default Checkbox;

--- a/packages/ember-glimmer/lib/components/link-to.ts
+++ b/packages/ember-glimmer/lib/components/link-to.ts
@@ -824,7 +824,7 @@ const LinkComponent = EmberComponent.extend({
   },
 });
 
-LinkComponent.toString = () => 'LinkComponent';
+LinkComponent.toString = () => '@ember/routing/link-component';
 
 LinkComponent.reopenClass({
   positionalParams: 'params',

--- a/packages/ember-glimmer/lib/components/text_area.ts
+++ b/packages/ember-glimmer/lib/components/text_area.ts
@@ -214,7 +214,7 @@ import layout from '../templates/empty';
   @uses Ember.TextSupport
   @public
 */
-export default Component.extend(TextSupport, {
+const TextArea = Component.extend(TextSupport, {
   classNames: ['ember-text-area'],
 
   layout,
@@ -234,3 +234,7 @@ export default Component.extend(TextSupport, {
   rows: null,
   cols: null,
 });
+
+TextArea.toString = () => '@ember/component/text-area';
+
+export default TextArea;

--- a/packages/ember-glimmer/lib/components/text_field.ts
+++ b/packages/ember-glimmer/lib/components/text_field.ts
@@ -49,7 +49,7 @@ function canSetTypeOfInput(type: string) {
   @uses Ember.TextSupport
   @public
 */
-export default Component.extend(TextSupport, {
+const TextField = Component.extend(TextSupport, {
   layout,
   classNames: ['ember-text-field'],
   tagName: 'input',
@@ -156,3 +156,7 @@ export default Component.extend(TextSupport, {
   */
   max: null,
 });
+
+TextField.toString = () => '@ember/component/text-field';
+
+export default TextField;

--- a/packages/ember-glimmer/tests/integration/components/to-string-test.js
+++ b/packages/ember-glimmer/tests/integration/components/to-string-test.js
@@ -1,0 +1,24 @@
+import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { Checkbox, Component, LinkComponent, TextArea, TextField } from 'ember-glimmer';
+
+moduleFor('built-in component toString', class AbstractAppendTest extends RenderingTest {
+  '@test text-field has the correct toString value'(assert) {
+    assert.strictEqual(TextField.toString(), '@ember/component/text-field');
+  }
+
+  '@test checkbox has the correct toString value'(assert) {
+    assert.strictEqual(Checkbox.toString(), '@ember/component/checkbox');
+  }
+
+  '@test text-area has the correct toString value'(assert) {
+    assert.strictEqual(TextArea.toString(), '@ember/component/text-area');
+  }
+
+  '@test component has the correct toString value'(assert) {
+    assert.strictEqual(Component.toString(), '@ember/component');
+  }
+
+  '@test LinkTo has the correct toString value'(assert) {
+    assert.strictEqual(LinkComponent.toString(), '@ember/routing/link-component');
+  }
+});


### PR DESCRIPTION
In older Ember versions the default components were generally labelled as `Ember.Component` or `Ember.TextField` via the `NAME_KEY` property on the class itself. During the glimmer-vm upgrade which landed during the 3.1 canary cycle the custom `NAME_KEY` was lost for `Ember.TextField`.

This commit removes needless usage of `NAME_KEY` (not needed since our normal `Ember.Object` instance's `.toString` methods check for the factories own `toString` properly), and updates the actual paths to match the new JS modules API locations (thus reducing more "globals" shenanigans).