### PR TITLE
[BUGFIX release] Ensure query param only link-to's work in error states.

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -487,7 +487,9 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_BUILT_INS) {
     _currentRouterState: alias('_routing.currentState'),
     _targetRouterState: alias('_routing.targetState'),
 
-    _route: computed('route', '_currentRoute', function computeLinkToComponentRoute(this: any) {
+    _route: computed('route', '_currentRouterState', function computeLinkToComponentRoute(
+      this: any
+    ) {
       let { route } = this;
       return route === UNDEFINED ? this._currentRoute : route;
     }),


### PR DESCRIPTION
Try to fix https://github.com/emberjs/ember.js/issues/17963, I'm not sure this is the right way and it's weird, but the old "qualifiedRouteName" property works in this way and "_route" is used similarly to "qualifiedRouteName".