### PR TITLE
replace this.get('router') with this.router in RoutingService docs

### DIFF
--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -274,7 +274,7 @@ export default class RouterService extends Service {
        @service router;
 
        displayComments() {
-         return this.get('router').isActive('posts');
+         return this.router.isActive('posts');
        }
      });
      ```
@@ -290,7 +290,7 @@ export default class RouterService extends Service {
        @service router;
 
        displayComments(post) {
-         return this.get('router').isActive('posts', post.id);
+         return this.router.isActive('posts', post.id);
        }
      });
      ```


### PR DESCRIPTION
👋 

Wasn't sure what "channel" this applies to, so I just used `[DOC]` instead of `[DOC channel]`. 