### PR TITLE
[BUGFIX lts] ember-template-compiler & fastboot compatibility

### DIFF
--- a/packages/ember-template-compiler/lib/system/initializer.ts
+++ b/packages/ember-template-compiler/lib/system/initializer.ts
@@ -18,12 +18,9 @@ if (
   Application.initializer({
     name: 'domTemplates',
     initialize() {
-      let context;
       if (hasDOM) {
-        context = document;
+        bootstrap({ context: document, hasTemplate, setTemplate });
       }
-
-      bootstrap({ context, hasTemplate, setTemplate });
     },
   });
 }


### PR DESCRIPTION
# Problem
When importing ember-template-compiler as part of the dist bundle, it's initializer for DOM Templates
comes along as well.

While this would normally just be extra bytes for no reason when used in conjunction with FastBoot.
It throws a `document is undefined error` within the bootstrap module.

# Patch
If no context is passed to the bootstrap module it throws the aforementioned error, The initializer does check if the current context has a dom but just uses it to set up the context, but a dom instance would not have existed when entering the bootstrap module.

For this, my patch solution would be to only call the bootstrap if a document instance is present.

# Moving forward

I would love to get some thoughts on the future of the bootstrap module and this initializer :).