### PR TITLE
Use `ember-cli-babel` to resolve module paths 

### DIFF
--- a/broccoli/to-named-amd.js
+++ b/broccoli/to-named-amd.js
@@ -1,5 +1,5 @@
 const Babel = require('broccoli-babel-transpiler');
-const resolveModuleSource = require('amd-name-resolver').moduleResolve;
+const { resolveRelativeModulePath } = require('ember-cli-babel/lib/relative-module-paths');
 const enifed = require('./transforms/transform-define');
 const injectNodeGlobals = require('./transforms/inject-node-globals');
 
@@ -20,7 +20,7 @@ module.exports = function processModulesOnly(tree, strict = false) {
       // ensures `@glimmer/compiler` requiring `crypto` works properly
       // in both browser and node-land
       injectNodeGlobals,
-      ['module-resolver', { resolvePath: resolveModuleSource }],
+      ['module-resolver', { resolvePath: resolveRelativeModulePath }],
       ['transform-es2015-modules-amd', transformOptions],
       enifed,
     ],

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^3.0.2",
     "chalk": "^2.3.0",
-    "ember-cli-babel": "^7.1.3",
+    "ember-cli-babel": "^7.1.4",
     "ember-cli-get-component-path-option": "^1.0.0",
     "ember-cli-is-package-missing": "^1.0.0",
     "ember-cli-normalize-entity-name": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "@glimmer/runtime": "^0.36.4",
     "@types/qunit": "^2.5.0",
     "@types/rsvp": "^4.0.1",
-    "amd-name-resolver": "^1.2.1",
     "auto-dist-tag": "^1.0.0",
     "aws-sdk": "^2.46.0",
     "babel-plugin-check-es2015-constants": "^6.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -838,13 +838,6 @@ amd-name-resolver@0.0.7:
   dependencies:
     ensure-posix-path "^1.0.1"
 
-amd-name-resolver@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz#fc41b3848824b557313897d71f8d5a0184fbe679"
-  integrity sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==
-  dependencies:
-    ensure-posix-path "^1.0.1"
-
 amd-name-resolver@^1.2.0, amd-name-resolver@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-1.2.1.tgz#cea40abff394268307df647ce340c83eda6e9cfc"
@@ -3449,16 +3442,16 @@ ember-cli-babel@^6.6.0:
     ember-cli-version-checker "^2.1.0"
     semver "^5.4.1"
 
-ember-cli-babel@^7.1.3:
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.1.3.tgz#a2a7374adb525369a3a205cedd54d8e0c3de3309"
-  integrity sha512-wkftzRiPiLTKAhBKphsJEH8gmJIspq04f03DUvoS2/bqrssF04hhQVRquF4EF0ZiNxKI8f4ka/puVOGeBuRWDg==
+ember-cli-babel@^7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.1.4.tgz#5f2b6ba2156d8dce2681aea92689b57ffbc71ccb"
+  integrity sha512-NmYtGSaFfXiwMX6NvpQ78u2LTWKmQjTvEKxTiFRumH0kRZ3PNiipLf2SqInUiAIHVUR2e6ihyAt5sL4mPCjK/w==
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/plugin-transform-modules-amd" "^7.0.0"
     "@babel/polyfill" "^7.0.0"
     "@babel/preset-env" "^7.0.0"
-    amd-name-resolver "1.2.0"
+    amd-name-resolver "^1.2.1"
     babel-plugin-debug-macros "^0.2.0-beta.6"
     babel-plugin-ember-modules-api-polyfill "^2.5.0"
     babel-plugin-module-resolver "^3.1.1"


### PR DESCRIPTION
This should now be fully compatible with a future upgrade of the build pipeline towards Babel 7

/cc @rwjblue 