### PR TITLE
[CLEANUP] remove dependence on `component.elementId` in `ViewRegistry`

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/renderer.ts
@@ -246,13 +246,9 @@ function loopEnd() {
 backburner.on('begin', loopBegin);
 backburner.on('end', loopEnd);
 
-interface ViewRegistry {
-  [viewId: string]: unknown;
-}
-
 export abstract class Renderer {
   private _rootTemplate: OwnedTemplate;
-  private _viewRegistry: ViewRegistry;
+  private _viewRegistry: Set<Component>;
   private _destinedForDOM: boolean;
   private _roots: RootState[];
   private _removedRoots: RootState[];
@@ -346,16 +342,11 @@ export abstract class Renderer {
   }
 
   register(view: any) {
-    let id = getViewId(view);
-    assert(
-      'Attempted to register a view with an id already in use: ' + id,
-      !this._viewRegistry[id]
-    );
-    this._viewRegistry[id] = view;
+    this._viewRegistry.add(view);
   }
 
   unregister(view: any) {
-    delete this._viewRegistry[getViewId(view)];
+    this._viewRegistry.delete(view);
   }
 
   remove(view: Component) {

--- a/packages/@ember/-internals/glimmer/lib/utils/curly-component-state-bucket.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/curly-component-state-bucket.ts
@@ -1,4 +1,9 @@
-import { clearElementView, clearViewElement, getViewElement } from '@ember/-internals/views';
+import {
+  clearElementView,
+  clearViewElement,
+  getViewElement,
+  removeChildView,
+} from '@ember/-internals/views';
 import { CapturedNamedArguments } from '@glimmer/interfaces';
 import { ComponentRootReference, VersionedReference } from '@glimmer/reference';
 import { Revision, valueForTag } from '@glimmer/validator';
@@ -22,6 +27,7 @@ export interface Component {
   destroy(): void;
   setProperties(props: { [key: string]: any }): void;
   renderer: Renderer;
+  parentView: Component;
 }
 
 type Finalizer = () => void;
@@ -70,6 +76,7 @@ export default class ComponentStateBucket {
       }
     }
 
+    removeChildView(component.parentView, component);
     component.renderer.unregister(component);
   }
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/life-cycle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/life-cycle-test.js
@@ -66,11 +66,15 @@ class LifeCycleHooksTest extends RenderingTestCase {
   }
 
   assertRegisteredViews(label) {
-    let viewRegistry = this.viewRegistry;
-    let topLevelId = getViewId(this.component);
-    let actual = Object.keys(viewRegistry)
-      .sort()
-      .filter(id => id !== topLevelId);
+    let { viewRegistry, component } = this;
+    let actual = [];
+    viewRegistry.forEach(function(view) {
+      if (component !== view) {
+        actual.push(getViewId(view));
+      }
+    });
+
+    actual.sort();
 
     if (this.isInteractive) {
       let expected = this.componentRegistry.sort();

--- a/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
@@ -2,6 +2,7 @@ import { moduleFor, ApplicationTestCase, RenderingTestCase, runTask } from 'inte
 
 import Controller from '@ember/controller';
 import {
+  getViewId,
   getRootViews,
   getChildViews,
   getViewBounds,
@@ -254,7 +255,12 @@ moduleFor(
     viewFor(id) {
       let owner = this.applicationInstance;
       let registry = owner.lookup('-view-registry:main');
-      return registry[id];
+
+      for (let view of registry) {
+        if (getViewId(view) === id) {
+          return view;
+        }
+      }
     }
   }
 );

--- a/packages/@ember/-internals/views/index.d.ts
+++ b/packages/@ember/-internals/views/index.d.ts
@@ -30,6 +30,7 @@ export function clearElementView(element: SimpleElement): void;
 export function clearViewElement(view: unknown): void;
 
 export function addChildView(parent: unknown, child: unknown): void;
+export function removeChildView(parent: unknown, child: unknown): void;
 
 export function isSimpleClick(event: Event): boolean;
 

--- a/packages/@ember/-internals/views/index.js
+++ b/packages/@ember/-internals/views/index.js
@@ -1,6 +1,7 @@
 export { jQuery, jQueryDisabled } from './lib/system/jquery';
 export {
   addChildView,
+  removeChildView,
   isSimpleClick,
   getViewBounds,
   getViewClientRects,

--- a/packages/@ember/application/lib/application.js
+++ b/packages/@ember/application/lib/application.js
@@ -2,7 +2,6 @@
 @module @ember/application
 */
 
-import { dictionary } from '@ember/-internals/utils';
 import { ENV } from '@ember/-internals/environment';
 import { hasDOM } from '@ember/-internals/browser-environment';
 import { assert, isTesting } from '@ember/debug';
@@ -1146,7 +1145,7 @@ function commonSetupRegistry(registry) {
   registry.register('router:main', Router.extend());
   registry.register('-view-registry:main', {
     create() {
-      return dictionary(null);
+      return new Set();
     },
   });
 

--- a/packages/internal-test-helpers/lib/test-cases/rendering.js
+++ b/packages/internal-test-helpers/lib/test-cases/rendering.js
@@ -21,7 +21,7 @@ export default class RenderingTestCase extends AbstractTestCase {
       bootOptions,
     }));
 
-    owner.register('-view-registry:main', Object.create(null), { instantiate: false });
+    owner.register('-view-registry:main', new Set(), { instantiate: false });
     owner.register('event_dispatcher:main', EventDispatcher);
 
     // TODO: why didn't buildOwner do this for us?

--- a/tests/node/visit-test.js
+++ b/tests/node/visit-test.js
@@ -308,7 +308,7 @@ QUnit.module('Ember.Application - visit() Integration Tests', function(hooks) {
       return App.visit(url, { isBrowser: false, shouldRender: false }).then(function(instance) {
         try {
           let viewRegistry = instance.lookup('-view-registry:main');
-          assert.strictEqual(Object.keys(viewRegistry).length, 0, 'did not create any views');
+          assert.strictEqual(viewRegistry.size, 0, 'did not create any views');
 
           let networkService = instance.lookup('service:network');
           assert.deepEqual(networkService.get('requests'), resources);


### PR DESCRIPTION
Using`Set` for `ViewRegistry` to simplify things, and remove dependence on `component.elementId` and `component guid`.
As a side-effect it enables registering components with duplicate `elementId`s (unsure if it is good or bad thing), at least for template-only components you can use duplicate ids currently.