### PR TITLE
Fix TypeScript linting warnings in 15 files

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/modifiers/on.ts
+++ b/packages/@ember/-internals/glimmer/lib/modifiers/on.ts
@@ -69,7 +69,7 @@ export class OnModifierState {
     this.args = args;
   }
 
-  updateFromArgs() {
+  updateFromArgs(): void {
     let { args } = this;
 
     let { once, passive, capture }: AddEventListenerOptions = reifyNamed(args.named);
@@ -321,15 +321,15 @@ export default class OnModifierManager implements ModifierManager<OnModifierStat
     this.owner = owner;
   }
 
-  getDebugName() {
+  getDebugName(): string {
     return 'on';
   }
 
-  get counters() {
+  get counters(): {adds: number, removes: number} {
     return { adds, removes };
   }
 
-  create(element: SimpleElement | Element, _state: unknown, args: VMArguments) {
+  create(element: SimpleElement | Element, _state: unknown, args: VMArguments): OnModifierState | null {
     if (!this.isInteractive) {
       return null;
     }
@@ -347,7 +347,7 @@ export default class OnModifierManager implements ModifierManager<OnModifierStat
     return state.tag;
   }
 
-  install(state: OnModifierState | null) {
+  install(state: OnModifierState | null): void {
     if (state === null) {
       return;
     }
@@ -363,7 +363,7 @@ export default class OnModifierManager implements ModifierManager<OnModifierStat
     state.shouldUpdate = false;
   }
 
-  update(state: OnModifierState | null) {
+  update(state: OnModifierState | null): void {
     if (state === null) {
       return;
     }
@@ -386,7 +386,7 @@ export default class OnModifierManager implements ModifierManager<OnModifierStat
     state.shouldUpdate = false;
   }
 
-  getDestroyable(state: OnModifierState | null) {
+  getDestroyable(state: OnModifierState | null): OnModifierState | null {
     return state;
   }
 }

--- a/packages/@ember/-internals/glimmer/lib/modifiers/on.ts
+++ b/packages/@ember/-internals/glimmer/lib/modifiers/on.ts
@@ -325,11 +325,15 @@ export default class OnModifierManager implements ModifierManager<OnModifierStat
     return 'on';
   }
 
-  get counters(): {adds: number, removes: number} {
+  get counters(): { adds: number; removes: number } {
     return { adds, removes };
   }
 
-  create(element: SimpleElement | Element, _state: unknown, args: VMArguments): OnModifierState | null {
+  create(
+    element: SimpleElement | Element,
+    _state: unknown,
+    args: VMArguments
+  ): OnModifierState | null {
     if (!this.isInteractive) {
       return null;
     }

--- a/packages/@ember/-internals/glimmer/lib/template_registry.ts
+++ b/packages/@ember/-internals/glimmer/lib/template_registry.ts
@@ -7,11 +7,11 @@ interface TemplatesRegistry {
 }
 let TEMPLATES: TemplatesRegistry = {};
 
-export function setTemplates(templates: TemplatesRegistry) {
+export function setTemplates(templates: TemplatesRegistry): void {
   TEMPLATES = templates;
 }
 
-export function getTemplates() {
+export function getTemplates(): TemplatesRegistry {
   return TEMPLATES;
 }
 

--- a/packages/@ember/-internals/glimmer/lib/utils/curly-component-state-bucket.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/curly-component-state-bucket.ts
@@ -60,7 +60,7 @@ export default class ComponentStateBucket {
     registerDestructor(this, () => this.component.destroy());
   }
 
-  willDestroy() {
+  willDestroy(): void {
     let { component, environment } = this;
 
     if (environment.isInteractive) {
@@ -80,7 +80,7 @@ export default class ComponentStateBucket {
     component.renderer.unregister(component);
   }
 
-  finalize() {
+  finalize(): void {
     let { finalizer } = this;
     finalizer();
     this.finalizer = NOOP;

--- a/packages/@ember/-internals/utils/lib/super.ts
+++ b/packages/@ember/-internals/utils/lib/super.ts
@@ -54,16 +54,16 @@ function createObserverListenerMetaFor(fn: Function) {
   return meta;
 }
 
-export function observerListenerMetaFor(fn: Function) {
+export function observerListenerMetaFor(fn: Function): ObserverListenerMeta | undefined {
   return OBSERVERS_LISTENERS_MAP.get(fn);
 }
 
-export function setObservers(func: Function, observers: { paths: string[]; sync: boolean }) {
+export function setObservers(func: Function, observers: { paths: string[]; sync: boolean }): void {
   let meta = createObserverListenerMetaFor(func);
   meta.observers = observers;
 }
 
-export function setListeners(func: Function, listeners: string[]) {
+export function setListeners(func: Function, listeners: string[]): void {
   let meta = createObserverListenerMetaFor(func);
   meta.listeners = listeners;
 }
@@ -82,7 +82,7 @@ const IS_WRAPPED_FUNCTION_SET = new WeakSet();
   @param {Function} superFunc The super function.
   @return {Function} wrapped function.
 */
-export function wrap(func: Function, superFunc: Function) {
+export function wrap(func: Function, superFunc: Function): Function {
   if (!hasSuper(func)) {
     return func;
   }

--- a/packages/@ember/-internals/views/lib/system/utils.ts
+++ b/packages/@ember/-internals/views/lib/system/utils.ts
@@ -9,14 +9,14 @@ import { Dict, Option } from '@glimmer/interfaces';
 @module ember
 */
 
-export function isSimpleClick(event: MouseEvent) {
+export function isSimpleClick(event: MouseEvent): boolean {
   let modifier = event.shiftKey || event.metaKey || event.altKey || event.ctrlKey;
   let secondaryClick = event.which > 1; // IE9 may return undefined
 
   return !modifier && !secondaryClick;
 }
 
-export function constructStyleDeprecationMessage(affectedStyle: string) {
+export function constructStyleDeprecationMessage(affectedStyle: string): string {
   return (
     '' +
     'Binding style attributes may introduce cross-site scripting vulnerabilities; ' +
@@ -116,7 +116,7 @@ const CHILD_VIEW_IDS: WeakMap<View, Set<string>> = new WeakMap();
   @method getChildViews
   @param {Ember.View} view
 */
-export function getChildViews(view: View) {
+export function getChildViews(view: View): View[] {
   let owner = getOwner(view);
   let registry = owner.lookup<Dict<View>>('-view-registry:main')!;
   return collectChildViews(view, registry);
@@ -227,12 +227,12 @@ export const elMatches: typeof Element.prototype.matches | undefined =
       Element.prototype['webkitMatchesSelector']
     : undefined;
 
-export function matches(el: Element, selector: string) {
+export function matches(el: Element, selector: string): boolean {
   assert('cannot call `matches` in fastboot mode', elMatches !== undefined);
   return elMatches!.call(el, selector);
 }
 
-export function contains(a: Node, b: Node) {
+export function contains(a: Node, b: Node): boolean {
   if (a.contains !== undefined) {
     return a.contains(b);
   }

--- a/packages/ember-template-compiler/lib/system/compile-options.ts
+++ b/packages/ember-template-compiler/lib/system/compile-options.ts
@@ -76,7 +76,7 @@ function wrapLegacyPluginIfNeeded(_plugin: PluginFunc | LegacyPluginClass): Plug
   return plugin as PluginFunc;
 }
 
-export function registerPlugin(type: string, _plugin: PluginFunc | LegacyPluginClass) {
+export function registerPlugin(type: string, _plugin: PluginFunc | LegacyPluginClass): void {
   if (type !== 'ast') {
     throw new Error(
       `Attempting to register ${_plugin} as "${type}" which is not a valid Glimmer plugin type.`
@@ -95,7 +95,7 @@ export function registerPlugin(type: string, _plugin: PluginFunc | LegacyPluginC
   USER_PLUGINS = [plugin, ...USER_PLUGINS];
 }
 
-export function unregisterPlugin(type: string, PluginClass: PluginFunc | LegacyPluginClass) {
+export function unregisterPlugin(type: string, PluginClass: PluginFunc | LegacyPluginClass): void {
   if (type !== 'ast') {
     throw new Error(
       `Attempting to unregister ${PluginClass} as "${type}" which is not a valid Glimmer plugin type.`

--- a/packages/ember-template-compiler/tests/utils/transform-test-case.ts
+++ b/packages/ember-template-compiler/tests/utils/transform-test-case.ts
@@ -5,7 +5,7 @@ import { AbstractTestCase } from 'internal-test-helpers';
 import { compileOptions } from '../../index';
 
 export default class extends AbstractTestCase {
-  assertTransformed(before: string, after: string) {
+  assertTransformed(before: string, after: string): void {
     this.assert.deepEqual(deloc(ast(before)), deloc(ast(after)));
   }
 }
@@ -31,7 +31,9 @@ function ast(template: string): AST.Program {
     moduleName: '-top-level',
   });
 
-  options.plugins!.ast!.push(extractProgram);
+  if (options.plugins.ast) {
+    options.plugins.ast.push(extractProgram);
+  }
 
   precompile(template, options as any);
 

--- a/packages/internal-test-helpers/lib/ember-dev/assertion.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/assertion.ts
@@ -30,7 +30,7 @@ const BREAK = {};
   In particular, this prevents `Ember.assert` from throw errors that would
   disrupt the control flow.
 */
-export function setupAssertionHelpers(hooks: NestedHooks, env: DebugEnv) {
+export function setupAssertionHelpers(hooks: NestedHooks, env: DebugEnv): void {
   let originalAssertFunc = env.getDebugFunction('assert');
 
   hooks.beforeEach(function (assert) {

--- a/packages/internal-test-helpers/lib/ember-dev/containers.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/containers.ts
@@ -2,7 +2,7 @@ import { Container } from '@ember/-internals/container';
 
 const { _leakTracking: containerLeakTracking } = Container;
 
-export function setupContainersCheck(hooks: NestedHooks) {
+export function setupContainersCheck(hooks: NestedHooks): void {
   hooks.afterEach(function () {
     if (containerLeakTracking === undefined) return;
 

--- a/packages/internal-test-helpers/lib/ember-dev/debug.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/debug.ts
@@ -12,13 +12,13 @@ class DebugAssert {
     this.tracker = null;
   }
 
-  inject() {}
+  inject(): void {}
 
-  restore() {
+  restore(): void {
     this.reset();
   }
 
-  reset() {
+  reset(): void {
     if (this.tracker) {
       this.tracker.restoreMethod();
     }
@@ -26,7 +26,7 @@ class DebugAssert {
     this.tracker = null;
   }
 
-  assert() {
+  assert(): void {
     if (this.tracker) {
       this.tracker.assert();
     }
@@ -38,7 +38,7 @@ class DebugAssert {
     func: (() => any) | undefined,
     callback: (tracker: MethodCallTracker) => void,
     async = false
-  ) {
+  ): void {
     let originalTracker: MethodCallTracker | null = null;
 
     // When helpers are passed a callback, they get a new tracker context

--- a/packages/internal-test-helpers/lib/ember-dev/deprecation.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/deprecation.ts
@@ -21,7 +21,7 @@ declare global {
   }
 }
 
-export function setupDeprecationHelpers(hooks: NestedHooks, env: DebugEnv) {
+export function setupDeprecationHelpers(hooks: NestedHooks, env: DebugEnv): void {
   let assertion = new DeprecationAssert(env);
 
   hooks.beforeEach(function () {
@@ -40,7 +40,7 @@ class DeprecationAssert extends DebugAssert {
     super('deprecate', env);
   }
 
-  inject() {
+  inject(): void {
     // Expects no deprecation to happen within a function, or if no function is
     // passed, from the time of calling until the end of the test.
     //
@@ -127,7 +127,7 @@ class DeprecationAssert extends DebugAssert {
     window.ignoreDeprecation = ignoreDeprecation;
   }
 
-  restore() {
+  restore(): void {
     super.restore();
     window.expectDeprecation = null;
     window.expectDeprecationAsync = null;

--- a/packages/internal-test-helpers/lib/ember-dev/method-call-tracker.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/method-call-tracker.ts
@@ -24,7 +24,7 @@ export default class MethodCallTracker {
     this._originalMethod = undefined;
   }
 
-  stubMethod() {
+  stubMethod(): void {
     if (this._originalMethod) {
       // Method is already stubbed
       return;
@@ -42,32 +42,32 @@ export default class MethodCallTracker {
     });
   }
 
-  restoreMethod() {
+  restoreMethod(): void {
     if (this._originalMethod) {
       this._env.setDebugFunction(this._methodName, this._originalMethod);
     }
   }
 
-  expectCall(message: Message, options?: OptionList) {
+  expectCall(message: Message, options?: OptionList): void {
     this.stubMethod();
     this._expectedMessages.push(message || /.*/);
     this._expectedOptionLists.push(options);
   }
 
-  expectNoCalls() {
+  expectNoCalls(): void {
     this.stubMethod();
     this._isExpectingNoCalls = true;
   }
 
-  isExpectingNoCalls() {
+  isExpectingNoCalls(): boolean {
     return this._isExpectingNoCalls;
   }
 
-  isExpectingCalls() {
+  isExpectingCalls(): boolean | number {
     return !this._isExpectingNoCalls && this._expectedMessages.length;
   }
 
-  assert() {
+  assert(): void {
     let { assert } = QUnit.config.current;
     let methodName = this._methodName;
     let isExpectingNoCalls = this._isExpectingNoCalls;

--- a/packages/internal-test-helpers/lib/ember-dev/namespaces.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/namespaces.ts
@@ -1,7 +1,7 @@
 import { NAMESPACES, NAMESPACES_BY_ID } from '@ember/-internals/metal';
 import { run } from '@ember/runloop';
 
-export function setupNamespacesCheck(hooks: NestedHooks) {
+export function setupNamespacesCheck(hooks: NestedHooks): void {
   hooks.afterEach(function () {
     let { assert } = QUnit.config.current;
 

--- a/packages/internal-test-helpers/lib/ember-dev/observers.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/observers.ts
@@ -1,7 +1,7 @@
 import { ASYNC_OBSERVERS, SYNC_OBSERVERS } from '@ember/-internals/metal';
 import { run } from '@ember/runloop';
 
-export function setupObserversCheck(hooks: NestedHooks) {
+export function setupObserversCheck(hooks: NestedHooks): void {
   hooks.afterEach(function () {
     let { assert } = QUnit.config.current;
 

--- a/packages/internal-test-helpers/lib/run.ts
+++ b/packages/internal-test-helpers/lib/run.ts
@@ -9,29 +9,29 @@ import {
 
 import { Promise } from 'rsvp';
 
-export function runAppend(view: any) {
+export function runAppend(view: any): void {
   run(view, 'appendTo', document.getElementById('qunit-fixture'));
 }
 
-export function runDestroy(toDestroy: any) {
+export function runDestroy(toDestroy: any): void {
   if (toDestroy) {
     run(toDestroy, 'destroy');
   }
 }
 
-export function runTask(callback: Function) {
+export function runTask(callback: Function): Function {
   return run(callback);
 }
 
 export function runTaskNext(): Promise<void> {
-  return new Promise((resolve) => {
+  return new Promise((resolve: Function) => {
     return next(resolve);
   });
 }
 
 // TODO: Find a better name 😎
 export function runLoopSettled(event?: any): Promise<void> {
-  return new Promise(function (resolve) {
+  return new Promise(function (resolve: Function) {
     // Every 5ms, poll for the async thing to have finished
     let watcher = setInterval(() => {
       // If there are scheduled timers or we are inside of a run loop, keep polling


### PR DESCRIPTION
This PR fixes mostly the `Missing return type on function` linter warning messages. In some files the `Forbidden non-null assertion` and `Unexpected any. Specify a different type` warnings have been fixed.