### PR TITLE
Begin working on emitting loose ES<latest> modules.

### DIFF
--- a/broccoli/packages.js
+++ b/broccoli/packages.js
@@ -338,6 +338,17 @@ module.exports.emberVersionES = function _emberVersionES() {
   });
 };
 
+module.exports.buildEmberEnvFlagsES = function(flags) {
+  let content = '';
+  for (let key in flags) {
+    content += `\nexport const ${key} = ${flags[key]};`;
+  }
+
+  return new WriteFile('ember-env-flags.js', content, {
+    annotation: 'ember-env-flags'
+  });
+};
+
 module.exports.emberLicense = function _emberLicense() {
   let license = new Funnel('generators', {
     files: ['license.js'],

--- a/broccoli/to-named-amd.js
+++ b/broccoli/to-named-amd.js
@@ -1,10 +1,14 @@
 const Babel = require('broccoli-babel-transpiler');
 const resolveModuleSource = require('amd-name-resolver').moduleResolve;
 const enifed = require('./transforms/transform-define');
+const injectNodeGlobals = require('./transforms/inject-node-globals');
 
 module.exports = function processModulesOnly(tree, annotation) {
   let options = {
     plugins: [
+      // ensures `@glimmer/compiler` requiring `crypto` works properly
+      // in both browser and node-land
+      injectNodeGlobals,
       ['transform-es2015-modules-amd', { loose: true, noInterop: true }],
       enifed,
     ],

--- a/broccoli/to-named-amd.js
+++ b/broccoli/to-named-amd.js
@@ -1,0 +1,17 @@
+const Babel = require('broccoli-babel-transpiler');
+const resolveModuleSource = require('amd-name-resolver').moduleResolve;
+const enifed = require('./transforms/transform-define');
+
+module.exports = function processModulesOnly(tree, annotation) {
+  let options = {
+    plugins: [
+      ['transform-es2015-modules-amd', { loose: true, noInterop: true }],
+      enifed,
+    ],
+    moduleIds: true,
+    resolveModuleSource,
+    annotation,
+  };
+
+  return new Babel(tree, options);
+};

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,7 @@ const MergeTrees = require('broccoli-merge-trees');
 const Funnel = require('broccoli-funnel');
 const babelHelpers = require('./broccoli/babel-helpers');
 const bootstrapModule = require('./broccoli/bootstrap-modules');
-const concat = require('./broccoli/concat-bundle');
+const concatBundle = require('./broccoli/concat-bundle');
 const testIndexHTML = require('./broccoli/test-index-html');
 const toES5 = require('./broccoli/to-es5');
 const stripForProd = toES5.stripForProd;
@@ -133,7 +133,7 @@ module.exports = function() {
     bootstrapModule('ember')
   ];
 
-  emberTestsBundle = concat(emberTestsBundle, {
+  emberTestsBundle = concatBundle(emberTestsBundle, {
     outputFile: 'ember-tests.js',
     hasBootstrap: false
   });
@@ -147,7 +147,7 @@ module.exports = function() {
     emberTemplateCompilerES5
   ]);
 
-  emberDebugBundle = concat(emberDebugBundle, {
+  emberDebugBundle = concatBundle(emberDebugBundle, {
     outputFile: 'ember.debug.js'
   });
 
@@ -160,7 +160,7 @@ module.exports = function() {
     nodeModule
   ]);
 
-  emberTestingBundle = concat(emberTestingBundle, {
+  emberTestingBundle = concatBundle(emberTestingBundle, {
     outputFile: 'ember-testing.js',
     hasBootstrap: false,
     footer: stripIndent`
@@ -265,7 +265,7 @@ module.exports = function() {
       loader
     ]);
 
-    prodTemplateCompiler = concat(prodTemplateCompiler, {
+    prodTemplateCompiler = concatBundle(prodTemplateCompiler, {
       outputFile: 'ember-template-compiler.js'
     });
 
@@ -279,15 +279,15 @@ module.exports = function() {
       nodeModule
     ]);
 
-    emberRuntimeBundle = concat(emberRuntimeBundle, {
+    emberRuntimeBundle = concatBundle(emberRuntimeBundle, {
       outputFile: 'ember-runtime.js'
     });
 
-    emberProdBundle = concat(emberProdBundle, {
+    emberProdBundle = concatBundle(emberProdBundle, {
       outputFile: 'ember.prod.js'
     });
 
-    emberProdTestsBundle = concat(emberProdTestsBundle, {
+    emberProdTestsBundle = concatBundle(emberProdTestsBundle, {
       outputFile: 'ember-tests.prod.js',
       hasBootstrap: false
     });
@@ -310,7 +310,7 @@ module.exports = function() {
       nodeModule
     ]);
 
-    emberTemplateCompilerBundle = concat(emberTemplateCompilerBundle, {
+    emberTemplateCompilerBundle = concatBundle(emberTemplateCompilerBundle, {
       outputFile: 'ember-template-compiler.js'
     });
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -61,7 +61,7 @@ module.exports = function() {
     emberPkgES('ember-utils'),
     emberPkgES('container'),
     ...emberES(),
-    ...dependenciesES()
+    ...dependenciesES({ includeGlimmerCompiler: true }),
   ]);
 
   let es = new Funnel(combinedES, {
@@ -346,12 +346,17 @@ module.exports = function() {
   ]);
 };
 
-function dependenciesES() {
+function dependenciesES(options = {}) {
   let glimmerEntries = [
     '@glimmer/node',
     '@glimmer/opcode-compiler',
     '@glimmer/runtime'
   ];
+
+  if (options.includeGlimmerCompiler) {
+    glimmerEntries.push('@glimmer/compiler');
+  }
+
   if (ENV === 'development') {
     let hasGlimmerDebug = true;
     try {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -40,7 +40,8 @@ module.exports = function() {
   let license = emberLicense();
   let nodeModule = nodeModuleUtils();
 
-  let es6 = new MergeTrees([
+  // generate "loose" ES<latest> modules...
+  let combinedES = new MergeTrees([
     emberVersionES(),
     emberFeaturesES(),
     emberPkgES('ember-testing'),
@@ -56,46 +57,53 @@ module.exports = function() {
     emberPkgES('ember-environment'),
     emberPkgES('ember-utils'),
     emberPkgES('container'),
-    ...emberES6(),
-    ...dependenciesES6()
+    ...emberES(),
+    ...dependenciesES()
   ]);
 
-  return es6;
+  let es = new Funnel(combinedES, {
+    destDir: 'es',
+  });
 
-  // let inlineParser = toES5(handlebarsES(), { annotation: 'handlebars' });
-  // let tokenizer = toES5(, { annotation: 'tokenizer' });
-  // let rsvp = toES5(, { annotation: 'rsvp' });
-  // let emberMetal = new Funnel('packages/ember-metal/lib', {
-  //   destDir: '/',
-  //   include: ['**/*.js']
-  // });
-  // let emberMetalES5 = rollupEmberMetal(emberMetal);
-  // let emberConsole = emberPkgES('ember-console', SHOULD_ROLLUP, [
-  //   'ember-environment'
-  // ]);
-  // let emberConsoleES5 = toES5(emberConsole, { annotation: 'ember-console' });
-  // let emberEnvironment = emberPkgES('ember-environment', SHOULD_ROLLUP);
-  // let emberEnvironmentES5 = toES5(emberEnvironment, {
-  //   annotation: 'ember-environment'
-  // });
-  // let emberUtils = emberPkgES('ember-utils', SHOULD_ROLLUP);
-  // let emberUtilsES5 = toES5(emberUtils, { annotation: 'ember-utils' });
-  // let container = emberPkgES('container', SHOULD_ROLLUP, [
-  //   'ember-debug',
-  //   'ember-utils',
-  //   'ember-environment',
-  //   'ember-env-flags',
-  //   'ember/features'
-  // ]);
-  // let containerES5 = toES5(container, { annotation: 'container' });
-  let emberCoreES6 = emberES6();
+  let debugFeatures = toES5(emberFeaturesES());
+  let version = toES5(emberVersionES());
+  let emberTesting = emberPkgES('ember-testing');
+  let emberTestingES5 = toES5(emberTesting, { annotation: 'ember-testing' });
+  let emberDebug = emberPkgES('ember-debug');
+  let emberDebugES5 = toES5(emberDebug, { annotation: 'ember-debug' });
+  let emberTemplateCompiler = emberPkgES('ember-template-compiler');
+  let emberTemplateCompilerES5 = toES5(emberTemplateCompiler, { annotation: 'ember-template-compiler' });
+  let babelDebugHelpersES5 = toES5(babelHelpers('debug'), { annotation: 'babel helpers debug' });
+  let inlineParser = toES5(handlebarsES(), { annotation: 'handlebars' });
+  let tokenizer = toES5(simpleHTMLTokenizerES(), { annotation: 'tokenizer' });
+  let rsvp = toES5(rsvpES(), { annotation: 'rsvp' });
+  let emberMetal = new Funnel('packages/ember-metal/lib', {
+    destDir: '/',
+    include: ['**/*.js']
+  });
+  let emberMetalES5 = rollupEmberMetal(emberMetal);
+  let emberConsole = emberPkgES('ember-console', SHOULD_ROLLUP, ['ember-environment']);
+  let emberConsoleES5 = toES5(emberConsole, { annotation: 'ember-console' });
+  let emberEnvironment = emberPkgES('ember-environment', SHOULD_ROLLUP);
+  let emberEnvironmentES5 = toES5(emberEnvironment, { annotation: 'ember-environment' });
+  let emberUtils = emberPkgES('ember-utils', SHOULD_ROLLUP);
+  let emberUtilsES5 = toES5(emberUtils, { annotation: 'ember-utils' });
+  let container = emberPkgES('container', SHOULD_ROLLUP, [
+    'ember-debug',
+    'ember-utils',
+    'ember-environment',
+    'ember-env-flags',
+    'ember/features'
+  ]);
+  let containerES5 = toES5(container, { annotation: 'container' });
+  let emberCoreES = emberES();
   let emberTests = emberTestsES6();
   let testHarness = testHarnessFiles();
-  // let backburner = toES5();
+  let backburner = toES5(backburnerES());
 
   // ES5
-  let dependenciesES5 = dependenciesES6().map(toES5);
-  let emberES5 = emberCoreES6.map(toES5);
+  let dependenciesES5 = dependenciesES().map(toES5);
+  let emberES5 = emberCoreES.map(toES5);
   let emberTestsES5 = emberTests.map(toES5);
 
   // Bundling
@@ -198,8 +206,8 @@ module.exports = function() {
     );
 
     let emberProdES5 = [
-      ...emberCoreES6,
-      ...dependenciesES6(),
+      ...emberCoreES,
+      ...dependenciesES(),
       container,
       emberUtils,
       emberEnvironment,
@@ -310,6 +318,7 @@ module.exports = function() {
   }
 
   return new MergeTrees([
+    es,
     ...trees,
     ...testHarness,
     emberTestsBundle,
@@ -319,7 +328,7 @@ module.exports = function() {
   ]);
 };
 
-function dependenciesES6() {
+function dependenciesES() {
   let glimmerEntries = [
     '@glimmer/node',
     '@glimmer/opcode-compiler',
@@ -363,7 +372,7 @@ function emberTestsES6() {
   ];
 }
 
-function emberES6() {
+function emberES() {
   return [
     emberPkgES('ember-views'),
     emberPkgES('ember'),

--- a/index.html
+++ b/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Pure ES</title>
+  <script type="text/javascript">
+    mainContext = this;
+    emberEnvFlags = {};
+    require$1 = function () {
+    }
+    require$1.has = function () {
+      return false;
+    }
+    nodeModule = {
+      require: null,
+      module: null,
+      IS_NODE: false }
+  </script>
+  <script src="rollup-bundle.es.js"></script>
+</head>
+<body>
+  <script type="text/javascript">
+    Ember = __Ember.default;
+    class MyApp extends Ember.Application {}
+    new MyApp();
+  </script>
+</body>
+</html>

--- a/packages/ember-debug/tests/error_test.js
+++ b/packages/ember-debug/tests/error_test.js
@@ -6,8 +6,12 @@ import {
 
 moduleFor('Ember Error Throwing', class extends TestCase {
   ['@test new EmberError displays provided message'](assert) {
-    assert.throws(() => {
-      throw new EmberError('A Message');
-    }, e => e.message === 'A Message', 'the assigned message was displayed');
+    assert.throws(
+      () => {
+        throw new EmberError('A Message');
+      },
+      function(e) { return e.message === 'A Message'; },
+      'the assigned message was displayed'
+    );
   }
 });

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -91,6 +91,8 @@ function makeCtor() {
               property === 'didDefineProperty' ||
               property === 'willWatchProperty' ||
               property === 'didUnwatchProperty' ||
+              property === 'didAddListener' ||
+              property === 'didRemoveListener' ||
               property === '__DESCRIPTOR__' ||
               property === 'isDescriptor' ||
               property in target

--- a/packages/ember-runtime/tests/mixins/promise_proxy_test.js
+++ b/packages/ember-runtime/tests/mixins/promise_proxy_test.js
@@ -214,12 +214,7 @@ QUnit.test('unhandled rejects still propagate to RSVP.on(\'error\', ...) ', func
 });
 
 QUnit.test('should work with promise inheritance', function(assert) {
-  function PromiseSubclass() {
-    RSVP.Promise.apply(this, arguments);
-  }
-
-  PromiseSubclass.prototype = Object.create(RSVP.Promise.prototype);
-  PromiseSubclass.prototype.constructor = PromiseSubclass;
+  class PromiseSubclass extends RSVP.Promise { }
 
   let proxy = ObjectPromiseProxy.create({
     promise: new PromiseSubclass(() => { })

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -643,9 +643,13 @@ moduleFor('Loading/Error Substates - nested routes', class extends ApplicationTe
       }
     }));
 
-    assert.throws(() => {
-      this.visit('/grandma/mom/sally');
-    }, (err) => err.msg === 'did it broke?', 'it broke');
+    assert.throws(
+      () => {
+        this.visit('/grandma/mom/sally');
+      },
+      function(err) { return err.msg === 'did it broke?'; },
+      'it broke'
+    );
 
     return this.runLoopSettled();
   }
@@ -678,9 +682,13 @@ moduleFor('Loading/Error Substates - nested routes', class extends ApplicationTe
       }
     }));
 
-    assert.throws(() => {
-      this.visit('/grandma/mom/sally');
-    }, (err) => err.msg  === 'did it broke?', `it broke`);
+    assert.throws(
+      () => {
+        this.visit('/grandma/mom/sally');
+      },
+      function(err) { return err.msg  === 'did it broke?'; },
+      `it broke`
+    );
 
     return this.runLoopSettled();
   }
@@ -701,9 +709,13 @@ moduleFor('Loading/Error Substates - nested routes', class extends ApplicationTe
       }
     }));
 
-    assert.throws(() => {
-      this.visit('/grandma/mom/sally');
-    }, (err) => err.msg == "did it broke?", 'Correct error was thrown');
+    assert.throws(
+      () => {
+        this.visit('/grandma/mom/sally');
+      },
+      function(err) { return err.msg == "did it broke?"; },
+      'Correct error was thrown'
+    );
 
     return this.runLoopSettled();
   }
@@ -736,9 +748,13 @@ moduleFor('Loading/Error Substates - nested routes', class extends ApplicationTe
       }
     }));
 
-    assert.throws(() => {
-      this.visit('/grandma/mom/sally');
-    }, (err) => err.msg === 'did it broke?', 'it broke');
+    assert.throws(
+      () => {
+        this.visit('/grandma/mom/sally');
+      },
+      function(err) { return err.msg === 'did it broke?'; },
+      'it broke'
+    );
 
     return this.runLoopSettled();
   }

--- a/packages/internal-test-helpers/lib/apply-mixins.js
+++ b/packages/internal-test-helpers/lib/apply-mixins.js
@@ -1,4 +1,5 @@
 import { assign } from 'ember-utils';
+import getAllPropertyNames from './get-all-property-names';
 
 function isGenerator(mixin) {
   return Array.isArray(mixin.cases) && (typeof mixin.generate === 'function');
@@ -18,16 +19,18 @@ export default function applyMixins(TestClass, ...mixins) {
 
       assign(TestClass.prototype, mixin);
     } else if (typeof mixinOrGenerator === 'function') {
+      let properties = getAllPropertyNames(mixinOrGenerator);
       mixin = new mixinOrGenerator();
-      for (let key in mixin) {
-        TestClass.prototype[key] = mixin[key];
-      }
+
+      properties.forEach(name => {
+        TestClass.prototype[name] = function() {
+          return mixin[name].apply(mixin, arguments);
+        };
+      });
     } else {
       mixin = mixinOrGenerator;
       assign(TestClass.prototype, mixin);
     }
-
-
   });
 
   return TestClass;

--- a/packages/internal-test-helpers/lib/get-all-property-names.js
+++ b/packages/internal-test-helpers/lib/get-all-property-names.js
@@ -1,0 +1,12 @@
+export default function getAllPropertyNames(Klass) {
+  let proto = Klass.prototype;
+  let properties = new Set();
+
+  while (proto !== Object.prototype) {
+    let names = Object.getOwnPropertyNames(proto);
+    names.forEach(name => properties.add(name));
+    proto = Object.getPrototypeOf(proto);
+  }
+
+  return properties;
+}

--- a/packages/internal-test-helpers/lib/module-for.js
+++ b/packages/internal-test-helpers/lib/module-for.js
@@ -1,5 +1,6 @@
 import { isFeatureEnabled } from 'ember-debug';
 import applyMixins from './apply-mixins';
+import getAllPropertyNames from './get-all-property-names';
 import { all } from 'rsvp';
 
 export default function moduleFor(description, TestClass, ...mixins) {
@@ -42,12 +43,8 @@ export default function moduleFor(description, TestClass, ...mixins) {
     applyMixins(TestClass, ...mixins);
   }
 
-  let proto = TestClass.prototype;
-
-  while (proto !== Object.prototype) {
-    Object.keys(proto).forEach(generateTest);
-    proto = Object.getPrototypeOf(proto);
-  }
+  let properties = getAllPropertyNames(TestClass);
+  properties.forEach(generateTest);
 
   function shouldTest(features) {
     return features.every(feature => {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,6 +25,7 @@ function emberPackage() {
         // console.log('resolved ' + resolved);
         return fs.realpathSync(resolved);
       } else {
+        // eslint-disable-next-line no-console
         console.log('could not resolve ' + importee + ' from ' + importer);
       }
     }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,32 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export default {
+  input: 'dist/ember/index.js',
+  plugins: [emberPackage()],
+  output: {
+    file: 'rollup-bundle.es.js',
+    format: 'iife',
+    name: '__Ember',
+    named: true,
+    sourcemap: true
+  }
+};
+
+function emberPackage() {
+  return {
+    resolveId(importee, importer) {
+      if (importee[0] === '.' || importee[0] === '/') return;
+      let resolved = [
+        path.resolve('dist', `${importee}.js`),
+        path.resolve('dist', `${importee}/index.js`)
+      ].find(fs.existsSync);
+      if (resolved) {
+        // console.log('resolved ' + resolved);
+        return fs.realpathSync(resolved);
+      } else {
+        console.log('could not resolve ' + importee + ' from ' + importer);
+      }
+    }
+  };
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 export default {
-  input: 'dist/ember/index.js',
+  input: 'dist/es/ember/index.js',
   plugins: [emberPackage()],
   output: {
     file: 'rollup-bundle.es.js',
@@ -18,8 +18,8 @@ function emberPackage() {
     resolveId(importee, importer) {
       if (importee[0] === '.' || importee[0] === '/') return;
       let resolved = [
-        path.resolve('dist', `${importee}.js`),
-        path.resolve('dist', `${importee}/index.js`)
+        path.resolve('dist', `es/${importee}.js`),
+        path.resolve('dist', `es/${importee}/index.js`)
       ].find(fs.existsSync);
       if (resolved) {
         // console.log('resolved ' + resolved);

--- a/tests/index.html
+++ b/tests/index.html
@@ -95,7 +95,8 @@
     </script>
 
     <script type="text/javascript">
-      Ember.testing = true;
+      var setTesting = Ember.__loader.require('ember-debug')['setTesting'];
+      setTesting(true);
     </script>
 
     <script>
@@ -135,12 +136,6 @@
             return skip(string, callback);
           }
         }
-
-        let EmberDebug = Ember.__loader.require('ember-debug');
-        EmberDebug.registerDeprecationHandler(function (message, options, next) {
-          var id = options && options.id;
-          next(message, options);
-        });
 
         window.EmberDev = window.EmberDev || {};
         EmberDev.runningProdBuild = !!QUnit.urlParams.prod;

--- a/tests/index.html
+++ b/tests/index.html
@@ -80,10 +80,17 @@
     <script>
       var dist = QUnit.urlParams.dist;
 
-      if (dist) {
-        loadScript('../ember.' + dist + '.js');
-      } else {
-        loadScript('../ember.debug.js');
+      switch (dist) {
+        case 'prod':
+        case 'min':
+          loadScript('../ember.' + dist + '.js');
+          break;
+        case 'es':
+          loadScript('../ember-all.debug.js');
+          break;
+        default:
+          loadScript('../ember.debug.js');
+          break;
       }
     </script>
 
@@ -97,8 +104,11 @@
 
     <script>
       var prod = QUnit.urlParams.prod;
+      var dist = QUnit.urlParams.dist;
 
-      if (prod) {
+      if (dist === 'es') {
+        // do nothing, tests are included
+      } else if (prod) {
         loadScript('../ember-tests.prod.js');
       } else {
         loadScript('../ember-tests.js');
@@ -120,7 +130,8 @@
           }
         }
 
-        Ember.Debug.registerDeprecationHandler(function (message, options, next) {
+        let EmberDebug = Ember.__loader.require('ember-debug');
+        EmberDebug.registerDeprecationHandler(function (message, options, next) {
           var id = options && options.id;
           next(message, options);
         });

--- a/tests/index.html
+++ b/tests/index.html
@@ -99,7 +99,13 @@
     </script>
 
     <script>
-      loadScript('../ember-template-compiler.js');
+      var dist = QUnit.urlParams.dist;
+
+      if (dist === 'es') {
+        // do nothing template compiler already included
+      } else {
+        loadScript('../ember-template-compiler.js');
+      }
     </script>
 
     <script>


### PR DESCRIPTION
This enables us to begin testing that our ES works untranspiled (and fixes a number of issues in that area).

This does not yet setup CI to run these tests with chrome and ES<latest> modules (there are more object model changes required for that to be possible), but this will provide a nice base for that object model work.