### PR TITLE
[CLEANUP] Allow routes to be named "array" and "object"

### DIFF
--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -26,7 +26,7 @@ class DSL {
           return true;
         }
 
-        return ['basic', 'object', 'application'].indexOf(name) === -1;
+        return ['basic', 'application'].indexOf(name) === -1;
       })()
     );
 

--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -26,7 +26,7 @@ class DSL {
           return true;
         }
 
-        return ['array', 'basic', 'object', 'application'].indexOf(name) === -1;
+        return ['basic', 'object', 'application'].indexOf(name) === -1;
       })()
     );
 

--- a/packages/ember-routing/tests/system/dsl_test.js
+++ b/packages/ember-routing/tests/system/dsl_test.js
@@ -17,7 +17,7 @@ moduleFor(
     }
 
     ['@test should fail when using a reserved route name'](assert) {
-      let reservedNames = ['basic', 'object', 'application'];
+      let reservedNames = ['basic', 'application'];
 
       assert.expect(reservedNames.length);
 

--- a/packages/ember-routing/tests/system/dsl_test.js
+++ b/packages/ember-routing/tests/system/dsl_test.js
@@ -17,7 +17,7 @@ moduleFor(
     }
 
     ['@test should fail when using a reserved route name'](assert) {
-      let reservedNames = ['array', 'basic', 'object', 'application'];
+      let reservedNames = ['basic', 'object', 'application'];
 
       assert.expect(reservedNames.length);
 


### PR DESCRIPTION
Hey all 👋 this is my first PR to Ember!

This resolves https://github.com/emberjs/ember.js/issues/16872 by removing "array" as a reserved route name.