### PR TITLE
Remove handling of baseURL in HistoryLocation

### DIFF
--- a/packages/@ember/-internals/routing/lib/location/history_location.ts
+++ b/packages/@ember/-internals/routing/lib/location/history_location.ts
@@ -73,13 +73,6 @@ export default class HistoryLocation extends EmberObject implements EmberLocatio
   init() {
     this._super(...arguments);
 
-    let base = document.querySelector('base');
-    let baseURL: string | null = '';
-    if (base) {
-      baseURL = base.getAttribute('href');
-    }
-
-    set(this, 'baseURL', baseURL);
     set(this, 'location', this.location || window.location);
 
     this._popstateHandler = undefined;
@@ -111,25 +104,21 @@ export default class HistoryLocation extends EmberObject implements EmberLocatio
   }
 
   /**
-    Returns the current `location.pathname` without `rootURL` or `baseURL`
+    Returns the current `location.pathname` without `rootURL`
 
     @private
     @method getURL
     @return url {String}
   */
   getURL() {
-    let { location, rootURL, baseURL } = this;
+    let { location, rootURL } = this;
     let path = location.pathname;
 
     // remove trailing slashes if they exists
     rootURL = rootURL.replace(/\/$/, '');
-    baseURL = baseURL.replace(/\/$/, '');
 
-    // remove baseURL and rootURL from start of path
-    let url = path
-      .replace(new RegExp(`^${baseURL}(?=/|$)`), '')
-      .replace(new RegExp(`^${rootURL}(?=/|$)`), '')
-      .replace(/\/\//g, '/'); // remove extra slashes
+    // remove rootURL from start of path
+    let url = path.replace(new RegExp(`^${rootURL}(?=/|$)`), '').replace(/\/\//g, '/'); // remove extra slashes
 
     let search = location.search || '';
     url += search + this.getHash();
@@ -262,19 +251,14 @@ export default class HistoryLocation extends EmberObject implements EmberLocatio
     @return formatted url {String}
   */
   formatURL(url: string) {
-    let { rootURL, baseURL } = this;
+    let { rootURL } = this;
 
     if (url !== '') {
       // remove trailing slashes if they exists
       rootURL = rootURL.replace(/\/$/, '');
-      baseURL = baseURL.replace(/\/$/, '');
-    } else if (baseURL[0] === '/' && rootURL[0] === '/') {
-      // if baseURL and rootURL both start with a slash
-      // ... remove trailing slash from baseURL if it exists
-      baseURL = baseURL.replace(/\/$/, '');
     }
 
-    return baseURL + rootURL + url;
+    return rootURL + url;
   }
 
   /**

--- a/packages/@ember/-internals/routing/tests/location/history_location_test.js
+++ b/packages/@ember/-internals/routing/tests/location/history_location_test.js
@@ -97,48 +97,6 @@ moduleFor(
       location.initState();
     }
 
-    ['@test base URL is removed when retrieving the current pathname'](assert) {
-      assert.expect(1);
-
-      HistoryTestLocation.reopen({
-        init() {
-          this._super(...arguments);
-
-          set(this, 'location', mockBrowserLocation('/base/foo/bar'));
-          set(this, 'baseURL', '/base/');
-        },
-
-        initState() {
-          this._super(...arguments);
-
-          assert.equal(this.getURL(), '/foo/bar');
-        },
-      });
-
-      createLocation();
-      location.initState();
-    }
-
-    ['@test base URL is preserved when moving around'](assert) {
-      assert.expect(2);
-
-      HistoryTestLocation.reopen({
-        init() {
-          this._super(...arguments);
-
-          set(this, 'location', mockBrowserLocation('/base/foo/bar'));
-          set(this, 'baseURL', '/base/');
-        },
-      });
-
-      createLocation();
-      location.initState();
-      location.setURL('/one/two');
-
-      assert.equal(location._historyState.path, '/base/one/two');
-      assert.ok(location._historyState.uuid);
-    }
-
     ['@test setURL continues to set even with a null state (iframes may set this)'](assert) {
       createLocation();
       location.initState();
@@ -161,22 +119,19 @@ moduleFor(
       assert.ok(location._historyState.uuid);
     }
 
-    ['@test HistoryLocation.getURL() returns the current url, excluding both rootURL and baseURL'](
-      assert
-    ) {
+    ['@test HistoryLocation.getURL() returns the current url, excluding rootURL'](assert) {
       HistoryTestLocation.reopen({
         init() {
           this._super(...arguments);
 
           set(this, 'location', mockBrowserLocation('/base/foo/bar'));
           set(this, 'rootURL', '/app/');
-          set(this, 'baseURL', '/base/');
         },
       });
 
       createLocation();
 
-      assert.equal(location.getURL(), '/foo/bar');
+      assert.equal(location.getURL(), '/base/foo/bar');
     }
 
     ['@test HistoryLocation.getURL() returns the current url, does not remove rootURL if its not at start of url'](


### PR DESCRIPTION
The `baseURL` feature was [deprecated in Ember CLI 2.7](https://blog.emberjs.com/2016/04/28/baseurl). 