### PR TITLE
[DOC] fix missing backtick

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -136,7 +136,7 @@ export const BOUNDS = symbol('BOUNDS');
       if (title) {
         return `${title} ${lastName}`;
       } else {
-        return `${firstName} ${lastName};
+        return `${firstName} ${lastName}`;
       }
     })
   });


### PR DESCRIPTION
Here's a screenshot of before: 
<img width="707" alt="Screen Shot 2019-07-10 at 1 08 14 PM" src="https://user-images.githubusercontent.com/16627268/60989357-cd904100-a313-11e9-9912-cda52cd82410.png">
