### PR TITLE
[BUGFIX beta] Router#url should not error when `location` is a string

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -1791,7 +1791,13 @@ EmberRouter.reopen(Evented, {
    @private
  */
   url: computed(function(this: Router<Route>) {
-    return get(this, 'location').getURL();
+    let location = get(this, 'location');
+
+    if (typeof location === 'string') {
+      return undefined;
+    }
+
+    return location.getURL();
   }),
 });
 

--- a/packages/@ember/-internals/routing/tests/system/router_test.js
+++ b/packages/@ember/-internals/routing/tests/system/router_test.js
@@ -283,5 +283,10 @@ moduleFor(
         router.transitionTo('./route-b/1');
       }, "A transition was attempted from 'route-a' to './route-b/1' but the application instance has already been destroyed.");
     }
+
+    ['@test computed url when location is a string should not crash'](assert) {
+      let router = createRouter(undefined, { disableSetup: true });
+      assert.equal(router.url, undefined);
+    }
   }
 );


### PR DESCRIPTION
See: #18260