### PR TITLE
[BUGFIX release] Fix misleading LinkTo error message

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -811,11 +811,8 @@ const LinkComponent = EmberComponent.extend({
           return routing.generateURL(route, models, query);
         } catch (e) {
           // tslint:disable-next-line:max-line-length
-          assert(
-            `You attempted to generate a link for the "${this.route}" route, but did not ` +
-              `pass the models required for generating its dynamic segments. ` +
-              e.message
-          );
+          e.message = `While generating link to route "${this.route}": ${e.message}`;
+          throw e;
         }
       } else {
         return routing.generateURL(route, models, query);


### PR DESCRIPTION
This fixes #18640. 

An easy way to demonstrate the original problem is to make a route that throws from `serialize`:

```js
export default class FooRoute extends Route {
  serialize() {
    throw new Error('boom');
  }
}
```

Before this change, you would see:

<img width="640" alt="Screen Shot 2021-01-18 at 1 45 14 PM" src="https://user-images.githubusercontent.com/319282/104953189-ead7ae00-5993-11eb-872d-f31a2c00880f.png">

Notice that both the message and the stack trace are misleading.

After this change, you would see:

<img width="634" alt="Screen Shot 2021-01-18 at 1 45 31 PM" src="https://user-images.githubusercontent.com/319282/104953227-fb882400-5993-11eb-940a-09d7dc9901b4.png">

In which the message is not so misleading anymore, and the stack trace points to the real site of the problem.

I also confirmed that this still gives reasonable results for the case of failing to pass enough dynamic parameters. Before:

<img width="639" alt="Screen Shot 2021-01-18 at 1 44 30 PM" src="https://user-images.githubusercontent.com/319282/104953297-1fe40080-5994-11eb-8071-4606486e785c.png">

And after:

<img width="641" alt="Screen Shot 2021-01-18 at 1 44 49 PM" src="https://user-images.githubusercontent.com/319282/104953312-283c3b80-5994-11eb-9451-0612529d8272.png">

