### PR TITLE
deprecate `NativeArray#copy`

### DIFF
--- a/packages/ember-runtime/lib/copy.js
+++ b/packages/ember-runtime/lib/copy.js
@@ -1,6 +1,7 @@
 import { assert } from '@ember/debug';
 import EmberObject from './system/object';
 import Copyable from './mixins/copyable';
+
 /**
  @module @ember/object
 */

--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -28,7 +28,6 @@ import Enumerable from './enumerable';
 import compare from '../compare';
 import { ENV } from 'ember-environment';
 import Observable from '../mixins/observable';
-import Copyable from '../mixins/copyable';
 import copy from '../copy';
 import EmberError from '@ember/error';
 import MutableEnumerable from './mutable_enumerable';
@@ -1628,7 +1627,7 @@ const MutableArray = Mixin.create(ArrayMixin, MutableEnumerable, {
   @uses Ember.Copyable
   @public
 */
-let NativeArray = Mixin.create(MutableArray, Observable, Copyable, {
+let NativeArray = Mixin.create(MutableArray, Observable, {
   objectAt(idx) {
     return this[idx];
   },
@@ -1643,6 +1642,11 @@ let NativeArray = Mixin.create(MutableArray, Observable, Copyable, {
   },
 
   copy(deep) {
+    deprecate(`Using \`NativeArray#copy\` is deprecated`, false, {
+      id: 'ember-runtime.using-array-copy',
+      until: '3.5.0',
+    });
+
     if (deep) {
       return this.map(item => copy(item, true));
     }

--- a/packages/ember-runtime/tests/system/native_array/copyable_suite_test.js
+++ b/packages/ember-runtime/tests/system/native_array/copyable_suite_test.js
@@ -6,8 +6,11 @@ moduleFor(
   class extends AbstractTestCase {
     ['@test deep copy is respected'](assert) {
       let array = emberA([{ id: 1 }, { id: 2 }, { id: 3 }]);
+      let copiedArray;
 
-      let copiedArray = array.copy(true);
+      expectDeprecation(() => {
+        copiedArray = array.copy(true);
+      }, `Using \`NativeArray#copy\` is deprecated`);
 
       assert.deepEqual(copiedArray, array, 'copied array is equivalent');
       assert.ok(copiedArray[0] !== array[0], 'objects inside should be unique');


### PR DESCRIPTION
as mentioned here: https://github.com/emberjs/ember.js/issues/16517