### PR TITLE
[DOC] Add example for typeOf(A())

### DIFF
--- a/packages/@ember/-internals/runtime/lib/type-of.js
+++ b/packages/@ember/-internals/runtime/lib/type-of.js
@@ -61,6 +61,7 @@ const { toString } = Object.prototype;
   typeOf(true);                   // 'boolean'
   typeOf(new Boolean(true));      // 'boolean'
   typeOf(A);                      // 'function'
+  typeOf(A());                    // 'array'
   typeOf([1, 2, 90]);             // 'array'
   typeOf(/abc/);                  // 'regexp'
   typeOf(new Date());             // 'date'


### PR DESCRIPTION
To distinguish typeOf(A) from typeOf(A()), since they return different values.

Calling `A` as constructor is deprecated.  `A()` is the recommended update.  It is a subtle but notable distinction.