### PR TITLE
Deprecate `disconnectOutlet`

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
@@ -25,6 +25,9 @@ import { SimpleElement, SimpleNode } from '@simple-dom/interface';
 import { compile } from 'ember-template-compiler';
 import { runTask } from 'internal-test-helpers/lib/run';
 
+// FIXME: make this globally available to all TypeScript test files
+declare function expectDeprecation(callback: () => void, message: string | RegExp): void;
+
 interface CapturedBounds {
   parentElement: SimpleElement;
   firstNode: SimpleNode;
@@ -224,7 +227,10 @@ if (ENV._DEBUG_RENDER_TREE) {
               if (showHeader) {
                 this.render('header', { outlet: 'header' });
               } else {
-                this.disconnectOutlet('header');
+                expectDeprecation(
+                  () => this.disconnectOutlet('header'),
+                  'The "disconnectOutlet" method has been deprecated.'
+                );
               }
             }
           }

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -1705,6 +1705,7 @@ class Route extends EmberObject implements IRoute {
       // backward compatibility with our existing semantics, which allow
       // any route to disconnectOutlet things originally rendered by any
       // other route. This should all get cut in 2.0.
+      // or 4.0.0?
       routeInfos[i].route!._disconnectOutlet(outletName, parentView);
     }
   }

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -1676,6 +1676,11 @@ class Route extends EmberObject implements IRoute {
     @public
   */
   disconnectOutlet(options: string | { outlet: string; parentView?: string }) {
+    deprecate('The "disconnectOutlet" method has been deprecated.', false, {
+      id: 'route.render',
+      until: '4.0.0',
+    });
+
     let outletName;
     let parentView;
     if (options) {

--- a/packages/ember/tests/routing/template_rendering_test.js
+++ b/packages/ember/tests/routing/template_rendering_test.js
@@ -848,10 +848,14 @@ moduleFor(
               });
             },
             hideModal() {
-              this.disconnectOutlet({
-                outlet: 'modal',
-                parentView: 'application',
-              });
+              expectDeprecation(
+                () =>
+                  this.disconnectOutlet({
+                    outlet: 'modal',
+                    parentView: 'application',
+                  }),
+                'The "disconnectOutlet" method has been deprecated.'
+              );
             },
           },
         })
@@ -867,7 +871,10 @@ moduleFor(
               });
             },
             hideExtra() {
-              this.disconnectOutlet({ parentView: 'posts/index' });
+              expectDeprecation(
+                () => this.disconnectOutlet({ parentView: 'posts/index' }),
+                'The "disconnectOutlet" method has been deprecated.'
+              );
             },
           },
         })

--- a/packages/ember/tests/routing/template_rendering_test.js
+++ b/packages/ember/tests/routing/template_rendering_test.js
@@ -978,7 +978,10 @@ moduleFor(
               });
             },
             hideModal() {
-              this.disconnectOutlet('modal');
+              expectDeprecation(
+                () => this.disconnectOutlet('modal'),
+                'The "disconnectOutlet" method has been deprecated.'
+              );
             },
           },
         })
@@ -1022,7 +1025,7 @@ moduleFor(
     }
 
     ['@test Route silently fails when cleaning an outlet from an inactive view'](assert) {
-      assert.expect(1); // handleURL
+      assert.expect(3); // handleURL
 
       this.addTemplate('application', '{{outlet}}');
       this.addTemplate('posts', "{{outlet 'modal'}}");
@@ -1037,16 +1040,23 @@ moduleFor(
         Route.extend({
           actions: {
             hideSelf() {
-              this.disconnectOutlet({
-                outlet: 'main',
-                parentView: 'application',
-              });
+              expectDeprecation(
+                () =>
+                  this.disconnectOutlet({
+                    outlet: 'main',
+                    parentView: 'application',
+                  }),
+                'The "disconnectOutlet" method has been deprecated.'
+              );
             },
             showModal() {
               this.render('modal', { into: 'posts', outlet: 'modal' });
             },
             hideModal() {
-              this.disconnectOutlet({ outlet: 'modal', parentView: 'posts' });
+              expectDeprecation(
+                () => this.disconnectOutlet({ outlet: 'modal', parentView: 'posts' }),
+                'The "disconnectOutlet" method has been deprecated.'
+              );
             },
           },
         })
@@ -1160,10 +1170,14 @@ moduleFor(
           },
           actions: {
             banish() {
-              this.disconnectOutlet({
-                parentView: 'application',
-                outlet: 'other',
-              });
+              expectDeprecation(
+                () =>
+                  this.disconnectOutlet({
+                    parentView: 'application',
+                    outlet: 'other',
+                  }),
+                'The "disconnectOutlet" method has been deprecated.'
+              );
             },
           },
         })
@@ -1329,10 +1343,14 @@ moduleFor(
               });
             },
             close() {
-              this.disconnectOutlet({
-                outlet: 'modal',
-                parentView: 'application',
-              });
+              expectDeprecation(
+                () =>
+                  this.disconnectOutlet({
+                    outlet: 'modal',
+                    parentView: 'application',
+                  }),
+                'The "disconnectOutlet" method has been deprecated.'
+              );
             },
           },
         })
@@ -1409,10 +1427,14 @@ moduleFor(
         Route.extend({
           actions: {
             close() {
-              this.disconnectOutlet({
-                parentView: 'application',
-                outlet: 'modal',
-              });
+              expectDeprecation(
+                () =>
+                  this.disconnectOutlet({
+                    parentView: 'application',
+                    outlet: 'modal',
+                  }),
+                'The "disconnectOutlet" method has been deprecated.'
+              );
             },
           },
         })
@@ -1518,10 +1540,14 @@ moduleFor(
               });
             },
             hideModal() {
-              this.disconnectOutlet({
-                outlet: undefined,
-                parentView: 'application',
-              });
+              expectDeprecation(
+                () =>
+                  this.disconnectOutlet({
+                    outlet: undefined,
+                    parentView: 'application',
+                  }),
+                'The "disconnectOutlet" method has been deprecated.'
+              );
             },
           },
         })


### PR DESCRIPTION
Working on [RFC 491](https://emberjs.github.io/rfcs/0491-deprecate-disconnect-outlet.html)