### PR TITLE
[BUGFIX beta] ES6 classes on/removeListener and observes/removeObserver interop v2

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/unbound-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/unbound-test.js
@@ -362,13 +362,13 @@ moduleFor(
     ['@test should be able to render an unbound helper invocation for helpers with dependent keys']() {
       this.registerHelper('capitalizeName', {
         destroy() {
-          this.removeObserver('value.firstName');
+          this.removeObserver('value.firstName', this, this.recompute);
           this._super(...arguments);
         },
 
         compute([value]) {
           if (this.get('value')) {
-            this.removeObserver('value.firstName');
+            this.removeObserver('value.firstName', this, this.recompute);
           }
           this.set('value', value);
           this.addObserver('value.firstName', this, this.recompute);
@@ -382,8 +382,8 @@ moduleFor(
           this._super(...arguments);
         },
         teardown() {
-          this.removeObserver('value.firstName');
-          this.removeObserver('value.lastName');
+          this.removeObserver('value.firstName', this, this.recompute);
+          this.removeObserver('value.lastName', this, this.recompute);
         },
         compute([value]) {
           if (this.get('value')) {
@@ -478,13 +478,13 @@ moduleFor(
     ['@test should be able to render an unbound helper invocation with bound hash options']() {
       this.registerHelper('capitalizeName', {
         destroy() {
-          this.removeObserver('value.firstName');
+          this.removeObserver('value.firstName', this, this.recompute);
           this._super(...arguments);
         },
 
         compute([value]) {
           if (this.get('value')) {
-            this.removeObserver('value.firstName');
+            this.removeObserver('value.firstName', this, this.recompute);
           }
           this.set('value', value);
           this.addObserver('value.firstName', this, this.recompute);
@@ -498,8 +498,8 @@ moduleFor(
           this._super(...arguments);
         },
         teardown() {
-          this.removeObserver('value.firstName');
-          this.removeObserver('value.lastName');
+          this.removeObserver('value.firstName', this, this.recompute);
+          this.removeObserver('value.lastName', this, this.recompute);
         },
         compute([value]) {
           if (this.get('value')) {

--- a/packages/@ember/-internals/meta/lib/meta.ts
+++ b/packages/@ember/-internals/meta/lib/meta.ts
@@ -562,8 +562,20 @@ export class Meta {
         kind,
       } as Listener);
     } else {
-      // update own listener
-      listeners[i].kind = kind;
+      let listener = listeners[i];
+      // If the listener is our own function listener and we are trying to
+      // remove it, we want to splice it out entirely so we don't hold onto a
+      // reference.
+      if (
+        typeof method === 'function' &&
+        kind === ListenerKind.REMOVE &&
+        listener.kind !== ListenerKind.REMOVE
+      ) {
+        listeners.splice(i, 1);
+      } else {
+        // update own listener
+        listener.kind = kind;
+      }
     }
   }
 

--- a/packages/@ember/-internals/meta/lib/meta.ts
+++ b/packages/@ember/-internals/meta/lib/meta.ts
@@ -12,6 +12,11 @@ export interface MetaCounters {
   deleteCalls: number;
   metaCalls: number;
   metaInstantiated: number;
+  addToListenersCalls: number;
+  removeFromListenersCalls: number;
+  removeAllListenersCalls: number;
+  listenersInherited: number;
+  reopensAfterFlatten: number;
 }
 
 let counters: MetaCounters | undefined;
@@ -23,6 +28,11 @@ if (DEBUG) {
     deleteCalls: 0,
     metaCalls: 0,
     metaInstantiated: 0,
+    addToListenersCalls: 0,
+    removeFromListenersCalls: 0,
+    removeAllListenersCalls: 0,
+    listenersInherited: 0,
+    reopensAfterFlatten: 0,
   };
 }
 
@@ -41,6 +51,38 @@ const enum MetaFlags {
   INITIALIZING = 1 << 3,
 }
 
+const enum ListenerKind {
+  ADD = 0,
+  ONCE = 1,
+  REMOVE = 2,
+  REMOVE_ALL = 3,
+}
+
+interface RemoveAllListener {
+  event: string;
+  target: null;
+  method: null;
+  kind: ListenerKind.REMOVE_ALL;
+}
+
+interface StringListener {
+  event: string;
+  target: null;
+  method: string;
+  kind: ListenerKind.ADD | ListenerKind.ONCE | ListenerKind.REMOVE;
+}
+
+interface FunctionListener {
+  event: string;
+  target: object | null;
+  method: Function;
+  kind: ListenerKind.ADD | ListenerKind.ONCE | ListenerKind.REMOVE;
+}
+
+type Listener = RemoveAllListener | StringListener | FunctionListener;
+
+let currentListenerVersion = 1;
+
 export class Meta {
   _descriptors: any | undefined;
   _watching: any | undefined;
@@ -54,8 +96,11 @@ export class Meta {
   source: object;
   proto: object | undefined;
   _parent: Meta | undefined | null;
-  _listeners: any | undefined;
-  _listenersFinalized: boolean;
+
+  _listeners: Listener[] | undefined;
+  _listenersVersion = 1;
+  _inheritedEnd = 0;
+  _flattenedVersion = 0;
 
   // DEBUG
   _values: any | undefined;
@@ -85,7 +130,6 @@ export class Meta {
     this.proto = obj.constructor === undefined ? undefined : obj.constructor.prototype;
 
     this._listeners = undefined;
-    this._listenersFinalized = false;
   }
 
   get parent() {
@@ -449,82 +493,199 @@ export class Meta {
     method: Function | string,
     once: boolean
   ) {
-    if (this._listeners === undefined) {
-      this._listeners = [];
+    if (DEBUG) {
+      counters!.addToListenersCalls++;
     }
-    this._listeners.push(eventName, target, method, once);
+
+    this.pushListener(eventName, target, method, once ? ListenerKind.ONCE : ListenerKind.ADD);
   }
 
-  _finalizeListeners() {
-    if (this._listenersFinalized) {
-      return;
+  removeFromListeners(eventName: string, target: object | null, method: Function | string): void {
+    if (DEBUG) {
+      counters!.removeFromListenersCalls++;
     }
-    if (this._listeners === undefined) {
-      this._listeners = [];
-    }
-    let pointer = this.parent;
-    while (pointer !== null) {
-      let listeners = pointer._listeners;
-      if (listeners !== undefined) {
-        this._listeners = this._listeners.concat(listeners);
-      }
-      if (pointer._listenersFinalized) {
-        break;
-      }
-      pointer = pointer.parent;
-    }
-    this._listenersFinalized = true;
+
+    this.pushListener(eventName, target, method, ListenerKind.REMOVE);
   }
 
-  removeFromListeners(eventName: string, target: any, method: Function | string): void {
-    let pointer: Meta | null = this;
-    while (pointer !== null) {
-      let listeners = pointer._listeners;
-      if (listeners !== undefined) {
-        for (let index = listeners.length - 4; index >= 0; index -= 4) {
-          if (
-            listeners[index] === eventName &&
-            (!method || (listeners[index + 1] === target && listeners[index + 2] === method))
-          ) {
-            if (pointer === this) {
-              listeners.splice(index, 4); // we are modifying our own list, so we edit directly
-            } else {
-              // we are trying to remove an inherited listener, so we do
-              // just-in-time copying to detach our own listeners from
-              // our inheritance chain.
-              this._finalizeListeners();
-              return this.removeFromListeners(eventName, target, method);
+  removeAllListeners(event: string) {
+    if (DEBUG) {
+      counters!.removeAllListenersCalls++;
+    }
+
+    let listeners = this.writableListeners();
+    let inheritedEnd = this._inheritedEnd;
+    // remove all listeners of event name
+    // adjusting the inheritedEnd if listener is below it
+    for (let i = listeners.length - 1; i >= 0; i--) {
+      let listener = listeners[i];
+      if (listener.event === event) {
+        listeners.splice(i, 1);
+        if (i < inheritedEnd) {
+          inheritedEnd--;
+        }
+      }
+    }
+    this._inheritedEnd = inheritedEnd;
+    // we put remove alls at start because rare and easy to check there
+    listeners.splice(inheritedEnd, 0, {
+      event,
+      target: null,
+      method: null,
+      kind: ListenerKind.REMOVE_ALL,
+    });
+  }
+
+  private pushListener(
+    event: string,
+    target: object | null,
+    method: Function | string,
+    kind: ListenerKind.ADD | ListenerKind.ONCE | ListenerKind.REMOVE
+  ): void {
+    let listeners = this.writableListeners();
+
+    let i = indexOfListener(listeners, event, target, method!);
+
+    // remove if found listener was inherited
+    if (i !== -1 && i < this._inheritedEnd) {
+      listeners.splice(i, 1);
+      this._inheritedEnd--;
+      i = -1;
+    }
+
+    // if not found, push
+    if (i === -1) {
+      listeners.push({
+        event,
+        target,
+        method,
+        kind,
+      } as Listener);
+    } else {
+      // update own listener
+      listeners[i].kind = kind;
+    }
+  }
+
+  /**
+    Flattening is based on a global revision counter. If the revision has
+    bumped it means that somewhere in a class inheritance chain something has
+    changed, so we need to reflatten everything. This can only happen if:
+
+    1. A meta has been flattened (listener has been called)
+    2. The meta is a prototype meta with children who have inherited its
+       listeners
+    3. A new listener is subsequently added to the meta (e.g. via `.reopen()`)
+
+    This is a very rare occurence, so while the counter is global it shouldn't
+    be updated very often in practice.
+  */
+  private _shouldFlatten() {
+    return this._flattenedVersion < currentListenerVersion;
+  }
+
+  private _isFlattened() {
+    // A meta is flattened _only_ if the saved version is equal to the current
+    // version. Otherwise, it will flatten again the next time
+    // `flattenedListeners` is called, so there is no reason to bump the global
+    // version again.
+    return this._flattenedVersion === currentListenerVersion;
+  }
+
+  private _setFlattened() {
+    this._flattenedVersion = currentListenerVersion;
+  }
+
+  private writableListeners(): Listener[] {
+    let listeners = this._listeners;
+
+    if (listeners === undefined) {
+      listeners = this._listeners = [] as Listener[];
+    }
+
+    // Check if the meta is owned by a prototype. If so, our listeners are
+    // inheritable so check the meta has been flattened. If it has, children
+    // have inherited its listeners, so bump the global version counter to
+    // invalidate.
+    if (this.source === this.proto && this._isFlattened()) {
+      if (DEBUG) {
+        counters!.reopensAfterFlatten++;
+      }
+
+      currentListenerVersion++;
+    }
+
+    return listeners;
+  }
+
+  private flattenedListeners(): Listener[] | undefined {
+    if (this._shouldFlatten()) {
+      let parent = this.parent;
+
+      if (parent !== null) {
+        // compute
+        let parentListeners = parent.flattenedListeners();
+
+        if (parentListeners !== undefined) {
+          let listeners = this._listeners;
+
+          if (listeners === undefined) {
+            listeners = this._listeners = [] as Listener[];
+          }
+
+          if (this._inheritedEnd > 0) {
+            listeners.splice(0, this._inheritedEnd);
+            this._inheritedEnd = 0;
+          }
+
+          for (let i = 0; i < parentListeners.length; i++) {
+            let listener = parentListeners[i];
+            let index = indexOfListener(
+              listeners,
+              listener.event,
+              listener.target,
+              listener.method
+            );
+
+            if (index === -1) {
+              if (DEBUG) {
+                counters!.listenersInherited++;
+              }
+
+              listeners.unshift(listener);
+              this._inheritedEnd++;
             }
           }
         }
       }
-      if (pointer._listenersFinalized) {
-        break;
-      }
-      pointer = pointer.parent;
+
+      this._setFlattened();
     }
+
+    return this._listeners;
   }
 
-  matchingListeners(eventName: string) {
-    let pointer: Meta | null = this;
-    // fix type
-    let result: any[] | undefined;
-    while (pointer !== null) {
-      let listeners = pointer._listeners;
-      if (listeners !== undefined) {
-        for (let index = 0; index < listeners.length; index += 4) {
-          if (listeners[index] === eventName) {
-            result = result || [];
-            pushUniqueListener(result, listeners, index);
-          }
+  matchingListeners(eventName: string): (string | boolean | object | null)[] | undefined | void {
+    let listeners = this.flattenedListeners();
+
+    if (listeners !== undefined) {
+      let result = [];
+
+      for (let index = 0; index < listeners.length; index++) {
+        let listener = listeners[index];
+
+        // REMOVE and REMOVE_ALL listeners are placeholders that tell us not to
+        // inherit, so they never match. Only ADD and ONCE can match.
+        if (
+          listener.event === eventName &&
+          (listener.kind === ListenerKind.ADD || listener.kind === ListenerKind.ONCE)
+        ) {
+          result.push(listener.target!, listener.method, listener.kind === ListenerKind.ONCE);
         }
       }
-      if (pointer._listenersFinalized) {
-        break;
-      }
-      pointer = pointer.parent;
+
+      return result.length === 0 ? undefined : result;
     }
-    return result;
   }
 }
 
@@ -774,24 +935,22 @@ export function isDescriptor(possibleDesc: any | undefined | null): boolean {
 
 export { counters };
 
-/*
- When we render a rich template hierarchy, the set of events that
- *might* happen tends to be much larger than the set of events that
- actually happen. This implies that we should make listener creation &
- destruction cheap, even at the cost of making event dispatch more
- expensive.
+function indexOfListener(
+  listeners: Listener[],
+  event: string,
+  target: object | null,
+  method: Function | string | null
+) {
+  for (let i = listeners.length - 1; i >= 0; i--) {
+    let listener = listeners[i];
 
- Thus we store a new listener with a single push and no new
- allocations, without even bothering to do deduplication -- we can
- save that for dispatch time, if an event actually happens.
- */
-function pushUniqueListener(destination: any[], source: any[], index: number) {
-  let target = source[index + 1];
-  let method = source[index + 2];
-  for (let destinationIndex = 0; destinationIndex < destination.length; destinationIndex += 3) {
-    if (destination[destinationIndex] === target && destination[destinationIndex + 1] === method) {
-      return;
+    if (
+      listener.event === event &&
+      ((listener.target === target && listener.method === method) ||
+        listener.kind === ListenerKind.REMOVE_ALL)
+    ) {
+      return i;
     }
   }
-  destination.push(target, method, source[index + 3]);
+  return -1;
 }

--- a/packages/@ember/-internals/meta/tests/listeners_test.js
+++ b/packages/@ember/-internals/meta/tests/listeners_test.js
@@ -1,0 +1,159 @@
+import { AbstractTestCase, moduleFor } from 'internal-test-helpers';
+import { meta, counters } from '..';
+
+moduleFor(
+  'Ember.meta listeners',
+  class extends AbstractTestCase {
+    ['@test basics'](assert) {
+      let t = {};
+      let m = meta({});
+      m.addToListeners('hello', t, 'm', 0);
+      let matching = m.matchingListeners('hello');
+      assert.equal(matching.length, 3);
+      assert.equal(matching[0], t);
+      m.removeFromListeners('hello', t, 'm');
+      matching = m.matchingListeners('hello');
+      assert.equal(matching, undefined);
+    }
+
+    ['@test inheritance'](assert) {
+      let target = {};
+      let parent = {};
+      let parentMeta = meta(parent);
+      parentMeta.addToListeners('hello', target, 'm', 0);
+
+      let child = Object.create(parent);
+      let m = meta(child);
+
+      let matching = m.matchingListeners('hello');
+      assert.equal(matching.length, 3);
+      assert.equal(matching[0], target);
+      assert.equal(matching[1], 'm');
+      assert.equal(matching[2], 0);
+      m.removeFromListeners('hello', target, 'm');
+      matching = m.matchingListeners('hello');
+      assert.equal(matching, undefined);
+      matching = parentMeta.matchingListeners('hello');
+      assert.equal(matching.length, 3);
+    }
+
+    ['@test deduplication'](assert) {
+      let t = {};
+      let m = meta({});
+      m.addToListeners('hello', t, 'm', 0);
+      m.addToListeners('hello', t, 'm', 0);
+      let matching = m.matchingListeners('hello');
+      assert.equal(matching.length, 3);
+      assert.equal(matching[0], t);
+    }
+
+    ['@test parent caching'](assert) {
+      counters.flattenedListenersCalls = 0;
+      counters.parentListenersUsed = 0;
+
+      class Class {}
+      let classMeta = meta(Class.prototype);
+      classMeta.addToListeners('hello', null, 'm', 0);
+
+      let instance = new Class();
+      let m = meta(instance);
+
+      let matching = m.matchingListeners('hello');
+
+      assert.equal(matching.length, 3);
+      assert.equal(counters.flattenedListenersCalls, 2);
+      assert.equal(counters.parentListenersUsed, 1);
+
+      matching = m.matchingListeners('hello');
+
+      assert.equal(matching.length, 3);
+      assert.equal(counters.flattenedListenersCalls, 3);
+      assert.equal(counters.parentListenersUsed, 1);
+    }
+
+    ['@test parent cache invalidation'](assert) {
+      counters.flattenedListenersCalls = 0;
+      counters.parentListenersUsed = 0;
+      counters.listenersInherited = 0;
+
+      class Class {}
+      let classMeta = meta(Class.prototype);
+      classMeta.addToListeners('hello', null, 'm', 0);
+
+      let instance = new Class();
+      let m = meta(instance);
+
+      let matching = m.matchingListeners('hello');
+
+      assert.equal(matching.length, 3);
+      assert.equal(counters.flattenedListenersCalls, 2);
+      assert.equal(counters.parentListenersUsed, 1);
+      assert.equal(counters.listenersInherited, 0);
+
+      m.addToListeners('hello', null, 'm2');
+
+      matching = m.matchingListeners('hello');
+
+      assert.equal(matching.length, 6);
+      assert.equal(counters.flattenedListenersCalls, 4);
+      assert.equal(counters.parentListenersUsed, 1);
+      assert.equal(counters.listenersInherited, 1);
+    }
+
+    ['@test reopen after flatten'](assert) {
+      // Ensure counter is zeroed
+      counters.reopensAfterFlatten = 0;
+
+      class Class1 {}
+      let class1Meta = meta(Class1.prototype);
+      class1Meta.addToListeners('hello', null, 'm', 0);
+
+      let instance1 = new Class1();
+      let m1 = meta(instance1);
+
+      class Class2 {}
+      let class2Meta = meta(Class2.prototype);
+      class2Meta.addToListeners('hello', null, 'm', 0);
+
+      let instance2 = new Class2();
+      let m2 = meta(instance2);
+
+      m1.matchingListeners('hello');
+      m2.matchingListeners('hello');
+
+      assert.equal(counters.reopensAfterFlatten, 0, 'no reopen calls yet');
+
+      m1.addToListeners('world', null, 'm', 0);
+      m2.addToListeners('world', null, 'm', 0);
+      m1.matchingListeners('world');
+      m2.matchingListeners('world');
+
+      assert.equal(counters.reopensAfterFlatten, 1, 'reopen calls after invalidating parent cache');
+
+      m1.addToListeners('world', null, 'm', 0);
+      m2.addToListeners('world', null, 'm', 0);
+      m1.matchingListeners('world');
+      m2.matchingListeners('world');
+
+      assert.equal(counters.reopensAfterFlatten, 1, 'no reopen calls after mutating leaf nodes');
+
+      class1Meta.removeFromListeners('hello', null, 'm');
+      class2Meta.removeFromListeners('hello', null, 'm');
+      m1.matchingListeners('hello');
+      m2.matchingListeners('hello');
+
+      assert.equal(counters.reopensAfterFlatten, 2, 'one reopen call after mutating parents');
+
+      class1Meta.addToListeners('hello', null, 'm', 0);
+      m1.matchingListeners('hello');
+      class2Meta.addToListeners('hello', null, 'm', 0);
+      m2.matchingListeners('hello');
+
+      assert.equal(
+        counters.reopensAfterFlatten,
+        3,
+        'one reopen call after mutating parents and flattening out of order'
+      );
+    }
+  }
+);

--- a/packages/@ember/-internals/meta/tests/meta_test.js
+++ b/packages/@ember/-internals/meta/tests/meta_test.js
@@ -1,5 +1,5 @@
 import { AbstractTestCase, moduleFor } from 'internal-test-helpers';
-import { meta } from '..';
+import { meta, counters } from '..';
 
 moduleFor(
   'Ember.meta',
@@ -74,6 +74,59 @@ moduleFor(
       let matching = m.matchingListeners('hello');
       assert.equal(matching.length, 3);
       assert.equal(matching[0], t);
+    }
+
+    ['@test meta.listeners reopen after flatten'](assert) {
+      // Ensure counter is zeroed
+      counters.reopensAfterFlatten = 0;
+
+      class Class1 {}
+      let class1Meta = meta(Class1.prototype);
+      class1Meta.addToListeners('hello', null, 'm', 0);
+
+      let instance1 = new Class1();
+      let m1 = meta(instance1);
+
+      class Class2 {}
+      let class2Meta = meta(Class2.prototype);
+      class2Meta.addToListeners('hello', null, 'm', 0);
+
+      let instance2 = new Class2();
+      let m2 = meta(instance2);
+
+      m1.matchingListeners('hello');
+      m2.matchingListeners('hello');
+
+      assert.equal(counters.reopensAfterFlatten, 0, 'no reopen calls yet');
+
+      m1.addToListeners('world', null, 'm', 0);
+      m2.addToListeners('world', null, 'm', 0);
+      m1.matchingListeners('world');
+      m2.matchingListeners('world');
+
+      assert.equal(
+        counters.reopensAfterFlatten,
+        0,
+        'no reopen calls after mutating leaf listeners'
+      );
+
+      class1Meta.removeFromListeners('hello', null, 'm');
+      class2Meta.removeFromListeners('hello', null, 'm');
+      m1.matchingListeners('hello');
+      m2.matchingListeners('hello');
+
+      assert.equal(counters.reopensAfterFlatten, 1, 'one reopen call after mutating parents');
+
+      class1Meta.addToListeners('hello', null, 'm', 0);
+      m1.matchingListeners('hello');
+      class2Meta.addToListeners('hello', null, 'm', 0);
+      m2.matchingListeners('hello');
+
+      assert.equal(
+        counters.reopensAfterFlatten,
+        2,
+        'one reopen call after mutating parents and flattening out of order'
+      );
     }
 
     ['@test meta.writeWatching issues useful error after destroy']() {

--- a/packages/@ember/-internals/meta/tests/meta_test.js
+++ b/packages/@ember/-internals/meta/tests/meta_test.js
@@ -1,5 +1,5 @@
 import { AbstractTestCase, moduleFor } from 'internal-test-helpers';
-import { meta, counters } from '..';
+import { meta } from '..';
 
 moduleFor(
   'Ember.meta',
@@ -31,102 +31,6 @@ moduleFor(
           assert.ok(false, 'meta should not fail JSON.stringify');
         }
       }
-    }
-
-    ['@test meta.listeners basics'](assert) {
-      let t = {};
-      let m = meta({});
-      m.addToListeners('hello', t, 'm', 0);
-      let matching = m.matchingListeners('hello');
-      assert.equal(matching.length, 3);
-      assert.equal(matching[0], t);
-      m.removeFromListeners('hello', t, 'm');
-      matching = m.matchingListeners('hello');
-      assert.equal(matching, undefined);
-    }
-
-    ['@test meta.listeners inheritance'](assert) {
-      let target = {};
-      let parent = {};
-      let parentMeta = meta(parent);
-      parentMeta.addToListeners('hello', target, 'm', 0);
-
-      let child = Object.create(parent);
-      let m = meta(child);
-
-      let matching = m.matchingListeners('hello');
-      assert.equal(matching.length, 3);
-      assert.equal(matching[0], target);
-      assert.equal(matching[1], 'm');
-      assert.equal(matching[2], 0);
-      m.removeFromListeners('hello', target, 'm');
-      matching = m.matchingListeners('hello');
-      assert.equal(matching, undefined);
-      matching = parentMeta.matchingListeners('hello');
-      assert.equal(matching.length, 3);
-    }
-
-    ['@test meta.listeners deduplication'](assert) {
-      let t = {};
-      let m = meta({});
-      m.addToListeners('hello', t, 'm', 0);
-      m.addToListeners('hello', t, 'm', 0);
-      let matching = m.matchingListeners('hello');
-      assert.equal(matching.length, 3);
-      assert.equal(matching[0], t);
-    }
-
-    ['@test meta.listeners reopen after flatten'](assert) {
-      // Ensure counter is zeroed
-      counters.reopensAfterFlatten = 0;
-
-      class Class1 {}
-      let class1Meta = meta(Class1.prototype);
-      class1Meta.addToListeners('hello', null, 'm', 0);
-
-      let instance1 = new Class1();
-      let m1 = meta(instance1);
-
-      class Class2 {}
-      let class2Meta = meta(Class2.prototype);
-      class2Meta.addToListeners('hello', null, 'm', 0);
-
-      let instance2 = new Class2();
-      let m2 = meta(instance2);
-
-      m1.matchingListeners('hello');
-      m2.matchingListeners('hello');
-
-      assert.equal(counters.reopensAfterFlatten, 0, 'no reopen calls yet');
-
-      m1.addToListeners('world', null, 'm', 0);
-      m2.addToListeners('world', null, 'm', 0);
-      m1.matchingListeners('world');
-      m2.matchingListeners('world');
-
-      assert.equal(
-        counters.reopensAfterFlatten,
-        0,
-        'no reopen calls after mutating leaf listeners'
-      );
-
-      class1Meta.removeFromListeners('hello', null, 'm');
-      class2Meta.removeFromListeners('hello', null, 'm');
-      m1.matchingListeners('hello');
-      m2.matchingListeners('hello');
-
-      assert.equal(counters.reopensAfterFlatten, 1, 'one reopen call after mutating parents');
-
-      class1Meta.addToListeners('hello', null, 'm', 0);
-      m1.matchingListeners('hello');
-      class2Meta.addToListeners('hello', null, 'm', 0);
-      m2.matchingListeners('hello');
-
-      assert.equal(
-        counters.reopensAfterFlatten,
-        2,
-        'one reopen call after mutating parents and flattening out of order'
-      );
     }
 
     ['@test meta.writeWatching issues useful error after destroy']() {

--- a/packages/@ember/-internals/metal/lib/events.ts
+++ b/packages/@ember/-internals/metal/lib/events.ts
@@ -80,7 +80,13 @@ export function removeListener(
     target = null;
   }
 
-  metaFor(obj).removeFromListeners(eventName, target, method!);
+  let m = metaFor(obj);
+
+  if (method === undefined) {
+    m.removeAllListeners(eventName);
+  } else {
+    m.removeFromListeners(eventName, target, method);
+  }
 }
 
 /**

--- a/packages/@ember/-internals/metal/tests/alias_test.js
+++ b/packages/@ember/-internals/metal/tests/alias_test.js
@@ -61,13 +61,14 @@ moduleFor(
     redefining the alias on the instance to another property dependent on same key
     does not call the observer twice`](assert) {
       let obj1 = Object.create(null);
+      obj1.incrementCount = incrementCount;
 
       meta(obj1).proto = obj1;
 
       defineProperty(obj1, 'foo', null, null);
       defineProperty(obj1, 'bar', alias('foo'));
       defineProperty(obj1, 'baz', alias('foo'));
-      addObserver(obj1, 'baz', incrementCount);
+      addObserver(obj1, 'baz', null, 'incrementCount');
 
       let obj2 = Object.create(obj1);
       defineProperty(obj2, 'baz', alias('bar')); // override baz
@@ -75,7 +76,7 @@ moduleFor(
       set(obj2, 'foo', 'FOO');
       assert.equal(count, 1);
 
-      removeObserver(obj2, 'baz', incrementCount);
+      removeObserver(obj2, 'baz', null, 'incrementCount');
 
       set(obj2, 'foo', 'OOF');
       assert.equal(count, 1);

--- a/packages/@ember/-internals/metal/tests/events_test.js
+++ b/packages/@ember/-internals/metal/tests/events_test.js
@@ -26,13 +26,15 @@ moduleFor(
     }
 
     ['@test listeners should be inherited'](assert) {
-      let obj = {};
       let count = 0;
-      let F = function() {
-        count++;
+
+      let obj = {
+        func() {
+          count++;
+        },
       };
 
-      addListener(obj, 'event!', F);
+      addListener(obj, 'event!', null, 'func');
 
       let obj2 = Object.create(obj);
 
@@ -41,7 +43,7 @@ moduleFor(
       sendEvent(obj2, 'event!');
       assert.equal(count, 1, 'received event');
 
-      removeListener(obj2, 'event!', F);
+      removeListener(obj2, 'event!', null, 'func');
 
       count = 0;
       sendEvent(obj2, 'event!');
@@ -52,13 +54,15 @@ moduleFor(
     }
 
     ['@test adding a listener more than once should only invoke once'](assert) {
-      let obj = {};
       let count = 0;
-      function F() {
-        count++;
-      }
-      addListener(obj, 'event!', F);
-      addListener(obj, 'event!', F);
+      let obj = {
+        func() {
+          count++;
+        },
+      };
+
+      addListener(obj, 'event!', null, 'func');
+      addListener(obj, 'event!', null, 'func');
 
       sendEvent(obj, 'event!');
       assert.equal(count, 1, 'should only invoke once');
@@ -135,19 +139,21 @@ moduleFor(
     }
 
     ['@test calling removeListener without method should remove all listeners'](assert) {
-      let obj = {};
-      function F() {}
-      function F2() {}
+      expectDeprecation(() => {
+        let obj = {};
+        function F() {}
+        function F2() {}
 
-      assert.equal(hasListeners(obj, 'event!'), false, 'no listeners at first');
+        assert.equal(hasListeners(obj, 'event!'), false, 'no listeners at first');
 
-      addListener(obj, 'event!', F);
-      addListener(obj, 'event!', F2);
+        addListener(obj, 'event!', F);
+        addListener(obj, 'event!', F2);
 
-      assert.equal(hasListeners(obj, 'event!'), true, 'has listeners');
-      removeListener(obj, 'event!');
+        assert.equal(hasListeners(obj, 'event!'), true, 'has listeners');
+        removeListener(obj, 'event!');
 
-      assert.equal(hasListeners(obj, 'event!'), false, 'has no more listeners');
+        assert.equal(hasListeners(obj, 'event!'), false, 'has no more listeners');
+      }, /The remove all functionality of removeListener and removeObserver has been deprecated/);
     }
 
     ['@test a listener can be added as part of a mixin'](assert) {

--- a/packages/@ember/-internals/metal/tests/observer_test.js
+++ b/packages/@ember/-internals/metal/tests/observer_test.js
@@ -914,6 +914,7 @@ moduleFor(
       let yetAnotherBeer = new Beer();
       addObserver(yetAnotherBeer, 'type', K);
       set(yetAnotherBeer, 'type', 'ale');
+      addObserver(beer, 'type', K);
       removeObserver(beer, 'type', K);
       assert.deepEqual(
         Object.keys(yetAnotherBeer),
@@ -923,6 +924,7 @@ moduleFor(
 
       let itsMyLastBeer = new Beer();
       set(itsMyLastBeer, 'type', 'ale');
+      addObserver(beer, 'type', K);
       removeObserver(beer, 'type', K);
       assert.deepEqual(Object.keys(itsMyLastBeer), ['type'], 'set -> removeObserver');
     }
@@ -945,6 +947,7 @@ moduleFor(
       let yetAnotherBeer = new Beer();
       addObserver(yetAnotherBeer, 'type', K);
       set(yetAnotherBeer, 'type', 'ale');
+      addObserver(beer, 'type', K);
       removeObserver(beer, 'type', K);
       assert.deepEqual(
         Object.keys(yetAnotherBeer),
@@ -954,6 +957,7 @@ moduleFor(
 
       let itsMyLastBeer = new Beer();
       set(itsMyLastBeer, 'type', 'ale');
+      addObserver(beer, 'type', K);
       removeObserver(beer, 'type', K);
       assert.deepEqual(Object.keys(itsMyLastBeer), ['type'], 'set -> removeObserver');
     }

--- a/packages/@ember/-internals/metal/tests/watching/is_watching_test.js
+++ b/packages/@ember/-internals/metal/tests/watching/is_watching_test.js
@@ -12,12 +12,11 @@ import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 function testObserver(assert, setup, teardown, key = 'key') {
   let obj = {};
-  function fn() {}
 
   assert.equal(isWatching(obj, key), false, 'precond - isWatching is false by default');
-  setup(obj, key, fn);
+  setup(obj, key, 'fn');
   assert.equal(isWatching(obj, key), true, 'isWatching is true when observers are added');
-  teardown(obj, key, fn);
+  teardown(obj, key, 'fn');
   assert.equal(isWatching(obj, key), false, 'isWatching is false after observers are removed');
 }
 
@@ -29,7 +28,7 @@ moduleFor(
         assert,
         (obj, key, fn) => {
           Mixin.create({
-            didChange: observer(key, fn),
+            [fn]: observer(key, function() {}),
           }).apply(obj);
         },
         (obj, key, fn) => removeObserver(obj, key, obj, fn)
@@ -62,10 +61,10 @@ moduleFor(
       testObserver(
         assert,
         (obj, key, fn) => {
-          defineProperty(obj, 'computed', computed(fn).property(key));
-          get(obj, 'computed');
+          defineProperty(obj, fn, computed(function() {}).property(key));
+          get(obj, fn);
         },
-        obj => defineProperty(obj, 'computed', null)
+        (obj, key, fn) => defineProperty(obj, fn, null)
       );
     }
 
@@ -73,10 +72,10 @@ moduleFor(
       testObserver(
         assert,
         (obj, key, fn) => {
-          defineProperty(obj, 'computed', computed(fn).property(key + '.bar'));
-          get(obj, 'computed');
+          defineProperty(obj, fn, computed(function() {}).property(key + '.bar'));
+          get(obj, fn);
         },
-        obj => defineProperty(obj, 'computed', null)
+        (obj, key, fn) => defineProperty(obj, fn, null)
       );
     }
 

--- a/packages/@ember/-internals/runtime/tests/system/object/es-compatibility-test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/es-compatibility-test.js
@@ -3,8 +3,12 @@ import {
   Mixin,
   defineProperty,
   computed,
+  observer,
+  on,
   addObserver,
+  removeObserver,
   addListener,
+  removeListener,
   sendEvent,
 } from '@ember/-internals/metal';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
@@ -276,6 +280,84 @@ moduleFor(
 
       // able to get meta without throwing an error
       SubEmberObject.metaForProperty('foo');
+    }
+
+    '@test observes / removeObserver on / removeListener interop'(assert) {
+      let fooDidChangeBase = 0;
+      let fooDidChangeA = 0;
+      let fooDidChangeB = 0;
+      let someEventBase = 0;
+      let someEventA = 0;
+      let someEventB = 0;
+      class A extends EmberObject.extend({
+        fooDidChange: observer('foo', function() {
+          fooDidChangeBase++;
+        }),
+
+        onSomeEvent: on('someEvent', function() {
+          someEventBase++;
+        }),
+      }) {
+        init() {
+          super.init();
+          this.foo = 'bar';
+        }
+
+        fooDidChange() {
+          super.fooDidChange();
+          fooDidChangeA++;
+        }
+
+        onSomeEvent() {
+          super.onSomeEvent();
+          someEventA++;
+        }
+      }
+
+      class B extends A {
+        fooDidChange() {
+          super.fooDidChange();
+          fooDidChangeB++;
+        }
+
+        onSomeEvent() {
+          super.onSomeEvent();
+          someEventB++;
+        }
+      }
+
+      removeObserver(B.prototype, 'foo', null, 'fooDidChange');
+      removeListener(B.prototype, 'someEvent', null, 'onSomeEvent');
+
+      assert.equal(fooDidChangeBase, 0);
+      assert.equal(fooDidChangeA, 0);
+      assert.equal(fooDidChangeB, 0);
+
+      assert.equal(someEventBase, 0);
+      assert.equal(someEventA, 0);
+      assert.equal(someEventB, 0);
+
+      let a = A.create();
+      a.set('foo', 'something');
+      assert.equal(fooDidChangeBase, 1);
+      assert.equal(fooDidChangeA, 1);
+      assert.equal(fooDidChangeB, 0);
+
+      sendEvent(a, 'someEvent');
+      assert.equal(someEventBase, 1);
+      assert.equal(someEventA, 1);
+      assert.equal(someEventB, 0);
+
+      let b = B.create();
+      b.set('foo', 'something');
+      assert.equal(fooDidChangeBase, 1);
+      assert.equal(fooDidChangeA, 1);
+      assert.equal(fooDidChangeB, 0);
+
+      sendEvent(b, 'someEvent');
+      assert.equal(someEventBase, 1);
+      assert.equal(someEventA, 1);
+      assert.equal(someEventB, 0);
     }
 
     '@test super and _super interop between old and new methods'(assert) {

--- a/packages/@ember/object/lib/computed/reduce_computed_macros.js
+++ b/packages/@ember/object/lib/computed/reduce_computed_macros.js
@@ -832,9 +832,16 @@ function propertySort(itemsKey, sortPropertiesKey) {
       let activeObserversMap = cp._activeObserverMap || (cp._activeObserverMap = new WeakMap());
       let activeObservers = activeObserversMap.get(this);
 
-      function sortPropertyDidChange() {
-        this.notifyPropertyChange(key);
+      let sortPropertyDidChangeMap =
+        cp._sortPropertyDidChangeMap || (cp._sortPropertyDidChangeMap = new WeakMap());
+
+      if (!sortPropertyDidChangeMap.has(this)) {
+        sortPropertyDidChangeMap.set(this, function() {
+          this.notifyPropertyChange(key);
+        });
       }
+
+      let sortPropertyDidChange = sortPropertyDidChangeMap.get(this);
 
       if (activeObservers !== undefined) {
         activeObservers.forEach(path => removeObserver(this, path, sortPropertyDidChange));
@@ -871,6 +878,7 @@ function propertySort(itemsKey, sortPropertiesKey) {
   );
 
   cp._activeObserverMap = undefined;
+  cp._sortPropertyDidChangeMap = undefined;
 
   return cp;
 }


### PR DESCRIPTION
This is a rework of #16874 which flattens and caches the state of event listeners more efficiently. Rather than rebuild the result of a `matchListeners` query each time, including deduping, we flatten the listeners down the hierarchy of metas the first time an event match is requested. This still defers the majority of the work early on (adding listeners is cheap) but also prevents us from having to do the work again later.

Should probably run ember-macro-benchmark against this to see if there is any notable perf difference before we merge. I'd also like to see if we can scope the revision counter down to a single hierarchy, so adding an observer on a prototype doesn't affect every class in the app.

cc @krisselden 