### PR TITLE
Mark defineProperty as public API.

### DIFF
--- a/packages/@ember/-internals/metal/lib/properties.ts
+++ b/packages/@ember/-internals/metal/lib/properties.ts
@@ -145,7 +145,7 @@ function DESCRIPTOR_GETTER_FUNCTION(name: string, descriptor: Descriptor) {
   }));
   ```
 
-  @private
+  @public
   @method defineProperty
   @static
   @for @ember/object


### PR DESCRIPTION
In most circumstances, `Ember.defineProperty` is **not** what you should do, however there are _some_ use cases that absolutely require it (e.g. as a primitive used to setup computed property getters on native ES classes).

Either way, this is already defacto public API so we should mark it as such.

Closes https://github.com/emberjs/rfcs/issues/350