### PR TITLE
[DOC lts] Remove mention on `transition-to` helper

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -231,8 +231,7 @@ import layout from '../templates/link-to';
   </li>
   ```
 
-  In general, this is not recommended. Instead, you can use the `transition-to` helper together
-  with a click event handler on the HTML tag of your choosing.
+  In general, this is not recommended.
 
   ### Supplying query parameters
 


### PR DESCRIPTION
The `transition-to` helper does not exists.

I suppose we could mention how to do this with the `{{on}}` modifier along with a custom action, but that would still be inappropriate for accessibility reasons in most cases. We should probably just deprecate this functionality, but in the meantime, we can probably just leave it at this.