### PR TITLE
fix missing verifyInjection `renderer` for Engine test

### DIFF
--- a/packages/@ember/engine/index.js
+++ b/packages/@ember/engine/index.js
@@ -1,7 +1,3 @@
-/**
-@module @ember/engine
-*/
-
 export { getEngineParent, setEngineParent } from './lib/engine-parent';
 
 import { canInvoke } from '@ember/-internals/utils';
@@ -27,6 +23,10 @@ function props(obj) {
 
   return properties;
 }
+
+/**
+@module @ember/engine
+*/
 
 /**
   The `Engine` class contains core functionality for both applications and

--- a/packages/@ember/engine/tests/engine_test.js
+++ b/packages/@ember/engine/tests/engine_test.js
@@ -61,6 +61,7 @@ moduleFor(
       );
       verifyRegistration(assert, engine, 'controller:basic');
       verifyInjection(assert, engine, 'view', '_viewRegistry', '-view-registry:main');
+      verifyInjection(assert, engine, 'renderer', '_viewRegistry', '-view-registry:main');
       verifyInjection(assert, engine, 'route', '_topLevelViewTemplate', 'template:-outlet');
       verifyInjection(assert, engine, 'view:-outlet', 'namespace', 'application:main');
 


### PR DESCRIPTION
Adds coverage to `renderer` injection on Engine

https://github.com/emberjs/ember.js/blob/8b273eb04023a876dbf968a05929d8a21a8fd27b/packages/%40ember/engine/index.js#L499

Move `@module comment` after imports like our pattern in other packages

https://github.com/emberjs/ember.js/blob/8b273eb04023a876dbf968a05929d8a21a8fd27b/packages/%40ember/-internals/glimmer/lib/component.ts#L18-L34