### PR TITLE
[BUGFIX lts] LinkTo with incomplete model failing in rendering tests

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-angle-test.js
@@ -126,9 +126,7 @@ moduleFor(
           });
         });
       });
-      debugger;
       return this.visit('/parents/1').then(() => {
-        debugger;
         this.assertText('Link To Child');
       });
     }
@@ -143,7 +141,7 @@ moduleFor(
 
       this.assertComponentElement(this.element.firstChild, {
         tagName: 'a',
-        attrs: { href: '#/' },
+        attrs: { href: null },
         content: 'Go to Index',
       });
     }
@@ -173,7 +171,6 @@ moduleFor(
 
     ['@test should be able to be inserted in DOM when router is setup but not started']() {
       this.render(`<LinkTo @route="dynamicWithChild.child">Link</LinkTo>`);
-      debugger;
       this.assertComponentElement(this.element.firstChild, {
         tagName: 'a',
         content: 'Link',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-angle-test.js
@@ -1,5 +1,11 @@
-import { moduleFor, ApplicationTestCase, RenderingTestCase, runTask } from 'internal-test-helpers';
-
+import {
+  moduleFor,
+  ApplicationTestCase,
+  RenderingTestCase,
+  RouterNonApplicationTestCase,
+  runTask,
+} from 'internal-test-helpers';
+import { Router, Route } from '@ember/-internals/routing';
 import Controller from '@ember/controller';
 import { set } from '@ember/-internals/metal';
 import { LinkComponent } from '@ember/-internals/glimmer';
@@ -92,6 +98,40 @@ moduleFor(
         this.assertText('Hello');
       });
     }
+
+    ['@test able to pupolate innermost dynamic segment when immediate parent route is active']() {
+      this.addTemplate('application', '{{outlet}}');
+      this.addTemplate('parents', '{{outlet}}');
+      this.addTemplate(
+        'parents.parent',
+        '<LinkTo @route="parents.parent.child" @model=1>Link To Child</LinkTo>'
+      );
+      this.addTemplate(
+        'parents.parent.child',
+        '<LinkTo @route="parents.parent">Link To Parent</LinkTo>'
+      );
+      this.add(
+        'route:parents.parent',
+        class extends Route {
+          async model({ id }) {
+            return { value: id };
+          }
+        }
+      );
+      this.router.map(function () {
+        this.route('parents', function () {
+          this.route('parent', { path: '/:parent_id' }, function () {
+            this.route('children');
+            this.route('child', { path: '/child/:child_id' });
+          });
+        });
+      });
+      debugger;
+      return this.visit('/parents/1').then(() => {
+        debugger;
+        this.assertText('Link To Child');
+      });
+    }
   }
 );
 
@@ -105,6 +145,38 @@ moduleFor(
         tagName: 'a',
         attrs: { href: '#/' },
         content: 'Go to Index',
+      });
+    }
+  }
+);
+
+moduleFor(
+  '<LinkTo /> component (rendering tests, with router not started)',
+  class extends RouterNonApplicationTestCase {
+    constructor() {
+      super(...arguments);
+      this.resolver.add('router:main', Router.extend(this.routerOptions));
+      this.router.map(function () {
+        this.route('dynamicWithChild', { path: '/dynamic-with-child/:dynamic_id' }, function () {
+          this.route('child');
+        });
+      });
+    }
+    get routerOptions() {
+      return {
+        location: 'none',
+      };
+    }
+    get router() {
+      return this.owner.resolveRegistration('router:main');
+    }
+
+    ['@test should be able to be inserted in DOM when router is setup but not started']() {
+      this.render(`<LinkTo @route="dynamicWithChild.child">Link</LinkTo>`);
+      debugger;
+      this.assertComponentElement(this.element.firstChild, {
+        tagName: 'a',
+        content: 'Link',
       });
     }
   }

--- a/packages/@ember/-internals/routing/lib/services/routing.ts
+++ b/packages/@ember/-internals/routing/lib/services/routing.ts
@@ -54,8 +54,10 @@ export default class RoutingService extends Service {
 
   generateURL(routeName: string, models: {}[], queryParams: {}) {
     let router = this.router;
-    // return early when the router microlib is not present, which is the case for {{link-to}} in integration tests
-    if (!router._routerMicrolib) {
+    // return early when the router microlib is not present, which is the case for <LinkTo/> in integration tests
+    // also return early when transition has not started, when rendering in tests without visit(),
+    // we cannot infer the route context which <LinkTo/> needs be aware of
+    if (!router._routerMicrolib || !router._initialTransitionStarted) {
       return;
     }
 

--- a/packages/@ember/-internals/routing/lib/services/routing.ts
+++ b/packages/@ember/-internals/routing/lib/services/routing.ts
@@ -54,10 +54,9 @@ export default class RoutingService extends Service {
 
   generateURL(routeName: string, models: {}[], queryParams: {}) {
     let router = this.router;
-    // return early when the router microlib is not present, which is the case for <LinkTo/> in integration tests
-    // also return early when transition has not started, when rendering in tests without visit(),
+    // Return early when transition has not started, when rendering in tests without visit(),
     // we cannot infer the route context which <LinkTo/> needs be aware of
-    if (!router._routerMicrolib || !router._initialTransitionStarted) {
+    if (!router._initialTransitionStarted) {
       return;
     }
 

--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -130,6 +130,7 @@ class EmberRouter extends EmberObject {
   rootURL!: string;
   _routerMicrolib!: Router<Route>;
   _didSetupRouter = false;
+  _initialTransitionStarted = false;
 
   currentURL: string | null = null;
   currentRouteName: string | null = null;
@@ -507,6 +508,7 @@ class EmberRouter extends EmberObject {
   }
 
   _doURLTransition(routerJsMethod: string, url: string) {
+    this._initialTransitionStarted = true;
     let transition = this._routerMicrolib[routerJsMethod](url || '/');
     didBeginTransition(transition, this);
     return transition;
@@ -621,6 +623,7 @@ class EmberRouter extends EmberObject {
    */
   reset() {
     this._didSetupRouter = false;
+    this._initialTransitionStarted = false;
     if (this._routerMicrolib) {
       this._routerMicrolib.reset();
     }
@@ -841,6 +844,8 @@ class EmberRouter extends EmberObject {
       `The route ${targetRouteName} was not found`,
       Boolean(targetRouteName) && this._routerMicrolib.hasRoute(targetRouteName)
     );
+
+    this._initialTransitionStarted = true;
 
     let queryParams = {};
 


### PR DESCRIPTION
LinkTo needs route context to allow omitting model from current active
route. Without the guard, tests where LinkTo rendered in tests without
routing transition started will break. See https://github.com/emberjs/ember.js/issues/19364

Add failing test before the fix:
While generating link to route "dynamicWithChild.child": can't access
property "shouldSupercede", newHandlerInfo is undefined