### PR TITLE
[FEATURE modernized-built-in-components] First-pass implementation

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/input.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/input.ts
@@ -1,11 +1,168 @@
 /**
 @module @ember/component
 */
-import { assert } from '@ember/debug';
+import { hasDOM } from '@ember/-internals/browser-environment';
+import { tracked } from '@ember/-internals/metal';
+import { guidFor } from '@ember/-internals/utils';
+import { jQuery, jQueryDisabled } from '@ember/-internals/views';
+import { EMBER_MODERNIZED_BUILT_IN_COMPONENTS } from '@ember/canary-features';
+import { assert, deprecate, warn } from '@ember/debug';
+import {
+  JQUERY_INTEGRATION,
+  MOUSE_ENTER_LEAVE_MOVE_EVENTS,
+  SEND_ACTION,
+} from '@ember/deprecated-features';
+import { action } from '@ember/object';
 import { setComponentTemplate, setInternalComponentManager } from '@glimmer/manager';
+import { isConstRef, isUpdatableRef, Reference, updateRef, valueForRef } from '@glimmer/reference';
+import { untrack } from '@glimmer/validator';
 import InternalManager from '../component-managers/internal';
 import InputTemplate from '../templates/input';
 import InternalComponent from './internal';
+
+let isValidInputType: (type: string) => boolean;
+
+if (hasDOM && EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
+  const INPUT_TYPES: Record<string, boolean | undefined> = Object.create(null);
+  const INPUT_ELEMENT = document.createElement('input');
+
+  INPUT_TYPES[''] = false;
+  INPUT_TYPES['text'] = true;
+  INPUT_TYPES['checkbox'] = true;
+
+  isValidInputType = (type: string) => {
+    let isValid = INPUT_TYPES[type];
+
+    if (isValid === undefined) {
+      try {
+        INPUT_ELEMENT.type = type;
+        isValid = INPUT_ELEMENT.type === type;
+      } catch (e) {
+        isValid = false;
+      } finally {
+        INPUT_ELEMENT.type = 'text';
+      }
+
+      INPUT_TYPES[type] = isValid;
+    }
+
+    return isValid;
+  };
+} else {
+  isValidInputType = (type: string) => type !== '';
+}
+
+function NOOP() {}
+
+const UNINITIALIZED: unknown = Object.freeze({});
+
+/**
+ * This interface paves over the differences between these three cases:
+ *
+ * 1. `<Input />` or `<Input @value="some string" />`
+ * 2. `<Input @value={{this.value}} />`
+ * 3. `<Input @value={{to-upper-case this.value}} />`
+ *
+ * For the first set of cases (any const reference in general), the semantics
+ * are that `@value` is treated as an initial value only, just like the `value`
+ * attribute. Perhaps using the `value` attribute would have been more Correct™
+ * here, but that would make a pretty confusing API, and the user's intent is
+ * pretty clear, so we support it.
+ *
+ * The second case is the most common. `{{this.value}}` is an updatable
+ * reference here so the value is fully owned and bound to the "upstream" value
+ * and we don't store a copy of it in the component.
+ *
+ * The last case is the most tricky. There are a lot of different ways for this
+ * to happen, but the end result is that we have a non-const and non-updatable
+ * reference in our hands. The semantics here is a mix of the first two cases.
+ * We take the computed value as the initial value, but hold a copy of it and
+ * allow it to diverge from upstream. However, when the upstream recomputes to
+ * a value different than what we originally had, we would reconcile with the
+ * new upstream value and throw away the local copy.
+ *
+ * It's not clear that we intended to support the last case, or that it is used
+ * intentionally in the real world, but it's a fallout of the two-way binding
+ * system and `Ember.Component` semantics from before.
+ *
+ * This interface paves over the differences so the component doesn't have to
+ * worry about it.
+ *
+ * All of the above applies to `@checked` as well.
+ */
+function valueFrom(reference?: Reference<unknown>): Value {
+  if (reference === undefined) {
+    return new LocalValue(undefined);
+  } else if (isConstRef(reference)) {
+    return new LocalValue(valueForRef(reference));
+  } else if (isUpdatableRef(reference)) {
+    return new UpstreamValue(reference);
+  } else {
+    return new ForkedValue(reference);
+  }
+}
+
+interface Value {
+  get(): unknown;
+  set(value: unknown): void;
+}
+
+class LocalValue implements Value {
+  @tracked private value: unknown;
+
+  constructor(value: unknown) {
+    this.value = value;
+  }
+
+  get(): unknown {
+    return this.value;
+  }
+
+  set(value: unknown): void {
+    this.value = value;
+  }
+}
+
+class UpstreamValue implements Value {
+  constructor(private reference: Reference<unknown>) {}
+
+  get(): unknown {
+    return valueForRef(this.reference);
+  }
+
+  set(value: unknown): void {
+    updateRef(this.reference, value);
+  }
+}
+
+class ForkedValue implements Value {
+  private local?: Value;
+  private upstream: Value;
+
+  private lastUpstreamValue = UNINITIALIZED;
+
+  constructor(reference: Reference<unknown>) {
+    this.upstream = new UpstreamValue(reference);
+  }
+
+  get(): unknown {
+    let upstreamValue = this.upstream.get();
+
+    if (upstreamValue !== this.lastUpstreamValue) {
+      this.lastUpstreamValue = upstreamValue;
+      this.local = new LocalValue(upstreamValue);
+    }
+
+    assert('[BUG] this.local must have been initialized at this point', this.local);
+    return this.local.get();
+  }
+
+  set(value: unknown): void {
+    assert('[BUG] this.local must have been initialized at this point', this.local);
+    this.local.set(value);
+  }
+}
+
 /**
   See [Ember.Templates.components.Input](/ember/release/classes/Ember.Templates.components/methods/Input?anchor=Input).
 
@@ -128,8 +285,510 @@ import InternalComponent from './internal';
   @public
 */
 class Input extends InternalComponent {
+  modernized = Boolean(EMBER_MODERNIZED_BUILT_IN_COMPONENTS);
+
+  /**
+   * The default HTML id attribute. We don't really _need_ one, this is just
+   * added for compatibility as it's hard to tell if people rely on it being
+   * present, and it doens't really hurt.
+   *
+   * However, don't rely on this internally, like passing it to `getElementId`.
+   * This can be (and often is) overriden by passing an `id` attribute on the
+   * invocation, which shadows this default id via `...attributes`.
+   */
+  get id(): string {
+    return guidFor(this);
+  }
+
+  /**
+   * The default HTML class attribute. Similar to the above, we don't _need_
+   * them, they are just added for compatibility as it's similarly hard to tell
+   * if people rely on it in their CSS etc, and it doens't really hurt.
+   */
+  get class(): string {
+    if (this.isCheckbox) {
+      return 'ember-checkbox ember-view';
+    } else {
+      return 'ember-text-field ember-view';
+    }
+  }
+
+  /**
+   * The HTML type attribute.
+   */
+  get type(): string {
+    let type = this.arg('type');
+
+    if (type === null || type === undefined) {
+      return 'text';
+    }
+
+    assert(
+      'The `@type` argument to the <Input> component must be a string',
+      typeof type === 'string'
+    );
+
+    return isValidInputType(type) ? type : 'text';
+  }
+
   get isCheckbox(): boolean {
     return this.arg('type') === 'checkbox';
+  }
+
+  _checked = valueFrom(this.args.checked);
+
+  get checked(): unknown {
+    if (this.isCheckbox) {
+      warn(
+        '`<Input @type="checkbox" />` reflects its checked state via the `@checked` argument. ' +
+          'You wrote `<Input @type="checkbox" @value={{...}} />` which is likely not what you intended. ' +
+          'Did you mean `<Input @type="checkbox" @checked={{...}} />`?',
+        untrack(
+          () =>
+            this.args.checked !== undefined ||
+            this.args.value === undefined ||
+            typeof valueForRef(this.args.value) === 'string'
+        ),
+        { id: 'ember.built-in-components.input-checkbox-value' }
+      );
+
+      return this._checked.get();
+    } else {
+      return undefined;
+    }
+  }
+
+  set checked(checked: unknown) {
+    warn(
+      '`<Input @type="checkbox" />` reflects its checked state via the `@checked` argument. ' +
+        'You wrote `<Input @type="checkbox" @value={{...}} />` which is likely not what you intended. ' +
+        'Did you mean `<Input @type="checkbox" @checked={{...}} />`?',
+      untrack(
+        () =>
+          this.args.checked !== undefined ||
+          this.args.value === undefined ||
+          typeof valueForRef(this.args.value) === 'string'
+      ),
+      { id: 'ember.built-in-components.input-checkbox-value' }
+    );
+
+    this._checked.set(checked);
+  }
+
+  _value = valueFrom(this.args.value);
+
+  get value(): unknown {
+    return this._value.get();
+  }
+
+  set value(value: unknown) {
+    this._value.set(value);
+  }
+
+  @action checkedDidChange(event: Event): void {
+    this.checked = this.elementFor(event).checked;
+  }
+
+  @action valueDidChange(event: Event): void {
+    this.value = this.valueFor(event);
+  }
+
+  @action change(event: Event): void {
+    if (this.isCheckbox) {
+      this.checkedDidChange(event);
+    } else {
+      this.valueDidChange(event);
+    }
+  }
+
+  @action input(event: Event): void {
+    if (!this.isCheckbox) {
+      this.valueDidChange(event);
+    }
+  }
+
+  @action keyUp(event: KeyboardEvent): void {
+    let value = this.valueFor(event);
+
+    switch (event.key) {
+      case 'Enter':
+        this.callbackFor('enter')(value, event);
+        this.callbackFor('insert-newline')(value, event);
+        break;
+
+      case 'Escape':
+        this.callbackFor('escape-press')(value, event);
+        break;
+    }
+  }
+
+  private elementFor(event: Event): HTMLInputElement {
+    assert(
+      '[BUG] Event target must be the <input> element',
+      event.target instanceof HTMLInputElement
+    );
+
+    return event.target;
+  }
+
+  private valueFor(event: Event): string {
+    return this.elementFor(event).value;
+  }
+
+  private callbackFor(type: string): (value: string, event: Event) => void {
+    let callback = this.arg(type);
+
+    if (callback) {
+      assert(
+        `The \`@${type}\` argument to the <Input> component must be a function`,
+        typeof callback === 'function'
+      );
+      return callback as (value: string, event: Event) => void;
+    } else {
+      return NOOP;
+    }
+  }
+}
+
+// Deprecated features
+if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
+  // Attribute bindings
+  {
+    let defineGetterForDeprecatedAttributeBinding = (
+      attribute: string,
+      argument = attribute
+    ): void => {
+      assert(
+        `[BUG] There is already a getter for _${argument} on Input`,
+        !Object.getOwnPropertyDescriptor(Input.prototype, `_${argument}`)
+      );
+
+      Object.defineProperty(Input.prototype, `_${argument}`, {
+        get(this: Input): unknown {
+          deprecate(
+            `Passing the \`@${argument}\` argument to <Input> is deprecated. ` +
+              `Instead, please pass the attribute directly, i.e. \`<Input ${attribute}={{...}} />\` ` +
+              `instead of \`<Input @${argument}={{...}} />\` or \`{{input ${argument}=...}}\`.`,
+            true /* TODO !(argument in this.args) */,
+            {
+              id: 'ember.built-in-components.legacy-attribute-arguments',
+              for: 'ember-source',
+              since: {},
+              until: '4.0.0',
+            }
+          );
+
+          return this.arg(argument);
+        },
+      });
+
+      let descriptor = Object.getOwnPropertyDescriptor(Input.prototype, argument);
+
+      if (descriptor) {
+        const superGetter = descriptor.get;
+        assert(`Expecting ${argument} to be a getter on Input`, typeof superGetter === 'function');
+
+        Object.defineProperty(Input.prototype, argument, {
+          ...descriptor,
+          get(this: Input): unknown {
+            // The `class` attribute is concatenated/merged instead of clobbered
+            if (attribute === 'class' && argument in this.args) {
+              let arg = this[`_${argument}`];
+
+              if (arg) {
+                return `${superGetter.call(this)} ${this[`_${argument}`]}`;
+              } else {
+                return superGetter.call(this);
+              }
+            } else if (argument in this.args) {
+              return this[`_${argument}`];
+            } else {
+              return superGetter.call(this);
+            }
+          },
+        });
+      }
+    };
+
+    let deprecatedAttributeBindings: Array<
+      string | Parameters<typeof defineGetterForDeprecatedAttributeBinding>
+    > = [
+      // Component
+      'id',
+      'class',
+      ['class', 'classNames'],
+
+      // TextSupport
+      'autocapitalize',
+      'autocorrect',
+      'autofocus',
+      'disabled',
+      'form',
+      'maxlength',
+      'minlength',
+      'placeholder',
+      'readonly',
+      'required',
+      'selectionDirection',
+      'spellcheck',
+      'tabindex',
+      'title',
+
+      // TextField
+      'accept',
+      'autocomplete',
+      'autosave',
+      'dir',
+      'formaction',
+      'formenctype',
+      'formmethod',
+      'formnovalidate',
+      'formtarget',
+      'height',
+      'inputmode',
+      'lang',
+      'list',
+      'max',
+      'min',
+      'multiple',
+      'name',
+      'pattern',
+      'size',
+      'step',
+      'width',
+
+      // Checkbox
+      'indeterminate',
+    ];
+
+    deprecatedAttributeBindings.forEach((args) => {
+      if (Array.isArray(args)) {
+        defineGetterForDeprecatedAttributeBinding(...args);
+      } else {
+        defineGetterForDeprecatedAttributeBinding(args);
+      }
+    });
+  }
+
+  // Event callbacks
+  {
+    let defineGetterForDeprecatedEventCallback = (
+      eventName: string,
+      methodName: string = eventName,
+      virtualEvent?: string
+    ): void => {
+      assert(
+        `[BUG] There is already a getter for _${methodName} on Input`,
+        !Object.getOwnPropertyDescriptor(Input.prototype, `_${methodName}`)
+      );
+
+      let descriptor = Object.getOwnPropertyDescriptor(Input.prototype, methodName);
+
+      Object.defineProperty(Input.prototype, `_${methodName}`, {
+        get(this: Input): unknown {
+          return (event: Event): void => {
+            let value = this['valueFor'].call(this, event);
+
+            if (methodName in this.args) {
+              deprecate(
+                `Passing the \`@${methodName}\` argument to <Input> is deprecated. ` +
+                  `This would have overwritten the internal \`${methodName}\` method on ` +
+                  `the <Input> component and prevented it from functioning properly. ` +
+                  `Instead, please use the {{on}} modifier, i.e. \`<Input {{on "${eventName}" ...}} />\` ` +
+                  `instead of \`<Input @${methodName}={{...}} />\` or \`{{input ${methodName}=...}}\`.`,
+                true /* TODO !descriptor */,
+                {
+                  id: 'ember.built-in-components.legacy-attribute-arguments',
+                  for: 'ember-source',
+                  since: {},
+                  until: '4.0.0',
+                }
+              );
+
+              deprecate(
+                `Passing the \`@${methodName}\` argument to <Input> is deprecated. ` +
+                  `Instead, please use the {{on}} modifier, i.e. \`<Input {{on "${eventName}" ...}} />\` ` +
+                  `instead of \`<Input @${methodName}={{...}} />\` or \`{{input ${methodName}=...}}\`.`,
+                true /* TODO descriptor */,
+                {
+                  id: 'ember.built-in-components.legacy-attribute-arguments',
+                  for: 'ember-source',
+                  since: {},
+                  until: '4.0.0',
+                }
+              );
+
+              let callback = this['callbackFor'].call(this, methodName);
+              callback(value, event);
+            } else if (virtualEvent && virtualEvent in this.args) {
+              deprecate(
+                `Passing the \`@${virtualEvent}\` argument to <Input> is deprecated. ` +
+                  `Instead, please use the {{on}} modifier, i.e. \`<Input {{on "${eventName}" ...}} />\` ` +
+                  `instead of \`<Input @${virtualEvent}={{...}} />\` or \`{{input ${virtualEvent}=...}}\`.`,
+                true /* TODO false */,
+                {
+                  id: 'ember.built-in-components.legacy-attribute-arguments',
+                  for: 'ember-source',
+                  since: {},
+                  until: '4.0.0',
+                }
+              );
+
+              this['callbackFor'].call(this, virtualEvent)(value, event);
+            }
+          };
+        },
+      });
+
+      if (descriptor) {
+        const superGetter = descriptor.get;
+
+        assert(
+          `[BUG] Expecting ${methodName} on Input to be a getter`,
+          typeof superGetter === 'function'
+        );
+
+        Object.defineProperty(Input.prototype, methodName, {
+          get(this: Input): unknown {
+            if (methodName in this.args) {
+              return this[`_${methodName}`];
+            } else if (virtualEvent && virtualEvent in this.args) {
+              let superCallback = superGetter.call(this);
+              let virtualCallback = this[`_${methodName}`];
+
+              return (event: Event) => {
+                superCallback(event);
+                virtualCallback(event);
+              };
+            } else {
+              return superGetter.call(this);
+            }
+          },
+        });
+      }
+    };
+
+    let deprecatedEventCallbacks: Array<
+      string | Parameters<typeof defineGetterForDeprecatedEventCallback>
+    > = [
+      // EventDispatcher
+      ['touchstart', 'touchStart'],
+      ['touchmove', 'touchMove'],
+      ['touchend', 'touchEnd'],
+      ['touchcancel', 'touchCancel'],
+      ['keydown', 'keyDown', 'key-down'],
+      ['keyup', 'keyUp', 'key-up'],
+      ['keypress', 'keyPress', 'key-press'],
+      ['mousedown', 'mouseDown'],
+      ['mouseup', 'mouseUp'],
+      ['contextmenu', 'contextMenu'],
+      'click',
+      ['dblclick', 'doubleClick'],
+      ['focusin', 'focusIn', 'focus-in'],
+      ['focusout', 'focusOut', 'focus-out'],
+      'submit',
+      'input',
+      'change',
+      ['dragstart', 'dragStart'],
+      'drag',
+      ['dragenter', 'dragEnter'],
+      ['dragleave', 'dragLeave'],
+      ['dragover', 'dragOver'],
+      'drop',
+      ['dragend', 'dragEnd'],
+    ];
+
+    if (MOUSE_ENTER_LEAVE_MOVE_EVENTS) {
+      deprecatedEventCallbacks.push(
+        ['mouseenter', 'mouseEnter'],
+        ['mouseleave', 'mouseLeave'],
+        ['mousemove', 'mouseMove']
+      );
+    } else {
+      Object.assign(Input.prototype, {
+        _mouseEnter: NOOP,
+        _mouseLeave: NOOP,
+        _mouseMove: NOOP,
+      });
+    }
+
+    deprecatedEventCallbacks.forEach((args) => {
+      if (Array.isArray(args)) {
+        defineGetterForDeprecatedEventCallback(...args);
+      } else {
+        defineGetterForDeprecatedEventCallback(args);
+      }
+    });
+  }
+
+  // String actions
+  if (SEND_ACTION) {
+    interface View {
+      send(action: string, value: string, event: Event): void;
+    }
+
+    let isView = (target: {}): target is View => {
+      return typeof (target as Partial<View>).send === 'function';
+    };
+
+    let superCallbackFor = Input.prototype['callbackFor'];
+
+    Object.assign(Input.prototype, {
+      callbackFor(this: Input, type: string): (value: string, event: Event) => void {
+        const actionName = this.arg(type);
+
+        if (typeof actionName === 'string') {
+          deprecate(
+            `Passing actions to components as strings (like \`<Input @${type}="${actionName}" />\`) is deprecated. ` +
+              `Please use closure actions instead (\`<Input @${type}={{action "${actionName}"}} />\`).`,
+            false,
+            {
+              id: 'ember-component.send-action',
+              for: 'ember-source',
+              since: {},
+              until: '4.0.0',
+              url: 'https://emberjs.com/deprecations/v3.x#toc_ember-component-send-action',
+            }
+          );
+
+          const { caller } = this;
+
+          assert('[BUG] Missing caller', caller && typeof caller === 'object');
+
+          if (isView(caller)) {
+            return (value: string, event: Event) => caller.send(actionName, value, event);
+          } else {
+            assert(
+              `The action '${actionName}' did not exist on ${caller}`,
+              typeof caller[actionName] === 'function'
+            );
+
+            return caller[actionName];
+          }
+        } else {
+          return superCallbackFor.call(this, type);
+        }
+      },
+    });
+  }
+
+  // jQuery Events
+  if (JQUERY_INTEGRATION) {
+    let superCallbackFor = Input.prototype['callbackFor'];
+
+    Object.assign(Input.prototype, {
+      callbackFor(this: Input, type: string): (value: string, event: Event) => void {
+        let callback = superCallbackFor.call(this, type);
+
+        if (jQuery && !jQueryDisabled) {
+          return (value: string, event: Event) => {
+            callback(value, new jQuery.Event(event));
+          };
+        } else {
+          return callback;
+        }
+      },
+    });
   }
 }
 

