### PR TITLE
[BUGFIX lts] support numbers in component names for Angle Brackets

### DIFF
--- a/packages/ember-template-compiler/lib/system/dasherize-component-name.ts
+++ b/packages/ember-template-compiler/lib/system/dasherize-component-name.ts
@@ -5,7 +5,7 @@ import { Cache } from '@ember/-internals/utils';
   `Ember.String.dasherize` would resolve it to `xfoo`..
 */
 const SIMPLE_DASHERIZE_REGEXP = /[A-Z]/g;
-const ALPHA = /[A-Za-z]/;
+const ALPHA = /[A-Za-z0-9]/;
 export default new Cache<string, string>(1000, key =>
   key.replace(SIMPLE_DASHERIZE_REGEXP, (char, index) => {
     if (index === 0 || !ALPHA.test(key[index - 1])) {

--- a/packages/ember-template-compiler/tests/system/dasherize-component-name-test.js
+++ b/packages/ember-template-compiler/tests/system/dasherize-component-name-test.js
@@ -8,6 +8,10 @@ moduleFor(
       assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('Foo'), 'foo');
       assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('foo-bar'), 'foo-bar');
       assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('FooBar'), 'foo-bar');
+      assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('F3Bar'), 'f3-bar');
+      assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('Foo3Bar'), 'foo3-bar');
+      assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('Foo3barBaz'), 'foo3bar-baz');
+      assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('FooB3ar'), 'foo-b3ar');
       assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('XBlah'), 'x-blah');
       assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('X-Blah'), 'x-blah');
       assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('Foo::BarBaz'), 'foo::bar-baz');


### PR DESCRIPTION
Previously, a component named `c3-plot` would not work when invoked as `<C3Plot />`.
Now it will resolve correctly.

Closes #17549

Behavior:

```
'F3Bar' => 'f3-bar'
'Foo3Bar' => 'foo3-bar'
'Foo3barBaz' => 'foo3bar-baz'
'FooB3ar' => 'foo-b3ar'
```

Notably it does not support `Foo2bar => foo-2bar`, but it did not support it before this change either.

It's a bit edge-casey but I think given the prevalent use of C3 and D3 in JS, it makes sense to lean towards this patch's behavior.