### PR TITLE
[BUGFIX beta] Async functions being treated as falsey in template conditionals

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/utils/shared-conditional-tests.js
+++ b/packages/@ember/-internals/glimmer/tests/utils/shared-conditional-tests.js
@@ -402,6 +402,7 @@ const IfUnlessWithTestCases = [
     ObjectProxy.create({ content: true }),
     Object,
     function() {},
+    async function() {},
     new String('hello'),
     new String(''),
     new Boolean(true),

--- a/packages/@ember/-internals/runtime/lib/type-of.js
+++ b/packages/@ember/-internals/runtime/lib/type-of.js
@@ -8,6 +8,7 @@ const TYPE_MAP = {
   '[object Number]': 'number',
   '[object String]': 'string',
   '[object Function]': 'function',
+  '[object AsyncFunction]': 'function',
   '[object Array]': 'array',
   '[object Date]': 'date',
   '[object RegExp]': 'regexp',

--- a/packages/@ember/-internals/runtime/tests/core/is_array_test.js
+++ b/packages/@ember/-internals/runtime/tests/core/is_array_test.js
@@ -18,6 +18,7 @@ moduleFor(
       let length = { length: 12 };
       let strangeLength = { length: 'yes' };
       let fn = function() {};
+      let asyncFn = async function() {};
       let arrayProxy = ArrayProxy.create({ content: emberA() });
 
       assert.equal(isArray(numarray), true, '[1,2,3]');
@@ -29,6 +30,7 @@ moduleFor(
       assert.equal(isArray(strangeLength), false, '{ length: "yes" }');
       assert.equal(isArray(global), false, 'global');
       assert.equal(isArray(fn), false, 'function() {}');
+      assert.equal(isArray(asyncFn), false, 'async function() {}');
       assert.equal(isArray(arrayProxy), true, '[]');
     }
 

--- a/packages/@ember/-internals/runtime/tests/core/type_of_test.js
+++ b/packages/@ember/-internals/runtime/tests/core/type_of_test.js
@@ -17,7 +17,10 @@ moduleFor(
       let a = null;
       let arr = [1, 2, 3];
       let obj = {};
-      let instance = EmberObject.create({ method() {} });
+      let instance = EmberObject.create({
+        method() {},
+        async asyncMethod() {},
+      });
 
       assert.equal(typeOf(), 'undefined', 'undefined');
       assert.equal(typeOf(null), 'null', 'null');
@@ -36,6 +39,7 @@ moduleFor(
       assert.equal(typeOf(obj), 'object', 'item of type object');
       assert.equal(typeOf(instance), 'instance', 'item of type instance');
       assert.equal(typeOf(instance.method), 'function', 'item of type function');
+      assert.equal(typeOf(instance.asyncMethod), 'function', 'item of type async function');
       assert.equal(typeOf(EmberObject.extend()), 'class', 'item of type class');
       assert.equal(typeOf(new Error()), 'error', 'item of type error');
     }


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember.js/issues/18641

The [typeOf TYPE_MAP](https://github.com/emberjs/ember.js/blob/56d60eac53/packages/%40ember/-internals/runtime/lib/type-of.js#L6) was missing an `[object AsyncFunction]` entry, which results in the typeOf helper returning `object` as the type for a given async function.

This will propagate the error to the [isArray method conditional](https://github.com/emberjs/ember.js/blob/56d60eac53/packages/@ember/-internals/runtime/lib/mixins/array.js#L168) and the [toBool util](https://github.com/emberjs/ember.js/blob/56d60eac537933e20ef66e735299b81dba9a1788/packages/@ember/-internals/glimmer/lib/utils/to-bool.ts#L4) ultimately used by the [inlineIf helper](https://github.com/emberjs/ember.js/blob/v3.4.8/packages/ember-glimmer/lib/helpers/if-unless.ts#L132) resulting in the bug.