### PR TITLE
[CLEANUP] remove some internal usage `view-registry`

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/component-managers/curly.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/curly.ts
@@ -2,7 +2,7 @@ import { privatize as P } from '@ember/-internals/container';
 import { ENV } from '@ember/-internals/environment';
 import { getOwner } from '@ember/-internals/owner';
 import { guidFor } from '@ember/-internals/utils';
-import { addChildView, setElementView, setViewElement } from '@ember/-internals/views';
+import { setElementView, setViewElement } from '@ember/-internals/views';
 import { assert, debugFreeze } from '@ember/debug';
 import { EMBER_COMPONENT_IS_VISIBLE } from '@ember/deprecated-features';
 import { _instrumentStart } from '@ember/instrumentation';
@@ -307,12 +307,6 @@ export default class CurlyComponentManager
     // We become the new parentView for downstream components, so save our
     // component off on the dynamic scope.
     dynamicScope.view = component;
-
-    // Unless we're the root component, we need to add ourselves to our parent
-    // component's childViews array.
-    if (parentView !== null && parentView !== undefined) {
-      addChildView(parentView, component);
-    }
 
     component.trigger('didReceiveAttrs');
 

--- a/packages/@ember/-internals/glimmer/lib/renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/renderer.ts
@@ -1,5 +1,6 @@
 import { ENV } from '@ember/-internals/environment';
 import { getOwner, Owner } from '@ember/-internals/owner';
+import { guidFor } from '@ember/-internals/utils';
 import { getViewElement, OwnedTemplateMeta } from '@ember/-internals/views';
 import { assert } from '@ember/debug';
 import { backburner, getCurrentRunLoop } from '@ember/runloop';
@@ -98,6 +99,7 @@ class RootState {
       template !== undefined
     );
 
+    this.id = guidFor(root);
     this.result = undefined;
     this.destroyed = false;
 

--- a/packages/@ember/-internals/glimmer/lib/utils/curly-component-state-bucket.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/curly-component-state-bucket.ts
@@ -1,4 +1,9 @@
-import { clearElementView, clearViewElement, getViewElement } from '@ember/-internals/views';
+import {
+  clearElementView,
+  clearViewElement,
+  getViewElement,
+  unregisterView,
+} from '@ember/-internals/views';
 import { CapturedNamedArguments } from '@glimmer/interfaces';
 import { createConstRef, Reference } from '@glimmer/reference';
 import { registerDestructor } from '@glimmer/runtime';
@@ -77,7 +82,7 @@ export default class ComponentStateBucket {
       }
     }
 
