### PR TITLE
[Backport] Add exception for `didRemoveListener` so evented proxy objects can

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -102,6 +102,7 @@ function makeCtor() {
               property === 'willWatchProperty' ||
               property === 'didUnwatchProperty' ||
               property === 'didAddListener' ||
+              property === 'didRemoveListener' ||
               property === '__DESCRIPTOR__' ||
               property === 'isDescriptor' ||
               property in target

--- a/packages/ember-runtime/tests/mixins/evented_test.js
+++ b/packages/ember-runtime/tests/mixins/evented_test.js
@@ -1,0 +1,22 @@
+import EventedMixin from '../../mixins/evented';
+import CoreObject from '../../system/core_object';
+
+QUnit.module('Ember.Evented');
+
+QUnit.test('works properly on proxy-ish objects', function(assert) {
+  let eventedProxyObj = CoreObject.extend(EventedMixin, {
+    unknownProperty() {
+      return true;
+    }
+  }).create();
+
+  let noop = function() {};
+
+  eventedProxyObj.on('foo', noop);
+  eventedProxyObj.off('foo', noop);
+
+  assert.ok(
+    true,
+    "An assertion was triggered"
+  );
+});


### PR DESCRIPTION
When `off` is called on an Evented proxyish object it checks to see if
didRemoveListener is a function (so that it can later call it).  This
check triggers the assertion for proxy-ish objects to use `get` rather
than installed es5-getter so we add a special case to allow it.

Prior to this change when you called `off` on the proxyish object it
would trigger an assertion telling you to call
`eventedProxyObj.get('didRemoveListener') rather than
`eventedProxyObj.didRemoveListener`.

A few notes about this test:

- the unknownProperty is how we let ember know this is a proxy
- the unknownProperty function must return a value other than undefined
- Evented Mixin must be mixed in