### PR TITLE
Allow notifyPropertyChange to be imported from @ember/object

### DIFF
--- a/packages/@ember/-internals/metal/lib/property_events.ts
+++ b/packages/@ember/-internals/metal/lib/property_events.ts
@@ -26,7 +26,7 @@ let deferred = 0;
   manually.
 
   @method notifyPropertyChange
-  @for Ember
+  @for @ember/object
   @param {Object} obj The object with the property that will change
   @param {String} keyName The property key (or path) that will change.
   @param {Meta} meta The objects meta.

--- a/packages/@ember/-internals/metal/lib/property_events.ts
+++ b/packages/@ember/-internals/metal/lib/property_events.ts
@@ -31,6 +31,7 @@ let deferred = 0;
   @param {String} keyName The property key (or path) that will change.
   @param {Meta} meta The objects meta.
   @return {void}
+  @since 3.1.0
   @public
 */
 function notifyPropertyChange(obj: object, keyName: string, _meta?: Meta): void {


### PR DESCRIPTION
```ts
import { notifyPropertyChange } from '@ember/object';
```

related: https://github.com/ember-cli/ember-rfc176-data/pull/84