### PR TITLE
[BUGFIX release] Fix {{each-in}} for array-like iterables

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/utils/iterator.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/iterator.ts
@@ -192,12 +192,18 @@ abstract class NativeIterator<T = unknown> implements IteratorDelegate {
   static from<T>(this: NativeIteratorConstructor<T>, iterable: Iterable<T>) {
     let iterator = iterable[Symbol.iterator]();
     let result = iterator.next();
-    let { done } = result;
+    let { done, value } = result;
 
-    if (done) {
+    if (done === true) {
       return null;
-    } else {
+    } else if (Array.isArray(value) && value.length === 2) {
+      // This check is for MapLike iterators, to see if the value is map-like.
+      // If so, return the iterator as expected. ArrayLike iterators will still
+      // return an array iterator, since we use `this`.
       return new this(iterator, result);
+    } else {
+      // It's not map-like, return an array iterator instead.
+      return new ArrayLikeNativeIterator(iterator, result);
     }
   }
 

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/each-in-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/each-in-test.js
@@ -618,7 +618,7 @@ moduleFor(
 );
 
 moduleFor(
-  'Syntax test: {{#each-in}} with ES6 Maps',
+  'Syntax test: {{#each-in}} with ES6 Maps and Sets',
   class extends EachInTest {
     createHash(pojo) {
       let map = new Map();
@@ -671,6 +671,44 @@ moduleFor(
         <li>three: qux</li>
       </ul>
     `);
+    }
+
+    [`@test it supports native ES6 Sets`]() {
+      let nativeSet = new Set();
+      nativeSet.add('foo');
+      nativeSet.add('bar');
+
+      this.render(
+        strip`
+          <ul>
+            {{#each-in set key="@identity" as |key value|}}
+              <li>{{key}}: {{value}}</li>
+            {{/each-in}}
+          </ul>
+        `,
+        { set: nativeSet }
+      );
+
+      this.assertHTML(strip`
+        <ul>
+          <li>0: foo</li>
+          <li>1: bar</li>
+        </ul>
+      `);
+
+      this.assertStableRerender();
+
+      runTask(() => {
+        let nativeSet = new Set();
+        nativeSet.add('qux');
+        set(this.context, 'set', nativeSet);
+      });
+
+      this.assertHTML(strip`
+        <ul>
+          <li>0: qux</li>
+        </ul>
+      `);
     }
   }
 );


### PR DESCRIPTION
Prior to the VM upgrade, the `{{each-in}}` iterator would treat
array-like native iterables as if they were an array, with values being
the value and the position in the order of the iteration being the
index. Map-like native iterables, e.g. ones whose values were arrays of
key/value pairs, would by contrast _extract_ the keys and values, and
use the key as the index and the value as the value instead of the
tuple.

This was lost in translation, and this PR adds it back, along with a
test.