### PR TITLE
[DOC release] Documented tagless component behavior

### DIFF
--- a/packages/@ember/-internals/views/lib/mixins/view_support.js
+++ b/packages/@ember/-internals/views/lib/mixins/view_support.js
@@ -367,6 +367,12 @@ let mixin = {
    must destroy and recreate the view element.
 
    By default, the render buffer will use a `<div>` tag for views.
+   
+   If the tagName is `''`, the view will be tagless, with no outer element.
+   Component properties that depend on the presence of an outer element, such
+   as `classNameBindings` and `attributeBindings`, do not work with tagless
+   components. Tagless components cannot implement methods to handle events,
+   and have no associated jQuery object to return with `$()`.
 
    @property tagName
    @type String


### PR DESCRIPTION
Detailed how components with an empty string tagName property behave.

@jenweber suggested that the API docs should cover the whole supported API surface, and while tagless components may be an anti-pattern, they are part of the API surface and their functionality is explicitly tested for. 