### PR TITLE
[BACKPORT LTS] do not throw on stable `elementId`

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
@@ -111,6 +111,39 @@ moduleFor(
       }
     }
 
+    ['@test elementId is stable when other values change']() {
+      let changingArg = 'arbitrary value';
+      let parentInstance;
+      this.registerComponent('foo-bar', {
+        ComponentClass: Component.extend({
+          init() {
+            this._super(...arguments);
+            parentInstance = this;
+          },
+          changingArg: changingArg,
+        }),
+        template: '{{quux-baz elementId="stable-id" changingArg=this.changingArg}}',
+      });
+
+      this.registerComponent('quux-baz', {
+        ComponentClass: Component.extend({}),
+        template: '{{changingArg}}',
+      });
+
+      this.render('{{foo-bar}}');
+      this.assertComponentElement(this.firstChild.firstChild, {
+        attrs: { id: 'stable-id' },
+        content: 'arbitrary value',
+      });
+
+      changingArg = 'a different value';
+      runTask(() => set(parentInstance, 'changingArg', changingArg));
+      this.assertComponentElement(this.firstChild.firstChild, {
+        attrs: { id: 'stable-id' },
+        content: changingArg,
+      });
+    }
+
     ['@test can specify template with `layoutName` property']() {
       let FooBarComponent = Component.extend({
         elementId: 'blahzorz',

--- a/packages/@ember/-internals/views/lib/views/states/in_dom.js
+++ b/packages/@ember/-internals/views/lib/views/states/in_dom.js
@@ -25,8 +25,10 @@ const inDOM = assign({}, hasElement, {
         get() {
           return elementId;
         },
-        set() {
-          throw new EmberError("Changing a view's elementId after creation is not allowed");
+        set(value) {
+          if (value !== elementId) {
+            throw new EmberError("Changing a view's elementId after creation is not allowed");
+          }
         },
       });
     }


### PR DESCRIPTION
Backport of #18807, fixing #18147 for 3.12 LTS