### PR TITLE
Router.js Generics & Route Infos Prep Work

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "puppeteer": "^1.3.0",
     "qunit": "^2.5.0",
     "route-recognizer": "^0.3.4",
-    "router_js": "^5.0.1",
+    "router_js": "^5.0.3",
     "rsvp": "^4.8.2",
     "semver": "^5.5.0",
     "serve-static": "^1.12.2",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "puppeteer": "^1.3.0",
     "qunit": "^2.5.0",
     "route-recognizer": "^0.3.4",
-    "router_js": "^4.0.3",
+    "router_js": "^5.0.1",
     "rsvp": "^4.8.2",
     "semver": "^5.5.0",
     "serve-static": "^1.12.2",

--- a/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
@@ -14,27 +14,21 @@ moduleFor(
     get routerOptions() {
       return {
         location: 'none',
-
-        // This creates a handler function similar to what is in use by ember-engines
-        // internally. Specifically, it returns a promise when transitioning _into_
-        // the first engine route, but returns the synchronously available handler
-        // _after_ the engine has been resolved.
         setupRouter() {
           this._super(...arguments);
-          let syncHandler = this._routerMicrolib.getHandler;
-
+          let getRoute = this._routerMicrolib.getRoute;
           this._enginePromises = Object.create(null);
           this._resolvedEngines = Object.create(null);
 
-          this._routerMicrolib.getHandler = name => {
+          this._routerMicrolib.getRoute = name => {
             let engineInfo = this._engineInfoByRoute[name];
             if (!engineInfo) {
-              return syncHandler(name);
+              return getRoute(name);
             }
 
             let engineName = engineInfo.name;
             if (this._resolvedEngines[engineName]) {
-              return syncHandler(name);
+              return getRoute(name);
             }
 
             let enginePromise = this._enginePromises[engineName];
@@ -50,7 +44,7 @@ moduleFor(
               this._enginePromises[engineName] = enginePromise;
             }
 
-            return enginePromise.then(() => syncHandler(name));
+            return enginePromise.then(() => getRoute(name));
           };
         },
       };

--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -65,7 +65,7 @@ export default class RouterService extends Service {
     let { routeName, models, queryParams } = extractRouteArgs(args);
 
     let transition = this._router._doTransition(routeName, models, queryParams, true);
-    transition._keepDefaultQueryParamValues = true;
+    transition['_keepDefaultQueryParamValues'] = true;
 
     return transition;
   }
@@ -108,8 +108,8 @@ export default class RouterService extends Service {
      @return {String} the string representing the generated URL
      @public
    */
-  urlFor(/* routeName, ...models, options */) {
-    return this._router.generate(...arguments);
+  urlFor(routeName: string, ...args: any[]) {
+    return this._router.generate(routeName, ...args);
   }
 
   /**
@@ -129,7 +129,7 @@ export default class RouterService extends Service {
     let { routeName, models, queryParams } = extractRouteArgs(args);
     let routerMicrolib = this._router._routerMicrolib;
 
-    if (!routerMicrolib.isActiveIntent(routeName, models, null)) {
+    if (!routerMicrolib.isActiveIntent(routeName, models)) {
       return false;
     }
     let hasQueryParams = Object.keys(queryParams).length > 0;
@@ -141,7 +141,7 @@ export default class RouterService extends Service {
         queryParams,
         true /* fromRouterService */
       );
-      return shallowEqual(queryParams, routerMicrolib.state.queryParams);
+      return shallowEqual(queryParams, routerMicrolib.state!.queryParams);
     }
 
     return true;

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -14,8 +14,7 @@ import { once } from '@ember/runloop';
 import { classify } from '@ember/string';
 import { DEBUG } from '@glimmer/env';
 import { TemplateFactory } from '@glimmer/opcode-compiler';
-import { Transition, TransitionState } from 'router_js';
-import HandlerInfo from 'router_js/dist/cjs/handler-info';
+import { InternalRouteInfo, Route as IRoute, Transition, TransitionState } from 'router_js';
 import {
   calculateCacheKey,
   normalizeControllerQueryParams,
@@ -65,7 +64,9 @@ export function hasDefaultSerialize(route: Route) {
   @public
 */
 
-class Route extends EmberObject {
+class Route extends EmberObject implements IRoute {
+  routeName!: string;
+  context: {} = {};
   serialize!: (model: {}, params: string[]) => object | undefined;
 
   _router!: EmberRouter;
@@ -115,22 +116,22 @@ class Route extends EmberObject {
 
     @method _stashNames
   */
-  _stashNames(handlerInfo: HandlerInfo, dynamicParent: HandlerInfo) {
+  _stashNames(routeInfo: InternalRouteInfo<this>, dynamicParent: InternalRouteInfo<this>) {
     if (this._names) {
       return;
     }
-    let names = (this._names = handlerInfo['_names']);
+    let names = (this._names = routeInfo['_names']);
 
     if (!names.length) {
-      handlerInfo = dynamicParent;
-      names = (handlerInfo && handlerInfo['_names']) || [];
+      routeInfo = dynamicParent;
+      names = (routeInfo && routeInfo['_names']) || [];
     }
 
     let qps = get(this, '_qp.qps');
 
     let namePaths = new Array(names.length);
     for (let a = 0; a < names.length; ++a) {
-      namePaths[a] = `${handlerInfo.name}.${names[a]}`;
+      namePaths[a] = `${routeInfo.name}.${names[a]}`;
     }
 
     for (let i = 0; i < qps.length; ++i) {
@@ -220,8 +221,8 @@ class Route extends EmberObject {
     let state = transition ? transition.state : this._router._routerMicrolib.state;
 
     let fullName = route.fullRouteName;
-    let params = assign({}, state.params[fullName]);
-    let queryParams = getQueryParamsFor(route, state);
+    let params = assign({}, state!.params[fullName]);
+    let queryParams = getQueryParamsFor(route, state!);
 
     return Object.keys(queryParams).reduce((params, key) => {
       assert(
@@ -331,7 +332,7 @@ class Route extends EmberObject {
     @method _reset
     @since 1.7.0
   */
-  _reset(isExiting: boolean, transition: Transition) {
+  reset(isExiting: boolean, transition: Transition) {
     let controller = this.controller;
     controller._qpDelegate = get(this, '_qp.states.inactive');
 
@@ -786,7 +787,8 @@ class Route extends EmberObject {
     @public
    */
   intermediateTransitionTo(...args: any[]) {
-    this._router.intermediateTransitionTo(...prefixRouteNameArg(this, args));
+    let [name, ...preparedArgs] = prefixRouteNameArg(this, args);
+    this._router.intermediateTransitionTo(name, ...preparedArgs);
   }
 
   /**
@@ -896,7 +898,7 @@ class Route extends EmberObject {
 
     if (transition) {
       // Update the model dep values used to calculate cache keys.
-      stashParamNames(this._router, transition.state!.handlerInfos);
+      stashParamNames(this._router, transition.state!.routeInfos);
 
       let cache = this._bucketCache;
       let params = transition.params;
@@ -1149,7 +1151,7 @@ class Route extends EmberObject {
         if (transition.resolveIndex < 1) {
           return;
         }
-        return transition.state!.handlerInfos[transition.resolveIndex - 1].context;
+        return transition.state!.routeInfos[transition.resolveIndex - 1].context;
       }
     }
 
@@ -1391,8 +1393,8 @@ class Route extends EmberObject {
     // resolved parent contexts on the current transitionEvent.
     if (transition !== undefined && transition !== null) {
       let modelLookupName = (route && route.routeName) || name;
-      if (transition.resolvedModels.hasOwnProperty(modelLookupName)) {
-        return transition.resolvedModels[modelLookupName];
+      if (transition.resolvedModels.hasOwnProperty(modelLookupName!)) {
+        return transition.resolvedModels[modelLookupName!];
       }
     }
 
@@ -1659,13 +1661,13 @@ class Route extends EmberObject {
 
     outletName = outletName || 'main';
     this._disconnectOutlet(outletName, parentView);
-    let handlerInfos = this._router._routerMicrolib.currentHandlerInfos;
-    for (let i = 0; i < handlerInfos.length; i++) {
+    let routeInfos = this._router._routerMicrolib.currentRouteInfos!;
+    for (let i = 0; i < routeInfos.length; i++) {
       // This non-local state munging is sadly necessary to maintain
       // backward compatibility with our existing semantics, which allow
       // any route to disconnectOutlet things originally rendered by any
       // other route. This should all get cut in 2.0.
-      handlerInfos[i].handler._disconnectOutlet(outletName, parentView);
+      routeInfos[i].route!._disconnectOutlet(outletName, parentView);
     }
   }
 
@@ -1718,20 +1720,20 @@ Route.reopenClass({
 });
 
 function parentRoute(route: Route) {
-  let handlerInfo = handlerInfoFor(route, route._router._routerMicrolib.state.handlerInfos, -1);
-  return handlerInfo && handlerInfo.handler;
+  let routeInfo = routeInfoFor(route, route._router._routerMicrolib.state!.routeInfos, -1);
+  return routeInfo && routeInfo.route;
 }
 
-function handlerInfoFor(route: Route, handlerInfos: HandlerInfo[], offset = 0) {
-  if (!handlerInfos) {
+function routeInfoFor(route: Route, routeInfos: InternalRouteInfo<Route>[], offset = 0) {
+  if (!routeInfos) {
     return;
   }
 
   let current: any;
-  for (let i = 0; i < handlerInfos.length; i++) {
-    current = handlerInfos[i].handler;
+  for (let i = 0; i < routeInfos.length; i++) {
+    current = routeInfos[i].route;
     if (current === route) {
-      return handlerInfos[i + offset];
+      return routeInfos[i + offset];
     }
   }
 
@@ -1836,7 +1838,7 @@ interface PartialRenderOptions {
   model?: {};
 }
 
-function getFullQueryParams(router: EmberRouter, state: TransitionState) {
+function getFullQueryParams(router: EmberRouter, state: TransitionState<Route>) {
   if (state['fullQueryParams']) {
     return state['fullQueryParams'];
   }
@@ -1844,11 +1846,11 @@ function getFullQueryParams(router: EmberRouter, state: TransitionState) {
   state['fullQueryParams'] = {};
   assign(state['fullQueryParams'], state.queryParams);
 
-  router._deserializeQueryParams(state.handlerInfos, state['fullQueryParams'] as QueryParam);
+  router._deserializeQueryParams(state.routeInfos, state['fullQueryParams'] as QueryParam);
   return state['fullQueryParams'];
 }
 
-function getQueryParamsFor(route: Route, state: TransitionState) {
+function getQueryParamsFor(route: Route, state: TransitionState<Route>) {
   state['queryParamsFor'] = state['queryParamsFor'] || {};
   let name = route.fullRouteName;
 
@@ -2426,13 +2428,13 @@ Route.reopen(ActionHandler, Evented, {
         return;
       }
 
-      let handlerInfos = transition.state!.handlerInfos;
+      let routeInfos = transition.state!.routeInfos;
       let router = this._router;
-      let qpMeta = router._queryParamsFor(handlerInfos);
+      let qpMeta = router._queryParamsFor(routeInfos);
       let changes = router._qpUpdates;
       let replaceUrl;
 
-      stashParamNames(router, handlerInfos);
+      stashParamNames(router, routeInfos);
 
       for (let i = 0; i < qpMeta.qps.length; ++i) {
         let qp = qpMeta.qps[i];

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -332,7 +332,7 @@ class Route extends EmberObject implements IRoute {
     @method _reset
     @since 1.7.0
   */
-  reset(isExiting: boolean, transition: Transition) {
+  _internalReset(isExiting: boolean, transition: Transition) {
     let controller = this.controller;
     controller._qpDelegate = get(this, '_qp.states.inactive');
 

--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -1,6 +1,7 @@
 import { computed, defineProperty, get, set } from '@ember/-internals/metal';
 import { getOwner, Owner } from '@ember/-internals/owner';
 import { A as emberA, Evented, Object as EmberObject, typeOf } from '@ember/-internals/runtime';
+import { EMBER_ROUTING_ROUTER_SERVICE } from '@ember/canary-features';
 import { assert, deprecate, info } from '@ember/debug';
 import { HANDLER_INFOS } from '@ember/deprecated-features';
 import EmberError from '@ember/error';
@@ -28,82 +29,93 @@ import { EngineRouteInfo } from './engines';
 if (HANDLER_INFOS) {
   Object.defineProperty(InternalRouteInfo.prototype, 'handler', {
     get() {
-      deprecate(
-        'You attempted to read "handlerInfo.handler" which is a private API that will be removed.',
-        false,
-        {
-          id: 'remove-handler-infos',
-          until: '3.9.0',
-        }
-      );
+      if (EMBER_ROUTING_ROUTER_SERVICE) {
+        deprecate(
+          'You attempted to read "handlerInfo.handler" which is a private API that will be removed.',
+          false,
+          {
+            id: 'remove-handler-infos',
+            until: '3.9.0',
+          }
+        );
+      }
       return this.route;
     },
 
     set(value: string) {
-      deprecate(
-        'You attempted to set "handlerInfo.handler" which is a private API that will be removed.',
-        false,
-        {
-          id: 'remove-handler-infos',
-          until: '3.9.0',
-        }
-      );
+      if (EMBER_ROUTING_ROUTER_SERVICE) {
+        deprecate(
+          'You attempted to set "handlerInfo.handler" which is a private API that will be removed.',
+          false,
+          {
+            id: 'remove-handler-infos',
+            until: '3.9.0',
+          }
+        );
+      }
       this.route = value;
     },
   });
 
   Object.defineProperty(InternalTransition.prototype, 'handlerInfos', {
     get() {
-      deprecate(
-        'You attempted to use "transition.handlerInfos" which is a private API that will be removed.',
-        false,
-        {
-          id: 'remove-handler-infos',
-          until: '3.9.0',
-        }
-      );
+      if (EMBER_ROUTING_ROUTER_SERVICE) {
+        deprecate(
+          'You attempted to use "transition.handlerInfos" which is a private API that will be removed.',
+          false,
+          {
+            id: 'remove-handler-infos',
+            until: '3.9.0',
+          }
+        );
+      }
       return this.routeInfos;
     },
   });
 
   Object.defineProperty(TransitionState.prototype, 'handlerInfos', {
     get() {
-      deprecate(
-        'You attempted to use "transition.state.handlerInfos" which is a private API that will be removed.',
-        false,
-        {
-          id: 'remove-handler-infos',
-          until: '3.9.0',
-        }
-      );
-
+      if (EMBER_ROUTING_ROUTER_SERVICE) {
+        deprecate(
+          'You attempted to use "transition.state.handlerInfos" which is a private API that will be removed.',
+          false,
+          {
+            id: 'remove-handler-infos',
+            until: '3.9.0',
+          }
+        );
+      }
       return this.routeInfos;
     },
   });
 
   Object.defineProperty(Router.prototype, 'currentHandlerInfos', {
     get() {
+      if (EMBER_ROUTING_ROUTER_SERVICE) {
+        deprecate(
+          'You attempted to use "_routerMicrolib.currentHandlerInfos" which is a private API that will be removed.',
+          false,
+          {
+            id: 'remove-handler-infos',
+            until: '3.9.0',
+          }
+        );
+      }
+      return this.currentRouteInfos;
+    },
+  });
+
+  Router.prototype['getHandler'] = function(name: string) {
+    if (EMBER_ROUTING_ROUTER_SERVICE) {
       deprecate(
-        'You attempted to use "_routerMicrolib.currentHandlerInfos" which is a private API that will be removed.',
+        'You attempted to use "_routerMicrolib.getHandler" which is a private API that will be removed.',
         false,
         {
           id: 'remove-handler-infos',
           until: '3.9.0',
         }
       );
-      return this.currentRouteInfos;
-    },
-  });
-
-  Router.prototype['getHandler'] = function(name: string) {
-    deprecate(
-      'You attempted to use "_routerMicrolib.getHandler" which is a private API that will be removed.',
-      false,
-      {
-        id: 'remove-handler-infos',
-        until: '3.9.0',
-      }
-    );
+    }
     return this.getRoute(name);
   };
 }

--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -1,7 +1,8 @@
 import { computed, defineProperty, get, set } from '@ember/-internals/metal';
 import { getOwner, Owner } from '@ember/-internals/owner';
 import { A as emberA, Evented, Object as EmberObject, typeOf } from '@ember/-internals/runtime';
-import { assert, info } from '@ember/debug';
+import { assert, deprecate, info } from '@ember/debug';
+import { HANDLER_INFOS } from '@ember/deprecated-features';
 import EmberError from '@ember/error';
 import { assign } from '@ember/polyfills';
 import { cancel, once, run, scheduleOnce } from '@ember/runloop';
@@ -11,14 +12,101 @@ import { calculateCacheKey, extractRouteArgs, getActiveTargetName, resemblesURL 
 import EmberRouterDSL from './dsl';
 import Route, { defaultSerialize, hasDefaultSerialize, RenderOptions } from './route';
 import RouterState from './router_state';
-
 /**
 @module @ember/routing
 */
 
 import { MatchCallback } from 'route-recognizer';
-import Router, { HandlerInfo, IHandler, Transition } from 'router_js';
+import Router, {
+  InternalRouteInfo,
+  InternalTransition,
+  Transition,
+  TransitionState,
+} from 'router_js';
 import { EngineRouteInfo } from './engines';
+
+if (HANDLER_INFOS) {
+  Object.defineProperty(InternalRouteInfo.prototype, 'handler', {
+    get() {
+      deprecate(
+        'You attempted to read "handlerInfo.handler" which is a private API that will be removed.',
+        false,
+        {
+          id: 'remove-handler-infos',
+          until: '3.9.0',
+        }
+      );
+      return this.route;
+    },
+
+    set(value: string) {
+      deprecate(
+        'You attempted to set "handlerInfo.handler" which is a private API that will be removed.',
+        false,
+        {
+          id: 'remove-handler-infos',
+          until: '3.9.0',
+        }
+      );
+      this.route = value;
+    },
+  });
+
+  Object.defineProperty(InternalTransition.prototype, 'handlerInfos', {
+    get() {
+      deprecate(
+        'You attempted to use "transition.handlerInfos" which is a private API that will be removed.',
+        false,
+        {
+          id: 'remove-handler-infos',
+          until: '3.9.0',
+        }
+      );
+      return this.routeInfos;
+    },
+  });
+
+  Object.defineProperty(TransitionState.prototype, 'handlerInfos', {
+    get() {
+      deprecate(
+        'You attempted to use "transition.state.handlerInfos" which is a private API that will be removed.',
+        false,
+        {
+          id: 'remove-handler-infos',
+          until: '3.9.0',
+        }
+      );
+
+      return this.routeInfos;
+    },
+  });
+
+  Object.defineProperty(Router.prototype, 'currentHandlerInfos', {
+    get() {
+      deprecate(
+        'You attempted to use "_routerMicrolib.currentHandlerInfos" which is a private API that will be removed.',
+        false,
+        {
+          id: 'remove-handler-infos',
+          until: '3.9.0',
+        }
+      );
+      return this.currentRouteInfos;
+    },
+  });
+
+  Router.prototype['getHandler'] = function(name: string) {
+    deprecate(
+      'You attempted to use "_routerMicrolib.getHandler" which is a private API that will be removed.',
+      false,
+      {
+        id: 'remove-handler-infos',
+        until: '3.9.0',
+      }
+    );
+    return this.getRoute(name);
+  };
+}
 
 interface RenderOutletState {
   name: string;
@@ -44,7 +132,9 @@ export interface QueryParam {
   scopedPropertyName: string;
 }
 
-function K(this: Router) {
+export type PrivateRouteInfo = InternalRouteInfo<Route>;
+
+function K(this: Router<Route>) {
   return this;
 }
 
@@ -62,6 +152,7 @@ const { slice } = Array.prototype;
 class EmberRouter extends EmberObject {
   location!: string | IEmberLocation;
   rootURL!: string;
+  _routerMicrolib!: Router<Route>;
 
   _initRouterJs() {
     let location = get(this, 'location');
@@ -69,8 +160,8 @@ class EmberRouter extends EmberObject {
     let owner = getOwner(this);
     let seen = Object.create(null);
 
-    class PrivateRouter extends Router {
-      getHandler(name: string) {
+    class PrivateRouter extends Router<Route> {
+      getRoute(name: string) {
         let routeName = name;
         let routeOwner = owner;
         let engineInfo = router._engineInfoByRoute[routeName];
@@ -84,18 +175,18 @@ class EmberRouter extends EmberObject {
 
         let fullRouteName = `route:${routeName}`;
 
-        let handler: IHandler = routeOwner.lookup(fullRouteName);
+        let route: Route = routeOwner.lookup(fullRouteName);
 
         if (seen[name]) {
-          return handler;
+          return route;
         }
 
         seen[name] = true;
 
-        if (!handler) {
+        if (!route) {
           let DefaultRoute: any = routeOwner.factoryFor('route:basic')!.class;
           routeOwner.register(fullRouteName, DefaultRoute.extend());
-          handler = routeOwner.lookup(fullRouteName);
+          route = routeOwner.lookup(fullRouteName);
 
           if (DEBUG) {
             if (get(router, 'namespace.LOG_ACTIVE_GENERATION')) {
@@ -104,15 +195,15 @@ class EmberRouter extends EmberObject {
           }
         }
 
-        (handler as any)._setRouteName(routeName);
+        route._setRouteName(routeName);
 
-        if (engineInfo && !hasDefaultSerialize(handler as any)) {
+        if (engineInfo && !hasDefaultSerialize(route)) {
           throw new Error(
             'Defining a custom serialize method on an Engine route is not supported.'
           );
         }
 
-        return handler;
+        return route;
       }
 
       getSerializer(name: string) {
@@ -133,21 +224,25 @@ class EmberRouter extends EmberObject {
         });
       }
 
-      didTransition(infos: HandlerInfo[]) {
+      didTransition(infos: PrivateRouteInfo[]) {
         router.didTransition(infos);
       }
 
-      willTransition(oldInfos: HandlerInfo[], newInfos: HandlerInfo[], transition: Transition) {
+      willTransition(
+        oldInfos: PrivateRouteInfo[],
+        newInfos: PrivateRouteInfo[],
+        transition: Transition
+      ) {
         router.willTransition(oldInfos, newInfos, transition);
       }
 
       triggerEvent(
-        handlerInfos: HandlerInfo[],
+        routeInfos: PrivateRouteInfo[],
         ignoreFailure: boolean,
         name: string,
         args: unknown[]
       ) {
-        return triggerEvent.bind(router)(handlerInfos, ignoreFailure, name, args);
+        return triggerEvent.bind(router)(routeInfos, ignoreFailure, name, args);
       }
 
       _triggerWillChangeContext() {
@@ -322,7 +417,7 @@ class EmberRouter extends EmberObject {
     @public
     @since 1.2.0
   */
-  didTransition(infos: HandlerInfo[]) {
+  didTransition(infos: PrivateRouteInfo[]) {
     updatePaths(this);
 
     this._cancelSlowTransitionTimer();
@@ -350,31 +445,31 @@ class EmberRouter extends EmberObject {
       return;
     }
 
-    let handlerInfos = this._routerMicrolib.currentHandlerInfos;
+    let routeInfos = this._routerMicrolib.currentRouteInfos;
     let route;
     let defaultParentState: OutletState;
     let liveRoutes = null;
 
-    if (!handlerInfos) {
+    if (!routeInfos) {
       return;
     }
 
-    for (let i = 0; i < handlerInfos.length; i++) {
-      route = handlerInfos[i].handler;
-      let connections = route.connections;
+    for (let i = 0; i < routeInfos.length; i++) {
+      route = routeInfos[i].route;
+      let connections = route!.connections;
       let ownState: OutletState;
       for (let j = 0; j < connections.length; j++) {
         let appended = appendLiveRoute(liveRoutes!, defaultParentState!, connections[j]);
         liveRoutes = appended.liveRoutes;
         if (
-          appended.ownState.render.name === route.routeName ||
+          appended.ownState.render.name === route!.routeName ||
           appended.ownState.render.outlet === 'main'
         ) {
           ownState = appended.ownState;
         }
       }
       if (connections.length === 0) {
-        ownState = representEmptyRoute(liveRoutes!, defaultParentState as OutletState, route);
+        ownState = representEmptyRoute(liveRoutes!, defaultParentState as OutletState, route!);
       }
       defaultParentState = ownState!;
     }
@@ -410,7 +505,11 @@ class EmberRouter extends EmberObject {
     @public
     @since 1.11.0
   */
-  willTransition(oldInfos: HandlerInfo[], newInfos: HandlerInfo[], transition: Transition) {
+  willTransition(
+    oldInfos: PrivateRouteInfo[],
+    newInfos: PrivateRouteInfo[],
+    transition: Transition
+  ) {
     once(this, this.trigger, 'willTransition', transition);
 
     if (DEBUG) {
@@ -474,13 +573,13 @@ class EmberRouter extends EmberObject {
     return this._doTransition(routeName, models, queryParams);
   }
 
-  intermediateTransitionTo(...args: any[]) {
-    this._routerMicrolib.intermediateTransitionTo(...args);
+  intermediateTransitionTo(name: string, ...args: any[]) {
+    this._routerMicrolib.intermediateTransitionTo(name, ...args);
 
     updatePaths(this);
 
     if (DEBUG) {
-      let infos = this._routerMicrolib.currentHandlerInfos;
+      let infos = this._routerMicrolib.currentRouteInfos;
       if (get(this, 'namespace').LOG_TRANSITIONS) {
         // eslint-disable-next-line no-console
         console.log(`Intermediate-transitioned into '${EmberRouter._routePath(infos)}'`);
@@ -492,8 +591,8 @@ class EmberRouter extends EmberObject {
     return this.transitionTo(...args).method('replace');
   }
 
-  generate(...args: any[]) {
-    let url = this._routerMicrolib.generate(...args);
+  generate(name: string, ...args: any[]) {
+    let url = this._routerMicrolib.generate(name, ...args);
     return (this.location as IEmberLocation).formatURL(url);
   }
 
@@ -505,8 +604,8 @@ class EmberRouter extends EmberObject {
     @return {Boolean}
     @private
   */
-  isActive() {
-    return this._routerMicrolib.isActive(...arguments);
+  isActive(routeName: string) {
+    return this._routerMicrolib.isActive(routeName);
   }
 
   /**
@@ -526,9 +625,9 @@ class EmberRouter extends EmberObject {
     return this.currentState!.isActiveIntent(routeName, models, queryParams);
   }
 
-  send(...args: any[]) {
+  send(name: string, ...args: any[]) {
     /*name, context*/
-    this._routerMicrolib.trigger(...args);
+    this._routerMicrolib.trigger(name, ...args);
   }
 
   /**
@@ -538,7 +637,7 @@ class EmberRouter extends EmberObject {
     @return {Boolean}
     @private
   */
-  hasRoute(route: Route) {
+  hasRoute(route: string) {
     return this._routerMicrolib.hasRoute(route);
   }
 
@@ -656,14 +755,14 @@ class EmberRouter extends EmberObject {
 
     @private
     @method _serializeQueryParams
-    @param {Arrray<HandlerInfo>} handlerInfos
+    @param {Arrray<RouteInfo>} routeInfos
     @param {Object} queryParams
     @return {Void}
   */
-  _serializeQueryParams(handlerInfos: HandlerInfo[], queryParams: QueryParam) {
+  _serializeQueryParams(routeInfos: PrivateRouteInfo[], queryParams: QueryParam) {
     forEachQueryParam(
       this,
-      handlerInfos,
+      routeInfos,
       queryParams,
       (key: string, value: unknown, qp: QueryParam) => {
         if (qp) {
@@ -701,14 +800,14 @@ class EmberRouter extends EmberObject {
 
     @private
     @method _deserializeQueryParams
-    @param {Array<HandlerInfo>} handlerInfos
+    @param {Array<RouteInfo>} routeInfos
     @param {Object} queryParams
     @return {Void}
   */
-  _deserializeQueryParams(handlerInfos: HandlerInfo[], queryParams: QueryParam) {
+  _deserializeQueryParams(routeInfos: PrivateRouteInfo[], queryParams: QueryParam) {
     forEachQueryParam(
       this,
-      handlerInfos,
+      routeInfos,
       queryParams,
       (key: string, value: unknown, qp: QueryParam) => {
         // If we don't have QP meta info for a given key, then we do nothing
@@ -748,12 +847,12 @@ class EmberRouter extends EmberObject {
 
     @private
     @method _pruneDefaultQueryParamValues
-    @param {Array<HandlerInfo>} handlerInfos
+    @param {Array<RouteInfo>} routeInfos
     @param {Object} queryParams
     @return {Void}
   */
-  _pruneDefaultQueryParamValues(handlerInfos: HandlerInfo[], queryParams: {}) {
-    let qps = this._queryParamsFor(handlerInfos);
+  _pruneDefaultQueryParamValues(routeInfos: PrivateRouteInfo[], queryParams: {}) {
+    let qps = this._queryParamsFor(routeInfos);
     for (let key in queryParams) {
       let qp = qps.map[key];
       if (qp && qp.serializedDefaultValue === queryParams[key]) {
@@ -771,7 +870,7 @@ class EmberRouter extends EmberObject {
     let targetRouteName = _targetRouteName || getActiveTargetName(this._routerMicrolib);
     assert(
       `The route ${targetRouteName} was not found`,
-      targetRouteName && this._routerMicrolib.hasRoute(targetRouteName)
+      !!targetRouteName && this._routerMicrolib.hasRoute(targetRouteName)
     );
 
     let queryParams = {};
@@ -842,10 +941,10 @@ class EmberRouter extends EmberObject {
   ) {
     let state = calculatePostTransitionState(this, targetRouteName, models);
     this._hydrateUnsuppliedQueryParams(state, queryParams, !!_fromRouterService);
-    this._serializeQueryParams(state.handlerInfos, queryParams);
+    this._serializeQueryParams(state.routeInfos, queryParams);
 
     if (!_fromRouterService) {
-      this._pruneDefaultQueryParamValues(state.handlerInfos, queryParams);
+      this._pruneDefaultQueryParamValues(state.routeInfos, queryParams);
     }
   }
 
@@ -855,26 +954,26 @@ class EmberRouter extends EmberObject {
 
     @private
     @method _getQPMeta
-    @param {HandlerInfo} handlerInfo
+    @param {RouteInfo} handlerInfo
     @return {Object}
   */
-  _getQPMeta(handlerInfo: HandlerInfo) {
-    let route = handlerInfo.handler;
+  _getQPMeta(handlerInfo: PrivateRouteInfo) {
+    let route = handlerInfo.route;
     return route && get(route, '_qp');
   }
 
   /**
-    Returns a merged query params meta object for a given set of handlerInfos.
+    Returns a merged query params meta object for a given set of routeInfos.
     Useful for knowing what query params are available for a given route hierarchy.
 
     @private
     @method _queryParamsFor
-    @param {Array<HandlerInfo>} handlerInfos
+    @param {Array<RouteInfo>} routeInfos
     @return {Object}
    */
-  _queryParamsFor(handlerInfos: HandlerInfo[]) {
-    let handlerInfoLength = handlerInfos.length;
-    let leafRouteName = handlerInfos[handlerInfoLength - 1].name;
+  _queryParamsFor(routeInfos: PrivateRouteInfo[]) {
+    let handlerInfoLength = routeInfos.length;
+    let leafRouteName = routeInfos[handlerInfoLength - 1].name;
     let cached = this._qpCache[leafRouteName];
     if (cached !== undefined) {
       return cached;
@@ -890,7 +989,7 @@ class EmberRouter extends EmberObject {
     let qpOther;
 
     for (let i = 0; i < handlerInfoLength; ++i) {
-      qpMeta = this._getQPMeta(handlerInfos[i]);
+      qpMeta = this._getQPMeta(routeInfos[i]);
 
       if (!qpMeta) {
         shouldCache = false;
@@ -947,10 +1046,10 @@ class EmberRouter extends EmberObject {
   */
   _fullyScopeQueryParams(leafRouteName: string, contexts: {}[], queryParams: {}) {
     let state = calculatePostTransitionState(this, leafRouteName, contexts);
-    let handlerInfos = state.handlerInfos;
+    let routeInfos = state.routeInfos;
     let qpMeta;
-    for (let i = 0, len = handlerInfos.length; i < len; ++i) {
-      qpMeta = this._getQPMeta(handlerInfos[i]);
+    for (let i = 0, len = routeInfos.length; i < len; ++i) {
+      qpMeta = this._getQPMeta(routeInfos[i]);
 
       if (!qpMeta) {
         continue;
@@ -988,18 +1087,18 @@ class EmberRouter extends EmberObject {
     @return {Void}
   */
   _hydrateUnsuppliedQueryParams(
-    state: { handlerInfos: HandlerInfo[]; params: {} },
+    state: TransitionState<Route>,
     queryParams: {},
     _fromRouterService: boolean
   ) {
-    let handlerInfos = state.handlerInfos;
+    let routeInfos = state.routeInfos;
     let appCache = this._bucketCache;
     let qpMeta;
     let qp;
     let presentProp;
 
-    for (let i = 0; i < handlerInfos.length; ++i) {
-      qpMeta = this._getQPMeta(handlerInfos[i]);
+    for (let i = 0; i < routeInfos.length; ++i) {
+      qpMeta = this._getQPMeta(routeInfos[i]);
 
       if (!qpMeta) {
         continue;
@@ -1066,7 +1165,7 @@ class EmberRouter extends EmberObject {
     let targetState = new RouterState(
       this,
       this._routerMicrolib,
-      this._routerMicrolib.activeTransition.state
+      this._routerMicrolib.activeTransition.state!
     );
     this.set('targetState', targetState);
 
@@ -1134,9 +1233,9 @@ class EmberRouter extends EmberObject {
 }
 
 /*
-  Helper function for iterating over routes in a set of handlerInfos that are
+  Helper function for iterating over routes in a set of routeInfos that are
   at or above the given origin route. Example: if `originRoute` === 'foo.bar'
-  and the handlerInfos given were for 'foo.bar.baz', then the given callback
+  and the routeInfos given were for 'foo.bar.baz', then the given callback
   will be invoked with the routes for 'foo.bar', 'foo', and 'application'
   individually.
 
@@ -1144,17 +1243,17 @@ class EmberRouter extends EmberObject {
 
   @private
   @param {Route} originRoute
-  @param {Array<HandlerInfo>} handlerInfos
+  @param {Array<HandlerInfo>} routeInfos
   @param {Function} callback
   @return {Void}
  */
 function forEachRouteAbove(
-  handlerInfos: HandlerInfo[],
-  callback: (route: Route, handlerInfo: HandlerInfo) => boolean
+  routeInfos: PrivateRouteInfo[],
+  callback: (route: Route, handlerInfo: PrivateRouteInfo) => boolean
 ) {
-  for (let i = handlerInfos.length - 1; i >= 0; --i) {
-    let handlerInfo = handlerInfos[i];
-    let route = handlerInfo.handler as any;
+  for (let i = routeInfos.length - 1; i >= 0; --i) {
+    let handlerInfo = routeInfos[i];
+    let route = handlerInfo.route;
 
     // handlerInfo.handler being `undefined` generally means either:
     //
@@ -1176,20 +1275,25 @@ function forEachRouteAbove(
 // These get invoked when an action bubbles above ApplicationRoute
 // and are not meant to be overridable.
 let defaultActionHandlers = {
-  willResolveModel(_handlerInfos: HandlerInfo[], transition: Transition, originRoute: Route) {
-    (this as any)._scheduleLoadingEvent(transition, originRoute);
+  willResolveModel(
+    this: EmberRouter,
+    _routeInfos: PrivateRouteInfo[],
+    transition: Transition,
+    originRoute: Route
+  ) {
+    this._scheduleLoadingEvent(transition, originRoute);
   },
 
   // Attempt to find an appropriate error route or substate to enter.
-  error(handlerInfos: HandlerInfo[], error: Error, transition: Transition) {
+  error(routeInfos: PrivateRouteInfo[], error: Error, transition: Transition) {
     let router: any = this;
 
-    let handlerInfoWithError = handlerInfos[handlerInfos.length - 1];
+    let handlerInfoWithError = routeInfos[routeInfos.length - 1];
 
-    forEachRouteAbove(handlerInfos, (route: Route, handlerInfo: HandlerInfo) => {
+    forEachRouteAbove(routeInfos, (route: Route, routeInfo: PrivateRouteInfo) => {
       // We don't check the leaf most handlerInfo since that would
       // technically be below where we're at in the route hierarchy.
-      if (handlerInfo !== handlerInfoWithError) {
+      if (routeInfo !== handlerInfoWithError) {
         // Check for the existence of an 'error' route.
         let errorRouteName = findRouteStateName(route, 'error');
         if (errorRouteName) {
@@ -1214,12 +1318,12 @@ let defaultActionHandlers = {
   },
 
   // Attempt to find an appropriate loading route or substate to enter.
-  loading(handlerInfos: HandlerInfo[], transition: Transition) {
+  loading(routeInfos: PrivateRouteInfo[], transition: Transition) {
     let router: any = this;
 
-    let handlerInfoWithSlowLoading = handlerInfos[handlerInfos.length - 1];
+    let handlerInfoWithSlowLoading = routeInfos[routeInfos.length - 1];
 
-    forEachRouteAbove(handlerInfos, (route: Route, handlerInfo: HandlerInfo) => {
+    forEachRouteAbove(routeInfos, (route: Route, handlerInfo: PrivateRouteInfo) => {
       // We don't check the leaf most handlerInfo since that would
       // technically be below where we're at in the route hierarchy.
       if (handlerInfo !== handlerInfoWithSlowLoading) {
@@ -1332,12 +1436,12 @@ function routeHasBeenDefined(owner: Owner, router: any, localName: string, fullN
 
 export function triggerEvent(
   this: EmberRouter,
-  handlerInfos: HandlerInfo[],
+  routeInfos: PrivateRouteInfo[],
   ignoreFailure: boolean,
   name: string,
   args: unknown[]
 ) {
-  if (!handlerInfos) {
+  if (!routeInfos) {
     if (ignoreFailure) {
       return;
     }
@@ -1349,9 +1453,9 @@ export function triggerEvent(
   let eventWasHandled = false;
   let handlerInfo, handler, actionHandler;
 
-  for (let i = handlerInfos.length - 1; i >= 0; i--) {
-    handlerInfo = handlerInfos[i];
-    handler = handlerInfo.handler as any;
+  for (let i = routeInfos.length - 1; i >= 0; i--) {
+    handlerInfo = routeInfos[i];
+    handler = handlerInfo.route;
     actionHandler = handler && handler.actions && handler.actions[name];
     if (actionHandler) {
       if (actionHandler.apply(handler, args) === true) {
@@ -1359,7 +1463,7 @@ export function triggerEvent(
       } else {
         // Should only hit here if a non-bubbling error action is triggered on a route.
         if (name === 'error') {
-          handler._router._markErrorAsHandled(args[0]);
+          handler!._router._markErrorAsHandled(args[0] as Error);
         }
         return;
       }
@@ -1368,7 +1472,7 @@ export function triggerEvent(
 
   let defaultHandler = defaultActionHandlers[name];
   if (defaultHandler) {
-    defaultHandler.apply(this, [handlerInfos, ...args]);
+    defaultHandler.apply(this, [routeInfos, ...args]);
     return;
   }
 
@@ -1385,10 +1489,10 @@ function calculatePostTransitionState(
   contexts: {}[]
 ) {
   let state = emberRouter._routerMicrolib.applyIntent(leafRouteName, contexts);
-  let { handlerInfos, params } = state;
+  let { routeInfos, params } = state;
 
-  for (let i = 0; i < handlerInfos.length; ++i) {
-    let handlerInfo = handlerInfos[i];
+  for (let i = 0; i < routeInfos.length; ++i) {
+    let handlerInfo = routeInfos[i];
 
     // If the handlerInfo is not resolved, we serialize the context into params
     if (!handlerInfo.isResolved) {
@@ -1401,7 +1505,7 @@ function calculatePostTransitionState(
 }
 
 function updatePaths(router: EmberRouter) {
-  let infos = router._routerMicrolib.currentHandlerInfos;
+  let infos = router._routerMicrolib.currentRouteInfos!;
   if (infos.length === 0) {
     return;
   }
@@ -1489,7 +1593,7 @@ EmberRouter.reopenClass({
     return this;
   },
 
-  _routePath(handlerInfos: HandlerInfo[]) {
+  _routePath(routeInfos: PrivateRouteInfo[]) {
     let path = [];
 
     // We have to handle coalescing resource names that
@@ -1506,8 +1610,8 @@ EmberRouter.reopenClass({
     }
 
     let name, nameParts, oldNameParts;
-    for (let i = 1; i < handlerInfos.length; i++) {
-      name = handlerInfos[i].name;
+    for (let i = 1; i < routeInfos.length; i++) {
+      name = routeInfos[i].name;
       nameParts = name.split('.');
       oldNameParts = slice.call(path);
 
@@ -1526,7 +1630,7 @@ EmberRouter.reopenClass({
 });
 
 function didBeginTransition(transition: Transition, router: EmberRouter) {
-  let routerState = new RouterState(router, router._routerMicrolib, transition.state);
+  let routerState = new RouterState(router, router._routerMicrolib, transition.state!);
 
   if (!router.currentState) {
     router.set('currentState', routerState);
@@ -1544,11 +1648,11 @@ function didBeginTransition(transition: Transition, router: EmberRouter) {
 
 function forEachQueryParam(
   router: EmberRouter,
-  handlerInfos: HandlerInfo[],
+  routeInfos: PrivateRouteInfo[],
   queryParams: QueryParam,
   callback: (key: string, value: unknown, qp: QueryParam) => void
 ) {
-  let qpCache = router._queryParamsFor(handlerInfos);
+  let qpCache = router._queryParamsFor(routeInfos);
 
   for (let key in queryParams) {
     if (!queryParams.hasOwnProperty(key)) {
@@ -1674,7 +1778,7 @@ EmberRouter.reopen(Evented, {
    @private
  */
 
-  url: computed(function(this: Router) {
+  url: computed(function(this: Router<Route>) {
     return get(this, 'location').getURL();
   }),
 });

--- a/packages/@ember/-internals/routing/lib/system/router_state.ts
+++ b/packages/@ember/-internals/routing/lib/system/router_state.ts
@@ -1,13 +1,18 @@
 import { assign } from '@ember/polyfills';
-import Router from 'router_js';
+import Router, { TransitionState } from 'router_js';
 import { shallowEqual } from '../utils';
+import Route from './route';
 import EmberRouter, { QueryParam } from './router';
 
 export default class RouterState {
-  router: Router;
+  router: Router<Route>;
   emberRouter: EmberRouter;
-  routerJsState: null | any;
-  constructor(emberRouter: EmberRouter, router: Router, routerJsState: null | any) {
+  routerJsState: TransitionState<Route>;
+  constructor(
+    emberRouter: EmberRouter,
+    router: Router<Route>,
+    routerJsState: TransitionState<Route>
+  ) {
     this.emberRouter = emberRouter;
     this.router = router;
     this.routerJsState = routerJsState;

--- a/packages/@ember/-internals/routing/tests/system/route_test.js
+++ b/packages/@ember/-internals/routing/tests/system/route_test.js
@@ -366,7 +366,7 @@ moduleFor(
         _deserializeQueryParams() {},
         _routerMicrolib: {
           state: {
-            handlerInfos: [{ name: 'posts' }],
+            routeInfos: [{ name: 'posts' }],
             params: {
               'foo.bar': { a: 'b' },
               'foo.bar.posts': { c: 'd' },

--- a/packages/@ember/-internals/routing/tests/system/router_test.js
+++ b/packages/@ember/-internals/routing/tests/system/router_test.js
@@ -118,12 +118,12 @@ moduleFor(
       createRouter();
 
       function routePath() {
-        let handlerInfos = Array.prototype.slice.call(arguments).map(function(s) {
+        let routeInfos = Array.prototype.slice.call(arguments).map(function(s) {
           return { name: s };
         });
-        handlerInfos.unshift({ name: 'ignored' });
+        routeInfos.unshift({ name: 'ignored' });
 
-        return Router._routePath(handlerInfos);
+        return Router._routePath(routeInfos);
       }
 
       assert.equal(routePath('foo'), 'foo');
@@ -207,10 +207,10 @@ moduleFor(
     ['@test Router#triggerEvent allows actions to bubble when returning true'](assert) {
       assert.expect(2);
 
-      let handlerInfos = [
+      let routeInfos = [
         {
           name: 'application',
-          handler: {
+          route: {
             actions: {
               loading() {
                 assert.ok(false, 'loading not handled by application route');
@@ -220,7 +220,7 @@ moduleFor(
         },
         {
           name: 'about',
-          handler: {
+          route: {
             actions: {
               loading() {
                 assert.ok(true, 'loading handled by about route');
@@ -231,7 +231,7 @@ moduleFor(
         },
         {
           name: 'about.me',
-          handler: {
+          route: {
             actions: {
               loading() {
                 assert.ok(true, 'loading handled by about.me route');
@@ -242,16 +242,16 @@ moduleFor(
         },
       ];
 
-      triggerEvent(handlerInfos, false, ['loading']);
+      triggerEvent(routeInfos, false, ['loading']);
     }
 
     ['@test Router#triggerEvent ignores handlers that have not loaded yet'](assert) {
       assert.expect(1);
 
-      let handlerInfos = [
+      let routeInfos = [
         {
           name: 'about',
-          handler: {
+          route: {
             actions: {
               loading() {
                 assert.ok(true, 'loading handled by about route');
@@ -261,11 +261,11 @@ moduleFor(
         },
         {
           name: 'about.me',
-          handler: undefined,
+          route: undefined,
         },
       ];
 
-      triggerEvent(handlerInfos, false, ['loading']);
+      triggerEvent(routeInfos, false, ['loading']);
     }
 
     ['@test transitionTo should throw an error when called after owner is destroyed']() {

--- a/packages/@ember/deprecated-features/index.ts
+++ b/packages/@ember/deprecated-features/index.ts
@@ -12,3 +12,4 @@ export const TARGET_OBJECT = !!'2.18.0-beta.1';
 export const MAP = !!'3.3.0-beta.1';
 export const ORDERED_SET = !!'3.3.0-beta.1';
 export const MERGE = !!'3.6.0-beta.1';
+export const HANDLER_INFOS = !!'3.9.0';

--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -11,7 +11,7 @@ import { Mixin, computed, set, addObserver, observer } from '@ember/-internals/m
 import { getTextOf } from 'internal-test-helpers';
 import { Component } from '@ember/-internals/glimmer';
 import Engine from '@ember/engine';
-import { Transition } from 'router_js';
+import { InternalTransition as Transition } from 'router_js';
 
 let originalConsoleError;
 

--- a/packages/ember/tests/routing/deprecated_handler_infos_test.js
+++ b/packages/ember/tests/routing/deprecated_handler_infos_test.js
@@ -1,0 +1,66 @@
+import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
+
+moduleFor(
+  'Deprecated HandlerInfos',
+  class extends ApplicationTestCase {
+    constructor() {
+      super(...arguments);
+      this.router.map(function() {
+        this.route('parent', function() {
+          this.route('child');
+          this.route('sibling');
+        });
+      });
+    }
+
+    get routerOptions() {
+      return {
+        willTransition(oldHandlers, newHandlers, transition) {
+          expectDeprecation(() => {
+            this._routerMicrolib.currentHandlerInfos;
+          }, 'You attempted to use "_routerMicrolib.currentHandlerInfos" which is a private API that will be removed.');
+
+          expectDeprecation(() => {
+            this._routerMicrolib.getHandler('parent');
+          }, 'You attempted to use "_routerMicrolib.getHandler" which is a private API that will be removed.');
+
+          oldHandlers.forEach(handler => {
+            expectDeprecation(() => {
+              handler.handler;
+            }, 'You attempted to read "handlerInfo.handler" which is a private API that will be removed.');
+          });
+          newHandlers.forEach(handler => {
+            expectDeprecation(() => {
+              handler.handler;
+            }, 'You attempted to read "handlerInfo.handler" which is a private API that will be removed.');
+          });
+
+          expectDeprecation(() => {
+            transition.handlerInfos;
+          }, 'You attempted to use "transition.handlerInfos" which is a private API that will be removed.');
+
+          expectDeprecation(() => {
+            transition.state.handlerInfos;
+          }, 'You attempted to use "transition.state.handlerInfos" which is a private API that will be removed.');
+          QUnit.assert.ok(true, 'willTransition');
+        },
+
+        didTransition(newHandlers) {
+          newHandlers.forEach(handler => {
+            expectDeprecation(() => {
+              handler.handler;
+            }, 'You attempted to read "handlerInfo.handler" which is a private API that will be removed.');
+          });
+          QUnit.assert.ok(true, 'didTransition');
+        },
+      };
+    }
+
+    '@test handlerInfos are deprecated and associated private apis'(assert) {
+      let done = assert.async();
+      return this.visit('/parent').then(() => {
+        done();
+      });
+    }
+  }
+);

--- a/packages/ember/tests/routing/deprecated_handler_infos_test.js
+++ b/packages/ember/tests/routing/deprecated_handler_infos_test.js
@@ -1,66 +1,69 @@
 import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
+import { EMBER_ROUTING_ROUTER_SERVICE } from '@ember/canary-features';
 
-moduleFor(
-  'Deprecated HandlerInfos',
-  class extends ApplicationTestCase {
-    constructor() {
-      super(...arguments);
-      this.router.map(function() {
-        this.route('parent', function() {
-          this.route('child');
-          this.route('sibling');
+if (EMBER_ROUTING_ROUTER_SERVICE) {
+  moduleFor(
+    'Deprecated HandlerInfos',
+    class extends ApplicationTestCase {
+      constructor() {
+        super(...arguments);
+        this.router.map(function() {
+          this.route('parent', function() {
+            this.route('child');
+            this.route('sibling');
+          });
         });
-      });
-    }
+      }
 
-    get routerOptions() {
-      return {
-        willTransition(oldHandlers, newHandlers, transition) {
-          expectDeprecation(() => {
-            this._routerMicrolib.currentHandlerInfos;
-          }, 'You attempted to use "_routerMicrolib.currentHandlerInfos" which is a private API that will be removed.');
-
-          expectDeprecation(() => {
-            this._routerMicrolib.getHandler('parent');
-          }, 'You attempted to use "_routerMicrolib.getHandler" which is a private API that will be removed.');
-
-          oldHandlers.forEach(handler => {
+      get routerOptions() {
+        return {
+          willTransition(oldHandlers, newHandlers, transition) {
             expectDeprecation(() => {
-              handler.handler;
-            }, 'You attempted to read "handlerInfo.handler" which is a private API that will be removed.');
-          });
-          newHandlers.forEach(handler => {
+              this._routerMicrolib.currentHandlerInfos;
+            }, 'You attempted to use "_routerMicrolib.currentHandlerInfos" which is a private API that will be removed.');
+
             expectDeprecation(() => {
-              handler.handler;
-            }, 'You attempted to read "handlerInfo.handler" which is a private API that will be removed.');
-          });
+              this._routerMicrolib.getHandler('parent');
+            }, 'You attempted to use "_routerMicrolib.getHandler" which is a private API that will be removed.');
 
-          expectDeprecation(() => {
-            transition.handlerInfos;
-          }, 'You attempted to use "transition.handlerInfos" which is a private API that will be removed.');
+            oldHandlers.forEach(handler => {
+              expectDeprecation(() => {
+                handler.handler;
+              }, 'You attempted to read "handlerInfo.handler" which is a private API that will be removed.');
+            });
+            newHandlers.forEach(handler => {
+              expectDeprecation(() => {
+                handler.handler;
+              }, 'You attempted to read "handlerInfo.handler" which is a private API that will be removed.');
+            });
 
-          expectDeprecation(() => {
-            transition.state.handlerInfos;
-          }, 'You attempted to use "transition.state.handlerInfos" which is a private API that will be removed.');
-          QUnit.assert.ok(true, 'willTransition');
-        },
-
-        didTransition(newHandlers) {
-          newHandlers.forEach(handler => {
             expectDeprecation(() => {
-              handler.handler;
-            }, 'You attempted to read "handlerInfo.handler" which is a private API that will be removed.');
-          });
-          QUnit.assert.ok(true, 'didTransition');
-        },
-      };
-    }
+              transition.handlerInfos;
+            }, 'You attempted to use "transition.handlerInfos" which is a private API that will be removed.');
 
-    '@test handlerInfos are deprecated and associated private apis'(assert) {
-      let done = assert.async();
-      return this.visit('/parent').then(() => {
-        done();
-      });
+            expectDeprecation(() => {
+              transition.state.handlerInfos;
+            }, 'You attempted to use "transition.state.handlerInfos" which is a private API that will be removed.');
+            QUnit.assert.ok(true, 'willTransition');
+          },
+
+          didTransition(newHandlers) {
+            newHandlers.forEach(handler => {
+              expectDeprecation(() => {
+                handler.handler;
+              }, 'You attempted to read "handlerInfo.handler" which is a private API that will be removed.');
+            });
+            QUnit.assert.ok(true, 'didTransition');
+          },
+        };
+      }
+
+      '@test handlerInfos are deprecated and associated private apis'(assert) {
+        let done = assert.async();
+        return this.visit('/parent').then(() => {
+          done();
+        });
+      }
     }
-  }
-);
+  );
+}

--- a/packages/ember/tests/routing/query_params_test/query_param_async_get_handler_test.js
+++ b/packages/ember/tests/routing/query_params_test/query_param_async_get_handler_test.js
@@ -23,9 +23,9 @@ moduleFor(
         setupRouter() {
           this._super(...arguments);
           let { _handlerPromises: handlerPromises, _seenHandlers: seenHandlers } = this;
-          let getHandler = this._routerMicrolib.getHandler;
+          let getRoute = this._routerMicrolib.getRoute;
 
-          this._routerMicrolib.getHandler = function(routeName) {
+          this._routerMicrolib.getRoute = function(routeName) {
             fetchedHandlers.push(routeName);
 
             // Cache the returns so we don't have more than one Promise for a
@@ -34,7 +34,7 @@ moduleFor(
               handlerPromises[routeName] ||
               (handlerPromises[routeName] = new RSVP.Promise(resolve => {
                 setTimeout(() => {
-                  let handler = getHandler(routeName);
+                  let handler = getRoute(routeName);
 
                   seenHandlers[routeName] = handler;
 

--- a/packages/ember/tests/routing/router_service_test/replaceWith_test.js
+++ b/packages/ember/tests/routing/router_service_test/replaceWith_test.js
@@ -1,6 +1,6 @@
 import { NoneLocation } from '@ember/-internals/routing';
 import { RouterTestCase, moduleFor } from 'internal-test-helpers';
-import { Transition } from 'router_js';
+import { InternalTransition as Transition } from 'router_js';
 import Controller from '@ember/controller';
 
 import { EMBER_ROUTING_ROUTER_SERVICE } from '@ember/canary-features';

--- a/packages/ember/tests/routing/router_service_test/transitionTo_test.js
+++ b/packages/ember/tests/routing/router_service_test/transitionTo_test.js
@@ -5,7 +5,7 @@ import Controller from '@ember/controller';
 import { run } from '@ember/runloop';
 import { get } from '@ember/-internals/metal';
 import { RouterTestCase, moduleFor } from 'internal-test-helpers';
-import { Transition } from 'router_js';
+import { InternalTransition as Transition } from 'router_js';
 
 import { EMBER_ROUTING_ROUTER_SERVICE } from '@ember/canary-features';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6405,9 +6405,9 @@ route-recognizer@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/route-recognizer/-/route-recognizer-0.3.4.tgz#39ab1ffbce1c59e6d2bdca416f0932611e4f3ca3"
 
-router_js@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/router_js/-/router_js-5.0.1.tgz#5c5ed5d306f71019b39128cabdbfbb5f09d10bc5"
+router_js@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/router_js/-/router_js-5.0.3.tgz#38dda09088f9b2bc764ada05eaab628d829f1c17"
   dependencies:
     "@types/node" "^10.5.5"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6405,9 +6405,9 @@ route-recognizer@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/route-recognizer/-/route-recognizer-0.3.4.tgz#39ab1ffbce1c59e6d2bdca416f0932611e4f3ca3"
 
-router_js@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/router_js/-/router_js-4.0.3.tgz#d96a2a55e57596a2ffc14f0503a2715a37be5b08"
+router_js@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/router_js/-/router_js-5.0.1.tgz#5c5ed5d306f71019b39128cabdbfbb5f09d10bc5"
   dependencies:
     "@types/node" "^10.5.5"
 


### PR DESCRIPTION
This PR pulls router.js's generics through Ember's router. It simultaneously introduces the concept of `RouteInfo`. `RouteInfo` is what we typically called `HandlerInfo`. While this was a private API we leaked it out in `did|willTransition` hooks. Because of that it effectively became intimate API. To compensate for this I have added deprecations around the following private apis

- `_routerMicrolib.currentHandlerInfos`
- `_routerMicrolib.getHandler`
- `transition.handlerInfos`
- `transition.state.handlerInfos`
- `handlerInfos[0].handler`

This is based on the usage from [EmberObserver](https://emberobserver.com/code-search?codeQuery=handlerInfos&regex=true)

There is going to be a quick follow that is going to expose `transition.to` and `transition.from` along with the `routeWillChange` and `routeDidChange` events as described by [Router Service RFC](https://github.com/emberjs/rfcs/blob/master/text/0095-router-service.md)