### PR TITLE
[BUGFIX release] Simplify factory instantiation

### DIFF
--- a/packages/@ember/-internals/container/index.ts
+++ b/packages/@ember/-internals/container/index.ts
@@ -6,4 +6,4 @@ The public API, specified on the application namespace should be considered the 
 */
 
 export { default as Registry, privatize } from './lib/registry';
-export { default as Container, FACTORY_FOR } from './lib/container';
+export { default as Container, FACTORY_FOR, INIT_FACTORY_FOR } from './lib/container';

--- a/packages/@ember/-internals/container/index.ts
+++ b/packages/@ember/-internals/container/index.ts
@@ -6,4 +6,4 @@ The public API, specified on the application namespace should be considered the 
 */
 
 export { default as Registry, privatize } from './lib/registry';
-export { default as Container, FACTORY_FOR, INIT_FACTORY_FOR } from './lib/container';
+export { default as Container, getFactoryFor, setFactoryFor, INIT_FACTORY } from './lib/container';

--- a/packages/@ember/-internals/container/tests/container_test.js
+++ b/packages/@ember/-internals/container/tests/container_test.js
@@ -190,13 +190,13 @@ moduleFor(
       assert.equal(container.lookup('doesnot:exist'), undefined);
     }
 
-    ['@test An invalid factory throws an error'](assert) {
+    ['@test An invalid factory throws an error']() {
       let registry = new Registry();
       let container = registry.container();
 
       registry.register('controller:foo', {});
 
-      assert.throws(() => {
+      expectAssertion(() => {
         container.lookup('controller:foo');
       }, /Failed to create an instance of 'controller:foo'/);
     }

--- a/packages/@ember/-internals/container/tests/container_test.js
+++ b/packages/@ember/-internals/container/tests/container_test.js
@@ -666,30 +666,6 @@ moduleFor(
       assert.equal(instrance.ajax, 'fetch');
     }
 
-    ['@test #factoryFor does not add properties to the object being instantiated when _initFactory is present'](
-      assert
-    ) {
-      let registry = new Registry();
-      let container = registry.container();
-
-      class Component {
-        static _initFactory() {}
-        static create(options) {
-          let instance = new this();
-          assign(instance, options);
-          return instance;
-        }
-      }
-      registry.register('component:foo-bar', Component);
-
-      let componentFactory = container.factoryFor('component:foo-bar');
-      let instance = componentFactory.create();
-
-      // note: _guid and isDestroyed are being set in the `factory` constructor
-      // not via registry/container shenanigans
-      assert.deepEqual(Object.keys(instance), []);
-    }
-
     [`@test assert when calling lookup after destroy on a container`](assert) {
       let registry = new Registry();
       let container = registry.container();

--- a/packages/@ember/-internals/container/tests/owner_test.js
+++ b/packages/@ember/-internals/container/tests/owner_test.js
@@ -16,5 +16,24 @@ moduleFor(
 
       assert.strictEqual(obj[OWNER], owner, 'owner has been set to the OWNER symbol');
     }
+
+    ['@test getOwner deprecates using LEGACY_OWNER'](assert) {
+      let owner = {};
+      let obj = {};
+
+      setOwner(obj, owner);
+
+      let legacyOwner;
+
+      for (let key in obj) {
+        legacyOwner = key;
+      }
+
+      let newObj = { [legacyOwner]: owner };
+
+      expectDeprecation(() => {
+        assert.strictEqual(getOwner(newObj), owner, 'owner has been set');
+      }, /You accessed the owner using `getOwner` on an object/);
+    }
   }
 );

--- a/packages/@ember/-internals/container/tests/owner_test.js
+++ b/packages/@ember/-internals/container/tests/owner_test.js
@@ -25,6 +25,8 @@ moduleFor(
 
       let legacyOwner;
 
+      // This is not something we expect to happen a lot, but does exist currently
+      // in the wild: https://github.com/hjdivad/ember-m3/pull/822
       for (let key in obj) {
         legacyOwner = key;
       }

--- a/packages/@ember/-internals/glimmer/lib/component-managers/root.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/root.ts
@@ -1,4 +1,4 @@
-import { FACTORY_FOR } from '@ember/-internals/container';
+import { getFactoryFor } from '@ember/-internals/container';
 import { ENV } from '@ember/-internals/environment';
 import { Factory } from '@ember/-internals/owner';
 import { _instrumentStart } from '@ember/instrumentation';
@@ -111,7 +111,7 @@ export class RootComponentDefinition implements ComponentDefinition {
   constructor(public component: Component) {
     let manager = new RootComponentManager(component);
     this.manager = manager;
-    let factory = FACTORY_FOR.get(component);
+    let factory = getFactoryFor(component);
     this.state = {
       name: factory!.fullName.slice(10),
       capabilities: ROOT_CAPABILITIES,

--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -1,7 +1,7 @@
 import { get, PROPERTY_DID_CHANGE } from '@ember/-internals/metal';
 import { getOwner } from '@ember/-internals/owner';
 import { TargetActionSupport } from '@ember/-internals/runtime';
-import { symbol } from '@ember/-internals/utils';
+import { enumerableSymbol, symbol } from '@ember/-internals/utils';
 import {
   ActionSupport,
   ChildViewsSupport,
@@ -18,10 +18,11 @@ import { normalizeProperty } from '@glimmer/runtime';
 import { createTag, dirtyTag } from '@glimmer/validator';
 import { Namespace } from '@simple-dom/interface';
 
+export const ARGS = enumerableSymbol('ARGS');
+export const HAS_BLOCK = enumerableSymbol('HAS_BLOCK');
+
 export const DIRTY_TAG = symbol('DIRTY_TAG');
-export const ARGS = symbol('ARGS');
 export const IS_DISPATCHING_ATTRS = symbol('IS_DISPATCHING_ATTRS');
-export const HAS_BLOCK = symbol('HAS_BLOCK');
 export const BOUNDS = symbol('BOUNDS');
 
 /**

--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -1,6 +1,6 @@
 import { get, PROPERTY_DID_CHANGE } from '@ember/-internals/metal';
 import { getOwner } from '@ember/-internals/owner';
-import { setFrameworkClass, TargetActionSupport } from '@ember/-internals/runtime';
+import { TargetActionSupport } from '@ember/-internals/runtime';
 import { symbol } from '@ember/-internals/utils';
 import {
   ActionSupport,
@@ -1114,7 +1114,5 @@ Component.reopenClass({
   isComponentFactory: true,
   positionalParams: [],
 });
-
-setFrameworkClass(Component);
 
 export default Component;

--- a/packages/@ember/-internals/glimmer/lib/helper.ts
+++ b/packages/@ember/-internals/glimmer/lib/helper.ts
@@ -3,7 +3,7 @@
 */
 
 import { Factory } from '@ember/-internals/owner';
-import { FrameworkObject, setFrameworkClass } from '@ember/-internals/runtime';
+import { FrameworkObject } from '@ember/-internals/runtime';
 import { symbol } from '@ember/-internals/utils';
 import { join } from '@ember/runloop';
 import { Dict } from '@glimmer/interfaces';
@@ -137,8 +137,6 @@ let Helper = FrameworkObject.extend({
 });
 
 Helper.isHelperFactory = true;
-
-setFrameworkClass(Helper);
 
 class Wrapper implements HelperFactory<SimpleHelper> {
   isHelperFactory: true = true;

--- a/packages/@ember/-internals/glimmer/lib/renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/renderer.ts
@@ -1,5 +1,5 @@
 import { ENV } from '@ember/-internals/environment';
-import { Owner, OWNER } from '@ember/-internals/owner';
+import { OWNER, Owner } from '@ember/-internals/owner';
 import { getViewElement, getViewId, OwnedTemplateMeta } from '@ember/-internals/views';
 import { assert } from '@ember/debug';
 import { backburner, getCurrentRunLoop } from '@ember/runloop';

--- a/packages/@ember/-internals/glimmer/lib/renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/renderer.ts
@@ -1,5 +1,5 @@
 import { ENV } from '@ember/-internals/environment';
-import { OWNER, Owner } from '@ember/-internals/owner';
+import { getOwner, Owner } from '@ember/-internals/owner';
 import { getViewElement, getViewId, OwnedTemplateMeta } from '@ember/-internals/views';
 import { assert } from '@ember/debug';
 import { backburner, getCurrentRunLoop } from '@ember/runloop';
@@ -543,22 +543,15 @@ export abstract class Renderer {
 }
 
 export class InertRenderer extends Renderer {
-  static create({
-    [OWNER]: owner,
-    document,
-    env,
-    rootTemplate,
-    _viewRegistry,
-    builder,
-  }: {
-    [OWNER]: Owner;
+  static create(props: {
     document: SimpleDocument;
     env: { isInteractive: boolean; hasDOM: boolean };
     rootTemplate: TemplateFactory;
     _viewRegistry: any;
     builder: any;
   }) {
-    return new this(owner, document, env, rootTemplate, _viewRegistry, false, builder);
+    let { document, env, rootTemplate, _viewRegistry, builder } = props;
+    return new this(getOwner(props), document, env, rootTemplate, _viewRegistry, false, builder);
   }
 
   getElement(_view: unknown): Option<SimpleElement> {
@@ -569,22 +562,15 @@ export class InertRenderer extends Renderer {
 }
 
 export class InteractiveRenderer extends Renderer {
-  static create({
-    [OWNER]: owner,
-    document,
-    env,
-    rootTemplate,
-    _viewRegistry,
-    builder,
-  }: {
-    [OWNER]: Owner;
+  static create(props: {
     document: SimpleDocument;
     env: { isInteractive: boolean; hasDOM: boolean };
     rootTemplate: TemplateFactory;
     _viewRegistry: any;
     builder: any;
   }) {
-    return new this(owner, document, env, rootTemplate, _viewRegistry, true, builder);
+    let { document, env, rootTemplate, _viewRegistry, builder } = props;
+    return new this(getOwner(props), document, env, rootTemplate, _viewRegistry, true, builder);
   }
 
   getElement(view: unknown): Option<SimpleElement> {

--- a/packages/@ember/-internals/glimmer/lib/views/outlet.ts
+++ b/packages/@ember/-internals/glimmer/lib/views/outlet.ts
@@ -1,4 +1,4 @@
-import { OWNER, Owner } from '@ember/-internals/owner';
+import { getOwner, Owner } from '@ember/-internals/owner';
 import { assign } from '@ember/polyfills';
 import { schedule } from '@ember/runloop';
 import { SimpleElement } from '@simple-dom/interface';
@@ -35,7 +35,7 @@ export default class OutletView {
 
   static create(options: any) {
     let { _environment, renderer, template: templateFactory } = options;
-    let owner = options[OWNER];
+    let owner = getOwner(options);
     let template = templateFactory(owner);
     return new OutletView(_environment, renderer, owner, template);
   }

--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -1,5 +1,5 @@
 import { Meta, meta as metaFor } from '@ember/-internals/meta';
-import { inspect, symbol, toString } from '@ember/-internals/utils';
+import { inspect, toString } from '@ember/-internals/utils';
 import { assert, deprecate, warn } from '@ember/debug';
 import EmberError from '@ember/error';
 import { isDestroyed } from '@glimmer/runtime';
@@ -37,8 +37,6 @@ import {
   PROPERTY_DID_CHANGE,
 } from './property_events';
 import { set } from './property_set';
-
-export const AUTO = symbol('COMPUTED_AUTO');
 
 export type ComputedPropertyGetter = (keyName: string) => any;
 export type ComputedPropertySetter = (keyName: string, value: any, cachedValue?: any) => any;

--- a/packages/@ember/-internals/metal/lib/events.ts
+++ b/packages/@ember/-internals/metal/lib/events.ts
@@ -146,11 +146,13 @@ export function sendEvent(
     if (!target) {
       target = obj;
     }
-    if (typeof method === 'string' || typeof method === 'symbol') {
-      method = target[method] as Function;
+
+    let type = typeof method;
+    if (type === 'string' || type === 'symbol') {
+      method = target[method as string] as Function;
     }
 
-    method.apply(target, params);
+    (method as Function).apply(target, params);
   }
   return true;
 }

--- a/packages/@ember/-internals/metal/lib/events.ts
+++ b/packages/@ember/-internals/metal/lib/events.ts
@@ -146,7 +146,7 @@ export function sendEvent(
     if (!target) {
       target = obj;
     }
-    if ('string' === typeof method) {
+    if (typeof method === 'string' || typeof method === 'symbol') {
       method = target[method] as Function;
     }
 

--- a/packages/@ember/-internals/metal/lib/property_events.ts
+++ b/packages/@ember/-internals/metal/lib/property_events.ts
@@ -1,5 +1,5 @@
 import { Meta, peekMeta } from '@ember/-internals/meta';
-import { symbol } from '@ember/-internals/utils';
+import { enumerableSymbol } from '@ember/-internals/utils';
 import {
   flushSyncObservers,
   resumeObserverDeactivation,
@@ -12,7 +12,7 @@ import { markObjectAsDirty } from './tags';
  @private
  */
 
-export const PROPERTY_DID_CHANGE = symbol('PROPERTY_DID_CHANGE');
+export const PROPERTY_DID_CHANGE = enumerableSymbol('PROPERTY_DID_CHANGE');
 
 let deferred = 0;
 

--- a/packages/@ember/-internals/metal/lib/tags.ts
+++ b/packages/@ember/-internals/metal/lib/tags.ts
@@ -1,4 +1,10 @@
-import { isObject, setupMandatorySetter, symbol, toString } from '@ember/-internals/utils';
+import {
+  enumerableSymbol,
+  isObject,
+  setupMandatorySetter,
+  symbol,
+  toString,
+} from '@ember/-internals/utils';
 import { assert } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 import { isDestroyed } from '@glimmer/runtime';
@@ -6,10 +12,10 @@ import { CONSTANT_TAG, dirtyTagFor, Tag, tagFor, TagMeta } from '@glimmer/valida
 
 /////////
 
-export const CUSTOM_TAG_FOR = symbol('CUSTOM_TAG_FOR');
+export const CUSTOM_TAG_FOR = enumerableSymbol('CUSTOM_TAG_FOR');
 
 // This is exported for `@tracked`, but should otherwise be avoided. Use `tagForObject`.
-export const SELF_TAG: string = symbol('SELF_TAG');
+export const SELF_TAG: string | symbol = symbol('SELF_TAG');
 
 export function tagForProperty(
   obj: object,

--- a/packages/@ember/-internals/owner/index.ts
+++ b/packages/@ember/-internals/owner/index.ts
@@ -40,7 +40,7 @@ export interface Owner {
 import { enumerableSymbol, symbol } from '@ember/-internals/utils';
 import { deprecate } from '@ember/debug';
 
-export const LEGACY_OWNER: unique symbol = enumerableSymbol('OWNER') as any;
+export const LEGACY_OWNER: unique symbol = enumerableSymbol('LEGACY_OWNER') as any;
 export const OWNER: unique symbol = symbol('OWNER') as any;
 
 /**

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -17,7 +17,6 @@ import {
   ActionHandler,
   Evented,
   Object as EmberObject,
-  setFrameworkClass,
   typeOf,
 } from '@ember/-internals/runtime';
 import { lookupDescriptor } from '@ember/-internals/utils';
@@ -2668,7 +2667,5 @@ if (ROUTER_EVENTS) {
     },
   });
 }
-
-setFrameworkClass(Route);
 
 export default Route;

--- a/packages/@ember/-internals/runtime/index.d.ts
+++ b/packages/@ember/-internals/runtime/index.d.ts
@@ -11,7 +11,6 @@ export function deprecatingAlias(
 ): any;
 
 export const FrameworkObject: any;
-export function setFrameworkClass<T>(klass: new () => T): void;
 export const Object: any;
 
 export function _contentFor(proxy: any): any;

--- a/packages/@ember/-internals/runtime/index.js
+++ b/packages/@ember/-internals/runtime/index.js
@@ -17,7 +17,7 @@ export { default as Comparable } from './lib/mixins/comparable';
 export { default as Namespace } from './lib/system/namespace';
 export { default as ArrayProxy } from './lib/system/array_proxy';
 export { default as ObjectProxy } from './lib/system/object_proxy';
-export { default as CoreObject, setFrameworkClass } from './lib/system/core_object';
+export { default as CoreObject } from './lib/system/core_object';
 export { default as ActionHandler } from './lib/mixins/action_handler';
 export { default as Copyable } from './lib/mixins/copyable';
 export { default as Enumerable } from './lib/mixins/enumerable';

--- a/packages/@ember/-internals/runtime/lib/system/core_object.js
+++ b/packages/@ember/-internals/runtime/lib/system/core_object.js
@@ -39,12 +39,6 @@ const prototypeMixinMap = new WeakMap();
 
 const initCalled = DEBUG ? new WeakSet() : undefined; // only used in debug builds to enable the proxy trap
 
-const FRAMEWORK_CLASSES = symbol('FRAMEWORK_CLASS');
-
-export function setFrameworkClass(klass) {
-  klass[FRAMEWORK_CLASSES] = true;
-}
-
 function initialize(obj, properties) {
   let m = meta(obj);
 
@@ -717,14 +711,7 @@ class CoreObject {
     @public
   */
   static create(props, extra) {
-    let C = this;
-    let instance;
-
-    if (this[FRAMEWORK_CLASSES]) {
-      instance = new C(props !== undefined ? getOwner(props) : undefined);
-    } else {
-      instance = new C();
-    }
+    let instance = new this(props !== undefined ? getOwner(props) : undefined);
 
     if (extra === undefined) {
       initialize(instance, props);

--- a/packages/@ember/-internals/runtime/lib/system/object.js
+++ b/packages/@ember/-internals/runtime/lib/system/object.js
@@ -2,9 +2,8 @@
 @module @ember/object
 */
 
-import { getFactoryFor, INIT_FACTORY } from '@ember/-internals/container';
-import { OWNER, setOwner } from '@ember/-internals/owner';
-import { HAS_NATIVE_SYMBOL, symbol, setName } from '@ember/-internals/utils';
+import { getFactoryFor } from '@ember/-internals/container';
+import { symbol, setName } from '@ember/-internals/utils';
 import { addListener } from '@ember/-internals/metal';
 import CoreObject from './core_object';
 import Observable from '../mixins/observable';
@@ -28,32 +27,6 @@ export default class EmberObject extends CoreObject {
   }
 }
 
-if (!HAS_NATIVE_SYMBOL) {
-  // Allows OWNER and INIT_FACTORY to be non-enumerable in IE11
-  let instanceOwner = new WeakMap();
-  let instanceFactory = new WeakMap();
-
-  Object.defineProperty(EmberObject.prototype, OWNER, {
-    get() {
-      return instanceOwner.get(this);
-    },
-
-    set(value) {
-      instanceOwner.set(this, value);
-    },
-  });
-
-  Object.defineProperty(EmberObject.prototype, INIT_FACTORY, {
-    get() {
-      return instanceFactory.get(this);
-    },
-
-    set(value) {
-      instanceFactory.set(this, value);
-    },
-  });
-}
-
 setName(EmberObject, 'Ember.Object');
 
 Observable.apply(EmberObject.prototype);
@@ -64,12 +37,6 @@ FrameworkObject = class FrameworkObject extends CoreObject {
   get _debugContainerKey() {
     let factory = getFactoryFor(this);
     return factory !== undefined && factory.fullName;
-  }
-
-  constructor(owner) {
-    super();
-
-    setOwner(this, owner);
   }
 };
 

--- a/packages/@ember/-internals/runtime/tests/system/core_object_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/core_object_test.js
@@ -1,7 +1,7 @@
 import { getOwner, setOwner } from '@ember/-internals/owner';
-import { get, set, observer } from '@ember/-internals/metal';
+import { get, set } from '@ember/-internals/metal';
 import CoreObject from '../../lib/system/core_object';
-import { moduleFor, AbstractTestCase, buildOwner, runLoopSettled } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase, buildOwner } from 'internal-test-helpers';
 import { track } from '@glimmer/validator';
 
 moduleFor(

--- a/packages/@ember/-internals/runtime/tests/system/core_object_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/core_object_test.js
@@ -7,29 +7,6 @@ import { track } from '@glimmer/validator';
 moduleFor(
   'Ember.CoreObject',
   class extends AbstractTestCase {
-    ['@test throws an error with new (one arg)']() {
-      expectAssertion(() => {
-        new CoreObject({
-          firstName: 'Stef',
-          lastName: 'Penner',
-        });
-      }, /You may have either used `new` instead of `.create\(\)`/);
-    }
-
-    ['@test throws an error with new (> 1 arg)']() {
-      expectAssertion(() => {
-        new CoreObject(
-          {
-            firstName: 'Stef',
-            lastName: 'Penner',
-          },
-          {
-            other: 'name',
-          }
-        );
-      }, /You may have either used `new` instead of `.create\(\)`/);
-    }
-
     ['@test toString should be not be added as a property when calling toString()'](assert) {
       let obj = CoreObject.create({
         firstName: 'Foo',
@@ -106,32 +83,6 @@ moduleFor(
           return undefined;
         },
       }).create(options);
-    }
-
-    async ['@test observed properties are enumerable when set GH#14594'](assert) {
-      let callCount = 0;
-      let Test = CoreObject.extend({
-        myProp: null,
-        anotherProp: undefined,
-        didChangeMyProp: observer('myProp', function() {
-          callCount++;
-        }),
-      });
-
-      let test = Test.create();
-      set(test, 'id', '3');
-      set(test, 'myProp', { id: 1 });
-
-      assert.deepEqual(Object.keys(test).sort(), ['id', 'myProp']);
-
-      set(test, 'anotherProp', 'nice');
-
-      assert.deepEqual(Object.keys(test).sort(), ['anotherProp', 'id', 'myProp']);
-      await runLoopSettled();
-
-      assert.equal(callCount, 1);
-
-      test.destroy();
     }
 
     ['@test native getters/setters do not cause rendering invalidation during init'](assert) {

--- a/packages/@ember/-internals/runtime/tests/system/object/create_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/create_test.js
@@ -1,3 +1,4 @@
+import { getFactoryFor, Registry } from '@ember/-internals/container';
 import { getOwner, setOwner } from '@ember/-internals/owner';
 import { computed, Mixin, observer, addObserver, alias } from '@ember/-internals/metal';
 import { DEBUG } from '@glimmer/env';
@@ -218,6 +219,39 @@ moduleFor(
           return undefined;
         },
       }).create(options);
+    }
+
+    ['@test does not create enumerable properties for owner and init factory when created by the container factory'](
+      assert
+    ) {
+      let registry = new Registry();
+      let container = registry.container();
+      container.owner = {};
+
+      registry.register('component:foo-bar', EmberObject);
+
+      let componentFactory = container.factoryFor('component:foo-bar');
+      let instance = componentFactory.create();
+
+      assert.deepEqual(Object.keys(instance), [], 'no enumerable properties were added');
+      assert.equal(getOwner(instance), container.owner, 'owner was defined on the instance');
+      assert.ok(getFactoryFor(instance), 'factory was defined on the instance');
+    }
+
+    ['@test does not create enumerable properties for owner and init factory when looked up on the container'](
+      assert
+    ) {
+      let registry = new Registry();
+      let container = registry.container();
+      container.owner = {};
+
+      registry.register('component:foo-bar', EmberObject);
+
+      let instance = container.lookup('component:foo-bar');
+
+      assert.deepEqual(Object.keys(instance), [], 'no enumerable properties were added');
+      assert.equal(getOwner(instance), container.owner, 'owner was defined on the instance');
+      assert.ok(getFactoryFor(instance), 'factory was defined on the instance');
     }
   }
 );

--- a/packages/@ember/-internals/runtime/tests/system/object/framework_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/framework_test.js
@@ -1,7 +1,6 @@
 import { getOwner } from '@ember/-internals/owner';
 import { FrameworkObject } from '../../../index';
 import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
-import { setFrameworkClass } from '../../../lib/system/core_object';
 
 moduleFor(
   'FrameworkObject',
@@ -23,7 +22,6 @@ moduleFor(
           assert.equal(owner, testContext.owner, 'owner was passed properly to the constructor');
         }
       }
-      setFrameworkClass(Model);
       this.owner.register('model:blah', Model);
 
       this.owner.factoryFor('model:blah').create();

--- a/packages/@ember/-internals/utils/index.ts
+++ b/packages/@ember/-internals/utils/index.ts
@@ -8,7 +8,7 @@
  Utility methods that are needed in < 80% of cases should be placed
  elsewhere (so they can be lazily evaluated / parsed).
 */
-export { default as symbol, isInternalSymbol } from './lib/symbol';
+export { symbol, enumerableSymbol, isInternalSymbol } from './lib/symbol';
 export { default as dictionary } from './lib/dictionary';
 export { default as getDebugName } from './lib/get-debug-name';
 export { default as getOwnPropertyDescriptors } from './lib/get-own-property-descriptors';

--- a/packages/@ember/-internals/utils/lib/ember-array.ts
+++ b/packages/@ember/-internals/utils/lib/ember-array.ts
@@ -1,4 +1,4 @@
-import symbol from './symbol';
+import { symbol } from './symbol';
 
 export const EMBER_ARRAY = symbol('EMBER_ARRAY');
 

--- a/packages/@ember/-internals/utils/lib/symbol.ts
+++ b/packages/@ember/-internals/utils/lib/symbol.ts
@@ -1,5 +1,7 @@
+import { DEBUG } from '@glimmer/env';
 import { GUID_KEY } from './guid';
 import intern from './intern';
+import { HAS_NATIVE_SYMBOL } from './symbol-utils';
 
 const GENERATED_SYMBOLS: string[] = [];
 
@@ -7,12 +9,21 @@ export function isInternalSymbol(possibleSymbol: string) {
   return GENERATED_SYMBOLS.indexOf(possibleSymbol) !== -1;
 }
 
-export default function symbol(debugName: string): string {
+// Some legacy symbols still need to be enumerable for a variety of reasons.
+// This code exists for that, and as a fallback in IE11. In general, prefer
+// `symbol` below when creating a new symbol.
+export function enumerableSymbol(debugName: string): string {
   // TODO: Investigate using platform symbols, but we do not
   // want to require non-enumerability for this API, which
   // would introduce a large cost.
   let id = GUID_KEY + Math.floor(Math.random() * Date.now());
   let symbol = intern(`__${debugName}${id}__`);
-  GENERATED_SYMBOLS.push(symbol);
+
+  if (DEBUG) {
+    GENERATED_SYMBOLS.push(symbol);
+  }
+
   return symbol;
 }
+
+export const symbol = HAS_NATIVE_SYMBOL ? Symbol : enumerableSymbol;

--- a/packages/@ember/controller/index.js
+++ b/packages/@ember/controller/index.js
@@ -1,4 +1,4 @@
-import { FrameworkObject, setFrameworkClass } from '@ember/-internals/runtime';
+import { FrameworkObject } from '@ember/-internals/runtime';
 import { inject as metalInject } from '@ember/-internals/metal';
 import ControllerMixin from './lib/controller_mixin';
 
@@ -13,8 +13,6 @@ import ControllerMixin from './lib/controller_mixin';
   @public
 */
 const Controller = FrameworkObject.extend(ControllerMixin);
-
-setFrameworkClass(Controller);
 
 /**
   Creates a property that lazily looks up another controller in the container.

--- a/packages/@ember/service/index.js
+++ b/packages/@ember/service/index.js
@@ -1,4 +1,4 @@
-import { FrameworkObject, setFrameworkClass } from '@ember/-internals/runtime';
+import { FrameworkObject } from '@ember/-internals/runtime';
 import { inject as metalInject } from '@ember/-internals/metal';
 
 /**
@@ -68,7 +68,5 @@ const Service = FrameworkObject.extend();
 Service.reopenClass({
   isServiceFactory: true,
 });
-
-setFrameworkClass(Service);
 
 export default Service;

--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -98,7 +98,6 @@ import {
   CoreObject,
   NativeArray,
   A,
-  setFrameworkClass,
 } from '@ember/-internals/runtime';
 import {
   Checkbox,
@@ -422,7 +421,6 @@ Ember._ContainerProxyMixin = ContainerProxyMixin;
 Ember.compare = compare;
 Ember.copy = copy;
 Ember.isEqual = isEqual;
-Ember._setFrameworkClass = setFrameworkClass;
 
 /**
 @module ember


### PR DESCRIPTION
Simplifies factory instantiation and object creation in a number of ways:

1. Removes the side-channeling done to provide the Owner and Factory during initialization. These are instead provided using native Symbols on the props that are provided during `create`.
2. Converts to using native symbols wherever possible (and in browsers that support them), so these properties are non-enumerable in general.
3. Removes the notion of FrameworkClasses that receive the Owner as a constructor param. Any CoreObject registered on the container will now receive the owner as the first parameter.

See the individual commits for more detailed explanations of the changes.

Benchmark results:

[artifact-64.pdf](https://github.com/emberjs/ember.js/files/5045534/artifact-64.pdf)
