### PR TITLE
[BUGFIX lts] build: Turn off sourcemaps for TS-to-ES compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,9 @@ jobs:
       - TEST_SUITE=built-tests
       - EMBER_ENV=production
     - env: TEST_SUITE=old-jquery-and-extend-prototypes
-    - env: TEST_SUITE=node
+    - env:
+      - TEST_SUITE=node
+      - EMBER_ENV=production
       node_js: "6"
     - env: TEST_SUITE=blueprints
       node_js: "6"

--- a/broccoli/packages.js
+++ b/broccoli/packages.js
@@ -87,7 +87,11 @@ module.exports.getPackagesES = function getPackagesES() {
     include: ['**/*.ts'],
   });
 
-  let typescriptCompiled = typescript(debugTree(typescriptContents, `get-packages-es:ts:input`));
+  let typescriptCompiled = typescript(debugTree(typescriptContents, `get-packages-es:ts:input`), {
+    compilerOptions: {
+      sourceMap: false,
+    },
+  });
 
   let debuggedCompiledTypescript = debugTree(typescriptCompiled, `get-packages-es:ts:output`);
 

--- a/tests/node/sourcemap-test.js
+++ b/tests/node/sourcemap-test.js
@@ -1,0 +1,27 @@
+var fs = require('fs');
+
+QUnit.module('sourcemap validation', function() {
+  var assets = ['ember.debug', 'ember.prod', 'ember.min'];
+
+  assets.forEach(asset => {
+    QUnit.test(`${asset} has only a single sourcemaps comment`, function(assert) {
+      var jsPath = `dist/${asset}.js`;
+      assert.ok(fs.existsSync(jsPath));
+
+      var contents = fs.readFileSync(jsPath, 'utf-8');
+      var num = count(contents, '//# sourceMappingURL=');
+      assert.equal(num, 1);
+    });
+  });
+});
+
+function count(source, find) {
+  var num = 0;
+
+  var i = -1;
+  while ((i = source.indexOf(find, i + 1)) !== -1) {
+    num += 1;
+  }
+
+  return num;
+}


### PR DESCRIPTION
We seem to use Babel to compile ES to AMD modules and that now includes ES modules there were originally written in TypeScript. The TypeScript compiler is apparently outputting sourcemaps by default, but it looks like Babel can't handle those properly. Instead Babel keeps the sourcemap comments inside of the AMD modules, which causes the final concatenated file to have *multiple* sourcemap comments, which is invalid. Future versions of Babel might fix this but for now we should turn off the TypeScript sourcemaps, so that the final build output is valid again.

Resolves #16881 

/cc @rwjblue @buschtoens @gossi