### PR TITLE
[BUGFIX beta] fix 'strict mode does not allow function declarations'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,8 +62,6 @@ module.exports = {
         'no-unused-vars': 'off',
         'no-undef': 'off',
 
-        'no-inner-declarations': 'off',
-
         'import/export': 'off',
         'import/named': 'off',
         'import/no-unresolved': 'off',

--- a/packages/@ember/-internals/metal/tests/tracked/get_test.ts
+++ b/packages/@ember/-internals/metal/tests/tracked/get_test.ts
@@ -3,7 +3,7 @@ import { AbstractTestCase, moduleFor } from 'internal-test-helpers';
 import { get, getWithDefault, tracked } from '../..';
 
 if (EMBER_METAL_TRACKED_PROPERTIES) {
-  function createObj() {
+  const createObj = function() {
     class Obj {
       @tracked string = 'string';
       @tracked number = 23;
@@ -13,7 +13,7 @@ if (EMBER_METAL_TRACKED_PROPERTIES) {
     }
 
     return new Obj();
-  }
+  };
 
   moduleFor(
     '@tracked decorator: get',

--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -266,6 +266,14 @@ RouterService.reopen({
 });
 
 if (EMBER_ROUTING_ROUTER_SERVICE) {
+  const cleanURL = function(url: string, rootURL: string) {
+    if (rootURL === '/') {
+      return url;
+    }
+
+    return url.substr(rootURL.length, url.length);
+  };
+
   RouterService.reopen(Evented, {
     init() {
       this._super(...arguments);
@@ -401,12 +409,4 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
       @public
     */
   });
-
-  function cleanURL(url: string, rootURL: string) {
-    if (rootURL === '/') {
-      return url;
-    }
-
-    return url.substr(rootURL.length, url.length);
-  }
 }


### PR DESCRIPTION
We've discovered that on ios9 (at least) there is an error `strict mode does not allow function declarations` which prevents the application to work normally. We assume, although we're not quite sure, it was released with the v3.6.

Anyways, it's related to the fact that the function `cleanURL` was declared within an `if` block in the `router.ts`.

It turns out that the eslint rule which cares about such issues had been disabled. After re-enabling it I found out that there are only 2 issues (the one with the router and another one in the test). 

I guess it's worth making the rule enabled; I also fixed the 2 failures by assigning functions to variables.