### PR TITLE
avoid calling `peekMeta` when meta does not exist

### DIFF
--- a/packages/@ember/-internals/meta/lib/meta.ts
+++ b/packages/@ember/-internals/meta/lib/meta.ts
@@ -612,7 +612,7 @@ export function setMeta(obj: object, meta: Meta) {
   metaStore.set(obj, meta);
 }
 
-export function peekMeta(obj: object) {
+export function peekMeta(obj: object): Meta | null {
   assert('Cannot call `peekMeta` on null', obj !== null);
   assert('Cannot call `peekMeta` on undefined', obj !== undefined);
   assert(
@@ -651,6 +651,8 @@ export function peekMeta(obj: object) {
 
     pointer = getPrototypeOf(pointer);
   }
+
+  return null;
 }
 
 /**
@@ -676,7 +678,7 @@ export function deleteMeta(obj: object) {
   }
 
   let meta = peekMeta(obj);
-  if (meta !== undefined) {
+  if (meta !== null) {
     meta.destroy();
   }
 }
@@ -717,7 +719,7 @@ export const meta: {
   let maybeMeta = peekMeta(obj);
 
   // remove this code, in-favor of explicit parent
-  if (maybeMeta !== undefined && maybeMeta.source === obj) {
+  if (maybeMeta !== null && maybeMeta.source === obj) {
     return maybeMeta;
   }
 
@@ -749,7 +751,7 @@ export function descriptorFor(obj: object, keyName: string, _meta?: Meta) {
 
   let meta = _meta === undefined ? peekMeta(obj) : _meta;
 
-  if (meta !== undefined) {
+  if (meta !== null) {
     return meta.peekDescriptors(keyName);
   }
 }

--- a/packages/@ember/-internals/metal/lib/chains.ts
+++ b/packages/@ember/-internals/metal/lib/chains.ts
@@ -117,7 +117,7 @@ function removeChainWatcher(obj: object, keyName: string, node: ChainNode, _meta
   let meta = _meta === undefined ? peekMeta(obj) : _meta;
 
   if (
-    meta === undefined ||
+    meta === null ||
     meta.isSourceDestroying() ||
     meta.isMetaDestroyed() ||
     meta.readableChainWatchers() === undefined
@@ -336,7 +336,7 @@ function lazyGet(obj: object, key: string): any {
   let meta = peekMeta(obj);
 
   // check if object meant only to be a prototype
-  if (meta !== undefined && meta.proto === obj) {
+  if (meta !== null && meta.proto === obj) {
     return;
   }
 

--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -359,7 +359,7 @@ class ComputedProperty extends Descriptor implements DescriptorWithDependentKeys
 
     // don't create objects just to invalidate
     let meta = peekMeta(obj);
-    if (meta === undefined || meta.source !== obj) {
+    if (meta === null || meta.source !== obj) {
       return;
     }
 

--- a/packages/@ember/-internals/metal/lib/events.ts
+++ b/packages/@ember/-internals/metal/lib/events.ts
@@ -148,7 +148,7 @@ export function sendEvent(
 */
 export function hasListeners(obj: object, eventName: string) {
   let meta = peekMeta(obj);
-  if (meta === undefined) {
+  if (meta === null) {
     return false;
   }
   let matched = meta.matchingListeners(eventName);

--- a/packages/@ember/-internals/metal/lib/mixin.ts
+++ b/packages/@ember/-internals/metal/lib/mixin.ts
@@ -547,7 +547,7 @@ export default class Mixin {
   static mixins(obj: object): Mixin[] {
     let meta = peekMeta(obj);
     let ret: Mixin[] = [];
-    if (meta === undefined) {
+    if (meta === null) {
       return ret;
     }
 
@@ -611,7 +611,7 @@ export default class Mixin {
       return _detect(obj, this);
     }
     let meta = peekMeta(obj);
-    if (meta === undefined) {
+    if (meta === null) {
       return false;
     }
     return meta.hasMixin(this);

--- a/packages/@ember/-internals/metal/lib/properties.ts
+++ b/packages/@ember/-internals/metal/lib/properties.ts
@@ -86,7 +86,7 @@ export function INHERITING_GETTER_FUNCTION(name: string): InheritingGetterFuncti
   function IGETTER_FUNCTION(this: any) {
     let meta = peekMeta(this);
     let val;
-    if (meta !== undefined) {
+    if (meta !== null) {
       val = meta.readInheritedValue('values', name);
     }
 

--- a/packages/@ember/-internals/metal/lib/property_events.ts
+++ b/packages/@ember/-internals/metal/lib/property_events.ts
@@ -88,7 +88,7 @@ if (ENABLE_PROPERTY_DID_CHANGE) {
 */
 function notifyPropertyChange(obj: object, keyName: string, _meta?: Meta): void {
   let meta = _meta === undefined ? peekMeta(obj) : _meta;
-  let hasMeta = meta !== undefined;
+  let hasMeta = meta !== null;
 
   if (hasMeta && (meta.isInitializing() || meta.isPrototypeMeta(obj))) {
     return;

--- a/packages/@ember/-internals/metal/lib/property_set.ts
+++ b/packages/@ember/-internals/metal/lib/property_set.ts
@@ -118,7 +118,7 @@ export function set(obj: object, keyName: string, value: any, tolerant?: boolean
 
 if (DEBUG) {
   setWithMandatorySetter = (meta, obj, keyName, value) => {
-    if (meta !== undefined && meta.peekWatching(keyName) > 0) {
+    if (meta !== null && meta.peekWatching(keyName) > 0) {
       makeEnumerable(obj, keyName);
       meta.writeValue(obj, keyName, value);
     } else {

--- a/packages/@ember/-internals/metal/lib/watch_key.ts
+++ b/packages/@ember/-internals/metal/lib/watch_key.ts
@@ -94,7 +94,7 @@ export function unwatchKey(obj: object, keyName: string, _meta?: Meta) {
   let meta = _meta === undefined ? peekMeta(obj) : _meta;
 
   // do nothing of this object has already been destroyed
-  if (meta === undefined || meta.isSourceDestroyed()) {
+  if (meta === null || meta.isSourceDestroyed()) {
     return;
   }
 

--- a/packages/@ember/-internals/metal/lib/watch_path.ts
+++ b/packages/@ember/-internals/metal/lib/watch_path.ts
@@ -14,7 +14,7 @@ export function watchPath(obj: any, keyPath: string, meta?: Meta): void {
 
 export function unwatchPath(obj: any, keyPath: string, meta?: Meta): void {
   let m = meta === undefined ? peekMeta(obj) : meta;
-  if (m === undefined) {
+  if (m === null) {
     return;
   }
   let counter = m.peekWatching(keyPath);

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -1334,7 +1334,7 @@ moduleFor(
         Route.extend({
           model(p, trans) {
             let m = peekMeta(trans[PARAMS_SYMBOL].application);
-            assert.ok(m === undefined, "A meta object isn't constructed for this params POJO");
+            assert.ok(m === null, "A meta object isn't constructed for this params POJO");
           },
         })
       );


### PR DESCRIPTION
differentiate between not passing `meta` and  `meta` not existing.

many `meta` related functions allow passing `meta` as last argument and do check if `meta` passed as following:
```javascript
let meta = _meta === undefined ? peekMeta(obj) : _meta;
```
is such case `peekMeta()` is called even if last argument is passed as `undefined` since `meta` does not exist, to avoid it made `peekMeta` to return `null` instead of `undefined`