### PR TITLE
Update deprecation for `{{-in-element}}` to be until: 3.25.0.

### DIFF
--- a/packages/ember-template-compiler/lib/plugins/transform-in-element.ts
+++ b/packages/ember-template-compiler/lib/plugins/transform-in-element.ts
@@ -77,7 +77,7 @@ export default function transformInElement(env: ASTPluginEnvironment): ASTPlugin
               false,
               {
                 id: 'glimmer.private-in-element',
-                until: '4.0.0',
+                until: '3.25.0',
               }
             );
           }


### PR DESCRIPTION
We can always delay removal until the community has fully migrated, but having the deprecation be through two LTS (master will be 3.20, then another LTS in 3.24) is more than enough for a private API.

/cc @simonihmig @chancancode