### PR TITLE
Remove Duplicate/Confusing Filter Tests

### DIFF
--- a/packages/@ember/-internals/runtime/tests/array/filter-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/filter-test.js
@@ -21,17 +21,6 @@ class FilterTest extends AbstractTestCase {
 }
 
 class FilterByTest extends AbstractTestCase {
-  '@test should filter based on object'() {
-    let obj, ary;
-
-    ary = [{ foo: 'foo', bar: 'BAZ' }, EmberObject.create({ foo: 'foo', bar: 'bar' })];
-
-    obj = this.newObject(ary);
-
-    this.assert.deepEqual(obj.filterBy('foo', 'foo'), ary, 'filterBy(foo)');
-    this.assert.deepEqual(obj.filterBy('bar', 'bar'), [ary[1]], 'filterBy(bar)');
-  }
-
   '@test should include in result if property is true'() {
     let obj, ary;
 
@@ -72,16 +61,6 @@ class FilterByTest extends AbstractTestCase {
     obj = this.newObject(ary);
 
     this.assert.deepEqual(obj.filterBy('foo', null), [ary[1], ary[2]], "filterBy('foo', 3)')");
-  }
-
-  '@test should not return all objects on undefined second argument'() {
-    let obj, ary;
-
-    ary = [{ name: 'obj1', foo: 3 }, EmberObject.create({ name: 'obj2', foo: 2 })];
-
-    obj = this.newObject(ary);
-
-    this.assert.deepEqual(obj.filterBy('foo', undefined), [], "filterBy('foo', 3)')");
   }
 
   '@test should correctly filter explicit undefined second argument'() {


### PR DESCRIPTION
The two tests removed duplicate functionality more extensively tested by other tests in this suite. Specifically:

`@test should filter based on object` - This tests the same behavior as `@test should filter on second argument if provided`, but against a smaller array. 
`@test should not return all objects on undefined second argument` - This tests the same behavior as `@test should correctly filter explicit undefined second argument`, but against an array where no objects have an explicit `undefined` value for that key. The second test correctly asserts that defined values should be filtered out *and* that explicit undefined values should be kept, making the first test unnecessary.