### PR TITLE
[DEPRECATION] Add Array Observers deprecation 

### DIFF
--- a/packages/@ember/-internals/metal/lib/array.ts
+++ b/packages/@ember/-internals/metal/lib/array.ts
@@ -1,4 +1,5 @@
-import { EmberArray } from '@ember/-internals/utils';
+import { EmberArray, getDebugName } from '@ember/-internals/utils';
+import { deprecate } from '@ember/debug';
 import { arrayContentDidChange, arrayContentWillChange } from './array_events';
 import { addListener, removeListener } from './events';
 import { notifyPropertyChange } from './property_events';
@@ -91,16 +92,48 @@ function arrayObserversHelper(
 
 export function addArrayObserver<T>(
   array: EmberArray<T>,
-  target: any,
-  opts?: ArrayObserverOptions | undefined
+  target: object | Function | null,
+  opts?: ArrayObserverOptions | undefined,
+  suppress = false
 ): ObjectHasArrayObservers {
+  deprecate(
+    `Array observers have been deprecated. Added an array observer to ${getDebugName?.(array)}.`,
+    suppress,
+    {
+      id: 'array-observers',
+      url: 'https://deprecations.emberjs.com/v3.x#toc_array-observers',
+      until: '4.0.0',
+      for: 'ember-source',
+      since: {
+        enabled: '3.26.0-beta.1',
+      },
+    }
+  );
+
   return arrayObserversHelper(array, target, opts, addListener, false);
 }
 
 export function removeArrayObserver<T>(
   array: EmberArray<T>,
-  target: any,
-  opts?: ArrayObserverOptions | undefined
+  target: object | Function | null,
+  opts?: ArrayObserverOptions | undefined,
+  suppress = false
 ): ObjectHasArrayObservers {
+  deprecate(
+    `Array observers have been deprecated. Removed an array observer from ${getDebugName?.(
+      array
+    )}.`,
+    suppress,
+    {
+      id: 'array-observers',
+      url: 'https://deprecations.emberjs.com/v3.x#toc_array-observers',
+      until: '4.0.0',
+      for: 'ember-source',
+      since: {
+        enabled: '3.26.0-beta.1',
+      },
+    }
+  );
+
   return arrayObserversHelper(array, target, opts, removeListener, true);
 }

--- a/packages/@ember/-internals/runtime/lib/system/array_proxy.js
+++ b/packages/@ember/-internals/runtime/lib/system/array_proxy.js
@@ -272,7 +272,7 @@ export default class ArrayProxy extends EmberObject {
         isArray(arrangedContent) || arrangedContent.isDestroyed
       );
 
-      addArrayObserver(arrangedContent, this, ARRAY_OBSERVER_MAPPING);
+      addArrayObserver(arrangedContent, this, ARRAY_OBSERVER_MAPPING, true);
 
       this._arrangedContent = arrangedContent;
     }
@@ -280,7 +280,7 @@ export default class ArrayProxy extends EmberObject {
 
   _removeArrangedContentArrayObserver() {
     if (this._arrangedContent) {
-      removeArrayObserver(this._arrangedContent, this, ARRAY_OBSERVER_MAPPING);
+      removeArrayObserver(this._arrangedContent, this, ARRAY_OBSERVER_MAPPING, true);
     }
   }
 

--- a/packages/@ember/-internals/runtime/tests/mixins/array_test.js
+++ b/packages/@ember/-internals/runtime/tests/mixins/array_test.js
@@ -196,6 +196,8 @@ moduleFor(
   'notify array observers',
   class extends AbstractTestCase {
     beforeEach(assert) {
+      expectDeprecation(/Array observers have been deprecated/);
+
       obj = DummyArray.create();
 
       observer = EmberObject.extend({

--- a/packages/@ember/-internals/runtime/tests/mutable-array/replace-test.js
+++ b/packages/@ember/-internals/runtime/tests/mutable-array/replace-test.js
@@ -241,6 +241,8 @@ class ReplaceTests extends AbstractTestCase {
   }
 
   async '@test Adding object should notify array observer'() {
+    expectDeprecation(/Array observers have been deprecated/);
+
     let fixtures = newFixture(4);
     let obj = this.newObject(fixtures);
     let observer = this.newObserver(obj).observeArray(obj);

--- a/packages/@ember/-internals/runtime/tests/system/array_proxy/array_observer_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/array_proxy/array_observer_test.js
@@ -7,7 +7,9 @@ moduleFor(
   'ArrayProxy - array observers',
   class extends AbstractTestCase {
     ['@test mutating content'](assert) {
-      assert.expect(4);
+      expectDeprecation(/Array observers have been deprecated/);
+
+      assert.expect(5);
 
       let content = A(['x', 'y', 'z']);
       let proxy = ArrayProxy.create({ content });
@@ -28,7 +30,9 @@ moduleFor(
     }
 
     ['@test assigning content'](assert) {
-      assert.expect(4);
+      expectDeprecation(/Array observers have been deprecated/);
+
+      assert.expect(5);
 
       let content = A(['x', 'y', 'z']);
       let proxy = ArrayProxy.create({ content });


### PR DESCRIPTION
Adds the array observers deprecation specified in RFC 692: https://github.com/emberjs/rfcs/blob/master/text/0692-deprecate-array-observers.md

Depends on #19379 