### PR TITLE
[BUGFIX lts] Fix leftover const expressions in legacy builds

### DIFF
--- a/broccoli/to-named-amd.js
+++ b/broccoli/to-named-amd.js
@@ -24,6 +24,7 @@ module.exports = function processModulesOnly(tree, strict = false) {
       // in both browser and node-land
       injectNodeGlobals,
       ['@babel/transform-template-literals', { loose: true }],
+      ['@babel/transform-block-scoping', { throwIfClosureRequired: true }],
       ['module-resolver', { resolvePath: resolveRelativeModulePath }],
       ['@babel/transform-modules-amd', transformOptions],
       enifed,


### PR DESCRIPTION
This fixes #18575. Feel free to backport to 3.8.

The `transform-block-scoping` plugin is needed since the `transform-template-literals` addon injects a number of `_templateObject()` functions into the code, within which is [a `const` assignment](https://github.com/babel/babel/blob/e239eb4c5593516fbbd4a4f0173c994f193f8825/packages/babel-plugin-transform-template-literals/src/index.js#L88-L92).