### PR TITLE
[CLEANUP beta] #16391 Cleaning up the test output

### DIFF
--- a/packages/ember-debug/tests/main_test.js
+++ b/packages/ember-debug/tests/main_test.js
@@ -30,6 +30,8 @@ let originalDeprecateHandler;
 let originalWarnHandler;
 let originalWarnOptions;
 let originalDeprecationOptions;
+const originalConsoleWarn = console.warn; // eslint-disable-line no-console
+const noop = function(){};
 
 moduleFor('ember-debug', class extends TestCase {
 
@@ -55,8 +57,13 @@ moduleFor('ember-debug', class extends TestCase {
     ENV._ENABLE_DEPRECATION_OPTIONS_SUPPORT = originalDeprecationOptions;
   }
 
+  afterEach() {
+    console.warn = originalConsoleWarn; // eslint-disable-line no-console
+  }
+
   ['@test deprecate does not throw if RAISE_ON_DEPRECATION is false'](assert) {
     assert.expect(1);
+    console.warn = noop; // eslint-disable-line no-console
 
     ENV.RAISE_ON_DEPRECATION = false;
 
@@ -70,6 +77,7 @@ moduleFor('ember-debug', class extends TestCase {
 
   ['@test deprecate resets deprecation level to RAISE if ENV.RAISE_ON_DEPRECATION is set'](assert) {
     assert.expect(2);
+    console.warn = noop; // eslint-disable-line no-console
 
     ENV.RAISE_ON_DEPRECATION = false;
 


### PR DESCRIPTION
This PR solves the task: `DEPRECATION: Should not throw [deprecation id: test]` from #16391

I have overwritten the console.warn function with a NOOP on two tests to supress the console output and reverted that change after each test. I would have preferred to use ember-debug.warn in the deprecate function, but I'm a bit unsure if the es2015 modules would be compiled to other formats (cjs, umd, etc.) and maybe cause circular dependencies, since the deprecate function (which uses console.warn) is being imported into the index file which sets up the `setDebugFunction` and `getDebugFunction` helpers.