### PR TITLE
internal-test-helpers: Remove obsolete promise filtering

### DIFF
--- a/packages/internal-test-helpers/lib/module-for.js
+++ b/packages/internal-test-helpers/lib/module-for.js
@@ -24,19 +24,7 @@ export default function moduleFor(description, TestClass, ...mixins) {
         promises.push(instance.afterEach());
       }
 
-      // this seems odd, but actually saves significant time
-      // in the test suite
-      //
-      // returning a promise from a QUnit test always adds a 13ms
-      // delay to the test, this filtering prevents returning a
-      // promise when it is not needed
-      //
-      // Remove after we can update to QUnit that includes
-      // https://github.com/qunitjs/qunit/pull/1246
-      let filteredPromises = promises.filter(Boolean);
-      if (filteredPromises.length > 0) {
-        return all(filteredPromises);
-      }
+      return all(promises);
     },
   });
 


### PR DESCRIPTION
We are using the most recent QUnit release now, that includes the fix mentioned in the comment.