### PR TITLE
[BUGFIX] Adds default implementations of Component lifecycle hooks

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -751,6 +751,7 @@ const Component = CoreView.extend(
      @public
      @since 1.13.0
      */
+    didReceiveAttrs() {},
 
     /**
      Called when the attributes passed into the component have been updated.
@@ -769,6 +770,7 @@ const Component = CoreView.extend(
      @public
      @since 1.13.0
      */
+    didRender() {},
 
     /**
      Called after a component has been rendered, both on initial render and
@@ -785,6 +787,7 @@ const Component = CoreView.extend(
      @public
      @since 1.13.0
      */
+    willRender() {},
 
     /**
      Called before a component has been rendered, both on initial render and
@@ -801,6 +804,7 @@ const Component = CoreView.extend(
      @public
      @since 1.13.0
      */
+    didUpdateAttrs() {},
 
     /**
      Called when the attributes passed into the component have been changed.
@@ -817,6 +821,7 @@ const Component = CoreView.extend(
      @public
      @since 1.13.0
      */
+    willUpdate() {},
 
     /**
      Called when the component is about to update and rerender itself.
@@ -833,6 +838,7 @@ const Component = CoreView.extend(
      @public
      @since 1.13.0
      */
+    didUpdate() {},
 
     /**
      Called when the component has updated and rerendered itself.

--- a/packages/@ember/-internals/glimmer/tests/integration/components/life-cycle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/life-cycle-test.js
@@ -1571,6 +1571,24 @@ moduleFor(
         ]
       );
     }
+
+    ['@test lifecycle hooks exist on the base class'](assert) {
+      // Make sure we get the finalized component prototype
+      let prototype = Component.proto();
+
+      assert.equal(typeof prototype.didDestroyElement, 'function', 'didDestroyElement exists');
+      assert.equal(typeof prototype.didInsertElement, 'function', 'didInsertElement exists');
+      assert.equal(typeof prototype.didReceiveAttrs, 'function', 'didReceiveAttrs exists');
+      assert.equal(typeof prototype.didRender, 'function', 'didRender exists');
+      assert.equal(typeof prototype.didUpdate, 'function', 'didUpdate exists');
+      assert.equal(typeof prototype.didUpdateAttrs, 'function', 'didUpdateAttrs exists');
+      assert.equal(typeof prototype.willClearRender, 'function', 'willClearRender exists');
+      assert.equal(typeof prototype.willDestroy, 'function', 'willDestroy exists');
+      assert.equal(typeof prototype.willDestroyElement, 'function', 'willDestroyElement exists');
+      assert.equal(typeof prototype.willInsertElement, 'function', 'willInsertElement exists');
+      assert.equal(typeof prototype.willRender, 'function', 'willRender exists');
+      assert.equal(typeof prototype.willUpdate, 'function', 'willUpdate exists');
+    }
   }
 );
 

--- a/packages/@ember/-internals/views/lib/mixins/view_support.js
+++ b/packages/@ember/-internals/views/lib/mixins/view_support.js
@@ -370,6 +370,14 @@ export default Mixin.create({
   willDestroyElement: K,
 
   /**
+    Called after the element of the view is destroyed.
+
+    @event willDestroyElement
+    @public
+  */
+  didDestroyElement: K,
+
+  /**
     Called when the parentView property has changed.
 
     @event parentViewDidChange


### PR DESCRIPTION
Adds default implementations for all of `Ember.Component`'s lifecycle hooks. Fixes #17156.

There are some notable concerns here:

1. Performance, default implementations means that we will be doing slightly more work in cases where users are calling `_super` in a hook which did not have a default implementation. This may be worth benchmarking, but I'm unsure if it would make that much of a difference.
2. The `didDestroyElement` hook was not previously documented, and may not have been considered public API. It is under test, and there are no internal usages of it besides test, so it may be a better idea to not publicly expose it and deprecate/remove it instead.

The alternative would be to remove lifecycle hook defaults entirely. As long as we're consistent in telling users "always call `super`" or "never call `super` unless its your own code" I think it would be fine. The current situation, where we sometimes-do-and-sometimes-don't, is the worst of both worlds. Removing lifecycle hooks entirely may require a deprecation.