### PR TITLE
[BUGFIX lts] Restores the shadowed property set behavior

### DIFF
--- a/packages/@ember/-internals/metal/lib/decorator.ts
+++ b/packages/@ember/-internals/metal/lib/decorator.ts
@@ -1,5 +1,6 @@
 import { Meta, meta as metaFor, peekMeta } from '@ember/-internals/meta';
 import { assert } from '@ember/debug';
+import { _WeakSet } from '@ember/polyfills';
 
 export type DecoratorPropertyDescriptor = PropertyDescriptor & { initializer?: any } | undefined;
 
@@ -79,10 +80,16 @@ function DESCRIPTOR_SETTER_FUNCTION(
   name: string,
   descriptor: ComputedDescriptor
 ): (value: any) => void {
-  return function CPSETTER_FUNCTION(this: object, value: any): void {
+  let set = function CPSETTER_FUNCTION(this: object, value: any): void {
     return descriptor.set(this, name, value);
   };
+
+  COMPUTED_SETTERS.add(set);
+
+  return set;
 }
+
+export const COMPUTED_SETTERS = new _WeakSet();
 
 export function makeComputedDecorator(
   desc: ComputedDescriptor,

--- a/packages/@ember/-internals/metal/lib/property_set.ts
+++ b/packages/@ember/-internals/metal/lib/property_set.ts
@@ -1,8 +1,13 @@
-import { HAS_NATIVE_PROXY, setWithMandatorySetter, toString } from '@ember/-internals/utils';
+import {
+  HAS_NATIVE_PROXY,
+  lookupDescriptor,
+  setWithMandatorySetter,
+  toString,
+} from '@ember/-internals/utils';
 import { assert } from '@ember/debug';
 import EmberError from '@ember/error';
 import { DEBUG } from '@glimmer/env';
-import { descriptorForProperty } from './decorator';
+import { COMPUTED_SETTERS } from './decorator';
 import { isPath } from './path_cache';
 import { notifyPropertyChange } from './property_events';
 import { _getPath as getPath, getPossibleMandatoryProxyValue } from './property_get';
@@ -67,10 +72,10 @@ export function set(obj: object, keyName: string, value: any, tolerant?: boolean
     return setPath(obj, keyName, value, tolerant);
   }
 
-  let descriptor = descriptorForProperty(obj, keyName);
+  let descriptor = lookupDescriptor(obj, keyName);
 
-  if (descriptor !== undefined) {
-    descriptor.set(obj, keyName, value);
+  if (descriptor !== null && COMPUTED_SETTERS.has(descriptor.set!)) {
+    obj[keyName] = value;
     return value;
   }
 

--- a/packages/@ember/-internals/metal/lib/tracked.ts
+++ b/packages/@ember/-internals/metal/lib/tracked.ts
@@ -5,6 +5,7 @@ import { DEBUG } from '@glimmer/env';
 import { consumeTag, dirtyTagFor, tagFor, trackedData } from '@glimmer/validator';
 import { CHAIN_PASS_THROUGH } from './chain-tags';
 import {
+  COMPUTED_SETTERS,
   Decorator,
   DecoratorPropertyDescriptor,
   isElementDescriptor,
@@ -181,6 +182,8 @@ function descriptorForField([target, key, desc]: [
     get,
     set,
   };
+
+  COMPUTED_SETTERS.add(set);
 
   metaFor(target).writeDescriptors(key, new TrackedDescriptor(get, set));
 

--- a/packages/@ember/-internals/metal/tests/tracked/set_test.js
+++ b/packages/@ember/-internals/metal/tests/tracked/set_test.js
@@ -31,5 +31,21 @@ moduleFor(
         assert.equal(get(newObj, key), obj[key], 'should set value');
       }
     }
+
+    ['@test set should not throw an error when setting on shadowed properties'](assert) {
+      class Obj {
+        @tracked value = 'emberjs';
+
+        constructor() {
+          Object.defineProperty(this, 'value', { writable: true, value: 'emberjs' });
+        }
+      }
+
+      let newObj = new Obj();
+
+      set(newObj, 'value', 123);
+
+      assert.equal(newObj.value, 123, 'it worked');
+    }
   }
 );


### PR DESCRIPTION
Restores the previous behavior that would happen when setting a shadowed
property.

Fixes #19179 on release/lts