### PR TITLE
If syntax error message

### DIFF
--- a/packages/ember-glimmer/tests/integration/helpers/if-unless-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/if-unless-test.js
@@ -10,13 +10,13 @@ moduleFor('Helpers test: inline {{if}}', class extends IfUnlessHelperTest {
   ['@test it raises when there are more than three arguments']() {
     expectAssertion(() => {
       this.render(`{{if condition 'a' 'b' 'c'}}`, { condition: true });
-    }, /The inline form of the `if` helper expects two or three arguments/);
+    }, `The inline form of the 'if' helper expects two or three arguments. ('-top-level' @ L1:C0) `);
   }
 
   ['@test it raises when there are less than two arguments']() {
     expectAssertion(() => {
       this.render(`{{if condition}}`, { condition: true });
-    }, /The inline form of the `if` helper expects two or three arguments/);
+    }, `The inline form of the 'if' helper expects two or three arguments. ('-top-level' @ L1:C0) `);
   }
 
 });

--- a/packages/ember-template-compiler/lib/plugins/assert-if-helper-without-arguments.js
+++ b/packages/ember-template-compiler/lib/plugins/assert-if-helper-without-arguments.js
@@ -1,0 +1,47 @@
+import { assert } from 'ember-debug';
+import calculateLocationDisplay from '../system/calculate-location-display';
+
+export default function assertIfHelperWithoutArguments(env) {
+  let { moduleName } = env.meta;
+
+  return {
+    name: 'assert-if-helper-without-arguments',
+
+    visitor: {
+      BlockStatement(node) {
+        if (isInvalidBlockIf(node)) {
+          assert(`${blockAssertMessage(node.path.original)} ${calculateLocationDisplay(moduleName, node.loc)}`);
+        }
+      },
+
+      MustacheStatement(node) {
+        if (isInvalidInlineIf(node)) {
+          assert(`${inlineAssertMessage(node.path.original)} ${calculateLocationDisplay(moduleName, node.loc)}`);
+        }
+      },
+
+      SubExpression(node) {
+        if (isInvalidInlineIf(node)) {
+          assert(`${inlineAssertMessage(node.path.original)} ${calculateLocationDisplay(moduleName, node.loc)}`);
+        }
+      }
+    }
+  };
+}
+
+function blockAssertMessage(original) {
+  return `#${original} requires a single argument.`;
+}
+
+function inlineAssertMessage(original) {
+  return `The inline form of the '${original}' helper expects two or three arguments.`;
+}
+
+function isInvalidInlineIf(node) {
+  return node.path.original === 'if' && (!node.params || node.params.length < 2 || node.params.length > 3);
+}
+
+function isInvalidBlockIf(node) {
+  return node.path.original === 'if' && (!node.params || node.params.length !== 1);
+}
+

--- a/packages/ember-template-compiler/lib/plugins/index.js
+++ b/packages/ember-template-compiler/lib/plugins/index.js
@@ -15,6 +15,7 @@ import TransformHasBlockSyntax from './transform-has-block-syntax';
 import TransformDotComponentInvocation from './transform-dot-component-invocation';
 import AssertInputHelperWithoutBlock from './assert-input-helper-without-block';
 import TransformInElement from './transform-in-element';
+import AssertIfHelperWithoutArguments from './assert-if-helper-without-arguments';
 
 const transforms = [
   TransformDotComponentInvocation,
@@ -34,6 +35,7 @@ const transforms = [
   TransformHasBlockSyntax,
   AssertInputHelperWithoutBlock,
   TransformInElement,
+  AssertIfHelperWithoutArguments
 ];
 
 export default Object.freeze(transforms);

--- a/packages/ember-template-compiler/tests/plugins/assert-if-helper-without-arguments-test.js
+++ b/packages/ember-template-compiler/tests/plugins/assert-if-helper-without-arguments-test.js
@@ -1,0 +1,50 @@
+import { compile } from '../../index';
+import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+
+moduleFor('ember-template-compiler: assert-if-helper-without-argument', class extends AbstractTestCase {
+  [`@test block if helper expects one argument`]() {
+    expectAssertion(() => {
+       compile(`{{#if}}aVal{{/if}}`, {
+        moduleName: 'baz/foo-bar'
+      });
+    }, `#if requires a single argument. ('baz/foo-bar' @ L1:C0) `);
+
+    expectAssertion(() => {
+       compile(`{{#if val1 val2}}aVal{{/if}}`, {
+        moduleName: 'baz/foo-bar'
+      });
+    }, `#if requires a single argument. ('baz/foo-bar' @ L1:C0) `);
+
+    expectAssertion(() => {
+      compile(`{{#if}}aVal{{/if}}`, {
+        moduleName: 'baz/foo-bar'
+      });
+    }, `#if requires a single argument. ('baz/foo-bar' @ L1:C0) `);
+  }
+
+  [`@test inline if helper expects between one and three arguments`]() {
+    expectAssertion(() => {
+      compile(`{{if}}`, {
+        moduleName: 'baz/foo-bar'
+      });
+    }, `The inline form of the 'if' helper expects two or three arguments. ('baz/foo-bar' @ L1:C0) `);
+
+    compile(`{{if foo bar baz}}`, {
+      moduleName: 'baz/foo-bar'
+    });
+  }
+
+  ['@test subexpression if helper expects between one and three arguments']() {
+    expectAssertion(() => {
+      compile(`{{input foo=(if)}}`, {
+        moduleName: 'baz/foo-bar'
+      });
+    }, `The inline form of the 'if' helper expects two or three arguments. ('baz/foo-bar' @ L1:C12) `);
+
+    compile(`{{some-thing foo=(if foo bar baz)}}`, {
+      moduleName: 'baz/foo-bar'
+    });
+  }
+
+});
+


### PR DESCRIPTION
This (hopefully) resolves [issue 16322](https://github.com/emberjs/ember.js/issues/16322) regarding an unclear error message when passing an incorrect number of arguments to an `if` helper.