### PR TITLE
Ensure multiple deprecations (warnings, etc) are tracked correctly

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
@@ -718,6 +718,13 @@ moduleFor(
       });
 
       expectDeprecation(() => {
+        // TODO: this must be a bug??
+        expectDeprecation(
+          backtrackingMessageFor('undefined', undefined, {
+            renderTree: ['\\(result of a `<\\(unknown\\).*?>` helper\\)'],
+          })
+        );
+
         this.render('{{hello-world}}');
       }, expectedMessage);
     }

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/partial-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/partial-test.js
@@ -239,7 +239,7 @@ moduleFor(
             names: emberA(['Alex', 'Ben']),
           }
         );
-      }, 'The use of `{{partial}}` is deprecated, please refactor the "outer-partial" partial to a component');
+      }, /The use of `{{partial}}` is deprecated, please refactor the "(inner|outer)-partial" partial to a component/);
 
       this.assertStableRerender();
 
@@ -247,7 +247,7 @@ moduleFor(
 
       expectDeprecation(() => {
         runTask(() => this.context.names.pushObject('Sophie'));
-      }, 'The use of `{{partial}}` is deprecated, please refactor the "outer-partial" partial to a component');
+      }, /The use of `{{partial}}` is deprecated, please refactor the "(inner|outer)-partial" partial to a component/);
 
       this.assertText(
         '0: [outer: Alex] [inner: Alex]1: [outer: Ben] [inner: Ben]2: [outer: Sophie] [inner: Sophie]'
@@ -294,7 +294,7 @@ moduleFor(
         {{/with}}`,
           { age: 0 }
         );
-      }, 'The use of `{{partial}}` is deprecated, please refactor the "person2-partial" partial to a component');
+      }, /The use of `{{partial}}` is deprecated, please refactor the "person(2|3|4)-partial" partial to a component/);
 
       this.assertStableRerender();
 
@@ -332,7 +332,7 @@ moduleFor(
             },
           }
         );
-      }, 'The use of `{{partial}}` is deprecated, please refactor the "odd" partial to a component');
+      }, /The use of `{{partial}}` is deprecated, please refactor the "(odd|even)" partial to a component/);
 
       this.assertStableRerender();
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
@@ -418,6 +418,13 @@ moduleFor(
       });
 
       expectDeprecation(() => {
+        // TODO: this must be a bug??
+        expectDeprecation(
+          backtrackingMessageFor('undefined', undefined, {
+            renderTree: ['\\(result of a `.*` helper\\)'],
+          })
+        );
+
         this.render('{{hello-world this.model}}', { model: {} });
       }, expectedMessage);
     }

--- a/packages/@ember/-internals/glimmer/tests/utils/backtracking-rerender.js
+++ b/packages/@ember/-internals/glimmer/tests/utils/backtracking-rerender.js
@@ -1,6 +1,12 @@
 export function backtrackingMessageFor(key, obj, { renderTree } = {}) {
   // Start off with standard backtracking assertion
-  let regex = [`You attempted to update \`${key}\` on \`${obj}\``];
+  let regex;
+
+  if (obj) {
+    regex = [`You attempted to update \`${key}\` on \`${obj}\``];
+  } else {
+    regex = [`You attempted to update \`${key}\``];
+  }
 
   if (renderTree) {
     // match the renderTree if it was included

--- a/packages/@ember/-internals/metal/tests/accessors/get_test.js
+++ b/packages/@ember/-internals/metal/tests/accessors/get_test.js
@@ -314,6 +314,11 @@ moduleFor(
       let obj = new EmberObject();
 
       expectDeprecation(() => {
+        // TODO: this must be a bug??
+        expectDeprecation(
+          /You attempted to update `undefined`, but it had already been used previously in the same computation/
+        );
+
         track(() => {
           get(obj, 'bar');
         });

--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -1418,7 +1418,7 @@ moduleFor(
           expectDeprecation(() => {
             assert.equal(appController.get('currentPath'), expectedPath);
             assert.equal(appController.get('currentRouteName'), expectedRouteName);
-          }, 'Accessing `currentPath` on `controller:application` is deprecated, use the `currentPath` property on `service:router` instead.');
+          }, /Accessing `(currentPath|currentRouteName)` on `controller:application` is deprecated, use the `(currentPath|currentRouteName)` property on `service:router` instead\./);
         }
 
         transitionAndCheck(null, 'index', 'index');

--- a/packages/internal-test-helpers/lib/ember-dev/method-call-tracker.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/method-call-tracker.ts
@@ -101,6 +101,7 @@ export default class MethodCallTracker {
 
     let actual: Actual | undefined;
     let match: Actual | undefined = undefined;
+    let matched: Set<number> = new Set();
 
     for (o = 0; o < expectedMessages.length; o++) {
       const expectedMessage = expectedMessages[o];
@@ -135,7 +136,8 @@ export default class MethodCallTracker {
 
         if (matchesMessage && matchesOptionList) {
           match = actual;
-          break;
+          matched.add(i);
+          continue;
         }
       }
 
@@ -169,6 +171,12 @@ export default class MethodCallTracker {
           false,
           `Did not receive failing Ember.${methodName} call matching '${expectedMessage}' ${expectedOptionsMessage}, last was failure with '${actual[0]}' ${actualOptionsMessage}`
         );
+      }
+    }
+
+    for (i = 0; i < actuals.length; i++) {
+      if (!matched.has(i) && actuals[i][1] !== true) {
+        assert.ok(false, `Unexpected Ember.${methodName} call: ${actuals[i][0]}`);
       }
     }
   }


### PR DESCRIPTION
This fixes the tracker to fail the tests when multiple deprecations are raised within the callback and not all of them are matched by the given expectations (either by passing a regex that matches all the messages, or by calling `expectDeprecation` multiple times).

This found some possible bugs that were masked by the fact that the current tracker code does not really care about unmatched messages as long as all the expectations matched *something*.

I don't have time to fix the feature, so I just changed the test to allow them, but those are likely bugs that we should fix.