### PR TITLE
Fixes 595 in ember-learn/ember-api-docs - missing has-block API documentation

### DIFF
--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -184,7 +184,9 @@
 
   This component is invoked with a block:
   ```handlebars
-  {{#my-component}}Hi Jenn!{{/my-component}}
+  {{#my-component}}
+    Hi Jenn!
+  {{/my-component}}
   ```
 
   This component is invoked without a block:
@@ -206,6 +208,42 @@
   @method hasBlock
   @for Ember.Templates.helpers
   @return {Boolean} `true` if the component was invoked with a block
+  @public
+ */
+
+/**
+  `{{has-block-params}}` indicates if the component was invoked with block params.
+
+  This component is invoked with block params:
+  ```handlebars
+  {{#my-component as |favoriteFlavor|}}
+    Hi Jenn!
+  {{/my-component}}
+  ```
+
+  This component is invoked without block params:
+  ```handlebars
+  {{#my-component}}
+    Hi Jenn!
+  {{/my-component}}
+  ```
+
+  This is useful when you want to create a component that can render itself
+  differently when it is not invoked with block params.
+
+  ```app/templates/components/my-component.hbs
+  {{#if (has-block-params)}}
+    Welcome {{yield favoriteFlavor}}, we're happy you're here and hope you
+    enjoy your favorite ice cream flavor.
+  {{else}}
+    Welcome {{yield}}, we're happy you're here, but we're unsure what
+    flavor ice cream you would enjoy.
+  {{/if}}
+  ```
+
+  @method hasBlockParams
+  @for Ember.Templates.helpers
+  @return {Boolean} `true` if the component was invoked with block params
   @public
  */
 

--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -179,7 +179,7 @@
   @public
  */
 
- /**
+/**
   `{{has-block}}` indicates if the component was invoked with a block.
 
   This component is invoked with a block:
@@ -207,7 +207,7 @@
   @for Ember.Templates.helpers
   @return {Boolean} `true` if the component was invoked with a block
   @public
-*/
+ */
 
 /**
   Execute the `debugger` statement in the current template's context.

--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -185,13 +185,22 @@
   This component is invoked with a block:
   ```handlebars
   {{#my-component}}
-    Hi Jenn!
+    Hi Jen!
   {{/my-component}}
   ```
 
   This component is invoked without a block:
   ```handlebars
   {{my-component}}
+  ```
+
+  Using angle bracket invocation, this looks like:
+  ```html
+  <MyComponent>Hi Jen!</MyComponent> {{! with a block}}
+  ```
+
+  ```html
+  <MyComponent/> {{! without a block}}
   ```
 
   This is useful when you want to create a component that can optionally take a block
@@ -207,6 +216,7 @@
 
   @method hasBlock
   @for Ember.Templates.helpers
+  @param {String} the name of the block. The name (at the moment) is either "main" or "inverse" (though only curly components support inverse)
   @return {Boolean} `true` if the component was invoked with a block
   @public
  */
@@ -217,7 +227,7 @@
   This component is invoked with block params:
   ```handlebars
   {{#my-component as |favoriteFlavor|}}
-    Hi Jenn!
+    Hi Jen!
   {{/my-component}}
   ```
 
@@ -243,6 +253,7 @@
 
   @method hasBlockParams
   @for Ember.Templates.helpers
+  @param {String} the name of the block. The name (at the moment) is either "main" or "inverse" (though only curly components support inverse)
   @return {Boolean} `true` if the component was invoked with block params
   @public
  */

--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -179,6 +179,36 @@
   @public
  */
 
+ /**
+  `{{has-block}}` indicates if the component was invoked with a block.
+
+  This component is invoked with a block:
+  ```handlebars
+  {{#my-component}}Hi Jenn!{{/my-component}}
+  ```
+
+  This component is invoked without a block:
+  ```handlebars
+  {{my-component}}
+  ```
+
+  This is useful when you want to create a component that can optionally take a block
+  and then render a default template when it is not invoked with a block.
+
+  ```app/templates/components/my-component.hbs
+  {{#if (has-block)}}
+    Welcome {{yield}}, we are happy you're here!
+  {{else}}
+    Hey you! You're great!
+  {{/if}}
+  ```
+
+  @method hasBlock
+  @for Ember.Templates.helpers
+  @return {Boolean} `true` if the component was invoked with a block
+  @public
+*/
+
 /**
   Execute the `debugger` statement in the current template's context.
 

--- a/tests/docs/expected.js
+++ b/tests/docs/expected.js
@@ -257,6 +257,7 @@ module.exports = {
     'handleURL',
     'has',
     'hasArrayObservers',
+    'hasBlock',
     'hasListeners',
     'hasObserverFor',
     'hasRegistration',

--- a/tests/docs/expected.js
+++ b/tests/docs/expected.js
@@ -258,6 +258,7 @@ module.exports = {
     'has',
     'hasArrayObservers',
     'hasBlock',
+    'hasBlockParams',
     'hasListeners',
     'hasObserverFor',
     'hasRegistration',


### PR DESCRIPTION
This fixes issue: https://github.com/ember-learn/ember-api-docs/issues/595 

I think there are a bunch of helpers that are more foundational to glimmer, like `{{yield}}` and `{{with}}` where the documentation was just put in the `packages/@ember/-internals/glimmer/index.ts`, despite the real functionality living deeper below. This seems to fall into that bucket, which probably explains why the documentation is missing from the API docs. The clearest place where I could find where the `{{has-block}}` helper is handled is: 

https://github.com/emberjs/ember.js/blob/master/packages/%40ember/-internals/glimmer/lib/component-managers/curly.ts#L239-L242

But really, I think there are a lot of places that actually contribute to this functionality. Probably documenting `{{has-block}}` in the `packages/@ember/-internals/glimmer/index.ts` file is the most straightforward place to put it.