### PR TITLE
[Failing Test] {{on}} modifier removes valueless attributes

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/modifiers/on-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/modifiers/on-test.js
@@ -374,13 +374,14 @@ moduleFor(
       this.assertCounts({ adds: 1, removes: 1 });
     }
 
-    '@test it respects boolean attributes'() {
+    '@test it respects valueless attributes'() {
       this.render(
         `
-        <input id='autofocus' autofocus {{on "input" this.callback}} />
-        <input id='readonly' readonly {{on "input" this.callback}} />
-        <input id='required' required {{on "input" this.callback}} />
-        <button id='disabled' disabled {{on "click" this.callback}}>Click Me</button> />
+        <input id='autofocus' autofocus {{on 'input' this.callback}} />
+        <input id='readonly' readonly {{on 'input' this.callback}} />
+        <input id='required' required {{on 'input' this.callback}} />
+        <button id='disabled' disabled {{on 'click' this.callback}}></button>
+        <video controls {{on 'canplay' this.callback once=true}}></video>
       `,
         {
           callback() {},
@@ -391,6 +392,7 @@ moduleFor(
       this.assert.equal(this.$('#readonly').prop('readOnly'), true, 'input is readonly');
       this.assert.equal(this.$('#required').prop('required'), true, 'input is required');
       this.assert.equal(this.$('#disabled').prop('disabled'), true, 'button is disabled');
+      this.assert.equal(this.$('video').prop('controls'), true, 'video has controls');
     }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/modifiers/on-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/modifiers/on-test.js
@@ -373,6 +373,25 @@ moduleFor(
 
       this.assertCounts({ adds: 1, removes: 1 });
     }
+
+    '@test it respects boolean attributes'() {
+      this.render(
+        `
+        <input id='autofocus' autofocus {{on "input" this.callback}} />
+        <input id='readonly' readonly {{on "input" this.callback}} />
+        <input id='required' required {{on "input" this.callback}} />
+        <button id='disabled' disabled {{on "click" this.callback}}>Click Me</button> />
+      `,
+        {
+          callback() {},
+        }
+      );
+
+      this.assert.equal(this.$('#autofocus').prop('autofocus'), true, 'input has autofocus');
+      this.assert.equal(this.$('#readonly').prop('readOnly'), true, 'input is readonly');
+      this.assert.equal(this.$('#required').prop('required'), true, 'input is required');
+      this.assert.equal(this.$('#disabled').prop('disabled'), true, 'button is disabled');
+    }
   }
 );
 


### PR DESCRIPTION
Noticed today that using the {{on}} modifier on an element with the `required` attribute removed the attribute.

e.g.
template: `<input type='text' required {{on 'input' this.onInput}} >`
resulted in
DOM: `<input type='text' >`

However, adding a value to the attribute caused it to remain.

e.g.
template: `<input type='text' required='true' {{on 'input' this.onInput}} >`
resulted in DOM
DOM: `<input type='text' required >`

While adding a failing test for `required`, I also added checks for other boolean attributes.
`autofocus`, `required`, and `disabled` are all removed, while `readonly` is preserved.

I believe the problem is with the {{on}} modifier because
template: `<input type='text' required >`
results in
DOM: `<input type='text' required >`.

I looked through the {{on}} modifier source and nothing jumped out at me, so maybe it isn't directly an {{on}} problem though?

Side Note:
I made the `disabled` element a `button` to show that it is not only `input` that is affected.