### PR TITLE
correctly pass debug name `computed.intersect`

### DIFF
--- a/packages/@ember/object/lib/computed/reduce_computed_macros.js
+++ b/packages/@ember/object/lib/computed/reduce_computed_macros.js
@@ -575,33 +575,37 @@ export let union = uniq;
   @public
 */
 export function intersect(...args) {
-  return multiArrayMacro(args, function(dependentKeys) {
-    let arrays = dependentKeys.map(dependentKey => {
-      let array = get(this, dependentKey);
-      return isArray(array) ? array : [];
-    });
+  return multiArrayMacro(
+    args,
+    function(dependentKeys) {
+      let arrays = dependentKeys.map(dependentKey => {
+        let array = get(this, dependentKey);
+        return isArray(array) ? array : [];
+      });
 
-    let results = arrays.pop().filter(candidate => {
-      for (let i = 0; i < arrays.length; i++) {
-        let found = false;
-        let array = arrays[i];
-        for (let j = 0; j < array.length; j++) {
-          if (array[j] === candidate) {
-            found = true;
-            break;
+      let results = arrays.pop().filter(candidate => {
+        for (let i = 0; i < arrays.length; i++) {
+          let found = false;
+          let array = arrays[i];
+          for (let j = 0; j < array.length; j++) {
+            if (array[j] === candidate) {
+              found = true;
+              break;
+            }
+          }
+
+          if (found === false) {
+            return false;
           }
         }
 
-        if (found === false) {
-          return false;
-        }
-      }
+        return true;
+      });
 
-      return true;
-    }, 'intersect');
-
-    return emberA(results);
-  });
+      return emberA(results);
+    },
+    'intersect'
+  );
 }
 
 /**


### PR DESCRIPTION
was committed here: https://github.com/emberjs/ember.js/commit/aabc86b5e7506cf53d4df728051c3719b652b5ed#diff-be5c035bb6df695f80dbf5d940188c68R568 , wrongly passing name of function which used for assertion