### PR TITLE
[BUGFIX] Ensure tagForProperty works on class constructors

### DIFF
--- a/packages/@ember/-internals/metal/lib/decorator.ts
+++ b/packages/@ember/-internals/metal/lib/decorator.ts
@@ -22,8 +22,9 @@ export function isElementDescriptor(
   return (
     // Ensure we have the right number of args
     args.length === 3 &&
-    // Make sure the target is an object
-    (typeof maybeTarget === 'object' && maybeTarget !== null) &&
+    // Make sure the target is a class or object (prototype)
+    (typeof maybeTarget === 'function' ||
+      (typeof maybeTarget === 'object' && maybeTarget !== null)) &&
     // Make sure the key is a string
     typeof maybeKey === 'string' &&
     // Make sure the descriptor is the right shape

--- a/packages/@ember/-internals/metal/lib/tags.ts
+++ b/packages/@ember/-internals/metal/lib/tags.ts
@@ -22,7 +22,8 @@ function makeTag(): TagWrapper<DirtyableTag> {
 }
 
 export function tagForProperty(object: any, propertyKey: string | symbol, _meta?: Meta): Tag {
-  if (typeof object !== 'object' || object === null) {
+  let objectType = typeof object;
+  if (objectType !== 'function' && (objectType !== 'object' || object === null)) {
     return CONSTANT_TAG;
   }
   let meta = _meta === undefined ? metaFor(object) : _meta;

--- a/packages/@ember/-internals/metal/tests/computed_decorator_test.js
+++ b/packages/@ember/-internals/metal/tests/computed_decorator_test.js
@@ -70,6 +70,25 @@ if (EMBER_NATIVE_DECORATOR_SUPPORT) {
         get(obj, 'fullName');
       }
 
+      ['@test computed property can be defined and accessed on a class constructor'](assert) {
+        let count = 0;
+
+        class Obj {
+          static bar = 123;
+
+          @computed
+          static get foo() {
+            count++;
+            return this.bar;
+          }
+        }
+
+        assert.equal(Obj.foo, 123, 'should return value');
+        Obj.foo;
+
+        assert.equal(count, 1, 'should only call getter once');
+      }
+
       ['@test it works with computed desc'](assert) {
         assert.expect(4);
 

--- a/packages/@ember/-internals/metal/tests/computed_test.js
+++ b/packages/@ember/-internals/metal/tests/computed_test.js
@@ -82,6 +82,25 @@ moduleFor(
       assert.equal(count, 1, 'should have invoked computed property');
     }
 
+    ['@test computed property can be defined and accessed on a class constructor'](assert) {
+      let count = 0;
+
+      let Obj = EmberObject.extend();
+      Obj.reopenClass({
+        bar: 123,
+
+        foo: computed(function() {
+          count++;
+          return this.bar;
+        }),
+      });
+
+      assert.equal(Obj.foo, 123, 'should return value');
+      Obj.foo;
+
+      assert.equal(count, 1, 'should only call getter once');
+    }
+
     ['@test can override volatile computed property'](assert) {
       let obj = {};
 


### PR DESCRIPTION
`tagForProperty` was returning the constant tag for functions, which
meant it would return the constant tag for properties on class
constructors. If a computed property was defined on the class
constructor it would fail because of this.

Fixes #17651