### PR TITLE
[BUGFIX release] Prevent errors in ember-engines + 3.1 + proxies.

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -109,6 +109,7 @@ function makeCtor(base) {
                 property === 'didAddListener' ||
                 property === 'didRemoveListener' ||
                 property === 'isDescriptor' ||
+                property === '_onLookup' ||
                 property in target
               ) {
                 return Reflect.get(target, property, receiver);

--- a/packages/ember-runtime/tests/system/core_object_test.js
+++ b/packages/ember-runtime/tests/system/core_object_test.js
@@ -1,7 +1,7 @@
 import { getOwner, setOwner } from 'ember-owner';
 import { get } from 'ember-metal';
 import CoreObject from '../../lib/system/core_object';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase, buildOwner } from 'internal-test-helpers';
 
 moduleFor(
   'Ember.CoreObject',
@@ -60,6 +60,24 @@ moduleFor(
 
       let proxy = get(obj, 'someProxyishThing');
       assert.equal(get(proxy, 'lolol'), true, 'should be able to get data from a proxy');
+    }
+
+    ['@test should not trigger proxy assertion when retrieving a re-registered proxy (GH#16610)'](
+      assert
+    ) {
+      let owner = buildOwner();
+
+      let someProxyishThing = CoreObject.extend({
+        unknownProperty() {
+          return true;
+        },
+      }).create();
+
+      // emulates ember-engines's process of registering services provided
+      // by the host app down to the engine
+      owner.register('thing:one', someProxyishThing, { instantiate: false });
+
+      assert.equal(owner.lookup('thing:one'), someProxyishThing);
     }
 
     ['@test should not trigger proxy assertion when probing for a "symbol"'](assert) {


### PR DESCRIPTION
Setup:

* In Ember 3.1 any service that has an `unknownProperty` method will trigger an assertion if properties are accessed directly and the `unknownProperty` implementation does not return `undefined` (which is commonly true for things like "features" service which always returns true or false).

* Ember Engines registers any service instances from the host app into the engines container (with `instantiate: false` set). This is the mechanism by which `engineDependencies` works.

* When a service is looked up (regardless of `instantiate: false`) the container looks for and calls the `_onLookup` method so that the class can validate all of its injections.

Combining these two pieces means that any engines with an `engineDependencies` provided service that has an `unknownProperty` will throw an error when the service is looked up.

Fixes #16610