### PR TITLE
cleanup `view states`

### DIFF
--- a/packages/@ember/-internals/views/lib/views/core_view.js
+++ b/packages/@ember/-internals/views/lib/views/core_view.js
@@ -1,6 +1,6 @@
 import { ActionHandler, Evented, FrameworkObject } from '@ember/-internals/runtime';
 import { initViewElement } from '../system/utils';
-import { cloneStates, states } from './states';
+import states from './states';
 
 /**
   `Ember.CoreView` is an abstract class that exists to give view-like behavior
@@ -21,7 +21,7 @@ import { cloneStates, states } from './states';
 const CoreView = FrameworkObject.extend(Evented, ActionHandler, {
   isView: true,
 
-  _states: cloneStates(states),
+  _states: states,
 
   init() {
     this._super(...arguments);

--- a/packages/@ember/-internals/views/lib/views/states.js
+++ b/packages/@ember/-internals/views/lib/views/states.js
@@ -1,28 +1,7 @@
-import { assign } from '@ember/polyfills';
-import _default from './states/default';
 import preRender from './states/pre_render';
 import hasElement from './states/has_element';
 import inDOM from './states/in_dom';
 import destroying from './states/destroying';
-
-export function cloneStates(from) {
-  let into = {};
-
-  into._default = {};
-  into.preRender = Object.create(into._default);
-  into.destroying = Object.create(into._default);
-  into.hasElement = Object.create(into._default);
-  into.inDOM = Object.create(into.hasElement);
-
-  for (let stateName in from) {
-    if (!from.hasOwnProperty(stateName)) {
-      continue;
-    }
-    assign(into[stateName], from[stateName]);
-  }
-
-  return into;
-}
 
 /*
   Describe how the specified actions should behave in the various
@@ -39,10 +18,11 @@ export function cloneStates(from) {
     method), it is in this state. No further actions can be invoked
     on a destroyed view.
 */
-export let states = {
-  _default,
+const states = Object.freeze({
   preRender,
   inDOM,
   hasElement,
   destroying,
-};
+});
+
+export default states;

--- a/packages/@ember/-internals/views/lib/views/states/default.js
+++ b/packages/@ember/-internals/views/lib/views/states/default.js
@@ -1,6 +1,6 @@
 import EmberError from '@ember/error';
 
-export default {
+const _default = {
   // appendChild is only legal while rendering the buffer.
   appendChild() {
     throw new EmberError("You can't use appendChild outside of the rendering process");
@@ -15,3 +15,5 @@ export default {
 
   destroy() {},
 };
+
+export default Object.freeze(_default);

--- a/packages/@ember/-internals/views/lib/views/states/destroying.js
+++ b/packages/@ember/-internals/views/lib/views/states/destroying.js
@@ -2,9 +2,7 @@ import { assign } from '@ember/polyfills';
 import EmberError from '@ember/error';
 import _default from './default';
 
-const destroying = Object.create(_default);
-
-assign(destroying, {
+const destroying = assign({}, _default, {
   appendChild() {
     throw new EmberError("You can't call appendChild on a view being destroyed");
   },
@@ -13,4 +11,4 @@ assign(destroying, {
   },
 });
 
-export default destroying;
+export default Object.freeze(destroying);

--- a/packages/@ember/-internals/views/lib/views/states/has_element.js
+++ b/packages/@ember/-internals/views/lib/views/states/has_element.js
@@ -3,9 +3,7 @@ import _default from './default';
 import { join } from '@ember/runloop';
 import { flaggedInstrument } from '@ember/instrumentation';
 
-const hasElement = Object.create(_default);
-
-assign(hasElement, {
+const hasElement = assign({}, _default, {
   rerender(view) {
     view.renderer.rerender(view);
   },
@@ -28,4 +26,4 @@ assign(hasElement, {
   },
 });
 
-export default hasElement;
+export default Object.freeze(hasElement);

--- a/packages/@ember/-internals/views/lib/views/states/in_dom.js
+++ b/packages/@ember/-internals/views/lib/views/states/in_dom.js
@@ -2,12 +2,9 @@ import { assign } from '@ember/polyfills';
 import { addObserver } from '@ember/-internals/metal';
 import EmberError from '@ember/error';
 import { DEBUG } from '@glimmer/env';
-
 import hasElement from './has_element';
 
-const inDOM = Object.create(hasElement);
-
-assign(inDOM, {
+const inDOM = assign({}, hasElement, {
   enter(view) {
     // Register the view for event handling. This hash is used by
     // Ember.EventDispatcher to dispatch incoming events.
@@ -25,4 +22,4 @@ assign(inDOM, {
   },
 });
 
-export default inDOM;
+export default Object.freeze(inDOM);

--- a/packages/@ember/-internals/views/lib/views/states/pre_render.js
+++ b/packages/@ember/-internals/views/lib/views/states/pre_render.js
@@ -1,3 +1,6 @@
 import _default from './default';
+import { assign } from '@ember/polyfills';
 
-export default Object.create(_default);
+const preRender = assign({}, _default);
+
+export default Object.freeze(preRender);


### PR DESCRIPTION
* removed `cloneStates` looks redundant, initially might have been added to avoid tampering of global`states` object so now using `Object.freeze` instead.

* instead of mixing inheritance and `assign`ments just using `assign` to inherit properties from `default` state