### PR TITLE
Demonstrate using `{{on}}` with `<Input ... />`.

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/input.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/input.ts
@@ -60,12 +60,14 @@ import InternalComponent from './internal';
   Starting with Ember Octane, we recommend using the {{on}} modifier to call actions 
   on specific events, such as the input event.
 
+  ```
   <label for="input-name">Name:</label>
   <Input
     @id="input-name"
     @value={{this.name}}
     {{on "input" this.validateName}}
   />
+  ```
 
   The event name (e.g. "focusout", "input", "keydown") always follows the casing 
   that the HTML standard uses.

--- a/packages/@ember/-internals/glimmer/lib/components/input.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/input.ts
@@ -57,7 +57,7 @@ import InternalComponent from './internal';
   <Input @value={{this.searchWord}} @enter={{this.query}} />
   ```
 
-  Starting with Ember Octane, we recommend using the {{on}} modifier to call actions 
+  Starting with Ember Octane, we recommend using the {{on}} modifier to call actions
   on specific events, such as the input event.
 
   ```
@@ -69,7 +69,7 @@ import InternalComponent from './internal';
   />
   ```
 
-  The event name (e.g. "focusout", "input", "keydown") always follows the casing 
+  The event name (e.g. "focusout", "input", "keydown") always follows the casing
   that the HTML standard uses.
 
   ### `<input>` HTML Attributes to Avoid

--- a/packages/@ember/-internals/glimmer/lib/components/input.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/input.ts
@@ -67,7 +67,8 @@ import InternalComponent from './internal';
     {{on "input" this.validateName}}
   />
 
-  The event name (e.g. "focusout", "input", "keydown") always follows the casing that the HTML standard uses.
+  The event name (e.g. "focusout", "input", "keydown") always follows the casing 
+  that the HTML standard uses.
 
   ### `<input>` HTML Attributes to Avoid
 

--- a/packages/@ember/-internals/glimmer/lib/components/input.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/input.ts
@@ -69,7 +69,7 @@ import InternalComponent from './internal';
   />
   ```
 
-  The event name (e.g. "focusout", "input", "keydown") always follows the casing
+  The event name (e.g. `focusout`, `input`, `keydown`) always follows the casing
   that the HTML standard uses.
 
   ### `<input>` HTML Attributes to Avoid

--- a/packages/@ember/-internals/glimmer/lib/components/input.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/input.ts
@@ -57,6 +57,18 @@ import InternalComponent from './internal';
   <Input @value={{this.searchWord}} @enter={{this.query}} />
   ```
 
+  Starting with Ember Octane, we recommend using the {{on}} modifier to call actions 
+  on specific events, such as the input event.
+
+  <label for="input-name">Name:</label>
+  <Input
+    @id="input-name"
+    @value={{this.name}}
+    {{on "input" this.validateName}}
+  />
+
+  The event name (e.g. "focusout", "input", "keydown") always follows the casing that the HTML standard uses.
+
   ### `<input>` HTML Attributes to Avoid
 
   In most cases, if you want to pass an attribute to the underlying HTML `<input>` element, you

--- a/packages/@ember/-internals/glimmer/lib/components/input.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/input.ts
@@ -60,7 +60,7 @@ import InternalComponent from './internal';
   Starting with Ember Octane, we recommend using the {{on}} modifier to call actions
   on specific events, such as the input event.
 
-  ```
+  ```handlebars
   <label for="input-name">Name:</label>
   <Input
     @id="input-name"

--- a/packages/@ember/-internals/glimmer/lib/components/input.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/input.ts
@@ -57,7 +57,7 @@ import InternalComponent from './internal';
   <Input @value={{this.searchWord}} @enter={{this.query}} />
   ```
 
-  Starting with Ember Octane, we recommend using the {{on}} modifier to call actions
+  Starting with Ember Octane, we recommend using the `{{on}}` modifier to call actions
   on specific events, such as the input event.
 
   ```handlebars


### PR DESCRIPTION
Fixes issue [#19201](https://github.com/emberjs/ember.js/issues/19201) <== [Documentation] Show using `{{on}}` for input components