### PR TITLE
Refactor template factory

### DIFF
--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -344,7 +344,12 @@
 */
 
 export { default as RootTemplate } from './lib/templates/root';
-export { default as template } from './lib/template';
+export {
+  default as template,
+  counters as templateCacheCounters,
+  Factory as TemplateFactory,
+  OwnedTemplate,
+} from './lib/template';
 export { default as Checkbox } from './lib/components/checkbox';
 export { default as TextField } from './lib/components/text-field';
 export { default as TextArea } from './lib/components/textarea';

--- a/packages/@ember/-internals/glimmer/lib/component-managers/mount.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/mount.ts
@@ -7,9 +7,9 @@ import { Destroyable, Opaque, Option } from '@glimmer/util';
 import { Owner } from '@ember/-internals/owner';
 import { generateControllerFactory } from '@ember/-internals/routing';
 import { OwnedTemplateMeta } from '@ember/-internals/views';
+import { TemplateFactory } from '../..';
 import Environment from '../environment';
 import RuntimeResolver from '../resolver';
-import { OwnedTemplate } from '../template';
 import { RootReference } from '../utils/references';
 import AbstractManager from './abstract';
 
@@ -54,8 +54,10 @@ class MountManager
   implements
     WithDynamicLayout<EngineState | EngineWithModelState, OwnedTemplateMeta, RuntimeResolver> {
   getDynamicLayout(state: EngineState, _: RuntimeResolver): Invocation {
-    let template = state.engine.lookup('template:application') as OwnedTemplate;
+    let templateFactory = state.engine.lookup('template:application') as TemplateFactory;
+    let template = templateFactory(state.engine);
     let layout = template.asLayout();
+
     return {
       handle: layout.compile(),
       symbolTable: layout.symbolTable,

--- a/packages/@ember/-internals/glimmer/lib/component-managers/root.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/root.ts
@@ -7,7 +7,6 @@ import { Arguments, ComponentDefinition } from '@glimmer/runtime';
 import { DIRTY_TAG } from '../component';
 import Environment from '../environment';
 import { DynamicScope } from '../renderer';
-import RuntimeResolver from '../resolver';
 import ComponentStateBucket, { Component } from '../utils/curly-component-state-bucket';
 import CurlyComponentManager, {
   initialRenderInstrumentDetails,
@@ -23,8 +22,8 @@ class RootComponentManager extends CurlyComponentManager {
     this.component = component;
   }
 
-  getLayout(_state: DefinitionState, resolver: RuntimeResolver) {
-    const template = this.templateFor(this.component, resolver);
+  getLayout(_state: DefinitionState) {
+    const template = this.templateFor(this.component);
     const layout = template.asWrappedLayout();
     return {
       handle: layout.compile(),

--- a/packages/@ember/-internals/glimmer/lib/renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/renderer.ts
@@ -23,7 +23,7 @@ import { BOUNDS } from './component';
 import { createRootOutlet } from './component-managers/outlet';
 import { RootComponentDefinition } from './component-managers/root';
 import Environment from './environment';
-import { OwnedTemplate } from './template';
+import { Factory as TemplateFactory, OwnedTemplate } from './template';
 import { Component } from './utils/curly-component-state-bucket';
 import { OutletState } from './utils/outlet';
 import { UnboundReference } from './utils/references';
@@ -246,7 +246,7 @@ interface ViewRegistry {
 
 export abstract class Renderer {
   private _env: Environment;
-  private _rootTemplate: any;
+  private _rootTemplate: OwnedTemplate;
   private _viewRegistry: ViewRegistry;
   private _destinedForDOM: boolean;
   private _destroyed: boolean;
@@ -258,13 +258,13 @@ export abstract class Renderer {
 
   constructor(
     env: Environment,
-    rootTemplate: OwnedTemplate,
+    rootTemplate: TemplateFactory,
     viewRegistry: ViewRegistry,
     destinedForDOM = false,
     builder = clientBuilder
   ) {
     this._env = env;
-    this._rootTemplate = rootTemplate;
+    this._rootTemplate = rootTemplate(env.owner);
     this._viewRegistry = viewRegistry;
     this._destinedForDOM = destinedForDOM;
     this._destroyed = false;
@@ -517,7 +517,7 @@ export class InertRenderer extends Renderer {
     builder,
   }: {
     env: Environment;
-    rootTemplate: OwnedTemplate;
+    rootTemplate: TemplateFactory;
     _viewRegistry: any;
     builder: any;
   }) {
@@ -539,7 +539,7 @@ export class InteractiveRenderer extends Renderer {
     builder,
   }: {
     env: Environment;
-    rootTemplate: OwnedTemplate;
+    rootTemplate: TemplateFactory;
     _viewRegistry: any;
     builder: any;
   }) {

--- a/packages/@ember/-internals/glimmer/lib/setup-registry.ts
+++ b/packages/@ember/-internals/glimmer/lib/setup-registry.ts
@@ -55,7 +55,7 @@ export function setupApplicationRegistry(registry: Registry) {
   registry.injection('service:-dom-builder', 'bootOptions', '-environment:main');
   registry.injection('renderer', 'builder', 'service:-dom-builder');
 
-  registry.register(P`template:-root`, RootTemplate);
+  registry.register(P`template:-root`, RootTemplate as any);
   registry.injection('renderer', 'rootTemplate', P`template:-root`);
 
   registry.register('renderer:-dom', InteractiveRenderer);
@@ -80,21 +80,21 @@ export function setupApplicationRegistry(registry: Registry) {
 }
 
 export function setupEngineRegistry(registry: Registry) {
+  registry.optionsForType('template', { instantiate: false });
+
   registry.register('view:-outlet', OutletView);
-  registry.register('template:-outlet', OutletTemplate);
+  registry.register('template:-outlet', OutletTemplate as any);
   registry.injection('view:-outlet', 'template', 'template:-outlet');
 
   registry.injection('service:-dom-changes', 'document', 'service:-document');
   registry.injection('service:-dom-tree-construction', 'document', 'service:-document');
 
-  registry.register(P`template:components/-default`, ComponentTemplate);
+  registry.register(P`template:components/-default`, ComponentTemplate as any);
 
   registry.register('service:-glimmer-environment', Environment);
 
   registry.register(P`template-compiler:main`, TemplateCompiler);
   registry.injection(P`template-compiler:main`, 'environment', '-environment:main');
-
-  registry.injection('template', 'compiler', P`template-compiler:main`);
 
   registry.optionsForType('helper', { instantiate: false });
 
@@ -106,7 +106,7 @@ export function setupEngineRegistry(registry: Registry) {
 
   if (EMBER_GLIMMER_ANGLE_BRACKET_BUILT_INS) {
     registry.register('component:input', Input);
-    registry.register('template:components/input', InputTemplate);
+    registry.register('template:components/input', InputTemplate as any);
 
     registry.register('component:textarea', TextArea);
   } else {

--- a/packages/@ember/-internals/glimmer/lib/views/outlet.ts
+++ b/packages/@ember/-internals/glimmer/lib/views/outlet.ts
@@ -34,8 +34,9 @@ export default class OutletView {
   }
 
   static create(options: any) {
-    let { _environment, renderer, template } = options;
+    let { _environment, renderer, template: templateFactory } = options;
     let owner = options[OWNER];
+    let template = templateFactory(owner);
     return new OutletView(_environment, renderer, owner, template);
   }
 

--- a/packages/@ember/-internals/glimmer/tests/integration/outlet-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/outlet-test.js
@@ -62,7 +62,7 @@ moduleFor(
           outlet: 'main',
           name: 'application',
           controller: {},
-          template: this.owner.lookup('template:application'),
+          template: this.owner.lookup('template:application')(this.owner),
         },
         outlets: Object.create(null),
       };
@@ -81,7 +81,7 @@ moduleFor(
           outlet: 'main',
           name: 'index',
           controller: {},
-          template: this.owner.lookup('template:index'),
+          template: this.owner.lookup('template:index')(this.owner),
         },
         outlets: Object.create(null),
       };
@@ -100,7 +100,7 @@ moduleFor(
           outlet: 'main',
           name: 'application',
           controller: {},
-          template: this.owner.lookup('template:application'),
+          template: this.owner.lookup('template:application')(this.owner),
         },
         outlets: Object.create(null),
       };
@@ -121,7 +121,7 @@ moduleFor(
           outlet: 'main',
           name: 'index',
           controller: {},
-          template: this.owner.lookup('template:index'),
+          template: this.owner.lookup('template:index')(this.owner),
         },
         outlets: Object.create(null),
       };
@@ -140,7 +140,7 @@ moduleFor(
           outlet: 'main',
           name: 'application',
           controller: {},
-          template: this.owner.lookup('template:application'),
+          template: this.owner.lookup('template:application')(this.owner),
         },
         outlets: Object.create(null),
       };
@@ -161,7 +161,7 @@ moduleFor(
           outlet: 'main',
           name: 'special',
           controller: {},
-          template: this.owner.lookup('template:special'),
+          template: this.owner.lookup('template:special')(this.owner),
         },
         outlets: Object.create(null),
       };
@@ -180,7 +180,7 @@ moduleFor(
           outlet: 'main',
           name: 'application',
           controller: {},
-          template: this.owner.lookup('template:application'),
+          template: this.owner.lookup('template:application')(this.owner),
         },
         outlets: Object.create(null),
       };
@@ -201,7 +201,7 @@ moduleFor(
           outlet: 'main',
           name: 'special',
           controller: {},
-          template: this.owner.lookup('template:special'),
+          template: this.owner.lookup('template:special')(this.owner),
         },
         outlets: Object.create(null),
       };
@@ -221,7 +221,7 @@ moduleFor(
           outlet: 'main',
           name: 'application',
           controller,
-          template: this.owner.lookup('template:application'),
+          template: this.owner.lookup('template:application')(this.owner),
         },
         outlets: Object.create(null),
       };
@@ -242,7 +242,7 @@ moduleFor(
           outlet: 'main',
           name: 'foo',
           controller: {},
-          template: this.owner.lookup('template:foo'),
+          template: this.owner.lookup('template:foo')(this.owner),
         },
         outlets: Object.create(null),
       };
@@ -255,7 +255,7 @@ moduleFor(
           outlet: 'main',
           name: 'bar',
           controller: {},
-          template: this.owner.lookup('template:bar'),
+          template: this.owner.lookup('template:bar')(this.owner),
         },
         outlets: Object.create(null),
       };
@@ -289,7 +289,7 @@ moduleFor(
           outlet: 'main',
           name: 'outer',
           controller: {},
-          template: this.owner.lookup('template:outer'),
+          template: this.owner.lookup('template:outer')(this.owner),
         },
         outlets: {
           main: {
@@ -299,7 +299,7 @@ moduleFor(
               outlet: 'main',
               name: 'inner',
               controller: {},
-              template: this.owner.lookup('template:inner'),
+              template: this.owner.lookup('template:inner')(this.owner),
             },
             outlets: Object.create(null),
           },

--- a/packages/@ember/-internals/glimmer/tests/unit/template-factory-test.js
+++ b/packages/@ember/-internals/glimmer/tests/unit/template-factory-test.js
@@ -1,6 +1,6 @@
 import { RenderingTestCase, moduleFor } from 'internal-test-helpers';
 
-import { template } from '@ember/-internals/glimmer';
+import { template, templateCacheCounters } from '@ember/-internals/glimmer';
 import { precompile, compile } from 'ember-template-compiler';
 
 import { Component } from '../utils/helpers';
@@ -9,8 +9,10 @@ moduleFor(
   'Template factory test',
   class extends RenderingTestCase {
     ['@test the template factory returned from precompile is the same as compile'](assert) {
+      // snapshot counters
+      this.getCacheCounters();
+
       let { owner } = this;
-      let { runtimeResolver } = this;
 
       let templateStr = 'Hello {{name}}';
       let options = { moduleName: 'my-app/templates/some-module.hbs' };
@@ -21,27 +23,33 @@ moduleFor(
       let exports = {};
       module(exports, template);
       let Precompiled = exports['default'];
-
       let Compiled = compile(templateStr, options);
 
-      assert.equal(typeof Precompiled.create, 'function', 'precompiled is a factory');
-      assert.ok(Precompiled.id, 'precompiled has id');
+      assert.equal(typeof Precompiled, 'function', 'precompiled is a factory');
+      assert.ok(Precompiled.__id, 'precompiled has id');
 
-      assert.equal(typeof Compiled.create, 'function', 'compiled is a factory');
-      assert.ok(Compiled.id, 'compiled has id');
+      assert.equal(typeof Compiled, 'function', 'compiled is a factory');
+      assert.ok(Compiled.__id, 'compiled has id');
 
-      assert.equal(runtimeResolver.templateCacheMisses, 0, 'misses 0');
-      assert.equal(runtimeResolver.templateCacheHits, 0, 'hits 0');
+      this.expectCacheChanges({}, 'no changes');
 
-      let precompiled = runtimeResolver.createTemplate(Precompiled, owner);
+      let precompiled = Precompiled(owner);
 
-      assert.equal(runtimeResolver.templateCacheMisses, 1, 'misses 1');
-      assert.equal(runtimeResolver.templateCacheHits, 0, 'hits 0');
+      this.expectCacheChanges(
+        {
+          templateCacheMisses: 1,
+        },
+        'misses 1'
+      );
 
-      let compiled = runtimeResolver.createTemplate(Compiled, owner);
+      let compiled = Compiled(owner);
 
-      assert.equal(runtimeResolver.templateCacheMisses, 2, 'misses 2');
-      assert.equal(runtimeResolver.templateCacheHits, 0, 'hits 0');
+      this.expectCacheChanges(
+        {
+          templateCacheMisses: 1,
+        },
+        'misses 1'
+      );
 
       assert.ok(typeof precompiled.spec !== 'string', 'Spec has been parsed');
       assert.ok(typeof compiled.spec !== 'string', 'Spec has been parsed');
@@ -60,10 +68,40 @@ moduleFor(
 
       this.render('{{x-precompiled name="precompiled"}} {{x-compiled name="compiled"}}');
 
-      assert.equal(runtimeResolver.templateCacheMisses, 2, 'misses 2');
-      assert.equal(runtimeResolver.templateCacheHits, 2, 'hits 2');
-
+      this.expectCacheChanges(
+        {
+          templateCacheHits: 2,
+          // from this.render
+          templateCacheMisses: 1,
+        },
+        'hits 2'
+      );
       this.assertText('Hello precompiled Hello compiled');
+    }
+
+    getCacheCounters() {
+      return (this._counters = {
+        templateCacheHits: templateCacheCounters.cacheHit,
+        templateCacheMisses: templateCacheCounters.cacheMiss,
+      });
+    }
+
+    expectCacheChanges(expected, message) {
+      let lastState = this._counters;
+      let state = this.getCacheCounters();
+      let actual = diff(state, lastState);
+      this.assert.deepEqual(actual, expected, message);
     }
   }
 );
+
+function diff(state, lastState) {
+  let res = {};
+  Object.keys(state).forEach(key => {
+    let delta = state[key] - lastState[key];
+    if (delta !== 0) {
+      res[key] = state[key] - lastState[key];
+    }
+  });
+  return res;
+}

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -1,3 +1,4 @@
+import { OwnedTemplate, TemplateFactory } from '@ember/-internals/glimmer';
 import {
   computed,
   defineProperty,
@@ -23,7 +24,6 @@ import { assign } from '@ember/polyfills';
 import { once } from '@ember/runloop';
 import { classify } from '@ember/string';
 import { DEBUG } from '@glimmer/env';
-import { TemplateFactory } from '@glimmer/opcode-compiler';
 import {
   InternalRouteInfo,
   PARAMS_SYMBOL,
@@ -1850,7 +1850,7 @@ function buildRenderOptions(
     (controller! as any).set('model', model);
   }
 
-  let template: TemplateFactory<unknown> = owner.lookup(`template:${templateName}`);
+  let template: TemplateFactory = owner.lookup(`template:${templateName}`);
   assert(
     `Could not find "${templateName}" template, view, or component.`,
     isDefaultRender || Boolean(template)
@@ -1861,13 +1861,13 @@ function buildRenderOptions(
     into = undefined;
   }
 
-  let renderOptions = {
+  let renderOptions: RenderOptions = {
     owner,
     into,
     outlet,
     name,
     controller: controller! as any,
-    template: template || route._topLevelViewTemplate,
+    template: template !== undefined ? template(owner) : route._topLevelViewTemplate(owner),
   };
 
   if (DEBUG) {
@@ -1888,7 +1888,7 @@ export interface RenderOptions {
   outlet: string;
   name: string;
   controller: any;
-  template: TemplateFactory<unknown>;
+  template: OwnedTemplate;
 }
 
 interface PartialRenderOptions {

--- a/packages/@ember/-internals/views/index.d.ts
+++ b/packages/@ember/-internals/views/index.d.ts
@@ -1,6 +1,7 @@
 import { Simple, Template, Option } from '@glimmer/interfaces';
 import { Opaque } from '@glimmer/util';
 import { Factory, Owner } from '@ember/-internals/owner';
+import { TemplateFactory } from '@ember/-internals/glimmer';
 
 export interface StaticTemplateMeta {
   moduleName: string;
@@ -41,11 +42,11 @@ export function lookupComponent(
   name: string,
   options?: { source?: string }
 ): {
-  layout: Template<OwnedTemplateMeta> | undefined;
+  layout: TemplateFactory | undefined;
   component: Factory<any, any> | undefined;
 };
 
-export function lookupPartial(templateName: string, owner: Owner): any;
+export function lookupPartial(templateName: string, owner: Owner): TemplateFactory;
 
 export function getViewId(view: any): string;
 

--- a/packages/@ember/application/tests/application_test.js
+++ b/packages/@ember/application/tests/application_test.js
@@ -207,7 +207,6 @@ moduleFor(
       verifyRegistration(assert, application, P`template:components/-default`);
       verifyRegistration(assert, application, 'template:-outlet');
       verifyInjection(assert, application, 'view:-outlet', 'template', 'template:-outlet');
-      verifyInjection(assert, application, 'template', 'compiler', P`template-compiler:main`);
 
       assert.deepEqual(
         application.registeredOptionsForType('helper'),

--- a/packages/@ember/engine/tests/engine_test.js
+++ b/packages/@ember/engine/tests/engine_test.js
@@ -117,7 +117,6 @@ moduleFor(
       verifyRegistration(assert, engine, P`template:components/-default`);
       verifyRegistration(assert, engine, 'template:-outlet');
       verifyInjection(assert, engine, 'view:-outlet', 'template', 'template:-outlet');
-      verifyInjection(assert, engine, 'template', 'compiler', P`template-compiler:main`);
       assert.deepEqual(
         engine.registeredOptionsForType('helper'),
         { instantiate: false },

--- a/tests/node/helpers/setup-component.js
+++ b/tests/node/helpers/setup-component.js
@@ -8,8 +8,6 @@ var distPath = path.join(__dirname, '../../../dist');
 var emberPath = path.join(distPath, 'ember.debug');
 var templateCompilerPath = path.join(distPath, 'ember-template-compiler');
 
-var templateId;
-
 function clearEmber() {
   delete global.Ember;
 
@@ -66,7 +64,7 @@ function setupComponentTest() {
 
   this._hasRendered = false;
   let OutletView = module.owner.factoryFor('view:-outlet');
-  var OutletTemplate = module.owner.lookup('template:-outlet');
+  var outletTemplateFactory = module.owner.lookup('template:-outlet');
   module.component = OutletView.create();
   this._outletState = {
     render: {
@@ -75,13 +73,11 @@ function setupComponentTest() {
       outlet: 'main',
       name: 'application',
       controller: module,
-      template: OutletTemplate,
+      template: outletTemplateFactory(module.owner),
     },
 
     outlets: {},
   };
-
-  templateId = 0;
 
   this.run(function() {
     module.component.setOutletState(module._outletState);
@@ -98,17 +94,15 @@ function setupComponentTest() {
 
 function render(_template) {
   var module = this;
-  var template = this.compile(_template);
+  var templateFactory = this.compile(_template);
 
-  var templateFullName = 'template:-undertest-' + ++templateId;
-  this.owner.register(templateFullName, template);
   var stateToRender = {
     owner: this.owner,
     into: undefined,
     outlet: 'main',
     name: 'index',
     controller: this,
-    template: this.owner.lookup(templateFullName),
+    template: templateFactory(this.owner),
   };
 
   stateToRender.name = 'index';


### PR DESCRIPTION
Per [RFC #481](https://github.com/emberjs/rfcs/pull/481), we want to align the factory signature between templates and component managers. Since the factories for component managers are just a function that takes the owner, we decided to move template factories in the same direction here as well.