### PR TITLE
[BUGFIX] Ensure @sort works on non-Ember.Objects.

### DIFF
--- a/packages/@ember/object/lib/computed/reduce_computed_macros.js
+++ b/packages/@ember/object/lib/computed/reduce_computed_macros.js
@@ -3,7 +3,13 @@
 */
 import { DEBUG } from '@glimmer/env';
 import { assert } from '@ember/debug';
-import { get, computed, addObserver, removeObserver } from '@ember/-internals/metal';
+import {
+  get,
+  computed,
+  addObserver,
+  removeObserver,
+  notifyPropertyChange,
+} from '@ember/-internals/metal';
 import { compare, isArray, A as emberA, uniqBy as uniqByArray } from '@ember/-internals/runtime';
 
 function reduceMacro(dependentKey, callback, initialValue, name) {
@@ -1427,7 +1433,7 @@ function propertySort(itemsKey, sortPropertiesKey) {
 
     if (!sortPropertyDidChangeMap.has(this)) {
       sortPropertyDidChangeMap.set(this, function() {
-        this.notifyPropertyChange(key);
+        notifyPropertyChange(this, key);
       });
     }
 


### PR DESCRIPTION
Assuming that `this.notifyPropertyChange` is a method on the object that the `sort` is operating on is not a safe assumption. Specifically, when operating on a `@glimmer/component` (which is _essentially_ just a very very basic native class) there is no `notifyPropertyChange` method and an error was thrown.

Fixes https://github.com/emberjs/ember.js/issues/17839