### PR TITLE
[BUGFIX] Ensure `updateComponent` is fired consistently

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/component-managers/custom.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/custom.ts
@@ -12,7 +12,7 @@ import {
   Option,
   ProgramSymbolTable,
 } from '@glimmer/interfaces';
-import { PathReference, Tag } from '@glimmer/reference';
+import { createTag, isConst, PathReference, Tag } from '@glimmer/reference';
 import {
   Arguments,
   CapturedArguments,
@@ -324,7 +324,12 @@ export default class CustomComponentManager<ComponentInstance>
   }
 
   getTag({ args }: CustomComponentState<ComponentInstance>): Tag {
-    return args.tag;
+    if (isConst(args)) {
+      // returning a const tag skips the update hook (VM BUG?)
+      return createTag();
+    } else {
+      return args.tag;
+    }
   }
 
   didRenderLayout() {}

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, RenderingTestCase, runTask } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, runTask, strip } from 'internal-test-helpers';
 
 import { Object as EmberObject } from '@ember/-internals/runtime';
 import { set, setProperties, computed } from '@ember/-internals/metal';
@@ -547,7 +547,7 @@ moduleFor(
       this.assertHTML(`<p>Chad Hietala</p>`);
     }
 
-    ['@test updating attributes triggers didUpdateComponent'](assert) {
+    ['@test updating attributes triggers updateComponent and didUpdateComponent'](assert) {
       let TestManager = EmberObject.extend({
         capabilities: capabilities('3.4', {
           destructor: true,
@@ -605,58 +605,104 @@ moduleFor(
       assert.verifySteps(['createComponent', 'getContext', 'didCreateComponent']);
 
       runTask(() => this.context.set('value', 'bar'));
-      assert.verifySteps(['didUpdateComponent']);
+      assert.verifySteps(['updateComponent', 'didUpdateComponent']);
+    }
+
+    ['@test updateComponent fires consistently with or without args'](assert) {
+      let updated = [];
+
+      class TestManager {
+        static create() {
+          return new TestManager();
+        }
+
+        capabilities = capabilities('3.13', {
+          updateHook: true,
+        });
+
+        createComponent(_factory, args) {
+          assert.step('createComponent');
+          return { id: args.named.id || 'no-id' };
+        }
+
+        updateComponent(component) {
+          assert.step('updateComponent');
+          updated.push(component);
+        }
+
+        getContext(component) {
+          assert.step('getContext');
+          return component;
+        }
+      }
+
+      let ComponentClass = setComponentManager(() => new TestManager(), {});
+
+      this.registerComponent('foo-bar', {
+        template: '{{yield}}',
+        ComponentClass,
+      });
+
+      this.render(
+        strip`
+          [<FooBar>{{this.value}}</FooBar>]
+          [<FooBar @id="static-id">{{this.value}}</FooBar>]
+          [<FooBar @id={{this.id}}>{{this.value}}</FooBar>]
+        `,
+        { id: 'dynamic-id', value: 'Hello World' }
+      );
+
+      this.assertHTML(`[Hello World][Hello World][Hello World]`);
+      assert.deepEqual(updated, []);
+      assert.verifySteps([
+        'createComponent',
+        'getContext',
+        'createComponent',
+        'getContext',
+        'createComponent',
+        'getContext',
+      ]);
+
+      runTask(() => this.context.set('value', 'bar'));
+      assert.deepEqual(updated, [{ id: 'no-id' }, { id: 'static-id' }, { id: 'dynamic-id' }]);
+      assert.verifySteps(['updateComponent', 'updateComponent', 'updateComponent']);
     }
 
     ['@test updating arguments does not trigger updateComponent or didUpdateComponent if `updateHook` is false'](
       assert
     ) {
-      let TestManager = EmberObject.extend({
-        capabilities: capabilities('3.13', {
-          updateHook: false,
-        }),
+      class TestManager {
+        capabilities = capabilities('3.13', {
+          /* implied: updateHook: false */
+        });
 
-        createComponent(factory, args) {
+        createComponent() {
           assert.step('createComponent');
-          return factory.create({ args });
-        },
-
-        updateComponent(component, args) {
-          assert.step('updateComponent');
-          set(component, 'args', args);
-        },
-
-        destroyComponent(component) {
-          component.destroy();
-        },
+          return {};
+        }
 
         getContext(component) {
           assert.step('getContext');
           return component;
-        },
+        }
 
-        didUpdateComponent(component) {
-          assert.step('didUpdateComponent');
-          component.didUpdate();
-        },
-      });
+        updateComponent() {
+          throw new Error('updateComponent called unexpectedly');
+        }
 
-      let ComponentClass = setComponentManager(
-        () => {
-          return TestManager.create();
-        },
-        EmberObject.extend({
-          didRender() {},
-          didUpdate() {},
-        })
-      );
+        didUpdateComponent() {
+          throw new Error('didUpdateComponent called unexpectedly');
+        }
+      }
+
+      let ComponentClass = setComponentManager(() => new TestManager(), {});
 
       this.registerComponent('foo-bar', {
         template: `<p ...attributes>Hello world!</p>`,
         ComponentClass,
       });
 
-      this.render('<FooBar data-test={{value}} />', { value: 'foo' });
+      this.render('<FooBar data-test={{this.value}} />', { value: 'foo' });
 
       this.assertHTML(`<p data-test="foo">Hello world!</p>`);
       assert.verifySteps(['createComponent', 'getContext']);


### PR DESCRIPTION
Previously, if you have no args, or all static args, the custom component's (technically, the manager's) `updateComponent` hook will never fire. This is a VM bug that we need to fix, but in the mean time, this is a fine workaround that doesn't has much cost associated with it.