### PR TITLE
Babel: Use `babel-plugin-module-resolver` instead of deprecated `resolveModuleSource` option

### DIFF
--- a/broccoli/to-named-amd.js
+++ b/broccoli/to-named-amd.js
@@ -20,11 +20,11 @@ module.exports = function processModulesOnly(tree, strict = false) {
       // ensures `@glimmer/compiler` requiring `crypto` works properly
       // in both browser and node-land
       injectNodeGlobals,
+      ['module-resolver', { resolvePath: resolveModuleSource }],
       ['transform-es2015-modules-amd', transformOptions],
       enifed,
     ],
     moduleIds: true,
-    resolveModuleSource,
   };
 
   return new Babel(tree, options);

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@glimmer/runtime": "^0.36.4",
     "@types/qunit": "^2.5.0",
     "@types/rsvp": "^4.0.1",
-    "amd-name-resolver": "^1.2.0",
+    "amd-name-resolver": "^1.2.1",
     "auto-dist-tag": "^1.0.0",
     "aws-sdk": "^2.46.0",
     "babel-plugin-check-es2015-constants": "^6.22.0",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "babel-plugin-check-es2015-constants": "^6.22.0",
     "babel-plugin-debug-macros": "^0.2.0",
     "babel-plugin-filter-imports": "^2.0.4",
+    "babel-plugin-module-resolver": "^3.1.1",
     "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
     "babel-plugin-transform-es2015-block-scoping": "^6.26.0",
     "babel-plugin-transform-es2015-classes": "^6.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -838,12 +838,20 @@ amd-name-resolver@0.0.7:
   dependencies:
     ensure-posix-path "^1.0.1"
 
-amd-name-resolver@1.2.0, amd-name-resolver@^1.2.0:
+amd-name-resolver@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz#fc41b3848824b557313897d71f8d5a0184fbe679"
   integrity sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==
   dependencies:
     ensure-posix-path "^1.0.1"
+
+amd-name-resolver@^1.2.0, amd-name-resolver@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-1.2.1.tgz#cea40abff394268307df647ce340c83eda6e9cfc"
+  integrity sha512-cm0sUV2S8L6pwq0wpu0cHdA2KeEAmCVKy+R/qeZl/VxEn3JmU8WMM0IQrKyrnMXLXbULkZ7ptTaX8vKA0NhNvQ==
+  dependencies:
+    ensure-posix-path "^1.0.1"
+    object-hash "^1.3.1"
 
 amdefine@>=0.0.4:
   version "1.0.1"
@@ -7278,6 +7286,11 @@ object-copy@^0.1.0:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
+
+object-hash@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
+  integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
 
 object-keys@^1.0.12:
   version "1.0.12"


### PR DESCRIPTION
The `resolveModuleSource` was removed in Babel 7, so it should be considered deprecated for anyone using Babel 6. The recommended alternative is the `babel-plugin-module-resolver` plugin. `babel-plugin-module-resolver` works with both Babel 6 and 7, so we should migrate to it while still keeping the build pipeline on Babel 6. The major difference is that Babel 7 will pass an absolute path to the resolver function, while Babel 6 uses a relative path.

Partly extracted from https://github.com/emberjs/ember.js/pull/16987

/cc @rwjblue 