### PR TITLE
[BUGFIX lts] Fixes ArrayProxy length reactivity

### DIFF
--- a/packages/@ember/-internals/runtime/tests/system/array_proxy/length_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/array_proxy/length_test.js
@@ -5,6 +5,7 @@ import { oneWay as reads, not } from '@ember/object/computed';
 import { A as a } from '../../../lib/mixins/array';
 import { moduleFor, AbstractTestCase, runTask, runLoopSettled } from 'internal-test-helpers';
 import { set, get } from '@ember/-internals/metal';
+import { createCache, getValue } from '@glimmer/validator';
 
 moduleFor(
   'Ember.ArrayProxy - content change (length)',
@@ -204,6 +205,50 @@ moduleFor(
       assert.equal(eCalled, 2, 'expected observer `colors.content.[]` to be called TWICE');
 
       obj.destroy();
+    }
+
+    async ['@test array proxy length is reactive when accessed normally'](assert) {
+      let proxy = ArrayProxy.create({
+        content: a([1, 2, 3]),
+      });
+
+      let lengthCache = createCache(() => proxy.length);
+
+      assert.equal(getValue(lengthCache), 3, 'length is correct');
+
+      proxy.pushObject(4);
+
+      assert.equal(getValue(lengthCache), 4, 'length is correct');
+
+      proxy.removeObject(1);
+
+      assert.equal(getValue(lengthCache), 3, 'length is correct');
+
+      proxy.set('content', []);
+
+      assert.equal(getValue(lengthCache), 0, 'length is correct');
+    }
+
+    async ['@test array proxy length is reactive when accessed using get'](assert) {
+      let proxy = ArrayProxy.create({
+        content: a([1, 2, 3]),
+      });
+
+      let lengthCache = createCache(() => get(proxy, 'length'));
+
+      assert.equal(getValue(lengthCache), 3, 'length is correct');
+
+      proxy.pushObject(4);
+
+      assert.equal(getValue(lengthCache), 4, 'length is correct');
+
+      proxy.removeObject(1);
+
+      assert.equal(getValue(lengthCache), 3, 'length is correct');
+
+      proxy.set('content', []);
+
+      assert.equal(getValue(lengthCache), 0, 'length is correct');
     }
   }
 );


### PR DESCRIPTION
Recent refactors for performance left a gap in the reactivity model,
specifically for the `length` property of ArrayProxy. We now only use
the `CUSTOM_TAG_FOR` API when getting chain tags, which is much better
for most `get()` usages since we don't have to do an extra brand check
that is not very commonly used. However, the `length` property of
ArrayProxy does not have a normal property tag, and it is a native
getter which does not entangle the value naturally when accessed via
autotracking.

This PR sets up the `length` tag eagerly whenever the content of the
ArrayProxy changes, and consumes it when the `length` property is
accessed. It also does the same thing for the `arrTag`, though that is
only used for chain tags. Normally, when the array tag is accessed, it
tracks things properly through the `objectAt` API.

Fixes #19105 