### PR TITLE
[BUGFIX beta] Better error when a route name is not valid

### DIFF
--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -30,6 +30,11 @@ class DSL {
       })()
     );
 
+    assert(
+      `'${name}' is not a valid route name. It cannot contain a ':'. You may want to use the 'path' option instead.`,
+      name.indexOf(':') === -1
+    );
+
     if (this.enableLoadingSubstates) {
       createRoute(this, `${name}_loading`, {
         resetNamespace: options.resetNamespace,

--- a/packages/ember-routing/tests/system/dsl_test.js
+++ b/packages/ember-routing/tests/system/dsl_test.js
@@ -35,6 +35,19 @@ moduleFor(
       });
     }
 
+    ['@test [GH#16642] better error when using a colon in a route name']() {
+      expectAssertion(() => {
+        Router = EmberRouter.extend();
+
+        Router.map(function() {
+          this.route('resource/:id');
+        });
+
+        let router = Router.create();
+        router._initRouterJs();
+      }, "'resource/:id' is not a valid route name. It cannot contain a ':'. You may want to use the 'path' option instead.");
+    }
+
     ['@test should retain resource namespace if nested with routes'](assert) {
       Router = Router.map(function() {
         this.route('bleep', function() {


### PR DESCRIPTION
Improves the error message shown when trying to define
a route with a ':' in the name.

Fixes #16642