### PR TITLE
Improve internal router type

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/engines.ts
+++ b/packages/@ember/-internals/routing/lib/system/engines.ts
@@ -7,5 +7,5 @@ export interface EngineInfo {
 
 export interface EngineRouteInfo extends EngineInfo {
   localFullName: string;
-  serializeMethod?: any;
+  serializeMethod?: (model: {}, params: string[]) => { [key: string]: unknown | undefined };
 }

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -47,7 +47,10 @@ import EmberRouter, { QueryParam } from './router';
 
 export const ROUTE_CONNECTIONS = new WeakMap();
 
-export function defaultSerialize(model: {}, params: string[]) {
+export function defaultSerialize(
+  model: {},
+  params: string[]
+): { [key: string]: unknown } | undefined {
   if (params.length < 1 || !model) {
     return;
   }
@@ -67,7 +70,7 @@ export function defaultSerialize(model: {}, params: string[]) {
   return object;
 }
 
-export function hasDefaultSerialize(route: Route) {
+export function hasDefaultSerialize(route: Route): boolean {
   return route.serialize === defaultSerialize;
 }
 


### PR DESCRIPTION
Fixing few ts warnings
- `serialize` signature is based on actual [router.js type](https://github.com/tildeio/router.js/pull/316) and https://github.com/emberjs/rfcs/pull/120
- `overrideNameAssertion` and `path` appear to be mis-duplicated from `RouteOptions`