### PR TITLE
[BUGFIX beta] Ensure @controller passes args correctly

### DIFF
--- a/packages/@ember/-internals/runtime/tests/inject_test.js
+++ b/packages/@ember/-internals/runtime/tests/inject_test.js
@@ -1,5 +1,4 @@
 import { inject } from '@ember/-internals/metal';
-import { EMBER_NATIVE_DECORATOR_SUPPORT } from '@ember/canary-features';
 import { DEBUG } from '@glimmer/env';
 import EmberObject from '../lib/system/object';
 import { buildOwner } from 'internal-test-helpers';
@@ -50,48 +49,3 @@ moduleFor(
     }
   }
 );
-
-if (EMBER_NATIVE_DECORATOR_SUPPORT) {
-  moduleFor(
-    'inject - decorator',
-    class extends AbstractTestCase {
-      ['@test works with native decorators'](assert) {
-        let owner = buildOwner();
-
-        class Service extends EmberObject {}
-
-        class Foo extends EmberObject {
-          @inject('service', 'main') main;
-        }
-
-        owner.register('service:main', Service);
-        owner.register('foo:main', Foo);
-
-        let foo = owner.lookup('foo:main');
-
-        assert.ok(foo.main instanceof Service, 'service injected correctly');
-      }
-
-      ['@test uses the decorated property key if not provided'](assert) {
-        let owner = buildOwner();
-
-        function service() {
-          return inject('service', ...arguments);
-        }
-
-        class Service extends EmberObject {}
-
-        class Foo extends EmberObject {
-          @service main;
-        }
-
-        owner.register('service:main', Service);
-        owner.register('foo:main', Foo);
-
-        let foo = owner.lookup('foo:main');
-
-        assert.ok(foo.main instanceof Service, 'service injected correctly');
-      }
-    }
-  );
-}

--- a/packages/@ember/controller/index.js
+++ b/packages/@ember/controller/index.js
@@ -55,8 +55,8 @@ const Controller = EmberObject.extend(ControllerMixin);
   @return {ComputedDecorator} injection decorator instance
   @public
 */
-export function inject(nameOrDesc, options) {
-  return metalInject('controller', nameOrDesc, options);
+export function inject() {
+  return metalInject('controller', ...arguments);
 }
 
 export default Controller;

--- a/packages/@ember/controller/tests/controller_test.js
+++ b/packages/@ember/controller/tests/controller_test.js
@@ -1,4 +1,5 @@
 import Controller, { inject as injectController } from '@ember/controller';
+import { EMBER_NATIVE_DECORATOR_SUPPORT } from '@ember/canary-features';
 import Service, { inject as injectService } from '@ember/service';
 import { Object as EmberObject } from '@ember/-internals/runtime';
 import { Mixin, get } from '@ember/-internals/metal';
@@ -207,3 +208,44 @@ moduleFor(
     }
   }
 );
+
+if (EMBER_NATIVE_DECORATOR_SUPPORT) {
+  moduleFor(
+    'Controller Injections',
+    class extends AbstractTestCase {
+      ['@test works with native decorators'](assert) {
+        let owner = buildOwner();
+
+        class MainController extends Controller {}
+
+        class IndexController extends Controller {
+          @injectController('main') main;
+        }
+
+        owner.register('controller:main', MainController);
+        owner.register('controller:index', IndexController);
+
+        let index = owner.lookup('controller:index');
+
+        assert.ok(index.main instanceof Controller, 'controller injected correctly');
+      }
+
+      ['@test uses the decorated property key if not provided'](assert) {
+        let owner = buildOwner();
+
+        class MainController extends Controller {}
+
+        class IndexController extends Controller {
+          @injectController main;
+        }
+
+        owner.register('controller:main', MainController);
+        owner.register('controller:index', IndexController);
+
+        let index = owner.lookup('controller:index');
+
+        assert.ok(index.main instanceof Controller, 'controller injected correctly');
+      }
+    }
+  );
+}

--- a/packages/@ember/service/tests/service_test.js
+++ b/packages/@ember/service/tests/service_test.js
@@ -1,0 +1,46 @@
+import { EMBER_NATIVE_DECORATOR_SUPPORT } from '@ember/canary-features';
+import Service, { inject as injectService } from '@ember/service';
+import { Object as EmberObject } from '@ember/-internals/runtime';
+import { buildOwner } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+
+if (EMBER_NATIVE_DECORATOR_SUPPORT) {
+  moduleFor(
+    'inject - decorator',
+    class extends AbstractTestCase {
+      ['@test works with native decorators'](assert) {
+        let owner = buildOwner();
+
+        class MainService extends Service {}
+
+        class Foo extends EmberObject {
+          @injectService('main') main;
+        }
+
+        owner.register('service:main', MainService);
+        owner.register('foo:main', Foo);
+
+        let foo = owner.lookup('foo:main');
+
+        assert.ok(foo.main instanceof Service, 'service injected correctly');
+      }
+
+      ['@test uses the decorated property key if not provided'](assert) {
+        let owner = buildOwner();
+
+        class MainService extends Service {}
+
+        class Foo extends EmberObject {
+          @injectService main;
+        }
+
+        owner.register('service:main', MainService);
+        owner.register('foo:main', Foo);
+
+        let foo = owner.lookup('foo:main');
+
+        assert.ok(foo.main instanceof Service, 'service injected correctly');
+      }
+    }
+  );
+}


### PR DESCRIPTION
@controller was not passing args correctly for parameter-less decorator
usage. We weren't actually testing it, which is why we didn't catch the
issue. This adds tests for both @service and @controller and fixes the problem.