### PR TITLE
[BUGFIX] Ensure entries are properly defined on loader

### DIFF
--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -790,7 +790,7 @@ function defineEmberTemplateCompilerLazyLoad(key) {
     configurable: true,
     enumerable: true,
     get() {
-      if (require.has('ember-template-compiler')) {
+      if (has('ember-template-compiler')) {
         let templateCompiler = require('ember-template-compiler');
 
         EmberHTMLBars.precompile = EmberHandlebars.precompile = templateCompiler.precompile;
@@ -863,7 +863,8 @@ Ember.__loader = {
   require,
   // eslint-disable-next-line no-undef
   define,
-  registry: require.entries,
+  // eslint-disable-next-line no-undef
+  registry: typeof requirejs !== 'undefined' ? requirejs.entries : require.entries,
 };
 
 export default Ember;

--- a/packages/loader/lib/index.js
+++ b/packages/loader/lib/index.js
@@ -92,5 +92,5 @@ var define, require;
     return Boolean(registry[moduleName]) || Boolean(registry[moduleName + '/index']);
   };
 
-  require._eak_seen = registry;
+  require._eak_seen = require.entries = registry;
 })();


### PR DESCRIPTION
Ensures the `registry` field on `Ember.__loader` is setup properly, and
that the shim loader has `entries` defined on it correctly.