### PR TITLE
Migrate CI to use Travis' Stages feature.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,12 @@ branches:
     # npm version tags
     - /^v\d+\.\d+\.\d+/
 
+stages:
+  - basic test
+  - additional tests
+  - name: deploy
+    if: type IN (push)
+
 env:
   global:
     - BROWSERSTACK_USERNAME=emberjscoreteam1
@@ -53,7 +59,6 @@ env:
     - secure: ! 'KXJmcGLpnxnPmmei/qPNVcdQxLX1xyYIaVocinQ0YAjtBvCtAwg63EWMFnGp
 
       VIzUNikE+Cej3g+nwEdDJiL1c9NFPL+zCnriR2iMVjPak+IQaG3YcMm0T+hY
-
       /WLEPAquZBKw1gU6lBEUuDumTlkXQQdHz3cJYoidAXz3uV1EXIU='
     - secure: ! 'qCW0BVNFuQjAI53pvvE6oeGxtEdZ+RlvcCpYjU4vxEjedidEEcHKtIVh7d7J
 
@@ -61,13 +66,42 @@ env:
 
       I/BFT0MbnR6JVCZiPV7TCWPgY1gvgZ6TEEIKGqauDMUBdL8ZK6I='
     - secure: e0yxVfwVW61d3Mi/QBOsY6Rfd1mZd3VXUd9xNRoz/fkvQJRuVwDe7oG3NOuJ4LZzvMw7BJ+zpDV9D8nKhAyPEEOgpkkMHUB7Ds83pHG4qSMzm4EAwBCadDLXCQirldz8dzN5FAqgGucXoj5fj/p2SKOkO6qWIZveGr8pdBJEG1E=
-  matrix:
-    - TEST_SUITE=browserstack
-    - TEST_SUITE=each-package-tests BUILD_TYPE=canary PUBLISH=true
-    - TEST_SUITE=built-tests EMBER_ENV=production
-    - TEST_SUITE=old-jquery-and-extend-prototypes
-    - TEST_SUITE=node
-    - TEST_SUITE=blueprints
-    - TEST_SUITE=travis-browsers
-    - TEST_SUITE=each-package-tests BUILD_TYPE=alpha PUBLISH=true
-    - TEST_SUITE=code-quality
+
+jobs:
+  fail_fast: true
+
+  include:
+
+    - stage: basic test
+      env: TEST_SUITE=each-package-tests
+
+    - env: TEST_SUITE=code-quality
+
+    - stage: additional tests
+
+      env: TEST_SUITE=browserstack
+    - env: TEST_SUITE=each-package-tests
+    - env:
+      - TEST_SUITE=built-tests
+      - EMBER_ENV=production
+    - env: TEST_SUITE=old-jquery-and-extend-prototypes
+    - env: TEST_SUITE=node
+    - env: TEST_SUITE=blueprints
+    - env: TEST_SUITE=travis-browsers
+    - env:
+      - TEST_SUITE=each-package-tests
+      - BUILD_TYPE=alpha
+
+    - stage: deploy
+
+    - env:
+      - BUILD_TYPE=canary
+      - PUBLISH=true
+      script:
+        - "./bin/publish_builds"
+
+      env:
+      - BUILD_TYPE=alpha
+      - PUBLISH=true
+      script:
+        - "./bin/publish_builds"


### PR DESCRIPTION
* Run linting
* Run each-package-tests
* IIF all prior jobs pass, run:
  * Browserstack Job
  * Travis Browsers
  * Old jQuery Tests
  * Production each-package-tests
  * Node tests
  * Blueprint tests
  * Alpha build each-package-tests
* IIF all prior jobs pass, run:
  * Deploy canary build
  * Deploy alpha build