### PR TITLE
Add RFC 232 variant detector for mocha & component blueprints

### DIFF
--- a/blueprints/component-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -1,0 +1,38 @@
+<% if (testType === 'integration') { %>import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+describe('<%= friendlyTestDescription %>', function() {
+  setupRenderingTest();
+
+  it('renders', async function() {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{<%= componentPathName %>}}`);
+
+    expect(this.element.textContent.trim()).to.equal('');
+
+    // Template block usage:
+    await render(hbs`
+      {{#<%= componentPathName %>}}
+        template block text
+      {{/<%= componentPathName %>}}
+    `);
+
+    expect(this.element.textContent.trim()).to.equal('template block text');
+  });
+});<% } else if (testType === 'unit') { %>import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('<%= friendlyTestDescription %>', function() {
+  setupTest();
+
+  it('exists', function() {
+    let component = this.owner.factoryFor('component:<%= componentPathName %>').create();
+    expect(component).to.be.ok;
+  });
+});<% } %>

--- a/blueprints/test-framework-detector.js
+++ b/blueprints/test-framework-detector.js
@@ -26,7 +26,15 @@ module.exports = function(blueprint) {
         type = 'qunit';
       }
     } else if ('ember-mocha' in dependencies) {
-      type = 'mocha-0.12';
+      let checker = new VersionChecker(this.project);
+      if (
+        fs.existsSync(this.path + '/mocha-rfc-232-files') &&
+        checker.for('ember-mocha', 'npm').gte('0.14.0')
+      ) {
+        type = 'mocha-rfc-232';
+      } else {
+        type = 'mocha-0.12';
+      }
     } else if ('ember-cli-mocha' in dependencies) {
       let checker = new VersionChecker(this.project);
       if (

--- a/node-tests/blueprints/component-test-test.js
+++ b/node-tests/blueprints/component-test-test.js
@@ -133,6 +133,32 @@ describe('Blueprint: component-test', function() {
         });
       });
     });
+
+    describe('with ember-mocha@0.14.0', function() {
+      beforeEach(function() {
+        modifyPackages([
+          { name: 'ember-cli-qunit', delete: true },
+          { name: 'ember-mocha', dev: true },
+        ]);
+        generateFakePackageManifest('ember-mocha', '0.14.0');
+      });
+
+      it('component-test x-foo', function() {
+        return emberGenerateDestroy(['component-test', 'x-foo'], _file => {
+          expect(_file('tests/integration/components/x-foo-test.js')).to.equal(
+            fixture('component-test/mocha-rfc232.js')
+          );
+        });
+      });
+
+      it('component-test x-foo --unit', function() {
+        return emberGenerateDestroy(['component-test', 'x-foo', '--unit'], _file => {
+          expect(_file('tests/unit/components/x-foo-test.js')).to.equal(
+            fixture('component-test/mocha-rfc232-unit.js')
+          );
+        });
+      });
+    });
   });
 
   describe('in app - module unification', function() {
@@ -236,6 +262,31 @@ describe('Blueprint: component-test', function() {
         return emberGenerateDestroy(['component-test', 'x-foo'], _file => {
           expect(_file('src/ui/components/x-foo/component-test.js')).to.equal(
             fixture('component-test/mocha-0.12.js')
+          );
+        });
+      });
+
+      it('component-test x-foo --unit', function() {
+        return expectError(
+          emberGenerate(['component-test', 'x-foo', '--unit']),
+          "The --unit flag isn't supported within a module unification app"
+        );
+      });
+    });
+
+    describe('with ember-mocha@0.14.0', function() {
+      beforeEach(function() {
+        modifyPackages([
+          { name: 'ember-cli-qunit', delete: true },
+          { name: 'ember-mocha', dev: true },
+        ]);
+        generateFakePackageManifest('ember-mocha', '0.14.0');
+      });
+
+      it('component-test x-foo', function() {
+        return emberGenerateDestroy(['component-test', 'x-foo'], _file => {
+          expect(_file('src/ui/components/x-foo/component-test.js')).to.equal(
+            fixture('component-test/mocha-rfc232.js')
           );
         });
       });

--- a/node-tests/fixtures/component-test/mocha-rfc232-unit.js
+++ b/node-tests/fixtures/component-test/mocha-rfc232-unit.js
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Component | x-foo', function() {
+  setupTest();
+
+  it('exists', function() {
+    let component = this.owner.factoryFor('component:x-foo').create();
+    expect(component).to.be.ok;
+  });
+});

--- a/node-tests/fixtures/component-test/mocha-rfc232.js
+++ b/node-tests/fixtures/component-test/mocha-rfc232.js
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+describe('Integration | Component | x-foo', function() {
+  setupRenderingTest();
+
+  it('renders', async function() {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{x-foo}}`);
+
+    expect(this.element.textContent.trim()).to.equal('');
+
+    // Template block usage:
+    await render(hbs`
+      {{#x-foo}}
+        template block text
+      {{/x-foo}}
+    `);
+
+    expect(this.element.textContent.trim()).to.equal('template block text');
+  });
+});


### PR DESCRIPTION
Addresses https://github.com/emberjs/ember.js/issues/16863 by adding logic to detect when rfc 232-style tests should be used with ember-mocha 0.14 and adds component rendering and unit test blueprints