### PR TITLE
Deprecate Ember.Map, Ember.MapWithDefault and Ember.OrderedSet

### DIFF
--- a/packages/@ember/map/index.js
+++ b/packages/@ember/map/index.js
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert, deprecate } from '@ember/debug';
 import { guidFor } from 'ember-utils';
 import OrderedSet from './lib/ordered-set';
 import { copyMap } from './lib/utils';
@@ -44,9 +44,15 @@ import { copyMap } from './lib/utils';
   @class Map
   @private
   @constructor
+  @deprecated use native `Map` instead.
 */
 class Map {
   constructor() {
+    deprecate('Use of @ember/Map is deprecated. Please use native `Map` instead', false, {
+      id: 'ember-map-deprecation',
+      until: '3.5.0',
+    });
+
     this._keys = new OrderedSet();
     this._values = Object.create(null);
     this.size = 0;

--- a/packages/@ember/map/lib/ordered-set.js
+++ b/packages/@ember/map/lib/ordered-set.js
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert, deprecate } from '@ember/debug';
 import { guidFor } from 'ember-utils';
 import { copyNull } from './utils';
 
@@ -14,6 +14,11 @@ import { copyNull } from './utils';
 */
 export default class OrderedSet {
   constructor() {
+    deprecate('Use of @ember/OrderedSet is deprecated. Please use native `Map` instead', false, {
+      id: 'ember-map-deprecation',
+      until: '3.5.0',
+    });
+
     this.clear();
   }
 

--- a/packages/@ember/map/tests/map_test.js
+++ b/packages/@ember/map/tests/map_test.js
@@ -550,7 +550,13 @@ moduleFor(
       number = 42;
       string = 'foo';
 
-      map = OrderedSet.create();
+      expectDeprecation(
+        () => {
+          map = OrderedSet.create();
+        },
+        'Use of @ember/OrderedSet is deprecated. Please use native `Map` instead',
+        { id: 'ember-map-deprecation', until: '3.5.0' }
+      );
     }
 
     ['@test add returns the set'](assert) {

--- a/packages/@ember/map/tests/map_test.js
+++ b/packages/@ember/map/tests/map_test.js
@@ -17,7 +17,13 @@ function testMap(nameAndFunc) {
         number = 42;
         string = 'foo';
 
-        map = nameAndFunc[1].create();
+        expectDeprecation(
+          () => {
+            map = nameAndFunc[1].create();
+          },
+          'Use of @ember/Map is deprecated. Please use native `Map` instead',
+          { id: 'ember-map-deprecation', until: '3.5.0' }
+        );
       }
 
       ['@test set'](assert) {
@@ -104,7 +110,14 @@ function testMap(nameAndFunc) {
         map.set(number, 'winning');
         map.set(string, 'winning');
 
-        let map2 = map.copy();
+        let map2;
+        expectDeprecation(
+          () => {
+            map2 = map.copy();
+          },
+          'Use of @ember/Map is deprecated. Please use native `Map` instead',
+          { id: 'ember-map-deprecation', until: '3.5.0' }
+        );
 
         map2.set(object, 'losing');
         map2.set(number, 'losing');
@@ -120,7 +133,14 @@ function testMap(nameAndFunc) {
         map.set(number, 'winning');
         map.set(string, 'winning');
 
-        let map2 = map.copy();
+        let map2;
+        expectDeprecation(
+          () => {
+            map2 = map.copy();
+          },
+          'Use of @ember/Map is deprecated. Please use native `Map` instead',
+          { id: 'ember-map-deprecation', until: '3.5.0' }
+        );
 
         map2.delete(object);
         map2.delete(number);
@@ -148,8 +168,14 @@ function testMap(nameAndFunc) {
         assert.equal(map.size, 2);
 
         //Check copy
-        let copy = map.copy();
-        assert.equal(copy.size, 2);
+        expectDeprecation(
+          () => {
+            let copy = map.copy();
+            assert.equal(copy.size, 2);
+          },
+          'Use of @ember/Map is deprecated. Please use native `Map` instead',
+          { id: 'ember-map-deprecation', until: '3.5.0' }
+        );
 
         //Remove a key twice
         map.delete(number);
@@ -428,11 +454,18 @@ moduleFor(
   'MapWithDefault - default values',
   class extends AbstractTestCase {
     ['@test Retrieving a value that has not been set returns and sets a default value'](assert) {
-      let map = MapWithDefault.create({
-        defaultValue(key) {
-          return [key];
+      let map;
+      expectDeprecation(
+        () => {
+          map = MapWithDefault.create({
+            defaultValue(key) {
+              return [key];
+            },
+          });
         },
-      });
+        'Use of @ember/Map is deprecated. Please use native `Map` instead',
+        { id: 'ember-map-deprecation', until: '3.5.0' }
+      );
 
       let value = map.get('ohai');
       assert.deepEqual(value, ['ohai']);
@@ -441,30 +474,56 @@ moduleFor(
     }
 
     ['@test Map.prototype.constructor'](assert) {
-      let map = new Map();
-      assert.equal(map.constructor, Map);
+      expectDeprecation(
+        () => {
+          let map = new Map();
+          assert.equal(map.constructor, Map);
+        },
+        'Use of @ember/Map is deprecated. Please use native `Map` instead',
+        { id: 'ember-map-deprecation', until: '3.5.0' }
+      );
     }
 
     ['@test MapWithDefault.prototype.constructor'](assert) {
-      let map = new MapWithDefault({
-        defaultValue(key) {
-          return key;
+      expectDeprecation(
+        () => {
+          let map = new MapWithDefault({
+            defaultValue(key) {
+              return key;
+            },
+          });
+          assert.equal(map.constructor, MapWithDefault);
         },
-      });
-      assert.equal(map.constructor, MapWithDefault);
+        'Use of @ember/Map is deprecated. Please use native `Map` instead',
+        { id: 'ember-map-deprecation', until: '3.5.0' }
+      );
     }
 
     ['@test Copying a MapWithDefault copies the default value'](assert) {
-      let map = MapWithDefault.create({
-        defaultValue(key) {
-          return [key];
+      let map;
+      expectDeprecation(
+        () => {
+          map = MapWithDefault.create({
+            defaultValue(key) {
+              return [key];
+            },
+          });
         },
-      });
+        'Use of @ember/Map is deprecated. Please use native `Map` instead',
+        { id: 'ember-map-deprecation', until: '3.5.0' }
+      );
 
       map.set('ohai', 1);
       map.get('bai');
 
-      let map2 = map.copy();
+      let map2;
+      expectDeprecation(
+        () => {
+          map2 = map.copy();
+        },
+        'Use of @ember/Map is deprecated. Please use native `Map` instead',
+        { id: 'ember-map-deprecation', until: '3.5.0' }
+      );
 
       assert.equal(map2.get('ohai'), 1);
       assert.deepEqual(map2.get('bai'), ['bai']);

--- a/packages/@ember/map/with-default.js
+++ b/packages/@ember/map/with-default.js
@@ -1,3 +1,4 @@
+import { deprecate } from '@ember/debug';
 import Map from './index';
 import { copyMap } from './lib/utils';
 
@@ -11,6 +12,15 @@ import { copyMap } from './lib/utils';
 */
 export default class MapWithDefault extends Map {
   constructor(options) {
+    deprecate(
+      'Use of @ember/MapWithDefault is deprecated. Please use native `Map` instead',
+      false,
+      {
+        id: 'ember-map-deprecation',
+        until: '3.5.0',
+      }
+    );
+
     super();
     this.defaultValue = options.defaultValue;
   }

--- a/packages/ember-metal/tests/is_empty_test.js
+++ b/packages/ember-metal/tests/is_empty_test.js
@@ -40,10 +40,16 @@ moduleFor(
     }
 
     ['@test isEmpty Ember.OrderedSet'](assert) {
-      let orderedSet = new OrderedSet();
-      assert.equal(true, isEmpty(orderedSet), 'Empty ordered set is empty');
-      orderedSet.add('foo');
-      assert.equal(false, isEmpty(orderedSet), 'Ordered set is not empty');
+      expectDeprecation(
+        () => {
+          let orderedSet = new OrderedSet();
+          assert.equal(true, isEmpty(orderedSet), 'Empty ordered set is empty');
+          orderedSet.add('foo');
+          assert.equal(false, isEmpty(orderedSet), 'Ordered set is not empty');
+        },
+        'Use of @ember/OrderedSet is deprecated. Please use native `Map` instead',
+        { id: 'ember-map-deprecation', until: '3.5.0' }
+      );
     }
   }
 );

--- a/packages/ember-metal/tests/is_empty_test.js
+++ b/packages/ember-metal/tests/is_empty_test.js
@@ -27,10 +27,16 @@ moduleFor(
     }
 
     ['@test isEmpty Map'](assert) {
-      let map = new Map();
-      assert.equal(true, isEmpty(map), 'Empty map is empty');
-      map.set('foo', 'bar');
-      assert.equal(false, isEmpty(map), 'Map is not empty');
+      expectDeprecation(
+        () => {
+          let map = new Map();
+          assert.equal(true, isEmpty(map), 'Empty map is empty');
+          map.set('foo', 'bar');
+          assert.equal(false, isEmpty(map), 'Map is not empty');
+        },
+        'Use of @ember/Map is deprecated. Please use native `Map` instead',
+        { id: 'ember-map-deprecation', until: '3.5.0' }
+      );
     }
 
     ['@test isEmpty Ember.OrderedSet'](assert) {


### PR DESCRIPTION
Fixes #16678 