### PR TITLE
[DOC release] Update RouterService docs to fix code examples for routeWillChange / routeDidChange

### DIFF
--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -361,7 +361,7 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
         router: service('router'),
         init() {
           this._super(...arguments);
-          this.router.on('routeWillUpdate', (transition) => {
+          this.router.on('routeWillChange', (transition) => {
             if (!transition.to.find(route => route.name === this.routeName)) {
               alert("Please save or cancel your changes.");
               transition.abort();
@@ -393,7 +393,7 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
         router: service('router'),
         init() {
           this._super(...arguments);
-          this.router.on('routeDidUpdate', (transition) => {
+          this.router.on('routeDidChange', (transition) => {
             ga.send('pageView', {
               current: transition.to.name,
               from: transition.from.name


### PR DESCRIPTION
The code examples were using routeWillUpdate / routeDidUpdate rather than the correct method name (routeWillChange / routeDidChange). I have updated them to match to reduce confusion.