### PR TITLE
[BUGFIX beta] Allow CPs to depend on nested args

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
@@ -516,6 +516,36 @@ if (EMBER_METAL_TRACKED_PROPERTIES) {
           this.assertText('hello!');
         }
 
+        '@test computed properties can depend on nested args'() {
+          let foo = EmberObject.create({
+            text: 'hello!',
+          });
+
+          class TestComponent extends GlimmerishComponent {
+            @computed('args.foo.text')
+            get text() {
+              return this.args.foo.text;
+            }
+          }
+
+          this.registerComponent('test', {
+            ComponentClass: TestComponent,
+            template: '<p>{{this.text}}</p>',
+          });
+
+          this.render('<Test @foo={{this.foo}}/>', {
+            foo: foo,
+          });
+
+          this.assertText('hello!');
+
+          runTask(() => foo.set('text', 'hello world!'));
+          this.assertText('hello world!');
+
+          runTask(() => foo.set('text', 'hello!'));
+          this.assertText('hello!');
+        }
+
         '@test named args are enumerable'() {
           class TestComponent extends GlimmerishComponent {
             get objectKeys() {


### PR DESCRIPTION
CP chaining on nested args was not setup properly in the last couple of
merges. This fixes and adds a test case.