### PR TITLE
[CLEANUP beta] Assert `_super` called in `willDestroy` for "FrameworkObject"

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/append-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/append-test.js
@@ -594,6 +594,7 @@ class AbstractAppendTest extends RenderingTestCase {
         },
 
         willDestroy() {
+          this._super(...arguments);
           this._instance.destroy();
         },
       }),
@@ -623,6 +624,7 @@ class AbstractAppendTest extends RenderingTestCase {
         },
 
         willDestroy() {
+          this._super(...arguments);
           this._instance.destroy();
         },
       }),

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
@@ -174,6 +174,21 @@ moduleFor(
       assert.deepEqual(hooks, ['init', 'compute', 'compute', 'destroy', 'willDestroy']);
     }
 
+    ['@test throws if `this._super` is not called from `willDestory`']() {
+      this.registerHelper('hello-world', {
+        compute() {},
+        willDestroy() {},
+      });
+
+      this.render('{{#if this.show}}{{hello-world}}{{/if}}', {
+        show: true,
+      });
+
+      expectAssertion(() => {
+        runTask(() => set(this.context, 'show', false));
+      }, /You must call `super.willDestroy\(...arguments\);` or `this._super\(...arguments\)` when overriding `willDestroy` on a framework object. Please update .*/);
+    }
+
     ['@test class-based helper with static arguments can recompute a new value'](assert) {
       let destroyCount = 0;
       let computeCount = 0;

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
@@ -174,7 +174,7 @@ moduleFor(
       assert.deepEqual(hooks, ['init', 'compute', 'compute', 'destroy', 'willDestroy']);
     }
 
-    ['@test throws if `this._super` is not called from `willDestory`']() {
+    ['@test warns if `this._super` is not called from `willDestory`']() {
       this.registerHelper('hello-world', {
         compute() {},
         willDestroy() {},
@@ -184,9 +184,9 @@ moduleFor(
         show: true,
       });
 
-      expectAssertion(() => {
+      expectDeprecation(() => {
         runTask(() => set(this.context, 'show', false));
-      }, /You must call `super.willDestroy\(...arguments\);` or `this._super\(...arguments\)` when overriding `willDestroy` on a framework object. Please update .*/);
+      }, /You must call `super.willDestroy\(...arguments\);` or `this._super\(...arguments\)` when overriding `willDestroy` on a framework object. Please update.*/);
     }
 
     ['@test class-based helper with static arguments can recompute a new value'](assert) {

--- a/packages/@ember/-internals/runtime/lib/system/core_object.js
+++ b/packages/@ember/-internals/runtime/lib/system/core_object.js
@@ -369,7 +369,10 @@ class CoreObject {
     }
 
     registerDestructor(self, ensureDestroyCalled, true);
-    registerDestructor(self, () => self.willDestroy());
+    registerDestructor(self, () => {
+      self.willDestroy();
+      sendEvent(self, 'willDestroy');
+    });
 
     // disable chains
     let m = meta(self);

--- a/packages/@ember/-internals/runtime/lib/system/object.js
+++ b/packages/@ember/-internals/runtime/lib/system/object.js
@@ -7,7 +7,7 @@ import { symbol } from '@ember/-internals/utils';
 import { addListener } from '@ember/-internals/metal';
 import CoreObject from './core_object';
 import Observable from '../mixins/observable';
-import { assert } from '@ember/debug';
+import { assert, deprecate } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 
 /**
@@ -44,7 +44,7 @@ if (DEBUG) {
   let INIT_WAS_CALLED = symbol('INIT_WAS_CALLED');
   let WILL_DESTROY_WAS_CALLED = symbol('WILL_DESTROY_WAS_CALLED');
   let ASSERT_INIT_WAS_CALLED = symbol('ASSERT_INIT_WAS_CALLED');
-  let ASSERT_WILL_DESTROY_WAS_CALLED = symbol('ASSERT_WILL_DESTROY_WAS_CALLED');
+  let DEPRECATE_WILL_DESTROY_WAS_CALLED = symbol('DEPRECATE_WILL_DESTROY_WAS_CALLED');
 
   FrameworkObject = class DebugFrameworkObject extends EmberObject {
     init() {
@@ -64,14 +64,20 @@ if (DEBUG) {
       );
     }
 
-    [ASSERT_WILL_DESTROY_WAS_CALLED]() {
-      assert(
+    [DEPRECATE_WILL_DESTROY_WAS_CALLED]() {
+      deprecate(
         `You must call \`super.willDestroy(...arguments);\` or \`this._super(...arguments)\` when overriding \`willDestroy\` on a framework object. Please update ${this} to call \`super.willDestroy(...arguments);\` from \`willDestroy\` when using native classes or \`this._super(...arguments)\` when using \`EmberObject.extend()\`.`,
-        this[WILL_DESTROY_WAS_CALLED]
+        this[WILL_DESTROY_WAS_CALLED],
+        {
+          id: 'component.will-destroy.super',
+          until: '4.0.0',
+          for: 'ember-source',
+          since: { enabled: '3.27.0' },
+        }
       );
     }
   };
 
   addListener(FrameworkObject.prototype, 'init', null, ASSERT_INIT_WAS_CALLED);
-  addListener(FrameworkObject.prototype, 'willDestroy', null, ASSERT_WILL_DESTROY_WAS_CALLED);
+  addListener(FrameworkObject.prototype, 'willDestroy', null, DEPRECATE_WILL_DESTROY_WAS_CALLED);
 }

--- a/packages/@ember/-internals/runtime/lib/system/object.js
+++ b/packages/@ember/-internals/runtime/lib/system/object.js
@@ -42,12 +42,19 @@ Observable.apply(FrameworkObject.prototype);
 
 if (DEBUG) {
   let INIT_WAS_CALLED = symbol('INIT_WAS_CALLED');
+  let WILL_DESTROY_WAS_CALLED = symbol('WILL_DESTROY_WAS_CALLED');
   let ASSERT_INIT_WAS_CALLED = symbol('ASSERT_INIT_WAS_CALLED');
+  let ASSERT_WILL_DESTROY_WAS_CALLED = symbol('ASSERT_WILL_DESTROY_WAS_CALLED');
 
   FrameworkObject = class DebugFrameworkObject extends EmberObject {
     init() {
       super.init(...arguments);
       this[INIT_WAS_CALLED] = true;
+    }
+
+    willDestroy() {
+      super.willDestroy(...arguments);
+      this[WILL_DESTROY_WAS_CALLED] = true;
     }
 
     [ASSERT_INIT_WAS_CALLED]() {
@@ -56,7 +63,15 @@ if (DEBUG) {
         this[INIT_WAS_CALLED]
       );
     }
+
+    [ASSERT_WILL_DESTROY_WAS_CALLED]() {
+      assert(
+        `You must call \`super.willDestroy(...arguments);\` or \`this._super(...arguments)\` when overriding \`willDestroy\` on a framework object. Please update ${this} to call \`super.willDestroy(...arguments);\` from \`willDestroy\` when using native classes or \`this._super(...arguments)\` when using \`EmberObject.extend()\`.`,
+        this[WILL_DESTROY_WAS_CALLED]
+      );
+    }
   };
 
   addListener(FrameworkObject.prototype, 'init', null, ASSERT_INIT_WAS_CALLED);
+  addListener(FrameworkObject.prototype, 'willDestroy', null, ASSERT_WILL_DESTROY_WAS_CALLED);
 }


### PR DESCRIPTION
Contributes to #15281

- send `willDestroy` event from "CoreObject"
- assert `_super` is called in `willDestroy` for "FrameworkObject"

If accepted, this would close the issue except that in the comments it was decided that an assertion should be added for `destroy` as well (perhaps that could be a separate issue).