### PR TITLE
[INTERNAL] Introduce `InternalModifier`

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/internal.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/internal.ts
@@ -23,8 +23,8 @@ export default class InternalComponent {
 
   constructor(
     protected owner: Owner,
-    public args: Record<string, Reference | undefined>,
-    public caller: unknown
+    protected readonly args: Record<string, Reference | undefined>,
+    protected readonly caller: unknown
   ) {
     setOwner(this, owner);
   }

--- a/packages/@ember/-internals/glimmer/lib/modifiers/internal.ts
+++ b/packages/@ember/-internals/glimmer/lib/modifiers/internal.ts
@@ -1,0 +1,107 @@
+import { Owner, setOwner } from '@ember/-internals/owner';
+import { guidFor } from '@ember/-internals/utils';
+import { assert } from '@ember/debug';
+import {
+  CapturedArguments,
+  Destroyable,
+  InternalModifierManager as ModifierManager,
+  VMArguments,
+} from '@glimmer/interfaces';
+import { valueForRef } from '@glimmer/reference';
+import { registerDestructor, setModifierManager } from '@glimmer/runtime';
+import { SimpleElement } from '@simple-dom/interface';
+
+export default class InternalModifier {
+  // Factory interface
+  static create(): never {
+    throw assert('Use constructor instead of create');
+  }
+
+  static get class(): typeof InternalModifier {
+    return this;
+  }
+
+  static get fullName(): string {
+    return this.name;
+  }
+
+  static get normalizedName(): string {
+    return this.name;
+  }
+
+  constructor(
+    protected owner: Owner,
+    protected readonly element: Element,
+    protected readonly args: CapturedArguments
+  ) {
+    setOwner(this, owner);
+  }
+
+  install(): void {}
+
+  remove(): void {}
+
+  protected positional(index: number): unknown {
+    let ref = this.args.positional[index];
+    return ref ? valueForRef(ref) : undefined;
+  }
+
+  protected named(key: string): unknown {
+    let ref = this.args.named[key];
+    return ref ? valueForRef(ref) : undefined;
+  }
+
+  toString(): string {
+    return `<${this.constructor.toString()}:${guidFor(this)}>`;
+  }
+}
+
+class InternalModifierState implements Destroyable {
+  constructor(readonly name: string, readonly instance: InternalModifier) {}
+}
+
+class InternalModifierManager
+  implements ModifierManager<InternalModifierState, typeof InternalModifier> {
+  constructor(private readonly owner: Owner) {}
+
+  create(
+    element: SimpleElement,
+    factory: typeof InternalModifier,
+    args: VMArguments
+  ): InternalModifierState {
+    assert('element must be an HTMLElement', element instanceof HTMLElement);
+
+    let instance = new factory(this.owner, element, args.capture());
+
+    registerDestructor(instance, (modifier) => modifier.remove());
+
+    return new InternalModifierState(
+      factory.name,
+      new factory(this.owner, element, args.capture())
+    );
+  }
+
+  // not needed for now, but feel free to implement this
+  getTag(): null {
+    return null;
+  }
+
+  getDebugName({ name }: InternalModifierState): string {
+    return name;
+  }
+
+  install({ instance }: InternalModifierState): void {
+    return instance.install();
+  }
+
+  // not needed for now, but feel free to implement this
+  update(): void {
+    assert('update should never be called on an internal modifier');
+  }
+
+  getDestroyable({ instance }: InternalModifierState): Destroyable {
+    return instance;
+  }
+}
+
+setModifierManager((owner: Owner) => new InternalModifierManager(owner), InternalModifier);


### PR DESCRIPTION
This commit introduces an `InternalModifier` API. Basically like the `InternalComponent` API introduced a while back but for modifiers.

It will probably makes sense to port things like `{{on}}` to use this eventually, but right now it's unused and untested.

I originally wrote the code to address https://github.com/emberjs/ember.js/pull/19218#discussion_r520138592. However, it occurred to me that in order to use an internal modifier we currently would have to register it with some kind of global name that would leak into the same global namespace that users can invoke.

It's not a nonstarter – we have done things like that before. However, soon we will be able to take advantage of [RFC #432](https://github.com/emberjs/rfcs/blob/73685c28378118bebb5e359b80e00b839a99f622/text/0432-contextual-helpers.md) and avoid the issue. Given the expected timeline of the work, I decided to punt on that for the time being so the code remain unused for now.