### PR TITLE
[BUGFIX lts] Check the EMBER_ENV environment variable after it is set

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,8 +9,6 @@ const buildDebugMacroPlugin = require('./build-debug-macro-plugin');
 const buildStripClassCallcheckPlugin = require('./build-strip-class-callcheck-plugin');
 const injectBabelHelpers = require('./transforms/inject-babel-helpers');
 
-const isProduction = process.env.EMBER_ENV === 'production';
-
 const PRE_BUILT_TARGETS = [
   'last 1 Chrome versions',
   'last 1 Firefox versions',
@@ -170,6 +168,8 @@ module.exports = {
 
     let ember;
     let targets = (this.project && this.project.targets && this.project.targets.browsers) || [];
+
+    const isProduction = process.env.EMBER_ENV === 'production';
 
     if (
       !isProduction &&


### PR DESCRIPTION
The EMBER_ENV variable doesn't get set until addon
hooks actually start running, so we weren't correctly
determining the environment.

Fixes #18294