### PR TITLE
[Bug]: route serialize does not extract param off proxy

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -18,7 +18,7 @@ import {
   Object as EmberObject,
   typeOf,
 } from '@ember/-internals/runtime';
-import { lookupDescriptor } from '@ember/-internals/utils';
+import { isProxy, lookupDescriptor } from '@ember/-internals/utils';
 import Controller from '@ember/controller';
 import { assert, deprecate, info, isTesting } from '@ember/debug';
 import { ROUTER_EVENTS } from '@ember/deprecated-features';
@@ -63,6 +63,8 @@ export function defaultSerialize(
       object[name] = get(model, name);
     } else if (/_id$/.test(name)) {
       object[name] = get(model, 'id');
+    } else if (isProxy(model)) {
+      object[name] = get(model, name);
     }
   } else {
     object = getProperties(model, params);

--- a/packages/@ember/-internals/routing/tests/system/route_test.js
+++ b/packages/@ember/-internals/routing/tests/system/route_test.js
@@ -4,6 +4,7 @@ import Service, { inject as injectService } from '@ember/service';
 import { Object as EmberObject } from '@ember/-internals/runtime';
 import EmberRoute from '../../lib/system/route';
 import { defineProperty } from '../../../metal';
+import ObjectProxy from '@ember/-internals/runtime/lib/system/object_proxy';
 
 let route, routeOne, routeTwo, lookupHash;
 
@@ -278,6 +279,12 @@ moduleFor(
       let model = { post_id: 3 };
 
       assert.deepEqual(route.serialize(model, ['post_id']), { post_id: 3 }, 'serialized correctly');
+    }
+
+    ['@test returns model.id if model is a Proxy'](assert) {
+      let model = ObjectProxy.create({ content: { id: 3 } });
+
+      assert.deepEqual(route.serialize(model, ['id']), { id: 3 }, 'serialized Proxy correctly');
     }
 
     ['@test returns undefined if model is not set'](assert) {


### PR DESCRIPTION
close https://github.com/emberjs/data/issues/7380

`name in model` does not work with our content in a Proxy.

This does not work where `tag` is a ED relationship on `@model`.

```
<LinkTo @route="tag" @model={{@model.tag}}>{{@model.tag.title}}</LinkTo>
```

```
Uncaught Error: Assertion Failed: You attempted to generate a link for the "tag" route, but did not pass the models required for generating its dynamic segments. You must provide param `id` to `generate`.
```