### PR TITLE
[BUGFIX beta] add 'symbol' to references primitive type check

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/utils/references.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/references.ts
@@ -529,7 +529,8 @@ function ensurePrimitive(value: unknown) {
         value === null ||
         typeof value === 'boolean' ||
         typeof value === 'number' ||
-        typeof value === 'string'
+        typeof value === 'string' ||
+        typeof value === 'symbol'
     );
   }
 }


### PR DESCRIPTION
This fix allows one to return a symbol from a helper. Currently doing so throws because symbol is not one of the enumerated primitives in this `ensurePrimitive` function.