### PR TITLE
access `length` directly

### DIFF
--- a/packages/ember-glimmer/lib/utils/iterable.ts
+++ b/packages/ember-glimmer/lib/utils/iterable.ts
@@ -98,8 +98,8 @@ class ArrayIterator extends BoundedIterator {
 }
 
 class EmberArrayIterator extends BoundedIterator {
-  static from(array: Opaque, keyFor: KeyFor): OpaqueIterator {
-    let length = get(array, 'length');
+  static from(array: Opaque[], keyFor: KeyFor): OpaqueIterator {
+    let { length } = array;
 
     if (length === 0) {
       return EMPTY_ITERATOR;
@@ -355,7 +355,7 @@ class EachIterable implements EmberIterable {
     if (Array.isArray(iterable)) {
       return ArrayIterator.from(iterable, keyFor);
     } else if (isEmberArray(iterable)) {
-      return EmberArrayIterator.from(iterable, keyFor);
+      return EmberArrayIterator.from(iterable as Opaque[], keyFor);
     } else if (HAS_NATIVE_SYMBOL && isNativeIterable(iterable)) {
       return ArrayLikeNativeIterator.from(iterable, keyFor);
     } else if (hasForEach(iterable)) {

--- a/packages/ember-metal/lib/array.js
+++ b/packages/ember-metal/lib/array.js
@@ -118,7 +118,7 @@ export function arrayContentDidChange(array, startIdx, removeAmt, addAmt) {
 
   let cache = peekCacheFor(array);
   if (cache !== undefined) {
-    let length = get(array, 'length');
+    let length = array.length;
     let addedAmount = addAmt === -1 ? 0 : addAmt;
     let removedAmount = removeAmt === -1 ? 0 : removeAmt;
     let delta = addedAmount - removedAmount;

--- a/packages/ember-metal/lib/each_proxy.js
+++ b/packages/ember-metal/lib/each_proxy.js
@@ -1,5 +1,4 @@
 import { assert } from '@ember/debug';
-import { get } from './property_get';
 import { notifyPropertyChange } from './property_events';
 import { addObserver, removeObserver } from './observer';
 import { meta, peekMeta } from './meta';
@@ -89,7 +88,7 @@ class EachProxy {
     if (!keys[keyName]) {
       keys[keyName] = 1;
       let content = this._content;
-      let len = get(content, 'length');
+      let len = content.length;
 
       addObserverForContentKey(content, keyName, this, 0, len);
     } else {
@@ -101,7 +100,7 @@ class EachProxy {
     let keys = this._keys;
     if (keys !== undefined && keys[keyName] > 0 && --keys[keyName] <= 0) {
       let content = this._content;
-      let len = get(content, 'length');
+      let len = content.length;
 
       removeObserverForContentKey(content, keyName, this, 0, len);
     }

--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -45,7 +45,7 @@ function iter(key, value) {
 }
 
 function indexOf(array, val, startAt = 0, withNaNCheck) {
-  let len = get(array, 'length');
+  let len = array.length;
 
   if (startAt < 0) {
     startAt += len;
@@ -139,7 +139,7 @@ const ArrayMixin = Mixin.create(Enumerable, {
     @public
   */
   objectAt(idx) {
-    if (idx < 0 || idx >= get(this, 'length')) {
+    if (idx < 0 || idx >= this.length) {
       return undefined;
     }
 
@@ -179,7 +179,7 @@ const ArrayMixin = Mixin.create(Enumerable, {
       return this;
     },
     set(key, value) {
-      this.replace(0, get(this, 'length'), value);
+      this.replace(0, this.length, value);
       return this;
     },
   }),
@@ -203,7 +203,7 @@ const ArrayMixin = Mixin.create(Enumerable, {
     @public
   */
   lastObject: computed(function() {
-    return objectAt(this, get(this, 'length') - 1);
+    return objectAt(this, this.length - 1);
   }).readOnly(),
 
   // Add any extra methods to EmberArray that are native to the built-in Array.
@@ -228,7 +228,7 @@ const ArrayMixin = Mixin.create(Enumerable, {
   */
   slice(beginIndex, endIndex) {
     let ret = A();
-    let length = get(this, 'length');
+    let length = this.length;
 
     if (isNone(beginIndex)) {
       beginIndex = 0;
@@ -272,6 +272,7 @@ const ArrayMixin = Mixin.create(Enumerable, {
     @return {Number} index or -1 if not found
     @public
   */
+
   indexOf(object, startAt) {
     return indexOf(this, object, startAt, false);
   },
@@ -300,7 +301,7 @@ const ArrayMixin = Mixin.create(Enumerable, {
     @public
   */
   lastIndexOf(object, startAt) {
-    let len = get(this, 'length');
+    let len = this.length;
 
     if (startAt === undefined || startAt >= len) {
       startAt = len - 1;
@@ -447,7 +448,7 @@ const ArrayMixin = Mixin.create(Enumerable, {
   forEach(callback, target = null) {
     assert('forEach expects a function as first argument.', typeof callback === 'function');
 
-    let length = get(this, 'length');
+    let length = this.length;
 
     for (let index = 0; index < length; index++) {
       let item = this.objectAt(index);
@@ -672,7 +673,7 @@ const ArrayMixin = Mixin.create(Enumerable, {
   find(callback, target = null) {
     assert('find expects a function as first argument.', typeof callback === 'function');
 
-    let length = get(this, 'length');
+    let length = this.length;
 
     for (let index = 0; index < length; index++) {
       let item = this.objectAt(index);
@@ -800,7 +801,7 @@ const ArrayMixin = Mixin.create(Enumerable, {
   any(callback, target = null) {
     assert('any expects a function as first argument.', typeof callback === 'function');
 
-    let length = get(this, 'length');
+    let length = this.length;
 
     for (let index = 0; index < length; index++) {
       let item = this.objectAt(index);
@@ -1090,7 +1091,7 @@ const OUT_OF_RANGE_EXCEPTION = 'Index out of range';
 
 export function removeAt(array, start, len) {
   if ('number' === typeof start) {
-    if (start < 0 || start >= get(array, 'length')) {
+    if (start < 0 || start >= array.length) {
       throw new EmberError(OUT_OF_RANGE_EXCEPTION);
     }
 
@@ -1162,7 +1163,7 @@ const MutableArray = Mixin.create(ArrayMixin, MutableEnumerable, {
     @public
   */
   clear() {
-    let len = get(this, 'length');
+    let len = this.length;
     if (len === 0) {
       return this;
     }
@@ -1189,7 +1190,7 @@ const MutableArray = Mixin.create(ArrayMixin, MutableEnumerable, {
     @public
   */
   insertAt(idx, object) {
-    if (idx > get(this, 'length')) {
+    if (idx > this.length) {
       throw new EmberError(OUT_OF_RANGE_EXCEPTION);
     }
 
@@ -1239,7 +1240,7 @@ const MutableArray = Mixin.create(ArrayMixin, MutableEnumerable, {
     @public
   */
   pushObject(obj) {
-    this.insertAt(get(this, 'length'), obj);
+    this.insertAt(this.length, obj);
     return obj;
   },
 
@@ -1262,7 +1263,7 @@ const MutableArray = Mixin.create(ArrayMixin, MutableEnumerable, {
     if (!Array.isArray(objects)) {
       throw new TypeError('Must pass Enumerable to MutableArray#pushObjects');
     }
-    this.replace(get(this, 'length'), 0, objects);
+    this.replace(this.length, 0, objects);
     return this;
   },
 
@@ -1282,7 +1283,7 @@ const MutableArray = Mixin.create(ArrayMixin, MutableEnumerable, {
     @public
   */
   popObject() {
-    let len = get(this, 'length');
+    let len = this.length;
     if (len === 0) {
       return null;
     }
@@ -1308,7 +1309,7 @@ const MutableArray = Mixin.create(ArrayMixin, MutableEnumerable, {
     @public
   */
   shiftObject() {
-    if (get(this, 'length') === 0) {
+    if (this.length === 0) {
       return null;
     }
 
@@ -1368,7 +1369,7 @@ const MutableArray = Mixin.create(ArrayMixin, MutableEnumerable, {
      @public
   */
   reverseObjects() {
-    let len = get(this, 'length');
+    let len = this.length;
     if (len === 0) {
       return this;
     }
@@ -1400,7 +1401,7 @@ const MutableArray = Mixin.create(ArrayMixin, MutableEnumerable, {
       return this.clear();
     }
 
-    let len = get(this, 'length');
+    let len = this.length;
     this.replace(0, len, objects);
     return this;
   },
@@ -1422,7 +1423,7 @@ const MutableArray = Mixin.create(ArrayMixin, MutableEnumerable, {
     @public
   */
   removeObject(obj) {
-    let loc = get(this, 'length') || 0;
+    let loc = this.length || 0;
     while (--loc >= 0) {
       let curObject = objectAt(this, loc);
 


### PR DESCRIPTION
since support of native getters, we could access `array.length` directly  without `get`