### PR TITLE
Refactor CoreObject to leverage native JS semantics.

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -12,14 +12,10 @@ import {
   schedule,
   bind,
   once,
+  processAllNamespaces,
+  setNamespaceSearchDisabled
 } from 'ember-metal';
-import {
-  Namespace,
-  setNamespaceSearchDisabled,
-  runLoadHooks,
-  _loaded,
-  RSVP
-} from 'ember-runtime';
+import { runLoadHooks, _loaded, RSVP } from 'ember-runtime';
 import { EventDispatcher, jQuery, jQueryDisabled } from 'ember-views';
 import {
   Route,
@@ -365,7 +361,8 @@ const Application = Engine.extend({
   */
   _applicationInstances: null,
 
-  init(options) { // eslint-disable-line no-unused-vars
+  init() {
+    // eslint-disable-line no-unused-vars
     this._super(...arguments);
 
     if (!this.$) {
@@ -579,8 +576,14 @@ const Application = Engine.extend({
     @public
   */
   deferReadiness() {
-    assert('You must call deferReadiness on an instance of Application', this instanceof Application);
-    assert('You cannot defer readiness since the `ready()` hook has already been called.', this._readinessDeferrals > 0);
+    assert(
+      'You must call deferReadiness on an instance of Application',
+      this instanceof Application
+    );
+    assert(
+      'You cannot defer readiness since the `ready()` hook has already been called.',
+      this._readinessDeferrals > 0
+    );
     this._readinessDeferrals++;
   },
 
@@ -594,7 +597,10 @@ const Application = Engine.extend({
     @public
   */
   advanceReadiness() {
-    assert('You must call advanceReadiness on an instance of Application', this instanceof Application);
+    assert(
+      'You must call advanceReadiness on an instance of Application',
+      this instanceof Application
+    );
     this._readinessDeferrals--;
 
     if (this._readinessDeferrals === 0) {
@@ -619,7 +625,9 @@ const Application = Engine.extend({
     @return {Promise<Application,Error>}
   */
   boot() {
-    if (this._bootPromise) { return this._bootPromise; }
+    if (this._bootPromise) {
+      return this._bootPromise;
+    }
 
     try {
       this._bootSync();
@@ -645,13 +653,15 @@ const Application = Engine.extend({
     @private
   */
   _bootSync() {
-    if (this._booted) { return; }
+    if (this._booted) {
+      return;
+    }
 
     // Even though this returns synchronously, we still need to make sure the
     // boot promise exists for book-keeping purposes: if anything went wrong in
     // the boot process, we need to store the error as a rejection on the boot
     // promise so that a future caller of `boot()` can tell what failed.
-    let defer = this._bootResolver = RSVP.defer();
+    let defer = (this._bootResolver = RSVP.defer());
     this._bootPromise = defer.promise;
 
     try {
@@ -740,10 +750,13 @@ const Application = Engine.extend({
     @public
   */
   reset() {
-    assert(`Calling reset() on instances of \`Application\` is not
+    assert(
+      `Calling reset() on instances of \`Application\` is not
             supported when globals mode is disabled; call \`visit()\` to
             create new \`ApplicationInstance\`s and dispose them
-            via their \`destroy()\` method instead.`, this._globalsMode && this.autoboot);
+            via their \`destroy()\` method instead.`,
+      this._globalsMode && this.autoboot
+    );
 
     let instance = this.__deprecatedInstance__;
 
@@ -770,7 +783,7 @@ const Application = Engine.extend({
       // TODO: Is this still needed for _globalsMode = false?
       if (!isTesting()) {
         // Eagerly name all classes that are already loaded
-        Namespace.processAll();
+        processAllNamespaces();
         setNamespaceSearchDisabled(true);
       }
 
@@ -819,7 +832,9 @@ const Application = Engine.extend({
     @event ready
     @public
   */
-  ready() { return this; },
+  ready() {
+    return this;
+  },
 
   // This method must be moved to the application instance object
   willDestroy() {
@@ -1040,7 +1055,8 @@ const Application = Engine.extend({
     return this.boot().then(() => {
       let instance = this.buildInstance();
 
-      return instance.boot(options)
+      return instance
+        .boot(options)
         .then(() => instance.visit(url))
         .catch(error => {
           run(instance, 'destroy');
@@ -1076,7 +1092,8 @@ Application.reopenClass({
     @return {Ember.Registry} the built registry
     @private
   */
-  buildRegistry(application, options = {}) { // eslint-disable-line no-unused-vars
+  buildRegistry() {
+    // eslint-disable-line no-unused-vars
     let registry = this._super(...arguments);
 
     commonSetupRegistry(registry);
@@ -1089,7 +1106,11 @@ Application.reopenClass({
 
 function commonSetupRegistry(registry) {
   registry.register('router:main', Router.extend());
-  registry.register('-view-registry:main', { create() { return dictionary(null); } });
+  registry.register('-view-registry:main', {
+    create() {
+      return dictionary(null);
+    }
+  });
 
   registry.register('route:basic', Route);
   registry.register('event_dispatcher:main', EventDispatcher);
@@ -1101,7 +1122,11 @@ function commonSetupRegistry(registry) {
   registry.register('location:history', HistoryLocation);
   registry.register('location:none', NoneLocation);
 
-  registry.register(P`-bucket-cache:main`, { create() { return new BucketCache(); } });
+  registry.register(P`-bucket-cache:main`, {
+    create() {
+      return new BucketCache();
+    }
+  });
 
   if (EMBER_ROUTING_ROUTER_SERVICE) {
     registry.register('service:router', RouterService);

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -1,24 +1,12 @@
 /*globals EmberDev */
 import { VERSION } from 'ember';
 import { ENV, context } from 'ember-environment';
-import { libraries } from 'ember-metal';
-import {
-  getDebugFunction,
-  setDebugFunction
-} from 'ember-debug';
+import { libraries, setNamespaceSearchDisabled } from 'ember-metal';
+import { getDebugFunction, setDebugFunction } from 'ember-debug';
 import Application from '../../system/application';
-import {
-  Router,
-  NoneLocation,
-  Route as EmberRoute
-} from 'ember-routing';
+import { Router, NoneLocation, Route as EmberRoute } from 'ember-routing';
 import { jQuery } from 'ember-views';
-import {
-  Controller,
-  Object as EmberObject,
-  setNamespaceSearchDisabled,
-  _loaded
-} from 'ember-runtime';
+import { Controller, Object as EmberObject, _loaded } from 'ember-runtime';
 import { setTemplates } from 'ember-glimmer';
 import { privatize as P } from 'container';
 import {
@@ -35,382 +23,546 @@ import {
 } from 'internal-test-helpers';
 import { run } from 'ember-metal';
 
-moduleFor('Application, autobooting multiple apps', class extends ApplicationTestCase {
-  get fixture() {
-    return `
+moduleFor(
+  'Application, autobooting multiple apps',
+  class extends ApplicationTestCase {
+    get fixture() {
+      return `
       <div id="one">
         <div id="one-child">HI</div>
       </div>
       <div id="two">HI</div>
     `;
-  }
+    }
 
-  get applicationOptions() {
-    return assign(super.applicationOptions, {
-      rootElement: '#one',
-      router: null,
-      autoboot: true
-    });
-  }
+    get applicationOptions() {
+      return assign(super.applicationOptions, {
+        rootElement: '#one',
+        router: null,
+        autoboot: true
+      });
+    }
 
-  createSecondApplication(options) {
-    let myOptions = assign(this.applicationOptions, options);
-    return this.secondApp = Application.create(myOptions);
-  }
+    createSecondApplication(options) {
+      let myOptions = assign(this.applicationOptions, options);
+      return (this.secondApp = Application.create(myOptions));
+    }
 
-  teardown() {
-    super.teardown();
+    teardown() {
+      super.teardown();
 
-    if (this.secondApp) {
-      this.runTask(() => this.secondApp.destroy());
+      if (this.secondApp) {
+        this.runTask(() => this.secondApp.destroy());
+      }
+    }
+
+    [`@test you can make a new application in a non-overlapping element`](
+      assert
+    ) {
+      let app = this.runTask(() =>
+        this.createSecondApplication({
+          rootElement: '#two'
+        })
+      );
+
+      this.runTask(() => app.destroy());
+      assert.ok(true, 'should not raise');
+    }
+
+    [`@test you cannot make a new application that is a parent of an existing application`]() {
+      expectAssertion(() => {
+        this.runTask(() =>
+          this.createSecondApplication({
+            rootElement: this.applicationOptions.rootElement
+          })
+        );
+      });
+    }
+
+    [`@test you cannot make a new application that is a descendant of an existing application`]() {
+      expectAssertion(() => {
+        this.runTask(() =>
+          this.createSecondApplication({
+            rootElement: '#one-child'
+          })
+        );
+      });
+    }
+
+    [`@test you cannot make a new application that is a duplicate of an existing application`]() {
+      expectAssertion(() => {
+        this.runTask(() =>
+          this.createSecondApplication({
+            rootElement: '#one'
+          })
+        );
+      });
+    }
+
+    [`@test you cannot make two default applications without a rootElement error`]() {
+      expectAssertion(() => {
+        this.runTask(() => this.createSecondApplication());
+      });
     }
   }
+);
 
-  [`@test you can make a new application in a non-overlapping element`](assert) {
-    let app = this.runTask(() => this.createSecondApplication({
-      rootElement: '#two'
-    }));
+moduleFor(
+  'Application',
+  class extends ApplicationTestCase {
+    [`@test builds a registry`](assert) {
+      let { application } = this;
+      assert.strictEqual(
+        application.resolveRegistration('application:main'),
+        application,
+        `application:main is registered`
+      );
+      assert.deepEqual(
+        application.registeredOptionsForType('component'),
+        { singleton: false },
+        `optionsForType 'component'`
+      );
+      assert.deepEqual(
+        application.registeredOptionsForType('view'),
+        { singleton: false },
+        `optionsForType 'view'`
+      );
 
-    this.runTask(() => app.destroy());
-    assert.ok(true, 'should not raise');
+      verifyRegistration(assert, application, 'controller:basic');
+      verifyRegistration(assert, application, '-view-registry:main');
+      verifyInjection(
+        assert,
+        application,
+        'view',
+        '_viewRegistry',
+        '-view-registry:main'
+      );
+      verifyInjection(
+        assert,
+        application,
+        'route',
+        '_topLevelViewTemplate',
+        'template:-outlet'
+      );
+      verifyRegistration(assert, application, 'route:basic');
+      verifyRegistration(assert, application, 'event_dispatcher:main');
+      verifyInjection(
+        assert,
+        application,
+        'router:main',
+        'namespace',
+        'application:main'
+      );
+      verifyInjection(
+        assert,
+        application,
+        'view:-outlet',
+        'namespace',
+        'application:main'
+      );
+
+      verifyRegistration(assert, application, 'location:auto');
+      verifyRegistration(assert, application, 'location:hash');
+      verifyRegistration(assert, application, 'location:history');
+      verifyRegistration(assert, application, 'location:none');
+
+      verifyInjection(
+        assert,
+        application,
+        'controller',
+        'target',
+        'router:main'
+      );
+      verifyInjection(
+        assert,
+        application,
+        'controller',
+        'namespace',
+        'application:main'
+      );
+
+      verifyRegistration(assert, application, P`-bucket-cache:main`);
+      verifyInjection(
+        assert,
+        application,
+        'router',
+        '_bucketCache',
+        P`-bucket-cache:main`
+      );
+      verifyInjection(
+        assert,
+        application,
+        'route',
+        '_bucketCache',
+        P`-bucket-cache:main`
+      );
+
+      verifyInjection(assert, application, 'route', '_router', 'router:main');
+
+      verifyRegistration(assert, application, 'component:-text-field');
+      verifyRegistration(assert, application, 'component:-text-area');
+      verifyRegistration(assert, application, 'component:-checkbox');
+      verifyRegistration(assert, application, 'component:link-to');
+
+      verifyRegistration(assert, application, 'service:-routing');
+      verifyInjection(
+        assert,
+        application,
+        'service:-routing',
+        'router',
+        'router:main'
+      );
+
+      // DEBUGGING
+      verifyRegistration(assert, application, 'resolver-for-debugging:main');
+      verifyInjection(
+        assert,
+        application,
+        'container-debug-adapter:main',
+        'resolver',
+        'resolver-for-debugging:main'
+      );
+      verifyInjection(
+        assert,
+        application,
+        'data-adapter:main',
+        'containerDebugAdapter',
+        'container-debug-adapter:main'
+      );
+      verifyRegistration(assert, application, 'container-debug-adapter:main');
+      verifyRegistration(assert, application, 'component-lookup:main');
+
+      verifyRegistration(assert, application, 'service:-glimmer-environment');
+      verifyRegistration(assert, application, 'service:-dom-changes');
+      verifyRegistration(assert, application, 'service:-dom-tree-construction');
+      verifyInjection(
+        assert,
+        application,
+        'service:-glimmer-environment',
+        'appendOperations',
+        'service:-dom-tree-construction'
+      );
+      verifyInjection(
+        assert,
+        application,
+        'service:-glimmer-environment',
+        'updateOperations',
+        'service:-dom-changes'
+      );
+      verifyInjection(
+        assert,
+        application,
+        'renderer',
+        'env',
+        'service:-glimmer-environment'
+      );
+      verifyRegistration(assert, application, 'view:-outlet');
+      verifyRegistration(assert, application, 'renderer:-dom');
+      verifyRegistration(assert, application, 'renderer:-inert');
+      verifyRegistration(assert, application, P`template:components/-default`);
+      verifyRegistration(assert, application, 'template:-outlet');
+      verifyInjection(
+        assert,
+        application,
+        'view:-outlet',
+        'template',
+        'template:-outlet'
+      );
+      verifyInjection(
+        assert,
+        application,
+        'template',
+        'compiler',
+        P`template-compiler:main`
+      );
+
+      assert.deepEqual(
+        application.registeredOptionsForType('helper'),
+        { instantiate: false },
+        `optionsForType 'helper'`
+      );
+    }
   }
+);
 
-  [`@test you cannot make a new application that is a parent of an existing application`]() {
-    expectAssertion(() => {
-      this.runTask(() => this.createSecondApplication({
-        rootElement: this.applicationOptions.rootElement
-      }));
-    });
-  }
+moduleFor(
+  'Application, default resolver with autoboot',
+  class extends DefaultResolverApplicationTestCase {
+    constructor() {
+      super();
+      this.originalLookup = context.lookup;
+    }
 
-  [`@test you cannot make a new application that is a descendant of an existing application`]() {
-    expectAssertion(() => {
-      this.runTask(() => this.createSecondApplication({
-        rootElement: '#one-child'
-      }));
-    });
-  }
+    teardown() {
+      context.lookup = this.originalLookup;
+      super.teardown();
+      setTemplates({});
+    }
 
-  [`@test you cannot make a new application that is a duplicate of an existing application`]() {
-    expectAssertion(() => {
-      this.runTask(() => this.createSecondApplication({
-        rootElement: '#one'
-      }));
-    });
-  }
+    get applicationOptions() {
+      return assign(super.applicationOptions, {
+        autoboot: true
+      });
+    }
 
-  [`@test you cannot make two default applications without a rootElement error`]() {
-    expectAssertion(() => {
-      this.runTask(() => this.createSecondApplication());
-    });
-  }
-});
+    [`@test acts like a namespace`](assert) {
+      let lookup = (context.lookup = {});
 
-moduleFor('Application', class extends ApplicationTestCase {
+      lookup.TestApp = this.runTask(() => this.createApplication());
 
-  [`@test builds a registry`](assert) {
-    let {application} = this;
-    assert.strictEqual(application.resolveRegistration('application:main'), application, `application:main is registered`);
-    assert.deepEqual(application.registeredOptionsForType('component'), { singleton: false }, `optionsForType 'component'`);
-    assert.deepEqual(application.registeredOptionsForType('view'), { singleton: false }, `optionsForType 'view'`);
+      setNamespaceSearchDisabled(false);
+      let Foo = (this.application.Foo = EmberObject.extend());
+      assert.equal(
+        Foo.toString(),
+        'TestApp.Foo',
+        'Classes pick up their parent namespace'
+      );
+    }
 
-    verifyRegistration(assert, application, 'controller:basic');
-    verifyRegistration(assert, application, '-view-registry:main');
-    verifyInjection(assert, application, 'view', '_viewRegistry', '-view-registry:main');
-    verifyInjection(assert, application, 'route', '_topLevelViewTemplate', 'template:-outlet');
-    verifyRegistration(assert, application, 'route:basic');
-    verifyRegistration(assert, application, 'event_dispatcher:main');
-    verifyInjection(assert, application, 'router:main', 'namespace', 'application:main');
-    verifyInjection(assert, application, 'view:-outlet', 'namespace', 'application:main');
-
-    verifyRegistration(assert, application, 'location:auto');
-    verifyRegistration(assert, application, 'location:hash');
-    verifyRegistration(assert, application, 'location:history');
-    verifyRegistration(assert, application, 'location:none');
-
-    verifyInjection(assert, application, 'controller', 'target', 'router:main');
-    verifyInjection(assert, application, 'controller', 'namespace', 'application:main');
-
-    verifyRegistration(assert, application, P`-bucket-cache:main`);
-    verifyInjection(assert, application, 'router', '_bucketCache', P`-bucket-cache:main`);
-    verifyInjection(assert, application, 'route', '_bucketCache', P`-bucket-cache:main`);
-
-    verifyInjection(assert, application, 'route', '_router', 'router:main');
-
-    verifyRegistration(assert, application, 'component:-text-field');
-    verifyRegistration(assert, application, 'component:-text-area');
-    verifyRegistration(assert, application, 'component:-checkbox');
-    verifyRegistration(assert, application, 'component:link-to');
-
-    verifyRegistration(assert, application, 'service:-routing');
-    verifyInjection(assert, application, 'service:-routing', 'router', 'router:main');
-
-    // DEBUGGING
-    verifyRegistration(assert, application, 'resolver-for-debugging:main');
-    verifyInjection(assert, application, 'container-debug-adapter:main', 'resolver', 'resolver-for-debugging:main');
-    verifyInjection(assert, application, 'data-adapter:main', 'containerDebugAdapter', 'container-debug-adapter:main');
-    verifyRegistration(assert, application, 'container-debug-adapter:main');
-    verifyRegistration(assert, application, 'component-lookup:main');
-
-    verifyRegistration(assert, application, 'service:-glimmer-environment');
-    verifyRegistration(assert, application, 'service:-dom-changes');
-    verifyRegistration(assert, application, 'service:-dom-tree-construction');
-    verifyInjection(assert, application, 'service:-glimmer-environment', 'appendOperations', 'service:-dom-tree-construction');
-    verifyInjection(assert, application, 'service:-glimmer-environment', 'updateOperations', 'service:-dom-changes');
-    verifyInjection(assert, application, 'renderer', 'env', 'service:-glimmer-environment');
-    verifyRegistration(assert, application, 'view:-outlet');
-    verifyRegistration(assert, application, 'renderer:-dom');
-    verifyRegistration(assert, application, 'renderer:-inert');
-    verifyRegistration(assert, application, P`template:components/-default`);
-    verifyRegistration(assert, application, 'template:-outlet');
-    verifyInjection(assert, application, 'view:-outlet', 'template', 'template:-outlet');
-    verifyInjection(assert, application, 'template', 'compiler', P`template-compiler:main`);
-
-    assert.deepEqual(application.registeredOptionsForType('helper'), { instantiate: false }, `optionsForType 'helper'`);
-  }
-
-});
-
-moduleFor('Application, default resolver with autoboot', class extends DefaultResolverApplicationTestCase {
-
-  constructor() {
-    super();
-    this.originalLookup = context.lookup;
-  }
-
-  teardown() {
-    context.lookup = this.originalLookup;
-    super.teardown();
-    setTemplates({});
-  }
-
-  get applicationOptions() {
-    return assign(super.applicationOptions, {
-      autoboot: true
-    });
-  }
-
-  [`@test acts like a namespace`](assert) {
-    let lookup = context.lookup = {};
-
-    lookup.TestApp = this.runTask(() => this.createApplication());
-
-    setNamespaceSearchDisabled(false);
-    let Foo = this.application.Foo = EmberObject.extend();
-    assert.equal(Foo.toString(), 'TestApp.Foo', 'Classes pick up their parent namespace');
-  }
-
-  [`@test can specify custom router`](assert) {
-    let MyRouter = Router.extend();
-    this.runTask(() => {
-      this.createApplication();
-      this.application.Router = MyRouter;
-    });
-
-    assert.ok(
-      this.application.__deprecatedInstance__.lookup('router:main') instanceof MyRouter,
-      'application resolved the correct router'
-    );
-  }
-
-  [`@test Minimal Application initialized with just an application template`]() {
-    this.setupFixture('<script type="text/x-handlebars">Hello World</script>');
-    this.runTask(() => this.createApplication());
-    this.assertInnerHTML('Hello World');
-  }
-
-});
-
-moduleFor('Application, autobooting', class extends AutobootApplicationTestCase {
-
-  constructor() {
-    super();
-    this.originalLogVersion = ENV.LOG_VERSION;
-    this.originalDebug = getDebugFunction('debug');
-    this.originalWarn = getDebugFunction('warn');
-  }
-
-  teardown() {
-    setDebugFunction('warn', this.originalWarn);
-    setDebugFunction('debug', this.originalDebug);
-    ENV.LOG_VERSION = this.originalLogVersion;
-    super.teardown();
-  }
-
-  [`@test initialized application goes to initial route`]() {
-    this.runTask(() => {
-      this.createApplication();
-      this.addTemplate('application', '{{outlet}}');
-      this.addTemplate('index', '<h1>Hi from index</h1>');
-    });
-
-    this.assertText('Hi from index');
-  }
-
-  [`@test ready hook is called before routing begins`](assert) {
-    assert.expect(2);
-
-    this.runTask(() => {
-      function registerRoute(application, name, callback) {
-        let route = EmberRoute.extend({
-          activate: callback
-        });
-
-        application.register('route:' + name, route);
-      }
-
-      let MyApplication = Application.extend({
-        ready() {
-          registerRoute(this, 'index', () => {
-            assert.ok(true, 'last-minute route is activated');
-          });
-        }
+    [`@test can specify custom router`](assert) {
+      let MyRouter = Router.extend();
+      this.runTask(() => {
+        this.createApplication();
+        this.application.Router = MyRouter;
       });
 
-      let app = this.createApplication({}, MyApplication);
-
-      registerRoute(app, 'application', () => assert.ok(true, 'normal route is activated'));
-    });
-  }
-
-  [`@test initialize application via initialize call`](assert) {
-    this.runTask(() => this.createApplication());
-    // This is not a public way to access the container; we just
-    // need to make some assertions about the created router
-    let router = this.applicationInstance.lookup('router:main');
-    assert.equal(router instanceof Router, true, 'Router was set from initialize call');
-    assert.equal(router.location instanceof NoneLocation, true, 'Location was set from location implementation name');
-  }
-
-  [`@test initialize application with stateManager via initialize call from Router class`](assert) {
-    this.runTask(() => {
-      this.createApplication();
-      this.addTemplate('application', '<h1>Hello!</h1>');
-    });
-    // This is not a public way to access the container; we just
-    // need to make some assertions about the created router
-    let router = this.application.__deprecatedInstance__.lookup('router:main');
-    assert.equal(router instanceof Router, true, 'Router was set from initialize call');
-    this.assertText('Hello!');
-  }
-
-  [`@test Application Controller backs the appplication template`]() {
-    this.runTask(() => {
-      this.createApplication();
-      this.addTemplate('application', '<h1>{{greeting}}</h1>');
-      this.add('controller:application', Controller.extend({
-        greeting: 'Hello!'
-      }));
-    });
-    this.assertText('Hello!');
-  }
-
-  [`@test enable log of libraries with an ENV var`](assert) {
-    if (EmberDev && EmberDev.runningProdBuild) {
-      assert.ok(true, 'Logging does not occur in production builds');
-      return;
+      assert.ok(
+        this.application.__deprecatedInstance__.lookup('router:main') instanceof
+          MyRouter,
+        'application resolved the correct router'
+      );
     }
 
-    let messages = [];
+    [`@test Minimal Application initialized with just an application template`]() {
+      this.setupFixture(
+        '<script type="text/x-handlebars">Hello World</script>'
+      );
+      this.runTask(() => this.createApplication());
+      this.assertInnerHTML('Hello World');
+    }
+  }
+);
 
-    ENV.LOG_VERSION = true;
-
-    setDebugFunction('debug', message => messages.push(message));
-
-    libraries.register('my-lib', '2.0.0a');
-
-    this.runTask(() => this.createApplication());
-
-    assert.equal(messages[1], 'Ember  : ' + VERSION);
-    if (jQuery) {
-      assert.equal(messages[2], 'jQuery : ' + jQuery().jquery);
-      assert.equal(messages[3], 'my-lib : ' + '2.0.0a');
-    } else {
-      assert.equal(messages[2], 'my-lib : ' + '2.0.0a');
+moduleFor(
+  'Application, autobooting',
+  class extends AutobootApplicationTestCase {
+    constructor() {
+      super();
+      this.originalLogVersion = ENV.LOG_VERSION;
+      this.originalDebug = getDebugFunction('debug');
+      this.originalWarn = getDebugFunction('warn');
     }
 
-    libraries.deRegister('my-lib');
+    teardown() {
+      setDebugFunction('warn', this.originalWarn);
+      setDebugFunction('debug', this.originalDebug);
+      ENV.LOG_VERSION = this.originalLogVersion;
+      super.teardown();
+    }
+
+    [`@test initialized application goes to initial route`]() {
+      this.runTask(() => {
+        this.createApplication();
+        this.addTemplate('application', '{{outlet}}');
+        this.addTemplate('index', '<h1>Hi from index</h1>');
+      });
+
+      this.assertText('Hi from index');
+    }
+
+    [`@test ready hook is called before routing begins`](assert) {
+      assert.expect(2);
+
+      this.runTask(() => {
+        function registerRoute(application, name, callback) {
+          let route = EmberRoute.extend({
+            activate: callback
+          });
+
+          application.register('route:' + name, route);
+        }
+
+        let MyApplication = Application.extend({
+          ready() {
+            registerRoute(this, 'index', () => {
+              assert.ok(true, 'last-minute route is activated');
+            });
+          }
+        });
+
+        let app = this.createApplication({}, MyApplication);
+
+        registerRoute(app, 'application', () =>
+          assert.ok(true, 'normal route is activated')
+        );
+      });
+    }
+
+    [`@test initialize application via initialize call`](assert) {
+      this.runTask(() => this.createApplication());
+      // This is not a public way to access the container; we just
+      // need to make some assertions about the created router
+      let router = this.applicationInstance.lookup('router:main');
+      assert.equal(
+        router instanceof Router,
+        true,
+        'Router was set from initialize call'
+      );
+      assert.equal(
+        router.location instanceof NoneLocation,
+        true,
+        'Location was set from location implementation name'
+      );
+    }
+
+    [`@test initialize application with stateManager via initialize call from Router class`](
+      assert
+    ) {
+      this.runTask(() => {
+        this.createApplication();
+        this.addTemplate('application', '<h1>Hello!</h1>');
+      });
+      // This is not a public way to access the container; we just
+      // need to make some assertions about the created router
+      let router = this.application.__deprecatedInstance__.lookup(
+        'router:main'
+      );
+      assert.equal(
+        router instanceof Router,
+        true,
+        'Router was set from initialize call'
+      );
+      this.assertText('Hello!');
+    }
+
+    [`@test Application Controller backs the appplication template`]() {
+      this.runTask(() => {
+        this.createApplication();
+        this.addTemplate('application', '<h1>{{greeting}}</h1>');
+        this.add(
+          'controller:application',
+          Controller.extend({
+            greeting: 'Hello!'
+          })
+        );
+      });
+      this.assertText('Hello!');
+    }
+
+    [`@test enable log of libraries with an ENV var`](assert) {
+      if (EmberDev && EmberDev.runningProdBuild) {
+        assert.ok(true, 'Logging does not occur in production builds');
+        return;
+      }
+
+      let messages = [];
+
+      ENV.LOG_VERSION = true;
+
+      setDebugFunction('debug', message => messages.push(message));
+
+      libraries.register('my-lib', '2.0.0a');
+
+      this.runTask(() => this.createApplication());
+
+      assert.equal(messages[1], 'Ember  : ' + VERSION);
+      if (jQuery) {
+        assert.equal(messages[2], 'jQuery : ' + jQuery().jquery);
+        assert.equal(messages[3], 'my-lib : ' + '2.0.0a');
+      } else {
+        assert.equal(messages[2], 'my-lib : ' + '2.0.0a');
+      }
+
+      libraries.deRegister('my-lib');
+    }
+
+    [`@test disable log of version of libraries with an ENV var`](assert) {
+      let logged = false;
+
+      ENV.LOG_VERSION = false;
+
+      setDebugFunction('debug', () => (logged = true));
+
+      this.runTask(() => this.createApplication());
+
+      assert.ok(!logged, 'library version logging skipped');
+    }
+
+    [`@test can resolve custom router`](assert) {
+      let CustomRouter = Router.extend();
+
+      this.runTask(() => {
+        this.createApplication();
+        this.add('router:main', CustomRouter);
+      });
+
+      assert.ok(
+        this.application.__deprecatedInstance__.lookup('router:main') instanceof
+          CustomRouter,
+        'application resolved the correct router'
+      );
+    }
+
+    [`@test does not leak itself in onLoad._loaded`](assert) {
+      assert.equal(_loaded.application, undefined);
+      this.runTask(() => this.createApplication());
+      assert.equal(_loaded.application, this.application);
+      this.runTask(() => this.application.destroy());
+      assert.equal(_loaded.application, undefined);
+    }
+
+    [`@test can build a registry via Application.buildRegistry() --- simulates ember-test-helpers`](
+      assert
+    ) {
+      let namespace = EmberObject.create({
+        Resolver: { create: function() {} }
+      });
+
+      let registry = Application.buildRegistry(namespace);
+
+      assert.equal(registry.resolve('application:main'), namespace);
+    }
   }
+);
 
-  [`@test disable log of version of libraries with an ENV var`](assert) {
-    let logged = false;
+moduleFor(
+  'Application#buildRegistry',
+  class extends AbstractTestCase {
+    [`@test can build a registry via Application.buildRegistry() --- simulates ember-test-helpers`](
+      assert
+    ) {
+      let namespace = EmberObject.create({
+        Resolver: { create() {} }
+      });
 
-    ENV.LOG_VERSION = false;
+      let registry = Application.buildRegistry(namespace);
 
-    setDebugFunction('debug', () => logged = true);
-
-    this.runTask(() => this.createApplication());
-
-    assert.ok(!logged, 'library version logging skipped');
+      assert.equal(registry.resolve('application:main'), namespace);
+    }
   }
+);
 
-  [`@test can resolve custom router`](assert) {
-    let CustomRouter = Router.extend();
+moduleFor(
+  'Application - instance tracking',
+  class extends ApplicationTestCase {
+    ['@test tracks built instance'](assert) {
+      let instance = this.application.buildInstance();
+      run(() => {
+        this.application.destroy();
+      });
 
-    this.runTask(() => {
-      this.createApplication();
-      this.add('router:main', CustomRouter);
-    });
+      assert.ok(instance.isDestroyed, 'instance was destroyed');
+    }
 
-    assert.ok(
-      this.application.__deprecatedInstance__.lookup('router:main') instanceof CustomRouter,
-      'application resolved the correct router'
-    );
+    ['@test tracks built instances'](assert) {
+      let instanceA = this.application.buildInstance();
+      let instanceB = this.application.buildInstance();
+      run(() => {
+        this.application.destroy();
+      });
+
+      assert.ok(instanceA.isDestroyed, 'instanceA was destroyed');
+      assert.ok(instanceB.isDestroyed, 'instanceB was destroyed');
+    }
   }
-
-  [`@test does not leak itself in onLoad._loaded`](assert) {
-    assert.equal(_loaded.application, undefined);
-    this.runTask(() => this.createApplication());
-    assert.equal(_loaded.application, this.application);
-    this.runTask(() => this.application.destroy());
-    assert.equal(_loaded.application, undefined);
-  }
-
-  [`@test can build a registry via Application.buildRegistry() --- simulates ember-test-helpers`](assert) {
-    let namespace = EmberObject.create({
-      Resolver: { create: function() { } }
-    });
-
-    let registry = Application.buildRegistry(namespace);
-
-    assert.equal(registry.resolve('application:main'), namespace);
-  }
-
-});
-
-moduleFor('Application#buildRegistry', class extends AbstractTestCase {
-
-  [`@test can build a registry via Application.buildRegistry() --- simulates ember-test-helpers`](assert) {
-    let namespace = EmberObject.create({
-      Resolver: { create() { } }
-    });
-
-    let registry = Application.buildRegistry(namespace);
-
-    assert.equal(registry.resolve('application:main'), namespace);
-  }
-
-});
-
-moduleFor('Application - instance tracking', class extends ApplicationTestCase {
-
-  ['@test tracks built instance'](assert) {
-    let instance = this.application.buildInstance();
-    run(() => {
-      this.application.destroy();
-    });
-
-    assert.ok(instance.isDestroyed, 'instance was destroyed');
-  }
-
-  ['@test tracks built instances'](assert) {
-    let instanceA = this.application.buildInstance();
-    let instanceB = this.application.buildInstance();
-    run(() => {
-      this.application.destroy();
-    });
-
-    assert.ok(instanceA.isDestroyed, 'instanceA was destroyed');
-    assert.ok(instanceB.isDestroyed, 'instanceB was destroyed');
-  }
-});
+);

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -12,340 +12,434 @@ import {
   Namespace
 } from 'ember-runtime';
 import { Route } from 'ember-routing';
-import {
-  Component,
-  Helper,
-  helper as makeHelper,
-} from 'ember-glimmer';
+import { Component, Helper, helper as makeHelper } from 'ember-glimmer';
 import { getDebugFunction, setDebugFunction } from 'ember-debug';
 
-moduleFor('Application Dependency Injection - Integration - default resolver', class extends DefaultResolverApplicationTestCase {
+moduleFor(
+  'Application Dependency Injection - Integration - default resolver',
+  class extends DefaultResolverApplicationTestCase {
+    beforeEach() {
+      this.runTask(() => this.createApplication());
+      return this.visit('/');
+    }
 
-  beforeEach() {
-    this.runTask(() => this.createApplication());
-    return this.visit('/');
-  }
+    get privateRegistry() {
+      return this.application.__registry__;
+    }
 
-  get privateRegistry() {
-    return this.application.__registry__;
-  }
-
-  /*
+    /*
    * This first batch of tests are integration tests against the public
    * applicationInstance API.
    */
 
-  [`@test the default resolver looks up templates in Ember.TEMPLATES`](assert) {
-    let fooTemplate = this.addTemplate('foo', `foo template`);
-    let fooBarTemplate = this.addTemplate('fooBar', `fooBar template`);
-    let fooBarBazTemplate = this.addTemplate('fooBar/baz', `fooBar/baz template`);
+    [`@test the default resolver looks up templates in Ember.TEMPLATES`](
+      assert
+    ) {
+      let fooTemplate = this.addTemplate('foo', `foo template`);
+      let fooBarTemplate = this.addTemplate('fooBar', `fooBar template`);
+      let fooBarBazTemplate = this.addTemplate(
+        'fooBar/baz',
+        `fooBar/baz template`
+      );
 
-    assert.equal(
-      this.applicationInstance.factoryFor('template:foo').class, fooTemplate,
-      'resolves template:foo'
-    );
-    assert.equal(
-      this.applicationInstance.factoryFor('template:fooBar').class, fooBarTemplate,
-      'resolves template:foo_bar'
-    );
-    assert.equal(
-      this.applicationInstance.factoryFor('template:fooBar.baz').class, fooBarBazTemplate,
-      'resolves template:foo_bar.baz'
-    );
-  }
+      assert.equal(
+        this.applicationInstance.factoryFor('template:foo').class,
+        fooTemplate,
+        'resolves template:foo'
+      );
+      assert.equal(
+        this.applicationInstance.factoryFor('template:fooBar').class,
+        fooBarTemplate,
+        'resolves template:foo_bar'
+      );
+      assert.equal(
+        this.applicationInstance.factoryFor('template:fooBar.baz').class,
+        fooBarBazTemplate,
+        'resolves template:foo_bar.baz'
+      );
+    }
 
-  [`@test the default resolver looks up basic name as no prefix`](assert) {
-    let instance = this.applicationInstance.lookup('controller:basic');
-    assert.ok(
-      Controller.detect(instance),
-      'locator looks up correct controller'
-    );
-  }
+    [`@test the default resolver looks up basic name as no prefix`](assert) {
+      let instance = this.applicationInstance.lookup('controller:basic');
+      assert.ok(
+        Controller.detect(instance),
+        'locator looks up correct controller'
+      );
+    }
 
-  [`@test the default resolver looks up arbitrary types on the namespace`](assert) {
-    let Class = this.application.FooManager = EmberObject.extend();
-    let resolvedClass = this.application.resolveRegistration('manager:foo');
-    assert.equal(
-      Class, resolvedClass,
-      'looks up FooManager on application'
-    );
-  }
+    [`@test the default resolver looks up arbitrary types on the namespace`](
+      assert
+    ) {
+      let Class = (this.application.FooManager = EmberObject.extend());
+      let resolvedClass = this.application.resolveRegistration('manager:foo');
+      assert.equal(Class, resolvedClass, 'looks up FooManager on application');
+    }
 
-  [`@test the default resolver resolves models on the namespace`](assert) {
-    let Class = this.application.Post = EmberObject.extend();
-    let factoryClass = this.applicationInstance.factoryFor('model:post').class;
-    assert.equal(
-      Class, factoryClass,
-      'looks up Post model on application'
-    );
-  }
+    [`@test the default resolver resolves models on the namespace`](assert) {
+      let Class = (this.application.Post = EmberObject.extend());
+      let factoryClass = this.applicationInstance.factoryFor('model:post')
+        .class;
+      assert.equal(Class, factoryClass, 'looks up Post model on application');
+    }
 
-  [`@test the default resolver resolves *:main on the namespace`](assert) {
-    let Class = this.application.FooBar = EmberObject.extend();
-    let factoryClass = this.applicationInstance.factoryFor('foo-bar:main').class;
-    assert.equal(
-      Class, factoryClass,
-      'looks up FooBar type without name on application'
-    );
-  }
+    [`@test the default resolver resolves *:main on the namespace`](assert) {
+      let Class = (this.application.FooBar = EmberObject.extend());
+      let factoryClass = this.applicationInstance.factoryFor('foo-bar:main')
+        .class;
+      assert.equal(
+        Class,
+        factoryClass,
+        'looks up FooBar type without name on application'
+      );
+    }
 
-  [`@test the default resolver resolves container-registered helpers`](assert) {
-    let shorthandHelper = makeHelper(() => {});
-    let helper = Helper.extend();
+    [`@test the default resolver resolves container-registered helpers`](
+      assert
+    ) {
+      let shorthandHelper = makeHelper(() => {});
+      let helper = Helper.extend();
 
-    this.application.register('helper:shorthand', shorthandHelper);
-    this.application.register('helper:complete', helper);
+      this.application.register('helper:shorthand', shorthandHelper);
+      this.application.register('helper:complete', helper);
 
-    let lookedUpShorthandHelper = this.applicationInstance.factoryFor('helper:shorthand').class;
+      let lookedUpShorthandHelper = this.applicationInstance.factoryFor(
+        'helper:shorthand'
+      ).class;
 
-    assert.ok(lookedUpShorthandHelper.isHelperFactory, 'shorthand helper isHelper');
+      assert.ok(
+        lookedUpShorthandHelper.isHelperFactory,
+        'shorthand helper isHelper'
+      );
 
-    let lookedUpHelper = this.applicationInstance.factoryFor('helper:complete').class;
+      let lookedUpHelper = this.applicationInstance.factoryFor(
+        'helper:complete'
+      ).class;
 
-    assert.ok(lookedUpHelper.isHelperFactory, 'complete helper is factory');
-    assert.ok(helper.detect(lookedUpHelper), 'looked up complete helper');
-  }
+      assert.ok(lookedUpHelper.isHelperFactory, 'complete helper is factory');
+      assert.ok(helper.detect(lookedUpHelper), 'looked up complete helper');
+    }
 
-  [`@test the default resolver resolves container-registered helpers via lookupFor`](assert) {
-    let shorthandHelper = makeHelper(() => {});
-    let helper = Helper.extend();
+    [`@test the default resolver resolves container-registered helpers via lookupFor`](
+      assert
+    ) {
+      let shorthandHelper = makeHelper(() => {});
+      let helper = Helper.extend();
 
-    this.application.register('helper:shorthand', shorthandHelper);
-    this.application.register('helper:complete', helper);
+      this.application.register('helper:shorthand', shorthandHelper);
+      this.application.register('helper:complete', helper);
 
-    let lookedUpShorthandHelper = this.applicationInstance.factoryFor('helper:shorthand').class;
+      let lookedUpShorthandHelper = this.applicationInstance.factoryFor(
+        'helper:shorthand'
+      ).class;
 
-    assert.ok(lookedUpShorthandHelper.isHelperFactory, 'shorthand helper isHelper');
+      assert.ok(
+        lookedUpShorthandHelper.isHelperFactory,
+        'shorthand helper isHelper'
+      );
 
-    let lookedUpHelper = this.applicationInstance.factoryFor('helper:complete').class;
+      let lookedUpHelper = this.applicationInstance.factoryFor(
+        'helper:complete'
+      ).class;
 
-    assert.ok(lookedUpHelper.isHelperFactory, 'complete helper is factory');
-    assert.ok(helper.detect(lookedUpHelper), 'looked up complete helper');
-  }
+      assert.ok(lookedUpHelper.isHelperFactory, 'complete helper is factory');
+      assert.ok(helper.detect(lookedUpHelper), 'looked up complete helper');
+    }
 
-  [`@test the default resolver resolves helpers on the namespace`](assert) {
-    let ShorthandHelper = makeHelper(() =>  {});
-    let CompleteHelper = Helper.extend();
+    [`@test the default resolver resolves helpers on the namespace`](assert) {
+      let ShorthandHelper = makeHelper(() => {});
+      let CompleteHelper = Helper.extend();
 
-    this.application.ShorthandHelper = ShorthandHelper;
-    this.application.CompleteHelper = CompleteHelper;
+      this.application.ShorthandHelper = ShorthandHelper;
+      this.application.CompleteHelper = CompleteHelper;
 
-    let resolvedShorthand = this.application.resolveRegistration('helper:shorthand');
-    let resolvedComplete = this.application.resolveRegistration('helper:complete');
+      let resolvedShorthand = this.application.resolveRegistration(
+        'helper:shorthand'
+      );
+      let resolvedComplete = this.application.resolveRegistration(
+        'helper:complete'
+      );
 
-    assert.equal(resolvedShorthand, ShorthandHelper, 'resolve fetches the shorthand helper factory');
-    assert.equal(resolvedComplete, CompleteHelper, 'resolve fetches the complete helper factory');
-  }
+      assert.equal(
+        resolvedShorthand,
+        ShorthandHelper,
+        'resolve fetches the shorthand helper factory'
+      );
+      assert.equal(
+        resolvedComplete,
+        CompleteHelper,
+        'resolve fetches the complete helper factory'
+      );
+    }
 
-  [`@test the default resolver resolves to the same instance, no matter the notation `](assert) {
-    this.application.NestedPostController = Controller.extend({});
+    [`@test the default resolver resolves to the same instance, no matter the notation `](
+      assert
+    ) {
+      this.application.NestedPostController = Controller.extend({});
 
-    assert.equal(
-      this.applicationInstance.lookup('controller:nested-post'),
-      this.applicationInstance.lookup('controller:nested_post'),
-      'looks up NestedPost controller on application'
-    );
-  }
+      assert.equal(
+        this.applicationInstance.lookup('controller:nested-post'),
+        this.applicationInstance.lookup('controller:nested_post'),
+        'looks up NestedPost controller on application'
+      );
+    }
 
-  [`@test the default resolver throws an error if the fullName to resolve is invalid`]() {
-    expectAssertion(() => { this.applicationInstance.resolveRegistration(undefined);}, /fullName must be a proper full name/);
-    expectAssertion(() => { this.applicationInstance.resolveRegistration(null);     }, /fullName must be a proper full name/);
-    expectAssertion(() => { this.applicationInstance.resolveRegistration('');       }, /fullName must be a proper full name/);
-    expectAssertion(() => { this.applicationInstance.resolveRegistration('');       }, /fullName must be a proper full name/);
-    expectAssertion(() => { this.applicationInstance.resolveRegistration(':');      }, /fullName must be a proper full name/);
-    expectAssertion(() => { this.applicationInstance.resolveRegistration('model');  }, /fullName must be a proper full name/);
-    expectAssertion(() => { this.applicationInstance.resolveRegistration('model:'); }, /fullName must be a proper full name/);
-    expectAssertion(() => { this.applicationInstance.resolveRegistration(':type');  }, /fullName must be a proper full name/);
-  }
+    [`@test the default resolver throws an error if the fullName to resolve is invalid`]() {
+      expectAssertion(() => {
+        this.applicationInstance.resolveRegistration(undefined);
+      }, /fullName must be a proper full name/);
+      expectAssertion(() => {
+        this.applicationInstance.resolveRegistration(null);
+      }, /fullName must be a proper full name/);
+      expectAssertion(() => {
+        this.applicationInstance.resolveRegistration('');
+      }, /fullName must be a proper full name/);
+      expectAssertion(() => {
+        this.applicationInstance.resolveRegistration('');
+      }, /fullName must be a proper full name/);
+      expectAssertion(() => {
+        this.applicationInstance.resolveRegistration(':');
+      }, /fullName must be a proper full name/);
+      expectAssertion(() => {
+        this.applicationInstance.resolveRegistration('model');
+      }, /fullName must be a proper full name/);
+      expectAssertion(() => {
+        this.applicationInstance.resolveRegistration('model:');
+      }, /fullName must be a proper full name/);
+      expectAssertion(() => {
+        this.applicationInstance.resolveRegistration(':type');
+      }, /fullName must be a proper full name/);
+    }
 
-  /*
+    /*
    * The following are integration tests against the private registry API.
    */
 
-  [`@test lookup description`](assert) {
-    this.application.toString = () => 'App';
+    [`@test lookup description`](assert) {
+      this.application.toString = () => 'App';
 
-    assert.equal(
-      this.privateRegistry.describe('controller:foo'), 'App.FooController',
-      'Type gets appended at the end'
-    );
-    assert.equal(
-      this.privateRegistry.describe('controller:foo.bar'), 'App.FooBarController',
-      'dots are removed'
-    );
-    assert.equal(
-      this.privateRegistry.describe('model:foo'), 'App.Foo',
-      'models don\'t get appended at the end'
-    );
-  }
+      assert.equal(
+        this.privateRegistry.describe('controller:foo'),
+        'App.FooController',
+        'Type gets appended at the end'
+      );
+      assert.equal(
+        this.privateRegistry.describe('controller:foo.bar'),
+        'App.FooBarController',
+        'dots are removed'
+      );
+      assert.equal(
+        this.privateRegistry.describe('model:foo'),
+        'App.Foo',
+        "models don't get appended at the end"
+      );
+    }
 
-  [`@test assertion for routes without isRouteFactory property`]() {
-    this.application.FooRoute = Component.extend();
+    [`@test assertion for routes without isRouteFactory property`]() {
+      this.application.FooRoute = Component.extend();
 
-    expectAssertion(() => {
+      expectAssertion(
+        () => {
+          this.privateRegistry.resolve(`route:foo`);
+        },
+        /to resolve to an Ember.Route/,
+        'Should assert'
+      );
+    }
+
+    [`@test no assertion for routes that extend from Route`](assert) {
+      assert.expect(0);
+      this.application.FooRoute = Route.extend();
       this.privateRegistry.resolve(`route:foo`);
-    }, /to resolve to an Ember.Route/, 'Should assert');
-  }
+    }
 
-  [`@test no assertion for routes that extend from Route`](assert) {
-    assert.expect(0);
-    this.application.FooRoute = Route.extend();
-    this.privateRegistry.resolve(`route:foo`);
-  }
+    [`@test deprecation warning for service factories without isServiceFactory property`]() {
+      expectAssertion(() => {
+        this.application.FooService = EmberObject.extend();
+        this.privateRegistry.resolve('service:foo');
+      }, /Expected service:foo to resolve to an Ember.Service but instead it was \.FooService\./);
+    }
 
-  [`@test deprecation warning for service factories without isServiceFactory property`]() {
-    expectAssertion(() =>{
-      this.application.FooService = EmberObject.extend();
+    [`@test no deprecation warning for service factories that extend from Service`](
+      assert
+    ) {
+      assert.expect(0);
+      this.application.FooService = Service.extend();
       this.privateRegistry.resolve('service:foo');
-    }, /Expected service:foo to resolve to an Ember.Service but instead it was \.FooService\./);
-  }
+    }
 
-  [`@test no deprecation warning for service factories that extend from Service`](assert) {
-    assert.expect(0);
-    this.application.FooService = Service.extend();
-    this.privateRegistry.resolve('service:foo');
-  }
+    [`@test deprecation warning for component factories without isComponentFactory property`]() {
+      expectAssertion(() => {
+        this.application.FooComponent = EmberObject.extend();
+        this.privateRegistry.resolve('component:foo');
+      }, /Expected component:foo to resolve to an Ember\.Component but instead it was \.FooComponent\./);
+    }
 
-  [`@test deprecation warning for component factories without isComponentFactory property`]() {
-    expectAssertion(() => {
-      this.application.FooComponent = EmberObject.extend();
+    [`@test no deprecation warning for component factories that extend from Component`]() {
+      expectNoDeprecation();
+      this.application.FooView = Component.extend();
       this.privateRegistry.resolve('component:foo');
-    }, /Expected component:foo to resolve to an Ember\.Component but instead it was \.FooComponent\./);
-  }
+    }
 
-  [`@test no deprecation warning for component factories that extend from Component`]() {
-    expectNoDeprecation();
-    this.application.FooView = Component.extend();
-    this.privateRegistry.resolve('component:foo');
-  }
+    [`@test knownForType returns each item for a given type found`](assert) {
+      this.application.FooBarHelper = 'foo';
+      this.application.BazQuxHelper = 'bar';
 
-  [`@test knownForType returns each item for a given type found`](assert) {
-    this.application.FooBarHelper = 'foo';
-    this.application.BazQuxHelper = 'bar';
+      let found = this.privateRegistry.resolver.knownForType('helper');
 
-    let found = this.privateRegistry.resolver.knownForType('helper');
-
-    assert.deepEqual(found, {
-      'helper:foo-bar': true,
-      'helper:baz-qux': true
-    });
-  }
-
-  [`@test knownForType is not required to be present on the resolver`](assert) {
-    delete this.privateRegistry.resolver.knownForType;
-
-    this.privateRegistry.resolver.knownForType('helper', () => { });
-
-    assert.ok(true, 'does not error');
-  }
-
-});
-
-moduleFor('Application Dependency Injection - Integration - default resolver w/ other namespace', class extends DefaultResolverApplicationTestCase {
-
-  beforeEach() {
-    this.UserInterface = context.lookup.UserInterface = Namespace.create();
-    this.runTask(() => this.createApplication());
-    return this.visit('/');
-  }
-
-  teardown() {
-    let UserInterfaceNamespace = Namespace.NAMESPACES_BY_ID['UserInterface'];
-    if (UserInterfaceNamespace) {
-      this.runTask(() => {
-        UserInterfaceNamespace.destroy();
+      assert.deepEqual(found, {
+        'helper:foo-bar': true,
+        'helper:baz-qux': true
       });
     }
-    super.teardown();
+
+    [`@test knownForType is not required to be present on the resolver`](
+      assert
+    ) {
+      delete this.privateRegistry.resolver.knownForType;
+
+      this.privateRegistry.resolver.knownForType('helper', () => {});
+
+      assert.ok(true, 'does not error');
+    }
   }
+);
 
-  [`@test the default resolver can look things up in other namespaces`](assert) {
-    this.UserInterface.NavigationController = Controller.extend();
-
-    let nav = this.applicationInstance.lookup('controller:userInterface/navigation');
-
-    assert.ok(
-      nav instanceof this.UserInterface.NavigationController,
-      'the result should be an instance of the specified class'
-    );
-  }
-});
-
-moduleFor('Application Dependency Injection - Integration - default resolver', class extends DefaultResolverApplicationTestCase {
-
-  constructor() {
-    super();
-    this._originalLookup = context.lookup;
-    this._originalInfo = getDebugFunction('info');
-  }
-
-  beforeEach() {
-    this.runTask(() => this.createApplication());
-    return this.visit('/');
-  }
-
-  teardown() {
-    setDebugFunction('info', this._originalInfo);
-    context.lookup = this._originalLookup;
-    super.teardown();
-  }
-
-  [`@test the default resolver logs hits if 'LOG_RESOLVER' is set`](assert) {
-    if (EmberDev && EmberDev.runningProdBuild) {
-      assert.ok(true, 'Logging does not occur in production builds');
-      return;
+moduleFor(
+  'Application Dependency Injection - Integration - default resolver w/ other namespace',
+  class extends DefaultResolverApplicationTestCase {
+    beforeEach() {
+      this.UserInterface = context.lookup.UserInterface = Namespace.create();
+      this.runTask(() => this.createApplication());
+      return this.visit('/');
     }
 
-    assert.expect(3);
-
-    this.application.LOG_RESOLVER = true;
-    this.application.ScoobyDoo = EmberObject.extend();
-    this.application.toString = () => 'App';
-
-    setDebugFunction('info', function(symbol, name, padding, lookupDescription) {
-      assert.equal(symbol, '[✓]', 'proper symbol is printed when a module is found');
-      assert.equal(name, 'doo:scooby', 'proper lookup value is logged');
-      assert.equal(lookupDescription, 'App.ScoobyDoo');
-    });
-
-    this.applicationInstance.resolveRegistration('doo:scooby');
-  }
-
-  [`@test the default resolver logs misses if 'LOG_RESOLVER' is set`](assert) {
-    if (EmberDev && EmberDev.runningProdBuild) {
-      assert.ok(true, 'Logging does not occur in production builds');
-      return;
+    teardown() {
+      let UserInterfaceNamespace = Namespace.NAMESPACES_BY_ID['UserInterface'];
+      if (UserInterfaceNamespace) {
+        this.runTask(() => {
+          UserInterfaceNamespace.destroy();
+        });
+      }
+      super.teardown();
     }
 
-    assert.expect(3);
+    [`@test the default resolver can look things up in other namespaces`](
+      assert
+    ) {
+      this.UserInterface.NavigationController = Controller.extend();
 
-    this.application.LOG_RESOLVER = true;
-    this.application.toString = () => 'App';
+      let nav = this.applicationInstance.lookup(
+        'controller:userInterface/navigation'
+      );
 
-    setDebugFunction('info', function(symbol, name, padding, lookupDescription) {
-      assert.equal(symbol, '[ ]', 'proper symbol is printed when a module is not found');
-      assert.equal(name, 'doo:scooby', 'proper lookup value is logged');
-      assert.equal(lookupDescription, 'App.ScoobyDoo');
-    });
-
-    this.applicationInstance.resolveRegistration('doo:scooby');
+      assert.ok(
+        nav instanceof this.UserInterface.NavigationController,
+        'the result should be an instance of the specified class'
+      );
+    }
   }
+);
 
-  [`@test doesn't log without LOG_RESOLVER`](assert) {
-    if (EmberDev && EmberDev.runningProdBuild) {
-      assert.ok(true, 'Logging does not occur in production builds');
-      return;
+moduleFor(
+  'Application Dependency Injection - Integration - default resolver',
+  class extends DefaultResolverApplicationTestCase {
+    constructor() {
+      super();
+      this._originalLookup = context.lookup;
+      this._originalInfo = getDebugFunction('info');
     }
 
-    let infoCount = 0;
+    beforeEach() {
+      this.runTask(() => this.createApplication());
+      return this.visit('/');
+    }
 
-    this.application.ScoobyDoo = EmberObject.extend();
+    teardown() {
+      setDebugFunction('info', this._originalInfo);
+      context.lookup = this._originalLookup;
+      super.teardown();
+    }
 
-    setDebugFunction('info', () => infoCount = infoCount + 1);
+    [`@test the default resolver logs hits if 'LOG_RESOLVER' is set`](assert) {
+      if (EmberDev && EmberDev.runningProdBuild) {
+        assert.ok(true, 'Logging does not occur in production builds');
+        return;
+      }
 
-    this.applicationInstance.resolveRegistration('doo:scooby');
-    this.applicationInstance.resolveRegistration('doo:scrappy');
-    assert.equal(infoCount, 0, 'console.info should not be called if LOG_RESOLVER is not set');
+      assert.expect(3);
+
+      this.application.LOG_RESOLVER = true;
+      this.application.ScoobyDoo = EmberObject.extend();
+      this.application.toString = () => 'App';
+
+      setDebugFunction('info', function(
+        symbol,
+        name,
+        padding,
+        lookupDescription
+      ) {
+        assert.equal(
+          symbol,
+          '[✓]',
+          'proper symbol is printed when a module is found'
+        );
+        assert.equal(name, 'doo:scooby', 'proper lookup value is logged');
+        assert.equal(lookupDescription, 'App.ScoobyDoo');
+      });
+
+      this.applicationInstance.resolveRegistration('doo:scooby');
+    }
+
+    [`@test the default resolver logs misses if 'LOG_RESOLVER' is set`](
+      assert
+    ) {
+      if (EmberDev && EmberDev.runningProdBuild) {
+        assert.ok(true, 'Logging does not occur in production builds');
+        return;
+      }
+
+      assert.expect(3);
+
+      this.application.LOG_RESOLVER = true;
+      this.application.toString = () => 'App';
+
+      setDebugFunction('info', function(
+        symbol,
+        name,
+        padding,
+        lookupDescription
+      ) {
+        assert.equal(
+          symbol,
+          '[ ]',
+          'proper symbol is printed when a module is not found'
+        );
+        assert.equal(name, 'doo:scooby', 'proper lookup value is logged');
+        assert.equal(lookupDescription, 'App.ScoobyDoo');
+      });
+
+      this.applicationInstance.resolveRegistration('doo:scooby');
+    }
+
+    [`@test doesn't log without LOG_RESOLVER`](assert) {
+      if (EmberDev && EmberDev.runningProdBuild) {
+        assert.ok(true, 'Logging does not occur in production builds');
+        return;
+      }
+
+      let infoCount = 0;
+
+      this.application.ScoobyDoo = EmberObject.extend();
+
+      setDebugFunction('info', () => (infoCount = infoCount + 1));
+
+      this.applicationInstance.resolveRegistration('doo:scooby');
+      this.applicationInstance.resolveRegistration('doo:scrappy');
+      assert.equal(
+        infoCount,
+        0,
+        'console.info should not be called if LOG_RESOLVER is not set'
+      );
+    }
   }
-
-});
+);

--- a/packages/ember-extension-support/lib/container_debug_adapter.js
+++ b/packages/ember-extension-support/lib/container_debug_adapter.js
@@ -88,7 +88,9 @@ export default EmberObject.extend({
 
     namespaces.forEach(namespace => {
       for (let key in namespace) {
-        if (!namespace.hasOwnProperty(key)) { continue; }
+        if (!namespace.hasOwnProperty(key)) {
+          continue;
+        }
         if (typeSuffixRegex.test(key)) {
           let klass = namespace[key];
           if (typeOf(klass) === 'class') {

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -1,12 +1,5 @@
 /* globals EmberDev */
-import {
-  set,
-  get,
-  observer,
-  on,
-  computed,
-  run
-} from 'ember-metal';
+import { set, get, observer, on, computed, run } from 'ember-metal';
 import {
   Object as EmberObject,
   A as emberA,
@@ -24,718 +17,943 @@ import {
   equalsElement,
   styles
 } from '../../utils/test-helpers';
-import {
-  MANDATORY_SETTER
-} from 'ember/features';
+import { MANDATORY_SETTER } from 'ember/features';
 
-moduleFor('Components test: curly components', class extends RenderingTest {
-  constructor() {
-    super();
-    this.originalDidInitAttrsSupport = ENV._ENABLE_DID_INIT_ATTRS_SUPPORT;
-  }
-
-  teardown() {
-    ENV._ENABLE_DID_INIT_ATTRS_SUPPORT = this.originalDidInitAttrsSupport;
-    super.teardown();
-  }
-
-  ['@test it can render a basic component']() {
-    this.registerComponent('foo-bar', { template: 'hello' });
-
-    this.render('{{foo-bar}}');
-
-    this.assertComponentElement(this.firstChild, { content: 'hello' });
-
-    this.runTask(() => this.rerender());
-
-    this.assertComponentElement(this.firstChild, { content: 'hello' });
-  }
-
-  ['@test it can have a custom id and it is not bound']() {
-    this.registerComponent('foo-bar', { template: '{{id}} {{elementId}}' });
-
-    this.render('{{foo-bar id=customId}}', {
-      customId: 'bizz'
-    });
-
-    this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { id: 'bizz' }, content: 'bizz bizz' });
-
-    this.runTask(() => this.rerender());
-
-    this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { id: 'bizz' }, content: 'bizz bizz' });
-
-    this.runTask(() => set(this.context, 'customId', 'bar'));
-
-    this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { id: 'bizz' }, content: 'bar bizz' });
-
-    this.runTask(() => set(this.context, 'customId', 'bizz'));
-
-    this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { id: 'bizz' }, content: 'bizz bizz' });
-  }
-
-  ['@test elementId cannot change'](assert) {
-    let component;
-    let FooBarComponent = Component.extend({
-      elementId: 'blahzorz',
-      init() {
-        this._super(...arguments);
-        component = this;
-      }
-    });
-
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: '{{elementId}}' });
-
-    this.render('{{foo-bar}}');
-
-    this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { id: 'blahzorz' }, content: 'blahzorz' });
-
-    if (EmberDev && !EmberDev.runningProdBuild) {
-      let willThrow = () => run(null, set, component, 'elementId', 'herpyderpy');
-
-      assert.throws(willThrow, /Changing a view's elementId after creation is not allowed/);
-
-      this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { id: 'blahzorz' }, content: 'blahzorz' });
+moduleFor(
+  'Components test: curly components',
+  class extends RenderingTest {
+    constructor() {
+      super();
+      this.originalDidInitAttrsSupport = ENV._ENABLE_DID_INIT_ATTRS_SUPPORT;
     }
-  }
 
-  ['@test can specify template with `layoutName` property']() {
-    let FooBarComponent = Component.extend({
-      elementId: 'blahzorz',
-      layoutName: 'fizz-bar',
-      init() {
-        this._super(...arguments);
-        this.local = 'hey';
-      }
-    });
+    teardown() {
+      ENV._ENABLE_DID_INIT_ATTRS_SUPPORT = this.originalDidInitAttrsSupport;
+      super.teardown();
+    }
 
-    this.registerTemplate('fizz-bar', `FIZZ BAR {{local}}`);
+    ['@test it can render a basic component']() {
+      this.registerComponent('foo-bar', { template: 'hello' });
 
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent });
-
-    this.render('{{foo-bar}}');
-
-    this.assertText('FIZZ BAR hey');
-  }
-
-  ['@test layout supports computed property']() {
-    let FooBarComponent = Component.extend({
-      elementId: 'blahzorz',
-      layout: computed(function () {
-        return compile('so much layout wat {{lulz}}');
-      }),
-      init() {
-        this._super(...arguments);
-        this.lulz = 'heyo';
-      }
-    });
-
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent });
-
-    this.render('{{foo-bar}}');
-
-    this.assertText('so much layout wat heyo');
-  }
-
-  ['@test passing undefined elementId results in a default elementId'](assert) {
-    let FooBarComponent = Component.extend({
-      tagName: 'h1'
-    });
-
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: 'something' });
-
-    this.render('{{foo-bar id=somethingUndefined}}');
-
-    let foundId = this.$('h1').attr('id');
-    assert.ok(/^ember/.test(foundId), 'Has a reasonable id attribute (found id=' + foundId + ').');
-
-    this.runTask(() => this.rerender());
-
-    let newFoundId = this.$('h1').attr('id');
-    assert.ok(/^ember/.test(newFoundId), 'Has a reasonable id attribute (found id=' + newFoundId + ').');
-
-    assert.equal(foundId, newFoundId);
-  }
-
-  ['@test id is an alias for elementId'](assert) {
-    let FooBarComponent = Component.extend({
-      tagName: 'h1'
-    });
-
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: 'something' });
-
-    this.render('{{foo-bar id="custom-id"}}');
-
-    let foundId = this.$('h1').attr('id');
-    assert.equal(foundId, 'custom-id');
-
-    this.runTask(() => this.rerender());
-
-    let newFoundId = this.$('h1').attr('id');
-    assert.equal(newFoundId, 'custom-id');
-
-    assert.equal(foundId, newFoundId);
-  }
-
-  ['@test cannot pass both id and elementId at the same time']() {
-    this.registerComponent('foo-bar', { template: '' });
-
-    expectAssertion(() => {
-      this.render('{{foo-bar id="zomg" elementId="lol"}}');
-    }, /You cannot invoke a component with both 'id' and 'elementId' at the same time./);
-  }
-
-  ['@test it can have a custom tagName']() {
-    let FooBarComponent = Component.extend({
-      tagName: 'foo-bar'
-    });
-
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: 'hello' });
-
-    this.render('{{foo-bar}}');
-
-    this.assertComponentElement(this.firstChild, { tagName: 'foo-bar', content: 'hello' });
-
-    this.runTask(() => this.rerender());
-
-    this.assertComponentElement(this.firstChild, { tagName: 'foo-bar', content: 'hello' });
-  }
-
-  ['@test it can have a custom tagName set in the constructor']() {
-    let FooBarComponent = Component.extend({
-      init() {
-        this._super();
-        this.tagName = 'foo-bar';
-      }
-    });
-
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: 'hello' });
-
-    this.render('{{foo-bar}}');
-
-    this.assertComponentElement(this.firstChild, { tagName: 'foo-bar', content: 'hello' });
-
-    this.runTask(() => this.rerender());
-
-    this.assertComponentElement(this.firstChild, { tagName: 'foo-bar', content: 'hello' });
-  }
-
-  ['@test it can have a custom tagName from the invocation']() {
-    this.registerComponent('foo-bar', { template: 'hello' });
-
-    this.render('{{foo-bar tagName="foo-bar"}}');
-
-    this.assertComponentElement(this.firstChild, { tagName: 'foo-bar', content: 'hello' });
-
-    this.runTask(() => this.rerender());
-
-    this.assertComponentElement(this.firstChild, { tagName: 'foo-bar', content: 'hello' });
-  }
-
-  ['@test tagName can not be a computed property']() {
-    let FooBarComponent = Component.extend({
-      tagName: computed(function() {
-        return 'foo-bar';
-      })
-    });
-
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: 'hello' });
-
-    expectAssertion(() => {
       this.render('{{foo-bar}}');
-    }, /You cannot use a computed property for the component's `tagName` \(<\(.+>\)\./);
-  }
 
-  ['@test class is applied before didInsertElement'](assert) {
-    let componentClass;
-    let FooBarComponent = Component.extend({
-      didInsertElement() {
-        componentClass = this.element.className;
+      this.assertComponentElement(this.firstChild, { content: 'hello' });
+
+      this.runTask(() => this.rerender());
+
+      this.assertComponentElement(this.firstChild, { content: 'hello' });
+    }
+
+    ['@test it can have a custom id and it is not bound']() {
+      this.registerComponent('foo-bar', { template: '{{id}} {{elementId}}' });
+
+      this.render('{{foo-bar id=customId}}', {
+        customId: 'bizz'
+      });
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'div',
+        attrs: { id: 'bizz' },
+        content: 'bizz bizz'
+      });
+
+      this.runTask(() => this.rerender());
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'div',
+        attrs: { id: 'bizz' },
+        content: 'bizz bizz'
+      });
+
+      this.runTask(() => set(this.context, 'customId', 'bar'));
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'div',
+        attrs: { id: 'bizz' },
+        content: 'bar bizz'
+      });
+
+      this.runTask(() => set(this.context, 'customId', 'bizz'));
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'div',
+        attrs: { id: 'bizz' },
+        content: 'bizz bizz'
+      });
+    }
+
+    ['@test elementId cannot change'](assert) {
+      let component;
+      let FooBarComponent = Component.extend({
+        elementId: 'blahzorz',
+        init() {
+          this._super(...arguments);
+          component = this;
+        }
+      });
+
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
+        template: '{{elementId}}'
+      });
+
+      this.render('{{foo-bar}}');
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'div',
+        attrs: { id: 'blahzorz' },
+        content: 'blahzorz'
+      });
+
+      if (EmberDev && !EmberDev.runningProdBuild) {
+        let willThrow = () =>
+          run(null, set, component, 'elementId', 'herpyderpy');
+
+        assert.throws(
+          willThrow,
+          /Changing a view's elementId after creation is not allowed/
+        );
+
+        this.assertComponentElement(this.firstChild, {
+          tagName: 'div',
+          attrs: { id: 'blahzorz' },
+          content: 'blahzorz'
+        });
       }
-    });
+    }
 
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: 'hello' });
+    ['@test can specify template with `layoutName` property']() {
+      let FooBarComponent = Component.extend({
+        elementId: 'blahzorz',
+        layoutName: 'fizz-bar',
+        init() {
+          this._super(...arguments);
+          this.local = 'hey';
+        }
+      });
 
-    this.render('{{foo-bar class="foo-bar"}}');
+      this.registerTemplate('fizz-bar', `FIZZ BAR {{local}}`);
 
-    assert.equal(componentClass, 'foo-bar ember-view');
-  }
+      this.registerComponent('foo-bar', { ComponentClass: FooBarComponent });
 
-  ['@test it can have custom classNames']() {
-    let FooBarComponent = Component.extend({
-      classNames: ['foo', 'bar']
-    });
+      this.render('{{foo-bar}}');
 
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: 'hello' });
+      this.assertText('FIZZ BAR hey');
+    }
 
-    this.render('{{foo-bar}}');
+    ['@test layout supports computed property']() {
+      let FooBarComponent = Component.extend({
+        elementId: 'blahzorz',
+        layout: computed(function() {
+          return compile('so much layout wat {{lulz}}');
+        }),
+        init() {
+          this._super(...arguments);
+          this.lulz = 'heyo';
+        }
+      });
 
-    this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { 'class': classes('ember-view foo bar') }, content: 'hello' });
+      this.registerComponent('foo-bar', { ComponentClass: FooBarComponent });
 
-    this.runTask(() => this.rerender());
+      this.render('{{foo-bar}}');
 
-    this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { 'class': classes('ember-view foo bar') }, content: 'hello' });
-  }
+      this.assertText('so much layout wat heyo');
+    }
 
-  ['@test should not apply falsy class name']() {
-    this.registerComponent('foo-bar', { template: 'hello' });
+    ['@test passing undefined elementId results in a default elementId'](
+      assert
+    ) {
+      let FooBarComponent = Component.extend({
+        tagName: 'h1'
+      });
 
-    this.render('{{foo-bar class=somethingFalsy}}', {
-      somethingFalsy: false
-    });
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
+        template: 'something'
+      });
 
-    this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { class: 'ember-view' }, content: 'hello' });
+      this.render('{{foo-bar id=somethingUndefined}}');
 
-    this.runTask(() => this.rerender());
+      let foundId = this.$('h1').attr('id');
+      assert.ok(
+        /^ember/.test(foundId),
+        'Has a reasonable id attribute (found id=' + foundId + ').'
+      );
 
-    this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { class: 'ember-view' }, content: 'hello' });
-  }
+      this.runTask(() => this.rerender());
 
-  ['@test should apply classes of the dasherized property name when bound property specified is true']() {
-    this.registerComponent('foo-bar', { template: 'hello' });
+      let newFoundId = this.$('h1').attr('id');
+      assert.ok(
+        /^ember/.test(newFoundId),
+        'Has a reasonable id attribute (found id=' + newFoundId + ').'
+      );
 
-    this.render('{{foo-bar class=model.someTruth}}', {
-      model: { someTruth: true }
-    });
+      assert.equal(foundId, newFoundId);
+    }
 
-    this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { class: classes('ember-view some-truth') }, content: 'hello' });
+    ['@test id is an alias for elementId'](assert) {
+      let FooBarComponent = Component.extend({
+        tagName: 'h1'
+      });
 
-    this.runTask(() => this.rerender());
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
+        template: 'something'
+      });
 
-    this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { class: classes('ember-view some-truth') }, content: 'hello' });
+      this.render('{{foo-bar id="custom-id"}}');
 
-    this.runTask(() => set(this.context, 'model.someTruth', false));
+      let foundId = this.$('h1').attr('id');
+      assert.equal(foundId, 'custom-id');
 
-    this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { class: classes('ember-view') }, content: 'hello' });
+      this.runTask(() => this.rerender());
 
-    this.runTask(() => set(this.context, 'model', { someTruth: true }));
+      let newFoundId = this.$('h1').attr('id');
+      assert.equal(newFoundId, 'custom-id');
 
-    this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { class: classes('ember-view some-truth') }, content: 'hello' });
-  }
+      assert.equal(foundId, newFoundId);
+    }
 
-  ['@test class property on components can be dynamic']() {
-    this.registerComponent('foo-bar', { template: 'hello' });
+    ['@test cannot pass both id and elementId at the same time']() {
+      this.registerComponent('foo-bar', { template: '' });
 
-    this.render('{{foo-bar class=(if fooBar "foo-bar")}}', {
-      fooBar: true
-    });
+      expectAssertion(() => {
+        this.render('{{foo-bar id="zomg" elementId="lol"}}');
+      }, /You cannot invoke a component with both 'id' and 'elementId' at the same time./);
+    }
 
-    this.assertComponentElement(this.firstChild, { content: 'hello', attrs: { 'class': classes('ember-view foo-bar') } });
+    ['@test it can have a custom tagName']() {
+      let FooBarComponent = Component.extend({
+        tagName: 'foo-bar'
+      });
 
-    this.runTask(() => this.rerender());
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
+        template: 'hello'
+      });
 
-    this.assertComponentElement(this.firstChild, { content: 'hello', attrs: { 'class': classes('ember-view foo-bar') } });
+      this.render('{{foo-bar}}');
 
-    this.runTask(() => set(this.context, 'fooBar', false));
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'foo-bar',
+        content: 'hello'
+      });
 
-    this.assertComponentElement(this.firstChild, { content: 'hello', attrs: { 'class': classes('ember-view') } });
+      this.runTask(() => this.rerender());
 
-    this.runTask(() => set(this.context, 'fooBar', true));
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'foo-bar',
+        content: 'hello'
+      });
+    }
 
-    this.assertComponentElement(this.firstChild, { content: 'hello', attrs: { 'class': classes('ember-view foo-bar') } });
-  }
+    ['@test it can have a custom tagName set in the constructor']() {
+      let FooBarComponent = Component.extend({
+        init() {
+          this._super();
+          this.tagName = 'foo-bar';
+        }
+      });
 
-  ['@test it can have custom classNames from constructor']() {
-    let FooBarComponent = Component.extend({
-      init() {
-        this._super();
-        this.classNames = this.classNames.slice();
-        this.classNames.push('foo', 'bar', `outside-${this.get('extraClass')}`);
-      }
-    });
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
+        template: 'hello'
+      });
 
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: 'hello' });
+      this.render('{{foo-bar}}');
 
-    this.render('{{foo-bar extraClass="baz"}}');
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'foo-bar',
+        content: 'hello'
+      });
 
-    this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { 'class': classes('ember-view foo bar outside-baz') }, content: 'hello' });
+      this.runTask(() => this.rerender());
 
-    this.runTask(() => this.rerender());
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'foo-bar',
+        content: 'hello'
+      });
+    }
 
-    this.assertComponentElement(this.firstChild, { tagName: 'div', attrs: { 'class': classes('ember-view foo bar outside-baz') }, content: 'hello' });
-  }
+    ['@test it can have a custom tagName from the invocation']() {
+      this.registerComponent('foo-bar', { template: 'hello' });
 
-  ['@test it can set custom classNames from the invocation']() {
-    let FooBarComponent = Component.extend({
-      classNames: ['foo']
-    });
+      this.render('{{foo-bar tagName="foo-bar"}}');
 
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: 'hello' });
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'foo-bar',
+        content: 'hello'
+      });
 
-    this.render(strip`
+      this.runTask(() => this.rerender());
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'foo-bar',
+        content: 'hello'
+      });
+    }
+
+    ['@test tagName can not be a computed property']() {
+      let FooBarComponent = Component.extend({
+        tagName: computed(function() {
+          return 'foo-bar';
+        })
+      });
+
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
+        template: 'hello'
+      });
+
+      expectAssertion(() => {
+        this.render('{{foo-bar}}');
+      }, /You cannot use a computed property for the component's `tagName` \(<.+?>\)\./);
+    }
+
+    ['@test class is applied before didInsertElement'](assert) {
+      let componentClass;
+      let FooBarComponent = Component.extend({
+        didInsertElement() {
+          componentClass = this.element.className;
+        }
+      });
+
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
+        template: 'hello'
+      });
+
+      this.render('{{foo-bar class="foo-bar"}}');
+
+      assert.equal(componentClass, 'foo-bar ember-view');
+    }
+
+    ['@test it can have custom classNames']() {
+      let FooBarComponent = Component.extend({
+        classNames: ['foo', 'bar']
+      });
+
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
+        template: 'hello'
+      });
+
+      this.render('{{foo-bar}}');
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'div',
+        attrs: { class: classes('ember-view foo bar') },
+        content: 'hello'
+      });
+
+      this.runTask(() => this.rerender());
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'div',
+        attrs: { class: classes('ember-view foo bar') },
+        content: 'hello'
+      });
+    }
+
+    ['@test should not apply falsy class name']() {
+      this.registerComponent('foo-bar', { template: 'hello' });
+
+      this.render('{{foo-bar class=somethingFalsy}}', {
+        somethingFalsy: false
+      });
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'div',
+        attrs: { class: 'ember-view' },
+        content: 'hello'
+      });
+
+      this.runTask(() => this.rerender());
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'div',
+        attrs: { class: 'ember-view' },
+        content: 'hello'
+      });
+    }
+
+    ['@test should apply classes of the dasherized property name when bound property specified is true']() {
+      this.registerComponent('foo-bar', { template: 'hello' });
+
+      this.render('{{foo-bar class=model.someTruth}}', {
+        model: { someTruth: true }
+      });
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'div',
+        attrs: { class: classes('ember-view some-truth') },
+        content: 'hello'
+      });
+
+      this.runTask(() => this.rerender());
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'div',
+        attrs: { class: classes('ember-view some-truth') },
+        content: 'hello'
+      });
+
+      this.runTask(() => set(this.context, 'model.someTruth', false));
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'div',
+        attrs: { class: classes('ember-view') },
+        content: 'hello'
+      });
+
+      this.runTask(() => set(this.context, 'model', { someTruth: true }));
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'div',
+        attrs: { class: classes('ember-view some-truth') },
+        content: 'hello'
+      });
+    }
+
+    ['@test class property on components can be dynamic']() {
+      this.registerComponent('foo-bar', { template: 'hello' });
+
+      this.render('{{foo-bar class=(if fooBar "foo-bar")}}', {
+        fooBar: true
+      });
+
+      this.assertComponentElement(this.firstChild, {
+        content: 'hello',
+        attrs: { class: classes('ember-view foo-bar') }
+      });
+
+      this.runTask(() => this.rerender());
+
+      this.assertComponentElement(this.firstChild, {
+        content: 'hello',
+        attrs: { class: classes('ember-view foo-bar') }
+      });
+
+      this.runTask(() => set(this.context, 'fooBar', false));
+
+      this.assertComponentElement(this.firstChild, {
+        content: 'hello',
+        attrs: { class: classes('ember-view') }
+      });
+
+      this.runTask(() => set(this.context, 'fooBar', true));
+
+      this.assertComponentElement(this.firstChild, {
+        content: 'hello',
+        attrs: { class: classes('ember-view foo-bar') }
+      });
+    }
+
+    ['@test it can have custom classNames from constructor']() {
+      let FooBarComponent = Component.extend({
+        init() {
+          this._super();
+          this.classNames = this.classNames.slice();
+          this.classNames.push(
+            'foo',
+            'bar',
+            `outside-${this.get('extraClass')}`
+          );
+        }
+      });
+
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
+        template: 'hello'
+      });
+
+      this.render('{{foo-bar extraClass="baz"}}');
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'div',
+        attrs: { class: classes('ember-view foo bar outside-baz') },
+        content: 'hello'
+      });
+
+      this.runTask(() => this.rerender());
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'div',
+        attrs: { class: classes('ember-view foo bar outside-baz') },
+        content: 'hello'
+      });
+    }
+
+    ['@test it can set custom classNames from the invocation']() {
+      let FooBarComponent = Component.extend({
+        classNames: ['foo']
+      });
+
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
+        template: 'hello'
+      });
+
+      this.render(strip`
       {{foo-bar class="bar baz"}}
       {{foo-bar classNames="bar baz"}}
       {{foo-bar}}
     `);
 
-    this.assertComponentElement(this.nthChild(0), { tagName: 'div', attrs: { 'class': classes('ember-view foo bar baz') }, content: 'hello' });
-    this.assertComponentElement(this.nthChild(1), { tagName: 'div', attrs: { 'class': classes('ember-view foo bar baz') }, content: 'hello' });
-    this.assertComponentElement(this.nthChild(2), { tagName: 'div', attrs: { 'class': classes('ember-view foo') }, content: 'hello' });
-
-    this.runTask(() => this.rerender());
-
-    this.assertComponentElement(this.nthChild(0), { tagName: 'div', attrs: { 'class': classes('ember-view foo bar baz') }, content: 'hello' });
-    this.assertComponentElement(this.nthChild(1), { tagName: 'div', attrs: { 'class': classes('ember-view foo bar baz') }, content: 'hello' });
-    this.assertComponentElement(this.nthChild(2), { tagName: 'div', attrs: { 'class': classes('ember-view foo') }, content: 'hello' });
-  }
-
-  ['@test it has an element']() {
-    let instance;
-
-    let FooBarComponent = Component.extend({
-      init() {
-        this._super();
-        instance = this;
-      }
-    });
-
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: 'hello' });
-
-    this.render('{{foo-bar}}');
-
-    let element1 = instance.element;
-
-    this.assertComponentElement(element1, { content: 'hello' });
-
-    this.runTask(() => this.rerender());
-
-    let element2 = instance.element;
-
-    this.assertComponentElement(element2, { content: 'hello' });
-
-    this.assertSameNode(element2, element1);
-  }
-
-  ['@test an empty component does not have childNodes'](assert) {
-    let fooBarInstance;
-    let FooBarComponent = Component.extend({
-      tagName: 'input',
-      init() {
-        this._super();
-        fooBarInstance = this;
-      }
-    });
-
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: '' });
-
-    this.render('{{foo-bar}}');
-
-    this.assertComponentElement(this.firstChild, { tagName: 'input' });
-
-    assert.strictEqual(fooBarInstance.element.childNodes.length, 0);
-
-    this.runTask(() => this.rerender());
-
-    this.assertComponentElement(this.firstChild, { tagName: 'input' });
-
-    assert.strictEqual(fooBarInstance.element.childNodes.length, 0);
-  }
-
-  ['@test it has the right parentView and childViews'](assert) {
-    let fooBarInstance, fooBarBazInstance;
-
-    let FooBarComponent = Component.extend({
-      init() {
-        this._super();
-        fooBarInstance = this;
-      }
-    });
-
-    let FooBarBazComponent = Component.extend({
-      init() {
-        this._super();
-        fooBarBazInstance = this;
-      }
-    });
-
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: 'foo-bar {{foo-bar-baz}}' });
-    this.registerComponent('foo-bar-baz', { ComponentClass: FooBarBazComponent, template: 'foo-bar-baz' });
-
-    this.render('{{foo-bar}}');
-    this.assertText('foo-bar foo-bar-baz');
-
-    assert.equal(fooBarInstance.parentView, this.component);
-    assert.equal(fooBarBazInstance.parentView, fooBarInstance);
-
-    assert.deepEqual(this.component.childViews, [fooBarInstance]);
-    assert.deepEqual(fooBarInstance.childViews, [fooBarBazInstance]);
-
-    this.runTask(() => this.rerender());
-    this.assertText('foo-bar foo-bar-baz');
-
-    assert.equal(fooBarInstance.parentView, this.component);
-    assert.equal(fooBarBazInstance.parentView, fooBarInstance);
-
-    assert.deepEqual(this.component.childViews, [fooBarInstance]);
-    assert.deepEqual(fooBarInstance.childViews, [fooBarBazInstance]);
-  }
-
-  ['@feature(ember-glimmer-named-arguments) it renders passed named arguments']() {
-    this.registerComponent('foo-bar', {
-      template: '{{@foo}}'
-    });
-
-    this.render('{{foo-bar foo=model.bar}}', {
-      model: {
-        bar: 'Hola'
-      }
-    });
-
-    this.assertText('Hola');
-
-    this.runTask(() => this.rerender());
-
-    this.assertText('Hola');
-
-    this.runTask(() => this.context.set('model.bar', 'Hello'));
-
-    this.assertText('Hello');
-
-    this.runTask(() => this.context.set('model', { bar: 'Hola' }));
-
-    this.assertText('Hola');
-  }
-
-  ['@test it reflects named arguments as properties']() {
-    this.registerComponent('foo-bar', {
-      template: '{{foo}}'
-    });
-
-    this.render('{{foo-bar foo=model.bar}}', {
-      model: {
-        bar: 'Hola'
-      }
-    });
-
-    this.assertText('Hola');
-
-    this.runTask(() => this.rerender());
-
-    this.assertText('Hola');
-
-    this.runTask(() => this.context.set('model.bar', 'Hello'));
-
-    this.assertText('Hello');
-
-    this.runTask(() => this.context.set('model', { bar: 'Hola' }));
-
-    this.assertText('Hola');
-  }
-
-  ['@test it can render a basic component with a block']() {
-    this.registerComponent('foo-bar', { template: '{{yield}} - In component' });
-
-    this.render('{{#foo-bar}}hello{{/foo-bar}}');
-
-    this.assertComponentElement(this.firstChild, { content: 'hello - In component' });
-
-    this.runTask(() => this.rerender());
-
-    this.assertComponentElement(this.firstChild, { content: 'hello - In component' });
-  }
-
-  ['@test it can render a basic component with a block when the yield is in a partial']() {
-    this.registerPartial('_partialWithYield', 'yielded: [{{yield}}]');
-
-    this.registerComponent('foo-bar', { template: '{{partial "partialWithYield"}} - In component' });
-
-    this.render('{{#foo-bar}}hello{{/foo-bar}}');
-
-    this.assertComponentElement(this.firstChild, { content: 'yielded: [hello] - In component' });
-
-    this.runTask(() => this.rerender());
-
-    this.assertComponentElement(this.firstChild, { content: 'yielded: [hello] - In component' });
-  }
-
-  ['@test it can render a basic component with a block param when the yield is in a partial']() {
-    this.registerPartial('_partialWithYield', 'yielded: [{{yield "hello"}}]');
-
-    this.registerComponent('foo-bar', { template: '{{partial "partialWithYield"}} - In component' });
-
-    this.render('{{#foo-bar as |value|}}{{value}}{{/foo-bar}}');
-
-    this.assertComponentElement(this.firstChild, { content: 'yielded: [hello] - In component' });
-
-    this.runTask(() => this.rerender());
-
-    this.assertComponentElement(this.firstChild, { content: 'yielded: [hello] - In component' });
-  }
-
-  ['@test it renders the layout with the component instance as the context']() {
-    let instance;
-
-    let FooBarComponent = Component.extend({
-      init() {
-        this._super();
-        instance = this;
-        this.set('message', 'hello');
-      }
-    });
-
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: '{{message}}' });
-
-    this.render('{{foo-bar}}');
-
-    this.assertComponentElement(this.firstChild, { content: 'hello' });
-
-    this.runTask(() => this.rerender());
-
-    this.assertComponentElement(this.firstChild, { content: 'hello' });
-
-    this.runTask(() => set(instance, 'message', 'goodbye'));
-
-    this.assertComponentElement(this.firstChild, { content: 'goodbye' });
-
-    this.runTask(() => set(instance, 'message', 'hello'));
-
-    this.assertComponentElement(this.firstChild, { content: 'hello' });
-  }
-
-  ['@test it preserves the outer context when yielding']() {
-    this.registerComponent('foo-bar', { template: '{{yield}}' });
-
-    this.render('{{#foo-bar}}{{message}}{{/foo-bar}}', { message: 'hello' });
-
-    this.assertComponentElement(this.firstChild, { content: 'hello' });
-
-    this.runTask(() => this.rerender());
-
-    this.assertComponentElement(this.firstChild, { content: 'hello' });
-
-    this.runTask(() => set(this.context, 'message', 'goodbye'));
-
-    this.assertComponentElement(this.firstChild, { content: 'goodbye' });
-
-    this.runTask(() => set(this.context, 'message', 'hello'));
-
-    this.assertComponentElement(this.firstChild, { content: 'hello' });
-  }
-
-  ['@test it can yield a block param named for reserved words [GH#14096]']() {
-    let instance;
-
-    let FooBarComponent = Component.extend({
-      init() {
-        this._super(...arguments);
-        instance = this;
-      },
-
-      name: 'foo-bar'
-    });
-
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: '{{yield this}}' });
-
-    this.render('{{#foo-bar as |component|}}{{component.name}}{{/foo-bar}}');
-
-    this.assertComponentElement(this.firstChild, { content: 'foo-bar' });
-
-    this.assertStableRerender();
-
-    this.runTask(() => set(instance, 'name', 'derp-qux'));
-
-    this.assertComponentElement(this.firstChild, { content: 'derp-qux' });
-
-    this.runTask(() => set(instance, 'name', 'foo-bar'));
-
-    this.assertComponentElement(this.firstChild, { content: 'foo-bar' });
-  }
-
-  ['@test it can yield internal and external properties positionally']() {
-    let instance;
-
-    let FooBarComponent = Component.extend({
-      init() {
-        this._super(...arguments);
-        instance = this;
-      },
-      greeting: 'hello'
-    });
-
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: '{{yield greeting greetee.firstName}}' });
-
-    this.render('{{#foo-bar greetee=person as |greeting name|}}{{name}} {{person.lastName}}, {{greeting}}{{/foo-bar}}', {
-      person: {
-        firstName: 'Joel',
-        lastName: 'Kang'
-      }
-    });
-
-    this.assertComponentElement(this.firstChild, { content: 'Joel Kang, hello' });
-
-    this.runTask(() => this.rerender());
-
-    this.assertComponentElement(this.firstChild, { content: 'Joel Kang, hello' });
-
-    this.runTask(() => set(this.context, 'person', { firstName: 'Dora', lastName: 'the Explorer' }));
-
-    this.assertComponentElement(this.firstChild, { content: 'Dora the Explorer, hello' });
-
-    this.runTask(() => set(instance, 'greeting', 'hola'));
-
-    this.assertComponentElement(this.firstChild, { content: 'Dora the Explorer, hola' });
-
-    this.runTask(() => {
-      set(instance, 'greeting', 'hello');
-      set(this.context, 'person', {
-        firstName: 'Joel',
-        lastName: 'Kang'
+      this.assertComponentElement(this.nthChild(0), {
+        tagName: 'div',
+        attrs: { class: classes('ember-view foo bar baz') },
+        content: 'hello'
       });
-    });
+      this.assertComponentElement(this.nthChild(1), {
+        tagName: 'div',
+        attrs: { class: classes('ember-view foo bar baz') },
+        content: 'hello'
+      });
+      this.assertComponentElement(this.nthChild(2), {
+        tagName: 'div',
+        attrs: { class: classes('ember-view foo') },
+        content: 'hello'
+      });
 
-    this.assertComponentElement(this.firstChild, { content: 'Joel Kang, hello' });
-  }
+      this.runTask(() => this.rerender());
 
-  ['@test #11519 - block param infinite loop']() {
-    let instance;
-    let FooBarComponent = Component.extend({
-      init() {
-        this._super(...arguments);
-        instance = this;
-      },
-      danger: 0
-    });
+      this.assertComponentElement(this.nthChild(0), {
+        tagName: 'div',
+        attrs: { class: classes('ember-view foo bar baz') },
+        content: 'hello'
+      });
+      this.assertComponentElement(this.nthChild(1), {
+        tagName: 'div',
+        attrs: { class: classes('ember-view foo bar baz') },
+        content: 'hello'
+      });
+      this.assertComponentElement(this.nthChild(2), {
+        tagName: 'div',
+        attrs: { class: classes('ember-view foo') },
+        content: 'hello'
+      });
+    }
 
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: '{{danger}}{{yield danger}}' });
+    ['@test it has an element']() {
+      let instance;
 
-    // On initial render, create streams. The bug will not have manifested yet, but at this point
-    // we have created streams that create a circular invalidation.
-    this.render(`{{#foo-bar as |dangerBlockParam|}}{{/foo-bar}}`);
-
-    this.assertText('0');
-
-    // Trigger a non-revalidating re-render. The yielded block will not be dirtied
-    // nor will block param streams, and thus no infinite loop will occur.
-    this.runTask(() => this.rerender());
-
-    this.assertText('0');
-
-    // Trigger a revalidation, which will cause an infinite loop without the fix
-    // in place.  Note that we do not see the infinite loop is in testing mode,
-    // because a deprecation warning about re-renders is issued, which Ember
-    // treats as an exception.
-    this.runTask(() => set(instance, 'danger', 1));
-
-    this.assertText('1');
-
-    this.runTask(() => set(instance, 'danger', 0));
-
-    this.assertText('0');
-  }
-
-  ['@test the component and its child components are destroyed'](assert) {
-    let destroyed = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 0 };
-
-    this.registerComponent('foo-bar', {
-      template: '{{id}} {{yield}}',
-      ComponentClass: Component.extend({
-        willDestroy() {
+      let FooBarComponent = Component.extend({
+        init() {
           this._super();
-          destroyed[this.get('id')]++;
+          instance = this;
         }
-      })
-    });
+      });
 
-    this.render(strip`
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
+        template: 'hello'
+      });
+
+      this.render('{{foo-bar}}');
+
+      let element1 = instance.element;
+
+      this.assertComponentElement(element1, { content: 'hello' });
+
+      this.runTask(() => this.rerender());
+
+      let element2 = instance.element;
+
+      this.assertComponentElement(element2, { content: 'hello' });
+
+      this.assertSameNode(element2, element1);
+    }
+
+    ['@test an empty component does not have childNodes'](assert) {
+      let fooBarInstance;
+      let FooBarComponent = Component.extend({
+        tagName: 'input',
+        init() {
+          this._super();
+          fooBarInstance = this;
+        }
+      });
+
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
+        template: ''
+      });
+
+      this.render('{{foo-bar}}');
+
+      this.assertComponentElement(this.firstChild, { tagName: 'input' });
+
+      assert.strictEqual(fooBarInstance.element.childNodes.length, 0);
+
+      this.runTask(() => this.rerender());
+
+      this.assertComponentElement(this.firstChild, { tagName: 'input' });
+
+      assert.strictEqual(fooBarInstance.element.childNodes.length, 0);
+    }
+
+    ['@test it has the right parentView and childViews'](assert) {
+      let fooBarInstance, fooBarBazInstance;
+
+      let FooBarComponent = Component.extend({
+        init() {
+          this._super();
+          fooBarInstance = this;
+        }
+      });
+
+      let FooBarBazComponent = Component.extend({
+        init() {
+          this._super();
+          fooBarBazInstance = this;
+        }
+      });
+
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
+        template: 'foo-bar {{foo-bar-baz}}'
+      });
+      this.registerComponent('foo-bar-baz', {
+        ComponentClass: FooBarBazComponent,
+        template: 'foo-bar-baz'
+      });
+
+      this.render('{{foo-bar}}');
+      this.assertText('foo-bar foo-bar-baz');
+
+      assert.equal(fooBarInstance.parentView, this.component);
+      assert.equal(fooBarBazInstance.parentView, fooBarInstance);
+
+      assert.deepEqual(this.component.childViews, [fooBarInstance]);
+      assert.deepEqual(fooBarInstance.childViews, [fooBarBazInstance]);
+
+      this.runTask(() => this.rerender());
+      this.assertText('foo-bar foo-bar-baz');
+
+      assert.equal(fooBarInstance.parentView, this.component);
+      assert.equal(fooBarBazInstance.parentView, fooBarInstance);
+
+      assert.deepEqual(this.component.childViews, [fooBarInstance]);
+      assert.deepEqual(fooBarInstance.childViews, [fooBarBazInstance]);
+    }
+
+    ['@feature(ember-glimmer-named-arguments) it renders passed named arguments']() {
+      this.registerComponent('foo-bar', {
+        template: '{{@foo}}'
+      });
+
+      this.render('{{foo-bar foo=model.bar}}', {
+        model: {
+          bar: 'Hola'
+        }
+      });
+
+      this.assertText('Hola');
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('Hola');
+
+      this.runTask(() => this.context.set('model.bar', 'Hello'));
+
+      this.assertText('Hello');
+
+      this.runTask(() => this.context.set('model', { bar: 'Hola' }));
+
+      this.assertText('Hola');
+    }
+
+    ['@test it reflects named arguments as properties']() {
+      this.registerComponent('foo-bar', {
+        template: '{{foo}}'
+      });
+
+      this.render('{{foo-bar foo=model.bar}}', {
+        model: {
+          bar: 'Hola'
+        }
+      });
+
+      this.assertText('Hola');
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('Hola');
+
+      this.runTask(() => this.context.set('model.bar', 'Hello'));
+
+      this.assertText('Hello');
+
+      this.runTask(() => this.context.set('model', { bar: 'Hola' }));
+
+      this.assertText('Hola');
+    }
+
+    ['@test it can render a basic component with a block']() {
+      this.registerComponent('foo-bar', {
+        template: '{{yield}} - In component'
+      });
+
+      this.render('{{#foo-bar}}hello{{/foo-bar}}');
+
+      this.assertComponentElement(this.firstChild, {
+        content: 'hello - In component'
+      });
+
+      this.runTask(() => this.rerender());
+
+      this.assertComponentElement(this.firstChild, {
+        content: 'hello - In component'
+      });
+    }
+
+    ['@test it can render a basic component with a block when the yield is in a partial']() {
+      this.registerPartial('_partialWithYield', 'yielded: [{{yield}}]');
+
+      this.registerComponent('foo-bar', {
+        template: '{{partial "partialWithYield"}} - In component'
+      });
+
+      this.render('{{#foo-bar}}hello{{/foo-bar}}');
+
+      this.assertComponentElement(this.firstChild, {
+        content: 'yielded: [hello] - In component'
+      });
+
+      this.runTask(() => this.rerender());
+
+      this.assertComponentElement(this.firstChild, {
+        content: 'yielded: [hello] - In component'
+      });
+    }
+
+    ['@test it can render a basic component with a block param when the yield is in a partial']() {
+      this.registerPartial('_partialWithYield', 'yielded: [{{yield "hello"}}]');
+
+      this.registerComponent('foo-bar', {
+        template: '{{partial "partialWithYield"}} - In component'
+      });
+
+      this.render('{{#foo-bar as |value|}}{{value}}{{/foo-bar}}');
+
+      this.assertComponentElement(this.firstChild, {
+        content: 'yielded: [hello] - In component'
+      });
+
+      this.runTask(() => this.rerender());
+
+      this.assertComponentElement(this.firstChild, {
+        content: 'yielded: [hello] - In component'
+      });
+    }
+
+    ['@test it renders the layout with the component instance as the context']() {
+      let instance;
+
+      let FooBarComponent = Component.extend({
+        init() {
+          this._super();
+          instance = this;
+          this.set('message', 'hello');
+        }
+      });
+
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
+        template: '{{message}}'
+      });
+
+      this.render('{{foo-bar}}');
+
+      this.assertComponentElement(this.firstChild, { content: 'hello' });
+
+      this.runTask(() => this.rerender());
+
+      this.assertComponentElement(this.firstChild, { content: 'hello' });
+
+      this.runTask(() => set(instance, 'message', 'goodbye'));
+
+      this.assertComponentElement(this.firstChild, { content: 'goodbye' });
+
+      this.runTask(() => set(instance, 'message', 'hello'));
+
+      this.assertComponentElement(this.firstChild, { content: 'hello' });
+    }
+
+    ['@test it preserves the outer context when yielding']() {
+      this.registerComponent('foo-bar', { template: '{{yield}}' });
+
+      this.render('{{#foo-bar}}{{message}}{{/foo-bar}}', { message: 'hello' });
+
+      this.assertComponentElement(this.firstChild, { content: 'hello' });
+
+      this.runTask(() => this.rerender());
+
+      this.assertComponentElement(this.firstChild, { content: 'hello' });
+
+      this.runTask(() => set(this.context, 'message', 'goodbye'));
+
+      this.assertComponentElement(this.firstChild, { content: 'goodbye' });
+
+      this.runTask(() => set(this.context, 'message', 'hello'));
+
+      this.assertComponentElement(this.firstChild, { content: 'hello' });
+    }
+
+    ['@test it can yield a block param named for reserved words [GH#14096]']() {
+      let instance;
+
+      let FooBarComponent = Component.extend({
+        init() {
+          this._super(...arguments);
+          instance = this;
+        },
+
+        name: 'foo-bar'
+      });
+
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
+        template: '{{yield this}}'
+      });
+
+      this.render('{{#foo-bar as |component|}}{{component.name}}{{/foo-bar}}');
+
+      this.assertComponentElement(this.firstChild, { content: 'foo-bar' });
+
+      this.assertStableRerender();
+
+      this.runTask(() => set(instance, 'name', 'derp-qux'));
+
+      this.assertComponentElement(this.firstChild, { content: 'derp-qux' });
+
+      this.runTask(() => set(instance, 'name', 'foo-bar'));
+
+      this.assertComponentElement(this.firstChild, { content: 'foo-bar' });
+    }
+
+    ['@test it can yield internal and external properties positionally']() {
+      let instance;
+
+      let FooBarComponent = Component.extend({
+        init() {
+          this._super(...arguments);
+          instance = this;
+        },
+        greeting: 'hello'
+      });
+
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
+        template: '{{yield greeting greetee.firstName}}'
+      });
+
+      this.render(
+        '{{#foo-bar greetee=person as |greeting name|}}{{name}} {{person.lastName}}, {{greeting}}{{/foo-bar}}',
+        {
+          person: {
+            firstName: 'Joel',
+            lastName: 'Kang'
+          }
+        }
+      );
+
+      this.assertComponentElement(this.firstChild, {
+        content: 'Joel Kang, hello'
+      });
+
+      this.runTask(() => this.rerender());
+
+      this.assertComponentElement(this.firstChild, {
+        content: 'Joel Kang, hello'
+      });
+
+      this.runTask(() =>
+        set(this.context, 'person', {
+          firstName: 'Dora',
+          lastName: 'the Explorer'
+        })
+      );
+
+      this.assertComponentElement(this.firstChild, {
+        content: 'Dora the Explorer, hello'
+      });
+
+      this.runTask(() => set(instance, 'greeting', 'hola'));
+
+      this.assertComponentElement(this.firstChild, {
+        content: 'Dora the Explorer, hola'
+      });
+
+      this.runTask(() => {
+        set(instance, 'greeting', 'hello');
+        set(this.context, 'person', {
+          firstName: 'Joel',
+          lastName: 'Kang'
+        });
+      });
+
+      this.assertComponentElement(this.firstChild, {
+        content: 'Joel Kang, hello'
+      });
+    }
+
+    ['@test #11519 - block param infinite loop']() {
+      let instance;
+      let FooBarComponent = Component.extend({
+        init() {
+          this._super(...arguments);
+          instance = this;
+        },
+        danger: 0
+      });
+
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
+        template: '{{danger}}{{yield danger}}'
+      });
+
+      // On initial render, create streams. The bug will not have manifested yet, but at this point
+      // we have created streams that create a circular invalidation.
+      this.render(`{{#foo-bar as |dangerBlockParam|}}{{/foo-bar}}`);
+
+      this.assertText('0');
+
+      // Trigger a non-revalidating re-render. The yielded block will not be dirtied
+      // nor will block param streams, and thus no infinite loop will occur.
+      this.runTask(() => this.rerender());
+
+      this.assertText('0');
+
+      // Trigger a revalidation, which will cause an infinite loop without the fix
+      // in place.  Note that we do not see the infinite loop is in testing mode,
+      // because a deprecation warning about re-renders is issued, which Ember
+      // treats as an exception.
+      this.runTask(() => set(instance, 'danger', 1));
+
+      this.assertText('1');
+
+      this.runTask(() => set(instance, 'danger', 0));
+
+      this.assertText('0');
+    }
+
+    ['@test the component and its child components are destroyed'](assert) {
+      let destroyed = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 0 };
+
+      this.registerComponent('foo-bar', {
+        template: '{{id}} {{yield}}',
+        ComponentClass: Component.extend({
+          willDestroy() {
+            this._super();
+            destroyed[this.get('id')]++;
+          }
+        })
+      });
+
+      this.render(
+        strip`
       {{#if cond1}}
         {{#foo-bar id=1}}
           {{#if cond2}}
@@ -757,409 +975,480 @@ moduleFor('Components test: curly components', class extends RenderingTest {
           {{/if}}
         {{/foo-bar}}
       {{/if}}`,
-      {
-        cond1: true,
-        cond2: true,
-        cond3: true,
-        cond4: true,
-        cond5: true
-      }
-    );
+        {
+          cond1: true,
+          cond2: true,
+          cond3: true,
+          cond4: true,
+          cond5: true
+        }
+      );
 
-    this.assertText('1 2 3 4 5 6 7 8 ');
+      this.assertText('1 2 3 4 5 6 7 8 ');
 
-    this.runTask(() => this.rerender());
+      this.runTask(() => this.rerender());
 
-    assert.deepEqual(destroyed, { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 0 });
+      assert.deepEqual(destroyed, {
+        1: 0,
+        2: 0,
+        3: 0,
+        4: 0,
+        5: 0,
+        6: 0,
+        7: 0,
+        8: 0
+      });
 
-    this.runTask(() => set(this.context, 'cond5', false));
+      this.runTask(() => set(this.context, 'cond5', false));
 
-    this.assertText('1 2 3 4 8 ');
+      this.assertText('1 2 3 4 8 ');
 
-    assert.deepEqual(destroyed, { 1: 0, 2: 0, 3: 0, 4: 0, 5: 1, 6: 1, 7: 1, 8: 0 });
+      assert.deepEqual(destroyed, {
+        1: 0,
+        2: 0,
+        3: 0,
+        4: 0,
+        5: 1,
+        6: 1,
+        7: 1,
+        8: 0
+      });
 
-    this.runTask(() => {
-      set(this.context, 'cond3', false);
-      set(this.context, 'cond5', true);
-      set(this.context, 'cond4', false);
-    });
+      this.runTask(() => {
+        set(this.context, 'cond3', false);
+        set(this.context, 'cond5', true);
+        set(this.context, 'cond4', false);
+      });
 
-    assert.deepEqual(destroyed, { 1: 0, 2: 0, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1 });
+      assert.deepEqual(destroyed, {
+        1: 0,
+        2: 0,
+        3: 1,
+        4: 1,
+        5: 1,
+        6: 1,
+        7: 1,
+        8: 1
+      });
 
-    this.runTask(() => {
-      set(this.context, 'cond2', false);
-      set(this.context, 'cond1', false);
-    });
+      this.runTask(() => {
+        set(this.context, 'cond2', false);
+        set(this.context, 'cond1', false);
+      });
 
-    assert.deepEqual(destroyed, { 1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1 });
-  }
+      assert.deepEqual(destroyed, {
+        1: 1,
+        2: 1,
+        3: 1,
+        4: 1,
+        5: 1,
+        6: 1,
+        7: 1,
+        8: 1
+      });
+    }
 
-  ['@test should escape HTML in normal mustaches']() {
-    let component;
-    let FooBarComponent = Component.extend({
-      init() {
-        this._super(...arguments);
-        component = this;
-      },
-      output: 'you need to be more <b>bold</b>'
-    });
+    ['@test should escape HTML in normal mustaches']() {
+      let component;
+      let FooBarComponent = Component.extend({
+        init() {
+          this._super(...arguments);
+          component = this;
+        },
+        output: 'you need to be more <b>bold</b>'
+      });
 
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: '{{output}}' });
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
+        template: '{{output}}'
+      });
 
-    this.render('{{foo-bar}}');
+      this.render('{{foo-bar}}');
 
-    this.assertText('you need to be more <b>bold</b>');
+      this.assertText('you need to be more <b>bold</b>');
 
-    this.runTask(() => this.rerender());
+      this.runTask(() => this.rerender());
 
-    this.assertText('you need to be more <b>bold</b>');
+      this.assertText('you need to be more <b>bold</b>');
 
-    this.runTask(() => set(component, 'output', 'you are so <i>super</i>'));
+      this.runTask(() => set(component, 'output', 'you are so <i>super</i>'));
 
-    this.assertText('you are so <i>super</i>');
+      this.assertText('you are so <i>super</i>');
 
-    this.runTask(() => set(component, 'output', 'you need to be more <b>bold</b>'));
-  }
+      this.runTask(() =>
+        set(component, 'output', 'you need to be more <b>bold</b>')
+      );
+    }
 
-  ['@test should not escape HTML in triple mustaches']() {
-    let expectedHtmlBold = 'you need to be more <b>bold</b>';
-    let expectedHtmlItalic = 'you are so <i>super</i>';
-    let component;
-    let FooBarComponent = Component.extend({
-      init() {
-        this._super(...arguments);
-        component = this;
-      },
-      output: expectedHtmlBold
-    });
+    ['@test should not escape HTML in triple mustaches']() {
+      let expectedHtmlBold = 'you need to be more <b>bold</b>';
+      let expectedHtmlItalic = 'you are so <i>super</i>';
+      let component;
+      let FooBarComponent = Component.extend({
+        init() {
+          this._super(...arguments);
+          component = this;
+        },
+        output: expectedHtmlBold
+      });
 
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: '{{{output}}}' });
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
+        template: '{{{output}}}'
+      });
 
-    this.render('{{foo-bar}}');
+      this.render('{{foo-bar}}');
 
-    equalTokens(this.firstChild, expectedHtmlBold);
+      equalTokens(this.firstChild, expectedHtmlBold);
 
-    this.runTask(() => this.rerender());
+      this.runTask(() => this.rerender());
 
-    equalTokens(this.firstChild, expectedHtmlBold);
+      equalTokens(this.firstChild, expectedHtmlBold);
 
-    this.runTask(() => set(component, 'output', expectedHtmlItalic));
+      this.runTask(() => set(component, 'output', expectedHtmlItalic));
 
-    equalTokens(this.firstChild, expectedHtmlItalic);
+      equalTokens(this.firstChild, expectedHtmlItalic);
 
-    this.runTask(() => set(component, 'output', expectedHtmlBold));
+      this.runTask(() => set(component, 'output', expectedHtmlBold));
 
-    equalTokens(this.firstChild, expectedHtmlBold);
-  }
+      equalTokens(this.firstChild, expectedHtmlBold);
+    }
 
-  ['@test should not escape HTML if string is a htmlSafe']() {
-    let expectedHtmlBold = 'you need to be more <b>bold</b>';
-    let expectedHtmlItalic = 'you are so <i>super</i>';
-    let component;
-    let FooBarComponent = Component.extend({
-      init() {
-        this._super(...arguments);
-        component = this;
-      },
-      output: htmlSafe(expectedHtmlBold)
-    });
+    ['@test should not escape HTML if string is a htmlSafe']() {
+      let expectedHtmlBold = 'you need to be more <b>bold</b>';
+      let expectedHtmlItalic = 'you are so <i>super</i>';
+      let component;
+      let FooBarComponent = Component.extend({
+        init() {
+          this._super(...arguments);
+          component = this;
+        },
+        output: htmlSafe(expectedHtmlBold)
+      });
 
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: '{{output}}' });
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
+        template: '{{output}}'
+      });
 
-    this.render('{{foo-bar}}');
+      this.render('{{foo-bar}}');
 
-    equalTokens(this.firstChild, expectedHtmlBold);
+      equalTokens(this.firstChild, expectedHtmlBold);
 
-    this.runTask(() => this.rerender());
+      this.runTask(() => this.rerender());
 
-    equalTokens(this.firstChild, expectedHtmlBold);
+      equalTokens(this.firstChild, expectedHtmlBold);
 
-    this.runTask(() => set(component, 'output', htmlSafe(expectedHtmlItalic)));
+      this.runTask(() =>
+        set(component, 'output', htmlSafe(expectedHtmlItalic))
+      );
 
-    equalTokens(this.firstChild, expectedHtmlItalic);
+      equalTokens(this.firstChild, expectedHtmlItalic);
 
-    this.runTask(() => set(component, 'output', htmlSafe(expectedHtmlBold)));
+      this.runTask(() => set(component, 'output', htmlSafe(expectedHtmlBold)));
 
-    equalTokens(this.firstChild, expectedHtmlBold);
-  }
+      equalTokens(this.firstChild, expectedHtmlBold);
+    }
 
-  ['@test late bound layouts return the same definition'](assert) {
-    let templateIds = [];
+    ['@test late bound layouts return the same definition'](assert) {
+      let templateIds = [];
 
-    // This is testing the scenario where you import a template and
-    // set it to the layout property:
-    //
-    // import Component from '@ember/component';
-    // import layout from './template';
-    //
-    // export default Component.extend({
-    //   layout
-    // });
-    let hello = compile('Hello');
-    let bye = compile('Bye');
+      // This is testing the scenario where you import a template and
+      // set it to the layout property:
+      //
+      // import Component from '@ember/component';
+      // import layout from './template';
+      //
+      // export default Component.extend({
+      //   layout
+      // });
+      let hello = compile('Hello');
+      let bye = compile('Bye');
 
-    let FooBarComponent = Component.extend({
-      init() {
-        this._super(...arguments);
-        this.layout = this.cond ? hello : bye;
-        templateIds.push(this.layout.id);
-      }
-    });
+      let FooBarComponent = Component.extend({
+        init() {
+          this._super(...arguments);
+          this.layout = this.cond ? hello : bye;
+          templateIds.push(this.layout.id);
+        }
+      });
 
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent });
+      this.registerComponent('foo-bar', { ComponentClass: FooBarComponent });
 
-    this.render('{{foo-bar cond=true}}{{foo-bar cond=false}}{{foo-bar cond=true}}{{foo-bar cond=false}}');
+      this.render(
+        '{{foo-bar cond=true}}{{foo-bar cond=false}}{{foo-bar cond=true}}{{foo-bar cond=false}}'
+      );
 
-    let [t1, t2, t3, t4] = templateIds;
-    assert.equal(t1, t3);
-    assert.equal(t2, t4);
-  }
+      let [t1, t2, t3, t4] = templateIds;
+      assert.equal(t1, t3);
+      assert.equal(t2, t4);
+    }
 
-  ['@test can use isStream property without conflict (#13271)']() {
-    let component;
-    let FooBarComponent = Component.extend({
-      isStream: true,
+    ['@test can use isStream property without conflict (#13271)']() {
+      let component;
+      let FooBarComponent = Component.extend({
+        isStream: true,
 
-      init() {
-        this._super(...arguments);
-        component = this;
-      }
-    });
+        init() {
+          this._super(...arguments);
+          component = this;
+        }
+      });
 
-    this.registerComponent('foo-bar', {
-      ComponentClass: FooBarComponent,
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
 
-      template: strip`
+        template: strip`
         {{#if isStream}}
           true
         {{else}}
           false
         {{/if}}
       `
-    });
+      });
 
-    this.render('{{foo-bar}}');
+      this.render('{{foo-bar}}');
 
-    this.assertComponentElement(this.firstChild, { content: 'true' });
+      this.assertComponentElement(this.firstChild, { content: 'true' });
 
-    this.runTask(() => this.rerender());
+      this.runTask(() => this.rerender());
 
-    this.assertComponentElement(this.firstChild, { content: 'true' });
+      this.assertComponentElement(this.firstChild, { content: 'true' });
 
-    this.runTask(() => set(component, 'isStream', false));
+      this.runTask(() => set(component, 'isStream', false));
 
-    this.assertComponentElement(this.firstChild, { content: 'false' });
+      this.assertComponentElement(this.firstChild, { content: 'false' });
 
-    this.runTask(() => set(component, 'isStream', true));
+      this.runTask(() => set(component, 'isStream', true));
 
-    this.assertComponentElement(this.firstChild, { content: 'true' });
-  }
-  ['@test lookup of component takes priority over property']() {
-    this.registerComponent('some-component', {
-      template: 'some-component'
-    });
+      this.assertComponentElement(this.firstChild, { content: 'true' });
+    }
+    ['@test lookup of component takes priority over property']() {
+      this.registerComponent('some-component', {
+        template: 'some-component'
+      });
 
-    this.render(
-      '{{some-prop}} {{some-component}}',
-      {
+      this.render('{{some-prop}} {{some-component}}', {
         'some-component': 'not-some-component',
         'some-prop': 'some-prop'
-      }
-    );
+      });
 
-    this.assertText('some-prop some-component');
+      this.assertText('some-prop some-component');
 
-    this.runTask(() => this.rerender());
+      this.runTask(() => this.rerender());
 
-    this.assertText('some-prop some-component');
-  }
-
-  ['@test component without dash is not looked up']() {
-    this.registerComponent('somecomponent', {
-      template: 'somecomponent'
-    });
-
-    this.render(
-      '{{somecomponent}}',
-      {
-        'somecomponent': 'notsomecomponent'
-      }
-    );
-
-    this.assertText('notsomecomponent');
-
-    this.runTask(() => this.rerender());
-
-    this.assertText('notsomecomponent');
-
-    this.runTask(() => this.context.set('somecomponent', 'not not notsomecomponent'));
-
-    this.assertText('not not notsomecomponent');
-
-    this.runTask(() => this.context.set('somecomponent', 'notsomecomponent'));
-
-    this.assertText('notsomecomponent');
-  }
-
-  ['@test non-block with properties on attrs']() {
-    this.registerComponent('non-block', {
-      template: 'In layout - someProp: {{attrs.someProp}}'
-    });
-
-    this.render('{{non-block someProp=prop}}', {
-      prop: 'something here'
-    });
-
-    this.assertText('In layout - someProp: something here');
-
-    this.runTask(() => this.rerender());
-
-    this.assertText('In layout - someProp: something here');
-
-    this.runTask(() => this.context.set('prop', 'other thing there'));
-
-    this.assertText('In layout - someProp: other thing there');
-
-    this.runTask(() => this.context.set('prop', 'something here'));
-
-    this.assertText('In layout - someProp: something here');
-  }
-
-  ['@feature(ember-glimmer-named-arguments) non-block with named argument']() {
-    this.registerComponent('non-block', {
-      template: 'In layout - someProp: {{@someProp}}'
-    });
-
-    this.render('{{non-block someProp=prop}}', {
-      prop: 'something here'
-    });
-
-    this.assertText('In layout - someProp: something here');
-
-    this.runTask(() => this.rerender());
-
-    this.assertText('In layout - someProp: something here');
-
-    this.runTask(() => this.context.set('prop', 'other thing there'));
-
-    this.assertText('In layout - someProp: other thing there');
-
-    this.runTask(() => this.context.set('prop', 'something here'));
-
-    this.assertText('In layout - someProp: something here');
-  }
-
-  ['@test non-block with properties overridden in init']() {
-    let instance;
-    this.registerComponent('non-block', {
-      ComponentClass: Component.extend({
-        init() {
-          this._super(...arguments);
-          instance = this;
-          this.someProp = 'value set in instance';
-        }
-      }),
-      template: 'In layout - someProp: {{someProp}}'
-    });
-
-    this.render('{{non-block someProp=prop}}', {
-      prop: 'something passed when invoked'
-    });
-
-    this.assertText('In layout - someProp: value set in instance');
-
-    this.runTask(() => this.rerender());
-
-    this.assertText('In layout - someProp: value set in instance');
-
-    this.runTask(() => this.context.set('prop', 'updated something passed when invoked'));
-
-    this.assertText('In layout - someProp: updated something passed when invoked');
-
-    this.runTask(() => instance.set('someProp', 'update value set in instance'));
-
-    this.assertText('In layout - someProp: update value set in instance');
-
-    this.runTask(() => this.context.set('prop', 'something passed when invoked'));
-    this.runTask(() => instance.set('someProp', 'value set in instance'));
-
-    this.assertText('In layout - someProp: value set in instance');
-  }
-
-  ['@test rerendering component with attrs from parent'](assert) {
-    let willUpdateCount = 0;
-    let didReceiveAttrsCount = 0;
-
-    function expectHooks({ willUpdate, didReceiveAttrs }, callback) {
-      willUpdateCount = 0;
-      didReceiveAttrsCount = 0;
-
-      callback();
-
-      if (willUpdate) {
-        assert.strictEqual(willUpdateCount, 1, 'The willUpdate hook was fired');
-      } else {
-        assert.strictEqual(willUpdateCount, 0, 'The willUpdate hook was not fired');
-      }
-
-      if (didReceiveAttrs) {
-        assert.strictEqual(didReceiveAttrsCount, 1, 'The didReceiveAttrs hook was fired');
-      } else {
-        assert.strictEqual(didReceiveAttrsCount, 0, 'The didReceiveAttrs hook was not fired');
-      }
+      this.assertText('some-prop some-component');
     }
 
-    this.registerComponent('non-block', {
-      ComponentClass: Component.extend({
-        didReceiveAttrs() {
-          didReceiveAttrsCount++;
-        },
-
-        willUpdate() {
-          willUpdateCount++;
-        }
-      }),
-      template: 'In layout - someProp: {{someProp}}'
-    });
-
-    expectHooks({ willUpdate: false, didReceiveAttrs: true }, () => {
-      this.render('{{non-block someProp=someProp}}', {
-        someProp: 'wycats'
+    ['@test component without dash is not looked up']() {
+      this.registerComponent('somecomponent', {
+        template: 'somecomponent'
       });
-    });
 
-    this.assertText('In layout - someProp: wycats');
+      this.render('{{somecomponent}}', {
+        somecomponent: 'notsomecomponent'
+      });
 
-    // Note: Hooks are not fired in Glimmer for idempotent re-renders
-    expectHooks({ willUpdate: false, didReceiveAttrs: false }, () => {
+      this.assertText('notsomecomponent');
+
       this.runTask(() => this.rerender());
-    });
 
-    this.assertText('In layout - someProp: wycats');
+      this.assertText('notsomecomponent');
 
-    expectHooks({ willUpdate: true, didReceiveAttrs: true }, () => {
-      this.runTask(() => this.context.set('someProp', 'tomdale'));
-    });
+      this.runTask(() =>
+        this.context.set('somecomponent', 'not not notsomecomponent')
+      );
 
-    this.assertText('In layout - someProp: tomdale');
+      this.assertText('not not notsomecomponent');
 
-    // Note: Hooks are not fired in Glimmer for idempotent re-renders
-    expectHooks({ willUpdate: false, didReceiveAttrs: false }, () => {
+      this.runTask(() => this.context.set('somecomponent', 'notsomecomponent'));
+
+      this.assertText('notsomecomponent');
+    }
+
+    ['@test non-block with properties on attrs']() {
+      this.registerComponent('non-block', {
+        template: 'In layout - someProp: {{attrs.someProp}}'
+      });
+
+      this.render('{{non-block someProp=prop}}', {
+        prop: 'something here'
+      });
+
+      this.assertText('In layout - someProp: something here');
+
       this.runTask(() => this.rerender());
-    });
 
-    this.assertText('In layout - someProp: tomdale');
+      this.assertText('In layout - someProp: something here');
 
-    expectHooks({ willUpdate: true, didReceiveAttrs: true }, () => {
-      this.runTask(() => this.context.set('someProp', 'wycats'));
-    });
+      this.runTask(() => this.context.set('prop', 'other thing there'));
 
-    this.assertText('In layout - someProp: wycats');
-  }
+      this.assertText('In layout - someProp: other thing there');
 
-  ['@feature(!ember-glimmer-named-arguments) this.attrs.foo === attrs.foo === foo']() {
-    this.registerComponent('foo-bar', {
-      template: strip`
+      this.runTask(() => this.context.set('prop', 'something here'));
+
+      this.assertText('In layout - someProp: something here');
+    }
+
+    ['@feature(ember-glimmer-named-arguments) non-block with named argument']() {
+      this.registerComponent('non-block', {
+        template: 'In layout - someProp: {{@someProp}}'
+      });
+
+      this.render('{{non-block someProp=prop}}', {
+        prop: 'something here'
+      });
+
+      this.assertText('In layout - someProp: something here');
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('In layout - someProp: something here');
+
+      this.runTask(() => this.context.set('prop', 'other thing there'));
+
+      this.assertText('In layout - someProp: other thing there');
+
+      this.runTask(() => this.context.set('prop', 'something here'));
+
+      this.assertText('In layout - someProp: something here');
+    }
+
+    ['@test non-block with properties overridden in init']() {
+      let instance;
+      this.registerComponent('non-block', {
+        ComponentClass: Component.extend({
+          init() {
+            this._super(...arguments);
+            instance = this;
+            this.someProp = 'value set in instance';
+          }
+        }),
+        template: 'In layout - someProp: {{someProp}}'
+      });
+
+      this.render('{{non-block someProp=prop}}', {
+        prop: 'something passed when invoked'
+      });
+
+      this.assertText('In layout - someProp: value set in instance');
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('In layout - someProp: value set in instance');
+
+      this.runTask(() =>
+        this.context.set('prop', 'updated something passed when invoked')
+      );
+
+      this.assertText(
+        'In layout - someProp: updated something passed when invoked'
+      );
+
+      this.runTask(() =>
+        instance.set('someProp', 'update value set in instance')
+      );
+
+      this.assertText('In layout - someProp: update value set in instance');
+
+      this.runTask(() =>
+        this.context.set('prop', 'something passed when invoked')
+      );
+      this.runTask(() => instance.set('someProp', 'value set in instance'));
+
+      this.assertText('In layout - someProp: value set in instance');
+    }
+
+    ['@test rerendering component with attrs from parent'](assert) {
+      let willUpdateCount = 0;
+      let didReceiveAttrsCount = 0;
+
+      function expectHooks({ willUpdate, didReceiveAttrs }, callback) {
+        willUpdateCount = 0;
+        didReceiveAttrsCount = 0;
+
+        callback();
+
+        if (willUpdate) {
+          assert.strictEqual(
+            willUpdateCount,
+            1,
+            'The willUpdate hook was fired'
+          );
+        } else {
+          assert.strictEqual(
+            willUpdateCount,
+            0,
+            'The willUpdate hook was not fired'
+          );
+        }
+
+        if (didReceiveAttrs) {
+          assert.strictEqual(
+            didReceiveAttrsCount,
+            1,
+            'The didReceiveAttrs hook was fired'
+          );
+        } else {
+          assert.strictEqual(
+            didReceiveAttrsCount,
+            0,
+            'The didReceiveAttrs hook was not fired'
+          );
+        }
+      }
+
+      this.registerComponent('non-block', {
+        ComponentClass: Component.extend({
+          didReceiveAttrs() {
+            didReceiveAttrsCount++;
+          },
+
+          willUpdate() {
+            willUpdateCount++;
+          }
+        }),
+        template: 'In layout - someProp: {{someProp}}'
+      });
+
+      expectHooks({ willUpdate: false, didReceiveAttrs: true }, () => {
+        this.render('{{non-block someProp=someProp}}', {
+          someProp: 'wycats'
+        });
+      });
+
+      this.assertText('In layout - someProp: wycats');
+
+      // Note: Hooks are not fired in Glimmer for idempotent re-renders
+      expectHooks({ willUpdate: false, didReceiveAttrs: false }, () => {
+        this.runTask(() => this.rerender());
+      });
+
+      this.assertText('In layout - someProp: wycats');
+
+      expectHooks({ willUpdate: true, didReceiveAttrs: true }, () => {
+        this.runTask(() => this.context.set('someProp', 'tomdale'));
+      });
+
+      this.assertText('In layout - someProp: tomdale');
+
+      // Note: Hooks are not fired in Glimmer for idempotent re-renders
+      expectHooks({ willUpdate: false, didReceiveAttrs: false }, () => {
+        this.runTask(() => this.rerender());
+      });
+
+      this.assertText('In layout - someProp: tomdale');
+
+      expectHooks({ willUpdate: true, didReceiveAttrs: true }, () => {
+        this.runTask(() => this.context.set('someProp', 'wycats'));
+      });
+
+      this.assertText('In layout - someProp: wycats');
+    }
+
+    ['@feature(!ember-glimmer-named-arguments) this.attrs.foo === attrs.foo === foo']() {
+      this.registerComponent('foo-bar', {
+        template: strip`
         Args: {{this.attrs.value}} | {{attrs.value}} | {{value}}
         {{#each this.attrs.items as |item|}}
           {{item}}
@@ -1171,32 +1460,34 @@ moduleFor('Components test: curly components', class extends RenderingTest {
           {{item}}
         {{/each}}
       `
-    });
+      });
 
-    this.render('{{foo-bar value=model.value items=model.items}}', {
-      model: {
-        value: 'wat',
-        items: [1, 2, 3]
-      }
-    });
+      this.render('{{foo-bar value=model.value items=model.items}}', {
+        model: {
+          value: 'wat',
+          items: [1, 2, 3]
+        }
+      });
 
-    this.assertStableRerender();
+      this.assertStableRerender();
 
-    this.runTask(() => {
-      this.context.set('model.value', 'lul');
-      this.context.set('model.items', [1]);
-    });
+      this.runTask(() => {
+        this.context.set('model.value', 'lul');
+        this.context.set('model.items', [1]);
+      });
 
-    this.assertText(strip`Args: lul | lul | lul111`);
+      this.assertText(strip`Args: lul | lul | lul111`);
 
-    this.runTask(() => this.context.set('model', { value: 'wat', items: [1, 2, 3] }));
+      this.runTask(() =>
+        this.context.set('model', { value: 'wat', items: [1, 2, 3] })
+      );
 
-    this.assertText('Args: wat | wat | wat123123123');
-  }
+      this.assertText('Args: wat | wat | wat123123123');
+    }
 
-  ['@feature(ember-glimmer-named-arguments) this.attrs.foo === attrs.foo === @foo === foo']() {
-    this.registerComponent('foo-bar', {
-      template: strip`
+    ['@feature(ember-glimmer-named-arguments) this.attrs.foo === attrs.foo === @foo === foo']() {
+      this.registerComponent('foo-bar', {
+        template: strip`
         Args: {{this.attrs.value}} | {{attrs.value}} | {{@value}} | {{value}}
         {{#each this.attrs.items as |item|}}
           {{item}}
@@ -1211,1727 +1502,1975 @@ moduleFor('Components test: curly components', class extends RenderingTest {
           {{item}}
         {{/each}}
       `
-    });
-
-    this.render('{{foo-bar value=model.value items=model.items}}', {
-      model: {
-        value: 'wat',
-        items: [1, 2, 3]
-      }
-    });
-
-    this.assertStableRerender();
-
-    this.runTask(() => {
-      this.context.set('model.value', 'lul');
-      this.context.set('model.items', [1]);
-    });
-
-    this.assertText(strip`Args: lul | lul | lul | lul1111`);
-
-    this.runTask(() => this.context.set('model', { value: 'wat', items: [1, 2, 3] }));
-
-    this.assertText('Args: wat | wat | wat | wat123123123123');
-  }
-
-  ['@test non-block with properties on self']() {
-    this.registerComponent('non-block', {
-      template: 'In layout - someProp: {{someProp}}'
-    });
-
-    this.render('{{non-block someProp=prop}}', {
-      prop: 'something here'
-    });
-
-    this.assertText('In layout - someProp: something here');
-
-    this.runTask(() => this.rerender());
-
-    this.assertText('In layout - someProp: something here');
-
-    this.runTask(() => this.context.set('prop', 'something else'));
-
-    this.assertText('In layout - someProp: something else');
-
-    this.runTask(() => this.context.set('prop', 'something here'));
-
-    this.assertText('In layout - someProp: something here');
-  }
-
-  ['@test block with properties on self']() {
-    this.registerComponent('with-block', {
-      template: 'In layout - someProp: {{someProp}} - {{yield}}'
-    });
-
-    this.render(strip`
-      {{#with-block someProp=prop}}
-        In template
-      {{/with-block}}`, {
-        prop: 'something here'
-      }
-    );
-
-    this.assertText('In layout - someProp: something here - In template');
-
-    this.runTask(() => this.rerender());
-
-    this.assertText('In layout - someProp: something here - In template');
-
-    this.runTask(() => this.context.set('prop', 'something else'));
-
-    this.assertText('In layout - someProp: something else - In template');
-
-    this.runTask(() => this.context.set('prop', 'something here'));
-
-    this.assertText('In layout - someProp: something here - In template');
-  }
-
-  ['@test block with properties on attrs']() {
-    this.registerComponent('with-block', {
-      template: 'In layout - someProp: {{attrs.someProp}} - {{yield}}'
-    });
-
-    this.render(strip`
-      {{#with-block someProp=prop}}
-        In template
-      {{/with-block}}`, {
-        prop: 'something here'
-      }
-    );
-
-    this.assertText('In layout - someProp: something here - In template');
-
-    this.runTask(() => this.rerender());
-
-    this.assertText('In layout - someProp: something here - In template');
-
-    this.runTask(() => this.context.set('prop', 'something else'));
-
-    this.assertText('In layout - someProp: something else - In template');
-
-    this.runTask(() => this.context.set('prop', 'something here'));
-
-    this.assertText('In layout - someProp: something here - In template');
-  }
-
-  ['@feature(ember-glimmer-named-arguments) block with named argument']() {
-    this.registerComponent('with-block', {
-      template: 'In layout - someProp: {{@someProp}} - {{yield}}'
-    });
-
-    this.render(strip`
-      {{#with-block someProp=prop}}
-        In template
-      {{/with-block}}`, {
-        prop: 'something here'
-      }
-    );
-
-    this.assertText('In layout - someProp: something here - In template');
-
-    this.runTask(() => this.rerender());
-
-    this.assertText('In layout - someProp: something here - In template');
-
-    this.runTask(() => this.context.set('prop', 'something else'));
-
-    this.assertText('In layout - someProp: something else - In template');
-
-    this.runTask(() => this.context.set('prop', 'something here'));
-
-    this.assertText('In layout - someProp: something here - In template');
-  }
-
-  ['@test static arbitrary number of positional parameters'](assert) {
-    this.registerComponent('sample-component', {
-      ComponentClass: Component.extend().reopenClass({
-        positionalParams: 'names'
-      }),
-      template: strip`
-        {{#each names as |name|}}
-          {{name}}
-        {{/each}}`
-    });
-
-    this.render(strip`
-      {{sample-component "Foo" 4 "Bar" elementId="args-3"}}
-      {{sample-component "Foo" 4 "Bar" 5 "Baz" elementId="args-5"}}`
-    );
-
-    assert.equal(this.$('#args-3').text(), 'Foo4Bar');
-    assert.equal(this.$('#args-5').text(), 'Foo4Bar5Baz');
-
-    this.runTask(() => this.rerender());
-
-    assert.equal(this.$('#args-3').text(), 'Foo4Bar');
-    assert.equal(this.$('#args-5').text(), 'Foo4Bar5Baz');
-  }
-
-  ['@test arbitrary positional parameter conflict with hash parameter is reported']() {
-    this.registerComponent('sample-component', {
-      ComponentClass: Component.extend().reopenClass({
-        positionalParams: 'names'
-      }),
-      template: strip`
-        {{#each names as |name|}}
-          {{name}}
-        {{/each}}`
-    });
-
-    expectAssertion(() => {
-      this.render(`{{sample-component "Foo" 4 "Bar" names=numbers id="args-3"}}`, {
-        numbers: [1, 2, 3]
       });
-    }, 'You cannot specify positional parameters and the hash argument `names`.');
-  }
 
-  ['@test can use hash parameter instead of arbitrary positional param [GH #12444]']() {
-    this.registerComponent('sample-component', {
-      ComponentClass: Component.extend().reopenClass({
-        positionalParams: 'names'
-      }),
-      template: strip`
+      this.render('{{foo-bar value=model.value items=model.items}}', {
+        model: {
+          value: 'wat',
+          items: [1, 2, 3]
+        }
+      });
+
+      this.assertStableRerender();
+
+      this.runTask(() => {
+        this.context.set('model.value', 'lul');
+        this.context.set('model.items', [1]);
+      });
+
+      this.assertText(strip`Args: lul | lul | lul | lul1111`);
+
+      this.runTask(() =>
+        this.context.set('model', { value: 'wat', items: [1, 2, 3] })
+      );
+
+      this.assertText('Args: wat | wat | wat | wat123123123123');
+    }
+
+    ['@test non-block with properties on self']() {
+      this.registerComponent('non-block', {
+        template: 'In layout - someProp: {{someProp}}'
+      });
+
+      this.render('{{non-block someProp=prop}}', {
+        prop: 'something here'
+      });
+
+      this.assertText('In layout - someProp: something here');
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('In layout - someProp: something here');
+
+      this.runTask(() => this.context.set('prop', 'something else'));
+
+      this.assertText('In layout - someProp: something else');
+
+      this.runTask(() => this.context.set('prop', 'something here'));
+
+      this.assertText('In layout - someProp: something here');
+    }
+
+    ['@test block with properties on self']() {
+      this.registerComponent('with-block', {
+        template: 'In layout - someProp: {{someProp}} - {{yield}}'
+      });
+
+      this.render(
+        strip`
+      {{#with-block someProp=prop}}
+        In template
+      {{/with-block}}`,
+        {
+          prop: 'something here'
+        }
+      );
+
+      this.assertText('In layout - someProp: something here - In template');
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('In layout - someProp: something here - In template');
+
+      this.runTask(() => this.context.set('prop', 'something else'));
+
+      this.assertText('In layout - someProp: something else - In template');
+
+      this.runTask(() => this.context.set('prop', 'something here'));
+
+      this.assertText('In layout - someProp: something here - In template');
+    }
+
+    ['@test block with properties on attrs']() {
+      this.registerComponent('with-block', {
+        template: 'In layout - someProp: {{attrs.someProp}} - {{yield}}'
+      });
+
+      this.render(
+        strip`
+      {{#with-block someProp=prop}}
+        In template
+      {{/with-block}}`,
+        {
+          prop: 'something here'
+        }
+      );
+
+      this.assertText('In layout - someProp: something here - In template');
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('In layout - someProp: something here - In template');
+
+      this.runTask(() => this.context.set('prop', 'something else'));
+
+      this.assertText('In layout - someProp: something else - In template');
+
+      this.runTask(() => this.context.set('prop', 'something here'));
+
+      this.assertText('In layout - someProp: something here - In template');
+    }
+
+    ['@feature(ember-glimmer-named-arguments) block with named argument']() {
+      this.registerComponent('with-block', {
+        template: 'In layout - someProp: {{@someProp}} - {{yield}}'
+      });
+
+      this.render(
+        strip`
+      {{#with-block someProp=prop}}
+        In template
+      {{/with-block}}`,
+        {
+          prop: 'something here'
+        }
+      );
+
+      this.assertText('In layout - someProp: something here - In template');
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('In layout - someProp: something here - In template');
+
+      this.runTask(() => this.context.set('prop', 'something else'));
+
+      this.assertText('In layout - someProp: something else - In template');
+
+      this.runTask(() => this.context.set('prop', 'something here'));
+
+      this.assertText('In layout - someProp: something here - In template');
+    }
+
+    ['@test static arbitrary number of positional parameters'](assert) {
+      this.registerComponent('sample-component', {
+        ComponentClass: Component.extend().reopenClass({
+          positionalParams: 'names'
+        }),
+        template: strip`
         {{#each names as |name|}}
           {{name}}
         {{/each}}`
-    });
+      });
 
-    this.render('{{sample-component names=things}}', {
-      things: emberA(['Foo', 4, 'Bar'])
-    });
+      this.render(strip`
+      {{sample-component "Foo" 4 "Bar" elementId="args-3"}}
+      {{sample-component "Foo" 4 "Bar" 5 "Baz" elementId="args-5"}}`);
 
-    this.assertText('Foo4Bar');
+      assert.equal(this.$('#args-3').text(), 'Foo4Bar');
+      assert.equal(this.$('#args-5').text(), 'Foo4Bar5Baz');
 
-    this.runTask(() => this.rerender());
+      this.runTask(() => this.rerender());
 
-    this.assertText('Foo4Bar');
+      assert.equal(this.$('#args-3').text(), 'Foo4Bar');
+      assert.equal(this.$('#args-5').text(), 'Foo4Bar5Baz');
+    }
 
-    this.runTask(() => this.context.get('things').pushObject(5));
+    ['@test arbitrary positional parameter conflict with hash parameter is reported']() {
+      this.registerComponent('sample-component', {
+        ComponentClass: Component.extend().reopenClass({
+          positionalParams: 'names'
+        }),
+        template: strip`
+        {{#each names as |name|}}
+          {{name}}
+        {{/each}}`
+      });
 
-    this.assertText('Foo4Bar5');
+      expectAssertion(() => {
+        this.render(
+          `{{sample-component "Foo" 4 "Bar" names=numbers id="args-3"}}`,
+          {
+            numbers: [1, 2, 3]
+          }
+        );
+      }, 'You cannot specify positional parameters and the hash argument `names`.');
+    }
 
-    this.runTask(() => this.context.get('things').shiftObject());
+    ['@test can use hash parameter instead of arbitrary positional param [GH #12444]']() {
+      this.registerComponent('sample-component', {
+        ComponentClass: Component.extend().reopenClass({
+          positionalParams: 'names'
+        }),
+        template: strip`
+        {{#each names as |name|}}
+          {{name}}
+        {{/each}}`
+      });
 
-    this.assertText('4Bar5');
+      this.render('{{sample-component names=things}}', {
+        things: emberA(['Foo', 4, 'Bar'])
+      });
 
-    this.runTask(() => this.context.get('things').clear());
+      this.assertText('Foo4Bar');
 
-    this.assertText('');
+      this.runTask(() => this.rerender());
 
-    this.runTask(() => this.context.set('things', emberA(['Foo', 4, 'Bar'])));
+      this.assertText('Foo4Bar');
 
-    this.assertText('Foo4Bar');
-  }
+      this.runTask(() => this.context.get('things').pushObject(5));
 
-  ['@test can use hash parameter instead of positional param'](assert) {
-    this.registerComponent('sample-component', {
-      ComponentClass: Component.extend().reopenClass({
-        positionalParams: ['first', 'second']
-      }),
-      template: '{{first}} - {{second}}'
-    });
+      this.assertText('Foo4Bar5');
 
-    // TODO: Fix when id is implemented
-    this.render(strip`
+      this.runTask(() => this.context.get('things').shiftObject());
+
+      this.assertText('4Bar5');
+
+      this.runTask(() => this.context.get('things').clear());
+
+      this.assertText('');
+
+      this.runTask(() => this.context.set('things', emberA(['Foo', 4, 'Bar'])));
+
+      this.assertText('Foo4Bar');
+    }
+
+    ['@test can use hash parameter instead of positional param'](assert) {
+      this.registerComponent('sample-component', {
+        ComponentClass: Component.extend().reopenClass({
+          positionalParams: ['first', 'second']
+        }),
+        template: '{{first}} - {{second}}'
+      });
+
+      // TODO: Fix when id is implemented
+      this.render(strip`
       {{sample-component "one" "two" elementId="two-positional"}}
       {{sample-component "one" second="two" elementId="one-positional"}}
       {{sample-component first="one" second="two" elementId="no-positional"}}`);
 
-    assert.equal(this.$('#two-positional').text(), 'one - two');
-    assert.equal(this.$('#one-positional').text(), 'one - two');
-    assert.equal(this.$('#no-positional').text(), 'one - two');
+      assert.equal(this.$('#two-positional').text(), 'one - two');
+      assert.equal(this.$('#one-positional').text(), 'one - two');
+      assert.equal(this.$('#no-positional').text(), 'one - two');
 
-    this.runTask(() => this.rerender());
+      this.runTask(() => this.rerender());
 
-    assert.equal(this.$('#two-positional').text(), 'one - two');
-    assert.equal(this.$('#one-positional').text(), 'one - two');
-    assert.equal(this.$('#no-positional').text(), 'one - two');
-  }
+      assert.equal(this.$('#two-positional').text(), 'one - two');
+      assert.equal(this.$('#one-positional').text(), 'one - two');
+      assert.equal(this.$('#no-positional').text(), 'one - two');
+    }
 
-  ['@test dynamic arbitrary number of positional parameters']() {
-    this.registerComponent('sample-component', {
-      ComponentClass: Component.extend().reopenClass({
-        positionalParams: 'n'
-      }),
-      template: strip`
+    ['@test dynamic arbitrary number of positional parameters']() {
+      this.registerComponent('sample-component', {
+        ComponentClass: Component.extend().reopenClass({
+          positionalParams: 'n'
+        }),
+        template: strip`
         {{#each n as |name|}}
           {{name}}
         {{/each}}`
-    });
+      });
 
-    this.render(`{{sample-component user1 user2}}`,
-      {
+      this.render(`{{sample-component user1 user2}}`, {
         user1: 'Foo',
         user2: 4
-      }
-    );
+      });
 
-    this.assertText('Foo4');
+      this.assertText('Foo4');
 
-    this.runTask(() => this.rerender());
+      this.runTask(() => this.rerender());
 
-    this.assertText('Foo4');
+      this.assertText('Foo4');
 
-    this.runTask(() => this.context.set('user1', 'Bar'));
+      this.runTask(() => this.context.set('user1', 'Bar'));
 
-    this.assertText('Bar4');
+      this.assertText('Bar4');
 
-    this.runTask(() => this.context.set('user2', '5'));
+      this.runTask(() => this.context.set('user2', '5'));
 
-    this.assertText('Bar5');
+      this.assertText('Bar5');
 
-    this.runTask(() => {
-      this.context.set('user1', 'Foo');
-      this.context.set('user2', 4);
-    });
+      this.runTask(() => {
+        this.context.set('user1', 'Foo');
+        this.context.set('user2', 4);
+      });
 
-    this.assertText('Foo4');
-  }
+      this.assertText('Foo4');
+    }
 
-  ['@test with ariaRole specified']() {
-    this.registerComponent('aria-test', {
-      template: 'Here!'
-    });
+    ['@test with ariaRole specified']() {
+      this.registerComponent('aria-test', {
+        template: 'Here!'
+      });
 
-    this.render('{{aria-test ariaRole=role}}', {
-      role: 'main'
-    });
+      this.render('{{aria-test ariaRole=role}}', {
+        role: 'main'
+      });
 
-    this.assertComponentElement(this.firstChild, { attrs: { role: 'main' } });
+      this.assertComponentElement(this.firstChild, { attrs: { role: 'main' } });
 
-    this.runTask(() => this.rerender());
+      this.runTask(() => this.rerender());
 
-    this.assertComponentElement(this.firstChild, { attrs: { role: 'main' } });
+      this.assertComponentElement(this.firstChild, { attrs: { role: 'main' } });
 
-    this.runTask(() => this.context.set('role', 'input'));
+      this.runTask(() => this.context.set('role', 'input'));
 
-    this.assertComponentElement(this.firstChild, { attrs: { role: 'input' } });
+      this.assertComponentElement(this.firstChild, {
+        attrs: { role: 'input' }
+      });
 
-    this.runTask(() => this.context.set('role', 'main'));
+      this.runTask(() => this.context.set('role', 'main'));
 
-    this.assertComponentElement(this.firstChild, { attrs: { role: 'main' } });
-  }
+      this.assertComponentElement(this.firstChild, { attrs: { role: 'main' } });
+    }
 
-  ['@test `template` specified in component is overridden by block']() {
-    this.registerComponent('with-template', {
-      ComponentClass: Component.extend({
-        template: compile('Should not be used')
-      }),
-      template: '[In layout - {{name}}] {{yield}}'
-    });
+    ['@test `template` specified in component is overridden by block']() {
+      this.registerComponent('with-template', {
+        ComponentClass: Component.extend({
+          template: compile('Should not be used')
+        }),
+        template: '[In layout - {{name}}] {{yield}}'
+      });
 
-    this.render(strip`
+      this.render(
+        strip`
       {{#with-template name="with-block"}}
         [In block - {{name}}]
       {{/with-template}}
-      {{with-template name="without-block"}}`, {
-        name: 'Whoop, whoop!'
-      }
-    );
+      {{with-template name="without-block"}}`,
+        {
+          name: 'Whoop, whoop!'
+        }
+      );
 
-    this.assertText('[In layout - with-block] [In block - Whoop, whoop!][In layout - without-block] ');
+      this.assertText(
+        '[In layout - with-block] [In block - Whoop, whoop!][In layout - without-block] '
+      );
 
-    this.runTask(() => this.rerender());
+      this.runTask(() => this.rerender());
 
-    this.assertText('[In layout - with-block] [In block - Whoop, whoop!][In layout - without-block] ');
+      this.assertText(
+        '[In layout - with-block] [In block - Whoop, whoop!][In layout - without-block] '
+      );
 
-    this.runTask(() => this.context.set('name', 'Ole, ole'));
+      this.runTask(() => this.context.set('name', 'Ole, ole'));
 
-    this.assertText('[In layout - with-block] [In block - Ole, ole][In layout - without-block] ');
+      this.assertText(
+        '[In layout - with-block] [In block - Ole, ole][In layout - without-block] '
+      );
 
-    this.runTask(() => this.context.set('name', 'Whoop, whoop!'));
+      this.runTask(() => this.context.set('name', 'Whoop, whoop!'));
 
-    this.assertText('[In layout - with-block] [In block - Whoop, whoop!][In layout - without-block] ');
-  }
+      this.assertText(
+        '[In layout - with-block] [In block - Whoop, whoop!][In layout - without-block] '
+      );
+    }
 
-  ['@test hasBlock is true when block supplied']() {
-    this.registerComponent('with-block', {
-      template: strip`
+    ['@test hasBlock is true when block supplied']() {
+      this.registerComponent('with-block', {
+        template: strip`
         {{#if hasBlock}}
           {{yield}}
         {{else}}
           No Block!
         {{/if}}`
-    });
+      });
 
-    this.render(strip`
+      this.render(strip`
       {{#with-block}}
         In template
-      {{/with-block}}`
-    );
+      {{/with-block}}`);
 
-    this.assertText('In template');
+      this.assertText('In template');
 
-    this.runTask(() => this.rerender());
+      this.runTask(() => this.rerender());
 
-    this.assertText('In template');
-  }
+      this.assertText('In template');
+    }
 
-  ['@test hasBlock is false when no block supplied']() {
-    this.registerComponent('with-block', {
-      template: strip`
+    ['@test hasBlock is false when no block supplied']() {
+      this.registerComponent('with-block', {
+        template: strip`
         {{#if hasBlock}}
           {{yield}}
         {{else}}
           No Block!
         {{/if}}`
-    });
+      });
 
-    this.render('{{with-block}}');
+      this.render('{{with-block}}');
 
-    this.assertText('No Block!');
+      this.assertText('No Block!');
 
-    this.runTask(() => this.rerender());
+      this.runTask(() => this.rerender());
 
-    this.assertText('No Block!');
-  }
+      this.assertText('No Block!');
+    }
 
-  ['@test hasBlockParams is true when block param supplied']() {
-    this.registerComponent('with-block', {
-      template: strip`
+    ['@test hasBlockParams is true when block param supplied']() {
+      this.registerComponent('with-block', {
+        template: strip`
         {{#if hasBlockParams}}
           {{yield this}} - In Component
         {{else}}
           {{yield}} No Block!
         {{/if}}`
-    });
+      });
 
-    this.render(strip`
+      this.render(strip`
       {{#with-block as |something|}}
         In template
-      {{/with-block}}`
-    );
+      {{/with-block}}`);
 
-    this.assertText('In template - In Component');
+      this.assertText('In template - In Component');
 
-    this.runTask(() => this.rerender());
+      this.runTask(() => this.rerender());
 
-    this.assertText('In template - In Component');
-  }
+      this.assertText('In template - In Component');
+    }
 
-  ['@test hasBlockParams is false when no block param supplied']() {
-    this.registerComponent('with-block', {
-      template: strip`
+    ['@test hasBlockParams is false when no block param supplied']() {
+      this.registerComponent('with-block', {
+        template: strip`
         {{#if hasBlockParams}}
           {{yield this}}
         {{else}}
           {{yield}} No Block Param!
         {{/if}}`
-    });
+      });
 
-    this.render(strip`
+      this.render(strip`
       {{#with-block}}
         In block
-      {{/with-block}}`
-    );
+      {{/with-block}}`);
 
-    this.assertText('In block No Block Param!');
+      this.assertText('In block No Block Param!');
 
-    this.runTask(() => this.rerender());
+      this.runTask(() => this.rerender());
 
-    this.assertText('In block No Block Param!');
-  }
+      this.assertText('In block No Block Param!');
+    }
 
-  ['@test static named positional parameters']() {
-    this.registerComponent('sample-component', {
-      ComponentClass: Component.extend().reopenClass({
-        positionalParams: ['name', 'age']
-      }),
-      template: '{{name}}{{age}}'
-    });
-
-    this.render('{{sample-component "Quint" 4}}');
-
-    this.assertText('Quint4');
-
-    this.runTask(() => this.rerender());
-
-    this.assertText('Quint4');
-  }
-
-  ['@test dynamic named positional parameters']() {
-    this.registerComponent('sample-component', {
-      ComponentClass: Component.extend().reopenClass({
-        positionalParams: ['name', 'age']
-      }),
-      template: '{{name}}{{age}}'
-    });
-
-    this.render('{{sample-component myName myAge}}', {
-      myName: 'Quint',
-      myAge: 4
-    });
-
-    this.assertText('Quint4');
-
-    this.runTask(() => this.rerender());
-
-    this.assertText('Quint4');
-
-    this.runTask(() => this.context.set('myName', 'Sergio'));
-
-    this.assertText('Sergio4');
-
-    this.runTask(() => this.context.set('myAge', 2));
-
-    this.assertText('Sergio2');
-
-    this.runTask(() => {
-      this.context.set('myName', 'Quint');
-      this.context.set('myAge', 4);
-    });
-
-    this.assertText('Quint4');
-  }
-
-  ['@test if a value is passed as a non-positional parameter, it raises an assertion']() {
-    this.registerComponent('sample-component', {
-      ComponentClass: Component.extend().reopenClass({
-        positionalParams: ['name']
-      }),
-      template: '{{name}}'
-    });
-
-    expectDeprecation(() => {
-      this.render('{{sample-component notMyName name=myName}}', {
-        myName: 'Quint',
-        notMyName: 'Sergio'
+    ['@test static named positional parameters']() {
+      this.registerComponent('sample-component', {
+        ComponentClass: Component.extend().reopenClass({
+          positionalParams: ['name', 'age']
+        }),
+        template: '{{name}}{{age}}'
       });
-    }, 'You cannot specify both a positional param (at position 0) and the hash argument `name`.');
-  }
 
-  ['@test yield to inverse']() {
-    this.registerComponent('my-if', {
-      template: strip`
+      this.render('{{sample-component "Quint" 4}}');
+
+      this.assertText('Quint4');
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('Quint4');
+    }
+
+    ['@test dynamic named positional parameters']() {
+      this.registerComponent('sample-component', {
+        ComponentClass: Component.extend().reopenClass({
+          positionalParams: ['name', 'age']
+        }),
+        template: '{{name}}{{age}}'
+      });
+
+      this.render('{{sample-component myName myAge}}', {
+        myName: 'Quint',
+        myAge: 4
+      });
+
+      this.assertText('Quint4');
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('Quint4');
+
+      this.runTask(() => this.context.set('myName', 'Sergio'));
+
+      this.assertText('Sergio4');
+
+      this.runTask(() => this.context.set('myAge', 2));
+
+      this.assertText('Sergio2');
+
+      this.runTask(() => {
+        this.context.set('myName', 'Quint');
+        this.context.set('myAge', 4);
+      });
+
+      this.assertText('Quint4');
+    }
+
+    ['@test if a value is passed as a non-positional parameter, it raises an assertion']() {
+      this.registerComponent('sample-component', {
+        ComponentClass: Component.extend().reopenClass({
+          positionalParams: ['name']
+        }),
+        template: '{{name}}'
+      });
+
+      expectDeprecation(() => {
+        this.render('{{sample-component notMyName name=myName}}', {
+          myName: 'Quint',
+          notMyName: 'Sergio'
+        });
+      }, 'You cannot specify both a positional param (at position 0) and the hash argument `name`.');
+    }
+
+    ['@test yield to inverse']() {
+      this.registerComponent('my-if', {
+        template: strip`
         {{#if predicate}}
           Yes:{{yield someValue}}
         {{else}}
           No:{{yield to="inverse"}}
         {{/if}}`
-    });
+      });
 
-    this.render(strip`
+      this.render(
+        strip`
       {{#my-if predicate=activated someValue=42 as |result|}}
         Hello{{result}}
       {{else}}
         Goodbye
       {{/my-if}}`,
-      {
-        activated: true
-      });
+        {
+          activated: true
+        }
+      );
 
-    this.assertText('Yes:Hello42');
+      this.assertText('Yes:Hello42');
 
-    this.runTask(() => this.rerender());
+      this.runTask(() => this.rerender());
 
-    this.assertText('Yes:Hello42');
+      this.assertText('Yes:Hello42');
 
-    this.runTask(() => this.context.set('activated', false));
+      this.runTask(() => this.context.set('activated', false));
 
-    this.assertText('No:Goodbye');
+      this.assertText('No:Goodbye');
 
-    this.runTask(() => this.context.set('activated', true));
+      this.runTask(() => this.context.set('activated', true));
 
-    this.assertText('Yes:Hello42');
-  }
+      this.assertText('Yes:Hello42');
+    }
 
-  ['@test expression hasBlock inverse']() {
-    this.registerComponent('check-inverse', {
-      template: strip`
+    ['@test expression hasBlock inverse']() {
+      this.registerComponent('check-inverse', {
+        template: strip`
         {{#if (hasBlock "inverse")}}
           Yes
         {{else}}
           No
         {{/if}}`
-    });
+      });
 
-    this.render(strip`
+      this.render(strip`
       {{#check-inverse}}{{/check-inverse}}
       {{#check-inverse}}{{else}}{{/check-inverse}}`);
 
-    this.assertComponentElement(this.firstChild, { content: 'No' });
-    this.assertComponentElement(this.nthChild(1), { content: 'Yes' });
+      this.assertComponentElement(this.firstChild, { content: 'No' });
+      this.assertComponentElement(this.nthChild(1), { content: 'Yes' });
 
-    this.assertStableRerender();
-  }
+      this.assertStableRerender();
+    }
 
-  ['@test expression hasBlock default']() {
-    this.registerComponent('check-block', {
-      template: strip`
+    ['@test expression hasBlock default']() {
+      this.registerComponent('check-block', {
+        template: strip`
         {{#if (hasBlock)}}
           Yes
         {{else}}
           No
         {{/if}}`
-    });
+      });
 
-    this.render(strip`
+      this.render(strip`
       {{check-block}}
       {{#check-block}}{{/check-block}}`);
 
-    this.assertComponentElement(this.firstChild, { content: 'No' });
-    this.assertComponentElement(this.nthChild(1), { content: 'Yes' });
+      this.assertComponentElement(this.firstChild, { content: 'No' });
+      this.assertComponentElement(this.nthChild(1), { content: 'Yes' });
 
-    this.assertStableRerender();
-  }
+      this.assertStableRerender();
+    }
 
-  ['@test expression hasBlockParams inverse']() {
-    this.registerComponent('check-inverse', {
-      template: strip`
+    ['@test expression hasBlockParams inverse']() {
+      this.registerComponent('check-inverse', {
+        template: strip`
         {{#if (hasBlockParams "inverse")}}
           Yes
         {{else}}
           No
         {{/if}}`
-    });
+      });
 
-    this.render(strip`
+      this.render(strip`
       {{#check-inverse}}{{/check-inverse}}
       {{#check-inverse as |something|}}{{/check-inverse}}`);
 
-    this.assertComponentElement(this.firstChild, { content: 'No' });
-    this.assertComponentElement(this.nthChild(1), { content: 'No' });
+      this.assertComponentElement(this.firstChild, { content: 'No' });
+      this.assertComponentElement(this.nthChild(1), { content: 'No' });
 
-    this.assertStableRerender();
-  }
+      this.assertStableRerender();
+    }
 
-  ['@test expression hasBlockParams default']() {
-    this.registerComponent('check-block', {
-      template: strip`
+    ['@test expression hasBlockParams default']() {
+      this.registerComponent('check-block', {
+        template: strip`
         {{#if (hasBlockParams)}}
           Yes
         {{else}}
           No
         {{/if}}`
-    });
+      });
 
-    this.render(strip`
+      this.render(strip`
       {{#check-block}}{{/check-block}}
       {{#check-block as |something|}}{{/check-block}}`);
 
-    this.assertComponentElement(this.firstChild, { content: 'No' });
-    this.assertComponentElement(this.nthChild(1), { content: 'Yes' });
+      this.assertComponentElement(this.firstChild, { content: 'No' });
+      this.assertComponentElement(this.nthChild(1), { content: 'Yes' });
 
-    this.assertStableRerender();
-  }
+      this.assertStableRerender();
+    }
 
-
-  ['@test non-expression hasBlock']() {
-    this.registerComponent('check-block', {
-      template: strip`
+    ['@test non-expression hasBlock']() {
+      this.registerComponent('check-block', {
+        template: strip`
         {{#if hasBlock}}
           Yes
         {{else}}
           No
         {{/if}}`
-    });
+      });
 
-    this.render(strip`
+      this.render(strip`
       {{check-block}}
       {{#check-block}}{{/check-block}}`);
 
-    this.assertComponentElement(this.firstChild, { content: 'No' });
-    this.assertComponentElement(this.nthChild(1), { content: 'Yes' });
+      this.assertComponentElement(this.firstChild, { content: 'No' });
+      this.assertComponentElement(this.nthChild(1), { content: 'Yes' });
 
-    this.assertStableRerender();
-  }
+      this.assertStableRerender();
+    }
 
-  ['@test expression hasBlockParams']() {
-    this.registerComponent('check-params', {
-      template: strip`
+    ['@test expression hasBlockParams']() {
+      this.registerComponent('check-params', {
+        template: strip`
         {{#if (hasBlockParams)}}
           Yes
         {{else}}
           No
         {{/if}}`
-    });
+      });
 
-    this.render(strip`
+      this.render(strip`
       {{#check-params}}{{/check-params}}
       {{#check-params as |foo|}}{{/check-params}}`);
 
-    this.assertComponentElement(this.firstChild, { content: 'No' });
-    this.assertComponentElement(this.nthChild(1), { content: 'Yes' });
+      this.assertComponentElement(this.firstChild, { content: 'No' });
+      this.assertComponentElement(this.nthChild(1), { content: 'Yes' });
 
-    this.assertStableRerender();
-  }
+      this.assertStableRerender();
+    }
 
-  ['@test non-expression hasBlockParams']() {
-    this.registerComponent('check-params', {
-      template: strip`
+    ['@test non-expression hasBlockParams']() {
+      this.registerComponent('check-params', {
+        template: strip`
         {{#if hasBlockParams}}
           Yes
         {{else}}
           No
         {{/if}}`
-    });
+      });
 
-    this.render(strip`
+      this.render(strip`
       {{#check-params}}{{/check-params}}
       {{#check-params as |foo|}}{{/check-params}}`);
 
-    this.assertComponentElement(this.firstChild, { content: 'No' });
-    this.assertComponentElement(this.nthChild(1), { content: 'Yes' });
+      this.assertComponentElement(this.firstChild, { content: 'No' });
+      this.assertComponentElement(this.nthChild(1), { content: 'Yes' });
 
-    this.assertStableRerender();
-  }
+      this.assertStableRerender();
+    }
 
-  ['@test hasBlock expression in an attribute'](assert) {
-    this.registerComponent('check-attr', {
-      template: '<button name={{hasBlock}}></button>'
-    });
+    ['@test hasBlock expression in an attribute'](assert) {
+      this.registerComponent('check-attr', {
+        template: '<button name={{hasBlock}}></button>'
+      });
 
-    this.render(strip`
+      this.render(strip`
       {{check-attr}}
       {{#check-attr}}{{/check-attr}}`);
 
-    equalsElement(assert, this.$('button')[0], 'button', { name: 'false' }, '');
-    equalsElement(assert, this.$('button')[1], 'button', { name: 'true' }, '');
+      equalsElement(
+        assert,
+        this.$('button')[0],
+        'button',
+        { name: 'false' },
+        ''
+      );
+      equalsElement(
+        assert,
+        this.$('button')[1],
+        'button',
+        { name: 'true' },
+        ''
+      );
 
-    this.assertStableRerender();
-  }
+      this.assertStableRerender();
+    }
 
-  ['@test hasBlock inverse expression in an attribute'](assert) {
-    this.registerComponent('check-attr', {
-      template: '<button name={{hasBlock "inverse"}}></button>'
-    }, '');
+    ['@test hasBlock inverse expression in an attribute'](assert) {
+      this.registerComponent(
+        'check-attr',
+        {
+          template: '<button name={{hasBlock "inverse"}}></button>'
+        },
+        ''
+      );
 
-    this.render(strip`
+      this.render(strip`
       {{#check-attr}}{{/check-attr}}
       {{#check-attr}}{{else}}{{/check-attr}}`);
 
-    equalsElement(assert, this.$('button')[0], 'button', { name: 'false' }, '');
-    equalsElement(assert, this.$('button')[1], 'button', { name: 'true' }, '');
+      equalsElement(
+        assert,
+        this.$('button')[0],
+        'button',
+        { name: 'false' },
+        ''
+      );
+      equalsElement(
+        assert,
+        this.$('button')[1],
+        'button',
+        { name: 'true' },
+        ''
+      );
 
-    this.assertStableRerender();
-  }
+      this.assertStableRerender();
+    }
 
-  ['@test hasBlockParams expression in an attribute'](assert) {
-    this.registerComponent('check-attr', {
-      template: '<button name={{hasBlockParams}}></button>'
-    });
+    ['@test hasBlockParams expression in an attribute'](assert) {
+      this.registerComponent('check-attr', {
+        template: '<button name={{hasBlockParams}}></button>'
+      });
 
-    this.render(strip`
+      this.render(strip`
       {{#check-attr}}{{/check-attr}}
       {{#check-attr as |something|}}{{/check-attr}}`);
 
-    equalsElement(assert, this.$('button')[0], 'button', { name: 'false' }, '');
-    equalsElement(assert, this.$('button')[1], 'button', { name: 'true' }, '');
+      equalsElement(
+        assert,
+        this.$('button')[0],
+        'button',
+        { name: 'false' },
+        ''
+      );
+      equalsElement(
+        assert,
+        this.$('button')[1],
+        'button',
+        { name: 'true' },
+        ''
+      );
 
-    this.assertStableRerender();
-  }
+      this.assertStableRerender();
+    }
 
-  ['@test hasBlockParams inverse expression in an attribute'](assert) {
-    this.registerComponent('check-attr', {
-      template: '<button name={{hasBlockParams "inverse"}}></button>'
-    }, '');
+    ['@test hasBlockParams inverse expression in an attribute'](assert) {
+      this.registerComponent(
+        'check-attr',
+        {
+          template: '<button name={{hasBlockParams "inverse"}}></button>'
+        },
+        ''
+      );
 
-    this.render(strip`
+      this.render(strip`
       {{#check-attr}}{{/check-attr}}
       {{#check-attr as |something|}}{{/check-attr}}`);
 
-    equalsElement(assert, this.$('button')[0], 'button', { name: 'false' }, '');
-    equalsElement(assert, this.$('button')[1], 'button', { name: 'false' }, '');
+      equalsElement(
+        assert,
+        this.$('button')[0],
+        'button',
+        { name: 'false' },
+        ''
+      );
+      equalsElement(
+        assert,
+        this.$('button')[1],
+        'button',
+        { name: 'false' },
+        ''
+      );
 
-    this.assertStableRerender();
-  }
+      this.assertStableRerender();
+    }
 
-  ['@test hasBlock as a param to a helper']() {
-    this.registerComponent('check-helper', {
-      template: '{{if hasBlock "true" "false"}}'
-    });
+    ['@test hasBlock as a param to a helper']() {
+      this.registerComponent('check-helper', {
+        template: '{{if hasBlock "true" "false"}}'
+      });
 
-    this.render(strip`
+      this.render(strip`
       {{check-helper}}
       {{#check-helper}}{{/check-helper}}`);
 
-    this.assertComponentElement(this.firstChild, { content: 'false' });
-    this.assertComponentElement(this.nthChild(1), { content: 'true' });
+      this.assertComponentElement(this.firstChild, { content: 'false' });
+      this.assertComponentElement(this.nthChild(1), { content: 'true' });
 
-    this.assertStableRerender();
-  }
+      this.assertStableRerender();
+    }
 
-  ['@test hasBlock as an expression param to a helper']() {
-    this.registerComponent('check-helper', {
-      template: '{{if (hasBlock) "true" "false"}}'
-    });
+    ['@test hasBlock as an expression param to a helper']() {
+      this.registerComponent('check-helper', {
+        template: '{{if (hasBlock) "true" "false"}}'
+      });
 
-    this.render(strip`
+      this.render(strip`
       {{check-helper}}
       {{#check-helper}}{{/check-helper}}`);
 
-    this.assertComponentElement(this.firstChild, { content: 'false' });
-    this.assertComponentElement(this.nthChild(1), { content: 'true' });
+      this.assertComponentElement(this.firstChild, { content: 'false' });
+      this.assertComponentElement(this.nthChild(1), { content: 'true' });
 
-    this.assertStableRerender();
-  }
+      this.assertStableRerender();
+    }
 
-  ['@test hasBlock inverse as a param to a helper']() {
-    this.registerComponent('check-helper', {
-      template: '{{if (hasBlock "inverse") "true" "false"}}'
-    });
+    ['@test hasBlock inverse as a param to a helper']() {
+      this.registerComponent('check-helper', {
+        template: '{{if (hasBlock "inverse") "true" "false"}}'
+      });
 
-    this.render(strip`
+      this.render(strip`
       {{#check-helper}}{{/check-helper}}
       {{#check-helper}}{{else}}{{/check-helper}}`);
 
-    this.assertComponentElement(this.firstChild, { content: 'false' });
-    this.assertComponentElement(this.nthChild(1), { content: 'true' });
+      this.assertComponentElement(this.firstChild, { content: 'false' });
+      this.assertComponentElement(this.nthChild(1), { content: 'true' });
 
-    this.assertStableRerender();
-  }
+      this.assertStableRerender();
+    }
 
-  ['@test hasBlockParams as a param to a helper']() {
-    this.registerComponent('check-helper', {
-      template: '{{if hasBlockParams "true" "false"}}'
-    });
+    ['@test hasBlockParams as a param to a helper']() {
+      this.registerComponent('check-helper', {
+        template: '{{if hasBlockParams "true" "false"}}'
+      });
 
-    this.render(strip`
+      this.render(strip`
       {{#check-helper}}{{/check-helper}}
       {{#check-helper as |something|}}{{/check-helper}}`);
 
-    this.assertComponentElement(this.firstChild, { content: 'false' });
-    this.assertComponentElement(this.nthChild(1), { content: 'true' });
+      this.assertComponentElement(this.firstChild, { content: 'false' });
+      this.assertComponentElement(this.nthChild(1), { content: 'true' });
 
-    this.assertStableRerender();
-  }
+      this.assertStableRerender();
+    }
 
-  ['@test hasBlockParams as an expression param to a helper']() {
-    this.registerComponent('check-helper', {
-      template: '{{if (hasBlockParams) "true" "false"}}'
-    });
+    ['@test hasBlockParams as an expression param to a helper']() {
+      this.registerComponent('check-helper', {
+        template: '{{if (hasBlockParams) "true" "false"}}'
+      });
 
-    this.render(strip`
+      this.render(strip`
       {{#check-helper}}{{/check-helper}}
       {{#check-helper as |something|}}{{/check-helper}}`);
 
-    this.assertComponentElement(this.firstChild, { content: 'false' });
-    this.assertComponentElement(this.nthChild(1), { content: 'true' });
+      this.assertComponentElement(this.firstChild, { content: 'false' });
+      this.assertComponentElement(this.nthChild(1), { content: 'true' });
 
-    this.assertStableRerender();
-  }
+      this.assertStableRerender();
+    }
 
-  ['@test hasBlockParams inverse as a param to a helper']() {
-    this.registerComponent('check-helper', {
-      template: '{{if (hasBlockParams "inverse") "true" "false"}}'
-    });
+    ['@test hasBlockParams inverse as a param to a helper']() {
+      this.registerComponent('check-helper', {
+        template: '{{if (hasBlockParams "inverse") "true" "false"}}'
+      });
 
-    this.render(strip`
+      this.render(strip`
       {{#check-helper}}{{/check-helper}}
       {{#check-helper as |something|}}{{/check-helper}}`);
 
-    this.assertComponentElement(this.firstChild, { content: 'false' });
-    this.assertComponentElement(this.nthChild(1), { content: 'false' });
+      this.assertComponentElement(this.firstChild, { content: 'false' });
+      this.assertComponentElement(this.nthChild(1), { content: 'false' });
 
-    this.assertStableRerender();
-  }
+      this.assertStableRerender();
+    }
 
-  ['@test component in template of a yielding component should have the proper parentView'](assert) {
-    let outer, innerTemplate, innerLayout;
+    ['@test component in template of a yielding component should have the proper parentView'](
+      assert
+    ) {
+      let outer, innerTemplate, innerLayout;
 
-    this.registerComponent('x-outer', {
-      ComponentClass: Component.extend({
-        init() {
-          this._super(...arguments);
-          outer = this;
-        }
-      }),
-      template: '{{x-inner-in-layout}}{{yield}}'
-    });
+      this.registerComponent('x-outer', {
+        ComponentClass: Component.extend({
+          init() {
+            this._super(...arguments);
+            outer = this;
+          }
+        }),
+        template: '{{x-inner-in-layout}}{{yield}}'
+      });
 
-    this.registerComponent('x-inner-in-template', {
-      ComponentClass: Component.extend({
-        init() {
-          this._super(...arguments);
-          innerTemplate = this;
-        }
-      })
-    });
+      this.registerComponent('x-inner-in-template', {
+        ComponentClass: Component.extend({
+          init() {
+            this._super(...arguments);
+            innerTemplate = this;
+          }
+        })
+      });
 
-    this.registerComponent('x-inner-in-layout', {
-      ComponentClass: Component.extend({
-        init() {
-          this._super(...arguments);
-          innerLayout = this;
-        }
-      })
-    });
+      this.registerComponent('x-inner-in-layout', {
+        ComponentClass: Component.extend({
+          init() {
+            this._super(...arguments);
+            innerLayout = this;
+          }
+        })
+      });
 
-    this.render('{{#x-outer}}{{x-inner-in-template}}{{/x-outer}}');
+      this.render('{{#x-outer}}{{x-inner-in-template}}{{/x-outer}}');
 
-    assert.equal(innerTemplate.parentView, outer, 'receives the wrapping component as its parentView in template blocks');
-    assert.equal(innerLayout.parentView, outer, 'receives the wrapping component as its parentView in layout');
-    assert.equal(outer.parentView, this.context, 'x-outer receives the ambient scope as its parentView');
+      assert.equal(
+        innerTemplate.parentView,
+        outer,
+        'receives the wrapping component as its parentView in template blocks'
+      );
+      assert.equal(
+        innerLayout.parentView,
+        outer,
+        'receives the wrapping component as its parentView in layout'
+      );
+      assert.equal(
+        outer.parentView,
+        this.context,
+        'x-outer receives the ambient scope as its parentView'
+      );
 
-    this.runTask(() => this.rerender());
+      this.runTask(() => this.rerender());
 
-    assert.equal(innerTemplate.parentView, outer, 'receives the wrapping component as its parentView in template blocks');
-    assert.equal(innerLayout.parentView, outer, 'receives the wrapping component as its parentView in layout');
-    assert.equal(outer.parentView, this.context, 'x-outer receives the ambient scope as its parentView');
-  }
+      assert.equal(
+        innerTemplate.parentView,
+        outer,
+        'receives the wrapping component as its parentView in template blocks'
+      );
+      assert.equal(
+        innerLayout.parentView,
+        outer,
+        'receives the wrapping component as its parentView in layout'
+      );
+      assert.equal(
+        outer.parentView,
+        this.context,
+        'x-outer receives the ambient scope as its parentView'
+      );
+    }
 
-  ['@test newly-added sub-components get correct parentView'](assert) {
-    let outer, inner;
+    ['@test newly-added sub-components get correct parentView'](assert) {
+      let outer, inner;
 
-    this.registerComponent('x-outer', {
-      ComponentClass: Component.extend({
-        init() {
-          this._super(...arguments);
-          outer = this;
-        }
-      })
-    });
+      this.registerComponent('x-outer', {
+        ComponentClass: Component.extend({
+          init() {
+            this._super(...arguments);
+            outer = this;
+          }
+        })
+      });
 
-    this.registerComponent('x-inner', {
-      ComponentClass: Component.extend({
-        init() {
-          this._super(...arguments);
-          inner = this;
-        }
-      })
-    });
+      this.registerComponent('x-inner', {
+        ComponentClass: Component.extend({
+          init() {
+            this._super(...arguments);
+            inner = this;
+          }
+        })
+      });
 
-    this.render(strip`
+      this.render(
+        strip`
       {{#x-outer}}
         {{#if showInner}}
           {{x-inner}}
         {{/if}}
       {{/x-outer}}`,
-      {
-        showInner: false
-      }
-    );
+        {
+          showInner: false
+        }
+      );
 
-    assert.equal(outer.parentView, this.context, 'x-outer receives the ambient scope as its parentView');
+      assert.equal(
+        outer.parentView,
+        this.context,
+        'x-outer receives the ambient scope as its parentView'
+      );
 
-    this.runTask(() => this.rerender());
+      this.runTask(() => this.rerender());
 
-    assert.equal(outer.parentView, this.context, 'x-outer receives the ambient scope as its parentView (after rerender)');
+      assert.equal(
+        outer.parentView,
+        this.context,
+        'x-outer receives the ambient scope as its parentView (after rerender)'
+      );
 
-    this.runTask(() => this.context.set('showInner', true));
+      this.runTask(() => this.context.set('showInner', true));
 
-    assert.equal(outer.parentView, this.context, 'x-outer receives the ambient scope as its parentView');
-    assert.equal(inner.parentView, outer, 'receives the wrapping component as its parentView in template blocks');
+      assert.equal(
+        outer.parentView,
+        this.context,
+        'x-outer receives the ambient scope as its parentView'
+      );
+      assert.equal(
+        inner.parentView,
+        outer,
+        'receives the wrapping component as its parentView in template blocks'
+      );
 
-    this.runTask(() => this.context.set('showInner', false));
+      this.runTask(() => this.context.set('showInner', false));
 
-    assert.equal(outer.parentView, this.context, 'x-outer receives the ambient scope as its parentView');
-  }
+      assert.equal(
+        outer.parentView,
+        this.context,
+        'x-outer receives the ambient scope as its parentView'
+      );
+    }
 
-  ['@test when a property is changed during children\'s rendering'](assert) {
-    let outer, middle;
+    ["@test when a property is changed during children's rendering"](assert) {
+      let outer, middle;
 
-    this.registerComponent('x-outer', {
-      ComponentClass: Component.extend({
-        init() {
-          this._super(...arguments);
-          outer = this;
-        },
-        value: 1
-      }),
-      template: '{{#x-middle}}{{x-inner value=value}}{{/x-middle}}'
-    });
+      this.registerComponent('x-outer', {
+        ComponentClass: Component.extend({
+          init() {
+            this._super(...arguments);
+            outer = this;
+          },
+          value: 1
+        }),
+        template: '{{#x-middle}}{{x-inner value=value}}{{/x-middle}}'
+      });
 
-    this.registerComponent('x-middle', {
-      ComponentClass: Component.extend({
-        init() {
-          this._super(...arguments);
-          middle = this;
-        },
-        value: null
-      }),
-      template: '<div id="middle-value">{{value}}</div>{{yield}}'
-    });
+      this.registerComponent('x-middle', {
+        ComponentClass: Component.extend({
+          init() {
+            this._super(...arguments);
+            middle = this;
+          },
+          value: null
+        }),
+        template: '<div id="middle-value">{{value}}</div>{{yield}}'
+      });
 
-    this.registerComponent('x-inner', {
-      ComponentClass: Component.extend({
-        value: null,
-        pushDataUp: observer('value', function() {
-          middle.set('value', this.get('value'));
-        })
-      }),
-      template: '<div id="inner-value">{{value}}</div>'
-    });
+      this.registerComponent('x-inner', {
+        ComponentClass: Component.extend({
+          value: null,
+          pushDataUp: observer('value', function() {
+            middle.set('value', this.get('value'));
+          })
+        }),
+        template: '<div id="inner-value">{{value}}</div>'
+      });
 
-    this.render('{{x-outer}}');
-
-    assert.equal(this.$('#inner-value').text(), '1', 'initial render of inner');
-    assert.equal(this.$('#middle-value').text(), '', 'initial render of middle (observers do not run during init)');
-
-    this.runTask(() => this.rerender());
-
-    assert.equal(this.$('#inner-value').text(), '1', 'initial render of inner');
-    assert.equal(this.$('#middle-value').text(), '', 'initial render of middle (observers do not run during init)');
-
-    let expectedBacktrackingMessage = /modified "value" twice on <\(.+> in a single render\. It was rendered in "component:x-middle" and modified in "component:x-inner"/;
-
-    expectAssertion(() => {
-      this.runTask(() => outer.set('value', 2));
-    }, expectedBacktrackingMessage);
-  }
-
-  ['@test when a shared dependency is changed during children\'s rendering']() {
-    this.registerComponent('x-outer', {
-      ComponentClass: Component.extend({
-        value: 1,
-        wrapper: EmberObject.create({ content: null })
-      }),
-      template: '<div id="outer-value">{{wrapper.content}}</div> {{x-inner value=value wrapper=wrapper}}'
-    });
-
-    this.registerComponent('x-inner', {
-      ComponentClass: Component.extend({
-        didReceiveAttrs() {
-          this.get('wrapper').set('content', this.get('value'));
-        },
-        value: null
-      }),
-      template: '<div id="inner-value">{{wrapper.content}}</div>'
-    });
-
-    let expectedBacktrackingMessage = /modified "wrapper\.content" twice on <Ember\.Object.+> in a single render\. It was rendered in "component:x-outer" and modified in "component:x-inner"/;
-
-    expectAssertion(() => {
       this.render('{{x-outer}}');
-    }, expectedBacktrackingMessage);
-  }
 
-  ['@test non-block with each rendering child components']() {
-    this.registerComponent('non-block', {
-      template: strip`
+      assert.equal(
+        this.$('#inner-value').text(),
+        '1',
+        'initial render of inner'
+      );
+      assert.equal(
+        this.$('#middle-value').text(),
+        '',
+        'initial render of middle (observers do not run during init)'
+      );
+
+      this.runTask(() => this.rerender());
+
+      assert.equal(
+        this.$('#inner-value').text(),
+        '1',
+        'initial render of inner'
+      );
+      assert.equal(
+        this.$('#middle-value').text(),
+        '',
+        'initial render of middle (observers do not run during init)'
+      );
+
+      let expectedBacktrackingMessage = /modified "value" twice on <.+?> in a single render\. It was rendered in "component:x-middle" and modified in "component:x-inner"/;
+
+      expectAssertion(() => {
+        this.runTask(() => outer.set('value', 2));
+      }, expectedBacktrackingMessage);
+    }
+
+    ["@test when a shared dependency is changed during children's rendering"]() {
+      this.registerComponent('x-outer', {
+        ComponentClass: Component.extend({
+          value: 1,
+          wrapper: EmberObject.create({ content: null })
+        }),
+        template:
+          '<div id="outer-value">{{wrapper.content}}</div> {{x-inner value=value wrapper=wrapper}}'
+      });
+
+      this.registerComponent('x-inner', {
+        ComponentClass: Component.extend({
+          didReceiveAttrs() {
+            this.get('wrapper').set('content', this.get('value'));
+          },
+          value: null
+        }),
+        template: '<div id="inner-value">{{wrapper.content}}</div>'
+      });
+
+      let expectedBacktrackingMessage = /modified "wrapper\.content" twice on <.+?> in a single render\. It was rendered in "component:x-outer" and modified in "component:x-inner"/;
+
+      expectAssertion(() => {
+        this.render('{{x-outer}}');
+      }, expectedBacktrackingMessage);
+    }
+
+    ['@test non-block with each rendering child components']() {
+      this.registerComponent('non-block', {
+        template: strip`
         In layout. {{#each items as |item|}}
           [{{child-non-block item=item}}]
         {{/each}}`
-    });
+      });
 
-    this.registerComponent('child-non-block', {
-      template: 'Child: {{item}}.'
-    });
+      this.registerComponent('child-non-block', {
+        template: 'Child: {{item}}.'
+      });
 
-    let items = emberA(['Tom', 'Dick', 'Harry']);
+      let items = emberA(['Tom', 'Dick', 'Harry']);
 
-    this.render('{{non-block items=items}}', { items });
+      this.render('{{non-block items=items}}', { items });
 
-    this.assertText('In layout. [Child: Tom.][Child: Dick.][Child: Harry.]');
+      this.assertText('In layout. [Child: Tom.][Child: Dick.][Child: Harry.]');
 
-    this.runTask(() => this.rerender());
+      this.runTask(() => this.rerender());
 
-    this.assertText('In layout. [Child: Tom.][Child: Dick.][Child: Harry.]');
+      this.assertText('In layout. [Child: Tom.][Child: Dick.][Child: Harry.]');
 
-    this.runTask(() => this.context.get('items').pushObject('Sergio'));
+      this.runTask(() => this.context.get('items').pushObject('Sergio'));
 
-    this.assertText('In layout. [Child: Tom.][Child: Dick.][Child: Harry.][Child: Sergio.]');
+      this.assertText(
+        'In layout. [Child: Tom.][Child: Dick.][Child: Harry.][Child: Sergio.]'
+      );
 
-    this.runTask(() => this.context.get('items').shiftObject());
+      this.runTask(() => this.context.get('items').shiftObject());
 
-    this.assertText('In layout. [Child: Dick.][Child: Harry.][Child: Sergio.]');
+      this.assertText(
+        'In layout. [Child: Dick.][Child: Harry.][Child: Sergio.]'
+      );
 
-    this.runTask(() => this.context.set('items', emberA(['Tom', 'Dick', 'Harry'])));
+      this.runTask(() =>
+        this.context.set('items', emberA(['Tom', 'Dick', 'Harry']))
+      );
 
-    this.assertText('In layout. [Child: Tom.][Child: Dick.][Child: Harry.]');
-  }
+      this.assertText('In layout. [Child: Tom.][Child: Dick.][Child: Harry.]');
+    }
 
-  ['@test specifying classNames results in correct class'](assert) {
-    this.registerComponent('some-clicky-thing', {
-      ComponentClass: Component.extend({
-        tagName: 'button',
-        classNames: ['foo', 'bar']
-      })
-    });
+    ['@test specifying classNames results in correct class'](assert) {
+      this.registerComponent('some-clicky-thing', {
+        ComponentClass: Component.extend({
+          tagName: 'button',
+          classNames: ['foo', 'bar']
+        })
+      });
 
-    this.render(strip`
+      this.render(strip`
       {{#some-clicky-thing classNames="baz"}}
         Click Me
-      {{/some-clicky-thing}}`
-    );
+      {{/some-clicky-thing}}`);
 
-    // TODO: ember-view is no longer viewable in the classNames array. Bug or
-    // feature?
-    let expectedClassNames = ['ember-view', 'foo', 'bar', 'baz'];
+      // TODO: ember-view is no longer viewable in the classNames array. Bug or
+      // feature?
+      let expectedClassNames = ['ember-view', 'foo', 'bar', 'baz'];
 
-    assert.ok(this.$('button').is('.foo.bar.baz.ember-view'), `the element has the correct classes: ${this.$('button').attr('class')}`);
-    // `ember-view` is no longer in classNames.
-    // assert.deepEqual(clickyThing.get('classNames'), expectedClassNames, 'classNames are properly combined');
-    this.assertComponentElement(this.firstChild, { tagName: 'button', attrs: { 'class': classes(expectedClassNames.join(' ')) } });
+      assert.ok(
+        this.$('button').is('.foo.bar.baz.ember-view'),
+        `the element has the correct classes: ${this.$('button').attr('class')}`
+      );
+      // `ember-view` is no longer in classNames.
+      // assert.deepEqual(clickyThing.get('classNames'), expectedClassNames, 'classNames are properly combined');
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'button',
+        attrs: { class: classes(expectedClassNames.join(' ')) }
+      });
 
-    this.runTask(() => this.rerender());
+      this.runTask(() => this.rerender());
 
-    assert.ok(this.$('button').is('.foo.bar.baz.ember-view'), `the element has the correct classes: ${this.$('button').attr('class')} (rerender)`);
-    // `ember-view` is no longer in classNames.
-    // assert.deepEqual(clickyThing.get('classNames'), expectedClassNames, 'classNames are properly combined (rerender)');
-    this.assertComponentElement(this.firstChild, { tagName: 'button', attrs: { 'class': classes(expectedClassNames.join(' ')) } });
-  }
+      assert.ok(
+        this.$('button').is('.foo.bar.baz.ember-view'),
+        `the element has the correct classes: ${this.$('button').attr(
+          'class'
+        )} (rerender)`
+      );
+      // `ember-view` is no longer in classNames.
+      // assert.deepEqual(clickyThing.get('classNames'), expectedClassNames, 'classNames are properly combined (rerender)');
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'button',
+        attrs: { class: classes(expectedClassNames.join(' ')) }
+      });
+    }
 
-  ['@test specifying custom concatenatedProperties avoids clobbering']() {
-    this.registerComponent('some-clicky-thing', {
-      ComponentClass: Component.extend({
-        concatenatedProperties: ['blahzz'],
-        blahzz: ['blark', 'pory']
-      }),
-      template: strip`
+    ['@test specifying custom concatenatedProperties avoids clobbering']() {
+      this.registerComponent('some-clicky-thing', {
+        ComponentClass: Component.extend({
+          concatenatedProperties: ['blahzz'],
+          blahzz: ['blark', 'pory']
+        }),
+        template: strip`
         {{#each blahzz as |p|}}
           {{p}}
         {{/each}}
         - {{yield}}`
-    });
+      });
 
-    this.render(strip`
+      this.render(strip`
       {{#some-clicky-thing blahzz="baz"}}
         Click Me
-      {{/some-clicky-thing}}`
-    );
+      {{/some-clicky-thing}}`);
 
-    this.assertText('blarkporybaz- Click Me');
+      this.assertText('blarkporybaz- Click Me');
 
-    this.runTask(() => this.rerender());
+      this.runTask(() => this.rerender());
 
-    this.assertText('blarkporybaz- Click Me');
-  }
+      this.assertText('blarkporybaz- Click Me');
+    }
 
-  ['@test a two way binding flows upstream when consumed in the template']() {
-    let component;
-    let FooBarComponent = Component.extend({
-      init() {
-        this._super(...arguments);
-        component = this;
+    ['@test a two way binding flows upstream when consumed in the template']() {
+      let component;
+      let FooBarComponent = Component.extend({
+        init() {
+          this._super(...arguments);
+          component = this;
+        }
+      });
+
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
+
+        template: '{{bar}}'
+      });
+
+      this.render('{{localBar}} - {{foo-bar bar=localBar}}', {
+        localBar: 'initial value'
+      });
+
+      this.assertText('initial value - initial value');
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('initial value - initial value');
+
+      if (MANDATORY_SETTER) {
+        expectAssertion(() => {
+          component.bar = 'foo-bar';
+        }, /You must use set\(\) to set the `bar` property \(of .+\) to `foo-bar`\./);
+
+        this.assertText('initial value - initial value');
       }
-    });
 
-    this.registerComponent('foo-bar', {
-      ComponentClass: FooBarComponent,
+      this.runTask(() => {
+        component.set('bar', 'updated value');
+      });
 
-      template: '{{bar}}'
-    });
+      this.assertText('updated value - updated value');
 
-    this.render('{{localBar}} - {{foo-bar bar=localBar}}', {
-      localBar: 'initial value'
-    });
+      this.runTask(() => {
+        component.set('bar', undefined);
+      });
 
-    this.assertText('initial value - initial value');
+      this.assertText(' - ');
 
-    this.runTask(() => this.rerender());
-
-    this.assertText('initial value - initial value');
-
-    if (MANDATORY_SETTER) {
-      expectAssertion(() => {
-        component.bar = 'foo-bar';
-      }, /You must use set\(\) to set the `bar` property \(of .+\) to `foo-bar`\./);
+      this.runTask(() => {
+        this.component.set('localBar', 'initial value');
+      });
 
       this.assertText('initial value - initial value');
     }
 
-    this.runTask(() => { component.set('bar', 'updated value'); });
-
-    this.assertText('updated value - updated value');
-
-    this.runTask(() => { component.set('bar', undefined); });
-
-    this.assertText(' - ');
-
-    this.runTask(() => { this.component.set('localBar', 'initial value'); });
-
-    this.assertText('initial value - initial value');
-  }
-
-  ['@test a two way binding flows upstream through a CP when consumed in the template']() {
-    let component;
-    let FooBarComponent = Component.extend({
-      init() {
-        this._super(...arguments);
-        component = this;
-      },
-
-      bar: computed({
-        get() {
-          return this._bar;
-        },
-
-        set(key, value) {
-          this._bar = value;
-          return this._bar;
-        }
-      })
-    });
-
-    this.registerComponent('foo-bar', {
-      ComponentClass: FooBarComponent,
-
-      template: '{{bar}}'
-    });
-
-    this.render('{{localBar}} - {{foo-bar bar=localBar}}', {
-      localBar: 'initial value'
-    });
-
-    this.assertText('initial value - initial value');
-
-    this.runTask(() => this.rerender());
-
-    this.assertText('initial value - initial value');
-
-    this.runTask(() => { component.set('bar', 'updated value'); });
-
-    this.assertText('updated value - updated value');
-
-    this.runTask(() => { this.component.set('localBar', 'initial value'); });
-
-    this.assertText('initial value - initial value');
-  }
-
-  ['@test a two way binding flows upstream through a CP without template consumption']() {
-    let component;
-    let FooBarComponent = Component.extend({
-      init() {
-        this._super(...arguments);
-        component = this;
-      },
-
-      bar: computed({
-        get() {
-          return this._bar;
-        },
-
-        set(key, value) {
-          this._bar = value;
-          return this._bar;
-        }
-      })
-    });
-
-    this.registerComponent('foo-bar', {
-      ComponentClass: FooBarComponent,
-      template: ''
-    });
-
-    this.render('{{localBar}}{{foo-bar bar=localBar}}', {
-      localBar: 'initial value'
-    });
-
-    this.assertText('initial value');
-
-    this.runTask(() => this.rerender());
-
-    this.assertText('initial value');
-
-    this.runTask(() => { component.set('bar', 'updated value'); });
-
-    this.assertText('updated value');
-
-    this.runTask(() => { this.component.set('localBar', 'initial value'); });
-
-    this.assertText('initial value');
-  }
-
-  ['@test services can be injected into components']() {
-    let service;
-    this.registerService('name', Service.extend({
-      init() {
-        this._super(...arguments);
-        service = this;
-      },
-      last: 'Jackson'
-    }));
-
-    this.registerComponent('foo-bar', {
-      ComponentClass: Component.extend({
-        name: inject.service()
-      }),
-      template: '{{name.last}}'
-    });
-
-    this.render('{{foo-bar}}');
-
-    this.assertText('Jackson');
-
-    this.runTask(() => this.rerender());
-
-    this.assertText('Jackson');
-
-    this.runTask(() => { service.set('last', 'McGuffey'); });
-
-    this.assertText('McGuffey');
-
-    this.runTask(() => { service.set('last', 'Jackson'); });
-
-    this.assertText('Jackson');
-  }
-
-  ['@test injecting an unknown service raises an exception']() {
-    this.registerComponent('foo-bar', {
-      ComponentClass: Component.extend({
-        missingService: inject.service()
-      })
-    });
-
-    expectAssertion(() => {
-      this.render('{{foo-bar}}');
-    }, 'Attempting to inject an unknown injection: \'service:missingService\'');
-  }
-
-  ['@test throws if `this._super` is not called from `init`']() {
-    this.registerComponent('foo-bar', {
-      ComponentClass: Component.extend({
-        init() {}
-      })
-    });
-
-    expectAssertion(() => {
-      this.render('{{foo-bar}}');
-    }, /You must call `this._super\(...arguments\);` when overriding `init` on a framework object. Please update .* to call `this._super\(...arguments\);` from `init`./);
-  }
-
-  ['@test should toggle visibility with isVisible'](assert) {
-    let assertStyle = (expected) => {
-      let matcher = styles(expected);
-      let actual = this.firstChild.getAttribute('style');
-
-      assert.pushResult({
-        result: matcher.match(actual),
-        message: matcher.message(),
-        actual,
-        expected
-      });
-    };
-
-    this.registerComponent('foo-bar', {
-      template: `<p>foo</p>`
-    });
-
-    this.render(`{{foo-bar id="foo-bar" isVisible=visible}}`, {
-      visible: false
-    });
-
-    assertStyle('display: none;');
-
-    this.assertStableRerender();
-
-    this.runTask(() => { set(this.context, 'visible', true); });
-    assertStyle('');
-
-    this.runTask(() => { set(this.context, 'visible', false); });
-    assertStyle('display: none;');
-  }
-
-  ['@test isVisible does not overwrite component style']() {
-    this.registerComponent('foo-bar', {
-      ComponentClass: Component.extend({
-        attributeBindings: ['style'],
-        style: htmlSafe('color: blue;')
-      }),
-
-      template: `<p>foo</p>`
-    });
-
-    this.render(`{{foo-bar id="foo-bar" isVisible=visible}}`, {
-      visible: false
-    });
-
-    this.assertComponentElement(this.firstChild, {
-      tagName: 'div',
-      attrs: { id: 'foo-bar',  style: styles('color: blue; display: none;') }
-    });
-
-    this.assertStableRerender();
-
-    this.runTask(() => { set(this.context, 'visible', true); });
-
-    this.assertComponentElement(this.firstChild, {
-      tagName: 'div',
-      attrs: { id: 'foo-bar', style: styles('color: blue;') }
-    });
-
-    this.runTask(() => { set(this.context, 'visible', false); });
-
-    this.assertComponentElement(this.firstChild, {
-      tagName: 'div',
-      attrs: { id: 'foo-bar',  style: styles('color: blue; display: none;') }
-    });
-  }
-
-  ['@test adds isVisible binding when style binding is missing and other bindings exist'](assert) {
-    let assertStyle = (expected) => {
-      let matcher = styles(expected);
-      let actual = this.firstChild.getAttribute('style');
-
-      assert.pushResult({
-        result: matcher.match(actual),
-        message: matcher.message(),
-        actual,
-        expected
-      });
-    };
-
-    this.registerComponent('foo-bar', {
-      ComponentClass: Component.extend({
-        attributeBindings: ['foo'],
-        foo: 'bar'
-      }),
-      template: `<p>foo</p>`
-    });
-
-    this.render(`{{foo-bar id="foo-bar" foo=foo isVisible=visible}}`, {
-      visible: false,
-      foo: 'baz'
-    });
-
-    assertStyle('display: none;');
-
-    this.assertStableRerender();
-
-    this.runTask(() => {
-      set(this.context, 'visible', true);
-    });
-
-    assertStyle('');
-
-    this.runTask(() => {
-      set(this.context, 'visible', false);
-      set(this.context, 'foo', 'woo');
-    });
-
-    assertStyle('display: none;');
-    assert.equal(this.firstChild.getAttribute('foo'), 'woo');
-  }
-
-  ['@test it can use readDOMAttr to read input value']() {
-    let component;
-    let assertElement = (expectedValue) => {
-      // value is a property, not an attribute
-      this.assertHTML(`<input class="ember-view" id="${component.elementId}">`);
-      this.assert.equal(this.firstChild.value, expectedValue, 'value property is correct');
-      this.assert.equal(get(component, 'value'), expectedValue, 'component.get("value") is correct');
-    };
-
-    this.registerComponent('one-way-input', {
-      ComponentClass: Component.extend({
-        tagName: 'input',
-        attributeBindings: ['value'],
-
+    ['@test a two way binding flows upstream through a CP when consumed in the template']() {
+      let component;
+      let FooBarComponent = Component.extend({
         init() {
           this._super(...arguments);
           component = this;
         },
 
-        change() {
-          let value = this.readDOMAttr('value');
-          this.set('value', value);
-        }
-      })
-    });
+        bar: computed({
+          get() {
+            return this._bar;
+          },
 
-    this.render('{{one-way-input value=value}}', {
-      value: 'foo'
-    });
+          set(key, value) {
+            this._bar = value;
+            return this._bar;
+          }
+        })
+      });
 
-    assertElement('foo');
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
 
-    this.assertStableRerender();
+        template: '{{bar}}'
+      });
 
-    this.runTask(() => {
-      this.firstChild.value = 'bar';
-      this.$('input').trigger('change');
-    });
+      this.render('{{localBar}} - {{foo-bar bar=localBar}}', {
+        localBar: 'initial value'
+      });
 
-    assertElement('bar');
+      this.assertText('initial value - initial value');
 
-    this.runTask(() => {
-      this.firstChild.value = 'foo';
-      this.$('input').trigger('change');
-    });
+      this.runTask(() => this.rerender());
 
-    assertElement('foo');
+      this.assertText('initial value - initial value');
 
-    this.runTask(() => {
-      set(component, 'value', 'bar');
-    });
+      this.runTask(() => {
+        component.set('bar', 'updated value');
+      });
 
-    assertElement('bar');
+      this.assertText('updated value - updated value');
 
-    this.runTask(() => {
-      this.firstChild.value = 'foo';
-      this.$('input').trigger('change');
-    });
+      this.runTask(() => {
+        this.component.set('localBar', 'initial value');
+      });
 
-    assertElement('foo');
-  }
+      this.assertText('initial value - initial value');
+    }
 
-  ['@test child triggers revalidate during parent destruction (GH#13846)']() {
-    this.registerComponent('x-select', {
-      ComponentClass: Component.extend({
-        tagName: 'select',
-
+    ['@test a two way binding flows upstream through a CP without template consumption']() {
+      let component;
+      let FooBarComponent = Component.extend({
         init() {
-          this._super();
-          this.options = emberA([]);
-          this.value = null;
-        },
-
-        updateValue() {
-          var newValue = this.get('options.lastObject.value');
-
-          this.set('value', newValue);
-        },
-
-        registerOption(option) {
-          this.get('options').addObject(option);
-        },
-
-        unregisterOption(option) {
-          this.get('options').removeObject(option);
-
-          this.updateValue();
-        }
-      }),
-
-      template: '{{yield this}}'
-    });
-
-    this.registerComponent('x-option', {
-      ComponentClass: Component.extend({
-        tagName: 'option',
-        attributeBindings: ['selected'],
-
-        didInsertElement() {
           this._super(...arguments);
-
-          this.get('select').registerOption(this);
+          component = this;
         },
 
-        selected: computed('select.value', function() {
-          return this.get('value') === this.get('select.value');
+        bar: computed({
+          get() {
+            return this._bar;
+          },
+
+          set(key, value) {
+            this._bar = value;
+            return this._bar;
+          }
+        })
+      });
+
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
+        template: ''
+      });
+
+      this.render('{{localBar}}{{foo-bar bar=localBar}}', {
+        localBar: 'initial value'
+      });
+
+      this.assertText('initial value');
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('initial value');
+
+      this.runTask(() => {
+        component.set('bar', 'updated value');
+      });
+
+      this.assertText('updated value');
+
+      this.runTask(() => {
+        this.component.set('localBar', 'initial value');
+      });
+
+      this.assertText('initial value');
+    }
+
+    ['@test services can be injected into components']() {
+      let service;
+      this.registerService(
+        'name',
+        Service.extend({
+          init() {
+            this._super(...arguments);
+            service = this;
+          },
+          last: 'Jackson'
+        })
+      );
+
+      this.registerComponent('foo-bar', {
+        ComponentClass: Component.extend({
+          name: inject.service()
+        }),
+        template: '{{name.last}}'
+      });
+
+      this.render('{{foo-bar}}');
+
+      this.assertText('Jackson');
+
+      this.runTask(() => this.rerender());
+
+      this.assertText('Jackson');
+
+      this.runTask(() => {
+        service.set('last', 'McGuffey');
+      });
+
+      this.assertText('McGuffey');
+
+      this.runTask(() => {
+        service.set('last', 'Jackson');
+      });
+
+      this.assertText('Jackson');
+    }
+
+    ['@test injecting an unknown service raises an exception']() {
+      this.registerComponent('foo-bar', {
+        ComponentClass: Component.extend({
+          missingService: inject.service()
+        })
+      });
+
+      expectAssertion(() => {
+        this.render('{{foo-bar}}');
+      }, "Attempting to inject an unknown injection: 'service:missingService'");
+    }
+
+    ['@test throws if `this._super` is not called from `init`']() {
+      this.registerComponent('foo-bar', {
+        ComponentClass: Component.extend({
+          init() {}
+        })
+      });
+
+      expectAssertion(() => {
+        this.render('{{foo-bar}}');
+      }, /You must call `this._super\(...arguments\);` when overriding `init` on a framework object. Please update .* to call `this._super\(...arguments\);` from `init`./);
+    }
+
+    ['@test should toggle visibility with isVisible'](assert) {
+      let assertStyle = expected => {
+        let matcher = styles(expected);
+        let actual = this.firstChild.getAttribute('style');
+
+        assert.pushResult({
+          result: matcher.match(actual),
+          message: matcher.message(),
+          actual,
+          expected
+        });
+      };
+
+      this.registerComponent('foo-bar', {
+        template: `<p>foo</p>`
+      });
+
+      this.render(`{{foo-bar id="foo-bar" isVisible=visible}}`, {
+        visible: false
+      });
+
+      assertStyle('display: none;');
+
+      this.assertStableRerender();
+
+      this.runTask(() => {
+        set(this.context, 'visible', true);
+      });
+      assertStyle('');
+
+      this.runTask(() => {
+        set(this.context, 'visible', false);
+      });
+      assertStyle('display: none;');
+    }
+
+    ['@test isVisible does not overwrite component style']() {
+      this.registerComponent('foo-bar', {
+        ComponentClass: Component.extend({
+          attributeBindings: ['style'],
+          style: htmlSafe('color: blue;')
         }),
 
-        willDestroyElement() {
-          this._super(...arguments);
-          this.get('select').unregisterOption(this);
-        }
-      })
-    });
+        template: `<p>foo</p>`
+      });
 
-    this.render(strip`
+      this.render(`{{foo-bar id="foo-bar" isVisible=visible}}`, {
+        visible: false
+      });
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'div',
+        attrs: { id: 'foo-bar', style: styles('color: blue; display: none;') }
+      });
+
+      this.assertStableRerender();
+
+      this.runTask(() => {
+        set(this.context, 'visible', true);
+      });
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'div',
+        attrs: { id: 'foo-bar', style: styles('color: blue;') }
+      });
+
+      this.runTask(() => {
+        set(this.context, 'visible', false);
+      });
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'div',
+        attrs: { id: 'foo-bar', style: styles('color: blue; display: none;') }
+      });
+    }
+
+    ['@test adds isVisible binding when style binding is missing and other bindings exist'](
+      assert
+    ) {
+      let assertStyle = expected => {
+        let matcher = styles(expected);
+        let actual = this.firstChild.getAttribute('style');
+
+        assert.pushResult({
+          result: matcher.match(actual),
+          message: matcher.message(),
+          actual,
+          expected
+        });
+      };
+
+      this.registerComponent('foo-bar', {
+        ComponentClass: Component.extend({
+          attributeBindings: ['foo'],
+          foo: 'bar'
+        }),
+        template: `<p>foo</p>`
+      });
+
+      this.render(`{{foo-bar id="foo-bar" foo=foo isVisible=visible}}`, {
+        visible: false,
+        foo: 'baz'
+      });
+
+      assertStyle('display: none;');
+
+      this.assertStableRerender();
+
+      this.runTask(() => {
+        set(this.context, 'visible', true);
+      });
+
+      assertStyle('');
+
+      this.runTask(() => {
+        set(this.context, 'visible', false);
+        set(this.context, 'foo', 'woo');
+      });
+
+      assertStyle('display: none;');
+      assert.equal(this.firstChild.getAttribute('foo'), 'woo');
+    }
+
+    ['@test it can use readDOMAttr to read input value']() {
+      let component;
+      let assertElement = expectedValue => {
+        // value is a property, not an attribute
+        this.assertHTML(
+          `<input class="ember-view" id="${component.elementId}">`
+        );
+        this.assert.equal(
+          this.firstChild.value,
+          expectedValue,
+          'value property is correct'
+        );
+        this.assert.equal(
+          get(component, 'value'),
+          expectedValue,
+          'component.get("value") is correct'
+        );
+      };
+
+      this.registerComponent('one-way-input', {
+        ComponentClass: Component.extend({
+          tagName: 'input',
+          attributeBindings: ['value'],
+
+          init() {
+            this._super(...arguments);
+            component = this;
+          },
+
+          change() {
+            let value = this.readDOMAttr('value');
+            this.set('value', value);
+          }
+        })
+      });
+
+      this.render('{{one-way-input value=value}}', {
+        value: 'foo'
+      });
+
+      assertElement('foo');
+
+      this.assertStableRerender();
+
+      this.runTask(() => {
+        this.firstChild.value = 'bar';
+        this.$('input').trigger('change');
+      });
+
+      assertElement('bar');
+
+      this.runTask(() => {
+        this.firstChild.value = 'foo';
+        this.$('input').trigger('change');
+      });
+
+      assertElement('foo');
+
+      this.runTask(() => {
+        set(component, 'value', 'bar');
+      });
+
+      assertElement('bar');
+
+      this.runTask(() => {
+        this.firstChild.value = 'foo';
+        this.$('input').trigger('change');
+      });
+
+      assertElement('foo');
+    }
+
+    ['@test child triggers revalidate during parent destruction (GH#13846)']() {
+      this.registerComponent('x-select', {
+        ComponentClass: Component.extend({
+          tagName: 'select',
+
+          init() {
+            this._super();
+            this.options = emberA([]);
+            this.value = null;
+          },
+
+          updateValue() {
+            var newValue = this.get('options.lastObject.value');
+
+            this.set('value', newValue);
+          },
+
+          registerOption(option) {
+            this.get('options').addObject(option);
+          },
+
+          unregisterOption(option) {
+            this.get('options').removeObject(option);
+
+            this.updateValue();
+          }
+        }),
+
+        template: '{{yield this}}'
+      });
+
+      this.registerComponent('x-option', {
+        ComponentClass: Component.extend({
+          tagName: 'option',
+          attributeBindings: ['selected'],
+
+          didInsertElement() {
+            this._super(...arguments);
+
+            this.get('select').registerOption(this);
+          },
+
+          selected: computed('select.value', function() {
+            return this.get('value') === this.get('select.value');
+          }),
+
+          willDestroyElement() {
+            this._super(...arguments);
+            this.get('select').unregisterOption(this);
+          }
+        })
+      });
+
+      this.render(strip`
       {{#x-select value=value as |select|}}
         {{#x-option value="1" select=select}}1{{/x-option}}
         {{#x-option value="2" select=select}}2{{/x-option}}
       {{/x-select}}
     `);
 
+      this.teardown();
 
-    this.teardown();
+      this.assert.ok(true, 'no errors during teardown');
+    }
 
-    this.assert.ok(true, 'no errors during teardown');
-  }
+    ['@test setting a property in willDestroyElement does not assert (GH#14273)'](
+      assert
+    ) {
+      assert.expect(2);
 
-  ['@test setting a property in willDestroyElement does not assert (GH#14273)'](assert) {
-    assert.expect(2);
+      this.registerComponent('foo-bar', {
+        ComponentClass: Component.extend({
+          init() {
+            this._super(...arguments);
+            this.showFoo = true;
+          },
 
-    this.registerComponent('foo-bar', {
-      ComponentClass: Component.extend({
-        init() {
-          this._super(...arguments);
-          this.showFoo = true;
-        },
-
-        willDestroyElement() {
-          this.set('showFoo', false);
-          assert.ok(true, 'willDestroyElement was fired');
-          this._super(...arguments);
-        }
-      }),
-
-      template: `{{#if showFoo}}things{{/if}}`
-    });
-
-    this.render(`{{foo-bar}}`);
-
-    this.assertText('things');
-  }
-
-  ['@test using didInitAttrs as an event is deprecated'](assert) {
-    ENV._ENABLE_DID_INIT_ATTRS_SUPPORT = true;
-
-    this.registerComponent('foo-bar', {
-      ComponentClass: Component.extend({
-        foo: on('didInitAttrs', function() {
-          assert.ok(true, 'should fire `didInitAttrs` event');
-        })
-      })
-    });
-
-    expectDeprecation(() => {
-      this.render('{{foo-bar}}');
-    }, /didInitAttrs called/);
-  }
-
-  ['@test using didInitAttrs as an event throws an assert'](assert) {
-    this.registerComponent('foo-bar', {
-      ComponentClass: Component.extend({
-        foo: on('didInitAttrs', function() {
-          assert.ok(true, 'should fire `didInitAttrs` event');
-        })
-      })
-    });
-
-    expectAssertion(() => {
-      this.render('{{foo-bar}}');
-    }, /didInitAttrs called/);
-  }
-
-  ['@test didReceiveAttrs fires after .init() but before observers become active'](assert) {
-    let barCopyDidChangeCount = 0;
-
-    this.registerComponent('foo-bar', {
-      ComponentClass: Component.extend({
-        init() {
-          this._super(...arguments);
-          this.didInit = true;
-        },
-
-        didReceiveAttrs() {
-          assert.ok(this.didInit, 'expected init to have run before didReceiveAttrs');
-          this.set('barCopy', this.attrs.bar.value + 1);
-        },
-
-        barCopyDidChange: observer('barCopy', () => { barCopyDidChangeCount++; })
-      }),
-
-      template: '{{bar}}-{{barCopy}}'
-    });
-
-    this.render(`{{foo-bar bar=bar}}`, { bar: 3 });
-
-    this.assertText('3-4');
-
-    assert.strictEqual(barCopyDidChangeCount, 1, 'expected observer firing for: barCopy');
-
-    this.runTask(() => set(this.context, 'bar', 7));
-
-    this.assertText('7-8');
-
-    assert.strictEqual(barCopyDidChangeCount, 2, 'expected observer firing for: barCopy');
-  }
-
-  ['@test overriding didReceiveAttrs does not trigger deprecation'](assert) {
-    this.registerComponent('foo-bar', {
-      ComponentClass: Component.extend({
-        didReceiveAttrs() {
-          assert.equal(1, this.get('foo'), 'expected attrs to have correct value');
-        }
-      }),
-
-      template: '{{foo}}-{{fooCopy}}-{{bar}}-{{barCopy}}'
-    });
-
-    this.render(`{{foo-bar foo=foo bar=bar}}`, { foo: 1, bar: 3 });
-  }
-
-  ['@test overriding didUpdateAttrs does not trigger deprecation'](assert) {
-    this.registerComponent('foo-bar', {
-      ComponentClass: Component.extend({
-        didUpdateAttrs() {
-          assert.equal(5, this.get('foo'), "expected newAttrs to have new value");
-        }
-      }),
-
-      template: '{{foo}}-{{fooCopy}}-{{bar}}-{{barCopy}}'
-    });
-
-    this.render(`{{foo-bar foo=foo bar=bar}}`, { foo: 1, bar: 3 });
-
-    this.runTask(() => set(this.context, 'foo', 5));
-  }
-
-  ['@test returning `true` from an action does not bubble if `target` is not specified (GH#14275)'](assert) {
-    this.registerComponent('display-toggle', {
-      ComponentClass: Component.extend({
-        actions: {
-          show() {
-            assert.ok(true, 'display-toggle show action was called');
-            return true;
+          willDestroyElement() {
+            this.set('showFoo', false);
+            assert.ok(true, 'willDestroyElement was fired');
+            this._super(...arguments);
           }
-        }
-      }),
-
-      template: `<button {{action 'show'}}>Show</button>`
-    });
-
-    this.render(`{{display-toggle}}`, {
-      send() {
-        assert.notOk(true, 'send should not be called when action is not "subscribed" to');
-      }
-    });
-
-    this.assertText('Show');
-
-    this.runTask(() => this.$('button').click());
-  }
-
-  ['@test returning `true` from an action bubbles to the `target` if specified'](assert) {
-    assert.expect(4);
-
-    this.registerComponent('display-toggle', {
-      ComponentClass: Component.extend({
-        actions: {
-          show() {
-            assert.ok(true, 'display-toggle show action was called');
-            return true;
-          }
-        }
-      }),
-
-      template: `<button {{action 'show'}}>Show</button>`
-    });
-
-    this.render(`{{display-toggle target=this}}`, {
-      send(actionName) {
-        assert.ok(true, 'send should be called when action is "subscribed" to');
-        assert.equal(actionName, 'show');
-      }
-    });
-
-    this.assertText('Show');
-
-    this.runTask(() => this.$('button').click());
-  }
-
-  ['@test triggering an event only attempts to invoke an identically named method, if it actually is a function (GH#15228)'](assert) {
-    assert.expect(3);
-
-    let payload = ['arbitrary', 'event', 'data'];
-
-    this.registerComponent('evented-component', {
-      ComponentClass: Component.extend({
-        someTruthyProperty: true,
-
-        init() {
-          this._super(...arguments);
-          this.trigger('someMethod', ...payload);
-          this.trigger('someTruthyProperty', ...payload);
-        },
-
-        someMethod(...data) {
-          assert.deepEqual(data, payload, 'the method `someMethod` should be called, when `someMethod` is triggered');
-        },
-
-        listenerForSomeMethod: on('someMethod', function(...data) {
-          assert.deepEqual(data, payload, 'the listener `listenerForSomeMethod` should be called, when `someMethod` is triggered');
         }),
 
-        listenerForSomeTruthyProperty: on('someTruthyProperty', function(...data) {
-          assert.deepEqual(data, payload, 'the listener `listenerForSomeTruthyProperty` should be called, when `someTruthyProperty` is triggered');
+        template: `{{#if showFoo}}things{{/if}}`
+      });
+
+      this.render(`{{foo-bar}}`);
+
+      this.assertText('things');
+    }
+
+    ['@test using didInitAttrs as an event is deprecated'](assert) {
+      ENV._ENABLE_DID_INIT_ATTRS_SUPPORT = true;
+
+      this.registerComponent('foo-bar', {
+        ComponentClass: Component.extend({
+          foo: on('didInitAttrs', function() {
+            assert.ok(true, 'should fire `didInitAttrs` event');
+          })
         })
-      })
-    });
+      });
 
-    this.render(`{{evented-component}}`);
-  }
+      expectDeprecation(() => {
+        this.render('{{foo-bar}}');
+      }, /didInitAttrs called/);
+    }
 
-  ['@test component yielding in an {{#each}} has correct block values after rerendering (GH#14284)']() {
-    this.registerComponent('list-items', {
-      template: `{{#each items as |item|}}{{yield item}}{{/each}}`
-    });
+    ['@test using didInitAttrs as an event throws an assert'](assert) {
+      this.registerComponent('foo-bar', {
+        ComponentClass: Component.extend({
+          foo: on('didInitAttrs', function() {
+            assert.ok(true, 'should fire `didInitAttrs` event');
+          })
+        })
+      });
 
-    this.render(strip`
+      expectAssertion(() => {
+        this.render('{{foo-bar}}');
+      }, /didInitAttrs called/);
+    }
+
+    ['@test didReceiveAttrs fires after .init() but before observers become active'](
+      assert
+    ) {
+      let barCopyDidChangeCount = 0;
+
+      this.registerComponent('foo-bar', {
+        ComponentClass: Component.extend({
+          init() {
+            this._super(...arguments);
+            this.didInit = true;
+          },
+
+          didReceiveAttrs() {
+            assert.ok(
+              this.didInit,
+              'expected init to have run before didReceiveAttrs'
+            );
+            this.set('barCopy', this.attrs.bar.value + 1);
+          },
+
+          barCopyDidChange: observer('barCopy', () => {
+            barCopyDidChangeCount++;
+          })
+        }),
+
+        template: '{{bar}}-{{barCopy}}'
+      });
+
+      this.render(`{{foo-bar bar=bar}}`, { bar: 3 });
+
+      this.assertText('3-4');
+
+      assert.strictEqual(
+        barCopyDidChangeCount,
+        1,
+        'expected observer firing for: barCopy'
+      );
+
+      this.runTask(() => set(this.context, 'bar', 7));
+
+      this.assertText('7-8');
+
+      assert.strictEqual(
+        barCopyDidChangeCount,
+        2,
+        'expected observer firing for: barCopy'
+      );
+    }
+
+    ['@test overriding didReceiveAttrs does not trigger deprecation'](assert) {
+      this.registerComponent('foo-bar', {
+        ComponentClass: Component.extend({
+          didReceiveAttrs() {
+            assert.equal(
+              1,
+              this.get('foo'),
+              'expected attrs to have correct value'
+            );
+          }
+        }),
+
+        template: '{{foo}}-{{fooCopy}}-{{bar}}-{{barCopy}}'
+      });
+
+      this.render(`{{foo-bar foo=foo bar=bar}}`, { foo: 1, bar: 3 });
+    }
+
+    ['@test overriding didUpdateAttrs does not trigger deprecation'](assert) {
+      this.registerComponent('foo-bar', {
+        ComponentClass: Component.extend({
+          didUpdateAttrs() {
+            assert.equal(
+              5,
+              this.get('foo'),
+              'expected newAttrs to have new value'
+            );
+          }
+        }),
+
+        template: '{{foo}}-{{fooCopy}}-{{bar}}-{{barCopy}}'
+      });
+
+      this.render(`{{foo-bar foo=foo bar=bar}}`, { foo: 1, bar: 3 });
+
+      this.runTask(() => set(this.context, 'foo', 5));
+    }
+
+    ['@test returning `true` from an action does not bubble if `target` is not specified (GH#14275)'](
+      assert
+    ) {
+      this.registerComponent('display-toggle', {
+        ComponentClass: Component.extend({
+          actions: {
+            show() {
+              assert.ok(true, 'display-toggle show action was called');
+              return true;
+            }
+          }
+        }),
+
+        template: `<button {{action 'show'}}>Show</button>`
+      });
+
+      this.render(`{{display-toggle}}`, {
+        send() {
+          assert.notOk(
+            true,
+            'send should not be called when action is not "subscribed" to'
+          );
+        }
+      });
+
+      this.assertText('Show');
+
+      this.runTask(() => this.$('button').click());
+    }
+
+    ['@test returning `true` from an action bubbles to the `target` if specified'](
+      assert
+    ) {
+      assert.expect(4);
+
+      this.registerComponent('display-toggle', {
+        ComponentClass: Component.extend({
+          actions: {
+            show() {
+              assert.ok(true, 'display-toggle show action was called');
+              return true;
+            }
+          }
+        }),
+
+        template: `<button {{action 'show'}}>Show</button>`
+      });
+
+      this.render(`{{display-toggle target=this}}`, {
+        send(actionName) {
+          assert.ok(
+            true,
+            'send should be called when action is "subscribed" to'
+          );
+          assert.equal(actionName, 'show');
+        }
+      });
+
+      this.assertText('Show');
+
+      this.runTask(() => this.$('button').click());
+    }
+
+    ['@test triggering an event only attempts to invoke an identically named method, if it actually is a function (GH#15228)'](
+      assert
+    ) {
+      assert.expect(3);
+
+      let payload = ['arbitrary', 'event', 'data'];
+
+      this.registerComponent('evented-component', {
+        ComponentClass: Component.extend({
+          someTruthyProperty: true,
+
+          init() {
+            this._super(...arguments);
+            this.trigger('someMethod', ...payload);
+            this.trigger('someTruthyProperty', ...payload);
+          },
+
+          someMethod(...data) {
+            assert.deepEqual(
+              data,
+              payload,
+              'the method `someMethod` should be called, when `someMethod` is triggered'
+            );
+          },
+
+          listenerForSomeMethod: on('someMethod', function(...data) {
+            assert.deepEqual(
+              data,
+              payload,
+              'the listener `listenerForSomeMethod` should be called, when `someMethod` is triggered'
+            );
+          }),
+
+          listenerForSomeTruthyProperty: on('someTruthyProperty', function(
+            ...data
+          ) {
+            assert.deepEqual(
+              data,
+              payload,
+              'the listener `listenerForSomeTruthyProperty` should be called, when `someTruthyProperty` is triggered'
+            );
+          })
+        })
+      });
+
+      this.render(`{{evented-component}}`);
+    }
+
+    ['@test component yielding in an {{#each}} has correct block values after rerendering (GH#14284)']() {
+      this.registerComponent('list-items', {
+        template: `{{#each items as |item|}}{{yield item}}{{/each}}`
+      });
+
+      this.render(
+        strip`
       {{#list-items items=items as |thing|}}
         |{{thing}}|
 
@@ -2939,250 +3478,274 @@ moduleFor('Components test: curly components', class extends RenderingTest {
           Remove {{thing}}
         {{/if}}
       {{/list-items}}
-    `, {
-      editMode: false,
-      items: ['foo', 'bar', 'qux', 'baz']
-    });
-
-    this.assertText('|foo||bar||qux||baz|');
-
-    this.assertStableRerender();
-
-    this.runTask(() => set(this.context, 'editMode', true));
-
-    this.assertText('|foo|Remove foo|bar|Remove bar|qux|Remove qux|baz|Remove baz');
-
-    this.runTask(() => set(this.context, 'editMode', false));
-
-    this.assertText('|foo||bar||qux||baz|');
-  }
-
-  ['@test unimplimented positionalParams do not cause an error GH#14416']() {
-    this.registerComponent('foo-bar', {
-      template: 'hello'
-    });
-
-    this.render('{{foo-bar wat}}');
-    this.assertText('hello');
-  }
-
-  ['@test using attrs for positional params']() {
-    let MyComponent = Component.extend();
-
-    this.registerComponent('foo-bar', {
-      ComponentClass: MyComponent.reopenClass({
-        positionalParams: ['myVar']
-      }),
-      template: 'MyVar1: {{attrs.myVar}} {{myVar}} MyVar2: {{myVar2}} {{attrs.myVar2}}'
-    });
-
-    this.render('{{foo-bar 1 myVar2=2}}');
-
-    this.assertText('MyVar1: 1 1 MyVar2: 2 2');
-  }
-
-  ['@feature(ember-glimmer-named-arguments) using named arguments for positional params']() {
-    let MyComponent = Component.extend();
-
-    this.registerComponent('foo-bar', {
-      ComponentClass: MyComponent.reopenClass({
-        positionalParams: ['myVar']
-      }),
-      template: 'MyVar1: {{@myVar}} {{myVar}} MyVar2: {{myVar2}} {{@myVar2}}'
-    });
-
-    this.render('{{foo-bar 1 myVar2=2}}');
-
-    this.assertText('MyVar1: 1 1 MyVar2: 2 2');
-  }
-
-  ['@test can use `{{this}}` to emit the component\'s toString value [GH#14581]']() {
-    this.registerComponent('foo-bar', {
-      ComponentClass: Component.extend({
-        toString() {
-          return 'special sauce goes here!';
+    `,
+        {
+          editMode: false,
+          items: ['foo', 'bar', 'qux', 'baz']
         }
-      }),
-      template: '{{this}}'
-    });
+      );
 
-    this.render('{{foo-bar}}');
+      this.assertText('|foo||bar||qux||baz|');
 
-    this.assertText('special sauce goes here!');
-  }
+      this.assertStableRerender();
 
-  ['@test can use `{{this` to access paths on current context [GH#14581]']() {
-    let instance;
-    this.registerComponent('foo-bar', {
-      ComponentClass: Component.extend({
-        init() {
-          this._super(...arguments);
+      this.runTask(() => set(this.context, 'editMode', true));
 
-          instance = this;
-        },
+      this.assertText(
+        '|foo|Remove foo|bar|Remove bar|qux|Remove qux|baz|Remove baz'
+      );
 
-        foo: {
-          bar: {
-            baz: 'huzzah!'
-          }
-        }
-      }),
-      template: '{{this.foo.bar.baz}}'
-    });
+      this.runTask(() => set(this.context, 'editMode', false));
 
-    this.render('{{foo-bar}}');
-
-    this.assertText('huzzah!');
-
-    this.assertStableRerender();
-
-    this.runTask(() => set(instance, 'foo.bar.baz', 'yippie!'));
-
-    this.assertText('yippie!');
-
-    this.runTask(() => set(instance, 'foo.bar.baz', 'huzzah!'));
-
-    this.assertText('huzzah!');
-  }
-
-  ['@test can use custom element in component layout']() {
-    this.registerComponent('foo-bar', {
-      template: '<blah-zorz>Hi!</blah-zorz>'
-    });
-
-    this.render('{{foo-bar}}');
-
-    this.assertText('Hi!');
-  }
-
-  ['@test can use nested custom element in component layout']() {
-    this.registerComponent('foo-bar', {
-      template: '<blah-zorz><hows-it-going>Hi!</hows-it-going></blah-zorz>'
-    });
-
-    this.render('{{foo-bar}}');
-
-    this.assertText('Hi!');
-  }
-
-  ['@feature(!ember-glimmer-named-arguments) can access properties off of rest style positionalParams array']() {
-    this.registerComponent('foo-bar', {
-      ComponentClass: Component.extend().reopenClass({ positionalParams: 'things' }),
-      // using `attrs` here to simulate `@things.length`
-      template: `{{attrs.things.length}}`
-    });
-
-    this.render('{{foo-bar "foo" "bar" "baz"}}');
-
-    this.assertText('3');
-  }
-
-  ['@feature(ember-glimmer-named-arguments) can access properties off of rest style positionalParams array']() {
-    this.registerComponent('foo-bar', {
-      ComponentClass: Component.extend().reopenClass({ positionalParams: 'things' }),
-      template: `{{@things.length}}`
-    });
-
-    this.render('{{foo-bar "foo" "bar" "baz"}}');
-
-    this.assertText('3');
-  }
-
-  ['@test has attrs by didReceiveAttrs with native classes'](assert) {
-    class FooBarComponent extends Component {
-      constructor(injections) {
-        super(injections);
-        // analagous to class field defaults
-        this.foo = 'bar';
-      }
-
-      didReceiveAttrs() {
-        assert.equal(this.foo, 'bar', 'received default attrs correctly');
-      }
+      this.assertText('|foo||bar||qux||baz|');
     }
 
-    this.registerComponent('foo-bar', { ComponentClass: FooBarComponent });
+    ['@test unimplimented positionalParams do not cause an error GH#14416']() {
+      this.registerComponent('foo-bar', {
+        template: 'hello'
+      });
 
-    this.render('{{foo-bar}}');
+      this.render('{{foo-bar wat}}');
+      this.assertText('hello');
+    }
+
+    ['@test using attrs for positional params']() {
+      let MyComponent = Component.extend();
+
+      this.registerComponent('foo-bar', {
+        ComponentClass: MyComponent.reopenClass({
+          positionalParams: ['myVar']
+        }),
+        template:
+          'MyVar1: {{attrs.myVar}} {{myVar}} MyVar2: {{myVar2}} {{attrs.myVar2}}'
+      });
+
+      this.render('{{foo-bar 1 myVar2=2}}');
+
+      this.assertText('MyVar1: 1 1 MyVar2: 2 2');
+    }
+
+    ['@feature(ember-glimmer-named-arguments) using named arguments for positional params']() {
+      let MyComponent = Component.extend();
+
+      this.registerComponent('foo-bar', {
+        ComponentClass: MyComponent.reopenClass({
+          positionalParams: ['myVar']
+        }),
+        template: 'MyVar1: {{@myVar}} {{myVar}} MyVar2: {{myVar2}} {{@myVar2}}'
+      });
+
+      this.render('{{foo-bar 1 myVar2=2}}');
+
+      this.assertText('MyVar1: 1 1 MyVar2: 2 2');
+    }
+
+    ["@test can use `{{this}}` to emit the component's toString value [GH#14581]"]() {
+      this.registerComponent('foo-bar', {
+        ComponentClass: Component.extend({
+          toString() {
+            return 'special sauce goes here!';
+          }
+        }),
+        template: '{{this}}'
+      });
+
+      this.render('{{foo-bar}}');
+
+      this.assertText('special sauce goes here!');
+    }
+
+    ['@test can use `{{this` to access paths on current context [GH#14581]']() {
+      let instance;
+      this.registerComponent('foo-bar', {
+        ComponentClass: Component.extend({
+          init() {
+            this._super(...arguments);
+
+            instance = this;
+          },
+
+          foo: {
+            bar: {
+              baz: 'huzzah!'
+            }
+          }
+        }),
+        template: '{{this.foo.bar.baz}}'
+      });
+
+      this.render('{{foo-bar}}');
+
+      this.assertText('huzzah!');
+
+      this.assertStableRerender();
+
+      this.runTask(() => set(instance, 'foo.bar.baz', 'yippie!'));
+
+      this.assertText('yippie!');
+
+      this.runTask(() => set(instance, 'foo.bar.baz', 'huzzah!'));
+
+      this.assertText('huzzah!');
+    }
+
+    ['@test can use custom element in component layout']() {
+      this.registerComponent('foo-bar', {
+        template: '<blah-zorz>Hi!</blah-zorz>'
+      });
+
+      this.render('{{foo-bar}}');
+
+      this.assertText('Hi!');
+    }
+
+    ['@test can use nested custom element in component layout']() {
+      this.registerComponent('foo-bar', {
+        template: '<blah-zorz><hows-it-going>Hi!</hows-it-going></blah-zorz>'
+      });
+
+      this.render('{{foo-bar}}');
+
+      this.assertText('Hi!');
+    }
+
+    ['@feature(!ember-glimmer-named-arguments) can access properties off of rest style positionalParams array']() {
+      this.registerComponent('foo-bar', {
+        ComponentClass: Component.extend().reopenClass({
+          positionalParams: 'things'
+        }),
+        // using `attrs` here to simulate `@things.length`
+        template: `{{attrs.things.length}}`
+      });
+
+      this.render('{{foo-bar "foo" "bar" "baz"}}');
+
+      this.assertText('3');
+    }
+
+    ['@feature(ember-glimmer-named-arguments) can access properties off of rest style positionalParams array']() {
+      this.registerComponent('foo-bar', {
+        ComponentClass: Component.extend().reopenClass({
+          positionalParams: 'things'
+        }),
+        template: `{{@things.length}}`
+      });
+
+      this.render('{{foo-bar "foo" "bar" "baz"}}');
+
+      this.assertText('3');
+    }
+
+    ['@test has attrs by didReceiveAttrs with native classes'](assert) {
+      class FooBarComponent extends Component {
+        constructor(injections) {
+          super(injections);
+          // analagous to class field defaults
+          this.foo = 'bar';
+        }
+
+        didReceiveAttrs() {
+          assert.equal(this.foo, 'bar', 'received default attrs correctly');
+        }
+      }
+
+      this.registerComponent('foo-bar', { ComponentClass: FooBarComponent });
+
+      this.render('{{foo-bar}}');
+    }
   }
-});
+);
 
 if (jQueryDisabled) {
-  moduleFor('Components test: curly components: jQuery disabled', class extends RenderingTest {
-    ['@test jQuery proxy is not available without jQuery']() {
-      let instance;
+  moduleFor(
+    'Components test: curly components: jQuery disabled',
+    class extends RenderingTest {
+      ['@test jQuery proxy is not available without jQuery']() {
+        let instance;
 
-      let FooBarComponent = Component.extend({
-        init() {
-          this._super();
-          instance = this;
-        }
-      });
+        let FooBarComponent = Component.extend({
+          init() {
+            this._super();
+            instance = this;
+          }
+        });
 
-      this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: 'hello' });
+        this.registerComponent('foo-bar', {
+          ComponentClass: FooBarComponent,
+          template: 'hello'
+        });
 
-      this.render('{{foo-bar}}');
+        this.render('{{foo-bar}}');
 
-      expectAssertion(() => {
-        instance.$()[0];
-      }, 'You cannot access this.$() with `jQuery` disabled.');
+        expectAssertion(() => {
+          instance.$()[0];
+        }, 'You cannot access this.$() with `jQuery` disabled.');
+      }
     }
-  });
+  );
 } else {
-  moduleFor('Components test: curly components: jQuery enabled', class extends RenderingTest {
-    ['@test it has a jQuery proxy to the element']() {
-      let instance;
+  moduleFor(
+    'Components test: curly components: jQuery enabled',
+    class extends RenderingTest {
+      ['@test it has a jQuery proxy to the element']() {
+        let instance;
 
-      let FooBarComponent = Component.extend({
-        init() {
-          this._super();
-          instance = this;
-        }
-      });
+        let FooBarComponent = Component.extend({
+          init() {
+            this._super();
+            instance = this;
+          }
+        });
 
-      this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: 'hello' });
+        this.registerComponent('foo-bar', {
+          ComponentClass: FooBarComponent,
+          template: 'hello'
+        });
 
-      this.render('{{foo-bar}}');
+        this.render('{{foo-bar}}');
 
-      let element1 = instance.$()[0];
+        let element1 = instance.$()[0];
 
-      this.assertComponentElement(element1, { content: 'hello' });
+        this.assertComponentElement(element1, { content: 'hello' });
 
-      this.runTask(() => this.rerender());
+        this.runTask(() => this.rerender());
 
-      let element2 = instance.$()[0];
+        let element2 = instance.$()[0];
 
-      this.assertComponentElement(element2, { content: 'hello' });
+        this.assertComponentElement(element2, { content: 'hello' });
 
-      this.assertSameNode(element2, element1);
+        this.assertSameNode(element2, element1);
+      }
+
+      ['@test it scopes the jQuery proxy to the component element'](assert) {
+        let instance;
+
+        let FooBarComponent = Component.extend({
+          init() {
+            this._super();
+            instance = this;
+          }
+        });
+
+        this.registerComponent('foo-bar', {
+          ComponentClass: FooBarComponent,
+          template: '<span class="inner">inner</span>'
+        });
+
+        this.render('<span class="outer">outer</span>{{foo-bar}}');
+
+        let $span = instance.$('span');
+
+        assert.equal($span.length, 1);
+        assert.equal($span.attr('class'), 'inner');
+
+        this.runTask(() => this.rerender());
+
+        $span = instance.$('span');
+
+        assert.equal($span.length, 1);
+        assert.equal($span.attr('class'), 'inner');
+      }
     }
-
-    ['@test it scopes the jQuery proxy to the component element'](assert) {
-      let instance;
-
-      let FooBarComponent = Component.extend({
-        init() {
-          this._super();
-          instance = this;
-        }
-      });
-
-      this.registerComponent('foo-bar', { ComponentClass: FooBarComponent, template: '<span class="inner">inner</span>' });
-
-      this.render('<span class="outer">outer</span>{{foo-bar}}');
-
-      let $span = instance.$('span');
-
-      assert.equal($span.length, 1);
-      assert.equal($span.attr('class'), 'inner');
-
-      this.runTask(() => this.rerender());
-
-      $span = instance.$('span');
-
-      assert.equal($span.length, 1);
-      assert.equal($span.attr('class'), 'inner');
-    }
-
-  });
+  );
 }

--- a/packages/ember-metal/lib/index.js
+++ b/packages/ember-metal/lib/index.js
@@ -1,4 +1,3 @@
-
 export { default } from './core'; // reexports
 export {
   default as computed,
@@ -24,23 +23,10 @@ export {
   setDispatchOverride,
   getDispatchOverride
 } from './error_handler';
-export {
-  descriptorFor,
-  meta,
-  peekMeta,
-  deleteMeta
-} from './meta';
+export { descriptorFor, meta, peekMeta, deleteMeta } from './meta';
 export { default as Cache } from './cache';
-export {
-  PROXY_CONTENT,
-  _getPath,
-  get,
-  getWithDefault
-} from './property_get';
-export {
-  set,
-  trySet
-} from './property_set';
+export { PROXY_CONTENT, _getPath, get, getWithDefault } from './property_get';
+export { set, trySet } from './property_set';
 export {
   objectAt,
   replace,
@@ -97,69 +83,48 @@ export {
   propertyWillChange,
   PROPERTY_DID_CHANGE
 } from './property_events';
-export {
-  defineProperty,
-  Descriptor
-} from './properties';
-export {
-  watchKey,
-  unwatchKey
-} from './watch_key';
-export {
-  ChainNode,
-  finishChains,
-  removeChainWatcher
-} from './chains';
-export {
-  watchPath,
-  unwatchPath
-} from './watch_path';
-export {
-  isWatching,
-  unwatch,
-  watch,
-  watcherCount
-} from './watching';
+export { defineProperty, Descriptor } from './properties';
+export { watchKey, unwatchKey } from './watch_key';
+export { ChainNode, finishChains, removeChainWatcher } from './chains';
+export { watchPath, unwatchPath } from './watch_path';
+export { isWatching, unwatch, watch, watcherCount } from './watching';
 export { default as libraries, Libraries } from './libraries';
-export {
-  Map,
-  MapWithDefault,
-  OrderedSet
-} from './map';
+export { Map, MapWithDefault, OrderedSet } from './map';
 export { default as getProperties } from './get_properties';
 export { default as setProperties } from './set_properties';
 export { default as expandProperties } from './expand_properties';
 
-export {
-  addObserver,
-  removeObserver
-} from './observer';
+export { addObserver, removeObserver } from './observer';
 export {
   Mixin,
   aliasMethod,
   mixin,
   observer,
   required,
-  REQUIRED,
-  hasUnprocessedMixins,
-  clearUnprocessedMixins,
+  REQUIRED
 } from './mixin';
 export { default as InjectedProperty } from './injected_property';
-export {
-  setHasViews,
-  tagForProperty,
-  tagFor,
-  markObjectAsDirty
-} from './tags';
+export { setHasViews, tagForProperty, tagFor, markObjectAsDirty } from './tags';
 export {
   default as runInTransaction,
   didRender,
   assertNotRendered
 } from './transaction';
 export { default as WeakSet } from './weak_set';
-export {
-  isProxy,
-  setProxy
-} from './is_proxy';
+export { isProxy, setProxy } from './is_proxy';
 export { default as descriptor } from './descriptor';
 export { tracked } from './tracked';
+
+export {
+  NAMESPACES,
+  NAMESPACES_BY_ID,
+  addNamespace,
+  classToString,
+  findNamespace,
+  findNamespaces,
+  processNamespace,
+  processAllNamespaces,
+  removeNamespace,
+  isSearchDisabled as isNamespaceSearchDisabled,
+  setSearchDisabled as setNamespaceSearchDisabled
+} from './namespace_search';

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -1,15 +1,13 @@
-import {
-  lookupDescriptor,
-  symbol,
-  toString
-} from 'ember-utils';
+import { lookupDescriptor, symbol, toString } from 'ember-utils';
 import { protoMethods as listenerMethods } from './meta_listeners';
 import { assert } from 'ember-debug';
 import { DEBUG } from 'ember-env-flags';
-import { DESCRIPTOR_TRAP, EMBER_METAL_ES5_GETTERS, MANDATORY_SETTER } from 'ember/features';
 import {
-  removeChainWatcher
-} from './chains';
+  DESCRIPTOR_TRAP,
+  EMBER_METAL_ES5_GETTERS,
+  MANDATORY_SETTER
+} from 'ember/features';
+import { removeChainWatcher } from './chains';
 import { ENV } from 'ember-environment';
 
 let counters;
@@ -88,7 +86,9 @@ export class Meta {
   }
 
   destroy() {
-    if (this.isMetaDestroyed()) { return; }
+    if (this.isMetaDestroyed()) {
+      return;
+    }
 
     // remove chainWatchers to remove circular references that would prevent GC
     let nodes, key, nodeObject;
@@ -188,7 +188,7 @@ export class Meta {
       }
       pointer = pointer.parent;
     }
-}
+  }
 
   _hasInInheritedSet(key, value) {
     let pointer = this;
@@ -207,7 +207,13 @@ export class Meta {
   // Implements a member that provides a lazily created map of maps,
   // with inheritance at both levels.
   writeDeps(subkey, itemkey, value) {
-    assert(`Cannot modify dependent keys for \`${itemkey}\` on \`${toString(this.source)}\` after it has been destroyed.`, !this.isMetaDestroyed());
+    assert(
+      this.isMetaDestroyed() &&
+        `Cannot modify dependent keys for \`${itemkey}\` on \`${toString(
+          this.source
+        )}\` after it has been destroyed.`,
+      !this.isMetaDestroyed()
+    );
 
     let outerMap = this._getOrCreateOwnMap('_deps');
     let innerMap = outerMap[subkey];
@@ -273,17 +279,27 @@ export class Meta {
     }
 
     if (calls !== undefined) {
-      for (let i = 0; i < calls.length; i+=2) {
+      for (let i = 0; i < calls.length; i += 2) {
         fn(calls[i], calls[i + 1]);
       }
     }
   }
 
-  writableTags() { return this._getOrCreateOwnMap('_tags'); }
-  readableTags() { return this._tags; }
+  writableTags() {
+    return this._getOrCreateOwnMap('_tags');
+  }
+  readableTags() {
+    return this._tags;
+  }
 
   writableTag(create) {
-    assert(`Cannot create a new tag for \`${toString(this.source)}\` after it has been destroyed.`, !this.isMetaDestroyed());
+    assert(
+      this.isMetaDestroyed() &&
+        `Cannot create a new tag for \`${toString(
+          this.source
+        )}\` after it has been destroyed.`,
+      !this.isMetaDestroyed()
+    );
     let ret = this._tag;
     if (ret === undefined) {
       ret = this._tag = create(this.source);
@@ -296,7 +312,13 @@ export class Meta {
   }
 
   writableChainWatchers(create) {
-    assert(`Cannot create a new chain watcher for \`${toString(this.source)}\` after it has been destroyed.`, !this.isMetaDestroyed());
+    assert(
+      this.isMetaDestroyed() &&
+        `Cannot create a new chain watcher for \`${toString(
+          this.source
+        )}\` after it has been destroyed.`,
+      !this.isMetaDestroyed()
+    );
     let ret = this._chainWatchers;
     if (ret === undefined) {
       ret = this._chainWatchers = create(this.source);
@@ -309,7 +331,13 @@ export class Meta {
   }
 
   writableChains(create) {
-    assert(`Cannot create a new chains for \`${toString(this.source)}\` after it has been destroyed.`, !this.isMetaDestroyed());
+    assert(
+      this.isMetaDestroyed() &&
+        `Cannot create a new chains for \`${toString(
+          this.source
+        )}\` after it has been destroyed.`,
+      !this.isMetaDestroyed()
+    );
     let ret = this._chains;
     if (ret === undefined) {
       if (this.parent === undefined) {
@@ -327,7 +355,13 @@ export class Meta {
   }
 
   writeWatching(subkey, value) {
-    assert(`Cannot update watchers for \`${subkey}\` on \`${toString(this.source)}\` after it has been destroyed.`, !this.isMetaDestroyed());
+    assert(
+      this.isMetaDestroyed() &&
+        `Cannot update watchers for \`${subkey}\` on \`${toString(
+          this.source
+        )}\` after it has been destroyed.`,
+      !this.isMetaDestroyed()
+    );
     let map = this._getOrCreateOwnMap('_watching');
     map[subkey] = value;
   }
@@ -337,7 +371,13 @@ export class Meta {
   }
 
   addMixin(mixin) {
-    assert(`Cannot add mixins of \`${toString(mixin)}\` on \`${toString(this.source)}\` call addMixin after it has been destroyed.`, !this.isMetaDestroyed());
+    assert(
+      this.isMetaDestroyed() &&
+        `Cannot add mixins of \`${toString(mixin)}\` on \`${toString(
+          this.source
+        )}\` call addMixin after it has been destroyed.`,
+      !this.isMetaDestroyed()
+    );
     let set = this._getOrCreateOwnSet('_mixins');
     set.add(mixin);
   }
@@ -353,7 +393,7 @@ export class Meta {
       let set = pointer._mixins;
       if (set !== undefined) {
         seen = seen === undefined ? new Set() : seen;
-        set.forEach((mixin)=> {
+        set.forEach(mixin => {
           if (!seen.has(mixin)) {
             seen.add(mixin);
             fn(mixin);
@@ -365,20 +405,35 @@ export class Meta {
   }
 
   writeBindings(subkey, value) {
-    assert('Cannot invoke `meta.writeBindings` when EmberENV._ENABLE_BINDING_SUPPORT is not set', ENV._ENABLE_BINDING_SUPPORT);
-    assert(`Cannot add a binding for \`${subkey}\` on \`${toString(this.source)}\` after it has been destroyed.`, !this.isMetaDestroyed());
+    assert(
+      'Cannot invoke `meta.writeBindings` when EmberENV._ENABLE_BINDING_SUPPORT is not set',
+      ENV._ENABLE_BINDING_SUPPORT
+    );
+    assert(
+      this.isMetaDestroyed() &&
+        `Cannot add a binding for \`${subkey}\` on \`${toString(
+          this.source
+        )}\` after it has been destroyed.`,
+      !this.isMetaDestroyed()
+    );
 
     let map = this._getOrCreateOwnMap('_bindings');
     map[subkey] = value;
   }
 
   peekBindings(subkey) {
-    assert('Cannot invoke `meta.peekBindings` when EmberENV._ENABLE_BINDING_SUPPORT is not set', ENV._ENABLE_BINDING_SUPPORT);
+    assert(
+      'Cannot invoke `meta.peekBindings` when EmberENV._ENABLE_BINDING_SUPPORT is not set',
+      ENV._ENABLE_BINDING_SUPPORT
+    );
     return this._findInherited('_bindings', subkey);
   }
 
   forEachBindings(fn) {
-    assert('Cannot invoke `meta.forEachBindings` when EmberENV._ENABLE_BINDING_SUPPORT is not set', ENV._ENABLE_BINDING_SUPPORT);
+    assert(
+      'Cannot invoke `meta.forEachBindings` when EmberENV._ENABLE_BINDING_SUPPORT is not set',
+      ENV._ENABLE_BINDING_SUPPORT
+    );
 
     let pointer = this;
     let seen;
@@ -398,11 +453,19 @@ export class Meta {
   }
 
   clearBindings() {
-    assert('Cannot invoke `meta.clearBindings` when EmberENV._ENABLE_BINDING_SUPPORT is not set', ENV._ENABLE_BINDING_SUPPORT);
-    assert(`Cannot clear bindings on \`${toString(this.source)}\` after it has been destroyed.`, !this.isMetaDestroyed());
+    assert(
+      'Cannot invoke `meta.clearBindings` when EmberENV._ENABLE_BINDING_SUPPORT is not set',
+      ENV._ENABLE_BINDING_SUPPORT
+    );
+    assert(
+      this.isMetaDestroyed() &&
+        `Cannot clear bindings on \`${toString(
+          this.source
+        )}\` after it has been destroyed.`,
+      !this.isMetaDestroyed()
+    );
     this._bindings = undefined;
   }
-
 }
 
 for (let name in listenerMethods) {
@@ -410,18 +473,24 @@ for (let name in listenerMethods) {
 }
 
 if (MANDATORY_SETTER) {
-  Meta.prototype.writeValues = function (subkey, value) {
-    assert(`Cannot set the value of \`${subkey}\` on \`${toString(this.source)}\` after it has been destroyed.`, !this.isMetaDestroyed());
+  Meta.prototype.writeValues = function(subkey, value) {
+    assert(
+      this.isMetaDestroyed() &&
+        `Cannot set the value of \`${subkey}\` on \`${toString(
+          this.source
+        )}\` after it has been destroyed.`,
+      !this.isMetaDestroyed()
+    );
 
     let map = this._getOrCreateOwnMap('_values');
     map[subkey] = value;
   };
 
-  Meta.prototype.peekValues = function (subkey) {
+  Meta.prototype.peekValues = function(subkey) {
     return this._findInherited('_values', subkey);
   };
 
-  Meta.prototype.deleteFromValues = function (subkey) {
+  Meta.prototype.deleteFromValues = function(subkey) {
     delete this._getOrCreateOwnMap('_values')[subkey];
   };
 
@@ -446,7 +515,8 @@ if (MANDATORY_SETTER) {
 
   Meta.prototype.writeValue = function(obj, key, value) {
     let descriptor = lookupDescriptor(obj, key);
-    let isMandatorySetter = descriptor !== null && descriptor.set && descriptor.set.isMandatorySetter;
+    let isMandatorySetter =
+      descriptor !== null && descriptor.set && descriptor.set.isMandatorySetter;
 
     if (isMandatorySetter) {
       this.writeValues(key, value);
@@ -458,7 +528,13 @@ if (MANDATORY_SETTER) {
 
 if (EMBER_METAL_ES5_GETTERS) {
   Meta.prototype.writeDescriptors = function(subkey, value) {
-    assert(`Cannot update descriptors for \`${subkey}\` on \`${toString(this.source)}\` after it has been destroyed.`, !this.isMetaDestroyed());
+    assert(
+      this.isMetaDestroyed() &&
+        `Cannot update descriptors for \`${subkey}\` on \`${toString(
+          this.source
+        )}\` after it has been destroyed.`,
+      !this.isMetaDestroyed()
+    );
     let map = this._getOrCreateOwnMap('_descriptors');
     map[subkey] = value;
   };
@@ -500,7 +576,10 @@ const metaStore = new WeakMap();
 export function setMeta(obj, meta) {
   assert('Cannot call `setMeta` on null', obj !== null);
   assert('Cannot call `setMeta` on undefined', obj !== undefined);
-  assert(`Cannot call \`setMeta\` on ${typeof obj}`, typeof obj === 'object' || typeof obj === 'function');
+  assert(
+    `Cannot call \`setMeta\` on ${typeof obj}`,
+    typeof obj === 'object' || typeof obj === 'function'
+  );
 
   if (DEBUG) {
     counters.setCalls++;
@@ -511,7 +590,10 @@ export function setMeta(obj, meta) {
 export function peekMeta(obj) {
   assert('Cannot call `peekMeta` on null', obj !== null);
   assert('Cannot call `peekMeta` on undefined', obj !== undefined);
-  assert(`Cannot call \`peekMeta\` on ${typeof obj}`, typeof obj === 'object' || typeof obj === 'function');
+  assert(
+    `Cannot call \`peekMeta\` on ${typeof obj}`,
+    typeof obj === 'object' || typeof obj === 'function'
+  );
 
   let pointer = obj;
   let meta;
@@ -545,7 +627,10 @@ export function peekMeta(obj) {
 export function deleteMeta(obj) {
   assert('Cannot call `deleteMeta` on null', obj !== null);
   assert('Cannot call `deleteMeta` on undefined', obj !== undefined);
-  assert(`Cannot call \`deleteMeta\` on ${typeof obj}`, typeof obj === 'object' || typeof obj === 'function');
+  assert(
+    `Cannot call \`deleteMeta\` on ${typeof obj}`,
+    typeof obj === 'object' || typeof obj === 'function'
+  );
 
   if (DEBUG) {
     counters.deleteCalls++;
@@ -578,7 +663,10 @@ export function deleteMeta(obj) {
 export function meta(obj) {
   assert('Cannot call `meta` on null', obj !== null);
   assert('Cannot call `meta` on undefined', obj !== undefined);
-  assert(`Cannot call \`meta\` on ${typeof obj}`, typeof obj === 'object' || typeof obj === 'function');
+  assert(
+    `Cannot call \`meta\` on ${typeof obj}`,
+    typeof obj === 'object' || typeof obj === 'function'
+  );
 
   if (DEBUG) {
     counters.metaCalls++;
@@ -622,7 +710,10 @@ export const DESCRIPTOR = '__DESCRIPTOR__';
 export function descriptorFor(obj, keyName, _meta) {
   assert('Cannot call `descriptorFor` on null', obj !== null);
   assert('Cannot call `descriptorFor` on undefined', obj !== undefined);
-  assert(`Cannot call \`descriptorFor\` on ${typeof obj}`, typeof obj === 'object' || typeof obj === 'function');
+  assert(
+    `Cannot call \`descriptorFor\` on ${typeof obj}`,
+    typeof obj === 'object' || typeof obj === 'function'
+  );
 
   if (EMBER_METAL_ES5_GETTERS) {
     let meta = _meta === undefined ? peekMeta(obj) : _meta;
@@ -643,7 +734,11 @@ export function descriptorFor(obj, keyName, _meta) {
 
 export function isDescriptorTrap(possibleDesc) {
   if (DESCRIPTOR_TRAP) {
-    return possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc[DESCRIPTOR] !== undefined;
+    return (
+      possibleDesc !== null &&
+      typeof possibleDesc === 'object' &&
+      possibleDesc[DESCRIPTOR] !== undefined
+    );
   } else {
     throw new Error('Cannot call `isDescriptorTrap` in production');
   }
@@ -658,7 +753,11 @@ export function isDescriptorTrap(possibleDesc) {
   @private
 */
 export function isDescriptor(possibleDesc) {
-  return possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor;
+  return (
+    possibleDesc !== null &&
+    typeof possibleDesc === 'object' &&
+    possibleDesc.isDescriptor
+  );
 }
 
 export { counters };

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -12,6 +12,7 @@ import { Descriptor, defineProperty } from './properties';
 import { ComputedProperty } from './computed';
 import { addObserver, removeObserver } from './observer';
 import { addListener, removeListener } from './events';
+import { setUnprocessedMixins, classToString } from './namespace_search';
 
 const a_concat = Array.prototype.concat;
 const { isArray } = Array;
@@ -538,7 +539,7 @@ export default class Mixin {
   */
   static create(...args) {
     // ES6TODO: this relies on a global state?
-    unprocessedFlag = true;
+    setUnprocessedMixins();
     let M = this;
     return new M(args, undefined);
   }
@@ -668,18 +669,10 @@ if (ENV._ENABLE_BINDING_SUPPORT) {
   Mixin.detectBinding = null;
 }
 
+Mixin.prototype.toString = classToString;
+
 if (DEBUG) {
   Object.seal(Mixin.prototype);
-}
-
-let unprocessedFlag = false;
-
-export function hasUnprocessedMixins() {
-  return unprocessedFlag;
-}
-
-export function clearUnprocessedMixins() {
-  unprocessedFlag = false;
 }
 
 function _detect(curMixin, targetMixin, seen = new Set()) {

--- a/packages/ember-metal/lib/namespace_search.js
+++ b/packages/ember-metal/lib/namespace_search.js
@@ -1,0 +1,200 @@
+import { getName, setName } from 'ember-utils';
+import { context } from 'ember-environment';
+
+// TODO, this only depends on context, otherwise it could be in utils
+// move into its own package
+// it is needed by Mixin for classToString
+// maybe move it into environment
+
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+let searchDisabled = false;
+
+const flags = {
+  _set: 0,
+  _unprocessedNamespaces: false,
+  get unprocessedNamespaces() {
+    return this._unprocessedNamespaces;
+  },
+  set unprocessedNamespaces(v) {
+    this._set++;
+    this._unprocessedNamespaces = v;
+  }
+};
+
+let unprocessedMixins = false;
+
+export const NAMESPACES = [];
+export const NAMESPACES_BY_ID = Object.create(null);
+
+export function addNamespace(namespace) {
+  flags.unprocessedNamespaces = true;
+  NAMESPACES.push(namespace);
+}
+
+export function removeNamespace(namespace) {
+  let id = namespace.toString();
+  if (id) {
+    delete NAMESPACES_BY_ID[id];
+    if (namespace === context.lookup[id]) {
+      context.lookup[id] = undefined;
+    }
+  }
+
+  NAMESPACES.splice(NAMESPACES.indexOf(namespace), 1);
+}
+
+export function findNamespaces() {
+  if (!flags.unprocessedNamespaces) {
+    return;
+  }
+  let lookup = context.lookup;
+  let keys = Object.keys(lookup);
+  for (let i = 0; i < keys.length; i++) {
+    let key = keys[i];
+    // Only process entities that start with uppercase A-Z
+    if (!isUppercase(key.charCodeAt(0))) {
+      continue;
+    }
+    let obj = tryIsNamespace(lookup, key);
+    if (obj) {
+      setName(obj, key);
+    }
+  }
+}
+
+export function findNamespace(name) {
+  if (!searchDisabled) {
+    processAllNamespaces();
+  }
+  return NAMESPACES_BY_ID[name];
+}
+
+export function processNamespace(namespace) {
+  _processNamespace([namespace.toString()], namespace, new Set());
+}
+
+export function processAllNamespaces() {
+  let unprocessedNamespaces = flags.unprocessedNamespaces;
+  if (unprocessedNamespaces) {
+    findNamespaces();
+    flags.unprocessedNamespaces = false;
+  }
+
+  if (unprocessedNamespaces || unprocessedMixins) {
+    let namespaces = NAMESPACES;
+
+    for (let i = 0; i < namespaces.length; i++) {
+      processNamespace(namespaces[i]);
+    }
+
+    unprocessedMixins = false;
+  }
+}
+
+export function classToString() {
+  let name = getName(this);
+  if (name !== void 0) {
+    return name;
+  }
+  name = calculateToString(this);
+  setName(this, name);
+  return name;
+}
+
+export function isSearchDisabled() {
+  return searchDisabled;
+}
+
+export function setSearchDisabled(flag) {
+  searchDisabled = !!flag;
+}
+
+export function setUnprocessedMixins() {
+  unprocessedMixins = true;
+}
+
+function _processNamespace(paths, root, seen) {
+  let idx = paths.length;
+
+  NAMESPACES_BY_ID[paths.join('.')] = root;
+
+  // Loop over all of the keys in the namespace, looking for classes
+  for (let key in root) {
+    if (!hasOwnProperty.call(root, key)) {
+      continue;
+    }
+    let obj = root[key];
+
+    // If we are processing the `Ember` namespace, for example, the
+    // `paths` will start with `["Ember"]`. Every iteration through
+    // the loop will update the **second** element of this list with
+    // the key, so processing `Ember.View` will make the Array
+    // `['Ember', 'View']`.
+    paths[idx] = key;
+
+    // If we have found an unprocessed class
+    if (obj && obj.toString === classToString && getName(obj) === void 0) {
+      // Replace the class' `toString` with the dot-separated path
+      setName(obj, paths.join('.'));
+      // Support nested namespaces
+    } else if (obj && obj.isNamespace) {
+      // Skip aliased namespaces
+      if (seen.has(obj)) {
+        continue;
+      }
+      seen.add(obj);
+
+      // Process the child namespace
+      _processNamespace(paths, obj, seen);
+    }
+  }
+
+  paths.length = idx; // cut out last item
+}
+
+function isUppercase(code) {
+  return (
+    code >= 65 && code <= 90 // A
+  ); // Z
+}
+
+function tryIsNamespace(lookup, prop) {
+  try {
+    let obj = lookup[prop];
+    return (
+      ((obj !== null && typeof obj === 'object') ||
+        typeof obj === 'function') &&
+      obj.isNamespace &&
+      obj
+    );
+  } catch (e) {
+    // continue
+  }
+}
+
+function calculateToString(target) {
+  let str;
+
+  if (!searchDisabled) {
+    processAllNamespaces();
+
+    str = getName(target);
+    if (str !== void 0) {
+      return str;
+    }
+    let superclass = target;
+    do {
+      superclass = Object.getPrototypeOf(superclass);
+      if (superclass === Function.prototype) {
+        break;
+      }
+      str = getName(target);
+      if (str !== void 0) {
+        str = `(subclass of ${str})`;
+        break;
+      }
+    } while (str === void 0);
+  }
+  return str || '(unknown)';
+}

--- a/packages/ember-runtime/lib/index.js
+++ b/packages/ember-runtime/lib/index.js
@@ -1,11 +1,7 @@
 export { default as Object, FrameworkObject } from './system/object';
 export { default as String } from './system/string';
-export {
-  default as RegistryProxyMixin,
-} from './mixins/registry_proxy';
-export {
-  default as ContainerProxyMixin
-} from './mixins/container_proxy';
+export { default as RegistryProxyMixin } from './mixins/registry_proxy';
+export { default as ContainerProxyMixin } from './mixins/container_proxy';
 export { default as copy } from './copy';
 export { default as inject } from './inject';
 export { default as compare } from './compare';
@@ -19,27 +15,18 @@ export {
   removeAt
 } from './mixins/array';
 export { default as Comparable } from './mixins/comparable';
-export {
-  default as Namespace,
-  isSearchDisabled as isNamespaceSearchDisabled,
-  setSearchDisabled as setNamespaceSearchDisabled
-} from './system/namespace';
+export { default as Namespace } from './system/namespace';
 export { default as ArrayProxy } from './system/array_proxy';
 export { default as ObjectProxy } from './system/object_proxy';
 export { default as CoreObject } from './system/core_object';
-export {
-  default as ActionHandler
-} from './mixins/action_handler';
+export { default as ActionHandler } from './mixins/action_handler';
 export { default as Copyable } from './mixins/copyable';
 export { default as Enumerable } from './mixins/enumerable';
 export {
-  default as _ProxyMixin, contentFor as _contentFor
+  default as _ProxyMixin,
+  contentFor as _contentFor
 } from './mixins/-proxy';
-export {
-  onLoad,
-  runLoadHooks,
-  _loaded
-} from './system/lazy_load';
+export { onLoad, runLoadHooks, _loaded } from './system/lazy_load';
 export { default as Observable } from './mixins/observable';
 export { default as MutableEnumerable } from './mixins/mutable_enumerable';
 export { default as TargetActionSupport } from './mixins/target_action_support';
@@ -85,15 +72,9 @@ export {
 export { default as Controller } from './controllers/controller';
 export { default as ControllerMixin } from './mixins/controller';
 export { default as Service } from './system/service';
-export {
-  default as RSVP,
-  onerrorDefault
-} from './ext/rsvp';     // just for side effect of extending Ember.RSVP
+export { default as RSVP, onerrorDefault } from './ext/rsvp'; // just for side effect of extending Ember.RSVP
 export { isArray, typeOf } from './utils';
-export {
-  getStrings,
-  setStrings
-} from './string_registry';
+export { getStrings, setStrings } from './string_registry';
 
-import './ext/string';   // just for side effect of extending String.prototype
+import './ext/string'; // just for side effect of extending String.prototype
 import './ext/function'; // just for side effect of extending Function.prototype

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -9,6 +9,7 @@ import {
   assign,
   guidFor,
   getName,
+  setName,
   makeArray,
   HAS_NATIVE_PROXY,
   isInternalSymbol
@@ -27,7 +28,8 @@ import {
   InjectedProperty,
   schedule,
   deleteMeta,
-  descriptor
+  descriptor,
+  classToString
 } from 'ember-metal';
 import ActionHandler from '../mixins/action_handler';
 import { validatePropertyInjections } from '../inject';
@@ -277,8 +279,6 @@ function makeCtor(base) {
     return Class.prototype;
   };
 
-  Class.toString = Mixin.prototype.toString;
-
   return Class;
 }
 
@@ -319,7 +319,10 @@ const IS_DESTROYING = descriptor({
   @public
 */
 let CoreObject = makeCtor();
-CoreObject.toString = () => 'Ember.CoreObject';
+CoreObject.prototype.toString = classToString;
+CoreObject.toString = classToString;
+setName(CoreObject, 'Ember.CoreObject');
+
 CoreObject.PrototypeMixin = Mixin.create({
   reopen(...args) {
     applyMixin(this, args, true);

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -8,10 +8,10 @@ import { FACTORY_FOR } from 'container';
 import {
   assign,
   guidFor,
+  getName,
   makeArray,
-  NAME_KEY,
   HAS_NATIVE_PROXY,
-  isInternalSymbol,
+  isInternalSymbol
 } from 'ember-utils';
 import {
   PROXY_CONTENT,
@@ -34,7 +34,11 @@ import { validatePropertyInjections } from '../inject';
 import { assert } from 'ember-debug';
 import { DEBUG } from 'ember-env-flags';
 import { ENV } from 'ember-environment';
-import { MANDATORY_GETTER, MANDATORY_SETTER, EMBER_METAL_ES5_GETTERS } from 'ember/features';
+import {
+  MANDATORY_GETTER,
+  MANDATORY_SETTER,
+  EMBER_METAL_ES5_GETTERS
+} from 'ember/features';
 
 const applyMixin = Mixin._apply;
 const reopen = Mixin.prototype.reopen;
@@ -79,9 +83,18 @@ function makeCtor(base) {
           beforeInitCalled = true;
         }
 
-        if (DEBUG && MANDATORY_GETTER && EMBER_METAL_ES5_GETTERS && HAS_NATIVE_PROXY && typeof self.unknownProperty === 'function') {
+        if (
+          DEBUG &&
+          MANDATORY_GETTER &&
+          EMBER_METAL_ES5_GETTERS &&
+          HAS_NATIVE_PROXY &&
+          typeof self.unknownProperty === 'function'
+        ) {
           let messageFor = (obj, property) => {
-            return `You attempted to access the \`${String(property)}\` property (of ${obj}).\n` +
+            return (
+              `You attempted to access the \`${String(
+                property
+              )}\` property (of ${obj}).\n` +
               `Since Ember 3.1, this is usually fine as you no longer need to use \`.get()\`\n` +
               `to access computed properties. However, in this case, the object in question\n` +
               `is a special kind of Ember object (a proxy). Therefore, it is still necessary\n` +
@@ -89,8 +102,9 @@ function makeCtor(base) {
               `If you encountered this error because of third-party code that you don't control,\n` +
               `there is more information at https://github.com/emberjs/ember.js/issues/16148, and\n` +
               `you can help us improve this error message by telling us more about what happened in\n` +
-              `this situation.`;
-            };
+              `this situation.`
+            );
+          };
 
           /* globals Proxy Reflect */
           self = new Proxy(this, {
@@ -128,18 +142,24 @@ function makeCtor(base) {
         m.proto = self;
 
         if (properties !== undefined) {
-          assert('EmberObject.create only accepts objects.', typeof properties === 'object' && properties !== null);
+          assert(
+            'EmberObject.create only accepts objects.',
+            typeof properties === 'object' && properties !== null
+          );
 
           assert(
             'EmberObject.create no longer supports mixing in other ' +
-            'definitions, use .extend & .create separately instead.',
+              'definitions, use .extend & .create separately instead.',
             !(properties instanceof Mixin)
           );
 
           let concatenatedProperties = self.concatenatedProperties;
           let mergedProperties = self.mergedProperties;
-          let hasConcatenatedProps = concatenatedProperties !== undefined && concatenatedProperties.length > 0;
-          let hasMergedProps = mergedProperties !== undefined && mergedProperties.length > 0;
+          let hasConcatenatedProps =
+            concatenatedProperties !== undefined &&
+            concatenatedProperties.length > 0;
+          let hasMergedProps =
+            mergedProperties !== undefined && mergedProperties.length > 0;
 
           let keyNames = Object.keys(properties);
 
@@ -153,18 +173,21 @@ function makeCtor(base) {
 
             assert(
               'EmberObject.create no longer supports defining computed ' +
-              'properties. Define computed properties using extend() or reopen() ' +
-              'before calling create().',
+                'properties. Define computed properties using extend() or reopen() ' +
+                'before calling create().',
               !(value instanceof ComputedProperty)
             );
             assert(
               'EmberObject.create no longer supports defining methods that call _super.',
-              !(typeof value === 'function' && value.toString().indexOf('._super') !== -1)
+              !(
+                typeof value === 'function' &&
+                value.toString().indexOf('._super') !== -1
+              )
             );
             assert(
               '`actions` must be provided at extend time, not at create time, ' +
-              'when Ember.ActionHandler is used (i.e. views, controllers & routes).',
-              !((keyName === 'actions') && ActionHandler.detect(this))
+                'when Ember.ActionHandler is used (i.e. views, controllers & routes).',
+              !(keyName === 'actions' && ActionHandler.detect(this))
             );
 
             let possibleDesc = descriptorFor(self, keyName, m);
@@ -173,7 +196,10 @@ function makeCtor(base) {
             if (!isDescriptor) {
               let baseValue = self[keyName];
 
-              if (hasConcatenatedProps && concatenatedProperties.indexOf(keyName) > -1) {
+              if (
+                hasConcatenatedProps &&
+                concatenatedProperties.indexOf(keyName) > -1
+              ) {
                 if (baseValue) {
                   value = makeArray(baseValue).concat(value);
                 } else {
@@ -188,7 +214,10 @@ function makeCtor(base) {
 
             if (isDescriptor) {
               possibleDesc.set(self, keyName, value);
-            } else if (typeof self.setUnknownProperty === 'function' && !(keyName in self)) {
+            } else if (
+              typeof self.setUnknownProperty === 'function' &&
+              !(keyName in self)
+            ) {
               self.setUnknownProperty(keyName, value);
             } else {
               if (MANDATORY_SETTER) {
@@ -236,7 +265,9 @@ function makeCtor(base) {
 
   Class.proto = () => {
     let superclass = Class.superclass;
-    if (superclass) { superclass.proto(); }
+    if (superclass) {
+      superclass.proto();
+    }
 
     if (!wasApplied) {
       wasApplied = true;
@@ -260,7 +291,10 @@ const IS_DESTROYED = descriptor({
   },
 
   set(value) {
-    assert(`You cannot set \`${this}.isDestroyed\` directly, please use \`.destroy()\`.`, value === IS_DESTROYED);
+    assert(
+      `You cannot set \`${this}.isDestroyed\` directly, please use \`.destroy()\`.`,
+      value === IS_DESTROYED
+    );
   }
 });
 
@@ -273,7 +307,10 @@ const IS_DESTROYING = descriptor({
   },
 
   set(value) {
-    assert(`You cannot set \`${this}.isDestroying\` directly, please use \`.destroy()\`.`, value === IS_DESTROYING);
+    assert(
+      `You cannot set \`${this}.isDestroying\` directly, please use \`.destroy()\`.`,
+      value === IS_DESTROYING
+    );
   }
 });
 
@@ -513,7 +550,9 @@ CoreObject.PrototypeMixin = Mixin.create({
   */
   destroy() {
     let m = peekMeta(this);
-    if (m.isSourceDestroying()) { return; }
+    if (m.isSourceDestroying()) {
+      return;
+    }
 
     m.setSourceDestroying();
 
@@ -539,7 +578,9 @@ CoreObject.PrototypeMixin = Mixin.create({
     @method _scheduledDestroy
   */
   _scheduledDestroy(m) {
-    if (m.isSourceDestroyed()) { return; }
+    if (m.isSourceDestroyed()) {
+      return;
+    }
     deleteMeta(this);
     m.setSourceDestroyed();
   },
@@ -587,7 +628,9 @@ CoreObject.PrototypeMixin = Mixin.create({
     let hasToStringExtension = typeof this.toStringExtension === 'function';
     let extension = hasToStringExtension ? `:${this.toStringExtension()}` : '';
 
-    let ret = `<${this[NAME_KEY] || FACTORY_FOR.get(this) || this.constructor.toString()}:${guidFor(this)}${extension}>`;
+    let ret = `<${getName(this) ||
+      FACTORY_FOR.get(this) ||
+      this.constructor.toString()}:${guidFor(this)}${extension}>`;
 
     return ret;
   }
@@ -598,11 +641,9 @@ CoreObject.PrototypeMixin.ownerConstructor = CoreObject;
 CoreObject.__super__ = null;
 
 let ClassMixinProps = {
-
   isClass: true,
 
   isMethod: false,
-  [NAME_KEY]: null,
   /**
     Creates a new subclass.
 
@@ -709,7 +750,7 @@ let ClassMixinProps = {
     reopen.apply(Class.PrototypeMixin, arguments);
 
     Class.superclass = this;
-    Class.__super__  = this.prototype;
+    Class.__super__ = this.prototype;
 
     let proto = Class.prototype;
     meta(proto).proto = proto; // this will disable observers on prototype
@@ -877,9 +918,13 @@ let ClassMixinProps = {
   },
 
   detect(obj) {
-    if ('function' !== typeof obj) { return false; }
+    if ('function' !== typeof obj) {
+      return false;
+    }
     while (obj) {
-      if (obj === this) { return true; }
+      if (obj === this) {
+        return true;
+      }
       obj = obj.superclass;
     }
     return false;
@@ -964,10 +1009,12 @@ function injectedPropertyAssertion() {
   assert('Injected properties are invalid', validatePropertyInjections(this));
 }
 
-function flattenProps(... props) {
+function flattenProps(...props) {
   let { concatenatedProperties, mergedProperties } = this;
-  let hasConcatenatedProps = concatenatedProperties !== undefined && concatenatedProperties.length > 0;
-  let hasMergedProps = mergedProperties !== undefined && mergedProperties.length > 0;
+  let hasConcatenatedProps =
+    concatenatedProperties !== undefined && concatenatedProperties.length > 0;
+  let hasMergedProps =
+    mergedProperties !== undefined && mergedProperties.length > 0;
 
   let initProperties = {};
 
@@ -976,7 +1023,7 @@ function flattenProps(... props) {
 
     assert(
       'EmberObject.create no longer supports mixing in other ' +
-      'definitions, use .extend & .create separately instead.',
+        'definitions, use .extend & .create separately instead.',
       !(properties instanceof Mixin)
     );
 
@@ -986,7 +1033,10 @@ function flattenProps(... props) {
       let keyName = keyNames[j];
       let value = properties[keyName];
 
-      if (hasConcatenatedProps && concatenatedProperties.indexOf(keyName) > -1) {
+      if (
+        hasConcatenatedProps &&
+        concatenatedProperties.indexOf(keyName) > -1
+      ) {
         let baseValue = initProperties[keyName];
 
         if (baseValue) {
@@ -1045,7 +1095,6 @@ if (DEBUG) {
     return injections;
   };
 }
-
 
 let ClassMixin = Mixin.create(ClassMixinProps);
 

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -39,197 +39,212 @@ import { MANDATORY_GETTER, MANDATORY_SETTER, EMBER_METAL_ES5_GETTERS } from 'emb
 const applyMixin = Mixin._apply;
 const reopen = Mixin.prototype.reopen;
 
-function makeCtor() {
+function makeCtor(base) {
   // Note: avoid accessing any properties on the object since it makes the
   // method a lot faster. This is glue code so we want it to be as fast as
   // possible.
 
   let wasApplied = false;
-  let initFactory;
+  let Class;
 
-  class Class {
-    constructor(properties) {
-      let self = this;
+  if (base) {
+    Class = class extends base {
+      constructor(properties) {
+        if (!wasApplied) {
+          Class.proto(); // prepare prototype...
+        }
 
-      if (!wasApplied) {
-        Class.proto(); // prepare prototype...
+        super(properties);
       }
+    };
+  } else {
+    let initFactory;
+    Class = class {
+      constructor(properties) {
+        if (!wasApplied) {
+          Class.proto(); // prepare prototype...
+        }
 
-      let beforeInitCalled; // only used in debug builds to enable the proxy trap
+        let self = this;
 
-      // using DEBUG here to avoid the extraneous variable when not needed
-      if (DEBUG) {
-        beforeInitCalled = true;
-      }
+        if (initFactory !== void 0) {
+          FACTORY_FOR.set(this, initFactory);
+          initFactory = void 0;
+        }
 
-      if (DEBUG && MANDATORY_GETTER && EMBER_METAL_ES5_GETTERS && HAS_NATIVE_PROXY && typeof self.unknownProperty === 'function') {
-        let messageFor = (obj, property) => {
-          return `You attempted to access the \`${String(property)}\` property (of ${obj}).\n` +
-            `Since Ember 3.1, this is usually fine as you no longer need to use \`.get()\`\n` +
-            `to access computed properties. However, in this case, the object in question\n` +
-            `is a special kind of Ember object (a proxy). Therefore, it is still necessary\n` +
-            `to use \`.get('${String(property)}')\` in this case.\n\n` +
-            `If you encountered this error because of third-party code that you don't control,\n` +
-            `there is more information at https://github.com/emberjs/ember.js/issues/16148, and\n` +
-            `you can help us improve this error message by telling us more about what happened in\n` +
-            `this situation.`;
-          };
+        let beforeInitCalled; // only used in debug builds to enable the proxy trap
 
-        /* globals Proxy Reflect */
-        self = new Proxy(this, {
-          get(target, property, receiver) {
-            if (property === PROXY_CONTENT) {
-              return target;
-            } else if (
-              beforeInitCalled ||
-              typeof property === 'symbol' ||
-              isInternalSymbol(property) ||
-              property === 'toJSON' ||
-              property === 'toString' ||
-              property === 'toStringExtension' ||
-              property === 'didDefineProperty' ||
-              property === 'willWatchProperty' ||
-              property === 'didUnwatchProperty' ||
-              property === 'didAddListener' ||
-              property === 'didRemoveListener' ||
-              property === '__DESCRIPTOR__' ||
-              property === 'isDescriptor' ||
-              property in target
-            ) {
-              return Reflect.get(target, property, receiver);
+        // using DEBUG here to avoid the extraneous variable when not needed
+        if (DEBUG) {
+          beforeInitCalled = true;
+        }
+
+        if (DEBUG && MANDATORY_GETTER && EMBER_METAL_ES5_GETTERS && HAS_NATIVE_PROXY && typeof self.unknownProperty === 'function') {
+          let messageFor = (obj, property) => {
+            return `You attempted to access the \`${String(property)}\` property (of ${obj}).\n` +
+              `Since Ember 3.1, this is usually fine as you no longer need to use \`.get()\`\n` +
+              `to access computed properties. However, in this case, the object in question\n` +
+              `is a special kind of Ember object (a proxy). Therefore, it is still necessary\n` +
+              `to use \`.get('${String(property)}')\` in this case.\n\n` +
+              `If you encountered this error because of third-party code that you don't control,\n` +
+              `there is more information at https://github.com/emberjs/ember.js/issues/16148, and\n` +
+              `you can help us improve this error message by telling us more about what happened in\n` +
+              `this situation.`;
+            };
+
+          /* globals Proxy Reflect */
+          self = new Proxy(this, {
+            get(target, property, receiver) {
+              if (property === PROXY_CONTENT) {
+                return target;
+              } else if (
+                beforeInitCalled ||
+                typeof property === 'symbol' ||
+                isInternalSymbol(property) ||
+                property === 'toJSON' ||
+                property === 'toString' ||
+                property === 'toStringExtension' ||
+                property === 'didDefineProperty' ||
+                property === 'willWatchProperty' ||
+                property === 'didUnwatchProperty' ||
+                property === 'didAddListener' ||
+                property === 'didRemoveListener' ||
+                property === '__DESCRIPTOR__' ||
+                property === 'isDescriptor' ||
+                property in target
+              ) {
+                return Reflect.get(target, property, receiver);
+              }
+
+              let value = target.unknownProperty.call(receiver, property);
+
+              assert(messageFor(receiver, property), value === undefined);
+            }
+          });
+        }
+
+        let m = meta(self);
+        let proto = m.proto;
+        m.proto = self;
+
+        if (properties !== undefined) {
+          assert('EmberObject.create only accepts objects.', typeof properties === 'object' && properties !== null);
+
+          assert(
+            'EmberObject.create no longer supports mixing in other ' +
+            'definitions, use .extend & .create separately instead.',
+            !(properties instanceof Mixin)
+          );
+
+          let concatenatedProperties = self.concatenatedProperties;
+          let mergedProperties = self.mergedProperties;
+          let hasConcatenatedProps = concatenatedProperties !== undefined && concatenatedProperties.length > 0;
+          let hasMergedProps = mergedProperties !== undefined && mergedProperties.length > 0;
+
+          let keyNames = Object.keys(properties);
+
+          for (let i = 0; i < keyNames.length; i++) {
+            let keyName = keyNames[i];
+            let value = properties[keyName];
+
+            if (ENV._ENABLE_BINDING_SUPPORT && Mixin.detectBinding(keyName)) {
+              m.writeBindings(keyName, value);
             }
 
-            let value = target.unknownProperty.call(receiver, property);
+            assert(
+              'EmberObject.create no longer supports defining computed ' +
+              'properties. Define computed properties using extend() or reopen() ' +
+              'before calling create().',
+              !(value instanceof ComputedProperty)
+            );
+            assert(
+              'EmberObject.create no longer supports defining methods that call _super.',
+              !(typeof value === 'function' && value.toString().indexOf('._super') !== -1)
+            );
+            assert(
+              '`actions` must be provided at extend time, not at create time, ' +
+              'when Ember.ActionHandler is used (i.e. views, controllers & routes).',
+              !((keyName === 'actions') && ActionHandler.detect(this))
+            );
 
-            assert(messageFor(receiver, property), value === undefined);
-          }
-        });
-      }
+            let possibleDesc = descriptorFor(self, keyName, m);
+            let isDescriptor = possibleDesc !== undefined;
 
-      let m = meta(self);
-      let proto = m.proto;
-      m.proto = self;
+            if (!isDescriptor) {
+              let baseValue = self[keyName];
 
-      if (initFactory) {
-        FACTORY_FOR.set(this, initFactory);
-        initFactory = null;
-      }
+              if (hasConcatenatedProps && concatenatedProperties.indexOf(keyName) > -1) {
+                if (baseValue) {
+                  value = makeArray(baseValue).concat(value);
+                } else {
+                  value = makeArray(value);
+                }
+              }
 
-      if (properties !== undefined) {
-        assert('EmberObject.create only accepts objects.', typeof properties === 'object' && properties !== null);
-
-        assert(
-          'EmberObject.create no longer supports mixing in other ' +
-          'definitions, use .extend & .create separately instead.',
-          !(properties instanceof Mixin)
-        );
-
-        let concatenatedProperties = self.concatenatedProperties;
-        let mergedProperties = self.mergedProperties;
-        let hasConcatenatedProps = concatenatedProperties !== undefined && concatenatedProperties.length > 0;
-        let hasMergedProps = mergedProperties !== undefined && mergedProperties.length > 0;
-
-        let keyNames = Object.keys(properties);
-
-        for (let i = 0; i < keyNames.length; i++) {
-          let keyName = keyNames[i];
-          let value = properties[keyName];
-
-          if (ENV._ENABLE_BINDING_SUPPORT && Mixin.detectBinding(keyName)) {
-            m.writeBindings(keyName, value);
-          }
-
-          assert(
-            'EmberObject.create no longer supports defining computed ' +
-            'properties. Define computed properties using extend() or reopen() ' +
-            'before calling create().',
-            !(value instanceof ComputedProperty)
-          );
-          assert(
-            'EmberObject.create no longer supports defining methods that call _super.',
-            !(typeof value === 'function' && value.toString().indexOf('._super') !== -1)
-          );
-          assert(
-            '`actions` must be provided at extend time, not at create time, ' +
-            'when Ember.ActionHandler is used (i.e. views, controllers & routes).',
-            !((keyName === 'actions') && ActionHandler.detect(this))
-          );
-
-          let possibleDesc = descriptorFor(self, keyName, m);
-          let isDescriptor = possibleDesc !== undefined;
-
-          if (!isDescriptor) {
-            let baseValue = self[keyName];
-
-            if (hasConcatenatedProps && concatenatedProperties.indexOf(keyName) > -1) {
-              if (baseValue) {
-                value = makeArray(baseValue).concat(value);
-              } else {
-                value = makeArray(value);
+              if (hasMergedProps && mergedProperties.indexOf(keyName) > -1) {
+                value = assign({}, baseValue, value);
               }
             }
 
-            if (hasMergedProps && mergedProperties.indexOf(keyName) > -1) {
-              value = assign({}, baseValue, value);
-            }
-          }
-
-          if (isDescriptor) {
-            possibleDesc.set(self, keyName, value);
-          } else if (typeof self.setUnknownProperty === 'function' && !(keyName in self)) {
-            self.setUnknownProperty(keyName, value);
-          } else {
-            if (MANDATORY_SETTER) {
-              defineProperty(self, keyName, null, value); // setup mandatory setter
+            if (isDescriptor) {
+              possibleDesc.set(self, keyName, value);
+            } else if (typeof self.setUnknownProperty === 'function' && !(keyName in self)) {
+              self.setUnknownProperty(keyName, value);
             } else {
-              self[keyName] = value;
+              if (MANDATORY_SETTER) {
+                defineProperty(self, keyName, null, value); // setup mandatory setter
+              } else {
+                self[keyName] = value;
+              }
             }
           }
         }
+
+        if (ENV._ENABLE_BINDING_SUPPORT) {
+          Mixin.finishPartial(self, m);
+        }
+
+        // using DEBUG here to avoid the extraneous variable when not needed
+        if (DEBUG) {
+          beforeInitCalled = false;
+        }
+        self.init(...arguments);
+
+        m.proto = proto;
+        finishChains(m);
+        sendEvent(self, 'init', undefined, undefined, undefined, m);
+
+        // only return when in debug builds and `self` is the proxy created above
+        if (DEBUG && self !== this) {
+          return self;
+        }
       }
 
-      if (ENV._ENABLE_BINDING_SUPPORT) {
-        Mixin.finishPartial(self, m);
+      static _initFactory(factory) {
+        initFactory = factory;
       }
-
-      // using DEBUG here to avoid the extraneous variable when not needed
-      if (DEBUG) {
-        beforeInitCalled = false;
-      }
-      self.init(...arguments);
-
-      m.proto = proto;
-      finishChains(m);
-      sendEvent(self, 'init', undefined, undefined, undefined, m);
-
-      // only return when in debug builds and `self` is the proxy created above
-      if (DEBUG && self !== this) {
-        return self;
-      }
-    }
-
-    static willReopen() {
-      if (wasApplied) {
-        Class.PrototypeMixin = Mixin.create(Class.PrototypeMixin);
-      }
-
-      wasApplied = false;
-    }
-
-    static _initFactory(factory) { initFactory = factory; }
-
-    static proto() {
-      let superclass = Class.superclass;
-      if (superclass) { superclass.proto(); }
-
-      if (!wasApplied) {
-        wasApplied = true;
-        Class.PrototypeMixin.applyPartial(Class.prototype);
-      }
-
-      return this.prototype;
-    }
+    };
   }
+
+  Class.willReopen = () => {
+    if (wasApplied) {
+      Class.PrototypeMixin = Mixin.create(Class.PrototypeMixin);
+    }
+
+    wasApplied = false;
+  };
+
+  Class.proto = () => {
+    let superclass = Class.superclass;
+    if (superclass) { superclass.proto(); }
+
+    if (!wasApplied) {
+      wasApplied = true;
+      Class.PrototypeMixin.applyPartial(Class.prototype);
+    }
+
+    return Class.prototype;
+  };
 
   Class.toString = Mixin.prototype.toString;
 
@@ -683,8 +698,8 @@ let ClassMixinProps = {
     @public
   */
   extend() {
-    let Class = makeCtor();
-    let proto;
+    let Class = makeCtor(this);
+
     Class.ClassMixin = Mixin.create(this.ClassMixin);
     Class.PrototypeMixin = Mixin.create(this.PrototypeMixin);
 
@@ -696,8 +711,7 @@ let ClassMixinProps = {
     Class.superclass = this;
     Class.__super__  = this.prototype;
 
-    proto = Class.prototype = Object.create(this.prototype);
-    proto.constructor = Class;
+    let proto = Class.prototype;
     meta(proto).proto = proto; // this will disable observers on prototype
 
     Class.ClassMixin.apply(Class);

--- a/packages/ember-runtime/lib/system/namespace.js
+++ b/packages/ember-runtime/lib/system/namespace.js
@@ -2,24 +2,18 @@
 @module ember
 */
 import {
+  NAMESPACES,
+  NAMESPACES_BY_ID,
+  addNamespace,
+  findNamespace,
+  findNamespaces,
   get,
-  Mixin,
-  hasUnprocessedMixins,
-  clearUnprocessedMixins
+  processNamespace,
+  processAllNamespaces,
+  removeNamespace
 } from 'ember-metal'; // Preloaded into namespaces
-import { context } from 'ember-environment';
-import { getName, setName } from 'ember-utils';
+import { getName } from 'ember-utils';
 import EmberObject from './object';
-
-let searchDisabled = false;
-
-export function isSearchDisabled() {
-  return searchDisabled;
-}
-
-export function setSearchDisabled(flag) {
-  searchDisabled = !!flag;
-}
 
 /**
   A Namespace is an object usually used to contain other objects or methods
@@ -43,8 +37,7 @@ const Namespace = EmberObject.extend({
   isNamespace: true,
 
   init() {
-    Namespace.NAMESPACES.push(this);
-    Namespace.PROCESSED = false;
+    addNamespace(this);
   },
 
   toString() {
@@ -58,178 +51,20 @@ const Namespace = EmberObject.extend({
   },
 
   nameClasses() {
-    processNamespace([this.toString()], this);
+    processNamespace(this);
   },
 
   destroy() {
-    let namespaces = Namespace.NAMESPACES;
-    let toString = this.toString();
-
-    if (toString) {
-      context.lookup[toString] = undefined;
-      delete Namespace.NAMESPACES_BY_ID[toString];
-    }
-    namespaces.splice(namespaces.indexOf(this), 1);
+    removeNamespace(this);
     this._super(...arguments);
   }
 });
 
 Namespace.reopenClass({
-  NAMESPACES: [],
-  NAMESPACES_BY_ID: {},
-  PROCESSED: false,
+  NAMESPACES,
+  NAMESPACES_BY_ID,
   processAll: processAllNamespaces,
-  byName(name) {
-    if (!searchDisabled) {
-      processAllNamespaces();
-    }
-
-    return NAMESPACES_BY_ID[name];
-  }
+  byName: findNamespace
 });
-
-let NAMESPACES_BY_ID = Namespace.NAMESPACES_BY_ID;
-
-let hasOwnProp = {}.hasOwnProperty;
-
-function processNamespace(paths, root, seen = new Set()) {
-  let idx = paths.length;
-
-  NAMESPACES_BY_ID[paths.join('.')] = root;
-
-  // Loop over all of the keys in the namespace, looking for classes
-  for (let key in root) {
-    if (!hasOwnProp.call(root, key)) {
-      continue;
-    }
-    let obj = root[key];
-
-    // If we are processing the `Ember` namespace, for example, the
-    // `paths` will start with `["Ember"]`. Every iteration through
-    // the loop will update the **second** element of this list with
-    // the key, so processing `Ember.View` will make the Array
-    // `['Ember', 'View']`.
-    paths[idx] = key;
-
-    // If we have found an unprocessed class
-    if (obj && obj.toString === classToString && getName(obj) === void 0) {
-      // Replace the class' `toString` with the dot-separated path
-      setName(obj, paths.join('.'));
-
-      // Support nested namespaces
-    } else if (obj && obj.isNamespace) {
-      // Skip aliased namespaces
-      if (seen.has(obj)) {
-        continue;
-      }
-      seen.add(obj);
-
-      // Process the child namespace
-      processNamespace(paths, obj, seen);
-    }
-  }
-
-  paths.length = idx; // cut out last item
-}
-
-function isUppercase(code) {
-  return (
-    code >= 65 && code <= 90 // A
-  ); // Z
-}
-
-function tryIsNamespace(lookup, prop) {
-  try {
-    let obj = lookup[prop];
-    return obj && obj.isNamespace && obj;
-  } catch (e) {
-    // continue
-  }
-}
-
-function findNamespaces() {
-  if (Namespace.PROCESSED) {
-    return;
-  }
-  let lookup = context.lookup;
-  let keys = Object.keys(lookup);
-  for (let i = 0; i < keys.length; i++) {
-    let key = keys[i];
-    // Only process entities that start with uppercase A-Z
-    if (!isUppercase(key.charCodeAt(0))) {
-      continue;
-    }
-    let obj = tryIsNamespace(lookup, key);
-    if (obj) {
-      setName(obj, key);
-    }
-  }
-}
-
-function superClassString(mixin) {
-  let superclass = mixin.superclass;
-  if (superclass) {
-    let superclassName = getName(superclass);
-    if (superclassName !== void 0) {
-      return superclassName;
-    }
-    return superClassString(superclass);
-  }
-}
-
-function calculateToString(target) {
-  let str;
-
-  if (!searchDisabled) {
-    processAllNamespaces();
-    // can also be set by processAllNamespaces
-    str = getName(target);
-    if (str !== void 0) {
-      return str;
-    } else {
-      str = superClassString(target);
-      str = str ? `(subclass of ${str})` : str;
-    }
-  }
-  if (str) {
-    return str;
-  } else {
-    return '(unknown mixin)';
-  }
-}
-
-function classToString() {
-  let name = getName(this);
-  if (name !== void 0) {
-    return name;
-  }
-  name = calculateToString(this);
-  setName(this, name);
-  return name;
-}
-
-function processAllNamespaces() {
-  let unprocessedNamespaces = !Namespace.PROCESSED;
-  let unprocessedMixins = hasUnprocessedMixins();
-
-  if (unprocessedNamespaces) {
-    findNamespaces();
-    Namespace.PROCESSED = true;
-  }
-
-  if (unprocessedNamespaces || unprocessedMixins) {
-    let namespaces = Namespace.NAMESPACES;
-    let namespace;
-
-    for (let i = 0; i < namespaces.length; i++) {
-      namespace = namespaces[i];
-      processNamespace([namespace.toString()], namespace);
-    }
-
-    clearUnprocessedMixins();
-  }
-}
-
-Mixin.prototype.toString = classToString; // ES6TODO: altering imported objects. SBB.
 
 export default Namespace;

--- a/packages/ember-runtime/lib/system/object.js
+++ b/packages/ember-runtime/lib/system/object.js
@@ -3,7 +3,7 @@
 */
 
 import { FACTORY_FOR } from 'container';
-import { symbol, OWNER } from 'ember-utils';
+import { symbol, OWNER, setName } from 'ember-utils';
 import { on, descriptor } from 'ember-metal';
 import CoreObject from './core_object';
 import Observable from '../mixins/observable';
@@ -52,7 +52,7 @@ const EmberObject = CoreObject.extend(Observable, {
   })
 });
 
-EmberObject.toString = () => 'Ember.Object';
+setName(EmberObject, 'Ember.Object');
 
 export let FrameworkObject = EmberObject;
 

--- a/packages/ember-runtime/tests/system/namespace/base_test.js
+++ b/packages/ember-runtime/tests/system/namespace/base_test.js
@@ -1,9 +1,7 @@
 import { context } from 'ember-environment';
-import { run, get } from 'ember-metal';
+import { run, get, setNamespaceSearchDisabled } from 'ember-metal';
 import EmberObject from '../../../system/object';
-import Namespace, {
-  setSearchDisabled as setNamespaceSearchDisabled
-} from '../../../system/namespace';
+import Namespace from '../../../system/namespace';
 
 const originalLookup = context.lookup;
 let lookup;
@@ -18,7 +16,9 @@ QUnit.module('Namespace', {
     setNamespaceSearchDisabled(false);
 
     for (let prop in lookup) {
-      if (lookup[prop]) { run(lookup[prop], 'destroy'); }
+      if (lookup[prop]) {
+        run(lookup[prop], 'destroy');
+      }
     }
 
     context.lookup = originalLookup;
@@ -30,28 +30,51 @@ QUnit.test('Namespace should be a subclass of EmberObject', function(assert) {
 });
 
 QUnit.test('Namespace should be duck typed', function(assert) {
-  assert.ok(get(Namespace.create(), 'isNamespace'), 'isNamespace property is true');
+  assert.ok(
+    get(Namespace.create(), 'isNamespace'),
+    'isNamespace property is true'
+  );
 });
 
 QUnit.test('Namespace is found and named', function(assert) {
-  let nsA = lookup.NamespaceA = Namespace.create();
-  assert.equal(nsA.toString(), 'NamespaceA', 'namespaces should have a name if they are on lookup');
+  let nsA = (lookup.NamespaceA = Namespace.create());
+  assert.equal(
+    nsA.toString(),
+    'NamespaceA',
+    'namespaces should have a name if they are on lookup'
+  );
 
-  let nsB = lookup.NamespaceB = Namespace.create();
-  assert.equal(nsB.toString(), 'NamespaceB', 'namespaces work if created after the first namespace processing pass');
+  let nsB = (lookup.NamespaceB = Namespace.create());
+  assert.equal(
+    nsB.toString(),
+    'NamespaceB',
+    'namespaces work if created after the first namespace processing pass'
+  );
 });
 
 QUnit.test('Classes under an Namespace are properly named', function(assert) {
-  let nsA = lookup.NamespaceA = Namespace.create();
+  let nsA = (lookup.NamespaceA = Namespace.create());
   nsA.Foo = EmberObject.extend();
-  assert.equal(nsA.Foo.toString(), 'NamespaceA.Foo', 'Classes pick up their parent namespace');
+  assert.equal(
+    nsA.Foo.toString(),
+    'NamespaceA.Foo',
+    'Classes pick up their parent namespace'
+  );
 
   nsA.Bar = EmberObject.extend();
-  assert.equal(nsA.Bar.toString(), 'NamespaceA.Bar', 'New Classes get the naming treatment too');
+  assert.equal(
+    nsA.Bar.toString(),
+    'NamespaceA.Bar',
+    'New Classes get the naming treatment too'
+  );
 
-  let nsB = lookup.NamespaceB = Namespace.create();
+  let nsB = (lookup.NamespaceB = Namespace.create());
   nsB.Foo = EmberObject.extend();
-  assert.equal(nsB.Foo.toString(), 'NamespaceB.Foo', 'Classes in new namespaces get the naming treatment');
+  assert.equal(
+    nsB.Foo.toString(),
+    'NamespaceB.Foo',
+    'Classes in new namespaces get the naming treatment'
+  );
 });
 
 //test("Classes under Ember are properly named", function() {
@@ -61,7 +84,7 @@ QUnit.test('Classes under an Namespace are properly named', function(assert) {
 //});
 
 QUnit.test('Lowercase namespaces are no longer supported', function(assert) {
-  let nsC = lookup.namespaceC = Namespace.create();
+  let nsC = (lookup.namespaceC = Namespace.create());
   assert.equal(nsC.toString(), undefined);
 });
 
@@ -70,35 +93,46 @@ QUnit.test('A namespace can be assigned a custom name', function(assert) {
     name: 'NamespaceA'
   });
 
-  let nsB = lookup.NamespaceB = Namespace.create({
+  let nsB = (lookup.NamespaceB = Namespace.create({
     name: 'CustomNamespaceB'
-  });
+  }));
 
   nsA.Foo = EmberObject.extend();
   nsB.Foo = EmberObject.extend();
 
-  assert.equal(nsA.Foo.toString(), 'NamespaceA.Foo', 'The namespace\'s name is used when the namespace is not in the lookup object');
-  assert.equal(nsB.Foo.toString(), 'CustomNamespaceB.Foo', 'The namespace\'s name is used when the namespace is in the lookup object');
+  assert.equal(
+    nsA.Foo.toString(),
+    'NamespaceA.Foo',
+    "The namespace's name is used when the namespace is not in the lookup object"
+  );
+  assert.equal(
+    nsB.Foo.toString(),
+    'CustomNamespaceB.Foo',
+    "The namespace's name is used when the namespace is in the lookup object"
+  );
 });
 
-QUnit.test('Calling namespace.nameClasses() eagerly names all classes', function(assert) {
-  setNamespaceSearchDisabled(true);
+QUnit.test(
+  'Calling namespace.nameClasses() eagerly names all classes',
+  function(assert) {
+    setNamespaceSearchDisabled(true);
 
-  let namespace = lookup.NS = Namespace.create();
+    let namespace = (lookup.NS = Namespace.create());
 
-  namespace.ClassA = EmberObject.extend();
-  namespace.ClassB = EmberObject.extend();
+    namespace.ClassA = EmberObject.extend();
+    namespace.ClassB = EmberObject.extend();
 
-  Namespace.processAll();
+    Namespace.processAll();
 
-  assert.equal(namespace.ClassA.toString(), 'NS.ClassA');
-  assert.equal(namespace.ClassB.toString(), 'NS.ClassB');
-});
+    assert.equal(namespace.ClassA.toString(), 'NS.ClassA');
+    assert.equal(namespace.ClassB.toString(), 'NS.ClassB');
+  }
+);
 
 QUnit.test('A namespace can be looked up by its name', function(assert) {
-  let NS = lookup.NS = Namespace.create();
-  let UI = lookup.UI = Namespace.create();
-  let CF = lookup.CF = Namespace.create();
+  let NS = (lookup.NS = Namespace.create());
+  let UI = (lookup.UI = Namespace.create());
+  let CF = (lookup.CF = Namespace.create());
 
   assert.equal(Namespace.byName('NS'), NS);
   assert.equal(Namespace.byName('UI'), UI);
@@ -106,24 +140,42 @@ QUnit.test('A namespace can be looked up by its name', function(assert) {
 });
 
 QUnit.test('A nested namespace can be looked up by its name', function(assert) {
-  let UI = lookup.UI = Namespace.create();
+  let UI = (lookup.UI = Namespace.create());
   UI.Nav = Namespace.create();
 
   assert.equal(Namespace.byName('UI.Nav'), UI.Nav);
 });
 
-QUnit.test('Destroying a namespace before caching lookup removes it from the list of namespaces', function(assert) {
-  let CF = lookup.CF = Namespace.create();
+QUnit.test(
+  'Destroying a namespace before caching lookup removes it from the list of namespaces',
+  function(assert) {
+    let CF = (lookup.CF = Namespace.create());
 
-  run(CF, 'destroy');
-  assert.equal(Namespace.byName('CF'), undefined, 'namespace can not be found after destroyed');
-});
+    run(CF, 'destroy');
+    assert.equal(
+      Namespace.byName('CF'),
+      undefined,
+      'namespace can not be found after destroyed'
+    );
+  }
+);
 
-QUnit.test('Destroying a namespace after looking up removes it from the list of namespaces', function(assert) {
-  let CF = lookup.CF = Namespace.create();
+QUnit.test(
+  'Destroying a namespace after looking up removes it from the list of namespaces',
+  function(assert) {
+    let CF = (lookup.CF = Namespace.create());
 
-  assert.equal(Namespace.byName('CF'), CF, 'precondition - namespace can be looked up by name');
+    assert.equal(
+      Namespace.byName('CF'),
+      CF,
+      'precondition - namespace can be looked up by name'
+    );
 
-  run(CF, 'destroy');
-  assert.equal(Namespace.byName('CF'), undefined, 'namespace can not be found after destroyed');
-});
+    run(CF, 'destroy');
+    assert.equal(
+      Namespace.byName('CF'),
+      undefined,
+      'namespace can not be found after destroyed'
+    );
+  }
+);

--- a/packages/ember-runtime/tests/system/object/toString_test.js
+++ b/packages/ember-runtime/tests/system/object/toString_test.js
@@ -1,4 +1,4 @@
-import { guidFor, NAME_KEY } from 'ember-utils';
+import { guidFor, setName } from 'ember-utils';
 import { context } from 'ember-environment';
 import EmberObject from '../../../system/object';
 import Namespace from '../../../system/namespace';
@@ -15,13 +15,13 @@ QUnit.module('system/object/toString', {
   }
 });
 
-QUnit.test('NAME_KEY slot is present on Class', function(assert) {
-  assert.ok(EmberObject.extend().hasOwnProperty(NAME_KEY), 'Ember Class\'s have a NAME_KEY slot');
-});
-
-QUnit.test('toString() returns the same value if called twice', function(assert) {
+QUnit.test('toString() returns the same value if called twice', function(
+  assert
+) {
   let Foo = Namespace.create();
-  Foo.toString = function() { return 'Foo'; };
+  Foo.toString = function() {
+    return 'Foo';
+  };
 
   Foo.Bar = EmberObject.extend();
 
@@ -36,36 +36,45 @@ QUnit.test('toString() returns the same value if called twice', function(assert)
   assert.equal(Foo.Bar.toString(), 'Foo.Bar');
 });
 
-QUnit.test('toString on a class returns a useful value when nested in a namespace', function(assert) {
-  let obj;
+QUnit.test(
+  'toString on a class returns a useful value when nested in a namespace',
+  function(assert) {
+    let obj;
 
-  let Foo = Namespace.create();
-  Foo.toString = function() { return 'Foo'; };
+    let Foo = Namespace.create();
+    Foo.toString = function() {
+      return 'Foo';
+    };
 
-  Foo.Bar = EmberObject.extend();
-  assert.equal(Foo.Bar.toString(), 'Foo.Bar');
+    Foo.Bar = EmberObject.extend();
+    assert.equal(Foo.Bar.toString(), 'Foo.Bar');
 
-  obj = Foo.Bar.create();
-  assert.equal(obj.toString(), '<Foo.Bar:' + guidFor(obj) + '>');
+    obj = Foo.Bar.create();
+    assert.equal(obj.toString(), '<Foo.Bar:' + guidFor(obj) + '>');
 
-  Foo.Baz = Foo.Bar.extend();
-  assert.equal(Foo.Baz.toString(), 'Foo.Baz');
+    Foo.Baz = Foo.Bar.extend();
+    assert.equal(Foo.Baz.toString(), 'Foo.Baz');
 
-  obj = Foo.Baz.create();
-  assert.equal(obj.toString(), '<Foo.Baz:' + guidFor(obj) + '>');
+    obj = Foo.Baz.create();
+    assert.equal(obj.toString(), '<Foo.Baz:' + guidFor(obj) + '>');
 
-  obj = Foo.Bar.create();
-  assert.equal(obj.toString(), '<Foo.Bar:' + guidFor(obj) + '>');
-});
+    obj = Foo.Bar.create();
+    assert.equal(obj.toString(), '<Foo.Bar:' + guidFor(obj) + '>');
+  }
+);
 
-QUnit.test('toString on a namespace finds the namespace in lookup', function(assert) {
-  let Foo = lookup.Foo = Namespace.create();
+QUnit.test('toString on a namespace finds the namespace in lookup', function(
+  assert
+) {
+  let Foo = (lookup.Foo = Namespace.create());
 
   assert.equal(Foo.toString(), 'Foo');
 });
 
-QUnit.test('toString on a namespace finds the namespace in lookup', function(assert) {
-  let Foo = lookup.Foo = Namespace.create();
+QUnit.test('toString on a namespace finds the namespace in lookup', function(
+  assert
+) {
+  let Foo = (lookup.Foo = Namespace.create());
   let obj;
 
   Foo.Bar = EmberObject.extend();
@@ -76,11 +85,14 @@ QUnit.test('toString on a namespace finds the namespace in lookup', function(ass
   assert.equal(obj.toString(), '<Foo.Bar:' + guidFor(obj) + '>');
 });
 
-QUnit.test('toString on a namespace falls back to modulePrefix, if defined', function(assert) {
-  let Foo = Namespace.create({ modulePrefix: 'foo' });
+QUnit.test(
+  'toString on a namespace falls back to modulePrefix, if defined',
+  function(assert) {
+    let Foo = Namespace.create({ modulePrefix: 'foo' });
 
-  assert.equal(Foo.toString(), 'foo');
-});
+    assert.equal(Foo.toString(), 'foo');
+  }
+);
 
 QUnit.test('toString includes toStringExtension if defined', function(assert) {
   let Foo = EmberObject.extend({
@@ -93,9 +105,17 @@ QUnit.test('toString includes toStringExtension if defined', function(assert) {
   let bar = Bar.create();
 
   // simulate these classes being defined on a Namespace
-  Foo[NAME_KEY] = 'Foo';
-  Bar[NAME_KEY] = 'Bar';
+  setName(Foo, 'Foo');
+  setName(Bar, 'Bar');
 
-  assert.equal(bar.toString(), '<Bar:' + guidFor(bar) + '>', 'does not include toStringExtension part');
-  assert.equal(foo.toString(), '<Foo:' + guidFor(foo) + ':fooey>', 'Includes toStringExtension result');
+  assert.equal(
+    bar.toString(),
+    '<Bar:' + guidFor(bar) + '>',
+    'does not include toStringExtension part'
+  );
+  assert.equal(
+    foo.toString(),
+    '<Foo:' + guidFor(foo) + ':fooey>',
+    'Includes toStringExtension result'
+  );
 });

--- a/packages/ember-utils/lib/index.d.ts
+++ b/packages/ember-utils/lib/index.d.ts
@@ -4,7 +4,7 @@ export interface Factory<T, C> {
   class: C;
   fullName: string;
   normalizedName: string;
-  create(props?: { [prop: string]: any; }): T;
+  create(props?: { [prop: string]: any }): T;
 }
 
 export interface LookupOptions {
@@ -15,13 +15,18 @@ export interface LookupOptions {
 export interface Owner {
   lookup<T>(fullName: string, options?: LookupOptions): T;
   lookup(fullName: string, options?: LookupOptions): any;
-  factoryFor<T, C>(fullName: string, options?: LookupOptions): Factory<T, C> | undefined;
-  factoryFor(fullName: string, options?: LookupOptions): Factory<any, any> | undefined;
+  factoryFor<T, C>(
+    fullName: string,
+    options?: LookupOptions
+  ): Factory<T, C> | undefined;
+  factoryFor(
+    fullName: string,
+    options?: LookupOptions
+  ): Factory<any, any> | undefined;
   buildChildEngineInstance<T>(name: string): T;
   hasRegistration(name: string, options?: LookupOptions): boolean;
 }
 
-export const NAME_KEY: string;
 export function getOwner(obj: {}): Owner;
 export function setOwner(obj: {}, owner: Owner): void;
 export function symbol(debugName: string): string;

--- a/packages/ember-utils/lib/index.js
+++ b/packages/ember-utils/lib/index.js
@@ -15,19 +15,14 @@ export { getOwner, setOwner, OWNER } from './owner';
 export { default as assign, assign as assignPolyfill } from './assign';
 
 export { default as dictionary } from './dictionary';
-export {
-  uuid,
-  GUID_KEY,
-  generateGuid,
-  guidFor
-} from './guid';
+export { uuid, GUID_KEY, generateGuid, guidFor } from './guid';
 export { default as intern } from './intern';
 export { checkHasSuper, ROOT, wrap } from './super';
 export { default as inspect } from './inspect';
 export { default as lookupDescriptor } from './lookup-descriptor';
 export { canInvoke, tryInvoke } from './invoke';
 export { default as makeArray } from './make-array';
-export { default as NAME_KEY } from './name';
+export { getName, setName } from './name';
 export { default as toString } from './to-string';
 export { HAS_NATIVE_SYMBOL } from './symbol-utils';
 export { HAS_NATIVE_PROXY } from './proxy-utils';

--- a/packages/ember-utils/lib/name.js
+++ b/packages/ember-utils/lib/name.js
@@ -1,2 +1,11 @@
-import symbol from './symbol';
-export default symbol('NAME_KEY');
+const NAMES = new WeakMap();
+
+export function setName(obj, name) {
+  if (obj !== null || typeof obj === 'object' || typeof obj === 'function')
+    NAMES.set(obj, name);
+}
+
+export function getName(obj) {
+  if (obj !== null || typeof obj === 'object' || typeof obj === 'function')
+    return NAMES.get(obj);
+}

--- a/packages/ember/lib/index.js
+++ b/packages/ember/lib/index.js
@@ -301,8 +301,6 @@ import {
   CoreObject,
   NativeArray,
   A,
-  isNamespaceSearchDisabled,
-  setNamespaceSearchDisabled,
   getStrings,
   setStrings,
 
@@ -445,8 +443,8 @@ Object.defineProperty(Ember, 'STRINGS', {
 Object.defineProperty(Ember, 'BOOTED', {
   configurable: false,
   enumerable: false,
-  get: isNamespaceSearchDisabled,
-  set: setNamespaceSearchDisabled
+  get: metal.isNamespaceSearchDisabled,
+  set: metal.setNamespaceSearchDisabled
 });
 
 import {

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -192,7 +192,7 @@ let allExports = [
   ['STRINGS', 'ember-runtime', { get: 'getStrings', set: 'setStrings' }],
   [
     'BOOTED',
-    'ember-runtime',
+    'ember-metal',
     { get: 'isNamespaceSearchDisabled', set: 'setNamespaceSearchDisabled' }
   ],
 

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -5,7 +5,7 @@ import { DEBUG } from 'ember-env-flags';
 
 QUnit.module('ember reexports');
 
-let allExports =[
+let allExports = [
   // ember-utils
   ['getOwner', 'ember-utils', 'getOwner'],
   ['setOwner', 'ember-utils', 'setOwner'],
@@ -112,7 +112,6 @@ let allExports =[
   ['getProperties', 'ember-metal'],
   ['setProperties', 'ember-metal'],
   ['expandProperties', 'ember-metal'],
-  ['NAME_KEY', 'ember-utils'],
   ['addObserver', 'ember-metal'],
   ['removeObserver', 'ember-metal'],
   ['aliasMethod', 'ember-metal'],
@@ -126,23 +125,31 @@ let allExports =[
   ['ViewUtils.getViewElement', 'ember-views', 'getViewElement'],
   ['ViewUtils.getViewBounds', 'ember-views', 'getViewBounds'],
   ['ViewUtils.getViewClientRects', 'ember-views', 'getViewClientRects'],
-  ['ViewUtils.getViewBoundingClientRect', 'ember-views', 'getViewBoundingClientRect'],
+  [
+    'ViewUtils.getViewBoundingClientRect',
+    'ember-views',
+    'getViewBoundingClientRect'
+  ],
   ['ViewUtils.getRootViews', 'ember-views', 'getRootViews'],
   ['ViewUtils.getChildViews', 'ember-views', 'getChildViews'],
-  ['ViewUtils.isSerializationFirstNode', 'ember-glimmer', 'isSerializationFirstNode'],
+  [
+    'ViewUtils.isSerializationFirstNode',
+    'ember-glimmer',
+    'isSerializationFirstNode'
+  ],
   ['TextSupport', 'ember-views'],
   ['ComponentLookup', 'ember-views'],
   ['EventDispatcher', 'ember-views'],
 
   // ember-glimmer
-  ['Component',     'ember-glimmer', 'Component'],
-  ['Helper',        'ember-glimmer', 'Helper'],
+  ['Component', 'ember-glimmer', 'Component'],
+  ['Helper', 'ember-glimmer', 'Helper'],
   ['Helper.helper', 'ember-glimmer', 'helper'],
-  ['Checkbox',      'ember-glimmer', 'Checkbox'],
+  ['Checkbox', 'ember-glimmer', 'Checkbox'],
   ['LinkComponent', 'ember-glimmer', 'LinkComponent'],
-  ['TextArea',      'ember-glimmer', 'TextArea'],
-  ['TextField',     'ember-glimmer', 'TextField'],
-  ['TEMPLATES',     'ember-glimmer', { get: 'getTemplates', set: 'setTemplates' }],
+  ['TextArea', 'ember-glimmer', 'TextArea'],
+  ['TextField', 'ember-glimmer', 'TextField'],
+  ['TEMPLATES', 'ember-glimmer', { get: 'getTemplates', set: 'setTemplates' }],
   ['Handlebars.template', 'ember-glimmer', 'template'],
   ['Handlebars.Utils.escapeExpression', 'ember-glimmer', 'escapeExpression'],
   ['String.htmlSafe', 'ember-glimmer', 'htmlSafe'],
@@ -183,7 +190,11 @@ let allExports =[
   ['_ProxyMixin', 'ember-runtime'],
   ['RSVP', 'ember-runtime'],
   ['STRINGS', 'ember-runtime', { get: 'getStrings', set: 'setStrings' }],
-  ['BOOTED', 'ember-runtime', { get: 'isNamespaceSearchDisabled', set: 'setNamespaceSearchDisabled' }],
+  [
+    'BOOTED',
+    'ember-runtime',
+    { get: 'isNamespaceSearchDisabled', set: 'setNamespaceSearchDisabled' }
+  ],
 
   // ember-routing
   ['Location', 'ember-routing'],
@@ -229,20 +240,37 @@ allExports.forEach(reexport => {
 });
 
 QUnit.test('Ember.String.isHTMLSafe exports correctly', function(assert) {
-  confirmExport(Ember, assert, 'String.isHTMLSafe', 'ember-glimmer', 'isHTMLSafe');
+  confirmExport(
+    Ember,
+    assert,
+    'String.isHTMLSafe',
+    'ember-glimmer',
+    'isHTMLSafe'
+  );
 });
 
 if (DEBUG) {
   QUnit.test('Ember.MODEL_FACTORY_INJECTIONS', function(assert) {
-    let descriptor = Object.getOwnPropertyDescriptor(Ember, 'MODEL_FACTORY_INJECTIONS');
+    let descriptor = Object.getOwnPropertyDescriptor(
+      Ember,
+      'MODEL_FACTORY_INJECTIONS'
+    );
     assert.equal(descriptor.enumerable, false, 'descriptor is not enumerable');
-    assert.equal(descriptor.configurable, false, 'descriptor is not configurable');
+    assert.equal(
+      descriptor.configurable,
+      false,
+      'descriptor is not configurable'
+    );
 
     assert.equal(Ember.MODEL_FACTORY_INJECTIONS, false);
 
     expectDeprecation(function() {
       Ember.MODEL_FACTORY_INJECTIONS = true;
     }, 'Ember.MODEL_FACTORY_INJECTIONS is no longer required');
-    assert.equal(Ember.MODEL_FACTORY_INJECTIONS, false, 'writing to the property has no affect');
+    assert.equal(
+      Ember.MODEL_FACTORY_INJECTIONS,
+      false,
+      'writing to the property has no affect'
+    );
   });
 }


### PR DESCRIPTION
* Make `.extend()` _actually_ use `class` for proper inheritance
* Move the concepts of `NAME_KEY` to a weakmap
* "prettier" some files...
* prevent meta assertions from eagerly "to-string"ing an object (when the assertion is not going to run anyways)
