### PR TITLE
Add (failing) tests for positional params with custom component managers

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
@@ -305,6 +305,58 @@ if (GLIMMER_CUSTOM_COMPONENT_MANAGER) {
         this.assertHTML(`<p>Chad Hietala</p>`);
       }
 
+      ['@test it can set positional params on the component instance']() {
+        let ComponentClass = setComponentManager(
+          createBasicManager,
+          EmberObject.extend({
+            salutation: computed('args.positional', function() {
+              return this.args.positional[0] + ' ' + this.args.positional[1];
+            }),
+          })
+        );
+
+        this.registerComponent('foo-bar', {
+          template: `<p>{{salutation}}</p>`,
+          ComponentClass,
+        });
+
+        this.render('{{foo-bar "Yehuda" "Katz"}}');
+
+        this.assertHTML(`<p>Yehuda Katz</p>`);
+      }
+
+      ['@test positional params are updated if they change']() {
+        let ComponentClass = setComponentManager(
+          createBasicManager,
+          EmberObject.extend({
+            salutation: computed('args.positional', function() {
+              return this.args.positional[0] + ' ' + this.args.positional[1];
+            }),
+          })
+        );
+
+        this.registerComponent('foo-bar', {
+          template: `<p>{{salutation}}</p>`,
+          ComponentClass,
+        });
+
+        this.render('{{foo-bar firstName lastName}}', {
+          firstName: 'Yehuda',
+          lastName: 'Katz',
+        });
+
+        this.assertHTML(`<p>Yehuda Katz</p>`);
+
+        runTask(() =>
+          setProperties(this.context, {
+            firstName: 'Chad',
+            lastName: 'Hietala',
+          })
+        );
+
+        this.assertHTML(`<p>Chad Hietala</p>`);
+      }
+
       ['@test it can opt-in to running destructor'](assert) {
         let ComponentClass = setComponentManager(
           () => {


### PR DESCRIPTION
@rwjblue has opened https://github.com/glimmerjs/glimmer-vm/pull/900 to fix the underlying issue with positional parameters for custom component managers, but suggested it would be helpful to have test coverage on the Ember side as well.

The tests here are pretty straightforward conversions of the two above them that test named args. I've confirmed that these pass when I apply the change from that PR to `opcode-builder` locally.