### PR TITLE
[FEAT] API Docs for @dependentKeyCompat

### DIFF
--- a/packages/@ember/object/compat.ts
+++ b/packages/@ember/object/compat.ts
@@ -34,6 +34,90 @@ let wrapGetterSetter = function(_target: object, key: string, desc: PropertyDesc
   return desc;
 };
 
+/**
+  `@dependentKeyCompat` is decorator that can be used on _native getters_ that
+  use tracked properties. It exposes the getter to Ember's classic computed
+  property and observer systems, so they can watch it for changes. It can be
+  used in both native and classic classes.
+
+  Native Example:
+
+  ```js
+  import { tracked } from '@glimmer/tracking';
+  import { dependentKeyCompat } from '@ember/object/compat';
+  import { computed, set } from '@ember/object';
+
+  class Person {
+    @tracked firstName;
+    @tracked lastName;
+
+    @dependentKeyCompat
+    get fullName() {
+      return `${this.firstName} ${this.lastName}`;
+    }
+  }
+
+  class Profile {
+    constructor(person) {
+      set(this, 'person', person);
+    }
+
+    @computed('person.fullName')
+    get helloMessage() {
+      return `Hello, ${this.person.fullName}!`;
+    }
+  }
+  ```
+
+  Classic Example:
+
+  ```js
+  import { tracked } from '@glimmer/tracking';
+  import { dependentKeyCompat } from '@ember/object/compat';
+  import EmberObject, { computed, observer, set } from '@ember/object';
+
+  const Person = EmberObject.extend({
+    firstName: tracked(),
+    lastName: tracked(),
+
+    fullName: dependentKeyCompat(function() {
+      return `${this.firstName} ${this.lastName}`;
+    }),
+  });
+
+  const Profile = EmberObject.extend({
+    person: null,
+
+    helloMessage: computed('person.fullName', function() {
+      return `Hello, ${this.person.fullName}!`;
+    }),
+
+    onNameUpdated: observer('person.fullName', function() {
+      console.log('person name updated!');
+    }),
+  });
+  ```
+
+  `dependentKeyCompat()` can receive a getter function or an object containing
+  `get`/`set` methods when used in classic classes, like computed properties.
+
+  In general, only properties which you _expect_ to be watched by older,
+  untracked clases should be marked as dependency compatible. The decorator is
+  meant as an interop layer for parts of Ember's older classic APIs, and should
+  not be applied to every possible getter/setter in classes. The number of
+  dependency compatible getters should be _minimized_ wherever possible. New
+  application code should not need to use `@dependentKeyCompat`, since it is
+  only for interoperation with older code.
+
+  @public
+  @method dependentKeyCompat
+  @for @ember/object/compat
+  @static
+  @param {PropertyDescriptor|undefined} desc A property descriptor containing
+                                             the getter and setter (when used in
+                                             classic classes)
+  @return {PropertyDecorator} property decorator instance
+ */
 export function dependentKeyCompat(
   target: object,
   key: string,

--- a/packages/@ember/object/index.js
+++ b/packages/@ember/object/index.js
@@ -106,12 +106,13 @@ import { isElementDescriptor, setClassicDecorator } from '@ember/-internals/meta
   They also do not have equivalents in JavaScript directly, so they cannot be
   used for other situations where binding would be useful.
 
+  @public
   @method action
   @for @ember/object
   @static
-  @param {} elementDesc the descriptor of the element to decorate
-  @return {ElementDescriptor} the decorated descriptor
-  @private
+  @param {Function|undefined} callback The function to turn into an action,
+                                       when used in classic classes
+  @return {PropertyDecorator} property decorator instance
 */
 
 const BINDINGS_MAP = new WeakMap();

--- a/tests/docs/expected.js
+++ b/tests/docs/expected.js
@@ -163,6 +163,7 @@ module.exports = {
     'defineProperty',
     'deleteMeta',
     'denodeify',
+    'dependentKeyCompat',
     'deprecate',
     'deprecateFunc',
     'deprecateProperty',


### PR DESCRIPTION
Adds the API docs for `@dependentKeyCompat` as specified in the RFC, and
updates the API docs for `@action` to be more accurate.

Fixes #18322 