### PR TITLE
Enforce usage of `capabilities` generation.

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/helpers/custom.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/custom.ts
@@ -3,10 +3,11 @@ import { DEBUG } from '@glimmer/env';
 import { Arguments, Helper as GlimmerHelper } from '@glimmer/interfaces';
 import { createComputeRef, UNDEFINED_REFERENCE } from '@glimmer/reference';
 import { argsProxyFor } from '../utils/args-proxy';
+import { buildCapabilities, InternalCapabilities } from '../utils/managers';
 
 export type HelperDefinition = object;
 
-export interface HelperCapabilities {
+export interface HelperCapabilities extends InternalCapabilities {
   hasValue: boolean;
   hasDestroyable: boolean;
   hasScheduledEffect: boolean;
@@ -29,11 +30,11 @@ export function helperCapabilities(
     !options.hasScheduledEffect
   );
 
-  return {
+  return buildCapabilities({
     hasValue: Boolean(options.hasValue),
     hasDestroyable: Boolean(options.hasDestroyable),
     hasScheduledEffect: Boolean(options.hasScheduledEffect),
-  };
+  });
 }
 
 export interface HelperManager<HelperStateBucket = unknown> {

--- a/packages/@ember/-internals/glimmer/lib/modifiers/custom.ts
+++ b/packages/@ember/-internals/glimmer/lib/modifiers/custom.ts
@@ -6,6 +6,7 @@ import { registerDestructor, reifyArgs } from '@glimmer/runtime';
 import { createUpdatableTag, untrack, UpdatableTag } from '@glimmer/validator';
 import { SimpleElement } from '@simple-dom/interface';
 import { argsProxyFor } from '../utils/args-proxy';
+import { buildCapabilities, InternalCapabilities } from '../utils/managers';
 
 export interface CustomModifierDefinitionState<ModifierInstance> {
   ModifierClass: Factory<ModifierInstance>;
@@ -25,7 +26,7 @@ export interface OptionalCapabilities {
   };
 }
 
-export interface Capabilities {
+export interface Capabilities extends InternalCapabilities {
   disableAutoTracking: boolean;
   useArgsProxy: boolean;
   passFactoryToCreate: boolean;
@@ -40,11 +41,11 @@ export function capabilities<Version extends keyof OptionalCapabilities>(
     managerAPI === '3.13' || managerAPI === '3.22'
   );
 
-  return {
+  return buildCapabilities({
     disableAutoTracking: Boolean(optionalFeatures.disableAutoTracking),
     useArgsProxy: managerAPI === '3.13' ? false : true,
     passFactoryToCreate: managerAPI === '3.13',
-  };
+  }) as Capabilities;
 }
 
 export class CustomModifierDefinition<ModifierInstance> {
@@ -123,11 +124,6 @@ class InteractiveCustomModifierManager<ModifierInstance>
   ) {
     let { delegate, ModifierClass } = definition;
     let capturedArgs = vmArgs.capture();
-
-    assert(
-      'Custom modifier managers must define their capabilities using the capabilities() helper function',
-      typeof delegate.capabilities === 'object' && delegate.capabilities !== null
-    );
 
     let { useArgsProxy, passFactoryToCreate } = delegate.capabilities;
 

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
@@ -522,6 +522,62 @@ moduleFor(
       this.assertHTML(`<p>hello max</p>`);
       assert.verifySteps(['updateComponent', 'didUpdateComponent']);
     }
+
+    '@test capabilities helper function must be used to generate capabilities'(assert) {
+      let ComponentClass = setComponentManager(
+        () => {
+          return EmberObject.create({
+            capabilities: {
+              asyncLifecycleCallbacks: true,
+              destructor: true,
+              update: false,
+            },
+
+            createComponent(factory, args) {
+              assert.step('createComponent');
+              return factory.create({ args });
+            },
+
+            updateComponent(component, args) {
+              assert.step('updateComponent');
+              set(component, 'args', args);
+            },
+
+            destroyComponent(component) {
+              assert.step('destroyComponent');
+              component.destroy();
+            },
+
+            getContext(component) {
+              assert.step('getContext');
+              return component;
+            },
+
+            didCreateComponent() {
+              assert.step('didCreateComponent');
+            },
+
+            didUpdateComponent() {
+              assert.step('didUpdateComponent');
+            },
+          });
+        },
+        EmberObject.extend({
+          greeting: 'hello',
+        })
+      );
+
+      this.registerComponent('foo-bar', {
+        template: `<p>{{greeting}} {{@name}}</p>`,
+        ComponentClass,
+      });
+
+      expectAssertion(() => {
+        this.render('{{foo-bar name=name}}', { name: 'world' });
+      }, /Custom component managers must have a `capabilities` property that is the result of calling the `capabilities\('3.4' \| '3.13'\)` \(imported via `import \{ capabilities \} from '@ember\/component';`\). /);
+
+      assert.verifySteps([]);
+    }
   }
 );
 
@@ -772,6 +828,62 @@ moduleFor(
       assert.verifySteps(['createComponent', 'getContext']);
 
       runTask(() => this.context.set('value', 'bar'));
+      assert.verifySteps([]);
+    }
+
+    '@test capabilities helper function must be used to generate capabilities'(assert) {
+      let ComponentClass = setComponentManager(
+        () => {
+          return EmberObject.create({
+            capabilities: {
+              asyncLifecycleCallbacks: true,
+              destructor: true,
+              update: false,
+            },
+
+            createComponent(factory, args) {
+              assert.step('createComponent');
+              return factory.create({ args });
+            },
+
+            updateComponent(component, args) {
+              assert.step('updateComponent');
+              set(component, 'args', args);
+            },
+
+            destroyComponent(component) {
+              assert.step('destroyComponent');
+              component.destroy();
+            },
+
+            getContext(component) {
+              assert.step('getContext');
+              return component;
+            },
+
+            didCreateComponent() {
+              assert.step('didCreateComponent');
+            },
+
+            didUpdateComponent() {
+              assert.step('didUpdateComponent');
+            },
+          });
+        },
+        EmberObject.extend({
+          greeting: 'hello',
+        })
+      );
+
+      this.registerComponent('foo-bar', {
+        template: `<p>{{greeting}} {{@name}}</p>`,
+        ComponentClass,
+      });
+
+      expectAssertion(() => {
+        this.render('<FooBar @name={{name}} />', { name: 'world' });
+      }, /Custom component managers must have a `capabilities` property that is the result of calling the `capabilities\('3.4' \| '3.13'\)` \(imported via `import \{ capabilities \} from '@ember\/component';`\). /);
+
       assert.verifySteps([]);
     }
   }

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/helper-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/helper-manager-test.js
@@ -289,6 +289,34 @@ if (EMBER_GLIMMER_HELPER_MANAGER) {
 
         this.assertText('hello');
       }
+
+      '@test capabilities helper function must be used to generate capabilities'(assert) {
+        class OverrideTestHelperManager extends TestHelperManager {
+          capabilities = {
+            hasValue: true,
+            hasDestroyable: true,
+            hasScheduledEffect: false,
+          };
+        }
+
+        class TestHelper {}
+
+        setHelperManager((owner) => new OverrideTestHelperManager(owner), TestHelper);
+        this.registerCustomHelper(
+          'hello',
+          class extends TestHelper {
+            value() {
+              return 'hello';
+            }
+          }
+        );
+
+        expectAssertion(() => {
+          this.render('{{hello}}');
+        }, /Custom helper managers must have a `capabilities` property that is the result of calling the `capabilities\('3.23'\)` \(imported via `import \{ capabilities \} from '@ember\/helper';`\). /);
+
+        assert.verifySteps([]);
+      }
     }
   );
 }


### PR DESCRIPTION
Prior to this change it was possible to avoid using a given type's `capabilities` builder function (intentionally or on accident) by doing something like:

```js
class MyManager {
  capabilities = {
    // magical properties from Ember's internals
  }
}
```

The API's that we _intended_ folks to be using is something like:

```js
import { capabilties as modifierCapabilities } from '@ember/modifier';

class MyManager {
  capabilities = modifierCapabilities('3.22');
}
```

This commit ensures that Ember's own internal structures can not be "spoofed" (avoiding our constraints, or creating a frankenstein manager).