### PR TITLE
Enable dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This will enable dependabot for github actions. 

I am not sure how the addition of a dependabot.yml will interact with existing configuration that I assume must be in a UI somewhere? Should I add configuration for npm?