### PR TITLE
[DOC beta] Octanify documentation

### DIFF
--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -128,14 +128,14 @@
   template, an optional block passed to the component should render:
 
   ```app/templates/application.hbs
-  {{#labeled-textfield value=someProperty}}
+  <LabeledTextfield @value={{@model.name}}>
     First name:
-  {{/labeled-textfield}}
+  </LabeledTextfield>
   ```
 
-  ```app/templates/components/labeled-textfield.hbs
+  ```app/components/labeled-textfield.hbs
   <label>
-    {{yield}} {{input value=value}}
+    {{yield}} <Input @value={{value}} />
   </label>
   ```
 
@@ -150,7 +150,7 @@
   Additionally you can `yield` properties into the context for use by the consumer:
 
   ```app/templates/application.hbs
-  {{#labeled-textfield value=someProperty validator=(action 'firstNameValidator') as |validationError|}}
+  <LabeledTextfield @value={{@model.validation}} @validator={{this.firstNameValidator}} as |validationError|>
     {{#if validationError}}
       <p class="error">{{validationError}}</p>
     {{/if}}
@@ -160,7 +160,7 @@
 
   ```app/templates/components/labeled-textfield.hbs
   <label>
-    {{yield validationError}} {{input value=value}}
+    {{yield this.validationError}} <Input @value={{value}} />
   </label>
   ```
 

--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -96,11 +96,11 @@
   If the aliased property is "falsey", for example: `false`, `undefined` `null`, `""`, `0`, `NaN` or
   an empty array, the block will not be rendered.
 
-  ```handlebars
+  ```app/templates/application.hbs
   {{! Will only render if user.posts contains items}}
-  {{#with user.posts as |blogPosts|}}
+  {{#with @model.posts as |blogPosts|}}
     <div class="notice">
-      There are {{blogPosts.length}} blog posts written by {{user.name}}.
+      There are {{blogPosts.length}} blog posts written by {{@model.name}}.
     </div>
     {{#each blogPosts as |post|}}
       <li>{{post.title}}</li>
@@ -108,9 +108,7 @@
   {{/with}}
   ```
 
-  NOTE: The alias should not reuse a name from the bound property path.
-
-  For example: `{{#with foo.bar as |foo|}}` is not supported because it attempts to alias using
+  Note that `{{#with foo.bar as |foo|}}` is not supported because it attempts to alias using
   the first part of the property path, `foo`. Instead, use `{{#with foo.bar as |baz|}}`.
 
   @method with

--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -1052,8 +1052,13 @@ const Component = CoreView.extend(
       Returns a jQuery object for this component's element. If you pass in a selector
       string, this method will return a jQuery object, using the current element
       as its buffer.
+
       For example, calling `component.$('li')` will return a jQuery object containing
       all of the `li` elements inside the DOM element of this component.
+
+      Please note that jQuery integration is off by default and this feature will
+      not work properly. To enable this feature, you can read the instructions in
+      the [jquery-integration optional feature guide](https://guides.emberjs.com/release/configuring-ember/optional-features/#toc_jquery-integration).
       @method $
       @param {String} [selector] a jQuery-compatible selector string
       @return {jQuery} the jQuery object for the DOM node

--- a/packages/@ember/-internals/glimmer/lib/components/textarea.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/textarea.ts
@@ -34,7 +34,7 @@ import layout from '../templates/empty';
   import Component from '@glimmer/component';
   import { tracked } from '@glimmer/tracking';
 
-  export default class extends Component {
+  export default class WordEditorComponent extends Component {
     @tracked writtenWords = "Lots of text that IS bound";
   }
   ```

--- a/packages/@ember/-internals/glimmer/lib/helper.ts
+++ b/packages/@ember/-internals/glimmer/lib/helper.ts
@@ -46,16 +46,20 @@ export function isSimpleHelper(helper: SimpleHelper | HelperInstance): helper is
   Ember Helpers are functions that can compute values, and are used in templates.
   For example, this code calls a helper named `format-currency`:
 
-  ```handlebars
-  <div>{{format-currency cents currency="$"}}</div>
+  ```app/templates/application.hbs
+  <Cost @cents={{230}} />
   ```
 
-  Additionally a helper can be called as a nested helper (sometimes called a
-  subexpression). In this example, the computed value of a helper is passed
-  to a component named `show-money`:
+  ```app/components/cost.hbs
+  <div>{{format-currency @cents currency="$"}}</div>
+  ```
+
+  Additionally a helper can be called as a nested helper.
+  In this example, we show the formatted currency value if the `showMoney`
+  named argument is truthy.
 
   ```handlebars
-  {{show-money amount=(format-currency cents currency="$")}}
+  {{if @showMoney (format-currency @cents currency="$")}}
   ```
 
   Helpers defined using a class must provide a `compute` function. For example:
@@ -63,11 +67,11 @@ export function isSimpleHelper(helper: SimpleHelper | HelperInstance): helper is
   ```app/helpers/format-currency.js
   import Helper from '@ember/component/helper';
 
-  export default Helper.extend({
+  export default class extends Helper {
     compute([cents], { currency }) {
       return `${currency}${cents * 0.01}`;
     }
-  });
+  }
   ```
 
   Each time the input to a helper changes, the `compute` function will be
@@ -100,13 +104,16 @@ let Helper = FrameworkObject.extend({
     import { inject as service } from '@ember/service'
     import { observer } from '@ember/object'
 
-    export default Helper.extend({
-      session: service(),
-      onNewUser: observer('session.currentUser', function() {
+    export default class extends Helper {
+      @service session;
+
+      @observer('session.currentUser)
+      onNewUser() {
         this.recompute();
       }),
+
       compute() {
-        return this.get('session.currentUser.email');
+        return this.session.currentUser.email;
       }
     });
     ```
@@ -148,16 +155,14 @@ class Wrapper implements HelperFactory<SimpleHelper> {
 }
 
 /**
-  In many cases, the ceremony of a full `Helper` class is not required.
-  The `helper` method create pure-function helpers without instances. For
-  example:
+  In many cases it is not necessary to use the full `Helper` class.
+  The `helper` method create pure-function helpers without instances.
+  For example:
 
   ```app/helpers/format-currency.js
   import { helper } from '@ember/component/helper';
 
-  export default helper(function(params, hash) {
-    let cents = params[0];
-    let currency = hash.currency;
+  export default helper(function([cents], {currency}) {
     return `${currency}${cents * 0.01}`;
   });
   ```

--- a/packages/@ember/-internals/glimmer/lib/helper.ts
+++ b/packages/@ember/-internals/glimmer/lib/helper.ts
@@ -67,7 +67,7 @@ export function isSimpleHelper(helper: SimpleHelper | HelperInstance): helper is
   ```app/helpers/format-currency.js
   import Helper from '@ember/component/helper';
 
-  export default class extends Helper {
+  export default class FormatCurrencyHelper extends Helper {
     compute([cents], { currency }) {
       return `${currency}${cents * 0.01}`;
     }
@@ -104,7 +104,7 @@ let Helper = FrameworkObject.extend({
     import { inject as service } from '@ember/service'
     import { observer } from '@ember/object'
 
-    export default class extends Helper {
+    export default class CurrentUserEmailHelper extends Helper {
       @service session;
 
       @observer('session.currentUser)

--- a/packages/@ember/-internals/glimmer/lib/helpers/action.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/action.ts
@@ -64,7 +64,7 @@ import { ACTION, INVOKE, UnboundReference } from '../utils/references';
   import Component from '@glimmer/component';
   import { action } from '@ember/object';
 
-  export default class extends Component {
+  export default class MyComponentComponent extends Component {
     @action
     save() {
       this.model.save();
@@ -96,7 +96,7 @@ import { ACTION, INVOKE, UnboundReference } from '../utils/references';
   import Component from '@glimmer/component';
   import { action } from '@ember/object';
 
-  export default class extends Component {
+  export default class UpdateNameComponent extends Component {
     @action
     setName(model, name) {
       model.set('name', name);
@@ -120,7 +120,7 @@ import { ACTION, INVOKE, UnboundReference } from '../utils/references';
   import Component from '@glimmer/component';
   import { action } from '@ember/object';
 
-  export default class extends Component {
+  export default class MyInputComponent extends Component {
     @action
     setName(model, name) {
       model.set('name', name);
@@ -265,7 +265,7 @@ import { ACTION, INVOKE, UnboundReference } from '../utils/references';
   import Controller from '@ember/controller';
   import { inject as service } from '@ember/service';
 
-  export default class extends Controller {
+  export default class ApplicationController extends Controller {
     @service someService;
   }
   ```

--- a/packages/@ember/-internals/glimmer/lib/helpers/action.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/action.ts
@@ -61,15 +61,15 @@ import { ACTION, INVOKE, UnboundReference } from '../utils/references';
   Here is an example action handler on a component:
 
   ```app/components/my-component.js
-  import Component from '@ember/component';
+  import Component from '@glimmer/component';
+  import { action } from '@ember/object';
 
-  export default Component.extend({
-    actions: {
-      save() {
-        this.get('model').save();
-      }
+  export default class extends Component {
+    @action
+    save() {
+      this.model.save();
     }
-  });
+  }
   ```
 
   Actions are always looked up on the `actions` property of the current context.
@@ -91,24 +91,24 @@ import { ACTION, INVOKE, UnboundReference } from '../utils/references';
   method. The first argument to `sendAction` is the action to be called, and
   additional arguments are passed to the action function. This has interesting
   properties combined with currying of arguments. For example:
+  
+  ```app/components/update-name.js
+  import Component from '@glimmer/component';
+  import { action } from '@ember/object';
 
-  ```app/templates/components/my-component.hbs
-  {{input on-input=(action (action 'setName' model) value="target.value")}}
-  ```
-
-  ```app/components/my-component.js
-  import Component from '@ember/component';
-
-  export default Component.extend({
-    actions: {
-      setName(model, name) {
-        model.set('name', name);
-      }
+  export default class extends Component {
+    @action
+    setName(model, name) {
+      model.set('name', name);
     }
-  });
+  }
   ```
 
-  The first argument (`model`) was curried over, and the run-time argument (`event`)
+  ```app/components/update-name.hbs
+  {{input on-input=(action (action 'setName' @model) value="target.value")}}
+  ```
+  
+  The first argument (`@model`) was curried over, and the run-time argument (`event`)
   becomes a second argument. Action calls can be nested this way because each simply
   returns a function. Any function can be passed to the `{{action}}` helper, including
   other actions.
@@ -117,23 +117,25 @@ import { ACTION, INVOKE, UnboundReference } from '../utils/references';
   with `on-input` above. For example:
 
   ```app/components/my-input.js
-  import Component from '@ember/component';
+  import Component from '@glimmer/component';
+  import { action } from '@ember/object';
 
-  export default Component.extend({
-    actions: {
-      setName(model, name) {
-        model.set('name', name);
-      }
+  export default class extends Component {
+    @action
+    setName(model, name) {
+      model.set('name', name);
     }
-  });
+  }
   ```
 
   ```handlebars
-  <MyInput @submit={{action 'setName' this.model}} />
+  <MyInput @submit={{action 'setName' @model}} />
   ```
+  
   or
+  
   ```handlebars
-  {{my-input submit=(action 'setName' model)}}
+  {{my-input submit=(action 'setName' @model)}}
   ```
 
   ```app/components/my-component.js
@@ -263,9 +265,9 @@ import { ACTION, INVOKE, UnboundReference } from '../utils/references';
   import Controller from '@ember/controller';
   import { inject as service } from '@ember/service';
 
-  export default Controller.extend({
-    someService: service()
-  });
+  export default class extends Controller {
+    @service someService;
+  }
   ```
 
   @method action

--- a/packages/@ember/-internals/glimmer/lib/helpers/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/component.ts
@@ -22,19 +22,15 @@
 
   ```app/controllers/application.js
   import Controller from '@ember/controller';
-  import { computed } from '@ember/object';
+  import { tracked } from '@glimmer/tracking';
 
-  export default Controller.extend({
-    infographicComponentName: computed('isMarketOpen', {
-      get() {
-        if (this.get('isMarketOpen')) {
-          return 'live-updating-chart';
-        } else {
-          return 'market-close-summary';
+  export default class ApplicationController extends Controller {
+    @tracked isMarketOpen = 'live-updating-chart'
+
+    get infographicComponentName() {
+      return this.isMarketOpen ? 'live-updating-chart' : 'market-close-summary';
         }
       }
-    })
-  });
   ```
 
   The `live-updating-chart` component will be appended when `isMarketOpen` is
@@ -68,22 +64,19 @@
   ```app/controllers/application.js
   import Controller from '@ember/controller';
   import { computed } from '@ember/object';
+  import { tracked } from '@glimmer/tracking';
 
-  export default Controller.extend({
-    lastUpdateTimestamp: computed(function() {
+  export default class ApplicationController extends Controller {
+    @tracked isMarketOpen = 'live-updating-chart'
+
+    get lastUpdateTimestamp() {
       return new Date();
-    }),
+    }
 
-    infographicComponentName: computed('isMarketOpen', {
-      get() {
-        if (this.get('isMarketOpen')) {
-          return 'live-updating-chart';
-        } else {
-          return 'market-close-summary';
-        }
-      }
-    })
-  });
+    get infographicComponentName() {
+      return this.isMarketOpen ? 'live-updating-chart' : 'market-close-summary';
+    }
+  }
   ```
 
   And the following component template:

--- a/packages/@ember/-internals/glimmer/lib/helpers/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/component.ts
@@ -15,7 +15,7 @@
   Given the following template:
 
   ```app/application.hbs
-  {{component infographicComponentName}}
+  {{component this.infographicComponentName}}
   ```
 
   And the following application code:
@@ -29,8 +29,8 @@
 
     get infographicComponentName() {
       return this.isMarketOpen ? 'live-updating-chart' : 'market-close-summary';
-        }
-      }
+    }
+  }
   ```
 
   The `live-updating-chart` component will be appended when `isMarketOpen` is
@@ -43,7 +43,9 @@
   ```app/templates/application.hbs
   <LiveUpdatingChart />
   ```
+
   or
+  
   ```app/templates/application.hbs
   {{live-updating-chart}}
   ```
@@ -54,8 +56,8 @@
   of a component. Given the following application template:
 
   ```app/templates/application.hbs
-  {{#component infographicComponentName}}
-    Last update: {{lastUpdateTimestamp}}
+  {{#component this.infographicComponentName}}
+    Last update: {{this.lastUpdateTimestamp}}
   {{/component}}
   ```
 
@@ -86,7 +88,7 @@
   {{yield}}
   ```
 
-  The `Last Update: {{lastUpdateTimestamp}}` will be rendered in place of the `{{yield}}`.
+  The `Last Update: {{this.lastUpdateTimestamp}}` will be rendered in place of the `{{yield}}`.
 
   ### Nested Usage
 
@@ -96,7 +98,7 @@
 
   ```app/templates/components/person-form.hbs
   {{yield (hash
-    nameInput=(component "my-input-component" value=model.name placeholder="First Name")
+    nameInput=(component "my-input-component" value=@model.name placeholder="First Name")
   )}}
   ```
 
@@ -123,7 +125,7 @@
   For example, below is a `full-name` component template:
 
   ```handlebars
-  {{yield (component "my-input-component" value=model.name placeholder="Name")}}
+  {{yield (component "my-input-component" value=@model.name placeholder="Name")}}
   ```
 
   ```

--- a/packages/@ember/-internals/glimmer/lib/helpers/each-in.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/each-in.ts
@@ -12,12 +12,16 @@ import { Opaque } from '@glimmer/util';
   The default behavior of `{{#each}}` is to yield its inner block once for every
   item in an array passing the item as the first block parameter.
 
-  ```javascript
-  var developers = [{ name: 'Yehuda' },{ name: 'Tom' }, { name: 'Paul' }];
+  ```app/components/developer-listing.js
+  import Component from '@glimmer/component';
+
+  export default class extends Component {
+    developers = [{ name: 'Yehuda' },{ name: 'Tom' }, { name: 'Paul' }];
+  }
   ```
 
-  ```handlebars
-  {{#each developers key="name" as |person|}}
+  ```app/components/developer-listing.hbs
+  {{#each this.developers key="name" as |person|}}
     {{person.name}}
     {{! `this` is whatever it was outside the #each }}
   {{/each}}
@@ -25,12 +29,16 @@ import { Opaque } from '@glimmer/util';
 
   The same rules apply to arrays of primitives.
 
-  ```javascript
-  var developerNames = ['Yehuda', 'Tom', 'Paul']
+  ```app/components/developer-listing.js
+  import Component from '@glimmer/component';
+
+  export default class extends Component {
+    developerNames = ['Yehuda', 'Tom', 'Paul']
+  }
   ```
 
-  ```handlebars
-  {{#each developerNames key="@index" as |name|}}
+  ```app/components/developer-listing.hbs
+  {{#each this.developerNames key="@index" as |name|}}
     {{name}}
   {{/each}}
   ```
@@ -39,7 +47,7 @@ import { Opaque } from '@glimmer/util';
 
   ```handlebars
   <ul>
-    {{#each people as |person index|}}
+    {{#each this.people as |person index|}}
       <li>Hello, {{person.name}}! You're number {{index}} in line</li>
     {{/each}}
   </ul>
@@ -55,7 +63,7 @@ import { Opaque } from '@glimmer/util';
   For example, here's the `{{#each}}` helper with its `key` set to `id`:
 
   ```handlebars
-  {{#each model key="id" as |item|}}
+  {{#each @model key="id" as |item|}}
   {{/each}}
   ```
 
@@ -70,7 +78,7 @@ import { Opaque } from '@glimmer/util';
   if the collection is empty.
 
   ```handlebars
-  {{#each developers as |person|}}
+  {{#each this.developers as |person|}}
     {{person.name}}
   {{else}}
     <p>Sorry, nobody is available for this task.</p>
@@ -87,19 +95,23 @@ import { Opaque } from '@glimmer/util';
 
   For example, given a `user` object that looks like:
 
-  ```javascript
-  {
-    "name": "Shelly Sails",
-    "age": 42
+  ```app/components/developer-details.js
+  import Component from '@glimmer/component';
+
+  export default class extends Component {
+    developer = {
+      "name": "Shelly Sails",
+      "age": 42
+    };
   }
   ```
 
   This template would display all properties on the `user`
   object in a list:
 
-  ```handlebars
+  ```app/components/developer-details.hbs
   <ul>
-  {{#each-in user as |key value|}}
+  {{#each-in this.developer as |key value|}}
     <li>{{key}}: {{value}}</li>
   {{/each-in}}
   </ul>

--- a/packages/@ember/-internals/glimmer/lib/helpers/each-in.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/each-in.ts
@@ -64,6 +64,7 @@ import { Opaque } from '@glimmer/util';
 
   ```handlebars
   {{#each @model key="id" as |item|}}
+    {{item}}
   {{/each}}
   ```
 

--- a/packages/@ember/-internals/glimmer/lib/helpers/each-in.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/each-in.ts
@@ -15,7 +15,7 @@ import { Opaque } from '@glimmer/util';
   ```app/components/developer-listing.js
   import Component from '@glimmer/component';
 
-  export default class extends Component {
+  export default class DeveloperListingComponent extends Component {
     developers = [{ name: 'Yehuda' },{ name: 'Tom' }, { name: 'Paul' }];
   }
   ```
@@ -32,7 +32,7 @@ import { Opaque } from '@glimmer/util';
   ```app/components/developer-listing.js
   import Component from '@glimmer/component';
 
-  export default class extends Component {
+  export default class DeveloperListingComponent extends Component {
     developerNames = ['Yehuda', 'Tom', 'Paul']
   }
   ```
@@ -99,7 +99,7 @@ import { Opaque } from '@glimmer/util';
   ```app/components/developer-details.js
   import Component from '@glimmer/component';
 
-  export default class extends Component {
+  export default class DeveloperDetailsComponent extends Component {
     developer = {
       "name": "Shelly Sails",
       "age": 42

--- a/packages/@ember/-internals/glimmer/lib/helpers/get.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/get.ts
@@ -23,16 +23,32 @@ import { CachedReference, referenceFromParts, UPDATE } from '../utils/references
 
   For example, these two usages are equivalent:
 
+  ```app/components/developer-detail.js
+  import Component from '@glimmer/component';
+
+  export default class extends Component {
+    developer = {
+      name: "Sandi Metz",
+      language: "Ruby"
+    }
+  }
+  ```
+
   ```handlebars
-  {{person.height}}
-  {{get person "height"}}
+  {{this.developer.name}}
+  {{get this.developer "name"}}
   ```
 
   If there were several facts about a person, the `{{get}}` helper can dynamically
   pick one:
 
+
+  ```app/templates/application.hbs
+  <DeveloperDetail @factName="language" />
+  ```
+
   ```handlebars
-  {{get person factName}}
+  {{get this.developer @factName}}
   ```
 
   For a more complex example, this template would allow the user to switch

--- a/packages/@ember/-internals/glimmer/lib/helpers/get.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/get.ts
@@ -26,7 +26,7 @@ import { CachedReference, referenceFromParts, UPDATE } from '../utils/references
   ```app/components/developer-detail.js
   import Component from '@glimmer/component';
 
-  export default class extends Component {
+  export default class DeveloperDetailComponent extends Component {
     developer = {
       name: "Sandi Metz",
       language: "Ruby"
@@ -58,7 +58,7 @@ import { CachedReference, referenceFromParts, UPDATE } from '../utils/references
   import Component from '@glimmer/component';
   import { tracked } from '@glimmer/tracking';
 
-  export default class extends Component {
+  export default class DeveloperDetailComponent extends Component {
     @tracked
     developer = {
       name: "Sandi Metz",

--- a/packages/@ember/-internals/glimmer/lib/helpers/get.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/get.ts
@@ -54,18 +54,40 @@ import { CachedReference, referenceFromParts, UPDATE } from '../utils/references
   For a more complex example, this template would allow the user to switch
   between showing the user's height and weight with a click:
 
-  ```handlebars
-  {{get person factName}}
-  <button {{action (fn (mut factName)) "height"}}>Show height</button>
-  <button {{action (fn (mut factName)) "weight"}}>Show weight</button>
+  ```app/components/developer-detail.js
+  import Component from '@glimmer/component';
+  import { tracked } from '@glimmer/tracking';
+
+  export default class extends Component {
+    @tracked
+    developer = {
+      name: "Sandi Metz",
+      language: "Ruby"
+    }
+
+    @tracked currentFact = 'name'
+
+    @action
+    showFact(fact) {
+      this.currentFact = fact;
+    }
+  }
+  ```
+
+  ```app/components/developer-detail.js
+  {{get developer currentFact}}
+
+  <button {{on 'click' (fn showFact "name")}}>Show name</button>
+  <button {{on 'click' (fn showFact "language")}}>Show language</button>
   ```
 
   The `{{get}}` helper can also respect mutable values itself. For example:
 
-  ```handlebars
-  {{input value=(mut (get person factName)) type="text"}}
-  <button {{action (fn (mut factName)) "height"}}>Show height</button>
-  <button {{action (fn (mut factName)) "weight"}}>Show weight</button>
+  ```app/components/developer-detail.js
+  <Input @value=(mut (get person currentFact)) />
+
+  <button {{on 'click' (fn showFact "name")}}>Show name</button>
+  <button {{on 'click' (fn showFact "language")}}>Show language</button>
   ```
 
   Would allow the user to swap what fact is being displayed, and also edit

--- a/packages/@ember/-internals/glimmer/lib/helpers/if-unless.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/if-unless.ts
@@ -113,20 +113,6 @@ class ConditionalHelperReference extends CachedReference {
   Hello Alex
   ```
 
-  ### Nested `if`
-
-  You can use the `if` helper inside another helper as a nested helper:
-
-  ```handlebars
-  <SomeComponent @height={{if isBig "100" "10"}} />
-  ```
-
-  or
-
-  ```handlebars
-  {{some-component height=(if isBig "100" "10")}}
-  ```
-
   One detail to keep in mind is that both branches of the `if` helper will be evaluated,
   so if you have `{{if condition "foo" (expensive-operation "bar")`,
   `expensive-operation` will always calculate.

--- a/packages/@ember/-internals/glimmer/lib/helpers/if-unless.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/if-unless.ts
@@ -155,10 +155,14 @@ export function inlineIf(_vm: VM, { positional }: Arguments) {
   the second argument will be displayed, otherwise, the third argument will be
   displayed
 
-  For example, if `useLongGreeting` is false below:
+  For example, if you pass a falsey `useLongGreeting` to the `Greeting` component:
 
-  ```handlebars
-  {{unless useLongGreeting "Hi" "Hello"}} Ben
+  ```app/templates/application.hbs
+  <Greeting @useLongGreeting={{false}} />
+  ```
+
+  ```app/components/greeting.hbs
+  {{unless @useLongGreeting "Hi" "Hello"}} Ben
   ```
 
   Then it will display:
@@ -171,27 +175,52 @@ export function inlineIf(_vm: VM, { positional }: Arguments) {
 
   Like the `if` helper, `unless` helper also has a block form.
 
-  ```handlebars
-  {{! If greetings are found, the text below will not render.}}
+  The following:
+
+  ```app/templates/application.hbs
+  <Greetings />
+  ```
+
+  ```app/components/greetings.hbs
   {{#unless greetings}}
     No greetings were found. Why not set one?
   {{/unless}}
   ```
 
+  Will not render anything.
+
   You can also use an `else` helper with the `unless` block. The
   `else` will display if the value is truthy.
 
-  ```handlebars
-  {{! Is the user logged in?}}
-  {{#unless userData}}
+  If you have the following component:
+
+  ```app/components/logged-in.hbs
+  {{#unless @userData}}
     Please login.
   {{else}}
     Welcome back!
   {{/unless}}
   ```
 
-  If `userData` is false, undefined, null, or empty in the above example,
-  then it will render:
+  Calling it with a truthy `userData`:
+
+  ```app/templates/application.hbs
+  <LoggedIn @userData={{hash username="Zoey"}} />
+  ```
+
+  Will render:
+
+  ```html
+  Welcome back!
+  ```
+
+  and calling it with a falsey `userData`:
+
+  ```app/templates/application.hbs
+  <LoggedIn @userData=false />
+
+
+  Will render:
 
   ```html
   Please login.

--- a/packages/@ember/-internals/glimmer/lib/helpers/if-unless.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/if-unless.ts
@@ -62,19 +62,22 @@ class ConditionalHelperReference extends CachedReference {
   using the block form to wrap the section of template you want to conditionally render.
   Like so:
 
-  ```handlebars
-  {{! will not render if foo is falsey}}
-  {{#if foo}}
-    Welcome to the {{foo.bar}}
+  ```app/templates/application.hbs
+  <Welcome />
+  ```
+
+  ```app/components/welcome.js
+  {{! will not render because greeting is undefined}}
+  {{#if @greeting}}
+    Welcome to our website!
   {{/if}}
   ```
 
-  You can also specify a template to show if the property is falsey by using
+  You can also what to show if the property is falsey by using
   the `else` helper.
 
-  ```handlebars
-  {{! is it raining outside?}}
-  {{#if isRaining}}
+  ```app/components/weather.hbs
+  {{#if @isRaining}}
     Yes, grab an umbrella!
   {{else}}
     No, it's lovely outside!
@@ -84,15 +87,25 @@ class ConditionalHelperReference extends CachedReference {
   You are also able to combine `else` and `if` helpers to create more complex
   conditional logic.
 
-  ```handlebars
-  {{#if isMorning}}
+  For the following template:
+
+  ```app/components/greeting.hbs
+  {{#if @isMorning}}
     Good morning
-  {{else if isAfternoon}}
+  {{else if @isAfternoon}}
     Good afternoon
   {{else}}
     Good night
   {{/if}}
   ```
+
+  If you call it by saying `isAfternoon` is true:
+  
+  ```app/templates/application.hbs
+  <Greeting @isAfternoon={{true}} />
+  ```
+
+  Then `Good afternoon` will be rendered.
 
   ## Inline form
 
@@ -103,8 +116,8 @@ class ConditionalHelperReference extends CachedReference {
 
   For example, if `useLongGreeting` is truthy, the following:
 
-  ```handlebars
-  {{if useLongGreeting "Hello" "Hi"}} Alex
+  ```app/components/greeting.hbs
+  {{if @useLongGreeting "Hello" "Hi"}} Alex
   ```
 
   Will render:

--- a/packages/@ember/-internals/glimmer/lib/helpers/if-unless.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/if-unless.ts
@@ -167,20 +167,6 @@ export function inlineIf(_vm: VM, { positional }: Arguments) {
   Hi
   ```
 
-  You can use the `unless` helper inside another helper as a subexpression.
-  If isBig is not true, it will set the height to 10:
-
-  ```handlebars
-  {{! If isBig is not true, it will set the height to 10.}}
-  <SomeComponent @height={{unless isBig "10" "100"}} />
-  ```
-
-  or
-
-  ```handlebars
-  {{some-component height=(unless isBig "10" "100")}}
-  ```
-
   ## Block form
 
   Like the `if` helper, `unless` helper also has a block form.

--- a/packages/@ember/-internals/glimmer/lib/helpers/if-unless.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/if-unless.ts
@@ -63,17 +63,17 @@ class ConditionalHelperReference extends CachedReference {
   Like so:
 
   ```app/templates/application.hbs
-  <Welcome />
+  <Weather />
   ```
 
-  ```app/components/welcome.js
+  ```app/components/weather.hbs
   {{! will not render because greeting is undefined}}
-  {{#if @greeting}}
-    Welcome to our website!
+  {{#if @isRaining}}
+    Yes, grab an umbrella!
   {{/if}}
   ```
 
-  You can also what to show if the property is falsey by using
+  You can also define what to show if the property is falsey by using
   the `else` helper.
 
   ```app/components/weather.hbs
@@ -89,23 +89,23 @@ class ConditionalHelperReference extends CachedReference {
 
   For the following template:
 
-  ```app/components/greeting.hbs
-  {{#if @isMorning}}
-    Good morning
-  {{else if @isAfternoon}}
-    Good afternoon
+    ```app/components/weather.hbs
+  {{#if @isRaining}}
+    Yes, grab an umbrella!
+  {{else if @isCold}}
+    Grab a coat, it's chilly!
   {{else}}
-    Good night
+    No, it's lovely outside!
   {{/if}}
   ```
 
-  If you call it by saying `isAfternoon` is true:
+  If you call it by saying `isCold` is true:
   
   ```app/templates/application.hbs
-  <Greeting @isAfternoon={{true}} />
+  <Weather @isCold={{true}} />
   ```
 
-  Then `Good afternoon` will be rendered.
+  Then `Grab a coat, it's chilly!` will be rendered.
 
   ## Inline form
 
@@ -115,6 +115,10 @@ class ConditionalHelperReference extends CachedReference {
   the value to render when truthy, and the value to render when falsey.
 
   For example, if `useLongGreeting` is truthy, the following:
+
+  ```app/templates/application.hbs
+  <Greeting @useLongGreeting={{true}} />
+  ```
 
   ```app/components/greeting.hbs
   {{if @useLongGreeting "Hello" "Hi"}} Alex
@@ -168,7 +172,7 @@ export function inlineIf(_vm: VM, { positional }: Arguments) {
   Then it will display:
 
   ```html
-  Hi
+  Hi Ben
   ```
 
   ## Block form

--- a/packages/@ember/-internals/glimmer/lib/helpers/query-param.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/query-param.ts
@@ -11,10 +11,15 @@ import { InternalHelperReference } from '../utils/references';
   This is a helper to be used in conjunction with the link-to helper.
   It will supply url query parameters to the target route.
 
-  Example
+  @example In this example we are setting the `direction` query param to the value `"asc"`
 
-  ```handlebars
-  {{#link-to 'posts' (query-params direction="asc")}}Sort{{/link-to}}
+  ```app/templates/application.hbs
+  <LinkTo
+    @route="posts"
+    {{query-params direction="asc"}}
+  >
+    Sort
+  </LinkTo>
   ```
 
   @method query-params

--- a/packages/@ember/-internals/glimmer/lib/helpers/unbound.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/unbound.ts
@@ -13,7 +13,7 @@ import { UnboundReference } from '../utils/references';
   if it is set with a new value:
 
   ```handlebars
-  {{unbound name}}
+  {{unbound this.name}}
   ```
 
   Like any helper, the `unbound` helper can accept a nested helper expression.
@@ -21,9 +21,9 @@ import { UnboundReference } from '../utils/references';
 
   ```handlebars
   {{unbound (some-custom-helper)}}
-  {{unbound (capitalize name)}}
+  {{unbound (capitalize this.name)}}
   {{! You can use any helper, including unbound, in a nested expression }}
-  {{capitalize (unbound name)}}
+  {{capitalize (unbound this.name)}}
   ```
 
   The `unbound` helper only accepts a single argument, and it return an

--- a/packages/@ember/-internals/glimmer/lib/syntax/outlet.ts
+++ b/packages/@ember/-internals/glimmer/lib/syntax/outlet.ts
@@ -20,22 +20,21 @@ import { OutletReference, OutletState } from '../utils/outlet';
   your template. An important use of the `{{outlet}}` helper is in your
   application's `application.hbs` file:
 
-  ```handlebars
-  {{! app/templates/application.hbs }}
-  <!-- header content goes here, and will always display -->
+  ```app/templates/application.hbs
   <MyHeader />
+
   <div class="my-dynamic-content">
     <!-- this content will change based on the current route, which depends on the current URL -->
     {{outlet}}
   </div>
-  <!-- footer content goes here, and will always display -->
+
   <MyFooter />
   ```
 
   You may also specify a name for the `{{outlet}}`, which is useful when using more than one
   `{{outlet}}` in a template:
 
-  ```handlebars
+  ```app/templates/application.hbs
   {{outlet "menu"}}
   {{outlet "sidebar"}}
   {{outlet "main"}}

--- a/packages/@ember/-internals/glimmer/lib/syntax/outlet.ts
+++ b/packages/@ember/-internals/glimmer/lib/syntax/outlet.ts
@@ -46,7 +46,7 @@ import { OutletReference, OutletState } from '../utils/outlet';
   ```app/routes/menu.js
   import Route from '@ember/routing/route';
 
-  export default class extends Route {
+  export default class MenuRoute extends Route {
     renderTemplate() {
       this.render({ outlet: 'menu' });
     }

--- a/packages/@ember/-internals/glimmer/lib/syntax/outlet.ts
+++ b/packages/@ember/-internals/glimmer/lib/syntax/outlet.ts
@@ -46,11 +46,11 @@ import { OutletReference, OutletState } from '../utils/outlet';
   ```app/routes/menu.js
   import Route from '@ember/routing/route';
 
-  export default Route.extend({
+  export default class extends Route {
     renderTemplate() {
       this.render({ outlet: 'menu' });
     }
-  });
+  }
   ```
 
   See the [routing guide](https://guides.emberjs.com/release/routing/rendering-a-template/) for more

--- a/packages/@ember/-internals/routing/lib/ext/controller.ts
+++ b/packages/@ember/-internals/routing/lib/ext/controller.ts
@@ -19,6 +19,7 @@ ControllerMixin.reopen({
     Available queryParam types: `boolean`, `number`, `array`.
     If query param type not specified, it will be `string`.
     To explicitly configure a query parameter property so it coerces as expected, you must define a type property:
+
     ```javascript
       queryParams: [{
         category: {
@@ -26,6 +27,7 @@ ControllerMixin.reopen({
         }
       }]
     ```
+
     @for Ember.ControllerMixin
     @property queryParams
     @public

--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -95,18 +95,18 @@ export default class RouterService extends Service {
      specific model from a Component.
 
      ```javascript
-     import Component from '@ember/component';
+     import Component from '@glimmer/component';
+     import { action } from '@ember/object';
      import { inject as service } from '@ember/service';
 
-     export default Component.extend({
-       router: service(),
+     export default class extends Component {
+       @service router;
 
-       actions: {
-         goToComments(post) {
-           this.router.transitionTo('comments', post);
-         }
+       @action
+       goToComments(post) {
+         this.router.transitionTo('comments', post);
        }
-     });
+     }
      ```
 
      @method transitionTo
@@ -147,7 +147,7 @@ export default class RouterService extends Service {
      ```app/routes/application.js
      import Route from '@ember/routing/route';
 
-     export default Route.extend({
+     export default class extends Route {
        beforeModel() {
          if (!authorized()){
            this.replaceWith('unauthorized');
@@ -177,21 +177,23 @@ export default class RouterService extends Service {
     In this example, the URL for the `author.books` route for a given author
     is copied to the clipboard.
 
+    ```app/templates/application.hbs
+    <CopyLink @author={{hash id="tomster" name="Tomster"}} />
+    ```
+
     ```app/components/copy-link.js
     import Component from '@glimmer/component';
     import { inject as service } from '@ember/service';
+    import { action } from '@ember/object';
 
     export default class extends Component {
       @service router;
       @service clipboard;
-
-      // Provided` in the template
-      // { id: 'tomster', name: 'Tomster' }
-      author: null,
       
+      @action
       copyBooksURL() {
         if (this.author) {
-          const url = this.router.urlFor('author.books', this.author);
+          const url = this.router.urlFor('author.books', this.args.author);
           this.clipboard.set(url);
           // Clipboard now has /author/tomster/books
         }
@@ -201,18 +203,20 @@ export default class RouterService extends Service {
     Just like with `transitionTo` and `replaceWith`, `urlFor` can also handle
     query parameters.
 
+    ```app/templates/application.hbs
+    <CopyLink @author={{hash id="tomster" name="Tomster"}} />
+    ```
+
     ```app/components/copy-link.js
     import Component from '@glimmer/component';
     import { inject as service } from '@ember/service';
+    import { action } from '@ember/object';
 
     export default class extends Component {
       @service router;
       @service clipboard;
 
-      // Provided in the template
-      // { id: 'tomster', name: 'Tomster' }
-      author: null,
-  
+      @action
       copyOnlyEmberBooksURL() {
         if (this.author) {
           const url = this.router.urlFor('author.books', this.author, {
@@ -286,16 +290,16 @@ export default class RouterService extends Service {
      import Component from '@ember/component';
      import { inject as service } from '@ember/service';
 
-     export default Component.extend({
-       router: service(),
-       path: '/',
+     export default class extends Component {
+       @service router;
+       path = '/';
 
        click() {
-         if(this.router.recognize(this.path)) {
+         if (this.router.recognize(this.path)) {
            this.router.transitionTo(this.path);
          }
        }
-     });
+     }
      ```
 
       @method recognize
@@ -341,12 +345,16 @@ export default class RouterService extends Service {
     half-filled out:
 
     ```app/routes/contact-form.js
+    import Route from '@ember/routing';
+    import { action } from '@ember/object';
     import { inject as service } from '@ember/service';
 
-    export default Route.extend({
-      router: service('router'),
-      init() {
-        this._super(...arguments);
+    export default class extends Route {
+      @service router;
+
+      constructor() {
+        super(...arguments);
+        
         this.router.on('routeWillChange', (transition) => {
           if (!transition.to.find(route => route.name === this.routeName)) {
             alert("Please save or cancel your changes.");
@@ -354,7 +362,7 @@ export default class RouterService extends Service {
           }
         })
       }
-    });
+    }
     ```
 
     The `routeWillChange` event fires whenever a new route is chosen as the desired target of a transition. This includes `transitionTo`, `replaceWith`, all redirection for any reason including error handling, and abort. Aborting implies changing the desired target back to where you already were. Once a transition has completed, `routeDidChange` fires.
@@ -372,12 +380,16 @@ export default class RouterService extends Service {
     A good example is sending some analytics when the route has transitioned:
 
     ```app/routes/contact-form.js
+    import Route from '@ember/routing';
+    import { action } from '@ember/object';
     import { inject as service } from '@ember/service';
 
-    export default Route.extend({
-      router: service('router'),
-      init() {
-        this._super(...arguments);
+    export default class extends Route {
+      @service router;
+
+      constructor() {
+        super(...arguments);
+        
         this.router.on('routeDidChange', (transition) => {
           ga.send('pageView', {
             current: transition.to.name,
@@ -385,7 +397,7 @@ export default class RouterService extends Service {
           });
         })
       }
-    });
+    }
     ```
 
     @event routeDidChange
@@ -533,14 +545,14 @@ RouterService.reopen(Evented, {
 
     Usage example:
     ```app/components/header.js
-      import Component from '@ember/component';
+      import Component from '@glimmer/component';
       import { inject as service } from '@ember/service';
-      import { computed } from '@ember/object';
+      import { notEmpty } from '@ember/object/computed';
 
-      export default Component.extend({
-        router: service(),
+      export default class extends Component {
+        @service router;
 
-        isChildRoute: computed.notEmpty('router.currentRoute.child')
+        @notEmpty('router.currentRoute.child') isChildRoute;
       });
     ```
 

--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -37,19 +37,20 @@ function cleanURL(url: string, rootURL: string) {
 
    In this example, the Router service is injected into a component to initiate a transition
    to a dedicated route:
+
    ```javascript
-   import Component from '@ember/component';
+   import Component from '@glimmer/component';
+   import { action } from '@ember/object';
    import { inject as service } from '@ember/service';
 
-   export default Component.extend({
-     router: service(),
+   export default class extends Component {
+     @service router;
 
-     actions: {
-       next() {
-         this.router.transitionTo('other.route');
-       }
+     @action
+     next() {
+       this.router.transitionTo('other.route');
      }
-   });
+   }
    ```
 
    Like any service, it can also be injected into helpers, routes, etc.
@@ -177,17 +178,17 @@ export default class RouterService extends Service {
     is copied to the clipboard.
 
     ```app/components/copy-link.js
-    import Component from '@ember/component';
-    import {inject as service} from '@ember/service';
+    import Component from '@glimmer/component';
+    import { inject as service } from '@ember/service';
 
-    export default Component.extend({
-      router: service('router'),
-      clipboard: service('clipboard')
+    export default class extends Component {
+      @service router;
+      @service clipboard;
 
-      // Provided in the template
+      // Provided` in the template
       // { id: 'tomster', name: 'Tomster' }
       author: null,
-
+      
       copyBooksURL() {
         if (this.author) {
           const url = this.router.urlFor('author.books', this.author);
@@ -195,24 +196,23 @@ export default class RouterService extends Service {
           // Clipboard now has /author/tomster/books
         }
       }
-    });
-    ```
+    }
 
     Just like with `transitionTo` and `replaceWith`, `urlFor` can also handle
     query parameters.
 
     ```app/components/copy-link.js
-    import Component from '@ember/component';
-    import {inject as service} from '@ember/service';
+    import Component from '@glimmer/component';
+    import { inject as service } from '@ember/service';
 
-    export default Component.extend({
-      router: service('router'),
-      clipboard: service('clipboard')
+    export default class extends Component {
+      @service router;
+      @service clipboard;
 
       // Provided in the template
       // { id: 'tomster', name: 'Tomster' }
       author: null,
-
+  
       copyOnlyEmberBooksURL() {
         if (this.author) {
           const url = this.router.urlFor('author.books', this.author, {
@@ -222,7 +222,7 @@ export default class RouterService extends Service {
           // Clipboard now has /author/tomster/books?filter=emberjs
         }
       }
-    });
+    }
     ```
 
      @method urlFor
@@ -341,7 +341,7 @@ export default class RouterService extends Service {
     half-filled out:
 
     ```app/routes/contact-form.js
-    import {inject as service} from '@ember/service';
+    import { inject as service } from '@ember/service';
 
     export default Route.extend({
       router: service('router'),
@@ -372,7 +372,7 @@ export default class RouterService extends Service {
     A good example is sending some analytics when the route has transitioned:
 
     ```app/routes/contact-form.js
-    import {inject as service} from '@ember/service';
+    import { inject as service } from '@ember/service';
 
     export default Route.extend({
       router: service('router'),

--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -38,12 +38,12 @@ function cleanURL(url: string, rootURL: string) {
    In this example, the Router service is injected into a component to initiate a transition
    to a dedicated route:
 
-   ```javascript
+   ```app/components/demo.js
    import Component from '@glimmer/component';
    import { action } from '@ember/object';
    import { inject as service } from '@ember/service';
 
-   export default class extends Component {
+   export default class DemoComponent extends Component {
      @service router;
 
      @action
@@ -94,12 +94,12 @@ export default class RouterService extends Service {
      In the following example we use the Router service to navigate to a route with a
      specific model from a Component.
 
-     ```javascript
+     ```app/components/blog-post.js
      import Component from '@glimmer/component';
      import { action } from '@ember/object';
      import { inject as service } from '@ember/service';
 
-     export default class extends Component {
+     export default class BlogPostComponent extends Component {
        @service router;
 
        @action
@@ -147,7 +147,7 @@ export default class RouterService extends Service {
      ```app/routes/application.js
      import Route from '@ember/routing/route';
 
-     export default class extends Route {
+     export default class ApplicationRoute extends Route {
        beforeModel() {
          if (!authorized()){
            this.replaceWith('unauthorized');
@@ -186,7 +186,7 @@ export default class RouterService extends Service {
     import { inject as service } from '@ember/service';
     import { action } from '@ember/object';
 
-    export default class extends Component {
+    export default class CopyLinkComponent extends Component {
       @service router;
       @service clipboard;
       
@@ -212,7 +212,7 @@ export default class RouterService extends Service {
     import { inject as service } from '@ember/service';
     import { action } from '@ember/object';
 
-    export default class extends Component {
+    export default class CopyLinkComponent extends Component {
       @service router;
       @service clipboard;
 
@@ -287,7 +287,7 @@ export default class RouterService extends Service {
      application before transitioning to it.
 
      ```
-     import Component from '@ember/component';
+     import Component from '@ember/component';x
      import { inject as service } from '@ember/service';
 
      export default class extends Component {
@@ -349,7 +349,7 @@ export default class RouterService extends Service {
     import { action } from '@ember/object';
     import { inject as service } from '@ember/service';
 
-    export default class extends Route {
+    export default class ContactFormRoute extends Route {
       @service router;
 
       constructor() {
@@ -384,7 +384,7 @@ export default class RouterService extends Service {
     import { action } from '@ember/object';
     import { inject as service } from '@ember/service';
 
-    export default class extends Route {
+    export default class ContactFormRoute extends Route {
       @service router;
 
       constructor() {
@@ -549,7 +549,7 @@ RouterService.reopen(Evented, {
       import { inject as service } from '@ember/service';
       import { notEmpty } from '@ember/object/computed';
 
-      export default class extends Component {
+      export default class HeaderComponent extends Component {
         @service router;
 
         @notEmpty('router.currentRoute.child') isChildRoute;

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -677,18 +677,18 @@ class Route extends EmberObject implements IRoute {
 
     ```app/routes/index.js
     import Route from '@ember/routing/route';
+    import { action } from '@ember/object';
 
-    export Route.extend({
-      actions: {
-        moveToSecret(context) {
-          if (authorized()) {
-            this.transitionTo('secret', context);
-          } else {
-            this.transitionTo('fourOhFour');
-          }
+    export default class extends Route {
+      @action
+      moveToSecret(context) {
+        if (authorized()) {
+          this.transitionTo('secret', context);
+        } else {
+          this.transitionTo('fourOhFour');
         }
       }
-    });
+    }
     ```
 
     Transition to a nested route
@@ -707,14 +707,14 @@ class Route extends EmberObject implements IRoute {
 
     ```app/routes/index.js
     import Route from '@ember/routing/route';
+    import { action } from '@ember/object';
 
-    export default Route.extend({
-      actions: {
-        transitionToNewArticle() {
-          this.transitionTo('articles.new');
-        }
+    export default class extends Route {
+      @action
+      transitionToNewArticle() {
+        this.transitionTo('articles.new');
       }
-    });
+    }
     ```
 
     Multiple Models Example
@@ -735,17 +735,17 @@ class Route extends EmberObject implements IRoute {
 
     ```app/routes/index.js
     import Route from '@ember/routing/route';
+    import { action } from '@ember/object';
 
-    export default Route.extend({
-      actions: {
-        moveToChocolateCereal() {
-          let cereal = { cerealId: 'ChocolateYumminess' };
-          let breakfast = { breakfastId: 'CerealAndMilk' };
+    export default class extends Route {
+      @action
+      moveToChocolateCereal() {
+        let cereal = { cerealId: 'ChocolateYumminess' };
+        let breakfast = { breakfastId: 'CerealAndMilk' };
 
-          this.transitionTo('breakfast.cereal', breakfast, cereal);
-        }
+        this.transitionTo('breakfast.cereal', breakfast, cereal);
       }
-    });
+    }
     ```
 
     Nested Route with Query String Example
@@ -765,13 +765,12 @@ class Route extends EmberObject implements IRoute {
     ```app/routes/index.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
-      actions: {
-        transitionToApples() {
-          this.transitionTo('fruits.apples', { queryParams: { color: 'red' } });
-        }
+    export default class extends Route {
+      @action
+      transitionToApples() {
+        this.transitionTo('fruits.apples', { queryParams: { color: 'red' } });
       }
-    });
+    }
     ```
 
     @method transitionTo
@@ -1377,12 +1376,13 @@ class Route extends EmberObject implements IRoute {
     ```app/routes/post/comments.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
-      model() {
+    export default class extends Route {
+      async model() {
         let post = this.modelFor('post');
-        return post.get('comments');
+
+        return post.comments;
       }
-    });
+    }
     ```
 
     @method modelFor
@@ -1433,7 +1433,7 @@ class Route extends EmberObject implements IRoute {
     ```app/routes/posts.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
+    export default class extends Route {
       renderTemplate(controller, model) {
         let favController = this.controllerFor('favoritePost');
 
@@ -1445,7 +1445,7 @@ class Route extends EmberObject implements IRoute {
           controller: favController
         });
       }
-    });
+    }
     ```
 
     @method renderTemplate
@@ -1495,14 +1495,14 @@ class Route extends EmberObject implements IRoute {
     ```app/routes/post.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
+    export default class extends Route {
       renderTemplate() {
         this.render('photos', {
           into: 'application',
           outlet: 'anOutletName'
         })
       }
-    });
+    }
     ```
 
     `render` additionally allows you to supply which `controller` and
@@ -1511,7 +1511,7 @@ class Route extends EmberObject implements IRoute {
     ```app/routes/posts.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
+    export default extend Route {
       renderTemplate(controller, model){
         this.render('posts', {    // the template to render, referenced by name
           into: 'application',    // the template to render into, referenced by name
@@ -1520,7 +1520,7 @@ class Route extends EmberObject implements IRoute {
           model: model            // the model to set on `options.controller`.
         })
       }
-    });
+    }
     ```
 
     The string values provided for the template name, and controller
@@ -1549,11 +1549,11 @@ class Route extends EmberObject implements IRoute {
     ```app/routes/post.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
+    export default class extends Route {
       renderTemplate() {
         this.render(); // all defaults apply
       }
-    });
+    }
     ```
 
     The name of the route, defined by the router, is `post`.
@@ -1617,24 +1617,25 @@ class Route extends EmberObject implements IRoute {
 
     ```app/routes/application.js
     import Route from '@ember/routing/route';
+    import { action } from '@ember/object';
 
-    export default Route.extend({
-      actions: {
-        showModal(evt) {
-          this.render(evt.modalName, {
-            outlet: 'modal',
-            into: 'application'
-          });
-        },
-
-        hideModal(evt) {
-          this.disconnectOutlet({
-            outlet: 'modal',
-            parentView: 'application'
-          });
-        }
+    export default class extends Route {
+      @action
+      showModal(evt) {
+        this.render(evt.modalName, {
+          outlet: 'modal',
+          into: 'application'
+        });
       }
-    });
+
+      @action
+      hideModal() {
+        this.disconnectOutlet({
+          outlet: 'modal',
+          parentView: 'application'
+        });
+      }
+    }
     ```
 
     Alternatively, you can pass the `outlet` name directly as a string.
@@ -1643,18 +1644,20 @@ class Route extends EmberObject implements IRoute {
 
     ```app/routes/application.js
     import Route from '@ember/routing/route';
+    import { action } from '@ember/object';
 
-    export default Route.extend({
-      actions: {
-        showModal(evt) {
-          // ...
-        },
-        hideModal(evt) {
-          this.disconnectOutlet('modal');
-        }
+    export default class extends Route {
+      @action
+      showModal(evt) {
+        // ...
       }
-    });
-        ```
+
+      @action
+      hideModal(evt) {
+        this.disconnectOutlet('modal');
+      }
+    }
+    ```
 
     @method disconnectOutlet
     @param {Object|String} options the options hash or outlet name
@@ -1747,26 +1750,29 @@ class Route extends EmberObject implements IRoute {
     ```app/routes/posts/index.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
+    export default class extends Route {
       buildRouteInfoMetadata() {
         return { title: 'Posts Page' }
       }
-    });
+    }
     ```
+
     ```app/routes/application.js
     import Route from '@ember/routing/route';
     import { inject as service } from '@ember/service';
 
-    export default Route.extend({
-      router: service('router'),
-      init() {
-        this._super(...arguments);
+    export default class extends Route {
+      @service router
+
+      constructor() {
+        super(...arguments);
+
         this.router.on('routeDidChange', transition => {
           document.title = transition.to.metadata.title;
           // would update document's title to "Posts Page"
         });
       }
-    });
+    }
     ```
 
     @return any
@@ -2025,20 +2031,19 @@ function getEngineRouteName(engine: Owner, routeName: string) {
     ```
 
     ```app/routes/post.js
-    import $ from 'jquery';
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
-      model(params) {
+    export default class extends Route {
+      async model({ post_id }) {
         // the server returns `{ id: 12 }`
-        return $.getJSON('/posts/' + params.post_id);
-      },
+        return fetch(`/posts/${post_id}`;
+      }
 
       serialize(model) {
         // this will make the URL `/posts/12`
         return { post_id: model.id };
       }
-    });
+    }
     ```
 
     The default `serialize` method will insert the model's `id` into the
@@ -2114,21 +2119,21 @@ Route.reopen(ActionHandler, Evented, {
     ```app/routes/posts/list.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
-      templateName: 'posts/list'
+    export default class extends Route {
+      templateName = 'posts/list'
     });
     ```
 
     ```app/routes/posts/index.js
     import PostsList from '../posts/list';
 
-    export default PostsList.extend();
+    export default class extends PostsList {};
     ```
 
     ```app/routes/posts/archived.js
     import PostsList from '../posts/list';
 
-    export default PostsList.extend();
+    export default class extends PostsList {};
     ```
 
     @property templateName
@@ -2365,14 +2370,14 @@ Route.reopen(ActionHandler, Evented, {
 
     ```app/routes/application.js
     import Route from '@ember/routing/route';
+    import { action } from '@ember/object';
 
-    export default Route.extend({
-      actions: {
-        track(arg) {
-          console.log(arg, 'was clicked');
-        }
+    export default class extends Route {
+      @action
+      track(arg) {
+        console.log(arg, 'was clicked');
       }
-    });
+    }
     ```
 
     ```app/routes/index.js

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -679,7 +679,7 @@ class Route extends EmberObject implements IRoute {
     import Route from '@ember/routing/route';
     import { action } from '@ember/object';
 
-    export default class extends Route {
+    export default class IndexRoute extends Route {
       @action
       moveToSecret(context) {
         if (authorized()) {
@@ -709,7 +709,7 @@ class Route extends EmberObject implements IRoute {
     import Route from '@ember/routing/route';
     import { action } from '@ember/object';
 
-    export default class extends Route {
+    export default class IndexRoute extends Route {
       @action
       transitionToNewArticle() {
         this.transitionTo('articles.new');
@@ -737,7 +737,7 @@ class Route extends EmberObject implements IRoute {
     import Route from '@ember/routing/route';
     import { action } from '@ember/object';
 
-    export default class extends Route {
+    export default class IndexRoute extends Route {
       @action
       moveToChocolateCereal() {
         let cereal = { cerealId: 'ChocolateYumminess' };
@@ -765,7 +765,7 @@ class Route extends EmberObject implements IRoute {
     ```app/routes/index.js
     import Route from '@ember/routing/route';
 
-    export default class extends Route {
+    export default class IndexRoute extends Route {
       @action
       transitionToApples() {
         this.transitionTo('fruits.apples', { queryParams: { color: 'red' } });
@@ -1376,7 +1376,7 @@ class Route extends EmberObject implements IRoute {
     ```app/routes/post/comments.js
     import Route from '@ember/routing/route';
 
-    export default class extends Route {
+    export default class PostCommentsRoute extends Route {
       async model() {
         let post = this.modelFor('post');
 
@@ -1433,7 +1433,7 @@ class Route extends EmberObject implements IRoute {
     ```app/routes/posts.js
     import Route from '@ember/routing/route';
 
-    export default class extends Route {
+    export default class PostsRoute extends Route {
       renderTemplate(controller, model) {
         let favController = this.controllerFor('favoritePost');
 
@@ -1495,7 +1495,7 @@ class Route extends EmberObject implements IRoute {
     ```app/routes/post.js
     import Route from '@ember/routing/route';
 
-    export default class extends Route {
+    export default class PostRoute extends Route {
       renderTemplate() {
         this.render('photos', {
           into: 'application',
@@ -1549,7 +1549,7 @@ class Route extends EmberObject implements IRoute {
     ```app/routes/post.js
     import Route from '@ember/routing/route';
 
-    export default class extends Route {
+    export default class PostRoute extends Route {
       renderTemplate() {
         this.render(); // all defaults apply
       }
@@ -1619,7 +1619,7 @@ class Route extends EmberObject implements IRoute {
     import Route from '@ember/routing/route';
     import { action } from '@ember/object';
 
-    export default class extends Route {
+    export default class ApplicationRoute extends Route {
       @action
       showModal(evt) {
         this.render(evt.modalName, {
@@ -1646,7 +1646,7 @@ class Route extends EmberObject implements IRoute {
     import Route from '@ember/routing/route';
     import { action } from '@ember/object';
 
-    export default class extends Route {
+    export default class ApplicationRoute extends Route {
       @action
       showModal(evt) {
         // ...
@@ -1750,7 +1750,7 @@ class Route extends EmberObject implements IRoute {
     ```app/routes/posts/index.js
     import Route from '@ember/routing/route';
 
-    export default class extends Route {
+    export default class PostsIndexRoute extends Route {
       buildRouteInfoMetadata() {
         return { title: 'Posts Page' }
       }
@@ -1761,7 +1761,7 @@ class Route extends EmberObject implements IRoute {
     import Route from '@ember/routing/route';
     import { inject as service } from '@ember/service';
 
-    export default class extends Route {
+    export default class ApplicationRoute extends Route {
       @service router
 
       constructor() {
@@ -2033,7 +2033,7 @@ function getEngineRouteName(engine: Owner, routeName: string) {
     ```app/routes/post.js
     import Route from '@ember/routing/route';
 
-    export default class extends Route {
+    export default class PostRoute extends Route {
       async model({ post_id }) {
         // the server returns `{ id: 12 }`
         return fetch(`/posts/${post_id}`;
@@ -2119,7 +2119,7 @@ Route.reopen(ActionHandler, Evented, {
     ```app/routes/posts/list.js
     import Route from '@ember/routing/route';
 
-    export default class extends Route {
+    export default class PostsListRoute extends Route {
       templateName = 'posts/list'
     });
     ```
@@ -2127,13 +2127,13 @@ Route.reopen(ActionHandler, Evented, {
     ```app/routes/posts/index.js
     import PostsList from '../posts/list';
 
-    export default class extends PostsList {};
+    export default class PostsIndexRoute extends PostsList {};
     ```
 
     ```app/routes/posts/archived.js
     import PostsList from '../posts/list';
 
-    export default class extends PostsList {};
+    export default class PostsArchivedRoute extends PostsList {};
     ```
 
     @property templateName
@@ -2372,7 +2372,7 @@ Route.reopen(ActionHandler, Evented, {
     import Route from '@ember/routing/route';
     import { action } from '@ember/object';
 
-    export default class extends Route {
+    export default class ApplicationRoute extends Route {
       @action
       track(arg) {
         console.log(arg, 'was clicked');

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -201,25 +201,25 @@ class Route extends EmberObject implements IRoute {
     ```app/routes/member.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
-      queryParams: {
+    export default class MemberRoute extends Route {
+      queryParams = {
         memberQp: { refreshModel: true }
       }
-    });
+    }
     ```
 
     ```app/routes/member/interest.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
-      queryParams: {
+    export default class MemberInterestRoute Route {
+      queryParams = {
         interestQp: { refreshModel: true }
-      },
+      }
 
       model() {
         return this.paramsFor('member');
       }
-    });
+    }
     ```
 
     If we visit `/turing/maths?memberQp=member&interestQp=interest` the model for
@@ -317,13 +317,13 @@ class Route extends EmberObject implements IRoute {
     ```app/routes/articles.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
+    export default class ArticlesRoute extends Route {
       resetController(controller, isExiting, transition) {
         if (isExiting && transition.targetName !== 'error') {
           controller.set('page', 1);
         }
       }
-    });
+    }
     ```
 
     @method resetController
@@ -859,13 +859,13 @@ class Route extends EmberObject implements IRoute {
     ```app/routes/secret.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
+    export default class SecretRoute Route {
       afterModel() {
         if (!authorized()){
           this.replaceWith('index');
         }
       }
-    });
+    }
     ```
 
     @method replaceWith
@@ -1004,13 +1004,13 @@ class Route extends EmberObject implements IRoute {
     ```app/routes/posts.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
+    export default class PostsRoute extends Route {
       afterModel(posts, transition) {
         if (posts.get('length') === 1) {
           this.transitionTo('post.show', posts.get('firstObject'));
         }
       }
-    });
+    }
     ```
 
     Refer to documentation for `beforeModel` for a description
@@ -1129,11 +1129,11 @@ class Route extends EmberObject implements IRoute {
     ```app/routes/post.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
+    export default class PostRoute extends Route {
       model(params) {
         return this.store.findRecord('post', params.post_id);
       }
-    });
+    }
     ```
 
     @method model
@@ -1213,23 +1213,22 @@ class Route extends EmberObject implements IRoute {
     If you implement the `setupController` hook in your Route, it will
     prevent this default behavior. If you want to preserve that behavior
     when implementing your `setupController` function, make sure to call
-    `_super`:
+    `super`:
 
     ```app/routes/photos.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
+    export default class PhotosRoute extendes Route {
       model() {
         return this.store.findAll('photo');
-      },
+      }
 
       setupController(controller, model) {
-        // Call _super for default behavior
-        this._super(controller, model);
-        // Implement your custom setup after
+        super.setupController(controller, model);
+
         this.controllerFor('application').set('showingPhotos', true);
       }
-    });
+    }
     ```
 
     The provided controller will be one resolved based on the name
@@ -1249,16 +1248,16 @@ class Route extends EmberObject implements IRoute {
     export default Router;
     ```
 
-    For the `post` route, a controller named `App.PostController` would
-    be used if it is defined. If it is not defined, a basic `Controller`
-    instance would be used.
+    If you have defined a file for the post controller, 
+    the framework will use it.
+    If it is not defined, a basic `Controller` instance would be used.
 
-    Example
+    @example Behavior of a basic Controller
 
     ```app/routes/post.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
+    export default class PostRoute extends Route {
       setupController(controller, model) {
         controller.set('model', model);
       }
@@ -1288,12 +1287,13 @@ class Route extends EmberObject implements IRoute {
     ```app/routes/post.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
+    export default class PostRoute extends Route {
       setupController(controller, post) {
-        this._super(controller, post);
+        super.setupController(controller, post);
+
         this.controllerFor('posts').set('currentPost', post);
       }
-    });
+    }
     ```
 
     @method controllerFor
@@ -1331,12 +1331,13 @@ class Route extends EmberObject implements IRoute {
     ```app/routes/post.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
+    export default class Post extends Route {
       setupController(controller, post) {
-        this._super(controller, post);
+        super.setupController(controller, post);
+
         this.generateController('posts');
       }
-    });
+    }
     ```
 
     @method generateController
@@ -2382,16 +2383,16 @@ Route.reopen(ActionHandler, Evented, {
 
     ```app/routes/index.js
     import Route from '@ember/routing/route';
+    import { action } from '@glimmer/tracking';
 
-    export default Route.extend({
-      actions: {
-        trackIfDebug(arg) {
-          if (debug) {
-            this.send('track', arg);
-          }
+    export default class IndexRoute extends Route {
+      @action
+      trackIfDebug(arg) {
+        if (debug) {
+          this.send('track', arg);
         }
       }
-    });
+    }
     ```
 
     @method send

--- a/packages/@ember/object/lib/computed/computed_macros.js
+++ b/packages/@ember/object/lib/computed/computed_macros.js
@@ -67,15 +67,16 @@ function generateComputedWithPredicate(name, predicate) {
   Example:
 
   ```javascript
-  import { set } from '@ember/object';
   import { empty } from '@ember/object/computed';
+  import { tracked } from '@glimmer/tracking';
 
   class ToDoList {
-    constructor(todos) {
-      set(this, 'todos', todos);
-    }
-
+    @tracked todos;
     @empty('todos') isDone;
+
+    constructor(todos) {
+      this.todos = todos
+    }
   }
 
   let todoList = new ToDoList(
@@ -83,7 +84,7 @@ function generateComputedWithPredicate(name, predicate) {
   );
 
   todoList.isDone; // false
-  set(todoList, 'todos', []);
+  todoList.todos = [];
   todoList.isDone; // true
   ```
 
@@ -135,15 +136,16 @@ export function empty(dependentKey) {
   Example:
 
   ```javascript
-  import { set } from '@ember/object';
   import { notEmpty } from '@ember/object/computed';
+  import { tracked } from '@glimmer/tracking';
 
   class Hamster {
-    constructor(backpack) {
-      set(this, 'backpack', backpack);
-    }
-
+    @tracked backpack;
     @notEmpty('backpack') hasStuff
+
+    constructor(backpack) {
+      this.backpack = backpack;
+    }
   }
 
   let hamster = new Hamster(
@@ -151,7 +153,7 @@ export function empty(dependentKey) {
   );
 
   hamster.hasStuff; // true
-  set(hamster, 'backpack', []);
+  hamster.backpack = []
   hamster.hasStuff; // false
   ```
 
@@ -199,21 +201,20 @@ export function notEmpty(dependentKey) {
   ==, which can be technically confusing.
 
   ```javascript
-  import { set } from '@ember/object';
   import { none } from '@ember/object/computed';
 
   class Hamster {
+    @tracked food;
     @none('food') isHungry;
   }
 
   let hamster = new Hamster();
-
   hamster.isHungry; // true
 
-  set(hamster, 'food', 'Banana');
+  hamster.food = 'Banana';
   hamster.isHungry; // false
-
-  set(hamster, 'food', null);
+  
+  hamster.food = null;
   hamster.isHungry; // true
   ```
 
@@ -264,11 +265,10 @@ export function none(dependentKey) {
   Example:
 
   ```javascript
-  import { set } from '@ember/object';
   import { not } from '@ember/object/computed';
 
   class User {
-    loggedIn = false;
+    @tracked loggedIn = false;
 
     @not('loggedIn') isAnonymous;
   }
@@ -276,7 +276,7 @@ export function none(dependentKey) {
   let user = new User();
 
   user.isAnonymous; // true
-  set(user, 'loggedIn', true);
+  user.loggedIn = true;
   user.isAnonymous; // false
   ```
 
@@ -325,25 +325,23 @@ export function not(dependentKey) {
   Example:
 
   ```javascript
-  import { set } from '@ember/object';
   import { bool } from '@ember/object/computed';
 
-
   class Hamster {
+    @tracked numBananas;
     @bool('numBananas') hasBananas
   }
 
   let hamster = new Hamster();
-
   hamster.hasBananas; // false
 
-  set(hamster, 'numBananas', 0);
+  hamster.numBananas = 0;
   hamster.hasBananas; // false
-
-  set(hamster, 'numBananas', 1);
+  
+  hamster.numBananas = 1;
   hamster.hasBananas; // true
-
-  set(hamster, 'numBananas', null);
+  
+  hamster.numBananas = null;
   hamster.hasBananas; // false
   ```
 
@@ -399,7 +397,6 @@ export function bool(dependentKey) {
   Example:
 
   ```javascript
-  import { set } from '@ember/object';
   import { match } from '@ember/object/computed';
 
   class User {
@@ -407,13 +404,12 @@ export function bool(dependentKey) {
   }
 
   let user = new User();
-
   user.hasValidEmail; // false
 
-  set(user, 'email', '');
+  user.email = '';
   user.hasValidEmail; // false
-
-  set(user, 'email', 'ember_hamster@example.com');
+  
+  user.email = 'ember_hamster@example.com';
   user.hasValidEmail; // true
   ```
 
@@ -466,7 +462,6 @@ export function match(dependentKey, regexp) {
   Example:
 
   ```javascript
-  import { set } from '@ember/object';
   import { equal } from '@ember/object/computed';
 
   class Hamster {
@@ -474,13 +469,12 @@ export function match(dependentKey, regexp) {
   }
 
   let hamster = new Hamster();
-
   hamster.satisfied; // false
 
-  set(hamster, 'percentCarrotsEaten', 100);
+  hamster.percentCarrotsEaten = 100;
   hamster.satisfied; // true
-
-  set(hamster, 'percentCarrotsEaten', 50);
+  
+  hamster.percentCarrotsEaten = 50;
   hamster.satisfied; // false
   ```
 
@@ -495,7 +489,6 @@ export function match(dependentKey, regexp) {
   });
 
   let hamster = Hamster.create();
-
   hamster.satisfied; // false
 
   set(hamster, 'percentCarrotsEaten', 100);
@@ -532,21 +525,21 @@ export function equal(dependentKey, value) {
   Example:
 
   ```javascript
-  import { set } from '@ember/object';
   import { gt } from '@ember/object/computed';
+  import { tracked } from '@glimmer/tracking';
 
   class Hamster {
+    @tracked numBananas;
     @gt('numBananas', 10) hasTooManyBananas;
   }
 
   let hamster = new Hamster();
-
   hamster.hasTooManyBananas; // false
 
-  set(hamster, 'numBananas', 3);
+  hamster.numBananas = 3;
   hamster.hasTooManyBananas; // false
-
-  set(hamster, 'numBananas', 11);
+  
+  hamster.numBananas = 11;
   hamster.hasTooManyBananas; // true
   ```
 
@@ -561,7 +554,6 @@ export function equal(dependentKey, value) {
   });
 
   let hamster = Hamster.create();
-
   hamster.hasTooManyBananas; // false
 
   set(hamster, 'numBananas', 3);
@@ -598,7 +590,6 @@ export function gt(dependentKey, value) {
   Example:
 
   ```javascript
-  import { set } from '@ember/object';
   import { gte } from '@ember/object/computed';
 
   class Hamster {
@@ -606,13 +597,12 @@ export function gt(dependentKey, value) {
   }
 
   let hamster = new Hamster();
-
   hamster.hasTooManyBananas; // false
 
-  set(hamster, 'numBananas', 3);
+  hamster.numBananas = 3;
   hamster.hasTooManyBananas; // false
-
-  set(hamster, 'numBananas', 10);
+  
+  hamster.numBananas = 10;
   hamster.hasTooManyBananas; // true
   ```
 
@@ -664,7 +654,6 @@ export function gte(dependentKey, value) {
   Example:
 
   ```javascript
-  import { set } from '@ember/object';
   import { lt } from '@ember/object/computed';
 
   class Hamster {
@@ -672,13 +661,12 @@ export function gte(dependentKey, value) {
   }
 
   let hamster = new Hamster();
-
   hamster.needsMoreBananas; // true
 
-  set(hamster, 'numBananas', 3);
+  hamster.numBananas = 3;
   hamster.needsMoreBananas; // false
 
-  set(hamster, 'numBananas', 2);
+  hamster.numBananas = 2;
   hamster.needsMoreBananas; // true
   ```
 
@@ -730,7 +718,7 @@ export function lt(dependentKey, value) {
   Example:
 
   ```javascript
-  import { set } from '@ember/object';
+
   import { lte } from '@ember/object/computed';
 
   class Hamster {
@@ -738,13 +726,12 @@ export function lt(dependentKey, value) {
   }
 
   let hamster = new Hamster();
-
   hamster.needsMoreBananas; // true
 
-  set(hamster, 'numBananas', 5);
+  hamster.numBananas = 5;
   hamster.needsMoreBananas; // false
 
-  set(hamster, 'numBananas', 3);
+  hamster.numBananas = 3;
   hamster.needsMoreBananas; // true
   ```
 

--- a/packages/@ember/object/lib/computed/computed_macros.js
+++ b/packages/@ember/object/lib/computed/computed_macros.js
@@ -796,19 +796,18 @@ export function lte(dependentKey, value) {
   }
 
   let tomster = new Hamster();
-
   tomster.readyForCamp; // false
 
-  set(tomster, 'hasTent', true);
+  tomster.hasTent = true;
   tomster.readyForCamp; // false
 
-  set(tomster, 'hasBackpack', true);
+  tomster.hasBackpack = true;
   tomster.readyForCamp; // true
 
-  set(tomster, 'hasBackpack', 'Yes');
+  tomster.hasBackpack = 'Yes';
   tomster.readyForCamp; // 'Yes'
 
-  set(tomster, 'hasWalkingStick', null);
+  tomster.hasWalkingStick = null;
   tomster.readyForHike; // null
   ```
 
@@ -824,7 +823,6 @@ export function lte(dependentKey, value) {
   });
 
   let tomster = Hamster.create();
-
   tomster.readyForCamp; // false
 
   set(tomster, 'hasTent', true);


### PR DESCRIPTION
Part of https://github.com/emberjs/ember.js/issues/18250.

## Missing
- [ ] what to do with `mut` in `get` documentation
- [ ] bring back classic component example for `component` helper
- [ ] normalize `set` and `tracked` in `computed_macros` file
- [ ] review `each-in` for correctness/coesion (key is used before it's introduced)
- [ ] confirm `get` + `mut` example updates properly
- [ ] `action_handler` switch examples to `EmberComponent` so that we can still use the classic `.extend` API.
- [ ] investigate syntax highlighting mishaps - [hasBlock](https://api.emberjs.com/ember/3.12/classes/Ember.Templates.helpers/methods?anchor=hasBlock), [hasBlockParams](https://api.emberjs.com/ember/3.12/classes/Ember.Templates.helpers/methods?anchor=hasBlockParams)
- [ ] `observer` is `Helper` class example
- [ ] `RouterService#recognize` uses a strange ember component

## Missing code samples
- [ ] `RouterService#isActive`
- [ ] `RouterService#recognizeAndLoad`

## Open questions

- [x] classes, named or anonymous? (`class extends Route` vs `class Menu extends Route`) -> named

### Router Service
- [ ] constructor seems ok in code samples? (cc @pzuraq)
- [ ] `currentRoute` example is using `notEmpty` CP decorator. should we replace with native getter? (cc @pzuraq)

### unless
- Consider introducing `not` to the framework, and deprecating `unless` for `{{if (not)}}`

### Action Handler
- [ ] (?) `action_handler` remove mixins (?)

### Controller
- [ ] figure out what to do with `Controller#addObserver` - it's currently using an EmberComponent, which seems strange

### action helper
- [ ] figure out how we want to address classic EmberComponent in [action helper](https://api.emberjs.com/ember/3.12/classes/Ember.Templates.helpers/methods?anchor=action)

### partial

While the partial deprecation is not [currently implemented](https://github.com/emberjs/rfc-tracking/issues/38), it is possible that Octane will ship with it.
Regardless, we should definitely suggest GlimmerComponents instead.

### Helper (class)

- `@observer`?

### Route

- `on('activate', function(){` + native class?
- `willTransition`, `didTransition`, `loading`, `error` actions + native class?