### PR TITLE
 [FEAT] Adds tracking logic to `ArrayMixin#objectAt`

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
@@ -1,5 +1,5 @@
 import { EMBER_METAL_TRACKED_PROPERTIES } from '@ember/canary-features';
-import { Object as EmberObject } from '@ember/-internals/runtime';
+import { A, Object as EmberObject } from '@ember/-internals/runtime';
 import { tracked, nativeDescDecorator as descriptor } from '@ember/-internals/metal';
 import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
 
@@ -251,6 +251,46 @@ if (EMBER_METAL_TRACKED_PROPERTIES) {
         runTask(() => this.$('button').click());
 
         this.assertText('Kris Selden');
+      }
+    }
+  );
+
+  moduleFor(
+    'Arrays Tracked Properties',
+    class extends RenderingTestCase {
+      '@test getters update when arrays are mutated'() {
+        let nums = A([0]);
+
+        let NumListComponent = Component.extend({
+          nums,
+
+          joined: descriptor({
+            get() {
+              let s = '';
+
+              for (let i = 0; i < this.nums.length; i++) {
+                s += this.nums.objectAt(i);
+              }
+
+              return s;
+            },
+          }),
+        });
+
+        this.registerComponent('num-list', {
+          ComponentClass: NumListComponent,
+          template: '{{this.joined}}',
+        });
+
+        window._testStarted = true;
+
+        this.render('<NumList />');
+
+        this.assertText('0');
+
+        runTask(() => nums.pushObject(1));
+
+        this.assertText('01');
       }
     }
   );

--- a/packages/@ember/-internals/runtime/lib/mixins/array.js
+++ b/packages/@ember/-internals/runtime/lib/mixins/array.js
@@ -19,7 +19,10 @@ import {
   removeArrayObserver,
   arrayContentWillChange,
   arrayContentDidChange,
+  tagForProperty,
+  getCurrentTracker,
 } from '@ember/-internals/metal';
+import { EMBER_METAL_TRACKED_PROPERTIES } from '@ember/canary-features';
 import { assert, deprecate } from '@ember/debug';
 import Enumerable from './enumerable';
 import compare from '../compare';
@@ -256,6 +259,12 @@ const ArrayMixin = Mixin.create(Enumerable, {
     @return {*} item at index or undefined
     @public
   */
+  objectAt() {
+    if (EMBER_METAL_TRACKED_PROPERTIES) {
+      let tracker = getCurrentTracker();
+      if (tracker) tracker.add(tagForProperty(this, '[]'));
+    }
+  },
 
   /**
     This returns the objects at the specified indexes, using `objectAt`.
@@ -1572,6 +1581,7 @@ const MutableArray = Mixin.create(ArrayMixin, MutableEnumerable, {
 */
 let NativeArray = Mixin.create(MutableArray, Observable, {
   objectAt(idx) {
+    this._super();
     return this[idx];
   },
 

--- a/packages/@ember/-internals/runtime/lib/system/array_proxy.js
+++ b/packages/@ember/-internals/runtime/lib/system/array_proxy.js
@@ -162,29 +162,6 @@ export default class ArrayProxy extends EmberObject {
     get(this, 'content').replace(idx, amt, objects);
   }
 
-  // Overriding objectAt is not supported.
-  objectAt(idx) {
-    if (this._objects === null) {
-      this._objects = [];
-    }
-
-    if (this._objectsDirtyIndex !== -1 && idx >= this._objectsDirtyIndex) {
-      let arrangedContent = get(this, 'arrangedContent');
-      if (arrangedContent) {
-        let length = (this._objects.length = get(arrangedContent, 'length'));
-
-        for (let i = this._objectsDirtyIndex; i < length; i++) {
-          this._objects[i] = this.objectAtContent(i);
-        }
-      } else {
-        this._objects.length = 0;
-      }
-      this._objectsDirtyIndex = -1;
-    }
-
-    return this._objects[idx];
-  }
-
   // Overriding length is not supported.
   get length() {
     if (this._lengthDirty) {
@@ -291,4 +268,29 @@ ArrayProxy.reopen(MutableArray, {
     @public
   */
   arrangedContent: alias('content'),
+
+  // Overriding objectAt is not supported.
+  objectAt(idx) {
+    this._super();
+
+    if (this._objects === null) {
+      this._objects = [];
+    }
+
+    if (this._objectsDirtyIndex !== -1 && idx >= this._objectsDirtyIndex) {
+      let arrangedContent = get(this, 'arrangedContent');
+      if (arrangedContent) {
+        let length = (this._objects.length = get(arrangedContent, 'length'));
+
+        for (let i = this._objectsDirtyIndex; i < length; i++) {
+          this._objects[i] = this.objectAtContent(i);
+        }
+      } else {
+        this._objects.length = 0;
+      }
+      this._objectsDirtyIndex = -1;
+    }
+
+    return this._objects[idx];
+  },
 });


### PR DESCRIPTION
This PR adds tracking logic to `ArrayMixin#objectAt`. This will allow implementers of the EmberArray interface to automatically have KVO compliant changes be tracked. Note that this implementation will not do much for `emberA()` since it wraps native arrays, and does _not_ replace many methods that would have to be intercepted to get the same effect (`map`, `join`, `forEach`, etc). If we want to support `emberA()`, we can:

1. Use a native Proxy in modern browser to wrap all methods
2.  Manually wrap all methods in IE11/older browsers.

I decided to go with the more minimal approach here, since we could also do this as an addon (`trackedA()`). However, it _is_ important that `ArrayMixin` has some way to entangle it's `[]` tag with the autotrack stack for Ember Data at least.

Depends on #17634