### PR TITLE
Add `eslint-plugin-qunit` dev dependency

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,11 +6,13 @@ module.exports = {
     'eslint:recommended',
     'prettier',
     'plugin:import/errors',
+    'plugin:qunit/recommended',
   ],
   plugins: [
     'ember-internal',
     'prettier',
     'import',
+    'qunit',
   ],
   rules: {
     'semi': 'error',
@@ -18,6 +20,8 @@ module.exports = {
     'no-throw-literal': 'error',
     'no-useless-escape': 'off', // TODO: bring this back
     'prettier/prettier': 'error',
+    'qunit/no-commented-tests': 'off',
+    'qunit/require-expect': 'off',
   },
 
   settings: {

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "eslint-plugin-import": "^2.12.0",
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-prettier": "^3.0.0",
+    "eslint-plugin-qunit": "^4.0.0",
     "execa": "^1.0.0",
     "express": "^4.16.2",
     "finalhandler": "^1.0.2",

--- a/packages/internal-test-helpers/lib/module-for.js
+++ b/packages/internal-test-helpers/lib/module-for.js
@@ -65,6 +65,7 @@ export default function moduleFor(description, TestClass, ...mixins) {
         return this.instance[name](assert);
       });
     } else if (name.indexOf('@only ') === 0) {
+      // eslint-disable-next-line qunit/no-only
       QUnit.only(name.slice(5), function(assert) {
         return this.instance[name](assert);
       });

--- a/tests/node/template-compiler-test.js
+++ b/tests/node/template-compiler-test.js
@@ -20,8 +20,12 @@ module('ember-template-compiler.js', {
 });
 
 test('can be required', function(assert) {
-  assert.ok(typeof templateCompiler.precompile === 'function', 'precompile function is present');
-  assert.ok(typeof templateCompiler.compile === 'function', 'compile function is present');
+  assert.strictEqual(
+    typeof templateCompiler.precompile,
+    'function',
+    'precompile function is present'
+  );
+  assert.strictEqual(typeof templateCompiler.compile, 'function', 'compile function is present');
 });
 
 test('can access _Ember.ENV (private API used by ember-cli-htmlbars)', function(assert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3964,6 +3964,11 @@ eslint-plugin-prettier@^3.0.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-qunit@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-qunit/-/eslint-plugin-qunit-4.0.0.tgz#5945ba3434bfe8879bea195192e906701051cf01"
+  integrity sha512-+0i2xcYryUoLawi47Lp0iJKzkP931G5GXwIOq1KBKQc2pknV1VPjfE6b4mI2mR2RnL7WRoS30YjwC9SjQgJDXQ==
+
 eslint-scope@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"


### PR DESCRIPTION
This will become more useful once we use regular QUnit tests again...