### PR TITLE
Implement in-app transitions for native anchor elements so that LinkTo isn't needed

### DIFF
--- a/packages/@ember/-internals/views/lib/system/event_dispatcher.js
+++ b/packages/@ember/-internals/views/lib/system/event_dispatcher.js
@@ -382,6 +382,26 @@ export default EmberObject.extend({
               if (actionHandler(target, event) === false) {
                 break;
               }
+            } else if (event.type === 'click' && target.tagName.toLowerCase() === 'a') {
+              let isSameOrigin = window.location.origin === target.origin;
+
+              if (isSameOrigin) {
+                // in-app-transition
+                let owner = getOwner(this);
+                let router = owner.lookup('service:router');
+                let destination = target.pathname + (target.search || '') + target.hash;
+
+                // It's possible the href is
+                // - mis-typed
+                // - belongs to an ember-engine
+                // - belongs to a separate app on the same domain
+                if (router.recognize(destination)) {
+                  event.preventDefault();
+                  event.stopPropagation();
+
+                  router.transitionTo(destination);
+                }
+              }
             }
 
             target = target.parentNode;


### PR DESCRIPTION
Adds support for using solely `<a>` tags for in-app navigation.

Ref: https://github.com/emberjs/rfcs/pull/391

Tested using: https://github.com/NullVoxPopuli/ember-tutorial-link-component/pull/1