### PR TITLE
[BUGFIX] fix issue with overidability of computed.volatile

### DIFF
--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -501,12 +501,11 @@ class ComputedProperty extends Descriptor implements DescriptorWithDependentKeys
 
   /* called before property is overridden */
   teardown(obj: object, keyName: string, meta?: any): void {
-    if (this._volatile) {
-      return;
-    }
-    let cache = peekCacheFor(obj);
-    if (cache !== undefined && cache.delete(keyName)) {
-      removeDependentKeys(this, obj, keyName, meta);
+    if (!this._volatile) {
+      let cache = peekCacheFor(obj);
+      if (cache !== undefined && cache.delete(keyName)) {
+        removeDependentKeys(this, obj, keyName, meta);
+      }
     }
     super.teardown(obj, keyName, meta);
   }

--- a/packages/@ember/-internals/metal/tests/computed_test.js
+++ b/packages/@ember/-internals/metal/tests/computed_test.js
@@ -76,6 +76,16 @@ moduleFor(
       assert.equal(count, 1, 'should have invoked computed property');
     }
 
+    ['@test can override volatile computed property'](assert) {
+      let obj = {};
+
+      defineProperty(obj, 'foo', computed(function() {}).volatile());
+
+      set(obj, 'foo', 'boom');
+
+      assert.equal(obj.foo, 'boom');
+    }
+
     ['@test defining computed property should invoke property on set'](assert) {
       let obj = {};
       let count = 0;


### PR DESCRIPTION
`super.teardown` was not called when `computed` is `volatile`, therefore was not torn down properly 