### PR TITLE
[DOC release-3-10] Replace @ in decorators code samples with &#64;

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/textarea.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/textarea.ts
@@ -35,7 +35,7 @@ import layout from '../templates/empty';
   import { tracked } from '@glimmer/tracking';
 
   export default class extends Component {
-    @tracked writtenWords = "Lots of text that IS bound";
+    &#64;tracked writtenWords = "Lots of text that IS bound";
   }
   ```
 

--- a/packages/@ember/-internals/glimmer/lib/helpers/fn.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/fn.ts
@@ -33,7 +33,7 @@ const context = buildUntouchableThis('`fn` helper');
   import { action } from '@ember/object';
 
   export default class ItemsList extends Component {
-    @action
+    &#64;action
     handleSelected(item) {
       // ...snip...
     }

--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -77,7 +77,7 @@ function noop(): void {}
       set(this, 'lastName', lastName);
     }
 
-    @computed('firstName', 'lastName')
+    &#64;computed('firstName', 'lastName')
     get fullName() {
       return `${this.firstName} ${this.lastName}`;
     }
@@ -101,7 +101,7 @@ function noop(): void {}
       set(this, 'lastName', lastName);
     }
 
-    @computed('firstName', 'lastName')
+    &#64;computed('firstName', 'lastName')
     get fullName() {
       return `${this.firstName} ${this.lastName}`;
     }
@@ -149,7 +149,7 @@ function noop(): void {}
   import { computed, set } from '@ember/object';
 
   function fullNameMacro(firstNameKey, lastNameKey) {
-    @computed(firstNameKey, lastNameKey, {
+    &#64;computed(firstNameKey, lastNameKey, {
       get() {
         return `${this[firstNameKey]} ${this[lastNameKey]}`;
       }
@@ -231,7 +231,7 @@ function noop(): void {}
       set(this, 'lastName', lastName);
     }
 
-    @computed('firstName', 'lastName').readOnly()
+    &#64;computed('firstName', 'lastName').readOnly()
     get fullName() {
       return `${this.firstName} ${this.lastName}`;
     }

--- a/packages/@ember/-internals/metal/lib/tracked.ts
+++ b/packages/@ember/-internals/metal/lib/tracked.ts
@@ -55,7 +55,7 @@ export class Tracker {
   Marking a property as tracked means that when that property changes,
   a rerender of the component is scheduled so the template is kept up to date.
 
-  There are two usages for the `@tracked` decorator, shown below.
+  There are two usages for the `&#64;tracked` decorator, shown below.
 
   @example No dependencies
 
