### PR TITLE
Ensure tests are run against Chrome 41

### DIFF
--- a/testem.dist.js
+++ b/testem.dist.js
@@ -72,6 +72,27 @@ module.exports = {
       ],
       protocol: 'browser',
     },
+    /* Chrome 41 for Googlebot as outlined by:
+     * https://developers.google.com/search/docs/guides/rendering
+     */
+    BS_Chrome_Googlebot: {
+      exe: 'node_modules/.bin/browserstack-launch',
+      args: [
+        '--os',
+        'Windows',
+        '--osv',
+        '10',
+        '--b',
+        'chrome',
+        '--bv',
+        '41.0',
+        '-t',
+        '1200',
+        '--u',
+        '<url>',
+      ],
+      protocol: 'browser',
+    },
     BS_Firefox_Current: {
       exe: 'node_modules/.bin/browserstack-launch',
       args: [


### PR DESCRIPTION
A recent error in a wrapper around WeakSet caused an issue that broke googlebot.  Chrome latest passed and was undisturbed.  This issue has since been resolved by:

https://github.com/emberjs/ember.js/commit/6346e827a67d0fab8ab02b312bcebca72e2c71d1#diff-ce0053d22123fcbc623fdbd0bd18c5f2

But Googlebot is considerably behind latest Chrome now.  And I'd wager that many people do intend for Googlebot to work.

I really just wanted to start a discussion to determine whether or not this is something that'd be valuable for us to include in our normal testing story.