### PR TITLE
Import DEBUG from @glimmer/env.

### DIFF
--- a/broccoli/packages.js
+++ b/broccoli/packages.js
@@ -273,8 +273,8 @@ module.exports.buildEmberEnvFlagsES = function(flags) {
     content += `\nexport const ${key} = ${flags[key]};`;
   }
 
-  return new WriteFile('ember-env-flags.js', content, {
-    annotation: 'ember-env-flags',
+  return new WriteFile('@glimmer/env.js', content, {
+    annotation: '@glimmer/env',
   });
 };
 

--- a/broccoli/to-es5.js
+++ b/broccoli/to-es5.js
@@ -28,7 +28,7 @@ module.exports = function toES5(tree, _options) {
           assertPredicateIndex: 1,
         },
         envFlags: {
-          source: 'ember-env-flags',
+          source: '@glimmer/env',
           flags: { DEBUG: options.environment !== 'production' },
         },
         features: {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   },
   "devDependencies": {
     "@glimmer/compiler": "^0.33.5",
+    "@glimmer/env": "^0.1.7",
     "@glimmer/interfaces": "^0.33.5",
     "@glimmer/node": "^0.33.5",
     "@glimmer/opcode-compiler": "^0.33.5",

--- a/packages/@ember/application/globals-resolver.js
+++ b/packages/@ember/application/globals-resolver.js
@@ -8,7 +8,7 @@ import { assert, info } from 'ember-debug';
 import { String as StringUtils, Object as EmberObject } from 'ember-runtime';
 import validateType from './lib/validate-type';
 import { getTemplate } from 'ember-glimmer';
-import { DEBUG } from 'ember-env-flags';
+import { DEBUG } from '@glimmer/env';
 
 export const Resolver = EmberObject.extend({
   /*

--- a/packages/@ember/application/lib/application.js
+++ b/packages/@ember/application/lib/application.js
@@ -5,7 +5,7 @@
 import { dictionary } from 'ember-utils';
 import { ENV, environment } from 'ember-environment';
 import { assert, isTesting } from 'ember-debug';
-import { DEBUG } from 'ember-env-flags';
+import { DEBUG } from '@glimmer/env';
 import { bind, join, once, run, schedule } from '@ember/runloop';
 import { libraries, processAllNamespaces, setNamespaceSearchDisabled } from 'ember-metal';
 import { _loaded, runLoadHooks } from '@ember/application';

--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -1,7 +1,7 @@
 /* globals Proxy */
 import { assert } from 'ember-debug';
 import { EMBER_MODULE_UNIFICATION } from 'ember/features';
-import { DEBUG } from 'ember-env-flags';
+import { DEBUG } from '@glimmer/env';
 import { OWNER, setOwner } from 'ember-owner';
 import { dictionary, assign, HAS_NATIVE_PROXY } from 'ember-utils';
 

--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -1,7 +1,7 @@
 import { dictionary, assign, intern } from 'ember-utils';
 import { assert, deprecate } from 'ember-debug';
 import Container from './container';
-import { DEBUG } from 'ember-env-flags';
+import { DEBUG } from '@glimmer/env';
 import { ENV } from 'ember-environment';
 
 const VALID_FULL_NAME_REGEXP = /^[^:]+:[^:]+$/;

--- a/packages/ember-debug/index.js
+++ b/packages/ember-debug/index.js
@@ -1,4 +1,4 @@
-import { DEBUG } from 'ember-env-flags';
+import { DEBUG } from '@glimmer/env';
 import { ENV, environment } from 'ember-environment';
 import { isTesting } from './lib/testing';
 import EmberError from '@ember/error';

--- a/packages/ember-debug/lib/deprecate.js
+++ b/packages/ember-debug/lib/deprecate.js
@@ -1,5 +1,4 @@
-/*global __fail__*/
-import { DEBUG } from 'ember-env-flags';
+import { DEBUG } from '@glimmer/env';
 import { ENV } from 'ember-environment';
 
 import { assert } from '../index';
@@ -83,7 +82,7 @@ if (DEBUG) {
   } else {
     captureErrorForStack = () => {
       try {
-        __fail__.fail();
+        __fail__.fail(); // eslint-disable-line
       } catch (e) {
         return e;
       }

--- a/packages/ember-debug/lib/handlers.js
+++ b/packages/ember-debug/lib/handlers.js
@@ -1,4 +1,4 @@
-import { DEBUG } from 'ember-env-flags';
+import { DEBUG } from '@glimmer/env';
 
 export let HANDLERS = {};
 

--- a/packages/ember-debug/lib/warn.js
+++ b/packages/ember-debug/lib/warn.js
@@ -1,4 +1,4 @@
-import { DEBUG } from 'ember-env-flags';
+import { DEBUG } from '@glimmer/env';
 import { ENV } from 'ember-environment';
 
 import deprecate from './deprecate';

--- a/packages/ember-glimmer/externs.d.ts
+++ b/packages/ember-glimmer/externs.d.ts
@@ -6,7 +6,3 @@ declare module 'ember/features' {
   export const EMBER_GLIMMER_DETECT_BACKTRACKING_RERENDER: boolean | null;
   export const MANDATORY_SETTER: boolean | null;
 }
-
-declare module 'ember-env-flags' {
-  export const DEBUG: boolean;
-}

--- a/packages/ember-glimmer/lib/component-managers/abstract.ts
+++ b/packages/ember-glimmer/lib/component-managers/abstract.ts
@@ -1,3 +1,4 @@
+import { DEBUG } from '@glimmer/env';
 import { ComponentCapabilities, Simple } from '@glimmer/interfaces';
 import { Tag, VersionedPathReference } from '@glimmer/reference';
 import {
@@ -10,7 +11,6 @@ import {
   PreparedArguments,
 } from '@glimmer/runtime';
 import { Destroyable, Opaque, Option } from '@glimmer/util';
-import { DEBUG } from 'ember-env-flags';
 import DebugStack from '../utils/debug-stack';
 
 // implements the ComponentManager interface as defined in glimmer:

--- a/packages/ember-glimmer/lib/component-managers/curly.ts
+++ b/packages/ember-glimmer/lib/component-managers/curly.ts
@@ -1,4 +1,5 @@
 import { _instrumentStart } from '@ember/instrumentation';
+import { DEBUG } from '@glimmer/env';
 import {
   ComponentCapabilities,
   Option,
@@ -23,7 +24,6 @@ import {
 import { Destroyable, EMPTY_ARRAY } from '@glimmer/util';
 import { privatize as P } from 'container';
 import { assert, deprecate } from 'ember-debug';
-import { DEBUG } from 'ember-env-flags';
 import { ENV } from 'ember-environment';
 import { get } from 'ember-metal';
 import { getOwner } from 'ember-owner';

--- a/packages/ember-glimmer/lib/component-managers/mount.ts
+++ b/packages/ember-glimmer/lib/component-managers/mount.ts
@@ -1,8 +1,8 @@
+import { DEBUG } from '@glimmer/env';
 import { ComponentCapabilities } from '@glimmer/interfaces';
 import { CONSTANT_TAG, Tag, VersionedPathReference } from '@glimmer/reference';
 import { ComponentDefinition, Invocation, WithDynamicLayout } from '@glimmer/runtime';
 import { Destroyable, Opaque, Option } from '@glimmer/util';
-import { DEBUG } from 'ember-env-flags';
 
 import { generateControllerFactory } from 'ember-routing';
 import { OwnedTemplateMeta } from 'ember-views';

--- a/packages/ember-glimmer/lib/component-managers/outlet.ts
+++ b/packages/ember-glimmer/lib/component-managers/outlet.ts
@@ -1,4 +1,5 @@
 import { _instrumentStart } from '@ember/instrumentation';
+import { DEBUG } from '@glimmer/env';
 import { ComponentCapabilities, Option, Unique } from '@glimmer/interfaces';
 import { CONSTANT_TAG, Tag, VersionedPathReference } from '@glimmer/reference';
 import {
@@ -12,7 +13,6 @@ import {
   WithStaticLayout,
 } from '@glimmer/runtime';
 import { Destroyable } from '@glimmer/util';
-import { DEBUG } from 'ember-env-flags';
 import { ENV } from 'ember-environment';
 import { assign, guidFor } from 'ember-utils';
 import { OwnedTemplateMeta } from 'ember-views';

--- a/packages/ember-glimmer/lib/component-managers/render.ts
+++ b/packages/ember-glimmer/lib/component-managers/render.ts
@@ -2,7 +2,7 @@ import { ComponentCapabilities } from '@glimmer/interfaces';
 import { CONSTANT_TAG, Tag, VersionedPathReference } from '@glimmer/reference';
 import { Arguments, ComponentDefinition, Invocation, WithStaticLayout } from '@glimmer/runtime';
 
-import { DEBUG } from 'ember-env-flags';
+import { DEBUG } from '@glimmer/env';
 import { Owner } from 'ember-owner';
 import { generateController, generateControllerFactory } from 'ember-routing';
 import { OwnedTemplateMeta } from 'ember-views';

--- a/packages/ember-glimmer/lib/component-managers/root.ts
+++ b/packages/ember-glimmer/lib/component-managers/root.ts
@@ -1,8 +1,8 @@
 import { _instrumentStart } from '@ember/instrumentation';
+import { DEBUG } from '@glimmer/env';
 import { ComponentCapabilities } from '@glimmer/interfaces';
 import { Arguments, ComponentDefinition } from '@glimmer/runtime';
 import { FACTORY_FOR } from 'container';
-import { DEBUG } from 'ember-env-flags';
 import { DIRTY_TAG } from '../component';
 import Environment from '../environment';
 import { DynamicScope } from '../renderer';

--- a/packages/ember-glimmer/lib/components/link-to.ts
+++ b/packages/ember-glimmer/lib/components/link-to.ts
@@ -297,8 +297,8 @@
 */
 
 import { flaggedInstrument } from '@ember/instrumentation';
+import { DEBUG } from '@glimmer/env';
 import { assert, warn } from 'ember-debug';
-import { DEBUG } from 'ember-env-flags';
 import { computed, get } from 'ember-metal';
 import { inject } from 'ember-runtime';
 import { isSimpleClick } from 'ember-views';

--- a/packages/ember-glimmer/lib/environment.ts
+++ b/packages/ember-glimmer/lib/environment.ts
@@ -1,3 +1,4 @@
+import { DEBUG } from '@glimmer/env';
 import { OpaqueIterable, VersionedReference } from '@glimmer/reference';
 import {
   ElementBuilder,
@@ -6,7 +7,6 @@ import {
 } from '@glimmer/runtime';
 import { Destroyable, Opaque } from '@glimmer/util';
 import { warn } from 'ember-debug';
-import { DEBUG } from 'ember-env-flags';
 import { OWNER, Owner } from 'ember-owner';
 import { constructStyleDeprecationMessage, lookupComponent } from 'ember-views';
 import DebugStack from './utils/debug-stack';

--- a/packages/ember-glimmer/lib/helpers/action.ts
+++ b/packages/ember-glimmer/lib/helpers/action.ts
@@ -3,11 +3,11 @@
 */
 import { flaggedInstrument } from '@ember/instrumentation';
 import { join } from '@ember/runloop';
+import { DEBUG } from '@glimmer/env';
 import { isConst, VersionedPathReference } from '@glimmer/reference';
 import { Arguments, VM } from '@glimmer/runtime';
 import { Opaque } from '@glimmer/util';
 import { assert } from 'ember-debug';
-import { DEBUG } from 'ember-env-flags';
 import { get, isNone } from 'ember-metal';
 import { ACTION, INVOKE, UnboundReference } from '../utils/references';
 

--- a/packages/ember-glimmer/lib/utils/debug-stack.ts
+++ b/packages/ember-glimmer/lib/utils/debug-stack.ts
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { DEBUG } from 'ember-env-flags';
+import { DEBUG } from '@glimmer/env';
 
 let DebugStack: any;
 

--- a/packages/ember-glimmer/lib/utils/references.ts
+++ b/packages/ember-glimmer/lib/utils/references.ts
@@ -1,3 +1,4 @@
+import { DEBUG } from '@glimmer/env';
 import { Opaque } from '@glimmer/interfaces';
 import {
   combine,
@@ -19,7 +20,6 @@ import {
   PrimitiveReference,
 } from '@glimmer/runtime';
 import { Option } from '@glimmer/util';
-import { DEBUG } from 'ember-env-flags';
 import { didRender, get, set, tagFor, tagForProperty, watchKey } from 'ember-metal';
 import { isProxy, symbol } from 'ember-utils';
 import { EMBER_GLIMMER_DETECT_BACKTRACKING_RERENDER, MANDATORY_SETTER } from 'ember/features';

--- a/packages/ember-glimmer/tests/unit/utils/debug-stack-test.js
+++ b/packages/ember-glimmer/tests/unit/utils/debug-stack-test.js
@@ -1,5 +1,5 @@
 import { DebugStack } from 'ember-glimmer';
-import { DEBUG } from 'ember-env-flags';
+import { DEBUG } from '@glimmer/env';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 moduleFor(

--- a/packages/ember-metal/lib/libraries.js
+++ b/packages/ember-metal/lib/libraries.js
@@ -1,5 +1,5 @@
 import { warn, debug } from 'ember-debug';
-import { DEBUG } from 'ember-env-flags';
+import { DEBUG } from '@glimmer/env';
 import { get } from './property_get';
 import { EMBER_LIBRARIES_ISREGISTERED } from 'ember/features';
 import VERSION from 'ember/version';

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -1,7 +1,7 @@
 import { lookupDescriptor, symbol, toString } from 'ember-utils';
 import { protoMethods as listenerMethods } from './meta_listeners';
 import { assert } from 'ember-debug';
-import { DEBUG } from 'ember-env-flags';
+import { DEBUG } from '@glimmer/env';
 import { DESCRIPTOR_TRAP, EMBER_METAL_ES5_GETTERS, MANDATORY_SETTER } from 'ember/features';
 import { removeChainWatcher } from './chains';
 import { ENV } from 'ember-environment';

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -4,7 +4,7 @@
 import { EMBER_METAL_ES5_GETTERS } from 'ember/features';
 import { assign, guidFor, ROOT, wrap, makeArray, NAME_KEY } from 'ember-utils';
 import { assert } from 'ember-debug';
-import { DEBUG } from 'ember-env-flags';
+import { DEBUG } from '@glimmer/env';
 import { ENV } from 'ember-environment';
 import { descriptorFor, meta as metaFor, peekMeta } from './meta';
 import expandProperties from './expand_properties';

--- a/packages/ember-metal/lib/transaction.js
+++ b/packages/ember-metal/lib/transaction.js
@@ -1,5 +1,5 @@
 import { assert } from 'ember-debug';
-import { DEBUG } from 'ember-env-flags';
+import { DEBUG } from '@glimmer/env';
 import { EMBER_GLIMMER_DETECT_BACKTRACKING_RERENDER } from 'ember/features';
 
 let runInTransaction, didRender, assertNotRendered;

--- a/packages/ember-routing/lib/system/generate_controller.js
+++ b/packages/ember-routing/lib/system/generate_controller.js
@@ -1,6 +1,6 @@
 import { get } from 'ember-metal';
 import { info } from 'ember-debug';
-import { DEBUG } from 'ember-env-flags';
+import { DEBUG } from '@glimmer/env';
 /**
 @module ember
 */

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -3,7 +3,7 @@ import { assign } from 'ember-utils';
 import { once } from '@ember/runloop';
 import { get, set, getProperties, setProperties, computed, isEmpty } from 'ember-metal';
 import { assert, info, isTesting, deprecate } from 'ember-debug';
-import { DEBUG } from 'ember-env-flags';
+import { DEBUG } from '@glimmer/env';
 import {
   typeOf,
   copy,

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -10,7 +10,7 @@ import EmberRouterDSL from './dsl';
 import EmberLocation from '../location/api';
 import { resemblesURL, getActiveTargetName, calculateCacheKey, extractRouteArgs } from '../utils';
 import RouterState from './router_state';
-import { DEBUG } from 'ember-env-flags';
+import { DEBUG } from '@glimmer/env';
 
 /**
 @module @ember/routing

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -33,7 +33,7 @@ import {
 import ActionHandler from '../mixins/action_handler';
 import { validatePropertyInjections } from '../inject';
 import { assert } from 'ember-debug';
-import { DEBUG } from 'ember-env-flags';
+import { DEBUG } from '@glimmer/env';
 import { ENV } from 'ember-environment';
 import { MANDATORY_GETTER, MANDATORY_SETTER, EMBER_METAL_ES5_GETTERS } from 'ember/features';
 

--- a/packages/ember-runtime/lib/system/object.js
+++ b/packages/ember-runtime/lib/system/object.js
@@ -9,7 +9,7 @@ import { on, descriptor } from 'ember-metal';
 import CoreObject from './core_object';
 import Observable from '../mixins/observable';
 import { assert } from 'ember-debug';
-import { DEBUG } from 'ember-env-flags';
+import { DEBUG } from '@glimmer/env';
 
 let OVERRIDE_OWNER = symbol('OVERRIDE_OWNER');
 

--- a/packages/ember-runtime/tests/inject_test.js
+++ b/packages/ember-runtime/tests/inject_test.js
@@ -1,7 +1,7 @@
 /* global EmberDev */
 
 import { InjectedProperty } from 'ember-metal';
-import { DEBUG } from 'ember-env-flags';
+import { DEBUG } from '@glimmer/env';
 import inject from '../lib/inject';
 import { createInjectionHelper } from '../lib/inject';
 import EmberObject from '../lib/system/object';

--- a/packages/ember-views/lib/views/states/in_dom.js
+++ b/packages/ember-views/lib/views/states/in_dom.js
@@ -1,7 +1,7 @@
 import { assign } from 'ember-utils';
 import { addObserver } from 'ember-metal';
 import EmberError from '@ember/error';
-import { DEBUG } from 'ember-env-flags';
+import { DEBUG } from '@glimmer/env';
 
 import hasElement from './has_element';
 

--- a/packages/ember/tests/production_build_test.js
+++ b/packages/ember/tests/production_build_test.js
@@ -1,4 +1,4 @@
-import { DEBUG } from 'ember-env-flags';
+import { DEBUG } from '@glimmer/env';
 import { assert as emberAssert, runInDebug } from 'ember-debug';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,6 +15,10 @@
   version "0.33.5"
   resolved "https://registry.yarnpkg.com/@glimmer/encoder/-/encoder-0.33.5.tgz#685c5235dc6b7d2d504fbe6ab7642b818ff8a68c"
 
+"@glimmer/env@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
+
 "@glimmer/interfaces@^0.33.5":
   version "0.33.5"
   resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.33.5.tgz#f6b1d12532ec67fd55c8e595cf7df5e5281c7070"


### PR DESCRIPTION
This updates ember-source's internal `DEBUG` flag to match that of normal ember-cli apps:

```js
import { DEBUG } from '@glimmer/env';
```