### PR TITLE
[DOC beta] document `Transition.to` as nullable

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/transition.ts
+++ b/packages/@ember/-internals/routing/lib/system/transition.ts
@@ -139,7 +139,7 @@
  * where the router is transitioning to. It's important
  * to note that a `RouteInfo` is a linked list and this
  * property represents the leafmost route.
- * @property {?RouteInfo|RouteInfoWithAttributes} to
+ * @property {null|RouteInfo|RouteInfoWithAttributes} to
  * @public
  */
 

--- a/packages/@ember/-internals/routing/lib/system/transition.ts
+++ b/packages/@ember/-internals/routing/lib/system/transition.ts
@@ -139,7 +139,7 @@
  * where the router is transitioning to. It's important
  * to note that a `RouteInfo` is a linked list and this
  * property represents the leafmost route.
- * @property {RouteInfo|RouteInfoWithAttributes} to
+ * @property {?RouteInfo|RouteInfoWithAttributes} to
  * @public
  */
 


### PR DESCRIPTION
Property `to` of `Transition` seems to be nullable. At least I got an error thrown in production that it was `null`. Please verify before merging that this is expected behavior. I've seen this after Ember Data has thrown an error caused by a 500 response.