### PR TITLE
[DOC beta] document `Transition.from` as nullable in JSDoc

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/transition.ts
+++ b/packages/@ember/-internals/routing/lib/system/transition.ts
@@ -150,7 +150,7 @@
  * property represents the head node of the list.
  * In the case of an initial render, `from` will be set to
  * `null`.
- * @property {?RouteInfoWithAttributes} from
+ * @property {null|RouteInfoWithAttributes} from
  * @public
  */
 

--- a/packages/@ember/-internals/routing/lib/system/transition.ts
+++ b/packages/@ember/-internals/routing/lib/system/transition.ts
@@ -150,7 +150,7 @@
  * property represents the head node of the list.
  * In the case of an initial render, `from` will be set to
  * `null`.
- * @property {RouteInfoWithAttributes} from
+ * @property {?RouteInfoWithAttributes} from
  * @public
  */
 


### PR DESCRIPTION
The description already mentions that it could be `null`.