### PR TITLE
Remove `_viewRegistry` injection to `view`

### DIFF
--- a/packages/@ember/application/tests/application_test.js
+++ b/packages/@ember/application/tests/application_test.js
@@ -129,7 +129,6 @@ moduleFor(
 
       verifyRegistration(assert, application, 'controller:basic');
       verifyRegistration(assert, application, '-view-registry:main');
-      verifyInjection(assert, application, 'view', '_viewRegistry', '-view-registry:main');
       verifyInjection(assert, application, 'route', '_topLevelViewTemplate', 'template:-outlet');
       verifyRegistration(assert, application, 'route:basic');
       verifyRegistration(assert, application, 'event_dispatcher:main');

--- a/packages/@ember/engine/index.js
+++ b/packages/@ember/engine/index.js
@@ -495,7 +495,6 @@ function commonSetupRegistry(registry) {
 
   registry.register('controller:basic', Controller, { instantiate: false });
 
-  registry.injection('view', '_viewRegistry', '-view-registry:main');
   registry.injection('renderer', '_viewRegistry', '-view-registry:main');
 
   registry.injection('route', '_topLevelViewTemplate', 'template:-outlet');

--- a/packages/@ember/engine/tests/engine_test.js
+++ b/packages/@ember/engine/tests/engine_test.js
@@ -62,7 +62,6 @@ moduleFor(
         `optionsForType 'view'`
       );
       verifyRegistration(assert, engine, 'controller:basic');
-      verifyInjection(assert, engine, 'view', '_viewRegistry', '-view-registry:main');
       verifyInjection(assert, engine, 'renderer', '_viewRegistry', '-view-registry:main');
       verifyInjection(assert, engine, 'route', '_topLevelViewTemplate', 'template:-outlet');
       verifyInjection(assert, engine, 'view:-outlet', 'namespace', 'application:main');

--- a/packages/internal-test-helpers/lib/test-cases/rendering.js
+++ b/packages/internal-test-helpers/lib/test-cases/rendering.js
@@ -25,7 +25,6 @@ export default class RenderingTestCase extends AbstractTestCase {
     owner.register('event_dispatcher:main', EventDispatcher);
 
     // TODO: why didn't buildOwner do this for us?
-    owner.inject('view', '_viewRegistry', '-view-registry:main');
     owner.inject('renderer', '_viewRegistry', '-view-registry:main');
 
     this.renderer = this.owner.lookup('renderer:-dom');


### PR DESCRIPTION
looks like legacy code that used in `view` internals before https://github.com/emberjs/ember.js/blob/fef509a5f33c7a4cc708a95951073f5346e37a32/packages/ember-views/lib/views/view.js#L1309-L1310