### PR TITLE
[BUGFIX LTS] invoke methods correctly in TextSupport sendAction

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/input-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/input-angle-test.js
@@ -1,5 +1,6 @@
 import { RenderingTestCase, moduleFor, runDestroy, runTask } from 'internal-test-helpers';
 
+import { action } from '@ember/object';
 import { assign } from '@ember/polyfills';
 import { set } from '@ember/-internals/metal';
 import { jQueryDisabled, jQuery } from '@ember/-internals/views';
@@ -779,6 +780,16 @@ moduleFor(
 
     ['@test sends an action with `<Input EVENT={{action "foo"}} />` for native DOM events']() {
       this.assertTriggersNativeDOMEvents();
+    }
+
+    ['@test triggers a method with `<Input @key-up={{this.didTrigger}} />`'](assert) {
+      this.render(`<Input @key-up={{this.didTrigger}} />`, {
+        didTrigger: action(function() {
+          assert.ok(true, 'action was triggered');
+        }),
+      });
+
+      this.triggerEvent('keyup', { keyCode: 65 });
     }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/input-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/input-curly-test.js
@@ -1,5 +1,6 @@
 import { RenderingTestCase, moduleFor, runDestroy, runTask } from 'internal-test-helpers';
 
+import { action } from '@ember/object';
 import { assign } from '@ember/polyfills';
 import { set } from '@ember/-internals/metal';
 import { jQueryDisabled, jQuery } from '@ember/-internals/views';
@@ -630,6 +631,16 @@ moduleFor(
 
     ['@test sends an action with `{{input EVENT=(action "foo")}}` for native DOM events']() {
       this.assertTriggersNativeDOMEvents();
+    }
+
+    ['@test triggers a method with `{{input key-up=this.didTrigger}}`'](assert) {
+      this.render(`{{input key-up=this.didTrigger}}`, {
+        didTrigger: action(function() {
+          assert.ok(true, 'action was triggered');
+        }),
+      });
+
+      this.triggerEvent('keyup', { keyCode: 65 });
     }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/textarea-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/textarea-angle-test.js
@@ -1,5 +1,6 @@
 import { RenderingTestCase, moduleFor, classes, applyMixins, runTask } from 'internal-test-helpers';
 
+import { action } from '@ember/object';
 import { assign } from '@ember/polyfills';
 import { set } from '@ember/-internals/metal';
 
@@ -208,6 +209,16 @@ moduleFor(
 
       runTask(() => set(this.context, 'model', { val: 'A beautiful day in Seattle' }));
       this.assertTextArea({ value: 'A beautiful day in Seattle' });
+    }
+
+    ['@test triggers a method with `<Textarea @key-up={{this.didTrigger}} />`'](assert) {
+      this.render(`<Textarea @key-up={{this.didTrigger}} />`, {
+        didTrigger: action(function() {
+          assert.ok(true, 'action was triggered');
+        }),
+      });
+
+      this.triggerEvent('keyup', { keyCode: 65 });
     }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/textarea-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/textarea-curly-test.js
@@ -1,5 +1,6 @@
 import { RenderingTestCase, moduleFor, classes, applyMixins, runTask } from 'internal-test-helpers';
 
+import { action } from '@ember/object';
 import { assign } from '@ember/polyfills';
 import { set } from '@ember/-internals/metal';
 
@@ -160,6 +161,16 @@ moduleFor(
 
       runTask(() => set(this.context, 'model', { val: 'A beautiful day in Seattle' }));
       this.assertTextArea({ value: 'A beautiful day in Seattle' });
+    }
+
+    ['@test triggers a method with `{{textarea key-up=this.didTrigger}}`'](assert) {
+      this.render(`{{textarea key-up=this.didTrigger}}`, {
+        didTrigger: action(function() {
+          assert.ok(true, 'action was triggered');
+        }),
+      });
+
+      this.triggerEvent('keyup', { keyCode: 65 });
     }
   }
 );


### PR DESCRIPTION
The introduction of the `attrs` API in Ember 3.13 included wrapping items passed to components with `MutableCell`, to support two-way binding. Although two-way binding is gone from much of Ember, the text input components (`Input` and `Textarea`) continue to support it, via the `TextSupport` mixins. The `sendAction` function used by the mixin previously assumed that the only options were for an action to be a string or a function -- not a function wrapped in a `MutableCell`.

The result was that this code, which would be expected to work, did not: it would simply never be invoked.

```hbs
<Textarea @focus-in={{this.didFocusIn}} />
```

Accordingly, add logic to `sendAction` in `text_support.js` to unwrap a mutable cell if it is set, and otherwise to carry on with the logic as it was previously.

Backports the fix for #18994 (f16d1747) to 3.16 LTS.