### PR TITLE
Remove `babel-plugin-transform-proto-to-assign` usage.

### DIFF
--- a/broccoli/to-es5.js
+++ b/broccoli/to-es5.js
@@ -52,7 +52,6 @@ module.exports = function toES5(tree, _options) {
     ['transform-es2015-block-scoping', { throwIfClosureRequired: true }],
     ['check-es2015-constants'],
     ['transform-es2015-classes', { loose: true }],
-    ['transform-proto-to-assign'],
     ['transform-object-assign'],
     injectNodeGlobals,
     ['transform-es2015-modules-amd', { noInterop: true, strict: true }],

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "babel-plugin-transform-es2015-spread": "^6.22.0",
     "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "babel-plugin-transform-object-assign": "^6.22.0",
-    "babel-plugin-transform-proto-to-assign": "^6.26.0",
     "babel-template": "^6.26.0",
     "backburner.js": "^2.2.2",
     "broccoli-babel-transpiler": "^6.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -886,13 +886,6 @@ babel-plugin-transform-object-assign@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-proto-to-assign@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-proto-to-assign/-/babel-plugin-transform-proto-to-assign-6.26.0.tgz#c493e24a62749a44f7ede96506c0cb3a1891f67b"
-  dependencies:
-    babel-runtime "^6.26.0"
-    lodash "^4.17.4"
-
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"


### PR DESCRIPTION
This supported IE < 11 (as they had no `Object.getPrototypeOf` / `Object.setPrototypeOf` / `__proto__` access) and is no longer needed.