### PR TITLE
Bugfix: fix typo in modifierCapabilities re-export

### DIFF
--- a/packages/@ember/modifier/index.ts
+++ b/packages/@ember/modifier/index.ts
@@ -1,1 +1,1 @@
-export { setModifierManager, modifierCapabilities as capabilties } from '@ember/-internals/glimmer';
+export { setModifierManager, modifierCapabilities as capabilities } from '@ember/-internals/glimmer';


### PR DESCRIPTION
`packages/@ember/modifier/index.ts` previously re-exported `modifierCapabilities as capabilties` instead of `as capabilities`. This fixes the re-export name.