### PR TITLE
Reduce dependabot frequency

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,13 @@
+# Create Pull-Requests for NPM updates automatically
+# https://dependabot.com/docs/config-file/
+
+version: 1
+update_configs:
+  # Keep package.json (& lockfiles) up to date.
+  #
+  # Security updates will be created immediately,
+  # other updates monthly, to cut down on repo noise.
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "monthly"
+    


### PR DESCRIPTION
Running dependabot too often creates a lot of noise in the commit logs, making it nearly useless to track actual progress.

Running it less often would reduce this problem (security updates still running immediately).

![image](https://user-images.githubusercontent.com/122287/82212745-56eca880-9913-11ea-8315-6cfcf0fe1708.png)


*I proposed something similar for Ember Data: https://github.com/emberjs/data/pull/7195*