### PR TITLE
[BUGFIX release] QP's bug for intermediate transitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-node-resolve": "^4.2.4",
     "route-recognizer": "^0.3.4",
-    "router_js": "^7.1.0",
+    "router_js": "^7.1.1",
     "rsvp": "^4.8.5",
     "serve-static": "^1.14.1",
     "simple-dom": "^1.4.0",

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-angle-test.js
@@ -879,5 +879,45 @@ moduleFor(
         this.shouldBeActive(assert, '#foos-link');
       });
     }
+
+    ['@test the <LinkTo /> component with dynamic segment and loading route should preserve query parameters'](
+      assert
+    ) {
+      this.router.map(function () {
+        this.route('foo', { path: ':foo' }, function () {
+          this.route('bar', function () {
+            this.route('baz');
+          });
+        });
+      });
+
+      this.addTemplate('foo.bar', `<LinkTo id='baz-link' @route='foo.bar.baz'>Baz</LinkTo>`);
+
+      this.addTemplate('foo.bar.loading', 'Loading');
+
+      this.add(
+        'controller:foo.bar',
+        Controller.extend({
+          queryParams: ['qux'],
+          qux: null,
+        })
+      );
+
+      this.add(
+        'route:foo.bar.baz',
+        Route.extend({
+          model() {
+            return new RSVP.Promise((resolve) => {
+              setTimeout(resolve, 1);
+            });
+          },
+        })
+      );
+
+      return this.visit('/foo/bar/baz?qux=abc').then(() => {
+        let bazLink = this.$('#baz-link');
+        assert.equal(bazLink.attr('href'), '/foo/bar/baz?qux=abc');
+      });
+    }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-curly-test.js
@@ -839,5 +839,45 @@ moduleFor(
         });
       });
     }
+
+    ['@test the {{link-to}} component with dynamic segment and loading route should preserve query parameters'](
+      assert
+    ) {
+      this.router.map(function () {
+        this.route('foo', { path: ':foo' }, function () {
+          this.route('bar', function () {
+            this.route('baz');
+          });
+        });
+      });
+
+      this.addTemplate('foo.bar', `{{link-to 'Baz' 'foo.bar.baz' id='baz-link'}}`);
+
+      this.addTemplate('foo.bar.loading', 'Loading');
+
+      this.add(
+        'controller:foo.bar',
+        Controller.extend({
+          queryParams: ['qux'],
+          qux: null,
+        })
+      );
+
+      this.add(
+        'route:foo.bar.baz',
+        Route.extend({
+          model() {
+            return new RSVP.Promise((resolve) => {
+              setTimeout(resolve, 1);
+            });
+          },
+        })
+      );
+
+      return this.visit('/foo/bar/baz?qux=abc').then(() => {
+        let bazLink = this.$('#baz-link');
+        assert.equal(bazLink.attr('href'), '/foo/bar/baz?qux=abc');
+      });
+    }
   }
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -8150,10 +8150,10 @@ route-recognizer@^0.3.4:
   resolved "https://registry.yarnpkg.com/route-recognizer/-/route-recognizer-0.3.4.tgz#39ab1ffbce1c59e6d2bdca416f0932611e4f3ca3"
   integrity sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==
 
-router_js@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/router_js/-/router_js-7.1.0.tgz#d2a47d7224a30f3b6416be20c9c80868fc14ff0c"
-  integrity sha512-03n6mJCD6hTX4bUkowS+HcsyI9ghP3AxmtVSRnMmDWzykNlHE/wXy+hbybdHmnOH2sDe97L/4V7q6MfrVQBoIg==
+router_js@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/router_js/-/router_js-7.1.1.tgz#cb7614a96cfb6bc65c066668b2dd32e3ad7ca38d"
+  integrity sha512-kOdKqBj7aj9GusG0umtWgkTtNtDspT9EfJNnJN9B8g0DDNp9CdIwpO+2Qnmf/fNos38Pj9jlfU44l/oycn5goQ==
   dependencies:
     "@glimmer/env" "^0.1.7"
 


### PR DESCRIPTION
### Information
This is to make sure that https://github.com/tildeio/router.js/pull/308 covers bug that resulted in missing query params in certain scenarios. Since there's a bunch of issues related to this bug we should write and combine failing tests together in this PR and land them after https://github.com/tildeio/router.js/pull/308 is released.

### Related issues
- https://github.com/emberjs/ember.js/issues/14438
- https://github.com/emberjs/ember.js/pull/16986
- https://github.com/emberjs/ember.js/issues/12107
- https://github.com/emberjs/ember.js/issues/11857

### TODOs
- [x] Tests for link-to component (rebased #16986)
- [x] Tests for for https://github.com/emberjs/ember.js/issues/14438
- [x] Upgrade router.js