### PR TITLE
[FEAT] Implements the Computed Property Modifier deprecation RFCs

### DIFF
--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -1,5 +1,5 @@
 import { meta as metaFor, peekMeta } from '@ember/-internals/meta';
-import { inspect } from '@ember/-internals/utils';
+import { inspect, toString } from '@ember/-internals/utils';
 import { EMBER_METAL_TRACKED_PROPERTIES } from '@ember/canary-features';
 import { assert, deprecate, warn } from '@ember/debug';
 import EmberError from '@ember/error';
@@ -476,7 +476,9 @@ class ComputedProperty extends Descriptor implements DescriptorWithDependentKeys
 
   clobberSet(obj: object, keyName: string, value: any): any {
     deprecate(
-      `The ${keyName} computed property was just overriden. This removes the computed property and replaces it with a plain value, and has been deprecated. If you want this behavior, consider defining a setter which does it manually.`,
+      `The ${toString(
+        obj
+      )}#${keyName} computed property was just overriden. This removes the computed property and replaces it with a plain value, and has been deprecated. If you want this behavior, consider defining a setter which does it manually.`,
       false,
       {
         id: 'computed-property.override',

--- a/packages/@ember/-internals/metal/tests/mixin/computed_test.js
+++ b/packages/@ember/-internals/metal/tests/mixin/computed_test.js
@@ -110,57 +110,62 @@ moduleFor(
     }
 
     ['@test setter behavior works properly when overriding computed properties'](assert) {
-      let obj = {};
+      expectDeprecation(() => {
+        let obj = {};
 
-      let MixinA = Mixin.create({
-        cpWithSetter2: computed(K),
-        cpWithSetter3: computed(K),
-        cpWithoutSetter: computed(K),
-      });
+        let MixinA = Mixin.create({
+          cpWithSetter2: computed(K),
+          cpWithSetter3: computed(K),
+          cpWithoutSetter: computed(K),
+        });
 
-      let cpWasCalled = false;
+        let cpWasCalled = false;
 
-      let MixinB = Mixin.create({
-        cpWithSetter2: computed({
-          get: K,
-          set() {
+        let MixinB = Mixin.create({
+          cpWithSetter2: computed({
+            get: K,
+            set() {
+              cpWasCalled = true;
+            },
+          }),
+
+          cpWithSetter3: computed({
+            get: K,
+            set() {
+              cpWasCalled = true;
+            },
+          }),
+
+          cpWithoutSetter: computed(function() {
             cpWasCalled = true;
-          },
-        }),
+          }),
+        });
 
-        cpWithSetter3: computed({
-          get: K,
-          set() {
-            cpWasCalled = true;
-          },
-        }),
+        MixinA.apply(obj);
+        MixinB.apply(obj);
 
-        cpWithoutSetter: computed(function() {
-          cpWasCalled = true;
-        }),
-      });
+        set(obj, 'cpWithSetter2', 'test');
+        assert.ok(
+          cpWasCalled,
+          'The computed property setter was called when defined with two args'
+        );
+        cpWasCalled = false;
 
-      MixinA.apply(obj);
-      MixinB.apply(obj);
+        set(obj, 'cpWithSetter3', 'test');
+        assert.ok(
+          cpWasCalled,
+          'The computed property setter was called when defined with three args'
+        );
+        cpWasCalled = false;
 
-      set(obj, 'cpWithSetter2', 'test');
-      assert.ok(cpWasCalled, 'The computed property setter was called when defined with two args');
-      cpWasCalled = false;
-
-      set(obj, 'cpWithSetter3', 'test');
-      assert.ok(
-        cpWasCalled,
-        'The computed property setter was called when defined with three args'
-      );
-      cpWasCalled = false;
-
-      set(obj, 'cpWithoutSetter', 'test');
-      assert.equal(
-        get(obj, 'cpWithoutSetter'),
-        'test',
-        'The default setter was called, the value is correct'
-      );
-      assert.ok(!cpWasCalled, 'The default setter was called, not the CP itself');
+        set(obj, 'cpWithoutSetter', 'test');
+        assert.equal(
+          get(obj, 'cpWithoutSetter'),
+          'test',
+          'The default setter was called, the value is correct'
+        );
+        assert.ok(!cpWasCalled, 'The default setter was called, not the CP itself');
+      }, /The cpWithoutSetter computed property was just overriden./);
     }
   }
 );

--- a/packages/@ember/-internals/metal/tests/mixin/computed_test.js
+++ b/packages/@ember/-internals/metal/tests/mixin/computed_test.js
@@ -110,62 +110,60 @@ moduleFor(
     }
 
     ['@test setter behavior works properly when overriding computed properties'](assert) {
-      expectDeprecation(() => {
-        let obj = {};
+      let obj = {};
 
-        let MixinA = Mixin.create({
-          cpWithSetter2: computed(K),
-          cpWithSetter3: computed(K),
-          cpWithoutSetter: computed(K),
-        });
+      let MixinA = Mixin.create({
+        cpWithSetter2: computed(K),
+        cpWithSetter3: computed(K),
+        cpWithoutSetter: computed(K),
+      });
 
-        let cpWasCalled = false;
+      let cpWasCalled = false;
 
-        let MixinB = Mixin.create({
-          cpWithSetter2: computed({
-            get: K,
-            set() {
-              cpWasCalled = true;
-            },
-          }),
-
-          cpWithSetter3: computed({
-            get: K,
-            set() {
-              cpWasCalled = true;
-            },
-          }),
-
-          cpWithoutSetter: computed(function() {
+      let MixinB = Mixin.create({
+        cpWithSetter2: computed({
+          get: K,
+          set() {
             cpWasCalled = true;
-          }),
-        });
+          },
+        }),
 
-        MixinA.apply(obj);
-        MixinB.apply(obj);
+        cpWithSetter3: computed({
+          get: K,
+          set() {
+            cpWasCalled = true;
+          },
+        }),
 
-        set(obj, 'cpWithSetter2', 'test');
-        assert.ok(
-          cpWasCalled,
-          'The computed property setter was called when defined with two args'
-        );
-        cpWasCalled = false;
+        cpWithoutSetter: computed(function() {
+          cpWasCalled = true;
+        }),
+      });
 
-        set(obj, 'cpWithSetter3', 'test');
-        assert.ok(
-          cpWasCalled,
-          'The computed property setter was called when defined with three args'
-        );
-        cpWasCalled = false;
+      MixinA.apply(obj);
+      MixinB.apply(obj);
 
+      set(obj, 'cpWithSetter2', 'test');
+      assert.ok(cpWasCalled, 'The computed property setter was called when defined with two args');
+      cpWasCalled = false;
+
+      set(obj, 'cpWithSetter3', 'test');
+      assert.ok(
+        cpWasCalled,
+        'The computed property setter was called when defined with three args'
+      );
+      cpWasCalled = false;
+
+      expectDeprecation(() => {
         set(obj, 'cpWithoutSetter', 'test');
-        assert.equal(
-          get(obj, 'cpWithoutSetter'),
-          'test',
-          'The default setter was called, the value is correct'
-        );
-        assert.ok(!cpWasCalled, 'The default setter was called, not the CP itself');
-      }, /The cpWithoutSetter computed property was just overriden./);
+      }, /The \[object Object\]#cpWithoutSetter computed property was just overriden./);
+
+      assert.equal(
+        get(obj, 'cpWithoutSetter'),
+        'test',
+        'The default setter was called, the value is correct'
+      );
+      assert.ok(!cpWasCalled, 'The default setter was called, not the CP itself');
     }
   }
 );

