### PR TITLE
[BUGFIX beta] Add error for modifier manager without capabilities.

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/modifiers/custom.ts
+++ b/packages/@ember/-internals/glimmer/lib/modifiers/custom.ts
@@ -141,6 +141,12 @@ class InteractiveCustomModifierManager<ModifierInstance>
 
   install(state: CustomModifierState<ModifierInstance>) {
     let { element, args, delegate, modifier, tag } = state;
+
+    assert(
+      'Custom modifier managers must define their capabilities using the capabilities() helper function',
+      typeof delegate.capabilities === 'object' && delegate.capabilities !== null
+    );
+
     let { capabilities } = delegate;
 
     if (capabilities.disableAutoTracking === true) {

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
@@ -36,6 +36,24 @@ class CustomModifierManager {
 moduleFor(
   'Basic Custom Modifier Manager',
   class extends ModifierManagerTest {
+    '@test throws a useful error when missing capabilities'() {
+      this.registerModifier(
+        'foo-bar',
+        setModifierManager(() => {
+          return {
+            createModifier() {},
+            installModifier() {},
+            updateModifier() {},
+            destroyModifier() {},
+          };
+        }, {})
+      );
+
+      expectAssertion(() => {
+        this.render('<h1 {{foo-bar}}>hello world</h1>');
+      }, /Custom modifier managers must define their capabilities/);
+    }
+
     '@test can register a custom element modifier and render it'(assert) {
       let ModifierClass = setModifierManager(
         owner => {


### PR DESCRIPTION
Now that the deprecation is removed (in 3.19.0-beta.1) folks that were previously getting the deprecation would get a very bizarre error:

```
Cannot read property 'disableAutoTracking' of undefined
```

This adds a much more helpful assertion.
