### PR TITLE
[BUGFIX beta] Fix template-only components clearing

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/component-managers/input.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/input.ts
@@ -18,7 +18,7 @@ const CAPABILITIES: ComponentCapabilities = {
   createCaller: true,
   dynamicScope: false,
   updateHook: true,
-  createInstance: false,
+  createInstance: true,
 };
 
 export interface InputComponentState {

--- a/packages/@ember/-internals/glimmer/lib/component-managers/root.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/root.ts
@@ -83,7 +83,7 @@ export const ROOT_CAPABILITIES: ComponentCapabilities = {
   createCaller: true,
   dynamicScope: true,
   updateHook: true,
-  createInstance: false,
+  createInstance: true,
 };
 
 export class RootComponentDefinition implements ComponentDefinition {

--- a/packages/@ember/-internals/glimmer/lib/component-managers/template-only.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/template-only.ts
@@ -21,7 +21,7 @@ const CAPABILITIES: ComponentCapabilities = {
   createCaller: false,
   dynamicScope: false,
   updateHook: false,
-  createInstance: false,
+  createInstance: true,
 };
 
 export default class TemplateOnlyComponentManager extends AbstractManager<null, OwnedTemplate>

--- a/packages/@ember/-internals/glimmer/tests/integration/components/template-only-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/template-only-components-test.js
@@ -105,6 +105,30 @@ moduleFor(
 
       this.assertInnerHTML('hello');
     }
+
+    ['@test it has the correct bounds']() {
+      this.registerComponent('foo-bar', 'hello');
+
+      this.render('outside {{#if this.isShowing}}before {{foo-bar}} after{{/if}} outside', {
+        isShowing: true,
+      });
+
+      this.assertInnerHTML('outside before hello after outside');
+
+      this.assertStableRerender();
+
+      runTask(() => this.context.set('isShowing', false));
+
+      this.assertInnerHTML('outside <!----> outside');
+
+      runTask(() => this.context.set('isShowing', null));
+
+      this.assertInnerHTML('outside <!----> outside');
+
+      runTask(() => this.context.set('isShowing', true));
+
+      this.assertInnerHTML('outside before hello after outside');
+    }
   }
 );
 


### PR DESCRIPTION
The root cause is when the `createInstance` flag is disabled, Glimmer omits the `DidRenderLayout` opcode, which has the unintended consequence of [skipping the `popBlock` call](https://github.com/glimmerjs/glimmer-vm/blob/3b36bbe3ee650647ac530d239244b3108c3a9a4b/packages/%40glimmer/runtime/lib/compiled/opcodes/component.ts#L703), causing an imbalance in the stack. This means additional content unrelated to the component will be treated as part of the component's bounds, causing other errors later on. It also causes other issues such as blocks not getting finalized due to the unbalanced push and pops.