### PR TITLE
mark Application/EngineInstance#boot as public

### DIFF
--- a/packages/@ember/application/lib/application.js
+++ b/packages/@ember/application/lib/application.js
@@ -612,7 +612,7 @@ const Application = Engine.extend({
     is disabled, this is automatically called when the first application instance is
     created via `visit`.
 
-    @private
+    @public
     @method boot
     @return {Promise<Application,Error>}
   */

--- a/packages/@ember/engine/instance.js
+++ b/packages/@ember/engine/instance.js
@@ -66,7 +66,7 @@ const EngineInstance = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixi
 
     See the documentation on `BootOptions` for the options it takes.
 
-    @private
+    @public
     @method boot
     @param options {Object}
     @return {Promise<EngineInstance,Error>}


### PR DESCRIPTION
This method is invoked RFC-232-style QUnit initializer tests

https://github.com/emberjs/ember.js/blob/04208064f8ecf4d9a31a428090191b37859be08c/blueprints/instance-initializer-test/qunit-rfc-232-files/tests/unit/instance-initializers/__name__-test.js#L24
https://github.com/emberjs/ember.js/blob/04208064f8ecf4d9a31a428090191b37859be08c/blueprints/initializer-test/qunit-rfc-232-files/__root__/__testType__/__path__/__name__-test.js#L27

Looks like this was [a suggestion from @rwjblue](https://github.com/emberjs/ember.js/pull/15945#discussion_r155932493) -- reading through the comments, I can't think of another way to programmatically boot an app and await.