### PR TITLE
[BUGFIX beta] Make assertions from `on` and `fn` more actionable.

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/renderer.ts
@@ -284,7 +284,7 @@ export abstract class Renderer {
     this._builder = builder;
 
     // resolver is exposed for tests
-    let runtimeResolver = (this._runtimeResolver = new RuntimeResolver(env.isInteractive));
+    let runtimeResolver = (this._runtimeResolver = new RuntimeResolver(owner, env.isInteractive));
     let compileTimeResolver = new CompileTimeResolver(runtimeResolver);
 
     let context = (this._context = JitContext(compileTimeResolver));

--- a/packages/@ember/-internals/glimmer/lib/resolver.ts
+++ b/packages/@ember/-internals/glimmer/lib/resolver.ts
@@ -287,12 +287,12 @@ export default class RuntimeResolver implements JitRuntimeResolver<OwnedTemplate
   public componentDefinitionCount = 0;
   public helperDefinitionCount = 0;
 
-  constructor(isInteractive: boolean) {
+  constructor(owner: Owner, isInteractive: boolean) {
     this.isInteractive = isInteractive;
 
     this.builtInModifiers = {
       action: { manager: new ActionModifierManager(), state: null },
-      on: { manager: new OnModifierManager(isInteractive), state: null },
+      on: { manager: new OnModifierManager(owner, isInteractive), state: null },
     };
   }
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/fn-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/fn-test.js
@@ -120,14 +120,34 @@ moduleFor(
       assert.equal(this.stashedFn(), 'arg1: foo, arg2: bar');
     }
 
-    '@test asserts if the first argument is not a function'() {
+    '@test asserts if no argument given'() {
+      expectAssertion(() => {
+        this.render(`{{invoke (fn)}}`, {
+          myFunc: null,
+          arg1: 'foo',
+          arg2: 'bar',
+        });
+      }, /You must pass a function as the `fn` helpers first argument./);
+    }
+
+    '@test asserts if the first argument is undefined'() {
+      expectAssertion(() => {
+        this.render(`{{invoke (fn this.myFunc this.arg1 this.arg2)}}`, {
+          myFunc: undefined,
+          arg1: 'foo',
+          arg2: 'bar',
+        });
+      }, /You must pass a function as the `fn` helpers first argument, you passed undefined. While rendering:\n\nthis.myFunc/);
+    }
+
+    '@test asserts if the first argument is null'() {
       expectAssertion(() => {
         this.render(`{{invoke (fn this.myFunc this.arg1 this.arg2)}}`, {
           myFunc: null,
           arg1: 'foo',
           arg2: 'bar',
         });
-      }, /You must pass a function as the `fn` helpers first argument, you passed null/);
+      }, /You must pass a function as the `fn` helpers first argument, you passed null. While rendering:\n\nthis.myFunc/);
     }
 
     '@test asserts if the provided function accesses `this` without being bound prior to passing to fn'(

--- a/packages/@ember/-internals/glimmer/tests/integration/modifiers/on-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/modifiers/on-test.js
@@ -309,13 +309,13 @@ moduleFor(
     '@test asserts when callback is undefined'() {
       expectAssertion(() => {
         this.render(`<button {{on 'click' this.foo}}>Click Me</button>`);
-      }, /You must pass a function as the second argument to the `on` modifier/);
+      }, /You must pass a function as the second argument to the `on` modifier, you passed undefined. While rendering:\n\nthis.foo/);
     }
 
     '@test asserts when callback is null'() {
       expectAssertion(() => {
         this.render(`<button {{on 'click' this.foo}}>Click Me</button>`, { foo: null });
-      }, /You must pass a function as the second argument to the `on` modifier/);
+      }, /You must pass a function as the second argument to the `on` modifier, you passed null. While rendering:\n\nthis.foo/);
     }
 
     '@test asserts if the provided callback accesses `this` without being bound prior to passing to on'(


### PR DESCRIPTION
Prior to these changes, the assertions for `fn` and `on` were very inactionable. This leverages the debug render tree information to print the template contexts (route hierarchy, component invocation heirarchy, etc) along with the path name used for the callback argument.

This is essentially a rewrite of the work started by @patricklx in #18353 (since that PR had to be reverted due to changes in glimmer-vm internals since it was proposed).