### PR TITLE
[FEATURE ember-glimmer-angle-bracket-built-ins] Add missing dependent key

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -818,6 +818,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_BUILT_INS) {
       @private
     */
     href: computed(
+      '_currentRouterState',
       '_route',
       '_models',
       '_query',


### PR DESCRIPTION
There are no failing tests for this at the moment, because we only test with all optional features on or off. It turns out that the tracked property feature is masking this failure. As a result, the PR that enables this feature (#17811) without tracked property has [some failing tests](https://travis-ci.org/emberjs/ember.js/jobs/512342974) which should be green again after rebasing on top of this patch.