### PR TITLE
[BUGFIX release] Publish builds to s3 on release & beta channels even

### DIFF
--- a/bin/publish_to_s3.js
+++ b/bin/publish_to_s3.js
@@ -17,7 +17,7 @@ const buildInfo = require('../broccoli/build-info').buildInfo();
 // ./bin/publish_to_s3.js
 // ```
 
-if (!buildInfo.tag) {
+if (!buildInfo.isBuildForTag) {
   const S3Publisher = require('ember-publisher');
   const configPath = require('path').join(__dirname, '../config/s3ProjectConfig.js');
 

--- a/config/s3ProjectConfig.js
+++ b/config/s3ProjectConfig.js
@@ -63,12 +63,6 @@ function fileObject(baseName, extension, contentType, currentRevision, tag, date
     },
   };
 
-  if (tag) {
-    for (var key in obj.destinations) {
-      obj.destinations[key].push('tags/' + tag + fullName);
-    }
-  }
-
   return obj;
 }
 


### PR DESCRIPTION
when there is a tag for the commit.

- Always publish as a tag when publishing locally (vs on Travis)

Fixes #17297 