### PR TITLE
Bugfix/query param serialization

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -735,7 +735,7 @@ class EmberRouter extends EmberObject {
   _serializeQueryParam(value: unknown, type: string) {
     if (value === null || value === undefined) {
       return value;
-    } else if (type === 'array' && value instanceof Array) {
+    } else if (type === 'array' && Array.isArray(value)) {
       return JSON.stringify(value);
     } else if (type === 'array' && typeof value === 'string') {
       while (typeof value === 'string') {

--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -735,7 +735,12 @@ class EmberRouter extends EmberObject {
   _serializeQueryParam(value: unknown, type: string) {
     if (value === null || value === undefined) {
       return value;
-    } else if (type === 'array') {
+    } else if (type === 'array' && value instanceof Array) {
+      return JSON.stringify(value);
+    } else if (type === 'array' && typeof value === 'string') {
+      while (typeof value === 'string') {
+        value = JSON.parse(value);
+      }
       return JSON.stringify(value);
     }
 

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -1229,7 +1229,7 @@ moduleFor(
     }
 
     async ['@test (de)serialization: arrays when corrupted'](assert) {
-      assert.expect(7);
+      assert.expect(6);
 
       this.add(
         'controller:index',

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -1228,6 +1228,29 @@ moduleFor(
       this.assertCurrentPath('/?foo=%5B%5D', 'longform supported');
     }
 
+    async ['@test (de)serialization: arrays when corrupted'](assert) {
+      assert.expect(7);
+
+      this.add(
+        'controller:index',
+        Controller.extend({
+          queryParams: [{ category: { type: 'array' } }],
+        })
+      );
+
+      await this.visitAndAssert('/');
+      await this.transitionTo({ queryParams: { category: [2, 3] } });
+      this.assertCurrentPath('/?category=%5B2%2C3%5D', 'handles normal array');
+      await this.transitionTo({ queryParams: { category: [] } });
+      this.assertCurrentPath('/?category=%5B%5D', 'handles empty array');
+      await this.transitionTo({ queryParams: { category: '"[2,3]"' } });
+      this.assertCurrentPath('/?category=%5B2%2C3%5D', 'handles double encoded JSON array');
+      await this.transitionTo({ queryParams: { category: '"\\"[2,3]\\""' } });
+      this.assertCurrentPath('/?category=%5B2%2C3%5D', 'handles triple encoded JSON array');
+      await this.transitionTo({ queryParams: { category: '"\\"\\\\\\"[2,3]\\\\\\"\\""' } });
+      this.assertCurrentPath('/?category=%5B2%2C3%5D', 'handles quadruple encoded JSON array');
+    }
+
     ['@test Url with array query param sets controller property to array'](assert) {
       assert.expect(1);
 


### PR DESCRIPTION
When Ember serializes a query parameter of type `Array`, it does so with JSON.stringify.

Deserialize converts the `string` back to an `Array`.

If there are slow / high latency network connections, it is possible for the `serialize` method to get called in rapid succesion, prior to `deserialize` being called.  This results in `JSON.stringify` being called multiple times on the value, which results in to being converted from an `Array` to a `string`

```js
array = ['red', 'blue'];
// Array [ "red", "blue" ]
once = JSON.stringify(array);
// "[\"red\",\"blue\"]"
twice = JSON.stringify(once);
// "\"[\\\"red\\\",\\\"blue\\\"]\""
```

I've put together a reproduction over on [ember-twiddle](https://ember-twiddle.com/9a887d0edf25027edade31f759e2e9be). **note** if you try too hard, it may crash the browser because the strings grow exponentially.

![QueryParams](https://user-images.githubusercontent.com/1583673/94026958-ee479800-fdec-11ea-9255-17df433b9f69.png)

I've added failing tests for this scenario and then implemented a fix.

I have added a `while` loop to recursively deal with scenarios where the QP's may have been repeatedly encoded.  I don't _think_ this could result in an infinite loop, rather it would result in a error breaking the loop.
