### PR TITLE
[core-object] Delay init until after construction

### DIFF
--- a/packages/@ember/-internals/runtime/lib/system/core_object.js
+++ b/packages/@ember/-internals/runtime/lib/system/core_object.js
@@ -27,7 +27,7 @@ import {
   classToString,
 } from '@ember/-internals/metal';
 import ActionHandler from '../mixins/action_handler';
-import { assert } from '@ember/debug';
+import { assert, deprecate } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 
 const reopen = Mixin.prototype.reopen;
@@ -37,6 +37,103 @@ const wasApplied = new WeakSet();
 const factoryMap = new WeakMap();
 
 const prototypeMixinMap = new WeakMap();
+
+const DELAY_INIT = Object.freeze({});
+
+let initCalled; // only used in debug builds to enable the proxy trap
+
+// using DEBUG here to avoid the extraneous variable when not needed
+if (DEBUG) {
+  initCalled = new WeakSet();
+}
+
+function initialize(obj, properties) {
+  let m = meta(obj);
+
+  if (properties !== undefined) {
+    assert(
+      'EmberObject.create only accepts objects.',
+      typeof properties === 'object' && properties !== null
+    );
+
+    assert(
+      'EmberObject.create no longer supports mixing in other ' +
+        'definitions, use .extend & .create separately instead.',
+      !(properties instanceof Mixin)
+    );
+
+    let concatenatedProperties = obj.concatenatedProperties;
+    let mergedProperties = obj.mergedProperties;
+    let hasConcatenatedProps =
+      concatenatedProperties !== undefined && concatenatedProperties.length > 0;
+    let hasMergedProps = mergedProperties !== undefined && mergedProperties.length > 0;
+
+    let keyNames = Object.keys(properties);
+
+    for (let i = 0; i < keyNames.length; i++) {
+      let keyName = keyNames[i];
+      let value = properties[keyName];
+
+      assert(
+        'EmberObject.create no longer supports defining computed ' +
+          'properties. Define computed properties using extend() or reopen() ' +
+          'before calling create().',
+        !(value instanceof ComputedProperty)
+      );
+      assert(
+        'EmberObject.create no longer supports defining methods that call _super.',
+        !(typeof value === 'function' && value.toString().indexOf('._super') !== -1)
+      );
+      assert(
+        '`actions` must be provided at extend time, not at create time, ' +
+          'when Ember.ActionHandler is used (i.e. views, controllers & routes).',
+        !(keyName === 'actions' && ActionHandler.detect(obj))
+      );
+
+      let possibleDesc = descriptorFor(obj, keyName, m);
+      let isDescriptor = possibleDesc !== undefined;
+
+      if (!isDescriptor) {
+        let baseValue = obj[keyName];
+
+        if (hasConcatenatedProps && concatenatedProperties.indexOf(keyName) > -1) {
+          if (baseValue) {
+            value = makeArray(baseValue).concat(value);
+          } else {
+            value = makeArray(value);
+          }
+        }
+
+        if (hasMergedProps && mergedProperties.indexOf(keyName) > -1) {
+          value = assign({}, baseValue, value);
+        }
+      }
+
+      if (isDescriptor) {
+        possibleDesc.set(obj, keyName, value);
+      } else if (typeof obj.setUnknownProperty === 'function' && !(keyName in obj)) {
+        obj.setUnknownProperty(keyName, value);
+      } else {
+        if (DEBUG) {
+          defineProperty(obj, keyName, null, value, m); // setup mandatory setter
+        } else {
+          obj[keyName] = value;
+        }
+      }
+    }
+  }
+
+  // using DEBUG here to avoid the extraneous variable when not needed
+  if (DEBUG) {
+    initCalled.add(obj);
+  }
+  obj.init(properties);
+
+  // re-enable chains
+  m.proto = obj.constructor.prototype;
+  finishChains(m);
+  sendEvent(obj, 'init', undefined, undefined, undefined, m);
+}
 
 /**
   @class CoreObject
@@ -60,13 +157,6 @@ class CoreObject {
 
     let self = this;
 
-    let beforeInitCalled; // only used in debug builds to enable the proxy trap
-
-    // using DEBUG here to avoid the extraneous variable when not needed
-    if (DEBUG) {
-      beforeInitCalled = true;
-    }
-
     if (DEBUG && HAS_NATIVE_PROXY && typeof self.unknownProperty === 'function') {
       let messageFor = (obj, property) => {
         return (
@@ -88,7 +178,8 @@ class CoreObject {
           if (property === PROXY_CONTENT) {
             return target;
           } else if (
-            beforeInitCalled ||
+            // init called will be set on the proxy, not the target, so get with the receiver
+            !initCalled.has(receiver) ||
             typeof property === 'symbol' ||
             isInternalSymbol(property) ||
             property === 'toJSON' ||
@@ -117,92 +208,22 @@ class CoreObject {
       FACTORY_FOR.set(self, initFactory);
     }
 
+    // disable chains
     let m = meta(self);
-    let proto = m.proto;
     m.proto = self;
 
-    if (properties !== undefined) {
-      assert(
-        'EmberObject.create only accepts objects.',
-        typeof properties === 'object' && properties !== null
+    if (properties !== DELAY_INIT) {
+      deprecate(
+        'using `new` with EmberObject has been deprecated. Please use `create` instead, or consider using native classes without extending from EmberObject.',
+        false,
+        {
+          id: 'object.new-constructor',
+          until: '3.9.0',
+        }
       );
 
-      assert(
-        'EmberObject.create no longer supports mixing in other ' +
-          'definitions, use .extend & .create separately instead.',
-        !(properties instanceof Mixin)
-      );
-
-      let concatenatedProperties = self.concatenatedProperties;
-      let mergedProperties = self.mergedProperties;
-      let hasConcatenatedProps =
-        concatenatedProperties !== undefined && concatenatedProperties.length > 0;
-      let hasMergedProps = mergedProperties !== undefined && mergedProperties.length > 0;
-
-      let keyNames = Object.keys(properties);
-
-      for (let i = 0; i < keyNames.length; i++) {
-        let keyName = keyNames[i];
-        let value = properties[keyName];
-
-        assert(
-          'EmberObject.create no longer supports defining computed ' +
-            'properties. Define computed properties using extend() or reopen() ' +
-            'before calling create().',
-          !(value instanceof ComputedProperty)
-        );
-        assert(
-          'EmberObject.create no longer supports defining methods that call _super.',
-          !(typeof value === 'function' && value.toString().indexOf('._super') !== -1)
-        );
-        assert(
-          '`actions` must be provided at extend time, not at create time, ' +
-            'when Ember.ActionHandler is used (i.e. views, controllers & routes).',
-          !(keyName === 'actions' && ActionHandler.detect(this))
-        );
-
-        let possibleDesc = descriptorFor(self, keyName, m);
-        let isDescriptor = possibleDesc !== undefined;
-
-        if (!isDescriptor) {
-          let baseValue = self[keyName];
-
-          if (hasConcatenatedProps && concatenatedProperties.indexOf(keyName) > -1) {
-            if (baseValue) {
-              value = makeArray(baseValue).concat(value);
-            } else {
-              value = makeArray(value);
-            }
-          }
-
-          if (hasMergedProps && mergedProperties.indexOf(keyName) > -1) {
-            value = assign({}, baseValue, value);
-          }
-        }
-
-        if (isDescriptor) {
-          possibleDesc.set(self, keyName, value);
-        } else if (typeof self.setUnknownProperty === 'function' && !(keyName in self)) {
-          self.setUnknownProperty(keyName, value);
-        } else {
-          if (DEBUG) {
-            defineProperty(self, keyName, null, value, m); // setup mandatory setter
-          } else {
-            self[keyName] = value;
-          }
-        }
-      }
+      initialize(self, properties);
     }
-
-    // using DEBUG here to avoid the extraneous variable when not needed
-    if (DEBUG) {
-      beforeInitCalled = false;
-    }
-    self.init(...arguments);
-
-    m.proto = proto;
-    finishChains(m);
-    sendEvent(self, 'init', undefined, undefined, undefined, m);
 
     // only return when in debug builds and `self` is the proxy created above
     if (DEBUG && self !== this) {
@@ -677,12 +698,15 @@ class CoreObject {
   */
   static create(props, extra) {
     let C = this;
+    let instance = new C(DELAY_INIT);
 
     if (extra === undefined) {
-      return new C(props);
+      initialize(instance, props);
     } else {
-      return new C(flattenProps.apply(this, arguments));
+      initialize(instance, flattenProps.apply(this, arguments));
     }
+
+    return instance;
   }
 
   /**

--- a/packages/@ember/-internals/runtime/tests/helpers/array.js
+++ b/packages/@ember/-internals/runtime/tests/helpers/array.js
@@ -171,7 +171,7 @@ class CopyableNativeArray extends AbstractArrayHelper {
 
 class CopyableArray extends AbstractArrayHelper {
   newObject() {
-    return new CopyableObject();
+    return CopyableObject.create();
   }
 
   isEqual(a, b) {
@@ -280,7 +280,7 @@ const CopyableObject = EmberObject.extend(Copyable, {
   },
 
   copy() {
-    let ret = new CopyableObject();
+    let ret = CopyableObject.create();
     set(ret, 'id', get(this, 'id'));
     return ret;
   },
@@ -288,7 +288,7 @@ const CopyableObject = EmberObject.extend(Copyable, {
 
 class MutableArrayHelpers extends NativeArrayHelpers {
   newObject(ary) {
-    return new TestMutableArray(super.newObject(ary));
+    return TestMutableArray.create(super.newObject(ary));
   }
 
   // allows for testing of the basic enumerable after an internal mutation
@@ -299,7 +299,7 @@ class MutableArrayHelpers extends NativeArrayHelpers {
 
 class EmberArrayHelpers extends MutableArrayHelpers {
   newObject(ary) {
-    return new TestArray(super.newObject(ary));
+    return TestArray.create(super.newObject(ary));
   }
 }
 

--- a/packages/@ember/-internals/runtime/tests/mixins/array_test.js
+++ b/packages/@ember/-internals/runtime/tests/mixins/array_test.js
@@ -63,7 +63,7 @@ moduleFor(
     }
 
     ['@test slice supports negative index arguments'](assert) {
-      let testArray = new TestArray({ _content: [1, 2, 3, 4] });
+      let testArray = TestArray.create({ _content: [1, 2, 3, 4] });
 
       assert.deepEqual(testArray.slice(-2), [3, 4], 'slice(-2)');
       assert.deepEqual(testArray.slice(-2, -1), [3], 'slice(-2, -1');
@@ -248,7 +248,7 @@ moduleFor(
   'EmberArray.@each support',
   class extends AbstractTestCase {
     beforeEach() {
-      ary = new TestArray({
+      ary = TestArray.create({
         _content: [
           { isDone: true, desc: 'Todo 1' },
           { isDone: false, desc: 'Todo 2' },

--- a/packages/@ember/-internals/runtime/tests/system/core_object_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/core_object_test.js
@@ -6,35 +6,31 @@ import { moduleFor, AbstractTestCase, buildOwner } from 'internal-test-helpers';
 moduleFor(
   'Ember.CoreObject',
   class extends AbstractTestCase {
-    ['@test works with new (one arg)'](assert) {
-      let obj = new CoreObject({
-        firstName: 'Stef',
-        lastName: 'Penner',
-      });
-
-      assert.equal(obj.firstName, 'Stef');
-      assert.equal(obj.lastName, 'Penner');
-    }
-
-    ['@test works with new (> 1 arg)'](assert) {
-      let obj = new CoreObject(
-        {
+    ['@test throws deprecation with new (one arg)']() {
+      expectDeprecation(() => {
+        new CoreObject({
           firstName: 'Stef',
           lastName: 'Penner',
-        },
-        {
-          other: 'name',
-        }
-      );
+        });
+      }, /using `new` with EmberObject has been deprecated/);
+    }
 
-      assert.equal(obj.firstName, 'Stef');
-      assert.equal(obj.lastName, 'Penner');
-
-      assert.equal(obj.other, undefined); // doesn't support multiple pojo' to the constructor
+    ['@test throws deprecation with new (> 1 arg)']() {
+      expectDeprecation(() => {
+        new CoreObject(
+          {
+            firstName: 'Stef',
+            lastName: 'Penner',
+          },
+          {
+            other: 'name',
+          }
+        );
+      }, /using `new` with EmberObject has been deprecated/);
     }
 
     ['@test toString should be not be added as a property when calling toString()'](assert) {
-      let obj = new CoreObject({
+      let obj = CoreObject.create({
         firstName: 'Foo',
         lastName: 'Bar',
       });
@@ -54,7 +50,7 @@ moduleFor(
         },
       }).create();
 
-      let obj = new CoreObject({
+      let obj = CoreObject.create({
         someProxyishThing,
       });
 

--- a/packages/@ember/-internals/runtime/tests/system/object/computed_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/computed_test.js
@@ -31,7 +31,7 @@ moduleFor(
         }),
       });
 
-      testWithDefault(assert, 'FOO', new MyClass(), 'foo');
+      testWithDefault(assert, 'FOO', MyClass.create(), 'foo');
     }
 
     ['@test computed property on subclass'](assert) {
@@ -47,7 +47,7 @@ moduleFor(
         }),
       });
 
-      testWithDefault(assert, 'BAR', new Subclass(), 'foo');
+      testWithDefault(assert, 'BAR', Subclass.create(), 'foo');
     }
 
     ['@test replacing computed property with regular val'](assert) {
@@ -61,7 +61,7 @@ moduleFor(
         foo: 'BAR',
       });
 
-      testWithDefault(assert, 'BAR', new Subclass(), 'foo');
+      testWithDefault(assert, 'BAR', Subclass.create(), 'foo');
     }
 
     ['@test complex depndent keys'](assert) {
@@ -83,8 +83,8 @@ moduleFor(
         count: 20,
       });
 
-      let obj1 = new MyClass();
-      let obj2 = new Subclass();
+      let obj1 = MyClass.create();
+      let obj2 = Subclass.create();
 
       testWithDefault(assert, 'BIFF 1', obj1, 'foo');
       testWithDefault(assert, 'BIFF 21', obj2, 'foo');
@@ -129,7 +129,7 @@ moduleFor(
         }).property('bar2.baz'),
       });
 
-      let obj2 = new Subclass();
+      let obj2 = Subclass.create();
 
       testWithDefault(assert, 'BIFF2 1', obj2, 'foo');
 

--- a/packages/@ember/-internals/runtime/tests/system/object/destroy_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/destroy_test.js
@@ -130,13 +130,13 @@ moduleFor(
         }),
       });
 
-      objs.a = new A();
+      objs.a = A.create();
 
-      objs.b = new B();
+      objs.b = B.create();
 
-      objs.c = new C();
+      objs.c = C.create();
 
-      new LongLivedObject();
+      LongLivedObject.create();
 
       run(() => {
         let keys = Object.keys(objs);

--- a/packages/@ember/-internals/runtime/tests/system/object/es-compatibility-test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/es-compatibility-test.js
@@ -264,7 +264,7 @@ moduleFor(
       MyObject.create();
       assert.deepEqual(
         calls,
-        ['before constructor', 'init', 'after constructor'],
+        ['before constructor', 'after constructor', 'init'],
         'constructor then init called (create)'
       );
 
@@ -281,7 +281,7 @@ moduleFor(
         bar: 789,
       });
 
-      assert.equal(obj.foo, 123, 'sets class fields on instance correctly');
+      assert.equal(obj.foo, 456, 'sets class fields on instance correctly');
       assert.equal(obj.bar, 789, 'sets passed in properties on instance correctly');
     }
 
@@ -395,13 +395,6 @@ moduleFor(
       });
 
       class D extends C {
-        constructor(props) {
-          if (props.last === undefined) {
-            props.last = 'Jackson';
-          }
-          super(props);
-        }
-
         init() {
           calls.push('D init before super.init');
           super.init(...arguments);
@@ -429,7 +422,7 @@ moduleFor(
       assert.deepEqual(changes, [], 'full has not changed');
       assert.deepEqual(events, [], 'onSomeEvent has not been triggered');
 
-      let d = D.create({ first: 'Robert' });
+      let d = D.create({ first: 'Robert', last: 'Jackson' });
 
       assert.deepEqual(calls, [
         'D init before super.init',

--- a/packages/@ember/-internals/runtime/tests/system/object/es-compatibility-test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/es-compatibility-test.js
@@ -47,25 +47,6 @@ moduleFor(
         'passed-property',
         'passed property available on instance (create)'
       );
-      calls = [];
-      myObject = new MyObject({ passedProperty: 'passed-property' });
-
-      assert.deepEqual(calls, ['constructor', 'init'], 'constructor then init called (new)');
-      assert.equal(
-        myObject.postInitProperty,
-        'post-init-property',
-        'constructor property available on instance (new)'
-      );
-      assert.equal(
-        myObject.initProperty,
-        'init-property',
-        'init property available on instance (new)'
-      );
-      assert.equal(
-        myObject.passedProperty,
-        'passed-property',
-        'passed property available on instance (new)'
-      );
     }
 
     ['@test normal method super'](assert) {
@@ -116,7 +97,7 @@ moduleFor(
 
       [Foo, Bar, Baz, Qux, Quux, Corge].forEach((Class, index) => {
         calls = [];
-        new Class().method();
+        Class.create().method();
 
         assert.deepEqual(
           calls,
@@ -199,7 +180,7 @@ moduleFor(
 
       class MyObject extends EmberObject.extend(Mixin1, Mixin2) {}
 
-      let myObject = new MyObject();
+      let myObject = MyObject.create();
       assert.equal(myObject.property1, 'data-1', 'includes the first mixin');
       assert.equal(myObject.property2, 'data-2', 'includes the second mixin');
     }
@@ -207,14 +188,10 @@ moduleFor(
     ['@test using instanceof'](assert) {
       class MyObject extends EmberObject {}
 
-      let myObject1 = MyObject.create();
-      let myObject2 = new MyObject();
+      let myObject = MyObject.create();
 
-      assert.ok(myObject1 instanceof MyObject);
-      assert.ok(myObject1 instanceof EmberObject);
-
-      assert.ok(myObject2 instanceof MyObject);
-      assert.ok(myObject2 instanceof EmberObject);
+      assert.ok(myObject instanceof MyObject);
+      assert.ok(myObject instanceof EmberObject);
     }
 
     ['@test extending an ES subclass of EmberObject'](assert) {
@@ -236,10 +213,6 @@ moduleFor(
 
       MyObject.create();
       assert.deepEqual(calls, ['constructor', 'init'], 'constructor then init called (create)');
-
-      calls = [];
-      new MyObject();
-      assert.deepEqual(calls, ['constructor', 'init'], 'constructor then init called (new)');
     }
 
     ['@test calling extend on an ES subclass of EmberObject'](assert) {
@@ -266,14 +239,6 @@ moduleFor(
         calls,
         ['before constructor', 'after constructor', 'init'],
         'constructor then init called (create)'
-      );
-
-      calls = [];
-      new MyObject();
-      assert.deepEqual(
-        calls,
-        ['before constructor', 'init', 'after constructor'],
-        'constructor then init called (new)'
       );
 
       let obj = MyObject.create({

--- a/packages/@ember/-internals/runtime/tests/system/object/extend_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/extend_test.js
@@ -8,14 +8,14 @@ moduleFor(
     ['@test Basic extend'](assert) {
       let SomeClass = EmberObject.extend({ foo: 'BAR' });
       assert.ok(SomeClass.isClass, 'A class has isClass of true');
-      let obj = new SomeClass();
+      let obj = SomeClass.create();
       assert.equal(obj.foo, 'BAR');
     }
 
     ['@test Sub-subclass'](assert) {
       let SomeClass = EmberObject.extend({ foo: 'BAR' });
       let AnotherClass = SomeClass.extend({ bar: 'FOO' });
-      let obj = new AnotherClass();
+      let obj = AnotherClass.create();
       assert.equal(obj.foo, 'BAR');
       assert.equal(obj.bar, 'FOO');
     }
@@ -49,7 +49,7 @@ moduleFor(
         },
       });
 
-      let obj = new FinalClass();
+      let obj = FinalClass.create();
       obj.foo();
       obj.bar();
       assert.equal(obj.fooCnt, 2, 'should invoke both');
@@ -76,9 +76,9 @@ moduleFor(
       });
       let AnotherClass = SomeClass.extend({ things: 'bar' });
       let YetAnotherClass = SomeClass.extend({ things: 'baz' });
-      let some = new SomeClass();
-      let another = new AnotherClass();
-      let yetAnother = new YetAnotherClass();
+      let some = SomeClass.create();
+      let another = AnotherClass.create();
+      let yetAnother = YetAnotherClass.create();
       assert.deepEqual(some.get('things'), ['foo'], 'base class should have just its value');
       assert.deepEqual(
         another.get('things'),
@@ -102,9 +102,9 @@ moduleFor(
       AnotherClass.reopenClass({ things: 'bar' });
       let YetAnotherClass = SomeClass.extend();
       YetAnotherClass.reopenClass({ things: 'baz' });
-      let some = new SomeClass();
-      let another = new AnotherClass();
-      let yetAnother = new YetAnotherClass();
+      let some = SomeClass.create();
+      let another = AnotherClass.create();
+      let yetAnother = YetAnotherClass.create();
       assert.deepEqual(
         get(some.constructor, 'things'),
         ['foo'],

--- a/packages/@ember/-internals/runtime/tests/system/object/observer_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/observer_test.js
@@ -15,7 +15,7 @@ moduleFor(
         }),
       });
 
-      let obj = new MyClass();
+      let obj = MyClass.create();
       assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
       set(obj, 'bar', 'BAZ');
@@ -37,7 +37,7 @@ moduleFor(
         }),
       });
 
-      let obj = new Subclass();
+      let obj = Subclass.create();
       assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
       set(obj, 'bar', 'BAZ');
@@ -200,7 +200,7 @@ moduleFor(
         },
       });
 
-      let parent = new ParentClass();
+      let parent = ParentClass.create();
 
       assert.equal(changed, false, 'precond');
 

--- a/packages/@ember/-internals/runtime/tests/system/object/reopen_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/reopen_test.js
@@ -14,8 +14,8 @@ moduleFor(
         bar: 'BAR',
       });
 
-      assert.equal(new Subclass().foo(), 'FOO', 'Adds method');
-      assert.equal(get(new Subclass(), 'bar'), 'BAR', 'Adds property');
+      assert.equal(Subclass.create().foo(), 'FOO', 'Adds method');
+      assert.equal(get(Subclass.create(), 'bar'), 'BAR', 'Adds property');
     }
 
     ['@test reopened properties inherited by subclasses'](assert) {
@@ -29,8 +29,8 @@ moduleFor(
         bar: 'BAR',
       });
 
-      assert.equal(new SubSub().foo(), 'FOO', 'Adds method');
-      assert.equal(get(new SubSub(), 'bar'), 'BAR', 'Adds property');
+      assert.equal(SubSub.create().foo(), 'FOO', 'Adds method');
+      assert.equal(get(SubSub.create(), 'bar'), 'BAR', 'Adds property');
     }
 
     ['@test allows reopening already instantiated classes'](assert) {

--- a/packages/ember-testing/lib/setup_for_testing.js
+++ b/packages/ember-testing/lib/setup_for_testing.js
@@ -29,7 +29,7 @@ export default function setupForTesting() {
   let adapter = getAdapter();
   // if adapter is not manually set default to QUnit
   if (!adapter) {
-    setAdapter(typeof self.QUnit === 'undefined' ? new Adapter() : new QUnitAdapter());
+    setAdapter(typeof self.QUnit === 'undefined' ? Adapter.create() : QUnitAdapter.create());
   }
 
   if (!jQueryDisabled) {

--- a/packages/ember-testing/tests/adapters/adapter_test.js
+++ b/packages/ember-testing/tests/adapters/adapter_test.js
@@ -9,7 +9,7 @@ moduleFor(
   class extends AbstractTestCase {
     constructor() {
       super();
-      adapter = new Adapter();
+      adapter = Adapter.create();
     }
 
     teardown() {

--- a/packages/ember-testing/tests/adapters/qunit_test.js
+++ b/packages/ember-testing/tests/adapters/qunit_test.js
@@ -15,7 +15,7 @@ moduleFor(
       delete QUnit.start;
       delete QUnit.stop;
 
-      adapter = new QUnitAdapter();
+      adapter = QUnitAdapter.create();
     }
 
     teardown() {

--- a/packages/internal-test-helpers/lib/build-owner.js
+++ b/packages/internal-test-helpers/lib/build-owner.js
@@ -25,7 +25,7 @@ export default function buildOwner(options = {}) {
 
   let Owner = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixin);
 
-  let namespace = new EmberObject({
+  let namespace = EmberObject.create({
     Resolver: new ResolverWrapper(resolver),
   });
 


### PR DESCRIPTION
Implements RFC 337, delaying initialization of create properties until after object construction. This PR is currently meant to be a PoC, and is dependent on the RFC being merged. It'll also help to inform certain behaviors, like for instance whether or not we should deprecate `new EmberObject()` altogether, or just deprecate passing in init properties.

There are two commits on this branch currently, one in which chains are _enabled_ during the initial construction phase, then disabled when the init properties are applied, and one where they are disabled throughout construction. Both have been benchmarked against master, which shows a minor regression in terms of speed.

[results.pdf](https://github.com/emberjs/ember.js/files/2168617/results.pdf)
[results.json.txt](https://github.com/emberjs/ember.js/files/2168618/results.json.txt)
