### PR TITLE
[RFC 674] Deprecate transition methods of controller and route

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/application/rendering-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/rendering-test.js
@@ -696,7 +696,9 @@ moduleFor(
         'route:index',
         Route.extend({
           activate() {
-            this.transitionTo('a');
+            expectDeprecation(() => {
+              this.transitionTo('a');
+            }, /Calling transitionTo on a route is deprecated/);
           },
         })
       );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
@@ -1876,7 +1876,7 @@ moduleFor(
     [`@test GJ: <LinkTo /> to a parent root model hook which performs a 'transitionTo' has correct active class #13256`](
       assert
     ) {
-      assert.expect(1);
+      assert.expect(3);
 
       this.router.map(function () {
         this.route('parent', function () {
@@ -1888,7 +1888,9 @@ moduleFor(
         'route:parent',
         Route.extend({
           afterModel() {
-            this.transitionTo('parent.child');
+            expectDeprecation(() => {
+              this.transitionTo('parent.child');
+            }, /Calling transitionTo on a route is deprecated/);
           },
         })
       );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-curly-test.js
@@ -2143,7 +2143,7 @@ moduleFor(
     [`@test GJ: {{link-to}} to a parent root model hook which performs a 'transitionTo' has correct active class #13256`](
       assert
     ) {
-      assert.expect(1);
+      assert.expect(3);
 
       this.router.map(function () {
         this.route('parent', function () {
@@ -2155,7 +2155,9 @@ moduleFor(
         'route:parent',
         Route.extend({
           afterModel() {
-            this.transitionTo('parent.child');
+            expectDeprecation(() => {
+              this.transitionTo('parent.child');
+            }, /Calling transitionTo on a route is deprecated/);
           },
         })
       );

--- a/packages/@ember/-internals/routing/lib/ext/controller.ts
+++ b/packages/@ember/-internals/routing/lib/ext/controller.ts
@@ -1,6 +1,6 @@
 import { get } from '@ember/-internals/metal';
 import ControllerMixin from '@ember/controller/lib/controller_mixin';
-import { prefixRouteNameArg } from '../utils';
+import { deprecateTransitionMethods, prefixRouteNameArg } from '../utils';
 
 /**
 @module ember
@@ -149,9 +149,12 @@ ControllerMixin.reopen({
     @method transitionToRoute
     @return {Transition} the transition object associated with this
       attempted transition
+    @deprecated Use transitionTo from the Router service instead.
     @public
   */
   transitionToRoute(...args: any[]) {
+    deprecateTransitionMethods('controller', 'transitionToRoute');
+
     // target may be either another controller or a router
     let target = get(this, 'target');
     let method = target.transitionToRoute || target.transitionTo;
@@ -218,6 +221,7 @@ ControllerMixin.reopen({
     @public
   */
   replaceRoute(...args: string[]) {
+    deprecateTransitionMethods('controller', 'replaceRoute');
     // target may be either another controller or a router
     let target = get(this, 'target');
     let method = target.replaceRoute || target.replaceWith;

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -38,6 +38,7 @@ import {
 } from 'router_js';
 import {
   calculateCacheKey,
+  deprecateTransitionMethods,
   normalizeControllerQueryParams,
   prefixRouteNameArg,
   stashParamNames,
@@ -805,10 +806,11 @@ class Route extends EmberObject implements IRoute {
     @return {Transition} the transition object associated with this
       attempted transition
     @since 1.0.0
+    @deprecated Use transitionTo from the Router service instead.
     @public
   */
   transitionTo(...args: any[]) {
-    // eslint-disable-line no-unused-vars
+    deprecateTransitionMethods('route', 'transitionTo');
     return this._router.transitionTo(...prefixRouteNameArg(this, args));
   }
 
@@ -903,6 +905,7 @@ class Route extends EmberObject implements IRoute {
     @public
   */
   replaceWith(...args: any[]) {
+    deprecateTransitionMethods('route', 'replaceWith');
     return this._router.replaceWith(...prefixRouteNameArg(this, args));
   }
 

--- a/packages/@ember/-internals/routing/lib/utils.ts
+++ b/packages/@ember/-internals/routing/lib/utils.ts
@@ -1,5 +1,6 @@
 import { get } from '@ember/-internals/metal';
 import { getOwner } from '@ember/-internals/owner';
+import { deprecate } from '@ember/debug';
 import EmberError from '@ember/error';
 import { assign } from '@ember/polyfills';
 import Router, { STATE_SYMBOL } from 'router_js';
@@ -241,4 +242,20 @@ export function shallowEqual(a: {}, b: {}) {
   }
 
   return aCount === bCount;
+}
+
+export function deprecateTransitionMethods(frameworkClass: string, methodName: string) {
+  deprecate(
+    `Calling ${methodName} on a ${frameworkClass} is deprecated. Use the RouterService instead.`,
+    false,
+    {
+      id: 'routing.transition-methods',
+      for: 'ember-source',
+      since: {
+        available: '3.24.0',
+      },
+      until: '4.0.0',
+      url: 'https://deprecations.emberjs.com/v3.x/#toc_routing-transition-methods',
+    }
+  );
 }

--- a/packages/@ember/-internals/routing/lib/utils.ts
+++ b/packages/@ember/-internals/routing/lib/utils.ts
@@ -252,7 +252,7 @@ export function deprecateTransitionMethods(frameworkClass: string, methodName: s
       id: 'routing.transition-methods',
       for: 'ember-source',
       since: {
-        available: '3.24.0',
+        enabled: '3.24.0',
       },
       until: '4.0.0',
       url: 'https://deprecations.emberjs.com/v3.x/#toc_routing-transition-methods',

--- a/packages/@ember/-internals/routing/lib/utils.ts
+++ b/packages/@ember/-internals/routing/lib/utils.ts
@@ -252,7 +252,7 @@ export function deprecateTransitionMethods(frameworkClass: string, methodName: s
       id: 'routing.transition-methods',
       for: 'ember-source',
       since: {
-        enabled: '3.24.0',
+        enabled: '3.25.0',
       },
       until: '4.0.0',
       url: 'https://deprecations.emberjs.com/v3.x/#toc_routing-transition-methods',

--- a/packages/@ember/-internals/routing/lib/utils.ts
+++ b/packages/@ember/-internals/routing/lib/utils.ts
@@ -252,7 +252,7 @@ export function deprecateTransitionMethods(frameworkClass: string, methodName: s
       id: 'routing.transition-methods',
       for: 'ember-source',
       since: {
-        enabled: '3.25.0',
+        enabled: '3.26.0',
       },
       until: '4.0.0',
       url: 'https://deprecations.emberjs.com/v3.x/#toc_routing-transition-methods',

--- a/packages/@ember/-internals/routing/tests/ext/controller_test.js
+++ b/packages/@ember/-internals/routing/tests/ext/controller_test.js
@@ -22,27 +22,35 @@ moduleFor(
       let controller = Controller.create({ target: router });
       setOwner(controller, engineInstance);
 
-      assert.strictEqual(
-        controller.transitionToRoute('application'),
-        'foo.bar.application',
-        'properly prefixes application route'
-      );
-      assert.strictEqual(
-        controller.transitionToRoute('posts'),
-        'foo.bar.posts',
-        'properly prefixes child routes'
-      );
-      assert.throws(
-        () => controller.transitionToRoute('/posts'),
-        'throws when trying to use a url'
-      );
+      expectDeprecation(() => {
+        assert.strictEqual(
+          controller.transitionToRoute('application'),
+          'foo.bar.application',
+          'properly prefixes application route'
+        );
+      }, /Calling transitionToRoute on a controller is deprecated/);
+      expectDeprecation(() => {
+        assert.strictEqual(
+          controller.transitionToRoute('posts'),
+          'foo.bar.posts',
+          'properly prefixes child routes'
+        );
+      }, /Calling transitionToRoute on a controller is deprecated/);
+      expectDeprecation(() => {
+        assert.throws(
+          () => controller.transitionToRoute('/posts'),
+          'throws when trying to use a url'
+        );
+      }, /Calling transitionToRoute on a controller is deprecated/);
 
       let queryParams = {};
-      assert.strictEqual(
-        controller.transitionToRoute(queryParams),
-        queryParams,
-        'passes query param only transitions through'
-      );
+      expectDeprecation(() => {
+        assert.strictEqual(
+          controller.transitionToRoute(queryParams),
+          queryParams,
+          'passes query param only transitions through'
+        );
+      }, /Calling transitionToRoute on a controller is deprecated/);
     }
 
     ["@test replaceRoute considers an engine's mountPoint"](assert) {
@@ -62,24 +70,32 @@ moduleFor(
       let controller = Controller.create({ target: router });
       setOwner(controller, engineInstance);
 
-      assert.strictEqual(
-        controller.replaceRoute('application'),
-        'foo.bar.application',
-        'properly prefixes application route'
-      );
-      assert.strictEqual(
-        controller.replaceRoute('posts'),
-        'foo.bar.posts',
-        'properly prefixes child routes'
-      );
-      assert.throws(() => controller.replaceRoute('/posts'), 'throws when trying to use a url');
+      expectDeprecation(() => {
+        assert.strictEqual(
+          controller.replaceRoute('application'),
+          'foo.bar.application',
+          'properly prefixes application route'
+        );
+      }, /Calling replaceRoute on a controller is deprecated/);
+      expectDeprecation(() => {
+        assert.strictEqual(
+          controller.replaceRoute('posts'),
+          'foo.bar.posts',
+          'properly prefixes child routes'
+        );
+      }, /Calling replaceRoute on a controller is deprecated/);
+      expectDeprecation(() => {
+        assert.throws(() => controller.replaceRoute('/posts'), 'throws when trying to use a url');
+      }, /Calling replaceRoute on a controller is deprecated/);
 
       let queryParams = {};
-      assert.strictEqual(
-        controller.replaceRoute(queryParams),
-        queryParams,
-        'passes query param only transitions through'
-      );
+      expectDeprecation(() => {
+        assert.strictEqual(
+          controller.replaceRoute(queryParams),
+          queryParams,
+          'passes query param only transitions through'
+        );
+      }, /Calling replaceRoute on a controller is deprecated/);
     }
   }
 );

--- a/packages/@ember/-internals/routing/tests/system/route_test.js
+++ b/packages/@ember/-internals/routing/tests/system/route_test.js
@@ -487,24 +487,32 @@ moduleFor(
       let route = EmberRoute.create({ _router: router });
       setOwner(route, engineInstance);
 
-      assert.strictEqual(
-        route.transitionTo('application'),
-        'foo.bar.application',
-        'properly prefixes application route'
-      );
-      assert.strictEqual(
-        route.transitionTo('posts'),
-        'foo.bar.posts',
-        'properly prefixes child routes'
-      );
-      assert.throws(() => route.transitionTo('/posts'), 'throws when trying to use a url');
+      expectDeprecation(() => {
+        assert.strictEqual(
+          route.transitionTo('application'),
+          'foo.bar.application',
+          'properly prefixes application route'
+        );
+      }, /Calling transitionTo on a route is deprecated/);
+      expectDeprecation(() => {
+        assert.strictEqual(
+          route.transitionTo('posts'),
+          'foo.bar.posts',
+          'properly prefixes child routes'
+        );
+      }, /Calling transitionTo on a route is deprecated/);
+      expectDeprecation(() => {
+        assert.throws(() => route.transitionTo('/posts'), 'throws when trying to use a url');
+      }, /Calling transitionTo on a route is deprecated/);
 
       let queryParams = {};
-      assert.strictEqual(
-        route.transitionTo(queryParams),
-        queryParams,
-        'passes query param only transitions through'
-      );
+      expectDeprecation(() => {
+        assert.strictEqual(
+          route.transitionTo(queryParams),
+          queryParams,
+          'passes query param only transitions through'
+        );
+      }, /Calling transitionTo on a route is deprecated/);
     }
 
     ["@test intermediateTransitionTo considers an engine's mountPoint"](assert) {
@@ -558,24 +566,32 @@ moduleFor(
       let route = EmberRoute.create({ _router: router });
       setOwner(route, engineInstance);
 
-      assert.strictEqual(
-        route.replaceWith('application'),
-        'foo.bar.application',
-        'properly prefixes application route'
-      );
-      assert.strictEqual(
-        route.replaceWith('posts'),
-        'foo.bar.posts',
-        'properly prefixes child routes'
-      );
-      assert.throws(() => route.replaceWith('/posts'), 'throws when trying to use a url');
+      expectDeprecation(() => {
+        assert.strictEqual(
+          route.replaceWith('application'),
+          'foo.bar.application',
+          'properly prefixes application route'
+        );
+      }, /Calling replaceWith on a route is deprecated/);
+      expectDeprecation(() => {
+        assert.strictEqual(
+          route.replaceWith('posts'),
+          'foo.bar.posts',
+          'properly prefixes child routes'
+        );
+      }, /Calling replaceWith on a route is deprecated/);
+      expectDeprecation(() => {
+        assert.throws(() => route.replaceWith('/posts'), 'throws when trying to use a url');
+      }, /Calling replaceWith on a route is deprecated/);
 
       let queryParams = {};
-      assert.strictEqual(
-        route.replaceWith(queryParams),
-        queryParams,
-        'passes query param only transitions through'
-      );
+      expectDeprecation(() => {
+        assert.strictEqual(
+          route.replaceWith(queryParams),
+          queryParams,
+          'passes query param only transitions through'
+        );
+      }, /Calling replaceWith on a route is deprecated/);
     }
   }
 );

--- a/packages/@ember/application/tests/visit_test.js
+++ b/packages/@ember/application/tests/visit_test.js
@@ -283,7 +283,9 @@ moduleFor(
         'route:a',
         Route.extend({
           afterModel() {
-            this.replaceWith('b', 'zomg');
+            expectDeprecation(() => {
+              this.replaceWith('b', 'zomg');
+            }, /Calling replaceWith on a route is deprecated/);
           },
         })
       );
@@ -292,7 +294,9 @@ moduleFor(
         'route:b',
         Route.extend({
           afterModel(params) {
-            this.transitionTo('c', params.b);
+            expectDeprecation(() => {
+              this.transitionTo('c', params.b);
+            }, /Calling transitionTo on a route is deprecated/);
           },
         })
       );
@@ -321,7 +325,9 @@ moduleFor(
         'route:a',
         Route.extend({
           afterModel() {
-            this.replaceWith('b', 'zomg');
+            expectDeprecation(() => {
+              this.replaceWith('b', 'zomg');
+            }, /Calling replaceWith on a route is deprecated/);
           },
         })
       );
@@ -330,7 +336,9 @@ moduleFor(
         'route:b',
         Route.extend({
           afterModel(params) {
-            this.transitionTo('c', params.b);
+            expectDeprecation(() => {
+              this.transitionTo('c', params.b);
+            }, /Calling transitionTo on a route is deprecated/);
           },
         })
       );

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -94,7 +94,9 @@ if (!jQueryDisabled) {
             'route:redirect',
             Route.extend({
               beforeModel() {
-                this.transitionTo('comments');
+                expectDeprecation(() => {
+                  this.transitionTo('comments');
+                }, /Calling transitionTo on a route is deprecated/);
               },
             })
           );
@@ -425,7 +427,7 @@ if (!jQueryDisabled) {
       }
 
       [`@test visiting a URL that causes another transition should yield the correct URL`](assert) {
-        assert.expect(1);
+        assert.expect(2);
 
         window.visit('/redirect');
 
@@ -437,7 +439,7 @@ if (!jQueryDisabled) {
       [`@test visiting a URL and then visiting a second URL with a transition should yield the correct URL`](
         assert
       ) {
-        assert.expect(2);
+        assert.expect(3);
 
         window.visit('/posts');
 

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -1199,7 +1199,11 @@ if (!jQueryDisabled) {
             'route:user.profile',
             Route.extend({
               beforeModel() {
-                return resolveLater().then(() => this.transitionTo('user.edit'));
+                return resolveLater().then(() => {
+                  return expectDeprecation(() => {
+                    return this.transitionTo('user.edit');
+                  }, /Calling transitionTo on a route is deprecated/);
+                });
               },
             })
           );
@@ -1229,7 +1233,7 @@ if (!jQueryDisabled) {
       }
 
       [`@test currentRouteName for '/user/profile'`](assert) {
-        assert.expect(4);
+        assert.expect(5);
 
         let {
           application: { testHelpers },

--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -681,7 +681,9 @@ moduleFor(
         Route.extend({
           redirect() {
             if (destination) {
-              this.transitionTo(destination);
+              expectDeprecation(() => {
+                this.transitionTo(destination);
+              }, /Calling transitionTo on a route is deprecated/);
             }
           },
 
@@ -708,7 +710,7 @@ moduleFor(
     }
 
     ['@test Redirecting from the middle of a route aborts the remainder of the routes'](assert) {
-      assert.expect(4);
+      assert.expect(5);
 
       this.router.map(function () {
         this.route('home');
@@ -723,7 +725,9 @@ moduleFor(
         'route:bar',
         Route.extend({
           redirect() {
-            this.transitionTo('home');
+            expectDeprecation(() => {
+              this.transitionTo('home');
+            }, /Calling transitionTo on a route is deprecated/);
           },
           setupController() {
             assert.ok(false, 'Should transition before setupController');
@@ -757,7 +761,7 @@ moduleFor(
     ['@test Redirecting to the current target in the middle of a route does not abort initial routing'](
       assert
     ) {
-      assert.expect(6);
+      assert.expect(7);
 
       this.router.map(function () {
         this.route('home');
@@ -774,9 +778,11 @@ moduleFor(
         'route:bar',
         Route.extend({
           redirect() {
-            return this.transitionTo('bar.baz').then(function () {
-              successCount++;
-            });
+            return expectDeprecation(() => {
+              return this.transitionTo('bar.baz').then(function () {
+                successCount++;
+              });
+            }, /Calling transitionTo on a route is deprecated/);
           },
 
           setupController() {
@@ -810,7 +816,7 @@ moduleFor(
     ['@test Redirecting to the current target with a different context aborts the remainder of the routes'](
       assert
     ) {
-      assert.expect(5);
+      assert.expect(7);
 
       this.router.map(function () {
         this.route('home');
@@ -832,7 +838,9 @@ moduleFor(
             if (count++ > 10) {
               assert.ok(false, 'infinite loop');
             } else {
-              this.transitionTo('bar.baz', model);
+              expectDeprecation(() => {
+                this.transitionTo('bar.baz', model);
+              }, /Calling transitionTo on a route is deprecated/);
             }
           },
         })
@@ -880,7 +888,9 @@ moduleFor(
         Route.extend({
           actions: {
             goToQux() {
-              this.transitionTo('foo.qux');
+              expectDeprecation(() => {
+                this.transitionTo('foo.qux');
+              }, /Calling transitionTo on a route is deprecated/);
             },
           },
         })
@@ -1131,7 +1141,7 @@ moduleFor(
     ['@test Aborting/redirecting the transition in `willTransition` prevents LoadingRoute from being entered'](
       assert
     ) {
-      assert.expect(5);
+      assert.expect(6);
 
       this.router.map(function () {
         this.route('index');
@@ -1149,7 +1159,9 @@ moduleFor(
               assert.ok(true, 'willTransition was called');
               if (redirect) {
                 // router.js won't refire `willTransition` for this redirect
-                this.transitionTo('about');
+                expectDeprecation(() => {
+                  this.transitionTo('about');
+                }, /Calling transitionTo on a route is deprecated/);
               } else {
                 transition.abort();
               }
@@ -1462,7 +1474,9 @@ moduleFor(
         'route:home',
         Route.extend({
           beforeModel() {
-            this.transitionTo('about', null);
+            expectDeprecation(() => {
+              this.transitionTo('about', null);
+            }, /Calling transitionTo on a route is deprecated/);
           },
         })
       );
@@ -1663,7 +1677,7 @@ moduleFor(
     }
 
     async ['@test Errors in transitionTo within redirect hook are logged'](assert) {
-      assert.expect(4);
+      assert.expect(5);
       let actual = [];
 
       this.router.map(function () {
@@ -1675,7 +1689,9 @@ moduleFor(
         'route:yondo',
         Route.extend({
           redirect() {
-            this.transitionTo('stink-bomb', { something: 'goes boom' });
+            expectDeprecation(() => {
+              this.transitionTo('stink-bomb', { something: 'goes boom' });
+            }, /Calling transitionTo on a route is deprecated/);
           },
         })
       );
@@ -1709,7 +1725,9 @@ moduleFor(
         'route:yondo',
         Route.extend({
           redirect() {
-            this.transitionTo('stink-bomb', { something: 'goes boom' });
+            expectDeprecation(() => {
+              this.transitionTo('stink-bomb', { something: 'goes boom' });
+            }, /Calling transitionTo on a route is deprecated/);
           },
         })
       );

--- a/packages/ember/tests/routing/model_loading_test.js
+++ b/packages/ember/tests/routing/model_loading_test.js
@@ -801,7 +801,9 @@ moduleFor(
         Route.extend({
           actions: {
             showPost(context) {
-              this.transitionTo('post', context);
+              expectDeprecation(() => {
+                this.transitionTo('post', context);
+              }, /Calling transitionTo on a route is deprecated/);
             },
           },
         })
@@ -820,7 +822,9 @@ moduleFor(
 
           actions: {
             editPost() {
-              this.transitionTo('post.edit');
+              expectDeprecation(() => {
+                this.transitionTo('post.edit');
+              }, /Calling transitionTo on a route is deprecated/);
             },
           },
         })

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -104,7 +104,7 @@ moduleFor(
     ['@test Calling transitionTo does not lose query params already on the activeTransition'](
       assert
     ) {
-      assert.expect(2);
+      assert.expect(3);
 
       this.router.map(function () {
         this.route('parent', function () {
@@ -117,7 +117,9 @@ moduleFor(
         'route:parent.child',
         Route.extend({
           afterModel() {
-            this.transitionTo('parent.sibling');
+            expectDeprecation(() => {
+              this.transitionTo('parent.sibling');
+            }, /Calling transitionTo on a route is deprecated/);
           },
         })
       );
@@ -140,7 +142,7 @@ moduleFor(
     ['@test Calling transitionTo does not serialize query params already serialized on the activeTransition'](
       assert
     ) {
-      assert.expect(3);
+      assert.expect(4);
 
       this.router.map(function () {
         this.route('parent', function () {
@@ -153,7 +155,9 @@ moduleFor(
         'route:parent.child',
         Route.extend({
           afterModel() {
-            this.transitionTo('parent.sibling');
+            expectDeprecation(() => {
+              this.transitionTo('parent.sibling');
+            }, /Calling transitionTo on a route is deprecated/);
           },
         })
       );
@@ -230,7 +234,7 @@ moduleFor(
       await this.setAndFlush(controller, 'foo', 'WOO');
       this.assertCurrentPath('/?other_foo=WOO', "QP updated correctly without 'as'");
 
-      this.transitionTo('/?other_foo=NAW');
+      await this.transitionTo('/?other_foo=NAW');
       assert.equal(controller.get('foo'), 'NAW', 'QP managed correctly on URL transition');
 
       await this.setAndFlush(controller, 'bar', 'NERK');
@@ -1135,6 +1139,7 @@ moduleFor(
 
       await this.visitAndAssert('/');
       await this.transitionTo({ queryParams: { foo: 'borf' } });
+
       this.assertCurrentPath('/?foo=borf', 'shorthand supported');
 
       await this.transitionTo({ queryParams: { 'index:foo': 'blaf' } });
@@ -1271,8 +1276,10 @@ moduleFor(
       await this.visitAndAssert('/');
       await this.transitionTo({ queryParams: { foo: [2, 3] } });
       this.assertCurrentPath('/?foo=%5B2%2C3%5D', 'shorthand supported');
+
       await this.transitionTo({ queryParams: { 'index:foo': [4, 5] } });
       this.assertCurrentPath('/?foo=%5B4%2C5%5D', 'longform supported');
+
       await this.transitionTo({ queryParams: { foo: [] } });
       this.assertCurrentPath('/?foo=%5B%5D', 'longform supported');
     }
@@ -1396,7 +1403,7 @@ moduleFor(
       );
 
       return this.visit('/').then(() => {
-        this.transitionTo('other');
+        return this.transitionTo('other');
       });
     }
 
@@ -1740,7 +1747,7 @@ moduleFor(
     async [`@test Updating single query parameter doesn't affect other query parameters. Issue #14438`](
       assert
     ) {
-      assert.expect(5);
+      assert.expect(6);
 
       this.router.map(function () {
         this.route('grandparent', { path: 'grandparent/:foo' }, function () {
@@ -1756,7 +1763,9 @@ moduleFor(
         'route:index',
         Route.extend({
           redirect() {
-            this.transitionTo('grandparent.parent.child', 1);
+            expectDeprecation(() => {
+              this.transitionTo('grandparent.parent.child', 1);
+            }, /Calling transitionTo on a route is deprecated/);
           },
         })
       );

--- a/packages/ember/tests/routing/router_service_test/events_test.js
+++ b/packages/ember/tests/routing/router_service_test/events_test.js
@@ -126,7 +126,7 @@ moduleFor(
     }
 
     '@test redirection with `transitionTo`'(assert) {
-      assert.expect(8);
+      assert.expect(11);
       let toChild = false;
       let toSister = false;
 
@@ -134,7 +134,9 @@ moduleFor(
         `route:parent`,
         Route.extend({
           model() {
-            this.transitionTo('parent.child');
+            expectDeprecation(() => {
+              this.transitionTo('parent.child');
+            }, /Calling transitionTo on a route is deprecated/);
           },
         })
       );
@@ -143,7 +145,9 @@ moduleFor(
         `route:parent.child`,
         Route.extend({
           model() {
-            this.transitionTo('parent.sister');
+            expectDeprecation(() => {
+              this.transitionTo('parent.sister');
+            }, /Calling transitionTo on a route is deprecated/);
           },
         })
       );
@@ -182,7 +186,7 @@ moduleFor(
     }
 
     '@test redirection with `replaceWith`'(assert) {
-      assert.expect(8);
+      assert.expect(11);
       let toChild = false;
       let toSister = false;
 
@@ -190,7 +194,9 @@ moduleFor(
         `route:parent`,
         Route.extend({
           model() {
-            this.replaceWith('parent.child');
+            expectDeprecation(() => {
+              this.replaceWith('parent.child');
+            }, /Calling replaceWith on a route is deprecated/);
           },
         })
       );
@@ -199,7 +205,9 @@ moduleFor(
         `route:parent.child`,
         Route.extend({
           model() {
-            this.replaceWith('parent.sister');
+            expectDeprecation(() => {
+              this.replaceWith('parent.sister');
+            }, /Calling replaceWith on a route is deprecated/);
           },
         })
       );
@@ -238,7 +246,7 @@ moduleFor(
     }
 
     '@test nested redirection with `transitionTo`'(assert) {
-      assert.expect(11);
+      assert.expect(12);
       let toChild = false;
       let toSister = false;
 
@@ -246,7 +254,9 @@ moduleFor(
         `route:parent.child`,
         Route.extend({
           model() {
-            this.transitionTo('parent.sister');
+            expectDeprecation(() => {
+              this.transitionTo('parent.sister');
+            }, /Calling transitionTo on a route is deprecated/);
           },
         })
       );
@@ -295,7 +305,7 @@ moduleFor(
     }
 
     '@test nested redirection with `replaceWith`'(assert) {
-      assert.expect(11);
+      assert.expect(12);
       let toChild = false;
       let toSister = false;
 
@@ -303,7 +313,9 @@ moduleFor(
         `route:parent.child`,
         Route.extend({
           model() {
-            this.replaceWith('parent.sister');
+            expectDeprecation(() => {
+              this.replaceWith('parent.sister');
+            }, /Calling replaceWith on a route is deprecated/);
           },
         })
       );
@@ -467,7 +479,7 @@ moduleFor(
     }
 
     '@test query param redirects with `transitionTo`'(assert) {
-      assert.expect(6);
+      assert.expect(7);
       let toSister = false;
 
       this.add(
@@ -475,7 +487,9 @@ moduleFor(
         Route.extend({
           model() {
             toSister = true;
-            this.transitionTo('/sister?a=a');
+            expectDeprecation(() => {
+              this.transitionTo('/sister?a=a');
+            }, /Calling transitionTo on a route is deprecated/);
           },
         })
       );
@@ -508,7 +522,7 @@ moduleFor(
       return this.visit('/child');
     }
     '@test query param redirects with `replaceWith`'(assert) {
-      assert.expect(6);
+      assert.expect(7);
       let toSister = false;
 
       this.add(
@@ -516,7 +530,9 @@ moduleFor(
         Route.extend({
           model() {
             toSister = true;
-            this.replaceWith('/sister?a=a');
+            expectDeprecation(() => {
+              this.replaceWith('/sister?a=a');
+            }, /Calling replaceWith on a route is deprecated/);
           },
         })
       );

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -754,7 +754,9 @@ moduleFor(
             error(err) {
               step(assert, 2, 'MomSallyRoute#actions.error');
               handledError = err;
-              this.transitionTo('mom.this-route-throws');
+              expectDeprecation(() => {
+                this.transitionTo('mom.this-route-throws');
+              }, /Calling transitionTo on a route is deprecated/);
 
               return false;
             },
@@ -829,7 +831,9 @@ moduleFor(
             error(err) {
               step(assert, 2, 'MomSallyRoute#actions.error');
               handledError = err;
-              this.transitionTo('mom.this-route-throws');
+              expectDeprecation(() => {
+                this.transitionTo('mom.this-route-throws');
+              }, /Calling transitionTo on a route is deprecated/);
 
               return false;
             },
@@ -1080,7 +1084,9 @@ moduleFor(
         'route:grandma',
         Route.extend({
           beforeModel: function () {
-            this.transitionTo('memere', 1);
+            expectDeprecation(() => {
+              this.transitionTo('memere', 1);
+            }, /Calling transitionTo on a route is deprecated/);
           },
         })
       );

--- a/packages/ember/tests/routing/template_rendering_test.js
+++ b/packages/ember/tests/routing/template_rendering_test.js
@@ -537,7 +537,9 @@ moduleFor(
         'route:application',
         Route.extend({
           afterModel() {
-            this.transitionTo('posts');
+            expectDeprecation(() => {
+              this.transitionTo('posts');
+            }, /Calling transitionTo on a route is deprecated/);
           },
         })
       );


### PR DESCRIPTION
Implements [RFC #674 "Deprecate transition methods of controller and route"](https://emberjs.github.io/rfcs/0674-deprecate-transition-methods-of-controller-and-route.html).
Deprecation guide [online](https://deprecations.emberjs.com/v3.x/#toc_routing-transition-methods).

I kept the original behavior in the tests and wrapped them in `expectDeprecation` because I'm assuming there might be timing differences and whatnot, the purpose of the test is to exercise the specific API? Please let me know if I should adjust something.