### PR TITLE
Update ember-cli to latest SHA

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "lint:fix": "eslint --fix .",
     "test": "node bin/run-tests.js",
     "test:blueprints": "node node-tests/nodetest-runner.js",
+    "test:blueprints-debugger": "node --inspect-brk node-tests/nodetest-runner.js",
     "test:node": "qunit tests/**/*-test.js",
     "test:browserstack": "node bin/run-browserstack-tests.js",
     "test:testem": "testem -f testem.dist.js"
@@ -107,7 +108,7 @@
     "broccoli-uglify-sourcemap": "^2.0.2",
     "common-tags": "^1.7.2",
     "dag-map": "^2.0.2",
-    "ember-cli": "github:ember-cli/ember-cli#8f5a13a02d8ea5a04683565340611161c63bef89",
+    "ember-cli": "github:ember-cli/ember-cli#f724919b2d0455899411908531c9179240f5ef41",
     "ember-cli-blueprint-test-helpers": "^0.18.3",
     "ember-cli-browserstack": "^0.0.6",
     "ember-cli-dependency-checker": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2548,9 +2548,9 @@ ember-cli-yuidoc@^0.8.8:
     rsvp "3.0.14"
     yuidocjs "^0.10.0"
 
-"ember-cli@github:ember-cli/ember-cli#8f5a13a02d8ea5a04683565340611161c63bef89":
-  version "3.1.0-beta.1"
-  resolved "https://codeload.github.com/ember-cli/ember-cli/tar.gz/8f5a13a02d8ea5a04683565340611161c63bef89"
+"ember-cli@github:ember-cli/ember-cli#f724919b2d0455899411908531c9179240f5ef41":
+  version "3.1.2"
+  resolved "https://codeload.github.com/ember-cli/ember-cli/tar.gz/f724919b2d0455899411908531c9179240f5ef41"
   dependencies:
     amd-name-resolver "^1.2.0"
     babel-plugin-transform-es2015-modules-amd "^6.24.0"


### PR DESCRIPTION
this includes https://github.com/ember-cli/ember-cli/pull/7764, https://github.com/ember-cli/ember-cli/pull/7767 and https://github.com/ember-cli/ember-cli/pull/7768 and will unblock some WIP module unification blueprint PRs such as https://github.com/emberjs/ember.js/pull/16492#issuecomment-381515742

TODO:

 * [x] [`Skip running custom "*-addon" blueprint if module unification`](https://github.com/ember-cli/ember-cli/pull/7764)
 * [x] [`Upgrade ember-load-initializers`](https://github.com/ember-cli/ember-cli/pull/7767)
 * [x] [`Don't try to use default addon-import if app is MU`](https://github.com/ember-cli/ember-cli/pull/7768)
