### PR TITLE
Polyfill QUnit memory leak prevention.

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -192,6 +192,9 @@
         });
 
         QUnit.testDone(function(results) {
+          // release the test callback (polyfill for https://github.com/qunitjs/qunit/pull/1279)
+          QUnit.config.current.callback = undefined;
+
           var oldFixture = document.getElementById('qunit-fixture');
           var parent = oldFixture.parentElement;
           var newFixture = document.createElement('div');
@@ -205,6 +208,11 @@
           } else {
             testsPassed++;
           }
+        });
+
+        QUnit.moduleDone(function() {
+          // release the module hooks (polyfill for https://github.com/qunitjs/qunit/pull/1279)
+          QUnit.config.current.module.hooks = {};
         });
 
         QUnit.done(function(result) {


### PR DESCRIPTION
This polyfills the changes from https://github.com/qunitjs/qunit/pull/1279 to older versions of QUnit.

---

Prior to the changes in this PR, all module and test callbacks are retained (forever). This may not seem significant, but as folks use closure scope to store data across tests (which is very common).

For example, prior to the changes in this PR the following would retain the local variable:

```js
QUnit.module('top', function(hooks) {
  let largeThing;

  hooks.beforeEach(function() {
    largeThing = new LargeThing();
  });

  hooks.afterEach(function() {
    largeThing.destroy();
  });

  test('something that uses largeThing', function(assert) {
    // ...snip...
    largeThing.someMethod();
  });
});
```