### PR TITLE
Update old jQuery versions for tests

### DIFF
--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -115,10 +115,10 @@ function generateBuiltTests() {
 
 function generateOldJQueryTests() {
   testFunctions.push(function() {
-    return run('jquery=1.8.3&nolint=true');
+    return run('jquery=1.10.2&nolint=true');
   });
   testFunctions.push(function() {
-    return run('jquery=1.10.2&nolint=true');
+    return run('jquery=1.12.4&nolint=true');
   });
   testFunctions.push(function() {
     return run('jquery=2.2.4&nolint=true');


### PR DESCRIPTION
Updates the suite of tests for old jQuery versions to run with latest of
1.10.x, 1.12.x and 2.2.x.

Unlocks #17227 which is failing due to jQuery 1.8 presumably not handling
events on SVGs correctly.