### PR TITLE
get() / set() perf optimizations

### DIFF
--- a/packages/@ember/-internals/meta/lib/meta.ts
+++ b/packages/@ember/-internals/meta/lib/meta.ts
@@ -259,7 +259,7 @@ export class Meta {
   _findInheritedMap(key: string, subkey: string): any | undefined {
     let pointer: Meta | null = this;
     while (pointer !== null) {
-      let map : Map<string, any> = pointer[key];
+      let map: Map<string, any> = pointer[key];
       if (map !== undefined) {
         let value = map.get(subkey);
         if (value !== undefined) {
@@ -741,7 +741,7 @@ export class Meta {
     return this._listeners;
   }
 
-  matchingListeners(eventName: string): (string | boolean | object | null)[] | undefined | void {
+  matchingListeners(eventName: string): (string | boolean | object | null)[] | undefined {
     let listeners = this.flattenedListeners();
     let result;
 
@@ -858,7 +858,7 @@ export function setMeta(obj: object, meta: Meta) {
   metaStore.set(obj, meta);
 }
 
-export function peekMeta(obj: object) : Meta | null {
+export function peekMeta(obj: object): Meta | null {
   assert('Cannot call `peekMeta` on null', obj !== null);
   assert('Cannot call `peekMeta` on undefined', obj !== undefined);
   assert(

--- a/packages/@ember/-internals/meta/lib/meta.ts
+++ b/packages/@ember/-internals/meta/lib/meta.ts
@@ -845,7 +845,7 @@ export function setMeta(obj: object, meta: Meta) {
   metaStore.set(obj, meta);
 }
 
-export function peekMeta(obj: object) {
+export function peekMeta(obj: object) : Meta | null {
   assert('Cannot call `peekMeta` on null', obj !== null);
   assert('Cannot call `peekMeta` on undefined', obj !== undefined);
   assert(
@@ -884,6 +884,8 @@ export function peekMeta(obj: object) {
 
     pointer = getPrototypeOf(pointer);
   }
+
+  return null;
 }
 
 /**
@@ -909,7 +911,7 @@ export function deleteMeta(obj: object) {
   }
 
   let meta = peekMeta(obj);
-  if (meta !== undefined) {
+  if (meta !== null) {
     meta.destroy();
   }
 }
@@ -950,7 +952,7 @@ export const meta: {
   let maybeMeta = peekMeta(obj);
 
   // remove this code, in-favor of explicit parent
-  if (maybeMeta !== undefined && maybeMeta.source === obj) {
+  if (maybeMeta !== null && maybeMeta.source === obj) {
     return maybeMeta;
   }
 
@@ -972,7 +974,7 @@ if (DEBUG) {
   @return {Descriptor}
   @private
 */
-export function descriptorFor(obj: object, keyName: string, _meta?: Meta) {
+export function descriptorFor(obj: object, keyName: string, _meta?: Meta | null) {
   assert('Cannot call `descriptorFor` on null', obj !== null);
   assert('Cannot call `descriptorFor` on undefined', obj !== undefined);
   assert(
@@ -982,7 +984,7 @@ export function descriptorFor(obj: object, keyName: string, _meta?: Meta) {
 
   let meta = _meta === undefined ? peekMeta(obj) : _meta;
 
-  if (meta !== undefined) {
+  if (meta !== null) {
     return meta.peekDescriptors(keyName);
   }
 }

--- a/packages/@ember/-internals/metal/lib/chains.ts
+++ b/packages/@ember/-internals/metal/lib/chains.ts
@@ -8,7 +8,7 @@ function isObject(obj: any): obj is object {
   return typeof obj === 'object' && obj !== null;
 }
 
-function isVolatile(obj: any, keyName: string, meta?: Meta): boolean {
+function isVolatile(obj: any, keyName: string, meta?: Meta | null): boolean {
   let desc = descriptorFor(obj, keyName, meta);
   return !(desc !== undefined && desc._volatile === false);
 }
@@ -117,7 +117,7 @@ function removeChainWatcher(obj: object, keyName: string, node: ChainNode, _meta
   let meta = _meta === undefined ? peekMeta(obj) : _meta;
 
   if (
-    meta === undefined ||
+    meta === null ||
     meta.isSourceDestroying() ||
     meta.isMetaDestroyed() ||
     meta.readableChainWatchers() === undefined
@@ -336,7 +336,7 @@ function lazyGet(obj: object, key: string): any {
   let meta = peekMeta(obj);
 
   // check if object meant only to be a prototype
-  if (meta !== undefined && meta.proto === obj) {
+  if (meta !== null && meta.proto === obj) {
     return;
   }
 

--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -359,7 +359,7 @@ class ComputedProperty extends Descriptor implements DescriptorWithDependentKeys
 
     // don't create objects just to invalidate
     let meta = peekMeta(obj);
-    if (meta === undefined || meta.source !== obj) {
+    if (meta === null || meta.source !== obj) {
       return;
     }
 

--- a/packages/@ember/-internals/metal/lib/events.ts
+++ b/packages/@ember/-internals/metal/lib/events.ts
@@ -119,7 +119,8 @@ export function sendEvent(
 ) {
   if (actions === undefined) {
     let meta = _meta === undefined ? peekMeta(obj) : _meta;
-    actions = (typeof meta === 'object' && meta !== null) ? meta.matchingListeners(eventName) : undefined;
+    actions =
+      typeof meta === 'object' && meta !== null ? meta.matchingListeners(eventName) : undefined;
   }
 
   if (actions === undefined || actions.length === 0) {

--- a/packages/@ember/-internals/metal/lib/events.ts
+++ b/packages/@ember/-internals/metal/lib/events.ts
@@ -115,11 +115,11 @@ export function sendEvent(
   eventName: string,
   params: any[],
   actions?: any[],
-  _meta?: Meta
-): boolean {
+  _meta?: Meta | null
+) {
   if (actions === undefined) {
     let meta = _meta === undefined ? peekMeta(obj) : _meta;
-    actions = typeof meta === 'object' && meta !== null && meta.matchingListeners(eventName);
+    actions = (typeof meta === 'object' && meta !== null) ? meta.matchingListeners(eventName) : undefined;
   }
 
   if (actions === undefined || actions.length === 0) {
@@ -161,7 +161,7 @@ export function sendEvent(
 */
 export function hasListeners(obj: object, eventName: string): boolean {
   let meta = peekMeta(obj);
-  if (meta === undefined) {
+  if (meta === null) {
     return false;
   }
   let matched = meta.matchingListeners(eventName);

--- a/packages/@ember/-internals/metal/lib/mixin.ts
+++ b/packages/@ember/-internals/metal/lib/mixin.ts
@@ -548,7 +548,7 @@ export default class Mixin {
   static mixins(obj: object): Mixin[] {
     let meta = peekMeta(obj);
     let ret: Mixin[] = [];
-    if (meta === undefined) {
+    if (meta === null) {
       return ret;
     }
 
@@ -612,7 +612,7 @@ export default class Mixin {
       return _detect(obj, this);
     }
     let meta = peekMeta(obj);
-    if (meta === undefined) {
+    if (meta === null) {
       return false;
     }
     return meta.hasMixin(this);

--- a/packages/@ember/-internals/metal/lib/properties.ts
+++ b/packages/@ember/-internals/metal/lib/properties.ts
@@ -63,7 +63,7 @@ interface ExtendedObject {
 
 export function MANDATORY_SETTER_FUNCTION(name: string): MandatorySetterFunction {
   function SETTER_FUNCTION(this: object, value: any | undefined | null): void {
-    let m = peekMeta(this);
+    let m = peekMeta(this)!;
     if (m.isInitializing() || m.isPrototypeMeta(this)) {
       m.writeValues(name, value);
     } else {
@@ -79,7 +79,7 @@ export function MANDATORY_SETTER_FUNCTION(name: string): MandatorySetterFunction
 export function DEFAULT_GETTER_FUNCTION(name: string): DefaultGetterFunction {
   return function GETTER_FUNCTION(this: any): void {
     let meta = peekMeta(this);
-    if (meta !== undefined) {
+    if (meta !== null) {
       return meta.peekValues(name);
     }
   };
@@ -89,7 +89,7 @@ export function INHERITING_GETTER_FUNCTION(name: string): InheritingGetterFuncti
   function IGETTER_FUNCTION(this: any): void {
     let meta = peekMeta(this);
     let val;
-    if (meta !== undefined) {
+    if (meta !== null) {
       val = meta.readInheritedValue('values', name);
       if (val === UNDEFINED) {
         let proto = Object.getPrototypeOf(this);

--- a/packages/@ember/-internals/metal/lib/property_events.ts
+++ b/packages/@ember/-internals/metal/lib/property_events.ts
@@ -34,11 +34,10 @@ let deferred = 0;
   @since 3.1.0
   @public
 */
-function notifyPropertyChange(obj: object, keyName: string, _meta?: Meta): void {
+function notifyPropertyChange(obj: object, keyName: string, _meta?: Meta | null): void {
   let meta = _meta === undefined ? peekMeta(obj) : _meta;
-  let hasMeta = meta !== undefined;
 
-  if (hasMeta && (meta.isInitializing() || meta.isPrototypeMeta(obj))) {
+  if (meta !== null && (meta.isInitializing() || meta.isPrototypeMeta(obj))) {
     return;
   }
 
@@ -48,7 +47,7 @@ function notifyPropertyChange(obj: object, keyName: string, _meta?: Meta): void 
     possibleDesc.didChange(obj, keyName);
   }
 
-  if (hasMeta && meta.peekWatching(keyName) > 0) {
+  if (meta !== null && meta.peekWatching(keyName) > 0) {
     dependentKeysDidChange(obj, keyName, meta);
     chainsDidChange(obj, keyName, meta);
     notifyObservers(obj, keyName, meta);
@@ -58,7 +57,7 @@ function notifyPropertyChange(obj: object, keyName: string, _meta?: Meta): void 
     obj[PROPERTY_DID_CHANGE](keyName);
   }
 
-  if (hasMeta) {
+  if (meta !== null) {
     if (meta.isSourceDestroying()) {
       return;
     }

--- a/packages/@ember/-internals/metal/lib/property_get.ts
+++ b/packages/@ember/-internals/metal/lib/property_get.ts
@@ -133,9 +133,9 @@ export function get(obj: object, keyName: string): any {
   return value;
 }
 
-export function _getPath<T extends object>(root: T, path: string): any {
+export function _getPath<T extends object>(root: T, path: string | string[]): any {
   let obj: any = root;
-  let parts = path.split('.');
+  let parts = typeof path === 'string' ? path.split('.') : path;
 
   for (let i = 0; i < parts.length; i++) {
     if (obj === undefined || obj === null || (obj as MaybeHasIsDestroyed).isDestroyed) {

--- a/packages/@ember/-internals/metal/lib/property_get.ts
+++ b/packages/@ember/-internals/metal/lib/property_get.ts
@@ -96,6 +96,10 @@ export function get(obj: object, keyName: string): any {
   let isFunction = type === 'function';
   let isObjectLike = isObject || isFunction;
 
+  if (isPath(keyName)) {
+    return isObjectLike ? _getPath(obj, keyName) : undefined;
+  }
+
   let value: any;
 
   if (isObjectLike) {
@@ -119,9 +123,6 @@ export function get(obj: object, keyName: string): any {
   }
 
   if (value === undefined) {
-    if (isPath(keyName)) {
-      return _getPath(obj, keyName);
-    }
     if (
       isObject &&
       !(keyName in obj) &&

--- a/packages/@ember/-internals/metal/lib/property_set.ts
+++ b/packages/@ember/-internals/metal/lib/property_set.ts
@@ -145,7 +145,9 @@ function setPath(root: object, path: string, value: any, tolerant?: boolean): an
   if (newRoot !== null && newRoot !== undefined) {
     return set(newRoot, keyName, value);
   } else if (!tolerant) {
-    throw new EmberError(`Property set failed: object in path "${parts.join('.')}" could not be found.`);
+    throw new EmberError(
+      `Property set failed: object in path "${parts.join('.')}" could not be found.`
+    );
   }
 }
 

--- a/packages/@ember/-internals/metal/lib/property_set.ts
+++ b/packages/@ember/-internals/metal/lib/property_set.ts
@@ -14,7 +14,7 @@ interface ExtendedObject {
 }
 
 let setWithMandatorySetter: <T extends object, K extends Extract<keyof T, string>>(
-  meta: Meta,
+  meta: Meta | null,
   obj: T,
   keyName: K,
   value: T[K]
@@ -116,7 +116,7 @@ export function set(obj: object, keyName: string, value: any, tolerant?: boolean
 
 if (DEBUG) {
   setWithMandatorySetter = (meta, obj, keyName, value) => {
-    if (meta !== undefined && meta.peekWatching(keyName) > 0) {
+    if (meta !== null && meta.peekWatching(keyName) > 0) {
       makeEnumerable(obj, keyName);
       meta.writeValue(obj, keyName, value);
     } else {

--- a/packages/@ember/-internals/metal/lib/property_set.ts
+++ b/packages/@ember/-internals/metal/lib/property_set.ts
@@ -136,17 +136,16 @@ if (DEBUG) {
 
 function setPath(root: object, path: string, value: any, tolerant?: boolean): any {
   let parts = path.split('.');
-  let keyName = parts.pop() as string;
+  let keyName = parts.pop()!;
 
-  assert('Property set failed: You passed an empty path', keyName!.trim().length > 0);
+  assert('Property set failed: You passed an empty path', keyName.trim().length > 0);
 
-  let newPath = parts.join('.');
-  let newRoot = getPath(root, newPath);
+  let newRoot = getPath(root, parts);
 
   if (newRoot !== null && newRoot !== undefined) {
     return set(newRoot, keyName, value);
   } else if (!tolerant) {
-    throw new EmberError(`Property set failed: object in path "${newPath}" could not be found.`);
+    throw new EmberError(`Property set failed: object in path "${parts.join('.')}" could not be found.`);
   }
 }
 

--- a/packages/@ember/-internals/metal/lib/watch_key.ts
+++ b/packages/@ember/-internals/metal/lib/watch_key.ts
@@ -94,7 +94,7 @@ export function unwatchKey(obj: object, keyName: string, _meta?: Meta): void {
   let meta = _meta === undefined ? peekMeta(obj) : _meta;
 
   // do nothing of this object has already been destroyed
-  if (meta === undefined || meta.isSourceDestroyed()) {
+  if (meta === null || meta.isSourceDestroyed()) {
     return;
   }
 

--- a/packages/@ember/-internals/metal/lib/watch_path.ts
+++ b/packages/@ember/-internals/metal/lib/watch_path.ts
@@ -14,7 +14,7 @@ export function watchPath(obj: any, keyPath: string, meta?: Meta): void {
 
 export function unwatchPath(obj: any, keyPath: string, meta?: Meta): void {
   let m = meta === undefined ? peekMeta(obj) : meta;
-  if (m === undefined) {
+  if (m === null) {
     return;
   }
   let counter = m.peekWatching(keyPath);

--- a/packages/@ember/-internals/metal/lib/watching.ts
+++ b/packages/@ember/-internals/metal/lib/watching.ts
@@ -33,7 +33,7 @@ export function isWatching(obj: any, key: string): boolean {
 
 export function watcherCount(obj: any, key: string): number {
   let meta = peekMeta(obj);
-  return (meta !== undefined && meta.peekWatching(key)) || 0;
+  return (meta !== null && meta.peekWatching(key)) || 0;
 }
 
 /**

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -1334,7 +1334,7 @@ moduleFor(
         Route.extend({
           model(p, trans) {
             let m = peekMeta(trans[PARAMS_SYMBOL].application);
-            assert.ok(m === undefined, "A meta object isn't constructed for this params POJO");
+            assert.ok(m === null, "A meta object isn't constructed for this params POJO");
           },
         })
       );


### PR DESCRIPTION
I noticed that the ember-performance Chrome scores of `get()` and `set()` dropped dramatically when `ember-metal-es5-getters` was enabled, so I had a look at it.

I have managed to mostly bring it back for `get()`, and improve it for `set()` using the included patches. Both are roughly 2x the canary performance. Additionally, it seems to have improved the `run()` benchmark as well.

All the patches should work individually, in case you only think some of them are suitable.

**Chrome**
```
User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.20 Safari/537.36

.------------------------------------------------------------------------.
|                   Ember Performance Suite - Results                    |
|------------------------------------------------------------------------|
|         Name         |       Speed        | Error  | Samples |  Mean   |
|----------------------|--------------------|--------|---------|---------|
|  -- Ember 3.0.0 --   |                    |        |         |         |
| Ember.get            | 1,626,872.70 / sec | ∓1.08% | 64      | 0.00 ms |
| Ember.run            | 670,554.44 / sec   | ∓2.42% | 65      | 0.00 ms |
| Ember.set            | 606,311.51 / sec   | ∓1.12% | 64      | 0.00 ms |
|  -- Ember 3.4.5 --   |                    |        |         |         |
| Ember.get            | 770,484.17 / sec   | ∓1.65% | 61      | 0.00 ms |
| Ember.run            | 710,395.41 / sec   | ∓6.42% | 58      | 0.00 ms |
| Ember.set            | 408,123.26 / sec   | ∓0.47% | 65      | 0.00 ms |
|  -- Ember canary --  |                    |        |         |         |
| Ember.get            | 858,315.30 / sec   | ∓0.96% | 61      | 0.00 ms |
| Ember.run            | 739,482.59 / sec   | ∓0.34% | 66      | 0.00 ms |
| Ember.set            | 453,404.65 / sec   | ∓0.61% | 65      | 0.00 ms |
|  -- Ember dev --     |                    |        |         |         |
| Ember.get            | 1,487,276.86 / sec | ∓1.04% | 63      | 0.00 ms |
| Ember.run            | 818,811.25 / sec   | ∓0.53% | 66      | 0.00 ms |
| Ember.set            | 996,207.06 / sec   | ∓1.33% | 61      | 0.00 ms |
'------------------------------------------------------------------------'
```

**Safari**
```
User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0.1 Safari/605.1.15

.------------------------------------------------------------------------.
|                   Ember Performance Suite - Results                    |
|------------------------------------------------------------------------|
|         Name         |       Speed        | Error  | Samples |  Mean   |
|----------------------|--------------------|--------|---------|---------|
|  -- Ember 3.0.0 --   |                    |        |         |         |
| Ember.get            | 1,024,541.17 / sec | ∓0.93% | 62      | 0.00 ms |
| Ember.run            | 216,263.15 / sec   | ∓3.47% | 37      | 0.00 ms |
| Ember.set            | 711,296.65 / sec   | ∓0.99% | 64      | 0.00 ms |
|  -- Ember 3.4.5 --   |                    |        |         |         |
| Ember.get            | 660,504.61 / sec   | ∓0.83% | 62      | 0.00 ms |
| Ember.run            | 227,034.91 / sec   | ∓3.44% | 36      | 0.00 ms |
| Ember.set            | 393,704.49 / sec   | ∓0.93% | 63      | 0.00 ms |
|  -- Ember canary --  |                    |        |         |         |
| Ember.get            | 888,268.20 / sec   | ∓0.96% | 61      | 0.00 ms |
| Ember.run            | 236,605.91 / sec   | ∓3.75% | 36      | 0.00 ms |
| Ember.set            | 490,658.82 / sec   | ∓0.80% | 63      | 0.00 ms |
|  -- Ember dev --     |                    |        |         |         |
| Ember.get            | 952,592.90 / sec   | ∓0.96% | 63      | 0.00 ms |
| Ember.run            | 256,341.28 / sec   | ∓3.60% | 37      | 0.00 ms |
| Ember.set            | 690,086.43 / sec   | ∓1.09% | 62      | 0.00 ms |
'------------------------------------------------------------------------'
```