### PR TITLE
Needed for 3.6 - Clarify that currentRoute's value is private API

### DIFF
--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -289,7 +289,9 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
      A RouteInfo that represents the current leaf route.
      It is guaranteed to change whenever a route transition
      happens (even when that transition only changes parameters
-     and doesn't change the active route)
+     and doesn't change the active route).
+     This property may be observed for changes, as public API.
+     However, its _value_ is private API, and should not be depended on.
 
      @property currentRoute
      @type RouteInfo


### PR DESCRIPTION
Following on discussion for the upcoming blog post, it seems that this documentation needs a little more detail. My understanding is that the property is public API, but the value is not.

Is this correct?

[Link to discussion and 3.6 post](https://github.com/emberjs/website/pull/3673#discussion_r234420576)