### PR TITLE
[BUGFIX release] avoid strict assertion when object proxy calls thru for function

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -116,7 +116,9 @@ function makeCtor(base) {
 
               let value = target.unknownProperty.call(receiver, property);
 
-              assert(messageFor(receiver, property), value === undefined || value === null);
+              if (typeof value !== 'function') {
+                assert(messageFor(receiver, property), value === undefined || value === null);
+              }
             },
           });
 

--- a/packages/ember-runtime/tests/system/object_proxy_test.js
+++ b/packages/ember-runtime/tests/system/object_proxy_test.js
@@ -100,6 +100,31 @@ moduleFor(
       assert.equal(JSON.stringify(proxy), JSON.stringify({ content: { foo: 'FOO' } }));
     }
 
+    ['@test calling a function on the proxy avoids the assertion'](assert) {
+      if (DEBUG && HAS_NATIVE_PROXY) {
+        let proxy = ObjectProxy.extend({
+          init() {
+            if (!this.foobar) {
+              this.foobar = function() {
+                let content = get(this, 'content');
+                return content.foobar.apply(content, []);
+              };
+            }
+          },
+        }).create({
+          content: {
+            foobar() {
+              return 'xoxo';
+            },
+          },
+        });
+
+        assert.equal(proxy.foobar(), 'xoxo', 'should be able to use a function from a proxy');
+      } else {
+        assert.expect(0);
+      }
+    }
+
     [`@test setting a property on the proxy avoids the assertion`](assert) {
       let proxy = ObjectProxy.create({
         toJSON: undefined,


### PR DESCRIPTION
Upgrading to ember v3.1 recently I bumped into this strict assertion around `ObjectProxy` which broke the consumers of that addon. More details (including a full example app) and discussion w/ Robert are included in the original issue I opened last week

https://github.com/emberjs/ember.js/issues/16521