### PR TITLE
[BUGFIX beta] Allow accessors in mixins

### DIFF
--- a/packages/@ember/-internals/metal/tests/mixin/accessor_test.js
+++ b/packages/@ember/-internals/metal/tests/mixin/accessor_test.js
@@ -1,0 +1,38 @@
+import { Mixin } from '../..';
+import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+
+moduleFor(
+  'Mixin Accessors',
+  class extends AbstractTestCase {
+    ['@test works with getters'](assert) {
+      let count = 0;
+
+      let MixinA = Mixin.create({
+        get prop() {
+          return count++;
+        },
+      });
+
+      let obj = {};
+      MixinA.apply(obj);
+
+      assert.equal(obj.prop, 0, 'getter defined correctly');
+      assert.equal(obj.prop, 1, 'getter defined correctly');
+    }
+
+    ['@test works with setters'](assert) {
+      let MixinA = Mixin.create({
+        set prop(value) {
+          this._prop = value + 1;
+        },
+      });
+
+      let obj = {};
+      MixinA.apply(obj);
+
+      obj.prop = 0;
+
+      assert.equal(obj._prop, 1, 'setter defined correctly');
+    }
+  }
+);

--- a/packages/@ember/-internals/utils/index.ts
+++ b/packages/@ember/-internals/utils/index.ts
@@ -10,6 +10,7 @@
 */
 export { default as symbol, isInternalSymbol } from './lib/symbol';
 export { default as dictionary } from './lib/dictionary';
+export { default as getOwnPropertyDescriptors } from './lib/get-own-property-descriptors';
 export { uuid, GUID_KEY, generateGuid, guidFor } from './lib/guid';
 export { default as intern } from './lib/intern';
 export {

--- a/packages/@ember/-internals/utils/lib/get-own-property-descriptors.ts
+++ b/packages/@ember/-internals/utils/lib/get-own-property-descriptors.ts
@@ -1,0 +1,17 @@
+let getOwnPropertyDescriptors: (obj: { [x: string]: any }) => { [x: string]: PropertyDescriptor };
+
+if (Object.getOwnPropertyDescriptors !== undefined) {
+  getOwnPropertyDescriptors = Object.getOwnPropertyDescriptors;
+} else {
+  getOwnPropertyDescriptors = function(obj: object) {
+    let descriptors = {};
+
+    Object.keys(obj).forEach(key => {
+      descriptors[key] = Object.getOwnPropertyDescriptor(obj, key);
+    });
+
+    return descriptors;
+  };
+}
+
+export default getOwnPropertyDescriptors;


### PR DESCRIPTION
This fix allows native object accessors to work in Ember Mixins. It does
this by looping over the properties of a new mixin and extracting their
descriptors, checking to see if any of them are accessors. If they are,
it wraps them in a descriptor decorator.

Benchmarked against Ember Observer, and didn't find any statistically significant changes:

[results.pdf](https://github.com/emberjs/ember.js/files/2934360/results.pdf)

Partially fixes #17709, the deprecation app needs to be updated still