### PR TITLE
Ensure internal package tests are ran in prod.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -241,6 +241,7 @@ function buildBundles(packagesES, dependenciesES, templateCompilerDependenciesES
     emberTestsProdFiles = new MergeTrees([
       new Funnel(packagesProdES, {
         include: [
+          '@ember/-internals/*/tests/**' /* internal packages */,
           'internal-test-helpers/**',
           '*/*/tests/**' /* scoped packages */,
           '*/tests/**' /* packages */,

--- a/packages/@ember/-internals/container/tests/container_test.js
+++ b/packages/@ember/-internals/container/tests/container_test.js
@@ -1,6 +1,7 @@
 import { OWNER } from '@ember/-internals/owner';
 import { assign } from '@ember/polyfills';
 import { EMBER_MODULE_UNIFICATION } from '@ember/canary-features';
+import { DEBUG } from '@glimmer/env';
 import { Registry } from '..';
 import { factory, moduleFor, AbstractTestCase, runTask } from 'internal-test-helpers';
 
@@ -199,7 +200,7 @@ moduleFor(
       }, /Failed to create an instance of \'controller:foo\'/);
     }
 
-    ['@test Injecting a failed lookup raises an error'](assert) {
+    ['@test Injecting a failed lookup raises an error']() {
       let registry = new Registry();
       let container = registry.container();
 
@@ -218,7 +219,7 @@ moduleFor(
       registry.register('model:foo', Foo);
       registry.injection('model:foo', 'store', 'store:main');
 
-      assert.throws(() => {
+      expectAssertion(() => {
         container.lookup('model:foo');
       });
     }
@@ -443,7 +444,7 @@ moduleFor(
       assert.deepEqual(resolveWasCalled, ['foo:post']);
     }
 
-    [`@test A factory's lazy injections are validated when first instantiated`](assert) {
+    [`@test A factory's lazy injections are validated when first instantiated`]() {
       let registry = new Registry();
       let container = registry.container();
       let Apple = factory();
@@ -458,12 +459,17 @@ moduleFor(
       registry.register('apple:main', Apple);
       registry.register('orange:main', Orange);
 
-      assert.throws(() => {
+      expectAssertion(() => {
         container.lookup('apple:main');
       }, /Attempting to inject an unknown injection: 'banana:main'/);
     }
 
     ['@test Lazy injection validations are cached'](assert) {
+      if (!DEBUG) {
+        assert.expect(0);
+        return;
+      }
+
       assert.expect(1);
 
       let registry = new Registry();

--- a/packages/@ember/-internals/container/tests/registry_test.js
+++ b/packages/@ember/-internals/container/tests/registry_test.js
@@ -180,10 +180,10 @@ moduleFor(
       );
     }
 
-    ['@test cannot register an `undefined` factory'](assert) {
+    ['@test cannot register an `undefined` factory']() {
       let registry = new Registry();
 
-      assert.throws(() => {
+      expectAssertion(() => {
         registry.register('controller:apple', undefined);
       }, '');
     }

--- a/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
@@ -1266,19 +1266,17 @@ moduleFor(
       this.assertStableRerender();
     }
 
-    ['@test GH#17121 implicit component invocations should not perform string lookup'](assert) {
+    ['@test GH#17121 implicit component invocations should not perform string lookup']() {
       this.registerComponent('foo-bar', { template: 'foo-bar component' });
 
-      assert.throws(
+      expectAssertion(
         () =>
           this.render(strip`
           {{#let 'foo-bar' as |foo|}}
             {{foo 1 2 3}}
           {{/let}}
         `),
-        new TypeError(
-          "expected `foo` to be a contextual component but found a string. Did you mean `(component foo)`? ('-top-level' @ L1:C29) "
-        )
+        "expected `foo` to be a contextual component but found a string. Did you mean `(component foo)`? ('-top-level' @ L1:C29) "
       );
     }
 

--- a/packages/@ember/-internals/meta/tests/listeners_test.js
+++ b/packages/@ember/-internals/meta/tests/listeners_test.js
@@ -1,3 +1,4 @@
+import { DEBUG } from '@glimmer/env';
 import { AbstractTestCase, moduleFor } from 'internal-test-helpers';
 import { meta, counters } from '..';
 
@@ -48,8 +49,10 @@ moduleFor(
     }
 
     ['@test parent caching'](assert) {
-      counters.flattenedListenersCalls = 0;
-      counters.parentListenersUsed = 0;
+      if (DEBUG) {
+        counters.flattenedListenersCalls = 0;
+        counters.parentListenersUsed = 0;
+      }
 
       class Class {}
       let classMeta = meta(Class.prototype);
@@ -61,20 +64,25 @@ moduleFor(
       let matching = m.matchingListeners('hello');
 
       assert.equal(matching.length, 3);
-      assert.equal(counters.flattenedListenersCalls, 2);
-      assert.equal(counters.parentListenersUsed, 1);
-
+      if (DEBUG) {
+        assert.equal(counters.flattenedListenersCalls, 2);
+        assert.equal(counters.parentListenersUsed, 1);
+      }
       matching = m.matchingListeners('hello');
 
       assert.equal(matching.length, 3);
-      assert.equal(counters.flattenedListenersCalls, 3);
-      assert.equal(counters.parentListenersUsed, 1);
+      if (DEBUG) {
+        assert.equal(counters.flattenedListenersCalls, 3);
+        assert.equal(counters.parentListenersUsed, 1);
+      }
     }
 
     ['@test parent cache invalidation'](assert) {
-      counters.flattenedListenersCalls = 0;
-      counters.parentListenersUsed = 0;
-      counters.listenersInherited = 0;
+      if (DEBUG) {
+        counters.flattenedListenersCalls = 0;
+        counters.parentListenersUsed = 0;
+        counters.listenersInherited = 0;
+      }
 
       class Class {}
       let classMeta = meta(Class.prototype);
@@ -86,21 +94,30 @@ moduleFor(
       let matching = m.matchingListeners('hello');
 
       assert.equal(matching.length, 3);
-      assert.equal(counters.flattenedListenersCalls, 2);
-      assert.equal(counters.parentListenersUsed, 1);
-      assert.equal(counters.listenersInherited, 0);
+      if (DEBUG) {
+        assert.equal(counters.flattenedListenersCalls, 2);
+        assert.equal(counters.parentListenersUsed, 1);
+        assert.equal(counters.listenersInherited, 0);
+      }
 
       m.addToListeners('hello', null, 'm2');
 
       matching = m.matchingListeners('hello');
 
       assert.equal(matching.length, 6);
-      assert.equal(counters.flattenedListenersCalls, 4);
-      assert.equal(counters.parentListenersUsed, 1);
-      assert.equal(counters.listenersInherited, 1);
+      if (DEBUG) {
+        assert.equal(counters.flattenedListenersCalls, 4);
+        assert.equal(counters.parentListenersUsed, 1);
+        assert.equal(counters.listenersInherited, 1);
+      }
     }
 
     ['@test reopen after flatten'](assert) {
+      if (!DEBUG) {
+        assert.expect(0);
+        return;
+      }
+
       // Ensure counter is zeroed
       counters.reopensAfterFlatten = 0;
 

--- a/packages/@ember/-internals/runtime/tests/mutable-array/insertAt-test.js
+++ b/packages/@ember/-internals/runtime/tests/mutable-array/insertAt-test.js
@@ -40,9 +40,8 @@ class InsertAtTests extends AbstractTestCase {
 
   '@test [].insertAt(200,X) => OUT_OF_RANGE_EXCEPTION exception'() {
     let obj = this.newObject([]);
-    let that = this;
-
-    this.assert.throws(() => obj.insertAt(200, that.newFixture(1)[0]), Error);
+    let item = newFixture(1)[0];
+    expectAssertion(() => obj.insertAt(200, item), /`insertAt` index provided is out of range/);
   }
 
   '@test [A].insertAt(0, X) => [X,A] + notify'() {

--- a/packages/@ember/-internals/runtime/tests/mutable-array/removeAt-test.js
+++ b/packages/@ember/-internals/runtime/tests/mutable-array/removeAt-test.js
@@ -34,7 +34,7 @@ class RemoveAtTests extends AbstractTestCase {
 
   '@test removeAt([], 200) => OUT_OF_RANGE_EXCEPTION exception'() {
     let obj = this.newObject([]);
-    this.assert.throws(() => removeAt(obj, 200), Error);
+    expectAssertion(() => removeAt(obj, 200), /`removeAt` index provided is out of range/);
   }
 
   '@test removeAt([A,B], 0) => [B] + notify'() {


### PR DESCRIPTION
Unfortunately when https://github.com/emberjs/ember.js/pull/16905 moved around all the internal files we missed updating the `ember-tests.prod.js` bundle to include the new `@ember/-internals/*/tests/**` files. This fixes that mistake and also fixes up a number of tests that had been introduced and are broken in production builds.

Fixes #17463 
