### PR TITLE
[BUGFIX lts] Update backburner.js to 2.4.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-template": "^6.26.0",
-    "backburner.js": "^2.4.1",
+    "backburner.js": "^2.4.2",
     "broccoli-babel-transpiler": "^6.1.4",
     "broccoli-concat": "^3.2.2",
     "broccoli-debug": "^0.6.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,10 +1718,10 @@ backbone@^1.1.2:
   dependencies:
     underscore ">=1.8.3"
 
-backburner.js@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-2.4.1.tgz#c9f62fa3323bee21e63a3fbdd4035eb85aa3baa3"
-  integrity sha512-GwdB7cB3LL5GbR2BWTwVYnHjd5GeFW0DKo4ZsTI19Ku1jdmUHBH0Dj0l+UWqQuswscWOiO9c/S6kxvJ9mUynWA==
+backburner.js@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-2.4.2.tgz#4cc2d3e78592ddd46ae9a48cfc168ca883b56e6b"
+  integrity sha512-YFgfwWvelbJ9JxsVF+sph7nLB2qQfwDyUXCr+ZPyeU6HOXGAT0Rt+ro+mU1zRMnUfYG57nwaTiz1yqvqNO6jQQ==
 
 backo2@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Adds `autorun` info to `backburner.getDebugInfo()`.