### PR TITLE
[CLEANUP beta] #16391 Cleaning up the test output

### DIFF
--- a/packages/ember-application/tests/system/application_instance_test.js
+++ b/packages/ember-application/tests/system/application_instance_test.js
@@ -9,11 +9,16 @@ import {
   moduleFor,
   AbstractTestCase as TestCase
 } from 'internal-test-helpers';
+import { getDebugFunction, setDebugFunction } from 'ember-debug';
+
+const originalDebug = getDebugFunction('debug');
+const noop = function(){};
 
 let application, appInstance;
 
 moduleFor('ApplicationInstance', class extends TestCase {
   constructor() {
+    setDebugFunction('debug', noop);
     super();
 
     document.getElementById('qunit-fixture').innerHTML = `
@@ -23,6 +28,7 @@ moduleFor('ApplicationInstance', class extends TestCase {
   }
 
   teardown() {
+    setDebugFunction('debug', originalDebug);
     if (appInstance) {
       run(appInstance, 'destroy');
     }

--- a/packages/ember-extension-support/tests/container_debug_adapter_test.js
+++ b/packages/ember-extension-support/tests/container_debug_adapter_test.js
@@ -3,11 +3,15 @@ import { assign } from 'ember-utils';
 import { run } from 'ember-metal';
 import { Controller as EmberController } from 'ember-runtime';
 import '../index'; // Must be required to export Ember.ContainerDebugAdapter.
+import { getDebugFunction, setDebugFunction } from 'ember-debug';
 
+const originalDebug = getDebugFunction('debug');
+const noop = function(){};
 let adapter;
 
 moduleFor('Container Debug Adapter', class extends ApplicationTestCase {
   constructor() {
+    setDebugFunction('debug', noop);
     super();
     adapter = this.application.__deprecatedInstance__.lookup('container-debug-adapter:main');
   }
@@ -19,6 +23,7 @@ moduleFor('Container Debug Adapter', class extends ApplicationTestCase {
   }
 
   teardown() {
+    setDebugFunction('debug', originalDebug);
     run(() => {
       adapter.destroy();
     });

--- a/packages/ember-glimmer/tests/integration/application/actions-test.js
+++ b/packages/ember-glimmer/tests/integration/application/actions-test.js
@@ -1,8 +1,21 @@
 import { Controller } from 'ember-runtime';
 import { moduleFor, ApplicationTest, RenderingTest } from '../../utils/test-case';
 import { Component } from '../../utils/helpers';
+import { getDebugFunction, setDebugFunction } from 'ember-debug';
+
+const originalDebug = getDebugFunction('debug');
+const noop = function(){};
 
 moduleFor('Application test: actions', class extends ApplicationTest {
+  constructor() {
+    setDebugFunction('debug', noop);
+    super();
+  }
+
+  teardown() {
+    setDebugFunction('debug', originalDebug);
+  }
+
   ['@test actions in top level template application template target application controller'](assert) {
     assert.expect(1);
 

--- a/packages/ember-routing/tests/system/controller_for_test.js
+++ b/packages/ember-routing/tests/system/controller_for_test.js
@@ -4,8 +4,21 @@ import {
 import controllerFor from '../../system/controller_for';
 import generateController from '../../system/generate_controller';
 import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
+import { getDebugFunction, setDebugFunction } from 'ember-debug';
+
+const originalDebug = getDebugFunction('debug');
+const noop = function(){};
 
 moduleFor('controllerFor', class extends ApplicationTestCase {
+  constructor() {
+    setDebugFunction('debug', noop);
+    super();
+  }
+
+  teardown() {
+    setDebugFunction('debug', originalDebug);
+  }
+
   ['@test controllerFor should lookup for registered controllers'](assert) {
     this.add('controller:app', Controller.extend());
 
@@ -19,6 +32,15 @@ moduleFor('controllerFor', class extends ApplicationTestCase {
 });
 
 moduleFor('generateController', class extends ApplicationTestCase {
+  constructor() {
+    setDebugFunction('debug', noop);
+    super();
+  }
+
+  teardown() {
+    setDebugFunction('debug', originalDebug);
+  }
+
   ['@test generateController should return Controller'](assert) {
     return this.visit('/').then(() => {
       let controller = generateController(this.applicationInstance, 'home');

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -9,10 +9,15 @@ import QUnitAdapter from '../adapters/qunit';
 import { Route } from 'ember-routing';
 import { RSVP } from 'ember-runtime';
 import { jQueryDisabled } from 'ember-views';
+import { getDebugFunction, setDebugFunction } from 'ember-debug';
+
+const originalDebug = getDebugFunction('debug');
+const noop = function(){};
 
 if (!jQueryDisabled) {
   moduleFor('ember-testing Acceptance', class extends AutobootApplicationTestCase {
     constructor() {
+      setDebugFunction('debug', noop);
       super();
       this._originalAdapter = Test.adapter;
 
@@ -85,6 +90,7 @@ if (!jQueryDisabled) {
     }
 
     teardown() {
+      setDebugFunction('debug', originalDebug);
       Test.adapter = this._originalAdapter;
       super.teardown();
     }

--- a/packages/ember-testing/tests/adapters_test.js
+++ b/packages/ember-testing/tests/adapters_test.js
@@ -5,6 +5,10 @@ import QUnitAdapter from '../adapters/qunit';
 import { Application as EmberApplication } from 'ember-application';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 import { RSVP } from 'ember-runtime';
+import { getDebugFunction, setDebugFunction } from 'ember-debug';
+
+const originalDebug = getDebugFunction('debug');
+const noop = function(){};
 
 var App, originalAdapter, originalQUnit, originalWindowOnerror;
 
@@ -22,6 +26,7 @@ function runThatThrowsAsync(message = 'Error for testing error handling') {
 
 class AdapterSetupAndTearDown extends AbstractTestCase {
   constructor() {
+    setDebugFunction('debug', noop);
     super();
     originalAdapter = Test.adapter;
     originalQUnit = window.QUnit;
@@ -29,6 +34,7 @@ class AdapterSetupAndTearDown extends AbstractTestCase {
   }
 
   teardown() {
+    setDebugFunction('debug', originalDebug);
     if (App) {
       run(App, App.destroy);
       App.removeTestHelpers();

--- a/packages/ember/tests/application_lifecycle_test.js
+++ b/packages/ember/tests/application_lifecycle_test.js
@@ -7,6 +7,10 @@ import { Route, Router } from 'ember-routing';
 import {
   Component,
 } from 'ember-glimmer';
+import { getDebugFunction, setDebugFunction } from 'ember-debug';
+
+const originalDebug = getDebugFunction('debug');
+const noop = function(){};
 
 moduleFor('Application Lifecycle - route hooks', class extends AutobootApplicationTestCase {
 
@@ -19,6 +23,7 @@ moduleFor('Application Lifecycle - route hooks', class extends AutobootApplicati
   }
 
   constructor() {
+    setDebugFunction('debug', noop);
     super();
     let menuItem = this.menuItem = {};
 
@@ -36,6 +41,10 @@ moduleFor('Application Lifecycle - route hooks', class extends AutobootApplicati
       this.add('route:index', SettingRoute);
       this.add('route:application', SettingRoute);
     });
+  }
+
+  teardown() {
+    setDebugFunction('debug', originalDebug);
   }
 
   get indexController() {


### PR DESCRIPTION
This PR solves the task: `the library version banner on app boot` from #16391

I have overwritten the debug function in certain test suites with a NOOP to supress the console output. But (!) I didn't do that for all tests, only for those that will be traversed in a full test run (and in that order). If a certain testsuite would be `skip`ped, the following test suite would still print the banner.
I would update the PR if this behavior was not intended. :)