### PR TITLE
Make changelog script fetch PR title Github on undefined/null as well as empty string

### DIFF
--- a/bin/changelog.js
+++ b/bin/changelog.js
@@ -138,7 +138,7 @@ async function getCommitMessage(commitInfo) {
 
     let lines = message.split(/\n\n/);
 
-    if (lines[1] === '') {
+    if (!lines[1]) {
       let pullRequest = await getPullRequest({
         user: 'emberjs',
         repo: 'ember.js',


### PR DESCRIPTION
Fix on top of #19247 - expands the condition where a PR title is fetched from Github to handle the case where the `lines` array doesn't have a second element (as well as the existing condition where the array has a second element and it's the empty string). This should really put a stop to the `undefined` entries being output.