### PR TITLE
Fix paths for ember-source addon.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,6 +66,7 @@ module.exports = {
       files: ['jquery.js'],
     });
 
+    let emberSourceDistPath = path.join(__dirname, '..', 'dist');
     var emberFiles = [
       'ember-runtime.js',
       'ember-template-compiler.js',
@@ -81,12 +82,12 @@ module.exports = {
         return flat.concat(jsAndMap);
       }, [])
       .filter(function(file) {
-        var fullPath = path.join(__dirname, '..', 'dist', file);
+        var fullPath = path.join(emberSourceDistPath, file);
 
         return fs.existsSync(fullPath);
       });
 
-    var ember = new Funnel(__dirname + '../dist', {
+    var ember = new Funnel(emberSourceDistPath, {
       destDir: 'ember',
       files: emberFiles,
     });


### PR DESCRIPTION
The refactor to move `index.js` -> `lib/index.js` left this in a broken state (the paths are incorrect and therefore the funnel threw an error at build time).