### PR TITLE
[BUGFIX release] Updated blueprints for component and helper tests to output the correct hbs import statement

### DIFF
--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -62,9 +62,9 @@ module.exports = useTestFrameworkDetector({
       componentPathName = [options.path, dasherizedModuleName].filter(Boolean).join('/');
     }
 
-    let hbsImportStatement = this._useSeparateInlinePrecompileAddon()
-      ? "import hbs from 'htmlbars-inline-precompile';"
-      : "import { hbs } from 'ember-cli-htmlbars';";
+    let hbsImportStatement = this._useNamedHbsImport()
+      ? "import { hbs } from 'ember-cli-htmlbars';"
+      : "import hbs from 'htmlbars-inline-precompile';";
 
     let templateInvocation = invocationFor(options);
     let componentName = templateInvocation;
@@ -86,21 +86,21 @@ module.exports = useTestFrameworkDetector({
     };
   },
 
-  _useSeparateInlinePrecompileAddon() {
+  _useNamedHbsImport() {
     let htmlbarsAddon = this.project.addons.find(a => a.name === 'ember-cli-htmlbars');
 
-    if (htmlbarsAddon === undefined) {
+    if (htmlbarsAddon && semver.gte(htmlbarsAddon.pkg.version, '4.0.0-alpha.1')) {
       return true;
-    } else if (semver.gte(htmlbarsAddon.pkg.version, '4.0.0-alpha.1')) {
-      return false;
     }
+
+    return false;
   },
 
   afterInstall: function(options) {
     if (
       !options.dryRun &&
       options.testType === 'integration' &&
-      this._useSeparateInlinePrecompileAddon() &&
+      !this._useNamedHbsImport() &&
       isPackageMissing(this, 'ember-cli-htmlbars-inline-precompile')
     ) {
       return this.addPackagesToProject([

--- a/blueprints/component-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -2,7 +2,7 @@
 import { describe, it } from 'mocha';
 import { setupRenderingTest } from 'ember-mocha';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+<%= hbsImportStatement %>
 
 describe('<%= friendlyTestDescription %>', function() {
   setupRenderingTest();

--- a/blueprints/helper-test/mocha-rfc-232-files/__root__/__testType__/__collection__/__name__-test.js
+++ b/blueprints/helper-test/mocha-rfc-232-files/__root__/__testType__/__collection__/__name__-test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 <% if (testType == 'integration') { %>import { describe, it } from 'mocha';
 import { setupRenderingTest } from 'ember-mocha';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+<%= hbsImportStatement %>
 
 describe('<%= friendlyTestName %>', function() {
   setupRenderingTest();

--- a/blueprints/helper-test/qunit-rfc-232-files/__root__/__testType__/__collection__/__name__-test.js
+++ b/blueprints/helper-test/qunit-rfc-232-files/__root__/__testType__/__collection__/__name__-test.js
@@ -1,7 +1,7 @@
 <% if (testType === 'integration') { %>import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+<%= hbsImportStatement %>
 
 module('<%= friendlyTestName %>', function(hooks) {
   setupRenderingTest(hooks);


### PR DESCRIPTION
## Description

This PR closes #18626.

## Tests

I wanted to write tests per contributing guide, but couldn't figure out how to make `this.project.addons` include `ember-cli-htmlbars` in a test. Currently, there isn't a test that checks the component test when the version of `ember-cli-htmlbars` is at least `4.0.0-alpha.1`, so I didn't have an example that I could follow.

It seemed like `ember-cli-blueprint-test-helpers` currently doesn't support updating the `addons` attribute (https://github.com/ember-cli/ember-cli-blueprint-test-helpers/blob/master/lib/modify-packages.js#L20-L26). If I missed something and setting `addons` is possible, please let me know and I'd be happy to add tests.

I did manually test locally using `yarn link ember-source` on a new Ember 3.15 project. If the version of `ember-cli-htmlbars` is at least `4.0.0-alpha.1`, the generators will add the named import statement. If the version is less, or if `ember-cli-htmlbars` doesn't exist, the generators will add the default import statement.