### PR TITLE
[WIP] Export `RouterService` class

### DIFF
--- a/packages/ember/lib/index.js
+++ b/packages/ember/lib/index.js
@@ -528,6 +528,7 @@ Ember.generateControllerFactory = routing.generateControllerFactory;
 Ember.generateController = routing.generateController;
 Ember.RouterDSL = routing.RouterDSL;
 Ember.Router = routing.Router;
+Ember.RouterService = routing.RouterService;
 Ember.Route = routing.Route;
 
 import * as application from 'ember-application';

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -181,6 +181,7 @@ let allExports =[
   ['generateController', 'ember-routing'],
   ['RouterDSL', 'ember-routing'],
   ['Router', 'ember-routing'],
+  ['RouterService', 'ember-routing'],
   ['Route', 'ember-routing'],
 
   // ember-application


### PR DESCRIPTION
This adds a public export of the `RouterService` class so that people are able to subclass it in their apps if needed.

I suppose this would also need to be added to the rfc176 repo. My suggestion would be `import RouterService from '@ember/routing/service';` or something like that.

/cc @rwjblue 