### PR TITLE
[refactor][tests] Removes new usage from tests

### DIFF
--- a/packages/@ember/-internals/runtime/tests/helpers/array.js
+++ b/packages/@ember/-internals/runtime/tests/helpers/array.js
@@ -171,7 +171,7 @@ class CopyableNativeArray extends AbstractArrayHelper {
 
 class CopyableArray extends AbstractArrayHelper {
   newObject() {
-    return new CopyableObject();
+    return CopyableObject.create();
   }
 
   isEqual(a, b) {
@@ -280,7 +280,7 @@ const CopyableObject = EmberObject.extend(Copyable, {
   },
 
   copy() {
-    let ret = new CopyableObject();
+    let ret = CopyableObject.create();
     set(ret, 'id', get(this, 'id'));
     return ret;
   },
@@ -288,7 +288,7 @@ const CopyableObject = EmberObject.extend(Copyable, {
 
 class MutableArrayHelpers extends NativeArrayHelpers {
   newObject(ary) {
-    return new TestMutableArray(super.newObject(ary));
+    return TestMutableArray.create(super.newObject(ary));
   }
 
   // allows for testing of the basic enumerable after an internal mutation
@@ -299,7 +299,7 @@ class MutableArrayHelpers extends NativeArrayHelpers {
 
 class EmberArrayHelpers extends MutableArrayHelpers {
   newObject(ary) {
-    return new TestArray(super.newObject(ary));
+    return TestArray.create(super.newObject(ary));
   }
 }
 

--- a/packages/@ember/-internals/runtime/tests/mixins/array_test.js
+++ b/packages/@ember/-internals/runtime/tests/mixins/array_test.js
@@ -63,7 +63,7 @@ moduleFor(
     }
 
     ['@test slice supports negative index arguments'](assert) {
-      let testArray = new TestArray({ _content: [1, 2, 3, 4] });
+      let testArray = TestArray.create({ _content: [1, 2, 3, 4] });
 
       assert.deepEqual(testArray.slice(-2), [3, 4], 'slice(-2)');
       assert.deepEqual(testArray.slice(-2, -1), [3], 'slice(-2, -1');
@@ -248,7 +248,7 @@ moduleFor(
   'EmberArray.@each support',
   class extends AbstractTestCase {
     beforeEach() {
-      ary = new TestArray({
+      ary = TestArray.create({
         _content: [
           { isDone: true, desc: 'Todo 1' },
           { isDone: false, desc: 'Todo 2' },

--- a/packages/@ember/-internals/runtime/tests/system/core_object_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/core_object_test.js
@@ -34,7 +34,7 @@ moduleFor(
     }
 
     ['@test toString should be not be added as a property when calling toString()'](assert) {
-      let obj = new CoreObject({
+      let obj = CoreObject.create({
         firstName: 'Foo',
         lastName: 'Bar',
       });
@@ -54,7 +54,7 @@ moduleFor(
         },
       }).create();
 
-      let obj = new CoreObject({
+      let obj = CoreObject.create({
         someProxyishThing,
       });
 

--- a/packages/@ember/-internals/runtime/tests/system/object/computed_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/computed_test.js
@@ -31,7 +31,7 @@ moduleFor(
         }),
       });
 
-      testWithDefault(assert, 'FOO', new MyClass(), 'foo');
+      testWithDefault(assert, 'FOO', MyClass.create(), 'foo');
     }
 
     ['@test computed property on subclass'](assert) {
@@ -47,7 +47,7 @@ moduleFor(
         }),
       });
 
-      testWithDefault(assert, 'BAR', new Subclass(), 'foo');
+      testWithDefault(assert, 'BAR', Subclass.create(), 'foo');
     }
 
     ['@test replacing computed property with regular val'](assert) {
@@ -61,7 +61,7 @@ moduleFor(
         foo: 'BAR',
       });
 
-      testWithDefault(assert, 'BAR', new Subclass(), 'foo');
+      testWithDefault(assert, 'BAR', Subclass.create(), 'foo');
     }
 
     ['@test complex depndent keys'](assert) {
@@ -83,8 +83,8 @@ moduleFor(
         count: 20,
       });
 
-      let obj1 = new MyClass();
-      let obj2 = new Subclass();
+      let obj1 = MyClass.create();
+      let obj2 = Subclass.create();
 
       testWithDefault(assert, 'BIFF 1', obj1, 'foo');
       testWithDefault(assert, 'BIFF 21', obj2, 'foo');
@@ -129,7 +129,7 @@ moduleFor(
         }).property('bar2.baz'),
       });
 
-      let obj2 = new Subclass();
+      let obj2 = Subclass.create();
 
       testWithDefault(assert, 'BIFF2 1', obj2, 'foo');
 

--- a/packages/@ember/-internals/runtime/tests/system/object/destroy_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/destroy_test.js
@@ -130,13 +130,13 @@ moduleFor(
         }),
       });
 
-      objs.a = new A();
+      objs.a = A.create();
 
-      objs.b = new B();
+      objs.b = B.create();
 
-      objs.c = new C();
+      objs.c = C.create();
 
-      new LongLivedObject();
+      LongLivedObject.create();
 
       run(() => {
         let keys = Object.keys(objs);

--- a/packages/@ember/-internals/runtime/tests/system/object/es-compatibility-test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/es-compatibility-test.js
@@ -47,25 +47,6 @@ moduleFor(
         'passed-property',
         'passed property available on instance (create)'
       );
-      calls = [];
-      myObject = new MyObject({ passedProperty: 'passed-property' });
-
-      assert.deepEqual(calls, ['constructor', 'init'], 'constructor then init called (new)');
-      assert.equal(
-        myObject.postInitProperty,
-        'post-init-property',
-        'constructor property available on instance (new)'
-      );
-      assert.equal(
-        myObject.initProperty,
-        'init-property',
-        'init property available on instance (new)'
-      );
-      assert.equal(
-        myObject.passedProperty,
-        'passed-property',
-        'passed property available on instance (new)'
-      );
     }
 
     ['@test normal method super'](assert) {
@@ -116,7 +97,7 @@ moduleFor(
 
       [Foo, Bar, Baz, Qux, Quux, Corge].forEach((Class, index) => {
         calls = [];
-        new Class().method();
+        Class.create().method();
 
         assert.deepEqual(
           calls,
@@ -199,7 +180,7 @@ moduleFor(
 
       class MyObject extends EmberObject.extend(Mixin1, Mixin2) {}
 
-      let myObject = new MyObject();
+      let myObject = MyObject.create();
       assert.equal(myObject.property1, 'data-1', 'includes the first mixin');
       assert.equal(myObject.property2, 'data-2', 'includes the second mixin');
     }
@@ -207,14 +188,10 @@ moduleFor(
     ['@test using instanceof'](assert) {
       class MyObject extends EmberObject {}
 
-      let myObject1 = MyObject.create();
-      let myObject2 = new MyObject();
+      let myObject = MyObject.create();
 
-      assert.ok(myObject1 instanceof MyObject);
-      assert.ok(myObject1 instanceof EmberObject);
-
-      assert.ok(myObject2 instanceof MyObject);
-      assert.ok(myObject2 instanceof EmberObject);
+      assert.ok(myObject instanceof MyObject);
+      assert.ok(myObject instanceof EmberObject);
     }
 
     ['@test extending an ES subclass of EmberObject'](assert) {
@@ -236,10 +213,6 @@ moduleFor(
 
       MyObject.create();
       assert.deepEqual(calls, ['constructor', 'init'], 'constructor then init called (create)');
-
-      calls = [];
-      new MyObject();
-      assert.deepEqual(calls, ['constructor', 'init'], 'constructor then init called (new)');
     }
 
     ['@test calling extend on an ES subclass of EmberObject'](assert) {
@@ -266,14 +239,6 @@ moduleFor(
         calls,
         ['before constructor', 'init', 'after constructor'],
         'constructor then init called (create)'
-      );
-
-      calls = [];
-      new MyObject();
-      assert.deepEqual(
-        calls,
-        ['before constructor', 'init', 'after constructor'],
-        'constructor then init called (new)'
       );
 
       let obj = MyObject.create({

--- a/packages/@ember/-internals/runtime/tests/system/object/extend_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/extend_test.js
@@ -8,14 +8,14 @@ moduleFor(
     ['@test Basic extend'](assert) {
       let SomeClass = EmberObject.extend({ foo: 'BAR' });
       assert.ok(SomeClass.isClass, 'A class has isClass of true');
-      let obj = new SomeClass();
+      let obj = SomeClass.create();
       assert.equal(obj.foo, 'BAR');
     }
 
     ['@test Sub-subclass'](assert) {
       let SomeClass = EmberObject.extend({ foo: 'BAR' });
       let AnotherClass = SomeClass.extend({ bar: 'FOO' });
-      let obj = new AnotherClass();
+      let obj = AnotherClass.create();
       assert.equal(obj.foo, 'BAR');
       assert.equal(obj.bar, 'FOO');
     }
@@ -49,7 +49,7 @@ moduleFor(
         },
       });
 
-      let obj = new FinalClass();
+      let obj = FinalClass.create();
       obj.foo();
       obj.bar();
       assert.equal(obj.fooCnt, 2, 'should invoke both');
@@ -76,9 +76,9 @@ moduleFor(
       });
       let AnotherClass = SomeClass.extend({ things: 'bar' });
       let YetAnotherClass = SomeClass.extend({ things: 'baz' });
-      let some = new SomeClass();
-      let another = new AnotherClass();
-      let yetAnother = new YetAnotherClass();
+      let some = SomeClass.create();
+      let another = AnotherClass.create();
+      let yetAnother = YetAnotherClass.create();
       assert.deepEqual(some.get('things'), ['foo'], 'base class should have just its value');
       assert.deepEqual(
         another.get('things'),
@@ -102,9 +102,9 @@ moduleFor(
       AnotherClass.reopenClass({ things: 'bar' });
       let YetAnotherClass = SomeClass.extend();
       YetAnotherClass.reopenClass({ things: 'baz' });
-      let some = new SomeClass();
-      let another = new AnotherClass();
-      let yetAnother = new YetAnotherClass();
+      let some = SomeClass.create();
+      let another = AnotherClass.create();
+      let yetAnother = YetAnotherClass.create();
       assert.deepEqual(
         get(some.constructor, 'things'),
         ['foo'],

--- a/packages/@ember/-internals/runtime/tests/system/object/observer_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/observer_test.js
@@ -15,7 +15,7 @@ moduleFor(
         }),
       });
 
-      let obj = new MyClass();
+      let obj = MyClass.create();
       assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
       set(obj, 'bar', 'BAZ');
@@ -37,7 +37,7 @@ moduleFor(
         }),
       });
 
-      let obj = new Subclass();
+      let obj = Subclass.create();
       assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
       set(obj, 'bar', 'BAZ');
@@ -200,7 +200,7 @@ moduleFor(
         },
       });
 
-      let parent = new ParentClass();
+      let parent = ParentClass.create();
 
       assert.equal(changed, false, 'precond');
 

--- a/packages/@ember/-internals/runtime/tests/system/object/reopen_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/reopen_test.js
@@ -14,8 +14,8 @@ moduleFor(
         bar: 'BAR',
       });
 
-      assert.equal(new Subclass().foo(), 'FOO', 'Adds method');
-      assert.equal(get(new Subclass(), 'bar'), 'BAR', 'Adds property');
+      assert.equal(Subclass.create().foo(), 'FOO', 'Adds method');
+      assert.equal(get(Subclass.create(), 'bar'), 'BAR', 'Adds property');
     }
 
     ['@test reopened properties inherited by subclasses'](assert) {
@@ -29,8 +29,8 @@ moduleFor(
         bar: 'BAR',
       });
 
-      assert.equal(new SubSub().foo(), 'FOO', 'Adds method');
-      assert.equal(get(new SubSub(), 'bar'), 'BAR', 'Adds property');
+      assert.equal(SubSub.create().foo(), 'FOO', 'Adds method');
+      assert.equal(get(SubSub.create(), 'bar'), 'BAR', 'Adds property');
     }
 
     ['@test allows reopening already instantiated classes'](assert) {

--- a/packages/ember-testing/lib/setup_for_testing.js
+++ b/packages/ember-testing/lib/setup_for_testing.js
@@ -29,7 +29,7 @@ export default function setupForTesting() {
   let adapter = getAdapter();
   // if adapter is not manually set default to QUnit
   if (!adapter) {
-    setAdapter(typeof self.QUnit === 'undefined' ? new Adapter() : new QUnitAdapter());
+    setAdapter(typeof self.QUnit === 'undefined' ? Adapter.create() : QUnitAdapter.create());
   }
 
   if (!jQueryDisabled) {

--- a/packages/ember-testing/tests/adapters/adapter_test.js
+++ b/packages/ember-testing/tests/adapters/adapter_test.js
@@ -9,7 +9,7 @@ moduleFor(
   class extends AbstractTestCase {
     constructor() {
       super();
-      adapter = new Adapter();
+      adapter = Adapter.create();
     }
 
     teardown() {

--- a/packages/ember-testing/tests/adapters/qunit_test.js
+++ b/packages/ember-testing/tests/adapters/qunit_test.js
@@ -15,7 +15,7 @@ moduleFor(
       delete QUnit.start;
       delete QUnit.stop;
 
-      adapter = new QUnitAdapter();
+      adapter = QUnitAdapter.create();
     }
 
     teardown() {

--- a/packages/internal-test-helpers/lib/build-owner.js
+++ b/packages/internal-test-helpers/lib/build-owner.js
@@ -25,7 +25,7 @@ export default function buildOwner(options = {}) {
 
   let Owner = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixin);
 
-  let namespace = new EmberObject({
+  let namespace = EmberObject.create({
     Resolver: new ResolverWrapper(resolver),
   });
 


### PR DESCRIPTION
Removes usage of `new EmberObject` from tests in preparation for
the changes of RFC 337