### PR TITLE
[BUGFIX] Don't get values for leaf dependencies

### DIFF
--- a/packages/@ember/-internals/metal/lib/chain-tags.ts
+++ b/packages/@ember/-internals/metal/lib/chain-tags.ts
@@ -81,6 +81,10 @@ export function getChainTagsForKey(obj: any, key: string) {
 
     chainTags.push(propertyTag);
 
+    if (segments.length === 0) {
+      break;
+    }
+
     descriptor = descriptorForProperty(current, segment);
 
     if (descriptor === undefined) {
@@ -103,7 +107,7 @@ export function getChainTagsForKey(obj: any, key: string) {
         } else {
           current = peekCacheFor(current).get(segment);
         }
-      } else if (segments.length > 0) {
+      } else {
         let placeholderTag = UpdatableTag.create(CONSTANT_TAG);
 
         metaFor(current)

--- a/packages/@ember/-internals/runtime/tests/system/object/computed_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/computed_test.js
@@ -7,6 +7,7 @@ import {
   observer,
   defineProperty,
 } from '@ember/-internals/metal';
+import { EMBER_METAL_TRACKED_PROPERTIES } from '@ember/canary-features';
 import { oneWay as reads } from '@ember/object/computed';
 import EmberObject from '../../../lib/system/object';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
@@ -375,6 +376,32 @@ moduleFor(
       obj.set('bar', 2);
 
       assert.equal(obj.get('foo'), 2);
+    }
+
+    ['@test native getters and setters work'](assert) {
+      if (!EMBER_METAL_TRACKED_PROPERTIES) {
+        return assert.expect(0);
+      }
+
+      let MyClass = EmberObject.extend({
+        bar: 123,
+
+        foo: computed({
+          get() {
+            return this.bar;
+          },
+
+          set(key, value) {
+            this.bar = value;
+          },
+        }),
+      });
+
+      let instance = MyClass.create();
+
+      assert.equal(instance.foo, 123, 'getters work');
+      instance.foo = 456;
+      assert.equal(instance.bar, 456, 'setters work');
     }
   }
 );


### PR DESCRIPTION
We don't need to actually get the value of a leaf dependency, only its
tag, so we can stop early.

Also adds a test for native computed setters.