### PR TITLE
add ability to pass `log` helper as action

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/helpers/-log-action.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/-log-action.ts
@@ -1,0 +1,19 @@
+import { Arguments, VM } from '@glimmer/runtime';
+import { ACTION, UnboundReference } from '../utils/references';
+
+export default function logAction(_vm: VM, args: Arguments) {
+  let { positional } = args;
+  let capturedArgs = positional.capture();
+
+  const fn = function() {
+    let allArgs = capturedArgs.value().concat(...arguments);
+
+    /* eslint-disable no-console */
+    console.log(...allArgs);
+    /* eslint-enable no-console */
+  };
+
+  fn[ACTION] = true;
+
+  return new UnboundReference(fn);
+}

--- a/packages/@ember/-internals/glimmer/lib/resolver.ts
+++ b/packages/@ember/-internals/glimmer/lib/resolver.ts
@@ -27,6 +27,7 @@ import { isHelperFactory, isSimpleHelper } from './helper';
 import { default as componentAssertionHelper } from './helpers/-assert-implicit-component-helper-argument';
 import { default as classHelper } from './helpers/-class';
 import { default as inputTypeHelper } from './helpers/-input-type';
+import { default as logAction } from './helpers/-log-action';
 import { default as normalizeClassHelper } from './helpers/-normalize-class';
 import { default as action } from './helpers/action';
 import { default as array } from './helpers/array';
