### PR TITLE
Add missing blueprints for MU `dummy` app.

### DIFF
--- a/blueprints/helper/index.js
+++ b/blueprints/helper/index.js
@@ -21,7 +21,7 @@ module.exports = {
           }
 
           if (options.inDummy) {
-            throw new Error("The --dummy flag isn't supported within a module unification app");
+            return path.join('tests', 'dummy', 'src');
           }
 
           return 'src';
@@ -31,7 +31,7 @@ module.exports = {
             throw new Error("Pods aren't supported within a module unification app");
           }
 
-          return 'ui/components';
+          return path.join('ui', 'components');
         },
       };
     } else {

--- a/blueprints/mixin/index.js
+++ b/blueprints/mixin/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const isModuleUnificationProject = require('../module-unification').isModuleUnificationProject;
+const path = require('path');
 
 module.exports = {
   description: 'Generates a mixin.',
@@ -11,6 +12,10 @@ module.exports = {
         __root__(options) {
           if (options.pod) {
             throw new Error("Pods aren't supported within a module unification app");
+          }
+
+          if (options.inDummy) {
+            return path.join('tests', 'dummy', 'src');
           }
 
           return 'src';

--- a/blueprints/service/index.js
+++ b/blueprints/service/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const path = require('path');
 const useEditionDetector = require('../edition-detector');
 const isModuleUnificationProject = require('../module-unification').isModuleUnificationProject;
 
@@ -12,6 +13,10 @@ module.exports = useEditionDetector({
         __root__(options) {
           if (options.pod) {
             throw new Error("Pods aren't supported within a module unification app");
+          }
+
+          if (options.inDummy) {
+            return path.join('tests', 'dummy', 'src');
           }
 
           return 'src';

--- a/blueprints/util/index.js
+++ b/blueprints/util/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const path = require('path');
 const isModuleUnificationProject = require('../module-unification').isModuleUnificationProject;
 
 module.exports = {
@@ -11,6 +12,10 @@ module.exports = {
         __root__(options) {
           if (options.pod) {
             throw new Error("Pods aren't supported within a module unification app");
+          }
+
+          if (options.inDummy) {
+            return path.join('tests', 'dummy', 'src');
           }
 
           return 'src';

--- a/node-tests/blueprints/helper-test.js
+++ b/node-tests/blueprints/helper-test.js
@@ -185,6 +185,15 @@ describe('Blueprint: helper', function() {
         );
       });
     });
+
+    it('helper foo/bar-baz --dummy', function() {
+      return emberGenerateDestroy(['helper', 'foo/bar-baz', '--dummy'], _file => {
+        expect(_file('tests/dummy/src/ui/components/foo/bar-baz.js')).to.equal(
+          fixture('helper/helper.js')
+        );
+        expect(_file('src/ui/components/foo/bar-baz.js')).to.not.exist;
+      });
+    });
   });
 
   describe('in in-repo-addon', function() {

--- a/node-tests/blueprints/mixin-test.js
+++ b/node-tests/blueprints/mixin-test.js
@@ -213,6 +213,16 @@ describe('Blueprint: mixin', function() {
         expect(_file('app/mixins/foo/bar/baz.js')).to.not.exist;
       });
     });
+
+    it('mixin foo/bar/baz --dummy', function() {
+      return emberGenerateDestroy(['mixin', 'foo/bar/baz', '--dummy'], _file => {
+        expect(_file('tests/dummy/app/mixins/foo/bar/baz.js'))
+          .to.contain("import Mixin from '@ember/object/mixin';")
+          .to.contain('export default Mixin.create({\n});');
+
+        expect(_file('addon/mixins/foo/bar/baz.js')).to.not.exist;
+      });
+    });
   });
 
   describe('in addon - module unification', function() {
@@ -255,6 +265,16 @@ describe('Blueprint: mixin', function() {
         expect(_file('src/mixins/foo/bar/baz-test.js')).to.contain(
           "import FooBarBazMixin from 'my-addon/mixins/foo/bar/baz';"
         );
+      });
+    });
+
+    it('mixin foo/bar/baz --dummy', function() {
+      return emberGenerateDestroy(['mixin', 'foo/bar/baz', '--dummy'], _file => {
+        expect(_file('tests/dummy/src/mixins/foo/bar/baz.js'))
+          .to.contain("import Mixin from '@ember/object/mixin';")
+          .to.contain('export default Mixin.create({\n});');
+
+        expect(_file('src/mixins/foo/bar/baz.js')).to.not.exist;
       });
     });
   });

--- a/node-tests/blueprints/service-test.js
+++ b/node-tests/blueprints/service-test.js
@@ -223,6 +223,15 @@ describe('Blueprint: service', function() {
         );
       });
     });
