### PR TITLE
Add a failing test case for 3.16 regression relating to array mutation and `didReceiveAttrs`

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
@@ -1496,6 +1496,42 @@ moduleFor(
       this.assertText('In layout - someProp: wycats');
     }
 
+    ['@test mutating an array from within component should not trigger `didReceiveAttrs`'](assert) {
+      let didReceiveAttrsCount = 0;
+
+      this.registerComponent('non-block', {
+        ComponentClass: Component.extend({
+          didReceiveAttrs() {
+            this._super(...arguments);
+            didReceiveAttrsCount++;
+          },
+
+          actions: {
+            click() {
+              this.model = this.model.replace(0, 1, ['foo']);
+            },
+          },
+        }),
+        template: `
+          <button {{action "click"}}>foobar</button>
+          <br>
+          <ul>
+            {{#each @model as |item|}}
+              <li>{{item}}</li>
+            {{/each}}
+          </ul>
+        `,
+      });
+
+      this.render('{{non-block model=model}}', {
+        model: emberA([1, 2, 3]),
+      });
+
+      runTask(() => this.$('button').click());
+
+      assert.equal(didReceiveAttrsCount, 1, '`didReceiveAttrs` only called once');
+    }
+
     ['@test this.attrs.foo === attrs.foo === @foo === foo']() {
       this.registerComponent('foo-bar', {
         template: strip`

--- a/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
@@ -1532,6 +1532,39 @@ moduleFor(
       assert.equal(didReceiveAttrsCount, 1, '`didReceiveAttrs` only called once');
     }
 
+    ['@test mutating an object from within component should not trigger `didReceiveAttrs`'](
+      assert
+    ) {
+      let didReceiveAttrsCount = 0;
+
+      this.registerComponent('non-block', {
+        ComponentClass: Component.extend({
+          didReceiveAttrs() {
+            this._super(...arguments);
+            didReceiveAttrsCount++;
+          },
+
+          actions: {
+            click() {
+              this.set('model.foo', 'baz');
+            },
+          },
+        }),
+        template: `
+          <button {{action "click"}}>foobar</button>
+          {{model.foo}}
+        `,
+      });
+
+      this.render('{{non-block model=model}}', {
+        model: { foo: 'bar' },
+      });
+
+      runTask(() => this.$('button').click());
+
+      assert.equal(didReceiveAttrsCount, 1, '`didReceiveAttrs` only called once');
+    }
+
     ['@test this.attrs.foo === attrs.foo === @foo === foo']() {
       this.registerComponent('foo-bar', {
         template: strip`


### PR DESCRIPTION
We're updating our application from 3.12 -> 3.16 and discovered this bug where `didReceiveAttrs` is called from changes that originated within the component itself.

After debugging this issue with @pzuraq, he suggested opening a PR with a failing test case. We _may_ have a workaround for this regression in our application, but we figured it would be good to at least document this regression somewhere.

Note that I confirmed that this test case passes on `lts-3-12`.