### PR TITLE
[BUGFIX] Ensures removeAllListeners doesn't break subsequent adds

### DIFF
--- a/packages/@ember/-internals/meta/lib/meta.ts
+++ b/packages/@ember/-internals/meta/lib/meta.ts
@@ -619,6 +619,10 @@ export class Meta {
       } else {
         // update own listener
         listener.kind = kind;
+
+        // TODO: Remove this when removing REMOVE_ALL, it won't be necessary
+        listener.target = target;
+        listener.method = method;
       }
     }
   }

--- a/packages/@ember/-internals/meta/tests/listeners_test.js
+++ b/packages/@ember/-internals/meta/tests/listeners_test.js
@@ -155,5 +155,31 @@ moduleFor(
         'one reopen call after mutating parents and flattening out of order'
       );
     }
+
+    ['@test REMOVE_ALL does not interfere with future adds'](assert) {
+      expectDeprecation(() => {
+        let t = {};
+        let m = meta({});
+
+        m.addToListeners('hello', t, 'm', 0);
+        let matching = m.matchingListeners('hello');
+
+        assert.equal(matching.length, 3);
+        assert.equal(matching[0], t);
+
+        // Remove all listeners
+        m.removeAllListeners('hello');
+
+        matching = m.matchingListeners('hello');
+        assert.equal(matching, undefined);
+
+        m.addToListeners('hello', t, 'm', 0);
+        matching = m.matchingListeners('hello');
+
+        // listener was added back successfully
+        assert.equal(matching.length, 3);
+        assert.equal(matching[0], t);
+      });
+    }
   }
 );


### PR DESCRIPTION
This popped up as a bug in Ember Inspector because they use the REMOVE_ALL functionality during tests. REMOVE_ALL's are tricky, they don't neatly fall into the new model for listeners (which is why we are deprecating and removing them in 3.9) but for now, this should prevent that particular bug from occurring again.

Resolves #17183