### PR TITLE
Ensure test harness provides a way to debug navigation away.

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -17,6 +17,14 @@
       window.loadScript = function(url) {
         document.write(unescape('%3Cscript src="'+url+'"%3E%3C/script%3E'));
       };
+      window.addEventListener('beforeunload', function (e) {
+        debugger
+
+        // Cancel the event
+        e.preventDefault();
+        // Chrome requires returnValue to be set
+        e.returnValue = '';
+      });
     </script>
 
     <script type="text/javascript">


### PR DESCRIPTION
When developing certain areas of Ember, a bug leads to navigation (e.g.  `LinkComponent` doesn't handle the click event properly and the browser attempts to actually navigate to whatever the href was with a full reload). This snippet attempts to make that situation somewhat easier to detect and resolve...