### PR TITLE
Fix links in documentation

### DIFF
--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -63,14 +63,16 @@
   )}}></span>
   ```
 
-  Ember's built-in helpers are described under the [Ember.Templates.helpers](/api/ember/release/classes/Ember.Templates.helpers)
+  Ember's built-in helpers are described under the [Ember.Templates.helpers](/ember/release/classes/Ember.Templates.helpers)
   namespace. Documentation on creating custom helpers can be found under
-  [Helper](/api/classes/Ember.Helper.html).
+  [helper](/ember/release/functions/@ember%2Fcomponent%2Fhelper/helper) (or
+  under [Helper](/ember/release/classes/Helper) if a helper requires access to
+  dependency injection).
 
   ### Invoking a Component
 
   Ember components represent state to the UI of an application. Further
-  reading on components can be found under [Component](/api/ember/release/classes/Component).
+  reading on components can be found under [Component](/ember/release/classes/Component).
 
   @module @ember/component
   @main @ember/component

--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -372,7 +372,7 @@ export const BOUNDS = symbol('BOUNDS');
   will be removed.
 
   Both `classNames` and `classNameBindings` are concatenated properties. See
-  [EmberObject](/api/ember/release/classes/EmberObject) documentation for more
+  [EmberObject](/ember/release/classes/EmberObject) documentation for more
   information about concatenated properties.
 
   ### Other HTML Attributes
@@ -514,7 +514,7 @@ export const BOUNDS = symbol('BOUNDS');
   update of the  HTML attribute in the component's HTML output.
 
   `attributeBindings` is a concatenated property. See
-  [EmberObject](/api/ember/release/classes/EmberObject) documentation for more
+  [EmberObject](/ember/release/classes/EmberObject) documentation for more
   information about concatenated properties.
 
   ## Layouts

--- a/packages/@ember/-internals/glimmer/lib/components/checkbox.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/checkbox.ts
@@ -12,7 +12,7 @@ import layout from '../templates/empty';
   The internal class used to create text inputs when the `{{input}}`
   helper is used with `type` of `checkbox`.
 
-  See [Ember.Templates.helpers.input](/api/ember/release/classes/Ember.Templates.helpers/methods/input?anchor=input)  for usage details.
+  See [Ember.Templates.helpers.input](/ember/release/classes/Ember.Templates.helpers/methods/input?anchor=input)  for usage details.
 
   ## Direct manipulation of `checked`
 

--- a/packages/@ember/-internals/glimmer/lib/components/input.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/input.ts
@@ -11,7 +11,7 @@ let Input: any;
 
 if (EMBER_GLIMMER_ANGLE_BRACKET_BUILT_INS) {
   /**
-    See [Ember.Templates.components.Input](/api/ember/release/classes/Ember.Templates.components/methods/Input?anchor=Input).
+    See [Ember.Templates.components.Input](/ember/release/classes/Ember.Templates.components/methods/Input?anchor=Input).
 
     @method input
     @for Ember.Templates.helpers
@@ -87,7 +87,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_BUILT_INS) {
     the helper to `TextField`'s `create` method. Subclassing `TextField` is supported but not
     recommended.
 
-    See [TextField](/api/ember/release/classes/TextField)
+    See [TextField](/ember/release/classes/TextField)
 
     ### Checkbox
 

--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -1165,7 +1165,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_BUILT_INS) {
     {{/link-to}}
     ```
 
-    See [LinkComponent](/api/ember/release/classes/LinkComponent) for a
+    See [LinkComponent](/ember/release/classes/LinkComponent) for a
     complete list of overrideable properties. Be sure to also
     check out inherited properties of `LinkComponent`.
 

