### PR TITLE
[RFC #481] change return of getComponentTemplate from null to undefined to align with RFC

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/resolver.ts
+++ b/packages/@ember/-internals/glimmer/lib/resolver.ts
@@ -99,7 +99,7 @@ function lookupComponentPair(
   if (component !== null && component.class !== undefined) {
     let layout = getComponentTemplate(component.class);
 
-    if (layout !== null) {
+    if (layout !== undefined) {
       return { component, layout };
     }
   }

--- a/packages/@ember/-internals/glimmer/lib/utils/component-template.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/component-template.ts
@@ -1,6 +1,5 @@
 import { toString } from '@ember/-internals/utils';
 import { assert } from '@ember/debug';
-import { Option } from '@glimmer/interfaces';
 import { Factory as TemplateFactory } from '../template';
 
 const TEMPLATES: WeakMap<object, TemplateFactory> = new WeakMap();
@@ -23,7 +22,7 @@ export function setComponentTemplate(factory: TemplateFactory, obj: object) {
   return obj;
 }
 
-export function getComponentTemplate(obj: object): Option<TemplateFactory> {
+export function getComponentTemplate(obj: object): TemplateFactory | undefined {
   let pointer = obj;
   while (pointer !== undefined && pointer !== null) {
     let template = TEMPLATES.get(pointer);
@@ -35,5 +34,5 @@ export function getComponentTemplate(obj: object): Option<TemplateFactory> {
     pointer = getPrototypeOf(pointer);
   }
 
-  return null;
+  return undefined;
 }


### PR DESCRIPTION
From [RFC #481](https://github.com/emberjs/rfcs/blob/master/text/0481-component-templates-co-location.md#low-level-primitives):

> The `getComponentTemplate` function takes a component class and returns the template associated with the given component class, if any, or one of its superclasses, if any, or **`undefined`** if no template association was found.

/cc @chancancode 