### PR TITLE
[BUGFIX release] Fix setDiff computed macro used within glimmer component

### DIFF
--- a/packages/@ember/object/lib/computed/reduce_computed_macros.js
+++ b/packages/@ember/object/lib/computed/reduce_computed_macros.js
@@ -1176,8 +1176,8 @@ export function setDiff(setAProperty, setBProperty) {
   );
 
   return computed(`${setAProperty}.[]`, `${setBProperty}.[]`, function() {
-    let setA = this.get(setAProperty);
-    let setB = this.get(setBProperty);
+    let setA = get(this, setAProperty);
+    let setB = get(this, setBProperty);
 
     if (!isArray(setA)) {
       return emberA();


### PR DESCRIPTION
Using `setDiff` computed macro within a glimmer component is failing due to `this.get` being unaccessible within that scope.

Replacing the `this.get` with the `get` imported from `@ember/-internals/metal` just as in every other macros fixes the issue.

As every `reduce_computed_macros` tests are within the `object` folder, I didn't really know where to create the new failing test for the current issue, as it seems related to the usage of a glimmer component. If anyone have any idea on how and where we should create a test for this, I'd be interested to know.

To reproduce the issue, create a glimmer component and use the setDiff computed macro:
```js
import Component from '@glimmer/component';
import { setDiff } from '@ember/object/computed';

export default class SetDiffComponent extends Component {
  fruits = [
    'banana',
    'grape',
    'kale'
  ]

  likes = [
    'grape',
    'kale'
  ]

  @setDiff('fruits', 'likes') wants;
}
```

And then trigger the computation of the `wants` property. This will be resulting in the following error: 

```
Uncaught (in promise) TypeError: this.get is not a function
    at SetDiffComponent.<anonymous> (reduce_computed_macros.js:1114)
    at index.js:2478
    at untrack (index.js:1018)
    at ComputedProperty.get (index.js:2477)
    at SetDiffComponent.CPGETTER_FUNCTION [as wants] (index.js:638)
    at getPossibleMandatoryProxyValue (index.js:1722)
    at get (index.js:1788)
    at index.js:460
    at runInAutotrackingTransaction (index.js:706)
    at track (index.js:986)
```
