### PR TITLE
[BUGFIX lts] Router service: Failing with query parameters on application controller

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -1063,7 +1063,10 @@ class EmberRouter extends EmberObject {
               return true;
             }
 
-            if (_fromRouterService && presentProp !== false) {
+            if (_fromRouterService && presentProp !== false && qp.urlKey != qp.prop) {
+              // assumptions (mainly from current transitionTo_test):
+              // - this is only supposed to be run when there is an alias to a query param and the alias is used to set the param
+              // - when there is no alias: qp.urlKey == qp.prop
               return false;
             }
 

--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -1063,7 +1063,7 @@ class EmberRouter extends EmberObject {
               return true;
             }
 
-            if (_fromRouterService && presentProp !== false && qp.urlKey != qp.prop) {
+            if (_fromRouterService && presentProp !== false && qp.urlKey !== qp.prop) {
               // assumptions (mainly from current transitionTo_test):
               // - this is only supposed to be run when there is an alias to a query param and the alias is used to set the param
               // - when there is no alias: qp.urlKey == qp.prop

--- a/packages/ember/tests/routing/router_service_test/transitionTo_test.js
+++ b/packages/ember/tests/routing/router_service_test/transitionTo_test.js
@@ -6,6 +6,7 @@ import { run } from '@ember/runloop';
 import { get } from '@ember/-internals/metal';
 import { RouterTestCase, moduleFor } from 'internal-test-helpers';
 import { InternalTransition as Transition } from 'router_js';
+import { inject as service } from '@ember/service';
 
 moduleFor(
   'Router Service - transitionTo',
@@ -360,6 +361,32 @@ moduleFor(
         expectAssertion(() => {
           return this.routerService.transitionTo('parent.child', queryParams);
         }, 'You passed the `cont_sort` query parameter during a transition into parent.child, please update to url_sort');
+      });
+    }
+
+    ['@test RouterService#transitionTo with application query params when redirecting form a different route'](
+      assert
+    ) {
+      assert.expect(1);
+
+      this.add(
+        'route:parent.child',
+        Route.extend({
+          router: service(),
+          beforeModel() {
+            this.router.transitionTo('parent');
+          },
+        })
+      );
+      this.add(
+        'controller:parent',
+        Controller.extend({
+          queryParams: ['url_sort'],
+        })
+      );
+
+      return this.visit('/child?url_sort=a').then(() => {
+        assert.equal(this.routerService.get('currentURL'), '/?url_sort=a');
       });
     }
   }


### PR DESCRIPTION
This PR should fix #16594 where an ember application would break when there is a query param on a parent route and another transition is triggered (for instance a redirect to a login page).

❗️ This PR should be reviewed by someone who is familiar with the details of the routing implementation

Additionally we probably should think about refactoring the `_hydrateUnsuppliedQueryParams` implementation, as I found it very difficult to figure out what the exact intent of this method and its assertions are. And I just added another conditional in trying to fix this, which makes things just a little worse.

Furthermore, my changes are based on assumptions I drew from current tests, which are:

- the assertion should only be triggered when there are aliases to query params
- when there is no alias: qp.urlKey == qp.prop

In case these assumptions are correct, I think we should clarify the message of the assertion. In case you run into this assertion the message does not make it very clear what actually is going on. And you find yourself in a sort of vacuum very quickly, where there are very, very little resources available that would help to figure things out.
