### PR TITLE
[BUGFIX beta] Restores the shadowed property set behavior

### DIFF
--- a/packages/@ember/-internals/metal/lib/tracked.ts
+++ b/packages/@ember/-internals/metal/lib/tracked.ts
@@ -5,8 +5,7 @@ import { DEBUG } from '@glimmer/env';
 import { consumeTag, dirtyTagFor, tagFor, trackedData } from '@glimmer/validator';
 import { CHAIN_PASS_THROUGH } from './chain-tags';
 import {
-  CPGETTERS,
-  CPSETTERS,
+  COMPUTED_SETTERS,
   Decorator,
   DecoratorPropertyDescriptor,
   isElementDescriptor,
@@ -184,10 +183,7 @@ function descriptorForField([target, key, desc]: [
     set,
   };
 
-  if (DEBUG) {
-    CPGETTERS.add(get);
-    CPSETTERS.add(set);
-  }
+  COMPUTED_SETTERS.add(set);
 
   metaFor(target).writeDescriptors(key, new TrackedDescriptor(get, set));
 

--- a/packages/@ember/-internals/metal/tests/tracked/set_test.js
+++ b/packages/@ember/-internals/metal/tests/tracked/set_test.js
@@ -32,7 +32,7 @@ moduleFor(
       }
     }
 
-    ['@test set should throw an error when setting on shadowed properties']() {
+    ['@test set should not throw an error when setting on shadowed properties'](assert) {
       class Obj {
         @tracked value = 'emberjs';
 
@@ -43,9 +43,9 @@ moduleFor(
 
       let newObj = new Obj();
 
-      expectAssertion(() => {
-        set(newObj, 'value', 123);
-      }, /Attempted to set `\[object Object\].value` using Ember.set\(\), but the property was a computed or tracked property that was shadowed by another property declaration. This can happen if you defined a tracked or computed property on a parent class, and then redefined it on a subclass/);
+      set(newObj, 'value', 123);
+
+      assert.equal(newObj.value, 123, 'it worked');
     }
   }
 );


### PR DESCRIPTION
Restores the previous behavior that would happen when setting a shadowed
property.

Based on #19231 it appears that our previous fix isn't enough, and the implications
of the change were wider spread than we initially believed. So, this restores the 
previous behavior. The plan is to add a lint rule to prevent unintentional shadowing
from causing issues, e.g. `model: Foo;` should instead be `declare model: Foo;`.