### PR TITLE
[BUGFIX beta] assert `<Input>` and `<Textarea>`

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/resolver.ts
+++ b/packages/@ember/-internals/glimmer/lib/resolver.ts
@@ -123,9 +123,6 @@ export default class RuntimeResolver implements IRuntimeResolver<OwnedTemplateMe
    * Called while executing Append Op.PushDynamicComponentManager if string
    */
   lookupComponentDefinition(name: string, meta: OwnedTemplateMeta): Option<ComponentDefinition> {
-    assert('You cannot use `textarea` as a component name.', name !== 'textarea');
-    assert('You cannot use `input` as a component name.', name !== 'input');
-
     let handle = this.lookupComponentHandle(name, meta);
     if (handle === null) {
       assert(
@@ -306,6 +303,9 @@ export default class RuntimeResolver implements IRuntimeResolver<OwnedTemplateMe
     _name: string,
     meta: OwnedTemplateMeta
   ): Option<ComponentDefinition> {
+    assert('You cannot use `textarea` as a component name.', _name !== 'textarea');
+    assert('You cannot use `input` as a component name.', _name !== 'input');
+
     let name = _name;
     let namespace = undefined;
     if (EMBER_MODULE_UNIFICATION) {

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/input-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/input-test.js
@@ -80,6 +80,12 @@ class InputRenderingTest extends RenderingTestCase {
 moduleFor(
   'Helpers test: {{input}}',
   class extends InputRenderingTest {
+    ['@test should not allow angle bracket invocation']() {
+      expectAssertion(() => {
+        this.render('<Input />');
+      }, 'You cannot use `input` as a component name.');
+    }
+
     ['@test a single text field is inserted into the DOM']() {
       this.render(`{{input type="text" value=value}}`, { value: 'hello' });
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/text-area-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/text-area-test.js
@@ -66,6 +66,12 @@ applyMixins(
 moduleFor(
   'Helpers test: {{textarea}}',
   class extends TextAreaRenderingTest {
+    ['@test Should not allow angle bracket invocation']() {
+      expectAssertion(() => {
+        this.render('<Textarea />');
+      }, 'You cannot use `textarea` as a component name.');
+    }
+
     ['@test Should insert a textarea'](assert) {
       this.render('{{textarea}}');
 


### PR DESCRIPTION
`input` and `textarea` are intended to be reserved component names, but the assertion was added to the wrong place. The end result is that only `(component "input")` and `(component "textarea")` were disallowed, but not when using the angle bracket syntax `<Input />` and `<Textarea />`.

This compliments the existing tests in https://github.com/emberjs/ember.js/blob/master/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js#L1220-L1230