### PR TITLE
only null check result of `Object.getPrototypeOf`

### DIFF
--- a/packages/@ember/-internals/meta/lib/meta.ts
+++ b/packages/@ember/-internals/meta/lib/meta.ts
@@ -865,7 +865,7 @@ export function peekMeta(obj: object) {
 
   let pointer = getPrototypeOf(obj);
 
-  while (pointer !== undefined && pointer !== null) {
+  while (pointer !== null) {
     if (DEBUG) {
       counters!.peekPrototypeWalks++;
     }

--- a/packages/@ember/-internals/metal/lib/properties.ts
+++ b/packages/@ember/-internals/metal/lib/properties.ts
@@ -91,14 +91,13 @@ export function INHERITING_GETTER_FUNCTION(name: string): InheritingGetterFuncti
     let val;
     if (meta !== undefined) {
       val = meta.readInheritedValue('values', name);
+      if (val === UNDEFINED) {
+        let proto = Object.getPrototypeOf(this);
+        return proto === null ? undefined : proto[name];
+      }
     }
 
-    if (val === UNDEFINED) {
-      let proto = Object.getPrototypeOf(this);
-      return proto && proto[name];
-    } else {
-      return val;
-    }
+    return val;
   }
 
   return Object.assign(IGETTER_FUNCTION as InheritingGetterFunction, {


### PR DESCRIPTION
`Object.getPrototypeOf` either returns `object` or `null`