### PR TITLE
Stop using deprecated `keyCode` on `KeyboardEvent`

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/input-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/input-angle-test.js
@@ -504,7 +504,7 @@ moduleFor(
       }, 'Passing actions to components as strings (like `<Input @enter="foo" />`) is deprecated. Please use closure actions instead (`<Input @enter={{action "foo"}} />`). (\'-top-level\' @ L1:C0) ');
 
       expectDeprecation(() => {
-        this.triggerEvent('keyup', { keyCode: 13 });
+        this.triggerEvent('keyup', { key: 'Enter' });
       }, 'Passing actions to components as strings (like `<Input @enter="foo" />`) is deprecated. Please use closure actions instead (`<Input @enter={{action "foo"}} />`).');
     }
 
@@ -527,7 +527,7 @@ moduleFor(
       });
 
       this.triggerEvent('keyup', {
-        keyCode: 13,
+        key: 'Enter',
       });
     }
 
@@ -552,7 +552,7 @@ moduleFor(
       }, 'Passing actions to components as strings (like `<Input @key-press="foo" />`) is deprecated. Please use closure actions instead (`<Input @key-press={{action "foo"}} />`). (\'-top-level\' @ L1:C0) ');
 
       expectDeprecation(() => {
-        this.triggerEvent('keypress', { keyCode: 65 });
+        this.triggerEvent('keypress', { key: 'A' });
       }, 'Passing actions to components as strings (like `<Input @key-press="foo" />`) is deprecated. Please use closure actions instead (`<Input @key-press={{action "foo"}} />`).');
     }
 
@@ -574,7 +574,7 @@ moduleFor(
         },
       });
 
-      this.triggerEvent('keypress', { keyCode: 65 });
+      this.triggerEvent('keypress', { key: 'A' });
     }
 
     ['@test sends an action to the parent level when `bubbles=true` is provided'](assert) {
@@ -630,7 +630,7 @@ moduleFor(
       });
 
       this.triggerEvent('keyup', {
-        keyCode: 13,
+        key: 'Enter',
       });
     }
 
@@ -655,7 +655,7 @@ moduleFor(
       }, 'Passing actions to components as strings (like `<Input @escape-press="foo" />`) is deprecated. Please use closure actions instead (`<Input @escape-press={{action "foo"}} />`). (\'-top-level\' @ L1:C0) ');
 
       expectDeprecation(() => {
-        this.triggerEvent('keyup', { keyCode: 27 });
+        this.triggerEvent('keyup', { key: 'Escape' });
       }, 'Passing actions to components as strings (like `<Input @escape-press="foo" />`) is deprecated. Please use closure actions instead (`<Input @escape-press={{action "foo"}} />`).');
     }
 
@@ -677,7 +677,7 @@ moduleFor(
         },
       });
 
-      this.triggerEvent('keyup', { keyCode: 27 });
+      this.triggerEvent('keyup', { key: 'Escape' });
     }
 
     ['@test [DEPRECATED] sends an action with `<Input @key-down="foo" />` when a key is pressed'](
@@ -701,7 +701,7 @@ moduleFor(
       }, 'Passing actions to components as strings (like `<Input @key-down="foo" />`) is deprecated. Please use closure actions instead (`<Input @key-down={{action "foo"}} />`). (\'-top-level\' @ L1:C0) ');
 
       expectDeprecation(() => {
-        this.triggerEvent('keydown', { keyCode: 65 });
+        this.triggerEvent('keydown', { key: 'A' });
       }, 'Passing actions to components as strings (like `<Input @key-down="foo" />`) is deprecated. Please use closure actions instead (`<Input @key-down={{action "foo"}} />`).');
     }
 
@@ -723,7 +723,7 @@ moduleFor(
         },
       });
 
