### PR TITLE
Remove obsolete `nolint` option

### DIFF
--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -87,7 +87,7 @@ function generateBuiltTests() {
   var common = 'skipPackage=container,ember-testing,@ember/debug';
 
   testFunctions.push(function() {
-    return run(common + '&nolint=true');
+    return run(common);
   });
   testFunctions.push(function() {
     return run(common + '&dist=min&prod=true');
@@ -99,7 +99,7 @@ function generateBuiltTests() {
     return run(common + '&enableoptionalfeatures=true&dist=prod&prod=true');
   });
   testFunctions.push(function() {
-    return run(common + '&legacy=true&nolint=true');
+    return run(common + '&legacy=true');
   });
   testFunctions.push(function() {
     return run(common + '&legacy=true&dist=min&prod=true');
@@ -114,22 +114,22 @@ function generateBuiltTests() {
 
 function generateOldJQueryTests() {
   testFunctions.push(function() {
-    return run('jquery=1.10.2&nolint=true');
+    return run('jquery=1.10.2');
   });
   testFunctions.push(function() {
-    return run('jquery=1.12.4&nolint=true');
+    return run('jquery=1.12.4');
   });
   testFunctions.push(function() {
-    return run('jquery=2.2.4&nolint=true');
+    return run('jquery=2.2.4');
   });
 }
 
 function generateExtendPrototypeTests() {
   testFunctions.push(function() {
-    return run('extendprototypes=true&nolint=true');
+    return run('extendprototypes=true');
   });
   testFunctions.push(function() {
-    return run('extendprototypes=true&nolint=true&enableoptionalfeatures=true');
+    return run('extendprototypes=true&enableoptionalfeatures=true');
   });
 }
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -165,8 +165,7 @@
         QUnit.config.urlConfig.push({ id: 'extendprototypes', label: 'Extend Prototypes'});
         // Enable/disable livereload
         QUnit.config.urlConfig.push({ id: 'livereload', label: 'Live Reload'});
-        // Handle ESLint
-        QUnit.config.urlConfig.push({ id: 'nolint', label: 'Skip ESLint'});
+
         QUnit.config.urlConfig.push('forceskip');
 
         if (QUnit.config.seed) {
@@ -237,7 +236,6 @@
       for (var moduleName in Ember.__loader.registry) {
         if (!moduleName.match(packageRegexp))   { continue; }
         if (moduleName.match(skipPackageRegexp)) { continue; }
-        if (QUnit.urlParams.nolint && moduleName.match(/lint-test$/)) { continue; }
 
         if (moduleName.match(/[_-]test$/)) { Ember.__loader.require(moduleName); }
       }


### PR DESCRIPTION
We don't seem to generate ESLint checks inside of the test suite anymore, so this option is no longer used anywhere.