### PR TITLE
[BUGFIX LTS] do not throw on stable `elementId`

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
@@ -109,6 +109,39 @@ moduleFor(
       }
     }
 
+    ['@test elementId is stable when other values change']() {
+      let changingArg = 'arbitrary value';
+      let parentInstance;
+      this.registerComponent('foo-bar', {
+        ComponentClass: Component.extend({
+          init() {
+            this._super(...arguments);
+            parentInstance = this;
+          },
+          changingArg: changingArg,
+        }),
+        template: '{{quux-baz elementId="stable-id" changingArg=this.changingArg}}',
+      });
+
+      this.registerComponent('quux-baz', {
+        ComponentClass: Component.extend({}),
+        template: '{{changingArg}}',
+      });
+
+      this.render('{{foo-bar}}');
+      this.assertComponentElement(this.firstChild.firstChild, {
+        attrs: { id: 'stable-id' },
+        content: 'arbitrary value',
+      });
+
+      changingArg = 'a different value';
+      runTask(() => set(parentInstance, 'changingArg', changingArg));
+      this.assertComponentElement(this.firstChild.firstChild, {
+        attrs: { id: 'stable-id' },
+        content: changingArg,
+      });
+    }
+
     ['@test can specify template with `layoutName` property']() {
       let FooBarComponent = Component.extend({
         elementId: 'blahzorz',

--- a/packages/@ember/-internals/views/lib/views/states/in_dom.js
+++ b/packages/@ember/-internals/views/lib/views/states/in_dom.js
@@ -22,8 +22,10 @@ const inDOM = assign({}, hasElement, {
         get() {
           return elementId;
         },
-        set() {
-          throw new EmberError("Changing a view's elementId after creation is not allowed");
+        set(value) {
+          if (value !== elementId) {
+            throw new EmberError("Changing a view's elementId after creation is not allowed");
+          }
         },
       });
     }


### PR DESCRIPTION
When refactoring from observers to setters during the 3.11 release (in 405d4238), an apparently-transparent change caused a regression around invocations of components including `elementId=...`. *Any* rerender of the component which included `elementId` assignment now triggered the assertion, rather than *only* changes which actually updated the value of `elementId`, because all invocations strigger a `set` on the property.

The simplest reproduction of this bug (given a component `foo-bar`):

```hbs
{{foo-bar
  elementId='stable'
  changingValue=this.fromBackingClass
}}
```

Changing the value `fromBackingClass` on the backing class *always* triggers the assertion, even though it is actually impossible for it to change the `elementId` value, because the assertion in the setter throws regardless of what the value is. (The observer-based did not throw in the same conditions because it would not retrigger when the observed key on the view did not change.)

The fix is to check equality between the passed `elementId` value and the previously set value, and only throw if they differ.

Fixes #18147