### PR TITLE
playing with an idea

### DIFF
--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -59,7 +59,7 @@ export default class RouterService extends Service {
    */
   transitionTo(...args: string[]) {
     let transition;
-    let didNotComplete = false;
+    let didComplete = false;
 
     try {
       if (resemblesURL(args[0])) {
@@ -70,9 +70,9 @@ export default class RouterService extends Service {
         let transition = this._router._doTransition(routeName, models, queryParams, true);
         transition._keepDefaultQueryParamValues = true;
       }
-      didNotComplete = true;
+      didComplete = true;
     } finally {
-      if (didNotComplete) {
+      if (didComplete !== true) {
         transition.isAborted = false;
       }
     }

--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -73,6 +73,7 @@ export default class RouterService extends Service {
       didComplete = true;
     } finally {
       if (didComplete !== true) {
+        // actually the routes active transition prior to starting this transitionTo
         transition.isAborted = false;
       }
     }

--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -60,6 +60,7 @@ export default class RouterService extends Service {
   transitionTo(...args: string[]) {
     let transition;
     let didComplete = false;
+    let activeTransition = /* grab the active transition */
 
     try {
       if (resemblesURL(args[0])) {
@@ -73,8 +74,8 @@ export default class RouterService extends Service {
       didComplete = true;
     } finally {
       if (didComplete !== true) {
-        // actually the routes active transition prior to starting this transitionTo
-        transition.isAborted = false;
+        // 
+        activeTransition.isAborted = false;
       }
     }
 

--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -60,6 +60,7 @@ export default class RouterService extends Service {
   transitionTo(...args: string[]) {
     let transition;
     let didComplete = false;
+    // Playing with an idea, not 100% sure where this type of solution should actually go
     let activeTransition = /* grab the active transition */
 
     try {

--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -58,14 +58,24 @@ export default class RouterService extends Service {
      @public
    */
   transitionTo(...args: string[]) {
-    if (resemblesURL(args[0])) {
-      return this._router._doURLTransition('transitionTo', args[0]);
+    let transition;
+    let didNotComplete = false;
+
+    try {
+      if (resemblesURL(args[0])) {
+        transition this._router._doURLTransition('transitionTo', args[0]);
+      } else {
+        let { routeName, models, queryParams } = extractRouteArgs(args);
+  
+        let transition = this._router._doTransition(routeName, models, queryParams, true);
+        transition._keepDefaultQueryParamValues = true;
+      }
+      didNotComplete = true;
+    } finally {
+      if (didNotComplete) {
+        transition.isAborted = false;
+      }
     }
-
-    let { routeName, models, queryParams } = extractRouteArgs(args);
-
-    let transition = this._router._doTransition(routeName, models, queryParams, true);
-    transition._keepDefaultQueryParamValues = true;
 
     return transition;
   }

--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -63,7 +63,7 @@ export default class RouterService extends Service {
 
     try {
       if (resemblesURL(args[0])) {
-        transition this._router._doURLTransition('transitionTo', args[0]);
+        transition = this._router._doURLTransition('transitionTo', args[0]);
       } else {
         let { routeName, models, queryParams } = extractRouteArgs(args);
   


### PR DESCRIPTION
playing around with hacky improvements for -> https://github.com/tildeio/router.js/pull/87#discussion_r220652231

Basically, if a `this.transitionTo` fails synchronously we should know that the transition is actually not an aborted transition rather a real error that must be surfaced.

I suspect a much better solution is possible. 

cc @chadhietala  / @asakusuma 

