### PR TITLE
tests/glimmer: Remove unnecessary `internal-test-helpers` reexports

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/application/actions-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/actions-test.js
@@ -1,7 +1,9 @@
+import { moduleFor, ApplicationTestCase, RenderingTestCase } from 'internal-test-helpers';
+
 import Controller from '@ember/controller';
-import { moduleFor, ApplicationTestCase, RenderingTestCase } from '../../utils/test-case';
-import { Component } from '../../utils/helpers';
 import { getDebugFunction, setDebugFunction } from '@ember/debug';
+
+import { Component } from '../../utils/helpers';
 
 const originalDebug = getDebugFunction('debug');
 const noop = function() {};

--- a/packages/@ember/-internals/glimmer/tests/integration/application/actions-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/actions-test.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { moduleFor, ApplicationTest, RenderingTest } from '../../utils/test-case';
+import { moduleFor, ApplicationTestCase, RenderingTestCase } from '../../utils/test-case';
 import { Component } from '../../utils/helpers';
 import { getDebugFunction, setDebugFunction } from '@ember/debug';
 
@@ -8,7 +8,7 @@ const noop = function() {};
 
 moduleFor(
   'Application test: actions',
-  class extends ApplicationTest {
+  class extends ApplicationTestCase {
     constructor() {
       setDebugFunction('debug', noop);
       super(...arguments);
@@ -80,7 +80,7 @@ moduleFor(
 
 moduleFor(
   'Rendering test: non-interactive actions',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     getBootOptions() {
       return { isInteractive: false };
     }

--- a/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
@@ -1,12 +1,13 @@
-import { moduleFor, ApplicationTestCase } from '../../utils/test-case';
-import { strip } from '../../utils/abstract-test-case';
-import { compile } from '../../utils/helpers';
+import { moduleFor, ApplicationTestCase, strip } from 'internal-test-helpers';
+
 import Controller from '@ember/controller';
 import { RSVP } from '@ember/-internals/runtime';
 import { Component } from '@ember/-internals/glimmer';
 import Engine from '@ember/engine';
 import { Route } from '@ember/-internals/routing';
 import { next } from '@ember/runloop';
+
+import { compile } from '../../utils/helpers';
 
 moduleFor(
   'Application test: engine rendering',

--- a/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, ApplicationTest } from '../../utils/test-case';
+import { moduleFor, ApplicationTestCase } from '../../utils/test-case';
 import { strip } from '../../utils/abstract-test-case';
 import { compile } from '../../utils/helpers';
 import Controller from '@ember/controller';
@@ -10,7 +10,7 @@ import { next } from '@ember/runloop';
 
 moduleFor(
   'Application test: engine rendering',
-  class extends ApplicationTest {
+  class extends ApplicationTestCase {
     get routerOptions() {
       return {
         location: 'none',

--- a/packages/@ember/-internals/glimmer/tests/integration/application/hot-reload-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/hot-reload-test.js
@@ -2,7 +2,7 @@ import { ENV } from '@ember/-internals/environment';
 import Service, { inject as injectService } from '@ember/service';
 import { Component, Helper } from '@ember/-internals/glimmer';
 import { expect } from '@glimmer/util';
-import { moduleFor, ApplicationTest } from '../../utils/test-case';
+import { moduleFor, ApplicationTestCase } from '../../utils/test-case';
 import { strip } from '../../utils/abstract-test-case';
 
 // This simuates what the template hot-reloading would do in development mode
@@ -10,7 +10,7 @@ import { strip } from '../../utils/abstract-test-case';
 
 moduleFor(
   'Appliation test: template hot reloading',
-  class extends ApplicationTest {
+  class extends ApplicationTestCase {
     constructor() {
       super(...arguments);
       this._APPLICATION_TEMPLATE_WRAPPER = ENV._APPLICATION_TEMPLATE_WRAPPER;

--- a/packages/@ember/-internals/glimmer/tests/integration/application/hot-reload-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/hot-reload-test.js
@@ -1,9 +1,9 @@
+import { moduleFor, ApplicationTestCase, strip } from 'internal-test-helpers';
+
 import { ENV } from '@ember/-internals/environment';
 import Service, { inject as injectService } from '@ember/service';
 import { Component, Helper } from '@ember/-internals/glimmer';
 import { expect } from '@glimmer/util';
-import { moduleFor, ApplicationTestCase } from '../../utils/test-case';
-import { strip } from '../../utils/abstract-test-case';
 
 // This simuates what the template hot-reloading would do in development mode
 // to avoid regressions

--- a/packages/@ember/-internals/glimmer/tests/integration/application/rendering-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/rendering-test.js
@@ -1,7 +1,7 @@
+import { moduleFor, ApplicationTestCase, strip } from 'internal-test-helpers';
+
 import { ENV } from '@ember/-internals/environment';
 import Controller from '@ember/controller';
-import { moduleFor, ApplicationTestCase } from '../../utils/test-case';
-import { strip } from '../../utils/abstract-test-case';
 import { Route } from '@ember/-internals/routing';
 import { Component } from '@ember/-internals/glimmer';
 

--- a/packages/@ember/-internals/glimmer/tests/integration/application/rendering-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/rendering-test.js
@@ -1,13 +1,13 @@
 import { ENV } from '@ember/-internals/environment';
 import Controller from '@ember/controller';
-import { moduleFor, ApplicationTest } from '../../utils/test-case';
+import { moduleFor, ApplicationTestCase } from '../../utils/test-case';
 import { strip } from '../../utils/abstract-test-case';
 import { Route } from '@ember/-internals/routing';
 import { Component } from '@ember/-internals/glimmer';
 
 moduleFor(
   'Application test: rendering',
-  class extends ApplicationTest {
+  class extends ApplicationTestCase {
     constructor() {
       super(...arguments);
       this._APPLICATION_TEMPLATE_WRAPPER = ENV._APPLICATION_TEMPLATE_WRAPPER;

--- a/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
@@ -1,9 +1,9 @@
+import { moduleFor, RenderingTestCase, strip, classes } from 'internal-test-helpers';
+
 import { EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION } from '@ember/canary-features';
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { set } from '@ember/-internals/metal';
+
 import { Component } from '../../utils/helpers';
-import { strip } from '../../utils/abstract-test-case';
-import { classes } from '../../utils/test-helpers';
 
 if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
   moduleFor(

--- a/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
@@ -1,5 +1,5 @@
 import { EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION } from '@ember/canary-features';
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { set } from '@ember/-internals/metal';
 import { Component } from '../../utils/helpers';
 import { strip } from '../../utils/abstract-test-case';
@@ -8,7 +8,7 @@ import { classes } from '../../utils/test-helpers';
 if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
   moduleFor(
     'AngleBracket Invocation',
-    class extends RenderingTest {
+    class extends RenderingTestCase {
       '@test it can resolve <XBlah /> to x-blah'() {
         this.registerComponent('x-blah', { template: 'hello' });
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/append-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/append-test.js
@@ -1,7 +1,8 @@
+import { moduleFor, RenderingTestCase, strip } from 'internal-test-helpers';
+
 import { set } from '@ember/-internals/metal';
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
+
 import { Component, compile } from '../../utils/helpers';
-import { strip } from '../../utils/abstract-test-case';
 
 class AbstractAppendTest extends RenderingTestCase {
   constructor() {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/append-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/append-test.js
@@ -1,9 +1,9 @@
 import { set } from '@ember/-internals/metal';
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { Component, compile } from '../../utils/helpers';
 import { strip } from '../../utils/abstract-test-case';
 
-class AbstractAppendTest extends RenderingTest {
+class AbstractAppendTest extends RenderingTestCase {
   constructor() {
     super(...arguments);
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/attribute-bindings-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/attribute-bindings-test.js
@@ -1,11 +1,11 @@
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { Component } from '../../utils/helpers';
 import { strip } from '../../utils/abstract-test-case';
 import { set } from '@ember/-internals/metal';
 
 moduleFor(
   'Attribute bindings integration',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test it can have attribute bindings']() {
       let FooBarComponent = Component.extend({
         attributeBindings: ['foo:data-foo', 'bar:data-bar'],

--- a/packages/@ember/-internals/glimmer/tests/integration/components/attribute-bindings-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/attribute-bindings-test.js
@@ -1,7 +1,8 @@
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
-import { Component } from '../../utils/helpers';
-import { strip } from '../../utils/abstract-test-case';
+import { moduleFor, RenderingTestCase, strip } from 'internal-test-helpers';
+
 import { set } from '@ember/-internals/metal';
+
+import { Component } from '../../utils/helpers';
 
 moduleFor(
   'Attribute bindings integration',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/attrs-lookup-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/attrs-lookup-test.js
@@ -1,11 +1,11 @@
-import { RenderingTest, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../../utils/test-case';
 import { Component, htmlSafe } from '../../utils/helpers';
 import { set, computed } from '@ember/-internals/metal';
 import { styles } from '../../utils/test-helpers';
 
 moduleFor(
   'Components test: attrs lookup',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test it should be able to lookup attrs without `attrs.` - template access']() {
       this.registerComponent('foo-bar', { template: '{{first}}' });
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/attrs-lookup-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/attrs-lookup-test.js
@@ -1,7 +1,8 @@
-import { RenderingTestCase, moduleFor } from '../../utils/test-case';
-import { Component, htmlSafe } from '../../utils/helpers';
+import { moduleFor, RenderingTestCase, styles } from 'internal-test-helpers';
+
 import { set, computed } from '@ember/-internals/metal';
-import { styles } from '../../utils/test-helpers';
+
+import { Component, htmlSafe } from '../../utils/helpers';
 
 moduleFor(
   'Components test: attrs lookup',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/class-bindings-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/class-bindings-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { Component } from '../../utils/helpers';
 import { classes } from '../../utils/test-helpers';
 import { set, computed } from '@ember/-internals/metal';
@@ -6,7 +6,7 @@ import { strip } from '../../utils/abstract-test-case';
 
 moduleFor(
   'ClassNameBindings integration',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test it can have class name bindings on the class definition']() {
       let FooBarComponent = Component.extend({
         classNameBindings: ['foo', 'isEnabled:enabled', 'isHappy:happy:sad'],
@@ -673,7 +673,7 @@ moduleFor(
 
 moduleFor(
   'ClassBinding integration',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test it should apply classBinding without condition always']() {
       this.registerComponent('foo-bar', { template: 'hello' });
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/class-bindings-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/class-bindings-test.js
@@ -1,8 +1,8 @@
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
-import { Component } from '../../utils/helpers';
-import { classes } from '../../utils/test-helpers';
+import { moduleFor, RenderingTestCase, strip, classes } from 'internal-test-helpers';
+
 import { set, computed } from '@ember/-internals/metal';
-import { strip } from '../../utils/abstract-test-case';
+
+import { Component } from '../../utils/helpers';
 
 moduleFor(
   'ClassNameBindings integration',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
@@ -1,13 +1,13 @@
 import { assign } from '@ember/polyfills';
 import { Component } from '../../utils/helpers';
 import { applyMixins, strip } from '../../utils/abstract-test-case';
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { isEmpty } from '@ember/-internals/metal';
 import { A as emberA } from '@ember/-internals/runtime';
 
 moduleFor(
   'Components test: contextual components',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test renders with component helper']() {
       let expectedText = 'Hodi';
 
@@ -1322,7 +1322,7 @@ moduleFor(
   }
 );
 
-class ContextualComponentMutableParamsTest extends RenderingTest {
+class ContextualComponentMutableParamsTest extends RenderingTestCase {
   render(templateStr, context = {}) {
     super.render(
       `${templateStr}<span class="value">{{model.val2}}</span>`,

--- a/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
@@ -1,9 +1,10 @@
+import { moduleFor, RenderingTestCase, applyMixins, strip } from 'internal-test-helpers';
+
 import { assign } from '@ember/polyfills';
-import { Component } from '../../utils/helpers';
-import { applyMixins, strip } from '../../utils/abstract-test-case';
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { isEmpty } from '@ember/-internals/metal';
 import { A as emberA } from '@ember/-internals/runtime';
+
+import { Component } from '../../utils/helpers';
 
 moduleFor(
   'Components test: contextual components',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
@@ -7,12 +7,12 @@ import { Object as EmberObject, A as emberA } from '@ember/-internals/runtime';
 import { jQueryDisabled } from '@ember/-internals/views';
 import { Component, compile, htmlSafe } from '../../utils/helpers';
 import { strip } from '../../utils/abstract-test-case';
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { classes, equalTokens, equalsElement, styles } from '../../utils/test-helpers';
 
 moduleFor(
   'Components test: curly components',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test it can render a basic component']() {
       this.registerComponent('foo-bar', { template: 'hello' });
 
@@ -3572,7 +3572,7 @@ moduleFor(
 if (jQueryDisabled) {
   moduleFor(
     'Components test: curly components: jQuery disabled',
-    class extends RenderingTest {
+    class extends RenderingTestCase {
       ['@test jQuery proxy is not available without jQuery']() {
         let instance;
 
@@ -3599,7 +3599,7 @@ if (jQueryDisabled) {
 } else {
   moduleFor(
     'Components test: curly components: jQuery enabled',
-    class extends RenderingTest {
+    class extends RenderingTestCase {
       ['@test it has a jQuery proxy to the element']() {
         let instance;
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
@@ -1,14 +1,23 @@
+/* globals EmberDev */
+
+import {
+  moduleFor,
+  RenderingTestCase,
+  strip,
+  classes,
+  equalTokens,
+  equalsElement,
+  styles,
+} from 'internal-test-helpers';
+
 import { run } from '@ember/runloop';
 import { DEBUG } from '@glimmer/env';
-/* globals EmberDev */
 import { set, get, observer, on, computed } from '@ember/-internals/metal';
 import Service, { inject as injectService } from '@ember/service';
 import { Object as EmberObject, A as emberA } from '@ember/-internals/runtime';
 import { jQueryDisabled } from '@ember/-internals/views';
+
 import { Component, compile, htmlSafe } from '../../utils/helpers';
-import { strip } from '../../utils/abstract-test-case';
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
-import { classes, equalTokens, equalsElement, styles } from '../../utils/test-helpers';
 
 moduleFor(
   'Components test: curly components',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/destroy-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/destroy-test.js
@@ -1,6 +1,8 @@
+import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
+
 import { set } from '@ember/-internals/metal';
+
 import { Component } from '../../utils/helpers';
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 
 moduleFor(
   'Component destroy',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/destroy-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/destroy-test.js
@@ -1,10 +1,10 @@
 import { set } from '@ember/-internals/metal';
 import { Component } from '../../utils/helpers';
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 
 moduleFor(
   'Component destroy',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test it correctly releases the destroyed components'](assert) {
       let FooBarComponent = Component.extend({});
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
@@ -1,9 +1,10 @@
+import { moduleFor, RenderingTestCase, strip } from 'internal-test-helpers';
+
 import { EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION } from '@ember/canary-features';
 import { set, computed } from '@ember/-internals/metal';
 import { jQueryDisabled } from '@ember/-internals/views';
+
 import { Component } from '../../utils/helpers';
-import { strip } from '../../utils/abstract-test-case';
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 
 moduleFor(
   'Components test: dynamic components',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
@@ -3,11 +3,11 @@ import { set, computed } from '@ember/-internals/metal';
 import { jQueryDisabled } from '@ember/-internals/views';
 import { Component } from '../../utils/helpers';
 import { strip } from '../../utils/abstract-test-case';
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 
 moduleFor(
   'Components test: dynamic components',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test it can render a basic component with a static component name argument']() {
       this.registerComponent('foo-bar', { template: 'hello {{name}}' });
 
@@ -804,7 +804,7 @@ moduleFor(
 if (jQueryDisabled) {
   moduleFor(
     'Components test: dynamic components: jQuery disabled',
-    class extends RenderingTest {
+    class extends RenderingTestCase {
       ['@test jQuery proxy is not available without jQuery']() {
         let instance;
 
@@ -831,7 +831,7 @@ if (jQueryDisabled) {
 } else {
   moduleFor(
     'Components test: dynamic components : jQuery enabled',
-    class extends RenderingTest {
+    class extends RenderingTestCase {
       ['@test it has a jQuery proxy to the element']() {
         let instance;
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/error-handling-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/error-handling-test.js
@@ -1,6 +1,8 @@
+import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
+
 import { set } from '@ember/-internals/metal';
+
 import { Component } from '../../utils/helpers';
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 
 moduleFor(
   'Errors thrown during render',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/error-handling-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/error-handling-test.js
@@ -1,10 +1,10 @@
 import { set } from '@ember/-internals/metal';
 import { Component } from '../../utils/helpers';
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 
 moduleFor(
   'Errors thrown during render',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test it can recover resets the transaction when an error is thrown during initial render'](
       assert
     ) {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/fragment-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/fragment-components-test.js
@@ -1,7 +1,8 @@
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
-import { strip } from '../../utils/abstract-test-case';
-import { Component } from '../../utils/helpers';
+import { moduleFor, RenderingTestCase, strip } from 'internal-test-helpers';
+
 import { set } from '@ember/-internals/metal';
+
+import { Component } from '../../utils/helpers';
 
 moduleFor(
   'Components test: fragment components',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/fragment-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/fragment-components-test.js
@@ -1,11 +1,11 @@
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { strip } from '../../utils/abstract-test-case';
 import { Component } from '../../utils/helpers';
 import { set } from '@ember/-internals/metal';
 
 moduleFor(
   'Components test: fragment components',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     getCustomDispatcherEvents() {
       return {
         hitDem: 'folks',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/instrumentation-compile-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/instrumentation-compile-test.js
@@ -1,9 +1,11 @@
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
-import { Component } from '../../utils/helpers';
+import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
+
 import {
   subscribe as instrumentationSubscribe,
   reset as instrumentationReset,
 } from '@ember/instrumentation';
+
+import { Component } from '../../utils/helpers';
 
 moduleFor(
   'Components compile instrumentation',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/instrumentation-compile-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/instrumentation-compile-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { Component } from '../../utils/helpers';
 import {
   subscribe as instrumentationSubscribe,
@@ -7,7 +7,7 @@ import {
 
 moduleFor(
   'Components compile instrumentation',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     constructor() {
       super(...arguments);
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/instrumentation-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/instrumentation-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { Component } from '../../utils/helpers';
 import { set } from '@ember/-internals/metal';
 import {
@@ -8,7 +8,7 @@ import {
 
 moduleFor(
   'Components instrumentation',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     constructor() {
       super(...arguments);
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/instrumentation-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/instrumentation-test.js
@@ -1,10 +1,12 @@
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
-import { Component } from '../../utils/helpers';
+import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
+
 import { set } from '@ember/-internals/metal';
 import {
   subscribe as instrumentationSubscribe,
   reset as instrumentationReset,
 } from '@ember/instrumentation';
+
+import { Component } from '../../utils/helpers';
 
 moduleFor(
   'Components instrumentation',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/life-cycle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/life-cycle-test.js
@@ -1,13 +1,12 @@
+import { moduleFor, RenderingTestCase, classes, strip, runAppend } from 'internal-test-helpers';
+
 import { schedule } from '@ember/runloop';
 import { set, setProperties } from '@ember/-internals/metal';
 import { A as emberA } from '@ember/-internals/runtime';
-import { Component } from '../../utils/helpers';
-import { strip } from '../../utils/abstract-test-case';
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { getViewId, getViewElement, jQueryDisabled } from '@ember/-internals/views';
-import { classes } from '../../utils/test-helpers';
 import { tryInvoke } from '@ember/-internals/utils';
-import { runAppend } from 'internal-test-helpers';
+
+import { Component } from '../../utils/helpers';
 
 class LifeCycleHooksTest extends RenderingTestCase {
   constructor() {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/life-cycle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/life-cycle-test.js
@@ -3,13 +3,13 @@ import { set, setProperties } from '@ember/-internals/metal';
 import { A as emberA } from '@ember/-internals/runtime';
 import { Component } from '../../utils/helpers';
 import { strip } from '../../utils/abstract-test-case';
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { getViewId, getViewElement, jQueryDisabled } from '@ember/-internals/views';
 import { classes } from '../../utils/test-helpers';
 import { tryInvoke } from '@ember/-internals/utils';
 import { runAppend } from 'internal-test-helpers';
 
-class LifeCycleHooksTest extends RenderingTest {
+class LifeCycleHooksTest extends RenderingTestCase {
   constructor() {
     super(...arguments);
     this.hooks = [];
@@ -1335,7 +1335,7 @@ moduleFor(
 
 moduleFor(
   'Run loop and lifecycle hooks',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test afterRender set']() {
       let ComponentClass = Component.extend({
         width: '5',
@@ -1595,7 +1595,7 @@ moduleFor(
 if (!jQueryDisabled) {
   moduleFor(
     'Run loop and lifecycle hooks - jQuery only',
-    class extends RenderingTest {
+    class extends RenderingTestCase {
       ['@test lifecycle hooks have proper access to this.$()'](assert) {
         assert.expect(6);
         let component;

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, ApplicationTest, RenderingTest } from '../../utils/test-case';
+import { moduleFor, ApplicationTestCase, RenderingTestCase } from '../../utils/test-case';
 import Controller from '@ember/controller';
 import { set } from '@ember/-internals/metal';
 import { LinkComponent } from '../../utils/helpers';
@@ -6,7 +6,7 @@ import { classes as classMatcher } from '../../utils/test-helpers';
 
 moduleFor(
   'Link-to component',
-  class extends ApplicationTest {
+  class extends ApplicationTestCase {
     visitWithDeprecation(path, deprecation) {
       let p;
 
@@ -157,7 +157,7 @@ moduleFor(
 
 moduleFor(
   'Link-to component with query-params',
-  class extends ApplicationTest {
+  class extends ApplicationTestCase {
     constructor() {
       super(...arguments);
 
@@ -202,7 +202,7 @@ moduleFor(
 
 moduleFor(
   'Link-to component',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test should be able to be inserted in DOM when the router is not present - block']() {
       this.render(`{{#link-to 'index'}}Go to Index{{/link-to}}`);
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to-test.js
@@ -1,8 +1,14 @@
-import { moduleFor, ApplicationTestCase, RenderingTestCase } from '../../utils/test-case';
+import {
+  moduleFor,
+  ApplicationTestCase,
+  RenderingTestCase,
+  classes as classMatcher,
+} from 'internal-test-helpers';
+
 import Controller from '@ember/controller';
 import { set } from '@ember/-internals/metal';
+
 import { LinkComponent } from '../../utils/helpers';
-import { classes as classMatcher } from '../../utils/test-helpers';
 
 moduleFor(
   'Link-to component',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/local-lookup-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/local-lookup-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { compile } from 'ember-template-compiler';
 import { ModuleBasedTestResolver } from 'internal-test-helpers';
 import { moduleFor as applicationModuleFor, ApplicationTestCase } from 'internal-test-helpers';
@@ -6,7 +6,7 @@ import { Component } from '../../utils/helpers';
 import { EMBER_MODULE_UNIFICATION } from '@ember/canary-features';
 import { helper, Helper } from '@ember/-internals/glimmer';
 
-class LocalLookupTest extends RenderingTest {
+class LocalLookupTest extends RenderingTestCase {
   ['@test it can lookup a local template']() {
     this.registerComponent('x-outer/x-inner', {
       template: 'Nested template says: {{yield}}',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/local-lookup-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/local-lookup-test.js
@@ -1,10 +1,15 @@
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
+import {
+  moduleFor,
+  RenderingTestCase,
+  ModuleBasedTestResolver,
+  ApplicationTestCase,
+} from 'internal-test-helpers';
+
 import { compile } from 'ember-template-compiler';
-import { ModuleBasedTestResolver } from 'internal-test-helpers';
-import { moduleFor as applicationModuleFor, ApplicationTestCase } from 'internal-test-helpers';
-import { Component } from '../../utils/helpers';
 import { EMBER_MODULE_UNIFICATION } from '@ember/canary-features';
 import { helper, Helper } from '@ember/-internals/glimmer';
+
+import { Component } from '../../utils/helpers';
 
 class LocalLookupTest extends RenderingTestCase {
   ['@test it can lookup a local template']() {
@@ -370,7 +375,7 @@ if (EMBER_MODULE_UNIFICATION) {
 }
 
 if (EMBER_MODULE_UNIFICATION) {
-  applicationModuleFor(
+  moduleFor(
     'Components test: local lookup with resolution referrer (MU)',
     class extends ApplicationTestCase {
       ['@test Ensure that the same specifier with two sources does not share a cache key'](assert) {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/namespaced-lookup-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/namespaced-lookup-test.js
@@ -1,11 +1,11 @@
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { EMBER_MODULE_UNIFICATION } from '@ember/canary-features';
 import { Component, helper } from '@ember/-internals/glimmer';
 
 if (EMBER_MODULE_UNIFICATION) {
   moduleFor(
     'Namespaced lookup',
-    class extends RenderingTest {
+    class extends RenderingTestCase {
       ['@test it can render a namespaced component']() {
         this.addTemplate(
           {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/namespaced-lookup-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/namespaced-lookup-test.js
@@ -1,4 +1,5 @@
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
+
 import { EMBER_MODULE_UNIFICATION } from '@ember/canary-features';
 import { Component, helper } from '@ember/-internals/glimmer';
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/target-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/target-action-test.js
@@ -1,11 +1,13 @@
+import { moduleFor, RenderingTestCase, ApplicationTestCase } from 'internal-test-helpers';
+
 import { assign } from '@ember/polyfills';
-import { moduleFor, RenderingTestCase, ApplicationTestCase } from '../../utils/test-case';
-import { strip } from '../../utils/abstract-test-case';
+import { strip } from 'internal-test-helpers';
 import { set, Mixin } from '@ember/-internals/metal';
-import { Component } from '../../utils/helpers';
 import Controller from '@ember/controller';
 import { Object as EmberObject } from '@ember/-internals/runtime';
 import { Route } from '@ember/-internals/routing';
+
+import { Component } from '../../utils/helpers';
 
 function expectSendActionDeprecation(fn) {
   expectDeprecation(

--- a/packages/@ember/-internals/glimmer/tests/integration/components/target-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/target-action-test.js
@@ -1,5 +1,5 @@
 import { assign } from '@ember/polyfills';
-import { moduleFor, RenderingTest, ApplicationTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase, ApplicationTestCase } from '../../utils/test-case';
 import { strip } from '../../utils/abstract-test-case';
 import { set, Mixin } from '@ember/-internals/metal';
 import { Component } from '../../utils/helpers';
@@ -16,7 +16,7 @@ function expectSendActionDeprecation(fn) {
 
 moduleFor(
   'Components test: sendAction',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     constructor() {
       super(...arguments);
       this.actionCounts = {};
@@ -333,7 +333,7 @@ moduleFor(
 
 moduleFor(
   'Components test: sendAction to a controller',
-  class extends ApplicationTest {
+  class extends ApplicationTestCase {
     ["@test sendAction should trigger an action on the parent component's controller if it exists"](
       assert
     ) {
@@ -518,7 +518,7 @@ moduleFor(
 
 moduleFor(
   'Components test: sendAction of a closure action',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test action should be called'](assert) {
       assert.expect(2);
       let component;
@@ -595,7 +595,7 @@ moduleFor(
 
 moduleFor(
   'Components test: send',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test sending to undefined actions triggers an error'](assert) {
       assert.expect(2);
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/target-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/target-action-test.js
@@ -1,7 +1,6 @@
-import { moduleFor, RenderingTestCase, ApplicationTestCase } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, ApplicationTestCase, strip } from 'internal-test-helpers';
 
 import { assign } from '@ember/polyfills';
-import { strip } from 'internal-test-helpers';
 import { set, Mixin } from '@ember/-internals/metal';
 import Controller from '@ember/controller';
 import { Object as EmberObject } from '@ember/-internals/runtime';

--- a/packages/@ember/-internals/glimmer/tests/integration/components/template-only-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/template-only-components-test.js
@@ -1,5 +1,5 @@
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
-import { classes } from '../../utils/test-helpers';
+import { moduleFor, RenderingTestCase, classes } from 'internal-test-helpers';
+
 import { ENV } from '@ember/-internals/environment';
 
 class TemplateOnlyComponentsTest extends RenderingTestCase {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/template-only-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/template-only-components-test.js
@@ -1,8 +1,8 @@
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { classes } from '../../utils/test-helpers';
 import { ENV } from '@ember/-internals/environment';
 
-class TemplateOnlyComponentsTest extends RenderingTest {
+class TemplateOnlyComponentsTest extends RenderingTestCase {
   registerComponent(name, template) {
     super.registerComponent(name, { template, ComponentClass: null });
   }

--- a/packages/@ember/-internals/glimmer/tests/integration/components/to-string-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/to-string-test.js
@@ -1,4 +1,5 @@
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
+
 import { Checkbox, Component, LinkComponent, TextArea, TextField } from '@ember/-internals/glimmer';
 
 moduleFor(

--- a/packages/@ember/-internals/glimmer/tests/integration/components/to-string-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/to-string-test.js
@@ -1,9 +1,9 @@
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { Checkbox, Component, LinkComponent, TextArea, TextField } from '@ember/-internals/glimmer';
 
 moduleFor(
   'built-in component toString',
-  class AbstractAppendTest extends RenderingTest {
+  class AbstractAppendTest extends RenderingTestCase {
     '@test text-field has the correct toString value'(assert) {
       assert.strictEqual(TextField.toString(), '@ember/component/text-field');
     }

--- a/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
@@ -1,3 +1,5 @@
+import { moduleFor, ApplicationTestCase, RenderingTestCase } from 'internal-test-helpers';
+
 import Controller from '@ember/controller';
 import {
   getRootViews,
@@ -6,7 +8,7 @@ import {
   getViewClientRects,
   getViewBoundingClientRect,
 } from '@ember/-internals/views';
-import { moduleFor, ApplicationTestCase, RenderingTestCase } from '../../utils/test-case';
+
 import { Component } from '../../utils/helpers';
 
 moduleFor(

--- a/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
@@ -6,12 +6,12 @@ import {
   getViewClientRects,
   getViewBoundingClientRect,
 } from '@ember/-internals/views';
-import { moduleFor, ApplicationTest, RenderingTest } from '../../utils/test-case';
+import { moduleFor, ApplicationTestCase, RenderingTestCase } from '../../utils/test-case';
 import { Component } from '../../utils/helpers';
 
 moduleFor(
   'View tree tests',
-  class extends ApplicationTest {
+  class extends ApplicationTestCase {
     constructor() {
       super(...arguments);
 
@@ -280,7 +280,7 @@ let ClientRectListCtor, ClientRectCtor;
 
 moduleFor(
   'Bounds tests',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test getViewBounds on a regular component'](assert) {
       let component;
       this.registerComponent('hi-mom', {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/web-component-fallback-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/web-component-fallback-test.js
@@ -1,9 +1,9 @@
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { set } from '@ember/-internals/metal';
 
 moduleFor(
   'Components test: web component fallback',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test custom elements are rendered']() {
       let template = `<foo-bar some-attr="123">hello</foo-bar>`;
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/web-component-fallback-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/web-component-fallback-test.js
@@ -1,4 +1,5 @@
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
+
 import { set } from '@ember/-internals/metal';
 
 moduleFor(

--- a/packages/@ember/-internals/glimmer/tests/integration/components/will-destroy-element-hook-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/will-destroy-element-hook-test.js
@@ -1,6 +1,8 @@
+import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
+
 import { set } from '@ember/-internals/metal';
+
 import { Component } from '../../utils/helpers';
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 
 moduleFor(
   'Component willDestroyElement hook',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/will-destroy-element-hook-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/will-destroy-element-hook-test.js
@@ -1,10 +1,10 @@
 import { set } from '@ember/-internals/metal';
 import { Component } from '../../utils/helpers';
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 
 moduleFor(
   'Component willDestroyElement hook',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test it calls willDestroyElement when removed by if'](assert) {
       let didInsertElementCount = 0;
       let willDestroyElementCount = 0;

--- a/packages/@ember/-internals/glimmer/tests/integration/content-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/content-test.js
@@ -1,5 +1,5 @@
 /* globals EmberDev */
-import { RenderingTest, moduleFor } from '../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../utils/test-case';
 import { applyMixins } from '../utils/abstract-test-case';
 import { set, computed } from '@ember/-internals/metal';
 import { getDebugFunction, setDebugFunction } from '@ember/debug';
@@ -11,7 +11,7 @@ import { Component, SafeString, htmlSafe } from '../utils/helpers';
 
 moduleFor(
   'Static content tests',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test it can render a static text node']() {
       this.render('hello');
       let text1 = this.assertTextNode(this.firstChild, 'hello');
@@ -65,7 +65,7 @@ moduleFor(
   }
 );
 
-class DynamicContentTest extends RenderingTest {
+class DynamicContentTest extends RenderingTestCase {
   /* abstract */
   renderPath(/* path, context = {} */) {
     throw new Error('Not implemented: `renderValues`');
@@ -883,7 +883,7 @@ moduleFor(
 
 moduleFor(
   'Dynamic content tests (integration)',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test it can render a dynamic template']() {
       let template = `
       <div class="header">
@@ -1528,7 +1528,7 @@ moduleFor(
 );
 
 let warnings, originalWarn;
-class StyleTest extends RenderingTest {
+class StyleTest extends RenderingTestCase {
   constructor() {
     super(...arguments);
     warnings = [];

--- a/packages/@ember/-internals/glimmer/tests/integration/content-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/content-test.js
@@ -1,11 +1,11 @@
 /* globals EmberDev */
-import { RenderingTestCase, moduleFor } from '../utils/test-case';
-import { applyMixins } from '../utils/abstract-test-case';
+
+import { RenderingTestCase, moduleFor, applyMixins, classes } from 'internal-test-helpers';
+
 import { set, computed } from '@ember/-internals/metal';
 import { getDebugFunction, setDebugFunction } from '@ember/debug';
 import { readOnly } from '@ember/object/computed';
 import { Object as EmberObject, ObjectProxy } from '@ember/-internals/runtime';
-import { classes } from '../utils/test-helpers';
 import { constructStyleDeprecationMessage } from '@ember/-internals/views';
 import { Component, SafeString, htmlSafe } from '../utils/helpers';
 

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
@@ -1,4 +1,5 @@
-import { moduleFor, RenderingTestCase } from '../utils/test-case';
+import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
+
 import { Object as EmberObject } from '@ember/-internals/runtime';
 import { set, setProperties, computed } from '@ember/-internals/metal';
 import {

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTest } from '../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../utils/test-case';
 import { Object as EmberObject } from '@ember/-internals/runtime';
 import { set, setProperties, computed } from '@ember/-internals/metal';
 import {
@@ -36,7 +36,7 @@ if (GLIMMER_CUSTOM_COMPONENT_MANAGER) {
 
   let InstrumentedComponentManager;
 
-  class ComponentManagerTest extends RenderingTest {
+  class ComponentManagerTest extends RenderingTestCase {
     constructor(assert) {
       super(...arguments);
 

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
@@ -1,11 +1,11 @@
-import { moduleFor, RenderingTest } from '../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../utils/test-case';
 import { Object as EmberObject } from '@ember/-internals/runtime';
 import { GLIMMER_MODIFIER_MANAGER } from '@ember/canary-features';
 import { setModifierManager } from '@ember/-internals/glimmer';
 import { set } from '@ember/-internals/metal';
 
 if (GLIMMER_MODIFIER_MANAGER) {
-  class ModifierManagerTest extends RenderingTest {}
+  class ModifierManagerTest extends RenderingTestCase {}
 
   class CustomModifierManager {
     constructor(owner) {

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
@@ -1,4 +1,5 @@
-import { moduleFor, RenderingTestCase } from '../utils/test-case';
+import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
+
 import { Object as EmberObject } from '@ember/-internals/runtime';
 import { GLIMMER_MODIFIER_MANAGER } from '@ember/canary-features';
 import { setModifierManager } from '@ember/-internals/glimmer';

--- a/packages/@ember/-internals/glimmer/tests/integration/event-dispatcher-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/event-dispatcher-test.js
@@ -1,4 +1,4 @@
-import { RenderingTest, moduleFor } from '../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../utils/test-case';
 import { Component } from '../utils/helpers';
 import { getCurrentRunLoop, run } from '@ember/runloop';
 import {
@@ -21,7 +21,7 @@ function fireNativeWithDataTransfer(node, type, dataTransfer) {
 
 moduleFor(
   'EventDispatcher',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test events bubble view hierarchy for form elements'](assert) {
       let receivedEvent;
 
@@ -352,7 +352,7 @@ moduleFor(
 
 moduleFor(
   'EventDispatcher#setup',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     constructor() {
       super(...arguments);
 
@@ -426,7 +426,7 @@ moduleFor(
 if (EMBER_IMPROVED_INSTRUMENTATION) {
   moduleFor(
     'EventDispatcher - Instrumentation',
-    class extends RenderingTest {
+    class extends RenderingTestCase {
       teardown() {
         super.teardown();
         instrumentationReset();
@@ -485,7 +485,7 @@ if (EMBER_IMPROVED_INSTRUMENTATION) {
 if (canDataTransfer) {
   moduleFor(
     'EventDispatcher - Event Properties',
-    class extends RenderingTest {
+    class extends RenderingTestCase {
       ['@test dataTransfer property is added to drop event'](assert) {
         let receivedEvent;
         this.registerComponent('x-foo', {
@@ -508,7 +508,7 @@ if (canDataTransfer) {
 if (jQueryDisabled) {
   moduleFor(
     'EventDispatcher#native-events',
-    class extends RenderingTest {
+    class extends RenderingTestCase {
       ['@test native events are passed when jQuery is not present'](assert) {
         let receivedEvent;
 
@@ -532,7 +532,7 @@ if (jQueryDisabled) {
 } else {
   moduleFor(
     'EventDispatcher#jquery-events',
-    class extends RenderingTest {
+    class extends RenderingTestCase {
       beforeEach() {
         this.jqueryIntegration = window.ENV._JQUERY_INTEGRATION;
       }

--- a/packages/@ember/-internals/glimmer/tests/integration/event-dispatcher-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/event-dispatcher-test.js
@@ -1,4 +1,5 @@
-import { RenderingTestCase, moduleFor } from '../utils/test-case';
+import { RenderingTestCase, moduleFor } from 'internal-test-helpers';
+
 import { Component } from '../utils/helpers';
 import { getCurrentRunLoop, run } from '@ember/runloop';
 import {

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/-class-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/-class-test.js
@@ -1,5 +1,5 @@
-import { RenderingTestCase, moduleFor } from '../../utils/test-case';
-import { classes } from '../../utils/test-helpers';
+import { RenderingTestCase, moduleFor, classes } from 'internal-test-helpers';
+
 import { set } from '@ember/-internals/metal';
 
 moduleFor(

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/-class-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/-class-test.js
@@ -1,10 +1,10 @@
-import { RenderingTest, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../../utils/test-case';
 import { classes } from '../../utils/test-helpers';
 import { set } from '@ember/-internals/metal';
 
 moduleFor(
   'Helpers test: {{-class}}',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test casts binding to dasherized class']() {
       this.registerComponent('foo-bar', { template: '' });
       this.render(`{{foo-bar class=(-class someTruth "someTruth")}}`, {

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/array-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/array-test.js
@@ -1,8 +1,9 @@
-import { RenderingTestCase, moduleFor } from '../../utils/test-case';
-import { strip } from '../../utils/abstract-test-case';
-import { Component } from '../../utils/helpers';
+import { RenderingTestCase, moduleFor, strip } from 'internal-test-helpers';
+
 import { set } from '@ember/-internals/metal';
 import { EMBER_GLIMMER_ARRAY_HELPER } from '@ember/canary-features';
+
+import { Component } from '../../utils/helpers';
 
 if (EMBER_GLIMMER_ARRAY_HELPER) {
   moduleFor(

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/array-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/array-test.js
@@ -1,4 +1,4 @@
-import { RenderingTest, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../../utils/test-case';
 import { strip } from '../../utils/abstract-test-case';
 import { Component } from '../../utils/helpers';
 import { set } from '@ember/-internals/metal';
@@ -7,7 +7,7 @@ import { EMBER_GLIMMER_ARRAY_HELPER } from '@ember/canary-features';
 if (EMBER_GLIMMER_ARRAY_HELPER) {
   moduleFor(
     'Helpers test: {{array}}',
-    class extends RenderingTest {
+    class extends RenderingTestCase {
       ['@test returns an array']() {
         this.render(strip`
         {{#with (array "Sergio") as |people|}}

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/closure-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/closure-action-test.js
@@ -1,3 +1,5 @@
+import { RenderingTestCase, moduleFor, strip } from 'internal-test-helpers';
+
 import {
   subscribe as instrumentationSubscribe,
   unsubscribe as instrumentationUnsubscribe,
@@ -5,8 +7,7 @@ import {
 import { getCurrentRunLoop } from '@ember/runloop';
 import { set, computed } from '@ember/-internals/metal';
 import { EMBER_IMPROVED_INSTRUMENTATION } from '@ember/canary-features';
-import { RenderingTestCase, moduleFor } from '../../utils/test-case';
-import { strip } from '../../utils/abstract-test-case';
+
 import { Component, INVOKE } from '../../utils/helpers';
 
 if (EMBER_IMPROVED_INSTRUMENTATION) {

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/closure-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/closure-action-test.js
@@ -5,14 +5,14 @@ import {
 import { getCurrentRunLoop } from '@ember/runloop';
 import { set, computed } from '@ember/-internals/metal';
 import { EMBER_IMPROVED_INSTRUMENTATION } from '@ember/canary-features';
-import { RenderingTest, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../../utils/test-case';
 import { strip } from '../../utils/abstract-test-case';
 import { Component, INVOKE } from '../../utils/helpers';
 
 if (EMBER_IMPROVED_INSTRUMENTATION) {
   moduleFor(
     'Helpers test: closure {{action}} improved instrumentation',
-    class extends RenderingTest {
+    class extends RenderingTestCase {
       subscribe(eventName, options) {
         this.subscriber = instrumentationSubscribe(eventName, options);
       }
@@ -181,7 +181,7 @@ if (EMBER_IMPROVED_INSTRUMENTATION) {
 
 moduleFor(
   'Helpers test: closure {{action}}',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test action should be called']() {
       let outerActionCalled = false;
       let component;

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/concat-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/concat-test.js
@@ -1,4 +1,5 @@
-import { RenderingTestCase, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from 'internal-test-helpers';
+
 import { set } from '@ember/-internals/metal';
 
 moduleFor(

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/concat-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/concat-test.js
@@ -1,9 +1,9 @@
-import { RenderingTest, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../../utils/test-case';
 import { set } from '@ember/-internals/metal';
 
 moduleFor(
   'Helpers test: {{concat}}',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test it concats static arguments']() {
       this.render(`{{concat "foo" " " "bar" " " "baz"}}`);
       this.assertText('foo bar baz');

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
@@ -1,11 +1,11 @@
 /* globals EmberDev */
-import { RenderingTest, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../../utils/test-case';
 import { runDestroy } from 'internal-test-helpers';
 import { set } from '@ember/-internals/metal';
 
 moduleFor(
   'Helpers test: custom helpers',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test it cannot override built-in syntax']() {
       this.registerHelper('if', () => 'Nope');
       expectAssertion(() => {
@@ -602,7 +602,7 @@ moduleFor(
 );
 
 if (!EmberDev.runningProdBuild) {
-  class HelperMutatingArgsTests extends RenderingTest {
+  class HelperMutatingArgsTests extends RenderingTestCase {
     buildCompute() {
       return (params, hash) => {
         this.assert.throws(() => {

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
@@ -1,6 +1,7 @@
 /* globals EmberDev */
-import { RenderingTestCase, moduleFor } from '../../utils/test-case';
-import { runDestroy } from 'internal-test-helpers';
+
+import { RenderingTestCase, moduleFor, runDestroy } from 'internal-test-helpers';
+
 import { set } from '@ember/-internals/metal';
 
 moduleFor(

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/element-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/element-action-test.js
@@ -1,16 +1,15 @@
-import { RenderingTestCase, moduleFor } from '../../utils/test-case';
-import { strip } from '../../utils/abstract-test-case';
-import { Component } from '../../utils/helpers';
+import { RenderingTestCase, moduleFor, strip } from 'internal-test-helpers';
+
 import { set } from '@ember/-internals/metal';
 import {
   subscribe as instrumentationSubscribe,
   reset as instrumentationReset,
 } from '@ember/instrumentation';
 import { EMBER_IMPROVED_INSTRUMENTATION } from '@ember/canary-features';
-
 import { Object as EmberObject, A as emberA } from '@ember/-internals/runtime';
-
 import { ActionManager } from '@ember/-internals/views';
+
+import { Component } from '../../utils/helpers';
 
 function getActionAttributes(element) {
   let attributes = element.attributes;

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/element-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/element-action-test.js
@@ -1,4 +1,4 @@
-import { RenderingTest, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../../utils/test-case';
 import { strip } from '../../utils/abstract-test-case';
 import { Component } from '../../utils/helpers';
 import { set } from '@ember/-internals/metal';
@@ -38,7 +38,7 @@ const isIE11 = !window.ActiveXObject && 'ActiveXObject' in window;
 if (EMBER_IMPROVED_INSTRUMENTATION) {
   moduleFor(
     'Helpers test: element action instrumentation',
-    class extends RenderingTest {
+    class extends RenderingTestCase {
       teardown() {
         super.teardown();
         instrumentationReset();
@@ -90,7 +90,7 @@ if (EMBER_IMPROVED_INSTRUMENTATION) {
 
 moduleFor(
   'Helpers test: element action',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test it can call an action on its enclosing component']() {
       let fooCallCount = 0;
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/get-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/get-test.js
@@ -1,10 +1,10 @@
-import { RenderingTest, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../../utils/test-case';
 import { Component } from '../../utils/helpers';
 import { set, get } from '@ember/-internals/metal';
 
 moduleFor(
   'Helpers test: {{get}}',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test should be able to get an object value with a static key']() {
       this.render(`[{{get colors 'apple'}}] [{{if true (get colors 'apple')}}]`, {
         colors: { apple: 'red' },

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/get-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/get-test.js
@@ -1,6 +1,8 @@
-import { RenderingTestCase, moduleFor } from '../../utils/test-case';
-import { Component } from '../../utils/helpers';
+import { RenderingTestCase, moduleFor } from 'internal-test-helpers';
+
 import { set, get } from '@ember/-internals/metal';
+
+import { Component } from '../../utils/helpers';
 
 moduleFor(
   'Helpers test: {{get}}',

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/hash-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/hash-test.js
@@ -1,10 +1,10 @@
-import { RenderingTest, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../../utils/test-case';
 import { Component } from '../../utils/helpers';
 import { set } from '@ember/-internals/metal';
 
 moduleFor(
   'Helpers test: {{hash}}',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test returns a hash with the right key-value']() {
       this.render(`{{#with (hash name=\"Sergio\") as |person|}}{{person.name}}{{/with}}`);
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/hash-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/hash-test.js
@@ -1,5 +1,7 @@
-import { RenderingTestCase, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from 'internal-test-helpers';
+
 import { Component } from '../../utils/helpers';
+
 import { set } from '@ember/-internals/metal';
 
 moduleFor(

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/if-unless-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/if-unless-test.js
@@ -1,4 +1,5 @@
-import { moduleFor } from '../../utils/test-case';
+import { moduleFor } from 'internal-test-helpers';
+
 import { IfUnlessHelperTest } from '../../utils/shared-conditional-tests';
 
 moduleFor(

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/input-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/input-test.js
@@ -1,9 +1,10 @@
+import { RenderingTestCase, moduleFor, runDestroy } from 'internal-test-helpers';
+
 import { assign } from '@ember/polyfills';
 import { set } from '@ember/-internals/metal';
-import { Component } from '../../utils/helpers';
-import { RenderingTestCase, moduleFor } from '../../utils/test-case';
-import { runDestroy } from 'internal-test-helpers';
 import { jQuery } from '@ember/-internals/views';
+
+import { Component } from '../../utils/helpers';
 
 class InputRenderingTest extends RenderingTestCase {
   $input() {

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/input-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/input-test.js
@@ -1,11 +1,11 @@
 import { assign } from '@ember/polyfills';
 import { set } from '@ember/-internals/metal';
 import { Component } from '../../utils/helpers';
-import { RenderingTest, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../../utils/test-case';
 import { runDestroy } from 'internal-test-helpers';
 import { jQuery } from '@ember/-internals/views';
 
-class InputRenderingTest extends RenderingTest {
+class InputRenderingTest extends RenderingTestCase {
   $input() {
     return this.$('input');
   }

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/loc-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/loc-test.js
@@ -1,10 +1,10 @@
-import { RenderingTest, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../../utils/test-case';
 import { set } from '@ember/-internals/metal';
 import { _setStrings } from '@ember/string';
 
 moduleFor(
   'Helpers test: {{loc}}',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     constructor() {
       super(...arguments);
       _setStrings({

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/loc-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/loc-test.js
@@ -1,4 +1,5 @@
-import { RenderingTestCase, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from 'internal-test-helpers';
+
 import { set } from '@ember/-internals/metal';
 import { _setStrings } from '@ember/string';
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/log-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/log-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from 'internal-test-helpers';
 
 moduleFor(
   'Helpers test: {{log}}',

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/log-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/log-test.js
@@ -1,8 +1,8 @@
-import { RenderingTest, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../../utils/test-case';
 
 moduleFor(
   'Helpers test: {{log}}',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     constructor() {
       super(...arguments);
       /* eslint-disable no-console */

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/mut-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/mut-test.js
@@ -1,11 +1,11 @@
-import { RenderingTest, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../../utils/test-case';
 import { Component, htmlSafe } from '../../utils/helpers';
 import { set, get, computed } from '@ember/-internals/metal';
 import { styles } from '../../utils/test-helpers';
 
 moduleFor(
   'Helpers test: {{mut}}',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test a simple mutable binding using `mut` propagates properly']() {
       let bottom;
 
@@ -430,7 +430,7 @@ moduleFor(
 
 moduleFor(
   'Mutable Bindings used in Computed Properties that are bound as attributeBindings',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test an attribute binding of a computed property of a 2-way bound attr recomputes when the attr changes']() {
       let input, output;
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/mut-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/mut-test.js
@@ -1,7 +1,8 @@
-import { RenderingTestCase, moduleFor } from '../../utils/test-case';
-import { Component, htmlSafe } from '../../utils/helpers';
+import { RenderingTestCase, moduleFor, styles } from 'internal-test-helpers';
+
 import { set, get, computed } from '@ember/-internals/metal';
-import { styles } from '../../utils/test-helpers';
+
+import { Component, htmlSafe } from '../../utils/helpers';
 
 moduleFor(
   'Helpers test: {{mut}}',

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/partial-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/partial-test.js
@@ -1,11 +1,11 @@
-import { RenderingTest, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../../utils/test-case';
 import { set } from '@ember/-internals/metal';
 import { A as emberA } from '@ember/-internals/runtime';
 import { strip } from '../../utils/abstract-test-case';
 
 moduleFor(
   'Helpers test: {{partial}}',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test should render other templates registered with the container']() {
       this.registerPartial('_subTemplateFromContainer', 'sub-template');
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/partial-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/partial-test.js
@@ -1,7 +1,7 @@
-import { RenderingTestCase, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor, strip } from 'internal-test-helpers';
+
 import { set } from '@ember/-internals/metal';
 import { A as emberA } from '@ember/-internals/runtime';
-import { strip } from '../../utils/abstract-test-case';
 
 moduleFor(
   'Helpers test: {{partial}}',

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/readonly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/readonly-test.js
@@ -1,10 +1,10 @@
-import { RenderingTest, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../../utils/test-case';
 import { Component } from '../../utils/helpers';
 import { set, get } from '@ember/-internals/metal';
 
 moduleFor(
   'Helpers test: {{readonly}}',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test {{readonly}} of a path should work']() {
       let component;
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/readonly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/readonly-test.js
@@ -1,6 +1,8 @@
-import { RenderingTestCase, moduleFor } from '../../utils/test-case';
-import { Component } from '../../utils/helpers';
+import { RenderingTestCase, moduleFor } from 'internal-test-helpers';
+
 import { set, get } from '@ember/-internals/metal';
+
+import { Component } from '../../utils/helpers';
 
 moduleFor(
   'Helpers test: {{readonly}}',

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/text-area-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/text-area-test.js
@@ -1,8 +1,7 @@
+import { RenderingTestCase, moduleFor, classes, applyMixins } from 'internal-test-helpers';
+
 import { assign } from '@ember/polyfills';
 import { set } from '@ember/-internals/metal';
-import { RenderingTestCase, moduleFor } from '../../utils/test-case';
-import { classes } from '../../utils/test-helpers';
-import { applyMixins } from '../../utils/abstract-test-case';
 
 class TextAreaRenderingTest extends RenderingTestCase {
   assertTextArea({ attrs, value } = {}) {

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/text-area-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/text-area-test.js
@@ -1,10 +1,10 @@
 import { assign } from '@ember/polyfills';
 import { set } from '@ember/-internals/metal';
-import { RenderingTest, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../../utils/test-case';
 import { classes } from '../../utils/test-helpers';
 import { applyMixins } from '../../utils/abstract-test-case';
 
-class TextAreaRenderingTest extends RenderingTest {
+class TextAreaRenderingTest extends RenderingTestCase {
   assertTextArea({ attrs, value } = {}) {
     let mergedAttrs = assign({ class: classes('ember-view ember-text-area') }, attrs);
     this.assertComponentElement(this.firstChild, {

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/unbound-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/unbound-test.js
@@ -1,4 +1,4 @@
-import { RenderingTest, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../../utils/test-case';
 import { strip } from '../../utils/abstract-test-case';
 import { set, get, setProperties } from '@ember/-internals/metal';
 import { Component } from '../../utils/helpers';
@@ -6,7 +6,7 @@ import { A as emberA } from '@ember/-internals/runtime';
 
 moduleFor(
   'Helpers test: {{unbound}}',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test should be able to output a property without binding']() {
       this.render(`<div id="first">{{unbound content.anUnboundString}}</div>`, {
         content: {

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/unbound-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/unbound-test.js
@@ -1,8 +1,9 @@
-import { RenderingTestCase, moduleFor } from '../../utils/test-case';
-import { strip } from '../../utils/abstract-test-case';
+import { RenderingTestCase, moduleFor, strip } from 'internal-test-helpers';
+
 import { set, get, setProperties } from '@ember/-internals/metal';
-import { Component } from '../../utils/helpers';
 import { A as emberA } from '@ember/-internals/runtime';
+
+import { Component } from '../../utils/helpers';
 
 moduleFor(
   'Helpers test: {{unbound}}',

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/yield-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/yield-test.js
@@ -1,5 +1,7 @@
-import { RenderingTestCase, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from 'internal-test-helpers';
+
 import { set } from '@ember/-internals/metal';
+
 import { Component } from '../../utils/helpers';
 
 moduleFor(

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/yield-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/yield-test.js
@@ -1,10 +1,10 @@
-import { RenderingTest, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../../utils/test-case';
 import { set } from '@ember/-internals/metal';
 import { Component } from '../../utils/helpers';
 
 moduleFor(
   'Helpers test: {{yield}} helper',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test can yield to block']() {
       this.registerComponent('yield-comp', {
         template: '[In layout:] {{yield}}',

--- a/packages/@ember/-internals/glimmer/tests/integration/input-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/input-test.js
@@ -1,4 +1,5 @@
-import { RenderingTestCase, moduleFor } from '../utils/test-case';
+import { RenderingTestCase, moduleFor } from 'internal-test-helpers';
+
 import { set } from '@ember/-internals/metal';
 
 moduleFor(

--- a/packages/@ember/-internals/glimmer/tests/integration/input-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/input-test.js
@@ -1,9 +1,9 @@
-import { RenderingTest, moduleFor } from '../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../utils/test-case';
 import { set } from '@ember/-internals/metal';
 
 moduleFor(
   'Input element tests',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     runAttributeTest(attributeName, values) {
       let template = `<input ${attributeName}={{value}}>`;
       this.render(template, { value: values[0] });

--- a/packages/@ember/-internals/glimmer/tests/integration/mount-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/mount-test.js
@@ -1,5 +1,6 @@
+import { moduleFor, ApplicationTestCase, RenderingTestCase } from 'internal-test-helpers';
+
 import { getOwner } from '@ember/-internals/owner';
-import { moduleFor, ApplicationTestCase, RenderingTestCase } from '../utils/test-case';
 import { compile, Component } from '../utils/helpers';
 import Controller from '@ember/controller';
 import { set } from '@ember/-internals/metal';

--- a/packages/@ember/-internals/glimmer/tests/integration/mount-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/mount-test.js
@@ -1,5 +1,5 @@
 import { getOwner } from '@ember/-internals/owner';
-import { moduleFor, ApplicationTest, RenderingTest } from '../utils/test-case';
+import { moduleFor, ApplicationTestCase, RenderingTestCase } from '../utils/test-case';
 import { compile, Component } from '../utils/helpers';
 import Controller from '@ember/controller';
 import { set } from '@ember/-internals/metal';
@@ -9,7 +9,7 @@ import { EMBER_ENGINES_MOUNT_PARAMS } from '@ember/canary-features';
 if (EMBER_ENGINES_MOUNT_PARAMS) {
   moduleFor(
     '{{mount}} single param assertion',
-    class extends RenderingTest {
+    class extends RenderingTestCase {
       ['@test it asserts that only a single param is passed']() {
         expectAssertion(() => {
           this.render('{{mount "chat" "foo"}}');
@@ -20,7 +20,7 @@ if (EMBER_ENGINES_MOUNT_PARAMS) {
 } else {
   moduleFor(
     '{{mount}} single param assertion',
-    class extends RenderingTest {
+    class extends RenderingTestCase {
       ['@test it asserts that only a single param is passed']() {
         expectAssertion(() => {
           this.render('{{mount "chat" "foo"}}');
@@ -32,7 +32,7 @@ if (EMBER_ENGINES_MOUNT_PARAMS) {
 
 moduleFor(
   '{{mount}} assertions',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test it asserts when an invalid engine name is provided']() {
       expectAssertion(() => {
         this.render('{{mount engineName}}', { engineName: {} });
@@ -49,7 +49,7 @@ moduleFor(
 
 moduleFor(
   '{{mount}} test',
-  class extends ApplicationTest {
+  class extends ApplicationTestCase {
     constructor() {
       super(...arguments);
 
@@ -300,7 +300,7 @@ moduleFor(
 if (EMBER_ENGINES_MOUNT_PARAMS) {
   moduleFor(
     '{{mount}} params tests',
-    class extends ApplicationTest {
+    class extends ApplicationTestCase {
       constructor() {
         super(...arguments);
 

--- a/packages/@ember/-internals/glimmer/tests/integration/outlet-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/outlet-test.js
@@ -1,10 +1,10 @@
-import { RenderingTest, moduleFor } from '../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../utils/test-case';
 import { runAppend } from 'internal-test-helpers';
 import { set } from '@ember/-internals/metal';
 
 moduleFor(
   'outlet view',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     constructor() {
       super(...arguments);
 

--- a/packages/@ember/-internals/glimmer/tests/integration/outlet-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/outlet-test.js
@@ -1,5 +1,5 @@
-import { RenderingTestCase, moduleFor } from '../utils/test-case';
-import { runAppend } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, runAppend } from 'internal-test-helpers';
+
 import { set } from '@ember/-internals/metal';
 
 moduleFor(

--- a/packages/@ember/-internals/glimmer/tests/integration/refinements-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/refinements-test.js
@@ -1,5 +1,5 @@
-import { RenderingTestCase, moduleFor } from '../utils/test-case';
-import { strip } from '../utils/abstract-test-case';
+import { RenderingTestCase, moduleFor, strip } from 'internal-test-helpers';
+
 import { set } from '@ember/-internals/metal';
 
 moduleFor(

--- a/packages/@ember/-internals/glimmer/tests/integration/refinements-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/refinements-test.js
@@ -1,10 +1,10 @@
-import { RenderingTest, moduleFor } from '../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../utils/test-case';
 import { strip } from '../utils/abstract-test-case';
 import { set } from '@ember/-internals/metal';
 
 moduleFor(
   'syntax refinements',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test block params should not be refined']() {
       this.registerHelper('foo', () => 'bar helper');
 

--- a/packages/@ember/-internals/glimmer/tests/integration/render-settled-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/render-settled-test.js
@@ -1,7 +1,9 @@
 import { RenderingTestCase, moduleFor, strip } from 'internal-test-helpers';
+
 import { renderSettled } from '@ember/-internals/glimmer';
-import { all } from 'rsvp';
 import { run, schedule } from '@ember/runloop';
+
+import { all } from 'rsvp';
 
 moduleFor(
   'renderSettled',

--- a/packages/@ember/-internals/glimmer/tests/integration/svg-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/svg-test.js
@@ -1,6 +1,6 @@
-import { RenderingTestCase, moduleFor } from '../utils/test-case';
+import { RenderingTestCase, moduleFor, strip } from 'internal-test-helpers';
+
 import { set } from '@ember/-internals/metal';
-import { strip } from '../utils/abstract-test-case';
 
 moduleFor(
   'SVG element tests',

--- a/packages/@ember/-internals/glimmer/tests/integration/svg-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/svg-test.js
@@ -1,10 +1,10 @@
-import { RenderingTest, moduleFor } from '../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../utils/test-case';
 import { set } from '@ember/-internals/metal';
 import { strip } from '../utils/abstract-test-case';
 
 moduleFor(
   'SVG element tests',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test unquoted viewBox property is output'](assert) {
       let viewBoxString = '0 0 100 100';
 

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/each-in-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/each-in-test.js
@@ -1,9 +1,9 @@
+import { moduleFor, RenderingTestCase, strip, applyMixins } from 'internal-test-helpers';
+
 import { get, set } from '@ember/-internals/metal';
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { Object as EmberObject, ObjectProxy } from '@ember/-internals/runtime';
-import { strip } from '../../utils/abstract-test-case';
 import { HAS_NATIVE_SYMBOL } from '@ember/-internals/utils';
-import { applyMixins } from '../../utils/abstract-test-case';
+
 import {
   TogglingSyntaxConditionalsTest,
   TruthyGenerator,

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/each-in-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/each-in-test.js
@@ -1,5 +1,5 @@
 import { get, set } from '@ember/-internals/metal';
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { Object as EmberObject, ObjectProxy } from '@ember/-internals/runtime';
 import { strip } from '../../utils/abstract-test-case';
 import { HAS_NATIVE_SYMBOL } from '@ember/-internals/utils';
@@ -96,7 +96,7 @@ moduleFor(
 moduleFor('Syntax test: {{#each-in}}', BasicSyntaxTest);
 
 // Rendering tests
-class AbstractEachInTest extends RenderingTest {
+class AbstractEachInTest extends RenderingTestCase {
   createHash(/* hash */) {
     throw new Error('Not implemented: `createHash`');
   }

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/each-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/each-test.js
@@ -1,6 +1,6 @@
 import { get, set, notifyPropertyChange } from '@ember/-internals/metal';
 import { applyMixins, strip } from '../../utils/abstract-test-case';
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { A as emberA, ArrayProxy, RSVP } from '@ember/-internals/runtime';
 import { Component, htmlSafe } from '../../utils/helpers';
 import { HAS_NATIVE_SYMBOL } from '@ember/-internals/utils';
@@ -244,7 +244,7 @@ moduleFor(
   }
 );
 
-class AbstractEachTest extends RenderingTest {
+class AbstractEachTest extends RenderingTestCase {
   /* abstract */
   createList(/* items */) {
     throw new Error('Not implemented: `createList`');
@@ -1090,7 +1090,7 @@ moduleFor(
 
 moduleFor(
   'Syntax test: {{#each as}} undefined path',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test keying off of `undefined` does not render']() {
       this.render(
         strip`
@@ -1119,7 +1119,7 @@ moduleFor(
 
 moduleFor(
   'Syntax test: {{#each}} with sparse arrays',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test it should itterate over holes']() {
       let sparseArray = [];
       sparseArray[3] = 'foo';
@@ -1151,7 +1151,7 @@ moduleFor(
 if (typeof MutationObserver === 'function') {
   moduleFor(
     'Syntax test: {{#each as}} DOM mutation test',
-    class extends RenderingTest {
+    class extends RenderingTestCase {
       constructor() {
         super(...arguments);
         this.observer = null;

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/each-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/each-test.js
@@ -1,9 +1,10 @@
+import { moduleFor, RenderingTestCase, applyMixins, strip } from 'internal-test-helpers';
+
 import { get, set, notifyPropertyChange } from '@ember/-internals/metal';
-import { applyMixins, strip } from '../../utils/abstract-test-case';
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { A as emberA, ArrayProxy, RSVP } from '@ember/-internals/runtime';
-import { Component, htmlSafe } from '../../utils/helpers';
 import { HAS_NATIVE_SYMBOL } from '@ember/-internals/utils';
+
+import { Component, htmlSafe } from '../../utils/helpers';
 import {
   TogglingSyntaxConditionalsTest,
   TruthyGenerator,

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/experimental-syntax-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/experimental-syntax-test.js
@@ -1,10 +1,10 @@
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { strip } from '../../utils/abstract-test-case';
 import { _registerMacros, _experimentalMacros } from '@ember/-internals/glimmer';
 
 moduleFor(
   'registerMacros',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     constructor() {
       let originalMacros = _experimentalMacros.slice();
 

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/experimental-syntax-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/experimental-syntax-test.js
@@ -1,5 +1,5 @@
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
-import { strip } from '../../utils/abstract-test-case';
+import { moduleFor, RenderingTestCase, strip } from 'internal-test-helpers';
+
 import { _registerMacros, _experimentalMacros } from '@ember/-internals/glimmer';
 
 moduleFor(

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/if-unless-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/if-unless-test.js
@@ -3,7 +3,7 @@ import { A as emberA } from '@ember/-internals/runtime';
 import { set } from '@ember/-internals/metal';
 import { strip } from '../../utils/abstract-test-case';
 
-import { RenderingTest, moduleFor } from '../../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../../utils/test-case';
 import { IfUnlessWithSyntaxTest } from '../../utils/shared-conditional-tests';
 
 moduleFor(
@@ -35,7 +35,7 @@ moduleFor(
 
 moduleFor(
   'Syntax test: {{#if}}',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test using `if` with an `{{each}}` destroys components when transitioning to and from inverse (GH #12267)'](
       assert
     ) {

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/if-unless-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/if-unless-test.js
@@ -1,9 +1,9 @@
-import { Component } from '../../utils/helpers';
+import { RenderingTestCase, moduleFor, strip } from 'internal-test-helpers';
+
 import { A as emberA } from '@ember/-internals/runtime';
 import { set } from '@ember/-internals/metal';
-import { strip } from '../../utils/abstract-test-case';
 
-import { RenderingTestCase, moduleFor } from '../../utils/test-case';
+import { Component } from '../../utils/helpers';
 import { IfUnlessWithSyntaxTest } from '../../utils/shared-conditional-tests';
 
 moduleFor(

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/in-element-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/in-element-test.js
@@ -1,6 +1,5 @@
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
-import { equalTokens } from '../../utils/test-helpers';
-import { strip } from '../../utils/abstract-test-case';
+import { moduleFor, RenderingTestCase, strip, equalTokens } from 'internal-test-helpers';
+
 import { Component } from '@ember/-internals/glimmer';
 import { set } from '@ember/-internals/metal';
 

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/in-element-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/in-element-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { equalTokens } from '../../utils/test-helpers';
 import { strip } from '../../utils/abstract-test-case';
 import { Component } from '@ember/-internals/glimmer';
@@ -6,7 +6,7 @@ import { set } from '@ember/-internals/metal';
 
 moduleFor(
   '{{-in-element}}',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test using {{#in-element whatever}} asserts']() {
       // the in-element keyword is not yet public API this test should be removed
       // once https://github.com/emberjs/rfcs/pull/287 lands and is enabled

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/let-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/let-test.js
@@ -1,11 +1,11 @@
 import { get, set } from '@ember/-internals/metal';
 import { A as emberA, ObjectProxy, removeAt } from '@ember/-internals/runtime';
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { strip } from '../../utils/abstract-test-case';
 
 moduleFor(
   'Syntax test: {{#let as}}',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     templateFor({ cond, truthy, falsy }) {
       return `{{#let ${cond} as |test|}}${truthy}{{else}}${falsy}{{/let}}`;
     }
@@ -210,7 +210,7 @@ moduleFor(
 
 moduleFor(
   'Syntax test: Multiple {{#let as}} helpers',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test re-using the same variable with different {{#let}} blocks does not override each other']() {
       this.render(
         `Admin: {{#let admin as |person|}}{{person.name}}{{/let}} User: {{#let user as |person|}}{{person.name}}{{/let}}`,

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/let-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/let-test.js
@@ -1,7 +1,7 @@
+import { moduleFor, RenderingTestCase, strip } from 'internal-test-helpers';
+
 import { get, set } from '@ember/-internals/metal';
 import { A as emberA, ObjectProxy, removeAt } from '@ember/-internals/runtime';
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
-import { strip } from '../../utils/abstract-test-case';
 
 moduleFor(
   'Syntax test: {{#let as}}',

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/with-dynamic-var-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/with-dynamic-var-test.js
@@ -1,9 +1,9 @@
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { strip } from '../../utils/abstract-test-case';
 
 moduleFor(
   '{{-with-dynamic-var}}',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test does not allow setting values other than outletState']() {
       expectAssertion(() => {
         this.render(strip`

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/with-dynamic-var-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/with-dynamic-var-test.js
@@ -1,5 +1,4 @@
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
-import { strip } from '../../utils/abstract-test-case';
+import { moduleFor, RenderingTestCase, strip } from 'internal-test-helpers';
 
 moduleFor(
   '{{-with-dynamic-var}}',

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/with-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/with-test.js
@@ -1,8 +1,9 @@
+import { moduleFor, RenderingTestCase, strip } from 'internal-test-helpers';
+
 import { get, set } from '@ember/-internals/metal';
 import { A as emberA, ObjectProxy, removeAt } from '@ember/-internals/runtime';
-import { moduleFor, RenderingTestCase } from '../../utils/test-case';
+
 import { IfUnlessWithSyntaxTest } from '../../utils/shared-conditional-tests';
-import { strip } from '../../utils/abstract-test-case';
 
 moduleFor(
   'Syntax test: {{#with}}',

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/with-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/with-test.js
@@ -1,6 +1,6 @@
 import { get, set } from '@ember/-internals/metal';
 import { A as emberA, ObjectProxy, removeAt } from '@ember/-internals/runtime';
-import { moduleFor, RenderingTest } from '../../utils/test-case';
+import { moduleFor, RenderingTestCase } from '../../utils/test-case';
 import { IfUnlessWithSyntaxTest } from '../../utils/shared-conditional-tests';
 import { strip } from '../../utils/abstract-test-case';
 
@@ -245,7 +245,7 @@ moduleFor(
 
 moduleFor(
   'Syntax test: Multiple {{#with as}} helpers',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test re-using the same variable with different {{#with}} blocks does not override each other']() {
       this.render(
         `Admin: {{#with admin as |person|}}{{person.name}}{{/with}} User: {{#with user as |person|}}{{person.name}}{{/with}}`,

--- a/packages/@ember/-internals/glimmer/tests/unit/outlet-test.js
+++ b/packages/@ember/-internals/glimmer/tests/unit/outlet-test.js
@@ -1,6 +1,7 @@
+import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+
 import { OutletView } from '@ember/-internals/glimmer';
 import { run, schedule } from '@ember/runloop';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 moduleFor(
   'Glimmer OutletView',

--- a/packages/@ember/-internals/glimmer/tests/unit/runtime-resolver-cache-test.js
+++ b/packages/@ember/-internals/glimmer/tests/unit/runtime-resolver-cache-test.js
@@ -1,7 +1,8 @@
-import { RenderingTestCase, moduleFor } from '../utils/test-case';
-import { Component } from '../utils/helpers';
+import { RenderingTestCase, moduleFor, runDestroy, runAppend } from 'internal-test-helpers';
+
 import { set } from '@ember/-internals/metal';
-import { runDestroy, runAppend } from 'internal-test-helpers';
+
+import { Component } from '../utils/helpers';
 
 moduleFor(
   'ember-glimmer runtime resolver cache',

--- a/packages/@ember/-internals/glimmer/tests/unit/runtime-resolver-cache-test.js
+++ b/packages/@ember/-internals/glimmer/tests/unit/runtime-resolver-cache-test.js
@@ -1,11 +1,11 @@
-import { RenderingTest, moduleFor } from '../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../utils/test-case';
 import { Component } from '../utils/helpers';
 import { set } from '@ember/-internals/metal';
 import { runDestroy, runAppend } from 'internal-test-helpers';
 
 moduleFor(
   'ember-glimmer runtime resolver cache',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     '@test a helper definition is only generated once'(assert) {
       this.registerHelper('foo-bar', () => 'foo-bar helper!');
       this.registerHelper('baz-qux', () => 'baz-qux helper!');

--- a/packages/@ember/-internals/glimmer/tests/unit/template-factory-test.js
+++ b/packages/@ember/-internals/glimmer/tests/unit/template-factory-test.js
@@ -1,6 +1,8 @@
-import { precompile, compile } from 'ember-template-compiler';
+import { RenderingTestCase, moduleFor } from 'internal-test-helpers';
+
 import { template } from '@ember/-internals/glimmer';
-import { RenderingTestCase, moduleFor } from '../utils/test-case';
+import { precompile, compile } from 'ember-template-compiler';
+
 import { Component } from '../utils/helpers';
 
 moduleFor(

--- a/packages/@ember/-internals/glimmer/tests/unit/template-factory-test.js
+++ b/packages/@ember/-internals/glimmer/tests/unit/template-factory-test.js
@@ -1,11 +1,11 @@
 import { precompile, compile } from 'ember-template-compiler';
 import { template } from '@ember/-internals/glimmer';
-import { RenderingTest, moduleFor } from '../utils/test-case';
+import { RenderingTestCase, moduleFor } from '../utils/test-case';
 import { Component } from '../utils/helpers';
 
 moduleFor(
   'Template factory test',
-  class extends RenderingTest {
+  class extends RenderingTestCase {
     ['@test the template factory returned from precompile is the same as compile'](assert) {
       let { owner } = this;
       let { runtimeResolver } = this;

--- a/packages/@ember/-internals/glimmer/tests/unit/utils/debug-stack-test.js
+++ b/packages/@ember/-internals/glimmer/tests/unit/utils/debug-stack-test.js
@@ -1,6 +1,7 @@
+import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+
 import { DebugStack } from '@ember/-internals/glimmer';
 import { DEBUG } from '@glimmer/env';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 moduleFor(
   'Glimmer DebugStack',

--- a/packages/@ember/-internals/glimmer/tests/utils/abstract-test-case.js
+++ b/packages/@ember/-internals/glimmer/tests/utils/abstract-test-case.js
@@ -1,1 +1,0 @@
-export { AbstractTestCase, applyMixins, strip } from 'internal-test-helpers';

--- a/packages/@ember/-internals/glimmer/tests/utils/abstract-test-case.js
+++ b/packages/@ember/-internals/glimmer/tests/utils/abstract-test-case.js
@@ -1,1 +1,1 @@
-export { AbstractTestCase as TestCase, applyMixins, strip } from 'internal-test-helpers';
+export { AbstractTestCase, applyMixins, strip } from 'internal-test-helpers';

--- a/packages/@ember/-internals/glimmer/tests/utils/shared-conditional-tests.js
+++ b/packages/@ember/-internals/glimmer/tests/utils/shared-conditional-tests.js
@@ -1,6 +1,6 @@
 import { assign } from '@ember/polyfills';
 import { applyMixins } from './abstract-test-case';
-import { RenderingTest } from './test-case';
+import { RenderingTestCase } from './test-case';
 import { get, set } from '@ember/-internals/metal';
 import {
   Object as EmberObject,
@@ -11,7 +11,7 @@ import {
 } from '@ember/-internals/runtime';
 import { Component } from './helpers';
 
-class AbstractConditionalsTest extends RenderingTest {
+class AbstractConditionalsTest extends RenderingTestCase {
   get truthyValue() {
     return true;
   }

--- a/packages/@ember/-internals/glimmer/tests/utils/shared-conditional-tests.js
+++ b/packages/@ember/-internals/glimmer/tests/utils/shared-conditional-tests.js
@@ -1,6 +1,6 @@
+import { RenderingTestCase, applyMixins } from 'internal-test-helpers';
+
 import { assign } from '@ember/polyfills';
-import { applyMixins } from './abstract-test-case';
-import { RenderingTestCase } from './test-case';
 import { get, set } from '@ember/-internals/metal';
 import {
   Object as EmberObject,
@@ -9,6 +9,7 @@ import {
   ArrayProxy,
   removeAt,
 } from '@ember/-internals/runtime';
+
 import { Component } from './helpers';
 
 class AbstractConditionalsTest extends RenderingTestCase {

--- a/packages/@ember/-internals/glimmer/tests/utils/string-test.js
+++ b/packages/@ember/-internals/glimmer/tests/utils/string-test.js
@@ -1,10 +1,10 @@
 import { SafeString, htmlSafe, isHTMLSafe } from './helpers';
-import { TestCase } from './abstract-test-case';
+import { AbstractTestCase } from './abstract-test-case';
 import { moduleFor } from './test-case';
 
 moduleFor(
   'SafeString',
-  class extends TestCase {
+  class extends AbstractTestCase {
     ['@test htmlSafe should return an instance of SafeString']() {
       let safeString = htmlSafe('you need to be more <b>bold</b>');
 
@@ -29,7 +29,7 @@ moduleFor(
 
 moduleFor(
   'SafeString isHTMLSafe',
-  class extends TestCase {
+  class extends AbstractTestCase {
     ['@test isHTMLSafe should detect SafeString']() {
       let safeString = htmlSafe('<em>Emphasize</em> the important things.');
 

--- a/packages/@ember/-internals/glimmer/tests/utils/string-test.js
+++ b/packages/@ember/-internals/glimmer/tests/utils/string-test.js
@@ -1,6 +1,6 @@
+import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+
 import { SafeString, htmlSafe, isHTMLSafe } from './helpers';
-import { AbstractTestCase } from './abstract-test-case';
-import { moduleFor } from './test-case';
 
 moduleFor(
   'SafeString',

--- a/packages/@ember/-internals/glimmer/tests/utils/test-case.js
+++ b/packages/@ember/-internals/glimmer/tests/utils/test-case.js
@@ -1,6 +1,6 @@
 export {
-  AbstractTestCase as TestCase,
-  ApplicationTestCase as ApplicationTest,
-  RenderingTestCase as RenderingTest,
+  AbstractTestCase,
+  ApplicationTestCase,
+  RenderingTestCase,
   moduleFor,
 } from 'internal-test-helpers';

--- a/packages/@ember/-internals/glimmer/tests/utils/test-case.js
+++ b/packages/@ember/-internals/glimmer/tests/utils/test-case.js
@@ -1,6 +1,0 @@
-export {
-  AbstractTestCase,
-  ApplicationTestCase,
-  RenderingTestCase,
-  moduleFor,
-} from 'internal-test-helpers';

--- a/packages/@ember/-internals/glimmer/tests/utils/test-helpers.js
+++ b/packages/@ember/-internals/glimmer/tests/utils/test-helpers.js
@@ -1,1 +1,0 @@
-export { styles, classes, equalTokens, equalsElement } from 'internal-test-helpers';


### PR DESCRIPTION
These imports don't seem to serve any purpose other than making the imports harder to follow. By removing the reexports it was also possible to merge some imports that ultimately imported from the same module.

The PR also reorders a few imports in the order of: test framework, ember, other deps, relative imports