### PR TITLE
[BUGFIX] Adds ability for computed props to depend on args 

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
@@ -485,6 +485,68 @@ if (EMBER_METAL_TRACKED_PROPERTIES) {
           assert.equal(outerRenderCount, 2, 'outer component updates based on context');
           assert.equal(innerRenderCount, 3, 'inner component updates based on outer component');
         }
+
+        '@test computed properties can depend on args'() {
+          class TestComponent extends GlimmerishComponent {
+            @computed('args.text')
+            get text() {
+              return this.args.text;
+            }
+          }
+
+          this.registerComponent('test', {
+            ComponentClass: TestComponent,
+            template: '<p>{{this.text}}</p>',
+          });
+
+          this.render('<Test @text={{this.text}}/>', {
+            text: 'hello!',
+          });
+
+          this.assertText('hello!');
+
+          runTask(() => this.context.set('text', 'hello world!'));
+          this.assertText('hello world!');
+
+          runTask(() => this.context.set('text', 'hello!'));
+          this.assertText('hello!');
+        }
+
+        '@test named args are enumerable'() {
+          class TestComponent extends GlimmerishComponent {
+            get objectKeys() {
+              return Object.keys(this.args).join('');
+            }
+
+            get hasArg() {
+              return 'text' in this.args;
+            }
+          }
+
+          this.registerComponent('test', {
+            ComponentClass: TestComponent,
+            template: '<p>{{this.objectKeys}} {{this.hasArg}}</p>',
+          });
+
+          this.render('<Test @text={{this.text}}/>', {
+            text: 'hello!',
+          });
+
+          this.assertText('text true');
+        }
+
+        '@test each-in works with args'() {
+          this.registerComponent('test', {
+            ComponentClass: class extends GlimmerishComponent {},
+            template: '{{#each-in this.args as |key value|}}{{key}}:{{value}}{{/each-in}}',
+          });
+
+          this.render('<Test @text={{this.text}}/>', {
+            text: 'hello!',
+          });
+
+          this.assertText('text:hello!');
+        }
       }
     );
   }

--- a/packages/@ember/-internals/metal/index.ts
+++ b/packages/@ember/-internals/metal/index.ts
@@ -48,7 +48,7 @@ export {
 } from './lib/descriptor_map';
 export { watchKey, unwatchKey } from './lib/watch_key';
 export { ChainNode, finishChains, removeChainWatcher } from './lib/chains';
-export { getChainTagsForKey } from './lib/chain-tags';
+export { getChainTagsForKey, ARGS_PROXY_TAGS } from './lib/chain-tags';
 export { watchPath, unwatchPath } from './lib/watch_path';
 export { isWatching, unwatch, watch, watcherCount } from './lib/watching';
 export { default as libraries, Libraries } from './lib/libraries';


### PR DESCRIPTION
This PR adds the ability for computed properties and observers to watch
`args` on custom components. Currently this does not work because the
`args` object is not a standard object, but a proxy that forwards
property access to the `CapturedNamedArgs` instance for the component,
and consumes its tag for autotracking.

CPs currently ignore autotracking, and have to depend on `args` manually
via the `chainTags` system. In the first attempt to support this we used
the `UNKNOWN_PROPERTY_TAG` API, but that actually doesn't work for this
case because these _aren't_ unknown properties, they do "exist" on the
proxy and should be enumerable.

Rather than adding another general API to the `tagForProperty` function,
I opted to add some special logic to the `chainTags` crawler, similar to
what we do for `@each`. When the chain is looking up `args` as its
segment, it'll also check to see if the value is an args proxy, and if
so it'll use the (saved) CapturedNamedArgs directly. This check should
be low overhead since it's a string comparison, and only applies to CPs
and observers rather than _all_ code (compared to adding it to
`tagForProperty`, which would affect new code as well).