### PR TITLE
Refactor controller blueprint tests to use fixtures

### DIFF
--- a/node-tests/blueprints/controller-test-test.js
+++ b/node-tests/blueprints/controller-test-test.js
@@ -21,19 +21,25 @@ describe('Blueprint: controller-test', function() {
       return emberNew();
     });
 
-    it('controller-test foo', function() {
-      return emberGenerateDestroy(['controller-test', 'foo'], _file => {
-        expect(_file('tests/unit/controllers/foo-test.js')).to.equal(
-          fixture('controller-test/default.js')
-        );
+    describe('with ember-cli-qunit@4.1.0', function() {
+      beforeEach(function() {
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0');
       });
-    });
 
-    it('controller-test foo/bar', function() {
-      return emberGenerateDestroy(['controller-test', 'foo/bar'], _file => {
-        expect(_file('tests/unit/controllers/foo/bar-test.js')).to.equal(
-          fixture('controller-test/default-nested.js')
-        );
+      it('controller-test foo', function() {
+        return emberGenerateDestroy(['controller-test', 'foo'], _file => {
+          expect(_file('tests/unit/controllers/foo-test.js')).to.equal(
+            fixture('controller-test/default.js')
+          );
+        });
+      });
+
+      it('controller-test foo/bar', function() {
+        return emberGenerateDestroy(['controller-test', 'foo/bar'], _file => {
+          expect(_file('tests/unit/controllers/foo/bar-test.js')).to.equal(
+            fixture('controller-test/default-nested.js')
+          );
+        });
       });
     });
 
@@ -143,19 +149,25 @@ describe('Blueprint: controller-test', function() {
       return emberNew().then(() => fs.ensureDirSync('src'));
     });
 
-    it('controller-test foo', function() {
-      return emberGenerateDestroy(['controller-test', 'foo'], _file => {
-        expect(_file('src/ui/routes/foo/controller-test.js')).to.equal(
-          fixture('controller-test/default.js')
-        );
+    describe('with ember-cli-qunit@4.1.0', function() {
+      beforeEach(function() {
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0');
       });
-    });
 
-    it('controller-test foo/bar', function() {
-      return emberGenerateDestroy(['controller-test', 'foo/bar'], _file => {
-        expect(_file('src/ui/routes/foo/bar/controller-test.js')).to.equal(
-          fixture('controller-test/default-nested.js')
-        );
+      it('controller-test foo', function() {
+        return emberGenerateDestroy(['controller-test', 'foo'], _file => {
+          expect(_file('src/ui/routes/foo/controller-test.js')).to.equal(
+            fixture('controller-test/default.js')
+          );
+        });
+      });
+
+      it('controller-test foo/bar', function() {
+        return emberGenerateDestroy(['controller-test', 'foo/bar'], _file => {
+          expect(_file('src/ui/routes/foo/bar/controller-test.js')).to.equal(
+            fixture('controller-test/default-nested.js')
+          );
+        });
       });
     });
 
@@ -262,7 +274,9 @@ describe('Blueprint: controller-test', function() {
 
   describe('in addon', function() {
     beforeEach(function() {
-      return emberNew({ target: 'addon' });
+      return emberNew({ target: 'addon' }).then(() =>
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0')
+      );
     });
 
     it('controller-test foo', function() {
@@ -284,7 +298,9 @@ describe('Blueprint: controller-test', function() {
 
   describe('in addon - module unification', function() {
     beforeEach(function() {
-      return emberNew().then(() => fs.ensureDirSync('src'));
+      return emberNew()
+        .then(() => fs.ensureDirSync('src'))
+        .then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
     });
 
     it('controller-test foo', function() {

--- a/node-tests/blueprints/controller-test.js
+++ b/node-tests/blueprints/controller-test.js
@@ -11,59 +11,58 @@ const chai = require('ember-cli-blueprint-test-helpers/chai');
 const fs = require('fs-extra');
 const expect = chai.expect;
 
+const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
+const fixture = require('../helpers/fixture');
+
 describe('Blueprint: controller', function() {
   setupTestHooks(this);
 
   describe('in app', function() {
     beforeEach(function() {
-      return emberNew();
+      return emberNew().then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
     });
 
     it('controller foo', function() {
       return emberGenerateDestroy(['controller', 'foo'], _file => {
-        expect(_file('app/controllers/foo.js'))
-          .to.contain("import Controller from '@ember/controller';")
-          .to.contain('export default Controller.extend({\n});');
+        expect(_file('app/controllers/foo.js')).to.equal(fixture('controller/controller.js'));
 
-        expect(_file('tests/unit/controllers/foo-test.js'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('controller:foo'");
+        expect(_file('tests/unit/controllers/foo-test.js')).to.equal(
+          fixture('controller-test/default.js')
+        );
       });
     });
 
     it('controller foo/bar', function() {
       return emberGenerateDestroy(['controller', 'foo/bar'], _file => {
-        expect(_file('app/controllers/foo/bar.js'))
-          .to.contain("import Controller from '@ember/controller';")
-          .to.contain('export default Controller.extend({\n});');
+        expect(_file('app/controllers/foo/bar.js')).to.equal(
+          fixture('controller/controller-nested.js')
+        );
 
-        expect(_file('tests/unit/controllers/foo/bar-test.js'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('controller:foo/bar'");
+        expect(_file('tests/unit/controllers/foo/bar-test.js')).to.equal(
+          fixture('controller-test/default-nested.js')
+        );
       });
     });
 
     it('controller foo --pod', function() {
       return emberGenerateDestroy(['controller', 'foo', '--pod'], _file => {
-        expect(_file('app/foo/controller.js'))
-          .to.contain("import Controller from '@ember/controller';")
-          .to.contain('export default Controller.extend({\n});');
+        expect(_file('app/foo/controller.js')).to.equal(fixture('controller/controller.js'));
 
-        expect(_file('tests/unit/foo/controller-test.js'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('controller:foo'");
+        expect(_file('tests/unit/foo/controller-test.js')).to.equal(
+          fixture('controller-test/default.js')
+        );
       });
     });
 
     it('controller foo/bar --pod', function() {
       return emberGenerateDestroy(['controller', 'foo/bar', '--pod'], _file => {
-        expect(_file('app/foo/bar/controller.js'))
-          .to.contain("import Controller from '@ember/controller';")
-          .to.contain('export default Controller.extend({\n});');
+        expect(_file('app/foo/bar/controller.js')).to.equal(
+          fixture('controller/controller-nested.js')
+        );
 
-        expect(_file('tests/unit/foo/bar/controller-test.js'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('controller:foo/bar'");
+        expect(_file('tests/unit/foo/bar/controller-test.js')).to.equal(
+          fixture('controller-test/default-nested.js')
+        );
       });
     });
 
@@ -74,25 +73,23 @@ describe('Blueprint: controller', function() {
 
       it('controller foo --pod podModulePrefix', function() {
         return emberGenerateDestroy(['controller', 'foo', '--pod'], _file => {
-          expect(_file('app/pods/foo/controller.js'))
-            .to.contain("import Controller from '@ember/controller';")
-            .to.contain('export default Controller.extend({\n});');
+          expect(_file('app/pods/foo/controller.js')).to.equal(fixture('controller/controller.js'));
 
-          expect(_file('tests/unit/pods/foo/controller-test.js'))
-            .to.contain("import { moduleFor, test } from 'ember-qunit';")
-            .to.contain("moduleFor('controller:foo'");
+          expect(_file('tests/unit/pods/foo/controller-test.js')).to.equal(
+            fixture('controller-test/default.js')
+          );
         });
       });
 
       it('controller foo/bar --pod podModulePrefix', function() {
         return emberGenerateDestroy(['controller', 'foo/bar', '--pod'], _file => {
-          expect(_file('app/pods/foo/bar/controller.js'))
-            .to.contain("import Controller from '@ember/controller';")
-            .to.contain('export default Controller.extend({\n});');
+          expect(_file('app/pods/foo/bar/controller.js')).to.equal(
+            fixture('controller/controller-nested.js')
+          );
 
-          expect(_file('tests/unit/pods/foo/bar/controller-test.js'))
-            .to.contain("import { moduleFor, test } from 'ember-qunit';")
-            .to.contain("moduleFor('controller:foo/bar'");
+          expect(_file('tests/unit/pods/foo/bar/controller-test.js')).to.equal(
+            fixture('controller-test/default-nested.js')
+          );
         });
       });
     });
@@ -100,46 +97,46 @@ describe('Blueprint: controller', function() {
 
   describe('in addon', function() {
     beforeEach(function() {
-      return emberNew({ target: 'addon' });
+      return emberNew({ target: 'addon' }).then(() =>
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0')
+      );
     });
 
     it('controller foo', function() {
       return emberGenerateDestroy(['controller', 'foo'], _file => {
-        expect(_file('addon/controllers/foo.js'))
-          .to.contain("import Controller from '@ember/controller';")
-          .to.contain('export default Controller.extend({\n});');
+        expect(_file('addon/controllers/foo.js')).to.equal(fixture('controller/controller.js'));
 
         expect(_file('app/controllers/foo.js')).to.contain(
           "export { default } from 'my-addon/controllers/foo';"
         );
 
-        expect(_file('tests/unit/controllers/foo-test.js'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('controller:foo'");
+        expect(_file('tests/unit/controllers/foo-test.js')).to.equal(
+          fixture('controller-test/default.js')
+        );
       });
     });
 
     it('controller foo/bar', function() {
       return emberGenerateDestroy(['controller', 'foo/bar'], _file => {
-        expect(_file('addon/controllers/foo/bar.js'))
-          .to.contain("import Controller from '@ember/controller';")
-          .to.contain('export default Controller.extend({\n});');
+        expect(_file('addon/controllers/foo/bar.js')).to.equal(
+          fixture('controller/controller-nested.js')
+        );
 
         expect(_file('app/controllers/foo/bar.js')).to.contain(
           "export { default } from 'my-addon/controllers/foo/bar';"
         );
 
-        expect(_file('tests/unit/controllers/foo/bar-test.js'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('controller:foo/bar'");
+        expect(_file('tests/unit/controllers/foo/bar-test.js')).to.equal(
+          fixture('controller-test/default-nested.js')
+        );
       });
     });
 
     it('controller foo --dummy', function() {
       return emberGenerateDestroy(['controller', 'foo', '--dummy'], _file => {
-        expect(_file('tests/dummy/app/controllers/foo.js'))
-          .to.contain("import Controller from '@ember/controller';")
-          .to.contain('export default Controller.extend({\n});');
+        expect(_file('tests/dummy/app/controllers/foo.js')).to.equal(
+          fixture('controller/controller.js')
+        );
 
         expect(_file('app/controllers/foo-test.js')).to.not.exist;
 
@@ -149,9 +146,9 @@ describe('Blueprint: controller', function() {
 
     it('controller foo/bar --dummy', function() {
       return emberGenerateDestroy(['controller', 'foo/bar', '--dummy'], _file => {
-        expect(_file('tests/dummy/app/controllers/foo/bar.js'))
-          .to.contain("import Controller from '@ember/controller';")
-          .to.contain('export default Controller.extend({\n});');
+        expect(_file('tests/dummy/app/controllers/foo/bar.js')).to.equal(
+          fixture('controller/controller-nested.js')
+        );
 
         expect(_file('app/controllers/foo/bar.js')).to.not.exist;
 
@@ -162,30 +159,32 @@ describe('Blueprint: controller', function() {
 
   describe('in app - module unification', function() {
     beforeEach(function() {
-      return emberNew().then(() => fs.ensureDirSync('src'));
+      return emberNew()
+        .then(() => fs.ensureDirSync('src'))
+        .then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
     });
 
     it('controller foo', function() {
       return emberGenerateDestroy(['controller', 'foo'], _file => {
-        expect(_file('src/ui/routes/foo/controller.js'))
-          .to.contain("import Controller from '@ember/controller';")
-          .to.contain('export default Controller.extend({\n});');
+        expect(_file('src/ui/routes/foo/controller.js')).to.equal(
+          fixture('controller/controller.js')
+        );
 
-        expect(_file('src/ui/routes/foo/controller-test.js'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('controller:foo'");
+        expect(_file('src/ui/routes/foo/controller-test.js')).to.equal(
+          fixture('controller-test/default.js')
+        );
       });
     });
 
     it('controller foo/bar', function() {
       return emberGenerateDestroy(['controller', 'foo/bar'], _file => {
-        expect(_file('src/ui/routes/foo/bar/controller.js'))
-          .to.contain("import Controller from '@ember/controller';")
-          .to.contain('export default Controller.extend({\n});');
+        expect(_file('src/ui/routes/foo/bar/controller.js')).to.equal(
+          fixture('controller/controller-nested.js')
+        );
 
-        expect(_file('src/ui/routes/foo/bar/controller-test.js'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('controller:foo/bar'");
+        expect(_file('src/ui/routes/foo/bar/controller-test.js')).to.equal(
+          fixture('controller-test/default-nested.js')
+        );
       });
     });
 
@@ -205,18 +204,20 @@ describe('Blueprint: controller', function() {
 
   describe('in addon - module unification', function() {
     beforeEach(function() {
-      return emberNew({ target: 'addon' }).then(() => fs.ensureDirSync('src'));
+      return emberNew({ target: 'addon' })
+        .then(() => fs.ensureDirSync('src'))
+        .then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
     });
 
     it('controller foo', function() {
       return emberGenerateDestroy(['controller', 'foo'], _file => {
-        expect(_file('src/ui/routes/foo/controller.js'))
-          .to.contain("import Controller from '@ember/controller';")
-          .to.contain('export default Controller.extend({\n});');
+        expect(_file('src/ui/routes/foo/controller.js')).to.equal(
+          fixture('controller/controller.js')
+        );
 
-        expect(_file('src/ui/routes/foo/controller-test.js'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('controller:foo'");
+        expect(_file('src/ui/routes/foo/controller-test.js')).to.equal(
+          fixture('controller-test/default.js')
+        );
 
         expect(_file('app/controllers/foo.js')).to.not.exist;
       });
@@ -224,13 +225,13 @@ describe('Blueprint: controller', function() {
 
     it('controller foo/bar', function() {
       return emberGenerateDestroy(['controller', 'foo/bar'], _file => {
-        expect(_file('src/ui/routes/foo/bar/controller.js'))
-          .to.contain("import Controller from '@ember/controller';")
-          .to.contain('export default Controller.extend({\n});');
+        expect(_file('src/ui/routes/foo/bar/controller.js')).to.equal(
+          fixture('controller/controller-nested.js')
+        );
 
-        expect(_file('src/ui/routes/foo/bar/controller-test.js'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('controller:foo/bar'");
+        expect(_file('src/ui/routes/foo/bar/controller-test.js')).to.equal(
+          fixture('controller-test/default-nested.js')
+        );
 
         expect(_file('app/controllers/foo/bar.js')).to.not.exist;
       });
@@ -238,9 +239,9 @@ describe('Blueprint: controller', function() {
 
     it('controller foo --dummy', function() {
       return emberGenerateDestroy(['controller', 'foo', '--dummy'], _file => {
-        expect(_file('tests/dummy/src/ui/routes/foo/controller.js'))
-          .to.contain("import Controller from '@ember/controller';")
-          .to.contain('export default Controller.extend({\n});');
+        expect(_file('tests/dummy/src/ui/routes/foo/controller.js')).to.equal(
+          fixture('controller/controller.js')
+        );
 
         expect(_file('src/ui/routes/foo/controller.js')).to.not.exist;
 
@@ -250,9 +251,9 @@ describe('Blueprint: controller', function() {
 
     it('controller foo/bar --dummy', function() {
       return emberGenerateDestroy(['controller', 'foo/bar', '--dummy'], _file => {
-        expect(_file('tests/dummy/src/ui/routes/foo/bar/controller.js'))
-          .to.contain("import Controller from '@ember/controller';")
-          .to.contain('export default Controller.extend({\n});');
+        expect(_file('tests/dummy/src/ui/routes/foo/bar/controller.js')).to.equal(
+          fixture('controller/controller-nested.js')
+        );
 
         expect(_file('src/ui/routes/foo/bar/controller.js')).to.not.exist;
 
@@ -276,38 +277,40 @@ describe('Blueprint: controller', function() {
 
   describe('in in-repo-addon', function() {
     beforeEach(function() {
-      return emberNew({ target: 'in-repo-addon' });
+      return emberNew({ target: 'in-repo-addon' }).then(() =>
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0')
+      );
     });
 
     it('controller foo --in-repo-addon=my-addon', function() {
       return emberGenerateDestroy(['controller', 'foo', '--in-repo-addon=my-addon'], _file => {
-        expect(_file('lib/my-addon/addon/controllers/foo.js'))
-          .to.contain("import Controller from '@ember/controller';")
-          .to.contain('export default Controller.extend({\n});');
+        expect(_file('lib/my-addon/addon/controllers/foo.js')).to.equal(
+          fixture('controller/controller.js')
+        );
 
         expect(_file('lib/my-addon/app/controllers/foo.js')).to.contain(
           "export { default } from 'my-addon/controllers/foo';"
         );
 
-        expect(_file('tests/unit/controllers/foo-test.js'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('controller:foo'");
+        expect(_file('tests/unit/controllers/foo-test.js')).to.equal(
+          fixture('controller-test/default.js')
+        );
       });
     });
 
     it('controller foo/bar --in-repo-addon=my-addon', function() {
       return emberGenerateDestroy(['controller', 'foo/bar', '--in-repo-addon=my-addon'], _file => {
-        expect(_file('lib/my-addon/addon/controllers/foo/bar.js'))
-          .to.contain("import Controller from '@ember/controller';")
-          .to.contain('export default Controller.extend({\n});');
+        expect(_file('lib/my-addon/addon/controllers/foo/bar.js')).to.equal(
+          fixture('controller/controller-nested.js')
+        );
 
         expect(_file('lib/my-addon/app/controllers/foo/bar.js')).to.contain(
           "export { default } from 'my-addon/controllers/foo/bar';"
         );
 
-        expect(_file('tests/unit/controllers/foo/bar-test.js'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('controller:foo/bar'");
+        expect(_file('tests/unit/controllers/foo/bar-test.js')).to.equal(
+          fixture('controller-test/default-nested.js')
+        );
       });
     });
   });

--- a/node-tests/fixtures/controller/controller-nested.js
+++ b/node-tests/fixtures/controller/controller-nested.js
@@ -1,0 +1,4 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+});

--- a/node-tests/fixtures/controller/controller.js
+++ b/node-tests/fixtures/controller/controller.js
@@ -1,0 +1,4 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+});


### PR DESCRIPTION
### What

Use fixtures for asserting the generated files' content for the `controller` and `controller-test` blueprints, instead of hard-coding it in the tests.

The `helper` tests already do this, and if this accepted I would like to follow up on this with all the other blueprint tests.

### Why?

I find it easier to read and maintain here. But the main motivation is updating and maintaining the [blueprints for ember-cli-typescript](https://github.com/typed-ember/ember-cli-typescript-blueprints). Those share the exact same logic (like support for pods, MU, different test frameworks etc.), only the generated files' content (and their extension) are different. By decoupling the blueprint logic from the blueprint's file contents in tests, this allows to easily update the blueprint's tests in `e-c-ts` in sync with the original ones, which currently is a *PITA*. For more context, see https://github.com/typed-ember/ember-cli-typescript-blueprints/issues/14