### PR TITLE
[DEPRECATION] deprecate `Component#isVisible`

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/component-managers/curly.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/curly.ts
@@ -9,6 +9,7 @@ import {
   setViewElement,
 } from '@ember/-internals/views';
 import { assert, debugFreeze } from '@ember/debug';
+import { EMBER_COMPONENT_IS_VISIBLE } from '@ember/deprecated-features';
 import { _instrumentStart } from '@ember/instrumentation';
 import { assign } from '@ember/polyfills';
 import { DEBUG } from '@glimmer/env';
@@ -92,7 +93,11 @@ function applyAttributeBindings(
     operations.setAttribute('id', PrimitiveReference.create(id), false, null);
   }
 
-  if (seen.indexOf('style') === -1) {
+  if (
+    EMBER_COMPONENT_IS_VISIBLE &&
+    IsVisibleBinding !== undefined &&
+    seen.indexOf('style') === -1
+  ) {
     IsVisibleBinding.install(element, component, operations);
   }
 }
@@ -368,7 +373,9 @@ export default class CurlyComponentManager
     } else {
       let id = component.elementId ? component.elementId : guidFor(component);
       operations.setAttribute('id', PrimitiveReference.create(id), false, null);
-      IsVisibleBinding.install(element, component, operations);
+      if (EMBER_COMPONENT_IS_VISIBLE && IsVisibleBinding !== undefined) {
+        IsVisibleBinding.install(element, component, operations);
+      }
     }
 
     if (classRef) {

--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -1104,6 +1104,7 @@ const Component = CoreView.extend(
      @property isVisible
      @type Boolean
      @default null
+     @deprecated Use `<div hidden={{this.isHidden}}>` or `{{#if this.showComponent}} <MyComponent /> {{/if}}`
      @public
      */
   }

--- a/packages/@ember/-internals/glimmer/lib/utils/bindings.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/bindings.ts
@@ -1,5 +1,6 @@
 import { get } from '@ember/-internals/metal';
-import { assert } from '@ember/debug';
+import { assert, deprecate } from '@ember/debug';
+import { EMBER_COMPONENT_IS_VISIBLE } from '@ember/deprecated-features';
 import { dasherize } from '@ember/string';
 import { Opaque, Option, Simple } from '@glimmer/interfaces';
 import { CachedReference, combine, map, Reference, Tag } from '@glimmer/reference';
@@ -106,8 +107,16 @@ export const AttributeBinding = {
       !(isSimple && isPath)
     );
 
-    if (attribute === 'style') {
-      reference = new StyleBindingReference(reference, referenceForKey(component, 'isVisible'));
+    if (
+      EMBER_COMPONENT_IS_VISIBLE &&
+      attribute === 'style' &&
+      StyleBindingReference !== undefined
+    ) {
+      reference = new StyleBindingReference(
+        reference,
+        referenceForKey(component, 'isVisible'),
+        component
+      );
     }
 
     operations.setAttribute(attribute, reference, false, null);
@@ -118,47 +127,94 @@ export const AttributeBinding = {
 const DISPLAY_NONE = 'display: none;';
 const SAFE_DISPLAY_NONE = htmlSafe(DISPLAY_NONE);
 
-class StyleBindingReference extends CachedReference<string | SafeString> {
-  public tag: Tag;
-  constructor(private inner: Reference<string>, private isVisible: Reference<Opaque>) {
-    super();
+let StyleBindingReference:
+  | undefined
+  | { new (...args: any[]): CachedReference<string | SafeString> };
 
-    this.tag = combine([inner.tag, isVisible.tag]);
-  }
+if (EMBER_COMPONENT_IS_VISIBLE) {
+  StyleBindingReference = class extends CachedReference<string | SafeString> {
+    public tag: Tag;
+    private component: Component;
+    constructor(
+      private inner: Reference<string>,
+      private isVisible: Reference<Opaque>,
+      component: Component
+    ) {
+      super();
 
-  compute(): string | SafeString {
-    let value = this.inner.value();
-    let isVisible = this.isVisible.value();
-
-    if (isVisible !== false) {
-      return value;
-    } else if (!value) {
-      return SAFE_DISPLAY_NONE;
-    } else {
-      let style = value + ' ' + DISPLAY_NONE;
-      return isHTMLSafe(value) ? htmlSafe(style) : style;
+      this.tag = combine([inner.tag, isVisible.tag]);
+      this.component = component;
     }
-  }
+
+    compute(): string | SafeString {
+      let value = this.inner.value();
+      let isVisible = this.isVisible.value();
+
+      if (isVisible !== undefined) {
+        deprecate(
+          `\`isVisible\` is deprecated (from "${this.component._debugContainerKey}")`,
+          false,
+          {
+            id: 'ember-component.is-visible',
+            until: '4.0.0',
+            url: 'https://deprecations.emberjs.com/v3.x#toc_ember-component-is-visible',
+          }
+        );
+      }
+
+      if (isVisible !== false) {
+        return value;
+      }
+
+      if (!value) {
+        return SAFE_DISPLAY_NONE;
+      } else {
+        let style = value + ' ' + DISPLAY_NONE;
+        return isHTMLSafe(value) ? htmlSafe(style) : style;
+      }
+    }
+  };
 }
 
-export const IsVisibleBinding = {
-  install(_element: Simple.Element, component: Component, operations: ElementOperations) {
-    operations.setAttribute(
-      'style',
-      map(referenceForKey(component, 'isVisible'), this.mapStyleValue),
-      false,
-      null
-    );
-    // // the upstream type for addDynamicAttribute's `value` argument
-    // // appears to be incorrect. It is currently a Reference<string>, I
-    // // think it should be a Reference<string|null>.
-    // operations.addDynamicAttribute(element, 'style', ref as any as Reference<string>, false);
-  },
+export let IsVisibleBinding:
+  | undefined
+  | {
+      install(element: Simple.Element, component: Component, operations: ElementOperations): void;
+      mapStyleValue(isVisible: boolean, component: Component): SafeString | null;
+    };
 
-  mapStyleValue(isVisible: boolean) {
-    return isVisible === false ? SAFE_DISPLAY_NONE : null;
-  },
-};
+if (EMBER_COMPONENT_IS_VISIBLE) {
+  IsVisibleBinding = {
+    install(_element: Simple.Element, component: Component, operations: ElementOperations) {
+      let componentMapStyleValue = (isVisible: boolean) => {
+        return this.mapStyleValue(isVisible, component);
+      };
+
+      operations.setAttribute(
+        'style',
+        map(referenceForKey(component, 'isVisible'), componentMapStyleValue),
+        false,
+        null
+      );
+      // // the upstream type for addDynamicAttribute's `value` argument
+      // // appears to be incorrect. It is currently a Reference<string>, I
+      // // think it should be a Reference<string|null>.
+      // operations.addDynamicAttribute(element, 'style', ref as any as Reference<string>, false);
+    },
+
+    mapStyleValue(isVisible: boolean, component: Component) {
+      if (isVisible !== undefined) {
+        deprecate(`\`isVisible\` is deprecated (from "${component._debugContainerKey}")`, false, {
+          id: 'ember-component.is-visible',
+          until: '4.0.0',
+          url: 'https://deprecations.emberjs.com/v3.x#toc_ember-component-is-visible',
+        });
+      }
+
+      return isVisible === false ? SAFE_DISPLAY_NONE : null;
+    },
+  };
+}
 
 export const ClassNameBinding = {
   install(

--- a/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
@@ -2904,22 +2904,30 @@ moduleFor(
         template: `<p>foo</p>`,
       });
 
-      this.render(`{{foo-bar id="foo-bar" isVisible=visible}}`, {
-        visible: false,
-      });
+      expectDeprecation(() => {
+        this.render(`{{foo-bar id="foo-bar" isVisible=visible}}`, {
+          visible: false,
+        });
+      }, '`isVisible` is deprecated (from "component:foo-bar")');
 
       assertStyle('display: none;');
 
       this.assertStableRerender();
 
-      runTask(() => {
-        set(this.context, 'visible', true);
-      });
+      expectDeprecation(() => {
+        runTask(() => {
+          set(this.context, 'visible', true);
+        });
+      }, '`isVisible` is deprecated (from "component:foo-bar")');
+
       assertStyle('');
 
-      runTask(() => {
-        set(this.context, 'visible', false);
-      });
+      expectDeprecation(() => {
+        runTask(() => {
+          set(this.context, 'visible', false);
+        });
+      }, '`isVisible` is deprecated (from "component:foo-bar")');
+
       assertStyle('display: none;');
     }
 
@@ -2933,9 +2941,11 @@ moduleFor(
         template: `<p>foo</p>`,
       });
 
-      this.render(`{{foo-bar id="foo-bar" isVisible=visible}}`, {
-        visible: false,
-      });
+      expectDeprecation(() => {
+        this.render(`{{foo-bar id="foo-bar" isVisible=visible}}`, {
+          visible: false,
+        });
+      }, '`isVisible` is deprecated (from "component:foo-bar")');
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -2944,18 +2954,22 @@ moduleFor(
 
       this.assertStableRerender();
 
-      runTask(() => {
-        set(this.context, 'visible', true);
-      });
+      expectDeprecation(() => {
+        runTask(() => {
+          set(this.context, 'visible', true);
+        });
+      }, '`isVisible` is deprecated (from "component:foo-bar")');
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
         attrs: { id: 'foo-bar', style: styles('color: blue;') },
       });
 
-      runTask(() => {
-        set(this.context, 'visible', false);
-      });
+      expectDeprecation(() => {
+        runTask(() => {
+          set(this.context, 'visible', false);
+        });
+      }, '`isVisible` is deprecated (from "component:foo-bar")');
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -2986,25 +3000,31 @@ moduleFor(
         template: `<p>foo</p>`,
       });
 
-      this.render(`{{foo-bar id="foo-bar" foo=foo isVisible=visible}}`, {
-        visible: false,
-        foo: 'baz',
-      });
+      expectDeprecation(() => {
+        this.render(`{{foo-bar id="foo-bar" foo=foo isVisible=visible}}`, {
+          visible: false,
+          foo: 'baz',
+        });
+      }, '`isVisible` is deprecated (from "component:foo-bar")');
 
       assertStyle('display: none;');
 
       this.assertStableRerender();
 
-      runTask(() => {
-        set(this.context, 'visible', true);
-      });
+      expectDeprecation(() => {
+        runTask(() => {
+          set(this.context, 'visible', true);
+        });
+      }, '`isVisible` is deprecated (from "component:foo-bar")');
 
       assertStyle('');
 
-      runTask(() => {
-        set(this.context, 'visible', false);
-        set(this.context, 'foo', 'woo');
-      });
+      expectDeprecation(() => {
+        runTask(() => {
+          set(this.context, 'visible', false);
+          set(this.context, 'foo', 'woo');
+        });
+      }, '`isVisible` is deprecated (from "component:foo-bar")');
 
       assertStyle('display: none;');
       assert.equal(this.firstChild.getAttribute('foo'), 'woo');

--- a/packages/@ember/deprecated-features/index.ts
+++ b/packages/@ember/deprecated-features/index.ts
@@ -14,3 +14,4 @@ export const ALIAS_METHOD = !!'3.9.0';
 export const APP_CTRL_ROUTER_PROPS = !!'3.10.0-beta.1';
 export const FUNCTION_PROTOTYPE_EXTENSIONS = !!'3.11.0-beta.1';
 export const MOUSE_ENTER_LEAVE_MOVE_EVENTS = !!'3.13.0-beta.1';
+export const EMBER_COMPONENT_IS_VISIBLE = !!'3.15.0-beta.1';


### PR DESCRIPTION
part of https://github.com/emberjs/ember.js/issues/17918

TODO:

- [x] Update the deprecation message to include the component's `toString`
- [x] Add svelting for the new deprecation
- [x] Update documentation to mark `isVisible` as `@deprecated`
- [x] Deprecation guide PR: https://github.com/ember-learn/deprecation-app/pull/451