### PR TITLE
[BUGFIX] Asserts when users attempt to set a shadowed value with Ember.set

### DIFF
--- a/packages/@ember/-internals/metal/lib/tracked.ts
+++ b/packages/@ember/-internals/metal/lib/tracked.ts
@@ -5,6 +5,8 @@ import { DEBUG } from '@glimmer/env';
 import { consumeTag, dirtyTagFor, tagFor, trackedData } from '@glimmer/validator';
 import { CHAIN_PASS_THROUGH } from './chain-tags';
 import {
+  CPGETTERS,
+  CPSETTERS,
   Decorator,
   DecoratorPropertyDescriptor,
   isElementDescriptor,
@@ -181,6 +183,11 @@ function descriptorForField([target, key, desc]: [
     get,
     set,
   };
+
+  if (DEBUG) {
+    CPGETTERS.add(get);
+    CPSETTERS.add(set);
+  }
 
   metaFor(target).writeDescriptors(key, new TrackedDescriptor(get, set));
 

--- a/packages/@ember/-internals/metal/tests/tracked/set_test.js
+++ b/packages/@ember/-internals/metal/tests/tracked/set_test.js
@@ -31,5 +31,21 @@ moduleFor(
         assert.equal(get(newObj, key), obj[key], 'should set value');
       }
     }
+
+    ['@test set should throw an error when setting on shadowed properties']() {
+      class Obj {
+        @tracked value = 'emberjs';
+
+        constructor() {
+          Object.defineProperty(this, 'value', { writable: true, value: 'emberjs' });
+        }
+      }
+
+      let newObj = new Obj();
+
+      expectAssertion(() => {
+        set(newObj, 'value', 123);
+      }, /Attempted to set `\[object Object\].value` using Ember.set\(\), but the property was a computed or tracked property that was shadowed by another property declaration. This can happen if you defined a tracked or computed property on a parent class, and then redefined it on a subclass/);
+    }
   }
 );

--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -671,7 +671,7 @@ class EmberRouter extends EmberObject {
     let owner = getOwner(this);
 
     if ('string' === typeof location && owner) {
-      let resolvedLocation = owner.lookup(`location:${location}`);
+      let resolvedLocation = owner.lookup<IEmberLocation>(`location:${location}`);
 
       if (resolvedLocation !== undefined) {
         location = set(this, 'location', resolvedLocation);


### PR DESCRIPTION
Prevents users from setting a value if it's been shadowed, which can cause inconsistencies in behavior.