### PR TITLE
[BUGFIX #17529] Refactor get to return object or path

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/each-in-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/each-in-test.js
@@ -297,6 +297,14 @@ class EachInTest extends AbstractEachInTest {
 
     this.assertText('Empty!');
   }
+
+  [`@test it supports keys with a period in them`]() {
+    this.makeHash({ 'key.period': 'val' });
+
+    this.render(`<ul>{{#each-in hash as |key value|}}<li>{{key}}: {{value}}</li>{{/each-in}}</ul>`);
+
+    this.assertText('key.period: val');
+  }
 }
 
 moduleFor(

--- a/packages/@ember/-internals/metal/lib/property_get.ts
+++ b/packages/@ember/-internals/metal/lib/property_get.ts
@@ -97,9 +97,9 @@ export function get(obj: object, keyName: string): any {
   let isObjectLike = isObject || isFunction;
 
   if (isPath(keyName)) {
-    if(isObjectLike) {
+    if (isObjectLike) {
       let path = _getPath(obj, keyName);
-      return ((path === undefined) && isObject) ? obj[keyName] : path;
+      return path === undefined && isObject ? obj[keyName] : path;
     } else {
       return undefined;
     }

--- a/packages/@ember/-internals/metal/lib/property_get.ts
+++ b/packages/@ember/-internals/metal/lib/property_get.ts
@@ -97,7 +97,12 @@ export function get(obj: object, keyName: string): any {
   let isObjectLike = isObject || isFunction;
 
   if (isPath(keyName)) {
-    return isObjectLike ? _getPath(obj, keyName) : undefined;
+    if(isObjectLike) {
+      let path = _getPath(obj, keyName);
+      return ((path === undefined) && isObject) ? obj[keyName] : path;
+    } else {
+      return undefined;
+    }
   }
 
   let value: any;


### PR DESCRIPTION
I tracked issue [#17529](https://github.com/emberjs/ember.js/issues/17529) and as suggested on the thread, it worked on the get property.
I wrote a new test based on the one from jasonmit and got it to pass, also all other test passed
![Screenshot from 2019-04-25 11-44-41](https://user-images.githubusercontent.com/48219815/56753459-35d97880-6750-11e9-9d62-118345044065.png)

Hope this will help, but any comment, suggestion or advice is welcome with open arms.
I am kind of new in the open source world so I hope I follow all of your contributing guides well but if I didn't it will be awesome if you could point out what I missed. Thanks :D