### PR TITLE
Merge pull request #18707 from emberjs/bugfix/fix-object-proxy-tags

### DIFF
--- a/packages/@ember/-internals/metal/lib/tags.ts
+++ b/packages/@ember/-internals/metal/lib/tags.ts
@@ -7,7 +7,6 @@ import {
   toString,
 } from '@ember/-internals/utils';
 import { assert, deprecate } from '@ember/debug';
-import { _WeakSet as WeakSet } from '@ember/polyfills';
 import { backburner } from '@ember/runloop';
 import { DEBUG } from '@glimmer/env';
 import {
@@ -55,12 +54,6 @@ export const CUSTOM_TAG_FOR = symbol('CUSTOM_TAG_FOR');
 // This is exported for `@tracked`, but should otherwise be avoided. Use `tagForObject`.
 export const SELF_TAG: string = symbol('SELF_TAG');
 
-let SEEN_TAGS: WeakSet<Tag> | undefined;
-
-if (DEBUG) {
-  SEEN_TAGS = new WeakSet();
-}
-
 export function tagForProperty(obj: unknown, propertyKey: string | symbol): Tag {
   if (!isObject(obj)) {
     return CONSTANT_TAG;
@@ -72,11 +65,10 @@ export function tagForProperty(obj: unknown, propertyKey: string | symbol): Tag 
 
   let tag = tagFor(obj, propertyKey);
 
-  if (DEBUG && !SEEN_TAGS!.has(tag)) {
-    SEEN_TAGS!.add(tag);
+  if (DEBUG) {
+    setupMandatorySetter!(tag, obj, propertyKey);
 
-    setupMandatorySetter!(obj, propertyKey);
-
+    // TODO: Replace this with something more first class for tracking tags in DEBUG
     (tag as any)._propertyKey = propertyKey;
   }
 

--- a/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
@@ -338,5 +338,33 @@ moduleFor(
         observe: observer('foo', function() {}),
       }).create();
     }
+
+    async '@test custom proxies should be able to notify property changes manually'(assert) {
+      let proxy = ObjectProxy.extend({
+        locals: { foo: 123 },
+
+        unknownProperty(key) {
+          return this.locals[key];
+        },
+
+        setUnknownProperty(key, value) {
+          this.locals[key] = value;
+          this.notifyPropertyChange(key);
+        },
+      }).create();
+
+      let count = 0;
+
+      proxy.addObserver('foo', function() {
+        count++;
+      });
+
+      proxy.set('foo', 456);
+      await runLoopSettled();
+
+      assert.equal(count, 1);
+      assert.equal(proxy.get('foo'), 456);
+      assert.equal(proxy.get('locals.foo'), 456);
+    }
   }
 );


### PR DESCRIPTION
Currently, the Proxy mixin uses the private `UNKNOWN_PROPERTY_TAG` API
to provide the tags for the content property that the mixin is proxying
to. However, previously the chains system would do this _and_ still
entangle changes to the local property. This allowed users to manually
notify in subclasses of Proxy.

This PR adds the tag for the property back to the returned tag, so it
works the same as before. It also refactors `setupMandatorySetter`,
since we now have to do that work in two places (to avoid re-entry).

Fixes #18704