### PR TITLE
[BUGFIX lts] dont access properties during init unless required

### DIFF
--- a/packages/@ember/-internals/runtime/lib/system/core_object.js
+++ b/packages/@ember/-internals/runtime/lib/system/core_object.js
@@ -102,9 +102,8 @@ function initialize(obj, properties) {
       let isDescriptor = possibleDesc !== undefined;
 
       if (!isDescriptor) {
-        let baseValue = obj[keyName];
-
         if (hasConcatenatedProps && concatenatedProperties.indexOf(keyName) > -1) {
+          let baseValue = obj[keyName];
           if (baseValue) {
             value = makeArray(baseValue).concat(value);
           } else {
@@ -113,6 +112,7 @@ function initialize(obj, properties) {
         }
 
         if (hasMergedProps && mergedProperties.indexOf(keyName) > -1) {
+          let baseValue = obj[keyName];
           value = assign({}, baseValue, value);
         }
       }

--- a/packages/@ember/-internals/runtime/tests/system/core_object_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/core_object_test.js
@@ -2,6 +2,7 @@ import { getOwner, setOwner } from '@ember/-internals/owner';
 import { get, set, observer } from '@ember/-internals/metal';
 import CoreObject from '../../lib/system/core_object';
 import { moduleFor, AbstractTestCase, buildOwner, runLoopSettled } from 'internal-test-helpers';
+import { track } from '@glimmer/validator';
 
 moduleFor(
   'Ember.CoreObject',
@@ -131,6 +132,25 @@ moduleFor(
       assert.equal(callCount, 1);
 
       test.destroy();
+    }
+
+    ['@test native getters/setters do not cause rendering invalidation during init'](assert) {
+      let objectMeta = Object.create(null);
+
+      class TestObject extends CoreObject {
+        get hiddenValue() {
+          let v = get(objectMeta, 'hiddenValue');
+          return v !== undefined ? v : false;
+        }
+        set hiddenValue(v) {
+          set(objectMeta, 'hiddenValue', v);
+        }
+      }
+
+      track(() => {
+        TestObject.create({ hiddenValue: true });
+        assert.ok(true, 'We did not error');
+      });
     }
   }
 );


### PR DESCRIPTION
Previously we were greedily accessing properties during init in all cases if a value for the property was passed into create. In the case of native getters/setters this could lead to rendering invalidations if initialization was triggered during render since the value would immediately change after access.

This possibly supplants #19009 and may fix if so #19003 but more investigation should be done to confirm that.