### PR TITLE
[BUGFIX beta] reimplement $.ready()

### DIFF
--- a/packages/@ember/application/tests/readiness_test.js
+++ b/packages/@ember/application/tests/readiness_test.js
@@ -96,6 +96,7 @@ moduleFor(
       run(() => {
         application = Application.create({ router: false });
         application.deferReadiness();
+        assert.equal(readyWasCalled, 0, "ready wasn't called yet");
       });
 
       assert.equal(readyWasCalled, 0, "ready wasn't called yet");
@@ -107,28 +108,6 @@ moduleFor(
       run(() => {
         application.advanceReadiness();
         assert.equal(readyWasCalled, 0);
-      });
-
-      assert.equal(readyWasCalled, 1, 'ready was called now all readiness deferrals are advanced');
-    }
-
-    ["@test Application's ready event can be deferred by other components (jQuery.isReady === false)"](
-      assert
-    ) {
-      jQuery.isReady = false;
-
-      run(() => {
-        application = Application.create({ router: false });
-        application.deferReadiness();
-        assert.equal(readyWasCalled, 0, "ready wasn't called yet");
-      });
-
-      domReady();
-
-      assert.equal(readyWasCalled, 0, "ready wasn't called yet");
-
-      run(() => {
-        application.advanceReadiness();
       });
 
       assert.equal(readyWasCalled, 1, 'ready was called now all readiness deferrals are advanced');

--- a/tests/docs/expected.js
+++ b/tests/docs/expected.js
@@ -22,6 +22,7 @@ module.exports = {
     '_applicationInstances',
     '_deserializeQueryParam',
     '_deserializeQueryParams',
+    '_document',
     '_fullyScopeQueryParams',
     '_getHashPath',
     '_getObjectsOnNamespaces',


### PR DESCRIPTION
## TODOs
- [x] refactor waitForDOMReady away from jQuery
- [x] figure out if `!this.$ === !hasDOM`
- [x] fix failing tests in `packages/@ember/application/tests/readiness_test.js`
  - [x] find a way to restore mocked readyState or a better way to mock it
  - [x] ~improve coverage for advanceReadiness/deferReadiness cases~

## NOTES
- jquery `.ready()` [implementation](https://github.com/jquery/jquery/blob/df6858df2ed3fc5c424591a5e09b900eb4ce0417/src/core/ready.js#L58-L78): 
  ```js
  function completed() {
    document.removeEventListener( "DOMContentLoaded", completed );
    window.removeEventListener( "load", completed );
    jQuery.ready();
  }


  // Catch cases where $(document).ready() is called
  // after the browser event has already occurred.
  if ( document.readyState !== "loading" ) {


    // Handle it asynchronously to allow scripts the opportunity to delay ready
    window.setTimeout( jQuery.ready );


  } else {


    // Use the handy event callback
    document.addEventListener( "DOMContentLoaded", completed );


    // A fallback to window.onload, that will always work
    window.addEventListener( "load", completed );
  }
  ```