### PR TITLE
Add test runs for "pure ES<latest>" builds.

### DIFF
--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -185,6 +185,9 @@ function generateEachPackageTests() {
     testFunctions.push(function() {
       return run('package=' + packageName);
     });
+    testFunctions.push(function() {
+      return run('package=' + packageName + '&dist=es');
+    });
     if (packages[packageName].requiresJQuery === false) {
       testFunctions.push(function() {
         return run('package=' + packageName + '&jquery=none');

--- a/packages/ember-glimmer/tests/integration/content-test.js
+++ b/packages/ember-glimmer/tests/integration/content-test.js
@@ -9,7 +9,7 @@ import {
   getDebugFunction,
   setDebugFunction
 } from 'ember-debug';
-import { Object as EmberObject, ObjectProxy } from 'ember-runtime';
+import { Object as EmberObject, ObjectProxy, readOnly } from 'ember-runtime';
 import { classes } from '../utils/test-helpers';
 import { constructStyleDeprecationMessage  } from 'ember-views';
 import { Component, SafeString, htmlSafe } from '../utils/helpers';
@@ -448,7 +448,7 @@ class DynamicContentTest extends RenderingTest {
 
   ['@test it can render a readOnly property of a path']() {
     let Messenger = EmberObject.extend({
-      message: computed.readOnly('a.b.c')
+      message: readOnly('a.b.c')
     });
 
     let messenger = Messenger.create({

--- a/packages/ember-metal/tests/main_test.js
+++ b/packages/ember-metal/tests/main_test.js
@@ -5,13 +5,6 @@ import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 const SEMVER_REGEX = /^((?:0|(?:[1-9]\d*)))\.((?:0|(?:[1-9]\d*)))\.((?:0|(?:[1-9]\d*)))(?:-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$/;
 
 moduleFor('ember-metal/core/main', class extends AbstractTestCase {
-  ['@test Ember registers itself'](assert) {
-    let lib = Ember.libraries._registry[0];
-
-    assert.equal(lib.name, 'Ember');
-    assert.equal(lib.version, Ember.VERSION);
-  }
-
   ['@test Ember.VERSION is in alignment with SemVer v2.0.0'](assert) {
     assert.ok(SEMVER_REGEX.test(Ember.VERSION), `Ember.VERSION (${Ember.VERSION})is valid SemVer v2.0.0`);
   }

--- a/packages/ember-runtime/tests/system/array_proxy/length_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/length_test.js
@@ -1,6 +1,7 @@
 import ArrayProxy from '../../../system/array_proxy';
 import EmberObject from '../../../system/object';
-import { observer, computed } from 'ember-metal';
+import { observer } from 'ember-metal';
+import { oneWay as reads } from 'ember-runtime';
 import { A as a } from '../../../mixins/array';
 
 QUnit.module('Ember.ArrayProxy - content change (length)');
@@ -11,8 +12,8 @@ QUnit.test('array proxy + aliasedProperty complex test', function(assert) {
   aCalled = bCalled = cCalled = dCalled = eCalled = 0;
 
   let obj = EmberObject.extend({
-    colors: computed.reads('model'),
-    length: computed.reads('colors.length'),
+    colors: reads('model'),
+    length: reads('colors.length'),
 
     a: observer('length',                () => aCalled++),
     b: observer('colors.length',         () => bCalled++),

--- a/packages/ember-runtime/tests/system/object/computed_test.js
+++ b/packages/ember-runtime/tests/system/object/computed_test.js
@@ -5,6 +5,7 @@ import {
   observer,
   defineProperty
 } from 'ember-metal';
+import { oneWay as reads } from 'ember-runtime';
 import { testWithDefault } from 'internal-test-helpers';
 import EmberObject from '../../../system/object';
 
@@ -300,7 +301,7 @@ QUnit.test('Calling _super in apply outside the immediate function of a CP gette
 
 QUnit.test('observing computed.reads prop and overriding it in create() works', function(assert) {
   let Obj = EmberObject.extend({
-    name: computed.reads('model.name'),
+    name: reads('model.name'),
     nameDidChange: observer('name', function() {})
   });
 


### PR DESCRIPTION
The `es` dist does extremely little processing of the raw files. This means that we are actually testing ES<latest> output (any typescript is transpiled to ES2017+) + AMD transpilation done (for basic modules support only).