### PR TITLE
Add deprecation for `Route#disconnectOutlet`

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
@@ -1,11 +1,10 @@
 import {
   ApplicationTestCase,
+  expectDeprecation,
   ModuleBasedTestResolver,
   moduleFor,
   strip,
 } from 'internal-test-helpers';
-import { ExpectDeprecationFunc } from '../../../../../../internal-test-helpers/lib/ember-dev/deprecation';
-declare let expectDeprecation: ExpectDeprecationFunc;
 
 import { ENV } from '@ember/-internals/environment';
 import { Component, setComponentManager } from '@ember/-internals/glimmer';

--- a/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
@@ -4,6 +4,8 @@ import {
   moduleFor,
   strip,
 } from 'internal-test-helpers';
+import { ExpectDeprecationFunc } from '../../../../../../internal-test-helpers/lib/ember-dev/deprecation';
+declare let expectDeprecation: ExpectDeprecationFunc;
 
 import { ENV } from '@ember/-internals/environment';
 import { Component, setComponentManager } from '@ember/-internals/glimmer';
@@ -225,7 +227,10 @@ if (ENV._DEBUG_RENDER_TREE) {
               if (showHeader) {
                 this.render('header', { outlet: 'header' });
               } else {
-                this.disconnectOutlet('header');
+                expectDeprecation(
+                  () => this.disconnectOutlet('header'),
+                  'The usage of `disconnectOutlet` is deprecated.'
+                );
               }
             }
           }

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -1705,6 +1705,15 @@ class Route extends EmberObject implements IRoute {
     @public
   */
   disconnectOutlet(options: string | { outlet: string; parentView?: string }) {
+    deprecate('The usage of `disconnectOutlet` is deprecated.', false, {
+      id: 'route-disconnect-outlet',
+      until: '4.0.0',
+      url: 'https://deprecations.emberjs.com/v3.x/#toc_route-disconnect-outlet',
+      for: 'ember-source',
+      since: {
+        enabled: '3.27.0',
+      },
+    });
     let outletName;
     let parentView;
     if (options) {

--- a/packages/ember/tests/routing/template_rendering_test.js
+++ b/packages/ember/tests/routing/template_rendering_test.js
@@ -775,10 +775,14 @@ moduleFor(
               });
             },
             hideModal() {
-              this.disconnectOutlet({
-                outlet: 'modal',
-                parentView: 'application',
-              });
+              expectDeprecation(
+                () =>
+                  this.disconnectOutlet({
+                    outlet: 'modal',
+                    parentView: 'application',
+                  }),
+                'The usage of `disconnectOutlet` is deprecated.'
+              );
             },
           },
         })
@@ -794,7 +798,10 @@ moduleFor(
               });
             },
             hideExtra() {
-              this.disconnectOutlet({ parentView: 'posts/index' });
+              expectDeprecation(
+                () => this.disconnectOutlet({ parentView: 'posts/index' }),
+                'The usage of `disconnectOutlet` is deprecated.'
+              );
             },
           },
         })
@@ -898,7 +905,10 @@ moduleFor(
               });
             },
             hideModal() {
-              this.disconnectOutlet('modal');
+              expectDeprecation(
+                () => this.disconnectOutlet('modal'),
+                'The usage of `disconnectOutlet` is deprecated.'
+              );
             },
           },
         })
@@ -942,7 +952,7 @@ moduleFor(
     }
 
     ['@test Route silently fails when cleaning an outlet from an inactive view'](assert) {
-      assert.expect(1); // handleURL
+      assert.expect(3); // handleURL
 
       this.addTemplate('application', '{{outlet}}');
       this.addTemplate('posts', "{{outlet 'modal'}}");
@@ -957,16 +967,23 @@ moduleFor(
         Route.extend({
           actions: {
             hideSelf() {
-              this.disconnectOutlet({
-                outlet: 'main',
-                parentView: 'application',
-              });
+              expectDeprecation(
+                () =>
+                  this.disconnectOutlet({
+                    outlet: 'main',
+                    parentView: 'application',
+                  }),
+                'The usage of `disconnectOutlet` is deprecated.'
+              );
             },
             showModal() {
               this.render('modal', { into: 'posts', outlet: 'modal' });
             },
             hideModal() {
-              this.disconnectOutlet({ outlet: 'modal', parentView: 'posts' });
+              expectDeprecation(
+                () => this.disconnectOutlet({ outlet: 'modal', parentView: 'posts' }),
+                'The usage of `disconnectOutlet` is deprecated.'
+              );
             },
           },
         })
@@ -1080,10 +1097,14 @@ moduleFor(
           },
           actions: {
             banish() {
-              this.disconnectOutlet({
-                parentView: 'application',
-                outlet: 'other',
-              });
+              expectDeprecation(
+                () =>
+                  this.disconnectOutlet({
+                    parentView: 'application',
+                    outlet: 'other',
+                  }),
+                'The usage of `disconnectOutlet` is deprecated.'
+              );
             },
           },
         })
