### PR TITLE
Fix issue with `Ember.trySet` on destroying objects

### DIFF
--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -49,9 +49,9 @@ export function set(obj, keyName, value, tolerant) {
     typeof keyName !== 'string' || keyName.lastIndexOf('this.', 0) !== 0
   );
 
-  if (obj.isDestroyed) {
+  if (obj.isDestroying) {
     assert(
-      `calling set on destroyed object: ${toString(obj)}.${keyName} = ${toString(value)}`,
+      `calling set on destroyed/destroying object: ${toString(obj)}.${keyName} = ${toString(value)}`,
       tolerant
     );
     return;

--- a/packages/ember-metal/tests/accessors/set_test.js
+++ b/packages/ember-metal/tests/accessors/set_test.js
@@ -118,8 +118,8 @@ moduleFor(
       assert.equal(obj.foo, 'bar');
     }
 
-    ['@test does not warn on attempts of calling set on a destroyed object with `trySet`'](assert) {
-      let obj = { isDestroyed: true };
+    ['@test does not warn on attempts of calling set on a destroying object with `trySet`'](assert) {
+      let obj = { isDestroying: true };
 
       trySet(obj, 'favoriteFood', 'hot dogs');
       assert.equal(obj.favoriteFood, undefined, 'does not set and does not error');


### PR DESCRIPTION
trySet is supposed to not blow up when used on destroyed/destroying objects. This commit makes sure it doesn't blow up one both - as the 'destroying' property on destroyed objects also has the value "true".