### PR TITLE
Fixup edgecases for angle bracket component dasherization.

### DIFF
--- a/packages/ember-glimmer/tests/integration/components/angle-bracket-invocation-test.js
+++ b/packages/ember-glimmer/tests/integration/components/angle-bracket-invocation-test.js
@@ -9,10 +9,22 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
   moduleFor(
     'AngleBracket Invocation',
     class extends RenderingTest {
-      '@test it can resolve <XBlah /> to x-outer'() {
+      '@test it can resolve <XBlah /> to x-blah'() {
         this.registerComponent('x-blah', { template: 'hello' });
 
         this.render('<XBlah />');
+
+        this.assertComponentElement(this.firstChild, { content: 'hello' });
+
+        this.runTask(() => this.rerender());
+
+        this.assertComponentElement(this.firstChild, { content: 'hello' });
+      }
+
+      '@test it can resolve <X-Blah /> to x-blah'() {
+        this.registerComponent('x-blah', { template: 'hello' });
+
+        this.render('<X-Blah />');
 
         this.assertComponentElement(this.firstChild, { content: 'hello' });
 

--- a/packages/ember-template-compiler/lib/system/compile-options.ts
+++ b/packages/ember-template-compiler/lib/system/compile-options.ts
@@ -1,8 +1,8 @@
 import { assign } from '@ember/polyfills';
 import { PrecompileOptions } from '@glimmer/compiler';
 import { AST, ASTPlugin, ASTPluginEnvironment, Syntax } from '@glimmer/syntax';
-import { Cache } from 'ember-utils';
 import PLUGINS, { APluginFunc } from '../plugins/index';
+import COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE from './dasherize-component-name';
 
 type PluginFunc = APluginFunc & {
   __raw?: LegacyPluginClass | undefined;
@@ -18,18 +18,6 @@ export interface CompileOptions {
   moduleName?: string | undefined;
   plugins?: Plugins | undefined;
 }
-
-/*
-  This diverges from `Ember.String.dasherize` so that`<XFoo />` can resolve to `x-foo`.
-  `Ember.String.dasherize` would resolve it to `xfoo`..
-*/
-const SIMPLE_DASHERIZE_REGEXP = /[A-Z]/g;
-const COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE = new Cache<string, string>(1000, key =>
-  key.replace(
-    SIMPLE_DASHERIZE_REGEXP,
-    (char, index) => (index !== 0 ? '-' : '') + char.toLowerCase()
-  )
-);
 
 export default function compileOptions(_options: Partial<CompileOptions>): PrecompileOptions {
   let options = assign({ meta: {} }, _options, {

--- a/packages/ember-template-compiler/lib/system/dasherize-component-name.ts
+++ b/packages/ember-template-compiler/lib/system/dasherize-component-name.ts
@@ -1,0 +1,17 @@
+import { Cache } from 'ember-utils';
+
+/*
+  This diverges from `Ember.String.dasherize` so that`<XFoo />` can resolve to `x-foo`.
+  `Ember.String.dasherize` would resolve it to `xfoo`..
+*/
+const SIMPLE_DASHERIZE_REGEXP = /[A-Z]/g;
+const ALPHA = /[A-Za-z]/;
+export default new Cache<string, string>(1000, key =>
+  key.replace(SIMPLE_DASHERIZE_REGEXP, (char, index) => {
+    if (index === 0 || !ALPHA.test(key[index - 1])) {
+      return char.toLowerCase();
+    }
+
+    return `-${char.toLowerCase()}`;
+  })
+);

--- a/packages/ember-template-compiler/tests/system/dasherize-component-name-test.js
+++ b/packages/ember-template-compiler/tests/system/dasherize-component-name-test.js
@@ -1,0 +1,19 @@
+import COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE from '../../lib/system/dasherize-component-name';
+
+QUnit.module('dasherize-component-name', function() {
+  function equals(input, expected) {
+    QUnit.test(`${input} -> ${expected}`, function(assert) {
+      assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get(input), expected);
+    });
+  }
+
+  equals('Foo', 'foo');
+  equals('foo-bar', 'foo-bar');
+  equals('FooBar', 'foo-bar');
+  equals('XBlah', 'x-blah');
+  equals('X-Blah', 'x-blah');
+  equals('Foo::BarBaz', 'foo::bar-baz');
+  equals('Foo::Bar-Baz', 'foo::bar-baz');
+  equals('Foo@BarBaz', 'foo@bar-baz');
+  equals('Foo@Bar-Baz', 'foo@bar-baz');
+});


### PR DESCRIPTION
Also add a small test harness for the various edge cases that the custom component name dasherization function needs to handle.