### PR TITLE
[BUGFIX] Fix transitionTo with scoped aliased queryParam.

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -1056,7 +1056,7 @@ class EmberRouter extends EmberObject {
         assert(
           `You passed the \`${presentProp}\` query parameter during a transition into ${qp.route.routeName}, please update to ${qp.urlKey}`,
           (function() {
-            if (qp.urlKey === presentProp) {
+            if (qp.urlKey === presentProp || qp.scopedPropertyName === presentProp) {
               return true;
             }
 

--- a/packages/ember/tests/routing/router_service_test/transitionTo_test.js
+++ b/packages/ember/tests/routing/router_service_test/transitionTo_test.js
@@ -451,6 +451,40 @@ moduleFor(
       });
     }
 
+    ['@test RouterService#transitionTo with aliased query params uses the original provided key also when scoped'](
+      assert
+    ) {
+      assert.expect(1);
+
+      this.add(
+        'route:parent',
+        Route.extend({
+          router: service(),
+          beforeModel() {
+            // in this call `url_sort` will be scoped (`parent.child:url_sort`)
+            // when passed into `_hydrateUnsuppliedQueryParams`
+            this.router.transitionTo('parent.child', {
+              queryParams: { url_sort: 'ASC' },
+            });
+          },
+        })
+      );
+
+      this.add(
+        'route:parent.child',
+        Route.extend({
+          queryParams: {
+            cont_sort: { as: 'url_sort' },
+          },
+          cont_sort: 'ASC',
+        })
+      );
+
+      return this.visit('/').then(() => {
+        assert.equal(this.routerService.get('currentURL'), '/child?url_sort=ASC');
+      });
+    }
+
     ['@test RouterService#transitionTo with application query params when redirecting form a different route'](
       assert
     ) {


### PR DESCRIPTION
When the router service scopes query params passed to `transitionTo`, this would raise an assertion when a query param has an alias.

Side note: There is some relevant discussion in #18244 on the complexity of `_hydrateUnsuppliedQueryParams`.