### PR TITLE
[BUGFIX release] Remove non-existing re-export from helper-addon blueprint

### DIFF
--- a/blueprints/helper-addon/files/__root__/__path__/__name__.js
+++ b/blueprints/helper-addon/files/__root__/__path__/__name__.js
@@ -1,1 +1,1 @@
-export { default, <%= camelizedModuleName %> } from '<%= modulePath %>';
+export { default } from '<%= modulePath %>';

--- a/node-tests/fixtures/helper/helper-addon.js
+++ b/node-tests/fixtures/helper/helper-addon.js
@@ -1,1 +1,1 @@
-export { default, fooBarBaz } from 'my-addon/helpers/foo/bar-baz';
+export { default } from 'my-addon/helpers/foo/bar-baz';


### PR DESCRIPTION
The blueprint for an addon's `app/helpers/foo.js` contains a re-export of a named export of `addon/helpers/foo.js` which does not exist, as it [only has a default export](https://github.com/emberjs/ember.js/blob/master/blueprints/helper/files/__root__/__collection__/__name__.js).

FWIW, Embroider is constantly complaining about this (rightly).