### PR TITLE
Acceptance testing blueprint will use the app's setup-application-test blueprint.

### DIFF
--- a/blueprints/acceptance-test/qunit-rfc-232-files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/qunit-rfc-232-files/tests/acceptance/__name__-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
-import { setupApplicationTest } from 'ember-qunit';
+import setupApplicationTest from '<%= dasherizedPackageName %>/tests/helpers/setup-application-test';
 
 module('<%= friendlyTestName %>', function(hooks) {
   setupApplicationTest(hooks);

--- a/blueprints/acceptance-test/qunit-rfc-232-files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/qunit-rfc-232-files/tests/acceptance/__name__-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
-import setupApplicationTest from '<%= dasherizedPackageName %>/tests/helpers/setup-application-test';
+import setupApplicationTest from '<%= testFolderRoot %>/tests/helpers/index';
 
 module('<%= friendlyTestName %>', function(hooks) {
   setupApplicationTest(hooks);


### PR DESCRIPTION
See https://github.com/ember-cli/ember-cli/pull/7657 for the ember-cli part of this.