### PR TITLE
[BUGFIX lts] Makes user helper computation lazy instead of eager

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
@@ -743,6 +743,19 @@ moduleFor(
         this.render('{{hello-world}}');
       }, expectedMessage);
     }
+
+    ['@test helpers are not computed eagerly when used with if expressions'](assert) {
+      this.registerHelper('is-ok', () => 'hello');
+      this.registerHelper('throws-error', () => assert.ok(false, 'helper was computed eagerly'));
+
+      this.render('{{if true (is-ok) (throws-error)}}');
+
+      this.assertText('hello');
+
+      runTask(() => this.rerender());
+
+      this.assertText('hello');
+    }
   }
 );
 


### PR DESCRIPTION
From 3.17-3.21, the behavior of certain helpers was slightly different.
Essentially, if we detected that the arguments to the helper were
constant, we would eagerly run the helper to determine if it was
constant. If it was constant, we would then not have to update the
helper.

This was a bit mistaken, because as we realized later on when we fully
converted the VM to use autotracking, we cannot eagerly detect if
arguments are constant in all cases. The solution was to have a system
which would convert cached values to be constant if no autotracked
values were detected during the first computation, whenever that
occured.

Unfortunately, in the affected versions, helpers sometimes run eagerly
when previously they would not. This PR fixes that for user helpers,
which could contain bugs if they ran eagerly when they previously
ran lazily.

Fixes https://github.com/emberjs/ember.js/issues/19404