### PR TITLE
[BUGFIX release] Consumes tags after fully getting values

### DIFF
--- a/packages/@ember/-internals/metal/tests/tracked/validation_test.js
+++ b/packages/@ember/-internals/metal/tests/tracked/validation_test.js
@@ -402,5 +402,25 @@ moduleFor(
         });
       }, /You attempted to update `foo` on `EmberObject`, but it had already been used previously in the same computation/);
     }
+
+    ['@test get() does not entangle in the autotracking stack until after retrieving the value'](
+      assert
+    ) {
+      assert.expect(0);
+
+      class EmberObject {
+        get foo() {
+          notifyPropertyChange(this, 'foo');
+
+          return 123;
+        }
+      }
+
+      let obj = new EmberObject();
+
+      track(() => {
+        get(obj, 'foo');
+      });
+    }
   }
 );


### PR DESCRIPTION
Currently get() consumes some tags before getting the values,
and getting the values itself can cause tag changes and notifications.
In some cases, this is invalid, because the value that is being notified
hasn't actually been consumed yet (it is in the process of being
consumed. More generally, consumption should always occur immediately
_after_ the relevant calculation - in this case, the getter.