### PR TITLE
[BUGFIX] compute once for constant args in `SimpleHelperReference`

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/resolver.ts
+++ b/packages/@ember/-internals/glimmer/lib/resolver.ts
@@ -264,7 +264,7 @@ export default class RuntimeResolver implements IRuntimeResolver<OwnedTemplateMe
     return (vm, args) => {
       const helper = factory.create();
       if (isSimpleHelper(helper)) {
-        return new SimpleHelperReference(helper.compute, args.capture());
+        return SimpleHelperReference.create(helper.compute, args.capture());
       }
       vm.newDestroyable(helper);
       return ClassBasedHelperReference.create(helper, args.capture());


### PR DESCRIPTION
I think it was typo here: https://github.com/emberjs/ember.js/commit/86d7f50435eedf64e3987a791ac3f0ab9e0edc87#diff-80f190cc4372dfc7275150e4b47cbd6bR250