### PR TITLE
Remove BUILD_TYPE from everywhere except alpha publish, it defaults on master to canary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,11 +91,9 @@ jobs:
     - env: TEST_SUITE=travis-browsers
     - env:
       - TEST_SUITE=each-package-tests
-      - BUILD_TYPE=alpha
 
     - stage: deploy
       env:
-      - BUILD_TYPE=canary
       - PUBLISH=true
       script:
         - "./bin/publish_builds"


### PR DESCRIPTION
- Should make beta.1 easier?