### PR TITLE
don't register `(query-params)` when angle-brackets enabled

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -863,17 +863,6 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_BUILT_INS) {
             this.query === UNDEFINED
           )
         );
-
-        if (DEBUG && this.query === UNDEFINED) {
-          let { _models: models } = this;
-          let lastModel = models.length > 0 && models[models.length - 1];
-
-          assert(
-            'The `(query-params)` helper can only be used when invoking the `{{link-to}}` component.',
-            !(lastModel && lastModel.isQueryParams)
-          );
-        }
-
         return;
       }
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-curly-test.js
@@ -1,7 +1,6 @@
 import Controller from '@ember/controller';
 import { RSVP } from '@ember/-internals/runtime';
 import { Route } from '@ember/-internals/routing';
-import { DEBUG } from '@glimmer/env';
 import {
   ApplicationTestCase,
   classes as classMatcher,
@@ -76,9 +75,7 @@ moduleFor(
         `{{#let (query-params foo='456' bar='NAW') as |qp|}}{{link-to 'Index' 'index' qp}}{{/let}}`
       );
 
-      // TODO If we visit this page at all in production mode, it'll fail for
-      // entirely different reasons than what this test is trying to test.
-      let promise = DEBUG ? this.visit('/') : null;
+      let promise = this.visit('/');
 
       await assert.rejectsAssertion(
         promise,

--- a/packages/@ember/-internals/routing/index.ts
+++ b/packages/@ember/-internals/routing/index.ts
@@ -15,7 +15,6 @@ export { default as controllerFor } from './lib/system/controller_for';
 export { default as RouterDSL } from './lib/system/dsl';
 export { default as Router } from './lib/system/router';
 export { default as Route } from './lib/system/route';
-export { default as QueryParams } from './lib/system/query_params';
 export { default as RoutingService } from './lib/services/routing';
 export { default as RouterService } from './lib/services/router';
 export { default as BucketCache } from './lib/system/cache';

--- a/packages/@ember/-internals/routing/lib/system/query_params.ts
+++ b/packages/@ember/-internals/routing/lib/system/query_params.ts
@@ -1,7 +1,0 @@
-export default class QueryParams {
-  values: null | object;
-  isQueryParams = true;
-  constructor(values = null) {
-    this.values = values;
-  }
-}


### PR DESCRIPTION
when `EMBER_GLIMMER_ANGLE_BRACKET_BUILT_INS ` enabled there is no need for `(query-params)` since it is being transformed to `@query={{hash ....}}` when correctly used, if not correctly used it throw assertion