### PR TITLE
[bugfix] Prevents the recursive redefinition of root chains

### DIFF
--- a/packages/ember-meta/lib/meta.ts
+++ b/packages/ember-meta/lib/meta.ts
@@ -323,12 +323,12 @@ export class Meta {
     );
     let ret = this._chains;
     if (ret === undefined) {
-      if (this.parent === null) {
-        ret = create(this.source);
-      } else {
-        ret = this.parent.writableChains(create).copy(this.source);
+      this._chains = ret = create(this.source);
+
+      if (this.parent !== null) {
+        let parentChains = this.parent.writableChains(create);
+        parentChains.copyTo(ret);
       }
-      this._chains = ret;
     }
     return ret;
   }

--- a/packages/ember-metal/lib/chains.ts
+++ b/packages/ember-metal/lib/chains.ts
@@ -208,18 +208,16 @@ class ChainNode {
   }
 
   // copies a top level object only
-  copy(obj: any) {
-    let ret = makeChainNode(obj);
+  copyTo(target: ChainNode) {
     let paths = this.paths;
     if (paths !== undefined) {
       let path;
       for (path in paths) {
         if (paths[path] > 0) {
-          ret.add(path);
+          target.add(path);
         }
       }
     }
-    return ret;
   }
 
   // called on the root node of a chain to setup watchers on the specified


### PR DESCRIPTION
This fix prevents an edge case where recursive call to `writableChains`
causes the root `_chains` ChainNode on a meta to be overwritten,
resulting in a chains node that does not match up with the `watching`
state of the meta.

This can occur when:

1. A computed property has been setup on a class, which lazily delays
finalizing chains.
2. An observer is then added to the class, which eagerly forces its
dependencies to setup their chains.

In the case observed, it was only triggered because there were some
number of intermediate aliases between the `computed` and the
`observer`. Aliases are not volatile, but they also don't use the
computed cache for values so they cannot rely on `getCachedValueFor`
when setting up chains. This results in eager fetching of computed
values, which leads to the nested recursive call.

This PR solves the problem by ensuring that the root chain node is set
on the meta before we attempt to add any values to it (e.g. with
`copy`). The copy method has been renamed to `copyTo` to indicate that
it is not actually creating or returning a copy (open to suggestions
for a better name).