### PR TITLE
[WIP] deprecate view registry

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/component-managers/curly.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/curly.ts
@@ -1,9 +1,11 @@
 import { privatize as P } from '@ember/-internals/container';
 import { get } from '@ember/-internals/metal';
 import { getOwner } from '@ember/-internals/owner';
-import { guidFor } from '@ember/-internals/utils';
 import {
   addChildView,
+  getElementId,
+  getViewId,
+  hasElementId,
   OwnedTemplateMeta,
   setElementView,
   setViewElement,
@@ -92,7 +94,7 @@ function applyAttributeBindings(
   }
 
   if (seen.indexOf('id') === -1) {
-    let id = component.elementId ? component.elementId : guidFor(component);
+    let id = hasElementId(component) ? getElementId(component) : getViewId(component);
     operations.setAttribute('id', PrimitiveReference.create(id), false, null);
   }
 
@@ -352,7 +354,7 @@ export default class CurlyComponentManager
     if (attributeBindings && attributeBindings.length) {
       applyAttributeBindings(element, attributeBindings, component, operations);
     } else {
-      let id = component.elementId ? component.elementId : guidFor(component);
+      let id = hasElementId(component) ? getElementId(component) : getViewId(component);
       operations.setAttribute('id', PrimitiveReference.create(id), false, null);
       IsVisibleBinding.install(element, component, operations);
     }
@@ -521,17 +523,15 @@ export function processComponentInitializationAssertions(component: Component, p
   );
 
   assert(
+    `You cannot use \`elementId\` on a tag-less component: ${component}`,
+    component.tagName !== '' || !hasElementId(component) || props.id === getElementId(component)
+  );
+
+  assert(
     `You cannot use \`classNameBindings\` on a tag-less component: ${component}`,
     component.tagName !== '' ||
       !component.classNameBindings ||
       component.classNameBindings.length === 0
-  );
-
-  assert(
-    `You cannot use \`elementId\` on a tag-less component: ${component}`,
-    component.tagName !== '' ||
-      props.id === component.elementId ||
-      (!component.elementId && component.elementId !== '')
   );
 
   assert(

--- a/packages/@ember/-internals/glimmer/lib/utils/bindings.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/bindings.ts
@@ -1,4 +1,4 @@
-import { get } from '@ember/-internals/metal';
+import { getElementId, getViewId } from '@ember/-internals/views';
 import { assert } from '@ember/debug';
 import { dasherize } from '@ember/string';
 import { Opaque, Option, Simple } from '@glimmer/interfaces';
@@ -86,13 +86,8 @@ export const AttributeBinding = {
     let [prop, attribute, isSimple] = parsed;
 
     if (attribute === 'id') {
-      let elementId = get(component, prop);
-      if (elementId === undefined || elementId === null) {
-        elementId = component.elementId;
-      }
-      elementId = PrimitiveReference.create(elementId);
-      operations.setAttribute('id', elementId, true, null);
-      // operations.addStaticAttribute(element, 'id', elementId);
+      let elementId = component[prop] || getElementId(component) || getViewId(component);
+      operations.setAttribute('id', PrimitiveReference.create(elementId), true, null);
       return;
     }
 
@@ -111,7 +106,6 @@ export const AttributeBinding = {
     }
 
     operations.setAttribute(attribute, reference, false, null);
-    // operations.addDynamicAttribute(element, attribute, reference, false);
   },
 };
 

--- a/packages/@ember/-internals/glimmer/lib/utils/curly-component-state-bucket.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/curly-component-state-bucket.ts
@@ -1,7 +1,7 @@
 import { clearElementView, clearViewElement, getViewElement } from '@ember/-internals/views';
 import { Revision, VersionedReference } from '@glimmer/reference';
 import { CapturedNamedArguments } from '@glimmer/runtime';
-import { Opaque } from '@glimmer/util';
+import { Opaque, Option } from '@glimmer/util';
 import Environment from '../environment';
 
 export interface Component {
@@ -35,7 +35,7 @@ function NOOP() {}
   @private
 */
 export default class ComponentStateBucket {
-  public classRef: VersionedReference<Opaque> | null = null;
+  public classRef: Option<VersionedReference<Opaque>> = null;
   public argsRevision: Revision;
 
   constructor(

--- a/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
@@ -99,7 +99,7 @@ moduleFor(
       if (EmberDev && !EmberDev.runningProdBuild) {
         let willThrow = () => run(null, set, component, 'elementId', 'herpyderpy');
 
-        assert.throws(willThrow, /Changing a view's elementId after creation is not allowed/);
+        assert.throws(willThrow, /cannot change `elementId` on <.+> once it is set/);
 
         this.assertComponentElement(this.firstChild, {
           tagName: 'div',
@@ -276,6 +276,23 @@ moduleFor(
         tagName: 'foo-bar',
         content: 'hello',
       });
+    }
+
+    ['@test elementId can not be a computed property']() {
+      let FooBarComponent = Component.extend({
+        elementId: computed(function() {
+          return 'foo-bar';
+        }),
+      });
+
+      this.registerComponent('foo-bar', {
+        ComponentClass: FooBarComponent,
+        template: 'hello',
+      });
+
+      expectAssertion(() => {
+        this.render('{{foo-bar}}');
+      }, /You cannot use a computed property for the component's `elementId` \(<.+?>\)\./);
     }
 
     ['@test tagName can not be a computed property']() {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/life-cycle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/life-cycle-test.js
@@ -22,7 +22,6 @@ class LifeCycleHooksTest extends RenderingTestCase {
     this.components = {};
     this.componentRegistry = [];
     this.teardownAssertions = [];
-    this.viewRegistry = this.owner.lookup('-view-registry:main');
   }
 
   afterEach() {
@@ -63,22 +62,6 @@ class LifeCycleHooksTest extends RenderingTestCase {
       invoke: bind(this.invocationFor, this),
       attr: bind(this.attrFor, this),
     };
-  }
-
-  assertRegisteredViews(label) {
-    let viewRegistry = this.viewRegistry;
-    let topLevelId = getViewId(this.component);
-    let actual = Object.keys(viewRegistry)
-      .sort()
-      .filter(id => id !== topLevelId);
-
-    if (this.isInteractive) {
-      let expected = this.componentRegistry.sort();
-
-      this.assert.deepEqual(actual, expected, 'registered views - ' + label);
-    } else {
-      this.assert.deepEqual(actual, [], 'no views should be registered for non-interactive mode');
-    }
   }
 
   registerComponent(name, { template = null }) {
@@ -335,7 +318,6 @@ class LifeCycleHooksTest extends RenderingTestCase {
     });
 
     this.assertText('Twitter: @tomdale|Name: Tom Dale|Website: tomdale.net');
-    this.assertRegisteredViews('intial render');
 
     this.assertHooks({
       label: 'after initial render',
@@ -532,8 +514,6 @@ class LifeCycleHooksTest extends RenderingTestCase {
           ['the-bottom', 'willDestroy'],
         ],
       });
-
-      this.assertRegisteredViews('after destroy');
     });
   }
 
@@ -575,7 +555,6 @@ class LifeCycleHooksTest extends RenderingTestCase {
     );
 
     this.assertText('Twitter: @tomdale|Name: Tom Dale|Website: tomdale.net');
-    this.assertRegisteredViews('intial render');
 
     this.assertHooks({
       label: 'after initial render',
@@ -853,8 +832,6 @@ class LifeCycleHooksTest extends RenderingTestCase {
           ['the-last-child', 'willDestroy'],
         ],
       });
-
-      this.assertRegisteredViews('after destroy');
     });
   }
 
@@ -889,7 +866,6 @@ class LifeCycleHooksTest extends RenderingTestCase {
     });
 
     this.assertText('Top: Middle: Bottom: @tomdale');
-    this.assertRegisteredViews('intial render');
 
     this.assertHooks({
       label: 'after initial render',
@@ -1038,8 +1014,6 @@ class LifeCycleHooksTest extends RenderingTestCase {
           ['the-bottom', 'willDestroy'],
         ],
       });
-
-      this.assertRegisteredViews('after destroy');
     });
   }
 
