### PR TITLE
[BUGFIX release] Ensures the arg proxy works with `get`

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
@@ -1,6 +1,6 @@
 import { Object as EmberObject, A, ArrayProxy, PromiseProxyMixin } from '@ember/-internals/runtime';
 import { EMBER_CUSTOM_COMPONENT_ARG_PROXY } from '@ember/canary-features';
-import { computed, tracked, nativeDescDecorator as descriptor } from '@ember/-internals/metal';
+import { computed, get, tracked, nativeDescDecorator as descriptor } from '@ember/-internals/metal';
 import { Promise } from 'rsvp';
 import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
 import GlimmerishComponent from '../../utils/glimmerish-component';
@@ -565,6 +565,50 @@ if (EMBER_CUSTOM_COMPONENT_ARG_PROXY) {
         this.assertText('hello world!');
 
         runTask(() => foo.set('text', 'hello!'));
+        this.assertText('hello!');
+      }
+
+      '@test args can be accessed with get()'() {
+        class TestComponent extends GlimmerishComponent {
+          get text() {
+            return get(this, 'args.text');
+          }
+        }
+
+        this.registerComponent('test', {
+          ComponentClass: TestComponent,
+          template: '<p>{{this.text}}</p>',
+        });
+
+        this.render('<Test @text={{this.text}}/>', {
+          text: 'hello!',
+        });
+
+        this.assertText('hello!');
+
+        runTask(() => this.context.set('text', 'hello world!'));
+        this.assertText('hello world!');
+
+        runTask(() => this.context.set('text', 'hello!'));
+        this.assertText('hello!');
+      }
+
+      '@test args can be accessed with get() if no value is passed'() {
+        class TestComponent extends GlimmerishComponent {
+          get text() {
+            return get(this, 'args.text') || 'hello!';
+          }
+        }
+
+        this.registerComponent('test', {
+          ComponentClass: TestComponent,
+          template: '<p>{{this.text}}</p>',
+        });
+
+        this.render('<Test/>', {
+          text: 'hello!',
+        });
+
         this.assertText('hello!');
       }
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/get-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/get-test.js
@@ -3,6 +3,7 @@ import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
 import { set, get } from '@ember/-internals/metal';
 
 import { Component } from '../../utils/helpers';
+import GlimmerishComponent from '../../utils/glimmerish-component';
 
 moduleFor(
   'Helpers test: {{get}}',
@@ -615,6 +616,32 @@ moduleFor(
       });
 
       assert.strictEqual(this.$('#get-input').val(), 'mcintosh');
+    }
+
+    '@test should be able to get an object value with a path from this.args in a glimmer component'() {
+      class PersonComponent extends GlimmerishComponent {
+        options = ['first', 'last', 'age'];
+      }
+
+      this.registerComponent('person-wrapper', {
+        ComponentClass: PersonComponent,
+        template: '{{#each this.options as |option|}}{{get this.args option}}{{/each}}',
+      });
+
+      this.render('<PersonWrapper @first={{first}} @last={{last}} @age={{age}}/>', {
+        first: 'miguel',
+        last: 'andrade',
+      });
+
+      this.assertText('miguelandrade');
+
+      runTask(() => this.rerender());
+
+      this.assertText('miguelandrade');
+
+      runTask(() => set(this.context, 'age', 30));
+
+      this.assertText('miguelandrade30');
     }
   }
 );

--- a/packages/@ember/-internals/metal/index.ts
+++ b/packages/@ember/-internals/metal/index.ts
@@ -44,7 +44,7 @@ export {
   isClassicDecorator,
   setClassicDecorator,
 } from './lib/descriptor_map';
-export { getChainTagsForKey, ARGS_PROXY_TAGS } from './lib/chain-tags';
+export { getChainTagsForKey } from './lib/chain-tags';
 export { default as libraries, Libraries } from './lib/libraries';
 export { default as getProperties } from './lib/get_properties';
 export { default as setProperties } from './lib/set_properties';
