### PR TITLE
Optimize the cache

### DIFF
--- a/packages/@ember/-internals/utils/lib/cache.ts
+++ b/packages/@ember/-internals/utils/lib/cache.ts
@@ -1,9 +1,4 @@
-// The type `V` is just anything but `undefined`, so the `Cache.get` can be optimised
-// since a call to `Map.has` is not needed anymore
-export default class Cache<
-  T,
-  V extends object | number | string | boolean | bigint | symbol | null
-> {
+export default class Cache<T, V> {
   public size = 0;
   public misses = 0;
   public hits = 0;
@@ -15,17 +10,17 @@ export default class Cache<
 
   get(key: T): V {
     let value = this.store.get(key);
-    if (value !== undefined) {
-      this.hits++;
-    } else {
+    if (value === undefined) {
       this.misses++;
       value = this.set(key, this.func(key));
+    } else {
+      this.hits++;
     }
 
     return value;
   }
 
-  set(key: T, value: V) {
+  set(key: T, value: V): V {
     if (this.limit > this.size) {
       this.size++;
       this.store.set(key, value);
@@ -34,7 +29,7 @@ export default class Cache<
     return value;
   }
 
-  purge() {
+  purge(): void {
     this.store.clear();
     this.size = 0;
     this.hits = 0;

--- a/packages/@ember/-internals/utils/lib/cache.ts
+++ b/packages/@ember/-internals/utils/lib/cache.ts
@@ -1,3 +1,5 @@
+// The type `V` is just anything but `undefined`, so the `Cache.get` can be optimised
+// since a call to `Map.has` is not needed anymore
 export default class Cache<
   T,
   V extends object | number | string | boolean | bigint | symbol | null

--- a/packages/@ember/-internals/utils/lib/cache.ts
+++ b/packages/@ember/-internals/utils/lib/cache.ts
@@ -1,21 +1,26 @@
-export default class Cache<T, V> {
+export default class Cache<
+  T,
+  V extends object | number | string | boolean | bigint | symbol | null
+> {
   public size = 0;
   public misses = 0;
   public hits = 0;
+  private store: Map<T, V>;
 
-  constructor(private limit: number, private func: (obj: T) => V, private store?: any) {
-    this.store = store || new Map();
+  constructor(private limit: number, private func: (obj: T) => V, store?: Map<T, V>) {
+    this.store = store || new Map<T, V>();
   }
 
   get(key: T): V {
-    if (this.store.has(key)) {
+    let value = this.store.get(key);
+    if (value !== undefined) {
       this.hits++;
-
-      return this.store.get(key);
     } else {
       this.misses++;
-      return this.set(key, this.func(key));
+      value = this.set(key, this.func(key));
     }
+
+    return value;
   }
 
   set(key: T, value: V) {


### PR DESCRIPTION
Our application has a large data set. One use-case includes destroying a large amount of data.
Analysing this scenario, I noticed that 20 seconds was spent in `Cache.get`: 10 seconds in `store.get` and 10 seconds in `store.has`.
By assuming that the return value never will be `undefined` (I verified this in the code), then the `store.has` is not needed.
If it is required that the return value of the function should also include `undefined`. Then this algorithm could be modified to optimise the hits over the misses. By changing the test `value !== undefined` too `value !== undefined || this.store.has(key)`