### PR TITLE
Fix issues with the recent template factory refactor and @ember/test-helpers v1.6.0

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/component-managers/curly.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/curly.ts
@@ -37,7 +37,7 @@ import { BOUNDS, DIRTY_TAG, HAS_BLOCK, IS_DISPATCHING_ATTRS, ROOT_REF } from '..
 import Environment from '../environment';
 import { DynamicScope } from '../renderer';
 import RuntimeResolver from '../resolver';
-import { Factory as TemplateFactory, OwnedTemplate } from '../template';
+import { Factory as TemplateFactory, isTemplateFactory, OwnedTemplate } from '../template';
 import {
   AttributeBinding,
   ClassNameBinding,
@@ -59,10 +59,6 @@ function aliasIdToElementId(args: Arguments, props: any) {
     );
     props.elementId = props.id;
   }
-}
-
-function isTemplateFactory(template: OwnedTemplate | TemplateFactory): template is TemplateFactory {
-  return typeof template === 'function';
 }
 
 // We must traverse the attributeBindings in reverse keeping track of

--- a/packages/@ember/-internals/glimmer/lib/syntax/outlet.ts
+++ b/packages/@ember/-internals/glimmer/lib/syntax/outlet.ts
@@ -12,6 +12,7 @@ import {
 import * as WireFormat from '@glimmer/wire-format';
 import { OutletComponentDefinition, OutletDefinitionState } from '../component-managers/outlet';
 import { DynamicScope } from '../renderer';
+import { isTemplateFactory } from '../template';
 import { OutletReference, OutletState } from '../utils/outlet';
 
 /**
@@ -124,6 +125,13 @@ function stateFor(
   if (render === undefined) return null;
   let template = render.template;
   if (template === undefined) return null;
+
+  // this guard can be removed once @ember/test-helpers@1.6.0 has "aged out"
+  // and is no longer considered supported
+  if (isTemplateFactory(template)) {
+    template = template(render.owner);
+  }
+
   return {
     ref,
     name: render.name,

--- a/packages/@ember/-internals/glimmer/lib/template.ts
+++ b/packages/@ember/-internals/glimmer/lib/template.ts
@@ -8,6 +8,10 @@ import { SerializedTemplateWithLazyBlock } from '@glimmer/wire-format';
 export type StaticTemplate = SerializedTemplateWithLazyBlock<StaticTemplateMeta>;
 export type OwnedTemplate = Template<OwnedTemplateMeta>;
 
+export function isTemplateFactory(template: OwnedTemplate | Factory): template is Factory {
+  return typeof template === 'function';
+}
+
 export function id(factory: Factory): string {
   return factory.__id;
 }

--- a/packages/@ember/-internals/glimmer/lib/utils/outlet.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/outlet.ts
@@ -1,7 +1,7 @@
 import { Owner } from '@ember/-internals/owner';
 import { Opaque } from '@glimmer/interfaces';
 import { combine, DirtyableTag, Reference, Tag, VersionedPathReference } from '@glimmer/reference';
-import { OwnedTemplate } from '../template';
+import { Factory as TemplateFactory, OwnedTemplate } from '../template';
 
 export interface RenderState {
   /**
@@ -34,7 +34,7 @@ export interface RenderState {
   /**
    * template (the layout of the outlet component)
    */
-  template: OwnedTemplate | undefined;
+  template: OwnedTemplate | TemplateFactory | undefined;
 }
 
 export interface Outlets {

--- a/packages/ember/tests/ember-test-helpers-test.js
+++ b/packages/ember/tests/ember-test-helpers-test.js
@@ -1,0 +1,131 @@
+import { Promise } from 'rsvp';
+import Application from '@ember/application';
+import { run, hasScheduledTimers, getCurrentRunLoop } from '@ember/runloop';
+import { compile } from 'ember-template-compiler';
+
+const { module, test } = QUnit;
+
+/*
+  This test file is intended to emulate what @ember/test-helpers does, and
+  should be considered a "smoke test" of when a given change will break
+  existing versions of @ember/test-helpers.
+
+  This generally means that we will have to represent multiple versions of
+  `@ember/test-helpers` here (will make a nested module for each significant
+  revision).
+*/
+module('@ember/test-helpers emulation test', function() {
+  module('v1.6.0', function() {
+    let EMPTY_TEMPLATE = compile('');
+
+    function settled() {
+      return new Promise(function(resolve) {
+        let watcher = setInterval(() => {
+          if (getCurrentRunLoop() || hasScheduledTimers()) {
+            return;
+          }
+
+          // Stop polling
+          clearInterval(watcher);
+
+          // Synchronously resolve the promise
+          run(null, resolve);
+        }, 10);
+      });
+    }
+
+    async function setupContext(context) {
+      // condensed version of https://github.com/emberjs/ember-test-helpers/blob/v1.6.0/addon-test-support/%40ember/test-helpers/build-owner.ts#L38
+      // without support for "custom resolver"
+      await context.application.boot();
+
+      context.owner = await context.application.buildInstance().boot();
+    }
+
+    function setupRenderingContext(context) {
+      let { owner } = context;
+      let OutletView = owner.factoryFor('view:-outlet');
+      let toplevelView = OutletView.create();
+
+      owner.register('-top-level-view:main', {
+        create() {
+          return toplevelView;
+        },
+      });
+
+      // initially render a simple empty template
+      return render(EMPTY_TEMPLATE, context).then(() => {
+        let rootElement = document.querySelector(owner.rootElement);
+        run(toplevelView, 'appendTo', rootElement);
+
+        context.element = rootElement;
+
+        return settled();
+      });
+    }
+
+    let templateId = 0;
+    function render(template, context) {
+      let { owner } = context;
+      let toplevelView = owner.lookup('-top-level-view:main');
+      let OutletTemplate = owner.lookup('template:-outlet');
+      templateId += 1;
+      let templateFullName = `template:-undertest-${templateId}`;
+      owner.register(templateFullName, template);
+
+      let outletState = {
+        render: {
+          owner,
+          into: undefined,
+          outlet: 'main',
+          name: 'application',
+          controller: undefined,
+          ViewClass: undefined,
+          template: OutletTemplate,
+        },
+
+        outlets: {
+          main: {
+            render: {
+              owner,
+              into: undefined,
+              outlet: 'main',
+              name: 'index',
+              controller: context,
+              ViewClass: undefined,
+              template: owner.lookup(templateFullName),
+              outlets: {},
+            },
+            outlets: {},
+          },
+        },
+      };
+      toplevelView.setOutletState(outletState);
+
+      return settled();
+    }
+
+    module('setupRenderingContext', function(hooks) {
+      hooks.beforeEach(async function() {
+        this.application = Application.create({
+          rootElement: '#qunit-fixture',
+          autoboot: false,
+        });
+
+        await setupContext(this);
+        await setupRenderingContext(this);
+      });
+
+      hooks.afterEach(function() {
+        run(this.owner, 'destroy');
+        run(this.application, 'destroy');
+      });
+
+      test('it basically works', async function(assert) {
+        await render(compile('Hi!'), this);
+
+        assert.equal(this.element.textContent, 'Hi!');
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR does two main things:

* Adds a smoke test that emulates what `@ember/test-helpers@1.6.0` does for `setupRenderingTest` type of tests
* Fixes issues within the `{{outlet}}` component manager when the result of `owner.lookup` is passed directly into the outlet state (which is what `@ember/test-helpers` has done for most of the 1.x series)

I do _personally_ think the fix/workaround is "fine" to leave in for quite some time, but it can be removed after `@ember/test-helpers@1.6.0` is "aged out" and no longer supported.