### PR TITLE
 testem: Run Firefox in headless mode 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,6 @@ stages:
     if: type IN (push)
 
 before_install:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
 

--- a/testem.travis-browsers.js
+++ b/testem.travis-browsers.js
@@ -10,4 +10,8 @@ module.exports = {
   launch_in_dev: ['Firefox'],
   launch_in_ci: ['Firefox'],
   reporter: FailureOnlyReporter,
+
+  browser_args: {
+    Firefox: { ci: ['-headless', '--window-size=1440,900'] },
+  },
 };


### PR DESCRIPTION
... to get rid of `xvfb`

/cc @stefanpenner 