### PR TITLE
[BUGFIX release] Fix descriptorFor to support fallback

### DIFF
--- a/packages/ember-meta/lib/meta.ts
+++ b/packages/ember-meta/lib/meta.ts
@@ -802,8 +802,13 @@ export function descriptorFor(obj: object, keyName: string, _meta?: Meta) {
   @private
 */
 export function isDescriptor(possibleDesc: any | undefined | null): boolean {
-  // TODO make this return possibleDesc is Descriptor
-  return possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor;
+  // TODO make this return `possibleDesc is Descriptor`
+  return (
+    possibleDesc !== undefined &&
+    possibleDesc !== null &&
+    typeof possibleDesc === 'object' &&
+    possibleDesc.isDescriptor === true
+  );
 }
 
 export { counters };

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -86,8 +86,7 @@ function notifyPropertyChange(obj, keyName, _meta) {
 
   let possibleDesc = descriptorFor(obj, keyName, meta);
 
-  // shouldn't this mean that we're watching this key?
-  if (possibleDesc !== undefined && possibleDesc.didChange) {
+  if (possibleDesc !== undefined && typeof possibleDesc.didChange === 'function') {
     possibleDesc.didChange(obj, keyName);
   }
 

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -78,7 +78,36 @@ moduleFor(
       obj.a = 10;
       notifyPropertyChange(obj, 'b');
 
-      assert.equal(get(obj, 'b'), 2);
+      assert.equal(obj.b, 2);
+    }
+
+    ['@test set works for a computed property not setup using Ember.defineProperty'](assert) {
+      let obj = {
+        a: 50,
+        b: computed('a', {
+          get() {
+            return this.a * 2;
+          },
+          set(_, value) {
+            set(this, 'a', value / 2);
+            return value;
+          },
+        }),
+      };
+
+      assert.equal(obj.a, 50);
+
+      expectDeprecation(function() {
+        set(obj, 'b', 80);
+      });
+
+      assert.equal(obj.b, 80);
+      assert.equal(obj.a, 40);
+
+      set(obj, 'a', 100);
+
+      assert.equal(obj.a, 100);
+      assert.equal(obj.b, 200);
     }
 
     ['@test defining computed property should invoke property on get'](assert) {

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -9,6 +9,7 @@ import {
   set,
   isWatching,
   addObserver,
+  notifyPropertyChange,
 } from '..';
 import { meta as metaFor } from 'ember-meta';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
@@ -58,6 +59,26 @@ moduleFor(
 
       assert.equal(obj.foo, 'computed foo', 'should return value');
       assert.equal(count, 1, 'should have invoked computed property');
+    }
+
+    ['@test `notifyPropertyChange` works for a computed property not setup using Ember.defineProperty #GH16427'](
+      assert
+    ) {
+      let obj = {
+        a: 50,
+        b: computed(function() {
+          return this.a / 5;
+        }),
+      };
+
+      expectDeprecation(function() {
+        assert.equal(get(obj, 'b'), 10);
+      });
+
+      obj.a = 10;
+      notifyPropertyChange(obj, 'b');
+
+      assert.equal(get(obj, 'b'), 2);
     }
 
     ['@test defining computed property should invoke property on get'](assert) {


### PR DESCRIPTION
Ensure all fallback cases are deprecated.

Fixes #16427 and add test for `notifyPropertyChange` not working for plain obj.