### PR TITLE
[RFC 445] Deprecate `{{#with}}`

### DIFF
--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -112,6 +112,7 @@
   @for Ember.Templates.helpers
   @param {Object} options
   @return {String} HTML string
+  @deprecated Use '{{#let}}' instead
   @public
  */
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
@@ -569,9 +569,9 @@ moduleFor(
       this.registerComponent('foo-bar', { template: 'hello' });
 
       this.render(strip`
-        {{#with (component 'foo-bar') as |Other|}}
+        {{#let (component 'foo-bar') as |Other|}}
           <Other />
-        {{/with}}
+        {{/let}}
       `);
 
       this.assertComponentElement(this.firstChild, { content: 'hello' });

--- a/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
@@ -272,9 +272,9 @@ moduleFor(
 
       this.render(
         strip`
-      {{#with (hash comp=(component "-looked-up" greeting=this.model.greeting)) as |my|}}
+      {{#let (hash comp=(component "-looked-up" greeting=this.model.greeting)) as |my|}}
         {{#my.comp}}{{/my.comp}}
-      {{/with}}`,
+      {{/let}}`,
         {
           model: {
             greeting: 'Hodi',
@@ -340,11 +340,11 @@ moduleFor(
 
       this.render(
         strip`
-      {{#with (component "-looked-up" greeting="Hola" name="Dolores" age=33) as |first|}}
-        {{#with (component first greeting="Hej" name="Sigmundur") as |second|}}
+      {{#let (component "-looked-up" greeting="Hola" name="Dolores" age=33) as |first|}}
+        {{#let (component first greeting="Hej" name="Sigmundur") as |second|}}
           {{component second greeting=this.model.greeting}}
-        {{/with}}
-      {{/with}}`,
+        {{/let}}
+      {{/let}}`,
         {
           model: {
             greeting: 'Hodi',
@@ -616,9 +616,9 @@ moduleFor(
       });
 
       this.render(strip`
-      {{#with (hash lookedup=(component "-looked-up")) as |object|}}
+      {{#let (hash lookedup=(component "-looked-up")) as |object|}}
         {{object.lookedup}}
-      {{/with}}`);
+      {{/let}}`);
 
       this.assertText(expectedText);
 
@@ -635,9 +635,9 @@ moduleFor(
 
       this.render(
         strip`
-      {{#with (hash lookedup=(component "-looked-up")) as |object|}}
+      {{#let (hash lookedup=(component "-looked-up")) as |object|}}
         {{object.lookedup expectedText=this.model.expectedText}}
-      {{/with}}`,
+      {{/let}}`,
         {
           model: {
             expectedText,
@@ -668,9 +668,9 @@ moduleFor(
 
       this.render(
         strip`
-      {{#with (hash lookedup=(component "-looked-up" expectedText=this.model.expectedText)) as |object|}}
+      {{#let (hash lookedup=(component "-looked-up" expectedText=this.model.expectedText)) as |object|}}
         {{object.lookedup}}
-      {{/with}}`,
+      {{/let}}`,
         {
           model: {
             expectedText,
@@ -705,9 +705,9 @@ moduleFor(
 
       this.render(
         strip`
-      {{#with (hash lookedup=(component "-looked-up")) as |object|}}
+      {{#let (hash lookedup=(component "-looked-up")) as |object|}}
         {{object.lookedup this.model.expectedText "Hola"}}
-      {{/with}}`,
+      {{/let}}`,
         {
           model: {
             expectedText,
@@ -748,9 +748,9 @@ moduleFor(
 
       this.render(
         strip`
-      {{#with (hash my-component=(component 'my-component' first)) as |c|}}
+      {{#let (hash my-component=(component 'my-component' first)) as |c|}}
         {{c.my-component}}
-      {{/with}}`,
+      {{/let}}`,
         { first: 'first' }
       );
 
@@ -946,9 +946,9 @@ moduleFor(
 
       this.render(
         strip`
-      {{#with (hash ctxCmp=(component "my-comp" isOpen=isOpen)) as |thing|}}
+      {{#let (hash ctxCmp=(component "my-comp" isOpen=isOpen)) as |thing|}}
         {{#thing.ctxCmp}}This is a contextual component{{/thing.ctxCmp}}
-      {{/with}}
+      {{/let}}
     `,
         {
           isOpen: true,
@@ -1010,9 +1010,9 @@ moduleFor(
 
       this.render(
         strip`
-      {{#with (hash ctxCmp=(component compName isOpen=isOpen)) as |thing|}}
+      {{#let (hash ctxCmp=(component compName isOpen=isOpen)) as |thing|}}
         {{#thing.ctxCmp}}This is a contextual component{{/thing.ctxCmp}}
-      {{/with}}
+      {{/let}}
     `,
         {
           compName: 'my-comp',
@@ -1088,9 +1088,9 @@ moduleFor(
 
       this.render(
         strip`
-      {{#with (hash ctxCmp=(component compName isOpen=isOpen)) as |thing|}}
+      {{#let (hash ctxCmp=(component compName isOpen=isOpen)) as |thing|}}
         {{#thing.ctxCmp}}This is a contextual component{{/thing.ctxCmp}}
-      {{/with}}
+      {{/let}}
     `,
         {
           compName: 'my-comp',
@@ -1198,7 +1198,7 @@ moduleFor(
       });
 
       this.render(
-        '{{#with (hash link=(component "my-link")) as |c|}}{{c.link params=allParams}}{{/with}}',
+        '{{#let (hash link=(component "my-link")) as |c|}}{{c.link params=allParams}}{{/let}}',
         {
           allParams: emberA(['a', 'b']),
         }

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/array-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/array-test.js
@@ -9,11 +9,11 @@ moduleFor(
   class extends RenderingTestCase {
     ['@test returns an array']() {
       this.render(strip`
-      {{#with (array "Sergio") as |people|}}
+      {{#let (array "Sergio") as |people|}}
         {{#each people as |personName|}}
           {{personName}}
         {{/each}}
-      {{/with}}`);
+      {{/let}}`);
 
       this.assertText('Sergio');
 
@@ -22,11 +22,11 @@ moduleFor(
 
     ['@test can have more than one value']() {
       this.render(strip`
-      {{#with (array "Sergio" "Robert") as |people|}}
+      {{#let (array "Sergio" "Robert") as |people|}}
         {{#each people as |personName|}}
           {{personName}},
         {{/each}}
-      {{/with}}`);
+      {{/let}}`);
 
       this.assertText('Sergio,Robert,');
 
@@ -35,11 +35,11 @@ moduleFor(
 
     ['@test binds values when variables are used']() {
       this.render(
-        strip`{{#with (array personOne) as |people|}}
+        strip`{{#let (array personOne) as |people|}}
               {{#each people as |personName|}}
                 {{personName}}
               {{/each}}
-            {{/with}}`,
+            {{/let}}`,
         {
           personOne: 'Tom',
         }
@@ -58,11 +58,11 @@ moduleFor(
 
     ['@test binds multiple values when variables are used']() {
       this.render(
-        strip`{{#with (array personOne personTwo) as |people|}}
+        strip`{{#let (array personOne personTwo) as |people|}}
               {{#each people as |personName|}}
                 {{personName}},
               {{/each}}
-            {{/with}}`,
+            {{/let}}`,
         {
           personOne: 'Tom',
           personTwo: 'Yehuda',
@@ -91,14 +91,14 @@ moduleFor(
 
     ['@test array helpers can be nested']() {
       this.render(
-        strip`{{#with (array (array personOne personTwo)) as |listOfPeople|}}
+        strip`{{#let (array (array personOne personTwo)) as |listOfPeople|}}
               {{#each listOfPeople as |people|}}
                 List:
                 {{#each people as |personName|}}
                   {{personName}},
                 {{/each}}
               {{/each}}
-            {{/with}}`,
+            {{/let}}`,
         {
           personOne: 'Tom',
           personTwo: 'Yehuda',

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/element-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/element-action-test.js
@@ -777,7 +777,7 @@ moduleFor(
       this.assert.equal(editHandlerWasCalled, true, 'the event handler was called');
     }
 
-    ['@test it should work properly in a {{#with foo as |bar|}} block']() {
+    ['@test it should work properly in a {{#let foo as |bar|}} block']() {
       let editHandlerWasCalled = false;
 
       let ExampleComponent = Component.extend({
@@ -792,7 +792,7 @@ moduleFor(
       this.registerComponent('example-component', {
         ComponentClass: ExampleComponent,
         template:
-          '{{#with something as |somethingElse|}}<a href="#" {{action "edit"}}>click me</a>{{/with}}',
+          '{{#let something as |somethingElse|}}<a href="#" {{action "edit"}}>click me</a>{{/let}}',
       });
 
       this.render('{{example-component}}');

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/hash-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/hash-test.js
@@ -8,7 +8,7 @@ moduleFor(
   'Helpers test: {{hash}}',
   class extends RenderingTestCase {
     ['@test returns a hash with the right key-value']() {
-      this.render(`{{#with (hash name="Sergio") as |person|}}{{person.name}}{{/with}}`);
+      this.render(`{{#let (hash name="Sergio") as |person|}}{{person.name}}{{/let}}`);
 
       this.assertText('Sergio');
 
@@ -19,7 +19,7 @@ moduleFor(
 
     ['@test can have more than one key-value']() {
       this.render(
-        `{{#with (hash name="Sergio" lastName="Arbeo") as |person|}}{{person.name}} {{person.lastName}}{{/with}}`
+        `{{#let (hash name="Sergio" lastName="Arbeo") as |person|}}{{person.name}} {{person.lastName}}{{/let}}`
       );
 
       this.assertText('Sergio Arbeo');
@@ -31,7 +31,7 @@ moduleFor(
 
     ['@test binds values when variables are used']() {
       this.render(
-        `{{#with (hash name=this.model.firstName lastName="Arbeo") as |person|}}{{person.name}} {{person.lastName}}{{/with}}`,
+        `{{#let (hash name=this.model.firstName lastName="Arbeo") as |person|}}{{person.name}} {{person.lastName}}{{/let}}`,
         {
           model: {
             firstName: 'Marisa',
@@ -56,7 +56,7 @@ moduleFor(
 
     ['@test binds multiple values when variables are used']() {
       this.render(
-        `{{#with (hash name=this.model.firstName lastName=this.model.lastName) as |person|}}{{person.name}} {{person.lastName}}{{/with}}`,
+        `{{#let (hash name=this.model.firstName lastName=this.model.lastName) as |person|}}{{person.name}} {{person.lastName}}{{/let}}`,
         {
           model: {
             firstName: 'Marisa',
@@ -91,7 +91,7 @@ moduleFor(
 
     ['@test hash helpers can be nested']() {
       this.render(
-        `{{#with (hash person=(hash name=this.model.firstName)) as |ctx|}}{{ctx.person.name}}{{/with}}`,
+        `{{#let (hash person=(hash name=this.model.firstName)) as |ctx|}}{{ctx.person.name}}{{/let}}`,
         {
           model: { firstName: 'Balint' },
         }

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/yield-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/yield-test.js
@@ -203,7 +203,7 @@ moduleFor(
         template: '<p>{{boundText}}</p><p>{{yield}}</p>',
       });
 
-      this.render('{{#with boundText as |item|}}{{#kiwi-comp}}{{item}}{{/kiwi-comp}}{{/with}}', {
+      this.render('{{#let boundText as |item|}}{{#kiwi-comp}}{{item}}{{/kiwi-comp}}{{/let}}', {
         boundText: 'Outer',
       });
       this.assertText('InnerOuter');
@@ -222,7 +222,7 @@ moduleFor(
 
       this.registerComponent('kiwi-comp', {
         ComponentClass: KiwiCompComponent,
-        template: '{{#with boundText as |item|}}<p>{{item}}</p><p>{{yield}}</p>{{/with}}',
+        template: '{{#let boundText as |item|}}<p>{{item}}</p><p>{{yield}}</p>{{/let}}',
       });
 
       this.render('{{#kiwi-comp}}{{item}}{{/kiwi-comp}}', { item: 'Outer' });
@@ -243,7 +243,7 @@ moduleFor(
       });
 
       this.render(
-        '{{#with boundText as |item|}}{{#kiwi-comp content=item}}{{item}}{{/kiwi-comp}}{{/with}}',
+        '{{#let boundText as |item|}}{{#kiwi-comp content=item}}{{item}}{{/kiwi-comp}}{{/let}}',
         { boundText: 'Outer' }
       );
       this.assertText('OuterOuter');

--- a/packages/@ember/-internals/glimmer/tests/integration/refinements-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/refinements-test.js
@@ -10,45 +10,45 @@ moduleFor(
 
       this.render(
         strip`
-      {{#with var as |foo|}}
+      {{#let var as |foo|}}
         {{foo}}
-      {{/with}}
+      {{/let}}
 
       ---
 
-      {{#with var as |outlet|}}
+      {{#let var as |outlet|}}
         {{outlet}}
-      {{/with}}
+      {{/let}}
 
       ---
 
-      {{#with var as |mount|}}
+      {{#let var as |mount|}}
         {{mount}}
-      {{/with}}
+      {{/let}}
 
       ---
 
-      {{#with var as |component|}}
+      {{#let var as |component|}}
         {{component}}
-      {{/with}}
+      {{/let}}
 
       ---
 
-      {{#with var as |input|}}
+      {{#let var as |input|}}
         {{input}}
-      {{/with}}
+      {{/let}}
 
       ---
 
-      {{#with var as |-with-dynamic-vars|}}
+      {{#let var as |-with-dynamic-vars|}}
         {{-with-dynamic-vars}}
-      {{/with}}
+      {{/let}}
 
       ---
 
-      {{#with var as |-in-element|}}
+      {{#let var as |-in-element|}}
         {{-in-element}}
-      {{/with}}`,
+      {{/let}}`,
         { var: 'var' }
       );
 

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/with-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/with-test.js
@@ -8,6 +8,10 @@ import { IfUnlessWithSyntaxTest } from '../../utils/shared-conditional-tests';
 moduleFor(
   'Syntax test: {{#with}}',
   class extends IfUnlessWithSyntaxTest {
+    beforeEach() {
+      expectDeprecation(/^`{{#with}}` is deprecated\./);
+    }
+
     templateFor({ cond, truthy, falsy }) {
       return `{{#with ${cond}}}${truthy}{{else}}${falsy}{{/with}}`;
     }
@@ -17,6 +21,10 @@ moduleFor(
 moduleFor(
   'Syntax test: {{#with as}}',
   class extends IfUnlessWithSyntaxTest {
+    beforeEach() {
+      expectDeprecation(/^`{{#with}}` is deprecated\./);
+    }
+
     templateFor({ cond, truthy, falsy }) {
       return `{{#with ${cond} as |test|}}${truthy}{{else}}${falsy}{{/with}}`;
     }
@@ -247,6 +255,10 @@ moduleFor(
 moduleFor(
   'Syntax test: Multiple {{#with as}} helpers',
   class extends RenderingTestCase {
+    beforeEach() {
+      expectDeprecation(/^`{{#with}}` is deprecated\./);
+    }
+
     ['@test re-using the same variable with different {{#with}} blocks does not override each other']() {
       this.render(
         `Admin: {{#with admin as |person|}}{{person.name}}{{/with}} User: {{#with user as |person|}}{{person.name}}{{/with}}`,

--- a/packages/ember-template-compiler/lib/plugins/deprecate-with.ts
+++ b/packages/ember-template-compiler/lib/plugins/deprecate-with.ts
@@ -1,0 +1,189 @@
+import { assert, deprecate } from '@ember/debug';
+import { AST, ASTPlugin } from '@glimmer/syntax';
+import calculateLocationDisplay from '../system/calculate-location-display';
+import { EmberASTPluginEnvironment } from '../types';
+import { isPath } from './utils';
+
+/**
+ @module ember
+*/
+
+/**
+  A Glimmer2 AST transformation that deprecates `{{#with}}` and replace it
+  with `{{#let}}` and `{{#if}}` as per RFC 445.
+
+  Transforms:
+
+  ```handlebars
+  {{#with this.foo as |bar|}}
+    ...
+  {{/with}}
+  ```
+
+  Into:
+
+  ```handlebars
+  {{#let this.foo as |bar|}}
+    {{#if bar}}
+      ...
+    {{/if}}
+  {{/let}}
+  ```
+
+  And:
+
+  ```handlebars
+  {{#with this.foo as |bar|}}
+    ...
+  {{else}}
+    ...
+  {{/with}}
+  ```
+
+  Into:
+
+  ```handlebars
+  {{#let this.foo as |bar|}}
+    {{#if bar}}
+      ...
+    {{else}}
+      ...
+    {{/if}}
+  {{/let}}
+  ```
+
+  And issues a deprecation message.
+
+  @private
+  @class DeprecateWith
+*/
+export default function deprecateWith(env: EmberASTPluginEnvironment): ASTPlugin {
+  let { moduleName } = env.meta;
+  let { builders: b } = env.syntax;
+
+  return {
+    name: 'deprecate-with',
+
+    visitor: {
+      BlockStatement(node: AST.BlockStatement) {
+        if (!isPath(node.path) || node.path.original !== 'with') return;
+
+        let { params, hash, program, inverse, loc, openStrip, inverseStrip, closeStrip } = node;
+
+        let sourceInformation = calculateLocationDisplay(moduleName, node.loc);
+
+        assert(
+          `\`{{#with}}\` takes a single positional argument (the path to alias), received ${displayParams(
+            params
+          )}. ${sourceInformation}`,
+          params.length === 1
+        );
+
+        assert(
+          `\`{{#with}}\` does not take any named arguments, received ${displayHash(
+            hash
+          )}. ${sourceInformation}`,
+          hash.pairs.length === 0
+        );
+
+        assert(
+          `\`{{#with}}\` yields a single block param, received ${displayBlockParams(
+            program.blockParams
+          )}. ${sourceInformation}`,
+          program.blockParams.length <= 1
+        );
+
+        let recommendation;
+
+        if (program.blockParams.length === 0) {
+          recommendation = 'Use `{{#if}}` instead.';
+        } else if (inverse) {
+          recommendation = 'Use `{{#let}}` together with `{{#if}} instead.';
+        } else {
+          recommendation =
+            'If you always want the block to render, replace `{{#with}}` with `{{#let}}`. ' +
+            'If you want to conditionally render the block, use `{{#let}}` together with `{{#if}} instead.';
+        }
+
+        deprecate(`\`{{#with}}\` is deprecated. ${recommendation} ${sourceInformation}`, false, {
+          id: 'ember-glimmer.with-syntax',
+          until: '4.0.0',
+          for: 'ember-source',
+          since: {
+            enabled: '3.26.0-beta.1',
+          },
+        });
+
+        if (program.blockParams.length === 0) {
+          return b.block(
+            'if',
+            params,
+            null,
+            program,
+            inverse,
+            loc,
+            openStrip,
+            inverseStrip,
+            closeStrip
+          );
+        } else {
+          return b.block(
+            'let',
+            params,
+            null,
+            b.blockItself(
+              [
+                b.block(
+                  'if',
+                  [b.path(program.blockParams[0])],
+                  null,
+                  b.blockItself(program.body, [], program.chained, program.loc),
+                  inverse,
+                  loc,
+                  openStrip,
+                  inverseStrip,
+                  closeStrip
+                ),
+              ],
+              program.blockParams,
+              false,
+              loc
+            ),
+            null,
+            loc,
+            openStrip,
+            inverseStrip,
+            closeStrip
+          );
+        }
+      },
+    },
+  };
+}
+
+function displayParams(params: AST.Expression[]): string {
+  if (params.length === 0) {
+    return 'no positional arguments';
+  } else {
+    let display = params.map((param) => `\`${JSON.stringify(param)}\``).join(', ');
+    return `${params.length} positional arguments: ${display}`;
+  }
+}
+
+function displayHash({ pairs }: AST.Hash): string {
+  if (pairs.length === 0) {
+    return 'no named arguments';
+  } else {
+    let display = pairs.map((pair) => `\`${pair.key}\``).join(', ');
+    return `${pairs.length} named arguments: ${display}`;
+  }
+}
+
+function displayBlockParams(blockParams: string[]): string {
+  if (blockParams.length === 0) {
+    return 'no block params';
+  } else {
+    let display = blockParams.map((param) => `\`${param}\``).join(', ');
+    return `${blockParams.length} block params: ${display}`;
+  }
+}

--- a/packages/ember-template-compiler/lib/plugins/index.ts
+++ b/packages/ember-template-compiler/lib/plugins/index.ts
@@ -4,6 +4,7 @@ import AssertInputHelperWithoutBlock from './assert-input-helper-without-block';
 import AssertReservedNamedArguments from './assert-reserved-named-arguments';
 import AssertSplattributeExpressions from './assert-splattribute-expression';
 import DeprecateSendAction from './deprecate-send-action';
+import DeprecateWith from './deprecate-with';
 import TransformActionSyntax from './transform-action-syntax';
 import TransformAttrsIntoArgs from './transform-attrs-into-args';
 import TransformEachInIntoEach from './transform-each-in-into-each';
@@ -34,6 +35,7 @@ export const RESOLUTION_MODE_TRANSFORMS = Object.freeze(
     AssertSplattributeExpressions,
     TransformEachTrackArray,
     TransformWrapMountAndOutlet,
+    DeprecateWith,
     SEND_ACTION ? DeprecateSendAction : null,
     !EMBER_NAMED_BLOCKS ? AssertAgainstNamedBlocks : null,
     !EMBER_DYNAMIC_HELPERS_AND_MODIFIERS ? AssertAgainstDynamicHelpersModifiers : null,
@@ -50,6 +52,7 @@ export const STRICT_MODE_TRANSFORMS = Object.freeze(
     AssertSplattributeExpressions,
     TransformEachTrackArray,
     TransformWrapMountAndOutlet,
+    DeprecateWith,
     SEND_ACTION ? DeprecateSendAction : null,
     !EMBER_NAMED_BLOCKS ? AssertAgainstNamedBlocks : null,
     !EMBER_DYNAMIC_HELPERS_AND_MODIFIERS ? AssertAgainstDynamicHelpersModifiers : null,


### PR DESCRIPTION
Also transforms `{{#with}}` into the equivalent combination of `{{#let}}` and/or `{{#if}}` to allow removing the legacy upstream code on the Glimmer VM side.

See [RFC 445](https://github.com/emberjs/rfcs/blob/master/text/0445-deprecate-with.md).