### PR TITLE
[BUGFIX beta] Eagerly consume aliases

### DIFF
--- a/packages/@ember/-internals/metal/lib/mixin.ts
+++ b/packages/@ember/-internals/metal/lib/mixin.ts
@@ -13,7 +13,6 @@ import {
   setObservers,
   wrap,
 } from '@ember/-internals/utils';
-import { EMBER_METAL_TRACKED_PROPERTIES } from '@ember/canary-features';
 import { assert, deprecate } from '@ember/debug';
 import { ALIAS_METHOD } from '@ember/deprecated-features';
 import { assign } from '@ember/polyfills';
@@ -33,7 +32,7 @@ import {
 import { addListener, removeListener } from './events';
 import expandProperties from './expand_properties';
 import { classToString, setUnprocessedMixins } from './namespace_search';
-import { addObserver, removeObserver, revalidateObservers } from './observer';
+import { addObserver, removeObserver } from './observer';
 import { defineProperty } from './properties';
 
 const a_concat = Array.prototype.concat;
@@ -477,12 +476,6 @@ export function applyMixin(obj: { [key: string]: any }, mixins: Mixin[]) {
     }
 
     defineProperty(obj, key, desc, value, meta);
-  }
-
-  if (EMBER_METAL_TRACKED_PROPERTIES) {
-    if (!meta.isPrototypeMeta(obj)) {
-      revalidateObservers(obj);
-    }
   }
 
   return obj;

--- a/packages/@ember/-internals/metal/lib/properties.ts
+++ b/packages/@ember/-internals/metal/lib/properties.ts
@@ -9,6 +9,7 @@ import { assert } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 import { Decorator } from './decorator';
 import { descriptorForProperty, isClassicDecorator } from './descriptor_map';
+import { revalidateObservers } from './observer';
 import { overrideChains } from './property_events';
 
 export type MandatorySetterFunction = ((this: object, value: any) => void) & {
@@ -203,8 +204,14 @@ export function defineProperty(
 
   // if key is being watched, override chains that
   // were initialized with the prototype
-  if (watching) {
-    overrideChains(obj, keyName, meta);
+  if (EMBER_METAL_TRACKED_PROPERTIES) {
+    if (!meta.isPrototypeMeta(obj)) {
+      revalidateObservers(obj);
+    }
+  } else {
+    if (watching) {
+      overrideChains(obj, keyName, meta);
+    }
   }
 
   // The `value` passed to the `didDefineProperty` hook is

--- a/packages/@ember/-internals/metal/tests/alias_test.js
+++ b/packages/@ember/-internals/metal/tests/alias_test.js
@@ -51,9 +51,6 @@ moduleFor(
       defineProperty(obj1, 'baz', alias('foo'));
       defineProperty(obj1, 'baz', alias('bar')); // redefine baz
 
-      // bootstrap the alias
-      obj1.baz;
-
       addObserver(obj1, 'baz', incrementCount);
 
       set(obj1, 'foo', 'FOO');
@@ -85,9 +82,6 @@ moduleFor(
       let obj2 = obj1.create();
       defineProperty(obj2, 'baz', alias('bar')); // override baz
 
-      // bootstrap the alias
-      obj2.baz;
-
       set(obj2, 'foo', 'FOO');
       await runLoopSettled();
 
@@ -104,9 +98,6 @@ moduleFor(
     async ['@test an observer of the alias works if added after defining the alias'](assert) {
       defineProperty(obj, 'bar', alias('foo.faz'));
 
-      // bootstrap the alias
-      obj.bar;
-
       addObserver(obj, 'bar', incrementCount);
       set(obj, 'foo.faz', 'BAR');
 
@@ -117,9 +108,6 @@ moduleFor(
     async ['@test an observer of the alias works if added before defining the alias'](assert) {
       addObserver(obj, 'bar', incrementCount);
       defineProperty(obj, 'bar', alias('foo.faz'));
-
-      // bootstrap the alias
-      obj.bar;
 
       set(obj, 'foo.faz', 'BAR');
 


### PR DESCRIPTION
This PR reverts alias's behavior to eagerly consume their alternate keys
when being observed or depended on by other CPs, the same behavior they
had prior to enabling tracked properties. This reintroduces a bug where
this would cause aliased values to be eagerly computed if they were
observed via their alias, but as this was a known issue with a
workaround, it's a better alternative to introducing a much larger
change in behavior.

Fixes #18318