### PR TITLE
[BUGFIX release] Ensure `ariaRole` can be initially false.

### DIFF
--- a/packages/ember-glimmer/lib/component-managers/curly.ts
+++ b/packages/ember-glimmer/lib/component-managers/curly.ts
@@ -351,8 +351,7 @@ export default class CurlyComponentManager
     }
     operations.setAttribute('class', PrimitiveReference.create('ember-view'), false, null);
 
-    const ariaRole = get(component, 'ariaRole');
-    if (ariaRole) {
+    if ('ariaRole' in component) {
       operations.setAttribute('role', referenceForKey(component, 'ariaRole'), false, null);
     }
 

--- a/packages/ember-glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/ember-glimmer/tests/integration/components/curly-components-test.js
@@ -1758,6 +1758,59 @@ moduleFor(
       this.assertComponentElement(this.firstChild, { attrs: { role: 'main' } });
     }
 
+    ['@test with ariaRole defined but initially falsey GH#16379']() {
+      this.registerComponent('aria-test', {
+        template: 'Here!',
+      });
+
+      this.render('{{aria-test ariaRole=role}}', {
+        role: undefined,
+      });
+
+      this.assertComponentElement(this.firstChild, { attrs: {} });
+
+      this.runTask(() => this.rerender());
+
+      this.assertComponentElement(this.firstChild, { attrs: {} });
+
+      this.runTask(() => this.context.set('role', 'input'));
+
+      this.assertComponentElement(this.firstChild, {
+        attrs: { role: 'input' },
+      });
+
+      this.runTask(() => this.context.set('role', undefined));
+
+      this.assertComponentElement(this.firstChild, { attrs: {} });
+    }
+
+    ['@test without ariaRole defined initially']() {
+      // we are using the ability to lazily add a role as a sign that we are
+      // doing extra work
+      let instance;
+      this.registerComponent('aria-test', {
+        ComponentClass: Component.extend({
+          init() {
+            this._super(...arguments);
+            instance = this;
+          },
+        }),
+        template: 'Here!',
+      });
+
+      this.render('{{aria-test}}');
+
+      this.assertComponentElement(this.firstChild, { attrs: {} });
+
+      this.runTask(() => this.rerender());
+
+      this.assertComponentElement(this.firstChild, { attrs: {} });
+
+      this.runTask(() => instance.set('ariaRole', 'input'));
+
+      this.assertComponentElement(this.firstChild, { attrs: {} });
+    }
+
     ['@test `template` specified in component is overridden by block']() {
       this.registerComponent('with-template', {
         ComponentClass: Component.extend({


### PR DESCRIPTION
It should be possible to start without an `ariaRole` and then only add one as needed. The previous logic prevented this from working properly because we would only setup the required attribute binding when the initial `ariaRole` was truthy.

Fixes #16379