### PR TITLE
New options for deprecate() function

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -752,6 +752,10 @@ const Component = CoreView.extend(
           id: 'ember-views.event-dispatcher.mouseenter-leave-move',
           until: '4.0.0',
           url: 'https://emberjs.com/deprecations/v3.x#toc_component-mouseenter-leave-move',
+          for: 'ember-source',
+          since: {
+            enabled: '3.13.0-beta.1',
+          },
         }
       );
       deprecate(
@@ -761,6 +765,10 @@ const Component = CoreView.extend(
           id: 'ember-views.event-dispatcher.mouseenter-leave-move',
           until: '4.0.0',
           url: 'https://emberjs.com/deprecations/v3.x#toc_component-mouseenter-leave-move',
+          for: 'ember-source',
+          since: {
+            enabled: '3.13.0-beta.1',
+          },
         }
       );
       deprecate(
@@ -770,6 +778,10 @@ const Component = CoreView.extend(
           id: 'ember-views.event-dispatcher.mouseenter-leave-move',
           until: '4.0.0',
           url: 'https://emberjs.com/deprecations/v3.x#toc_component-mouseenter-leave-move',
+          for: 'ember-source',
+          since: {
+            enabled: '3.13.0-beta.1',
+          },
         }
       );
     },

--- a/packages/@ember/-internals/glimmer/lib/environment.ts
+++ b/packages/@ember/-internals/glimmer/lib/environment.ts
@@ -64,6 +64,10 @@ if (DEBUG) {
       deprecate(message, false, {
         id: 'autotracking.mutation-after-consumption',
         until: '4.0.0',
+        for: 'ember-source',
+        since: {
+          enabled: '3.21.0',
+        },
       });
     },
 

--- a/packages/@ember/-internals/glimmer/lib/helpers/action.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/action.ts
@@ -415,6 +415,10 @@ function makeClosureAction(
       {
         until: '3.25.0',
         id: 'actions.custom-invoke-invokable',
+        for: 'ember-source',
+        since: {
+          enabled: '3.23.0-beta.1',
+        },
       }
     );
 

--- a/packages/@ember/-internals/glimmer/lib/modifiers/action.ts
+++ b/packages/@ember/-internals/glimmer/lib/modifiers/action.ts
@@ -156,6 +156,10 @@ export class ActionState {
           {
             until: '3.25.0',
             id: 'actions.custom-invoke-invokable',
+            for: 'ember-source',
+            since: {
+              enabled: '3.23.0-beta.1',
+            },
           }
         );
 
@@ -226,6 +230,10 @@ export default class ActionModifierManager implements ModifierManager<ActionStat
         id: 'ember-views.event-dispatcher.mouseenter-leave-move',
         until: '4.0.0',
         url: 'https://emberjs.com/deprecations/v3.x#toc_action-mouseenter-leave-move',
+        for: 'ember-source',
+        since: {
+          enabled: '3.13.0-beta.1',
+        },
       }
     );
 

--- a/packages/@ember/-internals/glimmer/lib/resolver.ts
+++ b/packages/@ember/-internals/glimmer/lib/resolver.ts
@@ -149,6 +149,10 @@ if (PARTIALS) {
         id: 'ember-views.partial',
         until: '4.0.0',
         url: 'https://deprecations.emberjs.com/v3.x#toc_ember-views-partial',
+        for: 'ember-source',
+        since: {
+          enabled: '3.15.0-beta.1',
+        },
       }
     );
 

--- a/packages/@ember/-internals/glimmer/lib/utils/bindings.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/bindings.ts
@@ -112,6 +112,10 @@ if (EMBER_COMPONENT_IS_VISIBLE) {
             id: 'ember-component.is-visible',
             until: '4.0.0',
             url: 'https://deprecations.emberjs.com/v3.x#toc_ember-component-is-visible',
+            for: 'ember-source',
+            since: {
+              enabled: '3.15.0-beta.1',
+            },
           }
         );
       }

--- a/packages/@ember/-internals/glimmer/lib/utils/managers.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/managers.ts
@@ -171,6 +171,10 @@ export function setComponentManager(
         id: 'deprecate-string-based-component-manager',
         until: '4.0.0',
         url: 'https://emberjs.com/deprecations/v3.x/#toc_component-manager-string-lookup',
+        for: 'ember-source',
+        since: {
+          enabled: '3.8.0',
+        },
       }
     );
     factory = function (owner: Owner) {

--- a/packages/@ember/-internals/meta/lib/meta.ts
+++ b/packages/@ember/-internals/meta/lib/meta.ts
@@ -144,6 +144,10 @@ export class Meta {
       {
         id: 'meta-destruction-apis',
         until: '3.25.0',
+        for: 'ember-source',
+        since: {
+          enabled: '3.21.0',
+        },
       }
     );
   }
