### PR TITLE
Failing test for issue with controllerName + queryParams + transitionTo

### DIFF
--- a/packages/ember/tests/routing/router_service_test/transitionTo_test.js
+++ b/packages/ember/tests/routing/router_service_test/transitionTo_test.js
@@ -260,34 +260,205 @@ moduleFor(
         .then(() => {
           assert.equal(this.routerService.get('currentURL'), '/child?sort=ASC');
         });
-    }
+      }
 
-    ['@test RouterService#transitionTo passing only queryParams works'](assert) {
-      assert.expect(2);
+      ['@test RouterService#transitionTo with basic query params does not remove query param defaults'](
+        assert
+      ) {
+        assert.expect(1);
 
-      this.add(
-        'controller:parent.child',
-        Controller.extend({
-          queryParams: ['sort'],
-        })
-      );
+        this.add(
+          'controller:parent.child',
+          Controller.extend({
+            queryParams: ['sort'],
+            sort: 'ASC',
+          })
+        );
 
-      let queryParams = this.buildQueryParams({ sort: 'DESC' });
+        let queryParams = this.buildQueryParams({ sort: 'ASC' });
 
-      return this.visit('/')
-        .then(() => {
-          return this.routerService.transitionTo('parent.child');
-        })
-        .then(() => {
-          assert.equal(this.routerService.get('currentURL'), '/child');
-        })
-        .then(() => {
-          return this.routerService.transitionTo(queryParams);
-        })
-        .then(() => {
-          assert.equal(this.routerService.get('currentURL'), '/child?sort=DESC');
-        });
-    }
+        return this.visit('/')
+          .then(() => {
+            return this.routerService.transitionTo('parent.child', queryParams);
+          })
+          .then(() => {
+            assert.equal(this.routerService.get('currentURL'), '/child?sort=ASC');
+          });
+      }
+
+      ['@test RouterService#transitionTo passing only queryParams works'](assert) {
+        assert.expect(2);
+
+        this.add(
+          'controller:parent.child',
+          Controller.extend({
+            queryParams: ['sort'],
+          })
+        );
+
+        let queryParams = this.buildQueryParams({ sort: 'DESC' });
+
+        return this.visit('/')
+          .then(() => {
+            return this.routerService.transitionTo('parent.child');
+          })
+          .then(() => {
+            assert.equal(this.routerService.get('currentURL'), '/child');
+          })
+          .then(() => {
+            return this.routerService.transitionTo(queryParams);
+          })
+          .then(() => {
+            assert.equal(this.routerService.get('currentURL'), '/child?sort=DESC');
+          });
+      }
+
+      ['@test RouterService#transitionTo with unspecified query params'](assert) {
+        assert.expect(1);
+
+        this.add(
+          'controller:parent.child',
+          Controller.extend({
+            queryParams: ['sort', 'page', 'category', 'extra'],
+            sort: 'ASC',
+            page: null,
+            category: undefined,
+          })
+        );
+
+        let queryParams = this.buildQueryParams({ sort: 'ASC' });
+
+        return this.visit('/')
+          .then(() => {
+            return this.routerService.transitionTo('parent.child', queryParams);
+          })
+          .then(() => {
+            assert.equal(this.routerService.get('currentURL'), '/child?sort=ASC');
+          });
+      }
+
+      ['@test RouterService#transitionTo with queryParams shared across routes using controllerName and no params passed'](
+        assert
+      ) {
+        this.add(
+          'controller:parent',
+          Controller.extend({
+            queryParams: ['foo'],
+          })
+        );
+
+        this.add(
+          'route:parent.child',
+          Route.extend({
+            controllerName: 'parent',
+          })
+        );
+
+        return this.visit('/')
+          .then(() => {
+            return this.routerService.transitionTo('parent.child');
+          })
+          .then(() => {
+            assert.equal(this.routerService.get('currentURL'), '/child');
+          });
+      }
+
+      ['@test RouterService#transitionTo with queryParams shared across routes using controllerName and some params passed'](
+        assert
+      ) {
+        this.add(
+          'controller:parent',
+          Controller.extend({
+            queryParams: ['foo', 'bar'],
+          })
+        );
+
+        this.add(
+          'route:parent.child',
+          Route.extend({
+            controllerName: 'parent',
+          })
+        );
+
+        return this.visit('/')
+          .then(() => {
+            return this.routerService.transitionTo('parent.child', {
+              queryParams: { foo: '123' },
+            });
+          })
+          .then(() => {
+            assert.equal(this.routerService.get('currentURL'), '/child?foo=123');
+          });
+      }
+
+      ['@test RouterService#transitionTo with queryParams shared across routes using controllerName and all params passed'](
+        assert
+      ) {
+        this.add(
+          'controller:parent',
+          Controller.extend({
+            queryParams: ['foo', 'bar'],
+          })
+        );
+
+        this.add(
+          'route:parent.child',
+          Route.extend({
+            controllerName: 'parent',
+          })
+        );
+
+        return this.visit('/')
+          .then(() => {
+            return this.routerService.transitionTo('parent.child', {
+              queryParams: { foo: '123', bar: '456' },
+            });
+          })
+          .then(() => {
+            assert.equal(this.routerService.get('currentURL'), '/child?foo=123&bar=456');
+          });
+      }
+
+      ['@test RouterService#transitionTo with aliased query params uses the original provided key'](
+        assert
+      ) {
+        assert.expect(1);
+
+        this.add(
+          'controller:parent.child',
+          Controller.extend({
+            queryParams: {
+              cont_sort: 'url_sort',
+            },
+            cont_sort: 'ASC',
+          })
+        );
+
+        let queryParams = this.buildQueryParams({ url_sort: 'ASC' });
+
+        return this.visit('/')
+          .then(() => {
+            return this.routerService.transitionTo('parent.child', queryParams);
+          })
+          .then(() => {
+            assert.equal(this.routerService.get('currentURL'), '/child?url_sort=ASC');
+          });
+      }
+
+      ['@test RouterService#transitionTo with aliased query params uses the original provided key when controller property name'](
+        assert
+      ) {
+        assert.expect(1);
+
+        this.add(
+          'controller:parent.child',
+          Controller.extend({
+            queryParams: {
+              cont_sort: 'url_sort',
+            },
+            cont_sort: 'ASC',
+          })
+        );
 
     ['@test RouterService#transitionTo with unspecified query params'](assert) {
       assert.expect(1);


### PR DESCRIPTION
When using the `controllerName` property to share a controller across a parent and child route, `RouterService#transitionTo` fails when attempting to transition to the route that that is "sharing" via `controllerName`.

For example, `parent` has a controller that defines `queryParams` as `['foo']`, and `parent.child` uses `controllerName: 'parent'` to share the controller. Attempting to call `RouterService#transitionTo('parent.child')` will throw the following error:

```
Assertion Failed: You passed the `parent:foo` query parameter during a transition into parent.child, please update to foo
```

Based on the digging I've done so far, I can tell you that this assertion is happening in `router.js` [here](https://github.com/emberjs/ember.js/blob/master/packages/@ember/-internals/routing/lib/system/router.js#L978-L993), and appears to be failing due to `parentProp` being undefined.

There appears to be prior discussion/work on this issue, as seen in the following commits/issues:
- https://github.com/emberjs/ember.js/commit/1c8c6ecad42228e94deffb7672fc6de905fca007
- https://github.com/emberjs/ember.js/commit/3b9489cf6acb61c5ee22f8016f7486ef1e7133d4
- https://github.com/emberjs/ember.js/issues/15725

However, I haven't found anything related specifically to the `controllerName` issue, though the same assertion is being triggered in all cases.

Here is [a twiddle](https://ember-twiddle.com/6d2b17d81c92abd5299ea8d434124381) that demonstrates the issue.

Fixes https://github.com/emberjs/ember.js/issues/14560.