### PR TITLE
[DEPRECATE] - RFC 421 - deprecate app ctrl router props

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -1,9 +1,14 @@
-import { computed, defineProperty, get, set } from '@ember/-internals/metal';
+import { computed, get, notifyPropertyChange, set } from '@ember/-internals/metal';
 import { getOwner, Owner } from '@ember/-internals/owner';
 import { A as emberA, Evented, Object as EmberObject, typeOf } from '@ember/-internals/runtime';
 import { EMBER_ROUTING_ROUTER_SERVICE } from '@ember/canary-features';
 import { assert, deprecate, info } from '@ember/debug';
-import { HANDLER_INFOS, ROUTER_EVENTS, TRANSITION_STATE } from '@ember/deprecated-features';
+import {
+  APP_CTRL_ROUTER_PROPS,
+  HANDLER_INFOS,
+  ROUTER_EVENTS,
+  TRANSITION_STATE,
+} from '@ember/deprecated-features';
 import EmberError from '@ember/error';
 import { assign } from '@ember/polyfills';
 import { cancel, once, run, scheduleOnce } from '@ember/runloop';
@@ -1635,18 +1640,45 @@ function updatePaths(router: EmberRouter) {
     // actually been entered at that point.
     return;
   }
+  if (APP_CTRL_ROUTER_PROPS) {
+    if (!('currentPath' in appController)) {
+      Object.defineProperty(appController, 'currentPath', {
+        get() {
+          deprecate(
+            'Accessing `currentPath` on `controller:application` is deprecated, use the `currentPath` property on `service:router` instead.',
+            false,
+            {
+              id: 'application-controller.router-properties',
+              until: '4.0.0',
+              url:
+                'https://emberjs.com/deprecations/v3.x#toc_application-controller-router-properties',
+            }
+          );
+          return get(router, 'currentPath');
+        },
+      });
+    }
+    notifyPropertyChange(appController, 'currentPath');
 
-  if (!('currentPath' in appController)) {
-    defineProperty(appController, 'currentPath');
+    if (!('currentRouteName' in appController)) {
+      Object.defineProperty(appController, 'currentRouteName', {
+        get() {
+          deprecate(
+            'Accessing `currentRouteName` on `controller:application` is deprecated, use the `currentRouteName` property on `service:router` instead.',
+            false,
+            {
+              id: 'application-controller.router-properties',
+              until: '4.0.0',
+              url:
+                'https://emberjs.com/deprecations/v3.x#toc_application-controller-router-properties',
+            }
+          );
+          return get(router, 'currentRouteName');
+        },
+      });
+    }
+    notifyPropertyChange(appController, 'currentRouteName');
   }
-
-  set(appController, 'currentPath', path);
-
-  if (!('currentRouteName' in appController)) {
-    defineProperty(appController, 'currentRouteName');
-  }
-
-  set(appController, 'currentRouteName', currentRouteName);
 }
 
 EmberRouter.reopenClass({

--- a/packages/@ember/application/tests/reset_test.js
+++ b/packages/@ember/application/tests/reset_test.js
@@ -124,7 +124,9 @@ moduleFor(
           let location = initialRouter.get('location');
 
           assert.equal(location.getURL(), '/one');
-          assert.equal(get(initialApplicationController, 'currentPath'), 'one');
+          expectDeprecation(() => {
+            assert.equal(get(initialApplicationController, 'currentPath'), 'one');
+          }, 'Accessing `currentPath` on `controller:application` is deprecated, use the `currentPath` property on `service:router` instead.');
 
           this.application.reset();
 
@@ -153,7 +155,9 @@ moduleFor(
           );
 
           assert.equal(location.getURL(), '/one');
-          assert.equal(get(applicationController, 'currentPath'), 'one');
+          expectDeprecation(() => {
+            assert.equal(get(applicationController, 'currentPath'), 'one');
+          }, 'Accessing `currentPath` on `controller:application` is deprecated, use the `currentPath` property on `service:router` instead.');
         });
     }
 

--- a/packages/@ember/deprecated-features/index.ts
+++ b/packages/@ember/deprecated-features/index.ts
@@ -14,3 +14,4 @@ export const TRANSITION_STATE = !!'3.9.0';
 export const COMPONENT_MANAGER_STRING_LOOKUP = !!'3.8.0';
 export const JQUERY_INTEGRATION = !!'3.9.0';
 export const ALIAS_METHOD = !!'3.9.0';
