### PR TITLE
[BUGFIX release] Fix SimpleHelper memory leak

### DIFF
--- a/packages/ember-glimmer/lib/helper.ts
+++ b/packages/ember-glimmer/lib/helper.ts
@@ -12,39 +12,33 @@ export const RECOMPUTE_TAG = symbol('RECOMPUTE_TAG');
 
 export type HelperFunction = (positional: Opaque[], named: Dict<Opaque>) => Opaque;
 
-export type SimpleHelperFactory = Factory<SimpleHelper, SimpleHelper>;
-export type ClassHelperFactory = Factory<HelperInstance, HelperStatic>;
+export type SimpleHelperFactory = Factory<SimpleHelper, HelperFactory<SimpleHelper>>;
+export type ClassHelperFactory = Factory<HelperInstance, HelperFactory<HelperInstance>>;
 
-export type HelperFactory = SimpleHelperFactory | ClassHelperFactory;
-
-export interface SimpleHelper {
+export interface HelperFactory<T> {
   isHelperFactory: true;
-  isSimpleHelper: true;
-
-  create(): SimpleHelper;
-  compute: HelperFunction;
-}
-
-export interface HelperStatic {
-  isHelperFactory: true;
-  isSimpleHelper: false;
-
-  create(): HelperInstance;
+  create(): T;
 }
 
 export interface HelperInstance {
-  compute: HelperFunction;
+  compute(positional: Opaque[], named: Dict<Opaque>): Opaque;
   destroy(): void;
 }
 
-export function isHelperFactory(helper: any | undefined | null): helper is HelperFactory {
+export interface SimpleHelper {
+  compute: HelperFunction;
+}
+
+export function isHelperFactory(
+  helper: any | undefined | null
+): helper is SimpleHelperFactory | ClassHelperFactory {
   return (
     typeof helper === 'object' && helper !== null && helper.class && helper.class.isHelperFactory
   );
 }
 
-export function isSimpleHelper(helper: HelperFactory): helper is SimpleHelperFactory {
-  return helper.class.isSimpleHelper;
+export function isSimpleHelper(helper: SimpleHelper | HelperInstance): helper is SimpleHelper {
+  return (helper as any).destroy === undefined;
 }
 
 /**
@@ -135,19 +129,18 @@ let Helper = FrameworkObject.extend({
   */
 });
 
-Helper.reopenClass({
-  isHelperFactory: true,
-  isSimpleHelper: false,
-});
+Helper.isHelperFactory = true;
 
-class Wrapper implements SimpleHelper {
+class Wrapper implements HelperFactory<SimpleHelper> {
   isHelperFactory: true = true;
-  isSimpleHelper: true = true;
 
   constructor(public compute: HelperFunction) {}
 
   create() {
-    return this;
+    // needs new instance or will leak containers
+    return {
+      compute: this.compute,
+    };
   }
 }
 
@@ -173,8 +166,8 @@ class Wrapper implements SimpleHelper {
   @public
   @since 1.13.0
 */
-export function helper(helperFn: HelperFunction): SimpleHelper {
+export function helper(helperFn: HelperFunction): HelperFactory<SimpleHelper> {
   return new Wrapper(helperFn);
 }
 
-export default Helper as HelperStatic;
+export default Helper as HelperFactory<HelperInstance>;

--- a/packages/ember-glimmer/lib/resolver.ts
+++ b/packages/ember-glimmer/lib/resolver.ts
@@ -244,15 +244,11 @@ export default class RuntimeResolver implements IRuntimeResolver<OwnedTemplateMe
       return null;
     }
 
-    if (isSimpleHelper(factory)) {
-      const helper = factory.create().compute;
-      return (_vm, args) => {
-        return SimpleHelperReference.create(helper, args.capture());
-      };
-    }
-
     return (vm, args) => {
       const helper = factory.create();
+      if (isSimpleHelper(helper)) {
+        return new SimpleHelperReference(helper.compute, args.capture());
+      }
       vm.newDestroyable(helper);
       return ClassBasedHelperReference.create(helper, args.capture());
     };


### PR DESCRIPTION
Faking a singleton via create() leaks memory because the factory manager associates itself via WeakMap to something that it thinks is going to GC with its container.