### PR TITLE
[BUGFIX] isEmpty on nested objects

### DIFF
--- a/packages/@ember/-internals/metal/lib/is_empty.ts
+++ b/packages/@ember/-internals/metal/lib/is_empty.ts
@@ -52,17 +52,15 @@ export default function isEmpty(obj: any): boolean {
     if (typeof size === 'number') {
       return !size;
     }
-  }
 
-  if (typeof obj.length === 'number' && objectType !== 'function') {
-    return !obj.length;
-  }
-
-  if (objectType === 'object') {
     let length = get(obj, 'length');
     if (typeof length === 'number') {
       return !length;
     }
+  }
+
+  if (typeof obj.length === 'number' && objectType !== 'function') {
+    return !obj.length;
   }
 
   return false;

--- a/packages/@ember/-internals/runtime/tests/core/is_empty_test.js
+++ b/packages/@ember/-internals/runtime/tests/core/is_empty_test.js
@@ -1,15 +1,27 @@
 import { isEmpty } from '@ember/-internals/metal';
 import ArrayProxy from '../../lib/system/array_proxy';
+import ObjectProxy from '../../lib/system/object_proxy';
 import { A as emberA } from '../../lib/mixins/array';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 moduleFor(
   'Ember.isEmpty',
   class extends AbstractTestCase {
-    ['@test Ember.isEmpty'](assert) {
+    ['@test Ember.isEmpty ArrayProxy'](assert) {
       let arrayProxy = ArrayProxy.create({ content: emberA() });
 
       assert.equal(true, isEmpty(arrayProxy), 'for an ArrayProxy that has empty content');
+    }
+
+    ['@test Ember.isEmpty ObjectProxy ArrayProxy'](assert) {
+      let arrayProxy = ArrayProxy.create({ content: emberA([]) });
+      let objectProxy = ObjectProxy.create({ content: arrayProxy });
+
+      assert.equal(
+        true,
+        isEmpty(objectProxy),
+        'for an ArrayProxy inside ObjectProxy that has empty content'
+      );
     }
   }
 );


### PR DESCRIPTION
So ArrayProxy inside ObjectProxy works with ES5 getters and there's no `Assertion Failed: You attempted to access the 'length' property` error.

Fixes #16878 