### PR TITLE
Lazily setup the router in non-application tests for <LinkTo> component

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-angle-test.js
@@ -1,4 +1,9 @@
-import { moduleFor, ApplicationTestCase, RenderingTestCase, runTask } from 'internal-test-helpers';
+import {
+  moduleFor,
+  ApplicationTestCase,
+  RenderingTestCase,
+  runTask,
+} from 'internal-test-helpers';
 
 import Controller from '@ember/controller';
 import { set } from '@ember/-internals/metal';
@@ -101,7 +106,7 @@ moduleFor(
     ['@test should be able to be inserted in DOM when the router is not present - block']() {
       this.render(`<LinkTo @route='index'>Go to Index</LinkTo>`);
 
-      this.assertText('Go to Index');
+      this.assertComponentElement(this.element.firstChild, { tagName: 'a', attrs: { href: '#/' }, content: 'Go to Index' });
     }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-angle-test.js
@@ -1,9 +1,4 @@
-import {
-  moduleFor,
-  ApplicationTestCase,
-  RenderingTestCase,
-  runTask,
-} from 'internal-test-helpers';
+import { moduleFor, ApplicationTestCase, RenderingTestCase, runTask } from 'internal-test-helpers';
 
 import Controller from '@ember/controller';
 import { set } from '@ember/-internals/metal';
@@ -106,7 +101,11 @@ moduleFor(
     ['@test should be able to be inserted in DOM when the router is not present - block']() {
       this.render(`<LinkTo @route='index'>Go to Index</LinkTo>`);
 
-      this.assertComponentElement(this.element.firstChild, { tagName: 'a', attrs: { href: '#/' }, content: 'Go to Index' });
+      this.assertComponentElement(this.element.firstChild, {
+        tagName: 'a',
+        attrs: { href: '#/' },
+        content: 'Go to Index',
+      });
     }
   }
 );

--- a/packages/@ember/-internals/routing/lib/services/routing.ts
+++ b/packages/@ember/-internals/routing/lib/services/routing.ts
@@ -2,11 +2,15 @@
 @module ember
 */
 
+import { getOwner, Owner } from '@ember/-internals/owner';
 import { readOnly } from '@ember/object/computed';
 import { assign } from '@ember/polyfills';
 import Service from '@ember/service';
+import { symbol } from '@ember/-internals/utils';
 import EmberRouter, { QueryParam } from '../system/router';
 import RouterState from '../system/router_state';
+
+const ROUTER = symbol('ROUTER') as string;
 
 /**
   The Routing service is used by LinkComponent, and provides facilities for
@@ -19,7 +23,17 @@ import RouterState from '../system/router_state';
   @class RoutingService
 */
 export default class RoutingService extends Service {
-  router!: EmberRouter;
+  get router(): EmberRouter {
+    let router = this[ROUTER];
+    if (router !== undefined) {
+      return router;
+    }
+    const owner = getOwner(this) as Owner;
+    router = owner.lookup('router:main') as EmberRouter;
+    router.setupRouter();
+    return (this[ROUTER] = router);
+  }
+
   hasRoute(routeName: string) {
     return this.router.hasRoute(routeName);
   }

--- a/packages/@ember/-internals/routing/lib/services/routing.ts
+++ b/packages/@ember/-internals/routing/lib/services/routing.ts
@@ -3,10 +3,10 @@
 */
 
 import { getOwner, Owner } from '@ember/-internals/owner';
+import { symbol } from '@ember/-internals/utils';
 import { readOnly } from '@ember/object/computed';
 import { assign } from '@ember/polyfills';
 import Service from '@ember/service';
-import { symbol } from '@ember/-internals/utils';
 import EmberRouter, { QueryParam } from '../system/router';
 import RouterState from '../system/router_state';
 

--- a/packages/@ember/application/tests/application_test.js
+++ b/packages/@ember/application/tests/application_test.js
@@ -156,7 +156,6 @@ moduleFor(
       verifyRegistration(assert, application, 'component:textarea');
 
       verifyRegistration(assert, application, 'service:-routing');
-      verifyInjection(assert, application, 'service:-routing', 'router', 'router:main');
 
       // DEBUGGING
       verifyRegistration(assert, application, 'resolver-for-debugging:main');

--- a/packages/@ember/engine/index.js
+++ b/packages/@ember/engine/index.js
@@ -511,8 +511,6 @@ function commonSetupRegistry(registry) {
 
   // Register the routing service...
   registry.register('service:-routing', RoutingService);
-  // Then inject the app router into it
-  registry.injection('service:-routing', 'router', 'router:main');
 
   // DEBUGGING
   registry.register('resolver-for-debugging:main', registry.resolver, {

--- a/packages/@ember/engine/tests/engine_test.js
+++ b/packages/@ember/engine/tests/engine_test.js
@@ -81,7 +81,6 @@ moduleFor(
       verifyRegistration(assert, engine, 'component:textarea');
 
       verifyRegistration(assert, engine, 'service:-routing');
-      verifyInjection(assert, engine, 'service:-routing', 'router', 'router:main');
 
       // DEBUGGING
       verifyRegistration(assert, engine, 'resolver-for-debugging:main');

--- a/packages/ember/tests/routing/query_params_test/query_param_async_get_handler_test.js
+++ b/packages/ember/tests/routing/query_params_test/query_param_async_get_handler_test.js
@@ -21,28 +21,31 @@ moduleFor(
         },
 
         setupRouter() {
-          this._super(...arguments);
-          let { _handlerPromises: handlerPromises, _seenHandlers: seenHandlers } = this;
-          let getRoute = this._routerMicrolib.getRoute;
+          let isNewSetup = this._super(...arguments);
+          if (isNewSetup) {
+            let { _handlerPromises: handlerPromises, _seenHandlers: seenHandlers } = this;
+            let getRoute = this._routerMicrolib.getRoute;
 
-          this._routerMicrolib.getRoute = function (routeName) {
-            fetchedHandlers.push(routeName);
+            this._routerMicrolib.getRoute = function (routeName) {
+              fetchedHandlers.push(routeName);
 
-            // Cache the returns so we don't have more than one Promise for a
-            // given handler.
-            return (
-              handlerPromises[routeName] ||
-              (handlerPromises[routeName] = new RSVP.Promise((resolve) => {
-                setTimeout(() => {
-                  let handler = getRoute(routeName);
+              // Cache the returns so we don't have more than one Promise for a
+              // given handler.
+              return (
+                handlerPromises[routeName] ||
+                (handlerPromises[routeName] = new RSVP.Promise((resolve) => {
+                  setTimeout(() => {
+                    let handler = getRoute(routeName);
 
-                  seenHandlers[routeName] = handler;
+                    seenHandlers[routeName] = handler;
 
-                  resolve(handler);
-                }, 10);
-              }))
-            );
-          };
+                    resolve(handler);
+                  }, 10);
+                }))
+              );
+            };
+          }
+          return isNewSetup;
         },
 
         _getQPMeta(routeInfo) {


### PR DESCRIPTION
## Summary
PR #19080 fixed the issue where accessing public router service throwing
error, however, the PR did not support LinkTo component which uses the
internal -routing service. This PR adds similar lazy setup to
-routing.router.

## Todo
- [x] edit https://github.com/ember-learn/super-rentals-tutorial/edit/master/src/markdown/tutorial/part-2/09-route-params.md to remove `this.owner.setupRouter();` for next release