### PR TITLE
Correct typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -543,7 +543,7 @@ Fixes a few issues:
 - [#15849](https://github.com/emberjs/ember.js/pull/15849) [BUGFIX] Fix issue when observing a computed property that is clobbered during creation.
 - [#15797](https://github.com/emberjs/ember.js/pull/15797) [BUGFIX] Fix issues with using partials nested within other partials.
 - [#15808](https://github.com/emberjs/ember.js/pull/15808) [BUGFIX] Fix a memory leak in certain testing scenarios.
-- [#15746](https://github.com/emberjs/ember.js/pull/15746) [BUGFIX] Fix computed sort regression when array property is initally `null`.
+- [#15746](https://github.com/emberjs/ember.js/pull/15746) [BUGFIX] Fix computed sort regression when array property is initially `null`.
 - [#15777](https://github.com/emberjs/ember.js/pull/15777) [BUGFIX] Fix various issues around accessing dynamic data within a partial.
 - [#15606](https://github.com/emberjs/ember.js/pull/15606) [BUGFIX] Add fs-extra to deps
 - [#15697](https://github.com/emberjs/ember.js/pull/15697) [BUGFIX] Move accessing meta out of the loop
@@ -569,7 +569,7 @@ Fixes a few issues:
 ### 2.16.1 (October 29, 2017)
 
 - [#15722](https://github.com/emberjs/ember.js/pull/15722) [BUGFIX] Avoid assertion when using `(get` helper with empty paths.
-- [#15746](https://github.com/emberjs/ember.js/pull/15746) [BUGFIX] Fix computed sort regression when array property is initally `null`.
+- [#15746](https://github.com/emberjs/ember.js/pull/15746) [BUGFIX] Fix computed sort regression when array property is initially `null`.
 - [#15613](https://github.com/emberjs/ember.js/pull/15613) [BUGFIX] Prevent an error from being thrown when partial set of query params are passed to the router service.
 - [#15777](https://github.com/emberjs/ember.js/pull/15777) [BUGFIX] Fix various issues around accessing dynamic data within a partial.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -543,7 +543,7 @@ Fixes a few issues:
 - [#15849](https://github.com/emberjs/ember.js/pull/15849) [BUGFIX] Fix issue when observing a computed property that is clobbered during creation.
 - [#15797](https://github.com/emberjs/ember.js/pull/15797) [BUGFIX] Fix issues with using partials nested within other partials.
 - [#15808](https://github.com/emberjs/ember.js/pull/15808) [BUGFIX] Fix a memory leak in certain testing scenarios.
-- [#15746](https://github.com/emberjs/ember.js/pull/15746) [BUGFIX] Fix computed sort regression when array property is initially `null`.
+- [#15746](https://github.com/emberjs/ember.js/pull/15746) [BUGFIX] Fix computed sort regression when array property is initally `null`.
 - [#15777](https://github.com/emberjs/ember.js/pull/15777) [BUGFIX] Fix various issues around accessing dynamic data within a partial.
 - [#15606](https://github.com/emberjs/ember.js/pull/15606) [BUGFIX] Add fs-extra to deps
 - [#15697](https://github.com/emberjs/ember.js/pull/15697) [BUGFIX] Move accessing meta out of the loop
@@ -569,7 +569,7 @@ Fixes a few issues:
 ### 2.16.1 (October 29, 2017)
 
 - [#15722](https://github.com/emberjs/ember.js/pull/15722) [BUGFIX] Avoid assertion when using `(get` helper with empty paths.
-- [#15746](https://github.com/emberjs/ember.js/pull/15746) [BUGFIX] Fix computed sort regression when array property is initially `null`.
+- [#15746](https://github.com/emberjs/ember.js/pull/15746) [BUGFIX] Fix computed sort regression when array property is initally `null`.
 - [#15613](https://github.com/emberjs/ember.js/pull/15613) [BUGFIX] Prevent an error from being thrown when partial set of query params are passed to the router service.
 - [#15777](https://github.com/emberjs/ember.js/pull/15777) [BUGFIX] Fix various issues around accessing dynamic data within a partial.
 

--- a/bin/build-for-publishing.js
+++ b/bin/build-for-publishing.js
@@ -86,7 +86,7 @@ Promise.resolve()
   })
   .then(
     // eslint-disable-next-line
-    () => console.log('build-for-publishing completed succesfully!'),
+    () => console.log('build-for-publishing completed successfully!'),
     error => {
       // eslint-disable-next-line
       console.error(error);

--- a/broccoli/find-package.js
+++ b/broccoli/find-package.js
@@ -20,11 +20,11 @@ module.exports = function findPackage(name, from) {
 };
 
 class PackageInfo {
-  constructor(resovled) {
-    let config = require(resovled);
+  constructor(resolved) {
+    let config = require(resolved);
     this.name = config.name;
     this.config = config;
-    this.dir = path.dirname(resovled);
+    this.dir = path.dirname(resolved);
   }
 
   get main() {

--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -575,10 +575,10 @@ export const BOUNDS = symbol('BOUNDS');
   actions with angle bracket invocation, adding event handler methods to the
   component's class, or adding actions to the component's template.
 
-  ### Passing Actions With Angle Bracket Invoation
+  ### Passing Actions With Angle Bracket Invocation
 
   For one-off events specific to particular instance of a component, it is possible
-  to pass actions to the component's element using angle bracket invoation syntax.
+  to pass actions to the component's element using angle bracket invocation syntax.
 
   ```handlebars
   <MyWidget {{action 'firstWidgetClicked'}} />
@@ -596,7 +596,7 @@ export const BOUNDS = symbol('BOUNDS');
   ### Event Handler Methods
 
   Components can also respond to user-initiated events by implementing a method
-  that matches the event name. This approach is appropiate when the same event
+  that matches the event name. This approach is appropriate when the same event
   should be handled by all instances of the same component.
 
   An event object will be passed as the argument to the event handler method.

--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -523,7 +523,7 @@ const LinkComponent = EmberComponent.extend({
     get(_key: string): boolean {
       // always returns false for `get` because (due to the `set` just below)
       // the cached return value from the set will prevent this getter from _ever_
-      // being called after a set has occured
+      // being called after a set has occurred
       return false;
     },
 

--- a/packages/@ember/-internals/glimmer/lib/syntax/mount.ts
+++ b/packages/@ember/-internals/glimmer/lib/syntax/mount.ts
@@ -28,7 +28,7 @@ export function mountHelper(
   let nameRef = args.positional.at(0);
   let captured: Option<CapturedArguments> = null;
 
-  // TODO: the functionailty to create a proper CapturedArgument should be
+  // TODO: the functionality to create a proper CapturedArgument should be
   // exported by glimmer, or that it should provide an overload for `curry`
   // that takes `PreparedArguments`
   if (args.named.has('model')) {

--- a/packages/@ember/-internals/glimmer/lib/syntax/outlet.ts
+++ b/packages/@ember/-internals/glimmer/lib/syntax/outlet.ts
@@ -133,7 +133,7 @@ class OutletModelReference implements VersionedPathReference {
       // created well before the component itself.
       this.debugStackLog = this.env.debugRenderTree.logCurrentRenderStack();
 
-      // This guarentees that we preserve the `debug()` output below
+      // This guarantees that we preserve the `debug()` output below
       return new NestedPropertyReference(this, property);
     } else {
       return PropertyReference.create(this, property);
@@ -166,7 +166,7 @@ class OutletComponentReference
       let map = dict<VersionedPathReference>();
       map.model = modelRef;
 
-      // TODO: the functionailty to create a proper CapturedArgument should be
+      // TODO: the functionality to create a proper CapturedArgument should be
       // exported by glimmer, or that it should provide an overload for `curry`
       // that takes `PreparedArguments`
       this.args = {

--- a/packages/@ember/-internals/glimmer/lib/utils/iterable.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/iterable.ts
@@ -438,12 +438,12 @@ function isIndexable(value: Opaque): value is Indexable {
 
 type KeyFor = (value: Opaque, memo: Opaque, position: number) => string;
 
-// Position in an array is guarenteed to be unique
+// Position in an array is guaranteed to be unique
 function Index(_value: Opaque, _memo: Opaque, position: number): string {
   return String(position);
 }
 
-// Object.keys(...) is guarenteed to be strings and unique
+// Object.keys(...) is guaranteed to be strings and unique
 function ObjectKey(_value: Opaque, memo: Opaque): string {
   return memo as string;
 }

--- a/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
@@ -3520,7 +3520,7 @@ moduleFor(
       class FooBarComponent extends Component {
         constructor(injections) {
           super(injections);
-          // analagous to class field defaults
+          // analogous to class field defaults
           this.foo = 'bar';
         }
 

--- a/packages/@ember/-internals/meta/lib/meta.ts
+++ b/packages/@ember/-internals/meta/lib/meta.ts
@@ -401,7 +401,7 @@ export class Meta {
 
     // if not found, push. Note that we must always push if a listener is not
     // found, even in the case of a function listener remove, because we may be
-    // attempting to add or remove listeners _before_ flattening has occured.
+    // attempting to add or remove listeners _before_ flattening has occurred.
     if (i === -1) {
       assert(
         'You cannot add function listeners to prototypes. Convert the listener to a string listener, or add it to the instance instead.',
@@ -486,7 +486,7 @@ export class Meta {
        listeners
     3. A new listener is subsequently added to the meta (e.g. via `.reopen()`)
 
-    This is a very rare occurence, so while the counter is global it shouldn't
+    This is a very rare occurrence, so while the counter is global it shouldn't
     be updated very often in practice.
   */
   private flattenedListeners(): Listener[] | undefined {

--- a/packages/@ember/-internals/metal/lib/chain-tags.ts
+++ b/packages/@ember/-internals/metal/lib/chain-tags.ts
@@ -217,7 +217,7 @@ export function getChainTagsForKey(obj: any, path: string) {
       // If the descriptor is defined, then its a normal CP (not an alias, which
       // would have been handled earlier). We get the last revision to check if
       // the CP is still valid, and if so we use the cached value. If not, then
-      // we create a lazy chain lookup, and the next time the CP is caluculated,
+      // we create a lazy chain lookup, and the next time the CP is calculated,
       // it will update that lazy chain.
       let lastRevision = getLastRevisionFor(current, segment);
 

--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -700,7 +700,7 @@ export class ComputedProperty extends ComputedDescriptor {
     deprecate(
       `The ${toString(
         obj
-      )}#${keyName} computed property was just overriden. This removes the computed property and replaces it with a plain value, and has been deprecated. If you want this behavior, consider defining a setter which does it manually.`,
+      )}#${keyName} computed property was just overridden. This removes the computed property and replaces it with a plain value, and has been deprecated. If you want this behavior, consider defining a setter which does it manually.`,
       false,
       {
         id: 'computed-property.override',

--- a/packages/@ember/-internals/metal/lib/decorator.ts
+++ b/packages/@ember/-internals/metal/lib/decorator.ts
@@ -109,7 +109,7 @@ export function makeComputedDecorator(
     isClassicDecorator?: boolean
   ): DecoratorPropertyDescriptor {
     assert(
-      `Only one computed property decorator can be applied to a class field or accessor, but '${key}' was decorated twice. You may have added the decorator to both a getter and setter, which is unecessary.`,
+      `Only one computed property decorator can be applied to a class field or accessor, but '${key}' was decorated twice. You may have added the decorator to both a getter and setter, which is unnecessary.`,
       isClassicDecorator ||
         !propertyDesc ||
         !propertyDesc.get ||

--- a/packages/@ember/-internals/metal/lib/descriptor_map.ts
+++ b/packages/@ember/-internals/metal/lib/descriptor_map.ts
@@ -7,7 +7,7 @@ const DECORATOR_DESCRIPTOR_MAP: WeakMap<
 > = new WeakMap();
 
 /**
-  Returns the CP descriptor assocaited with `obj` and `keyName`, if any.
+  Returns the CP descriptor associated with `obj` and `keyName`, if any.
 
   @method descriptorForProperty
   @param {Object} obj the object to check

--- a/packages/@ember/-internals/metal/tests/computed_decorator_test.js
+++ b/packages/@ember/-internals/metal/tests/computed_decorator_test.js
@@ -320,7 +320,7 @@ moduleFor(
           }
         }
         new Obj();
-      }, "Only one computed property decorator can be applied to a class field or accessor, but 'foo' was decorated twice. You may have added the decorator to both a getter and setter, which is unecessary.");
+      }, "Only one computed property decorator can be applied to a class field or accessor, but 'foo' was decorated twice. You may have added the decorator to both a getter and setter, which is unnecessary.");
     }
   }
 );

--- a/packages/@ember/-internals/metal/tests/computed_test.js
+++ b/packages/@ember/-internals/metal/tests/computed_test.js
@@ -128,7 +128,7 @@ moduleFor(
 
       expectDeprecation(() => {
         set(obj, 'foo', 'boom');
-      }, /The \[object Object\]#foo computed property was just overriden./);
+      }, /The \[object Object\]#foo computed property was just overridden./);
 
       assert.equal(obj.foo, 'boom');
     }
@@ -776,7 +776,7 @@ moduleFor(
 
       expectDeprecation(() => {
         testObj.set('aInt', '123');
-      }, /The <\(unknown\):ember\d*>#aInt computed property was just overriden/);
+      }, /The <\(unknown\):ember\d*>#aInt computed property was just overridden/);
 
       assert.ok(testObj.get('aInt') === '123', 'cp has been updated too');
     }
@@ -985,7 +985,7 @@ moduleFor(
 
       expectDeprecation(() => {
         set(obj, 'foo', 'bar');
-      }, /The \[object Object\]#foo computed property was just overriden./);
+      }, /The \[object Object\]#foo computed property was just overridden./);
 
       assert.equal(get(obj, 'foo'), 'bar', 'The set value is properly returned');
       assert.ok(typeof obj.foo === 'string', 'The computed property was removed');

--- a/packages/@ember/-internals/metal/tests/libraries_test.js
+++ b/packages/@ember/-internals/metal/tests/libraries_test.js
@@ -36,7 +36,7 @@ moduleFor(
     ['@test only the first registration of a library is stored'](assert) {
       assert.expect(3);
 
-      // overwrite warn to supress the double registration warning (see https://github.com/emberjs/ember.js/issues/16391)
+      // overwrite warn to suppress the double registration warning (see https://github.com/emberjs/ember.js/issues/16391)
       setDebugFunction('warn', noop);
       libs.register('magic', 1.23);
       libs.register('magic', 2.23);

--- a/packages/@ember/-internals/metal/tests/mixin/computed_test.js
+++ b/packages/@ember/-internals/metal/tests/mixin/computed_test.js
@@ -158,7 +158,7 @@ moduleFor(
 
       expectDeprecation(() => {
         set(obj, 'cpWithoutSetter', 'test');
-      }, /The \[object Object\]#cpWithoutSetter computed property was just overriden./);
+      }, /The \[object Object\]#cpWithoutSetter computed property was just overridden./);
 
       assert.equal(
         get(obj, 'cpWithoutSetter'),

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -1227,7 +1227,7 @@ class Route extends EmberObject implements IRoute {
     ```app/routes/photos.js
     import Route from '@ember/routing/route';
 
-    export default class PhotosRoute extendes Route {
+    export default class PhotosRoute extends Route {
       model() {
         return this.store.findAll('photo');
       }

--- a/packages/@ember/-internals/runtime/lib/mixins/array.js
+++ b/packages/@ember/-internals/runtime/lib/mixins/array.js
@@ -378,7 +378,7 @@ const ArrayMixin = Mixin.create(Enumerable, {
   },
 
   /**
-    Used to determine the passed object's first occurence in the array.
+    Used to determine the passed object's first occurrence in the array.
     Returns the index if found, -1 if no match is found.
 
     The optional `startAt` argument can be used to pass a starting

--- a/packages/@ember/object/lib/computed/reduce_computed_macros.js
+++ b/packages/@ember/object/lib/computed/reduce_computed_macros.js
@@ -1453,7 +1453,7 @@ export function sort(itemsKey, additionalDependentKeys, sortDefinition) {
     }
 
     assert(
-      '`computed.sort` can either be used with an array of sort properties or with a sort function. If used with an array of sort properties, it must receive exactly two arguments: the key of the array to sort, and the key of the array of sort properties. If used with a sort function, it may recieve up to three arguments: the key of the array to sort, an optional additional array of dependent keys for the computed property, and the sort function.',
+      '`computed.sort` can either be used with an array of sort properties or with a sort function. If used with an array of sort properties, it must receive exactly two arguments: the key of the array to sort, and the key of the array of sort properties. If used with a sort function, it may receive up to three arguments: the key of the array to sort, an optional additional array of dependent keys for the computed property, and the sort function.',
       argumentsValid
     );
   }

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -979,7 +979,7 @@ if (!jQueryDisabled) {
 
       [`@test pauseTest pauses`](assert) {
         assert.expect(1);
-        // overwrite info to supress the console output (see https://github.com/emberjs/ember.js/issues/16391)
+        // overwrite info to suppress the console output (see https://github.com/emberjs/ember.js/issues/16391)
         setDebugFunction('info', noop);
 
         let { andThen, pauseTest } = this.application.testHelpers;
@@ -995,7 +995,7 @@ if (!jQueryDisabled) {
 
       [`@test resumeTest resumes paused tests`](assert) {
         assert.expect(1);
-        // overwrite info to supress the console output (see https://github.com/emberjs/ember.js/issues/16391)
+        // overwrite info to suppress the console output (see https://github.com/emberjs/ember.js/issues/16391)
         setDebugFunction('info', noop);
 
         let {

--- a/packages/ember/tests/routing/router_service_test/events_test.js
+++ b/packages/ember/tests/routing/router_service_test/events_test.js
@@ -552,13 +552,13 @@ moduleFor(
     '@test params'(assert) {
       assert.expect(14);
 
-      let inital = true;
+      let initial = true;
 
       this.add(
         'route:dynamic',
         Route.extend({
           model(params) {
-            if (inital) {
+            if (initial) {
               assert.deepEqual(params, { dynamic_id: '123' });
             } else {
               assert.deepEqual(params, { dynamic_id: '1' });
@@ -577,7 +577,7 @@ moduleFor(
 
             this.router.on('routeWillChange', transition => {
               assert.equal(transition.to.name, 'dynamic');
-              if (inital) {
+              if (initial) {
                 assert.deepEqual(transition.to.paramNames, ['dynamic_id']);
                 assert.deepEqual(transition.to.params, { dynamic_id: '123' });
               } else {
@@ -589,7 +589,7 @@ moduleFor(
             this.router.on('routeDidChange', transition => {
               assert.equal(transition.to.name, 'dynamic');
               assert.deepEqual(transition.to.paramNames, ['dynamic_id']);
-              if (inital) {
+              if (initial) {
                 assert.deepEqual(transition.to.params, { dynamic_id: '123' });
               } else {
                 assert.deepEqual(transition.to.params, { dynamic_id: '1' });
@@ -600,7 +600,7 @@ moduleFor(
       );
 
       return this.visit('/dynamic/123').then(() => {
-        inital = false;
+        initial = false;
         return this.routerService.transitionTo('dynamic', 1);
       });
     }

--- a/packages/external-helpers/lib/external-helpers.js
+++ b/packages/external-helpers/lib/external-helpers.js
@@ -40,7 +40,7 @@ export function classCallCheck(instance, Constructor) {
   Overrides default `inheritsLoose` to _also_ call `Object.setPrototypeOf`.
   This is needed so that we can use `loose` option with the
   `@babel/plugin-transform-classes` (because we want simple assignment to the
-  prototype whereever possible) but also keep our constructor based prototypal
+  prototype wherever possible) but also keep our constructor based prototypal
   inheritance working properly
 */
 export function inheritsLoose(subClass, superClass) {

--- a/packages/internal-test-helpers/lib/confirm-export.js
+++ b/packages/internal-test-helpers/lib/confirm-export.js
@@ -38,7 +38,7 @@ export default function confirmExport(Ember, assert, path, moduleId, exportName)
   } catch (error) {
     assert.pushResult({
       result: false,
-      message: `An error occured while testing ${path} is exported from ${moduleId}.`,
+      message: `An error occurred while testing ${path} is exported from ${moduleId}.`,
       source: error,
     });
   }


### PR DESCRIPTION
Mostly fixed by running

```sh
misspell  -w -error -source=text .
```

First noticed while going through the guides

FWIW, specifically related to

- https://github.com/ember-learn/guides-source/pull/1247
- https://github.com/ember-learn/guides-source/pull/1248
- https://github.com/ember-learn/guides-source/pull/1249
- https://github.com/ember-learn/guides-source/pull/1250