### PR TITLE
[BUGFIX beta] Expose computed getter functions

### DIFF
--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -704,6 +704,13 @@ class ComputedDecoratorImpl extends Function {
     }
   }
 
+  // TODO: Remove this when we can provide alternatives in the ecosystem to
+  // addons such as ember-macro-helpers that use it.
+  get _getter(this: Decorator) {
+    return (descriptorForDecorator(this) as ComputedProperty)._getter;
+  }
+
+  // TODO: Refactor this, this is an internal API only
   set enumerable(this: Decorator, value: boolean) {
     (descriptorForDecorator(this) as ComputedProperty).enumerable = value;
   }


### PR DESCRIPTION
A few addons, namely ember-macro-helpers, still rely access to
the private `_getter` function on CP descriptors. There's no
easy way around this, since ember-macro-helpers can be used to
combine _existing_ macros, so this fix exposes the _getter function
for the time being until alternative solutions can be made.