### PR TITLE
[bugfix] Adds options checking ability to debug/deprecation test helpers

### DIFF
--- a/packages/ember-metal/tests/properties_test.js
+++ b/packages/ember-metal/tests/properties_test.js
@@ -81,7 +81,7 @@ moduleFor(
       assert.expect(3);
       let obj = { foo: 'bar' };
 
-      deprecateProperty(obj, 'baz', 'foo');
+      deprecateProperty(obj, 'baz', 'foo', { id: 'baz-deprecation', until: 'some.version' });
 
       expectDeprecation();
       assert.equal(obj.baz, obj.foo, 'baz and foo are equal');
@@ -94,7 +94,7 @@ moduleFor(
       assert.expect(2);
       let obj = { foo: 'bar', blammo: 'whammy' };
 
-      deprecateProperty(obj, 'baz', 'foo');
+      deprecateProperty(obj, 'baz', 'foo', { id: 'baz-deprecation', until: 'some.version' });
 
       for (let prop in obj) {
         if (obj.hasOwnProperty(prop)) {
@@ -109,7 +109,7 @@ moduleFor(
       assert.expect(3);
       let obj = { foo: 'bar' };
 
-      deprecateProperty(obj, 'baz', 'foo');
+      deprecateProperty(obj, 'baz', 'foo', { id: 'baz-deprecation', until: 'some.version' });
 
       expectDeprecation();
       obj.baz = 'bloop';

--- a/packages/ember-runtime/tests/computed/computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/computed_macros_test.js
@@ -473,10 +473,26 @@ moduleFor(
         })
       );
 
-      defineProperty(obj, 'barAlias', deprecatingAlias('bar'));
-      defineProperty(obj, 'bazAlias', deprecatingAlias('baz'));
-      defineProperty(obj, 'quzAlias', deprecatingAlias('quz'));
-      defineProperty(obj, 'bayAlias', deprecatingAlias('bay'));
+      defineProperty(
+        obj,
+        'barAlias',
+        deprecatingAlias('bar', { id: 'bar-deprecation', until: 'some.version' })
+      );
+      defineProperty(
+        obj,
+        'bazAlias',
+        deprecatingAlias('baz', { id: 'baz-deprecation', until: 'some.version' })
+      );
+      defineProperty(
+        obj,
+        'quzAlias',
+        deprecatingAlias('quz', { id: 'quz-deprecation', until: 'some.version' })
+      );
+      defineProperty(
+        obj,
+        'bayAlias',
+        deprecatingAlias('bay', { id: 'bay-deprecation', until: 'some.version' })
+      );
 
       expectDeprecation(function() {
         assert.equal(get(obj, 'barAlias'), 'asdf');

--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -139,7 +139,12 @@ Object.defineProperty(Ember, 'EXTEND_PROTOTYPES', {
   enumerable: false,
   get() {
     deprecate(
-      'Accessing Ember.EXTEND_PROTOTYPES is deprecated, please migrate to Ember.ENV.EXTEND_PROTOTYPES'
+      'Accessing Ember.EXTEND_PROTOTYPES is deprecated, please migrate to Ember.ENV.EXTEND_PROTOTYPES',
+      false,
+      {
+        id: 'ember-env.old-extend-prototypes',
+        until: '4.0.0',
+      }
     );
 
     return ENV.EXTEND_PROTOTYPES;

--- a/packages/internal-test-helpers/lib/ember-dev/deprecation.js
+++ b/packages/internal-test-helpers/lib/ember-dev/deprecation.js
@@ -54,7 +54,7 @@ class DeprecationAssert extends DebugAssert {
           throw new Error('expectDeprecation was called after expectNoDeprecation was called!');
         }
 
-        tracker.expectCall(message);
+        tracker.expectCall(message, ['id', 'until']);
       });
     };
 

--- a/packages/internal-test-helpers/lib/ember-dev/method-call-tracker.js
+++ b/packages/internal-test-helpers/lib/ember-dev/method-call-tracker.js
@@ -4,7 +4,8 @@ var MethodCallTracker = function(env, methodName) {
   this._env = env;
   this._methodName = methodName;
   this._isExpectingNoCalls = false;
-  this._expecteds = [];
+  this._expectedMessages = [];
+  this._expectedOptionLists = [];
   this._actuals = [];
 };
 
@@ -20,10 +21,10 @@ MethodCallTracker.prototype = {
 
     this._originalMethod = env.getDebugFunction(methodName);
 
-    env.setDebugFunction(methodName, (message, test) => {
+    env.setDebugFunction(methodName, (message, test, options) => {
       let resultOfTest = checkTest(test);
 
-      this._actuals.push([message, resultOfTest]);
+      this._actuals.push([message, resultOfTest, options]);
     });
   },
 
@@ -33,9 +34,10 @@ MethodCallTracker.prototype = {
     }
   },
 
-  expectCall(message) {
+  expectCall(message, options) {
     this.stubMethod();
-    this._expecteds.push(message || /.*/);
+    this._expectedMessages.push(message || /.*/);
+    this._expectedOptionLists.push(options);
   },
 
   expectNoCalls() {
@@ -48,7 +50,7 @@ MethodCallTracker.prototype = {
   },
 
   isExpectingCalls() {
-    return !this._isExpectingNoCalls && this._expecteds.length;
+    return !this._isExpectingNoCalls && this._expectedMessages.length;
   },
 
   assert() {
@@ -56,11 +58,12 @@ MethodCallTracker.prototype = {
     let env = this._env;
     let methodName = this._methodName;
     let isExpectingNoCalls = this._isExpectingNoCalls;
-    let expecteds = this._expecteds;
+    let expectedMessages = this._expectedMessages;
+    let expectedOptionLists = this._expectedOptionLists;
     let actuals = this._actuals;
-    let o, i;
+    let o, i, j;
 
-    if (!isExpectingNoCalls && expecteds.length === 0 && actuals.length === 0) {
+    if (!isExpectingNoCalls && expectedMessages.length === 0 && actuals.length === 0) {
       return;
     }
 
@@ -83,29 +86,63 @@ MethodCallTracker.prototype = {
       return;
     }
 
-    let expected, actual, match;
+    let expectedMessage,
+      expectedOptionList,
+      actual,
+      match,
+      matchesMessage,
+      matchesOptionList,
+      expectedOptionsMessage,
+      actualOptionsMessage;
 
-    for (o = 0; o < expecteds.length; o++) {
-      expected = expecteds[o];
+    for (o = 0; o < expectedMessages.length; o++) {
+      expectedMessage = expectedMessages[o];
+      expectedOptionList = expectedOptionLists[o];
+
       for (i = 0; i < actuals.length; i++) {
+        matchesMessage = false;
+        matchesOptionList = false;
         actual = actuals[i];
-        if (!actual[1]) {
-          if (expected instanceof RegExp) {
-            if (expected.test(actual[0])) {
-              match = actual;
-              break;
-            }
-          } else {
-            if (expected === actual[0]) {
-              match = actual;
-              break;
-            }
+
+        if (actual[1] === true) {
+          continue;
+        }
+
+        if (expectedMessage instanceof RegExp && expectedMessage.test(actual[0])) {
+          matchesMessage = true;
+        } else if (expectedMessage === actual[0]) {
+          matchesMessage = true;
+        }
+
+        if (expectedOptionList === undefined) {
+          matchesOptionList = true;
+        } else if (actual[2]) {
+          matchesOptionList = true;
+
+          for (j = 0; j < expectedOptionList.length; j++) {
+            matchesOptionList =
+              matchesOptionList && actual[2].hasOwnProperty(expectedOptionList[j]);
           }
+        }
+
+        if (matchesMessage && matchesOptionList) {
+          match = actual;
+          break;
         }
       }
 
+      expectedOptionsMessage = expectedOptionList
+        ? `and options: { ${expectedOptionList.join(', ')} }`
+        : 'and no options';
+      actualOptionsMessage = actual[2]
+        ? `and options: { ${Object.keys(actual[2]).join(', ')} }`
+        : 'and no options';
+
       if (!actual) {
-        assert.ok(false, `Received no Ember.${methodName} calls at all, expecting: ${expected}`);
+        assert.ok(
+          false,
+          `Received no Ember.${methodName} calls at all, expecting: ${expectedMessage}`
+        );
       } else if (match && !match[1]) {
         assert.ok(true, `Received failing Ember.${methodName} call with message: ${match[0]}`);
       } else if (match && match[1]) {
@@ -116,16 +153,16 @@ MethodCallTracker.prototype = {
       } else if (actual[1]) {
         assert.ok(
           false,
-          `Did not receive failing Ember.${methodName} call matching '${expected}', last was success with '${
+          `Did not receive failing Ember.${methodName} call matching '${expectedMessage}' ${expectedOptionsMessage}, last was success with '${
             actual[0]
-          }'`
+          }' ${actualOptionsMessage}`
         );
       } else if (!actual[1]) {
         assert.ok(
           false,
-          `Did not receive failing Ember.${methodName} call matching '${expected}', last was failure with '${
+          `Did not receive failing Ember.${methodName} call matching '${expectedMessage}' ${expectedOptionsMessage}, last was failure with '${
             actual[0]
-          }'`
+          }' ${actualOptionsMessage}`
         );
       }
     }


### PR DESCRIPTION
With Ember v3 we now require that deprecations receive `id` and `until`
options. It's a hard error if they are not included, as happened
recently. This PR adds the ability to check for options when asserting
in debug helpers, so we can assert that all deprecations internally
receive these options. It also updates all outstanding cases where an
id/until value were not passed.