### PR TITLE
Fix function name in documentation example

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/helpers/fn.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/fn.ts
@@ -49,7 +49,7 @@ const context = buildUntouchableThis('`fn` helper');
 
   - When invoked as `this.args.select()` the `handleSelected` function will
     receive the `item` from the loop as its first and only argument.
-  - When invoked as `this.args.selected('foo')` the `handleSelected` function
+  - When invoked as `this.args.select('foo')` the `handleSelected` function
     will receive the `item` from the loop as its first argument and the
     string `'foo'` as its second argument.
 


### PR DESCRIPTION
Renamed `this.args.selected` to `this.args.select`