### PR TITLE
[BUGFIX] avoid tampering `queryParam` argument in RouterService#isActive

### DIFF
--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -1,6 +1,7 @@
 import { Evented } from '@ember/-internals/runtime';
 import { assert } from '@ember/debug';
 import { readOnly } from '@ember/object/computed';
+import { assign } from '@ember/polyfills';
 import Service from '@ember/service';
 import { DEBUG } from '@glimmer/env';
 import { Transition } from 'router_js';
@@ -319,6 +320,7 @@ export default class RouterService extends Service {
     let hasQueryParams = Object.keys(queryParams).length > 0;
 
     if (hasQueryParams) {
+      queryParams = assign({}, queryParams);
       this._router._prepareQueryParams(
         // UNSAFE: casting `routeName as string` here encodes the existing
         // assumption but may be wrong: `extractRouteArgs` correctly returns it
@@ -334,6 +336,7 @@ export default class RouterService extends Service {
         queryParams as QueryParam,
         true /* fromRouterService */
       );
+
       return shallowEqual(queryParams, routerMicrolib.state!.queryParams);
     }
 

--- a/packages/ember/tests/routing/router_service_test/isActive_test.js
+++ b/packages/ember/tests/routing/router_service_test/isActive_test.js
@@ -105,5 +105,30 @@ moduleFor(
           );
         });
     }
+
+    ['@test RouterService#isActive does not alter query params hash'](assert) {
+      assert.expect(3);
+
+      this.add(
+        'controller:parent.child',
+        Controller.extend({
+          queryParams: ['sort', 'page'],
+          sort: 'ASC',
+          page: 1,
+        })
+      );
+
+      let qp = this.buildQueryParams({ sort: 'ascending' });
+
+      return this.visit('/')
+        .then(() => {
+          return this.routerService.transitionTo('parent.child', qp);
+        })
+        .then(() => {
+          assert.ok(this.routerService.isActive('parent.child', qp));
+          assert.ok(this.routerService.isActive('parent.child', qp)); // using same qp second time should not fail
+          assert.deepEqual(qp.queryParams, { sort: 'ascending' });
+        });
+    }
   }
 );


### PR DESCRIPTION
using same `query param` hash twice would fail in `RouterService#isActive`