### PR TITLE
use `Map` as default store and avoid using `UNDEFINED`

### DIFF
--- a/packages/ember-metal/lib/cache.js
+++ b/packages/ember-metal/lib/cache.js
@@ -1,30 +1,24 @@
-import { UNDEFINED } from './meta';
 
 export default class Cache {
-  constructor(limit, func, key, store) {
-    this.size = 0;
+  constructor(limit, func, key) {
     this.misses = 0;
     this.hits = 0;
     this.limit = limit;
     this.func = func;
     this.key = key;
-    this.store = store || new Map();
+    this.store = new Map();
   }
 
   get(obj) {
     let key = this.key === undefined ? obj : this.key(obj);
     let value = this.store.get(key);
-    if (value === undefined) {
+    if (this.store.has(key)) {
+      this.hits++;
+      value = this.store.get(key);
+    } else {
       this.misses++;
       value = this._set(key, this.func(obj));
-    } else if (value === UNDEFINED) {
-      this.hits++;
-      value = undefined;
-    } else {
-      this.hits++;
-      // nothing to translate
     }
-
     return value;
   }
 
@@ -34,21 +28,19 @@ export default class Cache {
   }
 
   _set(key, value) {
-    if (this.limit > this.size) {
-      this.size++;
-      if (value === undefined) {
-        this.store.set(key, UNDEFINED);
-      } else {
-        this.store.set(key, value);
-      }
+    if (this.limit > this.store.size) {
+      this.store.set(key, value);
     }
 
     return value;
   }
 
+  get size() {
+    return this.store.size;
+  }
+
   purge() {
     this.store.clear();
-    this.size = 0;
     this.hits = 0;
     this.misses = 0;
   }


### PR DESCRIPTION
using `Map` as default store will simplify things and avoids using `UNDEFINED` constant 