### PR TITLE
Add a failing test for query params cache with resetNamespace

### DIFF
--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -870,6 +870,46 @@ moduleFor(
       assert.equal(indexController.get('omg'), 'lol');
     }
 
+    ['@test query params caching works with reset namespaces'](assert) {
+      assert.expect(2);
+
+      this.router.map(function () {
+        this.route('parent', { path: '/parent/:parent_id/' }, function () {
+          this.route('child', { path: '/child/:child_id' }, function () {
+            this.route('grandchild', { path: '/grandchild', resetNamespace: true });
+          });
+        });
+      });
+
+      this.add(
+        'route:parent',
+        Route.extend({
+          model() {},
+        })
+      );
+
+      this.add(
+        'route:parent.child',
+        Route.extend({
+          model() {},
+        })
+      );
+
+      this.add(
+        'route:grandchild',
+        Route.extend({
+          model() {},
+        })
+      );
+
+      this.setSingleQPController('grandchild', 'query', '');
+
+      return this.visitAndAssert('/parent/1/child/2/grandchild?query=foo').then(() => {
+        this.transitionTo('grandchild', { id: 3 });
+        this.assertCurrentPath('/parent/1/child/3/grandchild');
+      });
+    }
+
     async ['@test can opt into a replace query by specifying replace:true in the Route config hash'](
       assert
     ) {


### PR DESCRIPTION
The basic issue here is that the cache key calculator uses the current route name to determine the prefix for the key which enables a correct value lookup. However, if you use `resetNamespace` the prefix won't match and it calculates the prefix incorrectly. In this example, it will try get the value from `parent.child.child_id` (IIRC) and instead of that getting the value of `child_id` from the `parent.child` route, it will try to get the value of `child.child_id` from the `parent` route.