### PR TITLE
[BUGFIX release] Clear chains in ProxyMixin when destroyed

### DIFF
--- a/packages/@ember/-internals/runtime/lib/mixins/-proxy.js
+++ b/packages/@ember/-internals/runtime/lib/mixins/-proxy.js
@@ -61,9 +61,9 @@ export default Mixin.create({
     m.writableTag(() => combine([DirtyableTag.create(), UpdatableTag.create(CONSTANT_TAG)]));
   },
 
-  destroy() {
-    this._super(...arguments);
+  willDestroy() {
     this.set('content', null);
+    this._super(...arguments);
   },
 
   isTruthy: computed('content', function() {

--- a/packages/@ember/-internals/runtime/lib/mixins/-proxy.js
+++ b/packages/@ember/-internals/runtime/lib/mixins/-proxy.js
@@ -61,6 +61,11 @@ export default Mixin.create({
     m.writableTag(() => combine([DirtyableTag.create(), UpdatableTag.create(CONSTANT_TAG)]));
   },
 
+  destroy() {
+    this._super(...arguments);
+    this.set('content', null);
+  },
+
   isTruthy: computed('content', function() {
     return !!get(this, 'content');
   }),


### PR DESCRIPTION
When a ObjectProxy is destroyed while the proxied object is still alive, then the ObjectProxy is leaked because the chains attached to the proxied object retains the ObjectProxy.
This is an issue for us, as ember-data uses proxies for their belongsTo relationships. (See https://github.com/emberjs/data/pull/5554 for more information)

A sample program that demonstrates this can be found at https://github.com/pieter-v/ember-proxy-leak

A memory snapshot before this fix:
![before](https://user-images.githubusercontent.com/7090162/43642178-c8a9d2fe-9726-11e8-83b5-e6715755bdce.png)

A memory snapshot after this fix:
![after](https://user-images.githubusercontent.com/7090162/43642183-d2c6596a-9726-11e8-9f84-a3b0d84dae47.png)
