### PR TITLE
[CLEANUP] Remove usages of property fallback lookup from tests

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/environment.ts
+++ b/packages/@ember/-internals/glimmer/lib/environment.ts
@@ -17,8 +17,6 @@ import toBool from './utils/to-bool';
 
 // Setup global context
 
-window._deprecationMap = {};
-
 setGlobalContext({
   scheduleRevalidate() {
     backburner.ensureInstance();

--- a/packages/@ember/-internals/glimmer/lib/environment.ts
+++ b/packages/@ember/-internals/glimmer/lib/environment.ts
@@ -17,6 +17,8 @@ import toBool from './utils/to-bool';
 
 // Setup global context
 
+window._deprecationMap = {};
+
 setGlobalContext({
   scheduleRevalidate() {
     backburner.ensureInstance();

--- a/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
@@ -108,7 +108,7 @@ moduleFor(
                 queryParams: ['official'],
               })
             );
-            this.register('template:application', compile('Engine{{lang}}{{outlet}}'));
+            this.register('template:application', compile('Engine{{this.lang}}{{outlet}}'));
             this.register(
               'route:application',
               Route.extend({
@@ -255,7 +255,7 @@ moduleFor(
                 contextType: 'Engine',
               })
             );
-            this.register('template:application', compile('Engine {{foo-bar wat=contextType}}'));
+            this.register('template:application', compile('Engine {{foo-bar wat=this.contextType}}'));
           },
         })
       );
@@ -281,7 +281,7 @@ moduleFor(
       this.assert.expect(1);
 
       let sharedTemplate = compile(strip`
-      <h1>{{contextType}}</h1>
+      <h1>{{this.contextType}}</h1>
       {{ambiguous-curlies}}
 
       {{outlet}}

--- a/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
@@ -255,7 +255,10 @@ moduleFor(
                 contextType: 'Engine',
               })
             );
-            this.register('template:application', compile('Engine {{foo-bar wat=this.contextType}}'));
+            this.register(
+              'template:application',
+              compile('Engine {{foo-bar wat=this.contextType}}')
+            );
           },
         })
       );

--- a/packages/@ember/-internals/glimmer/tests/integration/application/helper-registration-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/helper-registration-test.js
@@ -22,7 +22,10 @@ moduleFor(
     }
 
     ['@test Bound helpers registered on the container can be late-invoked'](assert) {
-      this.addTemplate('application', `<div id='wrapper'>{{x-reverse}} {{x-reverse this.foo}}</div>`);
+      this.addTemplate(
+        'application',
+        `<div id='wrapper'>{{x-reverse}} {{x-reverse this.foo}}</div>`
+      );
 
       this.add(
         'controller:application',

--- a/packages/@ember/-internals/glimmer/tests/integration/application/helper-registration-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/helper-registration-test.js
@@ -22,7 +22,7 @@ moduleFor(
     }
 
     ['@test Bound helpers registered on the container can be late-invoked'](assert) {
-      this.addTemplate('application', `<div id='wrapper'>{{x-reverse}} {{x-reverse foo}}</div>`);
+      this.addTemplate('application', `<div id='wrapper'>{{x-reverse}} {{x-reverse this.foo}}</div>`);
 
       this.add(
         'controller:application',

--- a/packages/@ember/-internals/glimmer/tests/integration/application/rendering-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/rendering-test.js
@@ -567,8 +567,8 @@ moduleFor(
         })
       );
 
-      this.addTemplate('a', '{{value}}');
-      this.addTemplate('b', '{{value}}');
+      this.addTemplate('a', '{{this.value}}');
+      this.addTemplate('b', '{{this.value}}');
 
       return this.visit('/a')
         .then(() => {
@@ -610,7 +610,7 @@ moduleFor(
         })
       );
 
-      this.addTemplate('color', 'model color: {{@model.color}}, controller color: {{color}}');
+      this.addTemplate('color', 'model color: {{@model.color}}, controller color: {{this.color}}');
 
       return this.visit('/colors/red')
         .then(() => {
@@ -661,7 +661,7 @@ moduleFor(
         })
       );
 
-      this.addTemplate('common', '{{prefix}} {{@model}}');
+      this.addTemplate('common', '{{this.prefix}} {{@model}}');
 
       return this.visit('/a')
         .then(() => {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
@@ -84,7 +84,7 @@ moduleFor(
 
     '@test it can render a basic component with template and javascript'() {
       this.registerComponent('foo-bar', {
-        template: 'FIZZ BAR {{local}}',
+        template: 'FIZZ BAR {{this.local}}',
         ComponentClass: Component.extend({ local: 'hey' }),
       });
 
@@ -120,9 +120,9 @@ moduleFor(
     }
 
     '@test it can have a custom id and it is not bound'() {
-      this.registerComponent('foo-bar', { template: '{{id}} {{elementId}}' });
+      this.registerComponent('foo-bar', { template: '{{this.id}} {{this.elementId}}' });
 
-      this.render('<FooBar @id={{customId}} />', {
+      this.render('<FooBar @id={{this.customId}} />', {
         customId: 'bizz',
       });
 
@@ -154,7 +154,7 @@ moduleFor(
     '@test it can have a custom id attribute and it is bound'() {
       this.registerComponent('foo-bar', { template: 'hello' });
 
-      this.render('<FooBar id={{customId}} />', {
+      this.render('<FooBar id={{this.customId}} />', {
         customId: 'bizz',
       });
 
@@ -256,7 +256,7 @@ moduleFor(
     '@test class property on components can be dynamic'() {
       this.registerComponent('foo-bar', { template: 'hello' });
 
-      this.render('<FooBar @class={{if fooBar "foo-bar"}} />', {
+      this.render('<FooBar @class={{if this.fooBar "foo-bar"}} />', {
         fooBar: true,
       });
 
@@ -441,7 +441,7 @@ moduleFor(
 
     '@test it reflects named arguments as properties'() {
       this.registerComponent('foo-bar', {
-        template: '{{foo}}',
+        template: '{{this.foo}}',
       });
 
       this.render('<FooBar @foo={{this.model.bar}} />', {
@@ -496,11 +496,11 @@ moduleFor(
 
       this.registerComponent('foo-bar', {
         ComponentClass: FooBarComponent,
-        template: '{{yield greeting greetee.firstName}}',
+        template: '{{yield this.greeting this.greetee.firstName}}',
       });
 
       this.render(
-        '<FooBar @greetee={{person}} as |greeting name|>{{name}} {{person.lastName}}, {{greeting}}</FooBar>',
+        '<FooBar @greetee={{this.person}} as |greeting name|>{{name}} {{this.person.lastName}}, {{greeting}}</FooBar>',
         {
           person: {
             firstName: 'Joel',
@@ -554,7 +554,7 @@ moduleFor(
         ComponentClass: Component.extend().reopenClass({
           positionalParams: ['first', 'second'],
         }),
-        template: '{{first}}{{second}}',
+        template: '{{this.first}}{{this.second}}',
       });
 
       // this is somewhat silly as the browser "corrects" for these as
@@ -646,7 +646,10 @@ moduleFor(
         template: 'hello',
       });
 
-      this.render('<FooBar data-foo={{foo}} data-bar={{bar}} />', { foo: 'foo', bar: 'bar' });
+      this.render('<FooBar data-foo={{this.foo}} data-bar={{this.bar}} />', {
+        foo: 'foo',
+        bar: 'bar',
+      });
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -725,7 +728,7 @@ moduleFor(
         template: '<div ...attributes>hello</div>',
       });
 
-      this.render('<FooBar data-foo={{foo}} data-bar={{bar}} />', { foo: 'foo', bar: 'bar' });
+      this.render('<FooBar data-foo={{this.foo}} data-bar={{this.bar}} />', { foo: 'foo', bar: 'bar' });
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -775,10 +778,10 @@ moduleFor(
             this.localProp = 'qux';
           },
         }),
-        template: '<div data-derp={{localProp}} ...attributes>hello</div>',
+        template: '<div data-derp={{this.localProp}} ...attributes>hello</div>',
       });
 
-      this.render('<FooBar data-foo={{foo}} data-bar={{bar}} />', { foo: 'foo', bar: 'bar' });
+      this.render('<FooBar data-foo={{this.foo}} data-bar={{this.bar}} />', { foo: 'foo', bar: 'bar' });
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -830,10 +833,10 @@ moduleFor(
             this.localProp = 'qux';
           },
         }),
-        template: '<div class={{localProp}} ...attributes>hello</div>',
+        template: '<div class={{this.localProp}} ...attributes>hello</div>',
       });
 
-      this.render('<FooBar class={{bar}} />', { bar: 'bar' });
+      this.render('<FooBar class={{this.bar}} />', { bar: 'bar' });
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -883,10 +886,10 @@ moduleFor(
             this.localProp = 'qux';
           },
         }),
-        template: '<div ...attributes class={{localProp}}>hello</div>',
+        template: '<div ...attributes class={{this.localProp}}>hello</div>',
       });
 
-      this.render('<FooBar class={{bar}} />', { bar: 'bar' });
+      this.render('<FooBar class={{this.bar}} />', { bar: 'bar' });
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1052,7 +1055,7 @@ moduleFor(
         template: '<div ...attributes>hello</div><p ...attributes>world</p>',
       });
 
-      this.render('<FooBar data-foo={{foo}} data-bar={{bar}} />', { foo: 'foo', bar: 'bar' });
+      this.render('<FooBar data-foo={{this.foo}} data-bar={{this.bar}} />', { foo: 'foo', bar: 'bar' });
 
       this.assertElement(this.firstChild, {
         tagName: 'div',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
@@ -728,7 +728,10 @@ moduleFor(
         template: '<div ...attributes>hello</div>',
       });
 
-      this.render('<FooBar data-foo={{this.foo}} data-bar={{this.bar}} />', { foo: 'foo', bar: 'bar' });
+      this.render('<FooBar data-foo={{this.foo}} data-bar={{this.bar}} />', {
+        foo: 'foo',
+        bar: 'bar',
+      });
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -781,7 +784,10 @@ moduleFor(
         template: '<div data-derp={{this.localProp}} ...attributes>hello</div>',
       });
 
-      this.render('<FooBar data-foo={{this.foo}} data-bar={{this.bar}} />', { foo: 'foo', bar: 'bar' });
+      this.render('<FooBar data-foo={{this.foo}} data-bar={{this.bar}} />', {
+        foo: 'foo',
+        bar: 'bar',
+      });
 
       this.assertElement(this.firstChild, {
         tagName: 'div',
@@ -1055,7 +1061,10 @@ moduleFor(
         template: '<div ...attributes>hello</div><p ...attributes>world</p>',
       });
 
-      this.render('<FooBar data-foo={{this.foo}} data-bar={{this.bar}} />', { foo: 'foo', bar: 'bar' });
+      this.render('<FooBar data-foo={{this.foo}} data-bar={{this.bar}} />', {
+        foo: 'foo',
+        bar: 'bar',
+      });
 
       this.assertElement(this.firstChild, {
         tagName: 'div',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/append-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/append-test.js
@@ -121,7 +121,8 @@ class AbstractAppendTest extends RenderingTestCase {
         layoutName: 'components/x-parent',
       }),
 
-      template: '[parent: {{foo}}]{{#x-child bar=foo}}[yielded: {{foo}}]{{/x-child}}',
+      template:
+        '[parent: {{this.foo}}]{{#x-child bar=this.foo}}[yielded: {{this.foo}}]{{/x-child}}',
     });
 
     this.registerComponent('x-child', {
@@ -129,7 +130,7 @@ class AbstractAppendTest extends RenderingTestCase {
         tagName: '',
       }),
 
-      template: '[child: {{bar}}]{{yield}}',
+      template: '[child: {{this.bar}}]{{yield}}',
     });
 
     let XParent;
@@ -293,7 +294,7 @@ class AbstractAppendTest extends RenderingTestCase {
         },
       }),
 
-      template: '[parent: {{foo}}]{{#x-child bar=foo}}[yielded: {{foo}}]{{/x-child}}',
+      template: '[parent: {{this.foo}}]{{#x-child bar=this.foo}}[yielded: {{this.foo}}]{{/x-child}}',
     });
 
     this.registerComponent('x-child', {
@@ -301,7 +302,7 @@ class AbstractAppendTest extends RenderingTestCase {
         tagName: '',
       }),
 
-      template: '[child: {{bar}}]{{yield}}',
+      template: '[child: {{this.bar}}]{{yield}}',
     });
 
     let XParent;
@@ -399,7 +400,7 @@ class AbstractAppendTest extends RenderingTestCase {
         },
       }),
 
-      template: 'x-first {{foo}}!',
+      template: 'x-first {{this.foo}}!',
     });
 
     this.registerComponent('x-second', {
@@ -411,7 +412,7 @@ class AbstractAppendTest extends RenderingTestCase {
         },
       }),
 
-      template: 'x-second {{bar}}!',
+      template: 'x-second {{this.bar}}!',
     });
 
     let First, Second;
@@ -630,7 +631,7 @@ class AbstractAppendTest extends RenderingTestCase {
     let destroyedRoots = 0;
     this.registerComponent('other-root', {
       ComponentClass: Component.extend({
-        layout: compile(`fake-thing: {{counter}}`),
+        layout: compile(`fake-thing: {{this.counter}}`),
         init() {
           this._super(...arguments);
           this.counter = instantiatedRoots++;
@@ -644,7 +645,7 @@ class AbstractAppendTest extends RenderingTestCase {
 
     this.render(
       strip`
-      {{#if showFooBar}}
+      {{#if this.showFooBar}}
         {{foo-bar}}
       {{else}}
         {{baz-qux}}

--- a/packages/@ember/-internals/glimmer/tests/integration/components/append-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/append-test.js
@@ -294,7 +294,8 @@ class AbstractAppendTest extends RenderingTestCase {
         },
       }),
 
-      template: '[parent: {{this.foo}}]{{#x-child bar=this.foo}}[yielded: {{this.foo}}]{{/x-child}}',
+      template:
+        '[parent: {{this.foo}}]{{#x-child bar=this.foo}}[yielded: {{this.foo}}]{{/x-child}}',
     });
 
     this.registerComponent('x-child', {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/attribute-bindings-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/attribute-bindings-test.js
@@ -17,7 +17,7 @@ moduleFor(
         template: 'hello',
       });
 
-      this.render('{{foo-bar foo=foo bar=bar}}', { foo: 'foo', bar: 'bar' });
+      this.render('{{foo-bar foo=this.foo bar=this.bar}}', { foo: 'foo', bar: 'bar' });
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -119,7 +119,7 @@ moduleFor(
         template: 'hello',
       });
 
-      this.render('{{foo-bar foo=foo}}', { foo: { bar: 'foo-bar' } });
+      this.render('{{foo-bar foo=this.foo}}', { foo: { bar: 'foo-bar' } });
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',
@@ -178,7 +178,7 @@ moduleFor(
         template: 'hello',
       });
 
-      this.render('{{foo-bar type=submit}}', {
+      this.render('{{foo-bar type=this.submit}}', {
         submit: 'submit',
       });
 
@@ -232,7 +232,7 @@ moduleFor(
       });
 
       expectAssertion(() => {
-        this.render('{{foo-bar foo=foo}}', { foo: { bar: 'foo-bar' } });
+        this.render('{{foo-bar foo=this.foo}}', { foo: { bar: 'foo-bar' } });
       }, /Illegal attributeBinding: 'foo.bar' is not a valid attribute name./);
     }
 
@@ -246,7 +246,7 @@ moduleFor(
         template: 'hello',
       });
 
-      this.render('{{foo-bar tiTLe=name}}', {
+      this.render('{{foo-bar tiTLe=this.name}}', {
         name: 'qux',
       });
 
@@ -285,7 +285,7 @@ moduleFor(
         template: 'hello',
       });
 
-      this.render('{{foo-bar foo=foo}}', {
+      this.render('{{foo-bar foo=this.foo}}', {
         foo: 'qux',
       });
 
@@ -325,7 +325,7 @@ moduleFor(
         template: '',
       });
 
-      this.render('{{foo-bar viewBox=foo}}', {
+      this.render('{{foo-bar viewBox=this.foo}}', {
         foo: '0 0 100 100',
       });
 
@@ -360,7 +360,7 @@ moduleFor(
         template: 'hello',
       });
 
-      this.render('{{foo-bar fizz=fizz bar=bar}}', {
+      this.render('{{foo-bar fizz=this.fizz bar=this.bar}}', {
         fizz: null,
         bar: undefined,
       });
@@ -412,7 +412,7 @@ moduleFor(
         template: 'hello',
       });
 
-      this.render('{{foo-bar size=size}}', {
+      this.render('{{foo-bar size=this.size}}', {
         size: 21,
       });
 
@@ -504,7 +504,7 @@ moduleFor(
 
       this.registerComponent('foo-bar', { ComponentClass: FooBarComponent });
 
-      this.render('{{foo-bar type=type isDisabled=disabled}}', {
+      this.render('{{foo-bar type=this.type isDisabled=this.disabled}}', {
         type: 'password',
         disabled: false,
       });
@@ -549,7 +549,7 @@ moduleFor(
 
       this.registerComponent('foo-bar', { ComponentClass: FooBarComponent });
 
-      this.render('{{foo-bar type=type xlinkHref=xlinkHref}}', {
+      this.render('{{foo-bar type=this.type xlinkHref=this.xlinkHref}}', {
         xlinkHref: '/foo.png',
       });
 
@@ -590,7 +590,7 @@ moduleFor(
 
       this.registerComponent('foo-bar', { ComponentClass: FooBarComponent });
 
-      this.render('{{foo-bar foo=foo}}', {
+      this.render('{{foo-bar foo=this.foo}}', {
         foo: function () {
           return this;
         }.call('bar'),
@@ -646,7 +646,7 @@ moduleFor(
 
       this.registerComponent('foo-bar', { ComponentClass: FooBarComponent });
 
-      this.render('{{foo-bar specialSauce=sauce}}', {
+      this.render('{{foo-bar specialSauce=this.sauce}}', {
         sauce: 'special-sauce',
       });
 
@@ -689,7 +689,7 @@ moduleFor(
 
       this.registerComponent('fizz-bar', { ComponentClass: FizzBarComponent });
 
-      this.render('{{fizz-bar newHref=href}}', {
+      this.render('{{fizz-bar newHref=this.href}}', {
         href: 'dog.html',
       });
 
@@ -739,10 +739,10 @@ moduleFor(
 
       this.render(
         strip`
-      {{foo-bar hasFoo=true foo=foo hasBar=false bar=bar}}
-      {{foo-bar hasFoo=false foo=foo hasBar=true bar=bar}}
-      {{foo-bar hasFoo=true foo=foo hasBar=true bar=bar}}
-      {{foo-bar hasFoo=false foo=foo hasBar=false bar=bar}}
+      {{foo-bar hasFoo=true foo=this.foo hasBar=false bar=this.bar}}
+      {{foo-bar hasFoo=false foo=this.foo hasBar=true bar=this.bar}}
+      {{foo-bar hasFoo=true foo=this.foo hasBar=true bar=this.bar}}
+      {{foo-bar hasFoo=false foo=this.foo hasBar=false bar=this.bar}}
     `,
         { foo: 'foo', bar: 'bar' }
       );
@@ -893,7 +893,7 @@ moduleFor(
         template: 'hello',
       });
 
-      this.render('{{foo-bar href=xss}}', {
+      this.render('{{foo-bar href=this.xss}}', {
         xss: "javascript:alert('foo')",
       });
 
@@ -911,7 +911,7 @@ moduleFor(
         template: 'hello',
       });
 
-      this.render('{{foo-bar role=role}}', { role: 'button' });
+      this.render('{{foo-bar role=this.role}}', { role: 'button' });
 
       this.assertComponentElement(this.firstChild, {
         tagName: 'div',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/attrs-lookup-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/attrs-lookup-test.js
@@ -8,9 +8,9 @@ moduleFor(
   'Components test: attrs lookup',
   class extends RenderingTestCase {
     ['@test it should be able to lookup attrs without `attrs.` - template access']() {
-      this.registerComponent('foo-bar', { template: '{{first}}' });
+      this.registerComponent('foo-bar', { template: '{{this.first}}' });
 
-      this.render(`{{foo-bar first=firstAttr}}`, {
+      this.render(`{{foo-bar first=this.firstAttr}}`, {
         firstAttr: 'first attr',
       });
 
@@ -40,10 +40,10 @@ moduleFor(
       });
       this.registerComponent('foo-bar', {
         ComponentClass: FooBarComponent,
-        template: '{{first}}',
+        template: '{{this.first}}',
       });
 
-      this.render(`{{foo-bar first=firstAttr}}`, {
+      this.render(`{{foo-bar first=this.firstAttr}}`, {
         firstAttr: 'first attr',
       });
 
@@ -76,7 +76,7 @@ moduleFor(
       });
       this.registerComponent('foo-bar', {
         ComponentClass: FooBarComponent,
-        template: '{{first}}',
+        template: '{{this.first}}',
       });
 
       this.render(`{{foo-bar first="first attr"}}`);
@@ -113,7 +113,7 @@ moduleFor(
       });
       this.registerComponent('foo-bar', { ComponentClass: FooBarComponent });
 
-      this.render(`{{foo-bar woot=woot}}`, {
+      this.render(`{{foo-bar woot=this.woot}}`, {
         woot: wootVal,
       });
 
@@ -172,7 +172,7 @@ moduleFor(
 
       this.registerComponent('foo-bar', { ComponentClass: FooBarComponent });
 
-      this.render(`{{foo-bar firstPositional first=first second=second}}`, {
+      this.render(`{{foo-bar this.firstPositional first=this.first second=this.second}}`, {
         firstPositional: 'firstPositional',
         first: 'first',
         second: 'second',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/class-bindings-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/class-bindings-test.js
@@ -17,7 +17,7 @@ moduleFor(
         template: 'hello',
       });
 
-      this.render('{{foo-bar foo=foo isEnabled=isEnabled isHappy=isHappy}}', {
+      this.render('{{foo-bar foo=this.foo isEnabled=this.isEnabled isHappy=this.isHappy}}', {
         foo: 'foo',
         isEnabled: true,
         isHappy: false,
@@ -207,7 +207,7 @@ moduleFor(
         template: 'hello',
       });
 
-      this.render('{{foo-bar foo=foo is=is}}', {
+      this.render('{{foo-bar foo=this.foo is=this.is}}', {
         foo: { bar: 'foo-bar' },
         is: { enabled: true, happy: false },
       });
@@ -281,7 +281,7 @@ moduleFor(
         template: 'hello',
       });
 
-      this.render('{{foo-bar fooBar=fooBar nested=nested}}', {
+      this.render('{{foo-bar fooBar=this.fooBar nested=this.nested}}', {
         fooBar: true,
         nested: { fooBarBaz: false },
       });
@@ -389,7 +389,7 @@ moduleFor(
         template: 'hello',
       });
 
-      this.render('{{foo-bar isEnabled=enabled}}', {
+      this.render('{{foo-bar isEnabled=this.enabled}}', {
         enabled: false,
       });
 
@@ -520,10 +520,10 @@ moduleFor(
 
       this.render(
         strip`
-      {{foo-bar foo=foo bindIsEnabled=true isEnabled=isEnabled bindIsHappy=false isHappy=isHappy}}
-      {{foo-bar foo=foo bindIsEnabled=false isEnabled=isEnabled bindIsHappy=true isHappy=isHappy}}
-      {{foo-bar foo=foo bindIsEnabled=true isEnabled=isEnabled bindIsHappy=true isHappy=isHappy}}
-      {{foo-bar foo=foo bindIsEnabled=false isEnabled=isEnabled bindIsHappy=false isHappy=isHappy}}
+      {{foo-bar foo=this.foo bindIsEnabled=true isEnabled=this.isEnabled bindIsHappy=false isHappy=this.isHappy}}
+      {{foo-bar foo=this.foo bindIsEnabled=false isEnabled=this.isEnabled bindIsHappy=true isHappy=this.isHappy}}
+      {{foo-bar foo=this.foo bindIsEnabled=true isEnabled=this.isEnabled bindIsHappy=true isHappy=this.isHappy}}
+      {{foo-bar foo=this.foo bindIsEnabled=false isEnabled=this.isEnabled bindIsHappy=false isHappy=this.isHappy}}
     `,
         { foo: 'foo', isEnabled: true, isHappy: false }
       );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
@@ -31,7 +31,7 @@ moduleFor(
         ComponentClass: Component.extend().reopenClass({
           positionalParams: ['name'],
         }),
-        template: '{{greeting}} {{name}}',
+        template: '{{this.greeting}} {{this.name}}',
       });
 
       this.render(strip`
@@ -49,7 +49,7 @@ moduleFor(
         ComponentClass: Component.extend().reopenClass({
           positionalParams: 'params',
         }),
-        template: '{{#each params as |p|}}{{p}}{{/each}}',
+        template: '{{#each this.params as |p|}}{{p}}{{/each}}',
       });
 
       this.render('{{component (component "-looked-up" this.model.greeting this.model.name)}}', {
@@ -84,7 +84,7 @@ moduleFor(
         ComponentClass: Component.extend().reopenClass({
           positionalParams: 'params',
         }),
-        template: '{{#each params as |p|}}{{p}}{{/each}}',
+        template: '{{#each this.params as |p|}}{{p}}{{/each}}',
       });
 
       this.render(
@@ -121,7 +121,7 @@ moduleFor(
         ComponentClass: Component.extend().reopenClass({
           positionalParams: 'params',
         }),
-        template: '{{#each params as |p|}}{{p}}{{/each}}',
+        template: '{{#each this.params as |p|}}{{p}}{{/each}}',
       });
 
       this.render(
@@ -158,7 +158,7 @@ moduleFor(
         ComponentClass: Component.extend().reopenClass({
           positionalParams: 'params',
         }),
-        template: '{{#each params as |p|}}{{p}}{{/each}}',
+        template: '{{#each this.params as |p|}}{{p}}{{/each}}',
       });
 
       this.render(
@@ -195,7 +195,7 @@ moduleFor(
         ComponentClass: Component.extend().reopenClass({
           positionalParams: ['name'],
         }),
-        template: '{{greeting}} {{name}}',
+        template: '{{this.greeting}} {{this.name}}',
       });
 
       this.render(strip`
@@ -241,7 +241,7 @@ moduleFor(
 
     ['@test updates when curried hash argument is bound']() {
       this.registerComponent('-looked-up', {
-        template: '{{greeting}}',
+        template: '{{this.greeting}}',
       });
 
       this.render(`{{component (component "-looked-up" greeting=this.model.greeting)}}`, {
@@ -267,7 +267,7 @@ moduleFor(
 
     ['@test updates when curried hash arguments is bound in block form']() {
       this.registerComponent('-looked-up', {
-        template: '{{greeting}}',
+        template: '{{this.greeting}}',
       });
 
       this.render(
@@ -302,7 +302,7 @@ moduleFor(
         ComponentClass: Component.extend().reopenClass({
           positionalParams: ['name', 'age'],
         }),
-        template: '{{name}} {{age}}',
+        template: '{{this.name}} {{this.age}}',
       });
 
       this.render(
@@ -321,7 +321,7 @@ moduleFor(
         ComponentClass: Component.extend().reopenClass({
           positionalParams: ['greeting', 'name', 'age'],
         }),
-        template: '{{greeting}} {{name}} {{age}}',
+        template: '{{this.greeting}} {{this.name}} {{this.age}}',
       });
 
       this.render('{{component (component (component "-looked-up" "Hi") "Max") 9}}');
@@ -335,7 +335,7 @@ moduleFor(
 
     ['@test nested components overwrite hash parameters']() {
       this.registerComponent('-looked-up', {
-        template: '{{greeting}} {{name}} {{age}}',
+        template: '{{this.greeting}} {{this.name}} {{this.age}}',
       });
 
       this.render(
@@ -372,14 +372,14 @@ moduleFor(
         ComponentClass: Component.extend().reopenClass({
           positionalParams: ['comp'],
         }),
-        template: '{{component comp "Inner"}}',
+        template: '{{component this.comp "Inner"}}',
       });
 
       this.registerComponent('-looked-up', {
         ComponentClass: Component.extend().reopenClass({
           positionalParams: ['name', 'age'],
         }),
-        template: '{{name}} {{age}}',
+        template: '{{this.name}} {{this.age}}',
       });
 
       this.render(
@@ -421,11 +421,11 @@ moduleFor(
         ComponentClass: Component.extend().reopenClass({
           positionalParams: ['comp'],
         }),
-        template: '{{component comp name="Inner"}}',
+        template: '{{component this.comp name="Inner"}}',
       });
 
       this.registerComponent('-looked-up', {
-        template: '{{name}} {{age}}',
+        template: '{{this.name}} {{this.age}}',
       });
 
       this.render(
@@ -469,7 +469,7 @@ moduleFor(
         ComponentClass: Component.extend().reopenClass({
           positionalParams: ['name'],
         }),
-        template: '{{greeting}} {{name}}',
+        template: '{{this.greeting}} {{this.name}}',
       });
 
       this.render('{{component (component "-looked-up" this.model.name greeting="Hodi")}}', {
@@ -494,9 +494,9 @@ moduleFor(
     }
 
     ['@test component with dynamic component name resolving to undefined, then an existing component']() {
-      this.registerComponent('foo-bar', { template: 'hello {{name}}' });
+      this.registerComponent('foo-bar', { template: 'hello {{this.name}}' });
 
-      this.render('{{component (component componentName name=name)}}', {
+      this.render('{{component (component this.componentName name=this.name)}}', {
         componentName: undefined,
         name: 'Alex',
       });
@@ -517,9 +517,9 @@ moduleFor(
     }
 
     ['@test component with dynamic component name resolving to a component, then undefined']() {
-      this.registerComponent('foo-bar', { template: 'hello {{name}}' });
+      this.registerComponent('foo-bar', { template: 'hello {{this.name}}' });
 
-      this.render('{{component (component componentName name=name)}}', {
+      this.render('{{component (component this.componentName name=this.name)}}', {
         componentName: 'foo-bar',
         name: 'Alex',
       });
@@ -540,9 +540,9 @@ moduleFor(
     }
 
     ['@test component with dynamic component name resolving to null, then an existing component']() {
-      this.registerComponent('foo-bar', { template: 'hello {{name}}' });
+      this.registerComponent('foo-bar', { template: 'hello {{this.name}}' });
 
-      this.render('{{component (component componentName name=name)}}', {
+      this.render('{{component (component this.componentName name=this.name)}}', {
         componentName: null,
         name: 'Alex',
       });
@@ -563,9 +563,9 @@ moduleFor(
     }
 
     ['@test component with dynamic component name resolving to a component, then null']() {
-      this.registerComponent('foo-bar', { template: 'hello {{name}}' });
+      this.registerComponent('foo-bar', { template: 'hello {{this.name}}' });
 
-      this.render('{{component (component componentName name=name)}}', {
+      this.render('{{component (component this.componentName name=this.name)}}', {
         componentName: 'foo-bar',
         name: 'Alex',
       });
@@ -603,7 +603,7 @@ moduleFor(
       }
 
       assert.throws(() => {
-        this.render('{{component (component compName)}}', {
+        this.render('{{component (component this.compName)}}', {
           compName: 'not-a-component',
         });
       }, 'Could not find component named "not-a-component" (no component or template with that name was found)');
@@ -630,7 +630,7 @@ moduleFor(
     ['@test renders with dot path and attr']() {
       let expectedText = 'Hodi';
       this.registerComponent('-looked-up', {
-        template: '{{expectedText}}',
+        template: '{{this.expectedText}}',
       });
 
       this.render(
@@ -663,7 +663,7 @@ moduleFor(
     ['@test renders with dot path and curried over attr']() {
       let expectedText = 'Hodi';
       this.registerComponent('-looked-up', {
-        template: '{{expectedText}}',
+        template: '{{this.expectedText}}',
       });
 
       this.render(
@@ -698,7 +698,7 @@ moduleFor(
         ComponentClass: Component.extend().reopenClass({
           positionalParams: 'params',
         }),
-        template: '{{params}}',
+        template: '{{this.params}}',
       });
 
       let expectedText = 'Hodi';
@@ -748,7 +748,7 @@ moduleFor(
 
       this.render(
         strip`
-      {{#let (hash my-component=(component 'my-component' first)) as |c|}}
+      {{#let (hash my-component=(component 'my-component' this.first)) as |c|}}
         {{c.my-component}}
       {{/let}}`,
         { first: 'first' }
@@ -764,12 +764,12 @@ moduleFor(
             this.set('myProp', this.getAttr('my-parent-attr'));
           },
         }),
-        template: '<span id="nested-prop">{{myProp}}</span>',
+        template: '<span id="nested-prop">{{this.myProp}}</span>',
       });
 
       this.registerComponent('my-component', {
         template:
-          '{{yield (hash my-nested-component=(component "my-nested-component" my-parent-attr=my-attr))}}',
+          '{{yield (hash my-nested-component=(component "my-nested-component" my-parent-attr=this.my-attr))}}',
       });
 
       this.registerComponent('my-action-component', {
@@ -781,7 +781,7 @@ moduleFor(
           },
         }),
         template: strip`
-        {{#my-component my-attr=myProp as |api|}}
+        {{#my-component my-attr=this.myProp as |api|}}
           {{api.my-nested-component}}
         {{/my-component}}
         <br>
@@ -821,7 +821,7 @@ moduleFor(
       });
 
       this.registerComponent('select-box-option', {
-        template: '{{label}}',
+        template: '{{this.label}}',
       });
 
       this.render(strip`
@@ -846,7 +846,7 @@ moduleFor(
           positionalParams: ['val'],
         }),
         template: strip`
-        <button {{action (action (mut val) 10)}} class="my-button">
+        <button {{action (action (mut this.val) 10)}} class="my-button">
           Change to 10
         </button>`,
       });
@@ -900,7 +900,7 @@ moduleFor(
           },
         }),
         template: strip`
-        message: {{message}}{{inner-component message=message}}
+        message: {{this.message}}{{inner-component message=this.message}}
         <button onclick={{action "change"}} />`,
       });
 
@@ -941,12 +941,12 @@ moduleFor(
           },
           isOpen: undefined,
         }),
-        template: '{{if isOpen "open" "closed"}}',
+        template: '{{if this.isOpen "open" "closed"}}',
       });
 
       this.render(
         strip`
-      {{#let (hash ctxCmp=(component "my-comp" isOpen=isOpen)) as |thing|}}
+      {{#let (hash ctxCmp=(component "my-comp" isOpen=this.isOpen)) as |thing|}}
         {{#thing.ctxCmp}}This is a contextual component{{/thing.ctxCmp}}
       {{/let}}
     `,
@@ -1005,12 +1005,12 @@ moduleFor(
           },
           isOpen: undefined,
         }),
-        template: '{{if isOpen "open" "closed"}}',
+        template: '{{if this.isOpen "open" "closed"}}',
       });
 
       this.render(
         strip`
-      {{#let (hash ctxCmp=(component compName isOpen=isOpen)) as |thing|}}
+      {{#let (hash ctxCmp=(component this.compName isOpen=this.isOpen)) as |thing|}}
         {{#thing.ctxCmp}}This is a contextual component{{/thing.ctxCmp}}
       {{/let}}
     `,
@@ -1070,7 +1070,7 @@ moduleFor(
           },
           isOpen: undefined,
         }),
-        template: 'my-comp: {{if isOpen "open" "closed"}}',
+        template: 'my-comp: {{if this.isOpen "open" "closed"}}',
       });
 
       this.registerComponent('your-comp', {
@@ -1083,12 +1083,12 @@ moduleFor(
           },
           isOpen: undefined,
         }),
-        template: 'your-comp: {{if isOpen "open" "closed"}}',
+        template: 'your-comp: {{if this.isOpen "open" "closed"}}',
       });
 
       this.render(
         strip`
-      {{#let (hash ctxCmp=(component compName isOpen=isOpen)) as |thing|}}
+      {{#let (hash ctxCmp=(component this.compName isOpen=this.isOpen)) as |thing|}}
         {{#thing.ctxCmp}}This is a contextual component{{/thing.ctxCmp}}
       {{/let}}
     `,
@@ -1155,10 +1155,10 @@ moduleFor(
         ComponentClass: Component.extend().reopenClass({
           positionalParams: 'params',
         }),
-        template: '{{#each params as |p|}}{{p}}{{/each}}',
+        template: '{{#each this.params as |p|}}{{p}}{{/each}}',
       });
 
-      this.render('{{component (component "my-link") params=allParams}}', {
+      this.render('{{component (component "my-link") params=this.allParams}}', {
         allParams: emberA(['a', 'b']),
       });
 
@@ -1194,11 +1194,11 @@ moduleFor(
         ComponentClass: Component.extend().reopenClass({
           positionalParams: 'params',
         }),
-        template: '{{#each params as |p|}}{{p}}{{/each}}',
+        template: '{{#each this.params as |p|}}{{p}}{{/each}}',
       });
 
       this.render(
-        '{{#let (hash link=(component "my-link")) as |c|}}{{c.link params=allParams}}{{/let}}',
+        '{{#let (hash link=(component "my-link")) as |c|}}{{c.link params=this.allParams}}{{/let}}',
         {
           allParams: emberA(['a', 'b']),
         }
@@ -1232,7 +1232,7 @@ moduleFor(
     }
 
     ['@test it can invoke input component']() {
-      this.render('{{component (component "input" type="text" value=value)}}', {
+      this.render('{{component (component "input" type="text" value=this.value)}}', {
         value: 'foo',
       });
 
@@ -1258,7 +1258,7 @@ moduleFor(
     }
 
     ['@test it can invoke textarea component']() {
-      this.render('{{component (component "textarea" value=value)}}', {
+      this.render('{{component (component "textarea" value=this.value)}}', {
         value: 'foo',
       });
 
@@ -1305,7 +1305,7 @@ moduleFor(
         ComponentClass: Component.extend().reopenClass({
           positionalParams: 'params',
         }),
-        template: 'foo-bar component:{{#each params as |param|}} {{param}}{{/each}}',
+        template: 'foo-bar component:{{#each this.params as |param|}} {{param}}{{/each}}',
       });
 
       this.render(strip`
@@ -1337,7 +1337,7 @@ moduleFor(
         ComponentClass: Component.extend().reopenClass({
           positionalParams: 'params',
         }),
-        template: 'inner:{{#each params as |param|}} {{param}}{{/each}}',
+        template: 'inner:{{#each this.params as |param|}} {{param}}{{/each}}',
       });
 
       this.render('{{x-outer inner=(component "x-inner")}}');
@@ -1448,7 +1448,7 @@ class MutableParamTestGenerator {
             positionalParams: ['val'],
           }),
           template: strip`
-          <button {{action (action (mut val) 10)}} class="my-button">
+          <button {{action (action (mut this.val) 10)}} class="my-button">
             Change to 10
           </button>`,
         });
@@ -1490,7 +1490,7 @@ applyMixins(
           ComponentClass: Component.extend().reopenClass({
             positionalParams: ['components'],
           }),
-          template: '{{component components.comp}}',
+          template: '{{component this.components.comp}}',
         });
 
         this.render('{{my-comp (hash comp=(component "change-button" this.model.val2))}}');
@@ -1512,7 +1512,7 @@ applyMixins(
       title: 'nested hash value',
       setup() {
         this.registerComponent('my-comp', {
-          template: '{{component components.button}}',
+          template: '{{component this.components.button}}',
         });
 
         this.render(

--- a/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
@@ -3819,7 +3819,10 @@ moduleFor(
         template: '{{this.baz}}',
       });
 
-      this.render('{{#if this.cond}}{{foo-bar baz=this.value}}{{/if}}', { cond: true, value: 'hello' });
+      this.render('{{#if this.cond}}{{foo-bar baz=this.value}}{{/if}}', {
+        cond: true,
+        value: 'hello',
+      });
 
       this.assertComponentElement(this.firstChild, { content: 'hello' });
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
@@ -36,9 +36,9 @@ moduleFor(
     }
 
     ['@test it can have a custom id and it is not bound']() {
-      this.registerComponent('foo-bar', { template: '{{id}} {{elementId}}' });
+      this.registerComponent('foo-bar', { template: '{{this.id}} {{this.elementId}}' });
 
-      this.render('{{foo-bar id=customId}}', {
+      this.render('{{foo-bar id=this.customId}}', {
         customId: 'bizz',
       });
 
@@ -85,7 +85,7 @@ moduleFor(
 
       this.registerComponent('foo-bar', {
         ComponentClass: FooBarComponent,
-        template: '{{elementId}}',
+        template: '{{this.elementId}}',
       });
 
       this.render('{{foo-bar}}');
@@ -125,7 +125,7 @@ moduleFor(
 
       this.registerComponent('quux-baz', {
         ComponentClass: Component.extend({}),
-        template: '{{changingArg}}',
+        template: '{{this.changingArg}}',
       });
 
       this.render('{{foo-bar}}');
@@ -152,7 +152,7 @@ moduleFor(
         },
       });
 
-      this.registerTemplate('fizz-bar', `FIZZ BAR {{local}}`);
+      this.registerTemplate('fizz-bar', `FIZZ BAR {{this.local}}`);
 
       this.registerComponent('foo-bar', { ComponentClass: FooBarComponent });
 
@@ -165,7 +165,7 @@ moduleFor(
       let FooBarComponent = Component.extend({
         elementId: 'blahzorz',
         layout: computed(function () {
-          return compile('so much layout wat {{lulz}}');
+          return compile('so much layout wat {{this.lulz}}');
         }),
         init() {
           this._super(...arguments);
@@ -190,7 +190,7 @@ moduleFor(
         template: 'something',
       });
 
-      this.render('{{foo-bar id=somethingUndefined}}');
+      this.render('{{foo-bar id=this.somethingUndefined}}');
 
       let foundId = this.$('h1').attr('id');
       assert.ok(
@@ -376,7 +376,7 @@ moduleFor(
     ['@test should not apply falsy class name']() {
       this.registerComponent('foo-bar', { template: 'hello' });
 
-      this.render('{{foo-bar class=somethingFalsy}}', {
+      this.render('{{foo-bar class=this.somethingFalsy}}', {
         somethingFalsy: false,
       });
 
@@ -398,7 +398,7 @@ moduleFor(
     ['@test should update class using inline if, initially false, no alternate']() {
       this.registerComponent('foo-bar', { template: 'hello' });
 
-      this.render('{{foo-bar class=(if predicate "thing") }}', {
+      this.render('{{foo-bar class=(if this.predicate "thing") }}', {
         predicate: false,
       });
 
@@ -430,7 +430,7 @@ moduleFor(
     ['@test should update class using inline if, initially true, no alternate']() {
       this.registerComponent('foo-bar', { template: 'hello' });
 
-      this.render('{{foo-bar class=(if predicate "thing") }}', {
+      this.render('{{foo-bar class=(if this.predicate "thing") }}', {
         predicate: true,
       });
 
@@ -462,7 +462,7 @@ moduleFor(
     ['@test class property on components can be dynamic']() {
       this.registerComponent('foo-bar', { template: 'hello' });
 
-      this.render('{{foo-bar class=(if fooBar "foo-bar")}}', {
+      this.render('{{foo-bar class=(if this.fooBar "foo-bar")}}', {
         fooBar: true,
       });
 
@@ -706,7 +706,7 @@ moduleFor(
 
     ['@test it reflects named arguments as properties']() {
       this.registerComponent('foo-bar', {
-        template: '{{foo}}',
+        template: '{{this.foo}}',
       });
 
       this.render('{{foo-bar foo=this.model.bar}}', {
@@ -805,7 +805,7 @@ moduleFor(
 
       this.registerComponent('foo-bar', {
         ComponentClass: FooBarComponent,
-        template: '{{message}}',
+        template: '{{this.message}}',
       });
 
       this.render('{{foo-bar}}');
@@ -828,7 +828,7 @@ moduleFor(
     ['@test it preserves the outer context when yielding']() {
       this.registerComponent('foo-bar', { template: '{{yield}}' });
 
-      this.render('{{#foo-bar}}{{message}}{{/foo-bar}}', { message: 'hello' });
+      this.render('{{#foo-bar}}{{this.message}}{{/foo-bar}}', { message: 'hello' });
 
       this.assertComponentElement(this.firstChild, { content: 'hello' });
 
@@ -890,11 +890,11 @@ moduleFor(
 
       this.registerComponent('foo-bar', {
         ComponentClass: FooBarComponent,
-        template: '{{yield greeting greetee.firstName}}',
+        template: '{{yield this.greeting this.greetee.firstName}}',
       });
 
       this.render(
-        '{{#foo-bar greetee=person as |greeting name|}}{{name}} {{person.lastName}}, {{greeting}}{{/foo-bar}}',
+        '{{#foo-bar greetee=this.person as |greeting name|}}{{name}} {{this.person.lastName}}, {{greeting}}{{/foo-bar}}',
         {
           person: {
             firstName: 'Joel',
@@ -955,7 +955,7 @@ moduleFor(
 
       this.registerComponent('foo-bar', {
         ComponentClass: FooBarComponent,
-        template: '{{danger}}{{yield danger}}',
+        template: '{{this.danger}}{{yield this.danger}}',
       });
 
       // On initial render, create streams. The bug will not have manifested yet, but at this point
@@ -987,7 +987,7 @@ moduleFor(
       let destroyed = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 0 };
 
       this.registerComponent('foo-bar', {
-        template: '{{id}} {{yield}}',
+        template: '{{this.id}} {{yield}}',
         ComponentClass: Component.extend({
           willDestroy() {
             this._super();
@@ -998,15 +998,15 @@ moduleFor(
 
       this.render(
         strip`
-      {{#if cond1}}
+      {{#if this.cond1}}
         {{#foo-bar id=1}}
-          {{#if cond2}}
+          {{#if this.cond2}}
             {{#foo-bar id=2}}{{/foo-bar}}
-            {{#if cond3}}
+            {{#if this.cond3}}
               {{#foo-bar id=3}}
-                {{#if cond4}}
+                {{#if this.cond4}}
                   {{#foo-bar id=4}}
-                    {{#if cond5}}
+                    {{#if this.cond5}}
                       {{#foo-bar id=5}}{{/foo-bar}}
                       {{#foo-bar id=6}}{{/foo-bar}}
                       {{#foo-bar id=7}}{{/foo-bar}}
@@ -1104,7 +1104,7 @@ moduleFor(
 
       this.registerComponent('foo-bar', {
         ComponentClass: FooBarComponent,
-        template: '{{output}}',
+        template: '{{this.output}}',
       });
 
       this.render('{{foo-bar}}');
@@ -1136,7 +1136,7 @@ moduleFor(
 
       this.registerComponent('foo-bar', {
         ComponentClass: FooBarComponent,
-        template: '{{{output}}}',
+        template: '{{{this.output}}}',
       });
 
       this.render('{{foo-bar}}');
@@ -1170,7 +1170,7 @@ moduleFor(
 
       this.registerComponent('foo-bar', {
         ComponentClass: FooBarComponent,
-        template: '{{output}}',
+        template: '{{this.output}}',
       });
 
       this.render('{{foo-bar}}');
@@ -1239,7 +1239,7 @@ moduleFor(
         ComponentClass: FooBarComponent,
 
         template: strip`
-        {{#if isStream}}
+        {{#if this.isStream}}
           true
         {{else}}
           false
@@ -1268,7 +1268,7 @@ moduleFor(
         template: 'some-component',
       });
 
-      this.render('{{some-prop}} {{some-component}}', {
+      this.render('{{this.some-prop}} {{some-component}}', {
         'some-component': 'not-some-component',
         'some-prop': 'some-prop',
       });
@@ -1307,7 +1307,7 @@ moduleFor(
         template: 'In layout - someProp: {{attrs.someProp}}',
       });
 
-      this.render('{{non-block someProp=prop}}', {
+      this.render('{{non-block someProp=this.prop}}', {
         prop: 'something here',
       });
 
@@ -1331,7 +1331,7 @@ moduleFor(
         template: 'In layout - someProp: {{@someProp}}',
       });
 
-      this.render('{{non-block someProp=prop}}', {
+      this.render('{{non-block someProp=this.prop}}', {
         prop: 'something here',
       });
 
@@ -1360,10 +1360,10 @@ moduleFor(
             this.someProp = 'value set in instance';
           },
         }),
-        template: 'In layout - someProp: {{someProp}}',
+        template: 'In layout - someProp: {{this.someProp}}',
       });
 
-      this.render('{{non-block someProp=prop}}', {
+      this.render('{{non-block someProp=this.prop}}', {
         prop: 'something passed when invoked',
       });
 
@@ -1420,11 +1420,11 @@ moduleFor(
             willUpdateCount++;
           },
         }),
-        template: 'In layout - someProp: {{someProp}}',
+        template: 'In layout - someProp: {{this.someProp}}',
       });
 
       expectHooks({ willUpdate: false, didReceiveAttrs: true }, () => {
-        this.render('{{non-block someProp=someProp}}', {
+        this.render('{{non-block someProp=this.someProp}}', {
           someProp: 'wycats',
         });
       });
@@ -1498,7 +1498,7 @@ moduleFor(
         `,
       });
 
-      this.render(`{{non-block counter=counter}}`, {
+      this.render(`{{non-block counter=this.counter}}`, {
         counter: 0,
       });
 
@@ -1514,7 +1514,7 @@ moduleFor(
     ['@test this.attrs.foo === attrs.foo === @foo === foo']() {
       this.registerComponent('foo-bar', {
         template: strip`
-        Args: {{this.attrs.value}} | {{attrs.value}} | {{@value}} | {{value}}
+        Args: {{this.attrs.value}} | {{attrs.value}} | {{@value}} | {{this.value}}
         {{#each this.attrs.items as |item|}}
           {{item}}
         {{/each}}
@@ -1524,7 +1524,7 @@ moduleFor(
         {{#each @items as |item|}}
           {{item}}
         {{/each}}
-        {{#each items as |item|}}
+        {{#each this.items as |item|}}
           {{item}}
         {{/each}}
       `,
@@ -1553,10 +1553,10 @@ moduleFor(
 
     ['@test non-block with properties on self']() {
       this.registerComponent('non-block', {
-        template: 'In layout - someProp: {{someProp}}',
+        template: 'In layout - someProp: {{this.someProp}}',
       });
 
-      this.render('{{non-block someProp=prop}}', {
+      this.render('{{non-block someProp=this.prop}}', {
         prop: 'something here',
       });
 
@@ -1577,12 +1577,12 @@ moduleFor(
 
     ['@test block with properties on self']() {
       this.registerComponent('with-block', {
-        template: 'In layout - someProp: {{someProp}} - {{yield}}',
+        template: 'In layout - someProp: {{this.someProp}} - {{yield}}',
       });
 
       this.render(
         strip`
-      {{#with-block someProp=prop}}
+      {{#with-block someProp=this.prop}}
         In template
       {{/with-block}}`,
         {
@@ -1612,7 +1612,7 @@ moduleFor(
 
       this.render(
         strip`
-      {{#with-block someProp=prop}}
+      {{#with-block someProp=this.prop}}
         In template
       {{/with-block}}`,
         {
@@ -1642,7 +1642,7 @@ moduleFor(
 
       this.render(
         strip`
-      {{#with-block someProp=prop}}
+      {{#with-block someProp=this.prop}}
         In template
       {{/with-block}}`,
         {
@@ -1671,7 +1671,7 @@ moduleFor(
           positionalParams: 'names',
         }),
         template: strip`
-        {{#each names as |name|}}
+        {{#each this.names as |name|}}
           {{name}}
         {{/each}}`,
       });
@@ -1695,13 +1695,13 @@ moduleFor(
           positionalParams: 'names',
         }),
         template: strip`
-        {{#each names as |name|}}
+        {{#each this.names as |name|}}
           {{name}}
         {{/each}}`,
       });
 
       expectAssertion(() => {
-        this.render(`{{sample-component "Foo" 4 "Bar" names=numbers id="args-3"}}`, {
+        this.render(`{{sample-component "Foo" 4 "Bar" names=this.numbers id="args-3"}}`, {
           numbers: [1, 2, 3],
         });
       }, 'You cannot specify positional parameters and the hash argument `names`.');
@@ -1713,12 +1713,12 @@ moduleFor(
           positionalParams: 'names',
         }),
         template: strip`
-        {{#each names as |name|}}
+        {{#each this.names as |name|}}
           {{name}}
         {{/each}}`,
       });
 
-      this.render('{{sample-component names=things}}', {
+      this.render('{{sample-component names=this.things}}', {
         things: emberA(['Foo', 4, 'Bar']),
       });
 
@@ -1750,7 +1750,7 @@ moduleFor(
         ComponentClass: Component.extend().reopenClass({
           positionalParams: ['first', 'second'],
         }),
-        template: '{{first}} - {{second}}',
+        template: '{{this.first}} - {{this.second}}',
       });
 
       // TODO: Fix when id is implemented
@@ -1776,12 +1776,12 @@ moduleFor(
           positionalParams: 'n',
         }),
         template: strip`
-        {{#each n as |name|}}
+        {{#each this.n as |name|}}
           {{name}}
         {{/each}}`,
       });
 
-      this.render(`{{sample-component user1 user2}}`, {
+      this.render(`{{sample-component this.user1 this.user2}}`, {
         user1: 'Foo',
         user2: 4,
       });
@@ -1813,7 +1813,7 @@ moduleFor(
         template: 'Here!',
       });
 
-      this.render('{{aria-test ariaRole=role}}', {
+      this.render('{{aria-test ariaRole=this.role}}', {
         role: 'main',
       });
 
@@ -1839,7 +1839,7 @@ moduleFor(
         template: 'Here!',
       });
 
-      this.render('{{aria-test ariaRole=role}}', {
+      this.render('{{aria-test ariaRole=this.role}}', {
         role: undefined,
       });
 
@@ -1892,13 +1892,13 @@ moduleFor(
         ComponentClass: Component.extend({
           template: compile('Should not be used'),
         }),
-        template: '[In layout - {{name}}] {{yield}}',
+        template: '[In layout - {{this.name}}] {{yield}}',
       });
 
       this.render(
         strip`
       {{#with-template name="with-block"}}
-        [In block - {{name}}]
+        [In block - {{this.name}}]
       {{/with-template}}
       {{with-template name="without-block"}}`,
         {
@@ -2017,7 +2017,7 @@ moduleFor(
         ComponentClass: Component.extend().reopenClass({
           positionalParams: ['name', 'age'],
         }),
-        template: '{{name}}{{age}}',
+        template: '{{this.name}}{{this.age}}',
       });
 
       this.render('{{sample-component "Quint" 4}}');
@@ -2034,10 +2034,10 @@ moduleFor(
         ComponentClass: Component.extend().reopenClass({
           positionalParams: ['name', 'age'],
         }),
-        template: '{{name}}{{age}}',
+        template: '{{this.name}}{{this.age}}',
       });
 
-      this.render('{{sample-component myName myAge}}', {
+      this.render('{{sample-component this.myName this.myAge}}', {
         myName: 'Quint',
         myAge: 4,
       });
@@ -2069,11 +2069,11 @@ moduleFor(
         ComponentClass: Component.extend().reopenClass({
           positionalParams: ['name'],
         }),
-        template: '{{name}}',
+        template: '{{this.name}}',
       });
 
       expectAssertion(() => {
-        this.render('{{sample-component notMyName name=myName}}', {
+        this.render('{{sample-component this.notMyName name=this.myName}}', {
           myName: 'Quint',
           notMyName: 'Sergio',
         });
@@ -2083,8 +2083,8 @@ moduleFor(
     ['@test yield to inverse']() {
       this.registerComponent('my-if', {
         template: strip`
-        {{#if predicate}}
-          Yes:{{yield someValue}}
+        {{#if this.predicate}}
+          Yes:{{yield this.someValue}}
         {{else}}
           No:{{yield to="inverse"}}
         {{/if}}`,
@@ -2092,7 +2092,7 @@ moduleFor(
 
       this.render(
         strip`
-      {{#my-if predicate=activated someValue=42 as |result|}}
+      {{#my-if predicate=this.activated someValue=42 as |result|}}
         Hello{{result}}
       {{else}}
         Goodbye
@@ -2509,7 +2509,7 @@ moduleFor(
       this.render(
         strip`
       {{#x-outer}}
-        {{#if showInner}}
+        {{#if this.showInner}}
           {{x-inner}}
         {{/if}}
       {{/x-outer}}`,
@@ -2561,7 +2561,7 @@ moduleFor(
         ComponentClass: Component.extend({
           value: 1,
         }),
-        template: '{{#x-middle}}{{x-inner value=value}}{{/x-middle}}',
+        template: '{{#x-middle}}{{x-inner value=this.value}}{{/x-middle}}',
       });
 
       this.registerComponent('x-middle', {
@@ -2572,7 +2572,7 @@ moduleFor(
           },
           value: null,
         }),
-        template: '<div id="middle-value">{{value}}</div>{{yield}}',
+        template: '<div id="middle-value">{{this.value}}</div>{{yield}}',
       });
 
       this.registerComponent('x-inner', {
@@ -2601,7 +2601,7 @@ moduleFor(
           wrapper: EmberObject.create({ content: null }),
         }),
         template:
-          '<div id="outer-value">{{wrapper.content}}</div> {{x-inner value=value wrapper=wrapper}}',
+          '<div id="outer-value">{{this.wrapper.content}}</div> {{x-inner value=this.value wrapper=this.wrapper}}',
       });
 
       this.registerComponent('x-inner', {
@@ -2626,18 +2626,18 @@ moduleFor(
     ['@test non-block with each rendering child components']() {
       this.registerComponent('non-block', {
         template: strip`
-        In layout. {{#each items as |item|}}
+        In layout. {{#each this.items as |item|}}
           [{{child-non-block item=item}}]
         {{/each}}`,
       });
 
       this.registerComponent('child-non-block', {
-        template: 'Child: {{item}}.',
+        template: 'Child: {{this.item}}.',
       });
 
       let items = emberA(['Tom', 'Dick', 'Harry']);
 
-      this.render('{{non-block items=items}}', { items });
+      this.render('{{non-block items=this.items}}', { items });
 
       this.assertText('In layout. [Child: Tom.][Child: Dick.][Child: Harry.]');
 
@@ -2707,7 +2707,7 @@ moduleFor(
           blahzz: ['blark', 'pory'],
         }),
         template: strip`
-        {{#each blahzz as |p|}}
+        {{#each this.blahzz as |p|}}
           {{p}}
         {{/each}}
         - {{yield}}`,
@@ -2737,10 +2737,10 @@ moduleFor(
       this.registerComponent('foo-bar', {
         ComponentClass: FooBarComponent,
 
-        template: '{{bar}}',
+        template: '{{this.bar}}',
       });
 
-      this.render('{{localBar}} - {{foo-bar bar=localBar}}', {
+      this.render('{{this.localBar}} - {{foo-bar bar=this.localBar}}', {
         localBar: 'initial value',
       });
 
@@ -2792,10 +2792,10 @@ moduleFor(
       this.registerComponent('foo-bar', {
         ComponentClass: FooBarComponent,
 
-        template: '{{bar}}',
+        template: '{{this.bar}}',
       });
 
-      this.render('{{localBar}} - {{foo-bar bar=localBar}}', {
+      this.render('{{this.localBar}} - {{foo-bar bar=this.localBar}}', {
         localBar: 'initial value',
       });
 
@@ -2843,7 +2843,7 @@ moduleFor(
         template: '',
       });
 
-      this.render('{{localBar}}{{foo-bar bar=localBar}}', {
+      this.render('{{this.localBar}}{{foo-bar bar=this.localBar}}', {
         localBar: 'initial value',
       });
 
@@ -2878,9 +2878,9 @@ moduleFor(
 
       this.registerComponent('parent', {
         ComponentClass: ParentComponent,
-        template: `{{child value=string}}
+        template: `{{child value=this.string}}
 
-        Parent String=<span data-test-parent-value>{{string}}</span>`,
+        Parent String=<span data-test-parent-value>{{this.string}}</span>`,
       });
 
       let ChildComponent = Component.extend({
@@ -2908,7 +2908,7 @@ moduleFor(
 
       this.registerComponent('child', {
         ComponentClass: ChildComponent,
-        template: '{{value}}',
+        template: '{{this.value}}',
       });
 
       this.render('{{parent}}');
@@ -2961,7 +2961,7 @@ moduleFor(
         ComponentClass: Component.extend({
           name: injectService(),
         }),
-        template: '{{name.last}}',
+        template: '{{this.name.last}}',
       });
 
       this.render('{{foo-bar}}');
@@ -3027,7 +3027,7 @@ moduleFor(
       });
 
       expectDeprecation(() => {
-        this.render(`{{foo-bar id="foo-bar" isVisible=visible}}`, {
+        this.render(`{{foo-bar id="foo-bar" isVisible=this.visible}}`, {
           visible: false,
         });
       }, debugStackMessageFor('The `isVisible` property on classic component classes is deprecated. Was accessed:', { renderTree: ['foo-bar'] }));
@@ -3064,7 +3064,7 @@ moduleFor(
       });
 
       expectDeprecation(() => {
-        this.render(`{{foo-bar id="foo-bar" isVisible=visible}}`, {
+        this.render(`{{foo-bar id="foo-bar" isVisible=this.visible}}`, {
           visible: false,
         });
       }, debugStackMessageFor('The `isVisible` property on classic component classes is deprecated. Was accessed:', { renderTree: ['foo-bar'] }));
@@ -3123,7 +3123,7 @@ moduleFor(
       });
 
       expectDeprecation(() => {
-        this.render(`{{foo-bar id="foo-bar" foo=foo isVisible=visible}}`, {
+        this.render(`{{foo-bar id="foo-bar" foo=this.foo isVisible=this.visible}}`, {
           visible: false,
           foo: 'baz',
         });
@@ -3182,7 +3182,7 @@ moduleFor(
         }),
       });
 
-      this.render('{{one-way-input value=value}}', {
+      this.render('{{one-way-input value=this.value}}', {
         value: 'foo',
       });
 
@@ -3272,7 +3272,7 @@ moduleFor(
       });
 
       this.render(strip`
-      {{#x-select value=value as |select|}}
+      {{#x-select value=this.value as |select|}}
         {{#x-option value="1" select=select}}1{{/x-option}}
         {{#x-option value="2" select=select}}2{{/x-option}}
       {{/x-select}}
@@ -3300,7 +3300,7 @@ moduleFor(
           },
         }),
 
-        template: `{{#if showFoo}}things{{/if}}`,
+        template: `{{#if this.showFoo}}things{{/if}}`,
       });
 
       this.render(`{{foo-bar}}`);
@@ -3328,10 +3328,10 @@ moduleFor(
           }),
         }),
 
-        template: '{{bar}}-{{barCopy}}',
+        template: '{{this.bar}}-{{this.barCopy}}',
       });
 
-      await this.render(`{{foo-bar bar=bar}}`, { bar: 3 });
+      await this.render(`{{foo-bar bar=this.bar}}`, { bar: 3 });
 
       this.assertText('3-4');
 
@@ -3354,10 +3354,10 @@ moduleFor(
           },
         }),
 
-        template: '{{foo}}-{{fooCopy}}-{{bar}}-{{barCopy}}',
+        template: '{{this.foo}}-{{this.fooCopy}}-{{this.bar}}-{{this.barCopy}}',
       });
 
-      this.render(`{{foo-bar foo=foo bar=bar}}`, { foo: 1, bar: 3 });
+      this.render(`{{foo-bar foo=this.foo bar=this.bar}}`, { foo: 1, bar: 3 });
     }
 
     ['@test overriding didUpdateAttrs does not trigger deprecation'](assert) {
@@ -3368,10 +3368,10 @@ moduleFor(
           },
         }),
 
-        template: '{{foo}}-{{fooCopy}}-{{bar}}-{{barCopy}}',
+        template: '{{this.foo}}-{{this.fooCopy}}-{{this.bar}}-{{this.barCopy}}',
       });
 
-      this.render(`{{foo-bar foo=foo bar=bar}}`, { foo: 1, bar: 3 });
+      this.render(`{{foo-bar foo=this.foo bar=this.bar}}`, { foo: 1, bar: 3 });
 
       runTask(() => set(this.context, 'foo', 5));
     }
@@ -3479,15 +3479,15 @@ moduleFor(
 
     ['@test component yielding in an {{#each}} has correct block values after rerendering (GH#14284)']() {
       this.registerComponent('list-items', {
-        template: `{{#each items as |item|}}{{yield item}}{{/each}}`,
+        template: `{{#each this.items as |item|}}{{yield item}}{{/each}}`,
       });
 
       this.render(
         strip`
-      {{#list-items items=items as |thing|}}
+      {{#list-items items=this.items as |thing|}}
         |{{thing}}|
 
-        {{#if editMode}}
+        {{#if this.editMode}}
           Remove {{thing}}
         {{/if}}
       {{/list-items}}
@@ -3516,7 +3516,7 @@ moduleFor(
         template: 'hello',
       });
 
-      this.render('{{foo-bar wat}}');
+      this.render('{{foo-bar this.wat}}');
       this.assertText('hello');
     }
 
@@ -3527,7 +3527,7 @@ moduleFor(
         ComponentClass: MyComponent.reopenClass({
           positionalParams: ['myVar'],
         }),
-        template: 'MyVar1: {{attrs.myVar}} {{myVar}} MyVar2: {{myVar2}} {{attrs.myVar2}}',
+        template: 'MyVar1: {{attrs.myVar}} {{this.myVar}} MyVar2: {{this.myVar2}} {{attrs.myVar2}}',
       });
 
       this.render('{{foo-bar 1 myVar2=2}}');
@@ -3542,7 +3542,7 @@ moduleFor(
         ComponentClass: MyComponent.reopenClass({
           positionalParams: ['myVar'],
         }),
-        template: 'MyVar1: {{@myVar}} {{myVar}} MyVar2: {{myVar2}} {{@myVar2}}',
+        template: 'MyVar1: {{@myVar}} {{this.myVar}} MyVar2: {{this.myVar2}} {{@myVar2}}',
       });
 
       this.render('{{foo-bar 1 myVar2=2}}');
@@ -3819,7 +3819,7 @@ moduleFor(
         template: '{{this.baz}}',
       });
 
-      this.render('{{#if cond}}{{foo-bar baz=this.value}}{{/if}}', { cond: true, value: 'hello' });
+      this.render('{{#if this.cond}}{{foo-bar baz=this.value}}{{/if}}', { cond: true, value: 'hello' });
 
       this.assertComponentElement(this.firstChild, { content: 'hello' });
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
@@ -11,9 +11,9 @@ moduleFor(
   'Components test: dynamic components',
   class extends RenderingTestCase {
     ['@test it can render a basic component with a static component name argument']() {
-      this.registerComponent('foo-bar', { template: 'hello {{name}}' });
+      this.registerComponent('foo-bar', { template: 'hello {{this.name}}' });
 
-      this.render('{{component "foo-bar" name=name}}', { name: 'Sarah' });
+      this.render('{{component "foo-bar" name=this.name}}', { name: 'Sarah' });
 
       this.assertComponentElement(this.firstChild, { content: 'hello Sarah' });
 
@@ -32,13 +32,13 @@ moduleFor(
 
     ['@test it can render a basic component with a dynamic component name argument']() {
       this.registerComponent('foo-bar', {
-        template: 'hello {{name}} from foo-bar',
+        template: 'hello {{this.name}} from foo-bar',
       });
       this.registerComponent('foo-bar-baz', {
-        template: 'hello {{name}} from foo-bar-baz',
+        template: 'hello {{this.name}} from foo-bar-baz',
       });
 
-      this.render('{{component componentName name=name}}', {
+      this.render('{{component this.componentName name=this.name}}', {
         componentName: 'foo-bar',
         name: 'Alex',
       });
@@ -175,7 +175,7 @@ moduleFor(
 
       this.registerComponent('foo-bar', {
         ComponentClass: FooBarComponent,
-        template: '{{message}}',
+        template: '{{this.message}}',
       });
 
       this.render('{{component "foo-bar"}}');
@@ -198,7 +198,7 @@ moduleFor(
     ['@test it preserves the outer context when yielding']() {
       this.registerComponent('foo-bar', { template: '{{yield}}' });
 
-      this.render('{{#component "foo-bar"}}{{message}}{{/component}}', {
+      this.render('{{#component "foo-bar"}}{{this.message}}{{/component}}', {
         message: 'hello',
       });
 
@@ -221,7 +221,7 @@ moduleFor(
       let destroyed = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 0 };
 
       this.registerComponent('foo-bar', {
-        template: '{{id}} {{yield}}',
+        template: '{{this.id}} {{yield}}',
         ComponentClass: Component.extend({
           willDestroy() {
             this._super();
@@ -232,15 +232,15 @@ moduleFor(
 
       this.render(
         strip`
-      {{#if cond1}}
+      {{#if this.cond1}}
         {{#component "foo-bar" id=1}}
-          {{#if cond2}}
+          {{#if this.cond2}}
             {{#component "foo-bar" id=2}}{{/component}}
-            {{#if cond3}}
+            {{#if this.cond3}}
               {{#component "foo-bar" id=3}}
-                {{#if cond4}}
+                {{#if this.cond4}}
                   {{#component "foo-bar" id=4}}
-                    {{#if cond5}}
+                    {{#if this.cond5}}
                       {{#component "foo-bar" id=5}}{{/component}}
                       {{#component "foo-bar" id=6}}{{/component}}
                       {{#component "foo-bar" id=7}}{{/component}}
@@ -358,7 +358,7 @@ moduleFor(
         }),
       });
 
-      this.render('{{component componentName name=name}}', {
+      this.render('{{component this.componentName name=this.name}}', {
         componentName: 'foo-bar',
       });
 
@@ -379,7 +379,7 @@ moduleFor(
 
     ['@test component helper with bound properties are updating correctly in init of component']() {
       this.registerComponent('foo-bar', {
-        template: 'foo-bar {{location}} {{locationCopy}} {{yield}}',
+        template: 'foo-bar {{this.location}} {{this.locationCopy}} {{yield}}',
         ComponentClass: Component.extend({
           init: function () {
             this._super(...arguments);
@@ -389,7 +389,7 @@ moduleFor(
       });
 
       this.registerComponent('foo-bar-baz', {
-        template: 'foo-bar-baz {{location}} {{locationCopy}} {{yield}}',
+        template: 'foo-bar-baz {{this.location}} {{this.locationCopy}} {{yield}}',
         ComponentClass: Component.extend({
           init: function () {
             this._super(...arguments);
@@ -399,7 +399,7 @@ moduleFor(
       });
 
       this.registerComponent('outer-component', {
-        template: '{{#component componentName location=location}}arepas!{{/component}}',
+        template: '{{#component this.componentName location=this.location}}arepas!{{/component}}',
         ComponentClass: Component.extend({
           componentName: computed('location', function () {
             if (this.get('location') === 'Caracas') {
@@ -411,7 +411,7 @@ moduleFor(
         }),
       });
 
-      this.render('{{outer-component location=location}}', {
+      this.render('{{outer-component location=this.location}}', {
         location: 'Caracas',
       });
 
@@ -453,7 +453,7 @@ moduleFor(
       let actionTriggered = 0;
       this.registerComponent('outer-component', {
         template:
-          '{{#component componentName somethingClicked=(action "mappedAction")}}arepas!{{/component}}',
+          '{{#component this.componentName somethingClicked=(action "mappedAction")}}arepas!{{/component}}',
         ComponentClass: Component.extend({
           classNames: 'outer-component',
           componentName: 'inner-component',
@@ -488,7 +488,7 @@ moduleFor(
       });
 
       this.render(
-        '{{#component componentName1 location=location}}{{#component componentName2 location=location}}arepas!{{/component}}{{/component}}',
+        '{{#component this.componentName1 location=this.location}}{{#component this.componentName2 location=this.location}}arepas!{{/component}}{{/component}}',
         {
           componentName1: 'foo-bar',
           componentName2: 'baz-qux',
@@ -525,7 +525,7 @@ moduleFor(
       }
 
       assert.throws(() => {
-        this.render('{{component componentName}}', {
+        this.render('{{component this.componentName}}', {
           componentName: 'does-not-exist',
         });
       }, /Attempted to resolve `does-not-exist`, which was expected to be a component, but nothing was found./);
@@ -543,9 +543,9 @@ moduleFor(
     }
 
     ['@test component with dynamic component name resolving to a component, then non-existent component']() {
-      this.registerComponent('foo-bar', { template: 'hello {{name}}' });
+      this.registerComponent('foo-bar', { template: 'hello {{this.name}}' });
 
-      this.render('{{component componentName name=name}}', {
+      this.render('{{component this.componentName name=this.name}}', {
         componentName: 'foo-bar',
         name: 'Alex',
       });
@@ -567,7 +567,7 @@ moduleFor(
 
     ['@test component helper properly invalidates hash params inside an {{each}} invocation #11044']() {
       this.registerComponent('foo-bar', {
-        template: '[{{internalName}} - {{name}}]',
+        template: '[{{this.internalName}} - {{this.name}}]',
         ComponentClass: Component.extend({
           willRender() {
             // store internally available name to ensure that the name available in `this.attrs.name`
@@ -577,7 +577,7 @@ moduleFor(
         }),
       });
 
-      this.render('{{#each items as |item|}}{{component "foo-bar" name=item.name}}{{/each}}', {
+      this.render('{{#each this.items as |item|}}{{component "foo-bar" name=item.name}}{{/each}}', {
         items: [{ name: 'Robert' }, { name: 'Jacquie' }],
       });
 
@@ -598,20 +598,20 @@ moduleFor(
 
     ['@test positional parameters does not clash when rendering different components']() {
       this.registerComponent('foo-bar', {
-        template: 'hello {{name}} ({{age}}) from foo-bar',
+        template: 'hello {{this.name}} ({{this.age}}) from foo-bar',
         ComponentClass: Component.extend().reopenClass({
           positionalParams: ['name', 'age'],
         }),
       });
 
       this.registerComponent('foo-bar-baz', {
-        template: 'hello {{name}} ({{age}}) from foo-bar-baz',
+        template: 'hello {{this.name}} ({{this.age}}) from foo-bar-baz',
         ComponentClass: Component.extend().reopenClass({
           positionalParams: ['name', 'age'],
         }),
       });
 
-      this.render('{{component componentName name age}}', {
+      this.render('{{component this.componentName this.name this.age}}', {
         componentName: 'foo-bar',
         name: 'Alex',
         age: 29,
@@ -658,14 +658,14 @@ moduleFor(
 
     ['@test positional parameters does not pollute the attributes when changing components']() {
       this.registerComponent('normal-message', {
-        template: 'Normal: {{something}}!',
+        template: 'Normal: {{this.something}}!',
         ComponentClass: Component.extend().reopenClass({
           positionalParams: ['something'],
         }),
       });
 
       this.registerComponent('alternative-message', {
-        template: 'Alternative: {{something}} {{somethingElse}}!',
+        template: 'Alternative: {{this.something}} {{this.somethingElse}}!',
         ComponentClass: Component.extend({
           something: 'Another',
         }).reopenClass({
@@ -673,7 +673,7 @@ moduleFor(
         }),
       });
 
-      this.render('{{component componentName message}}', {
+      this.render('{{component this.componentName this.message}}', {
         componentName: 'normal-message',
         message: 'Hello',
       });
@@ -716,7 +716,7 @@ moduleFor(
           positionalParams: 'names',
         }),
         template: strip`
-        {{#each names as |name|}}
+        {{#each this.names as |name|}}
           {{name}}
         {{/each}}`,
       });
@@ -736,12 +736,12 @@ moduleFor(
           positionalParams: 'n',
         }),
         template: strip`
-        {{#each n as |name|}}
+        {{#each this.n as |name|}}
           {{name}}
         {{/each}}`,
       });
 
-      this.render(`{{component "sample-component" user1 user2}}`, {
+      this.render(`{{component "sample-component" this.user1 this.user2}}`, {
         user1: 'Foo',
         user2: 4,
       });
@@ -781,7 +781,7 @@ moduleFor(
             });
           },
         }),
-        template: `Hi {{person.name}}! {{component "error-component" person=person}}`,
+        template: `Hi {{this.person.name}}! {{component "error-component" person=this.person}}`,
       });
 
       this.registerComponent('error-component', {
@@ -791,7 +791,7 @@ moduleFor(
             this.set('person.name', 'Ben');
           },
         }),
-        template: '{{person.name}}',
+        template: '{{this.person.name}}',
       });
 
       let expectedBacktrackingMessage = backtrackingMessageFor('name', 'Person \\(Ben\\)', {
@@ -799,7 +799,7 @@ moduleFor(
       });
 
       expectAssertion(() => {
-        this.render('{{component componentName}}', {
+        this.render('{{component this.componentName}}', {
           componentName: 'outer-component',
         });
       }, expectedBacktrackingMessage);

--- a/packages/@ember/-internals/glimmer/tests/integration/components/error-handling-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/error-handling-test.js
@@ -28,7 +28,9 @@ moduleFor(
       });
 
       assert.throws(() => {
-        this.render('{{#if this.switch}}{{#foo-bar}}{{foo-bar}}{{/foo-bar}}{{/if}}', { switch: true });
+        this.render('{{#if this.switch}}{{#foo-bar}}{{foo-bar}}{{/foo-bar}}{{/if}}', {
+          switch: true,
+        });
       }, /silly mistake in init/);
 
       assert.equal(
@@ -123,7 +125,9 @@ moduleFor(
       });
 
       assert.throws(() => {
-        this.render('{{#if this.switch}}{{#foo-bar}}{{foo-bar}}{{/foo-bar}}{{/if}}', { switch: true });
+        this.render('{{#if this.switch}}{{#foo-bar}}{{foo-bar}}{{/foo-bar}}{{/if}}', {
+          switch: true,
+        });
       }, /silly mistake/);
 
       assert.equal(

--- a/packages/@ember/-internals/glimmer/tests/integration/components/error-handling-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/error-handling-test.js
@@ -28,7 +28,7 @@ moduleFor(
       });
 
       assert.throws(() => {
-        this.render('{{#if switch}}{{#foo-bar}}{{foo-bar}}{{/foo-bar}}{{/if}}', { switch: true });
+        this.render('{{#if this.switch}}{{#foo-bar}}{{foo-bar}}{{/foo-bar}}{{/if}}', { switch: true });
       }, /silly mistake in init/);
 
       assert.equal(
@@ -70,7 +70,7 @@ moduleFor(
         template: 'hello',
       });
 
-      this.render('{{#if switch}}{{#foo-bar}}{{foo-bar}}{{/foo-bar}}{{/if}}', {
+      this.render('{{#if this.switch}}{{#foo-bar}}{{foo-bar}}{{/foo-bar}}{{/if}}', {
         switch: true,
       });
 
@@ -123,7 +123,7 @@ moduleFor(
       });
 
       assert.throws(() => {
-        this.render('{{#if switch}}{{#foo-bar}}{{foo-bar}}{{/foo-bar}}{{/if}}', { switch: true });
+        this.render('{{#if this.switch}}{{#foo-bar}}{{foo-bar}}{{/foo-bar}}{{/if}}', { switch: true });
       }, /silly mistake/);
 
       assert.equal(
@@ -155,7 +155,7 @@ moduleFor(
         template: 'hello',
       });
 
-      this.render('{{#if switch}}{{#foo-bar}}{{foo-bar}}{{/foo-bar}}{{/if}}', {
+      this.render('{{#if this.switch}}{{#foo-bar}}{{foo-bar}}{{/foo-bar}}{{/if}}', {
         switch: true,
       });
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/fragment-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/fragment-components-test.js
@@ -25,7 +25,7 @@ moduleFor(
         },
       });
 
-      let template = `{{#if foo}}<div>Hey</div>{{/if}}{{yield bar}}`;
+      let template = `{{#if this.foo}}<div>Hey</div>{{/if}}{{yield this.bar}}`;
 
       this.registerComponent('foo-bar', {
         ComponentClass: FooBarComponent,
@@ -153,7 +153,7 @@ moduleFor(
     }
 
     ['@test does not throw an error if `tagName` is an empty string and `id` is specified via JS']() {
-      let template = `{{id}}`;
+      let template = `{{this.id}}`;
       let FooBarComponent = Component.extend({
         tagName: '',
         id: 'baz',
@@ -168,7 +168,7 @@ moduleFor(
     }
 
     ['@test does not throw an error if `tagName` is an empty string and `id` is specified via template']() {
-      let template = `{{id}}`;
+      let template = `{{this.id}}`;
       let FooBarComponent = Component.extend({
         tagName: '',
       });
@@ -182,7 +182,7 @@ moduleFor(
     }
 
     ['@test does not throw an error if `tagName` is an empty string and `id` is bound property specified via template']() {
-      let template = `{{id}}`;
+      let template = `{{this.id}}`;
       let FooBarComponent = Component.extend({
         tagName: '',
       });
@@ -192,7 +192,7 @@ moduleFor(
         template,
       });
 
-      this.render(`{{#foo-bar id=fooBarId}}{{/foo-bar}}`, { fooBarId: 'baz' });
+      this.render(`{{#foo-bar id=this.fooBarId}}{{/foo-bar}}`, { fooBarId: 'baz' });
 
       this.assertText('baz');
 
@@ -208,12 +208,12 @@ moduleFor(
     }
 
     ['@test does not throw an error if `tagName` is an empty string and `id` is specified via template and passed to child component']() {
-      let fooBarTemplate = `{{#baz-child id=id}}{{/baz-child}}`;
+      let fooBarTemplate = `{{#baz-child id=this.id}}{{/baz-child}}`;
       let FooBarComponent = Component.extend({
         tagName: '',
       });
       let BazChildComponent = Component.extend();
-      let bazChildTemplate = `{{id}}`;
+      let bazChildTemplate = `{{this.id}}`;
 
       this.registerComponent('foo-bar', {
         ComponentClass: FooBarComponent,

--- a/packages/@ember/-internals/glimmer/tests/integration/components/input-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/input-angle-test.js
@@ -184,7 +184,7 @@ moduleFor(
   'Components test: <Input />',
   class extends InputRenderingTest {
     ['@test a single text field is inserted into the DOM']() {
-      this.render(`<Input @type="text" @value={{value}} />`, { value: 'hello' });
+      this.render(`<Input @type="text" @value={{this.value}} />`, { value: 'hello' });
 
       let id = this.inputID();
 
@@ -223,14 +223,14 @@ moduleFor(
     ['@test dynamic attributes (HTML attribute)']() {
       this.render(
         `
-      <Input @type="text" @value={{value}}
-        disabled={{disabled}}
-        placeholder={{placeholder}}
-        name={{name}}
-        maxlength={{maxlength}}
-        minlength={{minlength}}
-        size={{size}}
-        tabindex={{tabindex}}
+      <Input @type="text" @value={{this.value}}
+        disabled={{this.disabled}}
+        placeholder={{this.placeholder}}
+        name={{this.name}}
+        maxlength={{this.maxlength}}
+        minlength={{this.minlength}}
+        size={{this.size}}
+        tabindex={{this.tabindex}}
       />`,
         {
           value: 'Original value',
@@ -308,14 +308,14 @@ moduleFor(
     ['@test dynamic attributes (named argument)']() {
       this.render(
         `
-      <Input @type="text" @value={{value}}
-        @disabled={{disabled}}
-        @placeholder={{placeholder}}
-        @name={{name}}
-        @maxlength={{maxlength}}
-        @minlength={{minlength}}
-        @size={{size}}
-        @tabindex={{tabindex}}
+      <Input @type="text" @value={{this.value}}
+        @disabled={{this.disabled}}
+        @placeholder={{this.placeholder}}
+        @name={{this.name}}
+        @maxlength={{this.maxlength}}
+        @minlength={{this.minlength}}
+        @size={{this.size}}
+        @tabindex={{this.tabindex}}
       />`,
         {
           value: 'Original value',
@@ -461,7 +461,7 @@ moduleFor(
       // causes an event in Safari.
       runDestroy(this.owner.lookup('event_dispatcher:main'));
 
-      this.render(`<Input @type="text" @value={{value}} />`, { value: 'original' });
+      this.render(`<Input @type="text" @value={{this.value}} />`, { value: 'original' });
 
       let input = this.$input()[0];
 
@@ -544,7 +544,7 @@ moduleFor(
       assert.expect(4);
 
       expectDeprecation(() => {
-        this.render(`<Input @value={{value}} @key-press='foo' />`, {
+        this.render(`<Input @value={{this.value}} @key-press='foo' />`, {
           value: 'initial',
 
           actions: {
@@ -568,7 +568,7 @@ moduleFor(
     ['@test sends an action with `<Input @key-press={{action "foo"}} />` is pressed'](assert) {
       assert.expect(2);
 
-      this.render(`<Input @value={{value}} @key-press={{action 'foo'}} />`, {
+      this.render(`<Input @value={{this.value}} @key-press={{action 'foo'}} />`, {
         value: 'initial',
 
         actions: {
@@ -807,7 +807,7 @@ moduleFor(
   'Components test: <Input /> with dynamic type',
   class extends InputRenderingTest {
     ['@test a bound property can be used to determine type']() {
-      this.render(`<Input @type={{type}} />`, { type: 'password' });
+      this.render(`<Input @type={{this.type}} />`, { type: 'password' });
 
       this.assertAttr('type', 'password');
 
@@ -825,7 +825,7 @@ moduleFor(
     }
 
     ['@test a subexpression can be used to determine type']() {
-      this.render(`<Input @type={{if isTruthy trueType falseType}} />`, {
+      this.render(`<Input @type={{if this.isTruthy this.trueType this.falseType}} />`, {
         isTruthy: true,
         trueType: 'text',
         falseType: 'password',
@@ -848,13 +848,16 @@ moduleFor(
 
     ['@test GH16256 input macro does not modify params in place']() {
       this.registerComponent('my-input', {
-        template: `<Input @type={{inputType}} />`,
+        template: `<Input @type={{this.inputType}} />`,
       });
 
-      this.render(`<MyInput @inputType={{firstType}} /><MyInput @inputType={{secondType}} />`, {
-        firstType: 'password',
-        secondType: 'email',
-      });
+      this.render(
+        `<MyInput @inputType={{this.firstType}} /><MyInput @inputType={{this.secondType}} />`,
+        {
+          firstType: 'password',
+          secondType: 'email',
+        }
+      );
 
       let inputs = this.element.querySelectorAll('input');
       this.assert.equal(inputs.length, 2, 'there are two inputs');
@@ -869,10 +872,10 @@ moduleFor(
   class extends InputRenderingTest {
     ['@test dynamic attributes (HTML attribute)']() {
       this.render(
-        `<Input @type='checkbox' @checked={{checked}}
-          disabled={{disabled}}
-          name={{name}}
-          tabindex={{tabindex}}
+        `<Input @type='checkbox' @checked={{this.checked}}
+          disabled={{this.disabled}}
+          name={{this.name}}
+          tabindex={{this.tabindex}}
         />`,
         {
           disabled: false,
@@ -919,10 +922,10 @@ moduleFor(
 
     ['@test dynamic attributes (named argument)']() {
       this.render(
-        `<Input @type='checkbox' @checked={{checked}}
-          @disabled={{disabled}}
-          @name={{name}}
-          @tabindex={{tabindex}}
+        `<Input @type='checkbox' @checked={{this.checked}}
+          @disabled={{this.disabled}}
+          @name={{this.name}}
+          @tabindex={{this.tabindex}}
         />`,
         {
           disabled: false,
@@ -969,7 +972,7 @@ moduleFor(
 
     ['@feature(!EMBER_MODERNIZED_BUILT_IN_COMPONENTS) `value` property assertion']() {
       expectAssertion(() => {
-        this.render(`<Input @type="checkbox" @value={{value}} />`, {
+        this.render(`<Input @type="checkbox" @value={{this.value}} />`, {
           value: 'value',
         });
       }, /checkbox.+@value.+not supported.+use.+@checked.+instead/);
@@ -997,7 +1000,7 @@ moduleFor(
     }
 
     ['@test with a bound type']() {
-      this.render(`<Input @type={{inputType}} @checked={{isChecked}} />`, {
+      this.render(`<Input @type={{this.inputType}} @checked={{this.isChecked}} />`, {
         inputType: 'checkbox',
         isChecked: true,
       });
@@ -1083,13 +1086,13 @@ moduleFor(
 
       this.render(
         `
-      <Input @type="text" @value={{value}}
-        disabled={{disabled}}
-        placeholder={{placeholder}}
-        name={{name}}
-        maxlength={{maxlength}}
-        size={{size}}
-        tabindex={{tabindex}}
+      <Input @type="text" @value={{this.value}}
+        disabled={{this.disabled}}
+        placeholder={{this.placeholder}}
+        name={{this.name}}
+        maxlength={{this.maxlength}}
+        size={{this.size}}
+        tabindex={{this.tabindex}}
       />`,
         {
           value: null,
@@ -1152,13 +1155,13 @@ moduleFor(
 
       this.render(
         `
-      <Input @type="text" @value={{value}}
-        @disabled={{disabled}}
-        @placeholder={{placeholder}}
-        @name={{name}}
-        @maxlength={{maxlength}}
-        @size={{size}}
-        @tabindex={{tabindex}}
+      <Input @type="text" @value={{this.value}}
+        @disabled={{this.disabled}}
+        @placeholder={{this.placeholder}}
+        @name={{this.name}}
+        @maxlength={{this.maxlength}}
+        @size={{this.size}}
+        @tabindex={{this.tabindex}}
       />`,
         {
           value: null,

--- a/packages/@ember/-internals/glimmer/tests/integration/components/input-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/input-curly-test.js
@@ -144,7 +144,7 @@ moduleFor(
   'Components test: {{input}}',
   class extends InputRenderingTest {
     ['@test a single text field is inserted into the DOM']() {
-      this.render(`{{input type="text" value=value}}`, { value: 'hello' });
+      this.render(`{{input type="text" value=this.value}}`, { value: 'hello' });
 
       let id = this.inputID();
 
@@ -184,14 +184,14 @@ moduleFor(
       this.render(
         `
       {{input type="text"
-        disabled=disabled
-        value=value
-        placeholder=placeholder
-        name=name
-        maxlength=maxlength
-        minlength=minlength
-        size=size
-        tabindex=tabindex
+        disabled=this.disabled
+        value=this.value
+        placeholder=this.placeholder
+        name=this.name
+        maxlength=this.maxlength
+        minlength=this.minlength
+        size=this.size
+        tabindex=this.tabindex
       }}`,
         {
           disabled: false,
@@ -305,7 +305,7 @@ moduleFor(
       // causes an event in Safari.
       runDestroy(this.owner.lookup('event_dispatcher:main'));
 
-      this.render(`{{input type="text" value=value}}`, { value: 'original' });
+      this.render(`{{input type="text" value=this.value}}`, { value: 'original' });
 
       let input = this.$input()[0];
 
@@ -388,7 +388,7 @@ moduleFor(
       assert.expect(4);
 
       expectDeprecation(() => {
-        this.render(`{{input value=value key-press='foo'}}`, {
+        this.render(`{{input value=this.value key-press='foo'}}`, {
           value: 'initial',
 
           actions: {
@@ -412,7 +412,7 @@ moduleFor(
     ['@test sends an action with `{{input key-press=(action "foo")}}` is pressed'](assert) {
       assert.expect(2);
 
-      this.render(`{{input value=value key-press=(action 'foo')}}`, {
+      this.render(`{{input value=this.value key-press=(action 'foo')}}`, {
         value: 'initial',
 
         actions: {
@@ -649,7 +649,7 @@ moduleFor(
   'Components test: {{input}} with dynamic type',
   class extends InputRenderingTest {
     ['@test a bound property can be used to determine type']() {
-      this.render(`{{input type=type}}`, { type: 'password' });
+      this.render(`{{input type=this.type}}`, { type: 'password' });
 
       this.assertAttr('type', 'password');
 
@@ -667,7 +667,7 @@ moduleFor(
     }
 
     ['@test a subexpression can be used to determine type']() {
-      this.render(`{{input type=(if isTruthy trueType falseType)}}`, {
+      this.render(`{{input type=(if this.isTruthy this.trueType this.falseType)}}`, {
         isTruthy: true,
         trueType: 'text',
         falseType: 'password',
@@ -690,10 +690,10 @@ moduleFor(
 
     ['@test GH16256 input macro does not modify params in place']() {
       this.registerComponent('my-input', {
-        template: `{{input type=inputType}}`,
+        template: `{{input type=this.inputType}}`,
       });
 
-      this.render(`{{my-input inputType=firstType}}{{my-input inputType=secondType}}`, {
+      this.render(`{{my-input inputType=this.firstType}}{{my-input inputType=this.secondType}}`, {
         firstType: 'password',
         secondType: 'email',
       });
@@ -713,10 +713,10 @@ moduleFor(
       this.render(
         `{{input
       type='checkbox'
-      disabled=disabled
-      name=name
-      checked=checked
-      tabindex=tabindex
+      disabled=this.disabled
+      name=this.name
+      checked=this.checked
+      tabindex=this.tabindex
     }}`,
         {
           disabled: false,
@@ -763,7 +763,7 @@ moduleFor(
 
     ['@feature(!EMBER_MODERNIZED_BUILT_IN_COMPONENTS) `value` property assertion']() {
       expectAssertion(() => {
-        this.render(`{{input type="checkbox" value=value}}`, {
+        this.render(`{{input type="checkbox" value=this.value}}`, {
           value: 'value',
         });
       }, /checkbox.+value.+not supported.+use.+checked.+instead/);
@@ -791,7 +791,7 @@ moduleFor(
     }
 
     ['@test with a bound type']() {
-      this.render(`{{input type=inputType checked=isChecked}}`, {
+      this.render(`{{input type=this.inputType checked=this.isChecked}}`, {
         inputType: 'checkbox',
         isChecked: true,
       });
@@ -858,13 +858,13 @@ moduleFor(
       this.render(
         `
       {{input type="text"
-        disabled=disabled
-        value=value
-        placeholder=placeholder
-        name=name
-        maxlength=maxlength
-        size=size
-        tabindex=tabindex
+        disabled=this.disabled
+        value=this.value
+        placeholder=this.placeholder
+        name=this.name
+        maxlength=this.maxlength
+        size=this.size
+        tabindex=this.tabindex
       }}`,
         {
           disabled: null,

--- a/packages/@ember/-internals/glimmer/tests/integration/components/instrumentation-compile-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/instrumentation-compile-test.js
@@ -61,11 +61,11 @@ moduleFor(
       });
 
       this.registerComponent('x-bar', {
-        template: '[x-bar: {{bar}}]',
+        template: '[x-bar: {{this.bar}}]',
         ComponentClass: BaseClass.extend(),
       });
 
-      this.render(`[-top-level: {{foo}}] {{x-bar bar=bar}}`, {
+      this.render(`[-top-level: {{this.foo}}] {{x-bar bar=this.bar}}`, {
         foo: 'foo',
         bar: 'bar',
       });

--- a/packages/@ember/-internals/glimmer/tests/integration/components/instrumentation-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/instrumentation-test.js
@@ -66,22 +66,22 @@ moduleFor(
       });
 
       this.registerComponent('x-bar', {
-        template: '[x-bar: {{bar}}] {{yield}}',
+        template: '[x-bar: {{this.bar}}] {{yield}}',
         ComponentClass: BaseClass.extend(),
       });
 
       this.registerComponent('x-baz', {
-        template: '[x-baz: {{baz}}]',
+        template: '[x-baz: {{this.baz}}]',
         ComponentClass: BaseClass.extend(),
       });
 
       this.registerComponent('x-bat', {
-        template: '[x-bat: {{bat}}]',
+        template: '[x-bat: {{this.bat}}]',
         ComponentClass: BaseClass.extend(),
       });
 
       this.render(
-        `[-top-level: {{foo}}] {{#x-bar bar=bar}}{{x-baz baz=baz}}{{/x-bar}} {{x-bat bat=bat}}`,
+        `[-top-level: {{this.foo}}] {{#x-bar bar=this.bar}}{{x-baz baz=this.baz}}{{/x-bar}} {{x-bat bat=this.bat}}`,
         {
           foo: 'foo',
           bar: 'bar',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/life-cycle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/life-cycle-test.js
@@ -329,7 +329,7 @@ class LifeCycleHooksTest extends RenderingTestCase {
       </div>`,
     });
 
-    this.render(invoke('the-top', { twitter: expr('twitter') }), {
+    this.render(invoke('the-top', { twitter: expr(attr('twitter')) }), {
       twitter: '@tomdale',
     });
 
@@ -562,9 +562,9 @@ class LifeCycleHooksTest extends RenderingTestCase {
 
     this.render(
       invoke('the-parent', {
-        twitter: expr('twitter'),
-        name: expr('name'),
-        website: expr('website'),
+        twitter: expr(attr('twitter')),
+        name: expr(attr('name')),
+        website: expr(attr('website')),
       }),
       {
         twitter: '@tomdale',
@@ -883,7 +883,7 @@ class LifeCycleHooksTest extends RenderingTestCase {
       </div>`,
     });
 
-    this.render(invoke('the-top', { twitter: expr('twitter') }), {
+    this.render(invoke('the-top', { twitter: expr(attr('twitter')) }), {
       twitter: '@tomdale',
     });
 
@@ -1049,7 +1049,7 @@ class LifeCycleHooksTest extends RenderingTestCase {
 
     this.registerComponent('an-item', {
       template: strip`
-      {{#nested-item}}Item: {{count}}{{/nested-item}}
+      {{#nested-item}}Item: {{this.count}}{{/nested-item}}
     `,
     });
 
@@ -1061,7 +1061,7 @@ class LifeCycleHooksTest extends RenderingTestCase {
 
     this.render(
       strip`
-      {{#each items as |item|}}
+      {{#each this.items as |item|}}
         ${invoke('an-item', { count: expr('item') })}
       {{else}}
         ${invoke('no-items')}
@@ -1286,7 +1286,7 @@ class CurlyComponentsTest extends LifeCycleHooksTest {
   }
 
   attrFor(name) {
-    return `${name}`;
+    return `this.${name}`;
   }
 
   /* private */
@@ -1358,7 +1358,7 @@ moduleFor(
         },
       });
 
-      let template = `{{width}}`;
+      let template = `{{this.width}}`;
       this.registerComponent('foo-bar', { ComponentClass, template });
 
       this.render('{{foo-bar}}');
@@ -1380,11 +1380,11 @@ moduleFor(
         },
       });
 
-      let template = `{{foo}}`;
+      let template = `{{this.foo}}`;
 
       this.registerComponent('foo-bar', { ComponentClass, template });
 
-      this.render('{{foo-bar parent=this foo=foo}}');
+      this.render('{{foo-bar parent=this foo=this.foo}}');
 
       this.assertText('wat');
 
@@ -1438,8 +1438,8 @@ moduleFor(
       let PartentTemplate = strip`
       {{yield}}
       <ul>
-        {{#nested-component nestedId=(concat itemId '-A')}}A{{/nested-component}}
-        {{#nested-component nestedId=(concat itemId '-B')}}B{{/nested-component}}
+        {{#nested-component nestedId=(concat this.itemId '-A')}}A{{/nested-component}}
+        {{#nested-component nestedId=(concat this.itemId '-B')}}B{{/nested-component}}
       </ul>
     `;
 
@@ -1471,7 +1471,7 @@ moduleFor(
 
       this.render(
         strip`
-        {{#each items as |item|}}
+        {{#each this.items as |item|}}
           {{#parent-component itemId=item.id}}{{item.id}}{{/parent-component}}
         {{/each}}
         {{#if this.model.shouldShow}}

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-angle-test.js
@@ -308,7 +308,7 @@ moduleFor(
       this.addTemplate(
         'index',
         `
-        <LinkTo id="the-link" @query={{hash foo=boundThing}}>
+        <LinkTo id="the-link" @query={{hash foo=this.boundThing}}>
           Index
         </LinkTo>
         `
@@ -330,7 +330,7 @@ moduleFor(
       this.addTemplate(
         'index',
         `
-        <LinkTo id="the-link" @query={{hash abool=boundThing}}>
+        <LinkTo id="the-link" @query={{hash abool=this.boundThing}}>
           Index
         </LinkTo>
         `
@@ -547,7 +547,7 @@ moduleFor(
       this.addTemplate(
         'index',
         `
-        <LinkTo id='page-link' @query={{hash page=pageNumber}}>
+        <LinkTo id='page-link' @query={{hash page=this.pageNumber}}>
           Index
         </LinkTo>
         `
@@ -576,9 +576,9 @@ moduleFor(
       this.addTemplate(
         'index',
         `
-        <LinkTo id='array-link' @query={{hash pages=pagesArray}}>Index</LinkTo>
-        <LinkTo id='bigger-link' @query={{hash pages=biggerArray}}>Index</LinkTo>
-        <LinkTo id='empty-link' @query={{hash pages=emptyArray}}>Index</LinkTo>
+        <LinkTo id='array-link' @query={{hash pages=this.pagesArray}}>Index</LinkTo>
+        <LinkTo id='bigger-link' @query={{hash pages=this.biggerArray}}>Index</LinkTo>
+        <LinkTo id='empty-link' @query={{hash pages=this.emptyArray}}>Index</LinkTo>
         `
       );
 
@@ -631,7 +631,7 @@ moduleFor(
         `
         <LinkTo id='parent-link' @route='parent'>Parent</LinkTo>
         <LinkTo id='parent-child-link' @route='parent.child'>Child</LinkTo>
-        <LinkTo id='parent-link-qp' @route='parent' @query={{hash foo=cat}}>Parent</LinkTo>
+        <LinkTo id='parent-link-qp' @route='parent' @query={{hash foo=this.cat}}>Parent</LinkTo>
         {{outlet}}
         `
       );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-curly-test.js
@@ -274,7 +274,7 @@ moduleFor(
     ['@test supplied QP properties can be bound'](assert) {
       this.addTemplate(
         'index',
-        `{{#link-to (query-params foo=boundThing) id='the-link'}}Index{{/link-to}}`
+        `{{#link-to (query-params foo=this.boundThing) id='the-link'}}Index{{/link-to}}`
       );
 
       return this.visit('/').then(() => {
@@ -293,7 +293,7 @@ moduleFor(
       this.addTemplate(
         'index',
         `
-        {{#link-to (query-params abool=boundThing) id='the-link'}}
+        {{#link-to (query-params abool=this.boundThing) id='the-link'}}
           Index
         {{/link-to}}
         `
@@ -505,7 +505,7 @@ moduleFor(
       this.addTemplate(
         'index',
         `
-        {{#link-to (query-params page=pageNumber) id='page-link'}}
+        {{#link-to (query-params page=this.pageNumber) id='page-link'}}
           Index
         {{/link-to}}
         `
@@ -534,9 +534,9 @@ moduleFor(
       this.addTemplate(
         'index',
         `
-        {{#link-to (query-params pages=pagesArray) id='array-link'}}Index{{/link-to}}
-        {{#link-to (query-params pages=biggerArray) id='bigger-link'}}Index{{/link-to}}
-        {{#link-to (query-params pages=emptyArray) id='empty-link'}}Index{{/link-to}}
+        {{#link-to (query-params pages=this.pagesArray) id='array-link'}}Index{{/link-to}}
+        {{#link-to (query-params pages=this.biggerArray) id='bigger-link'}}Index{{/link-to}}
+        {{#link-to (query-params pages=this.emptyArray) id='empty-link'}}Index{{/link-to}}
         `
       );
 
@@ -589,7 +589,7 @@ moduleFor(
         `
         {{#link-to 'parent' id='parent-link'}}Parent{{/link-to}}
         {{#link-to 'parent.child' id='parent-child-link'}}Child{{/link-to}}
-        {{#link-to 'parent' (query-params foo=cat) id='parent-link-qp'}}Parent{{/link-to}}
+        {{#link-to 'parent' (query-params foo=this.cat) id='parent-link-qp'}}Parent{{/link-to}}
         {{outlet}}
         `
       );
@@ -771,7 +771,7 @@ moduleFor(
       this.addTemplate(
         'index',
         `
-        {{#link-to (query-params page=pageNumber) id='page-link'}}
+        {{#link-to (query-params page=this.pageNumber) id='page-link'}}
           Index
         {{/link-to}}
         `

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-angle-test.js
@@ -27,7 +27,7 @@ moduleFor(
     ['@test re-renders when title changes']() {
       let controller;
 
-      this.addTemplate('application', `<LinkTo @route='index'>{{title}}</LinkTo>`);
+      this.addTemplate('application', `<LinkTo @route='index'>{{this.title}}</LinkTo>`);
 
       this.add(
         'controller:application',
@@ -50,7 +50,7 @@ moduleFor(
     ['@test re-computes active class when params change'](assert) {
       let controller;
 
-      this.addTemplate('application', '<LinkTo @route={{routeName}}>foo</LinkTo>');
+      this.addTemplate('application', '<LinkTo @route={{this.routeName}}>foo</LinkTo>');
 
       this.add(
         'controller:application',
@@ -79,7 +79,7 @@ moduleFor(
         ComponentClass: LinkComponent.extend(),
       });
 
-      this.addTemplate('application', `<CustomLinkTo @route='index'>{{title}}</CustomLinkTo>`);
+      this.addTemplate('application', `<CustomLinkTo @route='index'>{{this.title}}</CustomLinkTo>`);
 
       this.add(
         'controller:application',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-curly-test.js
@@ -26,7 +26,7 @@ moduleFor(
     ['@test re-renders when title changes']() {
       let controller;
 
-      this.addTemplate('application', `{{link-to title 'index'}}`);
+      this.addTemplate('application', `{{link-to this.title 'index'}}`);
 
       this.add(
         'controller:application',
@@ -49,7 +49,7 @@ moduleFor(
     ['@test re-computes active class when params change'](assert) {
       let controller;
 
-      this.addTemplate('application', '{{link-to "foo" routeName}}');
+      this.addTemplate('application', '{{link-to "foo" this.routeName}}');
 
       this.add(
         'controller:application',
@@ -74,7 +74,7 @@ moduleFor(
     }
 
     ['@test escaped inline form (double curlies) escapes link title']() {
-      this.addTemplate('application', `{{link-to title 'index'}}`);
+      this.addTemplate('application', `{{link-to this.title 'index'}}`);
       this.add(
         'controller:application',
         Controller.extend({
@@ -88,7 +88,7 @@ moduleFor(
     }
 
     ['@test unescaped inline form (triple curlies) does not escape link title'](assert) {
-      this.addTemplate('application', `{{{link-to title 'index'}}}`);
+      this.addTemplate('application', `{{{link-to this.title 'index'}}}`);
       this.add(
         'controller:application',
         Controller.extend({
@@ -106,7 +106,10 @@ moduleFor(
       this.addComponent('custom-link-to', {
         ComponentClass: LinkComponent.extend(),
       });
-      this.addTemplate('application', `{{#custom-link-to 'index'}}{{title}}{{/custom-link-to}}`);
+      this.addTemplate(
+        'application',
+        `{{#custom-link-to 'index'}}{{this.title}}{{/custom-link-to}}`
+      );
       this.add(
         'controller:application',
         Controller.extend({
@@ -123,7 +126,7 @@ moduleFor(
       this.addComponent('custom-link-to', {
         ComponentClass: LinkComponent.extend(),
       });
-      this.addTemplate('application', `{{custom-link-to title 'index'}}`);
+      this.addTemplate('application', `{{custom-link-to this.title 'index'}}`);
       this.add(
         'controller:application',
         Controller.extend({

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
@@ -109,7 +109,7 @@ moduleFor(
         'index',
         `
         <LinkTo id="about-link-static" @route="about" @disabledWhen="shouldDisable">About</LinkTo>
-        <LinkTo id="about-link-dynamic" @route="about" @disabledWhen={{dynamicDisabledWhen}}>About</LinkTo>
+        <LinkTo id="about-link-dynamic" @route="about" @disabledWhen={{this.dynamicDisabledWhen}}>About</LinkTo>
         `
       );
 
@@ -175,7 +175,7 @@ moduleFor(
     [`@test the <LinkTo /> component supports a custom disabledClass set via bound param`](assert) {
       this.addTemplate(
         'index',
-        `<LinkTo id="about-link" @route="about" @disabledWhen={{true}} @disabledClass={{disabledClass}}>About</LinkTo>`
+        `<LinkTo id="about-link" @route="about" @disabledWhen={{true}} @disabledClass={{this.disabledClass}}>About</LinkTo>`
       );
 
       this.add(
@@ -229,7 +229,7 @@ moduleFor(
     ) {
       this.addTemplate(
         'index',
-        `<LinkTo id="about-link" @route="about" @disabledWhen={{disabledWhen}}>About</LinkTo>`
+        `<LinkTo id="about-link" @route="about" @disabledWhen={{this.disabledWhen}}>About</LinkTo>`
       );
 
       this.add(
@@ -294,7 +294,7 @@ moduleFor(
         `
         <h3 class="home">Home</h3>
         <LinkTo id='about-link' @route='about'>About</LinkTo>
-        <LinkTo id='self-link' @route='index' @activeClass={{activeClass}}>Self</LinkTo>
+        <LinkTo id='self-link' @route='index' @activeClass={{this.activeClass}}>Self</LinkTo>
         `
       );
 
@@ -645,7 +645,7 @@ moduleFor(
         'index',
         `
         <h3 class="home">Home</h3>
-        <LinkTo id='about-link' @route='about' @replace={{boundTruthyThing}}>About</LinkTo>
+        <LinkTo id='about-link' @route='about' @replace={{this.boundTruthyThing}}>About</LinkTo>
         `
       );
 
@@ -675,7 +675,7 @@ moduleFor(
         'index',
         `
         <h3 class="home">Home</h3>
-        <LinkTo id='about-link' @route='about' replace={{boundFalseyThing}}>About</LinkTo>
+        <LinkTo id='about-link' @route='about' replace={{this.boundFalseyThing}}>About</LinkTo>
         `
       );
 
@@ -887,7 +887,7 @@ moduleFor(
       this.addTemplate('index', `<h3 class="home">Home</h3>{{outlet}}`);
       this.addTemplate(
         'index.about',
-        `<LinkTo id='other-link' @route='items' @current-when={{currentWhen}}>ITEM</LinkTo>`
+        `<LinkTo id='other-link' @route='items' @current-when={{this.currentWhen}}>ITEM</LinkTo>`
       );
 
       return this.visit('/about').then(() => {
@@ -961,7 +961,7 @@ moduleFor(
       this.addTemplate(
         'index.about',
         `
-        <LinkTo id='index-link' @route='index' @current-when={{isCurrent}}>ITEM</LinkTo>
+        <LinkTo id='index-link' @route='index' @current-when={{this.isCurrent}}>ITEM</LinkTo>
         <LinkTo id='about-link' @route='item' @current-when={{true}}>ITEM</LinkTo>
         `
       );
@@ -1081,7 +1081,7 @@ moduleFor(
         'about',
         `
         <div {{action 'hide'}}>
-          <LinkTo id='about-contact' @route='about.contact' @bubbles={{boundFalseyThing}}>
+          <LinkTo id='about-contact' @route='about.contact' @bubbles={{this.boundFalseyThing}}>
             About
           </LinkTo>
         </div>
@@ -1249,7 +1249,7 @@ moduleFor(
         'index',
         `
         <h3 class="home">Home</h3>
-        <LinkTo id='self-link' @route='index' target={{boundLinkTarget}}>Self</LinkTo>
+        <LinkTo id='self-link' @route='index' target={{this.boundLinkTarget}}>Self</LinkTo>
         `
       );
 
@@ -1295,7 +1295,7 @@ moduleFor(
       });
     }
 
-    [`@test the <LinkTo /> component does not call preventDefault if '@preventDefault={{boundFalseyThing}}' is passed as an option`](
+    [`@test the <LinkTo /> component does not call preventDefault if '@preventDefault={{this.boundFalseyThing}}' is passed as an option`](
       assert
     ) {
       this.router.map(function () {
@@ -1304,7 +1304,7 @@ moduleFor(
 
       this.addTemplate(
         'index',
-        `<LinkTo id='about-link' @route='about' @preventDefault={{boundFalseyThing}}>About</LinkTo>`
+        `<LinkTo id='about-link' @route='about' @preventDefault={{this.boundFalseyThing}}>About</LinkTo>`
       );
 
       this.add(
@@ -1400,12 +1400,12 @@ moduleFor(
       this.addTemplate(
         'filter',
         `
-        <p>{{filter}}</p>
+        <p>{{this.filter}}</p>
         <LinkTo id="link" @route="filter" @model="unpopular">Unpopular</LinkTo>
-        <LinkTo id="path-link" @route="filter" @model={{filter}}>Unpopular</LinkTo>
-        <LinkTo id="post-path-link" @route="post" @model={{post_id}}>Post</LinkTo>
+        <LinkTo id="path-link" @route="filter" @model={{this.filter}}>Unpopular</LinkTo>
+        <LinkTo id="post-path-link" @route="post" @model={{this.post_id}}>Post</LinkTo>
         <LinkTo id="post-number-link" @route="post" @model={{123}}>Post</LinkTo>
-        <LinkTo id="repo-object-link" @route="repo" @model={{repo}}>Repo</LinkTo>
+        <LinkTo id="repo-object-link" @route="repo" @model={{this.repo}}>Repo</LinkTo>
         `
       );
 
@@ -1466,7 +1466,7 @@ moduleFor(
         'index',
         `
         <LinkTo id='string-link' @route='index'>string</LinkTo>
-        <LinkTo id='path-link' @route={{foo}}>path</LinkTo>
+        <LinkTo id='path-link' @route={{this.foo}}>path</LinkTo>
         `
       );
 
@@ -1500,7 +1500,10 @@ moduleFor(
       let post = { id: '1' };
       let secondPost = { id: '2' };
 
-      this.addTemplate('index', `<LinkTo id="post" @route="post" @model={{post}}>post</LinkTo>`);
+      this.addTemplate(
+        'index',
+        `<LinkTo id="post" @route="post" @model={{this.post}}>post</LinkTo>`
+      );
 
       this.add('controller:index', Controller.extend());
 
@@ -1582,14 +1585,14 @@ moduleFor(
       this.addTemplate(
         'index',
         `
-        {{#each routeNames as |routeName|}}
+        {{#each this.routeNames as |routeName|}}
           <LinkTo @route={{routeName}}>{{routeName}}</LinkTo>
         {{/each}}
-        {{#each routeNames as |r|}}
+        {{#each this.routeNames as |r|}}
           <LinkTo @route={{r}}>{{r}}</LinkTo>
         {{/each}}
-        <LinkTo @route={{route1}}>a</LinkTo>
-        <LinkTo @route={{route2}}>b</LinkTo>
+        <LinkTo @route={{this.route1}}>a</LinkTo>
+        <LinkTo @route={{this.route2}}>b</LinkTo>
         `
       );
 
@@ -1651,9 +1654,9 @@ moduleFor(
         'application',
         `
         <LinkTo id='home-link' @route='index'>Home</LinkTo>
-        <LinkTo id='default-post-link' @route='post' @model={{defaultPost}}>Default Post</LinkTo>
-        {{#if currentPost}}
-          <LinkTo id='current-post-link' @route='post' @model={{currentPost}}>Current Post</LinkTo>
+        <LinkTo id='default-post-link' @route='post' @model={{this.defaultPost}}>Default Post</LinkTo>
+        {{#if this.currentPost}}
+          <LinkTo id='current-post-link' @route='post' @model={{this.currentPost}}>Current Post</LinkTo>
         {{/if}}
         `
       );
@@ -1855,7 +1858,7 @@ moduleFor(
         'index',
         `
         <h3 class="home">Home</h3>
-        <LinkTo id="dynamic-link" @params={{dynamicLinkParams}}>Dynamic</LinkTo>
+        <LinkTo id="dynamic-link" @params={{this.dynamicLinkParams}}>Dynamic</LinkTo>
         `
       );
 
@@ -1924,10 +1927,10 @@ moduleFor(
       this.addTemplate(
         'index',
         `
-        <LinkTo id='context-link' @route={{destinationRoute}} @model={{routeContext}} @loadingClass='i-am-loading'>
+        <LinkTo id='context-link' @route={{this.destinationRoute}} @model={{this.routeContext}} @loadingClass='i-am-loading'>
           string
         </LinkTo>
-        <LinkTo id='static-link' @route={{secondRoute}} @loadingClass={{loadingClass}}>
+        <LinkTo id='static-link' @route={{this.secondRoute}} @loadingClass={{this.loadingClass}}>
           string
         </LinkTo>
         `

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-curly-test.js
@@ -109,7 +109,7 @@ moduleFor(
         'index',
         `
         {{#link-to "about" id="about-link-static" disabledWhen="shouldDisable"}}About{{/link-to}}
-        {{#link-to "about" id="about-link-dynamic" disabledWhen=dynamicDisabledWhen}}About{{/link-to}}
+        {{#link-to "about" id="about-link-dynamic" disabledWhen=this.dynamicDisabledWhen}}About{{/link-to}}
         `
       );
 
@@ -177,7 +177,7 @@ moduleFor(
     ) {
       this.addTemplate(
         'index',
-        `{{#link-to "about" id="about-link" disabledWhen=true disabledClass=disabledClass}}About{{/link-to}}`
+        `{{#link-to "about" id="about-link" disabledWhen=true disabledClass=this.disabledClass}}About{{/link-to}}`
       );
 
       this.add(
@@ -231,7 +231,7 @@ moduleFor(
     ) {
       this.addTemplate(
         'index',
-        `{{#link-to "about" id="about-link" disabledWhen=disabledWhen}}About{{/link-to}}`
+        `{{#link-to "about" id="about-link" disabledWhen=this.disabledWhen}}About{{/link-to}}`
       );
 
       this.add(
@@ -296,7 +296,7 @@ moduleFor(
         `
         <h3 class="home">Home</h3>
         {{#link-to 'about' id='about-link'}}About{{/link-to}}
-        {{#link-to 'index' id='self-link' activeClass=activeClass}}Self{{/link-to}}
+        {{#link-to 'index' id='self-link' activeClass=this.activeClass}}Self{{/link-to}}
         `
       );
 
@@ -646,7 +646,7 @@ moduleFor(
         'index',
         `
         <h3 class="home">Home</h3>
-        {{#link-to 'about' id='about-link' replace=boundTruthyThing}}About{{/link-to}}
+        {{#link-to 'about' id='about-link' replace=this.boundTruthyThing}}About{{/link-to}}
         `
       );
 
@@ -671,12 +671,12 @@ moduleFor(
         });
     }
 
-    ['@test The {{link-to}} component supports setting replace=boundFalseyThing'](assert) {
+    ['@test The {{link-to}} component supports setting replace=this.boundFalseyThing'](assert) {
       this.addTemplate(
         'index',
         `
         <h3 class="home">Home</h3>
-        {{#link-to 'about' id='about-link' replace=boundFalseyThing}}About{{/link-to}}
+        {{#link-to 'about' id='about-link' replace=this.boundFalseyThing}}About{{/link-to}}
         `
       );
 
@@ -888,7 +888,7 @@ moduleFor(
       this.addTemplate('index', `<h3 class="home">Home</h3>{{outlet}}`);
       this.addTemplate(
         'index.about',
-        `{{#link-to 'items' id='other-link' current-when=currentWhen}}ITEM{{/link-to}}`
+        `{{#link-to 'items' id='other-link' current-when=this.currentWhen}}ITEM{{/link-to}}`
       );
 
       return this.visit('/about').then(() => {
@@ -962,7 +962,7 @@ moduleFor(
       this.addTemplate(
         'index.about',
         `
-        {{#link-to 'index' id='index-link' current-when=isCurrent}}index{{/link-to}}
+        {{#link-to 'index' id='index-link' current-when=this.isCurrent}}index{{/link-to}}
         {{#link-to 'item' id='about-link' current-when=true}}ITEM{{/link-to}}
         `
       );
@@ -1081,7 +1081,7 @@ moduleFor(
         'about',
         `
         <div {{action 'hide'}}>
-          {{#link-to 'about.contact' id='about-contact' bubbles=boundFalseyThing}}
+          {{#link-to 'about.contact' id='about-contact' bubbles=this.boundFalseyThing}}
             About
           {{/link-to}}
         </div>
@@ -1247,7 +1247,7 @@ moduleFor(
     ) {
       this.addTemplate(
         'index',
-        `<h3 class="home">Home</h3>{{#link-to 'index' id='self-link' target=boundLinkTarget}}Self{{/link-to}}`
+        `<h3 class="home">Home</h3>{{#link-to 'index' id='self-link' target=this.boundLinkTarget}}Self{{/link-to}}`
       );
 
       this.add(
@@ -1292,7 +1292,7 @@ moduleFor(
       });
     }
 
-    [`@test the {{link-to}} component does not call preventDefault if 'preventDefault=boundFalseyThing' is passed as an option`](
+    [`@test the {{link-to}} component does not call preventDefault if 'preventDefault=this.boundFalseyThing' is passed as an option`](
       assert
     ) {
       this.router.map(function () {
@@ -1301,7 +1301,7 @@ moduleFor(
 
       this.addTemplate(
         'index',
-        `{{#link-to 'about' id='about-link' preventDefault=boundFalseyThing}}About{{/link-to}}`
+        `{{#link-to 'about' id='about-link' preventDefault=this.boundFalseyThing}}About{{/link-to}}`
       );
 
       this.add(
@@ -1397,12 +1397,12 @@ moduleFor(
       this.addTemplate(
         'filter',
         `
-        <p>{{filter}}</p>
+        <p>{{this.filter}}</p>
         {{#link-to "filter" "unpopular" id="link"}}Unpopular{{/link-to}}
-        {{#link-to "filter" filter id="path-link"}}Unpopular{{/link-to}}
-        {{#link-to "post" post_id id="post-path-link"}}Post{{/link-to}}
+        {{#link-to "filter" this.filter id="path-link"}}Unpopular{{/link-to}}
+        {{#link-to "post" this.post_id id="post-path-link"}}Post{{/link-to}}
         {{#link-to "post" 123 id="post-number-link"}}Post{{/link-to}}
-        {{#link-to "repo" repo id="repo-object-link"}}Repo{{/link-to}}
+        {{#link-to "repo" this.repo id="repo-object-link"}}Repo{{/link-to}}
         `
       );
 
@@ -1463,7 +1463,7 @@ moduleFor(
         'index',
         `
         {{#link-to 'index' id='string-link'}}string{{/link-to}}
-        {{#link-to foo id='path-link'}}path{{/link-to}}
+        {{#link-to this.foo id='path-link'}}path{{/link-to}}
         `
       );
 
@@ -1497,7 +1497,7 @@ moduleFor(
       let post = { id: '1' };
       let secondPost = { id: '2' };
 
-      this.addTemplate('index', `{{#link-to "post" post id="post"}}post{{/link-to}}`);
+      this.addTemplate('index', `{{#link-to "post" this.post id="post"}}post{{/link-to}}`);
 
       this.add('controller:index', Controller.extend());
 
@@ -1579,14 +1579,14 @@ moduleFor(
       this.addTemplate(
         'index',
         `
-        {{#each routeNames as |routeName|}}
+        {{#each this.routeNames as |routeName|}}
           {{#link-to routeName}}{{routeName}}{{/link-to}}
         {{/each}}
-        {{#each routeNames as |r|}}
+        {{#each this.routeNames as |r|}}
           {{#link-to r}}{{r}}{{/link-to}}
         {{/each}}
-        {{#link-to route1}}a{{/link-to}}
-        {{#link-to route2}}b{{/link-to}}
+        {{#link-to this.route1}}a{{/link-to}}
+        {{#link-to this.route2}}b{{/link-to}}
         `
       );
 
@@ -1680,7 +1680,7 @@ moduleFor(
         'index',
         `
         <h3 class="home">Home</h3>
-        {{link-to contactName 'contact' id='contact-link'}}
+        {{link-to this.contactName 'contact' id='contact-link'}}
         {{#link-to 'index' id='self-link'}}Self{{/link-to}}
         `
       );
@@ -1812,7 +1812,7 @@ moduleFor(
         'index',
         `
         {{link-to 'string' 'index' id='string-link'}}
-        {{link-to path foo id='path-link'}}
+        {{link-to this.path this.foo id='path-link'}}
         `
       );
 
@@ -1839,7 +1839,7 @@ moduleFor(
     }
 
     [`@test The non-block form {{link-to}} protects against XSS`](assert) {
-      this.addTemplate('application', `{{link-to display 'index' id='link'}}`);
+      this.addTemplate('application', `{{link-to this.display 'index' id='link'}}`);
 
       this.add(
         'controller:application',
@@ -1888,9 +1888,9 @@ moduleFor(
         'application',
         `
         {{#link-to 'index' id='home-link'}}Home{{/link-to}}
-        {{#link-to 'post' defaultPost id='default-post-link'}}Default Post{{/link-to}}
-        {{#if currentPost}}
-          {{#link-to 'post' currentPost id='current-post-link'}}Current Post{{/link-to}}
+        {{#link-to 'post' this.defaultPost id='default-post-link'}}Default Post{{/link-to}}
+        {{#if this.currentPost}}
+          {{#link-to 'post' this.currentPost id='current-post-link'}}Current Post{{/link-to}}
         {{/if}}
         `
       );
@@ -2122,7 +2122,7 @@ moduleFor(
         'index',
         `
         <h3 class="home">Home</h3>
-        {{#link-to params=dynamicLinkParams id="dynamic-link"}}Dynamic{{/link-to}}
+        {{#link-to params=this.dynamicLinkParams id="dynamic-link"}}Dynamic{{/link-to}}
         `
       );
 
@@ -2193,10 +2193,10 @@ moduleFor(
       this.addTemplate(
         'index',
         `
-        {{#link-to destinationRoute routeContext loadingClass='i-am-loading' id='context-link'}}
+        {{#link-to this.destinationRoute this.routeContext loadingClass='i-am-loading' id='context-link'}}
           string
         {{/link-to}}
-        {{#link-to secondRoute loadingClass=loadingClass id='static-link'}}
+        {{#link-to this.secondRoute loadingClass=this.loadingClass id='static-link'}}
           string
         {{/link-to}}
         `

--- a/packages/@ember/-internals/glimmer/tests/integration/components/target-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/target-action-test.js
@@ -126,7 +126,7 @@ moduleFor(
 
     // TODO consolidate these next 2 tests
     ['@test Calling sendAction on a component with a reference attr calls the function with arguments']() {
-      this.renderDelegate('{{action-delegate playing=playing}}', {
+      this.renderDelegate('{{action-delegate playing=this.playing}}', {
         playing: null,
       });
 
@@ -150,7 +150,7 @@ moduleFor(
     }
 
     ['@test Calling sendAction on a component with a {{mut}} attr calls the function with arguments']() {
-      this.renderDelegate('{{action-delegate playing=(mut playing)}}', {
+      this.renderDelegate('{{action-delegate playing=(mut this.playing)}}', {
         playing: null,
       });
 
@@ -323,7 +323,7 @@ moduleFor(
         }),
       });
 
-      this.render('{{#if shouldRender}}{{rip-alley}}{{/if}}', {
+      this.render('{{#if this.shouldRender}}{{rip-alley}}{{/if}}', {
         shouldRender: true,
       });
 
@@ -364,7 +364,7 @@ moduleFor(
             component = this;
           },
         }),
-        template: `{{val}}`,
+        template: `{{this.val}}`,
       });
 
       this.add(
@@ -546,7 +546,7 @@ moduleFor(
             assert.ok(true, 'outerSubmit called');
           },
         }),
-        template: '{{inner-component submitAction=(action outerSubmit)}}',
+        template: '{{inner-component submitAction=(action this.outerSubmit)}}',
       });
 
       this.render('{{outer-component}}');
@@ -583,7 +583,7 @@ moduleFor(
             },
           },
         }),
-        template: `{{inner-component innerSubmit=(action (action "outerSubmit" "${first}") "${second}" third)}}`,
+        template: `{{inner-component innerSubmit=(action (action "outerSubmit" "${first}") "${second}" this.third)}}`,
       });
 
       this.render('{{outer-component}}');
@@ -770,7 +770,7 @@ moduleFor(
         }),
       });
 
-      this.render('{{#if shouldRender}}{{rip-alley}}{{/if}}', {
+      this.render('{{#if this.shouldRender}}{{rip-alley}}{{/if}}', {
         shouldRender: true,
       });
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/template-only-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/template-only-components-test.js
@@ -30,7 +30,7 @@ if (ENV._TEMPLATE_ONLY_GLIMMER_COMPONENTS) {
       ['@test it can render named arguments']() {
         this.registerTemplateOnlyComponent('foo-bar', '|{{@foo}}|{{@bar}}|');
 
-        this.render('{{foo-bar foo=foo bar=bar}}', {
+        this.render('{{foo-bar foo=this.foo bar=this.bar}}', {
           foo: 'foo',
           bar: 'bar',
         });
@@ -53,7 +53,7 @@ if (ENV._TEMPLATE_ONLY_GLIMMER_COMPONENTS) {
       }
 
       ['@test it does not reflected arguments as properties']() {
-        this.registerTemplateOnlyComponent('foo-bar', '|{{foo}}|{{this.bar}}|');
+        this.registerTemplateOnlyComponent('foo-bar', '|{{this.foo}}|{{this.bar}}|');
 
         this.render('{{foo-bar foo=foo bar=bar}}', {
           foo: 'foo',
@@ -132,7 +132,7 @@ if (ENV._TEMPLATE_ONLY_GLIMMER_COMPONENTS) {
             wrapper: EmberObject.create({ content: null }),
           }),
           template:
-            '<div id="outer-value">{{x-inner-template-only value=this.wrapper.content wrapper=wrapper}}</div>{{x-inner value=value wrapper=wrapper}}',
+            '<div id="outer-value">{{x-inner-template-only value=this.wrapper.content wrapper=wrapper}}</div>{{x-inner value=this.value wrapper=this.wrapper}}',
         });
 
         this.registerComponent('x-inner', {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/textarea-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/textarea-angle-test.js
@@ -34,7 +34,7 @@ class BoundTextAreaAttributes {
   generate({ attribute, first, second }) {
     return {
       [`@test ${attribute} (HTML attribute)`]() {
-        this.render(`<Textarea ${attribute}={{value}} />`, {
+        this.render(`<Textarea ${attribute}={{this.value}} />`, {
           value: first,
         });
         this.assertTextArea({ attrs: { [attribute]: first } });
@@ -49,7 +49,7 @@ class BoundTextAreaAttributes {
       },
 
       [`@test @${attribute} (named argument)`]() {
-        this.render(`<Textarea @${attribute}={{value}} />`, {
+        this.render(`<Textarea @${attribute}={{this.value}} />`, {
           value: first,
         });
         this.assertTextArea({ attrs: { [attribute]: first } });
@@ -97,35 +97,35 @@ moduleFor(
     }
 
     ['@test Should respect disabled (HTML attribute)'](assert) {
-      this.render('<Textarea disabled={{disabled}} />', {
+      this.render('<Textarea disabled={{this.disabled}} />', {
         disabled: true,
       });
       assert.ok(this.$('textarea').is(':disabled'));
     }
 
     ['@test Should respect @disabled (named argument)'](assert) {
-      this.render('<Textarea @disabled={{disabled}} />', {
+      this.render('<Textarea @disabled={{this.disabled}} />', {
         disabled: true,
       });
       assert.ok(this.$('textarea').is(':disabled'));
     }
 
     ['@test Should respect disabled (HTML attribute) when false'](assert) {
-      this.render('<Textarea disabled={{disabled}} />', {
+      this.render('<Textarea disabled={{this.disabled}} />', {
         disabled: false,
       });
       assert.ok(this.$('textarea').is(':not(:disabled)'));
     }
 
     ['@test Should respect @disabled (named argument) when false'](assert) {
-      this.render('<Textarea @disabled={{disabled}} />', {
+      this.render('<Textarea @disabled={{this.disabled}} />', {
         disabled: false,
       });
       assert.ok(this.$('textarea').is(':not(:disabled)'));
     }
 
     ['@test Should become disabled (HTML attribute) when the context changes'](assert) {
-      this.render('<Textarea disabled={{disabled}} />');
+      this.render('<Textarea disabled={{this.disabled}} />');
       assert.ok(this.$('textarea').is(':not(:disabled)'));
 
       this.assertStableRerender();
@@ -138,7 +138,7 @@ moduleFor(
     }
 
     ['@test Should become @disabled (named argument) when the context changes'](assert) {
-      this.render('<Textarea @disabled={{disabled}} />');
+      this.render('<Textarea @disabled={{this.disabled}} />');
       assert.ok(this.$('textarea').is(':not(:disabled)'));
 
       this.assertStableRerender();
@@ -166,7 +166,7 @@ moduleFor(
     }
 
     ['@test GH#14001 Should correctly handle an empty string bound value']() {
-      this.render('<Textarea @value={{message}} />', { message: '' });
+      this.render('<Textarea @value={{this.message}} />', { message: '' });
 
       this.assert.strictEqual(this.firstChild.value, '');
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/textarea-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/textarea-curly-test.js
@@ -34,7 +34,7 @@ class BoundTextAreaAttributes {
   generate({ attribute, first, second }) {
     return {
       [`@test ${attribute}`]() {
-        this.render(`{{textarea ${attribute}=value}}`, {
+        this.render(`{{textarea ${attribute}=this.value}}`, {
           value: first,
         });
         this.assertTextArea({ attrs: { [attribute]: first } });
@@ -76,21 +76,21 @@ moduleFor(
     }
 
     ['@test Should respect disabled'](assert) {
-      this.render('{{textarea disabled=disabled}}', {
+      this.render('{{textarea disabled=this.disabled}}', {
         disabled: true,
       });
       assert.ok(this.$('textarea').is(':disabled'));
     }
 
     ['@test Should respect disabled when false'](assert) {
-      this.render('{{textarea disabled=disabled}}', {
+      this.render('{{textarea disabled=this.disabled}}', {
         disabled: false,
       });
       assert.ok(this.$('textarea').is(':not(:disabled)'));
     }
 
     ['@test Should become disabled when the context changes'](assert) {
-      this.render('{{textarea disabled=disabled}}');
+      this.render('{{textarea disabled=this.disabled}}');
       assert.ok(this.$('textarea').is(':not(:disabled)'));
 
       this.assertStableRerender();
@@ -118,7 +118,7 @@ moduleFor(
     }
 
     ['@test GH#14001 Should correctly handle an empty string bound value']() {
-      this.render('{{textarea value=message}}', { message: '' });
+      this.render('{{textarea value=this.message}}', { message: '' });
 
       this.assert.strictEqual(this.firstChild.value, '');
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
@@ -41,7 +41,7 @@ moduleFor(
         template: '{{@first}} {{@last}} | {{this.person.first}} {{this.person.last}}',
       });
 
-      this.render('<PersonWrapper @first={{first}} @last={{last}} />', {
+      this.render('<PersonWrapper @first={{this.first}} @last={{this.last}} />', {
         first: 'robert',
         last: 'jackson',
       });
@@ -76,7 +76,7 @@ moduleFor(
         template: '{{@first}} {{@last}} | {{this.person.first}} {{this.person.last}}',
       });
 
-      this.render('<PersonWrapper @first={{first}} @last={{last}} />', {
+      this.render('<PersonWrapper @first={{this.first}} @last={{this.last}} />', {
         first: 'robert',
         last: 'jackson',
       });
@@ -526,7 +526,7 @@ moduleFor(
         template: '{{this.person.first}} {{this.person.last}}',
       });
 
-      this.render('<PersonWrapper @first={{first}} @last={{last}} />', {
+      this.render('<PersonWrapper @first={{this.first}} @last={{this.last}} />', {
         first: 'robert',
         last: 'jackson',
       });

--- a/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
@@ -22,7 +22,8 @@ moduleFor(
           tagName: '',
         }),
 
-        template: '<div id="{{this.id}}">[{{this.id}}] {{#if this.isShowing}}{{yield}}{{/if}}</div>',
+        template:
+          '<div id="{{this.id}}">[{{this.id}}] {{#if this.isShowing}}{{yield}}{{/if}}</div>',
       });
 
       this.addComponent('x-toggle', {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
@@ -22,7 +22,7 @@ moduleFor(
           tagName: '',
         }),
 
-        template: '<div id="{{id}}">[{{id}}] {{#if isShowing}}{{yield}}{{/if}}</div>',
+        template: '<div id="{{this.id}}">[{{this.id}}] {{#if this.isShowing}}{{yield}}{{/if}}</div>',
       });
 
       this.addComponent('x-toggle', {
@@ -35,7 +35,7 @@ moduleFor(
           },
         }),
 
-        template: '[{{id}}] {{#if isExpanded}}{{yield}}{{/if}}',
+        template: '[{{this.id}}] {{#if this.isExpanded}}{{yield}}{{/if}}',
       });
 
       let ToggleController = Controller.extend({
@@ -65,7 +65,7 @@ moduleFor(
 
       <button id="toggle-application" {{action "toggle"}}>Toggle</button>
 
-      {{#if isExpanded}}
+      {{#if this.isExpanded}}
         {{x-toggle id="root-3"}}
       {{/if}}
 
@@ -95,7 +95,7 @@ moduleFor(
 
       <button id="toggle-index" {{action "toggle"}}>Toggle</button>
 
-      {{#if isExpanded}}
+      {{#if this.isExpanded}}
         {{x-toggle id="root-6"}}
       {{/if}}
     `

--- a/packages/@ember/-internals/glimmer/tests/integration/components/web-component-fallback-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/web-component-fallback-test.js
@@ -16,7 +16,7 @@ moduleFor(
     }
 
     ['@test custom elements can have bound attributes']() {
-      let template = `<foo-bar some-attr="{{name}}">hello</foo-bar>`;
+      let template = `<foo-bar some-attr="{{this.name}}">hello</foo-bar>`;
 
       this.render(template, { name: 'Robert' });
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/will-destroy-element-hook-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/will-destroy-element-hook-test.js
@@ -26,7 +26,7 @@ moduleFor(
         template: 'hello',
       });
 
-      this.render('{{#if switch}}{{foo-bar}}{{/if}}', { switch: true });
+      this.render('{{#if this.switch}}{{foo-bar}}{{/if}}', { switch: true });
 
       assert.equal(didInsertElementCount, 1, 'didInsertElement was called once');
 

--- a/packages/@ember/-internals/glimmer/tests/integration/content-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/content-test.js
@@ -170,7 +170,7 @@ class DynamicContentTest extends RenderingTestCase {
   }
 
   ['@test it can render a dynamic path']() {
-    this.renderPath('message', { message: 'hello' });
+    this.renderPath('this.message', { message: 'hello' });
 
     this.assertContent('hello');
 
@@ -188,7 +188,7 @@ class DynamicContentTest extends RenderingTestCase {
   }
 
   ['@test resolves the string length properly']() {
-    this.render('<p>{{foo.length}}</p>', { foo: undefined });
+    this.render('<p>{{this.foo.length}}</p>', { foo: undefined });
 
     this.assertHTML('<p></p>');
 
@@ -208,7 +208,7 @@ class DynamicContentTest extends RenderingTestCase {
   }
 
   ['@test resolves the array length properly']() {
-    this.render('<p>{{foo.length}}</p>', { foo: undefined });
+    this.render('<p>{{this.foo.length}}</p>', { foo: undefined });
 
     this.assertHTML('<p></p>');
 
@@ -230,7 +230,7 @@ class DynamicContentTest extends RenderingTestCase {
   ['@test it can render a capitalized path with no deprecation']() {
     expectNoDeprecation();
 
-    this.renderPath('CaptializedPath', { CaptializedPath: 'no deprecation' });
+    this.renderPath('this.CaptializedPath', { CaptializedPath: 'no deprecation' });
 
     this.assertContent('no deprecation');
 
@@ -248,7 +248,7 @@ class DynamicContentTest extends RenderingTestCase {
   }
 
   ['@test it can render undefined dynamic paths']() {
-    this.renderPath('name', {});
+    this.renderPath('this.name', {});
 
     this.assertIsEmpty();
 
@@ -264,7 +264,7 @@ class DynamicContentTest extends RenderingTestCase {
   }
 
   ['@test it can render a deeply nested dynamic path']() {
-    this.renderPath('a.b.c.d.e.f', {
+    this.renderPath('this.a.b.c.d.e.f', {
       a: { b: { c: { d: { e: { f: 'hello' } } } } },
     });
 
@@ -299,7 +299,7 @@ class DynamicContentTest extends RenderingTestCase {
 
     let m = Formatter.create({ message: 'hello' });
 
-    this.renderPath('m.formattedMessage', { m });
+    this.renderPath('this.m.formattedMessage', { m });
 
     this.assertContent('HELLO');
 
@@ -325,7 +325,7 @@ class DynamicContentTest extends RenderingTestCase {
 
     let m = Formatter.create({ messenger: { message: 'hello' } });
 
-    this.renderPath('m.formattedMessage', { m });
+    this.renderPath('this.m.formattedMessage', { m });
 
     this.assertContent('HELLO');
 
@@ -343,7 +343,7 @@ class DynamicContentTest extends RenderingTestCase {
   }
 
   ['@test it can read from a proxy object']() {
-    this.renderPath('proxy.name', {
+    this.renderPath('this.proxy.name', {
       proxy: ObjectProxy.create({ content: { name: 'Tom Dale' } }),
     });
 
@@ -379,7 +379,7 @@ class DynamicContentTest extends RenderingTestCase {
   }
 
   ['@test it can read from a nested path in a proxy object']() {
-    this.renderPath('proxy.name.last', {
+    this.renderPath('this.proxy.name.last', {
       proxy: ObjectProxy.create({
         content: { name: { first: 'Tom', last: 'Dale' } },
       }),
@@ -436,7 +436,7 @@ class DynamicContentTest extends RenderingTestCase {
   }
 
   ['@test it can read from a path flipping between a proxy and a real object']() {
-    this.renderPath('proxyOrObject.name.last', {
+    this.renderPath('this.proxyOrObject.name.last', {
       proxyOrObject: ObjectProxy.create({
         content: { name: { first: 'Tom', last: 'Dale' } },
       }),
@@ -514,7 +514,7 @@ class DynamicContentTest extends RenderingTestCase {
   }
 
   ['@test it can read from a path flipping between a real object and a proxy']() {
-    this.renderPath('objectOrProxy.name.last', {
+    this.renderPath('this.objectOrProxy.name.last', {
       objectOrProxy: { name: { first: 'Tom', last: 'Dale' } },
     });
 
@@ -589,7 +589,7 @@ class DynamicContentTest extends RenderingTestCase {
     let nullObject = Object.create(null);
     nullObject['message'] = 'hello';
 
-    this.renderPath('nullObject.message', { nullObject });
+    this.renderPath('this.nullObject.message', { nullObject });
 
     this.assertContent('hello');
 
@@ -622,7 +622,7 @@ class DynamicContentTest extends RenderingTestCase {
       },
     });
 
-    this.renderPath('messenger.message', { messenger });
+    this.renderPath('this.messenger.message', { messenger });
 
     this.assertContent('hello');
 
@@ -656,7 +656,7 @@ class DynamicContentTest extends RenderingTestCase {
     let func = () => {};
     func.aProp = 'this is a property on a function';
 
-    this.renderPath('func.aProp', { func });
+    this.renderPath('this.func.aProp', { func });
 
     this.assertContent('this is a property on a function');
 
@@ -689,7 +689,7 @@ class DynamicContentTestGenerator {
     if (expected === EMPTY) {
       return {
         [`${tag} rendering ${label}`]() {
-          this.renderPath('value', { value });
+          this.renderPath('this.value', { value });
 
           this.assertIsEmpty();
 
@@ -705,7 +705,7 @@ class DynamicContentTestGenerator {
     } else {
       return {
         [`${tag} rendering ${label}`]() {
-          this.renderPath('value', { value });
+          this.renderPath('this.value', { value });
 
           // NaN is unstable, not worth optimizing for in the VM
           let wasNaN = typeof value === 'number' && isNaN(value);
@@ -790,7 +790,7 @@ moduleFor(
     }
 
     ['@test it can render empty safe strings [GH#16314]']() {
-      this.render('before {{value}} after', { value: htmlSafe('hello') });
+      this.render('before {{this.value}} after', { value: htmlSafe('hello') });
 
       this.assertHTML('before hello after');
 
@@ -894,7 +894,7 @@ moduleFor(
     }
 
     ['@test updating trusted curlies']() {
-      this.render('{{{htmlContent}}}{{{nested.htmlContent}}}', {
+      this.render('{{{this.htmlContent}}}{{{this.nested.htmlContent}}}', {
         htmlContent: '<b>Max</b>',
         nested: { htmlContent: '<b>James</b>' },
       });
@@ -922,7 +922,7 @@ moduleFor(
     }
 
     ['@test empty content in trusted curlies [GH#14978]']() {
-      this.render('before {{{value}}} after', {
+      this.render('before {{{this.value}}} after', {
         value: 'hello',
       });
 
@@ -973,18 +973,18 @@ moduleFor(
     ['@test it can render a dynamic template']() {
       let template = `
       <div class="header">
-        <h1>Welcome to {{framework}}</h1>
+        <h1>Welcome to {{this.framework}}</h1>
       </div>
       <div class="body">
-        <h2>Why you should use {{framework}}?</h2>
+        <h2>Why you should use {{this.framework}}?</h2>
         <ol>
           <li>It's great</li>
           <li>It's awesome</li>
-          <li>It's {{framework}}</li>
+          <li>It's {{this.framework}}</li>
         </ol>
       </div>
       <div class="footer">
-        {{framework}} is free, open source and always will be.
+        {{this.framework}} is free, open source and always will be.
       </div>
     `;
 
@@ -1041,7 +1041,7 @@ moduleFor(
     }
 
     ['@test it should evaluate to nothing if part of the path is `undefined`']() {
-      this.render('{{foo.bar.baz.bizz}}', {
+      this.render('{{this.foo.bar.baz.bizz}}', {
         foo: {},
       });
 
@@ -1077,7 +1077,7 @@ moduleFor(
     }
 
     ['@test it should evaluate to nothing if part of the path is a primative']() {
-      this.render('{{foo.bar.baz.bizz}}', {
+      this.render('{{this.foo.bar.baz.bizz}}', {
         foo: { bar: true },
       });
 
@@ -1183,7 +1183,7 @@ moduleFor(
     }
 
     ['@test quoteless class attributes update correctly']() {
-      this.render('<div class={{if fooBar "foo-bar"}}>hello</div>', {
+      this.render('<div class={{if this.fooBar "foo-bar"}}>hello</div>', {
         fooBar: true,
       });
 
@@ -1215,7 +1215,7 @@ moduleFor(
     }
 
     ['@test quoted class attributes update correctly'](assert) {
-      this.render('<div class="{{if fooBar "foo-bar"}}">hello</div>', {
+      this.render('<div class="{{if this.fooBar "foo-bar"}}">hello</div>', {
         fooBar: true,
       });
 
@@ -1698,9 +1698,9 @@ if (DEBUG) {
   moduleFor(
     'Inline style tests - warnings',
     class extends StyleTest {
-      ['@test specifying <div style={{userValue}}></div> generates a warning']() {
+      ['@test specifying <div style={{this.userValue}}></div> generates a warning']() {
         let userValue = 'width: 42px';
-        this.render('<div style={{userValue}}></div>', {
+        this.render('<div style={{this.userValue}}></div>', {
           userValue,
         });
 
@@ -1717,23 +1717,23 @@ if (DEBUG) {
           template: 'hello',
         });
         let userValue = 'width: 42px';
-        this.render('{{foo-bar style=userValue}}', {
+        this.render('{{foo-bar style=this.userValue}}', {
           userValue,
         });
 
         this.assertStyleWarning(userValue);
       }
 
-      ['@test specifying `<div style={{{userValue}}}></div>` works properly without a warning']() {
-        this.render('<div style={{{userValue}}}></div>', {
+      ['@test specifying `<div style={{{this.userValue}}}></div>` works properly without a warning']() {
+        this.render('<div style={{{this.userValue}}}></div>', {
           userValue: 'width: 42px',
         });
 
         this.assertNoWarning();
       }
 
-      ['@test specifying `<div style={{userValue}}></div>` works properly with a SafeString']() {
-        this.render('<div style={{userValue}}></div>', {
+      ['@test specifying `<div style={{this.userValue}}></div>` works properly with a SafeString']() {
+        this.render('<div style={{this.userValue}}></div>', {
           userValue: new SafeString('width: 42px'),
         });
 
@@ -1741,7 +1741,7 @@ if (DEBUG) {
       }
 
       ['@test null value do not generate htmlsafe warning']() {
-        this.render('<div style={{userValue}}></div>', {
+        this.render('<div style={{this.userValue}}></div>', {
           userValue: null,
         });
 
@@ -1749,13 +1749,13 @@ if (DEBUG) {
       }
 
       ['@test undefined value do not generate htmlsafe warning']() {
-        this.render('<div style={{userValue}}></div>');
+        this.render('<div style={{this.userValue}}></div>');
 
         this.assertNoWarning();
       }
 
       ['@test no warnings are triggered when a safe string is quoted']() {
-        this.render('<div style="{{userValue}}"></div>', {
+        this.render('<div style="{{this.userValue}}"></div>', {
           userValue: new SafeString('width: 42px'),
         });
 
@@ -1764,7 +1764,7 @@ if (DEBUG) {
 
       ['@test binding warning is triggered when an unsafe string is quoted']() {
         let userValue = 'width: 42px';
-        this.render('<div style="{{userValue}}"></div>', {
+        this.render('<div style="{{this.userValue}}"></div>', {
           userValue,
         });
 
@@ -1773,7 +1773,7 @@ if (DEBUG) {
 
       ['@test binding warning is triggered when a safe string for a complete property is concatenated in place']() {
         let userValue = 'width: 42px';
-        this.render('<div style="color: green; {{userValue}}"></div>', {
+        this.render('<div style="color: green; {{this.userValue}}"></div>', {
           userValue: new SafeString('width: 42px'),
         });
 
@@ -1782,7 +1782,7 @@ if (DEBUG) {
 
       ['@test binding warning is triggered when a safe string for a value is concatenated in place']() {
         let userValue = '42px';
-        this.render('<div style="color: green; width: {{userValue}}"></div>', {
+        this.render('<div style="color: green; width: {{this.userValue}}"></div>', {
           userValue: new SafeString(userValue),
         });
 
@@ -1791,7 +1791,7 @@ if (DEBUG) {
 
       ['@test binding warning is triggered when a safe string for a property name is concatenated in place']() {
         let userValue = 'width';
-        this.render('<div style="color: green; {{userProperty}}: 42px"></div>', {
+        this.render('<div style="color: green; {{this.userProperty}}: 42px"></div>', {
           userProperty: new SafeString(userValue),
         });
 

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
@@ -100,7 +100,7 @@ moduleFor(
       );
 
       this.registerComponent('foo-bar', {
-        template: `<p>{{greeting}} world</p>`,
+        template: `<p>{{this.greeting}} world</p>`,
         ComponentClass,
       });
 
@@ -118,7 +118,7 @@ moduleFor(
       );
 
       this.registerComponent('foo-bar', {
-        template: `<p>{{greeting}} world</p>`,
+        template: `<p>{{this.greeting}} world</p>`,
         ComponentClass,
       });
 
@@ -237,7 +237,7 @@ moduleFor(
       );
 
       this.registerComponent('foo-bar', {
-        template: `<p>{{greeting}} world {{count}}</p>`,
+        template: `<p>{{this.greeting}} world {{this.count}}</p>`,
         ComponentClass,
       });
 
@@ -261,7 +261,7 @@ moduleFor(
       );
 
       this.registerComponent('foo-bar', {
-        template: `<p>{{salutation}}</p>`,
+        template: `<p>{{this.salutation}}</p>`,
         ComponentClass,
       });
 
@@ -281,11 +281,11 @@ moduleFor(
       );
 
       this.registerComponent('foo-bar', {
-        template: `<p>{{salutation}}</p>`,
+        template: `<p>{{this.salutation}}</p>`,
         ComponentClass,
       });
 
-      this.render('{{foo-bar firstName=firstName lastName=lastName}}', {
+      this.render('{{foo-bar firstName=this.firstName lastName=this.lastName}}', {
         firstName: 'Yehuda',
         lastName: 'Katz',
       });
@@ -313,7 +313,7 @@ moduleFor(
       );
 
       this.registerComponent('foo-bar', {
-        template: `<p>{{salutation}}</p>`,
+        template: `<p>{{this.salutation}}</p>`,
         ComponentClass,
       });
 
@@ -333,11 +333,11 @@ moduleFor(
       );
 
       this.registerComponent('foo-bar', {
-        template: `<p>{{salutation}}</p>`,
+        template: `<p>{{this.salutation}}</p>`,
         ComponentClass,
       });
 
-      this.render('{{foo-bar firstName lastName}}', {
+      this.render('{{foo-bar this.firstName this.lastName}}', {
         firstName: 'Yehuda',
         lastName: 'Katz',
       });
@@ -365,11 +365,11 @@ moduleFor(
       );
 
       this.registerComponent('foo-bar', {
-        template: `<p>{{salutation}}</p>`,
+        template: `<p>{{this.salutation}}</p>`,
         ComponentClass,
       });
 
-      this.render('{{foo-bar firstName lastName}}', {
+      this.render('{{foo-bar this.firstName this.lastName}}', {
         firstName: 'Yehuda',
         lastName: 'Katz',
       });
@@ -397,11 +397,11 @@ moduleFor(
       );
 
       this.registerComponent('foo-bar', {
-        template: `<p>{{salutation}}</p>`,
+        template: `<p>{{this.salutation}}</p>`,
         ComponentClass,
       });
 
-      this.render('{{foo-bar firstName lastName}}', {
+      this.render('{{foo-bar this.firstName this.lastName}}', {
         firstName: 'Yehuda',
         lastName: 'Katz',
       });
@@ -453,11 +453,11 @@ moduleFor(
       );
 
       this.registerComponent('foo-bar', {
-        template: `<p>{{greeting}} world</p>`,
+        template: `<p>{{this.greeting}} world</p>`,
         ComponentClass,
       });
 
-      this.render('{{#if show}}{{foo-bar}}{{/if}}', { show: true });
+      this.render('{{#if this.show}}{{foo-bar}}{{/if}}', { show: true });
 
       this.assertHTML(`<p>hello world</p>`);
 
@@ -511,11 +511,11 @@ moduleFor(
       );
 
       this.registerComponent('foo-bar', {
-        template: `<p>{{greeting}} {{@name}}</p>`,
+        template: `<p>{{this.greeting}} {{@name}}</p>`,
         ComponentClass,
       });
 
-      this.render('{{foo-bar name=name}}', { name: 'world' });
+      this.render('{{foo-bar name=this.name}}', { name: 'world' });
 
       this.assertHTML(`<p>hello world</p>`);
       assert.verifySteps(['createComponent', 'getContext', 'didCreateComponent']);
@@ -575,12 +575,12 @@ moduleFor(
       );
 
       this.registerComponent('foo-bar', {
-        template: `<p>{{greeting}} {{@name}}</p>`,
+        template: `<p>{{this.greeting}} {{@name}}</p>`,
         ComponentClass,
       });
 
       assert.throws(() => {
-        this.render('{{foo-bar name=name}}', { name: 'world' });
+        this.render('{{foo-bar name=this.name}}', { name: 'world' });
       }, /Custom component managers must have a `capabilities` property that is the result of calling the `capabilities\('3.4' \| '3.13'\)` \(imported via `import \{ capabilities \} from '@ember\/component';`\). /);
 
       assert.verifySteps([]);
@@ -600,7 +600,7 @@ moduleFor(
       );
 
       this.registerComponent('foo-bar', {
-        template: `<p>{{greeting}} world</p>`,
+        template: `<p>{{this.greeting}} world</p>`,
         ComponentClass,
       });
 
@@ -620,7 +620,7 @@ moduleFor(
       );
 
       this.registerComponent('foo-bar', {
-        template: `<p>{{salutation}}</p>`,
+        template: `<p>{{this.salutation}}</p>`,
         ComponentClass,
       });
 
@@ -653,11 +653,11 @@ moduleFor(
       );
 
       this.registerComponent('foo-bar', {
-        template: `<p>{{salutation}}</p>`,
+        template: `<p>{{this.salutation}}</p>`,
         ComponentClass,
       });
 
-      this.render('<FooBar @firstName={{firstName}} @lastName={{lastName}} />', {
+      this.render('<FooBar @firstName={{this.firstName}} @lastName={{this.lastName}} />', {
         firstName: 'Yehuda',
         lastName: 'Katz',
       });
@@ -726,7 +726,7 @@ moduleFor(
         ComponentClass,
       });
 
-      this.render('<FooBar data-test={{value}} />', { value: 'foo' });
+      this.render('<FooBar data-test={{this.value}} />', { value: 'foo' });
 
       this.assertHTML(`<p data-test="foo">Hello world!</p>`);
       assert.verifySteps(['createComponent', 'getContext', 'didCreateComponent']);
@@ -888,12 +888,12 @@ moduleFor(
       );
 
       this.registerComponent('foo-bar', {
-        template: `<p>{{greeting}} {{@name}}</p>`,
+        template: `<p>{{this.greeting}} {{@name}}</p>`,
         ComponentClass,
       });
 
       assert.throws(() => {
-        this.render('<FooBar @name={{name}} />', { name: 'world' });
+        this.render('<FooBar @name={{this.name}} />', { name: 'world' });
       }, /Custom component managers must have a `capabilities` property that is the result of calling the `capabilities\('3.4' \| '3.13'\)` \(imported via `import \{ capabilities \} from '@ember\/component';`\). /);
 
       assert.verifySteps([]);

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
@@ -86,7 +86,7 @@ class ModifierManagerTest extends RenderingTestCase {
       })
     );
 
-    this.render('{{#if truthy}}<h1 {{foo-bar truthy}}>hello world</h1>{{/if}}', {
+    this.render('{{#if this.truthy}}<h1 {{foo-bar this.truthy}}>hello world</h1>{{/if}}', {
       truthy: true,
     });
     this.assertHTML(`<h1>hello world</h1>`);
@@ -130,7 +130,7 @@ class ModifierManagerTest extends RenderingTestCase {
       })
     );
 
-    this.render('<h1 {{foo-bar truthy}}>hello world</h1>', {
+    this.render('<h1 {{foo-bar this.truthy}}>hello world</h1>', {
       truthy: true,
     });
     this.assertHTML(`<h1>hello world</h1>`);
@@ -169,7 +169,7 @@ class ModifierManagerTest extends RenderingTestCase {
       })
     );
 
-    this.render('<h1 {{foo-bar truthy}}>hello world</h1>', {
+    this.render('<h1 {{foo-bar this.truthy}}>hello world</h1>', {
       truthy: true,
     });
     this.assertHTML(`<h1>hello world</h1>`);
@@ -216,7 +216,7 @@ class ModifierManagerTest extends RenderingTestCase {
       })
     );
 
-    this.render('<h1 {{foo-bar truthy}}>hello world</h1>');
+    this.render('<h1 {{foo-bar this.truthy}}>hello world</h1>');
     this.assertHTML(`<h1>hello world</h1>`);
 
     assert.equal(insertCount, 1);
@@ -663,7 +663,7 @@ moduleFor(
 
       this.registerModifier('foo-bar', ModifierClass);
 
-      this.render('<h1 {{foo-bar baz}}>hello world</h1>');
+      this.render('<h1 {{foo-bar this.baz}}>hello world</h1>');
       runTask(() => this.context.set('baz', 'Hello'));
 
       this.assertHTML('<h1>hello world</h1>');
@@ -717,7 +717,7 @@ moduleFor(
 
       this.registerModifier('foo-bar', ModifierClass);
 
-      this.render('<h1 {{foo-bar baz}}>hello world</h1>');
+      this.render('<h1 {{foo-bar this.baz}}>hello world</h1>');
       runTask(() => this.context.set('baz', 'Hello'));
 
       this.assertHTML('<h1>hello world</h1>');

--- a/packages/@ember/-internals/glimmer/tests/integration/event-dispatcher-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/event-dispatcher-test.js
@@ -51,7 +51,7 @@ moduleFor(
             receivedEvent = event;
           },
         }),
-        template: `<button id="is-done" onclick={{action clicked}}>my button</button>`,
+        template: `<button id="is-done" onclick={{action this.clicked}}>my button</button>`,
       });
 
       this.render(`{{x-bar}}`);
@@ -70,7 +70,7 @@ moduleFor(
             receivedEvent = event;
           },
         }),
-        template: `<button id="is-done" onClick={{action clicked}}>my button</button>`,
+        template: `<button id="is-done" onClick={{action this.clicked}}>my button</button>`,
       });
 
       this.render(`{{x-bar}}`);

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/array-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/array-test.js
@@ -35,7 +35,7 @@ moduleFor(
 
     ['@test binds values when variables are used']() {
       this.render(
-        strip`{{#let (array personOne) as |people|}}
+        strip`{{#let (array this.personOne) as |people|}}
               {{#each people as |personName|}}
                 {{personName}}
               {{/each}}
@@ -58,7 +58,7 @@ moduleFor(
 
     ['@test binds multiple values when variables are used']() {
       this.render(
-        strip`{{#let (array personOne personTwo) as |people|}}
+        strip`{{#let (array this.personOne this.personTwo) as |people|}}
               {{#each people as |personName|}}
                 {{personName}},
               {{/each}}
@@ -91,7 +91,7 @@ moduleFor(
 
     ['@test array helpers can be nested']() {
       this.render(
-        strip`{{#let (array (array personOne personTwo)) as |listOfPeople|}}
+        strip`{{#let (array (array this.personOne this.personTwo)) as |listOfPeople|}}
               {{#each listOfPeople as |people|}}
                 List:
                 {{#each people as |personName|}}
@@ -176,7 +176,7 @@ moduleFor(
 
       this.registerComponent('foo-bar', {
         ComponentClass: FooBarComponent,
-        template: `{{yield (hash people=(array this.model.personOne personTwo))}}`,
+        template: `{{yield (hash people=(array this.model.personOne this.personTwo))}}`,
       });
 
       this.render(
@@ -216,12 +216,12 @@ moduleFor(
       this.registerComponent('foo-bar', {
         ComponentClass: FooBarComponent,
         template: strip`
-        {{#each people as |personName|}}
+        {{#each this.people as |personName|}}
           {{personName}},
         {{/each}}`,
       });
 
-      this.render(strip`{{foo-bar people=(array "Tom" personTwo)}}`, { personTwo: 'Chad' });
+      this.render(strip`{{foo-bar people=(array "Tom" this.personTwo)}}`, { personTwo: 'Chad' });
 
       this.assertText('Tom,Chad,');
 
@@ -248,12 +248,12 @@ moduleFor(
       this.registerComponent('foo-bar', {
         ComponentClass: FooBarComponent,
         template: strip`
-        {{#each people as |personName|}}
+        {{#each this.people as |personName|}}
           {{personName}},
         {{/each}}`,
       });
 
-      this.render(strip`{{foo-bar people=(array "Tom" personTwo)}}`, { personTwo: 'Chad' });
+      this.render(strip`{{foo-bar people=(array "Tom" this.personTwo)}}`, { personTwo: 'Chad' });
 
       let firstArray = fooBarInstance.people;
 
@@ -273,7 +273,7 @@ moduleFor(
         return 'captured';
       });
 
-      this.render(`{{capture (array 'Tom' personTwo)}}`, { personTwo: 'Godfrey' });
+      this.render(`{{capture (array 'Tom' this.personTwo)}}`, { personTwo: 'Godfrey' });
 
       this.assert.deepEqual(captured, ['Tom', 'Godfrey']);
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/closure-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/closure-action-test.js
@@ -50,7 +50,7 @@ if (EMBER_IMPROVED_INSTRUMENTATION) {
 
         this.registerComponent('outer-component', {
           ComponentClass: OuterComponent,
-          template: '{{inner-component submit=(action outerSubmit)}}',
+          template: '{{inner-component submit=(action this.outerSubmit)}}',
         });
 
         this.subscribe('interaction.ember-action', {
@@ -105,7 +105,7 @@ if (EMBER_IMPROVED_INSTRUMENTATION) {
 
         this.registerComponent('outer-component', {
           ComponentClass: OuterComponent,
-          template: '{{inner-component submit=(action outerSubmit)}}',
+          template: '{{inner-component submit=(action this.outerSubmit)}}',
         });
 
         this.subscribe('interaction.ember-action', {
@@ -160,7 +160,7 @@ if (EMBER_IMPROVED_INSTRUMENTATION) {
 
         this.registerComponent('outer-component', {
           ComponentClass: OuterComponent,
-          template: '{{inner-component submit=(action outerSubmit)}}',
+          template: '{{inner-component submit=(action this.outerSubmit)}}',
         });
 
         this.subscribe('interaction.ember-action', {
@@ -209,7 +209,7 @@ moduleFor(
       });
       this.registerComponent('outer-component', {
         ComponentClass: OuterComponent,
-        template: '{{inner-component submit=(action outerSubmit)}}',
+        template: '{{inner-component submit=(action this.outerSubmit)}}',
       });
 
       this.render('{{outer-component}}');
@@ -226,7 +226,7 @@ moduleFor(
         template: 'inner',
       });
       this.registerComponent('outer-component', {
-        template: '{{inner-component submit=(action somethingThatIsUndefined)}}',
+        template: '{{inner-component submit=(action this.somethingThatIsUndefined)}}',
       });
 
       expectAssertion(() => {
@@ -242,7 +242,7 @@ moduleFor(
         ComponentClass: Component.extend({
           nonFunctionThing: {},
         }),
-        template: '{{inner-component submit=(action nonFunctionThing)}}',
+        template: '{{inner-component submit=(action this.nonFunctionThing)}}',
       });
 
       expectAssertion(() => {
@@ -293,7 +293,7 @@ moduleFor(
 
       this.registerComponent('outer-component', {
         ComponentClass: OuterComponent,
-        template: '{{inner-component submit=(action outerSubmit)}}',
+        template: '{{inner-component submit=(action this.outerSubmit)}}',
       });
 
       this.render('{{outer-component}}');
@@ -338,7 +338,7 @@ moduleFor(
 
       this.registerComponent('outer-component', {
         ComponentClass: OuterComponent,
-        template: '{{inner-component submit=(action outerSubmit)}}',
+        template: '{{inner-component submit=(action this.outerSubmit)}}',
       });
 
       this.render('{{outer-component}}');
@@ -385,7 +385,7 @@ moduleFor(
 
       this.registerComponent('outer-component', {
         ComponentClass: OuterComponent,
-        template: `{{inner-component submit=(action (action outerSubmit "${first}") "${second}" third)}}`,
+        template: `{{inner-component submit=(action (action this.outerSubmit "${first}") "${second}" this.third)}}`,
       });
 
       this.render('{{outer-component}}');
@@ -481,7 +481,7 @@ moduleFor(
 
       this.registerComponent('outer-component', {
         ComponentClass: OuterComponent,
-        template: `{{inner-component submit=(action outerSubmit value)}}`,
+        template: `{{inner-component submit=(action this.outerSubmit this.value)}}`,
       });
 
       this.render('{{outer-component}}');
@@ -544,7 +544,7 @@ moduleFor(
 
       this.registerComponent('outer-component', {
         ComponentClass: OuterComponent,
-        template: `{{inner-component submit=(action outerSubmit first)}}`,
+        template: `{{inner-component submit=(action this.outerSubmit this.first)}}`,
       });
 
       this.render('{{outer-component}}');
@@ -594,7 +594,7 @@ moduleFor(
 
       this.registerComponent('outer-component', {
         ComponentClass: OuterComponent,
-        template: `{{inner-component submit=(action (mut outerMut))}}`,
+        template: `{{inner-component submit=(action (mut this.outerMut))}}`,
       });
 
       this.render('{{outer-component}}');
@@ -637,7 +637,7 @@ moduleFor(
 
       this.registerComponent('outer-component', {
         ComponentClass: OuterComponent,
-        template: `{{inner-component submit=(action (mut outerMut) '${newValue}')}}`,
+        template: `{{inner-component submit=(action (mut this.outerMut) '${newValue}')}}`,
       });
 
       this.render('{{outer-component}}');
@@ -782,7 +782,7 @@ moduleFor(
 
       this.registerComponent('outer-component', {
         ComponentClass: OuterComponent,
-        template: `{{inner-component submit=(action 'outerAction' target=otherComponent)}}`,
+        template: `{{inner-component submit=(action 'outerAction' target=this.otherComponent)}}`,
       });
 
       this.render('{{outer-component}}');
@@ -873,7 +873,7 @@ moduleFor(
 
       this.registerComponent('outer-component', {
         ComponentClass: OuterComponent,
-        template: `{{inner-component submit=(action outerAction value="readProp")}}`,
+        template: `{{inner-component submit=(action this.outerAction value="readProp")}}`,
       });
 
       this.render('{{outer-component}}');
@@ -917,7 +917,7 @@ moduleFor(
 
       this.registerComponent('outer-component', {
         ComponentClass: OuterComponent,
-        template: `{{inner-component submit=(action outerAction objectArgument value="readProp")}}`,
+        template: `{{inner-component submit=(action this.outerAction this.objectArgument value="readProp")}}`,
       });
 
       this.render('{{outer-component}}');
@@ -979,7 +979,7 @@ moduleFor(
 
       this.registerComponent('middle-component', {
         ComponentClass: MiddleComponent,
-        template: `{{inner-component attrs-submit=attrs.submit submit=submit}}`,
+        template: `{{inner-component attrs-submit=@submit submit=this.submit}}`,
       });
 
       this.registerComponent('outer-component', {
@@ -1075,7 +1075,7 @@ moduleFor(
 
         this.registerComponent('outer-component', {
           ComponentClass: OuterComponent,
-          template: `{{inner-component submit=(action submitTask 1 2 3)}}`,
+          template: `{{inner-component submit=(action this.submitTask 1 2 3)}}`,
         });
 
         this.render('{{outer-component}}');
@@ -1103,7 +1103,7 @@ moduleFor(
       this.registerComponent('example-component', {
         ComponentClass: ExampleComponent,
         template:
-          '<button onclick={{action (mut label) "Clicked!"}}>{{if label label "Click me"}}</button>',
+          '<button onclick={{action (mut this.label) "Clicked!"}}>{{if this.label this.label "Click me"}}</button>',
       });
 
       this.render('{{example-component}}');
@@ -1180,15 +1180,15 @@ moduleFor(
       this.registerComponent('outer-component', {
         ComponentClass: OuterComponent,
         template: strip`
-        <div id="counter">clicked: {{clicked}}; foo: {{foo}}</div>
+        <div id="counter">clicked: {{this.clicked}}; foo: {{this.foo}}</div>
 
         {{click-me id="string-action" onClick=(action "on-click")}}
-        {{click-me id="function-action" onClick=(action onClick)}}
-        {{click-me id="mut-action" onClick=(action (mut clicked))}}
+        {{click-me id="function-action" onClick=(action this.onClick)}}
+        {{click-me id="mut-action" onClick=(action (mut this.clicked))}}
       `,
       });
 
-      this.render('{{outer-component foo=foo}}', { foo: 1 });
+      this.render('{{outer-component foo=this.foo}}', { foo: 1 });
 
       this.assertText('clicked: 0; foo: 1');
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
@@ -17,7 +17,7 @@ moduleFor(
     ['@test it cannot override built-in syntax']() {
       this.registerHelper('array', () => 'Nope');
       expectAssertion(() => {
-        this.render(`{{array foo 'LOL'}}`, { foo: true });
+        this.render(`{{array this.foo 'LOL'}}`, { foo: true });
       }, /You attempted to overwrite the built-in helper "array" which is not allowed. Please rename the helper./);
     }
 
@@ -246,7 +246,7 @@ moduleFor(
         return values;
       });
 
-      this.render('{{#each (hello-world model) as |item|}}({{item}}){{/each}}', {
+      this.render('{{#each (hello-world this.model) as |item|}}({{item}}){{/each}}', {
         model: ['bob'],
       });
 
@@ -609,7 +609,7 @@ moduleFor(
       });
 
       this.registerComponent('some-component', {
-        template: '{{first}} {{second}} {{third}} {{fourth}} {{fifth}}',
+        template: '{{@first}} {{@second}} {{@third}} {{@fourth}} {{@fifth}}',
       });
 
       this.render(
@@ -828,15 +828,15 @@ if (DEBUG) {
     }
 
     ['@test cannot mutate params - no positional specified / named specified']() {
-      this.render('{{test-helper foo=bar}}', { bar: 'derp' });
+      this.render('{{test-helper foo=this.bar}}', { bar: 'derp' });
     }
 
     ['@test cannot mutate params - positional specified / no named specified']() {
-      this.render('{{test-helper bar}}', { bar: 'derp' });
+      this.render('{{test-helper this.bar}}', { bar: 'derp' });
     }
 
     ['@test cannot mutate params - positional specified / named specified']() {
-      this.render('{{test-helper bar foo=qux}}', { bar: 'derp', qux: 'baz' });
+      this.render('{{test-helper this.bar foo=this.qux}}', { bar: 'derp', qux: 'baz' });
     }
 
     ['@test cannot mutate params - no positional specified / no named specified']() {

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/element-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/element-action-test.js
@@ -146,7 +146,7 @@ moduleFor(
 
       this.registerComponent('example-component', {
         ComponentClass: ExampleComponent,
-        template: '<button {{action "foo" member}}>Click me</button>',
+        template: '<button {{action "foo" this.member}}>Click me</button>',
       });
 
       this.render('{{example-component}}');
@@ -280,7 +280,7 @@ moduleFor(
 
       this.registerComponent('other-component', {
         ComponentClass: OtherComponent,
-        template: '<a {{action "wat" target=anotherTarget}}>Wat?</a>',
+        template: '<a {{action "wat" target=this.anotherTarget}}>Wat?</a>',
       });
 
       this.render(strip`
@@ -323,7 +323,7 @@ moduleFor(
 
       this.registerComponent('example-component', {
         ComponentClass: ExampleComponent,
-        template: '<a {{action "edit" target=theTarget}}>Edit</a>',
+        template: '<a {{action "edit" target=this.theTarget}}>Edit</a>',
       });
 
       this.render('{{example-component}}');
@@ -406,7 +406,7 @@ moduleFor(
       this.registerComponent('example-component', {
         ComponentClass: ExampleComponent,
         template:
-          '<a href="#" {{action "edit" allowedKeys=altKey}}>click me</a> <div {{action "shortcut" allowedKeys=anyKey}}>click me too</div>',
+          '<a href="#" {{action "edit" allowedKeys=this.altKey}}>click me</a> <div {{action "shortcut" allowedKeys=this.anyKey}}>click me too</div>',
       });
 
       this.render('{{example-component}}');
@@ -447,7 +447,7 @@ moduleFor(
 
       this.registerComponent('example-component', {
         ComponentClass: ExampleComponent,
-        template: '<a href="#" {{action "edit" allowedKeys=acceptedKeys}}>click me</a>',
+        template: '<a href="#" {{action "edit" allowedKeys=this.acceptedKeys}}>click me</a>',
       });
 
       this.render('{{example-component}}');
@@ -629,7 +629,7 @@ moduleFor(
       this.registerComponent('example-component', {
         ComponentClass: ExampleComponent,
         template:
-          '<a id="edit" href="#" {{action "edit" bubbles=isFalse}}>edit</a><a id="delete" href="#" {{action "delete" bubbles=isFalse}}>delete</a>',
+          '<a id="edit" href="#" {{action "edit" bubbles=this.isFalse}}>edit</a><a id="delete" href="#" {{action "delete" bubbles=this.isFalse}}>delete</a>',
       });
 
       this.render('{{example-component}}');
@@ -686,7 +686,7 @@ moduleFor(
 
       this.registerComponent('example-component', {
         ComponentClass: ExampleComponent,
-        template: '<a id="edit" href="#" {{action "edit" bubbles=shouldBubble}}>edit</a>',
+        template: '<a id="edit" href="#" {{action "edit" bubbles=this.shouldBubble}}>edit</a>',
       });
 
       this.render('{{example-component}}');
@@ -765,7 +765,8 @@ moduleFor(
 
       this.registerComponent('example-component', {
         ComponentClass: ExampleComponent,
-        template: '{{#each items as |item|}}<a href="#" {{action "edit"}}>click me</a>{{/each}}',
+        template:
+          '{{#each this.items as |item|}}<a href="#" {{action "edit"}}>click me</a>{{/each}}',
       });
 
       this.render('{{example-component}}');
@@ -792,7 +793,7 @@ moduleFor(
       this.registerComponent('example-component', {
         ComponentClass: ExampleComponent,
         template:
-          '{{#let something as |somethingElse|}}<a href="#" {{action "edit"}}>click me</a>{{/let}}',
+          '{{#let this.something as |somethingElse|}}<a href="#" {{action "edit"}}>click me</a>{{/let}}',
       });
 
       this.render('{{example-component}}');
@@ -813,10 +814,10 @@ moduleFor(
 
       this.registerComponent('example-component', {
         ComponentClass: ExampleComponent,
-        template: '{{#if isActive}}<a href="#" {{action "edit"}}>click me</a>{{/if}}',
+        template: '{{#if this.isActive}}<a href="#" {{action "edit"}}>click me</a>{{/if}}',
       });
 
-      this.render('{{example-component isActive=isActive}}', {
+      this.render('{{example-component isActive=this.isActive}}', {
         isActive: true,
       });
 
@@ -1064,7 +1065,7 @@ moduleFor(
 
       this.registerComponent('example-component', {
         ComponentClass: ExampleComponent,
-        template: '<button {{action "edit" modelA modelB}}>click me</button>',
+        template: '<button {{action "edit" this.modelA this.modelB}}>click me</button>',
       });
 
       this.render('{{example-component}}');
@@ -1220,7 +1221,7 @@ moduleFor(
 
       this.registerComponent('example-component', {
         ComponentClass: ExampleComponent,
-        template: '<a id="bound-param" {{action hookMeUp}}>Whistle tips go woop woooop</a>',
+        template: '<a id="bound-param" {{action this.hookMeUp}}>Whistle tips go woop woooop</a>',
       });
 
       this.render('{{example-component}}');
@@ -1284,7 +1285,7 @@ moduleFor(
       this.registerComponent('example-component', {
         ComponentClass: ExampleComponent,
         template:
-          '{{#each allactions as |allaction|}}<a id="{{allaction.name}}" {{action allaction.name}}>{{allaction.title}}</a>{{/each}}',
+          '{{#each this.allactions as |allaction|}}<a id="{{allaction.name}}" {{action allaction.name}}>{{allaction.title}}</a>{{/each}}',
       });
 
       this.render('{{example-component}}');
@@ -1325,7 +1326,7 @@ moduleFor(
 
       this.registerComponent('example-component', {
         ComponentClass: ExampleComponent,
-        template: `<a {{action submit '${arg}'}}>Hi</a>`,
+        template: `<a {{action this.submit '${arg}'}}>Hi</a>`,
       });
 
       this.render('{{example-component}}');
@@ -1347,7 +1348,7 @@ moduleFor(
 
       this.registerComponent('example-component', {
         ComponentClass: ExampleComponent,
-        template: '<a id="oops-bound-param" {{action ohNoeNotValid}}>Hi</a>',
+        template: '<a id="oops-bound-param" {{action this.ohNoeNotValid}}>Hi</a>',
       });
 
       expectAssertion(() => {
@@ -1467,7 +1468,7 @@ moduleFor(
 
       this.registerComponent('example-component', {
         ComponentClass: ExampleComponent,
-        template: '<a {{action "show" preventDefault=shouldPreventDefault}}>Hi</a>',
+        template: '<a {{action "show" preventDefault=this.shouldPreventDefault}}>Hi</a>',
       });
 
       this.render('{{example-component}}');
@@ -1560,7 +1561,7 @@ moduleFor(
       this.registerComponent('example-component', {
         ComponentClass: ExampleComponent,
         template:
-          '<button {{action (mut label) "Clicked!"}}>{{if label label "Click me"}}</button>',
+          '<button {{action (mut this.label) "Clicked!"}}>{{if this.label this.label "Click me"}}</button>',
       });
 
       this.render('{{example-component}}');
@@ -1597,9 +1598,9 @@ moduleFor(
     ['@test it supports non-registered actions [GH#14888]']() {
       this.render(
         `
-      {{#if show}}
-        <button id='ddButton' {{action (mut show) false}}>
-          Show ({{show}})
+      {{#if this.show}}
+        <button id='ddButton' {{action (mut this.show) false}}>
+          Show ({{this.show}})
         </button>
       {{/if}}
     `,
@@ -1629,7 +1630,7 @@ moduleFor(
       this.registerComponent('example-component', {
         ComponentClass: ExampleComponent,
         template:
-          '<button class="{{if selected \'selected\'}}" {{action "toggleSelected"}}>Toggle Selected</button>',
+          '<button class="{{if this.selected \'selected\'}}" {{action "toggleSelected"}}>Toggle Selected</button>',
       });
 
       this.render('{{example-component}}');
@@ -1765,7 +1766,7 @@ moduleFor(
 
       this.registerComponent('example-component', {
         ComponentClass: ExampleComponent,
-        template: '<div id="inner" {{action "show" on=eventType}}></div>',
+        template: '<div id="inner" {{action "show" on=this.eventType}}></div>',
       });
 
       expectDeprecation(

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/get-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/get-test.js
@@ -9,7 +9,7 @@ moduleFor(
   'Helpers test: {{get}}',
   class extends RenderingTestCase {
     ['@test should be able to get an object value with a static key']() {
-      this.render(`[{{get colors 'apple'}}] [{{if true (get colors 'apple')}}]`, {
+      this.render(`[{{get this.colors 'apple'}}] [{{if true (get this.colors 'apple')}}]`, {
         colors: { apple: 'red' },
       });
 
@@ -33,13 +33,16 @@ moduleFor(
     }
 
     ['@test should be able to get an object value with nested static key']() {
-      this.render(`[{{get colors "apple.gala"}}] [{{if true (get colors "apple.gala")}}]`, {
-        colors: {
-          apple: {
-            gala: 'red and yellow',
+      this.render(
+        `[{{get this.colors "apple.gala"}}] [{{if true (get this.colors "apple.gala")}}]`,
+        {
+          colors: {
+            apple: {
+              gala: 'red and yellow',
+            },
           },
-        },
-      });
+        }
+      );
 
       this.assertText('[red and yellow] [red and yellow]');
 
@@ -57,7 +60,7 @@ moduleFor(
     }
 
     ['@test should be able to get an object value with a number']() {
-      this.render(`[{{get items 1}}][{{get items 2}}][{{get items 3}}]`, {
+      this.render(`[{{get this.items 1}}][{{get this.items 2}}][{{get this.items 3}}]`, {
         indexes: [1, 2, 3],
         items: {
           1: 'First',
@@ -82,7 +85,7 @@ moduleFor(
     }
 
     ['@test should be able to get an array value with a number']() {
-      this.render(`[{{get numbers 0}}][{{get numbers 1}}][{{get numbers 2}}]`, {
+      this.render(`[{{get this.numbers 0}}][{{get this.numbers 1}}][{{get this.numbers 2}}]`, {
         numbers: [1, 2, 3],
       });
 
@@ -102,7 +105,7 @@ moduleFor(
     }
 
     ['@test should be able to get an object value with a path evaluating to a number']() {
-      this.render(`{{#each indexes as |index|}}[{{get items index}}]{{/each}}`, {
+      this.render(`{{#each this.indexes as |index|}}[{{get this.items index}}]{{/each}}`, {
         indexes: [1, 2, 3],
         items: {
           1: 'First',
@@ -127,7 +130,7 @@ moduleFor(
     }
 
     ['@test should be able to get an array value with a path evaluating to a number']() {
-      this.render(`{{#each numbers as |num index|}}[{{get numbers index}}]{{/each}}`, {
+      this.render(`{{#each this.numbers as |num index|}}[{{get this.numbers index}}]{{/each}}`, {
         numbers: [1, 2, 3],
       });
 
@@ -143,7 +146,7 @@ moduleFor(
     }
 
     ['@test should be able to get an object value with a bound/dynamic key']() {
-      this.render(`[{{get colors key}}] [{{if true (get colors key)}}]`, {
+      this.render(`[{{get this.colors this.key}}] [{{if true (get this.colors this.key)}}]`, {
         colors: { apple: 'red', banana: 'yellow' },
         key: 'apple',
       });
@@ -175,7 +178,7 @@ moduleFor(
     }
 
     ['@test should be able to get an object value with nested dynamic key']() {
-      this.render(`[{{get colors key}}] [{{if true (get colors key)}}]`, {
+      this.render(`[{{get this.colors this.key}}] [{{if true (get this.colors this.key)}}]`, {
         colors: {
           apple: {
             gala: 'red and yellow',
@@ -207,7 +210,7 @@ moduleFor(
 
     ['@test should be able to get an object value with subexpression returning nested key']() {
       this.render(
-        `[{{get colors (concat 'apple' '.' 'gala')}}] [{{if true (get colors (concat 'apple' '.' 'gala'))}}]`,
+        `[{{get this.colors (concat 'apple' '.' 'gala')}}] [{{if true (get this.colors (concat 'apple' '.' 'gala'))}}]`,
         {
           colors: {
             apple: {
@@ -247,7 +250,7 @@ moduleFor(
 
     ['@test should be able to get an object value with a get helper as the key']() {
       this.render(
-        `[{{get colors (get possibleKeys key)}}] [{{if true (get colors (get possibleKeys key))}}]`,
+        `[{{get this.colors (get this.possibleKeys this.key)}}] [{{if true (get this.colors (get this.possibleKeys this.key))}}]`,
         {
           colors: { apple: 'red', banana: 'yellow' },
           key: 'key1',
@@ -283,7 +286,7 @@ moduleFor(
 
     ['@test should be able to get an object value with a get helper value as a bound/dynamic key']() {
       this.render(
-        `[{{get (get possibleValues objectKey) key}}] [{{if true (get (get possibleValues objectKey) key)}}]`,
+        `[{{get (get this.possibleValues this.objectKey) this.key}}] [{{if true (get (get this.possibleValues this.objectKey) this.key)}}]`,
         {
           possibleValues: {
             colors1: { apple: 'red', banana: 'yellow' },
@@ -325,7 +328,7 @@ moduleFor(
 
     ['@test should be able to get an object value with a get helper as the value and a get helper as the key']() {
       this.render(
-        `[{{get (get possibleValues objectKey) (get possibleKeys key)}}] [{{if true (get (get possibleValues objectKey) (get possibleKeys key))}}]`,
+        `[{{get (get this.possibleValues this.objectKey) (get this.possibleKeys this.key)}}] [{{if true (get (get this.possibleValues this.objectKey) (get this.possibleKeys this.key))}}]`,
         {
           possibleValues: {
             colors1: { apple: 'red', banana: 'yellow' },
@@ -382,10 +385,10 @@ moduleFor(
 
       this.registerComponent('foo-bar', {
         ComponentClass: FooBarComponent,
-        template: `{{yield (get colors mcintosh)}}`,
+        template: `{{yield (get this.colors this.mcintosh)}}`,
       });
 
-      this.render(`{{#foo-bar colors=colors as |value|}}{{value}}{{/foo-bar}}`, {
+      this.render(`{{#foo-bar colors=this.colors as |value|}}{{value}}{{/foo-bar}}`, {
         colors: {
           red: 'banana',
         },
@@ -413,7 +416,7 @@ moduleFor(
     }
 
     ['@test should handle object values as nulls']() {
-      this.render(`[{{get colors 'apple'}}] [{{if true (get colors 'apple')}}]`, {
+      this.render(`[{{get this.colors 'apple'}}] [{{if true (get this.colors 'apple')}}]`, {
         colors: null,
       });
 
@@ -433,7 +436,7 @@ moduleFor(
     }
 
     ['@test should handle object keys as nulls']() {
-      this.render(`[{{get colors key}}] [{{if true (get colors key)}}]`, {
+      this.render(`[{{get this.colors this.key}}] [{{if true (get this.colors this.key)}}]`, {
         colors: {
           apple: 'red',
           banana: 'yellow',
@@ -457,7 +460,7 @@ moduleFor(
     }
 
     ['@test should handle object values and keys as nulls']() {
-      this.render(`[{{get colors 'apple'}}] [{{if true (get colors key)}}]`, {
+      this.render(`[{{get this.colors 'apple'}}] [{{if true (get this.colors this.key)}}]`, {
         colors: null,
         key: null,
       });
@@ -466,7 +469,7 @@ moduleFor(
     }
 
     ['@test get helper value should be updatable using {{input}} and (mut) - static key'](assert) {
-      this.render(`{{input type='text' value=(mut (get source 'banana')) id='get-input'}}`, {
+      this.render(`{{input type='text' value=(mut (get this.source 'banana')) id='get-input'}}`, {
         source: {
           banana: 'banana',
         },
@@ -493,7 +496,7 @@ moduleFor(
     }
 
     ['@test get helper value should be updatable using {{input}} and (mut) - dynamic key'](assert) {
-      this.render(`{{input type='text' value=(mut (get source key)) id='get-input'}}`, {
+      this.render(`{{input type='text' value=(mut (get this.source this.key)) id='get-input'}}`, {
         source: {
           apple: 'apple',
           banana: 'banana',
@@ -536,7 +539,7 @@ moduleFor(
     ['@test get helper value should be updatable using {{input}} and (mut) - dynamic nested key'](
       assert
     ) {
-      this.render(`{{input type='text' value=(mut (get source key)) id='get-input'}}`, {
+      this.render(`{{input type='text' value=(mut (get this.source this.key)) id='get-input'}}`, {
         source: {
           apple: {
             gala: 'gala',
@@ -604,7 +607,7 @@ moduleFor(
         template: '{{#each this.options as |option|}}{{get this.args option}}{{/each}}',
       });
 
-      this.render('<PersonWrapper @first={{first}} @last={{last}} @age={{age}}/>', {
+      this.render('<PersonWrapper @first={{this.first}} @last={{this.last}} @age={{this.age}}/>', {
         first: 'miguel',
         last: 'andrade',
       });

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/hash-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/hash-test.js
@@ -156,7 +156,7 @@ moduleFor(
 
       this.registerComponent('foo-bar', {
         ComponentClass: FooBarComponent,
-        template: `{{yield (hash firstName=this.model.firstName lastName=lastName)}}`,
+        template: `{{yield (hash firstName=this.model.firstName lastName=this.lastName)}}`,
       });
 
       this.render(

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/helper-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/helper-manager-test.js
@@ -84,7 +84,7 @@ if (EMBER_GLIMMER_HELPER_MANAGER) {
           }
         );
 
-        this.render('{{hello foo=foo}}', {
+        this.render('{{hello foo=this.foo}}', {
           foo: 123,
         });
 
@@ -115,7 +115,7 @@ if (EMBER_GLIMMER_HELPER_MANAGER) {
           }
         );
 
-        this.render('{{hello foo}}', {
+        this.render('{{hello this.foo}}', {
           foo: 123,
         });
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/loc-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/loc-test.js
@@ -76,12 +76,15 @@ moduleFor(
 
     ['@test it updates when nested bound params change']() {
       expectDeprecation(() => {
-        this.render(`{{loc this.greetings.simple}} - {{loc this.greetings.personal 'Mr. Pitkin'}}`, {
-          greetings: {
-            simple: 'Hello Friend',
-            personal: 'Hello',
-          },
-        });
+        this.render(
+          `{{loc this.greetings.simple}} - {{loc this.greetings.personal 'Mr. Pitkin'}}`,
+          {
+            greetings: {
+              simple: 'Hello Friend',
+              personal: 'Hello',
+            },
+          }
+        );
       }, /loc is deprecated/);
       this.assertText('Hallo Freund - Hallo, Mr. Pitkin', 'the bound value is correct');
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/loc-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/loc-test.js
@@ -44,7 +44,7 @@ moduleFor(
 
     ['@test it updates when bound params change']() {
       expectDeprecation(() => {
-        this.render(`{{loc simple}} - {{loc personal 'Mr. Pitkin'}}`, {
+        this.render(`{{loc this.simple}} - {{loc this.personal 'Mr. Pitkin'}}`, {
           simple: 'Hello Friend',
           personal: 'Hello',
         });
@@ -76,7 +76,7 @@ moduleFor(
 
     ['@test it updates when nested bound params change']() {
       expectDeprecation(() => {
-        this.render(`{{loc greetings.simple}} - {{loc greetings.personal 'Mr. Pitkin'}}`, {
+        this.render(`{{loc this.greetings.simple}} - {{loc this.greetings.personal 'Mr. Pitkin'}}`, {
           greetings: {
             simple: 'Hello Friend',
             personal: 'Hello',
@@ -115,7 +115,7 @@ moduleFor(
 
     ['@test it can be overriden']() {
       this.registerHelper('loc', () => 'Yup');
-      this.render(`{{loc greeting}}`, {
+      this.render(`{{loc this.greeting}}`, {
         greeting: 'Hello Friend',
       });
       this.assertText('Yup', 'the localized string is correct');

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/log-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/log-test.js
@@ -37,7 +37,7 @@ moduleFor(
     }
 
     ['@test correctly logs a property']() {
-      this.render(`{{log value}}`, {
+      this.render(`{{log this.value}}`, {
         value: 'one',
       });
 
@@ -45,7 +45,7 @@ moduleFor(
     }
 
     ['@test correctly logs multiple arguments']() {
-      this.render(`{{log "my variable:" value}}`, {
+      this.render(`{{log "my variable:" this.value}}`, {
         value: 'one',
       });
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/mut-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/mut-test.js
@@ -16,14 +16,14 @@ moduleFor(
             bottom = this;
           },
         }),
-        template: '{{setMe}}',
+        template: '{{this.setMe}}',
       });
 
       this.registerComponent('middle-mut', {
-        template: '{{bottom-mut setMe=value}}',
+        template: '{{bottom-mut setMe=this.value}}',
       });
 
-      this.render('{{middle-mut value=(mut val)}}', {
+      this.render('{{middle-mut value=(mut this.val)}}', {
         val: 12,
       });
 
@@ -59,7 +59,7 @@ moduleFor(
             bottom = this;
           },
         }),
-        template: '{{setMe}}',
+        template: '{{this.setMe}}',
       });
 
       this.registerComponent('middle-mut', {
@@ -68,10 +68,10 @@ moduleFor(
             middle = this;
           },
         }),
-        template: '{{bottom-mut setMe=(mut value)}}',
+        template: '{{bottom-mut setMe=(mut this.value)}}',
       });
 
-      this.render('{{middle-mut value=(mut val)}}', {
+      this.render('{{middle-mut value=(mut this.val)}}', {
         val: 12,
       });
 
@@ -103,7 +103,7 @@ moduleFor(
     }
 
     ['@test passing a literal results in a assertion']() {
-      this.registerComponent('bottom-mut', { template: '{{setMe}}' });
+      this.registerComponent('bottom-mut', { template: '{{this.setMe}}' });
 
       expectAssertion(() => {
         this.render('{{bottom-mut setMe=(mut "foo bar")}}');
@@ -111,7 +111,7 @@ moduleFor(
     }
 
     ['@test passing the result of a helper invocation results in an assertion']() {
-      this.registerComponent('bottom-mut', { template: '{{setMe}}' });
+      this.registerComponent('bottom-mut', { template: '{{this.setMe}}' });
 
       expectAssertion(() => {
         this.render('{{bottom-mut setMe=(mut (concat "foo" " " "bar"))}}');
@@ -128,11 +128,11 @@ moduleFor(
             bottom = this;
           },
         }),
-        template: '{{stuff}}',
+        template: '{{this.stuff}}',
       });
 
       this.registerComponent('middle-mut', {
-        template: '{{bottom-mut stuff=value}}',
+        template: '{{bottom-mut stuff=this.value}}',
       });
 
       this.render('{{middle-mut value="foo"}}');
@@ -154,7 +154,7 @@ moduleFor(
             bottom = this;
           },
         }),
-        template: '{{setMe}}',
+        template: '{{this.setMe}}',
       });
 
       this.registerComponent('middle-mut', {
@@ -163,10 +163,10 @@ moduleFor(
             middle = this;
           },
         }),
-        template: '{{bottom-mut setMe=(readonly value)}}',
+        template: '{{bottom-mut setMe=(readonly this.value)}}',
       });
 
-      this.render('{{middle-mut value=(mut val)}}', {
+      this.render('{{middle-mut value=(mut this.val)}}', {
         val: 12,
       });
 
@@ -237,14 +237,14 @@ moduleFor(
             bottom = this;
           },
         }),
-        template: '{{setMe}}',
+        template: '{{this.setMe}}',
       });
 
       this.registerComponent('middle-mut', {
-        template: '{{bottom-mut setMe=(mut value)}}',
+        template: '{{bottom-mut setMe=(mut this.value)}}',
       });
 
-      this.render('{{middle-mut value=(mut val)}}', {
+      this.render('{{middle-mut value=(mut this.val)}}', {
         val: 12,
       });
 
@@ -285,7 +285,7 @@ moduleFor(
             bottom = this;
           },
         }),
-        template: '{{thingy}}',
+        template: '{{this.thingy}}',
       });
 
       this.registerComponent('middle-mut', {
@@ -298,7 +298,7 @@ moduleFor(
             middle = this;
           },
         }),
-        template: '{{bottom-mut thingy=(mut val)}}',
+        template: '{{bottom-mut thingy=(mut this.val)}}',
       });
 
       this.render('{{middle-mut}}');
@@ -337,14 +337,14 @@ moduleFor(
             inner = this;
           },
         }),
-        template: '{{foo}}',
+        template: '{{this.foo}}',
       });
 
       this.registerComponent('x-outer', {
-        template: '{{x-inner foo=bar}}',
+        template: '{{x-inner foo=this.bar}}',
       });
 
-      this.render('{{x-outer bar=baz}}', { baz: 'foo' });
+      this.render('{{x-outer bar=this.baz}}', { baz: 'foo' });
 
       this.assertText('foo');
 
@@ -458,10 +458,10 @@ moduleFor(
           }),
           height: 20,
         }),
-        template: '{{height}}',
+        template: '{{this.height}}',
       });
 
-      this.render('{{x-output height=height}}{{x-input height=(mut height)}}', {
+      this.render('{{x-output height=this.height}}{{x-input height=(mut this.height)}}', {
         height: 60,
       });
 
@@ -536,10 +536,10 @@ moduleFor(
             },
           }),
         }),
-        template: '{{width}}x{{height}}',
+        template: '{{this.width}}x{{this.height}}',
       });
 
-      this.render('{{x-output width=width}}{{x-input width=(mut width)}}', {
+      this.render('{{x-output width=this.width}}{{x-input width=(mut this.width)}}', {
         width: 70,
       });
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/partial-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/partial-test.js
@@ -61,7 +61,7 @@ moduleFor(
 
       expectDeprecation(() => {
         this.render(
-          'This {{partial templates.partialName}} is pretty {{partial nonexistent}}great.',
+          'This {{partial this.templates.partialName}} is pretty {{partial this.nonexistent}}great.',
           {
             templates: { partialName: 'subTemplate' },
           }
@@ -163,7 +163,7 @@ moduleFor(
       expectDeprecation(() => {
         this.render(
           strip`
-        {{#each items as |item|}}
+        {{#each this.items as |item|}}
           {{item.id}}: {{partial 'show-item'}} |
         {{/each}}`,
           {
@@ -195,7 +195,7 @@ moduleFor(
       expectDeprecation(() => {
         this.render(
           strip`
-        {{#each items as |item|}}
+        {{#each this.items as |item|}}
           {{item}}: {{partial 'show-item'}} |
         {{/each}}`,
           {
@@ -232,7 +232,7 @@ moduleFor(
       expectDeprecation(() => {
         this.render(
           strip`
-        {{#each names as |name i|}}
+        {{#each this.names as |name i|}}
           {{i}}: {{partial 'outer-partial'}}
         {{/each}}`,
           {
@@ -290,7 +290,7 @@ moduleFor(
         this.render(
           strip`
         {{#let 'Sophie' as |person1|}}
-          Hi {{person1}} (aged {{age}}). {{partial 'person2-partial'}}
+          Hi {{person1}} (aged {{this.age}}). {{partial 'person2-partial'}}
         {{/let}}`,
           { age: 0 }
         );
@@ -358,7 +358,7 @@ moduleFor(
       expectDeprecation(() => {
         this.render(
           strip`
-        {{#with item.thing as |t|}}
+        {{#with this.item.thing as |t|}}
           {{partial t}}
         {{else}}
           Nothing!
@@ -389,7 +389,7 @@ moduleFor(
 
       this.render(
         strip`
-      {{#let item.thing as |t|}}
+      {{#let this.item.thing as |t|}}
         {{partial t}}
       {{/let}}`,
         {
@@ -414,11 +414,11 @@ moduleFor(
 
     ['@test partials which contain contextual components']() {
       this.registerComponent('outer-component', {
-        template: '{{yield (hash inner=(component "inner-component" name=name))}}',
+        template: '{{yield (hash inner=(component "inner-component" name=this.name))}}',
       });
 
       this.registerComponent('inner-component', {
-        template: '{{yield (hash name=name)}}',
+        template: '{{yield (hash name=this.name)}}',
       });
 
       this.registerPartial(
@@ -433,7 +433,7 @@ moduleFor(
       expectDeprecation(() => {
         this.render(
           strip`
-        {{#outer-component name=name as |outer|}}
+        {{#outer-component name=this.name as |outer|}}
           {{partial 'some-partial'}}
         {{/outer-component}}`,
           { name: 'Sophie' }

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/readonly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/readonly-test.js
@@ -16,10 +16,10 @@ moduleFor(
             component = this;
           },
         }),
-        template: '{{value}}',
+        template: '{{this.value}}',
       });
 
-      this.render('{{foo-bar value=(readonly val)}}', {
+      this.render('{{foo-bar value=(readonly this.val)}}', {
         val: 12,
       });
 
@@ -56,10 +56,10 @@ moduleFor(
             outer = this;
           },
         }),
-        template: '{{x-inner onClick=(readonly onClick)}}',
+        template: '{{x-inner onClick=(readonly this.onClick)}}',
       });
 
-      this.render('{{x-outer onClick=(action doIt)}}', {
+      this.render('{{x-outer onClick=(action this.doIt)}}', {
         doIt() {
           assert.ok(true, 'action was called');
         },
@@ -90,10 +90,10 @@ moduleFor(
             component = this;
           },
         }),
-        template: '{{value}}',
+        template: '{{this.value}}',
       });
 
-      this.render('{{foo-bar value=(readonly thing)}}', {
+      this.render('{{foo-bar value=(readonly this.thing)}}', {
         thing: 'initial',
       });
 
@@ -125,10 +125,10 @@ moduleFor(
             component = this;
           },
         }),
-        template: '{{value.prop}}',
+        template: '{{this.value.prop}}',
       });
 
-      this.render('{{foo-bar value=(readonly thing)}}', {
+      this.render('{{foo-bar value=(readonly this.thing)}}', {
         thing: {
           prop: 'initial',
         },
@@ -162,7 +162,7 @@ moduleFor(
             component = this;
           },
         }),
-        template: '{{value}}',
+        template: '{{this.value}}',
       });
 
       this.render('{{foo-bar value=(readonly "12")}}');
@@ -193,7 +193,7 @@ moduleFor(
             bottom = this;
           },
         }),
-        template: '{{bar}}',
+        template: '{{this.bar}}',
       });
 
       this.registerComponent('x-middle', {
@@ -202,10 +202,10 @@ moduleFor(
             middle = this;
           },
         }),
-        template: '{{foo}} {{x-bottom bar=(mut foo)}}',
+        template: '{{this.foo}} {{x-bottom bar=(mut this.foo)}}',
       });
 
-      this.render('{{x-middle foo=(readonly val)}}', {
+      this.render('{{x-middle foo=(readonly this.val)}}', {
         val: 12,
       });
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/unbound-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/unbound-test.js
@@ -15,7 +15,7 @@ moduleFor(
   'Helpers test: {{unbound}}',
   class extends RenderingTestCase {
     ['@test should be able to output a property without binding']() {
-      this.render(`<div id="first">{{unbound content.anUnboundString}}</div>`, {
+      this.render(`<div id="first">{{unbound this.content.anUnboundString}}</div>`, {
         content: {
           anUnboundString: 'No spans here, son.',
         },
@@ -41,7 +41,7 @@ moduleFor(
     }
 
     ['@test should be able to use unbound helper in #each helper']() {
-      this.render(`<ul>{{#each items as |item|}}<li>{{unbound item}}</li>{{/each}}</ul>`, {
+      this.render(`<ul>{{#each this.items as |item|}}<li>{{unbound item}}</li>{{/each}}</ul>`, {
         items: emberA(['a', 'b', 'c', 1, 2, 3]),
       });
 
@@ -53,9 +53,12 @@ moduleFor(
     }
 
     ['@test should be able to use unbound helper in #each helper (with objects)']() {
-      this.render(`<ul>{{#each items as |item|}}<li>{{unbound item.wham}}</li>{{/each}}</ul>`, {
-        items: emberA([{ wham: 'bam' }, { wham: 1 }]),
-      });
+      this.render(
+        `<ul>{{#each this.items as |item|}}<li>{{unbound item.wham}}</li>{{/each}}</ul>`,
+        {
+          items: emberA([{ wham: 'bam' }, { wham: 1 }]),
+        }
+      );
 
       this.assertText('bam1');
 
@@ -74,7 +77,7 @@ moduleFor(
 
     ['@test it should assert unbound cannot be called with multiple arguments']() {
       let willThrow = () => {
-        this.render(`{{unbound foo bar}}`, {
+        this.render(`{{unbound this.foo this.bar}}`, {
           foo: 'BORK',
           bar: 'BLOOP',
         });
@@ -123,7 +126,7 @@ moduleFor(
       ]);
 
       this.render(
-        `<ul>{{#each people as |person|}}<li><a href="{{unbound person.url}}">{{person.name}}</a></li>{{/each}}</ul>`,
+        `<ul>{{#each this.people as |person|}}<li><a href="{{unbound person.url}}">{{person.name}}</a></li>{{/each}}</ul>`,
         {
           people: unsafeUrls,
         }
@@ -159,7 +162,7 @@ moduleFor(
     }
 
     ['@skip helper form updates on parent re-render']() {
-      this.render(`{{unbound foo}}`, {
+      this.render(`{{unbound this.foo}}`, {
         foo: 'BORK',
       });
 
@@ -192,7 +195,7 @@ moduleFor(
     ['@test sexpr form does not update no matter what']() {
       this.registerHelper('capitalize', (args) => args[0].toUpperCase());
 
-      this.render(`{{capitalize (unbound foo)}}`, {
+      this.render(`{{capitalize (unbound this.foo)}}`, {
         foo: 'bork',
       });
 
@@ -226,7 +229,7 @@ moduleFor(
 
       this.registerHelper('doublize', (params) => `${params[0]} ${params[0]}`);
 
-      this.render(`{{capitalize (unbound (doublize foo))}}`, {
+      this.render(`{{capitalize (unbound (doublize this.foo))}}`, {
         foo: 'bork',
       });
 
@@ -265,7 +268,7 @@ moduleFor(
       });
 
       this.render(
-        `{{unbound (repeat foo count=bar)}} {{repeat foo count=bar}} {{unbound (repeat foo count=2)}} {{repeat foo count=4}}`,
+        `{{unbound (repeat this.foo count=this.bar)}} {{repeat this.foo count=this.bar}} {{unbound (repeat this.foo count=2)}} {{repeat this.foo count=4}}`,
         {
           foo: 'X',
           bar: 5,
@@ -404,7 +407,7 @@ moduleFor(
       });
 
       this.render(
-        `{{capitalizeName person}} {{unbound (capitalizeName person)}} {{concatNames person}} {{unbound (concatNames person)}}`,
+        `{{capitalizeName this.person}} {{unbound (capitalizeName this.person)}} {{concatNames this.person}} {{unbound (concatNames this.person)}}`,
         {
           person: {
             firstName: 'shooby',
@@ -440,7 +443,7 @@ moduleFor(
       this.registerHelper('capitalize', (params) => params[0].toUpperCase());
 
       this.render(
-        `{{#each people as |person|}}{{capitalize person.firstName}} {{unbound (capitalize person.firstName)}}{{/each}}`,
+        `{{#each this.people as |person|}}{{capitalize person.firstName}} {{unbound (capitalize person.firstName)}}{{/each}}`,
         {
           people: emberA([
             {
@@ -523,7 +526,7 @@ moduleFor(
       });
 
       this.render(
-        `{{capitalizeName person}} {{unbound (capitalizeName person)}} {{concatNames person}} {{unbound (concatNames person)}}`,
+        `{{capitalizeName this.person}} {{unbound (capitalizeName this.person)}} {{concatNames this.person}} {{unbound (concatNames this.person)}}`,
         {
           person: {
             firstName: 'shooby',

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/yield-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/yield-test.js
@@ -12,7 +12,7 @@ moduleFor(
         template: '[In layout:] {{yield}}',
       });
 
-      this.render('{{#yield-comp}}[In Block:] {{object.title}}{{/yield-comp}}', {
+      this.render('{{#yield-comp}}[In Block:] {{this.object.title}}{{/yield-comp}}', {
         object: { title: 'Seattle' },
       });
       this.assertText('[In layout:] [In Block:] Seattle');
@@ -38,7 +38,7 @@ moduleFor(
         // ComponentClass: require('../../utils/glimmerish-component').default,
       });
 
-      this.render('<YieldComp><:block>[In block:] {{object.title}}</:block></YieldComp>', {
+      this.render('<YieldComp><:block>[In block:] {{this.object.title}}</:block></YieldComp>', {
         object: { title: 'Seattle' },
       });
 
@@ -58,10 +58,10 @@ moduleFor(
         template: '<div>[In layout:] {{yield}}</div>',
       });
       this.registerComponent('inner-comp', {
-        template: '{{#outer-comp}}[In Block:] {{object.title}}{{/outer-comp}}',
+        template: '{{#outer-comp}}[In Block:] {{this.object.title}}{{/outer-comp}}',
       });
 
-      this.render('{{inner-comp object=object}}', {
+      this.render('{{inner-comp object=this.object}}', {
         object: { title: 'Seattle' },
       });
       this.assertText('[In layout:] [In Block:] Seattle');
@@ -79,10 +79,10 @@ moduleFor(
       let list = [1, 2, 3];
 
       this.registerComponent('outer-comp', {
-        template: '{{#each list as |item|}}{{yield}}{{/each}}',
+        template: '{{#each this.list as |item|}}{{yield}}{{/each}}',
       });
 
-      this.render('{{#outer-comp list=list}}Hello{{/outer-comp}}', {
+      this.render('{{#outer-comp list=this.list}}Hello{{/outer-comp}}', {
         list: list,
       });
       this.assertText('HelloHelloHello');
@@ -98,10 +98,10 @@ moduleFor(
 
     ['@test templates should yield to block, when the yield is embedded in a if helper']() {
       this.registerComponent('outer-comp', {
-        template: '{{#if boolean}}{{yield}}{{/if}}',
+        template: '{{#if this.boolean}}{{yield}}{{/if}}',
       });
 
-      this.render('{{#outer-comp boolean=boolean}}Hello{{/outer-comp}}', {
+      this.render('{{#outer-comp boolean=this.boolean}}Hello{{/outer-comp}}', {
         boolean: true,
       });
       this.assertText('Hello');
@@ -117,10 +117,10 @@ moduleFor(
 
     ['@test simple curlies inside of a yielded block should work when the yield is nested inside of another view']() {
       this.registerComponent('kiwi-comp', {
-        template: '{{#if falsy}}{{else}}{{yield}}{{/if}}',
+        template: '{{#if this.falsy}}{{else}}{{yield}}{{/if}}',
       });
 
-      this.render('{{#kiwi-comp}}{{text}}{{/kiwi-comp}}', { text: 'ohai' });
+      this.render('{{#kiwi-comp}}{{this.text}}{{/kiwi-comp}}', { text: 'ohai' });
       this.assertText('ohai');
 
       this.assertStableRerender();
@@ -134,13 +134,13 @@ moduleFor(
 
     ['@test nested simple curlies inside of a yielded block should work when the yield is nested inside of another view']() {
       this.registerComponent('parent-comp', {
-        template: '{{#if falsy}}{{else}}{{yield}}{{/if}}',
+        template: '{{#if this.falsy}}{{else}}{{yield}}{{/if}}',
       });
       this.registerComponent('child-comp', {
-        template: '{{#if falsy}}{{else}}{{text}}{{/if}}',
+        template: '{{#if this.falsy}}{{else}}{{this.text}}{{/if}}',
       });
 
-      this.render('{{#parent-comp}}{{child-comp text=text}}{{/parent-comp}}', {
+      this.render('{{#parent-comp}}{{child-comp text=this.text}}{{/parent-comp}}', {
         text: 'ohai',
       });
       this.assertText('ohai');
@@ -157,10 +157,10 @@ moduleFor(
     ['@test yielding to a non-existent block is not an error']() {
       this.registerComponent('yielding-comp', { template: 'Hello:{{yield}}' });
       this.registerComponent('outer-comp', {
-        template: '{{yielding-comp}} {{title}}',
+        template: '{{yielding-comp}} {{this.title}}',
       });
 
-      this.render('{{outer-comp title=title}}', { title: 'Mr. Selden' });
+      this.render('{{outer-comp title=this.title}}', { title: 'Mr. Selden' });
 
       this.assertText('Hello: Mr. Selden');
 
@@ -178,10 +178,10 @@ moduleFor(
 
       this.registerComponent('kiwi-comp', {
         ComponentClass: KiwiCompComponent,
-        template: '<p>{{boundText}}</p><p>{{yield}}</p>',
+        template: '<p>{{this.boundText}}</p><p>{{yield}}</p>',
       });
 
-      this.render('{{#kiwi-comp}}{{boundText}}{{/kiwi-comp}}', {
+      this.render('{{#kiwi-comp}}{{this.boundText}}{{/kiwi-comp}}', {
         boundText: 'Original',
       });
       this.assertText('InnerOriginal');
@@ -200,10 +200,10 @@ moduleFor(
 
       this.registerComponent('kiwi-comp', {
         ComponentClass: KiwiCompComponent,
-        template: '<p>{{boundText}}</p><p>{{yield}}</p>',
+        template: '<p>{{this.boundText}}</p><p>{{yield}}</p>',
       });
 
-      this.render('{{#let boundText as |item|}}{{#kiwi-comp}}{{item}}{{/kiwi-comp}}{{/let}}', {
+      this.render('{{#let this.boundText as |item|}}{{#kiwi-comp}}{{item}}{{/kiwi-comp}}{{/let}}', {
         boundText: 'Outer',
       });
       this.assertText('InnerOuter');
@@ -222,10 +222,10 @@ moduleFor(
 
       this.registerComponent('kiwi-comp', {
         ComponentClass: KiwiCompComponent,
-        template: '{{#let boundText as |item|}}<p>{{item}}</p><p>{{yield}}</p>{{/let}}',
+        template: '{{#let this.boundText as |item|}}<p>{{item}}</p><p>{{yield}}</p>{{/let}}',
       });
 
-      this.render('{{#kiwi-comp}}{{item}}{{/kiwi-comp}}', { item: 'Outer' });
+      this.render('{{#kiwi-comp}}{{this.item}}{{/kiwi-comp}}', { item: 'Outer' });
       this.assertText('InnerOuter');
 
       this.assertStableRerender();
@@ -239,11 +239,11 @@ moduleFor(
 
     ['@test can bind a block param to a component and use it in yield']() {
       this.registerComponent('kiwi-comp', {
-        template: '<p>{{content}}</p><p>{{yield}}</p>',
+        template: '<p>{{this.content}}</p><p>{{yield}}</p>',
       });
 
       this.render(
-        '{{#let boundText as |item|}}{{#kiwi-comp content=item}}{{item}}{{/kiwi-comp}}{{/let}}',
+        '{{#let this.boundText as |item|}}{{#kiwi-comp content=item}}{{item}}{{/kiwi-comp}}{{/let}}',
         { boundText: 'Outer' }
       );
       this.assertText('OuterOuter');
@@ -287,7 +287,7 @@ moduleFor(
         template: '{{#inner-component}}<span>{{yield}}</span>{{/inner-component}}',
       });
 
-      this.render('{{#outer-component}}Hello {{boundText}}{{/outer-component}}', {
+      this.render('{{#outer-component}}Hello {{this.boundText}}{{/outer-component}}', {
         boundText: 'world',
       });
       this.assertText('Hello world');

--- a/packages/@ember/-internals/glimmer/tests/integration/input-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/input-test.js
@@ -6,7 +6,7 @@ moduleFor(
   'Input element tests',
   class extends RenderingTestCase {
     runAttributeTest(attributeName, values) {
-      let template = `<input ${attributeName}={{value}}>`;
+      let template = `<input ${attributeName}={{this.value}}>`;
       this.render(template, { value: values[0] });
       this.assertAttributeHasValue(
         attributeName,
@@ -34,7 +34,7 @@ moduleFor(
 
     runPropertyTest(propertyName, values) {
       let attributeName = propertyName;
-      let template = `<input ${attributeName}={{value}}>`;
+      let template = `<input ${attributeName}={{this.value}}>`;
       this.render(template, { value: values[0] });
       this.assertPropertyHasValue(
         propertyName,
@@ -62,7 +62,7 @@ moduleFor(
 
     runFalsyValueProperty(values) {
       let value = 'value';
-      let template = `<input value={{value}}>`;
+      let template = `<input value={{this.value}}>`;
       this.render(template, { value: values[0] });
       this.assertPropertyHasValue(value, '', `${value} is set on initial render`);
 
@@ -140,7 +140,7 @@ moduleFor(
     }
 
     ['@test cursor position is not lost when updating content']() {
-      let template = `<input value={{value}}>`;
+      let template = `<input value={{this.value}}>`;
       this.render(template, { value: 'hola' });
 
       this.setDOMValue('hello');
@@ -156,7 +156,7 @@ moduleFor(
     }
 
     ['@test input can be updated multiple times']() {
-      let template = `<input value={{value}}>`;
+      let template = `<input value={{this.value}}>`;
       this.render(template, { value: 'hola' });
 
       this.assertValue('hola', 'Value is initialised');
@@ -173,7 +173,7 @@ moduleFor(
     }
 
     ['@test DOM is SSOT if value is set']() {
-      let template = `<input value={{value}}>`;
+      let template = `<input value={{this.value}}>`;
       this.render(template, { value: 'hola' });
 
       this.assertValue('hola', 'Value is initialised');

--- a/packages/@ember/-internals/glimmer/tests/integration/modifiers/on-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/modifiers/on-test.js
@@ -148,7 +148,7 @@ moduleFor(
     ) {
       let count = 0;
 
-      this.render('<button {{on "click" this.callback once=once}}>Click Me</button>', {
+      this.render('<button {{on "click" this.callback once=this.once}}>Click Me</button>', {
         callback() {
           count++;
         },

--- a/packages/@ember/-internals/glimmer/tests/integration/mount-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/mount-test.js
@@ -30,7 +30,7 @@ moduleFor(
   class extends RenderingTestCase {
     ['@test it asserts when an invalid engine name is provided']() {
       expectAssertion(() => {
-        this.render('{{mount engineName}}', { engineName: {} });
+        this.render('{{mount this.engineName}}', { engineName: {} });
       }, /Invalid engine name '\[object Object\]' specified, engine name must be either a string, null or undefined./i);
     }
 
@@ -73,8 +73,10 @@ moduleFor(
       assert
     ) {
       this.engineRegistrations['template:application'] = compile(
-        '<h2>Chat here, {{username}}</h2>',
-        { moduleName: 'my-app/templates/application.hbs' }
+        '<h2>Chat here, {{this.username}}</h2>',
+        {
+          moduleName: 'my-app/templates/application.hbs',
+        }
       );
 
       let controller;
@@ -119,7 +121,7 @@ moduleFor(
       this.addTemplate('route-with-mount', '{{mount "chat"}}');
 
       this.engineRegistrations['template:application'] = compile(
-        'hi {{person.name}} [{{component-with-backtracking-set person=person}}]',
+        'hi {{this.person.name}} [{{component-with-backtracking-set person=this.person}}]',
         {
           moduleName: 'my-app/templates/application.hbs',
         }
@@ -170,7 +172,7 @@ moduleFor(
           },
         })
       );
-      this.addTemplate('bound-engine-name', '{{mount engineName}}');
+      this.addTemplate('bound-engine-name', '{{mount this.engineName}}');
 
       this.add(
         'engine:foo',
@@ -359,7 +361,7 @@ moduleFor(
       );
       this.addTemplate(
         'engine-params-bound',
-        '{{mount "paramEngine" model=(hash foo=boundParamValue)}}'
+        '{{mount "paramEngine" model=(hash foo=this.boundParamValue)}}'
       );
 
       return this.visit('/engine-params-bound').then(() => {

--- a/packages/@ember/-internals/glimmer/tests/integration/outlet-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/outlet-test.js
@@ -172,7 +172,7 @@ moduleFor(
     }
 
     ['@test does not default outlet name when positional argument is present']() {
-      this.registerTemplate('application', '<h1>HI</h1>{{outlet someUndefinedThing}}');
+      this.registerTemplate('application', '<h1>HI</h1>{{outlet this.someUndefinedThing}}');
       let outletState = {
         render: {
           owner: this.owner,
@@ -213,7 +213,7 @@ moduleFor(
 
     ['@test should support bound outlet name']() {
       let controller = { outletName: 'foo' };
-      this.registerTemplate('application', '<h1>HI</h1>{{outlet outletName}}');
+      this.registerTemplate('application', '<h1>HI</h1>{{outlet this.outletName}}');
       let outletState = {
         render: {
           owner: this.owner,

--- a/packages/@ember/-internals/glimmer/tests/integration/refinements-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/refinements-test.js
@@ -10,43 +10,43 @@ moduleFor(
 
       this.render(
         strip`
-      {{#let var as |foo|}}
+      {{#let this.var as |foo|}}
         {{foo}}
       {{/let}}
 
       ---
 
-      {{#let var as |outlet|}}
+      {{#let this.var as |outlet|}}
         {{outlet}}
       {{/let}}
 
       ---
 
-      {{#let var as |mount|}}
+      {{#let this.var as |mount|}}
         {{mount}}
       {{/let}}
 
       ---
 
-      {{#let var as |component|}}
+      {{#let this.var as |component|}}
         {{component}}
       {{/let}}
 
       ---
 
-      {{#let var as |input|}}
+      {{#let this.var as |input|}}
         {{input}}
       {{/let}}
 
       ---
 
-      {{#let var as |-with-dynamic-vars|}}
+      {{#let this.var as |-with-dynamic-vars|}}
         {{-with-dynamic-vars}}
       {{/let}}
 
       ---
 
-      {{#let var as |-in-element|}}
+      {{#let this.var as |-in-element|}}
         {{-in-element}}
       {{/let}}`,
         { var: 'var' }

--- a/packages/@ember/-internals/glimmer/tests/integration/render-settled-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/render-settled-test.js
@@ -15,7 +15,7 @@ moduleFor(
     }
 
     ['@test resolves renderers exist but no runloops are triggered'](assert) {
-      this.render(strip`{{foo}}`, { foo: 'bar' });
+      this.render(strip`{{this.foo}}`, { foo: 'bar' });
 
       return renderSettled().then(() => {
         assert.ok(true, 'resolved even without runloops');
@@ -32,7 +32,7 @@ moduleFor(
     }
 
     ['@test resolves when rendering has completed (after property update)']() {
-      this.render(strip`{{foo}}`, { foo: 'bar' });
+      this.render(strip`{{this.foo}}`, { foo: 'bar' });
 
       this.assertText('bar');
       this.component.set('foo', 'baz');
@@ -46,7 +46,7 @@ moduleFor(
     ['@test resolves in run loop when renderer has settled'](assert) {
       assert.expect(3);
 
-      this.render(strip`{{foo}}`, { foo: 'bar' });
+      this.render(strip`{{this.foo}}`, { foo: 'bar' });
 
       this.assertText('bar');
       let promise;

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/deprecated-in-element-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/deprecated-in-element-test.js
@@ -14,8 +14,8 @@ moduleFor(
 
       this.render(
         strip`
-          {{#-in-element someElement}}
-            {{text}}
+          {{#-in-element this.someElement}}
+            {{this.text}}
           {{/-in-element}}
         `,
         {
@@ -48,8 +48,8 @@ moduleFor(
 
       this.render(
         strip`
-          {{#-in-element someElement}}
-            {{text}}
+          {{#-in-element this.someElement}}
+            {{this.text}}
           {{/-in-element}}
         `,
         {
@@ -82,8 +82,8 @@ moduleFor(
 
       this.render(
         strip`
-          {{#-in-element someElement insertBefore=null}}
-            {{text}}
+          {{#-in-element this.someElement insertBefore=null}}
+            {{this.text}}
           {{/-in-element}}
         `,
         {
@@ -116,8 +116,8 @@ moduleFor(
 
       this.render(
         strip`
-          {{#-in-element someElement insertBefore=undefined}}
-            {{text}}
+          {{#-in-element this.someElement insertBefore=undefined}}
+            {{this.text}}
           {{/-in-element}}
         `,
         {
@@ -150,8 +150,8 @@ moduleFor(
       expectAssertion(() => {
         this.render(
           strip`
-            {{#-in-element someElement insertBefore=".foo"}}
-              {{text}}
+            {{#-in-element this.someElement insertBefore=".foo"}}
+              {{this.text}}
             {{/-in-element}}
           `,
           {
@@ -180,14 +180,14 @@ moduleFor(
           },
         }),
 
-        template: `{{text}}`,
+        template: `{{this.text}}`,
       });
 
       this.render(
         strip`
-          {{#if showModal}}
-            {{#-in-element someElement}}
-              {{modal-display text=text}}
+          {{#if this.showModal}}
+            {{#-in-element this.someElement}}
+              {{modal-display text=this.text}}
             {{/-in-element}}
           {{/if}}
         `,

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/each-in-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/each-in-test.js
@@ -267,7 +267,9 @@ class EachInTest extends AbstractEachInTest {
   ['@test keying off of `undefined` does not render']() {
     this.makeHash({});
 
-    this.render(`{{#each-in this.hash as |key value|}}{{key}}: {{value.baz}}{{else}}Empty!{{/each-in}}`);
+    this.render(
+      `{{#each-in this.hash as |key value|}}{{key}}: {{value.baz}}{{else}}Empty!{{/each-in}}`
+    );
 
     this.assertText('Empty!');
 

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/each-in-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/each-in-test.js
@@ -143,7 +143,7 @@ class EachInTest extends AbstractEachInTest {
     this.makeHash({ Smartphones: 8203, 'JavaScript Frameworks': Infinity });
 
     this.render(
-      `<ul>{{#each-in hash as |category count|}}<li>{{category}}: {{count}}</li>{{else}}Empty!{{/each-in}}</ul>`
+      `<ul>{{#each-in this.hash as |category count|}}<li>{{category}}: {{count}}</li>{{else}}Empty!{{/each-in}}</ul>`
     );
 
     this.assertText('Smartphones: 8203JavaScript Frameworks: Infinity');
@@ -169,7 +169,7 @@ class EachInTest extends AbstractEachInTest {
     });
 
     this.render(
-      `<ul>{{#each-in hash as |category data|}}<li>{{category}}: {{data.reports.unitsSold}}</li>{{else}}Empty!{{/each-in}}</ul>`
+      `<ul>{{#each-in this.hash as |category data|}}<li>{{category}}: {{data.reports.unitsSold}}</li>{{else}}Empty!{{/each-in}}</ul>`
     );
 
     this.assertText('Smartphones: 8203JavaScript Frameworks: Infinity');
@@ -200,7 +200,7 @@ class EachInTest extends AbstractEachInTest {
     });
 
     this.render(
-      `<ul>{{#each-in hash key='@identity' as |category count|}}<li>{{category}}: {{count}}</li>{{/each-in}}</ul>`
+      `<ul>{{#each-in this.hash key='@identity' as |category count|}}<li>{{category}}: {{count}}</li>{{/each-in}}</ul>`
     );
 
     this.assertText('Smartphones: 8203Tablets: 8203JavaScript Frameworks: InfinityBugs: Infinity');
@@ -237,7 +237,7 @@ class EachInTest extends AbstractEachInTest {
       },
     };
     this.render(
-      `<ul>{{#each-in (get hashes hashes.type) as |category count|}}<li>{{category}}: {{count}}</li>{{else}}Empty!{{/each-in}}</ul>`,
+      `<ul>{{#each-in (get this.hashes this.hashes.type) as |category count|}}<li>{{category}}: {{count}}</li>{{else}}Empty!{{/each-in}}</ul>`,
       context
     );
 
@@ -267,7 +267,7 @@ class EachInTest extends AbstractEachInTest {
   ['@test keying off of `undefined` does not render']() {
     this.makeHash({});
 
-    this.render(`{{#each-in hash as |key value|}}{{key}}: {{value.baz}}{{else}}Empty!{{/each-in}}`);
+    this.render(`{{#each-in this.hash as |key value|}}{{key}}: {{value.baz}}{{else}}Empty!{{/each-in}}`);
 
     this.assertText('Empty!');
 
@@ -286,7 +286,7 @@ class EachInTest extends AbstractEachInTest {
     this.makeHash({ '': 'empty-string', a: 'a' });
 
     this.render(
-      `<ul>{{#each-in hash as |key value|}}<li>{{key}}: {{value}}</li>{{else}}Empty!{{/each-in}}</ul>`
+      `<ul>{{#each-in this.hash as |key value|}}<li>{{key}}: {{value}}</li>{{else}}Empty!{{/each-in}}</ul>`
     );
 
     this.assertText(': empty-stringa: a');
@@ -302,7 +302,7 @@ class EachInTest extends AbstractEachInTest {
     this.makeHash({ 'period.key': 'a', 'other.period.key': 'b' });
 
     this.render(
-      `<ul>{{#each-in hash as |key value|}}<li>{{key}}: {{value}}</li>{{else}}Empty!{{/each-in}}</ul>`
+      `<ul>{{#each-in this.hash as |key value|}}<li>{{key}}: {{value}}</li>{{else}}Empty!{{/each-in}}</ul>`
     );
 
     this.assertText('period.key: aother.period.key: b');
@@ -349,7 +349,7 @@ moduleFor(
       categories['Alarm Clocks'] = 999;
 
       this.render(
-        `<ul>{{#each-in categories as |category count|}}<li>{{category}}: {{count}}</li>{{else}}Empty!{{/each-in}}</ul>`,
+        `<ul>{{#each-in this.categories as |category count|}}<li>{{category}}: {{count}}</li>{{else}}Empty!{{/each-in}}</ul>`,
         { categories }
       );
 
@@ -373,7 +373,7 @@ moduleFor(
       this.render(
         strip`
       <ul>
-        {{#each-in categories as |category count|}}
+        {{#each-in this.categories as |category count|}}
           <li>{{category}}: {{count}}</li>
         {{/each-in}}
       </ul>
@@ -443,7 +443,7 @@ moduleFor(
 
       this.render(
         strip`
-      {{#each-in arr as |key value|}}
+      {{#each-in this.arr as |key value|}}
         [{{key}}:{{value}}]
       {{/each-in}}`,
         { arr }
@@ -460,7 +460,7 @@ moduleFor(
 
       this.render(
         strip`
-      {{#each-in arr as |key value|}}
+      {{#each-in this.arr as |key value|}}
         [{{key}}:{{value}}]
       {{/each-in}}`,
         { arr }
@@ -550,7 +550,7 @@ moduleFor(
       this.render(
         strip`
       <ul>
-        {{#each-in categories as |category count|}}
+        {{#each-in this.categories as |category count|}}
           <li>{{category}}: {{count}}</li>
         {{/each-in}}
       </ul>
@@ -644,7 +644,7 @@ moduleFor(
       this.render(
         strip`
       <ul>
-        {{#each-in map key="@identity" as |key value|}}
+        {{#each-in this.map key="@identity" as |key value|}}
           <li>{{key.name}}: {{value}}</li>
         {{/each-in}}
       </ul>`,

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/each-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/each-test.js
@@ -325,7 +325,7 @@ class EachTest extends AbstractEachTest {
   ['@test it repeats the given block for each item in the array']() {
     this.makeList([{ text: 'hello' }]);
 
-    this.render(`{{#each list as |item|}}{{item.text}}{{else}}Empty{{/each}}`);
+    this.render(`{{#each this.list as |item|}}{{item.text}}{{else}}Empty{{/each}}`);
 
     this.assertText('hello');
 
@@ -390,7 +390,7 @@ class EachTest extends AbstractEachTest {
   ['@test it receives the index as the second parameter']() {
     this.makeList([{ text: 'hello' }, { text: 'world' }]);
 
-    this.render(`{{#each list as |item index|}}[{{index}}. {{item.text}}]{{/each}}`);
+    this.render(`{{#each this.list as |item index|}}[{{index}}. {{item.text}}]{{/each}}`);
 
     this.assertText('[0. hello][1. world]');
 
@@ -408,7 +408,7 @@ class EachTest extends AbstractEachTest {
   ['@test it accepts a string key']() {
     this.makeList([{ text: 'hello' }, { text: 'world' }]);
 
-    this.render(`{{#each list key='text' as |item|}}{{item.text}}{{/each}}`);
+    this.render(`{{#each this.list key='text' as |item|}}{{item.text}}{{/each}}`);
 
     this.assertText('helloworld');
 
@@ -426,7 +426,7 @@ class EachTest extends AbstractEachTest {
   ['@test it accepts a numeric key']() {
     this.makeList([{ id: 1 }, { id: 2 }]);
 
-    this.render(`{{#each list key='id' as |item|}}{{item.id}}{{/each}}`);
+    this.render(`{{#each this.list key='id' as |item|}}{{item.id}}{{/each}}`);
 
     this.assertText('12');
 
@@ -444,7 +444,7 @@ class EachTest extends AbstractEachTest {
   ['@test it can specify @index as the key']() {
     this.makeList([{ id: 1 }, { id: 2 }]);
 
-    this.render(`{{#each list key='@index' as |item|}}{{item.id}}{{/each}}`);
+    this.render(`{{#each this.list key='@index' as |item|}}{{item.id}}{{/each}}`);
 
     this.assertText('12');
 
@@ -462,7 +462,7 @@ class EachTest extends AbstractEachTest {
   ['@test it can specify @identity as the key for arrays of primitives']() {
     this.makeList([1, 2]);
 
-    this.render(`{{#each list key='@identity' as |item|}}{{item}}{{/each}}`);
+    this.render(`{{#each this.list key='@identity' as |item|}}{{item}}{{/each}}`);
 
     this.assertText('12');
 
@@ -480,7 +480,9 @@ class EachTest extends AbstractEachTest {
   ['@test it can specify @identity as the key for mixed arrays of objects and primitives']() {
     this.makeList([1, { id: 2 }, 3]);
 
-    this.render(`{{#each list key='@identity' as |item|}}{{if item.id item.id item}}{{/each}}`);
+    this.render(
+      `{{#each this.list key='@identity' as |item|}}{{if item.id item.id item}}{{/each}}`
+    );
 
     this.assertText('123');
 
@@ -498,7 +500,7 @@ class EachTest extends AbstractEachTest {
   ['@test it can render duplicate primitive items']() {
     this.makeList(['a', 'a', 'a']);
 
-    this.render(`{{#each list as |item|}}{{item}}{{/each}}`);
+    this.render(`{{#each this.list as |item|}}{{item}}{{/each}}`);
 
     this.assertText('aaa');
 
@@ -538,11 +540,11 @@ class EachTest extends AbstractEachTest {
 
     this.registerComponent('foo-bar', {
       ComponentClass: FooBarComponent,
-      template: '{{#if isEven}}{{item.value}}{{/if}}',
+      template: '{{#if this.isEven}}{{this.item.value}}{{/if}}',
     });
 
     this.render(strip`
-      {{#each list as |item|}}
+      {{#each this.list as |item|}}
         <li>Prev</li>
         {{foo-bar item=item}}
         <li>Next</li>
@@ -567,7 +569,7 @@ class EachTest extends AbstractEachTest {
 
     this.makeList([duplicateItem, duplicateItem, { text: 'bar' }, { text: 'baz' }]);
 
-    this.render(`{{#each list as |item|}}{{item.text}}{{/each}}`);
+    this.render(`{{#each this.list as |item|}}{{item.text}}{{/each}}`);
 
     this.assertText('foofoobarbaz');
 
@@ -589,7 +591,7 @@ class EachTest extends AbstractEachTest {
   [`@test it maintains DOM stability when condition changes between objects with the same keys`]() {
     this.makeList([{ text: 'Hello' }, { text: ' ' }, { text: 'world' }]);
 
-    this.render(`{{#each list key="text" as |item|}}{{item.text}}{{/each}}`);
+    this.render(`{{#each this.list key="text" as |item|}}{{item.text}}{{/each}}`);
 
     this.assertText('Hello world');
 
@@ -616,7 +618,7 @@ class EachTest extends AbstractEachTest {
   [`@test it maintains DOM stability for stable keys when list is updated`]() {
     this.makeList([{ text: 'Hello' }, { text: ' ' }, { text: 'world' }]);
 
-    this.render(`{{#each list key="text" as |item|}}{{item.text}}{{/each}}`);
+    this.render(`{{#each this.list key="text" as |item|}}{{item.text}}{{/each}}`);
 
     this.assertText('Hello world');
 
@@ -645,7 +647,7 @@ class EachTest extends AbstractEachTest {
   [`@test it renders all items with duplicate key values`]() {
     this.makeList([{ text: 'Hello' }, { text: 'Hello' }, { text: 'Hello' }]);
 
-    this.render(`{{#each list key="text" as |item|}}{{item.text}}{{/each}}`);
+    this.render(`{{#each this.list key="text" as |item|}}{{item.text}}{{/each}}`);
 
     this.assertText('HelloHelloHello');
 
@@ -663,9 +665,12 @@ class EachTest extends AbstractEachTest {
   ['@test context is not changed to the inner scope inside an {{#each as}} block']() {
     this.makeList([{ name: 'Chad' }, { name: 'Zack' }, { name: 'Asa' }]);
 
-    this.render(`{{name}}-{{#each list as |person|}}{{name}}{{/each}}-{{name}}`, {
-      name: 'Joel',
-    });
+    this.render(
+      `{{this.name}}-{{#each this.list as |person|}}{{this.name}}{{/each}}-{{this.name}}`,
+      {
+        name: 'Joel',
+      }
+    );
 
     this.assertText('Joel-JoelJoelJoel-Joel');
 
@@ -688,9 +693,12 @@ class EachTest extends AbstractEachTest {
   ['@test can access the item and the original scope']() {
     this.makeList([{ name: 'Tom Dale' }, { name: 'Yehuda Katz' }, { name: 'Godfrey Chan' }]);
 
-    this.render(`{{#each list key="name" as |person|}}[{{title}}: {{person.name}}]{{/each}}`, {
-      title: 'Señor Engineer',
-    });
+    this.render(
+      `{{#each this.list key="name" as |person|}}[{{this.title}}: {{person.name}}]{{/each}}`,
+      {
+        title: 'Señor Engineer',
+      }
+    );
 
     this.assertText(
       '[Señor Engineer: Tom Dale][Señor Engineer: Yehuda Katz][Señor Engineer: Godfrey Chan]'
@@ -725,7 +733,7 @@ class EachTest extends AbstractEachTest {
   ['@test the scoped variable is not available outside the {{#each}} block.']() {
     this.makeList(['Yehuda']);
 
-    this.render(`{{name}}-{{#each list as |name|}}{{name}}{{/each}}-{{name}}`, {
+    this.render(`{{name}}-{{#each this.list as |name|}}{{name}}{{/each}}-{{name}}`, {
       name: 'Stef',
     });
 
@@ -752,9 +760,12 @@ class EachTest extends AbstractEachTest {
   ['@test inverse template is displayed with context']() {
     this.makeList([]);
 
-    this.render(`{{#each list as |thing|}}Has Thing{{else}}No Thing {{otherThing}}{{/each}}`, {
-      otherThing: 'bar',
-    });
+    this.render(
+      `{{#each this.list as |thing|}}Has Thing{{else}}No Thing {{this.otherThing}}{{/each}}`,
+      {
+        otherThing: 'bar',
+      }
+    );
 
     this.assertText('No Thing bar');
 
@@ -790,7 +801,7 @@ class EachTest extends AbstractEachTest {
 
     this.makeList([]);
 
-    this.render(`{{#x-wrapper}}{{#each list as |obj|}}[{{obj.text}}]{{/each}}{{/x-wrapper}}`);
+    this.render(`{{#x-wrapper}}{{#each this.list as |obj|}}[{{obj.text}}]{{/each}}{{/x-wrapper}}`);
 
     this.assertText('');
 
@@ -830,7 +841,7 @@ class EachTest extends AbstractEachTest {
   ['@test empty trusted content clears properly [GH#16314]']() {
     this.makeList(['hello']);
 
-    this.render(`before {{#each list as |value|}}{{{value}}}{{/each}} after`);
+    this.render(`before {{#each this.list as |value|}}{{{value}}}{{/each}} after`);
 
     this.assertText('before hello after');
 
@@ -860,7 +871,7 @@ class EachTest extends AbstractEachTest {
     let users = this.createList([{ name: 'Yehuda Katz' }]);
 
     this.render(
-      `Admin: {{#each admins key="name" as |person|}}[{{person.name}}]{{/each}} User: {{#each users key="name" as |person|}}[{{person.name}}]{{/each}}`,
+      `Admin: {{#each this.admins key="name" as |person|}}[{{person.name}}]{{/each}} User: {{#each this.users key="name" as |person|}}[{{person.name}}]{{/each}}`,
       {
         admins: admins.list,
         users: users.list,
@@ -897,9 +908,9 @@ class EachTest extends AbstractEachTest {
 
     this.render(
       strip`
-      {{#each content as |value|}}
+      {{#each this.content as |value|}}
         {{value}}-
-        {{#each options as |option|}}
+        {{#each this.options as |option|}}
           {{option.value}}:{{option.label}}
         {{/each}}
       {{/each}}
@@ -942,7 +953,7 @@ class EachTest extends AbstractEachTest {
     let ninth = this.createList(['Treachery']);
 
     this.render(
-      `{{ring}}-{{#each first as |ring|}}{{ring}}-{{#each fifth as |ring|}}{{ring}}-{{#each ninth as |ring|}}{{ring}}-{{/each}}{{ring}}-{{/each}}{{ring}}-{{/each}}{{ring}}`,
+      `{{ring}}-{{#each this.first as |ring|}}{{ring}}-{{#each this.fifth as |ring|}}{{ring}}-{{#each this.ninth as |ring|}}{{ring}}-{{/each}}{{ring}}-{{/each}}{{ring}}-{{/each}}{{ring}}`,
       {
         ring: 'Greed',
         first: first.list,
@@ -981,12 +992,12 @@ class EachTest extends AbstractEachTest {
     this.assertText('Greed-Limbo-Wrath-Treachery-Wrath-Limbo-Greed');
   }
 
-  ['@test it should support {{#each name as |foo|}}, then {{#each foo as |bar|}}']() {
+  ['@test it should support {{#each this.name as |foo|}}, then {{#each foo as |bar|}}']() {
     let inner = this.createList(['caterpillar']);
     let outer = this.createList([inner.list]);
 
     this.render(
-      `{{#each name key="@index" as |foo|}}{{#each foo as |bar|}}{{bar}}{{/each}}{{/each}}`,
+      `{{#each this.name key="@index" as |foo|}}{{#each foo as |bar|}}{{bar}}{{/each}}{{/each}}`,
       {
         name: outer.list,
       }
@@ -1136,7 +1147,7 @@ moduleFor(
     ['@test keying off of `undefined` does not render']() {
       this.render(
         strip`
-      {{#each foo.bar.baz as |thing|}}
+      {{#each this.foo.bar.baz as |thing|}}
         {{thing}}
       {{/each}}`,
         { foo: {} }
@@ -1169,7 +1180,7 @@ moduleFor(
 
       this.render(
         strip`
-      {{#each list as |value key|}}
+      {{#each this.list as |value key|}}
         [{{key}}:{{value}}]
       {{/each}}`,
         { list: emberA(sparseArray) }

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/if-unless-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/if-unless-test.js
@@ -42,7 +42,7 @@ moduleFor(
       let destroyedChildrenCount = 0;
 
       this.registerComponent('foo-bar', {
-        template: '{{number}}',
+        template: '{{this.number}}',
         ComponentClass: Component.extend({
           willDestroy() {
             this._super();
@@ -53,8 +53,8 @@ moduleFor(
 
       this.render(
         strip`
-      {{#if cond}}
-        {{#each numbers as |number|}}
+      {{#if this.cond}}
+        {{#each this.numbers as |number|}}
           {{foo-bar number=number}}
         {{/each}}
       {{else}}
@@ -82,7 +82,7 @@ moduleFor(
     ['@test looking up `undefined` property defaults to false']() {
       this.render(
         strip`
-      {{#if foo.bar.baz}}
+      {{#if this.foo.bar.baz}}
         Here!
       {{else}}
         Nothing Here!

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/let-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/let-test.js
@@ -13,7 +13,7 @@ moduleFor(
     ['@test it renders the block if `undefined` is passed as an argument']() {
       this.render(
         strip`
-        {{#let foo.bar.baz as |thing|}}
+        {{#let this.foo.bar.baz as |thing|}}
           value: "{{thing}}"
         {{/let}}`,
         { foo: {} }
@@ -35,7 +35,7 @@ moduleFor(
     }
 
     ['@test it renders the block if arguments are falsey']() {
-      this.render(`{{#let cond1 cond2 as |cond|}}value: "{{cond1}}"{{/let}}`, {
+      this.render(`{{#let this.cond1 this.cond2 as |cond|}}value: "{{this.cond1}}"{{/let}}`, {
         cond1: false,
       });
 
@@ -55,7 +55,7 @@ moduleFor(
     }
 
     ['@test it yields multiple arguments in order']() {
-      this.render(`{{#let foo bar baz.name as |a b c|}}{{a}} {{b}} {{c}}{{/let}}`, {
+      this.render(`{{#let this.foo this.bar this.baz.name as |a b c|}}{{a}} {{b}} {{c}}{{/let}}`, {
         foo: 'Señor Engineer',
         bar: '',
         baz: { name: 'Dale' },
@@ -69,7 +69,7 @@ moduleFor(
     }
 
     ['@test can access alias and original scope']() {
-      this.render(`{{#let person as |tom|}}{{title}}: {{tom.name}}{{/let}}`, {
+      this.render(`{{#let this.person as |tom|}}{{this.title}}: {{tom.name}}{{/let}}`, {
         title: 'Señor Engineer',
         person: { name: 'Tom Dale' },
       });
@@ -96,7 +96,7 @@ moduleFor(
     }
 
     ['@test the scoped variable is not available outside the {{#let}} block.']() {
-      this.render(`{{name}}-{{#let other as |name|}}{{name}}{{/let}}-{{name}}`, {
+      this.render(`{{name}}-{{#let this.other as |name|}}{{name}}{{/let}}-{{name}}`, {
         name: 'Stef',
         other: 'Yehuda',
       });
@@ -124,7 +124,7 @@ moduleFor(
     }
 
     ['@test can access alias of a proxy']() {
-      this.render(`{{#let proxy as |person|}}{{person.name}}{{/let}}`, {
+      this.render(`{{#let this.proxy as |person|}}{{person.name}}{{/let}}`, {
         proxy: ObjectProxy.create({ content: { name: 'Tom Dale' } }),
       });
 
@@ -159,7 +159,7 @@ moduleFor(
 
     ['@test can access alias of an array']() {
       this.render(
-        `{{#let arrayThing as |words|}}{{#each words as |word|}}{{word}}{{/each}}{{/let}}`,
+        `{{#let this.arrayThing as |words|}}{{#each words as |word|}}{{word}}{{/each}}{{/let}}`,
         {
           arrayThing: emberA(['Hello', ' ', 'world']),
         }
@@ -187,7 +187,7 @@ moduleFor(
     }
 
     ['@test `attrs` can be used as a block param [GH#14678]']() {
-      this.render('{{#let hash as |attrs|}}[{{hash.foo}}-{{attrs.foo}}]{{/let}}', {
+      this.render('{{#let this.hash as |attrs|}}[{{this.hash.foo}}-{{attrs.foo}}]{{/let}}', {
         hash: { foo: 'foo' },
       });
 
@@ -213,7 +213,7 @@ moduleFor(
   class extends RenderingTestCase {
     ['@test re-using the same variable with different {{#let}} blocks does not override each other']() {
       this.render(
-        `Admin: {{#let admin as |person|}}{{person.name}}{{/let}} User: {{#let user as |person|}}{{person.name}}{{/let}}`,
+        `Admin: {{#let this.admin as |person|}}{{person.name}}{{/let}} User: {{#let this.user as |person|}}{{person.name}}{{/let}}`,
         {
           admin: { name: 'Tom Dale' },
           user: { name: 'Yehuda Katz' },
@@ -243,7 +243,7 @@ moduleFor(
 
     ['@test the scoped variable is not available outside the {{#let}} block']() {
       this.render(
-        `{{ring}}-{{#let first as |ring|}}{{ring}}-{{#let fifth as |ring|}}{{ring}}-{{#let ninth as |ring|}}{{ring}}-{{/let}}{{ring}}-{{/let}}{{ring}}-{{/let}}{{ring}}`,
+        `{{ring}}-{{#let this.first as |ring|}}{{ring}}-{{#let this.fifth as |ring|}}{{ring}}-{{#let this.ninth as |ring|}}{{ring}}-{{/let}}{{ring}}-{{/let}}{{ring}}-{{/let}}{{ring}}`,
         {
           ring: 'Greed',
           first: 'Limbo',
@@ -283,7 +283,7 @@ moduleFor(
     }
 
     ['@test it should support {{#let name as |foo|}}, then {{#let foo as |bar|}}']() {
-      this.render(`{{#let name as |foo|}}{{#let foo as |bar|}}{{bar}}{{/let}}{{/let}}`, {
+      this.render(`{{#let this.name as |foo|}}{{#let foo as |bar|}}{{bar}}{{/let}}{{/let}}`, {
         name: 'caterpillar',
       });
 
@@ -326,17 +326,17 @@ moduleFor(
       this.render(
         strip`
         {{name}}
-        {{#let committer1.name as |name|}}
+        {{#let this.committer1.name as |name|}}
           [{{name}}
-          {{#let committer2.name as |name|}}
+          {{#let this.committer2.name as |name|}}
             [{{name}}]
           {{/let}}
           {{name}}]
         {{/let}}
         {{name}}
-        {{#let committer2.name as |name|}}
+        {{#let this.committer2.name as |name|}}
           [{{name}}
-          {{#let committer1.name as |name|}}
+          {{#let this.committer1.name as |name|}}
             [{{name}}]
           {{/let}}
           {{name}}]

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/public-in-element-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/public-in-element-test.js
@@ -11,8 +11,8 @@ moduleFor(
 
       this.render(
         strip`
-          {{#in-element someElement}}
-            {{text}}
+          {{#in-element this.someElement}}
+            {{this.text}}
           {{/in-element}}
         `,
         {
@@ -43,8 +43,8 @@ moduleFor(
 
       this.render(
         strip`
-          {{#in-element someElement insertBefore=undefined}}
-            {{text}}
+          {{#in-element this.someElement insertBefore=undefined}}
+            {{this.text}}
           {{/in-element}}
         `,
         {
@@ -75,8 +75,8 @@ moduleFor(
 
       this.render(
         strip`
-          {{#in-element someElement insertBefore=null}}
-            {{text}}
+          {{#in-element this.someElement insertBefore=null}}
+            {{this.text}}
           {{/in-element}}
         `,
         {
@@ -107,8 +107,8 @@ moduleFor(
       expectAssertion(() => {
         this.render(
           strip`
-            {{#in-element someElement insertBefore=".foo"}}
-              {{text}}
+            {{#in-element this.someElement insertBefore=".foo"}}
+              {{this.text}}
             {{/in-element}}
           `,
           {
@@ -125,8 +125,8 @@ moduleFor(
       expectAssertion(() => {
         this.render(
           strip`
-            {{#in-element someElement}}
-              {{text}}
+            {{#in-element this.someElement}}
+              {{this.text}}
             {{/in-element}}
           `,
           {
@@ -143,8 +143,8 @@ moduleFor(
       expectAssertion(() => {
         this.render(
           strip`
-            {{#in-element someElement}}
-              {{text}}
+            {{#in-element this.someElement}}
+              {{this.text}}
             {{/in-element}}
           `,
           {
@@ -171,14 +171,14 @@ moduleFor(
           },
         }),
 
-        template: `{{text}}`,
+        template: `{{this.text}}`,
       });
 
       this.render(
         strip`
-          {{#if showModal}}
-            {{#in-element someElement}}
-              {{modal-display text=text}}
+          {{#if this.showModal}}
+            {{#in-element this.someElement}}
+              {{modal-display text=this.text}}
             {{/in-element}}
           {{/if}}
         `,

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/with-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/with-test.js
@@ -32,7 +32,7 @@ moduleFor(
     ['@test keying off of `undefined` does not render']() {
       this.render(
         strip`
-      {{#with foo.bar.baz as |thing|}}
+      {{#with this.foo.bar.baz as |thing|}}
         {{thing}}
       {{/with}}`,
         { foo: {} }
@@ -54,7 +54,7 @@ moduleFor(
     }
 
     ['@test it renders and hides the given block based on the conditional']() {
-      this.render(`{{#with cond1 as |cond|}}{{cond.greeting}}{{else}}False{{/with}}`, {
+      this.render(`{{#with this.cond1 as |cond|}}{{cond.greeting}}{{else}}False{{/with}}`, {
         cond1: { greeting: 'Hello' },
       });
 
@@ -78,7 +78,7 @@ moduleFor(
     }
 
     ['@test can access alias and original scope']() {
-      this.render(`{{#with person as |tom|}}{{title}}: {{tom.name}}{{/with}}`, {
+      this.render(`{{#with this.person as |tom|}}{{this.title}}: {{tom.name}}{{/with}}`, {
         title: 'Señor Engineer',
         person: { name: 'Tom Dale' },
       });
@@ -105,7 +105,7 @@ moduleFor(
     }
 
     ['@test the scoped variable is not available outside the {{#with}} block.']() {
-      this.render(`{{name}}-{{#with other as |name|}}{{name}}{{/with}}-{{name}}`, {
+      this.render(`{{name}}-{{#with this.other as |name|}}{{name}}{{/with}}-{{name}}`, {
         name: 'Stef',
         other: 'Yehuda',
       });
@@ -134,7 +134,7 @@ moduleFor(
 
     ['@test inverse template is displayed with context']() {
       this.render(
-        `{{#with falsyThing as |thing|}}Has Thing{{else}}No Thing {{otherThing}}{{/with}}`,
+        `{{#with this.falsyThing as |thing|}}Has Thing{{else}}No Thing {{this.otherThing}}{{/with}}`,
         {
           falsyThing: null,
           otherThing: 'bar',
@@ -168,7 +168,7 @@ moduleFor(
     }
 
     ['@test can access alias of a proxy']() {
-      this.render(`{{#with proxy as |person|}}{{person.name}}{{/with}}`, {
+      this.render(`{{#with this.proxy as |person|}}{{person.name}}{{/with}}`, {
         proxy: ObjectProxy.create({ content: { name: 'Tom Dale' } }),
       });
 
@@ -203,7 +203,7 @@ moduleFor(
 
     ['@test can access alias of an array']() {
       this.render(
-        `{{#with arrayThing as |words|}}{{#each words as |word|}}{{word}}{{/each}}{{/with}}`,
+        `{{#with this.arrayThing as |words|}}{{#each words as |word|}}{{word}}{{/each}}{{/with}}`,
         {
           arrayThing: emberA(['Hello', ' ', 'world']),
         }
@@ -231,7 +231,7 @@ moduleFor(
     }
 
     ['@test `attrs` can be used as a block param [GH#14678]']() {
-      this.render('{{#with hash as |attrs|}}[{{hash.foo}}-{{attrs.foo}}]{{/with}}', {
+      this.render('{{#with this.hash as |attrs|}}[{{this.hash.foo}}-{{attrs.foo}}]{{/with}}', {
         hash: { foo: 'foo' },
       });
 
@@ -261,7 +261,7 @@ moduleFor(
 
     ['@test re-using the same variable with different {{#with}} blocks does not override each other']() {
       this.render(
-        `Admin: {{#with admin as |person|}}{{person.name}}{{/with}} User: {{#with user as |person|}}{{person.name}}{{/with}}`,
+        `Admin: {{#with this.admin as |person|}}{{person.name}}{{/with}} User: {{#with this.user as |person|}}{{person.name}}{{/with}}`,
         {
           admin: { name: 'Tom Dale' },
           user: { name: 'Yehuda Katz' },
@@ -291,7 +291,7 @@ moduleFor(
 
     ['@test the scoped variable is not available outside the {{#with}} block']() {
       this.render(
-        `{{ring}}-{{#with first as |ring|}}{{ring}}-{{#with fifth as |ring|}}{{ring}}-{{#with ninth as |ring|}}{{ring}}-{{/with}}{{ring}}-{{/with}}{{ring}}-{{/with}}{{ring}}`,
+        `{{ring}}-{{#with this.first as |ring|}}{{ring}}-{{#with this.fifth as |ring|}}{{ring}}-{{#with this.ninth as |ring|}}{{ring}}-{{/with}}{{ring}}-{{/with}}{{ring}}-{{/with}}{{ring}}`,
         {
           ring: 'Greed',
           first: 'Limbo',
@@ -331,7 +331,7 @@ moduleFor(
     }
 
     ['@test it should support {{#with name as |foo|}}, then {{#with foo as |bar|}}']() {
-      this.render(`{{#with name as |foo|}}{{#with foo as |bar|}}{{bar}}{{/with}}{{/with}}`, {
+      this.render(`{{#with this.name as |foo|}}{{#with foo as |bar|}}{{bar}}{{/with}}{{/with}}`, {
         name: 'caterpillar',
       });
 
@@ -374,17 +374,17 @@ moduleFor(
       this.render(
         strip`
       {{name}}
-      {{#with committer1.name as |name|}}
+      {{#with this.committer1.name as |name|}}
         [{{name}}
-        {{#with committer2.name as |name|}}
+        {{#with this.committer2.name as |name|}}
           [{{name}}]
         {{/with}}
         {{name}}]
       {{/with}}
       {{name}}
-      {{#with committer2.name as |name|}}
+      {{#with this.committer2.name as |name|}}
         [{{name}}
-        {{#with committer1.name as |name|}}
+        {{#with this.committer1.name as |name|}}
           [{{name}}]
         {{/with}}
         {{name}}]

--- a/packages/@ember/-internals/glimmer/tests/unit/runtime-resolver-cache-test.js
+++ b/packages/@ember/-internals/glimmer/tests/unit/runtime-resolver-cache-test.js
@@ -23,7 +23,7 @@ moduleFor(
 
       this.render(
         `
-          {{~#if cond~}}
+          {{~#if this.cond~}}
             {{foo-bar}}
           {{~else~}}
             {{baz-qux}}
@@ -81,7 +81,7 @@ moduleFor(
       this.getCacheCounters();
 
       // show component-one for the first time
-      this.render(`{{component componentName}}`, {
+      this.render(`{{component this.componentName}}`, {
         componentName: 'component-one',
       });
 
@@ -145,7 +145,7 @@ moduleFor(
       // show component-one for the first time
       this.render(
         `
-    {{~#if cond~}}
+    {{~#if this.cond~}}
       {{component-one}}
     {{~else~}}
       {{component-two}}

--- a/packages/@ember/-internals/glimmer/tests/unit/template-factory-test.js
+++ b/packages/@ember/-internals/glimmer/tests/unit/template-factory-test.js
@@ -15,7 +15,7 @@ moduleFor(
 
       let { owner } = this;
 
-      let templateStr = 'Hello {{name}}';
+      let templateStr = 'Hello {{this.name}}';
       let options = { moduleName: 'my-app/templates/some-module.hbs' };
 
       let spec = precompile(templateStr, options);

--- a/packages/@ember/-internals/glimmer/tests/utils/shared-conditional-tests.js
+++ b/packages/@ember/-internals/glimmer/tests/utils/shared-conditional-tests.js
@@ -472,7 +472,9 @@ export class TogglingHelperConditionalsTest extends TogglingConditionalsTest {
     let context = {};
 
     for (let i = 1; i <= values.length; i++) {
-      templates.push(this.templateFor({ cond: `cond${i}`, truthy: `t${i}`, falsy: `f${i}` }));
+      templates.push(
+        this.templateFor({ cond: `this.cond${i}`, truthy: `this.t${i}`, falsy: `this.f${i}` })
+      );
       context[`t${i}`] = `T${i}`;
       context[`f${i}`] = `F${i}`;
       context[`cond${i}`] = values[i - 1];
@@ -484,8 +486,8 @@ export class TogglingHelperConditionalsTest extends TogglingConditionalsTest {
 
   ['@test it has access to the outer scope from both templates']() {
     let template = this.wrapperFor([
-      this.templateFor({ cond: 'cond1', truthy: 'truthy', falsy: 'falsy' }),
-      this.templateFor({ cond: 'cond2', truthy: 'truthy', falsy: 'falsy' }),
+      this.templateFor({ cond: 'this.cond1', truthy: 'this.truthy', falsy: 'this.falsy' }),
+      this.templateFor({ cond: 'this.cond2', truthy: 'this.truthy', falsy: 'this.falsy' }),
     ]);
 
     this.render(template, {
@@ -528,12 +530,12 @@ export class TogglingHelperConditionalsTest extends TogglingConditionalsTest {
   ['@test it does not update when the unbound helper is used']() {
     let template = this.wrapperFor([
       this.templateFor({
-        cond: '(unbound cond1)',
+        cond: '(unbound this.cond1)',
         truthy: '"T1"',
         falsy: '"F1"',
       }),
       this.templateFor({
-        cond: '(unbound cond2)',
+        cond: '(unbound this.cond2)',
         truthy: '"T2"',
         falsy: '"F2"',
       }),
@@ -597,7 +599,7 @@ export class TogglingHelperConditionalsTest extends TogglingConditionalsTest {
     });
 
     let template = this.wrappedTemplateFor({
-      cond: 'cond',
+      cond: 'this.cond',
 
       // pass values so the helpers don't eagerly compute
       truthy: '(x-truthy this.foo)',
@@ -640,9 +642,9 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
     for (let i = 1; i <= values.length; i++) {
       templates.push(
         this.templateFor({
-          cond: `cond${i}`,
-          truthy: `{{t}}${i}`,
-          falsy: `{{f}}${i}`,
+          cond: `this.cond${i}`,
+          truthy: `{{this.t}}${i}`,
+          falsy: `{{this.f}}${i}`,
         })
       );
       context[`cond${i}`] = values[i - 1];
@@ -654,11 +656,11 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
 
   ['@test it does not update when the unbound helper is used']() {
     let template = `${this.templateFor({
-      cond: '(unbound cond1)',
+      cond: '(unbound this.cond1)',
       truthy: 'T1',
       falsy: 'F1',
     })}${this.templateFor({
-      cond: '(unbound cond2)',
+      cond: '(unbound this.cond2)',
       truthy: 'T2',
       falsy: 'F2',
     })}`;
@@ -693,14 +695,14 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
   ['@test it has access to the outer scope from both templates']() {
     let template = this.wrapperFor([
       this.templateFor({
-        cond: 'cond1',
-        truthy: '{{truthy}}',
-        falsy: '{{falsy}}',
+        cond: 'this.cond1',
+        truthy: '{{this.truthy}}',
+        falsy: '{{this.falsy}}',
       }),
       this.templateFor({
-        cond: 'cond2',
-        truthy: '{{truthy}}',
-        falsy: '{{falsy}}',
+        cond: 'this.cond2',
+        truthy: '{{this.truthy}}',
+        falsy: '{{this.falsy}}',
       }),
     ]);
 
@@ -744,12 +746,12 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
   ['@test it updates correctly when enclosing another conditional']() {
     // This tests whether the outer conditional tracks its bounds correctly as its inner bounds changes
     let inner = this.templateFor({
-      cond: 'inner',
+      cond: 'this.inner',
       truthy: 'T-inner',
       falsy: 'F-inner',
     });
     let template = this.wrappedTemplateFor({
-      cond: 'outer',
+      cond: 'this.outer',
       truthy: inner,
       falsy: 'F-outer',
     });
@@ -776,8 +778,8 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
   ['@test it updates correctly when enclosing #each']() {
     // This tests whether the outer conditional tracks its bounds correctly as its inner bounds changes
     let template = this.wrappedTemplateFor({
-      cond: 'outer',
-      truthy: '{{#each inner as |text|}}{{text}}{{/each}}',
+      cond: 'this.outer',
+      truthy: '{{#each this.inner as |text|}}{{text}}{{/each}}',
       falsy: 'F-outer',
     });
 
@@ -824,8 +826,8 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
   ['@test it updates correctly when enclosing triple-curlies']() {
     // This tests whether the outer conditional tracks its bounds correctly as its inner bounds changes
     let template = this.wrappedTemplateFor({
-      cond: 'outer',
-      truthy: '{{{inner}}}',
+      cond: 'this.outer',
+      truthy: '{{{this.inner}}}',
       falsy: 'F-outer',
     });
 
@@ -867,12 +869,12 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
     });
 
     let innerTemplate = this.templateFor({
-      cond: 'cond2',
+      cond: 'this.cond2',
       truthy: '{{foo-bar}}',
       falsy: '',
     });
     let wrappedTemplate = this.wrappedTemplateFor({
-      cond: 'cond1',
+      cond: 'this.cond1',
       truthy: innerTemplate,
       falsy: '',
     });
@@ -938,7 +940,7 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
     });
 
     let template = this.wrappedTemplateFor({
-      cond: 'cond',
+      cond: 'this.cond',
       truthy: '{{x-truthy}}',
       falsy: '{{x-falsy}}',
     });

--- a/packages/@ember/application/tests/application_test.js
+++ b/packages/@ember/application/tests/application_test.js
@@ -320,7 +320,7 @@ moduleFor(
     [`@test Application Controller backs the appplication template`]() {
       runTask(() => {
         this.createApplication();
-        this.addTemplate('application', '<h1>{{greeting}}</h1>');
+        this.addTemplate('application', '<h1>{{this.greeting}}</h1>');
         this.add(
           'controller:application',
           Controller.extend({

--- a/packages/ember-template-compiler/tests/system/bootstrap-test.js
+++ b/packages/ember-template-compiler/tests/system/bootstrap-test.js
@@ -77,7 +77,8 @@ moduleFor(
     }
 
     ['@test template without data-template-name or id should default to application'](assert) {
-      fixture.innerHTML = '<script type="text/x-handlebars">{{this.firstName}} takes {{this.drug}}</script>';
+      fixture.innerHTML =
+        '<script type="text/x-handlebars">{{this.firstName}} takes {{this.drug}}</script>';
 
       checkTemplate('application', assert);
     }

--- a/packages/ember-template-compiler/tests/system/bootstrap-test.js
+++ b/packages/ember-template-compiler/tests/system/bootstrap-test.js
@@ -62,7 +62,7 @@ moduleFor(
       assert
     ) {
       fixture.innerHTML =
-        '<script type="text/x-handlebars" data-template-name="funkyTemplate">{{firstName}} takes {{drug}}</script>';
+        '<script type="text/x-handlebars" data-template-name="funkyTemplate">{{this.firstName}} takes {{this.drug}}</script>';
 
       checkTemplate('funkyTemplate', assert);
     }
@@ -71,13 +71,13 @@ moduleFor(
       assert
     ) {
       fixture.innerHTML =
-        '<script type="text/x-handlebars" id="funkyTemplate" >{{firstName}} takes {{drug}}</script>';
+        '<script type="text/x-handlebars" id="funkyTemplate" >{{this.firstName}} takes {{this.drug}}</script>';
 
       checkTemplate('funkyTemplate', assert);
     }
 
     ['@test template without data-template-name or id should default to application'](assert) {
-      fixture.innerHTML = '<script type="text/x-handlebars">{{firstName}} takes {{drug}}</script>';
+      fixture.innerHTML = '<script type="text/x-handlebars">{{this.firstName}} takes {{this.drug}}</script>';
 
       checkTemplate('application', assert);
     }
@@ -87,7 +87,7 @@ moduleFor(
       typeof Handlebars === 'object' ? '@test' : '@skip'
     } template with type text/x-raw-handlebars should be parsed`](assert) {
       fixture.innerHTML =
-        '<script type="text/x-raw-handlebars" data-template-name="funkyTemplate">{{name}}</script>';
+        '<script type="text/x-raw-handlebars" data-template-name="funkyTemplate">{{this.name}}</script>';
 
       run(() => bootstrap({ context: fixture, hasTemplate, setTemplate }));
 

--- a/packages/ember-template-compiler/tests/system/compile_options_test.js
+++ b/packages/ember-template-compiler/tests/system/compile_options_test.js
@@ -114,7 +114,7 @@ class CustomPluginsTests extends RenderingTestCase {
   }
 
   ['@test wrapped plugins are only invoked once per template'](assert) {
-    this.render('<div>{{#if falsey}}nope{{/if}}</div>');
+    this.render('<div>{{#if this.falsey}}nope{{/if}}</div>');
     assert.equal(customTransformCounter, 1, 'transform should only be instantiated once');
   }
 }

--- a/packages/ember/tests/component_context_test.js
+++ b/packages/ember/tests/component_context_test.js
@@ -12,7 +12,7 @@ moduleFor(
         'application',
         `
       <div id='wrapper'>
-        {{#my-component}}{{text}}{{/my-component}}
+        {{#my-component}}{{this.text}}{{/my-component}}
       </div>
     `
       );
@@ -27,7 +27,7 @@ moduleFor(
         ComponentClass: Component.extend({
           text: 'inner',
         }),
-        template: `{{text}}-{{yield}}`,
+        template: `{{this.text}}-{{yield}}`,
       });
 
       return this.visit('/').then(() => {
@@ -43,7 +43,7 @@ moduleFor(
         'application',
         `
       <div id='wrapper'>
-        {{#my-component}}{{text}}{{/my-component}}
+        {{#my-component}}{{this.text}}{{/my-component}}
       </div>
     `
       );
@@ -85,7 +85,7 @@ moduleFor(
         ComponentClass: Component.extend({
           text: 'inner',
         }),
-        template: '{{text}}',
+        template: '{{this.text}}',
       });
 
       return this.visit('/').then(() => {
@@ -128,7 +128,7 @@ moduleFor(
       this.addTemplate(
         'application',
         `
-      <div id='wrapper'>{{my-component data=foo}}</div>`
+      <div id='wrapper'>{{my-component data=this.foo}}</div>`
       );
 
       this.add(
@@ -158,7 +158,7 @@ moduleFor(
       this.addTemplate(
         'application',
         `
-      <div id='wrapper'>{{my-component attrs=foo}}</div>
+      <div id='wrapper'>{{my-component attrs=this.foo}}</div>
     `
       );
 

--- a/packages/ember/tests/component_registration_test.js
+++ b/packages/ember/tests/component_registration_test.js
@@ -164,9 +164,9 @@ moduleFor(
 
       this.addTemplate(
         'application',
-        `<div id='wrapper'>{{#my-component}}{{text}}{{/my-component}}</div>`
+        `<div id='wrapper'>{{#my-component}}{{this.text}}{{/my-component}}</div>`
       );
-      this.addTemplate('foo-bar-baz', '{{text}}-{{yield}}');
+      this.addTemplate('foo-bar-baz', '{{this.text}}-{{yield}}');
 
       this.application.instanceInitializer({
         name: 'application-controller',
@@ -203,7 +203,7 @@ moduleFor(
 
       this.addTemplate(
         'application',
-        `<div id='wrapper'>{{#my-component}}{{text}}{{/my-component}}</div>`
+        `<div id='wrapper'>{{#my-component}}{{this.text}}{{/my-component}}</div>`
       );
       this.addTemplate('foo-bar-baz', 'No way!');
 
@@ -226,7 +226,7 @@ moduleFor(
             Component.extend({
               text: 'inner',
               layoutName: 'foo-bar-baz',
-              layout: compile('{{text}}-{{yield}}'),
+              layout: compile('{{this.text}}-{{yield}}'),
             })
           );
         },

--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -551,7 +551,10 @@ moduleFor(
         })
       );
 
-      this.addTemplate('root.index', '<a {{action "showStuff" model1 model2}}>{{model1.name}}</a>');
+      this.addTemplate(
+        'root.index',
+        '<a {{action "showStuff" this.model1 this.model2}}>{{this.model1.name}}</a>'
+      );
 
       await this.visit('/');
 

--- a/packages/ember/tests/routing/model_loading_test.js
+++ b/packages/ember/tests/routing/model_loading_test.js
@@ -115,7 +115,7 @@ moduleFor(
     ['@test The Homepage with a `setupController` hook'](assert) {
       this.addTemplate(
         'home',
-        `<ul>{{#each hours as |entry|}}
+        `<ul>{{#each this.hours as |entry|}}
         <li>{{entry}}</li>
       {{/each}}
       </ul>
@@ -171,7 +171,7 @@ moduleFor(
     }
 
     ['@test the route controller can be specified via controllerName'](assert) {
-      this.addTemplate('home', '<p>{{myValue}}</p>');
+      this.addTemplate('home', '<p>{{this.myValue}}</p>');
       this.add(
         'route:home',
         Route.extend({
@@ -225,7 +225,7 @@ moduleFor(
         })
       );
 
-      this.addTemplate('alternative_home', '<p>alternative home: {{myValue}}</p>');
+      this.addTemplate('alternative_home', '<p>alternative home: {{this.myValue}}</p>');
 
       return this.visit('/').then(() => {
         let homeRoute = this.applicationInstance.lookup('route:home');
@@ -253,7 +253,7 @@ moduleFor(
         this.route('home', { path: '/' });
       });
 
-      this.addTemplate('home', '<p>home: {{myValue}}</p>');
+      this.addTemplate('home', '<p>home: {{this.myValue}}</p>');
 
       this.add(
         'route:home',
@@ -313,7 +313,10 @@ moduleFor(
         })
       );
 
-      this.addTemplate('home', '<ul>{{#each hours as |entry|}}<li>{{entry}}</li>{{/each}}</ul>');
+      this.addTemplate(
+        'home',
+        '<ul>{{#each this.hours as |entry|}}<li>{{entry}}</li>{{/each}}</ul>'
+      );
 
       return this.visit('/').then(() => {
         let text = this.$('ul li:nth-child(3)').text();
@@ -384,7 +387,10 @@ moduleFor(
         })
       );
 
-      this.addTemplate('home', '<ul>{{#each hours as |entry|}}<li>{{entry}}</li>{{/each}}</ul>');
+      this.addTemplate(
+        'home',
+        '<ul>{{#each this.hours as |entry|}}<li>{{entry}}</li>{{/each}}</ul>'
+      );
 
       return this.visit('/').then(() => {
         let text = this.$('ul li:nth-child(3)').text();

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -744,7 +744,7 @@ moduleFor(
     ) {
       this.addTemplate(
         'application',
-        '<button id="test-button" {{action \'increment\'}}>Increment</button><span id="test-value">{{foo}}</span>{{outlet}}'
+        '<button id="test-button" {{action \'increment\'}}>Increment</button><span id="test-value">{{this.foo}}</span>{{outlet}}'
       );
 
       this.setSingleQPController('application', 'foo', 1, {
@@ -1447,7 +1447,7 @@ moduleFor(
 
       this.addTemplate(
         'home',
-        "{{link-to 'Home' 'home' (query-params foo=nullValue) id='null-link'}}{{link-to 'Home' 'home' (query-params foo=undefinedValue) id='undefined-link'}}"
+        "{{link-to 'Home' 'home' (query-params foo=this.nullValue) id='null-link'}}{{link-to 'Home' 'home' (query-params foo=this.undefinedValue) id='undefined-link'}}"
       );
 
       this.router.map(function () {

--- a/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
@@ -334,7 +334,7 @@ moduleFor(
 
       this.addTemplate(
         'application',
-        "{{#each articles as |a|}} 1{{link-to 'Article' 'article' a id=a.id}} {{/each}} {{outlet}}"
+        "{{#each this.articles as |a|}} 1{{link-to 'Article' 'article' a id=a.id}} {{/each}} {{outlet}}"
       );
     }
 
@@ -440,7 +440,7 @@ moduleFor(
 
       this.addTemplate(
         'application',
-        "{{#each articles as |a|}} {{link-to 'Article' 'site.article' a id=a.id}} {{/each}} {{outlet}}"
+        "{{#each this.articles as |a|}} {{link-to 'Article' 'site.article' a id=a.id}} {{/each}} {{outlet}}"
       );
     }
 
@@ -591,7 +591,7 @@ moduleFor(
 
       this.addTemplate(
         'application',
-        "{{#each allSitesAllArticles as |a|}} {{#link-to 'site.article' a.site_id a.article_id id=a.id}}Article [{{a.site_id}}] [{{a.article_id}}]{{/link-to}} {{/each}} {{outlet}}"
+        "{{#each this.allSitesAllArticles as |a|}} {{#link-to 'site.article' a.site_id a.article_id id=a.id}}Article [{{a.site_id}}] [{{a.article_id}}]{{/link-to}} {{/each}} {{outlet}}"
       );
     }
 

--- a/packages/ember/tests/routing/query_params_test/shared_state_test.js
+++ b/packages/ember/tests/routing/query_params_test/shared_state_test.js
@@ -42,7 +42,7 @@ moduleFor(
       this.addTemplate('application', `{{link-to 'Home' 'home' }} <div> {{outlet}} </div>`);
       this.addTemplate(
         'home',
-        `{{link-to 'Dashboard' 'dashboard' }}{{input type="checkbox" id='filters-checkbox' checked=(mut filters.shared) }}`
+        `{{link-to 'Dashboard' 'dashboard' }}{{input type="checkbox" id='filters-checkbox' checked=(mut this.filters.shared) }}`
       );
       this.addTemplate('dashboard', `{{link-to 'Home' 'home' }}`);
     }

--- a/packages/ember/tests/routing/router_service_test/currenturl_lifecycle_test.js
+++ b/packages/ember/tests/routing/router_service_test/currenturl_lifecycle_test.js
@@ -130,7 +130,7 @@ moduleFor(
 
       this.addComponent('current-url', {
         ComponentClass: CurrenURLComponent,
-        template: '{{currentURL}}-{{currentRouteName}}-{{currentRoute.name}}',
+        template: '{{this.currentURL}}-{{this.currentRouteName}}-{{this.currentRoute.name}}',
       });
     }
 

--- a/packages/ember/tests/routing/template_rendering_test.js
+++ b/packages/ember/tests/routing/template_rendering_test.js
@@ -311,7 +311,7 @@ moduleFor(
       this.addTemplate('application', "<h1>Home</h1><div class='main'>{{outlet}}</div>");
       this.addTemplate('foo', "<div class='middle'>{{outlet}}</div>");
       this.addTemplate('bar', "<div class='bottom'>{{outlet}}</div>");
-      this.addTemplate('bar.baz', '<p>{{name}}Bottom!</p>');
+      this.addTemplate('bar.baz', '<p>{{this.name}}Bottom!</p>');
 
       this.router.map(function () {
         this.route('foo', { path: '/top' }, function () {
@@ -637,7 +637,7 @@ moduleFor(
 
       this.add('controller:shared', Controller.extend());
 
-      this.addTemplate('shared', '<p>{{message}}{{x-input}}</p>');
+      this.addTemplate('shared', '<p>{{this.message}}{{x-input}}</p>');
 
       let rootElement = document.getElementById('qunit-fixture');
       return this.visit('/first')
@@ -1005,7 +1005,7 @@ moduleFor(
     }
 
     ['@test {{outlet}} works when created after initial render'](assert) {
-      this.addTemplate('sample', 'Hi{{#if showTheThing}}{{outlet}}{{/if}}Bye');
+      this.addTemplate('sample', 'Hi{{#if this.showTheThing}}{{outlet}}{{/if}}Bye');
       this.addTemplate('sample.inner', 'Yay');
       this.addTemplate('sample.inner2', 'Boo');
       this.router.map(function () {
@@ -1354,7 +1354,7 @@ moduleFor(
     ) {
       this.addTemplate(
         'index',
-        '{{#if showFirst}}{{my-component}}{{else}}{{other-component}}{{/if}}'
+        '{{#if this.showFirst}}{{my-component}}{{else}}{{other-component}}{{/if}}'
       );
 
       let myComponentCounter = 0;


### PR DESCRIPTION
Removes all usages of property fallback from tests, except where the
tests are actually testing fallback lookup.

List of tests still containing property fallback:

```json
{
  "Application test: engine rendering:  sharing a template between engine and application has separate refinements": [
    "ambiguous-curlies"
  ],
  "Application test: engine rendering:  sharing a layout between engine and application has separate refinements": [
    "ambiguous-curlies"
  ],
  "Application test: rendering:  it can access the model provided by the route via implicit this fallback": [
    "model"
  ],
  "Application test: rendering:  interior mutations on the model with set": [
    "model.color"
  ],
  "Application test: rendering:  interior mutations on the model with tracked properties": [
    "model.color"
  ],
  "Application test: rendering:  exterior mutations on the model with set": [
    "model"
  ],
  "Application test: rendering:  exterior mutations on the model with tracked properties": [
    "model"
  ],
  "ClassNameBindings integration:  it can have class name bindings in the template": [
    "model.someInitiallyTrueProperty",
    "model.someInitiallyTrueProperty",
    "model.someInitiallyFalseProperty",
    "model.someInitiallyFalseProperty",
    "model.someInitiallyUndefinedProperty",
    "model.someInitiallyUndefinedProperty",
    "model.isBig",
    "model.isOpen",
    "model.isUp",
    "model.bar"
  ],
  "ClassNameBindings integration:  const bindings can be set as attrs": ["foo"],
  "ClassBinding integration:  it should merge classBinding with class": [
    "birdman"
  ],
  "ClassBinding integration:  it should apply classBinding with only truthy condition": [
    "myName"
  ],
  "ClassBinding integration:  it should apply classBinding with only falsy condition": [
    "myName"
  ],
  "ClassBinding integration:  it should apply nothing when classBinding is falsy but only supplies truthy class": [
    "myName"
  ],
  "ClassBinding integration:  it should apply nothing when classBinding is truthy but only supplies falsy class": [
    "myName"
  ],
  "ClassBinding integration:  it should apply classBinding with falsy condition": [
    "swag"
  ],
  "ClassBinding integration:  it should apply classBinding with truthy condition": [
    "swag"
  ],
  "Components test: contextual components -- mutable params:  parameters in a contextual component are mutable when value is a hash value": [
    "component"
  ],
  "Components test: curly components:  can use `{{component.foo}}` in a template GH#19313": [
    "component.foo"
  ],
  "{{link-to}} component (routing tests):  The {{link-to}} component supports 'classNameBindings' with custom values [GH #11699]": [
    "foo"
  ],
  "Helpers test: custom helpers:  it does not resolve helpers with a `.` (period)": [
    "hello.world"
  ],
  "Syntax test: {{#each}} with native arrays:  the scoped variable is not available outside the {{#each}} block.": [
    "name",
    "name"
  ],
  "Syntax test: {{#each}} with native arrays:  the scoped variable is not available outside the {{#each}} block": [
    "ring",
    "ring"
  ],
  "Syntax test: {{#each}} with emberA-wrapped arrays:  the scoped variable is not available outside the {{#each}} block.": [
    "name",
    "name"
  ],
  "Syntax test: {{#each}} with emberA-wrapped arrays:  the scoped variable is not available outside the {{#each}} block": [
    "ring",
    "ring"
  ],
  "Syntax test: {{#each}} with native Set:  the scoped variable is not available outside the {{#each}} block.": [
    "name",
    "name"
  ],
  "Syntax test: {{#each}} with native Set:  the scoped variable is not available outside the {{#each}} block": [
    "ring",
    "ring"
  ],
  "Syntax test: {{#each}} with array-like objects implementing forEach:  the scoped variable is not available outside the {{#each}} block.": [
    "name",
    "name"
  ],
  "Syntax test: {{#each}} with array-like objects implementing forEach:  the scoped variable is not available outside the {{#each}} block": [
    "ring",
    "ring"
  ],
  "Syntax test: {{#each}} with array-like objects implementing Symbol.iterator:  the scoped variable is not available outside the {{#each}} block.": [
    "name",
    "name"
  ],
  "Syntax test: {{#each}} with array-like objects implementing Symbol.iterator:  the scoped variable is not available outside the {{#each}} block": [
    "ring",
    "ring"
  ],
  "Syntax test: {{#each}} with array proxies, modifying itself:  the scoped variable is not available outside the {{#each}} block.": [
    "name",
    "name"
  ],
  "Syntax test: {{#each}} with array proxies, modifying itself:  the scoped variable is not available outside the {{#each}} block": [
    "ring",
    "ring"
  ],
  "Syntax test: {{#each}} with array proxies, replacing its content:  the scoped variable is not available outside the {{#each}} block.": [
    "name",
    "name"
  ],
  "Syntax test: {{#each}} with array proxies, replacing its content:  the scoped variable is not available outside the {{#each}} block": [
    "ring",
    "ring"
  ],
  "Syntax test: {{#each}} with array proxies, arrangedContent depends on external content:  the scoped variable is not available outside the {{#each}} block.": [
    "name",
    "name"
  ],
  "Syntax test: {{#each}} with array proxies, arrangedContent depends on external content:  the scoped variable is not available outside the {{#each}} block": [
    "ring",
    "ring"
  ],
  "Syntax test: {{#each}} with array proxies, content is updated after init:  the scoped variable is not available outside the {{#each}} block.": [
    "name",
    "name"
  ],
  "Syntax test: {{#each}} with array proxies, content is updated after init:  the scoped variable is not available outside the {{#each}} block": [
    "ring",
    "ring"
  ],
  "Syntax test: {{#let as}}:  the scoped variable is not available outside the {{#let}} block.": [
    "name",
    "name"
  ],
  "Syntax test: Multiple {{#let as}} helpers:  the scoped variable is not available outside the {{#let}} block": [
    "ring",
    "ring"
  ],
  "Syntax test: Multiple {{#let as}} helpers:  nested {{#let}} blocks should have access to root context": [
    "name",
    "name",
    "name"
  ],
  "Syntax test: {{#with as}}:  the scoped variable is not available outside the {{#with}} block.": [
    "name",
    "name"
  ],
  "Syntax test: Multiple {{#with as}} helpers:  the scoped variable is not available outside the {{#with}} block": [
    "ring",
    "ring"
  ],
  "Syntax test: Multiple {{#with as}} helpers:  nested {{#with}} blocks should have access to root context": [
    "name",
    "name",
    "name"
  ]
}

```
