### PR TITLE
Fix octane component blueprint and octane blueprint tests

### DIFF
--- a/blueprints/component-addon/index.js
+++ b/blueprints/component-addon/index.js
@@ -4,8 +4,9 @@ const path = require('path');
 const stringUtil = require('ember-cli-string-utils');
 const getPathOption = require('ember-cli-get-component-path-option');
 const normalizeEntityName = require('ember-cli-normalize-entity-name');
+const useEditionDetector = require('../edition-detector');
 
-module.exports = {
+module.exports = useEditionDetector({
   description: 'Generates a component.',
 
   fileMapTokens: function() {
@@ -28,6 +29,18 @@ module.exports = {
         }
         return 'app';
       },
+      __templatepath__: function(options) {
+        if (options.pod) {
+          return path.join(options.podPath, options.locals.path, options.dasherizedModuleName);
+        }
+        return 'templates/components';
+      },
+      __templatename__: function(options) {
+        if (options.pod) {
+          return 'template';
+        }
+        return options.dasherizedModuleName;
+      },
     };
   },
 
@@ -40,14 +53,24 @@ module.exports = {
     let addonName = stringUtil.dasherize(addonRawName);
     let fileName = stringUtil.dasherize(options.entity.name);
     let importPathName = [addonName, 'components', fileName].join('/');
+    let templatePath = '';
 
     if (options.pod) {
       importPathName = [addonName, 'components', fileName, 'component'].join('/');
     }
 
+    if (this.project.isEmberCLIAddon() || (options.inRepoAddon && !options.inDummy)) {
+      if (options.pod) {
+        templatePath = './template';
+      } else {
+        templatePath = [addonName, 'templates/components', fileName].join('/');
+      }
+    }
+
     return {
       modulePath: importPathName,
+      templatePath,
       path: getPathOption(options),
     };
   },
-};
+});

--- a/blueprints/component-addon/native-files/__root__/__path__/__name__.js
+++ b/blueprints/component-addon/native-files/__root__/__path__/__name__.js
@@ -1,0 +1,1 @@
+export { default } from '<%= modulePath %>';

--- a/blueprints/component-addon/native-files/__root__/__templatepath__/__templatename__.js
+++ b/blueprints/component-addon/native-files/__root__/__templatepath__/__templatename__.js
@@ -1,0 +1,1 @@
+export { default } from '<%= templatePath %>';

--- a/blueprints/component/native-files/__root__/__path__/__name__.js
+++ b/blueprints/component/native-files/__root__/__path__/__name__.js
@@ -1,4 +1,4 @@
 import Component from '@glimmer/component';
