### PR TITLE
add mocha rfc 232 util test

### DIFF
--- a/blueprints/util-test/mocha-rfc-232-files/__root__/__testType__/__name__-test.js
+++ b/blueprints/util-test/mocha-rfc-232-files/__root__/__testType__/__name__-test.js
@@ -1,0 +1,11 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import <%= camelizedModuleName %> from '<%= dasherizedPackageName %>/utils/<%= dasherizedModuleName %>';
+
+describe('<%= friendlyTestName %>', function() {
+  // Replace this with your real tests.
+  it('works', function() {
+    let result = <%= camelizedModuleName %>();
+    expect(result).to.be.ok;
+  });
+});

--- a/node-tests/blueprints/util-test-test.js
+++ b/node-tests/blueprints/util-test-test.js
@@ -55,6 +55,24 @@ describe('Blueprint: util-test', function() {
         });
       });
     });
+
+    describe('with ember-mocha@0.14.0', function() {
+      beforeEach(function() {
+        modifyPackages([
+          { name: 'ember-cli-qunit', delete: true },
+          { name: 'ember-mocha', dev: true },
+        ]);
+        generateFakePackageManifest('ember-mocha', '0.14.0');
+      });
+
+      it('util-test foo-bar', function() {
+        return emberGenerateDestroy(['util-test', 'foo-bar'], _file => {
+          expect(_file('tests/unit/utils/foo-bar-test.js')).to.equal(
+            fixture('util-test/mocha-rfc232.js')
+          );
+        });
+      });
+    });
   });
 
   describe('in app - module uninification', function() {

--- a/node-tests/fixtures/util-test/mocha-rfc232.js
+++ b/node-tests/fixtures/util-test/mocha-rfc232.js
@@ -1,0 +1,11 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import fooBar from 'my-app/utils/foo-bar';
+
+describe('Unit | Utility | foo-bar', function() {
+  // Replace this with your real tests.
+  it('works', function() {
+    let result = fooBar();
+    expect(result).to.be.ok;
+  });
+});


### PR DESCRIPTION
Addresses https://github.com/emberjs/ember.js/issues/16863

FWIW it doesn't look like we generate util tests for ember-cli-mocha 0.12 or greater