### PR TITLE
[FEATURE] allow to disable mandatory setters

### DIFF
--- a/packages/ember-environment/lib/env.ts
+++ b/packages/ember-environment/lib/env.ts
@@ -63,6 +63,19 @@ export const ENV = {
   */
   LOG_VERSION: true,
 
+  /**
+   The `MANDATORY_SETTERS` property, when true, tells Ember
+   that setting observed values needs to be done by Ember.set
+   Added to allow notifyPropertyChange still be used.
+
+   @property MANDATORY_SETTERS
+   @type Boolean
+   @default true
+   @for EmberENV
+   @public
+   */
+  MANDATORY_SETTERS: true,
+
   RAISE_ON_DEPRECATION: false,
 
   STRUCTURED_PROFILE: false,

--- a/packages/ember-metal/lib/properties.ts
+++ b/packages/ember-metal/lib/properties.ts
@@ -4,6 +4,7 @@
 
 import { assert } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
+import { ENV } from 'ember-environment';
 import { descriptorFor, Meta, meta as metaFor, peekMeta, UNDEFINED } from 'ember-meta';
 import { overrideChains } from './property_events';
 
@@ -201,7 +202,7 @@ export function defineProperty(
   } else if (desc === undefined || desc === null) {
     value = data;
 
-    if (DEBUG && watching) {
+    if (DEBUG && ENV.MANDATORY_SETTERS && watching) {
       meta.writeValues(keyName, data);
 
       let defaultDescriptor = {

--- a/packages/ember-metal/lib/watch_key.ts
+++ b/packages/ember-metal/lib/watch_key.ts
@@ -1,4 +1,5 @@
 import { DEBUG } from '@glimmer/env';
+import { ENV } from 'ember-environment';
 import {
   descriptorFor,
   isDescriptor,
@@ -43,14 +44,14 @@ export function watchKey(obj: object, keyName: string, _meta?: Meta) {
       (obj as MaybeHasWillWatchProperty).willWatchProperty!(keyName);
     }
 
-    if (DEBUG) {
+    if (DEBUG && ENV.MANDATORY_SETTERS) {
       // NOTE: this is dropped for prod + minified builds
       handleMandatorySetter(meta, obj, keyName);
     }
   }
 }
 
-if (DEBUG) {
+if (DEBUG && ENV.MANDATORY_SETTERS) {
   let hasOwnProperty = (obj: object, key: string) => Object.prototype.hasOwnProperty.call(obj, key);
   let propertyIsEnumerable = (obj: object, key: string) =>
     Object.prototype.propertyIsEnumerable.call(obj, key);
@@ -113,7 +114,7 @@ export function unwatchKey(obj: object, keyName: string, _meta?: Meta) {
       (obj as MaybeHasDidUnwatchProperty).didUnwatchProperty!(keyName);
     }
 
-    if (DEBUG) {
+    if (DEBUG && ENV.MANDATORY_SETTERS) {
       // It is true, the following code looks quite WAT. But have no fear, It
       // exists purely to improve development ergonomics and is removed from
       // ember.min.js and ember.prod.js builds.

--- a/packages/ember-runtime/tests/system/object/create_test.js
+++ b/packages/ember-runtime/tests/system/object/create_test.js
@@ -3,6 +3,7 @@ import { computed, Mixin, observer } from 'ember-metal';
 import { DEBUG } from '@glimmer/env';
 import EmberObject from '../../../lib/system/object';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { ENV } from 'ember-environment';
 
 moduleFor(
   'EmberObject.create',
@@ -47,6 +48,28 @@ moduleFor(
       } else {
         assert.expect(0);
       }
+    }
+
+    ['@test does not set up mandatory setters when mandatory setters are not enabled'](assert) {
+      let originalEnvValue = ENV.MANDATORY_SETTERS;
+      ENV.MANDATORY_SETTERS = false;
+
+      if (DEBUG) {
+        let MyClass = EmberObject.extend({
+          foo: null,
+          fooDidChange: observer('foo', function() {}),
+        });
+
+        let o = MyClass.create({ foo: 'bar', bar: 'baz' });
+        assert.equal(o.get('foo'), 'bar');
+
+        let descriptor = Object.getOwnPropertyDescriptor(o, 'foo');
+        assert.ok(!descriptor.set, 'Mandatory setter was not setup');
+      } else {
+        assert.expect(0);
+      }
+
+      ENV.MANDATORY_SETTERS = originalEnvValue;
     }
 
     ['@test calls setUnknownProperty if defined'](assert) {


### PR DESCRIPTION
Hi all, :) 

This PR adds new ENV field, to allow us to disable mandatory setters (the ability to do so was removed in this PR: https://github.com/emberjs/ember.js/pull/16538/files and prevented us from updating to Ember 3.4 LTS). 

The reason for that is, that we have a large shared library of complex non-ember domain models, which needs to be integrated into Ember app.  Mainly due to performance reasons (and also complexity) of alternative solutions like proxying objects, we used to integrate them using notifyPropertyChange (which is part of public Ember API - https://www.emberjs.com/api/ember/3.5/classes/Observable/methods/notifyPropertyChange?anchor=notifyPropertyChange). Due to removal of that feature flag we cannot use notifyPropertyChange anymore.

 I guess this isn’t a common use case, but without that, we would be forced to rewrite loads of stuff.