### PR TITLE
[Docs] Fix API docs suggest import path of deprecate

### DIFF
--- a/packages/@ember/debug/index.ts
+++ b/packages/@ember/debug/index.ts
@@ -211,7 +211,7 @@ if (DEBUG) {
   });
 
   /**
-   @module @ember/application
+   @module @ember/debug
    @public
   */
 
@@ -226,14 +226,14 @@ if (DEBUG) {
     incuring any performance penalty.
 
     ```javascript
-    import { deprecateFunc } from '@ember/application/deprecations';
+    import { deprecateFunc } from '@ember/debug';
 
     Ember.oldMethod = deprecateFunc('Please use the new, updated method', options, Ember.newMethod);
     ```
 
     @method deprecateFunc
     @static
-    @for @ember/application/deprecations
+    @for @ember/debug
     @param {String} message A description of the deprecation.
     @param {Object} [options] The options object for `deprecate`.
     @param {Function} func The new function called to replace its deprecated counterpart.

--- a/packages/@ember/debug/lib/deprecate.ts
+++ b/packages/@ember/debug/lib/deprecate.ts
@@ -24,7 +24,7 @@ export type DeprecateFunc = (message: string, test?: boolean, options?: Deprecat
 */
 /**
   Allows for runtime registration of handler functions that override the default deprecation behavior.
-  Deprecations are invoked by calls to [@ember/application/deprecations/deprecate](https://emberjs.com/api/ember/release/classes/@ember%2Fapplication%2Fdeprecations/methods/deprecate?anchor=deprecate).
+  Deprecations are invoked by calls to [deprecate](https://api.emberjs.com/ember/release/classes/@ember%2Fdebug%2F/methods/deprecate?anchor=deprecate).
   The following example demonstrates its usage by registering a handler that throws an error if the
   message contains the word "should", otherwise defers to the default handler.
 
@@ -155,7 +155,7 @@ if (DEBUG) {
   missingOptionsIdDeprecation = 'When calling `deprecate` you must provide `id` in options.';
   missingOptionsUntilDeprecation = 'When calling `deprecate` you must provide `until` in options.';
   /**
-   @module @ember/application
+   @module @ember/debug
    @public
    */
   /**
@@ -166,7 +166,7 @@ if (DEBUG) {
     Uses of this method in Ember itself are stripped from the ember.prod.js build.
 
     @method deprecate
-    @for @ember/application/deprecations
+    @for @ember/debug
     @param {String} message A description of the deprecation.
     @param {Boolean} test A boolean. If falsy, the deprecation will be displayed.
     @param {Object} options


### PR DESCRIPTION
`import { deprecate } from '@ember/debug'` will strip code in production, this is not true for `@ember/applications/deprecations`

Fix https://github.com/emberjs/ember.js/issues/17185