### PR TITLE
[BUGFIX beta] Allow ArrayProxy#pushObjects to accept ArrayProxy again

### DIFF
--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -1194,6 +1194,8 @@ const MutableArray = Mixin.create(ArrayMixin, MutableEnumerable, {
     You should replace amt objects started at idx with the objects in the
     passed array. You should also call `this.arrayContentDidChange()`
 
+    Note that this method is expected to validate the type(s) of objects that it expects.
+
     @method replace
     @param {Number} idx Starting index in the array to replace. If
       idx >= length, then append to the end of the array.
@@ -1318,9 +1320,6 @@ const MutableArray = Mixin.create(ArrayMixin, MutableEnumerable, {
     @public
   */
   pushObjects(objects) {
-    if (!Array.isArray(objects)) {
-      throw new TypeError('Must pass Enumerable to MutableArray#pushObjects');
-    }
     this.replace(this.length, 0, objects);
     return this;
   },

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -133,6 +133,8 @@ export default class ArrayProxy extends EmberObject {
     return objectAt(get(this, 'arrangedContent'), idx);
   }
 
+  // See additional docs for `replace` from `MutableArray`:
+  // https://www.emberjs.com/api/ember/3.3/classes/MutableArray/methods/replace?anchor=replace
   replace(idx, amt, objects) {
     assert(
       'Mutating an arranged ArrayProxy is not allowed',

--- a/packages/ember-runtime/tests/mutable-array/pushObjects-test.js
+++ b/packages/ember-runtime/tests/mutable-array/pushObjects-test.js
@@ -5,7 +5,7 @@ class PushObjectsTests extends AbstractTestCase {
   '@test should raise exception if not Ember.Enumerable is passed to pushObjects'() {
     let obj = this.newObject([]);
 
-    this.assert.throws(() => obj.pushObjects('string'));
+    expectAssertion(() => obj.pushObjects('string'));
   }
 }
 


### PR DESCRIPTION
This fixes #16621

@rwjblue and @hjdivad proposed the following solution:

- [x] Drop the assertion in pushObjects entirely
- [x] docs: Implementations have to assert their arguments in replace (which is the method implementations of MutableArray are expected to implement)

I'm don't know enough about Ember to know what `#2` means, but would be happy to implement it once I understand what needs to be added to the docs.