### PR TITLE
[DOC RouteInfo] Fix `find` docs

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/route-info.ts
+++ b/packages/@ember/-internals/routing/lib/system/route-info.ts
@@ -181,14 +181,14 @@
   leafmost `RouteInfo`.
   @property {RouteInfo|null} child
   @public
+*/
 
+/**
   Allows you to traverse through the linked list
   of `RouteInfo`s from the topmost to leafmost.
   Returns the first `RouteInfo` in the linked list
   for which the callback returns true.
-*/
 
-/**
     This method is similar to the `find()` method
     defined in ECMAScript 2015.
 


### PR DESCRIPTION
Sorry for the churn! I just realized that I misplaced the comment blocks in #17797.