### PR TITLE
[BUGFIX] Ensure that paths which start with // are properly persisted.

### DIFF
--- a/packages/ember-routing/index.d.ts
+++ b/packages/ember-routing/index.d.ts
@@ -37,7 +37,7 @@ export const HistoryLocation: {
   replaceURL(path: string): void;
   getState(): any;
   pushState(path: string): void;
-  replaceState(paht: string): void;
+  replaceState(path: string): void;
   onUpdateURL(callback: ()=>any): void;
   formatURL(url: string): string;
   willDestroy(): void;

--- a/packages/ember-routing/lib/location/history_location.js
+++ b/packages/ember-routing/lib/location/history_location.js
@@ -82,6 +82,9 @@ export default EmberObject.extend({
 
     let state = this.getState();
     let path = this.formatURL(this.getURL());
+
+    path = `${window.location.origin}${path}}`;
+
     if (state && state.path === path) {
       // preserve existing state
       // used for webkit workaround, since there will be no initial popstate event
@@ -139,7 +142,7 @@ export default EmberObject.extend({
   */
   setURL(path) {
     let state = this.getState();
-    path = this.formatURL(path);
+    path = `${window.location.origin}${this.formatURL(path)}`;
 
     if (!state || state.path !== path) {
       this.pushState(path);
@@ -156,7 +159,7 @@ export default EmberObject.extend({
   */
   replaceURL(path) {
     let state = this.getState();
-    path = this.formatURL(path);
+    path = `${window.location.origin}${this.formatURL(path)}`;
 
     if (!state || state.path !== path) {
       this.replaceState(path);


### PR DESCRIPTION
Given a URL like:
`http://www.example.com/<COUNTRY>/some/path`

There can exist unfortunate server code which can result in the (now-required-to-be-valid) URL:
`http://www.example.com//some/path`

After running through Ember's router we eventually end up at `HistoryLocation#pushState` which calculates the path: `'//some/path'`. So far so good.

This then delegates to `window.history.pushState(state, null, path)`. In the browser API `path` is allowed to be a relative URL. And now we have a problem:

> Uncaught DOMException: Failed to execute 'pushState' on 'History': A history state object with URL 'https://some/path' cannot be created in a document with origin 'https://www.example.com' and URL 'https://www.example.com//some/path'.

Given that all paths at this point are guaranteed to be fully-root-relative path names, we have an out: include the origin. I've elected to fix it one layer higher than `pushState` and `replaceState` to make the change just work for users such as:
https://github.com/dollarshaveclub/ember-router-scroll/blob/master/addon/locations/router-scroll.js
https://github.com/ember-fastboot/ember-cli-fastboot/blob/master/addon/locations/none.js

I'm opening this for discussion before finishing the task. Should we handle this _before calling_  **-or-** _inside of_ `HistoryLocation#pushState` and `HistoryLocation#replaceState`?