+export const APP_CTRL_ROUTER_PROPS = !!'4.0.0';

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1182,14 +1182,16 @@ moduleFor(
       return this.visit('/')
         .then(() => this.click('#about-link'))
         .then(() => {
-          let currentRouteName = this.applicationInstance
-            .lookup('controller:application')
-            .get('currentRouteName');
-          assert.notEqual(
-            currentRouteName,
-            'about',
-            'link-to should not transition if target is not equal to _self or empty'
-          );
+          expectDeprecation(() => {
+            let currentRouteName = this.applicationInstance
+              .lookup('controller:application')
+              .get('currentRouteName');
+            assert.notEqual(
+              currentRouteName,
+              'about',
+              'link-to should not transition if target is not equal to _self or empty'
+            );
+          }, 'Accessing `currentRouteName` on `controller:application` is deprecated, use the `currentRouteName` property on `service:router` instead.');
         });
     }
 

--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -69,7 +69,11 @@ moduleFor(
     }
 
     get currentPath() {
-      return this.getController('application').get('currentPath');
+      let currentPath;
+      expectDeprecation(() => {
+        currentPath = this.getController('application').get('currentPath');
+      }, 'Accessing `currentPath` on `controller:application` is deprecated, use the `currentPath` property on `service:router` instead.');
+      return currentPath;
     }
 
     get currentURL() {
@@ -1608,15 +1612,12 @@ moduleFor(
           1,
           'The home template was rendered'
         );
-        assert.equal(
-          this.applicationInstance.lookup('controller:application').get('currentPath'),
-          'home'
-        );
+        assert.equal(this.currentPath, 'home');
       });
     }
 
     ['@test Redirecting from the middle of a route aborts the remainder of the routes'](assert) {
-      assert.expect(3);
+      assert.expect(4);
 
       this.router.map(function() {
         this.route('home');
@@ -1651,10 +1652,13 @@ moduleFor(
       return this.visit('/').then(() => {
         let router = this.applicationInstance.lookup('router:main');
         this.handleURLAborts(assert, '/foo/bar/baz');
-        assert.equal(
-          this.applicationInstance.lookup('controller:application').get('currentPath'),
-          'home'
-        );
+        let currentPath;
+        expectDeprecation(() => {
+          currentPath = this.applicationInstance
+            .lookup('controller:application')
+            .get('currentPath');
+        }, 'Accessing `currentPath` on `controller:application` is deprecated, use the `currentPath` property on `service:router` instead.');
+        assert.equal(currentPath, 'home');
         assert.equal(router.get('location').getURL(), '/home');
       });
     }
@@ -1662,7 +1666,7 @@ moduleFor(
     ['@test Redirecting to the current target in the middle of a route does not abort initial routing'](
       assert
     ) {
-      assert.expect(5);
+      assert.expect(6);
 
       this.router.map(function() {
         this.route('home');
@@ -1701,10 +1705,13 @@ moduleFor(
 
       return this.visit('/foo/bar/baz').then(() => {
         assert.ok(true, '/foo/bar/baz has been handled');
-        assert.equal(
-          this.applicationInstance.lookup('controller:application').get('currentPath'),
-          'foo.bar.baz'
-        );
+        let currentPath;
+        expectDeprecation(() => {
+          currentPath = this.applicationInstance
+            .lookup('controller:application')
+            .get('currentPath');
+        }, 'Accessing `currentPath` on `controller:application` is deprecated, use the `currentPath` property on `service:router` instead.');
+        assert.equal(currentPath, 'foo.bar.baz');
         assert.equal(successCount, 1, 'transitionTo success handler was called once');
       });
     }
@@ -1712,7 +1719,7 @@ moduleFor(
     ['@test Redirecting to the current target with a different context aborts the remainder of the routes'](
       assert
     ) {
-      assert.expect(4);
+      assert.expect(5);
 
       this.router.map(function() {
         this.route('home');
@@ -1751,10 +1758,13 @@ moduleFor(
 
       return this.visit('/').then(() => {
         this.handleURLAborts(assert, '/foo/bar/1/baz');
-        assert.equal(
-          this.applicationInstance.lookup('controller:application').get('currentPath'),
-          'foo.bar.baz'
-        );
+        let currentPath;
+        expectDeprecation(() => {
+          currentPath = this.applicationInstance
+            .lookup('controller:application')
+            .get('currentPath');
+        }, 'Accessing `currentPath` on `controller:application` is deprecated, use the `currentPath` property on `service:router` instead.');
+        assert.equal(currentPath, 'foo.bar.baz');
         assert.equal(
           this.applicationInstance
             .lookup('router:main')
@@ -1792,9 +1802,17 @@ moduleFor(
         assert.ok(true, '/foo/bar/baz has been handled');
         let applicationController = this.applicationInstance.lookup('controller:application');
         let router = this.applicationInstance.lookup('router:main');
-        assert.equal(applicationController.get('currentPath'), 'foo.bar.baz');
+
+        let currentPath;
+        expectDeprecation(() => {
+          currentPath = applicationController.get('currentPath');
+        }, 'Accessing `currentPath` on `controller:application` is deprecated, use the `currentPath` property on `service:router` instead.');
+        assert.equal(currentPath, 'foo.bar.baz');
         run(() => router.send('goToQux'));
-        assert.equal(applicationController.get('currentPath'), 'foo.qux');
+        expectDeprecation(() => {
+          currentPath = applicationController.get('currentPath');
+        }, 'Accessing `currentPath` on `controller:application` is deprecated, use the `currentPath` property on `service:router` instead.');
+        assert.equal(currentPath, 'foo.qux');
         assert.equal(router.get('location').getURL(), '/foo/qux');
       });
     }
@@ -2404,7 +2422,9 @@ moduleFor(
         'controller:application',
         Controller.extend({
           currentPathDidChange: observer('currentPath', function() {
-            currentPath = this.currentPath;
+            expectDeprecation(() => {
+              currentPath = this.currentPath;
+            }, 'Accessing `currentPath` on `controller:application` is deprecated, use the `currentPath` property on `service:router` instead.');
           }),
         })
       );
@@ -3094,7 +3114,7 @@ moduleFor(
     ['@test currentRouteName is a property installed on ApplicationController that can be used in transitionTo'](
       assert
     ) {
-      assert.expect(24);
+      assert.expect(36);
 
       this.router.map(function() {
         this.route('index', { path: '/' });
@@ -3117,8 +3137,10 @@ moduleFor(
           if (path) {
             run(router, 'transitionTo', path);
           }
-          assert.equal(appController.get('currentPath'), expectedPath);
-          assert.equal(appController.get('currentRouteName'), expectedRouteName);
+          expectDeprecation(() => {
+            assert.equal(appController.get('currentPath'), expectedPath);
+            assert.equal(appController.get('currentRouteName'), expectedRouteName);
+          }, 'Accessing `currentPath` on `controller:application` is deprecated, use the `currentPath` property on `service:router` instead.');
         }
 
         transitionAndCheck(null, 'index', 'index');

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -25,7 +25,11 @@ moduleFor(
     }
 
     get currentPath() {
-      return this.getController('application').get('currentPath');
+      let currentPath;
+      expectDeprecation(() => {
+        currentPath = this.getController('application').get('currentPath');
+      }, 'Accessing `currentPath` on `controller:application` is deprecated, use the `currentPath` property on `service:router` instead.');
+      return currentPath;
     }
 
     ['@test Slow promise from a child route of application enters nested loading state'](assert) {
@@ -178,7 +182,6 @@ moduleFor(
 
           assert.equal(text, 'DUMMY', `dummy template has been rendered`);
         });
-
         assert.equal(this.currentPath, 'loading', `loading state entered`);
         deferred.resolve();
 
@@ -567,7 +570,11 @@ moduleFor(
     }
 
     get currentPath() {
-      return this.getController('application').get('currentPath');
+      let currentPath;
+      expectDeprecation(() => {
+        currentPath = this.getController('application').get('currentPath');
+      }, 'Accessing `currentPath` on `controller:application` is deprecated, use the `currentPath` property on `service:router` instead.');
+      return currentPath;
     }
 
     ['@test ApplicationRoute#currentPath reflects loading state path'](assert) {


### PR DESCRIPTION
Implements [RFC #421](https://github.com/emberjs/rfcs/pull/421/files).
Part of https://github.com/emberjs/ember.js/issues/17569.

Please let me know if `notifyPropertyChange` was an okay way to solve this.