### PR TITLE
remove support for `didRemoveListener` and `didAddListener`

### DIFF
--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -60,10 +60,6 @@ export function addListener(obj, eventName, target, method, once) {
   }
 
   metaFor(obj).addToListeners(eventName, target, method, once);
-
-  if ('function' === typeof obj.didAddListener) {
-    obj.didAddListener(eventName, target, method);
-  }
 }
 
 /**
@@ -88,9 +84,7 @@ export function removeListener(obj, eventName, target, method) {
     target = null;
   }
 
-  let func = ('function' === typeof obj.didRemoveListener) ?
-    obj.didRemoveListener.bind(obj) : ()=> {};
-  metaFor(obj).removeFromListeners(eventName, target, method, func);
+  metaFor(obj).removeFromListeners(eventName, target, method);
 }
 
 /**

--- a/packages/ember-metal/lib/meta_listeners.js
+++ b/packages/ember-metal/lib/meta_listeners.js
@@ -32,7 +32,7 @@ export const protoMethods = {
     this._listenersFinalized = true;
   },
 
-  removeFromListeners(eventName, target, method, didRemove) {
+  removeFromListeners(eventName, target, method) {
     let pointer = this;
     while (pointer !== undefined) {
       let listeners = pointer._listeners;
@@ -40,11 +40,7 @@ export const protoMethods = {
         for (let index = listeners.length - 4; index >= 0; index -= 4) {
           if (listeners[index] === eventName && (!method || (listeners[index + 1] === target && listeners[index + 2] === method))) {
             if (pointer === this) {
-              // we are modifying our own list, so we edit directly
-              if (typeof didRemove === 'function') {
-                didRemove(eventName, target, listeners[index + 2]);
-              }
-              listeners.splice(index, 4);
+              listeners.splice(index, 4); // we are modifying our own list, so we edit directly
             } else {
               // we are trying to remove an inherited listener, so we do
               // just-in-time copying to detach our own listeners from

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -91,8 +91,6 @@ function makeCtor() {
               property === 'didDefineProperty' ||
               property === 'willWatchProperty' ||
               property === 'didUnwatchProperty' ||
-              property === 'didAddListener' ||
-              property === 'didRemoveListener' ||
               property === '__DESCRIPTOR__' ||
               property === 'isDescriptor' ||
               property in target


### PR DESCRIPTION
was used in `EachProxy` before https://github.com/emberjs/ember.js/blob/90397ef15453da1cba1f6bda374e075f054bfdf4/packages/ember-runtime/lib/system/each_proxy.js#L194
now `EachProxy` doesn't use it 
no usage in wild https://emberobserver.com/code-search?codeQuery=didRemoveListener&sort=usages&sortAscending=false

cc @mmun 