### PR TITLE
tests/glimmer: Simplify `TrustedContentTest` class

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/content-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/content-test.js
@@ -787,17 +787,6 @@ class TrustedContentTest extends DynamicContentTest {
   assertContent(content) {
     this.assertHTML(content);
   }
-
-  assertStableRerender() {
-    this.takeSnapshot();
-    this.runTask(() => this.rerender());
-    super.assertInvariants();
-  }
-
-  assertInvariants() {
-    // If it's not stable, we will wipe out all the content and replace them,
-    // so there are no invariants
-  }
 }
 
 moduleFor(


### PR DESCRIPTION
`assertStableRerender()` is identical to the `super` implementation, and `assertInvariants()` is not used at all