### PR TITLE
[BUGFIX canary] Un-deprecate Route#(will|did)Transition events

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -19,7 +19,7 @@ import {
   EMBER_ROUTING_BUILD_ROUTEINFO_METADATA,
   EMBER_ROUTING_ROUTER_SERVICE,
 } from '@ember/canary-features';
-import { assert, deprecate, info, isTesting } from '@ember/debug';
+import { assert, info, isTesting } from '@ember/debug';
 import { ROUTER_EVENTS } from '@ember/deprecated-features';
 import { assign } from '@ember/polyfills';
 import { once } from '@ember/runloop';
@@ -2527,41 +2527,8 @@ Route.reopen(ActionHandler, Evented, {
   },
 });
 
-export let ROUTER_EVENT_DEPRECATIONS: any;
 if (EMBER_ROUTING_ROUTER_SERVICE && ROUTER_EVENTS) {
-  ROUTER_EVENT_DEPRECATIONS = {
-    on(name: string) {
-      this._super(...arguments);
-      let hasDidTransition = name === 'didTransition';
-      let hasWillTransition = name === 'willTransition';
-
-      if (hasDidTransition) {
-        deprecate(
-          'You attempted to listen to the "didTransition" event which is deprecated. Please inject the router service and listen to the "routeDidChange" event.',
-          false,
-          {
-            id: 'deprecate-router-events',
-            until: '4.0.0',
-            url: 'https://emberjs.com/deprecations/v3.x#toc_deprecate-router-events',
-          }
-        );
-      }
-
-      if (hasWillTransition) {
-        deprecate(
-          'You attempted to listen to the "willTransition" event which is deprecated. Please inject the router service and listen to the "routeWillChange" event.',
-          false,
-          {
-            id: 'deprecate-router-events',
-            until: '4.0.0',
-            url: 'https://emberjs.com/deprecations/v3.x#toc_deprecate-router-events',
-          }
-        );
-      }
-    },
-  };
-
-  Route.reopen(ROUTER_EVENT_DEPRECATIONS, {
+  Route.reopen({
     _paramsFor(routeName: string, params: {}) {
       let transition = this._router._routerMicrolib.activeTransition;
       if (transition !== undefined) {

--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -11,12 +11,7 @@ import { DEBUG } from '@glimmer/env';
 import EmberLocation, { EmberLocation as IEmberLocation } from '../location/api';
 import { calculateCacheKey, extractRouteArgs, getActiveTargetName, resemblesURL } from '../utils';
 import EmberRouterDSL from './dsl';
-import Route, {
-  defaultSerialize,
-  hasDefaultSerialize,
-  RenderOptions,
-  ROUTER_EVENT_DEPRECATIONS,
-} from './route';
+import Route, { defaultSerialize, hasDefaultSerialize, RenderOptions } from './route';
 import RouterState from './router_state';
 /**
 @module @ember/routing
@@ -1939,6 +1934,36 @@ EmberRouter.reopen(Evented, {
 });
 
 if (EMBER_ROUTING_ROUTER_SERVICE && ROUTER_EVENTS) {
-  EmberRouter.reopen(ROUTER_EVENT_DEPRECATIONS);
+  EmberRouter.reopen({
+    on(name: string) {
+      this._super(...arguments);
+      let hasDidTransition = name === 'didTransition';
+      let hasWillTransition = name === 'willTransition';
+
+      if (hasDidTransition) {
+        deprecate(
+          'You attempted to listen to the "didTransition" event which is deprecated. Please inject the router service and listen to the "routeDidChange" event.',
+          false,
+          {
+            id: 'deprecate-router-events',
+            until: '4.0.0',
+            url: 'https://emberjs.com/deprecations/v3.x#toc_deprecate-router-events',
+          }
+        );
+      }
+
+      if (hasWillTransition) {
+        deprecate(
+          'You attempted to listen to the "willTransition" event which is deprecated. Please inject the router service and listen to the "routeWillChange" event.',
+          false,
+          {
+            id: 'deprecate-router-events',
+            until: '4.0.0',
+            url: 'https://emberjs.com/deprecations/v3.x#toc_deprecate-router-events',
+          }
+        );
+      }
+    },
+  });
 }
 export default EmberRouter;

--- a/packages/ember/tests/routing/router_service_test/events_test.js
+++ b/packages/ember/tests/routing/router_service_test/events_test.js
@@ -694,36 +694,6 @@ if (EMBER_ROUTING_ROUTER_SERVICE) {
         });
       }
 
-      '@test willTransition events are deprecated on routes'() {
-        this.add(
-          'route:application',
-          Route.extend({
-            init() {
-              this._super(...arguments);
-              this.on('willTransition', () => {});
-            },
-          })
-        );
-        expectDeprecation(() => {
-          return this.visit('/');
-        }, 'You attempted to listen to the "willTransition" event which is deprecated. Please inject the router service and listen to the "routeWillChange" event.');
-      }
-
-      '@test didTransition events are deprecated on routes'() {
-        this.add(
-          'route:application',
-          Route.extend({
-            init() {
-              this._super(...arguments);
-              this.on('didTransition', () => {});
-            },
-          })
-        );
-        expectDeprecation(() => {
-          return this.visit('/');
-        }, 'You attempted to listen to the "didTransition" event which is deprecated. Please inject the router service and listen to the "routeDidChange" event.');
-      }
-
       '@test other events are not deprecated on routes'() {
         this.add(
           'route:application',


### PR DESCRIPTION
After re-reading the RFC it appears that the `Route` level events were not supposed to be deprecated. 