### PR TITLE
[BUGFIX beta] Rename private property Route#router to Router#_router

### DIFF
--- a/packages/ember-application/lib/system/engine.js
+++ b/packages/ember-application/lib/system/engine.js
@@ -502,7 +502,7 @@ function commonSetupRegistry(registry) {
   registry.injection('router', '_bucketCache', P`-bucket-cache:main`);
   registry.injection('route', '_bucketCache', P`-bucket-cache:main`);
 
-  registry.injection('route', 'router', 'router:main');
+  registry.injection('route', '_router', 'router:main');
 
   // Register the routing service...
   registry.register('service:-routing', RoutingService);

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -135,7 +135,7 @@ moduleFor('Application', class extends ApplicationTestCase {
     verifyInjection(assert, application, 'router', '_bucketCache', P`-bucket-cache:main`);
     verifyInjection(assert, application, 'route', '_bucketCache', P`-bucket-cache:main`);
 
-    verifyInjection(assert, application, 'route', 'router', 'router:main');
+    verifyInjection(assert, application, 'route', '_router', 'router:main');
 
     verifyRegistration(assert, application, 'component:-text-field');
     verifyRegistration(assert, application, 'component:-text-area');

--- a/packages/ember-application/tests/system/engine_test.js
+++ b/packages/ember-application/tests/system/engine_test.js
@@ -54,7 +54,7 @@ moduleFor('Engine', class extends TestCase {
     verifyInjection(assert, engine, 'router', '_bucketCache', P`-bucket-cache:main`);
     verifyInjection(assert, engine, 'route', '_bucketCache', P`-bucket-cache:main`);
 
-    verifyInjection(assert, engine, 'route', 'router', 'router:main');
+    verifyInjection(assert, engine, 'route', '_router', 'router:main');
 
     verifyRegistration(assert, engine, 'component:-text-field');
     verifyRegistration(assert, engine, 'component:-text-area');

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -1194,7 +1194,7 @@ function logError(_error, initialMessage) {
 */
 function findRouteSubstateName(route, state) {
   let owner = getOwner(route);
-  let { routeName, fullRouteName, router } = route;
+  let { routeName, fullRouteName, _router: router } = route;
 
   let substateName = `${routeName}_${state}`;
   let substateNameFull = `${fullRouteName}_${state}`;
@@ -1216,7 +1216,7 @@ function findRouteSubstateName(route, state) {
 */
 function findRouteStateName(route, state) {
   let owner = getOwner(route);
-  let { routeName, fullRouteName, router } = route;
+  let { routeName, fullRouteName, _router: router } = route;
 
   let stateName = routeName === 'application' ? state : `${routeName}.${state}`;
   let stateNameFull = fullRouteName === 'application' ? state : `${fullRouteName}.${state}`;
@@ -1264,7 +1264,7 @@ export function triggerEvent(handlerInfos, ignoreFailure, args) {
       } else {
         // Should only hit here if a non-bubbling error action is triggered on a route.
         if (name === 'error') {
-          handler.router._markErrorAsHandled(args[0]);
+          handler._router._markErrorAsHandled(args[0]);
         }
         return;
       }

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -327,9 +327,9 @@ moduleFor('Route with engines', class extends AbstractTestCase {
       }
     });
 
-    let applicationRoute = EmberRoute.create({ router, routeName: 'application', fullRouteName: 'foo.bar' });
-    let postsRoute = EmberRoute.create({ router, routeName: 'posts', fullRouteName: 'foo.bar.posts' });
-    let route = EmberRoute.create({ router });
+    let applicationRoute = EmberRoute.create({ _router: router, routeName: 'application', fullRouteName: 'foo.bar' });
+    let postsRoute = EmberRoute.create({ _router: router, routeName: 'posts', fullRouteName: 'foo.bar.posts' });
+    let route = EmberRoute.create({ _router: router });
 
     setOwner(applicationRoute, engineInstance);
     setOwner(postsRoute, engineInstance);
@@ -370,9 +370,9 @@ moduleFor('Route with engines', class extends AbstractTestCase {
       }
     });
 
-    let applicationRoute = EmberRoute.create({ router, routeName: 'application' });
-    let postsRoute = EmberRoute.create({ router, routeName: 'posts' });
-    let route = EmberRoute.create({ router });
+    let applicationRoute = EmberRoute.create({ _router: router, routeName: 'application' });
+    let postsRoute = EmberRoute.create({ _router: router, routeName: 'posts' });
+    let route = EmberRoute.create({ _router: router });
 
     setOwner(applicationRoute, engineInstance);
     setOwner(postsRoute, engineInstance);
@@ -396,7 +396,7 @@ moduleFor('Route with engines', class extends AbstractTestCase {
       }
     });
 
-    let route = EmberRoute.create({ router });
+    let route = EmberRoute.create({ _router: router });
     setOwner(route, engineInstance);
 
     assert.strictEqual(route.transitionTo('application'), 'foo.bar.application', 'properly prefixes application route');
@@ -422,7 +422,7 @@ moduleFor('Route with engines', class extends AbstractTestCase {
       }
     });
 
-    let route = EmberRoute.create({ router });
+    let route = EmberRoute.create({ _router: router });
     setOwner(route, engineInstance);
 
     route.intermediateTransitionTo('application');
@@ -452,7 +452,7 @@ moduleFor('Route with engines', class extends AbstractTestCase {
       }
     });
 
-    let route = EmberRoute.create({ router });
+    let route = EmberRoute.create({ _router: router });
     setOwner(route, engineInstance);
 
     assert.strictEqual(route.replaceWith('application'), 'foo.bar.application', 'properly prefixes application route');
@@ -461,5 +461,13 @@ moduleFor('Route with engines', class extends AbstractTestCase {
 
     let queryParams = {};
     assert.strictEqual(route.replaceWith(queryParams), queryParams, 'passes query param only transitions through');
+  }
+
+  ['@test `router` is a deprecated one-way alias to `_router`'](assert) {
+    let router = {};
+    let route = EmberRoute.create({ _router: router });
+    expectDeprecation(function() {
+      return assert.equal(route.router, router);
+    }, 'Route#router is an intimate API that has been renamed to Route#_router. However you might want to consider using the router service');
   }
 });

--- a/packages/ember/tests/routing/router_service_test/basic_test.js
+++ b/packages/ember/tests/routing/router_service_test/basic_test.js
@@ -72,7 +72,7 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
       this.add('route:parent.index', Route.extend({
         init() {
           this._super();
-          set(this.router, 'rootURL', '/homepage');
+          set(this._router, 'rootURL', '/homepage');
         }
       }));
 


### PR DESCRIPTION
The fact that this private property was named `router` was preventing users
from injecting the router service into routes like this:

```js
export default Route.extend({
  router: service()
});
```

I consider that the above code is pretty reasonable, and it should be
the private property the one that should be renamed to a clearer `_router`
name that is less likely to collide with user-defined properties or methods.

If you deem this an _intimate_ API we could consider adding a deprecated
alias, but I don't have evidence to consider it such, as `router` is too
common of a term to search for in emberobserver.

Closes #16088