@@ -155,6 +159,10 @@ export class Meta {
       {
         id: 'meta-destruction-apis',
         until: '3.25.0',
+        for: 'ember-source',
+        since: {
+          enabled: '3.21.0',
+        },
       }
     );
   }
@@ -166,6 +174,10 @@ export class Meta {
       {
         id: 'meta-destruction-apis',
         until: '3.25.0',
+        for: 'ember-source',
+        since: {
+          enabled: '3.21.0',
+        },
       }
     );
 
@@ -179,6 +191,10 @@ export class Meta {
       {
         id: 'meta-destruction-apis',
         until: '3.25.0',
+        for: 'ember-source',
+        since: {
+          enabled: '3.21.0',
+        },
       }
     );
 

--- a/packages/@ember/-internals/metal/lib/chain-tags.ts
+++ b/packages/@ember/-internals/metal/lib/chain-tags.ts
@@ -109,6 +109,10 @@ function getChainTags(
         {
           until: '3.17.0',
           id: 'ember-metal.computed-deep-each',
+          for: 'ember-source',
+          since: {
+            enabled: '3.13.0-beta.3',
+          },
         }
       );
 

--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -507,6 +507,10 @@ export class ComputedProperty extends ComputedDescriptor {
         id: 'computed-property.override',
         until: '4.0.0',
         url: 'https://emberjs.com/deprecations/v3.x#toc_computed-property-override',
+        for: 'ember-source',
+        since: {
+          enabled: '3.9.0-beta.1',
+        },
       }
     );
 
@@ -715,6 +719,10 @@ class ComputedDecoratorImpl extends Function {
         id: 'computed-property.volatile',
         until: '4.0.0',
         url: 'https://emberjs.com/deprecations/v3.x#toc_computed-property-volatile',
+        for: 'ember-source',
+        since: {
+          enabled: '3.9.0-beta.1',
+        },
       }
     );
     (descriptorForDecorator(this) as ComputedProperty)._volatile = true;
@@ -786,6 +794,10 @@ class ComputedDecoratorImpl extends Function {
         id: 'computed-property.property',
         until: '4.0.0',
         url: 'https://emberjs.com/deprecations/v3.x#toc_computed-property-property',
+        for: 'ember-source',
+        since: {
+          enabled: '3.9.0-beta.1',
+        },
       }
     );
     (descriptorForDecorator(this) as ComputedProperty)._property(...keys);

--- a/packages/@ember/-internals/metal/lib/mixin.ts
+++ b/packages/@ember/-internals/metal/lib/mixin.ts
@@ -826,6 +826,10 @@ if (ALIAS_METHOD) {
         id: 'object.alias-method',
         until: '4.0.0',
         url: 'https://emberjs.com/deprecations/v3.x#toc_object-alias-method',
+        for: 'ember-source',
+        since: {
+          enabled: '3.9.0',
+        },
       }
     );
     return new AliasImpl(methodName);

--- a/packages/@ember/-internals/metal/lib/property_get.ts
+++ b/packages/@ember/-internals/metal/lib/property_get.ts
@@ -189,6 +189,10 @@ export function getWithDefault<T extends object, K extends Extract<keyof T, stri
       id: 'ember-metal.get-with-default',
       until: '4.0.0',
       url: 'https://deprecations.emberjs.com/v3.x#toc_ember-metal-get-with-default',
+      for: 'ember-source',
+      since: {
+        enabled: '3.21.0',
+      },
     }
   );
 

--- a/packages/@ember/-internals/owner/index.ts
+++ b/packages/@ember/-internals/owner/index.ts
@@ -99,6 +99,10 @@ export function getOwner(object: any): Owner {
       {
         id: 'owner.legacy-owner-injection',
         until: '3.25.0',
+        for: 'ember-source',
+        since: {
+          enabled: '3.22.0',
+        },
       }
     );
   }

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -2640,6 +2640,10 @@ if (ROUTER_EVENTS) {
             id: 'deprecate-router-events',
             until: '4.0.0',
             url: 'https://emberjs.com/deprecations/v3.x#toc_deprecate-router-events',
+            for: 'ember-source',
+            since: {
+              enabled: '3.11.0',
+            },
           }
         );
       }
