### PR TITLE
[BUGFIX beta] computed.sort array should update if sort properties array is empty

### DIFF
--- a/packages/@ember/object/lib/computed/reduce_computed_macros.js
+++ b/packages/@ember/object/lib/computed/reduce_computed_macros.js
@@ -836,11 +836,17 @@ function propertySort(itemsKey, sortPropertiesKey) {
 
       let itemsKeyIsAtThis = itemsKey === '@this';
       let normalizedSortProperties = normalizeSortProperties(sortProperties);
-      activeObservers = normalizedSortProperties.map(([prop]) => {
-        let path = itemsKeyIsAtThis ? `@each.${prop}` : `${itemsKey}.@each.${prop}`;
+      if (normalizedSortProperties.length === 0) {
+        let path = itemsKeyIsAtThis ? `[]` : `${itemsKey}.[]`;
         addObserver(this, path, sortPropertyDidChange);
-        return [this, path, sortPropertyDidChange];
-      });
+        activeObservers = [[this, path, sortPropertyDidChange]];
+      } else {
+        activeObservers = normalizedSortProperties.map(([prop]) => {
+          let path = itemsKeyIsAtThis ? `@each.${prop}` : `${itemsKey}.@each.${prop}`;
+          addObserver(this, path, sortPropertyDidChange);
+          return [this, path, sortPropertyDidChange];
+        });
+      }
 
       activeObserversMap.set(this, activeObservers);
 

--- a/packages/@ember/object/tests/computed/reduce_computed_macros_test.js
+++ b/packages/@ember/object/tests/computed/reduce_computed_macros_test.js
@@ -1297,6 +1297,56 @@ moduleFor(
       );
     }
 
+    ['@test array should update if items to be sorted is replaced when sort properties array is empty'](
+      assert
+    ) {
+      var o = EmberObject.extend({
+        sortedItems: sort('items', 'itemSorting'),
+      }).create({
+        itemSorting: emberA([]),
+        items: emberA([6, 7, 8, 9, 10, 11, 0, 1, 2, 3, 4, 5]),
+      });
+
+      assert.deepEqual(
+        o.get('sortedItems'),
+        [6, 7, 8, 9, 10, 11, 0, 1, 2, 3, 4, 5],
+        'array is not changed'
+      );
+
+      set(o, 'items', emberA([5, 6, 7, 8, 9, 10, 11, 0, 1, 2, 3, 4]));
+
+      assert.deepEqual(
+        o.get('sortedItems'),
+        [5, 6, 7, 8, 9, 10, 11, 0, 1, 2, 3, 4],
+        'array was updated'
+      );
+    }
+
+    ['@test array should update if items to be sorted is mutated when sort properties array is empty'](
+      assert
+    ) {
+      var o = EmberObject.extend({
+        sortedItems: sort('items', 'itemSorting'),
+      }).create({
+        itemSorting: emberA([]),
+        items: emberA([6, 7, 8, 9, 10, 11, 0, 1, 2, 3, 4, 5]),
+      });
+
+      assert.deepEqual(
+        o.get('sortedItems'),
+        [6, 7, 8, 9, 10, 11, 0, 1, 2, 3, 4, 5],
+        'array is not changed'
+      );
+
+      o.get('items').pushObject(12);
+
+      assert.deepEqual(
+        o.get('sortedItems'),
+        [6, 7, 8, 9, 10, 11, 0, 1, 2, 3, 4, 5, 12],
+        'array was updated'
+      );
+    }
+
     ['@test array observers do not leak'](assert) {
       let daria = { name: 'Daria' };
       let jane = { name: 'Jane' };


### PR DESCRIPTION
Basically, when the sort properties array is empty, `computed.sort` was returning the original array, **but not** responding to any changes in that array.
The result was that any `computed.sort` never changed, even when the dependent array changed.

I hope the (previously failing) test is self explanatory.
Is there a chance we can backport this to previous ember versions?

Please let me know if anything else is needed from me. Thanks!