### PR TITLE
Add module unification tests for acceptance-test blueprint

### DIFF
--- a/node-tests/blueprints/acceptance-test-test.js
+++ b/node-tests/blueprints/acceptance-test-test.js
@@ -8,6 +8,7 @@ const modifyPackages = blueprintHelpers.modifyPackages;
 
 const chai = require('ember-cli-blueprint-test-helpers/chai');
 const expect = chai.expect;
+const fs = require('fs-extra');
 
 const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
 const fixture = require('../helpers/fixture');
@@ -87,6 +88,121 @@ describe('Blueprint: acceptance-test', function() {
   describe('in addon', function() {
     beforeEach(function() {
       return emberNew({ target: 'addon' });
+    });
+
+    describe('with ember-cli-qunit@4.1.0', function() {
+      beforeEach(function() {
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0');
+      });
+
+      it('acceptance-test foo', function() {
+        return emberGenerateDestroy(['acceptance-test', 'foo'], _file => {
+          expect(_file('tests/acceptance/foo-test.js')).to.equal(
+            fixture('acceptance-test/addon-default.js')
+          );
+
+          expect(_file('app/acceptance-tests/foo.js')).to.not.exist;
+        });
+      });
+
+      it('acceptance-test foo/bar', function() {
+        return emberGenerateDestroy(['acceptance-test', 'foo/bar'], _file => {
+          expect(_file('tests/acceptance/foo/bar-test.js')).to.equal(
+            fixture('acceptance-test/addon-nested.js')
+          );
+
+          expect(_file('app/acceptance-tests/foo/bar.js')).to.not.exist;
+        });
+      });
+    });
+
+    describe('with ember-cli-qunit@4.2.0', function() {
+      beforeEach(function() {
+        generateFakePackageManifest('ember-cli-qunit', '4.2.0');
+      });
+
+      it('acceptance-test foo', function() {
+        return emberGenerateDestroy(['acceptance-test', 'foo'], _file => {
+          expect(_file('tests/acceptance/foo-test.js')).to.equal(
+            fixture('acceptance-test/qunit-rfc268.js')
+          );
+        });
+      });
+    });
+  });
+
+  describe('in app - module unification', function() {
+    beforeEach(function() {
+      return emberNew().then(() => fs.ensureDirSync('src'));
+    });
+
+    describe('with ember-cli-qunit@4.1.0', function() {
+      beforeEach(function() {
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0');
+      });
+
+      it('acceptance-test foo', function() {
+        return emberGenerateDestroy(['acceptance-test', 'foo'], _file => {
+          expect(_file('tests/acceptance/foo-test.js')).to.equal(
+            fixture('acceptance-test/default.js')
+          );
+        });
+      });
+    });
+
+    describe('with ember-cli-qunit@4.2.0', function() {
+      beforeEach(function() {
+        generateFakePackageManifest('ember-cli-qunit', '4.2.0');
+      });
+
+      it('acceptance-test foo', function() {
+        return emberGenerateDestroy(['acceptance-test', 'foo'], _file => {
+          expect(_file('tests/acceptance/foo-test.js')).to.equal(
+            fixture('acceptance-test/qunit-rfc268.js')
+          );
+        });
+      });
+    });
+
+    describe('with ember-cli-mocha', function() {
+      beforeEach(function() {
+        return modifyPackages([
+          { name: 'ember-cli-qunit', delete: true },
+          { name: 'ember-cli-mocha', dev: true },
+        ]);
+      });
+
+      it('acceptance-test foo', function() {
+        return emberGenerateDestroy(['acceptance-test', 'foo'], _file => {
+          expect(_file('tests/acceptance/foo-test.js')).to.equal(
+            fixture('acceptance-test/mocha.js')
+          );
+        });
+      });
+    });
+
+    describe('with ember-mocha@0.14.0', function() {
+      beforeEach(function() {
+        modifyPackages([
+          { name: 'ember-cli-qunit', delete: true },
+          { name: 'ember-mocha', dev: true },
+        ]);
+        generateFakePackageManifest('ember-mocha', '0.14.0');
+      });
+
+      it('acceptance-test foo', function() {
+        return emberGenerateDestroy(['acceptance-test', 'foo'], _file => {
+          expect(_file('tests/acceptance/foo-test.js')).to.equal(
+            fixture('acceptance-test/mocha-rfc268.js')
+          );
+        });
+      });
+    });
+  });
+
+  describe('in addon - module unification', function() {
+    beforeEach(function() {
+      return emberNew({ target: 'addon' }).then(() => fs.ensureDirSync('src'));
     });
 
     describe('with ember-cli-qunit@4.1.0', function() {


### PR DESCRIPTION
Part of ember-cli/ember-cli#7530

The examples provided by the [Migration Tool](https://github.com/emberjs/rfcs/blob/master/text/0143-module-unification.md#migration-tool) show the blueprint should generate acceptance tests on the same `tests` folder than a classic app.

The PR only adds some tests to validate the `acceptance-test` blueprint with a MU app.