### PR TITLE
[BUGFIX beta] Use args proxy for modifier managers.

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/component-managers/custom.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/custom.ts
@@ -1,13 +1,9 @@
 import { ENV } from '@ember/-internals/environment';
-import { CUSTOM_TAG_FOR } from '@ember/-internals/metal';
 import { Factory } from '@ember/-internals/owner';
-import { HAS_NATIVE_PROXY } from '@ember/-internals/utils';
 import { assert } from '@ember/debug';
-import { DEBUG } from '@glimmer/env';
 import {
+  Arguments,
   Bounds,
-  CapturedArguments,
-  CapturedNamedArguments,
   ComponentCapabilities,
   ComponentDefinition,
   Destroyable,
@@ -16,13 +12,13 @@ import {
   VMArguments,
   WithStaticLayout,
 } from '@glimmer/interfaces';
-import { createConstRef, Reference, valueForRef } from '@glimmer/reference';
-import { registerDestructor, reifyPositional } from '@glimmer/runtime';
+import { createConstRef, Reference } from '@glimmer/reference';
+import { registerDestructor } from '@glimmer/runtime';
 import { unwrapTemplate } from '@glimmer/util';
-import { Tag, track } from '@glimmer/validator';
 import { EmberVMEnvironment } from '../environment';
 import RuntimeResolver from '../resolver';
 import { OwnedTemplate } from '../template';
+import { argsProxyFor } from '../utils/args-proxy';
 import AbstractComponentManager from './abstract';
 
 const CAPABILITIES = {
@@ -149,94 +145,6 @@ export interface ComponentArguments {
   named: Dict<unknown>;
 }
 
-function tagForNamedArg<NamedArgs extends CapturedNamedArguments, K extends keyof NamedArgs>(
-  namedArgs: NamedArgs,
-  key: K
-): Tag {
-  return track(() => valueForRef(namedArgs[key]));
-}
-
-let namedArgsProxyFor: (namedArgs: CapturedNamedArguments, debugName?: string) => Args['named'];
-
-if (HAS_NATIVE_PROXY) {
-  namedArgsProxyFor = <NamedArgs extends CapturedNamedArguments>(
-    namedArgs: NamedArgs,
-    debugName?: string
-  ) => {
-    let getTag = (key: keyof Args) => tagForNamedArg(namedArgs, key);
-
-    let handler: ProxyHandler<{}> = {
-      get(_target, prop) {
-        let ref = namedArgs[prop as string];
-
-        if (ref !== undefined) {
-          return valueForRef(ref);
-        } else if (prop === CUSTOM_TAG_FOR) {
-          return getTag;
-        }
-      },
-
-      has(_target, prop) {
-        return namedArgs[prop as string] !== undefined;
-      },
-
-      ownKeys(_target) {
-        return Object.keys(namedArgs);
-      },
-
-      getOwnPropertyDescriptor(_target, prop) {
-        assert(
-          'args proxies do not have real property descriptors, so you should never need to call getOwnPropertyDescriptor yourself. This code exists for enumerability, such as in for-in loops and Object.keys()',
-          namedArgs[prop as string] !== undefined
-        );
-
-        return {
-          enumerable: true,
-          configurable: true,
-        };
-      },
-    };
-
-    if (DEBUG) {
-      handler.set = function(_target, prop) {
-        assert(
-          `You attempted to set ${debugName}#${String(
-            prop
-          )} on a components arguments. Component arguments are immutable and cannot be updated directly, they always represent the values that are passed to your component. If you want to set default values, you should use a getter instead`
-        );
-
-        return false;
-      };
-    }
-
-    return new Proxy({}, handler);
-  };
-} else {
-  namedArgsProxyFor = <NamedArgs extends CapturedNamedArguments>(namedArgs: NamedArgs) => {
-    let getTag = (key: keyof Args) => tagForNamedArg(namedArgs, key);
-
-    let proxy = {};
-
-    Object.defineProperty(proxy, CUSTOM_TAG_FOR, {
-      configurable: false,
-      enumerable: false,
-      value: getTag,
-    });
-
-    Object.keys(namedArgs).forEach(name => {
-      Object.defineProperty(proxy, name, {
-        enumerable: true,
-        configurable: true,
-        get() {
-          return valueForRef(namedArgs[name]);
-        },
-      });
-    });
-
-    return proxy;
-  };
-}
-
 /**
   The CustomComponentManager allows addons to provide custom component
   implementations that integrate seamlessly into Ember. This is accomplished
@@ -276,25 +184,20 @@ export default class CustomComponentManager<ComponentInstance>
   create(
     env: EmberVMEnvironment,
     definition: CustomComponentDefinitionState<ComponentInstance>,
-    args: VMArguments
+    vmArgs: VMArguments
   ): CustomComponentState<ComponentInstance> {
     let { delegate } = definition;
-    let capturedArgs = args.capture();
-    let { named, positional } = capturedArgs;
-    let namedArgsProxy = namedArgsProxyFor(named);
+    let args = argsProxyFor(vmArgs.capture(), 'component');
 
-    let component = delegate.createComponent(definition.ComponentClass.class, {
-      named: namedArgsProxy,
-      positional: reifyPositional(positional),
-    });
+    let component = delegate.createComponent(definition.ComponentClass.class, args);
 
-    let bucket = new CustomComponentState(delegate, component, capturedArgs, env, namedArgsProxy);
+    let bucket = new CustomComponentState(delegate, component, args, env);
 
     if (ENV._DEBUG_RENDER_TREE) {
       env.extra.debugRenderTree.create(bucket, {
         type: 'component',
         name: definition.name,
-        args: args.capture(),
+        args: vmArgs.capture(),
         instance: component,
         template: definition.template,
       });
@@ -317,12 +220,9 @@ export default class CustomComponentManager<ComponentInstance>
     }
 
     if (hasUpdateHook(bucket.delegate)) {
-      let { delegate, component, args, namedArgsProxy } = bucket;
+      let { delegate, component, args } = bucket;
 
-      delegate.updateComponent(component, {
-        named: namedArgsProxy,
-        positional: reifyPositional(args.positional),
-      });
+      delegate.updateComponent(component, args);
     }
   }
 
@@ -383,9 +283,8 @@ export class CustomComponentState<ComponentInstance> {
   constructor(
     public delegate: ManagerDelegate<ComponentInstance>,
     public component: ComponentInstance,
-    public args: CapturedArguments,
-    public env: EmberVMEnvironment,
-    public namedArgsProxy: Args['named']
+    public args: Arguments,
+    public env: EmberVMEnvironment
   ) {
     if (hasDestructors(delegate)) {
       registerDestructor(this, () => delegate.destroyComponent(component));

--- a/packages/@ember/-internals/glimmer/lib/utils/args-proxy.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/args-proxy.ts
@@ -1,0 +1,210 @@
+import { CUSTOM_TAG_FOR } from '@ember/-internals/metal';
+import { HAS_NATIVE_PROXY } from '@ember/-internals/utils';
+import { assert } from '@ember/debug';
+import { DEBUG } from '@glimmer/env';
+import {
+  Arguments,
+  CapturedArguments,
+  CapturedNamedArguments,
+  CapturedPositionalArguments,
+} from '@glimmer/interfaces';
+import { Reference, valueForRef } from '@glimmer/reference';
+import { Tag, track } from '@glimmer/validator';
+
+function convertToInt(prop: number | string | symbol): number | null {
+  if (typeof prop === 'symbol') return null;
+
+  const num = Number(prop);
+
+  if (isNaN(num)) return null;
+
+  return num % 1 === 0 ? num : null;
+}
+
+function tagForNamedArg(namedArgs: CapturedNamedArguments, key: string): Tag {
+  return track(() => {
+    if (key in namedArgs) {
+      valueForRef(namedArgs[key]);
+    }
+  });
+}
+
+function tagForPositionalArg(positionalArgs: CapturedPositionalArguments, key: string): Tag {
+  return track(() => {
+    if (key === '[]') {
+      // consume all of the tags in the positional array
+      positionalArgs.forEach(valueForRef);
+    }
+
+    const parsed = convertToInt(key);
+
+    if (parsed !== null && parsed < positionalArgs.length) {
+      // consume the tag of the referenced index
+      valueForRef(positionalArgs[parsed]);
+    }
+  });
+}
+
+export let argsProxyFor: (
+  capturedArgs: CapturedArguments,
+  type: 'component' | 'helper' | 'modifier'
+) => Arguments;
+
+if (HAS_NATIVE_PROXY) {
+  argsProxyFor = (capturedArgs, type) => {
+    const { named, positional } = capturedArgs;
+
+    let getNamedTag = (key: string) => tagForNamedArg(named, key);
+    let getPositionalTag = (key: string) => tagForPositionalArg(positional, key);
+
+    const namedHandler: ProxyHandler<{}> = {
+      get(_target, prop) {
+        const ref = named[prop as string];
+
+        if (ref !== undefined) {
+          return valueForRef(ref);
+        } else if (prop === CUSTOM_TAG_FOR) {
+          return getNamedTag;
+        }
+      },
+
+      has(_target, prop) {
+        return prop in named;
+      },
+
+      ownKeys(_target) {
+        return Object.keys(named);
+      },
+
+      isExtensible() {
+        return false;
+      },
+
+      getOwnPropertyDescriptor(_target, prop) {
+        assert(
+          'args proxies do not have real property descriptors, so you should never need to call getOwnPropertyDescriptor yourself. This code exists for enumerability, such as in for-in loops and Object.keys()',
+          prop in named
+        );
+
+        return {
+          enumerable: true,
+          configurable: true,
+        };
+      },
+    };
+
+    const positionalHandler: ProxyHandler<[]> = {
+      get(target, prop) {
+        if (prop === 'length') {
+          return positional.length;
+        }
+
+        const parsed = convertToInt(prop);
+
+        if (parsed !== null && parsed < positional.length) {
+          return valueForRef(positional[parsed]);
+        }
+
+        if (prop === CUSTOM_TAG_FOR) {
+          return getPositionalTag;
+        }
+
+        return (target as any)[prop];
+      },
+
+      isExtensible() {
+        return false;
+      },
+
+      has(_target, prop) {
+        const parsed = convertToInt(prop);
+
+        return parsed !== null && parsed < positional.length;
+      },
+    };
+
+    const namedTarget = Object.create(null);
+    const positionalTarget: unknown[] = [];
+
+    if (DEBUG) {
+      const setHandler = function(_target: unknown, prop: symbol | string | number): never {
+        throw new Error(
+          `You attempted to set ${String(
+            prop
+          )} on the arguments of a component, helper, or modifier. Arguments are immutable and cannot be updated directly, they always represent the values that is passed down. If you want to set default values, you should use a getter and local tracked state instead.`
+        );
+      };
+
+      const forInDebugHandler = (): never => {
+        throw new Error(
+          `Object.keys() was called on the positional arguments array for a ${type}, which is not supported. This function is a low-level function that should not need to be called for positional argument arrays. You may be attempting to iterate over the array using for...in instead of for...of.`
+        );
+      };
+
+      namedHandler.set = setHandler;
+      positionalHandler.set = setHandler;
+      positionalHandler.ownKeys = forInDebugHandler;
+    }
+
+    return {
+      named: new Proxy(namedTarget, namedHandler),
+      positional: new Proxy(positionalTarget, positionalHandler),
+    };
+  };
+} else {
+  argsProxyFor = (capturedArgs, _type) => {
+    const { named, positional } = capturedArgs;
+
+    let getNamedTag = (key: string) => tagForNamedArg(named, key);
+    let getPositionalTag = (key: string) => tagForPositionalArg(positional, key);
+
+    let namedProxy = {};
+
+    Object.defineProperty(namedProxy, CUSTOM_TAG_FOR, {
+      configurable: false,
+      enumerable: false,
+      value: getNamedTag,
+    });
+
+    Object.keys(named).forEach(name => {
+      Object.defineProperty(namedProxy, name, {
+        enumerable: true,
+        configurable: true,
+        get() {
+          return valueForRef(named[name]);
+        },
+      });
+    });
+
+    let positionalProxy: unknown[] = [];
+
+    Object.defineProperty(positionalProxy, CUSTOM_TAG_FOR, {
+      configurable: false,
+      enumerable: false,
+      value: getPositionalTag,
+    });
+
+    positional.forEach((ref: Reference, index: number) => {
+      Object.defineProperty(positionalProxy, index, {
+        enumerable: true,
+        configurable: true,
+        get() {
+          return valueForRef(ref);
+        },
+      });
+    });
+
+    if (DEBUG) {
+      // Prevent mutations in development mode. This will not prevent the
+      // proxy from updating, but will prevent assigning new values or pushing
+      // for instance.
+      Object.freeze(namedProxy);
+      Object.freeze(positionalProxy);
+    }
+
+    return {
+      named: namedProxy,
+      positional: positionalProxy,
+    };
+  };
+}

--- a/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
@@ -1258,6 +1258,15 @@ moduleFor(
 moduleFor(
   'Element modifiers on AngleBracket components',
   class extends RenderingTestCase {
+    assertNamedArgs(actual, expected, message) {
+      // `actual` is likely to be a named args proxy, while the `deepEqual` below would see
+      // the values as the same it would still flag as not deep equals because the constructors
+      // of the two objects do not match (one is a proxy, one is Object)
+      let reifiedActual = Object.assign({}, actual);
+
+      this.assert.deepEqual(reifiedActual, expected, message);
+    }
+
     '@test modifiers are forwarded to a single element receiving the splattributes'(assert) {
       let modifierParams = null;
       let modifierNamedArgs = null;
@@ -1277,8 +1286,8 @@ moduleFor(
         })
       );
       this.render('<TheFoo {{bar "something" foo="else"}}/>', {});
-      assert.deepEqual(modifierParams, ['something']);
-      assert.deepEqual(modifierNamedArgs, { foo: 'else' });
+      assert.deepEqual(modifierParams, ['something'], 'positional arguments');
+      this.assertNamedArgs(modifierNamedArgs, { foo: 'else' }, 'named arguments');
       assert.equal(
         modifiedElement && modifiedElement.getAttribute('id'),
         'inner-div',
@@ -1293,12 +1302,13 @@ moduleFor(
         template:
           '<div id="inner-one" ...attributes>Foo</div><div id="inner-two" ...attributes>Bar</div>',
       });
+      let test = this;
       this.registerModifier(
         'bar',
         BaseModifier.extend({
           didInsertElement(params, namedArgs) {
             assert.deepEqual(params, ['something']);
-            assert.deepEqual(namedArgs, { foo: 'else' });
+            test.assertNamedArgs(namedArgs, { foo: 'else' });
             if (this.element) {
               elementIds.push(this.element.getAttribute('id'));
             }
@@ -1341,7 +1351,7 @@ moduleFor(
         foo: 'else',
       });
       assert.deepEqual(modifierParams, ['something']);
-      assert.deepEqual(modifierNamedArgs, { foo: 'else' });
+      this.assertNamedArgs(modifierNamedArgs, { foo: 'else' });
       assert.equal(
         modifiedElement && modifiedElement.getAttribute('id'),
         'inner-div',
@@ -1349,7 +1359,7 @@ moduleFor(
       );
       runTask(() => setProperties(this.context, { something: 'another', foo: 'thingy' }));
       assert.deepEqual(modifierParams, ['another']);
-      assert.deepEqual(modifierNamedArgs, { foo: 'thingy' });
+      this.assertNamedArgs(modifierNamedArgs, { foo: 'thingy' });
       assert.equal(
         modifiedElement && modifiedElement.getAttribute('id'),
         'inner-div',
@@ -1435,7 +1445,7 @@ moduleFor(
         { foo: 'bar' }
       );
       assert.deepEqual(modifierParams, ['bar']);
-      assert.deepEqual(modifierNamedArgs, { foo: 'bar' });
+      this.assertNamedArgs(modifierNamedArgs, { foo: 'bar' });
       assert.equal(
         modifiedElement && modifiedElement.getAttribute('id'),
         'inner-div',
@@ -1443,7 +1453,7 @@ moduleFor(
       );
       runTask(() => setProperties(this.context, { foo: 'qux' }));
       assert.deepEqual(modifierParams, ['qux']);
-      assert.deepEqual(modifierNamedArgs, { foo: 'qux' });
+      this.assertNamedArgs(modifierNamedArgs, { foo: 'qux' });
       assert.equal(
         modifiedElement && modifiedElement.getAttribute('id'),
         'inner-div',
@@ -1486,7 +1496,7 @@ moduleFor(
         { foo: 'bar' }
       );
       assert.deepEqual(modifierParams, ['bar']);
-      assert.deepEqual(modifierNamedArgs, { foo: 'bar' });
+      this.assertNamedArgs(modifierNamedArgs, { foo: 'bar' });
       assert.deepEqual(
         elementIds,
         ['outer-div', 'inner-div'],

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
@@ -304,7 +304,7 @@ moduleFor(
       let ComponentClass = setComponentManager(
         createBasicManager,
         EmberObject.extend({
-          salutation: computed('args.positional', function() {
+          salutation: computed('args.positional.[]', function() {
             return this.args.positional[0] + ' ' + this.args.positional[1];
           }),
         })
@@ -320,14 +320,78 @@ moduleFor(
       this.assertHTML(`<p>Yehuda Katz</p>`);
     }
 
-    ['@test positional params are updated if they change']() {
+    ['@test positional params are updated if they change (computed, arr tag)']() {
       let ComponentClass = setComponentManager(
         createBasicManager,
         EmberObject.extend({
-          salutation: computed('args.positional', function() {
+          salutation: computed('args.positional.[]', function() {
             return this.args.positional[0] + ' ' + this.args.positional[1];
           }),
         })
+      );
+
+      this.registerComponent('foo-bar', {
+        template: `<p>{{salutation}}</p>`,
+        ComponentClass,
+      });
+
+      this.render('{{foo-bar firstName lastName}}', {
+        firstName: 'Yehuda',
+        lastName: 'Katz',
+      });
+
+      this.assertHTML(`<p>Yehuda Katz</p>`);
+
+      runTask(() =>
+        setProperties(this.context, {
+          firstName: 'Chad',
+          lastName: 'Hietala',
+        })
+      );
+
+      this.assertHTML(`<p>Chad Hietala</p>`);
+    }
+
+    ['@test positional params are updated if they change (computed, individual tags)']() {
+      let ComponentClass = setComponentManager(
+        createBasicManager,
+        EmberObject.extend({
+          salutation: computed('args.positional.0', 'args.positional.1', function() {
+            return this.args.positional[0] + ' ' + this.args.positional[1];
+          }),
+        })
+      );
+
+      this.registerComponent('foo-bar', {
+        template: `<p>{{salutation}}</p>`,
+        ComponentClass,
+      });
+
+      this.render('{{foo-bar firstName lastName}}', {
+        firstName: 'Yehuda',
+        lastName: 'Katz',
+      });
+
+      this.assertHTML(`<p>Yehuda Katz</p>`);
+
+      runTask(() =>
+        setProperties(this.context, {
+          firstName: 'Chad',
+          lastName: 'Hietala',
+        })
+      );
+
+      this.assertHTML(`<p>Chad Hietala</p>`);
+    }
+
+    ['@test positional params are updated if they change (native)']() {
+      let ComponentClass = setComponentManager(
+        createBasicManager,
+        class extends EmberObject {
+          get salutation() {
+            return this.args.positional[0] + ' ' + this.args.positional[1];
+          }
+        }
       );
 
       this.registerComponent('foo-bar', {

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
@@ -5,11 +5,8 @@ import { setModifierManager, modifierCapabilities } from '@ember/-internals/glim
 import { set, tracked } from '@ember/-internals/metal';
 import { backtrackingMessageFor } from '../utils/backtracking-rerender';
 
-class ModifierManagerTest extends RenderingTestCase {}
-
 class CustomModifierManager {
   constructor(owner) {
-    this.capabilities = modifierCapabilities('3.13');
     this.owner = owner;
   }
 
@@ -32,185 +29,283 @@ class CustomModifierManager {
     instance.willDestroyElement();
   }
 }
+class ModifierManagerTest extends RenderingTestCase {
+  '@test throws a useful error when missing capabilities'() {
+    this.registerModifier(
+      'foo-bar',
+      setModifierManager(() => {
+        return {
+          createModifier() {},
+          installModifier() {},
+          updateModifier() {},
+          destroyModifier() {},
+        };
+      }, {})
+    );
 
-moduleFor(
-  'Basic Custom Modifier Manager',
-  class extends ModifierManagerTest {
-    '@test throws a useful error when missing capabilities'() {
-      this.registerModifier(
-        'foo-bar',
-        setModifierManager(() => {
-          return {
-            createModifier() {},
-            installModifier() {},
-            updateModifier() {},
-            destroyModifier() {},
-          };
-        }, {})
-      );
-
-      expectAssertion(() => {
-        this.render('<h1 {{foo-bar}}>hello world</h1>');
-      }, /Custom modifier managers must define their capabilities/);
-    }
-
-    '@test can register a custom element modifier and render it'(assert) {
-      let ModifierClass = setModifierManager(
-        owner => {
-          return new CustomModifierManager(owner);
-        },
-        EmberObject.extend({
-          didInsertElement() {},
-          didUpdate() {},
-          willDestroyElement() {},
-        })
-      );
-
-      this.registerModifier(
-        'foo-bar',
-        ModifierClass.extend({
-          didInsertElement() {
-            assert.ok(true, 'Called didInsertElement');
-          },
-        })
-      );
-
+    expectAssertion(() => {
       this.render('<h1 {{foo-bar}}>hello world</h1>');
-      this.assertHTML(`<h1>hello world</h1>`);
-    }
+    }, /Custom modifier managers must define their capabilities/);
+  }
 
-    '@test custom lifecycle hooks'(assert) {
-      assert.expect(9);
-      let ModifierClass = setModifierManager(
-        owner => {
-          return new CustomModifierManager(owner);
+  '@test can register a custom element modifier and render it'(assert) {
+    let ModifierClass = setModifierManager(
+      owner => {
+        return new this.CustomModifierManager(owner);
+      },
+      EmberObject.extend({
+        didInsertElement() {},
+        didUpdate() {},
+        willDestroyElement() {},
+      })
+    );
+
+    this.registerModifier(
+      'foo-bar',
+      ModifierClass.extend({
+        didInsertElement() {
+          assert.ok(true, 'Called didInsertElement');
         },
-        EmberObject.extend({
-          didInsertElement() {},
-          didUpdate() {},
-          willDestroyElement() {},
-        })
-      );
+      })
+    );
 
-      this.registerModifier(
-        'foo-bar',
-        ModifierClass.extend({
-          didUpdate([truthy]) {
-            assert.ok(true, 'Called didUpdate');
-            assert.equal(truthy, 'true', 'gets updated args');
-          },
-          didInsertElement([truthy]) {
-            assert.ok(true, 'Called didInsertElement');
-            assert.equal(truthy, true, 'gets initial args');
-          },
-          willDestroyElement() {
-            assert.ok(true, 'Called willDestroyElement');
-          },
-        })
-      );
+    this.render('<h1 {{foo-bar}}>hello world</h1>');
+    this.assertHTML(`<h1>hello world</h1>`);
+  }
 
-      this.render('{{#if truthy}}<h1 {{foo-bar truthy}}>hello world</h1>{{/if}}', {
-        truthy: true,
-      });
-      this.assertHTML(`<h1>hello world</h1>`);
+  '@test custom lifecycle hooks'(assert) {
+    assert.expect(9);
+    let ModifierClass = setModifierManager(
+      owner => {
+        return new this.CustomModifierManager(owner);
+      },
+      EmberObject.extend({
+        didInsertElement() {},
+        didUpdate() {},
+        willDestroyElement() {},
+      })
+    );
 
-      runTask(() => set(this.context, 'truthy', 'true'));
-
-      runTask(() => set(this.context, 'truthy', false));
-
-      runTask(() => set(this.context, 'truthy', true));
-    }
-
-    '@test associates manager even through an inheritance structure'(assert) {
-      assert.expect(5);
-      let ModifierClass = setModifierManager(
-        owner => {
-          return new CustomModifierManager(owner);
+    this.registerModifier(
+      'foo-bar',
+      ModifierClass.extend({
+        didUpdate([truthy]) {
+          assert.ok(true, 'Called didUpdate');
+          assert.equal(truthy, 'true', 'gets updated args');
         },
-        EmberObject.extend({
-          didInsertElement() {},
-          didUpdate() {},
-          willDestroyElement() {},
-        })
-      );
+        didInsertElement([truthy]) {
+          assert.ok(true, 'Called didInsertElement');
+          assert.equal(truthy, true, 'gets initial args');
+        },
+        willDestroyElement() {
+          assert.ok(true, 'Called willDestroyElement');
+        },
+      })
+    );
 
-      ModifierClass = ModifierClass.extend({
+    this.render('{{#if truthy}}<h1 {{foo-bar truthy}}>hello world</h1>{{/if}}', {
+      truthy: true,
+    });
+    this.assertHTML(`<h1>hello world</h1>`);
+
+    runTask(() => set(this.context, 'truthy', 'true'));
+
+    runTask(() => set(this.context, 'truthy', false));
+
+    runTask(() => set(this.context, 'truthy', true));
+  }
+
+  '@test associates manager even through an inheritance structure'(assert) {
+    assert.expect(5);
+    let ModifierClass = setModifierManager(
+      owner => {
+        return new this.CustomModifierManager(owner);
+      },
+      EmberObject.extend({
+        didInsertElement() {},
+        didUpdate() {},
+        willDestroyElement() {},
+      })
+    );
+
+    ModifierClass = ModifierClass.extend({
+      didInsertElement([truthy]) {
+        this._super(...arguments);
+        assert.ok(true, 'Called didInsertElement');
+        assert.equal(truthy, true, 'gets initial args');
+      },
+    });
+
+    this.registerModifier(
+      'foo-bar',
+      ModifierClass.extend({
         didInsertElement([truthy]) {
           this._super(...arguments);
           assert.ok(true, 'Called didInsertElement');
           assert.equal(truthy, true, 'gets initial args');
         },
-      });
+      })
+    );
 
-      this.registerModifier(
-        'foo-bar',
-        ModifierClass.extend({
-          didInsertElement([truthy]) {
-            this._super(...arguments);
-            assert.ok(true, 'Called didInsertElement');
-            assert.equal(truthy, true, 'gets initial args');
-          },
-        })
-      );
+    this.render('<h1 {{foo-bar truthy}}>hello world</h1>', {
+      truthy: true,
+    });
+    this.assertHTML(`<h1>hello world</h1>`);
+  }
 
-      this.render('<h1 {{foo-bar truthy}}>hello world</h1>', {
-        truthy: true,
-      });
-      this.assertHTML(`<h1>hello world</h1>`);
-    }
+  '@test can give consistent access to underlying DOM element'(assert) {
+    assert.expect(4);
+    let ModifierClass = setModifierManager(
+      owner => {
+        return new this.CustomModifierManager(owner);
+      },
+      EmberObject.extend({
+        didInsertElement() {},
+        didUpdate() {},
+        willDestroyElement() {},
+      })
+    );
 
-    '@test can give consistent access to underlying DOM element'(assert) {
-      assert.expect(4);
-      let ModifierClass = setModifierManager(
-        owner => {
-          return new CustomModifierManager(owner);
+    this.registerModifier(
+      'foo-bar',
+      ModifierClass.extend({
+        savedElement: undefined,
+        didInsertElement(positional) {
+          // consume first positional argument (ensures updates run)
+          positional[0];
+
+          assert.equal(this.element.tagName, 'H1');
+          this.set('savedElement', this.element);
         },
-        EmberObject.extend({
-          didInsertElement() {},
-          didUpdate() {},
-          willDestroyElement() {},
-        })
-      );
+        didUpdate() {
+          assert.equal(this.element, this.savedElement);
+        },
+        willDestroyElement() {
+          assert.equal(this.element, this.savedElement);
+        },
+      })
+    );
 
-      this.registerModifier(
-        'foo-bar',
-        ModifierClass.extend({
-          savedElement: undefined,
-          didInsertElement() {
-            assert.equal(this.element.tagName, 'H1');
-            this.set('savedElement', this.element);
-          },
-          didUpdate() {
-            assert.equal(this.element, this.savedElement);
-          },
-          willDestroyElement() {
-            assert.equal(this.element, this.savedElement);
-          },
-        })
-      );
+    this.render('<h1 {{foo-bar truthy}}>hello world</h1>', {
+      truthy: true,
+    });
+    this.assertHTML(`<h1>hello world</h1>`);
 
-      this.render('<h1 {{foo-bar truthy}}>hello world</h1>', {
-        truthy: true,
-      });
-      this.assertHTML(`<h1>hello world</h1>`);
+    runTask(() => set(this.context, 'truthy', 'true'));
+  }
 
-      runTask(() => set(this.context, 'truthy', 'true'));
+  '@test lifecycle hooks are autotracked by default'(assert) {
+    let TrackedClass = EmberObject.extend({
+      count: tracked({ value: 0 }),
+    });
+
+    let trackedOne = TrackedClass.create();
+    let trackedTwo = TrackedClass.create();
+
+    let insertCount = 0;
+    let updateCount = 0;
+
+    let ModifierClass = setModifierManager(
+      owner => {
+        return new this.CustomModifierManager(owner);
+      },
+      EmberObject.extend({
+        didInsertElement() {},
+        didUpdate() {},
+        willDestroyElement() {},
+      })
+    );
+
+    this.registerModifier(
+      'foo-bar',
+      ModifierClass.extend({
+        didInsertElement() {
+          // track the count of the first item
+          trackedOne.count;
+          insertCount++;
+        },
+
+        didUpdate() {
+          // track the count of the second item
+          trackedTwo.count;
+          updateCount++;
+        },
+      })
+    );
+
+    this.render('<h1 {{foo-bar truthy}}>hello world</h1>');
+    this.assertHTML(`<h1>hello world</h1>`);
+
+    assert.equal(insertCount, 1);
+    assert.equal(updateCount, 0);
+
+    runTask(() => trackedTwo.count++);
+    assert.equal(updateCount, 0);
+
+    runTask(() => trackedOne.count++);
+    assert.equal(updateCount, 1);
+
+    runTask(() => trackedOne.count++);
+    assert.equal(updateCount, 1);
+
+    runTask(() => trackedTwo.count++);
+    assert.equal(updateCount, 2);
+  }
+
+  '@test provides a helpful assertion when mutating a value that was consumed already'() {
+    class Person {
+      @tracked name = 'bob';
     }
 
-    '@test lifecycle hooks are autotracked by default'(assert) {
-      let TrackedClass = EmberObject.extend({
-        count: tracked({ value: 0 }),
-      });
+    let ModifierClass = setModifierManager(
+      owner => {
+        return new this.CustomModifierManager(owner);
+      },
+      class {
+        static create() {
+          return new this();
+        }
 
-      let trackedOne = TrackedClass.create();
-      let trackedTwo = TrackedClass.create();
+        didInsertElement() {}
+        didUpdate() {}
+        willDestroyElement() {}
+      }
+    );
 
+    this.registerModifier(
+      'foo-bar',
+      class MyModifier extends ModifierClass {
+        didInsertElement([person]) {
+          person.name;
+          person.name = 'sam';
+        }
+      }
+    );
+
+    let expectedMessage = backtrackingMessageFor('name', 'Person', {
+      renderTree: ['\\(instance of a `foo-bar` modifier\\)'],
+    });
+
+    expectAssertion(() => {
+      this.render('<h1 {{foo-bar this.person}}>hello world</h1>', { person: new Person() });
+    }, expectedMessage);
+  }
+}
+
+moduleFor(
+  'Basic Custom Modifier Manager: 3.13',
+  class extends ModifierManagerTest {
+    CustomModifierManager = class extends CustomModifierManager {
+      capabilities = modifierCapabilities('3.13');
+    };
+
+    '@test modifers consume all arguments'(assert) {
       let insertCount = 0;
       let updateCount = 0;
 
       let ModifierClass = setModifierManager(
         owner => {
-          return new CustomModifierManager(owner);
+          return new this.CustomModifierManager(owner);
         },
         EmberObject.extend({
           didInsertElement() {},
@@ -222,76 +317,153 @@ moduleFor(
       this.registerModifier(
         'foo-bar',
         ModifierClass.extend({
-          didInsertElement() {
-            // track the count of the first item
-            trackedOne.count;
+          didInsertElement(_positional, named) {
             insertCount++;
+
+            // consume qux
+            named.qux;
           },
 
-          didUpdate() {
-            // track the count of the second item
-            trackedTwo.count;
+          didUpdate(_positiona, named) {
             updateCount++;
+
+            // consume qux
+            named.qux;
           },
         })
       );
 
-      this.render('<h1 {{foo-bar truthy}}>hello world</h1>');
+      this.render('<h1 {{foo-bar bar=this.bar qux=this.qux}}>hello world</h1>', {
+        bar: 'bar',
+        qux: 'quz',
+      });
+
       this.assertHTML(`<h1>hello world</h1>`);
 
       assert.equal(insertCount, 1);
       assert.equal(updateCount, 0);
 
-      runTask(() => trackedTwo.count++);
-      assert.equal(updateCount, 0);
-
-      runTask(() => trackedOne.count++);
+      runTask(() => set(this.context, 'bar', 'other bar'));
       assert.equal(updateCount, 1);
 
-      runTask(() => trackedOne.count++);
-      assert.equal(updateCount, 1);
-
-      runTask(() => trackedTwo.count++);
+      runTask(() => set(this.context, 'qux', 'quuuuxxxxxx'));
       assert.equal(updateCount, 2);
     }
+  }
+);
 
-    '@test provides a helpful assertion when mutating a value that was consumed already'() {
-      class Person {
-        @tracked name = 'bob';
-      }
+moduleFor(
+  'Basic Custom Modifier Manager: 3.22',
+  class extends ModifierManagerTest {
+    CustomModifierManager = class extends CustomModifierManager {
+      capabilities = modifierCapabilities('3.22');
+    };
+
+    '@test modifers only track positional arguments they consume'(assert) {
+      let insertCount = 0;
+      let updateCount = 0;
 
       let ModifierClass = setModifierManager(
         owner => {
-          return new CustomModifierManager(owner);
+          return new this.CustomModifierManager(owner);
         },
-        class {
-          static create() {
-            return new this();
-          }
-
-          didInsertElement() {}
-          didUpdate() {}
-          willDestroyElement() {}
-        }
+        EmberObject.extend({
+          didInsertElement() {},
+          didUpdate() {},
+          willDestroyElement() {},
+        })
       );
 
       this.registerModifier(
         'foo-bar',
-        class MyModifier extends ModifierClass {
-          didInsertElement([person]) {
-            person.name;
-            person.name = 'sam';
-          }
+        ModifierClass.extend({
+          didInsertElement(positional) {
+            insertCount++;
+
+            // consume the second positional
+            positional[1];
+          },
+
+          didUpdate(positional) {
+            updateCount++;
+
+            // consume the second positional
+            positional[1];
+          },
+        })
+      );
+
+      this.render(
+        '<h1 {{foo-bar this.positionOne this.positionTwo bar=this.bar qux=this.qux}}>hello world</h1>',
+        {
+          positionOne: 'first!!!',
+          positionTwo: 'second :(',
+          bar: 'bar',
+          qux: 'quz',
         }
       );
 
-      let expectedMessage = backtrackingMessageFor('name', 'Person', {
-        renderTree: ['\\(instance of a `foo-bar` modifier\\)'],
+      this.assertHTML(`<h1>hello world</h1>`);
+
+      assert.equal(insertCount, 1);
+      assert.equal(updateCount, 0);
+
+      runTask(() => set(this.context, 'positionOne', 'no first?'));
+      assert.equal(updateCount, 0);
+
+      runTask(() => set(this.context, 'positionTwo', 'YASSSSSSS!!!'));
+      assert.equal(updateCount, 1);
+    }
+
+    '@test modifers only track named arguments they consume'(assert) {
+      let insertCount = 0;
+      let updateCount = 0;
+
+      let ModifierClass = setModifierManager(
+        owner => {
+          return new this.CustomModifierManager(owner);
+        },
+        EmberObject.extend({
+          didInsertElement() {},
+          didUpdate() {},
+          willDestroyElement() {},
+        })
+      );
+
+      this.registerModifier(
+        'foo-bar',
+        ModifierClass.extend({
+          didInsertElement(_positional, named) {
+            insertCount++;
+
+            // consume qux
+            named.qux;
+          },
+
+          didUpdate(_positiona, named) {
+            updateCount++;
+
+            // consume qux
+            named.qux;
+          },
+        })
+      );
+
+      this.render('<h1 {{foo-bar bar=this.bar qux=this.qux}}>hello world</h1>', {
+        bar: 'bar',
+        qux: 'quz',
       });
 
-      expectAssertion(() => {
-        this.render('<h1 {{foo-bar this.person}}>hello world</h1>', { person: new Person() });
-      }, expectedMessage);
+      this.assertHTML(`<h1>hello world</h1>`);
+
+      assert.equal(insertCount, 1);
+      assert.equal(updateCount, 0);
+
+      runTask(() => set(this.context, 'bar', 'other bar'));
+      assert.equal(updateCount, 0);
+
+      runTask(() => set(this.context, 'qux', 'quuuuxxxxxx'));
+      assert.equal(updateCount, 1);
     }
   }
 );


### PR DESCRIPTION
This PR does two main things:

1. Generalizes the args proxy for use in components, helpers, and modifiers. This does change the semantics slightly of `positional` arguments for component managers, notably it would make it so using computed properties with them would require a bit more work from custom component managers. The new semantics are more inline with the future of Ember, but if there many custom managers that use positional args we may want to reconsider this change.
2. Introduce the `3.22` manager API version to ensure that custom modifier managers only consume the arguments that are actually used by the manager. In order for specific modifiers to take advantage of these changes, they need to be updated to use `modifierCapabilities('3.22')` (instead of `3.13`).

Fixes #19162