### PR TITLE
[BUGFIX beta] Enable @ember/object#get to be called with an empty string

### DIFF
--- a/packages/ember-glimmer/tests/integration/syntax/each-in-test.js
+++ b/packages/ember-glimmer/tests/integration/syntax/each-in-test.js
@@ -281,6 +281,22 @@ class EachInTest extends AbstractEachInTest {
 
     this.assertText('Empty!');
   }
+
+  [`@test it can render items with a key of empty string`]() {
+    this.makeHash({ '': 'empty-string', a: 'a' });
+
+    this.render(
+      `<ul>{{#each-in hash as |key value|}}<li>{{key}}: {{value}}</li>{{else}}Empty!{{/each-in}}</ul>`
+    );
+
+    this.assertText(': empty-stringa: a');
+
+    this.assertStableRerender();
+
+    this.clear();
+
+    this.assertText('Empty!');
+  }
 }
 
 moduleFor(

--- a/packages/ember-metal/lib/property_get.ts
+++ b/packages/ember-metal/lib/property_get.ts
@@ -90,7 +90,6 @@ export function get(obj: object, keyName: string): any {
     `'this' in paths is not supported`,
     typeof keyName !== 'string' || keyName.lastIndexOf('this.', 0) !== 0
   );
-  assert('Cannot call `get` with an empty string', keyName !== '');
 
   let type = typeof obj;
 

--- a/packages/ember-metal/tests/accessors/get_test.js
+++ b/packages/ember-metal/tests/accessors/get_test.js
@@ -59,6 +59,20 @@ moduleFor(
       assert.equal(get(arr, 1), 'second');
     }
 
+    ['@test should retrieve an empty string key on an object'](assert) {
+      let obj = { '': 'empty-string' };
+
+      assert.equal(get(obj, ''), 'empty-string');
+    }
+
+    ['@test should return undefined when passed an empty string if that key does not exist on an object'](
+      assert
+    ) {
+      let obj = { tomster: true };
+
+      assert.equal(get(obj, ''), undefined);
+    }
+
     ['@test should not access a property more than once'](assert) {
       let count = 0;
       let obj = {
@@ -177,7 +191,6 @@ moduleFor(
         () => get(obj, false),
         /The key provided to get must be a string or number, you passed false/
       );
-      expectAssertion(() => get(obj, ''), /Cannot call `get` with an empty string/);
     }
 
     // ..........................................................


### PR DESCRIPTION
In plain JS, this works just fine
```js
let myObj = {
  '': 'true'
};

myObj['']; // true
```

However Ember throws an error if you do: `get(myObj, '')`. Spoke with @chancancode and he told me that previously there was a bug where calling `get` with an empty string would return `myObj`. However, this has been fixed at some point and it seems like this should work in Ember.

- [x] Remove `keyName !== ''` assertion
- [x] Add test to ensure calling get with empty string returns a value if the key `''` exists
- [x] Add test to ensure calling get with empty string returns undefined if the key `''` doesn't exist
- [x] Add tests to ensure `{{each-in}}` renders items when the hash has a key of empty string