### PR TITLE
tests: Remove obsolete IE8 comment

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -19,7 +19,7 @@
     </script>
 
     <script type="text/javascript">
-      // Load custom version of jQuery if possible (assign to window so IE8 can use in later blocks)
+      // Load custom version of jQuery if possible
       var jQueryVersion = QUnit.urlParams.jquery;
       if (jQueryVersion && jQueryVersion !== 'none') {
         loadScript('https://code.jquery.com/jquery-'+jQueryVersion+'.js');


### PR DESCRIPTION
This doesn't seem to be true anymore