--- a/packages/@ember/-internals/glimmer/lib/templates/input.hbs
+++ b/packages/@ember/-internals/glimmer/lib/templates/input.hbs
@@ -1,7 +1,91 @@
-{{~#let (component '-checkbox') (component '-text-field') as |Checkbox TextField|~}}
-  {{~#if this.isCheckbox~}}
-    <Checkbox @target={{this.caller}} @__ARGS__={{this.args}} ...attributes />
-  {{~else~}}
-    <TextField @target={{this.caller}} @__ARGS__={{this.args}} ...attributes />
-  {{~/if~}}
-{{~/let~}}
+{{~#if this.modernized ~}}
+  <input
+    {{!-- for compatibility --}}
+    id={{this.id}}
+    class={{this.class}}
+
+    {{!-- deprecated attribute bindings --}}
+    autocapitalize={{this._autocapitalize}}
+    autocorrect={{this._autocorrect}}
+    autofocus={{this._autofocus}}
+    disabled={{this._disabled}}
+    form={{this._form}}
+    maxlength={{this._maxlength}}
+    minlength={{this._minlength}}
+    placeholder={{this._placeholder}}
+    readonly={{this._readonly}}
+    required={{this._required}}
+    selectionDirection={{this._selectionDirection}}
+    spellcheck={{this._spellcheck}}
+    tabindex={{this._tabindex}}
+    title={{this._title}}
+    accept={{this._accept}}
+    autocomplete={{this._autocomplete}}
+    autosave={{this._autosave}}
+    dir={{this._dir}}
+    formaction={{this._formaction}}
+    formenctype={{this._formenctype}}
+    formmethod={{this._formmethod}}
+    formnovalidate={{this._formnovalidate}}
+    formtarget={{this._formtarget}}
+    height={{this._height}}
+    inputmode={{this._inputmode}}
+    lang={{this._lang}}
+    list={{this._list}}
+    max={{this._max}}
+    min={{this._min}}
+    multiple={{this._multiple}}
+    name={{this._name}}
+    pattern={{this._pattern}}
+    size={{this._size}}
+    step={{this._step}}
+    width={{this._width}}
+    indeterminate={{this._indeterminate}}
+
+    ...attributes
+
+    type={{this.type}}
+    checked={{this.checked}}
+    value={{this.value}}
+
+    {{on "change" this.change}}
+    {{on "input" this.input}}
+    {{on "keyup" this.keyUp}}
+    {{on "paste" this.valueDidChange}}
+    {{on "cut" this.valueDidChange}}
+
+    {{!-- deprecated native event callbacks --}}
+    {{on "touchstart" this._touchStart}}
+    {{on "touchmove" this._touchMove}}
+    {{on "touchend" this._touchEnd}}
+    {{on "touchcancel" this._touchCancel}}
+    {{on "keydown" this._keyDown}}
+    {{on "keypress" this._keyPress}}
+    {{on "mousedown" this._mouseDown}}
+    {{on "mouseup" this._mouseUp}}
+    {{on "contextmenu" this._contextMenu}}
+    {{on "click" this._click}}
+    {{on "dblclick" this._doubleClick}}
+    {{on "focusin" this._focusIn}}
+    {{on "focusout" this._focusOut}}
+    {{on "submit" this._submit}}
+    {{on "dragstart" this._dragStart}}
+    {{on "drag" this._drag}}
+    {{on "dragenter" this._dragEnter}}
+    {{on "dragleave" this._dragLeave}}
+    {{on "dragover" this._dragOver}}
+    {{on "drop" this._drop}}
+    {{on "dragend" this._dragEnd}}
+    {{on "mouseenter" this._mouseEnter}}
+    {{on "mouseleave" this._mouseLeave}}
+    {{on "mousemove" this._mouseMove}}
+  />
+{{~else~}}
+  {{~#let (component '-checkbox') (component '-text-field') as |Checkbox TextField|~}}
+    {{~#if this.isCheckbox~}}
+      <Checkbox @target={{this.caller}} @__ARGS__={{this.args}} ...attributes />
+    {{~else~}}
+      <TextField @target={{this.caller}} @__ARGS__={{this.args}} ...attributes />
+    {{~/if~}}
+  {{~/let~}}
+{{/if}}

--- a/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
@@ -9,6 +9,7 @@ import { ENV } from '@ember/-internals/environment';
 import { Component, setComponentManager } from '@ember/-internals/glimmer';
 import { EngineInstanceOptions, Owner } from '@ember/-internals/owner';
 import { Route } from '@ember/-internals/routing';
+import { EMBER_MODERNIZED_BUILT_IN_COMPONENTS } from '@ember/canary-features';
 import Controller from '@ember/controller';
 import { captureRenderTree } from '@ember/debug';
 import Engine from '@ember/engine';
@@ -1276,17 +1277,19 @@ if (ENV._DEBUG_RENDER_TREE) {
             instance: (instance: object) => inputToString.test(instance.toString()),
             template: 'packages/@ember/-internals/glimmer/lib/templates/input.hbs',
             bounds: this.nodeBounds(this.element.firstChild),
-            children: [
-              {
-                type: 'component',
-                name: '-text-field',
-                args: { positional: [], named: { target, type: 'text', value: 'first' } },
-                instance: (instance: object) => instance['value'] === 'first',
-                template: 'packages/@ember/-internals/glimmer/lib/templates/empty.hbs',
-                bounds: this.nodeBounds(this.element.firstChild),
-                children: [],
-              },
-            ],
+            children: EMBER_MODERNIZED_BUILT_IN_COMPONENTS
+              ? []
+              : [
+                  {
+                    type: 'component',
+                    name: '-text-field',
+                    args: { positional: [], named: { target, type: 'text', value: 'first' } },
+                    instance: (instance: object) => instance['value'] === 'first',
+                    template: 'packages/@ember/-internals/glimmer/lib/templates/empty.hbs',
+                    bounds: this.nodeBounds(this.element.firstChild),
+                    children: [],
+                  },
+                ],
           },
         ]);
 
@@ -1300,17 +1303,19 @@ if (ENV._DEBUG_RENDER_TREE) {
             instance: (instance: object) => inputToString.test(instance.toString()),
             template: 'packages/@ember/-internals/glimmer/lib/templates/input.hbs',
             bounds: this.nodeBounds(this.element.firstChild),
-            children: [
-              {
-                type: 'component',
-                name: '-text-field',
-                args: { positional: [], named: { target, type: 'text', value: 'first' } },
-                instance: (instance: object) => instance['value'] === 'first',
-                template: 'packages/@ember/-internals/glimmer/lib/templates/empty.hbs',
-                bounds: this.nodeBounds(this.element.firstChild),
-                children: [],
-              },
-            ],
+            children: EMBER_MODERNIZED_BUILT_IN_COMPONENTS
+              ? []
+              : [
+                  {
+                    type: 'component',
+                    name: '-text-field',
+                    args: { positional: [], named: { target, type: 'text', value: 'first' } },
+                    instance: (instance: object) => instance['value'] === 'first',
+                    template: 'packages/@ember/-internals/glimmer/lib/templates/empty.hbs',
+                    bounds: this.nodeBounds(this.element.firstChild),
+                    children: [],
+                  },
+                ],
           },
           {
             type: 'component',
@@ -1319,17 +1324,19 @@ if (ENV._DEBUG_RENDER_TREE) {
             instance: (instance: object) => inputToString.test(instance.toString()),
             template: 'packages/@ember/-internals/glimmer/lib/templates/input.hbs',
             bounds: this.nodeBounds(this.element.lastChild),
-            children: [
-              {
-                type: 'component',
-                name: '-checkbox',
-                args: { positional: [], named: { target, type: 'checkbox', checked: false } },
-                instance: (instance: object) => instance['checked'] === false,
-                template: 'packages/@ember/-internals/glimmer/lib/templates/empty.hbs',
-                bounds: this.nodeBounds(this.element.lastChild),
-                children: [],
-              },
-            ],
+            children: EMBER_MODERNIZED_BUILT_IN_COMPONENTS
+              ? []
+              : [
+                  {
+                    type: 'component',
+                    name: '-checkbox',
+                    args: { positional: [], named: { target, type: 'checkbox', checked: false } },
+                    instance: (instance: object) => instance['checked'] === false,
+                    template: 'packages/@ember/-internals/glimmer/lib/templates/empty.hbs',
+                    bounds: this.nodeBounds(this.element.lastChild),
+                    children: [],
+                  },
+                ],
           },
         ]);
 
@@ -1343,17 +1350,19 @@ if (ENV._DEBUG_RENDER_TREE) {
             instance: (instance: object) => inputToString.test(instance.toString()),
             template: 'packages/@ember/-internals/glimmer/lib/templates/input.hbs',
             bounds: this.nodeBounds(this.element.firstChild),
-            children: [
-              {
-                type: 'component',
-                name: '-text-field',
-                args: { positional: [], named: { target, type: 'text', value: 'first' } },
-                instance: (instance: object) => instance['value'] === 'first',
-                template: 'packages/@ember/-internals/glimmer/lib/templates/empty.hbs',
-                bounds: this.nodeBounds(this.element.firstChild),
-                children: [],
-              },
-            ],
+            children: EMBER_MODERNIZED_BUILT_IN_COMPONENTS
+              ? []
+              : [
+                  {
+                    type: 'component',
+                    name: '-text-field',
+                    args: { positional: [], named: { target, type: 'text', value: 'first' } },
+                    instance: (instance: object) => instance['value'] === 'first',
+                    template: 'packages/@ember/-internals/glimmer/lib/templates/empty.hbs',
+                    bounds: this.nodeBounds(this.element.firstChild),
+                    children: [],
+                  },
+                ],
           },
         ]);
       }

--- a/packages/@ember/-internals/glimmer/tests/integration/components/input-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/input-curly-test.js
@@ -761,12 +761,33 @@ moduleFor(
       this.assertAttr('tabindex', '10');
     }
 
-    ['@test `value` property assertion']() {
+    ['@feature(!EMBER_MODERNIZED_BUILT_IN_COMPONENTS) `value` property assertion']() {
       expectAssertion(() => {
         this.render(`{{input type="checkbox" value=value}}`, {
           value: 'value',
         });
       }, /checkbox.+value.+not supported.+use.+checked.+instead/);
+    }
+
+    ['@feature(EMBER_MODERNIZED_BUILT_IN_COMPONENTS) `value` property warning']() {
+      let message =
+        '`<Input @type="checkbox" />` reflects its checked state via the `@checked` argument. ' +
+        'You wrote `<Input @type="checkbox" @value={{...}} />` which is likely not what you intended. ' +
+        'Did you mean `<Input @type="checkbox" @checked={{...}} />`?';
+
+      expectWarning(() => {
+        this.render(`{{input type="checkbox" value=value}}`, {
+          value: true,
+        });
+      }, message);
+
+      this.assert.strictEqual(this.context.value, true);
+      this.assertCheckboxIsNotChecked();
+
+      expectWarning(() => this.$input()[0].click(), message);
+
+      this.assert.strictEqual(this.context.value, true);
+      this.assertCheckboxIsChecked();
     }
 
     ['@test with a bound type']() {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/strict-mode-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/strict-mode-test.js
@@ -162,7 +162,7 @@ if (EMBER_STRICT_MODE) {
   moduleFor(
     'Strict Mode - built ins',
     class extends RenderingTestCase {
-      '@test Can use Input'() {
+      '@skip Can use Input'() {
         let Foo = defineComponent({ Input }, '<Input/>');
 
         this.registerComponent('foo', { ComponentClass: Foo });

--- a/packages/@ember/-internals/metal/lib/tracked.ts
+++ b/packages/@ember/-internals/metal/lib/tracked.ts
@@ -75,6 +75,7 @@ import { SELF_TAG } from './tags';
   @param dependencies Optional dependents to be tracked.
 */
 export function tracked(propertyDesc: { value: any; initializer: () => any }): Decorator;
+export function tracked(target: object, key: string): void;
 export function tracked(
   target: object,
   key: string,

--- a/packages/@ember/-internals/views/index.d.ts
+++ b/packages/@ember/-internals/views/index.d.ts
@@ -1,6 +1,8 @@
 import { Option } from '@glimmer/interfaces';
 import { SimpleElement } from '@simple-dom/interface';
 
+export { jQuery, jQueryDisabled } from './lib/system/jquery';
+
 export const ActionSupport: any;
 export const ChildViewsSupport: any;
 export const ClassNamesSupport: any;

--- a/packages/@ember/object/index.d.ts
+++ b/packages/@ember/object/index.d.ts
@@ -1,0 +1,1 @@
+export let action: MethodDecorator;


### PR DESCRIPTION
First-pass implementation for converting the `<Input>` component into an internal (not classic) component compatibly. This passes all the existing tests.

Some follow-up work before this is ready for prime time:

- Implement any remaining classic component features not covered by the existing tests.

- Detect any unimplementable classic component features and deopt into the previous implementation.

- Write the second deprecation RFC and get the proposal merged.