--- a/packages/@ember/-internals/metal/tests/observer_test.js
+++ b/packages/@ember/-internals/metal/tests/observer_test.js
@@ -54,9 +54,9 @@ moduleFor(
       defineProperty(
         obj,
         'foo',
-        computed(function() {
+        computed('bar', function() {
           return get(this, 'bar').toUpperCase();
-        }).property('bar')
+        })
       );
 
       get(obj, 'foo');
@@ -139,17 +139,17 @@ moduleFor(
         defineProperty(
           obj,
           'foo',
-          computed(function() {
+          computed('bar', function() {
             return get(this, 'bar').toLowerCase();
-          }).property('bar')
+          })
         );
 
         defineProperty(
           obj,
           'bar',
-          computed(function() {
+          computed('baz', function() {
             return get(this, 'baz').toUpperCase();
-          }).property('baz')
+          })
         );
 
         mixin(obj, {
@@ -205,17 +205,17 @@ moduleFor(
       defineProperty(
         obj,
         'foo',
-        computed(function() {
+        computed('bar', function() {
           return get(this, 'bar').toLowerCase();
-        }).property('bar')
+        })
       );
 
       defineProperty(
         obj,
         'bar',
-        computed(function() {
+        computed('baz', function() {
           return get(this, 'baz').toUpperCase();
-        }).property('baz')
+        })
       );
 
       mixin(obj, {
@@ -690,14 +690,14 @@ moduleFor(
       defineProperty(
         obj,
         'foo',
-        computed({
+        computed('baz', {
           get: function() {
             return get(this, 'baz');
           },
           set: function(key, value) {
             return value;
           },
-        }).property('baz')
+        })
       );
 
       let count = 0;

--- a/packages/@ember/-internals/metal/tests/performance_test.js
+++ b/packages/@ember/-internals/metal/tests/performance_test.js
@@ -30,10 +30,10 @@ moduleFor(
       defineProperty(
         obj,
         'abc',
-        computed(function(key) {
+        computed('a', 'b', 'c', function(key) {
           cpCount++;
           return 'computed ' + key;
-        }).property('a', 'b', 'c')
+        })
       );
 
       get(obj, 'abc');

--- a/packages/@ember/-internals/metal/tests/watching/is_watching_test.js
+++ b/packages/@ember/-internals/metal/tests/watching/is_watching_test.js
@@ -61,7 +61,7 @@ moduleFor(
       testObserver(
         assert,
         (obj, key, fn) => {
-          defineProperty(obj, fn, computed(function() {}).property(key));
+          defineProperty(obj, fn, computed(key, function() {}));
           get(obj, fn);
         },
         (obj, key, fn) => defineProperty(obj, fn, null)
@@ -72,7 +72,7 @@ moduleFor(
       testObserver(
         assert,
         (obj, key, fn) => {
-          defineProperty(obj, fn, computed(function() {}).property(key + '.bar'));
+          defineProperty(obj, fn, computed(key + '.bar', function() {}));
           get(obj, fn);
         },
         (obj, key, fn) => defineProperty(obj, fn, null)

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -2185,134 +2185,128 @@ Route.reopen(ActionHandler, Evented, {
 
       @property _qp
     */
-  _qp: computed({
-    get(this: Route) {
-      let combinedQueryParameterConfiguration;
+  _qp: computed(function(this: Route) {
+    let combinedQueryParameterConfiguration;
 
-      let controllerName = this.controllerName || this.routeName;
-      let owner = getOwner(this);
-      let controller = owner.lookup(`controller:${controllerName}`);
-      let queryParameterConfiguraton = get(this, 'queryParams');
-      let hasRouterDefinedQueryParams = Object.keys(queryParameterConfiguraton).length > 0;
+    let controllerName = this.controllerName || this.routeName;
+    let owner = getOwner(this);
+    let controller = owner.lookup(`controller:${controllerName}`);
+    let queryParameterConfiguraton = get(this, 'queryParams');
+    let hasRouterDefinedQueryParams = Object.keys(queryParameterConfiguraton).length > 0;
 
-      if (controller) {
-        // the developer has authored a controller class in their application for
-        // this route find its query params and normalize their object shape them
-        // merge in the query params for the route. As a mergedProperty,
-        // Route#queryParams is always at least `{}`
+    if (controller) {
+      // the developer has authored a controller class in their application for
+      // this route find its query params and normalize their object shape them
+      // merge in the query params for the route. As a mergedProperty,
+      // Route#queryParams is always at least `{}`
 
-        let controllerDefinedQueryParameterConfiguration = get(controller, 'queryParams') || {};
-        let normalizedControllerQueryParameterConfiguration = normalizeControllerQueryParams(
-          controllerDefinedQueryParameterConfiguration
-        );
-        combinedQueryParameterConfiguration = mergeEachQueryParams(
-          normalizedControllerQueryParameterConfiguration,
-          queryParameterConfiguraton
-        );
-      } else if (hasRouterDefinedQueryParams) {
-        // the developer has not defined a controller but *has* supplied route query params.
-        // Generate a class for them so we can later insert default values
-        controller = generateController(owner, controllerName);
-        combinedQueryParameterConfiguration = queryParameterConfiguraton;
+      let controllerDefinedQueryParameterConfiguration = get(controller, 'queryParams') || {};
+      let normalizedControllerQueryParameterConfiguration = normalizeControllerQueryParams(
+        controllerDefinedQueryParameterConfiguration
+      );
+      combinedQueryParameterConfiguration = mergeEachQueryParams(
+        normalizedControllerQueryParameterConfiguration,
+        queryParameterConfiguraton
+      );
+    } else if (hasRouterDefinedQueryParams) {
+      // the developer has not defined a controller but *has* supplied route query params.
+      // Generate a class for them so we can later insert default values
+      controller = generateController(owner, controllerName);
+      combinedQueryParameterConfiguration = queryParameterConfiguraton;
+    }
+
+    let qps = [];
+    let map = {};
+    let propertyNames = [];
+
+    for (let propName in combinedQueryParameterConfiguration) {
+      if (!combinedQueryParameterConfiguration.hasOwnProperty(propName)) {
+        continue;
       }
 
-      let qps = [];
-      let map = {};
-      let propertyNames = [];
-
-      for (let propName in combinedQueryParameterConfiguration) {
-        if (!combinedQueryParameterConfiguration.hasOwnProperty(propName)) {
-          continue;
-        }
-
-        // to support the dubious feature of using unknownProperty
-        // on queryParams configuration
-        if (propName === 'unknownProperty' || propName === '_super') {
-          // possible todo: issue deprecation warning?
-          continue;
-        }
-
-        let desc = combinedQueryParameterConfiguration[propName];
-        let scope = desc.scope || 'model';
-        let parts;
-
-        if (scope === 'controller') {
-          parts = [];
-        }
-
-        let urlKey = desc.as || this.serializeQueryParamKey(propName);
-        let defaultValue = get(controller, propName);
-
-        if (Array.isArray(defaultValue)) {
-          defaultValue = emberA(defaultValue.slice());
-        }
-
-        let type = desc.type || typeOf(defaultValue);
-
-        let defaultValueSerialized = this.serializeQueryParam(defaultValue, urlKey, type);
-        let scopedPropertyName = `${controllerName}:${propName}`;
-        let qp = {
-          undecoratedDefaultValue: get(controller, propName),
-          defaultValue,
-          serializedDefaultValue: defaultValueSerialized,
-          serializedValue: defaultValueSerialized,
-
-          type,
-          urlKey,
-          prop: propName,
-          scopedPropertyName,
-          controllerName,
-          route: this,
-          parts, // provided later when stashNames is called if 'model' scope
-          values: null, // provided later when setup is called. no idea why.
-          scope,
-        };
-
-        map[propName] = map[urlKey] = map[scopedPropertyName] = qp;
-        qps.push(qp);
-        propertyNames.push(propName);
+      // to support the dubious feature of using unknownProperty
+      // on queryParams configuration
+      if (propName === 'unknownProperty' || propName === '_super') {
+        // possible todo: issue deprecation warning?
+        continue;
       }
 
-      return {
-        qps,
-        map,
-        propertyNames,
-        states: {
-          /*
-            Called when a query parameter changes in the URL, this route cares
-            about that query parameter, but the route is not currently
-            in the active route hierarchy.
-          */
-          inactive: (prop: string, value: unknown) => {
-            let qp = map[prop];
-            this._qpChanged(prop, value, qp);
-          },
-          /*
-            Called when a query parameter changes in the URL, this route cares
-            about that query parameter, and the route is currently
-            in the active route hierarchy.
-          */
-          active: (prop: string, value: unknown) => {
-            let qp = map[prop];
-            this._qpChanged(prop, value, qp);
-            return this._activeQPChanged(qp, value);
-          },
-          /*
-            Called when a value of a query parameter this route handles changes in a controller
-            and the route is currently in the active route hierarchy.
-          */
-          allowOverrides: (prop: string, value: unknown) => {
-            let qp = map[prop];
-            this._qpChanged(prop, value, qp);
-            return this._updatingQPChanged(qp);
-          },
-        },
+      let desc = combinedQueryParameterConfiguration[propName];
+      let scope = desc.scope || 'model';
+      let parts;
+
+      if (scope === 'controller') {
+        parts = [];
+      }
+
+      let urlKey = desc.as || this.serializeQueryParamKey(propName);
+      let defaultValue = get(controller, propName);
+
+      if (Array.isArray(defaultValue)) {
+        defaultValue = emberA(defaultValue.slice());
+      }
+
+      let type = desc.type || typeOf(defaultValue);
+
+      let defaultValueSerialized = this.serializeQueryParam(defaultValue, urlKey, type);
+      let scopedPropertyName = `${controllerName}:${propName}`;
+      let qp = {
+        undecoratedDefaultValue: get(controller, propName),
+        defaultValue,
+        serializedDefaultValue: defaultValueSerialized,
+        serializedValue: defaultValueSerialized,
+
+        type,
+        urlKey,
+        prop: propName,
+        scopedPropertyName,
+        controllerName,
+        route: this,
+        parts, // provided later when stashNames is called if 'model' scope
+        values: null, // provided later when setup is called. no idea why.
+        scope,
       };
-    },
 
-    set(key, value) {
-      defineProperty(this, key, null, value);
-    },
+      map[propName] = map[urlKey] = map[scopedPropertyName] = qp;
+      qps.push(qp);
+      propertyNames.push(propName);
+    }
+
+    return {
+      qps,
+      map,
+      propertyNames,
+      states: {
+        /*
+          Called when a query parameter changes in the URL, this route cares
+          about that query parameter, but the route is not currently
+          in the active route hierarchy.
+        */
+        inactive: (prop: string, value: unknown) => {
+          let qp = map[prop];
+          this._qpChanged(prop, value, qp);
+        },
+        /*
+          Called when a query parameter changes in the URL, this route cares
+          about that query parameter, and the route is currently
+          in the active route hierarchy.
+        */
+        active: (prop: string, value: unknown) => {
+          let qp = map[prop];
+          this._qpChanged(prop, value, qp);
+          return this._activeQPChanged(qp, value);
+        },
+        /*
+          Called when a value of a query parameter this route handles changes in a controller
+          and the route is currently in the active route hierarchy.
+        */
+        allowOverrides: (prop: string, value: unknown) => {
+          let qp = map[prop];
+          this._qpChanged(prop, value, qp);
+          return this._updatingQPChanged(qp);
+        },
+      },
+    };
   }),
 
   /**

--- a/packages/@ember/-internals/routing/tests/system/route_test.js
+++ b/packages/@ember/-internals/routing/tests/system/route_test.js
@@ -3,6 +3,7 @@ import { runDestroy, buildOwner, moduleFor, AbstractTestCase } from 'internal-te
 import Service, { inject as injectService } from '@ember/service';
 import { Object as EmberObject } from '@ember/-internals/runtime';
 import EmberRoute from '../../lib/system/route';
+import { defineProperty } from '../../../metal';
 
 let route, routeOne, routeTwo, lookupHash;
 
@@ -53,7 +54,8 @@ moduleFor(
       let owner = buildOwner(ownerOptions);
       setOwner(route, owner);
 
-      route.set('_qp', null);
+      // Override the computed property by redefining it
+      defineProperty(route, '_qp', null, null);
 
       assert.equal(route.model({ post_id: 1 }), post);
       assert.equal(route.findModel('post', 1), post, '#findModel returns the correct post');

--- a/packages/@ember/-internals/runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/@ember/-internals/runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -48,7 +48,7 @@ moduleFor(
       object = ObservableObject.extend(Observable, {
         computed: computed(function() {
           return 'value';
-        }).volatile(),
+        }),
         method() {
           return 'value';
         },
@@ -97,7 +97,7 @@ moduleFor(
       objectA = ObservableObject.extend({
         computed: computed(function() {
           return 'value';
-        }).volatile(),
+        }),
         method() {
           return 'value';
         },
@@ -164,7 +164,7 @@ moduleFor(
         bar: ObservableObject.extend({
           baz: computed(function() {
             return 'blargh';
-          }).volatile(),
+          }),
         }).create(),
       });
 
@@ -202,7 +202,7 @@ moduleFor(
             this._computed = value;
             return this._computed;
           },
-        }).volatile(),
+        }),
 
         method(key, value) {
           if (value !== undefined) {
@@ -284,99 +284,95 @@ moduleFor(
     beforeEach() {
       lookup = context.lookup = {};
 
-      object = ObservableObject.extend({
-        computed: computed({
-          get() {
-            this.computedCalls.push('getter-called');
-            return 'computed';
-          },
-          set(key, value) {
-            this.computedCalls.push(value);
-          },
-        }).volatile(),
+      expectDeprecation(() => {
+        object = ObservableObject.extend({
+          computed: computed({
+            get() {
+              this.computedCalls.push('getter-called');
+              return 'computed';
+            },
+            set(key, value) {
+              this.computedCalls.push(value);
+            },
+          }).volatile(),
 
-        computedCached: computed({
-          get() {
-            this.computedCachedCalls.push('getter-called');
-            return 'computedCached';
-          },
-          set: function(key, value) {
-            this.computedCachedCalls.push(value);
-          },
-        }),
+          computedCached: computed({
+            get() {
+              this.computedCachedCalls.push('getter-called');
+              return 'computedCached';
+            },
+            set: function(key, value) {
+              this.computedCachedCalls.push(value);
+            },
+          }),
 
-        dependent: computed({
-          get() {
-            this.dependentCalls.push('getter-called');
-            return 'dependent';
-          },
-          set(key, value) {
-            this.dependentCalls.push(value);
-          },
-        })
-          .property('changer')
-          .volatile(),
-        dependentFront: computed('changer', {
-          get() {
-            this.dependentFrontCalls.push('getter-called');
-            return 'dependentFront';
-          },
-          set(key, value) {
-            this.dependentFrontCalls.push(value);
-          },
-        }).volatile(),
-        dependentCached: computed({
-          get() {
-            this.dependentCachedCalls.push('getter-called!');
-            return 'dependentCached';
-          },
-          set(key, value) {
-            this.dependentCachedCalls.push(value);
-          },
-        }).property('changer'),
+          dependent: computed('changer', {
+            get() {
+              this.dependentCalls.push('getter-called');
+              return 'dependent';
+            },
+            set(key, value) {
+              this.dependentCalls.push(value);
+            },
+          }).volatile(),
+          dependentFront: computed('changer', {
+            get() {
+              this.dependentFrontCalls.push('getter-called');
+              return 'dependentFront';
+            },
+            set(key, value) {
+              this.dependentFrontCalls.push(value);
+            },
+          }).volatile(),
+          dependentCached: computed('changer', {
+            get() {
+              this.dependentCachedCalls.push('getter-called!');
+              return 'dependentCached';
+            },
+            set(key, value) {
+              this.dependentCachedCalls.push(value);
+            },
+          }),
 
-        inc: computed('changer', function() {
-          return this.incCallCount++;
-        }),
+          inc: computed('changer', function() {
+            return this.incCallCount++;
+          }),
 
-        nestedInc: computed(function() {
-          get(this, 'inc');
-          return this.nestedIncCallCount++;
-        }).property('inc'),
+          nestedInc: computed('inc', function() {
+            get(this, 'inc');
+            return this.nestedIncCallCount++;
+          }),
 
-        isOn: computed({
-          get() {
-            return this.get('state') === 'on';
-          },
-          set() {
-            this.set('state', 'on');
-            return this.get('state') === 'on';
-          },
-        })
-          .property('state')
-          .volatile(),
+          isOn: computed('state', {
+            get() {
+              return this.get('state') === 'on';
+            },
+            set() {
+              this.set('state', 'on');
+              return this.get('state') === 'on';
+            },
+          }).volatile(),
 
-        isOff: computed({
-          get() {
-            return this.get('state') === 'off';
-          },
-          set() {
-            this.set('state', 'off');
-            return this.get('state') === 'off';
-          },
-        })
-          .property('state')
-          .volatile(),
-      }).create({
-        computedCalls: [],
-        computedCachedCalls: [],
-        changer: 'foo',
-        dependentCalls: [],
-        dependentFrontCalls: [],
-        dependentCachedCalls: [],
-        incCallCount: 0,
-        nestedIncCallCount: 0,
-        state: 'on',
+          isOff: computed('state', {
+            get() {
+              return this.get('state') === 'off';
+            },
+            set() {
+              this.set('state', 'off');
+              return this.get('state') === 'off';
+            },
+          }).volatile(),
+        }).create({
+          computedCalls: [],
+          computedCachedCalls: [],
+          changer: 'foo',
+          dependentCalls: [],
+          dependentFrontCalls: [],
+          dependentCachedCalls: [],
+          incCallCount: 0,
+          nestedIncCallCount: 0,
+          state: 'on',
+        });
       });
     }
     afterEach() {
@@ -542,9 +538,9 @@ moduleFor(
 
     ['@test dependent keys should be able to be specified as property paths'](assert) {
       var depObj = ObservableObject.extend({
-        menuPrice: computed(function() {
+        menuPrice: computed('menu.price', function() {
           return this.get('menu.price');
-        }).property('menu.price'),
+        }),
       }).create({
         menu: ObservableObject.create({
           price: 5,

--- a/packages/@ember/-internals/runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
+++ b/packages/@ember/-internals/runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
@@ -112,8 +112,10 @@ moduleFor(
     ['@test should invalidate function property cache when notifyPropertyChange is called'](
       assert
     ) {
+      let a;
+
       expectDeprecation(() => {
-        let a = ObservableObject.extend({
+        a = ObservableObject.extend({
           b: computed({
             get() {
               return this._b;
@@ -126,19 +128,19 @@ moduleFor(
         }).create({
           _b: null,
         });
-
-        a.set('b', 'foo');
-        assert.equal(a.get('b'), 'foo', 'should have set the correct value for property b');
-
-        a._b = 'bar';
-        a.notifyPropertyChange('b');
-        a.set('b', 'foo');
-        assert.equal(
-          a.get('b'),
-          'foo',
-          'should have invalidated the cache so that the newly set value is actually set'
-        );
       }, /Setting a computed property as volatile has been deprecated/);
+
+      a.set('b', 'foo');
+      assert.equal(a.get('b'), 'foo', 'should have set the correct value for property b');
+
+      a._b = 'bar';
+      a.notifyPropertyChange('b');
+      a.set('b', 'foo');
+      assert.equal(
+        a.get('b'),
+        'foo',
+        'should have invalidated the cache so that the newly set value is actually set'
+      );
     }
   }
 );

--- a/packages/@ember/-internals/runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
+++ b/packages/@ember/-internals/runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
@@ -112,31 +112,33 @@ moduleFor(
     ['@test should invalidate function property cache when notifyPropertyChange is called'](
       assert
     ) {
-      let a = ObservableObject.extend({
-        b: computed({
-          get() {
-            return this._b;
-          },
-          set(key, value) {
-            this._b = value;
-            return this;
-          },
-        }).volatile(),
-      }).create({
-        _b: null,
-      });
+      expectDeprecation(() => {
+        let a = ObservableObject.extend({
+          b: computed({
+            get() {
+              return this._b;
+            },
+            set(key, value) {
+              this._b = value;
+              return this;
+            },
+          }).volatile(),
+        }).create({
+          _b: null,
+        });
 
-      a.set('b', 'foo');
-      assert.equal(a.get('b'), 'foo', 'should have set the correct value for property b');
+        a.set('b', 'foo');
+        assert.equal(a.get('b'), 'foo', 'should have set the correct value for property b');
 
-      a._b = 'bar';
-      a.notifyPropertyChange('b');
-      a.set('b', 'foo');
-      assert.equal(
-        a.get('b'),
-        'foo',
-        'should have invalidated the cache so that the newly set value is actually set'
-      );
+        a._b = 'bar';
+        a.notifyPropertyChange('b');
+        a.set('b', 'foo');
+        assert.equal(
+          a.get('b'),
+          'foo',
+          'should have invalidated the cache so that the newly set value is actually set'
+        );
+      }, /Setting a computed property as volatile has been deprecated/);
     }
   }
 );

--- a/packages/@ember/-internals/runtime/tests/system/array_proxy/arranged_content_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/array_proxy/arranged_content_test.js
@@ -146,7 +146,7 @@ moduleFor(
     beforeEach() {
       run(function() {
         array = ArrayProxy.extend({
-          arrangedContent: computed(function() {
+          arrangedContent: computed('content.[]', function() {
             let content = this.get('content');
             return (
               content &&
@@ -162,7 +162,7 @@ moduleFor(
                 })
               )
             );
-          }).property('content.[]'),
+          }),
 
           objectAtContent(idx) {
             let obj = objectAt(this.get('arrangedContent'), idx);

--- a/packages/@ember/-internals/runtime/tests/system/object/computed_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/computed_test.js
@@ -358,21 +358,23 @@ moduleFor(
     }
 
     ['@test can declare dependent keys with .property()'](assert) {
+      let Obj;
+
       expectDeprecation(() => {
-        let Obj = EmberObject.extend({
+        Obj = EmberObject.extend({
           foo: computed(function() {
             return this.bar;
           }).property('bar'),
         });
-
-        let obj = Obj.create({ bar: 1 });
-
-        assert.equal(obj.get('foo'), 1);
-
-        obj.set('bar', 2);
-
-        assert.equal(obj.get('foo'), 2);
       }, /Setting dependency keys using the `.property\(\)` modifier has been deprecated/);
+
+      let obj = Obj.create({ bar: 1 });
+
+      assert.equal(obj.get('foo'), 1);
+
+      obj.set('bar', 2);
+
+      assert.equal(obj.get('foo'), 2);
     }
   }
 );

--- a/packages/@ember/-internals/runtime/tests/system/object/computed_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/computed_test.js
@@ -73,10 +73,10 @@ moduleFor(
 
         count: 0,
 
-        foo: computed(function() {
+        foo: computed('bar.baz', function() {
           set(this, 'count', get(this, 'count') + 1);
           return get(get(this, 'bar'), 'baz') + ' ' + get(this, 'count');
-        }).property('bar.baz'),
+        }),
       });
 
       let Subclass = MyClass.extend({
@@ -109,10 +109,10 @@ moduleFor(
 
         count: 0,
 
-        foo: computed(function() {
+        foo: computed('bar.baz', function() {
           set(this, 'count', get(this, 'count') + 1);
           return get(get(this, 'bar'), 'baz') + ' ' + get(this, 'count');
-        }).property('bar.baz'),
+        }),
       });
 
       let Subclass = MyClass.extend({
@@ -123,10 +123,10 @@ moduleFor(
 
         count: 0,
 
-        foo: computed(function() {
+        foo: computed('bar2.baz', function() {
           set(this, 'count', get(this, 'count') + 1);
           return get(get(this, 'bar2'), 'baz') + ' ' + get(this, 'count');
-        }).property('bar2.baz'),
+        }),
       });
 
       let obj2 = Subclass.create();
@@ -152,7 +152,7 @@ moduleFor(
       );
 
       let ClassWithNoMetadata = EmberObject.extend({
-        computedProperty: computed(function() {}).volatile(),
+        computedProperty: computed(function() {}),
 
         staticProperty: 12,
       });
@@ -355,6 +355,24 @@ moduleFor(
 
       assert.equal(obj1.get('name'), '1');
       assert.equal(obj2.get('name'), '2');
+    }
+
+    ['@test can declare dependent keys with .property()'](assert) {
+      expectDeprecation(() => {
+        let Obj = EmberObject.extend({
+          foo: computed(function() {
+            return this.bar;
+          }).property('bar'),
+        });
+
+        let obj = Obj.create({ bar: 1 });
+
+        assert.equal(obj.get('foo'), 1);
+
+        obj.set('bar', 2);
+
+        assert.equal(obj.get('foo'), 2);
+      }, /Setting dependency keys using the `.property\(\)` modifier has been deprecated/);
     }
   }
 );

--- a/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
@@ -180,7 +180,7 @@ moduleFor(
       let last;
 
       let Proxy = ObjectProxy.extend({
-        fullName: computed(function() {
+        fullName: computed('firstName', 'lastName', function() {
           let firstName = this.get('firstName');
           let lastName = this.get('lastName');
 
@@ -188,7 +188,7 @@ moduleFor(
             return firstName + ' ' + lastName;
           }
           return firstName || lastName;
-        }).property('firstName', 'lastName'),
+        }),
       });
 
       let proxy = Proxy.create();


### PR DESCRIPTION
- Deprecates `.property()`
- Deprecates `.volatile()`
- Deprecates `clobberSet` internally
- Keeps injected properties and the `store` property on routes
  overridable for testing purposes
- Rewrites lots of usages in tests. For some reason `volatile` was
  frequently used in tests when it was not needed.
- Adds `additionalDependentKeys` array to `map`, `filter` and `sort`
  array functions. `sort` was overlooked in RFC, but suffers from the
  same problem so it shouldn't need an additional RFC.
- Adds tests for `additionalDependentKeys`