### PR TITLE
Ensure Ember.$.ajax works properly.

### DIFF
--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -561,19 +561,26 @@ Ember.VERSION = VERSION;
 
 // ****@ember/-internals/views****
 if (!views.jQueryDisabled) {
-  Ember.$ = function() {
-    deprecate(
-      "Using Ember.$() has been deprecated, use `import jQuery from 'jquery';` instead",
-      false,
-      {
-        id: 'ember-views.curly-components.jquery-element',
-        until: '4.0.0',
-        url: 'https://emberjs.com/deprecations/v3.x#toc_jquery-apis',
-      }
-    );
-    return views.jQuery.apply(this, arguments);
-  };
+  Object.defineProperty(Ember, '$', {
+    get() {
+      deprecate(
+        "Using Ember.$() has been deprecated, use `import jQuery from 'jquery';` instead",
+        false,
+        {
+          id: 'ember-views.curly-components.jquery-element',
+          until: '4.0.0',
+          url: 'https://emberjs.com/deprecations/v3.x#toc_jquery-apis',
+        }
+      );
+
+      return views.jQuery;
+    },
+
+    configurable: true,
+    enumerable: true,
+  });
 }
+
 Ember.ViewUtils = {
   isSimpleClick: views.isSimpleClick,
   getViewElement: views.getViewElement,

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -2,7 +2,7 @@ import Ember from '../index';
 import { FEATURES } from '@ember/canary-features';
 import { confirmExport } from 'internal-test-helpers';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
-import { jQueryDisabled } from '@ember/-internals/views';
+import { jQueryDisabled, jQuery } from '@ember/-internals/views';
 
 moduleFor(
   'ember reexports',
@@ -57,10 +57,15 @@ if (!jQueryDisabled) {
     'ember reexports: jQuery enabled',
     class extends AbstractTestCase {
       [`@test Ember.$ is exported`](assert) {
-        assert.ok(Ember.$, 'Ember.$ export exists');
         expectDeprecation(() => {
           let body = Ember.$('body').get(0);
           assert.equal(body, document.body, 'Ember.$ exports working jQuery instance');
+        }, "Using Ember.$() has been deprecated, use `import jQuery from 'jquery';` instead");
+      }
+
+      '@test Ember.$ _**is**_ window.jQuery'(assert) {
+        expectDeprecation(() => {
+          assert.strictEqual(Ember.$, jQuery);
         }, "Using Ember.$() has been deprecated, use `import jQuery from 'jquery';` instead");
       }
     }


### PR DESCRIPTION
The recent `Ember.$` deprecation accidentally introduced a regression when using `Ember.$` as _if_ it were the global `jQuery` object. The specific scenario that this cropped up in was an application calling `Ember.$.ajax`.