### PR TITLE
move writeDescriptors/removeDescriptors to setup/teardown

### DIFF
--- a/packages/@ember/-internals/metal/lib/alias.ts
+++ b/packages/@ember/-internals/metal/lib/alias.ts
@@ -29,10 +29,9 @@ export class AliasedProperty extends Descriptor implements DescriptorWithDepende
     this._dependentKeys = [altKey];
   }
 
-  setup(obj: object, keyName: string): void {
+  setup(obj: object, keyName: string, meta: Meta): void {
     assert(`Setting alias '${keyName}' on self`, this.altKey !== keyName);
-    super.setup(obj, keyName);
-    let meta = metaFor(obj);
+    super.setup(obj, keyName, meta);
     if (meta.peekWatching(keyName) > 0) {
       this.consume(obj, keyName, meta);
     }
@@ -40,6 +39,7 @@ export class AliasedProperty extends Descriptor implements DescriptorWithDepende
 
   teardown(obj: object, keyName: string, meta: Meta): void {
     this.unconsume(obj, keyName, meta);
+    super.teardown(obj, keyName, meta);
   }
 
   willWatch(obj: object, keyName: string, meta: Meta): void {

--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -508,6 +508,7 @@ class ComputedProperty extends Descriptor implements DescriptorWithDependentKeys
     if (cache !== undefined && cache.delete(keyName)) {
       removeDependentKeys(this, obj, keyName, meta);
     }
+    super.teardown(obj, keyName, meta);
   }
 
   auto!: () => ComputedProperty;

--- a/packages/@ember/-internals/metal/lib/descriptor.ts
+++ b/packages/@ember/-internals/metal/lib/descriptor.ts
@@ -1,3 +1,4 @@
+import { Meta } from '@ember/-internals/meta';
 import { Descriptor } from './properties';
 
 export default function descriptor(desc: PropertyDescriptor) {
@@ -22,8 +23,9 @@ class NativeDescriptor extends Descriptor {
     this.configurable = desc.configurable !== false;
   }
 
-  setup(obj: object, key: string) {
+  setup(obj: object, key: string, meta: Meta) {
     Object.defineProperty(obj, key, this.desc);
+    meta.writeDescriptors(key, this);
   }
 
   get(obj: object, key: string): any | null | undefined {

--- a/packages/@ember/-internals/metal/lib/properties.ts
+++ b/packages/@ember/-internals/metal/lib/properties.ts
@@ -31,15 +31,18 @@ export abstract class Descriptor {
   enumerable = true;
   configurable = true;
 
-  setup(obj: object, keyName: string): void {
+  setup(obj: object, keyName: string, meta: Meta): void {
     Object.defineProperty(obj, keyName, {
       enumerable: this.enumerable,
       configurable: this.configurable,
       get: DESCRIPTOR_GETTER_FUNCTION(keyName, this),
     });
+    meta.writeDescriptors(keyName, this);
   }
 
-  teardown(_obj: object, _keyName: string, _meta: Meta): void {}
+  teardown(_obj: object, keyName: string, meta: Meta): void {
+    meta.removeDescriptors(keyName);
+  }
 
   abstract get(obj: object, keyName: string): any | null | undefined;
   abstract set(obj: object, keyName: string, value: any | null | undefined): any | null | undefined;
@@ -174,7 +177,6 @@ export function defineProperty(
 
   if (wasDescriptor) {
     previousDesc.teardown(obj, keyName, meta);
-    meta.removeDescriptors(keyName);
   }
 
   // used to track if the the property being defined be enumerable
@@ -192,8 +194,7 @@ export function defineProperty(
   let value;
   if (desc instanceof Descriptor) {
     value = desc;
-    desc.setup(obj, keyName);
-    meta.writeDescriptors(keyName, value);
+    desc.setup(obj, keyName, meta);
   } else if (desc === undefined || desc === null) {
     value = data;
 


### PR DESCRIPTION
I think having `writeDescriptors/removeDescriptors` inside setup/teardown is more appropriate 