### PR TITLE
[BUGFIX beta] Fix hbs import path

### DIFF
--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -62,9 +62,9 @@ module.exports = useTestFrameworkDetector({
       componentPathName = [options.path, dasherizedModuleName].filter(Boolean).join('/');
     }
 
-    let inlinePrecompileModule = this._useSeparateInlinePrecompileAddon()
-      ? 'htmlbars-inline-precompile'
-      : 'ember-cli-htmlbars';
+    let hbsImportStatement = this._useSeparateInlinePrecompileAddon()
+      ? "import hbs from 'htmlbars-inline-precompile';"
+      : "import { hbs } from 'ember-cli-htmlbars';";
 
     let templateInvocation = invocationFor(options);
     let componentName = templateInvocation;
@@ -82,7 +82,7 @@ module.exports = useTestFrameworkDetector({
       closeComponent,
       selfCloseComponent,
       friendlyTestDescription,
-      inlinePrecompileModule,
+      hbsImportStatement,
     };
   },
 

--- a/blueprints/component-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -1,7 +1,7 @@
 <% if (testType === 'integration') { %>import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from '<%= inlinePrecompileModule %>';
+<%= hbsImportStatement %>
 
 module('<%= friendlyTestDescription %>', function(hooks) {
   setupRenderingTest(hooks);


### PR DESCRIPTION
This is currently broken on the Octane blueprint:

```
/home/travis/build/ember-learn/super-rentals-tutorial/dist/code/super-rentals/super-rentals/tests/integration/components/jumbo-test.js: Only `import { hbs } from 'ember-cli-htmlbars'` is supported. You used: `import hbs from 'ember-cli-htmlbars';`
  2 | import { setupRenderingTest } from 'ember-qunit';
  3 | import { render } from '@ember/test-helpers';
> 4 | import hbs from 'ember-cli-htmlbars';
    | ^
  5 |
  6 | module('Integration | Component | jumbo', function(hooks) {
  7 |   setupRenderingTest(hooks);
```