### PR TITLE
[BUGFIX beta] Fix for #17869 (link-to causing `hash` local variable assertions)

### DIFF
--- a/packages/ember-template-compiler/lib/plugins/index.ts
+++ b/packages/ember-template-compiler/lib/plugins/index.ts
@@ -23,7 +23,6 @@ export type APluginFunc = (env: ASTPluginEnvironment) => ASTPlugin | undefined;
 
 const transforms: Array<APluginFunc> = [
   TransformComponentInvocation,
-  TransformLinkTo,
   TransformOldClassBindingSyntax,
   TransformQuotedBindingsIntoJustBindings,
   AssertReservedNamedArguments,
@@ -32,6 +31,7 @@ const transforms: Array<APluginFunc> = [
   TransformEachInIntoEach,
   TransformHasBlockSyntax,
   AssertLocalVariableShadowingHelperInvocation,
+  TransformLinkTo,
   AssertInputHelperWithoutBlock,
   TransformInElement,
   AssertIfHelperWithoutArguments,


### PR DESCRIPTION
This doesn't really "fix" the issue, it just silent this particular assertion basically. This is ok, because the test will fail when we implement the "everything is a value" semantics, at which point we can fix it by renaming the hash helper. (We could fix it now by renaming the offending hash local variable too, but that would be pretty difficult to do correctly.)