@@ -1249,10 +1270,14 @@ moduleFor(
               });
             },
             close() {
-              this.disconnectOutlet({
-                outlet: 'modal',
-                parentView: 'application',
-              });
+              expectDeprecation(
+                () =>
+                  this.disconnectOutlet({
+                    outlet: 'modal',
+                    parentView: 'application',
+                  }),
+                'The usage of `disconnectOutlet` is deprecated.'
+              );
             },
           },
         })
@@ -1329,10 +1354,14 @@ moduleFor(
         Route.extend({
           actions: {
             close() {
-              this.disconnectOutlet({
-                parentView: 'application',
-                outlet: 'modal',
-              });
+              expectDeprecation(
+                () =>
+                  this.disconnectOutlet({
+                    parentView: 'application',
+                    outlet: 'modal',
+                  }),
+                'The usage of `disconnectOutlet` is deprecated.'
+              );
             },
           },
         })
@@ -1438,10 +1467,14 @@ moduleFor(
               });
             },
             hideModal() {
-              this.disconnectOutlet({
-                outlet: undefined,
-                parentView: 'application',
-              });
+              expectDeprecation(
+                () =>
+                  this.disconnectOutlet({
+                    outlet: undefined,
+                    parentView: 'application',
+                  }),
+                'The usage of `disconnectOutlet` is deprecated.'
+              );
             },
           },
         })

--- a/packages/internal-test-helpers/index.js
+++ b/packages/internal-test-helpers/index.js
@@ -8,6 +8,12 @@ export { default as strip } from './lib/strip';
 export { default as applyMixins } from './lib/apply-mixins';
 export { default as getTextOf } from './lib/get-text-of';
 export {
+  expectDeprecation,
+  expectNoDeprecation,
+  expectDeprecationAsync,
+  ignoreDeprecation,
+} from './lib/ember-dev/deprecation';
+export {
   defineComponent,
   defineSimpleHelper,
   defineSimpleModifier,

--- a/packages/internal-test-helpers/lib/ember-dev/deprecation.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/deprecation.ts
@@ -25,17 +25,49 @@ export function setupDeprecationHelpers(hooks: NestedHooks, env: DebugEnv): void
   });
 }
 
+export let expectDeprecation: DeprecationAssert['expectDeprecation'] = () => {
+  throw new Error(
+    'DeprecationAssert: To use `expectDeprecation` in a test you must call `setupDeprecationHelpers` first'
+  );
+};
+
+export let ignoreDeprecation: DeprecationAssert['ignoreDeprecation'] = () => {
+  throw new Error(
+    'DeprecationAssert: To use `ignoreDeprecation` in a test you must call `setupDeprecationHelpers` first'
+  );
+};
+
+export let expectDeprecationAsync: DeprecationAssert['expectDeprecationAsync'] = () => {
+  throw new Error(
+    'DeprecationAssert: To use `expectDeprecationAsync` in a test you must call `setupDeprecationHelpers` first'
+  );
+};
+
+export let expectNoDeprecation: DeprecationAssert['expectNoDeprecation'] = () => {
+  throw new Error(
+    'DeprecationAssert: To use `expectNoDeprecation` in a test you must call `setupDeprecationHelpers` first'
+  );
+};
+
+export let expectNoDeprecationAsync: DeprecationAssert['expectNoDeprecationAsync'] = () => {
+  throw new Error(
+    'DeprecationAssert: To use `expectNoDeprecationAsync` in a test you must call `setupDeprecationHelpers` first'
+  );
+};
+
 class DeprecationAssert extends DebugAssert {
   constructor(env: DebugEnv) {
     super('deprecate', env);
   }
 
   inject(): void {
-    window.expectNoDeprecation = this.expectNoDeprecation.bind(this);
-    window.expectNoDeprecationAsync = this.expectNoDeprecationAsync.bind(this);
-    window.expectDeprecation = this.expectDeprecation.bind(this);
-    window.expectDeprecationAsync = this.expectDeprecationAsync.bind(this);
-    window.ignoreDeprecation = this.ignoreDeprecation.bind(this);
+    window.expectNoDeprecation = expectNoDeprecation = this.expectNoDeprecation.bind(this);
+    window.expectNoDeprecationAsync = expectNoDeprecationAsync = this.expectNoDeprecationAsync.bind(
+      this
+    );
+    window.expectDeprecation = expectDeprecation = this.expectDeprecation.bind(this);
+    window.expectDeprecationAsync = expectDeprecationAsync = this.expectDeprecationAsync.bind(this);
+    window.ignoreDeprecation = ignoreDeprecation = this.ignoreDeprecation.bind(this);
     super.inject();
   }
 


### PR DESCRIPTION
Adds deprecation for `Route#disconnectOutlet`. See [RFC 491](https://emberjs.github.io/rfcs/0491-deprecate-disconnect-outlet.html) for more info.

I was initially going to ship the `disconnectOutlet`, `render` and `renderTemplate` deprecations together in https://github.com/emberjs/ember.js/pull/19388 but the amount of tests which break and require a `expectDeprecation` is a bit overwhelming and taking longer than expected 😅 I've decided to break this one out instead.

```js
id: 'route-disconnect-outlet',
until: '4.0.0',
url: 'https://deprecations.emberjs.com/v3.x/#toc_route-disconnect-outlet',
for: 'ember-source',
since: {
  enabled: '3.27.0',
},
```

