### PR TITLE
fix: QUnit mixin-tests in external addons should import from dummy/mixins

### DIFF
--- a/blueprints/mixin-test/index.js
+++ b/blueprints/mixin-test/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const stringUtils = require('ember-cli-string-utils');
+
 const path = require('path');
 
 const useTestFrameworkDetector = require('../test-framework-detector');
@@ -35,8 +37,13 @@ module.exports = useTestFrameworkDetector({
   },
 
   locals: function(options) {
+    let projectName = options.inRepoAddon ? options.inRepoAddon : options.project.name();
+    let dasherizedModulePrefix = options.inRepoAddon
+      ? projectName
+      : stringUtils.dasherize(options.project.config().modulePrefix);
     return {
-      projectName: options.inRepoAddon ? options.inRepoAddon : options.project.name(),
+      dasherizedModulePrefix,
+      projectName,
       friendlyTestName: ['Unit', 'Mixin', options.entity.name].join(' | '),
     };
   },

--- a/blueprints/mixin-test/qunit-files/__root__/__testType__/__name__-test.js
+++ b/blueprints/mixin-test/qunit-files/__root__/__testType__/__name__-test.js
@@ -1,5 +1,5 @@
 import EmberObject from '@ember/object';
-import <%= classifiedModuleName %>Mixin from '<%= projectName %>/mixins/<%= dasherizedModuleName %>';
+import <%= classifiedModuleName %>Mixin from '<%= dasherizedModulePrefix %>/mixins/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 
 module('<%= friendlyTestName %>');

--- a/blueprints/mixin-test/qunit-rfc-232-files/__root__/__testType__/__name__-test.js
+++ b/blueprints/mixin-test/qunit-rfc-232-files/__root__/__testType__/__name__-test.js
@@ -1,5 +1,5 @@
 import EmberObject from '@ember/object';
-import <%= classifiedModuleName %>Mixin from '<%= projectName %>/mixins/<%= dasherizedModuleName %>';
+import <%= classifiedModuleName %>Mixin from '<%= dasherizedModulePrefix %>/mixins/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 
 module('<%= friendlyTestName %>', function() {

--- a/node-tests/blueprints/mixin-test-test.js
+++ b/node-tests/blueprints/mixin-test-test.js
@@ -101,7 +101,7 @@ describe('Blueprint: mixin-test', function() {
 
     it('mixin-test foo', function() {
       return emberGenerateDestroy(['mixin-test', 'foo'], _file => {
-        expect(_file('tests/unit/mixins/foo-test.js')).to.equal(fixture('mixin-test/addon.js'));
+        expect(_file('tests/unit/mixins/foo-test.js')).to.equal(fixture('mixin-test/dummy.js'));
       });
     });
   });
@@ -113,7 +113,7 @@ describe('Blueprint: mixin-test', function() {
 
     it('mixin-test foo', function() {
       return emberGenerateDestroy(['mixin-test', 'foo'], _file => {
-        expect(_file('src/mixins/foo-test.js')).to.equal(fixture('mixin-test/addon.js'));
+        expect(_file('src/mixins/foo-test.js')).to.equal(fixture('mixin-test/dummy.js'));
       });
     });
   });

--- a/node-tests/blueprints/mixin-test.js
+++ b/node-tests/blueprints/mixin-test.js
@@ -175,7 +175,7 @@ describe('Blueprint: mixin', function() {
           .to.contain('export default Mixin.create({\n});');
 
         expect(_file('tests/unit/mixins/foo-test.js')).to.contain(
-          "import FooMixin from 'my-addon/mixins/foo';"
+          "import FooMixin from 'dummy/mixins/foo';"
         );
 
         expect(_file('app/mixins/foo.js')).to.not.exist;
@@ -189,7 +189,7 @@ describe('Blueprint: mixin', function() {
           .to.contain('export default Mixin.create({\n});');
 
         expect(_file('tests/unit/mixins/foo/bar-test.js')).to.contain(
-          "import FooBarMixin from 'my-addon/mixins/foo/bar';"
+          "import FooBarMixin from 'dummy/mixins/foo/bar';"
         );
 
         expect(_file('app/mixins/foo/bar.js')).to.not.exist;
@@ -203,7 +203,7 @@ describe('Blueprint: mixin', function() {
           .to.contain('export default Mixin.create({\n});');
 
         expect(_file('tests/unit/mixins/foo/bar/baz-test.js')).to.contain(
-          "import FooBarBazMixin from 'my-addon/mixins/foo/bar/baz';"
+          "import FooBarBazMixin from 'dummy/mixins/foo/bar/baz';"
         );
 
         expect(_file('app/mixins/foo/bar/baz.js')).to.not.exist;
@@ -223,7 +223,7 @@ describe('Blueprint: mixin', function() {
           .to.contain('export default Mixin.create({\n});');
 
         expect(_file('src/mixins/foo-test.js')).to.contain(
-          "import FooMixin from 'my-addon/mixins/foo';"
+          "import FooMixin from 'dummy/mixins/foo';"
         );
       });
     });
@@ -235,7 +235,7 @@ describe('Blueprint: mixin', function() {
           .to.contain('export default Mixin.create({\n});');
 
         expect(_file('src/mixins/foo/bar-test.js')).to.contain(
-          "import FooBarMixin from 'my-addon/mixins/foo/bar';"
+          "import FooBarMixin from 'dummy/mixins/foo/bar';"
         );
       });
     });
@@ -247,7 +247,7 @@ describe('Blueprint: mixin', function() {
           .to.contain('export default Mixin.create({\n});');
 
         expect(_file('src/mixins/foo/bar/baz-test.js')).to.contain(
-          "import FooBarBazMixin from 'my-addon/mixins/foo/bar/baz';"
+          "import FooBarBazMixin from 'dummy/mixins/foo/bar/baz';"
         );
       });
     });

--- a/node-tests/fixtures/mixin-test/dummy.js
+++ b/node-tests/fixtures/mixin-test/dummy.js
@@ -1,0 +1,12 @@
+import EmberObject from '@ember/object';
+import FooMixin from 'dummy/mixins/foo';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | foo');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let FooObject = EmberObject.extend(FooMixin);
+  let subject = FooObject.create();
+  assert.ok(subject);
+});


### PR DESCRIPTION
Currently, mixin-tests generated within an external addon import their respective mixins **directly from the `/addon` namespace** like this;

```js
import FooMixin from 'my-addon/mixins/foo';
```

I think it should be like this, to align with all other tests that need to import their respective "object being tested" as a module. 

```js
import FooMixin from 'dummy/mixins/foo';
```
Even if my addon's mixin lives exclusively in the `/app` folder or the dummy app, importing from `/dummy` will cause the test to pass immediately after being generated.

### Examples of this pattern elsewhere in ember's blueprints
##### Util Tests
https://github.com/emberjs/ember.js/blob/04208064f8ecf4d9a31a428090191b37859be08c/node-tests/fixtures/util-test/dummy.js#L1

##### Initializer Tests
https://github.com/emberjs/ember.js/blob/04208064f8ecf4d9a31a428090191b37859be08c/node-tests/fixtures/instance-initializer-test/dummy.js#L3

##### Helper Unit Tests
https://github.com/emberjs/ember.js/blob/04208064f8ecf4d9a31a428090191b37859be08c/blueprints/helper-test/qunit-rfc-232-files/tests/__testType__/helpers/__name__-test.js#L17

There may be others I haven't run into yet. The existing tests asserted the problematic result, and thus had to be altered.
