### PR TITLE
[BUGFIX] Fix instance-initializer-test blueprint for RFC232

### DIFF
--- a/blueprints/instance-initializer-test/qunit-rfc-232-files/tests/unit/instance-initializers/__name__-test.js
+++ b/blueprints/instance-initializer-test/qunit-rfc-232-files/tests/unit/instance-initializers/__name__-test.js
@@ -2,12 +2,9 @@ import Application from '@ember/application';
 
 import { initialize } from '<%= dasherizedModulePrefix %>/instance-initializers/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
 <% if (destroyAppExists) { %>import destroyApp from '../../helpers/destroy-app';<% } else { %>import { run } from '@ember/runloop';<% } %>
 
 module('<%= friendlyTestName %>', function(hooks) {
-  setupTest(hooks);
-
   hooks.beforeEach(function() {
     this.TestApplication = Application.extend();
     this.TestApplication.instanceInitializer({

--- a/node-tests/fixtures/instance-initializer-test/rfc232.js
+++ b/node-tests/fixtures/instance-initializer-test/rfc232.js
@@ -2,12 +2,9 @@ import Application from '@ember/application';
 
 import { initialize } from 'my-app/instance-initializers/foo';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 
 module('Unit | Instance Initializer | foo', function(hooks) {
-  setupTest(hooks);
-
   hooks.beforeEach(function() {
     this.TestApplication = Application.extend();
     this.TestApplication.instanceInitializer({


### PR DESCRIPTION
instance-initializer tests generated from blueprints fail because the test is attempting to start the application but setupTest hook already has.

Here's an example app with the blueprint and fixed version of the tests: https://github.com/stopdropandrew/ember-fix-instance-initializer-test-blueprint

Fixes https://github.com/emberjs/ember.js/issues/16216