### PR TITLE
WIP: Provide Tracked  Debugging Tools

### DIFF
--- a/packages/@ember/-internals/metal/index.ts
+++ b/packages/@ember/-internals/metal/index.ts
@@ -61,7 +61,7 @@ export { Mixin, aliasMethod, mixin, observer, applyMixin } from './lib/mixin';
 export { default as inject, DEBUG_INJECTION_FUNCTIONS } from './lib/injected_property';
 export { tagForProperty, tagFor, markObjectAsDirty, UNKNOWN_PROPERTY_TAG } from './lib/tags';
 export { default as runInTransaction, didRender, assertNotRendered } from './lib/transaction';
-export { consume, Tracker, tracked, track, untrack, isTracking } from './lib/tracked';
+export { consume, Tracker, tracked, track, untrack, isTracking } from './lib/tracked/index';
 
 export {
   NAMESPACES,

--- a/packages/@ember/-internals/metal/lib/alias.ts
+++ b/packages/@ember/-internals/metal/lib/alias.ts
@@ -24,7 +24,7 @@ import { defineProperty } from './properties';
 import { get } from './property_get';
 import { set } from './property_set';
 import { tagForProperty } from './tags';
-import { consume, untrack } from './tracked';
+import { consume, untrack } from './tracked/index';
 
 const CONSUMED = Object.freeze({});
 

--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -39,7 +39,7 @@ import { defineProperty } from './properties';
 import { beginPropertyChanges, endPropertyChanges, notifyPropertyChange } from './property_events';
 import { set } from './property_set';
 import { tagForProperty } from './tags';
-import { consume, track, untrack } from './tracked';
+import { consume, track, untrack } from './tracked/index';
 
 export type ComputedPropertyGetter = (keyName: string) => any;
 export type ComputedPropertySetter = (keyName: string, value: any, cachedValue?: any) => any;

--- a/packages/@ember/-internals/metal/lib/property_get.ts
+++ b/packages/@ember/-internals/metal/lib/property_get.ts
@@ -8,7 +8,7 @@ import { DEBUG } from '@glimmer/env';
 import { descriptorForProperty } from './descriptor_map';
 import { isPath } from './path_cache';
 import { tagForProperty } from './tags';
-import { consume, isTracking } from './tracked';
+import { consume, isTracking } from './tracked/index';
 
 export const PROXY_CONTENT = symbol('PROXY_CONTENT');
 

--- a/packages/@ember/-internals/metal/lib/tags.ts
+++ b/packages/@ember/-internals/metal/lib/tags.ts
@@ -37,6 +37,7 @@ export function tagForProperty(object: any, propertyKey: string | symbol, _meta?
       }
 
       (newTag as any)._propertyKey = propertyKey;
+      (newTag as any)._object = object;
     }
 
     return (tags[propertyKey] = newTag);

