### PR TITLE
[BUGFIX beta] Fix RouteInfo QP mutability

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "puppeteer": "^1.3.0",
     "qunit": "^2.5.0",
     "route-recognizer": "^0.3.4",
-    "router_js": "^6.0.2",
+    "router_js": "^6.0.3",
     "rsvp": "^4.8.2",
     "semver": "^5.5.0",
     "serve-static": "^1.12.2",

--- a/packages/ember/tests/routing/router_service_test/events_test.js
+++ b/packages/ember/tests/routing/router_service_test/events_test.js
@@ -381,7 +381,7 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
       }
 
       '@test query param transitions'(assert) {
-        assert.expect(9);
+        assert.expect(15);
         let initial = true;
         let addQP = false;
         let removeQP = false;
@@ -396,10 +396,13 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
               this.router.on('routeWillChange', transition => {
                 assert.equal(transition.to.name, 'parent.index');
                 if (initial) {
+                  assert.equal(transition.from, null);
                   assert.deepEqual(transition.to.queryParams, { a: 'true' });
                 } else if (addQP) {
+                  assert.deepEqual(transition.from.queryParams, { a: 'true' });
                   assert.deepEqual(transition.to.queryParams, { a: 'false', b: 'b' });
                 } else if (removeQP) {
+                  assert.deepEqual(transition.from.queryParams, { a: 'false', b: 'b' });
                   assert.deepEqual(transition.to.queryParams, { a: 'false' });
                 } else {
                   assert.ok(false, 'never');
@@ -408,10 +411,13 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
 
               this.router.on('routeDidChange', transition => {
                 if (initial) {
+                  assert.equal(transition.from, null);
                   assert.deepEqual(transition.to.queryParams, { a: 'true' });
                 } else if (addQP) {
+                  assert.deepEqual(transition.from.queryParams, { a: 'true' });
                   assert.deepEqual(transition.to.queryParams, { a: 'false', b: 'b' });
                 } else if (removeQP) {
+                  assert.deepEqual(transition.from.queryParams, { a: 'false', b: 'b' });
                   assert.deepEqual(transition.to.queryParams, { a: 'false' });
                 } else {
                   assert.ok(false, 'never');

--- a/packages/ember/tests/routing/router_service_test/recognize_test.js
+++ b/packages/ember/tests/routing/router_service_test/recognize_test.js
@@ -135,6 +135,8 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
         );
         return this.visit('/')
           .then(() => {
+            this.routerService.on('routeWillChange', () => assert.ok(false));
+            this.routerService.on('routeDidChange', () => assert.ok(false));
             return this.routerService.recognizeAndLoad('/child');
           })
           .then(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7378,10 +7378,10 @@ route-recognizer@^0.3.4:
   resolved "https://registry.yarnpkg.com/route-recognizer/-/route-recognizer-0.3.4.tgz#39ab1ffbce1c59e6d2bdca416f0932611e4f3ca3"
   integrity sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==
 
-router_js@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/router_js/-/router_js-6.0.2.tgz#4c759e519b7091067a246d7245935822ee53d73e"
-  integrity sha512-JkSkMIpVCvkC/RQCXgTTfIgW4/IiyHJcwxcwe47UKGGDaLkt+hS8HO0RwhyaeUqEnkDxnEQkLj44kBL2pNw6JQ==
+router_js@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/router_js/-/router_js-6.0.3.tgz#e92fa07e67342336d6a05242e37ab7857685e935"
+  integrity sha512-bbLjRaq/60+4GBJvDQX/L4GAURiytYbTIYlX09EqUsvHwtYBJ+xA50e5x1eVTxUEHuxtTFwHtSdJA9qWnjV8MA==
   dependencies:
     "@types/node" "^10.5.5"
 


### PR DESCRIPTION
This does 2 things:

- Introduces a fix for QPs being incorrect between the `routeWillChange` and `routeDidChange` events
- It freezes the `RouteInfo` objects during DEBUG