### PR TITLE
Perform early caching on singleton object instances

### DIFF
--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -73,7 +73,9 @@ export default class RouterService extends Service {
     }
     const owner = getOwner(this) as Owner;
     router = owner.lookup('router:main') as EmberRouter;
-    router.setupRouter();
+    if (!router.didSetupRouter) {
+      router.setupRouter();
+    }
     return (this[ROUTER] = router);
   }
 

--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -129,12 +129,12 @@ class EmberRouter extends EmberObject {
   location!: string | IEmberLocation;
   rootURL!: string;
   _routerMicrolib!: Router<Route>;
-  _didSetupRouter = false;
 
   currentURL: string | null = null;
   currentRouteName: string | null = null;
   currentPath: string | null = null;
   currentRoute = null;
+  didSetupRouter = false;
 
   _qpCache = Object.create(null);
   _qpUpdates = new Set();
@@ -418,10 +418,10 @@ class EmberRouter extends EmberObject {
   }
 
   setupRouter() {
-    if (this._didSetupRouter) {
+    if (this.didSetupRouter) {
       return false;
     }
-    this._didSetupRouter = true;
+    this.didSetupRouter = true;
     this._setupLocation();
 
     let location = get(this, 'location');
@@ -620,7 +620,7 @@ class EmberRouter extends EmberObject {
     @method reset
    */
   reset() {
-    this._didSetupRouter = false;
+    this.didSetupRouter = false;
     if (this._routerMicrolib) {
       this._routerMicrolib.reset();
     }

--- a/packages/@ember/-internals/routing/tests/system/router_test.js
+++ b/packages/@ember/-internals/routing/tests/system/router_test.js
@@ -64,7 +64,7 @@ moduleFor(
     ['@test should create a router.js instance after setupRouter'](assert) {
       let router = createRouter(undefined, { disableSetup: false });
 
-      assert.ok(router._didSetupRouter);
+      assert.ok(router.didSetupRouter);
       assert.ok(router._routerMicrolib);
     }
 

--- a/packages/@ember/-internals/runtime/lib/system/core_object.js
+++ b/packages/@ember/-internals/runtime/lib/system/core_object.js
@@ -842,11 +842,21 @@ class CoreObject {
   static create(props, extra) {
     let instance;
 
+    let factory;
+
     if (props !== undefined) {
+      factory = getFactoryFor(props);
       instance = new this(getOwner(props));
-      setFactoryFor(instance, getFactoryFor(props));
+      setFactoryFor(instance, factory);
     } else {
       instance = new this();
+    }
+
+    if (factory) {
+      let singletonInstanceNames = factory.container.singletonInstanceNames;
+      if (singletonInstanceNames && singletonInstanceNames.has(factory.fullName)) {
+        factory.container.cache[factory.fullName] = instance;
+      }
     }
 
     if (extra === undefined) {

--- a/packages/ember/tests/routing/router_service_test/basic_test.js
+++ b/packages/ember/tests/routing/router_service_test/basic_test.js
@@ -1,6 +1,7 @@
 import { Route, NoneLocation } from '@ember/-internals/routing';
 import { set } from '@ember/-internals/metal';
 import { RouterTestCase, moduleFor } from 'internal-test-helpers';
+import { inject as injectService } from '@ember/service';
 
 moduleFor(
   'Router Service - main',
@@ -149,6 +150,19 @@ moduleFor(
         assert.ok(location);
         assert.ok(location instanceof NoneLocation);
       });
+    }
+
+    ['@test RouterService can be injected into router and accessed on init'](assert) {
+      assert.expect(1);
+
+      this.router.reopen({
+        routerService: injectService('router'),
+        init() {
+          assert.equal(this.routerService._router, this);
+        },
+      });
+
+      return this.visit('/');
     }
   }
 );

--- a/packages/ember/tests/service_injection_test.js
+++ b/packages/ember/tests/service_injection_test.js
@@ -50,6 +50,34 @@ moduleFor(
       assert.ok(controller.get('myService') instanceof MyService);
       assert.equal(serviceOwner, instance, 'should be able to `getOwner` in init');
     }
+
+    ['@test Service does not cause too much recurison through circular reference to singleton'](
+      assert
+    ) {
+      this.add(
+        'controller:application',
+        Controller.extend({
+          myService: injectService('my-service'),
+          foo: 'bar',
+          init() {
+            this._super(...arguments);
+            assert.equal(this.myService.value, this.foo);
+          },
+        })
+      );
+      let MyService = Service.extend({
+        get _controller() {
+          return getOwner(this).lookup('controller:application');
+        },
+        get value() {
+          return this._controller.foo;
+        },
+      });
+
+      this.add('service:my-service', MyService);
+
+      this.visit('/');
+    }
   }
 );
 


### PR DESCRIPTION
This PR is intended to address this issue:
https://github.com/emberjs/ember.js/issues/17791

To summarize, injecting the `service:router` into `router:main` causes an infinite recursion error because `service:router` attempts to lookup `router:main` before `router:main` has had a chance to be cached as a singleton.  Caching of singletons doesn't happen until after initialization has completed.

<img width="370" alt="Screenshot 2021-02-07 at 20 44 33" src="https://user-images.githubusercontent.com/5193330/107176965-92ab2f00-69c8-11eb-8d54-feeeb41cb849.png">

Although this seems to be a peculiar use of the router service, this can be a problem when accessing other services that use `service:router` inside of the router before it has fully initialized, as would be the case if one was using [ember-router-scroll](https://github.com/DockYard/ember-router-scroll) and tried accessing `service:router-scroll`.

I'm not married at all to the approach taken here, and since this is my first contribution I'd be glad to take guidance.  I landed on this approach because it seems like it would prevent most infinite loops that could occur by a circular reference between a singleton through a service.

Basically, I chose to allow CoreObject to preemptively add the object instance to the container cache before it has been initialized, which is why further calls to `owner.lookup('router:main')` at that point won't try to spawn another router instance even when `init()` on the router has yet to have been called.

My reasoning is that it seems preferable that a service access a singleton that hasn't been 100% setup yet as opposed to running into an infinite loop.  For instance, even if something like the router hasn't fully initialized, it can still be useful to have other parts of an app be able to add event listeners to it.  There are ways to get around this issue, of course, but I can't imagine a philosophy around why such hypothetical workarounds must be taken in this case.

One possible drawback might be that an object instance that encounters an error when `init()` is called would still remain in `container.cache`, which wouldn't happen without this change.  Of course it would be very easy to perform a "rollback", but I left that out because there didn't actually seem to be a requirement for keeping instances that error on `init()` out of the cache.  A try-catch block could definitely be added if that's what we need.

Like I said, guidance on this would be welcome if we are open to something akin to what this PR is currently doing.  I tried to come up with a way to signal that an instance should be cached that wasn't intrusive to existing APIs.

One thing I also chose to do was to promote `_didSetupRouter` to being a public property; this is because I chose to access it inside `service:router` so that it doesn't attempt to perform `router.setupRouter()` before `router.startRouting()` has a chance to preform on `router:main`(which prevents that method from performing).  After searching the codebase and the issues in this repo, I couldn't come up with a reason why it needed to be private.