### PR TITLE
Failing test for angle bracket helper precedence

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
@@ -376,6 +376,21 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
         this.assertText('Hola');
       }
 
+      '@test arguments set in context should take precedence over helpers with same name'(assert) {
+        this.registerHelper('baz', () => { assert.ok(false, 'custom baz helper should not be called'); });
+
+        this.registerComponent('foo-bar', { template: '{{@foo}}' });
+
+        // this.render('{{foo-bar foo=baz}}', { baz: 'Hi' }); // This works
+        this.render('<FooBar @foo={{baz}} />', { baz: 'Hi' });
+
+        this.assertText('Hi');
+
+        this.runTask(() => this.context.set('baz', 'Hello'));
+
+        this.assertText('Hello');
+      }
+
       '@test it reflects named arguments as properties'() {
         this.registerComponent('foo-bar', {
           template: '{{foo}}',


### PR DESCRIPTION
We ran into an issue when converting the following line in a test:

From this:

```await render(hbs`{{foo-map map=map}}`)```

To this:

```await render(hbs`<FooMap @map={{map}} />`)```

The issue, in our case, was that we were also using the `ember-composable-helpers` addon which includes a `map` helper. It appears that the `map` helper takes precedence over the `map` value set within the context. The solution is either to use `this.map` or rename `map`.

Should this be the other way around? Looking at the [RFC](https://github.com/emberjs/rfcs/blob/master/text/0311-angle-bracket-invocation.md#arguments) it is unclear to me what the expected behavior should be.
