### PR TITLE
[BUGFIX release] Prevents observer re-entry

### DIFF
--- a/packages/@ember/-internals/metal/lib/observer.ts
+++ b/packages/@ember/-internals/metal/lib/observer.ts
@@ -217,9 +217,9 @@ export function flushSyncObservers() {
           observer.suspended = true;
           sendEvent(target, eventName, [target, observer.path]);
         } finally {
-          observer.suspended = false;
           observer.tag = combine(getChainTagsForKey(target, observer.path));
           observer.lastRevision = value(observer.tag);
+          observer.suspended = false;
         }
       }
     });


### PR DESCRIPTION
In some cases, observers may cause side effects while computing their tags
(aliases, primarily) which attempt to reflush the same observer