### PR TITLE
Add tests confirming tracked frame balancing.

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
@@ -1,5 +1,13 @@
 import { Object as EmberObject, A } from '@ember/-internals/runtime';
-import { get, set, tracked, nativeDescDecorator as descriptor } from '@ember/-internals/metal';
+import {
+  get,
+  set,
+  tracked,
+  nativeDescDecorator as descriptor,
+  track,
+  untrack,
+  isTracking,
+} from '@ember/-internals/metal';
 import Service, { inject } from '@ember/service';
 import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
 
@@ -378,6 +386,30 @@ moduleFor(
       expectAssertion(() => {
         this.render('{{hello-world this.model}}', { model: new Person() });
       }, expectedMessage);
+    }
+
+    '@test nested tracks work'(assert) {
+      assert.notOk(isTracking());
+
+      track(() => {
+        assert.ok(isTracking());
+
+        untrack(() => {
+          assert.notOk(isTracking());
+        });
+      });
+    }
+
+    '@test nested tracks and untracks work'(assert) {
+      track(() => {
+        track(() => {
+          untrack(() => {
+            track(() => {
+              assert.ok(isTracking(), 'tracking');
+            });
+          });
+        });
+      });
     }
   }
 );


### PR DESCRIPTION
These tests were added in glimmer-vm 0.50.2 to fix a bug (see https://github.com/glimmerjs/glimmer-vm/pull/1069 for details), and landed here in #18869. 

This just ensures that 3.16.x is **not** affected by the bug that was fixed for 3.17+.