### PR TITLE
[BUGFIX lts] Ensure {{each-in}} can iterate over keys with periods

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
@@ -304,6 +304,48 @@ if (EMBER_METAL_TRACKED_PROPERTIES) {
 
         assert.strictEqual(computeCount, 2, 'compute is called exactly 2 times');
       }
+
+      '@test each-in autotracks non-tracked values correctly'() {
+        let obj = EmberObject.create({ value: 'bob' });
+
+        this.registerComponent('person', {
+          ComponentClass: Component.extend({ obj }),
+          template: strip`
+            {{#each-in this.obj as |key value|}}
+              {{value}}-{{key}}
+            {{/each-in}}
+          `,
+        });
+
+        this.render('<Person/>');
+
+        this.assertText('bob-value');
+
+        runTask(() => obj.set('value', 'sal'));
+
+        this.assertText('sal-value');
+      }
+
+      '@test each-in autotracks arrays acorrectly'() {
+        let obj = EmberObject.create({ arr: A([1]) });
+
+        this.registerComponent('person', {
+          ComponentClass: Component.extend({ obj }),
+          template: strip`
+            {{#each-in this.obj as |key arr|}}
+              {{#each arr as |v|}}{{v}}{{/each}}
+            {{/each-in}}
+          `,
+        });
+
+        this.render('<Person/>');
+
+        this.assertText('1');
+
+        runTask(() => obj.arr.pushObject(2));
+
+        this.assertText('12');
+      }
     }
   );
 }

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/each-in-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/each-in-test.js
@@ -297,6 +297,22 @@ class EachInTest extends AbstractEachInTest {
 
     this.assertText('Empty!');
   }
+
+  [`@test it can render items that contain keys with periods in them`]() {
+    this.makeHash({ 'period.key': 'a', 'other.period.key': 'b' });
+
+    this.render(
+      `<ul>{{#each-in hash as |key value|}}<li>{{key}}: {{value}}</li>{{else}}Empty!{{/each-in}}</ul>`
+    );
+
+    this.assertText('period.key: aother.period.key: b');
+
+    this.assertStableRerender();
+
+    this.clear();
+
+    this.assertText('Empty!');
+  }
 }
 
 moduleFor(

--- a/packages/@ember/-internals/metal/index.ts
+++ b/packages/@ember/-internals/metal/index.ts
@@ -61,7 +61,7 @@ export { Mixin, aliasMethod, mixin, observer, applyMixin } from './lib/mixin';
 export { default as inject, DEBUG_INJECTION_FUNCTIONS } from './lib/injected_property';
 export { tagForProperty, tagFor, markObjectAsDirty, UNKNOWN_PROPERTY_TAG } from './lib/tags';
 export { default as runInTransaction, didRender, assertNotRendered } from './lib/transaction';
-export { consume, Tracker, tracked, track, untrack } from './lib/tracked';
+export { consume, Tracker, tracked, track, untrack, isTracking } from './lib/tracked';
 
 export {
   NAMESPACES,


### PR DESCRIPTION
This PR refactors the iterator in `each-in` to use standard object get
notation for getting values instead of `Ember.get`. This should work
because:

* All descriptors now install native getters
* Object iterators use `Object.keys` to get the list of keys to iterate
* `unknownProperty` is only ever triggered if a key is not `in` the
  object, which cannot be true if we just got the key using
  `Object.keys`. Thus `unknownProperty` will never be called for
  `each-in`.

This will allow users to use arbitrary keys for their objects, and
iterate over them with `each-in`. Keys will be tracked as if `get` were
used.