### PR TITLE
[BUG]: DEBUG mode does not set property on tracked, previous accessed obj

### DIFF
--- a/packages/@ember/-internals/utils/lib/mandatory-setter.ts
+++ b/packages/@ember/-internals/utils/lib/mandatory-setter.ts
@@ -129,8 +129,8 @@ if (DEBUG) {
           Object.defineProperty(obj, keyName, desc!);
         }
       }
-    } else {
-      obj[keyName] = value;
     }
+
+    obj[keyName] = value;
   };
 }


### PR DESCRIPTION
In DEBUG mode, an update to a tracked `obj` previous set on `MANDATORY_SETTERS` WeakMap is not applied.  This fixes the issue in the PR below but breaks everything else :(

- [ ] test

ref https://github.com/poteto/ember-changeset/pull/516