### PR TITLE
[BUGFIX beta] avoid ordered set deprecation

### DIFF
--- a/packages/@ember/map/lib/ordered-set.js
+++ b/packages/@ember/map/lib/ordered-set.js
@@ -12,16 +12,17 @@ import { copyNull } from './utils';
   @constructor
   @private
 */
-export default class OrderedSet {
-  constructor() {
-    deprecate('Use of @ember/OrderedSet is deprecated. Please use native `Map` instead', false, {
-      id: 'ember-map-deprecation',
-      until: '3.5.0',
-    });
 
+/**
+ * This is exported so it can be used by the OrderedSet library.
+ * This is private do not use it.
+ @private
+ */
+
+export class __OrderedSet__ {
+  constructor() {
     this.clear();
   }
-
   /**
     @method create
     @static
@@ -164,5 +165,15 @@ export default class OrderedSet {
     set.size = this.size;
 
     return set;
+  }
+}
+
+export default class OrderedSet extends __OrderedSet__ {
+  constructor() {
+    super();
+    deprecate('Use of @ember/OrderedSet is deprecated. Please use native `Map` instead', false, {
+      id: 'ember-map-deprecation',
+      until: '3.5.0',
+    });
   }
 }

--- a/packages/@ember/map/tests/map_test.js
+++ b/packages/@ember/map/tests/map_test.js
@@ -1,6 +1,6 @@
 import Map from '..';
 import MapWithDefault from '../with-default';
-import OrderedSet from '../lib/ordered-set';
+import OrderedSet, { __OrderedSet__ } from '../lib/ordered-set';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 let object, number, string, map, variety;
@@ -563,6 +563,16 @@ moduleFor(
       let obj = {};
       assert.equal(map.add(obj), map);
       assert.equal(map.add(obj), map, 'when it is already in the set');
+    }
+  }
+);
+
+moduleFor(
+  '__OrderedSet__',
+  class extends AbstractTestCase {
+    ['@test private __OrderedSet__ can be created without deprecation']() {
+      expectNoDeprecation();
+      __OrderedSet__.create();
     }
   }
 );

--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -123,7 +123,7 @@ import Engine from '@ember/engine';
 import EngineInstance from '@ember/engine/instance';
 import Map from '@ember/map';
 import MapWithDefault from '@ember/map/with-default';
-import OrderedSet from '@ember/map/lib/ordered-set';
+import OrderedSet, { __OrderedSet__ } from '@ember/map/lib/ordered-set';
 import { assign, merge } from '@ember/polyfills';
 import {
   PROPERTY_WILL_CHANGE,
@@ -183,6 +183,7 @@ Ember.EngineInstance = EngineInstance;
 
 // ****@ember/map****
 Ember.OrderedSet = OrderedSet;
+Ember.__OrderedSet__ = __OrderedSet__;
 Ember.Map = Map;
 Ember.MapWithDefault = MapWithDefault;
 


### PR DESCRIPTION
This is part of a fix for this bug: https://github.com/emberjs/ember-ordered-set/issues/19 by creating a private path that excludes the deprecation in the OrderedSet class. 