### PR TITLE
Make hasListeners public

### DIFF
--- a/packages/@ember/-internals/metal/lib/events.ts
+++ b/packages/@ember/-internals/metal/lib/events.ts
@@ -156,7 +156,7 @@ export function sendEvent(
 }
 
 /**
-  @private
+  @public
   @method hasListeners
   @static
   @for @ember/object/events


### PR DESCRIPTION
Allow for determining whether listeners exist on an object before calling removeListeners.
Method already exists, just making it public.