### PR TITLE
[BUGFIX beta] Pass resolver to Test app in generated initializer test

### DIFF
--- a/blueprints/initializer-test/qunit-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
+++ b/blueprints/initializer-test/qunit-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
@@ -2,17 +2,18 @@ import Application from '@ember/application';
 
 import { initialize } from '<%= modulePrefix %>/initializers/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
+import Resolver from 'ember-resolver';
 <% if (destroyAppExists) { %>import destroyApp from '../../helpers/destroy-app';<% } else { %>import { run } from '@ember/runloop';<% } %>
 
 module('<%= friendlyTestName %>', function(hooks) {
   hooks.beforeEach(function() {
-    this.TestApplication = Application.extend();
+    this.TestApplication = class TestApplication extends Application {}
     this.TestApplication.initializer({
       name: 'initializer under test',
       initialize
     });
 
-    this.application = this.TestApplication.create({ autoboot: false });
+    this.application = this.TestApplication.create({ autoboot: false, Resolver });
   });
 
   hooks.afterEach(function() {

--- a/blueprints/instance-initializer-test/qunit-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
+++ b/blueprints/instance-initializer-test/qunit-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
@@ -2,16 +2,17 @@ import Application from '@ember/application';
 
 import { initialize } from '<%= modulePrefix %>/instance-initializers/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
+import Resolver from 'ember-resolver';
 <% if (destroyAppExists) { %>import destroyApp from '../../helpers/destroy-app';<% } else { %>import { run } from '@ember/runloop';<% } %>
 
 module('<%= friendlyTestName %>', function(hooks) {
   hooks.beforeEach(function() {
-    this.TestApplication = Application.extend();
+    this.TestApplication = class TestApplication extends Application {}
     this.TestApplication.instanceInitializer({
       name: 'initializer under test',
       initialize
     });
-    this.application = this.TestApplication.create({ autoboot: false });
+    this.application = this.TestApplication.create({ autoboot: false, Resolver });
     this.instance = this.application.buildInstance();
   });
   hooks.afterEach(function() {

--- a/node-tests/fixtures/initializer-test/module-unification/rfc232.js
+++ b/node-tests/fixtures/initializer-test/module-unification/rfc232.js
@@ -2,17 +2,18 @@ import Application from '@ember/application';
 
 import { initialize } from 'my-app/init/initializers/foo';
 import { module, test } from 'qunit';
+import Resolver from 'ember-resolver';
 import { run } from '@ember/runloop';
 
 module('Unit | Initializer | foo', function(hooks) {
   hooks.beforeEach(function() {
-    this.TestApplication = Application.extend();
+    this.TestApplication = class TestApplication extends Application {}
     this.TestApplication.initializer({
       name: 'initializer under test',
       initialize
     });
 
-    this.application = this.TestApplication.create({ autoboot: false });
+    this.application = this.TestApplication.create({ autoboot: false, Resolver });
   });
 
   hooks.afterEach(function() {

--- a/node-tests/fixtures/initializer-test/rfc232.js
+++ b/node-tests/fixtures/initializer-test/rfc232.js
@@ -2,17 +2,18 @@ import Application from '@ember/application';
 
 import { initialize } from 'my-app/initializers/foo';
 import { module, test } from 'qunit';
+import Resolver from 'ember-resolver';
 import { run } from '@ember/runloop';
 
 module('Unit | Initializer | foo', function(hooks) {
   hooks.beforeEach(function() {
-    this.TestApplication = Application.extend();
+    this.TestApplication = class TestApplication extends Application {}
     this.TestApplication.initializer({
       name: 'initializer under test',
       initialize
     });
 
-    this.application = this.TestApplication.create({ autoboot: false });
+    this.application = this.TestApplication.create({ autoboot: false, Resolver });
   });
 
   hooks.afterEach(function() {

--- a/node-tests/fixtures/instance-initializer-test/module-unification/rfc232.js
+++ b/node-tests/fixtures/instance-initializer-test/module-unification/rfc232.js
@@ -2,16 +2,17 @@ import Application from '@ember/application';
 
 import { initialize } from 'my-app/init/instance-initializers/foo';
 import { module, test } from 'qunit';
+import Resolver from 'ember-resolver';
 import { run } from '@ember/runloop';
 
 module('Unit | Instance Initializer | foo', function(hooks) {
   hooks.beforeEach(function() {
-    this.TestApplication = Application.extend();
+    this.TestApplication = class TestApplication extends Application {}
     this.TestApplication.instanceInitializer({
       name: 'initializer under test',
       initialize
     });
-    this.application = this.TestApplication.create({ autoboot: false });
+    this.application = this.TestApplication.create({ autoboot: false, Resolver });
     this.instance = this.application.buildInstance();
   });
   hooks.afterEach(function() {

--- a/node-tests/fixtures/instance-initializer-test/rfc232.js
+++ b/node-tests/fixtures/instance-initializer-test/rfc232.js
@@ -2,16 +2,17 @@ import Application from '@ember/application';
 
 import { initialize } from 'my-app/instance-initializers/foo';
 import { module, test } from 'qunit';
+import Resolver from 'ember-resolver';
 import { run } from '@ember/runloop';
 
 module('Unit | Instance Initializer | foo', function(hooks) {
   hooks.beforeEach(function() {
-    this.TestApplication = Application.extend();
+    this.TestApplication = class TestApplication extends Application {}
     this.TestApplication.instanceInitializer({
       name: 'initializer under test',
       initialize
     });
-    this.application = this.TestApplication.create({ autoboot: false });
+    this.application = this.TestApplication.create({ autoboot: false, Resolver });
     this.instance = this.application.buildInstance();
   });
   hooks.afterEach(function() {


### PR DESCRIPTION
The default resolver (the globals resolver is deprecated), so we
always need to pass this in.

Closes #19046