### PR TITLE
Deprecate accessing jQuery.Event#originalEvent

### DIFF
--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -10,6 +10,7 @@ import { Object as EmberObject } from 'ember-runtime';
 import jQuery from './jquery';
 import ActionManager from './action_manager';
 import fallbackViewRegistry from '../compat/fallback-view-registry';
+import addJQueryEventDeprecation from './jquery_event_deprecation';
 
 const HAS_JQUERY = jQuery !== undefined;
 const ROOT_ELEMENT_CLASS = 'ember-application';
@@ -244,7 +245,7 @@ export default EmberObject.extend({
         let result = true;
 
         if (view) {
-          result = view.handleEvent(eventName, evt);
+          result = view.handleEvent(eventName, addJQueryEventDeprecation(evt));
         }
 
         return result;
@@ -253,6 +254,8 @@ export default EmberObject.extend({
       rootElement.on(`${event}.ember`, '[data-ember-action]', evt => {
         let attributes = evt.currentTarget.attributes;
         let handledActions = [];
+
+        evt = addJQueryEventDeprecation(evt);
 
         for (let i = 0; i < attributes.length; i++) {
           let attr = attributes.item(i);

--- a/packages/ember-views/lib/system/jquery_event_deprecation.js
+++ b/packages/ember-views/lib/system/jquery_event_deprecation.js
@@ -1,0 +1,51 @@
+/* global Proxy */
+import { deprecate } from '@ember/debug';
+import { ENV } from 'ember-environment';
+import { HAS_NATIVE_PROXY } from 'ember-utils';
+import { DEBUG } from '@glimmer/env';
+
+export default function addJQueryEventDeprecation(jqEvent) {
+  if (!DEBUG || !HAS_NATIVE_PROXY) {
+    return jqEvent;
+  }
+
+  let boundFunctions = new Map();
+
+  // wrap the jQuery event in a Proxy to add the deprecation message for originalEvent, according to RFC#294
+  // we need a native Proxy here, so we can make sure that the internal use of originalEvent in jQuery itself does
+  // not trigger a deprecation
+  return new Proxy(jqEvent, {
+    get(target, name) {
+      switch (name) {
+        case 'originalEvent':
+          deprecate(
+            'Accessing jQuery.Event specific properties is deprecated. Either use the ember-jquery-legacy addon to normalize events to native events, or explicitly opt into jQuery integration using @ember/optional-features.',
+            ENV._JQUERY_INTEGRATION === true,
+            {
+              id: 'ember-views.event-dispatcher.jquery-event',
+              until: '4.0.0',
+            }
+          );
+          return target[name];
+
+        // provide an escape hatch for ember-jquery-legacy to access originalEvent without a deprecation
+        case '__originalEvent':
+          return target.originalEvent;
+
+        default:
+          if (typeof target[name] === 'function') {
+            // cache functions for reuse
+            if (!boundFunctions.has(name)) {
+              // for jQuery.Event methods call them with `target` as the `this` context, so they will access
+              // `originalEvent` from the original jQuery event, not our proxy, thus not trigger the deprecation
+              boundFunctions.set(name, target[name].bind(target));
+            }
+
+            return boundFunctions.get(name);
+          }
+          // same for jQuery's getter functions for simple properties
+          return target[name];
+      }
+    },
+  });
+}


### PR DESCRIPTION
Implements the deprecation message for user-land code accessing `originalEvent` on `jQuery.Event` instances, as proposed by RFC#294 (https://github.com/emberjs/rfcs/blob/master/text/0294-optional-jquery.md#introducing-ember-jquery-legacy-and-deprecating-jqueryevent-usage)

Relates to #16687 introducing the `_JQUERY_INTEGRATION` flag also used here.