### PR TITLE
[BUGFIX release] Ensure legacy build of template compiler can be loaded.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -209,6 +209,7 @@ function buildBundles(packagesES, dependenciesES, templateCompilerDependenciesES
         '@ember/polyfills/index.js',
         '@ember/polyfills/lib/**',
         'ember/version.js',
+        'ember-babel.js',
         'ember-template-compiler/**',
       ],
     }),

--- a/tests/node/template-compiler-test.js
+++ b/tests/node/template-compiler-test.js
@@ -1,49 +1,67 @@
 var path = require('path');
 
 var distPath = path.join(__dirname, '../../dist');
-var templateCompilerPath = path.join(distPath, 'ember-template-compiler');
 
 var module = QUnit.module;
 var test = QUnit.test;
 
 var templateCompiler;
 
-module('ember-template-compiler.js', function(hooks) {
-  hooks.beforeEach(function() {
-    templateCompiler = require(templateCompilerPath);
-  });
+module('ember-template-compiler.js', function() {
+  ['', 'legacy'].forEach(type => {
+    module(`${type || 'modern'}`, function(hooks) {
+      hooks.beforeEach(function() {
+        this.templateCompilerPath = path.resolve(
+          path.join(distPath, type, 'ember-template-compiler.js')
+        );
+        templateCompiler = require(this.templateCompilerPath);
+      });
 
-  hooks.afterEach(function() {
-    // clear the previously cached version of this module
-    delete require.cache[templateCompilerPath + '.js'];
-  });
+      hooks.afterEach(function() {
+        // clear the previously cached version of this module
+        delete require.cache[this.templateCompilerPath];
+      });
 
-  test('can be required', function(assert) {
-    assert.strictEqual(
-      typeof templateCompiler.precompile,
-      'function',
-      'precompile function is present'
-    );
-    assert.strictEqual(typeof templateCompiler.compile, 'function', 'compile function is present');
-  });
+      test('can be required', function(assert) {
+        assert.strictEqual(
+          typeof templateCompiler.precompile,
+          'function',
+          'precompile function is present'
+        );
+        assert.strictEqual(
+          typeof templateCompiler.compile,
+          'function',
+          'compile function is present'
+        );
+      });
 
-  test('can access _Ember.ENV (private API used by ember-cli-htmlbars)', function(assert) {
-    assert.equal(typeof templateCompiler._Ember.ENV, 'object', '_Ember.ENV is present');
-    assert.notEqual(typeof templateCompiler._Ember.ENV, null, '_Ember.ENV is not null');
-  });
+      test('can access _Ember.ENV (private API used by ember-cli-htmlbars)', function(assert) {
+        assert.equal(typeof templateCompiler._Ember.ENV, 'object', '_Ember.ENV is present');
+        assert.notEqual(typeof templateCompiler._Ember.ENV, null, '_Ember.ENV is not null');
+      });
 
-  test('can access _Ember.FEATURES (private API used by ember-cli-htmlbars)', function(assert) {
-    assert.equal(typeof templateCompiler._Ember.FEATURES, 'object', '_Ember.FEATURES is present');
-    assert.notEqual(typeof templateCompiler._Ember.FEATURES, null, '_Ember.FEATURES is not null');
-  });
+      test('can access _Ember.FEATURES (private API used by ember-cli-htmlbars)', function(assert) {
+        assert.equal(
+          typeof templateCompiler._Ember.FEATURES,
+          'object',
+          '_Ember.FEATURES is present'
+        );
+        assert.notEqual(
+          typeof templateCompiler._Ember.FEATURES,
+          null,
+          '_Ember.FEATURES is not null'
+        );
+      });
 
-  test('can access _Ember.VERSION (private API used by ember-cli-htmlbars)', function(assert) {
-    assert.equal(typeof templateCompiler._Ember.VERSION, 'string', '_Ember.VERSION is present');
-  });
+      test('can access _Ember.VERSION (private API used by ember-cli-htmlbars)', function(assert) {
+        assert.equal(typeof templateCompiler._Ember.VERSION, 'string', '_Ember.VERSION is present');
+      });
 
-  test('can generate a template with a server side generated `id`', function(assert) {
-    var TemplateJSON = JSON.parse(templateCompiler.precompile('<div>simple text</div>'));
+      test('can generate a template with a server side generated `id`', function(assert) {
+        var TemplateJSON = JSON.parse(templateCompiler.precompile('<div>simple text</div>'));
 
-    assert.ok(TemplateJSON.id, 'an `id` was generated');
+        assert.ok(TemplateJSON.id, 'an `id` was generated');
+      });
+    });
   });
 });


### PR DESCRIPTION
Without this change the following error was triggered:

```
node -e 'require("ember-source/dist/legacy/ember-template-compiler")'
/Users/rjackson/src/emberjs/ember.js/dist/legacy/ember-template-compiler.js:21
      throw new Error('Could not find module ' + name + ' required by: ' + referrerName);
      ^

Error: Could not find module ember-babel required by: @glimmer/compiler
    at missingModule (/Users/rjackson/src/emberjs/ember.js/dist/legacy/ember-template-compiler.js:21:13)
    at internalRequire (/Users/rjackson/src/emberjs/ember.js/dist/legacy/ember-template-compiler.js:45:7)
    at internalRequire (/Users/rjackson/src/emberjs/ember.js/dist/legacy/ember-template-compiler.js:58:22)
    at internalRequire (/Users/rjackson/src/emberjs/ember.js/dist/legacy/ember-template-compiler.js:58:22)
    at internalRequire (/Users/rjackson/src/emberjs/ember.js/dist/legacy/ember-template-compiler.js:58:22)
    at internalRequire (/Users/rjackson/src/emberjs/ember.js/dist/legacy/ember-template-compiler.js:58:22)
    at internalRequire (/Users/rjackson/src/emberjs/ember.js/dist/legacy/ember-template-compiler.js:58:22)
    at requireModule (/Users/rjackson/src/emberjs/ember.js/dist/legacy/ember-template-compiler.js:99:14)
    at /Users/rjackson/src/emberjs/ember.js/dist/legacy/ember-template-compiler.js:14842:92
    at Object.<anonymous>
    (/Users/rjackson/src/emberjs/ember.js/dist/legacy/ember-template-compiler.js:14845:2)
```

This happened because the `ember-template-compiler.js` bundle did not include the babel helpers needed.

Fixes https://github.com/emberjs/ember.js/issues/17402