### PR TITLE
Add deprecation for Ember.$()

### DIFF
--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -561,7 +561,18 @@ Ember.VERSION = VERSION;
 
 // ****@ember/-internals/views****
 if (!views.jQueryDisabled) {
-  Ember.$ = views.jQuery;
+  Ember.$ = function() {
+    deprecate(
+      "Using Ember.$() has been deprecated, use `import jQuery from 'jquery';` instead",
+      false,
+      {
+        id: 'ember-views.curly-components.jquery-element',
+        until: '4.0.0',
+        url: 'https://emberjs.com/deprecations/v3.x#toc_jquery-apis',
+      }
+    );
+    return views.jQuery.apply(this, arguments);
+  };
 }
 Ember.ViewUtils = {
   isSimpleClick: views.isSimpleClick,

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -52,6 +52,21 @@ moduleFor(
   }
 );
 
+if (!jQueryDisabled) {
+  moduleFor(
+    'ember reexports: jQuery enabled',
+    class extends AbstractTestCase {
+      [`@test Ember.$ is exported`](assert) {
+        assert.ok(Ember.$, 'Ember.$ export exists');
+        expectDeprecation(() => {
+          let body = Ember.$('body').get(0);
+          assert.equal(body, document.body, 'Ember.$ exports working jQuery instance');
+        }, "Using Ember.$() has been deprecated, use `import jQuery from 'jquery';` instead");
+      }
+    }
+  );
+}
+
 let allExports = [
   // @ember/-internals/environment
   ['ENV', '@ember/-internals/environment', { get: 'getENV' }],
@@ -170,7 +185,6 @@ let allExports = [
   ['Logger', '@ember/-internals/console', 'default'],
 
   // @ember/-internals/views
-  !jQueryDisabled && ['$', '@ember/-internals/views', 'jQuery'],
   ['ViewUtils.isSimpleClick', '@ember/-internals/views', 'isSimpleClick'],
   ['ViewUtils.getViewElement', '@ember/-internals/views', 'getViewElement'],
   ['ViewUtils.getViewBounds', '@ember/-internals/views', 'getViewBounds'],


### PR DESCRIPTION
Deprecated as per [RFC386](https://github.com/emberjs/rfcs/blob/master/text/0386-remove-jquery.md#how-we-teach-this).