### PR TITLE
Test value parameter does not have to be a String

### DIFF
--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -727,7 +727,7 @@ const ArrayMixin = Mixin.create(Enumerable, {
 
     @method rejectBy
     @param {String} key the property to test
-    @param {String} [value] optional value to test against.
+    @param {*} [value] optional value to test against.
     @return {Array} rejected array
     @public
   */


### PR DESCRIPTION
The doc comments suggest that the test value parameter has to be a String, but this does not match the implementation.

Have also updated type definition here https://github.com/DefinitelyTyped/DefinitelyTyped/pull/26632