@@ -74,6 +75,7 @@ const BUILTINS_HELPERS = {
   readonly,
   unbound,
   unless: inlineUnless,
+  '-log-action': logAction,
   '-class': classHelper,
   '-each-in': eachIn,
   '-input-type': inputTypeHelper,

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/log-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/log-action-test.js
@@ -1,0 +1,69 @@
+/*globals MouseEvent */
+import { RenderingTestCase, moduleFor } from 'internal-test-helpers';
+
+moduleFor(
+  'Helpers test: {{-log-action}}',
+  class extends RenderingTestCase {
+    constructor() {
+      super(...arguments);
+      /* eslint-disable no-console */
+      this.originalLog = console.log;
+      this.logCalls = [];
+      console.log = (...args) => {
+        this.logCalls.push(...args);
+        /* eslint-enable no-console */
+      };
+    }
+
+    teardown() {
+      super.teardown();
+      /* eslint-disable no-console */
+      console.log = this.originalLog;
+      /* eslint-enable no-console */
+    }
+
+    ['@test can log as action']() {
+      this.render(`<button id='my-btn' onclick={{-log-action}}>Click!</button>`);
+      this.$('#my-btn').click();
+
+      this.assert.strictEqual(this.logCalls.length, 1);
+      this.assert.ok(this.logCalls[0] instanceof MouseEvent);
+    }
+
+    ['@test can log with multiple args']() {
+      this.render(`<button id='my-btn' onclick={{-log-action 'rainbow' 45}}>Click!</button>`);
+      this.$('#my-btn').click();
+
+      this.assert.strictEqual(this.logCalls.length, 3);
+      this.assert.equal(this.logCalls[0], 'rainbow');
+      this.assert.equal(this.logCalls[1], 45);
+      this.assert.ok(this.logCalls[2] instanceof MouseEvent);
+    }
+
+    ['@test can log with reference value']() {
+      this.render(`<button id='my-btn' onclick={{-log-action age 'rainbow'}}>Click!</button>`, {
+        age: 21,
+      });
+      this.$('#my-btn').click();
+
+      this.assert.strictEqual(this.logCalls.length, 3);
+      this.assert.equal(this.logCalls[0], 21);
+      this.assert.equal(this.logCalls[1], 'rainbow');
+      this.assert.ok(this.logCalls[2] instanceof MouseEvent);
+    }
+
+    ['@test can use with `action` helper combination']() {
+      this.render(
+        `<button id='my-btn' onclick={{action (action (-log-action age) 'rainbow') 'sun'}}>Click!</button>`,
+        { age: 21 }
+      );
+      this.$('#my-btn').click();
+
+      this.assert.strictEqual(this.logCalls.length, 4);
+      this.assert.equal(this.logCalls[0], 21);
+      this.assert.equal(this.logCalls[1], 'rainbow');
+      this.assert.equal(this.logCalls[2], 'sun');
+      this.assert.ok(this.logCalls[3] instanceof MouseEvent);
+    }
+  }
+);

--- a/packages/ember-template-compiler/lib/plugins/index.ts
+++ b/packages/ember-template-compiler/lib/plugins/index.ts
@@ -13,6 +13,7 @@ import TransformHasBlockSyntax from './transform-has-block-syntax';
 import TransformInElement from './transform-in-element';
 import TransformInputTypeSyntax from './transform-input-type-syntax';
 import TransformLinkTo from './transform-link-to';
+import TransformLogAction from './transform-log-action';
 import TransformOldClassBindingSyntax from './transform-old-class-binding-syntax';
 import TransformQuotedBindingsIntoJustBindings from './transform-quoted-bindings-into-just-bindings';
 
@@ -40,6 +41,7 @@ const transforms: Array<APluginFunc> = [
   TransformInElement,
   AssertIfHelperWithoutArguments,
   AssertSplattributeExpressions,
+  TransformLogAction,
 ];
 
 if (!EMBER_GLIMMER_ANGLE_BRACKET_BUILT_INS) {

--- a/packages/ember-template-compiler/lib/plugins/transform-log-action.ts
+++ b/packages/ember-template-compiler/lib/plugins/transform-log-action.ts
@@ -1,0 +1,65 @@
+import { AST, ASTPlugin, ASTPluginEnvironment } from '@glimmer/syntax';
+
+/**
+ @module ember
+*/
+
+/**
+  A Glimmer2 AST transformation that replaces all instances of
+
+  ```handlebars
+   <button {{log 'foo'}}>
+   <button onclick={{log 'foo'}}>
+   <button onclick={{action (log 'foo') 'bar'}}>
+  ```
+
+  with
+
+  ```handlebars
+   <button {{action (-log-action 'foo')}}>
+   <button onclick={{-log-action 'foo'}}>
+   <button onclick={{action (-log-action this 'foo') 'bar'}}>
+  ```
+
+  @private
+  @class TransformLogAction
+*/
+
+export default function transformLogActionSyntax({ syntax }: ASTPluginEnvironment): ASTPlugin {
+  let { builders: b } = syntax;
+
+  return {
+    name: 'transform-log-action-syntax',
+
+    visitor: {
+      ElementModifierStatement(node: AST.ElementModifierStatement) {
+        if (isLog(node)) {
+          node.path.original = 'action';
+          node.path.parts = ['action'];
+          let originalParams = node.params;
+          node.params = [b.sexpr(b.path('-log-action'), originalParams)];
+        }
+      },
+
+      AttrNode(node: AST.AttrNode) {
+        if (node.value.type === 'MustacheStatement' && isLog(node.value)) {
+          renameNode(node.value);
+        }
+      },
+
+      SubExpression(node: AST.SubExpression) {
+        if (isLog(node)) {
+          renameNode(node);
+        }
+      },
+    },
+  };
+}
+
+function isLog(node: AST.SubExpression | AST.MustacheStatement | AST.ElementModifierStatement) {
+  return node.path.original === 'log';
+}
+
+function renameNode(node: AST.SubExpression | AST.MustacheStatement) {
+  node.path.original = '-log-action';
+}


### PR DESCRIPTION
so following is possible: 

```javascript
  <button {{log 'rainbow'}}>Click!</button> // logs `rainbow` and `MouseEvent` on click
  <button onclick={{log 'rainbow'}}>Click!</button> // logs `rainbow` and `MouseEvent` on click
  <button onclick={{action (log 'rainbow') 'sun'}}>Click!</button>  // logs `rainbow`,  'sun' and `MouseEvent` on click
```