### PR TITLE
[BUGFIX beta] Fix routing path with double slash

### DIFF
--- a/packages/@ember/-internals/routing/lib/location/history_location.ts
+++ b/packages/@ember/-internals/routing/lib/location/history_location.ts
@@ -129,7 +129,7 @@ export default class HistoryLocation extends EmberObject implements EmberLocatio
     let url = path
       .replace(new RegExp(`^${baseURL}(?=/|$)`), '')
       .replace(new RegExp(`^${rootURL}(?=/|$)`), '')
-      .replace(/\/\/$/g, '/'); // remove extra slashes
+      .replace(/\/\//g, '/'); // remove extra slashes
 
     let search = location.search || '';
     url += search + this.getHash();

--- a/packages/@ember/-internals/routing/tests/location/history_location_test.js
+++ b/packages/@ember/-internals/routing/tests/location/history_location_test.js
@@ -288,15 +288,15 @@ moduleFor(
       HistoryTestLocation.reopen({
         init() {
           this._super(...arguments);
-          let location = mockBrowserLocation('//');
-          location.pathname = '//'; // mockBrowserLocation does not allow for `//`, so force it
+          let location = mockBrowserLocation('//admin//profile//');
+          location.pathname = '//admin//profile//'; // mockBrowserLocation does not allow for `//`, so force it
           set(this, 'location', location);
         },
       });
 
       createLocation();
 
-      assert.equal(location.getURL(), '/');
+      assert.equal(location.getURL(), '/admin/profile/');
     }
 
     ['@test Existing state is preserved on init'](assert) {


### PR DESCRIPTION
Fix: https://github.com/emberjs/ember.js/issues/14925

When a user is accessing a path followed by `//` eg. `http://localhost:4200//admin/profile` the browser is raising the following error:
```
Failed to execute 'replaceState' on 'History': A history state object with URL 'http://admin/profile' cannot be created in a document with origin 'http://localhost:4200' and URL 'http://localhost:4200//admin/profile'.
```

This PR fixes by replacing any `//` in the URL path to `/`.