### PR TITLE
[BUGFIX beta] Adds Component Manager 3.13 Capabilities

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/component-managers/custom.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/custom.ts
@@ -47,13 +47,21 @@ export interface OptionalCapabilities {
   updateHook?: boolean;
 }
 
-export function capabilities(managerAPI: '3.4', options: OptionalCapabilities = {}): Capabilities {
-  assert('Invalid component manager compatibility specified', managerAPI === '3.4');
+type managerAPIVersion = '3.4' | '3.13';
+
+export function capabilities(
+  managerAPI: managerAPIVersion,
+  options: OptionalCapabilities = {}
+): Capabilities {
+  assert(
+    'Invalid component manager compatibility specified',
+    managerAPI === '3.4' || managerAPI === '3.13'
+  );
 
   let updateHook = true;
 
   if (EMBER_CUSTOM_COMPONENT_ARG_PROXY) {
-    updateHook = 'updateHook' in options ? Boolean(options.updateHook) : true;
+    updateHook = managerAPI === '3.13' ? Boolean(options.updateHook) : true;
   }
 
   return {

--- a/packages/@ember/-internals/glimmer/tests/utils/glimmerish-component.js
+++ b/packages/@ember/-internals/glimmer/tests/utils/glimmerish-component.js
@@ -3,7 +3,7 @@ import { setOwner } from '@ember/-internals/owner';
 
 class GlimmerishComponentManager {
   constructor(owner) {
-    this.capabilities = capabilities('3.4', { updateHook: false });
+    this.capabilities = capabilities('3.13', { updateHook: false });
     this.owner = owner;
   }
 


### PR DESCRIPTION
Adds 3.13 component manager capabilities, which adds the ability to
enable/disable the `updateHook` for a component.

Forgot to tag this correctly, so I'm submitting directly to make sure we don't forget.