### PR TITLE
Remove JSBin from the list of recommended issue reproduction tools.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,10 +24,9 @@ fixed your bug.
 2. Search for similar issues. It's possible somebody has encountered
 this bug already.
 
-3. Provide Ember Twiddle or JSBin demo that specifically shows the problem. This
-demo should be fully operational with the exception of the bug you want to
-demonstrate. The more pared down, the better.
-preconfigured starting points for the latest Ember: [Ember Twiddle](http://ember-twiddle.com/) | [JSBin](http://emberjs.jsbin.com) (may not work with older IE versions due to MIME type issues).
+3. Provide [Ember Twiddle](http://ember-twiddle.com/) demo that specifically
+shows the problem. This demo should be fully operational with the exception
+of the bug you want to demonstrate. The more pared down, the better.
 If it is not possible to produce a fiddle, please make sure you provide very
 specific steps to reproduce the error. If we cannot reproduce it, we will
 close the ticket.


### PR DESCRIPTION
Removes [JSBin](http://emberjs.jsbin.com) from the list of recommended issue reproduction tools since Ember does not support the `<script>` tag anymore.

Addresses https://github.com/emberjs/ember.js/issues/18460.