### PR TITLE
Remove `Controller#content` alias.

### DIFF
--- a/packages/ember-runtime/lib/mixins/controller.js
+++ b/packages/ember-runtime/lib/mixins/controller.js
@@ -1,5 +1,4 @@
 import { Mixin } from 'ember-metal';
-import { deprecatingAlias } from '../computed/computed_macros';
 import ActionHandler from './action_handler';
 
 /**
@@ -40,13 +39,4 @@ export default Mixin.create(ActionHandler, {
     @public
   */
   model: null,
-
-  /**
-    @private
-  */
-  content: deprecatingAlias('model', {
-    id: 'ember-runtime.controller.content-alias',
-    until: '2.17.0',
-    url: 'https://emberjs.com/deprecations/v2.x/#toc_controller-content-alias'
-  })
 });

--- a/packages/ember-runtime/tests/controllers/controller_test.js
+++ b/packages/ember-runtime/tests/controllers/controller_test.js
@@ -106,17 +106,6 @@ QUnit.module('Controller deprecations');
 
 QUnit.module('Controller Content -> Model Alias');
 
-QUnit.test('`content` is a deprecated alias of `model`', function(assert) {
-  assert.expect(2);
-  let controller = Controller.extend({
-    model: 'foo-bar'
-  }).create();
-
-  expectDeprecation(function () {
-    assert.equal(controller.get('content'), 'foo-bar', 'content is an alias of model');
-  });
-});
-
 QUnit.test('`content` is not moved to `model` when `model` is unset', function(assert) {
   assert.expect(2);
   let controller;


### PR DESCRIPTION
This was deprecated and labeled as `until` 2.17. With 3.2 approaching beta soon, its time has passed...