### PR TITLE
initializer blueprint: removed unused import

### DIFF
--- a/blueprints/initializer-test/mocha-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
+++ b/blueprints/initializer-test/mocha-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { describe, it, beforeEach, afterEach } from 'mocha';
-import { setupTest } from 'ember-mocha';
 import Application from '@ember/application';
 import { initialize } from '<%= modulePrefix %>/initializers/<%= dasherizedModuleName %>';
 <% if (destroyAppExists) { %>import destroyApp from '../../helpers/destroy-app';<% } else { %>import { run } from '@ember/runloop';<% } %>

--- a/blueprints/initializer-test/qunit-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
+++ b/blueprints/initializer-test/qunit-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
@@ -2,7 +2,6 @@ import Application from '@ember/application';
 
 import { initialize } from '<%= modulePrefix %>/initializers/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
 <% if (destroyAppExists) { %>import destroyApp from '../../helpers/destroy-app';<% } else { %>import { run } from '@ember/runloop';<% } %>
 
 module('<%= friendlyTestName %>', function(hooks) {

--- a/node-tests/fixtures/initializer-test/mocha-rfc232.js
+++ b/node-tests/fixtures/initializer-test/mocha-rfc232.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { describe, it, beforeEach, afterEach } from 'mocha';
-import { setupTest } from 'ember-mocha';
 import Application from '@ember/application';
 import { initialize } from 'my-app/initializers/foo';
 import { run } from '@ember/runloop';

--- a/node-tests/fixtures/initializer-test/module-unification/mocha-rfc232.js
+++ b/node-tests/fixtures/initializer-test/module-unification/mocha-rfc232.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { describe, it, beforeEach, afterEach } from 'mocha';
-import { setupTest } from 'ember-mocha';
 import Application from '@ember/application';
 import { initialize } from 'my-app/init/initializers/foo';
 import { run } from '@ember/runloop';

--- a/node-tests/fixtures/initializer-test/module-unification/rfc232.js
+++ b/node-tests/fixtures/initializer-test/module-unification/rfc232.js
@@ -2,7 +2,6 @@ import Application from '@ember/application';
 
 import { initialize } from 'my-app/init/initializers/foo';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 
 module('Unit | Initializer | foo', function(hooks) {

--- a/node-tests/fixtures/initializer-test/rfc232.js
+++ b/node-tests/fixtures/initializer-test/rfc232.js
@@ -2,7 +2,6 @@ import Application from '@ember/application';
 
 import { initialize } from 'my-app/initializers/foo';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 
 module('Unit | Initializer | foo', function(hooks) {


### PR DESCRIPTION
`setupTest()` was removed, but the import was left behind. (Dang, sorry!)