### PR TITLE
[BUGFIX beta] Prevent infinite cycles from lazy computed computation

### DIFF
--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -552,8 +552,6 @@ export class ComputedProperty extends ComputedDescriptor {
           });
         }
 
-        finishLazyChains(obj, keyName, ret);
-
         if (this._dependentKeys !== undefined) {
           let tag = combine(getChainTagsForKeys(obj, this._dependentKeys));
 
@@ -565,6 +563,10 @@ export class ComputedProperty extends ComputedDescriptor {
         }
 
         setLastRevisionFor(obj, keyName, tagValue(propertyTag));
+
+        cache.set(keyName, ret);
+
+        finishLazyChains(obj, keyName, ret);
       }
 
       consume(propertyTag!);
@@ -574,8 +576,6 @@ export class ComputedProperty extends ComputedDescriptor {
       if (Array.isArray(ret) || isEmberArray(ret)) {
         consume(tagForProperty(ret, '[]'));
       }
-
-      cache.set(keyName, ret);
 
       return ret;
     } else {

--- a/packages/@ember/-internals/runtime/tests/system/object/computed_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/computed_test.js
@@ -497,5 +497,26 @@ moduleFor(
       set(options.objectAt(0), 'value', 'bar');
       assert.deepEqual(n.normalized, ['bar']);
     }
+
+    ['@test lazy computation cannot cause infinite cycles'](assert) {
+      // This is based off a real world bug found in ember-cp-validations:
+      // https://github.com/offirgolan/ember-cp-validations/issues/659
+      let CycleObject = EmberObject.extend({
+        foo: computed(function() {
+          return EmberObject.extend({
+            parent: this,
+            alias: alias('parent.foo'),
+          }).create();
+        }),
+        bar: computed('foo.alias', () => {}),
+      });
+
+      let obj = CycleObject.create();
+
+      obj.bar;
+      obj.foo;
+
+      assert.ok(true);
+    }
   }
 );


### PR DESCRIPTION
Lazy computed chaining can sometimes lead to infinite cycles that, if a
computed property setup has a natural cycle that leads back to the
original CP which is finishing its chains. Ensuring the cache and
revisions are set _before_ we finish chaining prevents this. Also moves
the `set` into the set block, so we don't reset the value if we're
returning from cache.