-      this.triggerEvent('keydown', { keyCode: 65 });
+      this.triggerEvent('keydown', { key: 'A' });
     }
 
     ['@test [DEPRECATED] sends an action with `<Input @key-up="foo" />` when a key is pressed'](
@@ -747,7 +747,7 @@ moduleFor(
       }, 'Passing actions to components as strings (like `<Input @key-up="foo" />`) is deprecated. Please use closure actions instead (`<Input @key-up={{action "foo"}} />`). (\'-top-level\' @ L1:C0) ');
 
       expectDeprecation(() => {
-        this.triggerEvent('keyup', { keyCode: 65 });
+        this.triggerEvent('keyup', { key: 'A' });
       }, 'Passing actions to components as strings (like `<Input @key-up="foo" />`) is deprecated. Please use closure actions instead (`<Input @key-up={{action "foo"}} />`).');
     }
 
@@ -768,7 +768,7 @@ moduleFor(
           },
         },
       });
-      this.triggerEvent('keyup', { keyCode: 65 });
+      this.triggerEvent('keyup', { key: 'A' });
     }
 
     ['@test GH#14727 can render a file input after having had render an input of other type']() {
@@ -789,7 +789,7 @@ moduleFor(
         }),
       });
 
-      this.triggerEvent('keyup', { keyCode: 65 });
+      this.triggerEvent('keyup', { key: 'A' });
     }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/input-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/input-curly-test.js
@@ -357,7 +357,7 @@ moduleFor(
       }, 'Passing actions to components as strings (like `{{input enter="foo"}}`) is deprecated. Please use closure actions instead (`{{input enter=(action "foo")}}`). (\'-top-level\' @ L1:C0) ');
 
       expectDeprecation(() => {
-        this.triggerEvent('keyup', { keyCode: 13 });
+        this.triggerEvent('keyup', { key: 'Enter' });
       }, 'Passing actions to components as strings (like `<Input @enter="foo" />`) is deprecated. Please use closure actions instead (`<Input @enter={{action "foo"}} />`).');
     }
 
@@ -380,7 +380,7 @@ moduleFor(
       });
 
       this.triggerEvent('keyup', {
-        keyCode: 13,
+        key: 'Enter',
       });
     }
 
@@ -405,7 +405,7 @@ moduleFor(
       }, 'Passing actions to components as strings (like `{{input key-press="foo"}}`) is deprecated. Please use closure actions instead (`{{input key-press=(action "foo")}}`). (\'-top-level\' @ L1:C0) ');
 
       expectDeprecation(() => {
-        this.triggerEvent('keypress', { keyCode: 65 });
+        this.triggerEvent('keypress', { key: 'A' });
       }, 'Passing actions to components as strings (like `<Input @key-press="foo" />`) is deprecated. Please use closure actions instead (`<Input @key-press={{action "foo"}} />`).');
     }
 
@@ -427,7 +427,7 @@ moduleFor(
         },
       });
 
-      this.triggerEvent('keypress', { keyCode: 65 });
+      this.triggerEvent('keypress', { key: 'A' });
     }
 
     ['@test sends an action to the parent level when `bubbles=true` is provided'](assert) {
@@ -483,7 +483,7 @@ moduleFor(
       });
 
       this.triggerEvent('keyup', {
-        keyCode: 13,
+        key: 'Enter',
       });
     }
 
@@ -508,7 +508,7 @@ moduleFor(
       }, 'Passing actions to components as strings (like `{{input escape-press="foo"}}`) is deprecated. Please use closure actions instead (`{{input escape-press=(action "foo")}}`). (\'-top-level\' @ L1:C0) ');
 
       expectDeprecation(() => {
-        this.triggerEvent('keyup', { keyCode: 27 });
+        this.triggerEvent('keyup', { key: 'Escape' });
       }, 'Passing actions to components as strings (like `<Input @escape-press="foo" />`) is deprecated. Please use closure actions instead (`<Input @escape-press={{action "foo"}} />`).');
     }
 
@@ -530,7 +530,7 @@ moduleFor(
         },
       });
 
