### PR TITLE
[BUGFIX beta] Blueprints can generate components with a single word name

### DIFF
--- a/blueprints/component-addon/index.js
+++ b/blueprints/component-addon/index.js
@@ -2,12 +2,11 @@
 
 const path = require('path');
 const stringUtil = require('ember-cli-string-utils');
-const validComponentName = require('ember-cli-valid-component-name');
 const getPathOption = require('ember-cli-get-component-path-option');
 const normalizeEntityName = require('ember-cli-normalize-entity-name');
 
 module.exports = {
-  description: 'Generates a component. Name must contain a hyphen.',
+  description: 'Generates a component.',
 
   fileMapTokens: function() {
     return {
@@ -33,9 +32,7 @@ module.exports = {
   },
 
   normalizeEntityName: function(entityName) {
-    entityName = normalizeEntityName(entityName);
-
-    return validComponentName(entityName);
+    return normalizeEntityName(entityName);
   },
 
   locals: function(options) {

--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -3,13 +3,12 @@
 const path = require('path');
 const stringUtil = require('ember-cli-string-utils');
 const pathUtil = require('ember-cli-path-utils');
-const validComponentName = require('ember-cli-valid-component-name');
 const getPathOption = require('ember-cli-get-component-path-option');
 const normalizeEntityName = require('ember-cli-normalize-entity-name');
 const isModuleUnificationProject = require('../module-unification').isModuleUnificationProject;
 
 module.exports = {
-  description: 'Generates a component. Name must contain a hyphen.',
+  description: 'Generates a component.',
 
   availableOptions: [
     {
@@ -72,9 +71,7 @@ module.exports = {
   },
 
   normalizeEntityName: function(entityName) {
-    entityName = normalizeEntityName(entityName);
-
-    return validComponentName(entityName);
+    return normalizeEntityName(entityName);
   },
 
   locals: function(options) {

--- a/node-tests/blueprints/component-addon-test.js
+++ b/node-tests/blueprints/component-addon-test.js
@@ -16,6 +16,13 @@ describe('Blueprint: component-addon', function() {
       return emberNew({ target: 'addon' });
     });
 
+    it('component-addon foo', function() {
+      return emberGenerateDestroy(['component-addon', 'foo'], _file => {
+        expect(_file('app/components/foo.js')).to.contain(
+          "export { default } from 'my-addon/components/foo';"
+        );
+      });
+    });
     it('component-addon foo-bar', function() {
       return emberGenerateDestroy(['component-addon', 'foo-bar'], _file => {
         expect(_file('app/components/foo-bar.js')).to.contain(

--- a/node-tests/blueprints/component-test.js
+++ b/node-tests/blueprints/component-test.js
@@ -18,6 +18,25 @@ describe('Blueprint: component', function() {
       return emberNew();
     });
 
+    it('component foo', function() {
+      return emberGenerateDestroy(['component', 'foo'], _file => {
+        expect(_file('app/components/foo.js'))
+          .to.contain("import Component from '@ember/component';")
+          .to.contain('export default Component.extend({')
+          .to.contain('});');
+
+        expect(_file('app/templates/components/foo.hbs')).to.equal('{{yield}}');
+
+        expect(_file('tests/integration/components/foo-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('foo'")
+          .to.contain('integration: true')
+          .to.contain('{{foo}}')
+          .to.contain('{{#foo}}');
+      });
+    });
+
     it('component x-foo', function() {
       return emberGenerateDestroy(['component', 'x-foo'], _file => {
         expect(_file('app/components/x-foo.js'))
@@ -233,6 +252,25 @@ describe('Blueprint: component', function() {
         setupPodConfig({ podModulePrefix: true });
       });
 
+      it('component foo --pod', function() {
+        return emberGenerateDestroy(['component', 'foo', '--pod'], _file => {
+          expect(_file('app/pods/components/foo/component.js'))
+            .to.contain("import Component from '@ember/component';")
+            .to.contain('export default Component.extend({')
+            .to.contain('});');
+
+          expect(_file('app/pods/components/foo/template.hbs')).to.equal('{{yield}}');
+
+          expect(_file('tests/integration/pods/components/foo/component-test.js'))
+            .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+            .to.contain("import hbs from 'htmlbars-inline-precompile';")
+            .to.contain("moduleForComponent('foo'")
+            .to.contain('integration: true')
+            .to.contain('{{foo}}')
+            .to.contain('{{#foo}}');
+        });
+      });
+
       it('component x-foo --pod', function() {
         return emberGenerateDestroy(['component', 'x-foo', '--pod'], _file => {
           expect(_file('app/pods/components/x-foo/component.js'))
@@ -394,6 +432,25 @@ describe('Blueprint: component', function() {
       return emberNew().then(() => fs.ensureDirSync('src'));
     });
 
+    it('component foo', function() {
+      return emberGenerateDestroy(['component', 'foo'], _file => {
+        expect(_file('src/ui/components/foo/component.js'))
+          .to.contain("import Component from '@ember/component';")
+          .to.contain('export default Component.extend({')
+          .to.contain('});');
+
+        expect(_file('src/ui/components/foo/template.hbs')).to.equal('{{yield}}');
+
+        expect(_file('src/ui/components/foo/component-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('foo'")
+          .to.contain('integration: true')
+          .to.contain('{{foo}}')
+          .to.contain('{{#foo}}');
+      });
+    });
+
     it('component x-foo', function() {
       return emberGenerateDestroy(['component', 'x-foo'], _file => {
         expect(_file('src/ui/components/x-foo/component.js'))
@@ -436,6 +493,31 @@ describe('Blueprint: component', function() {
   describe('in addon', function() {
     beforeEach(function() {
       return emberNew({ target: 'addon' });
+    });
+
+    it('component foo', function() {
+      return emberGenerateDestroy(['component', 'foo'], _file => {
+        expect(_file('addon/components/foo.js'))
+          .to.contain("import Component from '@ember/component';")
+          .to.contain("import layout from '../templates/components/foo';")
+          .to.contain('export default Component.extend({')
+          .to.contain('layout')
+          .to.contain('});');
+
+        expect(_file('addon/templates/components/foo.hbs')).to.equal('{{yield}}');
+
+        expect(_file('app/components/foo.js')).to.contain(
+          "export { default } from 'my-addon/components/foo';"
+        );
+
+        expect(_file('tests/integration/components/foo-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('foo'")
+          .to.contain('integration: true')
+          .to.contain('{{foo}}')
+          .to.contain('{{#foo}}');
+      });
     });
 
     it('component x-foo', function() {
@@ -548,6 +630,26 @@ describe('Blueprint: component', function() {
       return emberNew({ target: 'addon' }).then(() => fs.ensureDirSync('src'));
     });
 
+    it('component foo', function() {
+      return emberGenerateDestroy(['component', 'foo'], _file => {
+        expect(_file('src/ui/components/foo/component.js'))
+          .to.contain("import Component from '@ember/component';")
+          .to.contain('export default Component.extend({')
+          .to.contain('});');
+
+        expect(_file('src/ui/components/foo/template.hbs')).to.equal('{{yield}}');
+
+        expect(_file('src/ui/components/foo/component-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('my-addon::foo'")
+          .to.contain('integration: true')
+          .to.contain('{{my-addon::foo}}')
+          .to.contain('{{#my-addon::foo}}')
+          .to.contain('{{/my-addon::foo}}');
+      });
+    });
+
     it('component x-foo', function() {
       return emberGenerateDestroy(['component', 'x-foo'], _file => {
         expect(_file('src/ui/components/x-foo/component.js'))
@@ -624,6 +726,31 @@ describe('Blueprint: component', function() {
   describe('in in-repo-addon', function() {
     beforeEach(function() {
       return emberNew({ target: 'in-repo-addon' });
+    });
+
+    it('component foo --in-repo-addon=my-addon', function() {
+      return emberGenerateDestroy(['component', 'foo', '--in-repo-addon=my-addon'], _file => {
+        expect(_file('lib/my-addon/addon/components/foo.js'))
+          .to.contain("import Component from '@ember/component';")
+          .to.contain("import layout from '../templates/components/foo';")
+          .to.contain('export default Component.extend({')
+          .to.contain('layout')
+          .to.contain('});');
+
+        expect(_file('lib/my-addon/addon/templates/components/foo.hbs')).to.equal('{{yield}}');
+
+        expect(_file('lib/my-addon/app/components/foo.js')).to.contain(
+          "export { default } from 'my-addon/components/foo';"
+        );
+
+        expect(_file('tests/integration/components/foo-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('foo'")
+          .to.contain('integration: true')
+          .to.contain('{{foo}}')
+          .to.contain('{{#foo}}');
+      });
     });
 
     it('component x-foo --in-repo-addon=my-addon', function() {
@@ -735,6 +862,24 @@ describe('Blueprint: component', function() {
   describe('in in-repo-addon - module unification', function() {
     beforeEach(function() {
       return emberNew({ target: 'in-repo-addon' }).then(() => fs.ensureDirSync('src'));
+    });
+
+    it('component foo --in-repo-addon=my-addon', function() {
+      return emberGenerateDestroy(['component', 'foo', '--in-repo-addon=my-addon'], _file => {
+        expect(_file('packages/my-addon/src/ui/components/foo/component.js'))
+          .to.contain('export default Component.extend({')
+          .to.contain('});');
+
+        expect(_file('packages/my-addon/src/ui/components/foo/template.hbs')).to.equal('{{yield}}');
+
+        expect(_file('packages/my-addon/src/ui/components/foo/component-test.js'))
+          .to.contain("import { moduleForComponent, test } from 'ember-qunit';")
+          .to.contain("import hbs from 'htmlbars-inline-precompile';")
+          .to.contain("moduleForComponent('my-addon::foo'")
+          .to.contain('integration: true')
+          .to.contain('{{#my-addon::foo}}')
+          .to.contain('{{my-addon::foo}}');
+      });
     });
 
     it('component x-foo --in-repo-addon=my-addon', function() {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "ember-cli-normalize-entity-name": "^1.0.0",
     "ember-cli-path-utils": "^1.0.0",
     "ember-cli-string-utils": "^1.1.0",
-    "ember-cli-valid-component-name": "^1.0.0",
     "ember-cli-version-checker": "^2.1.0",
     "ember-router-generator": "^1.2.3",
     "inflection": "^1.12.0",


### PR DESCRIPTION
Closes ember-cli/ember-cli#8144

This change allows the blueprint to generate component with a single word name.

`ember generate component header`

I also wonder if there is a plan to change the blueprint to use the Angle Bracket syntax.