### PR TITLE
Drop support for Node 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "typescript-eslint-parser": "^18.0.0"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 8.*"
+    "node": "6.* || 8.* || >= 10.*"
   },
   "ember-addon": {
     "after": "ember-cli-legacy-blueprints"


### PR DESCRIPTION
CI has been running on Node 5, 6 and/or 10 for multiple years now, and Ember CLI also already dropped support according to the published support policy.

/cc @rwjblue 