### PR TITLE
📝 make queryParamsDidChange as public method

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -2414,7 +2414,7 @@ Route.reopen(ActionHandler, Evented, {
     @param totalPresent {Object} Keys are names of query params that are currently set.
     @param removed {Object} Keys are names of query params that have been removed.
     @returns {boolean}
-    @private
+    @public
    */
     queryParamsDidChange(this: Route, changed: {}, _totalPresent: unknown, removed: {}) {
       let qpMap = get(this, '_qp').map;


### PR DESCRIPTION
According to https://github.com/emberjs/ember.js/issues/15921, this PR make `queryParamsDidChange` as a public method. 



Related commit https://github.com/emberjs/ember.js/commit/50a5a5df8172acbe6d287b1ba74b44485802eced
Fixes https://github.com/emberjs/ember.js/issues/15921.