### PR TITLE
Add tests to detect missing API documentation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -157,7 +157,10 @@ module.exports = {
       },
     },
     {
-      files: [ 'tests/node/**/*.js' ],
+      files: [
+        'tests/node/**/*.js',
+        'bin/yuidoc-tests.js'
+      ],
 
       env: {
         qunit: true

--- a/bin/yuidoc-tests.js
+++ b/bin/yuidoc-tests.js
@@ -10,7 +10,7 @@ const docData = JSON.parse(fs.readFileSync('./docs/data.json', 'utf8'));
 const expectedCounts = [
   {
     category: 'files',
-    count: 180,
+    count: 178,
   },
   {
     category: 'modules',
@@ -18,11 +18,11 @@ const expectedCounts = [
   },
   {
     category: 'classes',
-    count: 109,
+    count: 101,
   },
   {
     category: 'classitems',
-    count: 811,
+    count: 781,
   },
 ];
 
@@ -42,7 +42,7 @@ const failedTestMessage = function(expectedCount, actualCount, category) {
 };
 
 expectedCounts.forEach(function(expected) {
-  QUnit.test(expected.category, function(assert) {
+  QUnit.test(expected.category + ' docs', function(assert) {
     const docsToCount = docData[expected.category];
     const actualCount = Object.keys(docsToCount).length;
     let message = failedTestMessage(expected.count, actualCount, expected.category);

--- a/bin/yuidoc-tests.js
+++ b/bin/yuidoc-tests.js
@@ -1,0 +1,51 @@
+'use strict';
+
+/**
+ * This tests whether there is a change in the number of modules, classes, or properties that yuidoc sees. It is not a guarantee that all documentation will show up in the Ember API docs app, but it checks for major regressions.
+ */
+
+const fs = require('fs');
+const docData = JSON.parse(fs.readFileSync('./docs/data.json', 'utf8'));
+
+const expectedCounts = [
+  {
+    category: 'files',
+    count: 180,
+  },
+  {
+    category: 'modules',
+    count: 21,
+  },
+  {
+    category: 'classes',
+    count: 109,
+  },
+  {
+    category: 'classitems',
+    count: 811,
+  },
+];
+
+const failedTestMessage = function(expectedCount, actualCount, category) {
+  let report = `${expectedCount} ${category} documentation entries expected, ${actualCount} present. \n`;
+  if (expectedCount < actualCount) {
+    return (
+      report +
+      'If you have added new features, please increment the expectedCounts in the yuidoc-tests.js and confirm that any public properties are marked both @public and @static to be included in the Ember API Docs viewer.'
+    );
+  } else {
+    return (
+      report +
+      'Documentation is missing, incorrectly formatted, or in a directory that is not watched by yuidoc. All files containing documentation must have a yuidoc class declaration.'
+    );
+  }
+};
+
+expectedCounts.forEach(function(expected) {
+  QUnit.test(expected.category, function(assert) {
+    const docsToCount = docData[expected.category];
+    const actualCount = Object.keys(docsToCount).length;
+    let message = failedTestMessage(expected.count, actualCount, expected.category);
+    assert.ok(actualCount === expected.count, message);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test:node": "qunit tests/**/*-test.js",
     "test:browserstack": "node bin/run-browserstack-tests.js",
     "test:testem": "testem -f testem.dist.js",
-    "test:docs": "ember ember-cli-yuidoc qunit bin/yuidoc-tests.js"
+    "test:docs": "ember ember-cli-yuidoc && qunit bin/yuidoc-tests.js"
   },
   "dependencies": {
     "broccoli-funnel": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "test:blueprints-debugger": "node --inspect-brk node-tests/nodetest-runner.js",
     "test:node": "qunit tests/**/*-test.js",
     "test:browserstack": "node bin/run-browserstack-tests.js",
-    "test:testem": "testem -f testem.dist.js"
+    "test:testem": "testem -f testem.dist.js",
+    "test:docs": "ember ember-cli-yuidoc && node bin/yuidoc-tests.js"
   },
   "dependencies": {
     "broccoli-funnel": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test:node": "qunit tests/**/*-test.js",
     "test:browserstack": "node bin/run-browserstack-tests.js",
     "test:testem": "testem -f testem.dist.js",
-    "test:docs": "ember ember-cli-yuidoc && node bin/yuidoc-tests.js"
+    "test:docs": "qunit bin/yuidoc-tests.js"
   },
   "dependencies": {
     "broccoli-funnel": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test:node": "qunit tests/**/*-test.js",
     "test:browserstack": "node bin/run-browserstack-tests.js",
     "test:testem": "testem -f testem.dist.js",
-    "test:docs": "qunit bin/yuidoc-tests.js"
+    "test:docs": "ember ember-cli-yuidoc qunit bin/yuidoc-tests.js"
   },
   "dependencies": {
     "broccoli-funnel": "^2.0.1",


### PR DESCRIPTION
### What it does
This PR includes a test of the highest-level yuidoc json. While a passing test does not guarantee that the docs will be rendered in the api app, it should help catch things that would definitely be missing.

### Why it's needed
Historically, ember.js minor releases have caused a regression in the API docs for our users of https://emberjs.com/api/ and a scramble to make a patch release.

### Changes made
- added a test to `bin/yuidoc-tests.js`
- added a command to `package.json` scripts,`test:docs` which builds the docs before running tests with qunit: `ember ember-cli-yuidoc qunit bin/yuidoc-tests.js`

### Help plz
- Is `bin` the right place for this test to go?
- What needs to happen to make the `test:docs` command run?