### PR TITLE
Restore fallback for `window.performance` in FastBoot

### DIFF
--- a/packages/@ember/instrumentation/index.ts
+++ b/packages/@ember/instrumentation/index.ts
@@ -105,7 +105,7 @@ function populateListeners(name: string) {
 }
 
 const time = ((): (() => number) => {
-  let perf: MaybePerf = 'undefined' !== typeof window ? window.performance : {};
+  let perf: MaybePerf = 'undefined' !== typeof window ? window.performance || {} : {};
   let fn = perf.now || perf.mozNow || perf.webkitNow || perf.msNow || perf.oNow;
 
   return fn ? fn.bind(perf) : Date.now;

--- a/tests/node/instrumentation-test.js
+++ b/tests/node/instrumentation-test.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var path = require('path');
+var distPath = path.join(__dirname, '../../dist');
+var emberPath = path.join(distPath, 'ember.debug');
+
+QUnit.module('instrumentation', function(hooks) {
+  hooks.afterEach(function() {
+    delete global.Ember;
+    delete require.cache[emberPath + '.js'];
+  });
+
+  QUnit.test('it works in FastBoot environment', function(assert) {
+    var _originalWindow = global.window;
+
+    global.window = {}; // mock window without `performance` property
+    var Ember = require(emberPath);
+
+    var result = Ember.instrument('render', {}, function() {
+      return 'hello';
+    });
+
+    assert.equal(result, 'hello', 'called block');
+
+    global.window = _originalWindow;
+  });
+});


### PR DESCRIPTION
This fallback was accidentally removed in #17456 (the issue appeared here 
https://github.com/ember-fastboot/ember-cli-fastboot/issues/596#issuecomment-453771176).