### PR TITLE
[DOCS release] improve types and docs for `transitionTo` methods

### DIFF
--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -110,11 +110,12 @@ export default class RouterService extends Service {
      ```
 
      @method transitionTo
-     @param {String} routeNameOrUrl the name of the route or a URL
-     @param {...Object} models the model(s) or identifier(s) to be used while
+     @param {String} [routeNameOrUrl] the name of the route or a URL
+     @param {...Object} [models] the model(s) or identifier(s) to be used while
        transitioning to the route.
      @param {Object} [options] optional hash with a queryParams property
-       containing a mapping of query parameters
+       containing a mapping of query parameters. May be supplied as the only
+      parameter to trigger a query-parameter-only transition.
      @return {Transition} the transition object associated with this
        attempted transition
      @public

--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -92,7 +92,8 @@ export default class RouterService extends Service {
      See the [Router Service RFC](https://github.com/emberjs/rfcs/blob/master/text/0095-router-service.md#query-parameter-semantics) for more info.
 
      In the following example we use the Router service to navigate to a route with a
-     specific model from a Component.
+     specific model from a Component in the first action, and in the second we trigger
+     a query-params only transition.
 
      ```app/components/example.js
      import Component from '@glimmer/component';
@@ -105,6 +106,13 @@ export default class RouterService extends Service {
        @action
        goToComments(post) {
          this.router.transitionTo('comments', post);
+       }
+
+       @action
+       fetchMoreComments(latestComment) {
+         this.router.transitionTo({
+           queryParams: { commentsAfter: latestComment }
+         });
        }
      }
      ```

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -785,11 +785,12 @@ class Route extends EmberObject implements IRoute {
     ```
 
     @method transitionTo
-    @param {String} name the name of the route or a URL
-    @param {...Object} models the model(s) or identifier(s) to be used while
+    @param {String} [name] the name of the route or a URL.
+    @param {...Object} [models] the model(s) or identifier(s) to be used while
       transitioning to the route.
     @param {Object} [options] optional hash with a queryParams property
-      containing a mapping of query parameters
+      containing a mapping of query parameters. May be supplied as the only
+      parameter to trigger a query-parameter-only transition.
     @return {Transition} the transition object associated with this
       attempted transition
     @since 1.0.0

--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -517,7 +517,7 @@ class EmberRouter extends EmberObject {
     @public
   */
   transitionTo(...args: unknown[]) {
-    if (resemblesURL(args[0] as string)) {
+    if (resemblesURL(args[0])) {
       assert(
         `A transition was attempted from '${this.currentRouteName}' to '${args[0]}' but the application instance has already been destroyed.`,
         !this.isDestroying && !this.isDestroyed
@@ -818,9 +818,9 @@ class EmberRouter extends EmberObject {
   }
 
   _doTransition(
-    _targetRouteName: string,
+    _targetRouteName: string | undefined,
     models: {}[],
-    _queryParams: QueryParam,
+    _queryParams: {},
     _keepDefaultQueryParamValues?: boolean
   ) {
     let targetRouteName = _targetRouteName || getActiveTargetName(this._routerMicrolib);


### PR DESCRIPTION
- Both `Route.transitionTo` and `RouterService.transitionTo` support query-params-only transitions, where the caller invokes the method like `transitionTo({ queryParams: { ... } })`. Document this invocation.
- A number of the type declarations in the router implementation were incorrect, overly loose, or both. Fix a number of them, and clearly mark safe casts with `// SAFETY: ...` and unsafe casts with `// UNSAFE: ...` comments explaining why the cast is or is not valid. Hopefully this will make it easier to (a) further improve the safety of this code later and (b) narrow down the cause of bugs since unsafe behavior is explicitly flagged.