### PR TITLE
Angle bracket blueprint

### DIFF
--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -11,9 +11,8 @@ const isModuleUnificationProject = require('../module-unification').isModuleUnif
 function needsCurlyBracketInvocation(options) {
   let path = options.path || '';
   let fullPaths = [...path.split('/'), ...options.entity.name.split('/')];
-  let ignoreClassicPrefix = !options.pod && options.path !== 'components';
   let ignoreCommonPrefix = ['', 'components'].includes(fullPaths[0]);
-  if (ignoreClassicPrefix || ignoreCommonPrefix) fullPaths.shift();
+  if (ignoreCommonPrefix) fullPaths.shift();
   return fullPaths.length > 1;
 }
 

--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -8,6 +8,15 @@ const getPathOption = require('ember-cli-get-component-path-option');
 const useTestFrameworkDetector = require('../test-framework-detector');
 const isModuleUnificationProject = require('../module-unification').isModuleUnificationProject;
 
+function needsCurlyBracketInvocation(options) {
+  let path = options.path || '';
+  let fullPaths = [...path.split('/'), ...options.entity.name.split('/')];
+  let ignoreClassicPrefix = !options.pod && options.path !== 'components';
+  let ignoreCommonPrefix = ['', 'components'].includes(fullPaths[0]);
+  if (ignoreClassicPrefix || ignoreCommonPrefix) fullPaths.shift();
+  return fullPaths.length > 1;
+}
+
 module.exports = useTestFrameworkDetector({
   description: 'Generates a component integration or unit test.',
 
@@ -72,7 +81,10 @@ module.exports = useTestFrameworkDetector({
   locals: function(options) {
     let dasherizedModuleName = stringUtil.dasherize(options.entity.name);
     let componentPathName = dasherizedModuleName;
+    let classifiedModuleName = stringUtil.classify(options.entity.name);
+    let templateInvocation = classifiedModuleName;
     let testType = options.testType || 'integration';
+    let componentName, openComponent, closeComponent, selfCloseComponent;
 
     let friendlyTestDescription = [
       testType === 'unit' ? 'Unit' : 'Integration',
@@ -85,15 +97,36 @@ module.exports = useTestFrameworkDetector({
     } else if (isModuleUnificationProject(this.project)) {
       if (options.inRepoAddon) {
         componentPathName = `${options.inRepoAddon}::${dasherizedModuleName}`;
+        templateInvocation = `${stringUtil.classify(options.inRepoAddon)}::${classifiedModuleName}`;
       } else if (this.project.isEmberCLIAddon()) {
         componentPathName = `${this.project.pkg.name}::${dasherizedModuleName}`;
+        templateInvocation = `${stringUtil.classify(
+          this.project.pkg.name
+        )}::${classifiedModuleName}`;
       }
+    }
+
+    if (needsCurlyBracketInvocation(options)) {
+      componentName = componentPathName;
+      openComponent = descriptor => `{{#${descriptor}}}`;
+      closeComponent = descriptor => `{{/${descriptor}}}`;
+      selfCloseComponent = descriptor => `{{${descriptor}}}`;
+    } else {
+      componentName = templateInvocation;
+      openComponent = descriptor => `<${descriptor}>`;
+      closeComponent = descriptor => `</${descriptor}>`;
+      selfCloseComponent = descriptor => `<${descriptor} />`;
     }
 
     return {
       path: getPathOption(options),
       testType: testType,
+      componentName: componentName,
       componentPathName: componentPathName,
+      templateInvocation: templateInvocation,
+      openComponent: openComponent,
+      closeComponent: closeComponent,
+      selfCloseComponent: selfCloseComponent,
       friendlyTestDescription: friendlyTestDescription,
     };
   },

--- a/blueprints/component-test/mocha-0.12-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/mocha-0.12-files/__root__/__testType__/__path__/__test__.js
@@ -13,15 +13,18 @@ describe('<%= friendlyTestDescription %>', function() {
   it('renders', function() {
     <% if (testType === 'integration' ) { %>// Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.on('myAction', function(val) { ... });
-    // Template block usage:
-    // this.render(hbs`
-    //   {{#<%= dasherizedModuleName %>}}
-    //     template content
-    //   {{/<%= dasherizedModuleName %>}}
-    // `);
 
-    this.render(hbs`{{<%= dasherizedModuleName %>}}`);
-    expect(this.$()).to.have.length(1);<% } else if(testType === 'unit') { %>// creates the component instance
+    this.render(hbs`<%= selfCloseComponent(componentName) %>`);
+    expect(this.$()).to.have.length(1);
+
+    // Template block usage:
+    this.render(hbs`
+      <%= openComponent(componentName) %>
+        template block text
+      <%= closeComponent(componentName) %>
+    `);
+
+    assert.equal(this.$().text().trim(), 'template block text');<% } else if(testType === 'unit') { %>// creates the component instance
     let component = this.subject();
     // renders the component on the page
     this.render();

--- a/blueprints/component-test/mocha-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/mocha-files/__root__/__testType__/__path__/__test__.js
@@ -12,15 +12,18 @@ describeComponent('<%= componentPathName %>', '<%= friendlyTestDescription %>',
     it('renders', function() {
       <% if (testType === 'integration' ) { %>// Set any properties with this.set('myProperty', 'value');
       // Handle any actions with this.on('myAction', function(val) { ... });
-      // Template block usage:
-      // this.render(hbs`
-      //   {{#<%= dasherizedModuleName %>}}
-      //     template content
-      //   {{/<%= dasherizedModuleName %>}}
-      // `);
 
-      this.render(hbs`{{<%= dasherizedModuleName %>}}`);
-      expect(this.$()).to.have.length(1);<% } else if(testType === 'unit') { %>// creates the component instance
+      this.render(hbs`<%= selfCloseComponent(componentName) %>`);
+      expect(this.$()).to.have.length(1);
+
+      // Template block usage:
+      this.render(hbs`
+        <%= openComponent(componentName) %>
+          template block text
+        <%= closeComponent(componentName) %>
+      `);
+
+      assert.equal(this.$().text().trim(), 'template block text');<% } else if(testType === 'unit') { %>// creates the component instance
       let component = this.subject();
       // renders the component on the page
       this.render();

--- a/blueprints/component-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -11,15 +11,15 @@ describe('<%= friendlyTestDescription %>', function() {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    await render(hbs`{{<%= componentPathName %>}}`);
+    await render(hbs`<%= selfCloseComponent(componentName) %>`);
 
     expect(this.element.textContent.trim()).to.equal('');
 
     // Template block usage:
     await render(hbs`
-      {{#<%= componentPathName %>}}
+      <%= openComponent(componentName) %>
         template block text
-      {{/<%= componentPathName %>}}
+      <%= closeComponent(componentName) %>
     `);
 
     expect(this.element.textContent.trim()).to.equal('template block text');

--- a/blueprints/component-test/qunit-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/qunit-files/__root__/__testType__/__path__/__test__.js
@@ -11,15 +11,15 @@ test('it renders', function(assert) {
   <% if (testType === 'integration' ) { %>// Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
 
-  this.render(hbs`{{<%= componentPathName %>}}`);
+  this.render(hbs`<%= selfCloseComponent(componentName) %>`);
 
   assert.equal(this.$().text().trim(), '');
 
   // Template block usage:
   this.render(hbs`
-    {{#<%= componentPathName %>}}
+    <%= openComponent(componentName) %>
       template block text
-    {{/<%= componentPathName %>}}
+    <%= closeComponent(componentName) %>
   `);
 
   assert.equal(this.$().text().trim(), 'template block text');<% } else if(testType === 'unit') { %>

--- a/blueprints/component-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -10,15 +10,15 @@ module('<%= friendlyTestDescription %>', function(hooks) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    await render(hbs`{{<%= componentPathName %>}}`);
+    await render(hbs`<%= selfCloseComponent(componentName) %>`);
 
     assert.equal(this.element.textContent.trim(), '');
 
     // Template block usage:
     await render(hbs`
-      {{#<%= componentPathName %>}}
+      <%= openComponent(componentName) %>
         template block text
-      {{/<%= componentPathName %>}}
+      <%= closeComponent(componentName) %>
     `);
 
     assert.equal(this.element.textContent.trim(), 'template block text');

--- a/node-tests/blueprints/component-test.js
+++ b/node-tests/blueprints/component-test.js
@@ -42,6 +42,7 @@ describe('Blueprint: component', function() {
           fixture('component-test/default-template.js', {
             replace: {
               component: 'foo',
+              componentInvocation: 'Foo',
             },
           })
         );
@@ -58,6 +59,7 @@ describe('Blueprint: component', function() {
           fixture('component-test/default-template.js', {
             replace: {
               component: 'x-foo',
+              componentInvocation: 'XFoo',
             },
           })
         );
@@ -73,7 +75,7 @@ describe('Blueprint: component', function() {
         expect(_file('app/templates/components/foo/x-foo.hbs')).to.equal('{{yield}}');
 
         expect(_file('tests/integration/components/foo/x-foo-test.js')).to.equal(
-          fixture('component-test/default-template.js', {
+          fixture('component-test/default-curly-template.js', {
             replace: {
               component: 'foo/x-foo',
             },
@@ -92,6 +94,7 @@ describe('Blueprint: component', function() {
           fixture('component-test/default-template.js', {
             replace: {
               component: 'x-foo',
+              componentInvocation: 'XFoo',
             },
           })
         );
@@ -110,6 +113,7 @@ describe('Blueprint: component', function() {
           fixture('component-test/default-template.js', {
             replace: {
               component: 'x-foo',
+              componentInvocation: 'XFoo',
             },
           })
         );
@@ -125,7 +129,7 @@ describe('Blueprint: component', function() {
         expect(_file('app/components/foo/x-foo/template.hbs')).to.equal('{{yield}}');
 
         expect(_file('tests/integration/components/foo/x-foo/component-test.js')).to.equal(
-          fixture('component-test/default-template.js', {
+          fixture('component-test/default-curly-template.js', {
             replace: {
               component: 'foo/x-foo',
             },
@@ -143,7 +147,7 @@ describe('Blueprint: component', function() {
         expect(_file('app/foo/x-foo/template.hbs')).to.equal('{{yield}}');
 
         expect(_file('tests/integration/foo/x-foo/component-test.js')).to.equal(
-          fixture('component-test/default-template.js', {
+          fixture('component-test/default-curly-template.js', {
             replace: {
               component: 'x-foo',
               path: 'foo/',
@@ -162,7 +166,7 @@ describe('Blueprint: component', function() {
         expect(_file('app/bar/foo/x-foo/template.hbs')).to.equal('{{yield}}');
 
         expect(_file('tests/integration/bar/foo/x-foo/component-test.js')).to.equal(
-          fixture('component-test/default-template.js', {
+          fixture('component-test/default-curly-template.js', {
             replace: {
               component: 'foo/x-foo',
               path: 'bar/',
@@ -181,7 +185,7 @@ describe('Blueprint: component', function() {
         expect(_file('app/bar/foo/x-foo/template.hbs')).to.equal('{{yield}}');
 
         expect(_file('tests/integration/bar/foo/x-foo/component-test.js')).to.equal(
-          fixture('component-test/default-template.js', {
+          fixture('component-test/default-curly-template.js', {
             replace: {
               component: 'x-foo',
               path: 'bar/foo/',
@@ -202,7 +206,7 @@ describe('Blueprint: component', function() {
           expect(_file('app/bar/baz/foo/x-foo/template.hbs')).to.equal('{{yield}}');
 
           expect(_file('tests/integration/bar/baz/foo/x-foo/component-test.js')).to.equal(
-            fixture('component-test/default-template.js', {
+            fixture('component-test/default-curly-template.js', {
               replace: {
                 component: 'foo/x-foo',
                 path: 'bar/baz/',
@@ -223,6 +227,7 @@ describe('Blueprint: component', function() {
           fixture('component-test/default-template.js', {
             replace: {
               component: 'x-foo',
+              componentInvocation: 'XFoo',
             },
           })
         );
@@ -238,7 +243,7 @@ describe('Blueprint: component', function() {
         expect(_file('app/foo/x-foo/template.hbs')).to.equal('{{yield}}');
 
         expect(_file('tests/integration/foo/x-foo/component-test.js')).to.equal(
-          fixture('component-test/default-template.js', {
+          fixture('component-test/default-curly-template.js', {
             replace: {
               component: 'foo/x-foo',
             },
@@ -264,6 +269,7 @@ describe('Blueprint: component', function() {
             fixture('component-test/default-template.js', {
               replace: {
                 component: 'foo',
+                componentInvocation: 'Foo',
               },
             })
           );
@@ -282,6 +288,7 @@ describe('Blueprint: component', function() {
             fixture('component-test/default-template.js', {
               replace: {
                 component: 'x-foo',
+                componentInvocation: 'XFoo',
               },
             })
           );
@@ -297,7 +304,7 @@ describe('Blueprint: component', function() {
           expect(_file('app/pods/components/foo/x-foo/template.hbs')).to.equal('{{yield}}');
 
           expect(_file('tests/integration/pods/components/foo/x-foo/component-test.js')).to.equal(
-            fixture('component-test/default-template.js', {
+            fixture('component-test/default-curly-template.js', {
               replace: {
                 component: 'foo/x-foo',
               },
@@ -315,7 +322,7 @@ describe('Blueprint: component', function() {
           expect(_file('app/pods/foo/x-foo/template.hbs')).to.equal('{{yield}}');
 
           expect(_file('tests/integration/pods/foo/x-foo/component-test.js')).to.equal(
-            fixture('component-test/default-template.js', {
+            fixture('component-test/default-curly-template.js', {
               replace: {
                 component: 'x-foo',
                 path: 'foo/',
@@ -334,7 +341,7 @@ describe('Blueprint: component', function() {
           expect(_file('app/pods/bar/foo/x-foo/template.hbs')).to.equal('{{yield}}');
 
           expect(_file('tests/integration/pods/bar/foo/x-foo/component-test.js')).to.equal(
-            fixture('component-test/default-template.js', {
+            fixture('component-test/default-curly-template.js', {
               replace: {
                 component: 'foo/x-foo',
                 path: 'bar/',
@@ -351,9 +358,8 @@ describe('Blueprint: component', function() {
           );
 
           expect(_file('app/pods/bar/foo/x-foo/template.hbs')).to.equal('{{yield}}');
-
           expect(_file('tests/integration/pods/bar/foo/x-foo/component-test.js')).to.equal(
-            fixture('component-test/default-template.js', {
+            fixture('component-test/default-curly-template.js', {
               replace: {
                 component: 'x-foo',
                 path: 'bar/foo/',
@@ -374,7 +380,7 @@ describe('Blueprint: component', function() {
             expect(_file('app/pods/bar/baz/foo/x-foo/template.hbs')).to.equal('{{yield}}');
 
             expect(_file('tests/integration/pods/bar/baz/foo/x-foo/component-test.js')).to.equal(
-              fixture('component-test/default-template.js', {
+              fixture('component-test/default-curly-template.js', {
                 replace: {
                   component: 'foo/x-foo',
                   path: 'bar/baz/',
@@ -397,6 +403,7 @@ describe('Blueprint: component', function() {
             fixture('component-test/default-template.js', {
               replace: {
                 component: 'x-foo',
+                componentInvocation: 'XFoo',
               },
             })
           );
@@ -412,7 +419,7 @@ describe('Blueprint: component', function() {
           expect(_file('app/pods/foo/x-foo/template.hbs')).to.equal('{{yield}}');
 
           expect(_file('tests/integration/pods/foo/x-foo/component-test.js')).to.equal(
-            fixture('component-test/default-template.js', {
+            fixture('component-test/default-curly-template.js', {
               replace: {
                 component: 'foo/x-foo',
               },
@@ -449,6 +456,7 @@ describe('Blueprint: component', function() {
           fixture('component-test/default-template.js', {
             replace: {
               component: 'foo',
+              componentInvocation: 'Foo',
             },
           })
         );
@@ -467,6 +475,7 @@ describe('Blueprint: component', function() {
           fixture('component-test/default-template.js', {
             replace: {
               component: 'x-foo',
+              componentInvocation: 'XFoo',
             },
           })
         );
@@ -482,7 +491,7 @@ describe('Blueprint: component', function() {
         expect(_file('src/ui/components/foo/x-foo/template.hbs')).to.equal('{{yield}}');
 
         expect(_file('src/ui/components/foo/x-foo/component-test.js')).to.equal(
-          fixture('component-test/default-template.js', {
+          fixture('component-test/default-curly-template.js', {
             replace: {
               component: 'foo/x-foo',
             },
@@ -518,6 +527,7 @@ describe('Blueprint: component', function() {
           fixture('component-test/default-template.js', {
             replace: {
               component: 'foo',
+              componentInvocation: 'Foo',
             },
           })
         );
@@ -536,6 +546,7 @@ describe('Blueprint: component', function() {
           fixture('component-test/default-template.js', {
             replace: {
               component: 'x-foo',
+              componentInvocation: 'XFoo',
             },
           })
         );
@@ -551,7 +562,7 @@ describe('Blueprint: component', function() {
         expect(_file('src/ui/components/foo/x-foo/template.hbs')).to.equal('{{yield}}');
 
         expect(_file('src/ui/components/foo/x-foo/component-test.js')).to.equal(
-          fixture('component-test/default-template.js', {
+          fixture('component-test/default-curly-template.js', {
             replace: {
               component: 'foo/x-foo',
             },
@@ -587,6 +598,7 @@ describe('Blueprint: component', function() {
           fixture('component-test/default-template.js', {
             replace: {
               component: 'foo',
+              componentInvocation: 'Foo',
             },
           })
         );
@@ -609,6 +621,7 @@ describe('Blueprint: component', function() {
           fixture('component-test/default-template.js', {
             replace: {
               component: 'x-foo',
+              componentInvocation: 'XFoo',
             },
           })
         );
@@ -628,7 +641,7 @@ describe('Blueprint: component', function() {
         );
 
         expect(_file('tests/integration/components/foo/x-foo-test.js')).to.equal(
-          fixture('component-test/default-template.js', {
+          fixture('component-test/default-curly-template.js', {
             replace: {
               component: 'foo/x-foo',
             },
@@ -681,6 +694,7 @@ describe('Blueprint: component', function() {
           fixture('component-test/default-template.js', {
             replace: {
               component: 'x-foo',
+              componentInvocation: 'XFoo',
             },
           })
         );
@@ -714,7 +728,9 @@ describe('Blueprint: component', function() {
           fixture('component-test/default-template.js', {
             replace: {
               component: 'foo',
+              componentInvocation: 'Foo',
               path: 'my-addon::',
+              pathInvocation: 'MyAddon::',
             },
           })
         );
@@ -733,7 +749,9 @@ describe('Blueprint: component', function() {
           fixture('component-test/default-template.js', {
             replace: {
               component: 'x-foo',
+              componentInvocation: 'XFoo',
               path: 'my-addon::',
+              pathInvocation: 'MyAddon::',
             },
           })
         );
@@ -749,7 +767,7 @@ describe('Blueprint: component', function() {
         expect(_file('src/ui/components/foo/x-foo/template.hbs')).to.equal('{{yield}}');
 
         expect(_file('src/ui/components/foo/x-foo/component-test.js')).to.equal(
-          fixture('component-test/default-template.js', {
+          fixture('component-test/default-curly-template.js', {
             replace: {
               component: 'foo/x-foo',
               path: 'my-addon::',
@@ -814,7 +832,9 @@ describe('Blueprint: component', function() {
           fixture('component-test/default-template.js', {
             replace: {
               component: 'foo',
+              componentInvocation: 'Foo',
               path: 'my-addon::',
+              pathInvocation: 'MyAddon::',
             },
           })
         );
@@ -833,7 +853,9 @@ describe('Blueprint: component', function() {
           fixture('component-test/default-template.js', {
             replace: {
               component: 'x-foo',
+              componentInvocation: 'XFoo',
               path: 'my-addon::',
+              pathInvocation: 'MyAddon::',
             },
           })
         );
@@ -849,7 +871,7 @@ describe('Blueprint: component', function() {
         expect(_file('src/ui/components/foo/x-foo/template.hbs')).to.equal('{{yield}}');
 
         expect(_file('src/ui/components/foo/x-foo/component-test.js')).to.equal(
-          fixture('component-test/default-template.js', {
+          fixture('component-test/default-curly-template.js', {
             replace: {
               component: 'foo/x-foo',
               path: 'my-addon::',
@@ -916,6 +938,7 @@ describe('Blueprint: component', function() {
           fixture('component-test/default-template.js', {
             replace: {
               component: 'foo',
+              componentInvocation: 'Foo',
             },
           })
         );
@@ -938,6 +961,7 @@ describe('Blueprint: component', function() {
           fixture('component-test/default-template.js', {
             replace: {
               component: 'x-foo',
+              componentInvocation: 'XFoo',
             },
           })
         );
@@ -959,7 +983,7 @@ describe('Blueprint: component', function() {
         );
 
         expect(_file('tests/integration/components/foo/x-foo-test.js')).to.equal(
-          fixture('component-test/default-template.js', {
+          fixture('component-test/default-curly-template.js', {
             replace: {
               component: 'foo/x-foo',
             },
@@ -986,6 +1010,7 @@ describe('Blueprint: component', function() {
             fixture('component-test/default-template.js', {
               replace: {
                 component: 'x-foo',
+                componentInvocation: 'XFoo',
               },
             })
           );
@@ -1010,7 +1035,7 @@ describe('Blueprint: component', function() {
           );
 
           expect(_file('tests/integration/components/foo/x-foo/component-test.js')).to.equal(
-            fixture('component-test/default-template.js', {
+            fixture('component-test/default-curly-template.js', {
               replace: {
                 component: 'foo/x-foo',
               },
@@ -1047,7 +1072,9 @@ describe('Blueprint: component', function() {
           fixture('component-test/default-template.js', {
             replace: {
               component: 'foo',
+              componentInvocation: 'Foo',
               path: 'my-addon::',
+              pathInvocation: 'MyAddon::',
             },
           })
         );
@@ -1068,7 +1095,9 @@ describe('Blueprint: component', function() {
           fixture('component-test/default-template.js', {
             replace: {
               component: 'x-foo',
+              componentInvocation: 'XFoo',
               path: 'my-addon::',
+              pathInvocation: 'MyAddon::',
             },
           })
         );
@@ -1102,7 +1131,9 @@ describe('Blueprint: component', function() {
           fixture('component-test/default-template.js', {
             replace: {
               component: 'foo',
+              componentInvocation: 'Foo',
               path: 'my-addon::',
+              pathInvocation: 'MyAddon::',
             },
           })
         );
@@ -1123,7 +1154,9 @@ describe('Blueprint: component', function() {
           fixture('component-test/default-template.js', {
             replace: {
               component: 'x-foo',
+              componentInvocation: 'XFoo',
               path: 'my-addon::',
+              pathInvocation: 'MyAddon::',
             },
           })
         );

--- a/node-tests/blueprints/component-test.js
+++ b/node-tests/blueprints/component-test.js
@@ -91,10 +91,9 @@ describe('Blueprint: component', function() {
         expect(_file('app/templates/components/x-foo.hbs')).to.equal('{{yield}}');
 
         expect(_file('tests/integration/components/x-foo-test.js')).to.equal(
-          fixture('component-test/default-template.js', {
+          fixture('component-test/default-curly-template.js', {
             replace: {
               component: 'x-foo',
-              componentInvocation: 'XFoo',
             },
           })
         );

--- a/node-tests/fixtures/component-test/default-curly-template.js
+++ b/node-tests/fixtures/component-test/default-curly-template.js
@@ -9,15 +9,15 @@ test('it renders', function(assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
 
-  this.render(hbs`<<%= pathInvocation =%><%= componentInvocation =%> />`);
+  this.render(hbs`{{<%= path =%><%= component =%>}}`);
 
   assert.equal(this.$().text().trim(), '');
 
   // Template block usage:
   this.render(hbs`
-    <<%= pathInvocation =%><%= componentInvocation =%>>
+    {{#<%= path =%><%= component =%>}}
       template block text
-    </<%= pathInvocation =%><%= componentInvocation =%>>
+    {{/<%= path =%><%= component =%>}}
   `);
 
   assert.equal(this.$().text().trim(), 'template block text');

--- a/node-tests/fixtures/component-test/default.js
+++ b/node-tests/fixtures/component-test/default.js
@@ -9,15 +9,15 @@ test('it renders', function(assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
 
-  this.render(hbs`{{x-foo}}`);
+  this.render(hbs`<XFoo />`);
 
   assert.equal(this.$().text().trim(), '');
 
   // Template block usage:
   this.render(hbs`
-    {{#x-foo}}
+    <XFoo>
       template block text
-    {{/x-foo}}
+    </XFoo>
   `);
 
   assert.equal(this.$().text().trim(), 'template block text');

--- a/node-tests/fixtures/component-test/mocha-0.12.js
+++ b/node-tests/fixtures/component-test/mocha-0.12.js
@@ -11,14 +11,17 @@ describe('Integration | Component | x-foo', function() {
   it('renders', function() {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.on('myAction', function(val) { ... });
-    // Template block usage:
-    // this.render(hbs`
-    //   {{#x-foo}}
-    //     template content
-    //   {{/x-foo}}
-    // `);
 
-    this.render(hbs`{{x-foo}}`);
+    this.render(hbs`<XFoo />`);
     expect(this.$()).to.have.length(1);
+
+    // Template block usage:
+    this.render(hbs`
+      <XFoo>
+        template block text
+      </XFoo>
+    `);
+
+    assert.equal(this.$().text().trim(), 'template block text');
   });
 });

--- a/node-tests/fixtures/component-test/mocha-rfc232.js
+++ b/node-tests/fixtures/component-test/mocha-rfc232.js
@@ -11,15 +11,15 @@ describe('Integration | Component | x-foo', function() {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    await render(hbs`{{x-foo}}`);
+    await render(hbs`<XFoo />`);
 
     expect(this.element.textContent.trim()).to.equal('');
 
     // Template block usage:
     await render(hbs`
-      {{#x-foo}}
+      <XFoo>
         template block text
-      {{/x-foo}}
+      </XFoo>
     `);
 
     expect(this.element.textContent.trim()).to.equal('template block text');

--- a/node-tests/fixtures/component-test/mocha.js
+++ b/node-tests/fixtures/component-test/mocha.js
@@ -10,15 +10,18 @@ describeComponent('x-foo', 'Integration | Component | x-foo',
     it('renders', function() {
       // Set any properties with this.set('myProperty', 'value');
       // Handle any actions with this.on('myAction', function(val) { ... });
-      // Template block usage:
-      // this.render(hbs`
-      //   {{#x-foo}}
-      //     template content
-      //   {{/x-foo}}
-      // `);
 
-      this.render(hbs`{{x-foo}}`);
+      this.render(hbs`<XFoo />`);
       expect(this.$()).to.have.length(1);
+
+      // Template block usage:
+      this.render(hbs`
+        <XFoo>
+          template block text
+        </XFoo>
+      `);
+
+      assert.equal(this.$().text().trim(), 'template block text');
     });
   }
 );

--- a/node-tests/fixtures/component-test/rfc232.js
+++ b/node-tests/fixtures/component-test/rfc232.js
@@ -10,15 +10,15 @@ module('Integration | Component | x-foo', function(hooks) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    await render(hbs`{{x-foo}}`);
+    await render(hbs`<XFoo />`);
 
     assert.equal(this.element.textContent.trim(), '');
 
     // Template block usage:
     await render(hbs`
-      {{#x-foo}}
+      <XFoo>
         template block text
-      {{/x-foo}}
+      </XFoo>
     `);
 
     assert.equal(this.element.textContent.trim(), 'template block text');


### PR DESCRIPTION
This PR supersedes #17666 and attempts to address issue #17625

When generating the blueprints for a component the component-test blueprint will attempt to generate a test that uses Angle Bracket Syntax unless it sees that the component is nested in a path requiring the generated test to fallback and use Curly Bracket Syntax.