### PR TITLE
[BUGFIX] `<LinkTo>` should link within the engine when used inside one

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
@@ -875,7 +875,7 @@ moduleFor(
 
     ["@test query params don't have stickiness by default between model"](assert) {
       assert.expect(1);
-      let tmpl = '{{#link-to "blog.category" 1337}}Category 1337{{/link-to}}';
+      let tmpl = '{{#link-to "category" 1337}}Category 1337{{/link-to}}';
       this.setupAppAndRoutableEngine();
       this.additionalEngineRegistrations(function () {
         this.register('template:category', compile(tmpl));
@@ -895,7 +895,7 @@ moduleFor(
     ) {
       assert.expect(2);
       let tmpl =
-        '{{#link-to "blog.author" 1337 class="author-1337"}}Author 1337{{/link-to}}{{#link-to "blog.author" 1 class="author-1"}}Author 1{{/link-to}}';
+        '{{#link-to "author" 1337 class="author-1337"}}Author 1337{{/link-to}}{{#link-to "author" 1 class="author-1"}}Author 1{{/link-to}}';
       this.setupAppAndRoutableEngine();
       this.additionalEngineRegistrations(function () {
         this.register('template:author', compile(tmpl));

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
@@ -1,11 +1,19 @@
-import { moduleFor, ApplicationTestCase, runLoopSettled, runTask } from 'internal-test-helpers';
+import {
+  ApplicationTestCase,
+  ModuleBasedTestResolver,
+  moduleFor,
+  runLoopSettled,
+  runTask,
+} from 'internal-test-helpers';
 import Controller, { inject as injectController } from '@ember/controller';
 import { A as emberA, RSVP } from '@ember/-internals/runtime';
 import { alias } from '@ember/-internals/metal';
 import { subscribe, reset } from '@ember/instrumentation';
 import { Route, NoneLocation } from '@ember/-internals/routing';
 import { EMBER_IMPROVED_INSTRUMENTATION } from '@ember/canary-features';
+import Engine from '@ember/engine';
 import { DEBUG } from '@glimmer/env';
+import { compile } from '../../../utils/helpers';
 
 // IE includes the host name
 function normalizeUrl(url) {
@@ -347,6 +355,209 @@ moduleFor(
           'The about-link was rendered with the truthy class after toggling the property'
         );
       });
+    }
+
+    async ['@test Using <LinkTo> inside a non-routable engine errors'](assert) {
+      this.add(
+        'engine:not-routable',
+        class NotRoutableEngine extends Engine {
+          Resolver = ModuleBasedTestResolver;
+
+          init() {
+            super.init(...arguments);
+            this.register(
+              'template:application',
+              compile(`<LinkTo @route='about'>About</LinkTo>`, {
+                moduleName: 'non-routable/templates/application.hbs',
+              })
+            );
+          }
+        }
+      );
+
+      this.addTemplate('index', `{{mount 'not-routable'}}`);
+
+      await assert.rejectsAssertion(
+        this.visit('/'),
+        'You attempted to use the <LinkTo> component within a routeless engine, this is not supported. ' +
+          'If you are using the ember-engines addon, use the <LinkToExternal> component instead. ' +
+          'See https://ember-engines.com/docs/links for more info.'
+      );
+    }
+
+    async ['@test Using <LinkTo> inside a routable engine link within the engine'](assert) {
+      this.add(
+        'engine:routable',
+        class RoutableEngine extends Engine {
+          Resolver = ModuleBasedTestResolver;
+
+          init() {
+            super.init(...arguments);
+            this.register(
+              'template:application',
+              compile(
+                `
+                <h2 id='engine-layout'>Routable Engine</h2>
+                {{outlet}}
+                <LinkTo @route='application' id='engine-application-link'>Engine Appliction</LinkTo>
+                `,
+                {
+                  moduleName: 'routable/templates/application.hbs',
+                }
+              )
+            );
+            this.register(
+              'template:index',
+              compile(
+                `
+                <h3 class='engine-home'>Engine Home</h3>
+                <LinkTo @route='about' id='engine-about-link'>Engine About</LinkTo>
+                <LinkTo @route='index' id='engine-self-link'>Engine Self</LinkTo>
+                `,
+                {
+                  moduleName: 'routable/templates/index.hbs',
+                }
+              )
+            );
+            this.register(
+              'template:about',
+              compile(
+                `
+                <h3 class='engine-about'>Engine About</h3>
+                <LinkTo @route='index' id='engine-home-link'>Engine Home</LinkTo>
+                <LinkTo @route='about' id='engine-self-link'>Engine Self</LinkTo>
+                `,
+                {
+                  moduleName: 'routable/templates/about.hbs',
+                }
+              )
+            );
+          }
+        }
+      );
+
+      this.router.map(function () {
+        this.mount('routable');
+      });
+
+      this.add('route-map:routable', function () {
+        this.route('about');
+      });
+
+      this.addTemplate(
+        'application',
+        `
+        <h1 id='application-layout'>Application</h1>
+        {{outlet}}
+        <LinkTo @route='application' id='application-link'>Appliction</LinkTo>
+        <LinkTo @route='routable' id='engine-link'>Engine</LinkTo>
+        `
+      );
+
+      await this.visit('/');
+
+      assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
+      assert.strictEqual(this.$('#engine-layout').length, 0, 'The engine layout was not rendered');
+      assert.equal(this.$('#application-link.active').length, 1, 'The application link is active');
+      assert.equal(this.$('#engine-link:not(.active)').length, 1, 'The engine link is not active');
+
+      assert.equal(this.$('h3.home').length, 1, 'The application index page is rendered');
+      assert.equal(this.$('#self-link.active').length, 1, 'The application index link is active');
+      assert.equal(
+        this.$('#about-link:not(.active)').length,
+        1,
+        'The application about link is not active'
+      );
+
+      await this.click('#about-link');
+
+      assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
+      assert.strictEqual(this.$('#engine-layout').length, 0, 'The engine layout was not rendered');
+      assert.equal(this.$('#application-link.active').length, 1, 'The application link is active');
+      assert.equal(this.$('#engine-link:not(.active)').length, 1, 'The engine link is not active');
+
+      assert.equal(this.$('h3.about').length, 1, 'The application about page is rendered');
+      assert.equal(this.$('#self-link.active').length, 1, 'The application about link is active');
+      assert.equal(
+        this.$('#home-link:not(.active)').length,
+        1,
+        'The application home link is not active'
+      );
+
+      await this.click('#engine-link');
+
+      assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
+      assert.equal(this.$('#engine-layout').length, 1, 'The engine layout was rendered');
+      assert.equal(this.$('#application-link.active').length, 1, 'The application link is active');
+      assert.equal(this.$('#engine-link.active').length, 1, 'The engine link is active');
+      assert.equal(
+        this.$('#engine-application-link.active').length,
+        1,
+        'The engine application link is active'
+      );
+
+      assert.equal(this.$('h3.engine-home').length, 1, 'The engine index page is rendered');
+      assert.equal(this.$('#engine-self-link.active').length, 1, 'The engine index link is active');
+      assert.equal(
+        this.$('#engine-about-link:not(.active)').length,
+        1,
+        'The engine about link is not active'
+      );
+
+      await this.click('#engine-about-link');
+
+      assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
+      assert.equal(this.$('#engine-layout').length, 1, 'The engine layout was rendered');
+      assert.equal(this.$('#application-link.active').length, 1, 'The application link is active');
+      assert.equal(this.$('#engine-link.active').length, 1, 'The engine link is active');
+      assert.equal(
+        this.$('#engine-application-link.active').length,
+        1,
+        'The engine application link is active'
+      );
+
+      assert.equal(this.$('h3.engine-about').length, 1, 'The engine about page is rendered');
+      assert.equal(this.$('#engine-self-link.active').length, 1, 'The engine about link is active');
+      assert.equal(
+        this.$('#engine-home-link:not(.active)').length,
+        1,
+        'The engine home link is not active'
+      );
+
+      await this.click('#engine-application-link');
+
+      assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
+      assert.equal(this.$('#engine-layout').length, 1, 'The engine layout was rendered');
+      assert.equal(this.$('#application-link.active').length, 1, 'The application link is active');
+      assert.equal(this.$('#engine-link.active').length, 1, 'The engine link is active');
+      assert.equal(
+        this.$('#engine-application-link.active').length,
+        1,
+        'The engine application link is active'
+      );
+
+      assert.equal(this.$('h3.engine-home').length, 1, 'The engine index page is rendered');
+      assert.equal(this.$('#engine-self-link.active').length, 1, 'The engine index link is active');
+      assert.equal(
+        this.$('#engine-about-link:not(.active)').length,
+        1,
+        'The engine about link is not active'
+      );
+
+      await this.click('#application-link');
+
+      assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
+      assert.strictEqual(this.$('#engine-layout').length, 0, 'The engine layout was not rendered');
+      assert.equal(this.$('#application-link.active').length, 1, 'The application link is active');
+      assert.equal(this.$('#engine-link:not(.active)').length, 1, 'The engine link is not active');
+
+      assert.equal(this.$('h3.home').length, 1, 'The application index page is rendered');
+      assert.equal(this.$('#self-link.active').length, 1, 'The application index link is active');
+      assert.equal(
+        this.$('#about-link:not(.active)').length,
+        1,
+        'The application about link is not active'
+      );
     }
   }
 );

--- a/packages/@ember/-internals/routing/lib/services/routing.ts
+++ b/packages/@ember/-internals/routing/lib/services/routing.ts
@@ -6,6 +6,7 @@ import { readOnly } from '@ember/object/computed';
 import { assign } from '@ember/polyfills';
 import Service from '@ember/service';
 import EmberRouter, { QueryParam } from '../system/router';
+import RouterState from '../system/router_state';
 
 /**
   The Routing service is used by LinkComponent, and provides facilities for
@@ -57,11 +58,10 @@ export default class RoutingService extends Service {
 
   isActiveForRoute(
     contexts: {}[],
-    queryParams: {},
+    queryParams: QueryParam | undefined,
     routeName: string,
-    routerState: any,
-    isCurrentWhenSpecified: any
-  ) {
+    routerState: RouterState
+  ): boolean {
     let handlers = this.router._routerMicrolib.recognizer.handlersFor(routeName);
     let leafName = handlers[handlers.length - 1].handler;
     let maximumContexts = numberOfContextsAcceptedByHandler(routeName, handlers);
@@ -80,7 +80,7 @@ export default class RoutingService extends Service {
       routeName = leafName;
     }
 
-    return routerState.isActiveIntent(routeName, contexts, queryParams, !isCurrentWhenSpecified);
+    return routerState.isActiveIntent(routeName, contexts, queryParams);
   }
 }
 

--- a/packages/@ember/-internals/routing/lib/system/router_state.ts
+++ b/packages/@ember/-internals/routing/lib/system/router_state.ts
@@ -18,18 +18,13 @@ export default class RouterState {
     this.routerJsState = routerJsState;
   }
 
-  isActiveIntent(
-    routeName: string,
-    models: {}[],
-    queryParams: QueryParam,
-    queryParamsMustMatch?: boolean
-  ) {
+  isActiveIntent(routeName: string, models: {}[], queryParams?: QueryParam): boolean {
     let state = this.routerJsState;
     if (!this.router.isActiveIntent(routeName, models, undefined, state)) {
       return false;
     }
 
-    if (queryParamsMustMatch && Object.keys(queryParams).length > 0) {
+    if (queryParams !== undefined && Object.keys(queryParams).length > 0) {
       let visibleQueryParams = assign({}, queryParams);
 
       this.emberRouter._prepareQueryParams(routeName, models, visibleQueryParams);

--- a/packages/@ember/engine/index.d.ts
+++ b/packages/@ember/engine/index.d.ts
@@ -1,5 +1,7 @@
-import { Owner, LookupOptions, Factory, EngineInstanceOptions } from '@ember/-internals/owner';
-import EngineInstance from './instance';
+export { default as EngineInstance } from './instance';
+export function getEngineParent(instance: EngineInstance): EngineInstance | undefined;
+
+import { EngineInstanceOptions, Factory } from '@ember/-internals/owner';
 
 export default class Engine {
   constructor(...args: any[]);


### PR DESCRIPTION
See https://github.com/ember-engines/ember-engines/issues/692#issuecomment-714490847. This should allow ember-engines to remove the `<LinkTo>` monkey patch (at least that's the intention).

Not sure what versions to target (if any) for the backport. This could arguably be a breaking bugfix for people using engines but not using the ember-engines addon? I don't know if that combination exists in the real world though.