### PR TITLE
[refactor] Adds initialization flag and isPrototypeMeta()

### DIFF
--- a/packages/@ember/-internals/metal/lib/properties.ts
+++ b/packages/@ember/-internals/metal/lib/properties.ts
@@ -61,7 +61,7 @@ interface ExtendedObject {
 export function MANDATORY_SETTER_FUNCTION(name: string): MandatorySetterFunction {
   function SETTER_FUNCTION(this: object, value: any | undefined | null) {
     let m = peekMeta(this);
-    if (!m.isInitialized(this)) {
+    if (m.isInitializing() || m.isPrototypeMeta(this)) {
       m.writeValues(name, value);
     } else {
       assert(

--- a/packages/@ember/-internals/metal/lib/property_events.ts
+++ b/packages/@ember/-internals/metal/lib/property_events.ts
@@ -90,7 +90,7 @@ function notifyPropertyChange(obj: object, keyName: string, _meta?: Meta): void 
   let meta = _meta === undefined ? peekMeta(obj) : _meta;
   let hasMeta = meta !== undefined;
 
-  if (hasMeta && !meta.isInitialized(obj)) {
+  if (hasMeta && (meta.isInitializing() || meta.isPrototypeMeta(obj))) {
     return;
   }
 

--- a/packages/@ember/-internals/metal/tests/observer_test.js
+++ b/packages/@ember/-internals/metal/tests/observer_test.js
@@ -360,7 +360,7 @@ moduleFor(
 
       obj2.count = 0;
       set(obj, 'foo', 'baz');
-      assert.equal(obj.count, 1, 'should have invoked observer on parent');
+      assert.equal(obj.count, 0, 'should not have invoked observer on parent');
       assert.equal(obj2.count, 0, 'should not have invoked observer on inherited');
     }
 

--- a/packages/@ember/-internals/metal/tests/property_events_test.js
+++ b/packages/@ember/-internals/metal/tests/property_events_test.js
@@ -1,0 +1,67 @@
+import { meta } from '@ember/-internals/meta';
+import { notifyPropertyChange, PROPERTY_DID_CHANGE } from '..';
+import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+
+moduleFor(
+  'notifyPropertyChange',
+  class extends AbstractTestCase {
+    ['@test notifies property changes on instances'](assert) {
+      class Foo {
+        [PROPERTY_DID_CHANGE](prop) {
+          assert.equal(prop, 'bar', 'property change notified');
+        }
+      }
+
+      let foo = new Foo();
+
+      notifyPropertyChange(foo, 'bar');
+    }
+
+    ['@test notifies property changes on instances with meta'](assert) {
+      class Foo {
+        [PROPERTY_DID_CHANGE](prop) {
+          assert.equal(prop, 'bar', 'property change notified');
+        }
+      }
+
+      let foo = new Foo();
+
+      meta(foo); // setup meta
+
+      notifyPropertyChange(foo, 'bar');
+    }
+
+    ['@test does not notify on class prototypes with meta'](assert) {
+      assert.expect(0);
+
+      class Foo {
+        [PROPERTY_DID_CHANGE](prop) {
+          assert.equal(prop, 'bar', 'property change notified');
+        }
+      }
+
+      let foo = new Foo();
+
+      meta(foo.constructor.prototype); // setup meta for prototype
+
+      notifyPropertyChange(foo.constructor.prototype, 'bar');
+    }
+
+    ['@test does not notify on non-class prototypes with meta'](assert) {
+      assert.expect(0);
+
+      let foo = {
+        [PROPERTY_DID_CHANGE](prop) {
+          assert.equal(prop, 'baz', 'property change notified');
+        },
+      };
+
+      let bar = Object.create(foo);
+
+      meta(foo); // setup meta for prototype
+      meta(bar); // setup meta for instance, switch prototype
+
+      notifyPropertyChange(foo, 'baz');
+    }
+  }
+);

--- a/packages/@ember/-internals/metal/tests/watching/watch_test.js
+++ b/packages/@ember/-internals/metal/tests/watching/watch_test.js
@@ -89,9 +89,9 @@ moduleFor(
       watch(obj, 'foo');
       assert.equal(get(obj, 'foo'), 'baz', 'should have original prop');
 
-      set(obj, 'foo', 'bar');
-      set(objB, 'foo', 'baz');
-      assert.equal(didCount, 2, 'should have invoked didCount once only');
+      set(objB, 'foo', 'bar');
+      set(obj, 'foo', 'baz');
+      assert.equal(didCount, 1, 'should have invoked didCount once only');
     }
 
     ['@test watching an object THEN defining it should work also'](assert) {

--- a/packages/@ember/-internals/runtime/lib/mixins/-proxy.js
+++ b/packages/@ember/-internals/runtime/lib/mixins/-proxy.js
@@ -90,9 +90,9 @@ export default Mixin.create({
   setUnknownProperty(key, value) {
     let m = meta(this);
 
-    if (m.proto === this) {
-      // if marked as prototype then just defineProperty
-      // rather than delegate
+    if (m.isInitializing() || m.isPrototypeMeta(this)) {
+      // if marked as prototype or object is initializing then just
+      // defineProperty rather than delegate
       defineProperty(this, key, null, value);
       return value;
     }

--- a/packages/@ember/-internals/runtime/lib/system/core_object.js
+++ b/packages/@ember/-internals/runtime/lib/system/core_object.js
@@ -129,7 +129,7 @@ function initialize(obj, properties) {
   obj.init(properties);
 
   // re-enable chains
-  m.proto = obj.constructor.prototype;
+  m.unsetInitializing();
   finishChains(m);
   sendEvent(obj, 'init', undefined, undefined, undefined, m);
 }
@@ -209,7 +209,7 @@ class CoreObject {
 
     // disable chains
     let m = meta(self);
-    m.proto = self;
+    m.setInitializing();
 
     if (properties !== DELAY_INIT) {
       deprecate(


### PR DESCRIPTION
Currently, `meta.isInitialized()` is used for two distinct purposes:

1. To check if the meta is for an _instance_ of `EmberObject` which is
currently being _initialized_.

2. To check if a meta is the meta for a class _prototype_.

In both cases, we want similar behavior - don't trigger event listeners,
mandatory setters, or `setUnknownProperty` in some cases. So, these two
functions were tied together historically out of convenience. This PR
separates them into two methods, `isInitialized` and `isPrototypeMeta`,
to clarify their purposes and allow us to distinguish the two states.

One quirk of `isPrototypeMeta` is that it still requires an object be
passed to it. This for the case where an object does not have it's own
meta, and is relying entirely on its parent's meta. In this case, the
parent meta is being used in the context of an instance, and should be
treated as if it were an instance meta for that particular usage.