### PR TITLE
Update to latest puppeteer (1.3.0).

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "lodash.uniq": "^4.5.0",
     "mocha": "^5.0.0",
     "prettier": "1.11.1",
-    "puppeteer": "^0.13.0",
+    "puppeteer": "^1.3.0",
     "qunit": "^2.5.0",
     "route-recognizer": "^0.3.3",
     "router_js": "2.0.0-beta.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5824,9 +5824,9 @@ punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-puppeteer@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-0.13.0.tgz#2e6956205f2c640964c2107f620ae1eef8bde8fd"
+puppeteer@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.3.0.tgz#f571c5f27153ca164a8188e6328ce2e4946878f3"
   dependencies:
     debug "^2.6.8"
     extract-zip "^1.6.5"


### PR DESCRIPTION
Migrates from Chromium 64 to 67