### PR TITLE
Simplify prod tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -280,7 +280,7 @@ Note: before using this approach, please be certain your test is really dependin
 
 To recreate this build environment locally:
 * Run `ember serve --environment=production` in a terminal (takes much much longer than a default `ember s`)
-* Browse to `localhost:4200/tests/index.html?skipPackage=container,ember-testing,@ember/debug&dist=prod&prod=true`
+* Browse to `localhost:4200/tests/index.html?dist=prod&prod=true`
 
 ### Single Unexplained Test Suite Failure
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -132,9 +132,9 @@ end
     1. Any feature that has been GOed gets changed to true
 1. Run `ember s -prod`
 1. Run tests at `http://localhost:4200/tests/index.html`
-1. Run production tests `http://localhost:4200/tests/index.html?skipPackage=container,ember-testing,@ember/debug&dist=prod&prod=true`
-1. In `.travis.yml`, remove `branches:` section e.g. [this commit](https://github.com/emberjs/ember.js/commit/e38ec5d910721a9e02a819b4105a4875723f4b1b).
-1. Now we have to look at the commit just prior to branching 2.4.0.beta-1. Then find the commit after that to start the new branch at.
+2. Run production tests `http://localhost:4200/tests/index.html?dist=prod&prod=true`
+3. In `.travis.yml`, remove `branches:` section e.g. [this commit](https://github.com/emberjs/ember.js/commit/e38ec5d910721a9e02a819b4105a4875723f4b1b).
+4. Now we have to look at the commit just prior to branching 2.4.0.beta-1. Then find the commit after that to start the new branch at.
 
 ### Changelog
 

--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -74,20 +74,14 @@ function generateEachPackageTests() {
 }
 
 function generateBuiltTests() {
-  // Container isn't publicly available.
-  // ember-testing and @ember/debug are stripped from prod/min.
-  var common = 'skipPackage=container,ember-testing,@ember/debug';
-
-  testFunctions.push(() => run(common));
-  testFunctions.push(() => run(common + '&dist=min&prod=true'));
-  testFunctions.push(() => run(common + '&dist=prod&prod=true'));
-  testFunctions.push(() => run(common + '&enableoptionalfeatures=true&dist=prod&prod=true'));
-  testFunctions.push(() => run(common + '&legacy=true'));
-  testFunctions.push(() => run(common + '&legacy=true&dist=min&prod=true'));
-  testFunctions.push(() => run(common + '&legacy=true&dist=prod&prod=true'));
-  testFunctions.push(() =>
-    run(common + '&legacy=true&enableoptionalfeatures=true&dist=prod&prod=true')
-  );
+  testFunctions.push(() => run(''));
+  testFunctions.push(() => run('dist=min&prod=true'));
+  testFunctions.push(() => run('dist=prod&prod=true'));
+  testFunctions.push(() => run('enableoptionalfeatures=true&dist=prod&prod=true'));
+  testFunctions.push(() => run('legacy=true'));
+  testFunctions.push(() => run('legacy=true&dist=min&prod=true'));
+  testFunctions.push(() => run('legacy=true&dist=prod&prod=true'));
+  testFunctions.push(() => run('legacy=true&enableoptionalfeatures=true&dist=prod&prod=true'));
 }
 
 function generateOldJQueryTests() {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -247,6 +247,7 @@ function buildBundles(packagesES, dependenciesES, templateCompilerDependenciesES
           '*/tests/**' /* packages */,
           'license.js',
         ],
+        exclude: ['@ember/debug/tests/**', 'ember-testing/tests/**'],
       }),
       bootstrapModule('empty'),
     ]);


### PR DESCRIPTION
* container tests pass in prod build now
* omit ember-testing and @ember/debug tests from ember-tests.prod.js