### PR TITLE
[BUGFIX] passing ObjectProxy with a property size to `isEmpty` would throw assertion

### DIFF
--- a/packages/@ember/-internals/metal/lib/is_empty.ts
+++ b/packages/@ember/-internals/metal/lib/is_empty.ts
@@ -41,7 +41,7 @@ export default function isEmpty(obj: any): boolean {
     return none;
   }
 
-  if (typeof obj.size === 'number') {
+  if (typeof obj.unknownProperty !== 'function' && typeof obj.size === 'number') {
     return !obj.size;
   }
 

--- a/packages/@ember/-internals/metal/tests/is_empty_test.js
+++ b/packages/@ember/-internals/metal/tests/is_empty_test.js
@@ -1,5 +1,6 @@
 import { isEmpty } from '..';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import ObjectProxy from '../../runtime/lib/system/object_proxy';
 
 moduleFor(
   'isEmpty',
@@ -8,6 +9,7 @@ moduleFor(
       let string = 'string';
       let fn = function () {};
       let object = { length: 0 };
+      let proxy = ObjectProxy.create({ content: { size: 0 } });
 
       assert.equal(true, isEmpty(null), 'for null');
       assert.equal(true, isEmpty(undefined), 'for undefined');
@@ -22,6 +24,7 @@ moduleFor(
       assert.equal(true, isEmpty([]), 'for an empty Array');
       assert.equal(false, isEmpty({}), 'for an empty Object');
       assert.equal(true, isEmpty(object), "for an Object that has zero 'length'");
+      assert.equal(true, isEmpty(proxy), "for a proxy that has zero 'size'");
     }
   }
 );


### PR DESCRIPTION
fixes #17032