### PR TITLE
adds tests and small docs for function key support in `uniqBy`

### DIFF
--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -1013,9 +1013,13 @@ const ArrayMixin = Mixin.create(Enumerable, {
     ```javascript
     let arr = [{ value: 'a' }, { value: 'a' }, { value: 'b' }, { value: 'b' }];
     arr.uniqBy('value');  // [{ value: 'a' }, { value: 'b' }]
+
+    let arr = [2.2, 2.1, 3.2, 3.3];
+    arr.uniqBy(Math.floor);  // [2.2, 3.2];
     ```
 
     @method uniqBy
+    @param {String,Function} key
     @return {EmberArray}
     @public
   */

--- a/packages/ember-runtime/lib/utils.js
+++ b/packages/ember-runtime/lib/utils.js
@@ -177,10 +177,10 @@ export function uniqBy(array, key = identityFunction) {
 
   let ret = A();
   let seen = new Set();
-  let getter = typeof key === 'function' ? key : get;
+  let getter = typeof key === 'function' ? key : item => get(item, key);
 
   array.forEach(item => {
-    let val = getter(item, key);
+    let val = getter(item);
     if (!seen.has(val)) {
       seen.add(val);
       ret.push(item);

--- a/packages/ember-runtime/tests/array/uniqBy-test.js
+++ b/packages/ember-runtime/tests/array/uniqBy-test.js
@@ -10,6 +10,24 @@ class UniqByTests extends AbstractTestCase {
     ]);
     this.assert.deepEqual(numbers.uniqBy('id'), [{ id: 1, value: 'one' }, { id: 2, value: 'two' }]);
   }
+
+  '@test supports function as key'() {
+    let numbers = this.newObject([
+      { id: 1, value: 'boom' },
+      { id: 2, value: 'boom' },
+      { id: 1, value: 'doom' },
+    ]);
+
+    let keyFunction = val => {
+      this.assert.equal(arguments.length, 1);
+      return val.value;
+    };
+
+    this.assert.deepEqual(numbers.uniqBy(keyFunction), [
+      { id: 1, value: 'boom' },
+      { id: 1, value: 'doom' },
+    ]);
+  }
 }
 
 runArrayTests('uniqBy', UniqByTests);


### PR DESCRIPTION
support for function `key` in `uniqBy` is nice side-effect of previous refactoring