### PR TITLE
[BUGFIX lts] Prevent `<base target="_parent">` from erroring in HistoryLocation

### DIFF
--- a/packages/@ember/-internals/routing/lib/location/history_location.ts
+++ b/packages/@ember/-internals/routing/lib/location/history_location.ts
@@ -77,7 +77,7 @@ export default class HistoryLocation extends EmberObject implements EmberLocatio
 
     let base = document.querySelector('base');
     let baseURL: string | null = '';
-    if (base) {
+    if (base !== null && base.hasAttribute('href')) {
       baseURL = base.getAttribute('href');
     }
 

--- a/packages/@ember/-internals/routing/tests/location/history_location_test.js
+++ b/packages/@ember/-internals/routing/tests/location/history_location_test.js
@@ -97,6 +97,42 @@ moduleFor(
       location.initState();
     }
 
+    ['@test <base> with href sets `baseURL`'](assert) {
+      assert.expect(1);
+
+      let base = document.createElement('base');
+      base.setAttribute('href', '/foo/');
+
+      document.head.appendChild(base);
+
+      try {
+        createLocation();
+        location.initState();
+
+        assert.strictEqual(location.get('baseURL'), '/foo/');
+      } finally {
+        document.head.removeChild(base);
+      }
+    }
+
+    ['@test <base> without href is ignored'](assert) {
+      assert.expect(1);
+
+      let base = document.createElement('base');
+      base.setAttribute('target', '_parent');
+
+      document.head.appendChild(base);
+
+      try {
+        createLocation();
+        location.initState();
+
+        assert.strictEqual(location.get('baseURL'), '');
+      } finally {
+        document.head.removeChild(base);
+      }
+    }
+
     ['@test base URL is removed when retrieving the current pathname'](assert) {
       assert.expect(1);
 


### PR DESCRIPTION
It is perfectly valid to have a `<base>` element without an `href` attribute but the code previously assumed that if a `<base>` was present that it **must** contain an `href`.

Specifically, prior to this change if you had a `<base>` like:

```html
<base target="_parent">
```

You would get the following error:

```
Uncaught TypeError: Cannot read property 'replace' of null
```

See [<base> on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base) for more details on usage of `<base>` without an `href`.

Fixes #19038