### PR TITLE
[WIP]  [BACKPORT 3.2] Make CoreObject rely more on ES2015 class features and interop better

### DIFF
--- a/packages/ember-application/lib/system/engine.js
+++ b/packages/ember-application/lib/system/engine.js
@@ -448,11 +448,9 @@ Engine.reopenClass({
   @return {*} the resolved value for a given lookup
 */
 function resolverFor(namespace) {
-  let ResolverClass = namespace.get('Resolver') || DefaultResolver;
-
-  return ResolverClass.create({
-    namespace,
-  });
+  let ResolverClass = get(namespace, 'Resolver') || DefaultResolver;
+  let props = { namespace };
+  return ResolverClass.create(props);
 }
 
 function buildInitializerMethod(bucketName, humanName) {

--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -10,23 +10,6 @@ import validateType from '../utils/validate-type';
 import { getTemplate } from 'ember-glimmer';
 import { DEBUG } from 'ember-env-flags';
 
-export const Resolver = EmberObject.extend({
-  /*
-    This will be set to the Application instance when it is
-    created.
-
-    @property namespace
-  */
-  namespace: null,
-  normalize: null, // required
-  resolve: null, // required
-  parseName: null, // required
-  lookupDescription: null, // required
-  makeToString: null, // required
-  resolveOther: null, // required
-  _logLookup: null, // required
-});
-
 /**
   The DefaultResolver defines the default lookup rules to resolve
   container lookups before consulting the container for registered
@@ -96,7 +79,21 @@ export const Resolver = EmberObject.extend({
   @public
 */
 
-const DefaultResolver = EmberObject.extend({
+class DefaultResolver extends EmberObject {
+  constructor(props) {
+    if (props == null) {
+      throw new Error('create missing props');
+    }
+    super(props);
+  }
+
+  static create(props) {
+    if (props == null) {
+      throw new Error('static create missing props');
+    }
+    return super.create(props);
+  }
+
   /**
     This will be set to the Application instance when it is
     created.
@@ -104,11 +101,13 @@ const DefaultResolver = EmberObject.extend({
     @property namespace
     @public
   */
-  namespace: null,
 
   init() {
+    if (this.namespace == null) {
+      throw new Error('init missing namespace');
+    }
     this._parseNameCache = dictionary(null);
-  },
+  }
 
   normalize(fullName) {
     let [type, name] = fullName.split(':');
@@ -127,7 +126,7 @@ const DefaultResolver = EmberObject.extend({
     } else {
       return fullName;
     }
-  },
+  }
 
   /**
     This method is called via the container's resolver method.
@@ -161,7 +160,7 @@ const DefaultResolver = EmberObject.extend({
     }
 
     return resolved;
-  },
+  }
 
   /**
     Convert the string name of the form 'type:name' to
@@ -177,7 +176,7 @@ const DefaultResolver = EmberObject.extend({
     return (
       this._parseNameCache[fullName] || (this._parseNameCache[fullName] = this._parseName(fullName))
     );
-  },
+  }
 
   _parseName(fullName) {
     let [type, fullNameWithoutType] = fullName.split(':');
@@ -215,7 +214,7 @@ const DefaultResolver = EmberObject.extend({
       root,
       resolveMethodName: `resolve${resolveMethodName}`,
     };
-  },
+  }
 
   /**
     Returns a human-readable description for a fullName. Used by the
@@ -242,11 +241,11 @@ const DefaultResolver = EmberObject.extend({
     }
 
     return description;
-  },
+  }
 
   makeToString(factory) {
     return factory.toString();
-  },
+  }
 
   /**
     Given a parseName object (output from `parseName`), apply
@@ -263,7 +262,7 @@ const DefaultResolver = EmberObject.extend({
     } else {
       parsedName.name = parsedName.name.replace(/\./g, '_');
     }
-  },
+  }
   /**
     Look up the template in Ember.TEMPLATES
 
@@ -276,7 +275,7 @@ const DefaultResolver = EmberObject.extend({
     let templateName = parsedName.fullNameWithoutType.replace(/\./g, '/');
 
     return getTemplate(templateName) || getTemplate(StringUtils.decamelize(templateName));
-  },
+  }
 
   /**
     Lookup the view using `resolveOther`
@@ -289,7 +288,7 @@ const DefaultResolver = EmberObject.extend({
   resolveView(parsedName) {
     this.useRouterNaming(parsedName);
     return this.resolveOther(parsedName);
-  },
+  }
 
   /**
     Lookup the controller using `resolveOther`
@@ -302,7 +301,7 @@ const DefaultResolver = EmberObject.extend({
   resolveController(parsedName) {
     this.useRouterNaming(parsedName);
     return this.resolveOther(parsedName);
-  },
+  }
   /**
     Lookup the route using `resolveOther`
 
@@ -314,7 +313,7 @@ const DefaultResolver = EmberObject.extend({
   resolveRoute(parsedName) {
     this.useRouterNaming(parsedName);
     return this.resolveOther(parsedName);
-  },
+  }
 
   /**
     Lookup the model on the Application namespace
@@ -329,7 +328,7 @@ const DefaultResolver = EmberObject.extend({
     let factory = get(parsedName.root, className);
 
     return factory;
-  },
+  }
   /**
     Look up the specified object (from parsedName) on the appropriate
     namespace (usually on the Application)
@@ -341,7 +340,7 @@ const DefaultResolver = EmberObject.extend({
   */
   resolveHelper(parsedName) {
     return this.resolveOther(parsedName);
-  },
+  }
   /**
     Look up the specified object (from parsedName) on the appropriate
     namespace (usually on the Application)
@@ -355,12 +354,12 @@ const DefaultResolver = EmberObject.extend({
     let className = StringUtils.classify(parsedName.name) + StringUtils.classify(parsedName.type);
     let factory = get(parsedName.root, className);
     return factory;
-  },
+  }
 
   resolveMain(parsedName) {
     let className = StringUtils.classify(parsedName.type);
     return get(parsedName.root, className);
-  },
+  }
 
   /**
     Used to iterate all items of a given type.
@@ -387,7 +386,7 @@ const DefaultResolver = EmberObject.extend({
     }
 
     return known;
-  },
+  }
 
   /**
     Converts provided name from the backing namespace into a container lookup name.
@@ -408,30 +407,28 @@ const DefaultResolver = EmberObject.extend({
     let dasherizedName = StringUtils.dasherize(namePrefix);
 
     return `${type}:${dasherizedName}`;
-  },
-});
+  }
+}
 
 export default DefaultResolver;
 
 if (DEBUG) {
-  DefaultResolver.reopen({
-    /**
+  /**
       @method _logLookup
       @param {Boolean} found
       @param {Object} parsedName
       @private
     */
-    _logLookup(found, parsedName) {
-      let symbol = found ? '[✓]' : '[ ]';
+  DefaultResolver.prototype._logLookup = function(found, parsedName) {
+    let symbol = found ? '[✓]' : '[ ]';
 
-      let padding;
-      if (parsedName.fullName.length > 60) {
-        padding = '.';
-      } else {
-        padding = new Array(60 - parsedName.fullName.length).join('.');
-      }
+    let padding;
+    if (parsedName.fullName.length > 60) {
+      padding = '.';
+    } else {
+      padding = new Array(60 - parsedName.fullName.length).join('.');
+    }
 
-      info(symbol, parsedName.fullName, padding, this.lookupDescription(parsedName.fullName));
-    },
-  });
+    info(symbol, parsedName.fullName, padding, this.lookupDescription(parsedName.fullName));
+  };
 }

--- a/packages/ember-metal/lib/meta_listeners.js
+++ b/packages/ember-metal/lib/meta_listeners.js
@@ -26,7 +26,7 @@ export const protoMethods = {
       this._listeners = [];
     }
     let pointer = this.parent;
-    while (pointer !== undefined) {
+    while (pointer !== null) {
       let listeners = pointer._listeners;
       if (listeners !== undefined) {
         this._listeners = this._listeners.concat(listeners);
@@ -41,7 +41,7 @@ export const protoMethods = {
 
   removeFromListeners(eventName, target, method) {
     let pointer = this;
-    while (pointer !== undefined) {
+    while (pointer !== null) {
       let listeners = pointer._listeners;
       if (listeners !== undefined) {
         for (let index = listeners.length - 4; index >= 0; index -= 4) {
@@ -71,7 +71,7 @@ export const protoMethods = {
   matchingListeners(eventName) {
     let pointer = this;
     let result;
-    while (pointer !== undefined) {
+    while (pointer !== null) {
       let listeners = pointer._listeners;
       if (listeners !== undefined) {
         for (let index = 0; index < listeners.length; index += 4) {

--- a/packages/ember-runtime/lib/ext/function.js
+++ b/packages/ember-runtime/lib/ext/function.js
@@ -4,175 +4,151 @@
 
 import { ENV } from 'ember-environment';
 import { on, computed, observer } from 'ember-metal';
-import { assert } from 'ember-debug';
-
-const FunctionPrototype = Function.prototype;
 
 if (ENV.EXTEND_PROTOTYPES.Function) {
-  /**
-    The `property` extension of Javascript's Function prototype is available
-    when `EmberENV.EXTEND_PROTOTYPES` or `EmberENV.EXTEND_PROTOTYPES.Function` is
-    `true`, which is the default.
+  Object.defineProperties(Function.prototype, {
+    /**
+      The `property` extension of Javascript's Function prototype is available
+      when `EmberENV.EXTEND_PROTOTYPES` or `EmberENV.EXTEND_PROTOTYPES.Function` is
+      `true`, which is the default.
 
-    Computed properties allow you to treat a function like a property:
+      Computed properties allow you to treat a function like a property:
 
-    ```app/utils/president.js
-    import EmberObject from '@ember/object';
+      ```app/utils/president.js
+      import EmberObject from '@ember/object';
 
-    export default EmberObject.extend({
-      firstName: '',
-      lastName:  '',
+      export default EmberObject.extend({
+        firstName: '',
+        lastName:  '',
 
-      fullName: function() {
-        return this.get('firstName') + ' ' + this.get('lastName');
-      }.property() // Call this flag to mark the function as a property
-    });
-    ```
+        fullName: function() {
+          return this.get('firstName') + ' ' + this.get('lastName');
+        }.property() // Call this flag to mark the function as a property
+      });
+      ```
 
-    ```javascript
-    let president = President.create({
-      firstName: 'Barack',
-      lastName: 'Obama'
-    });
+      ```javascript
+      let president = President.create({
+        firstName: 'Barack',
+        lastName: 'Obama'
+      });
 
-    president.get('fullName'); // 'Barack Obama'
-    ```
+      president.get('fullName'); // 'Barack Obama'
+      ```
 
-    Treating a function like a property is useful because they can work with
-    bindings, just like any other property.
+      Treating a function like a property is useful because they can work with
+      bindings, just like any other property.
 
-    Many computed properties have dependencies on other properties. For
-    example, in the above example, the `fullName` property depends on
-    `firstName` and `lastName` to determine its value. You can tell Ember
-    about these dependencies like this:
+      Many computed properties have dependencies on other properties. For
+      example, in the above example, the `fullName` property depends on
+      `firstName` and `lastName` to determine its value. You can tell Ember
+      about these dependencies like this:
 
-    ```app/utils/president.js
-    import EmberObject from '@ember/object';
+      ```app/utils/president.js
+      import EmberObject from '@ember/object';
 
-    export default EmberObject.extend({
-      firstName: '',
-      lastName:  '',
+      export default EmberObject.extend({
+        firstName: '',
+        lastName:  '',
 
-      fullName: function() {
-        return this.get('firstName') + ' ' + this.get('lastName');
+        fullName: function() {
+          return this.get('firstName') + ' ' + this.get('lastName');
 
-        // Tell Ember.js that this computed property depends on firstName
-        // and lastName
-      }.property('firstName', 'lastName')
-    });
-    ```
+          // Tell Ember.js that this computed property depends on firstName
+          // and lastName
+        }.property('firstName', 'lastName')
+      });
+      ```
 
-    Make sure you list these dependencies so Ember knows when to update
-    bindings that connect to a computed property. Changing a dependency
-    will not immediately trigger an update of the computed property, but
-    will instead clear the cache so that it is updated when the next `get`
-    is called on the property.
+      Make sure you list these dependencies so Ember knows when to update
+      bindings that connect to a computed property. Changing a dependency
+      will not immediately trigger an update of the computed property, but
+      will instead clear the cache so that it is updated when the next `get`
+      is called on the property.
 
-    See [ComputedProperty](/api/ember/release/classes/ComputedProperty), [@ember/object/computed](/api/ember/release/classes/@ember%2Fobject%2Fcomputed).
+      See [ComputedProperty](/api/ember/release/classes/ComputedProperty), [@ember/object/computed](/api/ember/release/classes/@ember%2Fobject%2Fcomputed).
 
-    @method property
-    @for Function
-    @public
-  */
-  Object.defineProperty(FunctionPrototype, 'property', {
-    configurable: true,
-    enumerable: false,
-    writable: true,
-    value: function() {
-      return computed(...arguments, this);
+      @method property
+      @for Function
+      @public
+    */
+    property: {
+      configurable: true,
+      enumerable: false,
+      writable: true,
+      value: function() {
+        return computed(...arguments, this);
+      },
     },
-  });
 
-  /**
-    The `observes` extension of Javascript's Function prototype is available
-    when `EmberENV.EXTEND_PROTOTYPES` or `EmberENV.EXTEND_PROTOTYPES.Function` is
-    true, which is the default.
+    /**
+      The `observes` extension of Javascript's Function prototype is available
+      when `EmberENV.EXTEND_PROTOTYPES` or `EmberENV.EXTEND_PROTOTYPES.Function` is
+      true, which is the default.
 
-    You can observe property changes simply by adding the `observes`
-    call to the end of your method declarations in classes that you write.
-    For example:
+      You can observe property changes simply by adding the `observes`
+      call to the end of your method declarations in classes that you write.
+      For example:
 
-    ```javascript
-    import EmberObject from '@ember/object';
+      ```javascript
+      import EmberObject from '@ember/object';
 
-    EmberObject.extend({
-      valueObserver: function() {
-        // Executes whenever the "value" property changes
-      }.observes('value')
-    });
-    ```
+      EmberObject.extend({
+        valueObserver: function() {
+          // Executes whenever the "value" property changes
+        }.observes('value')
+      });
+      ```
 
-    In the future this method may become asynchronous.
+      In the future this method may become asynchronous.
 
-    See `observer`.
+      See `observer`.
 
-    @method observes
-    @for Function
-    @public
-  */
-  Object.defineProperty(FunctionPrototype, 'observes', {
-    configurable: true,
-    enumerable: false,
-    writable: true,
-    value: function() {
-      return observer(...arguments, this);
+      @method observes
+      @for Function
+      @public
+    */
+    observes: {
+      configurable: true,
+      enumerable: false,
+      writable: true,
+      value: function() {
+        return observer(...arguments, this);
+      },
     },
-  });
 
-  Object.defineProperty(FunctionPrototype, '_observesImmediately', {
-    configurable: true,
-    enumerable: false,
-    writable: true,
-    value: function() {
-      assert(
-        'Immediate observers must observe internal properties only, ' +
-          'not properties on other objects.',
-        function checkIsInternalProperty() {
-          for (let i = 0; i < arguments.length; i++) {
-            if (arguments[i].indexOf('.') !== -1) {
-              return false;
-            }
-          }
-          return true;
-        }
-      );
+    /**
+      The `on` extension of Javascript's Function prototype is available
+      when `EmberENV.EXTEND_PROTOTYPES` or `EmberENV.EXTEND_PROTOTYPES.Function` is
+      true, which is the default.
 
-      // observes handles property expansion
-      return this.observes(...arguments);
-    },
-  });
+      You can listen for events simply by adding the `on` call to the end of
+      your method declarations in classes or mixins that you write. For example:
 
-  /**
-    The `on` extension of Javascript's Function prototype is available
-    when `EmberENV.EXTEND_PROTOTYPES` or `EmberENV.EXTEND_PROTOTYPES.Function` is
-    true, which is the default.
+      ```javascript
+      import Mixin from '@ember/mixin';
 
-    You can listen for events simply by adding the `on` call to the end of
-    your method declarations in classes or mixins that you write. For example:
+      Mixin.create({
+        doSomethingWithElement: function() {
+          // Executes whenever the "didInsertElement" event fires
+        }.on('didInsertElement')
+      });
+      ```
 
-    ```javascript
-    import Mixin from '@ember/mixin';
+      See `@ember/object/evented/on`.
 
-    Mixin.create({
-      doSomethingWithElement: function() {
-        // Executes whenever the "didInsertElement" event fires
-      }.on('didInsertElement')
-    });
-    ```
+      @method on
+      @for Function
+      @public
+    */
 
-    See `@ember/object/evented/on`.
-
-    @method on
-    @for Function
-    @public
-  */
-
-  Object.defineProperty(FunctionPrototype, 'on', {
-    configurable: true,
-    enumerable: false,
-    writable: true,
-    value: function() {
-      return on(...arguments, this);
+    on: {
+      configurable: true,
+      enumerable: false,
+      writable: true,
+      value: function() {
+        return on(...arguments, this);
+      },
     },
   });
 }

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -12,6 +12,7 @@ import {
   setName,
   makeArray,
   HAS_NATIVE_PROXY,
+  WeakSet,
   isInternalSymbol,
 } from 'ember-utils';
 import {
@@ -19,15 +20,14 @@ import {
   descriptorFor,
   meta,
   peekMeta,
+  schedule,
+  deleteMeta,
   finishChains,
   sendEvent,
   Mixin,
   defineProperty,
   ComputedProperty,
   InjectedProperty,
-  schedule,
-  deleteMeta,
-  descriptor,
   classToString,
 } from 'ember-metal';
 import ActionHandler from '../mixins/action_handler';
@@ -39,277 +39,197 @@ import { ENV } from 'ember-environment';
 const applyMixin = Mixin._apply;
 const reopen = Mixin.prototype.reopen;
 
-function makeCtor(base) {
-  // Note: avoid accessing any properties on the object since it makes the
-  // method a lot faster. This is glue code so we want it to be as fast as
-  // possible.
+const wasApplied = new WeakSet();
 
-  let wasApplied = false;
-  let Class;
+const factoryMap = new WeakMap();
 
-  if (base) {
-    Class = class extends base {
-      constructor(properties) {
-        if (!wasApplied) {
-          Class.proto(); // prepare prototype...
-        }
-
-        super(properties);
-      }
-    };
-  } else {
-    let initFactory;
-    Class = class {
-      constructor(properties) {
-        if (!wasApplied) {
-          Class.proto(); // prepare prototype...
-        }
-
-        let self = this;
-
-        if (initFactory !== void 0) {
-          FACTORY_FOR.set(this, initFactory);
-          initFactory = void 0;
-        }
-
-        let beforeInitCalled; // only used in debug builds to enable the proxy trap
-
-        // using DEBUG here to avoid the extraneous variable when not needed
-        if (DEBUG) {
-          beforeInitCalled = true;
-        }
-
-        if (DEBUG && HAS_NATIVE_PROXY && typeof self.unknownProperty === 'function') {
-          let messageFor = (obj, property) => {
-            return (
-              `You attempted to access the \`${String(property)}\` property (of ${obj}).\n` +
-              `Since Ember 3.1, this is usually fine as you no longer need to use \`.get()\`\n` +
-              `to access computed properties. However, in this case, the object in question\n` +
-              `is a special kind of Ember object (a proxy). Therefore, it is still necessary\n` +
-              `to use \`.get('${String(property)}')\` in this case.\n\n` +
-              `If you encountered this error because of third-party code that you don't control,\n` +
-              `there is more information at https://github.com/emberjs/ember.js/issues/16148, and\n` +
-              `you can help us improve this error message by telling us more about what happened in\n` +
-              `this situation.`
-            );
-          };
-
-          /* globals Proxy Reflect */
-          self = new Proxy(this, {
-            get(target, property, receiver) {
-              if (property === PROXY_CONTENT) {
-                return target;
-              } else if (
-                beforeInitCalled ||
-                typeof property === 'symbol' ||
-                isInternalSymbol(property) ||
-                property === 'toJSON' ||
-                property === 'toString' ||
-                property === 'toStringExtension' ||
-                property === 'didDefineProperty' ||
-                property === 'willWatchProperty' ||
-                property === 'didUnwatchProperty' ||
-                property === 'didAddListener' ||
-                property === 'didRemoveListener' ||
-                property === 'isDescriptor' ||
-                property === '_onLookup' ||
-                property in target
-              ) {
-                return Reflect.get(target, property, receiver);
-              }
-
-              let value = target.unknownProperty.call(receiver, property);
-
-              if (typeof value !== 'function') {
-                assert(messageFor(receiver, property), value === undefined || value === null);
-              }
-            },
-          });
-
-          FACTORY_FOR.set(self, FACTORY_FOR.get(this));
-        }
-
-        let m = meta(self);
-        let proto = m.proto;
-        m.proto = self;
-
-        if (properties !== undefined) {
-          assert(
-            'EmberObject.create only accepts objects.',
-            typeof properties === 'object' && properties !== null
-          );
-
-          assert(
-            'EmberObject.create no longer supports mixing in other ' +
-              'definitions, use .extend & .create separately instead.',
-            !(properties instanceof Mixin)
-          );
-
-          let concatenatedProperties = self.concatenatedProperties;
-          let mergedProperties = self.mergedProperties;
-          let hasConcatenatedProps =
-            concatenatedProperties !== undefined && concatenatedProperties.length > 0;
-          let hasMergedProps = mergedProperties !== undefined && mergedProperties.length > 0;
-
-          let keyNames = Object.keys(properties);
-
-          for (let i = 0; i < keyNames.length; i++) {
-            let keyName = keyNames[i];
-            let value = properties[keyName];
-
-            if (ENV._ENABLE_BINDING_SUPPORT && Mixin.detectBinding(keyName)) {
-              m.writeBindings(keyName, value);
-            }
-
-            assert(
-              'EmberObject.create no longer supports defining computed ' +
-                'properties. Define computed properties using extend() or reopen() ' +
-                'before calling create().',
-              !(value instanceof ComputedProperty)
-            );
-            assert(
-              'EmberObject.create no longer supports defining methods that call _super.',
-              !(typeof value === 'function' && value.toString().indexOf('._super') !== -1)
-            );
-            assert(
-              '`actions` must be provided at extend time, not at create time, ' +
-                'when Ember.ActionHandler is used (i.e. views, controllers & routes).',
-              !(keyName === 'actions' && ActionHandler.detect(this))
-            );
-
-            let possibleDesc = descriptorFor(self, keyName, m);
-            let isDescriptor = possibleDesc !== undefined;
-
-            if (!isDescriptor) {
-              let baseValue = self[keyName];
-
-              if (hasConcatenatedProps && concatenatedProperties.indexOf(keyName) > -1) {
-                if (baseValue) {
-                  value = makeArray(baseValue).concat(value);
-                } else {
-                  value = makeArray(value);
-                }
-              }
-
-              if (hasMergedProps && mergedProperties.indexOf(keyName) > -1) {
-                value = assign({}, baseValue, value);
-              }
-            }
-
-            if (isDescriptor) {
-              possibleDesc.set(self, keyName, value);
-            } else if (typeof self.setUnknownProperty === 'function' && !(keyName in self)) {
-              self.setUnknownProperty(keyName, value);
-            } else {
-              if (DEBUG) {
-                defineProperty(self, keyName, null, value); // setup mandatory setter
-              } else {
-                self[keyName] = value;
-              }
-            }
-          }
-        }
-
-        if (ENV._ENABLE_BINDING_SUPPORT) {
-          Mixin.finishPartial(self, m);
-        }
-
-        // using DEBUG here to avoid the extraneous variable when not needed
-        if (DEBUG) {
-          beforeInitCalled = false;
-        }
-        self.init(...arguments);
-
-        m.proto = proto;
-        finishChains(m);
-        sendEvent(self, 'init', undefined, undefined, undefined, m);
-
-        // only return when in debug builds and `self` is the proxy created above
-        if (DEBUG && self !== this) {
-          return self;
-        }
-      }
-
-      static _initFactory(factory) {
-        initFactory = factory;
-      }
-    };
-  }
-
-  Class.willReopen = function() {
-    if (wasApplied) {
-      Class.PrototypeMixin = Mixin.create(Class.PrototypeMixin);
-    }
-
-    wasApplied = false;
-  };
-
-  Class.proto = function() {
-    let superclass = Class.superclass;
-    if (superclass) {
-      superclass.proto();
-    }
-
-    if (!wasApplied) {
-      wasApplied = true;
-      Class.PrototypeMixin.applyPartial(Class.prototype);
-    }
-
-    // Native classes will call the nearest superclass's proto function,
-    // and proto is expected to return the current instance's prototype,
-    // so we need to return it from `this` instead
-    return this.prototype;
-  };
-
-  return Class;
-}
-
-const IS_DESTROYED = descriptor({
-  configurable: true,
-  enumerable: false,
-
-  get() {
-    return peekMeta(this).isSourceDestroyed();
-  },
-
-  set(value) {
-    assert(
-      `You cannot set \`${this}.isDestroyed\` directly, please use \`.destroy()\`.`,
-      value === IS_DESTROYED
-    );
-  },
-});
-
-const IS_DESTROYING = descriptor({
-  configurable: true,
-  enumerable: false,
-
-  get() {
-    return peekMeta(this).isSourceDestroying();
-  },
-
-  set(value) {
-    assert(
-      `You cannot set \`${this}.isDestroying\` directly, please use \`.destroy()\`.`,
-      value === IS_DESTROYING
-    );
-  },
-});
+const prototypeMixinMap = new WeakMap();
+const classMixinMap = new WeakMap();
 
 /**
   @class CoreObject
   @public
 */
-let CoreObject = makeCtor();
-CoreObject.prototype.toString = classToString;
-CoreObject.toString = classToString;
-setName(CoreObject, 'Ember.CoreObject');
+class CoreObject {
+  static _initFactory(factory) {
+    factoryMap.set(this, factory);
+  }
 
-CoreObject.PrototypeMixin = Mixin.create({
+  constructor(properties) {
+    // pluck off factory
+    let initFactory = factoryMap.get(this.constructor);
+    if (initFactory !== undefined) {
+      factoryMap.delete(this.constructor);
+      FACTORY_FOR.set(this, initFactory);
+    }
+
+    // prepare prototype...
+    this.constructor.proto();
+
+    let self = this;
+
+    let beforeInitCalled; // only used in debug builds to enable the proxy trap
+
+    // using DEBUG here to avoid the extraneous variable when not needed
+    if (DEBUG) {
+      beforeInitCalled = true;
+    }
+
+    if (DEBUG && HAS_NATIVE_PROXY && typeof self.unknownProperty === 'function') {
+      let messageFor = (obj, property) => {
+        return (
+          `You attempted to access the \`${String(property)}\` property (of ${obj}).\n` +
+          `Since Ember 3.1, this is usually fine as you no longer need to use \`.get()\`\n` +
+          `to access computed properties. However, in this case, the object in question\n` +
+          `is a special kind of Ember object (a proxy). Therefore, it is still necessary\n` +
+          `to use \`.get('${String(property)}')\` in this case.\n\n` +
+          `If you encountered this error because of third-party code that you don't control,\n` +
+          `there is more information at https://github.com/emberjs/ember.js/issues/16148, and\n` +
+          `you can help us improve this error message by telling us more about what happened in\n` +
+          `this situation.`
+        );
+      };
+
+      /* globals Proxy Reflect */
+      self = new Proxy(this, {
+        get(target, property, receiver) {
+          if (property === PROXY_CONTENT) {
+            return target;
+          } else if (
+            beforeInitCalled ||
+            typeof property === 'symbol' ||
+            isInternalSymbol(property) ||
+            property === 'toJSON' ||
+            property === 'toString' ||
+            property === 'toStringExtension' ||
+            property === 'didDefineProperty' ||
+            property === 'willWatchProperty' ||
+            property === 'didUnwatchProperty' ||
+            property === 'didAddListener' ||
+            property === 'didRemoveListener' ||
+            property === 'isDescriptor' ||
+            property === '_onLookup' ||
+            property in target
+          ) {
+            return Reflect.get(target, property, receiver);
+          }
+
+          let value = target.unknownProperty.call(receiver, property);
+
+          if (typeof value !== 'function') {
+            assert(messageFor(receiver, property), value === undefined || value === null);
+          }
+        },
+      });
+
+      FACTORY_FOR.set(self, initFactory);
+    }
+
+    let m = meta(self);
+    let proto = m.proto;
+    m.proto = self;
+
+    if (properties !== undefined) {
+      assert(
+        'EmberObject.create only accepts objects.',
+        typeof properties === 'object' && properties !== null
+      );
+
+      assert(
+        'EmberObject.create no longer supports mixing in other ' +
+          'definitions, use .extend & .create separately instead.',
+        !(properties instanceof Mixin)
+      );
+
+      let concatenatedProperties = self.concatenatedProperties;
+      let mergedProperties = self.mergedProperties;
+      let hasConcatenatedProps =
+        concatenatedProperties !== undefined && concatenatedProperties.length > 0;
+      let hasMergedProps = mergedProperties !== undefined && mergedProperties.length > 0;
+
+      let keyNames = Object.keys(properties);
+
+      for (let i = 0; i < keyNames.length; i++) {
+        let keyName = keyNames[i];
+        let value = properties[keyName];
+
+        if (ENV._ENABLE_BINDING_SUPPORT && Mixin.detectBinding(keyName)) {
+          m.writeBindings(keyName, value);
+        }
+
+        assert(
+          'EmberObject.create no longer supports defining computed ' +
+            'properties. Define computed properties using extend() or reopen() ' +
+            'before calling create().',
+          !(value instanceof ComputedProperty)
+        );
+        assert(
+          'EmberObject.create no longer supports defining methods that call _super.',
+          !(typeof value === 'function' && value.toString().indexOf('._super') !== -1)
+        );
+        assert(
+          '`actions` must be provided at extend time, not at create time, ' +
+            'when Ember.ActionHandler is used (i.e. views, controllers & routes).',
+          !(keyName === 'actions' && ActionHandler.detect(this))
+        );
+
+        let possibleDesc = descriptorFor(self, keyName, m);
+        let isDescriptor = possibleDesc !== undefined;
+
+        if (!isDescriptor) {
+          let baseValue = self[keyName];
+
+          if (hasConcatenatedProps && concatenatedProperties.indexOf(keyName) > -1) {
+            if (baseValue) {
+              value = makeArray(baseValue).concat(value);
+            } else {
+              value = makeArray(value);
+            }
+          }
+
+          if (hasMergedProps && mergedProperties.indexOf(keyName) > -1) {
+            value = assign({}, baseValue, value);
+          }
+        }
+
+        if (isDescriptor) {
+          possibleDesc.set(self, keyName, value);
+        } else if (typeof self.setUnknownProperty === 'function' && !(keyName in self)) {
+          self.setUnknownProperty(keyName, value);
+        } else {
+          if (DEBUG) {
+            defineProperty(self, keyName, null, value, m); // setup mandatory setter
+          } else {
+            self[keyName] = value;
+          }
+        }
+      }
+    }
+
+    if (ENV._ENABLE_BINDING_SUPPORT) {
+      Mixin.finishPartial(self, m);
+    }
+
+    // using DEBUG here to avoid the extraneous variable when not needed
+    if (DEBUG) {
+      beforeInitCalled = false;
+    }
+    self.init(...arguments);
+
+    m.proto = proto;
+    finishChains(m);
+    sendEvent(self, 'init', undefined, undefined, undefined, m);
+
+    // only return when in debug builds and `self` is the proxy created above
+    if (DEBUG && self !== this) {
+      return self;
+    }
+  }
+
   reopen(...args) {
     applyMixin(this, args, true);
     return this;
-  },
+  }
 
   /**
     An overridable method called when objects are instantiated. By default,
@@ -342,7 +262,7 @@ CoreObject.PrototypeMixin = Mixin.create({
     @method init
     @public
   */
-  init() {},
+  init() {}
 
   /**
     Defines the properties that will be concatenated from the superclass
@@ -417,7 +337,6 @@ CoreObject.PrototypeMixin = Mixin.create({
     @default null
     @public
   */
-  concatenatedProperties: null,
 
   /**
     Defines the properties that will be merged from the superclass
@@ -493,7 +412,6 @@ CoreObject.PrototypeMixin = Mixin.create({
     @default null
     @public
   */
-  mergedProperties: null,
 
   /**
     Destroyed object property flag.
@@ -505,7 +423,13 @@ CoreObject.PrototypeMixin = Mixin.create({
     @default false
     @public
   */
-  isDestroyed: IS_DESTROYED,
+  get isDestroyed() {
+    return peekMeta(this).isSourceDestroyed();
+  }
+
+  set isDestroyed(value) {
+    assert(`You cannot set \`${this}.isDestroyed\` directly, please use \`.destroy()\`.`, false);
+  }
 
   /**
     Destruction scheduled flag. The `destroy()` method has been called.
@@ -517,7 +441,13 @@ CoreObject.PrototypeMixin = Mixin.create({
     @default false
     @public
   */
-  isDestroying: IS_DESTROYING,
+  get isDestroying() {
+    return peekMeta(this).isSourceDestroying();
+  }
+
+  set isDestroying(value) {
+    assert(`You cannot set \`${this}.isDestroying\` directly, please use \`.destroy()\`.`, false);
+  }
 
   /**
     Destroys an object by setting the `isDestroyed` flag and removing its
@@ -545,7 +475,7 @@ CoreObject.PrototypeMixin = Mixin.create({
     schedule('destroy', this, this._scheduledDestroy, m);
 
     return this;
-  },
+  }
 
   /**
     Override to implement teardown.
@@ -553,7 +483,7 @@ CoreObject.PrototypeMixin = Mixin.create({
     @method willDestroy
     @public
   */
-  willDestroy() {},
+  willDestroy() {}
 
   /**
     Invoked by the run loop to actually destroy the object. This is
@@ -568,7 +498,7 @@ CoreObject.PrototypeMixin = Mixin.create({
     }
     deleteMeta(this);
     m.setSourceDestroyed();
-  },
+  }
 
   /**
     Returns a string representation which attempts to provide more information
@@ -618,17 +548,8 @@ CoreObject.PrototypeMixin = Mixin.create({
     )}${extension}>`;
 
     return ret;
-  },
-});
+  }
 
-CoreObject.PrototypeMixin.ownerConstructor = CoreObject;
-
-CoreObject.__super__ = null;
-
-let ClassMixinProps = {
-  isClass: true,
-
-  isMethod: false,
   /**
     Creates a new subclass.
 
@@ -723,26 +644,11 @@ let ClassMixinProps = {
     @param {Object} [arguments]* Object containing values to use within the new class
     @public
   */
-  extend() {
-    let Class = makeCtor(this);
-
-    Class.ClassMixin = Mixin.create(this.ClassMixin);
-    Class.PrototypeMixin = Mixin.create(this.PrototypeMixin);
-
-    Class.ClassMixin.ownerConstructor = Class;
-    Class.PrototypeMixin.ownerConstructor = Class;
-
+  static extend() {
+    let Class = class extends this {};
     reopen.apply(Class.PrototypeMixin, arguments);
-
-    Class.superclass = this;
-    Class.__super__ = this.prototype;
-
-    let proto = Class.prototype;
-    meta(proto).proto = proto; // this will disable observers on prototype
-
-    Class.ClassMixin.apply(Class);
     return Class;
-  },
+  }
 
   /**
     Creates an instance of a class. Accepts either no arguments, or an object
@@ -785,7 +691,7 @@ let ClassMixinProps = {
     @param [arguments]*
     @public
   */
-  create(props, extra) {
+  static create(props, extra) {
     let C = this;
 
     if (extra === undefined) {
@@ -793,7 +699,7 @@ let ClassMixinProps = {
     } else {
       return new C(flattenProps.apply(this, arguments));
     }
-  },
+  }
 
   /**
     Augments a constructor's prototype with additional
@@ -829,11 +735,19 @@ let ClassMixinProps = {
     @static
     @public
   */
-  reopen() {
+  static reopen() {
     this.willReopen();
     reopen.apply(this.PrototypeMixin, arguments);
     return this;
-  },
+  }
+
+  static willReopen() {
+    let p = this.prototype;
+    if (wasApplied.has(p)) {
+      wasApplied.delete(p);
+      prototypeMixinMap.set(this, Mixin.create(this.PrototypeMixin));
+    }
+  }
 
   /**
     Augments a constructor's own properties and functions:
@@ -896,13 +810,13 @@ let ClassMixinProps = {
     @static
     @public
   */
-  reopenClass() {
+  static reopenClass() {
     reopen.apply(this.ClassMixin, arguments);
     applyMixin(this, arguments, false);
     return this;
-  },
+  }
 
-  detect(obj) {
+  static detect(obj) {
     if ('function' !== typeof obj) {
       return false;
     }
@@ -913,11 +827,11 @@ let ClassMixinProps = {
       obj = obj.superclass;
     }
     return false;
-  },
+  }
 
-  detectInstance(obj) {
+  static detectInstance(obj) {
     return obj instanceof this;
-  },
+  }
 
   /**
     In some cases, you may want to annotate computed properties with additional
@@ -950,7 +864,7 @@ let ClassMixinProps = {
     @param key {String} property name
     @private
   */
-  metaForProperty(key) {
+  static metaForProperty(key) {
     let proto = this.proto(); // ensure prototype is initialized
     let possibleDesc = descriptorFor(proto, key);
 
@@ -960,7 +874,7 @@ let ClassMixinProps = {
     );
 
     return possibleDesc._meta || {};
-  },
+  }
 
   /**
     Iterate over each computed property for the class, passing its name
@@ -972,7 +886,7 @@ let ClassMixinProps = {
     @param {Object} binding
     @private
   */
-  eachComputedProperty(callback, binding = this) {
+  static eachComputedProperty(callback, binding = this) {
     this.proto(); // ensure prototype is initialized
     let empty = {};
 
@@ -982,12 +896,59 @@ let ClassMixinProps = {
         callback.call(binding, name, meta);
       }
     });
-  },
-};
+  }
 
-function injectedPropertyAssertion() {
-  assert('Injected properties are invalid', validatePropertyInjections(this));
+  static get ClassMixin() {
+    let classMixin = classMixinMap.get(this);
+    if (classMixin === undefined) {
+      let s = this.superclass;
+      classMixin = s === undefined ? Mixin.create() : Mixin.create(s.ClassMixin);
+      classMixin.ownerConstructor = this;
+      classMixinMap.set(this, classMixin);
+    }
+    return classMixin;
+  }
+
+  static get PrototypeMixin() {
+    let prototypeMixin = prototypeMixinMap.get(this);
+    if (prototypeMixin === undefined) {
+      let s = this.superclass;
+      prototypeMixin = s === undefined ? Mixin.create() : Mixin.create(s.PrototypeMixin);
+      prototypeMixin.ownerConstructor = this;
+      prototypeMixinMap.set(this, prototypeMixin);
+    }
+    return prototypeMixin;
+  }
+
+  static get superclass() {
+    let c = Object.getPrototypeOf(this);
+    if (c !== Function.prototype) return c;
+  }
+
+  static proto() {
+    let p = this.prototype;
+    if (!wasApplied.has(p)) {
+      wasApplied.add(p);
+      let parent = this.superclass;
+      if (parent) {
+        parent.proto();
+      }
+      this.PrototypeMixin.apply(p);
+    }
+    return p;
+  }
 }
+
+// CoreObject.prototype.concatenatedProperties = null;
+// CoreObject.prototype.mergedProperties = null;
+
+CoreObject.toString = classToString;
+setName(CoreObject, 'Ember.CoreObject');
+
+CoreObject.PrototypeMixin.ownerConstructor = CoreObject;
+
+CoreObject.isClass = true;
+CoreObject.isMethod = false;
 
 function flattenProps(...props) {
   let { concatenatedProperties, mergedProperties } = this;
@@ -1042,7 +1003,10 @@ if (DEBUG) {
     @private
     @method _onLookup
   */
-  ClassMixinProps._onLookup = injectedPropertyAssertion;
+  CoreObject._onLookup = function injectedPropertyAssertion() {
+    assert('Injected properties are invalid', validatePropertyInjections(this));
+  };
+
   /**
     Returns a hash of property names and container names that injected
     properties will lookup on the container lazily.
@@ -1051,7 +1015,7 @@ if (DEBUG) {
     @return {Object} Hash of all lazy injected property keys to container names
     @private
   */
-  ClassMixinProps._lazyInjections = function() {
+  CoreObject._lazyInjections = function() {
     let injections = {};
     let proto = this.proto();
     let key;
@@ -1072,11 +1036,4 @@ if (DEBUG) {
   };
 }
 
-let ClassMixin = Mixin.create(ClassMixinProps);
-
-ClassMixin.ownerConstructor = CoreObject;
-
-CoreObject.ClassMixin = ClassMixin;
-
-ClassMixin.apply(CoreObject);
 export default CoreObject;

--- a/packages/external-helpers/lib/external-helpers-dev.js
+++ b/packages/external-helpers/lib/external-helpers-dev.js
@@ -1,3 +1,7 @@
+const create = Object.create;
+const setPrototypeOf = Object.setPrototypeOf;
+const defineProperty = Object.defineProperty;
+
 export function classCallCheck(instance, Constructor) {
   if (!(instance instanceof Constructor)) {
     throw new TypeError('Cannot call a class as a function');
@@ -10,8 +14,7 @@ export function inherits(subClass, superClass) {
       'Super expression must either be null or a function, not ' + typeof superClass
     );
   }
-
-  subClass.prototype = Object.create(superClass && superClass.prototype, {
+  subClass.prototype = create(superClass === null ? null : superClass.prototype, {
     constructor: {
       value: subClass,
       enumerable: false,
@@ -19,11 +22,7 @@ export function inherits(subClass, superClass) {
       configurable: true,
     },
   });
-
-  if (superClass)
-    Object.setPrototypeOf
-      ? Object.setPrototypeOf(subClass, superClass)
-      : defaults(subClass, superClass);
+  if (superClass !== null) setPrototypeOf(subClass, superClass);
 }
 
 export function taggedTemplateLiteralLoose(strings, raw) {
@@ -37,33 +36,19 @@ function defineProperties(target, props) {
     descriptor.enumerable = descriptor.enumerable || false;
     descriptor.configurable = true;
     if ('value' in descriptor) descriptor.writable = true;
-    Object.defineProperty(target, descriptor.key, descriptor);
+    defineProperty(target, descriptor.key, descriptor);
   }
 }
 
 export function createClass(Constructor, protoProps, staticProps) {
-  if (protoProps) defineProperties(Constructor.prototype, protoProps);
-  if (staticProps) defineProperties(Constructor, staticProps);
+  if (protoProps !== undefined) defineProperties(Constructor.prototype, protoProps);
+  if (staticProps !== undefined) defineProperties(Constructor, staticProps);
   return Constructor;
-}
-
-export function defaults(obj, defaults) {
-  var keys = Object.getOwnPropertyNames(defaults);
-  for (var i = 0; i < keys.length; i++) {
-    var key = keys[i];
-    var value = Object.getOwnPropertyDescriptor(defaults, key);
-    if (value && value.configurable && obj[key] === undefined) {
-      Object.defineProperty(obj, key, value);
-    }
-  }
-  return obj;
 }
 
 export const possibleConstructorReturn = function(self, call) {
   if (!self) {
     throw new ReferenceError(`this hasn't been initialized - super() hasn't been called`);
   }
-  return call && (typeof call === 'object' || typeof call === 'function') ? call : self;
+  return (call !== null && typeof call === 'object') || typeof call === 'function' ? call : self;
 };
-
-export const slice = Array.prototype.slice;

--- a/packages/external-helpers/lib/external-helpers-prod.js
+++ b/packages/external-helpers/lib/external-helpers-prod.js
@@ -1,5 +1,11 @@
+const create = Object.create;
+const setPrototypeOf = Object.setPrototypeOf;
+const defineProperty = Object.defineProperty;
+
+export function classCallCheck() {}
+
 export function inherits(subClass, superClass) {
-  subClass.prototype = Object.create(superClass && superClass.prototype, {
+  subClass.prototype = create(superClass === null ? null : superClass.prototype, {
     constructor: {
       value: subClass,
       enumerable: false,
@@ -7,11 +13,7 @@ export function inherits(subClass, superClass) {
       configurable: true,
     },
   });
-
-  if (superClass)
-    Object.setPrototypeOf
-      ? Object.setPrototypeOf(subClass, superClass)
-      : defaults(subClass, superClass);
+  if (superClass !== null) setPrototypeOf(subClass, superClass);
 }
 
 export function taggedTemplateLiteralLoose(strings, raw) {
@@ -25,30 +27,16 @@ function defineProperties(target, props) {
     descriptor.enumerable = descriptor.enumerable || false;
     descriptor.configurable = true;
     if ('value' in descriptor) descriptor.writable = true;
-    Object.defineProperty(target, descriptor.key, descriptor);
+    defineProperty(target, descriptor.key, descriptor);
   }
 }
 
 export function createClass(Constructor, protoProps, staticProps) {
-  if (protoProps) defineProperties(Constructor.prototype, protoProps);
-  if (staticProps) defineProperties(Constructor, staticProps);
+  if (protoProps !== undefined) defineProperties(Constructor.prototype, protoProps);
+  if (staticProps !== undefined) defineProperties(Constructor, staticProps);
   return Constructor;
 }
 
-export function defaults(obj, defaults) {
-  var keys = Object.getOwnPropertyNames(defaults);
-  for (var i = 0; i < keys.length; i++) {
-    var key = keys[i];
-    var value = Object.getOwnPropertyDescriptor(defaults, key);
-    if (value && value.configurable && obj[key] === undefined) {
-      Object.defineProperty(obj, key, value);
-    }
-  }
-  return obj;
+export function possibleConstructorReturn(self, call) {
+  return (call !== null && typeof call === 'object') || typeof call === 'function' ? call : self;
 }
-
-export const possibleConstructorReturn = function(self, call) {
-  return call && (typeof call === 'object' || typeof call === 'function') ? call : self;
-};
-
-export const slice = Array.prototype.slice;

--- a/packages/internal-test-helpers/lib/build-owner.js
+++ b/packages/internal-test-helpers/lib/build-owner.js
@@ -3,6 +3,16 @@ import { Router } from 'ember-routing';
 import { Application, ApplicationInstance } from 'ember-application';
 import { RegistryProxyMixin, ContainerProxyMixin, Object as EmberObject } from 'ember-runtime';
 
+class ResolverWrapper {
+  constructor(resolver) {
+    this.resolver = resolver;
+  }
+
+  create() {
+    return this.resolver;
+  }
+}
+
 export default function buildOwner(options = {}) {
   let ownerOptions = options.ownerOptions || {};
   let resolver = options.resolver;
@@ -10,12 +20,8 @@ export default function buildOwner(options = {}) {
 
   let Owner = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixin);
 
-  let namespace = EmberObject.create({
-    Resolver: {
-      create() {
-        return resolver;
-      },
-    },
+  let namespace = new EmberObject({
+    Resolver: new ResolverWrapper(resolver),
   });
 
   let fallbackRegistry = Application.buildRegistry(namespace);


### PR DESCRIPTION
Make CoreObject rely more on ES2015 class features and interop better.

(cherry picked from commit d424af0b23811b4e751eb5bd989928c6ac6197a1)