### PR TITLE
Begin building the Ember global dynamically.

### DIFF
--- a/packages/ember-views/lib/system/jquery.js
+++ b/packages/ember-views/lib/system/jquery.js
@@ -1,5 +1,24 @@
 import { context, environment } from 'ember-environment';
 
+/**
+ @module jquery
+ @public
+ */
+
+/**
+ @class jquery
+ @public
+ @static
+ */
+
+/**
+  Alias for jQuery
+
+  @for jquery
+  @method $
+  @static
+  @public
+*/
 let jQuery;
 export let jQueryDisabled = false;
 

--- a/packages/internal-test-helpers/lib/confirm-export.js
+++ b/packages/internal-test-helpers/lib/confirm-export.js
@@ -21,7 +21,11 @@ export default function confirmExport(Ember, assert, path, moduleId, exportName)
 
     if (typeof exportName === 'string') {
       let mod = require(moduleId);
-      assert.equal(desc.value, mod[exportName], `Ember.${path} is exported correctly`);
+      if (desc.value) {
+        assert.equal(desc.value, mod[exportName], `Ember.${path} is exported correctly`);
+      } else {
+        assert.equal(desc.get(), mod[exportName], `Ember.${path} is exported correctly`);
+      }
       assert.notEqual(mod[exportName], undefined, `Ember.${path} is not \`undefined\``);
     } else if ('value' in desc) {
       assert.equal(desc.value, exportName.value, `Ember.${path} is exported correctly`);


### PR DESCRIPTION
This is another (in a long line) of interim steps to make the Ember global auto-generated. Ultimately, we want to avoid encoding the data structure at runtime, and instead just emit the correct `Object.defineProperty` calls.

This interim step however, gives us a nice little win: we now lazily require the modules used for the `Ember` global. This means we finally stop eagerly evaluating the _entire_ `ember.prod.js` asset...