### PR TITLE
[DOC release] Fix broken links to guides

### DIFF
--- a/packages/ember-glimmer/lib/syntax/outlet.ts
+++ b/packages/ember-glimmer/lib/syntax/outlet.ts
@@ -31,8 +31,6 @@ import { OutletReference, OutletState } from '../utils/outlet';
   {{my-footer}}
   ```
 
-  See [templates guide](https://guides.emberjs.com/release/templates/the-application-template/) for
-  additional information on using `{{outlet}}` in `application.hbs`.
   You may also specify a name for the `{{outlet}}`, which is useful when using more than one
   `{{outlet}}` in a template:
 


### PR DESCRIPTION
All links pointing to `emberjs.com/guides/*` updated to the new `guides.emberjs.com/release/*`.