### PR TITLE
Upgrade backburner.js to 2.2.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-plugin-transform-proto-to-assign": "^6.26.0",
     "babel-template": "^6.26.0",
-    "backburner.js": "2.1.0",
+    "backburner.js": "^2.2.2",
     "broccoli-babel-transpiler": "^6.1.2",
     "broccoli-concat": "^3.2.2",
     "broccoli-debug": "^0.6.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -988,9 +988,9 @@ backbone@^1.1.2:
   dependencies:
     underscore ">=1.8.3"
 
-backburner.js@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-2.1.0.tgz#2dd3b0f5043fc495b91407cf9f27d976e86159d5"
+backburner.js@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-2.2.2.tgz#c7215cafdd81004fcb3d950e2d80517ff8196248"
 
 backo2@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Upstream issue causing revert of 2.2.0 and 2.2.1 has been addressed,
this updates to the fixed version 2.2.2.

Once landed, further testing can be done..