### PR TITLE
[DOC release] Resolve #15856 re interaction of `set` with `setUnknownProperty`

### DIFF
--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -13,9 +13,11 @@ import { isDescriptor, peekMeta, descriptorFor } from './meta';
 */
 /**
   Sets the value of a property on an object, respecting computed properties
-  and notifying observers and other listeners of the change. If the
-  property is not defined but the object implements the `setUnknownProperty`
-  method then that will be invoked as well.
+  and notifying observers and other listeners of the change.
+  If the specified property is not defined on the object and the object
+  implements the `setUnknownProperty` method, then instead of setting the
+  value of the property on the object, its `setUnknownProperty` handler
+  will be invoked with the two parameters `keyName` and `value`.
 
   ```javascript
   import { set } from '@ember/object';


### PR DESCRIPTION
Corrects the description of the usage of `setUnknownProperty` by `set` to better reflect the actual behaviour of the code, as discussed in #15856. Specifically, it no longer states that `set` will set the given property on the object when it calls `setUnknownProperty`, since this call is made _instead_ of the default behaviour, rather than _as well as_.