### PR TITLE
Router(js) refactor (wip)

### DIFF
--- a/broccoli/packages.js
+++ b/broccoli/packages.js
@@ -25,7 +25,7 @@ module.exports.routerES = function _routerES() {
       external: ['route-recognizer', 'rsvp'],
       input: 'index.js',
       output: {
-        file: 'router.js',
+        file: 'router_js.js',
         format: 'es',
       },
     },

--- a/packages/@ember/-internals/routing/lib/services/router.js
+++ b/packages/@ember/-internals/routing/lib/services/router.js
@@ -219,9 +219,10 @@ const RouterService = Service.extend({
    */
   isActive(...args) {
     let { routeName, models, queryParams } = extractRouteArgs(args);
+    let router = this._router;
     let routerMicrolib = this._router._routerMicrolib;
 
-    if (!routerMicrolib.isActiveIntent(routeName, models, null)) {
+    if (!router._isActiveIntent(routeName, models, null)) {
       return false;
     }
     let hasQueryParams = Object.keys(queryParams).length > 0;

--- a/packages/@ember/-internals/routing/lib/services/routing.js
+++ b/packages/@ember/-internals/routing/lib/services/routing.js
@@ -48,7 +48,7 @@ export default Service.extend({
   generateURL(routeName, models, queryParams) {
     let router = get(this, 'router');
     // return early when the router microlib is not present, which is the case for {{link-to}} in integration tests
-    if (!router._routerMicrolib) {
+    if (!router._isSetup) {
       return;
     }
 

--- a/packages/@ember/-internals/routing/lib/system/route.js
+++ b/packages/@ember/-internals/routing/lib/system/route.js
@@ -417,7 +417,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
       return {};
     }
 
-    let transition = this._router._routerMicrolib.activeTransition;
+    let transition = this._router._activeTransition;
     let state = transition ? transition.state : this._router._routerMicrolib.state;
 
     let fullName = route.fullRouteName;
@@ -1934,10 +1934,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
   modelFor(_name) {
     let name;
     let owner = getOwner(this);
-    let transition =
-      this._router && this._router._routerMicrolib
-        ? this._router._routerMicrolib.activeTransition
-        : undefined;
+    let transition = this._router ? this._router._activeTransition : null;
 
     // Only change the route name when there is an active transition.
     // Otherwise, use the passed in route name.

--- a/packages/@ember/-internals/routing/lib/system/route.js
+++ b/packages/@ember/-internals/routing/lib/system/route.js
@@ -1934,7 +1934,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
   modelFor(_name) {
     let name;
     let owner = getOwner(this);
-    let transition = this._router ? this._router._activeTransition : null;
+    let transition = this._router && this._router._isSetup ? this._router._activeTransition : null;
 
     // Only change the route name when there is an active transition.
     // Otherwise, use the passed in route name.

--- a/packages/@ember/-internals/routing/lib/system/route.js
+++ b/packages/@ember/-internals/routing/lib/system/route.js
@@ -1320,7 +1320,7 @@ let Route = EmberObject.extend(ActionHandler, Evented, {
       }'.`,
       !this.isDestroying && !this.isDestroyed
     );
-    if ((this._router && this._router._routerMicrolib) || !isTesting()) {
+    if ((this._router && this._router._isSetup) || !isTesting()) {
       this._router.send(...args);
     } else {
       let name = args.shift();

--- a/packages/@ember/-internals/routing/lib/system/router.js
+++ b/packages/@ember/-internals/routing/lib/system/router.js
@@ -17,7 +17,7 @@ import { ORPHAN_OUTLET_RENDER } from '@ember/deprecated-features';
 @module @ember/routing
 */
 
-import Router from 'router';
+import Router from 'router_js';
 
 function K() {
   return this;
@@ -498,10 +498,10 @@ const EmberRouter = EmberObject.extend(Evented, {
     Use `isActiveIntent` if checking against the current state.
 
     @method _isActiveIntent
-    @param {*} routeName 
-    @param {*} models 
-    @param {*} queryParams 
-    @param {*} state 
+    @param {*} routeName
+    @param {*} models
+    @param {*} queryParams
+    @param {*} state
     @private
   */
   _isActiveIntent(routeName, models, queryParams, state) {

--- a/packages/@ember/-internals/routing/lib/system/router.js
+++ b/packages/@ember/-internals/routing/lib/system/router.js
@@ -184,27 +184,25 @@ const EmberRouter = EmberObject.extend(Evented, {
 
   /**
     Tell us if the router is currently loading.
-    
-    @method _isLoading
-    @return {Boolean} The loading state
+    @property _isLoading
+    @type {Boolean}
     @private
   */
-  get _isLoading() {
+  _isLoading: computed(function() {
     return !!this._activeTransition;
-  },
+  }).volatile(),
 
   /**
     The active transition
-  
-    @method _activeTransition
-    @return {Transition} Return router's active Transition object
+    @property _activeTransition
+    @type {Transition}
     @private
   */
-  get _activeTransition() {
+  _activeTransition: computed(function() {
     if (this._routerMicrolib) {
       return this._routerMicrolib.activeTransition;
     }
-  },
+  }).volatile(),
 
   _hasModuleBasedResolver() {
     let owner = getOwner(this);

--- a/packages/@ember/-internals/routing/lib/system/router.js
+++ b/packages/@ember/-internals/routing/lib/system/router.js
@@ -490,7 +490,22 @@ const EmberRouter = EmberObject.extend(Evented, {
     @since 1.7.0
   */
   isActiveIntent(routeName, models, queryParams) {
-    return this.currentState.isActiveIntent(routeName, models, queryParams);
+    return this._isActiveIntent(routeName, models, queryParams, this.currentState);
+  },
+
+  /**
+    Check if the intent is active for a given state and related arguments.
+    Use `isActiveIntent` if checking against the current state.
+
+    @method _isActiveIntent
+    @param {*} routeName 
+    @param {*} models 
+    @param {*} queryParams 
+    @param {*} state 
+    @private
+  */
+  _isActiveIntent(routeName, models, queryParams, state) {
+    return this._routerMicrolib.isActiveIntent(routeName, models, queryParams, state);
   },
 
   send() {
@@ -1049,7 +1064,7 @@ const EmberRouter = EmberObject.extend(Evented, {
       // the transition that put us in a loading state.
       return;
     }
-    let targetState = new RouterState(this, this._routerMicrolib, this._activeTransition.state);
+    let targetState = new RouterState(this, this._activeTransition.state);
     this.set('targetState', targetState);
 
     transition.trigger(true, 'loading', transition, originRoute);
@@ -1489,7 +1504,7 @@ EmberRouter.reopenClass({
 });
 
 function didBeginTransition(transition, router) {
-  let routerState = new RouterState(router, router._routerMicrolib, transition.state);
+  let routerState = new RouterState(router, transition.state);
 
   if (!router.currentState) {
     router.set('currentState', routerState);

--- a/packages/@ember/-internals/routing/lib/system/router.js
+++ b/packages/@ember/-internals/routing/lib/system/router.js
@@ -181,6 +181,19 @@ const EmberRouter = EmberObject.extend(Evented, {
     return get(this, 'location').getURL();
   }),
 
+  /**
+    Tell us if the router is currently loading.
+    
+    @method _isLoading
+    @return {Boolean} The loading state
+    @private
+  */
+  _isLoading: computed(function() {
+    if (this._routerMicrolib) {
+      return !!this._routerMicrolib.activeTransition;
+    }
+  }),
+
   _hasModuleBasedResolver() {
     let owner = getOwner(this);
     if (!owner) {

--- a/packages/@ember/-internals/routing/lib/system/router.js
+++ b/packages/@ember/-internals/routing/lib/system/router.js
@@ -188,7 +188,7 @@ const EmberRouter = EmberObject.extend(Evented, {
     @return {Boolean} The loading state
     @private
   */
-  _isLoading: computed(function() {
+  _isLoading: computed('_activeTransition', function() {
     return !!this._activeTransition;
   }),
 

--- a/packages/@ember/-internals/routing/lib/system/router.js
+++ b/packages/@ember/-internals/routing/lib/system/router.js
@@ -189,9 +189,9 @@ const EmberRouter = EmberObject.extend(Evented, {
     @return {Boolean} The loading state
     @private
   */
-  _isLoading: computed('_activeTransition', function() {
+  get _isLoading() {
     return !!this._activeTransition;
-  }),
+  },
 
   /**
     The active transition
@@ -200,11 +200,11 @@ const EmberRouter = EmberObject.extend(Evented, {
     @return {Transition} Return router's active Transition object
     @private
   */
-  _activeTransition: computed(function() {
+  get _activeTransition() {
     if (this._routerMicrolib) {
       return this._routerMicrolib.activeTransition;
     }
-  }),
+  },
 
   _hasModuleBasedResolver() {
     let owner = getOwner(this);

--- a/packages/@ember/-internals/routing/lib/system/router.js
+++ b/packages/@ember/-internals/routing/lib/system/router.js
@@ -104,6 +104,7 @@ const EmberRouter = EmberObject.extend(Evented, {
       replaceURL,
     }));
 
+    this._isSetup = true;
     routerMicrolib._triggerWillChangeContext = K;
     routerMicrolib._triggerWillLeave = K;
 

--- a/packages/@ember/-internals/routing/lib/system/router.js
+++ b/packages/@ember/-internals/routing/lib/system/router.js
@@ -189,8 +189,19 @@ const EmberRouter = EmberObject.extend(Evented, {
     @private
   */
   _isLoading: computed(function() {
+    return !!this._activeTransition;
+  }),
+
+  /**
+    The active transition
+  
+    @method _activeTransition
+    @return {Transition} Return router's active Transition object
+    @private
+  */
+  _activeTransition: computed(function() {
     if (this._routerMicrolib) {
-      return !!this._routerMicrolib.activeTransition;
+      return this._routerMicrolib.activeTransition;
     }
   }),
 
@@ -795,13 +806,13 @@ const EmberRouter = EmberObject.extend(Evented, {
   _processActiveTransitionQueryParams(targetRouteName, models, queryParams, _queryParams) {
     // merge in any queryParams from the active transition which could include
     // queryParams from the url on initial load.
-    if (!this._routerMicrolib.activeTransition) {
+    if (!this._activeTransition) {
       return;
     }
 
     let unchangedQPs = {};
     let qpUpdates = this._qpUpdates || {};
-    let params = this._routerMicrolib.activeTransition.queryParams;
+    let params = this._activeTransition.queryParams;
     for (let key in params) {
       if (!qpUpdates[key]) {
         unchangedQPs[key] = params[key];
@@ -1034,16 +1045,12 @@ const EmberRouter = EmberObject.extend(Evented, {
   targetState: null,
 
   _handleSlowTransition(transition, originRoute) {
-    if (!this._routerMicrolib.activeTransition) {
+    if (!this._activeTransition) {
       // Don't fire an event if we've since moved on from
       // the transition that put us in a loading state.
       return;
     }
-    let targetState = new RouterState(
-      this,
-      this._routerMicrolib,
-      this._routerMicrolib.activeTransition.state
-    );
+    let targetState = new RouterState(this, this._routerMicrolib, this._activeTransition.state);
     this.set('targetState', targetState);
 
     transition.trigger(true, 'loading', transition, originRoute);

--- a/packages/@ember/-internals/routing/lib/system/router_state.js
+++ b/packages/@ember/-internals/routing/lib/system/router_state.js
@@ -2,15 +2,14 @@ import { assign } from '@ember/polyfills';
 import { shallowEqual } from '../utils';
 
 export default class RouterState {
-  constructor(emberRouter = null, routerJs = null, routerJsState = null) {
+  constructor(emberRouter = null, routerJsState = null) {
     this.emberRouter = emberRouter;
-    this.routerJs = routerJs;
     this.routerJsState = routerJsState;
   }
 
   isActiveIntent(routeName, models, queryParams, queryParamsMustMatch) {
     let state = this.routerJsState;
-    if (!this.routerJs.isActiveIntent(routeName, models, null, state)) {
+    if (!this.emberRouter._isActiveIntent(routeName, models, null, state)) {
       return false;
     }
 

--- a/packages/@ember/-internals/routing/tests/system/route_test.js
+++ b/packages/@ember/-internals/routing/tests/system/route_test.js
@@ -424,12 +424,11 @@ moduleFor(
       let postsModel = { id: '2' };
 
       let router = {
-        _routerMicrolib: {
-          activeTransition: {
-            resolvedModels: {
-              'foo.bar': applicationModel,
-              'foo.bar.posts': postsModel,
-            },
+        _isSetup: true,
+        _activeTransition: {
+          resolvedModels: {
+            'foo.bar': applicationModel,
+            'foo.bar.posts': postsModel,
           },
         },
       };

--- a/packages/@ember/application/instance.js
+++ b/packages/@ember/application/instance.js
@@ -255,11 +255,8 @@ const ApplicationInstance = EngineInstance.extend({
     let handleTransitionReject = error => {
       if (error.error) {
         throw error.error;
-      } else if (error.name === 'TransitionAborted' && router._routerMicrolib.activeTransition) {
-        return router._routerMicrolib.activeTransition.then(
-          handleTransitionResolve,
-          handleTransitionReject
-        );
+      } else if (error.name === 'TransitionAborted' && router._activeTransition) {
+        return router._activeTransition.then(handleTransitionResolve, handleTransitionReject);
       } else if (error.name === 'TransitionAborted') {
         throw new Error(error.message);
       } else {

--- a/packages/ember-testing/lib/helpers/wait.js
+++ b/packages/ember-testing/lib/helpers/wait.js
@@ -43,7 +43,7 @@ export default function wait(app, value) {
     // Every 10ms, poll for the async thing to have finished
     let watcher = setInterval(() => {
       // 1. If the router is loading, keep polling
-      let routerIsLoading = router._routerMicrolib && !!router._routerMicrolib.activeTransition;
+      let routerIsLoading = router._isLoading;
       if (routerIsLoading) {
         return;
       }

--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -12,7 +12,7 @@ import { Mixin, computed, set, addObserver, observer } from '@ember/-internals/m
 import { getTextOf } from 'internal-test-helpers';
 import { Component } from '@ember/-internals/glimmer';
 import Engine from '@ember/engine';
-import { Transition } from 'router';
+import { Transition } from 'router_js';
 
 let originalRenderSupport;
 let originalConsoleError;

--- a/packages/ember/tests/routing/router_service_test/replaceWith_test.js
+++ b/packages/ember/tests/routing/router_service_test/replaceWith_test.js
@@ -1,6 +1,6 @@
 import { NoneLocation } from '@ember/-internals/routing';
 import { RouterTestCase, moduleFor } from 'internal-test-helpers';
-import { Transition } from 'router';
+import { Transition } from 'router_js';
 import Controller from '@ember/controller';
 
 import { EMBER_ROUTING_ROUTER_SERVICE } from '@ember/canary-features';

--- a/packages/ember/tests/routing/router_service_test/transitionTo_test.js
+++ b/packages/ember/tests/routing/router_service_test/transitionTo_test.js
@@ -5,7 +5,7 @@ import Controller from '@ember/controller';
 import { run } from '@ember/runloop';
 import { get } from '@ember/-internals/metal';
 import { RouterTestCase, moduleFor } from 'internal-test-helpers';
-import { Transition } from 'router';
+import { Transition } from 'router_js';
 
 import { EMBER_ROUTING_ROUTER_SERVICE } from '@ember/canary-features';
 


### PR DESCRIPTION
Putting this here for visibility, this is still a WIP, please don't merge.

---

Notes from slack:

```no-highlight
Nathan Hammond
Couple of thoughts:
- I generally dislike things like `isSetup` because eventually everything has that check on it. I understand why it's there, but it'd be nice not to need it in the future.

Nathan Hammond
The volatile CPs are because you're aliasing properties that are outside of Ember's world. This is actually a use case for observers. Or possibly refactoring router.js to emit something we can watch for.
```