### PR TITLE
throw Errors instead of literals

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
   rules: {
     'semi': 'error',
     'no-unused-vars': 'error',
+    'no-throw-literal': 'error',
     'no-useless-escape': 'off', // TODO: bring this back
     'prettier/prettier': 'error',
   },
@@ -79,6 +80,7 @@ module.exports = {
 
         'semi': 'error',
         'no-unused-vars': 'error',
+        'no-throw-literal': 'error',
         'comma-dangle': 'off',
       },
     },
@@ -134,6 +136,7 @@ module.exports = {
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         // add your custom rules and overrides for node files here
         'no-process-exit': 'off',
+        'no-throw-literal': 'error'
       }),
     },
     {

--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -39,14 +39,14 @@ module.exports = useTestFrameworkDetector({
         },
         __testType__(options) {
           if (options.locals.testType === 'unit') {
-            throw "The --unit flag isn't supported within a module unification app";
+            throw new Error("The --unit flag isn't supported within a module unification app");
           }
 
           return '';
         },
         __path__(options) {
           if (options.pod) {
-            throw "Pods aren't supported within a module unification app";
+            throw new Error("Pods aren't supported within a module unification app");
           }
           return path.join('ui', 'components', options.dasherizedModuleName);
         },

--- a/blueprints/controller-test/index.js
+++ b/blueprints/controller-test/index.js
@@ -28,7 +28,7 @@ module.exports = useTestFrameworkDetector({
         },
         __root__(options) {
           if (options.pod) {
-            throw "Pods aren't supported within a module unification app";
+            throw new Error("Pods aren't supported within a module unification app");
           }
           return 'src';
         },

--- a/blueprints/controller/index.js
+++ b/blueprints/controller/index.js
@@ -10,7 +10,7 @@ module.exports = {
       return {
         __root__(options) {
           if (options.pod) {
-            throw "Pods aren't supported within a module unification app";
+            throw new Error("Pods aren't supported within a module unification app");
           }
           if (options.inDummy) {
             return path.join('tests', 'dummy', 'src');

--- a/blueprints/initializer-test/index.js
+++ b/blueprints/initializer-test/index.js
@@ -15,7 +15,7 @@ module.exports = useTestFrameworkDetector({
       return {
         __root__(options) {
           if (options.pod) {
-            throw 'Pods arenʼt supported within a module unification app';
+            throw new Error('Pods arenʼt supported within a module unification app');
           } else if (options.inDummy) {
             return path.join('tests', 'dummy', 'src', 'init');
           }

--- a/blueprints/initializer/index.js
+++ b/blueprints/initializer/index.js
@@ -11,7 +11,7 @@ module.exports = {
       return {
         __root__(options) {
           if (options.pod) {
-            throw 'Pods arenʼt supported within a module unification app';
+            throw new Error('Pods arenʼt supported within a module unification app');
           } else if (options.inDummy) {
             return path.join('tests', 'dummy', 'src/init');
           }

--- a/blueprints/mixin-test/index.js
+++ b/blueprints/mixin-test/index.js
@@ -13,7 +13,7 @@ module.exports = useTestFrameworkDetector({
       return {
         __root__(options) {
           if (options.pod) {
-            throw "Pods aren't supported within a module unification app";
+            throw new Error("Pods aren't supported within a module unification app");
           }
 
           return 'src';

--- a/blueprints/mixin/index.js
+++ b/blueprints/mixin/index.js
@@ -10,7 +10,7 @@ module.exports = {
       return {
         __root__(options) {
           if (options.pod) {
-            throw "Pods aren't supported within a module unification app";
+            throw new Error("Pods aren't supported within a module unification app");
           }
 
           return 'src';

--- a/blueprints/route/index.js
+++ b/blueprints/route/index.js
@@ -32,7 +32,7 @@ module.exports = {
       return {
         __root__(options) {
           if (options.pod) {
-            throw "Pods aren't supported within a module unification app";
+            throw new Error("Pods aren't supported within a module unification app");
           }
           if (options.inDummy) {
             return path.join('tests', 'dummy', 'src');

--- a/blueprints/service-test/index.js
+++ b/blueprints/service-test/index.js
@@ -11,7 +11,7 @@ module.exports = useTestFrameworkDetector({
       return {
         __root__(options) {
           if (options.pod) {
-            throw "Pods aren't supported within a module unification app";
+            throw new Error("Pods aren't supported within a module unification app");
           }
 
           return 'src';

--- a/blueprints/service/index.js
+++ b/blueprints/service/index.js
@@ -10,7 +10,7 @@ module.exports = {
       return {
         __root__(options) {
           if (options.pod) {
-            throw "Pods aren't supported within a module unification app";
+            throw new Error("Pods aren't supported within a module unification app");
           }
 
           return 'src';

--- a/blueprints/template/index.js
+++ b/blueprints/template/index.js
@@ -10,7 +10,7 @@ module.exports = {
       return {
         __root__(options) {
           if (options.pod) {
-            throw "Pods aren't supported within a module unification app";
+            throw new Error("Pods aren't supported within a module unification app");
           } else if (options.inDummy) {
             return 'tests/dummy/src/ui/routes';
           } else {

--- a/blueprints/util-test/index.js
+++ b/blueprints/util-test/index.js
@@ -14,7 +14,7 @@ module.exports = useTestFrameworkDetector({
       return {
         __root__(options) {
           if (options.pod) {
-            throw "Pods aren't supported within a module unification app";
+            throw new Error("Pods aren't supported within a module unification app");
           }
 
           return 'src';

--- a/blueprints/util/index.js
+++ b/blueprints/util/index.js
@@ -10,7 +10,7 @@ module.exports = {
       return {
         __root__(options) {
           if (options.pod) {
-            throw "Pods aren't supported within a module unification app";
+            throw new Error("Pods aren't supported within a module unification app");
           }
 
           return 'src';

--- a/node-tests/blueprints/component-test-test.js
+++ b/node-tests/blueprints/component-test-test.js
@@ -177,7 +177,7 @@ describe('Blueprint: component-test', function() {
     it('component-test x-foo --unit', function() {
       return emberGenerate(['component-test', 'x-foo', '--unit'])
         .then(() => {
-          throw 'the command should raise an exception';
+          throw new Error('the command should raise an exception');
         })
         .catch(error => {
           expect(error).to.equal("The --unit flag isn't supported within a module unification app");

--- a/node-tests/blueprints/component-test-test.js
+++ b/node-tests/blueprints/component-test-test.js
@@ -175,13 +175,10 @@ describe('Blueprint: component-test', function() {
     });
 
     it('component-test x-foo --unit', function() {
-      return emberGenerate(['component-test', 'x-foo', '--unit'])
-        .then(() => {
-          throw new Error('the command should raise an exception');
-        })
-        .catch(error => {
-          expect(error).to.equal("The --unit flag isn't supported within a module unification app");
-        });
+      return expectError(
+        emberGenerate(['component-test', 'x-foo', '--unit']),
+        "The --unit flag isn't supported within a module unification app"
+      );
     });
 
     describe('with usePods=true', function() {

--- a/node-tests/helpers/expect-error.js
+++ b/node-tests/helpers/expect-error.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 module.exports = function expectError(promise, expectedErrorText) {
   return promise
     .then(() => {
-      throw 'the command should raise an exception';
+      throw new Error('the command should raise an exception');
     })
     .catch(error => {
       expect(error).to.equal(expectedErrorText);

--- a/node-tests/helpers/expect-error.js
+++ b/node-tests/helpers/expect-error.js
@@ -9,6 +9,6 @@ module.exports = function expectError(promise, expectedErrorText) {
       throw new Error('the command should raise an exception');
     })
     .catch(error => {
-      expect(error).to.equal(expectedErrorText);
+      expect(error.message).to.equal(expectedErrorText);
     });
 };

--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -72,7 +72,7 @@ moduleFor(
           assert.ok(false, 'expected handleURLing: `' + path + '` to fail');
         })
         .catch(reason => {
-          assert.equal(reason, expectedReason);
+          assert.equal(reason.message, expectedReason);
         });
     }
 
@@ -772,7 +772,7 @@ moduleFor(
           actions: {
             error(reason) {
               assert.equal(
-                reason,
+                reason.message,
                 'Setup error',
                 'SpecialRoute#error received the error thrown from setup'
               );
@@ -813,7 +813,7 @@ moduleFor(
           actions: {
             error(reason) {
               assert.equal(
-                reason,
+                reason.message,
                 'Setup error',
                 'error was correctly passed to custom ApplicationRoute handler'
               );

--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -767,7 +767,7 @@ moduleFor(
         'route:special',
         Route.extend({
           setup() {
-            throw 'Setup error';
+            throw new Error('Setup error');
           },
           actions: {
             error(reason) {
@@ -827,7 +827,7 @@ moduleFor(
         'route:special',
         Route.extend({
           setup() {
-            throw 'Setup error';
+            throw new Error('Setup error');
           },
         })
       );


### PR DESCRIPTION
![screen shot 2018-09-10 at 11 40 35 am](https://user-images.githubusercontent.com/558005/45317263-5a991c80-b4ee-11e8-8c6e-371850b1ea76.png)

![screen shot 2018-09-10 at 10 36 55 am](https://user-images.githubusercontent.com/558005/45317299-7997ae80-b4ee-11e8-8fc5-7788a1a09481.png)

Because I'm a trainer, I feel obligated to provide an explanation that I'm sure many readers don't need:

here's the difference between throwing literals vs errors in Node and Safari. Note the missing stack trace when literals are thrown.