### PR TITLE
[BUGFIX lts] Enable maximum rerendering limit to be customized.

### DIFF
--- a/packages/@ember/-internals/environment/lib/env.ts
+++ b/packages/@ember/-internals/environment/lib/env.ts
@@ -111,6 +111,19 @@ export const ENV = {
   */
   _JQUERY_INTEGRATION: true,
 
+  /**
+    Controls the maximum number of scheduled rerenders without "settling". In general,
+    applications should not need to modify this environment variable, but please
+    open an issue so that we can determine if a better default value is needed.
+
+    @property _RERENDER_LOOP_LIMIT
+    @for EmberENV
+    @type number
+    @default 1000
+    @private
+   */
+  _RERENDER_LOOP_LIMIT: 1000,
+
   EMBER_LOAD_HOOKS: {} as {
     [hook: string]: Function[];
   },

--- a/packages/@ember/-internals/glimmer/lib/renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/renderer.ts
@@ -1,3 +1,4 @@
+import { ENV } from '@ember/-internals/environment';
 import { runInTransaction } from '@ember/-internals/metal';
 import {
   fallbackViewRegistry,
@@ -227,7 +228,7 @@ let loops = 0;
 function loopEnd() {
   for (let i = 0; i < renderers.length; i++) {
     if (!renderers[i]._isValid()) {
-      if (loops > 10) {
+      if (loops > ENV._RERENDER_LOOP_LIMIT) {
         loops = 0;
         // TODO: do something better
         renderers[i].destroy();

--- a/tests/docs/expected.js
+++ b/tests/docs/expected.js
@@ -10,6 +10,7 @@ module.exports = {
     '[]',
     '_APPLICATION_TEMPLATE_WRAPPER',
     '_JQUERY_INTEGRATION',
+    '_RERENDER_LOOP_LIMIT',
     '_TEMPLATE_ONLY_GLIMMER_COMPONENTS',
     '__container__',
     '_activeQPChanged',


### PR DESCRIPTION
As of Ember 3.4 the autorun assertion is removed, and usage of native promises has increase the likely hood that this rerender limit of 10 will be hit in "normal" scenarios.

Co-authored-by: Kris Selden