### PR TITLE
Remove Hooks from qunit-rfc-232 util-test blueprint

### DIFF
--- a/blueprints/util-test/qunit-rfc-232-files/__root__/__testType__/__name__-test.js
+++ b/blueprints/util-test/qunit-rfc-232-files/__root__/__testType__/__name__-test.js
@@ -1,7 +1,7 @@
 import <%= camelizedModuleName %> from '<%= dasherizedModulePrefix %>/utils/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 
-module('<%= friendlyTestName %>', function(hooks) {
+module('<%= friendlyTestName %>', function() {
 
   // Replace this with your real tests.
   test('it works', function(assert) {

--- a/node-tests/fixtures/util-test/rfc232.js
+++ b/node-tests/fixtures/util-test/rfc232.js
@@ -1,7 +1,7 @@
 import fooBar from 'my-app/utils/foo-bar';
 import { module, test } from 'qunit';
 
-module('Unit | Utility | foo-bar', function(hooks) {
+module('Unit | Utility | foo-bar', function() {
 
   // Replace this with your real tests.
   test('it works', function(assert) {


### PR DESCRIPTION
It's not used
so a dev have to delete it by hand after generating a test