### PR TITLE
Changing bitwise evaluation to use more idiomatic pattern

### DIFF
--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -128,7 +128,7 @@ export class Meta {
   }
 
   isSourceDestroying() {
-    return (this._flags & SOURCE_DESTROYING) !== 0;
+    return this._hasFlag(SOURCE_DESTROYING);
   }
 
   setSourceDestroying() {
@@ -136,7 +136,7 @@ export class Meta {
   }
 
   isSourceDestroyed() {
-    return (this._flags & SOURCE_DESTROYED) !== 0;
+    return this._hasFlag(SOURCE_DESTROYED);
   }
 
   setSourceDestroyed() {
@@ -144,11 +144,15 @@ export class Meta {
   }
 
   isMetaDestroyed() {
-    return (this._flags & META_DESTROYED) !== 0;
+    return this._hasFlag(META_DESTROYED);
   }
 
   setMetaDestroyed() {
     this._flags |= META_DESTROYED;
+  }
+
+  _hasFlag(flag) {
+    return (this._flags & flag) === flag;
   }
 
   _getOrCreateOwnMap(key) {


### PR DESCRIPTION
While building out the latest version of ember-lifeline, I was testing/evaluating behavior around object destruction. As part of this, I came across the following pattern:

```js
  isSourceDestroying() {
    return (this._flags & SOURCE_DESTROYING) !== 0;
  }
```

In other languages (C#, for example), determining if an enumeration value is included in set of flags has a fairly idiomatic pattern.

```
(flags & flag) === flag
```

This PR aims to move these evaluations to a more idiomatic structure. It inverts the determination of whether the flag is included in the set of flags, rather than excluding. Additionally, it adds a method to help hint at what that code is doing, making it slightly more readable.