### PR TITLE
Fix mixin blueprint tests under Windows

### DIFF
--- a/node-tests/blueprints/mixin-test.js
+++ b/node-tests/blueprints/mixin-test.js
@@ -6,6 +6,7 @@ const emberNew = blueprintHelpers.emberNew;
 const emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
 const setupPodConfig = blueprintHelpers.setupPodConfig;
 const expectError = require('../helpers/expect-error');
+const EOL = require('os').EOL;
 
 const chai = require('ember-cli-blueprint-test-helpers/chai');
 const expect = chai.expect;
@@ -25,7 +26,7 @@ describe('Blueprint: mixin', function() {
       return emberGenerateDestroy(['mixin', 'foo'], _file => {
         expect(_file('app/mixins/foo.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain('export default Mixin.create({\n});');
+          .to.contain(`export default Mixin.create({${EOL}});`);
 
         expect(_file('tests/unit/mixins/foo-test.js')).to.contain(
           "import FooMixin from 'my-app/mixins/foo';"
@@ -37,7 +38,7 @@ describe('Blueprint: mixin', function() {
       return emberGenerateDestroy(['mixin', 'foo/bar'], _file => {
         expect(_file('app/mixins/foo/bar.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain('export default Mixin.create({\n});');
+          .to.contain(`export default Mixin.create({${EOL}});`);
 
         expect(_file('tests/unit/mixins/foo/bar-test.js')).to.contain(
           "import FooBarMixin from 'my-app/mixins/foo/bar';"
@@ -57,7 +58,7 @@ describe('Blueprint: mixin', function() {
       return emberGenerateDestroy(['mixin', 'foo', '--pod'], _file => {
         expect(_file('app/mixins/foo.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain('export default Mixin.create({\n});');
+          .to.contain(`export default Mixin.create({${EOL}});`);
 
         expect(_file('tests/unit/mixins/foo-test.js')).to.contain(
           "import FooMixin from 'my-app/mixins/foo';"
@@ -69,7 +70,7 @@ describe('Blueprint: mixin', function() {
       return emberGenerateDestroy(['mixin', 'foo/bar', '--pod'], _file => {
         expect(_file('app/mixins/foo/bar.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain('export default Mixin.create({\n});');
+          .to.contain(`export default Mixin.create({${EOL}});`);
 
         expect(_file('tests/unit/mixins/foo/bar-test.js')).to.contain(
           "import FooBarMixin from 'my-app/mixins/foo/bar';"
@@ -94,7 +95,7 @@ describe('Blueprint: mixin', function() {
         return emberGenerateDestroy(['mixin', 'foo', '--pod'], _file => {
           expect(_file('app/mixins/foo.js'))
             .to.contain("import Mixin from '@ember/object/mixin';")
-            .to.contain('export default Mixin.create({\n});');
+            .to.contain(`export default Mixin.create({${EOL}});`);
 
           expect(_file('tests/unit/mixins/foo-test.js')).to.contain(
             "import FooMixin from 'my-app/mixins/foo';"
@@ -106,7 +107,7 @@ describe('Blueprint: mixin', function() {
         return emberGenerateDestroy(['mixin', 'foo/bar', '--pod'], _file => {
           expect(_file('app/mixins/foo/bar.js'))
             .to.contain("import Mixin from '@ember/object/mixin';")
-            .to.contain('export default Mixin.create({\n});');
+            .to.contain(`export default Mixin.create({${EOL}});`);
 
           expect(_file('tests/unit/mixins/foo/bar-test.js')).to.contain(
             "import FooBarMixin from 'my-app/mixins/foo/bar';"
@@ -127,7 +128,7 @@ describe('Blueprint: mixin', function() {
       return emberGenerateDestroy(['mixin', 'foo'], _file => {
         expect(_file('src/mixins/foo.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain('export default Mixin.create({\n});');
+          .to.contain(`export default Mixin.create({${EOL}});`);
 
         expect(_file('src/mixins/foo-test.js')).to.contain(
           "import FooMixin from 'my-app/mixins/foo';"
@@ -139,7 +140,7 @@ describe('Blueprint: mixin', function() {
       return emberGenerateDestroy(['mixin', 'foo/bar'], _file => {
         expect(_file('src/mixins/foo/bar.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain('export default Mixin.create({\n});');
+          .to.contain(`export default Mixin.create({${EOL}});`);
 
         expect(_file('src/mixins/foo/bar-test.js')).to.contain(
           "import FooBarMixin from 'my-app/mixins/foo/bar';"
@@ -151,7 +152,7 @@ describe('Blueprint: mixin', function() {
       return emberGenerateDestroy(['mixin', 'foo/bar/baz'], _file => {
         expect(_file('src/mixins/foo/bar/baz.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain('export default Mixin.create({\n});');
+          .to.contain(`export default Mixin.create({${EOL}});`);
 
         expect(_file('src/mixins/foo/bar/baz-test.js')).to.contain(
           "import FooBarBazMixin from 'my-app/mixins/foo/bar/baz';"
@@ -176,7 +177,7 @@ describe('Blueprint: mixin', function() {
       return emberGenerateDestroy(['mixin', 'foo'], _file => {
         expect(_file('addon/mixins/foo.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain('export default Mixin.create({\n});');
+          .to.contain(`export default Mixin.create({${EOL}});`);
 
         expect(_file('tests/unit/mixins/foo-test.js')).to.contain(
           "import FooMixin from 'my-addon/mixins/foo';"
@@ -190,7 +191,7 @@ describe('Blueprint: mixin', function() {
       return emberGenerateDestroy(['mixin', 'foo/bar'], _file => {
         expect(_file('addon/mixins/foo/bar.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain('export default Mixin.create({\n});');
+          .to.contain(`export default Mixin.create({${EOL}});`);
 
         expect(_file('tests/unit/mixins/foo/bar-test.js')).to.contain(
           "import FooBarMixin from 'my-addon/mixins/foo/bar';"
@@ -204,7 +205,7 @@ describe('Blueprint: mixin', function() {
       return emberGenerateDestroy(['mixin', 'foo/bar/baz'], _file => {
         expect(_file('addon/mixins/foo/bar/baz.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain('export default Mixin.create({\n});');
+          .to.contain(`export default Mixin.create({${EOL}});`);
 
         expect(_file('tests/unit/mixins/foo/bar/baz-test.js')).to.contain(
           "import FooBarBazMixin from 'my-addon/mixins/foo/bar/baz';"
@@ -218,7 +219,7 @@ describe('Blueprint: mixin', function() {
       return emberGenerateDestroy(['mixin', 'foo/bar/baz', '--dummy'], _file => {
         expect(_file('tests/dummy/app/mixins/foo/bar/baz.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain('export default Mixin.create({\n});');
+          .to.contain(`export default Mixin.create({${EOL}});`);
 
         expect(_file('addon/mixins/foo/bar/baz.js')).to.not.exist;
       });
@@ -236,7 +237,7 @@ describe('Blueprint: mixin', function() {
       return emberGenerateDestroy(['mixin', 'foo'], _file => {
         expect(_file('src/mixins/foo.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain('export default Mixin.create({\n});');
+          .to.contain(`export default Mixin.create({${EOL}});`);
 
         expect(_file('src/mixins/foo-test.js')).to.contain(
           "import FooMixin from 'my-addon/mixins/foo';"
@@ -248,7 +249,7 @@ describe('Blueprint: mixin', function() {
       return emberGenerateDestroy(['mixin', 'foo/bar'], _file => {
         expect(_file('src/mixins/foo/bar.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain('export default Mixin.create({\n});');
+          .to.contain(`export default Mixin.create({${EOL}});`);
 
         expect(_file('src/mixins/foo/bar-test.js')).to.contain(
           "import FooBarMixin from 'my-addon/mixins/foo/bar';"
@@ -260,7 +261,7 @@ describe('Blueprint: mixin', function() {
       return emberGenerateDestroy(['mixin', 'foo/bar/baz'], _file => {
         expect(_file('src/mixins/foo/bar/baz.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain('export default Mixin.create({\n});');
+          .to.contain(`export default Mixin.create({${EOL}});`);
 
         expect(_file('src/mixins/foo/bar/baz-test.js')).to.contain(
           "import FooBarBazMixin from 'my-addon/mixins/foo/bar/baz';"
@@ -272,7 +273,7 @@ describe('Blueprint: mixin', function() {
       return emberGenerateDestroy(['mixin', 'foo/bar/baz', '--dummy'], _file => {
         expect(_file('tests/dummy/src/mixins/foo/bar/baz.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain('export default Mixin.create({\n});');
+          .to.contain(`export default Mixin.create({${EOL}});`);
 
         expect(_file('src/mixins/foo/bar/baz.js')).to.not.exist;
       });
@@ -288,7 +289,7 @@ describe('Blueprint: mixin', function() {
       return emberGenerateDestroy(['mixin', 'foo', '--in-repo-addon=my-addon'], _file => {
         expect(_file('lib/my-addon/addon/mixins/foo.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain('export default Mixin.create({\n});');
+          .to.contain(`export default Mixin.create({${EOL}});`);
 
         expect(_file('tests/unit/mixins/foo-test.js')).to.contain(
           "import FooMixin from 'my-addon/mixins/foo';"
@@ -300,7 +301,7 @@ describe('Blueprint: mixin', function() {
       return emberGenerateDestroy(['mixin', 'foo/bar', '--in-repo-addon=my-addon'], _file => {
         expect(_file('lib/my-addon/addon/mixins/foo/bar.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain('export default Mixin.create({\n});');
+          .to.contain(`export default Mixin.create({${EOL}});`);
 
         expect(_file('tests/unit/mixins/foo/bar-test.js')).to.contain(
           "import FooBarMixin from 'my-addon/mixins/foo/bar';"


### PR DESCRIPTION
Uncovered in https://github.com/typed-ember/ember-cli-typescript-blueprints/pull/74, tests fail under Windows due to hardcoded line ending character.