### PR TITLE
[BUGFIX] Use WeakMap to store tracked property values.

### DIFF
--- a/packages/@ember/controller/tests/controller_test.js
+++ b/packages/@ember/controller/tests/controller_test.js
@@ -138,10 +138,10 @@ moduleFor(
       assert.expect(3);
       expectNoDeprecation();
 
-      let controller = Controller.extend({
+      let controller = Controller.create({
         content: 'foo-bar',
         model: 'blammo',
-      }).create();
+      });
 
       assert.equal(get(controller, 'content'), 'foo-bar');
       assert.equal(get(controller, 'model'), 'blammo');

--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -155,8 +155,9 @@ moduleFor(
       this.add(
         'controller:homepage',
         Controller.extend({
-          model: {
-            home: 'Comes from homepage',
+          init() {
+            this._super(...arguments);
+            this.model = { home: 'Comes from homepage' };
           },
         })
       );
@@ -183,16 +184,18 @@ moduleFor(
       this.add(
         'controller:foo',
         Controller.extend({
-          model: {
-            home: 'Comes from foo',
+          init() {
+            this._super(...arguments);
+            this.model = { home: 'Comes from foo' };
           },
         })
       );
       this.add(
         'controller:homepage',
         Controller.extend({
-          model: {
-            home: 'Comes from homepage',
+          init() {
+            this._super(...arguments);
+            this.model = { home: 'Comes from homepage' };
           },
         })
       );
@@ -220,8 +223,9 @@ moduleFor(
       this.add(
         'controller:home',
         Controller.extend({
-          model: {
-            home: 'Comes from home.',
+          init() {
+            this._super(...arguments);
+            this.model = { home: 'Comes from home.' };
           },
         })
       );
@@ -241,8 +245,9 @@ moduleFor(
       this.add(
         'controller:home',
         Controller.extend({
-          model: {
-            home: 'YES I AM HOME',
+          init() {
+            this._super(...arguments);
+            this.model = { home: 'YES I AM HOME' };
           },
         })
       );


### PR DESCRIPTION
Using a `Symbol` causes issues on IE11 when using the core-js polyfill. Specifically, the polyfill adds every symbol to `Object.prototype` and therefore our `if (symbol in this) {` check was completely borked.

Migrating to a `WeakMap` exposed another issue: we were accidentally relying on the fact that the symbols would be inherited through the prototype chain (introduced by #18074). This meant that setting a tracked property on a prototype would actually affect the value seen by every instance of that prototype.

For example:

```js
class Thing {
  @Tracked baz;
}

Thing.prototype.baz = 'foo';

let thing = new Thing();

console.log(thing.baz)
```

Before the changes in this commit, the above `console.log` would emit `foo` and after these changes it would print `undefined`.

Fixes #18075