### PR TITLE
CI: Use `ember build -prod` instead of overriding `EMBER_ENV` env var

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ jobs:
     - stage: additional tests
       name: Browserstack Tests (Safari, Edge, IE11)
       script:
-        - EMBER_ENV=production yarn ember build
+        - yarn ember build -prod
         - yarn test:browserstack
 
     - env:
@@ -82,7 +82,7 @@ jobs:
     - name: Node.js Tests
       node_js: "6"
       script:
-        - EMBER_ENV=production yarn ember build
+        - yarn ember build -prod
         - yarn test:node
 
     - name: Blueprint Tests


### PR DESCRIPTION
It seems that this is identical but slightly more conventional.

/cc @rwjblue 