### PR TITLE
[Feature] Update instance-initializer blueprint for ember-mocha 0.14

### DIFF
--- a/blueprints/instance-initializer-test/mocha-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
+++ b/blueprints/instance-initializer-test/mocha-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import Application from '@ember/application';
+import { initialize } from '<%= modulePrefix %>/instance-initializers/<%= dasherizedModuleName %>';
+<% if (destroyAppExists) { %>import destroyApp from '../../helpers/destroy-app';<% } else { %>import { run } from '@ember/runloop';<% } %>
+
+describe('<%= friendlyTestName %>', function() {
+  beforeEach(function() {
+    this.TestApplication = Application.extend();
+    this.TestApplication.instanceInitializer({
+      name: 'initializer under test',
+      initialize
+    });
+    this.application = this.TestApplication.create({ autoboot: false });
+    this.instance = this.application.buildInstance();
+  });
+  afterEach(function() {
+    <% if (destroyAppExists) { %>destroyApp(this.instance);<% } else { %>run(this.instance, 'destroy');<% } %>
+    <% if (destroyAppExists) { %>destroyApp(this.application);<% } else { %>run(this.application, 'destroy');<% } %>
+  });
+
+  // Replace this with your real tests.
+  it('works', async function() {
+    await this.instance.boot();
+
+    expect(true).to.be.ok;
+  });
+});

--- a/node-tests/blueprints/instance-initializer-test-test.js
+++ b/node-tests/blueprints/instance-initializer-test-test.js
@@ -75,6 +75,21 @@ describe('Blueprint: instance-initializer-test', function() {
         });
       });
     });
+
+    describe('with ember-mocha@0.14.0', function() {
+      beforeEach(function() {
+        modifyPackages([{ name: 'ember-qunit', delete: true }, { name: 'ember-mocha', dev: true }]);
+        generateFakePackageManifest('ember-mocha', '0.14.0');
+      });
+
+      it('instance-initializer-test foo for mocha', function() {
+        return emberGenerateDestroy(['instance-initializer-test', 'foo'], _file => {
+          expect(_file('tests/unit/instance-initializers/foo-test.js')).to.equal(
+            fixture('instance-initializer-test/mocha-rfc232.js')
+          );
+        });
+      });
+    });
   });
 
   describe('in addon', function() {
@@ -156,6 +171,21 @@ describe('Blueprint: instance-initializer-test', function() {
         return emberGenerateDestroy(['instance-initializer-test', 'foo'], _file => {
           expect(_file('src/init/instance-initializers/foo-test.js')).to.equal(
             fixture('instance-initializer-test/module-unification/mocha.js')
+          );
+        });
+      });
+    });
+
+    describe('with ember-mocha@0.14.0', function() {
+      beforeEach(function() {
+        modifyPackages([{ name: 'ember-qunit', delete: true }, { name: 'ember-mocha', dev: true }]);
+        generateFakePackageManifest('ember-mocha', '0.14.0');
+      });
+
+      it('instance-initializer-test foo for mocha', function() {
+        return emberGenerateDestroy(['instance-initializer-test', 'foo'], _file => {
+          expect(_file('src/init/instance-initializers/foo-test.js')).to.equal(
+            fixture('instance-initializer-test/module-unification/mocha-rfc232.js')
           );
         });
       });

--- a/node-tests/fixtures/instance-initializer-test/mocha-rfc232.js
+++ b/node-tests/fixtures/instance-initializer-test/mocha-rfc232.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import Application from '@ember/application';
+import { initialize } from 'my-app/instance-initializers/foo';
+import { run } from '@ember/runloop';
+
+describe('Unit | Instance Initializer | foo', function() {
+  beforeEach(function() {
+    this.TestApplication = Application.extend();
+    this.TestApplication.instanceInitializer({
+      name: 'initializer under test',
+      initialize
+    });
+    this.application = this.TestApplication.create({ autoboot: false });
+    this.instance = this.application.buildInstance();
+  });
+  afterEach(function() {
+    run(this.instance, 'destroy');
+    run(this.application, 'destroy');
+  });
+
+  // Replace this with your real tests.
+  it('works', async function() {
+    await this.instance.boot();
+
+    expect(true).to.be.ok;
+  });
+});

--- a/node-tests/fixtures/instance-initializer-test/module-unification/mocha-rfc232.js
+++ b/node-tests/fixtures/instance-initializer-test/module-unification/mocha-rfc232.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import Application from '@ember/application';
+import { initialize } from 'my-app/init/instance-initializers/foo';
+import { run } from '@ember/runloop';
+
+describe('Unit | Instance Initializer | foo', function() {
+  beforeEach(function() {
+    this.TestApplication = Application.extend();
+    this.TestApplication.instanceInitializer({
+      name: 'initializer under test',
+      initialize
+    });
+    this.application = this.TestApplication.create({ autoboot: false });
+    this.instance = this.application.buildInstance();
+  });
+  afterEach(function() {
+    run(this.instance, 'destroy');
+    run(this.application, 'destroy');
+  });
+
+  // Replace this with your real tests.
+  it('works', async function() {
+    await this.instance.boot();
+
+    expect(true).to.be.ok;
+  });
+});


### PR DESCRIPTION
Related to #16863

*Note: this blueprint and the one for initializers (#17411) follow what the existing QUnit RFC232 blueprints do. However I wondered why for those qunit-based blueprints, the initializer test calls `setupTest()`, while the instance-initializer does not. For now the two new PRs for ember-mocha 0.14 do the same, but if there is no good reason for this, I can update all of those...*