### PR TITLE
[BUGFIX release] Prevent cycle dependency with owner association.

### DIFF
--- a/packages/@ember/-internals/runtime/lib/system/object.js
+++ b/packages/@ember/-internals/runtime/lib/system/object.js
@@ -11,7 +11,7 @@ import Observable from '../mixins/observable';
 import { assert } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 
-let OVERRIDE_OWNER = symbol('OVERRIDE_OWNER');
+const instanceOwner = new WeakMap();
 
 /**
   `EmberObject` is the main base class for all Ember objects. It is a subclass
@@ -30,8 +30,10 @@ export default class EmberObject extends CoreObject {
   }
 
   get [OWNER]() {
-    if (this[OVERRIDE_OWNER]) {
-      return this[OVERRIDE_OWNER];
+    let owner = instanceOwner.get(this);
+
+    if (owner !== undefined) {
+      return owner;
     }
 
     let factory = FACTORY_FOR.get(this);
@@ -41,7 +43,7 @@ export default class EmberObject extends CoreObject {
   // we need a setter here largely to support
   // folks calling `owner.ownerInjection()` API
   set [OWNER](value) {
-    this[OVERRIDE_OWNER] = value;
+    instanceOwner.set(this, value);
   }
 }
 


### PR DESCRIPTION
Prior to this change, using `assert.deepEqual(obj, ...)` and `expect(obj).to.deeply.equal(...)` would end up printing all of the owner interface (including all of the private properties on the container and registry). This avoids stashing the owner object directly on the object (instead sharing it via WeakMap) which makes certain that the owner/container/register/etc is not emitted.