### PR TITLE
[BUGFIX release] Update minimum @ember/edition-utils to 1.2.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@babel/helper-module-imports": "^7.0.0",
     "@babel/plugin-transform-block-scoping": "^7.6.2",
     "@babel/plugin-transform-object-assign": "^7.2.0",
-    "@ember/edition-utils": "^1.1.1",
+    "@ember/edition-utils": "^1.2.0",
     "babel-plugin-debug-macros": "^0.3.3",
     "babel-plugin-filter-imports": "^4.0.0",
     "broccoli-concat": "^3.7.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -796,10 +796,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember/edition-utils@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@ember/edition-utils/-/edition-utils-1.1.1.tgz#d5732c3da593f202e6e1ac6dbee56a758242403f"
-  integrity sha512-GEhri78jdQp/xxPpM6z08KlB0wrHfnfrJ9dmQk7JeQ4XCiMzXsJci7yooQgg/IcTKCM/PxE/IkGCQAo80adMkw==
+"@ember/edition-utils@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@ember/edition-utils/-/edition-utils-1.2.0.tgz#a039f542dc14c8e8299c81cd5abba95e2459cfa6"
+  integrity sha512-VmVq/8saCaPdesQmftPqbFtxJWrzxNGSQ+e8x8LLe3Hjm36pJ04Q8LeORGZkAeOhldoUX9seLGmSaHeXkIqoog==
 
 "@glimmer/compiler@0.47.4":
   version "0.47.4"


### PR DESCRIPTION
Prior to this, it was still possible to end up with apps using ember-source@3.16.0 with @ember/edition-utils@1.1.1. The most common reason for this is that the lock file mechanism (yarn or npm) attempts to preserve @ember/edition-utils@1.1.1 when updating ember-source from a prior version.