### PR TITLE
[BUGFIX beta] RouteInfoWithAttributes on transition

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "puppeteer": "^1.3.0",
     "qunit": "^2.5.0",
     "route-recognizer": "^0.3.4",
-    "router_js": "^6.0.4",
+    "router_js": "^6.1.3",
     "rsvp": "^4.8.2",
     "semver": "^5.5.0",
     "serve-static": "^1.12.2",

--- a/packages/@ember/-internals/routing/lib/system/transition.ts
+++ b/packages/@ember/-internals/routing/lib/system/transition.ts
@@ -139,7 +139,7 @@
  * where the router is transitioning to. It's important
  * to note that a `RouteInfo` is a linked list and this
  * property is simply represents leafmost route.
- * @property {RouteInfo} to
+ * @property {RouteInfo|RouteInfoWithAttributes} to
  * @public
  * @category ember-routing-router-service
  */
@@ -151,7 +151,7 @@
  * property is simply represents head node of the list.
  * In the case of an initial render, from will be set to
  * `null`.
- * @property {RouteInfo} from
+ * @property {RouteInfoWithAttributes} from
  * @public
  * @category ember-routing-router-service
  */

--- a/packages/ember/tests/routing/router_service_test/events_test.js
+++ b/packages/ember/tests/routing/router_service_test/events_test.js
@@ -580,7 +580,7 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
       }
 
       '@test nested params'(assert) {
-        assert.expect(24);
+        assert.expect(30);
         let initial = true;
 
         this.add(
@@ -592,7 +592,7 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
               } else {
                 assert.deepEqual(params, { dynamic_id: '456' });
               }
-              return params;
+              return params.dynamic_id;
             },
           })
         );
@@ -602,7 +602,7 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
           Route.extend({
             model(params) {
               assert.deepEqual(params, { child_id: '456' });
-              return params;
+              return params.child_id;
             },
           })
         );
@@ -622,6 +622,8 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
                 if (initial) {
                   assert.deepEqual(transition.to.parent.params, { dynamic_id: '123' });
                 } else {
+                  assert.deepEqual(transition.from.attributes, '456');
+                  assert.deepEqual(transition.from.parent.attributes, '123');
                   assert.deepEqual(transition.to.parent.params, { dynamic_id: '456' });
                 }
               });
@@ -634,6 +636,10 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
                 if (initial) {
                   assert.deepEqual(transition.to.parent.params, { dynamic_id: '123' });
                 } else {
+                  assert.deepEqual(transition.from.attributes, '456');
+                  assert.deepEqual(transition.from.parent.attributes, '123');
+                  assert.deepEqual(transition.to.attributes, '456');
+                  assert.deepEqual(transition.to.parent.attributes, '456');
                   assert.deepEqual(transition.to.parent.params, { dynamic_id: '456' });
                 }
               });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7378,10 +7378,10 @@ route-recognizer@^0.3.4:
   resolved "https://registry.yarnpkg.com/route-recognizer/-/route-recognizer-0.3.4.tgz#39ab1ffbce1c59e6d2bdca416f0932611e4f3ca3"
   integrity sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==
 
-router_js@^6.0.4:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/router_js/-/router_js-6.0.4.tgz#71a835e391754df6606922328d444bad19348abd"
-  integrity sha512-w/Xe7BKRd/bP8q4m9lhERG0lrOc1rdjlQov3nsv0JLppsFyrGRSb35KpZn5GDsR6fK7c4HEIEQtL8XPvs5bVcw==
+router_js@^6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/router_js/-/router_js-6.1.3.tgz#9fbecbb4b173f5a6c4580d15f94737cfeb4629e6"
+  integrity sha512-I3l/4wMpSl/Fd9SZQCa7kVAIn5H3v10KjA4CuJPg1gjihC5GKFi4owetf/psNg2lAqevmMn81yLCsIxBwoeK1A==
   dependencies:
     "@types/node" "^10.5.5"
 


### PR DESCRIPTION
It was pointed out that `transition.from` should always be a `RouteInfoWithAttributes` the active route path has been resolved. Also within the `routeDidChange` event `transition.to` has the same guarantees about being fully resolved so it to should be a `RouteInfoWithAttributes`.