### PR TITLE
[BUGFIX release] Ensure ControllerMixin is not listed in wrong module.

### DIFF
--- a/packages/@ember/controller/lib/controller_mixin.js
+++ b/packages/@ember/controller/lib/controller_mixin.js
@@ -2,6 +2,10 @@ import { Mixin } from '@ember/-internals/metal';
 import { ActionHandler } from '@ember/-internals/runtime';
 
 /**
+@module ember
+*/
+
+/**
   @class ControllerMixin
   @namespace Ember
   @uses Ember.ActionHandler


### PR DESCRIPTION
Currently, `ControllerMixin` shows up under `ember/canary-features` module (when looking at private and deprecated APIs). This fixes things so that it shows up under `ember` (note: there is no _actual_ public modules API analogue here, but this is still better IMHO).