### PR TITLE
[FEAT] Adds more assertions to native decorators, and parenless invocation

### DIFF
--- a/packages/@ember/-internals/metal/lib/decorator.ts
+++ b/packages/@ember/-internals/metal/lib/decorator.ts
@@ -20,6 +20,14 @@ export type Decorator = (
   isClassicDecorator?: boolean
 ) => ElementDescriptor;
 
+export function isElementDescriptor(maybeDesc: any): maybeDesc is ElementDescriptor {
+  return (
+    maybeDesc !== undefined &&
+    typeof maybeDesc.toString === 'function' &&
+    maybeDesc.toString() === '[object Descriptor]'
+  );
+}
+
 // ..........................................................
 // DEPENDENT KEYS
 //
@@ -133,6 +141,13 @@ export function makeComputedDecorator(
     assert(
       'Native decorators are not enabled without the EMBER_NATIVE_DECORATOR_SUPPORT flag',
       EMBER_NATIVE_DECORATOR_SUPPORT || isClassicDecorator
+    );
+
+    assert(
+      `Only one computed property decorator can be applied to a class field or accessor, but '${key}' was decorated twice. You may have added the decorator to both a getter and setter, which is unecessary.`,
+      isClassicDecorator ||
+        !propertyDesc.get ||
+        propertyDesc.get.toString().indexOf('CPGETTER_FUNCTION') === -1
     );
 
     elementDesc.kind = 'method';

--- a/packages/@ember/-internals/metal/lib/descriptor_map.ts
+++ b/packages/@ember/-internals/metal/lib/descriptor_map.ts
@@ -42,7 +42,7 @@ export function descriptorForDecorator(dec: import('./decorator').Decorator) {
   @return {boolean}
   @private
 */
-export function isComputedDecorator(dec: import('./decorator').Decorator | null | undefined) {
+export function isComputedDecorator(dec: any) {
   return dec !== null && dec !== undefined && DECORATOR_DESCRIPTOR_MAP.has(dec);
 }
 

--- a/packages/@ember/-internals/metal/lib/tracked.ts
+++ b/packages/@ember/-internals/metal/lib/tracked.ts
@@ -185,7 +185,7 @@ function getTrackedFieldValues(obj: any) {
 }
 
 function descriptorForField(elementDesc: ElementDescriptor): ElementDescriptor {
-  let { key, kind, initializer } = elementDesc as ElementDescriptor;
+  let { key, kind, initializer } = elementDesc;
 
   assert(
     `You attempted to use @tracked on ${key}, but that element is not a class field. @tracked is only usable on class fields. Native getters and setters will autotrack add any tracked fields they encounter, so there is no need mark getters and setters with @tracked.`,

--- a/packages/@ember/-internals/metal/tests/computed_decorator_test.js
+++ b/packages/@ember/-internals/metal/tests/computed_decorator_test.js
@@ -133,6 +133,26 @@ if (EMBER_NATIVE_DECORATOR_SUPPORT) {
           new Foo();
         }, /Attempted to apply a computed property that already has a getter\/setter to a foo, but it is a method or an accessor./);
       }
+
+      ['@test it throws if a CP is passed to it']() {
+        expectAssertion(() => {
+          class Foo {
+            bar;
+
+            @computed(
+              'bar',
+              computed({
+                get() {
+                  return this._foo;
+                },
+              })
+            )
+            foo;
+          }
+
+          new Foo();
+        }, 'You attempted to pass a computed property instance to computed(). Computed property instances are decorator functions, and cannot be passed to computed() because they cannot be turned into decorators twice');
+      }
     }
   );
 
@@ -154,7 +174,7 @@ if (EMBER_NATIVE_DECORATOR_SUPPORT) {
 
       ['@test computed property works with a getter'](assert) {
         class TestObj {
-          @computed()
+          @computed
           get someGetter() {
             return true;
           }
@@ -271,6 +291,19 @@ if (EMBER_NATIVE_DECORATOR_SUPPORT) {
 
         assert.equal(set(obj, 'foo', 'bar'), 'bar', 'should return set value with set()');
         assert.equal(count, 0, 'should not have invoked getter');
+      }
+
+      ['@test throws if a value is decorated twice']() {
+        expectAssertion(() => {
+          class Obj {
+            @computed
+            @computed
+            get foo() {
+              return this._foo;
+            }
+          }
+          new Obj();
+        }, "Only one computed property decorator can be applied to a class field or accessor, but 'foo' was decorated twice. You may have added the decorator to both a getter and setter, which is unecessary.");
       }
     }
   );

--- a/packages/@ember/-internals/metal/tests/injected_property_test.js
+++ b/packages/@ember/-internals/metal/tests/injected_property_test.js
@@ -6,12 +6,12 @@ moduleFor(
   'inject',
   class extends AbstractTestCase {
     ['@test injected properties should be descriptors'](assert) {
-      assert.ok(isComputedDecorator(inject()));
+      assert.ok(isComputedDecorator(inject('type')));
     }
 
     ['@test injected properties should be overridable'](assert) {
       let obj = {};
-      defineProperty(obj, 'foo', inject());
+      defineProperty(obj, 'foo', inject('type'));
 
       set(obj, 'foo', 'bar');
 

--- a/packages/@ember/-internals/runtime/tests/inject_test.js
+++ b/packages/@ember/-internals/runtime/tests/inject_test.js
@@ -1,4 +1,5 @@
 import { inject } from '@ember/-internals/metal';
+import { EMBER_NATIVE_DECORATOR_SUPPORT } from '@ember/canary-features';
 import { DEBUG } from '@glimmer/env';
 import EmberObject from '../lib/system/object';
 import { buildOwner } from 'internal-test-helpers';
@@ -49,3 +50,48 @@ moduleFor(
     }
   }
 );
+
+if (EMBER_NATIVE_DECORATOR_SUPPORT) {
+  moduleFor(
+    'inject - decorator',
+    class extends AbstractTestCase {
+      ['@test works with native decorators'](assert) {
+        let owner = buildOwner();
+
+        class Service extends EmberObject {}
+
+        class Foo extends EmberObject {
+          @inject('service', 'main') main;
+        }
+
+        owner.register('service:main', Service);
+        owner.register('foo:main', Foo);
+
+        let foo = owner.lookup('foo:main');
+
+        assert.ok(foo.main instanceof Service, 'service injected correctly');
+      }
+
+      ['@test uses the decorated property key if not provided'](assert) {
+        let owner = buildOwner();
+
+        function service() {
+          return inject('service', ...arguments);
+        }
+
+        class Service extends EmberObject {}
+
+        class Foo extends EmberObject {
+          @service main;
+        }
+
+        owner.register('service:main', Service);
+        owner.register('foo:main', Foo);
+
+        let foo = owner.lookup('foo:main');
+
+        assert.ok(foo.main instanceof Service, 'service injected correctly');
+      }
+    }
+  );
+}

--- a/packages/@ember/controller/index.js
+++ b/packages/@ember/controller/index.js
@@ -1,6 +1,6 @@
 import { Object as EmberObject } from '@ember/-internals/runtime';
-import ControllerMixin from './lib/controller_mixin';
 import { inject as metalInject } from '@ember/-internals/metal';
+import ControllerMixin from './lib/controller_mixin';
 
 /**
 @module @ember/controller
@@ -40,11 +40,11 @@ const Controller = EmberObject.extend(ControllerMixin);
   @since 1.10.0
   @param {String} name (optional) name of the controller to inject, defaults
          to the property's name
-  @return {Ember.InjectedProperty} injection descriptor instance
+  @return {ComputedDecorator} injection decorator instance
   @public
 */
-export function inject(name, options) {
-  return metalInject('controller', name, options);
+export function inject(nameOrDesc, options) {
+  return metalInject('controller', nameOrDesc, options);
 }
 
 export default Controller;

--- a/packages/@ember/service/index.js
+++ b/packages/@ember/service/index.js
@@ -35,11 +35,11 @@ import { inject as metalInject } from '@ember/-internals/metal';
   @for @ember/service
   @param {String} name (optional) name of the service to inject, defaults to
          the property's name
-  @return {Ember.InjectedProperty} injection descriptor instance
+  @return {ComputedDecorator} injection decorator instance
   @public
 */
-export function inject(name, options) {
-  return metalInject('service', name, options);
+export function inject(nameOrDesc, options) {
+  return metalInject('service', nameOrDesc, options);
 }
 
 /**


### PR DESCRIPTION
This upstreams a couple of helpful assertions from ember-decorators,
and also adds the ability to call `@service`, `@controller`, and
`@computed` without parens (only in native)