### PR TITLE
Improvements to changelog generation script

### DIFF
--- a/bin/changelog.js
+++ b/bin/changelog.js
@@ -19,23 +19,97 @@ const GitHubApi = require('github');
 const execSync = require('child_process').execSync;
 
 const github = new GitHubApi({ version: '3.0.0' });
+if (process.env.GITHUB_TOKEN) {
+  github.authenticate({
+    type: 'token',
+    token: process.env.GITHUB_TOKEN,
+  });
+}
 const compareCommits = RSVP.denodeify(github.repos.compareCommits);
+const getPullRequest = RSVP.denodeify(github.pullRequests.get);
 
 const currentVersion = process.env.PRIOR_VERSION;
 const head = process.env.HEAD || execSync('git rev-parse HEAD', { encoding: 'UTF-8' });
 
-compareCommits({
-  user: 'emberjs',
-  repo: 'ember.js',
-  base: currentVersion,
-  head: head,
-})
-  .then(processPages)
+generateChangelog()
   .then(console.log)
   .catch((err) => console.error(err));
 
-function getCommitMessage(commitInfo) {
+async function fetchAllChanges() {
+  let result = await compareCommits({
+    user: 'emberjs',
+    repo: 'ember.js',
+    base: currentVersion,
+    head,
+  });
+  let data = result.commits;
+  while (github.hasNextPage(result)) {
+    result = await github.getNextPage(result);
+    data.concat(result.commits);
+  }
+
+  return data;
+}
+
+async function generateChangelog() {
+  let commits = await fetchAllChanges();
+
+  let contributions = commits.filter(excludeDependabot).filter(isMergeOrCherryPick);
+
+  let changes = await Promise.all(
+    contributions.map(async function (commitInfo) {
+      let message = await getCommitMessage(commitInfo);
+
+      let mergeFromBranchRegex = /#(\d+) from (.+)\//;
+      let mergePullRequestRegex = /Merge pull request #(\d+)/;
+      let mergeWithPrReferenceRegex = /\(#(\d+)\)$/m;
+      let result = {
+        sha: commitInfo.sha,
+      };
+
+      if (mergeFromBranchRegex.test(message)) {
+        let match = message.match(mergeFromBranchRegex);
+        result.number = match[1];
+        result.title = message.split('\n\n')[1];
+      } else if (mergePullRequestRegex.test(message)) {
+        let match = message.match(mergePullRequestRegex);
+        result.number = match[1];
+        result.title = message.split('\n\n')[1];
+      } else if (mergeWithPrReferenceRegex.test(message)) {
+        let match = message.match(mergeWithPrReferenceRegex);
+        result.number = match[1];
+        result.title = message.split('\n')[0];
+      } else {
+        result.title = message.split('\n\n')[0];
+      }
+
+      return result;
+    })
+  );
+
+  return changes
+    .sort(comparePrNumber)
+    .filter(uniqueByPrNumber)
+    .map((pr) => {
+      let title = pr.title;
+      let link;
+      if (pr.number) {
+        link =
+          '[#' + pr.number + ']' + '(https://github.com/emberjs/ember.js/pull/' + pr.number + ')';
+      } else {
+        link =
+          '[' + pr.sha.slice(0, 8) + '](https://github.com/emberjs/ember.js/commit/' + pr.sha + ')';
+      }
+
+      return '- ' + link + ' ' + title;
+    })
+    .join('\n');
+}
+
+async function getCommitMessage(commitInfo) {
   let message = commitInfo.commit.message;
+
+  let matches;
 
   if (message.indexOf('cherry picked from commit') > -1) {
     let cherryPickRegex = /cherry picked from commit ([a-z0-9]+)/;
@@ -56,6 +130,24 @@ function getCommitMessage(commitInfo) {
     }
   }
 
+  if ((matches = message.match(/^Merge pull request #(\d+)/))) {
+    // if the commit was a merge from a PR and there's no additional content in
+    // the commit message (which is normally the title of the merged PR) then
+    // hit the Github API for the PR to get the title.
+    let prNumber = matches[1];
+
+    let lines = message.split(/\n\n/);
+
+    if (lines[1] === '') {
+      let pullRequest = await getPullRequest({
+        user: 'emberjs',
+        repo: 'ember.js',
+        number: prNumber,
+      });
+      return `Merge pull request #${prNumber}\n\n${pullRequest.title}`;
+    }
+  }
+
   return message;
 }
 
@@ -72,61 +164,21 @@ function isMergeOrCherryPick(commitInfo) {
 }
 
 function comparePrNumber(a, b) {
+  if (a.number && !b.number) return -1;
+  if (!a.number && b.number) return 1;
+  if (!a.number && !b.number) {
+    if (a.sha < b.sha) return -1;
+    if (a.sha > b.sha) return 1;
+    return 0;
+  }
+
   if (a.number < b.number) return -1;
   if (a.number > b.number) return 1;
   return 0;
 }
 
-function processPages(res) {
-  let contributions = res.commits
-    .filter(excludeDependabot)
-    .filter(isMergeOrCherryPick)
-    .map((commitInfo) => {
-      let message = getCommitMessage(commitInfo);
-
-      let mergeFromBranchRegex = /#(\d+) from (.*)\//;
-      let mergeWithPrReferenceRegex = /\(#(\d+)\)$/m;
-      let result = {
-        sha: commitInfo.sha,
-      };
-
-      if (mergeFromBranchRegex.test(message)) {
-        let match = message.match(mergeFromBranchRegex);
-        let numAndAuthor = match.slice(1, 3);
-
-        result.number = numAndAuthor[0];
-        result.title = message.split('\n\n')[1];
-      } else if (mergeWithPrReferenceRegex.test(message)) {
-        let match = message.match(mergeWithPrReferenceRegex);
-        result.number = match[1];
-        result.title = message.split('\n')[0];
-      } else {
-        result.title = message.split('\n\n')[0];
-      }
-
-      return result;
-    })
-    .sort(comparePrNumber)
-    .map((pr) => {
-      let title = pr.title;
-      let link;
-      if (pr.number) {
-        link =
-          '[#' + pr.number + ']' + '(https://github.com/emberjs/ember.js/pull/' + pr.number + ')';
-      } else {
-        link =
-          '[' + pr.sha.slice(0, 8) + '](https://github.com/emberjs/ember.js/commit/' + pr.sha + ')';
-      }
-
-      return '- ' + link + ' ' + title;
-    })
-    .join('\n');
-
-  if (github.hasNextPage(res)) {
-    return github.getNextPage(res).then((nextPage) => {
-      contributions += processPages(nextPage);
-    });
-  } else {
-    return RSVP.resolve(contributions);
-  }
+function uniqueByPrNumber(commitInfo, index, commits) {
+  const foundIndex = commits.findIndex(({ number }) => number === commitInfo.number);
+  // keep this item if it has a `number` that isn't elsewhere in the array, or doesn't have `number`
+  return foundIndex === index || foundIndex === -1;
 }


### PR DESCRIPTION
This PR refactors & improves the changelog generation script, hitting the Github API to grab a PR's title when it's referenced in a merge commit but the PR title isn't part of the commit message (as is happening sometimes, causing `undefined` to be output instead of a useful message).

Since this script now hits the Github API more, I added a facility for specifying an API access token via the `GITHUB_TOKEN` environment variable. This can be useful when the number of requests exceeds the amount allowed for anonymous API access.