### PR TITLE
[BUGFIX beta] Don't thread FactoryManager through createComponent

### DIFF
--- a/packages/ember-glimmer/lib/component-managers/custom.ts
+++ b/packages/ember-glimmer/lib/component-managers/custom.ts
@@ -156,7 +156,7 @@ export default class CustomComponentManager<ComponentInstance>
     const capturedArgs = args.capture();
 
     let invocationArgs = valueForCapturedArgs(capturedArgs);
-    const component = delegate.createComponent(definition.ComponentClass, invocationArgs);
+    const component = delegate.createComponent(definition.ComponentClass.class, invocationArgs);
 
     return new CustomComponentState(delegate, component, capturedArgs);
   }

--- a/packages/ember-glimmer/tests/integration/custom-component-manager-test.js
+++ b/packages/ember-glimmer/tests/integration/custom-component-manager-test.js
@@ -130,9 +130,8 @@ if (GLIMMER_CUSTOM_COMPONENT_MANAGER) {
           EmberObject.extend({
             capabilities: capabilities('3.4'),
 
-            createComponent(factory, args) {
-              let Klass = factory.class;
-              return new Klass(args);
+            createComponent(Factory, args) {
+              return new Factory(args);
             },
 
             updateComponent() {},


### PR DESCRIPTION
We should not be exposing the FactoryManager to the Custom Component Manager. Instead just pass the factory e.g. `.class` directly into the hook.