### PR TITLE
[BUGFIX release] Fix incorrect error message for octane features.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -99,7 +99,7 @@ module.exports = {
         !optionalFeatures.isFeatureEnabled('template-only-glimmer-components')
       ) {
         message.push(
-          `* The template-only-glimmer-components optional feature should be enabled under Octane, run \`ember feature:enabled template-only-glimmer-components\` to enable it`
+          `* The template-only-glimmer-components optional feature should be enabled under Octane, run \`ember feature:enable template-only-glimmer-components\` to enable it`
         );
       }
 


### PR DESCRIPTION
The correct command is `ember feature:enable` :sob: :weary:

Fixes: #18430