### PR TITLE
Add failing test for forwarding element modifiers (execution order not affected by splattributes' location)

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
@@ -1494,6 +1494,60 @@ if (EMBER_GLIMMER_FORWARD_MODIFIERS_WITH_SPLATTRIBUTES) {
           'Modifiers are called on all levels'
         );
       }
+
+      '@test angle bracket invocation can forward element modifiers and are attached in the specified order'(
+        assert
+      ) {
+        let eventInvocations = [];
+        this.registerComponent('default-first', {
+          ComponentClass: Component.extend({
+            tagName: '',
+            defaultHanlder() {
+              eventInvocations.push('defaultHandler');
+            },
+          }),
+          template:
+            '<div id="default-first" {{on "click" this.defaultHanlder}} ...attributes>{{yield}}</div>',
+        });
+        this.registerComponent('default-last', {
+          ComponentClass: Component.extend({
+            tagName: '',
+            defaultHanlder() {
+              eventInvocations.push('defaultHandler');
+            },
+          }),
+          template:
+            '<div id="default-last" ...attributes {{on "click" this.defaultHanlder}}>{{yield}}</div>',
+        });
+        this.registerComponent('the-foo', {
+          ComponentClass: Component.extend({
+            tagName: '',
+            customHandler() {
+              eventInvocations.push('customHandler');
+            },
+          }),
+          template: `
+            <DefaultFirst {{on "click" this.customHandler}}>Hello</DefaultFirst>
+            <DefaultLast {{on "click" this.customHandler}}>Hello</DefaultLast>
+          `,
+        });
+        this.render(`<TheFoo />`);
+        let event = new window.MouseEvent('click', { cancelable: true, bubbles: true });
+        this.element.querySelector('#default-first').dispatchEvent(event);
+        assert.deepEqual(
+          eventInvocations,
+          ['defaultHandler', 'customHandler'],
+          'When splattributes are after the modifier, the outer even runs last'
+        );
+        eventInvocations = [];
+        event = new window.MouseEvent('click', { cancelable: true, bubbles: true });
+        this.element.querySelector('#default-last').dispatchEvent(event);
+        assert.deepEqual(
+          eventInvocations,
+          ['customHandler', 'defaultHandler'],
+          'When splattributes are before the modifier, the outer even runs first'
+        );
+      }
     }
   );
 }


### PR DESCRIPTION
Now that element modifiers are forwarded with the splattibutes, I was expecting to be able to decide in my components if my event handlers run before or after those provided by the users.

Example:
```hbs
{{!-- my-component.hbs --}}
<div {{on "click" this.defaultHandler}} ...attributes>hello</div>
```
```hbs
<MyComponent {{on "click" this.userProvidedHandler}} />
```

In this scenario I'd expect `this.defaultHandler` to always be called first, because the user-provided handler is applied with the `...attributes` AFTER.

In this other scenario however:
```hbs
{{!-- my-component.hbs --}}
<div ...attributes {{on "click" this.defaultHandler}}>hello</div>
```
```hbs
<MyComponent {{on "click" this.userProvidedHandler}} />
```
I was expecting `this.userProvidedHandler` to be called first, and then `this.defaultHandler`, because the `...attributes` is placed before in the div element. 

Being able to decide the order of events is important to be able to call `event.stopImmediatePropagation()` and reliably know what handlers will not run.

That doesn't seem to be the case. Right regardless of where the `...attributes` is placed, the user-provided event is invoked first.