### PR TITLE
Remove `hasOwnProperty` checks. Closes #17018.

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -2204,10 +2204,6 @@ Route.reopen(ActionHandler, Evented, {
     let propertyNames = [];
 
     for (let propName in combinedQueryParameterConfiguration) {
-      if (!combinedQueryParameterConfiguration.hasOwnProperty(propName)) {
-        continue;
-      }
-
       // to support the dubious feature of using unknownProperty
       // on queryParams configuration
       if (propName === 'unknownProperty' || propName === '_super') {

--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -1665,9 +1665,6 @@ function forEachQueryParam(
   let qpCache = router._queryParamsFor(routeInfos);
 
   for (let key in queryParams) {
-    if (!queryParams.hasOwnProperty(key)) {
-      continue;
-    }
     let value = queryParams[key];
     let qp = qpCache.map[key];
 

--- a/packages/@ember/-internals/routing/lib/utils.ts
+++ b/packages/@ember/-internals/routing/lib/utils.ts
@@ -160,10 +160,6 @@ function accumulateQueryParamDescriptors(_desc: QueryParam, accum: {}) {
   }
 
   for (let key in desc) {
-    if (!desc.hasOwnProperty(key)) {
-      return;
-    }
-
     let singleDesc = desc[key];
     if (typeof singleDesc === 'string') {
       singleDesc = { as: singleDesc };


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember.js/issues/17018