### PR TITLE
[BUGFIX release] Remove requirement for jquery in Octane

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -79,9 +79,22 @@ module.exports = {
         );
       }
 
-      if (optionalFeaturesMissing || optionalFeatures.isFeatureEnabled('jquery-integration')) {
+      if (
+        optionalFeaturesMissing ||
+        typeof optionalFeatures.isFeatureExplicitlySet !== 'function'
+      ) {
         message.push(
-          `* The jquery-integration optional feature should be disabled under Octane, run \`ember feature:disable jquery-integration\` to disable it`
+          '* Unable to detect if jquery-integration is explicitly set to a value, please update `@ember/optional-features` to the latest version'
+        );
+      }
+
+      if (
+        optionalFeaturesMissing ||
+        (typeof optionalFeatures.isFeatureExplicitlySet === 'function' &&
+          !optionalFeatures.isFeatureExplicitlySet('jquery-integration'))
+      ) {
+        message.push(
+          `* The jquery-integration optional feature should be explicitly set to a value under Octane, run \`ember feature:disable jquery-integration\` to disable it, or \`ember feature:enable jquery-integration\` to explicitly enable it`
         );
       }
 


### PR DESCRIPTION
Based on community feedback and early testing, the core team
has decided that disabling jquery-integration does not need to be a
requirement for enabling Octane mode, so we can remove it from
the error messages.