### PR TITLE
internal-test-helpers/ember-dev: Convert to TypeScript 

### DIFF
--- a/packages/internal-test-helpers/lib/ember-dev/containers.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/containers.ts
@@ -2,7 +2,7 @@ import { Container } from '@ember/-internals/container';
 
 const { _leakTracking: containerLeakTracking } = Container;
 
-export function setupContainersCheck(hooks) {
+export function setupContainersCheck(hooks: NestedHooks) {
   hooks.afterEach(function() {
     if (containerLeakTracking === undefined) return;
 
@@ -19,7 +19,7 @@ export function setupContainersCheck(hooks) {
       originalFinish.call(this);
       originalFinish = undefined;
 
-      config.queue.unshift(function() {
+      (config as any).queue.unshift(function() {
         if (containerLeakTracking.hasContainers()) {
           containerLeakTracking.reset();
           // eslint-disable-next-line no-console

--- a/packages/internal-test-helpers/lib/ember-dev/namespaces.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/namespaces.ts
@@ -1,7 +1,7 @@
-import { run } from '@ember/runloop';
 import { NAMESPACES, NAMESPACES_BY_ID } from '@ember/-internals/metal';
+import { run } from '@ember/runloop';
 
-export function setupNamespacesCheck(hooks) {
+export function setupNamespacesCheck(hooks: NestedHooks) {
   hooks.afterEach(function() {
     let { assert } = QUnit.config.current;
 

--- a/packages/internal-test-helpers/lib/ember-dev/run-loop.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/run-loop.ts
@@ -1,6 +1,7 @@
+// @ts-ignore
 import { cancelTimers, end, getCurrentRunLoop, hasScheduledTimers } from '@ember/runloop';
 
-export function setupRunLoopCheck(hooks) {
+export function setupRunLoopCheck(hooks: NestedHooks) {
   hooks.afterEach(function() {
     let { assert } = QUnit.config.current;
 

--- a/packages/internal-test-helpers/lib/ember-dev/setup-qunit.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/setup-qunit.ts
@@ -1,7 +1,6 @@
 import { getDebugFunction, setDebugFunction } from '@ember/debug';
 
 import { setupAssertionHelpers } from './assertion';
-// @ts-ignore
 import { setupContainersCheck } from './containers';
 import { setupDeprecationHelpers } from './deprecation';
 import HooksCompat from './hooks-compat';

--- a/packages/internal-test-helpers/lib/ember-dev/setup-qunit.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/setup-qunit.ts
@@ -6,7 +6,6 @@ import { setupDeprecationHelpers } from './deprecation';
 import HooksCompat from './hooks-compat';
 // @ts-ignore
 import { setupNamespacesCheck } from './namespaces';
-// @ts-ignore
 import { setupRunLoopCheck } from './run-loop';
 import { DebugEnv } from './utils';
 import { setupWarningHelpers } from './warning';

--- a/packages/internal-test-helpers/lib/ember-dev/setup-qunit.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/setup-qunit.ts
@@ -4,7 +4,6 @@ import { setupAssertionHelpers } from './assertion';
 import { setupContainersCheck } from './containers';
 import { setupDeprecationHelpers } from './deprecation';
 import HooksCompat from './hooks-compat';
-// @ts-ignore
 import { setupNamespacesCheck } from './namespaces';
 import { setupRunLoopCheck } from './run-loop';
 import { DebugEnv } from './utils';


### PR DESCRIPTION
... because `@ts-ignore` is annoying 😅 