### PR TITLE
[FEATURE] buildRouteInfoMetadata more test assertions

### DIFF
--- a/packages/ember/tests/routing/router_service_test/build_routeinfo_metadata_test.js
+++ b/packages/ember/tests/routing/router_service_test/build_routeinfo_metadata_test.js
@@ -11,12 +11,17 @@ if (EMBER_ROUTING_BUILD_ROUTEINFO_METADATA && EMBER_ROUTING_ROUTER_SERVICE) {
     'buildRouteInfoMetadata',
     class extends RouterTestCase {
       '@test basic metadata'(assert) {
+        assert.expect(4);
         this.add(
           `route:application`,
           Route.extend({
             router: service('router'),
             init() {
               this._super(...arguments);
+              this.router.on('routeWillChange', transition => {
+                assert.equal(transition.to.name, 'parent.index');
+                assert.equal(transition.to.metadata, 'parent-index-page');
+              });
 
               this.router.on('routeDidChange', transition => {
                 assert.equal(transition.to.name, 'parent.index');
@@ -48,6 +53,15 @@ if (EMBER_ROUTING_BUILD_ROUTEINFO_METADATA && EMBER_ROUTING_ROUTER_SERVICE) {
             },
             init() {
               this._super(...arguments);
+
+              this.router.on('routeWillChange', transition => {
+                assert.equal(transition.to.name, 'parent.index');
+                assert.equal(transition.to.metadata, 'parent-index-page');
+                assert.equal(transition.to.parent.name, 'parent');
+                assert.equal(transition.to.parent.metadata, 'parent-page');
+                assert.equal(transition.to.parent.parent.name, 'application');
+                assert.equal(transition.to.parent.parent.metadata, 'application-shell');
+              });
 
               this.router.on('routeDidChange', transition => {
                 assert.equal(transition.to.name, 'parent.index');
@@ -90,6 +104,12 @@ if (EMBER_ROUTING_BUILD_ROUTEINFO_METADATA && EMBER_ROUTING_ROUTER_SERVICE) {
             init() {
               this._super(...arguments);
 
+              this.router.on('routeWillChange', transition => {
+                assert.equal(transition.to.name, 'parent.index');
+                assert.equal(transition.to.metadata.name, 'parent-index-page');
+                assert.equal(transition.to.metadata.title('PARENT'), 'My Name is PARENT');
+              });
+
               this.router.on('routeDidChange', transition => {
                 assert.equal(transition.to.name, 'parent.index');
                 assert.equal(transition.to.metadata.name, 'parent-index-page');
@@ -117,13 +137,25 @@ if (EMBER_ROUTING_BUILD_ROUTEINFO_METADATA && EMBER_ROUTING_ROUTER_SERVICE) {
       }
 
       '@test metadata is placed on the `from`'(assert) {
-        assert.expect(6);
+        assert.expect(12);
         this.add(
           `route:application`,
           Route.extend({
             router: service('router'),
             init() {
               this._super(...arguments);
+
+              this.router.on('routeWillChange', transition => {
+                if (transition.to.name === 'parent.index') {
+                  assert.equal(transition.to.metadata.name, 'parent-index-page');
+                  assert.equal(transition.to.metadata.title('INDEX'), 'My Name is INDEX');
+                } else {
+                  assert.equal(transition.from.metadata.name, 'parent-index-page');
+                  assert.equal(transition.from.metadata.title('INDEX'), 'My Name is INDEX');
+                  assert.equal(transition.to.metadata.name, 'parent-child-page');
+                  assert.equal(transition.to.metadata.title('CHILD'), 'My Name is CHILD!!');
+                }
+              });
 
               this.router.on('routeDidChange', transition => {
                 if (transition.to.name === 'parent.index') {


### PR DESCRIPTION
This assertions are being added to ensure the timing semantics of `buildRouteInfoMetadata` as router.js's test suite currently doesn't allow us to correctly test this.