### PR TITLE
Use bare `require` in conditional URL import

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/protocol-for-url.ts
+++ b/packages/@ember/-internals/glimmer/lib/protocol-for-url.ts
@@ -1,7 +1,6 @@
 /* globals module, URL */
 
 import { hasDOM } from '@ember/-internals/browser-environment';
-import { IS_NODE, require } from 'node-module';
 import Environment from './environment';
 
 let nodeURL: any;
@@ -24,7 +23,7 @@ export default function installProtocolForURL(environment: Environment) {
     // URL globally provided, likely from FastBoot's sandbox
     nodeURL = URL;
     environment.protocolForURL = nodeProtocolForURL;
-  } else if (IS_NODE) {
+  } else if (typeof require === 'function') {
     // Otherwise, we need to fall back to our own URL parsing.
     // Global `require` is shadowed by Ember's loader so we have to use the fully
     // qualified `module.require`.


### PR DESCRIPTION
This commit changes the code that sets up URL parsing in Glimmer to use the bare, global `require` in Node.js environments, rather than importing from our `node-module` helper package.

The `node-module` package is a shim we emit in the AMD build that exposes the underlying Node `module` and `require` globals which would otherwise be shadowed by the AMD loader. However, this creates problems when compiling Ember to package formats where we want to ultimately rely on standard Node resolution semantics, since `node-module` is not a package that appears in `node_modules`.

Instead, we switch the code to use a bare `require` and rely on the existing `inject-node-globals` Babel transform to detect this usage of bare `require` and inject the appropriate AMD require, only in the AMD build.