### PR TITLE
Fix engine rendering tests setup

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
@@ -19,12 +19,14 @@ moduleFor(
         // internally. Specifically, it returns a promise when transitioning _into_
         // the first engine route, but returns the synchronously available handler
         // _after_ the engine has been resolved.
-        _getHandlerFunction() {
-          let syncHandler = this._super(...arguments);
+        setupRouter() {
+          this._super(...arguments);
+          let syncHandler = this._routerMicrolib.getHandler;
+
           this._enginePromises = Object.create(null);
           this._resolvedEngines = Object.create(null);
 
-          return name => {
+          this._routerMicrolib.getHandler = name => {
             let engineInfo = this._engineInfoByRoute[name];
             if (!engineInfo) {
               return syncHandler(name);

--- a/packages/ember/tests/routing/query_params_test/query_param_async_get_handler_test.js
+++ b/packages/ember/tests/routing/query_params_test/query_param_async_get_handler_test.js
@@ -23,9 +23,9 @@ moduleFor(
         setupRouter() {
           this._super(...arguments);
           let { _handlerPromises: handlerPromises, _seenHandlers: seenHandlers } = this;
-          let getHandler = this._routerMicrolib.__proto__.getHandler;
+          let getHandler = this._routerMicrolib.getHandler;
 
-          this._routerMicrolib.__proto__.getHandler = function(routeName) {
+          this._routerMicrolib.getHandler = function(routeName) {
             fetchedHandlers.push(routeName);
 
             // Cache the returns so we don't have more than one Promise for a


### PR DESCRIPTION
This was missed in one of the migrations. Wasn't fatal but we should bring back the functionality.

_As the comment says:_

> This creates a handler function similar to what is in use by ember-engines internally. Specifically, it returns a promise when transitioning _into_ the first engine route, but returns the synchronously available handler _after_ the engine has been resolved.