### PR TITLE
[DOC] Improve documentation of unless template helper (issue #16592)

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/helpers/if-unless.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/if-unless.ts
@@ -145,18 +145,34 @@ export function inlineIf(_vm: VM, { positional }: Arguments) {
 }
 
 /**
+  The `unless` helper is the inverse of the `if` helper. It displays if a value
+  is falsey (`not true` or `is false`). Example values that will display with
+  `unless`: `false`, `undefined`, `null`, `""`, `0`, `NaN` or an empty array.
+
+  ## Inline form
+
   The inline `unless` helper conditionally renders a single property or string.
   This helper acts like a ternary operator. If the first property is falsy,
   the second argument will be displayed, otherwise, the third argument will be
   displayed
 
+  For example, if `useLongGreeting` is false below:
+
   ```handlebars
   {{unless useLongGreeting "Hi" "Hello"}} Ben
   ```
 
+  Then it will display:
+
+  ```html
+  Hi
+  ```
+
   You can use the `unless` helper inside another helper as a subexpression.
+  If isBig is not true, it will set the height to 10:
 
   ```handlebars
+  {{! If isBig is not true, it will set the height to 10.}}
   <SomeComponent @height={{unless isBig "10" "100"}} />
   ```
 
@@ -164,6 +180,36 @@ export function inlineIf(_vm: VM, { positional }: Arguments) {
 
   ```handlebars
   {{some-component height=(unless isBig "10" "100")}}
+  ```
+
+  ## Block form
+
+  Like the `if` helper, `unless` helper also has a block form.
+
+  ```handlebars
+  {{! If greetings are found, the text below will not render.}}
+  {{#unless greeting}}
+    No greetings were found. Why not set one?
+  {{/unless}}
+  ```
+
+  You can also use an `else` helper with the `unless` block. The
+  `else` will display if the value is truthy.
+
+  ```handlebars
+  {{! Is the user logged in?}}
+  {{#unless userData}}
+    Please login.
+  {{else}}
+    Welcome back!
+  {{/unless}}
+  ```
+
+  If `userData` is false, undefined, null, or empty in the above example,
+  then it will render:
+
+  ```html
+  Please login.
   ```
 
   @method unless

--- a/packages/@ember/-internals/glimmer/lib/helpers/if-unless.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/if-unless.ts
@@ -146,7 +146,7 @@ export function inlineIf(_vm: VM, { positional }: Arguments) {
 
 /**
   The `unless` helper is the inverse of the `if` helper. It displays if a value
-  is falsey (`not true` or `is false`). Example values that will display with
+  is falsey ("not true" or "is false"). Example values that will display with
   `unless`: `false`, `undefined`, `null`, `""`, `0`, `NaN` or an empty array.
 
   ## Inline form

--- a/packages/@ember/-internals/glimmer/lib/helpers/if-unless.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/if-unless.ts
@@ -188,7 +188,7 @@ export function inlineIf(_vm: VM, { positional }: Arguments) {
 
   ```handlebars
   {{! If greetings are found, the text below will not render.}}
-  {{#unless greeting}}
+  {{#unless greetings}}
     No greetings were found. Why not set one?
   {{/unless}}
   ```


### PR DESCRIPTION
This pull request updates the documentation for the `unless` helper, as requested in issue #16592. The aim is to make it less confusing for both native English speakers and multilingual developers.

This includes:
- Clarifying which values are falsey
- Using simpler language ("is not", "is false", etc.)
- Clarification in the examples of expected result
- Adds a block example
- Also a block with an else example

Closes https://github.com/emberjs/ember.js/issues/16592.