@@ -66,7 +66,7 @@ export class Tracker {
   import Component, { tracked } from '@glimmer/component';
 
   export default class MyComponent extends Component {
-    @tracked
+    &#64;tracked
     remainingApples = 10
   }
   ```
@@ -89,10 +89,10 @@ export class Tracker {
   const totalApples = 100;
 
   export default class MyComponent extends Component {
-    @tracked
+    &#64;tracked
     eatenApples = 0
 
-    @tracked('eatenApples')
+    &#64;tracked('eatenApples')
     get remainingApples() {
       return totalApples - this.eatenApples;
     }

--- a/packages/@ember/object/index.js
+++ b/packages/@ember/object/index.js
@@ -12,7 +12,7 @@ import { isElementDescriptor, setClassicDecorator } from '@ember/-internals/meta
   import { action, set } from '@ember/object';
 
   export default class Tooltip extends Component {
-    @action
+    &#64;action
     toggleShowing() {
       set(this, 'isShowing', !this.isShowing);
     }
@@ -76,7 +76,7 @@ import { isElementDescriptor, setClassicDecorator } from '@ember/-internals/meta
       document.addEventListener('click', this.toggleShowing);
     }
 
-    @action
+    &#64;action
     toggleShowing() {
       set(this, 'isShowing', !this.isShowing);
     }

--- a/packages/@ember/object/lib/computed/computed_macros.js
+++ b/packages/@ember/object/lib/computed/computed_macros.js
@@ -75,7 +75,7 @@ function generateComputedWithPredicate(name, predicate) {
       set(this, 'todos', todos);
     }
 
-    @empty('todos') isDone;
+    &#64;empty('todos') isDone;
   }
 
   let todoList = new ToDoList(
@@ -143,7 +143,7 @@ export function empty(dependentKey) {
       set(this, 'backpack', backpack);
     }
 
-    @notEmpty('backpack') hasStuff
+    &#64;notEmpty('backpack') hasStuff
   }
 
   let hamster = new Hamster(
@@ -203,7 +203,7 @@ export function notEmpty(dependentKey) {
   import { none } from '@ember/object/computed';
 
   class Hamster {
-    @none('food') isHungry;
+    &#64;none('food') isHungry;
   }
 
   let hamster = new Hamster();
@@ -220,7 +220,7 @@ export function notEmpty(dependentKey) {
   Classic Class Example:
 
   ```javascript
-  import EmberObject, { set } from '@ember/object';
+  import EmberObject, { set } from 'ember/object';
   import { none } from '@ember/object/computed';
 
   let Hamster = EmberObject.extend({
@@ -270,7 +270,7 @@ export function none(dependentKey) {
   class User {
     loggedIn = false;
 
-    @not('loggedIn') isAnonymous;
+    &#64;not('loggedIn') isAnonymous;
   }
 
   let user = new User();
@@ -330,7 +330,7 @@ export function not(dependentKey) {
 
 
   class Hamster {
-    @bool('numBananas') hasBananas
+    &#64;bool('numBananas') hasBananas
   }
 
   let hamster = new Hamster();
@@ -403,7 +403,7 @@ export function bool(dependentKey) {
   import { match } from '@ember/object/computed';
 
   class User {
-    @match('email', /^.+@.+\..+$/) hasValidEmail;
+    &#64;match('email', /^.+@.+\..+$/) hasValidEmail;
   }
 
   let user = new User();
@@ -470,7 +470,7 @@ export function match(dependentKey, regexp) {
   import { equal } from '@ember/object/computed';
 
   class Hamster {
-    @equal('percentCarrotsEaten', 100) satisfied;
+    &#64;equal('percentCarrotsEaten', 100) satisfied;
   }
 
   let hamster = new Hamster();
@@ -536,7 +536,7 @@ export function equal(dependentKey, value) {
   import { gt } from '@ember/object/computed';
 
   class Hamster {
-    @gt('numBananas', 10) hasTooManyBananas;
+    &#64;gt('numBananas', 10) hasTooManyBananas;
   }
 
   let hamster = new Hamster();
@@ -602,7 +602,7 @@ export function gt(dependentKey, value) {
   import { gte } from '@ember/object/computed';
 
   class Hamster {
-    @gte('numBananas', 10) hasTooManyBananas;
+    &#64;gte('numBananas', 10) hasTooManyBananas;
   }
 
   let hamster = new Hamster();
@@ -668,7 +668,7 @@ export function gte(dependentKey, value) {
   import { lt } from '@ember/object/computed';
 
   class Hamster {
-    @lt('numBananas', 3) needsMoreBananas;
+    &#64;lt('numBananas', 3) needsMoreBananas;
   }
 
   let hamster = new Hamster();
@@ -734,7 +734,7 @@ export function lt(dependentKey, value) {
   import { lte } from '@ember/object/computed';
 
   class Hamster {
-    @lte('numBananas', 3) needsMoreBananas;
+    &#64;lte('numBananas', 3) needsMoreBananas;
   }
 
   let hamster = new Hamster();
@@ -804,8 +804,8 @@ export function lte(dependentKey, value) {
   import { and } from '@ember/object/computed';
 
   class Hamster {
-    @and('hasTent', 'hasBackpack') readyForCamp;
-    @and('hasWalkingStick', 'hasBackpack') readyForHike;
+    &#64;and('hasTent', 'hasBackpack') readyForCamp;
+    &#64;and('hasWalkingStick', 'hasBackpack') readyForHike;
   }
 
   let tomster = new Hamster();
@@ -878,8 +878,8 @@ export const and = generateComputedWithPredicate('and', value => value);
   import { or } from '@ember/object/computed';
 
   let Hamster = EmberObject.extend({
-    @or('hasJacket', 'hasUmbrella') readyForRain;
-    @or('hasSunscreen', 'hasUmbrella') readyForBeach;
+    &#64;or('hasJacket', 'hasUmbrella') readyForRain;
+    &#64;or('hasSunscreen', 'hasUmbrella') readyForBeach;
   });
 
   let tomster = new Hamster();
@@ -945,7 +945,7 @@ export const or = generateComputedWithPredicate('or', value => !value);
   class Person {
     name = 'Alex Matchneer';
 
-    @alias('name') nomen;
+    &#64;alias('name') nomen;
   }
 
   let alex = new Person();
@@ -1006,7 +1006,7 @@ export const or = generateComputedWithPredicate('or', value => !value);
       set(this, 'lastName', lastName);
     }
 
-    @oneWay('firstName') nickName;
+    &#64;oneWay('firstName') nickName;
   }
 
   let teddy = new User('Teddy', 'Zeenny');
@@ -1092,7 +1092,7 @@ export function oneWay(dependentKey) {
       set(this, 'lastName', lastName);
     }
 
-    @readOnly('firstName') nickName;
+    &#64;readOnly('firstName') nickName;
   });
 
   let teddy = new User('Teddy', 'Zeenny');
@@ -1161,7 +1161,7 @@ export function readOnly(dependentKey) {
   import { deprecatingAlias } from '@ember/object/computed';
 
   class Hamster {
-    @deprecatingAlias('cavendishCount', {
+    &#64;deprecatingAlias('cavendishCount', {
       id: 'hamster.deprecate-banana',
       until: '3.0.0'
     })

--- a/packages/@ember/service/index.js
+++ b/packages/@ember/service/index.js
@@ -18,7 +18,7 @@ import { inject as metalInject } from '@ember/-internals/metal';
   import { inject as service } from '@ember/service';
 
   export default class ApplicationRoute extends Route {
-    @service('auth') authManager;
+    &#64;service('auth') authManager;
 
     model() {
       return this.authManager.findCurrentUser();


### PR DESCRIPTION
This is a patch because YUIdoc can't parse the @ of decorators in code blocks, and it broke the API docs. See #18063 for examples of the broken state.

Really we need to fix this in YUIdocs but that's a long haul.

I'm not sure I got them all. I had a hard time composing regex that would work in the command line or VSCode. If anyone can run this kind of search, it would be nice: `(?<!'|backtick-goes-here|/|\* )@`. Translation - find an @ symbol that is not preceded by a single quote, backtick, slash, or `* ` aka a bullet point used by YUIdoc labels like `@method`. Most command line things couldn't deal with the ' and VSCode couldn't deal with the `\* ` in the negative lookbehind.