### PR TITLE
[perf] Only apply PrototypeMixin if it exists

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -739,7 +739,13 @@ class CoreObject {
     let p = this.prototype;
     if (wasApplied.has(p)) {
       wasApplied.delete(p);
-      prototypeMixinMap.set(this, Mixin.create(this.PrototypeMixin));
+
+      // If the base mixin already exists and was applied, create a new mixin to
+      // make sure that it gets properly applied. Reusing the same mixin after
+      // the first `proto` call will cause it to get skipped.
+      if (prototypeMixinMap.has(this)) {
+        prototypeMixinMap.set(this, Mixin.create(this.PrototypeMixin));
+      }
     }
   }
 
@@ -915,6 +921,8 @@ class CoreObject {
         parent.proto();
       }
 
+      // If the prototype mixin exists, apply it. In the case of native classes,
+      // it will not exist (unless the class has been reopened).
       if (prototypeMixinMap.has(this)) {
         this.PrototypeMixin.apply(p);
       }

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -914,7 +914,10 @@ class CoreObject {
       if (parent) {
         parent.proto();
       }
-      this.PrototypeMixin.apply(p);
+
+      if (prototypeMixinMap.has(this)) {
+        this.PrototypeMixin.apply(p);
+      }
     }
     return p;
   }


### PR DESCRIPTION
Currently we are always applying the PrototypeMixin in `proto`, even if
it doesn't yet exist (as in the case of native classes). By checking to
see if it exists first, we should be able to avoid creating and applying
it unless it is necessary.