### PR TITLE
[BUGFIX lts] Fixes Travis by removing matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,6 @@ env:
       I/BFT0MbnR6JVCZiPV7TCWPgY1gvgZ6TEEIKGqauDMUBdL8ZK6I='
     - secure: e0yxVfwVW61d3Mi/QBOsY6Rfd1mZd3VXUd9xNRoz/fkvQJRuVwDe7oG3NOuJ4LZzvMw7BJ+zpDV9D8nKhAyPEEOgpkkMHUB7Ds83pHG4qSMzm4EAwBCadDLXCQirldz8dzN5FAqgGucXoj5fj/p2SKOkO6qWIZveGr8pdBJEG1E=
 
-matrix:
-  fast_finish: true
-
 cache:
   yarn: true
 


### PR DESCRIPTION
A recent change in the way Travis uses matrix broke our build.
It seems like we aren't using the matrix setting anymore
now that jobs are the way to do staging, so removing it for now
to fix the build.