### PR TITLE
Expand generate service blueprint test coverage

### DIFF
--- a/node-tests/blueprints/service-test.js
+++ b/node-tests/blueprints/service-test.js
@@ -206,4 +206,42 @@ describe('Blueprint: service', function() {
       });
     });
   });
+
+  describe('in in-repo-addon', function() {
+    beforeEach(function() {
+      return emberNew({ target: 'in-repo-addon' });
+    });
+
+    it('service foo --in-repo-addon=my-addon', function() {
+      return emberGenerateDestroy(['service', 'foo', '--in-repo-addon=my-addon'], _file => {
+        expect(_file('lib/my-addon/addon/services/foo.js'))
+          .to.contain("import Service from '@ember/service';")
+          .to.contain('export default Service.extend({\n});');
+
+        expect(_file('lib/my-addon/app/services/foo.js')).to.contain(
+          "export { default } from 'my-addon/services/foo';"
+        );
+
+        expect(_file('tests/unit/services/foo-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('service:foo'");
+      });
+    });
+
+    it('service foo/bar --in-repo-addon=my-addon', function() {
+      return emberGenerateDestroy(['service', 'foo/bar', '--in-repo-addon=my-addon'], _file => {
+        expect(_file('lib/my-addon/addon/services/foo/bar.js'))
+          .to.contain("import Service from '@ember/service';")
+          .to.contain('export default Service.extend({\n});');
+
+        expect(_file('lib/my-addon/app/services/foo/bar.js')).to.contain(
+          "export { default } from 'my-addon/services/foo/bar';"
+        );
+
+        expect(_file('tests/unit/services/foo/bar-test.js'))
+          .to.contain("import { moduleFor, test } from 'ember-qunit';")
+          .to.contain("moduleFor('service:foo/bar'");
+      });
+    });
+  });
 });


### PR DESCRIPTION
We're making a number of changes to existing blueprints to enable MU output. While doing so, we should be careful not to break existing classic functionality. 

This PR expands coverage of `ember generate service` to include the following missing test cases:

#### classic

 * [x] `ember generate service --in-repo-addon=my-addon`
 *  ~~`ember generate service --dummy`~~ **update**: it seems that this was never supported. I'll follow up at our next ST meeting and see if we think adding broad support for generators for dummy apps is desirable. 

#### module unification (will come in a follow up PR once we've updated [`in-repo-addon`](https://github.com/ember-cli/ember-cli/tree/master/blueprints/in-repo-addon) to MU)

 * `ember generate service --in-repo-addon=my-addon`
 * ~~`ember generate service --dummy`~~

This PR will then serve as a template for work on the other MU blueprints.



