### PR TITLE
[BUGFIX] normalize route and controller query params same way

### DIFF
--- a/packages/@ember/-internals/routing/lib/utils.js
+++ b/packages/@ember/-internals/routing/lib/utils.js
@@ -134,14 +134,21 @@ export function calculateCacheKey(prefix, parts = [], values) {
       }
     ]
 
+  Object
+    queryParams: { foo: 'foo', bar: 'bar' }
+
   This helper normalizes all three possible styles into the
   'Array of fully defined objects' style.
 */
-export function normalizeControllerQueryParams(queryParams) {
+export function normalizeQueryParamConfig(queryParams) {
   let qpMap = {};
 
-  for (let i = 0; i < queryParams.length; ++i) {
-    accumulateQueryParamDescriptors(queryParams[i], qpMap);
+  if (Array.isArray(queryParams)) {
+    for (let i = 0; i < queryParams.length; ++i) {
+      accumulateQueryParamDescriptors(queryParams[i], qpMap);
+    }
+  } else if (typeof queryParams === 'object' && queryParams !== null) {
+    accumulateQueryParamDescriptors(queryParams, qpMap);
   }
 
   return qpMap;
@@ -152,7 +159,7 @@ function accumulateQueryParamDescriptors(_desc, accum) {
   let tmp;
   if (typeof desc === 'string') {
     tmp = {};
-    tmp[desc] = { as: null };
+    tmp[desc] = {};
     desc = tmp;
   }
 
@@ -166,7 +173,7 @@ function accumulateQueryParamDescriptors(_desc, accum) {
       singleDesc = { as: singleDesc };
     }
 
-    tmp = accum[key] || { as: null, scope: 'model' };
+    tmp = accum[key] || { scope: 'model' };
     assign(tmp, singleDesc);
 
     accum[key] = tmp;

--- a/packages/@ember/-internals/routing/tests/utils_test.js
+++ b/packages/@ember/-internals/routing/tests/utils_test.js
@@ -1,13 +1,13 @@
-import { normalizeControllerQueryParams } from '../lib/utils';
+import { normalizeQueryParamConfig } from '../lib/utils';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 moduleFor(
-  'Routing query parameter utils - normalizeControllerQueryParams',
+  'Routing query parameter utils - normalizeQueryParamConfig',
   class extends AbstractTestCase {
     ['@test converts array style into verbose object style'](assert) {
       let paramName = 'foo';
       let params = [paramName];
-      let normalized = normalizeControllerQueryParams(params);
+      let normalized = normalizeQueryParamConfig(params);
 
       assert.ok(normalized[paramName], 'turns the query param name into key');
       assert.equal(normalized[paramName].as, null, "includes a blank alias in 'as' key");
@@ -17,7 +17,7 @@ moduleFor(
     ["@test converts object style [{foo: 'an_alias'}]"](assert) {
       let paramName = 'foo';
       let params = [{ foo: 'an_alias' }];
-      let normalized = normalizeControllerQueryParams(params);
+      let normalized = normalizeQueryParamConfig(params);
 
       assert.ok(normalized[paramName], 'retains the query param name as key');
       assert.equal(normalized[paramName].as, 'an_alias', "includes the provided alias in 'as' key");
@@ -26,11 +26,31 @@ moduleFor(
 
     ["@test retains maximally verbose object style [{foo: {as: 'foo'}}]"](assert) {
       let paramName = 'foo';
-      let params = [{ foo: { as: 'an_alias' } }];
-      let normalized = normalizeControllerQueryParams(params);
+      let params = [{ foo: { as: 'foo' } }];
+      let normalized = normalizeQueryParamConfig(params);
 
       assert.ok(normalized[paramName], 'retains the query param name as key');
-      assert.equal(normalized[paramName].as, 'an_alias', "includes the provided alias in 'as' key");
+      assert.equal(normalized[paramName].as, 'foo', "includes the provided alias in 'as' key");
+      assert.equal(normalized[paramName].scope, 'model', 'defaults scope to model');
+    }
+
+    ["@test converts object style { foo: { as: 'foo' } }"](assert) {
+      let paramName = 'foo';
+      let params = { foo: { as: 'foo' } };
+      let normalized = normalizeQueryParamConfig(params);
+
+      assert.ok(normalized[paramName], 'retains the query param name as key');
+      assert.equal(normalized[paramName].as, 'foo', "includes the provided alias in 'as' key");
+      assert.equal(normalized[paramName].scope, 'model', 'defaults scope to model');
+    }
+
+    ["@test converts object style { foo: 'foo' }"](assert) {
+      let paramName = 'foo';
+      let params = { foo: 'foo' };
+      let normalized = normalizeQueryParamConfig(params);
+
+      assert.ok(normalized[paramName], 'retains the query param name as key');
+      assert.equal(normalized[paramName].as, 'foo', "includes the provided alias in 'as' key");
       assert.equal(normalized[paramName].scope, 'model', 'defaults scope to model');
     }
   }

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -1575,5 +1575,55 @@ moduleFor(
         assert.equal(get(controller, 'foo'), '999');
       });
     }
+
+    ['@test Route queryparams correctly normalized'](assert) {
+      assert.expect(2);
+
+      this.router.map(function() {
+        this.route('constructor');
+      });
+
+      this.add(
+        'route:constructor',
+        Route.extend({
+          queryParams: {
+            foo: 'bar',
+            bar: 'boom',
+          },
+        })
+      );
+
+      return this.visit('/').then(() => {
+        this.transitionTo('constructor', { queryParams: { foo: '321' } });
+        this.assertCurrentPath('/constructor?bar=321');
+        this.transitionTo('constructor', { queryParams: { foo: '321', bar: 'apple' } });
+        this.assertCurrentPath('/constructor?bar=321&boom=apple');
+      });
+    }
+
+    ['@test Controller queryparams correctly normalized'](assert) {
+      assert.expect(2);
+
+      this.router.map(function() {
+        this.route('constructor');
+      });
+
+      this.add(
+        'controller:constructor',
+        Controller.extend({
+          queryParams: {
+            foo: 'bar',
+            bar: 'boom',
+          },
+        })
+      );
+
+      return this.visit('/').then(() => {
+        this.transitionTo('constructor', { queryParams: { foo: '321' } });
+        this.assertCurrentPath('/constructor?bar=321');
+        this.transitionTo('constructor', { queryParams: { foo: '321', bar: 'apple' } });
+        this.assertCurrentPath('/constructor?bar=321&boom=apple');
+      });
+    }
   }
 );


### PR DESCRIPTION
This enables object style queryParams in `Controller`s so it is consistent with `Route`'s  qp definition 
```javascript 
Controller.extend({
  queryParams: {  foo: 'bar' }
});
```

Also enables defining `queryParams` with shorthand in `Route`, which was not possible before  
```javascript 
Route.extend({
  queryParams: {  foo: 'bar' }
});
```