### PR TITLE
use `applyMixin` directly instead of using it through `Mixin`

### DIFF
--- a/packages/ember-metal/index.ts
+++ b/packages/ember-metal/index.ts
@@ -41,7 +41,7 @@ export { default as setProperties } from './lib/set_properties';
 export { default as expandProperties } from './lib/expand_properties';
 
 export { addObserver, removeObserver } from './lib/observer';
-export { Mixin, aliasMethod, mixin, observer } from './lib/mixin';
+export { Mixin, aliasMethod, mixin, observer, applyMixin } from './lib/mixin';
 export { default as InjectedProperty } from './lib/injected_property';
 export { setHasViews, tagForProperty, tagFor, markObjectAsDirty } from './lib/tags';
 export { default as runInTransaction, didRender, assertNotRendered } from './lib/transaction';

--- a/packages/ember-metal/lib/mixin.ts
+++ b/packages/ember-metal/lib/mixin.ts
@@ -361,7 +361,7 @@ function replaceObserversAndListeners(
   }
 }
 
-function applyMixin(obj: { [key: string]: any }, mixins: Mixin[], partial: boolean) {
+export function applyMixin(obj: { [key: string]: any }, mixins: Mixin[], partial: boolean) {
   let descs = {};
   let values = {};
   let meta = metaFor(obj);
@@ -546,14 +546,6 @@ export default class Mixin {
       guidFor(this);
       Object.seal(this);
     }
-  }
-
-  static _apply() {
-    return (applyMixin as any)(...arguments);
-  }
-
-  static applyPartial(obj: any, ...args: any[]) {
-    return applyMixin(obj, args, true);
   }
 
   /**

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -20,6 +20,7 @@ import {
   finishChains,
   sendEvent,
   Mixin,
+  applyMixin,
   defineProperty,
   ComputedProperty,
   InjectedProperty,
@@ -31,7 +32,6 @@ import { assert } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 import { ENV } from 'ember-environment';
 
-const applyMixin = Mixin._apply;
 const reopen = Mixin.prototype.reopen;
 
 function makeCtor(base) {


### PR DESCRIPTION
I think it is cleaner and readable just to export `applyMixin`  and use it directly instead of accessing though `Mixin` 