-    component.renderer.unregister(component);
+    unregisterView(component);
   }
 
   finalize() {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/life-cycle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/life-cycle-test.js
@@ -10,7 +10,7 @@ import {
 import { schedule } from '@ember/runloop';
 import { set, setProperties } from '@ember/-internals/metal';
 import { A as emberA } from '@ember/-internals/runtime';
-import { getViewId, getViewElement, jQueryDisabled } from '@ember/-internals/views';
+import { getViewId, getViewElement, jQueryDisabled, VIEW_REGISTRY } from '@ember/-internals/views';
 import { tryInvoke } from '@ember/-internals/utils';
 
 import { Component } from '../../utils/helpers';
@@ -22,7 +22,7 @@ class LifeCycleHooksTest extends RenderingTestCase {
     this.components = {};
     this.componentRegistry = [];
     this.teardownAssertions = [];
-    this.viewRegistry = this.owner.lookup('-view-registry:main');
+    this.viewRegistry = VIEW_REGISTRY;
   }
 
   afterEach() {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
@@ -3,6 +3,7 @@ import { moduleFor, ApplicationTestCase, RenderingTestCase, runTask } from 'inte
 import Controller from '@ember/controller';
 import {
   getRootViews,
+  VIEW_REGISTRY,
   getChildViews,
   getViewBounds,
   getViewClientRects,
@@ -252,9 +253,7 @@ moduleFor(
     }
 
     viewFor(id) {
-      let owner = this.applicationInstance;
-      let registry = owner.lookup('-view-registry:main');
-      return registry[id];
+      return VIEW_REGISTRY[id];
     }
   }
 );

--- a/packages/@ember/-internals/views/index.d.ts
+++ b/packages/@ember/-internals/views/index.d.ts
@@ -22,6 +22,7 @@ export const ViewMixin: any;
 export const ViewStateSupport: any;
 export const TextSupport: any;
 
+export const VIEW_REGISTRY: unknown;
 export function getElementView(element: SimpleElement): unknown;
 export function getViewElement(view: unknown): Option<SimpleElement>;
 export function registerView(view: unknown): Option<SimpleElement>;

--- a/packages/@ember/-internals/views/index.d.ts
+++ b/packages/@ember/-internals/views/index.d.ts
@@ -24,6 +24,8 @@ export const TextSupport: any;
 
 export function getElementView(element: SimpleElement): unknown;
 export function getViewElement(view: unknown): Option<SimpleElement>;
+export function registerView(view: unknown): Option<SimpleElement>;
+export function unregisterView(view: unknown): Option<SimpleElement>;
 export function setElementView(element: SimpleElement, view: unknown): void;
 export function setViewElement(view: unknown, element: SimpleElement): void;
 export function clearElementView(element: SimpleElement): void;

--- a/packages/@ember/-internals/views/index.js
+++ b/packages/@ember/-internals/views/index.js
@@ -1,5 +1,6 @@
 export { jQuery, jQueryDisabled } from './lib/system/jquery';
 export {
+  VIEW_REGISTRY,
   addChildView,
   isSimpleClick,
   getViewBounds,

--- a/packages/@ember/-internals/views/index.js
+++ b/packages/@ember/-internals/views/index.js
@@ -14,6 +14,8 @@ export {
   setViewElement,
   clearElementView,
   clearViewElement,
+  registerView,
+  unregisterView,
   constructStyleDeprecationMessage,
 } from './lib/system/utils';
 export { default as EventDispatcher } from './lib/system/event_dispatcher';

--- a/packages/@ember/-internals/views/lib/system/utils.ts
+++ b/packages/@ember/-internals/views/lib/system/utils.ts
@@ -39,6 +39,9 @@ interface View {
 }
 
 export function registerView(view: View) {
+  if (view.parentView !== null) {
+    addChildView(view.parentView, view);
+  }
   let owner = getOwner(view);
   let registry = owner.lookup<Dict<View>>('-view-registry:main')!;
 
@@ -48,6 +51,8 @@ export function registerView(view: View) {
 }
 
 export function unregisterView(view: View) {
+  removeChildView(view);
+
   let owner = getOwner(view);
   let registry = owner.lookup<Dict<View>>('-view-registry:main')!;
 
@@ -125,7 +130,7 @@ export function clearViewElement(view: View): void {
   VIEW_ELEMENT.delete(view);
 }
 
-const CHILD_VIEW_IDS: WeakMap<View, Set<string>> = new WeakMap();
+const CHILD_VIEWS: WeakMap<View, Set<View>> = new WeakMap();
 
 /**
   @private
@@ -133,40 +138,42 @@ const CHILD_VIEW_IDS: WeakMap<View, Set<string>> = new WeakMap();
   @param {Ember.View} view
 */
 export function getChildViews(view: View) {
-  let owner = getOwner(view);
-  let registry = owner.lookup<Dict<View>>('-view-registry:main')!;
-  return collectChildViews(view, registry);
-}
-
-export function initChildViews(view: View): Set<string> {
-  let childViews: Set<string> = new Set();
-  CHILD_VIEW_IDS.set(view, childViews);
-  return childViews;
-}
-
-export function addChildView(parent: View, child: View): void {
-  let childViews = CHILD_VIEW_IDS.get(parent);
-  if (childViews === undefined) {
-    childViews = initChildViews(parent);
-  }
-
-  childViews.add(getViewId(child));
-}
-
-export function collectChildViews(view: View, registry: Dict<View>): View[] {
   let views: View[] = [];
-  let childViews = CHILD_VIEW_IDS.get(view);
+  let childViews = CHILD_VIEWS.get(view);
 
   if (childViews !== undefined) {
-    childViews.forEach((id) => {
-      let view = registry[id];
-      if (view && !view.isDestroying && !view.isDestroyed) {
+    childViews.forEach(view => {
+      if (!view.isDestroying && !view.isDestroyed) {
         views.push(view);
       }
     });
   }
 
   return views;
+}
+
+export function initChildViews(view: View): Set<View> {
+  let childViews: Set<View> = new Set();
+  CHILD_VIEWS.set(view, childViews);
+  return childViews;
+}
+
+export function addChildView(parent: View, child: View): void {
+  let childViews = CHILD_VIEWS.get(parent);
+  if (childViews === undefined) {
+    childViews = initChildViews(parent);
+  }
+
+  childViews.add(child);
+}
+
+function removeChildView(view: View): void {
+  if (view.parentView !== null) {
+    let childViews = CHILD_VIEWS.get(view.parentView);
+    if (childViews !== undefined) {
+      childViews.delete(view);
+    }
+  }
 }
 
 /**

--- a/packages/@ember/-internals/views/lib/system/utils.ts
+++ b/packages/@ember/-internals/views/lib/system/utils.ts
@@ -38,6 +38,22 @@ interface View {
   isDestroyed: boolean;
 }
 
+export function registerView(view: View) {
+  let owner = getOwner(view);
+  let registry = owner.lookup<Dict<View>>('-view-registry:main')!;
+
+  let id = getViewId(view);
+  assert('Attempted to register a view with an id already in use: ' + id, !registry[id]);
+  registry[id] = view;
+}
+
+export function unregisterView(view: View) {
+  let owner = getOwner(view);
+  let registry = owner.lookup<Dict<View>>('-view-registry:main')!;
+
+  delete registry[getViewId(view)];
+}
+
 /**
   @private
   @method getRootViews

--- a/packages/@ember/-internals/views/lib/views/states/in_dom.js
+++ b/packages/@ember/-internals/views/lib/views/states/in_dom.js
@@ -3,12 +3,11 @@ import { assign } from '@ember/polyfills';
 import EmberError from '@ember/error';
 import { DEBUG } from '@glimmer/env';
 import hasElement from './has_element';
+import { registerView } from '@ember/-internals/views';
 
 const inDOM = assign({}, hasElement, {
   enter(view) {
-    // Register the view for event handling. This hash is used by
-    // Ember.EventDispatcher to dispatch incoming events.
-    view.renderer.register(view);
+    registerView(view);
 
     if (DEBUG) {
       let elementId = view.elementId;

--- a/packages/@ember/application/lib/application.js
+++ b/packages/@ember/application/lib/application.js
@@ -2,7 +2,6 @@
 @module @ember/application
 */
 
-import { dictionary } from '@ember/-internals/utils';
 import { ENV } from '@ember/-internals/environment';
 import { hasDOM } from '@ember/-internals/browser-environment';
 import { assert, isTesting } from '@ember/debug';
@@ -15,7 +14,7 @@ import {
 } from '@ember/-internals/metal';
 import { _loaded, runLoadHooks } from './lazy_load';
 import { RSVP } from '@ember/-internals/runtime';
-import { EventDispatcher, jQuery, jQueryDisabled } from '@ember/-internals/views';
+import { EventDispatcher, jQuery, jQueryDisabled, VIEW_REGISTRY } from '@ember/-internals/views';
 import {
   Route,
   Router,
@@ -1146,10 +1145,9 @@ function commonSetupRegistry(registry) {
   registry.register('router:main', Router);
   registry.register('-view-registry:main', {
     create() {
-      return dictionary(null);
+      return VIEW_REGISTRY;
     },
   });
-
   registry.register('route:basic', Route);
   registry.register('event_dispatcher:main', EventDispatcher);
 

--- a/packages/@ember/engine/index.js
+++ b/packages/@ember/engine/index.js
@@ -495,8 +495,6 @@ function commonSetupRegistry(registry) {
 
   registry.register('controller:basic', Controller, { instantiate: false });
 
-  registry.injection('renderer', '_viewRegistry', '-view-registry:main');
-
   registry.injection('route', '_topLevelViewTemplate', 'template:-outlet');
 
   registry.injection('view:-outlet', 'namespace', 'application:main');

--- a/packages/@ember/engine/tests/engine_test.js
+++ b/packages/@ember/engine/tests/engine_test.js
@@ -62,7 +62,6 @@ moduleFor(
         `optionsForType 'view'`
       );
       verifyRegistration(assert, engine, 'controller:basic');
-      verifyInjection(assert, engine, 'renderer', '_viewRegistry', '-view-registry:main');
       verifyInjection(assert, engine, 'route', '_topLevelViewTemplate', 'template:-outlet');
       verifyInjection(assert, engine, 'view:-outlet', 'namespace', 'application:main');
 

--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -671,6 +671,7 @@ if (JQUERY_INTEGRATION && !views.jQueryDisabled) {
 }
 
 Ember.ViewUtils = {
+  VIEW_REGISTRY: views.VIEW_REGISTRY,
   isSimpleClick: views.isSimpleClick,
   getElementView: views.getElementView,
   getViewElement: views.getViewElement,

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -237,6 +237,7 @@ let allExports = [
   ['Logger', '@ember/-internals/console', 'default'],
 
   // @ember/-internals/views
+  ['ViewUtils.VIEW_REGISTRY', '@ember/-internals/views', 'VIEW_REGISTRY'],
   ['ViewUtils.isSimpleClick', '@ember/-internals/views', 'isSimpleClick'],
   ['ViewUtils.getElementView', '@ember/-internals/views', 'getElementView'],
   ['ViewUtils.getViewElement', '@ember/-internals/views', 'getViewElement'],

--- a/packages/internal-test-helpers/lib/test-cases/rendering.js
+++ b/packages/internal-test-helpers/lib/test-cases/rendering.js
@@ -21,7 +21,6 @@ export default class RenderingTestCase extends AbstractTestCase {
       bootOptions,
     }));
 
-    owner.register('-view-registry:main', Object.create(null), { instantiate: false });
     owner.register('event_dispatcher:main', EventDispatcher);
 
     this.renderer = this.owner.lookup('renderer:-dom');

--- a/packages/internal-test-helpers/lib/test-cases/rendering.js
+++ b/packages/internal-test-helpers/lib/test-cases/rendering.js
@@ -24,9 +24,6 @@ export default class RenderingTestCase extends AbstractTestCase {
     owner.register('-view-registry:main', Object.create(null), { instantiate: false });
     owner.register('event_dispatcher:main', EventDispatcher);
 
-    // TODO: why didn't buildOwner do this for us?
-    owner.inject('renderer', '_viewRegistry', '-view-registry:main');
-
     this.renderer = this.owner.lookup('renderer:-dom');
     this.element = document.querySelector('#qunit-fixture');
     this.component = null;

--- a/tests/node/helpers/setup-app.js
+++ b/tests/node/helpers/setup-app.js
@@ -94,6 +94,7 @@ function createApplication() {
     autoboot: false,
   });
 
+  app.VIEW_REGISTRY = this.Ember.ViewUtils.VIEW_REGISTRY;
   app.Router = this.Ember.Router.extend({
     location: 'none',
   });

--- a/tests/node/visit-test.js
+++ b/tests/node/visit-test.js
@@ -307,7 +307,7 @@ QUnit.module('Ember.Application - visit() Integration Tests', function (hooks) {
     function assertResources(url, resources) {
       return App.visit(url, { isBrowser: false, shouldRender: false }).then(function (instance) {
         try {
-          let viewRegistry = instance.lookup('-view-registry:main');
+          let viewRegistry = App.VIEW_REGISTRY;
           assert.strictEqual(Object.keys(viewRegistry).length, 0, 'did not create any views');
 
           let networkService = instance.lookup('service:network');


### PR DESCRIPTION
* removed `_viewRegistry` from `renderer`
* removed usage of `view-registry` from `getChildViews`
* removed `this.owner.lookup('-view-registry:main');` internally and using `VIEW_REGISTRY` directly

Should we add deprecation for `this.owner.lookup('-view-registry:main');` ?