### PR TITLE
Lazy router setup in non-application tests

### DIFF
--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -57,7 +57,7 @@ export default class RouterService extends Service {
       this._router.startRouting();
     }
     return this._router;
-  };
+  }
 
   /**
      Transition the application into another route. The route may
@@ -154,12 +154,7 @@ export default class RouterService extends Service {
     let hasQueryParams = Object.keys(queryParams).length > 0;
 
     if (hasQueryParams) {
-      this.router._prepareQueryParams(
-        routeName,
-        models,
-        queryParams,
-        true /* fromRouterService */
-      );
+      this.router._prepareQueryParams(routeName, models, queryParams, true /* fromRouterService */);
       return shallowEqual(queryParams, routerMicrolib.state!.queryParams);
     }
 

--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -52,6 +52,12 @@ if (DEBUG) {
  */
 export default class RouterService extends Service {
   _router!: EmberRouter;
+  get router() {
+    if (!this._router._didSetupRouter) {
+      this._router.startRouting();
+    }
+    return this._router;
+  };
 
   /**
      Transition the application into another route. The route may
@@ -75,12 +81,12 @@ export default class RouterService extends Service {
    */
   transitionTo(...args: string[]) {
     if (resemblesURL(args[0])) {
-      return this._router._doURLTransition('transitionTo', args[0]);
+      return this.router._doURLTransition('transitionTo', args[0]);
     }
 
     let { routeName, models, queryParams } = extractRouteArgs(args);
 
-    let transition = this._router._doTransition(routeName, models, queryParams, true);
+    let transition = this.router._doTransition(routeName, models, queryParams, true);
     transition['_keepDefaultQueryParamValues'] = true;
 
     return transition;
@@ -123,7 +129,7 @@ export default class RouterService extends Service {
      @public
    */
   urlFor(routeName: string, ...args: any[]) {
-    return this._router.generate(routeName, ...args);
+    return this.router.generate(routeName, ...args);
   }
 
   /**
@@ -140,7 +146,7 @@ export default class RouterService extends Service {
    */
   isActive(...args: any[]) {
     let { routeName, models, queryParams } = extractRouteArgs(args);
-    let routerMicrolib = this._router._routerMicrolib;
+    let routerMicrolib = this.router._routerMicrolib;
 
     if (!routerMicrolib.isActiveIntent(routeName, models)) {
       return false;
@@ -148,7 +154,7 @@ export default class RouterService extends Service {
     let hasQueryParams = Object.keys(queryParams).length > 0;
 
     if (hasQueryParams) {
-      this._router._prepareQueryParams(
+      this.router._prepareQueryParams(
         routeName,
         models,
         queryParams,
@@ -322,7 +328,7 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
         url.indexOf(this.rootURL) === 0
       );
       let internalURL = cleanURL(url, this.rootURL);
-      return this._router._routerMicrolib.recognize(internalURL);
+      return this.router._routerMicrolib.recognize(internalURL);
     },
 
     /**
@@ -343,7 +349,7 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
         url.indexOf(this.rootURL) === 0
       );
       let internalURL = cleanURL(url, this.rootURL);
-      return this._router._routerMicrolib.recognizeAndLoad(internalURL);
+      return this.router._routerMicrolib.recognizeAndLoad(internalURL);
     },
     /**
       The `routeWillChange` event is fired at the beginning of any

--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -274,6 +274,7 @@ class EmberRouter extends EmberObject {
   location!: string | IEmberLocation;
   rootURL!: string;
   _routerMicrolib!: Router<Route>;
+  _didSetupRouter = false;
 
   _initRouterJs() {
     let location = get(this, 'location');
@@ -545,9 +546,8 @@ class EmberRouter extends EmberObject {
     @private
   */
   startRouting() {
-    let initialURL = get(this, 'initialURL');
-
     if (this.setupRouter()) {
+      let initialURL = get(this, 'initialURL');
       if (initialURL === undefined) {
         initialURL = get(this, 'location').getURL();
       }
@@ -559,6 +559,10 @@ class EmberRouter extends EmberObject {
   }
 
   setupRouter() {
+    if (this._didSetupRouter) {
+      return false;
+    }
+    this._didSetupRouter = true;
     this._setupLocation();
 
     let location = get(this, 'location');
@@ -630,7 +634,9 @@ class EmberRouter extends EmberObject {
       this._toplevelView = OutletView.create();
       this._toplevelView.setOutletState(liveRoutes);
       let instance: any = owner.lookup('-application-instance:main');
-      instance.didCreateRootView(this._toplevelView);
+      if (instance) {
+        instance.didCreateRootView(this._toplevelView);
+      }
     } else {
       this._toplevelView.setOutletState(liveRoutes);
     }

--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -274,7 +274,7 @@ class EmberRouter extends EmberObject {
   location!: string | IEmberLocation;
   rootURL!: string;
   _routerMicrolib!: Router<Route>;
-  _didSetupRouter = false;
+  _didSetupRouter!: boolean;
 
   _initRouterJs() {
     let location = get(this, 'location');
@@ -508,6 +508,7 @@ class EmberRouter extends EmberObject {
       this.currentRoute = null;
     }
 
+    this._didSetupRouter = false;
     this._qpCache = Object.create(null);
     this._qpUpdates = new Set();
     this._resetQueuedQueryParameterChanges();
@@ -767,6 +768,7 @@ class EmberRouter extends EmberObject {
     @method reset
    */
   reset() {
+    this._didSetupRouter = false;
     if (this._routerMicrolib) {
       this._routerMicrolib.reset();
     }

--- a/packages/@ember/-internals/routing/tests/system/router_test.js
+++ b/packages/@ember/-internals/routing/tests/system/router_test.js
@@ -61,6 +61,20 @@ moduleFor(
       assert.ok(!router._routerMicrolib);
     }
 
+    ['@test should create a router.js instance after setupRouter'](assert) {
+      let router = createRouter(undefined, { disableSetup: false });
+
+      assert.ok(router._didSetupRouter);
+      assert.ok(router._routerMicrolib);
+    }
+
+    ['@test should return false if setupRouter is called multiple times'](assert) {
+      let router = createRouter(undefined, { disableSetup: true });
+
+      assert.ok(router.setupRouter());
+      assert.notOk(router.setupRouter());
+    }
+
     ['@test should not reify location until setupRouter is called'](assert) {
       let router = createRouter(undefined, { disableSetup: true });
       assert.equal(typeof router.location, 'string', 'location is specified as a string');

--- a/packages/@ember/application/instance.js
+++ b/packages/@ember/application/instance.js
@@ -159,24 +159,18 @@ const ApplicationInstance = EngineInstance.extend({
   */
   startRouting() {
     this.router.startRouting();
-    this._didSetupRouter = true;
   },
 
   /**
-    @private
+   Sets up the router, initializing the child router and configuring the
+   location before routing begins.
 
-    Sets up the router, initializing the child router and configuring the
-    location before routing begins.
+   Because setup should only occur once, multiple calls to `router.setupRouter`
+   beyond the first call will have no effect.
 
-    Because setup should only occur once, multiple calls to `setupRouter`
-    beyond the first call have no effect.
+   @private
   */
   setupRouter() {
-    if (this._didSetupRouter) {
-      return;
-    }
-    this._didSetupRouter = true;
-
     this.router.setupRouter();
   },
 

--- a/packages/ember/tests/routing/router_service_test/non_application_test.js
+++ b/packages/ember/tests/routing/router_service_test/non_application_test.js
@@ -1,5 +1,5 @@
 import { inject as injectService } from '@ember/service';
-import { HashLocation } from '@ember/-internals/routing';
+import { Router, NoneLocation } from '@ember/-internals/routing';
 import { get } from '@ember/-internals/metal';
 import { run } from '@ember/runloop';
 import { Component } from '@ember/-internals/glimmer';
@@ -11,6 +11,8 @@ moduleFor(
   class extends AbstractRenderingTestCase {
     constructor() {
       super(...arguments);
+
+      this.resolver.add('router:main', Router.extend(this.routerOptions));
       this.router.map(function() {
         this.route('parent', { path: '/' }, function() {
           this.route('child');
@@ -24,12 +26,22 @@ moduleFor(
       });
     }
 
+    get routerOptions() {
+      return {
+        location: 'none',
+      };
+    }
+
     get router() {
       return this.owner.resolveRegistration('router:main');
     }
 
     get routerService() {
       return this.owner.lookup('service:router');
+    }
+
+    afterEach() {
+      super.afterEach();
     }
 
     ['@test RouterService can be instantiated in non application test'](assert) {
@@ -42,18 +54,18 @@ moduleFor(
       assert.expect(EMBER_ROUTING_ROUTER_SERVICE ? 7 : 6);
       assert.equal(this.routerService.get('currentRouteName'), null);
       assert.equal(this.routerService.get('currentURL'), null);
-      assert.equal(this.routerService.get('location'), 'hash');
+      assert.equal(this.routerService.get('location'), 'none');
       assert.equal(this.routerService.get('rootURL'), '/');
       if (EMBER_ROUTING_ROUTER_SERVICE) {
         assert.equal(this.routerService.get('currentRoute'), null);
       }
       assert.notOk(this.routerService._didSetupRouter);
       this.routerService.router;
-      assert.ok(this.routerService.get('location') instanceof HashLocation);
+      assert.ok(this.routerService.get('location') instanceof NoneLocation);
     }
 
     ['@test RouterService#urlFor returns url'](assert) {
-      assert.equal(this.routerService.urlFor('parent.child'), '#/child');
+      assert.equal(this.routerService.urlFor('parent.child'), '/child');
     }
 
     ['@test RouterService#transitionTo with basic route'](assert) {

--- a/packages/ember/tests/routing/router_service_test/non_application_test.js
+++ b/packages/ember/tests/routing/router_service_test/non_application_test.js
@@ -1,0 +1,108 @@
+import { inject as injectService } from '@ember/service';
+import { HashLocation } from '@ember/-internals/routing';
+import { get } from '@ember/-internals/metal';
+import { run } from '@ember/runloop';
+import { Component } from '@ember/-internals/glimmer';
+import { AbstractRenderingTestCase, moduleFor } from 'internal-test-helpers';
+import { EMBER_ROUTING_ROUTER_SERVICE } from '@ember/canary-features';
+
+moduleFor(
+  'Router Service - non application',
+  class extends AbstractRenderingTestCase {
+    constructor() {
+      super(...arguments);
+      this.router.map(function() {
+        this.route('parent', { path: '/' }, function() {
+          this.route('child');
+          this.route('sister');
+          this.route('brother');
+        });
+        this.route('dynamic', { path: '/dynamic/:dynamic_id' });
+        this.route('dynamicWithChild', { path: '/dynamic-with-child/:dynamic_id' }, function() {
+          this.route('child', { path: '/:child_id' });
+        });
+      });
+    }
+
+    get router() {
+      return this.owner.resolveRegistration('router:main');
+    }
+
+    get routerService() {
+      return this.owner.lookup('service:router');
+    }
+
+    ['@test RouterService can be instantiated in non application test'](assert) {
+      assert.ok(this.routerService);
+    }
+
+    ['@test RouterService properties can be accessed with default and should not start routing'](
+      assert
+    ) {
+      assert.expect(EMBER_ROUTING_ROUTER_SERVICE ? 7 : 6);
+      assert.equal(this.routerService.get('currentRouteName'), null);
+      assert.equal(this.routerService.get('currentURL'), null);
+      assert.equal(this.routerService.get('location'), 'hash');
+      assert.equal(this.routerService.get('rootURL'), '/');
+      if (EMBER_ROUTING_ROUTER_SERVICE) {
+        assert.equal(this.routerService.get('currentRoute'), null);
+      }
+      assert.notOk(this.routerService._didSetupRouter);
+      this.routerService.router;
+      assert.ok(this.routerService.get('location') instanceof HashLocation);
+    }
+
+    ['@test RouterService#urlFor returns url'](assert) {
+      assert.equal(this.routerService.urlFor('parent.child'), '#/child');
+    }
+
+    ['@test RouterService#transitionTo with basic route'](assert) {
+      assert.expect(2);
+
+      let componentInstance;
+
+      this.addTemplate('parent.index', '{{foo-bar}}');
+
+      this.addComponent('foo-bar', {
+        ComponentClass: Component.extend({
+          routerService: injectService('router'),
+          init() {
+            this._super(...arguments);
+            componentInstance = this;
+          },
+          actions: {
+            transitionToSister() {
+              get(this, 'routerService').transitionTo('parent.sister');
+            },
+          },
+        }),
+        template: `foo-bar`,
+      });
+
+      this.render('{{foo-bar}}');
+
+      run(function() {
+        componentInstance.send('transitionToSister');
+      });
+
+      assert.equal(this.routerService.get('currentRouteName'), 'parent.sister');
+      assert.ok(this.routerService.isActive('parent.sister'));
+    }
+
+    ['@test RouterService#recognize recognize returns routeInfo'](assert) {
+      if (EMBER_ROUTING_ROUTER_SERVICE) {
+        let routeInfo = this.routerService.recognize('/dynamic-with-child/123/1?a=b');
+        assert.ok(routeInfo);
+        let { name, localName, parent, child, params, queryParams, paramNames } = routeInfo;
+        assert.equal(name, 'dynamicWithChild.child');
+        assert.equal(localName, 'child');
+        assert.ok(parent);
+        assert.equal(parent.name, 'dynamicWithChild');
+        assert.notOk(child);
+        assert.deepEqual(params, { child_id: '1' });
+        assert.deepEqual(queryParams, { a: 'b' });
+        assert.deepEqual(paramNames, ['child_id']);
+      }
+    }
+  }
+);


### PR DESCRIPTION
During non `setupApplicationTests` type tests, the Router being injected into `service:router` and `service:routing` does not start routing, in which it initializes its `_routerMicrolib`. Calling public API on `service:router` will throw in those tests.

This commit will trigger startRouting on router, in non application tests the router service should _just work™_.

Link tested on https://github.com/xg-wang/__router-test/commit/df287142eecce502ebab557386a22c5794edb878. It fails on [travis-ci](https://travis-ci.com/xg-wang/__router-test).

Fixes https://github.com/emberjs/ember.js/issues/16831