### PR TITLE
[CLEANUP beta]  #16391 Cleaning up the test output

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/attrs-lookup-test.js
+++ b/packages/ember-glimmer/tests/integration/components/attrs-lookup-test.js
@@ -1,5 +1,5 @@
 import { RenderingTest, moduleFor } from '../../utils/test-case';
-import { Component } from '../../utils/helpers';
+import { Component, htmlSafe } from '../../utils/helpers';
 import { set, computed } from 'ember-metal';
 import { styles } from '../../utils/test-helpers';
 
@@ -213,7 +213,7 @@ moduleFor('Components test: attrs lookup', class extends RenderingTest {
       style: computed('height', 'color', function() {
         let height = this.get('height');
         let color = this.get('color');
-        return `height: ${height}px; background-color: ${color};`;
+        return htmlSafe(`height: ${height}px; background-color: ${color};`);
       }),
       color: 'red',
       height: 20

--- a/packages/ember-glimmer/tests/integration/content-test.js
+++ b/packages/ember-glimmer/tests/integration/content-test.js
@@ -12,7 +12,7 @@ import {
 import { Object as EmberObject, ObjectProxy } from 'ember-runtime';
 import { classes } from '../utils/test-helpers';
 import { constructStyleDeprecationMessage  } from 'ember-views';
-import { Component, SafeString } from '../utils/helpers';
+import { Component, SafeString, htmlSafe } from '../utils/helpers';
 
 moduleFor('Static content tests', class extends RenderingTest {
 
@@ -1199,7 +1199,7 @@ moduleFor('Inline style tests', class extends StyleTest {
   ['@test can set dynamic style']() {
     this.render('<div style={{model.style}}></div>', {
       model: {
-        style: 'width: 60px;'
+        style: htmlSafe('width: 60px;')
       }
     });
 
@@ -1225,7 +1225,7 @@ moduleFor('Inline style tests', class extends StyleTest {
   ['@test can set dynamic style with -html-safe']() {
     this.render('<div style={{-html-safe model.style}}></div>', {
       model: {
-        style: 'width: 60px;'
+        style: htmlSafe('width: 60px;')
       }
     });
 

--- a/packages/ember-glimmer/tests/integration/helpers/mut-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/mut-test.js
@@ -1,5 +1,5 @@
 import { RenderingTest, moduleFor } from '../../utils/test-case';
-import { Component } from '../../utils/helpers';
+import { Component, htmlSafe } from '../../utils/helpers';
 import { set, get, computed } from 'ember-metal';
 import { styles } from '../../utils/test-helpers';
 
@@ -436,7 +436,7 @@ moduleFor('Mutable Bindings used in Computed Properties that are bound as attrib
         },
         style: computed('height', function() {
           let height = this.get('height');
-          return `height: ${height}px;`;
+          return htmlSafe(`height: ${height}px;`);
         }),
         height: 20
       }),
@@ -489,7 +489,7 @@ moduleFor('Mutable Bindings used in Computed Properties that are bound as attrib
         style: computed('height', 'width', function() {
           let height = this.get('height');
           let width = this.get('width');
-          return `height: ${height}px; width: ${width}px;`;
+          return htmlSafe(`height: ${height}px; width: ${width}px;`);
         }),
         height: 20,
         width: computed('height', {


### PR DESCRIPTION
This PR remove all deprecation warnings (`Binding style attributes`) from the test output.
I've simply use the `htmlSafe` function to remove the warning