### PR TITLE
remove redundant `_getModels` in link-to

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -827,19 +827,6 @@ const LinkComponent = EmberComponent.extend({
     return true;
   }),
 
-  _getModels(params: any[]) {
-    let modelCount = params.length - 1;
-    let models = new Array(modelCount);
-
-    for (let i = 0; i < modelCount; i++) {
-      let value = params[i + 1];
-
-      models[i] = value;
-    }
-
-    return models;
-  },
-
   /**
     The default href value to use while a link-to is loading.
     Only applies when tagName is 'a'
@@ -891,11 +878,8 @@ const LinkComponent = EmberComponent.extend({
     this.set('queryParams', queryParams);
 
     // 4. Any remaining indices (excepting `targetRouteName` at 0) are `models`.
-    if (params.length > 1) {
-      this.set('models', this._getModels(params));
-    } else {
-      this.set('models', []);
-    }
+    params.shift();
+    this.set('models', params);
   },
 });
 


### PR DESCRIPTION
params already cloned here https://github.com/emberjs/ember.js/pull/16958/files#diff-69db29e32cf13d448d7c3db3008d1774L857 so it can be reused 