### PR TITLE
[Deprecation] `renderTemplate` and `disconnectOutlet` methods

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
@@ -4,6 +4,7 @@ import {
   moduleFor,
   strip,
 } from 'internal-test-helpers';
+// import { ExpectDeprecationFunc } from '../../../../../../internal-test-helpers/lib/ember-dev/deprecation';
 
 import { ENV } from '@ember/-internals/environment';
 import { Component, setComponentManager } from '@ember/-internals/glimmer';
@@ -180,6 +181,10 @@ if (ENV._DEBUG_RENDER_TREE) {
       }
 
       async '@test named outlets'() {
+        // TODO - fix this type error
+        // @ts-ignore-next-line
+        expectDeprecation(() => {}, 'The usage of `disconnectOutlet` is deprecated.');
+
         this.addTemplate(
           'application',
           strip`

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -1705,6 +1705,15 @@ class Route extends EmberObject implements IRoute {
     @public
   */
   disconnectOutlet(options: string | { outlet: string; parentView?: string }) {
+    deprecate('The usage of `disconnectOutlet` is deprecated.', false, {
+      id: 'router-render-methods.disconnect-outlet',
+      until: '4.0.0',
+      url: 'TODO',
+      for: 'ember-source',
+      since: {
+        enabled: '3.26.0',
+      },
+    });
     let outletName;
     let parentView;
     if (options) {

--- a/packages/ember/tests/routing/template_rendering_test.js
+++ b/packages/ember/tests/routing/template_rendering_test.js
@@ -752,6 +752,8 @@ moduleFor(
     }
 
     ['@test Route supports clearing outlet explicitly'](assert) {
+      expectDeprecation('The usage of `disconnectOutlet` is deprecated.');
+
       this.addTemplate('application', "{{outlet}}{{outlet 'modal'}}");
       this.addTemplate('posts', '{{outlet}}');
       this.addTemplate('users', 'users');
@@ -876,6 +878,7 @@ moduleFor(
     }
 
     ['@test Route supports clearing outlet using string parameter'](assert) {
+      expectDeprecation('The usage of `disconnectOutlet` is deprecated.');
       this.addTemplate('application', "{{outlet}}{{outlet 'modal'}}");
       this.addTemplate('posts', '{{outlet}}');
       this.addTemplate('users', 'users');
@@ -942,7 +945,9 @@ moduleFor(
     }
 
     ['@test Route silently fails when cleaning an outlet from an inactive view'](assert) {
-      assert.expect(1); // handleURL
+      assert.expect(2); // handleURL
+
+      expectDeprecation('The usage of `disconnectOutlet` is deprecated.');
 
       this.addTemplate('application', '{{outlet}}');
       this.addTemplate('posts', "{{outlet 'modal'}}");
@@ -1062,6 +1067,8 @@ moduleFor(
     }
 
     ['@test Can disconnect a named outlet at the top level'](assert) {
+      expectDeprecation('The usage of `disconnectOutlet` is deprecated.');
+
       this.addTemplate('application', 'A-{{outlet}}-B-{{outlet "other"}}-C');
       this.addTemplate('modal', 'Hello world');
       this.addTemplate('index', 'The index');
@@ -1232,6 +1239,8 @@ moduleFor(
     }
 
     ['@test Tolerates stacked renders'](assert) {
+      expectDeprecation('The usage of `disconnectOutlet` is deprecated.');
+
       this.addTemplate('application', '{{outlet}}{{outlet "modal"}}');
       this.addTemplate('index', 'hi');
       this.addTemplate('layer', 'layer');
@@ -1305,6 +1314,8 @@ moduleFor(
     }
 
     ["@test Allows any route to disconnectOutlet another route's templates"](assert) {
+      expectDeprecation('The usage of `disconnectOutlet` is deprecated.');
+
       this.addTemplate('application', '{{outlet}}{{outlet "modal"}}');
       this.addTemplate('index', 'hi');
       this.addTemplate('layer', 'layer');
@@ -1427,6 +1438,8 @@ moduleFor(
     }
 
     ['@test Exception if outlet name is undefined in render and disconnectOutlet']() {
+      expectDeprecation('The usage of `disconnectOutlet` is deprecated.');
+
       this.add(
         'route:application',
         Route.extend({


### PR DESCRIPTION
Deprecates `renderTemplate` ([RFC 418](https://emberjs.github.io/rfcs/0418-deprecate-route-render-methods.html)) and `disconnectOutlet` ([RFC 491](https://emberjs.github.io/rfcs/0491-deprecate-disconnect-outlet.html))

Taken from the [Deprecations list](https://www.notion.so/Deprecations-bbe769a13fb54bc8beafff175de4323a) 

## Task list
### `renderTemplate`
* [x] Deprecation guide added to deprecations app
* [x] Deprecation message `The usage of 'renderTemplate' is deprecated. Please see the following deprecation guide to migrate.`
* [x] Key: `route-render-methods`
* [x] Call to `deprecate`
* [x] Fix tests

### `disconnectOutlet`
* [x] Deprecation guide added to deprecations app
* [x] Deprecation message: `"The usage of 'disconnectOutlet' is deprecated. Please see the following deprecation guide to migrate.`
* [x] Key: `disconnect-outlet`
* [x] Call to `deprecate`
* [x] Fix tests

/cc @locks 