### PR TITLE
test: add failing test around `replaceWith` and `refreshModel`

### DIFF
--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -628,6 +628,39 @@ moduleFor(
       assert.equal(indexModelCount, 2, 'index model hook ran again due to refreshModel');
     }
 
+    async ['@test refreshModel does not force `replaceWith` to add a history entry'](assert) {
+      // Default to `omg` being empty
+      this.setSingleQPController('index', 'omg', null);
+
+      this.add(
+        'route:index',
+        Route.extend({
+          queryParams: {
+            omg: {
+              refreshModel: true,
+            },
+          },
+
+          model(params) {
+            return params;
+          },
+
+          afterModel({ omg }) {
+            // Pretend that we need the `model` state to compute the query param value
+            if (!omg) {
+              this.replaceWith({
+                queryParams: {
+                  omg: 'lol',
+                },
+              });
+            }
+          },
+        })
+      );
+
+      await this.visit('/');
+    }
+
     async ['@test multiple QP value changes only cause a single model refresh'](assert) {
       assert.expect(2);
 


### PR DESCRIPTION
I've been trying to see if I can bet to the bottom of what is going on in #18416. I figured I would start with a failing test and work backward from there, but I couldn't get very far before hitting a different failure altogether.

I don't intend to land the test in this partial state, but hope that this can be a starting place for actually fixing this bug.

I want _want_ the test to verify is that, when calling `replaceWith` in `afterModel`, the router does not unintentionally push a new state into the history stack, which is what actually happens. However, before I can even get to that kind of assertion in the test, I run into this error:

<img width="492" alt="Screen Shot 2020-08-12 at 5 11 23 PM" src="https://user-images.githubusercontent.com/1645881/90068574-de517a00-dcbe-11ea-8bda-96fd874dc32d.png">

(Screenshot from an [ember twiddle I created](https://ember-twiddle.com/4073a593a39b6f60fefec94c7f8011b2) to make sure that this error was actually happening in a "real" Ember app and not just the test suite. The test suite will fail with the same error.)

What appears to be happening is that the `Transition` object is created without any `routeInfos`

https://github.com/tildeio/router.js/blob/d885da22340da98dcadb45427766efade54ce832/lib/router/router.ts#L123-L130

but then those `routeInfos` are passed around to a number of functions that expect them to exist as a side-effect of calling `finalizeQueryParamChange`.

I am going to assume that this is a fix that will need to at least _start_ in `router.js` and then continue through to here, but figured I would at least post this PR as some small step toward getting to an actual fix.