### PR TITLE
[BUGFIX lts] Cleans up the DebugRenderTree more thoroughly on errors

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/utils/debug-render-tree.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/debug-render-tree.ts
@@ -128,6 +128,15 @@ export default class DebugRenderTree<Bucket extends object = object> {
 
       // TODO: We could warn here? But this happens all the time in our tests?
 
+      // Clean up the root reference to prevent errors from happening if we
+      // attempt to capture the render tree (Ember Inspector may do this)
+      let root = expect(this.stack.toArray()[0], 'expected root state when resetting render tree');
+      let ref = this.refs.get(root);
+
+      if (ref !== undefined) {
+        this.roots.delete(ref);
+      }
+
       while (!this.stack.isEmpty()) {
         this.stack.pop();
       }

--- a/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
@@ -1644,6 +1644,28 @@ if (ENV._DEBUG_RENDER_TREE) {
           this.assert.strictEqual(actual, expected, `Matching ${path}`);
         }
       }
+
+      async '@test cleans up correctly after errors'(assert: Assert) {
+        this.addTemplate(
+          'application',
+          strip`
+            <HelloWorld @name="first" />
+          `
+        );
+
+        this.addComponent('hello-world', {
+          ComponentClass: Component.extend({
+            init() {
+              throw new Error('oops!');
+            },
+          }),
+          template: 'Hello World',
+        });
+
+        await assert.rejectsAssertion(this.visit('/'), /oops!/);
+
+        assert.deepEqual(captureRenderTree(this.owner), [], 'there was no output');
+      }
     }
   );
 }


### PR DESCRIPTION
The DebugRenderTree is currently left in a bad state after an error
occurs during render. Specifically, if an error occurs and we call
`capture` on the tree, it will throw errors because the state hasn't
been setup correctly. In real world development, this can happen
whenever the Ember Inspector is open and an app has errored, as the
inspector polls regardless of the state of the app and doesn't take
error state into account. This results in a follow on error to the
original error, which is confusing and can make it more difficult to
debug.

![Screen Shot 2020-10-14 at 6 50 11 PM](https://user-images.githubusercontent.com/685518/96067375-79490a80-0e4e-11eb-854f-255ec2857cee.png)

This can be reproduced using [this repo](https://github.com/xg-wang/getter-error) and following
these steps:

1. Open the app
2. Open the Ember Inspector
3. Click the To View link

This fixes the issue by removing the affected root altogether, so that
it will not attempt to capture in the first place.