### PR TITLE
Enable currently available deprecations

### DIFF
--- a/packages/@ember/-internals/utils/lib/invoke.ts
+++ b/packages/@ember/-internals/utils/lib/invoke.ts
@@ -63,7 +63,7 @@ export function tryInvoke(
       until: '4.0.0',
       for: 'ember-source',
       since: {
-        available: '3.24.0',
+        enabled: '3.24.0',
       },
       url: 'https://deprecations.emberjs.com/v3.x#toc_ember-utils-try-invoke',
     }

--- a/packages/@ember/debug/lib/deprecate.ts
+++ b/packages/@ember/debug/lib/deprecate.ts
@@ -213,7 +213,7 @@ if (DEBUG) {
         until: '4.0.0',
         for: 'ember-source',
         since: {
-          available: '3.24.0',
+          enabled: '3.24.0',
         },
       });
     }
@@ -226,7 +226,7 @@ if (DEBUG) {
         until: '4.0.0',
         for: 'ember-source',
         since: {
-          available: '3.24.0',
+          enabled: '3.24.0',
         },
       });
     }

--- a/packages/@ember/debug/tests/main_test.js
+++ b/packages/@ember/debug/tests/main_test.js
@@ -65,7 +65,7 @@ moduleFor(
           id: 'test',
           until: 'forever',
           for: 'me',
-          since: { available: '1.0.0' },
+          since: { enabled: '1.0.0' },
         });
         assert.ok(true, 'deprecate did not throw');
       } catch (e) {
@@ -86,7 +86,7 @@ moduleFor(
           id: 'test',
           until: 'forever',
           for: 'me',
-          since: { available: '1.0.0' },
+          since: { enabled: '1.0.0' },
         });
         assert.ok(true, 'deprecate did not throw');
       } catch (e) {
@@ -100,7 +100,7 @@ moduleFor(
           id: 'test',
           until: 'forever',
           for: 'me',
-          since: { available: '1.0.0' },
+          since: { enabled: '1.0.0' },
         });
       }, /Should throw/);
     }
@@ -122,7 +122,7 @@ moduleFor(
           id: 'my-deprecation',
           until: 'forever',
           for: 'me',
-          since: { available: '1.0.0' },
+          since: { enabled: '1.0.0' },
         });
         assert.ok(true, 'Did not throw when level is set by id');
       } catch (e) {
@@ -134,7 +134,7 @@ moduleFor(
           id: 'test',
           until: 'forever',
           for: 'me',
-          since: { available: '1.0.0' },
+          since: { enabled: '1.0.0' },
         });
       }, /Should throw with no matching id/);
 
@@ -143,7 +143,7 @@ moduleFor(
           id: 'other-id',
           until: 'forever',
           for: 'me',
-          since: { available: '1.0.0' },
+          since: { enabled: '1.0.0' },
         });
       }, /Should throw with non-matching id/);
     }
@@ -156,7 +156,7 @@ moduleFor(
           id: 'test',
           until: 'forever',
           for: 'me',
-          since: { available: '1.0.0' },
+          since: { enabled: '1.0.0' },
         })
       );
       assert.throws(() =>
@@ -164,7 +164,7 @@ moduleFor(
           id: 'test',
           until: 'forever',
           for: 'me',
-          since: { available: '1.0.0' },
+          since: { enabled: '1.0.0' },
         })
       );
       assert.throws(() =>
@@ -172,7 +172,7 @@ moduleFor(
           id: 'test',
           until: 'forever',
           for: 'me',
-          since: { available: '1.0.0' },
+          since: { enabled: '1.0.0' },
         })
       );
     }
@@ -185,7 +185,7 @@ moduleFor(
         function () {
           assert.ok(false, 'this function should not be invoked');
         },
-        { id: 'test', until: 'forever', for: 'me', since: { available: '1.0.0' } }
+        { id: 'test', until: 'forever', for: 'me', since: { enabled: '1.0.0' } }
       );
 
       assert.ok(true, 'deprecations were not thrown');
@@ -198,19 +198,19 @@ moduleFor(
         id: 'test',
         until: 'forever',
         for: 'me',
-        since: { available: '1.0.0' },
+        since: { enabled: '1.0.0' },
       });
       deprecate('Deprecation is thrown', '1', {
         id: 'test',
         until: 'forever',
         for: 'me',
-        since: { available: '1.0.0' },
+        since: { enabled: '1.0.0' },
       });
       deprecate('Deprecation is thrown', 1, {
         id: 'test',
         until: 'forever',
         for: 'me',
-        since: { available: '1.0.0' },
+        since: { enabled: '1.0.0' },
       });
 
       assert.ok(true, 'deprecations were not thrown');
@@ -312,7 +312,7 @@ moduleFor(
 
       assert.throws(
         () =>
-          deprecate('foo', false, { until: 'forever', for: 'me', since: { available: '1.0.0' } }),
+          deprecate('foo', false, { until: 'forever', for: 'me', since: { enabled: '1.0.0' } }),
         new RegExp(missingOptionsIdDeprecation),
         'proper assertion is triggered when options.id is missing'
       );

--- a/packages/@ember/debug/tests/main_test.js
+++ b/packages/@ember/debug/tests/main_test.js
@@ -311,8 +311,7 @@ moduleFor(
       assert.expect(1);
 
       assert.throws(
-        () =>
-          deprecate('foo', false, { until: 'forever', for: 'me', since: { enabled: '1.0.0' } }),
+        () => deprecate('foo', false, { until: 'forever', for: 'me', since: { enabled: '1.0.0' } }),
         new RegExp(missingOptionsIdDeprecation),
         'proper assertion is triggered when options.id is missing'
       );

--- a/packages/@ember/string/index.ts
+++ b/packages/@ember/string/index.ts
@@ -305,7 +305,7 @@ if (ENV.EXTEND_PROTOTYPES.String) {
         id: 'ember-string.prototype-extensions',
         for: 'ember-source',
         since: {
-          available: '3.24',
+          enabled: '3.24',
         },
         until: '4.0.0',
         url: 'https://deprecations.emberjs.com/v3.x/#toc_ember-string-prototype_extensions',

--- a/packages/@ember/string/index.ts
+++ b/packages/@ember/string/index.ts
@@ -122,7 +122,7 @@ export function loc(str: string, formats: any[]): string {
       for: 'ember-source',
       url: 'https://deprecations.emberjs.com/v3.x#toc_ember-string-loc',
       since: {
-        available: '3.24',
+        enabled: '3.24',
       },
     }
   );


### PR DESCRIPTION
Some of the deprecations recently implemented were marked as available. It was discussed in the framework meeting to make these deprecations enabled, since the staged deprecation infrastructure hasn't completely arrived yet.