### PR TITLE
remove redundant `indexOf/lastIndexOf` from `NativeArray`

### DIFF
--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -1642,9 +1642,6 @@ let NativeArray = Mixin.create(MutableArray, Observable, Copyable, {
     return this;
   },
 
-  indexOf: Array.prototype.indexOf,
-  lastIndexOf: Array.prototype.lastIndexOf,
-
   copy(deep) {
     if (deep) {
       return this.map(item => copy(item, true));


### PR DESCRIPTION
since `NativeArray` is used to apply/extend native `Array` having `indexOf/lastIndexOf` looks redundant, before it was used for polyfills https://github.com/emberjs/ember.js/commit/62916e8f68b93f73b53e6ebd4254ff6560e6ae59#diff-7be349ee898133ade03bc4adca5582bcL87