### PR TITLE
Mark Application/Engine#buildInstance() as public

### DIFF
--- a/packages/@ember/application/lib/application.js
+++ b/packages/@ember/application/lib/application.js
@@ -394,7 +394,7 @@ const Application = Engine.extend({
   /**
     Create an ApplicationInstance for this application.
 
-    @private
+    @public
     @method buildInstance
     @return {ApplicationInstance} the application instance
   */

--- a/packages/@ember/engine/index.js
+++ b/packages/@ember/engine/index.js
@@ -75,7 +75,7 @@ const Engine = Namespace.extend(RegistryProxyMixin, {
   /**
     Create an EngineInstance for this engine.
 
-    @private
+    @public
     @method buildInstance
     @return {EngineInstance} the engine instance
   */


### PR DESCRIPTION
This method is invoked in instance-initializer tests:

https://github.com/emberjs/ember.js/blob/04208064f8ecf4d9a31a428090191b37859be08c/blueprints/instance-initializer-test/qunit-rfc-232-files/tests/unit/instance-initializers/__name__-test.js#L15

https://github.com/emberjs/ember.js/blob/04208064f8ecf4d9a31a428090191b37859be08c/blueprints/instance-initializer-test/qunit-files/tests/unit/instance-initializers/__name__-test.js#L11

https://github.com/emberjs/ember.js/blob/04208064f8ecf4d9a31a428090191b37859be08c/blueprints/instance-initializer-test/mocha-files/tests/unit/instance-initializers/__name__-test.js#L14

Similar to #16842, this was also included in the [suggestion](https://github.com/emberjs/ember.js/pull/15945#discussion_r155932493) by @rwjblue.