### PR TITLE
[BUGFIX] Fix `willDestroy` on class helpers

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/helper.ts
+++ b/packages/@ember/-internals/glimmer/lib/helper.ts
@@ -32,14 +32,14 @@ export interface SimpleHelper<T = unknown> {
 
 export function isHelperFactory(
   helper: any | undefined | null
-): helper is SimpleHelperFactory | ClassHelperFactory {
+): helper is Factory<SimpleHelper | HelperInstance, HelperFactory<SimpleHelper | HelperInstance>> {
   return (
     typeof helper === 'object' && helper !== null && helper.class && helper.class.isHelperFactory
   );
 }
 
-export function isSimpleHelper(helper: SimpleHelper | HelperInstance): helper is SimpleHelper {
-  return (helper as any).destroy === undefined;
+export function isClassHelper(helper: SimpleHelper | HelperInstance): helper is HelperInstance {
+  return (helper as any).destroy !== undefined;
 }
 
 /**

--- a/packages/@ember/-internals/glimmer/lib/resolver.ts
+++ b/packages/@ember/-internals/glimmer/lib/resolver.ts
@@ -28,7 +28,7 @@ import InternalComponentManager, {
   InternalComponentDefinition,
 } from './component-managers/internal';
 import { TemplateOnlyComponentDefinition } from './component-managers/template-only';
-import { isHelperFactory, isSimpleHelper } from './helper';
+import { isClassHelper, isHelperFactory } from './helper';
 import { default as componentAssertionHelper } from './helpers/-assert-implicit-component-helper-argument';
 import { default as inputTypeHelper } from './helpers/-input-type';
 import { default as normalizeClassHelper } from './helpers/-normalize-class';
@@ -425,8 +425,12 @@ export default class RuntimeResolver implements JitRuntimeResolver<OwnedTemplate
     return (args, vm) => {
       const helper = factory.create();
 
-      if (!isSimpleHelper(helper)) {
-        vm.associateDestroyable(helper);
+      if (isClassHelper(helper)) {
+        vm.associateDestroyable({
+          destroy() {
+            helper.destroy();
+          },
+        });
       } else if (DEBUG) {
         // Bind to null in case someone accidentally passed an unbound function
         // in, and attempts use `this` on it.

--- a/packages/@ember/-internals/glimmer/lib/utils/references.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/references.ts
@@ -5,7 +5,7 @@ import { CapturedArguments, Environment } from '@glimmer/interfaces';
 import { HelperRootReference, RootReference, VersionedPathReference } from '@glimmer/reference';
 import { PrimitiveReference } from '@glimmer/runtime';
 import { consume, deprecateMutationsInAutotrackingTransaction } from '@glimmer/validator';
-import { HelperInstance, isSimpleHelper, RECOMPUTE_TAG, SimpleHelper } from '../helper';
+import { HelperInstance, isClassHelper, RECOMPUTE_TAG, SimpleHelper } from '../helper';
 
 export class EmberHelperRootReference<T = unknown> extends HelperRootReference<T> {
   constructor(
@@ -40,9 +40,7 @@ export class EmberHelperRootReference<T = unknown> extends HelperRootReference<T
     };
 
     if (DEBUG) {
-      let debugName = isSimpleHelper(helper)
-        ? getDebugName!(helper.compute)
-        : getDebugName!(helper);
+      let debugName = isClassHelper(helper) ? getDebugName!(helper) : getDebugName!(helper.compute);
 
       super(fnWrapper, args, env, debugName);
     } else {


### PR DESCRIPTION
Class based helpers were having `willDestroy` be called twice, once by
the Glimmer VM's built-in destroyables implementation, and once
scheduled by `destroy` (which is the correct destruction). This is
because we were registering the class itself directly as the
destroyable, and Glimmer VM detected the `willDestroy` function on it
and called it eagerly.

This fix creates an intermediate destructor object with a `destroy()`
hook, but long term we need to finish the refactors to destroyables in
the VM and make it so these types of collisions can't happen again.

Added a basic lifecycle test for helpers to prevent this specific issue
from reoccuring.

Fixes #18830