### PR TITLE
[DOC release] Update class_names_support.js to include binding classes to false properties

### DIFF
--- a/packages/ember-views/lib/mixins/class_names_support.js
+++ b/packages/ember-views/lib/mixins/class_names_support.js
@@ -79,6 +79,18 @@ export default Mixin.create({
     });
     ```
 
+    If you would like to specify a class that should only be added when the
+    property is false, you can declare a binding like this:
+
+    ```javascript
+    // Applies the 'disabled' class to the view element
+    import Component from '@ember/component';
+    Component.extend({
+      classNameBindings: ['isEnabled::disabled'],
+      isEnabled: false
+    });
+    ```
+
     This list of properties is inherited from the component's superclasses as well.
 
     @property classNameBindings


### PR DESCRIPTION
This PR adds documentation for using `classNameBindings` to bind a class when a property is false. 

This is a feature that I use pretty frequently, and it's been a part of the guides since `1.10.0` from what I can tell (see: [Ember.js - Components: Customizing a Component's Element](https://guides.emberjs.com/v1.10.0/components/customizing-a-components-element/)), but it appears to be missing from the API docs.

