### PR TITLE
(issue 16790) Added @static tag so that we can see defineProperty in API doc

### DIFF
--- a/packages/ember-metal/lib/properties.ts
+++ b/packages/ember-metal/lib/properties.ts
@@ -143,6 +143,7 @@ function DESCRIPTOR_GETTER_FUNCTION(name: string, descriptor: Descriptor) {
 
   @private
   @method defineProperty
+  @static
   @for @ember/object
   @param {Object} obj the object to define this property on. This may be a prototype.
   @param {String} keyName the name of the property


### PR DESCRIPTION
With help from @jenweber, I added a `@static` tag to the YUIDoc for `defineProperty`, so that it may correctly appear in the Ember documentation.

Please note that `defineProperty` is marked as a private method, but the deprecation at [https://www.emberjs.com/deprecations/v3.x#toc_ember-meta-descriptor-on-object](https://www.emberjs.com/deprecations/v3.x#toc_ember-meta-descriptor-on-object) suggests that it can be used as a public method.