### PR TITLE
Use ember-cli-htmlbars for inline precompilation if possible.

### DIFF
--- a/blueprints/component-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -1,7 +1,7 @@
 <% if (testType === 'integration') { %>import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import hbs from '<%= inlinePrecompileModule %>';
 
 module('<%= friendlyTestDescription %>', function(hooks) {
   setupRenderingTest(hooks);

--- a/node-tests/blueprints/component-test-test.js
+++ b/node-tests/blueprints/component-test-test.js
@@ -22,6 +22,24 @@ describe('Blueprint: component-test', function() {
       return emberNew();
     });
 
+    describe('with default setup', function() {
+      it('component-test x-foo', function() {
+        return emberGenerateDestroy(['component-test', 'x-foo'], _file => {
+          expect(_file('tests/integration/components/x-foo-test.js')).to.equal(
+            fixture('component-test/rfc232.js')
+          );
+        });
+      });
+
+      it('component-test x-foo --unit', function() {
+        return emberGenerateDestroy(['component-test', 'x-foo', '--unit'], _file => {
+          expect(_file('tests/unit/components/x-foo-test.js')).to.equal(
+            fixture('component-test/rfc232-unit.js')
+          );
+        });
+      });
+    });
+
     describe('with ember-cli-qunit@4.1.0', function() {
       beforeEach(function() {
         modifyPackages([

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "inflection": "^1.12.0",
     "jquery": "^3.4.1",
     "resolve": "^1.11.1",
+    "semver": "^6.1.1",
     "silent-error": "^1.1.1"
   },
   "devDependencies": {
@@ -136,7 +137,6 @@
     "route-recognizer": "^0.3.4",
     "router_js": "^6.2.5",
     "rsvp": "^4.8.5",
-    "semver": "^6.1.1",
     "serve-static": "^1.14.1",
     "simple-dom": "^1.4.0",
     "testem": "^2.17.0",


### PR DESCRIPTION
ember-cli-htmlbars@4.0.0+ provides the ability to do inline precompilation out of the box (no need for a separate addon), this updates our test generator to import from the right place and avoid installing the second addon if we don't need it.