### PR TITLE
Make escapeExpression public

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/utils/string.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/string.ts
@@ -35,6 +35,24 @@ function escapeChar(chr: keyof typeof escape) {
   return escape[chr];
 }
 
+/**
+  Escapes the passed string, making it safe for use in templates.
+  
+  Replaces &, <, >, ", ', `, = in the string with the HTML-entity equivalents.
+  SafeString values created with `htmlSafe` are left untouched.
+
+  ```javascript
+  import { escapeExpression } from '@ember/template';
+
+  escapeExpression('<div>someString</div>')
+  ```
+
+  @method escapeExpression
+  @for @ember/template
+  @static
+  @return {String} An escaped string, safe for use in templates.
+  @public
+*/
 export function escapeExpression(string: any): string {
   if (typeof string !== 'string') {
     // don't escape SafeStrings, since they're already safe


### PR DESCRIPTION
This is a sibling method to `htmlSafe`. It's currently not available under the module import scheme.

It has historically been provided under `Handlebars.Utils.escapeExpression`.

A few open questions:

- This is not a re-export from handlebars, it's implemented in the Ember codebase. But that's also what's been done with `htmlSafe`[1] so I assume it'll work for this method too.

- Do we want to use the name `escapeExpression`? I think `escape` would be better

These files may need updating too:
- https://github.com/emberjs/ember.js/blob/561449b0bb18603d4cf5c74d8b7572a5a89cd38a/packages/%40ember/-internals/glimmer/tests/utils/string-test.js
- https://github.com/emberjs/ember.js/blob/1f08044fbdbbdffc9cc014b43861eeb4a2f4803f/packages/%40ember/-internals/glimmer/tests/integration/content-test.js
- https://github.com/emberjs/ember.js/blob/d96d9aad52e010da977d813f479494397ee53ec6/packages/%40ember/-internals/glimmer/tests/integration/components/curly-components-test.js

Closes #16817

For reference, here is [the RFC that moved htmlSafe](https://github.com/emberjs/rfcs/pull/236). It does not mention escapeExpression.

***

[1] https://github.com/emberjs/ember.js/blob/v3.16.1/packages/%40ember/-internals/glimmer/lib/utils/string.ts#L60-L86