### PR TITLE
[CLEANUP beta] #16391 Cleaning up the test output

### DIFF
--- a/packages/ember-application/tests/system/visit_test.js
+++ b/packages/ember-application/tests/system/visit_test.js
@@ -330,6 +330,14 @@ moduleFor(
     }
 
     [`@test visit() rejects if an error occurred during a transition`](assert) {
+      this.throwError = function(error) {
+        throw new Error(error);
+      };
+
+      Route.reopen({
+        outerTestPromise: this
+      });
+
       this.router.map(function() {
         this.route('a');
         this.route('b', { path: '/b/:b' });
@@ -359,6 +367,11 @@ moduleFor(
         Route.extend({
           afterModel() {
             throw new Error('transition failure');
+          },
+          actions: {
+            error(error) {
+              this.outerTestPromise.throwError(error);
+            }
           }
         })
       );
@@ -374,7 +387,7 @@ moduleFor(
             error instanceof Error,
             'It should reject the promise with the boot error'
           );
-          assert.equal(error.message, 'transition failure');
+          assert.equal(error.message, 'Error: transition failure');
         }
       );
     }

--- a/packages/ember-application/tests/system/visit_test.js
+++ b/packages/ember-application/tests/system/visit_test.js
@@ -334,10 +334,6 @@ moduleFor(
         throw new Error(error);
       };
 
-      Route.reopen({
-        outerTestPromise: this
-      });
-
       this.router.map(function() {
         this.route('a');
         this.route('b', { path: '/b/:b' });
@@ -365,12 +361,13 @@ moduleFor(
       this.add(
         'route:c',
         Route.extend({
+          outerTestPromise: this,
           afterModel() {
             throw new Error('transition failure');
           },
           actions: {
             error(error) {
-              this.outerTestPromise.throwError(error);
+              this.outerTestPromise.throwError(error.message);
             }
           }
         })
@@ -387,7 +384,7 @@ moduleFor(
             error instanceof Error,
             'It should reject the promise with the boot error'
           );
-          assert.equal(error.message, 'Error: transition failure');
+          assert.equal(error.message, 'transition failure');
         }
       );
     }

--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -89,6 +89,10 @@ moduleFor(
         });
     }
 
+    throwError(reason) {
+      throw reason;
+    }
+
     ['@test warn on URLs not included in the route set']() {
       return this.visit('/').then(() => {
         expectAssertion(() => {
@@ -865,6 +869,7 @@ moduleFor(
       this.add(
         'route:special',
         Route.extend({
+          outerTestPromise: this,
           setup() {
             throw 'Setup error';
           },
@@ -875,6 +880,7 @@ moduleFor(
                 'Setup error',
                 'SpecialRoute#error received the error thrown from setup'
               );
+              this.outerTestPromise.throwError(reason);
               return true;
             }
           }
@@ -911,6 +917,7 @@ moduleFor(
       this.add(
         'route:application',
         Route.extend({
+          outerTestPromise: this,
           actions: {
             error(reason) {
               assert.equal(
@@ -918,6 +925,7 @@ moduleFor(
                 'Setup error',
                 'error was correctly passed to custom ApplicationRoute handler'
               );
+              this.outerTestPromise.throwError(reason);
               return true;
             }
           }

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -354,11 +354,20 @@ moduleFor(
     ['@test error is thrown if dynamic segment and query param have same name'](
       assert
     ) {
-      assert.expect(1);
+      assert.expect(2);
 
       this.router.map(function() {
         this.route('index', { path: '/:foo' });
       });
+
+      this.add(
+        'route:index',
+        Route.extend({
+          actions: {
+            error() {}
+          }
+        })
+      );
 
       this.setSingleQPController('index');
 


### PR DESCRIPTION
This PR solves the task: Error while processing route: * in #16391 

_*I'm submitting this mainly for feedback before I apply a fix to all the other tests (the noisy output appears in many places)*_

This changes the test the trigger an error from within the promise instance of the outer scope. It seems like throwing an error in a mocked `Route` hook will cause a rejected promise, but the error message throws in the console (since it's not being caught). If there is a better approach, let me know! Thanks.