### PR TITLE
integration/components/life-cycle: fix removeComponent

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/life-cycle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/life-cycle-test.js
@@ -88,7 +88,7 @@ class LifeCycleHooksTest extends RenderingTestCase {
     };
 
     let removeComponent = instance => {
-      let index = this.componentRegistry.indexOf(instance);
+      let index = this.componentRegistry.indexOf(getViewId(instance));
       this.componentRegistry.splice(index, 1);
 
       delete this.components[name];


### PR DESCRIPTION
`this.componentRegistry` stores component ids not instances.