### PR TITLE
[FEATURE Router Service] currentRoute

### DIFF
--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -264,6 +264,19 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
     },
 
     /**
+     A RouteInfo that represents the current leaf route.
+     It is guaranteed to change whenever a route transition
+     happens (even when that transition only changes parameters
+    and doesn't change the active route)
+
+     @property currentRoute
+     @type RouteInfo
+     @category ember-routing-router-service
+     @public
+   */
+    currentRoute: readOnly('_router.currentRoute'),
+
+    /**
      Takes a string URL and returns a `RouteInfo` for the leafmost route represented
      by the URL. Returns `null` if the URL is not recognized. This method expects to
      receive the actual URL as seen by the browser including the app's `rootURL`.

--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -389,6 +389,7 @@ class EmberRouter extends EmberObject {
 
       routeDidChange(transition: Transition) {
         if (EMBER_ROUTING_ROUTER_SERVICE) {
+          router.set('currentRoute', transition.to);
           router.trigger('routeDidChange', transition);
         }
       }
@@ -488,6 +489,10 @@ class EmberRouter extends EmberObject {
     this.currentURL = null;
     this.currentRouteName = null;
     this.currentPath = null;
+
+    if (EMBER_ROUTING_ROUTER_SERVICE) {
+      this.currentRoute = null;
+    }
 
     this._qpCache = Object.create(null);
     this._qpUpdates = new Set();

--- a/packages/ember/tests/routing/router_service_test/basic_test.js
+++ b/packages/ember/tests/routing/router_service_test/basic_test.js
@@ -1,53 +1,121 @@
 import { Route, NoneLocation } from '@ember/-internals/routing';
 import { set } from '@ember/-internals/metal';
 import { RouterTestCase, moduleFor } from 'internal-test-helpers';
+import { EMBER_ROUTING_ROUTER_SERVICE } from '@ember/canary-features';
 
 moduleFor(
   'Router Service - main',
   class extends RouterTestCase {
     ['@test RouterService#currentRouteName is correctly set for top level route'](assert) {
-      assert.expect(1);
+      if (EMBER_ROUTING_ROUTER_SERVICE) {
+        assert.expect(6);
+      } else {
+        assert.expect(1);
+      }
 
       return this.visit('/').then(() => {
+        if (EMBER_ROUTING_ROUTER_SERVICE) {
+          let currentRoute = this.routerService.currentRoute;
+          let { name, localName, params, paramNames, queryParams } = currentRoute;
+          assert.equal(name, 'parent.index');
+          assert.equal(localName, 'index');
+          assert.deepEqual(params, {});
+          assert.deepEqual(queryParams, {});
+          assert.deepEqual(paramNames, []);
+        }
+
         assert.equal(this.routerService.get('currentRouteName'), 'parent.index');
       });
     }
 
     ['@test RouterService#currentRouteName is correctly set for child route'](assert) {
-      assert.expect(1);
+      if (EMBER_ROUTING_ROUTER_SERVICE) {
+        assert.expect(6);
+      } else {
+        assert.expect(1);
+      }
 
       return this.visit('/child').then(() => {
+        if (EMBER_ROUTING_ROUTER_SERVICE) {
+          let currentRoute = this.routerService.currentRoute;
+          let { name, localName, params, paramNames, queryParams } = currentRoute;
+          assert.equal(name, 'parent.child');
+          assert.equal(localName, 'child');
+          assert.deepEqual(params, {});
+          assert.deepEqual(queryParams, {});
+          assert.deepEqual(paramNames, []);
+        }
+
         assert.equal(this.routerService.get('currentRouteName'), 'parent.child');
       });
     }
 
     ['@test RouterService#currentRouteName is correctly set after transition'](assert) {
-      assert.expect(1);
+      if (EMBER_ROUTING_ROUTER_SERVICE) {
+        assert.expect(5);
+      } else {
+        assert.expect(1);
+      }
 
       return this.visit('/child')
         .then(() => {
+          if (EMBER_ROUTING_ROUTER_SERVICE) {
+            let currentRoute = this.routerService.currentRoute;
+            let { name, localName } = currentRoute;
+            assert.equal(name, 'parent.child');
+            assert.equal(localName, 'child');
+          }
+
           return this.routerService.transitionTo('parent.sister');
         })
         .then(() => {
+          if (EMBER_ROUTING_ROUTER_SERVICE) {
+            let currentRoute = this.routerService.currentRoute;
+            let { name, localName } = currentRoute;
+            assert.equal(name, 'parent.sister');
+            assert.equal(localName, 'sister');
+          }
           assert.equal(this.routerService.get('currentRouteName'), 'parent.sister');
         });
     }
 
     ['@test RouterService#currentRouteName is correctly set on each transition'](assert) {
-      assert.expect(3);
+      if (EMBER_ROUTING_ROUTER_SERVICE) {
+        assert.expect(9);
+      } else {
+        assert.expect(3);
+      }
 
       return this.visit('/child')
         .then(() => {
+          if (EMBER_ROUTING_ROUTER_SERVICE) {
+            let currentRoute = this.routerService.currentRoute;
+            let { name, localName } = currentRoute;
+            assert.equal(name, 'parent.child');
+            assert.equal(localName, 'child');
+          }
           assert.equal(this.routerService.get('currentRouteName'), 'parent.child');
 
           return this.visit('/sister');
         })
         .then(() => {
+          if (EMBER_ROUTING_ROUTER_SERVICE) {
+            let currentRoute = this.routerService.currentRoute;
+            let { name, localName } = currentRoute;
+            assert.equal(name, 'parent.sister');
+            assert.equal(localName, 'sister');
+          }
           assert.equal(this.routerService.get('currentRouteName'), 'parent.sister');
 
           return this.visit('/brother');
         })
         .then(() => {
+          if (EMBER_ROUTING_ROUTER_SERVICE) {
+            let currentRoute = this.routerService.currentRoute;
+            let { name, localName } = currentRoute;
+            assert.equal(name, 'parent.brother');
+            assert.equal(localName, 'brother');
+          }
           assert.equal(this.routerService.get('currentRouteName'), 'parent.brother');
         });
     }


### PR DESCRIPTION
This introduces a `currentRoute` field to the Router service that points to leafmost `RouteInfo`. This should be the last property that is required for to complete the Router Service.