### PR TITLE
remove redundant arg flipping in Evented#one

### DIFF
--- a/packages/@ember/-internals/runtime/lib/mixins/evented.js
+++ b/packages/@ember/-internals/runtime/lib/mixins/evented.js
@@ -94,11 +94,6 @@ export default Mixin.create({
     @public
   */
   one(name, target, method) {
-    if (!method) {
-      method = target;
-      target = null;
-    }
-
     addListener(this, name, target, method, true);
     return this;
   },


### PR DESCRIPTION
argument swapping is done in `addListener` downstream already