### PR TITLE
Fix helper blueprint for module unification

### DIFF
--- a/blueprints/helper/index.js
+++ b/blueprints/helper/index.js
@@ -8,6 +8,11 @@ const path = require('path');
 module.exports = {
   description: 'Generates a helper function.',
 
+  filesPath() {
+    let rootPath = isModuleUnificationProject(this.project) ? 'mu-files' : 'files';
+    return path.join(this.path, rootPath);
+  },
+
   fileMapTokens() {
     if (isModuleUnificationProject(this.project)) {
       return {

--- a/blueprints/helper/mu-files/__root__/__collection__/__name__.js
+++ b/blueprints/helper/mu-files/__root__/__collection__/__name__.js
@@ -1,0 +1,7 @@
+import { helper as buildHelper } from '@ember/component/helper';
+
+export function <%= camelizedModuleName %>(params/*, hash*/) {
+  return params;
+}
+
+export const helper = buildHelper(<%= camelizedModuleName %>);

--- a/node-tests/blueprints/helper-test.js
+++ b/node-tests/blueprints/helper-test.js
@@ -106,7 +106,7 @@ describe('Blueprint: helper', function() {
 
     it('helper foo/bar-baz', function() {
       return emberGenerateDestroy(['helper', 'foo/bar-baz'], _file => {
-        expect(_file('src/ui/components/foo/bar-baz.js')).to.equal(fixture('helper/helper.js'));
+        expect(_file('src/ui/components/foo/bar-baz.js')).to.equal(fixture('helper/mu-helper.js'));
         expect(_file('src/ui/components/foo/bar-baz-test.js')).to.equal(
           fixture('helper-test/integration.js')
         );
@@ -115,7 +115,7 @@ describe('Blueprint: helper', function() {
 
     it('helper foo/bar-baz unit', function() {
       return emberGenerateDestroy(['helper', '--test-type=unit', 'foo/bar-baz'], _file => {
-        expect(_file('src/ui/components/foo/bar-baz.js')).to.equal(fixture('helper/helper.js'));
+        expect(_file('src/ui/components/foo/bar-baz.js')).to.equal(fixture('helper/mu-helper.js'));
         expect(_file('src/ui/components/foo/bar-baz-test.js')).to.equal(
           fixture('helper-test/unit.js')
         );
@@ -170,7 +170,7 @@ describe('Blueprint: helper', function() {
 
     it('helper foo/bar-baz', function() {
       return emberGenerateDestroy(['helper', 'foo/bar-baz'], _file => {
-        expect(_file('src/ui/components/foo/bar-baz.js')).to.equal(fixture('helper/helper.js'));
+        expect(_file('src/ui/components/foo/bar-baz.js')).to.equal(fixture('helper/mu-helper.js'));
         expect(_file('src/ui/components/foo/bar-baz-test.js')).to.equal(
           fixture('helper-test/integration.js')
         );
@@ -179,7 +179,7 @@ describe('Blueprint: helper', function() {
 
     it('helper foo/bar-baz unit', function() {
       return emberGenerateDestroy(['helper', '--test-type=unit', 'foo/bar-baz'], _file => {
-        expect(_file('src/ui/components/foo/bar-baz.js')).to.equal(fixture('helper/helper.js'));
+        expect(_file('src/ui/components/foo/bar-baz.js')).to.equal(fixture('helper/mu-helper.js'));
         expect(_file('src/ui/components/foo/bar-baz-test.js')).to.equal(
           fixture('helper-test/module-unification/addon-unit.js')
         );
@@ -229,7 +229,7 @@ describe('Blueprint: helper', function() {
     it('helper foo/bar-baz --in-repo-addon=my-addon', function() {
       return emberGenerateDestroy(['helper', 'foo/bar-baz', '--in-repo-addon=my-addon'], _file => {
         expect(_file('packages/my-addon/src/ui/components/foo/bar-baz.js')).to.equal(
-          fixture('helper/helper.js')
+          fixture('helper/mu-helper.js')
         );
         expect(_file('packages/my-addon/src/ui/components/foo/bar-baz-test.js')).to.equal(
           fixture('helper-test/integration.js')
@@ -242,7 +242,7 @@ describe('Blueprint: helper', function() {
         ['helper', '--test-type=unit', 'foo/bar-baz', '--in-repo-addon=my-addon'],
         _file => {
           expect(_file('packages/my-addon/src/ui/components/foo/bar-baz.js')).to.equal(
-            fixture('helper/helper.js')
+            fixture('helper/mu-helper.js')
           );
           expect(_file('packages/my-addon/src/ui/components/foo/bar-baz-test.js')).to.equal(
             fixture('helper-test/module-unification/addon-unit.js')

--- a/node-tests/fixtures/helper/mu-helper.js
+++ b/node-tests/fixtures/helper/mu-helper.js
@@ -1,0 +1,7 @@
+import { helper as buildHelper } from '@ember/component/helper';
+
+export function fooBarBaz(params/*, hash*/) {
+  return params;
+}
+
+export const helper = buildHelper(fooBarBaz);


### PR DESCRIPTION
Prior to this change, the classic blueprint used a different construction for helper files. Since module unification this has changed.

This commit updates the blueprints to generate the new construction code for helpers when module unification is in use and still offers the classic construction code when not.

Fixes issue #17556