### PR TITLE
[BUGFIX beta] Use class inheritance for getters and setters

### DIFF
--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -630,6 +630,8 @@ export class ComputedProperty extends ComputedDescriptor {
       } finally {
         endPropertyChanges();
       }
+
+      return ret;
     } else {
       return this.setWithSuspend(obj, keyName, value);
     }

--- a/packages/@ember/-internals/metal/lib/decorator.ts
+++ b/packages/@ember/-internals/metal/lib/decorator.ts
@@ -1,6 +1,7 @@
 import { Meta, meta as metaFor } from '@ember/-internals/meta';
 import { EMBER_METAL_TRACKED_PROPERTIES } from '@ember/canary-features';
 import { assert } from '@ember/debug';
+import { _WeakSet as WeakSet } from '@ember/polyfills';
 import { setClassicDecorator } from './descriptor_map';
 import { unwatch, watch } from './watching';
 
@@ -140,10 +141,16 @@ function DESCRIPTOR_SETTER_FUNCTION(
   name: string,
   descriptor: ComputedDescriptor
 ): (value: any) => void {
-  return function CPSETTER_FUNCTION(this: object, value: any): void {
+  let func = function CPSETTER_FUNCTION(this: object, value: any): void {
     return descriptor.set(this, name, value);
   };
+
+  CP_SETTER_FUNCS.add(func);
+
+  return func;
 }
+
+export const CP_SETTER_FUNCS = new WeakSet();
 
 export function makeComputedDecorator(
   desc: ComputedDescriptor,

--- a/packages/@ember/-internals/metal/lib/property_get.ts
+++ b/packages/@ember/-internals/metal/lib/property_get.ts
@@ -111,9 +111,11 @@ export function get(obj: object, keyName: string): any {
       }
     }
 
-    let descriptor = descriptorForProperty(obj, keyName);
-    if (descriptor !== undefined) {
-      return descriptor.get(obj, keyName);
+    if (!EMBER_METAL_TRACKED_PROPERTIES) {
+      let descriptor = descriptorForProperty(obj, keyName);
+      if (descriptor !== undefined) {
+        return descriptor.get(obj, keyName);
+      }
     }
 
     if (DEBUG && HAS_NATIVE_PROXY) {

--- a/packages/@ember/-internals/metal/tests/accessors/get_test.js
+++ b/packages/@ember/-internals/metal/tests/accessors/get_test.js
@@ -1,6 +1,6 @@
 import { ENV } from '@ember/-internals/environment';
 import { Object as EmberObject } from '@ember/-internals/runtime';
-import { get, getWithDefault, Mixin, observer } from '../..';
+import { get, getWithDefault, Mixin, observer, computed } from '../..';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 import { run } from '@ember/runloop';
 
@@ -312,6 +312,51 @@ moduleFor(
         'foo',
         'should return the set value, not false'
       );
+    }
+
+    ['@test should respect prototypical inheritance when subclasses override CPs'](assert) {
+      let ParentClass = EmberObject.extend({
+        prop: computed({
+          get() {
+            assert.ok(false, 'incorrect getter called');
+            return 123;
+          },
+        }),
+      });
+
+      let SubClass = ParentClass.extend({
+        get prop() {
+          assert.ok(true, 'correct getter called');
+          return 456;
+        },
+      });
+
+      let instance = SubClass.create();
+
+      instance.prop;
+    }
+
+    ['@test should respect prototypical inheritance when subclasses override CPs with native classes'](
+      assert
+    ) {
+      class ParentClass extends EmberObject {
+        @computed
+        get prop() {
+          assert.ok(false, 'incorrect getter called');
+          return 123;
+        }
+      }
+
+      class SubClass extends ParentClass {
+        get prop() {
+          assert.ok(true, 'correct getter called');
+          return 456;
+        }
+      }
+
+      let instance = SubClass.create();
+
+      instance.prop;
     }
   }
 );

--- a/packages/@ember/-internals/metal/tests/accessors/set_test.js
+++ b/packages/@ember/-internals/metal/tests/accessors/set_test.js
@@ -1,4 +1,5 @@
-import { get, set, trySet } from '../..';
+import { Object as EmberObject } from '@ember/-internals/runtime';
+import { get, set, trySet, computed } from '../..';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 moduleFor(
@@ -141,6 +142,51 @@ moduleFor(
       assert.equal(set(obj, 'foo', 'bar'), 'bar', 'should return set value');
       assert.equal(count, 1, 'should have native setter');
       assert.equal(get(obj, 'foo'), 'computed bar', 'should return new value');
+    }
+
+    ['@test should respect prototypical inheritance when subclasses override CPs'](assert) {
+      let ParentClass = EmberObject.extend({
+        prop: computed({
+          set(key, val) {
+            assert.ok(false, 'incorrect setter called');
+            this._val = val;
+          },
+        }),
+      });
+
+      let SubClass = ParentClass.extend({
+        set prop(val) {
+          assert.ok(true, 'correct setter called');
+          this._val = val;
+        },
+      });
+
+      let instance = SubClass.create();
+
+      instance.prop = 123;
+    }
+
+    ['@test should respect prototypical inheritance when subclasses override CPs with native classes'](
+      assert
+    ) {
+      class ParentClass extends EmberObject {
+        @computed
+        set prop(val) {
+          assert.ok(false, 'incorrect setter called');
+          this._val = val;
+        }
+      }
+
+      class SubClass extends ParentClass {
+        set prop(val) {
+          assert.ok(true, 'correct setter called');
+          this._val = val;
+        }
+      }
+
+      let instance = SubClass.create();
+
+      instance.prop = 123;
     }
   }
 );

--- a/packages/@ember/-internals/utils/lib/lookup-descriptor.ts
+++ b/packages/@ember/-internals/utils/lib/lookup-descriptor.ts
@@ -1,4 +1,4 @@
-export default function lookupDescriptor(obj: object, keyName: string) {
+export default function lookupDescriptor(obj: object, keyName: string | symbol) {
   let current: object | null = obj;
   do {
     let descriptor = Object.getOwnPropertyDescriptor(current, keyName);


### PR DESCRIPTION
Currently, `get` and `set` will bypass class inheritance and lookup
descriptors for CPs. If they exist, they call them directly. This
results in bugs where plain, undecorated getters and setters cannot
override CPs on parent classes.

This fix converts us to using class inheritance, looking up descriptors
recursively on the class to find the actual property that is meant to be
accessed for this instance. In the `get` case, this is simple removing
the bypass altogether. For the `set` case, this would result in
behavioral differences:

* An additional `get` triggered just before setting, since `set` gets
the previous value in order to know if it should notify.
* An additional property change notification for CPs, since they must
notify themselves (when set using a native setter, for instance).

Instead, this PR looks up the descriptor and checks to see if it's a
`CPSETTER` function, and triggers it directly if so.

As an alternative, we could put all CPSETTER functions directly into a `WeakSet` and check to see if the setter function exists in that set, rather than checking its `toString()`. I was concerned about perf in doing that, but it would be a bit safer.