### PR TITLE
bin/publish_builds cleanup

### DIFF
--- a/bin/publish_builds
+++ b/bin/publish_builds
@@ -17,7 +17,7 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$PUBLISH" == "true" ]; then
     echo -e "CURRENT_TAG: ${TRAVIS_TAG}\n"
     echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}"> ~/.npmrc
 
-    NPM_USER=`npm whoami`
+    NPM_USER=$(npm whoami)
     echo -e "Publishing to npm as $NPM_USER...\n"
 
     # auto-dist-tag is ran by bin/build-for-publishing.js


### PR DESCRIPTION
Backtick command substitution `` `...` `` is legacy syntax with several issues.

- It has a series of undefined behaviors related to quoting in POSIX.
- It imposes a custom escaping mode with surprising results.
- It's exceptionally hard to nest.

source: https://github.com/koalaman/shellcheck/wiki/SC2006