### PR TITLE
[DOC release] bump yuidoc tooling version to fix decorators examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "ember-cli-blueprint-test-helpers": "^0.19.2",
     "ember-cli-browserstack": "^1.0.1",
     "ember-cli-dependency-checker": "^3.2.0",
-    "ember-cli-yuidoc": "^0.8.8",
+    "ember-cli-yuidoc": "^0.9.0",
     "ember-publisher": "0.0.7",
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^6.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3045,10 +3045,10 @@ ember-cli-version-checker@^3.1.3:
     resolve-package-path "^1.2.6"
     semver "^5.6.0"
 
-ember-cli-yuidoc@^0.8.8:
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/ember-cli-yuidoc/-/ember-cli-yuidoc-0.8.8.tgz#3858baaf85388a976024f9de40f1075fea58f606"
-  integrity sha1-OFi6r4U4ipdgJPneQPEHX+pY9gY=
+ember-cli-yuidoc@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-yuidoc/-/ember-cli-yuidoc-0.9.0.tgz#acf9344959fdcc9313a4ef3783a9466e7634fd45"
+  integrity sha512-Eupu3YOnBFPgOUhm6Zask0SSYF/p+qxM9R5B4ayy0UGewQRS6YJ0bh+4CDDqiAAh/tHbK8X/zAmP/sJDjuzoMQ==
   dependencies:
     broccoli-caching-writer "~2.0.4"
     broccoli-merge-trees "^1.1.1"


### PR DESCRIPTION
This is needed for 3.14, at least. It brings in Chris' work to help with decorators support in the code samples, restoring casing, among other fixes.

cc @sivakumar-kailasam @pzuraq 