@@ -1074,7 +1048,6 @@ class LifeCycleHooksTest extends RenderingTestCase {
     );
 
     this.assertText('Item: 1Item: 2Item: 3Item: 4Item: 5');
-    this.assertRegisteredViews('intial render');
 
     let initialHooks = () => {
       let ret = [['an-item', 'init'], ['an-item', 'on(init)'], ['an-item', 'didReceiveAttrs']];
@@ -1261,8 +1234,6 @@ class LifeCycleHooksTest extends RenderingTestCase {
 
         nonInteractive: [['no-items', 'willDestroy'], ['nested-item', 'willDestroy']],
       });
-
-      this.assertRegisteredViews('after destroy');
     });
   }
 }

--- a/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
@@ -4,6 +4,7 @@ import Controller from '@ember/controller';
 import {
   getRootViews,
   getChildViews,
+  getElementView,
   getViewBounds,
   getViewClientRects,
   getViewBoundingClientRect,
@@ -252,9 +253,8 @@ moduleFor(
     }
 
     viewFor(id) {
-      let owner = this.applicationInstance;
-      let registry = owner.lookup('-view-registry:main');
-      return registry[id];
+      let element = this.element.querySelector(`#${id}`);
+      return getElementView(element);
     }
   }
 );

--- a/packages/@ember/-internals/views/index.d.ts
+++ b/packages/@ember/-internals/views/index.d.ts
@@ -21,6 +21,9 @@ export const ViewMixin: any;
 export const ViewStateSupport: any;
 export const TextSupport: any;
 
