### PR TITLE
Revert "[BUGFIX lts] Prevents infinite rerenders when errors occur during render"

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/error-handling-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/error-handling-test.js
@@ -1,5 +1,3 @@
-import { DEBUG } from '@glimmer/env';
-
 import { moduleFor, RenderingTestCase, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
@@ -45,14 +43,10 @@ moduleFor(
 
       runTask(() => set(this.context, 'switch', true));
 
-      if (DEBUG) {
-        this.assertText('', 'it does not rerender after error in development');
-      } else {
-        this.assertText('hello', 'it rerenders after error in production');
-      }
+      this.assertText('hello');
     }
 
-    ['@test it can recover resets the transaction when an error is thrown during rerender'](
+    ['@skip it can recover resets the transaction when an error is thrown during rerender'](
       assert
     ) {
       let shouldThrow = false;
@@ -97,11 +91,7 @@ moduleFor(
 
       runTask(() => set(this.context, 'switch', true));
 
-      if (DEBUG) {
-        this.assertText('', 'it does not rerender after error in development');
-      } else {
-        this.assertText('hello', 'it does rerender after error in production');
-      }
+      this.assertText('hello');
     }
 
     ['@test it can recover resets the transaction when an error is thrown during didInsertElement'](


### PR DESCRIPTION
Reverts emberjs/ember.js#19200 as it caused some production test failures:

```
[1022/210630.114228:INFO:CONSOLE(52)] "    Failed assertion: Died on test #5     at generateTest (http://localhost:13141/tests/ember-tests.js:108736:15)
    at Set.forEach (<anonymous>)
    at setupTestClass (http://localhost:13141/tests/ember-tests.js:108722:16)
    at http://localhost:13141/tests/ember-tests.js:108669:22
    at Object.<anonymous> (http://localhost:13141/tests/ember-tests.js:108073:9)
    at processModule (http://localhost:13141/tests/qunit/qunit.js:1200:16)
    at module$1 (http://localhost:13141/tests/qunit/qunit.js:1225:4)
    at Object.QUnit.module (http://localhost:13141/tests/ember-tests.js:108065:14): Cannot read property 'firstNode' of null
TypeError: Cannot read property 'firstNode' of null
    at SimpleLiveBlock.firstNode (http://localhost:13141/tests/ember.js:49238:20)
    at UpdatableBlockImpl.firstNode (http://localhost:13141/tests/ember.js:49238:20)
    at clear (http://localhost:13141/tests/ember.js:48106:24)
    at UpdatableBlockImpl.reset (http://localhost:13141/tests/ember.js:49339:25)
    at Function.resume (http://localhost:13141/tests/ember.js:48941:31)
    at TryOpcode.handleException (http://localhost:13141/tests/ember.js:52983:44)
    at UpdatingVMFrame.handleException (http://localhost:13141/tests/ember.js:53228:31)
    at UpdatingVM._throw [as throw] (http://localhost:13141/tests/ember.js:52893:18)
    at Assert.evaluate (http://localhost:13141/tests/ember.js:50235:17)
    at UpdatingVM._execute (http://localhost:13141/tests/ember.js:52880:16)", source:  (52)
[1022/210630.114975:INFO:CONSOLE(52)] "    Failed assertion: afterEach failed on  it can recover resets the transaction when an error is thrown during rerender: Cannot read property 'firstNode' of null
TypeError: Cannot read property 'firstNode' of null
    at SimpleLiveBlock.firstNode (http://localhost:13141/tests/ember.js:49238:20)
    at UpdatableBlockImpl.firstNode (http://localhost:13141/tests/ember.js:49238:20)
    at SimpleLiveBlock.firstNode (http://localhost:13141/tests/ember.js:49238:20)
    at UpdatableBlockImpl.firstNode (http://localhost:13141/tests/ember.js:49238:20)
    at SimpleLiveBlock.firstNode (http://localhost:13141/tests/ember.js:49238:20)
    at clear (http://localhost:13141/tests/ember.js:48106:24)
    at http://localhost:13141/tests/ember.js:53245:16
    at invoke (http://localhost:13141/tests/ember.js:57176:16)
    at Queue.flush (http://localhost:13141/tests/ember.js:57066:13)
    at DeferredActionQueues.flush (http://localhost:13141/tests/ember.js:57273:21)", source:  (52)
```

It seems likely that this was caused by interactions between https://github.com/emberjs/ember.js/pull/19199 and https://github.com/emberjs/ember.js/pull/19200, but I have not dug into it.