### PR TITLE
[RFC#236] Deprecate Ember.String/(at)ember/string

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "prettier": "^1.18.2",
     "puppeteer": "^1.20.0",
     "qunit": "^2.9.3",
-    "rollup-plugin-commonjs": "^10.1.0",
+    "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-node-resolve": "^4.2.4",
     "route-recognizer": "^0.3.4",
     "router_js": "^6.2.5",

--- a/packages/@ember/string/index.ts
+++ b/packages/@ember/string/index.ts
@@ -7,6 +7,7 @@ export { getStrings as _getStrings, setStrings as _setStrings } from './lib/stri
 import { ENV } from '@ember/-internals/environment';
 import { Cache } from '@ember/-internals/utils';
 import { getString } from './lib/string_registry';
+import { deprecate } from '@ember/debug';
 
 const STRING_DASHERIZE_REGEXP = /[ _]/g;
 
@@ -64,6 +65,22 @@ const STRING_DECAMELIZE_REGEXP = /([a-z\d])([A-Z])/g;
 const DECAMELIZE_CACHE = new Cache<string, string>(1000, str =>
   str.replace(STRING_DECAMELIZE_REGEXP, '$1_$2').toLowerCase()
 );
+
+export function deprecateEmberStringUtil(name: string, fn: Function, opts = {}) {
+  return function() {
+    deprecate(
+      opts.message ||
+        `Ember.String namespace is deprecated. Please, use ${name} from '@ember/string' instead.`,
+      true,
+      opts.options || {
+        id: 'ember-string.namespace',
+        until: '3.5.0',
+        url: 'https://emberjs.com/deprecations/v2.x/#toc_ember-string-namespace',
+      }
+    );
+    return fn(...arguments);
+  };
+}
 
 /**
   Defines string helper methods including string formatting and localization.
@@ -286,6 +303,22 @@ export function capitalize(str: string): string {
   return CAPITALIZE_CACHE.get(str);
 }
 
+function deprecateEmberStringPrototypeExtension(
+  name: string,
+  fn: (utility: string, ...options: any) => string | string[],
+  message: string = `String prototype extensions are deprecated. Please, us ${name} from '@ember/string' instead.`
+) {
+  return function(this: string) {
+    deprecate(message, false, {
+      id: 'ember-string.prototype_extensions',
+      until: '4.0.0',
+      url: 'https://emberjs.com/deprecations/v3.x/#toc_ember-string-prototype-extensions',
+    });
+
+    return fn(this, ...arguments);
+  };
+}
+
 if (ENV.EXTEND_PROTOTYPES.String) {
   Object.defineProperties(String.prototype, {
     /**
@@ -301,9 +334,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
       configurable: true,
       enumerable: false,
       writeable: true,
-      value() {
-        return w(this);
-      },
+      value: deprecateEmberStringPrototypeExtension('w', w),
     },
 
     /**
@@ -319,9 +350,11 @@ if (ENV.EXTEND_PROTOTYPES.String) {
       configurable: true,
       enumerable: false,
       writeable: true,
-      value(this: string, ...args: any[]) {
-        return loc(this, args);
-      },
+      value: deprecateEmberStringPrototypeExtension(
+        'loc',
+        loc,
+        '`loc` is deprecated. Please, use an i18n addon instead. See https://emberobserver.com/categories/internationalization for a list of them.'
+      ),
     },
 
     /**
@@ -337,9 +370,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
       configurable: true,
       enumerable: false,
       writeable: true,
-      value() {
-        return camelize(this);
-      },
+      value: deprecateEmberStringPrototypeExtension('camelize', camelize),
     },
 
     /**
@@ -355,9 +386,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
       configurable: true,
       enumerable: false,
       writeable: true,
-      value() {
-        return decamelize(this);
-      },
+      value: deprecateEmberStringPrototypeExtension('decamelize', decamelize),
     },
 
     /**
@@ -373,9 +402,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
       configurable: true,
       enumerable: false,
       writeable: true,
-      value() {
-        return dasherize(this);
-      },
+      value: deprecateEmberStringPrototypeExtension('dasherize', dasherize),
     },
 
     /**
@@ -391,9 +418,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
       configurable: true,
       enumerable: false,
       writeable: true,
-      value() {
-        return underscore(this);
-      },
+      value: deprecateEmberStringPrototypeExtension('underscore', underscore),
     },
 
     /**
@@ -409,9 +434,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
       configurable: true,
       enumerable: false,
       writeable: true,
-      value() {
-        return classify(this);
-      },
+      value: deprecateEmberStringPrototypeExtension('classify', classify),
     },
 
     /**
@@ -427,9 +450,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
       configurable: true,
       enumerable: false,
       writeable: true,
-      value() {
-        return capitalize(this);
-      },
+      value: deprecateEmberStringPrototypeExtension('capitalize', capitalize),
     },
   });
 }

--- a/packages/@ember/string/index.ts
+++ b/packages/@ember/string/index.ts
@@ -109,6 +109,7 @@ function _fmt(str: string, formats: any[]) {
   @param {Array} formats Optional array of parameters to interpolate into string.
   @return {String} formatted string
   @public
+  @deprecated
 */
 export function loc(str: string, formats: any[]): string {
   if (!Array.isArray(formats) || arguments.length > 2) {
@@ -140,6 +141,7 @@ export function loc(str: string, formats: any[]): string {
   @param {String} str The string to split
   @return {Array} array containing the split strings
   @public
+  @deprecated
 */
 export function w(str: string): string[] {
   return str.split(/\s+/);
@@ -161,6 +163,7 @@ export function w(str: string): string[] {
   @param {String} str The string to decamelize.
   @return {String} the decamelized string.
   @public
+  @deprecated
 */
 export function decamelize(str: string): string {
   return DECAMELIZE_CACHE.get(str);
@@ -183,6 +186,7 @@ export function decamelize(str: string): string {
   @param {String} str The string to dasherize.
   @return {String} the dasherized string.
   @public
+  @deprecated
 */
 export function dasherize(str: string): string {
   return STRING_DASHERIZE_CACHE.get(str);
@@ -206,6 +210,7 @@ export function dasherize(str: string): string {
   @param {String} str The string to camelize.
   @return {String} the camelized string.
   @public
+  @deprecated
 */
 export function camelize(str: string): string {
   return CAMELIZE_CACHE.get(str);
@@ -228,6 +233,7 @@ export function camelize(str: string): string {
   @param {String} str the string to classify
   @return {String} the classified string
   @public
+  @deprecated
 */
 export function classify(str: string): string {
   return CLASSIFY_CACHE.get(str);
@@ -251,6 +257,7 @@ export function classify(str: string): string {
   @param {String} str The string to underscore.
   @return {String} the underscored string.
   @public
+  @deprecated
 */
 export function underscore(str: string): string {
   return UNDERSCORE_CACHE.get(str);
@@ -273,6 +280,7 @@ export function underscore(str: string): string {
   @param {String} str The string to capitalize.
   @return {String} The capitalized string.
   @public
+  @deprecated
 */
 export function capitalize(str: string): string {
   return CAPITALIZE_CACHE.get(str);
@@ -287,6 +295,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
       @for @ember/string
       @static
       @private
+      @deprecated
     */
     w: {
       configurable: true,
@@ -304,6 +313,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
       @for @ember/string
       @static
       @private
+      @deprecated
     */
     loc: {
       configurable: true,
@@ -321,6 +331,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
       @for @ember/string
       @static
       @private
+      @deprecated
     */
     camelize: {
       configurable: true,
@@ -338,6 +349,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
       @for @ember/string
       @static
       @private
+      @deprecated
     */
     decamelize: {
       configurable: true,
@@ -355,6 +367,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
       @for @ember/string
       @static
       @private
+      @deprecated
     */
     dasherize: {
       configurable: true,
@@ -372,6 +385,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
       @for @ember/string
       @static
       @private
+      @deprecated
     */
     underscore: {
       configurable: true,
@@ -389,6 +403,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
       @for @ember/string
       @static
       @private
+      @deprecated
     */
     classify: {
       configurable: true,
@@ -406,6 +421,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
       @for @ember/string
       @static
       @private
+      @deprecated
     */
     capitalize: {
       configurable: true,

--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -373,16 +373,34 @@ if (LOGGER) {
 
 // ****@ember/-internals/runtime****
 Ember.A = A;
+
+function deprecateStringNamespace(fn) {
+  return function() {
+    deprecate(
+      `Importing ${fn.name} \`@ember/string\` without the addon installed is deprecated`,
+      false,
+      {
+        id: 'ember-string.namespace',
+        until: '4.0.0',
+        url: 'https://deprecations.emberjs.com/v3.x#toc_ember-string-namespace',
+      }
+    );
+
+    fn(...arguments);
+  };
+}
+
 Ember.String = {
-  loc,
-  w,
-  dasherize,
-  decamelize,
-  camelize,
-  classify,
-  underscore,
-  capitalize,
+  loc: deprecateStringNamespace(loc),
+  w: deprecateStringNamespace(w),
+  dasherize: deprecateStringNamespace(dasherize),
+  decamelize: deprecateStringNamespace(decamelize),
+  camelize: deprecateStringNamespace(camelize),
+  classify: deprecateStringNamespace(classify),
+  underscore: deprecateStringNamespace(underscore),
+  capitalize: deprecateStringNamespace(capitalize),
 };
+
 Ember.Object = EmberObject;
 Ember._RegistryProxyMixin = RegistryProxyMixin;
 Ember._ContainerProxyMixin = ContainerProxyMixin;
@@ -544,11 +562,30 @@ Ember.HTMLBars = {
 
 if (ENV.EXTEND_PROTOTYPES.String) {
   String.prototype.htmlSafe = function() {
+    deprecate(
+      'Using string extensions is deprecated, please import htmlSafe from `@ember/template` instead.',
+      false,
+      {
+        id: 'ember-string.prototype_extensions',
+        until: '4.0.0',
+        url: 'https://deprecations.emberjs.com/v3.x#toc_ember-string-prototype_extensions',
+      }
+    );
+
     return htmlSafe(this);
   };
 }
-Ember.String.htmlSafe = htmlSafe;
-Ember.String.isHTMLSafe = isHTMLSafe;
+function deprecateStringHTMLSafe(fn, ...args) {
+  deprecate('This is deprecated, please import utilities from `@ember/template` instead.', false, {
+    id: 'ember-string.html_safe',
+    until: '4.0.0',
+    url: 'https://deprecations.emberjs.com/v3.x#toc_ember-string-html_safe',
+  });
+
+  fn(...args);
+}
+Ember.String.htmlSafe = deprecateStringHTMLSafe(htmlSafe);
+Ember.String.isHTMLSafe = deprecateStringHTMLSafe(isHTMLSafe);
 
 /**
   Global hash of shared templates. This will automatically be populated

--- a/packages/internal-test-helpers/lib/ember-dev/setup-qunit.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/setup-qunit.ts
@@ -45,7 +45,7 @@ export default function setupQUnit() {
 
       callback(hooks);
     });
-  };
+  } as typeof QUnit.module;
 
   QUnit.assert.rejects = async function(
     promise: Promise<any>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3989,7 +3989,7 @@ estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
   integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
 
-estree-walker@^0.6.1:
+estree-walker@^0.6.0, estree-walker@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
   integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
@@ -5470,7 +5470,7 @@ is-promise@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
   integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
 
-is-reference@^1.1.0, is-reference@^1.1.2:
+is-reference@^1.1.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.1.4.tgz#3f95849886ddb70256a3e6d062b1a68c13c51427"
   integrity sha512-uJA/CDPO3Tao3GTrxYn6AwkM4nUPJiGGYu5+cB8qbC7WGFlrKZbiRo7SFKxUAEpFUfiHofWCXBUNhvYJMh+6zw==
@@ -7867,7 +7867,7 @@ resolve@1.9.0:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.16.1, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
+resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.16.1, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.16.1.tgz#49fac5d8bacf1fd53f200fa51247ae736175832c"
   integrity sha512-rmAglCSqWWMrrBv/XM6sW0NuRFiKViw/W4d9EbC4pt+49H8JwHy+mcGmALTEg504AUDcLTvb1T2q3E9AnmY+ig==
@@ -7927,16 +7927,15 @@ rimraf@~2.5.2:
   dependencies:
     glob "^7.0.5"
 
-rollup-plugin-commonjs@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.1.0.tgz#417af3b54503878e084d127adf4d1caf8beb86fb"
-  integrity sha512-jlXbjZSQg8EIeAAvepNwhJj++qJWNJw1Cl0YnOqKtP5Djx+fFGkp3WRh+W0ASCaFG5w1jhmzDxgu3SJuVxPF4Q==
+rollup-plugin-commonjs@^9.3.4:
+  version "9.3.4"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.3.4.tgz#2b3dddbbbded83d45c36ff101cdd29e924fd23bc"
+  integrity sha512-DTZOvRoiVIHHLFBCL4pFxOaJt8pagxsVldEXBOn6wl3/V21wVaj17HFfyzTsQUuou3sZL3lEJZVWKPFblJfI6w==
   dependencies:
-    estree-walker "^0.6.1"
-    is-reference "^1.1.2"
+    estree-walker "^0.6.0"
     magic-string "^0.25.2"
-    resolve "^1.11.0"
-    rollup-pluginutils "^2.8.1"
+    resolve "^1.10.0"
+    rollup-pluginutils "^2.6.0"
 
 rollup-plugin-node-resolve@^4.2.4:
   version "4.2.4"
@@ -7948,7 +7947,7 @@ rollup-plugin-node-resolve@^4.2.4:
     is-module "^1.0.0"
     resolve "^1.10.0"
 
-rollup-pluginutils@^2.0.1, rollup-pluginutils@^2.8.1:
+rollup-pluginutils@^2.0.1, rollup-pluginutils@^2.6.0:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
   integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7867,7 +7867,7 @@ resolve@1.9.0:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.16.1, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
+resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.16.1, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.16.1.tgz#49fac5d8bacf1fd53f200fa51247ae736175832c"
   integrity sha512-rmAglCSqWWMrrBv/XM6sW0NuRFiKViw/W4d9EbC4pt+49H8JwHy+mcGmALTEg504AUDcLTvb1T2q3E9AnmY+ig==


### PR DESCRIPTION
## Tasks

The following tasks should have their own deprecation ids, IMO.
At first I was trying to put it all in the same deprecation guide, but it soon turned out to be too confusing.

- [ ] Deprecate `String.prototype` extensions