### PR TITLE
[BUGFIX beta] Negative indices in `positional` args proxy

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/utils/args-proxy.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/args-proxy.ts
@@ -101,7 +101,7 @@ if (HAS_NATIVE_PROXY) {
 
         const parsed = convertToInt(prop);
 
-        if (parsed !== null && parsed < positional.length) {
+        if (parsed !== null && parsed >= 0 && parsed < positional.length) {
           return valueForRef(positional[parsed]);
         }
 


### PR DESCRIPTION
In `ember-link` I had [code that potentially accessed a negative index](https://github.com/buschtoens/ember-link/pull/475) on a `positional` args proxy, which used to return `undefined`. Starting with the `3.23.0` beta, this throws an error.

This is because only the upper bound is checked.