### PR TITLE
[DOC release] fix missing docs for in-element

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/syntax/in-element.ts
+++ b/packages/@ember/-internals/glimmer/lib/syntax/in-element.ts
@@ -30,8 +30,6 @@
  `destinationElement`. Passing `null` changes the behaviour to appended at the end
  of any existing content. Any other value than `null` is currently not supported.
 
- ```
-
  @method in-element
  @for Ember.Templates.helpers
  @public

--- a/tests/docs/expected.js
+++ b/tests/docs/expected.js
@@ -276,6 +276,7 @@ module.exports = {
     'href',
     'htmlSafe',
     'if',
+    'in-element',
     'includes',
     'incrementProperty',
     'indexOf',


### PR DESCRIPTION
The new API docs for in-element did not render in the API docs viewer due to some stray triple backticks.