### PR TITLE
Prevent generation of .js.js or .hbs.hbs files with ember-cli

### DIFF
--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -72,7 +72,9 @@ module.exports = useEditionDetector({
   },
 
   normalizeEntityName: function(entityName) {
-    return normalizeEntityName(entityName);
+    return normalizeEntityName(
+      entityName.replace(/\.js$/, '') //Prevent generation of ".js.js" files
+    );
   },
 
   locals: function(options) {

--- a/blueprints/controller/index.js
+++ b/blueprints/controller/index.js
@@ -27,4 +27,7 @@ module.exports = useEditionDetector({
       };
     }
   },
+  normalizeEntityName: function(entityName) {
+    return entityName.replace(/\.js$/, ''); //Prevent generation of ".js.js" files
+  },
 });

--- a/blueprints/helper/index.js
+++ b/blueprints/helper/index.js
@@ -49,6 +49,8 @@ module.exports = {
   },
 
   normalizeEntityName: function(entityName) {
-    return normalizeEntityName(entityName);
+    return normalizeEntityName(
+      entityName.replace(/\.js$/, '') //Prevent generation of ".js.js" files
+    );
   },
 };

--- a/blueprints/mixin/index.js
+++ b/blueprints/mixin/index.js
@@ -23,4 +23,7 @@ module.exports = {
       };
     }
   },
+  normalizeEntityName: function(entityName) {
+    return entityName.replace(/\.js$/, ''); //Prevent generation of ".js.js" files
+  },
 };

--- a/blueprints/route/index.js
+++ b/blueprints/route/index.js
@@ -140,6 +140,9 @@ module.exports = useEditionDetector({
   afterUninstall: function(options) {
     updateRouter.call(this, 'remove', options);
   },
+  normalizeEntityName: function(entityName) {
+    return entityName.replace(/\.js$/, ''); //Prevent generation of ".js.js" files
+  },
 });
 
 function updateRouter(action, options) {

--- a/blueprints/service/index.js
+++ b/blueprints/service/index.js
@@ -24,4 +24,7 @@ module.exports = useEditionDetector({
       };
     }
   },
+  normalizeEntityName: function(entityName) {
+    return entityName.replace(/\.js$/, ''); //Prevent generation of ".js.js" files
+  },
 });

--- a/blueprints/template/index.js
+++ b/blueprints/template/index.js
@@ -28,4 +28,7 @@ module.exports = {
       };
     }
   },
+  normalizeEntityName: function(entityName) {
+    return entityName.replace(/\.hbs$/, ''); //Prevent generation of ".hbs.hbs" files
+  },
 };

--- a/blueprints/util/index.js
+++ b/blueprints/util/index.js
@@ -26,4 +26,7 @@ module.exports = {
       };
     }
   },
+  normalizeEntityName: function(entityName) {
+    return entityName.replace(/\.js$/, ''); //Prevent generation of ".js.js" files
+  },
 };

--- a/node-tests/blueprints/component-test.js
+++ b/node-tests/blueprints/component-test.js
@@ -100,6 +100,27 @@ describe('Blueprint: component', function() {
       });
     });
 
