### PR TITLE
internal-test-helpers: Extract `setupDeprecation/WarningHelpers()` functions

### DIFF
--- a/packages/internal-test-helpers/lib/ember-dev/deprecation.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/deprecation.ts
@@ -16,6 +16,20 @@ declare global {
   }
 }
 
+export function setupDeprecationHelpers(hooks: NestedHooks, env: DebugEnv) {
+  let assertion = new DeprecationAssert(env);
+
+  hooks.beforeEach(function() {
+    assertion.reset();
+    assertion.inject();
+  });
+
+  hooks.afterEach(function() {
+    assertion.assert();
+    assertion.restore();
+  });
+}
+
 class DeprecationAssert extends DebugAssert {
   constructor(env: DebugEnv) {
     super('deprecate', env);

--- a/packages/internal-test-helpers/lib/ember-dev/index.js
+++ b/packages/internal-test-helpers/lib/ember-dev/index.js
@@ -1,8 +1,0 @@
-import DeprecationAssert from './deprecation';
-import WarningAssert from './warning';
-
-import { buildCompositeAssert } from './utils';
-
-var EmberDevTestHelperAssert = buildCompositeAssert([DeprecationAssert, WarningAssert]);
-
-export default EmberDevTestHelperAssert;

--- a/packages/internal-test-helpers/lib/ember-dev/setup-qunit.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/setup-qunit.ts
@@ -3,14 +3,14 @@ import { getDebugFunction, setDebugFunction } from '@ember/debug';
 import { setupAssertionHelpers } from './assertion';
 // @ts-ignore
 import { setupContainersCheck } from './containers';
+import { setupDeprecationHelpers } from './deprecation';
 import HooksCompat from './hooks-compat';
-// @ts-ignore
-import EmberDevTestHelperAssert from './index';
 // @ts-ignore
 import { setupNamespacesCheck } from './namespaces';
 // @ts-ignore
 import { setupRunLoopCheck } from './run-loop';
 import { DebugEnv } from './utils';
+import { setupWarningHelpers } from './warning';
 
 export default function setupQUnit({ runningProdBuild }: { runningProdBuild: boolean }) {
   let env = {
@@ -19,23 +19,13 @@ export default function setupQUnit({ runningProdBuild }: { runningProdBuild: boo
     setDebugFunction,
   } as DebugEnv;
 
-  let assertion = new EmberDevTestHelperAssert(env);
-
   function setupAssert(hooks: NestedHooks) {
     setupContainersCheck(hooks);
     setupNamespacesCheck(hooks);
     setupRunLoopCheck(hooks);
     setupAssertionHelpers(hooks, env);
-
-    hooks.beforeEach(function() {
-      assertion.reset();
-      assertion.inject();
-    });
-
-    hooks.afterEach(function() {
-      assertion.assert();
-      assertion.restore();
-    });
+    setupDeprecationHelpers(hooks, env);
+    setupWarningHelpers(hooks, env);
   }
 
   let originalModule = QUnit.module;

--- a/packages/internal-test-helpers/lib/ember-dev/utils.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/utils.ts
@@ -1,25 +1,3 @@
-export type AssertClass = new (env: DebugEnv) => void;
-
-interface Composite {
-  asserts: ReadonlyArray<any>;
-}
-
-interface Obj {
-  [key: string]: () => void;
-}
-
-interface CallForEachSubject {
-  [key: string]: Obj[];
-}
-
-function callForEach(prop: string, func: string) {
-  return function(this: CallForEachSubject) {
-    for (let i = 0, l = this[prop].length; i < l; i++) {
-      this[prop][i][func]();
-    }
-  };
-}
-
 export type Message = string | RegExp;
 export type Test = (() => boolean) | boolean;
 export type DebugFunctionOptions = object;
@@ -29,23 +7,6 @@ export interface DebugEnv {
   runningProdBuild: boolean;
   getDebugFunction(name: string): DebugFunction;
   setDebugFunction(name: string, func: DebugFunction): void;
-}
-
-export function buildCompositeAssert<TAssert extends AssertClass>(
-  assertClasses: ReadonlyArray<TAssert>
-) {
-  function Composite(this: Composite, env: DebugEnv) {
-    this.asserts = assertClasses.map(Assert => new Assert(env));
-  }
-
-  Composite.prototype = {
-    reset: callForEach('asserts', 'reset'),
-    inject: callForEach('asserts', 'inject'),
-    assert: callForEach('asserts', 'assert'),
-    restore: callForEach('asserts', 'restore'),
-  };
-
-  return Composite;
 }
 
 function noop() {}

--- a/packages/internal-test-helpers/lib/ember-dev/warning.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/warning.ts
@@ -16,6 +16,20 @@ declare global {
   }
 }
 
+export function setupWarningHelpers(hooks: NestedHooks, env: DebugEnv) {
+  let assertion = new WarningAssert(env);
+
+  hooks.beforeEach(function() {
+    assertion.reset();
+    assertion.inject();
+  });
+
+  hooks.afterEach(function() {
+    assertion.assert();
+    assertion.restore();
+  });
+}
+
 class WarningAssert extends DebugAssert {
   constructor(env: DebugEnv) {
     super('warn', env);


### PR DESCRIPTION
... and get rid of the confusing `EmberDevTestHelperAssert` class