### PR TITLE
Vastly improve Ember.inspect output and safety.

### DIFF
--- a/packages/@ember/string/index.js
+++ b/packages/@ember/string/index.js
@@ -6,8 +6,6 @@ export { getStrings as _getStrings, setStrings as _setStrings } from './lib/stri
 
 import { ENV } from 'ember-environment';
 import { Cache } from 'ember-metal';
-import { inspect } from 'ember-utils';
-import { isArray } from 'ember-runtime';
 import { getString } from './lib/string_registry';
 
 const STRING_DASHERIZE_REGEXP = /[ _]/g;
@@ -76,22 +74,12 @@ const DECAMELIZE_CACHE = new Cache(1000, str =>
 */
 
 function _fmt(str, formats) {
-  let cachedFormats = formats;
-
-  if (!isArray(cachedFormats) || arguments.length > 2) {
-    cachedFormats = new Array(arguments.length - 1);
-
-    for (let i = 1; i < arguments.length; i++) {
-      cachedFormats[i - 1] = arguments[i];
-    }
-  }
-
   // first, replace any ORDERED replacements.
   let idx = 0; // the current index for non-numerical replacements
   return str.replace(/%@([0-9]+)?/g, (s, argIndex) => {
-    argIndex = argIndex ? parseInt(argIndex, 10) - 1 : idx++;
-    s = cachedFormats[argIndex];
-    return s === null ? '(null)' : s === undefined ? '' : inspect(s);
+    let i = argIndex ? parseInt(argIndex, 10) - 1 : idx++;
+    let r = i < formats.length ? formats[i] : undefined;
+    return typeof r === 'string' ? r : r === null ? '(null)' : r === undefined ? '' : '' + r;
   });
 }
 
@@ -122,7 +110,7 @@ function _fmt(str, formats) {
   @public
 */
 export function loc(str, formats) {
-  if (!isArray(formats) || arguments.length > 2) {
+  if (!Array.isArray(formats) || arguments.length > 2) {
     formats = Array.prototype.slice.call(arguments, 1);
   }
 

--- a/packages/@ember/string/tests/loc_test.js
+++ b/packages/@ember/string/tests/loc_test.js
@@ -70,7 +70,7 @@ moduleFor(
 
     ['@test works with argument form'](assert) {
       assert.equal(loc('_Hello %@', 'John'), 'Bonjour John');
-      assert.equal(loc('_Hello %@ %@', ['John'], 'Doe'), 'Bonjour [John] Doe');
+      assert.equal(loc('_Hello %@ %@', ['John'], 'Doe'), 'Bonjour John Doe');
     }
   }
 );

--- a/packages/ember-utils/lib/inspect.ts
+++ b/packages/ember-utils/lib/inspect.ts
@@ -1,4 +1,13 @@
-const objectToString = Object.prototype.toString;
+import WeakSet from './weak_set';
+const { toString: objectToString } = Object.prototype;
+const { toString: functionToString } = Function.prototype;
+const { isArray } = Array;
+const { keys: objectKeys } = Object;
+const { stringify } = JSON;
+const LIST_LIMIT = 100;
+const DEPTH_LIMIT = 4;
+const SAFE_KEY = /^[\w$]+$/;
+
 /**
  @module @ember/debug
 */
@@ -16,45 +25,96 @@ const objectToString = Object.prototype.toString;
   @since 1.4.0
   @private
 */
-export default function inspect(obj: any | null | undefined): string {
-  if (obj === null) {
-    return 'null';
-  }
-  if (obj === undefined) {
-    return 'undefined';
-  }
-  if (Array.isArray(obj)) {
-    return `[${obj}]`;
-  }
-  // for non objects
-  let type = typeof obj;
-  if (type !== 'object' && type !== 'symbol') {
-    return `${obj}`;
-  }
-  // overridden toString
-  if (typeof obj.toString === 'function' && obj.toString !== objectToString) {
-    return obj.toString();
+export default function inspect(this: any, obj: any | null | undefined): string {
+  // detect Node util.inspect call inspect(depth: number, opts: object)
+  if (typeof obj === 'number' && arguments.length === 2) {
+    return this;
   }
 
-  // Object.prototype.toString === {}.toString
-  let v;
-  let ret = [];
-  for (let key in obj) {
-    if (obj.hasOwnProperty(key)) {
-      v = obj[key];
-      if (v === 'toString') {
-        continue;
-      } // ignore useless items
-      if (typeof v === 'function') {
-        v = 'function() { ... }';
-      }
+  return inspectValue(obj, 0);
+}
 
-      if (v && typeof v.toString !== 'function') {
-        ret.push(`${key}: ${objectToString.call(v)}`);
-      } else {
-        ret.push(`${key}: ${v}`);
+function inspectValue(value: any | null | undefined, depth: number, seen?: WeakSet<object>) {
+  let valueIsArray = false;
+  switch (typeof value) {
+    case 'undefined':
+      return 'undefined';
+    case 'object':
+      if (value === null) return 'null';
+      if (isArray(value)) {
+        valueIsArray = true;
+        break;
       }
+      // is toString Object.prototype.toString or undefined then traverse
+      if (value.toString === objectToString || value.toString === undefined) {
+        break;
+      }
+      // custom toString
+      return value.toString();
+    case 'function':
+      return value.toString === functionToString
+        ? value.name ? `[Function:${value.name}]` : `[Function]`
+        : value.toString();
+    case 'string':
+      return stringify(value);
+    case 'symbol':
+    case 'boolean':
+    case 'number':
+    default:
+      return value.toString();
+  }
+  if (seen === undefined) {
+    seen = new WeakSet();
+  } else {
+    if (seen.has(value)) return `[Circular]`;
+  }
+  seen.add(value);
+
+  return valueIsArray
+    ? inspectArray(value, depth + 1, seen)
+    : inspectObject(value, depth + 1, seen);
+}
+
+function inspectKey(key: string) {
+  return SAFE_KEY.test(key) ? key : stringify(key);
+}
+
+function inspectObject(obj: object, depth: number, seen: WeakSet<object>) {
+  if (depth > DEPTH_LIMIT) {
+    return '[Object]';
+  }
+  let s = '{';
+  let keys = objectKeys(obj);
+  for (let i = 0; i < keys.length; i++) {
+    s += i === 0 ? ' ' : ', ';
+
+    if (i >= LIST_LIMIT) {
+      s += `... ${keys.length - LIST_LIMIT} more keys`;
+      break;
     }
+
+    let key = keys[i];
+    s += inspectKey(key) + ': ' + inspectValue(obj[key], depth, seen);
   }
-  return `{${ret.join(', ')}}`;
+  s += ' }';
+  return s;
+}
+
+function inspectArray(arr: any[], depth: number, seen: WeakSet<object>) {
+  if (depth > DEPTH_LIMIT) {
+    return '[Array]';
+  }
+  let s = '[';
+  for (let i = 0; i < arr.length; i++) {
+    s += i === 0 ? ' ' : ', ';
+
+    if (i >= LIST_LIMIT) {
+      s += `... ${arr.length - LIST_LIMIT} more items`;
+      break;
+    }
+
+    s += inspectValue(arr[i], depth, seen);
+  }
+  s += ' ]';
+  return s;
 }

--- a/packages/ember-utils/lib/weak_set.ts
+++ b/packages/ember-utils/lib/weak_set.ts
@@ -1,35 +1,20 @@
 /* globals WeakSet */
 
-export interface WeakSetLike<T extends object> {
-  add(val: T): this;
-  delete(val: T): boolean;
-  has(val: T): boolean;
-}
+export default (typeof WeakSet === 'function'
+  ? WeakSet
+  : class WeakSetPolyFill<T extends object> {
+      private _map = new WeakMap();
 
-export type WeakSetLikeConstructor = {
-  new (): WeakSetLike<object>;
-  new <T extends object>(): WeakSetLike<T>;
-  prototype: WeakSetLike<object>;
-};
+      add(val: T): this {
+        this._map.set(val, true);
+        return this;
+      }
 
-const WeakSetLike: WeakSetLikeConstructor =
-  typeof WeakSet === 'function'
-    ? WeakSet
-    : class WeakSetPolyFill<T extends object> implements WeakSetLike<T> {
-        private _map = new WeakMap();
+      delete(val: T) {
+        return this._map.delete(val);
+      }
 
-        add(val: T): this {
-          this._map.set(val, true);
-          return this;
-        }
-
-        delete(val: T) {
-          return this._map.delete(val);
-        }
-
-        has(val: T) {
-          return this._map.has(val);
-        }
-      };
-
-export default WeakSetLike;
+      has(val: T) {
+        return this._map.has(val);
+      }
+    }) as WeakSetConstructor;

--- a/packages/ember-utils/tests/inspect_test.js
+++ b/packages/ember-utils/tests/inspect_test.js
@@ -31,14 +31,17 @@ moduleFor(
     ['@test object'](assert) {
       assert.equal(inspect({}), '{ }');
       assert.equal(inspect({ foo: 'bar' }), '{ foo: "bar" }');
-      assert.equal(
-        inspect({
-          foo() {
-            return this;
-          },
-        }),
-        '{ foo: [Function:foo] }'
-      );
+      let obj = {
+        foo() {
+          return this;
+        },
+      };
+      // IE 11 doesn't have function name
+      if (obj.foo.name) {
+        assert.equal(inspect(obj), `{ foo: [Function:foo] }`);
+      } else {
+        assert.equal(inspect(obj), `{ foo: [Function] }`);
+      }
     }
 
     ['@test objects without a prototype'](assert) {


### PR DESCRIPTION
Vastly improve inspect output and safety, checks cycles, depth limit and list limit.

Detect node util.inspect call to Ember.inspect(depth, options) returning string "2".

Fixes https://github.com/emberjs/ember.js/issues/16381