### PR TITLE
move `isDestroyed` check from `getPath` to `get`

### DIFF
--- a/packages/@ember/-internals/metal/lib/is_empty.ts
+++ b/packages/@ember/-internals/metal/lib/is_empty.ts
@@ -1,4 +1,3 @@
-import { get } from './property_get';
 /**
  @module @ember/utils
 */
@@ -48,7 +47,7 @@ export default function isEmpty(obj: any): boolean {
   let objectType = typeof obj;
 
   if (objectType === 'object') {
-    let size = get(obj, 'size');
+    let size = obj.size;
     if (typeof size === 'number') {
       return !size;
     }
@@ -59,7 +58,7 @@ export default function isEmpty(obj: any): boolean {
   }
 
   if (objectType === 'object') {
-    let length = get(obj, 'length');
+    let length = obj.length;
     if (typeof length === 'number') {
       return !length;
     }

--- a/packages/@ember/-internals/metal/lib/property_set.ts
+++ b/packages/@ember/-internals/metal/lib/property_set.ts
@@ -66,7 +66,7 @@ export function set(obj: object, keyName: string, value: any, tolerant?: boolean
 
   if ((obj as ExtendedObject).isDestroyed) {
     assert(
-      `calling set on destroyed object: ${toString(obj)}.${keyName} = ${toString(value)}`,
+      `calling \`set\` on destroyed object: ${toString(obj)}.${keyName} = ${toString(value)}`,
       tolerant
     );
     return;

--- a/packages/@ember/-internals/metal/tests/accessors/set_test.js
+++ b/packages/@ember/-internals/metal/tests/accessors/set_test.js
@@ -105,7 +105,7 @@ moduleFor(
 
       expectAssertion(
         () => set(obj, 'favoriteFood', 'hot dogs'),
-        'calling set on destroyed object: [object Object].favoriteFood = hot dogs'
+        'calling `set` on destroyed object: [object Object].favoriteFood = hot dogs'
       );
     }
 

--- a/packages/@ember/-internals/runtime/tests/system/array_proxy/content_change_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/array_proxy/content_change_test.js
@@ -13,7 +13,9 @@ moduleFor(
 
       run(() => proxy1.destroy());
 
-      set(proxy2, 'content', proxy1);
+      expectWarning(() => {
+        set(proxy2, 'content', proxy1);
+      });
 
       assert.ok(true, 'No exception was raised');
     }

--- a/packages/@ember/-internals/runtime/tests/system/object/observer_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/observer_test.js
@@ -101,9 +101,11 @@ moduleFor(
 
       expectAssertion(function() {
         set(obj, 'bar', 'BAZ');
-      }, `calling set on destroyed object: ${obj}.bar = BAZ`);
+      }, `calling \`set\` on destroyed object: ${obj}.bar = BAZ`);
 
-      assert.equal(get(obj, 'count'), 0, 'should not invoke observer after change');
+      expectWarning(function() {
+        assert.equal(get(obj, 'count'), undefined);
+      }, `calling \`get\` on destroyed object: ${obj}.count`);
     }
 
     // ..........................................................

--- a/packages/@ember/-internals/views/lib/system/event_dispatcher.js
+++ b/packages/@ember/-internals/views/lib/system/event_dispatcher.js
@@ -424,6 +424,10 @@ export default EmberObject.extend({
   },
 
   destroy() {
+    if (this.isDestroyed) {
+      return;
+    }
+
     let rootElementSelector = get(this, 'rootElement');
     let rootElement;
     if (rootElementSelector.nodeType) {

--- a/packages/ember/tests/application_lifecycle_test.js
+++ b/packages/ember/tests/application_lifecycle_test.js
@@ -63,8 +63,13 @@ moduleFor(
 
       this.application.reset();
 
-      assert.equal(indexController.get('selectedMenuItem'), null);
-      assert.equal(applicationController.get('selectedMenuItem'), null);
+      expectWarning(() => {
+        assert.equal(indexController.get('selectedMenuItem'), undefined);
+      }, `calling \`get\` on destroyed object: ${indexController}.selectedMenuItem`);
+
+      expectWarning(() => {
+        assert.equal(applicationController.get('selectedMenuItem'), undefined);
+      }, `calling \`get\` on destroyed object: ${applicationController}.selectedMenuItem`);
     }
 
     [`@test Destroying the application resets the router before the appInstance is destroyed`](
@@ -78,8 +83,12 @@ moduleFor(
         this.application.destroy();
       });
 
-      assert.equal(indexController.get('selectedMenuItem'), null);
-      assert.equal(applicationController.get('selectedMenuItem'), null);
+      expectWarning(() => {
+        assert.equal(indexController.get('selectedMenuItem'), undefined);
+      }, `calling \`get\` on destroyed object: ${indexController}.selectedMenuItem`);
+      expectWarning(() => {
+        assert.equal(applicationController.get('selectedMenuItem'), undefined);
+      }, `calling \`get\` on destroyed object: ${applicationController}.selectedMenuItem`);
     }
   }
 );


### PR DESCRIPTION
make consistent `get` with `set` so it warns (maybe make it `assert` later) when used on destroyed object, I think it will help to discover hidden bugs 