### PR TITLE
Revert "Update to backburner.js@2.2.1."

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-plugin-transform-proto-to-assign": "^6.26.0",
     "babel-template": "^6.26.0",
-    "backburner.js": "^2.2.1",
+    "backburner.js": "2.1.0",
     "broccoli-babel-transpiler": "^6.1.2",
     "broccoli-concat": "^3.2.2",
     "broccoli-debug": "^0.6.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,102 +2,102 @@
 # yarn lockfile v1
 
 
-"@glimmer/compiler@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.33.0.tgz#949a37a53df490b5e842422b220032af79ae6f90"
+"@glimmer/compiler@^0.32.3":
+  version "0.32.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.32.3.tgz#fc15780ec38aa62b60da600618ca1f43da6b979c"
   dependencies:
-    "@glimmer/interfaces" "^0.33.0"
-    "@glimmer/syntax" "^0.33.0"
-    "@glimmer/util" "^0.33.0"
-    "@glimmer/wire-format" "^0.33.0"
+    "@glimmer/interfaces" "^0.32.3"
+    "@glimmer/syntax" "^0.32.3"
+    "@glimmer/util" "^0.32.3"
+    "@glimmer/wire-format" "^0.32.3"
     simple-html-tokenizer "^0.4.1"
 
-"@glimmer/encoder@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/encoder/-/encoder-0.33.0.tgz#102f48acd2893fa3e775d5fe0ae0e962d07ac1c0"
+"@glimmer/encoder@^0.32.3":
+  version "0.32.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/encoder/-/encoder-0.32.3.tgz#c5964802f85d6721556b1d1a199a0ac478b03d7a"
 
-"@glimmer/interfaces@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.33.0.tgz#bbf58422e15d6a1f11d917516ba92a0e5185711d"
+"@glimmer/interfaces@^0.32.3":
+  version "0.32.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.32.3.tgz#a328344d88490c1ae765ebe18ee357ed9a66f0fb"
   dependencies:
-    "@glimmer/wire-format" "^0.33.0"
+    "@glimmer/wire-format" "^0.32.3"
 
-"@glimmer/low-level@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/low-level/-/low-level-0.33.0.tgz#2ff459e45edf27a36b6ee06b7748305e431e50f6"
+"@glimmer/low-level@^0.32.3":
+  version "0.32.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/low-level/-/low-level-0.32.3.tgz#c393a66989d1eb134cda833b898784e41cadc70c"
 
-"@glimmer/node@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/node/-/node-0.33.0.tgz#388423f053de5c22550e73631813b25e7cd2ee41"
+"@glimmer/node@^0.32.3":
+  version "0.32.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/node/-/node-0.32.3.tgz#69673cb57f7921a39f598ebdac25f45e6452b45d"
   dependencies:
-    "@glimmer/interfaces" "^0.33.0"
-    "@glimmer/runtime" "^0.33.0"
+    "@glimmer/interfaces" "^0.32.3"
+    "@glimmer/runtime" "^0.32.3"
     simple-dom "^0.3.0"
 
-"@glimmer/opcode-compiler@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/opcode-compiler/-/opcode-compiler-0.33.0.tgz#81caa48f7ddc7ecaef581669c408ef3283f8cd11"
+"@glimmer/opcode-compiler@^0.32.3":
+  version "0.32.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/opcode-compiler/-/opcode-compiler-0.32.3.tgz#b5a4c2abc415707e228154d694e67a1f5ae5a700"
   dependencies:
-    "@glimmer/encoder" "^0.33.0"
-    "@glimmer/interfaces" "^0.33.0"
-    "@glimmer/program" "^0.33.0"
-    "@glimmer/reference" "^0.33.0"
-    "@glimmer/util" "^0.33.0"
-    "@glimmer/vm" "^0.33.0"
-    "@glimmer/wire-format" "^0.33.0"
+    "@glimmer/encoder" "^0.32.3"
+    "@glimmer/interfaces" "^0.32.3"
+    "@glimmer/program" "^0.32.3"
+    "@glimmer/reference" "^0.32.3"
+    "@glimmer/util" "^0.32.3"
+    "@glimmer/vm" "^0.32.3"
+    "@glimmer/wire-format" "^0.32.3"
 
-"@glimmer/program@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/program/-/program-0.33.0.tgz#8795a7b5017f211f70b4fc40bbe1573ad03931d9"
+"@glimmer/program@^0.32.3":
+  version "0.32.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/program/-/program-0.32.3.tgz#8fd0d7fa80ccb6df73f52e14474bde9db55ed3b9"
   dependencies:
