### PR TITLE
Update test blueprints to support ember-mocha2

### DIFF
--- a/blueprints/test-framework-detector.js
+++ b/blueprints/test-framework-detector.js
@@ -28,7 +28,7 @@ module.exports = function (blueprint) {
       } else {
         type = 'qunit';
       }
-    } else if ('ember-mocha' in dependencies) {
+    } else if ('ember-mocha' in dependencies || 'ember-mocha2' in dependencies) {
       let checker = new VersionChecker(this.project);
       if (
         fs.existsSync(`${this.path}/${mochaRfcVersion}-files`) &&


### PR DESCRIPTION
ember-mocha2 is a maintained fork of ember-mocha, until we can merge the fork into the mainline of ember-mocha it would be good to support it.
https://www.npmjs.com/package/ember-mocha2