### PR TITLE
[BUGFIX beta] Fix cycle detection in Ember.copy

### DIFF
--- a/packages/@ember/-internals/runtime/lib/copy.js
+++ b/packages/@ember/-internals/runtime/lib/copy.js
@@ -18,12 +18,17 @@ function _copy(obj, deep, seen, copies) {
     return copies[loc];
   }
 
+  if (deep) {
+    seen.push(obj);
+  }
+
   // IMPORTANT: this specific test will detect a native array only. Any other
   // object will need to implement Copyable.
   if (Array.isArray(obj)) {
     ret = obj.slice();
 
     if (deep) {
+      copies.push(ret);
       loc = ret.length;
 
       while (--loc >= 0) {
@@ -32,8 +37,14 @@ function _copy(obj, deep, seen, copies) {
     }
   } else if (Copyable.detect(obj)) {
     ret = obj.copy(deep, seen, copies);
+    if (deep) {
+      copies.push(ret);
+    }
   } else if (obj instanceof Date) {
     ret = new Date(obj.getTime());
+    if (deep) {
+      copies.push(ret);
+    }
   } else {
     assert(
       'Cannot clone an EmberObject that does not implement Copyable',
@@ -41,6 +52,10 @@ function _copy(obj, deep, seen, copies) {
     );
 
     ret = {};
+    if (deep) {
+      copies.push(ret);
+    }
+
     let key;
     for (key in obj) {
       // support Null prototype
@@ -56,11 +71,6 @@ function _copy(obj, deep, seen, copies) {
 
       ret[key] = deep ? _copy(obj[key], deep, seen, copies) : obj[key];
     }
-  }
-
-  if (deep) {
-    seen.push(obj);
-    copies.push(ret);
   }
 
   return ret;

--- a/packages/@ember/-internals/runtime/tests/core/copy_test.js
+++ b/packages/@ember/-internals/runtime/tests/core/copy_test.js
@@ -43,5 +43,22 @@ moduleFor(
 
       assert.deepEqual(array, arrayCopy, 'array content cloned successfully in new array');
     }
+
+    ['@test Ember.copy cycle detection'](assert) {
+      let obj = {
+        foo: {
+          bar: 'bar',
+        },
+      };
+      obj.foo.foo = obj.foo;
+      let cycleCopy = null;
+      expectDeprecation(() => {
+        cycleCopy = copy(obj, true);
+      }, 'Use ember-copy addon instead of copy method and Copyable mixin.');
+
+      assert.equal(cycleCopy.foo.bar, 'bar');
+      assert.notEqual(cycleCopy.foo.foo, obj.foo.foo);
+      assert.strictEqual(cycleCopy.foo.foo, cycleCopy.foo.foo);
+    }
   }
 );


### PR DESCRIPTION
Previously, key iteration in objects would recurse prior to updating `seen` and therefore miss the cycle check in the recursive call, leading to stack overflows.