### PR TITLE
[BUGFIX release] Adds isProduction flag for the template compiler

### DIFF
--- a/packages/ember-template-compiler/lib/plugins/assert-against-named-blocks.ts
+++ b/packages/ember-template-compiler/lib/plugins/assert-against-named-blocks.ts
@@ -1,7 +1,7 @@
-import { StaticTemplateMeta } from '@ember/-internals/views';
 import { assert } from '@ember/debug';
-import { AST, ASTPlugin, ASTPluginEnvironment } from '@glimmer/syntax';
+import { AST, ASTPlugin } from '@glimmer/syntax';
 import calculateLocationDisplay from '../system/calculate-location-display';
+import { EmberASTPluginEnvironment } from '../types';
 
 /**
  @module ember
@@ -13,8 +13,8 @@ import calculateLocationDisplay from '../system/calculate-location-display';
   @private
   @class AssertAgainstNamedBlocks
 */
-export default function assertAgainstNamedBlocks(env: ASTPluginEnvironment): ASTPlugin {
-  let { moduleName } = env.meta as StaticTemplateMeta;
+export default function assertAgainstNamedBlocks(env: EmberASTPluginEnvironment): ASTPlugin {
+  let { moduleName } = env.meta;
 
   return {
     name: 'assert-against-named-blocks',

--- a/packages/ember-template-compiler/lib/plugins/assert-if-helper-without-arguments.ts
+++ b/packages/ember-template-compiler/lib/plugins/assert-if-helper-without-arguments.ts
@@ -1,11 +1,11 @@
-import { StaticTemplateMeta } from '@ember/-internals/views';
 import { assert } from '@ember/debug';
-import { AST, ASTPlugin, ASTPluginEnvironment } from '@glimmer/syntax';
+import { AST, ASTPlugin } from '@glimmer/syntax';
 import calculateLocationDisplay from '../system/calculate-location-display';
+import { EmberASTPluginEnvironment } from '../types';
 import { isPath } from './utils';
 
-export default function assertIfHelperWithoutArguments(env: ASTPluginEnvironment): ASTPlugin {
-  let { moduleName } = env.meta as StaticTemplateMeta;
+export default function assertIfHelperWithoutArguments(env: EmberASTPluginEnvironment): ASTPlugin {
+  let { moduleName } = env.meta;
 
   return {
     name: 'assert-if-helper-without-arguments',

--- a/packages/ember-template-compiler/lib/plugins/assert-input-helper-without-block.ts
+++ b/packages/ember-template-compiler/lib/plugins/assert-input-helper-without-block.ts
@@ -1,11 +1,11 @@
-import { StaticTemplateMeta } from '@ember/-internals/views';
 import { assert } from '@ember/debug';
-import { AST, ASTPlugin, ASTPluginEnvironment } from '@glimmer/syntax';
+import { AST, ASTPlugin } from '@glimmer/syntax';
 import calculateLocationDisplay from '../system/calculate-location-display';
+import { EmberASTPluginEnvironment } from '../types';
 import { isPath } from './utils';
 
-export default function errorOnInputWithContent(env: ASTPluginEnvironment): ASTPlugin {
-  let { moduleName } = env.meta as StaticTemplateMeta;
+export default function errorOnInputWithContent(env: EmberASTPluginEnvironment): ASTPlugin {
+  let { moduleName } = env.meta;
 
   return {
     name: 'assert-input-helper-without-block',

--- a/packages/ember-template-compiler/lib/plugins/assert-local-variable-shadowing-helper-invocation.ts
+++ b/packages/ember-template-compiler/lib/plugins/assert-local-variable-shadowing-helper-invocation.ts
@@ -1,13 +1,13 @@
-import { StaticTemplateMeta } from '@ember/-internals/views';
 import { assert } from '@ember/debug';
-import { AST, ASTPlugin, ASTPluginEnvironment } from '@glimmer/syntax';
+import { AST, ASTPlugin } from '@glimmer/syntax';
 import calculateLocationDisplay from '../system/calculate-location-display';
+import { EmberASTPluginEnvironment } from '../types';
 import { isPath, trackLocals } from './utils';
 
 export default function assertLocalVariableShadowingHelperInvocation(
-  env: ASTPluginEnvironment
+  env: EmberASTPluginEnvironment
 ): ASTPlugin {
-  let { moduleName } = env.meta as StaticTemplateMeta;
+  let { moduleName } = env.meta;
   let { hasLocal, node } = trackLocals();
 
   return {

--- a/packages/ember-template-compiler/lib/plugins/assert-reserved-named-arguments.ts
+++ b/packages/ember-template-compiler/lib/plugins/assert-reserved-named-arguments.ts
@@ -1,10 +1,10 @@
-import { StaticTemplateMeta } from '@ember/-internals/views';
 import { assert } from '@ember/debug';
-import { AST, ASTPlugin, ASTPluginEnvironment } from '@glimmer/syntax';
+import { AST, ASTPlugin } from '@glimmer/syntax';
 import calculateLocationDisplay from '../system/calculate-location-display';
+import { EmberASTPluginEnvironment } from '../types';
 
-export default function assertReservedNamedArguments(env: ASTPluginEnvironment): ASTPlugin {
-  let { moduleName } = env.meta as StaticTemplateMeta;
+export default function assertReservedNamedArguments(env: EmberASTPluginEnvironment): ASTPlugin {
+  let { moduleName } = env.meta;
 
   return {
     name: 'assert-reserved-named-arguments',

--- a/packages/ember-template-compiler/lib/plugins/assert-splattribute-expression.ts
+++ b/packages/ember-template-compiler/lib/plugins/assert-splattribute-expression.ts
@@ -1,10 +1,10 @@
-import { StaticTemplateMeta } from '@ember/-internals/views';
 import { assert } from '@ember/debug';
-import { ASTPlugin, ASTPluginEnvironment } from '@glimmer/syntax';
+import { ASTPlugin } from '@glimmer/syntax';
 import calculateLocationDisplay from '../system/calculate-location-display';
+import { EmberASTPluginEnvironment } from '../types';
 
-export default function assertSplattributeExpressions(env: ASTPluginEnvironment): ASTPlugin {
-  let { moduleName } = env.meta as StaticTemplateMeta;
+export default function assertSplattributeExpressions(env: EmberASTPluginEnvironment): ASTPlugin {
+  let { moduleName } = env.meta;
 
   return {
     name: 'assert-splattribute-expressions',

--- a/packages/ember-template-compiler/lib/plugins/deprecate-send-action.ts
+++ b/packages/ember-template-compiler/lib/plugins/deprecate-send-action.ts
@@ -1,8 +1,8 @@
-import { StaticTemplateMeta } from '@ember/-internals/views';
 import { deprecate } from '@ember/debug';
 import { SEND_ACTION } from '@ember/deprecated-features';
-import { AST, ASTPlugin, ASTPluginEnvironment } from '@glimmer/syntax';
+import { AST, ASTPlugin } from '@glimmer/syntax';
 import calculateLocationDisplay from '../system/calculate-location-display';
+import { EmberASTPluginEnvironment } from '../types';
 import { isPath } from './utils';
 
 const EVENTS = [
@@ -16,9 +16,9 @@ const EVENTS = [
   'key-down',
 ];
 
-export default function deprecateSendAction(env: ASTPluginEnvironment): ASTPlugin | undefined {
+export default function deprecateSendAction(env: EmberASTPluginEnvironment): ASTPlugin {
   if (SEND_ACTION) {
-    let { moduleName } = env.meta as StaticTemplateMeta;
+    let { moduleName } = env.meta;
 
     let deprecationMessage = (node: AST.Node, eventName: string, actionName: string) => {
       let sourceInformation = calculateLocationDisplay(moduleName, node.loc);
@@ -83,5 +83,9 @@ export default function deprecateSendAction(env: ASTPluginEnvironment): ASTPlugi
       },
     };
   }
-  return;
+
+  return {
+    name: 'deprecate-send-action',
+    visitor: {},
+  };
 }

--- a/packages/ember-template-compiler/lib/plugins/index.ts
+++ b/packages/ember-template-compiler/lib/plugins/index.ts
@@ -19,12 +19,9 @@ import TransformWrapMountAndOutlet from './transform-wrap-mount-and-outlet';
 
 import { EMBER_NAMED_BLOCKS } from '@ember/canary-features';
 import { SEND_ACTION } from '@ember/deprecated-features';
-import { ASTPlugin, ASTPluginEnvironment } from '@glimmer/syntax';
-
-export type APluginFunc = (env: ASTPluginEnvironment) => ASTPlugin | undefined;
 
 // order of plugins is important
-const transforms: Array<APluginFunc> = [
+const transforms = [
   TransformComponentInvocation,
   TransformOldClassBindingSyntax,
   TransformQuotedBindingsIntoJustBindings,

--- a/packages/ember-template-compiler/lib/plugins/transform-action-syntax.ts
+++ b/packages/ember-template-compiler/lib/plugins/transform-action-syntax.ts
@@ -1,5 +1,5 @@
-import { AST, ASTPlugin, ASTPluginEnvironment } from '@glimmer/syntax';
-import { Builders } from '../types';
+import { AST, ASTPlugin } from '@glimmer/syntax';
+import { Builders, EmberASTPluginEnvironment } from '../types';
 import { isPath } from './utils';
 
 /**
@@ -27,7 +27,7 @@ import { isPath } from './utils';
   @class TransformActionSyntax
 */
 
-export default function transformActionSyntax({ syntax }: ASTPluginEnvironment): ASTPlugin {
+export default function transformActionSyntax({ syntax }: EmberASTPluginEnvironment): ASTPlugin {
   let { builders: b } = syntax;
 
   return {

--- a/packages/ember-template-compiler/lib/plugins/transform-attrs-into-args.ts
+++ b/packages/ember-template-compiler/lib/plugins/transform-attrs-into-args.ts
@@ -1,4 +1,5 @@
-import { AST, ASTPlugin, ASTPluginEnvironment } from '@glimmer/syntax';
+import { AST, ASTPlugin } from '@glimmer/syntax';
+import { EmberASTPluginEnvironment } from '../types';
 
 /**
  @module ember
@@ -24,7 +25,7 @@ import { AST, ASTPlugin, ASTPluginEnvironment } from '@glimmer/syntax';
   @class TransformAttrsToProps
 */
 
-export default function transformAttrsIntoArgs(env: ASTPluginEnvironment): ASTPlugin {
+export default function transformAttrsIntoArgs(env: EmberASTPluginEnvironment): ASTPlugin {
   let { builders: b } = env.syntax;
 
   let stack: string[][] = [[]];

--- a/packages/ember-template-compiler/lib/plugins/transform-component-invocation.ts
+++ b/packages/ember-template-compiler/lib/plugins/transform-component-invocation.ts
@@ -1,7 +1,6 @@
-import { StaticTemplateMeta } from '@ember/-internals/views';
-import { AST, ASTPlugin, ASTPluginEnvironment } from '@glimmer/syntax';
+import { AST, ASTPlugin } from '@glimmer/syntax';
 import calculateLocationDisplay from '../system/calculate-location-display';
-import { Builders } from '../types';
+import { Builders, EmberASTPluginEnvironment } from '../types';
 import { isPath, trackLocals } from './utils';
 
 /**
@@ -122,8 +121,8 @@ import { isPath, trackLocals } from './utils';
   @private
   @class TransFormComponentInvocation
 */
-export default function transformComponentInvocation(env: ASTPluginEnvironment): ASTPlugin {
-  let { moduleName } = env.meta as StaticTemplateMeta;
+export default function transformComponentInvocation(env: EmberASTPluginEnvironment): ASTPlugin {
+  let { moduleName } = env.meta;
   let { builders: b } = env.syntax;
 
   let { hasLocal, node } = trackLocals();

--- a/packages/ember-template-compiler/lib/plugins/transform-each-in-into-each.ts
+++ b/packages/ember-template-compiler/lib/plugins/transform-each-in-into-each.ts
@@ -1,4 +1,5 @@
-import { AST, ASTPlugin, ASTPluginEnvironment } from '@glimmer/syntax';
+import { AST, ASTPlugin } from '@glimmer/syntax';
+import { EmberASTPluginEnvironment } from '../types';
 import { isPath } from './utils';
 
 /**
@@ -21,7 +22,7 @@ import { isPath } from './utils';
   @private
   @class TransformHasBlockSyntax
 */
-export default function transformEachInIntoEach(env: ASTPluginEnvironment): ASTPlugin {
+export default function transformEachInIntoEach(env: EmberASTPluginEnvironment): ASTPlugin {
   let { builders: b } = env.syntax;
 
   return {

--- a/packages/ember-template-compiler/lib/plugins/transform-each-track-array.ts
+++ b/packages/ember-template-compiler/lib/plugins/transform-each-track-array.ts
@@ -1,4 +1,5 @@
-import { AST, ASTPlugin, ASTPluginEnvironment } from '@glimmer/syntax';
+import { AST, ASTPlugin } from '@glimmer/syntax';
+import { EmberASTPluginEnvironment } from '../types';
 import { isPath } from './utils';
 
 /**
@@ -21,7 +22,7 @@ import { isPath } from './utils';
   @private
   @class TransformHasBlockSyntax
 */
-export default function transformEachTrackArray(env: ASTPluginEnvironment): ASTPlugin {
+export default function transformEachTrackArray(env: EmberASTPluginEnvironment): ASTPlugin {
   let { builders: b } = env.syntax;
 
   return {

--- a/packages/ember-template-compiler/lib/plugins/transform-has-block-syntax.ts
+++ b/packages/ember-template-compiler/lib/plugins/transform-has-block-syntax.ts
@@ -1,5 +1,7 @@
-import { AST, ASTPlugin, ASTPluginEnvironment } from '@glimmer/syntax';
+import { AST, ASTPlugin } from '@glimmer/syntax';
+import { EmberASTPluginEnvironment } from '../types';
 import { isPath } from './utils';
+
 /**
  @module ember
 */
@@ -26,7 +28,7 @@ const TRANSFORMATIONS = {
   hasBlockParams: 'has-block-params',
 };
 
-export default function transformHasBlockSyntax(env: ASTPluginEnvironment): ASTPlugin {
+export default function transformHasBlockSyntax(env: EmberASTPluginEnvironment): ASTPlugin {
   let { builders: b } = env.syntax;
 
   return {

--- a/packages/ember-template-compiler/lib/plugins/transform-in-element.ts
+++ b/packages/ember-template-compiler/lib/plugins/transform-in-element.ts
@@ -57,7 +57,7 @@ export default function transformInElement(env: EmberASTPluginEnvironment): ASTP
           if (EMBER_GLIMMER_IN_ELEMENT) {
             let originalValue = node.params[0];
 
-            if (originalValue) {
+            if (originalValue && !env.isProduction) {
               let subExpr = b.sexpr('-in-el-null', [originalValue]);
 
               node.params.shift();

--- a/packages/ember-template-compiler/lib/plugins/transform-in-element.ts
+++ b/packages/ember-template-compiler/lib/plugins/transform-in-element.ts
@@ -1,8 +1,8 @@
-import { StaticTemplateMeta } from '@ember/-internals/views';
 import { EMBER_GLIMMER_IN_ELEMENT } from '@ember/canary-features';
 import { assert, deprecate } from '@ember/debug';
-import { AST, ASTPlugin, ASTPluginEnvironment } from '@glimmer/syntax';
+import { AST, ASTPlugin } from '@glimmer/syntax';
 import calculateLocationDisplay from '../system/calculate-location-display';
+import { EmberASTPluginEnvironment } from '../types';
 import { isPath } from './utils';
 
 /**
@@ -42,8 +42,8 @@ import { isPath } from './utils';
   @private
   @class TransformInElement
 */
-export default function transformInElement(env: ASTPluginEnvironment): ASTPlugin {
-  let { moduleName } = env.meta as StaticTemplateMeta;
+export default function transformInElement(env: EmberASTPluginEnvironment): ASTPlugin {
+  let { moduleName } = env.meta;
   let { builders: b } = env.syntax;
 
   return {

--- a/packages/ember-template-compiler/lib/plugins/transform-link-to.ts
+++ b/packages/ember-template-compiler/lib/plugins/transform-link-to.ts
@@ -1,8 +1,7 @@
-import { StaticTemplateMeta } from '@ember/-internals/views';
 import { assert } from '@ember/debug';
-import { AST, ASTPlugin, ASTPluginEnvironment } from '@glimmer/syntax';
+import { AST, ASTPlugin } from '@glimmer/syntax';
 import calculateLocationDisplay from '../system/calculate-location-display';
-import { Builders } from '../types';
+import { Builders, EmberASTPluginEnvironment } from '../types';
 import { isPath, isSubExpression } from './utils';
 
 function isInlineLinkTo(node: AST.MustacheStatement): boolean {
@@ -18,7 +17,7 @@ function isQueryParams(node: AST.Expression): node is AST.SubExpression {
 }
 
 function transformInlineLinkToIntoBlockForm(
-  env: ASTPluginEnvironment,
+  env: EmberASTPluginEnvironment,
   node: AST.MustacheStatement
 ): AST.BlockStatement {
   let { builders: b } = env.syntax;
@@ -39,11 +38,11 @@ function transformInlineLinkToIntoBlockForm(
 }
 
 function transformPositionalLinkToIntoNamedArguments(
-  env: ASTPluginEnvironment,
+  env: EmberASTPluginEnvironment,
   node: AST.BlockStatement
 ): AST.BlockStatement {
   let { builders: b } = env.syntax;
-  let { moduleName } = env.meta as StaticTemplateMeta;
+  let { moduleName } = env.meta;
   let {
     params,
     hash: { pairs },
@@ -181,7 +180,7 @@ function buildStatement(b: Builders, content: AST.Node, escaped: boolean, loc: A
   }
 }
 
-export default function transformLinkTo(env: ASTPluginEnvironment): ASTPlugin {
+export default function transformLinkTo(env: EmberASTPluginEnvironment): ASTPlugin {
   return {
     name: 'transform-link-to',
 

--- a/packages/ember-template-compiler/lib/plugins/transform-old-class-binding-syntax.ts
+++ b/packages/ember-template-compiler/lib/plugins/transform-old-class-binding-syntax.ts
@@ -1,7 +1,7 @@
-import { AST, ASTPlugin, ASTPluginEnvironment } from '@glimmer/syntax';
-import { Builders } from '../types';
+import { AST, ASTPlugin } from '@glimmer/syntax';
+import { Builders, EmberASTPluginEnvironment } from '../types';
 
-export default function transformOldClassBindingSyntax(env: ASTPluginEnvironment): ASTPlugin {
+export default function transformOldClassBindingSyntax(env: EmberASTPluginEnvironment): ASTPlugin {
   let b = env.syntax.builders;
 
   return {

--- a/packages/ember-template-compiler/lib/plugins/transform-wrap-mount-and-outlet.ts
+++ b/packages/ember-template-compiler/lib/plugins/transform-wrap-mount-and-outlet.ts
@@ -1,4 +1,5 @@
-import { AST, ASTPlugin, ASTPluginEnvironment } from '@glimmer/syntax';
+import { AST, ASTPlugin } from '@glimmer/syntax';
+import { EmberASTPluginEnvironment } from '../types';
 import { isPath, trackLocals } from './utils';
 
 /**
@@ -33,7 +34,7 @@ import { isPath, trackLocals } from './utils';
   @private
   @class TransformHasBlockSyntax
 */
-export default function transformWrapMountAndOutlet(env: ASTPluginEnvironment): ASTPlugin {
+export default function transformWrapMountAndOutlet(env: EmberASTPluginEnvironment): ASTPlugin {
   let { builders: b } = env.syntax;
 
   let { hasLocal, node } = trackLocals();

--- a/packages/ember-template-compiler/lib/system/compile-options.ts
+++ b/packages/ember-template-compiler/lib/system/compile-options.ts
@@ -9,11 +9,15 @@ let USER_PLUGINS: PluginFunc[] = [];
 export default function compileOptions(
   _options: Partial<CompileOptions> = {}
 ): EmberPrecompileOptions {
-  let options: EmberPrecompileOptions = assign({ meta: {}, plugins: { ast: [] } }, _options, {
-    customizeComponentName(tagname: string): string {
-      return COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get(tagname);
-    },
-  });
+  let options: EmberPrecompileOptions = assign(
+    { meta: {}, isProduction: false, plugins: { ast: [] } },
+    _options,
+    {
+      customizeComponentName(tagname: string): string {
+        return COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get(tagname);
+      },
+    }
+  );
 
   // move `moduleName` into `meta` property
   if (options.moduleName) {

--- a/packages/ember-template-compiler/lib/system/compile-options.ts
+++ b/packages/ember-template-compiler/lib/system/compile-options.ts
@@ -1,26 +1,15 @@
 import { assign } from '@ember/polyfills';
-import { PrecompileOptions } from '@glimmer/compiler';
 import { AST, ASTPlugin, ASTPluginEnvironment, Syntax } from '@glimmer/syntax';
-import PLUGINS, { APluginFunc } from '../plugins/index';
+import PLUGINS from '../plugins/index';
+import { CompileOptions, EmberPrecompileOptions, PluginFunc } from '../types';
 import COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE from './dasherize-component-name';
 
-type PluginFunc = APluginFunc & {
-  __raw?: LegacyPluginClass | undefined;
-};
 let USER_PLUGINS: PluginFunc[] = [];
 
-interface Plugins {
-  ast: PluginFunc[];
-}
-
-export interface CompileOptions {
-  meta?: any;
-  moduleName?: string | undefined;
-  plugins?: Plugins | undefined;
-}
-
-export default function compileOptions(_options: Partial<CompileOptions> = {}): PrecompileOptions {
-  let options = assign({ meta: {} }, _options, {
+export default function compileOptions(
+  _options: Partial<CompileOptions> = {}
+): EmberPrecompileOptions {
+  let options: EmberPrecompileOptions = assign({ meta: {}, plugins: { ast: [] } }, _options, {
     customizeComponentName(tagname: string): string {
       return COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get(tagname);
     },
@@ -32,13 +21,13 @@ export default function compileOptions(_options: Partial<CompileOptions> = {}): 
     meta.moduleName = options.moduleName;
   }
 
-  if (!options.plugins) {
+  if (!_options.plugins) {
     options.plugins = { ast: [...USER_PLUGINS, ...PLUGINS] };
   } else {
     let potententialPugins = [...USER_PLUGINS, ...PLUGINS];
     let providedPlugins = options.plugins.ast.map(plugin => wrapLegacyPluginIfNeeded(plugin));
     let pluginsToAdd = potententialPugins.filter(plugin => {
-      return options.plugins!.ast.indexOf(plugin) === -1;
+      return options.plugins.ast.indexOf(plugin) === -1;
     });
     options.plugins.ast = providedPlugins.concat(pluginsToAdd);
   }

--- a/packages/ember-template-compiler/lib/system/compile.ts
+++ b/packages/ember-template-compiler/lib/system/compile.ts
@@ -2,7 +2,7 @@
 @module ember
 */
 import require, { has } from 'require';
-import { CompileOptions } from './compile-options';
+import { CompileOptions } from '../types';
 import precompile from './precompile';
 
 // FIXME

--- a/packages/ember-template-compiler/lib/system/precompile.ts
+++ b/packages/ember-template-compiler/lib/system/precompile.ts
@@ -2,8 +2,9 @@
 @module ember
 */
 
-import { precompile as glimmerPrecompile } from '@glimmer/compiler';
-import compileOptions, { CompileOptions } from './compile-options';
+import { precompile as glimmerPrecompile, PrecompileOptions } from '@glimmer/compiler';
+import { CompileOptions } from '../types';
+import compileOptions from './compile-options';
 
 /**
   Uses HTMLBars `compile` function to process a string into a compiled template string.
@@ -15,6 +16,8 @@ import compileOptions, { CompileOptions } from './compile-options';
   @method precompile
   @param {String} templateString This is the string to be compiled by HTMLBars.
 */
-export default function precompile(templateString: string, options: CompileOptions = {}): string {
-  return glimmerPrecompile(templateString, compileOptions(options));
+export default function precompile(templateString: string, _options: CompileOptions = {}): string {
+  let options: PrecompileOptions = compileOptions(_options) as any;
+
+  return glimmerPrecompile(templateString, options);
 }

--- a/packages/ember-template-compiler/lib/types.d.ts
+++ b/packages/ember-template-compiler/lib/types.d.ts
@@ -1,3 +1,30 @@
-import { builders } from '@glimmer/syntax';
+import { ASTPlugin, ASTPluginEnvironment, builders } from '@glimmer/syntax';
+import { StaticTemplateMeta } from '@ember/-internals/views';
 
 export type Builders = typeof builders;
+
+export interface PluginFunc {
+  (env: EmberASTPluginEnvironment): ASTPlugin;
+  __raw?: LegacyPluginClass;
+}
+
+interface Plugins {
+  ast: PluginFunc[];
+}
+
+export interface CompileOptions {
+  meta?: any;
+  contents?: string;
+  moduleName?: string;
+  plugins?: Plugins;
+}
+
+export interface EmberPrecompileOptions {
+  customizeComponentName(tag: string): string;
+  contents?: string;
+  moduleName?: string;
+  plugins: Plugins;
+  meta: StaticTemplateMeta;
+}
+
+export type EmberASTPluginEnvironment = ASTPluginEnvironment & EmberPrecompileOptions;

--- a/packages/ember-template-compiler/lib/types.d.ts
+++ b/packages/ember-template-compiler/lib/types.d.ts
@@ -17,10 +17,12 @@ export interface CompileOptions {
   contents?: string;
   moduleName?: string;
   plugins?: Plugins;
+  isProduction?: boolean;
 }
 
 export interface EmberPrecompileOptions {
   customizeComponentName(tag: string): string;
+  isProduction: boolean;
   contents?: string;
   moduleName?: string;
   plugins: Plugins;

--- a/packages/ember-template-compiler/tests/plugins/transform-component-invocation-test.js
+++ b/packages/ember-template-compiler/tests/plugins/transform-component-invocation-test.js
@@ -1,4 +1,4 @@
-import { compile } from '../../index';
+import { compile, precompile } from '../../index';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 moduleFor(
@@ -25,6 +25,21 @@ moduleFor(
       ].forEach((layout, i) => {
         compile(layout, { moduleName: `example-${i}` });
       });
+    }
+
+    '@test production compilation results in smaller template size'(assert) {
+      let layout = `{{this.modal open}}`;
+
+      let debugOutput = precompile(layout, { moduleName: `example.hbs` });
+      let prodOutput = precompile(layout, { isProduction: true, moduleName: `example.hbs` });
+
+      assert.notStrictEqual(
+        prodOutput,
+        debugOutput,
+        'expected output to differ between prod and non-prod'
+      );
+
+      assert.ok(prodOutput.length < debugOutput.length, 'prod output is smaller');
     }
   }
 );

--- a/packages/ember-template-compiler/tests/utils/transform-test-case.ts
+++ b/packages/ember-template-compiler/tests/utils/transform-test-case.ts
@@ -33,7 +33,7 @@ function ast(template: string): AST.Program {
 
   options.plugins!.ast!.push(extractProgram);
 
-  precompile(template, options);
+  precompile(template, options as any);
 
   return program!;
 }


### PR DESCRIPTION
This PR adds an `isProduction` flag option to the template compiler that can be used to change the behavior of the compiler for production builds. We generally do this already for the JS side of Ember, but not for templates, and this closes that gap.

Notes:

Exposes an `env.isProduction` (or for legacy style AST plugins `this.options.isProduction`) boolean that can be used from within the plugin itself to toggle debug vs prod only behaviors.

Fixes https://github.com/emberjs/ember.js/issues/18598