### PR TITLE
Remove `hasViews` guard.

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/renderer.ts
@@ -1,4 +1,4 @@
-import { runInTransaction, setHasViews } from '@ember/-internals/metal';
+import { runInTransaction } from '@ember/-internals/metal';
 import {
   fallbackViewRegistry,
   getViewElement,
@@ -168,8 +168,6 @@ const renderers: Renderer[] = [];
 export function _resetRenderers() {
   renderers.length = 0;
 }
-
-setHasViews(() => renderers.length > 0);
 
 function register(renderer: Renderer): void {
   assert('Cannot register the same renderer twice', renderers.indexOf(renderer) === -1);
@@ -401,7 +399,7 @@ export abstract class Renderer {
 
   _renderRoots() {
     let { _roots: roots, _env: env, _removedRoots: removedRoots } = this;
-    let globalShouldReflush: boolean;
+    let globalShouldReflush = false;
     let initialRootsLength: number;
 
     do {

--- a/packages/@ember/-internals/metal/index.ts
+++ b/packages/@ember/-internals/metal/index.ts
@@ -47,7 +47,7 @@ export { default as expandProperties } from './lib/expand_properties';
 export { addObserver, removeObserver } from './lib/observer';
 export { Mixin, aliasMethod, mixin, observer, applyMixin } from './lib/mixin';
 export { default as inject, DEBUG_INJECTION_FUNCTIONS } from './lib/injected_property';
-export { setHasViews, tagForProperty, tagFor, markObjectAsDirty } from './lib/tags';
+export { tagForProperty, tagFor, markObjectAsDirty } from './lib/tags';
 export { default as runInTransaction, didRender, assertNotRendered } from './lib/transaction';
 export { tracked, getCurrentTracker, setCurrentTracker } from './lib/tracked';
 

--- a/packages/@ember/-internals/metal/lib/tags.ts
+++ b/packages/@ember/-internals/metal/lib/tags.ts
@@ -11,12 +11,6 @@ import {
   UpdatableTag,
 } from '@glimmer/reference';
 
-let hasViews: () => boolean = () => false;
-
-export function setHasViews(fn: () => boolean): void {
-  hasViews = fn;
-}
-
 function makeTag(): TagWrapper<DirtyableTag> {
   return DirtyableTag.create();
 }
@@ -95,7 +89,5 @@ export function markObjectAsDirty(obj: object, propertyKey: string, meta: Meta):
 }
 
 export function ensureRunloop(): void {
-  if (hasViews()) {
-    backburner.ensureInstance();
-  }
+  backburner.ensureInstance();
 }

--- a/packages/@ember/-internals/metal/tests/accessors/set_test.js
+++ b/packages/@ember/-internals/metal/tests/accessors/set_test.js
@@ -1,13 +1,9 @@
-import { get, set, trySet, setHasViews } from '../..';
+import { get, set, trySet } from '../..';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 moduleFor(
   'set',
   class extends AbstractTestCase {
-    teardown() {
-      setHasViews(() => false);
-    }
-
     ['@test should set arbitrary properties on an object'](assert) {
       let obj = {
         string: 'string',
@@ -110,7 +106,6 @@ moduleFor(
     }
 
     ['@test does not trigger auto-run assertion for objects that have not been tagged'](assert) {
-      setHasViews(() => true);
       let obj = {};
 
       set(obj, 'foo', 'bar');


### PR DESCRIPTION
This was originally added to ensure that we did not accidentally trigger
the auto-run assertion if we didn't have any components/views rendered.

However, as of Ember 3.4+ the autorun assertion is removed, making this
system completely useless and over complicates the remaining code.

Paired with @krisselden 