### PR TITLE
[V8 Team Recommendation]  Fix JS Object as dictionary reuse

### DIFF
--- a/packages/loader/lib/index.js
+++ b/packages/loader/lib/index.js
@@ -67,8 +67,8 @@ mainContext = this; // eslint-disable-line no-undef
   }
 
   if (typeof Ember.__loader === 'undefined') {
-    var registry = {};
-    var seen = {};
+    var registry = Object.create(null);
+    var seen = Object.create(null);
 
     enifed = function(name, deps, callback) {
       var value = {};


### PR DESCRIPTION
In recent discussion with the v8 team, they pointed out that our internal loader misuses `{}` as a dictionary, and recommended we use `Object.create(null)` instead.

The original loader already fixed this: https://github.com/ember-cli/loader.js/blob/b89c6932eed14abe9738993bfc21230ad1971e4f/lib/loader/loader.js#L31

We simply did not update this side of things.