### PR TITLE
Fix a few issues with ember-template-compiler

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -161,7 +161,6 @@ module.exports = function() {
     babelDebugHelpersES5,
     inlineParser,
     debugFeatures,
-    emberTemplateCompilerES5
   ]);
 
   emberDebugBundle = concatBundle(emberDebugBundle, {
@@ -289,7 +288,6 @@ module.exports = function() {
     let emberProdTestsBundle = new MergeTrees([
       ...emberProdTestES5,
       tokenizer,
-      emberTemplateCompilerES5,
       babelProdHelpersES5,
       license,
       loader,

--- a/packages/ember-template-compiler/lib/index.js
+++ b/packages/ember-template-compiler/lib/index.js
@@ -17,7 +17,7 @@ export {
   registerPlugin,
   unregisterPlugin
 } from './system/compile-options';
-export { default as defaultPlugins } from './plugins';
+export { default as defaultPlugins } from './plugins/index';
 
 // used for adding Ember.Handlebars.compile for backwards compat
 import './compat';

--- a/packages/ember-template-compiler/lib/system/compile-options.js
+++ b/packages/ember-template-compiler/lib/system/compile-options.js
@@ -1,5 +1,5 @@
 import { assign } from 'ember-utils';
-import PLUGINS from '../plugins';
+import PLUGINS from '../plugins/index';
 
 let USER_PLUGINS = [];
 

--- a/packages/ember-template-compiler/lib/system/precompile.js
+++ b/packages/ember-template-compiler/lib/system/precompile.js
@@ -3,9 +3,7 @@
 */
 
 import compileOptions from './compile-options';
-import require, { has } from 'require';
-
-let glimmerPrecompile;
+import { precompile as glimmerPrecompile } from '@glimmer/compiler';
 
 /**
   Uses HTMLBars `compile` function to process a string into a compiled template string.
@@ -18,13 +16,5 @@ let glimmerPrecompile;
   @param {String} templateString This is the string to be compiled by HTMLBars.
 */
 export default function precompile(templateString, options) {
-  if (!glimmerPrecompile && has('@glimmer/compiler')) {
-    glimmerPrecompile = require('@glimmer/compiler').precompile;
-  }
-
-  if (!glimmerPrecompile) {
-    throw new Error('Cannot call `compile` without the template compiler loaded. Please load `ember-template-compiler.js` prior to calling `compile`.');
-  }
-
   return glimmerPrecompile(templateString, compileOptions(options));
 }


### PR DESCRIPTION
* Import `@glimmer/compiler` directly in ember-template-compiler.
* Use explicit `/index` for importing from folder.