### PR TITLE
[BUGFIX lts] Prevents infinite rerenders when errors occur during render

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/renderer.ts
@@ -3,6 +3,7 @@ import { getOwner, Owner } from '@ember/-internals/owner';
 import { getViewElement, getViewId, OwnedTemplateMeta } from '@ember/-internals/views';
 import { assert } from '@ember/debug';
 import { backburner, getCurrentRunLoop } from '@ember/runloop';
+import { DEBUG } from '@glimmer/env';
 import {
   Bounds,
   Cursor,
@@ -77,6 +78,34 @@ export class DynamicScope implements GlimmerDynamicScope {
   }
 }
 
+// This wrapper logic prevents us from rerendering in case of a hard failure
+// during render. This prevents infinite revalidation type loops from occuring,
+// and ensures that errors are not swallowed by subsequent follow on failures.
+function errorLoopTransaction(fn: () => void) {
+  if (DEBUG) {
+    return () => {
+      let didError = true;
+
+      try {
+        fn();
+        didError = false;
+      } finally {
+        if (didError) {
+          // Noop the function so that we won't keep calling it and causing
+          // infinite looping failures;
+          fn = () => {
+            console.warn(
+              'Attempted to rerender, but the Ember application has had an unrecoverable error occur during render. You should reload the application after fixing the cause of the error.'
+            );
+          };
+        }
+      }
+    };
+  } else {
+    return fn;
+  }
+}
+
 class RootState {
   public id: string;
   public result: RenderResult | undefined;
@@ -102,7 +131,7 @@ class RootState {
     this.result = undefined;
     this.destroyed = false;
 
-    this.render = () => {
+    this.render = errorLoopTransaction(() => {
       let layout = unwrapTemplate(template).asLayout();
       let handle = layout.compile(context);
 
@@ -118,8 +147,8 @@ class RootState {
       let result = (this.result = iterator.sync());
 
       // override .render function after initial render
-      this.render = () => result.rerender({ alwaysRevalidate: false });
-    };
+      this.render = errorLoopTransaction(() => result.rerender({ alwaysRevalidate: false }));
+    });
   }
 
   isFor(possibleRoot: unknown): boolean {

--- a/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
@@ -1662,7 +1662,7 @@ if (ENV._DEBUG_RENDER_TREE) {
           template: 'Hello World',
         });
 
-        await assert.rejectsAssertion(this.visit('/'), /oops!/);
+        await assert.rejects(this.visit('/'), /oops!/);
 
         assert.deepEqual(captureRenderTree(this.owner), [], 'there was no output');
       }

--- a/packages/@ember/-internals/glimmer/tests/integration/components/error-handling-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/error-handling-test.js
@@ -1,3 +1,5 @@
+import { DEBUG } from '@glimmer/env';
+
 import { moduleFor, RenderingTestCase, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/-internals/metal';
@@ -43,7 +45,11 @@ moduleFor(
 
       runTask(() => set(this.context, 'switch', true));
 
-      this.assertText('hello');
+      if (DEBUG) {
+        this.assertText('', 'it does not rerender after error in development');
+      } else {
+        this.assertText('hello', 'it rerenders after error in production');
+      }
     }
 
     ['@skip it can recover resets the transaction when an error is thrown during rerender'](
@@ -91,7 +97,11 @@ moduleFor(
 
       runTask(() => set(this.context, 'switch', true));
 
-      this.assertText('hello');
+      if (DEBUG) {
+        this.assertText('', 'it does not rerender after error in development');
+      } else {
+        this.assertText('hello', 'it does rerender after error in production');
+      }
     }
 
     ['@test it can recover resets the transaction when an error is thrown during didInsertElement'](


### PR DESCRIPTION
This adds a preventative measure against infinite rerenders that happen
due to an unrecoverable error during rendering. This type of error is
really annoying from a DX perspective and can really throw developers
for a loop. The most common cases appear to be caused by the Ember
Inspector, which polls after a render has occured whether on not it was
succesful, and in doing so also dirties state, causing a rerender.

An example of this is seen in this [example reproduction](https://github.com/xg-wang/getter-error)
with the following steps:

1. Load the app
2. Click the To View link to enter the page with the error
3. Open up the Ember Inspector to activate it
4. Reload the page