### PR TITLE
Update inline docs for Ember.Application

### DIFF
--- a/packages/@ember/application/lib/application.js
+++ b/packages/@ember/application/lib/application.js
@@ -119,7 +119,7 @@ let librariesRegistered = false;
   For example, if only events inside a DOM element with the ID of `ember-app`
   should be delegated, set your application's `rootElement` property:
 
-  ```javascript
+  ```app/app.js
   import Application from '@ember/application';
 
   let App = Application.extend({

--- a/packages/@ember/application/lib/application.js
+++ b/packages/@ember/application/lib/application.js
@@ -99,7 +99,7 @@ let librariesRegistered = false;
   specify the event name with a `null` value in the `customEvents`
   property:
 
-  ```javascript
+  ```app/app.js
   import Application from '@ember/application';
 
   let App = Application.extend({

--- a/packages/@ember/application/lib/application.js
+++ b/packages/@ember/application/lib/application.js
@@ -239,7 +239,7 @@ const Application = Engine.extend({
 
     To add new events to be listened to:
 
-    ```javascript
+    ```app/app.js
     import Application from '@ember/application';
 
     let App = Application.extend({

--- a/packages/@ember/application/lib/application.js
+++ b/packages/@ember/application/lib/application.js
@@ -36,46 +36,32 @@ let librariesRegistered = false;
 
 /**
   An instance of `Application` is the starting point for every Ember
-  application. It helps to instantiate, initialize and coordinate the many
+  application. instantiates, initializes and coordinates the
   objects that make up your app.
 
-  Each Ember app has one and only one `Application` object. In fact, the
-  very first thing you should do in your application is create the instance:
+  Each Ember app has one and only one `Application` object. Although
+  Ember CLI creates this object implicitly, the `Application` class
+  is defined in the `app/app.js`. You can define a `ready` method on the
+  `Application` class, which will be run by Ember when the application is
+  initialized.
 
   ```javascript
-  import Application from '@ember/application';
-
-  window.App = Application.create();
+  let App = Application.extend({
+    ready() {
+      // your code here
+    }
+  })
   ```
 
-  Typically, the application object is the only global variable. All other
-  classes in your app should be properties on the `Application` instance,
-  which highlights its first role: a global namespace.
-
-  For example, if you define a view class, it might look like this:
-
-  ```javascript
-  import Application from '@ember/application';
-
-  App.MyView = Ember.View.extend();
-  ```
-
-  By default, calling `Application.create()` will automatically initialize
-  your application by calling the `Application.initialize()` method. If
-  you need to delay initialization, you can call your app's `deferReadiness()`
-  method. When you are ready for your app to be initialized, call its
-  `advanceReadiness()` method.
-
-  You can define a `ready` method on the `Application` instance, which
-  will be run by Ember when the application is initialized.
-
-  Because `Application` inherits from `Ember.Namespace`, any classes
+  Because `Application` ultimately inherits from `Ember.Namespace`, any classes
   you create will have useful string representations when calling `toString()`.
   See the `Ember.Namespace` documentation for more information.
 
   While you can think of your `Application` as a container that holds the
   other classes in your application, there are several other responsibilities
-  going on under-the-hood that you may want to understand.
+  going on under-the-hood that you may want to understand. It is also important
+  to understand that an `Application` is different from an `ApplicationInstance`.
+  Refer to the Guides to understand the difference between these.
 
   ### Event Delegation
 
@@ -101,7 +87,7 @@ let librariesRegistered = false;
   ```javascript
   import Application from '@ember/application';
 
-  let App = Application.create({
+  let App = Application.extend({
     customEvents: {
       // add support for the paste event
       paste: 'paste'
@@ -116,7 +102,7 @@ let librariesRegistered = false;
   ```javascript
   import Application from '@ember/application';
 
-  let App = Application.create({
+  let App = Application.extend({
     customEvents: {
       // prevent listeners for mouseenter/mouseleave events
       mouseenter: null,
@@ -136,7 +122,7 @@ let librariesRegistered = false;
   ```javascript
   import Application from '@ember/application';
 
-  let App = Application.create({
+  let App = Application.extend({
     rootElement: '#ember-app'
   });
   ```
@@ -152,25 +138,23 @@ let librariesRegistered = false;
 
   ### Initializers
 
-  Libraries on top of Ember can add initializers, like so:
+  To add behavior to the Application's boot process, you can define initializers in
+  the `app/initializers` directory, or with `ember generate initializer` using Ember CLI.
+  These files should export a named `initialize` function which will receive the created `application`
+  object as its first argument.
 
   ```javascript
-  import Application from '@ember/application';
-
-  Application.initializer({
-    name: 'api-adapter',
-
-    initialize: function(application) {
-      application.register('api-adapter:main', ApiAdapter);
-    }
-  });
+  export function initialize(application) {
+    // application.inject('route', 'foo', 'service:foo');
+  }
   ```
 
-  Initializers provide an opportunity to access the internal registry, which
-  organizes the different components of an Ember application. Additionally
-  they provide a chance to access the instantiated application. Beyond
-  being used for libraries, initializers are also a great way to organize
-  dependency injection or setup in your own application.
+  Application initializers can be used for a variety of reasons including:
+
+  - setting up external libraries
+  - injecting dependencies
+  - setting up event listeners in embedded apps
+  - deferring the boot process using the `deferReadiness` and `advanceReadiness` APIs.
 
   ### Routing
 
@@ -258,7 +242,7 @@ const Application = Engine.extend({
     ```javascript
     import Application from '@ember/application';
 
-    let App = Application.create({
+    let App = Application.extend({
       customEvents: {
         // add support for the paste event
         paste: 'paste'
@@ -271,7 +255,7 @@ const Application = Engine.extend({
     ```javascript
     import Application from '@ember/application';
 
-    let App = Application.create({
+    let App = Application.extend({
       customEvents: {
         // remove support for mouseenter / mouseleave events
         mouseenter: null,

--- a/packages/@ember/application/lib/application.js
+++ b/packages/@ember/application/lib/application.js
@@ -45,7 +45,7 @@ let librariesRegistered = false;
   `Application` class, which will be run by Ember when the application is
   initialized.
 
-  ```javascript
+  ```app/app.js
   const App = Application.extend({
     ready() {
       // your code here

--- a/packages/@ember/application/lib/application.js
+++ b/packages/@ember/application/lib/application.js
@@ -46,7 +46,7 @@ let librariesRegistered = false;
   initialized.
 
   ```javascript
-  let App = Application.extend({
+  const App = Application.extend({
     ready() {
       // your code here
     }

--- a/packages/@ember/application/lib/application.js
+++ b/packages/@ember/application/lib/application.js
@@ -252,7 +252,7 @@ const Application = Engine.extend({
 
     To prevent default events from being listened to:
 
-    ```javascript
+    ```app/app.js
     import Application from '@ember/application';
 
     let App = Application.extend({

--- a/packages/@ember/application/lib/application.js
+++ b/packages/@ember/application/lib/application.js
@@ -36,7 +36,7 @@ let librariesRegistered = false;
 
 /**
   An instance of `Application` is the starting point for every Ember
-  application. instantiates, initializes and coordinates the
+  application. It instantiates, initializes and coordinates the
   objects that make up your app.
 
   Each Ember app has one and only one `Application` object. Although

--- a/packages/@ember/application/lib/application.js
+++ b/packages/@ember/application/lib/application.js
@@ -84,7 +84,7 @@ let librariesRegistered = false;
   default, you can specify custom events and their corresponding view method
   names by setting the application's `customEvents` property:
 
-  ```javascript
+  ```app/app.js
   import Application from '@ember/application';
 
   let App = Application.extend({


### PR DESCRIPTION
Closes #18469 

- updates all references to `Application.create` with `Application.extend` (I'm not sure this is totally right)
- embellish the use cases for initializers
- leans more heavily on Ember CLI being the One True Way™ 