### PR TITLE
[BUGFIX release] Ensure production tests actually run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,6 +107,7 @@ jobs:
 
     - name: Browser Tests (Firefox)
       script:
+        - yarn ember build
         - yarn ember test -c testem.travis-browsers.js
 
     - stage: deploy

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "docs": "ember ember-cli-yuidoc",
     "link:glimmer": "node bin/yarn-link-glimmer.js",
     "start": "ember serve",
-    "pretest": "ember build",
     "lint": "yarn lint:tsc && yarn lint:tslint && yarn lint:eslint && yarn lint:docs",
     "lint:docs": "qunit tests/docs/coverage-test.js",
     "lint:eslint": "eslint . --cache --ext=js,ts",

--- a/packages/@ember/-internals/glimmer/lib/component-managers/curly.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/curly.ts
@@ -15,7 +15,6 @@ import { assign } from '@ember/polyfills';
 import { DEBUG } from '@glimmer/env';
 import {
   ComponentCapabilities,
-  Dict,
   Option,
   ProgramSymbolTable,
   Simple,
@@ -176,19 +175,15 @@ export default class CurlyComponentManager
 
   prepareArgs(state: DefinitionState, args: Arguments): Option<PreparedArguments> {
     if (args.named.has('__ARGS__')) {
-      let __args__ = args.named.get('__ARGS__').value() as Dict<VersionedPathReference>;
+      let { __ARGS__, ...rest } = args.named.capture().map;
 
       let prepared = {
         positional: EMPTY_POSITIONAL_ARGS,
         named: {
-          ...args.named.capture().map,
-          ...__args__,
+          ...rest,
+          ...__ARGS__.value(),
         },
       };
-
-      if (DEBUG) {
-        delete prepared.named.__ARGS__;
-      }
 
       return prepared;
     }


### PR DESCRIPTION
Production tests were not actually running in some of the test suites, because we had a `pretest` command that would build the development version immediately after we built the production version.