### PR TITLE
[BUGFIX beta] Ensures that `@each` works with non-arrays and array-likes

### DIFF
--- a/packages/@ember/-internals/metal/lib/chain-tags.ts
+++ b/packages/@ember/-internals/metal/lib/chain-tags.ts
@@ -75,9 +75,22 @@ export function getChainTagsForKey(obj: any, path: string) {
       lastSegmentEnd = segmentEnd + 1;
       segmentEnd = path.indexOf('.', lastSegmentEnd);
 
-      // There shouldn't be any more segments after an `@each`, so break
+      // There should be exactly one segment after an `@each` (i.e. `@each.foo`, not `@each.foo.bar`)
       deprecate(
-        `When using @each, you can only chain one property level deep, but ${path} contains a nested chain. Please create an intermediary computed property or switch to tracked properties.`,
+        `When using @each in a dependent-key or an observer, ` +
+          `you can only chain one property level deep after ` +
+          `the @each. That is, \`${path.slice(0, segmentEnd)}\` ` +
+          `is allowed but \`${path}\` (which is what you passed) ` +
+          `is not.\n\n` +
+          `This was never supported. Currently, the extra segments ` +
+          `are silently ignored, i.e. \`${path}\` behaves exactly ` +
+          `the same as \`${path.slice(0, segmentEnd)}\`. ` +
+          `In the future, this will throw an error.\n\n` +
+          `If the current behavior is acceptable for your use case, ` +
+          `please remove the extraneous segments by changing your ` +
+          `key to \`${path.slice(0, segmentEnd)}\`. ` +
+          `Otherwise, please create an intermediary computed property ` +
+          `or switch to using tracked properties.`,
         segmentEnd === -1,
         {
           until: '3.17.0',
@@ -102,13 +115,10 @@ export function getChainTagsForKey(obj: any, path: string) {
       }
 
       if (segmentEnd === -1) {
-        segmentEnd = pathLength;
-      }
-
-      segment = path.slice(lastSegmentEnd, segmentEnd)!;
-
-      if (segment.indexOf('.') !== -1) {
-        segment = segment.substr(0, segment.indexOf('.'));
+        segment = path.slice(lastSegmentEnd);
+      } else {
+        // Deprecated, remove once we turn the deprecation into an assertion
+        segment = path.slice(lastSegmentEnd, segmentEnd);
       }
 
       // Push the tags for each item's property

--- a/packages/@ember/-internals/metal/tests/computed_test.js
+++ b/packages/@ember/-internals/metal/tests/computed_test.js
@@ -193,6 +193,21 @@ moduleFor(
         defineProperty(obj, 'someProp', computed('todos.@each.owner.@each.name', () => {}));
       }, /You used the key "todos\.@each\.owner\.@each\.name" which is invalid\. /);
 
+      let expected = new RegExp(
+        'When using @each in a dependent-key or an observer, ' +
+          'you can only chain one property level deep after the @each\\. ' +
+          'That is, `todos\\.@each\\.owner` is allowed but ' +
+          '`todos\\.@each\\.owner\\.name` \\(which is what you passed\\) is not\\.\n\n' +
+          'This was never supported\\. Currently, the extra segments ' +
+          'are silently ignored, i\\.e\\. `todos\\.@each\\.owner\\.name` ' +
+          'behaves exactly the same as `todos\\.@each\\.owner`\\. ' +
+          'In the future, this will throw an error\\.\n\n' +
+          'If the current behavior is acceptable for your use case, ' +
+          'please remove the extraneous segments by changing your key to ' +
+          '`todos\\.@each\\.owner`\\. Otherwise, please create an ' +
+          'intermediary computed property or switch to using tracked properties\\.'
+      );
+
       expectDeprecation(() => {
         let obj = {
           todos: [],
@@ -200,7 +215,7 @@ moduleFor(
         defineProperty(obj, 'someProp', computed('todos.@each.owner.name', () => {}));
 
         get(obj, 'someProp');
-      }, /When using @each, you can only chain one property level deep, but todos.@each.owner.name contains a nested chain. Please create an intermediary computed property or switch to tracked properties./);
+      }, expected);
     }
   }
 );

