### PR TITLE
[BUGFIX] Using query params helper outside of link-to

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -838,14 +838,14 @@ const LinkComponent = EmberComponent.extend({
         )
       );
 
-      if (DEBUG && this.query === UNDEFINED) {
-        let { _models: models } = this;
-        let lastModel = models.length > 0 && models[models.length - 1];
+      let { _models: models } = this;
+      if (models.length > 0) {
+        let lastModel = models[models.length - 1];
 
-        assert(
-          'The `(query-params)` helper can only be used when invoking the `{{link-to}}` component.',
-          !(lastModel && lastModel.isQueryParams)
-        );
+        if (typeof lastModel === 'object' && lastModel !== null && lastModel.isQueryParams) {
+          this.query = lastModel.values;
+          models.pop();
+        }
       }
 
       return;

--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -3,7 +3,6 @@
 */
 
 import { alias, computed } from '@ember/-internals/metal';
-import { isQueryParams } from '@ember/-internals/routing/lib/system/query_params';
 import { isSimpleClick } from '@ember/-internals/views';
 import { assert, warn } from '@ember/debug';
 import { flaggedInstrument } from '@ember/instrumentation';
@@ -839,21 +838,14 @@ const LinkComponent = EmberComponent.extend({
         )
       );
 
-      if (this.query === UNDEFINED) {
-        let { _models: models } = this;
-        if (models.length > 0) {
-          let lastModel = models[models.length - 1];
+      let { _models: models } = this;
+      if (models.length > 0) {
+        let lastModel = models[models.length - 1];
 
-          if (typeof lastModel === 'object' && lastModel !== null && lastModel.isQueryParams) {
-            this.query = lastModel.values;
-            models.pop();
-          }
+        if (typeof lastModel === 'object' && lastModel !== null && lastModel.isQueryParams) {
+          this.query = lastModel.values;
+          models.pop();
         }
-      } else {
-        assert(
-          'Cannot pass a QueryParams object in @models and @query at the same time',
-          !(this.models.length === 0 || isQueryParams(this.models[this.models.length - 1]))
-        );
       }
 
       return;

--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -3,6 +3,7 @@
 */
 
 import { alias, computed } from '@ember/-internals/metal';
+import { isQueryParams } from '@ember/-internals/routing/lib/system/query_params';
 import { isSimpleClick } from '@ember/-internals/views';
 import { assert, warn } from '@ember/debug';
 import { flaggedInstrument } from '@ember/instrumentation';
@@ -838,14 +839,21 @@ const LinkComponent = EmberComponent.extend({
         )
       );
 
-      let { _models: models } = this;
-      if (models.length > 0) {
-        let lastModel = models[models.length - 1];
+      if (this.query === UNDEFINED) {
+        let { _models: models } = this;
+        if (models.length > 0) {
+          let lastModel = models[models.length - 1];
 
-        if (typeof lastModel === 'object' && lastModel !== null && lastModel.isQueryParams) {
-          this.query = lastModel.values;
-          models.pop();
+          if (typeof lastModel === 'object' && lastModel !== null && lastModel.isQueryParams) {
+            this.query = lastModel.values;
+            models.pop();
+          }
         }
+      } else {
+        assert(
+          'Cannot pass a QueryParams object in @models and @query at the same time',
+          !(this.models.length === 0 || isQueryParams(this.models[this.models.length - 1]))
+        );
       }
 
       return;

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-curly-test.js
@@ -76,13 +76,16 @@ moduleFor(
 
       this.addTemplate(
         'index',
-        `{{#let (query-params foo='456' bar='NAW') as |qp|}}{{link-to 'Index' 'index' qp}}{{/let}}`
+        `{{#let (query-params foo='456' alon='BUKAI') as |qp|}}{{link-to 'Index' 'index' qp}}{{/let}}`
       );
 
-      return assert.rejectsAssertion(
-        this.visit('/'),
-        /The `\(query-params\)` helper can only be used when invoking the `{{link-to}}` component\./
-      );
+      return this.visit('/').then(() => {
+        this.assertComponentElement(this.firstChild, {
+          tagName: 'a',
+          attrs: { href: '/?alon=BUKAI&foo=456', class: classMatcher('ember-view') },
+          content: 'Index',
+        });
+      });
     }
   }
 );

--- a/packages/@ember/-internals/routing/lib/system/query_params.ts
+++ b/packages/@ember/-internals/routing/lib/system/query_params.ts
@@ -1,13 +1,7 @@
-import { Option } from '@glimmer/interfaces';
-
 export default class QueryParams {
   values: null | object;
   isQueryParams = true;
-  constructor(values: Option<object> = null) {
+  constructor(values = null) {
     this.values = values;
   }
-}
-
-export function isQueryParams(obj: unknown): obj is QueryParams {
-  return typeof obj === 'object' && obj !== null && obj['isQueryParams'] === true;
 }

--- a/packages/@ember/-internals/routing/lib/system/query_params.ts
+++ b/packages/@ember/-internals/routing/lib/system/query_params.ts
@@ -1,7 +1,13 @@
+import { Option } from '@glimmer/interfaces';
+
 export default class QueryParams {
   values: null | object;
   isQueryParams = true;
-  constructor(values = null) {
+  constructor(values: Option<object> = null) {
     this.values = values;
   }
+}
+
+export function isQueryParams(obj: unknown): obj is QueryParams {
+  return typeof obj === 'object' && obj !== null && obj['isQueryParams'] === true;
 }


### PR DESCRIPTION
The (query-params) helper has always been able to be used outside of `link-to`.
This PR broke it: #17779 

Fixes: #18076 

Recommendations:
This should be backported to the version in which #17779 was included.

Thanks a lot to @rwjblue for the help in fixing this 😄 