### PR TITLE
[BUGFIX] Memory issues

### DIFF
--- a/packages/@ember/application/tests/application_instance_test.js
+++ b/packages/@ember/application/tests/application_instance_test.js
@@ -30,10 +30,12 @@ moduleFor(
       setDebugFunction('debug', originalDebug);
       if (appInstance) {
         run(appInstance, 'destroy');
+        appInstance = null;
       }
 
       if (application) {
         run(application, 'destroy');
+        application = null;
       }
 
       document.getElementById('qunit-fixture').innerHTML = '';

--- a/packages/@ember/application/tests/application_test.js
+++ b/packages/@ember/application/tests/application_test.js
@@ -234,7 +234,7 @@ moduleFor(
     [`@test acts like a namespace`](assert) {
       let lookup = (context.lookup = {});
 
-      lookup.TestApp = this.runTask(() => this.createApplication());
+      lookup.TestApp = this.application = this.runTask(() => this.createApplication());
 
       setNamespaceSearchDisabled(false);
       let Foo = (this.application.Foo = EmberObject.extend());

--- a/packages/@ember/application/tests/dependency_injection/normalization_test.js
+++ b/packages/@ember/application/tests/dependency_injection/normalization_test.js
@@ -15,7 +15,10 @@ moduleFor(
     }
 
     teardown() {
+      super.teardown();
       run(application, 'destroy');
+      application = undefined;
+      registry = undefined;
     }
 
     ['@test normalization'](assert) {

--- a/packages/@ember/application/tests/dependency_injection_test.js
+++ b/packages/@ember/application/tests/dependency_injection_test.js
@@ -42,8 +42,9 @@ moduleFor(
     }
 
     teardown() {
+      super.teardown();
       run(application, 'destroy');
-      application = locator = null;
+      registry = application = locator = null;
       context.lookup = originalLookup;
     }
 

--- a/packages/@ember/application/tests/readiness_test.js
+++ b/packages/@ember/application/tests/readiness_test.js
@@ -55,6 +55,7 @@ moduleFor(
     teardown() {
       if (application) {
         run(() => application.destroy());
+        jQuery = readyCallbacks = domReady = Application = application = undefined;
       }
     }
 

--- a/packages/@ember/engine/tests/engine_initializers_test.js
+++ b/packages/@ember/engine/tests/engine_initializers_test.js
@@ -11,10 +11,12 @@ moduleFor(
       run(() => {
         if (myEngineInstance) {
           myEngineInstance.destroy();
+          myEngineInstance = null;
         }
 
         if (myEngine) {
           myEngine.destroy();
+          myEngine = null;
         }
       });
     }

--- a/packages/@ember/engine/tests/engine_instance_initializers_test.js
+++ b/packages/@ember/engine/tests/engine_instance_initializers_test.js
@@ -22,6 +22,7 @@ moduleFor(
   'Engine instance initializers',
   class extends TestCase {
     teardown() {
+      super.teardown();
       run(() => {
         if (myEngineInstance) {
           myEngineInstance.destroy();
@@ -31,6 +32,7 @@ moduleFor(
           myEngine.destroy();
         }
       });
+      MyEngine = myEngine = myEngineInstance = undefined;
     }
 
     ["@test initializers require proper 'name' and 'initialize' properties"]() {

--- a/packages/@ember/engine/tests/engine_instance_test.js
+++ b/packages/@ember/engine/tests/engine_instance_test.js
@@ -20,10 +20,12 @@ moduleFor(
     teardown() {
       if (engineInstance) {
         run(engineInstance, 'destroy');
+        engineInstance = undefined;
       }
 
       if (engine) {
         run(engine, 'destroy');
+        engine = undefined;
       }
     }
 

--- a/packages/@ember/engine/tests/engine_test.js
+++ b/packages/@ember/engine/tests/engine_test.js
@@ -12,7 +12,6 @@ import {
 
 let engine;
 let originalLookup = context.lookup;
-let lookup;
 
 moduleFor(
   'Engine',
@@ -20,20 +19,21 @@ moduleFor(
     constructor() {
       super();
 
-      lookup = context.lookup = {};
-      engine = run(() => Engine.create());
+      run(() => {
+        engine = Engine.create();
+        context.lookup = { TestEngine: engine };
+      });
     }
 
     teardown() {
       context.lookup = originalLookup;
       if (engine) {
         run(engine, 'destroy');
+        engine = null;
       }
     }
 
     ['@test acts like a namespace'](assert) {
-      engine = run(() => (lookup.TestEngine = Engine.create()));
-
       engine.Foo = EmberObject.extend();
       assert.equal(
         engine.Foo.toString(),

--- a/packages/ember-extension-support/tests/data_adapter_test.js
+++ b/packages/ember-extension-support/tests/data_adapter_test.js
@@ -29,6 +29,11 @@ const DataAdapter = EmberDataAdapter.extend({
 moduleFor(
   'Data Adapter',
   class extends ApplicationTestCase {
+    teardown() {
+      super.teardown();
+      adapter = undefined;
+    }
+
     ['@test Model types added'](assert) {
       this.add(
         'data-adapter:main',

--- a/packages/ember-routing/tests/location/auto_location_test.js
+++ b/packages/ember-routing/tests/location/auto_location_test.js
@@ -40,7 +40,7 @@ function mockBrowserHistory(overrides, assert) {
 }
 
 function createLocation(location, history) {
-  let owner = buildOwner();
+  owner = buildOwner();
 
   owner.register('location:history', HistoryLocation);
   owner.register('location:hash', HashLocation);
@@ -56,14 +56,15 @@ function createLocation(location, history) {
   return autolocation;
 }
 
-let location;
+let location, owner;
 
 moduleFor(
   'AutoLocation',
   class extends AbstractTestCase {
     teardown() {
-      if (location) {
-        run(location, 'destroy');
+      if (owner) {
+        run(owner, 'destroy');
+        owner = location = undefined;
       }
     }
 

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -15,7 +15,9 @@ moduleFor(
     }
 
     teardown() {
+      super.teardown();
       runDestroy(route);
+      route = routeOne = routeTwo = lookupHash = undefined;
     }
 
     ['@test default store utilizes the container to acquire the model factory'](assert) {
@@ -48,12 +50,15 @@ moduleFor(
         },
       };
 
-      setOwner(route, buildOwner(ownerOptions));
+      let owner = buildOwner(ownerOptions);
+      setOwner(route, owner);
 
       route.set('_qp', null);
 
       assert.equal(route.model({ post_id: 1 }), post);
       assert.equal(route.findModel('post', 1), post, '#findModel returns the correct post');
+
+      runDestroy(owner);
     }
 
     ["@test 'store' can be injected by data persistence frameworks"](assert) {
@@ -84,6 +89,8 @@ moduleFor(
 
       assert.equal(route.model({ post_id: 1 }), post, '#model returns the correct post');
       assert.equal(route.findModel('post', 1), post, '#findModel returns the correct post');
+
+      runDestroy(owner);
     }
 
     ["@test assert if 'store.find' method is not found"]() {
@@ -100,6 +107,8 @@ moduleFor(
       expectAssertion(function() {
         route.findModel('post', 1);
       }, 'Post has no method `find`.');
+
+      runDestroy(owner);
     }
 
     ['@test asserts if model class is not found']() {
@@ -113,6 +122,8 @@ moduleFor(
       expectAssertion(function() {
         route.model({ post_id: 1 });
       }, /You used the dynamic segment post_id in your route undefined, but <Ember.Object:ember\d+>.Post did not exist and you did not override your route\'s `model` hook./);
+
+      runDestroy(owner);
     }
 
     ["@test 'store' does not need to be injected"](assert) {
@@ -129,6 +140,8 @@ moduleFor(
       });
 
       assert.ok(true, 'no error was raised');
+
+      runDestroy(owner);
     }
 
     ["@test modelFor doesn't require the router"](assert) {
@@ -144,6 +157,8 @@ moduleFor(
       owner.register('route:foo', FooRoute);
 
       assert.strictEqual(route.modelFor('foo'), foo);
+
+      runDestroy(owner);
     }
 
     ['@test .send just calls an action if the router is absent'](assert) {
@@ -167,6 +182,8 @@ moduleFor(
       assert.equal(true, route.send('returnsTrue', 1, 2));
       assert.equal(false, route.send('returnsFalse'));
       assert.equal(undefined, route.send('nonexistent', 1, 2, 3));
+
+      runDestroy(route);
     }
 
     ['@test .send just calls an action if the routers internal router property is absent'](assert) {
@@ -191,6 +208,8 @@ moduleFor(
       assert.equal(true, route.send('returnsTrue', 1, 2));
       assert.equal(false, route.send('returnsFalse'));
       assert.equal(undefined, route.send('nonexistent', 1, 2, 3));
+
+      runDestroy(route);
     }
 
     ['@test .send asserts if called on a destroyed route']() {

--- a/packages/ember-runtime/tests/system/namespace/base_test.js
+++ b/packages/ember-runtime/tests/system/namespace/base_test.js
@@ -34,7 +34,12 @@ moduleFor(
     }
 
     ['@test Namespace should be duck typed'](assert) {
-      assert.ok(get(Namespace.create(), 'isNamespace'), 'isNamespace property is true');
+      let namespace = Namespace.create();
+      try {
+        assert.ok(get(namespace, 'isNamespace'), 'isNamespace property is true');
+      } finally {
+        run(namespace, 'destroy');
+      }
     }
 
     ['@test Namespace is found and named'](assert) {
@@ -90,23 +95,27 @@ moduleFor(
         name: 'NamespaceA',
       });
 
-      let nsB = (lookup.NamespaceB = Namespace.create({
-        name: 'CustomNamespaceB',
-      }));
+      try {
+        let nsB = (lookup.NamespaceB = Namespace.create({
+          name: 'CustomNamespaceB',
+        }));
 
-      nsA.Foo = EmberObject.extend();
-      nsB.Foo = EmberObject.extend();
+        nsA.Foo = EmberObject.extend();
+        nsB.Foo = EmberObject.extend();
 
-      assert.equal(
-        nsA.Foo.toString(),
-        'NamespaceA.Foo',
-        "The namespace's name is used when the namespace is not in the lookup object"
-      );
-      assert.equal(
-        nsB.Foo.toString(),
-        'CustomNamespaceB.Foo',
-        "The namespace's name is used when the namespace is in the lookup object"
-      );
+        assert.equal(
+          nsA.Foo.toString(),
+          'NamespaceA.Foo',
+          "The namespace's name is used when the namespace is not in the lookup object"
+        );
+        assert.equal(
+          nsB.Foo.toString(),
+          'CustomNamespaceB.Foo',
+          "The namespace's name is used when the namespace is in the lookup object"
+        );
+      } finally {
+        run(nsA, 'destroy');
+      }
     }
 
     ['@test Calling namespace.nameClasses() eagerly names all classes'](assert) {
@@ -138,6 +147,8 @@ moduleFor(
       UI.Nav = Namespace.create();
 
       assert.equal(Namespace.byName('UI.Nav'), UI.Nav);
+
+      run(UI.Nav, 'destroy');
     }
 
     ['@test Destroying a namespace before caching lookup removes it from the list of namespaces'](

--- a/packages/ember-runtime/tests/system/object/toString_test.js
+++ b/packages/ember-runtime/tests/system/object/toString_test.js
@@ -1,3 +1,4 @@
+import { run } from '@ember/runloop';
 import { guidFor, setName } from 'ember-utils';
 import { context } from 'ember-environment';
 import EmberObject from '../../../lib/system/object';
@@ -35,6 +36,8 @@ moduleFor(
       assert.equal(obj.toString(), '<Foo.Bar:' + guidFor(obj) + '>');
 
       assert.equal(Foo.Bar.toString(), 'Foo.Bar');
+
+      run(Foo, 'destroy');
     }
 
     ['@test toString on a class returns a useful value when nested in a namespace'](assert) {
@@ -59,12 +62,16 @@ moduleFor(
 
       obj = Foo.Bar.create();
       assert.equal(obj.toString(), '<Foo.Bar:' + guidFor(obj) + '>');
+
+      run(Foo, 'destroy');
     }
 
     ['@test toString on a namespace finds the namespace in lookup'](assert) {
       let Foo = (lookup.Foo = Namespace.create());
 
       assert.equal(Foo.toString(), 'Foo');
+
+      run(Foo, 'destroy');
     }
 
     ['@test toString on a namespace finds the namespace in lookup'](assert) {
@@ -77,12 +84,16 @@ moduleFor(
 
       obj = Foo.Bar.create();
       assert.equal(obj.toString(), '<Foo.Bar:' + guidFor(obj) + '>');
+
+      run(Foo, 'destroy');
     }
 
     ['@test toString on a namespace falls back to modulePrefix, if defined'](assert) {
       let Foo = Namespace.create({ modulePrefix: 'foo' });
 
       assert.equal(Foo.toString(), 'foo');
+
+      run(Foo, 'destroy');
     }
 
     ['@test toString includes toStringExtension if defined'](assert) {

--- a/packages/ember-template-compiler/tests/system/bootstrap-test.js
+++ b/packages/ember-template-compiler/tests/system/bootstrap-test.js
@@ -35,7 +35,7 @@ function checkTemplate(templateName, assert) {
   runAppend(component);
 
   assert.equal(qunitFixture.textContent.trim(), 'Tobias takes teamocil', 'template works');
-  runDestroy(component);
+  runDestroy(owner);
 }
 
 moduleFor(
@@ -49,7 +49,7 @@ moduleFor(
 
     teardown() {
       setTemplates({});
-      runDestroy(component);
+      fixture = component = null;
     }
 
     ['@test template with data-template-name should add a new template to Ember.TEMPLATES'](

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -9,18 +9,20 @@ import { jQueryDisabled } from 'ember-views';
 import { getDebugFunction, setDebugFunction } from '@ember/debug';
 
 const originalDebug = getDebugFunction('debug');
-const noop = function() {};
 
 var originalConsoleError = console.error; // eslint-disable-line no-console
+let testContext;
 
 if (!jQueryDisabled) {
   moduleFor(
     'ember-testing Acceptance',
     class extends AutobootApplicationTestCase {
       constructor() {
-        setDebugFunction('debug', noop);
+        setDebugFunction('debug', function() {});
         super();
         this._originalAdapter = Test.adapter;
+
+        testContext = this;
 
         this.runTask(() => {
           this.createApplication();
@@ -35,7 +37,6 @@ if (!jQueryDisabled) {
 
           this.indexHitCount = 0;
           this.currentRoute = 'index';
-          let testContext = this;
 
           this.add(
             'route:index',
@@ -115,6 +116,9 @@ if (!jQueryDisabled) {
       teardown() {
         setDebugFunction('debug', originalDebug);
         Test.adapter = this._originalAdapter;
+        Test.unregisterHelper('slowHelper');
+        window.slowHelper = undefined;
+        testContext = undefined;
         super.teardown();
       }
 

--- a/packages/ember-testing/tests/helper_registration_test.js
+++ b/packages/ember-testing/tests/helper_registration_test.js
@@ -34,6 +34,7 @@ function destroyApp() {
   if (App) {
     run(App, 'destroy');
     App = null;
+    helperContainer = null;
   }
 }
 
@@ -81,6 +82,7 @@ moduleFor(
 
       unregisterHelper();
 
+      run(App, 'destroy');
       setupApp();
 
       assert.ok(

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -184,10 +184,14 @@ if (!jQueryDisabled) {
           injected++;
         });
 
-        this.runTask(() => {
-          this.createApplication();
-          this.application.setupForTesting();
-        });
+        // bind(this) so Babel doesn't leak _this
+        // into the context onInjectHelpers.
+        this.runTask(
+          function() {
+            this.createApplication();
+            this.application.setupForTesting();
+          }.bind(this)
+        );
 
         assert.equal(injected, 0, 'onInjectHelpers are not called before injectTestHelpers');
 
@@ -912,6 +916,7 @@ if (!jQueryDisabled) {
     'ember-testing: debugging helpers',
     class extends HelpersApplicationTestCase {
       afterEach() {
+        super.afterEach();
         setDebugFunction('info', originalInfo);
       }
 

--- a/packages/ember/tests/integration/multiple-app-test.js
+++ b/packages/ember/tests/integration/multiple-app-test.js
@@ -31,7 +31,7 @@ moduleFor(
       let secondApplicationOptions = { rootElement: '#two' };
       let myOptions = assign(applicationOptions, secondApplicationOptions, options);
       this.secondApp = Application.create(myOptions);
-      this.secondResolver = myOptions.Resolver.lastInstance;
+      this.secondResolver = this.secondApp.__registry__.resolver;
       return this.secondApp;
     }
 

--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -6,7 +6,7 @@ import { ENV } from 'ember-environment';
 import { Route, NoneLocation, HistoryLocation } from 'ember-routing';
 import Controller from '@ember/controller';
 import { Object as EmberObject, A as emberA, copy } from 'ember-runtime';
-import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
+import { moduleFor, ApplicationTestCase, runDestroy } from 'internal-test-helpers';
 import { run } from '@ember/runloop';
 import { Mixin, computed, set, addObserver, observer } from 'ember-metal';
 import { getTextOf } from 'internal-test-helpers';
@@ -2026,27 +2026,29 @@ moduleFor(
         obj.set('history', { state: { path: path } });
       };
 
+      let location = HistoryLocation.create({
+        initState() {
+          let path = rootURL + '/posts';
+
+          setHistory(this, path);
+          this.set('location', {
+            pathname: path,
+            href: 'http://localhost/' + path,
+          });
+        },
+
+        replaceState(path) {
+          setHistory(this, path);
+        },
+
+        pushState(path) {
+          setHistory(this, path);
+        },
+      });
+
       this.router.reopen({
         // location: 'historyTest',
-        location: HistoryLocation.create({
-          initState() {
-            let path = rootURL + '/posts';
-
-            setHistory(this, path);
-            this.set('location', {
-              pathname: path,
-              href: 'http://localhost/' + path,
-            });
-          },
-
-          replaceState(path) {
-            setHistory(this, path);
-          },
-
-          pushState(path) {
-            setHistory(this, path);
-          },
-        }),
+        location,
         rootURL: rootURL,
       });
 
@@ -2066,6 +2068,9 @@ moduleFor(
 
       return this.visit('/').then(() => {
         assert.ok(postsTemplateRendered, 'Posts route successfully stripped from rootURL');
+
+        runDestroy(location);
+        location = null;
       });
     }
 

--- a/packages/internal-test-helpers/lib/test-cases/application.js
+++ b/packages/internal-test-helpers/lib/test-cases/application.js
@@ -8,9 +8,9 @@ export default class ApplicationTestCase extends TestResolverApplicationTestCase
     super(...arguments);
 
     let { applicationOptions } = this;
-    this.application = this.runTask(() => this.createApplication(applicationOptions));
+    this.application = this.runTask(this.createApplication.bind(this, applicationOptions));
 
-    this.resolver = applicationOptions.Resolver.lastInstance;
+    this.resolver = this.application.__registry__.resolver;
 
     if (this.resolver) {
       this.resolver.add('router:main', Router.extend(this.routerOptions));

--- a/packages/internal-test-helpers/lib/test-cases/autoboot-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/autoboot-application.js
@@ -7,7 +7,7 @@ export default class AutobootApplicationTestCase extends TestResolverApplication
   createApplication(options, MyApplication = Application) {
     let myOptions = assign(this.applicationOptions, options);
     let application = (this.application = MyApplication.create(myOptions));
-    this.resolver = myOptions.Resolver.lastInstance;
+    this.resolver = application.__registry__.resolver;
 
     if (this.resolver) {
       this.resolver.add('router:main', Router.extend(this.routerOptions));

--- a/packages/internal-test-helpers/lib/test-resolver.js
+++ b/packages/internal-test-helpers/lib/test-resolver.js
@@ -14,7 +14,6 @@ function serializeKey(specifier, source, namespace) {
 class Resolver {
   constructor() {
     this._registered = {};
-    this.constructor.lastInstance = this;
   }
   resolve(specifier) {
     return this._registered[specifier] || this._registered[serializeKey(specifier)];


### PR DESCRIPTION
This is mixes cleanup I did for debug with real fixes. Need to pull them apart, maybe we should keep the manual teardown during container destroy or at least put it behind DEBUG since it greatly improves ability to debug memory leaks.

This further reduces memory leaks during test suite.

The stack.reset() is still an issue in tests that test error handling we don't flush the iterator all the way and it is what resets the stack when it is done.