### PR TITLE
Add {{page-title}} to route templates

### DIFF
--- a/blueprints/route/files/__root__/__templatepath__/__templatename__.hbs
+++ b/blueprints/route/files/__root__/__templatepath__/__templatename__.hbs
@@ -1,1 +1,2 @@
-{{outlet}}
+<% if (addTitle) {%>{{page-title "<%= routeName %>"}}
+<%}%>{{outlet}}

--- a/blueprints/route/index.js
+++ b/blueprints/route/index.js
@@ -73,13 +73,17 @@ module.exports = useEditionDetector({
 
   locals: function (options) {
     let moduleName = options.entity.name;
+    let rawRouteName = moduleName.split('/').pop();
+    let emberPageTitleExists = 'ember-page-title' in options.project.dependencies();
 
     if (options.resetNamespace) {
-      moduleName = moduleName.split('/').pop();
+      moduleName = rawRouteName;
     }
 
     return {
       moduleName: stringUtil.dasherize(moduleName),
+      routeName: stringUtil.classify(rawRouteName),
+      addTitle: emberPageTitleExists,
     };
   },
 

--- a/blueprints/route/native-files/__root__/__templatepath__/__templatename__.hbs
+++ b/blueprints/route/native-files/__root__/__templatepath__/__templatename__.hbs
@@ -1,1 +1,2 @@
-{{outlet}}
+<% if (addTitle) {%>{{page-title "<%= routeName %>"}}
+<%}%>{{outlet}}

--- a/node-tests/blueprints/route-test.js
+++ b/node-tests/blueprints/route-test.js
@@ -276,6 +276,24 @@ describe('Blueprint: route', function () {
         });
       });
     });
+
+    describe('ember-page-title is installed', function () {
+      beforeEach(function () {
+        return modifyPackages([{ name: 'ember-page-title', dev: true }]);
+      });
+
+      it('route foo', function () {
+        return emberGenerateDestroy(['route', 'foo'], (_file) => {
+          expect(_file('app/templates/foo.hbs')).to.equal('{{page-title "Foo"}}\n{{outlet}}');
+        });
+      });
+
+      it('route foo/bar', function () {
+        return emberGenerateDestroy(['route', 'foo/bar'], (_file) => {
+          expect(_file('app/templates/foo/bar.hbs')).to.equal('{{page-title "Bar"}}\n{{outlet}}');
+        });
+      });
+    });
   });
 
   describe('in addon', function () {
@@ -460,6 +478,24 @@ describe('Blueprint: route', function () {
         );
 
         expect(_file('tests/unit/foo/route-test.js')).to.equal(fixture('route-test/default.js'));
+      });
+    });
+
+    describe('ember-page-title is installed', function () {
+      beforeEach(function () {
+        return modifyPackages([{ name: 'ember-page-title', dev: true }]);
+      });
+
+      it('route foo', function () {
+        return emberGenerateDestroy(['route', 'foo'], (_file) => {
+          expect(_file('addon/templates/foo.hbs')).to.equal('{{page-title "Foo"}}\n{{outlet}}');
+        });
+      });
+
+      it('route foo/bar', function () {
+        return emberGenerateDestroy(['route', 'foo/bar'], (_file) => {
+          expect(_file('addon/templates/foo/bar.hbs')).to.equal('{{page-title "Bar"}}\n{{outlet}}');
+        });
       });
     });
   });
@@ -719,6 +755,24 @@ describe('Blueprint: route', function () {
         });
       });
     });
+
+    describe('ember-page-title is installed', function () {
+      beforeEach(function () {
+        return modifyPackages([{ name: 'ember-page-title', dev: true }]);
+      });
+
+      it('route foo', function () {
+        return emberGenerateDestroy(['route', 'foo'], (_file) => {
+          expect(_file('app/templates/foo.hbs')).to.equal('{{page-title "Foo"}}\n{{outlet}}');
+        });
+      });
+
+      it('route foo/bar', function () {
+        return emberGenerateDestroy(['route', 'foo/bar'], (_file) => {
+          expect(_file('app/templates/foo/bar.hbs')).to.equal('{{page-title "Bar"}}\n{{outlet}}');
+        });
+      });
+    });
   });
 
   describe('in addon - octane', function () {
@@ -907,6 +961,24 @@ describe('Blueprint: route', function () {
         expect(_file('tests/unit/foo/route-test.js')).to.equal(fixture('route-test/default.js'));
       });
     });
+
+    describe('ember-page-title is installed', function () {
+      beforeEach(function () {
+        return modifyPackages([{ name: 'ember-page-title', dev: true }]);
+      });
+
+      it('route foo', function () {
+        return emberGenerateDestroy(['route', 'foo'], (_file) => {
+          expect(_file('addon/templates/foo.hbs')).to.equal('{{page-title "Foo"}}\n{{outlet}}');
+        });
+      });
+
+      it('route foo/bar', function () {
+        return emberGenerateDestroy(['route', 'foo/bar'], (_file) => {
+          expect(_file('addon/templates/foo/bar.hbs')).to.equal('{{page-title "Bar"}}\n{{outlet}}');
+        });
+      });
+    });
   });
 
   describe('in in-repo-addon', function () {
@@ -982,6 +1054,28 @@ describe('Blueprint: route', function () {
         expect(_file('tests/unit/routes/foo/bar-test.js')).to.equal(
           fixture('route-test/default-nested.js')
         );
+      });
+    });
+
+    describe('ember-page-title is installed', function () {
+      beforeEach(function () {
+        return modifyPackages([{ name: 'ember-page-title', dev: true }]);
+      });
+
+      it('route foo', function () {
+        return emberGenerateDestroy(['route', 'foo', '--in-repo-addon=my-addon'], (_file) => {
+          expect(_file('lib/my-addon/addon/templates/foo.hbs')).to.equal(
+            '{{page-title "Foo"}}\n{{outlet}}'
+          );
+        });
+      });
+
+      it('route foo/bar', function () {
+        return emberGenerateDestroy(['route', 'foo/bar', '--in-repo-addon=my-addon'], (_file) => {
+          expect(_file('lib/my-addon/addon/templates/foo/bar.hbs')).to.equal(
+            '{{page-title "Bar"}}\n{{outlet}}'
+          );
+        });
       });
     });
   });


### PR DESCRIPTION
Changes in this PR are for `ember-page-title` RFC - https://github.com/ember-cli/ember-cli/issues/9370

Related PR for `ember-cli`: https://github.com/ember-cli/ember-cli/pull/9372

TODO

- [x] detect if the app has `ember-page-title` installed, and only add the `{{page-title ...}}` invocation