@@ -53,7 +53,7 @@ export { default as expandProperties } from './lib/expand_properties';
 export { addObserver, activateObserver, removeObserver, flushAsyncObservers } from './lib/observer';
 export { Mixin, aliasMethod, mixin, observer, applyMixin } from './lib/mixin';
 export { default as inject, DEBUG_INJECTION_FUNCTIONS } from './lib/injected_property';
-export { tagForProperty, tagForObject, markObjectAsDirty, UNKNOWN_PROPERTY_TAG } from './lib/tags';
+export { tagForProperty, tagForObject, markObjectAsDirty, CUSTOM_TAG_FOR } from './lib/tags';
 export { tracked } from './lib/tracked';
 
 export {

--- a/packages/@ember/-internals/metal/lib/tags.ts
+++ b/packages/@ember/-internals/metal/lib/tags.ts
@@ -50,7 +50,7 @@ if (DEBUG) {
 
 /////////
 
-export const UNKNOWN_PROPERTY_TAG = symbol('UNKNOWN_PROPERTY_TAG');
+export const CUSTOM_TAG_FOR = symbol('CUSTOM_TAG_FOR');
 
 // This is exported for `@tracked`, but should otherwise be avoided. Use `tagForObject`.
 export const SELF_TAG: string = symbol('SELF_TAG');
@@ -66,8 +66,8 @@ export function tagForProperty(obj: unknown, propertyKey: string | symbol): Tag 
     return CONSTANT_TAG;
   }
 
-  if (!(propertyKey in obj) && typeof obj[UNKNOWN_PROPERTY_TAG] === 'function') {
-    return obj[UNKNOWN_PROPERTY_TAG](propertyKey);
+  if (typeof obj[CUSTOM_TAG_FOR] === 'function') {
+    return obj[CUSTOM_TAG_FOR](propertyKey);
   }
 
   let tag = tagFor(obj, propertyKey);

--- a/packages/@ember/-internals/runtime/lib/mixins/-proxy.js
+++ b/packages/@ember/-internals/runtime/lib/mixins/-proxy.js
@@ -10,12 +10,12 @@ import {
   Mixin,
   tagForObject,
   computed,
-  UNKNOWN_PROPERTY_TAG,
+  CUSTOM_TAG_FOR,
   getChainTagsForKey,
 } from '@ember/-internals/metal';
 import { setProxy } from '@ember/-internals/utils';
 import { assert } from '@ember/debug';
-import { combine, update } from '@glimmer/validator';
+import { combine, update, tagFor } from '@glimmer/validator';
 
 export function contentFor(proxy) {
   let content = get(proxy, 'content');
@@ -57,8 +57,12 @@ export default Mixin.create({
     return Boolean(get(this, 'content'));
   }),
 
-  [UNKNOWN_PROPERTY_TAG](key) {
-    return combine(getChainTagsForKey(this, `content.${key}`));
+  [CUSTOM_TAG_FOR](key) {
+    if (key in this) {
+      return tagFor(this, key);
+    } else {
+      return combine(getChainTagsForKey(this, `content.${key}`));
+    }
   },
 
   unknownProperty(key) {


### PR DESCRIPTION
Previously, the arg proxy used a custom system for passing along its
`capturedArgs` directly to `getChainTags`, in order to interoperate with
computed properties. As it turns out, there are a number of other places
where the correct tag needs to be gotten and setup.

This PR replaces the `UNKNOWN_PROPERTY_TAG` system with a more general
`CUSTOM_TAG_FOR` system. In this system, if we detect that an object has
this method, we defer to it to get the tag, even if the property was
defined on the object. There are two users of this system:

- ProxyMixin
- The arg proxy

Given that it's private, and we have relatively few use cases, I believe
this is the cleanest solution at the moment. The alternative would be to
keep `UNKNOWN_PROPERTY_TAG` and also add `CUSTOM_TAG_FOR`, but that
seems unnecessary given low usage.

Fixes #18606