### PR TITLE
Correct doc on paths for component templates

### DIFF
--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -15,7 +15,7 @@
   });
   ```
 
-  ```app/components/person-profile.hbs
+  ```app/templates/components/person-profile.hbs
   {{name}}
   <div>{{name}}</div>
   <span data-name={{name}}></span>

--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -38,15 +38,15 @@ export const BOUNDS = symbol('BOUNDS');
 
   The easiest way to create a `Component` is via
   a template. If you name a template
-  `app/components/my-foo.hbs`, you will be able to use
+  `app/templates/components/my-foo.hbs`, you will be able to use
   `{{my-foo}}` in other templates, which will make
   an instance of the isolated component.
 
-  ```app/components/my-foo.hbs
+  ```app/templates/components/my-foo.hbs
   {{person-profile person=currentUser}}
   ```
 
-  ```app/components/person-profile.hbs
+  ```app/templates/components/person-profile.hbs
   <h1>{{person.title}}</h1>
   <img src={{person.avatar}}>
   <p class='signature'>{{person.signature}}</p>
@@ -64,7 +64,7 @@ export const BOUNDS = symbol('BOUNDS');
   {{/person-profile}}
   ```
 
-  ```app/components/person-profile.hbs
+  ```app/templates/components/person-profile.hbs
   <h1>{{person.title}}</h1>
   {{! Executed in the component's context. }}
   {{yield}} {{! block contents }}


### PR DESCRIPTION
The documented way to create a template-only component doesn't work. I have asked on Slack if this is a bug in Ember, but instead it appears to be deprecated advice dating back to the times where pod structure was a recommended practice. Or is it?

To reproduce:

1. Create a new Ember app (I tested with 3.3).
2. Create a simple template at `app/components/my-component.hbs`.
3. Reference it from `app/templates/application.hbs` with `{{my-component}}`.
4. On the console, you'll see the error "Error: Compile Error: my-component is not a helper". The application will fail to render.

The following Twiddle also exemplifies this behaviour: https://ember-twiddle.com/e0f104d9caa89f7c22c077fc5f737850?openFiles=templates.application.hbs%2C There's one difference: the error message in this case is "Error: Assertion Failed: Expected component:my-component to resolve to an Ember.Component but instead it was [object Object]."

This error is fixed (and the component rendered) if you move the file to either `app/components/my-component/template.hbs` or `app/templates/components/my-component/hbs`.

Note that a JS component at `app/components/my-component.js` (providing the template in `app/templates/components/my-component.hbs`, or inline in the `layout` property), does work.