### PR TITLE
[DOC release] Show `ObjectProxy` content as public

### DIFF
--- a/packages/@ember/-internals/runtime/lib/mixins/-proxy.js
+++ b/packages/@ember/-internals/runtime/lib/mixins/-proxy.js
@@ -43,9 +43,9 @@ export default Mixin.create({
     The object whose properties will be forwarded.
 
     @property content
-    @type EmberObject
+    @type {unknown}
     @default null
-    @private
+    @public
   */
   content: null,
 


### PR DESCRIPTION
Also, updates docs to proxying to arbitrary unknown values.