### PR TITLE
[BUGFIX release] bring back isObject guard for ember-utils/is_proxy

### DIFF
--- a/packages/ember-utils/lib/is_proxy.ts
+++ b/packages/ember-utils/lib/is_proxy.ts
@@ -4,7 +4,10 @@ import WeakSet from './weak_set';
 const PROXIES = new WeakSet();
 
 export function isProxy(object: any | undefined | null) {
-  return PROXIES.has(object);
+  if (isObject(object)) {
+    return PROXIES.has(object);
+  }
+  return false;
 }
 
 export function setProxy(object: object) {

--- a/packages/ember-utils/tests/is_proxy_test.js
+++ b/packages/ember-utils/tests/is_proxy_test.js
@@ -1,0 +1,18 @@
+import { isProxy, setProxy } from '..';
+import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+
+moduleFor(
+  'ember-utils isProxy',
+  class extends AbstractTestCase {
+    ['@test basic'](assert) {
+      let proxy = {};
+      setProxy(proxy);
+
+      assert.equal(isProxy(proxy), true);
+
+      assert.equal(isProxy({}), false);
+      assert.equal(isProxy(undefined), false);
+      assert.equal(isProxy(null), false);
+    }
+  }
+);


### PR DESCRIPTION
`WeakSet.has` throws `TypeError` if argument is not an object:
https://www.ecma-international.org/ecma-262/6.0/#sec-weakset.prototype.has

While recent Chrome versions just returns `false`.