### PR TITLE
[CLEANUP beta] #16391 Cleaning up the test output

### DIFF
--- a/packages/ember-metal/tests/libraries_test.js
+++ b/packages/ember-metal/tests/libraries_test.js
@@ -6,6 +6,7 @@ import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 let libs, registry;
 let originalWarn = getDebugFunction('warn');
+function noop() {}
 
 moduleFor('Libraries registry', class extends AbstractTestCase {
   beforeEach() {
@@ -33,6 +34,8 @@ moduleFor('Libraries registry', class extends AbstractTestCase {
   ['@test only the first registration of a library is stored'](assert) {
     assert.expect(3);
 
+    // overwrite warn to supress the double registration warning (see https://github.com/emberjs/ember.js/issues/16391)
+    setDebugFunction('warn', noop);
     libs.register('magic', 1.23);
     libs.register('magic', 2.23);
 

--- a/packages/ember-testing/lib/helpers/pause_test.js
+++ b/packages/ember-testing/lib/helpers/pause_test.js
@@ -2,7 +2,7 @@
 @module ember
 */
 import { RSVP } from 'ember-runtime';
-import { assert } from 'ember-debug';
+import { assert, info } from 'ember-debug';
 
 let resume;
 
@@ -57,8 +57,7 @@ export function resumeTest() {
  @public
 */
 export function pauseTest() {
-  // eslint-disable-next-line no-console
-  console.info('Testing paused. Use `resumeTest()` to continue.');
+  info('Testing paused. Use `resumeTest()` to continue.');
 
   return new RSVP.Promise((resolve) => {
     resume = resolve;

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -32,6 +32,10 @@ import {
   registerWaiter,
   unregisterWaiter
 } from '../test/waiters';
+import { getDebugFunction, setDebugFunction } from 'ember-debug';
+
+var originalInfo = getDebugFunction('info');
+var noop = function(){};
 
 function registerHelper() {
   Test.registerHelper('LeakyMcLeakLeak', () => {});
@@ -889,7 +893,10 @@ if (!jQueryDisabled) {
   });
 
   moduleFor('ember-testing: debugging helpers', class extends HelpersApplicationTestCase {
-
+    afterEach() {
+      setDebugFunction('info', originalInfo);
+    }
+  
     constructor() {
       super();
       this.runTask(() => {
@@ -899,6 +906,8 @@ if (!jQueryDisabled) {
 
     [`@test pauseTest pauses`](assert) {
       assert.expect(1);
+      // overwrite info to supress the console output (see https://github.com/emberjs/ember.js/issues/16391)
+      setDebugFunction('info', noop);
 
       let {application: {testHelpers: {andThen, pauseTest}}} = this;
       andThen(() => {
@@ -915,6 +924,8 @@ if (!jQueryDisabled) {
 
     [`@test resumeTest resumes paused tests`](assert) {
       assert.expect(1);
+      // overwrite info to supress the console output (see https://github.com/emberjs/ember.js/issues/16391)
+      setDebugFunction('info', noop);
 
       let {application: {testHelpers: {pauseTest, resumeTest}}} = this;
 


### PR DESCRIPTION
This resolves some Quest Tasks of Issue #16391:

```
Testing paused. Use resumeTest() to continue.
```
--> I switched the `console.info` with a call to `ember-debug.info` and then used the `setDebugFunction`-helper to set it to a NOOP and reset its behavior after each test accordingly.


```
WARNING: Library "magic" is already registered with Ember.
```
--> I overwrote the debug function "warn", so that the test case could register the same lib a second time without throwing an error.