### PR TITLE
Autocomplete attribute for ember textarea

### DIFF
--- a/packages/ember-glimmer/lib/components/text_area.ts
+++ b/packages/ember-glimmer/lib/components/text_area.ts
@@ -22,6 +22,7 @@ import layout from '../templates/empty';
     * `tabindex`
     * `selectionEnd`
     * `selectionStart`
+    * `autocomplete`
     * `selectionDirection`
     * `wrap`
     * `readonly`
@@ -226,6 +227,7 @@ const TextArea = Component.extend(TextSupport, {
     'name',
     'selectionEnd',
     'selectionStart',
+    'autocomplete',
     'wrap',
     'lang',
     'dir',


### PR DESCRIPTION
Latest chrome  64.0.3282.167 has tips abot textarea customatization, but, `{{textarea}}` can't use "autcomplete" attribute 

![image](https://user-images.githubusercontent.com/1360552/37036372-8ae1e10a-2160-11e8-93b2-0e6327a9e6ef.png)

https://developer.mozilla.org/ru/docs/Web/HTML/Element/textarea