### PR TITLE
prepend 'TODO: ' to 'Replace this with your real tests' comments

### DIFF
--- a/blueprints/controller-test/mocha-0.12-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/controller-test/mocha-0.12-files/__root__/__testType__/__path__/__test__.js
@@ -8,7 +8,7 @@ describe('<%= friendlyTestDescription %>', function() {
     // needs: ['controller:foo']
   });
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('exists', function() {
     let controller = this.subject();
     expect(controller).to.be.ok;

--- a/blueprints/controller-test/mocha-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/controller-test/mocha-files/__root__/__testType__/__path__/__test__.js
@@ -1,9 +1,7 @@
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
 
-describeModule(
-  'controller:<%= dasherizedModuleName %>',
-  '<%= friendlyTestDescription %>',
+describeModule('controller:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>',
   {
     // Specify the other units that are required for this test.
     // needs: ['controller:foo']

--- a/blueprints/controller-test/mocha-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/controller-test/mocha-files/__root__/__testType__/__path__/__test__.js
@@ -1,13 +1,15 @@
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
 
-describeModule('controller:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>',
+describeModule(
+  'controller:<%= dasherizedModuleName %>',
+  '<%= friendlyTestDescription %>',
   {
     // Specify the other units that are required for this test.
     // needs: ['controller:foo']
   },
   function() {
-    // Replace this with your real tests.
+    // TODO: Replace this with your real tests.
     it('exists', function() {
       let controller = this.subject();
       expect(controller).to.be.ok;

--- a/blueprints/controller-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/controller-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -5,7 +5,7 @@ import { setupTest } from 'ember-mocha';
 describe('<%= friendlyTestDescription %>', function() {
   setupTest();
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('exists', function() {
     let controller = this.owner.lookup('controller:<%= controllerPathName %>');
     expect(controller).to.be.ok;

--- a/blueprints/controller-test/qunit-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/controller-test/qunit-files/__root__/__testType__/__path__/__test__.js
@@ -5,7 +5,7 @@ moduleFor('controller:<%= dasherizedModuleName %>', '<%= friendlyTestDescription
   // needs: ['controller:foo']
 });
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it exists', function(assert) {
   let controller = this.subject();
   assert.ok(controller);

--- a/blueprints/controller-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/controller-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -4,7 +4,7 @@ import { setupTest } from 'ember-qunit';
 module('<%= friendlyTestDescription %>', function(hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   test('it exists', function(assert) {
     let controller = this.owner.lookup('controller:<%= controllerPathName %>');
     assert.ok(controller);

--- a/blueprints/helper-test/mocha-0.12-files/__root__/__testType__/__collection__/__name__-test.js
+++ b/blueprints/helper-test/mocha-0.12-files/__root__/__testType__/__collection__/__name__-test.js
@@ -29,7 +29,7 @@ import { <%= camelizedModuleName %> } from '<%= dasherizedPackageName %>/helpers
 
 describe('<%= friendlyTestName %>', function() {
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', function() {
     let result = <%= camelizedModuleName %>(42);
     expect(result).to.be.ok;

--- a/blueprints/helper-test/mocha-files/__root__/__testType__/__collection__/__name__-test.js
+++ b/blueprints/helper-test/mocha-files/__root__/__testType__/__collection__/__name__-test.js
@@ -30,7 +30,7 @@ import { <%= camelizedModuleName %> } from '<%= dasherizedPackageName %>/helpers
 
 describe('<%= friendlyTestName %>', function() {
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', function() {
     let result = <%= camelizedModuleName %>(42);
     expect(result).to.be.ok;

--- a/blueprints/helper-test/mocha-rfc-232-files/__root__/__testType__/__collection__/__name__-test.js
+++ b/blueprints/helper-test/mocha-rfc-232-files/__root__/__testType__/__collection__/__name__-test.js
@@ -7,7 +7,7 @@ import { render } from '@ember/test-helpers';
 describe('<%= friendlyTestName %>', function() {
   setupRenderingTest();
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('renders', async function() {
     this.set('inputValue', '1234');
 
@@ -20,7 +20,7 @@ import { <%= camelizedModuleName %> } from '<%= dasherizedPackageName %>/helpers
 
 describe('<%= friendlyTestName %>', function() {
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', function() {
     let result = <%= camelizedModuleName %>(42);
     expect(result).to.be.ok;

--- a/blueprints/helper-test/qunit-files/__root__/__testType__/__collection__/__name__-test.js
+++ b/blueprints/helper-test/qunit-files/__root__/__testType__/__collection__/__name__-test.js
@@ -5,7 +5,7 @@ moduleForComponent('<%= dasherizedModuleName %>', 'helper:<%= dasherizedModuleNa
   integration: true
 });
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it renders', function(assert) {
   this.set('inputValue', '1234');
 
@@ -18,7 +18,7 @@ import { module, test } from 'qunit';
 
 module('<%= friendlyTestName %>');
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it works', function(assert) {
   let result = <%= camelizedModuleName %>([42]);
   assert.ok(result);

--- a/blueprints/helper-test/qunit-rfc-232-files/__root__/__testType__/__collection__/__name__-test.js
+++ b/blueprints/helper-test/qunit-rfc-232-files/__root__/__testType__/__collection__/__name__-test.js
@@ -6,7 +6,7 @@ import { render } from '@ember/test-helpers';
 module('<%= friendlyTestName %>', function(hooks) {
   setupRenderingTest(hooks);
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   test('it renders', async function(assert) {
     this.set('inputValue', '1234');
 
@@ -21,7 +21,7 @@ import { setupTest } from 'ember-qunit';
 module('<%= friendlyTestName %>', function(hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   test('it works', function(assert) {
     let result = <%= camelizedModuleName %>([42]);
     assert.ok(result);

--- a/blueprints/initializer-test/mocha-files/__root__/__testType__/__path__/__name__-test.js
+++ b/blueprints/initializer-test/mocha-files/__root__/__testType__/__path__/__name__-test.js
@@ -19,7 +19,7 @@ describe('<%= friendlyTestName %>', function() {
     <% if (destroyAppExists) { %>destroyApp(application);<% } else { %>run(application, 'destroy');<% } %>
   });
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', function() {
     initialize(application);
 

--- a/blueprints/initializer-test/mocha-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
+++ b/blueprints/initializer-test/mocha-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
@@ -19,7 +19,7 @@ describe('<%= friendlyTestName %>', function() {
     <% if (destroyAppExists) { %>destroyApp(this.application);<% } else { %>run(this.application, 'destroy');<% } %>
   });
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', async function() {
     await this.application.boot();
 

--- a/blueprints/initializer-test/qunit-files/__root__/__testType__/__path__/__name__-test.js
+++ b/blueprints/initializer-test/qunit-files/__root__/__testType__/__path__/__name__-test.js
@@ -17,7 +17,7 @@ module('<%= friendlyTestName %>', {
   }
 });
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it works', function(assert) {
   initialize(this.application);
 

--- a/blueprints/initializer-test/qunit-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
+++ b/blueprints/initializer-test/qunit-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
@@ -19,7 +19,7 @@ module('<%= friendlyTestName %>', function(hooks) {
     <% if (destroyAppExists) { %>destroyApp(this.application);<% } else { %>run(this.application, 'destroy');<% } %>
   });
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   test('it works', async function(assert) {
     await this.application.boot();
 

--- a/blueprints/instance-initializer-test/mocha-files/__root__/__testType__/__path__/__name__-test.js
+++ b/blueprints/instance-initializer-test/mocha-files/__root__/__testType__/__path__/__name__-test.js
@@ -20,7 +20,7 @@ describe('<%= friendlyTestName %>', function() {
     destroyApp(application);
   });
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', function() {
     initialize(appInstance);
 

--- a/blueprints/instance-initializer-test/mocha-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
+++ b/blueprints/instance-initializer-test/mocha-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
@@ -19,7 +19,7 @@ describe('<%= friendlyTestName %>', function() {
     <% if (destroyAppExists) { %>destroyApp(this.application);<% } else { %>run(this.application, 'destroy');<% } %>
   });
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', async function() {
     await this.instance.boot();
 

--- a/blueprints/instance-initializer-test/qunit-files/__root__/__testType__/__path__/__name__-test.js
+++ b/blueprints/instance-initializer-test/qunit-files/__root__/__testType__/__path__/__name__-test.js
@@ -17,7 +17,7 @@ module('<%= friendlyTestName %>', {
   }
 });
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it works', function(assert) {
   initialize(this.appInstance);
 

--- a/blueprints/instance-initializer-test/qunit-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
+++ b/blueprints/instance-initializer-test/qunit-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
@@ -19,7 +19,7 @@ module('<%= friendlyTestName %>', function(hooks) {
     <% if (destroyAppExists) { %>destroyApp(this.application);<% } else { %>run(this.application, 'destroy');<% } %>
   });
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   test('it works', async function(assert) {
     await this.instance.boot();
 

--- a/blueprints/mixin-test/mocha-files/__root__/__testType__/__name__-test.js
+++ b/blueprints/mixin-test/mocha-files/__root__/__testType__/__name__-test.js
@@ -4,7 +4,7 @@ import EmberObject from '@ember/object';
 import <%= classifiedModuleName %>Mixin from '<%= dasherizedPackageName %>/mixins/<%= dasherizedModuleName %>';
 
 describe('<%= friendlyTestName %>', function() {
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', function() {
     let <%= classifiedModuleName %>Object = EmberObject.extend(<%= classifiedModuleName %>Mixin);
     let subject = <%= classifiedModuleName %>Object.create();

--- a/blueprints/mixin-test/mocha-rfc-232-files/__root__/__testType__/__name__-test.js
+++ b/blueprints/mixin-test/mocha-rfc-232-files/__root__/__testType__/__name__-test.js
@@ -4,7 +4,7 @@ import EmberObject from '@ember/object';
 import <%= classifiedModuleName %>Mixin from '<%= dasherizedPackageName %>/mixins/<%= dasherizedModuleName %>';
 
 describe('<%= friendlyTestName %>', function() {
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', function() {
     let <%= classifiedModuleName %>Object = EmberObject.extend(<%= classifiedModuleName %>Mixin);
     let subject = <%= classifiedModuleName %>Object.create();

--- a/blueprints/mixin-test/qunit-files/__root__/__testType__/__name__-test.js
+++ b/blueprints/mixin-test/qunit-files/__root__/__testType__/__name__-test.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 
 module('<%= friendlyTestName %>');
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it works', function(assert) {
   let <%= classifiedModuleName %>Object = EmberObject.extend(<%= classifiedModuleName %>Mixin);
   let subject = <%= classifiedModuleName %>Object.create();

--- a/blueprints/mixin-test/qunit-rfc-232-files/__root__/__testType__/__name__-test.js
+++ b/blueprints/mixin-test/qunit-rfc-232-files/__root__/__testType__/__name__-test.js
@@ -3,7 +3,7 @@ import <%= classifiedModuleName %>Mixin from '<%= projectName %>/mixins/<%= dash
 import { module, test } from 'qunit';
 
 module('<%= friendlyTestName %>', function() {
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   test('it works', function (assert) {
     let <%= classifiedModuleName %>Object = EmberObject.extend(<%= classifiedModuleName %>Mixin);
     let subject = <%= classifiedModuleName %>Object.create();

--- a/blueprints/service-test/mocha-0.12-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/service-test/mocha-0.12-files/__root__/__testType__/__path__/__test__.js
@@ -8,7 +8,7 @@ describe('<%= friendlyTestDescription %>', function() {
     // needs: ['service:foo']
   });
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('exists', function() {
     let service = this.subject();
     expect(service).to.be.ok;

--- a/blueprints/service-test/mocha-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/service-test/mocha-files/__root__/__testType__/__path__/__test__.js
@@ -1,9 +1,7 @@
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
 
-describeModule(
-  'service:<%= dasherizedModuleName %>',
-  '<%= friendlyTestDescription %>',
+describeModule('service:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>',
   {
     // Specify the other units that are required for this test.
     // needs: ['service:foo']

--- a/blueprints/service-test/mocha-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/service-test/mocha-files/__root__/__testType__/__path__/__test__.js
@@ -1,13 +1,15 @@
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
 
-describeModule('service:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>',
+describeModule(
+  'service:<%= dasherizedModuleName %>',
+  '<%= friendlyTestDescription %>',
   {
     // Specify the other units that are required for this test.
     // needs: ['service:foo']
   },
   function() {
-    // Replace this with your real tests.
+    // TODO: Replace this with your real tests.
     it('exists', function() {
       let service = this.subject();
       expect(service).to.be.ok;

--- a/blueprints/service-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/service-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -5,7 +5,7 @@ import { setupTest } from 'ember-mocha';
 describe('<%= friendlyTestDescription %>', function() {
   setupTest();
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('exists', function() {
     let service = this.owner.lookup('service:<%= dasherizedModuleName %>');
     expect(service).to.be.ok;

--- a/blueprints/service-test/qunit-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/service-test/qunit-files/__root__/__testType__/__path__/__test__.js
@@ -5,7 +5,7 @@ moduleFor('service:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>
   // needs: ['service:foo']
 });
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it exists', function(assert) {
   let service = this.subject();
   assert.ok(service);

--- a/blueprints/service-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/service-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -4,7 +4,7 @@ import { setupTest } from 'ember-qunit';
 module('<%= friendlyTestDescription %>', function(hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   test('it exists', function(assert) {
     let service = this.owner.lookup('service:<%= dasherizedModuleName %>');
     assert.ok(service);

--- a/blueprints/util-test/mocha-files/__root__/__testType__/__name__-test.js
+++ b/blueprints/util-test/mocha-files/__root__/__testType__/__name__-test.js
@@ -3,7 +3,7 @@ import { describe, it } from 'mocha';
 import <%= camelizedModuleName %> from '<%= dasherizedPackageName %>/utils/<%= dasherizedModuleName %>';
 
 describe('<%= friendlyTestName %>', function() {
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', function() {
     let result = <%= camelizedModuleName %>();
     expect(result).to.be.ok;

--- a/blueprints/util-test/mocha-rfc-232-files/__root__/__testType__/__name__-test.js
+++ b/blueprints/util-test/mocha-rfc-232-files/__root__/__testType__/__name__-test.js
@@ -3,7 +3,7 @@ import { describe, it } from 'mocha';
 import <%= camelizedModuleName %> from '<%= dasherizedPackageName %>/utils/<%= dasherizedModuleName %>';
 
 describe('<%= friendlyTestName %>', function() {
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', function() {
     let result = <%= camelizedModuleName %>();
     expect(result).to.be.ok;

--- a/blueprints/util-test/qunit-files/__root__/__testType__/__name__-test.js
+++ b/blueprints/util-test/qunit-files/__root__/__testType__/__name__-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 
 module('<%= friendlyTestName %>');
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it works', function(assert) {
   let result = <%= camelizedModuleName %>();
   assert.ok(result);

--- a/blueprints/util-test/qunit-rfc-232-files/__root__/__testType__/__name__-test.js
+++ b/blueprints/util-test/qunit-rfc-232-files/__root__/__testType__/__name__-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 
 module('<%= friendlyTestName %>', function() {
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   test('it works', function(assert) {
     let result = <%= camelizedModuleName %>();
     assert.ok(result);

--- a/node-tests/fixtures/controller-test/default-nested.js
+++ b/node-tests/fixtures/controller-test/default-nested.js
@@ -5,7 +5,7 @@ moduleFor('controller:foo/bar', 'Unit | Controller | foo/bar', {
   // needs: ['controller:foo']
 });
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it exists', function(assert) {
   let controller = this.subject();
   assert.ok(controller);

--- a/node-tests/fixtures/controller-test/default.js
+++ b/node-tests/fixtures/controller-test/default.js
@@ -5,7 +5,7 @@ moduleFor('controller:foo', 'Unit | Controller | foo', {
   // needs: ['controller:foo']
 });
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it exists', function(assert) {
   let controller = this.subject();
   assert.ok(controller);

--- a/node-tests/fixtures/controller-test/mocha-0.12-nested.js
+++ b/node-tests/fixtures/controller-test/mocha-0.12-nested.js
@@ -8,7 +8,7 @@ describe('Unit | Controller | foo/bar', function() {
     // needs: ['controller:foo']
   });
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('exists', function() {
     let controller = this.subject();
     expect(controller).to.be.ok;

--- a/node-tests/fixtures/controller-test/mocha-0.12.js
+++ b/node-tests/fixtures/controller-test/mocha-0.12.js
@@ -8,7 +8,7 @@ describe('Unit | Controller | foo', function() {
     // needs: ['controller:foo']
   });
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('exists', function() {
     let controller = this.subject();
     expect(controller).to.be.ok;

--- a/node-tests/fixtures/controller-test/mocha-nested.js
+++ b/node-tests/fixtures/controller-test/mocha-nested.js
@@ -7,7 +7,7 @@ describeModule('controller:foo/bar', 'Unit | Controller | foo/bar',
     // needs: ['controller:foo']
   },
   function() {
-    // Replace this with your real tests.
+    // TODO: Replace this with your real tests.
     it('exists', function() {
       let controller = this.subject();
       expect(controller).to.be.ok;

--- a/node-tests/fixtures/controller-test/mocha-rfc232-nested.js
+++ b/node-tests/fixtures/controller-test/mocha-rfc232-nested.js
@@ -5,7 +5,7 @@ import { setupTest } from 'ember-mocha';
 describe('Unit | Controller | foo/bar', function() {
   setupTest();
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('exists', function() {
     let controller = this.owner.lookup('controller:foo/bar');
     expect(controller).to.be.ok;

--- a/node-tests/fixtures/controller-test/mocha-rfc232.js
+++ b/node-tests/fixtures/controller-test/mocha-rfc232.js
@@ -5,7 +5,7 @@ import { setupTest } from 'ember-mocha';
 describe('Unit | Controller | foo', function() {
   setupTest();
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('exists', function() {
     let controller = this.owner.lookup('controller:foo');
     expect(controller).to.be.ok;

--- a/node-tests/fixtures/controller-test/mocha.js
+++ b/node-tests/fixtures/controller-test/mocha.js
@@ -7,7 +7,7 @@ describeModule('controller:foo', 'Unit | Controller | foo',
     // needs: ['controller:foo']
   },
   function() {
-    // Replace this with your real tests.
+    // TODO: Replace this with your real tests.
     it('exists', function() {
       let controller = this.subject();
       expect(controller).to.be.ok;

--- a/node-tests/fixtures/controller-test/rfc232-nested.js
+++ b/node-tests/fixtures/controller-test/rfc232-nested.js
@@ -4,7 +4,7 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Controller | foo/bar', function(hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   test('it exists', function(assert) {
     let controller = this.owner.lookup('controller:foo/bar');
     assert.ok(controller);

--- a/node-tests/fixtures/controller-test/rfc232.js
+++ b/node-tests/fixtures/controller-test/rfc232.js
@@ -4,7 +4,7 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Controller | foo', function(hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   test('it exists', function(assert) {
     let controller = this.owner.lookup('controller:foo');
     assert.ok(controller);

--- a/node-tests/fixtures/helper-test/integration.js
+++ b/node-tests/fixtures/helper-test/integration.js
@@ -5,7 +5,7 @@ moduleForComponent('foo/bar-baz', 'helper:foo/bar-baz', {
   integration: true
 });
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it renders', function(assert) {
   this.set('inputValue', '1234');
 

--- a/node-tests/fixtures/helper-test/mocha-0.12-unit.js
+++ b/node-tests/fixtures/helper-test/mocha-0.12-unit.js
@@ -4,7 +4,7 @@ import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';
 
 describe('Unit | Helper | foo/bar-baz', function() {
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', function() {
     let result = fooBarBaz(42);
     expect(result).to.be.ok;

--- a/node-tests/fixtures/helper-test/mocha-rfc232-unit.js
+++ b/node-tests/fixtures/helper-test/mocha-rfc232-unit.js
@@ -4,7 +4,7 @@ import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';
 
 describe('Unit | Helper | foo/bar-baz', function() {
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', function() {
     let result = fooBarBaz(42);
     expect(result).to.be.ok;

--- a/node-tests/fixtures/helper-test/mocha-rfc232.js
+++ b/node-tests/fixtures/helper-test/mocha-rfc232.js
@@ -7,7 +7,7 @@ import hbs from 'htmlbars-inline-precompile';
 describe('Integration | Helper | foo/bar-baz', function() {
   setupRenderingTest();
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('renders', async function() {
     this.set('inputValue', '1234');
 

--- a/node-tests/fixtures/helper-test/mocha-unit.js
+++ b/node-tests/fixtures/helper-test/mocha-unit.js
@@ -4,7 +4,7 @@ import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';
 
 describe('Unit | Helper | foo/bar-baz', function() {
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', function() {
     let result = fooBarBaz(42);
     expect(result).to.be.ok;

--- a/node-tests/fixtures/helper-test/module-unification/addon-unit.js
+++ b/node-tests/fixtures/helper-test/module-unification/addon-unit.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 
 module('Unit | Helper | foo/bar-baz');
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it works', function(assert) {
   let result = fooBarBaz([42]);
   assert.ok(result);

--- a/node-tests/fixtures/helper-test/rfc232-unit.js
+++ b/node-tests/fixtures/helper-test/rfc232-unit.js
@@ -5,7 +5,7 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Helper | foo/bar-baz', function(hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   test('it works', function(assert) {
     let result = fooBarBaz([42]);
     assert.ok(result);

--- a/node-tests/fixtures/helper-test/rfc232.js
+++ b/node-tests/fixtures/helper-test/rfc232.js
@@ -6,7 +6,7 @@ import hbs from 'htmlbars-inline-precompile';
 module('Integration | Helper | foo/bar-baz', function(hooks) {
   setupRenderingTest(hooks);
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   test('it renders', async function(assert) {
     this.set('inputValue', '1234');
 

--- a/node-tests/fixtures/helper-test/unit.js
+++ b/node-tests/fixtures/helper-test/unit.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 
 module('Unit | Helper | foo/bar-baz');
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it works', function(assert) {
   let result = fooBarBaz([42]);
   assert.ok(result);

--- a/node-tests/fixtures/initializer-test/default.js
+++ b/node-tests/fixtures/initializer-test/default.js
@@ -17,7 +17,7 @@ module('Unit | Initializer | foo', {
   }
 });
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it works', function(assert) {
   initialize(this.application);
 

--- a/node-tests/fixtures/initializer-test/dummy.js
+++ b/node-tests/fixtures/initializer-test/dummy.js
@@ -17,7 +17,7 @@ module('Unit | Initializer | foo', {
   }
 });
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it works', function(assert) {
   initialize(this.application);
 

--- a/node-tests/fixtures/initializer-test/mocha-rfc232.js
+++ b/node-tests/fixtures/initializer-test/mocha-rfc232.js
@@ -19,7 +19,7 @@ describe('Unit | Initializer | foo', function() {
     run(this.application, 'destroy');
   });
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', async function() {
     await this.application.boot();
 

--- a/node-tests/fixtures/initializer-test/mocha.js
+++ b/node-tests/fixtures/initializer-test/mocha.js
@@ -19,7 +19,7 @@ describe('Unit | Initializer | foo', function() {
     run(application, 'destroy');
   });
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', function() {
     initialize(application);
 

--- a/node-tests/fixtures/initializer-test/module-unification/default.js
+++ b/node-tests/fixtures/initializer-test/module-unification/default.js
@@ -17,7 +17,7 @@ module('Unit | Initializer | foo', {
   }
 });
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it works', function(assert) {
   initialize(this.application);
 

--- a/node-tests/fixtures/initializer-test/module-unification/dummy.js
+++ b/node-tests/fixtures/initializer-test/module-unification/dummy.js
@@ -17,7 +17,7 @@ module('Unit | Initializer | foo', {
   }
 });
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it works', function(assert) {
   initialize(this.application);
 

--- a/node-tests/fixtures/initializer-test/module-unification/mocha-rfc232.js
+++ b/node-tests/fixtures/initializer-test/module-unification/mocha-rfc232.js
@@ -19,7 +19,7 @@ describe('Unit | Initializer | foo', function() {
     run(this.application, 'destroy');
   });
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', async function() {
     await this.application.boot();
 

--- a/node-tests/fixtures/initializer-test/module-unification/mocha.js
+++ b/node-tests/fixtures/initializer-test/module-unification/mocha.js
@@ -19,7 +19,7 @@ describe('Unit | Initializer | foo', function() {
     run(application, 'destroy');
   });
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', function() {
     initialize(application);
 

--- a/node-tests/fixtures/initializer-test/module-unification/rfc232.js
+++ b/node-tests/fixtures/initializer-test/module-unification/rfc232.js
@@ -19,7 +19,7 @@ module('Unit | Initializer | foo', function(hooks) {
     run(this.application, 'destroy');
   });
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   test('it works', async function(assert) {
     await this.application.boot();
 

--- a/node-tests/fixtures/initializer-test/rfc232.js
+++ b/node-tests/fixtures/initializer-test/rfc232.js
@@ -19,7 +19,7 @@ module('Unit | Initializer | foo', function(hooks) {
     run(this.application, 'destroy');
   });
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   test('it works', async function(assert) {
     await this.application.boot();
 

--- a/node-tests/fixtures/instance-initializer-test/default.js
+++ b/node-tests/fixtures/instance-initializer-test/default.js
@@ -16,7 +16,7 @@ module('Unit | Instance Initializer | foo', {
   }
 });
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it works', function(assert) {
   initialize(this.appInstance);
 

--- a/node-tests/fixtures/instance-initializer-test/dummy.js
+++ b/node-tests/fixtures/instance-initializer-test/dummy.js
@@ -16,7 +16,7 @@ module('Unit | Instance Initializer | foo', {
   }
 });
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it works', function(assert) {
   initialize(this.appInstance);
 

--- a/node-tests/fixtures/instance-initializer-test/mocha-rfc232.js
+++ b/node-tests/fixtures/instance-initializer-test/mocha-rfc232.js
@@ -19,7 +19,7 @@ describe('Unit | Instance Initializer | foo', function() {
     run(this.application, 'destroy');
   });
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', async function() {
     await this.instance.boot();
 

--- a/node-tests/fixtures/instance-initializer-test/mocha.js
+++ b/node-tests/fixtures/instance-initializer-test/mocha.js
@@ -20,7 +20,7 @@ describe('Unit | Instance Initializer | foo', function() {
     destroyApp(application);
   });
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', function() {
     initialize(appInstance);
 

--- a/node-tests/fixtures/instance-initializer-test/module-unification/default.js
+++ b/node-tests/fixtures/instance-initializer-test/module-unification/default.js
@@ -16,7 +16,7 @@ module('Unit | Instance Initializer | foo', {
   }
 });
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it works', function(assert) {
   initialize(this.appInstance);
 

--- a/node-tests/fixtures/instance-initializer-test/module-unification/dummy.js
+++ b/node-tests/fixtures/instance-initializer-test/module-unification/dummy.js
@@ -16,7 +16,7 @@ module('Unit | Instance Initializer | foo', {
   }
 });
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it works', function(assert) {
   initialize(this.appInstance);
 

--- a/node-tests/fixtures/instance-initializer-test/module-unification/mocha-rfc232.js
+++ b/node-tests/fixtures/instance-initializer-test/module-unification/mocha-rfc232.js
@@ -19,7 +19,7 @@ describe('Unit | Instance Initializer | foo', function() {
     run(this.application, 'destroy');
   });
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', async function() {
     await this.instance.boot();
 

--- a/node-tests/fixtures/instance-initializer-test/module-unification/mocha.js
+++ b/node-tests/fixtures/instance-initializer-test/module-unification/mocha.js
@@ -20,7 +20,7 @@ describe('Unit | Instance Initializer | foo', function() {
     destroyApp(application);
   });
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', function() {
     initialize(appInstance);
 

--- a/node-tests/fixtures/instance-initializer-test/module-unification/rfc232.js
+++ b/node-tests/fixtures/instance-initializer-test/module-unification/rfc232.js
@@ -19,7 +19,7 @@ module('Unit | Instance Initializer | foo', function(hooks) {
     run(this.application, 'destroy');
   });
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   test('it works', async function(assert) {
     await this.instance.boot();
 

--- a/node-tests/fixtures/instance-initializer-test/rfc232.js
+++ b/node-tests/fixtures/instance-initializer-test/rfc232.js
@@ -19,7 +19,7 @@ module('Unit | Instance Initializer | foo', function(hooks) {
     run(this.application, 'destroy');
   });
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   test('it works', async function(assert) {
     await this.instance.boot();
 

--- a/node-tests/fixtures/mixin-test/addon.js
+++ b/node-tests/fixtures/mixin-test/addon.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 
 module('Unit | Mixin | foo');
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it works', function(assert) {
   let FooObject = EmberObject.extend(FooMixin);
   let subject = FooObject.create();

--- a/node-tests/fixtures/mixin-test/default.js
+++ b/node-tests/fixtures/mixin-test/default.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 
 module('Unit | Mixin | foo');
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it works', function(assert) {
   let FooObject = EmberObject.extend(FooMixin);
   let subject = FooObject.create();

--- a/node-tests/fixtures/mixin-test/mocha-rfc232.js
+++ b/node-tests/fixtures/mixin-test/mocha-rfc232.js
@@ -4,7 +4,7 @@ import EmberObject from '@ember/object';
 import FooMixin from 'my-app/mixins/foo';
 
 describe('Unit | Mixin | foo', function() {
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', function() {
     let FooObject = EmberObject.extend(FooMixin);
     let subject = FooObject.create();

--- a/node-tests/fixtures/mixin-test/mocha.js
+++ b/node-tests/fixtures/mixin-test/mocha.js
@@ -4,7 +4,7 @@ import EmberObject from '@ember/object';
 import FooMixin from 'my-app/mixins/foo';
 
 describe('Unit | Mixin | foo', function() {
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', function() {
     let FooObject = EmberObject.extend(FooMixin);
     let subject = FooObject.create();

--- a/node-tests/fixtures/mixin-test/rfc232.js
+++ b/node-tests/fixtures/mixin-test/rfc232.js
@@ -3,7 +3,7 @@ import FooMixin from 'my-app/mixins/foo';
 import { module, test } from 'qunit';
 
 module('Unit | Mixin | foo', function() {
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   test('it works', function (assert) {
     let FooObject = EmberObject.extend(FooMixin);
     let subject = FooObject.create();

--- a/node-tests/fixtures/service-test/default-nested.js
+++ b/node-tests/fixtures/service-test/default-nested.js
@@ -5,7 +5,7 @@ moduleFor('service:foo/bar', 'Unit | Service | foo/bar', {
   // needs: ['service:foo']
 });
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it exists', function(assert) {
   let service = this.subject();
   assert.ok(service);

--- a/node-tests/fixtures/service-test/default.js
+++ b/node-tests/fixtures/service-test/default.js
@@ -5,7 +5,7 @@ moduleFor('service:foo', 'Unit | Service | foo', {
   // needs: ['service:foo']
 });
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it exists', function(assert) {
   let service = this.subject();
   assert.ok(service);

--- a/node-tests/fixtures/service-test/mocha-0.12.js
+++ b/node-tests/fixtures/service-test/mocha-0.12.js
@@ -8,7 +8,7 @@ describe('Unit | Service | foo', function() {
     // needs: ['service:foo']
   });
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('exists', function() {
     let service = this.subject();
     expect(service).to.be.ok;

--- a/node-tests/fixtures/service-test/mocha-rfc232.js
+++ b/node-tests/fixtures/service-test/mocha-rfc232.js
@@ -5,7 +5,7 @@ import { setupTest } from 'ember-mocha';
 describe('Unit | Service | foo', function() {
   setupTest();
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('exists', function() {
     let service = this.owner.lookup('service:foo');
     expect(service).to.be.ok;

--- a/node-tests/fixtures/service-test/mocha.js
+++ b/node-tests/fixtures/service-test/mocha.js
@@ -7,7 +7,7 @@ describeModule('service:foo', 'Unit | Service | foo',
     // needs: ['service:foo']
   },
   function() {
-    // Replace this with your real tests.
+    // TODO: Replace this with your real tests.
     it('exists', function() {
       let service = this.subject();
       expect(service).to.be.ok;

--- a/node-tests/fixtures/service-test/rfc232.js
+++ b/node-tests/fixtures/service-test/rfc232.js
@@ -4,7 +4,7 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Service | foo', function(hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   test('it exists', function(assert) {
     let service = this.owner.lookup('service:foo');
     assert.ok(service);

--- a/node-tests/fixtures/util-test/addon-default-nested.js
+++ b/node-tests/fixtures/util-test/addon-default-nested.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 
 module('Unit | Utility | foo/bar-baz');
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it works', function(assert) {
   let result = fooBarBaz();
   assert.ok(result);

--- a/node-tests/fixtures/util-test/addon-default.js
+++ b/node-tests/fixtures/util-test/addon-default.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 
 module('Unit | Utility | foo-bar');
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it works', function(assert) {
   let result = fooBar();
   assert.ok(result);

--- a/node-tests/fixtures/util-test/default-nested.js
+++ b/node-tests/fixtures/util-test/default-nested.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 
 module('Unit | Utility | foo/bar-baz');
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it works', function(assert) {
   let result = fooBarBaz();
   assert.ok(result);

--- a/node-tests/fixtures/util-test/default.js
+++ b/node-tests/fixtures/util-test/default.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 
 module('Unit | Utility | foo-bar');
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it works', function(assert) {
   let result = fooBar();
   assert.ok(result);

--- a/node-tests/fixtures/util-test/dummy.js
+++ b/node-tests/fixtures/util-test/dummy.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 
 module('Unit | Utility | foo-bar');
 
-// Replace this with your real tests.
+// TODO: Replace this with your real tests.
 test('it works', function(assert) {
   let result = fooBar();
   assert.ok(result);

--- a/node-tests/fixtures/util-test/mocha-rfc232.js
+++ b/node-tests/fixtures/util-test/mocha-rfc232.js
@@ -3,7 +3,7 @@ import { describe, it } from 'mocha';
 import fooBar from 'my-app/utils/foo-bar';
 
 describe('Unit | Utility | foo-bar', function() {
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', function() {
     let result = fooBar();
     expect(result).to.be.ok;

--- a/node-tests/fixtures/util-test/mocha.js
+++ b/node-tests/fixtures/util-test/mocha.js
@@ -3,7 +3,7 @@ import { describe, it } from 'mocha';
 import fooBar from 'my-app/utils/foo-bar';
 
 describe('Unit | Utility | foo-bar', function() {
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   it('works', function() {
     let result = fooBar();
     expect(result).to.be.ok;

--- a/node-tests/fixtures/util-test/rfc232.js
+++ b/node-tests/fixtures/util-test/rfc232.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 
 module('Unit | Utility | foo-bar', function() {
 
-  // Replace this with your real tests.
+  // TODO: Replace this with your real tests.
   test('it works', function(assert) {
     let result = fooBar();
     assert.ok(result);


### PR DESCRIPTION
### What
- adds `TODO: ` to the generated `Replace this with your real tests` comments in test files
- adds the same to corresponding node-tests fixtures

### Why
- for those in a rush / without strong reviews, you end up with plenty of checked in test files that only have canary tests:
```javascript
  // Replace this with your real tests.
  test('it exists', function (assert) {
    let service = this.owner.lookup('service:company');
    assert.ok(service);
  });
```
- many devs have tooling that highlights TODO or FIXME or similar comments
- this change will nudge developers to start writing a meaningful test earlier in the process
- inspired by adding a lint rule [here](https://github.com/ember-cli/eslint-plugin-ember/issues/717)

As far as I can tell, YUIDOC does not have a standard format for TODO comments

JSDOC has `@todo`

I found a good list of conventions while looking for a highlighter plugin for SublimeText [here](https://forum.sublimetext.com/t/todo-syntax-highlighting/27604/11)