### PR TITLE
[CLEANUP beta] #16391 Cleaning up the test output

### DIFF
--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -3519,6 +3519,7 @@ moduleFor(
           },
         })
       );
+      console.error = () => {};
 
       this.visit('/').then(() => {
         let rootElement = document.querySelector('#qunit-fixture');


### PR DESCRIPTION
This PR remove the error message `More context objects were passed than there are dynamic segments for route: stink-bomb`. (Quest #16391)

I've just override `console.error` with a noop function.