### PR TITLE
Babel: Use `sourceMaps` instead of `sourceMap`

### DIFF
--- a/broccoli/to-es5.js
+++ b/broccoli/to-es5.js
@@ -6,7 +6,7 @@ const injectBabelHelpers = require('./transforms/inject-babel-helpers');
 module.exports = function toES6(tree, _options) {
   let options = Object.assign({}, _options);
 
-  options.sourceMap = true;
+  options.sourceMaps = true;
   options.plugins = [
     injectBabelHelpers,
     ['transform-es2015-template-literals', { loose: true }],

--- a/broccoli/to-named-amd.js
+++ b/broccoli/to-named-amd.js
@@ -15,7 +15,7 @@ module.exports = function processModulesOnly(tree, strict = false) {
   }
 
   let options = {
-    sourceMap: true,
+    sourceMaps: true,
     plugins: [
       // ensures `@glimmer/compiler` requiring `crypto` works properly
       // in both browser and node-land


### PR DESCRIPTION
see https://old.babeljs.io/docs/core-packages/#options