### PR TITLE
Prepare for tsc update

### DIFF
--- a/packages/internal-test-helpers/lib/ember-dev/setup-qunit.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/setup-qunit.ts
@@ -45,7 +45,7 @@ export default function setupQUnit() {
 
       callback(hooks);
     });
-  };
+  } as typeof QUnit.module;
 
   QUnit.assert.rejects = async function(
     promise: Promise<any>,


### PR DESCRIPTION
If I don't do the type casting here, it complains about the missing `QUnit.module.only`. Since these are node tests and I'm pretty sure`QUnit.module.only` has been broken for many moons, and I took a look at the internals of QUnit and got scared, I believe the casting is sufficient here.
This was motivated by this being one of the failing tests after the dependabot PRs were merged, so I'm preempting the fix.