+
+    it('service foo/bar --dummy', function() {
+      return emberGenerateDestroy(['service', 'foo/bar', '--dummy'], _file => {
+        expect(_file('tests/dummy/app/services/foo/bar.js')).to.equal(
+          fixture('service/service-nested.js')
+        );
+        expect(_file('addon/services/foo/bar.js')).to.not.exist;
+      });
+    });
   });
 
   describe('in addon - module unification', function() {
@@ -258,6 +267,15 @@ describe('Blueprint: service', function() {
         );
 
         expect(_file('app/services/foo/bar.js')).to.not.exist;
+      });
+    });
+
+    it('service foo/bar --dummy', function() {
+      return emberGenerateDestroy(['service', 'foo/bar', '--dummy'], _file => {
+        expect(_file('tests/dummy/src/services/foo/bar.js')).to.equal(
+          fixture('service/service-nested.js')
+        );
+        expect(_file('src/services/foo/bar.js')).to.not.exist;
       });
     });
   });
@@ -297,6 +315,16 @@ describe('Blueprint: service', function() {
         );
 
         expect(_file('app/services/foo/bar.js')).to.not.exist;
+      });
+    });
+
+    it('service foo/bar --dummy', function() {
+      return emberGenerateDestroy(['service', 'foo/bar', '--dummy'], _file => {
+        expect(_file('tests/dummy/src/services/foo/bar.js')).to.equal(
+          fixture('service/native-service-nested.js')
+        );
+
+        expect(_file('src/services/foo/bar.js')).to.not.exist;
       });
     });
   });

--- a/node-tests/blueprints/util-test.js
+++ b/node-tests/blueprints/util-test.js
@@ -164,6 +164,16 @@ describe('Blueprint: util', function() {
         );
       });
     });
+
+    it('util foo/bar-baz --dummy', function() {
+      return emberGenerateDestroy(['util', 'foo/bar-baz', '--dummy'], _file => {
+        expect(_file('tests/dummy/app/utils/foo/bar-baz.js')).to.equal(
+          fixture('util/util-nested.js')
+        );
+
+        expect(_file('addon/utils/foo/bar-baz.js')).to.not.exist;
+      });
+    });
   });
 
   describe('in addon - module unification', function() {
@@ -199,6 +209,16 @@ describe('Blueprint: util', function() {
         );
 
         expect(_file('app/utils/foo/bar-baz.js')).to.not.exist;
+      });
+    });
+
+    it('util foo/bar-baz --dummy', function() {
+      return emberGenerateDestroy(['util', 'foo/bar-baz', '--dummy'], _file => {
+        expect(_file('tests/dummy/src/utils/foo/bar-baz.js')).to.equal(
+          fixture('util/util-nested.js')
+        );
+
+        expect(_file('src/utils/foo/bar-baz.js')).to.not.exist;
       });
     });
   });


### PR DESCRIPTION
Closes #17656

Fix the following commands for MU `dummy` apps:

- [x] `ember g helper hola --dummy`
- [x] `ember g mixin hola --dummy`
- [x] `ember g service hola --dummy`
- [x] `ember g util hola --dummy`