### PR TITLE
Fix fn + mut usage

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/helpers/fn.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/fn.ts
@@ -1,23 +1,34 @@
 import { assert } from '@ember/debug';
+import { DEBUG } from '@glimmer/env';
 import { Arguments, VM } from '@glimmer/runtime';
 import { ICapturedArguments } from '@glimmer/runtime/dist/types/lib/vm/arguments';
 import { Opaque } from '@glimmer/util';
-import { InternalHelperReference } from '../utils/references';
+import { InternalHelperReference, INVOKE } from '../utils/references';
 import buildUntouchableThis from '../utils/untouchable-this';
 
 const context = buildUntouchableThis('`fn` helper');
 function fnHelper({ positional }: ICapturedArguments) {
-  assert(
-    `You must pass a function as the \`fn\` helpers first argument, you passed ${positional
-      .at(0)
-      .value()}`,
-    typeof positional.at(0).value() === 'function'
-  );
+  let callbackRef = positional.at(0);
+
+  if (DEBUG && typeof callbackRef[INVOKE] !== 'function') {
+    let callback = callbackRef.value();
+
+    assert(
+      `You must pass a function as the \`fn\` helpers first argument, you passed ${callback}`,
+      typeof callback === 'function'
+    );
+  }
 
   return (...invocationArgs: Opaque[]) => {
     let [fn, ...args] = positional.value();
 
-    return fn!['call'](context, ...args, ...invocationArgs);
+    if (typeof callbackRef[INVOKE] === 'function') {
+      // references with the INVOKE symbol expect the function behind
+      // the symbol to be bound to the reference
+      return callbackRef[INVOKE](...args, ...invocationArgs);
+    } else {
+      return fn!['call'](context, ...args, ...invocationArgs);
+    }
   };
 }
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/fn-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/fn-test.js
@@ -190,6 +190,19 @@ if (EMBER_GLIMMER_FN_HELPER) {
 
         this.assertText('arg1: foo, arg2: bar, arg3: qux');
       }
+
+      '@test can be used on the result of `mut`'() {
+        this.render(`{{this.arg1}}{{stash stashedFn=(fn (mut this.arg1) this.arg2)}}`, {
+          arg1: 'foo',
+          arg2: 'bar',
+        });
+
+        this.assertText('foo');
+
+        runTask(() => this.stashedFn());
+
+        this.assertText('bar');
+      }
     }
   );
 }


### PR DESCRIPTION
Prior to this change the following snippet would trigger the "You must pass a callback as the `fn` helpers first argument" assertion.

```hbs
{{fn (mut this.someProperty) 'new value'}}
```

This is ultimately due to the way `mut` works internally, it masquerades a references `UPDATE` (the thing that supports two way binding) as a special case `INVOKE` method. Other helpers/modfiers (specifically `action`) check for this special symbol and invoke it.

The fix in this commit updates `fn` to check for the `INVOKE` symbol to determine which underlying function to call.

Fixes https://github.com/emberjs/ember.js/issues/17966