### PR TITLE
[DOC release] Make it clear that cleanup must happen for callers of `…

### DIFF
--- a/packages/@ember/-internals/runtime/lib/mixins/container_proxy.js
+++ b/packages/@ember/-internals/runtime/lib/mixins/container_proxy.js
@@ -140,6 +140,10 @@ let containerProxyMixin = {
   // initial properties.
   ```
 
+  Any instances created via the factory's `.create()` method *must* be destroyed
+  manually by the caller of `.create()`. Typically, this is done during the creating
+  objects own `destroy` or `willDestroy` methods.
+
   @public
   @method factoryFor
   @param {String} fullName


### PR DESCRIPTION
…factoryFor().create()`.

Fixes https://github.com/emberjs/ember.js/issues/15241