+    it('component foo.js', function() {
+      return emberGenerateDestroy(['component', 'foo.js'], _file => {
+        expect(_file('app/components/foo.js.js')).to.not.exist;
+        expect(_file('app/templates/components/foo.js.hbs')).to.not.exist;
+        expect(_file('tests/integration/components/foo.js-test.js')).to.not.exist;
+
+        expect(_file('app/components/foo.js')).to.equal(fixture('component/component.js'));
+
+        expect(_file('app/templates/components/foo.hbs')).to.equal('{{yield}}');
+
+        expect(_file('tests/integration/components/foo-test.js')).to.equal(
+          fixture('component-test/default-template.js', {
+            replace: {
+              component: 'foo',
+              componentInvocation: 'Foo',
+            },
+          })
+        );
+      });
+    });
+
     it('component x-foo --pod', function() {
       return emberGenerateDestroy(['component', 'x-foo', '--pod'], _file => {
         expect(_file('app/components/x-foo/component.js')).to.equal(
@@ -245,6 +266,29 @@ describe('Blueprint: component', function() {
           fixture('component-test/default-curly-template.js', {
             replace: {
               component: 'foo/x-foo',
+            },
+          })
+        );
+      });
+    });
+
+    it('component x-foo.js --pod', function() {
+      return emberGenerateDestroy(['component', 'x-foo.js', '--pod'], _file => {
+        expect(_file('app/components/x-foo.js/component.js')).to.not.exist;
+        expect(_file('app/components/x-foo.js/template.hbs')).to.not.exist;
+        expect(_file('tests/integration/components/x-foo.js/component-test.js')).to.not.exist;
+
+        expect(_file('app/components/x-foo/component.js')).to.equal(
+          fixture('component/component-dash.js')
+        );
+
+        expect(_file('app/components/x-foo/template.hbs')).to.equal('{{yield}}');
+
+        expect(_file('tests/integration/components/x-foo/component-test.js')).to.equal(
+          fixture('component-test/default-template.js', {
+            replace: {
+              component: 'x-foo',
+              componentInvocation: 'XFoo',
             },
           })
         );
@@ -498,6 +542,29 @@ describe('Blueprint: component', function() {
         );
       });
     });
+
+    it('component foo.js', function() {
+      return emberGenerateDestroy(['component', 'foo.js'], _file => {
+        expect(_file('src/ui/components/foo.js/component.js')).to.not.exist;
+        expect(_file('src/ui/components/foo.js/template.hbs')).to.not.exist;
+        expect(_file('src/ui/components/foo.js/component-test.js')).to.not.exist;
+
+        expect(_file('src/ui/components/foo/component.js')).to.equal(
+          fixture('component/component.js')
+        );
+
+        expect(_file('src/ui/components/foo/template.hbs')).to.equal('{{yield}}');
+
+        expect(_file('src/ui/components/foo/component-test.js')).to.equal(
+          fixture('component-test/default-template.js', {
+            replace: {
+              component: 'foo',
+              componentInvocation: 'Foo',
+            },
+          })
+        );
+      });
+    });
   });
 
   describe('in app - octane', function() {
@@ -533,6 +600,29 @@ describe('Blueprint: component', function() {
 
     it('component x-foo', function() {
       return emberGenerateDestroy(['component', 'x-foo'], _file => {
+        expect(_file('app/components/x-foo.js')).to.equal(
+          fixture('component/native-component-dash.js')
+        );
+
+        expect(_file('app/templates/components/x-foo.hbs')).to.equal('{{yield}}');
+
+        expect(_file('tests/integration/components/x-foo-test.js')).to.equal(
+          fixture('component-test/default-template.js', {
+            replace: {
+              component: 'x-foo',
+              componentInvocation: 'XFoo',
+            },
+          })
+        );
+      });
+    });
+
+    it('component x-foo.js', function() {
+      return emberGenerateDestroy(['component', 'x-foo.js'], _file => {
+        expect(_file('app/components/x-foo.js.js')).to.not.exist;
+        expect(_file('app/templates/components/x-foo.js.hbs')).to.not.exist;
+        expect(_file('tests/integration/components/x-foo-test.js.js')).to.not.exist;
+
         expect(_file('app/components/x-foo.js')).to.equal(
           fixture('component/native-component-dash.js')
         );
@@ -625,6 +715,34 @@ describe('Blueprint: component', function() {
       });
     });
 
+    it('component x-foo.js', function() {
+      return emberGenerateDestroy(['component', 'x-foo.js'], _file => {
+        expect(_file('addon/components/x-foo.js.js')).to.not.exist;
+        expect(_file('addon/templates/components/x-foo.js.hbs')).to.not.exist;
+        expect(_file('app/components/x-foo.js.js')).to.not.exist;
+        expect(_file('tests/integration/components/x-foo.js-test.js')).to.not.exist;
+
+        expect(_file('addon/components/x-foo.js')).to.equal(
+          fixture('component/component-addon-dash.js')
+        );
+
+        expect(_file('addon/templates/components/x-foo.hbs')).to.equal('{{yield}}');
+
+        expect(_file('app/components/x-foo.js')).to.contain(
+          "export { default } from 'my-addon/components/x-foo';"
+        );
+
+        expect(_file('tests/integration/components/x-foo-test.js')).to.equal(
+          fixture('component-test/default-template.js', {
+            replace: {
+              component: 'x-foo',
+              componentInvocation: 'XFoo',
+            },
+          })
+        );
+      });
+    });
+
     it('component foo/x-foo', function() {
       return emberGenerateDestroy(['component', 'foo/x-foo'], _file => {
         expect(_file('addon/components/foo/x-foo.js')).to.equal(
@@ -672,6 +790,25 @@ describe('Blueprint: component', function() {
         expect(_file('app/components/foo/x-foo.js')).to.not.exist;
 
         expect(_file('tests/unit/components/foo/x-foo-test.js')).to.not.exist;
+      });
+    });
+
+    it('component x-foo.js --dummy', function() {
+      return emberGenerateDestroy(['component', 'x-foo.js', '--dummy'], _file => {
+        expect(_file('tests/dummy/app/components/x-foo.js.js')).to.not.exist;
+        expect(_file('tests/dummy/app/templates/components/x-foo.js.hbs')).to.not.exist;
+        expect(_file('app/components/x-foo.js.js')).to.not.exist;
+        expect(_file('tests/unit/components/x-foo.js-test.js')).to.not.exist;
+
+        expect(_file('tests/dummy/app/components/x-foo.js')).to.equal(
+          fixture('component/component-addon-dash.js')
+        );
+
+        expect(_file('tests/dummy/app/templates/components/x-foo.hbs')).to.equal('{{yield}}');
+
+        expect(_file('app/components/x-foo.js')).to.not.exist;
+
+        expect(_file('tests/unit/components/x-foo-test.js')).to.not.exist;
       });
     });
 
@@ -755,6 +892,31 @@ describe('Blueprint: component', function() {
       });
     });
 
+    it('component x-foo.js', function() {
+      return emberGenerateDestroy(['component', 'x-foo.js'], _file => {
+        expect(_file('src/ui/components/x-foo.js/component.js')).to.not.exist;
+        expect(_file('src/ui/components/x-foo.js/template.hbs')).to.not.exist;
+        expect(_file('src/ui/components/x-foo.js/component-test.js')).to.not.exist;
+
+        expect(_file('src/ui/components/x-foo/component.js')).to.equal(
+          fixture('component/component-dash.js')
+        );
+
+        expect(_file('src/ui/components/x-foo/template.hbs')).to.equal('{{yield}}');
+
+        expect(_file('src/ui/components/x-foo/component-test.js')).to.equal(
+          fixture('component-test/default-template.js', {
+            replace: {
+              component: 'x-foo',
+              componentInvocation: 'XFoo',
+              path: 'my-addon::',
+              pathInvocation: 'MyAddon::',
+            },
+          })
+        );
+      });
+    });
+
     it('component foo/x-foo', function() {
       return emberGenerateDestroy(['component', 'foo/x-foo'], _file => {
         expect(_file('src/ui/components/foo/x-foo/component.js')).to.equal(
@@ -776,6 +938,23 @@ describe('Blueprint: component', function() {
 
     it('component x-foo --dummy', function() {
       return emberGenerateDestroy(['component', 'x-foo', '--dummy'], _file => {
+        expect(_file('tests/dummy/src/ui/components/x-foo/component.js')).to.equal(
+          fixture('component/component-dash.js')
+        );
+
+        expect(_file('tests/dummy/src/ui/components/x-foo/template.hbs')).to.equal('{{yield}}');
+
+        expect(_file('src/ui/components/x-foo/component.js')).to.not.exist;
+
+        expect(_file('src/ui/components/x-foo/component-test.js')).to.not.exist;
+      });
+    });
+
+    it('component x-foo.js --dummy', function() {
+      return emberGenerateDestroy(['component', 'x-foo.js', '--dummy'], _file => {
+        expect(_file('tests/dummy/src/ui/components/x-foo.js/component.js')).to.not.exist;
+        expect(_file('tests/dummy/src/ui/components/x-foo.js/template.hbs')).to.not.exist;
+
         expect(_file('tests/dummy/src/ui/components/x-foo/component.js')).to.equal(
           fixture('component/component-dash.js')
         );
@@ -869,6 +1048,39 @@ describe('Blueprint: component', function() {
       });
     });
 
+    it('component x-foo.js', function() {
+      return emberGenerateDestroy(['component', 'x-foo.js'], _file => {
+        expect(_file('addon/components/x-foo.js.js')).to.not.exist;
+        expect(_file('addon/templates/components/x-foo.js.hbs')).to.not.exist;
+        expect(_file('app/components/x-foo.js.js')).to.not.exist;
+        expect(_file('app/templates/components/x-foo.js.js')).to.not.exist;
+        expect(_file('tests/integration/components/x-foo.js-test.js')).to.not.exist;
+
+        expect(_file('addon/components/x-foo.js')).to.equal(
+          fixture('component/native-component-dash.js')
+        );
+
+        expect(_file('addon/templates/components/x-foo.hbs')).to.equal('{{yield}}');
+
+        expect(_file('app/components/x-foo.js')).to.contain(
+          "export { default } from 'my-addon/components/x-foo';"
+        );
+
+        expect(_file('app/templates/components/x-foo.js')).to.contain(
+          "export { default } from 'my-addon/templates/components/x-foo';"
+        );
+
+        expect(_file('tests/integration/components/x-foo-test.js')).to.equal(
+          fixture('component-test/default-template.js', {
+            replace: {
+              component: 'x-foo',
+              componentInvocation: 'XFoo',
+            },
+          })
+        );
+      });
+    });
+
     it('component foo/x-foo', function() {
       return emberGenerateDestroy(['component', 'foo/x-foo'], _file => {
         expect(_file('addon/components/foo/x-foo.js')).to.equal(
@@ -897,6 +1109,24 @@ describe('Blueprint: component', function() {
 
     it('component x-foo --dummy', function() {
       return emberGenerateDestroy(['component', 'x-foo', '--dummy'], _file => {
+        expect(_file('tests/dummy/app/components/x-foo.js')).to.equal(
+          fixture('component/native-component-dash.js')
+        );
+
+        expect(_file('tests/dummy/app/templates/components/x-foo.hbs')).to.equal('{{yield}}');
+
+        expect(_file('app/components/x-foo.js')).to.not.exist;
+        expect(_file('app/templates/components/x-foo.js')).to.not.exist;
+
+        expect(_file('tests/integration/components/x-foo-test.js')).to.not.exist;
+      });
+    });
+
+    it('component x-foo.js --dummy', function() {
+      return emberGenerateDestroy(['component', 'x-foo.js', '--dummy'], _file => {
+        expect(_file('tests/dummy/app/components/x-foo.js.js')).to.not.exist;
+        expect(_file('tests/dummy/app/templates/components/x-foo.js.hbs')).to.not.exist;
+
         expect(_file('tests/dummy/app/components/x-foo.js')).to.equal(
           fixture('component/native-component-dash.js')
         );
@@ -984,6 +1214,34 @@ describe('Blueprint: component', function() {
       });
     });
 
+    it('component x-foo.js --in-repo-addon=my-addon', function() {
+      return emberGenerateDestroy(['component', 'x-foo.js', '--in-repo-addon=my-addon'], _file => {
+        expect(_file('lib/my-addon/addon/components/x-foo.js.js')).to.not.exist;
+        expect(_file('lib/my-addon/addon/templates/components/x-foo.js.hbs')).to.not.exist;
+        expect(_file('lib/my-addon/app/components/x-foo.js.js')).to.not.exist;
+        expect(_file('tests/integration/components/x-foo-test.js.js')).to.not.exist;
+
+        expect(_file('lib/my-addon/addon/components/x-foo.js')).to.equal(
+          fixture('component/component-addon-dash.js')
+        );
+
+        expect(_file('lib/my-addon/addon/templates/components/x-foo.hbs')).to.equal('{{yield}}');
+
+        expect(_file('lib/my-addon/app/components/x-foo.js')).to.contain(
+          "export { default } from 'my-addon/components/x-foo';"
+        );
+
+        expect(_file('tests/integration/components/x-foo-test.js')).to.equal(
+          fixture('component-test/default-template.js', {
+            replace: {
+              component: 'x-foo',
+              componentInvocation: 'XFoo',
+            },
+          })
+        );
+      });
+    });
+
     it('component foo/x-foo --in-repo-addon=my-addon', function() {
       return emberGenerateDestroy(['component', 'foo/x-foo', '--in-repo-addon=my-addon'], _file => {
         expect(_file('lib/my-addon/addon/components/foo/x-foo.js')).to.equal(
@@ -1012,6 +1270,37 @@ describe('Blueprint: component', function() {
       return emberGenerateDestroy(
         ['component', 'x-foo', '--in-repo-addon=my-addon', '--pod'],
         _file => {
+          expect(_file('lib/my-addon/addon/components/x-foo/component.js')).to.equal(
+            fixture('component/component-addon-dash-pod.js')
+          );
+
+          expect(_file('lib/my-addon/addon/components/x-foo/template.hbs')).to.equal('{{yield}}');
+
+          expect(_file('lib/my-addon/app/components/x-foo/component.js')).to.contain(
+            "export { default } from 'my-addon/components/x-foo/component';"
+          );
+
+          expect(_file('tests/integration/components/x-foo/component-test.js')).to.equal(
+            fixture('component-test/default-template.js', {
+              replace: {
+                component: 'x-foo',
+                componentInvocation: 'XFoo',
+              },
+            })
+          );
+        }
+      );
+    });
+
+    it('component x-foo.js --in-repo-addon=my-addon --pod', function() {
+      return emberGenerateDestroy(
+        ['component', 'x-foo.js', '--in-repo-addon=my-addon', '--pod'],
+        _file => {
+          expect(_file('lib/my-addon/addon/components/x-foo/component.js.js')).to.not.exist;
+          expect(_file('lib/my-addon/addon/components/x-foo/template.js.hbs')).to.not.exist;
+          expect(_file('lib/my-addon/app/components/x-foo/component.js.js')).to.not.exist;
+          expect(_file('tests/integration/components/x-foo/component-test.js.js')).to.not.exist;
+
           expect(_file('lib/my-addon/addon/components/x-foo/component.js')).to.equal(
             fixture('component/component-addon-dash-pod.js')
           );
@@ -1119,6 +1408,34 @@ describe('Blueprint: component', function() {
         );
       });
     });
+
+    it('component x-foo.js --in-repo-addon=my-addon', function() {
+      return emberGenerateDestroy(['component', 'x-foo.js', '--in-repo-addon=my-addon'], _file => {
+        expect(_file('packages/my-addon/src/ui/components/x-foo/component.js.js')).to.not.exist;
+        expect(_file('packages/my-addon/src/ui/components/x-foo/template.js.hbs')).to.not.exist;
+        expect(_file('packages/my-addon/src/ui/components/x-foo/component-test.js.js')).to.not
+          .exist;
+
+        expect(_file('packages/my-addon/src/ui/components/x-foo/component.js')).to.equal(
+          fixture('component/component-dash.js')
+        );
+
+        expect(_file('packages/my-addon/src/ui/components/x-foo/template.hbs')).to.equal(
+          '{{yield}}'
+        );
+
+        expect(_file('packages/my-addon/src/ui/components/x-foo/component-test.js')).to.equal(
+          fixture('component-test/default-template.js', {
+            replace: {
+              component: 'x-foo',
+              componentInvocation: 'XFoo',
+              path: 'my-addon::',
+              pathInvocation: 'MyAddon::',
+            },
+          })
+        );
+      });
+    });
   });
 
   describe('in in-repo-addon - octane', function() {
@@ -1164,6 +1481,39 @@ describe('Blueprint: component', function() {
 
     it('component x-foo --in-repo-addon=my-addon', function() {
       return emberGenerateDestroy(['component', 'x-foo', '--in-repo-addon=my-addon'], _file => {
+        expect(_file('lib/my-addon/addon/components/x-foo.js')).to.equal(
+          fixture('component/native-component-dash.js')
+        );
+
+        expect(_file('lib/my-addon/addon/templates/components/x-foo.hbs')).to.equal('{{yield}}');
+
+        expect(_file('lib/my-addon/app/components/x-foo.js')).to.contain(
+          "export { default } from 'my-addon/components/x-foo';"
+        );
+
+        expect(_file('lib/my-addon/app/templates/components/x-foo.js')).to.contain(
+          "export { default } from 'my-addon/templates/components/x-foo';"
+        );
+
+        expect(_file('tests/integration/components/x-foo-test.js')).to.equal(
+          fixture('component-test/default-template.js', {
+            replace: {
+              component: 'x-foo',
+              componentInvocation: 'XFoo',
+            },
+          })
+        );
+      });
+    });
+
+    it('component x-foo.js --in-repo-addon=my-addon', function() {
+      return emberGenerateDestroy(['component', 'x-foo.js', '--in-repo-addon=my-addon'], _file => {
+        expect(_file('lib/my-addon/addon/components/x-foo.js.js')).to.not.exist;
+        expect(_file('lib/my-addon/addon/templates/components/x-foo.js.hbs')).to.not.exist;
+        expect(_file('lib/my-addon/app/components/x-foo.js.js')).to.not.exist;
+        expect(_file('lib/my-addon/app/templates/components/x-foo.js.js')).to.not.exist;
+        expect(_file('tests/integration/components/x-foo-test.js.js')).to.not.exist;
+
         expect(_file('lib/my-addon/addon/components/x-foo.js')).to.equal(
           fixture('component/native-component-dash.js')
         );

--- a/node-tests/blueprints/controller-test.js
+++ b/node-tests/blueprints/controller-test.js
@@ -43,6 +43,19 @@ describe('Blueprint: controller', function() {
       });
     });
 
+    it('controller foo.js', function() {
+      return emberGenerateDestroy(['controller', 'foo.js'], _file => {
+        expect(_file('app/controllers/foo.js.js')).to.not.exist;
+        expect(_file('tests/unit/controllers/foo.js-test.js')).to.not.exist;
+
+        expect(_file('app/controllers/foo.js')).to.equal(fixture('controller/controller.js'));
+
+        expect(_file('tests/unit/controllers/foo-test.js')).to.equal(
+          fixture('controller-test/default.js')
+        );
+      });
+    });
+
     it('controller foo/bar', function() {
       return emberGenerateDestroy(['controller', 'foo/bar'], _file => {
         expect(_file('app/controllers/foo/bar.js')).to.equal(
@@ -57,6 +70,19 @@ describe('Blueprint: controller', function() {
 
     it('controller foo --pod', function() {
       return emberGenerateDestroy(['controller', 'foo', '--pod'], _file => {
+        expect(_file('app/foo/controller.js')).to.equal(fixture('controller/controller.js'));
+
+        expect(_file('tests/unit/foo/controller-test.js')).to.equal(
+          fixture('controller-test/default.js')
+        );
+      });
+    });
+
+    it('controller foo.js --pod', function() {
+      return emberGenerateDestroy(['controller', 'foo.js', '--pod'], _file => {
+        expect(_file('app/foo.js/controller.js')).to.not.exist;
+        expect(_file('tests/unit/foo.js/controller-test.js')).to.not.exist;
+
         expect(_file('app/foo/controller.js')).to.equal(fixture('controller/controller.js'));
 
         expect(_file('tests/unit/foo/controller-test.js')).to.equal(
@@ -84,6 +110,19 @@ describe('Blueprint: controller', function() {
 
       it('controller foo --pod podModulePrefix', function() {
         return emberGenerateDestroy(['controller', 'foo', '--pod'], _file => {
+          expect(_file('app/pods/foo/controller.js')).to.equal(fixture('controller/controller.js'));
+
+          expect(_file('tests/unit/pods/foo/controller-test.js')).to.equal(
+            fixture('controller-test/default.js')
+          );
+        });
+      });
+
+      it('controller foo.js --pod podModulePrefix', function() {
+        return emberGenerateDestroy(['controller', 'foo.js', '--pod'], _file => {
+          expect(_file('app/pods/foo.js/controller.js')).to.not.exist;
+          expect(_file('tests/unit/pods/foo.js/controller-test.js')).to.not.exist;
+
           expect(_file('app/pods/foo/controller.js')).to.equal(fixture('controller/controller.js'));
 
           expect(_file('tests/unit/pods/foo/controller-test.js')).to.equal(
@@ -132,6 +171,24 @@ describe('Blueprint: controller', function() {
       });
     });
 
+    it('controller foo.js', function() {
+      return emberGenerateDestroy(['controller', 'foo.js'], _file => {
+        expect(_file('addon/controllers/foo.js.js')).to.not.exist;
+        expect(_file('app/controllers/foo.js.js')).to.not.exist;
+        expect(_file('tests/unit/controllers/foo.js-test.js')).to.not.exist;
+
+        expect(_file('addon/controllers/foo.js')).to.equal(fixture('controller/controller.js'));
+
+        expect(_file('app/controllers/foo.js')).to.contain(
+          "export { default } from 'my-addon/controllers/foo';"
+        );
+
+        expect(_file('tests/unit/controllers/foo-test.js')).to.equal(
+          fixture('controller-test/default.js')
+        );
+      });
+    });
+
     it('controller foo/bar', function() {
       return emberGenerateDestroy(['controller', 'foo/bar'], _file => {
         expect(_file('addon/controllers/foo/bar.js')).to.equal(
@@ -150,6 +207,20 @@ describe('Blueprint: controller', function() {
 
     it('controller foo --dummy', function() {
       return emberGenerateDestroy(['controller', 'foo', '--dummy'], _file => {
+        expect(_file('tests/dummy/app/controllers/foo.js')).to.equal(
+          fixture('controller/controller.js')
+        );
+
+        expect(_file('app/controllers/foo-test.js')).to.not.exist;
+
+        expect(_file('tests/unit/controllers/foo-test.js')).to.not.exist;
+      });
+    });
+
+    it('controller foo.js --dummy', function() {
+      return emberGenerateDestroy(['controller', 'foo.js', '--dummy'], _file => {
+        expect(_file('tests/dummy/app/controllers/foo.js.js')).to.not.exist;
+
         expect(_file('tests/dummy/app/controllers/foo.js')).to.equal(
           fixture('controller/controller.js')
         );
@@ -189,6 +260,21 @@ describe('Blueprint: controller', function() {
 
     it('controller foo', function() {
       return emberGenerateDestroy(['controller', 'foo'], _file => {
+        expect(_file('src/ui/routes/foo/controller.js')).to.equal(
+          fixture('controller/controller.js')
+        );
+
+        expect(_file('src/ui/routes/foo/controller-test.js')).to.equal(
+          fixture('controller-test/default.js')
+        );
+      });
+    });
+
+    it('controller foo.js', function() {
+      return emberGenerateDestroy(['controller', 'foo.js'], _file => {
+        expect(_file('src/ui/routes/foo.js/controller.js')).to.not.exist;
+        expect(_file('src/ui/routes/foo.js/controller-test.js')).to.not.exist;
+
         expect(_file('src/ui/routes/foo/controller.js')).to.equal(
           fixture('controller/controller.js')
         );
@@ -253,6 +339,23 @@ describe('Blueprint: controller', function() {
       });
     });
 
+    it('controller foo.js', function() {
+      return emberGenerateDestroy(['controller', 'foo.js'], _file => {
+        expect(_file('src/ui/routes/foo.js/controller.js')).to.not.exist;
+        expect(_file('src/ui/routes/foo.js/controller-test.js')).to.not.exist;
+
+        expect(_file('src/ui/routes/foo/controller.js')).to.equal(
+          fixture('controller/controller.js')
+        );
+
+        expect(_file('src/ui/routes/foo/controller-test.js')).to.equal(
+          fixture('controller-test/default.js')
+        );
+
+        expect(_file('app/controllers/foo.js')).to.not.exist;
+      });
+    });
+
     it('controller foo/bar', function() {
       return emberGenerateDestroy(['controller', 'foo/bar'], _file => {
         expect(_file('src/ui/routes/foo/bar/controller.js')).to.equal(
@@ -269,6 +372,20 @@ describe('Blueprint: controller', function() {
 
     it('controller foo --dummy', function() {
       return emberGenerateDestroy(['controller', 'foo', '--dummy'], _file => {
+        expect(_file('tests/dummy/src/ui/routes/foo/controller.js')).to.equal(
+          fixture('controller/controller.js')
+        );
+
+        expect(_file('src/ui/routes/foo/controller.js')).to.not.exist;
+
+        expect(_file('src/ui/routes/foo/controller-test.js')).to.not.exist;
+      });
+    });
+
+    it('controller foo.js --dummy', function() {
+      return emberGenerateDestroy(['controller', 'foo.js', '--dummy'], _file => {
+        expect(_file('tests/dummy/src/ui/routes/foo.js/controller.js')).to.not.exist;
+
         expect(_file('tests/dummy/src/ui/routes/foo/controller.js')).to.equal(
           fixture('controller/controller.js')
         );
@@ -331,6 +448,21 @@ describe('Blueprint: controller', function() {
       });
     });
 
+    it('controller foo.js', function() {
+      return emberGenerateDestroy(['controller', 'foo.js'], _file => {
+        expect(_file('app/controllers/foo.js.js')).to.not.exist;
+        expect(_file('tests/unit/controllers/foo.js-test.js')).to.not.exist;
+
+        expect(_file('app/controllers/foo.js')).to.equal(
+          fixture('controller/native-controller.js')
+        );
+
+        expect(_file('tests/unit/controllers/foo-test.js')).to.equal(
+          fixture('controller-test/default.js')
+        );
+      });
+    });
+
     it('controller foo/bar', function() {
       return emberGenerateDestroy(['controller', 'foo/bar'], _file => {
         expect(_file('app/controllers/foo/bar.js')).to.equal(
@@ -350,6 +482,18 @@ describe('Blueprint: controller', function() {
 
       it('controller foo --pod podModulePrefix', function() {
         return emberGenerateDestroy(['controller', 'foo', '--pod'], _file => {
+          expect(_file('app/pods/foo/controller.js')).to.equal(
+            fixture('controller/native-controller.js')
+          );
+
+          expect(_file('tests/unit/pods/foo/controller-test.js')).to.equal(
+            fixture('controller-test/default.js')
+          );
+        });
+      });
+
+      it('controller foo.js --pod podModulePrefix', function() {
+        return emberGenerateDestroy(['controller', 'foo.js', '--pod'], _file => {
           expect(_file('app/pods/foo/controller.js')).to.equal(
             fixture('controller/native-controller.js')
           );
@@ -392,6 +536,26 @@ describe('Blueprint: controller', function() {
       });
     });
 
+    it('controller foo.js', function() {
+      return emberGenerateDestroy(['controller', 'foo.js'], _file => {
+        expect(_file('addon/controllers/foo.js.js')).to.not.exist;
+        expect(_file('app/controllers/foo.js.js')).to.not.exist;
+        expect(_file('tests/unit/controllers/foo.js-test.js')).to.not.exist;
+
+        expect(_file('addon/controllers/foo.js')).to.equal(
+          fixture('controller/native-controller.js')
+        );
+
+        expect(_file('app/controllers/foo.js')).to.contain(
+          "export { default } from 'my-addon/controllers/foo';"
+        );
+
+        expect(_file('tests/unit/controllers/foo-test.js')).to.equal(
+          fixture('controller-test/default.js')
+        );
+      });
+    });
+
     it('controller foo/bar', function() {
       return emberGenerateDestroy(['controller', 'foo/bar'], _file => {
         expect(_file('addon/controllers/foo/bar.js')).to.equal(
@@ -410,6 +574,20 @@ describe('Blueprint: controller', function() {
 
     it('controller foo --dummy', function() {
       return emberGenerateDestroy(['controller', 'foo', '--dummy'], _file => {
+        expect(_file('tests/dummy/app/controllers/foo.js')).to.equal(
+          fixture('controller/native-controller.js')
+        );
+
+        expect(_file('app/controllers/foo-test.js')).to.not.exist;
+
+        expect(_file('tests/unit/controllers/foo-test.js')).to.not.exist;
+      });
+    });
+
+    it('controller foo.js --dummy', function() {
+      return emberGenerateDestroy(['controller', 'foo.js', '--dummy'], _file => {
+        expect(_file('tests/dummy/app/controllers/foo.js.js')).to.not.exist;
+
         expect(_file('tests/dummy/app/controllers/foo.js')).to.equal(
           fixture('controller/native-controller.js')
         );
@@ -447,6 +625,26 @@ describe('Blueprint: controller', function() {
 
     it('controller foo --in-repo-addon=my-addon', function() {
       return emberGenerateDestroy(['controller', 'foo', '--in-repo-addon=my-addon'], _file => {
+        expect(_file('lib/my-addon/addon/controllers/foo.js')).to.equal(
+          fixture('controller/controller.js')
+        );
+
+        expect(_file('lib/my-addon/app/controllers/foo.js')).to.contain(
+          "export { default } from 'my-addon/controllers/foo';"
+        );
+
+        expect(_file('tests/unit/controllers/foo-test.js')).to.equal(
+          fixture('controller-test/default.js')
+        );
+      });
+    });
+
+    it('controller foo.js --in-repo-addon=my-addon', function() {
+      return emberGenerateDestroy(['controller', 'foo.js', '--in-repo-addon=my-addon'], _file => {
+        expect(_file('lib/my-addon/addon/controllers/foo.js.js')).to.not.exist;
+        expect(_file('lib/my-addon/app/controllers/foo.js.js')).to.not.exist;
+        expect(_file('tests/unit/controllers/foo.js-test.js')).to.not.exist;
+
         expect(_file('lib/my-addon/addon/controllers/foo.js')).to.equal(
           fixture('controller/controller.js')
         );

--- a/node-tests/blueprints/helper-test.js
+++ b/node-tests/blueprints/helper-test.js
@@ -39,6 +39,18 @@ describe('Blueprint: helper', function() {
       });
     });
 
+    it('helper foo/bar-baz.js', function() {
+      return emberGenerateDestroy(['helper', 'foo/bar-baz.js'], _file => {
+        expect(_file('app/helpers/foo/bar-baz.js.js')).to.not.exist;
+        expect(_file('tests/integration/helpers/foo/bar-baz.js-test.js')).to.not.exist;
+
+        expect(_file('app/helpers/foo/bar-baz.js')).to.equal(fixture('helper/helper.js'));
+        expect(_file('tests/integration/helpers/foo/bar-baz-test.js')).to.equal(
+          fixture('helper-test/integration.js')
+        );
+      });
+    });
+
     it('helper foo/bar-baz unit', function() {
       return emberGenerateDestroy(['helper', '--test-type=unit', 'foo/bar-baz'], _file => {
         expect(_file('app/helpers/foo/bar-baz.js')).to.equal(fixture('helper/helper.js'));
@@ -57,8 +69,11 @@ describe('Blueprint: helper', function() {
       });
     });
 
-    it('helper foo/bar-baz --pod', function() {
-      return emberGenerateDestroy(['helper', 'foo/bar-baz', '--pod'], _file => {
+    it('helper foo/bar-baz.js --pod', function() {
+      return emberGenerateDestroy(['helper', 'foo/bar-baz.js', '--pod'], _file => {
+        expect(_file('app/helpers/foo/bar-baz.js.js')).to.not.exist;
+        expect(_file('tests/integration/helpers/foo/bar-baz.js-test.js')).to.not.exist;
+
         expect(_file('app/helpers/foo/bar-baz.js')).to.equal(fixture('helper/helper.js'));
         expect(_file('tests/integration/helpers/foo/bar-baz-test.js')).to.equal(
           fixture('helper-test/integration.js')
@@ -80,8 +95,11 @@ describe('Blueprint: helper', function() {
         });
       });
 
-      it('helper foo/bar-baz --pod', function() {
-        return emberGenerateDestroy(['helper', 'foo/bar-baz', '--pod'], _file => {
+      it('helper foo/bar-baz.js --pod', function() {
+        return emberGenerateDestroy(['helper', 'foo/bar-baz.js', '--pod'], _file => {
+          expect(_file('app/helpers/foo/bar-baz.js.js')).to.not.exist;
+          expect(_file('tests/integration/helpers/foo/bar-baz.js-test.js')).to.not.exist;
+
           expect(_file('app/helpers/foo/bar-baz.js')).to.equal(fixture('helper/helper.js'));
           expect(_file('tests/integration/helpers/foo/bar-baz-test.js')).to.equal(
             fixture('helper-test/integration.js')
@@ -106,6 +124,18 @@ describe('Blueprint: helper', function() {
 
     it('helper foo/bar-baz', function() {
       return emberGenerateDestroy(['helper', 'foo/bar-baz'], _file => {
+        expect(_file('src/ui/components/foo/bar-baz.js')).to.equal(fixture('helper/mu-helper.js'));
+        expect(_file('src/ui/components/foo/bar-baz-test.js')).to.equal(
+          fixture('helper-test/integration.js')
+        );
+      });
+    });
+
+    it('helper foo/bar-baz.js', function() {
+      return emberGenerateDestroy(['helper', 'foo/bar-baz.js'], _file => {
+        expect(_file('src/ui/components/foo/bar-baz.js.js')).to.not.exist;
+        expect(_file('src/ui/components/foo/bar-baz.js-test.js')).to.not.exist;
+
         expect(_file('src/ui/components/foo/bar-baz.js')).to.equal(fixture('helper/mu-helper.js'));
         expect(_file('src/ui/components/foo/bar-baz-test.js')).to.equal(
           fixture('helper-test/integration.js')
@@ -144,8 +174,34 @@ describe('Blueprint: helper', function() {
       });
     });
 
+    it('helper foo/bar-baz.js', function() {
+      return emberGenerateDestroy(['helper', 'foo/bar-baz.js'], _file => {
+        expect(_file('addon/helpers/foo/bar-baz.js.js')).to.not.exist;
+        expect(_file('app/helpers/foo/bar-baz.js.js')).to.not.exist;
+        expect(_file('tests/integration/helpers/foo/bar-baz.js-test.js')).to.not.exist;
+
+        expect(_file('addon/helpers/foo/bar-baz.js')).to.equal(fixture('helper/helper.js'));
+        expect(_file('app/helpers/foo/bar-baz.js')).to.equal(fixture('helper/helper-addon.js'));
+        expect(_file('tests/integration/helpers/foo/bar-baz-test.js')).to.equal(
+          fixture('helper-test/integration.js')
+        );
+      });
+    });
+
     it('helper foo/bar-baz --dummy', function() {
       return emberGenerateDestroy(['helper', 'foo/bar-baz', '--dummy'], _file => {
+        expect(_file('tests/dummy/app/helpers/foo/bar-baz.js')).to.equal(
+          fixture('helper/helper.js')
+        );
+        expect(_file('app/helpers/foo/bar-baz.js')).to.not.exist;
+        expect(_file('tests/integration/helpers/foo/bar-baz-test.js')).to.not.exist;
+      });
+    });
+
+    it('helper foo/bar-baz.js --dummy', function() {
+      return emberGenerateDestroy(['helper', 'foo/bar-baz.js', '--dummy'], _file => {
+        expect(_file('tests/dummy/app/helpers/foo/bar-baz.js.js')).to.not.exist;
+
         expect(_file('tests/dummy/app/helpers/foo/bar-baz.js')).to.equal(
           fixture('helper/helper.js')
         );
@@ -186,8 +242,31 @@ describe('Blueprint: helper', function() {
       });
     });
 
+    it('helper foo/bar-baz.js unit', function() {
+      return emberGenerateDestroy(['helper', '--test-type=unit', 'foo/bar-baz'], _file => {
+        expect(_file('src/ui/components/foo/bar-baz.js.js')).to.not.exist;
+        expect(_file('src/ui/components/foo/bar-baz.js-test.js')).to.not.exist;
+
+        expect(_file('src/ui/components/foo/bar-baz.js')).to.equal(fixture('helper/mu-helper.js'));
+        expect(_file('src/ui/components/foo/bar-baz-test.js')).to.equal(
+          fixture('helper-test/module-unification/addon-unit.js')
+        );
+      });
+    });
+
     it('helper foo/bar-baz --dummy', function() {
       return emberGenerateDestroy(['helper', 'foo/bar-baz', '--dummy'], _file => {
+        expect(_file('tests/dummy/src/ui/components/foo/bar-baz.js')).to.equal(
+          fixture('helper/mu-helper.js')
+        );
+        expect(_file('src/ui/components/foo/bar-baz.js')).to.not.exist;
+      });
+    });
+
+    it('helper foo/bar-baz.js --dummy', function() {
+      return emberGenerateDestroy(['helper', 'foo/bar-baz.js', '--dummy'], _file => {
+        expect(_file('tests/dummy/src/ui/components/foo/bar-baz.js.js')).to.not.exist;
+
         expect(_file('tests/dummy/src/ui/components/foo/bar-baz.js')).to.equal(
           fixture('helper/mu-helper.js')
         );
@@ -220,6 +299,27 @@ describe('Blueprint: helper', function() {
         );
       });
     });
+
+    it('helper foo/bar-baz.js --in-repo-addon=my-addon', function() {
+      return emberGenerateDestroy(
+        ['helper', 'foo/bar-baz.js', '--in-repo-addon=my-addon'],
+        _file => {
+          expect(_file('lib/my-addon/addon/helpers/foo/bar-baz.js.js')).to.not.exist;
+          expect(_file('lib/my-addon/app/helpers/foo/bar-baz.js.js')).to.not.exist;
+          expect(_file('tests/integration/helpers/foo/bar-baz.js-test.js')).to.not.exist;
+
+          expect(_file('lib/my-addon/addon/helpers/foo/bar-baz.js')).to.equal(
+            fixture('helper/helper.js')
+          );
+          expect(_file('lib/my-addon/app/helpers/foo/bar-baz.js')).to.equal(
+            fixture('helper/helper-addon.js')
+          );
+          expect(_file('tests/integration/helpers/foo/bar-baz-test.js')).to.equal(
+            fixture('helper-test/integration.js')
+          );
+        }
+      );
+    });
   });
 
   describe('in in-repo-addon - module unification', function() {
@@ -244,6 +344,23 @@ describe('Blueprint: helper', function() {
           fixture('helper-test/integration.js')
         );
       });
+    });
+
+    it('helper foo/bar-baz.js --in-repo-addon=my-addon', function() {
+      return emberGenerateDestroy(
+        ['helper', 'foo/bar-baz.js', '--in-repo-addon=my-addon'],
+        _file => {
+          expect(_file('packages/my-addon/src/ui/components/foo/bar-baz.js.js')).to.not.exist;
+          expect(_file('packages/my-addon/src/ui/components/foo/bar-baz.js-test.js')).to.not.exist;
+
+          expect(_file('packages/my-addon/src/ui/components/foo/bar-baz.js')).to.equal(
+            fixture('helper/mu-helper.js')
+          );
+          expect(_file('packages/my-addon/src/ui/components/foo/bar-baz-test.js')).to.equal(
+            fixture('helper-test/integration.js')
+          );
+        }
+      );
     });
 
     it('helper foo/bar-baz unit --in-repo-addon=my-addon', function() {

--- a/node-tests/blueprints/mixin-test.js
+++ b/node-tests/blueprints/mixin-test.js
@@ -34,6 +34,21 @@ describe('Blueprint: mixin', function() {
       });
     });
 
+    it('mixin foo.js', function() {
+      return emberGenerateDestroy(['mixin', 'foo.js'], _file => {
+        expect(_file('app/mixins/foo.js.js')).to.not.exist;
+        expect(_file('tests/unit/mixins/foo.js-test.js')).to.not.exist;
+
+        expect(_file('app/mixins/foo.js'))
+          .to.contain("import Mixin from '@ember/object/mixin';")
+          .to.contain(`export default Mixin.create({${EOL}});`);
+
+        expect(_file('tests/unit/mixins/foo-test.js')).to.contain(
+          "import FooMixin from 'my-app/mixins/foo';"
+        );
+      });
+    });
+
     it('mixin foo/bar', function() {
       return emberGenerateDestroy(['mixin', 'foo/bar'], _file => {
         expect(_file('app/mixins/foo/bar.js'))
@@ -56,6 +71,21 @@ describe('Blueprint: mixin', function() {
 
     it('mixin foo --pod', function() {
       return emberGenerateDestroy(['mixin', 'foo', '--pod'], _file => {
+        expect(_file('app/mixins/foo.js'))
+          .to.contain("import Mixin from '@ember/object/mixin';")
+          .to.contain(`export default Mixin.create({${EOL}});`);
+
+        expect(_file('tests/unit/mixins/foo-test.js')).to.contain(
+          "import FooMixin from 'my-app/mixins/foo';"
+        );
+      });
+    });
+
+    it('mixin foo.js --pod', function() {
+      return emberGenerateDestroy(['mixin', 'foo.js', '--pod'], _file => {
+        expect(_file('app/mixins/foo.js.js')).to.not.exist;
+        expect(_file('tests/unit/mixins/foo.js-test.js')).to.not.exist;
+
         expect(_file('app/mixins/foo.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
           .to.contain(`export default Mixin.create({${EOL}});`);
@@ -103,6 +133,21 @@ describe('Blueprint: mixin', function() {
         });
       });
 
+      it('mixin foo.js --pod', function() {
+        return emberGenerateDestroy(['mixin', 'foo.js', '--pod'], _file => {
+          expect(_file('app/mixins/foo.js.js')).to.not.exist;
+          expect(_file('tests/unit/mixins/foo.js-test.js')).to.not.exist;
+
+          expect(_file('app/mixins/foo.js'))
+            .to.contain("import Mixin from '@ember/object/mixin';")
+            .to.contain(`export default Mixin.create({${EOL}});`);
+
+          expect(_file('tests/unit/mixins/foo-test.js')).to.contain(
+            "import FooMixin from 'my-app/mixins/foo';"
+          );
+        });
+      });
+
       it('mixin foo/bar --pod', function() {
         return emberGenerateDestroy(['mixin', 'foo/bar', '--pod'], _file => {
           expect(_file('app/mixins/foo/bar.js'))
@@ -126,6 +171,21 @@ describe('Blueprint: mixin', function() {
 
     it('mixin foo', function() {
       return emberGenerateDestroy(['mixin', 'foo'], _file => {
+        expect(_file('src/mixins/foo.js'))
+          .to.contain("import Mixin from '@ember/object/mixin';")
+          .to.contain(`export default Mixin.create({${EOL}});`);
+
+        expect(_file('src/mixins/foo-test.js')).to.contain(
+          "import FooMixin from 'my-app/mixins/foo';"
+        );
+      });
+    });
+
+    it('mixin foo.js', function() {
+      return emberGenerateDestroy(['mixin', 'foo'], _file => {
+        expect(_file('src/mixins/foo.js.js')).to.not.exist;
+        expect(_file('src/mixins/foo.js-test.js')).to.not.exist;
+
         expect(_file('src/mixins/foo.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
           .to.contain(`export default Mixin.create({${EOL}});`);
@@ -187,6 +247,23 @@ describe('Blueprint: mixin', function() {
       });
     });
 
+    it('mixin foo.js', function() {
+      return emberGenerateDestroy(['mixin', 'foo.js'], _file => {
+        expect(_file('addon/mixins/foo.js.js')).to.not.exist;
+        expect(_file('tests/unit/mixins/foo.js-test.js')).to.not.exist;
+
+        expect(_file('addon/mixins/foo.js'))
+          .to.contain("import Mixin from '@ember/object/mixin';")
+          .to.contain(`export default Mixin.create({${EOL}});`);
+
+        expect(_file('tests/unit/mixins/foo-test.js')).to.contain(
+          "import FooMixin from 'my-addon/mixins/foo';"
+        );
+
+        expect(_file('app/mixins/foo.js')).to.not.exist;
+      });
+    });
+
     it('mixin foo/bar', function() {
       return emberGenerateDestroy(['mixin', 'foo/bar'], _file => {
         expect(_file('addon/mixins/foo/bar.js'))
@@ -224,6 +301,18 @@ describe('Blueprint: mixin', function() {
         expect(_file('addon/mixins/foo/bar/baz.js')).to.not.exist;
       });
     });
+
+    it('mixin foo.js --dummy', function() {
+      return emberGenerateDestroy(['mixin', 'foo.js', '--dummy'], _file => {
+        expect(_file('tests/dummy/app/mixins/foo.js.js')).to.not.exist;
+
+        expect(_file('tests/dummy/app/mixins/foo.js'))
+          .to.contain("import Mixin from '@ember/object/mixin';")
+          .to.contain(`export default Mixin.create({${EOL}});`);
+
+        expect(_file('addon/mixins/foo.js')).to.not.exist;
+      });
+    });
   });
 
   describe('in addon - module unification', function() {
@@ -235,6 +324,21 @@ describe('Blueprint: mixin', function() {
 
     it('mixin foo', function() {
       return emberGenerateDestroy(['mixin', 'foo'], _file => {
+        expect(_file('src/mixins/foo.js'))
+          .to.contain("import Mixin from '@ember/object/mixin';")
+          .to.contain(`export default Mixin.create({${EOL}});`);
+
+        expect(_file('src/mixins/foo-test.js')).to.contain(
+          "import FooMixin from 'my-addon/mixins/foo';"
+        );
+      });
+    });
+
+    it('mixin foo.js', function() {
+      return emberGenerateDestroy(['mixin', 'foo.js'], _file => {
+        expect(_file('src/mixins/foo.js.js')).to.not.exist;
+        expect(_file('src/mixins/foo.js-test.js')).to.not.exist;
+
         expect(_file('src/mixins/foo.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
           .to.contain(`export default Mixin.create({${EOL}});`);
@@ -278,6 +382,18 @@ describe('Blueprint: mixin', function() {
         expect(_file('src/mixins/foo/bar/baz.js')).to.not.exist;
       });
     });
+
+    it('mixin foo.js --dummy', function() {
+      return emberGenerateDestroy(['mixin', 'foo.js', '--dummy'], _file => {
+        expect(_file('tests/dummy/src/mixins/foo.js.js')).to.not.exist;
+
+        expect(_file('tests/dummy/src/mixins/foo.js'))
+          .to.contain("import Mixin from '@ember/object/mixin';")
+          .to.contain(`export default Mixin.create({${EOL}});`);
+
+        expect(_file('src/mixins/foo.js')).to.not.exist;
+      });
+    });
   });
 
   describe('in in-repo-addon', function() {
@@ -287,6 +403,21 @@ describe('Blueprint: mixin', function() {
 
     it('mixin foo --in-repo-addon=my-addon', function() {
       return emberGenerateDestroy(['mixin', 'foo', '--in-repo-addon=my-addon'], _file => {
+        expect(_file('lib/my-addon/addon/mixins/foo.js'))
+          .to.contain("import Mixin from '@ember/object/mixin';")
+          .to.contain(`export default Mixin.create({${EOL}});`);
+
+        expect(_file('tests/unit/mixins/foo-test.js')).to.contain(
+          "import FooMixin from 'my-addon/mixins/foo';"
+        );
+      });
+    });
+
+    it('mixin foo.js --in-repo-addon=my-addon', function() {
+      return emberGenerateDestroy(['mixin', 'foo.js', '--in-repo-addon=my-addon'], _file => {
+        expect(_file('lib/my-addon/addon/mixins/foo.js.js')).to.not.exist;
+        expect(_file('tests/unit/mixins/foo.js-test.js')).to.not.exist;
+
         expect(_file('lib/my-addon/addon/mixins/foo.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
           .to.contain(`export default Mixin.create({${EOL}});`);

--- a/node-tests/blueprints/route-test.js
+++ b/node-tests/blueprints/route-test.js
@@ -51,6 +51,25 @@ describe('Blueprint: route', function() {
       });
     });
 
+    it('route foo.js', function() {
+      return emberGenerateDestroy(['route', 'foo.js'], _file => {
+        expect(_file('app/routes/foo.js.js')).to.not.exist;
+        expect(_file('app/templates/foo.js.hbs')).to.not.exist;
+        expect(_file('tests/unit/routes/foo.js-test.js')).to.not.exist;
+
+        expect(_file('app/routes/foo.js')).to.equal(fixture('route/route.js'));
+
+        expect(_file('app/templates/foo.hbs')).to.equal('{{outlet}}');
+
+        expect(_file('tests/unit/routes/foo-test.js')).to.equal(fixture('route-test/default.js'));
+
+        expect(file('app/router.js')).to.contain("this.route('foo')");
+        expect(file('app/router.js')).to.not.contain("this.route('foo.js')");
+      }).then(() => {
+        expect(file('app/router.js')).to.not.contain("this.route('foo')");
+      });
+    });
+
     it('route foo --skip-router', function() {
       return emberGenerateDestroy(['route', 'foo', '--skip-router'], _file => {
         expect(_file('app/routes/foo.js')).to.exist;
@@ -149,6 +168,25 @@ describe('Blueprint: route', function() {
 
     it('route foo --pod', function() {
       return emberGenerateDestroy(['route', 'foo', '--pod'], _file => {
+        expect(_file('app/foo.js/route.js')).to.not.exist;
+        expect(_file('app/foo.js/template.hbs')).to.not.exist;
+        expect(_file('tests/unit/foo.js/route-test.js')).to.not.exist;
+
+        expect(_file('app/foo/route.js')).to.equal(fixture('route/route.js'));
+
+        expect(_file('app/foo/template.hbs')).to.equal('{{outlet}}');
+
+        expect(_file('tests/unit/foo/route-test.js')).to.equal(fixture('route-test/default.js'));
+
+        expect(file('app/router.js')).to.contain("this.route('foo')");
+        expect(file('app/router.js')).to.not.contain("this.route('foo.js')");
+      }).then(() => {
+        expect(file('app/router.js')).to.not.contain("this.route('foo')");
+      });
+    });
+
+    it('route foo.js --pod', function() {
+      return emberGenerateDestroy(['route', 'foo.js', '--pod'], _file => {
         expect(_file('app/foo/route.js')).to.equal(fixture('route/route.js'));
 
         expect(_file('app/foo/template.hbs')).to.equal('{{outlet}}');
@@ -218,6 +256,27 @@ describe('Blueprint: route', function() {
           expect(file('app/router.js')).to.not.contain("this.route('foo')");
         });
       });
+
+      it('route foo.js --pod', function() {
+        return emberGenerateDestroy(['route', 'foo', '--pod'], _file => {
+          expect(_file('app/pods/foo.js/route.js')).to.not.exist;
+          expect(_file('app/pods/foo.js/template.hbs')).to.not.exist;
+          expect(_file('tests/unit/pods/foo.js/route-test.js')).to.not.exist;
+
+          expect(_file('app/pods/foo/route.js')).to.equal(fixture('route/route.js'));
+
+          expect(_file('app/pods/foo/template.hbs')).to.equal('{{outlet}}');
+
+          expect(_file('tests/unit/pods/foo/route-test.js')).to.equal(
+            fixture('route-test/default.js')
+          );
+
+          expect(file('app/router.js')).to.contain("this.route('foo')");
+          expect(file('app/router.js')).to.not.contain("this.route('foo.js')");
+        }).then(() => {
+          expect(file('app/router.js')).to.not.contain("this.route('foo')");
+        });
+      });
     });
   });
 
@@ -250,6 +309,35 @@ describe('Blueprint: route', function() {
         expect(_file('tests/unit/routes/foo-test.js')).to.equal(fixture('route-test/default.js'));
 
         expect(file('tests/dummy/app/router.js')).to.not.contain("this.route('foo')");
+      }).then(() => {
+        expect(file('tests/dummy/app/router.js')).to.not.contain("this.route('foo')");
+      });
+    });
+
+    it('route foo.js', function() {
+      return emberGenerateDestroy(['route', 'foo.js'], _file => {
+        expect(_file('addon/routes/foo.js.js')).to.not.exist;
+        expect(_file('addon/templates/foo.js.hbs')).to.not.exist;
+        expect(_file('app/routes/foo.js.js')).to.not.exist;
+        expect(_file('app/templates/foo.js.js')).to.not.exist;
+        expect(_file('tests/unit/routes/foo.js-test.js')).to.not.exist;
+
+        expect(_file('addon/routes/foo.js')).to.equal(fixture('route/route.js'));
+
+        expect(_file('addon/templates/foo.hbs')).to.equal('{{outlet}}');
+
+        expect(_file('app/routes/foo.js')).to.contain(
+          "export { default } from 'my-addon/routes/foo';"
+        );
+
+        expect(_file('app/templates/foo.js')).to.contain(
+          "export { default } from 'my-addon/templates/foo';"
+        );
+
+        expect(_file('tests/unit/routes/foo-test.js')).to.equal(fixture('route-test/default.js'));
+
+        expect(file('tests/dummy/app/router.js')).to.not.contain("this.route('foo')");
+        expect(file('tests/dummy/app/router.js')).to.not.contain("this.route('foo.js')");
       }).then(() => {
         expect(file('tests/dummy/app/router.js')).to.not.contain("this.route('foo')");
       });
@@ -295,6 +383,26 @@ describe('Blueprint: route', function() {
       });
     });
 
+    it('route foo.js --dummy', function() {
+      return emberGenerateDestroy(['route', 'foo.js', '--dummy'], _file => {
+        expect(_file('tests/dummy/app/routes/foo.js.js')).to.not.exist;
+        expect(_file('tests/dummy/app/templates/foo.js.hbs')).to.not.exist;
+
+        expect(_file('tests/dummy/app/routes/foo.js')).to.equal(fixture('route/route.js'));
+
+        expect(_file('tests/dummy/app/templates/foo.hbs')).to.equal('{{outlet}}');
+
+        expect(_file('app/routes/foo.js')).to.not.exist;
+        expect(_file('app/templates/foo.hbs')).to.not.exist;
+        expect(_file('tests/unit/routes/foo-test.js')).to.not.exist;
+
+        expect(file('tests/dummy/app/router.js')).to.contain("this.route('foo')");
+        expect(file('tests/dummy/app/router.js')).to.not.contain("this.route('foo.js')");
+      }).then(() => {
+        expect(file('tests/dummy/app/router.js')).to.not.contain("this.route('foo')");
+      });
+    });
+
     it('route foo/bar --dummy', function() {
       return emberGenerateDestroy(['route', 'foo/bar', '--dummy'], _file => {
         expect(_file('tests/dummy/app/routes/foo/bar.js')).to.equal(
@@ -317,6 +425,30 @@ describe('Blueprint: route', function() {
 
     it('route foo --pod', function() {
       return emberGenerateDestroy(['route', 'foo', '--pod'], _file => {
+        expect(_file('addon/foo/route.js')).to.equal(fixture('route/route.js'));
+
+        expect(_file('addon/foo/template.hbs')).to.equal('{{outlet}}');
+
+        expect(_file('app/foo/route.js')).to.contain(
+          "export { default } from 'my-addon/foo/route';"
+        );
+
+        expect(_file('app/foo/template.js')).to.contain(
+          "export { default } from 'my-addon/foo/template';"
+        );
+
+        expect(_file('tests/unit/foo/route-test.js')).to.equal(fixture('route-test/default.js'));
+      });
+    });
+
+    it('route foo.js --pod', function() {
+      return emberGenerateDestroy(['route', 'foo.js', '--pod'], _file => {
+        expect(_file('addon/foo.js/route.js')).to.not.exist;
+        expect(_file('addon/foo.js/template.hbs')).to.not.exist;
+        expect(_file('app/foo.js/route.js')).to.not.exist;
+        expect(_file('app/foo.js/template.js')).to.not.exist;
+        expect(_file('tests/unit/foo.js/route-test.js')).to.not.exist;
+
         expect(_file('addon/foo/route.js')).to.equal(fixture('route/route.js'));
 
         expect(_file('addon/foo/template.hbs')).to.equal('{{outlet}}');
@@ -357,6 +489,25 @@ describe('Blueprint: route', function() {
         expect(_file('src/ui/routes/foo/route-test.js')).to.equal(fixture('route-test/default.js'));
 
         expect(file('src/router.js')).to.contain("this.route('foo')");
+      }).then(() => {
+        expect(file('src/router.js')).to.not.contain("this.route('foo')");
+      });
+    });
+
+    it('route foo.js', function() {
+      return emberGenerateDestroy(['route', 'foo.js'], _file => {
+        expect(_file('src/ui/routes/foo.js/route.js')).to.not.exist;
+        expect(_file('src/ui/routes/foo.js/template.hbs')).to.not.exist;
+        expect(_file('src/ui/routes/foo.js/route-test.js')).to.not.exist;
+
+        expect(_file('src/ui/routes/foo/route.js')).to.equal(fixture('route/route.js'));
+
+        expect(_file('src/ui/routes/foo/template.hbs')).to.equal('{{outlet}}');
+
+        expect(_file('src/ui/routes/foo/route-test.js')).to.equal(fixture('route-test/default.js'));
+
+        expect(file('src/router.js')).to.contain("this.route('foo')");
+        expect(file('src/router.js')).to.not.contain("this.route('foo.js')");
       }).then(() => {
         expect(file('src/router.js')).to.not.contain("this.route('foo')");
       });
@@ -524,6 +675,25 @@ describe('Blueprint: route', function() {
       });
     });
 
+    it('route foo.js', function() {
+      return emberGenerateDestroy(['route', 'foo'], _file => {
+        expect(_file('src/ui/routes/foo.js/route.js')).to.not.exist;
+        expect(_file('src/ui/routes/foo.js/template.hbs')).to.not.exist;
+        expect(_file('src/ui/routes/foo.js/route-test.js')).to.not.exist;
+
+        expect(_file('src/ui/routes/foo/route.js')).to.equal(fixture('route/route.js'));
+
+        expect(_file('src/ui/routes/foo/template.hbs')).to.equal('{{outlet}}');
+
+        expect(_file('src/ui/routes/foo/route-test.js')).to.equal(fixture('route-test/default.js'));
+
+        expect(file('tests/dummy/src/router.js')).to.not.contain("this.route('foo')");
+        expect(file('tests/dummy/src/router.js')).to.not.contain("this.route('foo.js')");
+      }).then(() => {
+        expect(file('tests/dummy/src/router.js')).to.not.contain("this.route('foo')");
+      });
+    });
+
     it('route foo/bar', function() {
       return emberGenerateDestroy(['route', 'foo/bar'], _file => {
         expect(_file('src/ui/routes/foo/bar/route.js')).to.equal(fixture('route/route-nested.js'));
@@ -551,6 +721,26 @@ describe('Blueprint: route', function() {
         expect(_file('src/ui/routes/foo/route-test.js')).to.not.exist;
 
         expect(file('tests/dummy/src/router.js')).to.contain("this.route('foo')");
+      }).then(() => {
+        expect(file('tests/dummy/src/router.js')).to.not.contain("this.route('foo')");
+      });
+    });
+
+    it('route foo.js --dummy', function() {
+      return emberGenerateDestroy(['route', 'foo.js', '--dummy'], _file => {
+        expect(_file('tests/dummy/src/ui/routes/foo.js/route.js')).to.not.exist;
+        expect(_file('tests/dummy/src/ui/routes/foo.js/template.hbs')).to.not.exist;
+
+        expect(_file('tests/dummy/src/ui/routes/foo/route.js')).to.equal(fixture('route/route.js'));
+
+        expect(_file('tests/dummy/src/ui/routes/foo/template.hbs')).to.equal('{{outlet}}');
+
+        expect(_file('src/ui/routes/foo/route.js')).to.not.exist;
+        expect(_file('src/ui/routes/foo/template.hbs')).to.not.exist;
+        expect(_file('src/ui/routes/foo/route-test.js')).to.not.exist;
+
+        expect(file('tests/dummy/src/router.js')).to.contain("this.route('foo')");
+        expect(file('tests/dummy/src/router.js')).to.not.contain("this.route('foo.js')");
       }).then(() => {
         expect(file('tests/dummy/src/router.js')).to.not.contain("this.route('foo')");
       });
@@ -607,6 +797,25 @@ describe('Blueprint: route', function() {
         expect(_file('tests/unit/routes/foo-test.js')).to.equal(fixture('route-test/default.js'));
 
         expect(file('app/router.js')).to.contain("this.route('foo')");
+      }).then(() => {
+        expect(file('app/router.js')).to.not.contain("this.route('foo')");
+      });
+    });
+
+    it('route foo.js', function() {
+      return emberGenerateDestroy(['route', 'foo.js'], _file => {
+        expect(_file('app/routes/foo.js.js')).to.not.exist;
+        expect(_file('app/templates/foo.js.hbs')).to.not.exist;
+        expect(_file('tests/unit/routes/foo.js-test.js')).to.not.exist;
+
+        expect(_file('app/routes/foo.js')).to.equal(fixture('route/native-route.js'));
+
+        expect(_file('app/templates/foo.hbs')).to.equal('{{outlet}}');
+
+        expect(_file('tests/unit/routes/foo-test.js')).to.equal(fixture('route-test/default.js'));
+
+        expect(file('app/router.js')).to.contain("this.route('foo')");
+        expect(file('app/router.js')).to.not.contain("this.route('foo.js')");
       }).then(() => {
         expect(file('app/router.js')).to.not.contain("this.route('foo')");
       });
@@ -722,6 +931,25 @@ describe('Blueprint: route', function() {
       });
     });
 
+    it('route foo.js --pod', function() {
+      return emberGenerateDestroy(['route', 'foo.js', '--pod'], _file => {
+        expect(_file('app/foo.js/route.js')).to.not.exist;
+        expect(_file('app/foo.js/template.hbs')).to.not.exist;
+        expect(_file('tests/unit/foo.js/route-test.js')).to.not.exist;
+
+        expect(_file('app/foo/route.js')).to.equal(fixture('route/native-route.js'));
+
+        expect(_file('app/foo/template.hbs')).to.equal('{{outlet}}');
+
+        expect(_file('tests/unit/foo/route-test.js')).to.equal(fixture('route-test/default.js'));
+
+        expect(file('app/router.js')).to.contain("this.route('foo')");
+        expect(file('app/router.js')).to.not.contain("this.route('foo.js')");
+      }).then(() => {
+        expect(file('app/router.js')).to.not.contain("this.route('foo')");
+      });
+    });
+
     it('route foo --pod with --path', function() {
       return emberGenerate(['route', 'foo', '--pod', '--path=:foo_id/show'])
         .then(() =>
@@ -779,6 +1007,27 @@ describe('Blueprint: route', function() {
           expect(file('app/router.js')).to.not.contain("this.route('foo')");
         });
       });
+
+      it('route foo.js --pod', function() {
+        return emberGenerateDestroy(['route', 'foo.js', '--pod'], _file => {
+          expect(_file('app/pods/foo.js/route.js')).to.not.exist;
+          expect(_file('app/pods/foo.js/template.hbs')).to.not.exist;
+          expect(_file('tests/unit/pods/foo.js/route-test.js')).to.not.exist;
+
+          expect(_file('app/pods/foo/route.js')).to.equal(fixture('route/native-route.js'));
+
+          expect(_file('app/pods/foo/template.hbs')).to.equal('{{outlet}}');
+
+          expect(_file('tests/unit/pods/foo/route-test.js')).to.equal(
+            fixture('route-test/default.js')
+          );
+
+          expect(file('app/router.js')).to.contain("this.route('foo')");
+          expect(file('app/router.js')).to.not.contain("this.route('foo.js')");
+        }).then(() => {
+          expect(file('app/router.js')).to.not.contain("this.route('foo')");
+        });
+      });
     });
   });
 
@@ -813,6 +1062,35 @@ describe('Blueprint: route', function() {
         expect(_file('tests/unit/routes/foo-test.js')).to.equal(fixture('route-test/default.js'));
 
         expect(file('tests/dummy/app/router.js')).to.not.contain("this.route('foo')");
+      }).then(() => {
+        expect(file('tests/dummy/app/router.js')).to.not.contain("this.route('foo')");
+      });
+    });
+
+    it('route foo.js', function() {
+      return emberGenerateDestroy(['route', 'foo.js'], _file => {
+        expect(_file('addon/routes/foo.js.js')).to.not.exist;
+        expect(_file('addon/templates/foo.js.hbs')).to.not.exist;
+        expect(_file('app/routes/foo.js.js')).to.not.exist;
+        expect(_file('app/templates/foo.js.js')).to.not.exist;
+        expect(_file('tests/unit/routes/foo.js-test.js')).to.not.exist;
+
+        expect(_file('addon/routes/foo.js')).to.equal(fixture('route/native-route.js'));
+
+        expect(_file('addon/templates/foo.hbs')).to.equal('{{outlet}}');
+
+        expect(_file('app/routes/foo.js')).to.contain(
+          "export { default } from 'my-addon/routes/foo';"
+        );
+
+        expect(_file('app/templates/foo.js')).to.contain(
+          "export { default } from 'my-addon/templates/foo';"
+        );
+
+        expect(_file('tests/unit/routes/foo-test.js')).to.equal(fixture('route-test/default.js'));
+
+        expect(file('tests/dummy/app/router.js')).to.not.contain("this.route('foo')");
+        expect(file('tests/dummy/app/router.js')).to.not.contain("this.route('foo.js')");
       }).then(() => {
         expect(file('tests/dummy/app/router.js')).to.not.contain("this.route('foo')");
       });
@@ -858,6 +1136,26 @@ describe('Blueprint: route', function() {
       });
     });
 
+    it('route foo.js --dummy', function() {
+      return emberGenerateDestroy(['route', 'foo.js', '--dummy'], _file => {
+        expect(_file('tests/dummy/app/routes/foo.js.js')).to.not.exist;
+        expect(_file('tests/dummy/app/templates/foo.js.hbs')).to.not.exist;
+
+        expect(_file('tests/dummy/app/routes/foo.js')).to.equal(fixture('route/native-route.js'));
+
+        expect(_file('tests/dummy/app/templates/foo.hbs')).to.equal('{{outlet}}');
+
+        expect(_file('app/routes/foo.js')).to.not.exist;
+        expect(_file('app/templates/foo.hbs')).to.not.exist;
+        expect(_file('tests/unit/routes/foo-test.js')).to.not.exist;
+
+        expect(file('tests/dummy/app/router.js')).to.contain("this.route('foo')");
+        expect(file('tests/dummy/app/router.js')).to.not.contain("this.route('foo.js')");
+      }).then(() => {
+        expect(file('tests/dummy/app/router.js')).to.not.contain("this.route('foo')");
+      });
+    });
+
     it('route foo/bar --dummy', function() {
       return emberGenerateDestroy(['route', 'foo/bar', '--dummy'], _file => {
         expect(_file('tests/dummy/app/routes/foo/bar.js')).to.equal(
@@ -895,6 +1193,30 @@ describe('Blueprint: route', function() {
         expect(_file('tests/unit/foo/route-test.js')).to.equal(fixture('route-test/default.js'));
       });
     });
+
+    it('route foo.js --pod', function() {
+      return emberGenerateDestroy(['route', 'foo.js', '--pod'], _file => {
+        expect(_file('addon/foo.js/route.js')).to.not.exist;
+        expect(_file('addon/foo.js/template.hbs')).to.not.exist;
+        expect(_file('app/foo.js/route.js')).to.not.exist;
+        expect(_file('app/foo.js/template.js')).to.not.exist;
+        expect(_file('tests/unit/foo.js/route-test.js')).to.not.exist;
+
+        expect(_file('addon/foo/route.js')).to.equal(fixture('route/native-route.js'));
+
+        expect(_file('addon/foo/template.hbs')).to.equal('{{outlet}}');
+
+        expect(_file('app/foo/route.js')).to.contain(
+          "export { default } from 'my-addon/foo/route';"
+        );
+
+        expect(_file('app/foo/template.js')).to.contain(
+          "export { default } from 'my-addon/foo/template';"
+        );
+
+        expect(_file('tests/unit/foo/route-test.js')).to.equal(fixture('route-test/default.js'));
+      });
+    });
   });
 
   describe('in in-repo-addon', function() {
@@ -911,6 +1233,30 @@ describe('Blueprint: route', function() {
 
     it('route foo --in-repo-addon=my-addon', function() {
       return emberGenerateDestroy(['route', 'foo', '--in-repo-addon=my-addon'], _file => {
+        expect(_file('lib/my-addon/addon/routes/foo.js')).to.equal(fixture('route/route.js'));
+
+        expect(_file('lib/my-addon/addon/templates/foo.hbs')).to.equal('{{outlet}}');
+
+        expect(_file('lib/my-addon/app/routes/foo.js')).to.contain(
+          "export { default } from 'my-addon/routes/foo';"
+        );
+
+        expect(_file('lib/my-addon/app/templates/foo.js')).to.contain(
+          "export { default } from 'my-addon/templates/foo';"
+        );
+
+        expect(_file('tests/unit/routes/foo-test.js')).to.equal(fixture('route-test/default.js'));
+      });
+    });
+
+    it('route foo.js --in-repo-addon=my-addon', function() {
+      return emberGenerateDestroy(['route', 'foo.js', '--in-repo-addon=my-addon'], _file => {
+        expect(_file('lib/my-addon/addon/routes/foo.js.js')).to.not.exist;
+        expect(_file('lib/my-addon/addon/templates/foo.js.hbs')).to.not.exist;
+        expect(_file('lib/my-addon/app/routes/foo.js.js')).to.not.exist;
+        expect(_file('lib/my-addon/app/templates/foo.js.js')).to.not.exist;
+        expect(_file('tests/unit/routes/foo.js-test.js')).to.not.exist;
+
         expect(_file('lib/my-addon/addon/routes/foo.js')).to.equal(fixture('route/route.js'));
 
         expect(_file('lib/my-addon/addon/templates/foo.hbs')).to.equal('{{outlet}}');

--- a/node-tests/blueprints/service-test.js
+++ b/node-tests/blueprints/service-test.js
@@ -43,6 +43,19 @@ describe('Blueprint: service', function() {
       });
     });
 
+    it('service foo.js', function() {
+      return emberGenerateDestroy(['service', 'foo.js'], _file => {
+        expect(_file('app/services/foo.js.js')).to.not.exist;
+        expect(_file('tests/unit/services/foo-test.js.js')).to.not.exist;
+
+        expect(_file('app/services/foo.js')).to.equal(fixture('service/service.js'));
+
+        expect(_file('tests/unit/services/foo-test.js')).to.equal(
+          fixture('service-test/default.js')
+        );
+      });
+    });
+
     it('service foo/bar', function() {
       return emberGenerateDestroy(['service', 'foo/bar'], _file => {
         expect(_file('app/services/foo/bar.js')).to.equal(fixture('service/service-nested.js'));
@@ -55,6 +68,19 @@ describe('Blueprint: service', function() {
 
     it('service foo --pod', function() {
       return emberGenerateDestroy(['service', 'foo', '--pod'], _file => {
+        expect(_file('app/foo/service.js')).to.equal(fixture('service/service.js'));
+
+        expect(_file('tests/unit/foo/service-test.js')).to.equal(
+          fixture('service-test/default.js')
+        );
+      });
+    });
+
+    it('service foo.js --pod', function() {
+      return emberGenerateDestroy(['service', 'foo.js', '--pod'], _file => {
+        expect(_file('app/foo.js/service.js')).to.not.exist;
+        expect(_file('tests/unit/foo.js/service-test.js')).to.not.exist;
+
         expect(_file('app/foo/service.js')).to.equal(fixture('service/service.js'));
 
         expect(_file('tests/unit/foo/service-test.js')).to.equal(
@@ -80,6 +106,19 @@ describe('Blueprint: service', function() {
 
       it('service foo --pod', function() {
         return emberGenerateDestroy(['service', 'foo', '--pod'], _file => {
+          expect(_file('app/pods/foo/service.js')).to.equal(fixture('service/service.js'));
+
+          expect(_file('tests/unit/pods/foo/service-test.js')).to.equal(
+            fixture('service-test/default.js')
+          );
+        });
+      });
+
+      it('service foo.js --pod', function() {
+        return emberGenerateDestroy(['service', 'foo.js', '--pod'], _file => {
+          expect(_file('app/pods/foo.js/service.js')).to.not.exist;
+          expect(_file('tests/unit/pods/foo.js/service-test.js')).to.not.exist;
+
           expect(_file('app/pods/foo/service.js')).to.equal(fixture('service/service.js'));
 
           expect(_file('tests/unit/pods/foo/service-test.js')).to.equal(
@@ -118,6 +157,17 @@ describe('Blueprint: service', function() {
 
     it('service foo', function() {
       return emberGenerateDestroy(['service', 'foo'], _file => {
+        expect(_file('src/services/foo.js')).to.equal(fixture('service/service.js'));
+
+        expect(_file('src/services/foo-test.js')).to.equal(fixture('service-test/default.js'));
+      });
+    });
+
+    it('service foo.js', function() {
+      return emberGenerateDestroy(['service', 'foo.js'], _file => {
+        expect(_file('src/services/foo.js.js')).to.not.exist;
+        expect(_file('src/services/foo.js-test.js')).to.not.exist;
+
         expect(_file('src/services/foo.js')).to.equal(fixture('service/service.js'));
 
         expect(_file('src/services/foo-test.js')).to.equal(fixture('service-test/default.js'));
@@ -166,6 +216,19 @@ describe('Blueprint: service', function() {
       });
     });
 
+    it('service foo.js', function() {
+      return emberGenerateDestroy(['service', 'foo.js'], _file => {
+        expect(_file('app/services/foo.js.js')).to.not.exist;
+        expect(_file('tests/unit/services/foo.js-test.js')).to.not.exist;
+
+        expect(_file('app/services/foo.js')).to.equal(fixture('service/native-service.js'));
+
+        expect(_file('tests/unit/services/foo-test.js')).to.equal(
+          fixture('service-test/default.js')
+        );
+      });
+    });
+
     it('service foo/bar', function() {
       return emberGenerateDestroy(['service', 'foo/bar'], _file => {
         expect(_file('app/services/foo/bar.js')).to.equal(
@@ -180,6 +243,19 @@ describe('Blueprint: service', function() {
 
     it('service foo --pod', function() {
       return emberGenerateDestroy(['service', 'foo', '--pod'], _file => {
+        expect(_file('app/foo/service.js')).to.equal(fixture('service/native-service.js'));
+
+        expect(_file('tests/unit/foo/service-test.js')).to.equal(
+          fixture('service-test/default.js')
+        );
+      });
+    });
+
+    it('service foo.js --pod', function() {
+      return emberGenerateDestroy(['service', 'foo.js', '--pod'], _file => {
+        expect(_file('app/foo.js/service.js')).to.not.exist;
+        expect(_file('tests/unit/foo.js/service-test.js')).to.not.exist;
+
         expect(_file('app/foo/service.js')).to.equal(fixture('service/native-service.js'));
 
         expect(_file('tests/unit/foo/service-test.js')).to.equal(
@@ -207,6 +283,19 @@ describe('Blueprint: service', function() {
 
       it('service foo --pod', function() {
         return emberGenerateDestroy(['service', 'foo', '--pod'], _file => {
+          expect(_file('app/pods/foo/service.js')).to.equal(fixture('service/native-service.js'));
+
+          expect(_file('tests/unit/pods/foo/service-test.js')).to.equal(
+            fixture('service-test/default.js')
+          );
+        });
+      });
+
+      it('service foo.js --pod', function() {
+        return emberGenerateDestroy(['service', 'foo.js', '--pod'], _file => {
+          expect(_file('app/pods/foo.js/service.js')).to.not.exist;
+          expect(_file('tests/unit/pods/foo.js/service-test.js')).to.not.exist;
+
           expect(_file('app/pods/foo/service.js')).to.equal(fixture('service/native-service.js'));
 
           expect(_file('tests/unit/pods/foo/service-test.js')).to.equal(
@@ -255,6 +344,24 @@ describe('Blueprint: service', function() {
       });
     });
 
+    it('service foo.js', function() {
+      return emberGenerateDestroy(['service', 'foo.js'], _file => {
+        expect(_file('addon/services/foo.js.js')).to.not.exist;
+        expect(_file('app/services/foo.js.js')).to.not.exist;
+        expect(_file('tests/unit/services/foo.js-test.js')).to.not.exist;
+
+        expect(_file('addon/services/foo.js')).to.equal(fixture('service/service.js'));
+
+        expect(_file('app/services/foo.js')).to.contain(
+          "export { default } from 'my-addon/services/foo';"
+        );
+
+        expect(_file('tests/unit/services/foo-test.js')).to.equal(
+          fixture('service-test/default.js')
+        );
+      });
+    });
+
     it('service foo/bar', function() {
       return emberGenerateDestroy(['service', 'foo/bar'], _file => {
         expect(_file('addon/services/foo/bar.js')).to.equal(fixture('service/service-nested.js'));
@@ -271,6 +378,17 @@ describe('Blueprint: service', function() {
 
     it('service foo/bar --dummy', function() {
       return emberGenerateDestroy(['service', 'foo/bar', '--dummy'], _file => {
+        expect(_file('tests/dummy/app/services/foo/bar.js')).to.equal(
+          fixture('service/service-nested.js')
+        );
+        expect(_file('addon/services/foo/bar.js')).to.not.exist;
+      });
+    });
+
+    it('service foo/bar.js --dummy', function() {
+      return emberGenerateDestroy(['service', 'foo/bar.js', '--dummy'], _file => {
+        expect(_file('tests/dummy/app/services/foo/bar.js.js')).to.not.exist;
+
         expect(_file('tests/dummy/app/services/foo/bar.js')).to.equal(
           fixture('service/service-nested.js')
         );
@@ -303,6 +421,19 @@ describe('Blueprint: service', function() {
       });
     });
 
+    it('service foo.js', function() {
+      return emberGenerateDestroy(['service', 'foo'], _file => {
+        expect(_file('src/services/foo.js.js')).to.not.exist;
+        expect(_file('src/services/foo.js-test.js')).to.not.exist;
+
+        expect(_file('src/services/foo.js')).to.equal(fixture('service/service.js'));
+
+        expect(_file('src/services/foo-test.js')).to.equal(fixture('service-test/default.js'));
+
+        expect(_file('app/services/foo.js')).to.not.exist;
+      });
+    });
+
     it('service foo/bar', function() {
       return emberGenerateDestroy(['service', 'foo/bar'], _file => {
         expect(_file('src/services/foo/bar.js')).to.equal(fixture('service/service-nested.js'));
@@ -317,6 +448,17 @@ describe('Blueprint: service', function() {
 
     it('service foo/bar --dummy', function() {
       return emberGenerateDestroy(['service', 'foo/bar', '--dummy'], _file => {
+        expect(_file('tests/dummy/src/services/foo/bar.js')).to.equal(
+          fixture('service/service-nested.js')
+        );
+        expect(_file('src/services/foo/bar.js')).to.not.exist;
+      });
+    });
+
+    it('service foo/bar.js --dummy', function() {
+      return emberGenerateDestroy(['service', 'foo/bar.js', '--dummy'], _file => {
+        expect(_file('tests/dummy/src/services/foo/bar.js.js')).to.not.exist;
+
         expect(_file('tests/dummy/src/services/foo/bar.js')).to.equal(
           fixture('service/service-nested.js')
         );
@@ -353,6 +495,24 @@ describe('Blueprint: service', function() {
       });
     });
 
+    it('service foo.js', function() {
+      return emberGenerateDestroy(['service', 'foo.js'], _file => {
+        expect(_file('addon/services/foo.js.js')).to.not.exist;
+        expect(_file('app/services/foo.js.js')).to.not.exist;
+        expect(_file('tests/unit/services/foo.js-test.js')).to.not.exist;
+
+        expect(_file('addon/services/foo.js')).to.equal(fixture('service/native-service.js'));
+
+        expect(_file('app/services/foo.js')).to.contain(
+          "export { default } from 'my-addon/services/foo';"
+        );
+
+        expect(_file('tests/unit/services/foo-test.js')).to.equal(
+          fixture('service-test/default.js')
+        );
+      });
+    });
+
     it('service foo/bar', function() {
       return emberGenerateDestroy(['service', 'foo/bar'], _file => {
         expect(_file('addon/services/foo/bar.js')).to.equal(
@@ -377,6 +537,17 @@ describe('Blueprint: service', function() {
         expect(_file('addon/services/foo/bar.js')).to.not.exist;
       });
     });
+
+    it('service foo/bar.js --dummy', function() {
+      return emberGenerateDestroy(['service', 'foo/bar.js', '--dummy'], _file => {
+        expect(_file('tests/dummy/app/services/foo/bar.js.js')).to.not.exist;
+
+        expect(_file('tests/dummy/app/services/foo/bar.js')).to.equal(
+          fixture('service/native-service-nested.js')
+        );
+        expect(_file('addon/services/foo/bar.js')).to.not.exist;
+      });
+    });
   });
 
   describe('in in-repo-addon', function() {
@@ -393,6 +564,24 @@ describe('Blueprint: service', function() {
 
     it('service foo --in-repo-addon=my-addon', function() {
       return emberGenerateDestroy(['service', 'foo', '--in-repo-addon=my-addon'], _file => {
+        expect(_file('lib/my-addon/addon/services/foo.js')).to.equal(fixture('service/service.js'));
+
+        expect(_file('lib/my-addon/app/services/foo.js')).to.contain(
+          "export { default } from 'my-addon/services/foo';"
+        );
+
+        expect(_file('tests/unit/services/foo-test.js')).to.equal(
+          fixture('service-test/default.js')
+        );
+      });
+    });
+
+    it('service foo.js --in-repo-addon=my-addon', function() {
+      return emberGenerateDestroy(['service', 'foo.js', '--in-repo-addon=my-addon'], _file => {
+        expect(_file('lib/my-addon/addon/services/foo.js.js')).to.not.exist;
+        expect(_file('lib/my-addon/app/services/foo.js.js')).to.not.exist;
+        expect(_file('tests/unit/services/foo.js-test.js')).to.not.exist;
+
         expect(_file('lib/my-addon/addon/services/foo.js')).to.equal(fixture('service/service.js'));
 
         expect(_file('lib/my-addon/app/services/foo.js')).to.contain(

--- a/node-tests/blueprints/template-test.js
+++ b/node-tests/blueprints/template-test.js
@@ -27,6 +27,13 @@ describe('Blueprint: template', function() {
       });
     });
 
+    it('template foo.hbs', function() {
+      return emberGenerateDestroy(['template', 'foo.hbs'], _file => {
+        expect(_file('app/templates/foo.hbs.hbs')).to.not.exist;
+        expect(_file('app/templates/foo.hbs')).to.equal('');
+      });
+    });
+
     it('template foo/bar', function() {
       return emberGenerateDestroy(['template', 'foo/bar'], _file => {
         expect(_file('app/templates/foo/bar.hbs')).to.equal('');
@@ -40,6 +47,13 @@ describe('Blueprint: template', function() {
 
       it('template foo', function() {
         return emberGenerateDestroy(['template', 'foo'], _file => {
+          expect(_file('app/foo/template.hbs')).to.equal('');
+        });
+      });
+
+      it('template foo.hbs', function() {
+        return emberGenerateDestroy(['template', 'foo.hbs'], _file => {
+          expect(_file('app/foo.hbs/template.hbs')).to.not.exist;
           expect(_file('app/foo/template.hbs')).to.equal('');
         });
       });
@@ -65,6 +79,13 @@ describe('Blueprint: template', function() {
         });
       });
 
+      it('template foo.hbs', function() {
+        return emberGenerateDestroy(['template', 'foo.hbs'], _file => {
+          expect(_file('app/pods/foo.hbs/template.hbs')).to.not.exist;
+          expect(_file('app/pods/foo/template.hbs')).to.equal('');
+        });
+      });
+
       it('template foo/bar', function() {
         return emberGenerateDestroy(['template', 'foo/bar'], _file => {
           expect(_file('app/pods/foo/bar/template.hbs')).to.equal('');
@@ -84,6 +105,13 @@ describe('Blueprint: template', function() {
       });
     });
 
+    it('template foo.hbs', function() {
+      return emberGenerateDestroy(['template', 'foo.hbs'], _file => {
+        expect(_file('addon/templates/foo.hbs.hbs')).to.not.exist;
+        expect(_file('addon/templates/foo.hbs')).to.equal('');
+      });
+    });
+
     it('template foo/bar', function() {
       return emberGenerateDestroy(['template', 'foo/bar'], _file => {
         expect(_file('addon/templates/foo/bar.hbs')).to.equal('');
@@ -92,6 +120,13 @@ describe('Blueprint: template', function() {
 
     it('template foo --dummy', function() {
       return emberGenerateDestroy(['template', 'foo', '--dummy'], _file => {
+        expect(_file('tests/dummy/app/templates/foo.hbs')).to.equal('');
+      });
+    });
+
+    it('template foo.hbs --dummy', function() {
+      return emberGenerateDestroy(['template', 'foo.hbs', '--dummy'], _file => {
+        expect(_file('tests/dummy/app/templates/foo.hbs.hbs')).to.not.exist;
         expect(_file('tests/dummy/app/templates/foo.hbs')).to.equal('');
       });
     });
@@ -114,6 +149,13 @@ describe('Blueprint: template', function() {
       });
     });
 
+    it('template foo.hbs --in-repo-addon=my-addon', function() {
+      return emberGenerateDestroy(['template', 'foo.hbs', '--in-repo-addon=my-addon'], _file => {
+        expect(_file('lib/my-addon/addon/templates/foo.hbs.hbs')).to.not.exist;
+        expect(_file('lib/my-addon/addon/templates/foo.hbs')).to.equal('');
+      });
+    });
+
     it('template foo/bar --in-repo-addon=my-addon', function() {
       return emberGenerateDestroy(['template', 'foo/bar', '--in-repo-addon=my-addon'], _file => {
         expect(_file('lib/my-addon/addon/templates/foo/bar.hbs')).to.equal('');
@@ -130,6 +172,13 @@ describe('Blueprint: template', function() {
 
     it('template foo', function() {
       return emberGenerateDestroy(['template', 'foo'], _file => {
+        expect(_file('src/ui/routes/foo/template.hbs')).to.equal('');
+      });
+    });
+
+    it('template foo.hbs', function() {
+      return emberGenerateDestroy(['template', 'foo.hbs'], _file => {
+        expect(_file('src/ui/routes/foo.hbs/template.hbs')).to.not.exist;
         expect(_file('src/ui/routes/foo/template.hbs')).to.equal('');
       });
     });
@@ -169,6 +218,13 @@ describe('Blueprint: template', function() {
       });
     });
 
+    it('template foo.hbs', function() {
+      return emberGenerateDestroy(['template', 'foo.hbs'], _file => {
+        expect(_file('src/ui/routes/foo.hbs/template.hbs')).to.not.exist;
+        expect(_file('src/ui/routes/foo/template.hbs')).to.equal('');
+      });
+    });
+
     it('template foo/bar', function() {
       return emberGenerateDestroy(['template', 'foo/bar'], _file => {
         expect(_file('src/ui/routes/foo/bar/template.hbs')).to.equal('');
@@ -177,6 +233,13 @@ describe('Blueprint: template', function() {
 
     it('template foo --dummy', function() {
       return emberGenerateDestroy(['template', 'foo', '--dummy'], _file => {
+        expect(_file('tests/dummy/src/ui/routes/foo/template.hbs')).to.equal('');
+      });
+    });
+
+    it('template foo.hbs --dummy', function() {
+      return emberGenerateDestroy(['template', 'foo.hbs', '--dummy'], _file => {
+        expect(_file('tests/dummy/src/ui/routes/foo.hbs/template.hbs')).to.not.exist;
         expect(_file('tests/dummy/src/ui/routes/foo/template.hbs')).to.equal('');
       });
     });

--- a/node-tests/blueprints/util-test.js
+++ b/node-tests/blueprints/util-test.js
@@ -40,6 +40,17 @@ describe('Blueprint: util', function() {
       });
     });
 
+    it('util foo-bar.js', function() {
+      return emberGenerateDestroy(['util', 'foo-bar.js'], _file => {
+        expect(_file('app/utils/foo-bar.js.js')).to.not.exist;
+        expect(_file('tests/unit/utils/foo-bar.js-test.js')).to.not.exist;
+
+        expect(_file('app/utils/foo-bar.js')).to.equal(fixture('util/util.js'));
+
+        expect(_file('tests/unit/utils/foo-bar-test.js')).to.equal(fixture('util-test/default.js'));
+      });
+    });
+
     it('util foo/bar-baz', function() {
       return emberGenerateDestroy(['util', 'foo/bar-baz'], _file => {
         expect(_file('app/utils/foo/bar-baz.js')).to.equal(fixture('util/util-nested.js'));
@@ -52,6 +63,17 @@ describe('Blueprint: util', function() {
 
     it('util foo-bar --pod', function() {
       return emberGenerateDestroy(['util', 'foo-bar', '--pod'], _file => {
+        expect(_file('app/utils/foo-bar.js')).to.equal(fixture('util/util.js'));
+
+        expect(_file('tests/unit/utils/foo-bar-test.js')).to.equal(fixture('util-test/default.js'));
+      });
+    });
+
+    it('util foo-bar.js --pod', function() {
+      return emberGenerateDestroy(['util', 'foo-bar.js', '--pod'], _file => {
+        expect(_file('app/utils/foo-bar.js.js')).to.not.exist;
+        expect(_file('tests/unit/utils/foo-bar.js-test.js')).to.not.exist;
+
         expect(_file('app/utils/foo-bar.js')).to.equal(fixture('util/util.js'));
 
         expect(_file('tests/unit/utils/foo-bar-test.js')).to.equal(fixture('util-test/default.js'));
@@ -82,6 +104,19 @@ describe('Blueprint: util', function() {
           );
         });
       });
+
+      it('util foo-bar.js --pod', function() {
+        return emberGenerateDestroy(['util', 'foo-bar.js', '--pod'], _file => {
+          expect(_file('app/utils/foo-bar.js.js')).to.not.exist;
+          expect(_file('tests/unit/utils/foo-bar.js-test.js')).to.not.exist;
+
+          expect(_file('app/utils/foo-bar.js')).to.equal(fixture('util/util.js'));
+
+          expect(_file('tests/unit/utils/foo-bar-test.js')).to.equal(
+            fixture('util-test/default.js')
+          );
+        });
+      });
     });
   });
 
@@ -101,6 +136,17 @@ describe('Blueprint: util', function() {
 
     it('util foo-bar', function() {
       return emberGenerateDestroy(['util', 'foo-bar'], _file => {
+        expect(_file('src/utils/foo-bar.js')).to.equal(fixture('util/util.js'));
+
+        expect(_file('src/utils/foo-bar-test.js')).to.equal(fixture('util-test/default.js'));
+      });
+    });
+
+    it('util foo-bar.js', function() {
+      return emberGenerateDestroy(['util', 'foo-bar.js'], _file => {
+        expect(_file('src/utils/foo-bar.js.js')).to.not.exist;
+        expect(_file('src/utils/foo-bar.js-test.js')).to.not.exist;
+
         expect(_file('src/utils/foo-bar.js')).to.equal(fixture('util/util.js'));
 
         expect(_file('src/utils/foo-bar-test.js')).to.equal(fixture('util-test/default.js'));
@@ -139,6 +185,24 @@ describe('Blueprint: util', function() {
 
     it('util foo-bar', function() {
       return emberGenerateDestroy(['util', 'foo-bar'], _file => {
+        expect(_file('addon/utils/foo-bar.js')).to.equal(fixture('util/util.js'));
+
+        expect(_file('app/utils/foo-bar.js')).to.contain(
+          "export { default } from 'my-addon/utils/foo-bar';"
+        );
+
+        expect(_file('tests/unit/utils/foo-bar-test.js')).to.equal(
+          fixture('util-test/addon-default.js')
+        );
+      });
+    });
+
+    it('util foo-bar.js', function() {
+      return emberGenerateDestroy(['util', 'foo-bar.js'], _file => {
+        expect(_file('addon/utils/foo-bar.js.js')).to.not.exist;
+        expect(_file('app/utils/foo-bar.js.js')).to.not.exist;
+        expect(_file('tests/unit/utils/foo-bar.js-test.js')).to.not.exist;
+
         expect(_file('addon/utils/foo-bar.js')).to.equal(fixture('util/util.js'));
 
         expect(_file('app/utils/foo-bar.js')).to.contain(
@@ -200,6 +264,19 @@ describe('Blueprint: util', function() {
       });
     });
 
+    it('util foo-bar.js', function() {
+      return emberGenerateDestroy(['util', 'foo-bar.js'], _file => {
+        expect(_file('src/utils/foo-bar.js.js')).to.not.exist;
+        expect(_file('src/utils/foo-bar.js-test.js')).to.not.exist;
+
+        expect(_file('src/utils/foo-bar.js')).to.equal(fixture('util/util.js'));
+
+        expect(_file('src/utils/foo-bar-test.js')).to.equal(fixture('util-test/addon-default.js'));
+
+        expect(_file('app/utils/foo-bar.js')).to.not.exist;
+      });
+    });
+
     it('util foo-bar/baz', function() {
       return emberGenerateDestroy(['util', 'foo/bar-baz'], _file => {
         expect(_file('src/utils/foo/bar-baz.js')).to.equal(fixture('util/util-nested.js'));
@@ -214,6 +291,18 @@ describe('Blueprint: util', function() {
 
     it('util foo/bar-baz --dummy', function() {
       return emberGenerateDestroy(['util', 'foo/bar-baz', '--dummy'], _file => {
+        expect(_file('tests/dummy/src/utils/foo/bar-baz.js')).to.equal(
+          fixture('util/util-nested.js')
+        );
+
+        expect(_file('src/utils/foo/bar-baz.js')).to.not.exist;
+      });
+    });
+
+    it('util foo/bar-baz.js --dummy', function() {
+      return emberGenerateDestroy(['util', 'foo/bar-baz.js', '--dummy'], _file => {
+        expect(_file('tests/dummy/src/utils/foo/bar-baz.js.js')).to.not.exist;
+
         expect(_file('tests/dummy/src/utils/foo/bar-baz.js')).to.equal(
           fixture('util/util-nested.js')
         );
@@ -237,6 +326,22 @@ describe('Blueprint: util', function() {
 
     it('util foo-bar --in-repo-addon=my-addon', function() {
       return emberGenerateDestroy(['util', 'foo-bar', '--in-repo-addon=my-addon'], _file => {
+        expect(_file('lib/my-addon/addon/utils/foo-bar.js')).to.equal(fixture('util/util.js'));
+
+        expect(_file('lib/my-addon/app/utils/foo-bar.js')).to.contain(
+          "export { default } from 'my-addon/utils/foo-bar';"
+        );
+
+        expect(_file('tests/unit/utils/foo-bar-test.js')).to.equal(fixture('util-test/default.js'));
+      });
+    });
+
+    it('util foo-bar.js --in-repo-addon=my-addon', function() {
+      return emberGenerateDestroy(['util', 'foo-bar.js', '--in-repo-addon=my-addon'], _file => {
+        expect(_file('lib/my-addon/addon/utils/foo-bar.js.js')).to.not.exist;
+        expect(_file('lib/my-addon/app/utils/foo-bar.js.js')).to.not.exist;
+        expect(_file('tests/unit/utils/foo-bar.js-test.js')).to.not.exist;
+
         expect(_file('lib/my-addon/addon/utils/foo-bar.js')).to.equal(fixture('util/util.js'));
 
         expect(_file('lib/my-addon/app/utils/foo-bar.js')).to.contain(


### PR DESCRIPTION
https://github.com/ember-cli/ember-cli/issues/7699 Add/modify `blueprint.normalizeEntityName` to prevent creation of `.js.js`, `.js.hbs` or `.hbs.hbs` files when generate component, controller, helper, mixin, route, service, template and util.
Hope this is the right way to do it :thinking: ...