### PR TITLE
Drop Node 8 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,13 +95,11 @@ jobs:
         - yarn test
 
     - name: Node.js Tests
-      node_js: "8"
       script:
         - yarn ember build -prod
         - yarn test:node
 
     - name: Blueprint Tests
-      node_js: "8"
       script:
         - yarn test:blueprints
 

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "tslint": "^5.20.1"
   },
   "engines": {
-    "node": "8.* || 10.* || >= 12.*"
+    "node": "10.* || >= 12.*"
   },
   "ember-addon": {
     "after": "ember-cli-legacy-blueprints"


### PR DESCRIPTION
Our public API around Node version support says:

> To make it easier for us to deliver on our support promise we have adopted a policy that the HEAD of our master branches will be compatible with all versions of Node.js currently receiving support. For any Ember project on the day we drop support for a Node.js version the following things will happen:
>
> * We will update the engines key inside of package.json to specify the versions supported by the project.
> * We will update the testing targets to remove the newly-unsupported Node.js version from the list.
> * We will begin accepting code without testing it against the newly-unsupported version of Node.js.
>
> For projects with an unspecified release model we will release one last version of the project prior to those steps. The version number change will reflect SemVer with respect to the APIs of the project and not take into consideration removal of Node.js version support. This means that the release may show up as a "patch" version release. For example, if we're dropping support for Node.js 0.10 and have a project at version 1.3.3 we can drop Node.js 0.10 support when we release version 1.3.4.

(from https://blog.emberjs.com/2016/09/07/ember-node-lts-support.html)