### PR TITLE
Fix component-test blueprint for ember-cli-mocha

### DIFF
--- a/blueprints/component-test/mocha-0.12-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/mocha-0.12-files/__root__/__testType__/__path__/__test__.js
@@ -24,7 +24,7 @@ describe('<%= friendlyTestDescription %>', function() {
       <%= closeComponent(componentName) %>
     `);
 
-    assert.equal(this.$().text().trim(), 'template block text');<% } else if(testType === 'unit') { %>// creates the component instance
+    expect(this.$().text().trim()).to.equal('template block text');<% } else if(testType === 'unit') { %>// creates the component instance
     let component = this.subject();
     // renders the component on the page
     this.render();

--- a/blueprints/component-test/mocha-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/mocha-files/__root__/__testType__/__path__/__test__.js
@@ -23,7 +23,7 @@ describeComponent('<%= componentPathName %>', '<%= friendlyTestDescription %>',
         <%= closeComponent(componentName) %>
       `);
 
-      assert.equal(this.$().text().trim(), 'template block text');<% } else if(testType === 'unit') { %>// creates the component instance
+      expect(this.$().text().trim()).to.equal('template block text');<% } else if(testType === 'unit') { %>// creates the component instance
       let component = this.subject();
       // renders the component on the page
       this.render();

--- a/node-tests/fixtures/component-test/mocha-0.12.js
+++ b/node-tests/fixtures/component-test/mocha-0.12.js
@@ -22,6 +22,6 @@ describe('Integration | Component | x-foo', function() {
       </XFoo>
     `);
 
-    assert.equal(this.$().text().trim(), 'template block text');
+    expect(this.$().text().trim()).to.equal('template block text');
   });
 });

--- a/node-tests/fixtures/component-test/mocha.js
+++ b/node-tests/fixtures/component-test/mocha.js
@@ -21,7 +21,7 @@ describeComponent('x-foo', 'Integration | Component | x-foo',
         </XFoo>
       `);
 
-      assert.equal(this.$().text().trim(), 'template block text');
+      expect(this.$().text().trim()).to.equal('template block text');
     });
   }
 );


### PR DESCRIPTION
Removes incidental use of QUnit's `assert()` introduced in #17685.