### PR TITLE
[FAILING TEST] the position of `...attributes` should not matter

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
@@ -836,6 +836,28 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_INVOCATION) {
         });
       }
 
+      '@test `...attributes` are merged regardless of the position where they are defined'() {
+        this.registerComponent('foo-bar', {
+          ComponentClass: Component.extend({ tagName: '' }),
+          template:
+            '<div class="inner" ...attributes>hello</div><div ...attributes class="inner">hello</div>',
+        });
+
+        this.render('<FooBar class="outer" />');
+
+        this.assertElement(this.firstChild, {
+          tagName: 'div',
+          attrs: { class: classes('inner outer') },
+          content: 'hello',
+        });
+
+        this.assertElement(this.nthChild(1), {
+          tagName: 'div',
+          attrs: { class: classes('outer inner') },
+          content: 'hello',
+        });
+      }
+
       '@test the attributes passed on invocation trump over the default ones on elements with `...attributes` in yielded contextual component ("splattributes")'() {
         this.registerComponent('foo-bar', {
           ComponentClass: Component.extend({ tagName: '' }),


### PR DESCRIPTION
failing test for https://github.com/emberjs/ember.js/issues/17692

<img width="1211" alt="screen shot 2019-03-02 at 14 28 15" src="https://user-images.githubusercontent.com/2526/53683557-1139c500-3cfa-11e9-9d01-e495afe64db7.png">
