### PR TITLE
[DOC] New component syntax for getOwner example

### DIFF
--- a/packages/@ember/-internals/owner/index.ts
+++ b/packages/@ember/-internals/owner/index.ts
@@ -61,19 +61,20 @@ export const OWNER = symbol('OWNER');
 
   // Usage:
   //
-  //   {{play-audio audioType=model.audioType audioFile=model.file}}
+  //   <PlayAudio @audioType={{model.audioType}} @audioFile={{model.file}}/>
   //
-  export default Component.extend({
-    audioService: computed('audioType', function() {
+  export default class extends Component {
+    @computed('audioType')
+    get audioService() {
       let owner = getOwner(this);
       return owner.lookup(`service:${this.get('audioType')}`);
-    }),
+    }
 
     click() {
       let player = this.get('audioService');
       player.play(this.get('audioFile'));
     }
-  });
+  }
   ```
 
   @method getOwner

--- a/packages/@ember/-internals/owner/index.ts
+++ b/packages/@ember/-internals/owner/index.ts
@@ -52,7 +52,7 @@ export const OWNER = symbol('OWNER');
   into the owner.
 
   For example, this component dynamically looks up a service based on the
-  `audioType` passed as an attribute:
+  `audioType` passed as an argument:
 
   ```app/components/play-audio.js
   import Component from '@glimmer/component';
@@ -60,7 +60,7 @@ export const OWNER = symbol('OWNER');
 
   // Usage:
   //
-  //   <PlayAudio @audioType={{model.audioType}} @audioFile={{model.file}}/>
+  //   <PlayAudio @audioType={{@model.audioType}} @audioFile={{@model.file}}/>
   //
   export default class extends Component {
     get audioService() {

--- a/packages/@ember/-internals/owner/index.ts
+++ b/packages/@ember/-internals/owner/index.ts
@@ -55,7 +55,7 @@ export const OWNER = symbol('OWNER');
   `audioType` passed as an attribute:
 
   ```app/components/play-audio.js
-  import Component from '@ember/component';
+  import Component from '@glimmer/component';
   import { computed } from '@ember/object';
   import { getOwner } from '@ember/application';
 
@@ -67,12 +67,12 @@ export const OWNER = symbol('OWNER');
     @computed('audioType')
     get audioService() {
       let owner = getOwner(this);
-      return owner.lookup(`service:${this.get('audioType')}`);
+      return owner.lookup(`service:${this.args.audioType}`);
     }
 
     click() {
-      let player = this.get('audioService');
-      player.play(this.get('audioFile'));
+      let player = this.audioService;
+      player.play(this.args.audioFile);
     }
   }
   ```

--- a/packages/@ember/-internals/owner/index.ts
+++ b/packages/@ember/-internals/owner/index.ts
@@ -56,6 +56,7 @@ export const OWNER = symbol('OWNER');
 
   ```app/components/play-audio.js
   import Component from '@glimmer/component';
+  import { action } from '@ember/object';
   import { getOwner } from '@ember/application';
 
   // Usage:
@@ -68,7 +69,8 @@ export const OWNER = symbol('OWNER');
       return owner.lookup(`service:${this.args.audioType}`);
     }
 
-    click() {
+    @action
+    onPlay() {
       let player = this.audioService;
       player.play(this.args.audioFile);
     }

--- a/packages/@ember/-internals/owner/index.ts
+++ b/packages/@ember/-internals/owner/index.ts
@@ -56,7 +56,6 @@ export const OWNER = symbol('OWNER');
 
   ```app/components/play-audio.js
   import Component from '@glimmer/component';
-  import { computed } from '@ember/object';
   import { getOwner } from '@ember/application';
 
   // Usage:
@@ -64,7 +63,6 @@ export const OWNER = symbol('OWNER');
   //   <PlayAudio @audioType={{model.audioType}} @audioFile={{model.file}}/>
   //
   export default class extends Component {
-    @computed('audioType')
     get audioService() {
       let owner = getOwner(this);
       return owner.lookup(`service:${this.args.audioType}`);


### PR DESCRIPTION
This PR updates the usage example for [getOwner](http://api.emberjs.com/ember/3.13/functions/@ember%2Fapplication/getOwner).