+export function registerView(view: Opaque): void;
+export function unregisterView(view: Opaque): void;
+
 export function getElementView(element: Simple.Element): Opaque;
 export function getViewElement(view: Opaque): Option<Simple.Element>;
 export function setElementView(element: Simple.Element, view: Opaque): void;

--- a/packages/@ember/-internals/views/index.d.ts
+++ b/packages/@ember/-internals/views/index.d.ts
@@ -21,6 +21,9 @@ export const ViewMixin: any;
 export const ViewStateSupport: any;
 export const TextSupport: any;
 
+export function getElementId(view: Opaque): Option<string>;
+export function hasElementId(view: Opaque): boolean;
+
 export function registerView(view: Opaque): void;
 export function unregisterView(view: Opaque): void;
 

--- a/packages/@ember/-internals/views/index.js
+++ b/packages/@ember/-internals/views/index.js
@@ -2,6 +2,8 @@ export { default as jQuery, jQueryDisabled } from './lib/system/jquery';
 export {
   addChildView,
   isSimpleClick,
+  registerView,
+  unregisterView,
   getViewBounds,
   getViewClientRects,
   getViewBoundingClientRect,

--- a/packages/@ember/-internals/views/index.js
+++ b/packages/@ember/-internals/views/index.js
@@ -25,7 +25,7 @@ export { default as CoreView } from './lib/views/core_view';
 export { default as ClassNamesSupport } from './lib/mixins/class_names_support';
 export { default as ChildViewsSupport } from './lib/mixins/child_views_support';
 export { default as ViewStateSupport } from './lib/mixins/view_state_support';
-export { default as ViewMixin } from './lib/mixins/view_support';
+export { default as ViewMixin, getElementId, hasElementId } from './lib/mixins/view_support';
 export { default as ActionSupport } from './lib/mixins/action_support';
 export { MUTABLE_CELL } from './lib/compat/attrs';
 export { default as lookupPartial, hasPartial } from './lib/system/lookup_partial';

--- a/packages/@ember/-internals/views/lib/views/states/in_dom.js
+++ b/packages/@ember/-internals/views/lib/views/states/in_dom.js
@@ -1,7 +1,4 @@
 import { assign } from '@ember/polyfills';
-import { addObserver } from '@ember/-internals/metal';
-import EmberError from '@ember/error';
-import { DEBUG } from '@glimmer/env';
 import hasElement from './has_element';
 
 const inDOM = assign({}, hasElement, {
@@ -9,12 +6,6 @@ const inDOM = assign({}, hasElement, {
     // Register the view for event handling. This hash is used by
     // Ember.EventDispatcher to dispatch incoming events.
     view.renderer.register(view);
-
-    if (DEBUG) {
-      addObserver(view, 'elementId', () => {
-        throw new EmberError("Changing a view's elementId after creation is not allowed");
-      });
-    }
   },
 
   exit(view) {

--- a/packages/@ember/application/lib/application.js
+++ b/packages/@ember/application/lib/application.js
@@ -2,7 +2,6 @@
 @module @ember/application
 */
 
-import { dictionary } from '@ember/-internals/utils';
 import { ENV } from '@ember/-internals/environment';
 import { hasDOM } from '@ember/-internals/browser-environment';
 import { assert, isTesting } from '@ember/debug';
@@ -1102,11 +1101,6 @@ Application.reopenClass({
 
 function commonSetupRegistry(registry) {
   registry.register('router:main', Router.extend());
-  registry.register('-view-registry:main', {
-    create() {
-      return dictionary(null);
-    },
-  });
 
   registry.register('route:basic', Route);
   registry.register('event_dispatcher:main', EventDispatcher);

--- a/packages/@ember/application/tests/application_instance_test.js
+++ b/packages/@ember/application/tests/application_instance_test.js
@@ -165,7 +165,7 @@ moduleFor(
     }
 
     ['@test can build and boot a registered engine'](assert) {
-      assert.expect(11);
+      assert.expect(10);
 
       let ChatEngine = Engine.extend();
       let chatEngineInstance;
@@ -194,7 +194,6 @@ moduleFor(
         let singletons = [
           'router:main',
           P`-bucket-cache:main`,
-          '-view-registry:main',
           '-environment:main',
           'service:-document',
           'event_dispatcher:main',

--- a/packages/@ember/application/tests/application_test.js
+++ b/packages/@ember/application/tests/application_test.js
@@ -129,8 +129,6 @@ moduleFor(
       );
 
       verifyRegistration(assert, application, 'controller:basic');
-      verifyRegistration(assert, application, '-view-registry:main');
-      verifyInjection(assert, application, 'view', '_viewRegistry', '-view-registry:main');
       verifyInjection(assert, application, 'route', '_topLevelViewTemplate', 'template:-outlet');
       verifyRegistration(assert, application, 'route:basic');
       verifyRegistration(assert, application, 'event_dispatcher:main');

--- a/packages/@ember/engine/index.js
+++ b/packages/@ember/engine/index.js
@@ -495,9 +495,6 @@ function commonSetupRegistry(registry) {
 
   registry.register('controller:basic', Controller, { instantiate: false });
 
-  registry.injection('view', '_viewRegistry', '-view-registry:main');
-  registry.injection('renderer', '_viewRegistry', '-view-registry:main');
-
   registry.injection('route', '_topLevelViewTemplate', 'template:-outlet');
 
   registry.injection('view:-outlet', 'namespace', 'application:main');

--- a/packages/@ember/engine/instance.js
+++ b/packages/@ember/engine/instance.js
@@ -182,7 +182,6 @@ const EngineInstance = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixi
     let singletons = [
       'router:main',
       P`-bucket-cache:main`,
-      '-view-registry:main',
       `renderer:-${env.isInteractive ? 'dom' : 'inert'}`,
       'service:-document',
       P`template-compiler:main`,

--- a/packages/@ember/engine/tests/engine_test.js
+++ b/packages/@ember/engine/tests/engine_test.js
@@ -60,7 +60,6 @@ moduleFor(
         `optionsForType 'view'`
       );
       verifyRegistration(assert, engine, 'controller:basic');
-      verifyInjection(assert, engine, 'view', '_viewRegistry', '-view-registry:main');
       verifyInjection(assert, engine, 'route', '_topLevelViewTemplate', 'template:-outlet');
       verifyInjection(assert, engine, 'view:-outlet', 'namespace', 'application:main');
 

--- a/packages/@ember/string/tests/classify_test.js
+++ b/packages/@ember/string/tests/classify_test.js
@@ -45,7 +45,7 @@ moduleFor(
         'PrivateDocs/OwnerInvoice',
         'classify namespaced dasherized string'
       );
-      test(assert, '-view-registry', '_ViewRegistry', 'classify prefixed dasherized string');
+      test(assert, '-text-field', '_TextField', 'classify prefixed dasherized string');
       test(
         assert,
         'components/-text-field',

--- a/packages/internal-test-helpers/lib/test-cases/abstract-rendering.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract-rendering.js
@@ -21,12 +21,7 @@ export default class AbstractRenderingTestCase extends AbstractTestCase {
       bootOptions,
     }));
 
-    owner.register('-view-registry:main', Object.create(null), { instantiate: false });
     owner.register('event_dispatcher:main', EventDispatcher);
-
-    // TODO: why didn't buildOwner do this for us?
-    owner.inject('view', '_viewRegistry', '-view-registry:main');
-    owner.inject('renderer', '_viewRegistry', '-view-registry:main');
 
     this.renderer = this.owner.lookup('renderer:-dom');
     this.element = document.querySelector('#qunit-fixture');

--- a/tests/node/visit-test.js
+++ b/tests/node/visit-test.js
@@ -307,8 +307,7 @@ QUnit.module('Ember.Application - visit() Integration Tests', function(hooks) {
     function assertResources(url, resources) {
       return App.visit(url, { isBrowser: false, shouldRender: false }).then(function(instance) {
         try {
-          var viewRegistry = instance.lookup('-view-registry:main');
-          assert.strictEqual(Object.keys(viewRegistry).length, 0, 'did not create any views');
+          assert.strictEqual(xFooInstances, 0, 'did not create any views');
 
           var networkService = instance.lookup('service:network');
           assert.deepEqual(networkService.get('requests'), resources);


### PR DESCRIPTION
This fixes an issue where event dispatching stops working if `id` is passed with splattributes, because `elementId` will diverge from the actual `id`, causing the element to not be found during event dispatching.

~~This patch does not fix the `elementId` divergent problem, but changes the framework code to not rely on `elementId` and use a weak map instead. I have ideas for fixing the `elementId` issue, and making it optional, but I'll probably submit it separately.~~ (It's fixed.)

It's probably best to review this commit-by-commit.

This also removes the view registry private API. The theory is that there are very few addons that uses it, and we can transition them to using the new `Ember.ViewUtils.getElementView` instead.