### PR TITLE
internal-test-helpers: Move `NodeQuery` class out of the `test-cases` folder

### DIFF
--- a/packages/internal-test-helpers/lib/node-query.js
+++ b/packages/internal-test-helpers/lib/node-query.js
@@ -1,7 +1,7 @@
 /* global Node */
 
 import { assert } from '@ember/debug';
-import { fireEvent, focus, matches } from '../system/synthetic-events';
+import { fireEvent, focus, matches } from './system/synthetic-events';
 
 export default class NodeQuery {
   static query(selector, context = document) {

--- a/packages/internal-test-helpers/lib/test-cases/abstract.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract.js
@@ -3,7 +3,7 @@
 import { assign } from '@ember/polyfills';
 import { getCurrentRunLoop, hasScheduledTimers, next, run } from '@ember/runloop';
 
-import NodeQuery from './node-query';
+import NodeQuery from '../node-query';
 import equalInnerHTML from '../equal-inner-html';
 import equalTokens from '../equal-tokens';
 import { equalsElement, regex, classes } from '../matchers';


### PR DESCRIPTION
`NodeQuery` is a utility class, not an (abstract) test case.