### PR TITLE
[DOC beta] Add return types to Controller docs

### DIFF
--- a/packages/@ember/-internals/routing/lib/ext/controller.ts
+++ b/packages/@ember/-internals/routing/lib/ext/controller.ts
@@ -147,6 +147,8 @@ ControllerMixin.reopen({
       containing a mapping of query parameters
     @for Ember.ControllerMixin
     @method transitionToRoute
+    @return {Transition} the transition object associated with this
+      attempted transition
     @public
   */
   transitionToRoute(...args: any[]) {
@@ -211,6 +213,8 @@ ControllerMixin.reopen({
     while transitioning to the route.
     @for Ember.ControllerMixin
     @method replaceRoute
+    @return {Transition} the transition object associated with this
+      attempted transition
     @public
   */
   replaceRoute(...args: string[]) {


### PR DESCRIPTION
Closes #19181
- add `Transition` return type from [corresponding routes APIs](https://github.com/emberjs/ember.js/blob/v3.21.1/packages/%40ember/-internals/routing/lib/system/route.ts#L888) for Controller#{replaceRoute, transitionToRoute} 