### PR TITLE
[DOC release] Mark `owner.setupRouter()` as public.

### DIFF
--- a/packages/@ember/application/instance.js
+++ b/packages/@ember/application/instance.js
@@ -163,13 +163,21 @@ const ApplicationInstance = EngineInstance.extend({
   },
 
   /**
-    @private
-
     Sets up the router, initializing the child router and configuring the
     location before routing begins.
 
     Because setup should only occur once, multiple calls to `setupRouter`
     beyond the first call have no effect.
+    
+    This is commonly used in order to confirm things that rely on the router
+    are functioning properly from tests that are primarily rendering related.
+    
+    For example, from within [ember-qunit](https://github.com/emberjs/ember-qunit)'s
+    `setupRenderingTest` calling `this.owner.setupRouter()` would allow that
+    rendering test to confirm that any `<LinkTo></LinkTo>`'s that are rendered
+    have the correct URL.
+    
+    @public
   */
   setupRouter() {
     if (this._didSetupRouter) {


### PR DESCRIPTION
This is already very commonly used, and is considered _at least_ intimate APIs but IMHO should be public.