### PR TITLE
Update License to 2020

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019 Yehuda Katz, Tom Dale and Ember.js contributors
+Copyright (c) 2020 Yehuda Katz, Tom Dale and Ember.js contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/generators/license.js
+++ b/generators/license.js
@@ -1,6 +1,6 @@
 /*!
  * @overview  Ember - JavaScript Application Framework
- * @copyright Copyright 2011-2019 Tilde Inc. and contributors
+ * @copyright Copyright 2011-2020 Tilde Inc. and contributors
  *            Portions Copyright 2006-2011 Strobe Inc.
  *            Portions Copyright 2008-2011 Apple Inc. All rights reserved.
  * @license   Licensed under MIT license


### PR DESCRIPTION
Addresses #18841

Updates License year to the current year of 2020. Similar to how it was done in 2019: d418c4f6