### PR TITLE
Add DISABLE_MINIFICATION environment variable.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -278,7 +278,7 @@ function buildBundles(packagesES, dependenciesES, templateCompilerDependenciesES
   return new MergeTrees(
     [
       emberProdBundle,
-      emberMinBundle,
+      process.env.DISABLE_MINIFICATION !== '1' && emberMinBundle,
       emberProdTestsBundle,
       buildBundle('ember.debug.js', emberDebugFiles, vendor),
       buildBundle('ember-tests.js', emberTestsFiles, vendor),


### PR DESCRIPTION
This makes testing production (but not minified) builds a bit faster.