### PR TITLE
[bugfix] Fix `proto` return value for native classes

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -241,7 +241,7 @@ function makeCtor(base) {
     };
   }
 
-  Class.willReopen = () => {
+  Class.willReopen = function() {
     if (wasApplied) {
       Class.PrototypeMixin = Mixin.create(Class.PrototypeMixin);
     }
@@ -249,7 +249,7 @@ function makeCtor(base) {
     wasApplied = false;
   };
 
-  Class.proto = () => {
+  Class.proto = function() {
     let superclass = Class.superclass;
     if (superclass) {
       superclass.proto();
@@ -260,7 +260,10 @@ function makeCtor(base) {
       Class.PrototypeMixin.applyPartial(Class.prototype);
     }
 
-    return Class.prototype;
+    // Native classes will call the nearest superclass's proto function,
+    // and proto is expected to return the current instance's prototype,
+    // so we need to return it from `this` instead
+    return this.prototype;
   };
 
   return Class;

--- a/packages/ember-runtime/tests/system/object/es-compatibility-test.js
+++ b/packages/ember-runtime/tests/system/object/es-compatibility-test.js
@@ -1,5 +1,5 @@
 import EmberObject from '../../../lib/system/object';
-import { Mixin } from 'ember-metal';
+import { Mixin, defineProperty, computed } from 'ember-metal';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 moduleFor(
@@ -276,6 +276,25 @@ moduleFor(
 
       assert.equal(obj.foo, 123, 'sets class fields on instance correctly');
       assert.equal(obj.bar, 789, 'sets passed in properties on instance correctly');
+    }
+
+    ['@test calling metaForProperty on a native class works'](assert) {
+      assert.expect(0);
+
+      class SubEmberObject extends EmberObject {}
+
+      defineProperty(
+        SubEmberObject.prototype,
+        'foo',
+        computed('foo', {
+          get() {
+            return 'bar';
+          },
+        })
+      );
+
+      // able to get meta without throwing an error
+      SubEmberObject.metaForProperty('foo');
     }
   }
 );


### PR DESCRIPTION
Native classes end up calling the nearest class constructor, and with
the recent refactor those class constructors return their own prototype
instead of the class instance's. This breaks certain functions that
currently rely on the `proto` function return the prototype of the
instance itself. We're seeing failures in `@ember-decorators/data`
due to this bug.

This reverts to returning the protoype on the instance directly. 

The other option would be to instead make `proto` a purely side-effecting
function that doesn't return anything, and change the instances where
it is called to use the prototype of the instance they are calling it on. Unsure
if there are any perf implications here.

cc @rwjblue @krisselden 