### PR TITLE
[DEPRECATION] Deprecate globals resolver

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
@@ -1,4 +1,9 @@
-import { ApplicationTestCase, moduleFor, strip } from 'internal-test-helpers';
+import {
+  ApplicationTestCase,
+  ModuleBasedTestResolver,
+  moduleFor,
+  strip,
+} from 'internal-test-helpers';
 
 import { ENV } from '@ember/-internals/environment';
 import {
@@ -292,6 +297,7 @@ if (ENV._DEBUG_RENDER_TREE) {
           'engine:foo',
           class extends Engine {
             isFooEngine = true;
+            Resolver = ModuleBasedTestResolver;
 
             init() {
               super.init(...arguments);
@@ -327,6 +333,8 @@ if (ENV._DEBUG_RENDER_TREE) {
         this.add(
           'engine:bar',
           class extends Engine {
+            Resolver = ModuleBasedTestResolver;
+
             init() {
               super.init(...arguments);
               this.register(
@@ -670,6 +678,7 @@ if (ENV._DEBUG_RENDER_TREE) {
           'engine:foo',
           class extends Engine {
             isFooEngine = true;
+            Resolver = ModuleBasedTestResolver;
 
             init() {
               super.init(...arguments);

--- a/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
@@ -1,4 +1,10 @@
-import { moduleFor, ApplicationTestCase, strip, runTaskNext } from 'internal-test-helpers';
+import {
+  moduleFor,
+  ApplicationTestCase,
+  ModuleBasedTestResolver,
+  strip,
+  runTaskNext,
+} from 'internal-test-helpers';
 
 import { Component } from '@ember/-internals/glimmer';
 import { Route } from '@ember/-internals/routing';
@@ -80,6 +86,8 @@ moduleFor(
       this.add(
         'engine:blog',
         Engine.extend({
+          Resolver: ModuleBasedTestResolver,
+
           init() {
             this._super(...arguments);
             this.register(
@@ -131,6 +139,8 @@ moduleFor(
       this.add(
         'engine:chat-engine',
         Engine.extend({
+          Resolver: ModuleBasedTestResolver,
+
           init() {
             this._super(...arguments);
             this.register('template:application', compile('Engine'));
@@ -167,6 +177,8 @@ moduleFor(
       this.add(
         'engine:blog',
         Engine.extend({
+          Resolver: ModuleBasedTestResolver,
+
           init() {
             this._super(...arguments);
             this.register('template:foo', compile('foo partial'));
@@ -202,6 +214,8 @@ moduleFor(
       this.add(
         'engine:chat-engine',
         Engine.extend({
+          Resolver: ModuleBasedTestResolver,
+
           init() {
             this._super(...arguments);
             this.register('template:foo', compile('foo partial'));
@@ -230,6 +244,8 @@ moduleFor(
       this.add(
         'engine:chat-engine',
         Engine.extend({
+          Resolver: ModuleBasedTestResolver,
+
           init() {
             this._super(...arguments);
             this.register('template:components/foo-bar', compile(`{{partial "troll"}}`));
@@ -289,6 +305,8 @@ moduleFor(
       this.add(
         'engine:blog',
         Engine.extend({
+          Resolver: ModuleBasedTestResolver,
+
           init() {
             this._super(...arguments);
 
@@ -344,6 +362,8 @@ moduleFor(
       this.add(
         'engine:blog',
         Engine.extend({
+          Resolver: ModuleBasedTestResolver,
+
           init() {
             this._super(...arguments);
             this.register(
@@ -486,6 +506,8 @@ moduleFor(
       this.add(
         'engine:blog',
         Engine.extend({
+          Resolver: ModuleBasedTestResolver,
+
           init() {
             this._super(...arguments);
             this.register('template:application', compile('Engine{{outlet}}'));

--- a/packages/@ember/-internals/glimmer/tests/integration/mount-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/mount-test.js
@@ -1,4 +1,10 @@
-import { moduleFor, ApplicationTestCase, RenderingTestCase, runTask } from 'internal-test-helpers';
+import {
+  moduleFor,
+  ApplicationTestCase,
+  ModuleBasedTestResolver,
+  RenderingTestCase,
+  runTask,
+} from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
 import { getOwner } from '@ember/-internals/owner';
@@ -48,6 +54,7 @@ moduleFor(
         'engine:chat',
         Engine.extend({
           router: null,
+          Resolver: ModuleBasedTestResolver,
 
           init() {
             this._super(...arguments);
@@ -165,6 +172,8 @@ moduleFor(
         'engine:foo',
         Engine.extend({
           router: null,
+          Resolver: ModuleBasedTestResolver,
+
           init() {
             this._super(...arguments);
             this.register(
@@ -180,6 +189,8 @@ moduleFor(
         'engine:bar',
         Engine.extend({
           router: null,
+          Resolver: ModuleBasedTestResolver,
+
           init() {
             this._super(...arguments);
             this.register(
@@ -244,6 +255,8 @@ moduleFor(
         'engine:foo',
         Engine.extend({
           router: null,
+          Resolver: ModuleBasedTestResolver,
+
           init() {
             this._super(...arguments);
             this.register(
@@ -299,6 +312,8 @@ moduleFor(
         'engine:paramEngine',
         Engine.extend({
           router: null,
+          Resolver: ModuleBasedTestResolver,
+
           init() {
             this._super(...arguments);
             this.register(
@@ -393,6 +408,8 @@ moduleFor(
         'engine:componentParamEngine',
         Engine.extend({
           router: null,
+          Resolver: ModuleBasedTestResolver,
+
           init() {
             this._super(...arguments);
             this.register(
@@ -429,6 +446,8 @@ if (!EMBER_ROUTING_MODEL_ARG) {
           'engine:paramEngine',
           Engine.extend({
             router: null,
+            Resolver: ModuleBasedTestResolver,
+
             init() {
               this._super(...arguments);
               this.register(

--- a/packages/@ember/application/globals-resolver.js
+++ b/packages/@ember/application/globals-resolver.js
@@ -4,7 +4,7 @@
 
 import { dictionary } from '@ember/-internals/utils';
 import { get, findNamespace } from '@ember/-internals/metal';
-import { assert, info } from '@ember/debug';
+import { assert, info, deprecate } from '@ember/debug';
 import { capitalize, classify, dasherize, decamelize } from '@ember/string';
 import { Object as EmberObject } from '@ember/-internals/runtime';
 import { getTemplate } from '@ember/-internals/glimmer';
@@ -77,6 +77,7 @@ import { DEBUG } from '@glimmer/env';
   @class GlobalsResolver
   @extends EmberObject
   @public
+  @deprecated
 */
 
 class DefaultResolver extends EmberObject {
@@ -93,9 +94,20 @@ class DefaultResolver extends EmberObject {
 
     @property namespace
     @public
+    @deprecated
   */
 
   init() {
+    deprecate(
+      'Using the globals resolver is deprecated. Use the ember-resolver package instead. See https://deprecations.emberjs.com/v3.x#toc_ember-deprecate-globals-resolver',
+      false,
+      {
+        until: '4.0.0',
+        id: 'globals-resolver',
+        url: 'https://deprecations.emberjs.com/v3.x#toc_ember-deprecate-globals-resolver',
+      }
+    );
+
     this._parseNameCache = dictionary(null);
   }
 

--- a/packages/@ember/application/globals-resolver.js
+++ b/packages/@ember/application/globals-resolver.js
@@ -9,6 +9,7 @@ import { capitalize, classify, dasherize, decamelize } from '@ember/string';
 import { Object as EmberObject } from '@ember/-internals/runtime';
 import { getTemplate } from '@ember/-internals/glimmer';
 import { DEBUG } from '@glimmer/env';
+import { GLOBALS_RESOLVER } from '@ember/deprecated-features';
 
 /**
   The DefaultResolver defines the default lookup rules to resolve
@@ -80,374 +81,381 @@ import { DEBUG } from '@glimmer/env';
   @deprecated
 */
 
-class DefaultResolver extends EmberObject {
-  static create(props) {
-    // DO NOT REMOVE even though this doesn't do anything
-    // This is required for a FireFox 60+ JIT bug with our tests.
-    // without it, create(props) in our tests would lose props on a deopt.
-    return super.create(props);
-  }
+let DefaultResolver;
 
-  /**
-    This will be set to the Application instance when it is
-    created.
-
-    @property namespace
-    @public
-    @deprecated
-  */
-
-  init() {
-    deprecate(
-      'Using the globals resolver is deprecated. Use the ember-resolver package instead. See https://deprecations.emberjs.com/v3.x#toc_ember-deprecate-globals-resolver',
-      false,
-      {
-        until: '4.0.0',
-        id: 'globals-resolver',
-        url: 'https://deprecations.emberjs.com/v3.x#toc_ember-deprecate-globals-resolver',
-      }
-    );
-
-    this._parseNameCache = dictionary(null);
-  }
-
-  normalize(fullName) {
-    let [type, name] = fullName.split(':');
-
-    assert(
-      'Tried to normalize a container name without a colon (:) in it. ' +
-        'You probably tried to lookup a name that did not contain a type, ' +
-        'a colon, and a name. A proper lookup name would be `view:post`.',
-      fullName.split(':').length === 2
-    );
-
-    if (type !== 'template') {
-      let result = name.replace(/(\.|_|-)./g, m => m.charAt(1).toUpperCase());
-
-      return `${type}:${result}`;
-    } else {
-      return fullName;
-    }
-  }
-
-  /**
-    This method is called via the container's resolver method.
-    It parses the provided `fullName` and then looks up and
-    returns the appropriate template or class.
-
-    @method resolve
-    @param {String} fullName the lookup string
-    @return {Object} the resolved factory
-    @public
-  */
-  resolve(fullName) {
-    let parsedName = this.parseName(fullName);
-    let resolveMethodName = parsedName.resolveMethodName;
-    let resolved;
-
-    if (this[resolveMethodName]) {
-      resolved = this[resolveMethodName](parsedName);
+if (GLOBALS_RESOLVER) {
+  DefaultResolver = class DefaultResolver extends EmberObject {
+    static create(props) {
+      // DO NOT REMOVE even though this doesn't do anything
+      // This is required for a FireFox 60+ JIT bug with our tests.
+      // without it, create(props) in our tests would lose props on a deopt.
+      return super.create(props);
     }
 
-    resolved = resolved || this.resolveOther(parsedName);
+    /**
+      This will be set to the Application instance when it is
+      created.
 
-    if (DEBUG) {
-      if (parsedName.root && parsedName.root.LOG_RESOLVER) {
-        this._logLookup(resolved, parsedName);
-      }
+      @property namespace
+      @public
+      @deprecated
+    */
 
-      if (resolved) {
-        let VALIDATED_TYPES = {
-          route: ['isRouteFactory', 'Ember.Route'],
-          component: ['isComponentFactory', 'Ember.Component'],
-          view: ['isViewFactory', 'Ember.View'],
-          service: ['isServiceFactory', 'Ember.Service'],
-        };
-
-        let validationAttributes = VALIDATED_TYPES[parsedName.type];
-
-        if (validationAttributes) {
-          let [factoryFlag, expectedType] = validationAttributes;
-
-          assert(
-            `Expected ${parsedName.fullName} to resolve to an ${expectedType} but ` +
-              `instead it was ${resolved}.`,
-            Boolean(resolved[factoryFlag])
-          );
+    init() {
+      deprecate(
+        'Using the globals resolver is deprecated. Use the ember-resolver package instead. See https://deprecations.emberjs.com/v3.x#toc_ember-deprecate-globals-resolver',
+        false,
+        {
+          until: '4.0.0',
+          id: 'globals-resolver',
+          url: 'https://deprecations.emberjs.com/v3.x#toc_ember-deprecate-globals-resolver',
         }
-      }
+      );
+
+      this._parseNameCache = dictionary(null);
     }
 
-    return resolved;
-  }
-
-  /**
-    Convert the string name of the form 'type:name' to
-    a Javascript object with the parsed aspects of the name
-    broken out.
-
-    @param {String} fullName the lookup string
-    @method parseName
-    @protected
-  */
-
-  parseName(fullName) {
-    return (
-      this._parseNameCache[fullName] || (this._parseNameCache[fullName] = this._parseName(fullName))
-    );
-  }
-
-  _parseName(fullName) {
-    let [type, fullNameWithoutType] = fullName.split(':');
-
-    let name = fullNameWithoutType;
-    let namespace = get(this, 'namespace');
-    let root = namespace;
-    let lastSlashIndex = name.lastIndexOf('/');
-    let dirname = lastSlashIndex !== -1 ? name.slice(0, lastSlashIndex) : null;
-
-    if (type !== 'template' && lastSlashIndex !== -1) {
-      let parts = name.split('/');
-      name = parts[parts.length - 1];
-      let namespaceName = capitalize(parts.slice(0, -1).join('.'));
-      root = findNamespace(namespaceName);
+    normalize(fullName) {
+      let [type, name] = fullName.split(':');
 
       assert(
-        `You are looking for a ${name} ${type} in the ${namespaceName} namespace, but the namespace could not be found`,
-        root
+        'Tried to normalize a container name without a colon (:) in it. ' +
+          'You probably tried to lookup a name that did not contain a type, ' +
+          'a colon, and a name. A proper lookup name would be `view:post`.',
+        fullName.split(':').length === 2
+      );
+
+      if (type !== 'template') {
+        let result = name.replace(/(\.|_|-)./g, m => m.charAt(1).toUpperCase());
+
+        return `${type}:${result}`;
+      } else {
+        return fullName;
+      }
+    }
+
+    /**
+      This method is called via the container's resolver method.
+      It parses the provided `fullName` and then looks up and
+      returns the appropriate template or class.
+
+      @method resolve
+      @param {String} fullName the lookup string
+      @return {Object} the resolved factory
+      @public
+    */
+    resolve(fullName) {
+      let parsedName = this.parseName(fullName);
+      let resolveMethodName = parsedName.resolveMethodName;
+      let resolved;
+
+      if (this[resolveMethodName]) {
+        resolved = this[resolveMethodName](parsedName);
+      }
+
+      resolved = resolved || this.resolveOther(parsedName);
+
+      if (DEBUG) {
+        if (parsedName.root && parsedName.root.LOG_RESOLVER) {
+          this._logLookup(resolved, parsedName);
+        }
+
+        if (resolved) {
+          let VALIDATED_TYPES = {
+            route: ['isRouteFactory', 'Ember.Route'],
+            component: ['isComponentFactory', 'Ember.Component'],
+            view: ['isViewFactory', 'Ember.View'],
+            service: ['isServiceFactory', 'Ember.Service'],
+          };
+
+          let validationAttributes = VALIDATED_TYPES[parsedName.type];
+
+          if (validationAttributes) {
+            let [factoryFlag, expectedType] = validationAttributes;
+
+            assert(
+              `Expected ${parsedName.fullName} to resolve to an ${expectedType} but ` +
+                `instead it was ${resolved}.`,
+              Boolean(resolved[factoryFlag])
+            );
+          }
+        }
+      }
+
+      return resolved;
+    }
+
+    /**
+      Convert the string name of the form 'type:name' to
+      a Javascript object with the parsed aspects of the name
+      broken out.
+
+      @param {String} fullName the lookup string
+      @method parseName
+      @protected
+    */
+
+    parseName(fullName) {
+      return (
+        this._parseNameCache[fullName] ||
+        (this._parseNameCache[fullName] = this._parseName(fullName))
       );
     }
 
-    let resolveMethodName = fullNameWithoutType === 'main' ? 'Main' : classify(type);
+    _parseName(fullName) {
+      let [type, fullNameWithoutType] = fullName.split(':');
 
-    if (!(name && type)) {
-      throw new TypeError(`Invalid fullName: \`${fullName}\`, must be of the form \`type:name\` `);
+      let name = fullNameWithoutType;
+      let namespace = get(this, 'namespace');
+      let root = namespace;
+      let lastSlashIndex = name.lastIndexOf('/');
+      let dirname = lastSlashIndex !== -1 ? name.slice(0, lastSlashIndex) : null;
+
+      if (type !== 'template' && lastSlashIndex !== -1) {
+        let parts = name.split('/');
+        name = parts[parts.length - 1];
+        let namespaceName = capitalize(parts.slice(0, -1).join('.'));
+        root = findNamespace(namespaceName);
+
+        assert(
+          `You are looking for a ${name} ${type} in the ${namespaceName} namespace, but the namespace could not be found`,
+          root
+        );
+      }
+
+      let resolveMethodName = fullNameWithoutType === 'main' ? 'Main' : classify(type);
+
+      if (!(name && type)) {
+        throw new TypeError(
+          `Invalid fullName: \`${fullName}\`, must be of the form \`type:name\` `
+        );
+      }
+
+      return {
+        fullName,
+        type,
+        fullNameWithoutType,
+        dirname,
+        name,
+        root,
+        resolveMethodName: `resolve${resolveMethodName}`,
+      };
     }
 
-    return {
-      fullName,
-      type,
-      fullNameWithoutType,
-      dirname,
-      name,
-      root,
-      resolveMethodName: `resolve${resolveMethodName}`,
-    };
-  }
+    /**
+      Returns a human-readable description for a fullName. Used by the
+      Application namespace in assertions to describe the
+      precise name of the class that Ember is looking for, rather than
+      container keys.
 
-  /**
-    Returns a human-readable description for a fullName. Used by the
-    Application namespace in assertions to describe the
-    precise name of the class that Ember is looking for, rather than
-    container keys.
+      @param {String} fullName the lookup string
+      @method lookupDescription
+      @protected
+    */
+    lookupDescription(fullName) {
+      let parsedName = this.parseName(fullName);
+      let description;
 
-    @param {String} fullName the lookup string
-    @method lookupDescription
-    @protected
-  */
-  lookupDescription(fullName) {
-    let parsedName = this.parseName(fullName);
-    let description;
+      if (parsedName.type === 'template') {
+        return `template at ${parsedName.fullNameWithoutType.replace(/\./g, '/')}`;
+      }
 
-    if (parsedName.type === 'template') {
-      return `template at ${parsedName.fullNameWithoutType.replace(/\./g, '/')}`;
+      description = `${parsedName.root}.${classify(parsedName.name).replace(/\./g, '')}`;
+
+      if (parsedName.type !== 'model') {
+        description += classify(parsedName.type);
+      }
+
+      return description;
     }
 
-    description = `${parsedName.root}.${classify(parsedName.name).replace(/\./g, '')}`;
-
-    if (parsedName.type !== 'model') {
-      description += classify(parsedName.type);
+    makeToString(factory) {
+      return factory.toString();
     }
 
-    return description;
-  }
+    /**
+      Given a parseName object (output from `parseName`), apply
+      the conventions expected by `Router`
 
-  makeToString(factory) {
-    return factory.toString();
-  }
-
-  /**
-    Given a parseName object (output from `parseName`), apply
-    the conventions expected by `Router`
-
-    @param {Object} parsedName a parseName object with the parsed
-      fullName lookup string
-    @method useRouterNaming
-    @protected
-  */
-  useRouterNaming(parsedName) {
-    if (parsedName.name === 'basic') {
-      parsedName.name = '';
-    } else {
-      parsedName.name = parsedName.name.replace(/\./g, '_');
-    }
-  }
-  /**
-    Look up the template in Ember.TEMPLATES
-
-    @param {Object} parsedName a parseName object with the parsed
-      fullName lookup string
-    @method resolveTemplate
-    @protected
-  */
-  resolveTemplate(parsedName) {
-    let templateName = parsedName.fullNameWithoutType.replace(/\./g, '/');
-
-    return getTemplate(templateName) || getTemplate(decamelize(templateName));
-  }
-
-  /**
-    Lookup the view using `resolveOther`
-
-    @param {Object} parsedName a parseName object with the parsed
-      fullName lookup string
-    @method resolveView
-    @protected
-  */
-  resolveView(parsedName) {
-    this.useRouterNaming(parsedName);
-    return this.resolveOther(parsedName);
-  }
-
-  /**
-    Lookup the controller using `resolveOther`
-
-    @param {Object} parsedName a parseName object with the parsed
-      fullName lookup string
-    @method resolveController
-    @protected
-  */
-  resolveController(parsedName) {
-    this.useRouterNaming(parsedName);
-    return this.resolveOther(parsedName);
-  }
-  /**
-    Lookup the route using `resolveOther`
-
-    @param {Object} parsedName a parseName object with the parsed
-      fullName lookup string
-    @method resolveRoute
-    @protected
-  */
-  resolveRoute(parsedName) {
-    this.useRouterNaming(parsedName);
-    return this.resolveOther(parsedName);
-  }
-
-  /**
-    Lookup the model on the Application namespace
-
-    @param {Object} parsedName a parseName object with the parsed
-      fullName lookup string
-    @method resolveModel
-    @protected
-  */
-  resolveModel(parsedName) {
-    let className = classify(parsedName.name);
-    let factory = get(parsedName.root, className);
-
-    return factory;
-  }
-  /**
-    Look up the specified object (from parsedName) on the appropriate
-    namespace (usually on the Application)
-
-    @param {Object} parsedName a parseName object with the parsed
-      fullName lookup string
-    @method resolveHelper
-    @protected
-  */
-  resolveHelper(parsedName) {
-    return this.resolveOther(parsedName);
-  }
-  /**
-    Look up the specified object (from parsedName) on the appropriate
-    namespace (usually on the Application)
-
-    @param {Object} parsedName a parseName object with the parsed
-      fullName lookup string
-    @method resolveOther
-    @protected
-  */
-  resolveOther(parsedName) {
-    let className = classify(parsedName.name) + classify(parsedName.type);
-    let factory = get(parsedName.root, className);
-    return factory;
-  }
-
-  resolveMain(parsedName) {
-    let className = classify(parsedName.type);
-    return get(parsedName.root, className);
-  }
-
-  /**
-    Used to iterate all items of a given type.
-
-    @method knownForType
-    @param {String} type the type to search for
-    @private
-  */
-  knownForType(type) {
-    let namespace = get(this, 'namespace');
-    let suffix = classify(type);
-    let typeRegexp = new RegExp(`${suffix}$`);
-
-    let known = dictionary(null);
-    let knownKeys = Object.keys(namespace);
-    for (let index = 0; index < knownKeys.length; index++) {
-      let name = knownKeys[index];
-
-      if (typeRegexp.test(name)) {
-        let containerName = this.translateToContainerFullname(type, name);
-
-        known[containerName] = true;
+      @param {Object} parsedName a parseName object with the parsed
+        fullName lookup string
+      @method useRouterNaming
+      @protected
+    */
+    useRouterNaming(parsedName) {
+      if (parsedName.name === 'basic') {
+        parsedName.name = '';
+      } else {
+        parsedName.name = parsedName.name.replace(/\./g, '_');
       }
     }
+    /**
+      Look up the template in Ember.TEMPLATES
 
-    return known;
-  }
+      @param {Object} parsedName a parseName object with the parsed
+        fullName lookup string
+      @method resolveTemplate
+      @protected
+    */
+    resolveTemplate(parsedName) {
+      let templateName = parsedName.fullNameWithoutType.replace(/\./g, '/');
 
-  /**
-    Converts provided name from the backing namespace into a container lookup name.
+      return getTemplate(templateName) || getTemplate(decamelize(templateName));
+    }
 
-    Examples:
+    /**
+      Lookup the view using `resolveOther`
 
-    * App.FooBarHelper -> helper:foo-bar
-    * App.THelper -> helper:t
+      @param {Object} parsedName a parseName object with the parsed
+        fullName lookup string
+      @method resolveView
+      @protected
+    */
+    resolveView(parsedName) {
+      this.useRouterNaming(parsedName);
+      return this.resolveOther(parsedName);
+    }
 
-    @method translateToContainerFullname
-    @param {String} type
-    @param {String} name
-    @private
-  */
-  translateToContainerFullname(type, name) {
-    let suffix = classify(type);
-    let namePrefix = name.slice(0, suffix.length * -1);
-    let dasherizedName = dasherize(namePrefix);
+    /**
+      Lookup the controller using `resolveOther`
 
-    return `${type}:${dasherizedName}`;
+      @param {Object} parsedName a parseName object with the parsed
+        fullName lookup string
+      @method resolveController
+      @protected
+    */
+    resolveController(parsedName) {
+      this.useRouterNaming(parsedName);
+      return this.resolveOther(parsedName);
+    }
+    /**
+      Lookup the route using `resolveOther`
+
+      @param {Object} parsedName a parseName object with the parsed
+        fullName lookup string
+      @method resolveRoute
+      @protected
+    */
+    resolveRoute(parsedName) {
+      this.useRouterNaming(parsedName);
+      return this.resolveOther(parsedName);
+    }
+
+    /**
+      Lookup the model on the Application namespace
+
+      @param {Object} parsedName a parseName object with the parsed
+        fullName lookup string
+      @method resolveModel
+      @protected
+    */
+    resolveModel(parsedName) {
+      let className = classify(parsedName.name);
+      let factory = get(parsedName.root, className);
+
+      return factory;
+    }
+    /**
+      Look up the specified object (from parsedName) on the appropriate
+      namespace (usually on the Application)
+
+      @param {Object} parsedName a parseName object with the parsed
+        fullName lookup string
+      @method resolveHelper
+      @protected
+    */
+    resolveHelper(parsedName) {
+      return this.resolveOther(parsedName);
+    }
+    /**
+      Look up the specified object (from parsedName) on the appropriate
+      namespace (usually on the Application)
+
+      @param {Object} parsedName a parseName object with the parsed
+        fullName lookup string
+      @method resolveOther
+      @protected
+    */
+    resolveOther(parsedName) {
+      let className = classify(parsedName.name) + classify(parsedName.type);
+      let factory = get(parsedName.root, className);
+      return factory;
+    }
+
+    resolveMain(parsedName) {
+      let className = classify(parsedName.type);
+      return get(parsedName.root, className);
+    }
+
+    /**
+      Used to iterate all items of a given type.
+
+      @method knownForType
+      @param {String} type the type to search for
+      @private
+    */
+    knownForType(type) {
+      let namespace = get(this, 'namespace');
+      let suffix = classify(type);
+      let typeRegexp = new RegExp(`${suffix}$`);
+
+      let known = dictionary(null);
+      let knownKeys = Object.keys(namespace);
+      for (let index = 0; index < knownKeys.length; index++) {
+        let name = knownKeys[index];
+
+        if (typeRegexp.test(name)) {
+          let containerName = this.translateToContainerFullname(type, name);
+
+          known[containerName] = true;
+        }
+      }
+
+      return known;
+    }
+
+    /**
+      Converts provided name from the backing namespace into a container lookup name.
+
+      Examples:
+
+      * App.FooBarHelper -> helper:foo-bar
+      * App.THelper -> helper:t
+
+      @method translateToContainerFullname
+      @param {String} type
+      @param {String} name
+      @private
+    */
+    translateToContainerFullname(type, name) {
+      let suffix = classify(type);
+      let namePrefix = name.slice(0, suffix.length * -1);
+      let dasherizedName = dasherize(namePrefix);
+
+      return `${type}:${dasherizedName}`;
+    }
+  };
+
+  if (DEBUG) {
+    /**
+        @method _logLookup
+        @param {Boolean} found
+        @param {Object} parsedName
+        @private
+      */
+    DefaultResolver.prototype._logLookup = function(found, parsedName) {
+      let symbol = found ? '[✓]' : '[ ]';
+
+      let padding;
+      if (parsedName.fullName.length > 60) {
+        padding = '.';
+      } else {
+        padding = new Array(60 - parsedName.fullName.length).join('.');
+      }
+
+      info(symbol, parsedName.fullName, padding, this.lookupDescription(parsedName.fullName));
+    };
   }
 }
 
 export default DefaultResolver;
-
-if (DEBUG) {
-  /**
-      @method _logLookup
-      @param {Boolean} found
-      @param {Object} parsedName
-      @private
-    */
-  DefaultResolver.prototype._logLookup = function(found, parsedName) {
-    let symbol = found ? '[✓]' : '[ ]';
-
-    let padding;
-    if (parsedName.fullName.length > 60) {
-      padding = '.';
-    } else {
-      padding = new Array(60 - parsedName.fullName.length).join('.');
-    }
-
-    info(symbol, parsedName.fullName, padding, this.lookupDescription(parsedName.fullName));
-  };
-}

--- a/packages/@ember/application/tests/application_instance_test.js
+++ b/packages/@ember/application/tests/application_instance_test.js
@@ -5,7 +5,11 @@ import { run } from '@ember/runloop';
 import { privatize as P } from '@ember/-internals/container';
 import { factory } from 'internal-test-helpers';
 import { Object as EmberObject } from '@ember/-internals/runtime';
-import { moduleFor, AbstractTestCase as TestCase } from 'internal-test-helpers';
+import {
+  moduleFor,
+  ModuleBasedTestResolver,
+  AbstractTestCase as TestCase,
+} from 'internal-test-helpers';
 import { getDebugFunction, setDebugFunction } from '@ember/debug';
 
 const originalDebug = getDebugFunction('debug');
@@ -23,7 +27,13 @@ moduleFor(
       document.getElementById('qunit-fixture').innerHTML = `
       <div id='one'><div id='one-child'>HI</div></div><div id='two'>HI</div>
     `;
-      application = run(() => Application.create({ rootElement: '#one', router: null }));
+      application = run(() =>
+        Application.create({
+          rootElement: '#one',
+          router: null,
+          Resolver: ModuleBasedTestResolver,
+        })
+      );
     }
 
     teardown() {
@@ -167,7 +177,9 @@ moduleFor(
     ['@test can build and boot a registered engine'](assert) {
       assert.expect(11);
 
-      let ChatEngine = Engine.extend();
+      let ChatEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
       let chatEngineInstance;
 
       application.register('engine:chat', ChatEngine);

--- a/packages/@ember/application/tests/dependency_injection/default_resolver_test.js
+++ b/packages/@ember/application/tests/dependency_injection/default_resolver_test.js
@@ -198,6 +198,7 @@ moduleFor(
     }
 
     [`@test no assertion for routes that extend from Route`](assert) {
+      assert.test.assertions = []; // clear assertions that occurred in beforeEach
       assert.expect(0);
       this.application.FooRoute = Route.extend();
       this.privateRegistry.resolve(`route:foo`);
@@ -211,6 +212,7 @@ moduleFor(
     }
 
     [`@test no assertion for service factories that extend from Service`](assert) {
+      assert.test.assertions = []; // clear assertions that occurred in beforeEach
       assert.expect(0);
       this.application.FooService = Service.extend();
       this.privateRegistry.resolve('service:foo');
@@ -309,6 +311,7 @@ moduleFor(
         return;
       }
 
+      assert.test.assertions = []; // clear assertions that occurred in beforeEach
       assert.expect(3);
 
       this.application.LOG_RESOLVER = true;
@@ -330,6 +333,7 @@ moduleFor(
         return;
       }
 
+      assert.test.assertions = []; // clear assertions that occurred in beforeEach
       assert.expect(3);
 
       this.application.LOG_RESOLVER = true;

--- a/packages/@ember/application/tests/dependency_injection/default_resolver_test.js
+++ b/packages/@ember/application/tests/dependency_injection/default_resolver_test.js
@@ -11,7 +11,7 @@ import { Component, Helper, helper as makeHelper } from '@ember/-internals/glimm
 import { getDebugFunction, setDebugFunction } from '@ember/debug';
 
 moduleFor(
-  'Application Dependency Injection - Integration - default resolver',
+  'Application Dependency Injection - Integration - globals resolver [DEPRECATED]',
   class extends DefaultResolverApplicationTestCase {
     beforeEach() {
       runTask(() => this.createApplication());
@@ -161,6 +161,22 @@ moduleFor(
       }, /fullName must be a proper full name/);
     }
 
+    ['@test the default resolver normalizes lookups'](assert) {
+      let locator = this.applicationInstance.__container__;
+      this.application.PostIndexController = EmberObject.extend({});
+      this.application.register('controller:postIndex', this.application.PostIndexController, {
+        singleton: true,
+      });
+
+      let dotNotationController = locator.lookup('controller:post.index');
+      let camelCaseController = locator.lookup('controller:postIndex');
+
+      assert.ok(dotNotationController instanceof this.application.PostIndexController);
+      assert.ok(camelCaseController instanceof this.application.PostIndexController);
+
+      assert.equal(dotNotationController, camelCaseController);
+    }
+
     /*
      * The following are integration tests against the private registry API.
      */
@@ -198,7 +214,7 @@ moduleFor(
     }
 
     [`@test no assertion for routes that extend from Route`](assert) {
-      assert.test.assertions = []; // clear assertions that occurred in beforeEach
+      assert.test.assertions = []; // clear assertions that occurred in beforeEach so they don't affect count
       assert.expect(0);
       this.application.FooRoute = Route.extend();
       this.privateRegistry.resolve(`route:foo`);
@@ -212,7 +228,7 @@ moduleFor(
     }
 
     [`@test no assertion for service factories that extend from Service`](assert) {
-      assert.test.assertions = []; // clear assertions that occurred in beforeEach
+      assert.test.assertions = []; // clear assertions that occurred in beforeEach so they don't affect count
       assert.expect(0);
       this.application.FooService = Service.extend();
       this.privateRegistry.resolve('service:foo');
@@ -311,7 +327,7 @@ moduleFor(
         return;
       }
 
-      assert.test.assertions = []; // clear assertions that occurred in beforeEach
+      assert.test.assertions = []; // clear assertions that occurred in beforeEach so they don't affect count
       assert.expect(3);
 
       this.application.LOG_RESOLVER = true;
@@ -333,7 +349,7 @@ moduleFor(
         return;
       }
 
-      assert.test.assertions = []; // clear assertions that occurred in beforeEach
+      assert.test.assertions = []; // clear assertions that occurred in beforeEach so they don't affect count
       assert.expect(3);
 
       this.application.LOG_RESOLVER = true;

--- a/packages/@ember/application/tests/dependency_injection/normalization_test.js
+++ b/packages/@ember/application/tests/dependency_injection/normalization_test.js
@@ -10,7 +10,12 @@ moduleFor(
     constructor() {
       super();
 
-      application = run(Application, 'create');
+      // Must use default resolver because test resolver does not normalize
+      run(() => {
+        expectDeprecation(() => {
+          application = Application.create();
+        });
+      });
       registry = application.__registry__;
     }
 

--- a/packages/@ember/application/tests/dependency_injection/normalization_test.js
+++ b/packages/@ember/application/tests/dependency_injection/normalization_test.js
@@ -5,7 +5,7 @@ import { moduleFor, AbstractTestCase as TestCase } from 'internal-test-helpers';
 let application, registry;
 
 moduleFor(
-  'Application Dependency Injection - normalize',
+  'Application Dependency Injection - Globals Resolver - normalize [DEPRECATED]',
   class extends TestCase {
     constructor() {
       super();

--- a/packages/@ember/application/tests/dependency_injection_test.js
+++ b/packages/@ember/application/tests/dependency_injection_test.js
@@ -2,7 +2,11 @@ import { context } from '@ember/-internals/environment';
 import { run } from '@ember/runloop';
 import { Object as EmberObject } from '@ember/-internals/runtime';
 import EmberApplication from '@ember/application';
-import { moduleFor, AbstractTestCase as TestCase } from 'internal-test-helpers';
+import {
+  moduleFor,
+  ModuleBasedTestResolver,
+  AbstractTestCase as TestCase,
+} from 'internal-test-helpers';
 
 let originalLookup = context.lookup;
 let registry, locator, application;
@@ -13,11 +17,8 @@ moduleFor(
     constructor() {
       super();
 
-      // Must use default resolver because test resolver does not normalize
-      run(() => {
-        expectDeprecation(() => {
-          application = EmberApplication.create();
-        });
+      application = run(EmberApplication, 'create', {
+        Resolver: ModuleBasedTestResolver,
       });
 
       application.Person = EmberObject.extend({});
@@ -51,16 +52,6 @@ moduleFor(
       run(application, 'destroy');
       registry = application = locator = null;
       context.lookup = originalLookup;
-    }
-
-    ['@test container lookup is normalized'](assert) {
-      let dotNotationController = locator.lookup('controller:post.index');
-      let camelCaseController = locator.lookup('controller:postIndex');
-
-      assert.ok(dotNotationController instanceof application.PostIndexController);
-      assert.ok(camelCaseController instanceof application.PostIndexController);
-
-      assert.equal(dotNotationController, camelCaseController);
     }
 
     ['@test registered entities can be looked up later'](assert) {

--- a/packages/@ember/application/tests/dependency_injection_test.js
+++ b/packages/@ember/application/tests/dependency_injection_test.js
@@ -13,7 +13,12 @@ moduleFor(
     constructor() {
       super();
 
-      application = run(EmberApplication, 'create');
+      // Must use default resolver because test resolver does not normalize
+      run(() => {
+        expectDeprecation(() => {
+          application = EmberApplication.create();
+        });
+      });
 
       application.Person = EmberObject.extend({});
       application.Orange = EmberObject.extend({});

--- a/packages/@ember/application/tests/readiness_test.js
+++ b/packages/@ember/application/tests/readiness_test.js
@@ -1,4 +1,4 @@
-import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
+import { moduleFor, ModuleBasedTestResolver, ApplicationTestCase } from 'internal-test-helpers';
 import { run } from '@ember/runloop';
 import EmberApplication from '..';
 
@@ -45,6 +45,7 @@ moduleFor(
 
       Application = EmberApplication.extend({
         $: jQuery,
+        Resolver: ModuleBasedTestResolver,
 
         ready() {
           readyWasCalled++;

--- a/packages/@ember/application/tests/visit_test.js
+++ b/packages/@ember/application/tests/visit_test.js
@@ -1,4 +1,9 @@
-import { moduleFor, ApplicationTestCase, runTask } from 'internal-test-helpers';
+import {
+  moduleFor,
+  ModuleBasedTestResolver,
+  ApplicationTestCase,
+  runTask,
+} from 'internal-test-helpers';
 import { inject as injectService } from '@ember/service';
 import { Object as EmberObject, RSVP, onerrorDefault } from '@ember/-internals/runtime';
 import { later } from '@ember/runloop';
@@ -465,7 +470,9 @@ moduleFor(
       this.addTemplate('application', '<h1>Hello world</h1>');
 
       // Register engine
-      let BlogEngine = Engine.extend();
+      let BlogEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
       this.add('engine:blog', BlogEngine);
 
       // Register engine route map
@@ -502,6 +509,8 @@ moduleFor(
 
       // Register engine
       let BlogEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+
         init(...args) {
           this._super.apply(this, args);
           this.register('template:application', compile('{{cache-money}}'));
@@ -544,6 +553,8 @@ moduleFor(
 
       // Register engine
       let BlogEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+
         init(...args) {
           this._super.apply(this, args);
           this.register('template:application', compile('{{cache-money}}'));
@@ -582,6 +593,8 @@ moduleFor(
 
       // Register engine
       let BlogEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+
         init(...args) {
           this._super.apply(this, args);
           this.register('template:application', compile('{{swag}}'));

--- a/packages/@ember/deprecated-features/index.ts
+++ b/packages/@ember/deprecated-features/index.ts
@@ -16,3 +16,4 @@ export const FUNCTION_PROTOTYPE_EXTENSIONS = !!'3.11.0-beta.1';
 export const MOUSE_ENTER_LEAVE_MOVE_EVENTS = !!'3.13.0-beta.1';
 export const EMBER_COMPONENT_IS_VISIBLE = !!'3.15.0-beta.1';
 export const PARTIALS = !!'3.15.0-beta.1';
+export const GLOBALS_RESOLVER = !!'3.16.0';

--- a/packages/@ember/deprecated-features/index.ts
+++ b/packages/@ember/deprecated-features/index.ts
@@ -16,4 +16,4 @@ export const FUNCTION_PROTOTYPE_EXTENSIONS = !!'3.11.0-beta.1';
 export const MOUSE_ENTER_LEAVE_MOVE_EVENTS = !!'3.13.0-beta.1';
 export const EMBER_COMPONENT_IS_VISIBLE = !!'3.15.0-beta.1';
 export const PARTIALS = !!'3.15.0-beta.1';
-export const GLOBALS_RESOLVER = !!'3.16.0';
+export const GLOBALS_RESOLVER = !!'3.16.0-beta.1';

--- a/packages/@ember/engine/tests/engine_initializers_test.js
+++ b/packages/@ember/engine/tests/engine_initializers_test.js
@@ -1,6 +1,10 @@
 import { run } from '@ember/runloop';
 import Engine from '@ember/engine';
-import { moduleFor, AbstractTestCase as TestCase } from 'internal-test-helpers';
+import {
+  moduleFor,
+  ModuleBasedTestResolver,
+  AbstractTestCase as TestCase,
+} from 'internal-test-helpers';
 
 let MyEngine, myEngine, myEngineInstance;
 
@@ -22,7 +26,9 @@ moduleFor(
     }
 
     ["@test initializers require proper 'name' and 'initialize' properties"]() {
-      MyEngine = Engine.extend();
+      MyEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
 
       expectAssertion(() => {
         run(() => {
@@ -38,7 +44,9 @@ moduleFor(
     }
 
     ['@test initializers are passed an Engine'](assert) {
-      MyEngine = Engine.extend();
+      MyEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
 
       MyEngine.initializer({
         name: 'initializer',
@@ -54,7 +62,9 @@ moduleFor(
     ['@test initializers can be registered in a specified order'](assert) {
       let order = [];
 
-      MyEngine = Engine.extend();
+      MyEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
       MyEngine.initializer({
         name: 'fourth',
         after: 'third',
@@ -112,7 +122,9 @@ moduleFor(
     ['@test initializers can be registered in a specified order as an array'](assert) {
       let order = [];
 
-      MyEngine = Engine.extend();
+      MyEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
 
       MyEngine.initializer({
         name: 'third',
@@ -171,7 +183,9 @@ moduleFor(
     ['@test initializers can have multiple dependencies'](assert) {
       let order = [];
 
-      MyEngine = Engine.extend();
+      MyEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
 
       let a = {
         name: 'a',
@@ -226,7 +240,9 @@ moduleFor(
     ['@test initializers set on Engine subclasses are not shared between engines'](assert) {
       let firstInitializerRunCount = 0;
       let secondInitializerRunCount = 0;
-      let FirstEngine = Engine.extend();
+      let FirstEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
 
       FirstEngine.initializer({
         name: 'first',
@@ -235,7 +251,9 @@ moduleFor(
         },
       });
 
-      let SecondEngine = Engine.extend();
+      let SecondEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
 
       SecondEngine.initializer({
         name: 'second',
@@ -268,7 +286,9 @@ moduleFor(
     ['@test initializers are concatenated'](assert) {
       let firstInitializerRunCount = 0;
       let secondInitializerRunCount = 0;
-      let FirstEngine = Engine.extend();
+      let FirstEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
 
       FirstEngine.initializer({
         name: 'first',
@@ -277,7 +297,9 @@ moduleFor(
         },
       });
 
-      let SecondEngine = FirstEngine.extend();
+      let SecondEngine = FirstEngine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
 
       SecondEngine.initializer({
         name: 'second',
@@ -323,7 +345,9 @@ moduleFor(
     ['@test initializers are per-engine'](assert) {
       assert.expect(2);
 
-      let FirstEngine = Engine.extend();
+      let FirstEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
 
       FirstEngine.initializer({
         name: 'abc',
@@ -337,7 +361,9 @@ moduleFor(
         });
       });
 
-      let SecondEngine = Engine.extend();
+      let SecondEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
       SecondEngine.instanceInitializer({
         name: 'abc',
         initialize() {},
@@ -349,7 +375,9 @@ moduleFor(
     ['@test initializers are executed in their own context'](assert) {
       assert.expect(1);
 
-      MyEngine = Engine.extend();
+      MyEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
 
       MyEngine.initializer({
         name: 'coolInitializer',

--- a/packages/@ember/engine/tests/engine_initializers_test.js
+++ b/packages/@ember/engine/tests/engine_initializers_test.js
@@ -297,9 +297,7 @@ moduleFor(
         },
       });
 
-      let SecondEngine = FirstEngine.extend({
-        Resolver: ModuleBasedTestResolver,
-      });
+      let SecondEngine = FirstEngine.extend();
 
       SecondEngine.initializer({
         name: 'second',

--- a/packages/@ember/engine/tests/engine_instance_initializers_test.js
+++ b/packages/@ember/engine/tests/engine_instance_initializers_test.js
@@ -1,7 +1,11 @@
 import { run } from '@ember/runloop';
 import Engine, { setEngineParent } from '@ember/engine';
 import EngineInstance from '@ember/engine/instance';
-import { moduleFor, AbstractTestCase as TestCase } from 'internal-test-helpers';
+import {
+  moduleFor,
+  ModuleBasedTestResolver,
+  AbstractTestCase as TestCase,
+} from 'internal-test-helpers';
 
 let MyEngine, myEngine, myEngineInstance;
 
@@ -36,7 +40,9 @@ moduleFor(
     }
 
     ["@test initializers require proper 'name' and 'initialize' properties"]() {
-      MyEngine = Engine.extend();
+      MyEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
 
       expectAssertion(() => {
         run(() => {
@@ -52,7 +58,9 @@ moduleFor(
     }
 
     ['@test initializers are passed an engine instance'](assert) {
-      MyEngine = Engine.extend();
+      MyEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
 
       MyEngine.instanceInitializer({
         name: 'initializer',
@@ -69,7 +77,9 @@ moduleFor(
     ['@test initializers can be registered in a specified order'](assert) {
       let order = [];
 
-      MyEngine = Engine.extend();
+      MyEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
 
       MyEngine.instanceInitializer({
         name: 'fourth',
@@ -129,7 +139,9 @@ moduleFor(
 
     ['@test initializers can be registered in a specified order as an array'](assert) {
       let order = [];
-      MyEngine = Engine.extend();
+      MyEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
 
       MyEngine.instanceInitializer({
         name: 'third',
@@ -190,7 +202,9 @@ moduleFor(
     ['@test initializers can have multiple dependencies'](assert) {
       let order = [];
 
-      MyEngine = Engine.extend();
+      MyEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
 
       let a = {
         name: 'a',
@@ -247,7 +261,9 @@ moduleFor(
     ['@test initializers set on Engine subclasses should not be shared between engines'](assert) {
       let firstInitializerRunCount = 0;
       let secondInitializerRunCount = 0;
-      let FirstEngine = Engine.extend();
+      let FirstEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
       let firstEngine, firstEngineInstance;
 
       FirstEngine.instanceInitializer({
@@ -257,7 +273,9 @@ moduleFor(
         },
       });
 
-      let SecondEngine = Engine.extend();
+      let SecondEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
       let secondEngine, secondEngineInstance;
 
       SecondEngine.instanceInitializer({
@@ -297,7 +315,9 @@ moduleFor(
     ['@test initializers are concatenated'](assert) {
       let firstInitializerRunCount = 0;
       let secondInitializerRunCount = 0;
-      let FirstEngine = Engine.extend();
+      let FirstEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
 
       FirstEngine.instanceInitializer({
         name: 'first',
@@ -364,7 +384,9 @@ moduleFor(
     ['@test initializers are per-engine'](assert) {
       assert.expect(2);
 
-      let FirstEngine = Engine.extend();
+      let FirstEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
 
       FirstEngine.instanceInitializer({
         name: 'abc',
@@ -378,7 +400,9 @@ moduleFor(
         });
       });
 
-      let SecondEngine = Engine.extend();
+      let SecondEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
       SecondEngine.instanceInitializer({
         name: 'abc',
         initialize() {},
@@ -390,7 +414,9 @@ moduleFor(
     ['@test initializers are executed in their own context'](assert) {
       assert.expect(1);
 
-      let MyEngine = Engine.extend();
+      let MyEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
 
       MyEngine.instanceInitializer({
         name: 'coolInitializer',

--- a/packages/@ember/engine/tests/engine_instance_test.js
+++ b/packages/@ember/engine/tests/engine_instance_test.js
@@ -2,7 +2,11 @@ import Engine, { getEngineParent, setEngineParent } from '@ember/engine';
 import EngineInstance from '@ember/engine/instance';
 import { run } from '@ember/runloop';
 import { factory } from 'internal-test-helpers';
-import { moduleFor, AbstractTestCase as TestCase } from 'internal-test-helpers';
+import {
+  moduleFor,
+  ModuleBasedTestResolver,
+  AbstractTestCase as TestCase,
+} from 'internal-test-helpers';
 
 let engine, engineInstance;
 
@@ -13,7 +17,10 @@ moduleFor(
       super();
 
       run(() => {
-        engine = Engine.create({ router: null });
+        engine = Engine.create({
+          router: null,
+          Resolver: ModuleBasedTestResolver,
+        });
       });
     }
 
@@ -86,7 +93,9 @@ moduleFor(
     }
 
     ['@test can build a child instance of a registered engine'](assert) {
-      let ChatEngine = Engine.extend();
+      let ChatEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
       let chatEngineInstance;
 
       engine.register('engine:chat', ChatEngine);

--- a/packages/@ember/engine/tests/engine_test.js
+++ b/packages/@ember/engine/tests/engine_test.js
@@ -6,6 +6,7 @@ import { privatize as P } from '@ember/-internals/container';
 import {
   moduleFor,
   AbstractTestCase as TestCase,
+  ModuleBasedTestResolver,
   verifyInjection,
   verifyRegistration,
 } from 'internal-test-helpers';
@@ -20,7 +21,9 @@ moduleFor(
       super();
 
       run(() => {
-        engine = Engine.create();
+        engine = Engine.create({
+          Resolver: ModuleBasedTestResolver,
+        });
         context.lookup = { TestEngine: engine };
       });
     }

--- a/packages/ember-testing/tests/adapters_test.js
+++ b/packages/ember-testing/tests/adapters_test.js
@@ -4,7 +4,7 @@ import Test from '../lib/test';
 import Adapter from '../lib/adapters/adapter';
 import QUnitAdapter from '../lib/adapters/qunit';
 import EmberApplication from '@ember/application';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, ModuleBasedTestResolver, AbstractTestCase } from 'internal-test-helpers';
 import { RSVP } from '@ember/-internals/runtime';
 import { getDebugFunction, setDebugFunction } from '@ember/debug';
 
@@ -72,7 +72,9 @@ moduleFor(
       });
 
       run(function() {
-        App = EmberApplication.create();
+        App = EmberApplication.create({
+          Resolver: ModuleBasedTestResolver,
+        });
         Test.adapter = CustomAdapter.create();
         App.setupForTesting();
       });
@@ -86,7 +88,9 @@ moduleFor(
       Test.adapter = null;
 
       run(function() {
-        App = EmberApplication.create();
+        App = EmberApplication.create({
+          Resolver: ModuleBasedTestResolver,
+        });
         App.setupForTesting();
       });
 
@@ -101,7 +105,9 @@ moduleFor(
       Test.adapter = null;
 
       run(function() {
-        App = EmberApplication.create();
+        App = EmberApplication.create({
+          Resolver: ModuleBasedTestResolver,
+        });
         App.setupForTesting();
       });
 

--- a/packages/ember-testing/tests/helper_registration_test.js
+++ b/packages/ember-testing/tests/helper_registration_test.js
@@ -1,7 +1,7 @@
 import { run } from '@ember/runloop';
 import Test from '../lib/test';
 import EmberApplication from '@ember/application';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, ModuleBasedTestResolver, AbstractTestCase } from 'internal-test-helpers';
 
 let App, appBooted, helperContainer;
 
@@ -24,7 +24,9 @@ function setupApp() {
   helperContainer = {};
 
   run(function() {
-    App = EmberApplication.create();
+    App = EmberApplication.create({
+      Resolver: ModuleBasedTestResolver,
+    });
     App.setupForTesting();
     App.injectTestHelpers(helperContainer);
   });

--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -133,6 +133,7 @@ import EngineInstance from '@ember/engine/instance';
 import { assign, merge } from '@ember/polyfills';
 import { LOGGER, EMBER_EXTEND_PROTOTYPES, JQUERY_INTEGRATION } from '@ember/deprecated-features';
 import templateOnlyComponent from '@ember/component/template-only';
+
 // ****@ember/-internals/environment****
 
 const Ember = (typeof context.imports.Ember === 'object' && context.imports.Ember) || {};
@@ -175,8 +176,29 @@ if (EMBER_EXTEND_PROTOTYPES) {
 Ember.getOwner = getOwner;
 Ember.setOwner = setOwner;
 Ember.Application = Application;
-Ember.DefaultResolver = Ember.Resolver = Resolver;
 Ember.ApplicationInstance = ApplicationInstance;
+
+Object.defineProperty(Ember, 'Resolver', {
+  get() {
+    deprecate(
+      'Using the globals resolver is deprecated. Use the ember-resolver package instead. See https://deprecations.emberjs.com/v3.x#toc_ember-deprecate-globals-resolver',
+      false,
+      {
+        id: 'ember.globals-resolver',
+        until: '4.0.0',
+        url: 'https://deprecations.emberjs.com/v3.x#toc_ember-deprecate-globals-resolver',
+      }
+    );
+
+    return Resolver;
+  },
+});
+
+Object.defineProperty(Ember, 'DefaultResolver', {
+  get() {
+    return Ember.Resolver;
+  },
+});
 
 // ****@ember/engine****
 Ember.Engine = Engine;

--- a/packages/ember/tests/ember-test-helpers-test.js
+++ b/packages/ember/tests/ember-test-helpers-test.js
@@ -2,6 +2,7 @@ import { Promise } from 'rsvp';
 import Application from '@ember/application';
 import { run, hasScheduledTimers, getCurrentRunLoop } from '@ember/runloop';
 import { compile } from 'ember-template-compiler';
+import { ModuleBasedTestResolver } from 'internal-test-helpers';
 
 const { module, test } = QUnit;
 
@@ -110,6 +111,7 @@ module('@ember/test-helpers emulation test', function() {
         this.application = Application.create({
           rootElement: '#qunit-fixture',
           autoboot: false,
+          Resolver: ModuleBasedTestResolver,
         });
 
         await setupContext(this);

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -7,6 +7,7 @@ import {
 import { confirmExport } from 'internal-test-helpers';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 import { jQueryDisabled, jQuery } from '@ember/-internals/views';
+import Resolver from '@ember/application/globals-resolver';
 
 moduleFor(
   'ember reexports',
@@ -52,6 +53,18 @@ moduleFor(
       expectDeprecation(() => {
         Ember._setComputedDecorator;
       }, 'Please migrate from Ember._setComputedDecorator to Ember._setClassicDecorator');
+    }
+
+    ['@test Ember.Resolver is present (but deprecated)'](assert) {
+      expectDeprecation(() => {
+        assert.strictEqual(Ember.Resolver, Resolver, 'Ember.Resolver exists');
+      }, /Using the globals resolver is deprecated/);
+    }
+
+    ['@test Ember.DefaultResolver is present (but deprecated)'](assert) {
+      expectDeprecation(() => {
+        assert.strictEqual(Ember.DefaultResolver, Resolver, 'Ember.DefaultResolver exists');
+      }, /Using the globals resolver is deprecated/);
     }
   }
 );
@@ -340,8 +353,6 @@ let allExports = [
   ['ApplicationInstance', '@ember/application/instance', 'default'],
   ['Engine', '@ember/engine', 'default'],
   ['EngineInstance', '@ember/engine/instance', 'default'],
-  ['Resolver', '@ember/application/globals-resolver', 'default'],
-  ['DefaultResolver', '@ember/application/globals-resolver', 'default'],
 
   // @ember/-internals/extension-support
   ['DataAdapter', '@ember/-internals/extension-support'],

--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -5,10 +5,16 @@ import { compile } from 'ember-template-compiler';
 import { Route, NoneLocation, HistoryLocation } from '@ember/-internals/routing';
 import Controller from '@ember/controller';
 import { Object as EmberObject, A as emberA } from '@ember/-internals/runtime';
-import { moduleFor, ApplicationTestCase, runDestroy, runTask } from 'internal-test-helpers';
+import {
+  moduleFor,
+  ApplicationTestCase,
+  getTextOf,
+  ModuleBasedTestResolver,
+  runDestroy,
+  runTask,
+} from 'internal-test-helpers';
 import { run } from '@ember/runloop';
 import { Mixin, computed, set, addObserver } from '@ember/-internals/metal';
-import { getTextOf } from 'internal-test-helpers';
 import { Component } from '@ember/-internals/glimmer';
 import Engine from '@ember/engine';
 import { InternalTransition as Transition } from 'router_js';
@@ -4618,7 +4624,9 @@ moduleFor(
       assert.expect(2);
 
       // Register engine
-      let BlogEngine = Engine.extend();
+      let BlogEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
       this.add('engine:blog', BlogEngine);
 
       // Register engine route map
@@ -4654,7 +4662,9 @@ moduleFor(
       assert.expect(1);
 
       // Register engine
-      let BlogEngine = Engine.extend();
+      let BlogEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
       this.add('engine:blog', BlogEngine);
 
       // Register engine route map
@@ -4688,7 +4698,9 @@ moduleFor(
 
       let engineInstance;
       // Register engine
-      let BlogEngine = Engine.extend();
+      let BlogEngine = Engine.extend({
+        Resolver: ModuleBasedTestResolver,
+      });
       this.add('engine:blog', BlogEngine);
       let EngineIndexRoute = Route.extend({
         init() {

--- a/packages/internal-test-helpers/lib/test-cases/default-resolver-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/default-resolver-application.js
@@ -9,7 +9,18 @@ import { runTask } from '../run';
 
 export default class DefaultResolverApplicationTestCase extends AbstractApplicationTestCase {
   createApplication() {
-    let application = (this.application = Application.create(this.applicationOptions));
+    let application;
+    expectDeprecation(() => {
+      application = this.application = Application.create(this.applicationOptions);
+    }, /Using the globals resolver is deprecated/);
+
+    // If the test expects a certain number of assertions, increment that number
+    let { assert } = QUnit.config.current;
+    if (typeof assert.test.expected === 'number') {
+      assert.test.expected += 1;
+      QUnit.config.current.expected += 1;
+    }
+
     application.Router = Router.extend(this.routerOptions);
     return application;
   }


### PR DESCRIPTION
For https://github.com/emberjs/rfc-tracking/issues/20

- [x] Deprecate instantiating @ember/application/globals-resolver (in init of packages/@ember/application/globals-resolver.ts)
- [x] Deprecate using Ember.Resolver / Ember.DefaultResolver (in packages/ember/index.js)