### PR TITLE
[DOCS release] update paramsFor documentation

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -179,6 +179,10 @@ class Route extends EmberObject implements IRoute {
   /**
     Returns a hash containing the parameters of an ancestor route.
 
+    You may notice that `this.paramsFor` sometimes works when referring to a
+    child route, but this behavior should not be relied upon as only ancestor
+    routes are certain to be loaded in time.
+
     Example
 
     ```app/router.js


### PR DESCRIPTION
It may be that I'm misunderstanding the meaning of "ancestor" here, but in my experience I've found that I can use `paramsFor` with both parent and child routes. This could benefit from some clarity and I am happy to work with someone on a more accurate description.