### PR TITLE
Fix deserialization of array query params 

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -895,6 +895,8 @@ class EmberRouter extends EmberObject {
   _serializeQueryParam(value: unknown, type: string) {
     if (value === null || value === undefined) {
       return value;
+    } else if (typeof value === 'string' && type === 'array') {
+      value = JSON.parse(value);
     } else if (type === 'array') {
       return JSON.stringify(value);
     }


### PR DESCRIPTION
When Ember serializes an Array type param, it does so with JSON.stringify.
The deserialize converts back to an Array, but if you have a **slow connection**, the serialize method gets called again before deserialize which results in re-stringifying a string. 

Visual summary of what happens under the hood
![screenshot](https://puu.sh/BQIF3.png)

I've reproduced this behaviour with a twiddle here https://ember-twiddle.com/bc34a1cdf99ce9a013ace8bca3d25162?openFiles=controllers.application.js%2C

This is not ideal but for the above twiddle to work you need to use the [allow-control-allow-origin* chrome extension](https://chrome.google.com/webstore/detail/allow-control-allow-origi/nlfbmbojpeacfghkpbjhddihlkkiljbi?hl=en) as I'm making an external ajax request each time the query params is updated. Otherwise you'll get a console error ` No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'null' is therefore not allowed access.`. Not sure how to bypass this otherwise.


Steps: 
1. Simulate a slow connection by applying network throttling. In the gif I used a custom profile on Chrome with 10kb/s and 20,000ms of added latency.
2. Click a checkbox (arrays query param)
3. Start typing in the search bar.

Gif of what happens to the URL due to deserializing getting called before serialize which is apparent with a really slow internet connection
![emberarrays](https://user-images.githubusercontent.com/18437085/47497235-0c28bd00-d8a5-11e8-9ea3-e0be38bd4e92.gif)

Gif of what happens with a standard connection (expected behaviour)
![normalconnection](https://user-images.githubusercontent.com/18437085/47497256-21055080-d8a5-11e8-9a35-62c15b007d7b.gif)



Related issues: 
https://github.com/emberjs/ember.js/issues/14174
https://github.com/emberjs/ember.js/issues/13591
https://github.com/emberjs/ember.js/pull/14171