### PR TITLE
Add failing test for angle bracket overriding attr on input

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
@@ -1209,6 +1209,13 @@ moduleFor(
       this.assertHTML('<div id="top"></div>');
     }
 
+    '@test angle bracket invocation can allow invocation side to override attributes with ...attributes on input'() {
+      this.registerComponent('my-input', '<input type="text" ...attributes >');
+
+      this.render('<MyInput type="password" />');
+      this.assertHTML('<input type="password">');
+    }
+
     '@test angle bracket invocation can override invocation side attributes with ...attributes'() {
       this.registerComponent('qux', '<div ...attributes id="qux" />');
       this.registerComponent('bar', '<Qux ...attributes id="bar" />');


### PR DESCRIPTION
This is a reproduction of a component using splattributes in a `input` element.

#### Implementation: my-input.hbs

```hbs
<input type="text" ...attributes>
```

#### Invocation

```hbs
<MyInput type="password" name="user-password" />
```

#### Actual Result

```hbs
<input name="user-password" type="text">
```

#### Expected Result

I would expect this result, instead of the actual result. Did I miss something,
or is this a bug in Ember?

```hbs
<input name="user-password" type="password">

```