### PR TITLE
document Route `fullRouteName` property

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -131,6 +131,20 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     @since 1.0.0
     @public
   */
+  
+  /**
+    The name of the route, dot-delimited, including the engine prefix
+    if applicable.
+
+    For example, a route found at `addon/routes/posts/post.js` within an
+    engine named `admin` will have a `fullRouteName` of `admin.posts.post`.
+
+    @property fullRouteName
+    @for Route
+    @type String
+    @since 2.10.0
+    @public
+  */
 
   /**
     Sets the name for this route, including a fully resolved name for routes

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -131,7 +131,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
     @since 1.0.0
     @public
   */
-  
+
   /**
     The name of the route, dot-delimited, including the engine prefix
     if applicable.


### PR DESCRIPTION
I found this property when investigating a bug in ember-interactivity: https://github.com/elwayman02/ember-interactivity/pull/52