### PR TITLE
[BUGFIX] Matches assertion behavior for CPs computing after destroy

### DIFF
--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -541,6 +541,8 @@ export class ComputedProperty extends ComputedDescriptor {
     let ret;
 
     if (EMBER_METAL_TRACKED_PROPERTIES) {
+      // For backwards compatibility, we only throw if the CP has any dependencies. CPs without dependencies
+      // should be allowed, even after the object has been destroyed, which is why we check _dependentKeys.
       assert(
         `Attempted to access the computed ${obj}.${keyName} on a destroyed object, which is not allowed`,
         this._dependentKeys === undefined || !metaFor(obj).isMetaDestroyed()

--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -543,7 +543,7 @@ export class ComputedProperty extends ComputedDescriptor {
     if (EMBER_METAL_TRACKED_PROPERTIES) {
       assert(
         `Attempted to access the computed ${obj}.${keyName} on a destroyed object, which is not allowed`,
-        !metaFor(obj).isMetaDestroyed()
+        this._dependentKeys === undefined || !metaFor(obj).isMetaDestroyed()
       );
 
       // Create a tracker that absorbs any trackable actions inside the CP

--- a/packages/@ember/-internals/metal/tests/computed_test.js
+++ b/packages/@ember/-internals/metal/tests/computed_test.js
@@ -604,6 +604,23 @@ moduleFor(
 
       expectAssertion(() => get(obj, 'foo'), message);
     }
+
+    ['@test does not throw an assertion if an uncached `get` is called on computed without dependencies after object is destroyed'](
+      assert
+    ) {
+      let meta = metaFor(obj);
+      defineProperty(
+        obj,
+        'foo',
+        computed(function() {
+          return 'baz';
+        })
+      );
+
+      meta.destroy();
+
+      assert.equal(get(obj, 'foo'), 'baz', 'CP calculated successfully');
+    }
   }
 );
 


### PR DESCRIPTION
Previously, there was an assertion that threw whenever a CP was
calculated after destroy, _and_ updated its dependent keys (i.e.
updated chains). This meant that CPs without any dependencies would
still run after destroy, and everything would work. The new assertion
always threw if anyone accessed _any_ CP. This changes it to only throw
if the CP has dependencies, matching the old behavior.