### PR TITLE
Displayed the correct CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/ember-source"><img src="https://img.shields.io/npm/v/ember-source.svg?style=flat" alt="npm version"></a>
-  <a href="https://github.com/emberjs/ember.js/actions?query=workflow%3ABuild"><img src="https://github.com/emberjs/ember.js/workflows/Build/badge.svg" alt="Build Status"></a>
+  <a href="https://github.com/emberjs/ember.js/actions?query=workflow%3ACI"><img src="https://github.com/emberjs/ember.js/workflows/CI/badge.svg" alt="CI Status"></a>
   <a href="https://codeclimate.com/github/emberjs/ember.js"><img src="https://codeclimate.com/github/emberjs/ember.js.svg" alt="Code Climate"></a>
   <a href="https://discord.gg/zT3asNS"><img src="https://img.shields.io/discord/480462759797063690.svg?logo=discord" alt="Discord Community Server"></a>
   <a href="https://help-wanted.emberjs.com/"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"></a>


### PR DESCRIPTION
## Description

It looked like, when the GitHub Actions workflow was [renamed](https://github.com/emberjs/ember.js/pull/19064) from `Build` to `CI`, the badge in the README didn't get updated. As a result, the badge shows a failing status, which can leave a bad impression.