### PR TITLE
broccoli/inject-node-globals: Remove unnecessary `resolveModuleSource()` call

### DIFF
--- a/broccoli/transforms/inject-node-globals.js
+++ b/broccoli/transforms/inject-node-globals.js
@@ -12,7 +12,7 @@ function injectNodeGlobals({ types: t }) {
 
           if (requireId || moduleId) {
             let specifiers = [];
-            let source = t.stringLiteral(this.file.resolveModuleSource('node-module'));
+            let source = t.stringLiteral('node-module');
 
             if (requireId) {
               delete path.scope.globals.require;


### PR DESCRIPTION
I compared the outputs of `ember build -prod` and it seems that this call is unnecessary as both outputs were identical.

A similar change happened in https://github.com/emberjs/ember.js/pull/16987/commits/e6c3adbd435c2975d34f4c783a0928338d3bbbec, but the same works for Babel 6 too.

/cc @rwjblue 