### PR TITLE
Fix failing tests in `link_to_test.js` without jQuery

### DIFF
--- a/packages/ember-glimmer/lib/components/link-to.ts
+++ b/packages/ember-glimmer/lib/components/link-to.ts
@@ -897,6 +897,15 @@ const LinkComponent = EmberComponent.extend({
       this.set('models', []);
     }
   },
+
+  handleEvent() {
+    let propagate = this._super(...arguments);
+
+    if (this.bubbles === false) {
+      return this.bubbles;
+    }
+    return propagate;
+  },
 });
 
 LinkComponent.toString = () => '@ember/routing/link-component';


### PR DESCRIPTION
#16058 

This PR fixes the following tests:

`The {{link-to}} helper - nested routes and link-to arguments: The {{link-to}} helper supports bubbles=false`
`The {{link-to}} helper - nested routes and link-to arguments: The {{link-to}} helper supports bubbles=boundFalseyThing`

Status
- No tests fail w/ jQuery
- No tests fail w/o jQuery (except the test for `Ember.$ is not undefined`)

