### PR TITLE
Expose `hasScheduledTimers` on `Ember.run`

### DIFF
--- a/packages/ember/lib/index.js
+++ b/packages/ember/lib/index.js
@@ -96,6 +96,7 @@ Ember.run.bind = metal.bind;
 Ember.run.cancel = metal.cancel;
 Ember.run.debounce = metal.debounce;
 Ember.run.end = metal.end;
+Ember.run.hasScheduledTimers = metal.hasScheduledTimers;
 Ember.run.join = metal.join;
 Ember.run.later = metal.later;
 Ember.run.next = metal.next;

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -77,6 +77,7 @@ let allExports =[
   ['run.cancel', 'ember-metal', 'cancel'],
   ['run.debounce', 'ember-metal', 'debounce'],
   ['run.end', 'ember-metal', 'end'],
+  ['run.hasScheduledTimers', 'ember-metal', 'hasScheduledTimers'],
   ['run.join', 'ember-metal', 'join'],
   ['run.later', 'ember-metal', 'later'],
   ['run.next', 'ember-metal', 'next'],


### PR DESCRIPTION
It looks like https://github.com/emberjs/ember.js/pull/16431 had the side effect of removing `hasScheduledTimers` from the global `Ember.run`, which `@ember/test-helpers` [relies on](https://github.com/emberjs/ember-test-helpers/blob/master/addon-test-support/%40ember/test-helpers/settled.js#L146).