### PR TITLE
[BUGFIX release] Revert deprecation of htmlSafe and isHTMLSafe

### DIFF
--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -598,7 +598,7 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
           `Using Ember.${name} or importing from '${path}' has been deprecated, install the ` +
             `\`ember-legacy-built-in-components\` addon and use \`import { ${name} } from ` +
             `'ember-legacy-built-in-components';\` instead`,
-          true,
+          false,
           {
             id: 'ember.legacy-built-in-components',
             until: '4.0.0',

--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -598,7 +598,7 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
           `Using Ember.${name} or importing from '${path}' has been deprecated, install the ` +
             `\`ember-legacy-built-in-components\` addon and use \`import { ${name} } from ` +
             `'ember-legacy-built-in-components';\` instead`,
-          false,
+          true,
           {
             id: 'ember.legacy-built-in-components',
             until: '4.0.0',
@@ -661,7 +661,9 @@ const deprecateImportFromString = function (
   name,
   message = `Importing ${name} from '@ember/string' is deprecated. Please import ${name} from '@ember/template' instead.`
 ) {
-  deprecate(message, false, {
+  // Disabling this deprecation due to unintended errors in 3.25
+  // See https://github.com/emberjs/ember.js/issues/19393 fo more information.
+  deprecate(message, true, {
     id: 'ember-string.htmlsafe-ishtmlsafe',
     for: 'ember-source',
     since: {

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -68,7 +68,7 @@ moduleFor(
       });
     }
 
-    ['@test Ember.String.htmlSafe exports correctly (but deprecated)'](assert) {
+    ['@skip Ember.String.htmlSafe exports correctly (but deprecated)'](assert) {
       let glimmer = require('@ember/-internals/glimmer');
       expectDeprecation(() => {
         assert.equal(
@@ -80,7 +80,7 @@ moduleFor(
       assert.notEqual(glimmer.htmlSafe, undefined, 'Ember.String.htmlSafe is not `undefined`');
     }
 
-    ['@test Ember.String.isHTMLSafe exports correctly (but deprecated)'](assert) {
+    ['@skip Ember.String.isHTMLSafe exports correctly (but deprecated)'](assert) {
       let glimmer = require('@ember/-internals/glimmer');
       expectDeprecation(() => {
         assert.equal(


### PR DESCRIPTION
Starts addressing https://github.com/emberjs/ember.js/issues/19393.