### PR TITLE
[CLEANUP] Moving off QUnit.config.current.assert

### DIFF
--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -212,7 +212,7 @@ moduleFor(
   'Application, default resolver with autoboot',
   class extends DefaultResolverApplicationTestCase {
     constructor() {
-      super();
+      super(...arguments);
       this.originalLookup = context.lookup;
     }
 
@@ -263,7 +263,7 @@ moduleFor(
   'Application, autobooting',
   class extends AutobootApplicationTestCase {
     constructor() {
-      super();
+      super(...arguments);
       this.originalLogVersion = ENV.LOG_VERSION;
       this.originalDebug = getDebugFunction('debug');
       this.originalWarn = getDebugFunction('warn');

--- a/packages/ember-glimmer/tests/integration/application/actions-test.js
+++ b/packages/ember-glimmer/tests/integration/application/actions-test.js
@@ -11,7 +11,7 @@ moduleFor(
   class extends ApplicationTest {
     constructor() {
       setDebugFunction('debug', noop);
-      super();
+      super(...arguments);
     }
 
     teardown() {

--- a/packages/ember-glimmer/tests/integration/application/rendering-test.js
+++ b/packages/ember-glimmer/tests/integration/application/rendering-test.js
@@ -9,7 +9,7 @@ moduleFor(
   'Application test: rendering',
   class extends ApplicationTest {
     constructor() {
-      super();
+      super(...arguments);
       this._APPLICATION_TEMPLATE_WRAPPER = ENV._APPLICATION_TEMPLATE_WRAPPER;
     }
 

--- a/packages/ember-glimmer/tests/integration/components/append-test.js
+++ b/packages/ember-glimmer/tests/integration/components/append-test.js
@@ -5,7 +5,7 @@ import { strip } from '../../utils/abstract-test-case';
 
 class AbstractAppendTest extends RenderingTest {
   constructor() {
-    super();
+    super(...arguments);
 
     this.components = [];
     this.ids = [];

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -13,7 +13,7 @@ moduleFor(
   'Components test: curly components',
   class extends RenderingTest {
     constructor() {
-      super();
+      super(...arguments);
       this.originalDidInitAttrsSupport = ENV._ENABLE_DID_INIT_ATTRS_SUPPORT;
     }
 

--- a/packages/ember-glimmer/tests/integration/components/instrumentation-compile-test.js
+++ b/packages/ember-glimmer/tests/integration/components/instrumentation-compile-test.js
@@ -6,7 +6,7 @@ moduleFor(
   'Components compile instrumentation',
   class extends RenderingTest {
     constructor() {
-      super();
+      super(...arguments);
 
       this.resetEvents();
 

--- a/packages/ember-glimmer/tests/integration/components/instrumentation-test.js
+++ b/packages/ember-glimmer/tests/integration/components/instrumentation-test.js
@@ -6,7 +6,7 @@ moduleFor(
   'Components instrumentation',
   class extends RenderingTest {
     constructor() {
-      super();
+      super(...arguments);
 
       this.resetEvents();
 

--- a/packages/ember-glimmer/tests/integration/components/life-cycle-test.js
+++ b/packages/ember-glimmer/tests/integration/components/life-cycle-test.js
@@ -10,7 +10,7 @@ import { runAppend } from 'internal-test-helpers';
 
 class LifeCycleHooksTest extends RenderingTest {
   constructor() {
-    super();
+    super(...arguments);
     this.hooks = [];
     this.components = {};
     this.componentRegistry = [];

--- a/packages/ember-glimmer/tests/integration/components/target-action-test.js
+++ b/packages/ember-glimmer/tests/integration/components/target-action-test.js
@@ -10,7 +10,7 @@ moduleFor(
   'Components test: sendAction',
   class extends RenderingTest {
     constructor() {
-      super();
+      super(...arguments);
       this.actionCounts = {};
       this.sendCount = 0;
       this.actionArguments = null;

--- a/packages/ember-glimmer/tests/integration/components/template-only-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/template-only-components-test.js
@@ -12,7 +12,7 @@ moduleFor(
   'Components test: template-only components (glimmer components)',
   class extends TemplateOnlyComponentsTest {
     constructor() {
-      super();
+      super(...arguments);
       this._TEMPLATE_ONLY_GLIMMER_COMPONENTS = ENV._TEMPLATE_ONLY_GLIMMER_COMPONENTS;
       ENV._TEMPLATE_ONLY_GLIMMER_COMPONENTS = true;
     }
@@ -112,7 +112,7 @@ moduleFor(
   'Components test: template-only components (curly components)',
   class extends TemplateOnlyComponentsTest {
     constructor() {
-      super();
+      super(...arguments);
       this._TEMPLATE_ONLY_GLIMMER_COMPONENTS = ENV._TEMPLATE_ONLY_GLIMMER_COMPONENTS;
       ENV._TEMPLATE_ONLY_GLIMMER_COMPONENTS = false;
     }

--- a/packages/ember-glimmer/tests/integration/components/utils-test.js
+++ b/packages/ember-glimmer/tests/integration/components/utils-test.js
@@ -13,7 +13,7 @@ moduleFor(
   'View tree tests',
   class extends ApplicationTest {
     constructor() {
-      super();
+      super(...arguments);
 
       this.addComponent('x-tagless', {
         ComponentClass: Component.extend({

--- a/packages/ember-glimmer/tests/integration/event-dispatcher-test.js
+++ b/packages/ember-glimmer/tests/integration/event-dispatcher-test.js
@@ -113,7 +113,7 @@ moduleFor(
   'EventDispatcher#setup',
   class extends RenderingTest {
     constructor() {
-      super();
+      super(...arguments);
 
       let dispatcher = this.owner.lookup('event_dispatcher:main');
       run(dispatcher, 'destroy');

--- a/packages/ember-glimmer/tests/integration/helpers/custom-helper-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/custom-helper-test.js
@@ -3,8 +3,6 @@ import { RenderingTest, moduleFor } from '../../utils/test-case';
 import { runDestroy } from 'internal-test-helpers';
 import { set } from 'ember-metal';
 
-let assert = QUnit.assert;
-
 moduleFor(
   'Helpers test: custom helpers',
   class extends RenderingTest {
@@ -88,7 +86,7 @@ moduleFor(
       }, /You must call `this._super\(...arguments\);` when overriding `init` on a framework object. Please update .* to call `this._super\(...arguments\);` from `init`./);
     }
 
-    ['@test class-based helper can recompute a new value']() {
+    ['@test class-based helper can recompute a new value'](assert) {
       let destroyCount = 0;
       let computeCount = 0;
       let helper;
@@ -122,7 +120,7 @@ moduleFor(
       assert.strictEqual(destroyCount, 0, 'destroy is not called on recomputation');
     }
 
-    ['@test class-based helper with static arguments can recompute a new value']() {
+    ['@test class-based helper with static arguments can recompute a new value'](assert) {
       let destroyCount = 0;
       let computeCount = 0;
       let helper;
@@ -180,7 +178,7 @@ moduleFor(
       this.assertText('bob');
     }
 
-    ['@test simple helper is called for param changes']() {
+    ['@test simple helper is called for param changes'](assert) {
       let computeCount = 0;
 
       this.registerHelper('hello-world', ([value]) => {
@@ -215,7 +213,7 @@ moduleFor(
       assert.strictEqual(computeCount, 3, 'compute is called exactly 3 times');
     }
 
-    ['@test class-based helper compute is called for param changes']() {
+    ['@test class-based helper compute is called for param changes'](assert) {
       let createCount = 0;
       let computeCount = 0;
 
@@ -417,7 +415,7 @@ moduleFor(
       }, /Compile Error some-helper is not a modifier: Helpers may not be used in the element form/);
     }
 
-    ['@test class-based helper is torn down']() {
+    ['@test class-based helper is torn down'](assert) {
       let destroyCalled = 0;
 
       this.registerHelper('some-helper', {
@@ -585,7 +583,9 @@ moduleFor(
       assert.equal(instance.compute(), 'lolol', 'can invoke `.compute`');
     }
 
-    ['@test class-based helper can be invoked manually via `owner.factoryFor(...).create().compute()']() {
+    ['@test class-based helper can be invoked manually via `owner.factoryFor(...).create().compute()'](
+      assert
+    ) {
       this.registerHelper('some-helper', {
         compute() {
           assert.ok(true, 'some-helper helper invoked');
@@ -646,7 +646,7 @@ if (!EmberDev.runningProdBuild) {
     'Helpers test: mutation triggers errors - class based helper',
     class extends HelperMutatingArgsTests {
       constructor() {
-        super();
+        super(...arguments);
 
         let compute = this.buildCompute();
 
@@ -661,7 +661,7 @@ if (!EmberDev.runningProdBuild) {
     'Helpers test: mutation triggers errors - simple helper',
     class extends HelperMutatingArgsTests {
       constructor() {
-        super();
+        super(...arguments);
 
         let compute = this.buildCompute();
 

--- a/packages/ember-glimmer/tests/integration/helpers/loc-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/loc-test.js
@@ -6,7 +6,7 @@ moduleFor(
   'Helpers test: {{loc}}',
   class extends RenderingTest {
     constructor() {
-      super();
+      super(...arguments);
       setStrings({
         'Hello Friend': 'Hallo Freund',
         Hello: 'Hallo, %@',

--- a/packages/ember-glimmer/tests/integration/helpers/log-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/log-test.js
@@ -4,7 +4,7 @@ moduleFor(
   'Helpers test: {{log}}',
   class extends RenderingTest {
     constructor() {
-      super();
+      super(...arguments);
       /* eslint-disable no-console */
       this.originalLog = console.log;
       this.logCalls = [];

--- a/packages/ember-glimmer/tests/integration/helpers/render-test.js
+++ b/packages/ember-glimmer/tests/integration/helpers/render-test.js
@@ -7,7 +7,7 @@ moduleFor(
   'Helpers test: {{render}}',
   class extends RenderingTest {
     constructor() {
-      super();
+      super(...arguments);
       this.originalRenderSupport = ENV._ENABLE_RENDER_SUPPORT;
       ENV._ENABLE_RENDER_SUPPORT = true;
     }

--- a/packages/ember-glimmer/tests/integration/mount-test.js
+++ b/packages/ember-glimmer/tests/integration/mount-test.js
@@ -51,7 +51,7 @@ moduleFor(
   '{{mount}} test',
   class extends ApplicationTest {
     constructor() {
-      super();
+      super(...arguments);
 
       let engineRegistrations = (this.engineRegistrations = {});
 
@@ -302,7 +302,7 @@ if (EMBER_ENGINES_MOUNT_PARAMS) {
     '{{mount}} params tests',
     class extends ApplicationTest {
       constructor() {
-        super();
+        super(...arguments);
 
         this.add(
           'engine:paramEngine',

--- a/packages/ember-glimmer/tests/integration/syntax/each-in-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/each-in-test.js
@@ -287,7 +287,7 @@ moduleFor(
   'Syntax test: {{#each-in}} with POJOs',
   class extends EachInTest {
     constructor() {
-      super();
+      super(...arguments);
       this.allowsSetProp = true;
     }
 
@@ -460,7 +460,7 @@ moduleFor(
   'Syntax test: {{#each-in}} with EmberObjects',
   class extends EachInTest {
     constructor() {
-      super();
+      super(...arguments);
       this.allowsSetProp = true;
     }
     createHash(pojo) {
@@ -485,7 +485,7 @@ moduleFor(
   'Syntax test: {{#each-in}} with object proxies',
   class extends EachInTest {
     constructor() {
-      super();
+      super(...arguments);
       this.allowsSetProp = true;
     }
     createHash(pojo) {

--- a/packages/ember-glimmer/tests/integration/syntax/each-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/each-test.js
@@ -1128,7 +1128,7 @@ if (typeof MutationObserver === 'function') {
     'Syntax test: {{#each as}} DOM mutation test',
     class extends RenderingTest {
       constructor() {
-        super();
+        super(...arguments);
         this.observer = null;
       }
 

--- a/packages/ember-glimmer/tests/integration/syntax/experimental-syntax-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/experimental-syntax-test.js
@@ -15,7 +15,7 @@ moduleFor(
         });
       });
 
-      super();
+      super(...arguments);
       this.originalMacros = originalMacros;
     }
 

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1074,7 +1074,7 @@ moduleFor(
       });
     }
 
-    [`@test the {{link-to}} helper calls preventDefault`]() {
+    [`@test the {{link-to}} helper calls preventDefault`](assert) {
       this.router.map(function() {
         this.route('about');
       });
@@ -1087,11 +1087,13 @@ moduleFor(
       );
 
       return this.visit('/').then(() => {
-        assertNav({ prevented: true }, () => this.$('#about-link').click());
+        assertNav({ prevented: true }, () => this.$('#about-link').click(), assert);
       });
     }
 
-    [`@test the {{link-to}} helper does not call preventDefault if 'preventDefault=false' is passed as an option`]() {
+    [`@test the {{link-to}} helper does not call preventDefault if 'preventDefault=false' is passed as an option`](
+      assert
+    ) {
       this.router.map(function() {
         this.route('about');
       });
@@ -1104,11 +1106,13 @@ moduleFor(
       );
 
       return this.visit('/').then(() => {
-        assertNav({ prevented: false }, () => this.$('#about-link').trigger('click'));
+        assertNav({ prevented: false }, () => this.$('#about-link').trigger('click'), assert);
       });
     }
 
-    [`@test the {{link-to}} helper does not call preventDefault if 'preventDefault=boundFalseyThing' is passed as an option`]() {
+    [`@test the {{link-to}} helper does not call preventDefault if 'preventDefault=boundFalseyThing' is passed as an option`](
+      assert
+    ) {
       this.router.map(function() {
         this.route('about');
       });
@@ -1128,11 +1132,13 @@ moduleFor(
       );
 
       return this.visit('/').then(() => {
-        assertNav({ prevented: false }, () => this.$('#about-link').trigger('click'));
+        assertNav({ prevented: false }, () => this.$('#about-link').trigger('click'), assert);
       });
     }
 
-    [`@test The {{link-to}} helper does not call preventDefault if 'target' attribute is provided`]() {
+    [`@test The {{link-to}} helper does not call preventDefault if 'target' attribute is provided`](
+      assert
+    ) {
       this.addTemplate(
         'index',
         `
@@ -1142,11 +1148,11 @@ moduleFor(
       );
 
       return this.visit('/').then(() => {
-        assertNav({ prevented: false }, () => this.$('#self-link').click());
+        assertNav({ prevented: false }, () => this.$('#self-link').click(), assert);
       });
     }
 
-    [`@test The {{link-to}} helper should preventDefault when 'target = _self'`]() {
+    [`@test The {{link-to}} helper should preventDefault when 'target = _self'`](assert) {
       this.addTemplate(
         'index',
         `
@@ -1156,7 +1162,7 @@ moduleFor(
       );
 
       return this.visit('/').then(() => {
-        assertNav({ prevented: true }, () => this.$('#self-link').click());
+        assertNav({ prevented: true }, () => this.$('#self-link').click(), assert);
       });
     }
 
@@ -2077,11 +2083,11 @@ moduleFor(
   }
 );
 
-function assertNav(options, callback) {
+function assertNav(options, callback, assert) {
   let nav = false;
 
   function check(event) {
-    QUnit.assert.equal(
+    assert.equal(
       event.defaultPrevented,
       options.prevented,
       `expected defaultPrevented=${options.prevented}`
@@ -2095,6 +2101,6 @@ function assertNav(options, callback) {
     callback();
   } finally {
     document.removeEventListener('click', check);
-    QUnit.assert.ok(nav, 'Expected a link to be clicked');
+    assert.ok(nav, 'Expected a link to be clicked');
   }
 }

--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -19,7 +19,7 @@ moduleFor(
   'Basic Routing - Decoupled from global resolver',
   class extends ApplicationTestCase {
     constructor() {
-      super();
+      super(...arguments);
       this.addTemplate('home', '<h3 class="hours">Hours</h3>');
       this.addTemplate('camelot', '<section id="camelot"><h3>Is a silly place</h3></section>');
       this.addTemplate('homepage', '<h3 id="troll">Megatroll</h3><p>{{model.home}}</p>');

--- a/packages/ember/tests/routing/router_service_test/currenturl_lifecycle_test.js
+++ b/packages/ember/tests/routing/router_service_test/currenturl_lifecycle_test.js
@@ -33,7 +33,7 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
     'Router Service - currentURL',
     class extends RouterTestCase {
       constructor() {
-        super();
+        super(...arguments);
 
         results = [];
 

--- a/packages/ember/tests/routing/router_service_test/replaceWith_test.js
+++ b/packages/ember/tests/routing/router_service_test/replaceWith_test.js
@@ -10,7 +10,7 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
     'Router Service - replaceWith',
     class extends RouterTestCase {
       constructor() {
-        super();
+        super(...arguments);
 
         let testCase = this;
         testCase.state = [];

--- a/packages/ember/tests/routing/router_service_test/transitionTo_test.js
+++ b/packages/ember/tests/routing/router_service_test/transitionTo_test.js
@@ -13,7 +13,7 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
     'Router Service - transitionTo',
     class extends RouterTestCase {
       constructor() {
-        super();
+        super(...arguments);
 
         let testCase = this;
         testCase.state = [];

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -13,7 +13,7 @@ moduleFor(
   'Loading/Error Substates',
   class extends ApplicationTestCase {
     constructor() {
-      super();
+      super(...arguments);
       counter = 1;
 
       this.addTemplate('application', `<div id="app">{{outlet}}</div>`);
@@ -539,7 +539,7 @@ moduleFor(
   'Loading/Error Substates - nested routes',
   class extends ApplicationTestCase {
     constructor() {
-      super();
+      super(...arguments);
 
       counter = 1;
 

--- a/packages/ember/tests/routing/toplevel_dom_test.js
+++ b/packages/ember/tests/routing/toplevel_dom_test.js
@@ -5,7 +5,7 @@ moduleFor(
   'Top Level DOM Structure',
   class extends ApplicationTestCase {
     constructor() {
-      super();
+      super(...arguments);
       this._APPLICATION_TEMPLATE_WRAPPER = ENV._APPLICATION_TEMPLATE_WRAPPER;
     }
 

--- a/packages/internal-test-helpers/lib/test-cases/abstract-rendering.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract-rendering.js
@@ -12,7 +12,7 @@ const TextNode = window.Text;
 
 export default class AbstractRenderingTestCase extends AbstractTestCase {
   constructor() {
-    super();
+    super(...arguments);
     let bootOptions = this.getBootOptions();
 
     let owner = (this.owner = buildOwner({

--- a/packages/internal-test-helpers/lib/test-cases/abstract.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract.js
@@ -26,10 +26,10 @@ function isMarker(node) {
 }
 
 export default class AbstractTestCase {
-  constructor() {
+  constructor(assert) {
     this.element = null;
     this.snapshot = null;
-    this.assert = QUnit.config.current.assert;
+    this.assert = assert;
 
     let { fixture } = this;
     if (fixture) {

--- a/packages/internal-test-helpers/lib/test-cases/application.js
+++ b/packages/internal-test-helpers/lib/test-cases/application.js
@@ -5,7 +5,7 @@ import { assign } from 'ember-utils';
 
 export default class ApplicationTestCase extends TestResolverApplicationTestCase {
   constructor() {
-    super();
+    super(...arguments);
 
     let { applicationOptions } = this;
     this.application = this.runTask(() => this.createApplication(applicationOptions));

--- a/packages/internal-test-helpers/lib/test-cases/query-param.js
+++ b/packages/internal-test-helpers/lib/test-cases/query-param.js
@@ -6,7 +6,7 @@ import ApplicationTestCase from './application';
 
 export default class QueryParamTestCase extends ApplicationTestCase {
   constructor() {
-    super();
+    super(...arguments);
 
     let testCase = this;
     testCase.expectedPushURL = null;

--- a/packages/internal-test-helpers/lib/test-cases/rendering.js
+++ b/packages/internal-test-helpers/lib/test-cases/rendering.js
@@ -3,7 +3,7 @@ import { privatize as P } from 'container';
 
 export default class RenderingTestCase extends AbstractRenderingTestCase {
   constructor() {
-    super();
+    super(...arguments);
     let { owner } = this;
 
     this.env = owner.lookup('service:-glimmer-environment');

--- a/packages/internal-test-helpers/lib/test-cases/router.js
+++ b/packages/internal-test-helpers/lib/test-cases/router.js
@@ -2,7 +2,7 @@ import ApplicationTestCase from './application';
 
 export default class RouterTestCase extends ApplicationTestCase {
   constructor() {
-    super();
+    super(...arguments);
 
     this.router.map(function() {
       this.route('parent', { path: '/' }, function() {


### PR DESCRIPTION
Moving off of the QUnit global by refactoring away from QUnit.config.current.assert. There are still a couple more cases that need to be refactored away but those will be done in later PRs. 

This move as enabled by: https://github.com/emberjs/ember.js/pull/16441/files#diff-a1c01fcbc707fbc373ccbf31a27ed388

Apart of #15988