### PR TITLE
[DOC] Call super in Glimmer component willDestroy hook example

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/glimmer-component-docs.ts
+++ b/packages/@ember/-internals/glimmer/lib/glimmer-component-docs.ts
@@ -325,6 +325,8 @@
     @service myAnimations;
 
     willDestroy() {
+      super.willDestroy(...arguments);
+
       this.myAnimations.unregister(this);
     }
   }


### PR DESCRIPTION
It seems this is also automatically added when running `eslint . --fix`. Adding it to the docs makes sense I think.

cc @ijlee2.