### PR TITLE
internal-test-helpers: Implement `get/set/unsetContext()` functions

### DIFF
--- a/packages/internal-test-helpers/index.js
+++ b/packages/internal-test-helpers/index.js
@@ -9,6 +9,7 @@ export { default as applyMixins } from './lib/apply-mixins';
 export { default as getTextOf } from './lib/get-text-of';
 export { equalsElement, classes, styles, regex } from './lib/matchers';
 export { runAppend, runDestroy } from './lib/run';
+export { getContext, setContext, unsetContext } from './lib/test-context';
 
 export { default as AbstractTestCase } from './lib/test-cases/abstract';
 export { default as AbstractApplicationTestCase } from './lib/test-cases/abstract-application';

--- a/packages/internal-test-helpers/lib/element-helpers.ts
+++ b/packages/internal-test-helpers/lib/element-helpers.ts
@@ -1,0 +1,15 @@
+import { getContext } from './test-context';
+
+export function getElement(): Element {
+  let context = getContext();
+  if (!context) {
+    throw new Error('Test context is not set up.');
+  }
+
+  let element = context.element;
+  if (!element) {
+    throw new Error('`element` property on test context is not set up.');
+  }
+
+  return element;
+}

--- a/packages/internal-test-helpers/lib/module-for.js
+++ b/packages/internal-test-helpers/lib/module-for.js
@@ -33,7 +33,7 @@ export function setupTestClass(hooks, TestClass, ...mixins) {
       promises.push(instance.afterEach());
     }
 
-    return all(promises).then(() => {
+    return all(promises).finally(() => {
       unsetContext();
     });
   });

--- a/packages/internal-test-helpers/lib/module-for.js
+++ b/packages/internal-test-helpers/lib/module-for.js
@@ -1,6 +1,7 @@
 import { isEnabled } from '@ember/canary-features';
 import applyMixins from './apply-mixins';
 import getAllPropertyNames from './get-all-property-names';
+import { setContext, unsetContext } from './test-context';
 import { all } from 'rsvp';
 
 export default function moduleFor(description, TestClass, ...mixins) {
@@ -13,6 +14,9 @@ export function setupTestClass(hooks, TestClass, ...mixins) {
   hooks.beforeEach(function(assert) {
     let instance = new TestClass(assert);
     this.instance = instance;
+
+    setContext(instance);
+
     if (instance.beforeEach) {
       return instance.beforeEach(assert);
     }
@@ -29,7 +33,9 @@ export function setupTestClass(hooks, TestClass, ...mixins) {
       promises.push(instance.afterEach());
     }
 
-    return all(promises);
+    return all(promises).then(() => {
+      unsetContext();
+    });
   });
 
   if (mixins.length > 0) {

--- a/packages/internal-test-helpers/lib/test-cases/abstract.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract.js
@@ -6,6 +6,7 @@ import { getCurrentRunLoop, hasScheduledTimers, next, run } from '@ember/runloop
 import NodeQuery from '../node-query';
 import equalInnerHTML from '../equal-inner-html';
 import equalTokens from '../equal-tokens';
+import { getElement } from '../element-helpers';
 import { equalsElement, regex, classes } from '../matchers';
 import { Promise } from 'rsvp';
 
@@ -63,7 +64,7 @@ export default class AbstractTestCase {
 
   nthChild(n) {
     let i = 0;
-    let node = this.element.firstChild;
+    let node = getElement().firstChild;
 
     while (node) {
       if (!isMarker(node)) {
@@ -82,7 +83,7 @@ export default class AbstractTestCase {
 
   get nodesCount() {
     let count = 0;
-    let node = this.element.firstChild;
+    let node = getElement().firstChild;
 
     while (node) {
       if (!isMarker(node)) {
@@ -99,11 +100,11 @@ export default class AbstractTestCase {
     if (sel instanceof Element) {
       return NodeQuery.element(sel);
     } else if (typeof sel === 'string') {
-      return NodeQuery.query(sel, this.element);
+      return NodeQuery.query(sel, getElement());
     } else if (sel !== undefined) {
       throw new Error(`Invalid this.$(${sel})`);
     } else {
-      return NodeQuery.element(this.element);
+      return NodeQuery.element(getElement());
     }
   }
 
@@ -114,7 +115,7 @@ export default class AbstractTestCase {
   click(selector) {
     let element;
     if (typeof selector === 'string') {
-      element = this.element.querySelector(selector);
+      element = getElement().querySelector(selector);
     } else {
       element = selector;
     }
@@ -144,13 +145,13 @@ export default class AbstractTestCase {
   }
 
   textValue() {
-    return this.element.textContent;
+    return getElement().textContent;
   }
 
   takeSnapshot() {
     let snapshot = (this.snapshot = []);
 
-    let node = this.element.firstChild;
+    let node = getElement().firstChild;
 
     while (node) {
       if (!isMarker(node)) {
@@ -172,11 +173,11 @@ export default class AbstractTestCase {
   }
 
   assertInnerHTML(html) {
-    equalInnerHTML(this.assert, this.element, html);
+    equalInnerHTML(this.assert, getElement(), html);
   }
 
   assertHTML(html) {
-    equalTokens(this.element, html, `#qunit-fixture content should be: \`${html}\``);
+    equalTokens(getElement(), html, `#qunit-fixture content should be: \`${html}\``);
   }
 
   assertElement(node, { ElementType = HTMLElement, tagName, attrs = null, content = null }) {

--- a/packages/internal-test-helpers/lib/test-context.ts
+++ b/packages/internal-test-helpers/lib/test-context.ts
@@ -1,0 +1,30 @@
+export interface BaseContext {
+  [key: string]: any;
+}
+
+let __test_context__: BaseContext | undefined;
+
+/**
+ * Stores the provided context as the "global testing context".
+ *
+ * @param {Object} context the context to use
+ */
+export function setContext(context: BaseContext): void {
+  __test_context__ = context;
+}
+
+/**
+ * Retrive the "global testing context" as stored by `setContext`.
+ *
+ * @returns {Object} the previously stored testing context
+ */
+export function getContext(): BaseContext | undefined {
+  return __test_context__;
+}
+
+/**
+ * Clear the "global testing context".
+ */
+export function unsetContext(): void {
+  __test_context__ = undefined;
+}


### PR DESCRIPTION
This is roughly similar to what `@ember/test-helpers` does to enable importable test helpers that work on the test context.