### PR TITLE
[DOC] add metadata property for RouteInfo

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/route-info.ts
+++ b/packages/@ember/-internals/routing/lib/system/route-info.ts
@@ -167,6 +167,13 @@
 */
 
 /**
+  Will contain the result `Route#buildRouteInfoMetadata`
+  for the corresponding Route.
+  @property {Any} metadata
+  @public
+*/
+
+/**
   A reference to the parent route's `RouteInfo`.
   This can be used to traverse upward to the topmost
   `RouteInfo`.


### PR DESCRIPTION
The `metadata` property is [present](https://github.com/tildeio/router.js/blob/d885da22340da98dcadb45427766efade54ce832/lib/router/route-info.ts#L53) on `RouteInfo`, not just `RouteInfoWithAttributes`.

Also described in the RFC: https://emberjs.github.io/rfcs/0398-RouteInfo-Metadata.html#routeinfometadata