### PR TITLE
ES6 property syntax in Location example

### DIFF
--- a/packages/@ember/-internals/routing/lib/location/api.ts
+++ b/packages/@ember/-internals/routing/lib/location/api.ts
@@ -58,13 +58,16 @@ export type UpdateCallback = (url: string) => void;
   import HistoryLocation from '@ember/routing/history-location';
 
   export default class MyHistory {
-    implementation: 'my-custom-history',
+    implementation = 'my-custom-history';
+
     constructor() {
       this._history = HistoryLocation.create(...arguments);
     }
+
     create() {
       return new this(...arguments);
     }
+
     pushState(path) {
        this._history.pushState(path);
     }


### PR DESCRIPTION
Update API Location example to use ES6 syntax for the `implementation` property.

Continuation of https://github.com/emberjs/ember.js/pull/19324#issuecomment-767801005