### PR TITLE
[DEPRECATE] Deprecates aliasMethod

### DIFF
--- a/packages/@ember/-internals/metal/lib/mixin.ts
+++ b/packages/@ember/-internals/metal/lib/mixin.ts
@@ -13,6 +13,7 @@ import {
   wrap,
 } from '@ember/-internals/utils';
 import { assert, deprecate } from '@ember/debug';
+import { ALIAS_METHOD } from '@ember/deprecated-features';
 import { assign } from '@ember/polyfills';
 import { DEBUG } from '@glimmer/env';
 import { ComputedProperty, ComputedPropertyGetter, ComputedPropertySetter } from './computed';
@@ -301,28 +302,37 @@ function mergeMixins(
   }
 }
 
-function followMethodAlias(
+let followMethodAlias: (
   obj: object,
   alias: Alias,
   descs: { [key: string]: any },
   values: { [key: string]: any }
-) {
-  let altKey = alias.methodName;
-  let possibleDesc;
-  let desc = descs[altKey];
-  let value = values[altKey];
+) => { desc: any; value: any };
 
-  if (desc !== undefined || value !== undefined) {
-    // do nothing
-  } else if ((possibleDesc = descriptorFor(obj, altKey)) !== undefined) {
-    desc = possibleDesc;
-    value = undefined;
-  } else {
-    desc = undefined;
-    value = obj[altKey];
-  }
+if (ALIAS_METHOD) {
+  followMethodAlias = function(
+    obj: object,
+    alias: Alias,
+    descs: { [key: string]: any },
+    values: { [key: string]: any }
+  ) {
+    let altKey = alias.methodName;
+    let possibleDesc;
+    let desc = descs[altKey];
+    let value = values[altKey];
 
-  return { desc, value };
+    if (desc !== undefined || value !== undefined) {
+      // do nothing
+    } else if ((possibleDesc = descriptorFor(obj, altKey)) !== undefined) {
+      desc = possibleDesc;
+      value = undefined;
+    } else {
+      desc = undefined;
+      value = obj[altKey];
+    }
+
+    return { desc, value };
+  };
 }
 
 function updateObserversAndListeners(
@@ -387,10 +397,12 @@ export function applyMixin(obj: { [key: string]: any }, mixins: Mixin[]) {
     desc = descs[key];
     value = values[key];
 
-    while (value && value instanceof Alias) {
-      let followed = followMethodAlias(obj, value, descs, values);
-      desc = followed.desc;
-      value = followed.value;
+    if (ALIAS_METHOD) {
+      while (value && value instanceof AliasImpl) {
+        let followed = followMethodAlias(obj, value, descs, values);
+        desc = followed.desc;
+        value = followed.value;
+      }
     }
 
     if (desc === undefined && value === undefined) {
@@ -703,8 +715,17 @@ function _keys(mixin: Mixin, ret = new Set(), seen = new Set()) {
   return ret;
 }
 
-class Alias {
-  constructor(public methodName: string) {}
+declare class Alias {
+  public methodName: string;
+  constructor(methodName: string);
+}
+
+let AliasImpl: typeof Alias;
+
+if (ALIAS_METHOD) {
+  AliasImpl = class AliasImpl {
+    constructor(public methodName: string) {}
+  } as typeof Alias;
 }
 
 /**
@@ -737,17 +758,21 @@ class Alias {
   @param {String} methodName name of the method to alias
   @public
 */
-export function aliasMethod(methodName: string): Alias {
-  deprecate(
-    `You attempted to alias '${methodName}, but aliasMethod has been deprecated. Consider extracting the method into a shared utility function.`,
-    false,
-    {
-      id: 'object.alias-method',
-      until: '4.0.0',
-      url: 'https://emberjs.com/deprecations/v3.x#toc_object-alias-method',
-    }
-  );
-  return new Alias(methodName);
+export let aliasMethod: (methodName: string) => any;
+
+if (ALIAS_METHOD) {
+  aliasMethod = function aliasMethod(methodName: string): Alias {
+    deprecate(
+      `You attempted to alias '${methodName}, but aliasMethod has been deprecated. Consider extracting the method into a shared utility function.`,
+      false,
+      {
+        id: 'object.alias-method',
+        until: '4.0.0',
+        url: 'https://emberjs.com/deprecations/v3.x#toc_object-alias-method',
+      }
+    );
+    return new AliasImpl(methodName);
+  };
 }
 
 // ..........................................................

--- a/packages/@ember/-internals/metal/tests/mixin/alias_method_test.js
+++ b/packages/@ember/-internals/metal/tests/mixin/alias_method_test.js
@@ -10,82 +10,92 @@ moduleFor(
   'aliasMethod',
   class extends AbstractTestCase {
     ['@test methods of another name are aliased when the mixin is applied'](assert) {
-      let MyMixin = Mixin.create({
-        fooMethod() {
-          return 'FOO';
-        },
-        barMethod: aliasMethod('fooMethod'),
-      });
+      expectDeprecation(() => {
+        let MyMixin = Mixin.create({
+          fooMethod() {
+            return 'FOO';
+          },
+          barMethod: aliasMethod('fooMethod'),
+        });
 
-      let obj = MyMixin.apply({});
-      validateAliasMethod(assert, obj);
+        let obj = MyMixin.apply({});
+        validateAliasMethod(assert, obj);
+      }, /aliasMethod has been deprecated. Consider extracting the method into a shared utility function/);
     }
 
     ['@test should follow aliasMethods all the way down'](assert) {
-      let MyMixin = Mixin.create({
-        bar: aliasMethod('foo'), // put first to break ordered iteration
-        baz() {
-          return 'baz';
-        },
-        foo: aliasMethod('baz'),
-      });
+      expectDeprecation(() => {
+        let MyMixin = Mixin.create({
+          bar: aliasMethod('foo'), // put first to break ordered iteration
+          baz() {
+            return 'baz';
+          },
+          foo: aliasMethod('baz'),
+        });
 
-      let obj = MyMixin.apply({});
-      assert.equal(get(obj, 'bar')(), 'baz', 'should have followed aliasMethods');
+        let obj = MyMixin.apply({});
+        assert.equal(get(obj, 'bar')(), 'baz', 'should have followed aliasMethods');
+      }, /aliasMethod has been deprecated. Consider extracting the method into a shared utility function/);
     }
 
     ['@test should alias methods from other dependent mixins'](assert) {
-      let BaseMixin = Mixin.create({
-        fooMethod() {
-          return 'FOO';
-        },
-      });
+      expectDeprecation(() => {
+        let BaseMixin = Mixin.create({
+          fooMethod() {
+            return 'FOO';
+          },
+        });
 
-      let MyMixin = Mixin.create(BaseMixin, {
-        barMethod: aliasMethod('fooMethod'),
-      });
+        let MyMixin = Mixin.create(BaseMixin, {
+          barMethod: aliasMethod('fooMethod'),
+        });
 
-      let obj = MyMixin.apply({});
-      validateAliasMethod(assert, obj);
+        let obj = MyMixin.apply({});
+        validateAliasMethod(assert, obj);
+      }, /aliasMethod has been deprecated. Consider extracting the method into a shared utility function/);
     }
 
     ['@test should alias methods from other mixins applied at same time'](assert) {
-      let BaseMixin = Mixin.create({
-        fooMethod() {
-          return 'FOO';
-        },
-      });
+      expectDeprecation(() => {
+        let BaseMixin = Mixin.create({
+          fooMethod() {
+            return 'FOO';
+          },
+        });
 
-      let MyMixin = Mixin.create({
-        barMethod: aliasMethod('fooMethod'),
-      });
+        let MyMixin = Mixin.create({
+          barMethod: aliasMethod('fooMethod'),
+        });
 
-      let obj = mixin({}, BaseMixin, MyMixin);
-      validateAliasMethod(assert, obj);
+        let obj = mixin({}, BaseMixin, MyMixin);
+        validateAliasMethod(assert, obj);
+      }, /aliasMethod has been deprecated. Consider extracting the method into a shared utility function/);
     }
 
     ['@test should alias methods from mixins already applied on object'](assert) {
-      let BaseMixin = Mixin.create({
-        quxMethod() {
-          return 'qux';
-        },
-      });
+      expectDeprecation(() => {
+        let BaseMixin = Mixin.create({
+          quxMethod() {
+            return 'qux';
+          },
+        });
 
-      let MyMixin = Mixin.create({
-        bar: aliasMethod('foo'),
-        barMethod: aliasMethod('fooMethod'),
-      });
+        let MyMixin = Mixin.create({
+          bar: aliasMethod('foo'),
+          barMethod: aliasMethod('fooMethod'),
+        });
 
-      let obj = {
-        fooMethod() {
-          return 'FOO';
-        },
-      };
+        let obj = {
+          fooMethod() {
+            return 'FOO';
+          },
+        };
 
-      BaseMixin.apply(obj);
-      MyMixin.apply(obj);
+        BaseMixin.apply(obj);
+        MyMixin.apply(obj);
 
-      validateAliasMethod(assert, obj);
+        validateAliasMethod(assert, obj);
+      }, /aliasMethod has been deprecated. Consider extracting the method into a shared utility function/);
     }
   }
 );

--- a/packages/@ember/-internals/runtime/lib/mixins/array.js
+++ b/packages/@ember/-internals/runtime/lib/mixins/array.js
@@ -11,7 +11,6 @@ import {
   replaceInNativeArray,
   replace,
   computed,
-  aliasMethod,
   Mixin,
   hasListeners,
   beginPropertyChanges,
@@ -178,6 +177,10 @@ function nonEnumerableComputed() {
   let property = computed(...arguments);
   property.enumerable = false;
   return property;
+}
+
+function mapBy(key) {
+  return this.map(next => get(next, key));
 }
 
 // ..........................................................
@@ -572,7 +575,7 @@ const ArrayMixin = Mixin.create(Enumerable, {
     @return {Array} The mapped array.
     @public
   */
-  getEach: aliasMethod('mapBy'),
+  getEach: mapBy,
 
   /**
     Sets the value on the named property for each member. This is more
@@ -636,9 +639,7 @@ const ArrayMixin = Mixin.create(Enumerable, {
     @return {Array} The mapped array.
     @public
   */
-  mapBy(key) {
-    return this.map(next => get(next, key));
-  },
+  mapBy,
 
   /**
     Returns an array with all of the items in the enumeration that the passed

--- a/packages/@ember/deprecated-features/index.ts
+++ b/packages/@ember/deprecated-features/index.ts
@@ -10,3 +10,4 @@ export const ROUTER_EVENTS = !!'3.9.0';
 export const TRANSITION_STATE = !!'3.9.0';
 export const COMPONENT_MANAGER_STRING_LOOKUP = !!'4.0.0';
 export const JQUERY_INTEGRATION = !!'3.9.0';
+export const ALIAS_METHOD = !!'4.0.0';

--- a/packages/@ember/deprecated-features/index.ts
+++ b/packages/@ember/deprecated-features/index.ts
@@ -1,5 +1,8 @@
 /* eslint-disable no-implicit-coercion */
 
+// These versions should be the version that the deprecation was _introduced_,
+// not the version that the feature will be removed.
+
 export const SEND_ACTION = !!'3.4.0';
 export const EMBER_EXTEND_PROTOTYPES = !!'3.2.0-beta.5';
 export const RUN_SYNC = !!'3.0.0-beta.4';
@@ -10,4 +13,4 @@ export const ROUTER_EVENTS = !!'3.9.0';
 export const TRANSITION_STATE = !!'3.9.0';
 export const COMPONENT_MANAGER_STRING_LOOKUP = !!'4.0.0';
 export const JQUERY_INTEGRATION = !!'3.9.0';
-export const ALIAS_METHOD = !!'4.0.0';
+export const ALIAS_METHOD = !!'3.9.0';


### PR DESCRIPTION
Deprecates the aliasMethod descriptor, and refactors it to not
use the Descriptor system internall