--- a/packages/@ember/-internals/runtime/tests/system/object/computed_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/computed_test.js
@@ -9,6 +9,7 @@ import {
 } from '@ember/-internals/metal';
 import { EMBER_METAL_TRACKED_PROPERTIES } from '@ember/canary-features';
 import { oneWay as reads } from '@ember/object/computed';
+import { A as EmberArray, isArray } from '../../..';
 import EmberObject from '../../../lib/system/object';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
@@ -402,6 +403,99 @@ moduleFor(
       assert.equal(instance.foo, 123, 'getters work');
       instance.foo = 456;
       assert.equal(instance.bar, 456, 'setters work');
+    }
+
+    ['@test @each on maybe array'](assert) {
+      let Normalizer = EmberObject.extend({
+        options: null, // null | undefined | { value: any } | Array<{ value: any }>
+
+        // Normalize into Array<any>
+        normalized: computed('options', 'options.value', 'options.@each.value', function() {
+          let { options } = this;
+
+          if (isArray(options)) {
+            return options.map(item => item.value);
+          } else if (options !== null && typeof options === 'object') {
+            return [options.value];
+          } else {
+            return [];
+          }
+        }),
+      });
+
+      let n = Normalizer.create();
+      assert.deepEqual(n.normalized, []);
+
+      n.set('options', { value: 'foo' });
+      assert.deepEqual(n.normalized, ['foo']);
+
+      n.set('options.value', 'bar');
+      assert.deepEqual(n.normalized, ['bar']);
+
+      n.set('options', { extra: 'wat', value: 'baz' });
+      assert.deepEqual(n.normalized, ['baz']);
+
+      n.set('options', EmberArray([{ value: 'foo' }]));
+      assert.deepEqual(n.normalized, ['foo']);
+
+      n.options.pushObject({ value: 'bar' });
+      assert.deepEqual(n.normalized, ['foo', 'bar']);
+
+      n.options.pushObject({ extra: 'wat', value: 'baz' });
+      assert.deepEqual(n.normalized, ['foo', 'bar', 'baz']);
+
+      n.options.clear();
+      assert.deepEqual(n.normalized, []);
+
+      n.set('options', [{ value: 'foo' }, { value: 'bar' }]);
+      assert.deepEqual(n.normalized, ['foo', 'bar']);
+
+      set(n.options[0], 'value', 'FOO');
+      assert.deepEqual(n.normalized, ['FOO', 'bar']);
+
+      n.set('options', null);
+      assert.deepEqual(n.normalized, []);
+    }
+
+    ['@test @each works with array-likes'](assert) {
+      class ArrayLike {
+        constructor(arr = []) {
+          this.inner = arr;
+        }
+
+        get length() {
+          return this.inner.length;
+        }
+
+        objectAt(index) {
+          return this.inner[index];
+        }
+
+        map(fn) {
+          return this.inner.map(fn);
+        }
+      }
+
+      let Normalizer = EmberObject.extend({
+        options: null, // null | ArrayLike<{ value: any }>
+
+        // Normalize into Array<any>
+        normalized: computed('options.@each.value', function() {
+          let options = this.options || [];
+          return options.map(item => item.value);
+        }),
+      });
+
+      let n = Normalizer.create();
+      assert.deepEqual(n.normalized, []);
+
+      let options = new ArrayLike([{ value: 'foo' }]);
+
+      n.set('options', options);
+      assert.deepEqual(n.normalized, ['foo']);
+
+      set(options.objectAt(0), 'value', 'bar');
+      assert.deepEqual(n.normalized, ['bar']);
     }
   }
 );


### PR DESCRIPTION
`@each` should no-op with non arrays, since there is nothing to track,
and should work with array-likes (anything that implements the
`objectAt` and `length` properties.)