### PR TITLE
[DOC release]Fix module for template helpers to be ember

### DIFF
--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -79,6 +79,9 @@
 
 /**
  @module ember
+ */
+
+/**
  @class Ember.Templates.helpers
  @public
  */


### PR DESCRIPTION
Fixes the fact that Template helpers show `@ember/routing` for a module

![image](https://user-images.githubusercontent.com/3609063/45608853-23ad9400-ba23-11e8-8c41-f4f5c6438f82.png)

Now shows:

![image](https://user-images.githubusercontent.com/3609063/45608886-417af900-ba23-11e8-8754-332279468261.png)

As well as shows up in toc.
