### PR TITLE
[BUGFIX release] Ensure query param only <LinkTo /> are properly scoped in engines.

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -517,7 +517,8 @@ const LinkComponent = EmberComponent.extend({
 
   _route: computed('route', '_currentRouterState', function computeLinkToComponentRoute(this: any) {
     let { route } = this;
-    return this._namespaceRoute(route === UNDEFINED ? this._currentRoute : route);
+
+    return route === UNDEFINED ? this._currentRoute : this._namespaceRoute(route);
   }),
 
   _models: computed('model', 'models', function computeLinkToComponentModels(this: any) {

--- a/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
@@ -890,6 +890,25 @@ moduleFor(
       });
     }
 
+    '@test query params only transitions work properly'(assert) {
+      assert.expect(1);
+
+      let tmpl = '<LinkTo @query={{hash type="news"}}>News</LinkTo>';
+
+      this.setupAppAndRoutableEngine();
+      this.additionalEngineRegistrations(function () {
+        this.register('template:category', compile(tmpl));
+      });
+
+      return this.visit('/blog/category/1').then(() => {
+        let suffix = '/blog/category/1?type=news';
+        let href = this.element.querySelector('a').href;
+
+        // check if link ends with the suffix
+        assert.ok(this.stringsEndWith(href, suffix));
+      });
+    }
+
     async ['@test query params in customized controllerName have stickiness by default between model'](
       assert
     ) {


### PR DESCRIPTION
Prior to this change, the test would fail with the following:

```
Assertion Failed: You attempted to generate a link for the "UNDEFINED" route, but did not pass the models required for generating its dynamic segments. There is no route named blog.blog.category
    at assert (http://localhost:7020/tests/ember.js:32996:15)
    at Class.computeLinkToComponentHref (http://localhost:7020/tests/ember.js:5808:50)
    at http://localhost:7020/tests/ember.js:11860:25
    at untrack (http://localhost:7020/tests/ember.js:54650:14)
    at ComputedProperty.get (http://localhost:7020/tests/ember.js:11859:32)
    at Class.getter [as href] (http://localhost:7020/tests/ember.js:10949:25)
    at getPossibleMandatoryProxyValue (http://localhost:7020/tests/ember.js:11250:19)
    at _getProp (http://localhost:7020/tests/ember.js:11315:17)
    at http://localhost:7020/tests/ember.js:45192:45
    at http://localhost:7020/tests/ember.js:45140:37
```

This is because inside a QP only transition we always use `_currentRoute` which has **already been namespaced**.

---

Introduced in https://github.com/emberjs/ember.js/pull/19223 (and released in 3.24.0).