### PR TITLE
[BUGFIX canary] Ensure @tracked setter triggers a revalidation.

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
@@ -32,6 +32,37 @@ if (EMBER_METAL_TRACKED_PROPERTIES) {
         this.assertText('1');
       }
 
+      '@test tracked properties rerender when updated outside of a runloop'(assert) {
+        let done = assert.async();
+
+        let CountComponent = Component.extend({
+          count: tracked({ value: 0 }),
+
+          increment() {
+            setTimeout(() => {
+              this.count++;
+            }, 100);
+          },
+        });
+
+        this.registerComponent('counter', {
+          ComponentClass: CountComponent,
+          template: '<button {{action this.increment}}>{{this.count}}</button>',
+        });
+
+        this.render('<Counter />');
+
+        this.assertText('0');
+
+        // intentionally outside of a runTask
+        this.$('button').click();
+
+        setTimeout(() => {
+          this.assertText('1');
+          done();
+        }, 200);
+      }
+
       '@test nested tracked properties rerender when updated'() {
         let Counter = EmberObject.extend({
           count: tracked({ value: 0 }),

--- a/packages/@ember/-internals/metal/lib/tags.ts
+++ b/packages/@ember/-internals/metal/lib/tags.ts
@@ -94,7 +94,7 @@ export function markObjectAsDirty(obj: object, propertyKey: string, meta: Meta):
   }
 }
 
-function ensureRunloop(): void {
+export function ensureRunloop(): void {
   if (hasViews()) {
     backburner.ensureInstance();
   }

--- a/packages/@ember/-internals/metal/lib/tracked.ts
+++ b/packages/@ember/-internals/metal/lib/tracked.ts
@@ -4,7 +4,7 @@ import { DEBUG } from '@glimmer/env';
 import { combine, CONSTANT_TAG, Tag } from '@glimmer/reference';
 import { Decorator, ElementDescriptor } from './decorator';
 import { setComputedDecorator } from './descriptor_map';
-import { dirty, tagFor, tagForProperty } from './tags';
+import { dirty, ensureRunloop, tagFor, tagForProperty } from './tags';
 
 type Option<T> = T | null;
 
@@ -255,7 +255,7 @@ export interface Interceptors {
   [key: string]: boolean;
 }
 
-let propertyDidChange = function(): void {};
+let propertyDidChange = ensureRunloop;
 
 export function setPropertyDidChange(cb: () => void): void {
   propertyDidChange = cb;


### PR DESCRIPTION
Prior to this change, setting a tracked property when there was on ambient runloop would never schedule a revalidation and would therefore never rerender.

This change ensures that _any_ set of a `@Tracked` property will enqueue a revalidation regardless if there is a current runloop or not.