### PR TITLE
Correct property name in @union cp example

### DIFF
--- a/packages/@ember/object/lib/computed/reduce_computed_macros.js
+++ b/packages/@ember/object/lib/computed/reduce_computed_macros.js
@@ -948,7 +948,7 @@ export function uniqBy(dependentKey, propertyKey) {
       set(this, 'vegetables', vegetables);
     }
 
-    @union('fruits', 'vegetables') ediblePlants;
+    @union('fruits', 'vegetables') uniqueFruits;
   });
 
   let hamster = new, Hamster(


### PR DESCRIPTION
The example usage of `@union` defines `ediblePlants` but uses `hamster.uniqueFruits` instead.

Change `ediblePlants` to `uniqueFruits`.