### PR TITLE
[CLEANUP] Removes various deprecated APIs

### DIFF
--- a/packages/@ember/-internals/meta/tests/listeners_test.js
+++ b/packages/@ember/-internals/meta/tests/listeners_test.js
@@ -172,31 +172,5 @@ moduleFor(
         'one reopen call after mutating parents and flattening out of order'
       );
     }
-
-    ['@test REMOVE_ALL does not interfere with future adds'](assert) {
-      expectDeprecation(() => {
-        let t = {};
-        let m = meta({});
-
-        m.addToListeners('hello', t, 'm', 0);
-        let matching = m.matchingListeners('hello');
-
-        assert.equal(matching.length, 3);
-        assert.equal(matching[0], t);
-
-        // Remove all listeners
-        m.removeAllListeners('hello');
-
-        matching = m.matchingListeners('hello');
-        assert.equal(matching, undefined);
-
-        m.addToListeners('hello', t, 'm', 0);
-        matching = m.matchingListeners('hello');
-
-        // listener was added back successfully
-        assert.equal(matching.length, 3);
-        assert.equal(matching[0], t);
-      });
-    }
   }
 );

--- a/packages/@ember/-internals/metal/lib/events.ts
+++ b/packages/@ember/-internals/metal/lib/events.ts
@@ -73,26 +73,30 @@ export function addListener(
 export function removeListener(
   obj: object,
   eventName: string,
-  target: object | null,
-  method?: Function | string
+  targetOrFunction: object | Function | null,
+  functionOrName?: string | Function
 ): void {
   assert(
-    'You must pass at least an object and event name to removeListener',
-    Boolean(obj) && Boolean(eventName)
+    'You must pass at least an object, event name, and method or target and method/method name to removeListener',
+    Boolean(obj) &&
+      Boolean(eventName) &&
+      (typeof targetOrFunction === 'function' ||
+        (typeof targetOrFunction === 'object' && Boolean(functionOrName)))
   );
 
-  if (!method && 'function' === typeof target) {
-    method = target;
+  let target, method;
+
+  if (typeof targetOrFunction === 'object') {
+    target = targetOrFunction;
+    method = functionOrName!;
+  } else {
     target = null;
+    method = targetOrFunction;
   }
 
   let m = metaFor(obj);
 
-  if (method === undefined) {
-    m.removeAllListeners(eventName);
-  } else {
-    m.removeFromListeners(eventName, target, method);
-  }
+  m.removeFromListeners(eventName, target, method);
 }
 
 /**

--- a/packages/@ember/-internals/metal/tests/events_test.js
+++ b/packages/@ember/-internals/metal/tests/events_test.js
@@ -138,24 +138,6 @@ moduleFor(
       assert.equal(hasListeners(obj, 'event!'), true, 'has listeners');
     }
 
-    ['@test calling removeListener without method should remove all listeners'](assert) {
-      expectDeprecation(() => {
-        let obj = {};
-        function F() {}
-        function F2() {}
-
-        assert.equal(hasListeners(obj, 'event!'), false, 'no listeners at first');
-
-        addListener(obj, 'event!', F);
-        addListener(obj, 'event!', F2);
-
-        assert.equal(hasListeners(obj, 'event!'), true, 'has listeners');
-        removeListener(obj, 'event!');
-
-        assert.equal(hasListeners(obj, 'event!'), false, 'has no more listeners');
-      }, /The remove all functionality of removeListener and removeObserver has been deprecated/);
-    }
-
     ['@test a listener can be added as part of a mixin'](assert) {
       let triggered = 0;
       let MyMixin = Mixin.create({

--- a/packages/@ember/-internals/runtime/lib/mixins/array.js
+++ b/packages/@ember/-internals/runtime/lib/mixins/array.js
@@ -20,7 +20,7 @@ import {
   arrayContentWillChange,
   arrayContentDidChange,
 } from '@ember/-internals/metal';
-import { assert, deprecate } from '@ember/debug';
+import { assert } from '@ember/debug';
 import Enumerable from './enumerable';
 import compare from '../compare';
 import { ENV } from '@ember/-internals/environment';
@@ -1601,28 +1601,18 @@ if (ENV.EXTEND_PROTOTYPES.Array) {
   NativeArray.apply(Array.prototype);
 
   A = function(arr) {
-    deprecate(
-      '`new A()` has been deprecated, please update to calling A as a function: `A()`',
-      !(this instanceof A),
-      {
-        id: 'array.new-array-wrapper',
-        until: '3.9.0',
-        url: 'https://emberjs.com/deprecations/v3.x#toc_array-new-array-wrapper',
-      }
+    assert(
+      'You cannot create an Ember Array with `new A()`, please update to calling A as a function: `A()`',
+      !(this instanceof A)
     );
 
     return arr || [];
   };
 } else {
   A = function(arr) {
-    deprecate(
-      '`new A()` has been deprecated, please update to calling A as a function: `A()`',
-      !(this instanceof A),
-      {
-        id: 'array.new-array-wrapper',
-        until: '3.9.0',
-        url: 'https://emberjs.com/deprecations/v3.x#toc_array-new-array-wrapper',
-      }
+    assert(
+      'You cannot create an Ember Array with `new A()`, please update to calling A as a function: `A()`',
+      !(this instanceof A)
     );
 
     if (!arr) {

--- a/packages/@ember/-internals/runtime/tests/system/core_object_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/core_object_test.js
@@ -6,17 +6,17 @@ import { moduleFor, AbstractTestCase, buildOwner } from 'internal-test-helpers';
 moduleFor(
   'Ember.CoreObject',
   class extends AbstractTestCase {
-    ['@test throws deprecation with new (one arg)']() {
-      expectDeprecation(() => {
+    ['@test throws an error with new (one arg)']() {
+      expectAssertion(() => {
         new CoreObject({
           firstName: 'Stef',
           lastName: 'Penner',
         });
-      }, /using `new` with EmberObject has been deprecated/);
+      }, /You may have either used `new` instead of `.create\(\)`/);
     }
 
-    ['@test throws deprecation with new (> 1 arg)']() {
-      expectDeprecation(() => {
+    ['@test throws an error with new (> 1 arg)']() {
+      expectAssertion(() => {
         new CoreObject(
           {
             firstName: 'Stef',
@@ -26,7 +26,7 @@ moduleFor(
             other: 'name',
           }
         );
-      }, /using `new` with EmberObject has been deprecated/);
+      }, /You may have either used `new` instead of `.create\(\)`/);
     }
 
     ['@test toString should be not be added as a property when calling toString()'](assert) {

--- a/packages/@ember/-internals/runtime/tests/system/native_array/a_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/native_array/a_test.js
@@ -14,7 +14,7 @@ moduleFor(
     }
 
     ['@test new Ember.A'](assert) {
-      expectDeprecation(() => {
+      expectAssertion(() => {
         assert.deepEqual(new A([1, 2]), [1, 2], 'array values were not be modified');
         assert.deepEqual(new A(), [], 'returned an array with no arguments');
         assert.deepEqual(new A(null), [], 'returned an array with a null argument');


### PR DESCRIPTION
Also unsure if these should be picked onto the release, like #17843. We should really make deprecations hard fail as soon as they reach their `until` version, if they don't already.