### PR TITLE
[FEATURE Router Service] Deprecate touching transition state

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "puppeteer": "^1.3.0",
     "qunit": "^2.5.0",
     "route-recognizer": "^0.3.4",
-    "router_js": "^5.2.0",
+    "router_js": "^6.0.0",
     "rsvp": "^4.8.2",
     "semver": "^5.5.0",
     "serve-static": "^1.12.2",

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -15,7 +15,14 @@ import { once } from '@ember/runloop';
 import { classify } from '@ember/string';
 import { DEBUG } from '@glimmer/env';
 import { TemplateFactory } from '@glimmer/opcode-compiler';
-import { InternalRouteInfo, Route as IRoute, Transition, TransitionState } from 'router_js';
+import {
+  InternalRouteInfo,
+  PARAMS_SYMBOL,
+  Route as IRoute,
+  STATE_SYMBOL,
+  Transition,
+  TransitionState,
+} from 'router_js';
 import {
   calculateCacheKey,
   normalizeControllerQueryParams,
@@ -219,7 +226,7 @@ class Route extends EmberObject implements IRoute {
     }
 
     let transition = this._router._routerMicrolib.activeTransition;
-    let state = transition ? transition.state : this._router._routerMicrolib.state;
+    let state = transition ? transition[STATE_SYMBOL] : this._router._routerMicrolib.state;
 
     let fullName = route.fullRouteName;
     let params = assign({}, state!.params[fullName]);
@@ -899,10 +906,10 @@ class Route extends EmberObject implements IRoute {
 
     if (transition) {
       // Update the model dep values used to calculate cache keys.
-      stashParamNames(this._router, transition.state!.routeInfos);
+      stashParamNames(this._router, transition[STATE_SYMBOL]!.routeInfos);
 
       let cache = this._bucketCache;
-      let params = transition.params;
+      let params = transition[PARAMS_SYMBOL];
       let allParams = queryParams.propertyNames;
 
       allParams.forEach((prop: string) => {
@@ -914,7 +921,7 @@ class Route extends EmberObject implements IRoute {
         set(controller, prop, value);
       });
 
-      let qpValues = getQueryParamsFor(this, transition.state!);
+      let qpValues = getQueryParamsFor(this, transition[STATE_SYMBOL]!);
       setProperties(controller, qpValues);
     }
 
@@ -1152,7 +1159,7 @@ class Route extends EmberObject implements IRoute {
         if (transition.resolveIndex < 1) {
           return;
         }
-        return transition.state!.routeInfos[transition.resolveIndex - 1].context;
+        return transition[STATE_SYMBOL]!.routeInfos[transition.resolveIndex - 1].context;
       }
     }
 
@@ -2432,7 +2439,7 @@ Route.reopen(ActionHandler, Evented, {
         return;
       }
 
-      let routeInfos = transition.state!.routeInfos;
+      let routeInfos = transition[STATE_SYMBOL]!.routeInfos;
       let router = this._router;
       let qpMeta = router._queryParamsFor(routeInfos);
       let changes = router._qpUpdates;

--- a/packages/@ember/-internals/routing/lib/utils.ts
+++ b/packages/@ember/-internals/routing/lib/utils.ts
@@ -2,7 +2,7 @@ import { get } from '@ember/-internals/metal';
 import { getOwner } from '@ember/-internals/owner';
 import EmberError from '@ember/error';
 import { assign } from '@ember/polyfills';
-import Router from 'router_js';
+import Router, { STATE_SYMBOL } from 'router_js';
 import Route from './system/route';
 import EmberRouter, { PrivateRouteInfo, QueryParam } from './system/router';
 
@@ -26,7 +26,7 @@ export function extractRouteArgs(args: any[]) {
 
 export function getActiveTargetName(router: Router<Route>) {
   let routeInfos = router.activeTransition
-    ? router.activeTransition.state!.routeInfos
+    ? router.activeTransition[STATE_SYMBOL]!.routeInfos
     : router.state!.routeInfos;
   return routeInfos[routeInfos.length - 1].name;
 }

--- a/packages/@ember/deprecated-features/index.ts
+++ b/packages/@ember/deprecated-features/index.ts
@@ -14,3 +14,4 @@ export const ORDERED_SET = !!'3.3.0-beta.1';
 export const MERGE = !!'3.6.0-beta.1';
 export const HANDLER_INFOS = !!'3.9.0';
 export const ROUTER_EVENTS = !!'3.9.0';
+export const TRANSITION_STATE = !!'3.9.0';

--- a/packages/ember/tests/routing/deprecated_transition_state_test.js
+++ b/packages/ember/tests/routing/deprecated_transition_state_test.js
@@ -1,0 +1,45 @@
+import { RouterTestCase, moduleFor } from 'internal-test-helpers';
+import { EMBER_ROUTING_ROUTER_SERVICE } from '@ember/canary-features';
+
+if (EMBER_ROUTING_ROUTER_SERVICE) {
+  moduleFor(
+    'Deprecated Transition State',
+    class extends RouterTestCase {
+      '@test touching transition.state is deprecated'(assert) {
+        assert.expect(1);
+        return this.visit('/').then(() => {
+          this.routerService.on('routeWillChange', transition => {
+            expectDeprecation(() => {
+              transition.state;
+            }, 'You attempted to read "transition.state" which is a private API. You should read the `RouteInfo` object on "transition.to" or "transition.from" which has the public state on it.');
+          });
+          return this.routerService.transitionTo('/child');
+        });
+      }
+
+      '@test touching transition.queryParams is deprecated'(assert) {
+        assert.expect(1);
+        return this.visit('/').then(() => {
+          this.routerService.on('routeWillChange', transition => {
+            expectDeprecation(() => {
+              transition.queryParams;
+            }, 'You attempted to read "transition.queryParams" which is a private API. You should read the `RouteInfo` object on "transition.to" or "transition.from" which has the queryParams on it.');
+          });
+          return this.routerService.transitionTo('/child');
+        });
+      }
+
+      '@test touching transition.params is deprecated'(assert) {
+        assert.expect(1);
+        return this.visit('/').then(() => {
+          this.routerService.on('routeWillChange', transition => {
+            expectDeprecation(() => {
+              transition.params;
+            }, 'You attempted to read "transition.params" which is a private API. You should read the `RouteInfo` object on "transition.to" or "transition.from" which has the params on it.');
+          });
+          return this.routerService.transitionTo('/child');
+        });
+      }
+    }
+  );
+}

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -5,6 +5,7 @@ import { run } from '@ember/runloop';
 import { peekMeta } from '@ember/-internals/meta';
 import { get, computed } from '@ember/-internals/metal';
 import { Route } from '@ember/-internals/routing';
+import { PARAMS_SYMBOL } from 'router_js';
 
 import { QueryParamTestCase, moduleFor, getTextOf } from 'internal-test-helpers';
 
@@ -1332,7 +1333,7 @@ moduleFor(
         'route:other',
         Route.extend({
           model(p, trans) {
-            let m = peekMeta(trans.params.application);
+            let m = peekMeta(trans[PARAMS_SYMBOL].application);
             assert.ok(m === undefined, "A meta object isn't constructed for this params POJO");
           },
         })

--- a/yarn.lock
+++ b/yarn.lock
@@ -7385,10 +7385,10 @@ route-recognizer@^0.3.4:
   resolved "https://registry.yarnpkg.com/route-recognizer/-/route-recognizer-0.3.4.tgz#39ab1ffbce1c59e6d2bdca416f0932611e4f3ca3"
   integrity sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==
 
-router_js@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/router_js/-/router_js-5.2.0.tgz#8796d0ad7ab8a9d0ffbf5b02e5e00d2472a53e7d"
-  integrity sha512-v+gjYRwDWJpJW0jPB9tFphbcp0pD7R/ZRqu/tno9TXgQxanRArw/weyGFZnbpR95tY9B5SpFonAZk5opPNQUvQ==
+router_js@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/router_js/-/router_js-6.0.0.tgz#a9dd8918987f0464d31cfb409d8ea1496bf38ba2"
+  integrity sha512-2P0Be0+IMnYwLfv7SDsRs7PZCs5LWF1FTy4/m8FB5NdCCmIViCb829cfVYAdx40oeoHtRho+hiVUDWv+czqF9A==
   dependencies:
     "@types/node" "^10.5.5"
 


### PR DESCRIPTION
This deprecates access to the `state`, `params` and `queryParams` fields on the `Transition` that were private but became defacto public API since there was no other way to access it. The router service will expose `RouteInfo` objects which is the public object that has this state on it.