### PR TITLE
[BUGFIX lts] Avoid console.trace for every Ember.warn

### DIFF
--- a/packages/@ember/debug/lib/warn.ts
+++ b/packages/@ember/debug/lib/warn.ts
@@ -58,9 +58,6 @@ if (DEBUG) {
   registerHandler(function logWarning(message) {
     /* eslint-disable no-console */
     console.warn(`WARNING: ${message}`);
-    if (console.trace) {
-      console.trace();
-    }
     /* eslint-enable no-console */
   });
 


### PR DESCRIPTION
Originally (Ember < 3.2), `Ember.warn` used `Ember.Logger` as an abstraction layer in case `console` was not present. Since `Ember.Logger` was deprecated in [emberjs/rfcs#297](https://emberjs.github.io/rfcs/0297-deprecate-ember-logger.html) the internals have been refactored to use `console` directly instead.

When that change was made, the following:

```js
    Logger.warn(`WARNING: ${message}`);
    if ('trace' in Logger) {
      Logger.trace();
    }
```

Was changed to:

```js
    console.warn(`WARNING: ${message}`);
    if (console.trace) {
      console.trace();
    }
```

This _seems_ correct, however when you dig into it you will notice that the `Ember.Logger` class **never** had a `.trace` method! The reason for the original `'trace' in Logger` check was specifically so that you _could_ do `Ember.Logger.trace = () => console.trace` _IIF_ you wanted to see where a given warning was coming from. That was added back in 2012, but since then the developer tools of modern browsers have gotten massively better. At this point, **every** `console.log`/`console.warn` tracks its stack trace so that you can drill into the source in the dev tools. The primary difference between that functionality and calling `console.trace()` directly like this is that with `console.warn` the stack trace is hidden by default (and has to be manually expanded), whereas with `console.trace()` it is _always_ called and the full stack is printed.

**tldr;** when we refactored to address the `Ember.Logger` deprecation, we began calling `console.trace` for _every_ `Ember.warn` invocation and the `console.trace()` calls make the console fairly unusable even with a very low volumn of warnings.