### PR TITLE
[BUGFIX beta] Deprecate importing htmlSafe and isHTMLSafe from @ember/string

### DIFF
--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -651,8 +651,36 @@ if (ENV.EXTEND_PROTOTYPES.String) {
     return htmlSafe(this);
   };
 }
-Ember.String.htmlSafe = htmlSafe;
-Ember.String.isHTMLSafe = isHTMLSafe;
+const deprecateImportFromString = function (
+  name,
+  message = `Importing ${name} from '@ember/string' is deprecated. Please import ${name} from '@ember/template' instead.`
+) {
+  deprecate(message, false, {
+    id: 'ember-string.htmlsafe-ishtmlsafe',
+    for: 'ember-source',
+    since: {
+      enabled: '3.25',
+    },
+    until: '4.0.0',
+    url: 'https://deprecations.emberjs.com/v3.x/#toc_ember-string-htmlsafe-ishtmlsafe',
+  });
+};
+Object.defineProperty(Ember.String, 'htmlSafe', {
+  enumerable: true,
+  configurable: true,
+  get() {
+    deprecateImportFromString('htmlSafe');
+    return htmlSafe;
+  },
+});
+Object.defineProperty(Ember.String, 'isHTMLSafe', {
+  enumerable: true,
+  configurable: true,
+  get() {
+    deprecateImportFromString('isHTMLSafe');
+    return isHTMLSafe;
+  },
+});
 
 /**
   Global hash of shared templates. This will automatically be populated

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -68,8 +68,28 @@ moduleFor(
       });
     }
 
-    ['@test Ember.String.isHTMLSafe exports correctly'](assert) {
-      confirmExport(Ember, assert, 'String.isHTMLSafe', '@ember/-internals/glimmer', 'isHTMLSafe');
+    ['@test Ember.String.htmlSafe exports correctly (but deprecated)'](assert) {
+      let glimmer = require('@ember/-internals/glimmer');
+      expectDeprecation(() => {
+        assert.equal(
+          Ember.String.htmlSafe,
+          glimmer.htmlSafe,
+          'Ember.String.htmlSafe is exported correctly'
+        );
+      }, /Importing htmlSafe from '@ember\/string' is deprecated/);
+      assert.notEqual(glimmer.htmlSafe, undefined, 'Ember.String.htmlSafe is not `undefined`');
+    }
+
+    ['@test Ember.String.isHTMLSafe exports correctly (but deprecated)'](assert) {
+      let glimmer = require('@ember/-internals/glimmer');
+      expectDeprecation(() => {
+        assert.equal(
+          Ember.String.isHTMLSafe,
+          glimmer.isHTMLSafe,
+          'Ember.String.isHTMLSafe is exported correctly'
+        );
+      }, /Importing isHTMLSafe from '@ember\/string' is deprecated/);
+      assert.notEqual(glimmer.isHTMLSafe, undefined, 'Ember.String.isHTMLSafe is not `undefined`');
     }
 
     ['@test Ember.EXTEND_PROTOTYPES is present (but deprecated)'](assert) {
@@ -270,7 +290,6 @@ let allExports = [
   ['Handlebars.template', '@ember/-internals/glimmer', 'template'],
   ['HTMLBars.template', '@ember/-internals/glimmer', 'template'],
   ['Handlebars.Utils.escapeExpression', '@ember/-internals/glimmer', 'escapeExpression'],
-  ['String.htmlSafe', '@ember/-internals/glimmer', 'htmlSafe'],
   ['_setComponentManager', '@ember/-internals/glimmer', 'setComponentManager'],
   ['_componentManagerCapabilities', '@glimmer/manager', 'componentCapabilities'],
   ['_setComponentTemplate', '@glimmer/manager', 'setComponentTemplate'],


### PR DESCRIPTION
As per [RFC #236](https://github.com/emberjs/rfcs/blob/master/text/0236-deprecation-ember-string.md), this deprecates importing `htmlSafe` and `isHTMLSafe` from `@ember/string`.

The [tracking issue for RFC #236](https://github.com/emberjs/rfc-tracking/issues/26) says that these will be deprecated via linting, but the [linked issue](https://github.com/emberjs/ember.js/pull/15626) is only a docs change that doesn't make it clear that importing from `@ember/string` is deprecated. There has been much confusion around whether this is actually deprecated (especially with regard to the `@ember/string` type definitions).

I'm hoping this can be backported to 3.24 since the the string prototype extensions were deprecated in that version.