### PR TITLE
[BUGFIX] Adds a warning to {{action}} for undecorated methods

### DIFF
--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -300,7 +300,7 @@ export { default as AbstractComponentManager } from './lib/component-managers/ab
 // rather than the problem was solved
 // DebugStack should just test the assert message
 // it supports for example
-export { UpdatableReference, INVOKE } from './lib/utils/references';
+export { ACTION_METHOD, UpdatableReference, INVOKE } from './lib/utils/references';
 export { default as iterableFor } from './lib/utils/iterable';
 export { default as DebugStack } from './lib/utils/debug-stack';
 export { default as OutletView } from './lib/views/outlet';

--- a/packages/@ember/-internals/glimmer/lib/helpers/action.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/action.ts
@@ -2,14 +2,15 @@
 @module ember
 */
 import { get } from '@ember/-internals/metal';
-import { assert } from '@ember/debug';
+import { EMBER_NATIVE_DECORATOR_SUPPORT } from '@ember/canary-features';
+import { assert, warn } from '@ember/debug';
 import { flaggedInstrument } from '@ember/instrumentation';
 import { join } from '@ember/runloop';
 import { DEBUG } from '@glimmer/env';
 import { isConst, VersionedPathReference } from '@glimmer/reference';
 import { Arguments, VM } from '@glimmer/runtime';
 import { Opaque } from '@glimmer/util';
