### PR TITLE
[BUGFIX release] Use resetCache on container destroy

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -84,6 +84,7 @@ export default class Container {
    @return {any}
    */
   lookup(fullName, options) {
+    assert('expected container not to be destroyed', !this.isDestroyed);
     assert('fullName must be a proper full name', this.registry.isValidFullName(fullName));
     return lookup(this, this.registry.normalize(fullName), options);
   }
@@ -95,7 +96,7 @@ export default class Container {
    @method destroy
    */
   destroy() {
-    destroyDestroyables(this);
+    resetCache(this);
     this.isDestroyed = true;
   }
 
@@ -107,6 +108,7 @@ export default class Container {
    @param {String} fullName optional key to reset; if missing, resets everything
   */
   reset(fullName) {
+    if (this.isDestroyed) return;
     if (fullName === undefined) {
       resetCache(this);
     } else {
@@ -138,6 +140,7 @@ export default class Container {
    @return {any}
    */
   factoryFor(fullName, options = {}) {
+    assert('expected container not to be destroyed', !this.isDestroyed);
     let normalizedName = this.registry.normalize(fullName);
 
     assert('fullName must be a proper full name', this.registry.isValidFullName(normalizedName));
@@ -156,6 +159,7 @@ export default class Container {
     return factoryFor(this, normalizedName, fullName);
   }
 }
+
 /*
  * Wrap a factory manager in a proxy which will not permit properties to be
  * set on the manager.

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -671,6 +671,40 @@ moduleFor(
       assert.deepEqual(Object.keys(instance), []);
     }
 
+    [`@test assert when calling lookup after destroy on a container`](assert) {
+      let registry = new Registry();
+      let container = registry.container();
+      let Component = factory();
+      registry.register('component:foo-bar', Component);
+      let instance = container.lookup('component:foo-bar');
+      assert.ok(instance, 'precond lookup successful');
+
+      this.runTask(() => {
+        container.destroy();
+      });
+
+      expectAssertion(() => {
+        container.lookup('component:foo-bar');
+      });
+    }
+
+    [`@test assert when calling factoryFor after destroy on a container`](assert) {
+      let registry = new Registry();
+      let container = registry.container();
+      let Component = factory();
+      registry.register('component:foo-bar', Component);
+      let instance = container.factoryFor('component:foo-bar');
+      assert.ok(instance, 'precond lookup successful');
+
+      this.runTask(() => {
+        container.destroy();
+      });
+
+      expectAssertion(() => {
+        container.factoryFor('component:foo-bar');
+      });
+    }
+
     // this is skipped until templates and the glimmer environment do not require `OWNER` to be
     // passed in as constructor args
     ['@skip #factoryFor does not add properties to the object being instantiated'](assert) {

--- a/packages/ember-glimmer/tests/integration/components/life-cycle-test.js
+++ b/packages/ember-glimmer/tests/integration/components/life-cycle-test.js
@@ -16,6 +16,7 @@ class LifeCycleHooksTest extends RenderingTest {
     this.components = {};
     this.componentRegistry = [];
     this.teardownAssertions = [];
+    this.viewRegistry = this.owner.lookup('-view-registry:main');
   }
 
   afterEach() {
@@ -59,7 +60,7 @@ class LifeCycleHooksTest extends RenderingTest {
   }
 
   assertRegisteredViews(label) {
-    let viewRegistry = this.owner.lookup('-view-registry:main');
+    let viewRegistry = this.viewRegistry;
     let topLevelId = getViewId(this.component);
     let actual = Object.keys(viewRegistry)
       .sort()


### PR DESCRIPTION
Use resetCache on container destroy to help  reduce noise when a container is leaked.

Add asserts if lookup and factoryFor are called after destroy.
