### PR TITLE
Failing test to demonstrate query params bug

### DIFF
--- a/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
+++ b/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
@@ -605,6 +605,49 @@ moduleFor(
         });
     }
 
+    ['@test link-to with dynamic segment and loading route regression test'](assert) {
+      this.router.map(function() {
+        this.route('foo', { path: ':foo' }, function() {
+          this.route('bar', function() {
+            this.route('baz');
+          });
+        });
+      });
+
+      this.addTemplate(
+        'foo.bar',
+        `
+      {{link-to 'Baz' 'foo.bar.baz' id='baz-link'}}
+    `
+      );
+
+      this.addTemplate('foo.bar.loading', 'Loading');
+
+      this.add(
+        'controller:foo.bar',
+        Controller.extend({
+          queryParams: ['qux'],
+          qux: null,
+        })
+      );
+
+      this.add(
+        'route:foo.bar.baz',
+        Route.extend({
+          model() {
+            return new RSVP.Promise(resolve => {
+              setTimeout(resolve, 1);
+            });
+          },
+        })
+      );
+
+      return this.visit('/foo/bar/baz?qux=abc').then(() => {
+        let bazLink = this.$('#baz-link');
+        assert.equal(bazLink.attr('href'), '/foo/bar/baz?qux=abc');
+      });
+    }
+
     ['@test link-to default query params while in active transition regression test'](assert) {
       this.router.map(function() {
         this.route('foos');


### PR DESCRIPTION
If there's:

1. a dynamic segment
2. a loading template
3. a route with a model hook that returns a promise
4. a query param defined

then the query param is not sticky on `link-to`s

Possibly related to https://github.com/emberjs/ember.js/issues/12107

Twiddle demonstrating the issue: https://ember-twiddle.com/97f2c3d7596c97d51846033ad23d75f2