### PR TITLE
[BUGFIX lts] Entangles custom EmberArray implementations when accessed

### DIFF
--- a/packages/@ember/-internals/metal/lib/property_get.ts
+++ b/packages/@ember/-internals/metal/lib/property_get.ts
@@ -1,7 +1,7 @@
 /**
 @module @ember/object
 */
-import { HAS_NATIVE_PROXY, setProxy, symbol } from '@ember/-internals/utils';
+import { HAS_NATIVE_PROXY, isEmberArray, setProxy, symbol } from '@ember/-internals/utils';
 import { assert, deprecate } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 import {
@@ -130,7 +130,7 @@ export function _getProp(obj: object, keyName: string) {
     if (isTracking()) {
       consumeTag(tagFor(obj, keyName));
 
-      if (Array.isArray(value)) {
+      if (Array.isArray(value) || isEmberArray(value)) {
         // Add the tag of the returned value if it is an array, since arrays
         // should always cause updates if they are consumed and then changed
         consumeTag(tagFor(value, '[]'));

--- a/packages/@ember/-internals/metal/lib/tracked.ts
+++ b/packages/@ember/-internals/metal/lib/tracked.ts
@@ -1,3 +1,4 @@
+import { isEmberArray } from '@ember/-internals/utils';
 import { assert } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 import { consumeTag, dirtyTagFor, tagFor, trackedData } from '@glimmer/validator';
@@ -162,7 +163,7 @@ function descriptorForField([_target, key, desc]: [
 
       // Add the tag of the returned value if it is an array, since arrays
       // should always cause updates if they are consumed and then changed
-      if (Array.isArray(value)) {
+      if (Array.isArray(value) || isEmberArray(value)) {
         consumeTag(tagFor(value, '[]'));
       }
 

--- a/packages/@ember/-internals/runtime/lib/mixins/array.js
+++ b/packages/@ember/-internals/runtime/lib/mixins/array.js
@@ -3,7 +3,7 @@
 */
 import { DEBUG } from '@glimmer/env';
 import { PROXY_CONTENT } from '@ember/-internals/metal';
-import { EMBER_ARRAY, HAS_NATIVE_PROXY, tryInvoke } from '@ember/-internals/utils';
+import { setEmberArray, HAS_NATIVE_PROXY, tryInvoke } from '@ember/-internals/utils';
 import {
   get,
   set,
@@ -216,7 +216,10 @@ function mapBy(key) {
   @public
 */
 const ArrayMixin = Mixin.create(Enumerable, {
-  [EMBER_ARRAY]: true,
+  init() {
+    this._super(...arguments);
+    setEmberArray(this);
+  },
 
   /**
     __Required.__ You must implement this method to apply this mixin.

--- a/packages/@ember/-internals/utils/index.ts
+++ b/packages/@ember/-internals/utils/index.ts
@@ -32,7 +32,7 @@ export { HAS_NATIVE_SYMBOL } from './lib/symbol-utils';
 export { HAS_NATIVE_PROXY } from './lib/proxy-utils';
 export { isProxy, setProxy } from './lib/is_proxy';
 export { default as Cache } from './lib/cache';
-export { EMBER_ARRAY, EmberArray, isEmberArray } from './lib/ember-array';
+export { EmberArray, setEmberArray, isEmberArray } from './lib/ember-array';
 export {
   setupMandatorySetter,
   teardownMandatorySetter,

--- a/packages/@ember/-internals/utils/lib/ember-array.ts
+++ b/packages/@ember/-internals/utils/lib/ember-array.ts
@@ -1,6 +1,6 @@
-import { symbol } from './symbol';
+import { _WeakSet } from '@glimmer/util';
 
-export const EMBER_ARRAY = symbol('EMBER_ARRAY');
+const EMBER_ARRAYS = new _WeakSet();
 
 export interface EmberArray<T> {
   length: number;
@@ -10,6 +10,10 @@ export interface EmberArray<T> {
   splice(start: number, deleteCount: number, ...items: T[]): void;
 }
 
-export function isEmberArray(obj: any): obj is EmberArray<unknown> {
-  return obj && obj[EMBER_ARRAY];
+export function setEmberArray(obj: object) {
+  EMBER_ARRAYS.add(obj);
+}
+
+export function isEmberArray(obj: unknown): obj is EmberArray<unknown> {
+  return EMBER_ARRAYS.has(obj as object);
 }

--- a/packages/@ember/-internals/utils/tests/trackable-object-test.js
+++ b/packages/@ember/-internals/utils/tests/trackable-object-test.js
@@ -1,12 +1,15 @@
-import { EMBER_ARRAY, isEmberArray } from '..';
+import { setEmberArray, isEmberArray } from '..';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 moduleFor(
   '@ember/-internals/utils Trackable Object',
   class extends AbstractTestCase {
     ['@test classes'](assert) {
-      class Test {}
-      Test.prototype[EMBER_ARRAY] = true;
+      class Test {
+        constructor() {
+          setEmberArray(this);
+        }
+      }
 
       let instance = new Test();
 


### PR DESCRIPTION
Restores the previous logic that existed for entangling custom EmberArray implementations when they are accessed, along with a test for the functionality.