### PR TITLE
[BUGFIX beta] Ensures Ember.A is a constructor

### DIFF
--- a/packages/@ember/-internals/runtime/lib/mixins/array.js
+++ b/packages/@ember/-internals/runtime/lib/mixins/array.js
@@ -1641,12 +1641,36 @@ let A;
 
 if (ENV.EXTEND_PROTOTYPES.Array) {
   NativeArray.apply(Array.prototype);
-  A = arr => arr || [];
+
+  A = function(arr) {
+    deprecate(
+      '`new A()` has been deprecated, please update to calling A as a function: `A()`',
+      !(this instanceof A),
+      {
+        id: 'array.new-array-wrapper',
+        until: '3.9.0',
+        url: 'https://emberjs.com/deprecations/v3.x#toc_array-new-array-wrapper',
+      }
+    );
+
+    return arr || [];
+  };
 } else {
-  A = arr => {
+  A = function(arr) {
+    deprecate(
+      '`new A()` has been deprecated, please update to calling A as a function: `A()`',
+      !(this instanceof A),
+      {
+        id: 'array.new-array-wrapper',
+        until: '3.9.0',
+        url: 'https://emberjs.com/deprecations/v3.x#toc_array-new-array-wrapper',
+      }
+    );
+
     if (!arr) {
       arr = [];
     }
+
     return ArrayMixin.detect(arr) ? arr : NativeArray.apply(arr);
   };
 }

--- a/packages/@ember/-internals/runtime/tests/system/native_array/a_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/native_array/a_test.js
@@ -12,5 +12,15 @@ moduleFor(
       assert.ok(EmberArray.detect(A()), 'returned an ember array');
       assert.ok(EmberArray.detect(A([1, 2])), 'returned an ember array');
     }
+
+    ['@test new Ember.A'](assert) {
+      expectDeprecation(() => {
+        assert.deepEqual(new A([1, 2]), [1, 2], 'array values were not be modified');
+        assert.deepEqual(new A(), [], 'returned an array with no arguments');
+        assert.deepEqual(new A(null), [], 'returned an array with a null argument');
+        assert.ok(EmberArray.detect(new A()), 'returned an ember array');
+        assert.ok(EmberArray.detect(new A([1, 2])), 'returned an ember array');
+      });
+    }
   }
 );


### PR DESCRIPTION
The recent change to transpilation has made `new A()` break, because
A is an arrow function and arrow functions cannot be constructors. This
is a pretty common pattern in Ember apps and likely constitutes a
breaking change, so this PR fixes it by changing the arrow function to
a normal function.