### PR TITLE
Update Custom Components feature to match final RFC.

### DIFF
--- a/packages/ember-glimmer/index.ts
+++ b/packages/ember-glimmer/index.ts
@@ -301,6 +301,6 @@ export { UpdatableReference, INVOKE } from './lib/utils/references';
 export { default as iterableFor } from './lib/utils/iterable';
 export { default as DebugStack } from './lib/utils/debug-stack';
 export { default as OutletView } from './lib/views/outlet';
-export { default as CustomComponentManager } from './lib/component-managers/custom';
-export { COMPONENT_MANAGER, componentManager } from './lib/utils/custom-component-manager';
+export { capabilities } from './lib/component-managers/custom';
+export { setComponentManager, getComponentManager } from './lib/utils/custom-component-manager';
 export { isSerializationFirstNode } from './lib/utils/serialization-first-node-helpers';

--- a/packages/ember-glimmer/lib/component-managers/curly.ts
+++ b/packages/ember-glimmer/lib/component-managers/curly.ts
@@ -15,7 +15,6 @@ import {
   Arguments,
   Bounds,
   ComponentDefinition,
-  ComponentManager,
   ElementOperations,
   Invocation,
   PreparedArguments,
@@ -46,7 +45,6 @@ import {
 import ComponentStateBucket, { Component } from '../utils/curly-component-state-bucket';
 import { processComponentArgs } from '../utils/process-args';
 import AbstractManager from './abstract';
-import CustomComponentManager, { CustomComponentState } from './custom';
 import DefinitionState from './definition-state';
 
 function aliasIdToElementId(args: Arguments, props: any) {
@@ -560,13 +558,10 @@ export class CurlyComponentDefinition implements ComponentDefinition {
   public args: CurriedArgs | undefined;
   public state: DefinitionState;
   public symbolTable: ProgramSymbolTable | undefined;
-
+  public manager: CurlyComponentManager = CURLY_COMPONENT_MANAGER;
   // tslint:disable-next-line:no-shadowed-variable
   constructor(
     public name: string,
-    public manager:
-      | ComponentManager<ComponentStateBucket, DefinitionState>
-      | CustomComponentManager<CustomComponentState<any>> = CURLY_COMPONENT_MANAGER,
     public ComponentClass: any,
     public handle: Option<VMHandle>,
     template: OwnedTemplate,

--- a/packages/ember-glimmer/lib/resolver.ts
+++ b/packages/ember-glimmer/lib/resolver.ts
@@ -9,15 +9,14 @@ import {
   RuntimeResolver as IRuntimeResolver,
 } from '@glimmer/interfaces';
 import { LazyCompiler, Macros, PartialDefinition } from '@glimmer/opcode-compiler';
-import { ComponentManager, getDynamicVar, Helper, ModifierManager } from '@glimmer/runtime';
+import { getDynamicVar, Helper, ModifierManager } from '@glimmer/runtime';
 import { privatize as P } from 'container';
 import { ENV } from 'ember-environment';
 import { LookupOptions, Owner, setOwner } from 'ember-owner';
 import { lookupComponent, lookupPartial, OwnedTemplateMeta } from 'ember-views';
 import CompileTimeLookup from './compile-time-lookup';
 import { CurlyComponentDefinition } from './component-managers/curly';
-import CustomComponentManager, { CustomComponentState } from './component-managers/custom';
-import DefinitionState from './component-managers/definition-state';
+import { CustomManagerDefinition, ManagerDelegate } from './component-managers/custom';
 import { TemplateOnlyComponentDefinition } from './component-managers/template-only';
 import { isHelperFactory, isSimpleHelper } from './helper';
 import { default as classHelper } from './helpers/-class';
@@ -41,8 +40,7 @@ import { mountHelper } from './syntax/mount';
 import { outletHelper } from './syntax/outlet';
 import { renderHelper } from './syntax/render';
 import { Factory as TemplateFactory, Injections, OwnedTemplate } from './template';
-import ComponentStateBucket from './utils/curly-component-state-bucket';
-import getCustomComponentManager from './utils/custom-component-manager';
+import { getComponentManager } from './utils/custom-component-manager';
 import { ClassBasedHelperReference, SimpleHelperReference } from './utils/references';
 
 function instrumentationPayload(name: string) {
@@ -105,6 +103,7 @@ export default class RuntimeResolver implements IRuntimeResolver<OwnedTemplateMe
   // supports directly imported late bound layouts on component.prototype.layout
   private templateCache: Map<Owner, Map<TemplateFactory, OwnedTemplate>> = new Map();
   private componentDefinitionCache: Map<object, ComponentDefinition | null> = new Map();
+  private customManagerCache: Map<string, ManagerDelegate<Opaque>> = new Map();
 
   public templateCacheHits = 0;
   public templateCacheMisses = 0;
@@ -214,7 +213,7 @@ export default class RuntimeResolver implements IRuntimeResolver<OwnedTemplateMe
   }
 
   // needed for lazy compile time lookup
-  private handle(obj: any | null | undefined) {
+  private handle(obj: Opaque) {
     if (obj === undefined || obj === null) {
       return null;
     }
@@ -320,27 +319,42 @@ export default class RuntimeResolver implements IRuntimeResolver<OwnedTemplateMe
       return cachedComponentDefinition;
     }
 
+    let finalizer = _instrumentStart('render.getComponentDefinition', instrumentationPayload, name);
+
     if (layout && !component && ENV._TEMPLATE_ONLY_GLIMMER_COMPONENTS) {
       let definition = new TemplateOnlyComponentDefinition(layout);
+      finalizer();
       this.componentDefinitionCache.set(key, definition);
       return definition;
     }
 
-    let manager:
-      | ComponentManager<ComponentStateBucket, DefinitionState>
-      | CustomComponentManager<CustomComponentState<any>>
-      | undefined;
-
     if (GLIMMER_CUSTOM_COMPONENT_MANAGER && component && component.class) {
-      manager = getCustomComponentManager(meta.owner, component.class);
+      let managerId = getComponentManager(component.class);
+      if (managerId) {
+        let manager = this._lookupComponentManager(meta.owner, managerId);
+        assert(
+          `Could not find custom component manager '${managerId}' which was specified by ${
+            component.class
+          }`,
+          !!manager
+        );
+
+        let definition = new CustomManagerDefinition(
+          name,
+          component,
+          manager,
+          layout || meta.owner.lookup<OwnedTemplate>(P`template:components/-default`)
+        );
+        finalizer();
+        this.componentDefinitionCache.set(key, definition);
+        return definition;
+      }
     }
 
-    let finalizer = _instrumentStart('render.getComponentDefinition', instrumentationPayload, name);
     let definition =
       layout || component
         ? new CurlyComponentDefinition(
             name,
-            manager,
             component || meta.owner.factoryFor(P`component:-default`),
             null,
             layout! // TODO fix type
@@ -352,5 +366,16 @@ export default class RuntimeResolver implements IRuntimeResolver<OwnedTemplateMe
     this.componentDefinitionCache.set(key, definition);
 
     return definition;
+  }
+
+  _lookupComponentManager(owner: Owner, managerId: string): ManagerDelegate<Opaque> {
+    if (this.customManagerCache.has(managerId)) {
+      return this.customManagerCache.get(managerId)!;
+    }
+    let delegate = owner.lookup<ManagerDelegate<Opaque>>(`component-manager:${managerId}`);
+
+    this.customManagerCache.set(managerId, delegate);
+
+    return delegate;
   }
 }

--- a/packages/ember-glimmer/lib/utils/custom-component-manager.ts
+++ b/packages/ember-glimmer/lib/utils/custom-component-manager.ts
@@ -1,45 +1,27 @@
-import { assert } from '@ember/debug';
-import { Owner } from 'ember-owner';
-import { symbol } from 'ember-utils';
-
-import CustomComponentManager, { CustomComponentState } from '../component-managers/custom';
-
 import { GLIMMER_CUSTOM_COMPONENT_MANAGER } from '@ember/canary-features';
 
-export const COMPONENT_MANAGER = symbol('COMPONENT_MANAGER');
+const getPrototypeOf = Object.getPrototypeOf;
+const MANAGERS: WeakMap<any, string> = new WeakMap();
 
-export function componentManager(obj: any, managerId: String) {
-  if ('reopenClass' in obj) {
-    return obj.reopenClass({
-      [COMPONENT_MANAGER]: managerId,
-    });
-  }
+export function setComponentManager(managerId: string, obj: any) {
+  MANAGERS.set(obj, managerId);
 
-  obj[COMPONENT_MANAGER] = managerId;
   return obj;
 }
 
-export default function getCustomComponentManager(
-  owner: Owner,
-  obj: {}
-): CustomComponentManager<CustomComponentState<any>> | undefined {
+export function getComponentManager(obj: any): string | undefined {
   if (!GLIMMER_CUSTOM_COMPONENT_MANAGER) {
     return;
   }
 
-  if (!obj) {
-    return;
+  let pointer = obj;
+  while (pointer !== undefined && pointer !== null) {
+    if (MANAGERS.has(pointer)) {
+      return MANAGERS.get(pointer);
+    }
+
+    pointer = getPrototypeOf(pointer);
   }
 
-  let managerId = obj[COMPONENT_MANAGER];
-  if (!managerId) {
-    return;
-  }
-
-  let manager = new CustomComponentManager(
-    owner.lookup(`component-manager:${managerId}`)
-  ) as CustomComponentManager<CustomComponentState<any>>;
-  assert(`Could not find custom component manager '${managerId}' for ${obj}`, !!manager);
-
-  return manager;
+  return;
 }

--- a/packages/ember-glimmer/tests/integration/custom-component-manager-test.js
+++ b/packages/ember-glimmer/tests/integration/custom-component-manager-test.js
@@ -1,59 +1,88 @@
 import { moduleFor, RenderingTest } from '../utils/test-case';
-import { strip } from '../utils/abstract-test-case';
-import { Component } from '../utils/helpers';
-
 import { Object as EmberObject } from 'ember-runtime';
 import { set, setProperties, computed } from 'ember-metal';
-import { GLIMMER_CUSTOM_COMPONENT_MANAGER } from '@ember/canary-features';
-import { componentManager } from 'ember-glimmer';
-import { getChildViews } from 'ember-views';
-import { assign } from '@ember/polyfills';
-
-const MANAGER_ID = 'test-custom';
-
-const CustomComponent = componentManager(EmberObject.extend(), MANAGER_ID);
+import {
+  GLIMMER_CUSTOM_COMPONENT_MANAGER,
+  EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION,
+} from '@ember/canary-features';
+import { setComponentManager, capabilities } from 'ember-glimmer';
 
 if (GLIMMER_CUSTOM_COMPONENT_MANAGER) {
-  moduleFor(
-    'Components test: curly components with custom manager',
-    class extends RenderingTest {
-      /*
-     * Helper to register a custom component manager. Provides a basic, default
-     * implementation of the custom component manager API, but can be overridden
-     * by passing custom hooks.
-     */
-      registerCustomComponentManager(overrides = {}) {
-        let options = assign(
-          {
-            version: '3.1',
-            create({ ComponentClass }) {
-              return ComponentClass.create();
-            },
+  class ComponentManagerTest extends RenderingTest {
+    constructor(assert) {
+      super(...arguments);
 
-            getContext(component) {
-              return component;
-            },
+      this.registerComponentManager(
+        'basic',
+        EmberObject.extend({
+          capabilities: capabilities('3.4'),
 
-            update() {},
+          createComponent(factory, args) {
+            return factory.create({ args });
           },
-          overrides
-        );
 
-        this.owner.register(`component-manager:${MANAGER_ID}`, options, {
-          singleton: true,
-          instantiate: false,
-        });
-      }
+          updateComponent(component, args) {
+            set(component, 'args', args);
+          },
 
-      // Renders a simple component with a custom component manager and verifies
-      // that properties from the component are accessible from the component's
-      // template.
+          getContext(component) {
+            return component;
+          },
+        })
+      );
+
+      this.registerComponentManager(
+        'instrumented-full',
+        EmberObject.extend({
+          capabilities: capabilities('3.4', {
+            destructor: true,
+            asyncLifecycleCallbacks: true,
+          }),
+
+          createComponent(factory, args) {
+            assert.step('createComponent');
+            return factory.create({ args });
+          },
+
+          updateComponent(component, args) {
+            assert.step('updateComponent');
+            set(component, 'args', args);
+          },
+
+          destroyComponent(component) {
+            assert.step('destroyComponent');
+            component.destroy();
+          },
+
+          getContext(component) {
+            assert.step('getContext');
+            return component;
+          },
+
+          didCreateComponent(component) {
+            assert.step('didCreateComponent');
+            component.didRender();
+          },
+
+          didUpdateComponent(component) {
+            assert.step('didUpdateComponent');
+            component.didUpdate();
+          },
+        })
+      );
+    }
+  }
+
+  moduleFor(
+    'Component Manager - Curly Invocation',
+    class extends ComponentManagerTest {
       ['@test it can render a basic component with custom component manager']() {
-        this.registerCustomComponentManager();
-
-        let ComponentClass = CustomComponent.extend({
-          greeting: 'hello',
-        });
+        let ComponentClass = setComponentManager(
+          'basic',
+          EmberObject.extend({
+            greeting: 'hello',
+          })
+        );
 
         this.registerComponent('foo-bar', {
           template: `<p>{{greeting}} world</p>`,
@@ -62,28 +91,127 @@ if (GLIMMER_CUSTOM_COMPONENT_MANAGER) {
 
         this.render('{{foo-bar}}');
 
-        this.assertHTML(strip`<p>hello world</p>`);
+        this.assertHTML(`<p>hello world</p>`);
       }
 
-      // Tests the custom component manager's ability to override template context
-      // by implementing the getContext hook. Test performs an initial render and
-      // updating render and verifies that output came from the custom context,
-      // not the component instance.
+      ['@test it can have no template context']() {
+        this.registerComponentManager(
+          'pseudo-template-only',
+          EmberObject.extend({
+            capabilities: capabilities('3.4'),
+
+            createComponent() {
+              return null;
+            },
+
+            updateComponent() {},
+
+            getContext() {
+              return null;
+            },
+          })
+        );
+
+        let ComponentClass = setComponentManager('pseudo-template-only', {});
+
+        this.registerComponent('foo-bar', {
+          template: `<p>{{@greeting}} world</p>`,
+          ComponentClass,
+        });
+
+        this.render('{{foo-bar greeting="hello"}}');
+
+        this.assertHTML(`<p>hello world</p>`);
+      }
+
+      ['@test it can discover component manager through inheritance - ES Classes']() {
+        this.registerComponentManager(
+          'test',
+          EmberObject.extend({
+            capabilities: capabilities('3.4'),
+
+            createComponent(factory, args) {
+              let Klass = factory.class;
+              return new Klass(args);
+            },
+
+            updateComponent() {},
+
+            getContext(component) {
+              return component;
+            },
+          })
+        );
+
+        class Base {}
+        setComponentManager('test', Base);
+        class Child extends Base {}
+        class Grandchild extends Child {
+          constructor() {
+            super();
+            this.name = 'grandchild';
+          }
+        }
+
+        this.registerComponent('foo-bar', {
+          template: `{{this.name}}`,
+          ComponentClass: Grandchild,
+        });
+
+        this.render('{{foo-bar}}');
+
+        this.assertHTML(`grandchild`);
+      }
+
+      ['@test it can discover component manager through inheritance - Ember Object']() {
+        let Parent = setComponentManager('basic', EmberObject.extend());
+        let Child = Parent.extend();
+        let Grandchild = Child.extend({
+          init() {
+            this._super(...arguments);
+            this.name = 'grandchild';
+          },
+        });
+
+        this.registerComponent('foo-bar', {
+          template: `{{this.name}}`,
+          ComponentClass: Grandchild,
+        });
+
+        this.render('{{foo-bar}}');
+
+        this.assertHTML(`grandchild`);
+      }
+
       ['@test it can customize the template context']() {
         let customContext = {
           greeting: 'goodbye',
         };
 
-        this.registerCustomComponentManager({
-          getContext() {
-            return customContext;
-          },
-        });
+        this.registerComponentManager(
+          'test',
+          EmberObject.extend({
+            capabilities: capabilities('3.4'),
 
-        let ComponentClass = CustomComponent.extend({
-          greeting: 'hello',
-          count: 1234,
-        });
+            createComponent(factory) {
+              return factory.create();
+            },
+
+            getContext() {
+              return customContext;
+            },
+
+            updateComponent() {},
+          })
+        );
+
+        let ComponentClass = setComponentManager(
+          'test',
+          EmberObject.extend({
+            greeting: 'hello',
+            count: 1234,
+          })
+        );
 
         this.registerComponent('foo-bar', {
           template: `<p>{{greeting}} world {{count}}</p>`,
@@ -92,25 +220,22 @@ if (GLIMMER_CUSTOM_COMPONENT_MANAGER) {
 
         this.render('{{foo-bar}}');
 
-        this.assertHTML(strip`<p>goodbye world </p>`);
+        this.assertHTML(`<p>goodbye world </p>`);
 
         this.runTask(() => set(customContext, 'greeting', 'sayonara'));
 
-        this.assertHTML(strip`<p>sayonara world </p>`);
+        this.assertHTML(`<p>sayonara world </p>`);
       }
 
       ['@test it can set arguments on the component instance']() {
-        this.registerCustomComponentManager({
-          create({ ComponentClass, args }) {
-            return ComponentClass.create({ args });
-          },
-        });
-
-        let ComponentClass = CustomComponent.extend({
-          salutation: computed('args.firstName', 'args.lastName', function() {
-            return this.get('args.firstName') + ' ' + this.get('args.lastName');
-          }),
-        });
+        let ComponentClass = setComponentManager(
+          'basic',
+          EmberObject.extend({
+            salutation: computed('args.named.firstName', 'args.named.lastName', function() {
+              return this.args.named.firstName + ' ' + this.args.named.lastName;
+            }),
+          })
+        );
 
         this.registerComponent('foo-bar', {
           template: `<p>{{salutation}}</p>`,
@@ -119,25 +244,18 @@ if (GLIMMER_CUSTOM_COMPONENT_MANAGER) {
 
         this.render('{{foo-bar firstName="Yehuda" lastName="Katz"}}');
 
-        this.assertHTML(strip`<p>Yehuda Katz</p>`);
+        this.assertHTML(`<p>Yehuda Katz</p>`);
       }
 
       ['@test arguments are updated if they change']() {
-        this.registerCustomComponentManager({
-          create({ ComponentClass, args }) {
-            return ComponentClass.create({ args });
-          },
-
-          update(component, args) {
-            set(component, 'args', args);
-          },
-        });
-
-        let ComponentClass = CustomComponent.extend({
-          salutation: computed('args.firstName', 'args.lastName', function() {
-            return this.get('args.firstName') + ' ' + this.get('args.lastName');
-          }),
-        });
+        let ComponentClass = setComponentManager(
+          'basic',
+          EmberObject.extend({
+            salutation: computed('args.named.firstName', 'args.named.lastName', function() {
+              return this.args.named.firstName + ' ' + this.args.named.lastName;
+            }),
+          })
+        );
 
         this.registerComponent('foo-bar', {
           template: `<p>{{salutation}}</p>`,
@@ -149,7 +267,7 @@ if (GLIMMER_CUSTOM_COMPONENT_MANAGER) {
           lastName: 'Katz',
         });
 
-        this.assertHTML(strip`<p>Yehuda Katz</p>`);
+        this.assertHTML(`<p>Yehuda Katz</p>`);
 
         this.runTask(() =>
           setProperties(this.context, {
@@ -158,121 +276,234 @@ if (GLIMMER_CUSTOM_COMPONENT_MANAGER) {
           })
         );
 
-        this.assertHTML(strip`<p>Chad Hietala</p>`);
+        this.assertHTML(`<p>Chad Hietala</p>`);
       }
 
-      [`@test custom components appear in parent view's childViews array`](assert) {
-        this.registerCustomComponentManager();
+      ['@test it can opt-in to running destructor'](assert) {
+        this.registerComponentManager(
+          'test',
+          EmberObject.extend({
+            capabilities: capabilities('3.4', {
+              destructor: true,
+            }),
 
-        let ComponentClass = CustomComponent.extend({
-          isCustomComponent: true,
-        });
-
-        this.registerComponent('turbo-component', {
-          template: `<p>turbo</p>`,
-          ComponentClass,
-        });
-
-        this.registerComponent('curly-component', {
-          template: `<div>curly</div>`,
-          ComponentClass: Component.extend({
-            isClassicComponent: true,
-          }),
-        });
-
-        this.render('{{#if showTurbo}}{{turbo-component}}{{/if}} {{curly-component}}', {
-          showTurbo: true,
-        });
-
-        let { childViews } = this.context;
-
-        assert.equal(childViews.length, 2, 'root component has two child views');
-        assert.ok(childViews[0].isCustomComponent, 'first child view is custom component');
-        assert.ok(childViews[1].isClassicComponent, 'second child view is classic component');
-
-        this.runTask(() => set(this.context, 'showTurbo', false));
-
-        // childViews array is not live and must be re-fetched after changes
-        childViews = this.context.childViews;
-
-        assert.equal(
-          childViews.length,
-          1,
-          "turbo component is removed from parent's child views array"
-        );
-        assert.ok(childViews[0].isClassicComponent, 'first child view is classic component');
-
-        this.runTask(() => set(this.context, 'showTurbo', true));
-
-        childViews = this.context.childViews;
-        assert.equal(childViews.length, 2, 'root component has two child views');
-        assert.ok(childViews[0].isClassicComponent, 'first child view is classic component');
-        assert.ok(childViews[1].isCustomComponent, 'second child view is custom component');
-      }
-
-      ['@test can invoke classic components in custom components'](assert) {
-        this.registerCustomComponentManager();
-
-        let ComponentClass = CustomComponent.extend({
-          isCustomComponent: true,
-        });
-
-        this.registerComponent('turbo-component', {
-          template: `<p>turbo</p>{{curly-component}}`,
-          ComponentClass,
-        });
-
-        let classicComponent;
-
-        this.registerComponent('curly-component', {
-          template: `<div>curly</div>`,
-          ComponentClass: Component.extend({
-            init() {
-              this._super(...arguments);
-              classicComponent = this;
+            createComponent(factory) {
+              assert.step('createComponent');
+              return factory.create();
             },
 
-            isClassicComponent: true,
-          }),
-        });
+            getContext(component) {
+              return component;
+            },
 
-        this.render('{{turbo-component}}');
+            updateComponent() {},
 
-        this.assertElement(this.firstChild, {
-          tagName: 'P',
-          content: 'turbo',
-        });
-
-        this.assertComponentElement(this.firstChild.nextSibling, {
-          tagName: 'DIV',
-          content: '<div>curly</div>',
-        });
-
-        let { childViews } = this.context;
-
-        assert.equal(childViews.length, 1, 'root component has one child view');
-        assert.ok(childViews[0].isCustomComponent, 'root child view is custom component');
-
-        let customComponent = childViews[0];
-
-        assert.strictEqual(
-          customComponent.childViews,
-          undefined,
-          'custom component does not have childViews property'
+            destroyComponent(component) {
+              assert.step('destroyComponent');
+              component.destroy();
+            },
+          })
         );
 
-        childViews = getChildViews(customComponent);
-        assert.equal(childViews.length, 1, 'custom component has one child view');
-        assert.ok(
-          childViews[0].isClassicComponent,
-          'custom component child view is classic component'
+        let ComponentClass = setComponentManager(
+          'test',
+          EmberObject.extend({
+            greeting: 'hello',
+            destroy() {
+              assert.step('component.destroy()');
+              this._super(...arguments);
+            },
+          })
         );
 
-        assert.ok(
-          classicComponent.parentView.isCustomComponent,
-          `classic component's parentView is custom component`
+        this.registerComponent('foo-bar', {
+          template: `<p>{{greeting}} world</p>`,
+          ComponentClass,
+        });
+
+        this.render('{{#if show}}{{foo-bar}}{{/if}}', { show: true });
+
+        this.assertHTML(`<p>hello world</p>`);
+
+        this.runTask(() => this.context.set('show', false));
+
+        this.assertText('');
+
+        assert.verifySteps(['createComponent', 'destroyComponent', 'component.destroy()']);
+      }
+
+      ['@test it can opt-in to running async lifecycle hooks'](assert) {
+        this.registerComponentManager(
+          'test',
+          EmberObject.extend({
+            capabilities: capabilities('3.4', {
+              asyncLifecycleCallbacks: true,
+            }),
+
+            createComponent(factory, args) {
+              assert.step('createComponent');
+              return factory.create({ args });
+            },
+
+            updateComponent(component, args) {
+              assert.step('updateComponent');
+              set(component, 'args', args);
+            },
+
+            destroyComponent(component) {
+              assert.step('destroyComponent');
+              component.destroy();
+            },
+
+            getContext(component) {
+              assert.step('getContext');
+              return component;
+            },
+
+            didCreateComponent() {
+              assert.step('didCreateComponent');
+            },
+
+            didUpdateComponent() {
+              assert.step('didUpdateComponent');
+            },
+          })
         );
+
+        let ComponentClass = setComponentManager(
+          'test',
+          EmberObject.extend({
+            greeting: 'hello',
+          })
+        );
+
+        this.registerComponent('foo-bar', {
+          template: `<p>{{greeting}} {{@name}}</p>`,
+          ComponentClass,
+        });
+
+        this.render('{{foo-bar name=name}}', { name: 'world' });
+
+        this.assertHTML(`<p>hello world</p>`);
+        assert.verifySteps(['createComponent', 'getContext', 'didCreateComponent']);
+
+        this.runTask(() => this.context.set('name', 'max'));
+        this.assertHTML(`<p>hello max</p>`);
+        assert.verifySteps(['updateComponent', 'didUpdateComponent']);
       }
     }
   );
+
+  if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
+    moduleFor(
+      'Component Manager - Angle Invocation',
+      class extends ComponentManagerTest {
+        ['@test it can render a basic component with custom component manager']() {
+          let ComponentClass = setComponentManager(
+            'basic',
+            EmberObject.extend({
+              greeting: 'hello',
+            })
+          );
+
+          this.registerComponent('foo-bar', {
+            template: `<p>{{greeting}} world</p>`,
+            ComponentClass,
+          });
+
+          this.render('<FooBar />');
+
+          this.assertHTML(`<p>hello world</p>`);
+        }
+
+        ['@test it can set arguments on the component instance']() {
+          let ComponentClass = setComponentManager(
+            'basic',
+            EmberObject.extend({
+              salutation: computed('args.named.firstName', 'args.named.lastName', function() {
+                return this.args.named.firstName + ' ' + this.args.named.lastName;
+              }),
+            })
+          );
+
+          this.registerComponent('foo-bar', {
+            template: `<p>{{salutation}}</p>`,
+            ComponentClass,
+          });
+
+          this.render('<FooBar @firstName="Yehuda" @lastName="Katz" />');
+
+          this.assertHTML(`<p>Yehuda Katz</p>`);
+        }
+
+        ['@test it can pass attributes']() {
+          let ComponentClass = setComponentManager('basic', EmberObject.extend());
+
+          this.registerComponent('foo-bar', {
+            template: `<p ...attributes>Hello world!</p>`,
+            ComponentClass,
+          });
+
+          this.render('<FooBar data-test="foo" />');
+
+          this.assertHTML(`<p data-test="foo">Hello world!</p>`);
+        }
+
+        ['@test arguments are updated if they change']() {
+          let ComponentClass = setComponentManager(
+            'basic',
+            EmberObject.extend({
+              salutation: computed('args.named.firstName', 'args.named.lastName', function() {
+                return this.args.named.firstName + ' ' + this.args.named.lastName;
+              }),
+            })
+          );
+
+          this.registerComponent('foo-bar', {
+            template: `<p>{{salutation}}</p>`,
+            ComponentClass,
+          });
+
+          this.render('<FooBar @firstName={{firstName}} @lastName={{lastName}} />', {
+            firstName: 'Yehuda',
+            lastName: 'Katz',
+          });
+
+          this.assertHTML(`<p>Yehuda Katz</p>`);
+
+          this.runTask(() =>
+            setProperties(this.context, {
+              firstName: 'Chad',
+              lastName: 'Hietala',
+            })
+          );
+
+          this.assertHTML(`<p>Chad Hietala</p>`);
+        }
+
+        ['@test updating attributes triggers didUpdateComponent'](assert) {
+          let ComponentClass = setComponentManager(
+            'instrumented-full',
+            EmberObject.extend({
+              didRender() {},
+              didUpdate() {},
+            })
+          );
+
+          this.registerComponent('foo-bar', {
+            template: `<p ...attributes>Hello world!</p>`,
+            ComponentClass,
+          });
+
+          this.render('<FooBar data-test={{value}} />', { value: 'foo' });
+
+          this.assertHTML(`<p data-test="foo">Hello world!</p>`);
+          assert.verifySteps(['createComponent', 'getContext', 'didCreateComponent']);
+
+          this.runTask(() => this.context.set('value', 'bar'));
+          assert.verifySteps(['didUpdateComponent']);
+        }
+      }
+    );
+  }
 }

--- a/packages/ember-owner/index.ts
+++ b/packages/ember-owner/index.ts
@@ -13,7 +13,7 @@ export interface FactoryClass {
   positionalParams?: string | string[] | undefined | null;
 }
 
-export interface Factory<T, C extends FactoryClass | object> {
+export interface Factory<T, C extends FactoryClass | object = FactoryClass> {
   class?: C;
   fullName?: string;
   normalizedName?: string;

--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -93,7 +93,8 @@ import {
 import {
   Checkbox,
   Component,
-  componentManager,
+  setComponentManager,
+  capabilities,
   escapeExpression,
   getTemplates,
   Helper,
@@ -516,7 +517,8 @@ Ember.Checkbox = Checkbox;
 Ember.TextField = TextField;
 Ember.TextArea = TextArea;
 Ember.LinkComponent = LinkComponent;
-Ember._setComponentManager = componentManager;
+Ember._setComponentManager = setComponentManager;
+Ember._componentManagerCapabilities = capabilities;
 Ember.Handlebars = {
   template,
   Utils: {

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -195,7 +195,8 @@ let allExports = [
   ['HTMLBars.template', 'ember-glimmer', 'template'],
   ['Handlebars.Utils.escapeExpression', 'ember-glimmer', 'escapeExpression'],
   ['String.htmlSafe', 'ember-glimmer', 'htmlSafe'],
-  ['_setComponentManager', 'ember-glimmer', 'componentManager'],
+  ['_setComponentManager', 'ember-glimmer', 'setComponentManager'],
+  ['_componentManagerCapabilities', 'ember-glimmer', 'capabilities'],
 
   // ember-runtime
   ['A', 'ember-runtime'],

--- a/packages/internal-test-helpers/lib/test-cases/abstract-rendering.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract-rendering.js
@@ -170,6 +170,11 @@ export default class AbstractRenderingTestCase extends AbstractTestCase {
     }
   }
 
+  registerComponentManager(name, manager) {
+    let owner = this.env.owner || this.owner;
+    owner.register(`component-manager:${name}`, manager);
+  }
+
   registerTemplate(name, template) {
     let { owner } = this;
     if (typeof template === 'string') {


### PR DESCRIPTION
* Removes view hierarchy updating (not included in RFC)
* Updates custom manager hook method names to match final RFC
* Add `capabilities` system (still very basic)
* Disentangle curly component manager from custom component manager.
* Add optional capabilities (`destructor` / `asyncLifecycleCallbacks`)
* Add temporary global (private on the global, public via modules API)
  for `capabilities`
* Migrate `setComponentManager` to use `WeakMap`'s instead of mutation

(paired with @chancancode on some of the gnarly typescripting)

---

TODO:

- [x] Add more tests based on the examples from the RFC
- [x] Add tests using angle bracket invocation

Future TODO:

- [ ] Determine impact / APIs needed for proper ember-inspector support