### PR TITLE
[BUGFIX lts] Add test ensuring singletons instantiated during destruction are destroyed.

### DIFF
--- a/packages/@ember/-internals/container/tests/container_test.js
+++ b/packages/@ember/-internals/container/tests/container_test.js
@@ -736,6 +736,28 @@ moduleFor(
       assert.deepEqual(Object.keys(instance), []);
     }
 
+    '@test instantiating via container.lookup during destruction enqueues destruction'(assert) {
+      let registry = new Registry();
+      let container = registry.container();
+      let otherInstance;
+      class Service extends factory() {
+        destroy() {
+          otherInstance = container.lookup('service:other');
+
+          assert.ok(otherInstance.isDestroyed, 'service:other was destroyed');
+        }
+      }
+      registry.register('service:foo', Service);
+      registry.register('service:other', factory());
+      let instance = container.lookup('service:foo');
+      assert.ok(instance, 'precond lookup successful');
+
+      runTask(() => {
+        container.destroy();
+        container.finalizeDestroy();
+      });
+    }
+
     '@test instantiating via container.factoryFor().create() after destruction throws an error'(
       assert
     ) {


### PR DESCRIPTION
This brings back one of the tests that were added in https://github.com/emberjs/ember.js/pull/18717 and accidentally deleted in https://github.com/emberjs/ember.js/pull/18729.

/cc @chancancode