--- a/packages/@ember/-internals/glimmer/lib/components/text-field.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/text-field.ts
@@ -33,7 +33,7 @@ function canSetTypeOfInput(type: string): boolean {
 /**
   The internal class used to create text inputs when the `Input` component is used with `type` of `text`.
 
-  See [Ember.Templates.components.Input](/api/ember/release/classes/Ember.Templates.components/methods/Input?anchor=Input) for usage details.
+  See [Ember.Templates.components.Input](/ember/release/classes/Ember.Templates.components/methods/Input?anchor=Input) for usage details.
 
   ## Layout and LayoutName properties
 

--- a/packages/@ember/-internals/glimmer/lib/helpers/action.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/action.ts
@@ -87,7 +87,7 @@ import { ACTION, INVOKE, UnboundReference } from '../utils/references';
 
   Closure actions curry both their scope and any arguments. When invoked, any
   additional arguments are added to the already curried list.
-  Actions should be invoked using the [sendAction](/api/ember/release/classes/Component/methods/sendAction?anchor=sendAction)
+  Actions should be invoked using the [sendAction](/ember/release/classes/Component/methods/sendAction?anchor=sendAction)
   method. The first argument to `sendAction` is the action to be called, and
   additional arguments are passed to the action function. This has interesting
   properties combined with currying of arguments. For example:
@@ -208,7 +208,7 @@ import { ACTION, INVOKE, UnboundReference } from '../utils/references';
 
   If you need the default handler to trigger you should either register your
   own event handler, or use event methods on your view class. See
-  ["Responding to Browser Events"](/api/ember/release/classes/Component)
+  ["Responding to Browser Events"](/ember/release/classes/Component)
   in the documentation for `Component` for more information.
 
   ### Specifying DOM event type
@@ -223,7 +223,7 @@ import { ACTION, INVOKE, UnboundReference } from '../utils/references';
   </div>
   ```
 
-  See ["Event Names"](/api/ember/release/classes/Component) for a list of
+  See ["Event Names"](/ember/release/classes/Component) for a list of
   acceptable DOM event names.
 
   ### Specifying whitelisted modifier keys

--- a/packages/@ember/-internals/glimmer/lib/helpers/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/component.ts
@@ -4,7 +4,7 @@
 
 /**
   The `{{component}}` helper lets you add instances of `Component` to a
-  template. See [Component](/api/ember/release/classes/Component) for
+  template. See [Component](/ember/release/classes/Component) for
   additional information on how a `Component` functions.
   `{{component}}`'s primary use is for cases where you want to dynamically
   change which type of component is rendered as the state of your application

--- a/packages/@ember/-internals/glimmer/lib/helpers/loc.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/loc.ts
@@ -6,7 +6,7 @@ import { loc } from '@ember/string';
 import { helper } from '../helper';
 
 /**
-  Calls [loc](/api/classes/Ember.String.html#method_loc) with the
+  Calls [String.loc](/ember/release/classes/String/methods/loc?anchor=loc) with the
   provided string. This is a convenient way to localize text within a template.
   For example:
 
@@ -28,7 +28,7 @@ import { helper } from '../helper';
   </div>
   ```
 
-  See [String.loc](/api/ember/release/classes/String/methods/loc?anchor=loc) for how to
+  See [String.loc](/ember/release/classes/String/methods/loc?anchor=loc) for how to
   set up localized string references.
 
   @method loc

--- a/packages/@ember/-internals/glimmer/lib/syntax/input.ts
+++ b/packages/@ember/-internals/glimmer/lib/syntax/input.ts
@@ -29,7 +29,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_BUILT_INS) {
   /**
     The `{{input}}` helper lets you create an HTML `<input />` component.
     It causes a `TextField` component to be rendered.  For more info,
-    see the [TextField](/api/ember/release/classes/TextField) docs and
+    see the [TextField](/ember/release/classes/TextField) docs and
     the [templates guide](https://guides.emberjs.com/release/templates/input-helpers/).
 
     ```handlebars
@@ -97,7 +97,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_BUILT_INS) {
     ```handlebars
     {{input focus-out="alertMessage"}}
     ```
-    See more about [Text Support Actions](/api/ember/release/classes/TextField)
+    See more about [Text Support Actions](/ember/release/classes/TextField)
 
     ### Extending `TextField`
 
@@ -117,7 +117,7 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_BUILT_INS) {
     Keep in mind when writing `TextField` subclasses that `TextField`
     itself extends `Component`. Expect isolated component semantics, not
     legacy 1.x view semantics (like `controller` being present).
-    See more about [Ember components](/api/ember/release/classes/Component)
+    See more about [Ember components](/ember/release/classes/Component)
 
     ### Checkbox
 

--- a/packages/@ember/-internals/routing/lib/ext/controller.ts
+++ b/packages/@ember/-internals/routing/lib/ext/controller.ts
@@ -136,7 +136,7 @@ ControllerMixin.reopen({
     aController.transitionToRoute({ queryParams: { sort: 'date' } });
     ```
 
-    See also [replaceRoute](/api/ember/release/classes/Ember.ControllerMixin/methods/replaceRoute?anchor=replaceRoute).
+    See also [replaceRoute](/ember/release/classes/Ember.ControllerMixin/methods/replaceRoute?anchor=replaceRoute).
 
     @param {String} name the name of the route or a URL
     @param {...Object} models the model(s) or identifier(s) to be used

--- a/packages/@ember/-internals/routing/lib/location/api.ts
+++ b/packages/@ember/-internals/routing/lib/location/api.ts
@@ -27,10 +27,10 @@ export type UpdateCallback = (url: string) => void;
   You can pass an implementation name (`hash`, `history`, `none`, `auto`) to force a
   particular implementation to be used in your application.
 
-  See [HashLocation](/api/ember/release/classes/HashLocation).
-  See [HistoryLocation](/api/ember/release/classes/HistoryLocation).
-  See [NoneLocation](/api/ember/release/classes/NoneLocation).
-  See [AutoLocation](/api/ember/release/classes/AutoLocation).
+  See [HashLocation](/ember/release/classes/HashLocation).
+  See [HistoryLocation](/ember/release/classes/HistoryLocation).
+  See [NoneLocation](/ember/release/classes/NoneLocation).
+  See [AutoLocation](/ember/release/classes/AutoLocation).
 
   ## Location API
 

--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -84,7 +84,7 @@ export default class RouterService extends Service {
      Transition the application into another route. The route may
      be either a single route or route path:
 
-     See [transitionTo](/api/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo) for more info.
+     See [transitionTo](/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo) for more info.
 
      Calling `transitionTo` from the Router service will cause default query parameter values to be included in the URL.
      This behavior is different from calling `transitionTo` on a route or `transitionToRoute` on a controller.
@@ -117,7 +117,7 @@ export default class RouterService extends Service {
      Transition into another route while replacing the current URL, if possible.
      The route may be either a single route or route path:
 
-     See [replaceWith](/api/ember/release/classes/Route/methods/replaceWith?anchor=replaceWith) for more info.
+     See [replaceWith](/ember/release/classes/Route/methods/replaceWith?anchor=replaceWith) for more info.
 
      Calling `replaceWith` from the Router service will cause default query parameter values to be included in the URL.
      This behavior is different from calling `replaceWith` on a route.

--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -497,7 +497,7 @@ class EmberRouter extends EmberObject {
     Transition the application into another route. The route may
     be either a single route or route path:
 
-    See [transitionTo](/api/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo) for more info.
+    See [transitionTo](/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo) for more info.
 
     @method transitionTo
     @param {String} name the name of the route or a URL

--- a/packages/@ember/-internals/runtime/lib/ext/function.js
+++ b/packages/@ember/-internals/runtime/lib/ext/function.js
@@ -68,7 +68,7 @@ if (FUNCTION_PROTOTYPE_EXTENSIONS && ENV.EXTEND_PROTOTYPES.Function) {
       will instead clear the cache so that it is updated when the next `get`
       is called on the property.
 
-      See [ComputedProperty](/api/ember/release/classes/ComputedProperty), [@ember/object/computed](/api/ember/release/classes/@ember%2Fobject%2Fcomputed).
+      See [ComputedProperty](/ember/release/classes/ComputedProperty), [@ember/object/computed](/ember/release/classes/@ember%2Fobject%2Fcomputed).
 
       @method property
       @for Function

--- a/packages/@ember/string/index.ts
+++ b/packages/@ember/string/index.ts
@@ -281,7 +281,7 @@ export function capitalize(str: string): string {
 if (ENV.EXTEND_PROTOTYPES.String) {
   Object.defineProperties(String.prototype, {
     /**
-      See [String.w](/api/ember/release/classes/String/methods/w?anchor=w).
+      See [String.w](/ember/release/classes/String/methods/w?anchor=w).
 
       @method w
       @for @ember/string
@@ -298,7 +298,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
     },
 
     /**
-      See [String.loc](/api/ember/release/classes/String/methods/loc?anchor=loc).
+      See [String.loc](/ember/release/classes/String/methods/loc?anchor=loc).
 
       @method loc
       @for @ember/string
@@ -315,7 +315,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
     },
 
     /**
-      See [String.camelize](/api/ember/release/classes/String/methods/camelize?anchor=camelize).
+      See [String.camelize](/ember/release/classes/String/methods/camelize?anchor=camelize).
 
       @method camelize
       @for @ember/string
@@ -332,7 +332,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
     },
 
     /**
-      See [String.decamelize](/api/ember/release/classes/String/methods/decamelize?anchor=decamelize).
+      See [String.decamelize](/ember/release/classes/String/methods/decamelize?anchor=decamelize).
 
       @method decamelize
       @for @ember/string
@@ -349,7 +349,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
     },
 
     /**
-      See [String.dasherize](/api/ember/release/classes/String/methods/dasherize?anchor=dasherize).
+      See [String.dasherize](/ember/release/classes/String/methods/dasherize?anchor=dasherize).
 
       @method dasherize
       @for @ember/string
@@ -383,7 +383,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
     },
 
     /**
-      See [String.classify](/api/ember/release/classes/String/methods/classify?anchor=classify).
+      See [String.classify](/ember/release/classes/String/methods/classify?anchor=classify).
 
       @method classify
       @for @ember/string
@@ -400,7 +400,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
     },
 
     /**
-      See [String.capitalize](/api/ember/release/classes/String/methods/capitalize?anchor=capitalize).
+      See [String.capitalize](/ember/release/classes/String/methods/capitalize?anchor=capitalize).
 
       @method capitalize
       @for @ember/string


### PR DESCRIPTION
Documentation links were pointing at `/api/`, when the Ember documentation does not live at https://api.emberjs.com under that path. Thus all these links have been broken.

For example on [`@ember/component`](https://api.emberjs.com/ember/release/modules/@ember%2Fcomponent) the link to "Ember.Templates.helpers" is dead.

And correct a few broken for other reasons.

---

This fixes the links in the *current release*, but these links *remain broken as that release becomes supplanted by a newer one*. This is because these links are to `/ember/release/`. So if you are on the 3.10 docs after 3.11 has been released, clicking these links would take you to the *incorrect* spot, 3.11.

And additionally *many, many old links are broken*. For example on [`ember-templates` for 1.13](https://api.emberjs.com/ember/1.13/modules/ember-templates) that same link to "Ember.Templates.helpers" is broken. I think we are unlikely to backport this work to every release of Ember, so it should probably be resolved in the API docs app.

/cc @mansona @emberjs/learning-team-managers @rwjblue 