### PR TITLE
[DOC] Proper usage of _super in ArrayProxy init()

### DIFF
--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -60,6 +60,22 @@ const ARRAY_OBSERVER_MAPPING = {
   ap.get('firstObject'); // . 'DOG'
   ```
 
+  When overriding this class it is important to place the call to
+  `_super` *after* setting `content` so the internal observers have
+  a chance to fire properly:
+
+  ```javascript
+  import { A } from '@ember/array';
+  import ArrayProxy from '@ember/array/proxy';
+
+  export default ArrayProxy.extend({
+    init() {
+      this.set('content', A(['dog', 'cat', 'fish']));
+      this._super(...arguments);
+    }
+  });
+  ```
+
   @class ArrayProxy
   @extends EmberObject
   @uses MutableArray

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -60,7 +60,7 @@ const ARRAY_OBSERVER_MAPPING = {
   ap.get('firstObject'); // . 'DOG'
   ```
 
-  When overriding this class it is important to place the call to
+  When overriding this class, it is important to place the call to
   `_super` *after* setting `content` so the internal observers have
   a chance to fire properly:
 


### PR DESCRIPTION
The documentation for `ArrayProxy` does not clarify the importance of placing the call to `_super`**AFTER** setting the content, which is common when overriding the class.  Not doing this caused me so many hours of pain and frustration because the array "kind of" works, but sometimes behaves in a very weird way, that I believe it's imperative to have it documented.