### PR TITLE
Deprecate passing input actions as strings

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/input.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/input.ts
@@ -927,20 +927,18 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
         const actionName = this.arg(type);
 
         if (typeof actionName === 'string') {
-          // TODO: eagerly issue a deprecation for this as well (need to fix tests)
-          //
-          // deprecate(
-          //   `Passing actions to components as strings (like \`<${this.constructor} @${type}="${actionName}" />\`) is deprecated. ` +
-          //     `Please use closure actions instead (\`<${this.constructor} @${type}={{action "${actionName}"}} />\`).`,
-          //   false,
-          //   {
-          //     id: 'ember-component.send-action',
-          //     for: 'ember-source',
-          //     since: {},
-          //     until: '4.0.0',
-          //     url: 'https://emberjs.com/deprecations/v3.x#toc_ember-component-send-action',
-          //   }
-          // );
+          deprecate(
+            `Passing actions to components as strings (like \`<${this.constructor} @${type}="${actionName}" />\`) is deprecated. ` +
+              `Please use closure actions instead (\`<${this.constructor} @${type}={{action "${actionName}"}} />\`).`,
+            false,
+            {
+              id: 'ember-component.send-action',
+              for: 'ember-source',
+              since: {},
+              until: '4.0.0',
+              url: 'https://emberjs.com/deprecations/v3.x#toc_ember-component-send-action',
+            }
+          );
 
           const { caller } = this;
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/input-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/input-angle-test.js
@@ -609,11 +609,11 @@ moduleFor(
             },
           },
         });
-      }, 'Passing actions to components as strings (like `<Input @key-press="foo" />`) is deprecated. Please use closure actions instead (`<Input @key-press={{action "foo"}} />`). (\'-top-level\' @ L1:C0) ');
+      }, /Passing actions to components as strings \(like `({{input key-press="foo"}}|<Input @key-press="foo" \/>)`\) is deprecated\./);
 
       expectDeprecation(() => {
         this.triggerEvent('keypress', { key: 'A' });
-      }, 'Passing actions to components as strings (like `<Input @key-press="foo" />`) is deprecated. Please use closure actions instead (`<Input @key-press={{action "foo"}} />`).');
+      }, /Passing actions to components as strings \(like `({{input key-press="foo"}}|<Input @key-press="foo" \/>)`\) is deprecated\./);
     }
 
     ['@test sends an action with `<Input @key-press={{action "foo"}} />` is pressed'](assert) {
@@ -765,7 +765,7 @@ moduleFor(
             },
           },
         });
-      }, 'Passing actions to components as strings (like `<Input @key-down="foo" />`) is deprecated. Please use closure actions instead (`<Input @key-down={{action "foo"}} />`). (\'-top-level\' @ L1:C0) ');
+      }, /Passing actions to components as strings \(like `({{input key-down="foo"}}|<Input @key-down="foo" \/>)`\) is deprecated\./);
 
       expectDeprecation(() => {
         this.triggerEvent('keydown', { key: 'A' });
@@ -811,7 +811,7 @@ moduleFor(
             },
           },
         });
-      }, 'Passing actions to components as strings (like `<Input @key-up="foo" />`) is deprecated. Please use closure actions instead (`<Input @key-up={{action "foo"}} />`). (\'-top-level\' @ L1:C0) ');
+      }, /Passing actions to components as strings \(like `({{input key-up="foo"}}|<Input @key-up="foo" \/>)`\) is deprecated\./);
 
       expectDeprecation(() => {
         this.triggerEvent('keyup', { key: 'A' });

--- a/packages/@ember/-internals/glimmer/tests/integration/components/input-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/input-curly-test.js
@@ -439,11 +439,11 @@ moduleFor(
             },
           },
         });
-      }, 'Passing actions to components as strings (like `{{input key-press="foo"}}`) is deprecated. Please use closure actions instead (`{{input key-press=(action "foo")}}`). (\'-top-level\' @ L1:C0) ');
+      }, /Passing actions to components as strings \(like `({{input key-press="foo"}}|<Input @key-press="foo" \/>)`\) is deprecated\./);
 
       expectDeprecation(() => {
         this.triggerEvent('keypress', { key: 'A' });
-      }, 'Passing actions to components as strings (like `<Input @key-press="foo" />`) is deprecated. Please use closure actions instead (`<Input @key-press={{action "foo"}} />`).');
+      }, /Passing actions to components as strings \(like `({{input key-press="foo"}}|<Input @key-press="foo" \/>)`\) is deprecated\./);
     }
 
     ['@test sends an action with `{{input key-press=(action "foo")}}` is pressed'](assert) {
@@ -595,7 +595,7 @@ moduleFor(
             },
           },
         });
-      }, 'Passing actions to components as strings (like `{{input key-down="foo"}}`) is deprecated. Please use closure actions instead (`{{input key-down=(action "foo")}}`). (\'-top-level\' @ L1:C0) ');
+      }, /Passing actions to components as strings \(like `({{input key-down="foo"}}|<Input @key-down="foo" \/>)`\) is deprecated\./);
 
       expectDeprecation(() => {
         this.triggerEvent('keydown', { key: 'A' });
@@ -641,7 +641,7 @@ moduleFor(
             },
           },
         });
-      }, 'Passing actions to components as strings (like `{{input key-up="foo"}}`) is deprecated. Please use closure actions instead (`{{input key-up=(action "foo")}}`). (\'-top-level\' @ L1:C0) ');
+      }, /Passing actions to components as strings \(like `({{input key-up="foo"}}|<Input @key-up="foo" \/>)`\) is deprecated\./);
 
       expectDeprecation(() => {
         this.triggerEvent('keyup', { key: 'A' });


### PR DESCRIPTION
Tracking issue: #19270

Fixes input tests for passing actions to components as strings deprecation
