### PR TITLE
Add failing test demonstrating an issue updating a component property from `didReceiveAttrs` in test mode

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
@@ -3279,6 +3279,24 @@ moduleFor(
       this.runTask(() => set(this.context, 'foo', 5));
     }
 
+    ['@test properties can be updated in `didReceiveAttrs`']() {
+      this.registerComponent('foo-bar', {
+        ComponentClass: Component.extend({
+          didReceiveAttrs() {
+            this._super();
+
+            this.set('name', 'Updated');
+          },
+        }),
+
+        template: 'name: {{name}}',
+      });
+
+      this.render(`{{foo-bar name=name}}`, { name: 'Provided' });
+
+      this.assertText('name: Updated');
+    }
+
     ['@test returning `true` from an action does not bubble if `target` is not specified (GH#14275)'](
       assert
     ) {


### PR DESCRIPTION
This adds a failing test demonstrating an issue that I came across in our app when upgrading from 3.1 to 3.2 (the issue appears to be in 3.2 -> 3.5 and canary). The test added in this PR fails with a backtracking error:

<img width="1059" alt="screen shot 2018-12-06 at 10 24 30" src="https://user-images.githubusercontent.com/2526/49578442-ab7bae00-f941-11e8-8418-e16c4daac66b.png">

I've also reproduced the issue in [this 3.5 ember app](https://github.com/GavinJoyce/ember-did-receive-test-bug). The error only occurs when testing the component, it works fine when running the app in development mode:

<img width="749" alt="screen shot 2018-12-06 at 10 02 29" src="https://user-images.githubusercontent.com/2526/49578522-df56d380-f941-11e8-8758-373cb9424665.png">

<img width="750" alt="screen shot 2018-12-06 at 10 02 22" src="https://user-images.githubusercontent.com/2526/49578530-e2ea5a80-f941-11e8-97b0-3d39e56a6977.png">



