### PR TITLE
Minor fix for Tom Dale's missplelled name in code examples documentation

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/helpers/array.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/array.ts
@@ -11,7 +11,7 @@ import { PathReference } from '@glimmer/reference';
 
    ```handlebars
    <MyComponent @people={{array
-     'Tom Dade'
+     'Tom Dale'
      'Yehuda Katz'
      this.myOtherPerson}}
    />
@@ -19,7 +19,7 @@ import { PathReference } from '@glimmer/reference';
     or
    ```handlebars
    {{my-component people=(array
-     'Tom Dade'
+     'Tom Dale'
      'Yehuda Katz'
      this.myOtherPerson)
    }}
@@ -28,7 +28,7 @@ import { PathReference } from '@glimmer/reference';
    Would result in an object such as:
 
    ```js
-   ['Tom Date', 'Yehuda Katz', this.get('myOtherPerson')]
+   ['Tom Dale', 'Yehuda Katz', this.get('myOtherPerson')]
    ```
 
    Where the 3rd item in the array is bound to updates of the `myOtherPerson` property.


### PR DESCRIPTION
Current documentation: 

<img width="785" alt="Screenshot 2020-07-17 at 08 19 31" src="https://user-images.githubusercontent.com/12375430/88174827-88029580-cc42-11ea-9738-589d422336aa.png">

