### PR TITLE
Add ...attributes tests (when using tagless components).

### DIFF
--- a/packages/ember-glimmer/lib/component-managers/root.ts
+++ b/packages/ember-glimmer/lib/component-managers/root.ts
@@ -48,8 +48,10 @@ class RootComponentManager extends CurlyComponentManager {
 
     dynamicScope.view = component;
 
+    let hasWrappedElement = component.tagName !== '';
+
     // We usually do this in the `didCreateElement`, but that hook doesn't fire for tagless components
-    if (component.tagName === '') {
+    if (!hasWrappedElement) {
       if (environment.isInteractive) {
         component.trigger('willRender');
       }
@@ -65,7 +67,7 @@ class RootComponentManager extends CurlyComponentManager {
       processComponentInitializationAssertions(component, {});
     }
 
-    return new ComponentStateBucket(environment, component, null, finalizer);
+    return new ComponentStateBucket(environment, component, null, finalizer, hasWrappedElement);
   }
 }
 

--- a/packages/ember-glimmer/lib/utils/curly-component-state-bucket.ts
+++ b/packages/ember-glimmer/lib/utils/curly-component-state-bucket.ts
@@ -41,7 +41,8 @@ export default class ComponentStateBucket {
     public environment: Environment,
     public component: Component,
     public args: CapturedNamedArguments | null,
-    public finalizer: Finalizer
+    public finalizer: Finalizer,
+    public hasWrappedElement: boolean
   ) {
     this.classRef = null;
     this.argsRevision = args === null ? 0 : args.tag.value();

--- a/packages/ember-glimmer/tests/integration/components/angle-bracket-invocation-test.js
+++ b/packages/ember-glimmer/tests/integration/components/angle-bracket-invocation-test.js
@@ -560,6 +560,224 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'hello',
         });
       }
