### PR TITLE
[DOC] Update array.filterBy example to include all properties

### DIFF
--- a/packages/@ember/-internals/runtime/lib/mixins/array.js
+++ b/packages/@ember/-internals/runtime/lib/mixins/array.js
@@ -972,8 +972,8 @@ const ArrayMixin = Mixin.create(Enumerable, {
     ```javascript
     let things = Ember.A([{ food: 'apple', isFruit: true }, { food: 'beans', isFruit: false }]);
 
-    things.filterBy('food', 'beans'); // [{ food: 'beans' }]
-    things.filterBy('isFruit'); // [{ food: 'apple' }]
+    things.filterBy('food', 'beans'); // [{ food: 'beans', isFruit: false }]
+    things.filterBy('isFruit'); // [{ food: 'apple', isFruit: true }]
     ```
 
     @method filterBy


### PR DESCRIPTION
The API Docs for `EmberArray.filterBy` mistakenly implies other properties are stripped off the returned objects. The other methods don't imply this (like `findBy` which shows in the example that the full object is returned). The docs could be confusing if a dev takes this example at face value.