### PR TITLE
Refactor MU blueprint tests: remove `ensureDirSync` call

### DIFF
--- a/node-tests/blueprints/acceptance-test-test.js
+++ b/node-tests/blueprints/acceptance-test-test.js
@@ -8,7 +8,6 @@ const modifyPackages = blueprintHelpers.modifyPackages;
 
 const chai = require('ember-cli-blueprint-test-helpers/chai');
 const expect = chai.expect;
-const fs = require('fs-extra');
 
 const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
 const enableModuleUnification = require('../helpers/module-unification').enableModuleUnification;
@@ -149,7 +148,7 @@ describe('Blueprint: acceptance-test', function() {
     enableModuleUnification();
 
     beforeEach(function() {
-      return emberNew().then(() => fs.ensureDirSync('src'));
+      return emberNew();
     });
 
     describe('with ember-cli-qunit@4.1.0', function() {
@@ -225,7 +224,7 @@ describe('Blueprint: acceptance-test', function() {
     enableModuleUnification();
 
     beforeEach(function() {
-      return emberNew({ target: 'addon' }).then(() => fs.ensureDirSync('src'));
+      return emberNew({ target: 'addon' });
     });
 
     describe('with ember-cli-qunit@4.1.0', function() {

--- a/node-tests/blueprints/component-test-test.js
+++ b/node-tests/blueprints/component-test-test.js
@@ -177,7 +177,7 @@ describe('Blueprint: component-test', function() {
     enableModuleUnification();
 
     beforeEach(function() {
-      return emberNew().then(() => fs.ensureDirSync('src'));
+      return emberNew();
     });
 
     describe('with ember-cli-qunit@4.1.0', function() {

--- a/node-tests/blueprints/controller-test-test.js
+++ b/node-tests/blueprints/controller-test-test.js
@@ -12,7 +12,6 @@ const expect = chai.expect;
 const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
 const enableModuleUnification = require('../helpers/module-unification').enableModuleUnification;
 const fixture = require('../helpers/fixture');
-const fs = require('fs-extra');
 
 describe('Blueprint: controller-test', function() {
   setupTestHooks(this);
@@ -154,7 +153,7 @@ describe('Blueprint: controller-test', function() {
     enableModuleUnification();
 
     beforeEach(function() {
-      return emberNew().then(() => fs.ensureDirSync('src'));
+      return emberNew();
     });
 
     describe('with ember-cli-qunit@4.1.0', function() {
@@ -319,7 +318,6 @@ describe('Blueprint: controller-test', function() {
 
     beforeEach(function() {
       return emberNew()
-        .then(() => fs.ensureDirSync('src'))
         .then(() =>
           modifyPackages([
             { name: 'ember-qunit', delete: true },

--- a/node-tests/blueprints/helper-test-test.js
+++ b/node-tests/blueprints/helper-test-test.js
@@ -12,7 +12,6 @@ const expect = chai.expect;
 const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
 const enableModuleUnification = require('../helpers/module-unification').enableModuleUnification;
 const fixture = require('../helpers/fixture');
-const fs = require('fs-extra');
 
 describe('Blueprint: helper-test', function() {
   setupTestHooks(this);
@@ -154,7 +153,7 @@ describe('Blueprint: helper-test', function() {
     enableModuleUnification();
 
     beforeEach(function() {
-      return emberNew().then(() => fs.ensureDirSync('src'));
+      return emberNew();
     });
 
     describe('with ember-cli-qunit@4.1.0', function() {
@@ -309,15 +308,13 @@ describe('Blueprint: helper-test', function() {
     enableModuleUnification();
 
     beforeEach(function() {
-      return emberNew({ target: 'addon' })
-        .then(() => {
-          modifyPackages([
-            { name: 'ember-qunit', delete: true },
-            { name: 'ember-cli-qunit', dev: true },
-          ]);
-          generateFakePackageManifest('ember-cli-qunit', '4.1.0');
-        })
-        .then(() => fs.ensureDirSync('src'));
+      return emberNew({ target: 'addon' }).then(() => {
+        modifyPackages([
+          { name: 'ember-qunit', delete: true },
+          { name: 'ember-cli-qunit', dev: true },
+        ]);
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0');
+      });
     });
 
     it('helper-test foo/bar-baz', function() {

--- a/node-tests/blueprints/helper-test.js
+++ b/node-tests/blueprints/helper-test.js
@@ -13,7 +13,6 @@ const expect = chai.expect;
 const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
 const fixture = require('../helpers/fixture');
 const enableModuleUnification = require('../helpers/module-unification').enableModuleUnification;
-const fs = require('fs-extra');
 
 describe('Blueprint: helper', function() {
   setupTestHooks(this);
@@ -94,15 +93,13 @@ describe('Blueprint: helper', function() {
     enableModuleUnification();
 
     beforeEach(function() {
-      return emberNew()
-        .then(() => fs.ensureDirSync('src'))
-        .then(() => {
-          modifyPackages([
-            { name: 'ember-qunit', delete: true },
-            { name: 'ember-cli-qunit', dev: true },
-          ]);
-          generateFakePackageManifest('ember-cli-qunit', '4.1.0');
-        });
+      return emberNew().then(() => {
+        modifyPackages([
+          { name: 'ember-qunit', delete: true },
+          { name: 'ember-cli-qunit', dev: true },
+        ]);
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0');
+      });
     });
 
     it('helper foo/bar-baz', function() {
@@ -160,15 +157,13 @@ describe('Blueprint: helper', function() {
     enableModuleUnification();
 
     beforeEach(function() {
-      return emberNew({ target: 'addon' })
-        .then(() => fs.ensureDirSync('src'))
-        .then(() => {
-          modifyPackages([
-            { name: 'ember-qunit', delete: true },
-            { name: 'ember-cli-qunit', dev: true },
-          ]);
-          generateFakePackageManifest('ember-cli-qunit', '4.1.0');
-        });
+      return emberNew({ target: 'addon' }).then(() => {
+        modifyPackages([
+          { name: 'ember-qunit', delete: true },
+          { name: 'ember-cli-qunit', dev: true },
+        ]);
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0');
+      });
     });
 
     it('helper foo/bar-baz', function() {
@@ -220,15 +215,13 @@ describe('Blueprint: helper', function() {
     enableModuleUnification();
 
     beforeEach(function() {
-      return emberNew({ target: 'in-repo-addon' })
-        .then(() => fs.ensureDirSync('src'))
-        .then(() => {
-          modifyPackages([
-            { name: 'ember-qunit', delete: true },
-            { name: 'ember-cli-qunit', dev: true },
-          ]);
-          generateFakePackageManifest('ember-cli-qunit', '4.1.0');
-        });
+      return emberNew({ target: 'in-repo-addon' }).then(() => {
+        modifyPackages([
+          { name: 'ember-qunit', delete: true },
+          { name: 'ember-cli-qunit', dev: true },
+        ]);
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0');
+      });
     });
 
     it('helper foo/bar-baz --in-repo-addon=my-addon', function() {

--- a/node-tests/blueprints/initializer-test-test.js
+++ b/node-tests/blueprints/initializer-test-test.js
@@ -12,7 +12,6 @@ const expect = chai.expect;
 const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
 const enableModuleUnification = require('../helpers/module-unification').enableModuleUnification;
 const fixture = require('../helpers/fixture');
-const fs = require('fs-extra');
 
 describe('Blueprint: initializer-test', function() {
   setupTestHooks(this);
@@ -104,7 +103,7 @@ describe('Blueprint: initializer-test', function() {
     enableModuleUnification();
 
     beforeEach(function() {
-      return emberNew().then(() => fs.ensureDirSync('src'));
+      return emberNew();
     });
 
     describe('with ember-cli-qunit@4.1.0', function() {
@@ -165,7 +164,7 @@ describe('Blueprint: initializer-test', function() {
     enableModuleUnification();
 
     beforeEach(function() {
-      return emberNew({ target: 'addon' }).then(() => fs.ensureDirSync('src'));
+      return emberNew({ target: 'addon' });
     });
 
     describe('with ember-cli-qunit@4.1.0', function() {

--- a/node-tests/blueprints/initializer-test.js
+++ b/node-tests/blueprints/initializer-test.js
@@ -10,7 +10,6 @@ const expectError = require('../helpers/expect-error');
 
 const chai = require('ember-cli-blueprint-test-helpers/chai');
 const expect = chai.expect;
-const fs = require('fs-extra');
 
 const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
 const enableModuleUnification = require('../helpers/module-unification').enableModuleUnification;
@@ -197,7 +196,6 @@ describe('Blueprint: initializer', function() {
 
     beforeEach(function() {
       return emberNew()
-        .then(() => fs.ensureDirSync('src'))
         .then(() =>
           modifyPackages([
             { name: 'ember-qunit', delete: true },
@@ -271,7 +269,6 @@ describe('Blueprint: initializer', function() {
 
     beforeEach(function() {
       return emberNew({ target: 'addon' })
-        .then(() => fs.ensureDirSync('src'))
         .then(() =>
           modifyPackages([
             { name: 'ember-qunit', delete: true },

--- a/node-tests/blueprints/instance-initializer-test-test.js
+++ b/node-tests/blueprints/instance-initializer-test-test.js
@@ -12,7 +12,6 @@ const expect = chai.expect;
 const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
 const enableModuleUnification = require('../helpers/module-unification').enableModuleUnification;
 const fixture = require('../helpers/fixture');
-const fs = require('fs-extra');
 
 describe('Blueprint: instance-initializer-test', function() {
   setupTestHooks(this);
@@ -104,7 +103,7 @@ describe('Blueprint: instance-initializer-test', function() {
     enableModuleUnification();
 
     beforeEach(function() {
-      return emberNew().then(() => fs.ensureDirSync('src'));
+      return emberNew();
     });
 
     describe('with ember-cli-qunit@4.1.0', function() {
@@ -165,7 +164,7 @@ describe('Blueprint: instance-initializer-test', function() {
     enableModuleUnification();
 
     beforeEach(function() {
-      return emberNew({ target: 'addon' }).then(() => fs.ensureDirSync('src'));
+      return emberNew({ target: 'addon' });
     });
 
     describe('with ember-cli-qunit@4.1.0', function() {

--- a/node-tests/blueprints/instance-initializer-test.js
+++ b/node-tests/blueprints/instance-initializer-test.js
@@ -10,7 +10,6 @@ const expectError = require('../helpers/expect-error');
 
 const chai = require('ember-cli-blueprint-test-helpers/chai');
 const expect = chai.expect;
-const fs = require('fs-extra');
 
 const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
 const enableModuleUnification = require('../helpers/module-unification').enableModuleUnification;
@@ -211,7 +210,6 @@ describe('Blueprint: instance-initializer', function() {
 
     beforeEach(function() {
       return emberNew()
-        .then(() => fs.ensureDirSync('src'))
         .then(() =>
           modifyPackages([
             { name: 'ember-qunit', delete: true },
@@ -285,7 +283,6 @@ describe('Blueprint: instance-initializer', function() {
 
     beforeEach(function() {
       return emberNew({ target: 'addon' })
-        .then(() => fs.ensureDirSync('src'))
         .then(() =>
           modifyPackages([
             { name: 'ember-qunit', delete: true },

--- a/node-tests/blueprints/mixin-test-test.js
+++ b/node-tests/blueprints/mixin-test-test.js
@@ -8,7 +8,6 @@ const modifyPackages = blueprintHelpers.modifyPackages;
 
 const chai = require('ember-cli-blueprint-test-helpers/chai');
 const expect = chai.expect;
-const fs = require('fs-extra');
 
 const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
 const enableModuleUnification = require('../helpers/module-unification').enableModuleUnification;
@@ -89,7 +88,7 @@ describe('Blueprint: mixin-test', function() {
     enableModuleUnification();
 
     beforeEach(function() {
-      return emberNew().then(() => fs.ensureDirSync('src'));
+      return emberNew();
     });
 
     describe('with ember-cli-qunit@4.1.0', function() {
@@ -161,14 +160,12 @@ describe('Blueprint: mixin-test', function() {
     enableModuleUnification();
 
     beforeEach(function() {
-      return emberNew({ target: 'addon' })
-        .then(() =>
-          modifyPackages([
-            { name: 'ember-qunit', delete: true },
-            { name: 'ember-cli-qunit', dev: true },
-          ])
-        )
-        .then(() => fs.ensureDirSync('src'));
+      return emberNew({ target: 'addon' }).then(() =>
+        modifyPackages([
+          { name: 'ember-qunit', delete: true },
+          { name: 'ember-cli-qunit', dev: true },
+        ])
+      );
     });
 
     it('mixin-test foo', function() {

--- a/node-tests/blueprints/mixin-test.js
+++ b/node-tests/blueprints/mixin-test.js
@@ -10,7 +10,6 @@ const enableModuleUnification = require('../helpers/module-unification').enableM
 
 const chai = require('ember-cli-blueprint-test-helpers/chai');
 const expect = chai.expect;
-const fs = require('fs-extra');
 
 describe('Blueprint: mixin', function() {
   setupTestHooks(this);
@@ -119,7 +118,7 @@ describe('Blueprint: mixin', function() {
     enableModuleUnification();
 
     beforeEach(function() {
-      return emberNew().then(() => fs.ensureDirSync('src'));
+      return emberNew();
     });
 
     it('mixin foo', function() {
@@ -218,7 +217,7 @@ describe('Blueprint: mixin', function() {
     enableModuleUnification();
 
     beforeEach(function() {
-      return emberNew({ target: 'addon' }).then(() => fs.ensureDirSync('src'));
+      return emberNew({ target: 'addon' });
     });
 
     it('mixin foo', function() {

--- a/node-tests/blueprints/route-test.js
+++ b/node-tests/blueprints/route-test.js
@@ -336,7 +336,6 @@ describe('Blueprint: route', function() {
 
     beforeEach(function() {
       return emberNew()
-        .then(() => fs.ensureDirSync('src'))
         .then(() =>
           modifyPackages([
             { name: 'ember-qunit', delete: true },
@@ -499,7 +498,6 @@ describe('Blueprint: route', function() {
 
     beforeEach(function() {
       return emberNew({ target: 'addon' })
-        .then(() => fs.ensureDirSync('src'))
         .then(() =>
           modifyPackages([
             { name: 'ember-qunit', delete: true },

--- a/node-tests/blueprints/service-test.js
+++ b/node-tests/blueprints/service-test.js
@@ -10,7 +10,6 @@ const expectError = require('../helpers/expect-error');
 
 const chai = require('ember-cli-blueprint-test-helpers/chai');
 const expect = chai.expect;
-const fs = require('fs-extra');
 
 const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
 const enableModuleUnification = require('../helpers/module-unification').enableModuleUnification;
@@ -105,7 +104,6 @@ describe('Blueprint: service', function() {
 
     beforeEach(function() {
       return emberNew()
-        .then(() => fs.ensureDirSync('src'))
         .then(() =>
           modifyPackages([
             { name: 'ember-qunit', delete: true },
@@ -187,7 +185,6 @@ describe('Blueprint: service', function() {
 
     beforeEach(function() {
       return emberNew({ target: 'addon' })
-        .then(() => fs.ensureDirSync('src'))
         .then(() =>
           modifyPackages([
             { name: 'ember-qunit', delete: true },

--- a/node-tests/blueprints/template-test.js
+++ b/node-tests/blueprints/template-test.js
@@ -10,7 +10,6 @@ const enableModuleUnification = require('../helpers/module-unification').enableM
 
 const chai = require('ember-cli-blueprint-test-helpers/chai');
 const expect = chai.expect;
-const fs = require('fs-extra');
 
 describe('Blueprint: template', function() {
   setupTestHooks(this);
@@ -124,7 +123,7 @@ describe('Blueprint: template', function() {
     enableModuleUnification();
 
     beforeEach(function() {
-      return emberNew().then(() => fs.ensureDirSync('src'));
+      return emberNew();
     });
 
     it('template foo', function() {
@@ -144,7 +143,7 @@ describe('Blueprint: template', function() {
     enableModuleUnification();
 
     beforeEach(function() {
-      return emberNew().then(() => fs.ensureDirSync('src'));
+      return emberNew();
     });
 
     it('shows an error', function() {
@@ -159,7 +158,7 @@ describe('Blueprint: template', function() {
     enableModuleUnification();
 
     beforeEach(function() {
-      return emberNew({ target: 'addon' }).then(() => fs.ensureDirSync('src'));
+      return emberNew({ target: 'addon' });
     });
 
     it('template foo', function() {

--- a/node-tests/blueprints/util-test-test.js
+++ b/node-tests/blueprints/util-test-test.js
@@ -8,7 +8,6 @@ const modifyPackages = blueprintHelpers.modifyPackages;
 
 const chai = require('ember-cli-blueprint-test-helpers/chai');
 const expect = chai.expect;
-const fs = require('fs-extra');
 
 const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
 const enableModuleUnification = require('../helpers/module-unification').enableModuleUnification;
@@ -93,7 +92,7 @@ describe('Blueprint: util-test', function() {
     enableModuleUnification();
 
     beforeEach(function() {
-      return emberNew().then(() => fs.ensureDirSync('src'));
+      return emberNew();
     });
 
     describe('with ember-cli-qunit@4.1.0', function() {
@@ -170,7 +169,7 @@ describe('Blueprint: util-test', function() {
     enableModuleUnification();
 
     beforeEach(function() {
-      return emberNew({ target: 'addon' }).then(() => fs.ensureDirSync('src'));
+      return emberNew({ target: 'addon' });
     });
 
     describe('with ember-cli-qunit@4.1.0', function() {

--- a/node-tests/blueprints/util-test.js
+++ b/node-tests/blueprints/util-test.js
@@ -10,7 +10,6 @@ const expectError = require('../helpers/expect-error');
 
 const chai = require('ember-cli-blueprint-test-helpers/chai');
 const expect = chai.expect;
-const fs = require('fs-extra');
 
 const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
 const enableModuleUnification = require('../helpers/module-unification').enableModuleUnification;
@@ -89,7 +88,6 @@ describe('Blueprint: util', function() {
 
     beforeEach(function() {
       return emberNew()
-        .then(() => fs.ensureDirSync('src'))
         .then(() =>
           modifyPackages([
             { name: 'ember-qunit', delete: true },
@@ -171,7 +169,6 @@ describe('Blueprint: util', function() {
 
     beforeEach(function() {
       return emberNew({ target: 'addon' })
-        .then(() => fs.ensureDirSync('src'))
         .then(() =>
           modifyPackages([
             { name: 'ember-qunit', delete: true },


### PR DESCRIPTION
This PR removes the unnecessary call to `fs.ensureDirSync('src')` on MU blueprint tests.

This change was part of #17212 which was finally solved by #17253.

The tests are failing, but ember-cli/ember-cli#8240 will solve the error, I have created the PR to avoid forgetting this improvement, and I am following the related issue; I will notify when this PR can be finally be merged.
