### PR TITLE
 Remove deprecated `implicit-modifier-manager-capabilities`

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/modifiers/custom.ts
+++ b/packages/@ember/-internals/glimmer/lib/modifiers/custom.ts
@@ -1,6 +1,6 @@
 import { Factory } from '@ember/-internals/owner';
 import { getDebugName } from '@ember/-internals/utils';
-import { assert, deprecate } from '@ember/debug';
+import { assert } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 import { CapturedArguments, Dict, ModifierManager, VMArguments } from '@glimmer/interfaces';
 import {
@@ -33,19 +33,6 @@ export function capabilities(
   managerAPI: string,
   optionalFeatures: OptionalCapabilities = {}
 ): Capabilities {
-  if (managerAPI !== '3.13') {
-    managerAPI = '3.13';
-
-    deprecate(
-      'Modifier manager capabilities now require you to pass a valid version when being generated. Valid versions include: 3.13',
-      false,
-      {
-        until: '3.17.0',
-        id: 'implicit-modifier-manager-capabilities',
-      }
-    );
-  }
-
   assert('Invalid modifier manager compatibility specified', managerAPI === '3.13');
 
   return {
@@ -144,19 +131,6 @@ class InteractiveCustomModifierManager<ModifierInstance>
     const capturedArgs = args.capture();
 
     let instance = definition.delegate.createModifier(ModifierClass, capturedArgs.value());
-
-    if (delegate.capabilities === undefined) {
-      delegate.capabilities = capabilities('3.13');
-
-      deprecate(
-        'Custom modifier managers must define their capabilities using the capabilities() helper function',
-        false,
-        {
-          until: '3.17.0',
-          id: 'implicit-modifier-manager-capabilities',
-        }
-      );
-    }
 
     return new CustomModifierState(element, delegate, instance, capturedArgs);
   }

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
@@ -103,39 +103,6 @@ moduleFor(
       runTask(() => set(this.context, 'truthy', true));
     }
 
-    '@test requires modifier capabilities'() {
-      class WithoutCapabilities extends CustomModifierManager {
-        constructor(owner) {
-          super(owner);
-          this.capabilities = undefined;
-        }
-      }
-
-      let ModifierClass = setModifierManager(
-        owner => {
-          return new WithoutCapabilities(owner);
-        },
-        EmberObject.extend({
-          didInsertElement() {},
-          didUpdate() {},
-          willDestroyElement() {},
-        })
-      );
-
-      this.registerModifier(
-        'foo-bar',
-        ModifierClass.extend({
-          didUpdate() {},
-          didInsertElement() {},
-          willDestroyElement() {},
-        })
-      );
-
-      expectDeprecation(() => {
-        this.render('<h1 {{foo-bar truthy}}>hello world</h1>');
-      }, /Custom modifier managers must define their capabilities/);
-    }
-
     '@test associates manager even through an inheritance structure'(assert) {
       assert.expect(5);
       let ModifierClass = setModifierManager(

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
@@ -136,16 +136,6 @@ moduleFor(
       }, /Custom modifier managers must define their capabilities/);
     }
 
-    '@test modifier capabilities require a version'() {
-      expectDeprecation(() => {
-        modifierCapabilities();
-      }, /Modifier manager capabilities now require you to pass a valid version when being generated/);
-
-      expectDeprecation(() => {
-        modifierCapabilities('aoeu');
-      }, /Modifier manager capabilities now require you to pass a valid version when being generated/);
-    }
-
     '@test associates manager even through an inheritance structure'(assert) {
       assert.expect(5);
       let ModifierClass = setModifierManager(


### PR DESCRIPTION
I pooped up https://github.com/emberjs/ember.js/pull/18825 so had to open a new one. My bad!