### PR TITLE
Minor change to wording of doco for 'action' template helper

### DIFF
--- a/packages/ember-glimmer/lib/helpers/action.ts
+++ b/packages/ember-glimmer/lib/helpers/action.ts
@@ -31,8 +31,8 @@ import { ACTION, INVOKE, UnboundReference } from '../utils/references';
   In these contexts,
   the helper is called a "closure action" helper. Its behavior is simple:
   If passed a function name, read that function off the `actions` property
-  of the current context. Once that function is read (or if a function was
-  passed), create a closure over that function and any arguments.
+  of the current context. Once that function is read, or immediately if a function was
+  passed, create a closure over that function and any arguments.
   The resulting value of an action helper used this way is simply a function.
 
   For example, in the attribute context:


### PR DESCRIPTION
A proposed wording change to the 'action' template helper documentation.

This is with reference to #16586 .

I'm happy to be told otherwise by those more knowledgeable but I believe the current text just doesn't make sense , possibly due to an oversight when originally written.

I have suggested an additional word and minor change to punctuation which I believe will make the paragraph more useful .