### PR TITLE
[CI] Remove testem.js error

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -281,6 +281,12 @@ module.exports = function() {
     trees.push(emberTemplateCompilerBundle);
   }
 
+  let emberTestsEmptyTestem = new Funnel('tests', {
+    files: ['testem.js'],
+    destDir: '',
+    annotation: 'tests/testem.js',
+  });
+
   return new MergeTrees([
     new Funnel(es, { destDir: 'es' }),
     pkgAndTestESBundleDebug,
@@ -288,6 +294,7 @@ module.exports = function() {
     emberTestsBundle,
     emberDebugBundle,
     emberTestingBundle,
+    emberTestsEmptyTestem,
     nodeTests(),
 
     // test harness

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,7 +10,6 @@
       }
     </style>
     <script src="../qunit/qunit.js"></script>
-    <script src="/testem.js"></script>
 
     <script type="text/javascript">
       window.loadScript = function(url) {

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,6 +10,7 @@
       }
     </style>
     <script src="../qunit/qunit.js"></script>
+    <script src="/testem.js"></script>
 
     <script type="text/javascript">
       window.loadScript = function(url) {

--- a/tests/testem.js
+++ b/tests/testem.js
@@ -1,0 +1,3 @@
+/**
+ * Permit to remove the erreo `Refused to execute script from 'http://localhost:4200/testem.js' because its MIME type ('text/html') is not executable, and strict MIME type checking is enabled.`
+ */


### PR DESCRIPTION
This PR is related to this issue #17016.
As suggested I just remove the import of testem.js in the file `tests/index.html`and everything seems to works in local, all tests are green. With this PR we will see if everything still work as expected on travis