### PR TITLE
Namespaced invocation

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -146,21 +146,15 @@ export default class Container {
     let normalizedName = this.registry.normalize(fullName);
 
     assert('fullName must be a proper full name', this.registry.isValidFullName(normalizedName));
+    assert(
+      'EMBER_MODULE_UNIFICATION must be enabled to pass a namespace option to factoryFor',
+      EMBER_MODULE_UNIFICATION || !options.namespace
+    );
 
-    if (options.source) {
-      let expandedFullName = this.registry.expandLocalLookup(fullName, options);
-      // if expandLocalLookup returns falsey, we do not support local lookup
-      if (!EMBER_MODULE_UNIFICATION) {
-        if (!expandedFullName) {
-          return;
-        }
-
-        normalizedName = expandedFullName;
-      } else if (expandedFullName) {
-        // with ember-module-unification, if expandLocalLookup returns something,
-        // pass it to the resolve without the source
-        normalizedName = expandedFullName;
-        options = {};
+    if (options.source || options.namespace) {
+      normalizedName = this.registry.expandLocalLookup(fullName, options);
+      if (!normalizedName) {
+        return;
       }
     }
 
@@ -206,22 +200,17 @@ function isInstantiatable(container, fullName) {
 }
 
 function lookup(container, fullName, options = {}) {
+  assert(
+    'EMBER_MODULE_UNIFICATION must be enabled to pass a namespace option to lookup',
+    EMBER_MODULE_UNIFICATION || !options.namespace
+  );
+
   let normalizedName = fullName;
-  if (options.source) {
-    let expandedFullName = container.registry.expandLocalLookup(fullName, options);
 
-    if (!EMBER_MODULE_UNIFICATION) {
-      // if expandLocalLookup returns falsey, we do not support local lookup
-      if (!expandedFullName) {
-        return;
-      }
-
-      normalizedName = expandedFullName;
-    } else if (expandedFullName) {
-      // with ember-module-unification, if expandLocalLookup returns something,
-      // pass it to the resolve without the source
-      normalizedName = expandedFullName;
-      options = {};
+  if (options.source || options.namespace) {
+    normalizedName = container.registry.expandLocalLookup(fullName, options);
+    if (!normalizedName) {
+      return;
     }
   }
 

--- a/packages/container/tests/registry_test.js
+++ b/packages/container/tests/registry_test.js
@@ -698,9 +698,7 @@ moduleFor('Registry', class extends AbstractTestCase{
 
     let resolver = {
       resolve(name) {
-        if (EMBER_MODULE_UNIFICATION && name === 'foo:baz') { return; }
         resolvedFullNames.push(name);
-
         return 'yippie!';
       },
 
@@ -761,12 +759,51 @@ if (EMBER_MODULE_UNIFICATION) {
       let registry = new Registry({ resolver });
 
       assert.strictEqual(
+        registry.resolve(specifier),
+        undefined,
+        'Not returned when specifier not scoped'
+      );
+      assert.strictEqual(
         registry.resolve(specifier, { source }),
         PrivateComponent,
         'The correct factory was provided'
       );
       assert.strictEqual(
         registry.resolve(specifier, { source }),
+        PrivateComponent,
+        'The correct factory was provided again'
+      );
+    }
+
+    ['@test The registry can pass a namespace to the resolver'](assert) {
+      let PrivateComponent = factory();
+      let type = 'component';
+      let name = 'my-input';
+      let specifier = `${type}:${name}`;
+      let source = 'template:routes/application';
+      let namespace = 'my-addon';
+
+      let resolver = new ModuleBasedTestResolver();
+      resolver.add({specifier, source, namespace}, PrivateComponent);
+      let registry = new Registry({ resolver });
+
+      assert.strictEqual(
+        registry.resolve(specifier),
+        undefined,
+        'Not returned when specifier not scoped'
+      );
+      assert.strictEqual(
+        registry.resolve(specifier, {source}),
+        undefined,
+        'Not returned when specifier is missing namespace'
+      );
+      assert.strictEqual(
+        registry.resolve(specifier, { source, namespace }),
+        PrivateComponent,
+        'The correct factory was provided'
+      );
+      assert.strictEqual(
+        registry.resolve(specifier, { source, namespace }),
         PrivateComponent,
         'The correct factory was provided again'
       );

--- a/packages/ember-glimmer/lib/resolver.ts
+++ b/packages/ember-glimmer/lib/resolver.ts
@@ -21,6 +21,7 @@ import {
   lookupPartial,
   OwnedTemplateMeta,
 } from 'ember-views';
+import { EMBER_MODULE_UNIFICATION } from 'ember/features';
 import CompileTimeLookup from './compile-time-lookup';
 import { CurlyComponentDefinition } from './component-managers/curly';
 import { TemplateOnlyComponentDefinition } from './component-managers/template-only';
@@ -52,8 +53,11 @@ function instrumentationPayload(name: string) {
   return { object: `component:${name}` };
 }
 
-function makeOptions(moduleName: string) {
-  return moduleName !== undefined ? { source: `template:${moduleName}`} : undefined;
+function makeOptions(moduleName: string, namespace?: string): LookupOptions {
+  return {
+    source: moduleName !== undefined ? `template:${moduleName}` : undefined,
+    namespace
+  };
 }
 
 const BUILTINS_HELPERS = {
@@ -208,15 +212,23 @@ export default class RuntimeResolver implements IRuntimeResolver<OwnedTemplateMe
     return handle;
   }
 
-  private _lookupHelper(name: string, meta: OwnedTemplateMeta): Option<Helper> {
-    const helper = this.builtInHelpers[name];
+  private _lookupHelper(_name: string, meta: OwnedTemplateMeta): Option<Helper> {
+    const helper = this.builtInHelpers[_name];
     if (helper !== undefined) {
       return helper;
     }
 
     const { owner, moduleName } = meta;
 
-    const options: LookupOptions | undefined = makeOptions(moduleName);
+    let name = _name;
+    let namespace = undefined;
+    if (EMBER_MODULE_UNIFICATION) {
+      const parsed = this._parseNameForNamespace(_name);
+      name = parsed.name;
+      namespace = parsed.namespace;
+    }
+
+    const options: LookupOptions = makeOptions(moduleName, namespace);
 
     const factory = owner.factoryFor(`helper:${name}`, options) || owner.factoryFor(`helper:${name}`);
 
@@ -257,8 +269,27 @@ export default class RuntimeResolver implements IRuntimeResolver<OwnedTemplateMe
     return null;
   }
 
-  private _lookupComponentDefinition(name: string, meta: OwnedTemplateMeta): Option<ComponentDefinition> {
-    let { layout, component } = lookupComponent(meta.owner, name, makeOptions(meta.moduleName));
+  private _parseNameForNamespace(_name: string) {
+    let name = _name;
+    let namespace = undefined;
+    let namespaceDelimiterOffset = _name.indexOf('::');
+    if (namespaceDelimiterOffset !== -1) {
+      name = _name.slice(namespaceDelimiterOffset+2);
+      namespace = _name.slice(0, namespaceDelimiterOffset);
+    }
+
+    return {name, namespace};
+  }
+
+  private _lookupComponentDefinition(_name: string, meta: OwnedTemplateMeta): Option<ComponentDefinition> {
+    let name = _name;
+    let namespace = undefined;
+    if (EMBER_MODULE_UNIFICATION) {
+      const parsed = this._parseNameForNamespace(_name);
+      name = parsed.name;
+      namespace = parsed.namespace;
+    }
+    let { layout, component } = lookupComponent(meta.owner, name, makeOptions(meta.moduleName, namespace));
 
     if (layout && !component && ENV._TEMPLATE_ONLY_GLIMMER_COMPONENTS) {
       return new TemplateOnlyComponentDefinition(layout);

--- a/packages/ember-glimmer/tests/integration/components/local-lookup-test.js
+++ b/packages/ember-glimmer/tests/integration/components/local-lookup-test.js
@@ -201,6 +201,10 @@ function buildResolver() {
   let resolver = {
     resolve() { },
     expandLocalLookup(fullName, sourceFullName) {
+      if (!sourceFullName) {
+        return null;
+      }
+
       let [sourceType, sourceName ] = sourceFullName.split(':');
       let [type, name ] = fullName.split(':');
 

--- a/packages/ember-glimmer/tests/integration/components/namespaced-lookup-test.js
+++ b/packages/ember-glimmer/tests/integration/components/namespaced-lookup-test.js
@@ -1,0 +1,142 @@
+import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { EMBER_MODULE_UNIFICATION } from 'ember/features';
+import { Component, helper } from 'ember-glimmer';
+
+if (EMBER_MODULE_UNIFICATION) {
+
+  moduleFor('Namespaced lookup', class extends RenderingTest {
+    ['@test it can render a namespaced component']() {
+      this.addTemplate({
+        specifier: 'template:components/my-component',
+        namespace: 'my-addon'
+      }, 'namespaced template {{myProp}}');
+
+      this.add({
+        specifier: 'component:my-component',
+        namespace: 'my-addon'
+      }, Component.extend({
+        myProp: 'My property'
+      }));
+
+      this.addComponent('x-outer', { template: '{{my-addon::my-component}}' });
+
+      this.render('{{x-outer}}');
+
+      this.assertText('namespaced template My property');
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('namespaced template My property');
+    }
+
+    ['@test it can render a nested namespaced component']() {
+      this.addTemplate({
+        specifier: 'template:components/my-component',
+        namespace: 'second-addon'
+      }, 'second namespaced template');
+
+      this.addTemplate({
+        specifier: 'template:components/my-component',
+        namespace: 'first-addon'
+      }, 'first namespaced template - {{second-addon::my-component}}');
+
+      this.addComponent('x-outer', { template: '{{first-addon::my-component}}' });
+
+      this.render('{{x-outer}}');
+
+      this.assertText('first namespaced template - second namespaced template');
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('first namespaced template - second namespaced template');
+    }
+
+    ['@test it can render a nested un-namespaced component']() {
+      this.addTemplate({
+        specifier: 'template:components/addon-component',
+        source: 'template:first-addon/src/ui/components/my-component.hbs'
+      }, 'un-namespaced addon template');
+
+      this.addTemplate({
+        specifier: 'template:components/my-component',
+        moduleName: 'first-addon/src/ui/components/my-component.hbs',
+        namespace: 'first-addon'
+      }, '{{addon-component}}');
+
+      this.addComponent('x-outer', { template: '{{first-addon::my-component}}' });
+
+      this.render('{{x-outer}}');
+
+      this.assertText('un-namespaced addon template');
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('un-namespaced addon template');
+    }
+
+    ['@test it can render a namespaced main component']() {
+      this.addTemplate({
+        specifier: 'template:components/addon-component',
+        soruce: 'template:first-addon/src/ui/components/main.hbs'
+      }, 'Nested namespaced component');
+
+      this.addTemplate({
+        specifier: 'template:components/first-addon',
+        moduleName: 'first-addon/src/ui/components/main.hbs'
+      }, '{{addon-component}}');
+
+      this.addComponent('x-outer', { template: '{{first-addon}}' });
+
+      this.render('{{x-outer}}');
+
+      this.assertText('Nested namespaced component');
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('Nested namespaced component');
+    }
+
+    ['@test it does not render a main component when using a namespace']() {
+      this.addTemplate({
+        specifier: 'template:components/main',
+        namespace: 'my-addon'
+      }, 'namespaced template {{myProp}}');
+
+      this.add({
+        specifier: 'component:main',
+        namespace: 'my-addon'
+      }, Component.extend({
+        myProp: 'My property'
+      }));
+
+      this.add({
+        specifier: 'helper:my-addon',
+        namespace: 'empty-namespace'
+
+      }, helper(() => 'my helper'));
+
+      this.render('{{empty-namespace::my-addon}}');
+
+      this.assertText('my helper'); // component should be not found
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('my helper');
+    }
+
+    ['@test it renders a namespaced helper']() {
+      this.add({
+        specifier: 'helper:my-helper',
+        namespace: 'my-namespace'
+      }, helper(() => 'my helper'));
+
+      this.render('{{my-namespace::my-helper}}');
+
+      this.assertText('my helper');
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('my helper');
+    }
+  });
+}

--- a/packages/ember-metal/lib/injected_property.js
+++ b/packages/ember-metal/lib/injected_property.js
@@ -24,8 +24,20 @@ export default class InjectedProperty extends ComputedProperty {
     super(injectedPropertyGet);
 
     this.type = type;
-    this.name = name;
     this.source = options ? options.source : undefined;
+
+    if (name) {
+      let namespaceDelimiterOffset = name.indexOf('::');
+      if (namespaceDelimiterOffset === -1) {
+        this.name = name;
+        this.namespace = undefined;
+      } else {
+        this.name = name.slice(namespaceDelimiterOffset+2);
+        this.namespace = name.slice(0, namespaceDelimiterOffset);
+      }
+    } else {
+      this.name = undefined;
+    }
   }
 }
 
@@ -37,5 +49,5 @@ function injectedPropertyGet(keyName) {
   assert(`Attempting to lookup an injected property on an object without a container, ensure that the object was instantiated via a container.`, owner);
 
   let specifier = `${desc.type}:${desc.name || keyName}`;
-  return owner.lookup(specifier, {source: desc.source});
+  return owner.lookup(specifier, {source: desc.source, namespace: desc.namespace});
 }

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -1021,8 +1021,9 @@ if (DEBUG) {
       desc = descriptorFor(proto, key);
       if (desc instanceof InjectedProperty) {
         injections[key] = {
-          specifier: `${desc.type}:${desc.name || key}`,
-          source: desc.source
+          namespace: desc.namespace,
+          source: desc.source,
+          specifier: `${desc.type}:${desc.name || key}`
         };
       }
     }

--- a/packages/ember-runtime/tests/inject_test.js
+++ b/packages/ember-runtime/tests/inject_test.js
@@ -64,8 +64,8 @@ if (DEBUG) {
     assert.deepEqual(
       AnObject._lazyInjections(),
       {
-        'foo': { specifier: 'foo:bar', source: undefined },
-        'bar': { specifier: 'quux:bar', source: undefined }
+        'foo': { specifier: 'foo:bar', source: undefined, namespace: undefined },
+        'bar': { specifier: 'quux:bar', source: undefined, namespace: undefined }
       }, 'should return injected container keys');
   });
 }

--- a/packages/ember-utils/lib/index.d.ts
+++ b/packages/ember-utils/lib/index.d.ts
@@ -8,7 +8,8 @@ export interface Factory<T, C> {
 }
 
 export interface LookupOptions {
-  source: string;
+  source?: string;
+  namespace?: string;
 }
 
 export interface Owner {

--- a/packages/ember-views/lib/utils/lookup-component.js
+++ b/packages/ember-views/lib/utils/lookup-component.js
@@ -56,9 +56,7 @@ function lookupComponentPair(componentLookup, owner, name, options) {
 export default function lookupComponent(owner, name, options) {
   let componentLookup = owner.lookup('component-lookup:main');
 
-  let source = options && options.source;
-
-  if (source) {
+  if (options && (options.source || options.namespace)) {
     let localResult = lookupComponentPair(componentLookup, owner, name, options);
 
     if (localResult.component || localResult.layout) {

--- a/packages/ember/tests/service_injection_test.js
+++ b/packages/ember/tests/service_injection_test.js
@@ -168,6 +168,22 @@ if (EMBER_MODULE_UNIFICATION) {
       });
     }
 
+    ['@test Service with namespace can be injected and is resolved'](assert) {
+      this.add('controller:application', Controller.extend({
+        myService: inject.service('my-namespace::my-service')
+      }));
+      let MyService = Service.extend();
+      this.add({
+        specifier: 'service:my-service',
+        namespace: 'my-namespace'
+      }, MyService);
+
+      this.visit('/').then(() => {
+        let controller = this.applicationInstance.lookup('controller:application');
+        assert.ok(controller.get('myService') instanceof MyService);
+      });
+    }
+
   });
 
 }

--- a/packages/internal-test-helpers/lib/test-cases/abstract-rendering.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract-rendering.js
@@ -2,6 +2,7 @@ import { assign } from 'ember-utils';
 import { compile } from 'ember-template-compiler';
 import { EventDispatcher } from 'ember-views';
 import { helper, Helper, Component, _resetRenderers} from 'ember-glimmer';
+import { ModuleBasedResolver } from '../test-resolver';
 
 import AbstractTestCase from './abstract';
 import buildOwner from '../build-owner';
@@ -41,7 +42,42 @@ export default class AbstractRenderingTestCase extends AbstractTestCase {
 
   getOwnerOptions() { }
   getBootOptions() { }
-  getResolver() { }
+
+  get resolver() {
+    return this.owner.__registry__.fallback.resolver;
+  }
+
+  getResolver() {
+    return new ModuleBasedResolver();
+  }
+
+  add(specifier, factory) {
+    this.resolver.add(specifier, factory);
+  }
+
+  addTemplate(templateName, templateString) {
+    if (typeof templateName === 'string') {
+      this.resolver.add(`template:${templateName}`, this.compile(templateString, {
+        moduleName: templateName
+      }));
+    } else {
+      this.resolver.add(templateName, this.compile(templateString, {
+        moduleName: templateName.moduleName
+      }));
+    }
+  }
+
+  addComponent(name, { ComponentClass = null, template = null }) {
+    if (ComponentClass) {
+      this.resolver.add(`component:${name}`, ComponentClass);
+    }
+
+    if (typeof template === 'string') {
+      this.resolver.add(`template:components/${name}`, this.compile(template, {
+        moduleName: `components/${name}`
+      }));
+    }
+  }
 
   afterEach() {
     try {

--- a/packages/internal-test-helpers/lib/test-resolver.js
+++ b/packages/internal-test-helpers/lib/test-resolver.js
@@ -2,8 +2,9 @@ import { compile } from 'ember-template-compiler';
 
 const DELIMITER = '%';
 
-function serializeKey(specifier, source) {
-  return [specifier, source].join(DELIMITER);
+function serializeKey(specifier, source, namespace) {
+  let [type, name] = specifier.split(':');
+  return `${type}://${[name, (namespace ? '[source invalid due to namespace]' : source), namespace].join(DELIMITER)}`;
 }
 
 class Resolver {
@@ -14,16 +15,24 @@ class Resolver {
   resolve(specifier) {
     return this._registered[specifier] || this._registered[serializeKey(specifier)];
   }
-  expandLocalLookup(specifier, source) {
-    let key = serializeKey(specifier, source);
-    if (this._registered[key]) {
-      return key;
+  expandLocalLookup(specifier, source, namespace) {
+    if (specifier.indexOf('://') !== -1) {
+      return specifier; // an already expanded specifier
     }
 
-    /*
-     * For a top-level resolution or no resolution, return null
-     */
-    return null;
+    if (source || namespace) {
+      let key = serializeKey(specifier, source, namespace);
+      if (this._registered[key]) {
+        return key; // like local lookup
+      }
+
+      key = serializeKey(specifier);
+      if (this._registered[key]) {
+        return specifier; // top level resolution despite source/namespace
+      }
+    }
+
+    return specifier; // didn't know how to expand it
   }
   add(lookup, factory) {
     let key;
@@ -35,7 +44,7 @@ class Resolver {
         key = serializeKey(lookup);
         break;
       case 'object':
-        key = serializeKey(lookup.specifier, lookup.source);
+        key = serializeKey(lookup.specifier, lookup.source, lookup.namespace);
         break;
       default:
         throw new Error('Specifier string has an unknown type');


### PR DESCRIPTION
Replaces https://github.com/emberjs/ember.js/pull/16158

This commit adds support for invoking a component or injecting a service from a module unification namespace. It is in alignment with [RFC #309](https://github.com/emberjs/rfcs/pull/309).

Use `::` to delimit namespaces from the name of an invocation or injection. For example:

```hbs
{{! src/ui/components/app-component/template.hbs }}
{{my-addon::addon-component}}
```

```js
// src/ui/components/app-component/component.js
import { inject } from '@ember/services';
import Component from '@ember/component';

export default Component.extend({
  session: inject('ember-simple-auth::session')
});
```