### PR TITLE
[RFC#236] Deprecate Ember.String.loc and {{loc}}

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/helpers/loc.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/loc.ts
@@ -36,6 +36,7 @@ import { helper } from '../helper';
   @param {String} str The string to format.
   @see {String#loc}
   @public
+  @deprecated
 */
 export default helper(function (params) {
   return loc.apply(null, params as any /* let the other side handle errors */);

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/loc-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/loc-test.js
@@ -20,32 +20,36 @@ moduleFor(
     }
 
     ['@test it lets the original value through by default']() {
-      this.render(`{{loc "Hiya buddy!"}}`);
+      expectDeprecation(() => this.render(`{{loc "Hiya buddy!"}}`), /loc is deprecated/);
       this.assertText('Hiya buddy!', 'the unlocalized string is correct');
       runTask(() => this.rerender());
       this.assertText('Hiya buddy!', 'the unlocalized string is correct after rerender');
     }
 
     ['@test it localizes a simple string']() {
-      this.render(`{{loc "Hello Friend"}}`);
+      expectDeprecation(() => this.render(`{{loc "Hello Friend"}}`), /loc is deprecated/);
       this.assertText('Hallo Freund', 'the localized string is correct');
       runTask(() => this.rerender());
       this.assertText('Hallo Freund', 'the localized string is correct after rerender');
     }
 
     ['@test it takes passed formats into an account']() {
-      this.render(`{{loc "%@, %@" "Hello" "Mr. Pitkin"}}`);
+      expectDeprecation(() => {
+        this.render(`{{loc "%@, %@" "Hello" "Mr. Pitkin"}}`);
+      }, /loc is deprecated/);
       this.assertText('Hello, Mr. Pitkin', 'the formatted string is correct');
       runTask(() => this.rerender());
       this.assertText('Hello, Mr. Pitkin', 'the formatted string is correct after rerender');
     }
 
     ['@test it updates when bound params change']() {
-      this.render(`{{loc simple}} - {{loc personal 'Mr. Pitkin'}}`, {
-        simple: 'Hello Friend',
-        personal: 'Hello',
-      });
-      this.assertText('Hallo Freund - Hallo, Mr. Pitkin', 'the bound value is correct');
+      expectDeprecation(() => {
+        this.render(`{{loc simple}} - {{loc personal 'Mr. Pitkin'}}`, {
+          simple: 'Hello Friend',
+          personal: 'Hello',
+        });
+        this.assertText('Hallo Freund - Hallo, Mr. Pitkin', 'the bound value is correct');
+      }, /loc is deprecated/);
 
       runTask(() => this.rerender());
       this.assertText(
@@ -53,20 +57,32 @@ moduleFor(
         'the bound value is correct after rerender'
       );
 
-      runTask(() => set(this.context, 'simple', "G'day mate"));
-      this.assertText("G'day mate - Hallo, Mr. Pitkin", 'the bound value is correct after update');
+      expectDeprecation(() => {
+        runTask(() => set(this.context, 'simple', "G'day mate"));
+        this.assertText(
+          "G'day mate - Hallo, Mr. Pitkin",
+          'the bound value is correct after update'
+        );
+      }, /loc is deprecated/);
 
-      runTask(() => set(this.context, 'simple', 'Hello Friend'));
-      this.assertText('Hallo Freund - Hallo, Mr. Pitkin', 'the bound value is correct after reset');
+      expectDeprecation(() => {
+        runTask(() => set(this.context, 'simple', 'Hello Friend'));
+        this.assertText(
+          'Hallo Freund - Hallo, Mr. Pitkin',
+          'the bound value is correct after reset'
+        );
+      }, /loc is deprecated/);
     }
 
     ['@test it updates when nested bound params change']() {
-      this.render(`{{loc greetings.simple}} - {{loc greetings.personal 'Mr. Pitkin'}}`, {
-        greetings: {
-          simple: 'Hello Friend',
-          personal: 'Hello',
-        },
-      });
+      expectDeprecation(() => {
+        this.render(`{{loc greetings.simple}} - {{loc greetings.personal 'Mr. Pitkin'}}`, {
+          greetings: {
+            simple: 'Hello Friend',
+            personal: 'Hello',
+          },
+        });
+      }, /loc is deprecated/);
       this.assertText('Hallo Freund - Hallo, Mr. Pitkin', 'the bound value is correct');
 
       runTask(() => this.rerender());
@@ -75,22 +91,26 @@ moduleFor(
         'the bound value is correct after rerender'
       );
 
-      runTask(() => set(this.context, 'greetings.simple', "G'day mate"));
-      this.assertText(
-        "G'day mate - Hallo, Mr. Pitkin",
-        'the bound value is correct after interior mutation'
-      );
+      expectDeprecation(() => {
+        runTask(() => set(this.context, 'greetings.simple', "G'day mate"));
+        this.assertText(
+          "G'day mate - Hallo, Mr. Pitkin",
+          'the bound value is correct after interior mutation'
+        );
+      }, /loc is deprecated/);
 
-      runTask(() =>
-        set(this.context, 'greetings', {
-          simple: 'Hello Friend',
-          personal: 'Hello',
-        })
-      );
-      this.assertText(
-        'Hallo Freund - Hallo, Mr. Pitkin',
-        'the bound value is correct after replacement'
-      );
+      expectDeprecation(() => {
+        runTask(() =>
+          set(this.context, 'greetings', {
+            simple: 'Hello Friend',
+            personal: 'Hello',
+          })
+        );
+        this.assertText(
+          'Hallo Freund - Hallo, Mr. Pitkin',
+          'the bound value is correct after replacement'
+        );
+      }, /loc is deprecated/);
     }
 
     ['@test it can be overriden']() {

--- a/packages/@ember/string/index.ts
+++ b/packages/@ember/string/index.ts
@@ -110,8 +110,23 @@ function _fmt(str: string, formats: any[]) {
   @param {Array} formats Optional array of parameters to interpolate into string.
   @return {String} formatted string
   @public
+  @deprecated
 */
 export function loc(str: string, formats: any[]): string {
+  deprecate(
+    'loc is deprecated, please use a dedicated localization solution like ember-intl. More alternatives listed at https://emberobserver.com/categories/internationalization.',
+    false,
+    {
+      id: 'ember-string.loc',
+      until: '4.0.0',
+      for: 'ember-source',
+      url: 'https://deprecations.emberjs.com/v3.x#toc_ember-string-loc',
+      since: {
+        available: '3.24',
+      },
+    }
+  );
+
   if (!Array.isArray(formats) || arguments.length > 2) {
     formats = Array.prototype.slice.call(arguments, 1);
   }
@@ -324,6 +339,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
       @for @ember/string
       @static
       @private
+      @deprecated
     */
     loc: {
       configurable: true,

--- a/packages/@ember/string/tests/loc_test.js
+++ b/packages/@ember/string/tests/loc_test.js
@@ -6,10 +6,12 @@ import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 let oldString;
 
 function test(assert, given, args, expected, description) {
-  assert.equal(loc(given, args), expected, description);
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    assert.deepEqual(given.loc(...args), expected, description);
-  }
+  expectDeprecation(() => {
+    assert.equal(loc(given, args), expected, description);
+    if (ENV.EXTEND_PROTOTYPES.String) {
+      assert.deepEqual(given.loc(...args), expected, description);
+    }
+  }, /loc is deprecated/);
 }
 
 moduleFor(
@@ -69,8 +71,10 @@ moduleFor(
     }
 
     ['@test works with argument form'](assert) {
-      assert.equal(loc('_Hello %@', 'John'), 'Bonjour John');
-      assert.equal(loc('_Hello %@ %@', ['John'], 'Doe'), 'Bonjour John Doe');
+      expectDeprecation(() => {
+        assert.equal(loc('_Hello %@', 'John'), 'Bonjour John');
+        assert.equal(loc('_Hello %@ %@', ['John'], 'Doe'), 'Bonjour John Doe');
+      }, /loc is deprecated/);
     }
   }
 );


### PR DESCRIPTION
Part of [RFC#236 - `Ember.String` deprecation](https://github.com/emberjs/rfc-tracking/issues/26).

## Tasks
- [x] deprecate `Ember.String.loc`
  - [x] make sure deprecation URL is published and matches
- [x] deprecate `{{loc}}`