### PR TITLE
[DOC] Octanify API documentation

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -1052,8 +1052,13 @@ const Component = CoreView.extend(
       Returns a jQuery object for this component's element. If you pass in a selector
       string, this method will return a jQuery object, using the current element
       as its buffer.
+
       For example, calling `component.$('li')` will return a jQuery object containing
       all of the `li` elements inside the DOM element of this component.
+
+      Please note that jQuery integration is off by default and this feature will
+      not work properly. To enable this feature, you can read the instructions in
+      the [jquery-integration optional feature guide](https://guides.emberjs.com/release/configuring-ember/optional-features/#toc_jquery-integration).
       @method $
       @param {String} [selector] a jQuery-compatible selector string
       @return {jQuery} the jQuery object for the DOM node

--- a/packages/@ember/-internals/glimmer/lib/helpers/query-param.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/query-param.ts
@@ -11,10 +11,15 @@ import { InternalHelperReference } from '../utils/references';
   This is a helper to be used in conjunction with the link-to helper.
   It will supply url query parameters to the target route.
 
-  Example
+  @example In this example we are setting the `direction` query param to the value `"asc"`
 
-  ```handlebars
-  {{#link-to 'posts' (query-params direction="asc")}}Sort{{/link-to}}
+  ```app/templates/application.hbs
+  <LinkTo
+    @route="posts"
+    {{query-params direction="asc"}}
+  >
+    Sort
+  </LinkTo>
   ```
 
   @method query-params

--- a/packages/@ember/-internals/routing/lib/ext/controller.ts
+++ b/packages/@ember/-internals/routing/lib/ext/controller.ts
@@ -19,6 +19,7 @@ ControllerMixin.reopen({
     Available queryParam types: `boolean`, `number`, `array`.
     If query param type not specified, it will be `string`.
     To explicitly configure a query parameter property so it coerces as expected, you must define a type property:
+
     ```javascript
       queryParams: [{
         category: {
@@ -26,6 +27,7 @@ ControllerMixin.reopen({
         }
       }]
     ```
+
     @for Ember.ControllerMixin
     @property queryParams
     @public


### PR DESCRIPTION
Part of https://github.com/emberjs/ember.js/issues/18250.

## Tasks
- [ ] The use of `observer` in the `Helper` class needs an explanation as to why it requires the classic syntax