### PR TITLE
Rename `unknown` to `unusable`.

### DIFF
--- a/packages/ember-metal/lib/tracked.ts
+++ b/packages/ember-metal/lib/tracked.ts
@@ -2,7 +2,7 @@ import { combine, CONSTANT_TAG, Tag } from '@glimmer/reference';
 import { dirty, tagFor, tagForProperty, update } from './tags';
 
 type Option<T> = T | null;
-type unknown = null | undefined | void | {};
+type unusable = null | undefined | void | {};
 
 /**
   An object that that tracks @tracked properties that were consumed.
@@ -162,7 +162,7 @@ function descriptorForAccessor(
     return ret;
   }
 
-  function setter(this: unknown) {
+  function setter(this: unusable) {
     dirty(tagForProperty(this, key));
     set.apply(this, arguments);
   }


### PR DESCRIPTION
TypeScript 3.0 will be introducing a new `unknown` type, (which is a "top" type, and likely does exactly what you want here). As an unfortunate result, this means that `unknown` is a reserved type name, so `unknown` will have to either be renamed, or removed entirely in upgrading to TypeScript 3.0.