-<%= importTemplate %>
-export default class <%= classifiedModuleName %>Component extends Component {<%= contents %>
+
+export default class <%= classifiedModuleName %>Component extends Component {
 }

--- a/node-tests/blueprints/component-test.js
+++ b/node-tests/blueprints/component-test.js
@@ -516,13 +516,11 @@ describe('Blueprint: component', function() {
 
     it('component foo', function() {
       return emberGenerateDestroy(['component', 'foo'], _file => {
-        expect(_file('src/ui/components/foo/component.js')).to.equal(
-          fixture('component/native-component.js')
-        );
+        expect(_file('app/components/foo.js')).to.equal(fixture('component/native-component.js'));
 
-        expect(_file('src/ui/components/foo/template.hbs')).to.equal('{{yield}}');
+        expect(_file('app/templates/components/foo.hbs')).to.equal('{{yield}}');
 
-        expect(_file('src/ui/components/foo/component-test.js')).to.equal(
+        expect(_file('tests/integration/components/foo-test.js')).to.equal(
           fixture('component-test/default-template.js', {
             replace: {
               component: 'foo',
@@ -535,13 +533,13 @@ describe('Blueprint: component', function() {
 
     it('component x-foo', function() {
       return emberGenerateDestroy(['component', 'x-foo'], _file => {
-        expect(_file('src/ui/components/x-foo/component.js')).to.equal(
+        expect(_file('app/components/x-foo.js')).to.equal(
           fixture('component/native-component-dash.js')
         );
 
-        expect(_file('src/ui/components/x-foo/template.hbs')).to.equal('{{yield}}');
+        expect(_file('app/templates/components/x-foo.hbs')).to.equal('{{yield}}');
 
-        expect(_file('src/ui/components/x-foo/component-test.js')).to.equal(
+        expect(_file('tests/integration/components/x-foo-test.js')).to.equal(
           fixture('component-test/default-template.js', {
             replace: {
               component: 'x-foo',
@@ -554,13 +552,13 @@ describe('Blueprint: component', function() {
 
     it('component foo/x-foo', function() {
       return emberGenerateDestroy(['component', 'foo/x-foo'], _file => {
-        expect(_file('src/ui/components/foo/x-foo/component.js')).to.equal(
+        expect(_file('app/components/foo/x-foo.js')).to.equal(
           fixture('component/native-component-nested.js')
         );
 
-        expect(_file('src/ui/components/foo/x-foo/template.hbs')).to.equal('{{yield}}');
+        expect(_file('app/templates/components/foo/x-foo.hbs')).to.equal('{{yield}}');
 
-        expect(_file('src/ui/components/foo/x-foo/component-test.js')).to.equal(
+        expect(_file('tests/integration/components/foo/x-foo-test.js')).to.equal(
           fixture('component-test/default-curly-template.js', {
             replace: {
               component: 'foo/x-foo',
@@ -821,19 +819,23 @@ describe('Blueprint: component', function() {
 
     it('component foo', function() {
       return emberGenerateDestroy(['component', 'foo'], _file => {
-        expect(_file('src/ui/components/foo/component.js')).to.equal(
-          fixture('component/native-component.js')
+        expect(_file('addon/components/foo.js')).to.equal(fixture('component/native-component.js'));
+
+        expect(_file('addon/templates/components/foo.hbs')).to.equal('{{yield}}');
+
+        expect(_file('app/components/foo.js')).to.contain(
+          "export { default } from 'my-addon/components/foo';"
         );
 
-        expect(_file('src/ui/components/foo/template.hbs')).to.equal('{{yield}}');
+        expect(_file('app/templates/components/foo.js')).to.contain(
+          "export { default } from 'my-addon/templates/components/foo';"
+        );
 
-        expect(_file('src/ui/components/foo/component-test.js')).to.equal(
+        expect(_file('tests/integration/components/foo-test.js')).to.equal(
           fixture('component-test/default-template.js', {
             replace: {
               component: 'foo',
               componentInvocation: 'Foo',
-              path: 'my-addon::',
-              pathInvocation: 'MyAddon::',
             },
           })
         );
@@ -842,19 +844,25 @@ describe('Blueprint: component', function() {
 
     it('component x-foo', function() {
       return emberGenerateDestroy(['component', 'x-foo'], _file => {
-        expect(_file('src/ui/components/x-foo/component.js')).to.equal(
+        expect(_file('addon/components/x-foo.js')).to.equal(
           fixture('component/native-component-dash.js')
         );
 
-        expect(_file('src/ui/components/x-foo/template.hbs')).to.equal('{{yield}}');
+        expect(_file('addon/templates/components/x-foo.hbs')).to.equal('{{yield}}');
 
-        expect(_file('src/ui/components/x-foo/component-test.js')).to.equal(
+        expect(_file('app/components/x-foo.js')).to.contain(
+          "export { default } from 'my-addon/components/x-foo';"
+        );
+
+        expect(_file('app/templates/components/x-foo.js')).to.contain(
+          "export { default } from 'my-addon/templates/components/x-foo';"
+        );
+
+        expect(_file('tests/integration/components/x-foo-test.js')).to.equal(
           fixture('component-test/default-template.js', {
             replace: {
               component: 'x-foo',
               componentInvocation: 'XFoo',
-              path: 'my-addon::',
-              pathInvocation: 'MyAddon::',
             },
           })
         );
@@ -863,17 +871,24 @@ describe('Blueprint: component', function() {
 
     it('component foo/x-foo', function() {
       return emberGenerateDestroy(['component', 'foo/x-foo'], _file => {
-        expect(_file('src/ui/components/foo/x-foo/component.js')).to.equal(
+        expect(_file('addon/components/foo/x-foo.js')).to.equal(
           fixture('component/native-component-nested.js')
         );
 
-        expect(_file('src/ui/components/foo/x-foo/template.hbs')).to.equal('{{yield}}');
+        expect(_file('addon/templates/components/foo/x-foo.hbs')).to.equal('{{yield}}');
 
-        expect(_file('src/ui/components/foo/x-foo/component-test.js')).to.equal(
+        expect(_file('app/components/foo/x-foo.js')).to.contain(
+          "export { default } from 'my-addon/components/foo/x-foo';"
+        );
+
+        expect(_file('app/templates/components/foo/x-foo.js')).to.contain(
+          "export { default } from 'my-addon/templates/components/foo/x-foo';"
+        );
+
+        expect(_file('tests/integration/components/foo/x-foo-test.js')).to.equal(
           fixture('component-test/default-curly-template.js', {
             replace: {
               component: 'foo/x-foo',
-              path: 'my-addon::',
             },
           })
         );
@@ -882,29 +897,31 @@ describe('Blueprint: component', function() {
 
     it('component x-foo --dummy', function() {
       return emberGenerateDestroy(['component', 'x-foo', '--dummy'], _file => {
-        expect(_file('tests/dummy/src/ui/components/x-foo/component.js')).to.equal(
+        expect(_file('tests/dummy/app/components/x-foo.js')).to.equal(
           fixture('component/native-component-dash.js')
         );
 
-        expect(_file('tests/dummy/src/ui/components/x-foo/template.hbs')).to.equal('{{yield}}');
+        expect(_file('tests/dummy/app/templates/components/x-foo.hbs')).to.equal('{{yield}}');
 
-        expect(_file('src/ui/components/x-foo/component.js')).to.not.exist;
+        expect(_file('app/components/x-foo.js')).to.not.exist;
+        expect(_file('app/templates/components/x-foo.js')).to.not.exist;
 
-        expect(_file('src/ui/components/x-foo/component-test.js')).to.not.exist;
+        expect(_file('tests/integration/components/x-foo-test.js')).to.not.exist;
       });
     });
 
     it('component foo/x-foo --dummy', function() {
       return emberGenerateDestroy(['component', 'foo/x-foo', '--dummy'], _file => {
-        expect(_file('tests/dummy/src/ui/components/foo/x-foo/component.js')).to.equal(
+        expect(_file('tests/dummy/app/components/foo/x-foo.js')).to.equal(
           fixture('component/native-component-nested.js')
         );
 
-        expect(_file('tests/dummy/src/ui/components/foo/x-foo/template.hbs')).to.equal('{{yield}}');
+        expect(_file('tests/dummy/app/templates/components/foo/x-foo.hbs')).to.equal('{{yield}}');
 
-        expect(_file('src/ui/components/foo/x-foo/component.js')).to.not.exist;
+        expect(_file('app/components/foo/x-foo.js')).to.not.exist;
+        expect(_file('app/templates/components/foo/x-foo.js')).to.not.exist;
 
-        expect(_file('src/ui/components/foo/x-foo/component-test.js')).to.not.exist;
+        expect(_file('tests/integration/components/foo/x-foo-test.js')).to.not.exist;
       });
     });
   });
@@ -1120,19 +1137,25 @@ describe('Blueprint: component', function() {
 
     it('component foo --in-repo-addon=my-addon', function() {
       return emberGenerateDestroy(['component', 'foo', '--in-repo-addon=my-addon'], _file => {
-        expect(_file('packages/my-addon/src/ui/components/foo/component.js')).to.equal(
+        expect(_file('lib/my-addon/addon/components/foo.js')).to.equal(
           fixture('component/native-component.js')
         );
 
-        expect(_file('packages/my-addon/src/ui/components/foo/template.hbs')).to.equal('{{yield}}');
+        expect(_file('lib/my-addon/addon/templates/components/foo.hbs')).to.equal('{{yield}}');
 
-        expect(_file('packages/my-addon/src/ui/components/foo/component-test.js')).to.equal(
+        expect(_file('lib/my-addon/app/components/foo.js')).to.contain(
+          "export { default } from 'my-addon/components/foo';"
+        );
+
+        expect(_file('lib/my-addon/app/templates/components/foo.js')).to.contain(
+          "export { default } from 'my-addon/templates/components/foo';"
+        );
+
+        expect(_file('tests/integration/components/foo-test.js')).to.equal(
           fixture('component-test/default-template.js', {
             replace: {
               component: 'foo',
               componentInvocation: 'Foo',
-              path: 'my-addon::',
-              pathInvocation: 'MyAddon::',
             },
           })
         );
@@ -1141,21 +1164,25 @@ describe('Blueprint: component', function() {
 
     it('component x-foo --in-repo-addon=my-addon', function() {
       return emberGenerateDestroy(['component', 'x-foo', '--in-repo-addon=my-addon'], _file => {
-        expect(_file('packages/my-addon/src/ui/components/x-foo/component.js')).to.equal(
+        expect(_file('lib/my-addon/addon/components/x-foo.js')).to.equal(
           fixture('component/native-component-dash.js')
         );
 
-        expect(_file('packages/my-addon/src/ui/components/x-foo/template.hbs')).to.equal(
-          '{{yield}}'
+        expect(_file('lib/my-addon/addon/templates/components/x-foo.hbs')).to.equal('{{yield}}');
+
+        expect(_file('lib/my-addon/app/components/x-foo.js')).to.contain(
+          "export { default } from 'my-addon/components/x-foo';"
         );
 
-        expect(_file('packages/my-addon/src/ui/components/x-foo/component-test.js')).to.equal(
+        expect(_file('lib/my-addon/app/templates/components/x-foo.js')).to.contain(
+          "export { default } from 'my-addon/templates/components/x-foo';"
+        );
+
+        expect(_file('tests/integration/components/x-foo-test.js')).to.equal(
           fixture('component-test/default-template.js', {
             replace: {
               component: 'x-foo',
               componentInvocation: 'XFoo',
-              path: 'my-addon::',
-              pathInvocation: 'MyAddon::',
             },
           })
         );

--- a/node-tests/blueprints/controller-test.js
+++ b/node-tests/blueprints/controller-test.js
@@ -321,11 +321,11 @@ describe('Blueprint: controller', function() {
 
     it('controller foo', function() {
       return emberGenerateDestroy(['controller', 'foo'], _file => {
-        expect(_file('src/ui/routes/foo/controller.js')).to.equal(
+        expect(_file('app/controllers/foo.js')).to.equal(
           fixture('controller/native-controller.js')
         );
 
-        expect(_file('src/ui/routes/foo/controller-test.js')).to.equal(
+        expect(_file('tests/unit/controllers/foo-test.js')).to.equal(
           fixture('controller-test/default.js')
         );
       });
@@ -333,11 +333,11 @@ describe('Blueprint: controller', function() {
 
     it('controller foo/bar', function() {
       return emberGenerateDestroy(['controller', 'foo/bar'], _file => {
-        expect(_file('src/ui/routes/foo/bar/controller.js')).to.equal(
+        expect(_file('app/controllers/foo/bar.js')).to.equal(
           fixture('controller/native-controller-nested.js')
         );
 
-        expect(_file('src/ui/routes/foo/bar/controller-test.js')).to.equal(
+        expect(_file('tests/unit/controllers/foo/bar-test.js')).to.equal(
           fixture('controller-test/default-nested.js')
         );
       });
@@ -349,10 +349,15 @@ describe('Blueprint: controller', function() {
       });
 
       it('controller foo --pod podModulePrefix', function() {
-        return expectError(
-          emberGenerateDestroy(['controller', 'foo', '--pod']),
-          "Pods aren't supported within a module unification app"
-        );
+        return emberGenerateDestroy(['controller', 'foo', '--pod'], _file => {
+          expect(_file('app/pods/foo/controller.js')).to.equal(
+            fixture('controller/native-controller.js')
+          );
+
+          expect(_file('tests/unit/pods/foo/controller-test.js')).to.equal(
+            fixture('controller-test/default.js')
+          );
+        });
       });
     });
   });
@@ -373,66 +378,57 @@ describe('Blueprint: controller', function() {
 
     it('controller foo', function() {
       return emberGenerateDestroy(['controller', 'foo'], _file => {
-        expect(_file('src/ui/routes/foo/controller.js')).to.equal(
+        expect(_file('addon/controllers/foo.js')).to.equal(
           fixture('controller/native-controller.js')
         );
 
-        expect(_file('src/ui/routes/foo/controller-test.js')).to.equal(
-          fixture('controller-test/default.js')
+        expect(_file('app/controllers/foo.js')).to.contain(
+          "export { default } from 'my-addon/controllers/foo';"
         );
 
-        expect(_file('app/controllers/foo.js')).to.not.exist;
+        expect(_file('tests/unit/controllers/foo-test.js')).to.equal(
+          fixture('controller-test/default.js')
+        );
       });
     });
 
     it('controller foo/bar', function() {
       return emberGenerateDestroy(['controller', 'foo/bar'], _file => {
-        expect(_file('src/ui/routes/foo/bar/controller.js')).to.equal(
+        expect(_file('addon/controllers/foo/bar.js')).to.equal(
           fixture('controller/native-controller-nested.js')
         );
 
-        expect(_file('src/ui/routes/foo/bar/controller-test.js')).to.equal(
-          fixture('controller-test/default-nested.js')
+        expect(_file('app/controllers/foo/bar.js')).to.contain(
+          "export { default } from 'my-addon/controllers/foo/bar';"
         );
 
-        expect(_file('app/controllers/foo/bar.js')).to.not.exist;
+        expect(_file('tests/unit/controllers/foo/bar-test.js')).to.equal(
+          fixture('controller-test/default-nested.js')
+        );
       });
     });
 
     it('controller foo --dummy', function() {
       return emberGenerateDestroy(['controller', 'foo', '--dummy'], _file => {
-        expect(_file('tests/dummy/src/ui/routes/foo/controller.js')).to.equal(
+        expect(_file('tests/dummy/app/controllers/foo.js')).to.equal(
           fixture('controller/native-controller.js')
         );
 
-        expect(_file('src/ui/routes/foo/controller.js')).to.not.exist;
+        expect(_file('app/controllers/foo-test.js')).to.not.exist;
 
-        expect(_file('src/ui/routes/foo/controller-test.js')).to.not.exist;
+        expect(_file('tests/unit/controllers/foo-test.js')).to.not.exist;
       });
     });
 
     it('controller foo/bar --dummy', function() {
       return emberGenerateDestroy(['controller', 'foo/bar', '--dummy'], _file => {
-        expect(_file('tests/dummy/src/ui/routes/foo/bar/controller.js')).to.equal(
+        expect(_file('tests/dummy/app/controllers/foo/bar.js')).to.equal(
           fixture('controller/native-controller-nested.js')
         );
 
-        expect(_file('src/ui/routes/foo/bar/controller.js')).to.not.exist;
+        expect(_file('app/controllers/foo/bar.js')).to.not.exist;
 
-        expect(_file('src/ui/routes/foo/bar/controller-test.js')).to.not.exist;
-      });
-    });
-
-    describe('with podModulePrefix', function() {
-      beforeEach(function() {
-        setupPodConfig({ podModulePrefix: true });
-      });
-
-      it('controller foo --pod podModulePrefix', function() {
-        return expectError(
-          emberGenerateDestroy(['controller', 'foo', '--pod']),
-          "Pods aren't supported within a module unification app"
-        );
+        expect(_file('tests/unit/controllers/foo/bar-test.js')).to.not.exist;
       });
     });
   });

--- a/node-tests/blueprints/route-test.js
+++ b/node-tests/blueprints/route-test.js
@@ -600,43 +600,43 @@ describe('Blueprint: route', function() {
 
     it('route foo', function() {
       return emberGenerateDestroy(['route', 'foo'], _file => {
-        expect(_file('src/ui/routes/foo/route.js')).to.equal(fixture('route/native-route.js'));
+        expect(_file('app/routes/foo.js')).to.equal(fixture('route/native-route.js'));
 
-        expect(_file('src/ui/routes/foo/template.hbs')).to.equal('{{outlet}}');
+        expect(_file('app/templates/foo.hbs')).to.equal('{{outlet}}');
 
-        expect(_file('src/ui/routes/foo/route-test.js')).to.equal(fixture('route-test/default.js'));
+        expect(_file('tests/unit/routes/foo-test.js')).to.equal(fixture('route-test/default.js'));
 
-        expect(file('src/router.js')).to.contain("this.route('foo')");
+        expect(file('app/router.js')).to.contain("this.route('foo')");
       }).then(() => {
-        expect(file('src/router.js')).to.not.contain("this.route('foo')");
+        expect(file('app/router.js')).to.not.contain("this.route('foo')");
       });
     });
 
     it('route foo --skip-router', function() {
       return emberGenerateDestroy(['route', 'foo', '--skip-router'], _file => {
-        expect(_file('src/ui/routes/foo/route.js')).to.exist;
-        expect(_file('src/ui/routes/foo/template.hbs')).to.exist;
-        expect(_file('src/ui/routes/foo/route-test.js')).to.exist;
-        expect(file('src/router.js')).to.not.contain("this.route('foo')");
+        expect(_file('app/routes/foo.js')).to.exist;
+        expect(_file('app/templates/foo.hbs')).to.exist;
+        expect(_file('tests/unit/routes/foo-test.js')).to.exist;
+        expect(file('app/router.js')).to.not.contain("this.route('foo')");
       }).then(() => {
-        expect(file('src/router.js')).to.not.contain("this.route('foo')");
+        expect(file('app/router.js')).to.not.contain("this.route('foo')");
       });
     });
 
     it('route foo --path=:foo_id/show', function() {
       return emberGenerateDestroy(['route', 'foo', '--path=:foo_id/show'], _file => {
-        expect(_file('src/ui/routes/foo/route.js')).to.equal(fixture('route/native-route.js'));
+        expect(_file('app/routes/foo.js')).to.equal(fixture('route/native-route.js'));
 
-        expect(_file('src/ui/routes/foo/template.hbs')).to.equal('{{outlet}}');
+        expect(_file('app/templates/foo.hbs')).to.equal('{{outlet}}');
 
-        expect(_file('src/ui/routes/foo/route-test.js')).to.equal(fixture('route-test/default.js'));
+        expect(_file('tests/unit/routes/foo-test.js')).to.equal(fixture('route-test/default.js'));
 
-        expect(file('src/router.js'))
+        expect(file('app/router.js'))
           .to.contain("this.route('foo', {")
           .to.contain("path: ':foo_id/show'")
           .to.contain('});');
       }).then(() => {
-        expect(file('src/router.js'))
+        expect(file('app/router.js'))
           .to.not.contain("this.route('foo'")
           .to.not.contain("path: ':foo_id/show'");
       });
@@ -644,17 +644,15 @@ describe('Blueprint: route', function() {
 
     it('route parent/child --reset-namespace', function() {
       return emberGenerateDestroy(['route', 'parent/child', '--reset-namespace'], _file => {
-        expect(_file('src/ui/routes/parent/child/route.js')).to.equal(
-          fixture('route/native-route-child.js')
-        );
+        expect(_file('app/routes/child.js')).to.equal(fixture('route/native-route-child.js'));
 
-        expect(_file('src/ui/routes/parent/child/template.hbs')).to.equal('{{outlet}}');
+        expect(_file('app/templates/child.hbs')).to.equal('{{outlet}}');
 
-        expect(_file('src/ui/routes/parent/child/route-test.js')).to.equal(
+        expect(_file('tests/unit/routes/child-test.js')).to.equal(
           fixture('route-test/default-child.js')
         );
 
-        expect(file('src/router.js'))
+        expect(file('app/router.js'))
           .to.contain("this.route('parent', {")
           .to.contain("this.route('child', {")
           .to.contain('resetNamespace: true')
@@ -663,73 +661,102 @@ describe('Blueprint: route', function() {
     });
 
     it('route parent/child --reset-namespace --pod', function() {
-      return expectError(
-        emberGenerateDestroy(['route', 'parent/child', '--reset-namespace', '--pod']),
-        "Pods aren't supported within a module unification app"
+      return emberGenerateDestroy(
+        ['route', 'parent/child', '--reset-namespace', '--pod'],
+        _file => {
+          expect(_file('app/child/route.js')).to.equal(fixture('route/native-route-child.js'));
+
+          expect(_file('app/child/template.hbs')).to.equal('{{outlet}}');
+
+          expect(_file('tests/unit/child/route-test.js')).to.equal(
+            fixture('route-test/default-child.js')
+          );
+
+          expect(file('app/router.js'))
+            .to.contain("this.route('parent', {")
+            .to.contain("this.route('child', {")
+            .to.contain('resetNamespace: true')
+            .to.contain('});');
+        }
       );
     });
 
     it('route index', function() {
       return emberGenerateDestroy(['route', 'index'], _file => {
-        expect(_file('src/ui/routes/index/route.js')).to.exist;
-        expect(_file('src/ui/routes/index/template.hbs')).to.exist;
-        expect(_file('src/ui/routes/index/route-test.js')).to.exist;
-        expect(file('src/router.js')).to.not.contain("this.route('index')");
+        expect(_file('app/routes/index.js')).to.exist;
+        expect(_file('app/templates/index.hbs')).to.exist;
+        expect(_file('tests/unit/routes/index-test.js')).to.exist;
+        expect(file('app/router.js')).to.not.contain("this.route('index')");
       }).then(() => {
-        expect(file('src/router.js')).to.not.contain("this.route('index')");
+        expect(file('app/router.js')).to.not.contain("this.route('index')");
       });
     });
 
     it('route application', function() {
-      fs.removeSync('src/ui/routes/application/template.hbs');
+      fs.removeSync('app/templates/application.hbs');
       return emberGenerate(['route', 'application']).then(() => {
-        expect(file('src/ui/routes/application/template.hbs')).to.exist;
-        expect(file('src/router.js')).to.not.contain("this.route('application')");
+        expect(file('app/router.js')).to.not.contain("this.route('application')");
       });
     });
 
     it('route basic', function() {
       return emberGenerateDestroy(['route', 'basic'], _file => {
-        expect(_file('src/ui/routes/basic/route.js')).to.exist;
-        expect(file('src/router.js')).to.not.contain("this.route('basic')");
+        expect(_file('app/routes/basic.js')).to.exist;
+        expect(file('app/router.js')).to.not.contain("this.route('basic')");
       }).then(() => {
-        expect(file('src/router.js')).to.not.contain("this.route('basic')");
+        expect(file('app/router.js')).to.not.contain("this.route('basic')");
       });
     });
 
     it('route foo --pod', function() {
-      return expectError(
-        emberGenerateDestroy(['route', 'foo', '--pod']),
-        "Pods aren't supported within a module unification app"
-      );
+      return emberGenerateDestroy(['route', 'foo', '--pod'], _file => {
+        expect(_file('app/foo/route.js')).to.equal(fixture('route/native-route.js'));
+
+        expect(_file('app/foo/template.hbs')).to.equal('{{outlet}}');
+
+        expect(_file('tests/unit/foo/route-test.js')).to.equal(fixture('route-test/default.js'));
+
+        expect(file('app/router.js')).to.contain("this.route('foo')");
+      }).then(() => {
+        expect(file('app/router.js')).to.not.contain("this.route('foo')");
+      });
     });
 
     it('route foo --pod with --path', function() {
-      return expectError(
-        emberGenerateDestroy(['route', 'foo', '--pod', '--path=:foo_id/show']),
-        "Pods aren't supported within a module unification app"
-      );
+      return emberGenerate(['route', 'foo', '--pod', '--path=:foo_id/show'])
+        .then(() =>
+          expect(file('app/router.js'))
+            .to.contain("this.route('foo', {")
+            .to.contain("path: ':foo_id/show'")
+            .to.contain('});')
+        )
+
+        .then(() => emberDestroy(['route', 'foo', '--pod', '--path=:foo_id/show']))
+        .then(() =>
+          expect(file('app/router.js'))
+            .to.not.contain("this.route('foo', {")
+            .to.not.contain("path: ':foo_id/show'")
+        );
     });
 
     it('route index --pod', function() {
-      return expectError(
-        emberGenerate(['route', 'index', '--pod']),
-        "Pods aren't supported within a module unification app"
+      return emberGenerate(['route', 'index', '--pod']).then(() =>
+        expect(file('app/router.js')).to.not.contain("this.route('index')")
       );
     });
 
     it('route application --pod', function() {
-      return expectError(
-        emberGenerate(['route', 'application', '--pod']),
-        "Pods aren't supported within a module unification app"
-      );
+      return emberGenerate(['route', 'application', '--pod'])
+        .then(() => expect(file('app/application/route.js')).to.exist)
+        .then(() => expect(file('app/application/template.hbs')).to.exist)
+        .then(() => expect(file('app/router.js')).to.not.contain("this.route('application')"));
     });
 
     it('route basic --pod', function() {
-      return expectError(
-        emberGenerate(['route', 'basic', '--pod']),
-        "Pods aren't supported within a module unification app"
-      );
+      return emberGenerateDestroy(['route', 'basic', '--pod'], _file => {
+        expect(_file('app/basic/route.js')).to.exist;
+        expect(file('app/router.js')).to.not.contain("this.route('index')");
+      });
     });
 
     describe('with podModulePrefix', function() {
@@ -738,10 +765,19 @@ describe('Blueprint: route', function() {
       });
 
       it('route foo --pod', function() {
-        return expectError(
-          emberGenerateDestroy(['route', 'foo', '--pod']),
-          "Pods aren't supported within a module unification app"
-        );
+        return emberGenerateDestroy(['route', 'foo', '--pod'], _file => {
+          expect(_file('app/pods/foo/route.js')).to.equal(fixture('route/native-route.js'));
+
+          expect(_file('app/pods/foo/template.hbs')).to.equal('{{outlet}}');
+
+          expect(_file('tests/unit/pods/foo/route-test.js')).to.equal(
+            fixture('route-test/default.js')
+          );
+
+          expect(file('app/router.js')).to.contain("this.route('foo')");
+        }).then(() => {
+          expect(file('app/router.js')).to.not.contain("this.route('foo')");
+        });
       });
     });
   });
@@ -762,79 +798,102 @@ describe('Blueprint: route', function() {
 
     it('route foo', function() {
       return emberGenerateDestroy(['route', 'foo'], _file => {
-        expect(_file('src/ui/routes/foo/route.js')).to.equal(fixture('route/native-route.js'));
+        expect(_file('addon/routes/foo.js')).to.equal(fixture('route/native-route.js'));
 
-        expect(_file('src/ui/routes/foo/template.hbs')).to.equal('{{outlet}}');
+        expect(_file('addon/templates/foo.hbs')).to.equal('{{outlet}}');
 
-        expect(_file('src/ui/routes/foo/route-test.js')).to.equal(fixture('route-test/default.js'));
+        expect(_file('app/routes/foo.js')).to.contain(
+          "export { default } from 'my-addon/routes/foo';"
+        );
 
-        expect(file('tests/dummy/src/router.js')).to.not.contain("this.route('foo')");
+        expect(_file('app/templates/foo.js')).to.contain(
+          "export { default } from 'my-addon/templates/foo';"
+        );
+
+        expect(_file('tests/unit/routes/foo-test.js')).to.equal(fixture('route-test/default.js'));
+
+        expect(file('tests/dummy/app/router.js')).to.not.contain("this.route('foo')");
       }).then(() => {
-        expect(file('tests/dummy/src/router.js')).to.not.contain("this.route('foo')");
+        expect(file('tests/dummy/app/router.js')).to.not.contain("this.route('foo')");
       });
     });
 
     it('route foo/bar', function() {
       return emberGenerateDestroy(['route', 'foo/bar'], _file => {
-        expect(_file('src/ui/routes/foo/bar/route.js')).to.equal(
-          fixture('route/native-route-nested.js')
+        expect(_file('addon/routes/foo/bar.js')).to.equal(fixture('route/native-route-nested.js'));
+
+        expect(_file('addon/templates/foo/bar.hbs')).to.equal('{{outlet}}');
+
+        expect(_file('app/routes/foo/bar.js')).to.contain(
+          "export { default } from 'my-addon/routes/foo/bar';"
         );
 
-        expect(_file('src/ui/routes/foo/bar/template.hbs')).to.equal('{{outlet}}');
+        expect(_file('app/templates/foo/bar.js')).to.contain(
+          "export { default } from 'my-addon/templates/foo/bar';"
+        );
 
-        expect(_file('src/ui/routes/foo/bar/route-test.js')).to.equal(
+        expect(_file('tests/unit/routes/foo/bar-test.js')).to.equal(
           fixture('route-test/default-nested.js')
         );
 
-        expect(file('tests/dummy/src/router.js')).to.not.contain("this.route('bar')");
+        expect(file('tests/dummy/app/router.js')).to.not.contain("this.route('bar')");
       }).then(() => {
-        expect(file('tests/dummy/src/router.js')).to.not.contain("this.route('bar')");
+        expect(file('tests/dummy/app/router.js')).to.not.contain("this.route('bar')");
       });
     });
 
     it('route foo --dummy', function() {
       return emberGenerateDestroy(['route', 'foo', '--dummy'], _file => {
-        expect(_file('tests/dummy/src/ui/routes/foo/route.js')).to.equal(
-          fixture('route/native-route.js')
-        );
+        expect(_file('tests/dummy/app/routes/foo.js')).to.equal(fixture('route/native-route.js'));
 
-        expect(_file('tests/dummy/src/ui/routes/foo/template.hbs')).to.equal('{{outlet}}');
+        expect(_file('tests/dummy/app/templates/foo.hbs')).to.equal('{{outlet}}');
 
-        expect(_file('src/ui/routes/foo/route.js')).to.not.exist;
-        expect(_file('src/ui/routes/foo/template.hbs')).to.not.exist;
-        expect(_file('src/ui/routes/foo/route-test.js')).to.not.exist;
+        expect(_file('app/routes/foo.js')).to.not.exist;
+        expect(_file('app/templates/foo.hbs')).to.not.exist;
+        expect(_file('tests/unit/routes/foo-test.js')).to.not.exist;
 
-        expect(file('tests/dummy/src/router.js')).to.contain("this.route('foo')");
+        expect(file('tests/dummy/app/router.js')).to.contain("this.route('foo')");
       }).then(() => {
-        expect(file('tests/dummy/src/router.js')).to.not.contain("this.route('foo')");
+        expect(file('tests/dummy/app/router.js')).to.not.contain("this.route('foo')");
       });
     });
 
     it('route foo/bar --dummy', function() {
       return emberGenerateDestroy(['route', 'foo/bar', '--dummy'], _file => {
-        expect(_file('tests/dummy/src/ui/routes/foo/bar/route.js')).to.equal(
+        expect(_file('tests/dummy/app/routes/foo/bar.js')).to.equal(
           fixture('route/native-route-nested.js')
         );
 
-        expect(_file('tests/dummy/src/ui/routes/foo/bar/template.hbs')).to.equal('{{outlet}}');
+        expect(_file('tests/dummy/app/templates/foo/bar.hbs')).to.equal('{{outlet}}');
 
-        expect(_file('src/ui/routes/foo/route.js')).to.not.exist;
-        expect(_file('src/ui/routes/foo/template.hbs')).to.not.exist;
-        expect(_file('src/ui/routes/foo/route-test.js')).to.not.exist;
+        expect(_file('app/routes/foo/bar.js')).to.not.exist;
+        expect(_file('app/templates/foo/bar.hbs')).to.not.exist;
+        expect(_file('tests/unit/routes/foo/bar-test.js')).to.not.exist;
 
-        expect(file('tests/dummy/src/router.js'))
+        expect(file('tests/dummy/app/router.js'))
           .to.contain("this.route('foo', function() {")
           .to.contain("this.route('bar')");
       }).then(() => {
-        expect(file('tests/dummy/src/router.js')).to.not.contain("this.route('bar')");
+        expect(file('tests/dummy/app/router.js')).to.not.contain("this.route('bar')");
       });
     });
 
     it('route foo --pod', function() {
-      return expectError(
-        emberGenerateDestroy(['route', 'foo', '--pod']),
-        "Pods aren't supported within a module unification app"
-      );
+      return emberGenerateDestroy(['route', 'foo', '--pod'], _file => {
+        expect(_file('addon/foo/route.js')).to.equal(fixture('route/native-route.js'));
+
+        expect(_file('addon/foo/template.hbs')).to.equal('{{outlet}}');
+
+        expect(_file('app/foo/route.js')).to.contain(
+          "export { default } from 'my-addon/foo/route';"
+        );
+
+        expect(_file('app/foo/template.js')).to.contain(
+          "export { default } from 'my-addon/foo/template';"
+        );
+
+        expect(_file('tests/unit/foo/route-test.js')).to.equal(fixture('route-test/default.js'));
+      });
     });
   });
 

--- a/node-tests/blueprints/service-test.js
+++ b/node-tests/blueprints/service-test.js
@@ -158,29 +158,74 @@ describe('Blueprint: service', function() {
 
     it('service foo', function() {
       return emberGenerateDestroy(['service', 'foo'], _file => {
-        expect(_file('src/services/foo.js')).to.equal(fixture('service/native-service.js'));
+        expect(_file('app/services/foo.js')).to.equal(fixture('service/native-service.js'));
 
-        expect(_file('src/services/foo-test.js')).to.equal(fixture('service-test/default.js'));
+        expect(_file('tests/unit/services/foo-test.js')).to.equal(
+          fixture('service-test/default.js')
+        );
       });
     });
 
     it('service foo/bar', function() {
       return emberGenerateDestroy(['service', 'foo/bar'], _file => {
-        expect(_file('src/services/foo/bar.js')).to.equal(
+        expect(_file('app/services/foo/bar.js')).to.equal(
           fixture('service/native-service-nested.js')
         );
 
-        expect(_file('src/services/foo/bar-test.js')).to.equal(
+        expect(_file('tests/unit/services/foo/bar-test.js')).to.equal(
           fixture('service-test/default-nested.js')
         );
       });
     });
 
     it('service foo --pod', function() {
-      return expectError(
-        emberGenerateDestroy(['service', 'foo', '--pod']),
-        "Pods aren't supported within a module unification app"
-      );
+      return emberGenerateDestroy(['service', 'foo', '--pod'], _file => {
+        expect(_file('app/foo/service.js')).to.equal(fixture('service/native-service.js'));
+
+        expect(_file('tests/unit/foo/service-test.js')).to.equal(
+          fixture('service-test/default.js')
+        );
+      });
+    });
+
+    it('service foo/bar --pod', function() {
+      return emberGenerateDestroy(['service', 'foo/bar', '--pod'], _file => {
+        expect(_file('app/foo/bar/service.js')).to.equal(
+          fixture('service/native-service-nested.js')
+        );
+
+        expect(_file('tests/unit/foo/bar/service-test.js')).to.equal(
+          fixture('service-test/default-nested.js')
+        );
+      });
+    });
+
+    describe('with podModulePrefix', function() {
+      beforeEach(function() {
+        setupPodConfig({ podModulePrefix: true });
+      });
+
+      it('service foo --pod', function() {
+        return emberGenerateDestroy(['service', 'foo', '--pod'], _file => {
+          expect(_file('app/pods/foo/service.js')).to.equal(fixture('service/native-service.js'));
+
+          expect(_file('tests/unit/pods/foo/service-test.js')).to.equal(
+            fixture('service-test/default.js')
+          );
+        });
+      });
+
+      it('service foo/bar --pod', function() {
+        return emberGenerateDestroy(['service', 'foo/bar', '--pod'], _file => {
+          expect(_file('app/pods/foo/bar/service.js')).to.equal(
+            fixture('service/native-service-nested.js')
+          );
+
+          expect(_file('tests/unit/pods/foo/bar/service-test.js')).to.equal(
+            fixture('service-test/default-nested.js')
+          );
+        });
+      });
     });
   });
 
@@ -296,35 +341,40 @@ describe('Blueprint: service', function() {
 
     it('service foo', function() {
       return emberGenerateDestroy(['service', 'foo'], _file => {
-        expect(_file('src/services/foo.js')).to.equal(fixture('service/native-service.js'));
+        expect(_file('addon/services/foo.js')).to.equal(fixture('service/native-service.js'));
 
-        expect(_file('src/services/foo-test.js')).to.equal(fixture('service-test/default.js'));
+        expect(_file('app/services/foo.js')).to.contain(
+          "export { default } from 'my-addon/services/foo';"
+        );
 
-        expect(_file('app/services/foo.js')).to.not.exist;
+        expect(_file('tests/unit/services/foo-test.js')).to.equal(
+          fixture('service-test/default.js')
+        );
       });
     });
 
     it('service foo/bar', function() {
       return emberGenerateDestroy(['service', 'foo/bar'], _file => {
-        expect(_file('src/services/foo/bar.js')).to.equal(
+        expect(_file('addon/services/foo/bar.js')).to.equal(
           fixture('service/native-service-nested.js')
         );
 
-        expect(_file('src/services/foo/bar-test.js')).to.equal(
-          fixture('service-test/default-nested.js')
+        expect(_file('app/services/foo/bar.js')).to.contain(
+          "export { default } from 'my-addon/services/foo/bar';"
         );
 
-        expect(_file('app/services/foo/bar.js')).to.not.exist;
+        expect(_file('tests/unit/services/foo/bar-test.js')).to.equal(
+          fixture('service-test/default-nested.js')
+        );
       });
     });
 
     it('service foo/bar --dummy', function() {
       return emberGenerateDestroy(['service', 'foo/bar', '--dummy'], _file => {
-        expect(_file('tests/dummy/src/services/foo/bar.js')).to.equal(
+        expect(_file('tests/dummy/app/services/foo/bar.js')).to.equal(
           fixture('service/native-service-nested.js')
         );
-
-        expect(_file('src/services/foo/bar.js')).to.not.exist;
+        expect(_file('addon/services/foo/bar.js')).to.not.exist;
       });
     });
   });

--- a/node-tests/helpers/setup-test-environment.js
+++ b/node-tests/helpers/setup-test-environment.js
@@ -1,11 +1,9 @@
 function enableOctane() {
   beforeEach(function() {
-    process.env.EMBER_CLI_MODULE_UNIFICATION = 'true';
     process.env.EMBER_VERSION = 'OCTANE';
   });
 
   afterEach(function() {
-    delete process.env.EMBER_CLI_MODULE_UNIFICATION;
     delete process.env.EMBER_VERSION;
   });
 }


### PR DESCRIPTION
Closes #17737. The removal of the MU layout from the Octane edition requires to do some changes on the blueprints.

- Change the octane blueprint tests to disable the MU layout and fix the blueprint tests. 

- Fix octane in-addon component blueprint (based on the [sparkless addon blueprint](https://github.com/rwjblue/sparkles-component/tree/master/blueprints/sparkles-component-addon) implementation).