### PR TITLE
[BUGFIX beta] Autotrack Modifiers and Helpers

### DIFF
--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -393,6 +393,6 @@ export { default as OutletView } from './lib/views/outlet';
 export { capabilities } from './lib/component-managers/custom';
 export { setComponentManager, getComponentManager } from './lib/utils/custom-component-manager';
 export { setModifierManager, getModifierManager } from './lib/utils/custom-modifier-manager';
-export { capabilities as modifierCapabilties } from './lib/modifiers/custom';
+export { capabilities as modifierCapabilities } from './lib/modifiers/custom';
 export { isSerializationFirstNode } from './lib/utils/serialization-first-node-helpers';
 export { setComponentTemplate, getComponentTemplate } from './lib/utils/component-template';

--- a/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
@@ -1,6 +1,6 @@
 import { moduleFor, RenderingTestCase, strip, classes, runTask } from 'internal-test-helpers';
 import { ENV } from '@ember/-internals/environment';
-import { setModifierManager } from '@ember/-internals/glimmer';
+import { setModifierManager, modifierCapabilities } from '@ember/-internals/glimmer';
 import { Object as EmberObject } from '@ember/-internals/runtime';
 
 import { set, setProperties } from '@ember/-internals/metal';
@@ -9,6 +9,7 @@ import { Component } from '../../utils/helpers';
 
 class CustomModifierManager {
   constructor(owner) {
+    this.capabilities = modifierCapabilities('3.13');
     this.owner = owner;
   }
 

--- a/packages/@ember/-internals/metal/index.ts
+++ b/packages/@ember/-internals/metal/index.ts
@@ -61,7 +61,7 @@ export { Mixin, aliasMethod, mixin, observer, applyMixin } from './lib/mixin';
 export { default as inject, DEBUG_INJECTION_FUNCTIONS } from './lib/injected_property';
 export { tagForProperty, tagFor, markObjectAsDirty, UNKNOWN_PROPERTY_TAG } from './lib/tags';
 export { default as runInTransaction, didRender, assertNotRendered } from './lib/transaction';
-export { consume, Tracker, tracked, track } from './lib/tracked';
+export { consume, Tracker, tracked, track, untrack } from './lib/tracked';
 
 export {
   NAMESPACES,

--- a/packages/@ember/modifier/index.ts
+++ b/packages/@ember/modifier/index.ts
@@ -1,1 +1,1 @@
-export { setModifierManager, modifierCapabilties as capabilties } from '@ember/-internals/glimmer';
+export { setModifierManager, modifierCapabilities as capabilties } from '@ember/-internals/glimmer';

--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -112,7 +112,7 @@ import {
   TextArea,
   isSerializationFirstNode,
   setModifierManager,
-  modifierCapabilties,
+  modifierCapabilities,
   setComponentTemplate,
   getComponentTemplate,
 } from '@ember/-internals/glimmer';
@@ -528,7 +528,7 @@ Ember.LinkComponent = LinkComponent;
 Ember._setComponentManager = setComponentManager;
 Ember._componentManagerCapabilities = capabilities;
 Ember._setModifierManager = setModifierManager;
-Ember._modifierManagerCapabilties = modifierCapabilties;
+Ember._modifierManagerCapabilities = modifierCapabilities;
 if (EMBER_GLIMMER_SET_COMPONENT_TEMPLATE) {
   Ember._getComponentTemplate = getComponentTemplate;
   Ember._setComponentTemplate = setComponentTemplate;


### PR DESCRIPTION
This PR adds autotracking for modifiers and class based helpers.
Modifiers can opt out of autotracking via a new capabilities flag on
modifier managers.