### PR TITLE
[FEAT] Adds autotracked to the the Glimmer references system

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
@@ -1,0 +1,257 @@
+import { EMBER_METAL_TRACKED_PROPERTIES } from '@ember/canary-features';
+import { Object as EmberObject } from '@ember/-internals/runtime';
+import { tracked, nativeDescDecorator as descriptor } from '@ember/-internals/metal';
+import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
+
+import { Component } from '../../utils/helpers';
+
+if (EMBER_METAL_TRACKED_PROPERTIES) {
+  moduleFor(
+    'Component Tracked Properties',
+    class extends RenderingTestCase {
+      '@test tracked properties rerender when updated'() {
+        let CountComponent = Component.extend({
+          count: tracked({ value: 0 }),
+
+          increment() {
+            this.count++;
+          },
+        });
+
+        this.registerComponent('counter', {
+          ComponentClass: CountComponent,
+          template: '<button {{action this.increment}}>{{this.count}}</button>',
+        });
+
+        this.render('<Counter />');
+
+        this.assertText('0');
+
+        runTask(() => this.$('button').click());
+
+        this.assertText('1');
+      }
+
+      '@test nested tracked properties rerender when updated'() {
+        let Counter = EmberObject.extend({
+          count: tracked({ value: 0 }),
+        });
+
+        let CountComponent = Component.extend({
+          counter: Counter.create(),
+
+          increment() {
+            this.counter.count++;
+          },
+        });
+
+        this.registerComponent('counter', {
+          ComponentClass: CountComponent,
+          template: '<button {{action this.increment}}>{{this.counter.count}}</button>',
+        });
+
+        this.render('<Counter />');
+
+        this.assertText('0');
+
+        runTask(() => this.$('button').click());
+
+        this.assertText('1');
+      }
+
+      '@test getters update when dependent properties are invalidated'() {
+        let CountComponent = Component.extend({
+          count: tracked({ value: 0 }),
+
+          countAlias: descriptor({
+            get() {
+              return this.count;
+            },
+          }),
+
+          increment() {
+            this.count++;
+          },
+        });
+
+        this.registerComponent('counter', {
+          ComponentClass: CountComponent,
+          template: '<button {{action this.increment}}>{{this.countAlias}}</button>',
+        });
+
+        this.render('<Counter />');
+
+        this.assertText('0');
+
+        runTask(() => this.$('button').click());
+
+        this.assertText('1');
+      }
+
+      '@test nested getters update when dependent properties are invalidated'() {
+        let Counter = EmberObject.extend({
+          count: tracked({ value: 0 }),
+
+          countAlias: descriptor({
+            get() {
+              return this.count;
+            },
+          }),
+        });
+
+        let CountComponent = Component.extend({
+          counter: Counter.create(),
+
+          increment() {
+            this.counter.count++;
+          },
+        });
+
+        this.registerComponent('counter', {
+          ComponentClass: CountComponent,
+          template: '<button {{action this.increment}}>{{this.counter.countAlias}}</button>',
+        });
+
+        this.render('<Counter />');
+
+        this.assertText('0');
+
+        runTask(() => this.$('button').click());
+
+        this.assertText('1');
+      }
+
+      '@test tracked object passed down through components updates correctly'(assert) {
+        let Person = EmberObject.extend({
+          first: tracked({ value: 'Rob' }),
+          last: tracked({ value: 'Jackson' }),
+
+          full: descriptor({
+            get() {
+              return `${this.first} ${this.last}`;
+            },
+          }),
+        });
+
+        let ParentComponent = Component.extend({
+          person: Person.create(),
+        });
+
+        let ChildComponent = Component.extend({
+          updatePerson() {
+            this.person.first = 'Kris';
+            this.person.last = 'Selden';
+          },
+        });
+
+        this.registerComponent('parent', {
+          ComponentClass: ParentComponent,
+          template: strip`
+            <div id="parent">{{this.person.full}}</div>
+            <Child @person={{this.person}}/>
+          `,
+        });
+
+        this.registerComponent('child', {
+          ComponentClass: ChildComponent,
+          template: strip`
+            <div id="child">{{this.person.full}}</div>
+            <button onclick={{action this.updatePerson}}></button>
+          `,
+        });
+
+        this.render('<Parent />');
+
+        assert.equal(this.$('#parent').text(), 'Rob Jackson');
+        assert.equal(this.$('#child').text(), 'Rob Jackson');
+
+        runTask(() => this.$('button').click());
+
+        assert.equal(this.$('#parent').text(), 'Kris Selden');
+        assert.equal(this.$('#child').text(), 'Kris Selden');
+      }
+
+      '@test yielded getters update correctly'() {
+        let PersonComponent = Component.extend({
+          first: tracked({ value: 'Rob' }),
+          last: tracked({ value: 'Jackson' }),
+
+          full: descriptor({
+            get() {
+              return `${this.first} ${this.last}`;
+            },
+          }),
+
+          updatePerson() {
+            this.first = 'Kris';
+            this.last = 'Selden';
+          },
+        });
+
+        this.registerComponent('person', {
+          ComponentClass: PersonComponent,
+          template: strip`
+            {{yield this.full (action this.updatePerson)}}
+          `,
+        });
+
+        this.render(strip`
+          <Person as |name update|>
+            <button onclick={{update}}>
+              {{name}}
+            </button>
+          </Person>
+        `);
+
+        this.assertText('Rob Jackson');
+
+        runTask(() => this.$('button').click());
+
+        this.assertText('Kris Selden');
+      }
+
+      '@test yielded nested getters update correctly'() {
+        let Person = EmberObject.extend({
+          first: tracked({ value: 'Rob' }),
+          last: tracked({ value: 'Jackson' }),
+
+          full: descriptor({
+            get() {
+              return `${this.first} ${this.last}`;
+            },
+          }),
+        });
+
+        let PersonComponent = Component.extend({
+          person: Person.create(),
+
+          updatePerson() {
+            this.person.first = 'Kris';
+            this.person.last = 'Selden';
+          },
+        });
+
+        this.registerComponent('person', {
+          ComponentClass: PersonComponent,
+          template: strip`
+            {{yield this.person (action this.updatePerson)}}
+          `,
+        });
+
+        this.render(strip`
+          <Person as |p update|>
+            <button onclick={{update}}>
+              {{p.full}}
+            </button>
+          </Person>
+        `);
+
+        this.assertText('Rob Jackson');
+
+        runTask(() => this.$('button').click());
+
+        this.assertText('Kris Selden');
+      }
+    }
+  );
+}

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
@@ -1,0 +1,185 @@
+import { EMBER_METAL_TRACKED_PROPERTIES } from '@ember/canary-features';
+import { Object as EmberObject } from '@ember/-internals/runtime';
+import { tracked, nativeDescDecorator as descriptor } from '@ember/-internals/metal';
+import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
+
+import { Component } from '../../utils/helpers';
+
+if (EMBER_METAL_TRACKED_PROPERTIES) {
+  moduleFor(
+    'Helper Tracked Properties',
+    class extends RenderingTestCase {
+      '@test tracked properties rerender when updated'(assert) {
+        let computeCount = 0;
+
+        let PersonComponent = Component.extend({
+          name: tracked({ value: 'bob' }),
+
+          updateName() {
+            this.name = 'sal';
+          },
+        });
+
+        this.registerComponent('person', {
+          ComponentClass: PersonComponent,
+          template: strip`
+            <button onclick={{action this.updateName}}>
+              {{hello-world this.name}}
+            </button>
+          `,
+        });
+
+        this.registerHelper('hello-world', ([value]) => {
+          computeCount++;
+          return `${value}-value`;
+        });
+
+        this.render('<Person/>');
+
+        this.assertText('bob-value');
+
+        assert.strictEqual(computeCount, 1, 'compute is called exactly 1 time');
+
+        runTask(() => this.rerender());
+
+        this.assertText('bob-value');
+
+        assert.strictEqual(computeCount, 1, 'compute is called exactly 1 time');
+
+        runTask(() => this.$('button').click());
+
+        this.assertText('sal-value');
+
+        assert.strictEqual(computeCount, 2, 'compute is called exactly 2 times');
+      }
+
+      '@test nested tracked properties rerender when updated'(assert) {
+        let computeCount = 0;
+
+        let Person = EmberObject.extend({
+          name: tracked({ value: 'bob' }),
+        });
+
+        this.registerHelper('hello-world', ([value]) => {
+          computeCount++;
+          return `${value}-value`;
+        });
+
+        this.render('{{hello-world model.name}}', {
+          model: Person.create(),
+        });
+
+        this.assertText('bob-value');
+
+        assert.strictEqual(computeCount, 1, 'compute is called exactly 1 time');
+
+        runTask(() => this.rerender());
+
+        this.assertText('bob-value');
+
+        assert.strictEqual(computeCount, 1, 'compute is called exactly 1 time');
+
+        runTask(() => (this.context.model.name = 'sal'));
+
+        this.assertText('sal-value');
+
+        assert.strictEqual(computeCount, 2, 'compute is called exactly 2 times');
+      }
+
+      '@test getters update when dependent properties are invalidated'(assert) {
+        let computeCount = 0;
+
+        let PersonComponent = Component.extend({
+          first: tracked({ value: 'Rob' }),
+          last: tracked({ value: 'Jackson' }),
+
+          full: descriptor({
+            get() {
+              return `${this.first} ${this.last}`;
+            },
+          }),
+
+          updatePerson() {
+            this.first = 'Kris';
+            this.last = 'Selden';
+          },
+        });
+
+        this.registerComponent('person', {
+          ComponentClass: PersonComponent,
+          template: strip`
+            <button onclick={{action this.updatePerson}}>
+              {{hello-world this.full}}
+            </button>
+          `,
+        });
+
+        this.registerHelper('hello-world', ([value]) => {
+          computeCount++;
+          return value;
+        });
+
+        this.render('<Person/>');
+
+        this.assertText('Rob Jackson');
+
+        assert.strictEqual(computeCount, 1, 'compute is called exactly 1 time');
+
+        runTask(() => this.rerender());
+
+        this.assertText('Rob Jackson');
+
+        assert.strictEqual(computeCount, 1, 'compute is called exactly 1 time');
+
+        runTask(() => this.$('button').click());
+
+        this.assertText('Kris Selden');
+
+        assert.strictEqual(computeCount, 2, 'compute is called exactly 2 times');
+      }
+
+      '@test nested getters update when dependent properties are invalidated'(assert) {
+        let computeCount = 0;
+
+        let Person = EmberObject.extend({
+          first: tracked({ value: 'Rob' }),
+          last: tracked({ value: 'Jackson' }),
+
+          full: descriptor({
+            get() {
+              return `${this.first} ${this.last}`;
+            },
+          }),
+        });
+
+        this.registerHelper('hello-world', ([value]) => {
+          computeCount++;
+          return value;
+        });
+
+        this.render('{{hello-world model.full}}', {
+          model: Person.create(),
+        });
+
+        this.assertText('Rob Jackson');
+
+        assert.strictEqual(computeCount, 1, 'compute is called exactly 1 time');
+
+        runTask(() => this.rerender());
+
+        this.assertText('Rob Jackson');
+
+        assert.strictEqual(computeCount, 1, 'compute is called exactly 1 time');
+
+        runTask(() => {
+          this.context.model.first = 'Kris';
+          this.context.model.last = 'Selden';
+        });
+
+        this.assertText('Kris Selden');
+
+        assert.strictEqual(computeCount, 2, 'compute is called exactly 2 times');
+      }
+    }
+  );
+}


### PR DESCRIPTION
This PR adds autotracking around property references in Glimmer-Ember,
and adds high level acceptance tests that verify that it's working for
both components and helpers. This does _not_ test the behavior of
autotracking around modifiers, which is still ill-defined.

Note that while eventually simplifications may be possible, even
removing nested references altogether, currently it is not due to
two-way binding. Components that use two-way binding need to be able to
update a nested property reference, which means we need to store that
information somewhere accessible. It may still be possible to do this
only in cases where it is necessary (e.g. binding to a component's
arguments) but for the time being, this a smaller and iterative
approach.