-    "@glimmer/encoder" "^0.33.0"
-    "@glimmer/interfaces" "^0.33.0"
-    "@glimmer/util" "^0.33.0"
+    "@glimmer/encoder" "^0.32.3"
+    "@glimmer/interfaces" "^0.32.3"
+    "@glimmer/util" "^0.32.3"
 
-"@glimmer/reference@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.33.0.tgz#63501d9cca727a3b58eda56a759d0698383a9ddf"
+"@glimmer/reference@^0.32.3":
+  version "0.32.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.32.3.tgz#86b49109428e4c6a85caa841d22551f59664929a"
   dependencies:
-    "@glimmer/util" "^0.33.0"
+    "@glimmer/util" "^0.32.3"
 
-"@glimmer/runtime@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/runtime/-/runtime-0.33.0.tgz#2c3eb3874233d8c5c2351d8f5ab4312d0ab106d9"
+"@glimmer/runtime@^0.32.3":
+  version "0.32.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/runtime/-/runtime-0.32.3.tgz#f7ba4808646d472efb81c8983c43bcd7b70a4acf"
   dependencies:
-    "@glimmer/interfaces" "^0.33.0"
-    "@glimmer/low-level" "^0.33.0"
-    "@glimmer/program" "^0.33.0"
-    "@glimmer/reference" "^0.33.0"
-    "@glimmer/util" "^0.33.0"
-    "@glimmer/vm" "^0.33.0"
-    "@glimmer/wire-format" "^0.33.0"
+    "@glimmer/interfaces" "^0.32.3"
+    "@glimmer/low-level" "^0.32.3"
+    "@glimmer/program" "^0.32.3"
+    "@glimmer/reference" "^0.32.3"
+    "@glimmer/util" "^0.32.3"
+    "@glimmer/vm" "^0.32.3"
+    "@glimmer/wire-format" "^0.32.3"
 
-"@glimmer/syntax@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.33.0.tgz#5def8048e282f2ad7d77cdfa8859b2f292cdb697"
+"@glimmer/syntax@^0.32.3":
+  version "0.32.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.32.3.tgz#f6b035948013728e646731d774ccd8c49f7d10d1"
   dependencies:
-    "@glimmer/interfaces" "^0.33.0"
-    "@glimmer/util" "^0.33.0"
+    "@glimmer/interfaces" "^0.32.3"
+    "@glimmer/util" "^0.32.3"
     handlebars "^4.0.6"
     simple-html-tokenizer "^0.4.1"
 
-"@glimmer/util@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.33.0.tgz#8271fbcb59989f8475c316887d49b622b84a2dfa"
+"@glimmer/util@^0.32.3":
+  version "0.32.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.32.3.tgz#b73ccc1b73097ba6ec1e250954a1a2e1eb83eb48"
 
-"@glimmer/vm@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/vm/-/vm-0.33.0.tgz#a15a47109970baaeff74463c2ea3fe5a3e4f3f56"
+"@glimmer/vm@^0.32.3":
+  version "0.32.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/vm/-/vm-0.32.3.tgz#9686a823d5f4238ddce7ff0290a8f5fe3d3f1c65"
   dependencies:
-    "@glimmer/interfaces" "^0.33.0"
-    "@glimmer/program" "^0.33.0"
-    "@glimmer/util" "^0.33.0"
+    "@glimmer/interfaces" "^0.32.3"
+    "@glimmer/program" "^0.32.3"
+    "@glimmer/util" "^0.32.3"
 
-"@glimmer/wire-format@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.33.0.tgz#e3e42ec205a5bf7fd9349b79da4632df999dbe45"
+"@glimmer/wire-format@^0.32.3":
+  version "0.32.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.32.3.tgz#2f684a6d88ba7162d32cd5f01bd0b83151cdb73d"
   dependencies:
-    "@glimmer/util" "^0.33.0"
+    "@glimmer/util" "^0.32.3"
 
 "@types/acorn@*":
   version "4.0.3"
@@ -988,9 +988,9 @@ backbone@^1.1.2:
   dependencies:
     underscore ">=1.8.3"
 
-backburner.js@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-2.2.1.tgz#ceb0a1e77435dfb73d153fb0652b01ecb1217e8e"
+backburner.js@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-2.1.0.tgz#2dd3b0f5043fc495b91407cf9f27d976e86159d5"
 
 backo2@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Reverts emberjs/ember.js#16348

The whole timing bug isn't really fixed. I have the same kind of failures happening in https://travis-ci.org/ember-animation/ember-animated/builds/354470507