### PR TITLE
Cleanup type information for ember-metal

### DIFF
--- a/packages/@ember/-internals/metal/lib/alias.ts
+++ b/packages/@ember/-internals/metal/lib/alias.ts
@@ -46,17 +46,17 @@ export class AliasedProperty extends Descriptor implements DescriptorWithDepende
     this.consume(obj, keyName, meta);
   }
 
-  didUnwatch(obj: object, keyName: string, meta: Meta) {
+  didUnwatch(obj: object, keyName: string, meta: Meta): void {
     this.unconsume(obj, keyName, meta);
   }
 
-  get(obj: object, keyName: string) {
+  get(obj: object, keyName: string): any {
     let ret = get(obj, this.altKey);
     this.consume(obj, keyName, metaFor(obj));
     return ret;
   }
 
-  unconsume(obj: object, keyName: string, meta: Meta) {
+  unconsume(obj: object, keyName: string, meta: Meta): void {
     let wasConsumed = getCachedValueFor(obj, keyName) === CONSUMED;
     if (wasConsumed || meta.peekWatching(keyName) > 0) {
       removeDependentKeys(this, obj, keyName, meta);
@@ -66,7 +66,7 @@ export class AliasedProperty extends Descriptor implements DescriptorWithDepende
     }
   }
 
-  consume(obj: object, keyName: string, meta: Meta) {
+  consume(obj: object, keyName: string, meta: Meta): void {
     let cache = getCacheFor(obj);
     if (cache.get(keyName) !== CONSUMED) {
       cache.set(keyName, CONSUMED);
@@ -74,16 +74,16 @@ export class AliasedProperty extends Descriptor implements DescriptorWithDepende
     }
   }
 
-  set(obj: object, _keyName: string, value: any) {
+  set(obj: object, _keyName: string, value: any): any {
     return set(obj, this.altKey, value);
   }
 
-  readOnly() {
+  readOnly(): this {
     this.set = AliasedProperty_readOnlySet;
     return this;
   }
 
-  oneWay() {
+  oneWay(): this {
     this.set = AliasedProperty_oneWaySet;
     return this;
   }

--- a/packages/@ember/-internals/metal/lib/array.ts
+++ b/packages/@ember/-internals/metal/lib/array.ts
@@ -29,7 +29,7 @@ export function replace<T>(
   start: number,
   deleteCount: number,
   items = EMPTY_ARRAY
-) {
+): void {
   if (Array.isArray(array)) {
     replaceInNativeArray(array, start, deleteCount, items);
   } else {
@@ -46,7 +46,7 @@ export function replaceInNativeArray<T>(
   start: number,
   deleteCount: number,
   items: ReadonlyArray<T>
-) {
+): void {
   arrayContentWillChange(array, start, deleteCount, items.length);
 
   if (items.length <= CHUNK_SIZE) {
@@ -81,7 +81,7 @@ function arrayObserversHelper(
   opts: ArrayObserverOptions | undefined,
   operation: Operation,
   notify: boolean
-) {
+): ObjectHasArrayObservers {
   let willChange = (opts && opts.willChange) || 'arrayWillChange';
   let didChange = (opts && opts.didChange) || 'arrayDidChange';
   let hasObservers = get(obj, 'hasArrayObservers');
@@ -100,7 +100,7 @@ export function addArrayObserver<T>(
   array: EmberArray<T>,
   target: any,
   opts?: ArrayObserverOptions | undefined
-) {
+): ObjectHasArrayObservers {
   return arrayObserversHelper(array, target, opts, addListener, false);
 }
 
@@ -108,6 +108,6 @@ export function removeArrayObserver<T>(
   array: EmberArray<T>,
   target: any,
   opts?: ArrayObserverOptions | undefined
-) {
+): ObjectHasArrayObservers {
   return arrayObserversHelper(array, target, opts, removeListener, true);
 }

--- a/packages/@ember/-internals/metal/lib/array_events.ts
+++ b/packages/@ember/-internals/metal/lib/array_events.ts
@@ -4,12 +4,12 @@ import { eachProxyArrayDidChange, eachProxyArrayWillChange } from './each_proxy_
 import { sendEvent } from './events';
 import { notifyPropertyChange } from './property_events';
 
-export function arrayContentWillChange(
-  array: object,
+export function arrayContentWillChange<T extends object>(
+  array: T,
   startIdx: number,
   removeAmt: number,
   addAmt: number
-) {
+): T {
   // if no args are passed assume everything changes
   if (startIdx === undefined) {
     startIdx = 0;
@@ -31,12 +31,12 @@ export function arrayContentWillChange(
   return array;
 }
 
-export function arrayContentDidChange(
-  array: { length: number },
+export function arrayContentDidChange<T extends { length: number }>(
+  array: T,
   startIdx: number,
   removeAmt: number,
   addAmt: number
-) {
+): T {
   // if no args are passed assume everything changes
   if (startIdx === undefined) {
     startIdx = 0;

--- a/packages/@ember/-internals/metal/lib/chains.ts
+++ b/packages/@ember/-internals/metal/lib/chains.ts
@@ -4,7 +4,7 @@ import { eachProxyFor } from './each_proxy';
 import { get } from './property_get';
 import { unwatchKey, watchKey } from './watch_key';
 
-function isObject(obj: any): boolean {
+function isObject(obj: any): obj is object {
   return typeof obj === 'object' && obj !== null;
 }
 
@@ -134,7 +134,7 @@ function removeChainWatcher(obj: object, keyName: string, node: ChainNode, _meta
 }
 
 const NODE_STACK: ChainNode[] = [];
-function destroyRoot(root: ChainNode) {
+function destroyRoot(root: ChainNode): void {
   pushChildren(root);
   while (NODE_STACK.length > 0) {
     let node = NODE_STACK.pop()!;
@@ -143,14 +143,14 @@ function destroyRoot(root: ChainNode) {
   }
 }
 
-function destroyOne(node: ChainNode) {
+function destroyOne(node: ChainNode): void {
   if (node.isWatching) {
     removeChainWatcher(node.object!, node.key, node);
     node.isWatching = false;
   }
 }
 
-function pushChildren(node: ChainNode) {
+function pushChildren(node: ChainNode): void {
   let nodes = node.chains;
   if (nodes !== undefined) {
     for (let key in nodes) {
@@ -208,7 +208,7 @@ class ChainNode {
   }
 
   // copies a top level object only
-  copyTo(target: ChainNode) {
+  copyTo(target: ChainNode): void {
     let paths = this.paths;
     if (paths !== undefined) {
       let path;
@@ -315,7 +315,7 @@ class ChainNode {
     }
   }
 
-  populateAffected(path: string, depth: number, affected: (any | string)[]) {
+  populateAffected(path: string, depth: number, affected: (any | string)[]): void {
     if (this.key) {
       path = `${this.key}.${path}`;
     }

--- a/packages/@ember/-internals/metal/lib/change_event.ts
+++ b/packages/@ember/-internals/metal/lib/change_event.ts
@@ -1,5 +1,5 @@
 const AFTER_OBSERVERS = ':change';
 
-export default function changeEvent(keyName: string) {
+export default function changeEvent(keyName: string): string {
   return keyName + AFTER_OBSERVERS;
 }

--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -42,7 +42,7 @@ export interface ComputedPropertyOptions {
 
 const DEEP_EACH_REGEX = /\.@each\.[^.]+\./;
 
-function noop() {}
+function noop(): void {}
 
 /**
   A computed property transforms an object literal with object's accessor function(s) into a property.
@@ -293,7 +293,7 @@ class ComputedProperty extends Descriptor implements DescriptorWithDependentKeys
   property(...passedArgs: string[]): ComputedProperty {
     let args: string[] = [];
 
-    function addArg(property: string) {
+    function addArg(property: string): void {
       warn(
         `Dependent keys containing @each only work one level deep. ` +
           `You used the key "${property}" which is invalid. ` +
@@ -340,7 +340,7 @@ class ComputedProperty extends Descriptor implements DescriptorWithDependentKeys
     @chainable
     @public
   */
-  meta(meta?: any): any | undefined {
+  meta(meta?: any): any {
     if (arguments.length === 0) {
       return this._meta || {};
     } else {
@@ -350,7 +350,7 @@ class ComputedProperty extends Descriptor implements DescriptorWithDependentKeys
   }
 
   // invalidate cache when CP key changes
-  didChange(obj: object, keyName: string) {
+  didChange(obj: object, keyName: string): void {
     // _suspended is set via a CP.set to ensure we don't clear
     // the cached value set by the setter
     if (this._volatile || this._suspended === obj) {
@@ -369,7 +369,7 @@ class ComputedProperty extends Descriptor implements DescriptorWithDependentKeys
     }
   }
 
-  get(obj: object, keyName: string) {
+  get(obj: object, keyName: string): any {
     if (this._volatile) {
       return this._getter.call(obj, keyName);
     }
@@ -470,7 +470,7 @@ class ComputedProperty extends Descriptor implements DescriptorWithDependentKeys
     }
   }
 
-  _set(obj: object, keyName: string, value: any) {
+  _set(obj: object, keyName: string, value: any): any {
     let cache = getCacheFor(obj);
     let hadCachedValue = cache.has(keyName);
     let cachedValue = cache.get(keyName);
@@ -515,7 +515,7 @@ class ComputedProperty extends Descriptor implements DescriptorWithDependentKeys
 }
 
 if (EMBER_METAL_TRACKED_PROPERTIES) {
-  ComputedProperty.prototype.auto = function() {
+  ComputedProperty.prototype.auto = function(): ComputedProperty {
     this._auto = true;
     return this;
   };

--- a/packages/@ember/-internals/metal/lib/computed_cache.ts
+++ b/packages/@ember/-internals/metal/lib/computed_cache.ts
@@ -19,13 +19,13 @@ const COMPUTED_PROPERTY_LAST_REVISION = EMBER_METAL_TRACKED_PROPERTIES
   @return {Object} the cached value
   @public
 */
-export function getCacheFor(obj: object) {
+export function getCacheFor(obj: object): Map<string, any> {
   let cache = COMPUTED_PROPERTY_CACHED_VALUES.get(obj);
   if (cache === undefined) {
-    cache = new Map();
+    cache = new Map<string, any>();
 
     if (EMBER_METAL_TRACKED_PROPERTIES) {
-      COMPUTED_PROPERTY_LAST_REVISION!.set(obj, new Map());
+      COMPUTED_PROPERTY_LAST_REVISION!.set(obj, new Map<string, any>());
     }
 
     COMPUTED_PROPERTY_CACHED_VALUES.set(obj, cache);
@@ -33,7 +33,7 @@ export function getCacheFor(obj: object) {
   return cache;
 }
 
-export function getCachedValueFor(obj: object, key: string) {
+export function getCachedValueFor(obj: object, key: string): any {
   let cache = COMPUTED_PROPERTY_CACHED_VALUES.get(obj);
   if (cache !== undefined) {
     return cache.get(key);
@@ -60,6 +60,6 @@ if (EMBER_METAL_TRACKED_PROPERTIES) {
   };
 }
 
-export function peekCacheFor(obj: object) {
+export function peekCacheFor(obj: object): any {
   return COMPUTED_PROPERTY_CACHED_VALUES.get(obj);
 }

--- a/packages/@ember/-internals/metal/lib/deprecate_property.ts
+++ b/packages/@ember/-internals/metal/lib/deprecate_property.ts
@@ -24,8 +24,8 @@ export function deprecateProperty(
   deprecatedKey: string,
   newKey: string,
   options?: DeprecationOptions
-) {
-  function _deprecate() {
+): void {
+  function _deprecate(): void {
     deprecate(
       `Usage of \`${deprecatedKey}\` is deprecated, use \`${newKey}\` instead.`,
       false,
@@ -36,11 +36,11 @@ export function deprecateProperty(
   Object.defineProperty(object, deprecatedKey, {
     configurable: true,
     enumerable: false,
-    set(value) {
+    set(value): any {
       _deprecate();
       set(this, newKey, value);
     },
-    get() {
+    get(): any {
       _deprecate();
       return get(this, newKey);
     },

--- a/packages/@ember/-internals/metal/lib/descriptor.ts
+++ b/packages/@ember/-internals/metal/lib/descriptor.ts
@@ -1,7 +1,7 @@
 import { Meta } from '@ember/-internals/meta';
 import { Descriptor } from './properties';
 
-export default function descriptor(desc: PropertyDescriptor) {
+export default function descriptor(desc: PropertyDescriptor): NativeDescriptor {
   return new NativeDescriptor(desc);
 }
 
@@ -23,16 +23,16 @@ class NativeDescriptor extends Descriptor {
     this.configurable = desc.configurable !== false;
   }
 
-  setup(obj: object, key: string, meta: Meta) {
+  setup(obj: object, key: string, meta: Meta): void {
     Object.defineProperty(obj, key, this.desc);
     meta.writeDescriptors(key, this);
   }
 
-  get(obj: object, key: string): any | null | undefined {
+  get(obj: object, key: string): any {
     return obj[key];
   }
 
-  set(obj: object, key: string, value: any | null | undefined) {
+  set(obj: object, key: string, value: any): any {
     return (obj[key] = value);
   }
 }

--- a/packages/@ember/-internals/metal/lib/each_proxy.ts
+++ b/packages/@ember/-internals/metal/lib/each_proxy.ts
@@ -28,7 +28,11 @@ class EachProxy<T> {
   // ARRAY CHANGES
   // Invokes whenever the content array itself changes.
 
-  arrayWillChange(content: T[] | EmberArray<T>, idx: number, removedCnt: number /*, addedCnt */) {
+  arrayWillChange(
+    content: T[] | EmberArray<T>,
+    idx: number,
+    removedCnt: number /*, addedCnt */
+  ): void {
     // eslint-disable-line no-unused-vars
     let keys = this._keys;
     if (!keys) {
@@ -42,7 +46,12 @@ class EachProxy<T> {
     }
   }
 
-  arrayDidChange(content: T[] | EmberArray<T>, idx: number, _removedCnt: number, addedCnt: number) {
+  arrayDidChange(
+    content: T[] | EmberArray<T>,
+    idx: number,
+    _removedCnt: number,
+    addedCnt: number
+  ): void {
     let keys = this._keys;
     if (!keys) {
       return;
@@ -111,7 +120,7 @@ function addObserverForContentKey<T>(
   proxy: object | Function,
   idx: number,
   loc: number
-) {
+): void {
   while (--loc >= idx) {
     let item = objectAt(content, loc);
     if (item) {

--- a/packages/@ember/-internals/metal/lib/each_proxy_events.ts
+++ b/packages/@ember/-internals/metal/lib/each_proxy_events.ts
@@ -5,7 +5,7 @@ export function eachProxyArrayWillChange(
   idx: number,
   removedCnt: number,
   addedCnt: number
-) {
+): void {
   let eachProxy = EACH_PROXIES.get(array);
   if (eachProxy !== undefined) {
     eachProxy.arrayWillChange(array, idx, removedCnt, addedCnt);
@@ -17,7 +17,7 @@ export function eachProxyArrayDidChange(
   idx: number,
   removedCnt: number,
   addedCnt: number
-) {
+): void {
   let eachProxy = EACH_PROXIES.get(array);
   if (eachProxy !== undefined) {
     eachProxy.arrayDidChange(array, idx, removedCnt, addedCnt);

--- a/packages/@ember/-internals/metal/lib/events.ts
+++ b/packages/@ember/-internals/metal/lib/events.ts
@@ -42,7 +42,7 @@ export function addListener(
   target: object | Function | null,
   method?: Function | string,
   once?: boolean
-) {
+): void {
   assert('You must pass at least an object and event name to addListener', !!obj && !!eventName);
 
   if (!method && 'function' === typeof target) {
@@ -72,7 +72,7 @@ export function removeListener(
   eventName: string,
   target: object | null,
   method?: Function | string
-) {
+): void {
   assert('You must pass at least an object and event name to removeListener', !!obj && !!eventName);
 
   if (!method && 'function' === typeof target) {
@@ -101,7 +101,7 @@ export function removeListener(
   @param obj
   @param {String} eventName
   @param {Array} params Optional parameters for each listener.
-  @return true
+  @return {Boolean} if the event was delivered to one or more actions
   @public
 */
 export function sendEvent(
@@ -110,7 +110,7 @@ export function sendEvent(
   params: any[],
   actions?: any[],
   _meta?: Meta
-) {
+): boolean {
   if (actions === undefined) {
     let meta = _meta === undefined ? peekMeta(obj) : _meta;
     actions = typeof meta === 'object' && meta !== null && meta.matchingListeners(eventName);
@@ -151,8 +151,9 @@ export function sendEvent(
   @for @ember/object/events
   @param obj
   @param {String} eventName
+  @return {Boolean} if `obj` has listeners for event `eventName`
 */
-export function hasListeners(obj: object, eventName: string) {
+export function hasListeners(obj: object, eventName: string): boolean {
   let meta = peekMeta(obj);
   if (meta === undefined) {
     return false;
@@ -186,10 +187,10 @@ export function hasListeners(obj: object, eventName: string) {
   @for @ember/object/evented
   @param {String} eventNames*
   @param {Function} func
-  @return func
+  @return {Function} the listener function, passed as last argument to on(...)
   @public
 */
-export function on(...args: Array<string | Function>) {
+export function on(...args: Array<string | Function>): Function {
   let func = args.pop() as Function;
   let events = args as string[];
 

--- a/packages/@ember/-internals/metal/lib/expand_properties.ts
+++ b/packages/@ember/-internals/metal/lib/expand_properties.ts
@@ -67,7 +67,7 @@ function dive(
   pattern: string,
   start: number,
   callback: (expansion: string) => void
-) {
+): void {
   let end = pattern.indexOf('}'),
     i = 0,
     newStart,

--- a/packages/@ember/-internals/metal/lib/is_none.ts
+++ b/packages/@ember/-internals/metal/lib/is_none.ts
@@ -22,6 +22,6 @@
   @return {Boolean}
   @public
 */
-export default function isNone(obj: any): boolean {
+export default function isNone(obj: any): obj is null | undefined {
   return obj === null || obj === undefined;
 }

--- a/packages/@ember/-internals/metal/lib/is_present.ts
+++ b/packages/@ember/-internals/metal/lib/is_present.ts
@@ -32,6 +32,6 @@ import isBlank from './is_blank';
   @since 1.8.0
   @public
 */
-export default function isPresent(obj: object): any {
+export default function isPresent(obj: object): boolean {
   return !isBlank(obj);
 }

--- a/packages/@ember/-internals/metal/lib/libraries.ts
+++ b/packages/@ember/-internals/metal/lib/libraries.ts
@@ -82,7 +82,7 @@ if (EMBER_LIBRARIES_ISREGISTERED) {
 }
 
 if (DEBUG) {
-  Libraries.prototype.logVersions = function(this: Libraries) {
+  Libraries.prototype.logVersions = function(): void {
     let libs = this._registry;
     let nameLengths = libs.map(item => get(item, 'name.length'));
     let maxNameLength = Math.max.apply(null, nameLengths);

--- a/packages/@ember/-internals/metal/lib/mixin.ts
+++ b/packages/@ember/-internals/metal/lib/mixin.ts
@@ -25,7 +25,7 @@ import { defineProperty, Descriptor } from './properties';
 const a_concat = Array.prototype.concat;
 const { isArray } = Array;
 
-function isMethod(obj: any) {
+function isMethod(obj: any): boolean {
   return (
     'function' === typeof obj &&
     obj.isMethod !== false &&

--- a/packages/@ember/-internals/metal/lib/namespace_search.ts
+++ b/packages/@ember/-internals/metal/lib/namespace_search.ts
@@ -13,7 +13,7 @@ let searchDisabled = false;
 const flags = {
   _set: 0,
   _unprocessedNamespaces: false,
-  get unprocessedNamespaces() {
+  get unprocessedNamespaces(): boolean {
     return this._unprocessedNamespaces;
   },
   set unprocessedNamespaces(v) {
@@ -76,7 +76,7 @@ export function processNamespace(namespace: Namespace): void {
   _processNamespace([namespace.toString()], namespace, new Set());
 }
 
-export function processAllNamespaces() {
+export function processAllNamespaces(): void {
   let unprocessedNamespaces = flags.unprocessedNamespaces;
   if (unprocessedNamespaces) {
     findNamespaces();
@@ -116,7 +116,7 @@ export function setUnprocessedMixins(): void {
   unprocessedMixins = true;
 }
 
-function _processNamespace(paths: string[], root: Namespace, seen: Set<Namespace>) {
+function _processNamespace(paths: string[], root: Namespace, seen: Set<Namespace>): void {
   let idx = paths.length;
 
   let id = paths.join('.');

--- a/packages/@ember/-internals/metal/lib/observer_set.ts
+++ b/packages/@ember/-internals/metal/lib/observer_set.ts
@@ -24,7 +24,7 @@ export default class ObserverSet {
     this.queue = [];
   }
 
-  add(object: object, key: string, event: string) {
+  add(object: object, key: string, event: string): void {
     let keys = this.added.get(object);
     if (keys === undefined) {
       keys = new Set();
@@ -37,7 +37,7 @@ export default class ObserverSet {
     }
   }
 
-  flush() {
+  flush(): void {
     // The queue is saved off to support nested flushes.
     let queue = this.queue;
     this.added.clear();

--- a/packages/@ember/-internals/metal/lib/properties.ts
+++ b/packages/@ember/-internals/metal/lib/properties.ts
@@ -62,7 +62,7 @@ interface ExtendedObject {
 //
 
 export function MANDATORY_SETTER_FUNCTION(name: string): MandatorySetterFunction {
-  function SETTER_FUNCTION(this: object, value: any | undefined | null) {
+  function SETTER_FUNCTION(this: object, value: any | undefined | null): void {
     let m = peekMeta(this);
     if (m.isInitializing() || m.isPrototypeMeta(this)) {
       m.writeValues(name, value);
@@ -77,7 +77,7 @@ export function MANDATORY_SETTER_FUNCTION(name: string): MandatorySetterFunction
 }
 
 export function DEFAULT_GETTER_FUNCTION(name: string): DefaultGetterFunction {
-  return function GETTER_FUNCTION(this: any) {
+  return function GETTER_FUNCTION(this: any): void {
     let meta = peekMeta(this);
     if (meta !== undefined) {
       return meta.peekValues(name);
@@ -86,7 +86,7 @@ export function DEFAULT_GETTER_FUNCTION(name: string): DefaultGetterFunction {
 }
 
 export function INHERITING_GETTER_FUNCTION(name: string): InheritingGetterFunction {
-  function IGETTER_FUNCTION(this: any) {
+  function IGETTER_FUNCTION(this: any): void {
     let meta = peekMeta(this);
     let val;
     if (meta !== undefined) {
@@ -106,8 +106,8 @@ export function INHERITING_GETTER_FUNCTION(name: string): InheritingGetterFuncti
   });
 }
 
-function DESCRIPTOR_GETTER_FUNCTION(name: string, descriptor: Descriptor) {
-  return function CPGETTER_FUNCTION(this: object) {
+function DESCRIPTOR_GETTER_FUNCTION(name: string, descriptor: Descriptor): () => any {
+  return function CPGETTER_FUNCTION(this: object): any {
     return descriptor.get(this, name);
   };
 }
@@ -166,7 +166,7 @@ export function defineProperty(
   desc?: Descriptor | undefined | null,
   data?: any | undefined | null,
   meta?: Meta
-) {
+): void {
   if (meta === undefined) {
     meta = metaFor(obj);
   }

--- a/packages/@ember/-internals/metal/lib/property_events.ts
+++ b/packages/@ember/-internals/metal/lib/property_events.ts
@@ -73,7 +73,7 @@ const SEEN_MAP = new Map<object, Set<string>>();
 let IS_TOP_SEEN_MAP = true;
 
 // called whenever a property has just changed to update dependent keys
-function dependentKeysDidChange(obj: object, depKey: string, meta: Meta) {
+function dependentKeysDidChange(obj: object, depKey: string, meta: Meta): void {
   if (meta.isSourceDestroying() || !meta.hasDeps(depKey)) {
     return;
   }
@@ -98,7 +98,7 @@ function iterDeps(
   depKey: string,
   seen: Map<object, Set<string>>,
   meta: Meta
-) {
+): void {
   let current = seen.get(obj);
 
   if (current === undefined) {
@@ -122,14 +122,14 @@ function iterDeps(
   });
 }
 
-function chainsDidChange(_obj: object, keyName: string, meta: Meta) {
+function chainsDidChange(_obj: object, keyName: string, meta: Meta): void {
   let chainWatchers = meta.readableChainWatchers();
   if (chainWatchers !== undefined) {
     chainWatchers.notify(keyName, true, notifyPropertyChange);
   }
 }
 
-function overrideChains(_obj: object, keyName: string, meta: Meta) {
+function overrideChains(_obj: object, keyName: string, meta: Meta): void {
   let chainWatchers = meta.readableChainWatchers();
   if (chainWatchers !== undefined) {
     chainWatchers.revalidate(keyName);
@@ -141,7 +141,7 @@ function overrideChains(_obj: object, keyName: string, meta: Meta) {
   @chainable
   @private
 */
-function beginPropertyChanges() {
+function beginPropertyChanges(): void {
   deferred++;
 }
 
@@ -149,7 +149,7 @@ function beginPropertyChanges() {
   @method endPropertyChanges
   @private
 */
-function endPropertyChanges() {
+function endPropertyChanges(): void {
   deferred--;
   if (deferred <= 0) {
     observerSet.flush();
@@ -180,7 +180,7 @@ function changeProperties(callback: () => void): void {
   }
 }
 
-function notifyObservers(obj: object, keyName: string, meta: Meta) {
+function notifyObservers(obj: object, keyName: string, meta: Meta): void {
   if (meta.isSourceDestroying()) {
     return;
   }

--- a/packages/@ember/-internals/metal/lib/property_get.ts
+++ b/packages/@ember/-internals/metal/lib/property_get.ts
@@ -15,7 +15,7 @@ export const PROXY_CONTENT = symbol('PROXY_CONTENT');
 export let getPossibleMandatoryProxyValue: (obj: object, keyName: string) => any;
 
 if (DEBUG && HAS_NATIVE_PROXY) {
-  getPossibleMandatoryProxyValue = function getPossibleMandatoryProxyValue(obj, keyName) {
+  getPossibleMandatoryProxyValue = function getPossibleMandatoryProxyValue(obj, keyName): any {
     let content = obj[PROXY_CONTENT];
     if (content === undefined) {
       return obj[keyName];

--- a/packages/@ember/-internals/metal/lib/property_set.ts
+++ b/packages/@ember/-internals/metal/lib/property_set.ts
@@ -46,7 +46,7 @@ let makeEnumerable: (obj: object, keyName: string) => void;
   @return {Object} the passed value.
   @public
 */
-export function set(obj: object, keyName: string, value: any, tolerant?: boolean): any | void {
+export function set(obj: object, keyName: string, value: any, tolerant?: boolean): any {
   assert(
     `Set must be called with three or four arguments; an object, a property key, a value and tolerant true/false`,
     arguments.length === 3 || arguments.length === 4

--- a/packages/@ember/-internals/metal/lib/tags.ts
+++ b/packages/@ember/-internals/metal/lib/tags.ts
@@ -2,7 +2,14 @@ import { Meta, meta as metaFor } from '@ember/-internals/meta';
 import { isProxy } from '@ember/-internals/utils';
 import { EMBER_METAL_TRACKED_PROPERTIES } from '@ember/canary-features';
 import { backburner } from '@ember/runloop';
-import { combine, CONSTANT_TAG, DirtyableTag, Tag, UpdatableTag } from '@glimmer/reference';
+import {
+  combine,
+  CONSTANT_TAG,
+  DirtyableTag,
+  Tag,
+  TagWrapper,
+  UpdatableTag,
+} from '@glimmer/reference';
 
 let hasViews: () => boolean = () => false;
 
@@ -10,7 +17,7 @@ export function setHasViews(fn: () => boolean): void {
   hasViews = fn;
 }
 
-function makeTag() {
+function makeTag(): TagWrapper<DirtyableTag> {
   return DirtyableTag.create();
 }
 
@@ -87,7 +94,7 @@ export function markObjectAsDirty(obj: object, propertyKey: string, meta: Meta):
   }
 }
 
-function ensureRunloop() {
+function ensureRunloop(): void {
   if (hasViews()) {
     backburner.ensureInstance();
   }

--- a/packages/@ember/-internals/metal/lib/tracked.ts
+++ b/packages/@ember/-internals/metal/lib/tracked.ts
@@ -13,12 +13,12 @@ class Tracker {
   private tags = new Set<Tag>();
   private last: Option<Tag> = null;
 
-  add(tag: Tag) {
+  add(tag: Tag): void {
     this.tags.add(tag);
     this.last = tag;
   }
 
-  get size() {
+  get size(): number {
     return this.tags.size;
   }
 
@@ -145,7 +145,7 @@ function descriptorForAccessor(
   let get = descriptor.get as Function;
   let set = descriptor.set as Function;
 
-  function getter(this: any) {
+  function getter(this: any): any {
     // Swap the parent tracker for a new tracker
     let old = CURRENT_TRACKER;
     let tracker = (CURRENT_TRACKER = new Tracker());
@@ -167,7 +167,7 @@ function descriptorForAccessor(
     return ret;
   }
 
-  function setter(this: unusable) {
+  function setter(this: unusable): void {
     dirty(tagForProperty(this, key));
     set.apply(this, arguments);
   }
@@ -194,14 +194,17 @@ export type Key = string;
   from it.
  */
 
-function descriptorForDataProperty(key: string, descriptor: PropertyDescriptor) {
+function descriptorForDataProperty(
+  key: string,
+  descriptor: PropertyDescriptor
+): PropertyDescriptor {
   let shadowKey = Symbol(key);
 
   return {
     enumerable: true,
     configurable: true,
 
-    get() {
+    get(): any {
       if (CURRENT_TRACKER) CURRENT_TRACKER.add(tagForProperty(this, key));
 
       if (!(shadowKey in this)) {
@@ -211,7 +214,7 @@ function descriptorForDataProperty(key: string, descriptor: PropertyDescriptor) 
       return this[shadowKey];
     },
 
-    set(newValue: any) {
+    set(newValue: any): void {
       tagFor(this).inner!['dirty']();
       dirty(tagForProperty(this, key));
       this[shadowKey] = newValue;
@@ -224,9 +227,9 @@ export interface Interceptors {
   [key: string]: boolean;
 }
 
-let propertyDidChange = function() {};
+let propertyDidChange = function(): void {};
 
-export function setPropertyDidChange(cb: () => void) {
+export function setPropertyDidChange(cb: () => void): void {
   propertyDidChange = cb;
 }
 

--- a/packages/@ember/-internals/metal/lib/transaction.ts
+++ b/packages/@ember/-internals/metal/lib/transaction.ts
@@ -63,7 +63,7 @@ if (DEBUG) {
       return this.shouldReflush;
     }
 
-    didRender(object: object, key: string, reference: any) {
+    didRender(object: object, key: string, reference: any): void {
       if (!this.inTransaction) {
         return;
       }
@@ -120,7 +120,7 @@ if (DEBUG) {
       return this.getKey(object, key) === this.transactionId;
     }
 
-    before(context: object) {
+    before(context: object): void {
       this.inTransaction = true;
       this.shouldReflush = false;
       if (DEBUG) {
@@ -128,7 +128,7 @@ if (DEBUG) {
       }
     }
 
-    after() {
+    after(): void {
       this.transactionId++;
       this.inTransaction = false;
       if (DEBUG) {
@@ -137,13 +137,13 @@ if (DEBUG) {
       this.clearObjectMap();
     }
 
-    createMap(object: object) {
+    createMap(object: object): object {
       let map = Object.create(null);
       this.weakMap.set(object, map);
       return map;
     }
 
-    getOrCreateMap(object: object) {
+    getOrCreateMap(object: object): object {
       let map = this.weakMap.get(object);
       if (map === undefined) {
         map = this.createMap(object);
@@ -151,19 +151,19 @@ if (DEBUG) {
       return map;
     }
 
-    setKey(object: object, key: string, value: any) {
+    setKey(object: object, key: string, value: any): void {
       let map = this.getOrCreateMap(object);
       map[key] = value;
     }
 
-    getKey(object: object, key: string) {
+    getKey(object: object, key: string): any {
       let map = this.weakMap.get(object);
       if (map !== undefined) {
         return map[key];
       }
     }
 
-    clearObjectMap() {
+    clearObjectMap(): void {
       this.weakMap = new WeakMap();
     }
   }

--- a/packages/@ember/-internals/metal/lib/watch_key.ts
+++ b/packages/@ember/-internals/metal/lib/watch_key.ts
@@ -26,7 +26,7 @@ interface MaybeHasDidUnwatchProperty {
   didUnwatchProperty?: (keyName: string) => void;
 }
 
-export function watchKey(obj: object, keyName: string, _meta?: Meta) {
+export function watchKey(obj: object, keyName: string, _meta?: Meta): void {
   let meta = _meta === undefined ? metaFor(obj) : _meta;
   let count = meta.peekWatching(keyName);
   meta.writeWatching(keyName, count + 1);
@@ -58,7 +58,7 @@ if (DEBUG) {
   // Future traveler, although this code looks scary. It merely exists in
   // development to aid in development asertions. Production builds of
   // ember strip this entire block out
-  handleMandatorySetter = function handleMandatorySetter(m, obj, keyName) {
+  handleMandatorySetter = function handleMandatorySetter(m, obj, keyName): void {
     let descriptor = lookupDescriptor(obj, keyName);
     let hasDescriptor = descriptor !== null;
     let possibleDesc = hasDescriptor && descriptor!.value;
@@ -90,7 +90,7 @@ if (DEBUG) {
   };
 }
 
-export function unwatchKey(obj: object, keyName: string, _meta?: Meta) {
+export function unwatchKey(obj: object, keyName: string, _meta?: Meta): void {
   let meta = _meta === undefined ? peekMeta(obj) : _meta;
 
   // do nothing of this object has already been destroyed


### PR DESCRIPTION
This PR is a starting point for cleaning up some type information in ember-metal.

At a high level, here are some common things you'll find
- Call signature return types have been made explicit
    * Why? - [so that if changes are made to a function that deviate from the original developer intent, the type-checking will error at the definition of the function instead of all call-sites](https://agentcooper.github.io/typescript-play/#code/GYVwdgxgLglg9mABKSBGAFAQwE4HMBciYIAtgEYCm2AlIgN4BQiziECAzlEYgLyICymKAAsAdNkxgAJnBLpaAKkQ5cAbiYsA9AoUaWSgIJSpMMLkQiKiADamrla3ADuibBXYhrUdolN7mSlAAngAOFAC0EMIUEADWiFTYcNg+QhbRrJjW1ojsMFDuiHDAyOAQGNT+iAqa-pqaviXoSAA8iAAMtG5QINhIxNnqLK4UPX2IAAYAJHRgAL4T6nMMDCjQ8EhrAExYeITE5FTUhJzYpuaMw2xgnNx8giLikjJyisp4Q1o6VYbG5+lWWxgewURwuNweLw+PzDaoWUIRKIxeKJZKpLiWRBSCjAUz5Da5fJWYqlSA7SqwpQ-RAAVTA1ncPkxFAAHiFbBB8iMxkhgmFfD4opJcBQpIh0DBRBRRBY4LkoGczIgAD5ETzWCnDJRgOUQLLWcJ5Ao+JwwbKsWTszAwrW1Yb1Rri1odLqjXr9dWfZjdd2TGbzRYMZYrBjXW4ANyyqEwJwV-z4awwAGYk9R1GGuJHrFsY-LFeYE2Udim0ysM4gs6gyLH87xSeV0OES+mOJmsltq3n4-Wdk3U6ogA)
- Where possible (and simple), guard functions that returned `boolean` now appropriately narrow types
    * Why? - narrowing types in branching (`if`, `switch`, etc...) removes the need to explicitly cast
    * see [the User-Defined Type Guards section here](https://basarat.gitbooks.io/typescript/docs/types/typeGuard.html)
- At least since TS 2.5, any type union with `any` evaluates to an `any`
    * To avoid confusion, these are just changed to `any` where we can make very few assumptions (i.e., property access from an object)
    * In places where we know the value will always be truthy, we can use the `{}` type
    * In places where we know the vaue will never be truthy, we can define an `unusable` type
    * examples of these concepts and how they relate to `any` are [here](https://agentcooper.github.io/typescript-play/#code/C4TwDgpgBArgdjAzgQwEYBtoF4oPeqAH1jgBMIAzASzglKNwgDcIAnBpgeytIG4AofgHoAVCP5QRUACoALaAG8AvlFCQoyfJwDuiKBU7tkcEMFk0A5lE5m2q2cdwx8AGhLlqteoZIBrODpwEiJC-JjAUAAeAFxQylA4ACwCkQlQAOTyWukpaQoaFhCxAMwArFBKuTgAFACUCQB8Gcis0LaI0BABMBayUBCRyAC2YJh6IBDAAPw5-Kk48B40dFVO+Kvp6Rp68P6BG1vIerQsrAKCouKSMvIaJqrg0JroOnoGRiZmlsGh4VAgsWMIDSyX4wJwmQg2QE4PclGWfDBaTw6BhaU22z8AW0cDREMOx2YbHOl2CN2g8CQaEwD3Uz1e+h8QK+cCsZmQEQAxo4TnZUG1HgBaCAARxgVCYmi6EWAnA0qlYMFAUEl6BgEB+-Ao8E5wConDgjM4AEY6rFKSgMIolFqdXqDUaAExmkhUq1xKCtYAwVi4iq2uC6-WGgycYoui3UxSeyY+w2LeFeXj+7WB+0hzicRIRhCWmn5L1xtaoipAA)


CC: @krisselden 