### PR TITLE
 [BUGFIX beta] Prevents autotracking ArrayProxy creation

### DIFF
--- a/packages/@ember/-internals/metal/lib/array.ts
+++ b/packages/@ember/-internals/metal/lib/array.ts
@@ -1,7 +1,6 @@
 import { arrayContentDidChange, arrayContentWillChange } from './array_events';
 import { addListener, removeListener } from './events';
 import { notifyPropertyChange } from './property_events';
-import { get } from './property_get';
 
 const EMPTY_ARRAY = Object.freeze([]);
 
@@ -84,7 +83,7 @@ function arrayObserversHelper(
 ): ObjectHasArrayObservers {
   let willChange = (opts && opts.willChange) || 'arrayWillChange';
   let didChange = (opts && opts.didChange) || 'arrayDidChange';
-  let hasObservers = get(obj, 'hasArrayObservers');
+  let hasObservers = obj.hasArrayObservers;
 
   operation(obj, '@array:before', target, willChange);
   operation(obj, '@array:change', target, didChange);

--- a/packages/@ember/-internals/metal/tests/tracked/validation_test.js
+++ b/packages/@ember/-internals/metal/tests/tracked/validation_test.js
@@ -13,7 +13,6 @@ import { EMBER_METAL_TRACKED_PROPERTIES } from '@ember/canary-features';
 import { EMBER_ARRAY } from '@ember/-internals/utils';
 import { AbstractTestCase, moduleFor } from 'internal-test-helpers';
 import { value, validate } from '@glimmer/reference';
-import { DEBUG } from '@glimmer/env';
 
 if (EMBER_METAL_TRACKED_PROPERTIES) {
   moduleFor(
@@ -348,13 +347,30 @@ if (EMBER_METAL_TRACKED_PROPERTIES) {
         let obj = new EmberObject();
 
         expectAssertion(() => {
-          if (DEBUG) {
-            track(() => {
-              obj.value;
-              obj.value = 123;
-            });
-          }
+          track(() => {
+            obj.value;
+            obj.value = 123;
+          });
         }, /You attempted to update `value` on `EmberObject`, but it had already been used previously in the same computation/);
+      }
+
+      ['@test gives helpful assertion when a tracked property is mutated after access within unknownProperty within an autotracking transaction']() {
+        class EmberObject {
+          @tracked foo;
+
+          unknownProperty() {
+            this.foo;
+            this.foo = 123;
+          }
+        }
+
+        let obj = new EmberObject();
+
+        expectAssertion(() => {
+          track(() => {
+            get(obj, 'bar');
+          });
+        }, /You attempted to update `foo` on `EmberObject`, but it had already been used previously in the same computation/);
       }
     }
   );

--- a/packages/@ember/-internals/runtime/lib/mixins/array.js
+++ b/packages/@ember/-internals/runtime/lib/mixins/array.js
@@ -19,6 +19,7 @@ import {
   removeArrayObserver,
   arrayContentWillChange,
   arrayContentDidChange,
+  nativeDescDecorator as descriptor,
 } from '@ember/-internals/metal';
 import { assert } from '@ember/debug';
 import Enumerable from './enumerable';
@@ -564,8 +565,12 @@ const ArrayMixin = Mixin.create(Enumerable, {
     @property {Boolean} hasArrayObservers
     @public
   */
-  hasArrayObservers: nonEnumerableComputed(function() {
-    return hasListeners(this, '@array:change') || hasListeners(this, '@array:before');
+  hasArrayObservers: descriptor({
+    configurable: true,
+    enumerable: false,
+    get() {
+      hasListeners(this, '@array:change') || hasListeners(this, '@array:before');
+    },
   }),
 
   /**
@@ -695,7 +700,7 @@ const ArrayMixin = Mixin.create(Enumerable, {
     foods.forEach((food) => food.eaten = true);
 
     let output = '';
-    foods.forEach((item, index, array) => 
+    foods.forEach((item, index, array) =>
       output += `${index + 1}/${array.length} ${item.name}\n`;
     );
     console.log(output);
@@ -725,7 +730,7 @@ const ArrayMixin = Mixin.create(Enumerable, {
 
   /**
     Alias for `mapBy`.
-    
+
     Returns the value of the named
     property on all items in the enumeration.
 

--- a/packages/@ember/-internals/runtime/lib/system/array_proxy.js
+++ b/packages/@ember/-internals/runtime/lib/system/array_proxy.js
@@ -111,11 +111,11 @@ export default class ArrayProxy extends EmberObject {
       this._arrangedContentRevision = value(this._arrangedContentTag);
     }
 
-    this._addArrangedContentArrayObsever();
+    this._addArrangedContentArrayObserver();
   }
 
   willDestroy() {
-    this._removeArrangedContentArrayObsever();
+    this._removeArrangedContentArrayObserver();
   }
 
   /**
@@ -251,16 +251,16 @@ export default class ArrayProxy extends EmberObject {
     let arrangedContent = get(this, 'arrangedContent');
     let newLength = arrangedContent ? get(arrangedContent, 'length') : 0;
 
-    this._removeArrangedContentArrayObsever();
+    this._removeArrangedContentArrayObserver();
     this.arrayContentWillChange(0, oldLength, newLength);
 
     this._invalidate();
 
     this.arrayContentDidChange(0, oldLength, newLength);
-    this._addArrangedContentArrayObsever();
+    this._addArrangedContentArrayObserver();
   }
 
-  _addArrangedContentArrayObsever() {
+  _addArrangedContentArrayObserver() {
     let arrangedContent = get(this, 'arrangedContent');
     if (arrangedContent && !arrangedContent.isDestroyed) {
       assert("Can't set ArrayProxy's content to itself", arrangedContent !== this);
@@ -275,7 +275,7 @@ export default class ArrayProxy extends EmberObject {
     }
   }
 
-  _removeArrangedContentArrayObsever() {
+  _removeArrangedContentArrayObserver() {
     if (this._arrangedContent) {
       removeArrayObserver(this._arrangedContent, this, ARRAY_OBSERVER_MAPPING);
     }


### PR DESCRIPTION
This PR prevents an issue with immediate invalidation within the new
autotracking transaction. ArrayProxy currently reads from one of its
own properties, `hasArrayObservers`, and then immediately updates it
with `notifyPropertyChange`.

We avoid this by using a native descriptor instead of a computed, and
not using `get()` to access it. This way, nothing is tracked during
creation (even if it is mutated).

The original PR attempted to add array observers lazily, when the array was first accessed. However, tests in addons (such as Ember Data) were failing with this strategy. One issue was that adding observers to `length` wouldn't work, since there was no way to add the array observer when that occured. This strategy keeps the current semantics the same, and prevents the backtracking issue.

Also updated the PR to deprecate in `unknownProperty` if this occurs again, since it could happen in existing code today.