### PR TITLE
[LTS fix] only return empty href when LinkTo href generation throws error

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-angle-test.js
@@ -141,7 +141,7 @@ moduleFor(
 
       this.assertComponentElement(this.element.firstChild, {
         tagName: 'a',
-        attrs: { href: null },
+        attrs: { href: '#/' },
         content: 'Go to Index',
       });
     }
@@ -169,10 +169,24 @@ moduleFor(
       return this.owner.resolveRegistration('router:main');
     }
 
-    ['@test should be able to be inserted in DOM when router is setup but not started']() {
+    ['@test should be able to be inserted in DOM when initial transition not started']() {
       this.render(`<LinkTo @route="dynamicWithChild.child">Link</LinkTo>`);
       this.assertComponentElement(this.element.firstChild, {
         tagName: 'a',
+        attrs: {
+          href: null,
+        },
+        content: 'Link',
+      });
+    }
+
+    ['@test should be able to be inserted in DOM with valid href when complete models are passed even if initial transition is not started']() {
+      this.render(`<LinkTo @route="dynamicWithChild.child" @model="1">Link</LinkTo>`);
+      this.assertComponentElement(this.element.firstChild, {
+        tagName: 'a',
+        attrs: {
+          href: '/dynamic-with-child/1/child',
+        },
         content: 'Link',
       });
     }

--- a/packages/@ember/-internals/routing/lib/services/routing.ts
+++ b/packages/@ember/-internals/routing/lib/services/routing.ts
@@ -52,25 +52,28 @@ export default class RoutingService extends Service {
     this.router._prepareQueryParams(routeName, models, queryParams);
   }
 
-  generateURL(routeName: string, models: {}[], queryParams: {}) {
-    let router = this.router;
-    try {
-      let visibleQueryParams = {};
-      if (queryParams) {
-        assign(visibleQueryParams, queryParams);
-        this.normalizeQueryParams(routeName, models, visibleQueryParams as QueryParam);
-      }
+  _generateURL(routeName: string, models: {}[], queryParams: {}) {
+    let visibleQueryParams = {};
+    if (queryParams) {
+      assign(visibleQueryParams, queryParams);
+      this.normalizeQueryParams(routeName, models, visibleQueryParams as QueryParam);
+    }
 
-      return router.generate(routeName, ...models, {
-        queryParams: visibleQueryParams,
-      });
-    } catch (e) {
+    return this.router.generate(routeName, ...models, {
+      queryParams: visibleQueryParams,
+    });
+  }
+
+  generateURL(routeName: string, models: {}[], queryParams: {}) {
+    if (this.router._initialTransitionStarted) {
+      return this._generateURL(routeName, models, queryParams);
+    } else {
       // Swallow error when transition has not started.
       // When rendering in tests without visit(), we cannot infer the route context which <LinkTo/> needs be aware of
-      if (!router._initialTransitionStarted) {
+      try {
+        return this._generateURL(routeName, models, queryParams);
+      } catch (_e) {
         return;
-      } else {
-        throw e;
       }
     }
   }

--- a/packages/@ember/-internals/routing/lib/services/routing.ts
+++ b/packages/@ember/-internals/routing/lib/services/routing.ts
@@ -54,21 +54,25 @@ export default class RoutingService extends Service {
 
   generateURL(routeName: string, models: {}[], queryParams: {}) {
     let router = this.router;
-    // Return early when transition has not started, when rendering in tests without visit(),
-    // we cannot infer the route context which <LinkTo/> needs be aware of
-    if (!router._initialTransitionStarted) {
-      return;
-    }
+    try {
+      let visibleQueryParams = {};
+      if (queryParams) {
+        assign(visibleQueryParams, queryParams);
+        this.normalizeQueryParams(routeName, models, visibleQueryParams as QueryParam);
+      }
 
-    let visibleQueryParams = {};
-    if (queryParams) {
-      assign(visibleQueryParams, queryParams);
-      this.normalizeQueryParams(routeName, models, visibleQueryParams as QueryParam);
+      return router.generate(routeName, ...models, {
+        queryParams: visibleQueryParams,
+      });
+    } catch (e) {
+      // Swallow error when transition has not started.
+      // When rendering in tests without visit(), we cannot infer the route context which <LinkTo/> needs be aware of
+      if (!router._initialTransitionStarted) {
+        return;
+      } else {
+        throw e;
+      }
     }
-
-    return router.generate(routeName, ...models, {
-      queryParams: visibleQueryParams,
-    });
   }
 
   isActiveForRoute(


### PR DESCRIPTION
## Summary
In 3.24.0-3.24.2 we made changes to let LinkTo href generation returns
empty when initial transition is not started. This is not true and
causing regression on the super-rental tutorial https://github.com/ember-learn/super-rentals-tutorial/pull/176.

In previous tutorials, the LinkTo component will return empty href when
`this.owner.setupRouter()` is not called. It generates valid href if
`setupRouter()` is called and complete model are passed for dynamic
segments.

In our previous changes, we removed the requirement to call
`setupRouter`, and always return empty href when initial transition is
not started. This is not expected when passing complete dynamic segments
without initial transition.

## Test done
I linked the fix and `super-rentals-tutorials` pass test