### PR TITLE
Fix blueprint helper test

### DIFF
--- a/node-tests/blueprints/helper-test.js
+++ b/node-tests/blueprints/helper-test.js
@@ -189,7 +189,7 @@ describe('Blueprint: helper', function() {
     it('helper foo/bar-baz --dummy', function() {
       return emberGenerateDestroy(['helper', 'foo/bar-baz', '--dummy'], _file => {
         expect(_file('tests/dummy/src/ui/components/foo/bar-baz.js')).to.equal(
-          fixture('helper/helper.js')
+          fixture('helper/mu-helper.js')
         );
         expect(_file('src/ui/components/foo/bar-baz.js')).to.not.exist;
       });


### PR DESCRIPTION
It fixes the test when generating a helper in a MU `dummy` app.

It continues the work of #17658 that requires this change when #17689 was merged.