-      this.triggerEvent('keyup', { keyCode: 27 });
+      this.triggerEvent('keyup', { key: 'Escape' });
     }
 
     ['@test [DEPRECATED] sends an action with `{{input key-down="foo"}}` when a key is pressed'](
@@ -554,7 +554,7 @@ moduleFor(
       }, 'Passing actions to components as strings (like `{{input key-down="foo"}}`) is deprecated. Please use closure actions instead (`{{input key-down=(action "foo")}}`). (\'-top-level\' @ L1:C0) ');
 
       expectDeprecation(() => {
-        this.triggerEvent('keydown', { keyCode: 65 });
+        this.triggerEvent('keydown', { key: 'A' });
       }, 'Passing actions to components as strings (like `<Input @key-down="foo" />`) is deprecated. Please use closure actions instead (`<Input @key-down={{action "foo"}} />`).');
     }
 
@@ -576,7 +576,7 @@ moduleFor(
         },
       });
 
-      this.triggerEvent('keydown', { keyCode: 65 });
+      this.triggerEvent('keydown', { key: 'A' });
     }
 
     ['@test [DEPRECATED] sends an action with `{{input key-up="foo"}}` when a key is pressed'](
@@ -600,7 +600,7 @@ moduleFor(
       }, 'Passing actions to components as strings (like `{{input key-up="foo"}}`) is deprecated. Please use closure actions instead (`{{input key-up=(action "foo")}}`). (\'-top-level\' @ L1:C0) ');
 
       expectDeprecation(() => {
-        this.triggerEvent('keyup', { keyCode: 65 });
+        this.triggerEvent('keyup', { key: 'A' });
       }, 'Passing actions to components as strings (like `<Input @key-up="foo" />`) is deprecated. Please use closure actions instead (`<Input @key-up={{action "foo"}} />`).');
     }
 
@@ -619,7 +619,7 @@ moduleFor(
           },
         },
       });
-      this.triggerEvent('keyup', { keyCode: 65 });
+      this.triggerEvent('keyup', { key: 'A' });
     }
 
     ['@test GH#14727 can render a file input after having had render an input of other type']() {
@@ -640,7 +640,7 @@ moduleFor(
         }),
       });
 
-      this.triggerEvent('keyup', { keyCode: 65 });
+      this.triggerEvent('keyup', { key: 'A' });
     }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/textarea-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/textarea-angle-test.js
@@ -218,7 +218,7 @@ moduleFor(
         }),
       });
 
-      this.triggerEvent('keyup', { keyCode: 65 });
+      this.triggerEvent('keyup', { key: 'A' });
     }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/textarea-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/textarea-curly-test.js
@@ -170,7 +170,7 @@ moduleFor(
         }),
       });
 
-      this.triggerEvent('keyup', { keyCode: 65 });
+      this.triggerEvent('keyup', { key: 'A' });
     }
   }
 );

--- a/packages/@ember/-internals/views/lib/mixins/text_support.js
+++ b/packages/@ember/-internals/views/lib/mixins/text_support.js
@@ -9,8 +9,8 @@ import { SEND_ACTION } from '@ember/deprecated-features';
 import { MUTABLE_CELL } from '@ember/-internals/views';
 
 const KEY_EVENTS = {
-  13: 'insertNewline',
-  27: 'cancel',
+  Enter: 'insertNewline',
+  Escape: 'cancel',
 };
 
 /**
@@ -162,8 +162,7 @@ export default Mixin.create(TargetActionSupport, {
   bubbles: false,
 
   interpretKeyEvents(event) {
-    let map = KEY_EVENTS;
-    let method = map[event.keyCode];
+    let method = KEY_EVENTS[event.key];
 
     this._elementValueDidChange();
     if (method) {


### PR DESCRIPTION
Use `key` instead, which works in all supported browsers. This only touches the internal tests and implementation – there are still some occurrences of `keyCode` in `ember-testing` but it seems like some of them are public APIs, so I opted to not touch that package in this PR.