### PR TITLE
[BUGFIX] Scope down array tracking to the `[]` property

### DIFF
--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -33,7 +33,7 @@ import expandProperties from './expand_properties';
 import { defineProperty } from './properties';
 import { notifyPropertyChange } from './property_events';
 import { set } from './property_set';
-import { tagFor, tagForProperty, update } from './tags';
+import { tagForProperty, update } from './tags';
 import { consume, track } from './tracked';
 
 export type ComputedPropertyGetter = (keyName: string) => any;
@@ -573,7 +573,7 @@ export class ComputedProperty extends ComputedDescriptor {
       // Add the tag of the returned value if it is an array, since arrays
       // should always cause updates if they are consumed and then changed
       if (Array.isArray(ret) || isEmberArray(ret)) {
-        consume(tagFor(ret));
+        consume(tagForProperty(ret, '[]'));
       }
     } else {
       ret = this._getter!.call(obj, keyName);

--- a/packages/@ember/-internals/metal/lib/property_get.ts
+++ b/packages/@ember/-internals/metal/lib/property_get.ts
@@ -7,7 +7,7 @@ import { assert } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 import { descriptorForProperty } from './descriptor_map';
 import { isPath } from './path_cache';
-import { tagFor, tagForProperty } from './tags';
+import { tagForProperty } from './tags';
 import { consume, isTracking } from './tracked';
 
 export const PROXY_CONTENT = symbol('PROXY_CONTENT');
@@ -129,7 +129,7 @@ export function get(obj: object, keyName: string): any {
       tracking &&
       (Array.isArray(value) || isEmberArray(value))
     ) {
-      consume(tagFor(value));
+      consume(tagForProperty(value, '[]'));
     }
   } else {
     value = obj[keyName];

--- a/packages/@ember/-internals/metal/lib/tracked.ts
+++ b/packages/@ember/-internals/metal/lib/tracked.ts
@@ -5,7 +5,7 @@ import { DEBUG } from '@glimmer/env';
 import { combine, CONSTANT_TAG, Tag } from '@glimmer/reference';
 import { Decorator, DecoratorPropertyDescriptor, isElementDescriptor } from './decorator';
 import { setClassicDecorator } from './descriptor_map';
-import { markObjectAsDirty, tagFor, tagForProperty, update } from './tags';
+import { markObjectAsDirty, tagForProperty, update } from './tags';
 
 type Option<T> = T | null;
 
@@ -215,7 +215,7 @@ function descriptorForField([_target, key, desc]: [
       // Add the tag of the returned value if it is an array, since arrays
       // should always cause updates if they are consumed and then changed
       if (Array.isArray(value) || isEmberArray(value)) {
-        update(propertyTag, tagFor(value));
+        update(propertyTag, tagForProperty(value, '[]'));
       }
 
       return this[secretKey];

--- a/packages/@ember/-internals/metal/tests/tracked/validation_test.js
+++ b/packages/@ember/-internals/metal/tests/tracked/validation_test.js
@@ -333,7 +333,7 @@ if (EMBER_METAL_TRACKED_PROPERTIES && EMBER_NATIVE_DECORATOR_SUPPORT) {
         let emberArray = get(obj, 'emberArray');
         assert.equal(tag.validate(snapshot), true);
 
-        set(emberArray, 'foo', 123);
+        notifyPropertyChange(emberArray, '[]');
         assert.equal(
           tag.validate(snapshot),
           false,


### PR DESCRIPTION
This PR scopes automatic array tracking down to the `[]` property. We
observed in the `emberobserver` client a large increase in computed
property invalidations and narrowed it down to automatic array tracking.
Since any invalidation of any property will invalidate the main object's
tag, and since Ember arrays like Ember Data's `ManyArray` and
`RecordArray` are often pretty complex and have a fair amount of
internal state, my belief here is that we were notifying on generally
unrelated changes to array _elements_ or _length_, but invalidating many
CPs anyways because of this.

[results.pdf](https://github.com/emberjs/ember.js/files/3129650/results.pdf)
