### PR TITLE
Improve custom component manager interface

### DIFF
--- a/packages/ember-glimmer/lib/component-managers/curly.ts
+++ b/packages/ember-glimmer/lib/component-managers/curly.ts
@@ -65,6 +65,7 @@ import {
 import ComponentStateBucket, { Component } from '../utils/curly-component-state-bucket';
 import { processComponentArgs } from '../utils/process-args';
 import AbstractManager from './abstract';
+import CustomComponentManager, { CustomComponentState } from './custom';
 import DefinitionState from './definition-state';
 
 function aliasIdToElementId(args: Arguments, props: any) {
@@ -519,7 +520,7 @@ export class CurlyComponentDefinition implements ComponentDefinition {
   public symbolTable: ProgramSymbolTable | undefined;
 
   // tslint:disable-next-line:no-shadowed-variable
-  constructor(public name: string, public manager: ComponentManager<ComponentStateBucket, DefinitionState> = CURLY_COMPONENT_MANAGER, public ComponentClass: any, public handle: Option<VMHandle>, template: OwnedTemplate, args?: CurriedArgs) {
+  constructor(public name: string, public manager: ComponentManager<ComponentStateBucket, DefinitionState> | CustomComponentManager<CustomComponentState<any>> = CURLY_COMPONENT_MANAGER, public ComponentClass: any, public handle: Option<VMHandle>, template: OwnedTemplate, args?: CurriedArgs) {
     const layout = template && template.asLayout();
     const symbolTable = layout ? layout.symbolTable : undefined;
     this.symbolTable = symbolTable;

--- a/packages/ember-glimmer/lib/component-managers/custom.ts
+++ b/packages/ember-glimmer/lib/component-managers/custom.ts
@@ -81,6 +81,12 @@ export default class CustomComponentManager<T> extends AbstractComponentManager<
     this.delegate.update(component, args.value());
   }
 
+  didUpdate({ component }: CustomComponentState<T>) {
+    if (typeof this.delegate.didUpdate === 'function') {
+      this.delegate.didUpdate(component);
+    }
+  }
+
   getContext(component: T) {
     this.delegate.getContext(component);
   }
@@ -123,6 +129,9 @@ export default class CustomComponentManager<T> extends AbstractComponentManager<
   didRenderLayout({ component }: CustomComponentState<T>, _bounds: Bounds) {
     const renderer = getRenderer(component);
     renderer.register(component);
+    if (typeof this.delegate.didCreate === 'function') {
+      this.delegate.didCreate(component);
+    }
   }
 }
 

--- a/packages/ember-glimmer/lib/component-managers/custom.ts
+++ b/packages/ember-glimmer/lib/component-managers/custom.ts
@@ -129,7 +129,7 @@ export default class CustomComponentManager<T> extends AbstractComponentManager<
 /**
  * Stores internal state about a component instance after it's been created.
  */
-class CustomComponentState<T> {
+export class CustomComponentState<T> {
   constructor(
     public delegate: CustomComponentManagerDelegate<T>,
     public component: T,

--- a/packages/ember-glimmer/lib/resolver.ts
+++ b/packages/ember-glimmer/lib/resolver.ts
@@ -24,6 +24,7 @@ import {
 import { EMBER_MODULE_UNIFICATION, GLIMMER_CUSTOM_COMPONENT_MANAGER } from 'ember/features';
 import CompileTimeLookup from './compile-time-lookup';
 import { CurlyComponentDefinition } from './component-managers/curly';
+import CustomComponentManager, { CustomComponentState } from './component-managers/custom';
 import DefinitionState from './component-managers/definition-state';
 import { TemplateOnlyComponentDefinition } from './component-managers/template-only';
 import { isHelperFactory, isSimpleHelper } from './helper';
@@ -297,7 +298,7 @@ export default class RuntimeResolver implements IRuntimeResolver<OwnedTemplateMe
       return new TemplateOnlyComponentDefinition(layout);
     }
 
-    let manager: ComponentManager<ComponentStateBucket, DefinitionState> | undefined;
+    let manager: ComponentManager<ComponentStateBucket, DefinitionState> | CustomComponentManager<CustomComponentState<any>> | undefined;
 
     if (GLIMMER_CUSTOM_COMPONENT_MANAGER && component && component.class) {
       manager = getCustomComponentManager(meta.owner, component.class);

--- a/packages/ember-glimmer/lib/utils/custom-component-manager.ts
+++ b/packages/ember-glimmer/lib/utils/custom-component-manager.ts
@@ -1,10 +1,7 @@
-import { ComponentManager } from '@glimmer/runtime';
-
 import { assert } from 'ember-debug';
 import { Owner, symbol } from 'ember-utils';
 
-import DefinitionState from '../component-managers/definition-state';
-import ComponentStateBucket from '../utils/curly-component-state-bucket';
+import CustomComponentManager, { CustomComponentState } from '../component-managers/custom';
 
 import { GLIMMER_CUSTOM_COMPONENT_MANAGER } from 'ember/features';
 
@@ -21,7 +18,7 @@ export function componentManager(obj: any, managerId: String) {
   return obj;
 }
 
-export default function getCustomComponentManager(owner: Owner, obj: {}): ComponentManager<ComponentStateBucket, DefinitionState> | undefined {
+export default function getCustomComponentManager(owner: Owner, obj: {}): CustomComponentManager<CustomComponentState<any>> | undefined {
   if (!GLIMMER_CUSTOM_COMPONENT_MANAGER) { return; }
 
   if (!obj) { return; }
@@ -29,7 +26,7 @@ export default function getCustomComponentManager(owner: Owner, obj: {}): Compon
   let managerId = obj[COMPONENT_MANAGER];
   if (!managerId) { return; }
 
-  let manager = owner.lookup(`component-manager:${managerId}`) as ComponentManager<ComponentStateBucket, DefinitionState>;
+  let manager = new CustomComponentManager(owner.lookup(`component-manager:${managerId}`)) as CustomComponentManager<CustomComponentState<any>>;
   assert(`Could not find custom component manager '${managerId}' for ${obj}`, !!manager);
 
   return manager;

--- a/packages/ember-glimmer/tests/integration/custom-component-manager-test.js
+++ b/packages/ember-glimmer/tests/integration/custom-component-manager-test.js
@@ -5,7 +5,7 @@ import { Component } from '../utils/helpers';
 import { Object as EmberObject } from 'ember-runtime';
 import { set, setProperties, computed } from 'ember-metal';
 import { GLIMMER_CUSTOM_COMPONENT_MANAGER } from 'ember/features';
-import { componentManager, CustomComponentManager } from 'ember-glimmer';
+import { componentManager } from 'ember-glimmer';
 import { getChildViews } from 'ember-views';
 import { assign } from 'ember-utils';
 
@@ -35,9 +35,7 @@ if (GLIMMER_CUSTOM_COMPONENT_MANAGER) {
         }
       }, overrides);
 
-      let manager = new CustomComponentManager(options);
-
-      this.owner.register(`component-manager:${MANAGER_ID}`, manager, { singleton: true, instantiate: false });
+      this.owner.register(`component-manager:${MANAGER_ID}`, options, { singleton: true, instantiate: false });
     }
 
     // Renders a simple component with a custom component manager and verifies


### PR DESCRIPTION
The thing that is registered is the delegate, not the custom component
manager itself, which obviates the need to export
`CustomComponentManager`. Other changes are to satisfy TypeScript.