### PR TITLE
Remove references to unused dist/ember-runtime.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -68,7 +68,6 @@ module.exports = {
 
     let emberSourceDistPath = path.join(__dirname, '..', 'dist');
     var emberFiles = [
-      'ember-runtime.js',
       'ember-template-compiler.js',
       'ember-testing.js',
       'ember.debug.js',

--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
   "files": [
     "build-metadata.json",
     "blueprints",
-    "dist/ember-runtime.js",
-    "dist/ember-runtime.map",
     "dist/ember-template-compiler.js",
     "dist/ember-template-compiler.map",
     "dist/ember-testing.js",


### PR DESCRIPTION
`vendorForTree` and the `package.json`'s `files` array both refer to an `ember-runtime.js` file that is no longer produced in either development or production builds.