-import { ACTION, INVOKE, UnboundReference } from '../utils/references';
+import { ACTION, ACTION_METHOD, INVOKE, UnboundReference } from '../utils/references';
 
 /**
   The `{{action}}` helper provides a way to pass triggers for behavior (usually
@@ -389,6 +390,16 @@ function makeClosureAction(
 
       assert(`An action named '${action}' was not found in ${target}`, fn);
     } else if (typeofAction === 'function') {
+      if (EMBER_NATIVE_DECORATOR_SUPPORT) {
+        warn(
+          `You passed a method, ${debugKey}, to the {{action}} helper which was not decorated with the '@action' decorator. All actions should be decorated with the '@action' decorator.`,
+          target[debugKey] !== action || action[ACTION_METHOD] === true,
+          {
+            id: 'action-without-decorator',
+          }
+        );
+      }
+
       self = context;
       fn = action;
     } else {

--- a/packages/@ember/-internals/glimmer/lib/modifiers/action.ts
+++ b/packages/@ember/-internals/glimmer/lib/modifiers/action.ts
@@ -197,7 +197,7 @@ export default class ActionModifierManager implements ModifierManager<ActionStat
     dom: any
   ) {
     let { named, positional, tag } = args.capture();
-    let implicitTarget;
+    let implicitTarget: any;
     let actionName;
     let actionNameRef: any;
     if (positional.length > 1) {

--- a/packages/@ember/-internals/glimmer/lib/modifiers/action.ts
+++ b/packages/@ember/-internals/glimmer/lib/modifiers/action.ts
@@ -1,8 +1,10 @@
 import { uuid } from '@ember/-internals/utils';
 import { ActionManager, isSimpleClick } from '@ember/-internals/views';
-import { assert } from '@ember/debug';
+import { EMBER_NATIVE_DECORATOR_SUPPORT } from '@ember/canary-features';
+import { assert, warn } from '@ember/debug';
 import { flaggedInstrument } from '@ember/instrumentation';
 import { join } from '@ember/runloop';
+import { DEBUG } from '@glimmer/env';
 import { Opaque, Simple } from '@glimmer/interfaces';
 import { RevisionTag, TagWrapper } from '@glimmer/reference';
 import {
@@ -13,7 +15,7 @@ import {
   ModifierManager,
 } from '@glimmer/runtime';
 import { Destroyable } from '@glimmer/util';
-import { INVOKE } from '../utils/references';
+import { ACTION_METHOD, INVOKE } from '../utils/references';
 
 const MODIFIERS = ['alt', 'shift', 'meta', 'ctrl'];
 const POINTER_EVENT_TYPE_REGEX = /^click|mouse|touch/;
@@ -212,13 +214,28 @@ export default class ActionModifierManager implements ModifierManager<ActionStat
           'You specified a quoteless path, `' +
             actionLabel +
             '`, to the ' +
-            '{{action}} helper which did not resolve to an action name (a ' +
+            '{{action}} modifier which did not resolve to an action name (a ' +
             'string). Perhaps you meant to use a quoted actionName? (e.g. ' +
             '{{action "' +
             actionLabel +
             '"}}).',
           typeof actionName === 'string' || typeof actionName === 'function'
         );
+
+        if (DEBUG && EMBER_NATIVE_DECORATOR_SUPPORT) {
+          let implicitTargetValue = implicitTarget.value();
+
+          warn(
+            `You passed a method, ${actionLabel}, to the {{action}} modifier which was not decorated with the '@action' decorator. All actions should be decorated with the '@action' decorator.`,
+            typeof actionName !== 'function' ||
+              !implicitTargetValue ||
+              implicitTargetValue[actionLabel] !== actionName ||
+              actionName[ACTION_METHOD] === true,
+            {
+              id: 'action-without-decorator',
+            }
+          );
+        }
       }
     }
 

--- a/packages/@ember/-internals/glimmer/lib/utils/references.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/references.ts
@@ -38,6 +38,7 @@ import emberToBool from './to-bool';
 export const UPDATE = symbol('UPDATE');
 export const INVOKE = symbol('INVOKE');
 export const ACTION = symbol('ACTION');
+export const ACTION_METHOD = symbol('ACTION_METHOD');
 
 let maybeFreeze: (obj: any) => void;
 if (DEBUG) {

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/element-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/element-action-test.js
@@ -1317,7 +1317,7 @@ moduleFor(
 
       expectAssertion(() => {
         this.render('{{example-component}}');
-      }, 'You specified a quoteless path, `ohNoeNotValid`, to the {{action}} helper ' + 'which did not resolve to an action name (a string). ' + 'Perhaps you meant to use a quoted actionName? (e.g. {{action "ohNoeNotValid"}}).');
+      }, 'You specified a quoteless path, `ohNoeNotValid`, to the {{action}} modifier ' + 'which did not resolve to an action name (a string). ' + 'Perhaps you meant to use a quoted actionName? (e.g. {{action "ohNoeNotValid"}}).');
     }
 
     ['@test allows multiple actions on a single element']() {

--- a/packages/@ember/object/index.js
+++ b/packages/@ember/object/index.js
@@ -1,6 +1,8 @@
+import { ACTION_METHOD } from '@ember/-internals/glimmer';
 import { EMBER_NATIVE_DECORATOR_SUPPORT } from '@ember/canary-features';
 import { assert } from '@ember/debug';
 import { assign } from '@ember/polyfills';
+import { DEBUG } from '@glimmer/env';
 
 /**
   Decorator that turns the target function into an Action
@@ -70,6 +72,11 @@ if (EMBER_NATIVE_DECORATOR_SUPPORT) {
 
         if (fn === undefined) {
           fn = actionFn.bind(this);
+
+          if (DEBUG) {
+            fn[ACTION_METHOD] = true;
+          }
+
           bindings.set(actionFn, fn);
         }
 

--- a/packages/@ember/object/tests/action_test.js
+++ b/packages/@ember/object/tests/action_test.js
@@ -231,6 +231,68 @@ if (EMBER_NATIVE_DECORATOR_SUPPORT) {
           new TestObject();
         }, /The @action decorator must be applied to methods/);
       }
+
+      '@test action modifier warns if action decorator is not applied'() {
+        class FooComponent extends Component {
+          foo() {}
+        }
+
+        this.registerComponent('foo-bar', {
+          ComponentClass: FooComponent,
+          template: '<button {{action this.foo}}>Click Me!</button>',
+        });
+
+        return expectWarning(() => {
+          this.render('{{foo-bar}}');
+        }, "You passed a method, foo, to the {{action}} modifier which was not decorated with the '@action' decorator. All actions should be decorated with the '@action' decorator.");
+      }
+
+      '@test action helper warns if action decorator is not applied'() {
+        class FooComponent extends Component {
+          foo() {}
+        }
+
+        this.registerComponent('foo-bar', {
+          ComponentClass: FooComponent,
+          template: '<button {{action (action this.foo)}}>Click Me!</button>',
+        });
+
+        return expectWarning(() => {
+          this.render('{{foo-bar}}');
+        }, "You passed a method, foo, to the {{action}} helper which was not decorated with the '@action' decorator. All actions should be decorated with the '@action' decorator.");
+      }
+
+      '@test action modifier does not warn if passed an action'() {
+        class FooComponent extends Component {
+          @action
+          foo() {}
+        }
+
+        this.registerComponent('foo-bar', {
+          ComponentClass: FooComponent,
+          template: '<button {{action (action "foo")}}>Click Me!</button>',
+        });
+
+        return expectNoWarning(() => {
+          this.render('{{foo-bar}}');
+        });
+      }
+
+      '@test action helper does not warn if passed an action'() {
+        class FooComponent extends Component {
+          @action
+          foo() {}
+        }
+
+        this.registerComponent('foo-bar', {
+          ComponentClass: FooComponent,
+          template: '<button onclick={{action (action "foo")}}>Click Me!</button>',
+        });
+
+        return expectNoWarning(() => {
+          this.render('{{foo-bar}}');
+        });
+      }
     }
   );
 }

--- a/packages/internal-test-helpers/lib/ember-dev/warning.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/warning.ts
@@ -72,7 +72,7 @@ class WarningAssert extends DebugAssert {
     // expectWarning(/* optionalStringOrRegex */);
     // Ember.warn("Times definitely be changin'");
     //
-    let expectWarning: ExpectWarningFunc = (func, message) => {
+    let expectWarning: ExpectWarningFunc = (func, message, options?) => {
       let actualFunc: (() => void) | undefined;
       if (typeof func !== 'function') {
         message = func as Message;
@@ -86,7 +86,7 @@ class WarningAssert extends DebugAssert {
           throw new Error('expectWarning was called after expectNoWarning was called!');
         }
 
-        tracker.expectCall(message);
+        tracker.expectCall(message, options);
       });
     };
 


### PR DESCRIPTION
This PR adds a warning to the `{{action}}` modifier and the `{{action}}`
helper which tells the user they should add the `@action` decorator to
any method which is passed to it. We're only warning for the time being
since this _is_ a supported codepath, but has been actively discouraged
in the past.