### PR TITLE
internal-test-helpers: Convert runloop-related methods to importable test helpers

### DIFF
--- a/packages/@ember/-internals/container/tests/container_test.js
+++ b/packages/@ember/-internals/container/tests/container_test.js
@@ -2,7 +2,7 @@ import { OWNER } from '@ember/-internals/owner';
 import { assign } from '@ember/polyfills';
 import { EMBER_MODULE_UNIFICATION } from '@ember/canary-features';
 import { Registry } from '..';
-import { factory, moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { factory, moduleFor, AbstractTestCase, runTask } from 'internal-test-helpers';
 
 moduleFor(
   'Container',
@@ -679,7 +679,7 @@ moduleFor(
       let instance = container.lookup('component:foo-bar');
       assert.ok(instance, 'precond lookup successful');
 
-      this.runTask(() => {
+      runTask(() => {
         container.destroy();
         container.finalizeDestroy();
       });
@@ -697,7 +697,7 @@ moduleFor(
       let instance = container.factoryFor('component:foo-bar');
       assert.ok(instance, 'precond lookup successful');
 
-      this.runTask(() => {
+      runTask(() => {
         container.destroy();
         container.finalizeDestroy();
       });

--- a/packages/@ember/-internals/glimmer/tests/integration/application/actions-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/actions-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, ApplicationTestCase, RenderingTestCase } from 'internal-test-helpers';
+import { moduleFor, ApplicationTestCase, RenderingTestCase, runTask } from 'internal-test-helpers';
 
 import Controller from '@ember/controller';
 import { getDebugFunction, setDebugFunction } from '@ember/debug';
@@ -42,7 +42,7 @@ moduleFor(
       );
 
       return this.visit('/').then(() => {
-        this.runTask(() => this.$('#handle-it').click());
+        runTask(() => this.$('#handle-it').click());
       });
     }
 
@@ -74,7 +74,7 @@ moduleFor(
       this.addTemplate('index', '<button id="handle-it" {{action "handleIt"}}>Click!</button>');
 
       return this.visit('/').then(() => {
-        this.runTask(() => this.$('#handle-it').click());
+        runTask(() => this.$('#handle-it').click());
       });
     }
   }

--- a/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, ApplicationTestCase, strip } from 'internal-test-helpers';
+import { moduleFor, ApplicationTestCase, strip, runTaskNext } from 'internal-test-helpers';
 
 import Controller from '@ember/controller';
 import { RSVP } from '@ember/-internals/runtime';
@@ -695,7 +695,7 @@ moduleFor(
           this.assertText('ApplicationLoading');
           resolveLoading.resolve();
 
-          return this.runTaskNext().then(() => {
+          return runTaskNext().then(() => {
             this.assertText('ApplicationEnginePost');
             done();
           });
@@ -742,7 +742,7 @@ moduleFor(
           this.assertText('ApplicationEngineLoading');
           resolveLoading.resolve();
 
-          return this.runTaskNext().then(() => {
+          return runTaskNext().then(() => {
             this.assertText('ApplicationEnginePost');
             done();
           });
@@ -779,13 +779,13 @@ moduleFor(
         this.assertText('ApplicationEngineComments');
         let transition = this.transitionTo('blog.post.likes');
 
-        this.runTaskNext().then(() => {
+        runTaskNext().then(() => {
           this.assertText('ApplicationEngineLoading');
           resolveLoading();
         });
 
         return transition
-          .then(() => this.runTaskNext())
+          .then(() => runTaskNext())
           .then(() => this.assertText('ApplicationEngineLikes'));
       });
     }
@@ -829,7 +829,7 @@ moduleFor(
           this.assertText('ApplicationEngineLoading');
           resolveLoading.resolve();
 
-          return this.runTaskNext().then(() => {
+          return runTaskNext().then(() => {
             this.assertText('ApplicationEngineLikes');
             done();
           });

--- a/packages/@ember/-internals/glimmer/tests/integration/application/hot-reload-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/hot-reload-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, ApplicationTestCase, strip } from 'internal-test-helpers';
+import { moduleFor, ApplicationTestCase, strip, runTask } from 'internal-test-helpers';
 
 import { ENV } from '@ember/-internals/environment';
 import Service, { inject as injectService } from '@ember/service';
@@ -126,7 +126,7 @@ moduleFor(
           [x-bar]
         `);
 
-        this.runTask(() => {
+        runTask(() => {
           this.hotReload('x-foo', '<h1>{{@name}}</h1>');
         });
 
@@ -136,7 +136,7 @@ moduleFor(
           [x-bar]
         `);
 
-        this.runTask(() => {
+        runTask(() => {
           this.hotReload('x-bar', '<h2>wow</h2>');
         });
 
@@ -146,7 +146,7 @@ moduleFor(
           [<h2>wow</h2>]
         `);
 
-        this.runTask(() => {
+        runTask(() => {
           this.hotReload('x-foo', '<strong>x-foo</strong> <em>{{@name}}</em>');
         });
 
@@ -156,7 +156,7 @@ moduleFor(
           [<h2>wow</h2>]
         `);
 
-        this.runTask(() => {
+        runTask(() => {
           this.hotReload('x-foo', 'x-foo: {{@name}}');
           this.hotReload('x-bar', 'x-bar');
         });
@@ -210,7 +210,7 @@ moduleFor(
           [x-bar (2)]
         `);
 
-        this.runTask(() => {
+        runTask(() => {
           this.hotReload('x-foo', '<h1>{{@name}} ({{this.id}})</h1>');
         });
 
@@ -220,7 +220,7 @@ moduleFor(
           [x-bar (2)]
         `);
 
-        this.runTask(() => {
+        runTask(() => {
           this.hotReload('x-bar', '<h2>wow ({{this.id}})</h2>');
         });
 
@@ -230,7 +230,7 @@ moduleFor(
           [<h2>wow (5)</h2>]
         `);
 
-        this.runTask(() => {
+        runTask(() => {
           this.hotReload('x-foo', '<strong>x-foo</strong> <em>{{@name}} ({{this.id}})</em>');
         });
 
@@ -240,7 +240,7 @@ moduleFor(
           [<h2>wow (5)</h2>]
         `);
 
-        this.runTask(() => {
+        runTask(() => {
           this.hotReload('x-foo', 'x-foo: {{@name}} ({{this.id}})');
           this.hotReload('x-bar', 'x-bar ({{this.id}})');
         });

--- a/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase, strip, classes } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, strip, classes, runTask } from 'internal-test-helpers';
 
 import { EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION } from '@ember/canary-features';
 import { set } from '@ember/-internals/metal';
@@ -16,7 +16,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
 
         this.assertComponentElement(this.firstChild, { content: 'hello' });
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertComponentElement(this.firstChild, { content: 'hello' });
       }
@@ -28,7 +28,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
 
         this.assertComponentElement(this.firstChild, { content: 'hello' });
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertComponentElement(this.firstChild, { content: 'hello' });
       }
@@ -40,7 +40,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
 
         this.assertComponentElement(this.firstChild, { content: 'hello' });
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertComponentElement(this.firstChild, { content: 'hello' });
       }
@@ -63,7 +63,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
 
         this.assertComponentElement(this.firstChild, { content: 'hello' });
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertComponentElement(this.firstChild, { content: 'hello' });
       }
@@ -95,7 +95,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'bizz bizz',
         });
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertComponentElement(this.firstChild, {
           tagName: 'div',
@@ -103,7 +103,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'bizz bizz',
         });
 
-        this.runTask(() => set(this.context, 'customId', 'bar'));
+        runTask(() => set(this.context, 'customId', 'bar'));
 
         this.assertComponentElement(this.firstChild, {
           tagName: 'div',
@@ -111,7 +111,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'bar bizz',
         });
 
-        this.runTask(() => set(this.context, 'customId', 'bizz'));
+        runTask(() => set(this.context, 'customId', 'bizz'));
 
         this.assertComponentElement(this.firstChild, {
           tagName: 'div',
@@ -137,7 +137,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'hello',
         });
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertComponentElement(this.firstChild, {
           tagName: 'foo-bar',
@@ -155,7 +155,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'hello',
         });
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertComponentElement(this.firstChild, {
           tagName: 'foo-bar',
@@ -181,7 +181,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'hello',
         });
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertComponentElement(this.firstChild, {
           tagName: 'div',
@@ -202,21 +202,21 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           attrs: { class: classes('ember-view foo-bar') },
         });
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertComponentElement(this.firstChild, {
           content: 'hello',
           attrs: { class: classes('ember-view foo-bar') },
         });
 
-        this.runTask(() => set(this.context, 'fooBar', false));
+        runTask(() => set(this.context, 'fooBar', false));
 
         this.assertComponentElement(this.firstChild, {
           content: 'hello',
           attrs: { class: classes('ember-view') },
         });
 
-        this.runTask(() => set(this.context, 'fooBar', true));
+        runTask(() => set(this.context, 'fooBar', true));
 
         this.assertComponentElement(this.firstChild, {
           content: 'hello',
@@ -256,7 +256,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'hello',
         });
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertComponentElement(this.nthChild(0), {
           tagName: 'div',
@@ -296,7 +296,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
 
         this.assertComponentElement(element1, { content: 'hello' });
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         let element2 = instance.element;
 
@@ -340,7 +340,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
         assert.deepEqual(this.component.childViews, [fooBarInstance]);
         assert.deepEqual(fooBarInstance.childViews, [fooBarBazInstance]);
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
         this.assertText('foo-bar foo-bar-baz');
 
         assert.equal(fooBarInstance.parentView, this.component);
@@ -363,15 +363,15 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
 
         this.assertText('Hola');
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertText('Hola');
 
-        this.runTask(() => this.context.set('model.bar', 'Hello'));
+        runTask(() => this.context.set('model.bar', 'Hello'));
 
         this.assertText('Hello');
 
-        this.runTask(() => this.context.set('model', { bar: 'Hola' }));
+        runTask(() => this.context.set('model', { bar: 'Hola' }));
 
         this.assertText('Hola');
       }
@@ -389,15 +389,15 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
 
         this.assertText('Hola');
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertText('Hola');
 
-        this.runTask(() => this.context.set('model.bar', 'Hello'));
+        runTask(() => this.context.set('model.bar', 'Hello'));
 
         this.assertText('Hello');
 
-        this.runTask(() => this.context.set('model', { bar: 'Hola' }));
+        runTask(() => this.context.set('model', { bar: 'Hola' }));
 
         this.assertText('Hola');
       }
@@ -413,7 +413,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'hello - In component',
         });
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertComponentElement(this.firstChild, {
           content: 'hello - In component',
@@ -450,13 +450,13 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'Joel Kang, hello',
         });
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertComponentElement(this.firstChild, {
           content: 'Joel Kang, hello',
         });
 
-        this.runTask(() =>
+        runTask(() =>
           set(this.context, 'person', {
             firstName: 'Dora',
             lastName: 'the Explorer',
@@ -467,13 +467,13 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'Dora the Explorer, hello',
         });
 
-        this.runTask(() => set(instance, 'greeting', 'hola'));
+        runTask(() => set(instance, 'greeting', 'hola'));
 
         this.assertComponentElement(this.firstChild, {
           content: 'Dora the Explorer, hola',
         });
 
-        this.runTask(() => {
+        runTask(() => {
           set(instance, 'greeting', 'hello');
           set(this.context, 'person', {
             firstName: 'Joel',
@@ -513,7 +513,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
 
         this.assertComponentElement(this.firstChild, { content: 'hello' });
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertComponentElement(this.firstChild, { content: 'hello' });
 
@@ -527,7 +527,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
 
         this.assertComponentElement(this.firstChild.firstChild, { content: 'hello' });
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertComponentElement(this.firstChild.firstChild, { content: 'hello' });
 
@@ -541,7 +541,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
 
         this.assertComponentElement(this.firstChild.firstChild, { content: 'hello' });
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertComponentElement(this.firstChild.firstChild, { content: 'hello' });
 
@@ -599,7 +599,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'hello',
         });
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertComponentElement(this.firstChild, {
           tagName: 'div',
@@ -607,7 +607,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'hello',
         });
 
-        this.runTask(() => {
+        runTask(() => {
           set(this.context, 'foo', 'FOO');
           set(this.context, 'bar', undefined);
         });
@@ -618,7 +618,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'hello',
         });
 
-        this.runTask(() => {
+        runTask(() => {
           set(this.context, 'foo', 'foo');
           set(this.context, 'bar', 'bar');
         });
@@ -678,7 +678,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'hello',
         });
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertElement(this.firstChild, {
           tagName: 'div',
@@ -686,7 +686,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'hello',
         });
 
-        this.runTask(() => {
+        runTask(() => {
           set(this.context, 'foo', 'FOO');
           set(this.context, 'bar', undefined);
         });
@@ -697,7 +697,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'hello',
         });
 
-        this.runTask(() => {
+        runTask(() => {
           set(this.context, 'foo', 'foo');
           set(this.context, 'bar', 'bar');
         });
@@ -731,7 +731,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'hello',
         });
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertElement(this.firstChild, {
           tagName: 'div',
@@ -739,7 +739,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'hello',
         });
 
-        this.runTask(() => {
+        runTask(() => {
           set(this.context, 'foo', 'FOO');
           set(this.context, 'bar', undefined);
           set(instance, 'localProp', 'QUZ');
@@ -751,7 +751,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'hello',
         });
 
-        this.runTask(() => {
+        runTask(() => {
           set(this.context, 'foo', 'foo');
           set(this.context, 'bar', 'bar');
           set(instance, 'localProp', 'qux');
@@ -786,7 +786,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'hello',
         });
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertElement(this.firstChild, {
           tagName: 'div',
@@ -794,7 +794,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'hello',
         });
 
-        this.runTask(() => {
+        runTask(() => {
           set(this.context, 'bar', undefined);
           set(instance, 'localProp', 'QUZ');
         });
@@ -805,7 +805,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'hello',
         });
 
-        this.runTask(() => {
+        runTask(() => {
           set(this.context, 'bar', 'bar');
           set(instance, 'localProp', 'qux');
         });
@@ -874,7 +874,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'world',
         });
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertElement(this.firstChild, {
           tagName: 'div',
@@ -887,7 +887,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'world',
         });
 
-        this.runTask(() => {
+        runTask(() => {
           set(this.context, 'foo', 'FOO');
           set(this.context, 'bar', undefined);
         });
@@ -903,7 +903,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
           content: 'world',
         });
 
-        this.runTask(() => {
+        runTask(() => {
           set(this.context, 'foo', 'foo');
           set(this.context, 'bar', 'bar');
         });

--- a/packages/@ember/-internals/glimmer/tests/integration/components/append-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/append-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase, strip } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
 
@@ -16,7 +16,7 @@ class AbstractAppendTest extends RenderingTestCase {
     this.component = null;
 
     this.components.forEach(component => {
-      this.runTask(() => component.destroy());
+      runTask(() => component.destroy());
     });
 
     this.ids.forEach(id => {
@@ -170,7 +170,7 @@ class AbstractAppendTest extends RenderingTestCase {
 
     hooks.length = 0;
 
-    this.runTask(() => componentsByName['x-parent'].rerender());
+    runTask(() => componentsByName['x-parent'].rerender());
 
     assert.deepEqual(
       hooks,
@@ -186,7 +186,7 @@ class AbstractAppendTest extends RenderingTestCase {
 
     hooks.length = 0;
 
-    this.runTask(() => componentsByName['x-child'].rerender());
+    runTask(() => componentsByName['x-child'].rerender());
 
     assert.deepEqual(
       hooks,
@@ -208,7 +208,7 @@ class AbstractAppendTest extends RenderingTestCase {
 
     hooks.length = 0;
 
-    this.runTask(() => set(this.component, 'foo', 'wow'));
+    runTask(() => set(this.component, 'foo', 'wow'));
 
     assert.deepEqual(
       hooks,
@@ -233,7 +233,7 @@ class AbstractAppendTest extends RenderingTestCase {
 
     hooks.length = 0;
 
-    this.runTask(() => set(this.component, 'foo', 'zomg'));
+    runTask(() => set(this.component, 'foo', 'zomg'));
 
     assert.deepEqual(
       hooks,
@@ -258,7 +258,7 @@ class AbstractAppendTest extends RenderingTestCase {
 
     hooks.length = 0;
 
-    this.runTask(() => this.component.destroy());
+    runTask(() => this.component.destroy());
 
     assert.deepEqual(
       hooks,
@@ -323,7 +323,7 @@ class AbstractAppendTest extends RenderingTestCase {
       'It should be attached to the target'
     );
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertComponentElement(componentElement, {
       content: '[parent: zomg][child: zomg][yielded: zomg]',
@@ -335,7 +335,7 @@ class AbstractAppendTest extends RenderingTestCase {
       'It should be attached to the target'
     );
 
-    this.runTask(() => set(this.component, 'foo', 'wow'));
+    runTask(() => set(this.component, 'foo', 'wow'));
 
     this.assertComponentElement(componentElement, {
       content: '[parent: wow][child: wow][yielded: wow]',
@@ -347,7 +347,7 @@ class AbstractAppendTest extends RenderingTestCase {
       'It should be attached to the target'
     );
 
-    this.runTask(() => set(this.component, 'foo', 'zomg'));
+    runTask(() => set(this.component, 'foo', 'zomg'));
 
     this.assertComponentElement(componentElement, {
       content: '[parent: zomg][child: zomg][yielded: zomg]',
@@ -359,7 +359,7 @@ class AbstractAppendTest extends RenderingTestCase {
       'It should be attached to the target'
     );
 
-    this.runTask(() => this.component.destroy());
+    runTask(() => this.component.destroy());
 
     assert.ok(!this.component.element, 'It should not have an element');
     assert.ok(!componentElement.parentElement, 'The component element should be detached');
@@ -379,7 +379,7 @@ class AbstractAppendTest extends RenderingTestCase {
 
     assert.equal(renderer._roots.length, 1, 'added a root component');
 
-    this.runTask(() => this.component.destroy());
+    runTask(() => this.component.destroy());
 
     assert.equal(renderer._roots.length, 0, 'released the root component');
   }
@@ -424,8 +424,8 @@ class AbstractAppendTest extends RenderingTestCase {
 
     let wrapper1, wrapper2;
 
-    this.runTask(() => (wrapper1 = this.append(first)));
-    this.runTask(() => (wrapper2 = this.append(second)));
+    runTask(() => (wrapper1 = this.append(first)));
+    runTask(() => (wrapper2 = this.append(second)));
 
     let componentElement1 = first.element;
     let componentElement2 = second.element;
@@ -446,7 +446,7 @@ class AbstractAppendTest extends RenderingTestCase {
       'The second component should be attached to the target'
     );
 
-    this.runTask(() => set(first, 'foo', 'FOO'));
+    runTask(() => set(first, 'foo', 'FOO'));
 
     this.assertComponentElement(componentElement1, { content: 'x-first FOO!' });
     this.assertComponentElement(componentElement2, {
@@ -464,7 +464,7 @@ class AbstractAppendTest extends RenderingTestCase {
       'The second component should be attached to the target'
     );
 
-    this.runTask(() => set(second, 'bar', 'BAR'));
+    runTask(() => set(second, 'bar', 'BAR'));
 
     this.assertComponentElement(componentElement1, { content: 'x-first FOO!' });
     this.assertComponentElement(componentElement2, {
@@ -482,7 +482,7 @@ class AbstractAppendTest extends RenderingTestCase {
       'The second component should be attached to the target'
     );
 
-    this.runTask(() => {
+    runTask(() => {
       set(first, 'foo', 'foo');
       set(second, 'bar', 'bar');
     });
@@ -503,7 +503,7 @@ class AbstractAppendTest extends RenderingTestCase {
       'The second component should be attached to the target'
     );
 
-    this.runTask(() => {
+    runTask(() => {
       first.destroy();
       second.destroy();
     });
@@ -551,7 +551,7 @@ class AbstractAppendTest extends RenderingTestCase {
 
     let FirstComponent = this.owner.factoryFor('component:first-component');
 
-    this.runTask(() => append(FirstComponent.create()));
+    runTask(() => append(FirstComponent.create()));
 
     this.assertComponentElement(element1, { content: 'component-one' });
     this.assertComponentElement(element2, { content: 'component-two' });
@@ -656,7 +656,7 @@ class AbstractAppendTest extends RenderingTestCase {
 
     this.assertStableRerender();
 
-    this.runTask(() => set(this.context, 'showFooBar', false));
+    runTask(() => set(this.context, 'showFooBar', false));
 
     assert.equal(instantiatedRoots, 2);
     assert.equal(destroyedRoots, 1);
@@ -664,7 +664,7 @@ class AbstractAppendTest extends RenderingTestCase {
     this.assertComponentElement(element3, {});
     this.assertComponentElement(element4, { content: 'fake-thing: 1' });
 
-    this.runTask(() => {
+    runTask(() => {
       component1.destroy();
       component2.destroy();
     });
@@ -678,7 +678,7 @@ moduleFor(
   'append: no arguments (attaching to document.body)',
   class extends AbstractAppendTest {
     append(component) {
-      this.runTask(() => component.append());
+      runTask(() => component.append());
       this.didAppend(component);
       return document.body;
     }
@@ -689,7 +689,7 @@ moduleFor(
   'appendTo: a selector',
   class extends AbstractAppendTest {
     append(component) {
-      this.runTask(() => component.appendTo('#qunit-fixture'));
+      runTask(() => component.appendTo('#qunit-fixture'));
       this.didAppend(component);
       return document.getElementById('qunit-fixture');
     }
@@ -708,7 +708,7 @@ moduleFor(
 
       assert.ok(!this.component.element, 'precond - should not have an element');
 
-      this.runTask(() => {
+      runTask(() => {
         expectAssertion(() => {
           this.component.appendTo('#does-not-exist-in-dom');
         }, /You tried to append to \(#does-not-exist-in-dom\) but that isn't in the DOM/);
@@ -724,7 +724,7 @@ moduleFor(
   class extends AbstractAppendTest {
     append(component) {
       let element = document.getElementById('qunit-fixture');
-      this.runTask(() => component.appendTo(element));
+      runTask(() => component.appendTo(element));
       this.didAppend(component);
       return element;
     }
@@ -735,7 +735,7 @@ moduleFor(
   'appendTo: with multiple components',
   class extends AbstractAppendTest {
     append(component) {
-      this.runTask(() => component.appendTo('#qunit-fixture'));
+      runTask(() => component.appendTo('#qunit-fixture'));
       this.didAppend(component);
       return document.getElementById('qunit-fixture');
     }

--- a/packages/@ember/-internals/glimmer/tests/integration/components/attribute-bindings-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/attribute-bindings-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase, strip } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
 
@@ -25,7 +25,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -33,7 +33,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'foo', 'FOO');
         set(this.context, 'bar', undefined);
       });
@@ -44,7 +44,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'foo', 'foo');
         set(this.context, 'bar', 'bar');
       });
@@ -76,7 +76,7 @@ moduleFor(
         attrs: { 'data-bar': 'bar' },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -84,7 +84,7 @@ moduleFor(
         attrs: { 'data-bar': 'bar' },
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'model.foo', 'foo');
         set(this.context, 'model.baz.bar', undefined);
       });
@@ -95,7 +95,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'model', {
           foo: undefined,
           baz: { bar: 'bar' },
@@ -127,7 +127,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -135,7 +135,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'foo.bar', 'FOO-BAR'));
+      runTask(() => set(this.context, 'foo.bar', 'FOO-BAR'));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -143,7 +143,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'foo.bar', undefined));
+      runTask(() => set(this.context, 'foo.bar', undefined));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -151,7 +151,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'foo', undefined));
+      runTask(() => set(this.context, 'foo', undefined));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -159,7 +159,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'foo', { bar: 'foo-bar' }));
+      runTask(() => set(this.context, 'foo', { bar: 'foo-bar' }));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -188,7 +188,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -196,7 +196,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'submit', 'password'));
+      runTask(() => set(this.context, 'submit', 'password'));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -204,7 +204,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'submit', null));
+      runTask(() => set(this.context, 'submit', null));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -212,7 +212,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'submit', 'submit'));
+      runTask(() => set(this.context, 'submit', 'submit'));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -258,7 +258,7 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'name', null));
+      runTask(() => set(this.context, 'name', null));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -266,7 +266,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'name', 'qux'));
+      runTask(() => set(this.context, 'name', 'qux'));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -297,7 +297,7 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'foo', null));
+      runTask(() => set(this.context, 'foo', null));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -305,7 +305,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'foo', 'qux'));
+      runTask(() => set(this.context, 'foo', 'qux'));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -337,11 +337,11 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'foo', null));
+      runTask(() => set(this.context, 'foo', null));
 
       this.assert.ok(!this.firstChild.hasAttribute('viewBox'), 'viewBox attribute removed');
 
-      this.runTask(() => set(this.context, 'foo', '0 0 100 200'));
+      runTask(() => set(this.context, 'foo', '0 0 100 200'));
 
       this.assert.equal(
         this.firstChild.getAttribute('viewBox'),
@@ -371,7 +371,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -379,7 +379,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'fizz', 'fizz');
         set(this.context, 'bar', 'bar');
       });
@@ -390,7 +390,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'fizz', null);
         set(this.context, 'bar', undefined);
       });
@@ -422,7 +422,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -430,7 +430,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'size', 0));
+      runTask(() => set(this.context, 'size', 0));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -438,7 +438,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'size', 21));
+      runTask(() => set(this.context, 'size', 21));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -471,7 +471,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -479,7 +479,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(component, 'type', 'checkbox'));
+      runTask(() => set(component, 'type', 'checkbox'));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -487,7 +487,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(component, 'type', 'password'));
+      runTask(() => set(component, 'type', 'password'));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -514,14 +514,14 @@ moduleFor(
         attrs: { type: 'password' },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'input',
         attrs: { type: 'password' },
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'type', 'checkbox');
         set(this.context, 'disabled', true);
       });
@@ -531,7 +531,7 @@ moduleFor(
         attrs: { type: 'checkbox', disabled: '' },
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'type', 'password');
         set(this.context, 'disabled', false);
       });
@@ -558,21 +558,21 @@ moduleFor(
         attrs: { 'xlink:href': '/foo.png' },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
         attrs: { 'xlink:href': '/foo.png' },
       });
 
-      this.runTask(() => set(this.context, 'xlinkHref', '/lol.png'));
+      runTask(() => set(this.context, 'xlinkHref', '/lol.png'));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
         attrs: { 'xlink:href': '/lol.png' },
       });
 
-      this.runTask(() => set(this.context, 'xlinkHref', '/foo.png'));
+      runTask(() => set(this.context, 'xlinkHref', '/foo.png'));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -601,14 +601,14 @@ moduleFor(
         attrs: { foo: 'bar' },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
         attrs: { foo: 'bar' },
       });
 
-      this.runTask(() =>
+      runTask(() =>
         set(
           this.context,
           'foo',
@@ -623,7 +623,7 @@ moduleFor(
         attrs: { foo: 'baz' },
       });
 
-      this.runTask(() =>
+      runTask(() =>
         set(
           this.context,
           'foo',
@@ -655,21 +655,21 @@ moduleFor(
         attrs: { id: 'special-sauce' },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
         attrs: { id: 'special-sauce' },
       });
 
-      this.runTask(() => set(this.context, 'sauce', 'foo'));
+      runTask(() => set(this.context, 'sauce', 'foo'));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
         attrs: { id: 'special-sauce' },
       });
 
-      this.runTask(() => set(this.context, 'sauce', 'special-sauce'));
+      runTask(() => set(this.context, 'sauce', 'special-sauce'));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -698,14 +698,14 @@ moduleFor(
         attrs: { href: 'dog.html' },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
         attrs: { href: 'dog.html' },
       });
 
-      this.runTask(() => set(this.context, 'href', 'cat.html'));
+      runTask(() => set(this.context, 'href', 'cat.html'));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -768,7 +768,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.nthChild(0), {
         tagName: 'div',
@@ -791,7 +791,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'foo', 'FOO');
         set(this.context, 'bar', undefined);
       });
@@ -817,7 +817,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'bar', 'BAR'));
+      runTask(() => set(this.context, 'bar', 'BAR'));
 
       this.assertComponentElement(this.nthChild(0), {
         tagName: 'div',
@@ -840,7 +840,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'foo', 'foo');
         set(this.context, 'bar', 'bar');
       });
@@ -918,21 +918,21 @@ moduleFor(
         attrs: { role: 'button' },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
         attrs: { role: 'button' },
       });
 
-      this.runTask(() => set(this.context, 'role', 'combobox'));
+      runTask(() => set(this.context, 'role', 'combobox'));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
         attrs: { role: 'combobox' },
       });
 
-      this.runTask(() => set(this.context, 'role', null));
+      runTask(() => set(this.context, 'role', null));
 
       this.assertComponentElement(this.firstChild, { tagName: 'div' });
     }

--- a/packages/@ember/-internals/glimmer/tests/integration/components/attrs-lookup-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/attrs-lookup-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase, styles } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, styles, runTask } from 'internal-test-helpers';
 
 import { set, computed } from '@ember/-internals/metal';
 
@@ -16,15 +16,15 @@ moduleFor(
 
       this.assertText('first attr');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('first attr');
 
-      this.runTask(() => set(this.context, 'firstAttr', 'second attr'));
+      runTask(() => set(this.context, 'firstAttr', 'second attr'));
 
       this.assertText('second attr');
 
-      this.runTask(() => set(this.context, 'firstAttr', 'first attr'));
+      runTask(() => set(this.context, 'firstAttr', 'first attr'));
 
       this.assertText('first attr');
     }
@@ -49,15 +49,15 @@ moduleFor(
 
       assert.equal(instance.get('first'), 'first attr');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.equal(instance.get('first'), 'first attr');
 
-      this.runTask(() => set(this.context, 'firstAttr', 'second attr'));
+      runTask(() => set(this.context, 'firstAttr', 'second attr'));
 
       assert.equal(instance.get('first'), 'second attr');
 
-      this.runTask(() => set(this.context, 'firstAttr', 'first attr'));
+      runTask(() => set(this.context, 'firstAttr', 'first attr'));
 
       this.assertText('first attr');
     }
@@ -84,7 +84,7 @@ moduleFor(
       assert.equal(instance.get('first'), 'FIRST ATTR', 'component lookup uses local state');
       this.assertText('FIRST ATTR');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.equal(
         instance.get('first'),
@@ -119,18 +119,18 @@ moduleFor(
 
       assert.equal(instance.get('woot'), 'yes', 'component found attr');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.equal(instance.get('woot'), 'yes', 'component found attr after rerender');
 
-      this.runTask(() => {
+      runTask(() => {
         wootVal = 'nope';
         set(this.context, 'woot', wootVal);
       });
 
       assert.equal(instance.get('woot'), 'nope', 'component found attr after attr change');
 
-      this.runTask(() => {
+      runTask(() => {
         wootVal = 'yes';
         set(this.context, 'woot', wootVal);
       });
@@ -182,13 +182,13 @@ moduleFor(
       assert.equal(instance.get('first'), 'first', 'matches known value');
       assert.equal(instance.get('second'), 'second', 'matches known value');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.equal(instance.get('firstPositional'), 'firstPositional', 'matches known value');
       assert.equal(instance.get('first'), 'first', 'matches known value');
       assert.equal(instance.get('second'), 'second', 'matches known value');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'first', 'third');
       });
 
@@ -196,7 +196,7 @@ moduleFor(
       assert.equal(instance.get('first'), 'third', 'matches known value');
       assert.equal(instance.get('second'), 'second', 'matches known value');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'second', 'fourth');
       });
 
@@ -204,7 +204,7 @@ moduleFor(
       assert.equal(instance.get('first'), 'third', 'matches known value');
       assert.equal(instance.get('second'), 'fourth', 'matches known value');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'firstPositional', 'fifth');
       });
 
@@ -212,7 +212,7 @@ moduleFor(
       assert.equal(instance.get('first'), 'third', 'matches known value');
       assert.equal(instance.get('second'), 'fourth', 'matches known value');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'firstPositional', 'firstPositional');
         set(this.context, 'first', 'first');
         set(this.context, 'second', 'second');

--- a/packages/@ember/-internals/glimmer/tests/integration/components/class-bindings-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/class-bindings-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase, strip, classes } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, strip, classes, runTask } from 'internal-test-helpers';
 
 import { set, computed } from '@ember/-internals/metal';
 
@@ -29,7 +29,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -37,7 +37,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'foo', 'FOO');
         set(this.context, 'isEnabled', false);
       });
@@ -48,7 +48,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'foo', undefined);
         set(this.context, 'isHappy', true);
       });
@@ -59,7 +59,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'foo', 'foo');
         set(this.context, 'isEnabled', true);
         set(this.context, 'isHappy', false);
@@ -92,7 +92,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -100,7 +100,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'model.wat', true);
         set(this.context, 'model.super.robin', false);
       });
@@ -111,7 +111,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'model', {
           wat: false,
           super: { robin: true },
@@ -149,7 +149,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         attrs: {
@@ -158,7 +158,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'model.someInitiallyTrueProperty', false);
         set(this.context, 'model.someInitiallyFalseProperty', true);
         set(this.context, 'model.someInitiallyUndefinedProperty', true);
@@ -177,7 +177,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'model', {
           someInitiallyTrueProperty: true,
           someInitiallyFalseProperty: false,
@@ -218,7 +218,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -226,7 +226,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'foo.bar', 'FOO-BAR');
         set(this.context, 'is.enabled', false);
       });
@@ -237,7 +237,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'foo.bar', null);
         set(this.context, 'is.happy', true);
       });
@@ -248,7 +248,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'foo', null);
         set(this.context, 'is', null);
       });
@@ -259,7 +259,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'foo', { bar: 'foo-bar' });
         set(this.context, 'is', { enabled: true, happy: false });
       });
@@ -292,7 +292,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -300,7 +300,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'fooBar', false);
         set(this.context, 'nested.fooBarBaz', true);
       });
@@ -311,7 +311,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'fooBar', 'FOO-BAR');
         set(this.context, 'nested.fooBarBaz', null);
       });
@@ -322,7 +322,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'nested', null));
+      runTask(() => set(this.context, 'nested', null));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -330,7 +330,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'fooBar', true);
         set(this.context, 'nested', { fooBarBaz: false });
       });
@@ -354,7 +354,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -362,7 +362,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'foo', false));
+      runTask(() => set(this.context, 'foo', false));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -370,7 +370,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'foo', true));
+      runTask(() => set(this.context, 'foo', true));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -399,7 +399,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'enabled', true));
+      runTask(() => set(this.context, 'enabled', true));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -407,7 +407,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'enabled', false));
+      runTask(() => set(this.context, 'enabled', false));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -436,7 +436,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'enabled', true));
+      runTask(() => set(this.context, 'enabled', true));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -549,7 +549,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.nthChild(0), {
         tagName: 'div',
@@ -572,7 +572,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'foo', 'FOO');
         set(this.context, 'isEnabled', false);
       });
@@ -598,7 +598,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'foo', undefined);
         set(this.context, 'isHappy', true);
       });
@@ -624,7 +624,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'foo', 'foo');
         set(this.context, 'isEnabled', true);
         set(this.context, 'isHappy', false);
@@ -685,7 +685,7 @@ moduleFor(
         attrs: { class: classes('foo  ember-view') },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -707,7 +707,7 @@ moduleFor(
         attrs: { class: classes('respeck myName ember-view') },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -729,7 +729,7 @@ moduleFor(
         attrs: { class: classes('respeck  ember-view') },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -751,7 +751,7 @@ moduleFor(
         attrs: { class: classes('shade  ember-view') },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -773,7 +773,7 @@ moduleFor(
         attrs: { class: classes('ember-view') },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -793,7 +793,7 @@ moduleFor(
         attrs: { class: classes('ember-view') },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -815,7 +815,7 @@ moduleFor(
         attrs: { class: classes('scrub  ember-view') },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -837,7 +837,7 @@ moduleFor(
         attrs: { class: classes('fresh  ember-view') },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase, applyMixins, strip } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, applyMixins, strip, runTask } from 'internal-test-helpers';
 
 import { assign } from '@ember/polyfills';
 import { isEmpty } from '@ember/-internals/metal';
@@ -20,7 +20,7 @@ moduleFor(
 
       this.assertText(expectedText);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText(expectedText);
     }
@@ -38,7 +38,7 @@ moduleFor(
 
       this.assertText('Hodi Hodari');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Hodi Hodari');
     }
@@ -60,19 +60,19 @@ moduleFor(
 
       this.assertText('Gabon Zack');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Gabon Zack');
 
-      this.runTask(() => this.context.set('model.greeting', 'Good morning '));
+      runTask(() => this.context.set('model.greeting', 'Good morning '));
 
       this.assertText('Good morning Zack');
 
-      this.runTask(() => this.context.set('model.name', 'Matthew'));
+      runTask(() => this.context.set('model.name', 'Matthew'));
 
       this.assertText('Good morning Matthew');
 
-      this.runTask(() => this.context.set('model', { greeting: 'Gabon ', name: 'Zack' }));
+      runTask(() => this.context.set('model', { greeting: 'Gabon ', name: 'Zack' }));
 
       this.assertText('Gabon Zack');
     }
@@ -98,19 +98,19 @@ moduleFor(
 
       this.assertText('Gabon Zack Zack Gabon ');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Gabon Zack Zack Gabon ');
 
-      this.runTask(() => this.context.set('model.greeting', 'Good morning '));
+      runTask(() => this.context.set('model.greeting', 'Good morning '));
 
       this.assertText('Good morning Zack Zack Good morning ');
 
-      this.runTask(() => this.context.set('model.name', 'Matthew '));
+      runTask(() => this.context.set('model.name', 'Matthew '));
 
       this.assertText('Good morning Matthew Matthew Good morning ');
 
-      this.runTask(() => this.context.set('model', { greeting: 'Gabon ', name: 'Zack ' }));
+      runTask(() => this.context.set('model', { greeting: 'Gabon ', name: 'Zack ' }));
 
       this.assertText('Gabon Zack Zack Gabon ');
     }
@@ -132,19 +132,19 @@ moduleFor(
 
       this.assertText('Gabon Zack');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Gabon Zack');
 
-      this.runTask(() => this.context.set('model.greeting', 'Good morning '));
+      runTask(() => this.context.set('model.greeting', 'Good morning '));
 
       this.assertText('Good morning Zack');
 
-      this.runTask(() => this.context.set('model.name', 'Matthew'));
+      runTask(() => this.context.set('model.name', 'Matthew'));
 
       this.assertText('Good morning Matthew');
 
-      this.runTask(() => this.context.set('model', { greeting: 'Gabon ', name: 'Zack' }));
+      runTask(() => this.context.set('model', { greeting: 'Gabon ', name: 'Zack' }));
 
       this.assertText('Gabon Zack');
     }
@@ -169,19 +169,19 @@ moduleFor(
 
       this.assertText('Gabon Zack Zack Gabon ');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Gabon Zack Zack Gabon ');
 
-      this.runTask(() => this.context.set('model.greeting', 'Good morning '));
+      runTask(() => this.context.set('model.greeting', 'Good morning '));
 
       this.assertText('Good morning Zack Zack Good morning ');
 
-      this.runTask(() => this.context.set('model.name', 'Matthew '));
+      runTask(() => this.context.set('model.name', 'Matthew '));
 
       this.assertText('Good morning Matthew Matthew Good morning ');
 
-      this.runTask(() => this.context.set('model', { greeting: 'Gabon ', name: 'Zack ' }));
+      runTask(() => this.context.set('model', { greeting: 'Gabon ', name: 'Zack ' }));
 
       this.assertText('Gabon Zack Zack Gabon ');
     }
@@ -200,7 +200,7 @@ moduleFor(
 
       this.assertText('Hola Hodari');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Hola Hodari');
     }
@@ -222,15 +222,15 @@ moduleFor(
 
       this.assertText('ni hao');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('ni hao');
 
-      this.runTask(() => this.context.set('model.lookupComponent', '-hindi'));
+      runTask(() => this.context.set('model.lookupComponent', '-hindi'));
 
       this.assertText('Namaste');
 
-      this.runTask(() => this.context.set('model', { lookupComponent: '-mandarin' }));
+      runTask(() => this.context.set('model', { lookupComponent: '-mandarin' }));
 
       this.assertText('ni hao');
     }
@@ -248,15 +248,15 @@ moduleFor(
 
       this.assertText('Hodi');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Hodi');
 
-      this.runTask(() => this.context.set('model.greeting', 'Hola'));
+      runTask(() => this.context.set('model.greeting', 'Hola'));
 
       this.assertText('Hola');
 
-      this.runTask(() => this.context.set('model', { greeting: 'Hodi' }));
+      runTask(() => this.context.set('model', { greeting: 'Hodi' }));
 
       this.assertText('Hodi');
     }
@@ -280,15 +280,15 @@ moduleFor(
 
       this.assertText('Hodi');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Hodi');
 
-      this.runTask(() => this.context.set('model.greeting', 'Hola'));
+      runTask(() => this.context.set('model.greeting', 'Hola'));
 
       this.assertText('Hola');
 
-      this.runTask(() => this.context.set('model', { greeting: 'Hodi' }));
+      runTask(() => this.context.set('model', { greeting: 'Hodi' }));
 
       this.assertText('Hodi');
     }
@@ -307,7 +307,7 @@ moduleFor(
 
       this.assertText('Sergio 29');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Sergio 29');
     }
@@ -324,7 +324,7 @@ moduleFor(
 
       this.assertText('Hi Max 9');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Hi Max 9');
     }
@@ -350,15 +350,15 @@ moduleFor(
 
       this.assertText('Hodi Sigmundur 33');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Hodi Sigmundur 33');
 
-      this.runTask(() => this.context.set('model.greeting', 'Kaixo'));
+      runTask(() => this.context.set('model.greeting', 'Kaixo'));
 
       this.assertText('Kaixo Sigmundur 33');
 
-      this.runTask(() => this.context.set('model', { greeting: 'Hodi' }));
+      runTask(() => this.context.set('model', { greeting: 'Hodi' }));
 
       this.assertText('Hodi Sigmundur 33');
     }
@@ -390,19 +390,19 @@ moduleFor(
 
       this.assertText('Outer 28');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Outer 28');
 
-      this.runTask(() => this.context.set('model.outerAge', 29));
+      runTask(() => this.context.set('model.outerAge', 29));
 
       this.assertText('Outer 29');
 
-      this.runTask(() => this.context.set('model.outerName', 'Not outer'));
+      runTask(() => this.context.set('model.outerName', 'Not outer'));
 
       this.assertText('Not outer 29');
 
-      this.runTask(() => {
+      runTask(() => {
         this.context.set('model', {
           outerName: 'Outer',
           outerAge: 28,
@@ -436,19 +436,19 @@ moduleFor(
 
       this.assertText('Inner 28');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Inner 28');
 
-      this.runTask(() => this.context.set('model.outerAge', 29));
+      runTask(() => this.context.set('model.outerAge', 29));
 
       this.assertText('Inner 29');
 
-      this.runTask(() => this.context.set('model.outerName', 'Not outer'));
+      runTask(() => this.context.set('model.outerName', 'Not outer'));
 
       this.assertText('Inner 29');
 
-      this.runTask(() => {
+      runTask(() => {
         this.context.set('model', {
           outerName: 'Outer',
           outerAge: 28,
@@ -476,15 +476,15 @@ moduleFor(
 
       this.assertText('Hodi Hodari');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Hodi Hodari');
 
-      this.runTask(() => this.context.set('model.name', 'Sergio'));
+      runTask(() => this.context.set('model.name', 'Sergio'));
 
       this.assertText('Hodi Sergio');
 
-      this.runTask(() => this.context.set('model', { name: 'Hodari' }));
+      runTask(() => this.context.set('model', { name: 'Hodari' }));
 
       this.assertText('Hodi Hodari');
     }
@@ -499,15 +499,15 @@ moduleFor(
 
       this.assertText('');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('');
 
-      this.runTask(() => this.context.set('componentName', 'foo-bar'));
+      runTask(() => this.context.set('componentName', 'foo-bar'));
 
       this.assertText('hello Alex');
 
-      this.runTask(() => this.context.set('componentName', undefined));
+      runTask(() => this.context.set('componentName', undefined));
 
       this.assertText('');
     }
@@ -522,15 +522,15 @@ moduleFor(
 
       this.assertText('hello Alex');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('hello Alex');
 
-      this.runTask(() => this.context.set('componentName', undefined));
+      runTask(() => this.context.set('componentName', undefined));
 
       this.assertText('');
 
-      this.runTask(() => this.context.set('componentName', 'foo-bar'));
+      runTask(() => this.context.set('componentName', 'foo-bar'));
 
       this.assertText('hello Alex');
     }
@@ -545,15 +545,15 @@ moduleFor(
 
       this.assertText('');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('');
 
-      this.runTask(() => this.context.set('componentName', 'foo-bar'));
+      runTask(() => this.context.set('componentName', 'foo-bar'));
 
       this.assertText('hello Alex');
 
-      this.runTask(() => this.context.set('componentName', null));
+      runTask(() => this.context.set('componentName', null));
 
       this.assertText('');
     }
@@ -568,15 +568,15 @@ moduleFor(
 
       this.assertText('hello Alex');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('hello Alex');
 
-      this.runTask(() => this.context.set('componentName', null));
+      runTask(() => this.context.set('componentName', null));
 
       this.assertText('');
 
-      this.runTask(() => this.context.set('componentName', 'foo-bar'));
+      runTask(() => this.context.set('componentName', 'foo-bar'));
 
       this.assertText('hello Alex');
     }
@@ -608,7 +608,7 @@ moduleFor(
 
       this.assertText(expectedText);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText(expectedText);
     }
@@ -633,15 +633,15 @@ moduleFor(
 
       this.assertText(expectedText);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText(expectedText);
 
-      this.runTask(() => this.context.set('model.expectedText', 'Hola'));
+      runTask(() => this.context.set('model.expectedText', 'Hola'));
 
       this.assertText('Hola');
 
-      this.runTask(() => this.context.set('model', { expectedText }));
+      runTask(() => this.context.set('model', { expectedText }));
 
       this.assertText(expectedText);
     }
@@ -666,15 +666,15 @@ moduleFor(
 
       this.assertText(expectedText);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText(expectedText);
 
-      this.runTask(() => this.context.set('model.expectedText', 'Hola'));
+      runTask(() => this.context.set('model.expectedText', 'Hola'));
 
       this.assertText('Hola');
 
-      this.runTask(() => this.context.set('model', { expectedText }));
+      runTask(() => this.context.set('model', { expectedText }));
 
       this.assertText(expectedText);
     }
@@ -703,15 +703,15 @@ moduleFor(
 
       this.assertText(`${expectedText},Hola`);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText(`${expectedText},Hola`);
 
-      this.runTask(() => this.context.set('model.expectedText', 'Kaixo'));
+      runTask(() => this.context.set('model.expectedText', 'Kaixo'));
 
       this.assertText('Kaixo,Hola');
 
-      this.runTask(() => this.context.set('model', { expectedText }));
+      runTask(() => this.context.set('model', { expectedText }));
 
       this.assertText(`${expectedText},Hola`);
     }
@@ -782,19 +782,19 @@ moduleFor(
 
       assert.equal(this.$('#nested-prop').text(), '1');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.equal(this.$('#nested-prop').text(), '1');
 
-      this.runTask(() => this.$('button').click());
+      runTask(() => this.$('button').click());
 
       assert.equal(this.$('#nested-prop').text(), '2');
 
-      this.runTask(() => this.$('button').click());
+      runTask(() => this.$('button').click());
 
       assert.equal(this.$('#nested-prop').text(), '3');
 
-      this.runTask(() => this.context.set('model', { myProp: 1 }));
+      runTask(() => this.context.set('model', { myProp: 1 }));
 
       assert.equal(this.$('#nested-prop').text(), '1');
     }
@@ -818,7 +818,7 @@ moduleFor(
 
       this.assertText('Foo');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Foo');
     }
@@ -850,15 +850,15 @@ moduleFor(
 
       assert.equal(this.$('.value').text(), '8');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.equal(this.$('.value').text(), '8');
 
-      this.runTask(() => this.$('.my-button').click());
+      runTask(() => this.$('.my-button').click());
 
       assert.equal(this.$('.value').text(), '10');
 
-      this.runTask(() => this.context.set('model', { val2: 8 }));
+      runTask(() => this.context.set('model', { val2: 8 }));
 
       assert.equal(this.$('.value').text(), '8');
     }
@@ -870,7 +870,7 @@ moduleFor(
 
       this.render(`{{my-comp}}`);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.equal(this.$().text(), '');
     }
@@ -900,15 +900,15 @@ moduleFor(
 
       assert.equal(this.$().text(), 'message: hello');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.equal(this.$().text(), 'message: hello');
 
-      this.runTask(() => this.$('button').click());
+      runTask(() => this.$('button').click());
 
       assert.equal(this.$().text(), 'message: goodbye');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.equal(this.$().text(), 'message: goodbye');
     }
@@ -946,28 +946,28 @@ moduleFor(
       assert.equal(initCount, 1, 'the component was constructed exactly 1 time');
       assert.equal(this.$().text(), 'open', 'the components text is "open"');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.ok(!isEmpty(instance), 'the component instance exists');
       assert.equal(previousInstance, undefined, 'no previous component exists');
       assert.equal(initCount, 1, 'the component was constructed exactly 1 time');
       assert.equal(this.$().text(), 'open', 'the components text is "open"');
 
-      this.runTask(() => this.context.set('isOpen', false));
+      runTask(() => this.context.set('isOpen', false));
 
       assert.ok(!isEmpty(instance), 'the component instance exists');
       assert.equal(previousInstance, undefined, 'no previous component exists');
       assert.equal(initCount, 1, 'the component was constructed exactly 1 time');
       assert.equal(this.$().text(), 'closed', 'the component text is "closed"');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.ok(!isEmpty(instance), 'the component instance exists');
       assert.equal(previousInstance, undefined, 'no previous component exists');
       assert.equal(initCount, 1, 'the component was constructed exactly 1 time');
       assert.equal(this.$().text(), 'closed', 'the component text is "closed"');
 
-      this.runTask(() => this.context.set('isOpen', true));
+      runTask(() => this.context.set('isOpen', true));
 
       assert.ok(!isEmpty(instance), 'the component instance exists');
       assert.equal(previousInstance, undefined, 'no previous component exists');
@@ -1011,28 +1011,28 @@ moduleFor(
       assert.equal(initCount, 1, 'the component was constructed exactly 1 time');
       assert.equal(this.$().text(), 'open', 'the components text is "open"');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.ok(!isEmpty(instance), 'the component instance exists');
       assert.equal(previousInstance, undefined, 'no previous component exists');
       assert.equal(initCount, 1, 'the component was constructed exactly 1 time');
       assert.equal(this.$().text(), 'open', 'the components text is "open"');
 
-      this.runTask(() => this.context.set('isOpen', false));
+      runTask(() => this.context.set('isOpen', false));
 
       assert.ok(!isEmpty(instance), 'the component instance exists');
       assert.equal(previousInstance, undefined, 'no previous component exists');
       assert.equal(initCount, 1, 'the component was constructed exactly 1 time');
       assert.equal(this.$().text(), 'closed', 'the component text is "closed"');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.ok(!isEmpty(instance), 'the component instance exists');
       assert.equal(previousInstance, undefined, 'no previous component exists');
       assert.equal(initCount, 1, 'the component was constructed exactly 1 time');
       assert.equal(this.$().text(), 'closed', 'the component text is "closed"');
 
-      this.runTask(() => this.context.set('isOpen', true));
+      runTask(() => this.context.set('isOpen', true));
 
       assert.ok(!isEmpty(instance), 'the component instance exists');
       assert.equal(previousInstance, undefined, 'no previous component exists');
@@ -1089,14 +1089,14 @@ moduleFor(
       assert.equal(initCount, 1, 'the component was constructed exactly 1 time');
       assert.equal(this.$().text(), 'my-comp: open');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.ok(!isEmpty(instance), 'a instance exists after rerender');
       assert.equal(previousInstance, undefined, 'there is no previous instance after rerender');
       assert.equal(initCount, 1, 'the component was constructed exactly 1 time');
       assert.equal(this.$().text(), 'my-comp: open');
 
-      this.runTask(() => this.context.set('compName', 'your-comp'));
+      runTask(() => this.context.set('compName', 'your-comp'));
 
       assert.ok(!isEmpty(instance), 'an instance was created after component name changed');
       assert.ok(!isEmpty(previousInstance), 'a previous instance now exists');
@@ -1108,7 +1108,7 @@ moduleFor(
       assert.equal(initCount, 2, 'the component was constructed exactly 2 times');
       assert.equal(this.$().text(), 'your-comp: open');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.ok(
         !isEmpty(instance),
@@ -1123,7 +1123,7 @@ moduleFor(
       assert.equal(initCount, 2, 'the component was constructed exactly 2 times (rerender)');
       assert.equal(this.$().text(), 'your-comp: open');
 
-      this.runTask(() => this.context.set('compName', 'my-comp'));
+      runTask(() => this.context.set('compName', 'my-comp'));
 
       assert.ok(!isEmpty(instance), 'an instance was created after component name changed');
       assert.ok(!isEmpty(previousInstance), 'a previous instance still exists');
@@ -1150,27 +1150,27 @@ moduleFor(
 
       this.assertText('ab');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('ab');
 
-      this.runTask(() => this.context.get('allParams').pushObject('c'));
+      runTask(() => this.context.get('allParams').pushObject('c'));
 
       this.assertText('abc');
 
-      this.runTask(() => this.context.get('allParams').popObject());
+      runTask(() => this.context.get('allParams').popObject());
 
       this.assertText('ab');
 
-      this.runTask(() => this.context.get('allParams').clear());
+      runTask(() => this.context.get('allParams').clear());
 
       this.assertText('');
 
-      this.runTask(() => this.context.set('allParams', emberA(['1', '2'])));
+      runTask(() => this.context.set('allParams', emberA(['1', '2'])));
 
       this.assertText('12');
 
-      this.runTask(() => this.context.set('allParams', emberA(['a', 'b'])));
+      runTask(() => this.context.set('allParams', emberA(['a', 'b'])));
 
       this.assertText('ab');
     }
@@ -1192,27 +1192,27 @@ moduleFor(
 
       this.assertText('ab');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('ab');
 
-      this.runTask(() => this.context.get('allParams').pushObject('c'));
+      runTask(() => this.context.get('allParams').pushObject('c'));
 
       this.assertText('abc');
 
-      this.runTask(() => this.context.get('allParams').popObject());
+      runTask(() => this.context.get('allParams').popObject());
 
       this.assertText('ab');
 
-      this.runTask(() => this.context.get('allParams').clear());
+      runTask(() => this.context.get('allParams').clear());
 
       this.assertText('');
 
-      this.runTask(() => this.context.set('allParams', emberA(['1', '2'])));
+      runTask(() => this.context.set('allParams', emberA(['1', '2'])));
 
       this.assertText('12');
 
-      this.runTask(() => this.context.set('allParams', emberA(['a', 'b'])));
+      runTask(() => this.context.set('allParams', emberA(['a', 'b'])));
 
       this.assertText('ab');
     }
@@ -1354,15 +1354,15 @@ class MutableParamTestGenerator {
 
         assert.equal(this.$('.value').text(), '8');
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         assert.equal(this.$('.value').text(), '8');
 
-        this.runTask(() => this.$('.my-button').click());
+        runTask(() => this.$('.my-button').click());
 
         assert.equal(this.$('.value').text(), '10');
 
-        this.runTask(() => this.context.set('model', { val2: 8 }));
+        runTask(() => this.context.set('model', { val2: 8 }));
 
         assert.equal(this.$('.value').text(), '8');
       },

--- a/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
@@ -8,6 +8,7 @@ import {
   equalTokens,
   equalsElement,
   styles,
+  runTask,
 } from 'internal-test-helpers';
 
 import { run } from '@ember/runloop';
@@ -29,7 +30,7 @@ moduleFor(
 
       this.assertComponentElement(this.firstChild, { content: 'hello' });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, { content: 'hello' });
     }
@@ -47,7 +48,7 @@ moduleFor(
         content: 'bizz bizz',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -55,7 +56,7 @@ moduleFor(
         content: 'bizz bizz',
       });
 
-      this.runTask(() => set(this.context, 'customId', 'bar'));
+      runTask(() => set(this.context, 'customId', 'bar'));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -63,7 +64,7 @@ moduleFor(
         content: 'bar bizz',
       });
 
-      this.runTask(() => set(this.context, 'customId', 'bizz'));
+      runTask(() => set(this.context, 'customId', 'bizz'));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -164,7 +165,7 @@ moduleFor(
         'Has a reasonable id attribute (found id=' + foundId + ').'
       );
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       let newFoundId = this.$('h1').attr('id');
       assert.ok(
@@ -190,7 +191,7 @@ moduleFor(
       let foundId = this.$('h1').attr('id');
       assert.equal(foundId, 'custom-id');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       let newFoundId = this.$('h1').attr('id');
       assert.equal(newFoundId, 'custom-id');
@@ -223,7 +224,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'foo-bar',
@@ -251,7 +252,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'foo-bar',
@@ -269,7 +270,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'foo-bar',
@@ -330,7 +331,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -352,7 +353,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -374,8 +375,8 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'predicate', true));
-      this.runTask(() => this.rerender());
+      runTask(() => set(this.context, 'predicate', true));
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -383,8 +384,8 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'predicate', false));
-      this.runTask(() => this.rerender());
+      runTask(() => set(this.context, 'predicate', false));
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -406,8 +407,8 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'predicate', false));
-      this.runTask(() => this.rerender());
+      runTask(() => set(this.context, 'predicate', false));
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -415,8 +416,8 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'predicate', true));
-      this.runTask(() => this.rerender());
+      runTask(() => set(this.context, 'predicate', true));
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -438,7 +439,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -446,7 +447,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'model.someTruth', false));
+      runTask(() => set(this.context, 'model.someTruth', false));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -454,7 +455,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => set(this.context, 'model', { someTruth: true }));
+      runTask(() => set(this.context, 'model', { someTruth: true }));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -475,21 +476,21 @@ moduleFor(
         attrs: { class: classes('ember-view foo-bar') },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         content: 'hello',
         attrs: { class: classes('ember-view foo-bar') },
       });
 
-      this.runTask(() => set(this.context, 'fooBar', false));
+      runTask(() => set(this.context, 'fooBar', false));
 
       this.assertComponentElement(this.firstChild, {
         content: 'hello',
         attrs: { class: classes('ember-view') },
       });
 
-      this.runTask(() => set(this.context, 'fooBar', true));
+      runTask(() => set(this.context, 'fooBar', true));
 
       this.assertComponentElement(this.firstChild, {
         content: 'hello',
@@ -519,7 +520,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -560,7 +561,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.nthChild(0), {
         tagName: 'div',
@@ -600,7 +601,7 @@ moduleFor(
 
       this.assertComponentElement(element1, { content: 'hello' });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       let element2 = instance.element;
 
@@ -630,7 +631,7 @@ moduleFor(
 
       assert.strictEqual(fooBarInstance.element.childNodes.length, 0);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, { tagName: 'input' });
 
@@ -672,7 +673,7 @@ moduleFor(
       assert.deepEqual(this.component.childViews, [fooBarInstance]);
       assert.deepEqual(fooBarInstance.childViews, [fooBarBazInstance]);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
       this.assertText('foo-bar foo-bar-baz');
 
       assert.equal(fooBarInstance.parentView, this.component);
@@ -695,15 +696,15 @@ moduleFor(
 
       this.assertText('Hola');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Hola');
 
-      this.runTask(() => this.context.set('model.bar', 'Hello'));
+      runTask(() => this.context.set('model.bar', 'Hello'));
 
       this.assertText('Hello');
 
-      this.runTask(() => this.context.set('model', { bar: 'Hola' }));
+      runTask(() => this.context.set('model', { bar: 'Hola' }));
 
       this.assertText('Hola');
     }
@@ -721,15 +722,15 @@ moduleFor(
 
       this.assertText('Hola');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Hola');
 
-      this.runTask(() => this.context.set('model.bar', 'Hello'));
+      runTask(() => this.context.set('model.bar', 'Hello'));
 
       this.assertText('Hello');
 
-      this.runTask(() => this.context.set('model', { bar: 'Hola' }));
+      runTask(() => this.context.set('model', { bar: 'Hola' }));
 
       this.assertText('Hola');
     }
@@ -745,7 +746,7 @@ moduleFor(
         content: 'hello - In component',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         content: 'hello - In component',
@@ -765,7 +766,7 @@ moduleFor(
         content: 'yielded: [hello] - In component',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         content: 'yielded: [hello] - In component',
@@ -785,7 +786,7 @@ moduleFor(
         content: 'yielded: [hello] - In component',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         content: 'yielded: [hello] - In component',
@@ -812,15 +813,15 @@ moduleFor(
 
       this.assertComponentElement(this.firstChild, { content: 'hello' });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, { content: 'hello' });
 
-      this.runTask(() => set(instance, 'message', 'goodbye'));
+      runTask(() => set(instance, 'message', 'goodbye'));
 
       this.assertComponentElement(this.firstChild, { content: 'goodbye' });
 
-      this.runTask(() => set(instance, 'message', 'hello'));
+      runTask(() => set(instance, 'message', 'hello'));
 
       this.assertComponentElement(this.firstChild, { content: 'hello' });
     }
@@ -832,15 +833,15 @@ moduleFor(
 
       this.assertComponentElement(this.firstChild, { content: 'hello' });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, { content: 'hello' });
 
-      this.runTask(() => set(this.context, 'message', 'goodbye'));
+      runTask(() => set(this.context, 'message', 'goodbye'));
 
       this.assertComponentElement(this.firstChild, { content: 'goodbye' });
 
-      this.runTask(() => set(this.context, 'message', 'hello'));
+      runTask(() => set(this.context, 'message', 'hello'));
 
       this.assertComponentElement(this.firstChild, { content: 'hello' });
     }
@@ -868,11 +869,11 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(instance, 'name', 'derp-qux'));
+      runTask(() => set(instance, 'name', 'derp-qux'));
 
       this.assertComponentElement(this.firstChild, { content: 'derp-qux' });
 
-      this.runTask(() => set(instance, 'name', 'foo-bar'));
+      runTask(() => set(instance, 'name', 'foo-bar'));
 
       this.assertComponentElement(this.firstChild, { content: 'foo-bar' });
     }
@@ -907,13 +908,13 @@ moduleFor(
         content: 'Joel Kang, hello',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         content: 'Joel Kang, hello',
       });
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'person', {
           firstName: 'Dora',
           lastName: 'the Explorer',
@@ -924,13 +925,13 @@ moduleFor(
         content: 'Dora the Explorer, hello',
       });
 
-      this.runTask(() => set(instance, 'greeting', 'hola'));
+      runTask(() => set(instance, 'greeting', 'hola'));
 
       this.assertComponentElement(this.firstChild, {
         content: 'Dora the Explorer, hola',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(instance, 'greeting', 'hello');
         set(this.context, 'person', {
           firstName: 'Joel',
@@ -966,7 +967,7 @@ moduleFor(
 
       // Trigger a non-revalidating re-render. The yielded block will not be dirtied
       // nor will block param streams, and thus no infinite loop will occur.
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('0');
 
@@ -974,11 +975,11 @@ moduleFor(
       // in place.  Note that we do not see the infinite loop is in testing mode,
       // because a deprecation warning about re-renders is issued, which Ember
       // treats as an exception.
-      this.runTask(() => set(instance, 'danger', 1));
+      runTask(() => set(instance, 'danger', 1));
 
       this.assertText('1');
 
-      this.runTask(() => set(instance, 'danger', 0));
+      runTask(() => set(instance, 'danger', 0));
 
       this.assertText('0');
     }
@@ -1030,7 +1031,7 @@ moduleFor(
 
       this.assertText('1 2 3 4 5 6 7 8 ');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.deepEqual(destroyed, {
         1: 0,
@@ -1043,7 +1044,7 @@ moduleFor(
         8: 0,
       });
 
-      this.runTask(() => set(this.context, 'cond5', false));
+      runTask(() => set(this.context, 'cond5', false));
 
       this.assertText('1 2 3 4 8 ');
 
@@ -1058,7 +1059,7 @@ moduleFor(
         8: 0,
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'cond3', false);
         set(this.context, 'cond5', true);
         set(this.context, 'cond4', false);
@@ -1075,7 +1076,7 @@ moduleFor(
         8: 1,
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'cond2', false);
         set(this.context, 'cond1', false);
       });
@@ -1111,15 +1112,15 @@ moduleFor(
 
       this.assertText('you need to be more <b>bold</b>');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('you need to be more <b>bold</b>');
 
-      this.runTask(() => set(component, 'output', 'you are so <i>super</i>'));
+      runTask(() => set(component, 'output', 'you are so <i>super</i>'));
 
       this.assertText('you are so <i>super</i>');
 
-      this.runTask(() => set(component, 'output', 'you need to be more <b>bold</b>'));
+      runTask(() => set(component, 'output', 'you need to be more <b>bold</b>'));
     }
 
     ['@test should not escape HTML in triple mustaches']() {
@@ -1143,15 +1144,15 @@ moduleFor(
 
       equalTokens(this.firstChild, expectedHtmlBold);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       equalTokens(this.firstChild, expectedHtmlBold);
 
-      this.runTask(() => set(component, 'output', expectedHtmlItalic));
+      runTask(() => set(component, 'output', expectedHtmlItalic));
 
       equalTokens(this.firstChild, expectedHtmlItalic);
 
-      this.runTask(() => set(component, 'output', expectedHtmlBold));
+      runTask(() => set(component, 'output', expectedHtmlBold));
 
       equalTokens(this.firstChild, expectedHtmlBold);
     }
@@ -1177,15 +1178,15 @@ moduleFor(
 
       equalTokens(this.firstChild, expectedHtmlBold);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       equalTokens(this.firstChild, expectedHtmlBold);
 
-      this.runTask(() => set(component, 'output', htmlSafe(expectedHtmlItalic)));
+      runTask(() => set(component, 'output', htmlSafe(expectedHtmlItalic)));
 
       equalTokens(this.firstChild, expectedHtmlItalic);
 
-      this.runTask(() => set(component, 'output', htmlSafe(expectedHtmlBold)));
+      runTask(() => set(component, 'output', htmlSafe(expectedHtmlBold)));
 
       equalTokens(this.firstChild, expectedHtmlBold);
     }
@@ -1251,15 +1252,15 @@ moduleFor(
 
       this.assertComponentElement(this.firstChild, { content: 'true' });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, { content: 'true' });
 
-      this.runTask(() => set(component, 'isStream', false));
+      runTask(() => set(component, 'isStream', false));
 
       this.assertComponentElement(this.firstChild, { content: 'false' });
 
-      this.runTask(() => set(component, 'isStream', true));
+      runTask(() => set(component, 'isStream', true));
 
       this.assertComponentElement(this.firstChild, { content: 'true' });
     }
@@ -1275,7 +1276,7 @@ moduleFor(
 
       this.assertText('some-prop some-component');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('some-prop some-component');
     }
@@ -1291,15 +1292,15 @@ moduleFor(
 
       this.assertText('notsomecomponent');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('notsomecomponent');
 
-      this.runTask(() => this.context.set('somecomponent', 'not not notsomecomponent'));
+      runTask(() => this.context.set('somecomponent', 'not not notsomecomponent'));
 
       this.assertText('not not notsomecomponent');
 
-      this.runTask(() => this.context.set('somecomponent', 'notsomecomponent'));
+      runTask(() => this.context.set('somecomponent', 'notsomecomponent'));
 
       this.assertText('notsomecomponent');
     }
@@ -1315,15 +1316,15 @@ moduleFor(
 
       this.assertText('In layout - someProp: something here');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('In layout - someProp: something here');
 
-      this.runTask(() => this.context.set('prop', 'other thing there'));
+      runTask(() => this.context.set('prop', 'other thing there'));
 
       this.assertText('In layout - someProp: other thing there');
 
-      this.runTask(() => this.context.set('prop', 'something here'));
+      runTask(() => this.context.set('prop', 'something here'));
 
       this.assertText('In layout - someProp: something here');
     }
@@ -1339,15 +1340,15 @@ moduleFor(
 
       this.assertText('In layout - someProp: something here');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('In layout - someProp: something here');
 
-      this.runTask(() => this.context.set('prop', 'other thing there'));
+      runTask(() => this.context.set('prop', 'other thing there'));
 
       this.assertText('In layout - someProp: other thing there');
 
-      this.runTask(() => this.context.set('prop', 'something here'));
+      runTask(() => this.context.set('prop', 'something here'));
 
       this.assertText('In layout - someProp: something here');
     }
@@ -1371,20 +1372,20 @@ moduleFor(
 
       this.assertText('In layout - someProp: value set in instance');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('In layout - someProp: value set in instance');
 
-      this.runTask(() => this.context.set('prop', 'updated something passed when invoked'));
+      runTask(() => this.context.set('prop', 'updated something passed when invoked'));
 
       this.assertText('In layout - someProp: updated something passed when invoked');
 
-      this.runTask(() => instance.set('someProp', 'update value set in instance'));
+      runTask(() => instance.set('someProp', 'update value set in instance'));
 
       this.assertText('In layout - someProp: update value set in instance');
 
-      this.runTask(() => this.context.set('prop', 'something passed when invoked'));
-      this.runTask(() => instance.set('someProp', 'value set in instance'));
+      runTask(() => this.context.set('prop', 'something passed when invoked'));
+      runTask(() => instance.set('someProp', 'value set in instance'));
 
       this.assertText('In layout - someProp: value set in instance');
     }
@@ -1435,26 +1436,26 @@ moduleFor(
 
       // Note: Hooks are not fired in Glimmer for idempotent re-renders
       expectHooks({ willUpdate: false, didReceiveAttrs: false }, () => {
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
       });
 
       this.assertText('In layout - someProp: wycats');
 
       expectHooks({ willUpdate: true, didReceiveAttrs: true }, () => {
-        this.runTask(() => this.context.set('someProp', 'tomdale'));
+        runTask(() => this.context.set('someProp', 'tomdale'));
       });
 
       this.assertText('In layout - someProp: tomdale');
 
       // Note: Hooks are not fired in Glimmer for idempotent re-renders
       expectHooks({ willUpdate: false, didReceiveAttrs: false }, () => {
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
       });
 
       this.assertText('In layout - someProp: tomdale');
 
       expectHooks({ willUpdate: true, didReceiveAttrs: true }, () => {
-        this.runTask(() => this.context.set('someProp', 'wycats'));
+        runTask(() => this.context.set('someProp', 'wycats'));
       });
 
       this.assertText('In layout - someProp: wycats');
@@ -1485,14 +1486,14 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => {
+      runTask(() => {
         this.context.set('model.value', 'lul');
         this.context.set('model.items', [1]);
       });
 
       this.assertText(strip`Args: lul | lul | lul111`);
 
-      this.runTask(() => this.context.set('model', { value: 'wat', items: [1, 2, 3] }));
+      runTask(() => this.context.set('model', { value: 'wat', items: [1, 2, 3] }));
 
       this.assertText('Args: wat | wat | wat123123123');
     }
@@ -1525,14 +1526,14 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => {
+      runTask(() => {
         this.context.set('model.value', 'lul');
         this.context.set('model.items', [1]);
       });
 
       this.assertText(strip`Args: lul | lul | lul | lul1111`);
 
-      this.runTask(() => this.context.set('model', { value: 'wat', items: [1, 2, 3] }));
+      runTask(() => this.context.set('model', { value: 'wat', items: [1, 2, 3] }));
 
       this.assertText('Args: wat | wat | wat | wat123123123123');
     }
@@ -1548,15 +1549,15 @@ moduleFor(
 
       this.assertText('In layout - someProp: something here');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('In layout - someProp: something here');
 
-      this.runTask(() => this.context.set('prop', 'something else'));
+      runTask(() => this.context.set('prop', 'something else'));
 
       this.assertText('In layout - someProp: something else');
 
-      this.runTask(() => this.context.set('prop', 'something here'));
+      runTask(() => this.context.set('prop', 'something here'));
 
       this.assertText('In layout - someProp: something here');
     }
@@ -1578,15 +1579,15 @@ moduleFor(
 
       this.assertText('In layout - someProp: something here - In template');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('In layout - someProp: something here - In template');
 
-      this.runTask(() => this.context.set('prop', 'something else'));
+      runTask(() => this.context.set('prop', 'something else'));
 
       this.assertText('In layout - someProp: something else - In template');
 
-      this.runTask(() => this.context.set('prop', 'something here'));
+      runTask(() => this.context.set('prop', 'something here'));
 
       this.assertText('In layout - someProp: something here - In template');
     }
@@ -1608,15 +1609,15 @@ moduleFor(
 
       this.assertText('In layout - someProp: something here - In template');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('In layout - someProp: something here - In template');
 
-      this.runTask(() => this.context.set('prop', 'something else'));
+      runTask(() => this.context.set('prop', 'something else'));
 
       this.assertText('In layout - someProp: something else - In template');
 
-      this.runTask(() => this.context.set('prop', 'something here'));
+      runTask(() => this.context.set('prop', 'something here'));
 
       this.assertText('In layout - someProp: something here - In template');
     }
@@ -1638,15 +1639,15 @@ moduleFor(
 
       this.assertText('In layout - someProp: something here - In template');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('In layout - someProp: something here - In template');
 
-      this.runTask(() => this.context.set('prop', 'something else'));
+      runTask(() => this.context.set('prop', 'something else'));
 
       this.assertText('In layout - someProp: something else - In template');
 
-      this.runTask(() => this.context.set('prop', 'something here'));
+      runTask(() => this.context.set('prop', 'something here'));
 
       this.assertText('In layout - someProp: something here - In template');
     }
@@ -1669,7 +1670,7 @@ moduleFor(
       assert.equal(this.$('#args-3').text(), 'Foo4Bar');
       assert.equal(this.$('#args-5').text(), 'Foo4Bar5Baz');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.equal(this.$('#args-3').text(), 'Foo4Bar');
       assert.equal(this.$('#args-5').text(), 'Foo4Bar5Baz');
@@ -1710,23 +1711,23 @@ moduleFor(
 
       this.assertText('Foo4Bar');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Foo4Bar');
 
-      this.runTask(() => this.context.get('things').pushObject(5));
+      runTask(() => this.context.get('things').pushObject(5));
 
       this.assertText('Foo4Bar5');
 
-      this.runTask(() => this.context.get('things').shiftObject());
+      runTask(() => this.context.get('things').shiftObject());
 
       this.assertText('4Bar5');
 
-      this.runTask(() => this.context.get('things').clear());
+      runTask(() => this.context.get('things').clear());
 
       this.assertText('');
 
-      this.runTask(() => this.context.set('things', emberA(['Foo', 4, 'Bar'])));
+      runTask(() => this.context.set('things', emberA(['Foo', 4, 'Bar'])));
 
       this.assertText('Foo4Bar');
     }
@@ -1749,7 +1750,7 @@ moduleFor(
       assert.equal(this.$('#one-positional').text(), 'one - two');
       assert.equal(this.$('#no-positional').text(), 'one - two');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.equal(this.$('#two-positional').text(), 'one - two');
       assert.equal(this.$('#one-positional').text(), 'one - two');
@@ -1774,19 +1775,19 @@ moduleFor(
 
       this.assertText('Foo4');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Foo4');
 
-      this.runTask(() => this.context.set('user1', 'Bar'));
+      runTask(() => this.context.set('user1', 'Bar'));
 
       this.assertText('Bar4');
 
-      this.runTask(() => this.context.set('user2', '5'));
+      runTask(() => this.context.set('user2', '5'));
 
       this.assertText('Bar5');
 
-      this.runTask(() => {
+      runTask(() => {
         this.context.set('user1', 'Foo');
         this.context.set('user2', 4);
       });
@@ -1805,17 +1806,17 @@ moduleFor(
 
       this.assertComponentElement(this.firstChild, { attrs: { role: 'main' } });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, { attrs: { role: 'main' } });
 
-      this.runTask(() => this.context.set('role', 'input'));
+      runTask(() => this.context.set('role', 'input'));
 
       this.assertComponentElement(this.firstChild, {
         attrs: { role: 'input' },
       });
 
-      this.runTask(() => this.context.set('role', 'main'));
+      runTask(() => this.context.set('role', 'main'));
 
       this.assertComponentElement(this.firstChild, { attrs: { role: 'main' } });
     }
@@ -1831,17 +1832,17 @@ moduleFor(
 
       this.assertComponentElement(this.firstChild, { attrs: {} });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, { attrs: {} });
 
-      this.runTask(() => this.context.set('role', 'input'));
+      runTask(() => this.context.set('role', 'input'));
 
       this.assertComponentElement(this.firstChild, {
         attrs: { role: 'input' },
       });
 
-      this.runTask(() => this.context.set('role', undefined));
+      runTask(() => this.context.set('role', undefined));
 
       this.assertComponentElement(this.firstChild, { attrs: {} });
     }
@@ -1864,11 +1865,11 @@ moduleFor(
 
       this.assertComponentElement(this.firstChild, { attrs: {} });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, { attrs: {} });
 
-      this.runTask(() => instance.set('ariaRole', 'input'));
+      runTask(() => instance.set('ariaRole', 'input'));
 
       this.assertComponentElement(this.firstChild, { attrs: {} });
     }
@@ -1896,17 +1897,17 @@ moduleFor(
         '[In layout - with-block] [In block - Whoop, whoop!][In layout - without-block] '
       );
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText(
         '[In layout - with-block] [In block - Whoop, whoop!][In layout - without-block] '
       );
 
-      this.runTask(() => this.context.set('name', 'Ole, ole'));
+      runTask(() => this.context.set('name', 'Ole, ole'));
 
       this.assertText('[In layout - with-block] [In block - Ole, ole][In layout - without-block] ');
 
-      this.runTask(() => this.context.set('name', 'Whoop, whoop!'));
+      runTask(() => this.context.set('name', 'Whoop, whoop!'));
 
       this.assertText(
         '[In layout - with-block] [In block - Whoop, whoop!][In layout - without-block] '
@@ -1930,7 +1931,7 @@ moduleFor(
 
       this.assertText('In template');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('In template');
     }
@@ -1949,7 +1950,7 @@ moduleFor(
 
       this.assertText('No Block!');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('No Block!');
     }
@@ -1971,7 +1972,7 @@ moduleFor(
 
       this.assertText('In template - In Component');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('In template - In Component');
     }
@@ -1993,7 +1994,7 @@ moduleFor(
 
       this.assertText('In block No Block Param!');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('In block No Block Param!');
     }
@@ -2010,7 +2011,7 @@ moduleFor(
 
       this.assertText('Quint4');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Quint4');
     }
@@ -2030,19 +2031,19 @@ moduleFor(
 
       this.assertText('Quint4');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Quint4');
 
-      this.runTask(() => this.context.set('myName', 'Sergio'));
+      runTask(() => this.context.set('myName', 'Sergio'));
 
       this.assertText('Sergio4');
 
-      this.runTask(() => this.context.set('myAge', 2));
+      runTask(() => this.context.set('myAge', 2));
 
       this.assertText('Sergio2');
 
-      this.runTask(() => {
+      runTask(() => {
         this.context.set('myName', 'Quint');
         this.context.set('myAge', 4);
       });
@@ -2090,15 +2091,15 @@ moduleFor(
 
       this.assertText('Yes:Hello42');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Yes:Hello42');
 
-      this.runTask(() => this.context.set('activated', false));
+      runTask(() => this.context.set('activated', false));
 
       this.assertText('No:Goodbye');
 
-      this.runTask(() => this.context.set('activated', true));
+      runTask(() => this.context.set('activated', true));
 
       this.assertText('Yes:Hello42');
     }
@@ -2452,7 +2453,7 @@ moduleFor(
         'x-outer receives the ambient scope as its parentView'
       );
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.equal(
         innerTemplate.parentView,
@@ -2510,7 +2511,7 @@ moduleFor(
         'x-outer receives the ambient scope as its parentView'
       );
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.equal(
         outer.parentView,
@@ -2518,7 +2519,7 @@ moduleFor(
         'x-outer receives the ambient scope as its parentView (after rerender)'
       );
 
-      this.runTask(() => this.context.set('showInner', true));
+      runTask(() => this.context.set('showInner', true));
 
       assert.equal(
         outer.parentView,
@@ -2531,7 +2532,7 @@ moduleFor(
         'receives the wrapping component as its parentView in template blocks'
       );
 
-      this.runTask(() => this.context.set('showInner', false));
+      runTask(() => this.context.set('showInner', false));
 
       assert.equal(
         outer.parentView,
@@ -2584,7 +2585,7 @@ moduleFor(
         'initial render of middle (observers do not run during init)'
       );
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.equal(this.$('#inner-value').text(), '1', 'initial render of inner');
       assert.equal(
@@ -2596,7 +2597,7 @@ moduleFor(
       let expectedBacktrackingMessage = /modified "value" twice on <.+?> in a single render\. It was rendered in "component:x-middle" and modified in "component:x-inner"/;
 
       expectAssertion(() => {
-        this.runTask(() => outer.set('value', 2));
+        runTask(() => outer.set('value', 2));
       }, expectedBacktrackingMessage);
     }
 
@@ -2645,19 +2646,19 @@ moduleFor(
 
       this.assertText('In layout. [Child: Tom.][Child: Dick.][Child: Harry.]');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('In layout. [Child: Tom.][Child: Dick.][Child: Harry.]');
 
-      this.runTask(() => this.context.get('items').pushObject('Sergio'));
+      runTask(() => this.context.get('items').pushObject('Sergio'));
 
       this.assertText('In layout. [Child: Tom.][Child: Dick.][Child: Harry.][Child: Sergio.]');
 
-      this.runTask(() => this.context.get('items').shiftObject());
+      runTask(() => this.context.get('items').shiftObject());
 
       this.assertText('In layout. [Child: Dick.][Child: Harry.][Child: Sergio.]');
 
-      this.runTask(() => this.context.set('items', emberA(['Tom', 'Dick', 'Harry'])));
+      runTask(() => this.context.set('items', emberA(['Tom', 'Dick', 'Harry'])));
 
       this.assertText('In layout. [Child: Tom.][Child: Dick.][Child: Harry.]');
     }
@@ -2690,7 +2691,7 @@ moduleFor(
         attrs: { class: classes(expectedClassNames.join(' ')) },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.ok(
         this.$('button').is('.foo.bar.baz.ember-view'),
@@ -2724,7 +2725,7 @@ moduleFor(
 
       this.assertText('blarkporybaz- Click Me');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('blarkporybaz- Click Me');
     }
@@ -2750,7 +2751,7 @@ moduleFor(
 
       this.assertText('initial value - initial value');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('initial value - initial value');
 
@@ -2762,19 +2763,19 @@ moduleFor(
         this.assertText('initial value - initial value');
       }
 
-      this.runTask(() => {
+      runTask(() => {
         component.set('bar', 'updated value');
       });
 
       this.assertText('updated value - updated value');
 
-      this.runTask(() => {
+      runTask(() => {
         component.set('bar', undefined);
       });
 
       this.assertText(' - ');
 
-      this.runTask(() => {
+      runTask(() => {
         this.component.set('localBar', 'initial value');
       });
 
@@ -2813,17 +2814,17 @@ moduleFor(
 
       this.assertText('initial value - initial value');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('initial value - initial value');
 
-      this.runTask(() => {
+      runTask(() => {
         component.set('bar', 'updated value');
       });
 
       this.assertText('updated value - updated value');
 
-      this.runTask(() => {
+      runTask(() => {
         this.component.set('localBar', 'initial value');
       });
 
@@ -2861,17 +2862,17 @@ moduleFor(
 
       this.assertText('initial value');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('initial value');
 
-      this.runTask(() => {
+      runTask(() => {
         component.set('bar', 'updated value');
       });
 
       this.assertText('updated value');
 
-      this.runTask(() => {
+      runTask(() => {
         this.component.set('localBar', 'initial value');
       });
 
@@ -2902,17 +2903,17 @@ moduleFor(
 
       this.assertText('Jackson');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Jackson');
 
-      this.runTask(() => {
+      runTask(() => {
         service.set('last', 'McGuffey');
       });
 
       this.assertText('McGuffey');
 
-      this.runTask(() => {
+      runTask(() => {
         service.set('last', 'Jackson');
       });
 
@@ -2968,12 +2969,12 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'visible', true);
       });
       assertStyle('');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'visible', false);
       });
       assertStyle('display: none;');
@@ -3000,7 +3001,7 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'visible', true);
       });
 
@@ -3009,7 +3010,7 @@ moduleFor(
         attrs: { id: 'foo-bar', style: styles('color: blue;') },
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'visible', false);
       });
 
@@ -3051,13 +3052,13 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'visible', true);
       });
 
       assertStyle('');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'visible', false);
         set(this.context, 'foo', 'woo');
       });
@@ -3104,27 +3105,27 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => {
+      runTask(() => {
         this.firstChild.value = 'bar';
         this.$('input').trigger('change');
       });
 
       assertElement('bar');
 
-      this.runTask(() => {
+      runTask(() => {
         this.firstChild.value = 'foo';
         this.$('input').trigger('change');
       });
 
       assertElement('foo');
 
-      this.runTask(() => {
+      runTask(() => {
         set(component, 'value', 'bar');
       });
 
       assertElement('bar');
 
-      this.runTask(() => {
+      runTask(() => {
         this.firstChild.value = 'foo';
         this.$('input').trigger('change');
       });
@@ -3251,7 +3252,7 @@ moduleFor(
 
       assert.strictEqual(barCopyDidChangeCount, 1, 'expected observer firing for: barCopy');
 
-      this.runTask(() => set(this.context, 'bar', 7));
+      runTask(() => set(this.context, 'bar', 7));
 
       this.assertText('7-8');
 
@@ -3285,7 +3286,7 @@ moduleFor(
 
       this.render(`{{foo-bar foo=foo bar=bar}}`, { foo: 1, bar: 3 });
 
-      this.runTask(() => set(this.context, 'foo', 5));
+      runTask(() => set(this.context, 'foo', 5));
     }
 
     ['@test returning `true` from an action does not bubble if `target` is not specified (GH#14275)'](
@@ -3312,7 +3313,7 @@ moduleFor(
 
       this.assertText('Show');
 
-      this.runTask(() => this.$('button').click());
+      runTask(() => this.$('button').click());
     }
 
     ['@test returning `true` from an action bubbles to the `target` if specified'](assert) {
@@ -3340,7 +3341,7 @@ moduleFor(
 
       this.assertText('Show');
 
-      this.runTask(() => this.$('button').click());
+      runTask(() => this.$('button').click());
     }
 
     ['@test triggering an event only attempts to invoke an identically named method, if it actually is a function (GH#15228)'](
@@ -3414,11 +3415,11 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'editMode', true));
+      runTask(() => set(this.context, 'editMode', true));
 
       this.assertText('|foo|Remove foo|bar|Remove bar|qux|Remove qux|baz|Remove baz');
 
-      this.runTask(() => set(this.context, 'editMode', false));
+      runTask(() => set(this.context, 'editMode', false));
 
       this.assertText('|foo||bar||qux||baz|');
     }
@@ -3502,11 +3503,11 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(instance, 'foo.bar.baz', 'yippie!'));
+      runTask(() => set(instance, 'foo.bar.baz', 'yippie!'));
 
       this.assertText('yippie!');
 
-      this.runTask(() => set(instance, 'foo.bar.baz', 'huzzah!'));
+      runTask(() => set(instance, 'foo.bar.baz', 'huzzah!'));
 
       this.assertText('huzzah!');
     }
@@ -3630,7 +3631,7 @@ if (jQueryDisabled) {
 
         this.assertComponentElement(element1, { content: 'hello' });
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         let element2 = instance.$()[0];
 
@@ -3661,7 +3662,7 @@ if (jQueryDisabled) {
         assert.equal($span.length, 1);
         assert.equal($span.attr('class'), 'inner');
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         $span = instance.$('span');
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/destroy-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/destroy-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
 
@@ -21,7 +21,7 @@ moduleFor(
 
       this.assertComponentElement(this.firstChild, { content: 'hello' });
 
-      this.runTask(() => set(this.context, 'switch', false));
+      runTask(() => set(this.context, 'switch', false));
 
       this.assertText('');
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase, strip } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
 
 import { EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION } from '@ember/canary-features';
 import { set, computed } from '@ember/-internals/metal';
@@ -16,15 +16,15 @@ moduleFor(
 
       this.assertComponentElement(this.firstChild, { content: 'hello Sarah' });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, { content: 'hello Sarah' });
 
-      this.runTask(() => set(this.context, 'name', 'Gavin'));
+      runTask(() => set(this.context, 'name', 'Gavin'));
 
       this.assertComponentElement(this.firstChild, { content: 'hello Gavin' });
 
-      this.runTask(() => set(this.context, 'name', 'Sarah'));
+      runTask(() => set(this.context, 'name', 'Sarah'));
 
       this.assertComponentElement(this.firstChild, { content: 'hello Sarah' });
     }
@@ -46,25 +46,25 @@ moduleFor(
         content: 'hello Alex from foo-bar',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         content: 'hello Alex from foo-bar',
       });
 
-      this.runTask(() => set(this.context, 'name', 'Ben'));
+      runTask(() => set(this.context, 'name', 'Ben'));
 
       this.assertComponentElement(this.firstChild, {
         content: 'hello Ben from foo-bar',
       });
 
-      this.runTask(() => set(this.context, 'componentName', 'foo-bar-baz'));
+      runTask(() => set(this.context, 'componentName', 'foo-bar-baz'));
 
       this.assertComponentElement(this.firstChild, {
         content: 'hello Ben from foo-bar-baz',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'componentName', 'foo-bar');
         set(this.context, 'name', 'Alex');
       });
@@ -95,7 +95,7 @@ moduleFor(
 
       this.assertComponentElement(element1, { content: 'hello' });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       let element2 = instance.element;
 
@@ -139,7 +139,7 @@ moduleFor(
       assert.deepEqual(this.component.childViews, [fooBarInstance]);
       assert.deepEqual(fooBarInstance.childViews, [fooBarBazInstance]);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
       this.assertText('foo-bar foo-bar-baz');
 
       assert.equal(fooBarInstance.parentView, this.component);
@@ -156,7 +156,7 @@ moduleFor(
 
       this.assertComponentElement(this.firstChild, { content: 'hello' });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, { content: 'hello' });
     }
@@ -181,15 +181,15 @@ moduleFor(
 
       this.assertComponentElement(this.firstChild, { content: 'hello' });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, { content: 'hello' });
 
-      this.runTask(() => set(instance, 'message', 'goodbye'));
+      runTask(() => set(instance, 'message', 'goodbye'));
 
       this.assertComponentElement(this.firstChild, { content: 'goodbye' });
 
-      this.runTask(() => set(instance, 'message', 'hello'));
+      runTask(() => set(instance, 'message', 'hello'));
 
       this.assertComponentElement(this.firstChild, { content: 'hello' });
     }
@@ -203,15 +203,15 @@ moduleFor(
 
       this.assertComponentElement(this.firstChild, { content: 'hello' });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, { content: 'hello' });
 
-      this.runTask(() => set(this.context, 'message', 'goodbye'));
+      runTask(() => set(this.context, 'message', 'goodbye'));
 
       this.assertComponentElement(this.firstChild, { content: 'goodbye' });
 
-      this.runTask(() => set(this.context, 'message', 'hello'));
+      runTask(() => set(this.context, 'message', 'hello'));
 
       this.assertComponentElement(this.firstChild, { content: 'hello' });
     }
@@ -263,7 +263,7 @@ moduleFor(
 
       this.assertText('1 2 3 4 5 6 7 8 ');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.deepEqual(destroyed, {
         1: 0,
@@ -276,7 +276,7 @@ moduleFor(
         8: 0,
       });
 
-      this.runTask(() => set(this.context, 'cond5', false));
+      runTask(() => set(this.context, 'cond5', false));
 
       this.assertText('1 2 3 4 8 ');
 
@@ -291,7 +291,7 @@ moduleFor(
         8: 0,
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'cond3', false);
         set(this.context, 'cond5', true);
         set(this.context, 'cond4', false);
@@ -308,7 +308,7 @@ moduleFor(
         8: 1,
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'cond2', false);
         set(this.context, 'cond1', false);
       });
@@ -363,15 +363,15 @@ moduleFor(
 
       assert.deepEqual(destroyed, { 'foo-bar': 0, 'foo-bar-baz': 0 });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.deepEqual(destroyed, { 'foo-bar': 0, 'foo-bar-baz': 0 });
 
-      this.runTask(() => set(this.context, 'componentName', 'foo-bar-baz'));
+      runTask(() => set(this.context, 'componentName', 'foo-bar-baz'));
 
       assert.deepEqual(destroyed, { 'foo-bar': 1, 'foo-bar-baz': 0 });
 
-      this.runTask(() => set(this.context, 'componentName', 'foo-bar'));
+      runTask(() => set(this.context, 'componentName', 'foo-bar'));
 
       assert.deepEqual(destroyed, { 'foo-bar': 1, 'foo-bar-baz': 1 });
     }
@@ -416,15 +416,15 @@ moduleFor(
 
       this.assertText('foo-bar Caracas Caracas arepas!');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('foo-bar Caracas Caracas arepas!');
 
-      this.runTask(() => set(this.context, 'location', 'Loisaida'));
+      runTask(() => set(this.context, 'location', 'Loisaida'));
 
       this.assertText('foo-bar-baz Loisaida Loisaida arepas!');
 
-      this.runTask(() => set(this.context, 'location', 'Caracas'));
+      runTask(() => set(this.context, 'location', 'Caracas'));
 
       this.assertText('foo-bar Caracas Caracas arepas!');
     }
@@ -468,7 +468,7 @@ moduleFor(
 
       assert.equal(actionTriggered, 0, 'action was not triggered');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('.inner-component').click();
       });
 
@@ -497,19 +497,19 @@ moduleFor(
 
       this.assertText('yippie! Caracas yummy Caracas arepas!');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('yippie! Caracas yummy Caracas arepas!');
 
-      this.runTask(() => set(this.context, 'location', 'Loisaida'));
+      runTask(() => set(this.context, 'location', 'Loisaida'));
 
       this.assertText('yippie! Loisaida yummy Loisaida arepas!');
 
-      this.runTask(() => set(this.context, 'componentName1', 'corge-grault'));
+      runTask(() => set(this.context, 'componentName1', 'corge-grault'));
 
       this.assertText('delicious Loisaida yummy Loisaida arepas!');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'componentName1', 'foo-bar');
         set(this.context, 'location', 'Caracas');
       });
@@ -541,15 +541,15 @@ moduleFor(
 
       this.assertText('hello Alex');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('hello Alex');
 
-      this.runTask(() => set(this.context, 'componentName', undefined));
+      runTask(() => set(this.context, 'componentName', undefined));
 
       this.assertText('');
 
-      this.runTask(() => set(this.context, 'componentName', 'foo-bar'));
+      runTask(() => set(this.context, 'componentName', 'foo-bar'));
 
       this.assertText('hello Alex');
     }
@@ -572,15 +572,15 @@ moduleFor(
 
       this.assertText('[Robert - Robert][Jacquie - Jacquie]');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('[Robert - Robert][Jacquie - Jacquie]');
 
-      this.runTask(() => set(this.context, 'items', [{ name: 'Max' }, { name: 'James' }]));
+      runTask(() => set(this.context, 'items', [{ name: 'Max' }, { name: 'James' }]));
 
       this.assertText('[Max - Max][James - James]');
 
-      this.runTask(() => set(this.context, 'items', [{ name: 'Robert' }, { name: 'Jacquie' }]));
+      runTask(() => set(this.context, 'items', [{ name: 'Robert' }, { name: 'Jacquie' }]));
 
       this.assertText('[Robert - Robert][Jacquie - Jacquie]');
     }
@@ -623,31 +623,31 @@ moduleFor(
         content: 'hello Alex (29) from foo-bar',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         content: 'hello Alex (29) from foo-bar',
       });
 
-      this.runTask(() => set(this.context, 'name', 'Ben'));
+      runTask(() => set(this.context, 'name', 'Ben'));
 
       this.assertComponentElement(this.firstChild, {
         content: 'hello Ben (29) from foo-bar',
       });
 
-      this.runTask(() => set(this.context, 'age', 22));
+      runTask(() => set(this.context, 'age', 22));
 
       this.assertComponentElement(this.firstChild, {
         content: 'hello Ben (22) from foo-bar',
       });
 
-      this.runTask(() => set(this.context, 'componentName', 'foo-bar-baz'));
+      runTask(() => set(this.context, 'componentName', 'foo-bar-baz'));
 
       this.assertComponentElement(this.firstChild, {
         content: 'hello Ben (22) from foo-bar-baz',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'componentName', 'foo-bar');
         set(this.context, 'name', 'Alex');
         set(this.context, 'age', 29);
@@ -684,25 +684,25 @@ moduleFor(
         content: 'Normal: Hello!',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         content: 'Normal: Hello!',
       });
 
-      this.runTask(() => set(this.context, 'componentName', 'alternative-message'));
+      runTask(() => set(this.context, 'componentName', 'alternative-message'));
 
       this.assertComponentElement(this.firstChild, {
         content: 'Alternative: Another Hello!',
       });
 
-      this.runTask(() => set(this.context, 'message', 'Hi'));
+      runTask(() => set(this.context, 'message', 'Hi'));
 
       this.assertComponentElement(this.firstChild, {
         content: 'Alternative: Another Hi!',
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'componentName', 'normal-message');
         set(this.context, 'message', 'Hello');
       });
@@ -727,7 +727,7 @@ moduleFor(
 
       this.assertText('Foo4Bar5Baz');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Foo4Bar5Baz');
     }
@@ -750,19 +750,19 @@ moduleFor(
 
       this.assertText('Foo4');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Foo4');
 
-      this.runTask(() => this.context.set('user1', 'Bar'));
+      runTask(() => this.context.set('user1', 'Bar'));
 
       this.assertText('Bar4');
 
-      this.runTask(() => this.context.set('user2', '5'));
+      runTask(() => this.context.set('user2', '5'));
 
       this.assertText('Bar5');
 
-      this.runTask(() => {
+      runTask(() => {
         this.context.set('user1', 'Foo');
         this.context.set('user2', 4);
       });
@@ -854,7 +854,7 @@ if (jQueryDisabled) {
 
         this.assertComponentElement(element1, { content: 'hello' });
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         let element2 = instance.$()[0];
 
@@ -885,7 +885,7 @@ if (jQueryDisabled) {
         assert.equal($span.length, 1);
         assert.equal($span.attr('class'), 'inner');
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         $span = instance.$('span');
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/error-handling-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/error-handling-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
 
@@ -37,11 +37,11 @@ moduleFor(
 
       this.assertText('');
 
-      this.runTask(() => set(this.context, 'switch', false));
+      runTask(() => set(this.context, 'switch', false));
 
       shouldThrow = false;
 
-      this.runTask(() => set(this.context, 'switch', true));
+      runTask(() => set(this.context, 'switch', true));
 
       this.assertText('hello');
     }
@@ -70,12 +70,12 @@ moduleFor(
 
       this.assertText('hello');
 
-      this.runTask(() => set(this.context, 'switch', false));
+      runTask(() => set(this.context, 'switch', false));
 
       shouldThrow = true;
 
       assert.throws(() => {
-        this.runTask(() => set(this.context, 'switch', true));
+        runTask(() => set(this.context, 'switch', true));
       }, /silly mistake in init/);
 
       assert.equal(
@@ -86,10 +86,10 @@ moduleFor(
 
       this.assertText('');
 
-      this.runTask(() => set(this.context, 'switch', false));
+      runTask(() => set(this.context, 'switch', false));
       shouldThrow = false;
 
-      this.runTask(() => set(this.context, 'switch', true));
+      runTask(() => set(this.context, 'switch', true));
 
       this.assertText('hello');
     }
@@ -124,7 +124,7 @@ moduleFor(
 
       this.assertText('hello');
 
-      this.runTask(() => set(this.context, 'switch', false));
+      runTask(() => set(this.context, 'switch', false));
 
       this.assertText('');
     }
@@ -152,13 +152,13 @@ moduleFor(
       this.assertText('hello');
 
       assert.throws(() => {
-        this.runTask(() => set(this.context, 'switch', false));
+        runTask(() => set(this.context, 'switch', false));
       }, /silly mistake/);
 
       this.assertText('');
 
       shouldThrow = false;
-      this.runTask(() => set(this.context, 'switch', true));
+      runTask(() => set(this.context, 'switch', true));
 
       this.assertText('hello');
     }

--- a/packages/@ember/-internals/glimmer/tests/integration/components/fragment-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/fragment-components-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase, strip } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
 
@@ -38,15 +38,15 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(instance, 'foo', false));
+      runTask(() => set(instance, 'foo', false));
 
       this.assertHTML(strip`<!---->bar`);
 
-      this.runTask(() => set(instance, 'bar', 'bizz'));
+      runTask(() => set(instance, 'bar', 'bizz'));
 
       this.assertHTML(strip`<!---->bizz`);
 
-      this.runTask(() => {
+      runTask(() => {
         set(instance, 'bar', 'bar');
         set(instance, 'foo', true);
       });
@@ -197,11 +197,11 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'fooBarId', 'qux'));
+      runTask(() => set(this.context, 'fooBarId', 'qux'));
 
       this.assertText('qux');
 
-      this.runTask(() => set(this.context, 'fooBarId', 'baz'));
+      runTask(() => set(this.context, 'fooBarId', 'baz'));
 
       this.assertText('baz');
     }
@@ -275,7 +275,7 @@ moduleFor(
         tagName: 'span',
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertElement(this.firstChild, { tagName: 'section' });
       this.assertElement(this.firstChild.firstElementChild, {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/instrumentation-compile-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/instrumentation-compile-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, runTask } from 'internal-test-helpers';
 
 import {
   subscribe as instrumentationSubscribe,
@@ -74,7 +74,7 @@ moduleFor(
 
       this.assertEvents('after initial render');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertEvents('after no-op rerender');
     }

--- a/packages/@ember/-internals/glimmer/tests/integration/components/instrumentation-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/instrumentation-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
 import {
@@ -94,26 +94,26 @@ moduleFor(
 
       this.assertEvents('after initial render', true);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertEvents('after no-op rerender');
 
-      this.runTask(() => set(this.context, 'foo', 'FOO'));
+      runTask(() => set(this.context, 'foo', 'FOO'));
 
       this.assertEvents('after updating top-level');
 
-      this.runTask(() => set(this.context, 'baz', 'BAZ'));
+      runTask(() => set(this.context, 'baz', 'BAZ'));
 
       this.assertEvents('after updating inner-most');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'bar', 'BAR');
         set(this.context, 'bat', 'BAT');
       });
 
       this.assertEvents('after updating the rest');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'foo', 'FOO');
         set(this.context, 'bar', 'BAR');
         set(this.context, 'baz', 'BAZ');

--- a/packages/@ember/-internals/glimmer/tests/integration/components/life-cycle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/life-cycle-test.js
@@ -1,4 +1,11 @@
-import { moduleFor, RenderingTestCase, classes, strip, runAppend } from 'internal-test-helpers';
+import {
+  moduleFor,
+  RenderingTestCase,
+  classes,
+  strip,
+  runAppend,
+  runTask,
+} from 'internal-test-helpers';
 
 import { schedule } from '@ember/runloop';
 import { set, setProperties } from '@ember/-internals/metal';
@@ -382,7 +389,7 @@ class LifeCycleHooksTest extends RenderingTestCase {
       ],
     });
 
-    this.runTask(() => this.components['the-bottom'].rerender());
+    runTask(() => this.components['the-bottom'].rerender());
 
     this.assertText('Twitter: @tomdale|Name: Tom Dale|Website: tomdale.net');
 
@@ -415,7 +422,7 @@ class LifeCycleHooksTest extends RenderingTestCase {
       nonInteractive: [],
     });
 
-    this.runTask(() => this.components['the-middle'].rerender());
+    runTask(() => this.components['the-middle'].rerender());
 
     this.assertText('Twitter: @tomdale|Name: Tom Dale|Website: tomdale.net');
 
@@ -443,7 +450,7 @@ class LifeCycleHooksTest extends RenderingTestCase {
       nonInteractive: [],
     });
 
-    this.runTask(() => this.components['the-top'].rerender());
+    runTask(() => this.components['the-top'].rerender());
 
     this.assertText('Twitter: @tomdale|Name: Tom Dale|Website: tomdale.net');
 
@@ -465,7 +472,7 @@ class LifeCycleHooksTest extends RenderingTestCase {
       nonInteractive: [],
     });
 
-    this.runTask(() => set(this.context, 'twitter', '@horsetomdale'));
+    runTask(() => set(this.context, 'twitter', '@horsetomdale'));
 
     this.assertText('Twitter: @horsetomdale|Name: Tom Dale|Website: tomdale.net');
 
@@ -636,7 +643,7 @@ class LifeCycleHooksTest extends RenderingTestCase {
       ],
     });
 
-    this.runTask(() => this.components['the-first-child'].rerender());
+    runTask(() => this.components['the-first-child'].rerender());
 
     this.assertText('Twitter: @tomdale|Name: Tom Dale|Website: tomdale.net');
 
@@ -664,7 +671,7 @@ class LifeCycleHooksTest extends RenderingTestCase {
       nonInteractive: [],
     });
 
-    this.runTask(() => this.components['the-second-child'].rerender());
+    runTask(() => this.components['the-second-child'].rerender());
 
     this.assertText('Twitter: @tomdale|Name: Tom Dale|Website: tomdale.net');
 
@@ -692,7 +699,7 @@ class LifeCycleHooksTest extends RenderingTestCase {
       nonInteractive: [],
     });
 
-    this.runTask(() => this.components['the-last-child'].rerender());
+    runTask(() => this.components['the-last-child'].rerender());
 
     this.assertText('Twitter: @tomdale|Name: Tom Dale|Website: tomdale.net');
 
@@ -720,7 +727,7 @@ class LifeCycleHooksTest extends RenderingTestCase {
       nonInteractive: [],
     });
 
-    this.runTask(() => this.components['the-parent'].rerender());
+    runTask(() => this.components['the-parent'].rerender());
 
     this.assertText('Twitter: @tomdale|Name: Tom Dale|Website: tomdale.net');
 
@@ -742,7 +749,7 @@ class LifeCycleHooksTest extends RenderingTestCase {
       nonInteractive: [],
     });
 
-    this.runTask(() =>
+    runTask(() =>
       setProperties(this.context, {
         twitter: '@horsetomdale',
         name: 'Horse Tom Dale',
@@ -937,7 +944,7 @@ class LifeCycleHooksTest extends RenderingTestCase {
       ],
     });
 
-    this.runTask(() => set(this.context, 'twitter', '@horsetomdale'));
+    runTask(() => set(this.context, 'twitter', '@horsetomdale'));
 
     this.assertText('Top: Middle: Bottom: @horsetomdale');
 
@@ -994,7 +1001,7 @@ class LifeCycleHooksTest extends RenderingTestCase {
       ],
     });
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('Top: Middle: Bottom: @horsetomdale');
 
@@ -1139,7 +1146,7 @@ class LifeCycleHooksTest extends RenderingTestCase {
       this.assert.equal(this.component.childViews.length, 5, 'childViews precond');
     }
 
-    this.runTask(() => set(this.context, 'items', []));
+    runTask(() => set(this.context, 'items', []));
 
     // TODO: Is this correct? Should childViews be populated in non-interactive mode?
     if (this.isInteractive) {
@@ -1352,7 +1359,7 @@ moduleFor(
 
       this.assertText('10');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('10');
     }
@@ -1375,7 +1382,7 @@ moduleFor(
 
       this.assertText('wat');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('wat');
     }
@@ -1476,7 +1483,7 @@ moduleFor(
 
       this.assertText('1AB2AB3AB4AB5AB6AB7AB');
 
-      this.runTask(() => {
+      runTask(() => {
         array.removeAt(2);
         array.removeAt(2);
         set(this.context, 'model.shouldShow', false);
@@ -1629,7 +1636,7 @@ if (!jQueryDisabled) {
         let { owner } = this;
         let comp = owner.lookup('component:foo-bar');
         runAppend(comp);
-        this.runTask(() => tryInvoke(component, 'destroy'));
+        runTask(() => tryInvoke(component, 'destroy'));
       }
     }
   );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to-test.js
@@ -3,6 +3,7 @@ import {
   ApplicationTestCase,
   RenderingTestCase,
   classes as classMatcher,
+  runTask,
 } from 'internal-test-helpers';
 
 import Controller from '@ember/controller';
@@ -49,7 +50,7 @@ moduleFor(
 
       return this.visit('/').then(() => {
         this.assertText('foo');
-        this.runTask(() => set(controller, 'title', 'bar'));
+        runTask(() => set(controller, 'title', 'bar'));
         this.assertText('bar');
       });
     }
@@ -76,7 +77,7 @@ moduleFor(
 
       return this.visit('/bar').then(() => {
         assert.equal(this.firstChild.classList.contains('active'), false);
-        this.runTask(() => set(controller, 'routeName', 'bar'));
+        runTask(() => set(controller, 'routeName', 'bar'));
         assert.equal(this.firstChild.classList.contains('active'), true);
       });
     }

--- a/packages/@ember/-internals/glimmer/tests/integration/components/local-lookup-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/local-lookup-test.js
@@ -3,6 +3,7 @@ import {
   RenderingTestCase,
   ModuleBasedTestResolver,
   ApplicationTestCase,
+  runTask,
 } from 'internal-test-helpers';
 
 import { compile } from 'ember-template-compiler';
@@ -24,7 +25,7 @@ class LocalLookupTest extends RenderingTestCase {
 
     this.assertText('Nested template says: Hi!', 'Initial render works');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('Nested template says: Hi!', 'Re-render works');
   }
@@ -42,7 +43,7 @@ class LocalLookupTest extends RenderingTestCase {
 
     this.assertText('Nested template says: Hi!', 'Re-render works');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('Nested template says: Hi!', 'Re-render works');
   }
@@ -55,7 +56,7 @@ class LocalLookupTest extends RenderingTestCase {
 
     this.assertText('Nested template says: Hi!', 'Initial render works');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('Nested template says: Hi!', 'Re-render works');
   }
@@ -70,7 +71,7 @@ class LocalLookupTest extends RenderingTestCase {
 
     this.assertText('yall finished or yall done?');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('yall finished or yall done?');
   }
@@ -88,7 +89,7 @@ class LocalLookupTest extends RenderingTestCase {
 
     this.assertText('yall finished or yall done?');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('yall finished or yall done?');
   }
@@ -104,7 +105,7 @@ class LocalLookupTest extends RenderingTestCase {
 
     this.assertText('yall finished or yall done?');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('yall finished or yall done?');
   }
@@ -125,7 +126,7 @@ class LocalLookupTest extends RenderingTestCase {
 
     this.assertText('yall finished or yall done?');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('yall finished or yall done?');
   }
@@ -149,7 +150,7 @@ class LocalLookupTest extends RenderingTestCase {
 
     this.assertText('yall finished or yall done?');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('yall finished or yall done?');
   }
@@ -168,9 +169,9 @@ class LocalLookupTest extends RenderingTestCase {
 
     this.assertText('yall finished or yall done?');
 
-    this.runTask(() => this.context.set('bar', 'global-bar'));
+    runTask(() => this.context.set('bar', 'global-bar'));
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('yall finished or yall ready?');
   }
@@ -185,7 +186,7 @@ class LocalLookupTest extends RenderingTestCase {
 
     this.assertText('Who dat? Who dis?', 'Initial render works');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('Who dat? Who dis?', 'Re-render works');
   }
@@ -205,7 +206,7 @@ class LocalLookupTest extends RenderingTestCase {
 
     this.assertText('Who dat? Who dis? I dunno', 'Initial render works');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('Who dat? Who dis? I dunno', 'Re-render works');
   }
@@ -239,7 +240,7 @@ class LocalLookupTest extends RenderingTestCase {
       'Nested template says (from global): Hi! Nested template says (from local): Hi! Nested template says (from local): Hi!'
     );
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText(
       'Nested template says (from global): Hi! Nested template says (from local): Hi! Nested template says (from local): Hi!'

--- a/packages/@ember/-internals/glimmer/tests/integration/components/namespaced-lookup-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/namespaced-lookup-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, runTask } from 'internal-test-helpers';
 
 import { EMBER_MODULE_UNIFICATION } from '@ember/canary-features';
 import { Component, helper } from '@ember/-internals/glimmer';
@@ -34,7 +34,7 @@ if (EMBER_MODULE_UNIFICATION) {
 
         this.assertText('namespaced template My property');
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertText('namespaced template My property');
       }
@@ -64,7 +64,7 @@ if (EMBER_MODULE_UNIFICATION) {
 
         this.assertText('first namespaced template - second namespaced template');
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertText('first namespaced template - second namespaced template');
       }
@@ -95,7 +95,7 @@ if (EMBER_MODULE_UNIFICATION) {
 
         this.assertText('un-namespaced addon template');
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertText('un-namespaced addon template');
       }
@@ -123,7 +123,7 @@ if (EMBER_MODULE_UNIFICATION) {
 
         this.assertText('Nested namespaced component');
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertText('Nested namespaced component');
       }
@@ -159,7 +159,7 @@ if (EMBER_MODULE_UNIFICATION) {
 
         this.assertText('my helper'); // component should be not found
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertText('my helper');
       }
@@ -177,7 +177,7 @@ if (EMBER_MODULE_UNIFICATION) {
 
         this.assertText('my helper');
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertText('my helper');
       }

--- a/packages/@ember/-internals/glimmer/tests/integration/components/target-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/target-action-test.js
@@ -1,4 +1,10 @@
-import { moduleFor, RenderingTestCase, ApplicationTestCase, strip } from 'internal-test-helpers';
+import {
+  moduleFor,
+  RenderingTestCase,
+  ApplicationTestCase,
+  strip,
+  runTask,
+} from 'internal-test-helpers';
 
 import { assign } from '@ember/polyfills';
 import { set, Mixin } from '@ember/-internals/metal';
@@ -70,7 +76,7 @@ moduleFor(
       this.renderDelegate();
 
       expectSendActionDeprecation(() => {
-        this.runTask(() => this.delegate.sendAction());
+        runTask(() => this.delegate.sendAction());
       });
 
       this.assertSendCount(0);
@@ -80,7 +86,7 @@ moduleFor(
       this.renderDelegate();
 
       expectSendActionDeprecation(() => {
-        this.runTask(() => {
+        runTask(() => {
           set(this.delegate, 'action', 'addItem');
           this.delegate.sendAction();
         });
@@ -96,7 +102,7 @@ moduleFor(
       this.renderDelegate();
 
       expectSendActionDeprecation(() => {
-        this.runTask(() => {
+        runTask(() => {
           set(this.delegate, 'action', () => this.assert.ok(true, 'function is called'));
           this.delegate.sendAction();
         });
@@ -109,7 +115,7 @@ moduleFor(
 
       this.renderDelegate();
       expectSendActionDeprecation(() => {
-        this.runTask(() => {
+        runTask(() => {
           set(this.delegate, 'action', actualArgument => {
             this.assert.deepEqual(argument, actualArgument, 'argument is passed');
           });
@@ -125,16 +131,16 @@ moduleFor(
       });
 
       expectSendActionDeprecation(() => {
-        this.runTask(() => this.delegate.sendAction());
+        runTask(() => this.delegate.sendAction());
       });
 
       this.assertSendCount(0);
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'playing', 'didStartPlaying');
       });
       expectSendActionDeprecation(() => {
-        this.runTask(() => {
+        runTask(() => {
           this.delegate.sendAction('playing');
         });
       });
@@ -149,14 +155,14 @@ moduleFor(
       });
 
       expectSendActionDeprecation(() => {
-        this.runTask(() => this.delegate.sendAction('playing'));
+        runTask(() => this.delegate.sendAction('playing'));
       });
 
       this.assertSendCount(0);
 
-      this.runTask(() => this.delegate.attrs.playing.update('didStartPlaying'));
+      runTask(() => this.delegate.attrs.playing.update('didStartPlaying'));
       expectSendActionDeprecation(() => {
-        this.runTask(() => this.delegate.sendAction('playing'));
+        runTask(() => this.delegate.sendAction('playing'));
       });
 
       this.assertSendCount(1);
@@ -168,7 +174,7 @@ moduleFor(
 
       let component = this.delegate;
       expectSendActionDeprecation(() => {
-        this.runTask(() => {
+        runTask(() => {
           set(this.delegate, 'playing', 'didStartPlaying');
           component.sendAction('playing');
         });
@@ -178,14 +184,14 @@ moduleFor(
       this.assertNamedSendCount('didStartPlaying', 1);
 
       expectSendActionDeprecation(() => {
-        this.runTask(() => component.sendAction('playing'));
+        runTask(() => component.sendAction('playing'));
       });
 
       this.assertSendCount(2);
       this.assertNamedSendCount('didStartPlaying', 2);
 
       expectSendActionDeprecation(() => {
-        this.runTask(() => {
+        runTask(() => {
           set(component, 'action', 'didDoSomeBusiness');
           component.sendAction();
         });
@@ -198,7 +204,7 @@ moduleFor(
     ['@test Calling sendAction when the action name is not a string raises an exception']() {
       this.renderDelegate();
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.delegate, 'action', {});
         set(this.delegate, 'playing', {});
       });
@@ -218,7 +224,7 @@ moduleFor(
       let secondContext = { song: 'My Achey Breaky Ember' };
 
       expectSendActionDeprecation(() => {
-        this.runTask(() => {
+        runTask(() => {
           set(this.delegate, 'playing', 'didStartPlaying');
           this.delegate.sendAction('playing', testContext);
         });
@@ -229,7 +235,7 @@ moduleFor(
       this.assertSentWithArgs([testContext], 'context was sent with the action');
 
       expectSendActionDeprecation(() => {
-        this.runTask(() => {
+        runTask(() => {
           this.delegate.sendAction('playing', firstContext, secondContext);
         });
       });
@@ -297,7 +303,7 @@ moduleFor(
 
       this.renderDelegate();
       expectSendActionDeprecation(() => {
-        this.runTask(() => innerChild.sendAction('bar', 'something special'));
+        runTask(() => innerChild.sendAction('bar', 'something special'));
       });
     }
 
@@ -321,7 +327,7 @@ moduleFor(
         shouldRender: true,
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'shouldRender', false);
       });
 
@@ -545,7 +551,7 @@ moduleFor(
 
       this.render('{{outer-component}}');
       expectSendActionDeprecation(() => {
-        this.runTask(() => component.sendAction('submitAction'));
+        runTask(() => component.sendAction('submitAction'));
       });
     }
 
@@ -582,7 +588,7 @@ moduleFor(
 
       this.render('{{outer-component}}');
       expectSendActionDeprecation(() => {
-        this.runTask(() => innerComponent.sendAction('innerSubmit', fourth));
+        runTask(() => innerComponent.sendAction('innerSubmit', fourth));
       });
 
       this.assert.deepEqual(
@@ -618,7 +624,7 @@ moduleFor(
 
       this.render('{{foo-bar}}');
 
-      this.runTask(() => component.send('foo', 'bar'));
+      runTask(() => component.send('foo', 'bar'));
 
       expectAssertion(() => {
         return component.send('baz', 'bar');
@@ -646,7 +652,7 @@ moduleFor(
 
       this.render('{{foo-bar}}');
 
-      this.runTask(() => component.send('foo', 'baz'));
+      runTask(() => component.send('foo', 'baz'));
     }
 
     ['@test a handled action can be bubbled to the target for continued processing']() {
@@ -678,7 +684,7 @@ moduleFor(
 
       this.render('{{foo-bar poke="poke"}}');
 
-      this.runTask(() => component.send('poke'));
+      runTask(() => component.send('poke'));
     }
 
     ["@test action can be handled by a superclass' actions object"](assert) {
@@ -722,7 +728,7 @@ moduleFor(
 
       this.render('{{x-index}}');
 
-      this.runTask(() => {
+      runTask(() => {
         component.send('foo');
         component.send('bar', 'HELLO');
         component.send('baz');
@@ -768,7 +774,7 @@ moduleFor(
         shouldRender: true,
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'shouldRender', false);
       });
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/template-only-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/template-only-components-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase, classes } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, classes, runTask } from 'internal-test-helpers';
 
 import { ENV } from '@ember/-internals/environment';
 
@@ -44,15 +44,15 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => this.context.set('foo', 'FOO'));
+      runTask(() => this.context.set('foo', 'FOO'));
 
       this.assertInnerHTML('|FOO|bar|');
 
-      this.runTask(() => this.context.set('bar', 'BAR'));
+      runTask(() => this.context.set('bar', 'BAR'));
 
       this.assertInnerHTML('|FOO|BAR|');
 
-      this.runTask(() => this.context.setProperties({ foo: 'foo', bar: 'bar' }));
+      runTask(() => this.context.setProperties({ foo: 'foo', bar: 'bar' }));
 
       this.assertInnerHTML('|foo|bar|');
     }
@@ -69,15 +69,15 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => this.context.set('foo', 'FOO'));
+      runTask(() => this.context.set('foo', 'FOO'));
 
       this.assertInnerHTML('|||');
 
-      this.runTask(() => this.context.set('bar', null));
+      runTask(() => this.context.set('bar', null));
 
       this.assertInnerHTML('|||');
 
-      this.runTask(() => this.context.setProperties({ foo: 'foo', bar: 'bar' }));
+      runTask(() => this.context.setProperties({ foo: 'foo', bar: 'bar' }));
 
       this.assertInnerHTML('|||');
     }
@@ -93,15 +93,15 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => this.context.set('class', 'foo'));
+      runTask(() => this.context.set('class', 'foo'));
 
       this.assertInnerHTML('hello');
 
-      this.runTask(() => this.context.set('class', null));
+      runTask(() => this.context.set('class', null));
 
       this.assertInnerHTML('hello');
 
-      this.runTask(() => this.context.set('class', 'foo bar'));
+      runTask(() => this.context.set('class', 'foo bar'));
 
       this.assertInnerHTML('hello');
     }
@@ -144,15 +144,15 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => this.context.set('foo', 'FOO'));
+      runTask(() => this.context.set('foo', 'FOO'));
 
       this.assertComponentElement(this.firstChild, { content: '|FOO|bar|' });
 
-      this.runTask(() => this.context.set('bar', 'BAR'));
+      runTask(() => this.context.set('bar', 'BAR'));
 
       this.assertComponentElement(this.firstChild, { content: '|FOO|BAR|' });
 
-      this.runTask(() => this.context.setProperties({ foo: 'foo', bar: 'bar' }));
+      runTask(() => this.context.setProperties({ foo: 'foo', bar: 'bar' }));
 
       this.assertComponentElement(this.firstChild, { content: '|foo|bar|' });
     }
@@ -169,15 +169,15 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => this.context.set('foo', 'FOO'));
+      runTask(() => this.context.set('foo', 'FOO'));
 
       this.assertComponentElement(this.firstChild, { content: '|FOO|bar|' });
 
-      this.runTask(() => this.context.set('bar', null));
+      runTask(() => this.context.set('bar', null));
 
       this.assertComponentElement(this.firstChild, { content: '|FOO||' });
 
-      this.runTask(() => this.context.setProperties({ foo: 'foo', bar: 'bar' }));
+      runTask(() => this.context.setProperties({ foo: 'foo', bar: 'bar' }));
 
       this.assertComponentElement(this.firstChild, { content: '|foo|bar|' });
     }
@@ -197,7 +197,7 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => this.context.set('class', 'foo'));
+      runTask(() => this.context.set('class', 'foo'));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'p',
@@ -205,7 +205,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.context.set('class', null));
+      runTask(() => this.context.set('class', null));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'p',
@@ -213,7 +213,7 @@ moduleFor(
         content: 'hello',
       });
 
-      this.runTask(() => this.context.set('class', 'foo bar'));
+      runTask(() => this.context.set('class', 'foo bar'));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'p',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, ApplicationTestCase, RenderingTestCase } from 'internal-test-helpers';
+import { moduleFor, ApplicationTestCase, RenderingTestCase, runTask } from 'internal-test-helpers';
 
 import Controller from '@ember/controller';
 import {
@@ -139,11 +139,11 @@ moduleFor(
         .then(() => {
           this.assertRootViews(['root-1', 'root-2', 'root-3', 'root-4', 'root-5']);
 
-          this.runTask(() => this.$('#toggle-application').click());
+          runTask(() => this.$('#toggle-application').click());
 
           this.assertRootViews(['root-1', 'root-2', 'root-4', 'root-5']);
 
-          this.runTask(() => {
+          runTask(() => {
             this.$('#toggle-application').click();
             this.$('#toggle-index').click();
           });
@@ -180,11 +180,11 @@ moduleFor(
           this.assertChildViews('root-5', []);
           this.assertChildViews('inner-2', ['inner-3']);
 
-          this.runTask(() => this.$('#root-2').click());
+          runTask(() => this.$('#root-2').click());
 
           this.assertChildViews('root-2', []);
 
-          this.runTask(() => this.$('#root-5').click());
+          runTask(() => this.$('#root-5').click());
 
           this.assertChildViews('root-5', ['inner-4', 'inner-5']);
           this.assertChildViews('inner-5', ['inner-6']);
@@ -197,7 +197,7 @@ moduleFor(
           this.assertChildViews('inner-8', ['inner-9']);
           this.assertChildViews('root-9', []);
 
-          this.runTask(() => this.$('#root-8').click());
+          runTask(() => this.$('#root-8').click());
 
           this.assertChildViews('root-8', []);
 
@@ -214,8 +214,8 @@ moduleFor(
           this.assertChildViews('root-2', []);
           this.assertChildViews('root-5', []);
 
-          this.runTask(() => this.$('#root-2').click());
-          this.runTask(() => this.$('#inner-2').click());
+          runTask(() => this.$('#root-2').click());
+          runTask(() => this.$('#inner-2').click());
 
           this.assertChildViews('root-2', ['inner-1', 'inner-2']);
           this.assertChildViews('inner-2', []);
@@ -226,16 +226,16 @@ moduleFor(
       return this.visit('/').then(() => {
         this.assertChildViews('root-2', ['inner-1', 'inner-2']);
 
-        this.runTask(() => this.$('#root-2').click());
-        this.runTask(() => this.$('#root-2').click());
-        this.runTask(() => this.$('#root-2').click());
-        this.runTask(() => this.$('#root-2').click());
-        this.runTask(() => this.$('#root-2').click());
-        this.runTask(() => this.$('#root-2').click());
-        this.runTask(() => this.$('#root-2').click());
-        this.runTask(() => this.$('#root-2').click());
-        this.runTask(() => this.$('#root-2').click());
-        this.runTask(() => this.$('#root-2').click());
+        runTask(() => this.$('#root-2').click());
+        runTask(() => this.$('#root-2').click());
+        runTask(() => this.$('#root-2').click());
+        runTask(() => this.$('#root-2').click());
+        runTask(() => this.$('#root-2').click());
+        runTask(() => this.$('#root-2').click());
+        runTask(() => this.$('#root-2').click());
+        runTask(() => this.$('#root-2').click());
+        runTask(() => this.$('#root-2').click());
+        runTask(() => this.$('#root-2').click());
 
         this.assertChildViews('root-2', ['inner-1', 'inner-2']);
       });

--- a/packages/@ember/-internals/glimmer/tests/integration/components/web-component-fallback-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/web-component-fallback-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
 
@@ -24,11 +24,11 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'name', 'Kris'));
+      runTask(() => set(this.context, 'name', 'Kris'));
 
       this.assertHTML(`<foo-bar some-attr="Kris">hello</foo-bar>`);
 
-      this.runTask(() => set(this.context, 'name', 'Robert'));
+      runTask(() => set(this.context, 'name', 'Robert'));
 
       this.assertHTML(`<foo-bar some-attr="Robert">hello</foo-bar>`);
     }

--- a/packages/@ember/-internals/glimmer/tests/integration/components/will-destroy-element-hook-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/will-destroy-element-hook-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
 
@@ -32,7 +32,7 @@ moduleFor(
 
       this.assertComponentElement(this.firstChild, { content: 'hello' });
 
-      this.runTask(() => set(this.context, 'switch', false));
+      runTask(() => set(this.context, 'switch', false));
 
       assert.equal(willDestroyElementCount, 1, 'willDestroyElement was called once');
 

--- a/packages/@ember/-internals/glimmer/tests/integration/content-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/content-test.js
@@ -1,6 +1,6 @@
 /* globals EmberDev */
 
-import { RenderingTestCase, moduleFor, applyMixins, classes } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, applyMixins, classes, runTask } from 'internal-test-helpers';
 
 import { set, computed } from '@ember/-internals/metal';
 import { getDebugFunction, setDebugFunction } from '@ember/debug';
@@ -16,7 +16,7 @@ moduleFor(
       this.render('hello');
       let text1 = this.assertTextNode(this.firstChild, 'hello');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       let text2 = this.assertTextNode(this.firstChild, 'hello');
 
@@ -28,7 +28,7 @@ moduleFor(
       let p1 = this.assertElement(this.firstChild, { tagName: 'p' });
       let text1 = this.assertTextNode(this.firstChild.firstChild, 'hello');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       let p2 = this.assertElement(this.firstChild, { tagName: 'p' });
       let text2 = this.assertTextNode(this.firstChild.firstChild, 'hello');
@@ -58,7 +58,7 @@ moduleFor(
       this.render(template);
       this.assertHTML(template);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertHTML(template);
     }
@@ -87,12 +87,12 @@ class DynamicContentTest extends RenderingTestCase {
 
     this.assertStableRerender();
 
-    this.runTask(() => set(this.context, 'message', 'goodbye'));
+    runTask(() => set(this.context, 'message', 'goodbye'));
 
     this.assertContent('goodbye');
     this.assertInvariants();
 
-    this.runTask(() => set(this.context, 'message', 'hello'));
+    runTask(() => set(this.context, 'message', 'hello'));
 
     this.assertContent('hello');
     this.assertInvariants();
@@ -105,15 +105,15 @@ class DynamicContentTest extends RenderingTestCase {
 
     this.assertStableRerender();
 
-    this.runTask(() => set(this.context, 'foo', 'foo'));
+    runTask(() => set(this.context, 'foo', 'foo'));
 
     this.assertHTML('<p>3</p>');
 
-    this.runTask(() => set(this.context, 'foo', ''));
+    runTask(() => set(this.context, 'foo', ''));
 
     this.assertHTML('<p>0</p>');
 
-    this.runTask(() => set(this.context, 'foo', undefined));
+    runTask(() => set(this.context, 'foo', undefined));
 
     this.assertHTML('<p></p>');
   }
@@ -125,15 +125,15 @@ class DynamicContentTest extends RenderingTestCase {
 
     this.assertStableRerender();
 
-    this.runTask(() => set(this.context, 'foo', [1, 2, 3]));
+    runTask(() => set(this.context, 'foo', [1, 2, 3]));
 
     this.assertHTML('<p>3</p>');
 
-    this.runTask(() => set(this.context, 'foo', []));
+    runTask(() => set(this.context, 'foo', []));
 
     this.assertHTML('<p>0</p>');
 
-    this.runTask(() => set(this.context, 'foo', undefined));
+    runTask(() => set(this.context, 'foo', undefined));
 
     this.assertHTML('<p></p>');
   }
@@ -147,12 +147,12 @@ class DynamicContentTest extends RenderingTestCase {
 
     this.assertStableRerender();
 
-    this.runTask(() => set(this.context, 'CaptializedPath', 'still no deprecation'));
+    runTask(() => set(this.context, 'CaptializedPath', 'still no deprecation'));
 
     this.assertContent('still no deprecation');
     this.assertInvariants();
 
-    this.runTask(() => set(this.context, 'CaptializedPath', 'no deprecation'));
+    runTask(() => set(this.context, 'CaptializedPath', 'no deprecation'));
 
     this.assertContent('no deprecation');
     this.assertInvariants();
@@ -165,11 +165,11 @@ class DynamicContentTest extends RenderingTestCase {
 
     this.assertStableRerender();
 
-    this.runTask(() => set(this.context, 'name', 'foo-bar'));
+    runTask(() => set(this.context, 'name', 'foo-bar'));
 
     this.assertContent('foo-bar');
 
-    this.runTask(() => set(this.context, 'name', undefined));
+    runTask(() => set(this.context, 'name', undefined));
 
     this.assertIsEmpty();
   }
@@ -183,17 +183,17 @@ class DynamicContentTest extends RenderingTestCase {
 
     this.assertStableRerender();
 
-    this.runTask(() => set(this.context, 'a.b.c.d.e.f', 'goodbye'));
+    runTask(() => set(this.context, 'a.b.c.d.e.f', 'goodbye'));
 
     this.assertContent('goodbye');
     this.assertInvariants();
 
-    this.runTask(() => set(this.context, 'a.b.c.d', { e: { f: 'aloha' } }));
+    runTask(() => set(this.context, 'a.b.c.d', { e: { f: 'aloha' } }));
 
     this.assertContent('aloha');
     this.assertInvariants();
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'a', { b: { c: { d: { e: { f: 'hello' } } } } });
     });
 
@@ -216,12 +216,12 @@ class DynamicContentTest extends RenderingTestCase {
 
     this.assertStableRerender();
 
-    this.runTask(() => set(m, 'message', 'goodbye'));
+    runTask(() => set(m, 'message', 'goodbye'));
 
     this.assertContent('GOODBYE');
     this.assertInvariants();
 
-    this.runTask(() => set(this.context, 'm', Formatter.create({ message: 'hello' })));
+    runTask(() => set(this.context, 'm', Formatter.create({ message: 'hello' })));
 
     this.assertContent('HELLO');
     this.assertInvariants();
@@ -242,14 +242,12 @@ class DynamicContentTest extends RenderingTestCase {
 
     this.assertStableRerender();
 
-    this.runTask(() => set(m, 'messenger.message', 'goodbye'));
+    runTask(() => set(m, 'messenger.message', 'goodbye'));
 
     this.assertContent('GOODBYE');
     this.assertInvariants();
 
-    this.runTask(() =>
-      set(this.context, 'm', Formatter.create({ messenger: { message: 'hello' } }))
-    );
+    runTask(() => set(this.context, 'm', Formatter.create({ messenger: { message: 'hello' } })));
 
     this.assertContent('HELLO');
     this.assertInvariants();
@@ -264,26 +262,26 @@ class DynamicContentTest extends RenderingTestCase {
 
     this.assertStableRerender();
 
-    this.runTask(() => set(this.context, 'proxy.content.name', 'Yehuda Katz'));
+    runTask(() => set(this.context, 'proxy.content.name', 'Yehuda Katz'));
 
     this.assertContent('Yehuda Katz');
     this.assertInvariants();
 
-    this.runTask(() => set(this.context, 'proxy.content', { name: 'Godfrey Chan' }));
+    runTask(() => set(this.context, 'proxy.content', { name: 'Godfrey Chan' }));
 
     this.assertContent('Godfrey Chan');
     this.assertInvariants();
 
-    this.runTask(() => set(this.context, 'proxy.name', 'Stefan Penner'));
+    runTask(() => set(this.context, 'proxy.name', 'Stefan Penner'));
 
     this.assertContent('Stefan Penner');
     this.assertInvariants();
 
-    this.runTask(() => set(this.context, 'proxy.content', null));
+    runTask(() => set(this.context, 'proxy.content', null));
 
     this.assertIsEmpty();
 
-    this.runTask(() =>
+    runTask(() =>
       set(this.context, 'proxy', ObjectProxy.create({ content: { name: 'Tom Dale' } }))
     );
 
@@ -302,21 +300,21 @@ class DynamicContentTest extends RenderingTestCase {
 
     this.assertStableRerender();
 
-    this.runTask(() => set(this.context, 'proxy.content.name.last', 'Cruise'));
+    runTask(() => set(this.context, 'proxy.content.name.last', 'Cruise'));
 
     this.assertContent('Cruise');
     this.assertInvariants();
 
-    this.runTask(() => set(this.context, 'proxy.content.name.first', 'Suri'));
+    runTask(() => set(this.context, 'proxy.content.name.first', 'Suri'));
 
     this.assertStableRerender();
 
-    this.runTask(() => set(this.context, 'proxy.content.name', { first: 'Yehuda', last: 'Katz' }));
+    runTask(() => set(this.context, 'proxy.content.name', { first: 'Yehuda', last: 'Katz' }));
 
     this.assertContent('Katz');
     this.assertInvariants();
 
-    this.runTask(() =>
+    runTask(() =>
       set(this.context, 'proxy.content', {
         name: { first: 'Godfrey', last: 'Chan' },
       })
@@ -325,16 +323,16 @@ class DynamicContentTest extends RenderingTestCase {
     this.assertContent('Chan');
     this.assertInvariants();
 
-    this.runTask(() => set(this.context, 'proxy.name', { first: 'Stefan', last: 'Penner' }));
+    runTask(() => set(this.context, 'proxy.name', { first: 'Stefan', last: 'Penner' }));
 
     this.assertContent('Penner');
     this.assertInvariants();
 
-    this.runTask(() => set(this.context, 'proxy', null));
+    runTask(() => set(this.context, 'proxy', null));
 
     this.assertIsEmpty();
 
-    this.runTask(() =>
+    runTask(() =>
       set(
         this.context,
         'proxy',
@@ -359,7 +357,7 @@ class DynamicContentTest extends RenderingTestCase {
 
     this.assertStableRerender();
 
-    this.runTask(() =>
+    runTask(() =>
       set(this.context, 'proxyOrObject', {
         name: { first: 'Tom', last: 'Dale' },
       })
@@ -367,16 +365,16 @@ class DynamicContentTest extends RenderingTestCase {
 
     this.assertStableRerender();
 
-    this.runTask(() => set(this.context, 'proxyOrObject.name.last', 'Cruise'));
+    runTask(() => set(this.context, 'proxyOrObject.name.last', 'Cruise'));
 
     this.assertContent('Cruise');
     this.assertInvariants();
 
-    this.runTask(() => set(this.context, 'proxyOrObject.name.first', 'Suri'));
+    runTask(() => set(this.context, 'proxyOrObject.name.first', 'Suri'));
 
     this.assertStableRerender();
 
-    this.runTask(() =>
+    runTask(() =>
       set(this.context, 'proxyOrObject', {
         name: { first: 'Yehuda', last: 'Katz' },
       })
@@ -385,7 +383,7 @@ class DynamicContentTest extends RenderingTestCase {
     this.assertContent('Katz');
     this.assertInvariants();
 
-    this.runTask(() =>
+    runTask(() =>
       set(
         this.context,
         'proxyOrObject',
@@ -398,7 +396,7 @@ class DynamicContentTest extends RenderingTestCase {
     this.assertContent('Chan');
     this.assertInvariants();
 
-    this.runTask(() =>
+    runTask(() =>
       set(this.context, 'proxyOrObject.content.name', {
         first: 'Stefan',
         last: 'Penner',
@@ -408,11 +406,11 @@ class DynamicContentTest extends RenderingTestCase {
     this.assertContent('Penner');
     this.assertInvariants();
 
-    this.runTask(() => set(this.context, 'proxyOrObject', null));
+    runTask(() => set(this.context, 'proxyOrObject', null));
 
     this.assertIsEmpty();
 
-    this.runTask(() =>
+    runTask(() =>
       set(
         this.context,
         'proxyOrObject',
@@ -435,7 +433,7 @@ class DynamicContentTest extends RenderingTestCase {
 
     this.assertStableRerender();
 
-    this.runTask(() =>
+    runTask(() =>
       set(
         this.context,
         'objectOrProxy',
@@ -447,16 +445,16 @@ class DynamicContentTest extends RenderingTestCase {
 
     this.assertStableRerender();
 
-    this.runTask(() => set(this.context, 'objectOrProxy.content.name.last', 'Cruise'));
+    runTask(() => set(this.context, 'objectOrProxy.content.name.last', 'Cruise'));
 
     this.assertContent('Cruise');
     this.assertInvariants();
 
-    this.runTask(() => set(this.context, 'objectOrProxy.content.name.first', 'Suri'));
+    runTask(() => set(this.context, 'objectOrProxy.content.name.first', 'Suri'));
 
     this.assertStableRerender();
 
-    this.runTask(() =>
+    runTask(() =>
       set(this.context, 'objectOrProxy.content', {
         name: { first: 'Yehuda', last: 'Katz' },
       })
@@ -465,7 +463,7 @@ class DynamicContentTest extends RenderingTestCase {
     this.assertContent('Katz');
     this.assertInvariants();
 
-    this.runTask(() =>
+    runTask(() =>
       set(this.context, 'objectOrProxy', {
         name: { first: 'Godfrey', last: 'Chan' },
       })
@@ -474,7 +472,7 @@ class DynamicContentTest extends RenderingTestCase {
     this.assertContent('Chan');
     this.assertInvariants();
 
-    this.runTask(() =>
+    runTask(() =>
       set(this.context, 'objectOrProxy.name', {
         first: 'Stefan',
         last: 'Penner',
@@ -484,11 +482,11 @@ class DynamicContentTest extends RenderingTestCase {
     this.assertContent('Penner');
     this.assertInvariants();
 
-    this.runTask(() => set(this.context, 'objectOrProxy', null));
+    runTask(() => set(this.context, 'objectOrProxy', null));
 
     this.assertIsEmpty();
 
-    this.runTask(() =>
+    runTask(() =>
       set(this.context, 'objectOrProxy', {
         name: { first: 'Tom', last: 'Dale' },
       })
@@ -508,7 +506,7 @@ class DynamicContentTest extends RenderingTestCase {
 
     this.assertStableRerender();
 
-    this.runTask(() => set(nullObject, 'message', 'goodbye'));
+    runTask(() => set(nullObject, 'message', 'goodbye'));
 
     this.assertContent('goodbye');
     this.assertInvariants();
@@ -516,7 +514,7 @@ class DynamicContentTest extends RenderingTestCase {
     nullObject = Object.create(null);
     nullObject['message'] = 'hello';
 
-    this.runTask(() => set(this.context, 'nullObject', nullObject));
+    runTask(() => set(this.context, 'nullObject', nullObject));
 
     this.assertContent('hello');
     this.assertInvariants();
@@ -541,12 +539,12 @@ class DynamicContentTest extends RenderingTestCase {
 
     this.assertStableRerender();
 
-    this.runTask(() => set(messenger, 'a.b.c', 'hi'));
+    runTask(() => set(messenger, 'a.b.c', 'hi'));
 
     this.assertContent('hi');
     this.assertInvariants();
 
-    this.runTask(() =>
+    runTask(() =>
       set(this.context, 'messenger.a.b', {
         c: 'goodbye',
       })
@@ -555,7 +553,7 @@ class DynamicContentTest extends RenderingTestCase {
     this.assertContent('goodbye');
     this.assertInvariants();
 
-    this.runTask(() =>
+    runTask(() =>
       set(this.context, 'messenger', {
         message: 'hello',
       })
@@ -575,14 +573,14 @@ class DynamicContentTest extends RenderingTestCase {
 
     this.assertStableRerender();
 
-    // this.runTask(() => set(func, 'aProp', 'still a property on a function'));
+    // runTask(() => set(func, 'aProp', 'still a property on a function'));
     // this.assertContent('still a property on a function');
     // this.assertInvariants();
 
     // func = () => {};
     // func.aProp = 'a prop on a new function';
 
-    // this.runTask(() => set(this.context, 'func', func));
+    // runTask(() => set(this.context, 'func', func));
 
     // this.assertContent('a prop on a new function');
     // this.assertInvariants();
@@ -608,11 +606,11 @@ class ContentTestGenerator {
 
           this.assertIsEmpty();
 
-          this.runTask(() => set(this.context, 'value', 'hello'));
+          runTask(() => set(this.context, 'value', 'hello'));
 
           this.assertContent('hello');
 
-          this.runTask(() => set(this.context, 'value', value));
+          runTask(() => set(this.context, 'value', value));
 
           this.assertIsEmpty();
         },
@@ -626,11 +624,11 @@ class ContentTestGenerator {
 
           this.assertStableRerender();
 
-          this.runTask(() => set(this.context, 'value', 'hello'));
+          runTask(() => set(this.context, 'value', 'hello'));
           this.assertContent('hello');
           this.assertInvariants();
 
-          this.runTask(() => set(this.context, 'value', value));
+          runTask(() => set(this.context, 'value', value));
 
           this.assertContent(expected);
           this.assertInvariants();
@@ -710,11 +708,11 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'value', htmlSafe('')));
+      runTask(() => set(this.context, 'value', htmlSafe('')));
 
       this.assertHTML('before <!----> after');
 
-      this.runTask(() => set(this.context, 'value', htmlSafe('hello')));
+      runTask(() => set(this.context, 'value', htmlSafe('hello')));
 
       this.assertHTML('before hello after');
     }
@@ -790,7 +788,7 @@ class TrustedContentTest extends DynamicContentTest {
 
   assertStableRerender() {
     this.takeSnapshot();
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
     super.assertInvariants();
   }
 
@@ -815,19 +813,19 @@ moduleFor(
 
       this.assertContent('<b>Max</b><b>James</b>');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'htmlContent', '<i>M</i><u>a</u><s>x</s>'));
+      runTask(() => set(this.context, 'htmlContent', '<i>M</i><u>a</u><s>x</s>'));
 
       this.assertContent('<i>M</i><u>a</u><s>x</s><b>James</b>');
 
-      this.runTask(() => set(this.context, 'nested.htmlContent', 'Jammie'));
+      runTask(() => set(this.context, 'nested.htmlContent', 'Jammie'));
 
       this.assertContent('<i>M</i><u>a</u><s>x</s>Jammie');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'htmlContent', '<b>Max</b>');
         set(this.context, 'nested', { htmlContent: '<i>James</i>' });
       });
@@ -842,39 +840,39 @@ moduleFor(
 
       this.assertContent('before hello after');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'value', undefined));
+      runTask(() => set(this.context, 'value', undefined));
 
       this.assertContent('before <!----> after');
 
-      this.runTask(() => set(this.context, 'value', 'hello'));
+      runTask(() => set(this.context, 'value', 'hello'));
 
       this.assertContent('before hello after');
 
-      this.runTask(() => set(this.context, 'value', null));
+      runTask(() => set(this.context, 'value', null));
 
       this.assertContent('before <!----> after');
 
-      this.runTask(() => set(this.context, 'value', 'hello'));
+      runTask(() => set(this.context, 'value', 'hello'));
 
       this.assertContent('before hello after');
 
-      this.runTask(() => set(this.context, 'value', ''));
+      runTask(() => set(this.context, 'value', ''));
 
       this.assertContent('before <!----> after');
 
-      this.runTask(() => set(this.context, 'value', 'hello'));
+      runTask(() => set(this.context, 'value', 'hello'));
 
       this.assertContent('before hello after');
 
-      this.runTask(() => set(this.context, 'value', htmlSafe('')));
+      runTask(() => set(this.context, 'value', htmlSafe('')));
 
       this.assertContent('before <!----> after');
 
-      this.runTask(() => set(this.context, 'value', 'hello'));
+      runTask(() => set(this.context, 'value', 'hello'));
 
       this.assertContent('before hello after');
     }
@@ -941,15 +939,15 @@ moduleFor(
       });
       this.assertHTML(ember);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertHTML(ember);
 
-      this.runTask(() => set(this.context, 'framework', 'React'));
+      runTask(() => set(this.context, 'framework', 'React'));
 
       this.assertHTML(react);
 
-      this.runTask(() => set(this.context, 'framework', 'Ember.js'));
+      runTask(() => set(this.context, 'framework', 'Ember.js'));
 
       this.assertHTML(ember);
     }
@@ -961,11 +959,11 @@ moduleFor(
 
       this.assertText('');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('');
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'foo', {
           bar: { baz: { bizz: 'Hey!' } },
         })
@@ -973,11 +971,11 @@ moduleFor(
 
       this.assertText('Hey!');
 
-      this.runTask(() => set(this.context, 'foo', {}));
+      runTask(() => set(this.context, 'foo', {}));
 
       this.assertText('');
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'foo', {
           bar: { baz: { bizz: 'Hello!' } },
         })
@@ -985,7 +983,7 @@ moduleFor(
 
       this.assertText('Hello!');
 
-      this.runTask(() => set(this.context, 'foo', {}));
+      runTask(() => set(this.context, 'foo', {}));
 
       this.assertText('');
     }
@@ -997,11 +995,11 @@ moduleFor(
 
       this.assertText('');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('');
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'foo', {
           bar: false,
         })
@@ -1009,7 +1007,7 @@ moduleFor(
 
       this.assertText('');
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'foo', {
           bar: 'Haha',
         })
@@ -1017,7 +1015,7 @@ moduleFor(
 
       this.assertText('');
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'foo', {
           bar: null,
         })
@@ -1025,7 +1023,7 @@ moduleFor(
 
       this.assertText('');
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'foo', {
           bar: undefined,
         })
@@ -1033,7 +1031,7 @@ moduleFor(
 
       this.assertText('');
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'foo', {
           bar: 1,
         })
@@ -1041,7 +1039,7 @@ moduleFor(
 
       this.assertText('');
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'foo', {
           bar: { baz: { bizz: 'Hello!' } },
         })
@@ -1049,7 +1047,7 @@ moduleFor(
 
       this.assertText('Hello!');
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'foo', {
           bar: true,
         })
@@ -1071,7 +1069,7 @@ moduleFor(
         attrs: { href: 'http://example.com' },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertElement(this.firstChild, {
         tagName: 'a',
@@ -1079,7 +1077,7 @@ moduleFor(
         attrs: { href: 'http://example.com' },
       });
 
-      this.runTask(() => set(this.context, 'model.url', 'http://linkedin.com'));
+      runTask(() => set(this.context, 'model.url', 'http://linkedin.com'));
 
       this.assertElement(this.firstChild, {
         tagName: 'a',
@@ -1087,7 +1085,7 @@ moduleFor(
         attrs: { href: 'http://linkedin.com' },
       });
 
-      this.runTask(() => set(this.context, 'model', { url: 'http://example.com' }));
+      runTask(() => set(this.context, 'model', { url: 'http://example.com' }));
 
       this.assertElement(this.firstChild, {
         tagName: 'a',
@@ -1107,7 +1105,7 @@ moduleFor(
         attrs: { class: classes('foo-bar') },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1115,11 +1113,11 @@ moduleFor(
         attrs: { class: classes('foo-bar') },
       });
 
-      this.runTask(() => set(this.context, 'fooBar', false));
+      runTask(() => set(this.context, 'fooBar', false));
 
       this.assertElement(this.firstChild, { tagName: 'div', content: 'hello' });
 
-      this.runTask(() => set(this.context, 'fooBar', true));
+      runTask(() => set(this.context, 'fooBar', true));
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1139,7 +1137,7 @@ moduleFor(
         attrs: { class: classes('foo-bar') },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1147,11 +1145,11 @@ moduleFor(
         attrs: { class: classes('foo-bar') },
       });
 
-      this.runTask(() => set(this.context, 'fooBar', false));
+      runTask(() => set(this.context, 'fooBar', false));
 
       assert.equal(this.firstChild.className, '');
 
-      this.runTask(() => set(this.context, 'fooBar', true));
+      runTask(() => set(this.context, 'fooBar', true));
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1173,7 +1171,7 @@ moduleFor(
         attrs: { class: classes('foo bar baz') },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1181,7 +1179,7 @@ moduleFor(
         attrs: { class: classes('foo bar baz') },
       });
 
-      this.runTask(() => set(this.context, 'model.classes', 'fizz bizz'));
+      runTask(() => set(this.context, 'model.classes', 'fizz bizz'));
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1189,7 +1187,7 @@ moduleFor(
         attrs: { class: classes('fizz bizz') },
       });
 
-      this.runTask(() => set(this.context, 'model', { classes: 'foo bar baz' }));
+      runTask(() => set(this.context, 'model', { classes: 'foo bar baz' }));
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1211,7 +1209,7 @@ moduleFor(
         attrs: { class: classes('foo') },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1219,7 +1217,7 @@ moduleFor(
         attrs: { class: classes('foo') },
       });
 
-      this.runTask(() => set(this.context, 'model.foo', 'fizz'));
+      runTask(() => set(this.context, 'model.foo', 'fizz'));
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1227,7 +1225,7 @@ moduleFor(
         attrs: { class: classes('fizz') },
       });
 
-      this.runTask(() => set(this.context, 'model', { foo: 'foo' }));
+      runTask(() => set(this.context, 'model', { foo: 'foo' }));
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1249,7 +1247,7 @@ moduleFor(
         attrs: { class: classes('foo') },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1257,7 +1255,7 @@ moduleFor(
         attrs: { class: classes('foo') },
       });
 
-      this.runTask(() => set(this.context, 'model.foo', 'fizz'));
+      runTask(() => set(this.context, 'model.foo', 'fizz'));
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1265,7 +1263,7 @@ moduleFor(
         attrs: { class: classes('fizz') },
       });
 
-      this.runTask(() => set(this.context, 'model', { foo: 'foo' }));
+      runTask(() => set(this.context, 'model', { foo: 'foo' }));
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1287,7 +1285,7 @@ moduleFor(
         attrs: { class: classes('foo bar baz') },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1295,7 +1293,7 @@ moduleFor(
         attrs: { class: classes('foo bar baz') },
       });
 
-      this.runTask(() => set(this.context, 'model.classes', 'fizz bizz'));
+      runTask(() => set(this.context, 'model.classes', 'fizz bizz'));
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1303,7 +1301,7 @@ moduleFor(
         attrs: { class: classes('fizz bizz') },
       });
 
-      this.runTask(() => set(this.context, 'model', { classes: 'foo bar baz' }));
+      runTask(() => set(this.context, 'model', { classes: 'foo bar baz' }));
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1327,7 +1325,7 @@ moduleFor(
         attrs: { class: classes('foo bar bizz') },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1335,7 +1333,7 @@ moduleFor(
         attrs: { class: classes('foo bar bizz') },
       });
 
-      this.runTask(() => set(this.context, 'model.foo', 'fizz'));
+      runTask(() => set(this.context, 'model.foo', 'fizz'));
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1343,7 +1341,7 @@ moduleFor(
         attrs: { class: classes('fizz bar bizz') },
       });
 
-      this.runTask(() => set(this.context, 'model.bar', null));
+      runTask(() => set(this.context, 'model.bar', null));
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1351,7 +1349,7 @@ moduleFor(
         attrs: { class: classes('fizz bizz') },
       });
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'model', {
           foo: 'foo',
           bar: 'bar',
@@ -1385,7 +1383,7 @@ moduleFor(
         attrs: { class: classes('large') },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1393,7 +1391,7 @@ moduleFor(
         attrs: { class: classes('large') },
       });
 
-      this.runTask(() => set(this.context, 'model.hasShape', true));
+      runTask(() => set(this.context, 'model.hasShape', true));
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1401,7 +1399,7 @@ moduleFor(
         attrs: { class: classes('large round') },
       });
 
-      this.runTask(() => set(this.context, 'model.hasSize', false));
+      runTask(() => set(this.context, 'model.hasSize', false));
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1409,7 +1407,7 @@ moduleFor(
         attrs: { class: classes('round') },
       });
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'model', {
           size: 'large',
           hasSize: true,
@@ -1444,7 +1442,7 @@ moduleFor(
         attrs: { class: classes('foo bar fizz baz') },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1452,7 +1450,7 @@ moduleFor(
         attrs: { class: classes('foo bar fizz baz') },
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'model.foo', null);
         set(this.context, 'model.fizz', null);
       });
@@ -1463,7 +1461,7 @@ moduleFor(
         attrs: { class: classes('bar baz') },
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'model', {
           foo: 'foo',
           bar: 'bar',
@@ -1493,7 +1491,7 @@ moduleFor(
         attrs: { class: 'foo  static   bar' },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1501,7 +1499,7 @@ moduleFor(
         attrs: { class: 'foo  static   bar' },
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'model.bar', null);
       });
 
@@ -1511,7 +1509,7 @@ moduleFor(
         attrs: { class: 'foo  static   ' },
       });
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'model', {
           foo: 'foo',
           bar: 'bar',
@@ -1570,7 +1568,7 @@ moduleFor(
         attrs: { style: 'width: 60px;' },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1578,7 +1576,7 @@ moduleFor(
         attrs: { style: 'width: 60px;' },
       });
 
-      this.runTask(() => set(this.context, 'model.style', 'height: 60px;'));
+      runTask(() => set(this.context, 'model.style', 'height: 60px;'));
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1586,7 +1584,7 @@ moduleFor(
         attrs: { style: 'height: 60px;' },
       });
 
-      this.runTask(() => set(this.context, 'model.style', null));
+      runTask(() => set(this.context, 'model.style', null));
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1594,7 +1592,7 @@ moduleFor(
         attrs: {},
       });
 
-      this.runTask(() => set(this.context, 'model', { style: 'width: 60px;' }));
+      runTask(() => set(this.context, 'model', { style: 'width: 60px;' }));
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1616,7 +1614,7 @@ moduleFor(
         attrs: { style: 'width: 60px;' },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1624,7 +1622,7 @@ moduleFor(
         attrs: { style: 'width: 60px;' },
       });
 
-      this.runTask(() => set(this.context, 'model.style', 'height: 60px;'));
+      runTask(() => set(this.context, 'model.style', 'height: 60px;'));
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1632,7 +1630,7 @@ moduleFor(
         attrs: { style: 'height: 60px;' },
       });
 
-      this.runTask(() => set(this.context, 'model', { style: 'width: 60px;' }));
+      runTask(() => set(this.context, 'model', { style: 'width: 60px;' }));
 
       this.assertElement(this.firstChild, {
         tagName: 'div',

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, runTask } from 'internal-test-helpers';
 
 import { Object as EmberObject } from '@ember/-internals/runtime';
 import { set, setProperties, computed } from '@ember/-internals/metal';
@@ -248,7 +248,7 @@ if (GLIMMER_CUSTOM_COMPONENT_MANAGER) {
 
         this.assertHTML(`<p>goodbye world </p>`);
 
-        this.runTask(() => set(customContext, 'greeting', 'sayonara'));
+        runTask(() => set(customContext, 'greeting', 'sayonara'));
 
         this.assertHTML(`<p>sayonara world </p>`);
       }
@@ -295,7 +295,7 @@ if (GLIMMER_CUSTOM_COMPONENT_MANAGER) {
 
         this.assertHTML(`<p>Yehuda Katz</p>`);
 
-        this.runTask(() =>
+        runTask(() =>
           setProperties(this.context, {
             firstName: 'Chad',
             lastName: 'Hietala',
@@ -348,7 +348,7 @@ if (GLIMMER_CUSTOM_COMPONENT_MANAGER) {
 
         this.assertHTML(`<p>hello world</p>`);
 
-        this.runTask(() => this.context.set('show', false));
+        runTask(() => this.context.set('show', false));
 
         this.assertText('');
 
@@ -407,7 +407,7 @@ if (GLIMMER_CUSTOM_COMPONENT_MANAGER) {
         this.assertHTML(`<p>hello world</p>`);
         assert.verifySteps(['createComponent', 'getContext', 'didCreateComponent']);
 
-        this.runTask(() => this.context.set('name', 'max'));
+        runTask(() => this.context.set('name', 'max'));
         this.assertHTML(`<p>hello max</p>`);
         assert.verifySteps(['updateComponent', 'didUpdateComponent']);
       }
@@ -491,7 +491,7 @@ if (GLIMMER_CUSTOM_COMPONENT_MANAGER) {
 
           this.assertHTML(`<p>Yehuda Katz</p>`);
 
-          this.runTask(() =>
+          runTask(() =>
             setProperties(this.context, {
               firstName: 'Chad',
               lastName: 'Hietala',
@@ -558,7 +558,7 @@ if (GLIMMER_CUSTOM_COMPONENT_MANAGER) {
           this.assertHTML(`<p data-test="foo">Hello world!</p>`);
           assert.verifySteps(['createComponent', 'getContext', 'didCreateComponent']);
 
-          this.runTask(() => this.context.set('value', 'bar'));
+          runTask(() => this.context.set('value', 'bar'));
           assert.verifySteps(['didUpdateComponent']);
         }
       }

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, runTask } from 'internal-test-helpers';
 
 import { Object as EmberObject } from '@ember/-internals/runtime';
 import { GLIMMER_MODIFIER_MANAGER } from '@ember/canary-features';
@@ -96,11 +96,11 @@ if (GLIMMER_MODIFIER_MANAGER) {
         });
         this.assertHTML(`<h1>hello world</h1>`);
 
-        this.runTask(() => set(this.context, 'truthy', 'true'));
+        runTask(() => set(this.context, 'truthy', 'true'));
 
-        this.runTask(() => set(this.context, 'truthy', false));
+        runTask(() => set(this.context, 'truthy', false));
 
-        this.runTask(() => set(this.context, 'truthy', true));
+        runTask(() => set(this.context, 'truthy', true));
       }
 
       '@test associates manager even through an inheritance structure'(assert) {
@@ -176,7 +176,7 @@ if (GLIMMER_MODIFIER_MANAGER) {
         });
         this.assertHTML(`<h1>hello world</h1>`);
 
-        this.runTask(() => set(this.context, 'truthy', 'true'));
+        runTask(() => set(this.context, 'truthy', 'true'));
       }
     }
   );

--- a/packages/@ember/-internals/glimmer/tests/integration/event-dispatcher-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/event-dispatcher-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
 
 import { Component } from '../utils/helpers';
 import { getCurrentRunLoop, run } from '@ember/runloop';
@@ -37,7 +37,7 @@ moduleFor(
 
       this.render(`{{x-foo}}`);
 
-      this.runTask(() => this.$('#is-done').trigger('change'));
+      runTask(() => this.$('#is-done').trigger('change'));
       assert.ok(receivedEvent, 'change event was triggered');
       assert.strictEqual(receivedEvent.target, this.$('#is-done')[0]);
     }
@@ -56,7 +56,7 @@ moduleFor(
 
       this.render(`{{x-bar}}`);
 
-      this.runTask(() => this.$('#is-done').trigger('click'));
+      runTask(() => this.$('#is-done').trigger('click'));
       assert.ok(receivedEvent, 'change event was triggered');
       assert.strictEqual(receivedEvent.target, this.$('#is-done')[0]);
     }
@@ -75,7 +75,7 @@ moduleFor(
 
       this.render(`{{x-bar}}`);
 
-      this.runTask(() => this.$('#is-done').trigger('click'));
+      runTask(() => this.$('#is-done').trigger('click'));
       assert.ok(receivedEvent, 'change event was triggered');
       assert.strictEqual(receivedEvent.target, this.$('#is-done')[0]);
     }
@@ -101,7 +101,7 @@ moduleFor(
 
       this.render(`{{#x-foo}}{{x-bar}}{{/x-foo}}`);
 
-      this.runTask(() => this.$('#is-done').trigger('change'));
+      runTask(() => this.$('#is-done').trigger('change'));
       assert.ok(receivedEvent, 'change event was triggered');
       assert.strictEqual(receivedEvent.target, this.$('#is-done')[0]);
     }
@@ -129,7 +129,7 @@ moduleFor(
 
       this.render(`{{#x-foo}}{{x-bar}}{{/x-foo}}`);
 
-      this.runTask(() => this.$('#is-done').trigger('change'));
+      runTask(() => this.$('#is-done').trigger('change'));
       assert.notOk(hasReceivedEvent, 'change event has not been received');
     }
 
@@ -171,7 +171,7 @@ moduleFor(
       let inner = this.$('#inner')[0];
 
       // mouse moves over #outer
-      this.runTask(() => {
+      runTask(() => {
         this.$(outer).trigger('mouseenter', { canBubble: false, relatedTarget: parent });
         this.$(outer).trigger('mouseover', { relatedTarget: parent });
         this.$(parent).trigger('mouseout', { relatedTarget: outer });
@@ -180,21 +180,21 @@ moduleFor(
       assert.strictEqual(receivedEnterEvents[0].target, outer);
 
       // mouse moves over #inner
-      this.runTask(() => {
+      runTask(() => {
         this.$(inner).trigger('mouseover', { relatedTarget: outer });
         this.$(outer).trigger('mouseout', { relatedTarget: inner });
       });
       assert.equal(receivedEnterEvents.length, 1, 'mouseenter event was not triggered again');
 
       // mouse moves out of #inner
-      this.runTask(() => {
+      runTask(() => {
         this.$(inner).trigger('mouseout', { relatedTarget: outer });
         this.$(outer).trigger('mouseover', { relatedTarget: inner });
       });
       assert.equal(receivedLeaveEvents.length, 0, 'mouseleave event was not triggered');
 
       // mouse moves out of #outer
-      this.runTask(() => {
+      runTask(() => {
         this.$(outer).trigger('mouseleave', { canBubble: false, relatedTarget: parent });
         this.$(outer).trigger('mouseout', { relatedTarget: parent });
         this.$(parent).trigger('mouseover', { relatedTarget: outer });
@@ -227,7 +227,7 @@ moduleFor(
       let inner = this.$('#inner')[0];
 
       // mouse moves over #outer
-      this.runTask(() => {
+      runTask(() => {
         this.$(outer).trigger('mouseenter', { canBubble: false, relatedTarget: parent });
         this.$(outer).trigger('mouseover', { relatedTarget: parent });
         this.$(parent).trigger('mouseout', { relatedTarget: outer });
@@ -236,21 +236,21 @@ moduleFor(
       assert.strictEqual(receivedEnterEvents[0].target, outer);
 
       // mouse moves over #inner
-      this.runTask(() => {
+      runTask(() => {
         this.$(inner).trigger('mouseover', { relatedTarget: outer });
         this.$(outer).trigger('mouseout', { relatedTarget: inner });
       });
       assert.equal(receivedEnterEvents.length, 1, 'mouseenter event was not triggered again');
 
       // mouse moves out of #inner
-      this.runTask(() => {
+      runTask(() => {
         this.$(inner).trigger('mouseout', { relatedTarget: outer });
         this.$(outer).trigger('mouseover', { relatedTarget: inner });
       });
       assert.equal(receivedLeaveEvents.length, 0, 'mouseleave event was not triggered');
 
       // mouse moves out of #outer
-      this.runTask(() => {
+      runTask(() => {
         this.$(outer).trigger('mouseleave', { canBubble: false, relatedTarget: parent });
         this.$(outer).trigger('mouseout', { relatedTarget: parent });
         this.$(parent).trigger('mouseover', { relatedTarget: outer });
@@ -282,7 +282,7 @@ moduleFor(
       let inner = this.$('#inner')[0];
 
       // we replicate fast mouse movement, where mouseover is fired directly in #inner, skipping #outer
-      this.runTask(() => {
+      runTask(() => {
         this.$(outer).trigger('mouseenter', { canBubble: false, relatedTarget: parent });
         this.$(inner).trigger('mouseover', { relatedTarget: parent });
         this.$(parent).trigger('mouseout', { relatedTarget: inner });
@@ -291,7 +291,7 @@ moduleFor(
       assert.strictEqual(receivedEnterEvents[0].target, inner);
 
       // mouse moves out of #outer
-      this.runTask(() => {
+      runTask(() => {
         this.$(outer).trigger('mouseleave', { canBubble: false, relatedTarget: parent });
         this.$(inner).trigger('mouseout', { relatedTarget: parent });
         this.$(parent).trigger('mouseover', { relatedTarget: inner });
@@ -330,7 +330,7 @@ moduleFor(
       let inner = this.$('#inner')[0];
 
       // we replicate fast mouse movement, where mouseover is fired directly in #inner, skipping #outer
-      this.runTask(() => {
+      runTask(() => {
         this.$(outer).trigger('mouseenter', { canBubble: false, relatedTarget: parent });
         this.$(inner).trigger('mouseover', { relatedTarget: parent });
         this.$(parent).trigger('mouseout', { relatedTarget: inner });
@@ -339,7 +339,7 @@ moduleFor(
       assert.strictEqual(receivedEnterEvents[0].target, inner);
 
       // mouse moves out of #inner
-      this.runTask(() => {
+      runTask(() => {
         this.$(outer).trigger('mouseleave', { canBubble: false, relatedTarget: parent });
         this.$(inner).trigger('mouseout', { relatedTarget: parent });
         this.$(parent).trigger('mouseover', { relatedTarget: inner });
@@ -524,7 +524,7 @@ if (jQueryDisabled) {
 
         this.render(`{{x-foo}}`);
 
-        this.runTask(() => this.$('#foo').click());
+        runTask(() => this.$('#foo').click());
         assert.ok(receivedEvent, 'click event was triggered');
         assert.notOk(receivedEvent.originalEvent, 'event is not a jQuery.Event');
       }
@@ -556,7 +556,7 @@ if (jQueryDisabled) {
 
         this.render(`{{x-foo}}`);
 
-        this.runTask(() => this.$('#foo').click());
+        runTask(() => this.$('#foo').click());
         assert.ok(receivedEvent, 'click event was triggered');
         assert.ok(receivedEvent instanceof jQuery.Event, 'event is a jQuery.Event');
       }
@@ -577,7 +577,7 @@ if (jQueryDisabled) {
 
         this.render(`{{x-foo}}`);
 
-        this.runTask(() => this.$('#foo').click());
+        runTask(() => this.$('#foo').click());
         expectDeprecation(() => {
           let { originalEvent } = receivedEvent;
           assert.ok(originalEvent, 'jQuery event has originalEvent property');
@@ -599,7 +599,7 @@ if (jQueryDisabled) {
 
         this.render(`{{x-foo}}`);
 
-        this.runTask(() => this.$('#foo').click());
+        runTask(() => this.$('#foo').click());
         expectNoDeprecation(() => {
           receivedEvent.stopPropagation();
           receivedEvent.stopImmediatePropagation();
@@ -626,7 +626,7 @@ if (jQueryDisabled) {
 
         this.render(`{{x-foo}}`);
 
-        this.runTask(() => this.$('#foo').click());
+        runTask(() => this.$('#foo').click());
         expectNoDeprecation(() => {
           let { originalEvent } = receivedEvent;
           assert.ok(originalEvent, 'jQuery event has originalEvent property');
@@ -652,7 +652,7 @@ if (jQueryDisabled) {
 
         this.render(`{{x-foo}}`);
 
-        this.runTask(() => this.$('#foo').click());
+        runTask(() => this.$('#foo').click());
         expectNoDeprecation(() => {
           let { __originalEvent: originalEvent } = receivedEvent;
           assert.ok(originalEvent, 'jQuery event has __originalEvent property');

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/-class-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/-class-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor, classes } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, classes, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
 
@@ -16,21 +16,21 @@ moduleFor(
         attrs: { class: classes('some-truth ember-view') },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
         attrs: { class: classes('some-truth ember-view') },
       });
 
-      this.runTask(() => set(this.context, 'someTruth', false));
+      runTask(() => set(this.context, 'someTruth', false));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
         attrs: { class: classes('ember-view') },
       });
 
-      this.runTask(() => set(this.context, 'someTruth', true));
+      runTask(() => set(this.context, 'someTruth', true));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -51,21 +51,21 @@ moduleFor(
         attrs: { class: classes('some-truth ember-view') },
       });
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
         attrs: { class: classes('some-truth ember-view') },
       });
 
-      this.runTask(() => set(this.context, 'model.someTruth', false));
+      runTask(() => set(this.context, 'model.someTruth', false));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
         attrs: { class: classes('ember-view') },
       });
 
-      this.runTask(() => set(this.context, 'model', { someTruth: true }));
+      runTask(() => set(this.context, 'model', { someTruth: true }));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/array-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/array-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor, strip } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, strip, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
 import { EMBER_GLIMMER_ARRAY_HELPER } from '@ember/canary-features';
@@ -51,10 +51,10 @@ if (EMBER_GLIMMER_ARRAY_HELPER) {
 
         this.assertStableRerender();
 
-        this.runTask(() => set(this.context, 'personOne', 'Yehuda'));
+        runTask(() => set(this.context, 'personOne', 'Yehuda'));
         this.assertText('Yehuda');
 
-        this.runTask(() => set(this.context, 'personOne', 'Tom'));
+        runTask(() => set(this.context, 'personOne', 'Tom'));
         this.assertText('Tom');
       }
 
@@ -75,15 +75,15 @@ if (EMBER_GLIMMER_ARRAY_HELPER) {
 
         this.assertStableRerender();
 
-        this.runTask(() => set(this.context, 'personOne', 'Sergio'));
+        runTask(() => set(this.context, 'personOne', 'Sergio'));
 
         this.assertText('Sergio,Yehuda,');
 
-        this.runTask(() => set(this.context, 'personTwo', 'Tom'));
+        runTask(() => set(this.context, 'personTwo', 'Tom'));
 
         this.assertText('Sergio,Tom,');
 
-        this.runTask(() => {
+        runTask(() => {
           set(this.context, 'personOne', 'Tom');
           set(this.context, 'personTwo', 'Yehuda');
         });
@@ -111,15 +111,15 @@ if (EMBER_GLIMMER_ARRAY_HELPER) {
 
         this.assertStableRerender();
 
-        this.runTask(() => set(this.context, 'personOne', 'Chad'));
+        runTask(() => set(this.context, 'personOne', 'Chad'));
 
         this.assertText('List:Chad,Yehuda,');
 
-        this.runTask(() => set(this.context, 'personTwo', 'Balint'));
+        runTask(() => set(this.context, 'personTwo', 'Balint'));
 
         this.assertText('List:Chad,Balint,');
 
-        this.runTask(() => {
+        runTask(() => {
           set(this.context, 'personOne', 'Tom');
           set(this.context, 'personTwo', 'Yehuda');
         });
@@ -153,15 +153,15 @@ if (EMBER_GLIMMER_ARRAY_HELPER) {
 
         this.assertStableRerender();
 
-        this.runTask(() => set(fooBarInstance, 'model.personOne', 'Godfrey'));
+        runTask(() => set(fooBarInstance, 'model.personOne', 'Godfrey'));
 
         this.assertText('Godfrey');
 
-        this.runTask(() => set(fooBarInstance, 'model', { personOne: 'Chad' }));
+        runTask(() => set(fooBarInstance, 'model', { personOne: 'Chad' }));
 
         this.assertText('Chad');
 
-        this.runTask(() => set(fooBarInstance, 'model.personOne', 'Godfrey'));
+        runTask(() => set(fooBarInstance, 'model.personOne', 'Godfrey'));
 
         this.assertText('Godfrey');
       }
@@ -196,14 +196,14 @@ if (EMBER_GLIMMER_ARRAY_HELPER) {
 
         this.assertStableRerender();
 
-        this.runTask(() => {
+        runTask(() => {
           set(fooBarInstance, 'model.personOne', 'Godfrey');
           set(this.context, 'model.personTwo', 'Yehuda');
         });
 
         this.assertText('Godfrey,Yehuda,');
 
-        this.runTask(() => {
+        runTask(() => {
           set(fooBarInstance, 'model', { personOne: 'Chad' });
           set(this.context, 'model', { personTwo: 'Tom' });
         });
@@ -228,11 +228,11 @@ if (EMBER_GLIMMER_ARRAY_HELPER) {
 
         this.assertStableRerender();
 
-        this.runTask(() => set(this.context, 'personTwo', 'Godfrey'));
+        runTask(() => set(this.context, 'personTwo', 'Godfrey'));
 
         this.assertText('Tom,Godfrey,');
 
-        this.runTask(() => set(this.context, 'personTwo', 'Chad'));
+        runTask(() => set(this.context, 'personTwo', 'Chad'));
 
         this.assertText('Tom,Chad,');
       }
@@ -258,7 +258,7 @@ if (EMBER_GLIMMER_ARRAY_HELPER) {
 
         let firstArray = fooBarInstance.people;
 
-        this.runTask(() => set(this.context, 'personTwo', 'Godfrey'));
+        runTask(() => set(this.context, 'personTwo', 'Godfrey'));
 
         this.assert.ok(
           firstArray !== fooBarInstance.people,
@@ -278,11 +278,11 @@ if (EMBER_GLIMMER_ARRAY_HELPER) {
 
         this.assert.deepEqual(captured, ['Tom', 'Godfrey']);
 
-        this.runTask(() => set(this.context, 'personTwo', 'Robert'));
+        runTask(() => set(this.context, 'personTwo', 'Robert'));
 
         this.assert.deepEqual(captured, ['Tom', 'Robert']);
 
-        this.runTask(() => set(this.context, 'personTwo', 'Godfrey'));
+        runTask(() => set(this.context, 'personTwo', 'Godfrey'));
 
         this.assert.deepEqual(captured, ['Tom', 'Godfrey']);
       }

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/closure-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/closure-action-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor, strip } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, strip, runTask } from 'internal-test-helpers';
 
 import {
   subscribe as instrumentationSubscribe,
@@ -64,7 +64,7 @@ if (EMBER_IMPROVED_INSTRUMENTATION) {
 
         this.render(`{{outer-component}}`);
 
-        this.runTask(() => {
+        runTask(() => {
           this.$('#instrument-button').trigger('click');
         });
 
@@ -119,7 +119,7 @@ if (EMBER_IMPROVED_INSTRUMENTATION) {
 
         this.render(`{{outer-component}}`);
 
-        this.runTask(() => {
+        runTask(() => {
           this.$('#instrument-button').trigger('click');
         });
 
@@ -170,7 +170,7 @@ if (EMBER_IMPROVED_INSTRUMENTATION) {
 
         this.render(`{{outer-component}}`);
 
-        this.runTask(() => {
+        runTask(() => {
           this.$('#instrument-button').trigger('click');
         });
 
@@ -214,7 +214,7 @@ moduleFor(
 
       this.render('{{outer-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         component.fireAction();
       });
 
@@ -298,7 +298,7 @@ moduleFor(
 
       this.render('{{outer-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         innerComponent.fireAction();
       });
 
@@ -343,7 +343,7 @@ moduleFor(
 
       this.render('{{outer-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         innerComponent.fireAction();
       });
 
@@ -390,7 +390,7 @@ moduleFor(
 
       this.render('{{outer-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         innerComponent.fireAction();
       });
 
@@ -439,7 +439,7 @@ moduleFor(
 
       this.render('{{outer-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         innerComponent.fireAction();
       });
 
@@ -486,17 +486,17 @@ moduleFor(
 
       this.render('{{outer-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         innerComponent.fireAction();
       });
 
       this.assert.strictEqual(actualArg, '', 'action has the correct first arg');
 
-      this.runTask(() => {
+      runTask(() => {
         outerComponent.set('value', value);
       });
 
-      this.runTask(() => {
+      runTask(() => {
         innerComponent.fireAction();
       });
 
@@ -549,12 +549,12 @@ moduleFor(
 
       this.render('{{outer-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         outerComponent.set('first', first);
         outerComponent.set('second', second);
       });
 
-      this.runTask(() => {
+      runTask(() => {
         innerComponent.fireAction();
       });
 
@@ -599,7 +599,7 @@ moduleFor(
 
       this.render('{{outer-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         innerComponent.fireAction();
       });
 
@@ -642,7 +642,7 @@ moduleFor(
 
       this.render('{{outer-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         innerComponent.fireAction();
       });
 
@@ -692,7 +692,7 @@ moduleFor(
 
       this.render('{{outer-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         innerComponent.fireAction();
       });
 
@@ -787,7 +787,7 @@ moduleFor(
 
       this.render('{{outer-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         innerComponent.fireAction();
       });
 
@@ -835,7 +835,7 @@ moduleFor(
 
       this.render('{{outer-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         innerComponent.fireAction();
       });
 
@@ -878,7 +878,7 @@ moduleFor(
 
       this.render('{{outer-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         innerComponent.fireAction();
       });
 
@@ -922,7 +922,7 @@ moduleFor(
 
       this.render('{{outer-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         innerComponent.fireAction();
       });
 
@@ -989,7 +989,7 @@ moduleFor(
 
       this.render('{{outer-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         actualReturnedValue = innerComponent.fireAction();
       });
 
@@ -1032,7 +1032,7 @@ moduleFor(
 
       this.render('{{outer-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         innerComponent.fireAction();
       });
 
@@ -1078,7 +1078,7 @@ moduleFor(
 
       this.render('{{outer-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         innerComponent.fireAction();
       });
 
@@ -1109,25 +1109,25 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('button').click();
       });
 
       this.assertText('Clicked!');
 
-      this.runTask(() => {
+      runTask(() => {
         component.set('label', 'Dun clicked');
       });
 
       this.assertText('Dun clicked');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('button').click();
       });
 
       this.assertText('Clicked!');
 
-      this.runTask(() => {
+      runTask(() => {
         component.set('label', undefined);
       });
 
@@ -1191,31 +1191,31 @@ moduleFor(
 
       assert.equal(didReceiveAttrsFired, 3);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('clicked: 0; foo: 1');
 
       assert.equal(didReceiveAttrsFired, 3);
 
-      this.runTask(() => set(this.context, 'foo', 2));
+      runTask(() => set(this.context, 'foo', 2));
 
       this.assertText('clicked: 0; foo: 2');
 
       assert.equal(didReceiveAttrsFired, 3);
 
-      this.runTask(() => this.$('#string-action').click());
+      runTask(() => this.$('#string-action').click());
 
       this.assertText('clicked: 1; foo: 2');
 
       assert.equal(didReceiveAttrsFired, 3);
 
-      this.runTask(() => this.$('#function-action').click());
+      runTask(() => this.$('#function-action').click());
 
       this.assertText('clicked: 2; foo: 2');
 
       assert.equal(didReceiveAttrsFired, 3);
 
-      this.runTask(() =>
+      runTask(() =>
         set(outer, 'onClick', function() {
           outer.incrementProperty('clicked');
         })
@@ -1225,13 +1225,13 @@ moduleFor(
 
       assert.equal(didReceiveAttrsFired, 3);
 
-      this.runTask(() => this.$('#function-action').click());
+      runTask(() => this.$('#function-action').click());
 
       this.assertText('clicked: 3; foo: 2');
 
       assert.equal(didReceiveAttrsFired, 3);
 
-      this.runTask(() => this.$('#mut-action').click());
+      runTask(() => this.$('#mut-action').click());
 
       this.assertText('clicked: 4; foo: 2');
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/concat-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/concat-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
 
@@ -17,19 +17,19 @@ moduleFor(
 
       this.assertText('onetwo');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('onetwo');
 
-      this.runTask(() => set(this.context, 'model.first', 'three'));
+      runTask(() => set(this.context, 'model.first', 'three'));
 
       this.assertText('threetwo');
 
-      this.runTask(() => set(this.context, 'model.second', 'four'));
+      runTask(() => set(this.context, 'model.second', 'four'));
 
       this.assertText('threefour');
 
-      this.runTask(() => set(this.context, 'model', { first: 'one', second: 'two' }));
+      runTask(() => set(this.context, 'model', { first: 'one', second: 'two' }));
 
       this.assertText('onetwo');
     }
@@ -49,22 +49,22 @@ moduleFor(
 
       this.assertText('onetwothreefour');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('onetwothreefour');
 
-      this.runTask(() => set(this.context, 'model.first', 'five'));
+      runTask(() => set(this.context, 'model.first', 'five'));
 
       this.assertText('fivetwothreefour');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'model.second', 'six');
         set(this.context, 'model.third', 'seven');
       });
 
       this.assertText('fivesixsevenfour');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'model', {
           first: 'one',
           second: 'two',
@@ -91,15 +91,15 @@ moduleFor(
 
       this.assertText('Truthy!');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Truthy!');
 
-      this.runTask(() => set(this.context, 'model.first', 'three'));
+      runTask(() => set(this.context, 'model.first', 'three'));
 
       this.assertText('False');
 
-      this.runTask(() => set(this.context, 'model', { first: 'one', second: 'two' }));
+      runTask(() => set(this.context, 'model', { first: 'one', second: 'two' }));
 
       this.assertText('Truthy!');
     }

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
@@ -1,6 +1,6 @@
 /* globals EmberDev */
 
-import { RenderingTestCase, moduleFor, runDestroy } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, runDestroy, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
 
@@ -22,7 +22,7 @@ moduleFor(
 
       this.assertText('hello | hello world');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('hello | hello world');
     }
@@ -42,11 +42,11 @@ moduleFor(
 
       this.assertText('');
 
-      this.runTask(() => set(this.context, 'hello', { world: 'hello world!' }));
+      runTask(() => set(this.context, 'hello', { world: 'hello world!' }));
 
       this.assertText('hello world!');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'hello', {
           world: '',
         });
@@ -72,7 +72,7 @@ moduleFor(
 
       this.assertText('hello | hello world');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('hello | hello world');
     }
@@ -110,11 +110,11 @@ moduleFor(
 
       this.assertText('1');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('1');
 
-      this.runTask(() => helper.recompute());
+      runTask(() => helper.recompute());
 
       this.assertText('2');
 
@@ -144,11 +144,11 @@ moduleFor(
 
       this.assertText('1');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('1');
 
-      this.runTask(() => helper.recompute());
+      runTask(() => helper.recompute());
 
       this.assertText('2');
 
@@ -195,19 +195,19 @@ moduleFor(
 
       assert.strictEqual(computeCount, 1, 'compute is called exactly 1 time');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('bob-value');
 
       assert.strictEqual(computeCount, 1, 'compute is called exactly 1 time');
 
-      this.runTask(() => set(this.context, 'model.name', 'sal'));
+      runTask(() => set(this.context, 'model.name', 'sal'));
 
       this.assertText('sal-value');
 
       assert.strictEqual(computeCount, 2, 'compute is called exactly 2 times');
 
-      this.runTask(() => set(this.context, 'model', { name: 'bob' }));
+      runTask(() => set(this.context, 'model', { name: 'bob' }));
 
       this.assertText('bob-value');
 
@@ -237,19 +237,19 @@ moduleFor(
 
       assert.strictEqual(computeCount, 1, 'compute is called exactly 1 time');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('bob-value');
 
       assert.strictEqual(computeCount, 1, 'compute is called exactly 1 time');
 
-      this.runTask(() => set(this.context, 'model.name', 'sal'));
+      runTask(() => set(this.context, 'model.name', 'sal'));
 
       this.assertText('sal-value');
 
       assert.strictEqual(computeCount, 2, 'compute is called exactly 2 times');
 
-      this.runTask(() => set(this.context, 'model', { name: 'bob' }));
+      runTask(() => set(this.context, 'model', { name: 'bob' }));
 
       this.assertText('bob-value');
 
@@ -271,19 +271,19 @@ moduleFor(
 
       this.assertText('params: ["bob","rich"], hash: {"first":42,"last":"sam"}');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('params: ["bob","rich"], hash: {"first":42,"last":"sam"}');
 
-      this.runTask(() => set(this.context, 'model.name', 'sal'));
+      runTask(() => set(this.context, 'model.name', 'sal'));
 
       this.assertText('params: ["sal","rich"], hash: {"first":42,"last":"sam"}');
 
-      this.runTask(() => set(this.context, 'model.age', 28));
+      runTask(() => set(this.context, 'model.age', 28));
 
       this.assertText('params: ["sal","rich"], hash: {"first":28,"last":"sam"}');
 
-      this.runTask(() => set(this.context, 'model', { name: 'bob', age: 42 }));
+      runTask(() => set(this.context, 'model', { name: 'bob', age: 42 }));
 
       this.assertText('params: ["bob","rich"], hash: {"first":42,"last":"sam"}');
     }
@@ -304,19 +304,19 @@ moduleFor(
 
       this.assertText('params: ["bob","rich"], hash: {"first":42,"last":"sam"}');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('params: ["bob","rich"], hash: {"first":42,"last":"sam"}');
 
-      this.runTask(() => set(this.context, 'model.name', 'sal'));
+      runTask(() => set(this.context, 'model.name', 'sal'));
 
       this.assertText('params: ["sal","rich"], hash: {"first":42,"last":"sam"}');
 
-      this.runTask(() => set(this.context, 'model.age', 28));
+      runTask(() => set(this.context, 'model.age', 28));
 
       this.assertText('params: ["sal","rich"], hash: {"first":28,"last":"sam"}');
 
-      this.runTask(() => set(this.context, 'model', { name: 'bob', age: 42 }));
+      runTask(() => set(this.context, 'model', { name: 'bob', age: 42 }));
 
       this.assertText('params: ["bob","rich"], hash: {"first":42,"last":"sam"}');
     }
@@ -339,15 +339,15 @@ moduleFor(
 
       this.assertText('Who overcomes by force hath overcome but half his foe');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Who overcomes by force hath overcome but half his foe');
 
-      this.runTask(() => set(this.context, 'model.reason', 'Nickleback'));
+      runTask(() => set(this.context, 'model.reason', 'Nickleback'));
 
       this.assertText('Who overcomes by Nickleback hath overcome but half his foe');
 
-      this.runTask(() => set(this.context, 'model', { reason: 'force' }));
+      runTask(() => set(this.context, 'model', { reason: 'force' }));
 
       this.assertText('Who overcomes by force hath overcome but half his foe');
     }
@@ -361,7 +361,7 @@ moduleFor(
 
       this.assertText('true');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('true');
     }
@@ -375,7 +375,7 @@ moduleFor(
 
       this.assertHTML('<div data-foo-bar="baz"></div>');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertHTML('<div data-foo-bar="baz"></div>');
     }
@@ -466,19 +466,19 @@ moduleFor(
 
       this.assertText('Who overcomes by force hath overcome but half his foe');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Who overcomes by force hath overcome but half his foe');
 
       phrase = 'believes his';
 
-      this.runTask(() => helper.recompute());
+      runTask(() => helper.recompute());
 
       this.assertText('Who believes his force hath overcome but half his foe');
 
       phrase = 'overcomes by';
 
-      this.runTask(() => helper.recompute());
+      runTask(() => helper.recompute());
 
       this.assertText('Who overcomes by force hath overcome but half his foe');
     }
@@ -517,19 +517,19 @@ moduleFor(
 
       this.assertText('Who overcomes by force hath overcome but half his foe');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Who overcomes by force hath overcome but half his foe');
 
       phrase = 'believes his';
 
-      this.runTask(() => helper.recompute());
+      runTask(() => helper.recompute());
 
       this.assertText('Who believes his force hath overcome but half his foe');
 
       phrase = 'overcomes by';
 
-      this.runTask(() => helper.recompute());
+      runTask(() => helper.recompute());
 
       this.assertText('Who overcomes by force hath overcome but half his foe');
     }

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/element-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/element-action-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor, strip } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, strip, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
 import {
@@ -71,11 +71,11 @@ if (EMBER_IMPROVED_INSTRUMENTATION) {
 
         this.assert.equal(subscriberCallCount, 0, 'subscriber has not been called');
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assert.equal(subscriberCallCount, 0, 'subscriber has not been called');
 
-        this.runTask(() => {
+        runTask(() => {
           this.$('button').click();
         });
 
@@ -110,17 +110,17 @@ moduleFor(
 
       this.assert.equal(fooCallCount, 0, 'foo has not been called');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assert.equal(fooCallCount, 0, 'foo has not been called');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('button').click();
       });
 
       this.assert.equal(fooCallCount, 1, 'foo has been called 1 time');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('button').click();
       });
 
@@ -153,21 +153,21 @@ moduleFor(
 
       this.assert.deepEqual(fooArgs, [], 'foo has not been called');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assert.deepEqual(fooArgs, [], 'foo has not been called');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('button').click();
       });
 
       this.assert.deepEqual(fooArgs, ['a'], 'foo has not been called');
 
-      this.runTask(() => {
+      runTask(() => {
         component.set('member', 'b');
       });
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('button').click();
       });
 
@@ -209,7 +209,7 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('#show').trigger('mouseup');
       });
 
@@ -252,7 +252,7 @@ moduleFor(
 
       this.render('{{target-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('button').click();
       });
 
@@ -289,7 +289,7 @@ moduleFor(
           {{/target-component}}
         `);
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('a').click();
       });
 
@@ -328,17 +328,17 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('a').click();
       });
 
       this.assert.equal(firstEdit, 1);
 
-      this.runTask(() => {
+      runTask(() => {
         set(component, 'theTarget', second);
       });
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('a').click();
       });
 
@@ -369,13 +369,13 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('a[data-ember-action]').trigger('click', { altKey: true });
       });
 
       this.assert.equal(editHandlerWasCalled, true, 'the event handler was called');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('div[data-ember-action]').trigger('click', { ctrlKey: true });
       });
 
@@ -411,13 +411,13 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('a[data-ember-action]').trigger('click', { altKey: true });
       });
 
       this.assert.equal(editHandlerWasCalled, true, 'the event handler was called');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('div[data-ember-action]').trigger('click', { ctrlKey: true });
       });
 
@@ -452,7 +452,7 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('a[data-ember-action]').trigger('click', { altKey: true });
       });
 
@@ -460,11 +460,11 @@ moduleFor(
 
       editHandlerWasCalled = false;
 
-      this.runTask(() => {
+      runTask(() => {
         component.set('acceptedKeys', '');
       });
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('div[data-ember-action]').click();
       });
 
@@ -503,7 +503,7 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('#edit').click();
       });
 
@@ -517,7 +517,7 @@ moduleFor(
 
       editHandlerWasCalled = deleteHandlerWasCalled = originalHandlerWasCalled = false;
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('#delete').click();
       });
 
@@ -531,7 +531,7 @@ moduleFor(
 
       editHandlerWasCalled = deleteHandlerWasCalled = originalHandlerWasCalled = false;
 
-      this.runTask(() => {
+      runTask(() => {
         this.wrap(component.element).click();
       });
 
@@ -572,7 +572,7 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('#edit').click();
       });
 
@@ -582,7 +582,7 @@ moduleFor(
 
       editHandlerWasCalled = deleteHandlerWasCalled = originalHandlerWasCalled = false;
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('#delete').click();
       });
 
@@ -592,7 +592,7 @@ moduleFor(
 
       editHandlerWasCalled = deleteHandlerWasCalled = originalHandlerWasCalled = false;
 
-      this.runTask(() => {
+      runTask(() => {
         this.wrap(component.element).click();
       });
 
@@ -634,7 +634,7 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('#edit').click();
       });
 
@@ -644,7 +644,7 @@ moduleFor(
 
       editHandlerWasCalled = deleteHandlerWasCalled = originalHandlerWasCalled = false;
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('#delete').click();
       });
 
@@ -654,7 +654,7 @@ moduleFor(
 
       editHandlerWasCalled = deleteHandlerWasCalled = originalHandlerWasCalled = false;
 
-      this.runTask(() => {
+      runTask(() => {
         this.wrap(component.element).click();
       });
 
@@ -691,7 +691,7 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('#edit').click();
       });
 
@@ -700,11 +700,11 @@ moduleFor(
 
       editHandlerWasCalled = originalHandlerWasCalled = false;
 
-      this.runTask(() => {
+      runTask(() => {
         component.set('shouldBubble', true);
       });
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('#edit').click();
       });
 
@@ -731,7 +731,7 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('a').click();
       });
 
@@ -758,7 +758,7 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('a').click();
       });
 
@@ -789,19 +789,19 @@ moduleFor(
 
       assert.ok(ActionManager.registeredActions[actionId], 'An action is registered');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.equal(this.$('a[data-ember-action]').length, 1, 'The element is still present');
 
       assert.ok(ActionManager.registeredActions[actionId], 'The action is still registered');
 
-      this.runTask(() => set(this.context, 'isActive', false));
+      runTask(() => set(this.context, 'isActive', false));
 
       assert.strictEqual(this.$('a[data-ember-action]').length, 0, 'The element is removed');
 
       assert.ok(!ActionManager.registeredActions[actionId], 'The action is unregistered');
 
-      this.runTask(() => set(this.context, 'isActive', true));
+      runTask(() => set(this.context, 'isActive', true));
 
       assert.equal(this.$('a[data-ember-action]').length, 1, 'The element is rendered');
 
@@ -828,7 +828,7 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('button').click();
       });
 
@@ -860,7 +860,7 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('a').click();
       });
 
@@ -892,7 +892,7 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('a').click();
       });
 
@@ -918,7 +918,7 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('a').click();
       });
 
@@ -968,7 +968,7 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('#edit').click();
       });
 
@@ -994,7 +994,7 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('a').click();
       });
 
@@ -1002,7 +1002,7 @@ moduleFor(
 
       editHandlerWasCalled = false;
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('a').trigger('mouseover');
       });
 
@@ -1030,7 +1030,7 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('button').click();
       });
 
@@ -1061,7 +1061,7 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('button').click();
       });
 
@@ -1145,7 +1145,7 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('input').trigger('keyup', { char: 'a', which: 65 });
       });
 
@@ -1189,11 +1189,11 @@ moduleFor(
       let test = this;
 
       let testBoundAction = propertyValue => {
-        test.runTask(() => {
+        runTask(() => {
           component.set('hookMeUp', propertyValue);
         });
 
-        test.runTask(() => {
+        runTask(() => {
           this.wrap(component.element)
             .findAll('#bound-param')
             .click();
@@ -1255,7 +1255,7 @@ moduleFor(
       let test = this;
 
       let testBoundAction = propertyValue => {
-        test.runTask(() => {
+        runTask(() => {
           this.wrap(component.element)
             .findAll(`#${propertyValue}`)
             .click();
@@ -1295,7 +1295,7 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('a').click();
       });
 
@@ -1346,13 +1346,13 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('a').trigger('click');
       });
 
       this.assert.ok(clickActionWasCalled, 'the clicked action was called');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('a').trigger('dblclick');
       });
 
@@ -1375,7 +1375,7 @@ moduleFor(
 
       let event;
 
-      this.runTask(() => {
+      runTask(() => {
         event = this.$('a').click()[0];
       });
 
@@ -1405,13 +1405,13 @@ moduleFor(
 
       let event;
 
-      this.runTask(() => {
+      runTask(() => {
         event = this.$('a').trigger(event)[0];
       });
 
       this.assert.equal(event.defaultPrevented, false, 'should not preventDefault');
 
-      this.runTask(() => {
+      runTask(() => {
         component.set('shouldPreventDefault', true);
         event = this.$('a').trigger('click')[0];
       });
@@ -1469,7 +1469,7 @@ moduleFor(
 
       this.render('{{outer-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('button').click();
       });
 
@@ -1500,25 +1500,25 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('button').click();
       });
 
       this.assertText('Clicked!');
 
-      this.runTask(() => {
+      runTask(() => {
         component.set('label', 'Dun clicked');
       });
 
       this.assertText('Dun clicked');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('button').click();
       });
 
       this.assertText('Clicked!');
 
-      this.runTask(() => {
+      runTask(() => {
         component.set('label', undefined);
       });
 
@@ -1544,7 +1544,7 @@ moduleFor(
         'Show (true)'
       );
       // We need to focus in to simulate an actual click.
-      this.runTask(() => {
+      runTask(() => {
         document.getElementById('ddButton').focus();
         document.getElementById('ddButton').click();
       });
@@ -1570,7 +1570,7 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('button').click();
       });
 
@@ -1580,7 +1580,7 @@ moduleFor(
         "Element with action handler has properly updated it's conditional class"
       );
 
-      this.runTask(() => {
+      runTask(() => {
         this.$('button').click();
       });
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/get-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/get-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
 
 import { set, get } from '@ember/-internals/metal';
 
@@ -14,15 +14,15 @@ moduleFor(
 
       this.assertText('[red] [red]');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('[red] [red]');
 
-      this.runTask(() => set(this.context, 'colors.apple', 'green'));
+      runTask(() => set(this.context, 'colors.apple', 'green'));
 
       this.assertText('[green] [green]');
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'colors', {
           apple: 'red',
         })
@@ -42,15 +42,15 @@ moduleFor(
 
       this.assertText('[red and yellow] [red and yellow]');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('[red and yellow] [red and yellow]');
 
-      this.runTask(() => set(this.context, 'colors.apple.gala', 'yellow and red striped'));
+      runTask(() => set(this.context, 'colors.apple.gala', 'yellow and red striped'));
 
       this.assertText('[yellow and red striped] [yellow and red striped]');
 
-      this.runTask(() => set(this.context, 'colors', { apple: { gala: 'red and yellow' } }));
+      runTask(() => set(this.context, 'colors', { apple: { gala: 'red and yellow' } }));
 
       this.assertText('[red and yellow] [red and yellow]');
     }
@@ -67,15 +67,15 @@ moduleFor(
 
       this.assertText('[First][Second][Third]');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('[First][Second][Third]');
 
-      this.runTask(() => set(this.context, 'items.1', 'Qux'));
+      runTask(() => set(this.context, 'items.1', 'Qux'));
 
       this.assertText('[Qux][Second][Third]');
 
-      this.runTask(() => set(this.context, 'items', { 1: 'First', 2: 'Second', 3: 'Third' }));
+      runTask(() => set(this.context, 'items', { 1: 'First', 2: 'Second', 3: 'Third' }));
 
       this.assertText('[First][Second][Third]');
     }
@@ -87,15 +87,15 @@ moduleFor(
 
       this.assertText('[1][2][3]');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('[1][2][3]');
 
-      this.runTask(() => set(this.context, 'numbers', [3, 2, 1]));
+      runTask(() => set(this.context, 'numbers', [3, 2, 1]));
 
       this.assertText('[3][2][1]');
 
-      this.runTask(() => set(this.context, 'numbers', [1, 2, 3]));
+      runTask(() => set(this.context, 'numbers', [1, 2, 3]));
 
       this.assertText('[1][2][3]');
     }
@@ -112,15 +112,15 @@ moduleFor(
 
       this.assertText('[First][Second][Third]');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('[First][Second][Third]');
 
-      this.runTask(() => set(this.context, 'items.1', 'Qux'));
+      runTask(() => set(this.context, 'items.1', 'Qux'));
 
       this.assertText('[Qux][Second][Third]');
 
-      this.runTask(() => set(this.context, 'items', { 1: 'First', 2: 'Second', 3: 'Third' }));
+      runTask(() => set(this.context, 'items', { 1: 'First', 2: 'Second', 3: 'Third' }));
 
       this.assertText('[First][Second][Third]');
     }
@@ -132,11 +132,11 @@ moduleFor(
 
       this.assertText('[1][2][3]');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('[1][2][3]');
 
-      this.runTask(() => set(this.context, 'numbers', [3, 2, 1]));
+      runTask(() => set(this.context, 'numbers', [3, 2, 1]));
 
       this.assertText('[3][2][1]');
     }
@@ -149,26 +149,26 @@ moduleFor(
 
       this.assertText('[red] [red]');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('[red] [red]');
 
-      this.runTask(() => set(this.context, 'key', 'banana'));
+      runTask(() => set(this.context, 'key', 'banana'));
 
       this.assertText('[yellow] [yellow]');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'colors.apple', 'green');
         set(this.context, 'colors.banana', 'purple');
       });
 
       this.assertText('[purple] [purple]');
 
-      this.runTask(() => set(this.context, 'key', 'apple'));
+      runTask(() => set(this.context, 'key', 'apple'));
 
       this.assertText('[green] [green]');
 
-      this.runTask(() => set(this.context, 'colors', { apple: 'red' }));
+      runTask(() => set(this.context, 'colors', { apple: 'red' }));
 
       this.assertText('[red] [red]');
     }
@@ -187,19 +187,19 @@ moduleFor(
 
       this.assertText('[red and yellow] [red and yellow]');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('[red and yellow] [red and yellow]');
 
-      this.runTask(() => set(this.context, 'key', 'apple.mcintosh'));
+      runTask(() => set(this.context, 'key', 'apple.mcintosh'));
 
       this.assertText('[red] [red]');
 
-      this.runTask(() => set(this.context, 'key', 'banana'));
+      runTask(() => set(this.context, 'key', 'banana'));
 
       this.assertText('[yellow] [yellow]');
 
-      this.runTask(() => set(this.context, 'key', 'apple.gala'));
+      runTask(() => set(this.context, 'key', 'apple.gala'));
 
       this.assertText('[red and yellow] [red and yellow]');
     }
@@ -220,19 +220,19 @@ moduleFor(
 
       this.assertText('[red and yellow] [red and yellow]');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('[red and yellow] [red and yellow]');
 
-      this.runTask(() => set(this.context, 'colors.apple.gala', 'yellow and red striped'));
+      runTask(() => set(this.context, 'colors.apple.gala', 'yellow and red striped'));
 
       this.assertText('[yellow and red striped] [yellow and red striped]');
 
-      this.runTask(() => set(this.context, 'colors.apple.gala', 'yellow-redish'));
+      runTask(() => set(this.context, 'colors.apple.gala', 'yellow-redish'));
 
       this.assertText('[yellow-redish] [yellow-redish]');
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'colors', {
           apple: {
             gala: 'red and yellow',
@@ -256,26 +256,26 @@ moduleFor(
 
       this.assertText('[red] [red]');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('[red] [red]');
 
-      this.runTask(() => set(this.context, 'key', 'key2'));
+      runTask(() => set(this.context, 'key', 'key2'));
 
       this.assertText('[yellow] [yellow]');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'colors.apple', 'green');
         set(this.context, 'colors.banana', 'purple');
       });
 
       this.assertText('[purple] [purple]');
 
-      this.runTask(() => set(this.context, 'key', 'key1'));
+      runTask(() => set(this.context, 'key', 'key1'));
 
       this.assertText('[green] [green]');
 
-      this.runTask(() => set(this.context, 'colors', { apple: 'red', banana: 'yellow' }));
+      runTask(() => set(this.context, 'colors', { apple: 'red', banana: 'yellow' }));
 
       this.assertText('[red] [red]');
     }
@@ -295,31 +295,31 @@ moduleFor(
 
       this.assertText('[red] [red]');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('[red] [red]');
 
-      this.runTask(() => set(this.context, 'objectKey', 'colors2'));
+      runTask(() => set(this.context, 'objectKey', 'colors2'));
 
       this.assertText('[green] [green]');
 
-      this.runTask(() => set(this.context, 'objectKey', 'colors1'));
+      runTask(() => set(this.context, 'objectKey', 'colors1'));
 
       this.assertText('[red] [red]');
 
-      this.runTask(() => set(this.context, 'key', 'banana'));
+      runTask(() => set(this.context, 'key', 'banana'));
 
       this.assertText('[yellow] [yellow]');
 
-      this.runTask(() => set(this.context, 'objectKey', 'colors2'));
+      runTask(() => set(this.context, 'objectKey', 'colors2'));
 
       this.assertText('[purple] [purple]');
 
-      this.runTask(() => set(this.context, 'objectKey', 'colors1'));
+      runTask(() => set(this.context, 'objectKey', 'colors1'));
 
       this.assertText('[yellow] [yellow]');
 
-      this.runTask(() => set(this.context, 'key', 'apple'));
+      runTask(() => set(this.context, 'key', 'apple'));
     }
 
     ['@test should be able to get an object value with a get helper as the value and a get helper as the key']() {
@@ -341,27 +341,27 @@ moduleFor(
 
       this.assertText('[red] [red]');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('[red] [red]');
 
-      this.runTask(() => set(this.context, 'objectKey', 'colors2'));
+      runTask(() => set(this.context, 'objectKey', 'colors2'));
 
       this.assertText('[green] [green]');
 
-      this.runTask(() => set(this.context, 'objectKey', 'colors1'));
+      runTask(() => set(this.context, 'objectKey', 'colors1'));
 
       this.assertText('[red] [red]');
 
-      this.runTask(() => set(this.context, 'key', 'key2'));
+      runTask(() => set(this.context, 'key', 'key2'));
 
       this.assertText('[yellow] [yellow]');
 
-      this.runTask(() => set(this.context, 'objectKey', 'colors2'));
+      runTask(() => set(this.context, 'objectKey', 'colors2'));
 
       this.assertText('[purple] [purple]');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'objectKey', 'colors1');
         set(this.context, 'key', 'key1');
       });
@@ -392,18 +392,18 @@ moduleFor(
 
       this.assertText('banana');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('banana');
 
-      this.runTask(() => {
+      runTask(() => {
         set(fooBarInstance, 'mcintosh', 'yellow');
         set(this.context, 'colors', { yellow: 'bus' });
       });
 
       this.assertText('bus');
 
-      this.runTask(() => {
+      runTask(() => {
         set(fooBarInstance, 'mcintosh', 'red');
         set(this.context, 'colors', { red: 'banana' });
       });
@@ -418,15 +418,15 @@ moduleFor(
 
       this.assertText('[] []');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('[] []');
 
-      this.runTask(() => set(this.context, 'colors', { apple: 'green', banana: 'purple' }));
+      runTask(() => set(this.context, 'colors', { apple: 'green', banana: 'purple' }));
 
       this.assertText('[green] [green]');
 
-      this.runTask(() => set(this.context, 'colors', null));
+      runTask(() => set(this.context, 'colors', null));
 
       this.assertText('[] []');
     }
@@ -442,15 +442,15 @@ moduleFor(
 
       this.assertText('[] []');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('[] []');
 
-      this.runTask(() => set(this.context, 'key', 'banana'));
+      runTask(() => set(this.context, 'key', 'banana'));
 
       this.assertText('[yellow] [yellow]');
 
-      this.runTask(() => set(this.context, 'key', null));
+      runTask(() => set(this.context, 'key', null));
 
       this.assertText('[] []');
     }
@@ -473,15 +473,15 @@ moduleFor(
 
       assert.strictEqual(this.$('#get-input').val(), 'banana');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.strictEqual(this.$('#get-input').val(), 'banana');
 
-      this.runTask(() => set(this.context, 'source.banana', 'yellow'));
+      runTask(() => set(this.context, 'source.banana', 'yellow'));
 
       assert.strictEqual(this.$('#get-input').val(), 'yellow');
 
-      this.runTask(() =>
+      runTask(() =>
         this.$('#get-input')
           .val('some value')
           .trigger('change')
@@ -490,7 +490,7 @@ moduleFor(
       assert.strictEqual(this.$('#get-input').val(), 'some value');
       assert.strictEqual(get(this.context, 'source.banana'), 'some value');
 
-      this.runTask(() => set(this.context, 'source', { banana: 'banana' }));
+      runTask(() => set(this.context, 'source', { banana: 'banana' }));
 
       assert.strictEqual(this.$('#get-input').val(), 'banana');
     }
@@ -506,15 +506,15 @@ moduleFor(
 
       assert.strictEqual(this.$('#get-input').val(), 'banana');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.strictEqual(this.$('#get-input').val(), 'banana');
 
-      this.runTask(() => set(this.context, 'source.banana', 'yellow'));
+      runTask(() => set(this.context, 'source.banana', 'yellow'));
 
       assert.strictEqual(this.$('#get-input').val(), 'yellow');
 
-      this.runTask(() =>
+      runTask(() =>
         this.$('#get-input')
           .val('some value')
           .trigger('change')
@@ -523,11 +523,11 @@ moduleFor(
       assert.strictEqual(this.$('#get-input').val(), 'some value');
       assert.strictEqual(get(this.context, 'source.banana'), 'some value');
 
-      this.runTask(() => set(this.context, 'key', 'apple'));
+      runTask(() => set(this.context, 'key', 'apple'));
 
       assert.strictEqual(this.$('#get-input').val(), 'apple');
 
-      this.runTask(() =>
+      runTask(() =>
         this.$('#get-input')
           .val('some other value')
           .trigger('change')
@@ -536,7 +536,7 @@ moduleFor(
       assert.strictEqual(this.$('#get-input').val(), 'some other value');
       assert.strictEqual(get(this.context, 'source.apple'), 'some other value');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'key', 'banana');
         set(this.context, 'source', { banana: 'banana' });
       });
@@ -560,15 +560,15 @@ moduleFor(
 
       assert.strictEqual(this.$('#get-input').val(), 'mcintosh');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       assert.strictEqual(this.$('#get-input').val(), 'mcintosh');
 
-      this.runTask(() => set(this.context, 'source.apple.mcintosh', 'red'));
+      runTask(() => set(this.context, 'source.apple.mcintosh', 'red'));
 
       assert.strictEqual(this.$('#get-input').val(), 'red');
 
-      this.runTask(() =>
+      runTask(() =>
         this.$('#get-input')
           .val('some value')
           .trigger('change')
@@ -577,11 +577,11 @@ moduleFor(
       assert.strictEqual(this.$('#get-input').val(), 'some value');
       assert.strictEqual(get(this.context, 'source.apple.mcintosh'), 'some value');
 
-      this.runTask(() => set(this.context, 'key', 'apple.gala'));
+      runTask(() => set(this.context, 'key', 'apple.gala'));
 
       assert.strictEqual(this.$('#get-input').val(), 'gala');
 
-      this.runTask(() =>
+      runTask(() =>
         this.$('#get-input')
           .val('some other value')
           .trigger('change')
@@ -590,11 +590,11 @@ moduleFor(
       assert.strictEqual(this.$('#get-input').val(), 'some other value');
       assert.strictEqual(get(this.context, 'source.apple.gala'), 'some other value');
 
-      this.runTask(() => set(this.context, 'key', 'banana'));
+      runTask(() => set(this.context, 'key', 'banana'));
 
       assert.strictEqual(this.$('#get-input').val(), 'banana');
 
-      this.runTask(() =>
+      runTask(() =>
         this.$('#get-input')
           .val('yet another value')
           .trigger('change')
@@ -603,7 +603,7 @@ moduleFor(
       assert.strictEqual(this.$('#get-input').val(), 'yet another value');
       assert.strictEqual(get(this.context, 'source.banana'), 'yet another value');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'key', 'apple.mcintosh');
         set(this.context, 'source', {
           apple: {

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/hash-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/hash-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
 
 import { Component } from '../../utils/helpers';
 
@@ -12,7 +12,7 @@ moduleFor(
 
       this.assertText('Sergio');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Sergio');
     }
@@ -24,7 +24,7 @@ moduleFor(
 
       this.assertText('Sergio Arbeo');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Sergio Arbeo');
     }
@@ -41,15 +41,15 @@ moduleFor(
 
       this.assertText('Marisa Arbeo');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Marisa Arbeo');
 
-      this.runTask(() => set(this.context, 'model.firstName', 'Sergio'));
+      runTask(() => set(this.context, 'model.firstName', 'Sergio'));
 
       this.assertText('Sergio Arbeo');
 
-      this.runTask(() => set(this.context, 'model', { firstName: 'Marisa' }));
+      runTask(() => set(this.context, 'model', { firstName: 'Marisa' }));
 
       this.assertText('Marisa Arbeo');
     }
@@ -67,19 +67,19 @@ moduleFor(
 
       this.assertText('Marisa Arbeo');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Marisa Arbeo');
 
-      this.runTask(() => set(this.context, 'model.firstName', 'Sergio'));
+      runTask(() => set(this.context, 'model.firstName', 'Sergio'));
 
       this.assertText('Sergio Arbeo');
 
-      this.runTask(() => set(this.context, 'model.lastName', 'Smith'));
+      runTask(() => set(this.context, 'model.lastName', 'Smith'));
 
       this.assertText('Sergio Smith');
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'model', {
           firstName: 'Marisa',
           lastName: 'Arbeo',
@@ -99,15 +99,15 @@ moduleFor(
 
       this.assertText('Balint');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Balint');
 
-      this.runTask(() => set(this.context, 'model.firstName', 'Chad'));
+      runTask(() => set(this.context, 'model.firstName', 'Chad'));
 
       this.assertText('Chad');
 
-      this.runTask(() => set(this.context, 'model', { firstName: 'Balint' }));
+      runTask(() => set(this.context, 'model', { firstName: 'Balint' }));
 
       this.assertText('Balint');
     }
@@ -131,15 +131,15 @@ moduleFor(
 
       this.assertText('Chad');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Chad');
 
-      this.runTask(() => set(fooBarInstance, 'model.firstName', 'Godfrey'));
+      runTask(() => set(fooBarInstance, 'model.firstName', 'Godfrey'));
 
       this.assertText('Godfrey');
 
-      this.runTask(() => set(fooBarInstance, 'model', { firstName: 'Chad' }));
+      runTask(() => set(fooBarInstance, 'model', { firstName: 'Chad' }));
 
       this.assertText('Chad');
     }
@@ -168,18 +168,18 @@ moduleFor(
 
       this.assertText('Chad Hietala');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Chad Hietala');
 
-      this.runTask(() => {
+      runTask(() => {
         set(fooBarInstance, 'model.firstName', 'Godfrey');
         set(this.context, 'model.lastName', 'Chan');
       });
 
       this.assertText('Godfrey Chan');
 
-      this.runTask(() => {
+      runTask(() => {
         set(fooBarInstance, 'model', { firstName: 'Chad' });
         set(this.context, 'model', { lastName: 'Hietala' });
       });

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/input-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/input-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor, runDestroy } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, runDestroy, runTask } from 'internal-test-helpers';
 
 import { assign } from '@ember/polyfills';
 import { set } from '@ember/-internals/metal';
@@ -71,7 +71,7 @@ class InputRenderingTest extends RenderingTestCase {
     assign(event, options);
 
     let element = this.$input()[0];
-    this.runTask(() => {
+    runTask(() => {
       element.dispatchEvent(event);
     });
   }
@@ -88,19 +88,19 @@ moduleFor(
       this.assertValue('hello');
       this.assertSingleInput();
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertValue('hello');
       this.assertSingleInput();
       this.assertInputId(id);
 
-      this.runTask(() => set(this.context, 'value', 'goodbye'));
+      runTask(() => set(this.context, 'value', 'goodbye'));
 
       this.assertValue('goodbye');
       this.assertSingleInput();
       this.assertInputId(id);
 
-      this.runTask(() => set(this.context, 'value', 'hello'));
+      runTask(() => set(this.context, 'value', 'hello'));
 
       this.assertValue('hello');
       this.assertSingleInput();
@@ -112,7 +112,7 @@ moduleFor(
 
       this.assertAttr('type', 'text');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertAttr('type', 'text');
     }
@@ -151,7 +151,7 @@ moduleFor(
       // this.assertAttr('size', '20'); //NOTE: failing in IE  (TEST_SUITE=sauce)
       // this.assertAttr('tabindex', '30'); //NOTE: failing in IE (TEST_SUITE=sauce)
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertNotDisabled();
       this.assertValue('Original value');
@@ -162,7 +162,7 @@ moduleFor(
       // this.assertAttr('size', '20'); //NOTE: failing in IE (TEST_SUITE=sauce)
       // this.assertAttr('tabindex', '30'); //NOTE: failing in IE (TEST_SUITE=sauce)
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'value', 'Updated value');
         set(this.context, 'disabled', true);
         set(this.context, 'placeholder', 'Updated placeholder');
@@ -182,7 +182,7 @@ moduleFor(
       // this.assertAttr('size', '21'); //NOTE: failing in IE (TEST_SUITE=sauce)
       // this.assertAttr('tabindex', '31'); //NOTE: failing in IE (TEST_SUITE=sauce)
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'value', 'Original value');
         set(this.context, 'disabled', false);
         set(this.context, 'placeholder', 'Original placeholder');
@@ -225,7 +225,7 @@ moduleFor(
       // this.assertAttr('size', '20');  //NOTE: failing in IE (TEST_SUITE=sauce)
       // this.assertAttr('tabindex', '30');  //NOTE: failing in IE (TEST_SUITE=sauce)
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertDisabled();
       this.assertValue('Original value');
@@ -249,26 +249,26 @@ moduleFor(
       // See https://ember-twiddle.com/33e506329f8176ae874422644d4cc08c?openFiles=components.input-component.js%2Ctemplates.components.input-component.hbs
       // this.assertSelectionRange(8, 8); //NOTE: this is (0, 0) on Firefox (TEST_SUITE=sauce)
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       // this.assertSelectionRange(8, 8); //NOTE: this is (0, 0) on Firefox (TEST_SUITE=sauce)
 
-      this.runTask(() => {
+      runTask(() => {
         input.selectionStart = 2;
         input.selectionEnd = 4;
       });
 
       this.assertSelectionRange(2, 4);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertSelectionRange(2, 4);
 
-      // this.runTask(() => set(this.context, 'value', 'updated'));
+      // runTask(() => set(this.context, 'value', 'updated'));
       //
       // this.assertSelectionRange(7, 7); //NOTE: this fails in IE, the range is 0 -> 0 (TEST_SUITE=sauce)
       //
-      // this.runTask(() => set(this.context, 'value', 'original'));
+      // runTask(() => set(this.context, 'value', 'original'));
       //
       // this.assertSelectionRange(8, 8); //NOTE: this fails in IE, the range is 0 -> 0 (TEST_SUITE=sauce)
     }
@@ -378,7 +378,7 @@ moduleFor(
         },
       });
 
-      this.runTask(() => {
+      runTask(() => {
         this.$input().focus();
       });
 
@@ -532,15 +532,15 @@ moduleFor(
 
       this.assertAttr('type', 'password');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertAttr('type', 'password');
 
-      this.runTask(() => set(this.context, 'type', 'text'));
+      runTask(() => set(this.context, 'type', 'text'));
 
       this.assertAttr('type', 'text');
 
-      this.runTask(() => set(this.context, 'type', 'password'));
+      runTask(() => set(this.context, 'type', 'password'));
 
       this.assertAttr('type', 'password');
     }
@@ -554,15 +554,15 @@ moduleFor(
 
       this.assertAttr('type', 'text');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertAttr('type', 'text');
 
-      this.runTask(() => set(this.context, 'isTruthy', false));
+      runTask(() => set(this.context, 'isTruthy', false));
 
       this.assertAttr('type', 'password');
 
-      this.runTask(() => set(this.context, 'isTruthy', true));
+      runTask(() => set(this.context, 'isTruthy', true));
 
       this.assertAttr('type', 'text');
     }
@@ -610,14 +610,14 @@ moduleFor(
       this.assertAttr('name', 'original-name');
       this.assertAttr('tabindex', '10');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertSingleCheckbox();
       this.assertNotDisabled();
       this.assertAttr('name', 'original-name');
       this.assertAttr('tabindex', '10');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'disabled', true);
         set(this.context, 'name', 'updated-name');
         set(this.context, 'tabindex', 11);
@@ -628,7 +628,7 @@ moduleFor(
       this.assertAttr('name', 'updated-name');
       this.assertAttr('tabindex', '11');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'disabled', false);
         set(this.context, 'name', 'original-name');
         set(this.context, 'tabindex', 10);
@@ -657,15 +657,15 @@ moduleFor(
       this.assertSingleCheckbox();
       this.assertCheckboxIsChecked();
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertCheckboxIsChecked();
 
-      this.runTask(() => set(this.context, 'isChecked', false));
+      runTask(() => set(this.context, 'isChecked', false));
 
       this.assertCheckboxIsNotChecked();
 
-      this.runTask(() => set(this.context, 'isChecked', true));
+      runTask(() => set(this.context, 'isChecked', true));
 
       this.assertCheckboxIsChecked();
     }
@@ -692,7 +692,7 @@ moduleFor(
       this.assertAttr('tabindex', '10');
       this.assertAttr('name', 'original-name');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertSingleCheckbox();
       this.assertCheckboxIsNotChecked();
@@ -734,12 +734,12 @@ moduleFor(
       this.assertValue('');
       this.assertAllAttrs(attributes, undefined);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertValue('');
       this.assertAllAttrs(attributes, undefined);
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'disabled', true);
         set(this.context, 'value', 'Updated value');
         set(this.context, 'placeholder', 'Updated placeholder');
@@ -757,7 +757,7 @@ moduleFor(
       this.assertAttr('size', '21');
       this.assertAttr('tabindex', '31');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'disabled', null);
         set(this.context, 'value', null);
         set(this.context, 'placeholder', null);

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/loc-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/loc-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
 import { _setStrings } from '@ember/string';
@@ -22,21 +22,21 @@ moduleFor(
     ['@test it lets the original value through by default']() {
       this.render(`{{loc "Hiya buddy!"}}`);
       this.assertText('Hiya buddy!', 'the unlocalized string is correct');
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
       this.assertText('Hiya buddy!', 'the unlocalized string is correct after rerender');
     }
 
     ['@test it localizes a simple string']() {
       this.render(`{{loc "Hello Friend"}}`);
       this.assertText('Hallo Freund', 'the localized string is correct');
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
       this.assertText('Hallo Freund', 'the localized string is correct after rerender');
     }
 
     ['@test it takes passed formats into an account']() {
       this.render(`{{loc "%@, %@" "Hello" "Mr. Pitkin"}}`);
       this.assertText('Hello, Mr. Pitkin', 'the formatted string is correct');
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
       this.assertText('Hello, Mr. Pitkin', 'the formatted string is correct after rerender');
     }
 
@@ -47,16 +47,16 @@ moduleFor(
       });
       this.assertText('Hallo Freund - Hallo, Mr. Pitkin', 'the bound value is correct');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
       this.assertText(
         'Hallo Freund - Hallo, Mr. Pitkin',
         'the bound value is correct after rerender'
       );
 
-      this.runTask(() => set(this.context, 'simple', "G'day mate"));
+      runTask(() => set(this.context, 'simple', "G'day mate"));
       this.assertText("G'day mate - Hallo, Mr. Pitkin", 'the bound value is correct after update');
 
-      this.runTask(() => set(this.context, 'simple', 'Hello Friend'));
+      runTask(() => set(this.context, 'simple', 'Hello Friend'));
       this.assertText('Hallo Freund - Hallo, Mr. Pitkin', 'the bound value is correct after reset');
     }
 
@@ -69,19 +69,19 @@ moduleFor(
       });
       this.assertText('Hallo Freund - Hallo, Mr. Pitkin', 'the bound value is correct');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
       this.assertText(
         'Hallo Freund - Hallo, Mr. Pitkin',
         'the bound value is correct after rerender'
       );
 
-      this.runTask(() => set(this.context, 'greetings.simple', "G'day mate"));
+      runTask(() => set(this.context, 'greetings.simple', "G'day mate"));
       this.assertText(
         "G'day mate - Hallo, Mr. Pitkin",
         'the bound value is correct after interior mutation'
       );
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'greetings', {
           simple: 'Hello Friend',
           personal: 'Hello',

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/mut-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/mut-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor, styles } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, styles, runTask } from 'internal-test-helpers';
 
 import { set, get, computed } from '@ember/-internals/metal';
 
@@ -31,21 +31,21 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => bottom.attrs.setMe.update(13));
+      runTask(() => bottom.attrs.setMe.update(13));
 
       this.assertText('13', 'the set took effect');
       this.assert.strictEqual(get(bottom, 'setMe'), 13, "the set took effect on bottom's prop");
       this.assert.strictEqual(bottom.attrs.setMe.value, 13, "the set took effect on bottom's attr");
       this.assert.strictEqual(get(this.context, 'val'), 13, 'the set propagated back up');
 
-      this.runTask(() => set(bottom, 'setMe', 14));
+      runTask(() => set(bottom, 'setMe', 14));
 
       this.assertText('14', 'the set took effect');
       this.assert.strictEqual(get(bottom, 'setMe'), 14, "the set took effect on bottom's prop");
       this.assert.strictEqual(bottom.attrs.setMe.value, 14, "the set took effect on bottom's attr");
       this.assert.strictEqual(get(this.context, 'val'), 14, 'the set propagated back up');
 
-      this.runTask(() => set(this.context, 'val', 12));
+      runTask(() => set(this.context, 'val', 12));
 
       this.assertText('12');
     }
@@ -79,7 +79,7 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => bottom.attrs.setMe.update(13));
+      runTask(() => bottom.attrs.setMe.update(13));
 
       this.assertText('13', 'the set took effect');
       this.assert.strictEqual(get(bottom, 'setMe'), 13, "the set took effect on bottom's prop");
@@ -88,7 +88,7 @@ moduleFor(
       this.assert.strictEqual(middle.attrs.value.value, 13, "the set propagated to middle's attr");
       this.assert.strictEqual(get(this.context, 'val'), 13, 'the set propagated back up');
 
-      this.runTask(() => set(bottom, 'setMe', 14));
+      runTask(() => set(bottom, 'setMe', 14));
 
       this.assertText('14', 'the set took effect');
       this.assert.strictEqual(get(bottom, 'setMe'), 14, "the set took effect on bottom's prop");
@@ -97,7 +97,7 @@ moduleFor(
       this.assert.strictEqual(middle.attrs.value.value, 14, "the set propagated to middle's attr");
       this.assert.strictEqual(get(this.context, 'val'), 14, 'the set propagated back up');
 
-      this.runTask(() => set(this.context, 'val', 12));
+      runTask(() => set(this.context, 'val', 12));
 
       this.assertText('12');
     }
@@ -174,12 +174,12 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => middle.attrs.value.update(13));
+      runTask(() => middle.attrs.value.update(13));
 
       this.assert.strictEqual(get(middle, 'value'), 13, "the set took effect on middle's prop");
       this.assert.strictEqual(middle.attrs.value.value, 13, "the set took effect on middle's attr");
 
-      this.runTask(() => set(middle, 'value', 14));
+      runTask(() => set(middle, 'value', 14));
 
       this.assert.strictEqual(get(middle, 'value'), 14, "the set took effect on middle's prop");
       this.assert.strictEqual(middle.attrs.value.value, 14, "the set took effect on middle's attr");
@@ -191,7 +191,7 @@ moduleFor(
       this.assertText('14');
       this.assert.strictEqual(get(this.context, 'val'), 14, 'the set propagated back up');
 
-      this.runTask(() => set(this.context, 'val', 12));
+      runTask(() => set(this.context, 'val', 12));
 
       this.assertText('12');
     }
@@ -213,11 +213,11 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'model.name', 'Joel Kang'));
+      runTask(() => set(this.context, 'model.name', 'Joel Kang'));
 
       this.assertText('Joel Kang');
 
-      this.runTask(() => set(this.context, 'model', { name: 'Matthew Beale' }));
+      runTask(() => set(this.context, 'model', { name: 'Matthew Beale' }));
 
       this.assertText('Matthew Beale');
     }
@@ -258,19 +258,19 @@ moduleFor(
       this.assert.deepEqual(didInsert, [12], 'didInsert is [12]');
       this.assert.strictEqual(get(bottom, 'setMe'), 12, 'the data propagated');
 
-      this.runTask(() => bottom.attrs.setMe.update(13));
+      runTask(() => bottom.attrs.setMe.update(13));
 
       this.assert.strictEqual(get(bottom, 'setMe'), 13, "the set took effect on bottom's prop");
       this.assert.strictEqual(bottom.attrs.setMe.value, 13, "the set took effect on bottom's attr");
       this.assert.strictEqual(get(this.context, 'val'), 13, 'the set propagated back up');
 
-      this.runTask(() => set(bottom, 'setMe', 14));
+      runTask(() => set(bottom, 'setMe', 14));
 
       this.assert.strictEqual(get(bottom, 'setMe'), 14, "the set took effect on bottom's prop");
       this.assert.strictEqual(bottom.attrs.setMe.value, 14, "the set took effect on bottom's attr");
       this.assert.strictEqual(get(this.context, 'val'), 14, 'the set propagated back up');
 
-      this.runTask(() => set(this.context, 'val', 12));
+      runTask(() => set(this.context, 'val', 12));
 
       this.assertText('12');
     }
@@ -308,7 +308,7 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(middle, 'baseValue', 13));
+      runTask(() => set(middle, 'baseValue', 13));
 
       this.assert.strictEqual(get(middle, 'val'), 13, 'the set took effect');
       this.assert.strictEqual(
@@ -323,7 +323,7 @@ moduleFor(
       );
       this.assertText('13');
 
-      this.runTask(() => set(middle, 'baseValue', 12));
+      runTask(() => set(middle, 'baseValue', 12));
 
       this.assertText('12');
     }
@@ -350,13 +350,13 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => inner.attrs.foo.update('bar'));
+      runTask(() => inner.attrs.foo.update('bar'));
 
       this.assert.equal(inner.attrs.foo.value, 'bar');
       this.assert.equal(get(inner, 'foo'), 'bar');
       this.assertText('bar');
 
-      this.runTask(() => inner.attrs.foo.update('foo'));
+      runTask(() => inner.attrs.foo.update('foo'));
 
       this.assertText('foo');
     }
@@ -383,13 +383,13 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => inner.attrs.model.update(42));
+      runTask(() => inner.attrs.model.update(42));
 
       this.assert.equal(inner.attrs.model.value, 42);
       this.assert.equal(get(inner, 'model'), 42);
       this.assertText('42');
 
-      this.runTask(() => inner.attrs.model.update(undefined));
+      runTask(() => inner.attrs.model.update(undefined));
 
       this.assertText('');
     }
@@ -416,13 +416,13 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => inner.attrs.model.update(42));
+      runTask(() => inner.attrs.model.update(42));
 
       this.assert.equal(inner.attrs.model.value, 42);
       this.assert.equal(get(inner, 'model'), 42);
       this.assertText('hello42');
 
-      this.runTask(() => inner.attrs.model.update('foo'));
+      runTask(() => inner.attrs.model.update('foo'));
 
       this.assertText('hellofoo');
     }
@@ -470,7 +470,7 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => input.attrs.height.update(35));
+      runTask(() => input.attrs.height.update(35));
 
       this.assert.strictEqual(get(output, 'height'), 35, 'the set took effect');
       this.assert.strictEqual(get(this.context, 'height'), 35, 'the set propagated back up');
@@ -480,7 +480,7 @@ moduleFor(
         content: '35',
       });
 
-      this.runTask(() => set(input, 'height', 36));
+      runTask(() => set(input, 'height', 36));
 
       this.assert.strictEqual(get(output, 'height'), 36, 'the set took effect');
       this.assert.strictEqual(get(this.context, 'height'), 36, 'the set propagated back up');
@@ -490,7 +490,7 @@ moduleFor(
         content: '36',
       });
 
-      this.runTask(() => set(this.context, 'height', 60));
+      runTask(() => set(this.context, 'height', 60));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -548,7 +548,7 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(input, 'width', 80));
+      runTask(() => set(input, 'width', 80));
 
       this.assert.strictEqual(get(output, 'width'), 80, 'the set took effect');
       this.assert.strictEqual(get(this.context, 'width'), 80, 'the set propagated back up');
@@ -558,7 +558,7 @@ moduleFor(
         content: '80x40',
       });
 
-      this.runTask(() => input.attrs.width.update(90));
+      runTask(() => input.attrs.width.update(90));
 
       this.assert.strictEqual(get(output, 'width'), 90, 'the set took effect');
       this.assert.strictEqual(get(this.context, 'width'), 90, 'the set propagated back up');
@@ -568,7 +568,7 @@ moduleFor(
         content: '90x45',
       });
 
-      this.runTask(() => set(this.context, 'width', 70));
+      runTask(() => set(this.context, 'width', 70));
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/partial-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/partial-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor, strip } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, strip, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
 import { A as emberA } from '@ember/-internals/runtime';
@@ -40,11 +40,11 @@ moduleFor(
 
       this.assertText('Who is Kris Selden?');
 
-      this.runTask(() => set(this.context, 'model.firstName', 'Kelly'));
+      runTask(() => set(this.context, 'model.firstName', 'Kelly'));
 
       this.assertText('Who is Kelly Selden?');
 
-      this.runTask(() => set(this.context, 'model', { firstName: 'Kris', lastName: 'Selden' }));
+      runTask(() => set(this.context, 'model', { firstName: 'Kris', lastName: 'Selden' }));
 
       this.assertText('Who is Kris Selden?');
     }
@@ -64,15 +64,15 @@ moduleFor(
 
       this.assertText('This sub-template is pretty great.');
 
-      this.runTask(() => set(this.context, 'templates.partialName', 'otherTemplate'));
+      runTask(() => set(this.context, 'templates.partialName', 'otherTemplate'));
 
       this.assertText('This other-template is pretty great.');
 
-      this.runTask(() => set(this.context, 'templates.partialName', null));
+      runTask(() => set(this.context, 'templates.partialName', null));
 
       this.assertText('This  is pretty great.');
 
-      this.runTask(() => set(this.context, 'templates', { partialName: 'subTemplate' }));
+      runTask(() => set(this.context, 'templates', { partialName: 'subTemplate' }));
 
       this.assertText('This sub-template is pretty great.');
     }
@@ -96,11 +96,11 @@ moduleFor(
 
       this.assertText('apple: apple |orange: orange |banana: banana |');
 
-      this.runTask(() => this.context.model.items.pushObject('strawberry'));
+      runTask(() => this.context.model.items.pushObject('strawberry'));
 
       this.assertText('apple: apple |orange: orange |banana: banana |strawberry: strawberry |');
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'model', {
           items: emberA(['apple', 'orange', 'banana']),
         })
@@ -126,15 +126,15 @@ moduleFor(
 
       this.assertText('foo: 1');
 
-      this.runTask(() => set(this.context, 'model.id', 2));
+      runTask(() => set(this.context, 'model.id', 2));
 
       this.assertText('foo: 2');
 
-      this.runTask(() => set(this.context, 'model.name', 'bar'));
+      runTask(() => set(this.context, 'model.name', 'bar'));
 
       this.assertText('bar: 2');
 
-      this.runTask(() => set(this.context, 'model', { id: 1, name: 'foo' }));
+      runTask(() => set(this.context, 'model', { id: 1, name: 'foo' }));
 
       this.assertText('foo: 1');
     }
@@ -156,11 +156,11 @@ moduleFor(
 
       this.assertText('1: 1 |2: 2 |3: 3 |');
 
-      this.runTask(() => this.context.items.pushObject({ id: 4 }));
+      runTask(() => this.context.items.pushObject({ id: 4 }));
 
       this.assertText('1: 1 |2: 2 |3: 3 |4: 4 |');
 
-      this.runTask(() => set(this.context, 'items', emberA([{ id: 1 }, { id: 2 }, { id: 3 }])));
+      runTask(() => set(this.context, 'items', emberA([{ id: 1 }, { id: 2 }, { id: 3 }])));
 
       this.assertText('1: 1 |2: 2 |3: 3 |');
     }
@@ -182,11 +182,11 @@ moduleFor(
 
       this.assertText('apple: apple |:  |orange: orange |banana: banana |');
 
-      this.runTask(() => this.context.items.pushObject('strawberry'));
+      runTask(() => this.context.items.pushObject('strawberry'));
 
       this.assertText('apple: apple |:  |orange: orange |banana: banana |strawberry: strawberry |');
 
-      this.runTask(() => set(this.context, 'items', emberA(['apple', null, 'orange', 'banana'])));
+      runTask(() => set(this.context, 'items', emberA(['apple', null, 'orange', 'banana'])));
 
       this.assertText('apple: apple |:  |orange: orange |banana: banana |');
     }
@@ -215,13 +215,13 @@ moduleFor(
 
       this.assertText('0: [outer: Alex] [inner: Alex]1: [outer: Ben] [inner: Ben]');
 
-      this.runTask(() => this.context.names.pushObject('Sophie'));
+      runTask(() => this.context.names.pushObject('Sophie'));
 
       this.assertText(
         '0: [outer: Alex] [inner: Alex]1: [outer: Ben] [inner: Ben]2: [outer: Sophie] [inner: Sophie]'
       );
 
-      this.runTask(() => set(this.context, 'names', emberA(['Alex', 'Ben'])));
+      runTask(() => set(this.context, 'names', emberA(['Alex', 'Ben'])));
 
       this.assertText('0: [outer: Alex] [inner: Alex]1: [outer: Ben] [inner: Ben]');
     }
@@ -268,13 +268,13 @@ moduleFor(
         'Hi Sophie (aged 0). Hi Sophie (aged 0) and Ben. Hi Sophie (aged 0), Ben and Alex. Hi Sophie (aged 0), Ben, Alex and Sarah.'
       );
 
-      this.runTask(() => set(this.context, 'age', 1));
+      runTask(() => set(this.context, 'age', 1));
 
       this.assertText(
         'Hi Sophie (aged 1). Hi Sophie (aged 1) and Ben. Hi Sophie (aged 1), Ben and Alex. Hi Sophie (aged 1), Ben, Alex and Sarah.'
       );
 
-      this.runTask(() => set(this.context, 'age', 0));
+      runTask(() => set(this.context, 'age', 0));
 
       this.assertText(
         'Hi Sophie (aged 0). Hi Sophie (aged 0) and Ben. Hi Sophie (aged 0), Ben and Alex. Hi Sophie (aged 0), Ben, Alex and Sarah.'
@@ -302,11 +302,11 @@ moduleFor(
 
       this.assertText('number: EVEN0number: ODD1number: EVEN2number: ODD3');
 
-      this.runTask(() => set(this.context, 'model.type', 'integer'));
+      runTask(() => set(this.context, 'model.type', 'integer'));
 
       this.assertText('integer: EVEN0integer: ODD1integer: EVEN2integer: ODD3');
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'model', {
           items: ['even', 'odd', 'even', 'odd'],
           type: 'number',
@@ -335,11 +335,11 @@ moduleFor(
 
       this.assertText('Nothing!');
 
-      this.runTask(() => set(this.context, 'item.thing', 'thing'));
+      runTask(() => set(this.context, 'item.thing', 'thing'));
 
       this.assertText('thing');
 
-      this.runTask(() => set(this.context, 'item', { thing: false }));
+      runTask(() => set(this.context, 'item', { thing: false }));
 
       this.assertText('Nothing!');
     }
@@ -374,11 +374,11 @@ moduleFor(
 
       this.assertText('inner.name: Sophie');
 
-      this.runTask(() => set(this.context, 'name', 'Ben'));
+      runTask(() => set(this.context, 'name', 'Ben'));
 
       this.assertText('inner.name: Ben');
 
-      this.runTask(() => set(this.context, 'name', 'Sophie'));
+      runTask(() => set(this.context, 'name', 'Sophie'));
 
       this.assertText('inner.name: Sophie');
     }

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/readonly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/readonly-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
 
 import { set, get } from '@ember/-internals/metal';
 
@@ -27,7 +27,7 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(component, 'value', 13));
+      runTask(() => set(component, 'value', 13));
       this.assert.notOk(component.attrs.value.update);
 
       this.assertText('13', 'local property is updated');
@@ -105,13 +105,13 @@ moduleFor(
       assert.strictEqual(get(component, 'value'), 'initial', 'no mutable cell');
       assert.strictEqual(this.context.thing, 'initial');
 
-      this.runTask(() => set(this.context, 'thing', 'updated!'));
+      runTask(() => set(this.context, 'thing', 'updated!'));
 
       this.assertText('updated!');
       assert.strictEqual(component.attrs.value, 'updated!', 'passed down value was set in attrs');
       assert.strictEqual(get(component, 'value'), 'updated!', 'passed down value was set');
 
-      this.runTask(() => set(this.context, 'thing', 'initial'));
+      runTask(() => set(this.context, 'thing', 'initial'));
 
       this.assertText('initial');
     }
@@ -142,13 +142,13 @@ moduleFor(
       assert.deepEqual(get(component, 'value'), { prop: 'initial' });
       assert.deepEqual(this.context.thing, { prop: 'initial' });
 
-      this.runTask(() => set(component, 'value.prop', 'updated!'));
+      runTask(() => set(component, 'value.prop', 'updated!'));
 
       this.assertText('updated!', 'nested path is updated');
       assert.deepEqual(get(component, 'value'), { prop: 'updated!' });
       assert.deepEqual(this.context.thing, { prop: 'updated!' });
 
-      this.runTask(() => set(component, 'value.prop', 'initial'));
+      runTask(() => set(component, 'value.prop', 'initial'));
 
       this.assertText('initial');
     }
@@ -174,12 +174,12 @@ moduleFor(
       this.assert.notOk(component.attrs.value.update);
       this.assert.strictEqual(get(component, 'value'), '12');
 
-      this.runTask(() => set(component, 'value', '13'));
+      runTask(() => set(component, 'value', '13'));
 
       this.assertText('13', 'local property is updated');
       this.assert.strictEqual(get(component, 'value'), '13');
 
-      this.runTask(() => set(component, 'value', '12'));
+      runTask(() => set(component, 'value', '12'));
 
       this.assertText('12');
     }
@@ -217,7 +217,7 @@ moduleFor(
       this.assert.equal(get(middle, 'foo'), 12, "middle's local foo received the value");
 
       // updating the mut-cell directly
-      this.runTask(() => bottom.attrs.bar.update(13));
+      runTask(() => bottom.attrs.bar.update(13));
 
       this.assert.equal(
         get(bottom, 'bar'),
@@ -232,7 +232,7 @@ moduleFor(
       this.assertText('13 13');
       this.assert.equal(get(this.context, 'val'), 12, 'But context val is not updated');
 
-      this.runTask(() => set(bottom, 'bar', 14));
+      runTask(() => set(bottom, 'bar', 14));
 
       this.assert.equal(
         get(bottom, 'bar'),
@@ -248,7 +248,7 @@ moduleFor(
       this.assert.equal(get(this.context, 'val'), 12, 'But context val is not updated');
 
       this.assert.notOk(middle.attrs.foo.update, "middle's foo attr is not a mutable cell");
-      this.runTask(() => set(middle, 'foo', 15));
+      runTask(() => set(middle, 'foo', 15));
 
       this.assertText('15 15');
       this.assert.equal(get(middle, 'foo'), 15, "set of middle's foo took effect");
@@ -259,7 +259,7 @@ moduleFor(
       );
       this.assert.equal(get(this.context, 'val'), 12, 'Context val remains unchanged');
 
-      this.runTask(() => set(this.context, 'val', 10));
+      runTask(() => set(this.context, 'val', 10));
 
       this.assertText('10 10');
       this.assert.equal(
@@ -274,7 +274,7 @@ moduleFor(
       );
 
       // setting as a normal property
-      this.runTask(() => set(bottom, 'bar', undefined));
+      runTask(() => set(bottom, 'bar', undefined));
 
       this.assertText(' ');
       this.assert.equal(
@@ -288,7 +288,7 @@ moduleFor(
         "middle's local foo was updated to a falsy value"
       );
 
-      this.runTask(() => set(this.context, 'val', 12));
+      runTask(() => set(this.context, 'val', 12));
       this.assertText('12 12', 'bottom and middle were both reset');
     }
   }

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/text-area-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/text-area-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor, classes, applyMixins } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, classes, applyMixins, runTask } from 'internal-test-helpers';
 
 import { assign } from '@ember/polyfills';
 import { set } from '@ember/-internals/metal';
@@ -40,10 +40,10 @@ class BoundTextAreaAttributes {
 
         this.assertStableRerender();
 
-        this.runTask(() => set(this.context, 'value', second));
+        runTask(() => set(this.context, 'value', second));
         this.assertTextArea({ attrs: { [attribute]: second } });
 
-        this.runTask(() => set(this.context, 'value', first));
+        runTask(() => set(this.context, 'value', first));
         this.assertTextArea({ attrs: { [attribute]: first } });
       },
     };
@@ -94,10 +94,10 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'disabled', true));
+      runTask(() => set(this.context, 'disabled', true));
       assert.ok(this.$('textarea').is(':disabled'));
 
-      this.runTask(() => set(this.context, 'disabled', false));
+      runTask(() => set(this.context, 'disabled', false));
       assert.ok(this.$('textarea').is(':not(:disabled)'));
     }
 
@@ -109,10 +109,10 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'model.val', 'Auckland'));
+      runTask(() => set(this.context, 'model.val', 'Auckland'));
       this.assertTextArea({ value: 'Auckland' });
 
-      this.runTask(() => set(this.context, 'model', { val: 'A beautiful day in Seattle' }));
+      runTask(() => set(this.context, 'model', { val: 'A beautiful day in Seattle' }));
       this.assertTextArea({ value: 'A beautiful day in Seattle' });
     }
 
@@ -123,11 +123,11 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'message', 'hello'));
+      runTask(() => set(this.context, 'message', 'hello'));
 
       this.assert.strictEqual(this.firstChild.value, 'hello');
 
-      this.runTask(() => set(this.context, 'message', ''));
+      runTask(() => set(this.context, 'message', ''));
 
       this.assert.strictEqual(this.firstChild.value, '');
     }
@@ -140,25 +140,25 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => {
+      runTask(() => {
         this.firstChild.value = 'Auckland';
         this.triggerEvent('cut');
       });
       this.assertTextArea({ value: 'Auckland' });
 
-      this.runTask(() => {
+      runTask(() => {
         this.firstChild.value = 'Hope';
         this.triggerEvent('paste');
       });
       this.assertTextArea({ value: 'Hope' });
 
-      this.runTask(() => {
+      runTask(() => {
         this.firstChild.value = 'Boston';
         this.triggerEvent('input');
       });
       this.assertTextArea({ value: 'Boston' });
 
-      this.runTask(() => set(this.context, 'model', { val: 'A beautiful day in Seattle' }));
+      runTask(() => set(this.context, 'model', { val: 'A beautiful day in Seattle' }));
       this.assertTextArea({ value: 'A beautiful day in Seattle' });
     }
   }

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/unbound-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/unbound-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor, strip } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, strip, runTask } from 'internal-test-helpers';
 
 import { set, get, setProperties } from '@ember/-internals/metal';
 import { A as emberA } from '@ember/-internals/runtime';
@@ -17,15 +17,15 @@ moduleFor(
 
       this.assertText('No spans here, son.');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('No spans here, son.');
 
-      this.runTask(() => set(this.context, 'content.anUnboundString', 'HEY'));
+      runTask(() => set(this.context, 'content.anUnboundString', 'HEY'));
 
       this.assertText('No spans here, son.');
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'content', {
           anUnboundString: 'No spans here, son.',
         })
@@ -41,7 +41,7 @@ moduleFor(
 
       this.assertText('abc123');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('abc123');
     }
@@ -53,15 +53,15 @@ moduleFor(
 
       this.assertText('bam1');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('bam1');
 
-      this.runTask(() => this.context.items.setEach('wham', 'HEY'));
+      runTask(() => this.context.items.setEach('wham', 'HEY'));
 
       this.assertText('bam1');
 
-      this.runTask(() => set(this.context, 'items', emberA([{ wham: 'bam' }, { wham: 1 }])));
+      runTask(() => set(this.context, 'items', emberA([{ wham: 'bam' }, { wham: 1 }])));
 
       this.assertText('bam1');
     }
@@ -87,15 +87,15 @@ moduleFor(
 
       this.assertHTML('<a href="BORK"></a>');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertHTML('<a href="BORK"></a>');
 
-      this.runTask(() => set(this.context, 'model.foo', 'OOF'));
+      runTask(() => set(this.context, 'model.foo', 'OOF'));
 
       this.assertHTML('<a href="BORK"></a>');
 
-      this.runTask(() => set(this.context, 'model', { foo: 'BORK' }));
+      runTask(() => set(this.context, 'model', { foo: 'BORK' }));
 
       this.assertHTML('<a href="BORK"></a>');
     }
@@ -139,15 +139,15 @@ moduleFor(
 
       this.assertHTML(escapedHtml);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertHTML(escapedHtml);
 
-      this.runTask(() => this.context.people.setEach('url', 'http://google.com'));
+      runTask(() => this.context.people.setEach('url', 'http://google.com'));
 
       this.assertHTML(escapedHtml);
 
-      this.runTask(() => set(this.context, 'people', unsafeUrls));
+      runTask(() => set(this.context, 'people', unsafeUrls));
 
       this.assertHTML(escapedHtml);
     }
@@ -159,25 +159,25 @@ moduleFor(
 
       this.assertText('BORK');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('BORK');
 
-      this.runTask(() => set(this.context, 'foo', 'OOF'));
+      runTask(() => set(this.context, 'foo', 'OOF'));
 
       this.assertText('BORK');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('OOF');
 
-      this.runTask(() => set(this.context, 'foo', ''));
+      runTask(() => set(this.context, 'foo', ''));
 
       this.assertText('OOF');
 
-      this.runTask(() => set(this.context, 'foo', 'BORK'));
+      runTask(() => set(this.context, 'foo', 'BORK'));
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('BORK');
     }
@@ -192,22 +192,22 @@ moduleFor(
 
       this.assertText('BORK');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('BORK');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'foo', 'oof');
         this.rerender();
       });
 
       this.assertText('BORK');
 
-      this.runTask(() => set(this.context, 'foo', 'blip'));
+      runTask(() => set(this.context, 'foo', 'blip'));
 
       this.assertText('BORK');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'foo', 'bork');
         this.rerender();
       });
@@ -226,22 +226,22 @@ moduleFor(
 
       this.assertText('BORK BORK');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('BORK BORK');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'foo', 'oof');
         this.rerender();
       });
 
       this.assertText('BORK BORK');
 
-      this.runTask(() => set(this.context, 'foo', 'blip'));
+      runTask(() => set(this.context, 'foo', 'blip'));
 
       this.assertText('BORK BORK');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'foo', 'bork');
         this.rerender();
       });
@@ -268,15 +268,15 @@ moduleFor(
 
       this.assertText('XXXXX XXXXX XX XXXX');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('XXXXX XXXXX XX XXXX');
 
-      this.runTask(() => set(this.context, 'bar', 1));
+      runTask(() => set(this.context, 'bar', 1));
 
       this.assertText('XXXXX X XX XXXX');
 
-      this.runTask(() => set(this.context, 'bar', 5));
+      runTask(() => set(this.context, 'bar', 5));
 
       this.assertText('XXXXX XXXXX XX XXXX');
     }
@@ -298,11 +298,11 @@ moduleFor(
 
       this.assertText('before-core-bar before-core-bar bar-core-after bar-core-after');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('before-core-bar before-core-bar bar-core-after bar-core-after');
 
-      this.runTask(() => {
+      runTask(() => {
         setProperties(this.context.model, {
           prefix: 'beforeChanged',
           value: 'coreChanged',
@@ -314,7 +314,7 @@ moduleFor(
         'before-core-bar beforeChanged-coreChanged-bar bar-core-after bar-coreChanged-afterChanged'
       );
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'model', {
           prefix: 'before',
           value: 'core',
@@ -341,15 +341,15 @@ moduleFor(
 
       this.assertText('abc abc');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('abc abc');
 
-      this.runTask(() => set(this.context, 'model.bar', 'X'));
+      runTask(() => set(this.context, 'model.bar', 'X'));
 
       this.assertText('aXc abc');
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'model', {
           foo: 'a',
           bar: 'b',
@@ -409,15 +409,15 @@ moduleFor(
 
       this.assertText('SHOOBY SHOOBY shoobytaylor shoobytaylor');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('SHOOBY SHOOBY shoobytaylor shoobytaylor');
 
-      this.runTask(() => set(this.context, 'person.firstName', 'sally'));
+      runTask(() => set(this.context, 'person.firstName', 'sally'));
 
       this.assertText('SALLY SHOOBY sallytaylor shoobytaylor');
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'person', {
           firstName: 'shooby',
           lastName: 'taylor',
@@ -448,15 +448,15 @@ moduleFor(
 
       this.assertText('SHOOBY SHOOBYCINDY CINDY');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('SHOOBY SHOOBYCINDY CINDY');
 
-      this.runTask(() => this.context.people.setEach('firstName', 'chad'));
+      runTask(() => this.context.people.setEach('firstName', 'chad'));
 
       this.assertText('CHAD SHOOBYCHAD CINDY');
 
-      this.runTask(() =>
+      runTask(() =>
         set(
           this.context,
           'people',
@@ -525,15 +525,15 @@ moduleFor(
 
       this.assertText('SHOOBY SHOOBY shoobytaylor shoobytaylor');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('SHOOBY SHOOBY shoobytaylor shoobytaylor');
 
-      this.runTask(() => set(this.context, 'person.firstName', 'sally'));
+      runTask(() => set(this.context, 'person.firstName', 'sally'));
 
       this.assertText('SALLY SHOOBY sallytaylor shoobytaylor');
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'person', {
           firstName: 'shooby',
           lastName: 'taylor',
@@ -565,15 +565,15 @@ moduleFor(
 
       this.assertText('truetrue');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('truetrue');
 
-      this.runTask(() => set(this.context, 'model.bar', false));
+      runTask(() => set(this.context, 'model.bar', false));
 
       this.assertText('falsefalse');
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'model', {
           foo: true,
           notfoo: false,
@@ -603,15 +603,15 @@ moduleFor(
 
       this.assertText('bork');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('bork');
 
-      this.runTask(() => set(fooBarInstance, 'model.foo', 'oof'));
+      runTask(() => set(fooBarInstance, 'model.foo', 'oof'));
 
       this.assertText('bork');
 
-      this.runTask(() => set(fooBarInstance, 'model', { foo: 'bork' }));
+      runTask(() => set(fooBarInstance, 'model', { foo: 'bork' }));
 
       this.assertText('bork');
     }
@@ -635,15 +635,15 @@ moduleFor(
 
       this.assertText('bork');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('bork');
 
-      this.runTask(() => set(fooBarInstance, 'model.foo', 'oof'));
+      runTask(() => set(fooBarInstance, 'model.foo', 'oof'));
 
       this.assertText('bork');
 
-      this.runTask(() => set(fooBarInstance, 'model', { foo: 'bork' }));
+      runTask(() => set(fooBarInstance, 'model', { foo: 'bork' }));
 
       this.assertText('bork');
     }

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/yield-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/yield-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
 
@@ -19,10 +19,10 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'object.title', 'Vancouver'));
+      runTask(() => set(this.context, 'object.title', 'Vancouver'));
       this.assertText('[In layout:] [In Block:] Vancouver');
 
-      this.runTask(() => set(this.context, 'object', { title: 'Seattle' }));
+      runTask(() => set(this.context, 'object', { title: 'Seattle' }));
       this.assertText('[In layout:] [In Block:] Seattle');
     }
 
@@ -41,10 +41,10 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'object.title', 'Vancouver'));
+      runTask(() => set(this.context, 'object.title', 'Vancouver'));
       this.assertText('[In layout:] [In Block:] Vancouver');
 
-      this.runTask(() => set(this.context, 'object', { title: 'Seattle' }));
+      runTask(() => set(this.context, 'object', { title: 'Seattle' }));
       this.assertText('[In layout:] [In Block:] Seattle');
     }
 
@@ -62,10 +62,10 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'list', [4, 5]));
+      runTask(() => set(this.context, 'list', [4, 5]));
       this.assertText('HelloHello');
 
-      this.runTask(() => set(this.context, 'list', list));
+      runTask(() => set(this.context, 'list', list));
       this.assertText('HelloHelloHello');
     }
 
@@ -81,10 +81,10 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'boolean', false));
+      runTask(() => set(this.context, 'boolean', false));
       this.assertText('');
 
-      this.runTask(() => set(this.context, 'boolean', true));
+      runTask(() => set(this.context, 'boolean', true));
       this.assertText('Hello');
     }
 
@@ -98,10 +98,10 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'text', 'portland'));
+      runTask(() => set(this.context, 'text', 'portland'));
       this.assertText('portland');
 
-      this.runTask(() => set(this.context, 'text', 'ohai'));
+      runTask(() => set(this.context, 'text', 'ohai'));
       this.assertText('ohai');
     }
 
@@ -120,10 +120,10 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'text', 'portland'));
+      runTask(() => set(this.context, 'text', 'portland'));
       this.assertText('portland');
 
-      this.runTask(() => set(this.context, 'text', 'ohai'));
+      runTask(() => set(this.context, 'text', 'ohai'));
       this.assertText('ohai');
     }
 
@@ -139,10 +139,10 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'title', 'Mr. Chag'));
+      runTask(() => set(this.context, 'title', 'Mr. Chag'));
       this.assertText('Hello: Mr. Chag');
 
-      this.runTask(() => set(this.context, 'title', 'Mr. Selden'));
+      runTask(() => set(this.context, 'title', 'Mr. Selden'));
       this.assertText('Hello: Mr. Selden');
     }
 
@@ -161,10 +161,10 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'boundText', 'Otherworld'));
+      runTask(() => set(this.context, 'boundText', 'Otherworld'));
       this.assertText('InnerOtherworld');
 
-      this.runTask(() => set(this.context, 'boundText', 'Original'));
+      runTask(() => set(this.context, 'boundText', 'Original'));
       this.assertText('InnerOriginal');
     }
 
@@ -183,10 +183,10 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'boundText', 'Otherworld'));
+      runTask(() => set(this.context, 'boundText', 'Otherworld'));
       this.assertText('InnerOtherworld');
 
-      this.runTask(() => set(this.context, 'boundText', 'Outer'));
+      runTask(() => set(this.context, 'boundText', 'Outer'));
       this.assertText('InnerOuter');
     }
 
@@ -203,10 +203,10 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'item', 'Otherworld'));
+      runTask(() => set(this.context, 'item', 'Otherworld'));
       this.assertText('InnerOtherworld');
 
-      this.runTask(() => set(this.context, 'item', 'Outer'));
+      runTask(() => set(this.context, 'item', 'Outer'));
       this.assertText('InnerOuter');
     }
 
@@ -223,10 +223,10 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'boundText', 'Update'));
+      runTask(() => set(this.context, 'boundText', 'Update'));
       this.assertText('UpdateUpdate');
 
-      this.runTask(() => set(this.context, 'boundText', 'Outer'));
+      runTask(() => set(this.context, 'boundText', 'Outer'));
       this.assertText('OuterOuter');
     }
 
@@ -267,10 +267,10 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'boundText', 'update'));
+      runTask(() => set(this.context, 'boundText', 'update'));
       this.assertText('Hello update');
 
-      this.runTask(() => set(this.context, 'boundText', 'world'));
+      runTask(() => set(this.context, 'boundText', 'world'));
       this.assertText('Hello world');
     }
   }

--- a/packages/@ember/-internals/glimmer/tests/integration/input-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/input-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
 
@@ -14,7 +14,7 @@ moduleFor(
         `${attributeName} is set on initial render`
       );
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
       this.assertAttributeHasValue(
         attributeName,
         values[0],
@@ -42,7 +42,7 @@ moduleFor(
         `${propertyName} is set on initial render`
       );
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
       this.assertPropertyHasValue(
         propertyName,
         values[0],
@@ -66,7 +66,7 @@ moduleFor(
       this.render(template, { value: values[0] });
       this.assertPropertyHasValue(value, '', `${value} is set on initial render`);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
       this.assertPropertyHasValue(value, '', `${value} is set on noop rerender`);
       this.setComponentValue(values[1]);
 
@@ -83,21 +83,21 @@ moduleFor(
 
       this.assert.equal(this.$inputElement().prop('disabled'), false);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assert.equal(this.$inputElement().prop('disabled'), false);
 
-      this.runTask(() => this.context.set('model.value', true));
+      runTask(() => this.context.set('model.value', true));
 
       this.assert.equal(this.$inputElement().prop('disabled'), true);
       this.assertHTML('<input disabled="">'); // Note the DOM output is <input disabled>
 
-      this.runTask(() => this.context.set('model.value', 'wat'));
+      runTask(() => this.context.set('model.value', 'wat'));
 
       this.assert.equal(this.$inputElement().prop('disabled'), true);
       this.assertHTML('<input disabled="">'); // Note the DOM output is <input disabled>
 
-      this.runTask(() => this.context.set('model', { value: false }));
+      runTask(() => this.context.set('model', { value: false }));
 
       this.assert.equal(this.$inputElement().prop('disabled'), false);
       this.assertHTML('<input>');
@@ -207,7 +207,7 @@ moduleFor(
     }
 
     setComponentValue(value) {
-      this.runTask(() => set(this.context, 'value', value));
+      runTask(() => set(this.context, 'value', value));
     }
 
     setSelectionRange(start, end) {

--- a/packages/@ember/-internals/glimmer/tests/integration/mount-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/mount-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, ApplicationTestCase, RenderingTestCase } from 'internal-test-helpers';
+import { moduleFor, ApplicationTestCase, RenderingTestCase, runTask } from 'internal-test-helpers';
 
 import { getOwner } from '@ember/-internals/owner';
 import { compile, Component } from '../utils/helpers';
@@ -105,11 +105,11 @@ moduleFor(
 
         this.assertInnerHTML('<h2>Chat here, dgeb</h2>');
 
-        this.runTask(() => set(controller, 'username', 'chancancode'));
+        runTask(() => set(controller, 'username', 'chancancode'));
 
         this.assertInnerHTML('<h2>Chat here, chancancode</h2>');
 
-        this.runTask(() => set(controller, 'username', 'dgeb'));
+        runTask(() => set(controller, 'username', 'dgeb'));
 
         this.assertInnerHTML('<h2>Chat here, dgeb</h2>');
       });
@@ -204,27 +204,27 @@ moduleFor(
       return this.visit('/bound-engine-name').then(() => {
         this.assertInnerHTML('<!---->');
 
-        this.runTask(() => set(controller, 'engineName', 'foo'));
+        runTask(() => set(controller, 'engineName', 'foo'));
 
         this.assertInnerHTML('<h2>Foo Engine</h2>');
 
-        this.runTask(() => set(controller, 'engineName', undefined));
+        runTask(() => set(controller, 'engineName', undefined));
 
         this.assertInnerHTML('<!---->');
 
-        this.runTask(() => set(controller, 'engineName', 'foo'));
+        runTask(() => set(controller, 'engineName', 'foo'));
 
         this.assertInnerHTML('<h2>Foo Engine</h2>');
 
-        this.runTask(() => set(controller, 'engineName', 'bar'));
+        runTask(() => set(controller, 'engineName', 'bar'));
 
         this.assertInnerHTML('<h2>Bar Engine</h2>');
 
-        this.runTask(() => set(controller, 'engineName', 'foo'));
+        runTask(() => set(controller, 'engineName', 'foo'));
 
         this.assertInnerHTML('<h2>Foo Engine</h2>');
 
-        this.runTask(() => set(controller, 'engineName', null));
+        runTask(() => set(controller, 'engineName', null));
 
         this.assertInnerHTML('<!---->');
       });
@@ -356,27 +356,27 @@ if (EMBER_ENGINES_MOUNT_PARAMS) {
         return this.visit('/engine-params-bound').then(() => {
           this.assertInnerHTML('<h2>Param Engine: </h2>');
 
-          this.runTask(() => set(controller, 'boundParamValue', 'bar'));
+          runTask(() => set(controller, 'boundParamValue', 'bar'));
 
           this.assertInnerHTML('<h2>Param Engine: bar</h2>');
 
-          this.runTask(() => set(controller, 'boundParamValue', undefined));
+          runTask(() => set(controller, 'boundParamValue', undefined));
 
           this.assertInnerHTML('<h2>Param Engine: </h2>');
 
-          this.runTask(() => set(controller, 'boundParamValue', 'bar'));
+          runTask(() => set(controller, 'boundParamValue', 'bar'));
 
           this.assertInnerHTML('<h2>Param Engine: bar</h2>');
 
-          this.runTask(() => set(controller, 'boundParamValue', 'baz'));
+          runTask(() => set(controller, 'boundParamValue', 'baz'));
 
           this.assertInnerHTML('<h2>Param Engine: baz</h2>');
 
-          this.runTask(() => set(controller, 'boundParamValue', 'bar'));
+          runTask(() => set(controller, 'boundParamValue', 'bar'));
 
           this.assertInnerHTML('<h2>Param Engine: bar</h2>');
 
-          this.runTask(() => set(controller, 'boundParamValue', null));
+          runTask(() => set(controller, 'boundParamValue', null));
 
           this.assertInnerHTML('<h2>Param Engine: </h2>');
         });

--- a/packages/@ember/-internals/glimmer/tests/integration/outlet-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/outlet-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor, runAppend } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, runAppend, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
 
@@ -27,7 +27,7 @@ moduleFor(
         outlets: Object.create(null),
       };
 
-      this.runTask(() => this.component.setOutletState(outletState));
+      runTask(() => this.component.setOutletState(outletState));
 
       runAppend(this.component);
 
@@ -48,7 +48,7 @@ moduleFor(
         outlets: Object.create(null),
       };
 
-      this.runTask(() => this.component.setOutletState(outletState));
+      runTask(() => this.component.setOutletState(outletState));
 
       runAppend(this.component);
 
@@ -67,7 +67,7 @@ moduleFor(
         outlets: Object.create(null),
       };
 
-      this.runTask(() => this.component.setOutletState(outletState));
+      runTask(() => this.component.setOutletState(outletState));
 
       this.assertText('HI');
 
@@ -86,7 +86,7 @@ moduleFor(
         outlets: Object.create(null),
       };
 
-      this.runTask(() => this.component.setOutletState(outletState));
+      runTask(() => this.component.setOutletState(outletState));
 
       this.assertText('HIBYE');
     }
@@ -105,7 +105,7 @@ moduleFor(
         outlets: Object.create(null),
       };
 
-      this.runTask(() => this.component.setOutletState(outletState));
+      runTask(() => this.component.setOutletState(outletState));
 
       runAppend(this.component);
 
@@ -126,7 +126,7 @@ moduleFor(
         outlets: Object.create(null),
       };
 
-      this.runTask(() => this.component.setOutletState(outletState));
+      runTask(() => this.component.setOutletState(outletState));
 
       this.assertText('HIBYE');
     }
@@ -145,7 +145,7 @@ moduleFor(
         outlets: Object.create(null),
       };
 
-      this.runTask(() => this.component.setOutletState(outletState));
+      runTask(() => this.component.setOutletState(outletState));
 
       runAppend(this.component);
 
@@ -166,7 +166,7 @@ moduleFor(
         outlets: Object.create(null),
       };
 
-      this.runTask(() => this.component.setOutletState(outletState));
+      runTask(() => this.component.setOutletState(outletState));
 
       this.assertText('HIBYE');
     }
@@ -185,7 +185,7 @@ moduleFor(
         outlets: Object.create(null),
       };
 
-      this.runTask(() => this.component.setOutletState(outletState));
+      runTask(() => this.component.setOutletState(outletState));
 
       runAppend(this.component);
 
@@ -206,7 +206,7 @@ moduleFor(
         outlets: Object.create(null),
       };
 
-      this.runTask(() => this.component.setOutletState(outletState));
+      runTask(() => this.component.setOutletState(outletState));
 
       this.assertText('HI');
     }
@@ -226,7 +226,7 @@ moduleFor(
         outlets: Object.create(null),
       };
 
-      this.runTask(() => this.component.setOutletState(outletState));
+      runTask(() => this.component.setOutletState(outletState));
 
       runAppend(this.component);
 
@@ -260,11 +260,11 @@ moduleFor(
         outlets: Object.create(null),
       };
 
-      this.runTask(() => this.component.setOutletState(outletState));
+      runTask(() => this.component.setOutletState(outletState));
 
       this.assertText('HIFOO');
 
-      this.runTask(() => set(controller, 'outletName', 'bar'));
+      runTask(() => set(controller, 'outletName', 'bar'));
 
       this.assertText('HIBAR');
     }
@@ -306,7 +306,7 @@ moduleFor(
         },
       };
 
-      this.runTask(() => this.component.setOutletState(outletState));
+      runTask(() => this.component.setOutletState(outletState));
 
       runAppend(this.component);
 

--- a/packages/@ember/-internals/glimmer/tests/integration/refinements-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/refinements-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor, strip } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, strip, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
 
@@ -54,11 +54,11 @@ moduleFor(
 
       this.assertText('var---var---var---var---var---var---var');
 
-      this.runTask(() => set(this.context, 'var', 'RARRR!!!'));
+      runTask(() => set(this.context, 'var', 'RARRR!!!'));
 
       this.assertText('RARRR!!!---RARRR!!!---RARRR!!!---RARRR!!!---RARRR!!!---RARRR!!!---RARRR!!!');
 
-      this.runTask(() => set(this.context, 'var', 'var'));
+      runTask(() => set(this.context, 'var', 'var'));
 
       this.assertText('var---var---var---var---var---var---var');
     }

--- a/packages/@ember/-internals/glimmer/tests/integration/svg-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/svg-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor, strip } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, strip, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
 
@@ -20,7 +20,7 @@ moduleFor(
       </div>
     `);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertInnerHTML(strip`
       <div>
@@ -28,11 +28,11 @@ moduleFor(
       </div>
     `);
 
-      this.runTask(() => set(this.context, 'model.viewBoxString', null));
+      runTask(() => set(this.context, 'model.viewBoxString', null));
 
       assert.equal(this.firstChild.getAttribute('svg'), null);
 
-      this.runTask(() => set(this.context, 'model', { viewBoxString }));
+      runTask(() => set(this.context, 'model', { viewBoxString }));
 
       this.assertInnerHTML(strip`
       <div>
@@ -56,7 +56,7 @@ moduleFor(
       </div>
     `);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertInnerHTML(strip`
       <div>
@@ -64,11 +64,11 @@ moduleFor(
       </div>
     `);
 
-      this.runTask(() => set(this.context, 'model.viewBoxString', null));
+      runTask(() => set(this.context, 'model.viewBoxString', null));
 
       assert.equal(this.firstChild.getAttribute('svg'), null);
 
-      this.runTask(() => set(this.context, 'model', { viewBoxString }));
+      runTask(() => set(this.context, 'model', { viewBoxString }));
 
       this.assertInnerHTML(strip`
       <div>
@@ -92,7 +92,7 @@ moduleFor(
       </div>
     `);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertInnerHTML(strip`
       <div>
@@ -100,7 +100,7 @@ moduleFor(
       </div>
     `);
 
-      this.runTask(() => set(this.context, 'model.viewBoxString', '200 200'));
+      runTask(() => set(this.context, 'model.viewBoxString', '200 200'));
 
       this.assertInnerHTML(strip`
       <div>
@@ -108,7 +108,7 @@ moduleFor(
       </div>
     `);
 
-      this.runTask(() => set(this.context, 'model', { viewBoxString }));
+      runTask(() => set(this.context, 'model', { viewBoxString }));
 
       this.assertInnerHTML(strip`
       <div>
@@ -130,7 +130,7 @@ moduleFor(
       </div>
     `);
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertInnerHTML(strip`
       <div>
@@ -138,7 +138,7 @@ moduleFor(
       </div>
     `);
 
-      this.runTask(() => set(this.context, 'model.color', 'yellow'));
+      runTask(() => set(this.context, 'model.color', 'yellow'));
 
       this.assertInnerHTML(strip`
       <div>
@@ -146,7 +146,7 @@ moduleFor(
       </div>
     `);
 
-      this.runTask(() => set(this.context, 'model', { color: 'blue' }));
+      runTask(() => set(this.context, 'model', { color: 'blue' }));
 
       this.assertInnerHTML(strip`
       <div>

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/each-in-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/each-in-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase, strip, applyMixins } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, strip, applyMixins, runTask } from 'internal-test-helpers';
 
 import { get, set } from '@ember/-internals/metal';
 import { Object as EmberObject, ObjectProxy } from '@ember/-internals/runtime';
@@ -110,19 +110,19 @@ class AbstractEachInTest extends RenderingTestCase {
   }
 
   replaceHash(hash) {
-    this.runTask(() => set(this.context, 'hash', this.createHash(hash).hash));
+    runTask(() => set(this.context, 'hash', this.createHash(hash).hash));
   }
 
   clear() {
-    return this.runTask(() => set(this.context, 'hash', this.createHash({}).hash));
+    return runTask(() => set(this.context, 'hash', this.createHash({}).hash));
   }
 
   setProp(key, value) {
-    return this.runTask(() => this.delegate.setProp(this.context, key, value));
+    return runTask(() => this.delegate.setProp(this.context, key, value));
   }
 
   updateNestedValue(key, innerKey, value) {
-    return this.runTask(() => this.delegate.updateNestedValue(this.context, key, innerKey, value));
+    return runTask(() => this.delegate.updateNestedValue(this.context, key, innerKey, value));
   }
 
   render(template, context = {}) {
@@ -182,7 +182,7 @@ class EachInTest extends AbstractEachInTest {
       this.assertText('Smartphones: 8203JavaScript Frameworks: InfinityTweets: 100');
     }
 
-    this.runTask(() => this.updateNestedValue('Smartphones', 'reports.unitsSold', 8204));
+    runTask(() => this.updateNestedValue('Smartphones', 'reports.unitsSold', 8204));
 
     assert.ok(this.textValue().indexOf('Smartphones: 8204') > -1);
 
@@ -245,21 +245,21 @@ class EachInTest extends AbstractEachInTest {
 
     this.assertStableRerender();
 
-    this.runTask(() => set(context, 'hashes.type', 'otherCategories'));
+    runTask(() => set(context, 'hashes.type', 'otherCategories'));
 
     this.assertText('Emberinios: 533462Tweets: 7323');
 
-    this.runTask(() => set(context, 'hashes.type', 'categories'));
+    runTask(() => set(context, 'hashes.type', 'categories'));
 
     this.assertText('Smartphones: 8203JavaScript Frameworks: Infinity');
 
-    this.runTask(() => set(context, 'hashes.type', 'nonExistent'));
+    runTask(() => set(context, 'hashes.type', 'nonExistent'));
 
     this.clear();
 
     this.assertText('Empty!');
 
-    this.runTask(() => set(context, 'hashes.type', 'categories'));
+    runTask(() => set(context, 'hashes.type', 'categories'));
 
     this.assertText('Smartphones: 8203JavaScript Frameworks: Infinity');
   }
@@ -341,7 +341,7 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => {
+      runTask(() => {
         set(protoCategories, 'Robots', 666);
         set(categories, 'Tweets', 443115);
       });
@@ -379,21 +379,21 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => {
+      runTask(() => {
         let categories = get(this.context, 'categories');
         delete categories.Smartphones;
       });
 
       this.assertInvariants();
 
-      this.runTask(() => {
+      runTask(() => {
         let categories = get(this.context, 'categories');
         categories['Emberinios'] = 123456;
       });
 
       this.assertInvariants();
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'categories', {
           Emberinios: 123456,
         });
@@ -405,7 +405,7 @@ moduleFor(
       </ul>
     `);
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'categories', {
           Smartphones: 8203,
           'JavaScript Frameworks': Infinity,
@@ -452,11 +452,11 @@ moduleFor(
 
       this.assertText('[0:1][1:2][2:3][foo:bar]');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('[0:1][1:2][2:3][foo:bar]');
 
-      this.runTask(() => {
+      runTask(() => {
         set(arr, 'zomg', 'lol');
       });
 
@@ -465,7 +465,7 @@ moduleFor(
       arr = [1, 2, 3];
       arr.foo = 'bar';
 
-      this.runTask(() => set(this.context, 'arr', arr));
+      runTask(() => set(this.context, 'arr', arr));
 
       this.assertText('[0:1][1:2][2:3][foo:bar]');
     }
@@ -551,7 +551,7 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => {
+      runTask(() => {
         set(proxy, 'content.Smartphones', 100);
         set(proxy, 'content.Tweets', 443115);
       });
@@ -564,7 +564,7 @@ moduleFor(
       </ul>
     `);
 
-      this.runTask(() => {
+      runTask(() => {
         set(proxy, 'content', {
           Smartphones: 100,
           Tablets: 20,
@@ -578,7 +578,7 @@ moduleFor(
       </ul>
     `);
 
-      this.runTask(() =>
+      runTask(() =>
         set(
           this.context,
           'categories',
@@ -644,7 +644,7 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => {
+      runTask(() => {
         let map = new Map();
         map.set({ name: 'three' }, 'qux');
         set(this.context, 'map', map);

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/each-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/each-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase, applyMixins, strip } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, applyMixins, strip, runTask } from 'internal-test-helpers';
 
 import { get, set, notifyPropertyChange } from '@ember/-internals/metal';
 import { A as emberA, ArrayProxy, RSVP } from '@ember/-internals/runtime';
@@ -259,7 +259,7 @@ class AbstractEachTest extends RenderingTestCase {
   }
 
   replaceList(list) {
-    this.runTask(() => set(this.context, 'list', this.createList(list).list));
+    runTask(() => set(this.context, 'list', this.createList(list).list));
   }
 
   forEach(callback) {
@@ -329,22 +329,22 @@ class EachTest extends AbstractEachTest {
 
     this.assertText('hello');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('hello');
 
-    this.runTask(() => set(this.objectAt(0), 'text', 'Hello'));
+    runTask(() => set(this.objectAt(0), 'text', 'Hello'));
 
     this.assertText('Hello');
 
-    this.runTask(() => {
+    runTask(() => {
       this.pushObject({ text: ' ' });
       this.pushObject({ text: 'World' });
     });
 
     this.assertText('Hello World');
 
-    this.runTask(() => {
+    runTask(() => {
       this.pushObject({ text: 'Earth' });
       this.removeAt(1);
       this.insertAt(1, { text: 'Globe' });
@@ -352,7 +352,7 @@ class EachTest extends AbstractEachTest {
 
     this.assertText('HelloGlobeWorldEarth');
 
-    this.runTask(() => {
+    runTask(() => {
       this.pushObject({ text: 'Planet' });
       this.removeAt(1);
       this.insertAt(1, { text: ' ' });
@@ -363,7 +363,7 @@ class EachTest extends AbstractEachTest {
 
     this.assertText('Hello WorldPlanet Earth');
 
-    this.runTask(() => {
+    runTask(() => {
       this.pushObject({ text: 'Globe' });
       this.removeAt(1);
       this.insertAt(1, { text: ' ' });
@@ -374,11 +374,11 @@ class EachTest extends AbstractEachTest {
 
     this.assertText('Hello Planet EarthGlobe World');
 
-    this.runTask(() => this.replace(2, 4, [{ text: 'my' }]));
+    runTask(() => this.replace(2, 4, [{ text: 'my' }]));
 
     this.assertText('Hello my World');
 
-    this.runTask(() => this.clear());
+    runTask(() => this.clear());
 
     this.assertText('Empty');
 
@@ -396,7 +396,7 @@ class EachTest extends AbstractEachTest {
 
     this.assertStableRerender();
 
-    this.runTask(() => this.insertAt(1, { text: 'my' }));
+    runTask(() => this.insertAt(1, { text: 'my' }));
 
     this.assertText('[0. hello][1. my][2. world]');
 
@@ -414,7 +414,7 @@ class EachTest extends AbstractEachTest {
 
     this.assertStableRerender();
 
-    this.runTask(() => this.pushObject({ text: 'again' }));
+    runTask(() => this.pushObject({ text: 'again' }));
 
     this.assertText('helloworldagain');
 
@@ -432,7 +432,7 @@ class EachTest extends AbstractEachTest {
 
     this.assertStableRerender();
 
-    this.runTask(() => this.pushObject({ id: 3 }));
+    runTask(() => this.pushObject({ id: 3 }));
 
     this.assertText('123');
 
@@ -450,7 +450,7 @@ class EachTest extends AbstractEachTest {
 
     this.assertStableRerender();
 
-    this.runTask(() => this.pushObject({ id: 3 }));
+    runTask(() => this.pushObject({ id: 3 }));
 
     this.assertText('123');
 
@@ -468,7 +468,7 @@ class EachTest extends AbstractEachTest {
 
     this.assertStableRerender();
 
-    this.runTask(() => this.pushObject(3));
+    runTask(() => this.pushObject(3));
 
     this.assertText('123');
 
@@ -486,7 +486,7 @@ class EachTest extends AbstractEachTest {
 
     this.assertStableRerender();
 
-    this.runTask(() => this.insertAt(2, { id: 4 }));
+    runTask(() => this.insertAt(2, { id: 4 }));
 
     this.assertText('1243');
 
@@ -504,11 +504,11 @@ class EachTest extends AbstractEachTest {
 
     this.assertStableRerender();
 
-    this.runTask(() => this.pushObject('a'));
+    runTask(() => this.pushObject('a'));
 
     this.assertText('aaaa');
 
-    this.runTask(() => this.pushObject('a'));
+    runTask(() => this.pushObject('a'));
 
     this.assertText('aaaaa');
 
@@ -553,7 +553,7 @@ class EachTest extends AbstractEachTest {
 
     this.assertStableRerender();
 
-    this.runTask(() => set(this.objectAt(0), 'value', 3));
+    runTask(() => set(this.objectAt(0), 'value', 3));
 
     this.assertText('PrevNextPrev2NextPrev3Next');
 
@@ -573,11 +573,11 @@ class EachTest extends AbstractEachTest {
 
     this.assertStableRerender();
 
-    this.runTask(() => this.pushObject(duplicateItem));
+    runTask(() => this.pushObject(duplicateItem));
 
     this.assertText('foofoobarbazfoo');
 
-    this.runTask(() => this.pushObject(duplicateItem));
+    runTask(() => this.pushObject(duplicateItem));
 
     this.assertText('foofoobarbazfoofoo');
 
@@ -595,7 +595,7 @@ class EachTest extends AbstractEachTest {
 
     this.takeSnapshot();
 
-    this.runTask(() => {
+    runTask(() => {
       this.popObject();
       this.popObject();
       this.pushObject({ text: ' ' });
@@ -624,7 +624,7 @@ class EachTest extends AbstractEachTest {
 
     let oldSnapshot = this.takeSnapshot();
 
-    this.runTask(() => {
+    runTask(() => {
       this.unshiftObject({ text: ', ' });
       this.unshiftObject({ text: 'Hi' });
       this.pushObject({ text: '!' });
@@ -649,7 +649,7 @@ class EachTest extends AbstractEachTest {
 
     this.assertText('HelloHelloHello');
 
-    this.runTask(() => {
+    runTask(() => {
       this.forEach(hash => set(hash, 'text', 'Goodbye'));
     });
 
@@ -671,15 +671,15 @@ class EachTest extends AbstractEachTest {
 
     this.assertStableRerender();
 
-    this.runTask(() => this.shiftObject());
+    runTask(() => this.shiftObject());
 
     this.assertText('Joel-JoelJoel-Joel');
 
-    this.runTask(() => set(this.context, 'name', 'Godfrey'));
+    runTask(() => set(this.context, 'name', 'Godfrey'));
 
     this.assertText('Godfrey-GodfreyGodfrey-Godfrey');
 
-    this.runTask(() => set(this.context, 'name', 'Joel'));
+    runTask(() => set(this.context, 'name', 'Joel'));
     this.replaceList([{ name: 'Chad' }, { name: 'Zack' }, { name: 'Asa' }]);
 
     this.assertText('Joel-JoelJoelJoel-Joel');
@@ -696,13 +696,13 @@ class EachTest extends AbstractEachTest {
       '[Señor Engineer: Tom Dale][Señor Engineer: Yehuda Katz][Señor Engineer: Godfrey Chan]'
     );
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText(
       '[Señor Engineer: Tom Dale][Señor Engineer: Yehuda Katz][Señor Engineer: Godfrey Chan]'
     );
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.objectAt(1), 'name', 'Stefan Penner');
       this.removeAt(0);
       this.pushObject({ name: 'Tom Dale' });
@@ -714,7 +714,7 @@ class EachTest extends AbstractEachTest {
       '[Principal Engineer: Stefan Penner][Principal Engineer: Chad Hietala][Principal Engineer: Godfrey Chan][Principal Engineer: Tom Dale]'
     );
 
-    this.runTask(() => set(this.context, 'title', 'Señor Engineer'));
+    runTask(() => set(this.context, 'title', 'Señor Engineer'));
     this.replaceList([{ name: 'Tom Dale' }, { name: 'Yehuda Katz' }, { name: 'Godfrey Chan' }]);
 
     this.assertText(
@@ -731,19 +731,19 @@ class EachTest extends AbstractEachTest {
 
     this.assertText('Stef-Yehuda-Stef');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('Stef-Yehuda-Stef');
 
-    this.runTask(() => this.pushObjects([' ', 'Katz']));
+    runTask(() => this.pushObjects([' ', 'Katz']));
 
     this.assertText('Stef-Yehuda Katz-Stef');
 
-    this.runTask(() => set(this.context, 'name', 'Tom'));
+    runTask(() => set(this.context, 'name', 'Tom'));
 
     this.assertText('Tom-Yehuda Katz-Tom');
 
-    this.runTask(() => set(this.context, 'name', 'Stef'));
+    runTask(() => set(this.context, 'name', 'Stef'));
     this.replaceList(['Yehuda']);
 
     this.assertText('Stef-Yehuda-Stef');
@@ -758,23 +758,23 @@ class EachTest extends AbstractEachTest {
 
     this.assertText('No Thing bar');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('No Thing bar');
 
-    this.runTask(() => set(this.context, 'otherThing', 'biz'));
+    runTask(() => set(this.context, 'otherThing', 'biz'));
 
     this.assertText('No Thing biz');
 
-    this.runTask(() => this.pushObject('non-empty'));
+    runTask(() => this.pushObject('non-empty'));
 
     this.assertText('Has Thing');
 
-    this.runTask(() => set(this.context, 'otherThing', 'baz'));
+    runTask(() => set(this.context, 'otherThing', 'baz'));
 
     this.assertText('Has Thing');
 
-    this.runTask(() => set(this.context, 'otherThing', 'bar'));
+    runTask(() => set(this.context, 'otherThing', 'bar'));
     this.replaceList([]);
 
     this.assertText('No Thing bar');
@@ -794,31 +794,31 @@ class EachTest extends AbstractEachTest {
 
     this.assertText('');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('');
 
-    this.runTask(() => this.pushObject({ text: 'foo' }));
+    runTask(() => this.pushObject({ text: 'foo' }));
 
     this.assertText('[foo]');
 
-    this.runTask(() => set(this.objectAt(0), 'text', 'FOO'));
+    runTask(() => set(this.objectAt(0), 'text', 'FOO'));
 
     this.assertText('[FOO]');
 
-    this.runTask(() => this.pushObject({ text: 'bar' }));
+    runTask(() => this.pushObject({ text: 'bar' }));
 
     this.assertText('[FOO][bar]');
 
-    this.runTask(() => set(this.objectAt(1), 'text', 'BAR'));
+    runTask(() => set(this.objectAt(1), 'text', 'BAR'));
 
     this.assertText('[FOO][BAR]');
 
-    this.runTask(() => set(this.objectAt(1), 'text', 'baz'));
+    runTask(() => set(this.objectAt(1), 'text', 'baz'));
 
     this.assertText('[FOO][baz]');
 
-    this.runTask(() => this.replace(1, 1, [{ text: 'BAZ' }]));
+    runTask(() => this.replace(1, 1, [{ text: 'BAZ' }]));
 
     this.assertText('[FOO][BAZ]');
 
@@ -836,15 +836,15 @@ class EachTest extends AbstractEachTest {
 
     this.assertStableRerender();
 
-    this.runTask(() => this.pushObjects([null, ' world']));
+    runTask(() => this.pushObjects([null, ' world']));
 
     this.assertText('before hello world after');
 
-    this.runTask(() => this.replace(1, 2, [undefined, ' world!']));
+    runTask(() => this.replace(1, 2, [undefined, ' world!']));
 
     this.assertText('before hello world! after');
 
-    this.runTask(() => this.replace(1, 2, [htmlSafe(''), ' world!!']));
+    runTask(() => this.replace(1, 2, [htmlSafe(''), ' world!!']));
 
     this.assertText('before hello world!! after');
 
@@ -869,18 +869,18 @@ class EachTest extends AbstractEachTest {
 
     this.assertText('Admin: [Tom Dale] User: [Yehuda Katz]');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('Admin: [Tom Dale] User: [Yehuda Katz]');
 
-    this.runTask(() => {
+    runTask(() => {
       admins.delegate.pushObject({ name: 'Godfrey Chan' });
       set(users.delegate.objectAt(0), 'name', 'Stefan Penner');
     });
 
     this.assertText('Admin: [Tom Dale][Godfrey Chan] User: [Stefan Penner]');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'admins', this.createList([{ name: 'Tom Dale' }]).list);
       set(this.context, 'users', this.createList([{ name: 'Yehuda Katz' }]).list);
     });
@@ -911,14 +911,14 @@ class EachTest extends AbstractEachTest {
 
     this.assertStableRerender();
 
-    this.runTask(() => {
+    runTask(() => {
       content.delegate.pushObject('Z');
       set(options.delegate.objectAt(0), 'value', 0);
     });
 
     this.assertText('X-0:One2:TwoY-0:One2:TwoZ-0:One2:Two');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'content', this.createList(['X', 'Y']).list);
       set(
         this.context,
@@ -947,25 +947,25 @@ class EachTest extends AbstractEachTest {
 
     this.assertText('Greed-Limbo-Wrath-Treachery-Wrath-Limbo-Greed');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('Greed-Limbo-Wrath-Treachery-Wrath-Limbo-Greed');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'ring', 'O');
       fifth.delegate.insertAt(0, 'D');
     });
 
     this.assertText('O-Limbo-D-Treachery-D-Wrath-Treachery-Wrath-Limbo-O');
 
-    this.runTask(() => {
+    runTask(() => {
       first.delegate.pushObject('I');
       ninth.delegate.replace(0, 1, ['K']);
     });
 
     this.assertText('O-Limbo-D-K-D-Wrath-K-Wrath-Limbo-I-D-K-D-Wrath-K-Wrath-I-O');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'ring', 'Greed');
       set(this.context, 'first', this.createList(['Limbo']).list);
       set(this.context, 'fifth', this.createList(['Wrath']).list);
@@ -988,18 +988,18 @@ class EachTest extends AbstractEachTest {
 
     this.assertText('caterpillar');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('caterpillar');
 
-    this.runTask(() => {
+    runTask(() => {
       inner.delegate.replace(0, 1, ['lady']);
       outer.delegate.pushObject(this.createList(['bird']).list);
     });
 
     this.assertText('ladybird');
 
-    this.runTask(() =>
+    runTask(() =>
       set(this.context, 'name', this.createList([this.createList(['caterpillar']).list]).list)
     );
 
@@ -1103,15 +1103,15 @@ moduleFor(
 
       this.assertText('');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('');
 
-      this.runTask(() => set(this.context, 'foo', { bar: { baz: ['Here!'] } }));
+      runTask(() => set(this.context, 'foo', { bar: { baz: ['Here!'] } }));
 
       this.assertText('Here!');
 
-      this.runTask(() => set(this.context, 'foo', {}));
+      runTask(() => set(this.context, 'foo', {}));
 
       this.assertText('');
     }
@@ -1138,7 +1138,7 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => {
+      runTask(() => {
         let list = get(this.context, 'list');
         list.pushObject('baz');
       });
@@ -1215,7 +1215,7 @@ if (typeof MutationObserver === 'function') {
           .then(() => {
             this.assertNoMutation();
 
-            this.runTask(() => set(this.context, 'page', { title: 'Essays' }));
+            runTask(() => set(this.context, 'page', { title: 'Essays' }));
 
             this.assertHTML(strip`
           <h1>Essays</h1>
@@ -1229,7 +1229,7 @@ if (typeof MutationObserver === 'function') {
           .then(() => {
             this.assertNoMutation();
 
-            this.runTask(() => set(this.context.page, 'title', 'Think Pieces™'));
+            runTask(() => set(this.context.page, 'title', 'Think Pieces™'));
 
             this.assertHTML(strip`
           <h1>Think Pieces™</h1>

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/if-unless-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/if-unless-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor, strip } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, strip, runTask } from 'internal-test-helpers';
 
 import { A as emberA } from '@ember/-internals/runtime';
 import { set } from '@ember/-internals/metal';
@@ -65,16 +65,16 @@ moduleFor(
 
       this.assertText('123');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('123');
 
-      this.runTask(() => set(this.context, 'cond', false));
+      runTask(() => set(this.context, 'cond', false));
 
       this.assertText('Nothing Here!');
       assert.equal(destroyedChildrenCount, 3, 'the children were properly destroyed');
 
-      this.runTask(() => set(this.context, 'cond', true));
+      runTask(() => set(this.context, 'cond', true));
 
       this.assertText('123');
     }
@@ -92,15 +92,15 @@ moduleFor(
 
       this.assertText('Nothing Here!');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Nothing Here!');
 
-      this.runTask(() => set(this.context, 'foo', { bar: { baz: true } }));
+      runTask(() => set(this.context, 'foo', { bar: { baz: true } }));
 
       this.assertText('Here!');
 
-      this.runTask(() => set(this.context, 'foo', {}));
+      runTask(() => set(this.context, 'foo', {}));
 
       this.assertText('Nothing Here!');
     }

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/in-element-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/in-element-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase, strip, equalTokens } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, strip, equalTokens, runTask } from 'internal-test-helpers';
 
 import { Component } from '@ember/-internals/glimmer';
 import { set } from '@ember/-internals/metal';
@@ -36,12 +36,12 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'text', 'Huzzah!!'));
+      runTask(() => set(this.context, 'text', 'Huzzah!!'));
 
       equalTokens(this.element, '<!---->');
       equalTokens(someElement, 'Huzzah!!');
 
-      this.runTask(() => set(this.context, 'text', 'Whoop!'));
+      runTask(() => set(this.context, 'text', 'Whoop!'));
 
       equalTokens(this.element, '<!---->');
       equalTokens(someElement, 'Whoop!');
@@ -86,28 +86,28 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.runTask(() => set(this.context, 'showModal', true));
+      runTask(() => set(this.context, 'showModal', true));
 
       equalTokens(this.element, '<!---->');
       this.assertComponentElement(someElement.firstChild, {
         content: 'Whoop!',
       });
 
-      this.runTask(() => set(this.context, 'text', 'Huzzah!'));
+      runTask(() => set(this.context, 'text', 'Huzzah!'));
 
       equalTokens(this.element, '<!---->');
       this.assertComponentElement(someElement.firstChild, {
         content: 'Huzzah!',
       });
 
-      this.runTask(() => set(this.context, 'text', 'Whoop!'));
+      runTask(() => set(this.context, 'text', 'Whoop!'));
 
       equalTokens(this.element, '<!---->');
       this.assertComponentElement(someElement.firstChild, {
         content: 'Whoop!',
       });
 
-      this.runTask(() => set(this.context, 'showModal', false));
+      runTask(() => set(this.context, 'showModal', false));
 
       equalTokens(this.element, '<!---->');
       equalTokens(someElement, '');

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/let-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/let-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase, strip } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
 
 import { get, set } from '@ember/-internals/metal';
 import { A as emberA, ObjectProxy, removeAt } from '@ember/-internals/runtime';
@@ -21,15 +21,15 @@ moduleFor(
 
       this.assertText('value: ""');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('value: ""');
 
-      this.runTask(() => set(this.context, 'foo', { bar: { baz: 'Here!' } }));
+      runTask(() => set(this.context, 'foo', { bar: { baz: 'Here!' } }));
 
       this.assertText('value: "Here!"');
 
-      this.runTask(() => set(this.context, 'foo', {}));
+      runTask(() => set(this.context, 'foo', {}));
 
       this.assertText('value: ""');
     }
@@ -41,15 +41,15 @@ moduleFor(
 
       this.assertText('value: "false"');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('value: "false"');
 
-      this.runTask(() => set(this.context, 'cond1', ''));
+      runTask(() => set(this.context, 'cond1', ''));
 
       this.assertText('value: ""');
 
-      this.runTask(() => set(this.context, 'cond1', 0));
+      runTask(() => set(this.context, 'cond1', 0));
 
       this.assertText('value: "0"');
     }
@@ -63,7 +63,7 @@ moduleFor(
 
       this.assertText('Señor Engineer  Dale');
 
-      this.runTask(() => set(this.context, 'bar', 'Tom'));
+      runTask(() => set(this.context, 'bar', 'Tom'));
 
       this.assertText('Señor Engineer Tom Dale');
     }
@@ -76,18 +76,18 @@ moduleFor(
 
       this.assertText('Señor Engineer: Tom Dale');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Señor Engineer: Tom Dale');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'person.name', 'Yehuda Katz');
         set(this.context, 'title', 'Principal Engineer');
       });
 
       this.assertText('Principal Engineer: Yehuda Katz');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'person', { name: 'Tom Dale' });
         set(this.context, 'title', 'Señor Engineer');
       });
@@ -103,19 +103,19 @@ moduleFor(
 
       this.assertText('Stef-Yehuda-Stef');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Stef-Yehuda-Stef');
 
-      this.runTask(() => set(this.context, 'other', 'Chad'));
+      runTask(() => set(this.context, 'other', 'Chad'));
 
       this.assertText('Stef-Chad-Stef');
 
-      this.runTask(() => set(this.context, 'name', 'Tom'));
+      runTask(() => set(this.context, 'name', 'Tom'));
 
       this.assertText('Tom-Chad-Tom');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'name', 'Stef');
         set(this.context, 'other', 'Yehuda');
       });
@@ -130,27 +130,27 @@ moduleFor(
 
       this.assertText('Tom Dale');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Tom Dale');
 
-      this.runTask(() => set(this.context, 'proxy.name', 'Yehuda Katz'));
+      runTask(() => set(this.context, 'proxy.name', 'Yehuda Katz'));
 
       this.assertText('Yehuda Katz');
 
-      this.runTask(() => set(this.context, 'proxy.content', { name: 'Godfrey Chan' }));
+      runTask(() => set(this.context, 'proxy.content', { name: 'Godfrey Chan' }));
 
       this.assertText('Godfrey Chan');
 
-      this.runTask(() => set(this.context, 'proxy.content.name', 'Stefan Penner'));
+      runTask(() => set(this.context, 'proxy.content.name', 'Stefan Penner'));
 
       this.assertText('Stefan Penner');
 
-      this.runTask(() => set(this.context, 'proxy.content', null));
+      runTask(() => set(this.context, 'proxy.content', null));
 
       this.assertText('');
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'proxy', ObjectProxy.create({ content: { name: 'Tom Dale' } }))
       );
 
@@ -167,11 +167,11 @@ moduleFor(
 
       this.assertText('Hello world');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Hello world');
 
-      this.runTask(() => {
+      runTask(() => {
         let array = get(this.context, 'arrayThing');
         array.replace(0, 1, ['Goodbye']);
         removeAt(array, 1);
@@ -181,7 +181,7 @@ moduleFor(
 
       this.assertText('Goodbye, world!');
 
-      this.runTask(() => set(this.context, 'arrayThing', ['Hello', ' ', 'world']));
+      runTask(() => set(this.context, 'arrayThing', ['Hello', ' ', 'world']));
 
       this.assertText('Hello world');
     }
@@ -193,15 +193,15 @@ moduleFor(
 
       this.assertText('[foo-foo]');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('[foo-foo]');
 
-      this.runTask(() => this.context.set('hash.foo', 'FOO'));
+      runTask(() => this.context.set('hash.foo', 'FOO'));
 
       this.assertText('[FOO-FOO]');
 
-      this.runTask(() => this.context.set('hash.foo', 'foo'));
+      runTask(() => this.context.set('hash.foo', 'foo'));
 
       this.assertText('[foo-foo]');
     }
@@ -222,18 +222,18 @@ moduleFor(
 
       this.assertText('Admin: Tom Dale User: Yehuda Katz');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Admin: Tom Dale User: Yehuda Katz');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'admin.name', 'Godfrey Chan');
         set(this.context, 'user.name', 'Stefan Penner');
       });
 
       this.assertText('Admin: Godfrey Chan User: Stefan Penner');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'admin', { name: 'Tom Dale' });
         set(this.context, 'user', { name: 'Yehuda Katz' });
       });
@@ -254,25 +254,25 @@ moduleFor(
 
       this.assertText('Greed-Limbo-Wrath-Treachery-Wrath-Limbo-Greed');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Greed-Limbo-Wrath-Treachery-Wrath-Limbo-Greed');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'ring', 'O');
         set(this.context, 'fifth', 'D');
       });
 
       this.assertText('O-Limbo-D-Treachery-D-Limbo-O');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'first', 'I');
         set(this.context, 'ninth', 'K');
       });
 
       this.assertText('O-I-D-K-D-I-O');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'ring', 'Greed');
         set(this.context, 'first', 'Limbo');
         set(this.context, 'fifth', 'Wrath');
@@ -289,15 +289,15 @@ moduleFor(
 
       this.assertText('caterpillar');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('caterpillar');
 
-      this.runTask(() => set(this.context, 'name', 'butterfly'));
+      runTask(() => set(this.context, 'name', 'butterfly'));
 
       this.assertText('butterfly');
 
-      this.runTask(() => set(this.context, 'name', 'caterpillar'));
+      runTask(() => set(this.context, 'name', 'caterpillar'));
 
       this.assertText('caterpillar');
     }
@@ -309,15 +309,15 @@ moduleFor(
 
       this.assertText('Los Pivots');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Los Pivots');
 
-      this.runTask(() => set(this.context, 'name', "l'Pivots"));
+      runTask(() => set(this.context, 'name', "l'Pivots"));
 
       this.assertText("l'Pivots");
 
-      this.runTask(() => set(this.context, 'name', 'Los Pivots'));
+      runTask(() => set(this.context, 'name', 'Los Pivots'));
 
       this.assertText('Los Pivots');
     }
@@ -352,21 +352,21 @@ moduleFor(
 
       this.assertText('ebryn[trek[machty]trek]ebryn[machty[trek]machty]ebryn');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('ebryn[trek[machty]trek]ebryn[machty[trek]machty]ebryn');
 
-      this.runTask(() => set(this.context, 'name', 'chancancode'));
+      runTask(() => set(this.context, 'name', 'chancancode'));
 
       this.assertText('chancancode[trek[machty]trek]chancancode[machty[trek]machty]chancancode');
 
-      this.runTask(() => set(this.context, 'committer1', { name: 'krisselden' }));
+      runTask(() => set(this.context, 'committer1', { name: 'krisselden' }));
 
       this.assertText(
         'chancancode[krisselden[machty]krisselden]chancancode[machty[krisselden]machty]chancancode'
       );
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'committer1.name', 'wycats');
         set(this.context, 'committer2', { name: 'rwjblue' });
       });
@@ -375,7 +375,7 @@ moduleFor(
         'chancancode[wycats[rwjblue]wycats]chancancode[rwjblue[wycats]rwjblue]chancancode'
       );
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'name', 'ebryn');
         set(this.context, 'committer1', { name: 'trek' });
         set(this.context, 'committer2', { name: 'machty' });

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/with-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/with-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase, strip } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
 
 import { get, set } from '@ember/-internals/metal';
 import { A as emberA, ObjectProxy, removeAt } from '@ember/-internals/runtime';
@@ -32,15 +32,15 @@ moduleFor(
 
       this.assertText('');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('');
 
-      this.runTask(() => set(this.context, 'foo', { bar: { baz: 'Here!' } }));
+      runTask(() => set(this.context, 'foo', { bar: { baz: 'Here!' } }));
 
       this.assertText('Here!');
 
-      this.runTask(() => set(this.context, 'foo', {}));
+      runTask(() => set(this.context, 'foo', {}));
 
       this.assertText('');
     }
@@ -52,19 +52,19 @@ moduleFor(
 
       this.assertText('Hello');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Hello');
 
-      this.runTask(() => set(this.context, 'cond1.greeting', 'Hello world'));
+      runTask(() => set(this.context, 'cond1.greeting', 'Hello world'));
 
       this.assertText('Hello world');
 
-      this.runTask(() => set(this.context, 'cond1', false));
+      runTask(() => set(this.context, 'cond1', false));
 
       this.assertText('False');
 
-      this.runTask(() => set(this.context, 'cond1', { greeting: 'Hello' }));
+      runTask(() => set(this.context, 'cond1', { greeting: 'Hello' }));
 
       this.assertText('Hello');
     }
@@ -77,18 +77,18 @@ moduleFor(
 
       this.assertText('Señor Engineer: Tom Dale');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Señor Engineer: Tom Dale');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'person.name', 'Yehuda Katz');
         set(this.context, 'title', 'Principal Engineer');
       });
 
       this.assertText('Principal Engineer: Yehuda Katz');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'person', { name: 'Tom Dale' });
         set(this.context, 'title', 'Señor Engineer');
       });
@@ -104,19 +104,19 @@ moduleFor(
 
       this.assertText('Stef-Yehuda-Stef');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Stef-Yehuda-Stef');
 
-      this.runTask(() => set(this.context, 'other', 'Chad'));
+      runTask(() => set(this.context, 'other', 'Chad'));
 
       this.assertText('Stef-Chad-Stef');
 
-      this.runTask(() => set(this.context, 'name', 'Tom'));
+      runTask(() => set(this.context, 'name', 'Tom'));
 
       this.assertText('Tom-Chad-Tom');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'name', 'Stef');
         set(this.context, 'other', 'Yehuda');
       });
@@ -135,23 +135,23 @@ moduleFor(
 
       this.assertText('No Thing bar');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('No Thing bar');
 
-      this.runTask(() => set(this.context, 'otherThing', 'biz'));
+      runTask(() => set(this.context, 'otherThing', 'biz'));
 
       this.assertText('No Thing biz');
 
-      this.runTask(() => set(this.context, 'falsyThing', true));
+      runTask(() => set(this.context, 'falsyThing', true));
 
       this.assertText('Has Thing');
 
-      this.runTask(() => set(this.context, 'otherThing', 'baz'));
+      runTask(() => set(this.context, 'otherThing', 'baz'));
 
       this.assertText('Has Thing');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'otherThing', 'bar');
         set(this.context, 'falsyThing', null);
       });
@@ -166,27 +166,27 @@ moduleFor(
 
       this.assertText('Tom Dale');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Tom Dale');
 
-      this.runTask(() => set(this.context, 'proxy.name', 'Yehuda Katz'));
+      runTask(() => set(this.context, 'proxy.name', 'Yehuda Katz'));
 
       this.assertText('Yehuda Katz');
 
-      this.runTask(() => set(this.context, 'proxy.content', { name: 'Godfrey Chan' }));
+      runTask(() => set(this.context, 'proxy.content', { name: 'Godfrey Chan' }));
 
       this.assertText('Godfrey Chan');
 
-      this.runTask(() => set(this.context, 'proxy.content.name', 'Stefan Penner'));
+      runTask(() => set(this.context, 'proxy.content.name', 'Stefan Penner'));
 
       this.assertText('Stefan Penner');
 
-      this.runTask(() => set(this.context, 'proxy.content', null));
+      runTask(() => set(this.context, 'proxy.content', null));
 
       this.assertText('');
 
-      this.runTask(() =>
+      runTask(() =>
         set(this.context, 'proxy', ObjectProxy.create({ content: { name: 'Tom Dale' } }))
       );
 
@@ -203,11 +203,11 @@ moduleFor(
 
       this.assertText('Hello world');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Hello world');
 
-      this.runTask(() => {
+      runTask(() => {
         let array = get(this.context, 'arrayThing');
         array.replace(0, 1, ['Goodbye']);
         removeAt(array, 1);
@@ -217,7 +217,7 @@ moduleFor(
 
       this.assertText('Goodbye, world!');
 
-      this.runTask(() => set(this.context, 'arrayThing', ['Hello', ' ', 'world']));
+      runTask(() => set(this.context, 'arrayThing', ['Hello', ' ', 'world']));
 
       this.assertText('Hello world');
     }
@@ -229,15 +229,15 @@ moduleFor(
 
       this.assertText('[foo-foo]');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('[foo-foo]');
 
-      this.runTask(() => this.context.set('hash.foo', 'FOO'));
+      runTask(() => this.context.set('hash.foo', 'FOO'));
 
       this.assertText('[FOO-FOO]');
 
-      this.runTask(() => this.context.set('hash.foo', 'foo'));
+      runTask(() => this.context.set('hash.foo', 'foo'));
 
       this.assertText('[foo-foo]');
     }
@@ -258,18 +258,18 @@ moduleFor(
 
       this.assertText('Admin: Tom Dale User: Yehuda Katz');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Admin: Tom Dale User: Yehuda Katz');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'admin.name', 'Godfrey Chan');
         set(this.context, 'user.name', 'Stefan Penner');
       });
 
       this.assertText('Admin: Godfrey Chan User: Stefan Penner');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'admin', { name: 'Tom Dale' });
         set(this.context, 'user', { name: 'Yehuda Katz' });
       });
@@ -290,25 +290,25 @@ moduleFor(
 
       this.assertText('Greed-Limbo-Wrath-Treachery-Wrath-Limbo-Greed');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Greed-Limbo-Wrath-Treachery-Wrath-Limbo-Greed');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'ring', 'O');
         set(this.context, 'fifth', 'D');
       });
 
       this.assertText('O-Limbo-D-Treachery-D-Limbo-O');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'first', 'I');
         set(this.context, 'ninth', 'K');
       });
 
       this.assertText('O-I-D-K-D-I-O');
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'ring', 'Greed');
         set(this.context, 'first', 'Limbo');
         set(this.context, 'fifth', 'Wrath');
@@ -325,15 +325,15 @@ moduleFor(
 
       this.assertText('caterpillar');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('caterpillar');
 
-      this.runTask(() => set(this.context, 'name', 'butterfly'));
+      runTask(() => set(this.context, 'name', 'butterfly'));
 
       this.assertText('butterfly');
 
-      this.runTask(() => set(this.context, 'name', 'caterpillar'));
+      runTask(() => set(this.context, 'name', 'caterpillar'));
 
       this.assertText('caterpillar');
     }
@@ -345,15 +345,15 @@ moduleFor(
 
       this.assertText('Los Pivots');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('Los Pivots');
 
-      this.runTask(() => set(this.context, 'name', "l'Pivots"));
+      runTask(() => set(this.context, 'name', "l'Pivots"));
 
       this.assertText("l'Pivots");
 
-      this.runTask(() => set(this.context, 'name', 'Los Pivots'));
+      runTask(() => set(this.context, 'name', 'Los Pivots'));
 
       this.assertText('Los Pivots');
     }
@@ -388,21 +388,21 @@ moduleFor(
 
       this.assertText('ebryn[trek[machty]trek]ebryn[machty[trek]machty]ebryn');
 
-      this.runTask(() => this.rerender());
+      runTask(() => this.rerender());
 
       this.assertText('ebryn[trek[machty]trek]ebryn[machty[trek]machty]ebryn');
 
-      this.runTask(() => set(this.context, 'name', 'chancancode'));
+      runTask(() => set(this.context, 'name', 'chancancode'));
 
       this.assertText('chancancode[trek[machty]trek]chancancode[machty[trek]machty]chancancode');
 
-      this.runTask(() => set(this.context, 'committer1', { name: 'krisselden' }));
+      runTask(() => set(this.context, 'committer1', { name: 'krisselden' }));
 
       this.assertText(
         'chancancode[krisselden[machty]krisselden]chancancode[machty[krisselden]machty]chancancode'
       );
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'committer1.name', 'wycats');
         set(this.context, 'committer2', { name: 'rwjblue' });
       });
@@ -411,7 +411,7 @@ moduleFor(
         'chancancode[wycats[rwjblue]wycats]chancancode[rwjblue[wycats]rwjblue]chancancode'
       );
 
-      this.runTask(() => {
+      runTask(() => {
         set(this.context, 'name', 'ebryn');
         set(this.context, 'committer1', { name: 'trek' });
         set(this.context, 'committer2', { name: 'machty' });

--- a/packages/@ember/-internals/glimmer/tests/unit/runtime-resolver-cache-test.js
+++ b/packages/@ember/-internals/glimmer/tests/unit/runtime-resolver-cache-test.js
@@ -1,4 +1,10 @@
-import { RenderingTestCase, moduleFor, runDestroy, runAppend } from 'internal-test-helpers';
+import {
+  RenderingTestCase,
+  moduleFor,
+  runDestroy,
+  runAppend,
+  runTask,
+} from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
 
@@ -44,7 +50,7 @@ moduleFor(
       );
 
       // show component-two for the first time
-      this.runTask(() => set(this.context, 'cond', false));
+      runTask(() => set(this.context, 'cond', false));
 
       this.assertText('baz-qux helper!');
       state = this.expectCacheChanges(
@@ -56,13 +62,13 @@ moduleFor(
       );
 
       // show foo-bar again
-      this.runTask(() => set(this.context, 'cond', true));
+      runTask(() => set(this.context, 'cond', true));
 
       this.assertText('foo-bar helper!');
       state = this.expectCacheChanges({}, state, 'toggle back to foo-bar cache hit');
 
       // show baz-qux again
-      this.runTask(() => set(this.context, 'cond', false));
+      runTask(() => set(this.context, 'cond', false));
 
       this.assertText('baz-qux helper!');
       state = this.expectCacheChanges({}, state, 'toggle back to baz-qux cache hit');
@@ -102,7 +108,7 @@ moduleFor(
       );
 
       // show component-two for the first time
-      this.runTask(() => set(this.context, 'componentName', 'component-two'));
+      runTask(() => set(this.context, 'componentName', 'component-two'));
 
       this.assertText('Two');
       state = this.expectCacheChanges(
@@ -112,13 +118,13 @@ moduleFor(
       );
 
       // show component-one again
-      this.runTask(() => set(this.context, 'componentName', 'component-one'));
+      runTask(() => set(this.context, 'componentName', 'component-one'));
 
       this.assertText('One');
       state = this.expectCacheChanges({}, state, 'toggle back to component-one no change');
 
       // show component-two again
-      this.runTask(() => set(this.context, 'componentName', 'component-two'));
+      runTask(() => set(this.context, 'componentName', 'component-two'));
 
       this.assertText('Two');
       state = this.expectCacheChanges({}, state, 'toggle back to component-two no change');
@@ -175,7 +181,7 @@ moduleFor(
       );
 
       // show component-two for the first time
-      this.runTask(() => set(this.context, 'cond', false));
+      runTask(() => set(this.context, 'cond', false));
 
       this.assertText('Two');
       state = this.expectCacheChanges(
@@ -188,13 +194,13 @@ moduleFor(
       );
 
       // show component-one again
-      this.runTask(() => set(this.context, 'cond', true));
+      runTask(() => set(this.context, 'cond', true));
 
       this.assertText('One');
       state = this.expectCacheChanges({}, state, 'toggle back to component-one no change');
 
       // show component-two again
-      this.runTask(() => set(this.context, 'cond', false));
+      runTask(() => set(this.context, 'cond', false));
 
       this.assertText('Two');
       state = this.expectCacheChanges(

--- a/packages/@ember/-internals/glimmer/tests/utils/shared-conditional-tests.js
+++ b/packages/@ember/-internals/glimmer/tests/utils/shared-conditional-tests.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, applyMixins } from 'internal-test-helpers';
+import { RenderingTestCase, applyMixins, runTask } from 'internal-test-helpers';
 
 import { assign } from '@ember/polyfills';
 import { get, set } from '@ember/-internals/metal';
@@ -70,15 +70,15 @@ export class TruthyGenerator extends AbstractGenerator {
 
         this.assertText('T1');
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertText('T1');
 
-        this.runTask(() => set(this.context, 'cond1', this.falsyValue));
+        runTask(() => set(this.context, 'cond1', this.falsyValue));
 
         this.assertText('F1');
 
-        this.runTask(() => set(this.context, 'cond1', value));
+        runTask(() => set(this.context, 'cond1', value));
 
         this.assertText('T1');
       },
@@ -94,15 +94,15 @@ export class FalsyGenerator extends AbstractGenerator {
 
         this.assertText('F1');
 
-        this.runTask(() => this.rerender());
+        runTask(() => this.rerender());
 
         this.assertText('F1');
 
-        this.runTask(() => set(this.context, 'cond1', this.truthyValue));
+        runTask(() => set(this.context, 'cond1', this.truthyValue));
 
         this.assertText('T1');
 
-        this.runTask(() => set(this.context, 'cond1', value));
+        runTask(() => set(this.context, 'cond1', value));
 
         this.assertText('F1');
       },
@@ -120,13 +120,13 @@ export class StableTruthyGenerator extends TruthyGenerator {
 
         this.takeSnapshot();
 
-        this.runTask(() => set(this.context, 'cond1', this.truthyValue));
+        runTask(() => set(this.context, 'cond1', this.truthyValue));
 
         this.assertText('T1');
 
         this.assertInvariants();
 
-        this.runTask(() => set(this.context, 'cond1', value));
+        runTask(() => set(this.context, 'cond1', value));
 
         this.assertText('T1');
 
@@ -146,13 +146,13 @@ export class StableFalsyGenerator extends FalsyGenerator {
 
         this.takeSnapshot();
 
-        this.runTask(() => set(this.context, 'cond1', this.falsyValue));
+        runTask(() => set(this.context, 'cond1', this.falsyValue));
 
         this.assertText('F1');
 
         this.assertInvariants();
 
-        this.runTask(() => set(this.context, 'cond1', value));
+        runTask(() => set(this.context, 'cond1', value));
 
         this.assertText('F1');
 
@@ -175,15 +175,15 @@ class ObjectProxyGenerator extends AbstractGenerator {
 
           this.assertText('T1');
 
-          this.runTask(() => this.rerender());
+          runTask(() => this.rerender());
 
           this.assertText('T1');
 
-          this.runTask(() => set(this.context, 'cond1.content', this.falsyValue));
+          runTask(() => set(this.context, 'cond1.content', this.falsyValue));
 
           this.assertText('F1');
 
-          this.runTask(() => set(this.context, 'cond1', ObjectProxy.create({ content: value })));
+          runTask(() => set(this.context, 'cond1', ObjectProxy.create({ content: value })));
 
           this.assertText('T1');
         },
@@ -197,15 +197,15 @@ class ObjectProxyGenerator extends AbstractGenerator {
 
           this.assertText('F1');
 
-          this.runTask(() => this.rerender());
+          runTask(() => this.rerender());
 
           this.assertText('F1');
 
-          this.runTask(() => set(this.context, 'cond1.content', this.truthyValue));
+          runTask(() => set(this.context, 'cond1.content', this.truthyValue));
 
           this.assertText('T1');
 
-          this.runTask(() => set(this.context, 'cond1', ObjectProxy.create({ content: value })));
+          runTask(() => set(this.context, 'cond1', ObjectProxy.create({ content: value })));
 
           this.assertText('F1');
         },
@@ -222,22 +222,22 @@ export class BasicConditionalsTest extends AbstractConditionalsTest {
 
     this.assertText('T1F2');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('T1F2');
 
-    this.runTask(() => set(this.context, 'cond1', this.falsyValue));
+    runTask(() => set(this.context, 'cond1', this.falsyValue));
 
     this.assertText('F1F2');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'cond1', this.truthyValue);
       set(this.context, 'cond2', this.truthyValue);
     });
 
     this.assertText('T1T2');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'cond1', this.truthyValue);
       set(this.context, 'cond2', this.falsyValue);
     });
@@ -257,18 +257,18 @@ export const ObjectTestCases = {
 
     this.assertText('T1T2F3');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('T1T2F3');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'cond1.content', null);
       set(this.context, 'cond2.content', null);
     });
 
     this.assertText('F1F2F3');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'cond1.content', EmberObject.create());
       set(this.context, 'cond2.content', {});
       set(this.context, 'cond3.content', { foo: 'bar' });
@@ -276,7 +276,7 @@ export const ObjectTestCases = {
 
     this.assertText('T1T2T3');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'cond1', ObjectProxy.create({ content: {} }));
       set(this.context, 'cond2', ObjectProxy.create({ content: EmberObject.create() }));
       set(this.context, 'cond3', ObjectProxy.create({ content: null }));
@@ -293,22 +293,22 @@ export const ArrayTestCases = {
 
     this.assertText('T1F2');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('T1F2');
 
-    this.runTask(() => removeAt(get(this.context, 'cond1'), 0));
+    runTask(() => removeAt(get(this.context, 'cond1'), 0));
 
     this.assertText('F1F2');
 
-    this.runTask(() => {
+    runTask(() => {
       get(this.context, 'cond1').pushObject('hello');
       get(this.context, 'cond2').pushObjects([1]);
     });
 
     this.assertText('T1T2');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'cond1', emberA(['hello']));
       set(this.context, 'cond2', emberA());
     });
@@ -324,25 +324,25 @@ export const ArrayTestCases = {
 
     this.assertText('T1F2');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('T1F2');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'cond1.content', null);
       set(this.context, 'cond2.content', null);
     });
 
     this.assertText('F1F2');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'cond1.content', emberA(['hello']));
       set(this.context, 'cond2.content', emberA([1]));
     });
 
     this.assertText('T1T2');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'cond1', ArrayProxy.create({ content: emberA(['hello']) }));
       set(this.context, 'cond2', ArrayProxy.create({ content: null }));
     });
@@ -358,22 +358,22 @@ export const ArrayTestCases = {
 
     this.assertText('T1F2');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('T1F2');
 
-    this.runTask(() => removeAt(get(this.context, 'cond1.content'), 0));
+    runTask(() => removeAt(get(this.context, 'cond1.content'), 0));
 
     this.assertText('F1F2');
 
-    this.runTask(() => {
+    runTask(() => {
       get(this.context, 'cond1.content').pushObject('hello');
       get(this.context, 'cond2.content').pushObjects([1]);
     });
 
     this.assertText('T1T2');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'cond1', ArrayProxy.create({ content: emberA(['hello']) }));
       set(this.context, 'cond2', ArrayProxy.create({ content: emberA() }));
     });
@@ -491,25 +491,25 @@ export class TogglingHelperConditionalsTest extends TogglingConditionalsTest {
 
     this.assertText('YESNO');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('YESNO');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'truthy', 'YASS');
       set(this.context, 'falsy', 'NOPE');
     });
 
     this.assertText('YASSNOPE');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'cond1', this.falsyValue);
       set(this.context, 'cond2', this.truthyValue);
     });
 
     this.assertText('NOPEYASS');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'truthy', 'YES');
       set(this.context, 'falsy', 'NO');
       set(this.context, 'cond1', this.truthyValue);
@@ -537,22 +537,22 @@ export class TogglingHelperConditionalsTest extends TogglingConditionalsTest {
 
     this.assertText('T1F2');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('T1F2');
 
-    this.runTask(() => set(this.context, 'cond1', this.falsyValue));
+    runTask(() => set(this.context, 'cond1', this.falsyValue));
 
     this.assertText('T1F2');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'cond1', this.truthyValue);
       set(this.context, 'cond2', this.truthyValue);
     });
 
     this.assertText('T1F2');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'cond1', this.truthyValue);
       set(this.context, 'cond2', this.falsyValue);
     });
@@ -600,19 +600,19 @@ export class TogglingHelperConditionalsTest extends TogglingConditionalsTest {
 
     this.assertText('T');
 
-    withoutEvaluatingFalsy(() => this.runTask(() => this.rerender()));
+    withoutEvaluatingFalsy(() => runTask(() => this.rerender()));
 
     this.assertText('T');
 
-    withoutEvaluatingTruthy(() => this.runTask(() => set(this.context, 'cond', this.falsyValue)));
+    withoutEvaluatingTruthy(() => runTask(() => set(this.context, 'cond', this.falsyValue)));
 
     this.assertText('F');
 
-    withoutEvaluatingTruthy(() => this.runTask(() => this.rerender()));
+    withoutEvaluatingTruthy(() => runTask(() => this.rerender()));
 
     this.assertText('F');
 
-    withoutEvaluatingFalsy(() => this.runTask(() => set(this.context, 'cond', this.truthyValue)));
+    withoutEvaluatingFalsy(() => runTask(() => set(this.context, 'cond', this.truthyValue)));
 
     this.assertText('T');
   }
@@ -659,22 +659,22 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
 
     this.assertText('T1F2');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('T1F2');
 
-    this.runTask(() => set(this.context, 'cond1', this.falsyValue));
+    runTask(() => set(this.context, 'cond1', this.falsyValue));
 
     this.assertText('T1F2');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'cond1', this.truthyValue);
       set(this.context, 'cond2', this.truthyValue);
     });
 
     this.assertText('T1F2');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'cond1', this.truthyValue);
       set(this.context, 'cond2', this.falsyValue);
     });
@@ -705,25 +705,25 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
 
     this.assertText('YESNO');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('YESNO');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'truthy', 'YASS');
       set(this.context, 'falsy', 'NOPE');
     });
 
     this.assertText('YASSNOPE');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'cond1', this.falsyValue);
       set(this.context, 'cond2', this.truthyValue);
     });
 
     this.assertText('NOPEYASS');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'truthy', 'YES');
       set(this.context, 'falsy', 'NO');
       set(this.context, 'cond1', this.truthyValue);
@@ -750,17 +750,17 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
 
     this.assertText('T-inner');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('T-inner');
 
     // Changes the inner bounds
-    this.runTask(() => set(this.context, 'inner', this.falsyValue));
+    runTask(() => set(this.context, 'inner', this.falsyValue));
 
     this.assertText('F-inner');
 
     // Now rerender the outer conditional, which require first clearing its bounds
-    this.runTask(() => set(this.context, 'outer', this.falsyValue));
+    runTask(() => set(this.context, 'outer', this.falsyValue));
 
     this.assertText('F-outer');
   }
@@ -780,22 +780,22 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
 
     this.assertText('inner-before');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('inner-before');
 
     // Changes the inner bounds
-    this.runTask(() => set(this.context, 'inner', ['inner-after']));
+    runTask(() => set(this.context, 'inner', ['inner-after']));
 
     this.assertText('inner-after');
 
     // Now rerender the outer conditional, which require first clearing its bounds
-    this.runTask(() => set(this.context, 'outer', this.falsyValue));
+    runTask(() => set(this.context, 'outer', this.falsyValue));
 
     this.assertText('F-outer');
 
     // Reset
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'inner', ['inner-again']);
       set(this.context, 'outer', this.truthyValue);
     });
@@ -803,12 +803,12 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
     this.assertText('inner-again');
 
     // Now clear the inner bounds
-    this.runTask(() => set(this.context, 'inner', []));
+    runTask(() => set(this.context, 'inner', []));
 
     this.assertText('');
 
     // Now rerender the outer conditional, which require first clearing its bounds
-    this.runTask(() => set(this.context, 'outer', this.falsyValue));
+    runTask(() => set(this.context, 'outer', this.falsyValue));
 
     this.assertText('F-outer');
   }
@@ -828,17 +828,17 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
 
     this.assertText('inner-before');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     this.assertText('inner-before');
 
     // Changes the inner bounds
-    this.runTask(() => set(this.context, 'inner', '<p>inner-after</p>'));
+    runTask(() => set(this.context, 'inner', '<p>inner-after</p>'));
 
     this.assertText('inner-after');
 
     // Now rerender the outer conditional, which require first clearing its bounds
-    this.runTask(() => set(this.context, 'outer', this.falsyValue));
+    runTask(() => set(this.context, 'outer', this.falsyValue));
 
     this.assertText('F-outer');
   }
@@ -877,12 +877,12 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
     assert.ok(!childCreated);
     this.assertText('');
 
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
 
     assert.ok(!childCreated);
     this.assertText('');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'cond2', this.truthyValue);
       set(this.context, 'cond1', this.falsyValue);
     });
@@ -890,7 +890,7 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
     assert.ok(!childCreated);
     this.assertText('');
 
-    this.runTask(() => {
+    runTask(() => {
       set(this.context, 'cond2', this.falsyValue);
       set(this.context, 'cond1', this.truthyValue);
     });
@@ -939,19 +939,19 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
 
     this.assertText('T');
 
-    withoutEvaluatingFalsy(() => this.runTask(() => this.rerender()));
+    withoutEvaluatingFalsy(() => runTask(() => this.rerender()));
 
     this.assertText('T');
 
-    withoutEvaluatingTruthy(() => this.runTask(() => set(this.context, 'cond', this.falsyValue)));
+    withoutEvaluatingTruthy(() => runTask(() => set(this.context, 'cond', this.falsyValue)));
 
     this.assertText('F');
 
-    withoutEvaluatingTruthy(() => this.runTask(() => this.rerender()));
+    withoutEvaluatingTruthy(() => runTask(() => this.rerender()));
 
     this.assertText('F');
 
-    withoutEvaluatingFalsy(() => this.runTask(() => set(this.context, 'cond', this.truthyValue)));
+    withoutEvaluatingFalsy(() => runTask(() => set(this.context, 'cond', this.truthyValue)));
 
     this.assertText('T');
   }

--- a/packages/@ember/-internals/runtime/tests/system/array_proxy/length_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/array_proxy/length_test.js
@@ -3,7 +3,7 @@ import EmberObject from '../../../lib/system/object';
 import { observer } from '@ember/-internals/metal';
 import { oneWay as reads, not } from '@ember/object/computed';
 import { A as a } from '../../../lib/mixins/array';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase, runTask } from 'internal-test-helpers';
 import { set, get } from '@ember/-internals/metal';
 
 moduleFor(
@@ -90,7 +90,7 @@ moduleFor(
 
       assert.equal(obj.length, 2, 'precond');
 
-      this.runTask(() => obj.destroy());
+      runTask(() => obj.destroy());
 
       assert.equal(obj.length, 0, 'length is 0 without content');
       assert.deepEqual(obj.content, null, 'content was updated');

--- a/packages/@ember/application/tests/application_test.js
+++ b/packages/@ember/application/tests/application_test.js
@@ -20,6 +20,7 @@ import {
   DefaultResolverApplicationTestCase,
   verifyInjection,
   verifyRegistration,
+  runTask,
 } from 'internal-test-helpers';
 import { run } from '@ember/runloop';
 
@@ -52,24 +53,24 @@ moduleFor(
       super.teardown();
 
       if (this.secondApp) {
-        this.runTask(() => this.secondApp.destroy());
+        runTask(() => this.secondApp.destroy());
       }
     }
 
     [`@test you can make a new application in a non-overlapping element`](assert) {
-      let app = this.runTask(() =>
+      let app = runTask(() =>
         this.createSecondApplication({
           rootElement: '#two',
         })
       );
 
-      this.runTask(() => app.destroy());
+      runTask(() => app.destroy());
       assert.ok(true, 'should not raise');
     }
 
     [`@test you cannot make a new application that is a parent of an existing application`]() {
       expectAssertion(() => {
-        this.runTask(() =>
+        runTask(() =>
           this.createSecondApplication({
             rootElement: this.applicationOptions.rootElement,
           })
@@ -79,7 +80,7 @@ moduleFor(
 
     [`@test you cannot make a new application that is a descendant of an existing application`]() {
       expectAssertion(() => {
-        this.runTask(() =>
+        runTask(() =>
           this.createSecondApplication({
             rootElement: '#one-child',
           })
@@ -89,7 +90,7 @@ moduleFor(
 
     [`@test you cannot make a new application that is a duplicate of an existing application`]() {
       expectAssertion(() => {
-        this.runTask(() =>
+        runTask(() =>
           this.createSecondApplication({
             rootElement: '#one',
           })
@@ -99,7 +100,7 @@ moduleFor(
 
     [`@test you cannot make two default applications without a rootElement error`]() {
       expectAssertion(() => {
-        this.runTask(() => this.createSecondApplication());
+        runTask(() => this.createSecondApplication());
       });
     }
   }
@@ -232,14 +233,14 @@ moduleFor(
     }
 
     [`@test acts like a namespace`](assert) {
-      this.application = this.runTask(() => this.createApplication());
+      this.application = runTask(() => this.createApplication());
       let Foo = (this.application.Foo = EmberObject.extend());
       assert.equal(Foo.toString(), 'TestApp.Foo', 'Classes pick up their parent namespace');
     }
 
     [`@test can specify custom router`](assert) {
       let MyRouter = Router.extend();
-      this.runTask(() => {
+      runTask(() => {
         this.createApplication();
         this.application.Router = MyRouter;
       });
@@ -252,7 +253,7 @@ moduleFor(
 
     [`@test Minimal Application initialized with just an application template`]() {
       this.setupFixture('<script type="text/x-handlebars">Hello World</script>');
-      this.runTask(() => this.createApplication());
+      runTask(() => this.createApplication());
       this.assertInnerHTML('Hello World');
     }
   }
@@ -276,7 +277,7 @@ moduleFor(
     }
 
     [`@test initialized application goes to initial route`]() {
-      this.runTask(() => {
+      runTask(() => {
         this.createApplication();
         this.addTemplate('application', '{{outlet}}');
         this.addTemplate('index', '<h1>Hi from index</h1>');
@@ -288,7 +289,7 @@ moduleFor(
     [`@test ready hook is called before routing begins`](assert) {
       assert.expect(2);
 
-      this.runTask(() => {
+      runTask(() => {
         function registerRoute(application, name, callback) {
           let route = EmberRoute.extend({
             activate: callback,
@@ -312,7 +313,7 @@ moduleFor(
     }
 
     [`@test initialize application via initialize call`](assert) {
-      this.runTask(() => this.createApplication());
+      runTask(() => this.createApplication());
       // This is not a public way to access the container; we just
       // need to make some assertions about the created router
       let router = this.applicationInstance.lookup('router:main');
@@ -327,7 +328,7 @@ moduleFor(
     [`@test initialize application with stateManager via initialize call from Router class`](
       assert
     ) {
-      this.runTask(() => {
+      runTask(() => {
         this.createApplication();
         this.addTemplate('application', '<h1>Hello!</h1>');
       });
@@ -339,7 +340,7 @@ moduleFor(
     }
 
     [`@test Application Controller backs the appplication template`]() {
-      this.runTask(() => {
+      runTask(() => {
         this.createApplication();
         this.addTemplate('application', '<h1>{{greeting}}</h1>');
         this.add(
@@ -366,7 +367,7 @@ moduleFor(
 
       libraries.register('my-lib', '2.0.0a');
 
-      this.runTask(() => this.createApplication());
+      runTask(() => this.createApplication());
 
       assert.equal(messages[1], 'Ember  : ' + VERSION);
       if (jQueryDisabled) {
@@ -386,7 +387,7 @@ moduleFor(
 
       setDebugFunction('debug', () => (logged = true));
 
-      this.runTask(() => this.createApplication());
+      runTask(() => this.createApplication());
 
       assert.ok(!logged, 'library version logging skipped');
     }
@@ -394,7 +395,7 @@ moduleFor(
     [`@test can resolve custom router`](assert) {
       let CustomRouter = Router.extend();
 
-      this.runTask(() => {
+      runTask(() => {
         this.createApplication();
         this.add('router:main', CustomRouter);
       });
@@ -407,9 +408,9 @@ moduleFor(
 
     [`@test does not leak itself in onLoad._loaded`](assert) {
       assert.equal(_loaded.application, undefined);
-      this.runTask(() => this.createApplication());
+      runTask(() => this.createApplication());
       assert.equal(_loaded.application, this.application);
-      this.runTask(() => this.application.destroy());
+      runTask(() => this.application.destroy());
       assert.equal(_loaded.application, undefined);
     }
 

--- a/packages/@ember/application/tests/bootstrap-test.js
+++ b/packages/@ember/application/tests/bootstrap-test.js
@@ -1,5 +1,5 @@
 import { assign } from '@ember/polyfills';
-import { moduleFor, DefaultResolverApplicationTestCase } from 'internal-test-helpers';
+import { moduleFor, DefaultResolverApplicationTestCase, runTask } from 'internal-test-helpers';
 
 moduleFor(
   'Application with default resolver and autoboot',
@@ -21,7 +21,7 @@ moduleFor(
     }
 
     ['@test templates in script tags are extracted at application creation'](assert) {
-      this.runTask(() => this.createApplication());
+      runTask(() => this.createApplication());
       assert.equal(document.getElementById('app').textContent, 'Hello World!');
     }
   }

--- a/packages/@ember/application/tests/dependency_injection/custom_resolver_test.js
+++ b/packages/@ember/application/tests/dependency_injection/custom_resolver_test.js
@@ -1,6 +1,6 @@
 import DefaultResolver from '@ember/application/globals-resolver';
 import { assign } from '@ember/polyfills';
-import { moduleFor, DefaultResolverApplicationTestCase } from 'internal-test-helpers';
+import { moduleFor, DefaultResolverApplicationTestCase, runTask } from 'internal-test-helpers';
 
 moduleFor(
   'Application with extended default resolver and autoboot',
@@ -25,7 +25,7 @@ moduleFor(
     }
 
     [`@test a resolver can be supplied to application`]() {
-      this.runTask(() => this.createApplication());
+      runTask(() => this.createApplication());
       this.assertText('Fallback');
     }
   }

--- a/packages/@ember/application/tests/dependency_injection/default_resolver_test.js
+++ b/packages/@ember/application/tests/dependency_injection/default_resolver_test.js
@@ -1,5 +1,5 @@
 /* globals EmberDev */
-import { moduleFor, DefaultResolverApplicationTestCase } from 'internal-test-helpers';
+import { moduleFor, DefaultResolverApplicationTestCase, runTask } from 'internal-test-helpers';
 
 import { context } from '@ember/-internals/environment';
 import Controller from '@ember/controller';
@@ -13,7 +13,7 @@ moduleFor(
   'Application Dependency Injection - Integration - default resolver',
   class extends DefaultResolverApplicationTestCase {
     beforeEach() {
-      this.runTask(() => this.createApplication());
+      runTask(() => this.createApplication());
       return this.visit('/');
     }
 
@@ -255,14 +255,14 @@ moduleFor(
   class extends DefaultResolverApplicationTestCase {
     beforeEach() {
       this.UserInterface = context.lookup.UserInterface = Namespace.create();
-      this.runTask(() => this.createApplication());
+      runTask(() => this.createApplication());
       return this.visit('/');
     }
 
     teardown() {
       let UserInterfaceNamespace = Namespace.NAMESPACES_BY_ID['UserInterface'];
       if (UserInterfaceNamespace) {
-        this.runTask(() => {
+        runTask(() => {
           UserInterfaceNamespace.destroy();
         });
       }
@@ -292,7 +292,7 @@ moduleFor(
     }
 
     beforeEach() {
-      this.runTask(() => this.createApplication());
+      runTask(() => this.createApplication());
       return this.visit('/');
     }
 

--- a/packages/@ember/application/tests/dependency_injection/to_string_test.js
+++ b/packages/@ember/application/tests/dependency_injection/to_string_test.js
@@ -6,6 +6,7 @@ import {
   ApplicationTestCase,
   ModuleBasedTestResolver,
   DefaultResolverApplicationTestCase,
+  runTask,
 } from 'internal-test-helpers';
 
 moduleFor(
@@ -13,7 +14,7 @@ moduleFor(
   class extends DefaultResolverApplicationTestCase {
     constructor() {
       super();
-      this.runTask(() => this.createApplication());
+      runTask(() => this.createApplication());
       this.application.Post = EmberObject.extend();
     }
 

--- a/packages/@ember/application/tests/initializers_test.js
+++ b/packages/@ember/application/tests/initializers_test.js
@@ -1,5 +1,5 @@
 import { assign } from '@ember/polyfills';
-import { moduleFor, AutobootApplicationTestCase } from 'internal-test-helpers';
+import { moduleFor, AutobootApplicationTestCase, runTask } from 'internal-test-helpers';
 import Application from '..';
 
 moduleFor(
@@ -33,7 +33,7 @@ moduleFor(
       super.teardown();
 
       if (this.secondApp) {
-        this.runTask(() => this.secondApp.destroy());
+        runTask(() => this.secondApp.destroy());
       }
     }
 
@@ -63,7 +63,7 @@ moduleFor(
         },
       });
 
-      this.runTask(() => {
+      runTask(() => {
         this.createApplication(
           {
             autoboot: false,
@@ -75,7 +75,7 @@ moduleFor(
       let app = this.application;
 
       try {
-        this.runTask(() => {
+        runTask(() => {
           app.boot().then(
             () => {
               assert.ok(false, 'The boot promise should not resolve when there is a boot error');
@@ -102,7 +102,7 @@ moduleFor(
         },
       });
 
-      this.runTask(() => this.createApplication({}, MyApplication));
+      runTask(() => this.createApplication({}, MyApplication));
     }
 
     [`@test initializers can be registered in a specified order`](assert) {
@@ -157,7 +157,7 @@ moduleFor(
         },
       });
 
-      this.runTask(() => this.createApplication({}, MyApplication));
+      runTask(() => this.createApplication({}, MyApplication));
 
       assert.deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
     }
@@ -214,7 +214,7 @@ moduleFor(
         },
       });
 
-      this.runTask(() => this.createApplication({}, MyApplication));
+      runTask(() => this.createApplication({}, MyApplication));
 
       assert.deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
     }
@@ -263,7 +263,7 @@ moduleFor(
       MyApplication.initializer(afterB);
       MyApplication.initializer(c);
 
-      this.runTask(() => this.createApplication({}, MyApplication));
+      runTask(() => this.createApplication({}, MyApplication));
 
       assert.ok(order.indexOf(a.name) < order.indexOf(b.name), 'a < b');
       assert.ok(order.indexOf(b.name) < order.indexOf(c.name), 'b < c');
@@ -292,12 +292,12 @@ moduleFor(
         },
       });
 
-      this.runTask(() => this.createApplication({}, FirstApp));
+      runTask(() => this.createApplication({}, FirstApp));
 
       assert.equal(firstInitializerRunCount, 1, 'first initializer only was run');
       assert.equal(secondInitializerRunCount, 0, 'first initializer only was run');
 
-      this.runTask(() => this.createSecondApplication({}, SecondApp));
+      runTask(() => this.createSecondApplication({}, SecondApp));
 
       assert.equal(firstInitializerRunCount, 1, 'second initializer only was run');
       assert.equal(secondInitializerRunCount, 1, 'second initializer only was run');
@@ -323,7 +323,7 @@ moduleFor(
         },
       });
 
-      this.runTask(() => this.createApplication({}, FirstApp));
+      runTask(() => this.createApplication({}, FirstApp));
 
       assert.equal(
         firstInitializerRunCount,
@@ -337,7 +337,7 @@ moduleFor(
       );
 
       firstInitializerRunCount = 0;
-      this.runTask(() => this.createSecondApplication({}, SecondApp));
+      runTask(() => this.createSecondApplication({}, SecondApp));
 
       assert.equal(firstInitializerRunCount, 1, 'first initializer was run when subclass created');
       assert.equal(
@@ -385,7 +385,7 @@ moduleFor(
         },
       });
 
-      this.runTask(() => this.createApplication({}, MyApplication));
+      runTask(() => this.createApplication({}, MyApplication));
     }
   }
 );

--- a/packages/@ember/application/tests/instance_initializers_test.js
+++ b/packages/@ember/application/tests/instance_initializers_test.js
@@ -1,5 +1,5 @@
 import { assign } from '@ember/polyfills';
-import { moduleFor, AutobootApplicationTestCase } from 'internal-test-helpers';
+import { moduleFor, AutobootApplicationTestCase, runTask } from 'internal-test-helpers';
 import ApplicationInstance from '@ember/application/instance';
 import Application from '@ember/application';
 
@@ -34,7 +34,7 @@ moduleFor(
       super.teardown();
 
       if (this.secondApp) {
-        this.runTask(() => this.secondApp.destroy());
+        runTask(() => this.secondApp.destroy());
       }
     }
 
@@ -49,7 +49,7 @@ moduleFor(
         MyApplication.instanceInitializer({ initialize() {} });
       });
 
-      this.runTask(() => this.createApplication({}, MyApplication));
+      runTask(() => this.createApplication({}, MyApplication));
     }
 
     [`@test initializers are passed an app instance`](assert) {
@@ -65,7 +65,7 @@ moduleFor(
         },
       });
 
-      this.runTask(() => this.createApplication({}, MyApplication));
+      runTask(() => this.createApplication({}, MyApplication));
     }
 
     [`@test initializers can be registered in a specified order`](assert) {
@@ -120,7 +120,7 @@ moduleFor(
         },
       });
 
-      this.runTask(() => this.createApplication({}, MyApplication));
+      runTask(() => this.createApplication({}, MyApplication));
 
       assert.deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
     }
@@ -177,7 +177,7 @@ moduleFor(
         },
       });
 
-      this.runTask(() => this.createApplication({}, MyApplication));
+      runTask(() => this.createApplication({}, MyApplication));
 
       assert.deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
     }
@@ -226,7 +226,7 @@ moduleFor(
       MyApplication.instanceInitializer(afterB);
       MyApplication.instanceInitializer(c);
 
-      this.runTask(() => this.createApplication({}, MyApplication));
+      runTask(() => this.createApplication({}, MyApplication));
 
       assert.ok(order.indexOf(a.name) < order.indexOf(b.name), 'a < b');
       assert.ok(order.indexOf(b.name) < order.indexOf(c.name), 'b < c');
@@ -254,12 +254,12 @@ moduleFor(
         },
       });
 
-      this.runTask(() => this.createApplication({}, FirstApp));
+      runTask(() => this.createApplication({}, FirstApp));
 
       assert.equal(firstInitializerRunCount, 1, 'first initializer only was run');
       assert.equal(secondInitializerRunCount, 0, 'first initializer only was run');
 
-      this.runTask(() => this.createSecondApplication({}, SecondApp));
+      runTask(() => this.createSecondApplication({}, SecondApp));
 
       assert.equal(firstInitializerRunCount, 1, 'second initializer only was run');
       assert.equal(secondInitializerRunCount, 1, 'second initializer only was run');
@@ -285,7 +285,7 @@ moduleFor(
         },
       });
 
-      this.runTask(() => this.createApplication({}, FirstApp));
+      runTask(() => this.createApplication({}, FirstApp));
 
       assert.equal(
         firstInitializerRunCount,
@@ -299,7 +299,7 @@ moduleFor(
       );
 
       firstInitializerRunCount = 0;
-      this.runTask(() => this.createSecondApplication({}, SecondApp));
+      runTask(() => this.createSecondApplication({}, SecondApp));
 
       assert.equal(firstInitializerRunCount, 1, 'first initializer was run when subclass created');
       assert.equal(
@@ -325,7 +325,7 @@ moduleFor(
         });
       });
 
-      this.runTask(() => this.createApplication({}, FirstApp));
+      runTask(() => this.createApplication({}, FirstApp));
 
       let SecondApp = Application.extend();
       SecondApp.instanceInitializer({
@@ -333,7 +333,7 @@ moduleFor(
         initialize() {},
       });
 
-      this.runTask(() => this.createSecondApplication({}, SecondApp));
+      runTask(() => this.createSecondApplication({}, SecondApp));
 
       assert.ok(true, 'Two apps can have initializers named the same.');
     }
@@ -356,7 +356,7 @@ moduleFor(
         },
       });
 
-      this.runTask(() => this.createApplication({}, MyApplication));
+      runTask(() => this.createApplication({}, MyApplication));
     }
 
     [`@test initializers are executed in their own context`](assert) {
@@ -372,7 +372,7 @@ moduleFor(
         },
       });
 
-      this.runTask(() => this.createApplication({}, MyApplication));
+      runTask(() => this.createApplication({}, MyApplication));
     }
 
     [`@test initializers get an instance on app reset`](assert) {
@@ -387,9 +387,9 @@ moduleFor(
         },
       });
 
-      this.runTask(() => this.createApplication({}, MyApplication));
+      runTask(() => this.createApplication({}, MyApplication));
 
-      this.runTask(() => this.application.reset());
+      runTask(() => this.application.reset());
     }
   }
 );

--- a/packages/@ember/application/tests/visit_test.js
+++ b/packages/@ember/application/tests/visit_test.js
@@ -1,4 +1,4 @@
-import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
+import { moduleFor, ApplicationTestCase, runTask } from 'internal-test-helpers';
 import { inject as injectService } from '@ember/service';
 import { Object as EmberObject, RSVP, onerrorDefault } from '@ember/-internals/runtime';
 import { later } from '@ember/runloop';
@@ -78,7 +78,7 @@ moduleFor(
           );
         })
         .then(() => {
-          return this.runTask(() => {
+          return runTask(() => {
             this.applicationInstance.destroy();
             this.applicationInstance = null;
           });
@@ -138,7 +138,7 @@ moduleFor(
           assert.ok(appBooted === 0, '500ms elapsed without app being booted');
           assert.ok(instanceBooted === 0, '500ms elapsed without instances being booted');
 
-          return this.runTask(() => this.application.boot());
+          return runTask(() => this.application.boot());
         })
         .then(() => {
           assert.ok(appBooted === 1, 'app should boot when manually calling `app.boot()`');
@@ -191,7 +191,7 @@ moduleFor(
         },
       });
 
-      return this.runTask(() => this.application.boot())
+      return runTask(() => this.application.boot())
         .then(() => {
           assert.ok(appBooted === 1, 'the app should be booted');
           assert.ok(instanceBooted === 0, 'no instances should be booted');
@@ -205,7 +205,7 @@ moduleFor(
           /*
            * Destroy the instance.
            */
-          return this.runTask(() => {
+          return runTask(() => {
             this.applicationInstance.destroy();
             this.applicationInstance = null;
           });
@@ -721,12 +721,12 @@ moduleFor(
       let instances = [];
 
       return RSVP.all([
-        this.runTask(() => {
+        runTask(() => {
           return this.application.visit(`/x-foo?data=${data}`, {
             rootElement: foo,
           });
         }),
-        this.runTask(() => {
+        runTask(() => {
           return this.application.visit('/x-bar', { rootElement: bar });
         }),
       ])
@@ -750,7 +750,7 @@ moduleFor(
           assert.equal(bar.querySelector('button').textContent, 'Join 0 others in clicking me!');
           assert.ok(bar.textContent.indexOf('X-Foo') === -1);
 
-          this.runTask(() => {
+          runTask(() => {
             this.click(foo.querySelector('x-foo'));
           });
 
@@ -760,7 +760,7 @@ moduleFor(
           );
           assert.equal(bar.querySelector('button').textContent, 'Join 1 others in clicking me!');
 
-          this.runTask(() => {
+          runTask(() => {
             this.click(bar.querySelector('button'));
             this.click(bar.querySelector('button'));
           });
@@ -772,7 +772,7 @@ moduleFor(
           assert.equal(bar.querySelector('button').textContent, 'Join 3 others in clicking me!');
         })
         .finally(() => {
-          this.runTask(() => {
+          runTask(() => {
             instances.forEach(instance => {
               instance.destroy();
             });

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -1,4 +1,4 @@
-import { moduleFor, AutobootApplicationTestCase } from 'internal-test-helpers';
+import { moduleFor, AutobootApplicationTestCase, runTask } from 'internal-test-helpers';
 
 import { later } from '@ember/runloop';
 import Test from '../lib/test';
@@ -24,7 +24,7 @@ if (!jQueryDisabled) {
 
         testContext = this;
 
-        this.runTask(() => {
+        runTask(() => {
           this.createApplication();
           this.router.map(function() {
             this.route('posts');
@@ -460,14 +460,14 @@ if (!jQueryDisabled) {
       [`@test that the setup/teardown happens correctly`](assert) {
         assert.expect(2);
 
-        this.runTask(() => {
+        runTask(() => {
           this.createApplication();
         });
         this.application.injectTestHelpers();
 
         assert.ok(typeof Test.Promise.prototype.click === 'function');
 
-        this.runTask(() => {
+        runTask(() => {
           this.application.destroy();
         });
 

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -1,4 +1,4 @@
-import { moduleFor, AutobootApplicationTestCase, isIE11 } from 'internal-test-helpers';
+import { moduleFor, AutobootApplicationTestCase, isIE11, runTask } from 'internal-test-helpers';
 
 import { Route } from '@ember/-internals/routing';
 import Controller from '@ember/controller';
@@ -82,7 +82,7 @@ class HelpersTestCase extends AutobootApplicationTestCase {
 class HelpersApplicationTestCase extends HelpersTestCase {
   constructor() {
     super();
-    this.runTask(() => {
+    runTask(() => {
       this.createApplication();
       this.application.setupForTesting();
       this.application.injectTestHelpers();
@@ -95,7 +95,7 @@ if (!jQueryDisabled) {
     'ember-testing: Helper setup',
     class extends HelpersTestCase {
       [`@test Ember.Application#injectTestHelpers/#removeTestHelper`](assert) {
-        this.runTask(() => {
+        runTask(() => {
           this.createApplication();
         });
 
@@ -121,7 +121,7 @@ if (!jQueryDisabled) {
       }
 
       [`@test Ember.Application#setupForTesting`](assert) {
-        this.runTask(() => {
+        runTask(() => {
           this.createApplication();
           this.application.setupForTesting();
         });
@@ -131,7 +131,7 @@ if (!jQueryDisabled) {
       }
 
       [`@test Ember.Application.setupForTesting sets the application to 'testing'`](assert) {
-        this.runTask(() => {
+        runTask(() => {
           this.createApplication();
           this.application.setupForTesting();
         });
@@ -140,7 +140,7 @@ if (!jQueryDisabled) {
       }
 
       [`@test Ember.Application.setupForTesting leaves the system in a deferred state.`](assert) {
-        this.runTask(() => {
+        runTask(() => {
           this.createApplication();
           this.application.setupForTesting();
         });
@@ -155,7 +155,7 @@ if (!jQueryDisabled) {
       [`@test App.reset() after Application.setupForTesting leaves the system in a deferred state.`](
         assert
       ) {
-        this.runTask(() => {
+        runTask(() => {
           this.createApplication();
           this.application.setupForTesting();
         });
@@ -186,7 +186,7 @@ if (!jQueryDisabled) {
 
         // bind(this) so Babel doesn't leak _this
         // into the context onInjectHelpers.
-        this.runTask(
+        runTask(
           function() {
             this.createApplication();
             this.application.setupForTesting();
@@ -203,7 +203,7 @@ if (!jQueryDisabled) {
       [`@test Ember.Application#injectTestHelpers adds helpers to provided object.`](assert) {
         let helpers = {};
 
-        this.runTask(() => {
+        runTask(() => {
           this.createApplication();
           this.application.setupForTesting();
         });
@@ -222,7 +222,7 @@ if (!jQueryDisabled) {
       ) {
         let helpers = { visit: 'snazzleflabber' };
 
-        this.runTask(() => {
+        runTask(() => {
           this.createApplication();
           this.application.setupForTesting();
         });
@@ -253,7 +253,7 @@ if (!jQueryDisabled) {
           return ++other > 2;
         }
 
-        this.runTask(() => {
+        runTask(() => {
           this.application.advanceReadiness();
         });
 
@@ -301,7 +301,7 @@ if (!jQueryDisabled) {
       [`@test 'wait' helper can be passed a resolution value`](assert) {
         assert.expect(4);
 
-        this.runTask(() => {
+        runTask(() => {
           this.application.advanceReadiness();
         });
 
@@ -387,7 +387,7 @@ if (!jQueryDisabled) {
       `
         );
 
-        this.runTask(() => {
+        runTask(() => {
           this.application.advanceReadiness();
         });
 
@@ -473,7 +473,7 @@ if (!jQueryDisabled) {
       `
         );
 
-        this.runTask(() => {
+        runTask(() => {
           this.application.advanceReadiness();
         });
 
@@ -517,7 +517,7 @@ if (!jQueryDisabled) {
 
         this.addTemplate('index', `{{#index-wrapper}}some text{{/index-wrapper}}`);
 
-        this.runTask(() => {
+        runTask(() => {
           this.application.advanceReadiness();
         });
 
@@ -542,7 +542,7 @@ if (!jQueryDisabled) {
       [`@test 'wait' waits for outstanding timers`](assert) {
         assert.expect(1);
 
-        this.runTask(() => {
+        runTask(() => {
           this.application.advanceReadiness();
         });
 
@@ -571,7 +571,7 @@ if (!jQueryDisabled) {
           return ++other > 2;
         }
 
-        this.runTask(() => {
+        runTask(() => {
           this.application.advanceReadiness();
         });
 
@@ -630,7 +630,7 @@ if (!jQueryDisabled) {
       `
         );
 
-        this.runTask(() => {
+        runTask(() => {
           this.application.advanceReadiness();
         });
 
@@ -683,7 +683,7 @@ if (!jQueryDisabled) {
         );
         this.addTemplate('index', `{{index-wrapper}}`);
 
-        this.runTask(() => {
+        runTask(() => {
           this.application.advanceReadiness();
         });
 
@@ -729,7 +729,7 @@ if (!jQueryDisabled) {
         );
         this.addTemplate('index', `{{index-wrapper}}`);
 
-        this.runTask(() => {
+        runTask(() => {
           this.application.advanceReadiness();
         });
 
@@ -765,7 +765,7 @@ if (!jQueryDisabled) {
       `
         );
 
-        this.runTask(() => {
+        runTask(() => {
           this.application.advanceReadiness();
         });
 
@@ -806,7 +806,7 @@ if (!jQueryDisabled) {
       `
         );
 
-        this.runTask(() => {
+        runTask(() => {
           this.application.advanceReadiness();
         });
 
@@ -853,7 +853,7 @@ if (!jQueryDisabled) {
       `
         );
 
-        this.runTask(() => {
+        runTask(() => {
           this.application.advanceReadiness();
         });
 
@@ -885,7 +885,7 @@ if (!jQueryDisabled) {
       `
         );
 
-        this.runTask(() => {
+        runTask(() => {
           this.application.advanceReadiness();
         });
 
@@ -934,7 +934,7 @@ if (!jQueryDisabled) {
         );
         this.addTemplate('index', `{{index-wrapper}}`);
 
-        this.runTask(() => {
+        runTask(() => {
           this.application.advanceReadiness();
         });
 
@@ -972,7 +972,7 @@ if (!jQueryDisabled) {
 
       constructor() {
         super();
-        this.runTask(() => {
+        runTask(() => {
           this.application.advanceReadiness();
         });
       }
@@ -1025,7 +1025,7 @@ if (!jQueryDisabled) {
     class extends HelpersTestCase {
       constructor() {
         super();
-        this.runTask(() => {
+        runTask(() => {
           this.createApplication();
           this.application.setupForTesting();
           this.application.injectTestHelpers();
@@ -1036,7 +1036,7 @@ if (!jQueryDisabled) {
             });
           });
         });
-        this.runTask(() => {
+        runTask(() => {
           this.application.advanceReadiness();
         });
       }
@@ -1165,7 +1165,7 @@ if (!jQueryDisabled) {
       constructor() {
         super();
 
-        this.runTask(() => {
+        runTask(() => {
           this.createApplication();
 
           this.router.map(function() {
@@ -1208,7 +1208,7 @@ if (!jQueryDisabled) {
         });
 
         this.application.injectTestHelpers();
-        this.runTask(() => {
+        runTask(() => {
           this.application.advanceReadiness();
         });
       }
@@ -1250,7 +1250,7 @@ if (!jQueryDisabled) {
     class extends HelpersTestCase {
       constructor() {
         super();
-        this.runTask(() => {
+        runTask(() => {
           this.createApplication();
           this.application.setupForTesting();
         });

--- a/packages/ember-testing/tests/integration_test.js
+++ b/packages/ember-testing/tests/integration_test.js
@@ -1,4 +1,4 @@
-import { moduleFor, AutobootApplicationTestCase } from 'internal-test-helpers';
+import { moduleFor, AutobootApplicationTestCase, runTask } from 'internal-test-helpers';
 import Test from '../lib/test';
 
 import { A as emberA } from '@ember/-internals/runtime';
@@ -14,7 +14,7 @@ moduleFor(
       this.modelContent = [];
       this._originalAdapter = Test.adapter;
 
-      this.runTask(() => {
+      runTask(() => {
         this.createApplication();
 
         this.addTemplate(
@@ -42,7 +42,7 @@ moduleFor(
         this.application.setupForTesting();
       });
 
-      this.runTask(() => {
+      runTask(() => {
         this.application.reset();
       });
 
@@ -56,13 +56,13 @@ moduleFor(
 
     [`@test template is bound to empty array of people`](assert) {
       if (!jQueryDisabled) {
-        this.runTask(() => this.application.advanceReadiness());
+        runTask(() => this.application.advanceReadiness());
         window.visit('/').then(() => {
           let rows = window.find('.name').length;
           assert.equal(rows, 0, 'successfully stubbed an empty array of people');
         });
       } else {
-        this.runTask(() => this.application.advanceReadiness());
+        runTask(() => this.application.advanceReadiness());
         window.visit('/').then(() => {
           expectAssertion(
             () => window.find('.name'),
@@ -78,7 +78,7 @@ moduleFor(
         this.modelContent.pushObject({ firstName: 'x' });
         this.modelContent.pushObject({ firstName: 'y' });
 
-        this.runTask(() => this.application.advanceReadiness());
+        runTask(() => this.application.advanceReadiness());
         window.visit('/').then(() => {
           let rows = window.find('.name').length;
           assert.equal(rows, 2, 'successfully stubbed a non empty array of people');

--- a/packages/ember/tests/application_lifecycle_test.js
+++ b/packages/ember/tests/application_lifecycle_test.js
@@ -1,4 +1,4 @@
-import { moduleFor, AutobootApplicationTestCase } from 'internal-test-helpers';
+import { moduleFor, AutobootApplicationTestCase, runTask } from 'internal-test-helpers';
 import Application from '@ember/application';
 import { Route, Router } from '@ember/-internals/routing';
 import { Component } from '@ember/-internals/glimmer';
@@ -26,7 +26,7 @@ moduleFor(
       super();
       let menuItem = (this.menuItem = {});
 
-      this.runTask(() => {
+      runTask(() => {
         this.createApplication();
 
         let SettingRoute = Route.extend({
@@ -74,7 +74,7 @@ moduleFor(
       assert.equal(indexController.get('selectedMenuItem'), this.menuItem);
       assert.equal(applicationController.get('selectedMenuItem'), this.menuItem);
 
-      this.runTask(() => {
+      runTask(() => {
         this.application.destroy();
       });
 
@@ -101,7 +101,7 @@ moduleFor(
     [`@test Destroying a route after the router does create an undestroyed 'toplevelView'`](
       assert
     ) {
-      this.runTask(() => {
+      runTask(() => {
         this.createApplication();
         this.addTemplate('index', `Index!`);
         this.addTemplate('application', `Application! {{outlet}}`);
@@ -110,13 +110,13 @@ moduleFor(
       let router = this.applicationInstance.lookup('router:main');
       let route = this.applicationInstance.lookup('route:index');
 
-      this.runTask(() => router.destroy());
+      runTask(() => router.destroy());
       assert.equal(router._toplevelView, null, 'the toplevelView was cleared');
 
-      this.runTask(() => route.destroy());
+      runTask(() => route.destroy());
       assert.equal(router._toplevelView, null, 'the toplevelView was not reinitialized');
 
-      this.runTask(() => this.application.destroy());
+      runTask(() => this.application.destroy());
       assert.equal(router._toplevelView, null, 'the toplevelView was not reinitialized');
     }
 
@@ -134,7 +134,7 @@ moduleFor(
         },
       });
 
-      this.runTask(() => {
+      runTask(() => {
         this.createApplication({}, MyApplication);
 
         this.add(
@@ -166,7 +166,7 @@ moduleFor(
           };
         },
       });
-      this.runTask(() => {
+      runTask(() => {
         this.createApplication({}, MyApplication);
 
         this.add(

--- a/packages/ember/tests/component_registration_test.js
+++ b/packages/ember/tests/component_registration_test.js
@@ -2,7 +2,7 @@ import Application from '@ember/application';
 import Controller from '@ember/controller';
 import { Component } from '@ember/-internals/glimmer';
 import { compile } from 'ember-template-compiler';
-import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
+import { moduleFor, ApplicationTestCase, runLoopSettled } from 'internal-test-helpers';
 import { ENV } from '@ember/-internals/environment';
 
 moduleFor(
@@ -246,7 +246,7 @@ moduleFor(
         this.visit('/');
       }, /.* named "no-good" .*/);
 
-      return this.runLoopSettled();
+      return runLoopSettled();
     }
   }
 );

--- a/packages/ember/tests/controller_test.js
+++ b/packages/ember/tests/controller_test.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
+import { moduleFor, ApplicationTestCase, runTask } from 'internal-test-helpers';
 import { Component } from '@ember/-internals/glimmer';
 
 /*
@@ -37,7 +37,7 @@ moduleFor(
       this.addTemplate('index', '{{component-with-action action=(action "componentAction")}}');
 
       return this.visit('/').then(() => {
-        this.runTask(() => this.$('.component-with-action').click());
+        runTask(() => this.$('.component-with-action').click());
       });
     }
   }

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1,4 +1,4 @@
-import { moduleFor, ApplicationTestCase, runLoopSettled } from 'internal-test-helpers';
+import { moduleFor, ApplicationTestCase, runLoopSettled, runTask } from 'internal-test-helpers';
 import Controller, { inject as injectController } from '@ember/controller';
 import { A as emberA } from '@ember/-internals/runtime';
 import { alias } from '@ember/-internals/metal';
@@ -127,7 +127,7 @@ moduleFor(
         );
 
         let controller = this.applicationInstance.lookup('controller:index');
-        this.runTask(() => controller.set('dynamicDisabledWhen', false));
+        runTask(() => controller.set('dynamicDisabledWhen', false));
 
         assert.equal(
           this.$('#about-link-dynamic.disabled').length,
@@ -349,7 +349,7 @@ moduleFor(
         );
 
         let controller = this.applicationInstance.lookup('controller:index');
-        this.runTask(() => controller.set('foo', true));
+        runTask(() => controller.set('foo', true));
 
         assert.equal(
           this.$('#about-link.foo-is-true').length,
@@ -780,7 +780,7 @@ moduleFor(
         );
 
         let controller = this.applicationInstance.lookup('controller:index.about');
-        this.runTask(() => controller.set('isCurrent', true));
+        runTask(() => controller.set('isCurrent', true));
 
         assert.ok(
           this.$('#index-link').hasClass('active'),
@@ -1301,7 +1301,7 @@ moduleFor(
         assertEquality('/');
 
         let controller = this.applicationInstance.lookup('controller:index');
-        this.runTask(() => controller.set('foo', 'about'));
+        runTask(() => controller.set('foo', 'about'));
 
         assertEquality('/about');
       });
@@ -1326,7 +1326,7 @@ moduleFor(
 
       return this.visit('/').then(() => {
         let indexController = this.applicationInstance.lookup('controller:index');
-        this.runTask(() => indexController.set('post', post));
+        runTask(() => indexController.set('post', post));
 
         assert.equal(
           normalizeUrl(this.$('#post').attr('href')),
@@ -1334,7 +1334,7 @@ moduleFor(
           'precond - Link has rendered href attr properly'
         );
 
-        this.runTask(() => indexController.set('post', secondPost));
+        runTask(() => indexController.set('post', secondPost));
 
         assert.equal(
           this.$('#post').attr('href'),
@@ -1342,7 +1342,7 @@ moduleFor(
           'href attr was updated after one of the params had been changed'
         );
 
-        this.runTask(() => indexController.set('post', null));
+        runTask(() => indexController.set('post', null));
 
         assert.equal(
           this.$('#post').attr('href'),
@@ -1432,11 +1432,11 @@ moduleFor(
         linksEqual(this.$('a'), ['/foo', '/bar', '/rar', '/foo', '/bar', '/rar', '/bar', '/foo']);
 
         let indexController = this.applicationInstance.lookup('controller:index');
-        this.runTask(() => indexController.set('route1', 'rar'));
+        runTask(() => indexController.set('route1', 'rar'));
 
         linksEqual(this.$('a'), ['/foo', '/bar', '/rar', '/foo', '/bar', '/rar', '/rar', '/foo']);
 
-        this.runTask(() => indexController.routeNames.shiftObject());
+        runTask(() => indexController.routeNames.shiftObject());
 
         linksEqual(this.$('a'), ['/bar', '/rar', '/bar', '/rar', '/rar', '/foo']);
       });
@@ -1525,7 +1525,7 @@ moduleFor(
           );
 
           let controller = this.applicationInstance.lookup('controller:index');
-          this.runTask(() => controller.set('contactName', 'Joe'));
+          runTask(() => controller.set('contactName', 'Joe'));
 
           assert.equal(
             this.$('#contact-link').text(),
@@ -1533,7 +1533,7 @@ moduleFor(
             'The link title is correctly updated when the bound property changes'
           );
 
-          this.runTask(() => controller.set('contactName', 'Robert'));
+          runTask(() => controller.set('contactName', 'Robert'));
 
           assert.equal(
             this.$('#contact-link').text(),
@@ -1658,7 +1658,7 @@ moduleFor(
         assertEquality('/');
 
         let controller = this.applicationInstance.lookup('controller:index');
-        this.runTask(() => controller.set('foo', 'about'));
+        runTask(() => controller.set('foo', 'about'));
 
         assertEquality('/about');
       });
@@ -1678,7 +1678,7 @@ moduleFor(
         assert.equal(this.$('#link').text(), 'blahzorz');
 
         let controller = this.applicationInstance.lookup('controller:application');
-        this.runTask(() => controller.set('display', '<b>BLAMMO</b>'));
+        runTask(() => controller.set('display', '<b>BLAMMO</b>'));
 
         assert.equal(this.$('#link').text(), '<b>BLAMMO</b>');
         assert.equal(this.$('b').length, 0);
@@ -1928,7 +1928,7 @@ moduleFor(
         assert.equal(link.attr('href'), '/foo/one/two');
 
         let controller = this.applicationInstance.lookup('controller:index');
-        this.runTask(() => {
+        runTask(() => {
           controller.set('dynamicLinkParams', ['bar', 'one', 'two', 'three']);
         });
 
@@ -2044,25 +2044,25 @@ moduleFor(
         })
         .then(() => {
           // Set the destinationRoute (context is still null).
-          this.runTask(() => controller.set('destinationRoute', 'thing'));
+          runTask(() => controller.set('destinationRoute', 'thing'));
           assertLinkStatus(contextLink);
 
           // Set the routeContext to an id
-          this.runTask(() => controller.set('routeContext', '456'));
+          runTask(() => controller.set('routeContext', '456'));
           assertLinkStatus(contextLink, '/thing/456');
 
           // Test that 0 isn't interpreted as falsy.
-          this.runTask(() => controller.set('routeContext', 0));
+          runTask(() => controller.set('routeContext', 0));
           assertLinkStatus(contextLink, '/thing/0');
 
           // Set the routeContext to an object
-          this.runTask(() => {
+          runTask(() => {
             controller.set('routeContext', { id: 123 });
           });
           assertLinkStatus(contextLink, '/thing/123');
 
           // Set the destinationRoute back to null.
-          this.runTask(() => controller.set('destinationRoute', null));
+          runTask(() => controller.set('destinationRoute', null));
           assertLinkStatus(contextLink);
 
           return expectWarning(() => {
@@ -2070,7 +2070,7 @@ moduleFor(
           }, warningMessage);
         })
         .then(() => {
-          this.runTask(() => controller.set('secondRoute', 'about'));
+          runTask(() => controller.set('secondRoute', 'about'));
           assertLinkStatus(staticLink, '/about');
 
           // Click the now-active link

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1,4 +1,4 @@
-import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
+import { moduleFor, ApplicationTestCase, runLoopSettled } from 'internal-test-helpers';
 import Controller, { inject as injectController } from '@ember/controller';
 import { A as emberA } from '@ember/-internals/runtime';
 import { alias } from '@ember/-internals/metal';
@@ -252,7 +252,7 @@ moduleFor(
           let controller = this.applicationInstance.lookup('controller:index');
           controller.set('disabledWhen', false);
 
-          return this.runLoopSettled();
+          return runLoopSettled();
         })
         .then(() => {
           return this.click('#about-link');
@@ -1698,7 +1698,7 @@ moduleFor(
         this.visit('/');
       }, /(You attempted to define a `\{\{link-to "post"\}\}` but did not pass the parameters required for generating its dynamic segments.|You must provide param `post_id` to `generate`)/);
 
-      return this.runLoopSettled();
+      return runLoopSettled();
     }
 
     [`@test the {{link-to}} helper does not throw an error if its route has exited`](assert) {

--- a/packages/ember/tests/helpers/link_to_test/link_to_transitioning_classes_test.js
+++ b/packages/ember/tests/helpers/link_to_test/link_to_transitioning_classes_test.js
@@ -1,6 +1,6 @@
 import { RSVP } from '@ember/-internals/runtime';
 import { Route } from '@ember/-internals/routing';
-import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
+import { moduleFor, ApplicationTestCase, runTask } from 'internal-test-helpers';
 
 function assertHasClass(assert, selector, label) {
   let testLabel = `${selector.attr('id')} should have class ${label}`;
@@ -100,7 +100,7 @@ moduleFor(
       assertHasNoClass(assert, $about, 'ember-transitioning-out');
       assertHasNoClass(assert, $other, 'ember-transitioning-out');
 
-      this.runTask(() => this.aboutDefer.resolve());
+      runTask(() => this.aboutDefer.resolve());
 
       assertHasNoClass(assert, $index, 'active');
       assertHasClass(assert, $about, 'active');
@@ -134,7 +134,7 @@ moduleFor(
       assertHasNoClass(assert, $news, 'ember-transitioning-out');
       assertHasNoClass(assert, $other, 'ember-transitioning-out');
 
-      this.runTask(() => this.newsDefer.resolve());
+      runTask(() => this.newsDefer.resolve());
 
       assertHasNoClass(assert, $index, 'active');
       assertHasNoClass(assert, $news, 'active');
@@ -206,14 +206,14 @@ moduleFor(
     }
 
     resolveAbout() {
-      return this.runTask(() => {
+      return runTask(() => {
         this.aboutDefer.resolve();
         this.aboutDefer = RSVP.defer();
       });
     }
 
     resolveOther() {
-      return this.runTask(() => {
+      return runTask(() => {
         this.otherDefer.resolve();
         this.otherDefer = RSVP.defer();
       });

--- a/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
+++ b/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { RSVP } from '@ember/-internals/runtime';
 import { Route } from '@ember/-internals/routing';
-import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
+import { moduleFor, ApplicationTestCase, runLoopSettled } from 'internal-test-helpers';
 
 moduleFor(
   'The {{link-to}} helper: invoking with query params',
@@ -688,7 +688,7 @@ moduleFor(
         this.visit('/');
       }, /You must provide one or more parameters to the link-to component/);
 
-      return this.runLoopSettled();
+      return runLoopSettled();
     }
   }
 );

--- a/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
+++ b/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { RSVP } from '@ember/-internals/runtime';
 import { Route } from '@ember/-internals/routing';
-import { moduleFor, ApplicationTestCase, runLoopSettled } from 'internal-test-helpers';
+import { moduleFor, ApplicationTestCase, runLoopSettled, runTask } from 'internal-test-helpers';
 
 moduleFor(
   'The {{link-to}} helper: invoking with query params',
@@ -184,7 +184,7 @@ moduleFor(
         let theLink = this.$('#the-link');
         assert.equal(theLink.attr('href'), '/about?baz=lol');
 
-        this.runTask(() => this.click('#the-link'));
+        runTask(() => this.click('#the-link'));
 
         let aboutController = this.getController('about');
 
@@ -210,7 +210,7 @@ moduleFor(
 
         assert.equal(theLink.attr('href'), '/?foo=OMG');
 
-        this.runTask(() => indexController.set('boundThing', 'ASL'));
+        runTask(() => indexController.set('boundThing', 'ASL'));
 
         assert.equal(theLink.attr('href'), '/?foo=ASL');
       });
@@ -232,7 +232,7 @@ moduleFor(
 
         assert.equal(theLink.attr('href'), '/?abool=OMG');
 
-        this.runTask(() => indexController.set('boundThing', false));
+        runTask(() => indexController.set('boundThing', false));
 
         assert.equal(theLink.attr('href'), '/?abool=false');
 
@@ -259,11 +259,11 @@ moduleFor(
 
         assert.equal(theLink.attr('href'), '/?foo=lol');
 
-        this.runTask(() => indexController.set('bar', 'BORF'));
+        runTask(() => indexController.set('bar', 'BORF'));
 
         assert.equal(theLink.attr('href'), '/?bar=BORF&foo=lol');
 
-        this.runTask(() => indexController.set('foo', 'YEAH'));
+        runTask(() => indexController.set('foo', 'YEAH'));
 
         assert.equal(theLink.attr('href'), '/?bar=BORF&foo=lol');
       });
@@ -306,13 +306,13 @@ moduleFor(
 
         assert.equal(router.currentRouteName, 'cars.create');
 
-        this.runTask(() => this.click('#close-link'));
+        runTask(() => this.click('#close-link'));
 
         assert.equal(router.currentRouteName, 'cars.index');
         assert.equal(router.get('url'), '/cars');
         assert.equal(carsController.get('page'), 1, 'The page query-param is 1');
 
-        this.runTask(() => this.click('#page2-link'));
+        runTask(() => this.click('#page2-link'));
 
         assert.equal(router.currentRouteName, 'cars.index', 'The active route is still cars');
         assert.equal(router.get('url'), '/cars?page=2', 'The url has been updated');
@@ -593,13 +593,13 @@ moduleFor(
 
           assert.equal(parentController.get('page'), 2);
 
-          this.runTask(() => parentController.set('page', 3));
+          runTask(() => parentController.set('page', 3));
 
           assert.equal(router.get('location.path'), '/parent?page=3');
           this.shouldBeActive(assert, '#app-link');
           this.shouldBeActive(assert, '#parent-link');
 
-          this.runTask(() => this.click('#app-link'));
+          runTask(() => this.click('#app-link'));
 
           assert.equal(router.get('location.path'), '/parent');
         });
@@ -666,13 +666,13 @@ moduleFor(
         this.shouldNotBeActive(assert, '#baz-foos-link');
         this.shouldNotBeActive(assert, '#bars-link');
 
-        this.runTask(() => barsLink.click());
+        runTask(() => barsLink.click());
         this.shouldNotBeActive(assert, '#bars-link');
 
-        this.runTask(() => foosLink.click());
+        runTask(() => foosLink.click());
         this.shouldNotBeActive(assert, '#foos-link');
 
-        this.runTask(() => foos.resolve());
+        runTask(() => foos.resolve());
 
         assert.equal(router.get('location.path'), '/foos');
         this.shouldBeActive(assert, '#foos-link');

--- a/packages/ember/tests/integration/multiple-app-test.js
+++ b/packages/ember/tests/integration/multiple-app-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
+import { moduleFor, ApplicationTestCase, runTask } from 'internal-test-helpers';
 import Application from '@ember/application';
 import { Component } from '@ember/-internals/glimmer';
 import { getOwner } from '@ember/-internals/owner';
@@ -14,7 +14,7 @@ moduleFor(
       <div id="two"></div>
     `;
       super();
-      this.runTask(() => {
+      runTask(() => {
         this.createSecondApplication();
       });
     }
@@ -39,7 +39,7 @@ moduleFor(
       super.teardown();
 
       if (this.secondApp) {
-        this.runTask(() => {
+        runTask(() => {
           this.secondApp.destroy();
         });
       }

--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -5,7 +5,7 @@ import { compile } from 'ember-template-compiler';
 import { Route, NoneLocation, HistoryLocation } from '@ember/-internals/routing';
 import Controller from '@ember/controller';
 import { Object as EmberObject, A as emberA } from '@ember/-internals/runtime';
-import { moduleFor, ApplicationTestCase, runDestroy } from 'internal-test-helpers';
+import { moduleFor, ApplicationTestCase, runDestroy, runTask } from 'internal-test-helpers';
 import { run } from '@ember/runloop';
 import { Mixin, computed, set, addObserver, observer } from '@ember/-internals/metal';
 import { getTextOf } from 'internal-test-helpers';
@@ -310,7 +310,7 @@ moduleFor(
           let text = this.$('p').text();
           assert.equal(text, 'THIS IS THE REAL HOME', 'the homepage template was rendered');
 
-          return this.runTask(() => this.appRouter.send('showAlert'));
+          return runTask(() => this.appRouter.send('showAlert'));
         })
         .then(() => {
           let text = this.$('.alert-box').text();

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -1,6 +1,6 @@
 import { RSVP } from '@ember/-internals/runtime';
 import { Route } from '@ember/-internals/routing';
-import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
+import { moduleFor, ApplicationTestCase, runLoopSettled } from 'internal-test-helpers';
 
 let counter;
 
@@ -720,7 +720,7 @@ moduleFor(
         'it broke'
       );
 
-      return this.runLoopSettled();
+      return runLoopSettled();
     }
 
     [`@test Handled errors that re-throw aren't swallowed`](assert) {
@@ -767,7 +767,7 @@ moduleFor(
         `it broke`
       );
 
-      return this.runLoopSettled();
+      return runLoopSettled();
     }
 
     ['@test errors that are bubbled are thrown at a higher level if not handled'](assert) {
@@ -799,7 +799,7 @@ moduleFor(
         'Correct error was thrown'
       );
 
-      return this.runLoopSettled();
+      return runLoopSettled();
     }
 
     [`@test Handled errors that are thrown through rejection aren't swallowed`](assert) {
@@ -846,7 +846,7 @@ moduleFor(
         'it broke'
       );
 
-      return this.runLoopSettled();
+      return runLoopSettled();
     }
 
     ['@test Default error events move into nested route, prioritizing more specifically named error routes - NEW'](

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -1,6 +1,6 @@
 import { RSVP } from '@ember/-internals/runtime';
 import { Route } from '@ember/-internals/routing';
-import { moduleFor, ApplicationTestCase, runLoopSettled } from 'internal-test-helpers';
+import { moduleFor, ApplicationTestCase, runLoopSettled, runTask } from 'internal-test-helpers';
 
 let counter;
 
@@ -653,7 +653,7 @@ moduleFor(
           return visit;
         })
         .then(() => {
-          this.runTask(() => puppiesDeferred.resolve());
+          runTask(() => puppiesDeferred.resolve());
 
           assert.equal(this.currentPath, 'grandma.puppies', 'Finished transition');
         });
@@ -941,7 +941,7 @@ moduleFor(
         `The loading template is nested in application template's outlet`
       );
 
-      this.runTask(() => grandmaDeferred.resolve());
+      runTask(() => grandmaDeferred.resolve());
       text = this.$('#app').text();
 
       assert.equal(

--- a/packages/internal-test-helpers/index.js
+++ b/packages/internal-test-helpers/index.js
@@ -8,7 +8,7 @@ export { default as strip } from './lib/strip';
 export { default as applyMixins } from './lib/apply-mixins';
 export { default as getTextOf } from './lib/get-text-of';
 export { equalsElement, classes, styles, regex } from './lib/matchers';
-export { runAppend, runDestroy, runTaskNext, runLoopSettled } from './lib/run';
+export { runAppend, runDestroy, runTask, runTaskNext, runLoopSettled } from './lib/run';
 export { getContext, setContext, unsetContext } from './lib/test-context';
 
 export { default as AbstractTestCase } from './lib/test-cases/abstract';

--- a/packages/internal-test-helpers/index.js
+++ b/packages/internal-test-helpers/index.js
@@ -8,7 +8,7 @@ export { default as strip } from './lib/strip';
 export { default as applyMixins } from './lib/apply-mixins';
 export { default as getTextOf } from './lib/get-text-of';
 export { equalsElement, classes, styles, regex } from './lib/matchers';
-export { runAppend, runDestroy, runTaskNext } from './lib/run';
+export { runAppend, runDestroy, runTaskNext, runLoopSettled } from './lib/run';
 export { getContext, setContext, unsetContext } from './lib/test-context';
 
 export { default as AbstractTestCase } from './lib/test-cases/abstract';

--- a/packages/internal-test-helpers/index.js
+++ b/packages/internal-test-helpers/index.js
@@ -8,7 +8,7 @@ export { default as strip } from './lib/strip';
 export { default as applyMixins } from './lib/apply-mixins';
 export { default as getTextOf } from './lib/get-text-of';
 export { equalsElement, classes, styles, regex } from './lib/matchers';
-export { runAppend, runDestroy } from './lib/run';
+export { runAppend, runDestroy, runTaskNext } from './lib/run';
 export { getContext, setContext, unsetContext } from './lib/test-context';
 
 export { default as AbstractTestCase } from './lib/test-cases/abstract';

--- a/packages/internal-test-helpers/lib/run.ts
+++ b/packages/internal-test-helpers/lib/run.ts
@@ -19,6 +19,10 @@ export function runDestroy(toDestroy: any) {
   }
 }
 
+export function runTask(callback: Function) {
+  return run(callback);
+}
+
 export function runTaskNext(): Promise<void> {
   return new Promise(resolve => {
     return next(resolve);

--- a/packages/internal-test-helpers/lib/run.ts
+++ b/packages/internal-test-helpers/lib/run.ts
@@ -1,4 +1,10 @@
-import { run } from '@ember/runloop';
+import {
+  // @ts-ignore
+  next,
+  run,
+} from '@ember/runloop';
+
+import { Promise } from 'rsvp';
 
 export function runAppend(view: any) {
   run(view, 'appendTo', document.getElementById('qunit-fixture'));
@@ -8,4 +14,10 @@ export function runDestroy(toDestroy: any) {
   if (toDestroy) {
     run(toDestroy, 'destroy');
   }
+}
+
+export function runTaskNext(): Promise<void> {
+  return new Promise(resolve => {
+    return next(resolve);
+  });
 }

--- a/packages/internal-test-helpers/lib/run.ts
+++ b/packages/internal-test-helpers/lib/run.ts
@@ -1,10 +1,10 @@
 import { run } from '@ember/runloop';
 
-export function runAppend(view) {
+export function runAppend(view: any) {
   run(view, 'appendTo', document.getElementById('qunit-fixture'));
 }
 
-export function runDestroy(toDestroy) {
+export function runDestroy(toDestroy: any) {
   if (toDestroy) {
     run(toDestroy, 'destroy');
   }

--- a/packages/internal-test-helpers/lib/run.ts
+++ b/packages/internal-test-helpers/lib/run.ts
@@ -1,4 +1,7 @@
 import {
+  getCurrentRunLoop,
+  // @ts-ignore
+  hasScheduledTimers,
   // @ts-ignore
   next,
   run,
@@ -19,5 +22,24 @@ export function runDestroy(toDestroy: any) {
 export function runTaskNext(): Promise<void> {
   return new Promise(resolve => {
     return next(resolve);
+  });
+}
+
+// TODO: Find a better name 😎
+export function runLoopSettled(event?: any): Promise<void> {
+  return new Promise(function(resolve) {
+    // Every 5ms, poll for the async thing to have finished
+    let watcher = setInterval(() => {
+      // If there are scheduled timers or we are inside of a run loop, keep polling
+      if (hasScheduledTimers() || getCurrentRunLoop()) {
+        return;
+      }
+
+      // Stop polling
+      clearInterval(watcher);
+
+      // Synchronously resolve the promise
+      resolve(event);
+    }, 5);
   });
 }

--- a/packages/internal-test-helpers/lib/test-cases/abstract-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract-application.js
@@ -1,7 +1,7 @@
 import { compile } from 'ember-template-compiler';
 import { ENV } from '@ember/-internals/environment';
 import AbstractTestCase from './abstract';
-import { runDestroy } from '../run';
+import { runDestroy, runTask } from '../run';
 
 export default class AbstractApplicationTestCase extends AbstractTestCase {
   _ensureInstance(bootOptions) {
@@ -9,20 +9,18 @@ export default class AbstractApplicationTestCase extends AbstractTestCase {
       return this._applicationInstancePromise;
     }
 
-    return (this._applicationInstancePromise = this.runTask(() => this.application.boot()).then(
-      app => {
-        this.applicationInstance = app.buildInstance();
+    return (this._applicationInstancePromise = runTask(() => this.application.boot()).then(app => {
+      this.applicationInstance = app.buildInstance();
 
-        return this.applicationInstance.boot(bootOptions);
-      }
-    ));
+      return this.applicationInstance.boot(bootOptions);
+    }));
   }
 
   visit(url, options) {
     // TODO: THIS IS HORRIBLE
     // the promise returned by `ApplicationInstance.protoype.visit` does **not**
     // currently guarantee rendering is completed
-    return this.runTask(() => {
+    return runTask(() => {
       return this._ensureInstance(options).then(instance => instance.visit(url));
     });
   }

--- a/packages/internal-test-helpers/lib/test-cases/abstract.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract.js
@@ -1,14 +1,14 @@
 /* global Element */
 
 import { assign } from '@ember/polyfills';
-import { getCurrentRunLoop, hasScheduledTimers, run } from '@ember/runloop';
+import { run } from '@ember/runloop';
 
 import NodeQuery from '../node-query';
 import equalInnerHTML from '../equal-inner-html';
 import equalTokens from '../equal-tokens';
 import { getElement } from '../element-helpers';
 import { equalsElement, regex, classes } from '../matchers';
-import { Promise } from 'rsvp';
+import { runLoopSettled } from '../run';
 
 const TextNode = window.Text;
 const HTMLElement = window.HTMLElement;
@@ -116,26 +116,7 @@ export default class AbstractTestCase {
 
     let event = element.click();
 
-    return this.runLoopSettled(event);
-  }
-
-  // TODO: Find a better name 😎
-  runLoopSettled(value) {
-    return new Promise(function(resolve) {
-      // Every 5ms, poll for the async thing to have finished
-      let watcher = setInterval(() => {
-        // If there are scheduled timers or we are inside of a run loop, keep polling
-        if (hasScheduledTimers() || getCurrentRunLoop()) {
-          return;
-        }
-
-        // Stop polling
-        clearInterval(watcher);
-
-        // Synchronously resolve the promise
-        resolve(value);
-      }, 5);
-    });
+    return runLoopSettled(event);
   }
 
   textValue() {

--- a/packages/internal-test-helpers/lib/test-cases/abstract.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract.js
@@ -1,14 +1,13 @@
 /* global Element */
 
 import { assign } from '@ember/polyfills';
-import { run } from '@ember/runloop';
 
 import NodeQuery from '../node-query';
 import equalInnerHTML from '../equal-inner-html';
 import equalTokens from '../equal-tokens';
 import { getElement } from '../element-helpers';
 import { equalsElement, regex, classes } from '../matchers';
-import { runLoopSettled } from '../run';
+import { runLoopSettled, runTask } from '../run';
 
 const TextNode = window.Text;
 const HTMLElement = window.HTMLElement;
@@ -40,10 +39,6 @@ export default class AbstractTestCase {
 
   teardown() {}
   afterEach() {}
-
-  runTask(callback) {
-    return run(callback);
-  }
 
   setupFixture(innerHTML) {
     let fixture = document.getElementById('qunit-fixture');
@@ -192,7 +187,7 @@ export default class AbstractTestCase {
 
   assertStableRerender() {
     this.takeSnapshot();
-    this.runTask(() => this.rerender());
+    runTask(() => this.rerender());
     this.assertInvariants();
   }
 }

--- a/packages/internal-test-helpers/lib/test-cases/abstract.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract.js
@@ -1,7 +1,7 @@
 /* global Element */
 
 import { assign } from '@ember/polyfills';
-import { getCurrentRunLoop, hasScheduledTimers, next, run } from '@ember/runloop';
+import { getCurrentRunLoop, hasScheduledTimers, run } from '@ember/runloop';
 
 import NodeQuery from '../node-query';
 import equalInnerHTML from '../equal-inner-html';
@@ -43,12 +43,6 @@ export default class AbstractTestCase {
 
   runTask(callback) {
     return run(callback);
-  }
-
-  runTaskNext() {
-    return new Promise(resolve => {
-      return next(resolve);
-    });
   }
 
   setupFixture(innerHTML) {

--- a/packages/internal-test-helpers/lib/test-cases/application.js
+++ b/packages/internal-test-helpers/lib/test-cases/application.js
@@ -3,12 +3,14 @@ import Application from '@ember/application';
 import { Router } from '@ember/-internals/routing';
 import { assign } from '@ember/polyfills';
 
+import { runTask } from '../run';
+
 export default class ApplicationTestCase extends TestResolverApplicationTestCase {
   constructor() {
     super(...arguments);
 
     let { applicationOptions } = this;
-    this.application = this.runTask(this.createApplication.bind(this, applicationOptions));
+    this.application = runTask(this.createApplication.bind(this, applicationOptions));
 
     this.resolver = this.application.__registry__.resolver;
 
@@ -32,7 +34,7 @@ export default class ApplicationTestCase extends TestResolverApplicationTestCase
   }
 
   transitionTo() {
-    return this.runTask(() => {
+    return runTask(() => {
       return this.appRouter.transitionTo(...arguments);
     });
   }

--- a/packages/internal-test-helpers/lib/test-cases/default-resolver-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/default-resolver-application.js
@@ -5,6 +5,8 @@ import { setTemplates, setTemplate } from '@ember/-internals/glimmer';
 import { assign } from '@ember/polyfills';
 import { Router } from '@ember/-internals/routing';
 
+import { runTask } from '../run';
+
 export default class DefaultResolverApplicationTestCase extends AbstractApplicationTestCase {
   createApplication() {
     let application = (this.application = Application.create(this.applicationOptions));
@@ -30,7 +32,7 @@ export default class DefaultResolverApplicationTestCase extends AbstractApplicat
   }
 
   transitionTo() {
-    return this.runTask(() => {
+    return runTask(() => {
       return this.appRouter.transitionTo(...arguments);
     });
   }


### PR DESCRIPTION
This eliminates more dependencies on the testing base classes.