+
+      '@test includes invocation specified attributes in `...attributes` slot in tagless component ("splattributes")'() {
+        this.registerComponent('foo-bar', {
+          ComponentClass: Component.extend({ tagName: '' }),
+          template: '<div ...attributes>hello</div>',
+        });
+
+        this.render('<FooBar data-foo={{foo}} data-bar={{bar}} />', { foo: 'foo', bar: 'bar' });
+
+        this.assertElement(this.firstChild, {
+          tagName: 'div',
+          attrs: { 'data-foo': 'foo', 'data-bar': 'bar' },
+          content: 'hello',
+        });
+
+        this.runTask(() => this.rerender());
+
+        this.assertElement(this.firstChild, {
+          tagName: 'div',
+          attrs: { 'data-foo': 'foo', 'data-bar': 'bar' },
+          content: 'hello',
+        });
+
+        this.runTask(() => {
+          set(this.context, 'foo', 'FOO');
+          set(this.context, 'bar', undefined);
+        });
+
+        this.assertElement(this.firstChild, {
+          tagName: 'div',
+          attrs: { 'data-foo': 'FOO' },
+          content: 'hello',
+        });
+
+        this.runTask(() => {
+          set(this.context, 'foo', 'foo');
+          set(this.context, 'bar', 'bar');
+        });
+
+        this.assertElement(this.firstChild, {
+          tagName: 'div',
+          attrs: { 'data-foo': 'foo', 'data-bar': 'bar' },
+          content: 'hello',
+        });
+      }
+
+      '@test merges attributes with `...attributes` in tagless component ("splattributes")'() {
+        let instance;
+        this.registerComponent('foo-bar', {
+          ComponentClass: Component.extend({
+            tagName: '',
+            init() {
+              instance = this;
+              this._super(...arguments);
+              this.localProp = 'qux';
+            },
+          }),
+          template: '<div data-derp={{localProp}} ...attributes>hello</div>',
+        });
+
+        this.render('<FooBar data-foo={{foo}} data-bar={{bar}} />', { foo: 'foo', bar: 'bar' });
+
+        this.assertElement(this.firstChild, {
+          tagName: 'div',
+          attrs: { 'data-derp': 'qux', 'data-foo': 'foo', 'data-bar': 'bar' },
+          content: 'hello',
+        });
+
+        this.runTask(() => this.rerender());
+
+        this.assertElement(this.firstChild, {
+          tagName: 'div',
+          attrs: { 'data-derp': 'qux', 'data-foo': 'foo', 'data-bar': 'bar' },
+          content: 'hello',
+        });
+
+        this.runTask(() => {
+          set(this.context, 'foo', 'FOO');
+          set(this.context, 'bar', undefined);
+          set(instance, 'localProp', 'QUZ');
+        });
+
+        this.assertElement(this.firstChild, {
+          tagName: 'div',
+          attrs: { 'data-derp': 'QUZ', 'data-foo': 'FOO' },
+          content: 'hello',
+        });
+
+        this.runTask(() => {
+          set(this.context, 'foo', 'foo');
+          set(this.context, 'bar', 'bar');
+          set(instance, 'localProp', 'qux');
+        });
+
+        this.assertElement(this.firstChild, {
+          tagName: 'div',
+          attrs: { 'data-derp': 'qux', 'data-foo': 'foo', 'data-bar': 'bar' },
+          content: 'hello',
+        });
+      }
+
+      '@test merges class attribute with `...attributes` in tagless component ("splattributes")'() {
+        let instance;
+        this.registerComponent('foo-bar', {
+          ComponentClass: Component.extend({
+            tagName: '',
+            init() {
+              instance = this;
+              this._super(...arguments);
+              this.localProp = 'qux';
+            },
+          }),
+          template: '<div class={{localProp}} ...attributes>hello</div>',
+        });
+
+        this.render('<FooBar class={{bar}} />', { bar: 'bar' });
+
+        this.assertElement(this.firstChild, {
+          tagName: 'div',
+          attrs: { class: classes('qux bar') },
+          content: 'hello',
+        });
+
+        this.runTask(() => this.rerender());
+
+        this.assertElement(this.firstChild, {
+          tagName: 'div',
+          attrs: { class: classes('qux bar') },
+          content: 'hello',
+        });
+
+        this.runTask(() => {
+          set(this.context, 'bar', undefined);
+          set(instance, 'localProp', 'QUZ');
+        });
+
+        this.assertElement(this.firstChild, {
+          tagName: 'div',
+          attrs: { class: classes('QUZ') },
+          content: 'hello',
+        });
+
+        this.runTask(() => {
+          set(this.context, 'bar', 'bar');
+          set(instance, 'localProp', 'qux');
+        });
+
+        this.assertElement(this.firstChild, {
+          tagName: 'div',
+          attrs: { class: classes('qux bar') },
+          content: 'hello',
+        });
+      }
+
+      '@test can include `...attributes` in multiple elements in tagless component ("splattributes")'() {
+        this.registerComponent('foo-bar', {
+          ComponentClass: Component.extend({ tagName: '' }),
+          template: '<div ...attributes>hello</div><p ...attributes>world</p>',
+        });
+
+        this.render('<FooBar data-foo={{foo}} data-bar={{bar}} />', { foo: 'foo', bar: 'bar' });
+
+        this.assertElement(this.firstChild, {
+          tagName: 'div',
+          attrs: { 'data-foo': 'foo', 'data-bar': 'bar' },
+          content: 'hello',
+        });
+        this.assertElement(this.nthChild(1), {
+          tagName: 'p',
+          attrs: { 'data-foo': 'foo', 'data-bar': 'bar' },
+          content: 'world',
+        });
+
+        this.runTask(() => this.rerender());
+
+        this.assertElement(this.firstChild, {
+          tagName: 'div',
+          attrs: { 'data-foo': 'foo', 'data-bar': 'bar' },
+          content: 'hello',
+        });
+        this.assertElement(this.nthChild(1), {
+          tagName: 'p',
+          attrs: { 'data-foo': 'foo', 'data-bar': 'bar' },
+          content: 'world',
+        });
+
+        this.runTask(() => {
+          set(this.context, 'foo', 'FOO');
+          set(this.context, 'bar', undefined);
+        });
+
+        this.assertElement(this.firstChild, {
+          tagName: 'div',
+          attrs: { 'data-foo': 'FOO' },
+          content: 'hello',
+        });
+        this.assertElement(this.nthChild(1), {
+          tagName: 'p',
+          attrs: { 'data-foo': 'FOO' },
+          content: 'world',
+        });
+
+        this.runTask(() => {
+          set(this.context, 'foo', 'foo');
+          set(this.context, 'bar', 'bar');
+        });
+
+        this.assertElement(this.firstChild, {
+          tagName: 'div',
+          attrs: { 'data-foo': 'foo', 'data-bar': 'bar' },
+          content: 'hello',
+        });
+        this.assertElement(this.nthChild(1), {
+          tagName: 'p',
+          attrs: { 'data-foo': 'foo', 'data-bar': 'bar' },
+          content: 'world',
+        });
+      }
     }
   );
 }


### PR DESCRIPTION
* Wrap `didCreateElement` logic of curly component manager in a guard (so that we only do things like add classes and whatnot when the component we created uses a wrapped element.
* Added various tests for tagless components using `...attributes`

Addresses a few more items under https://github.com/emberjs/ember.js/issues/16688