### PR TITLE
[docs beta] refresh yarn lock so that it picks up rsvp 4.8.4

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8448,12 +8448,7 @@ rsvp@^4.7.0:
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.7.0.tgz#dc1b0b1a536f7dec9d2be45e0a12ad4197c9fd96"
   integrity sha1-3BsLGlNvfeydK+ReChKtQZfJ/ZY=
 
-rsvp@^4.8.2:
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.2.tgz#9d5647108735784eb13418cdddb56f75b919d722"
-  integrity sha512-8CU1Wjxvzt6bt8zln+hCjyieneU9s0LRW+lPRsjyVCY8Vm1kTbK7btBIrCGg6yY9U4undLDm/b1hKEEi1tLypg==
-
-rsvp@^4.8.3, rsvp@^4.8.4:
+rsvp@^4.8.2, rsvp@^4.8.3, rsvp@^4.8.4:
   version "4.8.4"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.4.tgz#b50e6b34583f3dd89329a2f23a8a2be072845911"
   integrity sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA==


### PR DESCRIPTION
Addresses https://github.com/ember-learn/ember-api-docs/issues/537

in yarn lock rsvp 4 is split into 2 entries, one taking rsvp 4.8.4 and one taking 4.8.2.  At yarn install time, yarn is picking 4.8.2 to install, and thus picking up older docs.
See: https://github.com/emberjs/ember.js/blob/beta/yarn.lock#L8451-L8459

For this PR I'm just running `yarn upgrade rsvp@^4.8.2`, which just consolidates the the 4.x releases under one entry.

This pr is point to beta.  its already fixed in release, probably from a refresh of the yarn lock.

