### PR TITLE
[BUGFIX beta] Prevent errors with debug compiled templates in prod.

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/helpers/-assert-implicit-component-helper-argument.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/-assert-implicit-component-helper-argument.ts
@@ -1,36 +1,36 @@
 import { DEBUG } from '@glimmer/env';
 import { Opaque } from '@glimmer/interfaces';
 import { Tag, VersionedPathReference } from '@glimmer/reference';
-import { Arguments, Helper, VM } from '@glimmer/runtime';
-import { Maybe } from '@glimmer/util';
+import { Arguments, VM } from '@glimmer/runtime';
 
-let helper: Maybe<Helper> = undefined;
+class ComponentAssertionReference implements VersionedPathReference<Opaque> {
+  public tag: Tag;
 
-if (DEBUG) {
-  class ComponentAssertionReference implements VersionedPathReference<Opaque> {
-    public tag: Tag;
-
-    constructor(private component: VersionedPathReference<Opaque>, private message: string) {
-      this.tag = component.tag;
-    }
-
-    value(): Opaque {
-      let value = this.component.value();
-
-      if (typeof value === 'string') {
-        throw new TypeError(this.message);
-      }
-
-      return value;
-    }
-
-    get(property: string): VersionedPathReference<Opaque> {
-      return this.component.get(property);
-    }
+  constructor(private component: VersionedPathReference<Opaque>, private message: string) {
+    this.tag = component.tag;
   }
 
-  helper = (_vm: VM, args: Arguments) =>
-    new ComponentAssertionReference(args.positional.at(0), args.positional.at(1).value() as string);
+  value(): Opaque {
+    let value = this.component.value();
+
+    if (typeof value === 'string') {
+      throw new TypeError(this.message);
+    }
+
+    return value;
+  }
+
+  get(property: string): VersionedPathReference<Opaque> {
+    return this.component.get(property);
+  }
 }
 
-export default helper;
+export default (_vm: VM, args: Arguments) => {
+  if (DEBUG) {
+    return new ComponentAssertionReference(args.positional.at(0), args.positional
+      .at(1)
+      .value() as string);
+  } else {
+    return args.positional.at(0);
+  }
+};

--- a/packages/@ember/-internals/glimmer/lib/resolver.ts
+++ b/packages/@ember/-internals/glimmer/lib/resolver.ts
@@ -9,7 +9,6 @@ import {
 } from '@ember/canary-features';
 import { assert } from '@ember/debug';
 import { _instrumentStart } from '@ember/instrumentation';
-import { DEBUG } from '@glimmer/env';
 import {
   ComponentDefinition,
   Opaque,
@@ -82,11 +81,8 @@ const BUILTINS_HELPERS = {
   '-get-dynamic-var': getDynamicVar,
   '-mount': mountHelper,
   '-outlet': outletHelper,
+  '-assert-implicit-component-helper-argument': componentAssertionHelper,
 };
-
-if (DEBUG) {
-  BUILTINS_HELPERS['-assert-implicit-component-helper-argument'] = componentAssertionHelper;
-}
 
 const BUILTIN_MODIFIERS = {
   action: { manager: new ActionModifierManager(), state: null },


### PR DESCRIPTION
When using `ember-template-compiler.js` compiled templates, we always compile and run in "debug builds".

Fixes https://github.com/emberjs/ember.js/issues/17172