### PR TITLE
[DOC release] `fn` helper has no `value` param

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/helpers/mut.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/mut.ts
@@ -75,12 +75,6 @@ import { Tag } from '@glimmer/validator';
   </button>
   ```
 
-  You can also use the `value` option:
-
-  ```handlebars
-  <input value={{name}} oninput={{fn (mut name) value="target.value"}}>
-  ```
-
   @method mut
   @param {Object} [attr] the "two-way" attribute that can be modified.
   @for Ember.Templates.helpers


### PR DESCRIPTION
the `mut` helper docstring has an example using the `fn` helper with
`value` param, but `fn` has no `value` param.

looks like a small oversight updating the docs away from `action`.