### PR TITLE
[BUGFIX] Suspend observer deactivation during property changes

### DIFF
--- a/packages/@ember/-internals/metal/lib/property_events.ts
+++ b/packages/@ember/-internals/metal/lib/property_events.ts
@@ -1,6 +1,10 @@
 import { Meta, peekMeta } from '@ember/-internals/meta';
 import { symbol } from '@ember/-internals/utils';
-import { flushSyncObservers } from './observer';
+import {
+  flushSyncObservers,
+  resumeObserverDeactivation,
+  suspendedObserverDeactivation,
+} from './observer';
 import { markObjectAsDirty } from './tags';
 
 /**
@@ -54,6 +58,7 @@ function notifyPropertyChange(obj: object, keyName: string, _meta?: Meta | null)
 */
 function beginPropertyChanges(): void {
   deferred++;
+  suspendedObserverDeactivation();
 }
 
 /**
@@ -64,6 +69,7 @@ function endPropertyChanges(): void {
   deferred--;
   if (deferred <= 0) {
     flushSyncObservers();
+    resumeObserverDeactivation();
   }
 }
 


### PR DESCRIPTION
We accidentally removed some tests for timing changes in observers when
we were originally refactoring observers. This PR adds these tests back,
and suspends deactivation of observers until after property changes have
completed and observers have been properly fired.