### PR TITLE
fix: docs should not use undocumented property

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -1861,16 +1861,19 @@ EmberRouter.reopen(Evented, {
     ```javascript
     import config from './config/environment';
     import EmberRouter from '@ember/routing/router';
+    import { inject as service } from '@ember/service';
 
     let Router = EmberRouter.extend({
       location: config.locationType,
 
+      router: service(),
+
       didTransition: function() {
         this._super(...arguments);
 
-        return ga('send', 'pageview', {
-          'page': this.get('url'),
-          'title': this.get('url')
+        ga('send', 'pageview', {
+          page: this.router.currentURL,
+          title: this.router.currentRouteName,
         });
       }
     });


### PR DESCRIPTION
`url` property of EmberRouter is not documented. I'm not even sure if it was ever documented. Checked API docs for some version (2.18, 2.12, 2.4, 1.13) and didn't found it in there docs either.

Refactored the example given in `didTransition()` method therefore. Since user tracking is a good example, I kept it but refactored it to use public router service.

Also removed the usage of `.get()`, which is not needed anymore for recent versions of Ember.