### PR TITLE
[BUGFIX] Ensure `ArrayMixin#invoke` returns an Ember.A.

### DIFF
--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -951,7 +951,11 @@ const ArrayMixin = Mixin.create(Enumerable, {
     @public
   */
   invoke(methodName, ...args) {
-    return this.map(item => tryInvoke(item, methodName, args));
+    let ret = A();
+
+    this.forEach(item => ret.push(tryInvoke(item, methodName, args)));
+
+    return ret;
   },
 
   /**

--- a/packages/ember-runtime/tests/array/invoke-test.js
+++ b/packages/ember-runtime/tests/array/invoke-test.js
@@ -1,4 +1,4 @@
-import EmberObject from '../../lib/system/object';
+import { Object as EmberObject, NativeArray } from '../../index';
 import { AbstractTestCase } from 'internal-test-helpers';
 import { runArrayTests } from '../helpers/array';
 
@@ -27,6 +27,33 @@ class InvokeTests extends AbstractTestCase {
     cnt = 0;
     obj.invoke('foo', 2);
     this.assert.equal(cnt, 6, 'should have invoked 3 times, passing param');
+  }
+
+  '@test invoke should return an array containing the results of each invoked method'(assert) {
+    let obj = this.newObject([
+      {
+        foo() {
+          return 'one';
+        },
+      },
+      {}, // intentionally not including `foo` method
+      {
+        foo() {
+          return 'two';
+        },
+      },
+    ]);
+
+    let result = obj.invoke('foo');
+    assert.deepEqual(result, ['one', undefined, 'two']);
+  }
+
+  '@test invoke should return an extended array (aka Ember.A)'(assert) {
+    let obj = this.newObject([{ foo() {} }, { foo() {} }]);
+
+    let result = obj.invoke('foo');
+
+    assert.ok(NativeArray.detect(result), 'NativeArray has been applied');
   }
 }
 


### PR DESCRIPTION
This is a partial revert of bee179dd, moving back to a manual `forEach` so that we can control the return value a bit more. When prototype extensions are disabled, we cannot rely on `this.map` to return an extended array.

Fixes a regression detected by ember-data's test suite running against ember-source's canary channel.