### PR TITLE
[BUGFIX lts] Check length of targets

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -160,7 +160,7 @@ module.exports = {
     let ember;
     let targets = (this.project && this.project.targets && this.project.targets.browsers) || [];
 
-    if (!isProduction && PRE_BUILT_TARGETS.every(target => targets.includes(target))) {
+    if (!isProduction && (PRE_BUILT_TARGETS.every(target => targets.includes(target)) && targets.length === PRE_BUILT_TARGETS.length)) {
       ember = new Funnel(tree, {
         destDir: 'ember',
         include: ['ember.debug.js', 'ember.debug.map', 'ember-testing.js', 'ember-testing.map'],

--- a/lib/index.js
+++ b/lib/index.js
@@ -160,7 +160,11 @@ module.exports = {
     let ember;
     let targets = (this.project && this.project.targets && this.project.targets.browsers) || [];
 
-    if (!isProduction && (PRE_BUILT_TARGETS.every(target => targets.includes(target)) && targets.length === PRE_BUILT_TARGETS.length)) {
+    if (
+      !isProduction &&
+      (PRE_BUILT_TARGETS.every(target => targets.includes(target)) &&
+        targets.length === PRE_BUILT_TARGETS.length)
+    ) {
       ember = new Funnel(tree, {
         destDir: 'ember',
         include: ['ember.debug.js', 'ember.debug.map', 'ember-testing.js', 'ember-testing.map'],


### PR DESCRIPTION
We had a bug where if you had additional targets added, they would not be checked, we were just checking that all the prebuilt targets were included. This adds a check for length to ensure all the targets are there and no additional ones are.