### PR TITLE
[BUGFIX Beta] Decrement counter of pending requests in the next tick

### DIFF
--- a/packages/ember-testing/lib/test/pending_requests.js
+++ b/packages/ember-testing/lib/test/pending_requests.js
@@ -13,10 +13,12 @@ export function incrementPendingRequests(_, xhr) {
 }
 
 export function decrementPendingRequests(_, xhr) {
-  for (let i = 0; i < requests.length; i++) {
-    if (xhr === requests[i]) {
-      requests.splice(i, 1);
-      break;
+  setTimeout(function() {
+    for (let i = 0; i < requests.length; i++) {
+      if (xhr === requests[i]) {
+        requests.splice(i, 1);
+        break;
+      }
     }
-  }
+  }, 0);
 }

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -1040,6 +1040,7 @@ if (!jQueryDisabled) {
       }
 
       [`@test pendingRequests is maintained for ajaxSend and ajaxComplete events`](assert) {
+        let done = assert.async();
         assert.equal(pendingRequests(), 0);
 
         let xhr = { some: 'xhr' };
@@ -1048,7 +1049,10 @@ if (!jQueryDisabled) {
         assert.equal(pendingRequests(), 1, 'Ember.Test.pendingRequests was incremented');
 
         this.trigger('ajaxComplete', xhr);
-        assert.equal(pendingRequests(), 0, 'Ember.Test.pendingRequests was decremented');
+        setTimeout(function() {
+          assert.equal(pendingRequests(), 0, 'Ember.Test.pendingRequests was decremented');
+          done();
+        }, 0);
       }
 
       [`@test pendingRequests is ignores ajaxComplete events from past setupForTesting calls`](


### PR DESCRIPTION
Made to align with the implementation in ember-test-helpers: https://github.com/emberjs/ember-test-helpers/blob/7f9a3d082958ba993c6db863886d370d73fd98ef/addon-test-support/%40ember/test-helpers/settled.js#L53-L70