### PR TITLE
Clarify error message when attempting to set component’s immutable arguments

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/component-managers/custom.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/custom.ts
@@ -232,7 +232,7 @@ export default class CustomComponentManager<ComponentInstance>
         if (DEBUG) {
           handler.set = function(_target, prop) {
             assert(
-              `You attempted to set ${definition.ComponentClass.class}#${String(
+              `You attempted to set ${definition.name}#${String(
                 prop
               )} on a components arguments. Component arguments are immutable and cannot be updated directly, they always represent the values that are passed to your component. If you want to set default values, you should use a getter instead`
             );


### PR DESCRIPTION
While working on my local instance of our ember app, I stumbled upon this error because I was attempting to set a component's argument, but I found the error message to be too long because it was including the whole contents of the class, not just the class name or the path to that class.

I am suggesting a change here that replaces this with the path to that class.

Before:
```
Assertion Failed: You attempted to set class ClassName extends _component.default {
  constructor() {
    ...
  }

  [... all class contents...]
}#propertyName on a components arguments. [...]
```

After:
```
Assertion Failed: You attempted to set path/to/component#propertyName on a components arguments. [...]
```