### PR TITLE
[BUGFIX beta] improve `fn` & `on` undefined callback message

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/helpers/fn.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/fn.ts
@@ -86,8 +86,9 @@ function fnHelper({ positional }: ICapturedArguments) {
   if (DEBUG && typeof callbackRef[INVOKE] !== 'function') {
     let callback = callbackRef.value();
 
+    const debug = (<any>callbackRef).debug && (<any>callbackRef).debug();
     assert(
-      `You must pass a function as the \`fn\` helpers first argument, you passed ${callback}`,
+      `You must pass a function as the \`fn\` helpers first argument, you passed ${debug} to \`fn\` but it was ${callback}`,
       typeof callback === 'function'
     );
   }

--- a/packages/@ember/-internals/glimmer/lib/modifiers/on.ts
+++ b/packages/@ember/-internals/glimmer/lib/modifiers/on.ts
@@ -101,11 +101,15 @@ export class OnModifierState {
       this.eventName = eventName;
       this.shouldUpdate = true;
     }
+    if (DEBUG) {
+      const debug = args.positional.at(1) && (<any>args.positional.at(1)).debug();
+      const value = args.positional.at(1) && args.positional.at(1).value();
+      assert(
+        `You must pass a function as the second argument to the \`on\` modifier, you passed ${debug} to \`on\` but it was ${value}`,
+        value !== undefined && typeof value === 'function'
+      );
+    }
 
-    assert(
-      'You must pass a function as the second argument to the `on` modifier',
-      args.positional.at(1) !== undefined && typeof args.positional.at(1).value() === 'function'
-    );
     let userProvidedCallback = args.positional.at(1).value() as EventListener;
     if (userProvidedCallback !== this.userProvidedCallback) {
       this.userProvidedCallback = userProvidedCallback;

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/fn-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/fn-test.js
@@ -127,7 +127,7 @@ moduleFor(
           arg1: 'foo',
           arg2: 'bar',
         });
-      }, /You must pass a function as the `fn` helpers first argument, you passed null/);
+      }, /You must pass a function as the `fn` helpers first argument, you passed this.myFunc to `fn` but it was null/);
     }
 
     '@test asserts if the provided function accesses `this` without being bound prior to passing to fn'(


### PR DESCRIPTION
include parent and property key in the message