### PR TITLE
[DOC] Update since tag on array helper to be v3.8

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/helpers/array.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/array.ts
@@ -31,7 +31,7 @@ import { Opaque } from '@glimmer/util';
    @param {Array} options
    @return {Array} Array
    @category array-helper
-   @since 3.7.0
+   @since 3.8.0
    @public
  */
 


### PR DESCRIPTION
According to [this commit](https://github.com/emberjs/ember.js/commit/2648bec5bbcbae51b09376cb386aad364bd2e429). This feature will be released in Ember v3.8.0