@@ -2652,6 +2656,10 @@ if (ROUTER_EVENTS) {
             id: 'deprecate-router-events',
             until: '4.0.0',
             url: 'https://emberjs.com/deprecations/v3.x#toc_deprecate-router-events',
+            for: 'ember-source',
+            since: {
+              enabled: '3.11.0',
+            },
           }
         );
       }

--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -230,6 +230,10 @@ class EmberRouter extends EmberObject {
                 id: 'deprecate-router-events',
                 until: '4.0.0',
                 url: 'https://emberjs.com/deprecations/v3.x#toc_deprecate-router-events',
+                for: 'ember-source',
+                since: {
+                  enabled: '3.11.0',
+                },
               }
             );
           }
@@ -251,6 +255,10 @@ class EmberRouter extends EmberObject {
                 id: 'deprecate-router-events',
                 until: '4.0.0',
                 url: 'https://emberjs.com/deprecations/v3.x#toc_deprecate-router-events',
+                for: 'ember-source',
+                since: {
+                  enabled: '3.11.0',
+                },
               }
             );
           }
@@ -1486,6 +1494,10 @@ function updatePaths(router: EmberRouter) {
               until: '4.0.0',
               url:
                 'https://emberjs.com/deprecations/v3.x#toc_application-controller-router-properties',
+              for: 'ember-source',
+              since: {
+                enabled: '3.10.0-beta.1',
+              },
             }
           );
           return get(router, 'currentPath');
@@ -1505,6 +1517,10 @@ function updatePaths(router: EmberRouter) {
               until: '4.0.0',
               url:
                 'https://emberjs.com/deprecations/v3.x#toc_application-controller-router-properties',
+              for: 'ember-source',
+              since: {
+                enabled: '3.10.0-beta.1',
+              },
             }
           );
           return get(router, 'currentRouteName');

--- a/packages/@ember/polyfills/lib/merge.ts
+++ b/packages/@ember/polyfills/lib/merge.ts
@@ -32,6 +32,10 @@ function merge(original: object, updates: object) {
     id: 'ember-polyfills.deprecate-merge',
     until: '4.0.0',
     url: 'https://emberjs.com/deprecations/v3.x/#toc_ember-polyfills-deprecate-merge',
+    for: 'ember-source',
+    since: {
+      enabled: '3.6.0-beta.1',
+    },
   });
 
   if (updates === null || typeof updates !== 'object') {

--- a/packages/ember-template-compiler/lib/plugins/deprecate-send-action.ts
+++ b/packages/ember-template-compiler/lib/plugins/deprecate-send-action.ts
@@ -49,6 +49,10 @@ export default function deprecateSendAction(env: EmberASTPluginEnvironment): AST
                     id: 'ember-component.send-action',
                     until: '4.0.0',
                     url: 'https://emberjs.com/deprecations/v3.x#toc_ember-component-send-action',
+                    for: 'ember-source',
+                    since: {
+                      enabled: '3.4.0',
+                    },
                   });
                 } else if (
                   value.type === 'MustacheStatement' &&
@@ -58,6 +62,10 @@ export default function deprecateSendAction(env: EmberASTPluginEnvironment): AST
                     id: 'ember-component.send-action',
                     until: '4.0.0',
                     url: 'https://emberjs.com/deprecations/v3.x#toc_ember-component-send-action',
+                    for: 'ember-source',
+                    since: {
+                      enabled: '3.4.0',
+                    },
                   });
                 }
               }
@@ -76,6 +84,10 @@ export default function deprecateSendAction(env: EmberASTPluginEnvironment): AST
                 id: 'ember-component.send-action',
                 until: '4.0.0',
                 url: 'https://emberjs.com/deprecations/v3.x#toc_ember-component-send-action',
+                for: 'ember-source',
+                since: {
+                  enabled: '3.4.0',
+                },
               });
             }
           });

--- a/packages/ember-template-compiler/lib/plugins/transform-in-element.ts
+++ b/packages/ember-template-compiler/lib/plugins/transform-in-element.ts
@@ -86,6 +86,10 @@ export default function transformInElement(env: EmberASTPluginEnvironment): ASTP
               {
                 id: 'glimmer.private-in-element',
                 until: '3.25.0',
+                for: 'ember-source',
+                since: {
+                  enabled: '3.20.0',
+                },
               }
             );
           }


### PR DESCRIPTION
This implements the `for` and `since` options for the `deprecate()` function as detailed in github.com/emberjs/rfcs/pull/649 Not sure if it's the right place to start, but seemed like the lowest hanging fruit. 

cc @rwjblue @pzuraq 