--- a/packages/@ember/-internals/metal/lib/tracked/debug-printing.ts
+++ b/packages/@ember/-internals/metal/lib/tracked/debug-printing.ts
@@ -54,12 +54,11 @@ function printDependents(
   let verboseOverride = getTrackingInfo().verbose;
 
   dependencies.forEach(dependency => {
-    let isChangedProperty = rootTag.tag.propertyName === dependency.propertyName;
-
-    let wasChanged = hasChanged(rootTag, dependency.dependencies);
+    let isChanged = rootTag.tag.lastChecked === dependency.revision;
+    let isChangedProperty = isChanged;
 
     if (!verboseOverride) {
-      if (!verbose && !wasChanged) {
+      if (!verbose && !isChangedProperty) {
         return;
       }
     }
@@ -81,4 +80,3 @@ function printDependents(
     printDependents(rootTag, dependency.dependencies, verbose, indent + 2);
   });
 }
-

--- a/packages/@ember/-internals/metal/lib/tracked/debug-printing.ts
+++ b/packages/@ember/-internals/metal/lib/tracked/debug-printing.ts
@@ -1,0 +1,84 @@
+import { TrackerSnapshot, TagSnapshot } from './debug-types';
+import { hasBeenSet, hasChanged, getTrackingInfo } from './debug-utils';
+
+export function prettyPrintTrackingInfo({ verbose = false, showInitial = true } = {}) {
+  let history = getTrackingInfo().history;
+  let revisions = Object.keys(history)
+    .map(revision => parseInt(revision, 10))
+    .sort((a, b) => a - b);
+
+  let i;
+  let currentRevision: number;
+  let currentBatch: TrackerSnapshot[];
+  let changedTag: TrackerSnapshot;
+
+  for (i = 0; i < revisions.length; i++) {
+    currentRevision = revisions[i];
+    currentBatch = history[currentRevision] || [];
+
+    if (!showInitial && `${currentRevision}` === '1') {
+      continue;
+    }
+
+    // eslint-disable-next-line no-console
+    console.log(`[Revision: ${currentRevision}]`, currentBatch);
+    changedTag = currentBatch[0];
+
+    currentBatch.forEach((tracker, idx: number) => {
+      let { objectName, propertyName, objectId } = tracker.tag;
+
+      let wasSet = hasBeenSet(tracker);
+
+      if (wasSet) {
+        // eslint-disable-next-line no-console
+        console.log(`  #${idx}: ${propertyName} on ${objectName} (#${objectId}) has been set!`);
+      } else {
+        // eslint-disable-next-line no-console
+        console.log(`  #${idx}: ${propertyName} on ${objectName} (#${objectId}) has changed!`);
+      }
+
+      printDependents(changedTag, tracker.dependencies, verbose);
+    });
+  }
+}
+
+function printDependents(
+  rootTag: TrackerSnapshot,
+  dependencies: TagSnapshot[],
+  verbose: boolean,
+  indent = 6
+) {
+  if (!dependencies || dependencies.length === 0) return;
+
+  let indentation = ' '.repeat(indent);
+  let verboseOverride = getTrackingInfo().verbose;
+
+  dependencies.forEach(dependency => {
+    let isChangedProperty = rootTag.tag.propertyName === dependency.propertyName;
+
+    let wasChanged = hasChanged(rootTag, dependency.dependencies);
+
+    if (!verboseOverride) {
+      if (!verbose && !wasChanged) {
+        return;
+      }
+    }
+
+    if (!dependency.objectRef && !dependency.propertyName) {
+      // eslint-disable-next-line no-console
+      console.log(`${indentation} Intermediate Tracking Tag @ rev: ${dependency.revision}`);
+    } else {
+      // eslint-disable-next-line no-console
+      console.log(
+        `${indentation}Dependency: ${dependency.propertyName} ` +
+          `(rev: ${dependency.revision}) on ` +
+          `${dependency.objectName} ` +
+          `(#${dependency.objectId}) ` +
+          `${isChangedProperty ? 'changed' : 'did not change'}`
+      );
+    }
+
+    printDependents(rootTag, dependency.dependencies, verbose, indent + 2);
+  });
+}
+

--- a/packages/@ember/-internals/metal/lib/tracked/debug-types.ts
+++ b/packages/@ember/-internals/metal/lib/tracked/debug-types.ts
@@ -1,0 +1,36 @@
+import { Tag, UpdatableTag } from '@glimmer/reference';
+
+export interface StartOptions {
+  watch?: boolean;
+  forObject?: object;
+  history?: boolean;
+  verbose?: boolean;
+}
+export interface DebugTracking {
+  history: { [revision: number]: TrackerSnapshot[] };
+  objectMap: WeakMap<object, number>;
+  isRecording: boolean;
+  isWatching: boolean;
+  isTrackingHistory: boolean;
+  verbose: boolean;
+  objectOfRelevance?: object;
+  print: (options?: { verbose?: boolean; showInitial?: boolean }) => void;
+  start: (options: StartOptions) => void;
+  stop: () => void;
+}
+
+export interface TrackerSnapshot {
+  tag: TagSnapshot;
+  dependencies: TagSnapshot[];
+  all: TagSnapshot[];
+}
+
+export interface TagSnapshot {
+  propertyName: string;
+  objectName: string;
+  objectRef: object;
+  objectId: number;
+  revision: number;
+  tag: Tag | UpdatableTag;
+  dependencies: TagSnapshot[];
+}

--- a/packages/@ember/-internals/metal/lib/tracked/debug-types.ts
+++ b/packages/@ember/-internals/metal/lib/tracked/debug-types.ts
@@ -31,6 +31,7 @@ export interface TagSnapshot {
   objectRef: object;
   objectId: number;
   revision: number;
+  lastChecked: number;
   tag: Tag | UpdatableTag;
   dependencies: TagSnapshot[];
 }

--- a/packages/@ember/-internals/metal/lib/tracked/debug-utils.ts
+++ b/packages/@ember/-internals/metal/lib/tracked/debug-utils.ts
@@ -1,0 +1,53 @@
+import { TrackerSnapshot, TagSnapshot, DebugTracking } from './debug-types';
+
+export function containsRelevantObject(trackerSnapshot: TrackerSnapshot): boolean {
+  let obj = getTrackingInfo().objectOfRelevance;
+
+  function isRelevant(tag: TagSnapshot): boolean {
+    if (tag.objectRef === obj) {
+      return true;
+    }
+
+    for (let dep of tag.dependencies || []) {
+      if (isRelevant(dep)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  for (let tag of trackerSnapshot.all) {
+    if (isRelevant(tag)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function getTrackingInfo(): DebugTracking {
+  return Ember.EMBER_DEBUG.TRACKING;
+}
+
+export function hasBeenSet(tracker: TrackerSnapshot) {
+  return tracker.dependencies.length === 0;
+}
+
+export function hasChanged(rootTag: TrackerSnapshot, dependencies: TagSnapshot[]): boolean {
+  if (!dependencies || dependencies.length === 0) return false;
+
+  for (let i = 0; i < dependencies.length; i++) {
+    let dependency = dependencies[i];
+    let isChangedProperty = rootTag.tag.propertyName === dependency.propertyName;
+
+    if (isChangedProperty) {
+      return true;
+    }
+
+    return hasChanged(rootTag, dependency.dependencies);
+  }
+
+  return false;
+}
+

--- a/packages/@ember/-internals/metal/lib/tracked/debugging.ts
+++ b/packages/@ember/-internals/metal/lib/tracked/debugging.ts
@@ -18,6 +18,8 @@ interface TagSnapshot {
   propertyName: string;
   objectName: string;
   objectRef: object;
+  revision: number;
+  lastChecked: number;
   tag: Tag | UpdatableTag;
   dependencies: TagSnapshot[];
 }
@@ -35,7 +37,7 @@ function prettyPrintTrackingInfo() {
   let history = getTrackingInfo().history;
   let revisions = Object.keys(history)
     .map(revision => parseInt(revision, 10))
-    .sort();
+    .sort((a, b) => a - b);
 
   let i;
   let currentRevision: number;
@@ -78,12 +80,12 @@ function printDependents(rootTag: TrackerSnapshot, dependencies: TagSnapshot[], 
 
     if (!dependency.objectRef && !dependency.propertyName) {
       // eslint-disable-next-line no-console
-      console.log(`${indentation} Intermediate Tracking Tag @ rev: ${(dependency.tag as any).revision}`);
+      console.log(`${indentation} Intermediate Tracking Tag @ rev: ${dependency.revision}`);
     } else {
       // eslint-disable-next-line no-console
       console.log(
         `${indentation}Dependency: ${dependency.propertyName} ` +
-          `(rev: ${(dependency.tag as any).revision}) on ` +
+          `(rev: ${dependency.revision}) on ` +
           `${dependency.objectName} ` +
           `${isChangedProperty ? 'changed' : 'did not change'}`
       );
@@ -165,6 +167,8 @@ function toTagSnapshot(tag: any): TagSnapshot {
   let result: Partial<TagSnapshot> = {
     objectName: hostObject && hostObject.__proto__.constructor.name,
     objectRef: hostObject,
+    revision: tag.revision,
+    lastChecked: tag.lastChecked,
     tag,
   };
 

--- a/packages/@ember/-internals/metal/lib/tracked/debugging.ts
+++ b/packages/@ember/-internals/metal/lib/tracked/debugging.ts
@@ -4,39 +4,147 @@ import { Tracker } from './tracker';
 
 type Option<T> = T | null;
 
-Ember.EMBER_DEBUG = {};
-
-interface TrackerHistory {
-  property: string;
-  value: any;
-  tracker: Tracker;
-}
-
 interface DebugTracking {
-  history: TrackerHistory[];
-  stacks: Set<Tracker>;
+  history: { [revision: number]: TrackerSnapshot[] };
 }
 
 interface TrackerSnapshot {
-  tags: Array<Tag | UpdatableTag>;
+  tag: TagSnapshot;
+  dependents: TagSnapshot[];
+  all: TagSnapshot[];
 }
 
-interface TrackerProperty {
+interface TagSnapshot {
   propertyName: string;
   objectName: string;
   objectRef: object;
   tag: Tag | UpdatableTag;
 }
 
+Ember.EMBER_DEBUG = {};
 Ember.EMBER_DEBUG.TRACKING = {
   history: [],
-  stacks: new Set<Tracker>(),
 } as DebugTracking;
 
-function normalizeTrackerEntry(tag: any) {
+/*
+ * example / summary of how tracking works:
+ *
+from @pzuraq:
+
+class Component {
+  get foo() {
+    return this.bar;
+  }
+
+  get bar() {
+    consume(this._barTag);
+    return this._bar;
+  }
+
+  set bar(value) {
+    dirty(this._barTag);
+    this._bar = value;
+  }
+}
+
+let component = new Component();
+
+let tag = track(() => {
+  // get {{this.foo}} to render it
+  component.foo
+});
+let tagValue = value(tag);
+validate(tag, tagValue); // true, nothing has changed
+
+// later
+component.bar = 123;
+
+validate(tag, tagValue); // false, something has changed
+
+ *
+ */
+function getTrackingInfo(): DebugTracking {
+  return Ember.EMBER_DEBUG.TRACKING;
+}
+
+function prettyPrintTrackingInfo() {
+  let history = getTrackingInfo().history;
+  let revisions = Object.keys(history)
+    .map(revision => parseInt(revision, 10))
+    .sort();
+
+  let i;
+  let currentRevision: number;
+  let currentBatch: TrackerSnapshot[];
+  let changedTag: TrackerSnapshot;
+
+  for (i = 0; i < revisions.length; i++) {
+    currentRevision = revisions[i];
+    currentBatch = history[currentRevision] || [];
+
+    console.log(`[Revision: ${currentRevision}]`, currentBatch);
+    changedTag = currentBatch[0];
+
+    currentBatch.forEach((tracker, idx: number) => {
+      if (tracker.dependents.length === 0) {
+        console.log(
+          `  #${idx}: ${tracker.tag.propertyName} on ${tracker.tag.objectName} has been set!`
+        );
+      } else {
+        console.log(
+          `  #${idx}: ${tracker.tag.propertyName} on ${tracker.tag.objectName} has changed!`
+        );
+
+        tracker.dependents.forEach(dependent => {
+          let isChangedProperty = changedTag.tag.propertyName === dependent.propertyName;
+
+          console.log(
+            `      Dependency: ${dependent.propertyName} on ${dependent.objectName} ` +
+              `${isChangedProperty ? 'changed' : 'did not change'}`
+          );
+        });
+      }
+    });
+  }
+}
+
+Ember.EMBER_DEBUG.TRACKING.print = prettyPrintTrackingInfo;
+
+export function debugTracker(current: Tracker, _parent: Option<Tracker>) {
+  // Put into "revision" buckets, based on "lastChecked"
+  // (because the revision of a tag may not have changed if the value didn't changed
+  //  but last-checked is the last revision to inspect it)
+  let lastChecked = `${(current as any).last.lastChecked}`;
+  console.log('debugTrack', current, lastChecked);
+
+  // Convert the Tracker to an isolated moment in time
+  // hack around tags being a private field
+  let tags = Array.from((current as any).tags.values()) as Tag[];
+
+  // NOTE: if a tag has subtags, it is computed
+  // TODO: tests -- this is getting complicated
+  let normalizedTags = tags.map(toTagSnapshot);
+  let [trackedTag, ...trackedDependents] = normalizedTags;
+  let dependents = trackedDependents || (trackedTag.tag.subtags || []).map(toTagSnapshot);
+
+  let trackerSnapshot = {
+    tag: trackedTag,
+    dependents,
+    all: normalizedTags,
+  } as TrackerSnapshot;
+
+  let currentBatch = getTrackingInfo().history[lastChecked];
+  let batch = currentBatch || [];
+
+  batch.push(trackerSnapshot);
+
+  Ember.EMBER_DEBUG.TRACKING.history[lastChecked] = batch;
+}
+
+function toTagSnapshot(tag: any): TagSnapshot {
   let hostObject = tag.key ? tag.ref.parentValue : tag._object;
 
-  let result: Partial<TrackerProperty> = {
+  let result: Partial<TagSnapshot> = {
     objectName: hostObject && hostObject.__proto__.constructor.name,
     objectRef: hostObject,
     tag,
@@ -44,44 +152,19 @@ function normalizeTrackerEntry(tag: any) {
 
   result.propertyName = tag.key || tag._propertyKey;
 
-  return result;
+  return result as TagSnapshot;
 }
 
-function prettyPrintTrackingInfo() {
-  let history = Ember.EMBER_DEBUG.TRACKING.history;
-
-  // console.log(history, TAG_MAP);
-  history.forEach((tracker: TrackerSnapshot, i: number) => {
-    // tags seems to always be a touple
-    // (property that changed, the source property)
-    let values = tracker.tags;
-
-    let first = values[0];
-    let last = values[values.length - 1];
-
-    console.log(
-      '\t',
-      i,
-      normalizeTrackerEntry(first),
-      'Because',
-      normalizeTrackerEntry(last),
-      'changed'
-    );
-  });
-}
-
-Ember.EMBER_DEBUG.TRACKING.print = prettyPrintTrackingInfo;
-
-export function debugTracker(current: Tracker, parent: Option<Tracker>) {
-  console.log('debugTrack', current, parent);
-  // Convert the Tracker to an isolated moment in time
-  Ember.EMBER_DEBUG.TRACKING.history.push({
-    // hack around tags being a private field
-    tags: Array.from((current as any).tags.values()),
-  });
-}
-
-
+// NOTE:
+//  track is a wrapper around a tag
+//    cosume is called on other tags
+//
+//  let tag = track(() => {
+//    cosume(someTag);
+//    cosume(someTagB);
+//  })
+//
+//  dirty(someTag); // also invalidates 'tag';
 export function debugConsume(tracker: Tracker, tag: Tag | UpdatableTag) {
   console.log('Consume', tracker, tag);
 }

--- a/packages/@ember/-internals/metal/lib/tracked/debugging.ts
+++ b/packages/@ember/-internals/metal/lib/tracked/debugging.ts
@@ -136,9 +136,9 @@ function prettyPrintTrackingInfo({ verbose = false }) {
       } else {
         // eslint-disable-next-line no-console
         console.log(`  #${idx}: ${propertyName} on ${objectName} (#${objectId}) has changed!`);
-
-        printDependents(changedTag, tracker.dependencies, verbose);
       }
+
+      printDependents(changedTag, tracker.dependencies, verbose);
     });
   }
 }

--- a/packages/@ember/-internals/metal/lib/tracked/debugging.ts
+++ b/packages/@ember/-internals/metal/lib/tracked/debugging.ts
@@ -25,7 +25,6 @@ interface TagSnapshot {
   objectRef: object;
   objectId: number;
   revision: number;
-  lastChecked: number;
   tag: Tag | UpdatableTag;
   dependencies: TagSnapshot[];
 }
@@ -234,9 +233,13 @@ function getOrAssignId(obj: object) {
   return id;
 }
 
+function nameOf(obj: any) {
+  return obj && obj.__proto__.constructor.name;
+}
+
 // the attributes we want live all over the place
 function toTagSnapshot(tag: any): TagSnapshot {
-  let kind = tag.__proto__.constructor.name;
+  let kind = nameOf(tag);
 
   if (kind === 'TwoWayFlushDetectionTag') {
     let hostObject = tag.ref.propertyTag.subtag._object;
@@ -244,7 +247,7 @@ function toTagSnapshot(tag: any): TagSnapshot {
     let revision = Math.max(tag.ref.lastRevision, tag.ref.propertyTag.lastChecked);
 
     return {
-      objectName: hostObject && hostObject.__proto__.constructor.name,
+      objectName: nameOf(hostObject),
       objectRef: hostObject,
       objectId: objectId || -1,
       propertyName: tag.key,
@@ -257,10 +260,9 @@ function toTagSnapshot(tag: any): TagSnapshot {
     let revision = Math.max(tag.lastValue, tag.lastChecked);
 
     return {
-      objectName: hostObject && hostObject.__proto__.constructor.name,
+      objectName: nameOf(hostObject),
       objectRef: hostObject,
       objectId: objectId || -1,
-      lastChecked: tag.lastChecked,
       propertyName: tag._propertyKey,
       revision,
       tag,

--- a/packages/@ember/-internals/metal/lib/tracked/debugging.ts
+++ b/packages/@ember/-internals/metal/lib/tracked/debugging.ts
@@ -9,8 +9,10 @@ interface DebugTracking {
   history: { [revision: number]: TrackerSnapshot[] };
   objectMap: WeakMap<object, number>;
   isRecording: boolean;
+  isWatching: boolean;
   start: () => void;
   stop: () => void;
+  watch: () => void;
 }
 
 interface TrackerSnapshot {
@@ -40,6 +42,9 @@ Ember.EMBER_DEBUG.TRACKING = {
     getTrackingInfo().history = {};
     getTrackingInfo().objectMap = new WeakMap();
     getTrackingInfo().isRecording = true;
+  },
+  watch() {
+    getTrackingInfo().isWatching = true;
   },
   stop() {
     getTrackingInfo().isRecording = false;
@@ -83,6 +88,11 @@ export function debugTracker(current: Tracker, _parent: Option<Tracker>) {
   batch.push(trackerSnapshot);
 
   Ember.EMBER_DEBUG.TRACKING.history[revision] = batch;
+
+  if (getTrackingInfo().isWatching) {
+    console.clear();
+    prettyPrintTrackingInfo();
+  }
 }
 
 function hasBeenSet(tracker: TrackerSnapshot) {
@@ -106,7 +116,7 @@ function hasChanged(rootTag: TrackerSnapshot, dependencies: TagSnapshot[]): bool
   return false;
 }
 
-function prettyPrintTrackingInfo({ verbose = false }) {
+function prettyPrintTrackingInfo({ verbose = false } = {}) {
   let history = getTrackingInfo().history;
   let revisions = Object.keys(history)
     .map(revision => parseInt(revision, 10))

--- a/packages/@ember/-internals/metal/lib/tracked/debugging.ts
+++ b/packages/@ember/-internals/metal/lib/tracked/debugging.ts
@@ -139,7 +139,6 @@ export function debugTracker(current: Tracker, _parent: Option<Tracker>) {
   }
 
   if (isWatching) {
-    console.clear();
     prettyPrintTrackingInfo();
   }
 }

--- a/packages/@ember/-internals/metal/lib/tracked/debugging.ts
+++ b/packages/@ember/-internals/metal/lib/tracked/debugging.ts
@@ -73,6 +73,7 @@ function prettyPrintTrackingInfo() {
 Ember.EMBER_DEBUG.TRACKING.print = prettyPrintTrackingInfo;
 
 export function debugTracker(current: Tracker, parent: Option<Tracker>) {
+  console.log('debugTrack', current, parent);
   // Convert the Tracker to an isolated moment in time
   Ember.EMBER_DEBUG.TRACKING.history.push({
     // hack around tags being a private field
@@ -81,6 +82,6 @@ export function debugTracker(current: Tracker, parent: Option<Tracker>) {
 }
 
 
-export function debugConsume(tracker: Tracker, tag: Tag | UpdatableTag, target: any) {
-  console.log('Consume started', tracker, tag);
+export function debugConsume(tracker: Tracker, tag: Tag | UpdatableTag) {
+  console.log('Consume', tracker, tag);
 }

--- a/packages/@ember/-internals/metal/lib/tracked/debugging.ts
+++ b/packages/@ember/-internals/metal/lib/tracked/debugging.ts
@@ -135,7 +135,7 @@ export function debugTracker(current: Tracker, _parent: Option<Tracker>) {
 
     Ember.EMBER_DEBUG.TRACKING.history[revision] = batch;
   } else {
-    Ember.EMBER_DEBUG.TRACKING.history['latest'] = [trackerSnapshot];
+    Ember.EMBER_DEBUG.TRACKING.history['0'] = [trackerSnapshot];
   }
 
   if (isWatching) {

--- a/packages/@ember/-internals/metal/lib/tracked/debugging.ts
+++ b/packages/@ember/-internals/metal/lib/tracked/debugging.ts
@@ -1,0 +1,110 @@
+import { Tag, CONSTANT_TAG, UpdatableTag } from '@glimmer/reference';
+
+import { Tracker } from './tracker';
+
+type Option<T> = T | null;
+
+Ember.EMBER_DEBUG = {};
+
+let TAG_MAP = new Map<Tag | UpdatableTag, any>();
+
+interface TrackerHistory {
+  property: string;
+  value: any;
+  tracker: Tracker;
+}
+
+interface DebugTracking {
+  history: TrackerHistory[];
+  stacks: Set<Tracker>;
+}
+
+interface TrackerSnapshot {
+  tags: Array<Tag | UpdatableTag>;
+}
+
+interface TrackerProperty {
+  propertyName: string;
+  objectName: string;
+  objectRef: object;
+  tag: Tag | UpdatableTag;
+}
+
+Ember.EMBER_DEBUG.TRACKING = {
+  history: [],
+  stacks: new Set<Tracker>(),
+} as DebugTracking;
+
+function normalizeTrackerEntry(tag: any) {
+  // it looks like there are two types of data on a tracker's tag list.
+  // one type has the shape (which maybe isn't a tag?):
+  //   key: string
+  //   ref: object
+  //   tag: object
+  // the other is an actual Tag,
+  //   but with a private secret property _propertyName
+
+  let hostObject = TAG_MAP.get(tag);
+
+  let result: Partial<TrackerProperty> = {
+    objectName: hostObject && hostObject.__proto__.constructor.name,
+    objectRef: hostObject,
+    tag,
+  };
+
+  result.propertyName = tag.key || tag._propertyKey;
+
+  return result;
+}
+
+function prettyPrintTrackingInfo() {
+  let history = Ember.EMBER_DEBUG.TRACKING.history;
+
+  console.log(history, TAG_MAP);
+  history.forEach((tracker: TrackerSnapshot, i: number) => {
+    // tags seems to always be a touple
+    // (property that changed, the source property)
+    let values = tracker.tags;
+
+    let first = values[0];
+    let last = values[values.length - 1];
+
+    console.log(
+      '\t',
+      i,
+      normalizeTrackerEntry(first),
+      'Because',
+      normalizeTrackerEntry(last),
+      'changed'
+    );
+  });
+}
+
+Ember.EMBER_DEBUG.TRACKING.print = prettyPrintTrackingInfo;
+
+export function debugTracker(current: Tracker, parent: Option<Tracker>) {
+  // Convert the Tracker to an isolated moment in time
+  Ember.EMBER_DEBUG.TRACKING.history.push({
+    // hack around tags being a private field
+    tags: Array.from((current as any).tags.values()),
+  });
+
+  console.log('[ track event ] current:', current, 'parent:', parent);
+  // Ember.EMBER_DEBUG.TRACKING.print();
+}
+
+
+export function debugConsume(tracker: Tracker, tag: Tag | UpdatableTag, target: any) {
+  if (!TAG_MAP.has(tag)) {
+    TAG_MAP.set(tag, target);
+  }
+  console.log(TAG_MAP, tracker, tag === CONSTANT_TAG);
+
+
+  // If trackers keep getting added, how do they get cleaned up?
+  // seems like this list grows forever if I were to keep changing values.
+  // I would have thought that trackers would be re-used? idk.
+  //
+  // Ember.EMBER_DEBUG.TRACKING.stacks.add(tracker);
+  // console.log('property consumed. Stacks:', Ember.EMBER_DEBUG.TRACKING.stacks);
+}

--- a/packages/@ember/-internals/metal/lib/tracked/debugging.ts
+++ b/packages/@ember/-internals/metal/lib/tracked/debugging.ts
@@ -82,6 +82,7 @@ export function debugTracker(current: Tracker, _parent: Option<Tracker>) {
 
     Ember.EMBER_DEBUG.TRACKING.history[revision] = batch;
   } else {
+    Ember.EMBER_DEBUG.TRACKING.history = {};
     Ember.EMBER_DEBUG.TRACKING.history[revision] = [trackerSnapshot];
   }
 

--- a/packages/@ember/-internals/metal/lib/tracked/debugging.ts
+++ b/packages/@ember/-internals/metal/lib/tracked/debugging.ts
@@ -72,7 +72,7 @@ export function debugTracker(current: Tracker, _parent: Option<Tracker>) {
   // this is to help with performance of cpu / memory
   if (objectOfRelevance && !containsRelevantObject(trackerSnapshot)) return;
 
-  let revision = `${trackerSnapshot.tag.revision}`;
+  let revision = `${trackerSnapshot.tag.lastChecked}`;
 
   if (isTrackingHistory) {
     let currentBatch = getTrackingInfo().history[revision];
@@ -153,27 +153,27 @@ function toTagSnapshot(tag: any): TagSnapshot {
   if (kind === 'TwoWayFlushDetectionTag') {
     let hostObject = tag.ref.propertyTag.subtag._object;
     let objectId = getOrAssignId(hostObject);
-    let revision = Math.max(tag.ref.lastRevision, tag.ref.propertyTag.lastChecked);
 
     return {
       objectName: nameOf(hostObject),
       objectRef: hostObject,
       objectId: objectId || -1,
       propertyName: tag.key,
-      revision,
+      revision: tag.ref.lastRevision,
+      lastChecked: tag.ref.propertyTag.lastChecked,
       tag,
     } as TagSnapshot;
   } else if (kind === 'MonomorphicTagImpl') {
     let hostObject = tag._object;
     let objectId = getOrAssignId(hostObject);
-    let revision = Math.max(tag.lastValue, tag.lastChecked);
 
     return {
       objectName: nameOf(hostObject),
       objectRef: hostObject,
       objectId: objectId || -1,
       propertyName: tag._propertyKey,
-      revision,
+      revision: tag.lastValue,
+      lastChecked: tag.lastChecked,
       tag,
     } as TagSnapshot;
   }

--- a/packages/@ember/-internals/metal/lib/tracked/debugging.ts
+++ b/packages/@ember/-internals/metal/lib/tracked/debugging.ts
@@ -1,12 +1,10 @@
-import { Tag, CONSTANT_TAG, UpdatableTag } from '@glimmer/reference';
+import { Tag, UpdatableTag } from '@glimmer/reference';
 
 import { Tracker } from './tracker';
 
 type Option<T> = T | null;
 
 Ember.EMBER_DEBUG = {};
-
-let TAG_MAP = new Map<Tag | UpdatableTag, any>();
 
 interface TrackerHistory {
   property: string;
@@ -36,15 +34,7 @@ Ember.EMBER_DEBUG.TRACKING = {
 } as DebugTracking;
 
 function normalizeTrackerEntry(tag: any) {
-  // it looks like there are two types of data on a tracker's tag list.
-  // one type has the shape (which maybe isn't a tag?):
-  //   key: string
-  //   ref: object
-  //   tag: object
-  // the other is an actual Tag,
-  //   but with a private secret property _propertyName
-
-  let hostObject = TAG_MAP.get(tag);
+  let hostObject = tag.key ? tag.ref.parentValue : tag._object;
 
   let result: Partial<TrackerProperty> = {
     objectName: hostObject && hostObject.__proto__.constructor.name,
@@ -60,7 +50,7 @@ function normalizeTrackerEntry(tag: any) {
 function prettyPrintTrackingInfo() {
   let history = Ember.EMBER_DEBUG.TRACKING.history;
 
-  console.log(history, TAG_MAP);
+  // console.log(history, TAG_MAP);
   history.forEach((tracker: TrackerSnapshot, i: number) => {
     // tags seems to always be a touple
     // (property that changed, the source property)
@@ -88,23 +78,9 @@ export function debugTracker(current: Tracker, parent: Option<Tracker>) {
     // hack around tags being a private field
     tags: Array.from((current as any).tags.values()),
   });
-
-  console.log('[ track event ] current:', current, 'parent:', parent);
-  // Ember.EMBER_DEBUG.TRACKING.print();
 }
 
 
 export function debugConsume(tracker: Tracker, tag: Tag | UpdatableTag, target: any) {
-  if (!TAG_MAP.has(tag)) {
-    TAG_MAP.set(tag, target);
-  }
-  console.log(TAG_MAP, tracker, tag === CONSTANT_TAG);
-
-
-  // If trackers keep getting added, how do they get cleaned up?
-  // seems like this list grows forever if I were to keep changing values.
-  // I would have thought that trackers would be re-used? idk.
-  //
-  // Ember.EMBER_DEBUG.TRACKING.stacks.add(tracker);
-  // console.log('property consumed. Stacks:', Ember.EMBER_DEBUG.TRACKING.stacks);
+  console.log('Consume started', tracker, tag);
 }

--- a/packages/@ember/-internals/metal/lib/tracked/index.ts
+++ b/packages/@ember/-internals/metal/lib/tracked/index.ts
@@ -226,10 +226,7 @@ export function track(callback: () => void) {
   CURRENT_TRACKER = current;
 
   try {
-    console.log('pre-callback', current, parent);
     callback();
-    console.log('post-callback', current, parent);
-
 
     debugTracker(current, parent);
   } finally {
@@ -238,7 +235,6 @@ export function track(callback: () => void) {
 
   let result = current.combine();
 
-  console.log('post combine', current, parent);
   return result;
 }
 

--- a/packages/@ember/-internals/metal/lib/tracked/index.ts
+++ b/packages/@ember/-internals/metal/lib/tracked/index.ts
@@ -167,7 +167,7 @@ function descriptorForField([_target, key, desc]: [
 
       if (CURRENT_TRACKER) {
         CURRENT_TRACKER.add(propertyTag);
-        debugConsume(CURRENT_TRACKER, propertyTag, this);
+        debugConsume(CURRENT_TRACKER, propertyTag);
       }
 
       let value;
@@ -226,14 +226,20 @@ export function track(callback: () => void) {
   CURRENT_TRACKER = current;
 
   try {
+    console.log('pre-callback', current, parent);
     callback();
+    console.log('post-callback', current, parent);
+
 
     debugTracker(current, parent);
   } finally {
     CURRENT_TRACKER = parent;
   }
 
-  return current.combine();
+  let result = current.combine();
+
+  console.log('post combine', current, parent);
+  return result;
 }
 
 export function consume(tag: Tag) {

--- a/packages/@ember/-internals/metal/lib/tracked/index.ts
+++ b/packages/@ember/-internals/metal/lib/tracked/index.ts
@@ -5,7 +5,7 @@ import { Tag, UpdatableTag, update } from '@glimmer/reference';
 import { Decorator, DecoratorPropertyDescriptor, isElementDescriptor } from '../decorator';
 import { setClassicDecorator } from '../descriptor_map';
 import { markObjectAsDirty, tagForProperty } from '../tags';
-import { debugTracker, debugConsume } from './debugging';
+import { debugTracker } from './debugging';
 
 import { Tracker } from './tracker';
 import { Option } from './types';
@@ -167,7 +167,6 @@ function descriptorForField([_target, key, desc]: [
 
       if (CURRENT_TRACKER) {
         CURRENT_TRACKER.add(propertyTag);
-        debugConsume(CURRENT_TRACKER, propertyTag);
       }
 
       let value;
@@ -241,7 +240,6 @@ export function track(callback: () => void) {
 export function consume(tag: Tag) {
   if (CURRENT_TRACKER !== null) {
     CURRENT_TRACKER.add(tag);
-    debugConsume(CURRENT_TRACKER, tag);
   }
 }
 

--- a/packages/@ember/-internals/metal/lib/tracked/tracker.ts
+++ b/packages/@ember/-internals/metal/lib/tracked/tracker.ts
@@ -1,0 +1,33 @@
+import { combine, CONSTANT_TAG, Tag } from '@glimmer/reference';
+import { Option } from './types';
+
+/**
+  An object that that tracks @tracked properties that were consumed.
+
+  @private
+*/
+export class Tracker {
+  private tags = new Set<Tag>();
+  private last: Option<Tag> = null;
+
+  add(tag: Tag): void {
+    this.tags.add(tag);
+    this.last = tag;
+  }
+
+  get size(): number {
+    return this.tags.size;
+  }
+
+  combine(): Tag {
+    if (this.tags.size === 0) {
+      return CONSTANT_TAG;
+    } else if (this.tags.size === 1) {
+      return this.last as Tag;
+    } else {
+      let tags: Tag[] = [];
+      this.tags.forEach(tag => tags.push(tag));
+      return combine(tags);
+    }
+  }
+}

--- a/packages/@ember/-internals/metal/lib/tracked/types.ts
+++ b/packages/@ember/-internals/metal/lib/tracked/types.ts
@@ -1,0 +1,1 @@
+export type Option<T> = T | null;


### PR DESCRIPTION
This is super WIP.
atm, I'm trying to figure out how tracked works, and how I can get access to objects when things are tracked.

Ideally, what I'm trying to provide
 - history of "the tracked state"
 - provide reasons why a tracked property changed
   - what property changed on what object
 - provide references to objects that tracked properties are defined on so that ember inspector can tie in to all this
 
Eventually:
 - build a snapshot of the tree of dependencies and their values, and what objects the properties live on 

Latest Screenshot:
![image](https://user-images.githubusercontent.com/199018/65389880-64bc4080-dd28-11e9-97e1-5eddea01ff8c.png)


Tracking History at boot on emberclear:
![image](https://user-images.githubusercontent.com/199018/65395318-33af3080-dd67-11e9-9867-8276161fea17.png)

Looks like Tracking History might not be feasible for real apps.
This took a while to print to the console:
![image](https://user-images.githubusercontent.com/199018/65395354-9ef90280-dd67-11e9-9efd-5499c3dc3452.png)

It looks like the Memory in use still isn't that bad (I have no idea where this data would be on here, but it's all in low #s of MB)
![image](https://user-images.githubusercontent.com/199018/65395381-00b96c80-dd68-11e9-9f21-0fbfa2b6eace.png)

After clicking around a bit, and sending myself some messages, it looks like I either have a memory leak, or tracking all this history _is_ actually problematic:
![image](https://user-images.githubusercontent.com/199018/65395396-49712580-dd68-11e9-9431-f5af244ec778.png)

Yeah here is a memory snapshot after doing similar actions on the deployed site: 
![image](https://user-images.githubusercontent.com/199018/65395444-e338d280-dd68-11e9-92a0-32be7dcbc5f7.png)
I'm much more inclined to think I have less of a memory leak and more that I'm just tracking too much stuff. (I do have a memory leak -- it's just _much_ slower of a leak than what the initial memory snapshots show)

To mitigate this memory bloat, there is a start/stop method for optionally recording the tracked stacks.