### PR TITLE
[BUGFIX lts] Fixes a regression in the legacy build

### DIFF
--- a/broccoli/to-es5.js
+++ b/broccoli/to-es5.js
@@ -3,13 +3,12 @@
 const Babel = require('broccoli-babel-transpiler');
 const injectBabelHelpers = require('./transforms/inject-babel-helpers');
 
-module.exports = function toES6(tree, _options) {
+module.exports = function toES5(tree, _options) {
   let options = Object.assign({}, _options);
 
   options.sourceMaps = true;
   options.plugins = [
     injectBabelHelpers,
-    ['@babel/transform-template-literals', { loose: true }],
     ['@babel/transform-literals'],
     ['@babel/transform-arrow-functions'],
     ['@babel/transform-destructuring', { loose: true }],

--- a/broccoli/to-named-amd.js
+++ b/broccoli/to-named-amd.js
@@ -23,6 +23,7 @@ module.exports = function processModulesOnly(tree, strict = false) {
       // ensures `@glimmer/compiler` requiring `crypto` works properly
       // in both browser and node-land
       injectNodeGlobals,
+      ['@babel/transform-template-literals', { loose: true }],
       ['module-resolver', { resolvePath: resolveRelativeModulePath }],
       ['@babel/transform-modules-amd', transformOptions],
       enifed,

--- a/lib/index.js
+++ b/lib/index.js
@@ -70,7 +70,6 @@ module.exports = {
 
     let emberCliBabel = this.addons.find(a => a.name === 'ember-cli-babel');
     let needsLegacyBuild = [
-      'transform-template-literals',
       'transform-literals',
       'transform-arrow-functions',
       'transform-destructuring',
@@ -79,6 +78,7 @@ module.exports = {
       'transform-computed-properties',
       'transform-shorthand-properties',
       'transform-block-scoping',
+      'transform-classes',
     ].some(p => emberCliBabel.isPluginRequired(p));
 
     if (needsLegacyBuild) {


### PR DESCRIPTION
For some reason, the 'transform-template-literals' plugin is now required even
in our standard non-evergreen builds. We really just need to finish up making
ember-source an addon, but this should fix people's builds for the time being.

Fixes #17809