### PR TITLE
Backport/bugfix query params helpers pr #18458 issue #18076

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -864,14 +864,14 @@ if (EMBER_GLIMMER_ANGLE_BRACKET_BUILT_INS) {
           )
         );
 
-        if (DEBUG && this.query === UNDEFINED) {
-          let { _models: models } = this;
-          let lastModel = models.length > 0 && models[models.length - 1];
+        let { _models: models } = this;
+        if (models.length > 0) {
+          let lastModel = models[models.length - 1];
 
-          assert(
-            'The `(query-params)` helper can only be used when invoking the `{{link-to}}` component.',
-            !(lastModel && lastModel.isQueryParams)
-          );
+          if (typeof lastModel === 'object' && lastModel !== null && lastModel.isQueryParams) {
+            this.query = lastModel.values;
+            models.pop();
+          }
         }
 
         return;

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-curly-test.js
@@ -68,7 +68,11 @@ moduleFor(
       });
     }
 
-    ['@test `(query-params)` can be used outside of `{{link-to}}']() {
+    ['@test `(query-params)` can be used outside of `{{link-to}}'](assert) {
+      if (!DEBUG) {
+        assert.expect(0);
+        return;
+      }
       this.addTemplate(
         'index',
         `{{#let (query-params foo='456' alon='BUKAI') as |qp|}}{{link-to 'Index' 'index' qp}}{{/let}}`

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-curly-test.js
@@ -68,22 +68,19 @@ moduleFor(
       });
     }
 
-    async ['@feature(ember-glimmer-angle-bracket-built-ins) `(query-params)` must be used in conjunction with `{{link-to}}'](
-      assert
-    ) {
+    ['@test `(query-params)` can be used outside of `{{link-to}}']() {
       this.addTemplate(
         'index',
-        `{{#let (query-params foo='456' bar='NAW') as |qp|}}{{link-to 'Index' 'index' qp}}{{/let}}`
+        `{{#let (query-params foo='456' alon='BUKAI') as |qp|}}{{link-to 'Index' 'index' qp}}{{/let}}`
       );
 
-      // TODO If we visit this page at all in production mode, it'll fail for
-      // entirely different reasons than what this test is trying to test.
-      let promise = DEBUG ? this.visit('/') : null;
-
-      await assert.rejectsAssertion(
-        promise,
-        /The `\(query-params\)` helper can only be used when invoking the `{{link-to}}` component\./
-      );
+      return this.visit('/').then(async () => {
+        this.assertComponentElement(this.firstChild, {
+          tagName: 'a',
+          attrs: { href: '/?alon=BUKAI&foo=456', class: classMatcher('ember-view') },
+          content: 'Index',
+        });
+      });
     }
   }
 );


### PR DESCRIPTION
Had a weird problem with cherrypicking so I reapplied the changes.

Also I realized that in the original PR I didn't change the name of the test.
I did so in this PR.
I will create another PR to get the same test name on master

Thanks @NullVoxPopuli !